### PR TITLE
Refresh approved contributors

### DIFF
--- a/.github/APPROVED_CONTRIBUTORS
+++ b/.github/APPROVED_CONTRIBUTORS
@@ -15,6 +15,7 @@
 2lim5lim pr
 9erson pr
 a1re1 pr
+aaronwestphal pr
 aAtila pr
 abhimehro pr
 abhishekbhakat pr
@@ -24,6 +25,7 @@ aconcepcion pr
 adamhelfgott pr
 adamkmccarthy pr
 adampearse pr
+adamteece pr
 adityadaniel pr
 AdrianAlonsoDev pr
 afadlallah pr
@@ -319,6 +321,7 @@ ivanfioravanti pr
 ivanvarghese pr
 ivorpad pr
 j-amelunxen pr
+j-mee pr
 jackberger03 pr
 jackwimbish pr
 jakekinchen pr
@@ -344,6 +347,7 @@ Jibbscript pr
 jim-brown pr
 jim380 pr
 jinstrel pr
+jitendravyas pr
 jmaartenson pr
 jmdfm pr
 Jmeg8r pr
@@ -519,11 +523,13 @@ qtm pr
 Qwantime pr
 radosek pr
 RadRebelSam pr
+rahulxsomething pr
 raphaelluethy pr
 ratulsarna pr
 raydocs pr
 Razheemus pr
 rbirving45 pr
+redrumkev pr
 redwhitblack pr
 regismesquita pr
 Reksa97 pr
@@ -629,6 +635,7 @@ tri9ne pr
 triangulair pr
 triken22 pr
 truediger10 pr
+tslaton pr
 twentyonedot pr
 twilwa pr
 tyom pr
@@ -646,6 +653,7 @@ varunrayen pr
 vchepeli pr
 vdt pr
 vega113 pr
+Vibenna pr
 vida994 pr
 vikrapivin pr
 viktortnk pr


### PR DESCRIPTION
## Summary
- refresh `.github/APPROVED_CONTRIBUTORS` from live customer claims
- contributor count: 697 -> 705
- unresolved claim-form GitHub IDs: `Tyschultz7`, `hsinskip`

## Validation
- `make guardrails`
- commit preflight: `.agents/skills/rpce-contribution-check/scripts/preflight.sh commit`
- push preflight: `.agents/skills/rpce-contribution-check/scripts/preflight.sh push`