### PR TITLE
Harden Sparkle release configuration validation

### DIFF
--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -94,6 +94,9 @@ jobs:
           ./trusted-control-plane/Scripts/validate_embedded_mcp_helper_layout.sh \
             extracted/RepoPrompt.app \
             "Reviewed ZIP MCP helper layout"
+          ./trusted-control-plane/Scripts/validate_sparkle_helper_layout.sh \
+            extracted/RepoPrompt.app \
+            "Reviewed ZIP Sparkle helper layout"
 
       - name: Execute reviewed helper without inherited secrets
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -259,6 +259,9 @@ jobs:
           ./trusted-control-plane/Scripts/validate_embedded_mcp_helper_layout.sh \
             extracted/RepoPrompt.app \
             "Signed draft MCP helper layout"
+          ./trusted-control-plane/Scripts/validate_sparkle_helper_layout.sh \
+            extracted/RepoPrompt.app \
+            "Signed draft Sparkle helper layout"
 
       - name: Execute signed helper without inherited secrets
         run: |

--- a/README.md
+++ b/README.md
@@ -58,6 +58,19 @@ Apple Development signing path.
 | `x` | Stop the app                                |
 | `q` | Close the launcher without stopping the app |
 
+### Updating from v1.0.0
+
+If RepoPrompt CE v1.0.0 detects v1.0.2 or later but fails with:
+
+```text
+Update Error! An error occurred while connecting to the installer. Please try again later.
+```
+
+manually download and install the latest RepoPrompt CE release. v1.0.0's running
+Sparkle updater configuration controls that attempted self-update, so a later
+release cannot repair the already-running v1.0.0 installer path before the app is
+replaced. After the manual install, normal in-app updates should resume.
+
 ### Install a local production build
 
 For a release-mode app under `/Applications`, install Python 3 and double-click

--- a/Scripts/package_app.sh
+++ b/Scripts/package_app.sh
@@ -205,6 +205,22 @@ Path('$APP_BUNDLE/Contents/Info.plist').write_text(s)
 PY
 run plutil -lint "$APP_BUNDLE/Contents/Info.plist"
 
+validate_sparkle_update_configuration(){
+    (( IS_RELEASE )) || return 0
+    phase "Validating Sparkle update configuration"
+    [[ -f "$CONTROL_PLANE_SCRIPTS_DIR/validate_sparkle_update_configuration.py" ]] || fail "Missing Sparkle update configuration validator"
+    if [[ -n "$APP_ENTITLEMENTS" && -f "$APP_ENTITLEMENTS" ]]; then
+        run python3 "$CONTROL_PLANE_SCRIPTS_DIR/validate_sparkle_update_configuration.py" \
+            "$APP_BUNDLE/Contents/Info.plist" \
+            "$APP_ENTITLEMENTS"
+    else
+        run python3 "$CONTROL_PLANE_SCRIPTS_DIR/validate_sparkle_update_configuration.py" \
+            "$APP_BUNDLE/Contents/Info.plist" \
+            "$APP_ENTITLEMENTS_TEMPLATE" \
+            "$LOCAL_SELF_SIGNED_ENTITLEMENTS_TEMPLATE"
+    fi
+}
+
 if (( USE_LOCAL_SELF_SIGNED_RELEASE )); then
     phase "Rendering local self-signed entitlements"
     [[ -f "$LOCAL_SELF_SIGNED_ENTITLEMENTS_TEMPLATE" ]] || fail "Missing local self-signed entitlements template: $LOCAL_SELF_SIGNED_ENTITLEMENTS_TEMPLATE"
@@ -235,6 +251,8 @@ Path('$APP_ENTITLEMENTS').write_text(s)
 PY
     run plutil -lint "$APP_ENTITLEMENTS"
 fi
+
+validate_sparkle_update_configuration
 
 phase "Copying dynamic frameworks"
 printf 'Framework destination: %s\n' "$APP_BUNDLE/Contents/Frameworks"
@@ -308,6 +326,7 @@ fi
 run codesign --verify --deep --strict --verbose=2 "$APP_BUNDLE"
 verify_signed_app_identity
 run "$CONTROL_PLANE_SCRIPTS_DIR/validate_embedded_mcp_helper_layout.sh" "$APP_BUNDLE" "Packaged app MCP helper layout"
+run "$CONTROL_PLANE_SCRIPTS_DIR/validate_sparkle_helper_layout.sh" "$APP_BUNDLE" "Packaged app Sparkle helper layout"
 run "$RUN_WITHOUT_GITHUB_TOKENS" "$CONTROL_PLANE_SCRIPTS_DIR/smoke_embedded_mcp_helper.sh" "$APP_BUNDLE" "Packaged app MCP helper"
 if [[ "$(python3 - <<PY
 from pathlib import Path

--- a/Scripts/promote_release.sh
+++ b/Scripts/promote_release.sh
@@ -50,6 +50,10 @@ validate_embedded_mcp_helper_layout() {
     "$CONTROL_PLANE_SCRIPTS_DIR/validate_embedded_mcp_helper_layout.sh" "$@"
 }
 
+validate_sparkle_helper_layout() {
+    "$CONTROL_PLANE_SCRIPTS_DIR/validate_sparkle_helper_layout.sh" "$@"
+}
+
 require_env() {
     [[ -n "${!1:-}" ]] || fail "Missing required environment variable: $1"
 }
@@ -154,6 +158,7 @@ validate_app_bundle() {
     REPOPROMPT_RELEASE_SOURCE_ROOT="$ROOT_DIR" \
         "$CONTROL_PLANE_SCRIPTS_DIR/validate_packaged_legal.sh" "$app_bundle"
     validate_embedded_mcp_helper_layout "$app_bundle" "Reviewed ZIP MCP helper layout"
+    validate_sparkle_helper_layout "$app_bundle" "Reviewed ZIP Sparkle helper layout"
 }
 
 validate_dmg_matches_zip_app() {
@@ -166,6 +171,7 @@ validate_dmg_matches_zip_app() {
     diff -qr "$APP_BUNDLE" "$dmg_app" ||
         fail "DMG app contents do not match the verified update ZIP app"
     validate_embedded_mcp_helper_layout "$dmg_app" "Mounted DMG MCP helper layout"
+    validate_sparkle_helper_layout "$dmg_app" "Mounted DMG Sparkle helper layout"
 
     hdiutil detach "$DMG_MOUNT_POINT" >/dev/null
     DMG_MOUNT_POINT=""
@@ -243,6 +249,7 @@ verify_source_release() {
     require_file "$CONTROL_PLANE_SCRIPTS_DIR/verify_sparkle_vendor.sh"
     require_file "$CONTROL_PLANE_SCRIPTS_DIR/verify_sparkle_signature.swift"
     require_file "$CONTROL_PLANE_SCRIPTS_DIR/validate_embedded_mcp_helper_layout.sh"
+    require_file "$CONTROL_PLANE_SCRIPTS_DIR/validate_sparkle_helper_layout.sh"
     "$CONTROL_PLANE_SCRIPTS_DIR/verify_remote_release_commit.sh" "$RELEASE_TAG" "$RELEASE_COMMIT"
     REPOPROMPT_RELEASE_SOURCE_ROOT="$ROOT_DIR" \
         "$CONTROL_PLANE_SCRIPTS_DIR/verify_sparkle_vendor.sh"

--- a/Scripts/promote_release.sh
+++ b/Scripts/promote_release.sh
@@ -54,6 +54,17 @@ validate_sparkle_helper_layout() {
     "$CONTROL_PLANE_SCRIPTS_DIR/validate_sparkle_helper_layout.sh" "$@"
 }
 
+validate_sparkle_update_configuration() {
+    local app_bundle="$1"
+    local label="$2"
+    local entitlements_plist="$TMP_DIR/${label//[^A-Za-z0-9_.-]/-}-entitlements.plist"
+    codesign -d --entitlements :- "$app_bundle" > "$entitlements_plist" 2>/dev/null ||
+        fail "Unable to extract signed entitlements for $label"
+    python3 "$CONTROL_PLANE_SCRIPTS_DIR/validate_sparkle_update_configuration.py" \
+        "$app_bundle/Contents/Info.plist" \
+        "$entitlements_plist"
+}
+
 require_env() {
     [[ -n "${!1:-}" ]] || fail "Missing required environment variable: $1"
 }
@@ -159,6 +170,7 @@ validate_app_bundle() {
         "$CONTROL_PLANE_SCRIPTS_DIR/validate_packaged_legal.sh" "$app_bundle"
     validate_embedded_mcp_helper_layout "$app_bundle" "Reviewed ZIP MCP helper layout"
     validate_sparkle_helper_layout "$app_bundle" "Reviewed ZIP Sparkle helper layout"
+    validate_sparkle_update_configuration "$app_bundle" "Reviewed ZIP Sparkle update configuration"
 }
 
 validate_dmg_matches_zip_app() {
@@ -250,6 +262,7 @@ verify_source_release() {
     require_file "$CONTROL_PLANE_SCRIPTS_DIR/verify_sparkle_signature.swift"
     require_file "$CONTROL_PLANE_SCRIPTS_DIR/validate_embedded_mcp_helper_layout.sh"
     require_file "$CONTROL_PLANE_SCRIPTS_DIR/validate_sparkle_helper_layout.sh"
+    require_file "$CONTROL_PLANE_SCRIPTS_DIR/validate_sparkle_update_configuration.py"
     "$CONTROL_PLANE_SCRIPTS_DIR/verify_remote_release_commit.sh" "$RELEASE_TAG" "$RELEASE_COMMIT"
     REPOPROMPT_RELEASE_SOURCE_ROOT="$ROOT_DIR" \
         "$CONTROL_PLANE_SCRIPTS_DIR/verify_sparkle_vendor.sh"

--- a/Scripts/publish_public_update_test.sh
+++ b/Scripts/publish_public_update_test.sh
@@ -39,8 +39,10 @@ trap cleanup EXIT
     fail "Missing embedded MCP helper layout validator"
 [[ -x "$ROOT_DIR/Scripts/validate_sparkle_helper_layout.sh" ]] ||
     fail "Missing Sparkle helper layout validator"
+[[ -x "$ROOT_DIR/Scripts/validate_sparkle_update_configuration.py" ]] ||
+    fail "Missing Sparkle update configuration validator"
 
-for command in codesign curl ditto gh plutil shasum xcrun; do
+for command in codesign curl ditto gh plutil python3 shasum xcrun; do
     require_command "$command"
 done
 
@@ -70,8 +72,14 @@ printf '%s\n' "$signature_details" | grep -q '^Authority=Developer ID Applicatio
 [[ "$team_identifier" == "$SIGNING_TEAM_ID" ]] ||
     fail "Signed app team mismatch: expected $SIGNING_TEAM_ID, got ${team_identifier:-<missing>}"
 xcrun stapler validate "$APP_BUNDLE"
+SIGNED_ENTITLEMENTS="$TMP_DIR/public-updater-app-entitlements.plist"
+codesign -d --entitlements :- "$APP_BUNDLE" > "$SIGNED_ENTITLEMENTS" 2>/dev/null ||
+    fail "Unable to extract signed entitlements from public updater ZIP app"
 "$ROOT_DIR/Scripts/validate_embedded_mcp_helper_layout.sh" "$APP_BUNDLE" "Public updater ZIP MCP helper layout"
 "$ROOT_DIR/Scripts/validate_sparkle_helper_layout.sh" "$APP_BUNDLE" "Public updater ZIP Sparkle helper layout"
+python3 "$ROOT_DIR/Scripts/validate_sparkle_update_configuration.py" \
+    "$APP_BUNDLE/Contents/Info.plist" \
+    "$SIGNED_ENTITLEMENTS"
 
 bundle_identifier="$(plutil -extract CFBundleIdentifier raw "$APP_BUNDLE/Contents/Info.plist")"
 marketing_version="$(plutil -extract CFBundleShortVersionString raw "$APP_BUNDLE/Contents/Info.plist")"

--- a/Scripts/publish_public_update_test.sh
+++ b/Scripts/publish_public_update_test.sh
@@ -37,6 +37,8 @@ trap cleanup EXIT
 [[ -x "$GENERATE_APPCAST" ]] || fail "Missing Sparkle generate_appcast tool: $GENERATE_APPCAST"
 [[ -x "$ROOT_DIR/Scripts/validate_embedded_mcp_helper_layout.sh" ]] ||
     fail "Missing embedded MCP helper layout validator"
+[[ -x "$ROOT_DIR/Scripts/validate_sparkle_helper_layout.sh" ]] ||
+    fail "Missing Sparkle helper layout validator"
 
 for command in codesign curl ditto gh plutil shasum xcrun; do
     require_command "$command"
@@ -69,6 +71,7 @@ printf '%s\n' "$signature_details" | grep -q '^Authority=Developer ID Applicatio
     fail "Signed app team mismatch: expected $SIGNING_TEAM_ID, got ${team_identifier:-<missing>}"
 xcrun stapler validate "$APP_BUNDLE"
 "$ROOT_DIR/Scripts/validate_embedded_mcp_helper_layout.sh" "$APP_BUNDLE" "Public updater ZIP MCP helper layout"
+"$ROOT_DIR/Scripts/validate_sparkle_helper_layout.sh" "$APP_BUNDLE" "Public updater ZIP Sparkle helper layout"
 
 bundle_identifier="$(plutil -extract CFBundleIdentifier raw "$APP_BUNDLE/Contents/Info.plist")"
 marketing_version="$(plutil -extract CFBundleShortVersionString raw "$APP_BUNDLE/Contents/Info.plist")"

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -64,6 +64,7 @@ prepare_dist() {
 
 run_preflight() {
     require_command plutil
+    require_command python3
     require_command shasum
     require_file "$CONTROL_PLANE_SCRIPTS_DIR/swiftpm_notice_guardrails.sh"
     require_file "$CONTROL_PLANE_SCRIPTS_DIR/validate_packaged_legal.sh"
@@ -76,11 +77,13 @@ run_preflight() {
     require_file "$CONTROL_PLANE_SCRIPTS_DIR/sign_staged_release.sh"
     require_file "$CONTROL_PLANE_SCRIPTS_DIR/smoke_embedded_mcp_helper.sh"
     require_file "$CONTROL_PLANE_SCRIPTS_DIR/validate_embedded_mcp_helper_layout.sh"
+    require_file "$CONTROL_PLANE_SCRIPTS_DIR/validate_sparkle_helper_layout.sh"
     require_file "$CONTROL_PLANE_SCRIPTS_DIR/extract_staged_release.py"
     require_file "$CONTROL_PLANE_SCRIPTS_DIR/validate_staged_release.sh"
     require_file "$RUN_WITHOUT_GITHUB_TOKENS"
     require_file "$CONTROL_PLANE_SCRIPTS_DIR/verify_remote_release_commit.sh"
     require_file "$CONTROL_PLANE_SCRIPTS_DIR/verify_sparkle_vendor.sh"
+    require_file "$CONTROL_PLANE_SCRIPTS_DIR/validate_sparkle_update_configuration.py"
     require_file "$TRUSTED_ROOT/Vendor/Sparkle/INSTALLED_MANIFEST.tsv"
     require_file "$TRUSTED_ROOT/Vendor/Sparkle/bin/generate_appcast"
     require_file "$SPARKLE_FRAMEWORK_INFO"
@@ -90,6 +93,10 @@ run_preflight() {
     feed_url="$(plutil -extract SUFeedURL raw "$ROOT_DIR/AppBundle/Info.plist.template")"
     [[ "$sparkle_version" == "2.9.2" ]] || fail "Expected vendored Sparkle 2.9.2, got $sparkle_version"
     [[ "$feed_url" == "$EXPECTED_FEED_URL" ]] || fail "Expected CE Sparkle feed $EXPECTED_FEED_URL, got $feed_url"
+    python3 "$CONTROL_PLANE_SCRIPTS_DIR/validate_sparkle_update_configuration.py" \
+        "$ROOT_DIR/AppBundle/Info.plist.template" \
+        "$ROOT_DIR/AppBundle/RepoPrompt.entitlements.template" \
+        "$ROOT_DIR/AppBundle/RepoPrompt.local-self-signed.entitlements.template"
     REPOPROMPT_RELEASE_SOURCE_ROOT="$ROOT_DIR" \
         "$CONTROL_PLANE_SCRIPTS_DIR/verify_sparkle_vendor.sh"
     REPOPROMPT_RELEASE_SOURCE_ROOT="$ROOT_DIR" \

--- a/Scripts/sign_staged_release.sh
+++ b/Scripts/sign_staged_release.sh
@@ -61,6 +61,9 @@ PYTHON
 plutil -lint "$app_entitlements"
 plutil -replace RepoPromptDebugSecureStorageBackend -string keychain "$APP_BUNDLE/Contents/Info.plist"
 plutil -replace RepoPromptSigningMode -string developer-id "$APP_BUNDLE/Contents/Info.plist"
+python3 "$SCRIPT_DIR/validate_sparkle_update_configuration.py" \
+    "$APP_BUNDLE/Contents/Info.plist" \
+    "$app_entitlements"
 
 sign_path() {
     local path="$1"
@@ -88,6 +91,7 @@ plutil -convert xml1 -o "$canonical_signed_entitlements" "$signed_entitlements"
 cmp "$canonical_app_entitlements" "$canonical_signed_entitlements" ||
     fail "Signed app entitlements do not match trusted release policy"
 "$SCRIPT_DIR/validate_embedded_mcp_helper_layout.sh" "$APP_BUNDLE" "Developer ID staged app MCP helper layout"
+"$SCRIPT_DIR/validate_sparkle_helper_layout.sh" "$APP_BUNDLE" "Developer ID staged app Sparkle helper layout"
 
 signature_details="$(codesign -dv --verbose=4 "$APP_BUNDLE" 2>&1)"
 identifier="$(printf '%s\n' "$signature_details" | awk -F= '/^Identifier=/{print $2; exit}')"

--- a/Scripts/test_release_promotion.py
+++ b/Scripts/test_release_promotion.py
@@ -151,11 +151,13 @@ class ReleasePromotionTests(unittest.TestCase):
             scripts / "validate_embedded_mcp_helper_layout.sh",
         )
         shutil.copy2(SCRIPT_DIR / "validate_packaged_legal.sh", scripts / "validate_packaged_legal.sh")
+        shutil.copy2(SCRIPT_DIR / "validate_sparkle_helper_layout.sh", scripts / "validate_sparkle_helper_layout.sh")
         shutil.copy2(SCRIPT_DIR / "load_release_metadata.sh", scripts / "load_release_metadata.sh")
         shutil.copy2(SCRIPT_DIR / "verify_sparkle_signature.swift", scripts / "verify_sparkle_signature.swift")
         (scripts / "promote_release.sh").chmod(0o755)
         (scripts / "validate_embedded_mcp_helper_layout.sh").chmod(0o755)
         (scripts / "validate_packaged_legal.sh").chmod(0o755)
+        (scripts / "validate_sparkle_helper_layout.sh").chmod(0o755)
         self.write_stub(scripts, "verify_remote_release_commit.sh", "printf 'OK: fixture remote tag remains bound.\\n'\n")
         self.write_stub(scripts, "verify_sparkle_vendor.sh", "printf 'OK: fixture Sparkle payload matches.\\n'\n")
         (root / "version.env").write_text(
@@ -179,6 +181,7 @@ class ReleasePromotionTests(unittest.TestCase):
         )
         (app / "Contents" / "Resources" / "repoprompt-mcp").symlink_to("../MacOS/repoprompt-mcp")
         (app / "Contents" / "Resources" / "bin" / "repoprompt-mcp").symlink_to("../../MacOS/repoprompt-mcp")
+        self.write_sparkle_helper_layout(app)
         self.write_legal_tree(root, app)
         shutil.copytree(app, dmg_app, symlinks=True)
         if mismatched_dmg_app:
@@ -415,6 +418,33 @@ class ReleasePromotionTests(unittest.TestCase):
         if mode == "promote" and result.returncode == 0:
             (temp_dir / "promotion-published").touch()
         return result, capture, tool_capture
+
+    @staticmethod
+    def write_sparkle_helper_layout(app: Path) -> None:
+        framework = app / "Contents" / "Frameworks" / "Sparkle.framework"
+        version_b = framework / "Versions" / "B"
+        for directory in (
+            version_b / "Headers",
+            version_b / "Modules",
+            version_b / "PrivateHeaders",
+            version_b / "Resources",
+            version_b / "Updater.app" / "Contents" / "MacOS",
+            version_b / "XPCServices" / "Installer.xpc" / "Contents" / "MacOS",
+            version_b / "XPCServices" / "Downloader.xpc" / "Contents" / "MacOS",
+        ):
+            directory.mkdir(parents=True, exist_ok=True)
+        for executable in (
+            version_b / "Autoupdate",
+            version_b / "Sparkle",
+            version_b / "Updater.app" / "Contents" / "MacOS" / "Updater",
+            version_b / "XPCServices" / "Installer.xpc" / "Contents" / "MacOS" / "Installer",
+            version_b / "XPCServices" / "Downloader.xpc" / "Contents" / "MacOS" / "Downloader",
+        ):
+            executable.write_text(f"{executable.name}\n", encoding="utf-8")
+            executable.chmod(0o755)
+        (framework / "Versions" / "Current").symlink_to("B")
+        for name in ("Autoupdate", "Headers", "Modules", "PrivateHeaders", "Resources", "Sparkle", "Updater.app", "XPCServices"):
+            (framework / name).symlink_to(f"Versions/Current/{name}")
 
     @staticmethod
     def write_legal_tree(root: Path, app: Path) -> None:

--- a/Scripts/test_release_promotion.py
+++ b/Scripts/test_release_promotion.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import hashlib
 import os
+import plistlib
 import shutil
 import subprocess
 import tempfile
@@ -108,6 +109,12 @@ class ReleasePromotionTests(unittest.TestCase):
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("Appcast enclosure URL mismatch", result.stderr)
 
+    def test_verify_rejects_reviewed_zip_with_incompatible_sparkle_configuration(self) -> None:
+        result, _capture, _tools = self.run_promotion("verify", installer_launcher_enabled=True)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("non-sandboxed apps must not enable Sparkle sandbox services", result.stderr)
+
     def test_verify_rejects_tag_that_disagrees_with_release_metadata(self) -> None:
         result, _capture, _tools = self.run_promotion("verify", release_tag="v1.0.1")
 
@@ -132,6 +139,7 @@ class ReleasePromotionTests(unittest.TestCase):
         latest_http_status: str = "404",
         reviewed_checksums_sha256: str = "",
         release_tag: str = "v1.0.0",
+        installer_launcher_enabled: bool = False,
     ) -> tuple[subprocess.CompletedProcess[str], Path, Path]:
         temp_dir = Path(tempfile.mkdtemp())
         self.addCleanup(shutil.rmtree, temp_dir, True)
@@ -152,6 +160,10 @@ class ReleasePromotionTests(unittest.TestCase):
         )
         shutil.copy2(SCRIPT_DIR / "validate_packaged_legal.sh", scripts / "validate_packaged_legal.sh")
         shutil.copy2(SCRIPT_DIR / "validate_sparkle_helper_layout.sh", scripts / "validate_sparkle_helper_layout.sh")
+        shutil.copy2(
+            SCRIPT_DIR / "validate_sparkle_update_configuration.py",
+            scripts / "validate_sparkle_update_configuration.py",
+        )
         shutil.copy2(SCRIPT_DIR / "load_release_metadata.sh", scripts / "load_release_metadata.sh")
         shutil.copy2(SCRIPT_DIR / "verify_sparkle_signature.swift", scripts / "verify_sparkle_signature.swift")
         (scripts / "promote_release.sh").chmod(0o755)
@@ -173,7 +185,16 @@ class ReleasePromotionTests(unittest.TestCase):
             ),
             encoding="utf-8",
         )
-        (app / "Contents" / "Info.plist").write_text("fixture plist\n", encoding="utf-8")
+        info_plist = {
+            "CFBundleIdentifier": "com.pvncher.repoprompt.ce",
+            "CFBundleShortVersionString": "1.0.0",
+            "CFBundleVersion": "1",
+            "SUFeedURL": "https://github.com/repoprompt/repoprompt-ce-updates/releases/latest/download/appcast.xml",
+            "SUPublicEDKey": "fixture-public-key",
+        }
+        if installer_launcher_enabled:
+            info_plist["SUEnableInstallerLauncherService"] = True
+        self.write_plist(app / "Contents" / "Info.plist", info_plist)
         self.write_stub(
             app / "Contents" / "MacOS",
             "repoprompt-mcp",
@@ -302,6 +323,12 @@ class ReleasePromotionTests(unittest.TestCase):
             """\
             if [[ "$1" == "-dv" ]]; then
                 printf 'Authority=Developer ID Application: Fixture (648A27MST5)\\nTeamIdentifier=648A27MST5\\n' >&2
+            elif [[ "$1" == "-d" && "$2" == "--entitlements" ]]; then
+                cat <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict/></plist>
+PLIST
             fi
             """,
         )
@@ -457,6 +484,11 @@ class ReleasePromotionTests(unittest.TestCase):
         shutil.copy2(root / "LICENSE", legal / "LICENSE")
         shutil.copy2(root / "THIRD_PARTY_NOTICES.md", legal / "THIRD_PARTY_NOTICES.md")
         shutil.copytree(root / "ThirdPartyLicenses", legal / "ThirdPartyLicenses")
+
+    @staticmethod
+    def write_plist(path: Path, value: dict[str, object]) -> Path:
+        path.write_bytes(plistlib.dumps(value))
+        return path
 
     @staticmethod
     def sha256(path: Path) -> str:

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -21,7 +21,6 @@ class ReleaseToolingTests(unittest.TestCase):
     def test_custom_packaging_resigns_sparkle_helpers_without_recursive_entitlement_propagation(self) -> None:
         package_script = (SCRIPT_DIR / "package_app.sh").read_text(encoding="utf-8")
         staged_signing_script = (SCRIPT_DIR / "sign_staged_release.sh").read_text(encoding="utf-8")
-        info_plist = plistlib.loads((SCRIPT_DIR.parent / "AppBundle" / "Info.plist.template").read_bytes())
 
         for script in (package_script, staged_signing_script):
             self.assertIn('sign_path "$framework/Versions/B/XPCServices/Installer.xpc"', script)
@@ -36,9 +35,93 @@ class ReleaseToolingTests(unittest.TestCase):
         self.assertIn('APP_SIGN_ARGS=()', package_script)
         self.assertNotIn('APP_SIGN_ARGS=(--deep)', package_script)
         self.assertNotIn('sign_path "$APP_BUNDLE" --deep', staged_signing_script)
-        self.assertNotIn("SUEnableInstallerLauncherService", info_plist)
         self.assertIn("trap 'finish $?' EXIT", package_script)
         self.assertIn('local status="$1" now total', package_script)
+
+    def test_sparkle_update_configuration_validator_accepts_current_source(self) -> None:
+        result = self.run_sparkle_validator(
+            SCRIPT_DIR.parent / "AppBundle" / "Info.plist.template",
+            [
+                SCRIPT_DIR.parent / "AppBundle" / "RepoPrompt.entitlements.template",
+                SCRIPT_DIR.parent / "AppBundle" / "RepoPrompt.local-self-signed.entitlements.template",
+            ],
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Sparkle update configuration is compatible", result.stdout)
+
+    def test_sparkle_update_configuration_validator_enforces_sandbox_semantics(self) -> None:
+        temp_dir = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, temp_dir, True)
+        non_sandboxed = self.write_plist(temp_dir / "non-sandboxed.entitlements", {})
+        sandboxed = self.write_plist(temp_dir / "sandboxed.entitlements", {"com.apple.security.app-sandbox": True})
+
+        cases = (
+            (
+                "non-sandboxed launcher true",
+                {"SUEnableInstallerLauncherService": True},
+                [non_sandboxed],
+                1,
+                "non-sandboxed apps must not enable SUEnableInstallerLauncherService",
+            ),
+            (
+                "sandboxed missing launcher",
+                {},
+                [sandboxed],
+                1,
+                "sandboxed apps must set SUEnableInstallerLauncherService to true",
+            ),
+            (
+                "sandboxed launcher false",
+                {"SUEnableInstallerLauncherService": False},
+                [sandboxed],
+                1,
+                "sandboxed apps must set SUEnableInstallerLauncherService to true",
+            ),
+            (
+                "sandboxed launcher true",
+                {"SUEnableInstallerLauncherService": True},
+                [sandboxed],
+                0,
+                "Sparkle update configuration is compatible",
+            ),
+            (
+                "mixed entitlement sandbox states",
+                {"SUEnableInstallerLauncherService": True},
+                [non_sandboxed, sandboxed],
+                1,
+                "entitlement profiles disagree on sandbox state",
+            ),
+        )
+
+        for label, info, entitlements, expected_returncode, expected_message in cases:
+            with self.subTest(label=label):
+                info_path = self.write_plist(temp_dir / f"{label}.Info.plist", info)
+                result = self.run_sparkle_validator(info_path, entitlements)
+                self.assertEqual(result.returncode, expected_returncode, result.stderr)
+                self.assertIn(expected_message, result.stdout + result.stderr)
+
+    def test_sparkle_update_configuration_validator_rejects_non_boolean_values(self) -> None:
+        temp_dir = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, temp_dir, True)
+        non_sandboxed = self.write_plist(temp_dir / "non-sandboxed.entitlements", {})
+
+        non_boolean_info = self.write_plist(
+            temp_dir / "non-boolean-info.plist",
+            {"SUEnableInstallerLauncherService": "true"},
+        )
+        rejected_info = self.run_sparkle_validator(non_boolean_info, [non_sandboxed])
+        self.assertNotEqual(rejected_info.returncode, 0)
+        self.assertIn("SUEnableInstallerLauncherService must be a Boolean", rejected_info.stderr)
+
+        empty_info = self.write_plist(temp_dir / "empty-info.plist", {})
+        non_boolean_entitlements = self.write_plist(
+            temp_dir / "non-boolean.entitlements",
+            {"com.apple.security.app-sandbox": "true"},
+        )
+        rejected_entitlements = self.run_sparkle_validator(empty_info, [non_boolean_entitlements])
+        self.assertNotEqual(rejected_entitlements.returncode, 0)
+        self.assertIn("com.apple.security.app-sandbox must be a Boolean", rejected_entitlements.stderr)
 
     def test_release_paths_use_static_validation_in_privileged_contexts_and_token_stripped_local_smoke(self) -> None:
         package_script = (SCRIPT_DIR / "package_app.sh").read_text(encoding="utf-8")
@@ -49,16 +132,27 @@ class ReleaseToolingTests(unittest.TestCase):
 
         package_outer_sign = package_script.index('sign_path "$APP_BUNDLE" "${APP_SIGN_ARGS[@]}"')
         package_layout = package_script.index('"$CONTROL_PLANE_SCRIPTS_DIR/validate_embedded_mcp_helper_layout.sh"')
+        package_sparkle_layout = package_script.index('"$CONTROL_PLANE_SCRIPTS_DIR/validate_sparkle_helper_layout.sh"')
         package_smoke = package_script.index(
             '"$RUN_WITHOUT_GITHUB_TOKENS" "$CONTROL_PLANE_SCRIPTS_DIR/smoke_embedded_mcp_helper.sh"'
         )
         self.assertLess(package_outer_sign, package_layout)
-        self.assertLess(package_layout, package_smoke)
+        self.assertLess(package_layout, package_sparkle_layout)
+        self.assertLess(package_sparkle_layout, package_smoke)
 
         for privileged_script in (staged_signing_script, promote_script, public_update_script):
             self.assertIn("validate_embedded_mcp_helper_layout.sh", privileged_script)
+            self.assertIn("validate_sparkle_helper_layout.sh", privileged_script)
             self.assertNotIn("smoke_embedded_mcp_helper.sh", privileged_script)
         self.assertIn('require_file "$CONTROL_PLANE_SCRIPTS_DIR/validate_embedded_mcp_helper_layout.sh"', release_script)
+        self.assertIn('require_file "$CONTROL_PLANE_SCRIPTS_DIR/validate_sparkle_helper_layout.sh"', release_script)
+        self.assertIn('require_file "$CONTROL_PLANE_SCRIPTS_DIR/validate_sparkle_update_configuration.py"', release_script)
+        self.assertIn('python3 "$CONTROL_PLANE_SCRIPTS_DIR/validate_sparkle_update_configuration.py"', release_script)
+        self.assertIn('python3 "$CONTROL_PLANE_SCRIPTS_DIR/validate_sparkle_update_configuration.py"', package_script)
+        self.assertIn('python3 "$SCRIPT_DIR/validate_sparkle_update_configuration.py"', staged_signing_script)
+        staged_validator = (SCRIPT_DIR / "validate_staged_release.sh").read_text(encoding="utf-8")
+        self.assertIn('python3 "$SCRIPT_DIR/validate_sparkle_update_configuration.py"', staged_validator)
+        self.assertIn('"$SCRIPT_DIR/validate_sparkle_helper_layout.sh"', staged_validator)
 
     def test_embedded_mcp_helper_smoke_rejects_exit_137(self) -> None:
         temp_dir = Path(tempfile.mkdtemp())
@@ -118,6 +212,56 @@ class ReleaseToolingTests(unittest.TestCase):
                 result = self.run_layout_validation(app)
                 self.assertNotEqual(result.returncode, 0)
 
+    def test_sparkle_helper_layout_validator_accepts_canonical_layout(self) -> None:
+        app = self.make_sparkle_helper_layout()
+
+        result = self.run_sparkle_helper_validation(app)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("matches the Sparkle helper layout policy", result.stdout)
+
+    def test_sparkle_helper_layout_validator_rejects_invalid_metadata(self) -> None:
+        def escaping_current_symlink(app: Path) -> None:
+            current = app / "Contents" / "Frameworks" / "Sparkle.framework" / "Versions" / "Current"
+            current.unlink()
+            current.symlink_to("../../../../MacOS")
+
+        def missing_autoupdate(app: Path) -> None:
+            (app / "Contents" / "Frameworks" / "Sparkle.framework" / "Versions" / "B" / "Autoupdate").unlink()
+
+        def escaping_extra_symlink(app: Path) -> None:
+            extra = app / "Contents" / "Frameworks" / "Sparkle.framework" / "Versions" / "B" / "Resources" / "escape"
+            extra.symlink_to("/tmp")
+
+        def non_executable_downloader(app: Path) -> None:
+            downloader = (
+                app
+                / "Contents"
+                / "Frameworks"
+                / "Sparkle.framework"
+                / "Versions"
+                / "B"
+                / "XPCServices"
+                / "Downloader.xpc"
+                / "Contents"
+                / "MacOS"
+                / "Downloader"
+            )
+            downloader.chmod(0o644)
+
+        for label, mutate, expected_message in (
+            ("broken current symlink", escaping_current_symlink, "broken Sparkle framework symlink"),
+            ("missing Autoupdate", missing_autoupdate, "broken Sparkle framework symlink"),
+            ("escaping extra symlink", escaping_extra_symlink, "escaping Sparkle framework symlink"),
+            ("non-executable Downloader", non_executable_downloader, "must be executable"),
+        ):
+            with self.subTest(label=label):
+                app = self.make_sparkle_helper_layout()
+                mutate(app)
+                result = self.run_sparkle_helper_validation(app)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(expected_message, result.stderr)
+
     def test_release_workflows_isolate_executable_helper_smoke_and_harden_p12_cleanup(self) -> None:
         release_workflow = (SCRIPT_DIR.parent / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
         promote_workflow = (SCRIPT_DIR.parent / ".github" / "workflows" / "release-promote.yml").read_text(
@@ -143,6 +287,7 @@ class ReleaseToolingTests(unittest.TestCase):
         self.assertIn("shasum -a 256 -c", signed_smoke)
         self.assertLess(signed_smoke.index("shasum -a 256 -c"), signed_smoke.index("ditto -x -k"))
         self.assertIn("validate_embedded_mcp_helper_layout.sh", signed_smoke)
+        self.assertIn("validate_sparkle_helper_layout.sh", signed_smoke)
         self.assertIn("env -i", signed_smoke)
         self.assertIn("PATH=/usr/bin:/bin:/usr/sbin:/sbin", signed_smoke)
         self.assertIn('HOME="$HOME"', signed_smoke)
@@ -154,6 +299,7 @@ class ReleaseToolingTests(unittest.TestCase):
         self.assertIn("GH_TOKEN: ${{ github.token }}", reviewed_smoke)
         self.assertIn("reviewed_checksums_sha256", reviewed_smoke)
         self.assertIn("validate_embedded_mcp_helper_layout.sh", reviewed_smoke)
+        self.assertIn("validate_sparkle_helper_layout.sh", reviewed_smoke)
         self.assertIn("env -i", reviewed_smoke)
         promote_job = promote_workflow.split("\n  promote:", 1)[1]
         self.assertIn("- smoke-reviewed-helper", promote_job)
@@ -216,6 +362,44 @@ class ReleaseToolingTests(unittest.TestCase):
 
                 self.assertNotEqual(result.returncode, 0)
                 self.assertIn("unexpected or escaping staged symlink", result.stderr)
+
+    def test_staged_release_validator_rejects_invalid_sparkle_helper_layout(self) -> None:
+        cases = (
+            (
+                "missing Installer",
+                lambda app: (
+                    app
+                    / "Contents"
+                    / "Frameworks"
+                    / "Sparkle.framework"
+                    / "Versions"
+                    / "B"
+                    / "XPCServices"
+                    / "Installer.xpc"
+                    / "Contents"
+                    / "MacOS"
+                    / "Installer"
+                ).unlink(),
+                "missing Sparkle helper executable",
+            ),
+            (
+                "non-executable Autoupdate",
+                lambda app: (
+                    app / "Contents" / "Frameworks" / "Sparkle.framework" / "Versions" / "B" / "Autoupdate"
+                ).chmod(0o644),
+                "must be executable",
+            ),
+        )
+        for label, mutate, expected_message in cases:
+            with self.subTest(label=label):
+                approved, staged, scripts = self.make_staged_release_fixture()
+                app = staged / ".build" / "release" / "RepoPrompt.app"
+                mutate(app)
+
+                result = self.run_staged_validation(approved, staged, scripts)
+
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(expected_message, result.stderr)
 
     def test_runtime_bundle_verifier_is_removed_without_changing_sparkle_or_anti_debug_startup(self) -> None:
         app_delegate = (SCRIPT_DIR.parent / "Sources" / "RepoPrompt" / "App" / "AppDelegate.swift").read_text(
@@ -601,10 +785,70 @@ class ReleaseToolingTests(unittest.TestCase):
         (resources_bin / "repoprompt-mcp").symlink_to("../../MacOS/repoprompt-mcp")
         return app
 
+    def make_sparkle_helper_layout(self) -> Path:
+        temp_dir = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, temp_dir, True)
+        app = temp_dir / "RepoPrompt.app"
+        self.add_sparkle_helper_layout(app)
+        return app
+
+    @staticmethod
+    def add_sparkle_helper_layout(app: Path) -> None:
+        framework = app / "Contents" / "Frameworks" / "Sparkle.framework"
+        version_b = framework / "Versions" / "B"
+        for directory in (
+            version_b / "Headers",
+            version_b / "Modules",
+            version_b / "PrivateHeaders",
+            version_b / "Resources",
+            version_b / "Updater.app" / "Contents" / "MacOS",
+            version_b / "XPCServices" / "Installer.xpc" / "Contents" / "MacOS",
+            version_b / "XPCServices" / "Downloader.xpc" / "Contents" / "MacOS",
+        ):
+            directory.mkdir(parents=True, exist_ok=True)
+        for executable in (
+            version_b / "Autoupdate",
+            version_b / "Sparkle",
+            version_b / "Updater.app" / "Contents" / "MacOS" / "Updater",
+            version_b / "XPCServices" / "Installer.xpc" / "Contents" / "MacOS" / "Installer",
+            version_b / "XPCServices" / "Downloader.xpc" / "Contents" / "MacOS" / "Downloader",
+        ):
+            executable.write_text(f"{executable.name}\n", encoding="utf-8")
+            executable.chmod(0o755)
+        (framework / "Versions" / "Current").symlink_to("B")
+        for name in ("Autoupdate", "Headers", "Modules", "PrivateHeaders", "Resources", "Sparkle", "Updater.app", "XPCServices"):
+            (framework / name).symlink_to(f"Versions/Current/{name}")
+
     @staticmethod
     def run_layout_validation(app: Path) -> subprocess.CompletedProcess[str]:
         return subprocess.run(
             [str(SCRIPT_DIR / "validate_embedded_mcp_helper_layout.sh"), str(app), "Fixture helper layout"],
+            text=True,
+            capture_output=True,
+        )
+
+    @staticmethod
+    def run_sparkle_helper_validation(app: Path) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [str(SCRIPT_DIR / "validate_sparkle_helper_layout.sh"), str(app), "Fixture Sparkle helper layout"],
+            text=True,
+            capture_output=True,
+        )
+
+    @staticmethod
+    def write_plist(path: Path, value: dict[str, object]) -> Path:
+        path.write_bytes(plistlib.dumps(value))
+        return path
+
+    @staticmethod
+    def run_sparkle_validator(info_plist: Path, entitlements: list[Path]) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                "python3",
+                str(SCRIPT_DIR / "validate_sparkle_update_configuration.py"),
+                str(info_plist),
+                *[str(path) for path in entitlements],
+            ],
             text=True,
             capture_output=True,
         )
@@ -646,7 +890,9 @@ SIGNING_TEAM_ID=648A27MST5
         for name in (
             "load_release_metadata.sh",
             "validate_embedded_mcp_helper_layout.sh",
+            "validate_sparkle_helper_layout.sh",
             "validate_packaged_legal.sh",
+            "validate_sparkle_update_configuration.py",
             "validate_staged_release.sh",
         ):
             shutil.copy2(SCRIPT_DIR / name, scripts / name)
@@ -664,8 +910,11 @@ SIGNING_TEAM_ID=648A27MST5
             (root / "LICENSE").write_text("license\n", encoding="utf-8")
             (root / "THIRD_PARTY_NOTICES.md").write_text("notices\n", encoding="utf-8")
             (root / "ThirdPartyLicenses" / "fixture" / "LICENSE").write_text("fixture\n", encoding="utf-8")
-        template = (SCRIPT_DIR.parent / "AppBundle" / "Info.plist.template").read_text(encoding="utf-8")
+        app_bundle_source = SCRIPT_DIR.parent / "AppBundle"
+        template = (app_bundle_source / "Info.plist.template").read_text(encoding="utf-8")
         (approved / "AppBundle" / "Info.plist.template").write_text(template, encoding="utf-8")
+        for name in ("RepoPrompt.entitlements.template", "RepoPrompt.local-self-signed.entitlements.template"):
+            shutil.copy2(app_bundle_source / name, approved / "AppBundle" / name)
         for key, value in {
             "__APP_NAME__": "RepoPrompt",
             "__DISPLAY_NAME__": "RepoPrompt CE",
@@ -682,6 +931,7 @@ SIGNING_TEAM_ID=648A27MST5
         (app / "Contents" / "MacOS" / "repoprompt-mcp").chmod(0o755)
         (app / "Contents" / "Resources" / "repoprompt-mcp").symlink_to("../MacOS/repoprompt-mcp")
         (app / "Contents" / "Resources" / "bin" / "repoprompt-mcp").symlink_to("../../MacOS/repoprompt-mcp")
+        self.add_sparkle_helper_layout(app)
         legal = app / "Contents" / "Resources" / "Legal"
         shutil.copy2(staged / "LICENSE", legal / "LICENSE")
         shutil.copy2(staged / "THIRD_PARTY_NOTICES.md", legal / "THIRD_PARTY_NOTICES.md")

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -62,7 +62,14 @@ class ReleaseToolingTests(unittest.TestCase):
                 {"SUEnableInstallerLauncherService": True},
                 [non_sandboxed],
                 1,
-                "non-sandboxed apps must not enable SUEnableInstallerLauncherService",
+                "non-sandboxed apps must not enable Sparkle sandbox services",
+            ),
+            (
+                "non-sandboxed downloader true",
+                {"SUEnableDownloaderService": True},
+                [non_sandboxed],
+                1,
+                "non-sandboxed apps must not enable Sparkle sandbox services",
             ),
             (
                 "sandboxed missing launcher",
@@ -149,6 +156,8 @@ class ReleaseToolingTests(unittest.TestCase):
         self.assertIn('require_file "$CONTROL_PLANE_SCRIPTS_DIR/validate_sparkle_update_configuration.py"', release_script)
         self.assertIn('python3 "$CONTROL_PLANE_SCRIPTS_DIR/validate_sparkle_update_configuration.py"', release_script)
         self.assertIn('python3 "$CONTROL_PLANE_SCRIPTS_DIR/validate_sparkle_update_configuration.py"', package_script)
+        self.assertIn('python3 "$CONTROL_PLANE_SCRIPTS_DIR/validate_sparkle_update_configuration.py"', promote_script)
+        self.assertIn('python3 "$ROOT_DIR/Scripts/validate_sparkle_update_configuration.py"', public_update_script)
         self.assertIn('python3 "$SCRIPT_DIR/validate_sparkle_update_configuration.py"', staged_signing_script)
         staged_validator = (SCRIPT_DIR / "validate_staged_release.sh").read_text(encoding="utf-8")
         self.assertIn('python3 "$SCRIPT_DIR/validate_sparkle_update_configuration.py"', staged_validator)

--- a/Scripts/validate_sparkle_helper_layout.sh
+++ b/Scripts/validate_sparkle_helper_layout.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_BUNDLE="${1:-}"
+LAYOUT_LABEL="${2:-Sparkle helper layout}"
+
+fail() {
+    printf 'ERROR: %s\n' "$*" >&2
+    exit 1
+}
+
+[[ -n "$APP_BUNDLE" ]] || fail "Usage: $0 <app-bundle> [label]"
+
+python3 - "$APP_BUNDLE" "$LAYOUT_LABEL" <<'PYTHON'
+import os
+import stat
+import sys
+from pathlib import Path
+
+app = Path(sys.argv[1])
+label = sys.argv[2]
+framework = app / "Contents" / "Frameworks" / "Sparkle.framework"
+versions = framework / "Versions"
+version_b = versions / "B"
+expected_symlinks = {
+    framework / "Autoupdate": "Versions/Current/Autoupdate",
+    framework / "Headers": "Versions/Current/Headers",
+    framework / "Modules": "Versions/Current/Modules",
+    framework / "PrivateHeaders": "Versions/Current/PrivateHeaders",
+    framework / "Resources": "Versions/Current/Resources",
+    framework / "Sparkle": "Versions/Current/Sparkle",
+    framework / "Updater.app": "Versions/Current/Updater.app",
+    framework / "XPCServices": "Versions/Current/XPCServices",
+    versions / "Current": "B",
+}
+helper_executables = [
+    version_b / "Autoupdate",
+    version_b / "Updater.app" / "Contents" / "MacOS" / "Updater",
+    version_b / "XPCServices" / "Installer.xpc" / "Contents" / "MacOS" / "Installer",
+    version_b / "XPCServices" / "Downloader.xpc" / "Contents" / "MacOS" / "Downloader",
+]
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"ERROR: {message}")
+
+
+def require_real_directory(path: Path) -> None:
+    try:
+        mode = path.lstat().st_mode
+    except FileNotFoundError:
+        fail(f"missing Sparkle directory: {path}")
+    if not stat.S_ISDIR(mode):
+        fail(f"Sparkle path must be a real directory: {path}")
+
+
+def require_symlink(path: Path, expected_target: str) -> None:
+    try:
+        mode = path.lstat().st_mode
+    except FileNotFoundError:
+        fail(f"missing Sparkle framework symlink: {path}")
+    if not stat.S_ISLNK(mode):
+        fail(f"Sparkle framework path must be a symlink: {path}")
+    actual_target = os.readlink(path)
+    if actual_target != expected_target:
+        fail(f"Sparkle framework symlink target mismatch: {path} -> {actual_target}; expected {expected_target}")
+    try:
+        resolved = path.resolve(strict=True)
+    except FileNotFoundError:
+        fail(f"broken Sparkle framework symlink: {path} -> {actual_target}")
+    if not resolved.is_relative_to(framework.resolve(strict=True)):
+        fail(f"escaping Sparkle framework symlink: {path} -> {actual_target}")
+
+
+def require_regular_executable(path: Path) -> None:
+    try:
+        mode = path.lstat().st_mode
+    except FileNotFoundError:
+        fail(f"missing Sparkle helper executable: {path}")
+    if not stat.S_ISREG(mode):
+        fail(f"Sparkle helper executable must be a non-symlink regular file: {path}")
+    if not mode & 0o111:
+        fail(f"Sparkle helper executable must be executable: {path}")
+
+
+for path in (framework, versions, version_b):
+    require_real_directory(path)
+
+for path, expected_target in expected_symlinks.items():
+    require_symlink(path, expected_target)
+
+framework_root = framework.resolve(strict=True)
+for path in framework.rglob("*"):
+    mode = path.lstat().st_mode
+    if stat.S_ISLNK(mode):
+        target = os.readlink(path)
+        try:
+            resolved = path.resolve(strict=True)
+        except FileNotFoundError:
+            fail(f"broken Sparkle framework symlink: {path} -> {target}")
+        if not resolved.is_relative_to(framework_root):
+            fail(f"escaping Sparkle framework symlink: {path} -> {target}")
+
+for path in helper_executables:
+    require_regular_executable(path)
+
+print(f"OK: {label} matches the Sparkle helper layout policy.")
+PYTHON

--- a/Scripts/validate_sparkle_update_configuration.py
+++ b/Scripts/validate_sparkle_update_configuration.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Validate Sparkle updater plist semantics against app sandbox entitlements."""
+
+from __future__ import annotations
+
+import argparse
+import plistlib
+import sys
+from pathlib import Path
+from typing import Any
+
+SANDBOX_ENTITLEMENT_KEY = "com.apple.security.app-sandbox"
+SPARKLE_SANDBOX_SERVICE_KEYS = ("SUEnableInstallerLauncherService",)
+
+
+def fail(message: str) -> None:
+    print(f"ERROR: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def load_plist(path: Path) -> dict[str, Any]:
+    try:
+        value = plistlib.loads(path.read_bytes())
+    except FileNotFoundError:
+        fail(f"missing plist: {path}")
+    except plistlib.InvalidFileException as error:
+        fail(f"invalid plist {path}: {error}")
+    except OSError as error:
+        fail(f"could not read plist {path}: {error}")
+
+    if not isinstance(value, dict):
+        fail(f"plist root must be a dictionary: {path}")
+    return value
+
+
+def require_optional_bool(plist: dict[str, Any], key: str, path: Path) -> bool | None:
+    if key not in plist:
+        return None
+    value = plist[key]
+    if type(value) is not bool:
+        fail(f"{path}: {key} must be a Boolean when present, got {type(value).__name__}")
+    return value
+
+
+def validate(info_plist_path: Path, entitlement_paths: list[Path]) -> None:
+    info_plist = load_plist(info_plist_path)
+    for key in SPARKLE_SANDBOX_SERVICE_KEYS:
+        require_optional_bool(info_plist, key, info_plist_path)
+
+    sandbox_states: list[tuple[Path, bool]] = []
+    for entitlement_path in entitlement_paths:
+        entitlements = load_plist(entitlement_path)
+        sandbox_value = require_optional_bool(entitlements, SANDBOX_ENTITLEMENT_KEY, entitlement_path)
+        sandbox_states.append((entitlement_path, sandbox_value is True))
+
+    derived_states = {state for _, state in sandbox_states}
+    if len(derived_states) != 1:
+        details = ", ".join(f"{path}={'sandboxed' if state else 'non-sandboxed'}" for path, state in sandbox_states)
+        fail(f"entitlement profiles disagree on sandbox state: {details}")
+
+    is_sandboxed = next(iter(derived_states))
+    installer_launcher_enabled = info_plist.get("SUEnableInstallerLauncherService") is True
+
+    if is_sandboxed and not installer_launcher_enabled:
+        fail("sandboxed apps must set SUEnableInstallerLauncherService to true for Sparkle installer-launcher support")
+    if not is_sandboxed and installer_launcher_enabled:
+        fail("non-sandboxed apps must not enable SUEnableInstallerLauncherService")
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate Sparkle updater configuration against sandbox entitlements."
+    )
+    parser.add_argument("info_plist", type=Path, help="Info.plist or Info.plist template to validate")
+    parser.add_argument(
+        "entitlements",
+        nargs="+",
+        type=Path,
+        help="One or more entitlement plist/template files that must agree on sandbox state",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    validate(args.info_plist, args.entitlements)
+    print("OK: Sparkle update configuration is compatible with entitlement sandbox state.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/Scripts/validate_sparkle_update_configuration.py
+++ b/Scripts/validate_sparkle_update_configuration.py
@@ -10,7 +10,12 @@ from pathlib import Path
 from typing import Any
 
 SANDBOX_ENTITLEMENT_KEY = "com.apple.security.app-sandbox"
-SPARKLE_SANDBOX_SERVICE_KEYS = ("SUEnableInstallerLauncherService",)
+SPARKLE_SANDBOX_SERVICE_KEYS = (
+    "SUEnableInstallerLauncherService",
+    "SUEnableDownloaderService",
+    "SUEnableInstallerConnectionService",
+    "SUEnableInstallerStatusService",
+)
 
 
 def fail(message: str) -> None:
@@ -59,12 +64,18 @@ def validate(info_plist_path: Path, entitlement_paths: list[Path]) -> None:
         fail(f"entitlement profiles disagree on sandbox state: {details}")
 
     is_sandboxed = next(iter(derived_states))
+    enabled_sandbox_services = [
+        key for key in SPARKLE_SANDBOX_SERVICE_KEYS if info_plist.get(key) is True
+    ]
     installer_launcher_enabled = info_plist.get("SUEnableInstallerLauncherService") is True
 
     if is_sandboxed and not installer_launcher_enabled:
         fail("sandboxed apps must set SUEnableInstallerLauncherService to true for Sparkle installer-launcher support")
-    if not is_sandboxed and installer_launcher_enabled:
-        fail("non-sandboxed apps must not enable SUEnableInstallerLauncherService")
+    if not is_sandboxed and enabled_sandbox_services:
+        fail(
+            "non-sandboxed apps must not enable Sparkle sandbox services: "
+            + ", ".join(enabled_sandbox_services)
+        )
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:

--- a/Scripts/validate_staged_release.sh
+++ b/Scripts/validate_staged_release.sh
@@ -102,6 +102,7 @@ for path in root.rglob("*"):
 PYTHON
 
 "$SCRIPT_DIR/validate_embedded_mcp_helper_layout.sh" "$APP_BUNDLE" "Staged app MCP helper layout"
+"$SCRIPT_DIR/validate_sparkle_helper_layout.sh" "$APP_BUNDLE" "Staged app Sparkle helper layout"
 
 [[ "$(cat "$ROOT_DIR/RELEASE_COMMIT")" == "$RELEASE_COMMIT" ]] ||
     fail "Staged release commit does not match approved commit"
@@ -135,5 +136,10 @@ for key, value in {
 if plistlib.loads(text.encode("utf-8")) != plistlib.loads(Path(actual).read_bytes()):
     raise SystemExit("ERROR: staged Info.plist does not match the approved release candidate")
 PYTHON
+
+python3 "$SCRIPT_DIR/validate_sparkle_update_configuration.py" \
+    "$APP_BUNDLE/Contents/Info.plist" \
+    "$APPROVED_SOURCE_ROOT/AppBundle/RepoPrompt.entitlements.template" \
+    "$APPROVED_SOURCE_ROOT/AppBundle/RepoPrompt.local-self-signed.entitlements.template"
 
 printf 'OK: staged release payload matches approved source and confined path policy.\n'

--- a/docs/open-source-readiness.md
+++ b/docs/open-source-readiness.md
@@ -1,6 +1,6 @@
 # Open-Source and Release Readiness Notes
 
-Current as of 2026-06-01. This is a contributor/maintainer inventory for RepoPrompt CE's public-readiness work. It documents the current state and follow-ups; it is not legal advice or a substitute for legal review.
+Current as of 2026-06-02. This is a contributor/maintainer inventory for RepoPrompt CE's public-readiness work. It documents the current state and follow-ups; it is not legal advice or a substitute for legal review.
 
 ## Release metadata and signing
 
@@ -41,6 +41,25 @@ repository. This keeps the appcast and signed updater ZIP anonymously
 downloadable while the source repository remains private during validation.
 The organization currently disables GitHub Pages creation, so the feed uses
 public GitHub Release assets in that repository rather than Pages.
+
+Release validation semantically couples Sparkle installer-launcher configuration
+to the app's entitlement sandbox state. RepoPrompt CE is currently
+non-sandboxed, so `SUEnableInstallerLauncherService` and other Sparkle
+sandbox-service keys must remain absent or `false` unless maintainers migrate
+the app to sandboxed entitlements in the same release configuration change. A
+future sandbox migration should update the Info.plist template and all release
+entitlement profiles together so static validation can prove the update channel
+configuration is coherent.
+
+Known update-channel limitation: v1.0.0 shipped with
+`SUEnableInstallerLauncherService=true` even though the CE app was
+non-sandboxed. An installed v1.0.0 app may detect v1.0.2 or later but fail while
+connecting to Sparkle's installer. Because the already-running v1.0.0 updater
+configuration controls that attempted self-update, later source fixes cannot
+repair v1.0.0 before replacement; manual installation of the latest release is
+the official workaround. Continue to verify future candidates with static
+release validation and, when available, a dedicated self-update smoke from a
+known-good previous release.
 
 ## Dependency pins
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -197,6 +197,15 @@ The current app enables Sparkle's required update-archive verification through
 `SURequireSignedFeed` mode, so do not describe the XML feed itself as
 cryptographically required.
 
+Release validation must also preserve the semantic relationship between Sparkle
+installer-launcher settings and the app's sandbox state. The CE app is currently
+non-sandboxed, so Sparkle sandbox-service keys such as
+`SUEnableInstallerLauncherService` must remain absent or `false`. Release
+preflight, release package rendering, staged artifact validation, and trusted
+signing validation are expected to reject an incompatible Sparkle
+installer-launcher/sandbox-entitlement combination before a public update is
+promoted.
+
 ## GitHub-hosted Sparkle feed
 
 The appcast URL committed in the app is:
@@ -248,6 +257,21 @@ The helper reads the CE Sparkle private key from the local Sparkle Keychain
 account `repoprompt-ce`. It refuses to overwrite an existing public test tag
 and publishes that tag with `--latest=false`, so a private-source smoke run
 cannot replace the stable feed selected by `latest/download/appcast.xml`.
+
+### Follow-up: self-update smoke
+
+The current release checks validate static configuration, generated assets,
+appcast metadata, signatures, notarization, packaged legal files, and embedded
+helper layout. They do not install a previous public app and drive Sparkle
+through an actual app replacement to the candidate build.
+
+Before treating a release as fully exercised through the update channel,
+maintainers should run or plan a disposable macOS GUI-machine smoke that installs
+the previous public release, points it at the candidate/public test feed, accepts
+the Sparkle update, and confirms the replacement app launches. This heavier E2E
+lane may require signed and notarized artifacts, a writable installation
+location, a GUI session, and controlled public or private appcast hosting; do not
+block the static release gates on that future automation.
 
 ## Promote and verify
 
@@ -326,6 +350,20 @@ when the existing updater assets match the reviewed source assets exactly. For
 a public regression, withdraw the bad release if policy allows it and publish a
 new hotfix tag with a higher `BUILD_NUMBER`; explicitly promote the hotfix as
 latest.
+
+### v1.0.0 updater caveat
+
+RepoPrompt CE v1.0.0 may detect v1.0.2 or later but fail the in-app install with
+an installer-connection error. Because v1.0.0's running Sparkle configuration
+controls that attempted self-update, a fixed v1.0.2+ release cannot repair the
+already-running v1.0.0 installer path before installation. The official recovery
+path for affected users is to manually download and install the latest release;
+normal updates should resume after that replacement.
+
+Do not treat repeated in-app retries from an installed v1.0.0 app as a release
+candidate validation signal. Validate new candidates with the static release
+checks above and, when available, a self-update smoke from a known-good previous
+release.
 
 ## References
 


### PR DESCRIPTION
## Summary
- Add semantic Sparkle update configuration validation for installer-launcher settings vs sandbox entitlements
- Add Sparkle helper layout/executable validation across release packaging and promotion paths
- Document the v1.0.0 manual-install workaround and self-update limitation

Fixes https://github.com/repoprompt/repoprompt-ce/issues/42

## Validation
- `make guardrails`
- `make dev-lint`
- `make release-selftest`
- `./Scripts/release.sh preflight`
- `ALLOW_ADHOC_SIGNING=1 make dev-build`

## Live update verification

### Baseline failure
- Manually tested stock RepoPrompt CE v1.0.0 to verify that the in-app update path was actually broken.
- Stock v1.0.0 detected the public update, but the Sparkle install attempt failed with the installer-connection error instead of installing the update.

### Patched v1.0.0 test build
- Created a separate `v1.0.0` worktree.
- Applied the minimal historical-update-path fixes to that test build:
  - removed `SUEnableInstallerLauncherService` from `AppBundle/Info.plist.template`
  - restored Sparkle `Updater.app` into the embedded Sparkle framework payload
- Built the patched v1.0.0 test app with explicit ad-hoc signing.
- Confirmed the packaged app reported version/build `1.0.0` / `1`.
- Confirmed `SUEnableInstallerLauncherService` was absent from the packaged app `Info.plist`.
- Confirmed Sparkle helper executables were present/executable for `Autoupdate`, `Downloader.xpc`, `Installer.xpc`, and `Updater.app`.
- Re-signed the patched test app and verified codesign successfully.

### End-to-end update result
- With approval, backed up the existing `/Applications/RepoPrompt.app` and installed the patched v1.0.0 test app to `/Applications/RepoPrompt.app`.
- Launched the patched v1.0.0 app and selected **Check for Updates…** from the app menu.
- Sparkle detected the public latest update as RepoPrompt CE 1.0.3 build 4.
- Clicked **Install Update**.
- The patched app reached Sparkle's **Ready to Install** / **Install and Relaunch** state instead of the installer-connection error.
- Clicked **Install and Relaunch**.
- The app relaunched successfully as RepoPrompt CE 1.0.3 build 4.

This confirms the suspected v1.0.0 updater-path failure is addressed when the installer-launcher configuration is removed and the Sparkle helper payload is complete. Existing v1.0.0 installations still cannot be repaired retroactively before installation, so the user-facing manual-install workaround remains necessary.
