### PR TITLE
Improve native Web Search tool cards

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Transcript/AgentToolCardRenderSummary.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Transcript/AgentToolCardRenderSummary.swift
@@ -187,6 +187,7 @@ struct AgentToolCardRenderSummary: Codable, Equatable {
         switch toolName {
         case "git": "Git"
         case "file_search": "Search"
+        case "search": "Web Search"
         case "manage_selection": "Selection"
         case "read_file": "Read File"
         case "workspace_context": "Context"
@@ -213,6 +214,9 @@ enum AgentToolCardRenderSummaryBuilder {
     private static let safeGitDiffOnelinerRegex = try! NSRegularExpression(
         pattern: #"^(?:[0-9]+ repos?: )?[0-9]+ files? \(\+[0-9]+ -[0-9]+\)$"#
     )
+    private static let safeNativeToolNameRegex = try! NSRegularExpression(
+        pattern: #"^[a-z][a-z0-9_]{1,48}$"#
+    )
 
     static func build(
         normalizedToolName: String?,
@@ -230,6 +234,8 @@ enum AgentToolCardRenderSummaryBuilder {
             return readFileSummary(statusWord: statusWord, rawObject: rawObject, argsObject: argsObject)
         case "file_search":
             return fileSearchSummary(statusWord: statusWord, rawObject: rawObject, argsObject: argsObject)
+        case "search":
+            return webSearchSummary(statusWord: statusWord, rawObject: rawObject, argsObject: argsObject)
         case "manage_selection":
             return manageSelectionSummary(statusWord: statusWord, rawObject: rawObject, argsObject: argsObject)
         case "workspace_context":
@@ -241,7 +247,7 @@ enum AgentToolCardRenderSummaryBuilder {
         case "git":
             return gitSummary(statusWord: statusWord, rawObject: rawObject, argsObject: argsObject)
         default:
-            return nil
+            return safeNativeToolSummary(normalizedToolName: normalizedToolName, statusWord: statusWord, rawObject: rawObject, argsObject: argsObject)
         }
     }
 
@@ -290,6 +296,14 @@ enum AgentToolCardRenderSummaryBuilder {
         guard let object else { return nil }
         for key in keys {
             if let value = object[key] as? [Any] { return value }
+        }
+        return nil
+    }
+
+    static func objectValue(_ object: [String: Any]?, keys: [String]) -> [String: Any]? {
+        guard let object else { return nil }
+        for key in keys {
+            if let value = object[key] as? [String: Any] { return value }
         }
         return nil
     }
@@ -354,6 +368,68 @@ enum AgentToolCardRenderSummaryBuilder {
             detailText: nil,
             status: renderStatus,
             op: "file_search"
+        )
+    }
+
+    private static func webSearchSummary(statusWord: String, rawObject: [String: Any]?, argsObject: [String: Any]?) -> AgentToolCardRenderSummary? {
+        guard rawObject != nil || argsObject != nil else { return nil }
+        let query = trimmed(stringValue(argsObject, keys: ["query", "q", "search_query", "searchQuery", "text", "value"]))
+            ?? trimmed(stringValue(rawObject, keys: ["query", "q", "search_query", "searchQuery", "text", "value"]))
+        let resultCount = firstSearchResultCount(rawObject)
+        let sourceCount = firstSearchSourceCount(rawObject)
+        let errorDetail = webSearchErrorDetail(rawObject)
+        let countSummary: String? = {
+            var parts: [String] = []
+            if let resultCount { parts.append("\(resultCount) result\(resultCount == 1 ? "" : "s")") }
+            if let sourceCount { parts.append("\(sourceCount) source\(sourceCount == 1 ? "" : "s")") }
+            return parts.isEmpty ? nil : parts.joined(separator: " • ")
+        }()
+        let subtitle = [query.map { "\"\($0)\"" }, countSummary]
+            .compactMap(\.self)
+            .joined(separator: " • ")
+        let baseStatus = status(from: stringValue(rawObject, keys: ["status", "state", "outcome"]) ?? statusWord, defaultStatus: .neutral)
+        let resultDetail = webSearchDetailText(rawObject)
+        let renderStatus: AgentToolCardRenderStatus = {
+            if errorDetail != nil, baseStatus != .success { return .failure }
+            if baseStatus == .failure || baseStatus == .warning || baseStatus == .running { return baseStatus }
+            if (resultCount ?? 0) > 0 || (sourceCount ?? 0) > 0 { return .success }
+            if resultDetail != nil { return .success }
+            return baseStatus
+        }()
+        let detailText = baseStatus == .success ? (resultDetail ?? errorDetail) : (errorDetail ?? resultDetail)
+        return AgentToolCardRenderSummary(
+            toolName: "search",
+            title: "Web Search",
+            subtitle: subtitle.isEmpty ? nil : subtitle,
+            detailText: detailText,
+            status: renderStatus,
+            op: "search"
+        )
+    }
+
+    private static func safeNativeToolSummary(
+        normalizedToolName: String,
+        statusWord: String,
+        rawObject: [String: Any]?,
+        argsObject: [String: Any]?
+    ) -> AgentToolCardRenderSummary? {
+        guard isSafeNativeToolName(normalizedToolName), rawObject != nil || argsObject != nil else { return nil }
+        let subtitle = nativeScalarSummary(
+            object: argsObject,
+            preferredKeys: ["query", "q", "prompt", "text", "value", "name", "id", "operation", "op"]
+        )
+        let detailText = nativeScalarSummary(
+            object: rawObject,
+            preferredKeys: ["summary", "answer", "message", "text", "title", "status", "state", "outcome"]
+        )
+        guard subtitle != nil || detailText != nil else { return nil }
+        return AgentToolCardRenderSummary(
+            toolName: normalizedToolName,
+            title: nativeToolTitle(from: normalizedToolName),
+            subtitle: subtitle,
+            detailText: detailText,
+            status: status(from: stringValue(rawObject, keys: ["status", "state", "outcome"]) ?? statusWord, defaultStatus: .neutral),
+            op: normalizedToolName
         )
     }
 
@@ -567,6 +643,171 @@ enum AgentToolCardRenderSummaryBuilder {
             status: renderStatus,
             op: op.lowercased()
         )
+    }
+
+    private static func webSearchDetailText(_ object: [String: Any]?) -> String? {
+        if let direct = trimmed(stringValue(object, keys: ["summary", "answer", "snippet", "message", "text"])) {
+            return safeCollapsedText(direct)
+        }
+        for arrayKey in ["results", "items", "web_results", "webResults", "search_results", "searchResults"] {
+            guard let first = arrayValue(object, keys: [arrayKey])?.first else { continue }
+            if let text = webSearchDetailText(fromResult: first) { return text }
+        }
+        if let nested = objectValue(object, keys: ["result", "output", "response", "content", "data", "payload"]),
+           let text = webSearchDetailText(nested)
+        {
+            return text
+        }
+        for arrayKey in ["sources", "citations"] {
+            guard let first = arrayValue(object, keys: [arrayKey])?.first else { continue }
+            if let text = webSearchDetailText(fromResult: first) { return text }
+        }
+        return nil
+    }
+
+    private static func webSearchDetailText(fromResult value: Any) -> String? {
+        if let text = value as? String { return safeCollapsedText(text) }
+        guard let object = value as? [String: Any] else { return nil }
+        let title = safeCollapsedText(stringValue(object, keys: ["title", "name", "source", "url"]))
+        let snippet = safeCollapsedText(stringValue(object, keys: ["snippet", "summary", "text", "description", "content"]))
+        return join(title, snippet)
+    }
+
+    private static func webSearchErrorDetail(_ object: [String: Any]?) -> String? {
+        guard let object else { return nil }
+        if let error = object["error"] as? String { return safeCollapsedText(error) }
+        if let errorMessage = trimmed(stringValue(object, keys: ["error_message", "errorMessage"])) {
+            return safeCollapsedText(errorMessage)
+        }
+        if let error = object["error"] as? [String: Any] {
+            return safeCollapsedText(stringValue(error, keys: ["message", "detail", "description", "code"]))
+        }
+        if let errors = object["errors"] as? [Any], let first = errors.first {
+            if let text = first as? String { return safeCollapsedText(text) }
+            if let error = first as? [String: Any] {
+                return safeCollapsedText(stringValue(error, keys: ["message", "detail", "description", "code"]))
+            }
+        }
+        return nil
+    }
+
+    private static func firstSearchResultCount(_ object: [String: Any]?) -> Int? {
+        firstArrayCount(object, keys: ["results", "items", "web_results", "webResults", "search_results", "searchResults"])
+            ?? intValue(object, keys: ["result_count", "resultCount", "total_results", "totalResults", "count"])
+            ?? firstNestedSearchResultCount(object)
+    }
+
+    private static func firstNestedSearchResultCount(_ object: [String: Any]?) -> Int? {
+        for key in ["result", "output", "response", "content", "data", "payload"] {
+            guard let nested = objectValue(object, keys: [key]) else { continue }
+            if let count = firstSearchResultCount(nested) { return count }
+        }
+        return nil
+    }
+
+    private static func firstSearchSourceCount(_ object: [String: Any]?) -> Int? {
+        firstArrayCount(object, keys: ["sources", "citations"])
+            ?? intValue(object, keys: [
+                "source_count", "sourceCount", "total_sources", "totalSources",
+                "citation_count", "citationCount", "total_citations", "totalCitations"
+            ])
+            ?? firstNestedSearchSourceCount(object)
+    }
+
+    private static func firstNestedSearchSourceCount(_ object: [String: Any]?) -> Int? {
+        for key in ["result", "output", "response", "content", "data", "payload"] {
+            guard let nested = objectValue(object, keys: [key]) else { continue }
+            if let count = firstSearchSourceCount(nested) { return count }
+        }
+        return nil
+    }
+
+    private static func firstArrayCount(_ object: [String: Any]?, keys: [String]) -> Int? {
+        for key in keys {
+            if let count = arrayValue(object, keys: [key])?.count { return count }
+        }
+        return nil
+    }
+
+    private static func safeCollapsedText(_ value: String?) -> String? {
+        guard let value = trimmed(value) else { return nil }
+        guard !value.contains("\n"), !value.contains("\r") else {
+            let oneline = value
+                .components(separatedBy: .newlines)
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }
+                .joined(separator: " ")
+            return smallSummaryString(oneline)
+        }
+        let lowered = value.lowercased()
+        guard !(value.hasPrefix("{") || value.hasPrefix("[")),
+              !lowered.contains("\"results\""),
+              !lowered.contains("\"content\"")
+        else { return nil }
+        return smallSummaryString(value)
+    }
+
+    private static func smallSummaryString(_ value: String?) -> String? {
+        guard let value = trimmed(value) else { return nil }
+        if value.count <= 240 { return value }
+        let prefix = value.prefix(237).trimmingCharacters(in: .whitespacesAndNewlines)
+        return prefix.isEmpty ? nil : prefix + "…"
+    }
+
+    private static func nativeScalarSummary(object: [String: Any]?, preferredKeys: [String]) -> String? {
+        guard let object else { return nil }
+        for key in preferredKeys {
+            if let value = safeNativeScalar(object[key]) { return value }
+        }
+        return nil
+    }
+
+    private static func safeNativeScalar(_ value: Any?) -> String? {
+        switch value {
+        case let string as String:
+            safeCollapsedText(string)
+        case let number as NSNumber:
+            number.stringValue
+        default:
+            nil
+        }
+    }
+
+    static func isSafeNativeFallbackToolName(_ name: String?) -> Bool {
+        guard let name else { return false }
+        return isSafeNativeToolName(name)
+    }
+
+    private static func isSafeNativeToolName(_ name: String) -> Bool {
+        let normalized = name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard normalized == name,
+              normalized != "tool",
+              normalized != "other",
+              !normalized.hasPrefix("mcp__"),
+              !normalized.contains("."),
+              !normalized.contains("/")
+        else { return false }
+        switch normalized {
+        case "read", "read_file", "file_search", "grep", "bash", "shell", "apply_edits", "apply_patch", "edit",
+             "get_file_tree", "get_code_structure", "file_actions", "manage_selection", "workspace_context", "prompt",
+             "ask_oracle", "oracle_send", "oracle_utils", "oracle_chat_log", "chat_send", "chats", "list_models",
+             "bind_context", "manage_workspaces", "git", "manage_worktree", "context_builder", "request_user_input",
+             "ask_user", "ask_user_question", "agent_explore", "agent_run", "agent_manage", "app_settings":
+            return false
+        default:
+            break
+        }
+        let range = NSRange(normalized.startIndex ..< normalized.endIndex, in: normalized)
+        return safeNativeToolNameRegex.firstMatch(in: normalized, range: range) != nil
+    }
+
+    private static func nativeToolTitle(from name: String) -> String {
+        name.split(separator: "_")
+            .map { part in
+                guard let first = part.first else { return "" }
+                return String(first).uppercased() + part.dropFirst().lowercased()
+            }
+            .joined(separator: " ")
     }
 
     private static func status(from rawStatus: String, defaultStatus: AgentToolCardRenderStatus) -> AgentToolCardRenderStatus {

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Transcript/AgentTranscriptToolVisibilityPolicy.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Transcript/AgentTranscriptToolVisibilityPolicy.swift
@@ -114,8 +114,10 @@ enum AgentTranscriptToolVisibilityPolicy {
             "read_file"
         case "read_file_tool", "read_file_contents":
             "read_file"
-        case "file_search", "filesearch", "grep", "search":
+        case "file_search", "filesearch", "grep":
             "file_search"
+        case "search", "web_search", "web_search_request", "google_web_search", "search_web":
+            "search"
         case "bash", "shell", "local_shell", "unified_exec", "exec", "exec_command", "run_shell_command", "command":
             "bash"
         case "filechange", "file_change":

--- a/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/ClusterToolCategory.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/ClusterToolCategory.swift
@@ -218,10 +218,10 @@ enum ClusterToolCategory {
     // MARK: - Tool categories
 
     private static let navigationTools: Set<String> = [
-        "get_file_tree", "read_file", "read", "file_search", "get_code_structure"
+        "get_file_tree", "read_file", "read", "file_search", "search", "get_code_structure"
     ]
     private static let summaryTitleNavigationTools: Set<String> = [
-        "get_file_tree", "read_file", "read", "file_search", "get_code_structure"
+        "get_file_tree", "read_file", "read", "file_search", "search", "get_code_structure"
     ]
     private static let editTools: Set<String> = [
         "apply_edits", "apply_patch", "edit", "file_actions"

--- a/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/ToolCardContainer.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/ToolCardContainer.swift
@@ -468,7 +468,7 @@ func toolIcon(for toolName: String?) -> String {
         return "doc.text"
     case "bash", "shell", "local_shell", "unified_exec", "exec_command", "run_shell_command":
         return "terminal"
-    case "search", "web_search", "web_search_request", "google_web_search":
+    case "search", "web_search", "web_search_request", "google_web_search", "search_web":
         return "globe"
     case "apply_edits", "mcp__RepoPrompt__apply_edits":
         return "pencil"
@@ -536,7 +536,7 @@ func toolDisplayName(for toolName: String?) -> String {
         return "Question"
     case "bash", "shell", "local_shell", "unified_exec", "exec_command", "run_shell_command":
         return "Bash"
-    case "search", "web_search", "web_search_request", "google_web_search":
+    case "search", "web_search", "web_search_request", "google_web_search", "search_web":
         return "Web Search"
     case "read", "Read":
         return "Read"

--- a/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/ToolCardRouter.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/ToolCardRouter.swift
@@ -123,6 +123,7 @@ enum ToolCardRouter {
         "apply_patch",
         "edit",
         "file_search",
+        "search",
         "get_file_tree",
         "get_code_structure",
         "file_actions",
@@ -190,6 +191,8 @@ enum ToolCardRouter {
             return AnyView(CursorNativeEditResultCard(item: item, isMostRecentEdit: isMostRecentEditBubble))
         case "file_search":
             return AnyView(FileSearchResultCard(item: item))
+        case "search":
+            return AnyView(WebSearchResultCard(item: item))
         case "get_file_tree":
             return AnyView(FileTreeResultCard(item: item))
         case "get_code_structure":
@@ -234,6 +237,9 @@ enum ToolCardRouter {
         case "app_settings":
             return AnyView(AppSettingsResultCard(item: item))
         default:
+            if NativeToolCardPresentationBuilder.build(item: item, normalizedToolName: key) != nil {
+                return AnyView(NativeToolResultCard(item: item, normalizedToolName: key))
+            }
             return AnyView(UnknownToolResultCard(item: item, title: toolDisplayName(for: normalized ?? item.toolName)))
         }
     }
@@ -448,7 +454,7 @@ private enum ToolCardSubtitleBuilder {
             {
                 return command
             }
-        case "search", "web_search", "web_search_request", "google_web_search":
+        case "search", "web_search", "web_search_request", "google_web_search", "search_web":
             if let query = stringArgument(from: argsJSON, keys: ["query", "q", "search_query", "searchQuery", "text", "value"]),
                !query.isEmpty
             {

--- a/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/ToolResultReadSearchCards.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/ToolResultReadSearchCards.swift
@@ -139,6 +139,110 @@ struct FileSearchResultCard: View {
     }
 }
 
+struct WebSearchResultCard: View {
+    let item: AgentChatItem
+    @State private var isExpanded = false
+
+    private var presentation: AgentToolCardRenderSummary? {
+        NativeToolCardPresentationBuilder.build(item: item, normalizedToolName: "search")
+    }
+
+    private var summary: String? {
+        presentation?.inlineSummaryText ?? storageStatusSubtitle(for: item)
+    }
+
+    private var status: ToolCardStatus {
+        if let presentation {
+            return ToolCardStatus.fromRenderStatus(presentation.status)
+        }
+        return ToolResultStatusResolver.resolve(toolIsError: item.toolIsError, raw: item.toolResultJSON, fallback: .neutral)
+    }
+
+    var body: some View {
+        ToolCardContainer(
+            iconName: toolIcon(for: "search"),
+            iconColor: ToolCardAccentResolver.color(for: "search"),
+            title: "Web Search",
+            subtitle: nonEmptyToolCardSummary(summary, fallbackStatusFor: item),
+            status: status,
+            timestamp: item.timestamp,
+            isExpandable: toolResultHasPayload(item),
+            isExpanded: $isExpanded
+        ) {
+            ToolMarkdownExpandedContent(item: item)
+        }
+    }
+}
+
+struct NativeToolResultCard: View {
+    let item: AgentChatItem
+    let normalizedToolName: String?
+    @State private var isExpanded = false
+
+    private var presentation: AgentToolCardRenderSummary? {
+        NativeToolCardPresentationBuilder.build(item: item, normalizedToolName: normalizedToolName)
+    }
+
+    var body: some View {
+        ToolCardContainer(
+            iconName: toolIcon(for: normalizedToolName ?? item.toolName),
+            iconColor: ToolCardAccentResolver.color(for: normalizedToolName ?? item.toolName),
+            title: presentation?.title ?? toolDisplayName(for: normalizedToolName ?? item.toolName),
+            subtitle: nonEmptyToolCardSummary(presentation?.inlineSummaryText, fallbackStatusFor: item),
+            status: presentation.map { ToolCardStatus.fromRenderStatus($0.status) }
+                ?? ToolResultStatusResolver.resolve(toolIsError: item.toolIsError, raw: item.toolResultJSON, fallback: .neutral),
+            timestamp: item.timestamp,
+            isExpandable: toolResultHasPayload(item),
+            isExpanded: $isExpanded
+        ) {
+            ToolMarkdownExpandedContent(item: item)
+        }
+    }
+}
+
+enum NativeToolCardPresentationBuilder {
+    static func build(item: AgentChatItem, normalizedToolName: String?) -> AgentToolCardRenderSummary? {
+        let normalizedToolName = normalizedToolName?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if let summaryObject = ToolRawJSON.object(from: item.toolResultJSON),
+           let renderSummary = AgentToolCardRenderSummary(summaryOnlyObject: summaryObject)
+        {
+            guard canTrustStoredSummary(renderSummary, normalizedToolName: normalizedToolName) else { return nil }
+            return renderSummary
+        }
+        let rawObject = ToolRawJSON.object(from: item.toolResultJSON)
+        let argsObject = ToolRawJSON.object(from: item.toolArgsJSON)
+        let statusWord = statusWord(for: item)
+        return AgentToolCardRenderSummaryBuilder.build(
+            normalizedToolName: normalizedToolName,
+            statusWord: statusWord,
+            rawObject: rawObject,
+            argsObject: argsObject,
+            allowExistingSummaryOnly: true
+        )
+    }
+
+    private static func canTrustStoredSummary(
+        _ renderSummary: AgentToolCardRenderSummary,
+        normalizedToolName: String?
+    ) -> Bool {
+        guard let normalizedToolName, renderSummary.toolName == normalizedToolName else { return false }
+        if normalizedToolName == "search" { return true }
+        return AgentToolCardRenderSummaryBuilder.isSafeNativeFallbackToolName(normalizedToolName)
+    }
+
+    private static func statusWord(for item: AgentChatItem) -> String {
+        if item.toolIsError == true { return "failed" }
+        if item.toolIsError == false { return "success" }
+        guard let object = ToolRawJSON.object(from: item.toolResultJSON) else { return "unknown" }
+        for key in ["status", "state", "outcome", "result"] {
+            if let value = ToolRawJSON.string(object, key: key)?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty {
+                return value
+            }
+        }
+        return "unknown"
+    }
+}
+
 struct FileActionResultCard: View {
     let item: AgentChatItem
     @State private var isExpanded = false

--- a/Sources/RepoPrompt/Features/Diagnostics/MCP/MCPConnectionManager+DebugDiagnostics.swift
+++ b/Sources/RepoPrompt/Features/Diagnostics/MCP/MCPConnectionManager+DebugDiagnostics.swift
@@ -116,9 +116,17 @@ import MCP
                     return debugDiagnosticsError(op: op, code: "unavailable", message: "`workspace_loading_snapshot` is only available in DEBUG builds.")
                 #endif
             case "mcp_read_search_capture_begin":
-                return debugMCPReadSearchCaptureBeginPayload(op: op, arguments: arguments)
+                #if DEBUG
+                    return debugMCPReadSearchCaptureBeginPayload(op: op, arguments: arguments)
+                #else
+                    return debugDiagnosticsError(op: op, code: "unavailable", message: "`mcp_read_search_capture_begin` is only available in DEBUG builds.")
+                #endif
             case "mcp_read_search_capture_snapshot":
-                return debugMCPReadSearchCaptureSnapshotPayload(op: op, arguments: arguments)
+                #if DEBUG
+                    return debugMCPReadSearchCaptureSnapshotPayload(op: op, arguments: arguments)
+                #else
+                    return debugDiagnosticsError(op: op, code: "unavailable", message: "`mcp_read_search_capture_snapshot` is only available in DEBUG builds.")
+                #endif
             case "bootstrap_diagnostics":
                 return await debugBootstrapDiagnosticsPayload(op: op)
             case "sparkle_status":

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexNativeSessionController.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexNativeSessionController.swift
@@ -4182,7 +4182,7 @@ final class CodexNativeSessionController {
                 "id", "itemId", "item_id", "callId", "call_id", "invocationId", "invocation_id", "toolCallId", "tool_call_id"
             ])
             let invocationID = invocationID(from: itemID)
-            let argsJSON = toolArgsJSON(from: candidate)
+            let argsJSON = toolArgsJSON(from: candidate, toolName: toolName)
 
             if isStarted {
                 let dedupKey = toolDedupKey(
@@ -4194,7 +4194,7 @@ final class CodexNativeSessionController {
                 return .call(name: toolName, invocationID: invocationID, argsJSON: argsJSON, dedupKey: dedupKey)
             }
 
-            let resultJSON = toolResultJSON(from: candidate)
+            let resultJSON = toolResultJSON(from: candidate, toolName: toolName)
             let isError = toolIsError(from: candidate)
             let isCommandLike = toolName == "bash"
                 || typeRaw.contains("command")
@@ -6176,11 +6176,14 @@ final class CodexNativeSessionController {
         return nil
     }
 
-    private func toolArgsJSON(from candidate: [String: Any]) -> String? {
+    private func toolArgsJSON(from candidate: [String: Any], toolName: String? = nil) -> String? {
         for key in ["arguments", "args", "input", "parameters", "params"] {
             if let value = candidate[key], let json = jsonString(from: value), !json.isEmpty {
                 return json
             }
+        }
+        if toolName == "search", let query = searchQueryValue(from: candidate), !query.isEmpty {
+            return jsonString(from: ["query": query])
         }
         if let command = stringValue(from: candidate, keys: ["command", "cmd"]), !command.isEmpty {
             var payload: [String: Any] = ["command": command]
@@ -6200,7 +6203,10 @@ final class CodexNativeSessionController {
         return nil
     }
 
-    private func toolResultJSON(from candidate: [String: Any]) -> String? {
+    private func toolResultJSON(from candidate: [String: Any], toolName: String? = nil) -> String? {
+        if toolName == "search", let searchJSON = webSearchToolResultJSON(from: candidate) {
+            return searchJSON
+        }
         for key in ["result", "output", "response", "content"] {
             if let value = candidate[key], let json = jsonString(from: value), !json.isEmpty {
                 return json
@@ -6213,6 +6219,112 @@ final class CodexNativeSessionController {
             return json
         }
         return nil
+    }
+
+    private func webSearchToolResultJSON(from candidate: [String: Any]) -> String? {
+        var object: [String: Any] = [:]
+        copySearchMetadata(from: candidate, into: &object)
+
+        for key in ["result", "output", "response", "content"] {
+            guard let value = candidate[key] else { continue }
+            if let array = value as? [Any] {
+                if !array.isEmpty { object[searchArrayKey(forWrapper: key)] = array }
+                copySearchPayloadFields(from: candidate, into: &object)
+                normalizeSearchContentArrays(in: &object)
+                return jsonString(from: object)
+            }
+            if let wrapped = value as? [String: Any] {
+                var merged = wrapped
+                copySearchMetadata(from: candidate, into: &merged)
+                copySearchPayloadFields(from: candidate, into: &merged)
+                normalizeSearchContentArrays(in: &merged)
+                return jsonString(from: merged)
+            }
+            if let text = value as? String, !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                object[searchTextKey(forWrapper: key)] = text
+                copySearchPayloadFields(from: candidate, into: &object)
+                return jsonString(from: object)
+            }
+            if let json = jsonString(from: value), !json.isEmpty {
+                object[searchTextKey(forWrapper: key)] = json
+                copySearchPayloadFields(from: candidate, into: &object)
+                return jsonString(from: object)
+            }
+        }
+
+        copySearchPayloadFields(from: candidate, into: &object)
+        normalizeSearchContentArrays(in: &object)
+        return object.isEmpty ? nil : jsonString(from: object)
+    }
+
+    private func copySearchMetadata(from candidate: [String: Any], into object: inout [String: Any]) {
+        for key in ["status", "query", "q", "searchQuery", "search_query", "isError", "is_error"] {
+            if object[key] == nil, let value = candidate[key] {
+                object[key] = value
+            }
+        }
+        if object["query"] == nil,
+           let query = searchQueryValue(from: candidate),
+           !query.isEmpty
+        {
+            object["query"] = query
+        }
+        if object["error"] == nil, let error = candidate["error"] {
+            object["error"] = error
+        }
+    }
+
+    private func searchQueryValue(from candidate: [String: Any]) -> String? {
+        if let query = stringValue(from: candidate, keys: ["query", "q", "searchQuery", "search_query", "search_text", "searchText"]),
+           !query.isEmpty
+        {
+            return query
+        }
+        for key in ["action", "search", "request", "parameters", "params"] {
+            guard let nested = candidate[key] as? [String: Any] else { continue }
+            if let query = searchQueryValue(from: nested), !query.isEmpty {
+                return query
+            }
+        }
+        return nil
+    }
+
+    private func copySearchPayloadFields(from candidate: [String: Any], into object: inout [String: Any]) {
+        for key in ["results", "items", "web_results", "webResults", "search_results", "searchResults", "sources", "citations", "result_count", "resultCount", "total_results", "totalResults", "count", "source_count", "sourceCount", "total_sources", "totalSources", "citation_count", "citationCount", "total_citations", "totalCitations", "summary", "answer", "snippet", "text", "message", "error", "errors", "error_message", "errorMessage"] {
+            guard object[key] == nil, let value = candidate[key] else { continue }
+            object[key] = value
+        }
+    }
+
+    private func normalizeSearchContentArrays(in object: inout [String: Any]) {
+        if object["results"] == nil, let content = object["content"] as? [Any], !content.isEmpty {
+            object["results"] = content
+            object.removeValue(forKey: "content")
+        }
+        if object["results"] == nil, let result = object["result"] as? [Any], !result.isEmpty {
+            object["results"] = result
+            object.removeValue(forKey: "result")
+        }
+    }
+
+    private func searchArrayKey(forWrapper key: String) -> String {
+        switch key {
+        case "content", "result", "output", "response":
+            "results"
+        default:
+            "results"
+        }
+    }
+
+    private func searchTextKey(forWrapper key: String) -> String {
+        switch key {
+        case "response":
+            "answer"
+        case "output", "content", "result":
+            "text"
+        default:
+            "text"
+        }
     }
 
     private func toolIsError(from candidate: [String: Any]) -> Bool? {
@@ -6254,10 +6366,45 @@ final class CodexNativeSessionController {
                 return false
             }
         }
+        if hasNonEmptyErrorSignal(in: candidate) {
+            Self.logCodexDebug("[CodexNativeController] toolIsError tool=\(debugToolName) decision=true reason=error-payload status=\(debugStatus)")
+            return true
+        }
         if typeRaw.contains("command") || debugToolName == "bash" || debugToolName == "exec_command" {
             Self.logCodexDebug("[CodexNativeController] toolIsError tool=\(debugToolName) decision=nil reason=insufficient-signals status=\(debugStatus)")
         }
         return nil
+    }
+
+    private func hasNonEmptyErrorSignal(in candidate: [String: Any]) -> Bool {
+        for key in ["error", "errors", "error_message", "errorMessage"] {
+            guard let value = candidate[key] else { continue }
+            if hasNonEmptyErrorValue(value) { return true }
+        }
+        return false
+    }
+
+    private func hasNonEmptyErrorValue(_ value: Any) -> Bool {
+        if let text = value as? String {
+            return !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+        if let array = value as? [Any] {
+            return array.contains { hasNonEmptyErrorValue($0) }
+        }
+        if let object = value as? [String: Any] {
+            if object.isEmpty { return false }
+            for key in ["message", "detail", "description", "code", "error", "error_message", "errorMessage"] {
+                guard let nested = object[key] else { continue }
+                if hasNonEmptyErrorValue(nested) { return true }
+            }
+            return object.values.contains { value in
+                if value is [String: Any] || value is [Any] {
+                    return hasNonEmptyErrorValue(value)
+                }
+                return false
+            }
+        }
+        return false
     }
 
     private func stringValue(from candidate: [String: Any], keys: [String]) -> String? {

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexNativeSessionControllerEventRecoveryTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexNativeSessionControllerEventRecoveryTests.swift
@@ -68,27 +68,6 @@ final class CodexNativeSessionControllerEventRecoveryTests: XCTestCase {
         XCTAssertEqual(resultObject["exitCode"] as? Int, 0)
     }
 
-    func testNativeWebSearchAliasesParseAsCanonicalSearchCalls() throws {
-        for alias in Self.webSearchAliases {
-            let controller = makeController()
-            let started = try XCTUnwrap(controller.test_parseToolLifecycleEvent(
-                method: "item/started",
-                params: toolParams(item: [
-                    "type": "toolCall",
-                    "id": "call_\(alias)",
-                    "name": alias,
-                    "query": "latest Swift concurrency"
-                ])
-            ), alias)
-
-            XCTAssertEqual(started.kind, "call", alias)
-            XCTAssertEqual(started.name, "search", alias)
-            XCTAssertNotNil(started.invocationID, alias)
-            let argsObject = try XCTUnwrap(jsonObject(from: started.argsJSON), alias)
-            XCTAssertEqual(argsObject["query"] as? String, "latest Swift concurrency", alias)
-        }
-    }
-
     func testNativeWebSearchAliasesPairStartedAndCompletedInvocations() throws {
         for alias in Self.webSearchAliases {
             let controller = makeController()
@@ -156,7 +135,9 @@ final class CodexNativeSessionControllerEventRecoveryTests: XCTestCase {
                         "items": [["title": "Result", "snippet": "Useful result"]]
                     ],
                     "sources": [["title": "Wrapped Source"]],
-                    "total_results": 3
+                    "total_results": 3,
+                    "source_count": 4,
+                    "citationCount": 2
                 ],
                 nil,
                 1,
@@ -197,34 +178,12 @@ final class CodexNativeSessionControllerEventRecoveryTests: XCTestCase {
                 XCTAssertEqual((resultObject["sources"] as? [[String: Any]])?.count, expectedSources, row.label)
             }
             XCTAssertNotNil(resultObject[row.expectedDetailKey], row.label)
+            if row.label == "wrapped response" {
+                XCTAssertEqual(resultObject["total_results"] as? Int, 3)
+                XCTAssertEqual(resultObject["source_count"] as? Int, 4)
+                XCTAssertEqual(resultObject["citationCount"] as? Int, 2)
+            }
         }
-    }
-
-    func testNativeWebSearchWrappedPayloadPreservesScalarSourceCitationCounts() throws {
-        let controller = makeController()
-        let completed = try XCTUnwrap(controller.test_parseToolLifecycleEvent(
-            method: "item/completed",
-            params: toolParams(item: [
-                "type": "toolCall",
-                "id": "call_search_wrapped_scalar_counts",
-                "name": "web_search",
-                "status": "completed",
-                "query": "wrapped scalar counts",
-                "response": [
-                    "items": [["title": "Wrapped", "snippet": "Usable result"]]
-                ],
-                "source_count": 4,
-                "citationCount": 2
-            ])
-        ))
-
-        XCTAssertEqual(completed.kind, "result")
-        XCTAssertEqual(completed.name, "search")
-        XCTAssertEqual(completed.isError, false)
-        let resultObject = try XCTUnwrap(jsonObject(from: completed.resultJSON))
-        XCTAssertEqual((resultObject["items"] as? [[String: Any]])?.count, 1)
-        XCTAssertEqual(resultObject["source_count"] as? Int, 4)
-        XCTAssertEqual(resultObject["citationCount"] as? Int, 2)
     }
 
     func testNativeWebSearchWrappedPayloadMergesSiblingSearchFieldsAndSuccessfulStatusWins() throws {
@@ -278,60 +237,6 @@ final class CodexNativeSessionControllerEventRecoveryTests: XCTestCase {
         let resultObject = try XCTUnwrap(jsonObject(from: completed.resultJSON))
         XCTAssertEqual(resultObject["query"] as? String, "transient web outage")
         XCTAssertEqual(resultObject["errorMessage"] as? String, "web search timed out")
-    }
-
-    func testNativeWebSearchNestedActionQueryParsesIntoArgsAndResults() throws {
-        let controller = makeController()
-        let started = try XCTUnwrap(controller.test_parseToolLifecycleEvent(
-            method: "item/started",
-            params: toolParams(item: [
-                "type": "web_search_call",
-                "id": "call_search_action",
-                "action": ["query": "nested action query"]
-            ])
-        ))
-
-        XCTAssertEqual(started.kind, "call")
-        XCTAssertEqual(started.name, "search")
-        let argsObject = try XCTUnwrap(jsonObject(from: started.argsJSON))
-        XCTAssertEqual(argsObject["query"] as? String, "nested action query")
-
-        let completed = try XCTUnwrap(controller.test_parseToolLifecycleEvent(
-            method: "item/completed",
-            params: toolParams(item: [
-                "type": "web_search_call",
-                "id": "call_search_action",
-                "status": "completed",
-                "action": ["query": "nested action query"],
-                "results": [["title": "Nested", "snippet": "Nested search result"]]
-            ])
-        ))
-        let resultObject = try XCTUnwrap(jsonObject(from: completed.resultJSON))
-        XCTAssertEqual(resultObject["query"] as? String, "nested action query")
-        XCTAssertEqual((resultObject["results"] as? [[String: Any]])?.count, 1)
-    }
-
-    func testNativeWebSearchErrorPayloadPreservesQueryAndFailureState() throws {
-        let controller = makeController()
-        let completed = try XCTUnwrap(controller.test_parseToolLifecycleEvent(
-            method: "item/completed",
-            params: toolParams(item: [
-                "type": "toolCall",
-                "id": "call_search_error",
-                "name": "search_web",
-                "status": "failed",
-                "query": "network outage",
-                "error": ["message": "web search unavailable"]
-            ])
-        ))
-
-        XCTAssertEqual(completed.kind, "result")
-        XCTAssertEqual(completed.name, "search")
-        XCTAssertEqual(completed.isError, true)
-        let resultObject = try XCTUnwrap(jsonObject(from: completed.resultJSON))
-        XCTAssertEqual(resultObject["query"] as? String, "network outage")
-        let error = try XCTUnwrap(resultObject["error"] as? [String: Any])
-        XCTAssertEqual(error["message"] as? String, "web search unavailable")
     }
 
     private func makeController() -> CodexNativeSessionController {

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexNativeSessionControllerEventRecoveryTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexNativeSessionControllerEventRecoveryTests.swift
@@ -3,6 +3,8 @@ import Foundation
 import XCTest
 
 final class CodexNativeSessionControllerEventRecoveryTests: XCTestCase {
+    private static let webSearchAliases = ["search", "web_search", "web_search_request", "google_web_search", "search_web"]
+
     func testNormalizedCommandExecutionLifecycleParsesAsBashCallAndResult() throws {
         let controller = CodexNativeSessionController(
             client: CodexAppServerClient(),
@@ -64,6 +66,290 @@ final class CodexNativeSessionControllerEventRecoveryTests: XCTestCase {
         XCTAssertEqual(resultObject["processId"] as? String, "47551")
         XCTAssertEqual(resultObject["aggregatedOutput"] as? String, "hi\n")
         XCTAssertEqual(resultObject["exitCode"] as? Int, 0)
+    }
+
+    func testNativeWebSearchAliasesParseAsCanonicalSearchCalls() throws {
+        for alias in Self.webSearchAliases {
+            let controller = makeController()
+            let started = try XCTUnwrap(controller.test_parseToolLifecycleEvent(
+                method: "item/started",
+                params: toolParams(item: [
+                    "type": "toolCall",
+                    "id": "call_\(alias)",
+                    "name": alias,
+                    "query": "latest Swift concurrency"
+                ])
+            ), alias)
+
+            XCTAssertEqual(started.kind, "call", alias)
+            XCTAssertEqual(started.name, "search", alias)
+            XCTAssertNotNil(started.invocationID, alias)
+            let argsObject = try XCTUnwrap(jsonObject(from: started.argsJSON), alias)
+            XCTAssertEqual(argsObject["query"] as? String, "latest Swift concurrency", alias)
+        }
+    }
+
+    func testNativeWebSearchAliasesPairStartedAndCompletedInvocations() throws {
+        for alias in Self.webSearchAliases {
+            let controller = makeController()
+            let itemID = "call_pair_\(alias)"
+            let started = try XCTUnwrap(controller.test_parseToolLifecycleEvent(
+                method: "item/started",
+                params: toolParams(item: [
+                    "type": "toolCall",
+                    "id": itemID,
+                    "name": alias,
+                    "query": "paired alias \(alias)"
+                ])
+            ), alias)
+
+            let completed = try XCTUnwrap(controller.test_parseToolLifecycleEvent(
+                method: "item/completed",
+                params: toolParams(item: [
+                    "type": "toolCall",
+                    "id": itemID,
+                    "name": alias,
+                    "status": "completed",
+                    "query": "paired alias \(alias)",
+                    "response": [
+                        "results": [["title": "Paired", "snippet": alias]]
+                    ]
+                ])
+            ), alias)
+
+            XCTAssertEqual(started.kind, "call", alias)
+            XCTAssertEqual(completed.kind, "result", alias)
+            XCTAssertEqual(completed.name, "search", alias)
+            XCTAssertEqual(completed.invocationID, started.invocationID, alias)
+            XCTAssertEqual(completed.isError, false, alias)
+        }
+    }
+
+    func testNativeWebSearchCompletionPayloadsPreserveCompactSearchFields() throws {
+        let rows: [(label: String, alias: String, item: [String: Any], expectedResults: Int?, expectedSources: Int?, expectedDetailKey: String)] = [
+            (
+                "root results",
+                "web_search",
+                [
+                    "type": "toolCall",
+                    "id": "call_search_root",
+                    "name": "web_search",
+                    "status": "completed",
+                    "query": "RepoPrompt CE",
+                    "results": [["title": "RepoPrompt CE", "url": "https://example.com/repo", "snippet": "Native cards"]],
+                    "sources": [["title": "Docs", "url": "https://example.com/docs"]]
+                ],
+                1,
+                1,
+                "results"
+            ),
+            (
+                "wrapped response",
+                "web_search_request",
+                [
+                    "type": "toolCall",
+                    "id": "call_search_wrapped",
+                    "name": "web_search_request",
+                    "query": "macOS app search",
+                    "response": [
+                        "summary": "Search completed",
+                        "items": [["title": "Result", "snippet": "Useful result"]]
+                    ],
+                    "sources": [["title": "Wrapped Source"]],
+                    "total_results": 3
+                ],
+                nil,
+                1,
+                "items"
+            ),
+            (
+                "array content",
+                "google_web_search",
+                [
+                    "type": "toolCall",
+                    "id": "call_search_array",
+                    "name": "google_web_search",
+                    "query": "Codex native web search",
+                    "content": [["title": "Codex", "snippet": "Web search result"]]
+                ],
+                1,
+                nil,
+                "results"
+            )
+        ]
+
+        for row in rows {
+            let controller = makeController()
+            let completed = try XCTUnwrap(controller.test_parseToolLifecycleEvent(
+                method: "item/completed",
+                params: toolParams(item: row.item)
+            ), row.label)
+
+            XCTAssertEqual(completed.kind, "result", row.label)
+            XCTAssertEqual(completed.name, "search", row.label)
+            XCTAssertNotEqual(completed.isError, true, row.label)
+            let resultObject = try XCTUnwrap(jsonObject(from: completed.resultJSON), row.label)
+            XCTAssertEqual(resultObject["query"] as? String, row.item["query"] as? String, row.label)
+            if let expectedResults = row.expectedResults {
+                XCTAssertEqual((resultObject["results"] as? [[String: Any]])?.count, expectedResults, row.label)
+            }
+            if let expectedSources = row.expectedSources {
+                XCTAssertEqual((resultObject["sources"] as? [[String: Any]])?.count, expectedSources, row.label)
+            }
+            XCTAssertNotNil(resultObject[row.expectedDetailKey], row.label)
+        }
+    }
+
+    func testNativeWebSearchWrappedPayloadPreservesScalarSourceCitationCounts() throws {
+        let controller = makeController()
+        let completed = try XCTUnwrap(controller.test_parseToolLifecycleEvent(
+            method: "item/completed",
+            params: toolParams(item: [
+                "type": "toolCall",
+                "id": "call_search_wrapped_scalar_counts",
+                "name": "web_search",
+                "status": "completed",
+                "query": "wrapped scalar counts",
+                "response": [
+                    "items": [["title": "Wrapped", "snippet": "Usable result"]]
+                ],
+                "source_count": 4,
+                "citationCount": 2
+            ])
+        ))
+
+        XCTAssertEqual(completed.kind, "result")
+        XCTAssertEqual(completed.name, "search")
+        XCTAssertEqual(completed.isError, false)
+        let resultObject = try XCTUnwrap(jsonObject(from: completed.resultJSON))
+        XCTAssertEqual((resultObject["items"] as? [[String: Any]])?.count, 1)
+        XCTAssertEqual(resultObject["source_count"] as? Int, 4)
+        XCTAssertEqual(resultObject["citationCount"] as? Int, 2)
+    }
+
+    func testNativeWebSearchWrappedPayloadMergesSiblingSearchFieldsAndSuccessfulStatusWins() throws {
+        let controller = makeController()
+        let completed = try XCTUnwrap(controller.test_parseToolLifecycleEvent(
+            method: "item/completed",
+            params: toolParams(item: [
+                "type": "toolCall",
+                "id": "call_search_completed_with_stale_error",
+                "name": "web_search",
+                "status": "completed",
+                "query": "completed despite stale error field",
+                "response": [
+                    "items": [["title": "Completed", "snippet": "Usable result"]]
+                ],
+                "citations": [["title": "Citation"]],
+                "total_results": 9,
+                "errorMessage": "stale retry warning",
+                "errors": [["message": "stale retry detail"]]
+            ])
+        ))
+
+        XCTAssertEqual(completed.kind, "result")
+        XCTAssertEqual(completed.name, "search")
+        XCTAssertEqual(completed.isError, false)
+        let resultObject = try XCTUnwrap(jsonObject(from: completed.resultJSON))
+        XCTAssertEqual(resultObject["query"] as? String, "completed despite stale error field")
+        XCTAssertEqual((resultObject["items"] as? [[String: Any]])?.count, 1)
+        XCTAssertEqual((resultObject["citations"] as? [[String: Any]])?.count, 1)
+        XCTAssertEqual(resultObject["total_results"] as? Int, 9)
+        XCTAssertEqual(resultObject["errorMessage"] as? String, "stale retry warning")
+        XCTAssertEqual((resultObject["errors"] as? [[String: Any]])?.count, 1)
+    }
+
+    func testNativeWebSearchErrorPayloadWithoutFailedStatusParsesAsFailure() throws {
+        let controller = makeController()
+        let completed = try XCTUnwrap(controller.test_parseToolLifecycleEvent(
+            method: "item/completed",
+            params: toolParams(item: [
+                "type": "toolCall",
+                "id": "call_search_error_without_status",
+                "name": "web_search",
+                "query": "transient web outage",
+                "errorMessage": "web search timed out"
+            ])
+        ))
+
+        XCTAssertEqual(completed.kind, "result")
+        XCTAssertEqual(completed.name, "search")
+        XCTAssertEqual(completed.isError, true)
+        let resultObject = try XCTUnwrap(jsonObject(from: completed.resultJSON))
+        XCTAssertEqual(resultObject["query"] as? String, "transient web outage")
+        XCTAssertEqual(resultObject["errorMessage"] as? String, "web search timed out")
+    }
+
+    func testNativeWebSearchNestedActionQueryParsesIntoArgsAndResults() throws {
+        let controller = makeController()
+        let started = try XCTUnwrap(controller.test_parseToolLifecycleEvent(
+            method: "item/started",
+            params: toolParams(item: [
+                "type": "web_search_call",
+                "id": "call_search_action",
+                "action": ["query": "nested action query"]
+            ])
+        ))
+
+        XCTAssertEqual(started.kind, "call")
+        XCTAssertEqual(started.name, "search")
+        let argsObject = try XCTUnwrap(jsonObject(from: started.argsJSON))
+        XCTAssertEqual(argsObject["query"] as? String, "nested action query")
+
+        let completed = try XCTUnwrap(controller.test_parseToolLifecycleEvent(
+            method: "item/completed",
+            params: toolParams(item: [
+                "type": "web_search_call",
+                "id": "call_search_action",
+                "status": "completed",
+                "action": ["query": "nested action query"],
+                "results": [["title": "Nested", "snippet": "Nested search result"]]
+            ])
+        ))
+        let resultObject = try XCTUnwrap(jsonObject(from: completed.resultJSON))
+        XCTAssertEqual(resultObject["query"] as? String, "nested action query")
+        XCTAssertEqual((resultObject["results"] as? [[String: Any]])?.count, 1)
+    }
+
+    func testNativeWebSearchErrorPayloadPreservesQueryAndFailureState() throws {
+        let controller = makeController()
+        let completed = try XCTUnwrap(controller.test_parseToolLifecycleEvent(
+            method: "item/completed",
+            params: toolParams(item: [
+                "type": "toolCall",
+                "id": "call_search_error",
+                "name": "search_web",
+                "status": "failed",
+                "query": "network outage",
+                "error": ["message": "web search unavailable"]
+            ])
+        ))
+
+        XCTAssertEqual(completed.kind, "result")
+        XCTAssertEqual(completed.name, "search")
+        XCTAssertEqual(completed.isError, true)
+        let resultObject = try XCTUnwrap(jsonObject(from: completed.resultJSON))
+        XCTAssertEqual(resultObject["query"] as? String, "network outage")
+        let error = try XCTUnwrap(resultObject["error"] as? [String: Any])
+        XCTAssertEqual(error["message"] as? String, "web search unavailable")
+    }
+
+    private func makeController() -> CodexNativeSessionController {
+        CodexNativeSessionController(
+            client: CodexAppServerClient(),
+            runID: UUID(),
+            tabID: UUID(),
+            windowID: 1,
+            workspacePath: nil
+        )
+    }
+
+    private func toolParams(item: [String: Any]) -> [String: Any] {
+        [
+            "threadId": "thread-active",
+            "turnId": "turn-current",
+            "item": item
+        ]
     }
 
     private func jsonObject(from raw: String?) -> [String: Any]? {

--- a/Tests/RepoPromptTests/AgentMode/ToolCards/WebSearchToolCardTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/ToolCards/WebSearchToolCardTests.swift
@@ -2,33 +2,28 @@
 import XCTest
 
 final class WebSearchToolCardTests: XCTestCase {
-    func testToolCardNormalizationMapsWebSearchAliasesToSearch() {
+    func testWebSearchNamesStayDistinctFromFileSearchAndRouteAsKnownResult() {
         for alias in ["search", "web_search", "web_search_request", "google_web_search", "search_web"] {
             XCTAssertEqual(normalizedToolCardName(alias), "search", alias)
-        }
-        XCTAssertEqual(normalizedToolCardName("file_search"), "file_search")
-    }
-
-    func testTranscriptNormalizationKeepsNativeSearchSeparateFromFileSearch() {
-        for alias in ["search", "web_search", "web_search_request", "google_web_search", "search_web"] {
             XCTAssertEqual(AgentToolResultPersistencePolicy.normalizedToolName(alias), "search", alias)
         }
         for alias in ["file_search", "filesearch", "grep"] {
             XCTAssertEqual(AgentToolResultPersistencePolicy.normalizedToolName(alias), "file_search", alias)
         }
-    }
-
-    func testRouterRecognizesWebSearchResultTool() {
         XCTAssertTrue(ToolCardRouter.knownResultTools.contains("search"))
     }
 
-    func testWebSearchPresentationForLiveAndSummaryOnlyPayloads() throws {
+    func testWebSearchPresentationCoversLiveAndSummaryOnlyPayloads() throws {
         let args = jsonString(["query": "native web search cards"])
         let raw = jsonString([
             "status": "completed",
             "query": "native web search cards",
-            "results": [["title": "Native card", "snippet": "Readable web result"]],
-            "sources": [["title": "Docs"]]
+            "total_results": 12,
+            "response": [
+                "web_results": [["title": "Native card", "snippet": "Readable web result"]],
+                "citations": [["title": "Docs"]]
+            ],
+            "errorMessage": "stale retry warning"
         ])
         let liveItem = AgentChatItem(
             kind: .toolResult,
@@ -43,9 +38,10 @@ final class WebSearchToolCardTests: XCTestCase {
         XCTAssertEqual(live.title, "Web Search")
         XCTAssertEqual(live.status, .success)
         XCTAssertTrue(live.subtitle?.contains("native web search cards") == true)
-        XCTAssertTrue(live.subtitle?.contains("1 result") == true)
+        XCTAssertTrue(live.subtitle?.contains("12 results") == true)
         XCTAssertTrue(live.subtitle?.contains("1 source") == true)
         XCTAssertTrue(live.detailText?.contains("Native card") == true)
+        XCTAssertFalse(live.detailText?.contains("stale retry") == true)
 
         let summaryOnly = jsonString([
             "status": "success",
@@ -67,56 +63,7 @@ final class WebSearchToolCardTests: XCTestCase {
         XCTAssertFalse(toolResultHasPayload(storedItem))
     }
 
-    func testWebSearchPresentationSuccessfulStatusWinsOverStaleErrorFields() throws {
-        let raw = jsonString([
-            "status": "completed",
-            "query": "completed web search",
-            "results": [["title": "Completed Result", "snippet": "Usable answer"]],
-            "sources": [["title": "Source"]],
-            "errorMessage": "stale retry warning",
-            "errors": [["message": "stale retry detail"]]
-        ])
-        let item = AgentChatItem(
-            kind: .toolResult,
-            text: raw,
-            toolName: "search",
-            toolArgsJSON: jsonString(["query": "completed web search"]),
-            toolResultJSON: raw,
-            toolIsError: false
-        )
-
-        let presentation = try XCTUnwrap(NativeToolCardPresentationBuilder.build(item: item, normalizedToolName: "search"))
-        XCTAssertEqual(presentation.status, .success)
-        XCTAssertTrue(presentation.detailText?.contains("Completed Result") == true)
-        XCTAssertFalse(presentation.detailText?.contains("stale retry") == true)
-    }
-
-    func testWebSearchPresentationUsesNumericCountsAndAlternateArrays() throws {
-        let raw = jsonString([
-            "status": "completed",
-            "query": "alternate web search payload",
-            "total_results": 12,
-            "response": [
-                "web_results": [["title": "Alternate Result", "snippet": "Alternate snippet"]],
-                "citations": [["title": "Citation", "snippet": "Cited source"]]
-            ]
-        ])
-        let item = AgentChatItem(
-            kind: .toolResult,
-            text: raw,
-            toolName: "search",
-            toolArgsJSON: jsonString(["query": "alternate web search payload"]),
-            toolResultJSON: raw,
-            toolIsError: false
-        )
-
-        let presentation = try XCTUnwrap(NativeToolCardPresentationBuilder.build(item: item, normalizedToolName: "search"))
-        XCTAssertTrue(presentation.subtitle?.contains("12 results") == true)
-        XCTAssertTrue(presentation.subtitle?.contains("1 source") == true)
-        XCTAssertTrue(presentation.detailText?.contains("Alternate Result") == true)
-    }
-
-    func testNativeFallbackDoesNotTrustSpoofedStoredRenderSummary() {
+    func testNativeFallbackRequiresSafeNameMatchingSummaryAndScalarSignals() throws {
         let spoofedSummary = AgentToolCardRenderSummary(
             toolName: "search",
             title: "Web Search",
@@ -130,82 +77,28 @@ final class WebSearchToolCardTests: XCTestCase {
             "summary_only": true,
             "render_summary": spoofedSummary.dictionary
         ])
-        let unsafeItem = AgentChatItem(
-            kind: .toolResult,
-            text: spoofedRaw,
-            toolName: "mcp__RepoPrompt__unknown",
-            toolResultJSON: spoofedRaw
-        )
-        XCTAssertNil(NativeToolCardPresentationBuilder.build(item: unsafeItem, normalizedToolName: "mcp__RepoPrompt__unknown"))
+        XCTAssertNil(NativeToolCardPresentationBuilder.build(
+            item: AgentChatItem(kind: .toolResult, text: spoofedRaw, toolName: "mcp__RepoPrompt__unknown", toolResultJSON: spoofedRaw),
+            normalizedToolName: "mcp__RepoPrompt__unknown"
+        ))
+        XCTAssertNil(NativeToolCardPresentationBuilder.build(
+            item: AgentChatItem(kind: .toolResult, text: spoofedRaw, toolName: "weather_lookup", toolResultJSON: spoofedRaw),
+            normalizedToolName: "weather_lookup"
+        ))
 
-        let mismatchedItem = AgentChatItem(
+        let safeItem = AgentChatItem(
             kind: .toolResult,
-            text: spoofedRaw,
+            text: jsonString(["status": "completed", "summary": "Sunny and mild"]),
             toolName: "weather_lookup",
-            toolResultJSON: spoofedRaw
-        )
-        XCTAssertNil(NativeToolCardPresentationBuilder.build(item: mismatchedItem, normalizedToolName: "weather_lookup"))
-
-        let trustedSummary = AgentToolCardRenderSummary(
-            toolName: "weather_lookup",
-            title: "Weather Lookup",
-            subtitle: "tomorrow weather",
-            detailText: "Sunny",
-            status: .success,
-            op: "weather_lookup"
-        )
-        let trustedRaw = jsonString([
-            "status": "success",
-            "summary_only": true,
-            "render_summary": trustedSummary.dictionary
-        ])
-        let trustedItem = AgentChatItem(
-            kind: .toolResult,
-            text: trustedRaw,
-            toolName: "weather_lookup",
-            toolResultJSON: trustedRaw
-        )
-        XCTAssertEqual(
-            NativeToolCardPresentationBuilder.build(item: trustedItem, normalizedToolName: "weather_lookup")?.title,
-            "Weather Lookup"
-        )
-    }
-
-    func testSafeNativeFallbackRequiresSafeNameAndScalarSignals() throws {
-        let args = jsonString(["query": "tomorrow weather"])
-        let raw = jsonString(["status": "completed", "summary": "Sunny and mild"])
-        let item = AgentChatItem(
-            kind: .toolResult,
-            text: raw,
-            toolName: "weather_lookup",
-            toolArgsJSON: args,
-            toolResultJSON: raw,
+            toolArgsJSON: jsonString(["query": "tomorrow weather"]),
+            toolResultJSON: jsonString(["status": "completed", "summary": "Sunny and mild"]),
             toolIsError: false
         )
-
-        let presentation = try XCTUnwrap(NativeToolCardPresentationBuilder.build(item: item, normalizedToolName: "weather_lookup"))
-        XCTAssertEqual(presentation.title, "Weather Lookup")
-        XCTAssertEqual(presentation.subtitle, "tomorrow weather")
-        XCTAssertEqual(presentation.detailText, "Sunny and mild")
-        XCTAssertEqual(presentation.status, .success)
-
-        XCTAssertNil(NativeToolCardPresentationBuilder.build(item: item, normalizedToolName: "mcp__RepoPrompt__unknown"))
-        XCTAssertNil(NativeToolCardPresentationBuilder.build(item: item, normalizedToolName: "tool"))
-        let arrayOnly = AgentChatItem(
-            kind: .toolResult,
-            text: jsonString(["results": [["title": "raw"]]]),
-            toolName: "future_tool",
-            toolArgsJSON: nil,
-            toolResultJSON: jsonString(["results": [["title": "raw"]]]),
-            toolIsError: nil
-        )
-        XCTAssertNil(NativeToolCardPresentationBuilder.build(item: arrayOnly, normalizedToolName: "future_tool"))
-    }
-
-    func testClusterClassifiesSearchAsNavigationWithoutRegressingFileSearch() {
-        XCTAssertEqual(ClusterToolCategory.classification(forNormalizedToolName: "search").family, .navigation)
-        XCTAssertEqual(ClusterToolCategory.classification(forNormalizedToolName: "search").summaryTitleSignal, .navigation)
-        XCTAssertEqual(ClusterToolCategory.classification(forNormalizedToolName: "file_search").family, .navigation)
+        let safe = try XCTUnwrap(NativeToolCardPresentationBuilder.build(item: safeItem, normalizedToolName: "weather_lookup"))
+        XCTAssertEqual(safe.title, "Weather Lookup")
+        XCTAssertEqual(safe.subtitle, "tomorrow weather")
+        XCTAssertEqual(safe.detailText, "Sunny and mild")
+        XCTAssertNil(NativeToolCardPresentationBuilder.build(item: safeItem, normalizedToolName: "tool"))
     }
 
     private func jsonString(_ object: [String: Any], file: StaticString = #filePath, line: UInt = #line) -> String {

--- a/Tests/RepoPromptTests/AgentMode/ToolCards/WebSearchToolCardTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/ToolCards/WebSearchToolCardTests.swift
@@ -1,0 +1,216 @@
+@testable import RepoPrompt
+import XCTest
+
+final class WebSearchToolCardTests: XCTestCase {
+    func testToolCardNormalizationMapsWebSearchAliasesToSearch() {
+        for alias in ["search", "web_search", "web_search_request", "google_web_search", "search_web"] {
+            XCTAssertEqual(normalizedToolCardName(alias), "search", alias)
+        }
+        XCTAssertEqual(normalizedToolCardName("file_search"), "file_search")
+    }
+
+    func testTranscriptNormalizationKeepsNativeSearchSeparateFromFileSearch() {
+        for alias in ["search", "web_search", "web_search_request", "google_web_search", "search_web"] {
+            XCTAssertEqual(AgentToolResultPersistencePolicy.normalizedToolName(alias), "search", alias)
+        }
+        for alias in ["file_search", "filesearch", "grep"] {
+            XCTAssertEqual(AgentToolResultPersistencePolicy.normalizedToolName(alias), "file_search", alias)
+        }
+    }
+
+    func testRouterRecognizesWebSearchResultTool() {
+        XCTAssertTrue(ToolCardRouter.knownResultTools.contains("search"))
+    }
+
+    func testWebSearchPresentationForLiveAndSummaryOnlyPayloads() throws {
+        let args = jsonString(["query": "native web search cards"])
+        let raw = jsonString([
+            "status": "completed",
+            "query": "native web search cards",
+            "results": [["title": "Native card", "snippet": "Readable web result"]],
+            "sources": [["title": "Docs"]]
+        ])
+        let liveItem = AgentChatItem(
+            kind: .toolResult,
+            text: raw,
+            toolName: "search",
+            toolArgsJSON: args,
+            toolResultJSON: raw,
+            toolIsError: false
+        )
+
+        let live = try XCTUnwrap(NativeToolCardPresentationBuilder.build(item: liveItem, normalizedToolName: "search"))
+        XCTAssertEqual(live.title, "Web Search")
+        XCTAssertEqual(live.status, .success)
+        XCTAssertTrue(live.subtitle?.contains("native web search cards") == true)
+        XCTAssertTrue(live.subtitle?.contains("1 result") == true)
+        XCTAssertTrue(live.subtitle?.contains("1 source") == true)
+        XCTAssertTrue(live.detailText?.contains("Native card") == true)
+
+        let summaryOnly = jsonString([
+            "status": "success",
+            "summary_only": true,
+            "render_summary": live.dictionary
+        ])
+        let storedItem = AgentChatItem(
+            kind: .toolResult,
+            text: summaryOnly,
+            toolName: "search",
+            toolArgsJSON: args,
+            toolResultJSON: summaryOnly,
+            toolIsError: false
+        )
+        let stored = try XCTUnwrap(NativeToolCardPresentationBuilder.build(item: storedItem, normalizedToolName: "search"))
+        XCTAssertEqual(stored.title, "Web Search")
+        XCTAssertEqual(stored.status, .success)
+        XCTAssertEqual(stored.subtitle, live.subtitle)
+        XCTAssertFalse(toolResultHasPayload(storedItem))
+    }
+
+    func testWebSearchPresentationSuccessfulStatusWinsOverStaleErrorFields() throws {
+        let raw = jsonString([
+            "status": "completed",
+            "query": "completed web search",
+            "results": [["title": "Completed Result", "snippet": "Usable answer"]],
+            "sources": [["title": "Source"]],
+            "errorMessage": "stale retry warning",
+            "errors": [["message": "stale retry detail"]]
+        ])
+        let item = AgentChatItem(
+            kind: .toolResult,
+            text: raw,
+            toolName: "search",
+            toolArgsJSON: jsonString(["query": "completed web search"]),
+            toolResultJSON: raw,
+            toolIsError: false
+        )
+
+        let presentation = try XCTUnwrap(NativeToolCardPresentationBuilder.build(item: item, normalizedToolName: "search"))
+        XCTAssertEqual(presentation.status, .success)
+        XCTAssertTrue(presentation.detailText?.contains("Completed Result") == true)
+        XCTAssertFalse(presentation.detailText?.contains("stale retry") == true)
+    }
+
+    func testWebSearchPresentationUsesNumericCountsAndAlternateArrays() throws {
+        let raw = jsonString([
+            "status": "completed",
+            "query": "alternate web search payload",
+            "total_results": 12,
+            "response": [
+                "web_results": [["title": "Alternate Result", "snippet": "Alternate snippet"]],
+                "citations": [["title": "Citation", "snippet": "Cited source"]]
+            ]
+        ])
+        let item = AgentChatItem(
+            kind: .toolResult,
+            text: raw,
+            toolName: "search",
+            toolArgsJSON: jsonString(["query": "alternate web search payload"]),
+            toolResultJSON: raw,
+            toolIsError: false
+        )
+
+        let presentation = try XCTUnwrap(NativeToolCardPresentationBuilder.build(item: item, normalizedToolName: "search"))
+        XCTAssertTrue(presentation.subtitle?.contains("12 results") == true)
+        XCTAssertTrue(presentation.subtitle?.contains("1 source") == true)
+        XCTAssertTrue(presentation.detailText?.contains("Alternate Result") == true)
+    }
+
+    func testNativeFallbackDoesNotTrustSpoofedStoredRenderSummary() {
+        let spoofedSummary = AgentToolCardRenderSummary(
+            toolName: "search",
+            title: "Web Search",
+            subtitle: "\"spoofed\"",
+            detailText: "spoofed detail",
+            status: .success,
+            op: "search"
+        )
+        let spoofedRaw = jsonString([
+            "status": "success",
+            "summary_only": true,
+            "render_summary": spoofedSummary.dictionary
+        ])
+        let unsafeItem = AgentChatItem(
+            kind: .toolResult,
+            text: spoofedRaw,
+            toolName: "mcp__RepoPrompt__unknown",
+            toolResultJSON: spoofedRaw
+        )
+        XCTAssertNil(NativeToolCardPresentationBuilder.build(item: unsafeItem, normalizedToolName: "mcp__RepoPrompt__unknown"))
+
+        let mismatchedItem = AgentChatItem(
+            kind: .toolResult,
+            text: spoofedRaw,
+            toolName: "weather_lookup",
+            toolResultJSON: spoofedRaw
+        )
+        XCTAssertNil(NativeToolCardPresentationBuilder.build(item: mismatchedItem, normalizedToolName: "weather_lookup"))
+
+        let trustedSummary = AgentToolCardRenderSummary(
+            toolName: "weather_lookup",
+            title: "Weather Lookup",
+            subtitle: "tomorrow weather",
+            detailText: "Sunny",
+            status: .success,
+            op: "weather_lookup"
+        )
+        let trustedRaw = jsonString([
+            "status": "success",
+            "summary_only": true,
+            "render_summary": trustedSummary.dictionary
+        ])
+        let trustedItem = AgentChatItem(
+            kind: .toolResult,
+            text: trustedRaw,
+            toolName: "weather_lookup",
+            toolResultJSON: trustedRaw
+        )
+        XCTAssertEqual(
+            NativeToolCardPresentationBuilder.build(item: trustedItem, normalizedToolName: "weather_lookup")?.title,
+            "Weather Lookup"
+        )
+    }
+
+    func testSafeNativeFallbackRequiresSafeNameAndScalarSignals() throws {
+        let args = jsonString(["query": "tomorrow weather"])
+        let raw = jsonString(["status": "completed", "summary": "Sunny and mild"])
+        let item = AgentChatItem(
+            kind: .toolResult,
+            text: raw,
+            toolName: "weather_lookup",
+            toolArgsJSON: args,
+            toolResultJSON: raw,
+            toolIsError: false
+        )
+
+        let presentation = try XCTUnwrap(NativeToolCardPresentationBuilder.build(item: item, normalizedToolName: "weather_lookup"))
+        XCTAssertEqual(presentation.title, "Weather Lookup")
+        XCTAssertEqual(presentation.subtitle, "tomorrow weather")
+        XCTAssertEqual(presentation.detailText, "Sunny and mild")
+        XCTAssertEqual(presentation.status, .success)
+
+        XCTAssertNil(NativeToolCardPresentationBuilder.build(item: item, normalizedToolName: "mcp__RepoPrompt__unknown"))
+        XCTAssertNil(NativeToolCardPresentationBuilder.build(item: item, normalizedToolName: "tool"))
+        let arrayOnly = AgentChatItem(
+            kind: .toolResult,
+            text: jsonString(["results": [["title": "raw"]]]),
+            toolName: "future_tool",
+            toolArgsJSON: nil,
+            toolResultJSON: jsonString(["results": [["title": "raw"]]]),
+            toolIsError: nil
+        )
+        XCTAssertNil(NativeToolCardPresentationBuilder.build(item: arrayOnly, normalizedToolName: "future_tool"))
+    }
+
+    func testClusterClassifiesSearchAsNavigationWithoutRegressingFileSearch() {
+        XCTAssertEqual(ClusterToolCategory.classification(forNormalizedToolName: "search").family, .navigation)
+        XCTAssertEqual(ClusterToolCategory.classification(forNormalizedToolName: "search").summaryTitleSignal, .navigation)
+        XCTAssertEqual(ClusterToolCategory.classification(forNormalizedToolName: "file_search").family, .navigation)
+    }
+
+    private func jsonString(_ object: [String: Any], file: StaticString = #filePath, line: UInt = #line) -> String {
+        XCTAssertTrue(JSONSerialization.isValidJSONObject(object), file: file, line: line)
+        let data = try! JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+        return String(data: data, encoding: .utf8)!
+    }
+}

--- a/Tests/RepoPromptTests/AgentMode/Transcript/AgentToolResultPersistencePolicyTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Transcript/AgentToolResultPersistencePolicyTests.swift
@@ -127,6 +127,63 @@ final class AgentToolResultPersistencePolicyTests: XCTestCase {
         XCTAssertLessThanOrEqual(summary.resultJSON.utf8.count, AgentToolResultPersistencePolicy.maxPersistedToolSummaryBytes)
     }
 
+    func testWebSearchPersistsBoundedSummaryOnlySuccessPresentation() throws {
+        let bulkySnippet = String(repeating: "full page body ", count: 80)
+        let raw = jsonString([
+            "status": "completed",
+            "query": "native web search cards",
+            "results": [[
+                "title": "Native Web Search Cards",
+                "url": "https://example.com/search-cards",
+                "snippet": bulkySnippet
+            ]],
+            "sources": [["title": "Plan", "url": "https://example.com/plan"]]
+        ])
+        let args = jsonString(["query": "native web search cards"])
+
+        let summary = try XCTUnwrap(persistedSummary(toolName: "search", rawResultJSON: raw, argsJSON: args))
+        let object = try decodedObject(summary.resultJSON)
+        let renderSummary = try XCTUnwrap(object["render_summary"] as? [String: Any])
+        let restored = try XCTUnwrap(StoredToolCardPresentation.fromSummaryOnly(raw: summary.resultJSON))
+
+        XCTAssertTrue(summary.summaryOnly)
+        XCTAssertEqual(object["summary_only"] as? Bool, true)
+        XCTAssertEqual(renderSummary["tool_name"] as? String, "search")
+        XCTAssertEqual(renderSummary["title"] as? String, "Web Search")
+        XCTAssertEqual(renderSummary["status"] as? String, "success")
+        XCTAssertTrue((renderSummary["subtitle"] as? String)?.contains("native web search cards") == true)
+        XCTAssertTrue((renderSummary["subtitle"] as? String)?.contains("1 result") == true)
+        XCTAssertTrue((renderSummary["subtitle"] as? String)?.contains("1 source") == true)
+        XCTAssertEqual(restored.title, "Web Search")
+        XCTAssertEqual(restored.status, .success)
+        XCTAssertFalse(summary.resultJSON.contains(bulkySnippet))
+        XCTAssertNil(object["results"])
+        XCTAssertLessThanOrEqual(summary.resultJSON.utf8.count, AgentToolResultPersistencePolicy.maxPersistedToolSummaryBytes)
+    }
+
+    func testWebSearchPersistsBoundedSummaryOnlyErrorPresentation() throws {
+        let raw = jsonString([
+            "status": "failed",
+            "query": "native web search cards",
+            "error": ["message": "web search unavailable"]
+        ])
+        let args = jsonString(["query": "native web search cards"])
+
+        let summary = try XCTUnwrap(persistedSummary(toolName: "web_search", rawResultJSON: raw, argsJSON: args))
+        let object = try decodedObject(summary.resultJSON)
+        let renderSummary = try XCTUnwrap(object["render_summary"] as? [String: Any])
+        let restored = try XCTUnwrap(StoredToolCardPresentation.fromSummaryOnly(raw: summary.resultJSON))
+
+        XCTAssertTrue(summary.summaryOnly)
+        XCTAssertEqual(renderSummary["tool_name"] as? String, "search")
+        XCTAssertEqual(renderSummary["title"] as? String, "Web Search")
+        XCTAssertEqual(renderSummary["status"] as? String, "failure")
+        XCTAssertTrue((renderSummary["detail_text"] as? String)?.contains("web search unavailable") == true)
+        XCTAssertEqual(restored.title, "Web Search")
+        XCTAssertEqual(restored.status, .failure)
+        XCTAssertLessThanOrEqual(summary.resultJSON.utf8.count, AgentToolResultPersistencePolicy.maxPersistedToolSummaryBytes)
+    }
+
     func testSummaryOnlyFalseOnlyForPromptExportStructuredMetadata() throws {
         let promptRaw = jsonString([
             "op": "export",
@@ -148,20 +205,21 @@ final class AgentToolResultPersistencePolicyTests: XCTestCase {
         XCTAssertNil(promptObject["summary_only"])
     }
 
-    private func persistedSummary(toolName: String, rawResultJSON: String) -> AgentPersistedToolResultSummary? {
+    private func persistedSummary(toolName: String, rawResultJSON: String, argsJSON: String? = nil) -> AgentPersistedToolResultSummary? {
         let invocationID = UUID()
         let item = AgentChatItem(
             kind: .toolResult,
             text: rawResultJSON,
             toolName: toolName,
             toolInvocationID: invocationID,
+            toolArgsJSON: argsJSON,
             toolResultJSON: rawResultJSON
         )
         let execution = AgentTranscriptToolExecution(
             stableExecutionID: invocationID.uuidString,
             toolName: toolName,
             invocationID: invocationID,
-            argsJSON: nil,
+            argsJSON: argsJSON,
             resultJSON: rawResultJSON,
             toolIsError: nil,
             status: .unknown


### PR DESCRIPTION
## Summary
- add first-class Codex native Web Search result cards for live and persisted transcripts
- keep native `search` distinct from RepoPrompt `file_search` through transcript/persistence normalization
- add bounded Web Search render summaries plus a narrow safe native-tool fallback
- harden Codex Web Search parser coverage for aliases, wrapped/root/array payloads, error states, and source/citation counts

## Validation
- `rpce-contribution-check` commit preflight ✅
- Clean draft-PR branch created from `upstream/main` with one commit: `df619f3 Improve native Web Search tool cards`
- `rpce-contribution-check` push preflight on clean branch ✅
  - outgoing range: `upstream/main..HEAD`
  - outgoing secret scan: no leaks
  - `./conductor lint` ✅
  - `./conductor test` ✅
  - `./conductor swift-build --product RepoPrompt` ✅
- Additional focused validation during implementation:
  - `make dev-format` ✅
  - `make dev-test FILTER=CodexNativeSessionControllerEventRecoveryTests` ✅
  - `make dev-test FILTER=WebSearchToolCardTests` ✅
  - `make dev-test FILTER=AgentToolResultPersistencePolicyTests` ✅
  - `make dev-test FILTER=MCPFileSearchDisplayPathTests` ✅
  - `swift build -c release --product RepoPrompt` ✅
- Oracle review: satisfied, no remaining findings ✅

## Notes
- Manual comparison against v1.0.3 showed the old Web Search result presentation was generic/unclear and the patched app renders a clearer Web Search card.
- `make dev-smoke` was attempted after relaunching the patched debug app, but blocked because the live window was on `Default` with MCP tools unavailable for window 1 (`workspace switch repoprompt-ce` failed). No app-code failure was observed in that smoke attempt.

