### PR TITLE
Add CI badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # RepoPrompt CE
 
+[![CI](https://github.com/repoprompt/repoprompt-ce/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/repoprompt/repoprompt-ce/actions/workflows/ci.yml?query=branch%3Amain)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 ![Platform: macOS 26+](https://img.shields.io/badge/platform-macOS%2026%2B-black)
 


### PR DESCRIPTION
## Summary

- Adds the GitHub Actions CI badge to the README header
- Keeps the existing Apache-2.0 license and macOS 26+ platform badges intact

## Validation

- `make guardrails`