### PR TITLE
Prevent MCP frame starvation and lifecycle cleanup races

### DIFF
--- a/Sources/RepoPrompt/App/WindowStateComposition.swift
+++ b/Sources/RepoPrompt/App/WindowStateComposition.swift
@@ -28,7 +28,8 @@ enum WindowStateCompositionFactory {
     static func make(
         windowID: Int,
         deferredInitialAgentSystemWorkspaceRefresh: Bool,
-        sharedMCPService: MCPService
+        sharedMCPService: MCPService,
+        contextBuilderProviderFactory: ContextBuilderAgentViewModel.ProviderFactory? = nil
     ) -> WindowStateComposition {
         // 1) Workspace file context store + visible file-tree UI adapter
         let workspaceFileContextStore = WorkspaceFileContextStore()
@@ -120,7 +121,8 @@ enum WindowStateCompositionFactory {
             promptManager: promptManager,
             workspaceManager: workspaceManager,
             mcpServer: mcpServer,
-            oracleViewModel: oracleViewModel
+            oracleViewModel: oracleViewModel,
+            providerFactory: contextBuilderProviderFactory
         )
 
         // 13) Agent mode (for minimal agent UI)

--- a/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderAgentViewModel.swift
+++ b/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderAgentViewModel.swift
@@ -95,6 +95,12 @@ enum ContextBuilderFollowUpType: String, CaseIterable, Codable {
 
 @MainActor
 final class ContextBuilderAgentViewModel: ObservableObject {
+    typealias ProviderFactory = (
+        _ agent: AgentProviderKind,
+        _ modelString: String?,
+        _ workspacePath: String?
+    ) -> HeadlessAgentProvider
+
     private func debugLog(_ message: @autoclosure () -> String) {
         #if DEBUG
             if AgentRuntimeProviderService.enableDebugLogging {
@@ -387,6 +393,28 @@ final class ContextBuilderAgentViewModel: ObservableObject {
 
     /// Owns active and terminal-cleanup Context Builder attempts.
     private let runRegistry = ContextBuilderRunRegistry()
+
+    #if DEBUG
+        struct RunTestHooks {
+            let beforeProcessingProviderEvent: ((_ result: AIStreamResult, _ runID: UUID) async -> Void)?
+            let providerEventDisposition: ((_ result: AIStreamResult, _ runID: UUID, _ accepted: Bool) -> Void)?
+            let teardownCompleted: ((_ runID: UUID) -> Void)?
+        }
+
+        private var runTestHooks: RunTestHooks?
+
+        func installRunTestHooks(_ hooks: RunTestHooks?) {
+            runTestHooks = hooks
+        }
+
+        func activeRunIDForTesting(tabID: UUID) -> UUID? {
+            runRegistry.activeRecord(tabID: tabID)?.runID
+        }
+
+        func isRunTeardownPendingForTesting(runID: UUID) -> Bool {
+            runRegistry.record(runID: runID)?.isTeardownPending == true
+        }
+    #endif
 
     // MARK: - Published session-scoped proxies
 
@@ -748,6 +776,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
     private let promptManager: PromptViewModel
     private weak var workspaceManager: WorkspaceManagerViewModel?
     private let mcpServer: MCPServerViewModel
+    private let providerFactory: ProviderFactory
     /// Chat VM used for headless plan generation from discovery.
     /// Weak to avoid accidental strong cycles with the view layer.
     private weak var oracleViewModel: OracleViewModel?
@@ -779,12 +808,20 @@ final class ContextBuilderAgentViewModel: ObservableObject {
         promptManager: PromptViewModel,
         workspaceManager: WorkspaceManagerViewModel,
         mcpServer: MCPServerViewModel,
-        oracleViewModel: OracleViewModel
+        oracleViewModel: OracleViewModel,
+        providerFactory: ProviderFactory? = nil
     ) {
         self.promptManager = promptManager
         self.workspaceManager = workspaceManager
         self.mcpServer = mcpServer
         self.oracleViewModel = oracleViewModel
+        self.providerFactory = providerFactory ?? { agent, modelString, workspacePath in
+            AgentRuntimeProviderService.shared.makeProvider(
+                for: agent,
+                modelString: modelString,
+                workspacePath: workspacePath
+            )
+        }
         refreshAvailableAgents()
 
         handleWorkspaceSwitch(workspaceManager.activeWorkspace)
@@ -1876,6 +1913,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
             if runRegistry.removeAfterTeardown(record) {
                 #if DEBUG
                     AgentModePerfDiagnostics.increment("contextBuilder.run.teardown.completed", tabID: record.tabID)
+                    runTestHooks?.teardownCompleted?(record.runID)
                 #endif
             }
         }
@@ -2064,11 +2102,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
 
             activeAgentRuns.insert(runID)
             let modelString = record.modelRaw == AgentModel.defaultModel.rawValue ? nil : record.modelRaw
-            let provider = AgentRuntimeProviderService.shared.makeProvider(
-                for: record.agentKind,
-                modelString: modelString,
-                workspacePath: currentWorkspacePath
-            )
+            let provider = providerFactory(record.agentKind, modelString, currentWorkspacePath)
             guard record.installProvider(provider) else {
                 await provider.dispose()
                 await lease.failAndCleanup()
@@ -2086,7 +2120,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
                 debugLog("System prompt length: \(message.systemPrompt.count)")
                 debugLog("User message length: \(message.userMessage.count)")
                 let stream = try await provider.streamAgentMessage(message, runID: runID)
-                guard acceptsEvents(from: record) else {
+                guard !Task.isCancelled, acceptsEvents(from: record) else {
                     await lease.failAndCleanup()
                     return .cancelled
                 }
@@ -2116,48 +2150,12 @@ final class ContextBuilderAgentViewModel: ObservableObject {
                 )
                 updateRuntimeBindings(from: session)
 
-                do {
-                    for try await result in stream {
-                        guard !Task.isCancelled, acceptsEvents(from: record) else {
-                            return .cancelled
-                        }
-                        if case .rejected = session.recordRunProgress(
-                            ownership: record.ownership,
-                            kind: .providerEvent,
-                            stage: .running
-                        ) {
-                            return .cancelled
-                        }
-
-                        debugLog("Received stream result type: \(result.type)")
-                        if result.type == "content" {
-                            if record.output.append(result.text ?? "", messageID: result.contentMessageID) {
-                                noteAssistantPreviewChanged(for: record)
-                            }
-                            continue
-                        }
-
-                        if result.type == "final_content" {
-                            if let finalContent = result.text,
-                               record.output.replace(with: finalContent)
-                            {
-                                noteAssistantPreviewChanged(for: record)
-                            }
-                            continue
-                        }
-
-                        flushAssistantPreview(for: record)
-                        if let mapping = mapStreamResultToLogEntry(result),
-                           session.appendLogEntry(mapping.entry, dedupeKey: mapping.dedupeKey)
-                        {
-                            updateAgentLogBinding(from: session)
-                        }
-                    }
-                } catch is CancellationError {
-                    return .cancelled
-                } catch {
-                    guard acceptsEvents(from: record) else { return .cancelled }
-                    return .failed(extractVerboseErrorMessage(from: error))
+                let streamOutcome = await consumeContextBuilderProviderStream(
+                    stream,
+                    record: record
+                )
+                guard streamOutcome == .completed else {
+                    return streamOutcome
                 }
             } catch is CancellationError {
                 await lease.failAndCleanup()
@@ -2173,6 +2171,77 @@ final class ContextBuilderAgentViewModel: ObservableObject {
             guard committed, acceptsEvents(from: record) else { return .cancelled }
             return .completed
         }
+    }
+
+    private func consumeContextBuilderProviderStream(
+        _ stream: AsyncThrowingStream<AIStreamResult, Error>,
+        record: ContextBuilderRunRecord
+    ) async -> ContextBuilderRunTerminalOutcome {
+        let session = record.session
+
+        do {
+            for try await result in stream {
+                #if DEBUG
+                    await runTestHooks?.beforeProcessingProviderEvent?(result, record.runID)
+                #endif
+                guard !Task.isCancelled, acceptsEvents(from: record) else {
+                    #if DEBUG
+                        runTestHooks?.providerEventDisposition?(result, record.runID, false)
+                    #endif
+                    return .cancelled
+                }
+                if case .rejected = session.recordRunProgress(
+                    ownership: record.ownership,
+                    kind: .providerEvent,
+                    stage: .running
+                ) {
+                    #if DEBUG
+                        runTestHooks?.providerEventDisposition?(result, record.runID, false)
+                    #endif
+                    return .cancelled
+                }
+
+                debugLog("Received stream result type: \(result.type)")
+                if result.type == "content" {
+                    if record.output.append(result.text ?? "", messageID: result.contentMessageID) {
+                        noteAssistantPreviewChanged(for: record)
+                    }
+                    #if DEBUG
+                        runTestHooks?.providerEventDisposition?(result, record.runID, true)
+                    #endif
+                    continue
+                }
+
+                if result.type == "final_content" {
+                    if let finalContent = result.text,
+                       record.output.replace(with: finalContent)
+                    {
+                        noteAssistantPreviewChanged(for: record)
+                    }
+                    #if DEBUG
+                        runTestHooks?.providerEventDisposition?(result, record.runID, true)
+                    #endif
+                    continue
+                }
+
+                flushAssistantPreview(for: record)
+                if let mapping = mapStreamResultToLogEntry(result),
+                   session.appendLogEntry(mapping.entry, dedupeKey: mapping.dedupeKey)
+                {
+                    updateAgentLogBinding(from: session)
+                }
+                #if DEBUG
+                    runTestHooks?.providerEventDisposition?(result, record.runID, true)
+                #endif
+            }
+        } catch is CancellationError {
+            return .cancelled
+        } catch {
+            guard acceptsEvents(from: record) else { return .cancelled }
+            return .failed(extractVerboseErrorMessage(from: error))
+        }
+
+        return .completed
     }
 
     func cancelAgentRun() async {

--- a/Sources/RepoPrompt/Infrastructure/MCP/AppShared/NewlineDelimitedSocketReader.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/AppShared/NewlineDelimitedSocketReader.swift
@@ -60,26 +60,114 @@ public enum ReadSourceFDPreflight {
     }
 }
 
+public enum NewlineDelimitedSocketReaderTerminal: @unchecked Sendable {
+    case eof(hasResidualData: Bool)
+    case error(Swift.Error)
+}
+
 /// Event-driven reader for newline-delimited socket frames.
 /// Not actor-isolated; intended to be driven from transports on a dedicated queue.
+/// Each instance is single-use; create a new reader after stop or terminal delivery.
 public final class NewlineDelimitedSocketReader {
+    typealias ReadOperation = (Int32, UnsafeMutableRawPointer?, Int) -> Int
+
+    private struct ReadEventSource {
+        let id: ObjectIdentifier
+        private let setEventHandlerImpl: (@escaping () -> Void) -> Void
+        private let setCancelHandlerImpl: (@escaping () -> Void) -> Void
+        private let resumeImpl: () -> Void
+        private let cancelImpl: () -> Void
+
+        init(_ source: DispatchSourceRead) {
+            id = ObjectIdentifier(source as AnyObject)
+            setEventHandlerImpl = { source.setEventHandler(handler: $0) }
+            setCancelHandlerImpl = { source.setCancelHandler(handler: $0) }
+            resumeImpl = { source.resume() }
+            cancelImpl = { source.cancel() }
+        }
+
+        func setEventHandler(_ handler: @escaping () -> Void) {
+            setEventHandlerImpl(handler)
+        }
+
+        func setCancelHandler(_ handler: @escaping () -> Void) {
+            setCancelHandlerImpl(handler)
+        }
+
+        func resume() {
+            resumeImpl()
+        }
+
+        func cancel() {
+            cancelImpl()
+        }
+    }
+
+    private enum Lifecycle: Equatable {
+        case idle
+        case running
+        case terminal
+        case stopped
+    }
+
+    private static let defaultMaxReadCallsPerEvent = 32
+    private static let defaultMaxBytesPerEvent = 256 * 1024
+    private static let defaultMaxFramesPerEvent = 128
+
     private let fd: Int32
     private let queue: DispatchQueue
     private let logger: Logger
     private let delimiter: UInt8
     private let chunkSize: Int
     private let bufferReservation: Int
+    private let maxReadCallsPerEvent: Int
+    private let maxBytesPerEvent: Int
+    private let maxFramesPerEvent: Int
+    private let readOperation: ReadOperation
+    private let queueKey = DispatchSpecificKey<UInt8>()
     private let onFrame: (Data) -> Void
     private let onEOF: (_ hasResidualData: Bool) -> Void
     private let onError: (Swift.Error) -> Void
     private let onBytesRead: (() -> Void)?
     private let onCancel: (() -> Void)?
 
-    private var source: DispatchSourceRead?
+    private var source: ReadEventSource?
+    private var pendingCancelledSources: [ObjectIdentifier: ReadEventSource] = [:]
     private var buffer = Data()
-    private var started = false
+    private var lifecycle = Lifecycle.idle
+    private var generation: UInt64 = 0
+    private var pumpRunning = false
+    private var pumpScheduled = false
+    private var readableEventPending = false
 
-    public init(
+    public convenience init(
+        fd: Int32,
+        queue: DispatchQueue,
+        logger: Logger,
+        delimiter: UInt8 = UInt8(ascii: "\n"),
+        chunkSize: Int = 16384,
+        bufferReservation: Int = 64 * 1024,
+        onFrame: @escaping (Data) -> Void,
+        onTerminal: @escaping (NewlineDelimitedSocketReaderTerminal) -> Void,
+        onBytesRead: (() -> Void)? = nil,
+        onCancel: (() -> Void)? = nil
+    ) {
+        self.init(
+            fd: fd,
+            queue: queue,
+            logger: logger,
+            delimiter: delimiter,
+            chunkSize: chunkSize,
+            bufferReservation: bufferReservation,
+            onFrame: onFrame,
+            onEOF: { onTerminal(.eof(hasResidualData: $0)) },
+            onError: { onTerminal(.error($0)) },
+            onBytesRead: onBytesRead,
+            onCancel: onCancel
+        )
+    }
+
+    public convenience init(
         fd: Int32,
         queue: DispatchQueue,
         logger: Logger,
@@ -92,91 +180,272 @@ public final class NewlineDelimitedSocketReader {
         onBytesRead: (() -> Void)? = nil,
         onCancel: (() -> Void)? = nil
     ) {
+        self.init(
+            fd: fd,
+            queue: queue,
+            logger: logger,
+            delimiter: delimiter,
+            chunkSize: chunkSize,
+            bufferReservation: bufferReservation,
+            maxReadCallsPerEvent: Self.defaultMaxReadCallsPerEvent,
+            maxBytesPerEvent: Self.defaultMaxBytesPerEvent,
+            maxFramesPerEvent: Self.defaultMaxFramesPerEvent,
+            readOperation: systemRead,
+            onFrame: onFrame,
+            onEOF: onEOF,
+            onError: onError,
+            onBytesRead: onBytesRead,
+            onCancel: onCancel
+        )
+    }
+
+    init(
+        fd: Int32,
+        queue: DispatchQueue,
+        logger: Logger,
+        delimiter: UInt8 = UInt8(ascii: "\n"),
+        chunkSize: Int = 16384,
+        bufferReservation: Int = 64 * 1024,
+        maxReadCallsPerEvent: Int = NewlineDelimitedSocketReader.defaultMaxReadCallsPerEvent,
+        maxBytesPerEvent: Int = NewlineDelimitedSocketReader.defaultMaxBytesPerEvent,
+        maxFramesPerEvent: Int = NewlineDelimitedSocketReader.defaultMaxFramesPerEvent,
+        readOperation: @escaping ReadOperation,
+        onFrame: @escaping (Data) -> Void,
+        onEOF: @escaping (_ hasResidualData: Bool) -> Void,
+        onError: @escaping (Swift.Error) -> Void,
+        onBytesRead: (() -> Void)? = nil,
+        onCancel: (() -> Void)? = nil
+    ) {
         self.fd = fd
         self.queue = queue
         self.logger = logger
         self.delimiter = delimiter
         self.chunkSize = chunkSize
         self.bufferReservation = bufferReservation
+        self.maxReadCallsPerEvent = max(1, maxReadCallsPerEvent)
+        self.maxBytesPerEvent = max(1, maxBytesPerEvent)
+        self.maxFramesPerEvent = max(1, maxFramesPerEvent)
+        self.readOperation = readOperation
         self.onFrame = onFrame
         self.onEOF = onEOF
         self.onError = onError
         self.onBytesRead = onBytesRead
         self.onCancel = onCancel
         buffer.reserveCapacity(bufferReservation)
+        queue.setSpecific(key: queueKey, value: 1)
     }
 
     public func start() throws {
-        guard !started else { return }
+        try syncOnQueue {
+            guard lifecycle == .idle else { return }
 
-        let source = try ReadSourceFDPreflight.makeReadSource(
-            fileDescriptor: fd,
-            queue: queue,
-            label: "newline-delimited socket reader"
-        )
-        self.source = source
+            generation &+= 1
+            let sourceGeneration = generation
+            buffer.removeAll(keepingCapacity: true)
+            readableEventPending = false
+            pumpRunning = false
+            pumpScheduled = false
 
-        source.setEventHandler { [weak self] in
-            guard let self else { return }
+            let dispatchSource = try ReadSourceFDPreflight.makeReadSource(
+                fileDescriptor: fd,
+                queue: queue,
+                label: "newline-delimited socket reader"
+            )
+            let source = ReadEventSource(dispatchSource)
+            let sourceID = source.id
+            self.source = source
+            lifecycle = .running
 
-            let readBuffer = UnsafeMutablePointer<UInt8>.allocate(capacity: chunkSize)
-            defer { readBuffer.deallocate() }
+            source.setEventHandler { [weak self] in
+                self?.handleReadableEventOnQueue(generation: sourceGeneration)
+            }
+            source.setCancelHandler { [weak self] in
+                self?.handleSourceCancelledOnQueue(sourceID: sourceID)
+            }
+            source.resume()
+        }
+    }
 
-            var anyBytesRead = false
+    func processReadableEvent() {
+        syncOnQueue {
+            if lifecycle == .idle {
+                generation &+= 1
+                lifecycle = .running
+            }
+            handleReadableEventOnQueue(generation: generation)
+        }
+    }
 
-            while true {
-                let bytesRead = systemRead(fd, readBuffer, chunkSize)
+    private func handleReadableEventOnQueue(generation eventGeneration: UInt64) {
+        guard eventGeneration == generation, lifecycle == .running else { return }
+        readableEventPending = true
+        guard !pumpRunning else { return }
+        runReadablePumpOnQueue(generation: eventGeneration)
+    }
 
-                if bytesRead < 0 {
-                    let err = errno
-                    if err == EINTR {
-                        continue
-                    } else if err == EAGAIN || err == EWOULDBLOCK {
-                        break
-                    } else {
-                        let posixError = POSIXError(POSIXErrorCode(rawValue: err) ?? .EIO)
-                        logger.error("NewlineDelimitedSocketReader read error: \(err)")
-                        onError(posixError)
-                        return
-                    }
-                }
+    private func runReadablePumpOnQueue(generation pumpGeneration: UInt64) {
+        guard pumpGeneration == generation, lifecycle == .running else { return }
+        pumpRunning = true
+        readableEventPending = false
+        let needsContinuation = processReadableEventPass(generation: pumpGeneration)
+        pumpRunning = false
+        if needsContinuation {
+            readableEventPending = true
+        }
+        schedulePendingReadableEventIfNeeded(generation: pumpGeneration)
+    }
 
-                if bytesRead == 0 {
-                    onEOF(!buffer.isEmpty)
-                    return
-                }
+    private func processReadableEventPass(generation pumpGeneration: UInt64) -> Bool {
+        let readBuffer = UnsafeMutablePointer<UInt8>.allocate(capacity: chunkSize)
+        defer { readBuffer.deallocate() }
 
-                buffer.append(readBuffer, count: bytesRead)
-                anyBytesRead = true
+        var notifiedBytesRead = false
+        var readCallCount = 0
+        var byteCount = 0
+        var frameCount = 0
+
+        while pumpGeneration == generation, lifecycle == .running {
+            frameCount += drainCompleteFrames(
+                limit: maxFramesPerEvent - frameCount,
+                generation: pumpGeneration
+            )
+            guard pumpGeneration == generation, lifecycle == .running else { return false }
+            if frameCount >= maxFramesPerEvent {
+                return true
+            }
+            if readCallCount >= maxReadCallsPerEvent || byteCount >= maxBytesPerEvent {
+                return true
             }
 
-            if anyBytesRead {
+            let requestedBytes = min(chunkSize, maxBytesPerEvent - byteCount)
+            readCallCount += 1
+            let bytesRead = readOperation(fd, readBuffer, requestedBytes)
+
+            if bytesRead < 0 {
+                let err = errno
+                if err == EINTR {
+                    continue
+                } else if err == EAGAIN || err == EWOULDBLOCK {
+                    break
+                } else {
+                    let posixError = POSIXError(POSIXErrorCode(rawValue: err) ?? .EIO)
+                    logger.error("NewlineDelimitedSocketReader read error: \(err)")
+                    finishTerminalOnQueue(.failure(posixError), generation: pumpGeneration)
+                    return false
+                }
+            }
+
+            if bytesRead == 0 {
+                finishTerminalOnQueue(.success(!buffer.isEmpty), generation: pumpGeneration)
+                return false
+            }
+
+            buffer.append(readBuffer, count: bytesRead)
+            byteCount += bytesRead
+            if !notifiedBytesRead {
+                notifiedBytesRead = true
                 onBytesRead?()
-            }
-
-            while let newlineIndex = buffer.firstIndex(of: delimiter) {
-                let frame = Data(buffer[..<newlineIndex])
-                let nextStart = buffer.index(after: newlineIndex)
-                buffer.removeSubrange(..<nextStart)
-
-                if !frame.isEmpty {
-                    onFrame(frame)
-                }
+                guard pumpGeneration == generation, lifecycle == .running else { return false }
             }
         }
+        return false
+    }
 
-        source.setCancelHandler { [weak self] in
+    @discardableResult
+    private func drainCompleteFrames(limit: Int, generation pumpGeneration: UInt64) -> Int {
+        guard limit > 0 else { return 0 }
+
+        var drainedCount = 0
+        while drainedCount < limit,
+              pumpGeneration == generation,
+              lifecycle == .running,
+              let newlineIndex = buffer.firstIndex(of: delimiter)
+        {
+            let frame = Data(buffer[..<newlineIndex])
+            let nextStart = buffer.index(after: newlineIndex)
+            buffer.removeSubrange(..<nextStart)
+            drainedCount += 1
+
+            if !frame.isEmpty {
+                onFrame(frame)
+            }
+        }
+        return drainedCount
+    }
+
+    private func schedulePendingReadableEventIfNeeded(generation pumpGeneration: UInt64) {
+        guard pumpGeneration == generation,
+              lifecycle == .running,
+              readableEventPending
+        else {
+            readableEventPending = false
+            return
+        }
+        guard !pumpScheduled else { return }
+        pumpScheduled = true
+        queue.async { [weak self] in
             guard let self else { return }
-            onCancel?()
+            pumpScheduled = false
+            guard pumpGeneration == generation,
+                  lifecycle == .running,
+                  readableEventPending
+            else {
+                return
+            }
+            runReadablePumpOnQueue(generation: pumpGeneration)
         }
-
-        source.resume()
-        started = true
     }
 
     public func stop() {
-        source?.cancel()
-        source = nil
-        started = false
+        syncOnQueue {
+            stopOnQueue()
+        }
+    }
+
+    private func stopOnQueue() {
+        guard lifecycle != .stopped else { return }
+        generation &+= 1
+        lifecycle = .stopped
+        readableEventPending = false
+        pumpScheduled = false
+        buffer.removeAll(keepingCapacity: true)
+        cancelCurrentSourceOnQueue()
+    }
+
+    private func finishTerminalOnQueue(
+        _ result: Result<Bool, Swift.Error>,
+        generation terminalGeneration: UInt64
+    ) {
+        guard terminalGeneration == generation, lifecycle == .running else { return }
+        lifecycle = .terminal
+        readableEventPending = false
+        pumpScheduled = false
+        cancelCurrentSourceOnQueue()
+
+        switch result {
+        case let .success(hasResidualData):
+            onEOF(hasResidualData)
+        case let .failure(error):
+            onError(error)
+        }
+    }
+
+    private func cancelCurrentSourceOnQueue() {
+        guard let source else { return }
+        self.source = nil
+        pendingCancelledSources[source.id] = source
+        source.cancel()
+    }
+
+    private func handleSourceCancelledOnQueue(sourceID: ObjectIdentifier) {
+        guard pendingCancelledSources.removeValue(forKey: sourceID) != nil else { return }
+        onCancel?()
+    }
+
+    private func syncOnQueue<T>(_ operation: () throws -> T) rethrows -> T {
+        if DispatchQueue.getSpecific(key: queueKey) != nil {
+            return try operation()
+        }
+        return try queue.sync(execute: operation)
     }
 }

--- a/Sources/RepoPrompt/Infrastructure/MCP/MCPConnectionManager.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/MCPConnectionManager.swift
@@ -8400,6 +8400,24 @@ actor ServerNetworkManager {
         return await limiter.activeCount() > 0
     }
 
+    #if DEBUG
+        func connectionLimiterSnapshotForTesting(
+            connectionID: UUID
+        ) async -> AsyncLimiter.DebugSnapshot? {
+            guard let limiter = callLimiters[connectionID] else { return nil }
+            return await limiter.debugSnapshot()
+        }
+
+        func setConnectionLimiterStateObserverForTesting(
+            connectionID: UUID,
+            observer: ((AsyncLimiter.DebugSnapshot) -> Void)?
+        ) async -> Bool {
+            guard let limiter = callLimiters[connectionID] else { return false }
+            await limiter.setDebugStateObserver(observer)
+            return true
+        }
+    #endif
+
     private func oldestEvictableConnectionID() async -> UUID? {
         let threshold = pressureEvictIdleSeconds
         guard threshold > 0 else { return nil }
@@ -8587,6 +8605,16 @@ actor AsyncLimiter {
     /// Tracks the number of tasks currently inside withPermit (including queued ones)
     private var inFlight: Int = 0
 
+    #if DEBUG
+        struct DebugSnapshot: Equatable {
+            let permits: Int
+            let waiterCount: Int
+            let inFlight: Int
+        }
+
+        private var debugStateObserver: ((DebugSnapshot) -> Void)?
+    #endif
+
     init(limit: Int) {
         self.limit = max(1, limit)
         permits = max(1, limit)
@@ -8596,9 +8624,13 @@ actor AsyncLimiter {
     private func acquirePermit() async {
         if permits > 0 {
             permits -= 1
+            notifyDebugStateChanged()
             return
         }
-        await withCheckedContinuation { waiters.append($0) }
+        await withCheckedContinuation {
+            waiters.append($0)
+            notifyDebugStateChanged()
+        }
         // When resumed, the caller now has a permit (recycled from a release)
     }
 
@@ -8611,6 +8643,7 @@ actor AsyncLimiter {
         } else {
             permits = min(permits + 1, limit)
         }
+        notifyDebugStateChanged()
     }
 
     /// Number of in-flight operations (0 means idle).
@@ -8619,12 +8652,43 @@ actor AsyncLimiter {
         inFlight
     }
 
+    #if DEBUG
+        func debugSnapshot() -> DebugSnapshot {
+            makeDebugSnapshot()
+        }
+
+        func setDebugStateObserver(
+            _ observer: ((DebugSnapshot) -> Void)?
+        ) {
+            debugStateObserver = observer
+            observer?(makeDebugSnapshot())
+        }
+
+        private func makeDebugSnapshot() -> DebugSnapshot {
+            DebugSnapshot(
+                permits: permits,
+                waiterCount: waiters.count,
+                inFlight: inFlight
+            )
+        }
+
+        private func notifyDebugStateChanged() {
+            debugStateObserver?(makeDebugSnapshot())
+        }
+    #else
+        private func notifyDebugStateChanged() {}
+    #endif
+
     /// Executes an operation with a permit, limiting concurrency.
     func withPermit<T>(
         _ op: @Sendable () async throws -> T
     ) async rethrows -> T {
         inFlight += 1
-        defer { inFlight -= 1 }
+        notifyDebugStateChanged()
+        defer {
+            inFlight -= 1
+            notifyDebugStateChanged()
+        }
         await acquirePermit()
         defer { releasePermit() }
         return try await op()

--- a/Sources/RepoPrompt/Infrastructure/MCP/UnixSocketMCPTransport.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/UnixSocketMCPTransport.swift
@@ -21,6 +21,58 @@ import RepoPromptShared
     private func unixSocketMCPTransportDebugLog(_ message: @autoclosure () -> String) {}
 #endif
 
+#if DEBUG
+    private final class UnixSocketMCPTransportCallbackGate: @unchecked Sendable {
+        enum Kind: Hashable {
+            case terminal
+            case cancellation
+        }
+
+        private let lock = NSLock()
+        private var heldKinds: Set<Kind> = []
+        private var pendingCallbacks: [Kind: [@Sendable () -> Void]] = [:]
+
+        func hold(_ kind: Kind) {
+            lock.lock()
+            heldKinds.insert(kind)
+            lock.unlock()
+        }
+
+        func submit(_ kind: Kind, callback: @escaping @Sendable () -> Void) {
+            lock.lock()
+            guard heldKinds.contains(kind) else {
+                lock.unlock()
+                callback()
+                return
+            }
+            pendingCallbacks[kind, default: []].append(callback)
+            lock.unlock()
+        }
+
+        func release(_ kind: Kind) {
+            lock.lock()
+            heldKinds.remove(kind)
+            let callbacks = pendingCallbacks.removeValue(forKey: kind) ?? []
+            lock.unlock()
+            callbacks.forEach { $0() }
+        }
+    }
+
+    struct UnixSocketMCPTransportCleanupSnapshot {
+        let hasActiveReader: Bool
+        let pendingReaderCancellationCount: Int
+        let earlyReaderCancellationCount: Int
+        let readerIsRetained: Bool
+        let terminalCallbackCount: Int
+        let cancellationCallbackCount: Int
+        let finalizationCount: Int
+        let descriptorCloseCount: Int
+        let staleCancellationCount: Int
+        let staleTerminalCount: Int
+        let socketIsOwned: Bool
+    }
+#endif
+
 private final class MCPTransportIngressGate: @unchecked Sendable {
     enum OfferResult {
         case accepted
@@ -117,42 +169,81 @@ public actor UnixSocketMCPTransport: Transport {
     /// If true, this transport was created with an existing FD (no connect needed)
     private let ownsExistingFD: Bool
 
-    // Message stream for received data
-    private nonisolated let messageStream: AsyncThrowingStream<Data, Swift.Error>
-    private var messageContinuation: AsyncThrowingStream<Data, Swift.Error>.Continuation
-    private let ingressGate: MCPTransportIngressGate
+    private struct InboundChannel {
+        let stream: AsyncThrowingStream<Data, Swift.Error>
+        let continuation: AsyncThrowingStream<Data, Swift.Error>.Continuation
+        let gate: MCPTransportIngressGate
 
-    // Close notification stream for cleanup signaling
-    private nonisolated let closeStream: AsyncStream<Void>
-    private var closeContinuation: AsyncStream<Void>.Continuation
+        init(capacity: Int) {
+            var continuation: AsyncThrowingStream<Data, Swift.Error>.Continuation!
+            stream = AsyncThrowingStream(
+                Data.self,
+                bufferingPolicy: .bufferingOldest(capacity)
+            ) { continuation = $0 }
+            self.continuation = continuation
+            gate = MCPTransportIngressGate(capacity: capacity)
+        }
+    }
+
+    private struct CloseChannel {
+        let stream: AsyncStream<Void>
+        let continuation: AsyncStream<Void>.Continuation
+
+        init() {
+            var continuation: AsyncStream<Void>.Continuation!
+            stream = AsyncStream(Void.self) { continuation = $0 }
+            self.continuation = continuation
+        }
+    }
+
+    /// Connection-local inbound and close channels. URL-backed transports replace
+    /// these after teardown so a successor connection cannot inherit terminal state.
+    private let receiveBufferCapacity: Int
+    private var inboundChannel: InboundChannel
+    private var closeChannel: CloseChannel
     private var closeSignaled = false
 
-    // Event-driven read source (replaces poll loop)
-    private var reader: NewlineDelimitedSocketReader?
+    /// Event-driven read source (replaces poll loop)
     private let readQueue = DispatchQueue(label: "com.repoprompt.mcp.unix.read", qos: .userInitiated)
 
-    /// Track fd that the read source is bound to (helps avoid closing wrong fd on reuse)
-    private var readSourceFD: Int32?
-    private var readSourceToken: UInt64?
-    private var readSourceSocketOwnershipGeneration: UInt64?
     private var nextReadSourceToken: UInt64 = 0
+
+    private struct ReaderIdentity: Hashable {
+        let fd: Int32
+        let token: UInt64
+        let socketOwnershipGeneration: UInt64
+    }
+
+    private struct ActiveReaderOwnership {
+        let identity: ReaderIdentity
+        let reader: NewlineDelimitedSocketReader
+    }
 
     /// Retains cancelled readers until their delayed cancel handlers perform final close.
     /// The transport retainer intentionally forms a temporary cycle so cleanup does not
     /// depend on an external manager keeping this actor alive after disconnect returns.
     private struct PendingReaderCancellation {
-        let fd: Int32
-        let socketOwnershipGeneration: UInt64
+        let identity: ReaderIdentity
         let reader: NewlineDelimitedSocketReader
         let transportRetainer: UnixSocketMCPTransport
     }
 
+    private var activeReaderOwnership: ActiveReaderOwnership?
     private var pendingReaderCancellations: [UInt64: PendingReaderCancellation] = [:]
+    private var earlyReaderCancellations: Set<ReaderIdentity> = []
 
     /// Changes whenever socketFD is replaced or synchronously closed.
     private var socketOwnershipGeneration: UInt64 = 0
 
     #if DEBUG
+        private nonisolated let callbackGate = UnixSocketMCPTransportCallbackGate()
+        private weak var debugLastReader: NewlineDelimitedSocketReader?
+        private var debugTerminalCallbackCount = 0
+        private var debugCancellationCallbackCount = 0
+        private var debugReaderFinalizationCount = 0
+        private var debugDescriptorCloseCount = 0
+        private var debugStaleCancellationCount = 0
+        private var debugStaleTerminalCount = 0
         /// Forces the adopted-FD startup path to fail after preparation but before reader ownership.
         private var failNextExistingFDConnectBeforeReaderStart = false
         /// Leaves a selected overflow pending so tests can race it with another teardown path.
@@ -191,23 +282,9 @@ public actor UnixSocketMCPTransport: Transport {
         self.logger = Self.createLogger(logger)
         self.writeStallTimeout = writeStallTimeout
         self.writePollIntervalMilliseconds = Self.sanitizedWritePollIntervalMilliseconds(writePollIntervalMilliseconds)
-        ingressGate = MCPTransportIngressGate(capacity: sanitizedReceiveBufferCapacity)
-
-        // Initialize streams
-        var msgCont: AsyncThrowingStream<Data, Swift.Error>.Continuation!
-        messageStream = AsyncThrowingStream(
-            Data.self,
-            bufferingPolicy: .bufferingOldest(sanitizedReceiveBufferCapacity)
-        ) { continuation in
-            msgCont = continuation
-        }
-        messageContinuation = msgCont
-
-        var closeCont: AsyncStream<Void>.Continuation!
-        closeStream = AsyncStream(Void.self) { continuation in
-            closeCont = continuation
-        }
-        closeContinuation = closeCont
+        self.receiveBufferCapacity = sanitizedReceiveBufferCapacity
+        inboundChannel = InboundChannel(capacity: sanitizedReceiveBufferCapacity)
+        closeChannel = CloseChannel()
     }
 
     /// Creates a transport using an already-connected file descriptor.
@@ -240,23 +317,9 @@ public actor UnixSocketMCPTransport: Transport {
         self.logger = Self.createLogger(logger)
         self.writeStallTimeout = writeStallTimeout
         self.writePollIntervalMilliseconds = Self.sanitizedWritePollIntervalMilliseconds(writePollIntervalMilliseconds)
-        ingressGate = MCPTransportIngressGate(capacity: sanitizedReceiveBufferCapacity)
-
-        // Initialize streams
-        var msgCont: AsyncThrowingStream<Data, Swift.Error>.Continuation!
-        messageStream = AsyncThrowingStream(
-            Data.self,
-            bufferingPolicy: .bufferingOldest(sanitizedReceiveBufferCapacity)
-        ) { continuation in
-            msgCont = continuation
-        }
-        messageContinuation = msgCont
-
-        var closeCont: AsyncStream<Void>.Continuation!
-        closeStream = AsyncStream(Void.self) { continuation in
-            closeCont = continuation
-        }
-        closeContinuation = closeCont
+        self.receiveBufferCapacity = sanitizedReceiveBufferCapacity
+        inboundChannel = InboundChannel(capacity: sanitizedReceiveBufferCapacity)
+        closeChannel = CloseChannel()
     }
 
     private static func createLogger(_ logger: Logger?) -> Logger {
@@ -293,9 +356,7 @@ public actor UnixSocketMCPTransport: Transport {
 
         unixSocketMCPTransportDebugLog("connecting to \(socketURL.path)")
 
-        isStopping = false
-        streamFinished = false
-        closeSignaled = false
+        prepareForConnectionAttempt()
 
         // Wait for socket file to appear and connect
         let startTime = Date()
@@ -376,17 +437,17 @@ public actor UnixSocketMCPTransport: Transport {
 
     /// Returns the async stream of received messages.
     public func receive() -> AsyncThrowingStream<Data, Swift.Error> {
-        messageStream
+        inboundChannel.stream
     }
 
     /// Returns the close notification stream.
     /// Use this to detect when the socket closes so connections can be cleaned up promptly.
     public func closed() -> AsyncStream<Void> {
-        closeStream
+        closeChannel.stream
     }
 
     func ingressSnapshot() -> MCPTransportIngressSnapshot {
-        ingressGate.snapshot()
+        inboundChannel.gate.snapshot()
     }
 
     /// Returns seconds since last activity, or nil if never active.
@@ -396,6 +457,16 @@ public actor UnixSocketMCPTransport: Transport {
     }
 
     // MARK: - Private Implementation
+
+    private func prepareForConnectionAttempt() {
+        isStopping = false
+        if streamFinished || closeSignaled {
+            inboundChannel = InboundChannel(capacity: receiveBufferCapacity)
+            closeChannel = CloseChannel()
+        }
+        streamFinished = false
+        closeSignaled = false
+    }
 
     /// Connects to the UNIX socket at socketURL.
     private func connectToSocket() throws {
@@ -469,6 +540,9 @@ public actor UnixSocketMCPTransport: Transport {
     private func closeSocket() {
         if socketFD >= 0 {
             Darwin.close(socketFD)
+            #if DEBUG
+                debugDescriptorCloseCount += 1
+            #endif
             socketFD = -1
             socketOwnershipGeneration &+= 1
         }
@@ -479,7 +553,7 @@ public actor UnixSocketMCPTransport: Transport {
     /// avoid a stale callback closing a reused descriptor number.
     private func tearDownSocket(error proposedError: Swift.Error?) {
         guard !streamFinished else { return }
-        let ingressSnapshot = ingressGate.closeAndSnapshot()
+        let ingressSnapshot = inboundChannel.gate.closeAndSnapshot()
         let resolvedError: Swift.Error? = if ingressSnapshot.terminalCause == .receiveBufferOverflow {
             MCPReceiveBufferOverflowError(
                 capacity: ingressSnapshot.receiveBufferCapacity,
@@ -506,7 +580,7 @@ public actor UnixSocketMCPTransport: Transport {
 
     private func connectExistingFD() throws {
         if isConnected {
-            guard reader != nil else {
+            guard activeReaderOwnership != nil else {
                 let error = MCPError.connectionClosed
                 tearDownSocket(error: error)
                 throw error
@@ -563,7 +637,60 @@ public actor UnixSocketMCPTransport: Transport {
         func debugDeferNextReceiveOverflowTeardown() {
             deferNextReceiveOverflowTeardown = true
         }
+
+        func debugHoldReaderTerminalCallback() {
+            callbackGate.hold(.terminal)
+        }
+
+        func debugReleaseReaderTerminalCallbacks() {
+            callbackGate.release(.terminal)
+        }
+
+        func debugHoldReaderCancellationCallback() {
+            callbackGate.hold(.cancellation)
+        }
+
+        func debugReleaseReaderCancellationCallbacks() {
+            callbackGate.release(.cancellation)
+        }
+
+        func debugTriggerReadErrorForCleanupTest() {
+            guard let identity = activeReaderOwnership?.identity else { return }
+            handleReaderTerminal(.error(POSIXError(.EIO)), from: identity)
+        }
+
+        func debugCleanupSnapshot() -> UnixSocketMCPTransportCleanupSnapshot {
+            UnixSocketMCPTransportCleanupSnapshot(
+                hasActiveReader: activeReaderOwnership != nil,
+                pendingReaderCancellationCount: pendingReaderCancellations.count,
+                earlyReaderCancellationCount: earlyReaderCancellations.count,
+                readerIsRetained: debugLastReader != nil,
+                terminalCallbackCount: debugTerminalCallbackCount,
+                cancellationCallbackCount: debugCancellationCallbackCount,
+                finalizationCount: debugReaderFinalizationCount,
+                descriptorCloseCount: debugDescriptorCloseCount,
+                staleCancellationCount: debugStaleCancellationCount,
+                staleTerminalCount: debugStaleTerminalCount,
+                socketIsOwned: socketFD >= 0
+            )
+        }
     #endif
+
+    private nonisolated func scheduleReaderTerminalCallback(_ callback: @escaping @Sendable () -> Void) {
+        #if DEBUG
+            callbackGate.submit(.terminal, callback: callback)
+        #else
+            callback()
+        #endif
+    }
+
+    private nonisolated func scheduleReaderCancellationCallback(_ callback: @escaping @Sendable () -> Void) {
+        #if DEBUG
+            callbackGate.submit(.cancellation, callback: callback)
+        #else
+            callback()
+        #endif
+    }
 
     private nonisolated static func ensureNonBlocking(fd: Int32) throws {
         let flags = fcntl(fd, F_GETFL)
@@ -723,15 +850,14 @@ public actor UnixSocketMCPTransport: Transport {
         try ReadSourceFDPreflight.validateOpenFD(fd, label: "UnixSocketMCPTransport read socket")
         stopReadSource()
 
-        // Track which FD this source is bound to
         nextReadSourceToken &+= 1
-        let token = nextReadSourceToken
-        readSourceFD = fd
-        readSourceToken = token
-        readSourceSocketOwnershipGeneration = socketOwnershipGeneration
+        let identity = ReaderIdentity(
+            fd: fd,
+            token: nextReadSourceToken,
+            socketOwnershipGeneration: socketOwnershipGeneration
+        )
 
-        let cont = messageContinuation
-        let ingressGate = ingressGate
+        let inboundChannel = inboundChannel
         let log = logger
 
         let newReader = NewlineDelimitedSocketReader(
@@ -740,100 +866,137 @@ public actor UnixSocketMCPTransport: Transport {
             logger: log,
             onFrame: { [weak self] frame in
                 guard let self else { return }
-                switch ingressGate.offer(frame, to: cont) {
+                switch inboundChannel.gate.offer(frame, to: inboundChannel.continuation) {
                 case .accepted:
                     mcpTransportLog("UnixSocketMCPTransport accepted message of \(frame.count) bytes")
                 case let .overflow(error):
                     mcpConnectionLog("UnixSocketMCPTransport receive buffer overflow; terminating connection")
-                    Task { await self.handleReceiveBufferOverflow(error) }
+                    let transport = self
+                    Task { await transport.handleReceiveBufferOverflow(error, from: identity) }
                 case .terminal:
                     break
                 }
             },
-            onEOF: { hasResidual in
-                mcpConnectionLog("UnixSocketMCPTransport received EOF")
-                Task { self.handleReadEOF(hasResidualData: hasResidual) }
+            onTerminal: { [weak self] terminal in
+                guard let transport = self else { return }
+                transport.scheduleReaderTerminalCallback {
+                    Task { await transport.handleReaderTerminal(terminal, from: identity) }
+                }
             },
-            onError: { error in
-                Task { self.handleReadError(error: error) }
+            onBytesRead: { [weak self] in
+                guard let transport = self else { return }
+                Task { await transport.noteActivity(from: identity) }
             },
-            onBytesRead: { Task { self.noteActivity() } },
             onCancel: { [weak self] in
-                mcpConnectionLog("UnixSocketMCPTransport read source cancelled for fd=\(fd) token=\(token)")
-                Task { await self?.readSourceDidCancel(fd: fd, token: token) }
+                guard let transport = self else { return }
+                mcpConnectionLog(
+                    "UnixSocketMCPTransport read source cancelled for fd=\(identity.fd) token=\(identity.token)"
+                )
+                transport.scheduleReaderCancellationCallback {
+                    Task { await transport.readSourceDidCancel(identity) }
+                }
             }
         )
 
-        reader = newReader
+        activeReaderOwnership = ActiveReaderOwnership(identity: identity, reader: newReader)
+        #if DEBUG
+            debugLastReader = newReader
+        #endif
         do {
             try newReader.start()
         } catch {
-            reader = nil
-            readSourceFD = nil
-            readSourceToken = nil
-            readSourceSocketOwnershipGeneration = nil
+            if activeReaderOwnership?.identity == identity {
+                activeReaderOwnership = nil
+            }
             throw error
         }
         mcpConnectionLog("UnixSocketMCPTransport read source started for fd=\(fd)")
     }
 
-    /// Stops the read source. Does NOT close the FD - that happens in cancelHandler.
+    /// Moves active reader ownership to the cancellation finalizer before requesting cancellation.
     private func stopReadSource() {
-        guard let reader else { return }
-        guard let fd = readSourceFD,
-              let token = readSourceToken,
-              let socketOwnershipGeneration = readSourceSocketOwnershipGeneration
-        else {
-            self.reader = nil
-            readSourceFD = nil
-            readSourceToken = nil
-            readSourceSocketOwnershipGeneration = nil
-            reader.stop()
-            return
-        }
+        guard let activeOwnership = activeReaderOwnership else { return }
+        activeReaderOwnership = nil
 
-        pendingReaderCancellations[token] = PendingReaderCancellation(
-            fd: fd,
-            socketOwnershipGeneration: socketOwnershipGeneration,
-            reader: reader,
+        let identity = activeOwnership.identity
+        pendingReaderCancellations[identity.token] = PendingReaderCancellation(
+            identity: identity,
+            reader: activeOwnership.reader,
             transportRetainer: self
         )
-        self.reader = nil
-        readSourceFD = nil
-        readSourceToken = nil
-        readSourceSocketOwnershipGeneration = nil
-        reader.stop()
-        // Note: retained reader cleanup happens in readSourceDidCancel
+        activeOwnership.reader.stop()
+
+        if earlyReaderCancellations.contains(identity) {
+            finalizeReaderCancellation(identity)
+        }
     }
 
     private func pendingReaderCancellationOwnsCurrentSocket() -> Bool {
         pendingReaderCancellations.values.contains { ownership in
-            ownership.fd == socketFD &&
-                ownership.socketOwnershipGeneration == socketOwnershipGeneration
+            ownership.identity.fd == socketFD &&
+                ownership.identity.socketOwnershipGeneration == socketOwnershipGeneration
         }
     }
 
-    /// Called by the read source's cancel handler. Closes the FD safely.
-    private func readSourceDidCancel(fd: Int32, token: UInt64) {
-        guard let ownership = pendingReaderCancellations.removeValue(forKey: token) else { return }
-        guard ownership.fd == fd else {
-            logger.error("UnixSocketMCPTransport reader cancellation fd mismatch for token=\(token)")
+    /// Called by the read source's cancel handler. Cancellation may beat terminal teardown.
+    private func readSourceDidCancel(_ identity: ReaderIdentity) {
+        #if DEBUG
+            debugCancellationCallbackCount += 1
+        #endif
+
+        if pendingReaderCancellations[identity.token]?.identity == identity {
+            finalizeReaderCancellation(identity)
             return
         }
 
-        if socketFD == fd, socketOwnershipGeneration != ownership.socketOwnershipGeneration {
-            logger.warning("UnixSocketMCPTransport skipping stale reader cancellation close for reused fd=\(fd)")
+        if activeReaderOwnership?.identity == identity {
+            earlyReaderCancellations.insert(identity)
             return
         }
 
-        Darwin.close(fd)
-        if socketFD == fd {
-            socketFD = -1
-            socketOwnershipGeneration &+= 1
+        #if DEBUG
+            debugStaleCancellationCount += 1
+        #endif
+    }
+
+    /// Sole final-close owner for a reader cancellation identity.
+    private func finalizeReaderCancellation(_ identity: ReaderIdentity) {
+        guard pendingReaderCancellations[identity.token]?.identity == identity,
+              let ownership = pendingReaderCancellations.removeValue(forKey: identity.token)
+        else {
+            return
+        }
+        earlyReaderCancellations.remove(identity)
+        withExtendedLifetime(ownership) {
+            #if DEBUG
+                debugReaderFinalizationCount += 1
+            #endif
+
+            if socketFD == identity.fd,
+               socketOwnershipGeneration != identity.socketOwnershipGeneration
+            {
+                logger.warning(
+                    "UnixSocketMCPTransport skipping stale reader cancellation close for reused fd=\(identity.fd)"
+                )
+                return
+            }
+
+            Darwin.close(identity.fd)
+            #if DEBUG
+                debugDescriptorCloseCount += 1
+            #endif
+            if socketFD == identity.fd {
+                socketFD = -1
+                socketOwnershipGeneration &+= 1
+            }
         }
     }
 
-    private func handleReceiveBufferOverflow(_ error: MCPReceiveBufferOverflowError) {
+    private func handleReceiveBufferOverflow(
+        _ error: MCPReceiveBufferOverflowError,
+        from identity: ReaderIdentity
+    ) {
+        guard activeReaderOwnership?.identity == identity else { return }
         guard !streamFinished else { return }
         #if DEBUG
             if deferNextReceiveOverflowTeardown {
@@ -844,20 +1007,33 @@ public actor UnixSocketMCPTransport: Transport {
         tearDownSocket(error: error)
     }
 
-    /// Called when read encounters an error.
-    private func handleReadError(error: Swift.Error) {
-        tearDownSocket(error: error)
-    }
+    private func handleReaderTerminal(
+        _ terminal: NewlineDelimitedSocketReaderTerminal,
+        from identity: ReaderIdentity
+    ) {
+        #if DEBUG
+            debugTerminalCallbackCount += 1
+        #endif
 
-    /// Called when read encounters EOF.
-    /// - Parameter hasResidualData: If true, buffer had incomplete frame data
-    private func handleReadEOF(hasResidualData: Bool) {
-        if hasResidualData {
+        guard activeReaderOwnership?.identity == identity else {
+            #if DEBUG
+                debugStaleTerminalCount += 1
+            #endif
+            return
+        }
+
+        switch terminal {
+        case let .error(error):
+            tearDownSocket(error: error)
+        case let .eof(hasResidualData):
+            mcpConnectionLog("UnixSocketMCPTransport received EOF")
+            guard hasResidualData else {
+                tearDownSocket(error: nil)
+                return
+            }
             // Treat residual incomplete frame as a protocol error
             let truncationError = MCPError.internalError("Connection closed with incomplete frame data")
             tearDownSocket(error: truncationError)
-        } else {
-            tearDownSocket(error: nil)
         }
     }
 
@@ -876,7 +1052,8 @@ public actor UnixSocketMCPTransport: Transport {
     }
 
     /// Updates the activity timestamp (called from read handler).
-    private func noteActivity() {
+    private func noteActivity(from identity: ReaderIdentity) {
+        guard activeReaderOwnership?.identity == identity else { return }
         lastActivityTime = Date()
     }
 
@@ -885,9 +1062,9 @@ public actor UnixSocketMCPTransport: Transport {
         guard !streamFinished else { return }
         streamFinished = true
         if let error {
-            messageContinuation.finish(throwing: error)
+            inboundChannel.continuation.finish(throwing: error)
         } else {
-            messageContinuation.finish()
+            inboundChannel.continuation.finish()
         }
     }
 
@@ -895,7 +1072,7 @@ public actor UnixSocketMCPTransport: Transport {
     private func signalClosedOnce() {
         guard !closeSignaled else { return }
         closeSignaled = true
-        closeContinuation.yield()
-        closeContinuation.finish()
+        closeChannel.continuation.yield()
+        closeChannel.continuation.finish()
     }
 }

--- a/Sources/RepoPromptMCP/Shared/NewlineDelimitedSocketReader.swift
+++ b/Sources/RepoPromptMCP/Shared/NewlineDelimitedSocketReader.swift
@@ -60,26 +60,114 @@ public enum ReadSourceFDPreflight {
     }
 }
 
+public enum NewlineDelimitedSocketReaderTerminal: @unchecked Sendable {
+    case eof(hasResidualData: Bool)
+    case error(Swift.Error)
+}
+
 /// Event-driven reader for newline-delimited socket frames.
 /// Not actor-isolated; intended to be driven from transports on a dedicated queue.
+/// Each instance is single-use; create a new reader after stop or terminal delivery.
 public final class NewlineDelimitedSocketReader {
+    typealias ReadOperation = (Int32, UnsafeMutableRawPointer?, Int) -> Int
+
+    private struct ReadEventSource {
+        let id: ObjectIdentifier
+        private let setEventHandlerImpl: (@escaping () -> Void) -> Void
+        private let setCancelHandlerImpl: (@escaping () -> Void) -> Void
+        private let resumeImpl: () -> Void
+        private let cancelImpl: () -> Void
+
+        init(_ source: DispatchSourceRead) {
+            id = ObjectIdentifier(source as AnyObject)
+            setEventHandlerImpl = { source.setEventHandler(handler: $0) }
+            setCancelHandlerImpl = { source.setCancelHandler(handler: $0) }
+            resumeImpl = { source.resume() }
+            cancelImpl = { source.cancel() }
+        }
+
+        func setEventHandler(_ handler: @escaping () -> Void) {
+            setEventHandlerImpl(handler)
+        }
+
+        func setCancelHandler(_ handler: @escaping () -> Void) {
+            setCancelHandlerImpl(handler)
+        }
+
+        func resume() {
+            resumeImpl()
+        }
+
+        func cancel() {
+            cancelImpl()
+        }
+    }
+
+    private enum Lifecycle: Equatable {
+        case idle
+        case running
+        case terminal
+        case stopped
+    }
+
+    private static let defaultMaxReadCallsPerEvent = 32
+    private static let defaultMaxBytesPerEvent = 256 * 1024
+    private static let defaultMaxFramesPerEvent = 128
+
     private let fd: Int32
     private let queue: DispatchQueue
     private let logger: Logger
     private let delimiter: UInt8
     private let chunkSize: Int
     private let bufferReservation: Int
+    private let maxReadCallsPerEvent: Int
+    private let maxBytesPerEvent: Int
+    private let maxFramesPerEvent: Int
+    private let readOperation: ReadOperation
+    private let queueKey = DispatchSpecificKey<UInt8>()
     private let onFrame: (Data) -> Void
     private let onEOF: (_ hasResidualData: Bool) -> Void
     private let onError: (Swift.Error) -> Void
     private let onBytesRead: (() -> Void)?
     private let onCancel: (() -> Void)?
 
-    private var source: DispatchSourceRead?
+    private var source: ReadEventSource?
+    private var pendingCancelledSources: [ObjectIdentifier: ReadEventSource] = [:]
     private var buffer = Data()
-    private var started = false
+    private var lifecycle = Lifecycle.idle
+    private var generation: UInt64 = 0
+    private var pumpRunning = false
+    private var pumpScheduled = false
+    private var readableEventPending = false
 
-    public init(
+    public convenience init(
+        fd: Int32,
+        queue: DispatchQueue,
+        logger: Logger,
+        delimiter: UInt8 = UInt8(ascii: "\n"),
+        chunkSize: Int = 16384,
+        bufferReservation: Int = 64 * 1024,
+        onFrame: @escaping (Data) -> Void,
+        onTerminal: @escaping (NewlineDelimitedSocketReaderTerminal) -> Void,
+        onBytesRead: (() -> Void)? = nil,
+        onCancel: (() -> Void)? = nil
+    ) {
+        self.init(
+            fd: fd,
+            queue: queue,
+            logger: logger,
+            delimiter: delimiter,
+            chunkSize: chunkSize,
+            bufferReservation: bufferReservation,
+            onFrame: onFrame,
+            onEOF: { onTerminal(.eof(hasResidualData: $0)) },
+            onError: { onTerminal(.error($0)) },
+            onBytesRead: onBytesRead,
+            onCancel: onCancel
+        )
+    }
+
+    public convenience init(
         fd: Int32,
         queue: DispatchQueue,
         logger: Logger,
@@ -92,91 +180,272 @@ public final class NewlineDelimitedSocketReader {
         onBytesRead: (() -> Void)? = nil,
         onCancel: (() -> Void)? = nil
     ) {
+        self.init(
+            fd: fd,
+            queue: queue,
+            logger: logger,
+            delimiter: delimiter,
+            chunkSize: chunkSize,
+            bufferReservation: bufferReservation,
+            maxReadCallsPerEvent: Self.defaultMaxReadCallsPerEvent,
+            maxBytesPerEvent: Self.defaultMaxBytesPerEvent,
+            maxFramesPerEvent: Self.defaultMaxFramesPerEvent,
+            readOperation: systemRead,
+            onFrame: onFrame,
+            onEOF: onEOF,
+            onError: onError,
+            onBytesRead: onBytesRead,
+            onCancel: onCancel
+        )
+    }
+
+    init(
+        fd: Int32,
+        queue: DispatchQueue,
+        logger: Logger,
+        delimiter: UInt8 = UInt8(ascii: "\n"),
+        chunkSize: Int = 16384,
+        bufferReservation: Int = 64 * 1024,
+        maxReadCallsPerEvent: Int = NewlineDelimitedSocketReader.defaultMaxReadCallsPerEvent,
+        maxBytesPerEvent: Int = NewlineDelimitedSocketReader.defaultMaxBytesPerEvent,
+        maxFramesPerEvent: Int = NewlineDelimitedSocketReader.defaultMaxFramesPerEvent,
+        readOperation: @escaping ReadOperation,
+        onFrame: @escaping (Data) -> Void,
+        onEOF: @escaping (_ hasResidualData: Bool) -> Void,
+        onError: @escaping (Swift.Error) -> Void,
+        onBytesRead: (() -> Void)? = nil,
+        onCancel: (() -> Void)? = nil
+    ) {
         self.fd = fd
         self.queue = queue
         self.logger = logger
         self.delimiter = delimiter
         self.chunkSize = chunkSize
         self.bufferReservation = bufferReservation
+        self.maxReadCallsPerEvent = max(1, maxReadCallsPerEvent)
+        self.maxBytesPerEvent = max(1, maxBytesPerEvent)
+        self.maxFramesPerEvent = max(1, maxFramesPerEvent)
+        self.readOperation = readOperation
         self.onFrame = onFrame
         self.onEOF = onEOF
         self.onError = onError
         self.onBytesRead = onBytesRead
         self.onCancel = onCancel
         buffer.reserveCapacity(bufferReservation)
+        queue.setSpecific(key: queueKey, value: 1)
     }
 
     public func start() throws {
-        guard !started else { return }
+        try syncOnQueue {
+            guard lifecycle == .idle else { return }
 
-        let source = try ReadSourceFDPreflight.makeReadSource(
-            fileDescriptor: fd,
-            queue: queue,
-            label: "newline-delimited socket reader"
-        )
-        self.source = source
+            generation &+= 1
+            let sourceGeneration = generation
+            buffer.removeAll(keepingCapacity: true)
+            readableEventPending = false
+            pumpRunning = false
+            pumpScheduled = false
 
-        source.setEventHandler { [weak self] in
-            guard let self else { return }
+            let dispatchSource = try ReadSourceFDPreflight.makeReadSource(
+                fileDescriptor: fd,
+                queue: queue,
+                label: "newline-delimited socket reader"
+            )
+            let source = ReadEventSource(dispatchSource)
+            let sourceID = source.id
+            self.source = source
+            lifecycle = .running
 
-            let readBuffer = UnsafeMutablePointer<UInt8>.allocate(capacity: chunkSize)
-            defer { readBuffer.deallocate() }
+            source.setEventHandler { [weak self] in
+                self?.handleReadableEventOnQueue(generation: sourceGeneration)
+            }
+            source.setCancelHandler { [weak self] in
+                self?.handleSourceCancelledOnQueue(sourceID: sourceID)
+            }
+            source.resume()
+        }
+    }
 
-            var anyBytesRead = false
+    func processReadableEvent() {
+        syncOnQueue {
+            if lifecycle == .idle {
+                generation &+= 1
+                lifecycle = .running
+            }
+            handleReadableEventOnQueue(generation: generation)
+        }
+    }
 
-            while true {
-                let bytesRead = systemRead(fd, readBuffer, chunkSize)
+    private func handleReadableEventOnQueue(generation eventGeneration: UInt64) {
+        guard eventGeneration == generation, lifecycle == .running else { return }
+        readableEventPending = true
+        guard !pumpRunning else { return }
+        runReadablePumpOnQueue(generation: eventGeneration)
+    }
 
-                if bytesRead < 0 {
-                    let err = errno
-                    if err == EINTR {
-                        continue
-                    } else if err == EAGAIN || err == EWOULDBLOCK {
-                        break
-                    } else {
-                        let posixError = POSIXError(POSIXErrorCode(rawValue: err) ?? .EIO)
-                        logger.error("NewlineDelimitedSocketReader read error: \(err)")
-                        onError(posixError)
-                        return
-                    }
-                }
+    private func runReadablePumpOnQueue(generation pumpGeneration: UInt64) {
+        guard pumpGeneration == generation, lifecycle == .running else { return }
+        pumpRunning = true
+        readableEventPending = false
+        let needsContinuation = processReadableEventPass(generation: pumpGeneration)
+        pumpRunning = false
+        if needsContinuation {
+            readableEventPending = true
+        }
+        schedulePendingReadableEventIfNeeded(generation: pumpGeneration)
+    }
 
-                if bytesRead == 0 {
-                    onEOF(!buffer.isEmpty)
-                    return
-                }
+    private func processReadableEventPass(generation pumpGeneration: UInt64) -> Bool {
+        let readBuffer = UnsafeMutablePointer<UInt8>.allocate(capacity: chunkSize)
+        defer { readBuffer.deallocate() }
 
-                buffer.append(readBuffer, count: bytesRead)
-                anyBytesRead = true
+        var notifiedBytesRead = false
+        var readCallCount = 0
+        var byteCount = 0
+        var frameCount = 0
+
+        while pumpGeneration == generation, lifecycle == .running {
+            frameCount += drainCompleteFrames(
+                limit: maxFramesPerEvent - frameCount,
+                generation: pumpGeneration
+            )
+            guard pumpGeneration == generation, lifecycle == .running else { return false }
+            if frameCount >= maxFramesPerEvent {
+                return true
+            }
+            if readCallCount >= maxReadCallsPerEvent || byteCount >= maxBytesPerEvent {
+                return true
             }
 
-            if anyBytesRead {
+            let requestedBytes = min(chunkSize, maxBytesPerEvent - byteCount)
+            readCallCount += 1
+            let bytesRead = readOperation(fd, readBuffer, requestedBytes)
+
+            if bytesRead < 0 {
+                let err = errno
+                if err == EINTR {
+                    continue
+                } else if err == EAGAIN || err == EWOULDBLOCK {
+                    break
+                } else {
+                    let posixError = POSIXError(POSIXErrorCode(rawValue: err) ?? .EIO)
+                    logger.error("NewlineDelimitedSocketReader read error: \(err)")
+                    finishTerminalOnQueue(.failure(posixError), generation: pumpGeneration)
+                    return false
+                }
+            }
+
+            if bytesRead == 0 {
+                finishTerminalOnQueue(.success(!buffer.isEmpty), generation: pumpGeneration)
+                return false
+            }
+
+            buffer.append(readBuffer, count: bytesRead)
+            byteCount += bytesRead
+            if !notifiedBytesRead {
+                notifiedBytesRead = true
                 onBytesRead?()
-            }
-
-            while let newlineIndex = buffer.firstIndex(of: delimiter) {
-                let frame = buffer[..<newlineIndex]
-                let nextStart = buffer.index(after: newlineIndex)
-                buffer.removeSubrange(..<nextStart)
-
-                if !frame.isEmpty {
-                    onFrame(Data(frame))
-                }
+                guard pumpGeneration == generation, lifecycle == .running else { return false }
             }
         }
+        return false
+    }
 
-        source.setCancelHandler { [weak self] in
+    @discardableResult
+    private func drainCompleteFrames(limit: Int, generation pumpGeneration: UInt64) -> Int {
+        guard limit > 0 else { return 0 }
+
+        var drainedCount = 0
+        while drainedCount < limit,
+              pumpGeneration == generation,
+              lifecycle == .running,
+              let newlineIndex = buffer.firstIndex(of: delimiter)
+        {
+            let frame = Data(buffer[..<newlineIndex])
+            let nextStart = buffer.index(after: newlineIndex)
+            buffer.removeSubrange(..<nextStart)
+            drainedCount += 1
+
+            if !frame.isEmpty {
+                onFrame(frame)
+            }
+        }
+        return drainedCount
+    }
+
+    private func schedulePendingReadableEventIfNeeded(generation pumpGeneration: UInt64) {
+        guard pumpGeneration == generation,
+              lifecycle == .running,
+              readableEventPending
+        else {
+            readableEventPending = false
+            return
+        }
+        guard !pumpScheduled else { return }
+        pumpScheduled = true
+        queue.async { [weak self] in
             guard let self else { return }
-            onCancel?()
+            pumpScheduled = false
+            guard pumpGeneration == generation,
+                  lifecycle == .running,
+                  readableEventPending
+            else {
+                return
+            }
+            runReadablePumpOnQueue(generation: pumpGeneration)
         }
-
-        source.resume()
-        started = true
     }
 
     public func stop() {
-        source?.cancel()
-        source = nil
-        started = false
+        syncOnQueue {
+            stopOnQueue()
+        }
+    }
+
+    private func stopOnQueue() {
+        guard lifecycle != .stopped else { return }
+        generation &+= 1
+        lifecycle = .stopped
+        readableEventPending = false
+        pumpScheduled = false
+        buffer.removeAll(keepingCapacity: true)
+        cancelCurrentSourceOnQueue()
+    }
+
+    private func finishTerminalOnQueue(
+        _ result: Result<Bool, Swift.Error>,
+        generation terminalGeneration: UInt64
+    ) {
+        guard terminalGeneration == generation, lifecycle == .running else { return }
+        lifecycle = .terminal
+        readableEventPending = false
+        pumpScheduled = false
+        cancelCurrentSourceOnQueue()
+
+        switch result {
+        case let .success(hasResidualData):
+            onEOF(hasResidualData)
+        case let .failure(error):
+            onError(error)
+        }
+    }
+
+    private func cancelCurrentSourceOnQueue() {
+        guard let source else { return }
+        self.source = nil
+        pendingCancelledSources[source.id] = source
+        source.cancel()
+    }
+
+    private func handleSourceCancelledOnQueue(sourceID: ObjectIdentifier) {
+        guard pendingCancelledSources.removeValue(forKey: sourceID) != nil else { return }
+        onCancel?()
+    }
+
+    private func syncOnQueue<T>(_ operation: () throws -> T) rethrows -> T {
+        if DispatchQueue.getSpecific(key: queueKey) != nil {
+            return try operation()
+        }
+        return try queue.sync(execute: operation)
     }
 }

--- a/Sources/RepoPromptMCP/Transports/BootstrapSocketMCPTransport.swift
+++ b/Sources/RepoPromptMCP/Transports/BootstrapSocketMCPTransport.swift
@@ -19,6 +19,44 @@ import SystemPackage
     import Glibc
 #endif
 
+#if DEBUG
+    private final class BootstrapSocketMCPTransportCallbackGate: @unchecked Sendable {
+        enum Kind: Hashable {
+            case terminal
+            case cancellation
+        }
+
+        private let lock = NSLock()
+        private var heldKinds: Set<Kind> = []
+        private var pendingCallbacks: [Kind: [@Sendable () -> Void]] = [:]
+
+        func hold(_ kind: Kind) {
+            lock.lock()
+            heldKinds.insert(kind)
+            lock.unlock()
+        }
+
+        func submit(_ kind: Kind, callback: @escaping @Sendable () -> Void) {
+            lock.lock()
+            guard heldKinds.contains(kind) else {
+                lock.unlock()
+                callback()
+                return
+            }
+            pendingCallbacks[kind, default: []].append(callback)
+            lock.unlock()
+        }
+
+        func release(_ kind: Kind) {
+            lock.lock()
+            heldKinds.remove(kind)
+            let callbacks = pendingCallbacks.removeValue(forKey: kind) ?? []
+            lock.unlock()
+            callbacks.forEach { $0() }
+        }
+    }
+#endif
+
 /// MCP Transport implementation for CLI that wraps an already-connected UNIX socket FD.
 /// This is used after the bootstrap handshake completes to run MCP.Client over the socket.
 public actor BootstrapSocketMCPTransport: Transport {
@@ -33,22 +71,42 @@ public actor BootstrapSocketMCPTransport: Transport {
     private nonisolated let messageStream: AsyncThrowingStream<Data, Swift.Error>
     private var messageContinuation: AsyncThrowingStream<Data, Swift.Error>.Continuation
 
-    private var reader: NewlineDelimitedSocketReader?
     private let readQueue = DispatchQueue(label: "com.repoprompt.ce.mcp.cli.socket.read", qos: .userInitiated)
-    private var readSourceFD: Int32?
-    private var readSourceToken: UInt64?
     private var nextReadSourceToken: UInt64 = 0
+
+    private struct ReaderIdentity: Hashable {
+        let fd: Int32
+        let token: UInt64
+    }
+
+    private struct ActiveReaderOwnership {
+        let identity: ReaderIdentity
+        let reader: NewlineDelimitedSocketReader
+    }
 
     /// Retains cancelled readers until their delayed cancel handlers perform final close.
     /// The transport retainer intentionally forms a temporary cycle so cleanup does not
     /// depend on an external owner keeping this actor alive after disconnect returns.
     private struct PendingReaderCancellation {
-        let fd: Int32
+        let identity: ReaderIdentity
         let reader: NewlineDelimitedSocketReader
         let transportRetainer: BootstrapSocketMCPTransport
     }
 
+    private var activeReaderOwnership: ActiveReaderOwnership?
     private var pendingReaderCancellations: [UInt64: PendingReaderCancellation] = [:]
+    private var earlyReaderCancellations: Set<ReaderIdentity> = []
+
+    #if DEBUG
+        private nonisolated let callbackGate = BootstrapSocketMCPTransportCallbackGate()
+        private weak var debugLastReader: NewlineDelimitedSocketReader?
+        private var debugTerminalCallbackCount = 0
+        private var debugCancellationCallbackCount = 0
+        private var debugReaderFinalizationCount = 0
+        private var debugDescriptorCloseCount = 0
+        private var debugStaleCancellationCount = 0
+        private var debugStaleTerminalCount = 0
+    #endif
 
     /// Maximum time a write may make no forward progress before the connection is failed closed.
     private let writeStallTimeout: TimeInterval
@@ -298,6 +356,40 @@ public actor BootstrapSocketMCPTransport: Transport {
         }
     }
 
+    #if DEBUG
+        func debugHoldReaderTerminalCallback() {
+            callbackGate.hold(.terminal)
+        }
+
+        func debugReleaseReaderTerminalCallbacks() {
+            callbackGate.release(.terminal)
+        }
+
+        func debugHoldReaderCancellationCallback() {
+            callbackGate.hold(.cancellation)
+        }
+
+        func debugReleaseReaderCancellationCallbacks() {
+            callbackGate.release(.cancellation)
+        }
+    #endif
+
+    private nonisolated func scheduleReaderTerminalCallback(_ callback: @escaping @Sendable () -> Void) {
+        #if DEBUG
+            callbackGate.submit(.terminal, callback: callback)
+        #else
+            callback()
+        #endif
+    }
+
+    private nonisolated func scheduleReaderCancellationCallback(_ callback: @escaping @Sendable () -> Void) {
+        #if DEBUG
+            callbackGate.submit(.cancellation, callback: callback)
+        #else
+            callback()
+        #endif
+    }
+
     // MARK: - Private
 
     /// Starts the DispatchSourceRead to receive data without blocking the actor executor.
@@ -306,9 +398,7 @@ public actor BootstrapSocketMCPTransport: Transport {
         stopReadSource()
 
         nextReadSourceToken &+= 1
-        let token = nextReadSourceToken
-        readSourceFD = fd
-        readSourceToken = token
+        let identity = ReaderIdentity(fd: fd, token: nextReadSourceToken)
 
         let cont = messageContinuation
         let log = logger
@@ -320,74 +410,116 @@ public actor BootstrapSocketMCPTransport: Transport {
             onFrame: { frame in
                 cont.yield(frame)
             },
-            onEOF: { [weak self] hasResidual in
-                Task { await self?.handleReadEOF(hasResidualData: hasResidual) }
-            },
-            onError: { [weak self] error in
-                Task { await self?.handleReadError(error: error) }
+            onTerminal: { [weak self] terminal in
+                guard let transport = self else { return }
+                transport.scheduleReaderTerminalCallback {
+                    Task { await transport.handleReaderTerminal(terminal, from: identity) }
+                }
             },
             onCancel: { [weak self] in
-                Task { await self?.readSourceDidCancel(fd: fd, token: token) }
+                guard let transport = self else { return }
+                transport.scheduleReaderCancellationCallback {
+                    Task { await transport.readSourceDidCancel(identity) }
+                }
             }
         )
 
-        reader = newReader
+        activeReaderOwnership = ActiveReaderOwnership(identity: identity, reader: newReader)
+        #if DEBUG
+            debugLastReader = newReader
+        #endif
         do {
             try newReader.start()
         } catch {
-            reader = nil
-            readSourceFD = nil
-            readSourceToken = nil
+            if activeReaderOwnership?.identity == identity {
+                activeReaderOwnership = nil
+            }
             throw error
         }
     }
 
-    /// Stops the read source. FD is closed in cancel handler to avoid races.
+    /// Moves active reader ownership to the cancellation finalizer before requesting cancellation.
     private func stopReadSource() {
-        guard let reader else { return }
-        guard let fd = readSourceFD, let token = readSourceToken else {
-            self.reader = nil
-            readSourceFD = nil
-            readSourceToken = nil
-            reader.stop()
-            return
-        }
+        guard let activeOwnership = activeReaderOwnership else { return }
+        activeReaderOwnership = nil
 
-        pendingReaderCancellations[token] = PendingReaderCancellation(
-            fd: fd,
-            reader: reader,
+        let identity = activeOwnership.identity
+        pendingReaderCancellations[identity.token] = PendingReaderCancellation(
+            identity: identity,
+            reader: activeOwnership.reader,
             transportRetainer: self
         )
-        self.reader = nil
-        readSourceFD = nil
-        readSourceToken = nil
-        reader.stop()
-        // Note: retained reader cleanup happens in readSourceDidCancel.
+        activeOwnership.reader.stop()
+
+        if earlyReaderCancellations.contains(identity) {
+            finalizeReaderCancellation(identity)
+        }
     }
 
     private func pendingReaderCancellationOwnsCurrentSocket() -> Bool {
-        pendingReaderCancellations.values.contains { $0.fd == socketFD }
+        pendingReaderCancellations.values.contains { $0.identity.fd == socketFD }
     }
 
-    private func readSourceDidCancel(fd: Int32, token: UInt64) {
-        guard let ownership = pendingReaderCancellations.removeValue(forKey: token) else { return }
-        guard ownership.fd == fd else {
-            logger.error("BootstrapSocketMCPTransport reader cancellation fd mismatch for token=\(token)")
+    private func readSourceDidCancel(_ identity: ReaderIdentity) {
+        #if DEBUG
+            debugCancellationCallbackCount += 1
+        #endif
+
+        if pendingReaderCancellations[identity.token]?.identity == identity {
+            finalizeReaderCancellation(identity)
             return
         }
-        closeSocketIfNeeded()
+
+        if activeReaderOwnership?.identity == identity {
+            earlyReaderCancellations.insert(identity)
+            return
+        }
+
+        #if DEBUG
+            debugStaleCancellationCount += 1
+        #endif
     }
 
-    private func handleReadError(error: Swift.Error) {
-        tearDownSocket(error: error)
+    private func finalizeReaderCancellation(_ identity: ReaderIdentity) {
+        guard pendingReaderCancellations[identity.token]?.identity == identity,
+              let ownership = pendingReaderCancellations.removeValue(forKey: identity.token)
+        else {
+            return
+        }
+        earlyReaderCancellations.remove(identity)
+        withExtendedLifetime(ownership) {
+            #if DEBUG
+                debugReaderFinalizationCount += 1
+            #endif
+            closeSocketIfNeeded()
+        }
     }
 
-    private func handleReadEOF(hasResidualData: Bool) {
-        if hasResidualData {
+    private func handleReaderTerminal(
+        _ terminal: NewlineDelimitedSocketReaderTerminal,
+        from identity: ReaderIdentity
+    ) {
+        #if DEBUG
+            debugTerminalCallbackCount += 1
+        #endif
+
+        guard activeReaderOwnership?.identity == identity else {
+            #if DEBUG
+                debugStaleTerminalCount += 1
+            #endif
+            return
+        }
+
+        switch terminal {
+        case let .error(error):
+            tearDownSocket(error: error)
+        case let .eof(hasResidualData):
+            guard hasResidualData else {
+                tearDownSocket()
+                return
+            }
             let truncationError = MCPError.internalError("Connection closed with incomplete frame data")
             tearDownSocket(error: truncationError)
-        } else {
-            tearDownSocket()
         }
     }
 
@@ -420,5 +552,8 @@ public actor BootstrapSocketMCPTransport: Transport {
         socketClosed = true
         POSIXDescriptorSupport.shutdownSocketReadWrite(socketFD)
         Darwin.close(socketFD)
+        #if DEBUG
+            debugDescriptorCloseCount += 1
+        #endif
     }
 }

--- a/Tests/RepoPromptTests/ContextBuilder/ContextBuilderRunLifecycleTests.swift
+++ b/Tests/RepoPromptTests/ContextBuilder/ContextBuilderRunLifecycleTests.swift
@@ -106,6 +106,213 @@ final class ContextBuilderRunLifecycleTests: XCTestCase {
         XCTAssertTrue(registry.acceptsEvents(from: second, currentSession: session))
     }
 
+    func testProductionMCPCancellationResumesBeforeTeardownAndRejectsLateProviderEvent() async throws {
+        let firstStreamStarted = expectation(description: "first provider stream started")
+        let firstEventAccepted = expectation(description: "first provider event accepted")
+        let firstDisposeStarted = expectation(description: "first provider disposal started")
+        let firstDisposeFinished = expectation(description: "first provider disposal finished")
+        let firstTeardownCompleted = expectation(description: "first run teardown completed")
+        let successorStreamStarted = expectation(description: "successor provider stream started")
+        let successorEventAccepted = expectation(description: "successor provider event accepted")
+        let lateEventParked = expectation(description: "late provider event parked before processing")
+        let lateEventRejected = expectation(description: "late provider event rejected")
+        let firstProvider = ControllableLifecycleTestProvider(
+            eventTexts: ["first-run-event", "late-old-run-event"],
+            blocksDisposal: true,
+            streamStartedExpectation: firstStreamStarted,
+            disposeStartedExpectation: firstDisposeStarted,
+            disposeFinishedExpectation: firstDisposeFinished
+        )
+        let successorProvider = ControllableLifecycleTestProvider(
+            eventTexts: ["successor-event"],
+            blocksDisposal: false,
+            streamStartedExpectation: successorStreamStarted
+        )
+        let providers = LifecycleTestProviderQueue([firstProvider, successorProvider])
+        let previousMCPEnabled = await ServerNetworkManager.shared.debugIsEnabledForBootstrapSocketURLOverride()
+
+        let previousMCPAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
+        GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
+        let testMCPService = MCPService()
+        let composition = WindowStateCompositionFactory.make(
+            windowID: -74,
+            deferredInitialAgentSystemWorkspaceRefresh: true,
+            sharedMCPService: testMCPService,
+            contextBuilderProviderFactory: { _, _, _ in providers.next() }
+        )
+        GlobalSettingsStore.shared.setMCPAutoStart(previousMCPAutoStart, commit: false)
+        await composition.workspaceManager.awaitInitialized()
+
+        do {
+            let workspaceRoot = FileManager.default.temporaryDirectory
+                .appendingPathComponent("ContextBuilderRunLifecycleTests-\(UUID().uuidString)")
+            try FileManager.default.createDirectory(
+                at: workspaceRoot,
+                withIntermediateDirectories: true
+            )
+            defer {
+                try? FileManager.default.removeItem(at: workspaceRoot)
+            }
+
+            let workspace = composition.workspaceManager.createWorkspace(
+                name: "Context Builder lifecycle test",
+                repoPaths: [workspaceRoot.path],
+                ephemeral: true
+            )
+            await composition.workspaceManager.switchWorkspace(
+                to: workspace,
+                saveState: false,
+                reason: "ContextBuilderRunLifecycleTests"
+            )
+
+            let activeWorkspace = try XCTUnwrap(composition.workspaceManager.activeWorkspace)
+            let tabID = try XCTUnwrap(
+                activeWorkspace.activeComposeTabID ?? activeWorkspace.composeTabs.first?.id
+            )
+            let viewModel = composition.contextBuilderAgentViewModel
+            let lateEventGate = LifecycleTestGate()
+            let firstWaiterCompletion = LifecycleTestCounter()
+            var firstRunID: UUID?
+
+            viewModel.installRunTestHooks(
+                ContextBuilderAgentViewModel.RunTestHooks(
+                    beforeProcessingProviderEvent: { result, _ in
+                        if result.text == "late-old-run-event" {
+                            lateEventParked.fulfill()
+                            await lateEventGate.arriveAndWait()
+                        }
+                    },
+                    providerEventDisposition: { result, _, accepted in
+                        switch (result.text, accepted) {
+                        case ("first-run-event", true):
+                            firstEventAccepted.fulfill()
+                        case ("successor-event", true):
+                            successorEventAccepted.fulfill()
+                        case ("late-old-run-event", false):
+                            lateEventRejected.fulfill()
+                        default:
+                            break
+                        }
+                    },
+                    teardownCompleted: { runID in
+                        if runID == firstRunID {
+                            firstTeardownCompleted.fulfill()
+                        }
+                    }
+                )
+            )
+            defer {
+                viewModel.installRunTestHooks(nil)
+                Task {
+                    await lateEventGate.release()
+                    await firstProvider.releaseDisposal()
+                }
+            }
+
+            let firstToken = try viewModel.beginMCPControlledRun(
+                forTabID: tabID,
+                responseType: nil,
+                planModelName: nil
+            )
+            let firstWaiterFinished = expectation(description: "first MCP waiter finished")
+            let firstWaiter = Task<Bool, Never> { @MainActor in
+                let wasCancelled: Bool
+                do {
+                    _ = try await viewModel.runContextBuilderForMCP(
+                        tabID: tabID,
+                        mcpControlToken: firstToken
+                    )
+                    wasCancelled = false
+                } catch is CancellationError {
+                    wasCancelled = true
+                } catch {
+                    XCTFail("Unexpected first-run error: \(error)")
+                    wasCancelled = false
+                }
+                await firstWaiterCompletion.increment()
+                firstWaiterFinished.fulfill()
+                return wasCancelled
+            }
+
+            await fulfillment(
+                of: [firstStreamStarted, firstEventAccepted, lateEventParked],
+                timeout: 2
+            )
+            firstRunID = try XCTUnwrap(viewModel.activeRunIDForTesting(tabID: tabID))
+
+            try await viewModel.cancelMCPContextBuilderRun(runID: XCTUnwrap(firstRunID))
+            await fulfillment(of: [firstWaiterFinished, firstDisposeStarted], timeout: 1)
+
+            let firstWaiterWasCancelled = await firstWaiter.value
+            let firstCompletionCount = await firstWaiterCompletion.value()
+            XCTAssertTrue(firstWaiterWasCancelled)
+            XCTAssertEqual(firstCompletionCount, 1)
+            XCTAssertNil(viewModel.activeRunIDForTesting(tabID: tabID))
+            XCTAssertTrue(try viewModel.isRunTeardownPendingForTesting(runID: XCTUnwrap(firstRunID)))
+
+            let successorToken = try viewModel.beginMCPControlledRun(
+                forTabID: tabID,
+                responseType: nil,
+                planModelName: nil
+            )
+            let successorWaiterFinished = expectation(description: "successor MCP waiter finished")
+            let successorWaiter = Task<Bool, Never> { @MainActor in
+                let wasCancelled: Bool
+                do {
+                    _ = try await viewModel.runContextBuilderForMCP(
+                        tabID: tabID,
+                        mcpControlToken: successorToken
+                    )
+                    wasCancelled = false
+                } catch is CancellationError {
+                    wasCancelled = true
+                } catch {
+                    XCTFail("Unexpected successor error: \(error)")
+                    wasCancelled = false
+                }
+                successorWaiterFinished.fulfill()
+                return wasCancelled
+            }
+
+            await fulfillment(of: [successorStreamStarted, successorEventAccepted], timeout: 2)
+            let successorRunID = try XCTUnwrap(viewModel.activeRunIDForTesting(tabID: tabID))
+            XCTAssertNotEqual(successorRunID, firstRunID)
+            XCTAssertTrue(try viewModel.isRunTeardownPendingForTesting(runID: XCTUnwrap(firstRunID)))
+            let disposalFinishedBeforeLateEvent = await firstProvider.isDisposalFinished()
+            XCTAssertFalse(disposalFinishedBeforeLateEvent)
+
+            await lateEventGate.release()
+            await fulfillment(of: [lateEventRejected], timeout: 1)
+
+            let completionCountAfterLateEvent = await firstWaiterCompletion.value()
+            XCTAssertEqual(completionCountAfterLateEvent, 1)
+            XCTAssertFalse(viewModel.agentLog.contains { $0.message.contains("late-old-run-event") })
+            XCTAssertTrue(viewModel.agentLog.contains { $0.message.contains("successor-event") })
+            XCTAssertEqual(viewModel.activeRunIDForTesting(tabID: tabID), successorRunID)
+            XCTAssertTrue(try viewModel.isRunTeardownPendingForTesting(runID: XCTUnwrap(firstRunID)))
+            let disposalFinishedBeforeRelease = await firstProvider.isDisposalFinished()
+            XCTAssertFalse(disposalFinishedBeforeRelease)
+
+            await firstProvider.releaseDisposal()
+            await fulfillment(of: [firstDisposeFinished, firstTeardownCompleted], timeout: 1)
+            XCTAssertFalse(try viewModel.isRunTeardownPendingForTesting(runID: XCTUnwrap(firstRunID)))
+
+            await viewModel.cancelMCPContextBuilderRun(runID: successorRunID)
+            await fulfillment(of: [successorWaiterFinished], timeout: 1)
+            let successorWasCancelled = await successorWaiter.value
+            XCTAssertTrue(successorWasCancelled)
+
+            await composition.mcpServer.stopServer()
+            await composition.mcpServer.shutdownListener()
+            await ServerNetworkManager.shared.setEnabled(previousMCPEnabled)
+        } catch {
+            await composition.mcpServer.stopServer()
+            await composition.mcpServer.shutdownListener()
+            await ServerNetworkManager.shared.setEnabled(previousMCPEnabled)
+            throw error
+        }
+    }
+
     private func makeRecord(
         tabID: UUID,
         session: ContextBuilderAgentViewModel.TabSession,
@@ -134,4 +341,152 @@ private final class LifecycleTestProvider: HeadlessAgentProvider {
     }
 
     func dispose() async {}
+}
+
+private final class ControllableLifecycleTestProvider: HeadlessAgentProvider {
+    private let eventTexts: [String]
+    private let blocksDisposal: Bool
+    private let streamStartedExpectation: XCTestExpectation?
+    private let disposeStartedExpectation: XCTestExpectation?
+    private let disposeFinishedExpectation: XCTestExpectation?
+    private let disposeGate = LifecycleTestGate()
+    private let state = LifecycleTestProviderState()
+    private var streamContinuation: AsyncThrowingStream<AIStreamResult, Error>.Continuation?
+
+    init(
+        eventTexts: [String],
+        blocksDisposal: Bool,
+        streamStartedExpectation: XCTestExpectation? = nil,
+        disposeStartedExpectation: XCTestExpectation? = nil,
+        disposeFinishedExpectation: XCTestExpectation? = nil
+    ) {
+        self.eventTexts = eventTexts
+        self.blocksDisposal = blocksDisposal
+        self.streamStartedExpectation = streamStartedExpectation
+        self.disposeStartedExpectation = disposeStartedExpectation
+        self.disposeFinishedExpectation = disposeFinishedExpectation
+    }
+
+    func streamAgentMessage(
+        _ message: AgentMessage,
+        runID: UUID?
+    ) async throws -> AsyncThrowingStream<AIStreamResult, Error> {
+        _ = message
+        guard let runID else {
+            throw CancellationError()
+        }
+        let stream = AsyncThrowingStream<AIStreamResult, Error> { continuation in
+            streamContinuation = continuation
+            for text in eventTexts {
+                continuation.yield(AIStreamResult(type: "content", text: text))
+            }
+        }
+        await MCPRoutingWaiter.notifyRouted(runID: runID)
+        streamStartedExpectation?.fulfill()
+        return stream
+    }
+
+    func dispose() async {
+        await state.recordDisposeCall()
+        disposeStartedExpectation?.fulfill()
+        if blocksDisposal {
+            await disposeGate.arriveAndWait()
+        }
+        streamContinuation?.finish()
+        streamContinuation = nil
+        await state.recordDisposalFinished()
+        disposeFinishedExpectation?.fulfill()
+    }
+
+    func releaseDisposal() async {
+        await disposeGate.release()
+    }
+
+    func disposeCallCount() async -> Int {
+        await state.disposeCallCount
+    }
+
+    func isDisposalFinished() async -> Bool {
+        await state.disposalFinished
+    }
+}
+
+@MainActor
+private final class LifecycleTestProviderQueue {
+    private var providers: [HeadlessAgentProvider]
+
+    init(_ providers: [HeadlessAgentProvider]) {
+        self.providers = providers
+    }
+
+    func next() -> HeadlessAgentProvider {
+        precondition(!providers.isEmpty, "Unexpected Context Builder provider request")
+        return providers.removeFirst()
+    }
+}
+
+private actor LifecycleTestProviderState {
+    private(set) var disposeCallCount = 0
+    private(set) var disposalFinished = false
+
+    func recordDisposeCall() {
+        disposeCallCount += 1
+    }
+
+    func recordDisposalFinished() {
+        disposalFinished = true
+    }
+}
+
+private actor LifecycleTestCounter {
+    private var count = 0
+
+    func increment() {
+        count += 1
+    }
+
+    func value() -> Int {
+        count
+    }
+}
+
+private actor LifecycleTestGate {
+    private var arrived = false
+    private var released = false
+    private var arrivalWaiters: [CheckedContinuation<Void, Never>] = []
+    private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func arrive() {
+        arrived = true
+        let waiters = arrivalWaiters
+        arrivalWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
+        }
+    }
+
+    func arriveAndWait() async {
+        arrive()
+        guard !released else { return }
+        await withCheckedContinuation { continuation in
+            releaseWaiters.append(continuation)
+        }
+    }
+
+    func waitUntilArrived() async {
+        guard !arrived else { return }
+        await withCheckedContinuation { continuation in
+            arrivalWaiters.append(continuation)
+        }
+    }
+
+    func release() {
+        guard !released else { return }
+        released = true
+        let waiters = releaseWaiters
+        releaseWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
+        }
+    }
 }

--- a/Tests/RepoPromptTests/MCP/Control/MCPSocketDescriptorHardeningTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/MCPSocketDescriptorHardeningTests.swift
@@ -562,7 +562,65 @@ final class MCPSocketDescriptorHardeningTests: XCTestCase {
         XCTAssertTrue(transport.contains("POSIXDescriptorSupport.shutdownSocketReadWrite(socketFD)"))
     }
 
-    func testNonImportableCLITransportRetainsPendingReaderUntilDelayedFinalClose() throws {
+    func testAppAndCLIReadersShareFairOneShotTerminalCancellationLifecycle() throws {
+        let root = try RepoRoot.url()
+        let appReader = try Self.sourceText(
+            "Sources/RepoPrompt/Infrastructure/MCP/AppShared/NewlineDelimitedSocketReader.swift",
+            relativeTo: root
+        )
+        let cliReader = try Self.sourceText(
+            "Sources/RepoPromptMCP/Shared/NewlineDelimitedSocketReader.swift",
+            relativeTo: root
+        )
+
+        XCTAssertEqual(appReader, cliReader)
+        Self.assertSourceContains(
+            [
+                "public enum NewlineDelimitedSocketReaderTerminal: @unchecked Sendable",
+                "onTerminal: @escaping (NewlineDelimitedSocketReaderTerminal) -> Void",
+                "onEOF: { onTerminal(.eof(hasResidualData: $0)) }",
+                "onError: { onTerminal(.error($0)) }",
+                "private enum Lifecycle: Equatable",
+                "private var generation: UInt64 = 0",
+                "private var pendingCancelledSources: [ObjectIdentifier: ReadEventSource] = [:]",
+                "finishTerminalOnQueue(.failure(posixError), generation: pumpGeneration)",
+                "finishTerminalOnQueue(.success(!buffer.isEmpty), generation: pumpGeneration)",
+                "guard terminalGeneration == generation, lifecycle == .running else { return }",
+                "cancelCurrentSourceOnQueue()",
+                "guard pendingCancelledSources.removeValue(forKey: sourceID) != nil else { return }"
+            ],
+            in: appReader
+        )
+    }
+
+    func testAppTransportReplacesTerminalInboundChannelsBeforeReconnect() throws {
+        let root = try RepoRoot.url()
+        let transport = try Self.sourceText(
+            "Sources/RepoPrompt/Infrastructure/MCP/UnixSocketMCPTransport.swift",
+            relativeTo: root
+        )
+
+        Self.assertSourceContains(
+            [
+                "private struct InboundChannel {",
+                "private struct CloseChannel {",
+                "private let receiveBufferCapacity: Int",
+                "private var inboundChannel: InboundChannel",
+                "private var closeChannel: CloseChannel",
+                "prepareForConnectionAttempt()",
+                "if streamFinished || closeSignaled {",
+                "inboundChannel = InboundChannel(capacity: receiveBufferCapacity)",
+                "closeChannel = CloseChannel()",
+                "let inboundChannel = inboundChannel",
+                "inboundChannel.gate.offer(frame, to: inboundChannel.continuation)",
+                "inboundChannel.continuation.finish",
+                "closeChannel.continuation.finish()"
+            ],
+            in: transport
+        )
+    }
+
+    func testNonImportableCLITransportClaimsEarlyAndDelayedReaderCancellationExactlyOnce() throws {
         let root = try RepoRoot.url()
         let transport = try Self.sourceText(
             "Sources/RepoPromptMCP/Transports/BootstrapSocketMCPTransport.swift",
@@ -571,13 +629,27 @@ final class MCPSocketDescriptorHardeningTests: XCTestCase {
 
         Self.assertSourceContains(
             [
+                "private struct ReaderIdentity: Hashable {",
+                "private struct ActiveReaderOwnership {",
                 "private struct PendingReaderCancellation {",
                 "let reader: NewlineDelimitedSocketReader",
                 "let transportRetainer: BootstrapSocketMCPTransport",
+                "private var activeReaderOwnership: ActiveReaderOwnership?",
                 "private var pendingReaderCancellations: [UInt64: PendingReaderCancellation] = [:]",
-                "pendingReaderCancellations[token] = PendingReaderCancellation(",
+                "private var earlyReaderCancellations: Set<ReaderIdentity> = []",
+                "activeReaderOwnership = ActiveReaderOwnership(identity: identity, reader: newReader)",
+                "activeReaderOwnership = nil\n\n        let identity = activeOwnership.identity",
+                "pendingReaderCancellations[identity.token] = PendingReaderCancellation(",
                 "transportRetainer: self",
-                "guard let ownership = pendingReaderCancellations.removeValue(forKey: token) else { return }",
+                "activeOwnership.reader.stop()",
+                "if earlyReaderCancellations.contains(identity) {\n            finalizeReaderCancellation(identity)",
+                "if pendingReaderCancellations[identity.token]?.identity == identity {",
+                "if activeReaderOwnership?.identity == identity {\n            earlyReaderCancellations.insert(identity)",
+                "let ownership = pendingReaderCancellations.removeValue(forKey: identity.token)",
+                "earlyReaderCancellations.remove(identity)",
+                "withExtendedLifetime(ownership) {",
+                "Task { await transport.handleReaderTerminal(terminal, from: identity) }",
+                "guard activeReaderOwnership?.identity == identity else {",
                 "if !pendingReaderCancellationOwnsCurrentSocket() {",
                 "closeSocketIfNeeded()"
             ],
@@ -585,8 +657,16 @@ final class MCPSocketDescriptorHardeningTests: XCTestCase {
         )
 
         XCTAssertTrue(
-            transport.contains("onCancel: { [weak self] in\n                Task { await self?.readSourceDidCancel(fd: fd, token: token) }"),
-            "Delayed DispatchSource cancellation must route through the tokenized final-close handler."
+            transport.contains(
+                "onTerminal: { [weak self] terminal in\n                guard let transport = self else { return }"
+            ),
+            "Reader terminal delivery must avoid a permanent reader/transport cycle."
+        )
+        XCTAssertTrue(
+            transport.contains(
+                "transport.scheduleReaderCancellationCallback {\n                    Task { await transport.readSourceDidCancel(identity) }"
+            ),
+            "Cancellation delivery must strongly retain the transport until the actor claims the identity."
         )
     }
 

--- a/Tests/RepoPromptTests/MCP/Control/PersistentMCPDistinctConnectionConcurrencyTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/PersistentMCPDistinctConnectionConcurrencyTests.swift
@@ -194,7 +194,11 @@ final class PersistentMCPDistinctConnectionConcurrencyTests: XCTestCase {
                 return
             }
             let heldStore = fixture.contextA.window.workspaceFileContextStore
-            let gate = SearchAdmissionGate()
+            let heldSearchStarted = expectation(description: "both broad searches acquired admission")
+            heldSearchStarted.expectedFulfillmentCount = 2
+            let gate = SearchAdmissionGate {
+                heldSearchStarted.fulfill()
+            }
             await coordinator.setPermitAcquiredHandlerForTesting { store in
                 guard ObjectIdentifier(store) == ObjectIdentifier(heldStore) else { return }
                 await gate.markStartedAndWaitForRelease()
@@ -206,8 +210,9 @@ final class PersistentMCPDistinctConnectionConcurrencyTests: XCTestCase {
                 let secondHeldSearch = Task {
                     try await endpointAQueued.callTool(name: MCPWindowToolName.search, arguments: Self.searchArguments)
                 }
-                let heldSearchesStarted = await gate.waitUntilStartedCount(2)
-                XCTAssertTrue(heldSearchesStarted)
+                await fulfillment(of: [heldSearchStarted], timeout: 1)
+                let heldSearchStartedCount = await gate.startedCountSnapshot()
+                XCTAssertEqual(heldSearchStartedCount, 2)
                 let heldSnapshot = await coordinator.snapshot(for: heldStore)
                 XCTAssertEqual(heldSnapshot.activePermitCount, 2)
                 XCTAssertEqual(heldSnapshot.waiterCount, 0)
@@ -215,29 +220,35 @@ final class PersistentMCPDistinctConnectionConcurrencyTests: XCTestCase {
                 let overflow = try await endpointAOverflow.callTool(name: MCPWindowToolName.search, arguments: Self.searchArguments)
                 try Self.assertSearchBackpressureResult(overflow)
 
-                guard case .started = EditFlowPerf.beginDebugCapture(label: "retained-same-connection-read-wait", maxSamples: 500) else {
-                    throw ClientFixtureError.telemetryCaptureBusy
+                let sameConnectionReadQueued = expectation(description: "same-connection read queued in limiter")
+                let observerInstalled = await fixture.networkManager.setConnectionLimiterStateObserverForTesting(
+                    connectionID: endpointA.connectionID
+                ) { snapshot in
+                    if snapshot.permits == 0,
+                       snapshot.waiterCount == 1,
+                       snapshot.inFlight == 2
+                    {
+                        sameConnectionReadQueued.fulfill()
+                    }
                 }
-                defer { EditFlowPerf.resetDebugCaptureForTesting() }
-                let sameConnectionReadFinished = CompletionSignal()
+                XCTAssertTrue(observerInstalled)
                 let sameConnectionRead = Task {
-                    let response = try await endpointA.callTool(
+                    try await endpointA.callTool(
                         name: MCPWindowToolName.readFile,
                         arguments: ["path": fixture.contextA.fileURL.path]
                     )
-                    await sameConnectionReadFinished.mark()
-                    return response
                 }
-                let sameConnectionReadReachedLimiterWait = await Self.waitForLifecycleEvent(
-                    "MCP.ToolCall.LimiterWaitBegan",
-                    containingDimension: "tool=read_file"
+                await fulfillment(of: [sameConnectionReadQueued], timeout: 1)
+                _ = await fixture.networkManager.setConnectionLimiterStateObserverForTesting(
+                    connectionID: endpointA.connectionID,
+                    observer: nil
                 )
-                XCTAssertTrue(sameConnectionReadReachedLimiterWait)
-                let sameConnectionReadCompletedBeforeRelease = await sameConnectionReadFinished.isMarked()
-                XCTAssertFalse(
-                    sameConnectionReadCompletedBeforeRelease,
-                    "A read observed waiting on the held search connection must remain behind the per-connection limiter."
+                let queuedLimiterState = await fixture.networkManager.connectionLimiterSnapshotForTesting(
+                    connectionID: endpointA.connectionID
                 )
+                XCTAssertEqual(queuedLimiterState?.permits, 0)
+                XCTAssertEqual(queuedLimiterState?.waiterCount, 1)
+                XCTAssertEqual(queuedLimiterState?.inFlight, 2)
 
                 let exactRead = try await endpointARead.callTool(
                     name: MCPWindowToolName.readFile,
@@ -269,6 +280,13 @@ final class PersistentMCPDistinctConnectionConcurrencyTests: XCTestCase {
                 let peerSearch = try await endpointB.callTool(name: MCPWindowToolName.search, arguments: Self.searchArguments)
                 try Self.assertSearchResult(peerSearch, contains: fixture.contextB.fileURL.lastPathComponent, excludes: fixture.contextA.fileURL.lastPathComponent)
 
+                let limiterStateAfterPeerCalls = await fixture.networkManager.connectionLimiterSnapshotForTesting(
+                    connectionID: endpointA.connectionID
+                )
+                XCTAssertEqual(limiterStateAfterPeerCalls?.permits, 0)
+                XCTAssertEqual(limiterStateAfterPeerCalls?.waiterCount, 1)
+                XCTAssertEqual(limiterStateAfterPeerCalls?.inFlight, 2)
+
                 await gate.release()
                 let firstHeld = try await firstHeldSearch.value
                 let secondHeld = try await secondHeldSearch.value
@@ -276,13 +294,12 @@ final class PersistentMCPDistinctConnectionConcurrencyTests: XCTestCase {
                 try Self.assertSearchResult(firstHeld, contains: fixture.contextA.fileURL.lastPathComponent, excludes: fixture.contextB.fileURL.lastPathComponent)
                 try Self.assertSearchResult(secondHeld, contains: fixture.contextA.fileURL.lastPathComponent, excludes: fixture.contextB.fileURL.lastPathComponent)
                 try Self.assertReadResult(serializedRead, contains: fixture.contextA.sentinel, excludes: fixture.contextB.sentinel)
-                let sameConnectionReadCompletedAfterRelease = await sameConnectionReadFinished.isMarked()
-                XCTAssertTrue(sameConnectionReadCompletedAfterRelease)
-                let sameConnectionCapture = EditFlowPerf.debugCaptureSnapshot(finish: true)
-                XCTAssertTrue(sameConnectionCapture.lifecycleEvents.contains {
-                    $0.eventName == "MCP.ToolCall.LimiterWaitBegan" &&
-                        $0.sanitizedDimensions.contains("tool=read_file")
-                })
+                let settledLimiterState = await fixture.networkManager.connectionLimiterSnapshotForTesting(
+                    connectionID: endpointA.connectionID
+                )
+                XCTAssertEqual(settledLimiterState?.permits, 1)
+                XCTAssertEqual(settledLimiterState?.waiterCount, 0)
+                XCTAssertEqual(settledLimiterState?.inFlight, 0)
 
                 let settledRetry = try await endpointAOverflow.callTool(name: MCPWindowToolName.search, arguments: Self.searchArguments)
                 try Self.assertSearchResult(settledRetry, contains: fixture.contextA.fileURL.lastPathComponent, excludes: fixture.contextB.fileURL.lastPathComponent)
@@ -295,6 +312,10 @@ final class PersistentMCPDistinctConnectionConcurrencyTests: XCTestCase {
                 )
             } catch {
                 await gate.release()
+                _ = await fixture.networkManager.setConnectionLimiterStateObserverForTesting(
+                    connectionID: endpointA.connectionID,
+                    observer: nil
+                )
                 await restoreBroadSearchAdmissionConfiguration(
                     baselineConfiguration,
                     coordinator: coordinator
@@ -713,26 +734,6 @@ final class PersistentMCPDistinctConnectionConcurrencyTests: XCTestCase {
             XCTAssertEqual((object["id"] as? NSNumber)?.intValue, response.id)
             XCTAssertNil(object["error"])
             return object
-        }
-
-        static func waitForLifecycleEvent(
-            _ eventName: String,
-            containingDimension: String,
-            timeoutNanoseconds: UInt64 = 1_000_000_000
-        ) async -> Bool {
-            let interval: UInt64 = 10_000_000
-            var waited: UInt64 = 0
-            while waited < timeoutNanoseconds {
-                let snapshot = EditFlowPerf.debugCaptureSnapshot(finish: false)
-                if snapshot.lifecycleEvents.contains(where: {
-                    $0.eventName == eventName && $0.sanitizedDimensions.contains(containingDimension)
-                }) {
-                    return true
-                }
-                try? await Task.sleep(nanoseconds: interval)
-                waited += interval
-            }
-            return false
         }
 
         static func measureMilliseconds(_ operation: () async throws -> Void) async rethrows -> Double {
@@ -1414,42 +1415,29 @@ final class PersistentMCPDistinctConnectionConcurrencyTests: XCTestCase {
         }
     }
 
-    private actor CompletionSignal {
-        private var marked = false
-
-        func mark() {
-            marked = true
-        }
-
-        func isMarked() -> Bool {
-            marked
-        }
-    }
-
     private actor SearchAdmissionGate {
+        private let onStarted: @Sendable () -> Void
         private var startedCount = 0
         private var released = false
-        private var startWaiters: [CheckedContinuation<Void, Never>] = []
         private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+
+        init(onStarted: @escaping @Sendable () -> Void) {
+            self.onStarted = onStarted
+        }
 
         func markStartedAndWaitForRelease() async {
             startedCount += 1
-            startWaiters.forEach { $0.resume() }
-            startWaiters.removeAll()
+            if startedCount <= 2 {
+                onStarted()
+            }
             guard !released else { return }
             await withCheckedContinuation { continuation in
                 releaseWaiters.append(continuation)
             }
         }
 
-        func waitUntilStartedCount(_ expectedCount: Int, timeoutNanoseconds: UInt64 = 1_000_000_000) async -> Bool {
-            let interval: UInt64 = 10_000_000
-            var waited: UInt64 = 0
-            while startedCount < expectedCount, waited < timeoutNanoseconds {
-                try? await Task.sleep(nanoseconds: interval)
-                waited += interval
-            }
-            return startedCount >= expectedCount
+        func startedCountSnapshot() -> Int {
+            startedCount
         }
 
         func release() {
@@ -1462,7 +1450,6 @@ final class PersistentMCPDistinctConnectionConcurrencyTests: XCTestCase {
     private enum ClientFixtureError: Error {
         case exactAbsoluteCatalogMiss
         case routingServiceUnavailable
-        case telemetryCaptureBusy
         case toolReturnedError(String)
     }
 #endif

--- a/Tests/RepoPromptTests/MCP/Control/UnixSocketMCPReceiveOverflowTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/UnixSocketMCPReceiveOverflowTests.swift
@@ -89,6 +89,19 @@ final class UnixSocketMCPReceiveOverflowTests: XCTestCase {
 
             let peerSawEOF = await Self.waitUntil { Self.peerObservedEOF(on: descriptors[1]) }
             XCTAssertTrue(peerSawEOF)
+            let cleanupCompleted = await Self.waitUntil {
+                let cleanup = await transport.debugCleanupSnapshot()
+                return !cleanup.hasActiveReader
+                    && cleanup.pendingReaderCancellationCount == 0
+                    && cleanup.earlyReaderCancellationCount == 0
+                    && !cleanup.readerIsRetained
+                    && cleanup.terminalCallbackCount == 0
+                    && cleanup.cancellationCallbackCount == 1
+                    && cleanup.finalizationCount == 1
+                    && cleanup.descriptorCloseCount == 1
+                    && !cleanup.socketIsOwned
+            }
+            XCTAssertTrue(cleanupCompleted)
             await transport.disconnect()
             await transport.disconnect()
         #else
@@ -133,6 +146,15 @@ final class UnixSocketMCPReceiveOverflowTests: XCTestCase {
 
             let peerSawEOF = await Self.waitUntil { Self.peerObservedEOF(on: descriptors[1]) }
             XCTAssertTrue(peerSawEOF)
+            let cleanupCompleted = await Self.waitUntil {
+                let cleanup = await transport.debugCleanupSnapshot()
+                return cleanup.pendingReaderCancellationCount == 0
+                    && cleanup.earlyReaderCancellationCount == 0
+                    && !cleanup.readerIsRetained
+                    && cleanup.finalizationCount == 1
+                    && cleanup.descriptorCloseCount == 1
+            }
+            XCTAssertTrue(cleanupCompleted)
         #else
             throw XCTSkip("Overflow teardown race seam requires a DEBUG build")
         #endif
@@ -188,6 +210,20 @@ final class UnixSocketMCPReceiveOverflowTests: XCTestCase {
 
         let firstPeerSawEOF = await Self.waitUntil { Self.peerObservedEOF(on: firstDescriptors[1]) }
         XCTAssertTrue(firstPeerSawEOF)
+        #if DEBUG
+            let firstCleanupCompleted = await Self.waitUntil {
+                let cleanup = await firstTransport.debugCleanupSnapshot()
+                return cleanup.pendingReaderCancellationCount == 0
+                    && cleanup.earlyReaderCancellationCount == 0
+                    && !cleanup.readerIsRetained
+                    && cleanup.finalizationCount == 1
+                    && cleanup.descriptorCloseCount == 1
+            }
+            XCTAssertTrue(firstCleanupCompleted)
+            let secondCleanupBeforeDisconnect = await secondTransport.debugCleanupSnapshot()
+            XCTAssertTrue(secondCleanupBeforeDisconnect.hasActiveReader)
+            XCTAssertEqual(secondCleanupBeforeDisconnect.descriptorCloseCount, 0)
+        #endif
         XCTAssertFalse(Self.peerObservedEOF(on: secondDescriptors[1]))
         await firstTransport.disconnect()
         await secondTransport.disconnect()

--- a/Tests/RepoPromptTests/MCP/Control/UnixSocketMCPTerminalCleanupTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/UnixSocketMCPTerminalCleanupTests.swift
@@ -312,7 +312,7 @@ final class UnixSocketMCPTerminalCleanupTests: XCTestCase {
                 let pending = await Self.waitUntil {
                     let snapshot = await transport.debugCleanupSnapshot()
                     return snapshot.pendingReaderCancellationCount == 1
-                        && snapshot.terminalCallbackCount == 1
+                        && snapshot.terminalCallbackCount == 1 + snapshot.staleTerminalCount
                         && snapshot.descriptorCloseCount == 0
                 }
                 XCTAssertTrue(pending)

--- a/Tests/RepoPromptTests/MCP/Control/UnixSocketMCPTerminalCleanupTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/UnixSocketMCPTerminalCleanupTests.swift
@@ -1,0 +1,536 @@
+import Darwin
+import Foundation
+@testable import RepoPrompt
+import XCTest
+
+final class UnixSocketMCPTerminalCleanupTests: XCTestCase {
+    func testCancellationCallbackBeforeTerminalTaskFinalizesExactlyOnce() async throws {
+        #if DEBUG
+            let descriptors = try Self.makeSocketPair()
+            defer { Self.closeIfOpen(descriptors[1]) }
+
+            let transport: UnixSocketMCPTransport? = try UnixSocketMCPTransport(connectedFD: descriptors[0])
+            let connectedTransport = try XCTUnwrap(transport)
+            await connectedTransport.debugHoldReaderTerminalCallback()
+            try await connectedTransport.connect()
+            let stream = await connectedTransport.receive()
+
+            XCTAssertEqual(Darwin.shutdown(descriptors[1], SHUT_WR), 0)
+
+            let cancellationArrivedFirst = await Self.waitUntil {
+                let snapshot = await connectedTransport.debugCleanupSnapshot()
+                return snapshot.cancellationCallbackCount == 1
+                    && snapshot.earlyReaderCancellationCount == 1
+                    && snapshot.hasActiveReader
+                    && snapshot.terminalCallbackCount == 0
+            }
+            XCTAssertTrue(cancellationArrivedFirst)
+            var snapshot = await connectedTransport.debugCleanupSnapshot()
+            XCTAssertEqual(snapshot.descriptorCloseCount, 0)
+            XCTAssertEqual(snapshot.finalizationCount, 0)
+            XCTAssertTrue(snapshot.readerIsRetained)
+            XCTAssertTrue(snapshot.socketIsOwned)
+            XCTAssertFalse(Self.peerObservedEOF(on: descriptors[1]))
+
+            await connectedTransport.debugReleaseReaderTerminalCallbacks()
+            var iterator = stream.makeAsyncIterator()
+            let terminalFrame = try await iterator.next()
+            XCTAssertNil(terminalFrame)
+
+            let cleanupCompleted = await Self.waitUntil {
+                let snapshot = await connectedTransport.debugCleanupSnapshot()
+                return !snapshot.hasActiveReader
+                    && snapshot.pendingReaderCancellationCount == 0
+                    && snapshot.earlyReaderCancellationCount == 0
+                    && !snapshot.readerIsRetained
+                    && snapshot.terminalCallbackCount == 1
+                    && snapshot.finalizationCount == 1
+                    && snapshot.descriptorCloseCount == 1
+                    && !snapshot.socketIsOwned
+            }
+            XCTAssertTrue(cleanupCompleted)
+            XCTAssertTrue(Self.isClosed(descriptors[0]))
+            XCTAssertTrue(Self.peerObservedEOF(on: descriptors[1]))
+
+            await connectedTransport.disconnect()
+            await connectedTransport.disconnect()
+            snapshot = await connectedTransport.debugCleanupSnapshot()
+            XCTAssertEqual(snapshot.terminalCallbackCount, 1)
+            XCTAssertEqual(snapshot.cancellationCallbackCount, 1)
+            XCTAssertEqual(snapshot.finalizationCount, 1)
+            XCTAssertEqual(snapshot.descriptorCloseCount, 1)
+            XCTAssertEqual(snapshot.staleCancellationCount, 0)
+
+        #else
+            throw XCTSkip("Deterministic transport callback gates require a DEBUG build")
+        #endif
+    }
+
+    func testTerminalTaskBeforeCancellationCallbackRetainsThenReleasesOwnership() async throws {
+        #if DEBUG
+            let descriptors = try Self.makeSocketPair()
+            defer { Self.closeIfOpen(descriptors[1]) }
+
+            let transport: UnixSocketMCPTransport? = try UnixSocketMCPTransport(connectedFD: descriptors[0])
+            let connectedTransport = try XCTUnwrap(transport)
+            await connectedTransport.debugHoldReaderCancellationCallback()
+            try await connectedTransport.connect()
+            let stream = await connectedTransport.receive()
+
+            XCTAssertEqual(Darwin.shutdown(descriptors[1], SHUT_WR), 0)
+
+            let terminalArrivedFirst = await Self.waitUntil {
+                let snapshot = await connectedTransport.debugCleanupSnapshot()
+                return snapshot.terminalCallbackCount == 1
+                    && snapshot.pendingReaderCancellationCount == 1
+                    && snapshot.cancellationCallbackCount == 0
+                    && !snapshot.hasActiveReader
+            }
+            XCTAssertTrue(terminalArrivedFirst)
+            var snapshot = await connectedTransport.debugCleanupSnapshot()
+            XCTAssertEqual(snapshot.earlyReaderCancellationCount, 0)
+            XCTAssertEqual(snapshot.finalizationCount, 0)
+            XCTAssertEqual(snapshot.descriptorCloseCount, 0)
+            XCTAssertTrue(snapshot.readerIsRetained)
+            XCTAssertTrue(snapshot.socketIsOwned)
+
+            var iterator = stream.makeAsyncIterator()
+            let terminalFrame = try await iterator.next()
+            XCTAssertNil(terminalFrame)
+
+            await connectedTransport.debugReleaseReaderCancellationCallbacks()
+            let cleanupCompleted = await Self.waitUntil {
+                let snapshot = await connectedTransport.debugCleanupSnapshot()
+                return snapshot.pendingReaderCancellationCount == 0
+                    && snapshot.earlyReaderCancellationCount == 0
+                    && !snapshot.readerIsRetained
+                    && snapshot.cancellationCallbackCount == 1
+                    && snapshot.finalizationCount == 1
+                    && snapshot.descriptorCloseCount == 1
+                    && !snapshot.socketIsOwned
+            }
+            XCTAssertTrue(cleanupCompleted)
+            XCTAssertTrue(Self.isClosed(descriptors[0]))
+            XCTAssertTrue(Self.peerObservedEOF(on: descriptors[1]))
+
+            await connectedTransport.disconnect()
+            snapshot = await connectedTransport.debugCleanupSnapshot()
+            XCTAssertEqual(snapshot.terminalCallbackCount, 1)
+            XCTAssertEqual(snapshot.cancellationCallbackCount, 1)
+            XCTAssertEqual(snapshot.finalizationCount, 1)
+            XCTAssertEqual(snapshot.descriptorCloseCount, 1)
+            XCTAssertEqual(snapshot.staleCancellationCount, 0)
+
+        #else
+            throw XCTSkip("Deterministic transport callback gates require a DEBUG build")
+        #endif
+    }
+
+    func testTerminalCleanupReleasesTransportRetainer() async throws {
+        #if DEBUG
+            let descriptors = try Self.makeSocketPair()
+            defer { Self.closeIfOpen(descriptors[1]) }
+            weak var weakTransport: UnixSocketMCPTransport?
+
+            do {
+                let transport = try UnixSocketMCPTransport(connectedFD: descriptors[0])
+                weakTransport = transport
+                await transport.debugHoldReaderCancellationCallback()
+                try await transport.connect()
+                XCTAssertEqual(Darwin.shutdown(descriptors[1], SHUT_WR), 0)
+
+                let pending = await Self.waitUntil {
+                    let snapshot = await transport.debugCleanupSnapshot()
+                    return snapshot.pendingReaderCancellationCount == 1
+                        && snapshot.readerIsRetained
+                        && snapshot.terminalCallbackCount == 1
+                }
+                XCTAssertTrue(pending)
+                await transport.debugReleaseReaderCancellationCallbacks()
+                let cleaned = await Self.waitUntil {
+                    let snapshot = await transport.debugCleanupSnapshot()
+                    return snapshot.pendingReaderCancellationCount == 0
+                        && !snapshot.readerIsRetained
+                        && snapshot.finalizationCount == 1
+                }
+                XCTAssertTrue(cleaned)
+            }
+
+            let transportReleased = await Self.waitUntil { weakTransport == nil }
+            XCTAssertTrue(transportReleased)
+        #else
+            throw XCTSkip("Deterministic transport callback gates require a DEBUG build")
+        #endif
+    }
+
+    func testExplicitStopFencesHeldTerminalCallback() async throws {
+        #if DEBUG
+            let descriptors = try Self.makeSocketPair()
+            defer { Self.closeIfOpen(descriptors[1]) }
+
+            let transport = try UnixSocketMCPTransport(connectedFD: descriptors[0])
+            await transport.debugHoldReaderTerminalCallback()
+            try await transport.connect()
+            XCTAssertEqual(Darwin.shutdown(descriptors[1], SHUT_WR), 0)
+
+            let cancellationArrived = await Self.waitUntil {
+                let snapshot = await transport.debugCleanupSnapshot()
+                return snapshot.earlyReaderCancellationCount == 1
+                    && snapshot.terminalCallbackCount == 0
+            }
+            XCTAssertTrue(cancellationArrived)
+
+            await transport.disconnect()
+            let stopped = await Self.waitUntil {
+                let snapshot = await transport.debugCleanupSnapshot()
+                return snapshot.finalizationCount == 1
+                    && snapshot.descriptorCloseCount == 1
+                    && !snapshot.readerIsRetained
+            }
+            XCTAssertTrue(stopped)
+
+            await transport.debugReleaseReaderTerminalCallbacks()
+            let staleTerminalWasFenced = await Self.waitUntil {
+                let snapshot = await transport.debugCleanupSnapshot()
+                return snapshot.terminalCallbackCount == 1
+                    && snapshot.staleTerminalCount == 1
+            }
+            XCTAssertTrue(staleTerminalWasFenced)
+            let snapshot = await transport.debugCleanupSnapshot()
+            XCTAssertEqual(snapshot.cancellationCallbackCount, 1)
+            XCTAssertEqual(snapshot.finalizationCount, 1)
+            XCTAssertEqual(snapshot.descriptorCloseCount, 1)
+            XCTAssertFalse(snapshot.socketIsOwned)
+        #else
+            throw XCTSkip("Deterministic transport callback gates require a DEBUG build")
+        #endif
+    }
+
+    func testHeldOldTerminalCallbackCannotCloseReplacementConnection() async throws {
+        #if DEBUG
+            let suffix = UUID().uuidString.prefix(8)
+            let directoryURL = URL(fileURLWithPath: "/tmp/rpce-t-\(getpid())-\(suffix)", isDirectory: true)
+            try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: directoryURL) }
+            let socketURL = directoryURL.appendingPathComponent("transport.sock")
+            let listenerFD = try Self.makeUnixListener(at: socketURL)
+            defer { Self.closeIfOpen(listenerFD) }
+
+            let transport = UnixSocketMCPTransport(socketURL: socketURL)
+            await transport.debugHoldReaderTerminalCallback()
+            try await transport.connect()
+            let firstPeerFD = Darwin.accept(listenerFD, nil, nil)
+            XCTAssertGreaterThanOrEqual(firstPeerFD, 0)
+            defer { Self.closeIfOpen(firstPeerFD) }
+
+            XCTAssertEqual(Darwin.shutdown(firstPeerFD, SHUT_WR), 0)
+            let oldCancellationArrived = await Self.waitUntil {
+                let snapshot = await transport.debugCleanupSnapshot()
+                return snapshot.earlyReaderCancellationCount == 1
+                    && snapshot.terminalCallbackCount == 0
+            }
+            XCTAssertTrue(oldCancellationArrived)
+
+            await transport.disconnect()
+            try await transport.connect()
+            let replacementPeerFD = Darwin.accept(listenerFD, nil, nil)
+            XCTAssertGreaterThanOrEqual(replacementPeerFD, 0)
+            defer { Self.closeIfOpen(replacementPeerFD) }
+            let replacementStream = await transport.receive()
+            var replacementIterator = replacementStream.makeAsyncIterator()
+            var snapshot = await transport.debugCleanupSnapshot()
+            XCTAssertTrue(snapshot.hasActiveReader)
+            XCTAssertTrue(snapshot.socketIsOwned)
+            XCTAssertEqual(snapshot.descriptorCloseCount, 1)
+            var replacementIngress = await transport.ingressSnapshot()
+            XCTAssertFalse(replacementIngress.isTerminal)
+            XCTAssertEqual(replacementIngress.acceptedFrameCount, 0)
+
+            await transport.debugReleaseReaderTerminalCallbacks()
+            let staleTerminalWasFenced = await Self.waitUntil {
+                let snapshot = await transport.debugCleanupSnapshot()
+                return snapshot.terminalCallbackCount == 1
+                    && snapshot.staleTerminalCount == 1
+            }
+            XCTAssertTrue(staleTerminalWasFenced)
+            snapshot = await transport.debugCleanupSnapshot()
+            XCTAssertTrue(snapshot.hasActiveReader)
+            XCTAssertTrue(snapshot.socketIsOwned)
+            XCTAssertEqual(snapshot.descriptorCloseCount, 1)
+            replacementIngress = await transport.ingressSnapshot()
+            XCTAssertFalse(replacementIngress.isTerminal)
+
+            try await transport.send(Data("replacement-probe".utf8))
+            let replacementFrame = try Self.readLine(from: replacementPeerFD)
+            XCTAssertEqual(replacementFrame, Data("replacement-probe".utf8))
+
+            try Self.writeAll(Data("replacement-inbound\n".utf8), to: replacementPeerFD)
+            let replacementInboundFrame = try await replacementIterator.next()
+            XCTAssertEqual(replacementInboundFrame, Data("replacement-inbound".utf8))
+            replacementIngress = await transport.ingressSnapshot()
+            XCTAssertEqual(replacementIngress.acceptedFrameCount, 1)
+            XCTAssertFalse(replacementIngress.isTerminal)
+
+            await transport.disconnect()
+            let replacementCleaned = await Self.waitUntil {
+                let snapshot = await transport.debugCleanupSnapshot()
+                return snapshot.finalizationCount == 2
+                    && snapshot.descriptorCloseCount == 2
+                    && !snapshot.readerIsRetained
+            }
+            XCTAssertTrue(replacementCleaned)
+        #else
+            throw XCTSkip("Deterministic transport callback gates require a DEBUG build")
+        #endif
+    }
+
+    func testExplicitStopAndHardErrorUseSameSingleFinalizer() async throws {
+        #if DEBUG
+            try await Self.assertControlledCleanup { transport, _ in
+                await transport.debugHoldReaderCancellationCallback()
+                await transport.disconnect()
+                let pending = await Self.waitUntil {
+                    let snapshot = await transport.debugCleanupSnapshot()
+                    return snapshot.pendingReaderCancellationCount == 1
+                        && snapshot.descriptorCloseCount == 0
+                }
+                XCTAssertTrue(pending)
+                await transport.debugReleaseReaderCancellationCallbacks()
+            }
+
+            try await Self.assertControlledCleanup { transport, stream in
+                await transport.debugHoldReaderCancellationCallback()
+                await transport.debugTriggerReadErrorForCleanupTest()
+                var iterator = stream.makeAsyncIterator()
+                do {
+                    _ = try await iterator.next()
+                    XCTFail("Expected the forced read error to terminate the stream")
+                } catch is POSIXError {
+                } catch {
+                    XCTFail("Unexpected forced read terminal error: \(error)")
+                }
+                let pending = await Self.waitUntil {
+                    let snapshot = await transport.debugCleanupSnapshot()
+                    return snapshot.pendingReaderCancellationCount == 1
+                        && snapshot.terminalCallbackCount == 1
+                        && snapshot.descriptorCloseCount == 0
+                }
+                XCTAssertTrue(pending)
+                await transport.debugReleaseReaderCancellationCallbacks()
+            }
+        #else
+            throw XCTSkip("Deterministic transport callback gates require a DEBUG build")
+        #endif
+    }
+
+    func testTerminalCleanupIsConnectionLocalWhilePeerContinues() async throws {
+        #if DEBUG
+            let firstDescriptors = try Self.makeSocketPair()
+            let secondDescriptors = try Self.makeSocketPair()
+            defer {
+                Self.closeIfOpen(firstDescriptors[1])
+                Self.closeIfOpen(secondDescriptors[1])
+            }
+
+            let firstTransport = try UnixSocketMCPTransport(connectedFD: firstDescriptors[0])
+            let secondTransport = try UnixSocketMCPTransport(connectedFD: secondDescriptors[0])
+            await firstTransport.debugHoldReaderTerminalCallback()
+            try await firstTransport.connect()
+            try await secondTransport.connect()
+            let secondStream = await secondTransport.receive()
+
+            XCTAssertEqual(Darwin.shutdown(firstDescriptors[1], SHUT_WR), 0)
+            let firstCancellationArrived = await Self.waitUntil {
+                let snapshot = await firstTransport.debugCleanupSnapshot()
+                return snapshot.earlyReaderCancellationCount == 1
+                    && snapshot.terminalCallbackCount == 0
+            }
+            XCTAssertTrue(firstCancellationArrived)
+
+            try Self.writeAll(Data("peer-frame\n".utf8), to: secondDescriptors[1])
+            var secondIterator = secondStream.makeAsyncIterator()
+            let firstPeerFrame = try await secondIterator.next()
+            XCTAssertEqual(firstPeerFrame, Data("peer-frame".utf8))
+            let secondBeforeCleanup = await secondTransport.debugCleanupSnapshot()
+            XCTAssertTrue(secondBeforeCleanup.hasActiveReader)
+            XCTAssertEqual(secondBeforeCleanup.descriptorCloseCount, 0)
+            XCTAssertFalse(Self.peerObservedEOF(on: secondDescriptors[1]))
+
+            await firstTransport.debugReleaseReaderTerminalCallbacks()
+            let firstCleaned = await Self.waitUntil {
+                let snapshot = await firstTransport.debugCleanupSnapshot()
+                return snapshot.finalizationCount == 1
+                    && snapshot.descriptorCloseCount == 1
+                    && !snapshot.readerIsRetained
+            }
+            XCTAssertTrue(firstCleaned)
+            XCTAssertTrue(Self.peerObservedEOF(on: firstDescriptors[1]))
+            XCTAssertFalse(Self.peerObservedEOF(on: secondDescriptors[1]))
+
+            try Self.writeAll(Data("peer-frame-2\n".utf8), to: secondDescriptors[1])
+            let secondPeerFrame = try await secondIterator.next()
+            XCTAssertEqual(secondPeerFrame, Data("peer-frame-2".utf8))
+
+            await firstTransport.disconnect()
+            await secondTransport.disconnect()
+            let secondCleaned = await Self.waitUntil {
+                let snapshot = await secondTransport.debugCleanupSnapshot()
+                return snapshot.finalizationCount == 1
+                    && snapshot.descriptorCloseCount == 1
+                    && !snapshot.readerIsRetained
+            }
+            XCTAssertTrue(secondCleaned)
+        #else
+            throw XCTSkip("Deterministic transport callback gates require a DEBUG build")
+        #endif
+    }
+
+    #if DEBUG
+        private static func assertControlledCleanup(
+            trigger: (UnixSocketMCPTransport, AsyncThrowingStream<Data, Swift.Error>) async throws -> Void
+        ) async throws {
+            let descriptors = try makeSocketPair()
+            defer { closeIfOpen(descriptors[1]) }
+
+            let transport = try UnixSocketMCPTransport(connectedFD: descriptors[0])
+            try await transport.connect()
+            let stream = await transport.receive()
+            try await trigger(transport, stream)
+
+            let cleanupCompleted = await waitUntil {
+                let snapshot = await transport.debugCleanupSnapshot()
+                return !snapshot.hasActiveReader
+                    && snapshot.pendingReaderCancellationCount == 0
+                    && snapshot.earlyReaderCancellationCount == 0
+                    && !snapshot.readerIsRetained
+                    && snapshot.cancellationCallbackCount == 1
+                    && snapshot.finalizationCount == 1
+                    && snapshot.descriptorCloseCount == 1
+                    && !snapshot.socketIsOwned
+            }
+            XCTAssertTrue(cleanupCompleted)
+            XCTAssertTrue(isClosed(descriptors[0]))
+            XCTAssertTrue(peerObservedEOF(on: descriptors[1]))
+
+            await transport.disconnect()
+            let snapshot = await transport.debugCleanupSnapshot()
+            XCTAssertEqual(snapshot.cancellationCallbackCount, 1)
+            XCTAssertEqual(snapshot.finalizationCount, 1)
+            XCTAssertEqual(snapshot.descriptorCloseCount, 1)
+            XCTAssertEqual(snapshot.staleCancellationCount, 0)
+        }
+    #endif
+
+    private static func makeSocketPair() throws -> [Int32] {
+        var descriptors = [Int32](repeating: -1, count: 2)
+        guard Darwin.socketpair(AF_UNIX, SOCK_STREAM, 0, &descriptors) == 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        return descriptors
+    }
+
+    private static func makeUnixListener(at socketURL: URL) throws -> Int32 {
+        let fd = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        do {
+            var address = try unixSocketAddress(for: socketURL)
+            let bindResult = withUnsafePointer(to: &address) { pointer in
+                pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { socketAddress in
+                    Darwin.bind(fd, socketAddress, socklen_t(MemoryLayout<sockaddr_un>.size))
+                }
+            }
+            guard bindResult == 0, Darwin.listen(fd, 4) == 0 else {
+                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+            }
+            return fd
+        } catch {
+            closeIfOpen(fd)
+            throw error
+        }
+    }
+
+    private static func unixSocketAddress(for socketURL: URL) throws -> sockaddr_un {
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        let pathBytes = socketURL.path.utf8CString
+        guard pathBytes.count <= MemoryLayout.size(ofValue: address.sun_path) else {
+            throw POSIXError(.ENAMETOOLONG)
+        }
+        withUnsafeMutablePointer(to: &address.sun_path) { pointer in
+            pointer.withMemoryRebound(to: CChar.self, capacity: pathBytes.count) { destination in
+                for (index, byte) in pathBytes.enumerated() {
+                    destination[index] = byte
+                }
+            }
+        }
+        return address
+    }
+
+    private static func readLine(from fd: Int32, timeout: TimeInterval = 2) throws -> Data {
+        let deadline = Date().addingTimeInterval(timeout)
+        var data = Data()
+        while Date() < deadline {
+            var descriptor = pollfd(fd: fd, events: Int16(POLLIN | POLLHUP | POLLERR), revents: 0)
+            let pollResult = Darwin.poll(&descriptor, 1, 50)
+            if pollResult < 0, errno == EINTR { continue }
+            guard pollResult > 0 else { continue }
+
+            var byte: UInt8 = 0
+            let count = Darwin.read(fd, &byte, 1)
+            if count < 0, errno == EINTR { continue }
+            guard count > 0 else { throw POSIXError(.EIO) }
+            if byte == UInt8(ascii: "\n") {
+                return data
+            }
+            data.append(byte)
+        }
+        throw POSIXError(.ETIMEDOUT)
+    }
+
+    private static func writeAll(_ data: Data, to fd: Int32) throws {
+        var remaining = data
+        while !remaining.isEmpty {
+            let written = remaining.withUnsafeBytes { buffer in
+                Darwin.write(fd, buffer.baseAddress, buffer.count)
+            }
+            if written < 0 {
+                if errno == EINTR { continue }
+                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+            }
+            guard written > 0 else { throw POSIXError(.EIO) }
+            remaining = remaining.dropFirst(written)
+        }
+    }
+
+    private static func peerObservedEOF(on fd: Int32) -> Bool {
+        var descriptor = pollfd(fd: fd, events: Int16(POLLIN | POLLHUP), revents: 0)
+        guard poll(&descriptor, 1, 0) > 0 else { return false }
+        var byte: UInt8 = 0
+        return Darwin.read(fd, &byte, 1) == 0
+    }
+
+    private static func isClosed(_ fd: Int32) -> Bool {
+        errno = 0
+        return fcntl(fd, F_GETFD) == -1 && errno == EBADF
+    }
+
+    private static func closeIfOpen(_ fd: Int32) {
+        guard fd >= 0, !isClosed(fd) else { return }
+        Darwin.close(fd)
+    }
+
+    private static func waitUntil(
+        timeout: TimeInterval = 2,
+        pollIntervalNanoseconds: UInt64 = 5_000_000,
+        _ condition: @escaping () async -> Bool
+    ) async -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if await condition() { return true }
+            try? await Task.sleep(nanoseconds: pollIntervalNanoseconds)
+        }
+        return await condition()
+    }
+}

--- a/Tests/RepoPromptTests/MCP/NewlineDelimitedSocketReaderFairnessTests.swift
+++ b/Tests/RepoPromptTests/MCP/NewlineDelimitedSocketReaderFairnessTests.swift
@@ -1,0 +1,394 @@
+import Darwin
+import Dispatch
+import Foundation
+import Logging
+@testable import RepoPrompt
+import XCTest
+
+final class NewlineDelimitedSocketReaderFairnessTests: XCTestCase {
+    func testContinuouslyReadableInputYieldsThenResumesProgress() {
+        let queue = DispatchQueue(label: "NewlineDelimitedSocketReaderFairnessTests.continuous")
+        let script = ContinuousFrameReadOperation(frameCount: 6)
+        let state = ReaderCallbackState()
+        let queueYielded = expectation(description: "serial queue yielded")
+
+        let reader = makeReader(
+            queue: queue,
+            maxReadCallsPerEvent: 3,
+            readOperation: script.read,
+            state: state
+        )
+
+        queue.suspend()
+        queue.async {
+            reader.processReadableEvent()
+        }
+        queue.async {
+            state.readAttemptsObservedAtYield = script.readAttemptCount
+            state.framesObservedAtYield = state.frames
+            queueYielded.fulfill()
+        }
+        queue.resume()
+
+        wait(for: [queueYielded], timeout: 1)
+        XCTAssertEqual(state.readAttemptsObservedAtYield, 3)
+        XCTAssertEqual(state.framesObservedAtYield, ["frame-0", "frame-1", "frame-2"])
+        queue.sync {}
+        reader.stop()
+
+        XCTAssertEqual(state.frames, [
+            "frame-0", "frame-1", "frame-2",
+            "frame-3", "frame-4", "frame-5"
+        ])
+        XCTAssertEqual(state.bytesReadNotifications, 2)
+        XCTAssertTrue(state.errors.isEmpty)
+        XCTAssertEqual(state.eofResiduals, [])
+    }
+
+    func testSplitAndMultipleFramesPreserveOrderAcrossReadableEvents() {
+        let script = ScriptedReadOperation(outcomes: [
+            .data(Data("fir".utf8)),
+            .data(Data("st\nsecond\nthi".utf8)),
+            .wouldBlock,
+            .data(Data("rd\nfourth\n".utf8)),
+            .wouldBlock
+        ])
+        let state = ReaderCallbackState()
+        let reader = makeReader(readOperation: script.read, state: state)
+
+        reader.processReadableEvent()
+        XCTAssertEqual(state.frames, ["first", "second"])
+        XCTAssertEqual(state.bytesReadNotifications, 1)
+
+        reader.processReadableEvent()
+        XCTAssertEqual(state.frames, ["first", "second", "third", "fourth"])
+        XCTAssertEqual(state.bytesReadNotifications, 2)
+        XCTAssertEqual(script.readAttemptCount, 5)
+        XCTAssertTrue(state.errors.isEmpty)
+        XCTAssertEqual(state.eofResiduals, [])
+    }
+
+    func testEOFThroughDispatchSourceDrainsCompleteFramesBeforeTerminal() throws {
+        var sockets = [Int32](repeating: -1, count: 2)
+        XCTAssertEqual(socketpair(AF_UNIX, SOCK_STREAM, 0, &sockets), 0)
+        defer {
+            if sockets[0] >= 0 {
+                close(sockets[0])
+            }
+            if sockets[1] >= 0 {
+                close(sockets[1])
+            }
+        }
+
+        let flags = fcntl(sockets[0], F_GETFL)
+        XCTAssertGreaterThanOrEqual(flags, 0)
+        XCTAssertEqual(fcntl(sockets[0], F_SETFL, flags | O_NONBLOCK), 0)
+
+        let queue = DispatchQueue(label: "NewlineDelimitedSocketReaderFairnessTests.eof")
+        let state = ReaderCallbackState()
+        let eofDelivered = expectation(description: "EOF delivered")
+        let reader = NewlineDelimitedSocketReader(
+            fd: sockets[0],
+            queue: queue,
+            logger: Logger(label: "NewlineDelimitedSocketReaderFairnessTests.eof"),
+            onFrame: { frame in
+                let text = String(decoding: frame, as: UTF8.self)
+                state.frames.append(text)
+                state.callbackOrder.append("frame:\(text)")
+            },
+            onEOF: { hasResidualData in
+                state.eofResiduals.append(hasResidualData)
+                state.callbackOrder.append("eof:\(hasResidualData)")
+                eofDelivered.fulfill()
+            },
+            onError: { state.errors.append($0) },
+            onBytesRead: { state.bytesReadNotifications += 1 }
+        )
+        try reader.start()
+
+        let payload = Data("first\nsecond\npartial".utf8)
+        let written = payload.withUnsafeBytes { bytes in
+            Darwin.write(sockets[1], bytes.baseAddress, bytes.count)
+        }
+        XCTAssertEqual(written, payload.count)
+        XCTAssertEqual(shutdown(sockets[1], SHUT_WR), 0)
+        wait(for: [eofDelivered], timeout: 1)
+        queue.sync {}
+
+        XCTAssertEqual(state.callbackOrder, ["frame:first", "frame:second", "eof:true"])
+        XCTAssertEqual(state.frames, ["first", "second"])
+        XCTAssertEqual(state.eofResiduals, [true])
+        XCTAssertEqual(state.bytesReadNotifications, 1)
+        XCTAssertTrue(state.errors.isEmpty)
+    }
+
+    func testHardReadErrorIsTerminalAndDeliveredExactlyOnce() {
+        let script = ScriptedReadOperation(outcomes: [.error(EIO)])
+        let state = ReaderCallbackState()
+        let reader = makeReader(readOperation: script.read, state: state)
+
+        reader.processReadableEvent()
+        reader.processReadableEvent()
+
+        XCTAssertEqual(script.readAttemptCount, 1)
+        XCTAssertEqual(state.errors.count, 1)
+        XCTAssertTrue(state.frames.isEmpty)
+        XCTAssertTrue(state.eofResiduals.isEmpty)
+    }
+
+    func testReentrantReadableEventDoesNotNestFrameDelivery() {
+        let queue = DispatchQueue(label: "NewlineDelimitedSocketReaderFairnessTests.reentrant")
+        let script = ScriptedReadOperation(outcomes: [
+            .data(Data("first\n".utf8)),
+            .data(Data("second\n".utf8)),
+            .wouldBlock
+        ])
+        let delivered = expectation(description: "both frames delivered")
+        var frames: [String] = []
+        var callbackDepth = 0
+        var maximumCallbackDepth = 0
+        weak var weakReader: NewlineDelimitedSocketReader?
+
+        let reader = NewlineDelimitedSocketReader(
+            fd: -1,
+            queue: queue,
+            logger: Logger(label: "NewlineDelimitedSocketReaderFairnessTests.reentrant"),
+            chunkSize: 64,
+            maxReadCallsPerEvent: 1,
+            readOperation: script.read,
+            onFrame: { frame in
+                callbackDepth += 1
+                maximumCallbackDepth = max(maximumCallbackDepth, callbackDepth)
+                frames.append(String(decoding: frame, as: UTF8.self))
+                if frames.count == 1 {
+                    weakReader?.processReadableEvent()
+                } else {
+                    weakReader?.stop()
+                    delivered.fulfill()
+                }
+                callbackDepth -= 1
+            },
+            onEOF: { _ in XCTFail("Unexpected EOF") },
+            onError: { XCTFail("Unexpected read error: \($0)") }
+        )
+        weakReader = reader
+
+        reader.processReadableEvent()
+        wait(for: [delivered], timeout: 1)
+
+        XCTAssertEqual(frames, ["first", "second"])
+        XCTAssertEqual(maximumCallbackDepth, 1)
+        XCTAssertEqual(script.readAttemptCount, 2)
+    }
+
+    func testStopDuringFrameDeliveryCancelsSourceAndSuppressesBufferedFrames() throws {
+        var sockets = [Int32](repeating: -1, count: 2)
+        XCTAssertEqual(socketpair(AF_UNIX, SOCK_STREAM, 0, &sockets), 0)
+        defer {
+            if sockets[0] >= 0 {
+                close(sockets[0])
+            }
+            if sockets[1] >= 0 {
+                close(sockets[1])
+            }
+        }
+
+        let flags = fcntl(sockets[0], F_GETFL)
+        XCTAssertGreaterThanOrEqual(flags, 0)
+        XCTAssertEqual(fcntl(sockets[0], F_SETFL, flags | O_NONBLOCK), 0)
+
+        let queue = DispatchQueue(label: "NewlineDelimitedSocketReaderFairnessTests.stop")
+        let cancelled = expectation(description: "read source cancelled")
+        var frames: [String] = []
+        var cancelCount = 0
+        weak var weakReader: NewlineDelimitedSocketReader?
+
+        let reader = NewlineDelimitedSocketReader(
+            fd: sockets[0],
+            queue: queue,
+            logger: Logger(label: "NewlineDelimitedSocketReaderFairnessTests.stop"),
+            onFrame: { frame in
+                frames.append(String(decoding: frame, as: UTF8.self))
+                weakReader?.stop()
+            },
+            onEOF: { _ in XCTFail("Unexpected EOF") },
+            onError: { XCTFail("Unexpected read error: \($0)") },
+            onCancel: {
+                cancelCount += 1
+                cancelled.fulfill()
+            }
+        )
+        weakReader = reader
+        try reader.start()
+
+        let payload = Data("first\nsecond\n".utf8)
+        let written = payload.withUnsafeBytes { bytes in
+            Darwin.write(sockets[1], bytes.baseAddress, bytes.count)
+        }
+        XCTAssertEqual(written, payload.count)
+
+        wait(for: [cancelled], timeout: 1)
+        queue.sync {}
+
+        XCTAssertEqual(frames, ["first"])
+        XCTAssertEqual(cancelCount, 1)
+    }
+
+    func testCrossQueueStopPreventsFurtherReadsAndCallbacks() {
+        let queue = DispatchQueue(label: "NewlineDelimitedSocketReaderFairnessTests.crossQueueStop")
+        let script = ScriptedReadOperation(outcomes: [
+            .data(Data("first\n".utf8)),
+            .wouldBlock,
+            .data(Data("second\n".utf8)),
+            .wouldBlock
+        ])
+        let state = ReaderCallbackState()
+        let reader = makeReader(queue: queue, readOperation: script.read, state: state)
+        let stopped = expectation(description: "cross-queue stop returned")
+
+        reader.processReadableEvent()
+        DispatchQueue.global().async {
+            reader.stop()
+            stopped.fulfill()
+        }
+        wait(for: [stopped], timeout: 1)
+
+        reader.processReadableEvent()
+        queue.sync {}
+
+        XCTAssertEqual(script.readAttemptCount, 2)
+        XCTAssertEqual(state.frames, ["first"])
+        XCTAssertEqual(state.bytesReadNotifications, 1)
+        XCTAssertTrue(state.errors.isEmpty)
+        XCTAssertTrue(state.eofResiduals.isEmpty)
+    }
+
+    func testAppAndCLISocketReaderCopiesRemainIdentical() throws {
+        var root = URL(fileURLWithPath: #filePath)
+        for _ in 0 ..< 4 {
+            root.deleteLastPathComponent()
+        }
+
+        let appCopy = try Data(
+            contentsOf: root.appendingPathComponent(
+                "Sources/RepoPrompt/Infrastructure/MCP/AppShared/NewlineDelimitedSocketReader.swift"
+            )
+        )
+        let cliCopy = try Data(
+            contentsOf: root.appendingPathComponent(
+                "Sources/RepoPromptMCP/Shared/NewlineDelimitedSocketReader.swift"
+            )
+        )
+        XCTAssertEqual(appCopy, cliCopy)
+    }
+
+    private func makeReader(
+        queue: DispatchQueue = DispatchQueue(label: "NewlineDelimitedSocketReaderFairnessTests"),
+        maxReadCallsPerEvent: Int = 32,
+        readOperation: @escaping NewlineDelimitedSocketReader.ReadOperation,
+        state: ReaderCallbackState
+    ) -> NewlineDelimitedSocketReader {
+        NewlineDelimitedSocketReader(
+            fd: -1,
+            queue: queue,
+            logger: Logger(label: "NewlineDelimitedSocketReaderFairnessTests"),
+            chunkSize: 64,
+            maxReadCallsPerEvent: maxReadCallsPerEvent,
+            readOperation: readOperation,
+            onFrame: { frame in
+                let text = String(decoding: frame, as: UTF8.self)
+                state.frames.append(text)
+                state.callbackOrder.append("frame:\(text)")
+            },
+            onEOF: { hasResidualData in
+                state.eofResiduals.append(hasResidualData)
+                state.callbackOrder.append("eof:\(hasResidualData)")
+            },
+            onError: { state.errors.append($0) },
+            onBytesRead: { state.bytesReadNotifications += 1 },
+            onCancel: { state.cancelCount += 1 }
+        )
+    }
+}
+
+private final class ReaderCallbackState {
+    var frames: [String] = []
+    var eofResiduals: [Bool] = []
+    var errors: [Error] = []
+    var callbackOrder: [String] = []
+    var bytesReadNotifications = 0
+    var cancelCount = 0
+    var readAttemptsObservedAtYield = 0
+    var framesObservedAtYield: [String] = []
+}
+
+private final class ContinuousFrameReadOperation {
+    private let frameCount: Int
+    private(set) var readAttemptCount = 0
+
+    init(frameCount: Int) {
+        self.frameCount = frameCount
+    }
+
+    func read(
+        _ fd: Int32,
+        _ buffer: UnsafeMutableRawPointer?,
+        _ count: Int
+    ) -> Int {
+        _ = fd
+        guard readAttemptCount < frameCount else {
+            errno = EAGAIN
+            readAttemptCount += 1
+            return -1
+        }
+        let frame = Data("frame-\(readAttemptCount)\n".utf8)
+        readAttemptCount += 1
+        precondition(frame.count <= count)
+        frame.copyBytes(to: buffer!.assumingMemoryBound(to: UInt8.self), count: frame.count)
+        return frame.count
+    }
+}
+
+private final class ScriptedReadOperation {
+    enum Outcome {
+        case data(Data)
+        case wouldBlock
+        case eof
+        case error(Int32)
+    }
+
+    private var outcomes: [Outcome]
+    private(set) var readAttemptCount = 0
+
+    init(outcomes: [Outcome]) {
+        self.outcomes = outcomes
+    }
+
+    func read(
+        _ fd: Int32,
+        _ buffer: UnsafeMutableRawPointer?,
+        _ count: Int
+    ) -> Int {
+        _ = fd
+        readAttemptCount += 1
+        guard !outcomes.isEmpty else {
+            errno = EAGAIN
+            return -1
+        }
+
+        switch outcomes.removeFirst() {
+        case let .data(chunk):
+            precondition(chunk.count <= count)
+            chunk.copyBytes(to: buffer!.assumingMemoryBound(to: UInt8.self), count: chunk.count)
+            return chunk.count
+        case .wouldBlock:
+            errno = EAGAIN
+            return -1
+        case .eof:
+            return 0
+        case let .error(errorCode):
+            errno = errorCode
+            return -1
+        }
+    }
+}


### PR DESCRIPTION
## Summary

A parked Context Builder/MCP call was anecdotally observed to resume after unrelated agent activity. The investigation found no direct cross-run wake path, but did identify two plausible causes: sustained socket input could delay complete-frame delivery until the reader reached `EAGAIN`, and terminal/reconnect cleanup could race with newer connection state.

This change:
- bounds reader work per readable event so complete frames are delivered fairly;
- makes terminal cleanup exactly-once and generation-fenced, with fresh inbound channels on reconnect;
- adds production-path Context Builder coverage for cancellation, successor success, and ignored late events;
- verifies the per-connection limiter deterministically, including distinct concurrent connections.

No inactivity deadline was added; parked operations retain their existing timeout semantics.

## Validation

- Push preflight: whitespace check, repository guardrails, outgoing-range secret scan, strict Swift lint, full root test suite, and `RepoPrompt` / `repoprompt-mcp` product builds
- Focused lifecycle/socket suites: `ContextBuilderRunLifecycleTests`, `NewlineDelimitedSocketReaderFairnessTests`, `UnixSocketMCPTerminalCleanupTests`, `PersistentMCPDistinctConnectionConcurrencyTests`, `MCPSocketDescriptorHardeningTests`, and `UnixSocketMCPReceiveOverflowTests`
- Non-disruptive CE MCP smoke: `make dev-smoke`
