### PR TITLE
Validate staged release before creating dist

### DIFF
--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -204,7 +204,6 @@ publish_staged_release() {
     require_command xcrun
     verify_publish_inputs
     require_env REPOPROMPT_APPROVED_SOURCE_ROOT
-    prepare_dist
     TMP_DIR="$(mktemp -d)"
 
     [[ -d "$APP_BUNDLE" ]] || fail "Missing secret-free staged app bundle: $APP_BUNDLE"
@@ -212,6 +211,7 @@ publish_staged_release() {
         "$CONTROL_PLANE_SCRIPTS_DIR/validate_staged_release.sh"
     REPOPROMPT_RELEASE_SOURCE_ROOT="$ROOT_DIR" \
         "$CONTROL_PLANE_SCRIPTS_DIR/sign_staged_release.sh"
+    prepare_dist
     validate_packaged_legal "$APP_BUNDLE"
 
     local notary_zip="$TMP_DIR/$ARCHIVE_BASENAME-notarization.zip"

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -17,6 +17,19 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 
 
 class ReleaseToolingTests(unittest.TestCase):
+    def test_publish_staged_validates_before_creating_dist(self) -> None:
+        release_script = (SCRIPT_DIR / "release.sh").read_text(encoding="utf-8")
+        publish_staged = release_script.split("publish_staged_release() {", 1)[1].split("\n}", 1)[0]
+
+        self.assertLess(
+            publish_staged.index('"$CONTROL_PLANE_SCRIPTS_DIR/validate_staged_release.sh"'),
+            publish_staged.index('"$CONTROL_PLANE_SCRIPTS_DIR/sign_staged_release.sh"'),
+        )
+        self.assertLess(
+            publish_staged.index('"$CONTROL_PLANE_SCRIPTS_DIR/sign_staged_release.sh"'),
+            publish_staged.index("prepare_dist"),
+        )
+
     def test_modern_sparkle_key_seed_derives_public_key(self) -> None:
         descriptor, key_path = tempfile.mkstemp()
         os.close(descriptor)


### PR DESCRIPTION
## Summary
- delay release output directory creation until the extracted stage has passed closed-world validation and signing
- add a regression assertion for the publish-staged ordering

## Validation
- `bash -n Scripts/release.sh Scripts/sign_staged_release.sh Scripts/validate_staged_release.sh`
- `git diff --check`
- `make guardrails`
- `make release-selftest`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh commit`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh push`