### PR TITLE
Harden flaky worktree CI tests

### DIFF
--- a/Tests/RepoPromptTests/Helpers/GitWorktreeTestSupport.swift
+++ b/Tests/RepoPromptTests/Helpers/GitWorktreeTestSupport.swift
@@ -1,0 +1,234 @@
+import Foundation
+@testable import RepoPrompt
+import XCTest
+
+enum GitWorktreeTestSupport {
+    private static let gitExecutable = URL(fileURLWithPath: "/usr/bin/git")
+
+    static func waitForStableDescriptor(
+        repo: URL,
+        path: URL,
+        expectedBranch: String? = nil,
+        expectedHead: String? = nil,
+        timeout: Duration = .seconds(5),
+        listDescriptors: () async throws -> [GitWorktreeDescriptor],
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws -> GitWorktreeDescriptor {
+        let standardizedPath = path.standardizedFileURL.path
+        let deadline = ContinuousClock.now + timeout
+        var lastDescriptors: [GitWorktreeDescriptor] = []
+        var lastError: Error?
+
+        while true {
+            do {
+                let descriptors = try await listDescriptors()
+                lastDescriptors = descriptors
+                if let descriptor = descriptors.first(where: { samePath($0.path, standardizedPath) }),
+                   isStableDescriptor(descriptor, expectedBranch: expectedBranch, expectedHead: expectedHead)
+                {
+                    return descriptor
+                }
+            } catch {
+                lastError = error
+            }
+
+            if ContinuousClock.now >= deadline { break }
+            try await Task.sleep(for: .milliseconds(50))
+        }
+
+        let message = worktreeDescriptorDump(
+            repo: repo,
+            expectedPath: standardizedPath,
+            expectedBranch: expectedBranch,
+            expectedHead: expectedHead,
+            descriptors: lastDescriptors,
+            lastError: lastError
+        )
+        XCTFail(message, file: file, line: line)
+        throw NSError(
+            domain: "GitWorktreeTestSupport.waitForStableDescriptor",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: message]
+        )
+    }
+
+    static func descriptorDump(
+        repo: URL,
+        expectedPath: URL? = nil,
+        requestedID: String? = nil,
+        descriptors: [GitWorktreeDescriptor]
+    ) -> String {
+        worktreeDescriptorDump(
+            repo: repo,
+            expectedPath: expectedPath?.standardizedFileURL.path,
+            expectedBranch: nil,
+            expectedHead: nil,
+            requestedID: requestedID,
+            descriptors: descriptors,
+            lastError: nil
+        )
+    }
+
+    static func mergeApplyDiagnostics(
+        preview: GitWorktreeMergePreview,
+        result: GitWorktreeMergeApplyResult
+    ) async -> String {
+        let inspection = preview.inspection
+        async let sourceLive = fingerprint(at: inspection.source.url)
+        async let targetLive = fingerprint(at: inspection.target.url)
+        async let sourceStatus = gitOutput(["status", "--porcelain=v1", "--branch"], cwd: inspection.source.url)
+        async let targetStatus = gitOutput(["status", "--porcelain=v1", "--branch"], cwd: inspection.target.url)
+        async let sourceHead = gitOutput(["rev-parse", "HEAD"], cwd: inspection.source.url)
+        async let targetHead = gitOutput(["rev-parse", "HEAD"], cwd: inspection.target.url)
+        async let sourceTree = gitOutput(["rev-parse", "HEAD^{tree}"], cwd: inspection.source.url)
+        async let targetTree = gitOutput(["rev-parse", "HEAD^{tree}"], cwd: inspection.target.url)
+
+        let liveSourceFingerprint = await sourceLive
+        let liveTargetFingerprint = await targetLive
+        let sourceChanged = liveSourceFingerprint.map { $0 != inspection.sourceFingerprint } ?? true
+        let targetChanged = liveTargetFingerprint.map { $0 != inspection.targetFingerprint } ?? true
+
+        return await """
+        merge apply diagnostics:
+        operation_id: \(preview.operationID)
+        result_status: \(result.status.rawValue)
+        stale_reason: \(result.staleReason ?? "nil")
+        error_message: \(result.errorMessage ?? "nil")
+        source_endpoint: \(endpointSummary(inspection.source))
+        target_endpoint: \(endpointSummary(inspection.target))
+        source_changed_since_preview: \(sourceChanged)
+        target_changed_since_preview: \(targetChanged)
+        preview_source_fingerprint: \(fingerprintSummary(inspection.sourceFingerprint))
+        live_source_fingerprint: \(fingerprintSummary(liveSourceFingerprint))
+        preview_target_fingerprint: \(fingerprintSummary(inspection.targetFingerprint))
+        live_target_fingerprint: \(fingerprintSummary(liveTargetFingerprint))
+        source_head_now: \(oneLine(sourceHead))
+        target_head_now: \(oneLine(targetHead))
+        source_tree_now: \(oneLine(sourceTree))
+        target_tree_now: \(oneLine(targetTree))
+        source_status_now:
+        \(sourceStatus)
+        target_status_now:
+        \(targetStatus)
+        """
+    }
+
+    static func assertApplyStatus(
+        _ result: GitWorktreeMergeApplyResult,
+        equals expected: GitWorktreeMergeApplyStatus,
+        preview: GitWorktreeMergePreview,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        guard result.status != expected else { return }
+        let diagnostics = await mergeApplyDiagnostics(preview: preview, result: result)
+        XCTFail("Expected merge apply status \(expected.rawValue), got \(result.status.rawValue).\n\(diagnostics)", file: file, line: line)
+    }
+
+    static func gitOutput(_ arguments: [String], cwd: URL) async -> String {
+        do {
+            return try runGit(arguments, cwd: cwd)
+        } catch {
+            return "<git \(arguments.joined(separator: " ")) failed: \(error.localizedDescription)>"
+        }
+    }
+
+    static func runGit(_ arguments: [String], cwd: URL) throws -> String {
+        let process = Process()
+        process.executableURL = gitExecutable
+        process.arguments = arguments
+        process.currentDirectoryURL = cwd
+        var environment = ProcessInfo.processInfo.environment
+        environment["GIT_CONFIG_NOSYSTEM"] = "1"
+        environment["GIT_CONFIG_GLOBAL"] = "/dev/null"
+        environment["GIT_TERMINAL_PROMPT"] = "0"
+        process.environment = environment
+        let output = Pipe()
+        process.standardOutput = output
+        process.standardError = output
+        try process.run()
+        process.waitUntilExit()
+        let data = output.fileHandleForReading.readDataToEndOfFile()
+        let text = String(decoding: data, as: UTF8.self)
+        guard process.terminationStatus == 0 else {
+            throw NSError(
+                domain: "GitWorktreeTestSupport.git",
+                code: Int(process.terminationStatus),
+                userInfo: [NSLocalizedDescriptionKey: "git \(arguments.joined(separator: " ")) failed in \(cwd.path): \(text)"]
+            )
+        }
+        return text
+    }
+
+    private static func isStableDescriptor(
+        _ descriptor: GitWorktreeDescriptor,
+        expectedBranch: String?,
+        expectedHead: String?
+    ) -> Bool {
+        guard descriptor.gitDir != nil || descriptor.isMain else { return false }
+        guard let head = descriptor.head, !head.isEmpty else { return false }
+        if let expectedHead, head != expectedHead { return false }
+        if let expectedBranch, descriptor.branch != expectedBranch { return false }
+        return true
+    }
+
+    private static func worktreeDescriptorDump(
+        repo: URL,
+        expectedPath: String?,
+        expectedBranch: String?,
+        expectedHead: String?,
+        requestedID: String? = nil,
+        descriptors: [GitWorktreeDescriptor],
+        lastError: Error?
+    ) -> String {
+        let rawList = (try? runGit(["worktree", "list", "--porcelain"], cwd: repo)) ?? "<git worktree list failed>"
+        let rawListZ = (try? runGit(["worktree", "list", "--porcelain", "-z"], cwd: repo))?
+            .replacingOccurrences(of: "\0", with: "\\0\n") ?? "<git worktree list -z failed>"
+        let lines = descriptors.map(descriptorSummary).joined(separator: "\n")
+        return """
+        timed out waiting for stable Git worktree descriptor
+        repo: \(repo.standardizedFileURL.path)
+        expected_path: \(expectedPath ?? "nil")
+        expected_branch: \(expectedBranch ?? "nil")
+        expected_head: \(expectedHead ?? "nil")
+        requested_id: \(requestedID ?? "nil")
+        last_error: \(lastError.map(\.localizedDescription) ?? "nil")
+        resolver_visible_descriptors:
+        \(lines.isEmpty ? "<none>" : lines)
+        raw_git_worktree_list_porcelain:
+        \(rawList)
+        raw_git_worktree_list_porcelain_z:
+        \(rawListZ)
+        """
+    }
+
+    private static func descriptorSummary(_ descriptor: GitWorktreeDescriptor) -> String {
+        "- id=\(descriptor.worktreeID) path=\(descriptor.path) gitDir=\(descriptor.gitDir ?? "nil") branch=\(descriptor.branch ?? "nil") head=\(descriptor.head ?? "nil") isMain=\(descriptor.isMain) isCurrent=\(descriptor.isCurrent) locked=\(descriptor.isLocked) prunable=\(descriptor.isPrunable)"
+    }
+
+    private static func endpointSummary(_ endpoint: GitWorktreeMergeEndpoint) -> String {
+        "id=\(endpoint.worktreeID) path=\(endpoint.path) branch=\(endpoint.branch ?? "nil") head=\(endpoint.head) repo=\(endpoint.repositoryID)"
+    }
+
+    private static func fingerprint(at url: URL) async -> GitDiffFingerprint? {
+        try? await VCSService().getStatusFingerprint(at: url, baseRef: "HEAD")
+    }
+
+    private static func fingerprintSummary(_ fingerprint: GitDiffFingerprint?) -> String {
+        guard let fingerprint else { return "nil" }
+        return fingerprintSummary(fingerprint)
+    }
+
+    private static func fingerprintSummary(_ fingerprint: GitDiffFingerprint) -> String {
+        "headSHA=\(fingerprint.headSHA) baseRef=\(fingerprint.baseRef) statusHash=\(fingerprint.statusHash) generatedAt=\(fingerprint.generatedAt)"
+    }
+
+    private static func oneLine(_ text: String) -> String {
+        text.trimmingCharacters(in: .whitespacesAndNewlines).replacingOccurrences(of: "\n", with: " | ")
+    }
+
+    private static func samePath(_ lhs: String, _ rhs: String) -> Bool {
+        URL(fileURLWithPath: lhs).standardizedFileURL.path == URL(fileURLWithPath: rhs).standardizedFileURL.path
+    }
+}

--- a/Tests/RepoPromptTests/MCP/AgentRunWorktreeStartTests.swift
+++ b/Tests/RepoPromptTests/MCP/AgentRunWorktreeStartTests.swift
@@ -602,10 +602,26 @@ final class AgentRunWorktreeStartTests: XCTestCase {
             let fixture = try makeGitFixture()
             let parentWorktree = fixture.sandbox.appendingPathComponent("parent-worktree", isDirectory: true)
             let explicitWorktree = fixture.sandbox.appendingPathComponent("explicit-worktree", isDirectory: true)
-            try runGit(["worktree", "add", "-b", "feature/parent-\(fixture.suffix)", parentWorktree.path, "HEAD"], cwd: fixture.repo)
-            try runGit(["worktree", "add", "-b", "feature/explicit-\(fixture.suffix)", explicitWorktree.path, "HEAD"], cwd: fixture.repo)
-            let descriptors = try await VCSService.shared.listGitWorktrees(at: fixture.repo)
-            let explicitDescriptor = try XCTUnwrap(descriptors.first { samePath($0.path, explicitWorktree.path) })
+            let expectedHead = try GitWorktreeTestSupport.runGit(["rev-parse", "HEAD"], cwd: fixture.repo)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let parentBranch = "feature/parent-\(fixture.suffix)"
+            let explicitBranch = "feature/explicit-\(fixture.suffix)"
+            try runGit(["worktree", "add", "-b", parentBranch, parentWorktree.path, "HEAD"], cwd: fixture.repo)
+            try runGit(["worktree", "add", "-b", explicitBranch, explicitWorktree.path, "HEAD"], cwd: fixture.repo)
+            _ = try await GitWorktreeTestSupport.waitForStableDescriptor(
+                repo: fixture.repo,
+                path: parentWorktree,
+                expectedBranch: parentBranch,
+                expectedHead: expectedHead,
+                listDescriptors: { try await VCSService.shared.listGitWorktrees(at: fixture.repo) }
+            )
+            let explicitDescriptor = try await GitWorktreeTestSupport.waitForStableDescriptor(
+                repo: fixture.repo,
+                path: explicitWorktree,
+                expectedBranch: explicitBranch,
+                expectedHead: expectedHead,
+                listDescriptors: { try await VCSService.shared.listGitWorktrees(at: fixture.repo) }
+            )
             let window = try await makeWindow(root: fixture.repo)
             defer { WindowStatesManager.shared.unregisterWindowState(window) }
             let sourceTabID = try XCTUnwrap(window.workspaceManager.activeWorkspace?.activeComposeTabID)
@@ -628,7 +644,23 @@ final class AgentRunWorktreeStartTests: XCTestCase {
                 args["inherit_worktree"] = .bool(false)
             }
 
-            let value = try await service.execute(args: args)
+            let value: Value
+            do {
+                value = try await service.execute(args: args)
+            } catch {
+                let descriptors = await (try? VCSService.shared.listGitWorktrees(at: fixture.repo)) ?? []
+                XCTFail("""
+                agent_run.start failed after explicit worktree descriptor had stabilized: \(error.localizedDescription)
+                requested_worktree_id: \(explicitDescriptor.worktreeID)
+                \(GitWorktreeTestSupport.descriptorDump(
+                    repo: fixture.repo,
+                    expectedPath: explicitWorktree,
+                    requestedID: explicitDescriptor.worktreeID,
+                    descriptors: descriptors
+                ))
+                """)
+                throw error
+            }
 
             let object = try XCTUnwrap(value.objectValue)
             let sessionObject = try XCTUnwrap(object["session"]?.objectValue)

--- a/Tests/RepoPromptTests/Services/VCS/GitWorktreeMergeEndToEndTests.swift
+++ b/Tests/RepoPromptTests/Services/VCS/GitWorktreeMergeEndToEndTests.swift
@@ -11,6 +11,10 @@ final class GitWorktreeMergeEndToEndTests: XCTestCase {
         let abortPreview = try await abortFixture.preview(publishArtifacts: false)
         let reloadedApplyingOperation = AgentWorktreeMergeCoordinator.makeOperation(preview: abortPreview, status: .applying)
         let conflict = try await VCSService().applyGitWorktreeMerge(.init(preview: abortPreview))
+        if conflict.status != .conflicted {
+            await GitWorktreeTestSupport.assertApplyStatus(conflict, equals: .conflicted, preview: abortPreview)
+            return
+        }
 
         XCTAssertEqual(conflict.status, .conflicted)
         XCTAssertEqual(conflict.conflictFiles, ["Common.txt"])
@@ -35,6 +39,10 @@ final class GitWorktreeMergeEndToEndTests: XCTestCase {
 
         let continuePreview = try await continueFixture.preview(publishArtifacts: false)
         let continueConflict = try await VCSService().applyGitWorktreeMerge(.init(preview: continuePreview))
+        if continueConflict.status != .conflicted {
+            await GitWorktreeTestSupport.assertApplyStatus(continueConflict, equals: .conflicted, preview: continuePreview)
+            return
+        }
         XCTAssertEqual(continueConflict.status, .conflicted)
 
         try "resolved\n".write(to: continueFixture.repo.appendingPathComponent("Common.txt"), atomically: true, encoding: .utf8)
@@ -97,9 +105,18 @@ private struct Fixture {
     }
 
     func endpoint(for path: URL, using git: GitService) async throws -> GitWorktreeMergeEndpoint {
-        let worktrees = try await git.listWorktrees(at: repo)
-        let standardized = path.standardizedFileURL.path
-        let descriptor = try XCTUnwrap(worktrees.first { $0.path == standardized })
+        let expectedHead = try gitOutput(["rev-parse", "HEAD"], cwd: path)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let branch = try gitOutput(["branch", "--show-current"], cwd: path)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let expectedBranch = branch.isEmpty ? nil : branch
+        let descriptor = try await GitWorktreeTestSupport.waitForStableDescriptor(
+            repo: repo,
+            path: path,
+            expectedBranch: expectedBranch,
+            expectedHead: expectedHead,
+            listDescriptors: { try await git.listWorktrees(at: repo) }
+        )
         return try GitWorktreeMergeEndpoint(descriptor: descriptor)
     }
 

--- a/Tests/RepoPromptTests/Services/VCS/GitWorktreeMergeGitServiceTests.swift
+++ b/Tests/RepoPromptTests/Services/VCS/GitWorktreeMergeGitServiceTests.swift
@@ -97,6 +97,10 @@ final class GitWorktreeMergeGitServiceTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: artifacts.mapPath), artifacts.mapPath)
         XCTAssertTrue(FileManager.default.fileExists(atPath: artifacts.sidecarPath), artifacts.sidecarPath)
         let result = try await VCSService().applyGitWorktreeMerge(.init(preview: preview))
+        if result.status != .completed {
+            await GitWorktreeTestSupport.assertApplyStatus(result, equals: .completed, preview: preview)
+            return
+        }
 
         XCTAssertEqual(result.status, .completed)
         XCTAssertNotNil(result.mergeCommit)
@@ -248,19 +252,30 @@ final class GitWorktreeMergeGitServiceTests: XCTestCase {
         try FileManager.default.createDirectory(at: mutexDir, withIntermediateDirectories: true)
         let lockPath = mutexDir.appendingPathComponent("worktree.lock").path
         let readyPath = fixture.sandbox.appendingPathComponent("cross-process-lock-ready").path
+        let releasePath = fixture.sandbox.appendingPathComponent("cross-process-lock-release").path
         let script = """
         import fcntl, os, sys, time
-        fd = os.open(sys.argv[1], os.O_CREAT | os.O_RDWR, 0o600)
+        lock_path, ready_path, release_path = sys.argv[1], sys.argv[2], sys.argv[3]
+        fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+        print(f"holder pid={os.getpid()} opening {lock_path}", flush=True)
         fcntl.flock(fd, fcntl.LOCK_EX)
-        with open(sys.argv[2], "w", encoding="utf-8") as ready:
-            ready.write("ready")
-        time.sleep(0.6)
+        print("holder acquired flock", flush=True)
+        with open(ready_path, "w", encoding="utf-8") as ready:
+            ready.write(f"pid={os.getpid()} lock={lock_path}\\n")
+        deadline = time.monotonic() + 20
+        while not os.path.exists(release_path):
+            if time.monotonic() >= deadline:
+                print(f"timed out waiting for release file {release_path}", file=sys.stderr, flush=True)
+                sys.exit(42)
+            time.sleep(0.05)
+        print("holder saw release file", flush=True)
         fcntl.flock(fd, fcntl.LOCK_UN)
         os.close(fd)
+        print("holder released flock", flush=True)
         """
         let holder = Process()
         holder.executableURL = python
-        holder.arguments = ["-c", script, lockPath, readyPath]
+        holder.arguments = ["-c", script, lockPath, readyPath, releasePath]
         let output = Pipe()
         holder.standardOutput = output
         holder.standardError = output
@@ -272,17 +287,29 @@ final class GitWorktreeMergeGitServiceTests: XCTestCase {
             }
         }
 
-        let readyDeadline = Date().addingTimeInterval(2)
-        while !FileManager.default.fileExists(atPath: readyPath), Date() < readyDeadline {
+        let readyDeadline = ContinuousClock.now + .seconds(10)
+        while !FileManager.default.fileExists(atPath: readyPath), ContinuousClock.now < readyDeadline {
             if !holder.isRunning {
-                let data = output.fileHandleForReading.readDataToEndOfFile()
-                let text = String(decoding: data, as: UTF8.self)
+                let text = String(decoding: output.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
                 throw XCTSkip("Unable to start cross-process flock holder: \(text)")
             }
-            try await Task.sleep(nanoseconds: 50_000_000)
+            try await Task.sleep(for: .milliseconds(50))
         }
         guard FileManager.default.fileExists(atPath: readyPath) else {
-            XCTFail("Timed out waiting for cross-process flock holder")
+            holder.terminate()
+            holder.waitUntilExit()
+            let text = String(decoding: output.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+            XCTFail("""
+            Timed out waiting for cross-process flock holder readiness.
+            lock_path: \(lockPath)
+            ready_path: \(readyPath)
+            release_path: \(releasePath)
+            holder_running_after_timeout: \(holder.isRunning)
+            holder_status: \(holder.terminationStatus)
+            lock_exists: \(FileManager.default.fileExists(atPath: lockPath))
+            holder_output:
+            \(text)
+            """)
             return
         }
 
@@ -293,25 +320,61 @@ final class GitWorktreeMergeGitServiceTests: XCTestCase {
                 await order.append("swift-enter")
             }
         }
-        try await Task.sleep(nanoseconds: 100_000_000)
+        try await Task.sleep(for: .milliseconds(200))
         let beforeRelease = await order.snapshot()
         XCTAssertEqual(beforeRelease, [], "Swift lock entered while another process held the common Git dir lock")
 
-        let exitDeadline = Date().addingTimeInterval(2)
-        while holder.isRunning, Date() < exitDeadline {
-            try await Task.sleep(nanoseconds: 50_000_000)
+        try "release\n".write(to: URL(fileURLWithPath: releasePath), atomically: true, encoding: .utf8)
+        let exitDeadline = ContinuousClock.now + .seconds(10)
+        while holder.isRunning, ContinuousClock.now < exitDeadline {
+            try await Task.sleep(for: .milliseconds(50))
         }
         guard !holder.isRunning else {
             holder.terminate()
             holder.waitUntilExit()
-            _ = try? await waiter.value
-            XCTFail("Timed out waiting for cross-process flock holder to release the lock")
+            waiter.cancel()
+            XCTFail("""
+            Timed out waiting for cross-process flock holder to release after writing release file.
+            lock_path: \(lockPath)
+            ready_path: \(readyPath)
+            release_path: \(releasePath)
+            ready_contents: \((try? String(contentsOfFile: readyPath, encoding: .utf8)) ?? "<unreadable>")
+            release_exists: \(FileManager.default.fileExists(atPath: releasePath))
+            observed_order_before_release: \(beforeRelease)
+            lock_exists: \(FileManager.default.fileExists(atPath: lockPath))
+            """)
             return
         }
-        XCTAssertEqual(holder.terminationStatus, 0)
-        try await waiter.value
+        let holderOutput = String(decoding: output.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+        XCTAssertEqual(holder.terminationStatus, 0, holderOutput)
+
+        let waiterCompleted = try await withThrowingTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                try await waiter.value
+                return true
+            }
+            group.addTask {
+                try await Task.sleep(for: .seconds(10))
+                return false
+            }
+            let completed = try await group.next() ?? false
+            group.cancelAll()
+            return completed
+        }
+        guard waiterCompleted else {
+            waiter.cancel()
+            await XCTFail("""
+            Swift lock waiter did not enter after holder released the cross-process flock.
+            lock_path: \(lockPath)
+            holder_output:
+            \(holderOutput)
+            observed_order_before_release: \(beforeRelease)
+            observed_order_after_timeout: \(order.snapshot())
+            """)
+            return
+        }
         let afterRelease = await order.snapshot()
-        XCTAssertEqual(afterRelease, ["swift-enter"])
+        XCTAssertEqual(afterRelease, ["swift-enter"], holderOutput)
     }
 }
 
@@ -374,9 +437,18 @@ private struct GitMergeFixture {
     }
 
     func endpoint(for path: URL, using git: GitService) async throws -> GitWorktreeMergeEndpoint {
-        let worktrees = try await git.listWorktrees(at: repo)
-        let standardized = path.standardizedFileURL.path
-        let descriptor = try XCTUnwrap(worktrees.first { $0.path == standardized })
+        let expectedHead = try gitOutput(["rev-parse", "HEAD"], cwd: path)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let branch = try gitOutput(["branch", "--show-current"], cwd: path)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let expectedBranch = branch.isEmpty ? nil : branch
+        let descriptor = try await GitWorktreeTestSupport.waitForStableDescriptor(
+            repo: repo,
+            path: path,
+            expectedBranch: expectedBranch,
+            expectedHead: expectedHead,
+            listDescriptors: { try await git.listWorktrees(at: repo) }
+        )
         return try GitWorktreeMergeEndpoint(descriptor: descriptor)
     }
 


### PR DESCRIPTION
## Summary

Stacked on #69 to harden the flaky Git/worktree CI tests without changing production behavior.

This adds test-only stabilization and diagnostics for the failures seen in the PR #69 Build and Test workflow:

- merge apply returning `.stale` instead of `.completed` / `.conflicted`
- explicit `worktree_id` resolution intermittently failing after raw `git worktree add`
- cross-process flock holder timing out on slower macOS CI runners

## What changed

- Added `GitWorktreeTestSupport` helpers for stable real-Git worktree descriptor waiting and diagnostic dumps.
- Made the explicit `agent_run.start(worktree_id:)` test wait for stable descriptor identity before invoking the MCP flow.
- Added resolver-visible descriptor diagnostics for the explicit worktree ID path.
- Added merge apply diagnostics that print stale reason, endpoint details, preview vs live fingerprints, HEAD/tree values, and status output.
- Replaced the cross-process flock test's fixed sleep with a readiness/release-file protocol and longer bounded deadlines.

## Intentional non-changes

- No production files changed.
- No stale detection was weakened.
- No retry-after-`.stale` behavior was added.
- The flock test is not skipped on timeout; timeout now fails with better diagnostics.

## Validation

- `make dev-format`
- `make dev-format-check`
- `make dev-test FILTER=AgentRunWorktreeStartTests`
- `make dev-test FILTER=GitWorktreeMergeGitServiceTests`
- `make dev-test FILTER=GitWorktreeMergeEndToEndTests`
- Extra loop: each focused filter passed 2 additional times
- Push preflight passed, including:
  - guardrails
  - outgoing secret scan
  - `make dev-lint`
  - full `make dev-test`
  - `make dev-swift-build PRODUCT=RepoPrompt`
