### PR TITLE
Add .worktreeinclude support for managed worktrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ another Mac or redistributed.
 - **Context Builder**: Let an agent explore the repository, identify relevant
   files, and curate context within a token budget.
 - **Agent orchestration**: Run and coordinate CLI-backed coding agents from the
-  native macOS app.
+  native macOS app. See [`docs/worktrees.md`](docs/worktrees.md) for app-managed
+  worktrees and `.worktreeinclude` local file copying.
 - **MCP server and CLI integration**: Connect external MCP-compatible tools and
   CLI agents to RepoPrompt CE's repository context and agent harness.
 - **Multi-root workspaces**: Work across related repositories, packages, and

--- a/Scripts/source_layout_guardrails.sh
+++ b/Scripts/source_layout_guardrails.sh
@@ -270,6 +270,7 @@ allowed_tracked_docs=(
   "docs/architecture/source-layout.md"
   "docs/open-source-readiness.md"
   "docs/releasing.md"
+  "docs/worktrees.md"
   "docs/investigations/test-coverage-value-audit-ledger-2026-05-29.md"
   "docs/plans/test-coverage-value-audit-2026-05-29.md"
 )

--- a/Sources/RepoPrompt/Infrastructure/MCP/ToolOutputFormatter.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ToolOutputFormatter.swift
@@ -3666,7 +3666,10 @@ extension ToolOutputFormatter {
         }
         if let warning = dto.warning, !warning.isEmpty {
             out.append("")
-            out.append("> ⚠️ \(warning)")
+            let lines = warning.components(separatedBy: .newlines).filter { !$0.isEmpty }
+            for (index, line) in lines.enumerated() {
+                out.append(index == 0 ? "> ⚠️ \(line)" : "> \(line)")
+            }
         }
         return [.text(out.joined(separator: "\n"))]
     }

--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPWorktreeToolProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPWorktreeToolProvider.swift
@@ -201,7 +201,8 @@ final class MCPWorktreeToolProvider: MCPWindowToolProviding {
             )
         )
 
-        let created = try await vcsService.createGitWorktree(request: plan.createRequest, at: context.repo.rootURL)
+        let createResult = try await vcsService.createGitWorktreeWithResult(request: plan.createRequest, at: context.repo.rootURL)
+        let created = createResult.descriptor
         let identity = try persistOrResolveVisualIdentity(
             for: created,
             args: args,
@@ -229,6 +230,12 @@ final class MCPWorktreeToolProvider: MCPWindowToolProviding {
             }
         }
 
+        let includeCopyWarning = createResult.includeCopyResult?.warningText
+        let fallbackBindingWarning = bindAfterCreate && bindingDTO == nil
+            ? "Worktree created but no session binding was applied."
+            : nil
+        let warning = combinedWarnings([includeCopyWarning, bindingWarning, fallbackBindingWarning])
+
         return ToolResultDTOs.ManageWorktreeReplyDTO(
             op: "create",
             repository: repositoryDTO(from: created.repository, fallback: context.repo),
@@ -236,7 +243,7 @@ final class MCPWorktreeToolProvider: MCPWindowToolProviding {
             createdWorktree: createdDTO,
             binding: bindingDTO,
             previousBinding: previousDTO,
-            warning: bindingWarning ?? (bindAfterCreate && bindingDTO == nil ? "Worktree created but no session binding was applied." : nil)
+            warning: warning
         )
     }
 
@@ -750,6 +757,17 @@ final class MCPWorktreeToolProvider: MCPWindowToolProviding {
 
     func parseBool(_ value: Value?) -> Bool? {
         value?.boolValue
+    }
+
+    private func combinedWarnings(_ warnings: [String?]) -> String? {
+        let parts = warnings.compactMap { warning -> String? in
+            guard let warning = warning?.trimmingCharacters(in: .whitespacesAndNewlines), !warning.isEmpty else {
+                return nil
+            }
+            return warning
+        }
+        guard !parts.isEmpty else { return nil }
+        return parts.joined(separator: "\n")
     }
 
     private func standardizedPath(_ path: String) -> String {

--- a/Sources/RepoPrompt/Infrastructure/VCS/GitBackend.swift
+++ b/Sources/RepoPrompt/Infrastructure/VCS/GitBackend.swift
@@ -108,6 +108,13 @@ actor GitBackend: VCSBackend {
         try await gitService.createWorktree(request: request, at: repoURL)
     }
 
+    func createWorktreeWithResult(
+        request: GitWorktreeCreateRequest,
+        at repoURL: URL
+    ) async throws -> GitWorktreeCreateResult {
+        try await gitService.createWorktreeWithResult(request: request, at: repoURL)
+    }
+
     // MARK: - Worktree Merge Operations
 
     func inspectWorktreeMerge(_ request: GitWorktreeMergeInspectRequest) async throws -> GitWorktreeMergeInspection {

--- a/Sources/RepoPrompt/Infrastructure/VCS/GitService.swift
+++ b/Sources/RepoPrompt/Infrastructure/VCS/GitService.swift
@@ -145,10 +145,19 @@ actor GitService {
         request: GitWorktreeCreateRequest,
         at repoURL: URL
     ) async throws -> GitWorktreeDescriptor {
+        let result = try await createWorktreeWithResult(request: request, at: repoURL)
+        return result.descriptor
+    }
+
+    /// Create a Git worktree and return best-effort `.worktreeinclude` copy details.
+    func createWorktreeWithResult(
+        request: GitWorktreeCreateRequest,
+        at repoURL: URL
+    ) async throws -> GitWorktreeCreateResult {
         let mutationKey = getLayout(for: repoURL)?.commonDir.standardizedFileURL.path
             ?? repoURL.standardizedFileURL.path
 
-        return try await worktreeMutationCoordinator.withLock(key: mutationKey) { [weak self] in
+        let created = try await worktreeMutationCoordinator.withLock(key: mutationKey) { [weak self] in
             guard let self else {
                 throw GitError(message: "git service was released before worktree creation")
             }
@@ -198,6 +207,60 @@ actor GitService {
 
             throw GitError(message: "git worktree add succeeded but created worktree was not listed: \(createdPath)")
         }
+
+        let destinationURL = URL(fileURLWithPath: created.path, isDirectory: true)
+        let includeCopyResult = await copyWorktreeIncludeFilesIfRequested(
+            request: request,
+            sourceRepoURL: repoURL,
+            destinationURL: destinationURL
+        )
+        return GitWorktreeCreateResult(descriptor: created, includeCopyResult: includeCopyResult)
+    }
+
+    private func copyWorktreeIncludeFilesIfRequested(
+        request: GitWorktreeCreateRequest,
+        sourceRepoURL: URL,
+        destinationURL: URL
+    ) async -> GitWorktreeIncludeCopyResult? {
+        guard request.copyWorktreeIncludeFiles,
+              let appManagedContainer = request.appManagedContainer,
+              Self.isPath(destinationURL, equalToOrInside: appManagedContainer)
+        else { return nil }
+        let includeURL = sourceRepoURL.appendingPathComponent(".worktreeinclude", isDirectory: false)
+        guard FileManager.default.fileExists(atPath: includeURL.path) else { return nil }
+
+        do {
+            let (stdout, stderr, exitCode) = try await runGit(
+                ["ls-files", "--others", "--ignored", "--exclude-standard", "-z"],
+                at: sourceRepoURL
+            )
+            guard exitCode == 0 else {
+                return GitWorktreeIncludeCopyResult(
+                    copiedCount: 0,
+                    matchedCount: 0,
+                    errorSummaries: ["could not list Git-ignored files: \(stderr)"]
+                )
+            }
+            return GitWorktreeIncludeCopier.copyIncludedFiles(
+                from: sourceRepoURL,
+                to: destinationURL,
+                ignoredFilesNULOutput: stdout,
+                appManagedContainer: appManagedContainer
+            )
+        } catch {
+            return GitWorktreeIncludeCopyResult(
+                copiedCount: 0,
+                matchedCount: 0,
+                errorSummaries: ["could not copy .worktreeinclude files: \(error.localizedDescription)"]
+            )
+        }
+    }
+
+    private static func isPath(_ path: URL, equalToOrInside root: URL) -> Bool {
+        StandardizedPath.isDescendant(
+            StandardizedPath.absolute(path.path),
+            of: StandardizedPath.absolute(root.path)
+        )
     }
 
     // MARK: - Worktree Merge Primitives

--- a/Sources/RepoPrompt/Infrastructure/VCS/GitWorktreeDefaultPathPlanner.swift
+++ b/Sources/RepoPrompt/Infrastructure/VCS/GitWorktreeDefaultPathPlanner.swift
@@ -75,6 +75,7 @@ enum GitWorktreeDefaultPathPlanner {
         }
 
         let branch = normalizedBranch(request.branch) ?? defaultBranch(for: request)
+        let copyWorktreeIncludeFiles = isPath(path, equalToOrInside: container)
         let createRequest = GitWorktreeCreateRequest(
             path: path,
             branch: branch,
@@ -85,7 +86,8 @@ enum GitWorktreeDefaultPathPlanner {
             allowExternalPath: request.allowExternalPath,
             appManagedContainer: container,
             mainWorktreeRoot: mainRoot,
-            knownWorktreeRoots: existingRoots
+            knownWorktreeRoots: existingRoots,
+            copyWorktreeIncludeFiles: copyWorktreeIncludeFiles
         )
         return Plan(path: path, branch: branch, appManagedContainer: container, createRequest: createRequest)
     }

--- a/Sources/RepoPrompt/Infrastructure/VCS/GitWorktreeIncludeCopier.swift
+++ b/Sources/RepoPrompt/Infrastructure/VCS/GitWorktreeIncludeCopier.swift
@@ -1,0 +1,166 @@
+import Foundation
+
+enum GitWorktreeIncludeCopier {
+    private static let includeFileName = ".worktreeinclude"
+
+    static func copyIncludedFiles(
+        from sourceRoot: URL,
+        to destinationRoot: URL,
+        ignoredFilesNULOutput: String,
+        appManagedContainer: URL? = nil,
+        fileManager: FileManager = .default
+    ) -> GitWorktreeIncludeCopyResult? {
+        let includeURL = sourceRoot.appendingPathComponent(includeFileName, isDirectory: false)
+        guard fileManager.fileExists(atPath: includeURL.path) else { return nil }
+
+        let content: String
+        do {
+            content = try String(contentsOf: includeURL, encoding: .utf8)
+        } catch {
+            return GitWorktreeIncludeCopyResult(
+                copiedCount: 0,
+                matchedCount: 0,
+                errorSummaries: ["could not read .worktreeinclude: \(error.localizedDescription)"]
+            )
+        }
+
+        let rules = GitignoreCompiler.compile(content: content, directoryPath: "")
+        var copiedCount = 0
+        var matchedCount = 0
+        var skippedSummaries: [String] = []
+        var errorSummaries: [String] = []
+        let appManagedContainerComponents = appManagedContainer.flatMap {
+            relativePathComponentsIfInside(child: $0, root: sourceRoot)
+        }
+
+        for relativePathSlice in ignoredFilesNULOutput.split(separator: "\0", omittingEmptySubsequences: false) {
+            guard !relativePathSlice.isEmpty else { continue }
+            let relativePath = String(relativePathSlice)
+            guard let pathComponents = safePathComponents(relativePath) else {
+                skippedSummaries.append("skipped unsafe path \(relativePath)")
+                continue
+            }
+            if let appManagedContainerComponents,
+               isPathComponents(pathComponents, equalToOrInside: appManagedContainerComponents)
+            {
+                continue
+            }
+
+            let matchComponents = pathComponents.map { Substring($0) }
+            guard rules.outcome(for: matchComponents, isDirectory: false) == .ignore else {
+                continue
+            }
+            matchedCount += 1
+
+            guard let sourceURL = fileURL(root: sourceRoot, pathComponents: pathComponents),
+                  let destinationURL = fileURL(root: destinationRoot, pathComponents: pathComponents)
+            else {
+                skippedSummaries.append("skipped unsafe path \(relativePath)")
+                continue
+            }
+
+            guard !hasSymlinkAncestor(root: sourceRoot, pathComponents: pathComponents, fileManager: fileManager) else {
+                skippedSummaries.append("source path uses a symlink ancestor for \(relativePath)")
+                continue
+            }
+            guard !hasSymlinkAncestor(
+                root: destinationRoot,
+                pathComponents: pathComponents,
+                fileManager: fileManager
+            ) else {
+                skippedSummaries.append("destination path uses a symlink ancestor for \(relativePath)")
+                continue
+            }
+            guard !isSymlink(destinationURL, fileManager: fileManager) else {
+                skippedSummaries.append("destination is a symlink for \(relativePath)")
+                continue
+            }
+            guard fileManager.fileExists(atPath: destinationURL.path) == false else {
+                skippedSummaries.append("destination already exists for \(relativePath)")
+                continue
+            }
+
+            do {
+                let values = try sourceURL.resourceValues(forKeys: [.isRegularFileKey, .isSymbolicLinkKey])
+                guard values.isSymbolicLink != true, values.isRegularFile == true else {
+                    skippedSummaries.append("source is not a regular file for \(relativePath)")
+                    continue
+                }
+                try fileManager.createDirectory(
+                    at: destinationURL.deletingLastPathComponent(),
+                    withIntermediateDirectories: true
+                )
+                try fileManager.copyItem(at: sourceURL, to: destinationURL)
+                copiedCount += 1
+            } catch {
+                errorSummaries.append("failed to copy \(relativePath): \(error.localizedDescription)")
+            }
+        }
+
+        guard matchedCount > 0 || !skippedSummaries.isEmpty || !errorSummaries.isEmpty else {
+            return nil
+        }
+        return GitWorktreeIncludeCopyResult(
+            copiedCount: copiedCount,
+            matchedCount: matchedCount,
+            skippedSummaries: skippedSummaries,
+            errorSummaries: errorSummaries
+        )
+    }
+
+    private static func safePathComponents(_ relativePath: String) -> [String]? {
+        guard !relativePath.isEmpty, !relativePath.hasPrefix("/") else { return nil }
+        let components = relativePath.split(separator: "/", omittingEmptySubsequences: false).map(String.init)
+        guard !components.isEmpty else { return nil }
+        guard components.allSatisfy({ !$0.isEmpty && $0 != "." && $0 != ".." }) else { return nil }
+        return components
+    }
+
+    private static func fileURL(root: URL, pathComponents: [String]) -> URL? {
+        guard !pathComponents.isEmpty else { return nil }
+        return pathComponents.reduce(root.standardizedFileURL) { partial, component in
+            partial.appendingPathComponent(component, isDirectory: false)
+        }
+    }
+
+    private static func relativePathComponentsIfInside(child: URL, root: URL) -> [String]? {
+        let childPath = StandardizedPath.absolute(child.path)
+        let rootPath = StandardizedPath.absolute(root.path)
+        guard StandardizedPath.isDescendant(childPath, of: rootPath) else { return nil }
+        guard childPath != rootPath else { return [] }
+
+        let suffix: Substring = if rootPath == "/" {
+            childPath.dropFirst()
+        } else {
+            childPath.dropFirst(rootPath.count)
+        }
+        let relativePath = StandardizedPath.relative(String(suffix))
+        guard !relativePath.isEmpty else { return [] }
+        return safePathComponents(relativePath)
+    }
+
+    private static func isPathComponents(_ pathComponents: [String], equalToOrInside rootComponents: [String]) -> Bool {
+        guard pathComponents.count >= rootComponents.count else { return false }
+        return Array(pathComponents.prefix(rootComponents.count)) == rootComponents
+    }
+
+    private static func hasSymlinkAncestor(
+        root: URL,
+        pathComponents: [String],
+        fileManager: FileManager
+    ) -> Bool {
+        guard pathComponents.count > 1 else { return false }
+        var current = root.standardizedFileURL
+        for component in pathComponents.dropLast() {
+            current = current.appendingPathComponent(component, isDirectory: true)
+            if isSymlink(current, fileManager: fileManager) {
+                return true
+            }
+        }
+        return false
+    }
+
+    private static func isSymlink(_ url: URL, fileManager: FileManager) -> Bool {
+        (try? fileManager.destinationOfSymbolicLink(atPath: url.path)) != nil
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/VCS/GitWorktreeModels.swift
+++ b/Sources/RepoPrompt/Infrastructure/VCS/GitWorktreeModels.swift
@@ -85,6 +85,7 @@ public struct GitWorktreeCreateRequest: Sendable, Equatable {
     public let appManagedContainer: URL?
     public let mainWorktreeRoot: URL?
     public let knownWorktreeRoots: [URL]
+    public let copyWorktreeIncludeFiles: Bool
 
     public init(
         path: URL,
@@ -96,7 +97,8 @@ public struct GitWorktreeCreateRequest: Sendable, Equatable {
         allowExternalPath: Bool = false,
         appManagedContainer: URL? = nil,
         mainWorktreeRoot: URL? = nil,
-        knownWorktreeRoots: [URL] = []
+        knownWorktreeRoots: [URL] = [],
+        copyWorktreeIncludeFiles: Bool = false
     ) {
         self.path = path
         self.branch = branch
@@ -108,6 +110,48 @@ public struct GitWorktreeCreateRequest: Sendable, Equatable {
         self.appManagedContainer = appManagedContainer
         self.mainWorktreeRoot = mainWorktreeRoot
         self.knownWorktreeRoots = knownWorktreeRoots
+        self.copyWorktreeIncludeFiles = copyWorktreeIncludeFiles
+    }
+}
+
+public struct GitWorktreeCreateResult: Sendable, Equatable {
+    public let descriptor: GitWorktreeDescriptor
+    public let includeCopyResult: GitWorktreeIncludeCopyResult?
+
+    public init(
+        descriptor: GitWorktreeDescriptor,
+        includeCopyResult: GitWorktreeIncludeCopyResult? = nil
+    ) {
+        self.descriptor = descriptor
+        self.includeCopyResult = includeCopyResult
+    }
+}
+
+public struct GitWorktreeIncludeCopyResult: Sendable, Equatable {
+    public let copiedCount: Int
+    public let matchedCount: Int
+    public let skippedSummaries: [String]
+    public let errorSummaries: [String]
+
+    public init(
+        copiedCount: Int,
+        matchedCount: Int,
+        skippedSummaries: [String] = [],
+        errorSummaries: [String] = []
+    ) {
+        self.copiedCount = copiedCount
+        self.matchedCount = matchedCount
+        self.skippedSummaries = skippedSummaries
+        self.errorSummaries = errorSummaries
+    }
+
+    public var warningText: String? {
+        let details = (skippedSummaries + errorSummaries).filter { !$0.isEmpty }
+        guard !details.isEmpty else { return nil }
+        let detailText = details.prefix(5).joined(separator: "; ")
+        let remaining = details.count - min(details.count, 5)
+        let suffix = remaining > 0 ? "; +\(remaining) more" : ""
+        return ".worktreeinclude copied \(copiedCount) of \(matchedCount) eligible file(s); some files were skipped or failed: \(detailText)\(suffix)"
     }
 }
 

--- a/Sources/RepoPrompt/Infrastructure/VCS/VCSService.swift
+++ b/Sources/RepoPrompt/Infrastructure/VCS/VCSService.swift
@@ -454,6 +454,18 @@ public extension VCSService {
         request: GitWorktreeCreateRequest,
         at repoURL: URL
     ) async throws -> GitWorktreeDescriptor {
+        let result = try await createGitWorktreeWithResult(request: request, at: repoURL)
+        if let warning = result.includeCopyResult?.warningText {
+            NSLog("RepoPrompt .worktreeinclude copy warning for worktree %@: %@", result.descriptor.path, warning)
+        }
+        return result.descriptor
+    }
+
+    /// Create a Git worktree and keep best-effort `.worktreeinclude` copy details.
+    func createGitWorktreeWithResult(
+        request: GitWorktreeCreateRequest,
+        at repoURL: URL
+    ) async throws -> GitWorktreeCreateResult {
         let resolved = await resolveRepo(from: repoURL)
         guard let resolved else {
             throw VCSError.notARepository(path: repoURL.path)
@@ -462,10 +474,10 @@ public extension VCSService {
             throw VCSError.unsupportedOperation(operation: "create_worktree", backend: resolved.backendKind)
         }
 
-        let created = try await gitBackend().createWorktree(request: request, at: resolved.rootURL)
+        let result = try await gitBackend().createWorktreeWithResult(request: request, at: resolved.rootURL)
         invalidateCache(for: resolved.rootURL)
         invalidateCache(for: request.path)
-        return created
+        return result
     }
 
     func inspectGitWorktreeMerge(_ request: GitWorktreeMergeInspectRequest) async throws -> GitWorktreeMergeInspection {

--- a/Tests/RepoPromptTests/MCP/ToolOutputFormatterWorktreeTests.swift
+++ b/Tests/RepoPromptTests/MCP/ToolOutputFormatterWorktreeTests.swift
@@ -21,6 +21,23 @@ final class ToolOutputFormatterWorktreeTests: XCTestCase {
         XCTAssertTrue(text.contains("\"worktree_id\":\"wt_feature\""))
     }
 
+    func testCreateOutputShowsWorktreeIncludeWarning() throws {
+        let dto = ToolResultDTOs.ManageWorktreeReplyDTO(
+            op: "create",
+            worktree: Self.worktreeDTO(),
+            createdWorktree: Self.worktreeDTO(),
+            warning: "\n\n"
+                + ".worktreeinclude copied 1 of 2 eligible file(s); some files were skipped or failed: destination already exists for .env.local\n"
+                + "Worktree created but no session binding was applied."
+        )
+
+        let text = try Self.onlyText(ToolOutputFormatter.formatManageWorktree(args: [:], value: Self.value(dto)))
+
+        XCTAssertTrue(text.contains("> ⚠️ .worktreeinclude copied 1 of 2 eligible file(s)"), text)
+        XCTAssertTrue(text.contains("destination already exists for .env.local"), text)
+        XCTAssertTrue(text.contains("> Worktree created but no session binding was applied."), text)
+    }
+
     func testBindOutputIncludesPreviousBindingAndNextStepCommands() throws {
         let dto = ToolResultDTOs.ManageWorktreeReplyDTO(
             op: "bind",

--- a/Tests/RepoPromptTests/Services/VCS/GitWorktreeDefaultPathPlannerTests.swift
+++ b/Tests/RepoPromptTests/Services/VCS/GitWorktreeDefaultPathPlannerTests.swift
@@ -43,6 +43,7 @@ final class GitWorktreeDefaultPathPlannerTests: XCTestCase {
         XCTAssertEqual(plan.createRequest.mainWorktreeRoot, mainRoot.standardizedFileURL)
         XCTAssertEqual(plan.createRequest.appManagedContainer, expectedContainer)
         XCTAssertFalse(plan.createRequest.allowExternalPath)
+        XCTAssertTrue(plan.createRequest.copyWorktreeIncludeFiles)
     }
 
     func testAgentStartDefaultsToAgentBranchAndReadablePathPrefix() throws {
@@ -90,6 +91,7 @@ final class GitWorktreeDefaultPathPlannerTests: XCTestCase {
             purpose: .standaloneCreate(now: Date(timeIntervalSince1970: 0))
         ))
         XCTAssertEqual(allowed.path, externalPath.standardizedFileURL)
+        XCTAssertFalse(allowed.createRequest.copyWorktreeIncludeFiles)
     }
 
     func testRejectsRelativeExplicitPathAndExpandsHomePath() throws {
@@ -132,6 +134,7 @@ final class GitWorktreeDefaultPathPlannerTests: XCTestCase {
         ))
 
         XCTAssertEqual(plan.path, managedPath.standardizedFileURL)
+        XCTAssertTrue(plan.createRequest.copyWorktreeIncludeFiles)
     }
 
     func testRejectsExplicitPathInsideRepoOrGitDirectory() throws {

--- a/Tests/RepoPromptTests/Services/VCS/GitWorktreeIncludeCopyTests.swift
+++ b/Tests/RepoPromptTests/Services/VCS/GitWorktreeIncludeCopyTests.swift
@@ -1,0 +1,293 @@
+@testable import RepoPrompt
+import XCTest
+
+final class GitWorktreeIncludeCopyTests: XCTestCase {
+    private var fixture: GitWorktreeIncludeFixture!
+
+    override func tearDownWithError() throws {
+        fixture?.cleanup()
+        fixture = nil
+    }
+
+    func testMissingWorktreeIncludeNoOps() async throws {
+        fixture = try GitWorktreeIncludeFixture(name: "missing-include")
+        try fixture.write(".gitignore", ".env.local\n")
+        try fixture.commit(paths: [".gitignore"], message: "Add ignore file")
+        try fixture.write(".env.local", "secret\n")
+
+        let result = try await fixture.createManagedWorktree()
+
+        XCTAssertNil(result.includeCopyResult)
+        XCTAssertFalse(fixture.fileExists(".env.local", in: result.descriptor))
+    }
+
+    func testCopierIgnoresAppManagedContainerInsideSourceRoot() throws {
+        let sandbox = FileManager.default.temporaryDirectory
+            .appendingPathComponent("GitWorktreeIncludeCopyTests-managed-container-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: sandbox) }
+        let sourceRoot = sandbox.appendingPathComponent("source", isDirectory: true)
+        let destinationRoot = sandbox.appendingPathComponent("destination", isDirectory: true)
+        let appManagedContainer = sourceRoot.appendingPathComponent(".repoprompt-worktrees", isDirectory: true)
+        try FileManager.default.createDirectory(at: sourceRoot, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: destinationRoot, withIntermediateDirectories: true)
+        try "**\n".write(
+            to: sourceRoot.appendingPathComponent(".worktreeinclude"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try ".repoprompt-worktrees/\n.env.local\n".write(
+            to: sourceRoot.appendingPathComponent(".gitignore"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try "secret\n".write(
+            to: sourceRoot.appendingPathComponent(".env.local"),
+            atomically: true,
+            encoding: .utf8
+        )
+        let managedFile = appManagedContainer.appendingPathComponent("repo/rp-worktree/.env.local")
+        try FileManager.default.createDirectory(at: managedFile.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try "managed secret\n".write(to: managedFile, atomically: true, encoding: .utf8)
+
+        let result = try XCTUnwrap(GitWorktreeIncludeCopier.copyIncludedFiles(
+            from: sourceRoot,
+            to: destinationRoot,
+            ignoredFilesNULOutput: ".env.local\0.repoprompt-worktrees/repo/rp-worktree/.env.local\0",
+            appManagedContainer: appManagedContainer
+        ))
+
+        XCTAssertEqual(result.copiedCount, 1)
+        XCTAssertEqual(result.matchedCount, 1)
+        XCTAssertEqual(
+            try String(contentsOf: destinationRoot.appendingPathComponent(".env.local"), encoding: .utf8),
+            "secret\n"
+        )
+        XCTAssertFalse(FileManager.default.fileExists(
+            atPath: destinationRoot.appendingPathComponent(".repoprompt-worktrees/repo/rp-worktree/.env.local").path
+        ))
+    }
+
+    func testCopiesOnlyIgnoredFilesThatMatchWorktreeInclude() async throws {
+        fixture = try GitWorktreeIncludeFixture(name: "copy-matches")
+        try fixture.write(".gitignore", """
+        .env.local
+        certs/local/
+        certs glob/local/**
+        secrets/*.txt
+        """)
+        try fixture.write(".worktreeinclude", """
+        .env.local
+        certs/local/
+        certs glob/local/**
+        secrets/*.txt
+        unignored.txt
+        Tracked.txt
+        !certs/local/skip.pem
+        """)
+        try fixture.write("Tracked.txt", "committed\n")
+        try fixture.commit(paths: [".gitignore", ".worktreeinclude", "Tracked.txt"], message: "Initial files")
+
+        try fixture.write(".env.local", "secret\n")
+        try fixture.write("certs/local/key.pem", "directory-only pattern\n")
+        try fixture.write("certs/local/skip.pem", "negated\n")
+        try fixture.write("certs glob/local/key.pem", "globstar pattern\n")
+        try fixture.write("secrets/with space.txt", "space path\n")
+        try fixture.write("unignored.txt", "should not copy\n")
+        try fixture.write("Tracked.txt", "dirty working copy\n")
+
+        let result = try await fixture.createManagedWorktree()
+
+        XCTAssertEqual(result.includeCopyResult?.copiedCount, 4)
+        XCTAssertEqual(result.includeCopyResult?.matchedCount, 4)
+        XCTAssertNil(result.includeCopyResult?.warningText)
+        XCTAssertEqual(try fixture.read(".env.local", in: result.descriptor), "secret\n")
+        XCTAssertEqual(try fixture.read("certs/local/key.pem", in: result.descriptor), "directory-only pattern\n")
+        XCTAssertEqual(try fixture.read("certs glob/local/key.pem", in: result.descriptor), "globstar pattern\n")
+        XCTAssertEqual(try fixture.read("secrets/with space.txt", in: result.descriptor), "space path\n")
+        XCTAssertFalse(fixture.fileExists("certs/local/skip.pem", in: result.descriptor))
+        XCTAssertFalse(fixture.fileExists("unignored.txt", in: result.descriptor))
+        XCTAssertEqual(try fixture.read("Tracked.txt", in: result.descriptor), "committed\n")
+    }
+
+    func testExistingDestinationFileIsNotOverwrittenAndWarns() async throws {
+        fixture = try GitWorktreeIncludeFixture(name: "existing-destination")
+        try fixture.write(".gitignore", "collision.txt\n")
+        try fixture.write(".worktreeinclude", "collision.txt\n")
+        try fixture.commit(paths: [".gitignore", ".worktreeinclude"], message: "Initial files")
+
+        try fixture.runGit(["checkout", "-b", "with-collision"])
+        try fixture.write("collision.txt", "tracked branch\n")
+        try fixture.runGit(["add", "-f", "collision.txt"])
+        try fixture.runGit(["commit", "-m", "Track collision file"])
+        try fixture.runGit(["checkout", "main"])
+        try fixture.write("collision.txt", "ignored source\n")
+
+        let result = try await fixture.createManagedWorktree(baseRef: "with-collision")
+
+        XCTAssertEqual(result.includeCopyResult?.copiedCount, 0)
+        XCTAssertEqual(result.includeCopyResult?.matchedCount, 1)
+        XCTAssertEqual(try fixture.read("collision.txt", in: result.descriptor), "tracked branch\n")
+        XCTAssertTrue(result.includeCopyResult?.warningText?.contains("destination already exists") ?? false)
+    }
+
+    func testExplicitExternalWorktreePathDoesNotCopyWorktreeIncludeFiles() async throws {
+        fixture = try GitWorktreeIncludeFixture(name: "external-path")
+        try fixture.write(".gitignore", ".env.local\n")
+        try fixture.write(".worktreeinclude", ".env.local\n")
+        try fixture.commit(paths: [".gitignore", ".worktreeinclude"], message: "Initial files")
+        try fixture.write(".env.local", "secret\n")
+
+        let externalPath = fixture.sandbox.appendingPathComponent("external worktree", isDirectory: true)
+        let result = try await fixture.createExternalWorktree(path: externalPath, forceCopyFlag: true)
+
+        XCTAssertFalse(result.descriptor.path.contains(".repoprompt-worktrees"))
+        XCTAssertNil(result.includeCopyResult)
+        XCTAssertFalse(fixture.fileExists(".env.local", in: result.descriptor))
+    }
+
+    func testCopierSkipsDestinationSymlinkAncestor() throws {
+        let sandbox = FileManager.default.temporaryDirectory
+            .appendingPathComponent("GitWorktreeIncludeCopyTests-symlink-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: sandbox) }
+        let sourceRoot = sandbox.appendingPathComponent("source", isDirectory: true)
+        let destinationRoot = sandbox.appendingPathComponent("destination", isDirectory: true)
+        let outsideRoot = sandbox.appendingPathComponent("outside", isDirectory: true)
+        try FileManager.default.createDirectory(at: sourceRoot, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: destinationRoot, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: outsideRoot, withIntermediateDirectories: true)
+        try ".env.local\ncerts/local/key.pem\n".write(
+            to: sourceRoot.appendingPathComponent(".worktreeinclude"),
+            atomically: true,
+            encoding: .utf8
+        )
+        let sourceFile = sourceRoot.appendingPathComponent("certs/local/key.pem")
+        try FileManager.default.createDirectory(at: sourceFile.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try "secret\n".write(to: sourceFile, atomically: true, encoding: .utf8)
+        try FileManager.default.createSymbolicLink(
+            at: destinationRoot.appendingPathComponent("certs"),
+            withDestinationURL: outsideRoot
+        )
+
+        let result = try XCTUnwrap(GitWorktreeIncludeCopier.copyIncludedFiles(
+            from: sourceRoot,
+            to: destinationRoot,
+            ignoredFilesNULOutput: "certs/local/key.pem\0"
+        ))
+
+        XCTAssertEqual(result.copiedCount, 0)
+        XCTAssertEqual(result.matchedCount, 1)
+        XCTAssertTrue(result.warningText?.contains("symlink ancestor") ?? false)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: outsideRoot.appendingPathComponent("local/key.pem").path))
+    }
+}
+
+private struct GitWorktreeIncludeFixture {
+    let sandbox: URL
+    let repo: URL
+
+    init(name: String) throws {
+        sandbox = FileManager.default.temporaryDirectory
+            .appendingPathComponent("GitWorktreeIncludeCopyTests-\(name)-\(UUID().uuidString)", isDirectory: true)
+            .standardizedFileURL
+        repo = sandbox.appendingPathComponent("repo", isDirectory: true).standardizedFileURL
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+        try runGit(["init"], cwd: repo)
+        try runGit(["config", "user.name", "RepoPrompt Test"], cwd: repo)
+        try runGit(["config", "user.email", "repoprompt@example.test"], cwd: repo)
+        try runGit(["config", "commit.gpgSign", "false"], cwd: repo)
+        try runGit(["checkout", "-b", "main"], cwd: repo)
+        try write("README.md", "base\n")
+        try commit(paths: ["README.md"], message: "Initial commit")
+    }
+
+    func cleanup() {
+        try? FileManager.default.removeItem(at: sandbox)
+    }
+
+    func createManagedWorktree(baseRef: String? = nil) async throws -> GitWorktreeCreateResult {
+        let plan = try GitWorktreeDefaultPathPlanner.plan(.init(
+            mainWorktreeRoot: repo,
+            baseRef: baseRef,
+            purpose: .standaloneCreate(now: Date(timeIntervalSince1970: 0))
+        ))
+        XCTAssertTrue(plan.createRequest.copyWorktreeIncludeFiles)
+        return try await VCSService().createGitWorktreeWithResult(request: plan.createRequest, at: repo)
+    }
+
+    func createExternalWorktree(path: URL, forceCopyFlag: Bool = false) async throws -> GitWorktreeCreateResult {
+        let plan = try GitWorktreeDefaultPathPlanner.plan(.init(
+            mainWorktreeRoot: repo,
+            explicitPath: path,
+            allowExternalPath: true,
+            purpose: .standaloneCreate(now: Date(timeIntervalSince1970: 0))
+        ))
+        XCTAssertFalse(plan.createRequest.copyWorktreeIncludeFiles)
+        let request = forceCopyFlag ? GitWorktreeCreateRequest(
+            path: plan.createRequest.path,
+            branch: plan.createRequest.branch,
+            baseRef: plan.createRequest.baseRef,
+            detach: plan.createRequest.detach,
+            force: plan.createRequest.force,
+            lockReason: plan.createRequest.lockReason,
+            allowExternalPath: plan.createRequest.allowExternalPath,
+            appManagedContainer: plan.createRequest.appManagedContainer,
+            mainWorktreeRoot: plan.createRequest.mainWorktreeRoot,
+            knownWorktreeRoots: plan.createRequest.knownWorktreeRoots,
+            copyWorktreeIncludeFiles: true
+        ) : plan.createRequest
+        return try await VCSService().createGitWorktreeWithResult(request: request, at: repo)
+    }
+
+    func write(_ relativePath: String, _ contents: String) throws {
+        let url = repo.appendingPathComponent(relativePath)
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try contents.write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    func read(_ relativePath: String, in descriptor: GitWorktreeDescriptor) throws -> String {
+        try String(contentsOf: worktreeURL(descriptor).appendingPathComponent(relativePath), encoding: .utf8)
+    }
+
+    func fileExists(_ relativePath: String, in descriptor: GitWorktreeDescriptor) -> Bool {
+        FileManager.default.fileExists(atPath: worktreeURL(descriptor).appendingPathComponent(relativePath).path)
+    }
+
+    func commit(paths: [String], message: String) throws {
+        try runGit(["add"] + paths)
+        try runGit(["commit", "-m", message])
+    }
+
+    func runGit(_ arguments: [String]) throws {
+        try Self.runGit(arguments, cwd: repo)
+    }
+
+    private func worktreeURL(_ descriptor: GitWorktreeDescriptor) -> URL {
+        URL(fileURLWithPath: descriptor.path, isDirectory: true).standardizedFileURL
+    }
+
+    private static func runGit(_ arguments: [String], cwd: URL) throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+        process.arguments = arguments
+        process.currentDirectoryURL = cwd
+        var environment = ProcessInfo.processInfo.environment
+        environment["GIT_CONFIG_NOSYSTEM"] = "1"
+        environment["GIT_CONFIG_GLOBAL"] = "/dev/null"
+        environment["GIT_TERMINAL_PROMPT"] = "0"
+        process.environment = environment
+        let output = Pipe()
+        process.standardOutput = output
+        process.standardError = output
+        try process.run()
+        process.waitUntilExit()
+        let data = output.fileHandleForReading.readDataToEndOfFile()
+        let text = String(decoding: data, as: UTF8.self)
+        guard process.terminationStatus == 0 else {
+            throw NSError(
+                domain: "GitWorktreeIncludeCopyTests.git",
+                code: Int(process.terminationStatus),
+                userInfo: [NSLocalizedDescriptionKey: "git \(arguments.joined(separator: " ")) failed: \(text)"]
+            )
+        }
+    }
+}

--- a/docs/worktrees.md
+++ b/docs/worktrees.md
@@ -1,0 +1,81 @@
+# Worktrees
+
+RepoPrompt CE can create Git worktrees for MCP tools and Agent Mode. For app-managed worktrees, you can ask RepoPrompt to copy selected local files that are useful for development but should not be committed.
+
+The common example is a local environment file:
+
+```text
+main checkout has .env.local
+RepoPrompt creates .repoprompt-worktrees/my-repo-agent
+RepoPrompt copies .env.local into the new worktree
+agent starts with the same local setup
+```
+
+## Copying local ignored files with `.worktreeinclude`
+
+Create a file named `.worktreeinclude` at the repository root of your main checkout.
+
+RepoPrompt reads that file when it creates a new app-managed worktree. The file uses `.gitignore` syntax: one pattern per line, `#` comments, directory patterns, globs, and `!` negation patterns work the same way they do in `.gitignore`.
+
+Only files that pass both checks are copied:
+
+1. Git already treats the file as ignored, using the repository's normal ignore rules.
+2. The file matches `.worktreeinclude` with a positive final match.
+
+That means tracked files are not copied from your dirty working tree, and ordinary untracked files are not copied just because they match `.worktreeinclude`. The file must already be Git-ignored.
+
+## Example
+
+```gitignore
+# .gitignore
+.env.local
+config/secrets.json
+certs/local/
+```
+
+```gitignore
+# .worktreeinclude
+.env.local
+config/secrets.json
+certs/local/
+certs/local/**
+
+# Keep this one out even though the directory is included.
+!certs/local/production.pem
+```
+
+With those files in the repo root, RepoPrompt copies ignored local files such as:
+
+- `.env.local`
+- `config/secrets.json`
+- files under `certs/local/`
+
+RepoPrompt does not copy:
+
+- tracked files, even if their names match `.worktreeinclude`
+- unignored untracked files
+- files excluded by a later `!` pattern
+- symlinks, directories, non-regular files, unsafe paths, or files that would overwrite an existing destination file
+
+## Where it applies
+
+`.worktreeinclude` copying only applies to RepoPrompt-managed worktrees, such as worktrees created under the app's `.repoprompt-worktrees` container by Agent Mode or `manage_worktree create`.
+
+If you create a worktree at an explicit external path with `allow_external_path=true`, RepoPrompt creates the worktree but does not copy `.worktreeinclude` files into it.
+
+## Output and diagnostics
+
+Successful copying is silent. If everything requested is copied, RepoPrompt does not add extra output.
+
+If something goes wrong after the worktree was created, RepoPrompt keeps the worktree and reports the copy issue where it can:
+
+- `manage_worktree create` may include a warning in its output.
+- Agent Mode and descriptor-only flows record production-safe diagnostics for debugging.
+
+For example, if the destination file already exists, the worktree still exists and the warning explains that the file was skipped rather than overwritten.
+
+## Be careful with broad patterns
+
+RepoPrompt does not add a hidden file-count or size limit to `.worktreeinclude` copying. If you write a broad pattern such as `**` or `local-cache/**`, RepoPrompt may copy a lot of local data into every new app-managed worktree.
+
+Use narrow patterns for the files agents actually need. A good `.worktreeinclude` is usually a short list of local setup files, not a second copy of your whole ignored cache directory.


### PR DESCRIPTION
## Summary

- Add `.worktreeinclude` support for RepoPrompt-managed Git worktrees.
- Copy only local files that are both Git-ignored and positively matched by repo-root `.worktreeinclude` patterns.
- Surface copy warnings through `manage_worktree create`, keep descriptor-only flows diagnostic-only, and document the behavior in `docs/worktrees.md`.

## Testing

- [x] `make dev-format`
- [x] `make dev-format-check`
- [x] commit preflight guardrails / staged secret scan
- [ ] I still need to do more end-to-end testing before this is ready to merge.

Notes: focused Swift tests were attempted locally, but the local toolchain currently fails before RepoPrompt tests run due dependency/tooling issues:

- `KeyboardShortcuts` preview macro failure: `PreviewsMacros.SwiftUIView` not found.
- SwiftLint/SourceKitten `sourcekitdInProc` loading failure during push preflight lint.
