### PR TITLE
Add local self-signed production installer

### DIFF
--- a/.agents/skills/rpce-release/SKILL.md
+++ b/.agents/skills/rpce-release/SKILL.md
@@ -17,6 +17,16 @@ make dev-release-preflight
 make dev-release-artifact
 ```
 
+For a local-only release-mode installation signed by the user's own dedicated
+self-signed identity, use:
+
+```bash
+CONFIRM_LOCAL_PRODUCTION_INSTALL=1 make dev-install-local-production
+```
+
+This app is not notarized and must not be distributed or uploaded to GitHub
+Releases.
+
 Report the files written under `dist/`. Clearly state that the archive is
 ad-hoc signed, intended for packaging validation, and not distributable.
 

--- a/AppBundle/Info.plist.template
+++ b/AppBundle/Info.plist.template
@@ -15,6 +15,7 @@
   <key>NSHighResolutionCapable</key><true/>
   <key>NSPrincipalClass</key><string>NSApplication</string>
   <key>RepoPromptDebugSecureStorageBackend</key><string>__DEBUG_SECURE_STORAGE_BACKEND__</string>
+  <key>RepoPromptSigningMode</key><string>__SIGNING_MODE__</string>
   <key>LSEnvironment</key><dict><key>REPOPROMPT_LAUNCH_SOURCE</key><string>launchservices</string></dict>
   <key>CFBundleURLTypes</key><array><dict><key>CFBundleTypeRole</key><string>Viewer</string><key>CFBundleURLName</key><string>com.pvncher.repoprompt.ce</string><key>CFBundleURLSchemes</key><array><string>repoprompt-ce</string></array><key>CFBundleURLIconFile</key><string>AppIcon</string></dict></array>
   <key>NSAppTransportSecurity</key><dict><key>NSAllowsArbitraryLoads</key><true/></dict>

--- a/AppBundle/RepoPrompt.local-self-signed.entitlements.template
+++ b/AppBundle/RepoPrompt.local-self-signed.entitlements.template
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.files.bookmarks.app-scope</key>
+    <true/>
+    <key>com.apple.security.temporary-exception.mach-lookup.global-name</key>
+    <array>
+        <string>__BUNDLE_ID__-spks</string>
+        <string>__BUNDLE_ID__-spki</string>
+    </array>
+</dict>
+</plist>

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: doctor setup install-format-tools format-tools-status format format-check lint install-debug-cli uninstall-debug-cli debug-cli-status resolve build run test guardrails conductor-selftest release-preflight release-artifact dev-status dev-build dev-swift-build dev-run dev-test dev-provider-test dev-smoke dev-smoke-launch dev-format dev-format-check dev-lint dev-format-tools-status dev-check-format-tools dev-install-format-tools dev-release-preflight dev-release-artifact dev-stop-app dev-daemon-stop clean
+.PHONY: doctor setup install-format-tools format-tools-status format format-check lint install-debug-cli uninstall-debug-cli debug-cli-status resolve build run test guardrails conductor-selftest release-preflight release-artifact install-local-production dev-status dev-build dev-swift-build dev-run dev-test dev-provider-test dev-smoke dev-smoke-launch dev-format dev-format-check dev-lint dev-format-tools-status dev-check-format-tools dev-install-format-tools dev-release-preflight dev-release-artifact dev-install-local-production dev-stop-app dev-daemon-stop clean
 
 PRODUCT ?= all
 
@@ -53,12 +53,16 @@ guardrails:
 conductor-selftest:
 	python3 Scripts/test_conductor_output.py
 	python3 Scripts/test_conductor_lifecycle.py
+	python3 Scripts/test_local_production_installer.py
 
 release-preflight:
 	./Scripts/release.sh preflight
 
 release-artifact:
 	./Scripts/release.sh artifact
+
+install-local-production:
+	./Scripts/install_local_production.sh
 
 dev-status:
 	./conductor status
@@ -107,6 +111,9 @@ dev-release-preflight:
 
 dev-release-artifact:
 	./conductor release artifact
+
+dev-install-local-production:
+	./conductor release local-install
 
 dev-stop-app:
 	./conductor app stop

--- a/Scripts/conductor.py
+++ b/Scripts/conductor.py
@@ -128,7 +128,7 @@ Operation commands:
   ./conductor smoke [--launch] [--workspace <name>] [--window-id <id>] [--agent-run]
     (without --launch, requires the CE debug app to already be running and CLI installed)
   ./conductor diagnostics agent-mode-on [--log-file <path>]
-  ./conductor release preflight|artifact|package
+  ./conductor release preflight|artifact|package|local-install
 
 Foundation validation operation:
   ./conductor sleep <seconds> [--lane <lane>]... [--message <text>] [--exit-code <n>]
@@ -762,6 +762,10 @@ class OperationRegistry:
         "SIGNING_TEAM_ID",
         "ALLOW_ADHOC_SIGNING",
         "RELEASE_ALLOW_ADHOC_SIGNING",
+        "CONFIRM_LOCAL_PRODUCTION_INSTALL",
+        "LOCAL_CERTIFICATE_DAYS",
+        "LOCAL_PRODUCTION_INSTALL_DIR",
+        "LOCAL_SELF_SIGNED_RELEASE",
         "PREFER_STABLE_DEBUG_SIGNING",
         "DEBUG_SECURE_STORAGE_BACKEND",
         "REPOPROMPT_PROVISIONING_PROFILE",
@@ -917,6 +921,8 @@ class OperationRegistry:
             subcommand = args.get("subcommand")
             if subcommand == "package":
                 return [script("package_app.sh"), "release"], ["build", "debugArtifact", "release"], cwd, env, effective_timeout
+            if subcommand == "local-install":
+                return [script("install_local_production.sh")], ["build", "debugArtifact", "release"], cwd, env, effective_timeout
             if subcommand == "artifact":
                 return [script("release.sh"), "artifact"], ["build", "debugArtifact", "release"], cwd, env, effective_timeout
             if subcommand == "preflight":
@@ -972,7 +978,7 @@ class OperationRegistry:
             return SHORT_TIMEOUT_SECONDS
         if operation == "app" and args.get("subcommand") in {"status", "stop"}:
             return SHORT_TIMEOUT_SECONDS
-        if operation in {"package", "release"} and (args.get("config") == "release" or args.get("subcommand") in {"artifact", "package"}):
+        if operation in {"package", "release"} and (args.get("config") == "release" or args.get("subcommand") in {"artifact", "package", "local-install"}):
             return RELEASE_TIMEOUT_SECONDS
         if operation == "smoke" and args.get("agentRun"):
             return MEDIUM_TIMEOUT_SECONDS
@@ -2891,7 +2897,7 @@ def handle_real_operation(paths: Paths, operation: str, argv: List[str]) -> int:
         args.update({"subcommand": ns.subcommand, "logFile": ns.log_file, "windowId": ns.window_id})
     elif operation == "release":
         parser = argparse.ArgumentParser(prog="conductor release")
-        parser.add_argument("subcommand", choices=["preflight", "artifact", "package"])
+        parser.add_argument("subcommand", choices=["preflight", "artifact", "package", "local-install"])
         ns = parser.parse_args(rest)
         args["subcommand"] = ns.subcommand
     else:

--- a/Scripts/install_local_production.sh
+++ b/Scripts/install_local_production.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+set -a
+source "$ROOT_DIR/version.env"
+set +a
+
+LOCAL_SELF_SIGNED_CERTIFICATE_NAME="RepoPrompt CE Local Self-Signed Code Signing"
+LOCAL_PRODUCTION_INSTALL_DIR="${LOCAL_PRODUCTION_INSTALL_DIR:-/Applications}"
+LOCAL_PRODUCTION_APP="$LOCAL_PRODUCTION_INSTALL_DIR/$DISPLAY_NAME.app"
+LOCAL_CERTIFICATE_DAYS="${LOCAL_CERTIFICATE_DAYS:-3650}"
+LOCAL_SIGNING_REQUIREMENT="anchor trusted and identifier \"$BUNDLE_ID\" and certificate leaf[subject.CN] = \"$LOCAL_SELF_SIGNED_CERTIFICATE_NAME\""
+TMP_DIR=""
+STAGED_DIR=""
+STAGED_APP=""
+BACKUP_DIR=""
+BACKUP_APP=""
+
+fail() {
+    printf 'ERROR: %s\n' "$*" >&2
+    exit 1
+}
+
+require_command() {
+    command -v "$1" >/dev/null 2>&1 || fail "Missing required command: $1"
+}
+
+cleanup() {
+    [[ -z "$TMP_DIR" ]] || rm -rf "$TMP_DIR"
+    [[ -z "$STAGED_DIR" ]] || rm -rf "$STAGED_DIR"
+    if [[ -n "$BACKUP_APP" && -e "$BACKUP_APP" ]]; then
+        if [[ ! -e "$LOCAL_PRODUCTION_APP" ]]; then
+            mv "$BACKUP_APP" "$LOCAL_PRODUCTION_APP" ||
+                printf 'ERROR: Could not restore prior app from backup: %s\n' "$BACKUP_APP" >&2
+        else
+            printf 'WARNING: Preserving prior app backup after failed replacement: %s\n' "$BACKUP_APP" >&2
+        fi
+    fi
+    [[ -z "$BACKUP_DIR" ]] || rmdir "$BACKUP_DIR" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+[[ "${CONFIRM_LOCAL_PRODUCTION_INSTALL:-}" == "1" ]] ||
+    fail "Set CONFIRM_LOCAL_PRODUCTION_INSTALL=1 to build and replace the local production app in $LOCAL_PRODUCTION_INSTALL_DIR."
+
+for command in codesign ditto openssl plutil security swift; do
+    require_command "$command"
+done
+
+LOGIN_KEYCHAIN="$(security default-keychain -d user | sed -e 's/^[[:space:]]*"//' -e 's/"[[:space:]]*$//')"
+[[ -n "$LOGIN_KEYCHAIN" && -f "$LOGIN_KEYCHAIN" ]] || fail "Could not resolve the user's default login keychain."
+
+TMP_DIR="$(mktemp -d)"
+CERTIFICATE_PEM="$TMP_DIR/repoprompt-ce-local-signing.pem"
+
+find_local_identity() {
+    security find-identity -v -p codesigning "$LOGIN_KEYCHAIN" 2>/dev/null |
+        awk -F'\"' -v name="$LOCAL_SELF_SIGNED_CERTIFICATE_NAME" '$2 == name { print $1; exit }' |
+        awk '{ print $2 }'
+}
+
+trust_existing_certificate_if_present() {
+    security find-certificate -c "$LOCAL_SELF_SIGNED_CERTIFICATE_NAME" -p "$LOGIN_KEYCHAIN" > "$CERTIFICATE_PEM" 2>/dev/null || true
+    if [[ -s "$CERTIFICATE_PEM" ]]; then
+        printf 'Trusting existing local RepoPrompt CE code-signing certificate for code signing. macOS may ask for confirmation.\n'
+        security add-trusted-cert -r trustRoot -p codeSign -k "$LOGIN_KEYCHAIN" "$CERTIFICATE_PEM"
+    fi
+}
+
+mint_local_identity() {
+    local password
+    password="$(openssl rand -hex 24)"
+    printf 'Creating user-local RepoPrompt CE self-signed code-signing identity. macOS may ask for confirmation when its trust policy is installed.\n'
+    cat > "$TMP_DIR/openssl.cnf" <<EOF
+[req]
+distinguished_name = distinguished_name
+x509_extensions = codesign_extensions
+prompt = no
+
+[distinguished_name]
+CN = $LOCAL_SELF_SIGNED_CERTIFICATE_NAME
+O = RepoPrompt CE Local
+OU = Local Build
+
+[codesign_extensions]
+basicConstraints = critical,CA:TRUE
+keyUsage = critical,digitalSignature
+extendedKeyUsage = codeSigning
+subjectKeyIdentifier = hash
+EOF
+    openssl req -new -newkey rsa:2048 -x509 -sha256 -days "$LOCAL_CERTIFICATE_DAYS" -nodes \
+        -config "$TMP_DIR/openssl.cnf" \
+        -out "$CERTIFICATE_PEM" \
+        -keyout "$TMP_DIR/repoprompt-ce-local-signing-key.pem"
+    openssl pkcs12 -export -legacy \
+        -out "$TMP_DIR/repoprompt-ce-local-signing.p12" \
+        -inkey "$TMP_DIR/repoprompt-ce-local-signing-key.pem" \
+        -in "$CERTIFICATE_PEM" \
+        -name "$LOCAL_SELF_SIGNED_CERTIFICATE_NAME" \
+        -passout "pass:$password"
+    security import "$TMP_DIR/repoprompt-ce-local-signing.p12" \
+        -k "$LOGIN_KEYCHAIN" \
+        -P "$password" \
+        -T /usr/bin/codesign \
+        -T /usr/bin/security
+    security add-trusted-cert -r trustRoot -p codeSign -k "$LOGIN_KEYCHAIN" "$CERTIFICATE_PEM"
+}
+
+SIGN_IDENTITY="$(find_local_identity)"
+if [[ -z "$SIGN_IDENTITY" ]]; then
+    trust_existing_certificate_if_present
+    SIGN_IDENTITY="$(find_local_identity)"
+fi
+if [[ -z "$SIGN_IDENTITY" ]]; then
+    mint_local_identity
+    SIGN_IDENTITY="$(find_local_identity)"
+fi
+[[ -n "$SIGN_IDENTITY" ]] || fail "The user-local RepoPrompt CE code-signing identity is not valid after installation."
+printf 'Using user-local code-signing identity: %s\n' "$LOCAL_SELF_SIGNED_CERTIFICATE_NAME"
+
+LOCAL_SELF_SIGNED_RELEASE=1 \
+    SIGN_IDENTITY="$SIGN_IDENTITY" \
+    "$ROOT_DIR/Scripts/package_app.sh" release
+
+BUILD_DIR="$(swift build -c release --show-bin-path)"
+SOURCE_APP="$BUILD_DIR/$APP_NAME.app"
+[[ -d "$SOURCE_APP" ]] || fail "Missing packaged local production app: $SOURCE_APP"
+[[ "$(plutil -extract RepoPromptSigningMode raw "$SOURCE_APP/Contents/Info.plist")" == "local-self-signed" ]] ||
+    fail "Packaged app is missing the local self-signed runtime marker."
+codesign --verify --deep --strict --verbose=2 "$SOURCE_APP"
+codesign --verify --deep --strict --verbose=2 -R="$LOCAL_SIGNING_REQUIREMENT" "$SOURCE_APP"
+
+if pgrep -f "$LOCAL_PRODUCTION_APP/Contents/MacOS/$APP_NAME" >/dev/null 2>&1; then
+    fail "Quit $DISPLAY_NAME before replacing $LOCAL_PRODUCTION_APP."
+fi
+
+mkdir -p "$LOCAL_PRODUCTION_INSTALL_DIR"
+STAGED_DIR="$(mktemp -d "$LOCAL_PRODUCTION_INSTALL_DIR/.$DISPLAY_NAME.app.installing.XXXXXX")"
+STAGED_APP="$STAGED_DIR/$DISPLAY_NAME.app"
+ditto "$SOURCE_APP" "$STAGED_APP"
+codesign --verify --deep --strict --verbose=2 "$STAGED_APP"
+codesign --verify --deep --strict --verbose=2 -R="$LOCAL_SIGNING_REQUIREMENT" "$STAGED_APP"
+if [[ -e "$LOCAL_PRODUCTION_APP" ]]; then
+    BACKUP_DIR="$(mktemp -d "$LOCAL_PRODUCTION_INSTALL_DIR/.$DISPLAY_NAME.app.backup.XXXXXX")"
+    BACKUP_APP="$BACKUP_DIR/$DISPLAY_NAME.app"
+    mv "$LOCAL_PRODUCTION_APP" "$BACKUP_APP"
+fi
+mv "$STAGED_APP" "$LOCAL_PRODUCTION_APP"
+STAGED_APP=""
+rmdir "$STAGED_DIR"
+STAGED_DIR=""
+if [[ -n "$BACKUP_APP" ]]; then
+    rm -rf "$BACKUP_APP"
+    rmdir "$BACKUP_DIR"
+    BACKUP_APP=""
+    BACKUP_DIR=""
+fi
+
+printf 'Installed local self-signed production app: %s\n' "$LOCAL_PRODUCTION_APP"
+printf 'This app is local-only, not notarized, and must not be distributed or uploaded to GitHub Releases.\n'

--- a/Scripts/package_app.sh
+++ b/Scripts/package_app.sh
@@ -62,13 +62,19 @@ fi
 SIGN_IDENTITY="${SIGN_IDENTITY:-}"
 ALLOW_ADHOC_SIGNING="${ALLOW_ADHOC_SIGNING:-0}"
 RELEASE_ALLOW_ADHOC_SIGNING="${RELEASE_ALLOW_ADHOC_SIGNING:-0}"
+LOCAL_SELF_SIGNED_RELEASE="${LOCAL_SELF_SIGNED_RELEASE:-0}"
+LOCAL_SELF_SIGNED_CERTIFICATE_NAME="RepoPrompt CE Local Self-Signed Code Signing"
+LOCAL_SELF_SIGNED_REQUIREMENT="anchor trusted and identifier \"$BUNDLE_ID\" and certificate leaf[subject.CN] = \"$LOCAL_SELF_SIGNED_CERTIFICATE_NAME\""
 PREFER_STABLE_DEBUG_SIGNING="${PREFER_STABLE_DEBUG_SIGNING:-1}"
 DEBUG_SECURE_STORAGE_BACKEND="${DEBUG_SECURE_STORAGE_BACKEND:-}"
 REPOPROMPT_PROVISIONING_PROFILE="${REPOPROMPT_PROVISIONING_PROFILE:-}"
 APP_ENTITLEMENTS_TEMPLATE="${APP_ENTITLEMENTS_TEMPLATE:-$ROOT_DIR/AppBundle/RepoPrompt.entitlements.template}"
+LOCAL_SELF_SIGNED_ENTITLEMENTS_TEMPLATE="$ROOT_DIR/AppBundle/RepoPrompt.local-self-signed.entitlements.template"
 APP_ENTITLEMENTS=""
 USE_ADHOC_SIGNING=0
+USE_LOCAL_SELF_SIGNED_RELEASE=0
 DEBUG_STORAGE_BACKEND_MARKER="alternate-in-memory"
+SIGNING_MODE_MARKER="debug-apple-development"
 warn_adhoc_signing(){
     echo "WARNING: Using explicit ad-hoc signing for a debug package."
     echo "WARNING: RepoPrompt debug runtime will use ephemeral in-memory secure storage instead of macOS Keychain for API keys and secure permission documents."
@@ -79,6 +85,13 @@ warn_release_candidate_signing(){
     echo "WARNING: Using explicit ad-hoc signing for a release-candidate package."
     echo "WARNING: This artifact exercises release packaging only. It is not notarizable, distributable, or suitable for GitHub Releases."
 }
+if [[ "$LOCAL_SELF_SIGNED_RELEASE" == "1" || "$LOCAL_SELF_SIGNED_RELEASE" == "true" ]]; then
+    (( IS_RELEASE )) || fail "LOCAL_SELF_SIGNED_RELEASE is only supported for release packaging."
+    [[ -n "$SIGN_IDENTITY" ]] || fail "LOCAL_SELF_SIGNED_RELEASE requires SIGN_IDENTITY pointing at the user-local self-signed code-signing identity."
+    USE_LOCAL_SELF_SIGNED_RELEASE=1
+    echo "WARNING: Building a local-only self-signed production app."
+    echo "WARNING: This app is for installation on this Mac only. It is not notarized and must not be uploaded to GitHub Releases."
+fi
 if [[ -z "$SIGN_IDENTITY" ]] && (( ! IS_RELEASE )) && [[ "$PREFER_STABLE_DEBUG_SIGNING" == "1" || "$PREFER_STABLE_DEBUG_SIGNING" == "true" ]]; then
     AUTO_SIGN_IDENTITY="$(security find-identity -v -p codesigning 2>/dev/null | awk -F'"' '/"Apple Development: / { print $2; exit }')"
     if [[ -n "$AUTO_SIGN_IDENTITY" ]]; then
@@ -113,8 +126,14 @@ else
     fi
 fi
 
-if (( IS_RELEASE )) && (( ! USE_ADHOC_SIGNING )); then
+if (( USE_LOCAL_SELF_SIGNED_RELEASE )); then
     DEBUG_STORAGE_BACKEND_MARKER="keychain"
+    SIGNING_MODE_MARKER="local-self-signed"
+elif (( IS_RELEASE )) && (( ! USE_ADHOC_SIGNING )); then
+    DEBUG_STORAGE_BACKEND_MARKER="keychain"
+    SIGNING_MODE_MARKER="developer-id"
+elif (( IS_RELEASE )); then
+    SIGNING_MODE_MARKER="release-candidate-adhoc"
 elif [[ -n "$DEBUG_SECURE_STORAGE_BACKEND" ]]; then
     case "$DEBUG_SECURE_STORAGE_BACKEND" in
         keychain|alternate-in-memory) DEBUG_STORAGE_BACKEND_MARKER="$DEBUG_SECURE_STORAGE_BACKEND" ;;
@@ -122,14 +141,22 @@ elif [[ -n "$DEBUG_SECURE_STORAGE_BACKEND" ]]; then
     esac
 elif (( SIGN_IDENTITY_WAS_EXPLICIT )) && (( ! USE_ADHOC_SIGNING )); then
     DEBUG_STORAGE_BACKEND_MARKER="keychain"
+elif (( USE_ADHOC_SIGNING )); then
+    SIGNING_MODE_MARKER="debug-adhoc"
 fi
 printf 'Debug secure storage backend marker: %s\n' "$DEBUG_STORAGE_BACKEND_MARKER"
+printf 'Signing mode marker: %s\n' "$SIGNING_MODE_MARKER"
+
+SWIFT_BUILD_ARGS=(-c "$CONF")
+if (( USE_LOCAL_SELF_SIGNED_RELEASE )); then
+    SWIFT_BUILD_ARGS+=(-Xswiftc -DREPOPROMPT_LOCAL_SELF_SIGNED_BUILD)
+fi
 
 phase "Building $APP_NAME ($CONF)"
-run swift build -c "$CONF" --product "$APP_NAME"
+run swift build "${SWIFT_BUILD_ARGS[@]}" --product "$APP_NAME"
 
 phase "Building repoprompt-mcp ($CONF)"
-run swift build -c "$CONF" --product repoprompt-mcp
+run swift build "${SWIFT_BUILD_ARGS[@]}" --product repoprompt-mcp
 
 phase "Resolving build artifact paths"
 echo_cmd swift build -c "$CONF" --show-bin-path
@@ -173,12 +200,23 @@ phase "Writing Info.plist"
 run python3 - <<PY
 from pathlib import Path
 s=Path('AppBundle/Info.plist.template').read_text()
-for k,v in {'__APP_NAME__':'$APP_NAME','__DISPLAY_NAME__':'$DISPLAY_NAME','__BUNDLE_ID__':'$BUNDLE_ID','__MARKETING_VERSION__':'$MARKETING_VERSION','__BUILD_NUMBER__':'$BUILD_NUMBER','__DEBUG_SECURE_STORAGE_BACKEND__':'$DEBUG_STORAGE_BACKEND_MARKER'}.items(): s=s.replace(k,v)
+for k,v in {'__APP_NAME__':'$APP_NAME','__DISPLAY_NAME__':'$DISPLAY_NAME','__BUNDLE_ID__':'$BUNDLE_ID','__MARKETING_VERSION__':'$MARKETING_VERSION','__BUILD_NUMBER__':'$BUILD_NUMBER','__DEBUG_SECURE_STORAGE_BACKEND__':'$DEBUG_STORAGE_BACKEND_MARKER','__SIGNING_MODE__':'$SIGNING_MODE_MARKER'}.items(): s=s.replace(k,v)
 Path('$APP_BUNDLE/Contents/Info.plist').write_text(s)
 PY
 run plutil -lint "$APP_BUNDLE/Contents/Info.plist"
 
-if (( IS_RELEASE )) && (( ! USE_ADHOC_SIGNING )); then
+if (( USE_LOCAL_SELF_SIGNED_RELEASE )); then
+    phase "Rendering local self-signed entitlements"
+    [[ -f "$LOCAL_SELF_SIGNED_ENTITLEMENTS_TEMPLATE" ]] || fail "Missing local self-signed entitlements template: $LOCAL_SELF_SIGNED_ENTITLEMENTS_TEMPLATE"
+    APP_ENTITLEMENTS="$(mktemp)"
+    run python3 - <<PY
+from pathlib import Path
+s=Path('$LOCAL_SELF_SIGNED_ENTITLEMENTS_TEMPLATE').read_text()
+s=s.replace('__BUNDLE_ID__', '$BUNDLE_ID')
+Path('$APP_ENTITLEMENTS').write_text(s)
+PY
+    run plutil -lint "$APP_ENTITLEMENTS"
+elif (( IS_RELEASE )) && (( ! USE_ADHOC_SIGNING )); then
     phase "Embedding release provisioning profile and entitlements"
     [[ -f "$REPOPROMPT_PROVISIONING_PROFILE" ]] || fail "Signed release packaging requires REPOPROMPT_PROVISIONING_PROFILE pointing to the RepoPrompt CE Developer ID provisioning profile."
     [[ -f "$APP_ENTITLEMENTS_TEMPLATE" ]] || fail "Missing release entitlements template: $APP_ENTITLEMENTS_TEMPLATE"
@@ -211,6 +249,8 @@ sign_path(){
     local args=(--force --sign "$SIGN_IDENTITY")
     if (( USE_ADHOC_SIGNING )); then
         args+=(--timestamp=none)
+    elif (( USE_LOCAL_SELF_SIGNED_RELEASE )); then
+        args+=(--timestamp=none --options runtime)
     elif (( IS_RELEASE )); then
         args+=(--timestamp --options runtime)
     else
@@ -220,7 +260,7 @@ sign_path(){
 }
 verify_signed_app_identity(){
     local details identifier team authorities
-    details="$(codesign -dv "$APP_BUNDLE" 2>&1 || true)"
+    details="$(codesign -dv --verbose=4 "$APP_BUNDLE" 2>&1 || true)"
     identifier="$(printf '%s\n' "$details" | awk -F= '/^Identifier=/{print $2; exit}')"
     team="$(printf '%s\n' "$details" | awk -F= '/^TeamIdentifier=/{print $2; exit}')"
     authorities="$(printf '%s\n' "$details" | awk -F= '/^Authority=/{print $2}' | paste -sd ', ' -)"
@@ -234,6 +274,9 @@ verify_signed_app_identity(){
     if (( USE_ADHOC_SIGNING )); then
         [[ -z "$team" || "$team" == "not set" ]] || echo "WARNING: Expected ad-hoc signing without a team identifier, but found team '$team'."
         echo "WARNING: Ad-hoc package created explicitly; do not use this artifact for release."
+    elif (( USE_LOCAL_SELF_SIGNED_RELEASE )); then
+        [[ -z "$team" || "$team" == "not set" ]] || fail "Local self-signed app unexpectedly has team identifier '$team'."
+        run codesign --verify --deep --strict --verbose=2 -R="$LOCAL_SELF_SIGNED_REQUIREMENT" "$APP_BUNDLE"
     elif (( IS_RELEASE )); then
         [[ "$team" == "$SIGNING_TEAM_ID" ]] || fail "Signed app team mismatch: expected $SIGNING_TEAM_ID, got ${team:-<missing>}"
     else

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -55,6 +55,7 @@ run_preflight() {
     require_command plutil
     require_file "$ROOT_DIR/AppBundle/Info.plist.template"
     require_file "$ROOT_DIR/AppBundle/RepoPrompt.entitlements.template"
+    require_file "$ROOT_DIR/AppBundle/RepoPrompt.local-self-signed.entitlements.template"
     require_file "$ROOT_DIR/Vendor/Sparkle/LICENSE"
     require_file "$ROOT_DIR/Vendor/Sparkle/PROVENANCE.md"
     require_file "$ROOT_DIR/Vendor/Sparkle/SHA256SUMS"

--- a/Scripts/swift_style.sh
+++ b/Scripts/swift_style.sh
@@ -40,6 +40,19 @@ EXCLUDED_SWIFT_PREFIXES=(
     "Packages/RepoPromptAgentProviders/.build/"
 )
 
+EXCLUDED_SWIFT_FILES=(
+    "Sources/RepoPrompt/Infrastructure/AI/Prompts/Workflows/WorkflowPromptSharedFragments.swift"
+    "Sources/RepoPrompt/Infrastructure/AI/Prompts/Workflows/WorkflowPrompt+Build.swift"
+    "Sources/RepoPrompt/Infrastructure/AI/Prompts/Workflows/WorkflowPrompt+DeepPlan.swift"
+    "Sources/RepoPrompt/Infrastructure/AI/Prompts/Workflows/WorkflowPrompt+Investigate.swift"
+    "Sources/RepoPrompt/Infrastructure/AI/Prompts/Workflows/WorkflowPrompt+Optimize.swift"
+    "Sources/RepoPrompt/Infrastructure/AI/Prompts/Workflows/WorkflowPrompt+OracleExport.swift"
+    "Sources/RepoPrompt/Infrastructure/AI/Prompts/Workflows/WorkflowPrompt+Orchestrate.swift"
+    "Sources/RepoPrompt/Infrastructure/AI/Prompts/Workflows/WorkflowPrompt+Refactor.swift"
+    "Sources/RepoPrompt/Infrastructure/AI/Prompts/Workflows/WorkflowPrompt+Reminder.swift"
+    "Sources/RepoPrompt/Infrastructure/AI/Prompts/Workflows/WorkflowPrompt+Review.swift"
+)
+
 fail(){ echo "ERROR: $*" >&2; exit 1; }
 
 ensure_tool(){
@@ -55,9 +68,12 @@ run(){
 
 should_include_swift_file(){
     local file="$1"
-    local prefix
+    local excluded prefix
     for prefix in "${EXCLUDED_SWIFT_PREFIXES[@]}"; do
         [[ "$file" == "$prefix"* ]] && return 1
+    done
+    for excluded in "${EXCLUDED_SWIFT_FILES[@]}"; do
+        [[ "$file" == "$excluded" ]] && return 1
     done
     return 0
 }
@@ -89,6 +105,11 @@ collect_swift_files(){
 run_swiftformat(){
     local mode="$1"
     ensure_tool swiftformat
+    collect_swift_files
+
+    if (( ${#SWIFT_FILES[@]} == 0 )); then
+        fail "No Swift files found in configured style scope."
+    fi
 
     local args=(--config "$ROOT_DIR/.swiftformat")
     if [[ "$mode" == "check" ]]; then
@@ -99,7 +120,7 @@ run_swiftformat(){
     fi
 
     cd "$ROOT_DIR"
-    run swiftformat "${args[@]}" "${STYLE_PATHS[@]}"
+    run swiftformat "${args[@]}" "${SWIFT_FILES[@]}"
 }
 
 run_swiftlint(){

--- a/Scripts/test_conductor_lifecycle.py
+++ b/Scripts/test_conductor_lifecycle.py
@@ -117,6 +117,26 @@ class LifecycleQueueTests(LifecycleTestCase):
         self.assertEqual(lanes, ["build", "debugArtifact", "release"])
         self.assertEqual(timeout, conductor.RELEASE_TIMEOUT_SECONDS)
 
+    def test_release_local_install_delegates_installer_with_release_lanes_and_confirmation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            registry = conductor.OperationRegistry(Path(tmp))
+            argv, lanes, _cwd, env, timeout = registry.prepare(
+                {
+                    "operation": "release",
+                    "args": {"subcommand": "local-install"},
+                    "env": {
+                        "CONFIRM_LOCAL_PRODUCTION_INSTALL": "1",
+                        "LOCAL_SELF_SIGNED_CERTIFICATE_NAME": "divergent override",
+                    },
+                }
+            )
+
+        self.assertEqual(Path(argv[0]).name, "install_local_production.sh")
+        self.assertEqual(lanes, ["build", "debugArtifact", "release"])
+        self.assertEqual(env["CONFIRM_LOCAL_PRODUCTION_INSTALL"], "1")
+        self.assertNotIn("LOCAL_SELF_SIGNED_CERTIFICATE_NAME", env)
+        self.assertEqual(timeout, conductor.RELEASE_TIMEOUT_SECONDS)
+
     def test_app_stop_supersedes_queued_live_app_but_not_build_only_work(self) -> None:
         tmp, state = self.make_state()
         self.addCleanup(tmp.cleanup)

--- a/Scripts/test_local_production_installer.py
+++ b/Scripts/test_local_production_installer.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Focused regression tests for the local production installer."""
+
+from __future__ import annotations
+
+import os
+import plistlib
+import shutil
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+ROOT_DIR = SCRIPT_DIR.parent
+PINNED_CERTIFICATE_NAME = "RepoPrompt CE Local Self-Signed Code Signing"
+
+
+class LocalProductionInstallerTests(unittest.TestCase):
+    def test_local_entitlements_keep_runtime_capabilities_without_developer_id_identity_keys(self) -> None:
+        template = ROOT_DIR / "AppBundle" / "RepoPrompt.local-self-signed.entitlements.template"
+        with template.open("rb") as handle:
+            entitlements = plistlib.load(handle)
+
+        self.assertEqual(
+            entitlements,
+            {
+                "com.apple.security.cs.allow-jit": True,
+                "com.apple.security.files.bookmarks.app-scope": True,
+                "com.apple.security.temporary-exception.mach-lookup.global-name": [
+                    "__BUNDLE_ID__-spks",
+                    "__BUNDLE_ID__-spki",
+                ],
+            },
+        )
+
+        package_script = (SCRIPT_DIR / "package_app.sh").read_text(encoding="utf-8")
+        self.assertIn('LOCAL_SELF_SIGNED_CERTIFICATE_NAME="RepoPrompt CE Local Self-Signed Code Signing"', package_script)
+        self.assertIn('phase "Rendering local self-signed entitlements"', package_script)
+        self.assertIn('APP_SIGN_ARGS+=(--entitlements "$APP_ENTITLEMENTS")', package_script)
+
+    def test_failed_replacement_restores_prior_app_and_preserves_spaces_in_keychain_path(self) -> None:
+        result, install_dir = self.run_installer(fail_final_install_move=True)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual((install_dir / "RepoPrompt CE.app" / "payload.txt").read_text(encoding="utf-8"), "old\n")
+        self.assertEqual(list(install_dir.glob(".RepoPrompt CE.app.backup.*")), [])
+
+    def test_successful_replacement_removes_backup(self) -> None:
+        result, install_dir = self.run_installer(fail_final_install_move=False)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual((install_dir / "RepoPrompt CE.app" / "payload.txt").read_text(encoding="utf-8"), "new\n")
+        self.assertEqual(list(install_dir.glob(".RepoPrompt CE.app.backup.*")), [])
+        self.assertEqual(list(install_dir.glob(".RepoPrompt CE.app.installing.*")), [])
+
+    def run_installer(self, *, fail_final_install_move: bool) -> tuple[subprocess.CompletedProcess[str], Path]:
+        temp_dir = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, temp_dir, True)
+        root = temp_dir / "repo"
+        scripts = root / "Scripts"
+        scripts.mkdir(parents=True)
+        shutil.copy2(SCRIPT_DIR / "install_local_production.sh", scripts / "install_local_production.sh")
+        (root / "version.env").write_text(
+            'APP_NAME=RepoPrompt\nDISPLAY_NAME="RepoPrompt CE"\nBUNDLE_ID=com.pvncher.repoprompt.ce\n',
+            encoding="utf-8",
+        )
+
+        build_dir = temp_dir / "build"
+        install_dir = temp_dir / "Applications"
+        installed_app = install_dir / "RepoPrompt CE.app"
+        installed_app.mkdir(parents=True)
+        (installed_app / "payload.txt").write_text("old\n", encoding="utf-8")
+        keychain = temp_dir / "Library" / "Keychains" / "login keychain-db"
+        keychain.parent.mkdir(parents=True)
+        keychain.touch()
+
+        (scripts / "package_app.sh").write_text(
+            textwrap.dedent(
+                """\
+                #!/usr/bin/env bash
+                set -euo pipefail
+                app="$FAKE_BUILD_DIR/RepoPrompt.app"
+                mkdir -p "$app/Contents"
+                printf 'new\\n' > "$app/payload.txt"
+                cat > "$app/Contents/Info.plist" <<'EOF'
+                <?xml version="1.0" encoding="UTF-8"?>
+                <plist version="1.0"><dict><key>RepoPromptSigningMode</key><string>local-self-signed</string></dict></plist>
+                EOF
+                """
+            ),
+            encoding="utf-8",
+        )
+        (scripts / "package_app.sh").chmod(0o755)
+
+        bin_dir = temp_dir / "bin"
+        bin_dir.mkdir()
+        self.write_stub(
+            bin_dir,
+            "security",
+            """\
+            case "$1" in
+                default-keychain) printf '    "%s"\\n' "$FAKE_KEYCHAIN" ;;
+                find-identity) printf '  1) ABCDEF "%s"\\n' "$PINNED_CERTIFICATE_NAME" ;;
+                *) exit 0 ;;
+            esac
+            """,
+        )
+        self.write_stub(bin_dir, "swift", 'printf "%s\\n" "$FAKE_BUILD_DIR"\n')
+        self.write_stub(
+            bin_dir,
+            "plutil",
+            """\
+            if [[ "$1" == "-extract" ]]; then
+                printf 'local-self-signed\\n'
+            fi
+            """,
+        )
+        self.write_stub(bin_dir, "codesign", "exit 0\n")
+        self.write_stub(bin_dir, "openssl", "exit 0\n")
+        self.write_stub(bin_dir, "pgrep", "exit 1\n")
+        self.write_stub(bin_dir, "ditto", 'cp -R "$1" "$2"\n')
+        self.write_stub(
+            bin_dir,
+            "mv",
+            """\
+            if [[ "${FAIL_FINAL_INSTALL_MOVE:-0}" == "1" && "$1" == *".installing."*"/RepoPrompt CE.app" && "$2" == *"/RepoPrompt CE.app" ]]; then
+                exit 23
+            fi
+            exec /bin/mv "$@"
+            """,
+        )
+
+        env = os.environ.copy()
+        env.update(
+            {
+                "PATH": f"{bin_dir}:{env.get('PATH', '')}",
+                "CONFIRM_LOCAL_PRODUCTION_INSTALL": "1",
+                "LOCAL_PRODUCTION_INSTALL_DIR": str(install_dir),
+                "LOCAL_SELF_SIGNED_CERTIFICATE_NAME": "divergent override",
+                "FAKE_BUILD_DIR": str(build_dir),
+                "FAKE_KEYCHAIN": str(keychain),
+                "PINNED_CERTIFICATE_NAME": PINNED_CERTIFICATE_NAME,
+                "FAIL_FINAL_INSTALL_MOVE": "1" if fail_final_install_move else "0",
+            }
+        )
+        result = subprocess.run(
+            ["bash", str(scripts / "install_local_production.sh")],
+            env=env,
+            text=True,
+            capture_output=True,
+            timeout=10,
+        )
+        return result, install_dir
+
+    @staticmethod
+    def write_stub(bin_dir: Path, name: str, body: str) -> None:
+        path = bin_dir / name
+        path.write_text("#!/usr/bin/env bash\nset -euo pipefail\n" + textwrap.dedent(body), encoding="utf-8")
+        path.chmod(0o755)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Sources/RepoPrompt/Infrastructure/Security/BundleVerifier.swift
+++ b/Sources/RepoPrompt/Infrastructure/Security/BundleVerifier.swift
@@ -12,11 +12,16 @@ import Security
 class BundleVerifier {
     private static let expectedBundleIdentifier = SecurityObfuscation.decode(SecurityObfuscation.expectedBundleIdentifierEncoded)
     private static let expectedTeamIdentifier = SecurityObfuscation.decode(SecurityObfuscation.expectedTeamIdentifierEncoded)
+    #if REPOPROMPT_LOCAL_SELF_SIGNED_BUILD
+        private static let localSelfSignedCertificateName = "RepoPrompt CE Local Self-Signed Code Signing"
+        private static let localSelfSignedSigningMode = "local-self-signed"
+    #endif
 
     /// Error types that can occur during bundle verification
     enum VerificationError: Error, CustomStringConvertible {
         case bundleURLInvalid
         case codeSignatureCreationFailed
+        case signingModeInvalid
         case signatureValidationFailed(OSStatus)
 
         var description: String {
@@ -25,6 +30,8 @@ class BundleVerifier {
                 "Invalid bundle URL"
             case .codeSignatureCreationFailed:
                 "Failed to create code signature reference"
+            case .signingModeInvalid:
+                "Invalid signing mode"
             case let .signatureValidationFailed(status):
                 SecCopyErrorMessageString(status, nil) as String? ?? "Signature validation failed (\(status))"
             }
@@ -65,17 +72,22 @@ class BundleVerifier {
             throw VerificationError.signatureValidationFailed(validationResult)
         }
 
-        try verifySigningIdentity(for: code)
+        try verifySigningIdentity(for: code, bundle: bundle)
 
         return true
     }
 
     // MARK: - Identity Requirements
 
-    private static func verifySigningIdentity(for code: SecStaticCode) throws {
+    private static func verifySigningIdentity(for code: SecStaticCode, bundle: Bundle) throws {
         // In debug builds, verify team ID only (bundle ID differs between debug/release)
         // In release builds, verify both bundle ID and team ID
-        #if DEBUG
+        #if REPOPROMPT_LOCAL_SELF_SIGNED_BUILD
+            guard bundle.object(forInfoDictionaryKey: "RepoPromptSigningMode") as? String == localSelfSignedSigningMode else {
+                throw VerificationError.signingModeInvalid
+            }
+            let requirementString = "anchor trusted and identifier \"\(expectedBundleIdentifier)\" and certificate leaf[subject.CN] = \"\(localSelfSignedCertificateName)\""
+        #elseif DEBUG
             let requirementString = "anchor apple generic and certificate leaf[subject.OU] = \"\(expectedTeamIdentifier)\""
         #else
             let requirementString = "anchor apple generic and identifier \"\(expectedBundleIdentifier)\" and certificate leaf[subject.OU] = \"\(expectedTeamIdentifier)\""

--- a/Tests/RepoPromptTests/AgentMode/ClaudeCompatible/ClaudeCompatiblePluginBridgeTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/ClaudeCompatible/ClaudeCompatiblePluginBridgeTests.swift
@@ -145,7 +145,7 @@ final class ClaudeCompatiblePluginBridgeTests: XCTestCase {
             guard resourceValues.isRegularFile == true else { continue }
             let contents = try String(contentsOf: url, encoding: .utf8)
             guard contents.contains("import RepoPromptClaudeCompatibleProvider") else { continue }
-            imports.append(url.path.replacingOccurrences(of: repoRoot.path + "/", with: ""))
+            imports.append(RepoRoot.relativePath(for: url, relativeTo: repoRoot))
         }
         return imports.sorted()
     }

--- a/Tests/RepoPromptTests/Helpers/RepoRoot.swift
+++ b/Tests/RepoPromptTests/Helpers/RepoRoot.swift
@@ -30,6 +30,15 @@ enum RepoRoot {
             current = parent
         }
     }
+
+    static func relativePath(for fileURL: URL, relativeTo rootURL: URL) -> String {
+        let rootPath = rootURL.standardizedFileURL.path
+        let filePath = fileURL.standardizedFileURL.path
+        let prefix = rootPath.hasSuffix("/") ? rootPath : rootPath + "/"
+
+        guard filePath.hasPrefix(prefix) else { return filePath }
+        return String(filePath.dropFirst(prefix.count))
+    }
 }
 
 enum RepoRootError: Error, CustomStringConvertible {

--- a/Tests/RepoPromptTests/MCP/CECLINamingAndRoutingTests.swift
+++ b/Tests/RepoPromptTests/MCP/CECLINamingAndRoutingTests.swift
@@ -41,7 +41,7 @@ final class CECLINamingAndRoutingTests: XCTestCase {
             includingPropertiesForKeys: nil
         )
         .filter { $0.pathExtension == "swift" }
-        .map { $0.path.replacingOccurrences(of: root.path + "/", with: "") }
+        .map { RepoRoot.relativePath(for: $0, relativeTo: root) }
         .sorted()
 
         let relativePaths = [

--- a/Tests/RepoPromptTests/Prompt/PromptResourceMirrorRemovalTests.swift
+++ b/Tests/RepoPromptTests/Prompt/PromptResourceMirrorRemovalTests.swift
@@ -22,7 +22,7 @@ final class PromptResourceMirrorRemovalTests: XCTestCase {
 
         for file in try swiftFiles(under: scannedRoots) {
             let contents = try String(contentsOf: file, encoding: .utf8)
-            let displayPath = file.path.replacingOccurrences(of: repoRoot.path + "/", with: "")
+            let displayPath = RepoRoot.relativePath(for: file, relativeTo: repoRoot)
 
             for fragment in forbiddenFragments {
                 XCTAssertFalse(

--- a/docs/open-source-readiness.md
+++ b/docs/open-source-readiness.md
@@ -86,6 +86,7 @@ Completed account setup on 2026-05-31:
 
 Remaining blockers:
 
+- Resolve the GitHub Actions admission failure before the first protected CI draft release: newly queued jobs currently fail before any steps run with GitHub's billing-or-spending-limit annotation.
 - Enable a GitHub configuration that exposes required-reviewer protection for the `release` environment, or document and enforce an equivalent maintainer approval gate before treating the publishing workflow as protected. The current private-repository settings do not expose a required-reviewer control.
 - Scrub the historical contributor cohort from existing git history before the repository is made public.
 - Finish the comprehensive notice inventory for SwiftPM dependencies.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -63,6 +63,35 @@ artifact.
 Contributors should not upload this artifact to GitHub Releases. It is useful
 for packaging review and local testing only.
 
+## Install a local self-signed production build
+
+Users who want a release-mode build without maintainer credentials can install
+a local-only production app with:
+
+```bash
+CONFIRM_LOCAL_PRODUCTION_INSTALL=1 make dev-install-local-production
+```
+
+The direct fallback command is:
+
+```bash
+CONFIRM_LOCAL_PRODUCTION_INSTALL=1 make install-local-production
+```
+
+The installer creates or reuses a dedicated user-local self-signed code-signing
+identity named `RepoPrompt CE Local Self-Signed Code Signing`, installs its
+trust policy for code signing in the user's default login keychain, builds the
+release configuration, deep-signs the complete bundle, verifies the signature,
+and installs `RepoPrompt CE.app` under `/Applications`. macOS may ask the user
+to confirm the local certificate trust change when the identity is first
+created.
+
+This path is intentionally separate from public distribution. The resulting app
+is compiled with a local-only runtime verification mode, is not notarized, must
+not be uploaded to GitHub Releases, and should not be copied to another Mac.
+Official releases continue to require the CE Developer ID identity,
+provisioning profile, hardened runtime entitlements, notarization, and stapling.
+
 ## Maintainer setup
 
 Create a protected GitHub Actions environment named `release`. Require


### PR DESCRIPTION
## Summary
- add a local-only release-mode installer that creates or reuses a dedicated user-local self-signed code-signing identity
- sign and verify the complete bundle with narrow local entitlements and a runtime signing-mode marker
- route the installer through conductor, document the contributor workflow, and record the GitHub Actions billing admission blocker
- keep SwiftFormat scoped to canonical first-party files and make repository-root test paths robust in macOS temporary worktrees

## Validation
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh commit`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh push`
- `make dev-release-preflight`
- `make dev-release-artifact`
- `CONFIRM_LOCAL_PRODUCTION_INSTALL=1 LOCAL_PRODUCTION_INSTALL_DIR=/tmp/repoprompt-ce-local-production-smoke make dev-install-local-production`
- direct verification of installed bundle marker, deep signature, trusted local CN requirement, no team identifier, and narrow local entitlements
- `make conductor-selftest`
- `make guardrails`
- `make dev-lint`
- full coordinated root tests via push preflight
- focused `CECLINamingAndRoutingTests`, `ClaudeCompatiblePluginBridgeTests`, and `PromptResourceMirrorRemovalTests`

## Live smoke note
- non-disruptive `make dev-smoke` was attempted and recorded; it could not connect because the CE debug app is not currently running or MCP is disabled. No visible app launch was performed.
