### PR TITLE
Fix signed test build verifier auth

### DIFF
--- a/Scripts/verify_signed_test_build_ref.sh
+++ b/Scripts/verify_signed_test_build_ref.sh
@@ -35,13 +35,11 @@ fetch_args=(
 )
 server_url="${GITHUB_SERVER_URL:-https://github.com}"
 server_url="${server_url%/}/"
-if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+token="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
+if [[ -n "$token" ]]; then
+    auth_header="$(printf 'x-access-token:%s' "$token" | base64 | tr -d '\n')"
     fetch_args+=(
-        -c "http.$server_url.extraheader=AUTHORIZATION: bearer $GITHUB_TOKEN"
-    )
-elif [[ -n "${GH_TOKEN:-}" ]]; then
-    fetch_args+=(
-        -c "http.$server_url.extraheader=AUTHORIZATION: bearer $GH_TOKEN"
+        -c "http.$server_url.extraheader=AUTHORIZATION: basic $auth_header"
     )
 fi
 fetch_args+=(


### PR DESCRIPTION
## Summary
- fix signed-test source verifier git fetch authentication when checkout credentials are not persisted
- use GitHub-compatible Basic auth (`x-access-token:<token>`) for the transient `http.extraheader`

## Validation
- reproduced the failed workflow shape locally with an HTTPS origin, no persisted credentials, and only a transient `GITHUB_TOKEN`; verifier succeeded for `codex/computer-use-runtime-setup` and returned `01b644b47eb721517eacfb1b08f1bf0f0211660d`
- `bash -n Scripts/verify_signed_test_build_ref.sh`
- `make release-selftest`
- `actionlint .github/workflows/signed-test-build.yml`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh commit`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh push`

## Notes
Direct push to `main` was blocked by repository rules, so this must merge via PR before re-dispatching the signed test build for PR #44.
