### PR TITLE
Harden updater activation and release validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,9 +55,29 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Install gitleaks
         run: brew install gitleaks
+
+      - name: Scan introduced commit range
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+          CURRENT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            range="$PR_BASE_SHA..$PR_HEAD_SHA"
+          elif [[ -n "$PUSH_BEFORE_SHA" && ! "$PUSH_BEFORE_SHA" =~ ^0+$ ]]; then
+            range="$PUSH_BEFORE_SHA..$CURRENT_SHA"
+          else
+            range="$CURRENT_SHA"
+          fi
+          gitleaks git --redact --log-opts="$range" .
 
       - name: Scan checked-in source tree
         run: gitleaks dir --redact .

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ The launcher builds RepoPrompt CE from source, opens the debug app, and keeps a
 small terminal window available for rebuild, status, and stop controls.
 
 > **Note:** If you use the debug app to modify RepoPrompt CE itself, validation
-> will rebuild and relaunch the app. Expect the debug app to restart while those
-> checks run.
+> flows that launch the app or run live smoke checks may rebuild and relaunch it.
+> Expect the debug app to restart while those checks run.
 
 | Key | Action                                      |
 | --- | ------------------------------------------- |

--- a/Scripts/install_local_production.sh
+++ b/Scripts/install_local_production.sh
@@ -95,7 +95,11 @@ EOF
         -config "$TMP_DIR/openssl.cnf" \
         -out "$CERTIFICATE_PEM" \
         -keyout "$TMP_DIR/repoprompt-ce-local-signing-key.pem"
-    openssl pkcs12 -export -legacy \
+    local -a pkcs12_args=(-export)
+    if { openssl pkcs12 -help 2>&1 || true; } | grep -q -- '-legacy'; then
+        pkcs12_args+=(-legacy)
+    fi
+    openssl pkcs12 "${pkcs12_args[@]}" \
         -out "$TMP_DIR/repoprompt-ce-local-signing.p12" \
         -inkey "$TMP_DIR/repoprompt-ce-local-signing-key.pem" \
         -in "$CERTIFICATE_PEM" \

--- a/Scripts/test_local_production_installer.py
+++ b/Scripts/test_local_production_installer.py
@@ -167,7 +167,22 @@ class LocalProductionInstallerTests(unittest.TestCase):
         self.assertEqual(list(install_dir.glob(".RepoPrompt CE.app.backup.*")), [])
         self.assertEqual(list(install_dir.glob(".RepoPrompt CE.app.installing.*")), [])
 
-    def run_installer(self, *, fail_final_install_move: bool) -> tuple[subprocess.CompletedProcess[str], Path]:
+    def test_certificate_minting_omits_legacy_when_openssl_does_not_support_it(self) -> None:
+        result, _ = self.run_installer(
+            fail_final_install_move=False,
+            existing_identity=False,
+            openssl_rejects_legacy=True,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def run_installer(
+        self,
+        *,
+        fail_final_install_move: bool,
+        existing_identity: bool = True,
+        openssl_rejects_legacy: bool = False,
+    ) -> tuple[subprocess.CompletedProcess[str], Path]:
         temp_dir = Path(tempfile.mkdtemp())
         self.addCleanup(shutil.rmtree, temp_dir, True)
         root = temp_dir / "repo"
@@ -214,7 +229,12 @@ class LocalProductionInstallerTests(unittest.TestCase):
             """\
             case "$1" in
                 default-keychain) printf '    "%s"\\n' "$FAKE_KEYCHAIN" ;;
-                find-identity) printf '  1) ABCDEF "%s"\\n' "$PINNED_CERTIFICATE_NAME" ;;
+                find-identity)
+                    if [[ "$FAKE_EXISTING_IDENTITY" == "1" || -f "$FAKE_IMPORTED_IDENTITY" ]]; then
+                        printf '  1) ABCDEF "%s"\\n' "$PINNED_CERTIFICATE_NAME"
+                    fi
+                    ;;
+                import) : > "$FAKE_IMPORTED_IDENTITY" ;;
                 *) exit 0 ;;
             esac
             """,
@@ -230,7 +250,22 @@ class LocalProductionInstallerTests(unittest.TestCase):
             """,
         )
         self.write_stub(bin_dir, "codesign", "exit 0\n")
-        self.write_stub(bin_dir, "openssl", "exit 0\n")
+        self.write_stub(
+            bin_dir,
+            "openssl",
+            """\
+            if [[ "$1" == "rand" ]]; then
+                printf '0123456789abcdef0123456789abcdef0123456789abcdef\\n'
+            elif [[ "$1" == "pkcs12" && "${2:-}" == "-help" ]]; then
+                printf 'usage: pkcs12\\n'
+            elif [[ "$1" == "pkcs12" && "$OPENSSL_REJECTS_LEGACY" == "1" ]]; then
+                for argument in "$@"; do
+                    [[ "$argument" != "-legacy" ]] || exit 64
+                done
+            fi
+            exit 0
+            """,
+        )
         self.write_stub(bin_dir, "pgrep", "exit 1\n")
         self.write_stub(bin_dir, "ditto", 'cp -R "$1" "$2"\n')
         self.write_stub(
@@ -253,6 +288,9 @@ class LocalProductionInstallerTests(unittest.TestCase):
                 "LOCAL_SELF_SIGNED_CERTIFICATE_NAME": "divergent override",
                 "FAKE_BUILD_DIR": str(build_dir),
                 "FAKE_KEYCHAIN": str(keychain),
+                "FAKE_EXISTING_IDENTITY": "1" if existing_identity else "0",
+                "FAKE_IMPORTED_IDENTITY": str(temp_dir / "imported-identity"),
+                "OPENSSL_REJECTS_LEGACY": "1" if openssl_rejects_legacy else "0",
                 "PINNED_CERTIFICATE_NAME": PINNED_CERTIFICATE_NAME,
                 "FAIL_FINAL_INSTALL_MOVE": "1" if fail_final_install_move else "0",
             }

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -17,6 +17,32 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 
 
 class ReleaseToolingTests(unittest.TestCase):
+    def test_sparkle_start_is_deferred_until_release_bundle_verification(self) -> None:
+        app_delegate = (SCRIPT_DIR.parent / "Sources" / "RepoPrompt" / "App" / "AppDelegate.swift").read_text(
+            encoding="utf-8"
+        )
+        sparkle_manager = (
+            SCRIPT_DIR.parent / "Sources" / "RepoPrompt" / "App" / "Sparkle" / "SparkleUpdateManager.swift"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("startingUpdater: false", app_delegate)
+        verification = app_delegate.index("let isValid = try await verificationService.verify()")
+        release_activation = app_delegate.index("sparkleManager.startUpdater()", verification)
+        self.assertLess(verification, release_activation)
+        manager_init = sparkle_manager.split("init(updaterController: SPUStandardUpdaterController) {", 1)[1].split(
+            "\n    func startUpdater()", 1
+        )[0]
+        self.assertNotIn("updaterController.startUpdater()", manager_init)
+        self.assertIn("guard sparkleConfigurationValid, !updaterStarted else { return }", sparkle_manager)
+        self.assertIn("guard updaterStarted, sparkleConfigurationValid else { return false }", sparkle_manager)
+
+    def test_ci_secret_scan_covers_introduced_commit_range_and_checked_out_tree(self) -> None:
+        workflow = (SCRIPT_DIR.parent / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+
+        self.assertIn("fetch-depth: 0", workflow)
+        self.assertIn('gitleaks git --redact --log-opts="$range" .', workflow)
+        self.assertIn("gitleaks dir --redact .", workflow)
+
     def test_publish_staged_validates_before_creating_dist(self) -> None:
         release_script = (SCRIPT_DIR / "release.sh").read_text(encoding="utf-8")
         publish_staged = release_script.split("publish_staged_release() {", 1)[1].split("\n}", 1)[0]

--- a/Sources/RepoPrompt/App/AppDelegate.swift
+++ b/Sources/RepoPrompt/App/AppDelegate.swift
@@ -46,7 +46,7 @@ class AppDelegate: NSObject, ObservableObject, NSApplicationDelegate {
 
         // Initialize Sparkle updater
         let updaterController = SPUStandardUpdaterController(
-            startingUpdater: true,
+            startingUpdater: false,
             updaterDelegate: nil,
             userDriverDelegate: nil
         )
@@ -99,6 +99,7 @@ class AppDelegate: NSObject, ObservableObject, NSApplicationDelegate {
         }
 
         #if DEBUG
+            sparkleManager.startUpdater()
             if !launchConfiguration.suppressesNonessentialLaunchSideEffects {
                 Task {
                     // Ensure the user-space CLI symlink is available for external tools
@@ -129,7 +130,8 @@ class AppDelegate: NSObject, ObservableObject, NSApplicationDelegate {
                     return
                 }
 
-                // Only proceed with security monitoring after verification succeeds
+                // Only activate updates and proceed with security monitoring after verification succeeds
+                sparkleManager.startUpdater()
 
                 // 1) Security checks
                 ApplicationSecurity.startMonitoring()

--- a/Sources/RepoPrompt/App/Sparkle/SparkleUpdateManager.swift
+++ b/Sources/RepoPrompt/App/Sparkle/SparkleUpdateManager.swift
@@ -80,6 +80,7 @@ final class SparkleUpdaterManager: ObservableObject {
 
     private let updaterController: SPUStandardUpdaterController
     private var cancellables = Set<AnyCancellable>()
+    private var updaterStarted = false
     private var periodicCheckTimer: Timer?
     private var appcastCheckTask: Task<AppcastUpdateInfo?, Never>?
     private var userInitiatedSparkleCheckInProgress = false
@@ -144,21 +145,25 @@ final class SparkleUpdaterManager: ObservableObject {
 
         if !sparkleConfigurationValid {
             disableUpdatesForIntegrityFailure()
-            return
         }
+    }
 
-        // Setup observers for update status
+    func startUpdater() {
+        guard sparkleConfigurationValid, !updaterStarted else { return }
+
+        // Install observers before activation so no Sparkle event can race registration.
         setupObservers()
-
-        // Initialize with current state
+        updaterController.startUpdater()
+        updaterStarted = true
+        forceSparkleAutomaticChecksOff()
         canCheckForUpdates = updaterController.updater.canCheckForUpdates
 
-        // Schedule a background check after a short delay
+        // Schedule a background check after a short delay.
         DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) { [weak self] in
             self?.performInitialUpdateCheck()
         }
 
-        // Setup periodic passive update checking if enabled
+        // Setup periodic passive update checking if enabled.
         setupPeriodicUpdateCheck()
     }
 
@@ -177,7 +182,7 @@ final class SparkleUpdaterManager: ObservableObject {
 
     /// Performs initial passive update check using appcast parsing only.
     private func performInitialUpdateCheck() {
-        guard sparkleConfigurationValid, automaticallyChecksForUpdates else { return }
+        guard updaterStarted, sparkleConfigurationValid, automaticallyChecksForUpdates else { return }
         Task {
             await performPassiveAppcastCheck()
         }
@@ -187,7 +192,7 @@ final class SparkleUpdaterManager: ObservableObject {
     private func setupPeriodicUpdateCheck() {
         periodicCheckTimer?.invalidate()
         periodicCheckTimer = nil
-        guard sparkleConfigurationValid, automaticallyChecksForUpdates else { return }
+        guard updaterStarted, sparkleConfigurationValid, automaticallyChecksForUpdates else { return }
         forceSparkleAutomaticChecksOff()
         // Check if we need to do an immediate check based on last check time
         let lastCheck = UserDefaults.standard.double(forKey: Self.lastCheckKey)
@@ -233,7 +238,7 @@ final class SparkleUpdaterManager: ObservableObject {
     /// Returns true only when the appcast fetch and parse produced update info.
     @discardableResult
     func checkAppcastDirectly() async -> Bool {
-        guard sparkleConfigurationValid else { return false }
+        guard updaterStarted, sparkleConfigurationValid else { return false }
         guard let feedURL = Bundle.main.infoDictionary?["SUFeedURL"] as? String,
               let url = URL(string: feedURL)
         else {
@@ -445,7 +450,7 @@ final class SparkleUpdaterManager: ObservableObject {
     }
 
     func checkForUpdates(silent: Bool = false) {
-        guard sparkleConfigurationValid else { return }
+        guard updaterStarted, sparkleConfigurationValid else { return }
         if silent {
             // Passive checks are appcast-only by design; Sparkle UI remains user-initiated.
             guard automaticallyChecksForUpdates else { return }
@@ -458,7 +463,7 @@ final class SparkleUpdaterManager: ObservableObject {
     }
 
     func installUpdate() {
-        guard sparkleConfigurationValid else { return }
+        guard updaterStarted, sparkleConfigurationValid else { return }
         beginUserInitiatedSparkleCheck()
     }
 
@@ -578,6 +583,7 @@ final class SparkleUpdaterManager: ObservableObject {
         func debugPublishedSnapshot() -> [String: Any] {
             var snapshot: [String: Any] = [
                 "sparkle_configuration_valid": sparkleConfigurationValid,
+                "updater_started": updaterStarted,
                 "updates_disabled_message": updatesDisabledMessage ?? NSNull(),
                 "can_check_for_updates": canCheckForUpdates,
                 "sparkle_can_check_for_updates": updaterController.updater.canCheckForUpdates,

--- a/Sources/RepoPrompt/Infrastructure/Security/BundleVerifier.swift
+++ b/Sources/RepoPrompt/Infrastructure/Security/BundleVerifier.swift
@@ -12,10 +12,15 @@ import Security
 class BundleVerifier {
     private static let expectedBundleIdentifier = SecurityObfuscation.decode(SecurityObfuscation.expectedBundleIdentifierEncoded)
     private static let expectedTeamIdentifier = SecurityObfuscation.decode(SecurityObfuscation.expectedTeamIdentifierEncoded)
-    #if REPOPROMPT_LOCAL_SELF_SIGNED_BUILD
-        private static let localSelfSignedCertificateName = "RepoPrompt CE Local Self-Signed Code Signing"
-        private static let localSelfSignedSigningMode = "local-self-signed"
-    #endif
+    private static let localSelfSignedCertificateName = "RepoPrompt CE Local Self-Signed Code Signing"
+    private static let localSelfSignedSigningMode = "local-self-signed"
+    static let developerIDApplicationCertificateExtension = "1.2.840.113635.100.6.1.13"
+
+    enum SigningIdentityRequirementMode {
+        case localSelfSigned
+        case debugAppleDevelopment
+        case officialDeveloperID
+    }
 
     /// Error types that can occur during bundle verification
     enum VerificationError: Error, CustomStringConvertible {
@@ -79,19 +84,31 @@ class BundleVerifier {
 
     // MARK: - Identity Requirements
 
+    static func signingIdentityRequirementString(for mode: SigningIdentityRequirementMode) -> String {
+        switch mode {
+        case .localSelfSigned:
+            "anchor trusted and identifier \"\(expectedBundleIdentifier)\" and certificate leaf[subject.CN] = \"\(localSelfSignedCertificateName)\""
+        case .debugAppleDevelopment:
+            "anchor apple generic and certificate leaf[subject.OU] = \"\(expectedTeamIdentifier)\""
+        case .officialDeveloperID:
+            "anchor apple generic and identifier \"\(expectedBundleIdentifier)\" and certificate leaf[subject.OU] = \"\(expectedTeamIdentifier)\" and certificate leaf[field.\(developerIDApplicationCertificateExtension)] exists"
+        }
+    }
+
     private static func verifySigningIdentity(for code: SecStaticCode, bundle: Bundle) throws {
-        // In debug builds, verify team ID only (bundle ID differs between debug/release)
-        // In release builds, verify both bundle ID and team ID
+        // In debug builds, verify team ID only (bundle ID differs between debug/release).
+        // Official release builds also require the Developer ID Application certificate class.
         #if REPOPROMPT_LOCAL_SELF_SIGNED_BUILD
             guard bundle.object(forInfoDictionaryKey: "RepoPromptSigningMode") as? String == localSelfSignedSigningMode else {
                 throw VerificationError.signingModeInvalid
             }
-            let requirementString = "anchor trusted and identifier \"\(expectedBundleIdentifier)\" and certificate leaf[subject.CN] = \"\(localSelfSignedCertificateName)\""
+            let requirementMode = SigningIdentityRequirementMode.localSelfSigned
         #elseif DEBUG
-            let requirementString = "anchor apple generic and certificate leaf[subject.OU] = \"\(expectedTeamIdentifier)\""
+            let requirementMode = SigningIdentityRequirementMode.debugAppleDevelopment
         #else
-            let requirementString = "anchor apple generic and identifier \"\(expectedBundleIdentifier)\" and certificate leaf[subject.OU] = \"\(expectedTeamIdentifier)\""
+            let requirementMode = SigningIdentityRequirementMode.officialDeveloperID
         #endif
+        let requirementString = signingIdentityRequirementString(for: requirementMode)
 
         var requirement: SecRequirement?
         let requirementStatus = SecRequirementCreateWithString(requirementString as CFString, [], &requirement)

--- a/Tests/RepoPromptTests/Security/BundleVerifierRequirementTests.swift
+++ b/Tests/RepoPromptTests/Security/BundleVerifierRequirementTests.swift
@@ -1,0 +1,21 @@
+@testable import RepoPrompt
+import Security
+import XCTest
+
+final class BundleVerifierRequirementTests: XCTestCase {
+    func testOfficialReleaseRequirementExcludesAppleDevelopmentCertificateClass() {
+        let officialRequirement = BundleVerifier.signingIdentityRequirementString(for: .officialDeveloperID)
+        let debugRequirement = BundleVerifier.signingIdentityRequirementString(for: .debugAppleDevelopment)
+        let developerIDClause = "certificate leaf[field.\(BundleVerifier.developerIDApplicationCertificateExtension)] exists"
+
+        XCTAssertTrue(officialRequirement.contains(developerIDClause))
+        XCTAssertFalse(debugRequirement.contains(developerIDClause))
+
+        var parsedRequirement: SecRequirement?
+        XCTAssertEqual(
+            SecRequirementCreateWithString(officialRequirement as CFString, [], &parsedRequirement),
+            errSecSuccess
+        )
+        XCTAssertNotNil(parsedRequirement)
+    }
+}

--- a/docs/open-source-readiness.md
+++ b/docs/open-source-readiness.md
@@ -1,6 +1,6 @@
 # Open-Source and Release Readiness Notes
 
-Current as of 2026-05-31. This is a contributor/maintainer inventory for RepoPrompt CE's public-readiness work. It documents the current state and follow-ups; it is not legal advice or a substitute for legal review.
+Current as of 2026-06-01. This is a contributor/maintainer inventory for RepoPrompt CE's public-readiness work. It documents the current state and follow-ups; it is not legal advice or a substitute for legal review.
 
 ## Release metadata and signing
 
@@ -81,46 +81,27 @@ guardrail keeps the resolved SwiftPM inventory aligned with `Package.resolved`
 and verifies the copied notice checksums, including the complete curated
 Tree-sitter bundle.
 
-## Remaining public-release blockers
+## Public release readiness status
 
-Completed setup on 2026-05-31:
+Completed setup through 2026-06-01:
 
 - Registered the explicit Apple Developer App ID `com.pvncher.repoprompt.ce`.
 - Created and validated the `RepoPromptCEDeveloperID` Developer ID provisioning profile for `648A27MST5.com.pvncher.repoprompt.ce`.
 - Enabled App Store Connect API access, created a least-privilege `Developer` team key for notarization, and verified its credentials with a read-only `notarytool history` request.
 - Created the GitHub `release` environment, stored its Developer ID PKCS#12, export password, ephemeral CI keychain password, CE provisioning profile, CE Sparkle private key, and `NOTARYTOOL_*` secrets, and set the `SIGN_IDENTITY` environment variable.
+- Enabled required-reviewer protection for the `release` environment and restricted deployment branches to protected `main`.
+- Added an immutable `v*` release-tag ruleset that permits new tags while preventing updates and deletion after creation.
+- Enabled GitHub Release immutability for both `repoprompt/repoprompt-ce` and `repoprompt/repoprompt-ce-updates`.
+- Added the fine-grained `PUBLIC_UPDATE_REPOSITORY_TOKEN` secret scoped only to `repoprompt/repoprompt-ce-updates` with repository contents read/write permission.
+- Published the source repository, reran CI, and exercised the protected **Publish Release** draft and **Promote Release** flow through public publication.
 - Kept the opted-in contributor cohort in the tracked `.github/APPROVED_CONTRIBUTORS` file so changes remain public and reviewable. The issue and pull-request gates read that default-branch file directly.
 - Curated copied license and notice files for every remote dependency in the resolved root SwiftPM graph and added machine guardrails for inventory drift and copied-file checksums.
 - Added the environment-scoped **Promote Release** workflow. It uses trusted tooling pinned to a validated `main` SHA, requires the requested tag to be reachable from protected `main`, verifies reviewed source-draft assets and ZIP/DMG contents, validates packaged legal files and the protected CE Sparkle private key, mirrors update assets into `repoprompt-ce-updates`, enforces monotonically increasing stable builds, resumes matching partial states, publishes without rebuilding, explicitly selects the latest release, and runs anonymous post-publish checks.
 
-Pre-public validation limitation:
-
-- The source repository is currently private, and newly queued GitHub Actions
-  jobs fail before runner startup with GitHub's billing-or-spending-limit
-  annotation. This is not expected to block the public workflow:
-  [GitHub documents](https://docs.github.com/en/billing/concepts/product-billing/github-actions)
-  that standard GitHub-hosted runners are free in public repositories, and CE's
-  workflows use the standard `macos-26` label rather than a larger-runner label.
-  After switching the source repository public, rerun CI and **Publish Release**
-  before relying on the release path.
-
-Remaining blockers:
-
-- Enable a GitHub configuration that exposes required-reviewer protection for
-  the `release` environment and restrict its deployment branches to protected
-  `main`. The current private-repository settings do not expose a
-  required-reviewer control.
-- Add an immutable `v*` release-tag ruleset that allows new tag creation but
-  prevents updates and deletion after creation.
-- Enable GitHub Release immutability for both the source repository and
-  `repoprompt-ce-updates` before the first stable publish.
-- Add the `PUBLIC_UPDATE_REPOSITORY_TOKEN` secret to the protected `release`
-  environment before production promotion. Use a fine-grained GitHub token
-  scoped only to `repoprompt/repoprompt-ce-updates` with repository contents
-  read/write permission.
-- After switching the source repository public, rerun CI, create and test the
-  first **Publish Release** draft, dispatch **Promote Release**, and confirm an
-  installed app updates through the public channel.
+The previously tracked external GitHub configuration gates are complete and are
+no longer public-release blockers. Continue to verify an installed app update
+through the public channel for each release candidate before relying on a new
+stable update.
 
 ## Contributor validation touchpoints
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -27,7 +27,9 @@ The intended process is:
 1. A contributor opens a release PR that updates `version.env`, release notes,
    and any relevant changelog entry.
 2. CI runs ordinary validation plus the secret-free release-candidate lane.
-3. Contributors and maintainers test the ad-hoc release-candidate artifact.
+3. Contributors and maintainers inspect the ad-hoc release-candidate artifact
+   for packaging correctness. Runnable release-mode local testing uses the
+   self-signed local production installer.
 4. A maintainer merges the PR and creates a new immutable tag for that exact
    commit.
 5. A maintainer dispatches **Publish Release**. CI imports the
@@ -57,7 +59,9 @@ path on `main` and on manual dispatch, then uploads the archive as a workflow
 artifact.
 
 Contributors should not upload this artifact to GitHub Releases. It is useful
-for packaging review and local testing only.
+for packaging inspection only; its ad-hoc signature intentionally does not pass
+the official release runtime integrity check. For runnable release-mode local
+testing, use the self-signed local production installer below.
 
 ## Install a local self-signed production build
 


### PR DESCRIPTION
## Summary

- defer Sparkle activation until configuration and production bundle integrity checks succeed
- make the local self-signed installer portable across OpenSSL variants
- scan introduced Git history in CI while retaining final-tree secret scanning
- tighten official Developer ID runtime verification and clarify contributor release-candidate guidance
- update public-readiness status and narrow the README relaunch note

## Validation

- `.agents/skills/rpce-contribution-check/scripts/preflight.sh commit`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh push`
- `python3 Scripts/test_local_production_installer.py`
- `python3 Scripts/test_release_tooling.py`
- `bash -n Scripts/install_local_production.sh`
- `gitleaks git --redact --log-opts='-1 HEAD' .`
- `make dev-lint`
- `make dev-test`
- `make dev-swift-build PRODUCT=RepoPrompt`
- `make dev-smoke` *(expected unavailable: app is not running; no visible launch was performed)*
