### PR TITLE
Document KeyboardShortcuts packaging workaround

### DIFF
--- a/Scripts/package_app.sh
+++ b/Scripts/package_app.sh
@@ -152,6 +152,9 @@ printf 'Signing mode marker: %s\n' "$SIGNING_MODE_MARKER"
 
 SWIFT_BUILD_ARGS=(-c "$CONF")
 
+# KeyboardShortcuts' default Bundle.module lookup does not match RepoPrompt's
+# packaged resource layout. Patch the pinned SwiftPM checkout before compiling;
+# this is intentionally not a post-build or post-signing mutation.
 phase "Patching KeyboardShortcuts resource lookup"
 run "$CONTROL_PLANE_SCRIPTS_DIR/patch_keyboard_shortcuts_resource_lookup.sh" "$ROOT_DIR"
 

--- a/Scripts/patch_keyboard_shortcuts_resource_lookup.sh
+++ b/Scripts/patch_keyboard_shortcuts_resource_lookup.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Temporary release workaround for KeyboardShortcuts 2.3.0 resource lookup in
+# RepoPrompt's packaged app layout. Prefer an upstream fix, pinned fork, or
+# vendored package over long-term mutation of SwiftPM's .build/checkouts state.
+
 ROOT_DIR="${1:-}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RUN_WITHOUT_GITHUB_TOKENS="$SCRIPT_DIR/run_without_github_tokens.sh"

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -69,6 +69,43 @@ for packaging inspection only; it is not notarized or suitable for public
 distribution. For runnable release-mode local testing, use the self-signed local
 production installer below.
 
+## KeyboardShortcuts resource lookup workaround
+
+RepoPrompt currently patches the pinned `KeyboardShortcuts` SwiftPM checkout
+during app packaging so the package's localized resources are found inside the
+packaged app bundle. The patch targets:
+
+```text
+.build/checkouts/KeyboardShortcuts/Sources/KeyboardShortcuts/Utilities.swift
+```
+
+The patch is applied **before** Swift compilation, not after the app is built or
+signed:
+
+1. `package_app.sh` runs `patch_keyboard_shortcuts_resource_lookup.sh`.
+2. `swift build` compiles `RepoPrompt` with the patched dependency source.
+3. SwiftPM resource bundles are copied into `RepoPrompt.app/Contents/Resources`.
+4. The packaged resource layout is validated.
+5. The app is signed.
+
+This workaround exists because RepoPrompt's manual app packaging copies the
+SwiftPM resource bundle to:
+
+```text
+RepoPrompt.app/Contents/Resources/KeyboardShortcuts_KeyboardShortcuts.bundle
+```
+
+The package patch makes KeyboardShortcuts look there before falling back to its
+normal `Bundle.module` lookup. Keep the patch, bundle copy, and validator in
+sync; do not remove the workaround without validating that **Settings → Keyboard
+Shortcuts** opens successfully in a packaged app build.
+
+This is an intentional short-term release workaround, not the preferred
+long-term dependency strategy. A cleaner long-term fix should make the adjusted
+KeyboardShortcuts source part of normal dependency resolution by upstreaming the
+resource lookup fix, depending on a pinned RepoPrompt fork, or vendoring a local
+patched package.
+
 ## Install a local self-signed production build
 
 Users who want a release-mode build without maintainer credentials can install


### PR DESCRIPTION
## Summary
- Document the KeyboardShortcuts SwiftPM resource lookup workaround in `docs/releasing.md`
- Clarify that the checkout patch runs before Swift compilation, not after build/signing
- Add short comments near the packaging script patch call and patch helper explaining the temporary workaround and preferred long-term dependency fixes
