### PR TITLE
Package CE releases with the CE bundle name

### DIFF
--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -92,7 +92,7 @@ jobs:
           mkdir extracted
           ditto -x -k "${archives[0]}" extracted
           ./trusted-control-plane/Scripts/validate_embedded_mcp_helper_layout.sh \
-            extracted/RepoPrompt.app \
+            "extracted/RepoPrompt CE.app" \
             "Reviewed ZIP MCP helper layout"
 
       - name: Execute reviewed helper without inherited secrets
@@ -102,7 +102,7 @@ jobs:
             HOME="$HOME" \
             TMPDIR="$RUNNER_TEMP" \
             ./trusted-control-plane/Scripts/smoke_embedded_mcp_helper.sh \
-            extracted/RepoPrompt.app \
+            "extracted/RepoPrompt CE.app" \
             "Reviewed ZIP MCP helper"
 
   promote:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -257,7 +257,7 @@ jobs:
           mkdir extracted
           ditto -x -k "$archive" extracted
           ./trusted-control-plane/Scripts/validate_embedded_mcp_helper_layout.sh \
-            extracted/RepoPrompt.app \
+            "extracted/RepoPrompt CE.app" \
             "Signed draft MCP helper layout"
 
       - name: Execute signed helper without inherited secrets
@@ -267,5 +267,5 @@ jobs:
             HOME="$HOME" \
             TMPDIR="$RUNNER_TEMP" \
             ./trusted-control-plane/Scripts/smoke_embedded_mcp_helper.sh \
-            extracted/RepoPrompt.app \
+            "extracted/RepoPrompt CE.app" \
             "Signed draft MCP helper"

--- a/.github/workflows/signed-test-build.yml
+++ b/.github/workflows/signed-test-build.yml
@@ -379,7 +379,7 @@ jobs:
           mkdir extracted
           ditto -x -k "$archive" extracted
           ./trusted-control-plane/Scripts/validate_embedded_mcp_helper_layout.sh \
-            extracted/RepoPrompt.app \
+            "extracted/RepoPrompt CE.app" \
             "Signed test build MCP helper layout"
 
       - name: Execute signed helper without inherited secrets
@@ -389,5 +389,5 @@ jobs:
             HOME="$HOME" \
             TMPDIR="$RUNNER_TEMP" \
             ./trusted-control-plane/Scripts/smoke_embedded_mcp_helper.sh \
-            extracted/RepoPrompt.app \
+            "extracted/RepoPrompt CE.app" \
             "Signed test build MCP helper"

--- a/Scripts/promote_release.sh
+++ b/Scripts/promote_release.sh
@@ -18,6 +18,7 @@ SOURCE_GH_TOKEN="${SOURCE_GH_TOKEN:-${GH_TOKEN:-}}"
 PUBLIC_UPDATE_GH_TOKEN="${PUBLIC_UPDATE_GH_TOKEN:-}"
 REVIEWED_CHECKSUMS_SHA256="${REVIEWED_CHECKSUMS_SHA256:-}"
 ARCHIVE_BASENAME="${APP_NAME}-${MARKETING_VERSION}-${BUILD_NUMBER}"
+DISTRIBUTION_APP_BUNDLE_NAME="$DISPLAY_NAME.app"
 UPDATE_ZIP_NAME="$ARCHIVE_BASENAME.zip"
 DMG_NAME="$ARCHIVE_BASENAME.dmg"
 APPCAST_NAME="appcast.xml"
@@ -161,8 +162,8 @@ validate_dmg_matches_zip_app() {
     mkdir -p "$DMG_MOUNT_POINT"
     hdiutil attach "$DMG" -readonly -nobrowse -mountpoint "$DMG_MOUNT_POINT" >/dev/null
 
-    local dmg_app="$DMG_MOUNT_POINT/$APP_NAME.app"
-    [[ -d "$dmg_app" ]] || fail "DMG does not contain $APP_NAME.app at its root"
+    local dmg_app="$DMG_MOUNT_POINT/$DISTRIBUTION_APP_BUNDLE_NAME"
+    [[ -d "$dmg_app" ]] || fail "DMG does not contain $DISTRIBUTION_APP_BUNDLE_NAME at its root"
     diff -qr "$APP_BUNDLE" "$dmg_app" ||
         fail "DMG app contents do not match the verified update ZIP app"
     validate_embedded_mcp_helper_layout "$dmg_app" "Mounted DMG MCP helper layout"
@@ -288,8 +289,9 @@ verify_source_release() {
     validate_checksum_manifest
 
     ditto -x -k "$UPDATE_ZIP" "$EXTRACT_DIR"
-    [[ -d "$EXTRACT_DIR/$APP_NAME.app" ]] || fail "Update ZIP must contain $APP_NAME.app at its root"
-    APP_BUNDLE="$EXTRACT_DIR/$APP_NAME.app"
+    [[ -d "$EXTRACT_DIR/$DISTRIBUTION_APP_BUNDLE_NAME" ]] ||
+        fail "Update ZIP must contain $DISTRIBUTION_APP_BUNDLE_NAME at its root"
+    APP_BUNDLE="$EXTRACT_DIR/$DISTRIBUTION_APP_BUNDLE_NAME"
     validate_app_bundle "$APP_BUNDLE"
     xcrun stapler validate "$DMG"
     validate_dmg_matches_zip_app

--- a/Scripts/publish_public_update_test.sh
+++ b/Scripts/publish_public_update_test.sh
@@ -57,8 +57,8 @@ CHECKSUMS="$TMP_DIR/SHA256SUMS"
 mkdir -p "$EXTRACT_DIR" "$APPCAST_DIR"
 
 ditto -x -k "$UPDATE_ZIP" "$EXTRACT_DIR"
-APP_BUNDLE="$(find "$EXTRACT_DIR" -type d -name "$APP_NAME.app" -print -quit)"
-[[ -n "$APP_BUNDLE" ]] || fail "Update ZIP does not contain $APP_NAME.app"
+APP_BUNDLE="$EXTRACT_DIR/$DISPLAY_NAME.app"
+[[ -d "$APP_BUNDLE" ]] || fail "Update ZIP does not contain $DISPLAY_NAME.app at its root"
 
 codesign --verify --deep --strict --verbose=2 "$APP_BUNDLE"
 signature_details="$(codesign -dv --verbose=4 "$APP_BUNDLE" 2>&1)"

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -13,6 +13,7 @@ load_release_metadata "$ROOT_DIR"
 
 DIST_DIR="${DIST_DIR:-$ROOT_DIR/dist}"
 APP_BUNDLE="$ROOT_DIR/.build/release/$APP_NAME.app"
+DISTRIBUTION_APP_BUNDLE_NAME="$DISPLAY_NAME.app"
 ARCHIVE_BASENAME="${APP_NAME}-${MARKETING_VERSION}-${BUILD_NUMBER}"
 UPDATE_ZIP="$DIST_DIR/$ARCHIVE_BASENAME.zip"
 DMG="$DIST_DIR/$ARCHIVE_BASENAME.dmg"
@@ -140,7 +141,9 @@ package_release_candidate() {
         "$CONTROL_PLANE_SCRIPTS_DIR/package_app.sh" release
     run_preflight
     validate_packaged_legal "$APP_BUNDLE"
-    ditto -c -k --norsrc --keepParent "$APP_BUNDLE" "$UPDATE_ZIP"
+    TMP_DIR="$(mktemp -d)"
+    ditto "$APP_BUNDLE" "$TMP_DIR/$DISTRIBUTION_APP_BUNDLE_NAME"
+    ditto -c -k --norsrc --keepParent "$TMP_DIR/$DISTRIBUTION_APP_BUNDLE_NAME" "$UPDATE_ZIP"
     (
         cd "$DIST_DIR"
         shasum -a 256 "$(basename "$UPDATE_ZIP")" > "$(basename "$CHECKSUMS")"
@@ -340,12 +343,12 @@ publish_staged_release() {
     xcrun stapler staple "$APP_BUNDLE"
     xcrun stapler validate "$APP_BUNDLE"
 
-    ditto -c -k --norsrc --keepParent "$APP_BUNDLE" "$UPDATE_ZIP"
+    local distribution_dir="$TMP_DIR/distribution"
+    mkdir -p "$distribution_dir"
+    ditto "$APP_BUNDLE" "$distribution_dir/$DISTRIBUTION_APP_BUNDLE_NAME"
+    ditto -c -k --norsrc --keepParent "$distribution_dir/$DISTRIBUTION_APP_BUNDLE_NAME" "$UPDATE_ZIP"
 
-    local dmg_staging="$TMP_DIR/dmg"
-    mkdir -p "$dmg_staging"
-    ditto "$APP_BUNDLE" "$dmg_staging/$APP_NAME.app"
-    hdiutil create -volname "$DISPLAY_NAME" -srcfolder "$dmg_staging" -ov -format UDZO "$DMG"
+    hdiutil create -volname "$DISPLAY_NAME" -srcfolder "$distribution_dir" -ov -format UDZO "$DMG"
     submit_notarization "$DMG"
     xcrun stapler staple "$DMG"
     xcrun stapler validate "$DMG"
@@ -409,12 +412,12 @@ publish_signed_test_build() {
     xcrun stapler staple "$APP_BUNDLE"
     xcrun stapler validate "$APP_BUNDLE"
 
-    ditto -c -k --norsrc --keepParent "$APP_BUNDLE" "$UPDATE_ZIP"
+    local distribution_dir="$TMP_DIR/distribution"
+    mkdir -p "$distribution_dir"
+    ditto "$APP_BUNDLE" "$distribution_dir/$DISTRIBUTION_APP_BUNDLE_NAME"
+    ditto -c -k --norsrc --keepParent "$distribution_dir/$DISTRIBUTION_APP_BUNDLE_NAME" "$UPDATE_ZIP"
 
-    local dmg_staging="$TMP_DIR/dmg"
-    mkdir -p "$dmg_staging"
-    ditto "$APP_BUNDLE" "$dmg_staging/$APP_NAME.app"
-    hdiutil create -volname "$DISPLAY_NAME" -srcfolder "$dmg_staging" -ov -format UDZO "$DMG"
+    hdiutil create -volname "$DISPLAY_NAME" -srcfolder "$distribution_dir" -ov -format UDZO "$DMG"
     submit_notarization "$DMG"
     xcrun stapler staple "$DMG"
     xcrun stapler validate "$DMG"

--- a/Scripts/test_release_promotion.py
+++ b/Scripts/test_release_promotion.py
@@ -140,8 +140,8 @@ class ReleasePromotionTests(unittest.TestCase):
         vendor_bin = root / "Vendor" / "Sparkle" / "bin"
         assets = temp_dir / "assets"
         fake_bin = temp_dir / "bin"
-        app = temp_dir / "fixture" / "RepoPrompt.app"
-        dmg_app = temp_dir / "dmg-fixture" / "RepoPrompt.app"
+        app = temp_dir / "fixture" / "RepoPrompt CE.app"
+        dmg_app = temp_dir / "dmg-fixture" / "RepoPrompt CE.app"
         for directory in (scripts, vendor_bin, assets, fake_bin, app / "Contents" / "MacOS", app / "Contents" / "Resources" / "bin"):
             directory.mkdir(parents=True, exist_ok=True)
 
@@ -279,7 +279,7 @@ class ReleasePromotionTests(unittest.TestCase):
             printf 'ditto\\n' >> "$FAKE_TOOL_CAPTURE"
             target="${@: -1}"
             mkdir -p "$target"
-            cp -R "$FAKE_APP_SOURCE" "$target/RepoPrompt.app"
+            cp -R "$FAKE_APP_SOURCE" "$target/RepoPrompt CE.app"
             """,
         )
         self.write_stub(
@@ -289,7 +289,7 @@ class ReleasePromotionTests(unittest.TestCase):
             printf 'hdiutil\\n' >> "$FAKE_TOOL_CAPTURE"
             if [[ "$1" == "attach" ]]; then
                 target="${@: -1}"
-                cp -R "$FAKE_DMG_APP_SOURCE" "$target/RepoPrompt.app"
+                cp -R "$FAKE_DMG_APP_SOURCE" "$target/RepoPrompt CE.app"
             fi
             """,
         )

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -59,6 +59,10 @@ class ReleaseToolingTests(unittest.TestCase):
             self.assertIn("validate_embedded_mcp_helper_layout.sh", privileged_script)
             self.assertNotIn("smoke_embedded_mcp_helper.sh", privileged_script)
         self.assertIn('require_file "$CONTROL_PLANE_SCRIPTS_DIR/validate_embedded_mcp_helper_layout.sh"', release_script)
+        self.assertIn('DISTRIBUTION_APP_BUNDLE_NAME="$DISPLAY_NAME.app"', release_script)
+        self.assertIn('ditto "$APP_BUNDLE" "$distribution_dir/$DISTRIBUTION_APP_BUNDLE_NAME"', release_script)
+        self.assertIn('DISTRIBUTION_APP_BUNDLE_NAME="$DISPLAY_NAME.app"', promote_script)
+        self.assertIn('APP_BUNDLE="$EXTRACT_DIR/$DISPLAY_NAME.app"', public_update_script)
 
     def test_embedded_mcp_helper_smoke_rejects_exit_137(self) -> None:
         temp_dir = Path(tempfile.mkdtemp())
@@ -147,6 +151,7 @@ class ReleaseToolingTests(unittest.TestCase):
         self.assertIn("shasum -a 256 -c", signed_smoke)
         self.assertLess(signed_smoke.index("shasum -a 256 -c"), signed_smoke.index("ditto -x -k"))
         self.assertIn("validate_embedded_mcp_helper_layout.sh", signed_smoke)
+        self.assertIn('"extracted/RepoPrompt CE.app"', signed_smoke)
         self.assertIn("env -i", signed_smoke)
         self.assertIn("PATH=/usr/bin:/bin:/usr/sbin:/sbin", signed_smoke)
         self.assertIn('HOME="$HOME"', signed_smoke)
@@ -158,6 +163,7 @@ class ReleaseToolingTests(unittest.TestCase):
         self.assertIn("GH_TOKEN: ${{ github.token }}", reviewed_smoke)
         self.assertIn("reviewed_checksums_sha256", reviewed_smoke)
         self.assertIn("validate_embedded_mcp_helper_layout.sh", reviewed_smoke)
+        self.assertIn('"extracted/RepoPrompt CE.app"', reviewed_smoke)
         self.assertIn("env -i", reviewed_smoke)
         promote_job = promote_workflow.split("\n  promote:", 1)[1]
         self.assertIn("- smoke-reviewed-helper", promote_job)
@@ -229,6 +235,7 @@ class ReleaseToolingTests(unittest.TestCase):
         self.assertIn("Provenance reachable refs must be a non-empty list", signed_test_smoke)
         self.assertIn("developer-id-signed-test-build", signed_test_smoke)
         self.assertIn("validate_embedded_mcp_helper_layout.sh", signed_test_smoke)
+        self.assertIn('"extracted/RepoPrompt CE.app"', signed_test_smoke)
         self.assertIn("env -i", signed_test_smoke)
 
         stage_test = release_script.split("stage_signed_test_build() {", 1)[1].split("\n}", 1)[0]


### PR DESCRIPTION
## Summary
- distribute signed ZIP and DMG artifacts with the filesystem bundle name `RepoPrompt CE.app`
- update promotion and CI smoke checks to expect the CE-named bundle
- add regression coverage for release naming

## Validation
- `bash -n Scripts/release.sh Scripts/promote_release.sh Scripts/publish_public_update_test.sh`
- `python3 Scripts/test_release_tooling.py`
- `python3 Scripts/test_release_promotion.py`
- `python3 Scripts/test_local_production_installer.py`
- `git diff --check`
- `make dev-release-preflight`
- `make dev-release-artifact`
- extracted `dist/RepoPrompt-1.0.5-6.zip` root is `RepoPrompt CE.app/`
- extracted CE-named helper passes `Scripts/smoke_embedded_mcp_helper.sh`

No release is deployed by this PR.