### PR TITLE
Add Finder launcher for local production installs

### DIFF
--- a/.agents/skills/rpce-release/SKILL.md
+++ b/.agents/skills/rpce-release/SKILL.md
@@ -18,7 +18,9 @@ make dev-release-artifact
 ```
 
 For a local-only release-mode installation signed by the user's own dedicated
-self-signed identity, use:
+self-signed identity, double-click
+[`Install RepoPrompt CE Local Production.command`](../../../Install%20RepoPrompt%20CE%20Local%20Production.command)
+in Finder or use:
 
 ```bash
 CONFIRM_LOCAL_PRODUCTION_INSTALL=1 make dev-install-local-production

--- a/Install RepoPrompt CE Local Production.command
+++ b/Install RepoPrompt CE Local Production.command
@@ -5,6 +5,8 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONDUCTOR="$ROOT_DIR/conductor"
 INSTALL_SCRIPT="$ROOT_DIR/Scripts/install_local_production.sh"
 INSTALL_MODE="coordinated"
+INSTALL_DIR="${LOCAL_PRODUCTION_INSTALL_DIR:-/Applications}"
+TARGET_APP="$INSTALL_DIR/RepoPrompt CE.app"
 
 if ! command -v python3 >/dev/null 2>&1; then
     INSTALL_MODE="direct"
@@ -47,14 +49,15 @@ else
     echo "Mode:    direct (python3 unavailable - running without the dev daemon)"
 fi
 echo
-echo "This installs a release-mode RepoPrompt CE.app under /Applications using a"
-echo "dedicated self-signed certificate trusted only on this Mac."
+echo "This builds a release-mode app and replaces any existing app at:"
+echo "$TARGET_APP"
+echo "using a dedicated self-signed certificate trusted only on this Mac."
 echo
 echo "The installed app is local-only: it is not notarized, must not be uploaded"
 echo "to GitHub Releases, and should not be copied to another Mac."
 echo
 
-if ! IFS= read -r -p "Continue with the local production install? [y/N] " choice; then
+if ! IFS= read -r -p "Build and replace $TARGET_APP? [y/N] " choice; then
     echo
     echo "Install canceled."
     exit 0

--- a/Install RepoPrompt CE Local Production.command
+++ b/Install RepoPrompt CE Local Production.command
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONDUCTOR="$ROOT_DIR/conductor"
+INSTALL_SCRIPT="$ROOT_DIR/Scripts/install_local_production.sh"
+INSTALL_MODE="coordinated"
+
+if ! command -v python3 >/dev/null 2>&1; then
+    INSTALL_MODE="direct"
+    if [[ ! -x "$INSTALL_SCRIPT" ]]; then
+        echo "Python 3 isn't available, and the direct installer script is missing:"
+        echo "$INSTALL_SCRIPT"
+        echo
+        echo "Make sure this file is still in the repoprompt-ce folder and that Scripts/install_local_production.sh is executable."
+        read -r -p "Press Return to close this window..." || true
+        exit 1
+    fi
+elif [[ ! -x "$CONDUCTOR" ]]; then
+    echo "Couldn't find the coordinated installer:"
+    echo "$CONDUCTOR"
+    echo
+    echo "Make sure this file is still in the repoprompt-ce folder and that conductor is executable."
+    read -r -p "Press Return to close this window..." || true
+    exit 1
+fi
+
+install_app() {
+    echo
+    echo "Building and installing RepoPrompt CE..."
+    echo "macOS may ask you to approve the dedicated local code-signing certificate."
+    echo
+    if [[ "$INSTALL_MODE" == "coordinated" ]]; then
+        CONFIRM_LOCAL_PRODUCTION_INSTALL=1 "$CONDUCTOR" release local-install
+    else
+        CONFIRM_LOCAL_PRODUCTION_INSTALL=1 "$INSTALL_SCRIPT"
+    fi
+}
+
+clear 2>/dev/null || true
+echo "RepoPrompt CE - local self-signed production installer"
+echo
+echo "Project: $ROOT_DIR"
+if [[ "$INSTALL_MODE" == "coordinated" ]]; then
+    echo "Mode:    coordinated (build and install run through the dev daemon)"
+else
+    echo "Mode:    direct (python3 unavailable - running without the dev daemon)"
+fi
+echo
+echo "This installs a release-mode RepoPrompt CE.app under /Applications using a"
+echo "dedicated self-signed certificate trusted only on this Mac."
+echo
+echo "The installed app is local-only: it is not notarized, must not be uploaded"
+echo "to GitHub Releases, and should not be copied to another Mac."
+echo
+
+if ! IFS= read -r -p "Continue with the local production install? [y/N] " choice; then
+    echo
+    echo "Install canceled."
+    exit 0
+fi
+
+case "$choice" in
+    y | Y | yes | YES | Yes)
+        ;;
+    *)
+        echo
+        echo "Install canceled."
+        exit 0
+        ;;
+esac
+
+cd "$ROOT_DIR" || exit 1
+if install_app; then
+    echo
+    echo "RepoPrompt CE local production app installed successfully."
+else
+    status=$?
+    echo
+    echo "RepoPrompt CE local production install failed."
+    echo "Review the output above, then run this launcher again to retry."
+    read -r -p "Press Return to close this window..." || true
+    exit "$status"
+fi
+
+echo
+read -r -p "Press Return to close this window..." || true

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 ![Platform: macOS 26+](https://img.shields.io/badge/platform-macOS%2026%2B-black)
 
-**A native macOS app and agent orchestrator for context engineering.**
+**A free, open-source native macOS app and agent orchestrator for context engineering.**
 
 RepoPrompt CE helps coding agents understand your codebase before they act. It
 assembles focused, reviewable context from files, CodeMaps, repository
@@ -39,7 +39,7 @@ For a release-mode app under `/Applications`, double-click
 [`Install RepoPrompt CE Local Production.command`](Install%20RepoPrompt%20CE%20Local%20Production.command)
 in Finder.
 
-The installer builds RepoPrompt CE from source and installs
+The installer builds RepoPrompt CE from source and replaces any existing
 `/Applications/RepoPrompt CE.app` using a dedicated self-signed certificate
 trusted only on your Mac. macOS may ask you to approve the certificate.
 

--- a/README.md
+++ b/README.md
@@ -1,53 +1,30 @@
 # RepoPrompt CE
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
-![Platform: macOS 14+](https://img.shields.io/badge/platform-macOS%2014%2B-black)
+![Platform: macOS 26+](https://img.shields.io/badge/platform-macOS%2026%2B-black)
 
-**The open-source macOS Context IDE for AI coding agents.**
+**A native macOS app and agent orchestrator for context engineering.**
 
-RepoPrompt CE helps you assemble, inspect, and hand off rich codebase context.
-Pick the right files across one or more repositories, summarize project
-structure and Git history, and package it all into a dense, reviewable prompt
-for ChatGPT, Claude, Codex, Cursor, and other AI coding tools — or hand that
-context straight to agents through the bundled MCP server and CLI.
+RepoPrompt CE helps coding agents understand your codebase before they act. It
+assembles focused, reviewable context from files, CodeMaps, repository
+structure, and Git diffs, then hands that context to AI tools and CLI agents.
 
-> **Heads up:** RepoPrompt CE is built largely *with* and *for* AI coding
-> agents. This README is written for people getting started; the deeper
-> day-to-day development workflow lives in [`AGENTS.md`](AGENTS.md) and is
-> geared toward agents.
+RepoPrompt CE also builds an agent harness around its bundled MCP server.
+Connect MCP-compatible clients and CLI agents to search repositories, inspect
+files, curate context, run agent sessions, and orchestrate work through a shared
+native macOS interface.
 
-## Features
+## Get Started
 
-- **Curate context** — Build focused, reviewable context for an AI model from
-  one or more repositories.
-- **Combine everything** — Merge selected files, project-structure maps,
-  function/type CodeMaps, and Git diffs into a single prompt.
-- **Discover automatically** — Run Context Builder to find relevant code and
-  produce an optimized prompt for you.
-- **Think it through** — Plan, review, and ask follow-up questions in built-in
-  chat, including an Oracle flow for second opinions.
-- **Run agents** — Drive longer sessions in Agent Mode with supported
-  CLI-backed providers.
-- **Connect your tools** — Let external MCP clients search, inspect, and select
-  repository context from your own setup.
+Choose one of these local setup paths. You do not need to open Xcode.
 
-## Quick Start
+### Build and launch locally
 
-RepoPrompt CE currently runs as a local source build — you do not need to open
-Xcode.
+For development and quick evaluation, double-click
+[`Launch RepoPrompt CE.command`](Launch%20RepoPrompt%20CE.command) in Finder.
 
-**Requirements**
-
-- macOS 14 (Sonoma) or later
-- Xcode 26, or the matching Command Line Tools with the macOS 26 SDK
-
-**Run the app**
-
-1. Double-click [`Launch RepoPrompt CE.command`](Launch%20RepoPrompt%20CE.command)
-   in Finder. The launcher builds and opens RepoPrompt CE for you.
-2. Keep the small launcher terminal open while you use the app.
-
-**Launcher controls**
+The launcher builds RepoPrompt CE from source, opens the debug app, and keeps a
+small terminal window available for rebuild, status, and stop controls.
 
 | Key | Action                                      |
 | --- | ------------------------------------------- |
@@ -56,42 +33,65 @@ Xcode.
 | `x` | Stop the app                                |
 | `q` | Close the launcher without stopping the app |
 
-**Install a local production build**
+### Install a local production build
 
-Double-click
+For a release-mode app under `/Applications`, double-click
 [`Install RepoPrompt CE Local Production.command`](Install%20RepoPrompt%20CE%20Local%20Production.command)
-in Finder to build and install a release-mode app under `/Applications` using
-your own self-signed local certificate. The resulting app is local-only: it is
-not notarized and should not be redistributed.
+in Finder.
+
+The installer builds RepoPrompt CE from source and installs
+`/Applications/RepoPrompt CE.app` using a dedicated self-signed certificate
+trusted only on your Mac. macOS may ask you to approve the certificate.
+
+The resulting app is local-only. It is not notarized and should not be copied to
+another Mac or redistributed.
+
+### Source-build requirements
+
+- macOS 26 or later
+- Xcode 26, or matching Command Line Tools with the macOS 26 SDK
+
+## Features
+
+- **Context engineering**: Build dense, reviewable prompts with the files and
+  repository details an AI model actually needs.
+- **Codebase orientation**: Combine file trees, selected file contents, line
+  slices, CodeMaps, and Git diffs.
+- **Context Builder**: Let an agent explore the repository, identify relevant
+  files, and curate context within a token budget.
+- **Agent orchestration**: Run and coordinate CLI-backed coding agents from the
+  native macOS app.
+- **MCP server and CLI integration**: Connect external MCP-compatible tools and
+  CLI agents to RepoPrompt CE's repository context and agent harness.
+- **Multi-root workspaces**: Work across related repositories, packages, and
+  documentation folders in one workspace.
+- **Reviewable handoffs**: Inspect and refine selected context before sending it
+  to another model or agent.
 
 ## About the Community Edition
 
-RepoPrompt CE is the open-source community edition of RepoPrompt, originally a
-paid macOS app. It removes paid activation flows and license keys while keeping
-the core prompt, copy, chat, CodeMap, Agent Mode, and custom-provider features
-available without paid license gates.
+RepoPrompt CE is the free, open-source community edition of RepoPrompt. It is a
+native macOS workspace for context engineering, agent orchestration, and local
+development.
 
 Maintainers track release signing, Sparkle metadata, dependency pins, and
 third-party notices in
 [`docs/open-source-readiness.md`](docs/open-source-readiness.md).
 
-## Documentation
+## Contributor Documentation
 
-The detailed development workflow is split across focused docs — most are
-oriented toward contributors and agents:
-
-- [`AGENTS.md`](AGENTS.md) — start here for coordinated builds, tests, launches,
-  live MCP checks, source placement, and contribution preflight.
-- [`CONTRIBUTING.md`](CONTRIBUTING.md) — contribution policy and pull request
-  steps.
-- [`docs/architecture/source-layout.md`](docs/architecture/source-layout.md) —
-  source ownership and placement rules.
-- [`docs/architecture/provider-plugins.md`](docs/architecture/provider-plugins.md)
-  — Agent Mode provider architecture.
-- [`docs/releasing.md`](docs/releasing.md) — release-candidate and publishing
-  workflows.
-- [`docs/open-source-readiness.md`](docs/open-source-readiness.md) — public
-  readiness inventory.
+- [`AGENTS.md`](AGENTS.md): coordinated builds, tests, launches, live MCP
+  checks, source placement, and contribution preflight
+- [`CONTRIBUTING.md`](CONTRIBUTING.md): contribution policy and pull request
+  steps
+- [`docs/architecture/source-layout.md`](docs/architecture/source-layout.md):
+  source ownership and placement rules
+- [`docs/architecture/provider-plugins.md`](docs/architecture/provider-plugins.md):
+  Agent Mode provider architecture
+- [`docs/releasing.md`](docs/releasing.md): release-candidate and publishing
+  workflows
+- [`docs/open-source-readiness.md`](docs/open-source-readiness.md): public
+  readiness inventory
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@ Xcode.
 | `x` | Stop the app                                |
 | `q` | Close the launcher without stopping the app |
 
+**Install a local production build**
+
+Double-click
+[`Install RepoPrompt CE Local Production.command`](Install%20RepoPrompt%20CE%20Local%20Production.command)
+in Finder to build and install a release-mode app under `/Applications` using
+your own self-signed local certificate. The resulting app is local-only: it is
+not notarized and should not be redistributed.
+
 ## About the Community Edition
 
 RepoPrompt CE is the open-source community edition of RepoPrompt, originally a

--- a/Scripts/test_local_production_installer.py
+++ b/Scripts/test_local_production_installer.py
@@ -55,6 +55,80 @@ class LocalProductionInstallerTests(unittest.TestCase):
 
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(captured_lines, ["1", "release", "local-install"])
+        self.assertIn("replaces any existing app at", result.stdout)
+        self.assertIn(
+            'read -r -p "Build and replace $TARGET_APP? [y/N] "',
+            launcher.read_text(encoding="utf-8"),
+        )
+
+    def test_finder_launcher_decline_does_not_invoke_conductor(self) -> None:
+        launcher = ROOT_DIR / "Install RepoPrompt CE Local Production.command"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            copied_launcher = root / launcher.name
+            shutil.copy2(launcher, copied_launcher)
+            capture = root / "capture.txt"
+            conductor = root / "conductor"
+            conductor.write_text(
+                "#!/bin/bash\nprintf 'invoked\\n' > \"$LAUNCHER_CAPTURE\"\n",
+                encoding="utf-8",
+            )
+            conductor.chmod(0o755)
+
+            env = os.environ.copy()
+            env["LAUNCHER_CAPTURE"] = str(capture)
+            result = subprocess.run(
+                ["bash", str(copied_launcher)],
+                env=env,
+                input="n\n",
+                text=True,
+                capture_output=True,
+                timeout=10,
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertFalse(capture.exists())
+        self.assertIn("Install canceled.", result.stdout)
+
+    def test_finder_launcher_falls_back_to_direct_installer_without_python3(self) -> None:
+        launcher = ROOT_DIR / "Install RepoPrompt CE Local Production.command"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            copied_launcher = root / launcher.name
+            shutil.copy2(launcher, copied_launcher)
+            scripts = root / "Scripts"
+            scripts.mkdir()
+            capture = root / "capture.txt"
+            direct_installer = scripts / "install_local_production.sh"
+            direct_installer.write_text(
+                "#!/bin/bash\nprintf '%s\\n' \"$CONFIRM_LOCAL_PRODUCTION_INSTALL\" > \"$LAUNCHER_CAPTURE\"\n",
+                encoding="utf-8",
+            )
+            direct_installer.chmod(0o755)
+            bin_dir = root / "bin"
+            bin_dir.mkdir()
+            dirname = shutil.which("dirname")
+            self.assertIsNotNone(dirname)
+            os.symlink(dirname, bin_dir / "dirname")
+
+            env = os.environ.copy()
+            env["PATH"] = str(bin_dir)
+            env["LAUNCHER_CAPTURE"] = str(capture)
+            result = subprocess.run(
+                ["/bin/bash", str(copied_launcher)],
+                env=env,
+                input="y\n\n",
+                text=True,
+                capture_output=True,
+                timeout=10,
+            )
+            captured_lines = capture.read_text(encoding="utf-8").splitlines()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(captured_lines, ["1"])
+        self.assertIn("Mode:    direct (python3 unavailable - running without the dev daemon)", result.stdout)
 
     def test_local_entitlements_keep_runtime_capabilities_without_developer_id_identity_keys(self) -> None:
         template = ROOT_DIR / "AppBundle" / "RepoPrompt.local-self-signed.entitlements.template"

--- a/Scripts/test_local_production_installer.py
+++ b/Scripts/test_local_production_installer.py
@@ -18,6 +18,44 @@ PINNED_CERTIFICATE_NAME = "RepoPrompt CE Local Self-Signed Code Signing"
 
 
 class LocalProductionInstallerTests(unittest.TestCase):
+    def test_finder_launcher_routes_confirmed_install_through_conductor(self) -> None:
+        launcher = ROOT_DIR / "Install RepoPrompt CE Local Production.command"
+        self.assertTrue(os.access(launcher, os.X_OK))
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            copied_launcher = root / launcher.name
+            shutil.copy2(launcher, copied_launcher)
+            capture = root / "capture.txt"
+            conductor = root / "conductor"
+            conductor.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/usr/bin/env bash
+                    set -euo pipefail
+                    printf '%s\\n' "$CONFIRM_LOCAL_PRODUCTION_INSTALL" > "$LAUNCHER_CAPTURE"
+                    printf '%s\\n' "$@" >> "$LAUNCHER_CAPTURE"
+                    """
+                ),
+                encoding="utf-8",
+            )
+            conductor.chmod(0o755)
+
+            env = os.environ.copy()
+            env["LAUNCHER_CAPTURE"] = str(capture)
+            result = subprocess.run(
+                ["bash", str(copied_launcher)],
+                env=env,
+                input="y\n\n",
+                text=True,
+                capture_output=True,
+                timeout=10,
+            )
+            captured_lines = capture.read_text(encoding="utf-8").splitlines()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(captured_lines, ["1", "release", "local-install"])
+
     def test_local_entitlements_keep_runtime_capabilities_without_developer_id_identity_keys(self) -> None:
         template = ROOT_DIR / "AppBundle" / "RepoPrompt.local-self-signed.entitlements.template"
         with template.open("rb") as handle:

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -68,9 +68,10 @@ for packaging review and local testing only.
 Users who want a release-mode build without maintainer credentials can install
 a local-only production app by double-clicking
 [`Install RepoPrompt CE Local Production.command`](../Install%20RepoPrompt%20CE%20Local%20Production.command)
-in Finder. The launcher confirms the local-only install, runs the coordinated
-developer daemon when Python 3 is available, and keeps the terminal window open
-so certificate approval prompts and build results remain visible.
+in Finder. The launcher confirms replacement of any existing installed app,
+runs the coordinated developer daemon when Python 3 is available, and keeps
+the terminal window open so certificate approval prompts and build results
+remain visible.
 
 The equivalent command-line path is:
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -66,7 +66,13 @@ for packaging review and local testing only.
 ## Install a local self-signed production build
 
 Users who want a release-mode build without maintainer credentials can install
-a local-only production app with:
+a local-only production app by double-clicking
+[`Install RepoPrompt CE Local Production.command`](../Install%20RepoPrompt%20CE%20Local%20Production.command)
+in Finder. The launcher confirms the local-only install, runs the coordinated
+developer daemon when Python 3 is available, and keeps the terminal window open
+so certificate approval prompts and build results remain visible.
+
+The equivalent command-line path is:
 
 ```bash
 CONFIRM_LOCAL_PRODUCTION_INSTALL=1 make dev-install-local-production


### PR DESCRIPTION
## Summary
- add a double-clickable Finder launcher for the local self-signed production installer
- route confirmed installs through the coordinated daemon with a direct fallback when Python 3 is unavailable
- document the Finder path and cover launcher delegation with a focused regression test

## Validation
- `bash -n "Install RepoPrompt CE Local Production.command" Scripts/install_local_production.sh Scripts/package_app.sh Scripts/release.sh Scripts/swift_style.sh`
- `git diff --check`
- `python3 Scripts/test_local_production_installer.py`
- `make conductor-selftest`
- `make guardrails`
- `make dev-release-preflight`
- `make dev-lint`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh commit`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh push`