### PR TITLE
Fix nested release helper signing

### DIFF
--- a/AppBundle/Info.plist.template
+++ b/AppBundle/Info.plist.template
@@ -23,7 +23,6 @@
   <key>UTExportedTypeDeclarations</key><array><dict><key>UTTypeIdentifier</key><string>com.pvncher.repoprompt.ce.document</string><key>UTTypeDescription</key><string>RepoPrompt CE Document</string><key>UTTypeConformsTo</key><array><string>public.data</string></array></dict></array>
   <key>SUFeedURL</key><string>https://github.com/repoprompt/repoprompt-ce-updates/releases/latest/download/appcast.xml</string>
   <key>SUPublicEDKey</key><string>845kp9v5+kp4U6no85H53cUdnbfN3NmE1PJHKwH8Pd4=</string>
-  <key>SUEnableInstallerLauncherService</key><true/>
   <key>SUBundleName</key><string>RepoPrompt CE.app</string>
   <key>NSLocalNetworkUsageDescription</key><string>RepoPrompt CE needs local network access to enable MCP server functionality, allowing external tools to connect and interact with your workspace.</string>
   <key>NSBonjourServices</key><array><string>_preflight_check._tcp</string><string>_mcp._tcp</string></array>

--- a/AppBundle/RepoPrompt.local-self-signed.entitlements.template
+++ b/AppBundle/RepoPrompt.local-self-signed.entitlements.template
@@ -4,6 +4,8 @@
 <dict>
     <key>com.apple.security.cs.allow-jit</key>
     <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
     <key>com.apple.security.files.bookmarks.app-scope</key>
     <true/>
     <key>com.apple.security.temporary-exception.mach-lookup.global-name</key>

--- a/Scripts/package_app.sh
+++ b/Scripts/package_app.sh
@@ -30,7 +30,7 @@ run(){
 }
 fail(){ echo "ERROR: $*" >&2; exit 1; }
 finish(){
-    local status=$? now total
+    local status="$1" now total
     [[ -z "${APP_ENTITLEMENTS:-}" ]] || rm -f "$APP_ENTITLEMENTS"
     now="$(date +%s)"
     total=$((now - START_TIME))
@@ -41,7 +41,7 @@ finish(){
     fi
     exit "$status"
 }
-trap finish EXIT
+trap 'finish $?' EXIT
 
 BUNDLE_ID_OVERRIDE="${BUNDLE_ID:-}"
 source "$CONTROL_PLANE_SCRIPTS_DIR/load_release_metadata.sh"
@@ -263,6 +263,14 @@ sign_path(){
     fi
     run codesign "${args[@]}" "$@" "$path"
 }
+sign_sparkle_framework(){
+    local framework="$1"
+    sign_path "$framework/Versions/B/XPCServices/Installer.xpc"
+    sign_path "$framework/Versions/B/XPCServices/Downloader.xpc" --preserve-metadata=entitlements
+    sign_path "$framework/Versions/B/Autoupdate"
+    sign_path "$framework/Versions/B/Updater.app"
+    sign_path "$framework"
+}
 verify_signed_app_identity(){
     local details identifier team authorities
     details="$(codesign -dv --verbose=4 "$APP_BUNDLE" 2>&1 || true)"
@@ -288,16 +296,21 @@ verify_signed_app_identity(){
         [[ -n "$team" && "$team" != "not set" ]] || fail "Debug app was expected to be signed with a stable identity, but no team identifier was found."
     fi
 }
-if [[ -d "$APP_BUNDLE/Contents/Frameworks/Sparkle.framework" ]]; then sign_path "$APP_BUNDLE/Contents/Frameworks/Sparkle.framework"; fi
+if [[ -d "$APP_BUNDLE/Contents/Frameworks/Sparkle.framework" ]]; then sign_sparkle_framework "$APP_BUNDLE/Contents/Frameworks/Sparkle.framework"; fi
 sign_path "$APP_BUNDLE/Contents/MacOS/repoprompt-mcp"
 sign_path "$APP_BUNDLE/Contents/MacOS/$APP_NAME"
-APP_SIGN_ARGS=(--deep)
+APP_SIGN_ARGS=()
 if (( IS_RELEASE )) && (( ! USE_ADHOC_SIGNING )); then
     APP_SIGN_ARGS+=(--entitlements "$APP_ENTITLEMENTS")
 fi
-sign_path "$APP_BUNDLE" "${APP_SIGN_ARGS[@]}"
+if (( ${#APP_SIGN_ARGS[@]} )); then
+    sign_path "$APP_BUNDLE" "${APP_SIGN_ARGS[@]}"
+else
+    sign_path "$APP_BUNDLE"
+fi
 run codesign --verify --deep --strict --verbose=2 "$APP_BUNDLE"
 verify_signed_app_identity
+run "$CONTROL_PLANE_SCRIPTS_DIR/smoke_embedded_mcp_helper.sh" "$APP_BUNDLE" "Packaged app MCP helper"
 if [[ "$(python3 - <<PY
 from pathlib import Path
 print(Path('$APP_BUNDLE').resolve(strict=False) == Path('$COMPAT_APP_BUNDLE').resolve(strict=False))

--- a/Scripts/promote_release.sh
+++ b/Scripts/promote_release.sh
@@ -46,6 +46,10 @@ require_file() {
     [[ -f "$1" ]] || fail "Missing required file: $1"
 }
 
+smoke_embedded_mcp_helper() {
+    "$CONTROL_PLANE_SCRIPTS_DIR/smoke_embedded_mcp_helper.sh" "$@"
+}
+
 require_env() {
     [[ -n "${!1:-}" ]] || fail "Missing required environment variable: $1"
 }
@@ -149,6 +153,7 @@ validate_app_bundle() {
 
     REPOPROMPT_RELEASE_SOURCE_ROOT="$ROOT_DIR" \
         "$CONTROL_PLANE_SCRIPTS_DIR/validate_packaged_legal.sh" "$app_bundle"
+    smoke_embedded_mcp_helper "$app_bundle" "Reviewed ZIP MCP helper"
 }
 
 validate_dmg_matches_zip_app() {
@@ -160,6 +165,7 @@ validate_dmg_matches_zip_app() {
     [[ -d "$dmg_app" ]] || fail "DMG does not contain $APP_NAME.app at its root"
     diff -qr "$APP_BUNDLE" "$dmg_app" ||
         fail "DMG app contents do not match the verified update ZIP app"
+    smoke_embedded_mcp_helper "$dmg_app" "Mounted DMG MCP helper"
 
     hdiutil detach "$DMG_MOUNT_POINT" >/dev/null
     DMG_MOUNT_POINT=""
@@ -236,6 +242,7 @@ verify_source_release() {
     require_file "$CONTROL_PLANE_SCRIPTS_DIR/verify_remote_release_commit.sh"
     require_file "$CONTROL_PLANE_SCRIPTS_DIR/verify_sparkle_vendor.sh"
     require_file "$CONTROL_PLANE_SCRIPTS_DIR/verify_sparkle_signature.swift"
+    require_file "$CONTROL_PLANE_SCRIPTS_DIR/smoke_embedded_mcp_helper.sh"
     "$CONTROL_PLANE_SCRIPTS_DIR/verify_remote_release_commit.sh" "$RELEASE_TAG" "$RELEASE_COMMIT"
     REPOPROMPT_RELEASE_SOURCE_ROOT="$ROOT_DIR" \
         "$CONTROL_PLANE_SCRIPTS_DIR/verify_sparkle_vendor.sh"

--- a/Scripts/publish_public_update_test.sh
+++ b/Scripts/publish_public_update_test.sh
@@ -35,6 +35,8 @@ trap cleanup EXIT
     fail "Set CONFIRM_PUBLIC_UPDATE_TEST=1 to acknowledge that this publishes a signed test update publicly."
 [[ -f "$UPDATE_ZIP" ]] || fail "Missing update ZIP: $UPDATE_ZIP"
 [[ -x "$GENERATE_APPCAST" ]] || fail "Missing Sparkle generate_appcast tool: $GENERATE_APPCAST"
+[[ -x "$ROOT_DIR/Scripts/smoke_embedded_mcp_helper.sh" ]] ||
+    fail "Missing embedded MCP helper smoke script"
 
 for command in codesign curl ditto gh plutil shasum xcrun; do
     require_command "$command"
@@ -66,6 +68,7 @@ printf '%s\n' "$signature_details" | grep -q '^Authority=Developer ID Applicatio
 [[ "$team_identifier" == "$SIGNING_TEAM_ID" ]] ||
     fail "Signed app team mismatch: expected $SIGNING_TEAM_ID, got ${team_identifier:-<missing>}"
 xcrun stapler validate "$APP_BUNDLE"
+"$ROOT_DIR/Scripts/smoke_embedded_mcp_helper.sh" "$APP_BUNDLE" "Public updater ZIP MCP helper"
 
 bundle_identifier="$(plutil -extract CFBundleIdentifier raw "$APP_BUNDLE/Contents/Info.plist")"
 marketing_version="$(plutil -extract CFBundleShortVersionString raw "$APP_BUNDLE/Contents/Info.plist")"

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -74,6 +74,7 @@ run_preflight() {
     require_file "$ROOT_DIR/Vendor/Sparkle/PROVENANCE.md"
     require_file "$ROOT_DIR/Vendor/Sparkle/SHA256SUMS"
     require_file "$CONTROL_PLANE_SCRIPTS_DIR/sign_staged_release.sh"
+    require_file "$CONTROL_PLANE_SCRIPTS_DIR/smoke_embedded_mcp_helper.sh"
     require_file "$CONTROL_PLANE_SCRIPTS_DIR/extract_staged_release.py"
     require_file "$CONTROL_PLANE_SCRIPTS_DIR/validate_staged_release.sh"
     require_file "$RUN_WITHOUT_GITHUB_TOKENS"

--- a/Scripts/sign_staged_release.sh
+++ b/Scripts/sign_staged_release.sh
@@ -68,16 +68,26 @@ sign_path() {
     codesign --force --sign "$SIGN_IDENTITY" --timestamp --options runtime "$@" "$path"
 }
 
-sign_path "$STAGED_SPARKLE_FRAMEWORK"
+sign_sparkle_framework() {
+    local framework="$1"
+    sign_path "$framework/Versions/B/XPCServices/Installer.xpc"
+    sign_path "$framework/Versions/B/XPCServices/Downloader.xpc" --preserve-metadata=entitlements
+    sign_path "$framework/Versions/B/Autoupdate"
+    sign_path "$framework/Versions/B/Updater.app"
+    sign_path "$framework"
+}
+
+sign_sparkle_framework "$STAGED_SPARKLE_FRAMEWORK"
 sign_path "$APP_BUNDLE/Contents/MacOS/repoprompt-mcp"
 sign_path "$APP_BUNDLE/Contents/MacOS/$APP_NAME"
-sign_path "$APP_BUNDLE" --deep --entitlements "$app_entitlements"
+sign_path "$APP_BUNDLE" --entitlements "$app_entitlements"
 codesign --verify --deep --strict --verbose=2 "$APP_BUNDLE"
 codesign -d --entitlements :- "$APP_BUNDLE" > "$signed_entitlements"
 plutil -convert xml1 -o "$canonical_app_entitlements" "$app_entitlements"
 plutil -convert xml1 -o "$canonical_signed_entitlements" "$signed_entitlements"
 cmp "$canonical_app_entitlements" "$canonical_signed_entitlements" ||
     fail "Signed app entitlements do not match trusted release policy"
+"$SCRIPT_DIR/smoke_embedded_mcp_helper.sh" "$APP_BUNDLE" "Developer ID staged app MCP helper"
 
 signature_details="$(codesign -dv --verbose=4 "$APP_BUNDLE" 2>&1)"
 identifier="$(printf '%s\n' "$signature_details" | awk -F= '/^Identifier=/{print $2; exit}')"

--- a/Scripts/smoke_embedded_mcp_helper.sh
+++ b/Scripts/smoke_embedded_mcp_helper.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_BUNDLE="${1:-}"
+SMOKE_LABEL="${2:-Embedded MCP helper}"
+
+fail() {
+    printf 'ERROR: %s\n' "$*" >&2
+    exit 1
+}
+
+[[ -n "$APP_BUNDLE" ]] || fail "Usage: $0 <app-bundle> [label]"
+[[ -d "$APP_BUNDLE" ]] || fail "Missing app bundle: $APP_BUNDLE"
+
+MCP_HELPER="$APP_BUNDLE/Contents/MacOS/repoprompt-mcp"
+[[ -x "$MCP_HELPER" ]] || fail "Missing executable MCP helper: $MCP_HELPER"
+
+status=0
+"$MCP_HELPER" --version || status=$?
+(( status == 0 )) ||
+    fail "$SMOKE_LABEL failed --version smoke (exit $status): $MCP_HELPER"
+
+printf 'OK: %s passed --version smoke.\n' "$SMOKE_LABEL"

--- a/Scripts/test_local_production_installer.py
+++ b/Scripts/test_local_production_installer.py
@@ -139,6 +139,7 @@ class LocalProductionInstallerTests(unittest.TestCase):
             entitlements,
             {
                 "com.apple.security.cs.allow-jit": True,
+                "com.apple.security.cs.disable-library-validation": True,
                 "com.apple.security.files.bookmarks.app-scope": True,
                 "com.apple.security.temporary-exception.mach-lookup.global-name": [
                     "__BUNDLE_ID__-spks",

--- a/Scripts/test_release_promotion.py
+++ b/Scripts/test_release_promotion.py
@@ -142,14 +142,16 @@ class ReleasePromotionTests(unittest.TestCase):
         fake_bin = temp_dir / "bin"
         app = temp_dir / "fixture" / "RepoPrompt.app"
         dmg_app = temp_dir / "dmg-fixture" / "RepoPrompt.app"
-        for directory in (scripts, vendor_bin, assets, fake_bin, app / "Contents"):
+        for directory in (scripts, vendor_bin, assets, fake_bin, app / "Contents" / "MacOS"):
             directory.mkdir(parents=True, exist_ok=True)
 
         shutil.copy2(SCRIPT_DIR / "promote_release.sh", scripts / "promote_release.sh")
+        shutil.copy2(SCRIPT_DIR / "smoke_embedded_mcp_helper.sh", scripts / "smoke_embedded_mcp_helper.sh")
         shutil.copy2(SCRIPT_DIR / "validate_packaged_legal.sh", scripts / "validate_packaged_legal.sh")
         shutil.copy2(SCRIPT_DIR / "load_release_metadata.sh", scripts / "load_release_metadata.sh")
         shutil.copy2(SCRIPT_DIR / "verify_sparkle_signature.swift", scripts / "verify_sparkle_signature.swift")
         (scripts / "promote_release.sh").chmod(0o755)
+        (scripts / "smoke_embedded_mcp_helper.sh").chmod(0o755)
         (scripts / "validate_packaged_legal.sh").chmod(0o755)
         self.write_stub(scripts, "verify_remote_release_commit.sh", "printf 'OK: fixture remote tag remains bound.\\n'\n")
         self.write_stub(scripts, "verify_sparkle_vendor.sh", "printf 'OK: fixture Sparkle payload matches.\\n'\n")
@@ -167,6 +169,7 @@ class ReleasePromotionTests(unittest.TestCase):
             encoding="utf-8",
         )
         (app / "Contents" / "Info.plist").write_text("fixture plist\n", encoding="utf-8")
+        self.write_stub(app / "Contents" / "MacOS", "repoprompt-mcp", "printf 'fixture repoprompt-mcp 1.0.0\\n'\n")
         self.write_legal_tree(root, app)
         shutil.copytree(app, dmg_app)
         if mismatched_dmg_app:

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import base64
 import os
+import plistlib
 import shutil
 import stat
 import subprocess
@@ -17,6 +18,78 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 
 
 class ReleaseToolingTests(unittest.TestCase):
+    def test_custom_packaging_resigns_sparkle_helpers_without_recursive_entitlement_propagation(self) -> None:
+        package_script = (SCRIPT_DIR / "package_app.sh").read_text(encoding="utf-8")
+        staged_signing_script = (SCRIPT_DIR / "sign_staged_release.sh").read_text(encoding="utf-8")
+        info_plist = plistlib.loads((SCRIPT_DIR.parent / "AppBundle" / "Info.plist.template").read_bytes())
+
+        for script in (package_script, staged_signing_script):
+            self.assertIn('sign_path "$framework/Versions/B/XPCServices/Installer.xpc"', script)
+            self.assertIn(
+                'sign_path "$framework/Versions/B/XPCServices/Downloader.xpc" --preserve-metadata=entitlements',
+                script,
+            )
+            self.assertIn('sign_path "$framework/Versions/B/Autoupdate"', script)
+            self.assertIn('sign_path "$framework/Versions/B/Updater.app"', script)
+            self.assertIn('sign_path "$framework"', script)
+
+        self.assertIn('APP_SIGN_ARGS=()', package_script)
+        self.assertNotIn('APP_SIGN_ARGS=(--deep)', package_script)
+        self.assertNotIn('sign_path "$APP_BUNDLE" --deep', staged_signing_script)
+        self.assertNotIn("SUEnableInstallerLauncherService", info_plist)
+        self.assertIn("trap 'finish $?' EXIT", package_script)
+        self.assertIn('local status="$1" now total', package_script)
+
+    def test_release_paths_smoke_embedded_mcp_helper_after_signing_and_before_publish(self) -> None:
+        package_script = (SCRIPT_DIR / "package_app.sh").read_text(encoding="utf-8")
+        staged_signing_script = (SCRIPT_DIR / "sign_staged_release.sh").read_text(encoding="utf-8")
+        promote_script = (SCRIPT_DIR / "promote_release.sh").read_text(encoding="utf-8")
+        public_update_script = (SCRIPT_DIR / "publish_public_update_test.sh").read_text(encoding="utf-8")
+
+        package_outer_sign = package_script.index('sign_path "$APP_BUNDLE" "${APP_SIGN_ARGS[@]}"')
+        package_smoke = package_script.index('"$CONTROL_PLANE_SCRIPTS_DIR/smoke_embedded_mcp_helper.sh"')
+        self.assertLess(package_outer_sign, package_smoke)
+
+        staged_outer_sign = staged_signing_script.index('sign_path "$APP_BUNDLE" --entitlements "$app_entitlements"')
+        staged_smoke = staged_signing_script.index('"$SCRIPT_DIR/smoke_embedded_mcp_helper.sh"')
+        self.assertLess(staged_outer_sign, staged_smoke)
+
+        validate_app_bundle = promote_script.split("validate_app_bundle() {", 1)[1].split("\n}", 1)[0]
+        self.assertLess(
+            validate_app_bundle.index('codesign --verify --deep --strict --verbose=2 "$app_bundle"'),
+            validate_app_bundle.index('smoke_embedded_mcp_helper "$app_bundle" "Reviewed ZIP MCP helper"'),
+        )
+        validate_dmg = promote_script.split("validate_dmg_matches_zip_app() {", 1)[1].split("\n}", 1)[0]
+        self.assertLess(
+            validate_dmg.index('diff -qr "$APP_BUNDLE" "$dmg_app"'),
+            validate_dmg.index('smoke_embedded_mcp_helper "$dmg_app" "Mounted DMG MCP helper"'),
+        )
+        self.assertLess(
+            validate_dmg.index('smoke_embedded_mcp_helper "$dmg_app" "Mounted DMG MCP helper"'),
+            validate_dmg.index('hdiutil detach "$DMG_MOUNT_POINT"'),
+        )
+        self.assertLess(
+            public_update_script.index('"$ROOT_DIR/Scripts/smoke_embedded_mcp_helper.sh"'),
+            public_update_script.index('gh release create "$PUBLIC_UPDATE_TAG"'),
+        )
+
+    def test_embedded_mcp_helper_smoke_rejects_exit_137(self) -> None:
+        temp_dir = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, temp_dir, True)
+        helper = temp_dir / "RepoPrompt.app" / "Contents" / "MacOS" / "repoprompt-mcp"
+        helper.parent.mkdir(parents=True)
+        helper.write_text("#!/usr/bin/env bash\nexit 137\n", encoding="utf-8")
+        helper.chmod(0o755)
+
+        result = subprocess.run(
+            [str(SCRIPT_DIR / "smoke_embedded_mcp_helper.sh"), str(temp_dir / "RepoPrompt.app"), "Fixture helper"],
+            text=True,
+            capture_output=True,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Fixture helper failed --version smoke (exit 137)", result.stderr)
+
     def test_sparkle_start_is_deferred_until_release_bundle_verification(self) -> None:
         app_delegate = (SCRIPT_DIR.parent / "Sources" / "RepoPrompt" / "App" / "AppDelegate.swift").read_text(
             encoding="utf-8"


### PR DESCRIPTION
## Summary
- sign Sparkle helpers inside-out and stop recursive app-entitlement propagation
- verify embedded `repoprompt-mcp --version` after packaging, staged Developer ID signing, reviewed ZIP extraction, mounted-DMG validation, and public updater smoke validation
- fix package exit-status handling and cover AMFI-style exit `137` regressions

## Validation
- `python3 Scripts/test_release_tooling.py`
- `python3 Scripts/test_release_promotion.py`
- `python3 Scripts/test_local_production_installer.py`
- `bash -n Scripts/package_app.sh Scripts/release.sh Scripts/sign_staged_release.sh Scripts/promote_release.sh Scripts/publish_public_update_test.sh Scripts/smoke_embedded_mcp_helper.sh`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh commit`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh push`
- temporary local self-signed installer build and strict signature validation
- temporary self-signed app visible boot smoke

## Release follow-up
The existing immutable `v1.0.0` release remains broken. After merge, publish a new hotfix tag with a higher build number; do not overwrite `v1.0.0`.