### PR TITLE
Harden signed test build workflow

### DIFF
--- a/.github/workflows/signed-test-build.yml
+++ b/.github/workflows/signed-test-build.yml
@@ -1,0 +1,368 @@
+name: Signed Test Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_ref:
+        description: Upstream branch, tag, or upstream-reachable SHA to build and sign
+        required: true
+        default: main
+        type: string
+
+concurrency:
+  group: signed-test-build
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  validate-ref:
+    name: Validate Test Build Ref
+    if: github.ref == 'refs/heads/main'
+    runs-on: macos-26
+    outputs:
+      commit: ${{ steps.source-ref.outputs.commit }}
+      reachable_refs: ${{ steps.source-ref.outputs.reachable_refs }}
+      tooling-commit: ${{ steps.tooling-ref.outputs.commit }}
+    steps:
+      - name: Require trusted workflow dispatch
+        env:
+          SOURCE_REF: ${{ inputs.source_ref }}
+        run: |
+          set -euo pipefail
+          [[ -n "$SOURCE_REF" ]] || { echo "source_ref is required" >&2; exit 1; }
+          [[ "$SOURCE_REF" != -* ]] || { echo "source_ref must not start with '-'" >&2; exit 1; }
+          [[ "$SOURCE_REF" != *$'\n'* && "$SOURCE_REF" != *$'\r'* ]] || { echo "source_ref must be a single line" >&2; exit 1; }
+          [[ "$SOURCE_REF" != *:* ]] || { echo "Signed test builds must use canonical upstream refs, not fork shorthand refs." >&2; exit 1; }
+          case "$SOURCE_REF" in
+            refs/pull/*|pull/*|refs/remotes/*/pull/*)
+              echo "Signed test builds must use an upstream branch, tag, or upstream-reachable SHA, not a pull-request ref." >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Check out trusted release tooling
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: main
+          path: trusted-control-plane
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Resolve trusted tooling commit
+        id: tooling-ref
+        run: echo "commit=$(git -C trusted-control-plane rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Check out requested source ref
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: ${{ inputs.source_ref }}
+          path: requested-source
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify source commit is reachable from upstream refs
+        id: source-ref
+        env:
+          SOURCE_REF: ${{ inputs.source_ref }}
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_SERVER_URL: ${{ github.server_url }}
+        run: ./trusted-control-plane/Scripts/verify_signed_test_build_ref.sh "$SOURCE_REF" requested-source
+
+  stage:
+    name: Build Requested Source Without Secrets
+    needs: validate-ref
+    if: github.ref == 'refs/heads/main'
+    runs-on: macos-26
+    permissions:
+      contents: read
+    steps:
+      - name: Check out trusted release tooling
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: ${{ needs.validate-ref.outputs.tooling-commit }}
+          path: trusted-control-plane
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Check out requested source
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: ${{ needs.validate-ref.outputs.commit }}
+          path: release-source
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Build and stage requested source
+        env:
+          RELEASE_COMMIT: ${{ needs.validate-ref.outputs.commit }}
+          REPOPROMPT_CONTROL_PLANE_SCRIPTS_DIR: ${{ github.workspace }}/trusted-control-plane/Scripts
+          REPOPROMPT_RELEASE_SOURCE_ROOT: ${{ github.workspace }}/release-source
+        run: ./trusted-control-plane/Scripts/release.sh stage-test-build
+
+      - name: Upload staged signed test build source
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: RepoPrompt-CE-staged-signed-test-build
+          path: |
+            release-source/dist/*-stage.zip
+            release-source/dist/*-stage.zip.sha256
+          if-no-files-found: error
+          retention-days: 1
+
+  sign:
+    name: Sign and Notarize Test Build
+    needs:
+      - validate-ref
+      - stage
+    if: github.ref == 'refs/heads/main'
+    environment: release
+    runs-on: macos-26
+    permissions:
+      contents: read
+    steps:
+      - name: Check out trusted release tooling
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: ${{ needs.validate-ref.outputs.tooling-commit }}
+          path: trusted-control-plane
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Download staged signed test build source
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: RepoPrompt-CE-staged-signed-test-build
+          path: staged-release
+
+      - name: Check out approved source as data
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: ${{ needs.validate-ref.outputs.commit }}
+          path: approved-source
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify and expand staged signed test build source
+        env:
+          RELEASE_COMMIT: ${{ needs.validate-ref.outputs.commit }}
+        run: |
+          set -euo pipefail
+          cd staged-release
+          shopt -s nullglob
+          archives=(./*-stage.zip)
+          checksum_files=(./*-stage.zip.sha256)
+          [[ "${#archives[@]}" == "1" ]] || { echo "Expected exactly one staged ZIP" >&2; exit 1; }
+          [[ "${#checksum_files[@]}" == "1" ]] || { echo "Expected exactly one staged ZIP checksum" >&2; exit 1; }
+          archive="${archives[0]}"
+          [[ "${checksum_files[0]}" == "$archive.sha256" ]] || { echo "Staged ZIP checksum name mismatch" >&2; exit 1; }
+          shasum -a 256 -c "${checksum_files[0]}"
+          staged_sha256="$(awk '{ print $1 }' "${checksum_files[0]}")"
+          echo "SIGNED_TEST_STAGED_ARCHIVE_NAME=$(basename "$archive")" >> "$GITHUB_ENV"
+          echo "SIGNED_TEST_STAGED_ARCHIVE_SHA256=$staged_sha256" >> "$GITHUB_ENV"
+          ../trusted-control-plane/Scripts/extract_staged_release.py "$archive" ../release-source RepoPrompt
+          REPOPROMPT_RELEASE_SOURCE_ROOT=../release-source \
+            REPOPROMPT_APPROVED_SOURCE_ROOT=../approved-source \
+            ../trusted-control-plane/Scripts/validate_staged_release.sh
+
+      - name: Import Developer ID certificate
+        env:
+          CERTIFICATE_P12_BASE64: ${{ secrets.DEVELOPER_ID_APPLICATION_P12_BASE64 }}
+          CERTIFICATE_P12_PASSWORD: ${{ secrets.DEVELOPER_ID_APPLICATION_P12_PASSWORD }}
+          CI_KEYCHAIN_PASSWORD: ${{ secrets.CI_KEYCHAIN_PASSWORD }}
+          CONFIGURED_SIGN_IDENTITY: ${{ vars.SIGN_IDENTITY }}
+        run: |
+          set -euo pipefail
+          umask 077
+          KEYCHAIN_PATH="$RUNNER_TEMP/repoprompt-release.keychain-db"
+          CERTIFICATE_PATH="$RUNNER_TEMP/repoprompt-release.p12"
+          keychain_created=0
+          cleanup_certificate_and_failed_keychain() {
+            status=$?
+            rm -f "$CERTIFICATE_PATH"
+            if (( status != 0 )) && (( keychain_created )); then
+              security delete-keychain "$KEYCHAIN_PATH" || true
+            fi
+          }
+          trap cleanup_certificate_and_failed_keychain EXIT
+          printf '%s' "$CERTIFICATE_P12_BASE64" | base64 --decode > "$CERTIFICATE_PATH"
+          security create-keychain -p "$CI_KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          keychain_created=1
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$CI_KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$CERTIFICATE_PATH" -k "$KEYCHAIN_PATH" -P "$CERTIFICATE_P12_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$CI_KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security list-keychains -d user -s "$KEYCHAIN_PATH"
+          echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
+          echo "SIGN_IDENTITY=${CONFIGURED_SIGN_IDENTITY:-Developer ID Application: Eric Provencher (648A27MST5)}" >> "$GITHUB_ENV"
+
+      - name: Prepare provisioning profile and notarization key
+        env:
+          PROVISIONING_PROFILE_BASE64: ${{ secrets.REPOPROMPT_CE_PROVISIONING_PROFILE_BASE64 }}
+          NOTARYTOOL_PRIVATE_KEY_BASE64: ${{ secrets.NOTARYTOOL_PRIVATE_KEY_BASE64 }}
+        run: |
+          set -euo pipefail
+          umask 077
+          SECRETS_DIR="$RUNNER_TEMP/repoprompt-release-secrets"
+          mkdir -p "$SECRETS_DIR"
+          printf '%s' "$PROVISIONING_PROFILE_BASE64" | base64 --decode > "$SECRETS_DIR/repoprompt-ce.provisionprofile"
+          printf '%s' "$NOTARYTOOL_PRIVATE_KEY_BASE64" | base64 --decode > "$SECRETS_DIR/notarytool-private-key.p8"
+          echo "REPOPROMPT_PROVISIONING_PROFILE=$SECRETS_DIR/repoprompt-ce.provisionprofile" >> "$GITHUB_ENV"
+          echo "NOTARYTOOL_PRIVATE_KEY=$SECRETS_DIR/notarytool-private-key.p8" >> "$GITHUB_ENV"
+
+      - name: Sign, notarize, and package test build
+        env:
+          RELEASE_COMMIT: ${{ needs.validate-ref.outputs.commit }}
+          REPOPROMPT_CONTROL_PLANE_SCRIPTS_DIR: ${{ github.workspace }}/trusted-control-plane/Scripts
+          REPOPROMPT_GIT_ROOT: ${{ github.workspace }}/trusted-control-plane
+          REPOPROMPT_RELEASE_SOURCE_ROOT: ${{ github.workspace }}/release-source
+          REPOPROMPT_APPROVED_SOURCE_ROOT: ${{ github.workspace }}/approved-source
+          REPOPROMPT_REQUIRE_HEAD_MATCH: 0
+          SIGNED_TEST_SOURCE_REF: ${{ inputs.source_ref }}
+          SIGNED_TEST_REACHABLE_REFS: ${{ needs.validate-ref.outputs.reachable_refs }}
+          SIGNED_TEST_TOOLING_COMMIT: ${{ needs.validate-ref.outputs.tooling-commit }}
+          SIGNED_TEST_WORKFLOW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          NOTARYTOOL_KEY_ID: ${{ secrets.NOTARYTOOL_KEY_ID }}
+          NOTARYTOOL_ISSUER_ID: ${{ secrets.NOTARYTOOL_ISSUER_ID }}
+        run: ./trusted-control-plane/Scripts/release.sh publish-test-build
+
+      - name: Remove ephemeral keychain
+        if: always()
+        run: |
+          KEYCHAIN_PATH="$RUNNER_TEMP/repoprompt-release.keychain-db"
+          CERTIFICATE_PATH="$RUNNER_TEMP/repoprompt-release.p12"
+          security delete-keychain "$KEYCHAIN_PATH" || true
+          rm -f "$CERTIFICATE_PATH"
+          rm -rf "$RUNNER_TEMP/repoprompt-release-secrets"
+
+      - name: Upload signed test build
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: RepoPrompt-CE-signed-test-build
+          path: |
+            release-source/dist/*.zip
+            release-source/dist/*.dmg
+            release-source/dist/SHA256SUMS
+            release-source/dist/*-signed-test-provenance.json
+          if-no-files-found: error
+          retention-days: 7
+
+  smoke-signed-helper:
+    name: Smoke Signed Helper Without Release Secrets
+    needs:
+      - validate-ref
+      - sign
+    if: github.ref == 'refs/heads/main'
+    runs-on: macos-26
+    permissions:
+      contents: read
+    steps:
+      - name: Check out trusted release tooling
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: ${{ needs.validate-ref.outputs.tooling-commit }}
+          path: trusted-control-plane
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Download signed test build
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: RepoPrompt-CE-signed-test-build
+          path: signed-test-build
+
+      - name: Extract and statically validate signed helper layout
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          archives=(signed-test-build/*.zip)
+          dmgs=(signed-test-build/*.dmg)
+          manifests=(signed-test-build/*SHA256SUMS)
+          provenances=(signed-test-build/*-signed-test-provenance.json)
+          [[ "${#archives[@]}" == "1" ]] || { echo "Expected exactly one signed ZIP" >&2; exit 1; }
+          [[ "${#dmgs[@]}" == "1" ]] || { echo "Expected exactly one signed DMG" >&2; exit 1; }
+          [[ "${#manifests[@]}" == "1" ]] || { echo "Expected exactly one signed ZIP checksum manifest" >&2; exit 1; }
+          [[ "${#provenances[@]}" == "1" ]] || { echo "Expected exactly one signed test provenance file" >&2; exit 1; }
+          python3 - "${archives[0]}" "${dmgs[0]}" "${manifests[0]}" "${provenances[0]}" <<'PY'
+          import hashlib
+          import json
+          import sys
+          from pathlib import Path
+
+          zip_path, dmg_path, checksums_path, provenance_path = map(Path, sys.argv[1:])
+          provenance = json.loads(provenance_path.read_text(encoding="utf-8"))
+          required = {
+              "requested_ref",
+              "resolved_source_commit",
+              "trusted_tooling_commit",
+              "workflow_run_url",
+              "signing_mode",
+              "source_reachable_refs",
+              "artifacts",
+          }
+          missing = sorted(required - provenance.keys())
+          if missing:
+              raise SystemExit(f"Missing provenance fields: {', '.join(missing)}")
+          if provenance.get("schema_version") != 1:
+              raise SystemExit("Unexpected signed test build provenance schema version")
+          if provenance.get("hash_algorithm") != "SHA-256":
+              raise SystemExit("Unexpected signed test build provenance hash algorithm")
+          if provenance["requested_ref"] != "${{ inputs.source_ref }}":
+              raise SystemExit("Provenance requested ref mismatch")
+          if provenance["resolved_source_commit"] != "${{ needs.validate-ref.outputs.commit }}":
+              raise SystemExit("Provenance source commit mismatch")
+          if provenance["trusted_tooling_commit"] != "${{ needs.validate-ref.outputs.tooling-commit }}":
+              raise SystemExit("Provenance tooling commit mismatch")
+          expected_run_url = "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          if provenance["workflow_run_url"] != expected_run_url:
+              raise SystemExit("Provenance workflow run URL mismatch")
+          if provenance["signing_mode"] != "developer-id-signed-test-build":
+              raise SystemExit("Unexpected signed test build signing mode")
+          if not isinstance(provenance["source_reachable_refs"], list) or not provenance["source_reachable_refs"]:
+              raise SystemExit("Provenance reachable refs must be a non-empty list")
+
+          def sha256(path: Path) -> str:
+              digest = hashlib.sha256()
+              with path.open("rb") as handle:
+                  for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                      digest.update(chunk)
+              return digest.hexdigest()
+
+          expected = {
+              "zip": zip_path,
+              "dmg": dmg_path,
+              "checksums": checksums_path,
+          }
+          artifacts = provenance["artifacts"]
+          for key, path in expected.items():
+              entry = artifacts.get(key)
+              if not isinstance(entry, dict):
+                  raise SystemExit(f"Missing provenance artifact entry: {key}")
+              if entry.get("file") != path.name:
+                  raise SystemExit(f"Provenance {key} file mismatch")
+              if entry.get("sha256") != sha256(path):
+                  raise SystemExit(f"Provenance {key} hash mismatch")
+          PY
+          archive="${archives[0]}"
+          archive_name="$(basename "$archive")"
+          archive_checksum_entry="$RUNNER_TEMP/signed-test-build-zip.sha256"
+          awk -v archive_name="$archive_name" '$2 == archive_name { print }' "${manifests[0]}" > "$archive_checksum_entry"
+          [[ "$(wc -l < "$archive_checksum_entry" | tr -d ' ')" == "1" ]] || { echo "Expected exactly one signed ZIP checksum entry" >&2; exit 1; }
+          (cd signed-test-build && shasum -a 256 -c "$archive_checksum_entry")
+          mkdir extracted
+          ditto -x -k "$archive" extracted
+          ./trusted-control-plane/Scripts/validate_embedded_mcp_helper_layout.sh \
+            extracted/RepoPrompt.app \
+            "Signed test build MCP helper layout"
+
+      - name: Execute signed helper without inherited secrets
+        run: |
+          env -i \
+            PATH=/usr/bin:/bin:/usr/sbin:/sbin \
+            HOME="$HOME" \
+            TMPDIR="$RUNNER_TEMP" \
+            ./trusted-control-plane/Scripts/smoke_embedded_mcp_helper.sh \
+            extracted/RepoPrompt.app \
+            "Signed test build MCP helper"

--- a/.github/workflows/signed-test-build.yml
+++ b/.github/workflows/signed-test-build.yml
@@ -142,8 +142,28 @@ jobs:
         with:
           ref: ${{ needs.validate-ref.outputs.commit }}
           path: approved-source
-          fetch-depth: 1
+          fetch-depth: 0
           persist-credentials: false
+
+      - name: Revalidate source ref after release approval
+        id: sign-source-ref
+        env:
+          SOURCE_REF: ${{ inputs.source_ref }}
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_SERVER_URL: ${{ github.server_url }}
+        run: ./trusted-control-plane/Scripts/verify_signed_test_build_ref.sh "$SOURCE_REF" approved-source
+
+      - name: Require sign-time source ref to match validated commit
+        env:
+          EXPECTED_COMMIT: ${{ needs.validate-ref.outputs.commit }}
+          ACTUAL_COMMIT: ${{ steps.sign-source-ref.outputs.commit }}
+        run: |
+          set -euo pipefail
+          [[ "$ACTUAL_COMMIT" == "$EXPECTED_COMMIT" ]] || {
+            echo "source_ref resolved differently after release approval: expected $EXPECTED_COMMIT, got $ACTUAL_COMMIT" >&2
+            exit 1
+          }
 
       - name: Verify and expand staged signed test build source
         env:
@@ -221,7 +241,7 @@ jobs:
           REPOPROMPT_APPROVED_SOURCE_ROOT: ${{ github.workspace }}/approved-source
           REPOPROMPT_REQUIRE_HEAD_MATCH: 0
           SIGNED_TEST_SOURCE_REF: ${{ inputs.source_ref }}
-          SIGNED_TEST_REACHABLE_REFS: ${{ needs.validate-ref.outputs.reachable_refs }}
+          SIGNED_TEST_REACHABLE_REFS: ${{ steps.sign-source-ref.outputs.reachable_refs }}
           SIGNED_TEST_TOOLING_COMMIT: ${{ needs.validate-ref.outputs.tooling-commit }}
           SIGNED_TEST_WORKFLOW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           NOTARYTOOL_KEY_ID: ${{ secrets.NOTARYTOOL_KEY_ID }}
@@ -274,6 +294,11 @@ jobs:
           path: signed-test-build
 
       - name: Extract and statically validate signed helper layout
+        env:
+          EXPECTED_REQUESTED_REF: ${{ inputs.source_ref }}
+          EXPECTED_SOURCE_COMMIT: ${{ needs.validate-ref.outputs.commit }}
+          EXPECTED_TOOLING_COMMIT: ${{ needs.validate-ref.outputs.tooling-commit }}
+          EXPECTED_WORKFLOW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
           shopt -s nullglob
@@ -288,6 +313,7 @@ jobs:
           python3 - "${archives[0]}" "${dmgs[0]}" "${manifests[0]}" "${provenances[0]}" <<'PY'
           import hashlib
           import json
+          import os
           import sys
           from pathlib import Path
 
@@ -309,14 +335,13 @@ jobs:
               raise SystemExit("Unexpected signed test build provenance schema version")
           if provenance.get("hash_algorithm") != "SHA-256":
               raise SystemExit("Unexpected signed test build provenance hash algorithm")
-          if provenance["requested_ref"] != "${{ inputs.source_ref }}":
+          if provenance["requested_ref"] != os.environ["EXPECTED_REQUESTED_REF"]:
               raise SystemExit("Provenance requested ref mismatch")
-          if provenance["resolved_source_commit"] != "${{ needs.validate-ref.outputs.commit }}":
+          if provenance["resolved_source_commit"] != os.environ["EXPECTED_SOURCE_COMMIT"]:
               raise SystemExit("Provenance source commit mismatch")
-          if provenance["trusted_tooling_commit"] != "${{ needs.validate-ref.outputs.tooling-commit }}":
+          if provenance["trusted_tooling_commit"] != os.environ["EXPECTED_TOOLING_COMMIT"]:
               raise SystemExit("Provenance tooling commit mismatch")
-          expected_run_url = "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          if provenance["workflow_run_url"] != expected_run_url:
+          if provenance["workflow_run_url"] != os.environ["EXPECTED_WORKFLOW_RUN_URL"]:
               raise SystemExit("Provenance workflow run URL mismatch")
           if provenance["signing_mode"] != "developer-id-signed-test-build":
               raise SystemExit("Unexpected signed test build signing mode")

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -18,6 +18,7 @@ UPDATE_ZIP="$DIST_DIR/$ARCHIVE_BASENAME.zip"
 DMG="$DIST_DIR/$ARCHIVE_BASENAME.dmg"
 APPCAST="$DIST_DIR/appcast.xml"
 CHECKSUMS="$DIST_DIR/SHA256SUMS"
+SIGNED_TEST_PROVENANCE="$DIST_DIR/$ARCHIVE_BASENAME-signed-test-provenance.json"
 STAGE_ARCHIVE="$DIST_DIR/$ARCHIVE_BASENAME-stage.zip"
 STAGE_ARCHIVE_CHECKSUM="$STAGE_ARCHIVE.sha256"
 RELEASE_TAG="${RELEASE_TAG:-}"
@@ -80,6 +81,7 @@ run_preflight() {
     require_file "$CONTROL_PLANE_SCRIPTS_DIR/validate_staged_release.sh"
     require_file "$RUN_WITHOUT_GITHUB_TOKENS"
     require_file "$CONTROL_PLANE_SCRIPTS_DIR/verify_remote_release_commit.sh"
+    require_file "$CONTROL_PLANE_SCRIPTS_DIR/verify_signed_test_build_ref.sh"
     require_file "$CONTROL_PLANE_SCRIPTS_DIR/verify_sparkle_vendor.sh"
     require_file "$TRUSTED_ROOT/Vendor/Sparkle/INSTALLED_MANIFEST.tsv"
     require_file "$TRUSTED_ROOT/Vendor/Sparkle/bin/generate_appcast"
@@ -199,6 +201,114 @@ stage_publish_release() {
     printf 'Created staged release artifact: %s\n' "$STAGE_ARCHIVE"
 }
 
+stage_signed_test_build() {
+    require_env RELEASE_COMMIT
+    require_command ditto
+    unset GH_TOKEN GITHUB_TOKEN SOURCE_GH_TOKEN
+    resolve_without_lockfile_drift
+    run_preflight
+    prepare_dist
+    "$RUN_WITHOUT_GITHUB_TOKENS" env -u SIGN_IDENTITY \
+        REPOPROMPT_RELEASE_SOURCE_ROOT="$ROOT_DIR" \
+        REPOPROMPT_CONTROL_PLANE_SCRIPTS_DIR="$CONTROL_PLANE_SCRIPTS_DIR" \
+        RELEASE_ALLOW_ADHOC_SIGNING=1 \
+        "$CONTROL_PLANE_SCRIPTS_DIR/package_app.sh" release
+    run_preflight
+    validate_packaged_legal "$APP_BUNDLE"
+    TMP_DIR="$(mktemp -d)"
+    local stage_root="$TMP_DIR/signed-test-build-stage"
+    mkdir -p "$stage_root/.build/release"
+    ditto "$APP_BUNDLE" "$stage_root/.build/release/$APP_NAME.app"
+    cp "$ROOT_DIR/version.env" "$ROOT_DIR/LICENSE" "$ROOT_DIR/THIRD_PARTY_NOTICES.md" "$stage_root/"
+    cp -R "$ROOT_DIR/ThirdPartyLicenses" "$stage_root/"
+    printf '%s\n' "$RELEASE_COMMIT" > "$stage_root/RELEASE_COMMIT"
+    ditto -c -k --norsrc "$stage_root" "$STAGE_ARCHIVE"
+    (
+        cd "$DIST_DIR"
+        shasum -a 256 "$(basename "$STAGE_ARCHIVE")" > "$(basename "$STAGE_ARCHIVE_CHECKSUM")"
+    )
+    printf 'OK: secret-free signed test build source staged for %s.\n' "$RELEASE_COMMIT"
+    printf 'Created staged signed test build artifact: %s\n' "$STAGE_ARCHIVE"
+}
+
+verify_signed_test_build_inputs() {
+    require_command python3
+    require_env RELEASE_COMMIT
+    require_env SIGN_IDENTITY
+    require_env REPOPROMPT_PROVISIONING_PROFILE
+    require_env NOTARYTOOL_PRIVATE_KEY
+    require_env NOTARYTOOL_KEY_ID
+    require_env NOTARYTOOL_ISSUER_ID
+    require_env REPOPROMPT_APPROVED_SOURCE_ROOT
+    require_env SIGNED_TEST_SOURCE_REF
+    require_env SIGNED_TEST_REACHABLE_REFS
+    require_env SIGNED_TEST_TOOLING_COMMIT
+    require_env SIGNED_TEST_WORKFLOW_RUN_URL
+    require_env SIGNED_TEST_STAGED_ARCHIVE_NAME
+    require_env SIGNED_TEST_STAGED_ARCHIVE_SHA256
+    require_file "$REPOPROMPT_PROVISIONING_PROFILE"
+    require_file "$NOTARYTOOL_PRIVATE_KEY"
+}
+
+sha256_file() {
+    shasum -a 256 "$1" | awk '{ print $1 }'
+}
+
+write_signed_test_build_provenance() {
+    local zip_name dmg_name checksums_name
+    zip_name="$(basename "$UPDATE_ZIP")"
+    dmg_name="$(basename "$DMG")"
+    checksums_name="$(basename "$CHECKSUMS")"
+
+    SIGNED_TEST_PROVENANCE_PATH="$SIGNED_TEST_PROVENANCE" \
+    SIGNED_TEST_ZIP_NAME="$zip_name" \
+    SIGNED_TEST_ZIP_SHA256="$(sha256_file "$UPDATE_ZIP")" \
+    SIGNED_TEST_DMG_NAME="$dmg_name" \
+    SIGNED_TEST_DMG_SHA256="$(sha256_file "$DMG")" \
+    SIGNED_TEST_CHECKSUMS_NAME="$checksums_name" \
+    SIGNED_TEST_CHECKSUMS_SHA256="$(sha256_file "$CHECKSUMS")" \
+    python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+reachable_refs = [ref for ref in os.environ["SIGNED_TEST_REACHABLE_REFS"].split(",") if ref]
+provenance = {
+    "schema_version": 1,
+    "artifact": "RepoPrompt CE signed test build",
+    "requested_ref": os.environ["SIGNED_TEST_SOURCE_REF"],
+    "resolved_source_commit": os.environ["RELEASE_COMMIT"],
+    "trusted_tooling_commit": os.environ["SIGNED_TEST_TOOLING_COMMIT"],
+    "workflow_run_url": os.environ["SIGNED_TEST_WORKFLOW_RUN_URL"],
+    "signing_mode": "developer-id-signed-test-build",
+    "source_reachable_refs": reachable_refs,
+    "hash_algorithm": "SHA-256",
+    "artifacts": {
+        "zip": {
+            "file": os.environ["SIGNED_TEST_ZIP_NAME"],
+            "sha256": os.environ["SIGNED_TEST_ZIP_SHA256"],
+        },
+        "dmg": {
+            "file": os.environ["SIGNED_TEST_DMG_NAME"],
+            "sha256": os.environ["SIGNED_TEST_DMG_SHA256"],
+        },
+        "checksums": {
+            "file": os.environ["SIGNED_TEST_CHECKSUMS_NAME"],
+            "sha256": os.environ["SIGNED_TEST_CHECKSUMS_SHA256"],
+        },
+        "staged_source_archive": {
+            "file": os.environ["SIGNED_TEST_STAGED_ARCHIVE_NAME"],
+            "sha256": os.environ["SIGNED_TEST_STAGED_ARCHIVE_SHA256"],
+        },
+    },
+}
+Path(os.environ["SIGNED_TEST_PROVENANCE_PATH"]).write_text(
+    json.dumps(provenance, indent=2, sort_keys=True) + "\n",
+    encoding="utf-8",
+)
+PY
+}
+
 publish_staged_release() {
     require_command ditto
     require_command gh
@@ -270,10 +380,58 @@ publish_staged_release() {
     printf 'Created draft GitHub release assets for %s.\n' "$RELEASE_TAG"
 }
 
+publish_signed_test_build() {
+    require_command ditto
+    require_command hdiutil
+    require_command xcrun
+    verify_signed_test_build_inputs
+    TMP_DIR="$(mktemp -d)"
+
+    [[ -d "$APP_BUNDLE" ]] || fail "Missing secret-free staged app bundle: $APP_BUNDLE"
+    REPOPROMPT_RELEASE_SOURCE_ROOT="$ROOT_DIR" \
+        "$CONTROL_PLANE_SCRIPTS_DIR/validate_staged_release.sh"
+    REPOPROMPT_RELEASE_SOURCE_ROOT="$ROOT_DIR" \
+        "$CONTROL_PLANE_SCRIPTS_DIR/sign_staged_release.sh"
+    prepare_dist
+    validate_packaged_legal "$APP_BUNDLE"
+
+    local notary_zip="$TMP_DIR/$ARCHIVE_BASENAME-signed-test-notarization.zip"
+    ditto -c -k --norsrc --keepParent "$APP_BUNDLE" "$notary_zip"
+    submit_notarization "$notary_zip"
+    xcrun stapler staple "$APP_BUNDLE"
+    xcrun stapler validate "$APP_BUNDLE"
+
+    ditto -c -k --norsrc --keepParent "$APP_BUNDLE" "$UPDATE_ZIP"
+
+    local dmg_staging="$TMP_DIR/dmg"
+    mkdir -p "$dmg_staging"
+    ditto "$APP_BUNDLE" "$dmg_staging/$APP_NAME.app"
+    hdiutil create -volname "$DISPLAY_NAME" -srcfolder "$dmg_staging" -ov -format UDZO "$DMG"
+    submit_notarization "$DMG"
+    xcrun stapler staple "$DMG"
+    xcrun stapler validate "$DMG"
+
+    (
+        cd "$DIST_DIR"
+        shasum -a 256 \
+            "$(basename "$UPDATE_ZIP")" \
+            "$(basename "$DMG")" \
+            > "$(basename "$CHECKSUMS")"
+    )
+    write_signed_test_build_provenance
+
+    printf 'Created signed test build ZIP: %s\n' "$UPDATE_ZIP"
+    printf 'Created signed test build DMG: %s\n' "$DMG"
+    printf 'Created signed test build provenance: %s\n' "$SIGNED_TEST_PROVENANCE"
+    printf 'This artifact is signed and notarized for testing only. It is not a GitHub Release or stable update.\n'
+}
+
 case "$MODE" in
     preflight) run_preflight ;;
     artifact) package_release_candidate ;;
     stage-publish) stage_publish_release ;;
     publish-staged) publish_staged_release ;;
-    *) fail "Usage: $0 preflight|artifact|stage-publish|publish-staged" ;;
+    stage-test-build) stage_signed_test_build ;;
+    publish-test-build) publish_signed_test_build ;;
+    *) fail "Usage: $0 preflight|artifact|stage-publish|publish-staged|stage-test-build|publish-test-build" ;;
 esac

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -123,6 +123,10 @@ class ReleaseToolingTests(unittest.TestCase):
         promote_workflow = (SCRIPT_DIR.parent / ".github" / "workflows" / "release-promote.yml").read_text(
             encoding="utf-8"
         )
+        signed_test_workflow = (SCRIPT_DIR.parent / ".github" / "workflows" / "signed-test-build.yml").read_text(
+            encoding="utf-8"
+        )
+        release_script = (SCRIPT_DIR / "release.sh").read_text(encoding="utf-8")
 
         publish_job = release_workflow.split("\n  publish:", 1)[1].split("\n  smoke-signed-helper:", 1)[0]
         publish_staged = "        run: ./trusted-control-plane/Scripts/release.sh publish-staged"
@@ -175,6 +179,64 @@ class ReleaseToolingTests(unittest.TestCase):
         self.assertIn('CERTIFICATE_PATH="$RUNNER_TEMP/repoprompt-release.p12"', final_cleanup)
         self.assertIn('rm -f "$CERTIFICATE_PATH"', final_cleanup)
         self.assertIn('rm -rf "$RUNNER_TEMP/repoprompt-release-secrets"', final_cleanup)
+
+        self.assertIn("group: signed-test-build", signed_test_workflow)
+        self.assertIn("verify_signed_test_build_ref.sh", signed_test_workflow)
+        self.assertIn("reachable_refs: ${{ steps.source-ref.outputs.reachable_refs }}", signed_test_workflow)
+        self.assertIn("upstream-reachable SHA", signed_test_workflow)
+        self.assertIn("source_ref must not start with '-'", signed_test_workflow)
+        self.assertIn("source_ref must be a single line", signed_test_workflow)
+        self.assertIn("GITHUB_SERVER_URL", signed_test_workflow)
+        self.assertNotIn("branch, tag, or SHA to build and sign", signed_test_workflow)
+
+        signed_test_stage = signed_test_workflow.split("\n  stage:", 1)[1].split("\n  sign:", 1)[0]
+        self.assertNotIn("environment: release", signed_test_stage)
+        self.assertIn("persist-credentials: false", signed_test_stage)
+        self.assertIn("release.sh stage-test-build", signed_test_stage)
+        self.assertIn("RepoPrompt-CE-staged-signed-test-build", signed_test_stage)
+
+        signed_test_sign = signed_test_workflow.split("\n  sign:", 1)[1].split("\n  smoke-signed-helper:", 1)[0]
+        self.assertIn("environment: release", signed_test_sign)
+        self.assertIn("- stage", signed_test_sign)
+        self.assertIn("RepoPrompt-CE-staged-signed-test-build", signed_test_sign)
+        self.assertIn("release.sh publish-test-build", signed_test_sign)
+        self.assertIn("release-source/dist/*.zip", signed_test_sign)
+        self.assertIn("release-source/dist/*.dmg", signed_test_sign)
+        self.assertIn("release-source/dist/*-signed-test-provenance.json", signed_test_sign)
+        self.assertIn("SIGNED_TEST_SOURCE_REF", signed_test_sign)
+        self.assertIn("SIGNED_TEST_REACHABLE_REFS", signed_test_sign)
+        self.assertIn("SIGNED_TEST_TOOLING_COMMIT", signed_test_sign)
+        self.assertIn("SIGNED_TEST_WORKFLOW_RUN_URL", signed_test_sign)
+        self.assertNotIn("gh release create", signed_test_sign)
+        self.assertNotIn("SPARKLE_PRIVATE_KEY", signed_test_sign)
+
+        signed_test_smoke = signed_test_workflow.split("\n  smoke-signed-helper:", 1)[1]
+        self.assertNotIn("environment: release", signed_test_smoke)
+        self.assertIn("RepoPrompt-CE-signed-test-build", signed_test_smoke)
+        self.assertIn("provenances=(signed-test-build/*-signed-test-provenance.json)", signed_test_smoke)
+        self.assertIn("Expected exactly one signed test provenance file", signed_test_smoke)
+        self.assertIn("Provenance requested ref mismatch", signed_test_smoke)
+        self.assertIn("Provenance source commit mismatch", signed_test_smoke)
+        self.assertIn("Provenance workflow run URL mismatch", signed_test_smoke)
+        self.assertIn("Provenance reachable refs must be a non-empty list", signed_test_smoke)
+        self.assertIn("developer-id-signed-test-build", signed_test_smoke)
+        self.assertIn("validate_embedded_mcp_helper_layout.sh", signed_test_smoke)
+        self.assertIn("env -i", signed_test_smoke)
+
+        stage_test = release_script.split("stage_signed_test_build() {", 1)[1].split("\n}", 1)[0]
+        self.assertIn("unset GH_TOKEN GITHUB_TOKEN SOURCE_GH_TOKEN", stage_test)
+        self.assertIn("RELEASE_ALLOW_ADHOC_SIGNING=1", stage_test)
+        self.assertIn('SIGNED_TEST_PROVENANCE="$DIST_DIR/$ARCHIVE_BASENAME-signed-test-provenance.json"', release_script)
+        self.assertIn("write_signed_test_build_provenance", release_script)
+        self.assertIn("SIGNED_TEST_SOURCE_REF", release_script)
+        self.assertIn("SIGNED_TEST_REACHABLE_REFS", release_script)
+        self.assertIn("SIGNED_TEST_STAGED_ARCHIVE_SHA256", release_script)
+        self.assertIn("developer-id-signed-test-build", release_script)
+        self.assertIn('"staged_source_archive"', release_script)
+        publish_test = release_script.split("publish_signed_test_build() {", 1)[1].split("\n}", 1)[0]
+        self.assertNotIn("gh release create", publish_test)
+        self.assertNotIn("SPARKLE_PRIVATE_KEY", publish_test)
+        self.assertIn('shasum -a 256', publish_test)
 
     def test_staged_release_extractor_rejects_alternate_in_app_cli_target(self) -> None:
         for relative, alternate_target in (
@@ -585,6 +647,55 @@ class ReleaseToolingTests(unittest.TestCase):
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("canonical", result.stderr)
 
+
+    def test_signed_test_build_ref_helper_requires_upstream_reachability(self) -> None:
+        remote, work = self.make_git_remote()
+        first = self.commit_file(work, "first")
+        self.git(work, "tag", "v1.0.0")
+        self.git(work, "push", "origin", "main", "v1.0.0")
+
+        for source_ref in ("main", "v1.0.0", first):
+            with self.subTest(source_ref=source_ref):
+                self.git(work, "checkout", source_ref)
+                accepted = self.run_signed_test_ref_verify(work, source_ref)
+                self.assertEqual(accepted.returncode, 0, accepted.stderr)
+                self.assertEqual(accepted.stdout.strip(), first)
+
+        self.git(work, "checkout", "main")
+        self.commit_file(work, "unreachable")
+        unreachable = self.git(work, "rev-parse", "HEAD").stdout.strip()
+        rejected = self.run_signed_test_ref_verify(work, unreachable)
+        self.assertNotEqual(rejected.returncode, 0)
+        self.assertIn("not reachable from any upstream branch or tag", rejected.stderr)
+
+    def test_signed_test_build_ref_helper_rejects_pr_and_fork_refs(self) -> None:
+        remote, work = self.make_git_remote()
+        self.commit_file(work, "first")
+        self.git(work, "push", "origin", "main")
+
+        for source_ref, expected in (
+            ("refs/pull/123/head", "pull-request ref"),
+            ("pull/123/head", "pull-request ref"),
+            ("someuser:branch", "fork shorthand refs"),
+        ):
+            with self.subTest(source_ref=source_ref):
+                result = self.run_signed_test_ref_verify(work, source_ref)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(expected, result.stderr)
+
+    def test_signed_test_build_docs_describe_reachability_and_provenance(self) -> None:
+        docs = (SCRIPT_DIR.parent / "docs" / "releasing.md").read_text(encoding="utf-8")
+
+        self.assertIn("upstream-reachable commit SHA", docs)
+        self.assertIn("unreachable", docs)
+        self.assertIn("SHA-only commits", docs)
+        self.assertIn("signed-test-provenance.json", docs)
+        self.assertIn("resolved source commit", docs)
+        self.assertIn("trusted tooling commit", docs)
+        self.assertIn("workflow run URL", docs)
+        self.assertIn("ZIP, DMG, checksum manifest", docs)
+        self.assertIn("archive hashes", docs)
+
     def make_embedded_helper_layout(self) -> Path:
         temp_dir = Path(tempfile.mkdtemp())
         self.addCleanup(shutil.rmtree, temp_dir, True)
@@ -726,6 +837,15 @@ SIGNING_TEAM_ID=648A27MST5
         self.git(work, "add", "value.txt")
         self.git(work, "commit", "-m", content)
         return self.git(work, "rev-parse", "HEAD").stdout.strip()
+
+    def run_signed_test_ref_verify(self, work: Path, source_ref: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [str(SCRIPT_DIR / "verify_signed_test_build_ref.sh"), source_ref, str(work)],
+            cwd=work,
+            env={"PATH": os.environ["PATH"]},
+            text=True,
+            capture_output=True,
+        )
 
     def run_remote_verify(self, work: Path, expected: str) -> subprocess.CompletedProcess[str]:
         return subprocess.run(

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -203,8 +203,13 @@ class ReleaseToolingTests(unittest.TestCase):
         self.assertIn("release-source/dist/*.zip", signed_test_sign)
         self.assertIn("release-source/dist/*.dmg", signed_test_sign)
         self.assertIn("release-source/dist/*-signed-test-provenance.json", signed_test_sign)
+        self.assertIn("Revalidate source ref after release approval", signed_test_sign)
+        self.assertIn("id: sign-source-ref", signed_test_sign)
+        self.assertIn("Require sign-time source ref to match validated commit", signed_test_sign)
+        self.assertLess(signed_test_sign.index("Revalidate source ref after release approval"), signed_test_sign.index("Import Developer ID certificate"))
         self.assertIn("SIGNED_TEST_SOURCE_REF", signed_test_sign)
-        self.assertIn("SIGNED_TEST_REACHABLE_REFS", signed_test_sign)
+        self.assertIn("SIGNED_TEST_REACHABLE_REFS: ${{ steps.sign-source-ref.outputs.reachable_refs }}", signed_test_sign)
+        self.assertNotIn("SIGNED_TEST_REACHABLE_REFS: ${{ needs.validate-ref.outputs.reachable_refs }}", signed_test_sign)
         self.assertIn("SIGNED_TEST_TOOLING_COMMIT", signed_test_sign)
         self.assertIn("SIGNED_TEST_WORKFLOW_RUN_URL", signed_test_sign)
         self.assertNotIn("gh release create", signed_test_sign)
@@ -215,6 +220,9 @@ class ReleaseToolingTests(unittest.TestCase):
         self.assertIn("RepoPrompt-CE-signed-test-build", signed_test_smoke)
         self.assertIn("provenances=(signed-test-build/*-signed-test-provenance.json)", signed_test_smoke)
         self.assertIn("Expected exactly one signed test provenance file", signed_test_smoke)
+        self.assertIn("EXPECTED_REQUESTED_REF: ${{ inputs.source_ref }}", signed_test_smoke)
+        self.assertIn('os.environ["EXPECTED_REQUESTED_REF"]', signed_test_smoke)
+        self.assertNotIn('provenance["requested_ref"] != "${{ inputs.source_ref }}"', signed_test_smoke)
         self.assertIn("Provenance requested ref mismatch", signed_test_smoke)
         self.assertIn("Provenance source commit mismatch", signed_test_smoke)
         self.assertIn("Provenance workflow run URL mismatch", signed_test_smoke)
@@ -648,13 +656,14 @@ class ReleaseToolingTests(unittest.TestCase):
         self.assertIn("canonical", result.stderr)
 
 
-    def test_signed_test_build_ref_helper_requires_upstream_reachability(self) -> None:
+    def test_signed_test_build_ref_helper_requires_exact_ref_and_upstream_reachability(self) -> None:
         remote, work = self.make_git_remote()
         first = self.commit_file(work, "first")
         self.git(work, "tag", "v1.0.0")
-        self.git(work, "push", "origin", "main", "v1.0.0")
+        self.git(work, "tag", "-a", "v1.0.0-annotated", "-m", "annotated")
+        self.git(work, "push", "origin", "main", "v1.0.0", "v1.0.0-annotated")
 
-        for source_ref in ("main", "v1.0.0", first):
+        for source_ref in ("main", "refs/heads/main", "v1.0.0", "refs/tags/v1.0.0", "v1.0.0-annotated", first):
             with self.subTest(source_ref=source_ref):
                 self.git(work, "checkout", source_ref)
                 accepted = self.run_signed_test_ref_verify(work, source_ref)
@@ -668,14 +677,48 @@ class ReleaseToolingTests(unittest.TestCase):
         self.assertNotEqual(rejected.returncode, 0)
         self.assertIn("not reachable from any upstream branch or tag", rejected.stderr)
 
+    def test_signed_test_build_ref_helper_rejects_commitish_and_mismatched_inputs(self) -> None:
+        remote, work = self.make_git_remote()
+        first = self.commit_file(work, "first")
+        self.git(work, "push", "origin", "main")
+        second = self.commit_file(work, "second")
+        self.git(work, "push", "origin", "main")
+
+        for source_ref in ("main~1", "main^", "main..HEAD", first[:12], "refs/remotes/origin/main"):
+            with self.subTest(source_ref=source_ref):
+                self.git(work, "checkout", first)
+                result = self.run_signed_test_ref_verify(work, source_ref)
+                self.assertNotEqual(result.returncode, 0)
+
+        self.git(work, "checkout", first)
+        mismatched = self.run_signed_test_ref_verify(work, "main")
+        self.assertNotEqual(mismatched.returncode, 0)
+        self.assertIn("checkout HEAD", mismatched.stderr)
+
+    def test_signed_test_build_ref_helper_rejects_ambiguous_branch_tag_names(self) -> None:
+        remote, work = self.make_git_remote()
+        self.commit_file(work, "first")
+        self.git(work, "push", "origin", "main")
+        self.git(work, "checkout", "-b", "ambiguous")
+        self.commit_file(work, "branch")
+        self.git(work, "push", "origin", "ambiguous")
+        self.git(work, "checkout", "main")
+        self.git(work, "tag", "ambiguous")
+        self.git(work, "push", "origin", "refs/tags/ambiguous")
+
+        self.git(work, "checkout", "refs/heads/ambiguous")
+        rejected = self.run_signed_test_ref_verify(work, "ambiguous")
+        self.assertNotEqual(rejected.returncode, 0)
+        self.assertIn("ambiguous", rejected.stderr)
+
     def test_signed_test_build_ref_helper_rejects_pr_and_fork_refs(self) -> None:
         remote, work = self.make_git_remote()
         self.commit_file(work, "first")
         self.git(work, "push", "origin", "main")
 
         for source_ref, expected in (
-            ("refs/pull/123/head", "pull-request ref"),
-            ("pull/123/head", "pull-request ref"),
+            ("refs/pull/123/head", "pull-request"),
+            ("pull/123/head", "pull-request"),
             ("someuser:branch", "fork shorthand refs"),
         ):
             with self.subTest(source_ref=source_ref):
@@ -686,11 +729,12 @@ class ReleaseToolingTests(unittest.TestCase):
     def test_signed_test_build_docs_describe_reachability_and_provenance(self) -> None:
         docs = (SCRIPT_DIR.parent / "docs" / "releasing.md").read_text(encoding="utf-8")
 
-        self.assertIn("upstream-reachable commit SHA", docs)
+        self.assertIn("full 40-character commit SHA", docs)
         self.assertIn("unreachable", docs)
-        self.assertIn("SHA-only commits", docs)
+        self.assertIn("revspecs", docs)
+        self.assertIn("`sign` job", docs)
         self.assertIn("signed-test-provenance.json", docs)
-        self.assertIn("resolved source commit", docs)
+        self.assertIn("source commit", docs)
         self.assertIn("trusted tooling commit", docs)
         self.assertIn("workflow run URL", docs)
         self.assertIn("ZIP, DMG, checksum manifest", docs)

--- a/Scripts/verify_signed_test_build_ref.sh
+++ b/Scripts/verify_signed_test_build_ref.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+    printf 'ERROR: %s\n' "$*" >&2
+    exit 1
+}
+
+usage() {
+    fail "Usage: $0 <source-ref> <checkout-root>"
+}
+
+[[ "$#" == "2" ]] || usage
+
+SOURCE_REF="$1"
+CHECKOUT_ROOT="$2"
+
+[[ -n "$SOURCE_REF" ]] || fail "source_ref is required"
+[[ "$SOURCE_REF" != -* ]] || fail "Signed test build source_ref must not start with '-'"
+[[ "$SOURCE_REF" != *$'\n'* && "$SOURCE_REF" != *$'\r'* ]] || fail "Signed test build source_ref must be a single line"
+[[ "$SOURCE_REF" != *:* ]] || fail "Signed test builds must use refs from the canonical upstream repository, not fork shorthand refs"
+case "$SOURCE_REF" in
+    refs/pull/*|pull/*|refs/remotes/*/pull/*)
+        fail "Signed test builds must use an upstream branch, tag, or upstream-reachable SHA, not a pull-request ref"
+        ;;
+esac
+
+[[ -d "$CHECKOUT_ROOT/.git" ]] || fail "Missing git checkout: $CHECKOUT_ROOT"
+
+resolved_commit="$(git -C "$CHECKOUT_ROOT" rev-parse --verify HEAD^{commit})"
+[[ "$resolved_commit" =~ ^[0-9a-f]{40}$ ]] || fail "Resolved source commit is not a full SHA: $resolved_commit"
+
+fetch_args=(
+    -C "$CHECKOUT_ROOT"
+)
+server_url="${GITHUB_SERVER_URL:-https://github.com}"
+server_url="${server_url%/}/"
+if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+    fetch_args+=(
+        -c "http.$server_url.extraheader=AUTHORIZATION: bearer $GITHUB_TOKEN"
+    )
+elif [[ -n "${GH_TOKEN:-}" ]]; then
+    fetch_args+=(
+        -c "http.$server_url.extraheader=AUTHORIZATION: bearer $GH_TOKEN"
+    )
+fi
+fetch_args+=(
+    fetch
+    --prune
+    --tags
+    origin
+    '+refs/heads/*:refs/remotes/origin/*'
+    '+refs/tags/*:refs/tags/*'
+)
+
+git "${fetch_args[@]}"
+
+containing_refs=()
+while IFS= read -r ref; do
+    [[ -n "$ref" ]] || continue
+    containing_refs+=("$ref")
+done < <(
+    git -C "$CHECKOUT_ROOT" for-each-ref \
+        --format='%(refname)' \
+        --contains "$resolved_commit" \
+        refs/remotes/origin refs/tags | \
+    grep -Ev '^refs/remotes/origin/(HEAD|pull/)' | \
+    sort
+)
+
+[[ "${#containing_refs[@]}" -gt 0 ]] || \
+    fail "Signed test build commit $resolved_commit is not reachable from any upstream branch or tag in the canonical repository"
+
+reachable_refs="$(IFS=,; printf '%s' "${containing_refs[*]}")"
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    {
+        printf 'commit=%s\n' "$resolved_commit"
+        printf 'reachable_refs=%s\n' "$reachable_refs"
+    } >> "$GITHUB_OUTPUT"
+fi
+
+printf '%s\n' "$resolved_commit"

--- a/Scripts/verify_signed_test_build_ref.sh
+++ b/Scripts/verify_signed_test_build_ref.sh
@@ -20,15 +20,15 @@ CHECKOUT_ROOT="$2"
 [[ "$SOURCE_REF" != *$'\n'* && "$SOURCE_REF" != *$'\r'* ]] || fail "Signed test build source_ref must be a single line"
 [[ "$SOURCE_REF" != *:* ]] || fail "Signed test builds must use refs from the canonical upstream repository, not fork shorthand refs"
 case "$SOURCE_REF" in
-    refs/pull/*|pull/*|refs/remotes/*/pull/*)
-        fail "Signed test builds must use an upstream branch, tag, or upstream-reachable SHA, not a pull-request ref"
+    refs/pull/*|pull/*|refs/remotes/*|*/pull/*)
+        fail "Signed test builds must use an exact upstream branch, tag, or full SHA, not a pull-request or remote ref"
         ;;
 esac
 
 [[ -d "$CHECKOUT_ROOT/.git" ]] || fail "Missing git checkout: $CHECKOUT_ROOT"
 
-resolved_commit="$(git -C "$CHECKOUT_ROOT" rev-parse --verify HEAD^{commit})"
-[[ "$resolved_commit" =~ ^[0-9a-f]{40}$ ]] || fail "Resolved source commit is not a full SHA: $resolved_commit"
+checkout_commit="$(git -C "$CHECKOUT_ROOT" rev-parse --verify HEAD^{commit})"
+[[ "$checkout_commit" =~ ^[0-9a-f]{40}$ ]] || fail "Resolved checkout commit is not a full SHA: $checkout_commit"
 
 fetch_args=(
     -C "$CHECKOUT_ROOT"
@@ -55,29 +55,89 @@ fetch_args+=(
 
 git "${fetch_args[@]}"
 
+resolve_commit=""
+branch_ref=""
+tag_ref=""
+
+resolve_branch() {
+    local branch_name="$1"
+    [[ -n "$branch_name" ]] || return 1
+    git -C "$CHECKOUT_ROOT" check-ref-format "refs/heads/$branch_name" >/dev/null 2>&1 || return 1
+    git -C "$CHECKOUT_ROOT" show-ref --verify --quiet "refs/remotes/origin/$branch_name" || return 1
+    git -C "$CHECKOUT_ROOT" rev-parse --verify "refs/remotes/origin/$branch_name^{commit}"
+}
+
+resolve_tag() {
+    local tag_name="$1"
+    [[ -n "$tag_name" ]] || return 1
+    git -C "$CHECKOUT_ROOT" check-ref-format "refs/tags/$tag_name" >/dev/null 2>&1 || return 1
+    git -C "$CHECKOUT_ROOT" show-ref --verify --quiet "refs/tags/$tag_name" || return 1
+    git -C "$CHECKOUT_ROOT" rev-parse --verify "refs/tags/$tag_name^{commit}"
+}
+
+if [[ "$SOURCE_REF" =~ ^[0-9a-fA-F]{40}$ ]]; then
+    resolve_commit="$(git -C "$CHECKOUT_ROOT" rev-parse --verify "$SOURCE_REF^{commit}")" || \
+        fail "Signed test build SHA is not a commit: $SOURCE_REF"
+elif [[ "$SOURCE_REF" == refs/heads/* ]]; then
+    branch_name="${SOURCE_REF#refs/heads/}"
+    resolve_commit="$(resolve_branch "$branch_name")" || \
+        fail "Signed test build source_ref is not an exact upstream branch: $SOURCE_REF"
+elif [[ "$SOURCE_REF" == refs/tags/* ]]; then
+    tag_name="${SOURCE_REF#refs/tags/}"
+    resolve_commit="$(resolve_tag "$tag_name")" || \
+        fail "Signed test build source_ref is not an exact upstream tag: $SOURCE_REF"
+elif [[ "$SOURCE_REF" == refs/* ]]; then
+    fail "Signed test builds must use refs/heads/<branch>, refs/tags/<tag>, a short upstream branch or tag, or a full SHA"
+else
+    branch_commit=""
+    tag_commit=""
+    if branch_commit="$(resolve_branch "$SOURCE_REF")"; then
+        branch_ref="refs/remotes/origin/$SOURCE_REF"
+    fi
+    if tag_commit="$(resolve_tag "$SOURCE_REF")"; then
+        tag_ref="refs/tags/$SOURCE_REF"
+    fi
+
+    if [[ -n "$branch_commit" && -n "$tag_commit" ]]; then
+        fail "Signed test build source_ref is ambiguous; use refs/heads/$SOURCE_REF or refs/tags/$SOURCE_REF"
+    elif [[ -n "$branch_commit" ]]; then
+        resolve_commit="$branch_commit"
+    elif [[ -n "$tag_commit" ]]; then
+        resolve_commit="$tag_commit"
+    else
+        fail "Signed test build source_ref must be an exact upstream branch, exact upstream tag, or full 40-hex SHA: $SOURCE_REF"
+    fi
+fi
+
+[[ "$resolve_commit" =~ ^[0-9a-f]{40}$ ]] || fail "Resolved source_ref is not a full SHA: $resolve_commit"
+[[ "$resolve_commit" == "$checkout_commit" ]] || \
+    fail "Signed test build source_ref resolves to $resolve_commit, but checkout HEAD is $checkout_commit"
+
 containing_refs=()
 while IFS= read -r ref; do
     [[ -n "$ref" ]] || continue
+    case "$ref" in
+        refs/remotes/origin/HEAD|refs/remotes/origin/pull/*) continue ;;
+    esac
     containing_refs+=("$ref")
 done < <(
     git -C "$CHECKOUT_ROOT" for-each-ref \
         --format='%(refname)' \
-        --contains "$resolved_commit" \
+        --contains "$resolve_commit" \
         refs/remotes/origin refs/tags | \
-    grep -Ev '^refs/remotes/origin/(HEAD|pull/)' | \
     sort
 )
 
 [[ "${#containing_refs[@]}" -gt 0 ]] || \
-    fail "Signed test build commit $resolved_commit is not reachable from any upstream branch or tag in the canonical repository"
+    fail "Signed test build commit $resolve_commit is not reachable from any upstream branch or tag in the canonical repository"
 
 reachable_refs="$(IFS=,; printf '%s' "${containing_refs[*]}")"
 
 if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
     {
-        printf 'commit=%s\n' "$resolved_commit"
+        printf 'commit=%s\n' "$resolve_commit"
         printf 'reachable_refs=%s\n' "$reachable_refs"
     } >> "$GITHUB_OUTPUT"
 fi
 
-printf '%s\n' "$resolved_commit"
+printf '%s\n' "$resolve_commit"

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -22,6 +22,11 @@ PR, merges it, creates the immutable release tag, dispatches the protected
 workflow, tests the resulting draft assets, and promotes the already-reviewed
 draft without rebuilding it.
 
+Write-access collaborators may request a signed, notarized test build through
+the manual **Signed Test Build** workflow, but that request does not grant
+access to Apple signing credentials. The build can stage without secrets; the
+Developer ID signing job waits on the protected `release` environment.
+
 The intended process is:
 
 1. A contributor opens a release PR that updates `version.env`, release notes,
@@ -104,7 +109,8 @@ notarization, and stapling.
 Create a protected GitHub Actions environment named `release`. Require
 maintainer approval before jobs can access its secrets, and restrict deployment
 branches to protected `main`. Do not run production publication until both
-controls are enabled.
+controls are enabled. Enable the environment setting that prevents self-review
+so the person requesting a signed build cannot approve their own run.
 
 Add an immutable release-tag ruleset for `v*` tags. Allow maintainers to create
 new release tags, but prevent updates and deletion after creation. The release
@@ -156,6 +162,41 @@ API** shows **Request Access**, complete that approval step before creating the
 three `NOTARYTOOL_*` secrets. A team key with the least-privilege `Developer`
 role is sufficient for the documented `notarytool` flow. After storing the
 secrets, remove the one-time `.p8` download from the local machine.
+
+## Signed test build
+
+Use **Signed Test Build** when a write-access collaborator needs a real
+Developer ID signed and notarized build before the code is ready for a public
+release tag.
+
+Dispatch the workflow from protected `main` and enter an upstream branch, tag,
+or upstream-reachable commit SHA in `source_ref`. Raw SHAs are allowed only when
+the resolved commit is already reachable from a branch or tag in the canonical
+upstream repository. Do not use fork or pull-request refs for this lane; have
+the collaborator push an inspectable branch to the upstream repository first.
+The workflow rejects fork shorthand, `refs/pull/*` inputs, and unreachable
+SHA-only commits before staging.
+
+The unprotected job checks out trusted release tooling from `main`, checks out
+the requested source ref separately, verifies that the resolved source commit is
+reachable from canonical upstream branch or tag refs, strips GitHub tokens
+before SwiftPM-driven commands, builds an ad-hoc release-mode app, and uploads a
+short-lived staged artifact. The protected `sign` job uses the `release`
+environment, so it pauses for required reviewer approval before importing the
+Developer ID certificate, provisioning profile, and notarization key. After
+approval, trusted tooling verifies the staged payload against a data-only
+checkout of the requested commit, replaces the staged Sparkle framework with the
+trusted closed-world copy, signs, notarizes, staples, and uploads ZIP, DMG,
+checksum, and provenance workflow artifacts.
+
+Signed test builds do not create GitHub Releases, do not publish updater
+assets, and do not use the Sparkle private key. Each final artifact set includes
+a `signed-test-provenance.json` file that records the requested ref, resolved
+source commit, trusted tooling commit, workflow run URL, signing mode,
+reachable upstream refs, and ZIP, DMG, checksum manifest, and staged source
+archive hashes. A fresh secret-free smoke job downloads the signed ZIP,
+validates the provenance hash bindings and embedded MCP helper layout, and runs
+the helper `--version` smoke under a minimal environment.
 
 ## Build a draft release
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -169,22 +169,29 @@ Use **Signed Test Build** when a write-access collaborator needs a real
 Developer ID signed and notarized build before the code is ready for a public
 release tag.
 
-Dispatch the workflow from protected `main` and enter an upstream branch, tag,
-or upstream-reachable commit SHA in `source_ref`. Raw SHAs are allowed only when
-the resolved commit is already reachable from a branch or tag in the canonical
-upstream repository. Do not use fork or pull-request refs for this lane; have
-the collaborator push an inspectable branch to the upstream repository first.
-The workflow rejects fork shorthand, `refs/pull/*` inputs, and unreachable
-SHA-only commits before staging.
+Dispatch the workflow from protected `main` and enter an exact upstream branch,
+exact upstream tag, or full 40-character commit SHA in `source_ref`. Short
+branch/tag names and explicit `refs/heads/<branch>` or `refs/tags/<tag>` inputs
+are accepted. Raw SHAs are allowed only when the resolved commit is already
+reachable from a branch or tag in the canonical upstream repository. Do not use
+fork or pull-request refs for this lane; have the collaborator push an
+inspectable branch to the upstream repository first. The workflow rejects fork
+shorthand, `refs/pull/*` inputs, remote refs, short SHAs, revspecs such as
+`main~1` or `main^`, ambiguous branch/tag names, and unreachable SHA-only
+commits before staging.
 
 The unprotected job checks out trusted release tooling from `main`, checks out
-the requested source ref separately, verifies that the resolved source commit is
+the requested source ref separately, verifies that the literal requested ref
+resolves exactly to the checked-out source commit and that the commit is
 reachable from canonical upstream branch or tag refs, strips GitHub tokens
 before SwiftPM-driven commands, builds an ad-hoc release-mode app, and uploads a
 short-lived staged artifact. The protected `sign` job uses the `release`
 environment, so it pauses for required reviewer approval before importing the
 Developer ID certificate, provisioning profile, and notarization key. After
-approval, trusted tooling verifies the staged payload against a data-only
+approval, trusted tooling revalidates the same requested ref against the
+approved-source checkout before importing signing material. If the branch or tag
+was deleted, force-pushed, or no longer reaches the validated commit, signing
+fails. The signing path then verifies the staged payload against a data-only
 checkout of the requested commit, replaces the staged Sparkle framework with the
 trusted closed-world copy, signs, notarizes, staples, and uploads ZIP, DMG,
 checksum, and provenance workflow artifacts.
@@ -193,8 +200,8 @@ Signed test builds do not create GitHub Releases, do not publish updater
 assets, and do not use the Sparkle private key. Each final artifact set includes
 a `signed-test-provenance.json` file that records the requested ref, resolved
 source commit, trusted tooling commit, workflow run URL, signing mode,
-reachable upstream refs, and ZIP, DMG, checksum manifest, and staged source
-archive hashes. A fresh secret-free smoke job downloads the signed ZIP,
+sign-time reachable upstream refs, and ZIP, DMG, checksum manifest, and staged
+source archive hashes. A fresh secret-free smoke job downloads the signed ZIP,
 validates the provenance hash bindings and embedded MCP helper layout, and runs
 the helper `--version` smoke under a minimal environment.
 


### PR DESCRIPTION
## Summary
- add a signed-test source ref verifier that rejects PR/fork/malformed refs and only allows commits reachable from canonical upstream branches or tags
- generate and upload signed-test provenance JSON binding requested ref, resolved source commit, trusted tooling commit, workflow run URL, signing mode, reachable refs, and artifact hashes
- strengthen signed-test smoke validation, release-tooling regression tests, and release docs

## Validation
- `python3 Scripts/test_release_tooling.py ReleaseToolingTests.test_signed_test_build_ref_helper_requires_upstream_reachability ReleaseToolingTests.test_signed_test_build_ref_helper_rejects_pr_and_fork_refs ReleaseToolingTests.test_signed_test_build_docs_describe_reachability_and_provenance ReleaseToolingTests.test_release_workflows_isolate_executable_helper_smoke_and_harden_p12_cleanup`
- `bash -n Scripts/release.sh Scripts/verify_signed_test_build_ref.sh`
- `python3 -m py_compile Scripts/test_release_tooling.py`
- `actionlint .github/workflows/signed-test-build.yml`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh commit`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh push`

## Notes
- Full `Scripts/test_release_tooling.py` currently hangs in existing `test_legacy_sparkle_key_export_is_rejected`; targeted coverage for this change passes.
