### PR TITLE
[codex] Refresh approved contributors

### DIFF
--- a/.github/APPROVED_CONTRIBUTORS
+++ b/.github/APPROVED_CONTRIBUTORS
@@ -103,6 +103,7 @@ BradferdT pr
 bradhallett pr
 brandonskane pr
 brasazza pr
+brettmadill pr
 brianhays pr
 brichase pr
 brytoncooper pr
@@ -200,6 +201,7 @@ dlbroadfoot pr
 dlcen pr
 dnnaji pr
 dnszero pr
+doetschnet pr
 doganozturk pr
 donlair pr
 dpaluy pr
@@ -252,6 +254,7 @@ FUenal pr
 gadekar-pravin pr
 Gadi-Chait pr
 gapurov pr
+gauravhp pr
 gavinmclelland pr
 gcavanaugh pr
 gchahal1982 pr
@@ -287,6 +290,7 @@ helpimfalling pr
 HendrikReh pr
 henrycarrero pr
 heomin86 pr
+heyalchang pr
 hierosir1984 pr
 highlandhodl pr
 hmottestad pr
@@ -322,6 +326,7 @@ jakio pr
 jamesblackwell pr
 jamesjlundin pr
 jasenlew pr
+jasonbarbee pr
 jayashan10 pr
 jayvijaygohil pr
 jblwilliams pr
@@ -329,6 +334,7 @@ JCblack369 pr
 je2ryw pr
 jeanfbrito pr
 Jercik pr
+jeremyvaught pr
 jerryharrison pr
 jessegoldberg pr
 Jetemadi pr
@@ -409,8 +415,10 @@ malayyka pr
 manansh11 pr
 mancevd pr
 manifoldfrs pr
+marcisme pr
 marcmagn1 pr
 marcromeyn pr
+marcschauer96 pr
 markgrossnickle pr
 marvos pr
 masonjames pr
@@ -559,6 +567,7 @@ shauntrennery pr
 shawnharmsen pr
 shillcock pr
 shiori pr
+shirvani-jr pr
 SijanC147 pr
 SiTaggart pr
 sivash-922 pr
@@ -632,6 +641,7 @@ uniyalabhishek pr
 uportnykh pr
 valenteg pr
 Varkoff pr
+varunkasi pr
 varunrayen pr
 vchepeli pr
 vdt pr
@@ -639,6 +649,7 @@ vega113 pr
 vida994 pr
 vikrapivin pr
 viktortnk pr
+VinceHellsing pr
 viniciussoares pr
 virionai pr
 visualinc pr
@@ -671,6 +682,7 @@ ybbuc pr
 ybugrara pr
 yerffejytnac pr
 yihuikhuu pr
+Yip-Yip pr
 yjsoon pr
 youqad pr
 yourDomainAdmin pr


### PR DESCRIPTION
## Summary
Refreshes the approved-contributor allowlist from live customer claims.

Previous contributor count: 685
New contributor count: 697
Net change: +12

Unresolved claim-form GitHub IDs:
- `Tyschultz7` (`not_found`)
- `hsinskip` (`not_found`)

## Validation
- `make guardrails`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh commit`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh push`
