### PR TITLE
Document debug validation relaunches

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ For development and quick evaluation, double-click
 The launcher builds RepoPrompt CE from source, opens the debug app, and keeps a
 small terminal window available for rebuild, status, and stop controls.
 
+> **Note:** If you use the debug app to modify RepoPrompt CE itself, validation
+> will rebuild and relaunch the app. Expect the debug app to restart while those
+> checks run.
+
 | Key | Action                                      |
 | --- | ------------------------------------------- |
 | `r` | Rebuild and relaunch                        |


### PR DESCRIPTION
## Summary

- explain that validation may rebuild and relaunch the debug app when contributors use RepoPrompt CE to modify itself

## Validation

- `.agents/skills/rpce-contribution-check/scripts/preflight.sh commit`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh push`