### PR TITLE
Add Agent Mode session row context menus

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionRows.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionRows.swift
@@ -117,6 +117,35 @@ struct AgentSessionRow: View {
         isThreadCollapsed ? "Expand sub-agent chats" : "Collapse sub-agent chats"
     }
 
+    private var pinActionLabel: String {
+        isPinned ? "Unpin chat" : "Pin chat"
+    }
+
+    private var renameActionLabel: String {
+        "Rename chat"
+    }
+
+    private var stashActionLabel: String {
+        "Stash chat for later"
+    }
+
+    private var dismissAttentionActionLabel: String {
+        "Dismiss status badge"
+    }
+
+    private var deleteActionLabel: String {
+        "Delete chat"
+    }
+
+    private func beginRename() {
+        renameText = title
+        showRenameAlert = true
+    }
+
+    private func requestDeleteConfirmation() {
+        showDeleteConfirmation = true
+    }
+
     var body: some View {
         HStack(spacing: rowSpacing) {
             if threadDepth > 0 {
@@ -176,8 +205,8 @@ struct AgentSessionRow: View {
                     }
                     .buttonStyle(.plain)
                     .onHover { isDismissAttentionHovered = $0 }
-                    .hoverTooltip("Dismiss status badge")
-                    .accessibilityLabel("Dismiss status badge")
+                    .hoverTooltip(dismissAttentionActionLabel)
+                    .accessibilityLabel(dismissAttentionActionLabel)
                 }
 
                 Button(action: onTogglePin) {
@@ -187,19 +216,16 @@ struct AgentSessionRow: View {
                 }
                 .buttonStyle(.plain)
                 .onHover { isPinHovered = $0 }
-                .hoverTooltip(isPinned ? "Unpin chat" : "Pin chat")
+                .hoverTooltip(pinActionLabel)
 
-                Button {
-                    renameText = title
-                    showRenameAlert = true
-                } label: {
+                Button(action: beginRename) {
                     Image(systemName: "pencil")
                         .font(.system(size: 11))
                         .foregroundColor(isRenameHovered ? .accentColor : .secondary)
                 }
                 .buttonStyle(.plain)
                 .onHover { isRenameHovered = $0 }
-                .hoverTooltip("Rename chat")
+                .hoverTooltip(renameActionLabel)
 
                 Button(action: onStash) {
                     Image(systemName: "tray.and.arrow.down")
@@ -208,18 +234,16 @@ struct AgentSessionRow: View {
                 }
                 .buttonStyle(.plain)
                 .onHover { isStashHovered = $0 }
-                .hoverTooltip("Stash chat for later")
+                .hoverTooltip(stashActionLabel)
 
-                Button {
-                    showDeleteConfirmation = true
-                } label: {
+                Button(action: requestDeleteConfirmation) {
                     Image(systemName: "trash")
                         .font(.system(size: 11))
                         .foregroundColor(isDeleteHovered ? .red : .secondary)
                 }
                 .buttonStyle(.plain)
                 .onHover { isDeleteHovered = $0 }
-                .hoverTooltip("Delete chat")
+                .hoverTooltip(deleteActionLabel)
             }
             // Selected state is already signaled by the accent-tinted background +
             // semibold title weight; a trailing checkmark was redundant.
@@ -239,6 +263,21 @@ struct AgentSessionRow: View {
             }
         )
         .contentShape(Rectangle())
+        .contextMenu {
+            Button(pinActionLabel, action: onTogglePin)
+
+            Button(renameActionLabel, action: beginRename)
+
+            Button(stashActionLabel, action: onStash)
+
+            if attentionRunState != nil, let onDismissAttention {
+                Button(dismissAttentionActionLabel, action: onDismissAttention)
+            }
+
+            Divider()
+
+            Button(deleteActionLabel, role: .destructive, action: requestDeleteConfirmation)
+        }
         .onHover { isHovered = $0 }
         .onTapGesture { onSelect() }
         .accessibilityLabel(title)
@@ -698,6 +737,14 @@ struct AgentStashedSessionRow: View {
         fontPreset.scaledClamped(10, max: 13)
     }
 
+    private var restoreActionLabel: String {
+        "Restore tab"
+    }
+
+    private var deleteActionLabel: String {
+        "Delete stashed tab"
+    }
+
     var body: some View {
         HStack(spacing: rowSpacing) {
             Image(systemName: "tray.and.arrow.down")
@@ -728,7 +775,7 @@ struct AgentStashedSessionRow: View {
                 }
                 .buttonStyle(.plain)
                 .onHover { isRestoreHovered = $0 }
-                .hoverTooltip("Restore tab")
+                .hoverTooltip(restoreActionLabel)
 
                 Button(action: onDelete) {
                     Image(systemName: "trash")
@@ -737,7 +784,7 @@ struct AgentStashedSessionRow: View {
                 }
                 .buttonStyle(.plain)
                 .onHover { isDeleteHovered = $0 }
-                .hoverTooltip("Delete stashed tab")
+                .hoverTooltip(deleteActionLabel)
             }
         }
         .padding(.horizontal, rowHorizontalPadding)
@@ -752,6 +799,13 @@ struct AgentStashedSessionRow: View {
             }
         )
         .contentShape(Rectangle())
+        .contextMenu {
+            Button(restoreActionLabel, action: onRestore)
+
+            Divider()
+
+            Button(deleteActionLabel, role: .destructive, action: onDelete)
+        }
         .onHover { isHovered = $0 }
         .onTapGesture(perform: onRestore)
         .accessibilityLabel("\(stashed.tab.name), archived session")


### PR DESCRIPTION
## Summary

- Add right-click context menus to active Agent Mode session rows for pin/unpin, rename, stash, dismiss status badge, and delete.
- Add right-click context menus to archived/stashed Agent Mode session rows for restore and delete.
- Reuse existing row labels/actions so hover buttons and context menus stay in sync.
- Preserve existing delete semantics: active delete still opens confirmation; archived individual delete remains immediate.

Refs #54

## Testing

- ✅ Commit preflight passed: whitespace, staged secret scan, source layout guardrails, contributor allowlist guardrails, SwiftPM notice guardrails.
- ✅ `make dev-format-check` passed during implementation/simplify cleanup.
- ✅ Oracle review found no blockers and considered the change safe to commit.
- ⚠️ `make dev-lint` could not complete because SwiftLint/SourceKitten failed to load `sourcekitdInProc` under Command Line Tools. Retrying with full Xcode was blocked because the Xcode license has not been accepted on this machine.
- ⚠️ `make dev-swift-build PRODUCT=RepoPrompt` failed before app code in third-party `KeyboardShortcuts` `#Preview` macro plugin resolution.
- ⚠️ `make dev-smoke` could not run because `rpce-cli-debug` is not installed/resolvable in this environment.

## Manual testing still needed

I still need to do additional UI testing before merging, especially:

- Right-click active session rows and confirm all expected menu items appear.
- Confirm active Delete from the context menu opens the existing confirmation popover.
- Right-click archived/stashed rows and confirm the context menu opens without triggering restore.
- Confirm hover buttons and primary click behavior are unchanged.
