### PR TITLE
Show Git worktree context in Agent sidebar

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentWorkspaceRootsSidebarStore.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentWorkspaceRootsSidebarStore.swift
@@ -5,42 +5,45 @@ struct AgentWorkspaceRootRow: Identifiable, Equatable {
     let id: UUID
     let name: String
     let fullPath: String
+    let standardizedFullPath: String
     let isPrimary: Bool
     let canMoveUp: Bool
     let canMoveDown: Bool
-    /// Bound-worktree visual identity for the active Agent session, when this
-    /// logical root is bound (Item 10). Populated by the roots section view,
-    /// not by `rows(from:)` — the store stays session-agnostic.
+    let gitContext: GitWorktreeContextSummary?
     let worktree: AgentWorktreeIndicator?
 
     init(
         id: UUID,
         name: String,
         fullPath: String,
+        standardizedFullPath: String? = nil,
         isPrimary: Bool,
         canMoveUp: Bool,
         canMoveDown: Bool,
+        gitContext: GitWorktreeContextSummary? = nil,
         worktree: AgentWorktreeIndicator? = nil
     ) {
         self.id = id
         self.name = name
         self.fullPath = fullPath
+        self.standardizedFullPath = standardizedFullPath ?? StandardizedPath.absolute(fullPath)
         self.isPrimary = isPrimary
         self.canMoveUp = canMoveUp
         self.canMoveDown = canMoveDown
+        self.gitContext = gitContext
         self.worktree = worktree
     }
 
-    /// Returns a copy of this row carrying `worktree` as its bound-worktree
-    /// identity. Used to enrich store-derived rows with active-session state.
     func withWorktree(_ worktree: AgentWorktreeIndicator?) -> AgentWorkspaceRootRow {
         AgentWorkspaceRootRow(
             id: id,
             name: name,
             fullPath: fullPath,
+            standardizedFullPath: standardizedFullPath,
             isPrimary: isPrimary,
             canMoveUp: canMoveUp,
             canMoveDown: canMoveDown,
+            gitContext: gitContext,
             worktree: worktree
         )
     }
@@ -54,6 +57,8 @@ final class AgentWorkspaceRootsSidebarStore: ObservableObject {
 
     private let rootProjections: @MainActor () -> [WorkspaceRootShellProjection]
     private let rootChanges: AnyPublisher<Void, Never>
+    private let gitContextLookup: @MainActor (String) -> GitWorktreeContextSummary?
+    private let gitContextChanges: AnyPublisher<Void, Never>
     private let workspaceManager: WorkspaceManagerViewModel
     let windowID: Int
 
@@ -67,11 +72,15 @@ final class AgentWorkspaceRootsSidebarStore: ObservableObject {
     init(
         rootProjections: @escaping @MainActor () -> [WorkspaceRootShellProjection],
         rootChanges: AnyPublisher<Void, Never>,
+        gitContextLookup: @escaping @MainActor (String) -> GitWorktreeContextSummary? = { _ in nil },
+        gitContextChanges: AnyPublisher<Void, Never> = Empty<Void, Never>().eraseToAnyPublisher(),
         workspaceManager: WorkspaceManagerViewModel,
         windowID: Int
     ) {
         self.rootProjections = rootProjections
         self.rootChanges = rootChanges
+        self.gitContextLookup = gitContextLookup
+        self.gitContextChanges = gitContextChanges
         self.workspaceManager = workspaceManager
         self.windowID = windowID
 
@@ -83,16 +92,21 @@ final class AgentWorkspaceRootsSidebarStore: ObservableObject {
         resnapshotTask?.cancel()
     }
 
-    static func rows(from projections: [WorkspaceRootShellProjection]) -> [AgentWorkspaceRootRow] {
+    static func rows(
+        from projections: [WorkspaceRootShellProjection],
+        gitContextLookup: (String) -> GitWorktreeContextSummary? = { _ in nil }
+    ) -> [AgentWorkspaceRootRow] {
         let rootCount = projections.count
         return projections.enumerated().map { index, projection in
             AgentWorkspaceRootRow(
                 id: projection.id,
                 name: projection.name,
                 fullPath: projection.fullPath,
+                standardizedFullPath: projection.standardizedFullPath,
                 isPrimary: rootCount > 1 && index == 0,
                 canMoveUp: rootCount > 1 && index > 0,
-                canMoveDown: rootCount > 1 && index < rootCount - 1
+                canMoveDown: rootCount > 1 && index < rootCount - 1,
+                gitContext: gitContextLookup(projection.standardizedFullPath)
             )
         }
     }
@@ -149,6 +163,14 @@ final class AgentWorkspaceRootsSidebarStore: ObservableObject {
             }
             .store(in: &cancellables)
 
+        gitContextChanges
+            .sink { [weak self] in
+                Task { @MainActor in
+                    self?.scheduleResnapshot()
+                }
+            }
+            .store(in: &cancellables)
+
         workspaceManager.objectWillChange
             .sink { [weak self] _ in
                 Task { @MainActor in
@@ -170,7 +192,10 @@ final class AgentWorkspaceRootsSidebarStore: ObservableObject {
     }
 
     private func resnapshot() {
-        let nextRootRows = Self.rows(from: rootProjections())
+        let nextRootRows = Self.rows(
+            from: rootProjections(),
+            gitContextLookup: gitContextLookup
+        )
         let nextWorkspaceLabel = Self.workspaceLabel(for: workspaceManager.activeWorkspace)
         let nextIsExitDisabled = workspaceManager.activeWorkspace?.isSystemWorkspace ?? true
 

--- a/Sources/RepoPrompt/Features/AgentMode/Views/AgentModeView.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/AgentModeView.swift
@@ -36,6 +36,8 @@ struct AgentModeView: View {
         _rootsSidebarStore = StateObject(wrappedValue: AgentWorkspaceRootsSidebarStore(
             rootProjections: { windowState.workspaceFilesViewModel.visibleRootShellProjections },
             rootChanges: windowState.workspaceFilesViewModel.objectWillChange.map { _ in () }.eraseToAnyPublisher(),
+            gitContextLookup: { promptManager.gitViewModel.gitWorktreeContext(forStandardizedRootPath: $0) },
+            gitContextChanges: promptManager.gitViewModel.gitWorktreeContextChanges,
             workspaceManager: windowState.workspaceManager,
             windowID: windowState.windowID
         ))

--- a/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentWorkspaceRootsSectionView.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentWorkspaceRootsSectionView.swift
@@ -148,8 +148,7 @@ struct AgentWorkspaceRootsSectionView: View {
         if let direct = worktreeIndicatorsByLogicalRootPath[row.fullPath] {
             return direct
         }
-        let standardized = URL(fileURLWithPath: row.fullPath).standardizedFileURL.path
-        return worktreeIndicatorsByLogicalRootPath[standardized]
+        return worktreeIndicatorsByLogicalRootPath[row.standardizedFullPath]
     }
 
     /// Resolves the active worktree merge attention for `row`, if any.
@@ -157,8 +156,7 @@ struct AgentWorkspaceRootsSectionView: View {
         if let direct = worktreeMergeAttentionsByLogicalRootPath[row.fullPath] {
             return direct
         }
-        let standardized = URL(fileURLWithPath: row.fullPath).standardizedFileURL.path
-        return worktreeMergeAttentionsByLogicalRootPath[standardized]
+        return worktreeMergeAttentionsByLogicalRootPath[row.standardizedFullPath]
     }
 
     private var estimatedFolderListHeight: CGFloat {
@@ -354,6 +352,7 @@ struct AgentWorkspaceRootsSectionView: View {
                 .font(fontPreset.swiftUIFont(sizeAtNormal: 12))
                 .lineLimit(1)
                 .truncationMode(.middle)
+                .layoutPriority(1)
 
             if row.isPrimary {
                 Text("PRIMARY")
@@ -365,6 +364,11 @@ struct AgentWorkspaceRootsSectionView: View {
                         Capsule()
                             .strokeBorder(Color.secondary.opacity(0.35), lineWidth: 0.75)
                     )
+            }
+
+            if let gitContext = row.gitContext {
+                gitContextCapsule(gitContext)
+                    .layoutPriority(-1)
             }
 
             if let worktree = row.worktree {
@@ -428,6 +432,31 @@ struct AgentWorkspaceRootsSectionView: View {
             hoveredRootID = hovered ? row.id : nil
         }
         .hoverTooltip(row.fullPath, .top)
+    }
+
+    // MARK: - Git Context Capsule
+
+    private func gitContextCapsule(_ context: GitWorktreeContextSummary) -> some View {
+        HStack(spacing: fontPreset.scaledClamped(3, max: 4)) {
+            Image(systemName: "point.topleft.down.curvedto.point.bottomright.up")
+                .font(fontPreset.swiftUIFont(sizeAtNormal: 7, weight: .semibold))
+            Text(context.breadcrumbText)
+                .font(fontPreset.swiftUIFont(sizeAtNormal: 8, weight: .medium))
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .frame(maxWidth: fontPreset.scaledClamped(118, min: 72, max: 150), alignment: .leading)
+        }
+        .foregroundColor(.secondary)
+        .padding(.horizontal, fontPreset.scaledClamped(4, max: 6))
+        .padding(.vertical, fontPreset.scaledClamped(1, max: 2))
+        .background(
+            Capsule().fill(Color.secondary.opacity(0.10))
+        )
+        .overlay(
+            Capsule().strokeBorder(Color.secondary.opacity(0.35), lineWidth: 0.75)
+        )
+        .hoverTooltip(context.tooltipText, .top)
+        .accessibilityLabel(context.accessibilityText)
     }
 
     // MARK: - Worktree Capsule

--- a/Sources/RepoPrompt/Features/WorkspaceFiles/ViewModels/GitViewModel.swift
+++ b/Sources/RepoPrompt/Features/WorkspaceFiles/ViewModels/GitViewModel.swift
@@ -30,9 +30,40 @@ final class GitViewModel: ObservableObject {
     @Published var errorMessage: String?
     @Published var availableRootFolders: [FolderViewModel] = []
     @Published private var gitEnabledStatus: [String: Bool] = [:] // fullPath -> isGitRepo
+    @Published private(set) var gitWorktreeContextsByRootPath: [String: GitWorktreeContextSummary] = [:]
     @Published private(set) var fileSelectionStates: [String: Bool] = [:] { // relativePath -> isSelected
         didSet {
             assert(Thread.isMainThread, "fileSelectionStates mutated off main thread")
+        }
+    }
+
+    var gitWorktreeContextChanges: AnyPublisher<Void, Never> {
+        $gitWorktreeContextsByRootPath
+            .map { _ in () }
+            .receive(on: RunLoop.main)
+            .eraseToAnyPublisher()
+    }
+
+    func gitWorktreeContext(forStandardizedRootPath path: String) -> GitWorktreeContextSummary? {
+        gitWorktreeContextsByRootPath[path]
+    }
+
+    private func setGitWorktreeContextsByRootPath(_ contexts: [String: GitWorktreeContextSummary]) {
+        guard gitWorktreeContextsByRootPath != contexts else { return }
+        gitWorktreeContextsByRootPath = contexts
+    }
+
+    private func setGitWorktreeContext(_ context: GitWorktreeContextSummary?, forStandardizedRootPath path: String) {
+        if let context {
+            guard gitWorktreeContextsByRootPath[path] != context else { return }
+            var next = gitWorktreeContextsByRootPath
+            next[path] = context
+            gitWorktreeContextsByRootPath = next
+        } else {
+            guard gitWorktreeContextsByRootPath[path] != nil else { return }
+            var next = gitWorktreeContextsByRootPath
+            next.removeValue(forKey: path)
+            gitWorktreeContextsByRootPath = next
         }
     }
 
@@ -130,6 +161,14 @@ final class GitViewModel: ObservableObject {
         availableRemoteBranches = snapshot.availableRemoteBranches
         availableTags = snapshot.availableTags
         currentGitRootPath = snapshot.gitRootPath
+        if !snapshot.rootPath.isEmpty {
+            let standardizedRootPath = if selectedRootFolder?.fullPath == snapshot.rootPath {
+                selectedRootFolder?.standardizedFullPath ?? Self.normalizeForComparison(snapshot.rootPath)
+            } else {
+                Self.normalizeForComparison(snapshot.rootPath)
+            }
+            setGitWorktreeContext(snapshot.gitWorktreeContext, forStandardizedRootPath: standardizedRootPath)
+        }
         latestStatusGeneration = snapshot.generation
         latestStatusRootPath = snapshot.rootPath
 
@@ -297,21 +336,24 @@ final class GitViewModel: ObservableObject {
     func updateRootFolders(_ rootFolders: [FolderViewModel]) {
         availableRootFolders = rootFolders
 
-        // Prune gitEnabledStatus for removed roots
         gitEnabledStatus = gitEnabledStatus.filter { key, _ in
             rootFolders.contains { $0.fullPath == key }
         }
+        let visibleStandardizedPaths = Set(rootFolders.map(\.standardizedFullPath))
+        setGitWorktreeContextsByRootPath(gitWorktreeContextsByRootPath.filter { key, _ in
+            visibleStandardizedPaths.contains(key)
+        })
 
         let rootPaths = rootFolders.map(\.fullPath)
-        let standardizedRootPaths = rootPaths.map(Self.normalizeForComparison)
-        guard standardizedRootPaths != lastVisibleRootPaths else { return }
+        let standardizedRootPaths = rootFolders.map(\.standardizedFullPath)
+        let standardizedPathByRootPath = Dictionary(uniqueKeysWithValues: rootFolders.map { ($0.fullPath, $0.standardizedFullPath) })
         lastVisibleRootPaths = standardizedRootPaths
         rootUpdateGeneration &+= 1
         let generation = rootUpdateGeneration
         let inclusionMode = gitDiffInclusionMode
 
         rootUpdateTask?.cancel()
-        rootUpdateTask = Task { [weak self, statusActor, rootFolders, rootPaths, standardizedRootPaths, generation, inclusionMode] in
+        rootUpdateTask = Task { [weak self, statusActor, rootFolders, rootPaths, standardizedRootPaths, standardizedPathByRootPath, generation, inclusionMode] in
             try? await Task.sleep(nanoseconds: 150_000_000)
             guard !Task.isCancelled else { return }
             let currentInclusionMode = await MainActor.run {
@@ -329,12 +371,18 @@ final class GitViewModel: ObservableObject {
                 guard standardizedRootPaths == lastVisibleRootPaths else { return (false, nil) }
 
                 var map: [String: Bool] = [:]
+                var contexts: [String: GitWorktreeContextSummary] = [:]
                 for detection in detections {
                     map[detection.rootPath] = detection.isGitRepo
+                    if let context = detection.gitWorktreeContext {
+                        let standardizedPath = standardizedPathByRootPath[detection.rootPath]
+                            ?? StandardizedPath.absolute(detection.rootPath)
+                        contexts[standardizedPath] = context
+                    }
                 }
                 gitEnabledStatus = map
+                setGitWorktreeContextsByRootPath(contexts)
 
-                // Update selected folder (prefer git-enabled roots)
                 let gitFolders = gitEnabledRootFolders
                 if selectedRootFolder == nil ||
                     !gitFolders.contains(where: { $0.id == self.selectedRootFolder?.id })
@@ -616,6 +664,7 @@ final class GitViewModel: ObservableObject {
         latestStatusGeneration = 0
         latestStatusRootPath = nil
         currentGitRootPath = nil
+        setGitWorktreeContextsByRootPath([:])
         availableBranches = []
         availableRemoteBranches = []
         availableTags = []

--- a/Sources/RepoPrompt/Infrastructure/VCS/GitStatusActor.swift
+++ b/Sources/RepoPrompt/Infrastructure/VCS/GitStatusActor.swift
@@ -19,6 +19,7 @@ actor GitStatusActor {
         let rootPath: String
         let isGitRepo: Bool // Kept for compatibility; true for any VCS (git or jj)
         let backendKind: VCSBackendKind?
+        let gitWorktreeContext: GitWorktreeContextSummary?
     }
 
     struct GitStatusSnapshot {
@@ -32,6 +33,7 @@ actor GitStatusActor {
         let availableBranches: [VCSBranch]
         let availableRemoteBranches: [VCSBranch]
         let availableTags: [VCSTag]
+        let gitWorktreeContext: GitWorktreeContextSummary?
 
         let totalAdditions: Int
         let totalDeletions: Int
@@ -55,6 +57,18 @@ actor GitStatusActor {
         let isRepo: Bool
         let repoRootPath: String?
         let backendKind: VCSBackendKind?
+        let resolvedRepo: VCSResolvedRepo?
+        let gitWorktreeContext: GitWorktreeContextSummary?
+    }
+
+    private struct RootContextRequest {
+        let rootPath: String
+        let resolved: VCSResolvedRepo
+    }
+
+    private struct RootContextResult {
+        let rootPath: String
+        let context: GitWorktreeContextSummary?
     }
 
     /// rootPath -> repo info
@@ -113,15 +127,12 @@ actor GitStatusActor {
         let removedRoots = previousRoots.subtracting(currentRoots)
         workspaceRoots = roots
 
-        // Drop stale detections for removed roots
         rootInfos = rootInfos.filter { key, _ in currentRoots.contains(key) }
 
-        // Avoid clearing the shared VCS cache on every root publication; only invalidate removed roots.
         for root in removedRoots {
             await vcsService.invalidateCache(for: URL(fileURLWithPath: root))
         }
 
-        // Run detection in parallel for added/missing roots only.
         let rootsToDetect = roots.filter { rootInfos[$0] == nil }
         await withTaskGroup(of: (String, RootInfo).self) { group in
             for root in rootsToDetect {
@@ -131,10 +142,18 @@ actor GitStatusActor {
                         return (root, RootInfo(
                             isRepo: true,
                             repoRootPath: resolved.rootURL.path,
-                            backendKind: resolved.backendKind
+                            backendKind: resolved.backendKind,
+                            resolvedRepo: resolved,
+                            gitWorktreeContext: nil
                         ))
                     } else {
-                        return (root, RootInfo(isRepo: false, repoRootPath: nil, backendKind: nil))
+                        return (root, RootInfo(
+                            isRepo: false,
+                            repoRootPath: nil,
+                            backendKind: nil,
+                            resolvedRepo: nil,
+                            gitWorktreeContext: nil
+                        ))
                     }
                 }
             }
@@ -144,13 +163,64 @@ actor GitStatusActor {
             }
         }
 
+        await refreshGitWorktreeContexts(for: roots)
+
         return roots.map { root in
             let info = rootInfos[root]
             return RepoDetection(
                 rootPath: root,
                 isGitRepo: info?.isRepo ?? false,
-                backendKind: info?.backendKind
+                backendKind: info?.backendKind,
+                gitWorktreeContext: info?.gitWorktreeContext
             )
+        }
+    }
+
+    private func refreshGitWorktreeContexts(for roots: [String]) async {
+        let requests = roots.compactMap { root -> RootContextRequest? in
+            guard let info = rootInfos[root],
+                  info.backendKind == .git,
+                  let resolved = info.resolvedRepo
+            else { return nil }
+            return RootContextRequest(rootPath: root, resolved: resolved)
+        }
+        guard !requests.isEmpty else { return }
+
+        let grouped = Dictionary(grouping: requests) { request in
+            StandardizedPath.absolute(request.resolved.rootURL.path)
+        }
+
+        await withTaskGroup(of: [RootContextResult].self) { group in
+            for groupRequests in grouped.values {
+                group.addTask { [vcsService] in
+                    guard let resolved = groupRequests.first?.resolved else { return [] }
+                    let worktrees = try? await vcsService.listGitWorktrees(for: resolved)
+                    var results: [RootContextResult] = []
+                    results.reserveCapacity(groupRequests.count)
+                    for request in groupRequests {
+                        let context = await vcsService.gitWorktreeContext(
+                            for: URL(fileURLWithPath: request.rootPath),
+                            resolved: request.resolved,
+                            worktrees: worktrees
+                        )
+                        results.append(RootContextResult(rootPath: request.rootPath, context: context))
+                    }
+                    return results
+                }
+            }
+
+            for await results in group {
+                for result in results {
+                    guard let current = rootInfos[result.rootPath] else { continue }
+                    rootInfos[result.rootPath] = RootInfo(
+                        isRepo: current.isRepo,
+                        repoRootPath: current.repoRootPath,
+                        backendKind: current.backendKind,
+                        resolvedRepo: current.resolvedRepo,
+                        gitWorktreeContext: result.context
+                    )
+                }
+            }
         }
     }
 
@@ -235,6 +305,7 @@ actor GitStatusActor {
                 availableBranches: [],
                 availableRemoteBranches: [],
                 availableTags: [],
+                gitWorktreeContext: nil,
                 totalAdditions: 0,
                 totalDeletions: 0,
                 commitDelta: nil,
@@ -270,6 +341,7 @@ actor GitStatusActor {
                 availableBranches: [],
                 availableRemoteBranches: [],
                 availableTags: [],
+                gitWorktreeContext: nil,
                 totalAdditions: 0,
                 totalDeletions: 0,
                 commitDelta: nil,
@@ -314,12 +386,14 @@ actor GitStatusActor {
         async let branchesTask = (try? backend.getLocalBranches(at: repoURL, limit: 50))
         async let remoteBranchesTask = (try? backend.getRemoteBranches(at: repoURL, limit: 10))
         async let tagsTask = (try? backend.getTags(at: repoURL, limit: 50))
+        async let gitWorktreeContextTask = vcsService.gitWorktreeContext(for: URL(fileURLWithPath: rootPath))
 
         var files: [VCSUncommittedFile] = []
         var currentBranch: String?
         var branches: [VCSBranch] = []
         var remoteBranches: [VCSBranch] = []
         var tags: [VCSTag] = []
+        var gitWorktreeContext: GitWorktreeContextSummary?
         var errorMsg: String?
         var delta: (ahead: Int, behind: Int)?
 
@@ -332,6 +406,14 @@ actor GitStatusActor {
         branches = await branchesTask ?? []
         remoteBranches = await remoteBranchesTask ?? []
         tags = await tagsTask ?? []
+        gitWorktreeContext = await gitWorktreeContextTask ?? rootInfo?.gitWorktreeContext
+        rootInfos[rootPath] = RootInfo(
+            isRepo: true,
+            repoRootPath: gitRoot,
+            backendKind: backendKind,
+            resolvedRepo: backendKind.map { VCSResolvedRepo(rootURL: repoURL, backendKind: $0) },
+            gitWorktreeContext: gitWorktreeContext
+        )
 
         // Ahead/behind for non-tag branches (only when comparing to a branch, not HEAD)
         if selectedDiffBranch != "HEAD" {
@@ -389,6 +471,7 @@ actor GitStatusActor {
             availableBranches: cappedBranches,
             availableRemoteBranches: cappedRemoteBranches,
             availableTags: tags,
+            gitWorktreeContext: gitWorktreeContext,
             totalAdditions: totalAdd,
             totalDeletions: totalDel,
             commitDelta: delta,

--- a/Sources/RepoPrompt/Infrastructure/VCS/GitWorktreeModels.swift
+++ b/Sources/RepoPrompt/Infrastructure/VCS/GitWorktreeModels.swift
@@ -74,6 +74,110 @@ public struct GitWorktreeDescriptor: Sendable, Equatable, Hashable {
     }
 }
 
+public struct GitWorktreeContextSummary: Sendable, Equatable, Hashable {
+    public let repositoryID: String
+    public let repoKey: String
+    public let repositoryDisplayName: String
+    public let worktreeID: String?
+    public let worktreePath: String
+    public let worktreeName: String
+    public let branch: String?
+    public let head: String?
+    public let isDetached: Bool
+
+    public init(
+        repositoryID: String,
+        repoKey: String,
+        repositoryDisplayName: String,
+        worktreeID: String?,
+        worktreePath: String,
+        worktreeName: String,
+        branch: String?,
+        head: String?,
+        isDetached: Bool
+    ) {
+        self.repositoryID = repositoryID
+        self.repoKey = repoKey
+        self.repositoryDisplayName = repositoryDisplayName
+        self.worktreeID = worktreeID
+        self.worktreePath = worktreePath
+        self.worktreeName = worktreeName
+        self.branch = Self.normalizedOptional(branch)
+        self.head = Self.normalizedOptional(head)
+        self.isDetached = isDetached
+    }
+
+    public init(descriptor: GitWorktreeDescriptor) {
+        self.init(
+            repositoryID: descriptor.repository.repositoryID,
+            repoKey: descriptor.repository.repoKey,
+            repositoryDisplayName: descriptor.repository.displayName,
+            worktreeID: descriptor.worktreeID,
+            worktreePath: descriptor.path,
+            worktreeName: descriptor.name ?? Self.fallbackWorktreeName(from: descriptor.path),
+            branch: descriptor.branch,
+            head: descriptor.head,
+            isDetached: descriptor.isDetached
+        )
+    }
+
+    public var branchDisplayText: String? {
+        if let branch {
+            return branch
+        }
+        if isDetached, let short = shortHead {
+            return "detached @ \(short)"
+        }
+        if let short = shortHead {
+            return "HEAD @ \(short)"
+        }
+        return nil
+    }
+
+    public var breadcrumbText: String {
+        [repositoryDisplayName, worktreeName, branchDisplayText]
+            .compactMap(\.self)
+            .filter { !$0.isEmpty }
+            .joined(separator: " / ")
+    }
+
+    public var tooltipText: String {
+        let branchText = branchDisplayText ?? "unknown branch"
+        var parts = [
+            "Repository: \(repositoryDisplayName)",
+            "Worktree: \(worktreeName)",
+            "Branch: \(branchText)",
+            "Path: \(worktreePath)"
+        ]
+        if let head {
+            parts.insert("HEAD: \(head)", at: 3)
+        }
+        return parts.joined(separator: "\n")
+    }
+
+    public var accessibilityText: String {
+        let branchText = branchDisplayText ?? "unknown branch"
+        return "Git repository \(repositoryDisplayName), worktree \(worktreeName), branch \(branchText)"
+    }
+
+    private var shortHead: String? {
+        guard let head else { return nil }
+        return String(head.prefix(7))
+    }
+
+    private static func normalizedOptional(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty else {
+            return nil
+        }
+        return trimmed
+    }
+
+    private static func fallbackWorktreeName(from path: String) -> String {
+        let last = URL(fileURLWithPath: path).lastPathComponent
+        return last.isEmpty ? "worktree" : last
+    }
+}
+
 public struct GitWorktreeCreateRequest: Sendable, Equatable {
     public let path: URL
     public let branch: String?

--- a/Sources/RepoPrompt/Infrastructure/VCS/VCSService.swift
+++ b/Sources/RepoPrompt/Infrastructure/VCS/VCSService.swift
@@ -443,10 +443,111 @@ public extension VCSService {
         guard let resolved else {
             throw VCSError.notARepository(path: repoURL.path)
         }
+        return try await listGitWorktrees(for: resolved)
+    }
+
+    func listGitWorktrees(for resolved: VCSResolvedRepo) async throws -> [GitWorktreeDescriptor] {
         guard resolved.backendKind == .git else {
             throw VCSError.unsupportedOperation(operation: "list_worktrees", backend: resolved.backendKind)
         }
         return try await gitBackend().listWorktrees(at: resolved.rootURL)
+    }
+
+    /// Resolve the read-only Git repo/worktree/branch context for a filesystem path.
+    ///
+    /// The input may be either a worktree root or a subdirectory inside a worktree.
+    /// Non-Git roots return `nil`; no checkout, branch switching, or worktree mutation
+    /// is performed.
+    func gitWorktreeContext(for url: URL) async -> GitWorktreeContextSummary? {
+        guard let resolved = await resolveRepo(from: url) else { return nil }
+        return await gitWorktreeContext(for: url, resolved: resolved)
+    }
+
+    func gitWorktreeContext(for url: URL, resolved: VCSResolvedRepo) async -> GitWorktreeContextSummary? {
+        guard resolved.backendKind == .git else { return nil }
+        do {
+            let worktrees = try await listGitWorktrees(for: resolved)
+            return await gitWorktreeContext(for: url, resolved: resolved, worktrees: worktrees)
+        } catch {
+            return await gitWorktreeContext(for: url, resolved: resolved, worktrees: nil)
+        }
+    }
+
+    func gitWorktreeContext(
+        for url: URL,
+        resolved: VCSResolvedRepo,
+        worktrees: [GitWorktreeDescriptor]?
+    ) async -> GitWorktreeContextSummary? {
+        guard resolved.backendKind == .git else { return nil }
+
+        if let worktrees,
+           let summary = gitWorktreeContextFromList(
+               for: url,
+               resolved: resolved,
+               worktrees: worktrees
+           )
+        {
+            return summary
+        }
+
+        return await fallbackGitWorktreeContext(for: resolved.rootURL)
+    }
+
+    private nonisolated func gitWorktreeContextFromList(
+        for url: URL,
+        resolved: VCSResolvedRepo,
+        worktrees: [GitWorktreeDescriptor]
+    ) -> GitWorktreeContextSummary? {
+        let inputPath = StandardizedPath.absolute(url.path)
+        let resolvedRootPath = StandardizedPath.absolute(resolved.rootURL.path)
+        if let exact = worktrees.first(where: { StandardizedPath.absolute($0.path) == resolvedRootPath }) {
+            return GitWorktreeContextSummary(descriptor: exact)
+        }
+        if let contained = worktrees.first(where: { descriptor in
+            let worktreePath = StandardizedPath.absolute(descriptor.path)
+            return StandardizedPath.isDescendant(inputPath, of: worktreePath)
+                || StandardizedPath.isDescendant(resolvedRootPath, of: worktreePath)
+        }) {
+            return GitWorktreeContextSummary(descriptor: contained)
+        }
+        return nil
+    }
+
+    private func fallbackGitWorktreeContext(for repoURL: URL) async -> GitWorktreeContextSummary? {
+        let repoRootPath = StandardizedPath.absolute(repoURL.path)
+        guard let layout = gitRepositoryLayout(forRepoRoot: repoURL) else {
+            return nil
+        }
+        let mainWorktreeRoot = layout.commonDir.deletingLastPathComponent()
+        let identity = GitWorktreeIdentity.repositoryIdentity(
+            commonGitDir: layout.commonDir,
+            mainWorktreeRoot: mainWorktreeRoot
+        )
+        let branch = try? await gitBackend().getCurrentBranch(at: repoURL)
+        let head = try? await gitBackend().getHeadID(at: repoURL)
+        let worktreeName = Self.fallbackName(from: repoRootPath, fallback: "worktree")
+        let worktreeID = GitWorktreeIdentity.worktreeID(
+            repositoryID: identity.repositoryID,
+            gitDir: layout.gitDir,
+            isMain: !layout.isWorktree,
+            path: layout.workTreeRoot
+        )
+        return GitWorktreeContextSummary(
+            repositoryID: identity.repositoryID,
+            repoKey: identity.repoKey,
+            repositoryDisplayName: identity.displayName,
+            worktreeID: worktreeID,
+            worktreePath: repoRootPath,
+            worktreeName: worktreeName,
+            branch: branch,
+            head: head,
+            isDetached: branch == nil && head != nil
+        )
+    }
+
+    private nonisolated static func fallbackName(from path: String, fallback: String) -> String {
+        let name = URL(fileURLWithPath: path).lastPathComponent
+        return name.isEmpty ? fallback : name
     }
 
     /// Create a Git worktree for a repository.

--- a/Tests/RepoPromptTests/AgentMode/AgentWorkspaceRootsSidebarStoreTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentWorkspaceRootsSidebarStoreTests.swift
@@ -17,7 +17,9 @@ final class AgentWorkspaceRootsSidebarStoreTests: XCTestCase {
         XCTAssertEqual(rows.map(\.isPrimary), [true, false, false])
         XCTAssertEqual(rows.map(\.canMoveUp), [false, true, true])
         XCTAssertEqual(rows.map(\.canMoveDown), [true, true, false])
+        XCTAssertEqual(rows.map(\.standardizedFullPath), [rootA.standardizedFullPath, rootB.standardizedFullPath, rootC.standardizedFullPath])
         XCTAssertEqual(rows.map(\.worktree), [nil, nil, nil])
+        XCTAssertEqual(rows.map(\.gitContext), [nil, nil, nil])
     }
 
     func testRowsDoNotMarkSingleRootAsPrimaryOrMovable() {
@@ -30,11 +32,28 @@ final class AgentWorkspaceRootsSidebarStoreTests: XCTestCase {
                 id: root.id,
                 name: "Only",
                 fullPath: "/tmp/Only",
+                standardizedFullPath: root.standardizedFullPath,
                 isPrimary: false,
                 canMoveUp: false,
                 canMoveDown: false
             )
         ])
+    }
+
+    func testRowsAttachGitContextByStandardizedRootPathWithoutChangingOrder() {
+        let rootA = makeProjection(name: "A", path: "/tmp/A")
+        let rootB = makeProjection(name: "B", path: "/tmp/B")
+        let contextB = makeGitContext(repository: "Repo", worktree: "B", branch: "feature/b")
+
+        let rows = AgentWorkspaceRootsSidebarStore.rows(from: [rootA, rootB]) { path in
+            path == rootB.standardizedFullPath ? contextB : nil
+        }
+
+        XCTAssertEqual(rows.map(\.id), [rootA.id, rootB.id])
+        XCTAssertEqual(rows.map(\.isPrimary), [true, false])
+        XCTAssertNil(rows[0].gitContext)
+        XCTAssertEqual(rows[1].gitContext, contextB)
+        XCTAssertEqual(rows[1].gitContext?.breadcrumbText, "Repo / B / feature/b")
     }
 
     // MARK: - Worktree indicators (Item 10)
@@ -57,9 +76,30 @@ final class AgentWorkspaceRootsSidebarStoreTests: XCTestCase {
         XCTAssertEqual(enriched.id, base.id)
         XCTAssertEqual(enriched.name, base.name)
         XCTAssertEqual(enriched.fullPath, base.fullPath)
+        XCTAssertEqual(enriched.standardizedFullPath, base.standardizedFullPath)
         XCTAssertEqual(enriched.isPrimary, base.isPrimary)
         XCTAssertEqual(enriched.canMoveUp, base.canMoveUp)
         XCTAssertEqual(enriched.canMoveDown, base.canMoveDown)
+        XCTAssertEqual(enriched.gitContext, base.gitContext)
+    }
+
+    func testWithWorktreePreservesGitContext() {
+        let context = makeGitContext(repository: "Repo", worktree: "repo", branch: "main")
+        let base = AgentWorkspaceRootRow(
+            id: UUID(),
+            name: "Repo",
+            fullPath: "/tmp/Repo",
+            isPrimary: true,
+            canMoveUp: false,
+            canMoveDown: true,
+            gitContext: context
+        )
+        let indicator = makeIndicator()
+
+        let enriched = base.withWorktree(indicator)
+
+        XCTAssertEqual(enriched.gitContext, context)
+        XCTAssertEqual(enriched.worktree, indicator)
     }
 
     func testIndicatorMakePrefersBindingColorAndLabel() {
@@ -166,6 +206,24 @@ final class AgentWorkspaceRootsSidebarStoreTests: XCTestCase {
             visualLabel: visualLabel,
             visualColorHex: visualColorHex,
             boundAt: Date()
+        )
+    }
+
+    private func makeGitContext(
+        repository: String,
+        worktree: String,
+        branch: String?
+    ) -> GitWorktreeContextSummary {
+        GitWorktreeContextSummary(
+            repositoryID: "gitrepo-test",
+            repoKey: "repo-test",
+            repositoryDisplayName: repository,
+            worktreeID: "wt-test",
+            worktreePath: "/tmp/\(worktree)",
+            worktreeName: worktree,
+            branch: branch,
+            head: "1234567890abcdef",
+            isDetached: false
         )
     }
 

--- a/Tests/RepoPromptTests/Services/VCS/GitWorktreeContextSummaryTests.swift
+++ b/Tests/RepoPromptTests/Services/VCS/GitWorktreeContextSummaryTests.swift
@@ -1,0 +1,154 @@
+import Foundation
+@testable import RepoPrompt
+import XCTest
+
+final class GitWorktreeContextResolverTests: XCTestCase {
+    private var tempRoot: URL?
+
+    override func tearDownWithError() throws {
+        if let tempRoot {
+            try? FileManager.default.removeItem(at: tempRoot)
+        }
+        tempRoot = nil
+        try super.tearDownWithError()
+    }
+
+    func testResolverReturnsNilForNonGitRoot() async throws {
+        let root = try makeTemporaryDirectory().appendingPathComponent("plain", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+
+        let context = await VCSService().gitWorktreeContext(for: root)
+
+        XCTAssertNil(context)
+    }
+
+    func testResolverMatchesVisibleSubdirectoryInsideWorktree() async throws {
+        let repo = try makeGitFixture()
+        let nested = repo.appendingPathComponent("apps/web", isDirectory: true)
+
+        let resolvedContext = await VCSService().gitWorktreeContext(for: nested)
+        let context = try XCTUnwrap(resolvedContext)
+
+        XCTAssertEqual(context.repositoryDisplayName, "repo")
+        XCTAssertEqual(context.worktreeName, "repo")
+        XCTAssertEqual(context.branchDisplayText, "main")
+        XCTAssertEqual(context.breadcrumbText, "repo / repo / main")
+        XCTAssertEqual(URL(fileURLWithPath: context.worktreePath).standardizedFileURL.path, repo.standardizedFileURL.path)
+    }
+
+    func testGitStatusActorRefreshesCachedContextForUnchangedRootList() async throws {
+        let repo = try makeGitFixture()
+        let actor = GitStatusActor(vcsService: VCSService())
+
+        let initial = await actor.updateRoots([repo.path])
+        XCTAssertEqual(initial.first?.gitWorktreeContext?.branchDisplayText, "main")
+
+        try runGit(["checkout", "-b", "feature/context-refresh"], cwd: repo)
+
+        let refreshed = await actor.updateRoots([repo.path])
+        XCTAssertEqual(refreshed.first?.gitWorktreeContext?.branchDisplayText, "feature/context-refresh")
+    }
+
+    private func makeGitFixture() throws -> URL {
+        let root = try makeTemporaryDirectory()
+        let repo = root.appendingPathComponent("repo", isDirectory: true)
+        try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+        try runGit(["init", "-b", "main"], cwd: repo)
+        try runGit(["config", "user.email", "test@example.com"], cwd: repo)
+        try runGit(["config", "user.name", "Test User"], cwd: repo)
+        let nested = repo.appendingPathComponent("apps/web", isDirectory: true)
+        try FileManager.default.createDirectory(at: nested, withIntermediateDirectories: true)
+        try "hello\n".write(to: nested.appendingPathComponent("README.md"), atomically: true, encoding: .utf8)
+        try runGit(["add", "."], cwd: repo)
+        try runGit(["commit", "-m", "Initial commit"], cwd: repo)
+        return repo
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("GitWorktreeContextResolverTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        tempRoot = root
+        return root
+    }
+
+    private func runGit(_ arguments: [String], cwd: URL) throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+        process.arguments = arguments
+        process.currentDirectoryURL = cwd
+        var environment = ProcessInfo.processInfo.environment
+        environment["GIT_CONFIG_NOSYSTEM"] = "1"
+        environment["GIT_CONFIG_GLOBAL"] = "/dev/null"
+        environment["GIT_TERMINAL_PROMPT"] = "0"
+        process.environment = environment
+        let output = Pipe()
+        process.standardOutput = output
+        process.standardError = output
+        try process.run()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            let data = output.fileHandleForReading.readDataToEndOfFile()
+            let text = String(data: data, encoding: .utf8) ?? ""
+            throw NSError(
+                domain: "GitWorktreeContextResolverTests",
+                code: Int(process.terminationStatus),
+                userInfo: [NSLocalizedDescriptionKey: "git \(arguments.joined(separator: " ")) failed: \(text)"]
+            )
+        }
+    }
+}
+
+final class GitWorktreeContextSummaryTests: XCTestCase {
+    func testNormalBranchUsesBranchInBreadcrumbTooltipAndAccessibility() {
+        let summary = makeSummary(branch: "main", head: "1234567890abcdef", isDetached: false)
+
+        XCTAssertEqual(summary.branchDisplayText, "main")
+        XCTAssertEqual(summary.breadcrumbText, "Repo / repo / main")
+        XCTAssertTrue(summary.tooltipText.contains("Branch: main"))
+        XCTAssertTrue(summary.accessibilityText.contains("branch main"))
+    }
+
+    func testDetachedHeadUsesShortShaDisplay() {
+        let summary = makeSummary(branch: nil, head: "abcdef1234567890", isDetached: true)
+
+        XCTAssertEqual(summary.branchDisplayText, "detached @ abcdef1")
+        XCTAssertEqual(summary.breadcrumbText, "Repo / repo / detached @ abcdef1")
+        XCTAssertTrue(summary.tooltipText.contains("Branch: detached @ abcdef1"))
+    }
+
+    func testMissingBranchWithKnownHeadUsesHeadFallback() {
+        let summary = makeSummary(branch: nil, head: "fedcba9876543210", isDetached: false)
+
+        XCTAssertEqual(summary.branchDisplayText, "HEAD @ fedcba9")
+        XCTAssertEqual(summary.breadcrumbText, "Repo / repo / HEAD @ fedcba9")
+        XCTAssertTrue(summary.tooltipText.contains("Branch: HEAD @ fedcba9"))
+    }
+
+    func testUnknownBranchIsOnlySurfacedInTooltipAndAccessibility() {
+        let summary = makeSummary(branch: nil, head: nil, isDetached: false)
+
+        XCTAssertNil(summary.branchDisplayText)
+        XCTAssertEqual(summary.breadcrumbText, "Repo / repo")
+        XCTAssertTrue(summary.tooltipText.contains("Branch: unknown branch"))
+        XCTAssertTrue(summary.accessibilityText.contains("branch unknown branch"))
+    }
+
+    private func makeSummary(
+        branch: String?,
+        head: String?,
+        isDetached: Bool
+    ) -> GitWorktreeContextSummary {
+        GitWorktreeContextSummary(
+            repositoryID: "gitrepo-test",
+            repoKey: "repo-test",
+            repositoryDisplayName: "Repo",
+            worktreeID: "wt-test",
+            worktreePath: "/tmp/repo",
+            worktreeName: "repo",
+            branch: branch,
+            head: head,
+            isDetached: isDetached
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Add read-only Git repo/worktree/branch context summaries for visible workspace roots.
- Publish per-root Git context through the existing Git status/root detection flow.
- Render a compact `repo / worktree / branch` breadcrumb capsule in the Agent Mode workspace roots card, separate from active Agent `WT` bindings.
- Add focused coverage for formatting, path matching, stale refresh, and sidebar row preservation.

Fixes #52

## Testing
- [x] `make dev-format`
- [x] `make dev-format-check`
- [x] `Scripts/swift_style.sh lint` with `XCODE_DEFAULT_TOOLCHAIN_OVERRIDE` / `SOURCEKIT_TOOLCHAIN_PATH` pointing at the Xcode toolchain — `0 violations, 0 serious in 969 files`
- [x] Commit preflight

Blocked locally before project code:
- `make dev-test FILTER=GitWorktreeContext` — blocked while compiling third-party `KeyboardShortcuts` because SwiftUI `#Preview` cannot find `PreviewsMacros.SwiftUIView`.
- `make dev-swift-build PRODUCT=RepoPrompt` — same `KeyboardShortcuts` / `PreviewsMacros` blocker.
- Coordinated `make dev-lint` / push-preflight lint — SwiftLint daemon crashes because SourceKitten cannot load `sourcekitdInProc` from the active Command Line Tools environment. Direct lint passes with the Xcode toolchain override above.

## Manual testing needed
This is intentionally a draft PR because I still need to test the UI manually before marking it ready for review, especially:
- breadcrumb appearance/truncation in narrow sidebars;
- multi-root workspaces;
- linked worktrees and subdirectory roots;
- non-Git roots showing no chip;
- active Agent session `WT` capsule remaining visually distinct from the read-only Git breadcrumb.
