### PR TITLE
Sync MCP CLI version during release prep

### DIFF
--- a/.agents/skills/rpce-release/SKILL.md
+++ b/.agents/skills/rpce-release/SKILL.md
@@ -52,6 +52,8 @@ profiles, certificate exports, tokens, or passwords into logs or chat.
 
 RepoPrompt CE starts its independent release history at `1.0.0 (1)`.
 Increment `BUILD_NUMBER` monotonically for every later public update.
+After changing `version.env`, run `make release-sync-cli-version` and commit the
+synchronized MCP CLI version before creating the release tag.
 
 For an explicit private-source updater smoke test, use the maintainer-only
 `Scripts/publish_public_update_test.sh` helper documented in

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: doctor setup install-format-tools format-tools-status format format-check lint install-debug-cli uninstall-debug-cli debug-cli-status resolve build run test guardrails conductor-selftest release-selftest release-preflight release-artifact install-local-production dev-status dev-build dev-swift-build dev-run dev-test dev-provider-test dev-smoke dev-smoke-launch dev-format dev-format-check dev-lint dev-format-tools-status dev-check-format-tools dev-install-format-tools dev-release-preflight dev-release-artifact dev-install-local-production dev-stop-app dev-daemon-stop clean
+.PHONY: doctor setup install-format-tools format-tools-status format format-check lint install-debug-cli uninstall-debug-cli debug-cli-status resolve build run test guardrails conductor-selftest release-selftest release-sync-cli-version release-preflight release-artifact install-local-production dev-status dev-build dev-swift-build dev-run dev-test dev-provider-test dev-smoke dev-smoke-launch dev-format dev-format-check dev-lint dev-format-tools-status dev-check-format-tools dev-install-format-tools dev-release-preflight dev-release-artifact dev-install-local-production dev-stop-app dev-daemon-stop clean
 
 PRODUCT ?= all
 
@@ -59,6 +59,9 @@ conductor-selftest:
 release-selftest:
 	python3 Scripts/test_release_promotion.py
 	python3 Scripts/test_release_tooling.py
+
+release-sync-cli-version:
+	./Scripts/release.sh sync-cli-version
 
 release-preflight:
 	./Scripts/release.sh preflight

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -76,6 +76,7 @@ run_preflight() {
     require_file "$ROOT_DIR/Vendor/Sparkle/SHA256SUMS"
     require_file "$CONTROL_PLANE_SCRIPTS_DIR/sign_staged_release.sh"
     require_file "$CONTROL_PLANE_SCRIPTS_DIR/smoke_embedded_mcp_helper.sh"
+    require_file "$CONTROL_PLANE_SCRIPTS_DIR/sync_mcp_cli_version.sh"
     require_file "$CONTROL_PLANE_SCRIPTS_DIR/validate_embedded_mcp_helper_layout.sh"
     require_file "$CONTROL_PLANE_SCRIPTS_DIR/extract_staged_release.py"
     require_file "$CONTROL_PLANE_SCRIPTS_DIR/validate_staged_release.sh"
@@ -96,9 +97,16 @@ run_preflight() {
         "$CONTROL_PLANE_SCRIPTS_DIR/verify_sparkle_vendor.sh"
     REPOPROMPT_RELEASE_SOURCE_ROOT="$ROOT_DIR" \
         "$CONTROL_PLANE_SCRIPTS_DIR/swiftpm_notice_guardrails.sh"
+    REPOPROMPT_RELEASE_SOURCE_ROOT="$ROOT_DIR" \
+        "$CONTROL_PLANE_SCRIPTS_DIR/sync_mcp_cli_version.sh" --check
 
     printf 'OK: release preflight passed for %s %s (%s) with Sparkle %s.\n' \
         "$DISPLAY_NAME" "$MARKETING_VERSION" "$BUILD_NUMBER" "$sparkle_version"
+}
+
+sync_mcp_cli_version() {
+    REPOPROMPT_RELEASE_SOURCE_ROOT="$ROOT_DIR" \
+        "$CONTROL_PLANE_SCRIPTS_DIR/sync_mcp_cli_version.sh"
 }
 
 resolve_without_lockfile_drift() {
@@ -427,11 +435,12 @@ publish_signed_test_build() {
 }
 
 case "$MODE" in
+    sync-cli-version) sync_mcp_cli_version ;;
     preflight) run_preflight ;;
     artifact) package_release_candidate ;;
     stage-publish) stage_publish_release ;;
     publish-staged) publish_staged_release ;;
     stage-test-build) stage_signed_test_build ;;
     publish-test-build) publish_signed_test_build ;;
-    *) fail "Usage: $0 preflight|artifact|stage-publish|publish-staged|stage-test-build|publish-test-build" ;;
+    *) fail "Usage: $0 sync-cli-version|preflight|artifact|stage-publish|publish-staged|stage-test-build|publish-test-build" ;;
 esac

--- a/Scripts/sync_mcp_cli_version.sh
+++ b/Scripts/sync_mcp_cli_version.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE="${1:-sync}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="${REPOPROMPT_RELEASE_SOURCE_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+CLI_SOURCE="$ROOT_DIR/Sources/RepoPromptMCP/main.swift"
+
+source "$SCRIPT_DIR/load_release_metadata.sh"
+load_release_metadata "$ROOT_DIR"
+
+python3 - "$MODE" "$CLI_SOURCE" "$MARKETING_VERSION" <<'PYTHON'
+import re
+import sys
+from pathlib import Path
+
+mode, source_path, marketing_version = sys.argv[1:]
+source = Path(source_path)
+text = source.read_text(encoding="utf-8")
+pattern = re.compile(r'^let CLI_VERSION = "[^"]+"$', re.MULTILINE)
+matches = pattern.findall(text)
+if len(matches) != 1:
+    raise SystemExit(
+        f"ERROR: expected exactly one MCP CLI version declaration in {source}, found {len(matches)}"
+    )
+
+current = matches[0]
+expected = f'let CLI_VERSION = "{marketing_version}"'
+if mode == "--check":
+    if current != expected:
+        raise SystemExit(
+            "ERROR: MCP CLI version is out of sync with version.env. "
+            "Run ./Scripts/release.sh sync-cli-version after updating version.env."
+        )
+    print(f"OK: MCP CLI version matches release metadata ({marketing_version}).")
+elif mode == "sync":
+    if current == expected:
+        print(f"OK: MCP CLI version already matches release metadata ({marketing_version}).")
+    else:
+        source.write_text(text.replace(current, expected, 1), encoding="utf-8")
+        print(f"Updated MCP CLI version to {marketing_version}: {source}")
+else:
+    raise SystemExit(f"ERROR: usage: {sys.argv[0]} [sync|--check]")
+PYTHON

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -597,6 +597,32 @@ class ReleaseToolingTests(unittest.TestCase):
         self.assertNotEqual(result.returncode, 0)
         self.assertFalse(marker.exists())
 
+    def test_mcp_cli_version_sync_updates_source_and_check_detects_drift(self) -> None:
+        root = self.make_metadata_root()
+        source = root / "Sources" / "RepoPromptMCP" / "main.swift"
+        source.parent.mkdir(parents=True)
+        source.write_text('let CLI_VERSION = "9.9.9"\n', encoding="utf-8")
+        env = os.environ.copy()
+        env["REPOPROMPT_RELEASE_SOURCE_ROOT"] = str(root)
+        helper = SCRIPT_DIR / "sync_mcp_cli_version.sh"
+
+        rejected = subprocess.run([str(helper), "--check"], env=env, text=True, capture_output=True)
+        synced = subprocess.run([str(helper)], env=env, text=True, capture_output=True)
+        accepted = subprocess.run([str(helper), "--check"], env=env, text=True, capture_output=True)
+
+        self.assertNotEqual(rejected.returncode, 0)
+        self.assertIn("Run ./Scripts/release.sh sync-cli-version", rejected.stderr)
+        self.assertEqual(synced.returncode, 0, synced.stderr)
+        self.assertEqual(source.read_text(encoding="utf-8"), 'let CLI_VERSION = "1.0.0"\n')
+        self.assertEqual(accepted.returncode, 0, accepted.stderr)
+
+    def test_release_preflight_requires_synchronized_mcp_cli_version(self) -> None:
+        release_script = (SCRIPT_DIR / "release.sh").read_text(encoding="utf-8")
+
+        self.assertIn('require_file "$CONTROL_PLANE_SCRIPTS_DIR/sync_mcp_cli_version.sh"', release_script)
+        self.assertIn('"$CONTROL_PLANE_SCRIPTS_DIR/sync_mcp_cli_version.sh" --check', release_script)
+        self.assertIn("sync-cli-version) sync_mcp_cli_version", release_script)
+
     def test_remote_release_commit_helper_rejects_moved_tag(self) -> None:
         remote, work = self.make_git_remote()
         first = self.commit_file(work, "first")

--- a/Sources/RepoPromptMCP/main.swift
+++ b/Sources/RepoPromptMCP/main.swift
@@ -9,7 +9,7 @@ import SystemPackage
 // MARK: - Version Constants
 
 /// Update this when releasing new versions
-let CLI_VERSION = "2.1.24"
+let CLI_VERSION = "1.0.4"
 
 /// CLI verbose mode - controls debug output (enabled by --verbose flag)
 var cliVerboseMode = false

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -29,7 +29,8 @@ Developer ID signing job waits on the protected `release` environment.
 
 The intended process is:
 
-1. A contributor opens a release PR that updates `version.env`, release notes,
+1. A contributor updates `version.env`, runs `make release-sync-cli-version`,
+   and opens a release PR with the synchronized MCP CLI version, release notes,
    and any relevant changelog entry.
 2. CI runs ordinary validation plus the secret-free release-candidate lane.
 3. Contributors and maintainers inspect the ad-hoc release-candidate artifact
@@ -207,7 +208,8 @@ the helper `--version` smoke under a minimal environment.
 
 ## Build a draft release
 
-1. Update `version.env` and commit the release state.
+1. Update `version.env`, run `make release-sync-cli-version`, and commit the
+   synchronized release state.
 2. Create and push a tag pointing at that commit.
 3. Dispatch **Publish Release** from protected `main` with the existing tag.
 4. Review and test the draft GitHub Release assets before promotion.


### PR DESCRIPTION
## Summary
- add `make release-sync-cli-version` to synchronize the hard-coded MCP CLI version with `version.env`
- fail release preflight if the committed MCP CLI version drifts from release metadata
- synchronize the current MCP CLI version to `1.0.4`
- document the release-prep step and cover it with regression tests

## Validation
- `python3 Scripts/test_release_tooling.py`
- `python3 Scripts/test_release_promotion.py`
- `bash -n Scripts/sync_mcp_cli_version.sh Scripts/release.sh`
- `make dev-release-preflight`
- `make dev-lint`
- `make dev-swift-build PRODUCT=repoprompt-mcp`
- `make dev-release-artifact`
- release-candidate ZIP layout validation, checksum verification, and minimal-environment embedded helper smoke: `rpce-cli (repoprompt-mcp) 1.0.4`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh push`

## Live smoke note
A non-disruptive `./conductor smoke --workspace repoprompt-ce-live-smoke` attempt was intentionally left blocked because switching the current CE workspace would terminate seven active agent sessions. No live app or session state was changed.