### PR TITLE
Polish contributor-facing repository instructions

### DIFF
--- a/.agents/skills/rpce-contribution-check/SKILL.md
+++ b/.agents/skills/rpce-contribution-check/SKILL.md
@@ -39,8 +39,6 @@ Push mode validates only the current branch against its configured upstream. For
 
 Obtain explicit user approval immediately before force-push, history rewrite, branch deletion, fork deletion, credential rotation, any other GitHub-visible destructive mutation, visible app launch/relaunch, or stopping a visible app. Do not bundle approval for a future destructive step into an earlier request.
 
-When removing exposed credentials, revoke or rotate them even after rewriting history. Scan forks and cached GitHub commit access without printing decoded values.
-
 ## Focused validation
 
-Read [references/validation-matrix.md](references/validation-matrix.md) when deciding whether additional focused tests, builds, live smoke, or GitHub Support cleanup are required.
+Read [references/validation-matrix.md](references/validation-matrix.md) when deciding whether additional focused tests, builds, or live smoke are required.

--- a/.agents/skills/rpce-contribution-check/references/validation-matrix.md
+++ b/.agents/skills/rpce-contribution-check/references/validation-matrix.md
@@ -18,6 +18,4 @@ Use this after the scripted preflight when the touched boundary needs focused ev
 
 - Treat obfuscated, encoded, or split credentials as secrets. Do not print their decoded values.
 - Use `gitleaks` with `--redact` for materialized staged index blobs and outgoing commits.
-- Revoke or rotate any exposed credentials even after rewriting history.
-- Remember that deleted branches, forks, cached commit views, pull requests, and collaborator clones may retain old objects. Follow GitHub Support cleanup guidance when direct SHA access remains.
 - Do not commit local configuration, prompt exports, daemon logs, raw provider traces, or generated diagnostic artifacts unless the repository explicitly allows the exact path.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# Claude Instructions
+
+Read and follow [`AGENTS.md`](AGENTS.md) before working in this repository.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,1 @@
-# Claude Instructions
-
-Read and follow [`AGENTS.md`](AGENTS.md) before working in this repository.
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -35,172 +35,36 @@ available without paid license gates. The project is licensed under
 Maintainers track release signing, Sparkle metadata, dependency pins, and
 third-party notices in [`docs/open-source-readiness.md`](docs/open-source-readiness.md).
 
-## Requirements
+## User Guide
 
-- macOS 14 or later to run the app
-- Xcode 26 or matching Command Line Tools with the macOS 26 SDK
-- `python3` for the coordinated developer daemon
-- Homebrew only when installing SwiftFormat and SwiftLint
+RepoPrompt CE currently runs as a local source build. You need macOS 14 or
+later and Xcode 26 or matching Command Line Tools with the macOS 26 SDK. You do
+not need to open Xcode.
 
-RepoPrompt CE does not use an Xcode project. You need Apple's toolchain and SDK,
-but you do not need to open Xcode.
+To run the app, double-click
+[`Launch RepoPrompt CE.command`](Launch%20RepoPrompt%20CE.command) in Finder.
+The launcher builds and opens RepoPrompt CE for you.
 
-## Start Here
-
-From the repository root:
-
-```bash
-make doctor    # check toolchain, SDK, signing, SwiftUI symbols, and debug CLI status
-make dev-build # build and package .build/debug/RepoPrompt.app
-make dev-run   # build, package, stop an existing RepoPrompt process, and launch
-```
-
-`make dev-*` commands use the repository's `conductor` daemon. Prefer them for
-builds, tests, launches, and style checks so concurrent developers and coding
-agents do not run conflicting jobs against the same checkout.
-
-The daemon starts automatically on first use. It serializes jobs that share a
-build, package, live-app, release, or style lane and prints a reconnectable
-ticket for each job.
-
-## Common Commands
-
-```bash
-make dev-status
-make dev-build
-make dev-swift-build PRODUCT=RepoPrompt
-make dev-swift-build PRODUCT=repoprompt-mcp
-make dev-test
-make dev-test FILTER=WorkspaceFileContextStoreTests
-make dev-provider-test
-make dev-lint
-make guardrails
-```
-
-For a user-directed rebuild and relaunch, use:
-
-```bash
-./conductor app relaunch
-```
-
-This supersedes older queued or active live-app work. `make dev-run` remains
-the ordinary FIFO launch path for automation.
-
-Long jobs can run asynchronously:
-
-```bash
-./conductor build --async --request-key debug-package
-./conductor job wait --request-key debug-package
-```
-
-Daemon output is concise by default. It prints progress highlights, a summary,
-and the full log path. Add `--full-log` when you need the raw build output:
-
-```bash
-./conductor build --full-log
-./conductor job wait --request-key debug-package --full-log
-```
-
-See [`AGENTS.md`](AGENTS.md) for the complete coordinated validation workflow,
-lane behavior, live MCP smoke commands, and source placement rules.
-
-## Direct Fallback
-
-Use direct commands only when `conductor` is unavailable, such as on a machine
-without `python3`. They do not coordinate with other developers or agents:
-
-```bash
-make build
-make run
-make test
-make lint
-```
-
-## Finder Launcher
-
-Open [`Launch RepoPrompt CE.command`](Launch%20RepoPrompt%20CE.command) for an
-interactive debug launcher:
+Keep the small launcher terminal open while you use the app:
 
 - `r` rebuilds and relaunches.
-- `s` shows app and daemon-job status.
-- `x` stops the app and supersedes older live-app work.
+- `s` shows app status.
+- `x` stops the app.
 - `q` closes the launcher without stopping the app.
 
-When `python3` is unavailable, the launcher falls back to direct mode.
+## Contributor And Agent Docs
 
-## Debug Signing
+The detailed development workflow lives in focused docs:
 
-Debug packaging may auto-detect an Apple Development signing identity. To opt
-in to persistent debug Keychain storage, pass an explicit identity:
-
-```bash
-SIGN_IDENTITY="Apple Development: ..." make dev-build
-```
-
-Without a stable identity, explicitly allow an ad-hoc debug build:
-
-```bash
-ALLOW_ADHOC_SIGNING=1 make dev-build
-```
-
-Ad-hoc debug builds use in-memory secure storage, so API keys and secure
-permission changes do not persist across launches. Release packaging requires
-`SIGN_IDENTITY`.
-
-## Debug CLI
-
-Use the CE-specific debug CLI for live app and MCP checks. Production
-`rp-cli` / `rp-cli-debug` commands may connect to the non-CE app.
-
-```bash
-make install-debug-cli
-make debug-cli-status
-make dev-smoke        # requires an already-running debug app
-make dev-smoke-launch # builds, launches, and runs the smoke flow
-```
-
-## Contributing
-
-New issues and pull requests from accounts outside the maintainer-managed
-contributor gate are closed automatically. The private allowlist does not grant
-repository access or organization membership. See [`CONTRIBUTING.md`](CONTRIBUTING.md)
-for the full contribution policy.
-
-Before opening a pull request, run:
-
-```bash
-make guardrails
-make dev-lint
-```
-
-Add the smallest relevant `make dev-test FILTER=<SuiteName>` coverage for
-behavior changes.
-
-## Source Layout
-
-Product flows live under `Sources/RepoPrompt/Features`, app composition under
-`Sources/RepoPrompt/App`, shared infrastructure under
-`Sources/RepoPrompt/Infrastructure`, shared MCP protocol code under
-`Sources/RepoPromptShared/MCP`, and tests under `Tests/RepoPromptTests`.
-
-See [`docs/architecture/source-layout.md`](docs/architecture/source-layout.md)
-for the ownership map and documented exceptions.
-
-## Release Packaging
-
-Contributors can exercise release packaging without credentials:
-
-```bash
-make dev-release-preflight
-make dev-release-artifact
-```
-
-The generated archive is ad-hoc signed and is not distributable. Maintainers
-publish Developer ID signed, notarized GitHub Releases through the protected
-workflow documented in [`docs/releasing.md`](docs/releasing.md). See
-[`docs/open-source-readiness.md`](docs/open-source-readiness.md) for the
-remaining public-readiness inventory.
-
-RepoPrompt CE starts its independent release history at `1.0.0`. Contributors
-prepare testable release candidates; maintainers own public tags, Apple
-credentials, Sparkle signing keys, draft GitHub Releases, and final promotion.
+- [`AGENTS.md`](AGENTS.md): start here for coordinated builds, tests, launches,
+  live MCP checks, source placement, and contribution preflight.
+- [`CONTRIBUTING.md`](CONTRIBUTING.md): contribution policy and pull request
+  steps.
+- [`docs/architecture/source-layout.md`](docs/architecture/source-layout.md):
+  source ownership and placement rules.
+- [`docs/architecture/provider-plugins.md`](docs/architecture/provider-plugins.md):
+  Agent Mode provider architecture.
+- [`docs/releasing.md`](docs/releasing.md): release-candidate and publishing
+  workflows.
+- [`docs/open-source-readiness.md`](docs/open-source-readiness.md): public
+  readiness inventory.

--- a/README.md
+++ b/README.md
@@ -5,66 +5,86 @@
 
 **The open-source macOS Context IDE for AI coding agents.**
 
-RepoPrompt CE helps you assemble, inspect, and hand off rich codebase context:
-pick the right files, summarize project structure and Git history, and package
-it all into a dense, reviewable prompt for ChatGPT, Claude, Codex, Cursor, and
-other AI coding tools. You can also hand that context straight to agents through
-the bundled MCP server and CLI.
+RepoPrompt CE helps you assemble, inspect, and hand off rich codebase context.
+Pick the right files across one or more repositories, summarize project
+structure and Git history, and package it all into a dense, reviewable prompt
+for ChatGPT, Claude, Codex, Cursor, and other AI coding tools — or hand that
+context straight to agents through the bundled MCP server and CLI.
 
-## What You Can Do
+> **Heads up:** RepoPrompt CE is built largely *with* and *for* AI coding
+> agents. This README is written for people getting started; the deeper
+> day-to-day development workflow lives in [`AGENTS.md`](AGENTS.md) and is
+> geared toward agents.
 
-- Curate focused, reviewable context for an AI model from one or more
-  repositories.
-- Combine selected files, project-structure maps, function/type CodeMaps, and
-  Git diffs in a single prompt.
-- Run Context Builder to discover relevant code and produce an optimized prompt.
-- Plan, review, and ask follow-up questions in built-in chat, including an
-  Oracle flow for second opinions.
-- Run longer agent sessions in Agent Mode with supported CLI-backed providers.
-- Connect external MCP clients to search, inspect, and select repository context
-  from your own tools.
+## Features
 
-## Project Status
+- **Curate context** — Build focused, reviewable context for an AI model from
+  one or more repositories.
+- **Combine everything** — Merge selected files, project-structure maps,
+  function/type CodeMaps, and Git diffs into a single prompt.
+- **Discover automatically** — Run Context Builder to find relevant code and
+  produce an optimized prompt for you.
+- **Think it through** — Plan, review, and ask follow-up questions in built-in
+  chat, including an Oracle flow for second opinions.
+- **Run agents** — Drive longer sessions in Agent Mode with supported
+  CLI-backed providers.
+- **Connect your tools** — Let external MCP clients search, inspect, and select
+  repository context from your own setup.
+
+## Quick Start
+
+RepoPrompt CE currently runs as a local source build — you do not need to open
+Xcode.
+
+**Requirements**
+
+- macOS 14 (Sonoma) or later
+- Xcode 26, or the matching Command Line Tools with the macOS 26 SDK
+
+**Run the app**
+
+1. Double-click [`Launch RepoPrompt CE.command`](Launch%20RepoPrompt%20CE.command)
+   in Finder. The launcher builds and opens RepoPrompt CE for you.
+2. Keep the small launcher terminal open while you use the app.
+
+**Launcher controls**
+
+| Key | Action                                      |
+| --- | ------------------------------------------- |
+| `r` | Rebuild and relaunch                        |
+| `s` | Show app status                             |
+| `x` | Stop the app                                |
+| `q` | Close the launcher without stopping the app |
+
+## About the Community Edition
 
 RepoPrompt CE is the open-source community edition of RepoPrompt, originally a
 paid macOS app. It removes paid activation flows and license keys while keeping
 the core prompt, copy, chat, CodeMap, Agent Mode, and custom-provider features
-available without paid license gates. The project is licensed under
-[Apache-2.0](LICENSE).
+available without paid license gates.
 
 Maintainers track release signing, Sparkle metadata, dependency pins, and
-third-party notices in [`docs/open-source-readiness.md`](docs/open-source-readiness.md).
+third-party notices in
+[`docs/open-source-readiness.md`](docs/open-source-readiness.md).
 
-## User Guide
+## Documentation
 
-RepoPrompt CE currently runs as a local source build. You need macOS 14 or
-later and Xcode 26 or matching Command Line Tools with the macOS 26 SDK. You do
-not need to open Xcode.
+The detailed development workflow is split across focused docs — most are
+oriented toward contributors and agents:
 
-To run the app, double-click
-[`Launch RepoPrompt CE.command`](Launch%20RepoPrompt%20CE.command) in Finder.
-The launcher builds and opens RepoPrompt CE for you.
-
-Keep the small launcher terminal open while you use the app:
-
-- `r` rebuilds and relaunches.
-- `s` shows app status.
-- `x` stops the app.
-- `q` closes the launcher without stopping the app.
-
-## Contributor And Agent Docs
-
-The detailed development workflow lives in focused docs:
-
-- [`AGENTS.md`](AGENTS.md): start here for coordinated builds, tests, launches,
+- [`AGENTS.md`](AGENTS.md) — start here for coordinated builds, tests, launches,
   live MCP checks, source placement, and contribution preflight.
-- [`CONTRIBUTING.md`](CONTRIBUTING.md): contribution policy and pull request
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — contribution policy and pull request
   steps.
-- [`docs/architecture/source-layout.md`](docs/architecture/source-layout.md):
+- [`docs/architecture/source-layout.md`](docs/architecture/source-layout.md) —
   source ownership and placement rules.
-- [`docs/architecture/provider-plugins.md`](docs/architecture/provider-plugins.md):
-  Agent Mode provider architecture.
-- [`docs/releasing.md`](docs/releasing.md): release-candidate and publishing
+- [`docs/architecture/provider-plugins.md`](docs/architecture/provider-plugins.md)
+  — Agent Mode provider architecture.
+- [`docs/releasing.md`](docs/releasing.md) — release-candidate and publishing
   workflows.
-- [`docs/open-source-readiness.md`](docs/open-source-readiness.md): public
+- [`docs/open-source-readiness.md`](docs/open-source-readiness.md) — public
   readiness inventory.
+
+## License
+
+RepoPrompt CE is licensed under [Apache-2.0](LICENSE).


### PR DESCRIPTION
## Summary
- simplify and polish the README for human readers
- point Claude agents at the repository instructions
- streamline contribution preflight docs

## Validation
- repository contribution push preflight
- outgoing-range secret scan
- source layout and contributor allowlist guardrails