### PR TITLE
Wait for reconciled Codex liveness status in test

### DIFF
--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexAgentModeCoordinatorLivenessTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexAgentModeCoordinatorLivenessTests.swift
@@ -8,12 +8,15 @@ final class CodexAgentModeCoordinatorLivenessTests: XCTestCase {
         let controller = LivenessFakeCodexController(snapshot: .active(activeFlags: ["waiting_for_user_input"]))
         let viewModel = makeViewModel(controller: controller)
         let session = preparedCodexSession(in: viewModel, controller: controller)
+        let waitingStatus = "Codex reports it is waiting for user input…"
 
         await viewModel.test_codexCoordinator.test_handleCodexNativeEvent(.assistantDelta("progress"), session: session)
 
-        try await waitUntil { controller.readSnapshotCountSync() > 0 }
+        try await waitUntil {
+            controller.readSnapshotCountSync() > 0 && session.runningStatusText == waitingStatus
+        }
 
-        XCTAssertEqual(session.runningStatusText, "Codex reports it is waiting for user input…")
+        XCTAssertEqual(session.runningStatusText, waitingStatus)
         XCTAssertFalse(session.items.contains { item in
             item.kind == .error && item.text.contains("Repo Prompt thinks Codex has stalled")
         })


### PR DESCRIPTION
## Summary
- wait for the Codex liveness snapshot to be reconciled before asserting the transport status text
- remove a race where the fake controller read counter advanced before the returned snapshot had been applied

## Validation
- `make dev-format`
- `make dev-lint`
- `make dev-test FILTER=CodexAgentModeCoordinatorLivenessTests`
- 10 consecutive `./conductor test --filter CodexAgentModeCoordinatorLivenessTests` runs
- `make dev-test`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh commit`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh push`