### PR TITLE
Authenticate promotion latest release probe

### DIFF
--- a/Scripts/promote_release.sh
+++ b/Scripts/promote_release.sh
@@ -327,6 +327,8 @@ verify_strictly_newer_build() {
         --location \
         --silent \
         --show-error \
+        --header "Authorization: Bearer $PUBLIC_UPDATE_GH_TOKEN" \
+        --header "Accept: application/vnd.github+json" \
         --output "$latest_json_file" \
         --write-out '%{http_code}' \
         "https://api.github.com/repos/$PUBLIC_UPDATE_REPOSITORY/releases/latest")"; then
@@ -477,17 +479,19 @@ verify_anonymous_publish() {
     cmp "$APPCAST" "$published_source_appcast"
     cmp "$CHECKSUMS" "$published_source_checksums"
 
-    local update_latest source_latest
-    update_latest="$(curl_anonymous \
-        "https://api.github.com/repos/$PUBLIC_UPDATE_REPOSITORY/releases/latest" |
-        jq -r .tag_name)"
-    source_latest="$(curl_anonymous \
-        "https://api.github.com/repos/$SOURCE_GITHUB_REPOSITORY/releases/latest" |
-        jq -r .tag_name)"
-    [[ "$update_latest" == "$RELEASE_TAG" ]] ||
-        fail "Public updater latest tag mismatch: expected $RELEASE_TAG, got $update_latest"
-    [[ "$source_latest" == "$RELEASE_TAG" ]] ||
-        fail "Source latest tag mismatch: expected $RELEASE_TAG, got $source_latest"
+    local update_latest_url source_latest_url
+    update_latest_url="$(curl_anonymous \
+        --output /dev/null \
+        --write-out '%{url_effective}' \
+        "https://github.com/$PUBLIC_UPDATE_REPOSITORY/releases/latest")"
+    source_latest_url="$(curl_anonymous \
+        --output /dev/null \
+        --write-out '%{url_effective}' \
+        "https://github.com/$SOURCE_GITHUB_REPOSITORY/releases/latest")"
+    [[ "$update_latest_url" == "https://github.com/$PUBLIC_UPDATE_REPOSITORY/releases/tag/$RELEASE_TAG" ]] ||
+        fail "Public updater latest redirect mismatch: $update_latest_url"
+    [[ "$source_latest_url" == "https://github.com/$SOURCE_GITHUB_REPOSITORY/releases/tag/$RELEASE_TAG" ]] ||
+        fail "Source latest redirect mismatch: $source_latest_url"
 
     printf 'OK: anonymous release smoke passed for %s.\n' "$RELEASE_TAG"
 }

--- a/Scripts/test_release_promotion.py
+++ b/Scripts/test_release_promotion.py
@@ -318,6 +318,7 @@ class ReleasePromotionTests(unittest.TestCase):
             fake_bin,
             "curl",
             """\
+            args="$*"
             output=""
             url=""
             write_status=false
@@ -331,7 +332,9 @@ class ReleasePromotionTests(unittest.TestCase):
             done
             case "$url" in
                 https://api.github.com/repos/repoprompt/repoprompt-ce-updates/releases/latest)
-                    if [[ -n "$FAKE_LATEST_BUILD" && ! -f "$FAKE_PROMOTION_PUBLISHED" ]]; then
+                    if [[ "$args" != *"Authorization: Bearer update-token"* ]]; then
+                        $write_status && printf '403'
+                    elif [[ -n "$FAKE_LATEST_BUILD" && ! -f "$FAKE_PROMOTION_PUBLISHED" ]]; then
                         printf '{"tag_name":"v0.9.0"}\\n' > "$output"
                         $write_status && printf '200'
                     elif grep -q 'release edit v1.0.0 --repo repoprompt/repoprompt-ce-updates' "$FAKE_GH_CAPTURE" 2>/dev/null; then
@@ -345,8 +348,11 @@ class ReleasePromotionTests(unittest.TestCase):
                         $write_status && printf '%s' "$FAKE_LATEST_HTTP_STATUS"
                     fi
                     ;;
-                https://api.github.com/repos/repoprompt/repoprompt-ce/releases/latest)
-                    printf '{"tag_name":"v1.0.0"}\\n'
+                https://github.com/repoprompt/repoprompt-ce-updates/releases/latest)
+                    $write_status && printf 'https://github.com/repoprompt/repoprompt-ce-updates/releases/tag/v1.0.0'
+                    ;;
+                https://github.com/repoprompt/repoprompt-ce/releases/latest)
+                    $write_status && printf 'https://github.com/repoprompt/repoprompt-ce/releases/tag/v1.0.0'
                     ;;
                 */v0.9.0/appcast.xml) cp "$FAKE_ASSET_DIR/previous-appcast.xml" "$output" ;;
                 */appcast.xml) cp "$FAKE_ASSET_DIR/appcast.xml" "$output" ;;


### PR DESCRIPTION
## Summary
- authenticate the rollback-protection REST read with the narrowly scoped updater token to avoid shared-runner unauthenticated rate limits
- keep the final public proof anonymous by checking GitHub release-page redirects and release asset downloads
- simulate the unauthenticated `403` in the promotion regression fixture

## Validation
- `bash -n Scripts/promote_release.sh`
- `git diff --check`
- `make guardrails`
- `make release-selftest`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh commit`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh push`