### PR TITLE
Distinguish web tool card action labels

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/Models/AgentChatModels.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Models/AgentChatModels.swift
@@ -245,8 +245,8 @@ public struct AgentChatItem: Codable, Identifiable, Sendable, Equatable {
         AgentChatItem(kind: .toolCall, text: "Using tool: \(name)", toolName: name, toolInvocationID: invocationID, toolArgsJSON: argsJSON, sequenceIndex: sequenceIndex)
     }
 
-    public static func toolResult(name: String, invocationID: UUID? = nil, resultJSON: String, isError: Bool? = nil, sequenceIndex: Int = 0) -> AgentChatItem {
-        AgentChatItem(kind: .toolResult, text: resultJSON, toolName: name, toolInvocationID: invocationID, toolResultJSON: resultJSON, toolIsError: isError, sequenceIndex: sequenceIndex)
+    public static func toolResult(name: String, invocationID: UUID? = nil, argsJSON: String? = nil, resultJSON: String, isError: Bool? = nil, sequenceIndex: Int = 0) -> AgentChatItem {
+        AgentChatItem(kind: .toolResult, text: resultJSON, toolName: name, toolInvocationID: invocationID, toolArgsJSON: argsJSON, toolResultJSON: resultJSON, toolIsError: isError, sequenceIndex: sequenceIndex)
     }
 
     public static func system(_ text: String, sequenceIndex: Int = 0) -> AgentChatItem {

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Codex/CodexAgentModeCoordinator.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Codex/CodexAgentModeCoordinator.swift
@@ -3586,14 +3586,14 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
             updated.text = resultJSON
             session.replaceItem(at: index, with: updated)
         } else {
-            var toolResultItem = AgentChatItem.toolResult(
+            let toolResultItem = AgentChatItem.toolResult(
                 name: toolName,
                 invocationID: invocationID,
+                argsJSON: argsJSON,
                 resultJSON: resultJSON,
                 isError: isError,
                 sequenceIndex: session.nextSequenceIndex
             )
-            toolResultItem.toolArgsJSON = argsJSON
             session.appendItem(toolResultItem)
         }
         reconcileCodexCommandExecutionRunningUpdate(
@@ -4431,6 +4431,7 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
                 let toolResultItem = AgentChatItem.toolResult(
                     name: toolName,
                     invocationID: invocationID,
+                    argsJSON: argsJSON,
                     resultJSON: resultJSON,
                     isError: isError,
                     sequenceIndex: session.nextSequenceIndex
@@ -5087,14 +5088,14 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
             }
         } else {
             let runningJSON = Self.initialRunningCommandExecutionJSON(argsJSON: argsJSON)
-            var runningItem = AgentChatItem.toolResult(
+            let runningItem = AgentChatItem.toolResult(
                 name: toolName,
                 invocationID: invocationID,
+                argsJSON: argsJSON,
                 resultJSON: runningJSON,
                 isError: false,
                 sequenceIndex: session.nextSequenceIndex
             )
-            runningItem.toolArgsJSON = argsJSON
             session.appendItem(runningItem)
             itemIndex = session.items.count - 1
         }

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Codex/CodexAgentModeCoordinator.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Codex/CodexAgentModeCoordinator.swift
@@ -4646,14 +4646,15 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
     private static func normalizedExternalToolName(_ raw: String?) -> String? {
         guard let raw = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty else { return nil }
         let lowered = raw.lowercased()
+        if let webCanonical = AgentWebToolCanonicalNames.canonicalToolCardName(lowered) {
+            return webCanonical
+        }
         let suffix = lowered.split(separator: ".").last.map(String.init) ?? lowered
         switch suffix {
         case "local_shell", "shell", "unified_exec", "exec_command", "run_shell_command":
             return "bash"
-        case "web_search", "web_search_request", "google_web_search", "search_web":
-            return "search"
         default:
-            return suffix
+            return AgentWebToolCanonicalNames.canonicalToolCardName(suffix) ?? suffix
         }
     }
 

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Transcript/AgentToolCardRenderSummary.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Transcript/AgentToolCardRenderSummary.swift
@@ -188,6 +188,7 @@ struct AgentToolCardRenderSummary: Codable, Equatable {
         case "git": "Git"
         case "file_search": "Search"
         case "search": "Web Search"
+        case "web_read": "Read Web Page"
         case "manage_selection": "Selection"
         case "read_file": "Read File"
         case "workspace_context": "Context"
@@ -220,6 +221,7 @@ enum AgentToolCardRenderSummaryBuilder {
 
     static func build(
         normalizedToolName: String?,
+        rawToolName: String? = nil,
         statusWord: String,
         rawObject: [String: Any]?,
         argsObject: [String: Any]?,
@@ -234,8 +236,14 @@ enum AgentToolCardRenderSummaryBuilder {
             return readFileSummary(statusWord: statusWord, rawObject: rawObject, argsObject: argsObject)
         case "file_search":
             return fileSearchSummary(statusWord: statusWord, rawObject: rawObject, argsObject: argsObject)
-        case "search":
-            return webSearchSummary(statusWord: statusWord, rawObject: rawObject, argsObject: argsObject)
+        case "search", "web_read":
+            return webToolSummary(
+                normalizedToolName: normalizedToolName,
+                rawToolName: rawToolName,
+                statusWord: statusWord,
+                rawObject: rawObject,
+                argsObject: argsObject
+            )
         case "manage_selection":
             return manageSelectionSummary(statusWord: statusWord, rawObject: rawObject, argsObject: argsObject)
         case "workspace_context":
@@ -368,6 +376,49 @@ enum AgentToolCardRenderSummaryBuilder {
             detailText: nil,
             status: renderStatus,
             op: "file_search"
+        )
+    }
+
+    private static func webToolSummary(
+        normalizedToolName: String,
+        rawToolName: String?,
+        statusWord: String,
+        rawObject: [String: Any]?,
+        argsObject: [String: Any]?
+    ) -> AgentToolCardRenderSummary? {
+        guard rawObject != nil || argsObject != nil else { return nil }
+        guard let webPresentation = AgentWebToolActionPresentation.classify(AgentWebToolActionInput(
+            rawToolName: rawToolName,
+            normalizedToolName: normalizedToolName,
+            argsObject: argsObject,
+            resultObject: rawObject
+        )) else { return nil }
+        if webPresentation.action == .webSearch {
+            return webSearchSummary(statusWord: statusWord, rawObject: rawObject, argsObject: argsObject)
+        }
+        let baseStatus = status(from: stringValue(rawObject, keys: ["status", "state", "outcome"]) ?? statusWord, defaultStatus: .neutral)
+        let errorDetail = webSearchErrorDetail(rawObject)
+        let detailText: String? = switch webPresentation.action {
+        case .readWebPage:
+            webPageReadDetailText(rawObject)
+        case .findInPage:
+            webFindDetailText(rawObject)
+        case .webSearch:
+            nil
+        }
+        let renderStatus: AgentToolCardRenderStatus = {
+            if errorDetail != nil, baseStatus != .success { return .failure }
+            if baseStatus == .failure || baseStatus == .warning || baseStatus == .running { return baseStatus }
+            if detailText != nil { return .success }
+            return baseStatus
+        }()
+        return AgentToolCardRenderSummary(
+            toolName: normalizedToolName == "web_read" ? "web_read" : "search",
+            title: webPresentation.title,
+            subtitle: webPresentation.subtitle,
+            detailText: renderStatus == .failure ? (errorDetail ?? detailText) : (detailText ?? errorDetail),
+            status: renderStatus,
+            op: webPresentation.op
         )
     }
 
@@ -643,6 +694,31 @@ enum AgentToolCardRenderSummaryBuilder {
             status: renderStatus,
             op: op.lowercased()
         )
+    }
+
+    private static func webPageReadDetailText(_ object: [String: Any]?) -> String? {
+        guard let object else { return nil }
+        if let title = safeCollapsedText(stringValue(object, keys: ["title", "page_title", "pageTitle", "name"])) {
+            return title
+        }
+        if let nested = objectValue(object, keys: ["page", "document", "metadata"]),
+           let title = safeCollapsedText(stringValue(nested, keys: ["title", "page_title", "pageTitle", "name"]))
+        {
+            return title
+        }
+        return nil
+    }
+
+    private static func webFindDetailText(_ object: [String: Any]?) -> String? {
+        guard let object else { return nil }
+        let count = intValue(object, keys: ["match_count", "matchCount", "total_matches", "totalMatches", "count"])
+            ?? arrayValue(object, keys: ["matches"])?.count
+            ?? (object["result"] as? [String: Any]).flatMap { nested in
+                intValue(nested, keys: ["match_count", "matchCount", "total_matches", "totalMatches", "count"])
+                    ?? arrayValue(nested, keys: ["matches"])?.count
+            }
+        guard let count else { return nil }
+        return "\(count) match\(count == 1 ? "" : "es")"
     }
 
     private static func webSearchDetailText(_ object: [String: Any]?) -> String? {

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Transcript/AgentTranscriptToolVisibilityPolicy.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Transcript/AgentTranscriptToolVisibilityPolicy.swift
@@ -109,15 +109,16 @@ enum AgentTranscriptToolVisibilityPolicy {
     }
 
     private static func canonicalAlias(forNormalizedName normalized: String) -> String? {
-        switch normalized {
+        if let webCanonical = AgentWebToolCanonicalNames.canonicalToolCardName(normalized) {
+            return webCanonical
+        }
+        return switch normalized {
         case "readfile", "read_file":
             "read_file"
         case "read_file_tool", "read_file_contents":
             "read_file"
         case "file_search", "filesearch", "grep":
             "file_search"
-        case "search", "web_search", "web_search_request", "google_web_search", "search_web":
-            "search"
         case "bash", "shell", "local_shell", "unified_exec", "exec", "exec_command", "run_shell_command", "command":
             "bash"
         case "filechange", "file_change":

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Transcript/AgentWebToolActionPresentation.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Transcript/AgentWebToolActionPresentation.swift
@@ -47,11 +47,14 @@ struct AgentWebToolActionPresentation: Equatable {
 
 enum AgentWebToolPayloadKeys {
     static let wrapperKeys = ["input", "args", "arguments", "parameters", "params", "rawInput"]
+    static let resultWrapperKeys = ["result", "output", "response", "content"]
+    static let actionTypeKeys = ["type", "action_type", "actionType"]
     static let urlTargetKeys = ["url", "uri", "href", "link", "page_url", "pageUrl", "source_url", "sourceUrl"]
     static let refTargetKeys = ["ref", "ref_id", "refId", "page_ref", "pageRef"]
     static let findKeys = ["pattern", "needle", "find", "find_text", "findText", "text_to_find", "textToFind", "phrase"]
     static let operationKeys = ["op", "action", "operation"]
     static let queryKeys = ["query", "q", "search_query", "searchQuery", "search_text", "searchText"]
+    static let queryListKeys = ["queries", "search_queries", "searchQueries"]
     static let legacySearchQueryKeys = queryKeys + ["text", "value"]
     static let compactScalarKeys = urlTargetKeys + refTargetKeys + findKeys + operationKeys
     static let readResultMetadataKeys = [
@@ -61,6 +64,20 @@ enum AgentWebToolPayloadKeys {
 }
 
 enum AgentWebToolCanonicalNames {
+    static func canonicalWebActionType(_ raw: String?) -> String? {
+        guard let raw = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty else { return nil }
+        switch raw {
+        case "search":
+            return "search"
+        case "open_page", "openPage":
+            return "open_page"
+        case "find_in_page", "findInPage":
+            return "find_in_page"
+        default:
+            return nil
+        }
+    }
+
     static func canonicalToolCardName(_ raw: String?) -> String? {
         guard let raw else { return nil }
         let names = normalizedNameCandidates(raw)
@@ -139,11 +156,11 @@ private enum AgentWebToolActionClassifier {
 
     private struct PayloadSignals {
         let source: PayloadSource
+        let authoritativeActionType: String?
         let target: Target?
         let findText: String?
         let hasFindOperation: Bool
         let hasReadOperation: Bool
-        let hasQuery: Bool
         let query: String?
     }
 
@@ -179,30 +196,26 @@ private enum AgentWebToolActionClassifier {
             input.resultObject.map { payloadSignals(from: $0, source: .result, isSupportedWebName: isSupportedWebName) }
         }
 
-        if let find = actionPresentation(
-            action: .findInPage,
-            signals: argsSignals,
-            isSearchName: isSearchName,
-            isReadName: isReadName
-        ) {
+        if let find = findInPagePresentation(signals: argsSignals) {
             return find
         }
 
         if let argsSignals,
-           argsSignals.hasQuery,
+           argsSignals.query != nil,
            isSearchName,
            !argsSignals.hasReadOperation,
            argsSignals.findText == nil,
            !argsSignals.hasFindOperation
         {
-            if let codexQueryPresentation = codexSearchQueryPresentation(query: argsSignals.query) {
+            if argsSignals.authoritativeActionType == nil,
+               let codexQueryPresentation = codexSearchQueryPresentation(query: argsSignals.query)
+            {
                 return codexQueryPresentation
             }
             return webSearch(query: argsSignals.query)
         }
 
-        if let read = actionPresentation(
-            action: .readWebPage,
+        if let read = readWebPagePresentation(
             signals: argsSignals,
             isSearchName: isSearchName,
             isReadName: isReadName
@@ -211,16 +224,10 @@ private enum AgentWebToolActionClassifier {
         }
 
         let fallbackResultSignals = resultSignals()
-        if let find = actionPresentation(
-            action: .findInPage,
-            signals: fallbackResultSignals,
-            isSearchName: isSearchName,
-            isReadName: isReadName
-        ) {
+        if let find = findInPagePresentation(signals: fallbackResultSignals) {
             return find
         }
-        if let read = actionPresentation(
-            action: .readWebPage,
+        if let read = readWebPagePresentation(
             signals: fallbackResultSignals,
             isSearchName: isSearchName,
             isReadName: isReadName
@@ -238,43 +245,42 @@ private enum AgentWebToolActionClassifier {
         return webSearch(query: argsSignals?.query ?? fallbackResultSignals?.query)
     }
 
-    private static func actionPresentation(
-        action: AgentWebToolActionPresentation.Action,
+    private static func findInPagePresentation(signals: PayloadSignals?) -> AgentWebToolActionPresentation? {
+        guard let signals,
+              signals.findText != nil || signals.hasFindOperation
+        else { return nil }
+        if signals.authoritativeActionType == "find_in_page" {
+            return findInPage(target: signals.target, findText: signals.findText)
+        }
+        guard let target = signals.target else { return nil }
+        return findInPage(target: target, findText: signals.findText)
+    }
+
+    private static func readWebPagePresentation(
         signals: PayloadSignals?,
         isSearchName: Bool,
         isReadName: Bool
     ) -> AgentWebToolActionPresentation? {
-        guard let signals else { return nil }
-        switch action {
-        case .findInPage:
-            guard let target = signals.target,
-                  signals.findText != nil || signals.hasFindOperation
-            else { return nil }
-            return findInPage(target: target, findText: signals.findText)
-        case .readWebPage:
-            guard let target = signals.target else { return nil }
-            if case .result = signals.source,
-               !isReadName,
-               !signals.hasReadOperation,
-               !signals.hasFindOperation
-            {
-                return nil
-            }
-            if isSearchName,
-               signals.hasQuery,
-               !signals.hasReadOperation,
-               !signals.hasFindOperation,
-               !isReadName
-            {
-                return nil
-            }
-            if isReadName || signals.hasReadOperation || signals.hasFindOperation || targetIsURL(target) {
-                return readWebPage(target: target)
-            }
-            return nil
-        case .webSearch:
+        guard let signals, let target = signals.target else { return nil }
+        if case .result = signals.source,
+           !isReadName,
+           !signals.hasReadOperation,
+           !signals.hasFindOperation
+        {
             return nil
         }
+        if isSearchName,
+           signals.query != nil,
+           !signals.hasReadOperation,
+           !signals.hasFindOperation,
+           !isReadName
+        {
+            return nil
+        }
+        if isReadName || signals.hasReadOperation || signals.hasFindOperation || targetIsURL(target) {
+            return readWebPage(target: target)
+        }
+        return nil
     }
 
     private static func payloadSignals(
@@ -283,11 +289,15 @@ private enum AgentWebToolActionClassifier {
         isSupportedWebName: Bool
     ) -> PayloadSignals {
         let objects = boundedPayloadObjects(from: object)
-        let operation = firstString(in: objects, keys: AgentWebToolPayloadKeys.operationKeys)?.lowercased()
-        let hasFindOperation = operation == "find"
-        let hasReadOperation = ["read", "open", "fetch", "get", "retrieve"].contains(operation ?? "")
+        let rawOperation = firstString(in: objects, keys: AgentWebToolPayloadKeys.operationKeys)
+        let authoritativeActionType = firstCanonicalWebActionType(in: objects)
+            ?? AgentWebToolCanonicalNames.canonicalWebActionType(rawOperation)
+        let operation = authoritativeActionType
+            ?? rawOperation?.lowercased()
+        let hasFindOperation = operation == "find" || operation == "find_in_page"
+        let hasReadOperation = ["read", "open", "open_page", "fetch", "get", "retrieve"].contains(operation ?? "")
         let findText = firstString(in: objects, keys: AgentWebToolPayloadKeys.findKeys)
-        let query = firstString(in: objects, keys: AgentWebToolPayloadKeys.legacySearchQueryKeys)
+        let query = firstSearchQuery(in: objects)
         let target = firstTarget(
             in: objects,
             isSupportedWebName: isSupportedWebName,
@@ -295,11 +305,11 @@ private enum AgentWebToolActionClassifier {
         )
         return PayloadSignals(
             source: source,
+            authoritativeActionType: authoritativeActionType,
             target: target,
             findText: findText,
             hasFindOperation: hasFindOperation,
             hasReadOperation: hasReadOperation,
-            hasQuery: query != nil,
             query: query
         )
     }
@@ -311,7 +321,25 @@ private enum AgentWebToolActionClassifier {
                 objects.append(nested)
             }
         }
+        let containers = objects
+        for payload in containers {
+            if let action = payload["action"] as? [String: Any] {
+                objects.append(action)
+            }
+        }
         return objects
+    }
+
+    private static func firstCanonicalWebActionType(in objects: [[String: Any]]) -> String? {
+        for object in objects {
+            for key in AgentWebToolPayloadKeys.actionTypeKeys {
+                guard let value = object[key], let raw = stringValue(value) else { continue }
+                if let canonical = AgentWebToolCanonicalNames.canonicalWebActionType(raw) {
+                    return canonical
+                }
+            }
+        }
+        return nil
     }
 
     private static func containsInvalidLocalTarget(in object: [String: Any]) -> Bool {
@@ -319,6 +347,24 @@ private enum AgentWebToolActionClassifier {
             guard let rawURL = firstString(in: [payload], keys: AgentWebToolPayloadKeys.urlTargetKeys) else { return false }
             return compactWebURLSubtitle(rawURL) == nil && isLocalOrInternalTarget(rawURL)
         }
+    }
+
+    private static func firstSearchQuery(in objects: [[String: Any]]) -> String? {
+        if let query = firstString(in: objects, keys: AgentWebToolPayloadKeys.legacySearchQueryKeys) {
+            return query
+        }
+        for object in objects {
+            for key in AgentWebToolPayloadKeys.queryListKeys {
+                guard let queries = object[key] as? [String] else { continue }
+                let compactQueries = queries.compactMap { query -> String? in
+                    let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+                    return trimmed.isEmpty ? nil : trimmed
+                }
+                guard let first = compactQueries.first else { continue }
+                return compactQueries.count > 1 ? "\(first) ..." : first
+            }
+        }
+        return nil
     }
 
     private static func firstTarget(
@@ -432,15 +478,15 @@ private enum AgentWebToolActionClassifier {
         )
     }
 
-    private static func findInPage(target: Target, findText: String?) -> AgentWebToolActionPresentation {
+    private static func findInPage(target: Target?, findText: String?) -> AgentWebToolActionPresentation {
         let compactFind = findText.map { compactText($0, maxLength: 48) }
-        let subtitle = [target.subtitle, compactFind.map { "\"\($0)\"" }]
+        let subtitle = [target?.subtitle, compactFind.map { "\"\($0)\"" }]
             .compactMap(\.self)
             .joined(separator: " • ")
         return AgentWebToolActionPresentation(
             action: .findInPage,
             title: "Find In Page",
-            subtitle: subtitle.isEmpty ? target.subtitle : subtitle,
+            subtitle: subtitle.isEmpty ? nil : subtitle,
             op: "find_in_page"
         )
     }

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Transcript/AgentWebToolActionPresentation.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Transcript/AgentWebToolActionPresentation.swift
@@ -195,6 +195,9 @@ private enum AgentWebToolActionClassifier {
            argsSignals.findText == nil,
            !argsSignals.hasFindOperation
         {
+            if let codexQueryPresentation = codexSearchQueryPresentation(query: argsSignals.query) {
+                return codexQueryPresentation
+            }
             return webSearch(query: argsSignals.query)
         }
 
@@ -371,6 +374,53 @@ private enum AgentWebToolActionClassifier {
             subtitle: query.map { "\"\(compactText($0, maxLength: 80))\"" },
             op: "search"
         )
+    }
+
+    private static func codexSearchQueryPresentation(query: String?) -> AgentWebToolActionPresentation? {
+        guard let query else { return nil }
+        if let target = exactHTTPURLTarget(query) {
+            return readWebPage(target: target)
+        }
+        if let findQuery = codexFindInPageQuery(query) {
+            return findInPage(target: findQuery.target, findText: findQuery.findText)
+        }
+        return nil
+    }
+
+    private static func exactHTTPURLTarget(_ raw: String) -> Target? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              trimmed.unicodeScalars.allSatisfy({ !compactTextSeparators.contains($0) }),
+              let subtitle = compactWebURLSubtitle(trimmed)
+        else { return nil }
+        return .url(trimmed, subtitle: subtitle)
+    }
+
+    private static func codexFindInPageQuery(_ raw: String) -> (findText: String, target: Target)? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        for marker in [" in https://", " in http://"] {
+            guard let markerRange = trimmed.range(of: marker, options: [.caseInsensitive, .backwards]) else { continue }
+            let rawFindText = String(trimmed[..<markerRange.lowerBound]).trimmingCharacters(in: .whitespacesAndNewlines)
+            let urlStart = trimmed.index(markerRange.lowerBound, offsetBy: 4)
+            let rawURL = String(trimmed[urlStart...]).trimmingCharacters(in: .whitespacesAndNewlines)
+            guard let target = exactHTTPURLTarget(rawURL),
+                  let findText = unquotedFindText(rawFindText)
+            else { continue }
+            return (findText, target)
+        }
+        return nil
+    }
+
+    private static func unquotedFindText(_ raw: String) -> String? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let quotePairs: [(Character, Character)] = [("'", "'"), ("\"", "\""), ("“", "”"), ("‘", "’")]
+        for (opening, closing) in quotePairs where trimmed.first == opening && trimmed.last == closing && trimmed.count >= 2 {
+            let unquoted = String(trimmed.dropFirst().dropLast()).trimmingCharacters(in: .whitespacesAndNewlines)
+            return unquoted.isEmpty ? nil : unquoted
+        }
+        return trimmed
     }
 
     private static func readWebPage(target: Target?) -> AgentWebToolActionPresentation {

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Transcript/AgentWebToolActionPresentation.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Transcript/AgentWebToolActionPresentation.swift
@@ -1,0 +1,469 @@
+import Foundation
+
+struct AgentWebToolActionInput {
+    let rawToolName: String?
+    let normalizedToolName: String?
+    let argsObject: [String: Any]?
+    let resultObject: [String: Any]?
+}
+
+struct AgentWebToolActionPresentation: Equatable {
+    enum Action: Equatable {
+        case webSearch
+        case readWebPage
+        case findInPage
+    }
+
+    let action: Action
+    let title: String
+    let subtitle: String?
+    let op: String
+
+    static func classify(_ input: AgentWebToolActionInput) -> AgentWebToolActionPresentation? {
+        AgentWebToolActionClassifier.classify(input)
+    }
+
+    static func classify(
+        rawToolName: String?,
+        normalizedToolName: String?,
+        argsJSON: String?,
+        resultJSON: String?
+    ) -> AgentWebToolActionPresentation? {
+        guard AgentWebToolCanonicalNames.canonicalToolCardName(rawToolName) != nil
+            || AgentWebToolCanonicalNames.canonicalToolCardName(normalizedToolName) != nil
+        else { return nil }
+        return classify(AgentWebToolActionInput(
+            rawToolName: rawToolName,
+            normalizedToolName: normalizedToolName,
+            argsObject: jsonObject(from: argsJSON),
+            resultObject: jsonObject(from: resultJSON)
+        ))
+    }
+
+    private static func jsonObject(from raw: String?) -> [String: Any]? {
+        ToolRawJSON.object(from: raw)
+    }
+}
+
+enum AgentWebToolPayloadKeys {
+    static let wrapperKeys = ["input", "args", "arguments", "parameters", "params", "rawInput"]
+    static let urlTargetKeys = ["url", "uri", "href", "link", "page_url", "pageUrl", "source_url", "sourceUrl"]
+    static let refTargetKeys = ["ref", "ref_id", "refId", "page_ref", "pageRef"]
+    static let findKeys = ["pattern", "needle", "find", "find_text", "findText", "text_to_find", "textToFind", "phrase"]
+    static let operationKeys = ["op", "action", "operation"]
+    static let queryKeys = ["query", "q", "search_query", "searchQuery", "search_text", "searchText"]
+    static let legacySearchQueryKeys = queryKeys + ["text", "value"]
+    static let compactScalarKeys = urlTargetKeys + refTargetKeys + findKeys + operationKeys
+    static let readResultMetadataKeys = [
+        "status", "title", "page_title", "pageTitle", "summary", "description", "match_count", "matchCount",
+        "total_matches", "totalMatches", "count"
+    ]
+}
+
+enum AgentWebToolCanonicalNames {
+    static func canonicalToolCardName(_ raw: String?) -> String? {
+        guard let raw else { return nil }
+        let names = normalizedNameCandidates(raw)
+        if names.contains(where: isWebSearchName) { return "search" }
+        if names.contains(where: isWebReadName) { return "web_read" }
+        return nil
+    }
+
+    static func isWebSearchName(_ name: String) -> Bool {
+        switch normalizedName(name) {
+        case "search", "web_search", "web_search_request", "google_web_search", "search_web", "websearch":
+            true
+        default:
+            false
+        }
+    }
+
+    static func isWebReadName(_ name: String) -> Bool {
+        switch normalizedName(name) {
+        case "webfetch", "web_fetch", "web_read", "read_web", "browser.open", "browser_open", "open_url",
+             "read_url", "fetch_url", "web_page", "webpage", "read_web_page":
+            true
+        default:
+            false
+        }
+    }
+
+    static func isExcludedNonWebName(raw: String?, normalized: String?) -> Bool {
+        nameCandidates(rawToolName: raw, normalizedToolName: normalized).contains { name in
+            switch normalizedName(name) {
+            case "file_search", "filesearch", "grep", "mcp__repoprompt__file_search", "read_file", "readfile",
+                 "get_code_structure", "get_file_tree", "mcp__repoprompt__read_file",
+                 "mcp__repoprompt__get_code_structure", "mcp__repoprompt__get_file_tree":
+                true
+            default:
+                false
+            }
+        }
+    }
+
+    static func nameCandidates(rawToolName: String?, normalizedToolName: String?) -> [String] {
+        var names: [String] = []
+        if let rawToolName { names.append(contentsOf: normalizedNameCandidates(rawToolName)) }
+        if let normalizedToolName { names.append(contentsOf: normalizedNameCandidates(normalizedToolName)) }
+        var seen = Set<String>()
+        return names.filter { seen.insert($0).inserted }
+    }
+
+    private static func normalizedNameCandidates(_ raw: String) -> [String] {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return [] }
+        let stripped = trimmed.replacingOccurrences(of: "mcp__RepoPrompt__", with: "")
+        let normalized = normalizedName(stripped)
+        var names = [normalized]
+        if let suffix = normalized.split(separator: ".").last.map(String.init), suffix != normalized {
+            names.append(suffix)
+        }
+        return names
+    }
+
+    private static func normalizedName(_ raw: String) -> String {
+        raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .replacingOccurrences(of: "-", with: "_")
+            .replacingOccurrences(of: " ", with: "_")
+    }
+}
+
+private enum AgentWebToolActionClassifier {
+    private static let compactTextSeparators = CharacterSet.whitespacesAndNewlines
+
+    private enum PayloadSource {
+        case args
+        case result
+    }
+
+    private struct PayloadSignals {
+        let source: PayloadSource
+        let target: Target?
+        let findText: String?
+        let hasFindOperation: Bool
+        let hasReadOperation: Bool
+        let hasQuery: Bool
+        let query: String?
+    }
+
+    private enum Target: Equatable {
+        case url(String, subtitle: String)
+        case ref(String, subtitle: String)
+
+        var subtitle: String {
+            switch self {
+            case let .url(_, subtitle), let .ref(_, subtitle): subtitle
+            }
+        }
+    }
+
+    static func classify(_ input: AgentWebToolActionInput) -> AgentWebToolActionPresentation? {
+        if AgentWebToolCanonicalNames.isExcludedNonWebName(raw: input.rawToolName, normalized: input.normalizedToolName) {
+            return nil
+        }
+
+        let names = AgentWebToolCanonicalNames.nameCandidates(
+            rawToolName: input.rawToolName,
+            normalizedToolName: input.normalizedToolName
+        )
+        let isSearchName = names.contains(where: AgentWebToolCanonicalNames.isWebSearchName)
+        let isReadName = names.contains(where: AgentWebToolCanonicalNames.isWebReadName)
+        let isSupportedWebName = isSearchName || isReadName
+        guard isSupportedWebName else { return nil }
+
+        let argsSignals = input.argsObject.map {
+            payloadSignals(from: $0, source: .args, isSupportedWebName: isSupportedWebName)
+        }
+        func resultSignals() -> PayloadSignals? {
+            input.resultObject.map { payloadSignals(from: $0, source: .result, isSupportedWebName: isSupportedWebName) }
+        }
+
+        if let find = actionPresentation(
+            action: .findInPage,
+            signals: argsSignals,
+            isSearchName: isSearchName,
+            isReadName: isReadName
+        ) {
+            return find
+        }
+
+        if let argsSignals,
+           argsSignals.hasQuery,
+           isSearchName,
+           !argsSignals.hasReadOperation,
+           argsSignals.findText == nil,
+           !argsSignals.hasFindOperation
+        {
+            return webSearch(query: argsSignals.query)
+        }
+
+        if let read = actionPresentation(
+            action: .readWebPage,
+            signals: argsSignals,
+            isSearchName: isSearchName,
+            isReadName: isReadName
+        ) {
+            return read
+        }
+
+        let fallbackResultSignals = resultSignals()
+        if let find = actionPresentation(
+            action: .findInPage,
+            signals: fallbackResultSignals,
+            isSearchName: isSearchName,
+            isReadName: isReadName
+        ) {
+            return find
+        }
+        if let read = actionPresentation(
+            action: .readWebPage,
+            signals: fallbackResultSignals,
+            isSearchName: isSearchName,
+            isReadName: isReadName
+        ) {
+            return read
+        }
+
+        if isReadName {
+            if input.argsObject.map(containsInvalidLocalTarget) == true || input.resultObject.map(containsInvalidLocalTarget) == true {
+                return nil
+            }
+            return readWebPage(target: nil)
+        }
+
+        return webSearch(query: argsSignals?.query ?? fallbackResultSignals?.query)
+    }
+
+    private static func actionPresentation(
+        action: AgentWebToolActionPresentation.Action,
+        signals: PayloadSignals?,
+        isSearchName: Bool,
+        isReadName: Bool
+    ) -> AgentWebToolActionPresentation? {
+        guard let signals else { return nil }
+        switch action {
+        case .findInPage:
+            guard let target = signals.target,
+                  signals.findText != nil || signals.hasFindOperation
+            else { return nil }
+            return findInPage(target: target, findText: signals.findText)
+        case .readWebPage:
+            guard let target = signals.target else { return nil }
+            if case .result = signals.source,
+               !isReadName,
+               !signals.hasReadOperation,
+               !signals.hasFindOperation
+            {
+                return nil
+            }
+            if isSearchName,
+               signals.hasQuery,
+               !signals.hasReadOperation,
+               !signals.hasFindOperation,
+               !isReadName
+            {
+                return nil
+            }
+            if isReadName || signals.hasReadOperation || signals.hasFindOperation || targetIsURL(target) {
+                return readWebPage(target: target)
+            }
+            return nil
+        case .webSearch:
+            return nil
+        }
+    }
+
+    private static func payloadSignals(
+        from object: [String: Any],
+        source: PayloadSource,
+        isSupportedWebName: Bool
+    ) -> PayloadSignals {
+        let objects = boundedPayloadObjects(from: object)
+        let operation = firstString(in: objects, keys: AgentWebToolPayloadKeys.operationKeys)?.lowercased()
+        let hasFindOperation = operation == "find"
+        let hasReadOperation = ["read", "open", "fetch", "get", "retrieve"].contains(operation ?? "")
+        let findText = firstString(in: objects, keys: AgentWebToolPayloadKeys.findKeys)
+        let query = firstString(in: objects, keys: AgentWebToolPayloadKeys.legacySearchQueryKeys)
+        let target = firstTarget(
+            in: objects,
+            isSupportedWebName: isSupportedWebName,
+            hasExplicitWebAction: hasFindOperation || hasReadOperation
+        )
+        return PayloadSignals(
+            source: source,
+            target: target,
+            findText: findText,
+            hasFindOperation: hasFindOperation,
+            hasReadOperation: hasReadOperation,
+            hasQuery: query != nil,
+            query: query
+        )
+    }
+
+    private static func boundedPayloadObjects(from object: [String: Any]) -> [[String: Any]] {
+        var objects = [object]
+        for key in AgentWebToolPayloadKeys.wrapperKeys {
+            if let nested = object[key] as? [String: Any] {
+                objects.append(nested)
+            }
+        }
+        return objects
+    }
+
+    private static func containsInvalidLocalTarget(in object: [String: Any]) -> Bool {
+        boundedPayloadObjects(from: object).contains { payload in
+            guard let rawURL = firstString(in: [payload], keys: AgentWebToolPayloadKeys.urlTargetKeys) else { return false }
+            return compactWebURLSubtitle(rawURL) == nil && isLocalOrInternalTarget(rawURL)
+        }
+    }
+
+    private static func firstTarget(
+        in objects: [[String: Any]],
+        isSupportedWebName: Bool,
+        hasExplicitWebAction: Bool
+    ) -> Target? {
+        for object in objects {
+            if let rawURL = firstString(in: [object], keys: AgentWebToolPayloadKeys.urlTargetKeys) {
+                if let subtitle = compactWebURLSubtitle(rawURL) {
+                    return .url(rawURL, subtitle: subtitle)
+                }
+                if isLocalOrInternalTarget(rawURL) {
+                    continue
+                }
+            }
+        }
+        guard isSupportedWebName || hasExplicitWebAction else { return nil }
+        for object in objects {
+            if let ref = firstString(in: [object], keys: AgentWebToolPayloadKeys.refTargetKeys) {
+                return .ref(ref, subtitle: compactRefSubtitle(ref))
+            }
+        }
+        return nil
+    }
+
+    private static func firstString(in objects: [[String: Any]], keys: [String]) -> String? {
+        for object in objects {
+            for key in keys {
+                guard let value = object[key] else { continue }
+                if let string = stringValue(value) { return string }
+            }
+        }
+        return nil
+    }
+
+    private static func stringValue(_ value: Any) -> String? {
+        if let string = value as? String {
+            let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        }
+        if let number = value as? NSNumber {
+            let text = number.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+            return text.isEmpty ? nil : text
+        }
+        return nil
+    }
+
+    private static func webSearch(query: String?) -> AgentWebToolActionPresentation {
+        AgentWebToolActionPresentation(
+            action: .webSearch,
+            title: "Web Search",
+            subtitle: query.map { "\"\(compactText($0, maxLength: 80))\"" },
+            op: "search"
+        )
+    }
+
+    private static func readWebPage(target: Target?) -> AgentWebToolActionPresentation {
+        AgentWebToolActionPresentation(
+            action: .readWebPage,
+            title: "Read Web Page",
+            subtitle: target?.subtitle,
+            op: "read_web_page"
+        )
+    }
+
+    private static func findInPage(target: Target, findText: String?) -> AgentWebToolActionPresentation {
+        let compactFind = findText.map { compactText($0, maxLength: 48) }
+        let subtitle = [target.subtitle, compactFind.map { "\"\($0)\"" }]
+            .compactMap(\.self)
+            .joined(separator: " • ")
+        return AgentWebToolActionPresentation(
+            action: .findInPage,
+            title: "Find In Page",
+            subtitle: subtitle.isEmpty ? target.subtitle : subtitle,
+            op: "find_in_page"
+        )
+    }
+
+    private static func targetIsURL(_ target: Target) -> Bool {
+        if case .url = target { return true }
+        return false
+    }
+
+    private static func compactWebURLSubtitle(_ raw: String) -> String? {
+        guard let components = URLComponents(string: raw),
+              let scheme = components.scheme?.lowercased(),
+              scheme == "http" || scheme == "https",
+              let host = components.host?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !host.isEmpty
+        else { return nil }
+        var authority = host
+        if let port = components.port,
+           !(scheme == "http" && port == 80),
+           !(scheme == "https" && port == 443)
+        {
+            authority += ":\(port)"
+        }
+        let pathComponents = (components.percentEncodedPath.removingPercentEncoding ?? components.path)
+            .split(separator: "/")
+            .map(String.init)
+            .filter { !$0.isEmpty }
+        let text: String = switch pathComponents.count {
+        case 0:
+            authority
+        case 1, 2:
+            ([authority] + pathComponents).joined(separator: "/")
+        default:
+            "\(authority)/…/\(pathComponents.last ?? "")"
+        }
+        return compactMiddle(text, maxLength: 80)
+    }
+
+    private static func compactRefSubtitle(_ raw: String) -> String {
+        let ref = compactMiddle(raw, maxLength: 28)
+        return "ref \(ref)"
+    }
+
+    private static func isLocalOrInternalTarget(_ raw: String) -> Bool {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if trimmed.hasPrefix("file:") || trimmed.hasPrefix("repoprompt:") || trimmed.hasPrefix("mcp:") { return true }
+        if raw.hasPrefix("/") || raw.hasPrefix("~") || raw.hasPrefix("./") || raw.hasPrefix("../") { return true }
+        return false
+    }
+
+    private static func compactText(_ raw: String, maxLength: Int) -> String {
+        var output = ""
+        output.reserveCapacity(min(raw.count, maxLength + 8))
+        var lastWasWhitespace = true
+        for scalar in raw.unicodeScalars {
+            if compactTextSeparators.contains(scalar) {
+                if !lastWasWhitespace, !output.isEmpty {
+                    output.append(" ")
+                    lastWasWhitespace = true
+                }
+            } else {
+                output.unicodeScalars.append(scalar)
+                lastWasWhitespace = false
+            }
+            if output.count > maxLength * 2 { break }
+        }
+        return compactMiddle(output.trimmingCharacters(in: .whitespacesAndNewlines), maxLength: maxLength)
+    }
+
+    private static func compactMiddle(_ raw: String, maxLength: Int) -> String {
+        guard raw.count > maxLength, maxLength > 3 else { return raw }
+        let sideLength = max((maxLength - 1) / 2, 1)
+        let suffixLength = maxLength - sideLength - 1
+        return "\(raw.prefix(sideLength))…\(raw.suffix(suffixLength))"
+    }
+}

--- a/Sources/RepoPrompt/Features/AgentMode/Views/AgentMessageBubble.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/AgentMessageBubble.swift
@@ -491,21 +491,22 @@ struct AgentMessageBubble: View {
     // MARK: - Tool Call Bubble
 
     private var toolCallBubble: some View {
-        HStack {
+        let presentation = toolCallBubblePresentation(toolName: item.toolName, args: item.toolArgsJSON)
+        return HStack {
             VStack(alignment: .leading, spacing: 4) {
                 VStack(alignment: .leading, spacing: 8) {
                     // Header with tool icon and name
                     HStack(spacing: 6) {
-                        Image(systemName: toolIconName(for: item.toolName))
+                        Image(systemName: presentation.iconName)
                             .font(fontPreset.swiftUIFont(sizeAtNormal: 11))
                             .foregroundColor(.orange)
 
-                        Text(toolDisplayName(for: item.toolName))
+                        Text(presentation.title)
                             .font(fontPreset.swiftUIFont(sizeAtNormal: 12, weight: .semibold))
                             .foregroundColor(.primary)
 
                         // Show key argument inline for common tools
-                        if let summary = toolArgsSummary(toolName: item.toolName, args: item.toolArgsJSON) {
+                        if let summary = presentation.summary {
                             Text(summary)
                                 .font(fontPreset.swiftUIFont(sizeAtNormal: 11))
                                 .foregroundColor(.secondary)
@@ -965,14 +966,37 @@ struct AgentMessageBubble: View {
 
     // MARK: - Tool Display Helpers
 
+    private struct ToolCallBubblePresentation {
+        let iconName: String
+        let title: String
+        let summary: String?
+    }
+
+    private func toolCallBubblePresentation(toolName: String?, args: String?) -> ToolCallBubblePresentation {
+        let normalized = normalizedToolCardName(toolName) ?? toolName
+        let argsObject = parseJSONObject(args)
+        let webPresentation = AgentWebToolActionPresentation.classify(AgentWebToolActionInput(
+            rawToolName: toolName,
+            normalizedToolName: normalized,
+            argsObject: argsObject,
+            resultObject: nil
+        ))
+        return ToolCallBubblePresentation(
+            iconName: toolIconName(forNormalizedToolName: normalized),
+            title: webPresentation?.title ?? toolDisplayName(forNormalizedToolName: normalized),
+            summary: webPresentation?.subtitle ?? toolArgsSummary(normalizedToolName: normalized, argsObject: argsObject)
+        )
+    }
+
     /// Get appropriate icon for tool call
-    private func toolIconName(for toolName: String?) -> String {
-        switch toolName {
+    private func toolIconName(forNormalizedToolName normalized: String?) -> String {
+        switch normalized {
         case "ask_user_question", "ask_user": "questionmark.circle"
         case "read_file": "doc.text"
         case "apply_edits": "pencil"
         case "file_actions": "doc.badge.plus"
         case "file_search": "magnifyingglass.circle"
+        case "search", "web_read": "globe"
         case "get_file_tree": "folder"
         case "get_code_structure": "list.bullet.indent"
         case "manage_selection": "checkmark.circle"
@@ -986,13 +1010,15 @@ struct AgentMessageBubble: View {
     }
 
     /// Get human-readable display name for tool
-    private func toolDisplayName(for toolName: String?) -> String {
-        switch toolName {
+    private func toolDisplayName(forNormalizedToolName normalized: String?) -> String {
+        switch normalized {
         case "ask_user_question", "ask_user": "User Question"
         case "read_file": "Read File"
         case "apply_edits": "Edit File"
         case "file_actions": "File Action"
         case "file_search": "Search"
+        case "search": "Web Search"
+        case "web_read": "Read Web Page"
         case "get_file_tree": "File Tree"
         case "get_code_structure": "Code Structure"
         case "manage_selection": "Selection"
@@ -1007,10 +1033,10 @@ struct AgentMessageBubble: View {
     }
 
     /// Extract key argument for inline display
-    private func toolArgsSummary(toolName: String?, args: String?) -> String? {
-        guard let json = parseJSONObject(args) else { return nil }
+    private func toolArgsSummary(normalizedToolName: String?, argsObject json: [String: Any]?) -> String? {
+        guard let json else { return nil }
 
-        switch toolName {
+        switch normalizedToolName {
         case "ask_user_question", "ask_user":
             if let question = json["question"] as? String {
                 return compactSingleLine(question, maxLength: 80)

--- a/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/ClusterToolCategory.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/ClusterToolCategory.swift
@@ -56,7 +56,7 @@ enum ClusterToolCategory {
         let entries = toolNames.map {
             ToolEntry(
                 rawName: $0,
-                normalizedName: $0.lowercased(),
+                normalizedName: normalizedToolCardName($0)?.lowercased() ?? $0.lowercased(),
                 count: counts[$0] ?? counts[$0.lowercased()] ?? 1
             )
         }
@@ -181,7 +181,8 @@ enum ClusterToolCategory {
         var hasExecution = false
         var hasAgentControl = false
         for toolName in sourceNames {
-            switch classification(forNormalizedToolName: toolName).summaryTitleSignal {
+            let normalizedToolName = normalizedToolCardName(toolName)?.lowercased() ?? toolName.lowercased()
+            switch classification(forNormalizedToolName: normalizedToolName).summaryTitleSignal {
             case .navigation:
                 hasNavigation = true
             case .edit:
@@ -218,10 +219,10 @@ enum ClusterToolCategory {
     // MARK: - Tool categories
 
     private static let navigationTools: Set<String> = [
-        "get_file_tree", "read_file", "read", "file_search", "search", "get_code_structure"
+        "get_file_tree", "read_file", "read", "file_search", "search", "web_read", "get_code_structure"
     ]
     private static let summaryTitleNavigationTools: Set<String> = [
-        "get_file_tree", "read_file", "read", "file_search", "search", "get_code_structure"
+        "get_file_tree", "read_file", "read", "file_search", "search", "web_read", "get_code_structure"
     ]
     private static let editTools: Set<String> = [
         "apply_edits", "apply_patch", "edit", "file_actions"

--- a/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/ToolCardContainer.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/ToolCardContainer.swift
@@ -468,7 +468,7 @@ func toolIcon(for toolName: String?) -> String {
         return "doc.text"
     case "bash", "shell", "local_shell", "unified_exec", "exec_command", "run_shell_command":
         return "terminal"
-    case "search", "web_search", "web_search_request", "google_web_search", "search_web":
+    case "search", "web_read":
         return "globe"
     case "apply_edits", "mcp__RepoPrompt__apply_edits":
         return "pencil"
@@ -536,8 +536,10 @@ func toolDisplayName(for toolName: String?) -> String {
         return "Question"
     case "bash", "shell", "local_shell", "unified_exec", "exec_command", "run_shell_command":
         return "Bash"
-    case "search", "web_search", "web_search_request", "google_web_search", "search_web":
+    case "search":
         return "Web Search"
+    case "web_read":
+        return "Read Web Page"
     case "read", "Read":
         return "Read"
     case "read_file":

--- a/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/ToolCardRouter.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/ToolCardRouter.swift
@@ -7,13 +7,16 @@ func normalizedToolCardName(_ name: String?) -> String? {
     let canonical = MCPIntegrationHelper.canonicalRepoPromptToolName(raw) ?? raw
     // External tools can be namespaced (for example, "functions.bash").
     // Route by suffix so tool cards stay consistent.
+    if let webCanonical = AgentWebToolCanonicalNames.canonicalToolCardName(canonical.lowercased()) {
+        return webCanonical
+    }
     let suffix = canonical.split(separator: ".").last.map(String.init) ?? canonical
     let lowered = suffix.lowercased()
     if lowered == "local_shell" || lowered == "shell" || lowered == "unified_exec" || lowered == "exec_command" || lowered == "run_shell_command" {
         return "bash"
     }
-    if lowered == "web_search" || lowered == "web_search_request" || lowered == "google_web_search" || lowered == "search_web" {
-        return "search"
+    if let webCanonical = AgentWebToolCanonicalNames.canonicalToolCardName(lowered) {
+        return webCanonical
     }
     if lowered == "filechange" || lowered == "file_change" {
         return "apply_patch"
@@ -125,6 +128,7 @@ enum ToolCardRouter {
         "edit",
         "file_search",
         "search",
+        "web_read",
         "get_file_tree",
         "get_code_structure",
         "file_actions",
@@ -155,11 +159,12 @@ enum ToolCardRouter {
     ) -> AnyView {
         let normalized = normalizedToolCardName(item.toolName)
         let key = normalized?.lowercased()
-        let subtitle = callSubtitle(for: key, argsJSON: item.toolArgsJSON)
+        let presentation = callPresentation(for: item)
+        let subtitle = presentation?.subtitle ?? callSubtitle(for: key, argsJSON: item.toolArgsJSON)
         return AnyView(
             ToolCallCard(
                 item: item,
-                title: toolDisplayName(for: normalized ?? item.toolName),
+                title: presentation?.title ?? toolDisplayName(for: normalized ?? item.toolName),
                 subtitle: subtitle,
                 oracleOpenContext: oracleOpenContext,
                 showRunScopedToolCancel: showRunScopedToolCancel,
@@ -193,7 +198,9 @@ enum ToolCardRouter {
         case "file_search":
             return AnyView(FileSearchResultCard(item: item))
         case "search":
-            return AnyView(WebSearchResultCard(item: item))
+            return AnyView(WebSearchResultCard(item: item, normalizedToolName: "search"))
+        case "web_read":
+            return AnyView(WebSearchResultCard(item: item, normalizedToolName: "web_read"))
         case "get_file_tree":
             return AnyView(FileTreeResultCard(item: item))
         case "get_code_structure":
@@ -243,6 +250,22 @@ enum ToolCardRouter {
             }
             return AnyView(UnknownToolResultCard(item: item, title: toolDisplayName(for: normalized ?? item.toolName)))
         }
+    }
+
+    struct ToolCallPresentation: Equatable {
+        let title: String
+        let subtitle: String?
+    }
+
+    static func callPresentation(for item: AgentChatItem) -> ToolCallPresentation? {
+        let normalized = normalizedToolCardName(item.toolName)?.lowercased()
+        guard let webPresentation = AgentWebToolActionPresentation.classify(
+            rawToolName: item.toolName,
+            normalizedToolName: normalized,
+            argsJSON: item.toolArgsJSON,
+            resultJSON: nil
+        ) else { return nil }
+        return ToolCallPresentation(title: webPresentation.title, subtitle: webPresentation.subtitle)
     }
 
     static func callSubtitle(for toolName: String?, argsJSON: String?) -> String? {
@@ -455,8 +478,8 @@ private enum ToolCardSubtitleBuilder {
             {
                 return command
             }
-        case "search", "web_search", "web_search_request", "google_web_search", "search_web":
-            if let query = stringArgument(from: argsJSON, keys: ["query", "q", "search_query", "searchQuery", "text", "value"]),
+        case "search":
+            if let query = stringArgument(from: argsJSON, keys: AgentWebToolPayloadKeys.legacySearchQueryKeys),
                !query.isEmpty
             {
                 return "\"\(query)\""

--- a/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/ToolResultReadSearchCards.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/ToolResultReadSearchCards.swift
@@ -218,9 +218,17 @@ enum NativeToolCardPresentationBuilder {
         _ renderSummary: AgentToolCardRenderSummary,
         normalizedToolName: String?
     ) -> Bool {
-        guard let normalizedToolName, renderSummary.toolName == normalizedToolName else { return false }
-        if normalizedToolName == "search" { return true }
-        return AgentToolCardRenderSummaryBuilder.isSafeNativeFallbackToolName(normalizedToolName)
+        guard let normalizedToolName else { return false }
+        let storedName = summaryToolNameKey(renderSummary.toolName)
+        let currentName = summaryToolNameKey(normalizedToolName)
+        guard storedName == currentName else { return false }
+        if currentName == "search" { return true }
+        return AgentToolCardRenderSummaryBuilder.isSafeNativeFallbackToolName(currentName)
+    }
+
+    private static func summaryToolNameKey(_ raw: String) -> String {
+        let normalized = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return AgentWebToolCanonicalNames.canonicalToolCardName(normalized) ?? normalized
     }
 
     private static func statusWord(for item: AgentChatItem) -> String {

--- a/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/ToolResultReadSearchCards.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/ToolResultReadSearchCards.swift
@@ -141,28 +141,23 @@ struct FileSearchResultCard: View {
 
 struct WebSearchResultCard: View {
     let item: AgentChatItem
+    let normalizedToolName: String
     @State private var isExpanded = false
 
-    private var presentation: AgentToolCardRenderSummary? {
-        NativeToolCardPresentationBuilder.build(item: item, normalizedToolName: "search")
-    }
-
-    private var summary: String? {
-        presentation?.inlineSummaryText ?? storageStatusSubtitle(for: item)
-    }
-
-    private var status: ToolCardStatus {
-        if let presentation {
-            return ToolCardStatus.fromRenderStatus(presentation.status)
-        }
-        return ToolResultStatusResolver.resolve(toolIsError: item.toolIsError, raw: item.toolResultJSON, fallback: .neutral)
+    init(item: AgentChatItem, normalizedToolName: String = "search") {
+        self.item = item
+        self.normalizedToolName = normalizedToolName
     }
 
     var body: some View {
-        ToolCardContainer(
-            iconName: toolIcon(for: "search"),
-            iconColor: ToolCardAccentResolver.color(for: "search"),
-            title: "Web Search",
+        let presentation = NativeToolCardPresentationBuilder.build(item: item, normalizedToolName: normalizedToolName)
+        let summary = presentation?.inlineSummaryText ?? storageStatusSubtitle(for: item)
+        let status = presentation.map { ToolCardStatus.fromRenderStatus($0.status) }
+            ?? ToolResultStatusResolver.resolve(toolIsError: item.toolIsError, raw: item.toolResultJSON, fallback: .neutral)
+        return ToolCardContainer(
+            iconName: toolIcon(for: normalizedToolName),
+            iconColor: ToolCardAccentResolver.color(for: normalizedToolName),
+            title: presentation?.title ?? toolDisplayName(for: normalizedToolName),
             subtitle: nonEmptyToolCardSummary(summary, fallbackStatusFor: item),
             status: status,
             timestamp: item.timestamp,
@@ -179,12 +174,9 @@ struct NativeToolResultCard: View {
     let normalizedToolName: String?
     @State private var isExpanded = false
 
-    private var presentation: AgentToolCardRenderSummary? {
-        NativeToolCardPresentationBuilder.build(item: item, normalizedToolName: normalizedToolName)
-    }
-
     var body: some View {
-        ToolCardContainer(
+        let presentation = NativeToolCardPresentationBuilder.build(item: item, normalizedToolName: normalizedToolName)
+        return ToolCardContainer(
             iconName: toolIcon(for: normalizedToolName ?? item.toolName),
             iconColor: ToolCardAccentResolver.color(for: normalizedToolName ?? item.toolName),
             title: presentation?.title ?? toolDisplayName(for: normalizedToolName ?? item.toolName),
@@ -214,6 +206,7 @@ enum NativeToolCardPresentationBuilder {
         let statusWord = statusWord(for: item)
         return AgentToolCardRenderSummaryBuilder.build(
             normalizedToolName: normalizedToolName,
+            rawToolName: item.toolName,
             statusWord: statusWord,
             rawObject: rawObject,
             argsObject: argsObject,

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexNativeSessionController.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexNativeSessionController.swift
@@ -4295,8 +4295,13 @@ final class CodexNativeSessionController {
     }
 
     private static func isItemLifecycleCompletedMethod(_ lowerMethod: String) -> Bool {
+        guard !isRawResponseItemCompletedMethod(lowerMethod) else { return false }
         guard lowerMethod.contains("item/") || lowerMethod.contains("item_") else { return false }
         return lowerMethod.hasSuffix("/completed") || lowerMethod.hasSuffix("_completed")
+    }
+
+    private static func isRawResponseItemCompletedMethod(_ lowerMethod: String) -> Bool {
+        lowerMethod == "rawresponseitem/completed"
     }
 
     private static let minimalCompletedCommandExecutionResultJSON = #"{"type":"commandExecution","status":"completed"}"#
@@ -6375,12 +6380,12 @@ final class CodexNativeSessionController {
             }
         }
         if toolName == "search", var payload = compactWebActionScalars(from: candidate) {
-            if payload["query"] == nil, let query = searchQueryValue(from: candidate), !query.isEmpty {
+            if payload["query"] == nil, let query = searchQueryValue(from: candidate) {
                 payload["query"] = query
             }
             return jsonString(from: payload)
         }
-        if toolName == "search", let query = searchQueryValue(from: candidate), !query.isEmpty {
+        if toolName == "search", let query = searchQueryValue(from: candidate) {
             return jsonString(from: ["query": query])
         }
         if toolName == "web_read", let payload = compactWebActionScalars(from: candidate) {
@@ -6411,7 +6416,7 @@ final class CodexNativeSessionController {
         if toolName == "web_read", let readJSON = webReadToolResultJSON(from: candidate) {
             return readJSON
         }
-        for key in ["result", "output", "response", "content"] {
+        for key in AgentWebToolPayloadKeys.resultWrapperKeys {
             if let value = candidate[key], let json = jsonString(from: value), !json.isEmpty {
                 return json
             }
@@ -6428,19 +6433,20 @@ final class CodexNativeSessionController {
     private func webReadToolResultJSON(from candidate: [String: Any]) -> String? {
         var object: [String: Any] = [:]
         copyWebActionScalars(from: candidate, into: &object)
-        copyWebReadResultFields(from: candidate, into: &object)
-        return object.isEmpty ? nil : jsonString(from: object)
+        copyWebReadResultFieldsIncludingWrappers(from: candidate, into: &object)
+        let hasResultWrapper = AgentWebToolPayloadKeys.resultWrapperKeys.contains { candidate[$0] != nil }
+        return object.isEmpty && !hasResultWrapper ? nil : jsonString(from: object)
     }
 
     private func webSearchToolResultJSON(from candidate: [String: Any]) -> String? {
         var object: [String: Any] = [:]
         copySearchMetadata(from: candidate, into: &object)
         if isSearchWebReadOrFindPayload(object) {
-            copyWebReadResultFields(from: candidate, into: &object)
+            copyWebReadResultFieldsIncludingWrappers(from: candidate, into: &object)
             return jsonString(from: object)
         }
 
-        for key in ["result", "output", "response", "content"] {
+        for key in AgentWebToolPayloadKeys.resultWrapperKeys {
             guard let value = candidate[key] else { continue }
             if let array = value as? [Any] {
                 if !array.isEmpty { object[searchArrayKey(forWrapper: key)] = array }
@@ -6474,14 +6480,20 @@ final class CodexNativeSessionController {
 
     private func copySearchMetadata(from candidate: [String: Any], into object: inout [String: Any]) {
         copyWebActionScalars(from: candidate, into: &object)
-        for key in ["status", "query", "q", "searchQuery", "search_query", "isError", "is_error"] {
+        for key in ["status", "isError", "is_error"] {
             if object[key] == nil, let value = candidate[key] {
                 object[key] = value
             }
         }
+        for key in AgentWebToolPayloadKeys.queryKeys {
+            guard object[key] == nil,
+                  let value = candidate[key] as? String,
+                  let query = compactWebQueryText(value)
+            else { continue }
+            object[key] = query
+        }
         if object["query"] == nil,
-           let query = searchQueryValue(from: candidate),
-           !query.isEmpty
+           let query = searchQueryValue(from: candidate)
         {
             object["query"] = query
         }
@@ -6492,14 +6504,23 @@ final class CodexNativeSessionController {
 
     private func copyWebReadResultFields(from candidate: [String: Any], into object: inout [String: Any]) {
         for key in AgentWebToolPayloadKeys.readResultMetadataKeys {
-            guard object[key] == nil, let value = candidate[key] else { continue }
-            object[key] = value
+            guard object[key] == nil,
+                  let value = candidate[key],
+                  let compactValue = compactWebReadResultValue(value)
+            else { continue }
+            object[key] = compactValue
         }
-        if object["error"] == nil, let error = candidate["error"] {
-            object["error"] = error
+        if object["error"] == nil,
+           let error = candidate["error"],
+           let compactError = compactWebReadErrorValue(error)
+        {
+            object["error"] = compactError
         }
-        if object["errorMessage"] == nil, let errorMessage = candidate["errorMessage"] ?? candidate["error_message"] {
-            object["errorMessage"] = errorMessage
+        if object["errorMessage"] == nil,
+           let errorMessage = candidate["errorMessage"] ?? candidate["error_message"],
+           let compactErrorMessage = compactWebReadResultValue(errorMessage)
+        {
+            object["errorMessage"] = compactErrorMessage
         }
         if object["match_count"] == nil, object["matchCount"] == nil,
            let matches = candidate["matches"] as? [Any], !matches.isEmpty
@@ -6508,9 +6529,63 @@ final class CodexNativeSessionController {
         }
     }
 
+    private func copyWebReadResultFieldsIncludingWrappers(
+        from candidate: [String: Any],
+        into object: inout [String: Any]
+    ) {
+        copyWebReadResultFields(from: candidate, into: &object)
+        for key in AgentWebToolPayloadKeys.resultWrapperKeys {
+            guard let wrapped = candidate[key] as? [String: Any] else { continue }
+            copyWebActionScalars(from: wrapped, into: &object)
+            copyWebReadResultFields(from: wrapped, into: &object)
+            copyWebReadFailureMessage(from: wrapped, into: &object)
+        }
+        copyWebReadFailureMessage(from: candidate, into: &object)
+    }
+
+    private func copyWebReadFailureMessage(from candidate: [String: Any], into object: inout [String: Any]) {
+        guard webReadResultIndicatesFailure(candidate), object["errorMessage"] == nil else { return }
+        for key in ["errorMessage", "error_message", "result", "output", "response", "message", "text"] {
+            guard let value = candidate[key],
+                  !(value is [String: Any]),
+                  let compactErrorMessage = compactWebReadResultValue(value)
+            else { continue }
+            object["errorMessage"] = compactErrorMessage
+            return
+        }
+    }
+
+    private func webReadResultIndicatesFailure(_ candidate: [String: Any]) -> Bool {
+        if boolValue(from: candidate, keys: ["isError", "is_error"]) == true { return true }
+        if let status = stringValue(from: candidate, keys: ["status"])?.lowercased(),
+           ["error", "failed", "failure"].contains(status)
+        {
+            return true
+        }
+        return hasNonEmptyErrorSignal(in: candidate)
+    }
+
+    private func compactWebReadResultValue(_ value: Any) -> Any? {
+        if let text = value as? String { return compactWebText(text) }
+        if value is NSNumber { return value }
+        return nil
+    }
+
+    private func compactWebReadErrorValue(_ value: Any) -> Any? {
+        if let compact = compactWebReadResultValue(value) { return compact }
+        guard let error = value as? [String: Any] else { return nil }
+        var compactError: [String: Any] = [:]
+        for key in ["message", "type", "code", "param", "status"] {
+            guard let value = error[key], let compact = compactWebReadResultValue(value) else { continue }
+            compactError[key] = compact
+        }
+        return compactError.isEmpty ? nil : compactError
+    }
+
     private func isSearchWebReadOrFindPayload(_ object: [String: Any]) -> Bool {
-        let action = stringValue(from: object, keys: AgentWebToolPayloadKeys.operationKeys)?.lowercased()
-        if ["open", "read", "fetch", "find"].contains(action ?? "") { return true }
+        let rawAction = stringValue(from: object, keys: AgentWebToolPayloadKeys.operationKeys)
+        let action = AgentWebToolCanonicalNames.canonicalWebActionType(rawAction) ?? rawAction?.lowercased()
+        if ["open", "open_page", "read", "fetch", "find", "find_in_page"].contains(action ?? "") { return true }
         let hasTarget = stringValue(from: object, keys: AgentWebToolPayloadKeys.urlTargetKeys + AgentWebToolPayloadKeys.refTargetKeys) != nil
         let hasFind = stringValue(from: object, keys: AgentWebToolPayloadKeys.findKeys) != nil
         return hasTarget && hasFind
@@ -6527,6 +6602,43 @@ final class CodexNativeSessionController {
             guard object[key] == nil, let value = candidate[key], isCompactWebActionScalar(value) else { continue }
             object[key] = value
         }
+
+        var containers = [candidate]
+        for key in AgentWebToolPayloadKeys.wrapperKeys {
+            if let nested = candidate[key] as? [String: Any] {
+                containers.append(nested)
+            }
+        }
+        for container in containers {
+            guard let action = container["action"] as? [String: Any],
+                  let actionType = stringValue(from: action, keys: AgentWebToolPayloadKeys.actionTypeKeys),
+                  let canonicalActionType = AgentWebToolCanonicalNames.canonicalWebActionType(actionType)
+            else { continue }
+            if object["action"] == nil {
+                object["action"] = canonicalActionType
+            }
+            for key in AgentWebToolPayloadKeys.compactScalarKeys {
+                guard key != "action",
+                      object[key] == nil,
+                      let value = action[key],
+                      isCompactWebActionScalar(value)
+                else { continue }
+                object[key] = value
+            }
+            copyCompactWebSearchQueries(from: action, into: &object)
+        }
+    }
+
+    private func copyCompactWebSearchQueries(from candidate: [String: Any], into object: inout [String: Any]) {
+        guard object["queries"] == nil else { return }
+        for key in AgentWebToolPayloadKeys.queryListKeys {
+            guard let queries = candidate[key] as? [String] else { continue }
+            let compactQueries = queries.prefix(10).compactMap(compactWebText)
+            if !compactQueries.isEmpty {
+                object["queries"] = compactQueries
+                return
+            }
+        }
     }
 
     private func isCompactWebActionScalar(_ value: Any) -> Bool {
@@ -6539,17 +6651,33 @@ final class CodexNativeSessionController {
 
     private func searchQueryValue(from candidate: [String: Any]) -> String? {
         if let query = stringValue(from: candidate, keys: AgentWebToolPayloadKeys.queryKeys),
-           !query.isEmpty
+           let compactQuery = compactWebQueryText(query)
         {
-            return query
+            return compactQuery
+        }
+        for key in AgentWebToolPayloadKeys.queryListKeys {
+            guard let queries = candidate[key] as? [String] else { continue }
+            let compactQueries = queries.compactMap(compactWebQueryText)
+            guard let first = compactQueries.first else { continue }
+            return compactWebQueryText(compactQueries.count > 1 ? "\(first) ..." : first)
         }
         for key in ["action", "search", "request", "parameters", "params"] {
             guard let nested = candidate[key] as? [String: Any] else { continue }
-            if let query = searchQueryValue(from: nested), !query.isEmpty {
+            if let query = searchQueryValue(from: nested) {
                 return query
             }
         }
         return nil
+    }
+
+    private func compactWebQueryText(_ raw: String) -> String? {
+        compactWebText(raw)
+    }
+
+    private func compactWebText(_ raw: String) -> String? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        return trimmed.count <= 500 ? trimmed : String(trimmed.prefix(499)) + "…"
     }
 
     private func copySearchPayloadFields(from candidate: [String: Any], into object: inout [String: Any]) {

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexNativeSessionController.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexNativeSessionController.swift
@@ -6345,12 +6345,8 @@ final class CodexNativeSessionController {
         {
             return "bash"
         }
-        if lowered == "web_search"
-            || lowered == "web_search_request"
-            || lowered == "google_web_search"
-            || lowered == "search_web"
-        {
-            return "search"
+        if let webCanonical = AgentWebToolCanonicalNames.canonicalToolCardName(lowered) {
+            return webCanonical
         }
         if !raw.isEmpty {
             if isRepoPromptToolCandidate(candidate, toolName: raw) {
@@ -6378,8 +6374,17 @@ final class CodexNativeSessionController {
                 return json
             }
         }
+        if toolName == "search", var payload = compactWebActionScalars(from: candidate) {
+            if payload["query"] == nil, let query = searchQueryValue(from: candidate), !query.isEmpty {
+                payload["query"] = query
+            }
+            return jsonString(from: payload)
+        }
         if toolName == "search", let query = searchQueryValue(from: candidate), !query.isEmpty {
             return jsonString(from: ["query": query])
+        }
+        if toolName == "web_read", let payload = compactWebActionScalars(from: candidate) {
+            return jsonString(from: payload)
         }
         if let command = stringValue(from: candidate, keys: ["command", "cmd"]), !command.isEmpty {
             var payload: [String: Any] = ["command": command]
@@ -6403,6 +6408,9 @@ final class CodexNativeSessionController {
         if toolName == "search", let searchJSON = webSearchToolResultJSON(from: candidate) {
             return searchJSON
         }
+        if toolName == "web_read", let readJSON = webReadToolResultJSON(from: candidate) {
+            return readJSON
+        }
         for key in ["result", "output", "response", "content"] {
             if let value = candidate[key], let json = jsonString(from: value), !json.isEmpty {
                 return json
@@ -6417,9 +6425,20 @@ final class CodexNativeSessionController {
         return nil
     }
 
+    private func webReadToolResultJSON(from candidate: [String: Any]) -> String? {
+        var object: [String: Any] = [:]
+        copyWebActionScalars(from: candidate, into: &object)
+        copyWebReadResultFields(from: candidate, into: &object)
+        return object.isEmpty ? nil : jsonString(from: object)
+    }
+
     private func webSearchToolResultJSON(from candidate: [String: Any]) -> String? {
         var object: [String: Any] = [:]
         copySearchMetadata(from: candidate, into: &object)
+        if isSearchWebReadOrFindPayload(object) {
+            copyWebReadResultFields(from: candidate, into: &object)
+            return jsonString(from: object)
+        }
 
         for key in ["result", "output", "response", "content"] {
             guard let value = candidate[key] else { continue }
@@ -6454,6 +6473,7 @@ final class CodexNativeSessionController {
     }
 
     private func copySearchMetadata(from candidate: [String: Any], into object: inout [String: Any]) {
+        copyWebActionScalars(from: candidate, into: &object)
         for key in ["status", "query", "q", "searchQuery", "search_query", "isError", "is_error"] {
             if object[key] == nil, let value = candidate[key] {
                 object[key] = value
@@ -6470,8 +6490,55 @@ final class CodexNativeSessionController {
         }
     }
 
+    private func copyWebReadResultFields(from candidate: [String: Any], into object: inout [String: Any]) {
+        for key in AgentWebToolPayloadKeys.readResultMetadataKeys {
+            guard object[key] == nil, let value = candidate[key] else { continue }
+            object[key] = value
+        }
+        if object["error"] == nil, let error = candidate["error"] {
+            object["error"] = error
+        }
+        if object["errorMessage"] == nil, let errorMessage = candidate["errorMessage"] ?? candidate["error_message"] {
+            object["errorMessage"] = errorMessage
+        }
+        if object["match_count"] == nil, object["matchCount"] == nil,
+           let matches = candidate["matches"] as? [Any], !matches.isEmpty
+        {
+            object["match_count"] = matches.count
+        }
+    }
+
+    private func isSearchWebReadOrFindPayload(_ object: [String: Any]) -> Bool {
+        let action = stringValue(from: object, keys: AgentWebToolPayloadKeys.operationKeys)?.lowercased()
+        if ["open", "read", "fetch", "find"].contains(action ?? "") { return true }
+        let hasTarget = stringValue(from: object, keys: AgentWebToolPayloadKeys.urlTargetKeys + AgentWebToolPayloadKeys.refTargetKeys) != nil
+        let hasFind = stringValue(from: object, keys: AgentWebToolPayloadKeys.findKeys) != nil
+        return hasTarget && hasFind
+    }
+
+    private func compactWebActionScalars(from candidate: [String: Any]) -> [String: Any]? {
+        var object: [String: Any] = [:]
+        copyWebActionScalars(from: candidate, into: &object)
+        return object.isEmpty ? nil : object
+    }
+
+    private func copyWebActionScalars(from candidate: [String: Any], into object: inout [String: Any]) {
+        for key in AgentWebToolPayloadKeys.compactScalarKeys {
+            guard object[key] == nil, let value = candidate[key], isCompactWebActionScalar(value) else { continue }
+            object[key] = value
+        }
+    }
+
+    private func isCompactWebActionScalar(_ value: Any) -> Bool {
+        if let text = value as? String {
+            return !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && text.count <= 500
+        }
+        if value is NSNumber { return true }
+        return false
+    }
+
     private func searchQueryValue(from candidate: [String: Any]) -> String? {
-        if let query = stringValue(from: candidate, keys: ["query", "q", "searchQuery", "search_query", "search_text", "searchText"]),
+        if let query = stringValue(from: candidate, keys: AgentWebToolPayloadKeys.queryKeys),
            !query.isEmpty
         {
             return query
@@ -6486,6 +6553,7 @@ final class CodexNativeSessionController {
     }
 
     private func copySearchPayloadFields(from candidate: [String: Any], into object: inout [String: Any]) {
+        copyWebActionScalars(from: candidate, into: &object)
         for key in ["results", "items", "web_results", "webResults", "search_results", "searchResults", "sources", "citations", "result_count", "resultCount", "total_results", "totalResults", "count", "source_count", "sourceCount", "total_sources", "totalSources", "citation_count", "citationCount", "total_citations", "totalCitations", "summary", "answer", "snippet", "text", "message", "error", "errors", "error_message", "errorMessage"] {
             guard object[key] == nil, let value = candidate[key] else { continue }
             object[key] = value

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexAgentModeCoordinatorLivenessTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexAgentModeCoordinatorLivenessTests.swift
@@ -49,6 +49,44 @@ final class CodexAgentModeCoordinatorLivenessTests: XCTestCase {
         XCTAssertEqual(session.runState, .running)
     }
 
+    func testUnmatchedCompletionOnlyWebResultPreservesArgsForPersistenceAndReplay() async throws {
+        let controller = LivenessFakeCodexController(snapshot: .active(activeFlags: []))
+        let viewModel = makeViewModel(controller: controller)
+        let session = preparedCodexSession(in: viewModel, controller: controller)
+        let invocationID = UUID()
+        let argsJSON = #"{"action":"find_in_page","url":"https://example.com/docs","pattern":"install"}"#
+        let resultJSON = #"{"status":"completed","match_count":2}"#
+
+        await viewModel.test_codexCoordinator.test_handleCodexNativeEvent(
+            .toolResult(
+                name: "search",
+                invocationID: invocationID,
+                argsJSON: argsJSON,
+                resultJSON: resultJSON,
+                isError: false
+            ),
+            session: session
+        )
+
+        let item = try XCTUnwrap(session.items.last)
+        XCTAssertEqual(item.kind, .toolResult)
+        XCTAssertEqual(item.toolInvocationID, invocationID)
+        XCTAssertEqual(item.toolArgsJSON, argsJSON)
+        let livePresentation = try XCTUnwrap(
+            NativeToolCardPresentationBuilder.build(item: item, normalizedToolName: "search")
+        )
+        XCTAssertEqual(livePresentation.title, "Find In Page")
+
+        let persisted = AgentChatItemPersist(from: item)
+        let restored = persisted.toItem()
+        XCTAssertEqual(restored.toolInvocationID, invocationID)
+        let restoredPresentation = try XCTUnwrap(
+            NativeToolCardPresentationBuilder.build(item: restored, normalizedToolName: "search")
+        )
+        XCTAssertEqual(restoredPresentation.title, "Find In Page")
+        XCTAssertEqual(restoredPresentation.detailText, "2 matches")
+    }
+
     func testStructuredRetryAndMissingMetadataFallbackRemainActiveWithoutRows() async {
         let controller = LivenessFakeCodexController(snapshot: .active(activeFlags: []))
         let viewModel = makeViewModel(controller: controller)

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexNativeSessionControllerEventRecoveryTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexNativeSessionControllerEventRecoveryTests.swift
@@ -237,6 +237,167 @@ final class CodexNativeSessionControllerEventRecoveryTests: XCTestCase {
         XCTAssertNil(completedResult["content"])
     }
 
+    func testActualCodexWebSearchLifecycleShapesPreserveQueriesAndIgnoreRawDuplicate() throws {
+        let controller = makeController()
+        let started = try XCTUnwrap(controller.test_parseToolLifecycleEvent(
+            method: "item/started",
+            params: toolParams(item: [
+                "type": "webSearch",
+                "id": "ws_actual",
+                "query": "",
+                "action": ["type": "other"]
+            ])
+        ))
+        XCTAssertEqual(started.kind, "call")
+        XCTAssertEqual(started.name, "search")
+        XCTAssertNil(started.argsJSON)
+
+        let completed = try XCTUnwrap(controller.test_parseToolLifecycleEvent(
+            method: "item/completed",
+            params: toolParams(item: [
+                "type": "webSearch",
+                "id": "ws_actual",
+                "query": "first query ...",
+                "action": [
+                    "type": "search",
+                    "query": NSNull(),
+                    "queries": ["first query", "second query"]
+                ]
+            ])
+        ))
+        XCTAssertEqual(completed.kind, "result")
+        XCTAssertEqual(completed.name, "search")
+        XCTAssertEqual(completed.invocationID, started.invocationID)
+        XCTAssertNil(completed.isError)
+        let args = try XCTUnwrap(jsonObject(from: completed.argsJSON))
+        let result = try XCTUnwrap(jsonObject(from: completed.resultJSON))
+        XCTAssertEqual(args["action"] as? String, "search")
+        XCTAssertEqual(args["query"] as? String, "first query ...")
+        XCTAssertEqual(args["queries"] as? [String], ["first query", "second query"])
+        XCTAssertEqual(result["action"] as? String, "search")
+        XCTAssertEqual(result["query"] as? String, "first query ...")
+        XCTAssertEqual(result["queries"] as? [String], ["first query", "second query"])
+
+        XCTAssertFalse(CodexNativeSessionController.test_isItemLifecycleNotificationMethod("rawResponseItem/completed"))
+        XCTAssertNil(controller.test_parseToolLifecycleEvent(
+            method: "rawResponseItem/completed",
+            params: toolParams(item: [
+                "type": "web_search_call",
+                "status": "completed",
+                "action": [
+                    "type": "search",
+                    "queries": ["first query", "second query"]
+                ]
+            ])
+        ))
+
+        let recovered = try XCTUnwrap(controller.test_parseToolLifecycleEvent(
+            method: "item/completed",
+            params: toolParams(item: [
+                "type": "webSearch",
+                "id": "ws_recovered_begin",
+                "query": "",
+                "action": NSNull()
+            ])
+        ))
+        XCTAssertEqual(recovered.name, "search")
+        XCTAssertNil(recovered.argsJSON)
+    }
+
+    func testNativeWebSearchNestedTaggedActionsPreserveCompactFieldsAcrossLifecycle() throws {
+        let rows: [(label: String, action: [String: Any], expectedAction: String, expectedFields: [String: String])] = [
+            (
+                "search",
+                ["type": "search", "query": "nested Codex query"],
+                "search",
+                ["query": "nested Codex query"]
+            ),
+            (
+                "camel open page",
+                ["type": "openPage", "url": "https://docs.example.com/open", "refId": "turn0search0"],
+                "open_page",
+                ["url": "https://docs.example.com/open", "refId": "turn0search0"]
+            ),
+            (
+                "actual targetless find in page",
+                ["type": "findInPage", "url": NSNull(), "pattern": "installation"],
+                "find_in_page",
+                ["pattern": "installation"]
+            )
+        ]
+
+        for (index, row) in rows.enumerated() {
+            let controller = makeController()
+            let itemID = "call_nested_web_\(index)"
+            let started = try XCTUnwrap(controller.test_parseToolLifecycleEvent(
+                method: "item/started",
+                params: toolParams(item: [
+                    "type": "webSearch",
+                    "id": itemID,
+                    "action": row.action
+                ])
+            ), row.label)
+            XCTAssertEqual(started.kind, "call", row.label)
+            XCTAssertEqual(started.name, "search", row.label)
+            let startedArgs = try XCTUnwrap(jsonObject(from: started.argsJSON), row.label)
+            XCTAssertEqual(startedArgs["action"] as? String, row.expectedAction, row.label)
+            for (key, value) in row.expectedFields {
+                XCTAssertEqual(startedArgs[key] as? String, value, "\(row.label) started \(key)")
+            }
+
+            let completed = try XCTUnwrap(controller.test_parseToolLifecycleEvent(
+                method: "item/completed",
+                params: toolParams(item: [
+                    "type": "webSearch",
+                    "id": itemID,
+                    "status": "completed",
+                    "action": row.action
+                ])
+            ), row.label)
+            XCTAssertEqual(completed.kind, "result", row.label)
+            XCTAssertEqual(completed.name, "search", row.label)
+            XCTAssertEqual(completed.invocationID, started.invocationID, row.label)
+            let completedArgs = try XCTUnwrap(jsonObject(from: completed.argsJSON), row.label)
+            let completedResult = try XCTUnwrap(jsonObject(from: completed.resultJSON), row.label)
+            XCTAssertEqual(completedArgs["action"] as? String, row.expectedAction, row.label)
+            XCTAssertEqual(completedResult["action"] as? String, row.expectedAction, row.label)
+            for (key, value) in row.expectedFields {
+                XCTAssertEqual(completedArgs[key] as? String, value, "\(row.label) completed args \(key)")
+                XCTAssertEqual(completedResult[key] as? String, value, "\(row.label) completed result \(key)")
+            }
+        }
+
+        let bodyMarker = "wrapped nested web body"
+        let wrappedController = makeController()
+        let wrapped = try XCTUnwrap(wrappedController.test_parseToolLifecycleEvent(
+            method: "item/completed",
+            params: toolParams(item: [
+                "type": "webSearch",
+                "id": "call_nested_wrapped_find",
+                "status": "failed",
+                "action": [
+                    "type": "findInPage",
+                    "url": "https://docs.example.com/wrapped-find",
+                    "pattern": "installation"
+                ],
+                "response": [
+                    "title": "Wrapped find page",
+                    "matches": [["text": String(repeating: bodyMarker, count: 100)]],
+                    "error": ["message": "wrapped find failed"],
+                    "content": String(repeating: bodyMarker, count: 100)
+                ]
+            ])
+        ))
+        let wrappedResult = try XCTUnwrap(jsonObject(from: wrapped.resultJSON))
+        XCTAssertEqual(wrappedResult["action"] as? String, "find_in_page")
+        XCTAssertEqual(wrappedResult["url"] as? String, "https://docs.example.com/wrapped-find")
+        XCTAssertEqual(wrappedResult["pattern"] as? String, "installation")
+        XCTAssertEqual(wrappedResult["title"] as? String, "Wrapped find page")
+        XCTAssertEqual(wrappedResult["match_count"] as? Int, 1)
+        XCTAssertEqual((wrappedResult["error"] as? [String: Any])?["message"] as? String, "wrapped find failed")
+        XCTAssertFalse(wrapped.resultJSON?.contains(bodyMarker) == true)
+    }
+
     func testNativeWebReadAndFindEventsUseCanonicalWebReadNameAndCompactResults() throws {
         let controller = makeController()
         let started = try XCTUnwrap(controller.test_parseToolLifecycleEvent(
@@ -279,7 +440,159 @@ final class CodexNativeSessionControllerEventRecoveryTests: XCTestCase {
         XCTAssertFalse(completed.resultJSON?.contains("full page body") == true)
     }
 
+    func testNativeWebReadWrapperResultsUnwrapCompactMetadataAndErrors() throws {
+        for wrapperKey in ["result", "output", "response", "content"] {
+            let bodyMarker = "full wrapped page body"
+            let controller = makeController()
+            let completed = try XCTUnwrap(controller.test_parseToolLifecycleEvent(
+                method: "item/completed",
+                params: toolParams(item: [
+                    "type": "toolCall",
+                    "id": "call_web_read_\(wrapperKey)",
+                    "name": "web_fetch",
+                    "url": "https://docs.example.com/wrapped",
+                    wrapperKey: [
+                        "status": "completed",
+                        "title": "Wrapped docs",
+                        "description": String(repeating: "compact metadata ", count: 80),
+                        "error": [
+                            "message": "bounded warning",
+                            "code": 42,
+                            "details": String(repeating: "unbounded detail ", count: 100)
+                        ],
+                        "content": String(repeating: bodyMarker, count: 100)
+                    ]
+                ])
+            ), wrapperKey)
+
+            XCTAssertEqual(completed.name, "web_read", wrapperKey)
+            let result = try XCTUnwrap(jsonObject(from: completed.resultJSON), wrapperKey)
+            XCTAssertEqual(result["url"] as? String, "https://docs.example.com/wrapped", wrapperKey)
+            XCTAssertEqual(result["status"] as? String, "completed", wrapperKey)
+            XCTAssertEqual(result["title"] as? String, "Wrapped docs", wrapperKey)
+            XCTAssertLessThanOrEqual((result["description"] as? String)?.count ?? 0, 500, wrapperKey)
+            let error = try XCTUnwrap(result["error"] as? [String: Any], wrapperKey)
+            XCTAssertEqual(error["message"] as? String, "bounded warning", wrapperKey)
+            XCTAssertEqual(error["code"] as? Int, 42, wrapperKey)
+            XCTAssertNil(error["details"], wrapperKey)
+            XCTAssertNil(result[wrapperKey], wrapperKey)
+            XCTAssertFalse(completed.resultJSON?.contains(bodyMarker) == true, wrapperKey)
+
+            let bodyOnly = try XCTUnwrap(controller.test_parseToolLifecycleEvent(
+                method: "item/completed",
+                params: toolParams(item: [
+                    "type": "toolCall",
+                    "id": "call_web_read_body_only_\(wrapperKey)",
+                    "name": "web_fetch",
+                    wrapperKey: ["content": String(repeating: bodyMarker, count: 100)]
+                ])
+            ), "\(wrapperKey) body only")
+            XCTAssertEqual(try XCTUnwrap(jsonObject(from: bodyOnly.resultJSON)).count, 0, wrapperKey)
+            XCTAssertFalse(bodyOnly.resultJSON?.contains(bodyMarker) == true, wrapperKey)
+
+            let successfulScalar = try XCTUnwrap(controller.test_parseToolLifecycleEvent(
+                method: "item/completed",
+                params: toolParams(item: [
+                    "type": "toolCall",
+                    "id": "call_web_read_scalar_success_\(wrapperKey)",
+                    "name": "web_fetch",
+                    "status": "completed",
+                    wrapperKey: String(repeating: bodyMarker, count: 100)
+                ])
+            ), "\(wrapperKey) successful scalar")
+            let scalarResult = try XCTUnwrap(jsonObject(from: successfulScalar.resultJSON), wrapperKey)
+            XCTAssertEqual(scalarResult.count, 1, wrapperKey)
+            XCTAssertEqual(scalarResult["status"] as? String, "completed", wrapperKey)
+            XCTAssertFalse(successfulScalar.resultJSON?.contains(bodyMarker) == true, wrapperKey)
+        }
+
+        for wrapperKey in ["result", "output", "response"] {
+            let controller = makeController()
+            let failed = try XCTUnwrap(controller.test_parseToolLifecycleEvent(
+                method: "item/completed",
+                params: toolParams(item: [
+                    "type": "toolCall",
+                    "id": "call_web_read_scalar_failure_\(wrapperKey)",
+                    "name": "web_fetch",
+                    "status": "failed",
+                    wrapperKey: "request timed out"
+                ])
+            ), "\(wrapperKey) failed scalar")
+            let failedResult = try XCTUnwrap(jsonObject(from: failed.resultJSON), wrapperKey)
+            XCTAssertEqual(failedResult["status"] as? String, "failed", wrapperKey)
+            XCTAssertEqual(failedResult["errorMessage"] as? String, "request timed out", wrapperKey)
+        }
+
+        let nestedFailureController = makeController()
+        let nestedFailure = try XCTUnwrap(nestedFailureController.test_parseToolLifecycleEvent(
+            method: "item/completed",
+            params: toolParams(item: [
+                "type": "toolCall",
+                "id": "call_web_read_nested_failure",
+                "name": "web_fetch",
+                "result": [
+                    "status": "failed",
+                    "message": "request blocked"
+                ]
+            ])
+        ))
+        let nestedFailureResult = try XCTUnwrap(jsonObject(from: nestedFailure.resultJSON))
+        XCTAssertEqual(nestedFailureResult["status"] as? String, "failed")
+        XCTAssertEqual(nestedFailureResult["errorMessage"] as? String, "request blocked")
+
+        let legacyMessageController = makeController()
+        let legacyMessage = try XCTUnwrap(legacyMessageController.test_parseToolLifecycleEvent(
+            method: "item/completed",
+            params: toolParams(item: [
+                "type": "toolCall",
+                "id": "call_web_read_legacy_message",
+                "name": "web_fetch",
+                "isError": true,
+                "message": "legacy request failed"
+            ])
+        ))
+        let legacyMessageResult = try XCTUnwrap(jsonObject(from: legacyMessage.resultJSON))
+        XCTAssertEqual(legacyMessageResult["errorMessage"] as? String, "legacy request failed")
+    }
+
     func testNativeWebSearchCompletionPayloadsPreserveCompactSearchFields() throws {
+        let longQuery = String(repeating: "query", count: 140)
+        let boundedController = makeController()
+        let bounded = try XCTUnwrap(boundedController.test_parseToolLifecycleEvent(
+            method: "item/completed",
+            params: toolParams(item: [
+                "type": "webSearch",
+                "id": "call_search_bounded_query",
+                "query": longQuery,
+                "action": ["type": "search", "query": longQuery]
+            ])
+        ))
+        let boundedArgs = try XCTUnwrap(jsonObject(from: bounded.argsJSON))
+        let boundedResult = try XCTUnwrap(jsonObject(from: bounded.resultJSON))
+        XCTAssertEqual((boundedArgs["query"] as? String)?.count, 500)
+        XCTAssertEqual((boundedResult["query"] as? String)?.count, 500)
+        XCTAssertTrue((boundedResult["query"] as? String)?.hasSuffix("…") == true)
+
+        let rawQueries = (0 ..< 12).map { index in
+            index == 0 ? longQuery : "query \(index)"
+        }
+        let boundedList = try XCTUnwrap(makeController().test_parseToolLifecycleEvent(
+            method: "item/completed",
+            params: toolParams(item: [
+                "type": "webSearch",
+                "id": "call_search_bounded_queries",
+                "action": ["type": "search", "queries": rawQueries]
+            ])
+        ))
+        let boundedListArgs = try XCTUnwrap(jsonObject(from: boundedList.argsJSON))
+        let boundedListResult = try XCTUnwrap(jsonObject(from: boundedList.resultJSON))
+        let argsQueries = try XCTUnwrap(boundedListArgs["queries"] as? [String])
+        let resultQueries = try XCTUnwrap(boundedListResult["queries"] as? [String])
+        XCTAssertEqual(argsQueries.count, 10)
+        XCTAssertEqual(resultQueries, argsQueries)
+        XCTAssertEqual(argsQueries.first?.count, 500)
+        XCTAssertTrue(argsQueries.first?.hasSuffix("…") == true)
+
         let rows: [(label: String, alias: String, item: [String: Any], expectedResults: Int?, expectedSources: Int?, expectedDetailKey: String)] = [
             (
                 "root results",

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexNativeSessionControllerEventRecoveryTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexNativeSessionControllerEventRecoveryTests.swift
@@ -196,6 +196,89 @@ final class CodexNativeSessionControllerEventRecoveryTests: XCTestCase {
         }
     }
 
+    func testNativeWebActionTopLevelScalarsSurviveStartedAndCompletedEvents() throws {
+        let controller = makeController()
+        let started = try XCTUnwrap(controller.test_parseToolLifecycleEvent(
+            method: "item/started",
+            params: toolParams(item: [
+                "type": "toolCall",
+                "id": "call_search_open",
+                "name": "web_search",
+                "query": "docs",
+                "url": "https://docs.example.com/a/b/c",
+                "action": "open"
+            ])
+        ))
+        XCTAssertEqual(started.kind, "call")
+        XCTAssertEqual(started.name, "search")
+        let startedArgs = try XCTUnwrap(jsonObject(from: started.argsJSON))
+        XCTAssertEqual(startedArgs["query"] as? String, "docs")
+        XCTAssertEqual(startedArgs["url"] as? String, "https://docs.example.com/a/b/c")
+        XCTAssertEqual(startedArgs["action"] as? String, "open")
+
+        let completed = try XCTUnwrap(controller.test_parseToolLifecycleEvent(
+            method: "item/completed",
+            params: toolParams(item: [
+                "type": "toolCall",
+                "id": "call_search_open",
+                "name": "web_search",
+                "status": "completed",
+                "url": "https://docs.example.com/a/b/c",
+                "action": "open",
+                "title": "Docs page",
+                "content": String(repeating: "full page body ", count: 80)
+            ])
+        ))
+        XCTAssertEqual(completed.kind, "result")
+        XCTAssertEqual(completed.name, "search")
+        let completedResult = try XCTUnwrap(jsonObject(from: completed.resultJSON))
+        XCTAssertEqual(completedResult["url"] as? String, "https://docs.example.com/a/b/c")
+        XCTAssertEqual(completedResult["action"] as? String, "open")
+        XCTAssertNil(completedResult["content"])
+    }
+
+    func testNativeWebReadAndFindEventsUseCanonicalWebReadNameAndCompactResults() throws {
+        let controller = makeController()
+        let started = try XCTUnwrap(controller.test_parseToolLifecycleEvent(
+            method: "item/started",
+            params: toolParams(item: [
+                "type": "toolCall",
+                "id": "call_webfetch",
+                "name": "webfetch",
+                "url": "https://docs.example.com/a/b/c",
+                "needle": "install"
+            ])
+        ))
+        XCTAssertEqual(started.kind, "call")
+        XCTAssertEqual(started.name, "web_read")
+        let args = try XCTUnwrap(jsonObject(from: started.argsJSON))
+        XCTAssertEqual(args["url"] as? String, "https://docs.example.com/a/b/c")
+        XCTAssertEqual(args["needle"] as? String, "install")
+
+        let completed = try XCTUnwrap(controller.test_parseToolLifecycleEvent(
+            method: "item/completed",
+            params: toolParams(item: [
+                "type": "toolCall",
+                "id": "call_webfetch",
+                "name": "webfetch",
+                "status": "completed",
+                "url": "https://docs.example.com/a/b/c",
+                "needle": "install",
+                "matches": [["text": String(repeating: "full page body ", count: 80)]],
+                "content": String(repeating: "full page body ", count: 80)
+            ])
+        ))
+        XCTAssertEqual(completed.kind, "result")
+        XCTAssertEqual(completed.name, "web_read")
+        let result = try XCTUnwrap(jsonObject(from: completed.resultJSON))
+        XCTAssertEqual(result["url"] as? String, "https://docs.example.com/a/b/c")
+        XCTAssertEqual(result["needle"] as? String, "install")
+        XCTAssertEqual(result["match_count"] as? Int, 1)
+        XCTAssertNil(result["matches"])
+        XCTAssertNil(result["content"])
+        XCTAssertFalse(completed.resultJSON?.contains("full page body") == true)
+    }
+
     func testNativeWebSearchCompletionPayloadsPreserveCompactSearchFields() throws {
         let rows: [(label: String, alias: String, item: [String: Any], expectedResults: Int?, expectedSources: Int?, expectedDetailKey: String)] = [
             (

--- a/Tests/RepoPromptTests/AgentMode/ToolCards/WebSearchToolCardTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/ToolCards/WebSearchToolCardTests.swift
@@ -50,6 +50,52 @@ final class WebSearchToolCardTests: XCTestCase {
         XCTAssertEqual(webPresentation(toolName: "search", result: ["results": [["url": "https://example.com/result"]]])?.title, "Web Search")
     }
 
+    func testNestedTaggedWebActionsClassifySearchOpenAndFind() throws {
+        let search = try XCTUnwrap(webPresentation(
+            toolName: "search",
+            args: ["action": ["type": "search", "query": "nested query"]]
+        ))
+        XCTAssertEqual(search.title, "Web Search")
+        XCTAssertEqual(search.subtitle, "\"nested query\"")
+
+        let multiSearch = try XCTUnwrap(webPresentation(
+            toolName: "search",
+            args: ["action": ["type": "search", "queries": ["first query", "second query"]]]
+        ))
+        XCTAssertEqual(multiSearch.title, "Web Search")
+        XCTAssertEqual(multiSearch.subtitle, "\"first query ...\"")
+
+        let open = try XCTUnwrap(webPresentation(
+            toolName: "search",
+            args: ["action": ["type": "openPage", "url": "https://example.com/docs"]]
+        ))
+        XCTAssertEqual(open.title, "Read Web Page")
+        XCTAssertEqual(open.subtitle, "example.com/docs")
+
+        let find = try XCTUnwrap(webPresentation(
+            toolName: "search",
+            args: ["action": ["type": "findInPage", "url": NSNull(), "pattern": "install"]]
+        ))
+        XCTAssertEqual(find.title, "Find In Page")
+        XCTAssertEqual(find.subtitle, "\"install\"")
+        XCTAssertEqual(
+            webPresentation(toolName: "search", args: ["action": "find_in_page", "pattern": "install"])?.title,
+            "Find In Page"
+        )
+
+        for query in [
+            "https://example.com/docs",
+            "'installation' in https://example.com/docs"
+        ] {
+            let authoritativeSearch = try XCTUnwrap(webPresentation(
+                toolName: "search",
+                args: ["query": query, "action": ["type": "search", "query": query]]
+            ), query)
+            XCTAssertEqual(authoritativeSearch.title, "Web Search", query)
+            XCTAssertEqual(authoritativeSearch.op, "search", query)
+        }
+    }
+
     func testCodexSearchQueryGrammarRecognizesReadAndFindInPage() throws {
         let read = try XCTUnwrap(webPresentation(
             toolName: "search",
@@ -189,6 +235,47 @@ final class WebSearchToolCardTests: XCTestCase {
         let stored = try XCTUnwrap(NativeToolCardPresentationBuilder.build(item: storedItem, normalizedToolName: "search"))
         XCTAssertEqual(stored.title, "Find In Page")
         XCTAssertEqual(stored.subtitle, find.subtitle)
+    }
+
+    func testLegacyWebReadSummaryAliasesRestoreByCanonicalEquivalenceWithoutSpoofing() throws {
+        for alias in ["webfetch", "web_fetch"] {
+            let renderSummary = AgentToolCardRenderSummary(
+                toolName: alias,
+                title: "Read Web Page",
+                subtitle: "example.com/docs",
+                detailText: "Legacy docs",
+                status: .success,
+                op: "read_web_page"
+            )
+            let summaryOnly = jsonString([
+                "status": "success",
+                "summary_only": true,
+                "render_summary": renderSummary.dictionary
+            ])
+            let legacyItem = AgentChatItem(
+                kind: .toolResult,
+                text: summaryOnly,
+                toolName: alias,
+                toolResultJSON: summaryOnly,
+                toolIsError: false
+            )
+            let restored = try XCTUnwrap(
+                NativeToolCardPresentationBuilder.build(item: legacyItem, normalizedToolName: "web_read"),
+                alias
+            )
+            XCTAssertEqual(restored.title, "Read Web Page", alias)
+            XCTAssertEqual(restored.subtitle, "example.com/docs", alias)
+
+            XCTAssertNil(NativeToolCardPresentationBuilder.build(
+                item: AgentChatItem(
+                    kind: .toolResult,
+                    text: summaryOnly,
+                    toolName: "weather_lookup",
+                    toolResultJSON: summaryOnly
+                ),
+                normalizedToolName: "weather_lookup"
+            ), alias)
+        }
     }
 
     func testWebSearchPresentationCoversLiveAndSummaryOnlyPayloads() throws {

--- a/Tests/RepoPromptTests/AgentMode/ToolCards/WebSearchToolCardTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/ToolCards/WebSearchToolCardTests.swift
@@ -3,14 +3,128 @@ import XCTest
 
 final class WebSearchToolCardTests: XCTestCase {
     func testWebSearchNamesStayDistinctFromFileSearchAndRouteAsKnownResult() {
-        for alias in ["search", "web_search", "web_search_request", "google_web_search", "search_web"] {
+        for alias in ["search", "web_search", "web_search_request", "google_web_search", "search_web", "websearch"] {
             XCTAssertEqual(normalizedToolCardName(alias), "search", alias)
             XCTAssertEqual(AgentToolResultPersistencePolicy.normalizedToolName(alias), "search", alias)
+        }
+        for alias in ["webfetch", "web_fetch", "browser_open", "browser.open", "open_url"] {
+            XCTAssertEqual(normalizedToolCardName(alias), "web_read", alias)
+            XCTAssertEqual(AgentToolResultPersistencePolicy.normalizedToolName(alias), "web_read", alias)
         }
         for alias in ["file_search", "filesearch", "grep"] {
             XCTAssertEqual(AgentToolResultPersistencePolicy.normalizedToolName(alias), "file_search", alias)
         }
         XCTAssertTrue(ToolCardRouter.knownResultTools.contains("search"))
+    }
+
+    func testWebActionClassifierDistinguishesSearchReadFindAndCodeSearch() throws {
+        XCTAssertEqual(webPresentation(toolName: "search", args: ["query": "native web search cards"])?.title, "Web Search")
+
+        let searchWithSources = webPresentation(
+            toolName: "search",
+            args: ["query": "native web search cards"],
+            result: ["sources": [["url": "https://example.com/source"]]]
+        )
+        XCTAssertEqual(searchWithSources?.title, "Web Search")
+
+        let resultOnlyURL = webPresentation(toolName: "search", result: ["url": "https://example.com/page"])
+        XCTAssertEqual(resultOnlyURL?.title, "Web Search")
+
+        let read = try XCTUnwrap(webPresentation(toolName: "webfetch", args: ["url": "https://docs.example.com/a/b/c"]), "webfetch read")
+        XCTAssertEqual(read.title, "Read Web Page")
+        XCTAssertEqual(read.subtitle, "docs.example.com/…/c")
+
+        XCTAssertEqual(webPresentation(toolName: "browser_open", args: ["url": "https://example.com/docs"])?.title, "Read Web Page")
+        XCTAssertEqual(webPresentation(toolName: "browser.open", args: ["url": "https://example.com/docs"])?.title, "Read Web Page")
+        XCTAssertEqual(webPresentation(toolName: "search", args: ["url": "https://example.com/docs", "action": "open"])?.title, "Read Web Page")
+
+        let find = try XCTUnwrap(webPresentation(toolName: "search", args: ["url": "https://example.com/docs", "pattern": "install"]), "search find")
+        XCTAssertEqual(find.title, "Find In Page")
+        XCTAssertTrue(find.subtitle?.contains("example.com/docs") == true)
+        XCTAssertTrue(find.subtitle?.contains("install") == true)
+        XCTAssertEqual(webPresentation(toolName: "webfetch", args: ["url": "https://example.com/docs", "needle": "API"])?.title, "Find In Page")
+        XCTAssertEqual(webPresentation(toolName: "search", args: ["pattern": "install"])?.title, "Web Search")
+        XCTAssertNil(webPresentation(toolName: "file_search", args: ["pattern": "TODO", "path": "Sources"]))
+        XCTAssertNil(webPresentation(toolName: "grep", args: ["pattern": "TODO"]))
+        XCTAssertNil(webPresentation(toolName: "webfetch", args: ["uri": "file:///tmp/x", "pattern": "TODO"]))
+        XCTAssertEqual(webPresentation(toolName: "search", result: ["results": [["url": "https://example.com/result"]]])?.title, "Web Search")
+    }
+
+    func testWebActionSubtitleFormatting() throws {
+        XCTAssertEqual(webPresentation(toolName: "webfetch", args: ["url": "https://example.com"])?.subtitle, "example.com")
+        XCTAssertEqual(webPresentation(toolName: "webfetch", args: ["url": "https://example.com/docs/api?token=secret#section"])?.subtitle, "example.com/docs/api")
+        XCTAssertEqual(webPresentation(toolName: "webfetch", args: ["url": "https://example.com/docs/api/"])?.subtitle, "example.com/docs/api")
+        XCTAssertEqual(webPresentation(toolName: "webfetch", args: ["url": "https://example.com/a/b/c/d"])?.subtitle, "example.com/…/d")
+        XCTAssertEqual(webPresentation(toolName: "webfetch", args: ["url": "https://example.com/docs/Swift%20API"])?.subtitle, "example.com/docs/Swift API")
+        let longURL = "https://example.com/docs/" + String(repeating: "very-long-component-", count: 8)
+        XCTAssertLessThanOrEqual(try XCTUnwrap(webPresentation(toolName: "webfetch", args: ["url": longURL])?.subtitle).count, 80)
+        XCTAssertEqual(webPresentation(toolName: "webfetch", args: ["ref_id": "abc123"])?.subtitle, "ref abc123")
+        XCTAssertTrue(try XCTUnwrap(webPresentation(toolName: "webfetch", args: ["ref_id": "abcdefghijklmnopqrstuvwxyz0123456789"])?.subtitle).contains("…"))
+    }
+
+    func testRunningCallPresentationUsesWebActionLabels() throws {
+        let readItem = AgentChatItem(
+            kind: .toolCall,
+            text: "",
+            toolName: "webfetch",
+            toolArgsJSON: jsonString(["url": "https://docs.example.com/a/b/c"])
+        )
+        let read = try XCTUnwrap(ToolCardRouter.callPresentation(for: readItem))
+        XCTAssertEqual(read.title, "Read Web Page")
+        XCTAssertEqual(read.subtitle, "docs.example.com/…/c")
+
+        let findItem = AgentChatItem(
+            kind: .toolCall,
+            text: "",
+            toolName: "search",
+            toolArgsJSON: jsonString(["url": "https://example.com/docs", "pattern": "needle"])
+        )
+        let find = try XCTUnwrap(ToolCardRouter.callPresentation(for: findItem))
+        XCTAssertEqual(find.title, "Find In Page")
+
+        let fileSearchItem = AgentChatItem(
+            kind: .toolCall,
+            text: "",
+            toolName: "file_search",
+            toolArgsJSON: jsonString(["pattern": "needle"])
+        )
+        XCTAssertNil(ToolCardRouter.callPresentation(for: fileSearchItem))
+    }
+
+    func testReadAndFindPresentationsCoverLiveAndSummaryOnlyPayloads() throws {
+        let readArgs = jsonString(["url": "https://docs.example.com/a/b/c"])
+        let readRaw = jsonString(["status": "completed", "title": "Docs page", "content": String(repeating: "body ", count: 200)])
+        let readItem = AgentChatItem(kind: .toolResult, text: readRaw, toolName: "webfetch", toolArgsJSON: readArgs, toolResultJSON: readRaw, toolIsError: false)
+        let read = try XCTUnwrap(NativeToolCardPresentationBuilder.build(item: readItem, normalizedToolName: "web_read"))
+        XCTAssertEqual(read.toolName, "web_read")
+        XCTAssertEqual(read.title, "Read Web Page")
+        XCTAssertEqual(read.subtitle, "docs.example.com/…/c")
+        XCTAssertEqual(read.detailText, "Docs page")
+        XCTAssertFalse(read.dictionary.description.contains("body body"))
+
+        let findArgs = jsonString(["url": "https://example.com/docs", "pattern": "needle"])
+        let findRaw = jsonString(["status": "completed", "match_count": 3])
+        let findItem = AgentChatItem(kind: .toolResult, text: findRaw, toolName: "search", toolArgsJSON: findArgs, toolResultJSON: findRaw, toolIsError: false)
+        let find = try XCTUnwrap(NativeToolCardPresentationBuilder.build(item: findItem, normalizedToolName: "search"))
+        XCTAssertEqual(find.toolName, "search")
+        XCTAssertEqual(find.title, "Find In Page")
+        XCTAssertEqual(find.op, "find_in_page")
+        XCTAssertEqual(find.detailText, "3 matches")
+
+        let minimalWebReadSummary = jsonString([
+            "status": "success",
+            "summary_only": true,
+            "render_summary": ["schema_version": 1, "tool_name": "web_read", "status": "success", "subtitle": "example.com/docs"]
+        ])
+        let minimalStoredItem = AgentChatItem(kind: .toolResult, text: minimalWebReadSummary, toolName: "webfetch", toolResultJSON: minimalWebReadSummary, toolIsError: false)
+        let minimalStored = try XCTUnwrap(NativeToolCardPresentationBuilder.build(item: minimalStoredItem, normalizedToolName: "web_read"))
+        XCTAssertEqual(minimalStored.title, "Read Web Page")
+
+        let summaryOnly = jsonString(["status": "success", "summary_only": true, "render_summary": find.dictionary])
+        let storedItem = AgentChatItem(kind: .toolResult, text: summaryOnly, toolName: "search", toolArgsJSON: findArgs, toolResultJSON: summaryOnly, toolIsError: false)
+        let stored = try XCTUnwrap(NativeToolCardPresentationBuilder.build(item: storedItem, normalizedToolName: "search"))
+        XCTAssertEqual(stored.title, "Find In Page")
+        XCTAssertEqual(stored.subtitle, find.subtitle)
     }
 
     func testWebSearchPresentationCoversLiveAndSummaryOnlyPayloads() throws {
@@ -99,6 +213,19 @@ final class WebSearchToolCardTests: XCTestCase {
         XCTAssertEqual(safe.subtitle, "tomorrow weather")
         XCTAssertEqual(safe.detailText, "Sunny and mild")
         XCTAssertNil(NativeToolCardPresentationBuilder.build(item: safeItem, normalizedToolName: "tool"))
+    }
+
+    private func webPresentation(
+        toolName: String,
+        args: [String: Any]? = nil,
+        result: [String: Any]? = nil
+    ) -> AgentWebToolActionPresentation? {
+        AgentWebToolActionPresentation.classify(AgentWebToolActionInput(
+            rawToolName: toolName,
+            normalizedToolName: normalizedToolCardName(toolName),
+            argsObject: args,
+            resultObject: result
+        ))
     }
 
     private func jsonString(_ object: [String: Any], file: StaticString = #filePath, line: UInt = #line) -> String {

--- a/Tests/RepoPromptTests/AgentMode/ToolCards/WebSearchToolCardTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/ToolCards/WebSearchToolCardTests.swift
@@ -50,6 +50,70 @@ final class WebSearchToolCardTests: XCTestCase {
         XCTAssertEqual(webPresentation(toolName: "search", result: ["results": [["url": "https://example.com/result"]]])?.title, "Web Search")
     }
 
+    func testCodexSearchQueryGrammarRecognizesReadAndFindInPage() throws {
+        let read = try XCTUnwrap(webPresentation(
+            toolName: "search",
+            args: ["query": "https://www.theguardian.com/europe"]
+        ))
+        XCTAssertEqual(read.title, "Read Web Page")
+        XCTAssertEqual(read.subtitle, "www.theguardian.com/europe")
+        XCTAssertEqual(read.op, "read_web_page")
+
+        let normalizedOnlyRead = try XCTUnwrap(AgentWebToolActionPresentation.classify(AgentWebToolActionInput(
+            rawToolName: "codex_web_search",
+            normalizedToolName: "search",
+            argsObject: ["query": "https://example.com/docs"],
+            resultObject: nil
+        )))
+        XCTAssertEqual(normalizedOnlyRead.title, "Read Web Page")
+        XCTAssertEqual(normalizedOnlyRead.subtitle, "example.com/docs")
+
+        let quotedFind = try XCTUnwrap(webPresentation(
+            toolName: "search",
+            args: ["query": "'Netherlands' in https://www.theguardian.com/europe"]
+        ))
+        XCTAssertEqual(quotedFind.title, "Find In Page")
+        XCTAssertEqual(quotedFind.subtitle, "www.theguardian.com/europe • \"Netherlands\"")
+        XCTAssertEqual(quotedFind.op, "find_in_page")
+
+        let unquotedFind = try XCTUnwrap(webPresentation(
+            toolName: "search",
+            args: ["query": "Netherlands in https://www.theguardian.com/europe"]
+        ))
+        XCTAssertEqual(unquotedFind.title, "Find In Page")
+        XCTAssertEqual(unquotedFind.subtitle, "www.theguardian.com/europe • \"Netherlands\"")
+
+        let curlyPossessiveFind = try XCTUnwrap(webPresentation(
+            toolName: "search",
+            args: ["query": "teachers’ in https://example.com"]
+        ))
+        XCTAssertEqual(curlyPossessiveFind.title, "Find In Page")
+        XCTAssertEqual(curlyPossessiveFind.subtitle, "example.com • \"teachers’\"")
+
+        let straightPossessiveFind = try XCTUnwrap(webPresentation(
+            toolName: "search",
+            args: ["query": "dogs' in https://example.com"]
+        ))
+        XCTAssertEqual(straightPossessiveFind.title, "Find In Page")
+        XCTAssertEqual(straightPossessiveFind.subtitle, "example.com • \"dogs'\"")
+    }
+
+    func testCodexSearchQueryGrammarKeepsOrdinaryURLMentionsAsWebSearchAndExcludesCodeSearch() throws {
+        for query in [
+            "Netherlands https://www.theguardian.com/europe",
+            "https://www.theguardian.com/europe Netherlands",
+            "site:https://www.theguardian.com/europe Netherlands",
+            "Netherlands in https://www.theguardian.com/europe latest news"
+        ] {
+            let presentation = try XCTUnwrap(webPresentation(toolName: "search", args: ["query": query]), query)
+            XCTAssertEqual(presentation.title, "Web Search", query)
+            XCTAssertEqual(presentation.op, "search", query)
+        }
+
+        XCTAssertNil(webPresentation(toolName: "file_search", args: ["query": "https://example.com/docs"]))
+        XCTAssertNil(webPresentation(toolName: "grep", args: ["query": "'needle' in https://example.com/docs"]))
+    }
+
     func testWebActionSubtitleFormatting() throws {
         XCTAssertEqual(webPresentation(toolName: "webfetch", args: ["url": "https://example.com"])?.subtitle, "example.com")
         XCTAssertEqual(webPresentation(toolName: "webfetch", args: ["url": "https://example.com/docs/api?token=secret#section"])?.subtitle, "example.com/docs/api")

--- a/Tests/RepoPromptTests/AgentMode/Transcript/AgentToolResultPersistencePolicyTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Transcript/AgentToolResultPersistencePolicyTests.swift
@@ -127,6 +127,35 @@ final class AgentToolResultPersistencePolicyTests: XCTestCase {
         XCTAssertLessThanOrEqual(summary.resultJSON.utf8.count, AgentToolResultPersistencePolicy.maxPersistedToolSummaryBytes)
     }
 
+    func testCompletionOnlyToolResultFactoryPreservesArgsForPersistenceClassification() throws {
+        let args = jsonString([
+            "action": "find_in_page",
+            "url": "https://example.com/docs",
+            "pattern": "install"
+        ])
+        let invocationID = UUID()
+        let raw = jsonString(["status": "completed", "match_count": 2])
+        let item = AgentChatItem.toolResult(
+            name: "search",
+            invocationID: invocationID,
+            argsJSON: args,
+            resultJSON: raw,
+            isError: false,
+            sequenceIndex: 42
+        )
+
+        XCTAssertEqual(item.toolInvocationID, invocationID)
+        XCTAssertEqual(item.toolArgsJSON, args)
+        XCTAssertEqual(item.toolResultJSON, raw)
+        XCTAssertEqual(item.toolIsError, false)
+        XCTAssertEqual(item.sequenceIndex, 42)
+        let persisted = AgentChatItemPersist(from: item)
+        let object = try decodedObject(XCTUnwrap(persisted.toolResultJSON))
+        let renderSummary = try XCTUnwrap(object["render_summary"] as? [String: Any])
+        XCTAssertEqual(renderSummary["title"] as? String, "Find In Page")
+        XCTAssertEqual(renderSummary["op"] as? String, "find_in_page")
+    }
+
     func testWebSearchPersistsBoundedSummaryOnlySuccessPresentation() throws {
         let bulkySnippet = String(repeating: "full page body ", count: 80)
         let raw = jsonString([

--- a/Tests/RepoPromptTests/AgentMode/Transcript/AgentToolResultPersistencePolicyTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Transcript/AgentToolResultPersistencePolicyTests.swift
@@ -161,6 +161,42 @@ final class AgentToolResultPersistencePolicyTests: XCTestCase {
         XCTAssertLessThanOrEqual(summary.resultJSON.utf8.count, AgentToolResultPersistencePolicy.maxPersistedToolSummaryBytes)
     }
 
+    func testWebReadAndFindPersistActionAwareSummaryOnlyPresentations() throws {
+        let readRaw = jsonString([
+            "status": "completed",
+            "title": "RepoPrompt docs",
+            "content": String(repeating: "full page body ", count: 80)
+        ])
+        let readArgs = jsonString(["url": "https://docs.example.com/a/b/c"])
+        let readSummary = try XCTUnwrap(persistedSummary(toolName: "webfetch", rawResultJSON: readRaw, argsJSON: readArgs))
+        let readObject = try decodedObject(readSummary.resultJSON)
+        let readRenderSummary = try XCTUnwrap(readObject["render_summary"] as? [String: Any])
+        XCTAssertEqual(readRenderSummary["tool_name"] as? String, "web_read")
+        XCTAssertEqual(readRenderSummary["title"] as? String, "Read Web Page")
+        XCTAssertEqual(readRenderSummary["subtitle"] as? String, "docs.example.com/…/c")
+        XCTAssertEqual(readRenderSummary["detail_text"] as? String, "RepoPrompt docs")
+        XCTAssertFalse(readSummary.resultJSON.contains("full page body"))
+
+        let bodySummaryRaw = jsonString([
+            "status": "completed",
+            "summary": String(repeating: "page body ", count: 80)
+        ])
+        let bodySummary = try XCTUnwrap(persistedSummary(toolName: "webfetch", rawResultJSON: bodySummaryRaw, argsJSON: readArgs))
+        XCTAssertFalse(bodySummary.resultJSON.contains("page body"))
+
+        let findRaw = jsonString(["status": "completed", "match_count": 3])
+        let findArgs = jsonString(["url": "https://example.com/docs", "pattern": "needle"])
+        let findSummary = try XCTUnwrap(persistedSummary(toolName: "search", rawResultJSON: findRaw, argsJSON: findArgs))
+        let findObject = try decodedObject(findSummary.resultJSON)
+        let findRenderSummary = try XCTUnwrap(findObject["render_summary"] as? [String: Any])
+        XCTAssertEqual(findRenderSummary["tool_name"] as? String, "search")
+        XCTAssertEqual(findRenderSummary["title"] as? String, "Find In Page")
+        XCTAssertEqual(findRenderSummary["op"] as? String, "find_in_page")
+        XCTAssertEqual(findRenderSummary["detail_text"] as? String, "3 matches")
+        let restored = try XCTUnwrap(StoredToolCardPresentation.fromSummaryOnly(raw: findSummary.resultJSON))
+        XCTAssertEqual(restored.title, "Find In Page")
+    }
+
     func testWebSearchPersistsBoundedSummaryOnlyErrorPresentation() throws {
         let raw = jsonString([
             "status": "failed",


### PR DESCRIPTION
## Summary

Fixes #64.

This PR improves Agent Mode web tool cards so web-like actions no longer all collapse into generic Web Search/Search labels. It adds a shared classifier that can distinguish:

- Web Search
- Read Web Page
- Find In Page

It covers shared tool-card surfaces, summary-only restoration, native web names such as `webfetch` / `websearch`, and Codex cases where a URL or `'<text>' in <url>` is encoded as a search query.

## What changed

- Added `AgentWebToolActionPresentation` to centralize web action classification, canonical web tool names, compact URL/ref subtitles, and conservative false-positive handling.
- Wired web action labels into running calls, completed result cards, native presentation summaries, summary-only persistence, collapsed/category helpers, and the legacy bubble helper.
- Preserved existing Web Search behavior for normal query/search payloads.
- Kept RepoPrompt `file_search`, `grep`, and code/path tools out of web classification.
- Updated Codex native lifecycle parsing to preserve compact URL/ref/find/action metadata without persisting bulky page bodies.
- Added focused tests for classifier behavior, Codex payload recovery, persistence, and false-positive cases.

## Validation

- `make dev-format` ✅
- `make dev-test FILTER=WebSearchToolCardTests` ✅
- `make dev-test FILTER=AgentToolResultPersistencePolicyTests` ✅
- `make dev-test FILTER=CodexNativeSessionControllerEventRecoveryTests` ✅
- `make dev-lint` ✅
- `make dev-test` ✅
- `make dev-swift-build PRODUCT=RepoPrompt` ✅
- Push preflight: `.agents/skills/rpce-contribution-check/scripts/preflight.sh push` ✅
- Manual spot testing in UI ✅
  - [x] Claude Code: ask for a normal web search and confirm the transcript card stays labeled `Web Search`.
  - [x] Claude Code: ask it to read/fetch a specific URL and confirm the transcript card is labeled `Read Web Page` with the site/URL subtitle.
  - [x] Codex: ask for a normal web search and confirm the transcript card stays labeled `Web Search`.
  - [x] Codex: ask it to read/fetch a specific URL and confirm the transcript card is labeled `Read Web Page` rather than `Web Search`.
  - [x] Codex: ask it to find text within a specific URL, e.g. `'<term>' in https://example.com/...`, and confirm the transcript card is labeled `Find In Page`.
  - [x] Confirm ordinary URL-containing searches still remain `Web Search` rather than being over-classified as page reads.

## Notes

No plan files, prompt exports, review artifacts, or local investigation files are included in this PR.

