### PR TITLE
Allow ad-hoc release manifests without designated requirements

### DIFF
--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -380,10 +380,16 @@ case "$*" in
 PLIST
     ;;
   *-r-*)
-    [[ "${FAKE_MISSING_REQUIREMENT:-0}" != "1" ]] || exit 1
+    [[ "${FAKE_MISSING_REQUIREMENT:-0}" != "1" ]] || exit 0
     printf 'designated => identifier "fixture"\n' >&2
     ;;
-  *) printf 'Identifier=fixture\nTeamIdentifier=not set\n' >&2 ;;
+  *)
+    if [[ "${FAKE_CERTIFICATE_BACKED:-0}" == "1" ]]; then
+      printf 'Identifier=fixture\nTeamIdentifier=TEAMID\nAuthority=Developer ID Application: Fixture\n' >&2
+    else
+      printf 'Identifier=fixture\nTeamIdentifier=not set\n' >&2
+    fi
+    ;;
 esac
 """,
             encoding="utf-8",
@@ -437,12 +443,57 @@ esac
             text=True,
             capture_output=True,
         )
-        self.assertNotEqual(missing_requirement.returncode, 0)
-        self.assertIn("could not read designated requirement", missing_requirement.stderr)
-        env.pop("FAKE_MISSING_REQUIREMENT")
+        self.assertEqual(missing_requirement.returncode, 0, missing_requirement.stderr)
+        missing_requirement_manifest = json.loads(
+            (app.parent / "missing-requirement.json").read_text(encoding="utf-8")
+        )
+        self.assertIsNone(missing_requirement_manifest["bundle_signing"]["designated_requirement"])
+        for executable in missing_requirement_manifest["executables"]:
+            self.assertIsNone(executable["signing"]["designated_requirement"])
+
+        env["FAKE_CERTIFICATE_BACKED"] = "1"
+        certificate_backed_missing_requirement = subprocess.run(
+            [
+                str(writer),
+                "write",
+                "--app",
+                str(app),
+                "--output",
+                str(app.parent / "certificate-backed-missing-requirement.json"),
+            ],
+            env=env,
+            text=True,
+            capture_output=True,
+        )
+        self.assertNotEqual(certificate_backed_missing_requirement.returncode, 0)
+        self.assertIn(
+            "certificate-backed signed path did not expose a designated requirement",
+            certificate_backed_missing_requirement.stderr,
+        )
+        env.pop("FAKE_CERTIFICATE_BACKED")
 
         info["RepoPromptSigningMode"] = "developer-id"
         (app / "Contents" / "Info.plist").write_bytes(plistlib.dumps(info))
+        developer_id_missing_requirement = subprocess.run(
+            [
+                str(writer),
+                "write",
+                "--app",
+                str(app),
+                "--output",
+                str(app.parent / "developer-id-missing-requirement.json"),
+            ],
+            env=env,
+            text=True,
+            capture_output=True,
+        )
+        self.assertNotEqual(developer_id_missing_requirement.returncode, 0)
+        self.assertIn(
+            "signed path did not expose a designated requirement",
+            developer_id_missing_requirement.stderr,
+        )
+        env.pop("FAKE_MISSING_REQUIREMENT")
+
         env["FAKE_MISSING_ENTITLEMENTS"] = "1"
         missing_entitlements = subprocess.run(
             [str(writer), "write", "--app", str(app), "--output", str(app.parent / "missing-entitlements.json")],

--- a/Scripts/write_app_artifact_manifest.py
+++ b/Scripts/write_app_artifact_manifest.py
@@ -38,7 +38,7 @@ def architectures(path: Path) -> list[str]:
     return sorted(set((result.stdout or "").split()))
 
 
-def signing_details(path: Path) -> dict[str, Any]:
+def signing_details(path: Path, *, allow_adhoc_without_requirement: bool = False) -> dict[str, Any]:
     codesign = os.environ.get("CODESIGN", "codesign")
     details = run([codesign, "-dv", "--verbose=4", str(path)])
     if details.returncode != 0:
@@ -51,7 +51,7 @@ def signing_details(path: Path) -> dict[str, Any]:
             values.setdefault(key.strip(), []).append(value.strip())
 
     requirement_result = run([codesign, "-d", "-r-", str(path)])
-    if requirement_result.returncode != 0:
+    if requirement_result.returncode != 0 and not allow_adhoc_without_requirement:
         fail(f"could not read designated requirement for {path}")
     requirement_text = "\n".join(
         filter(None, [requirement_result.stdout or "", requirement_result.stderr or ""])
@@ -61,9 +61,6 @@ def signing_details(path: Path) -> dict[str, Any]:
         if line.startswith("designated => "):
             designated_requirement = line.removeprefix("designated => ").strip()
             break
-    if not designated_requirement:
-        fail(f"signed path did not expose a designated requirement: {path}")
-
     entitlements_result = run([codesign, "-d", "--entitlements", ":-", str(path)], binary=True)
     entitlement_hash = None
     if entitlements_result.returncode == 0:
@@ -95,6 +92,11 @@ def signing_details(path: Path) -> dict[str, Any]:
     if team in {"", "not set"}:
         team = None
     authorities = values.get("Authority", [])
+    if not designated_requirement:
+        if not allow_adhoc_without_requirement:
+            fail(f"signed path did not expose a designated requirement: {path}")
+        if team is not None or authorities or certificate_sha256 is not None:
+            fail(f"certificate-backed signed path did not expose a designated requirement: {path}")
     return {
         "identifier": (values.get("Identifier") or [None])[0],
         "team_identifier": team,
@@ -105,7 +107,12 @@ def signing_details(path: Path) -> dict[str, Any]:
     }
 
 
-def executable_entry(app: Path, relative: str) -> dict[str, Any]:
+def executable_entry(
+    app: Path,
+    relative: str,
+    *,
+    allow_adhoc_without_requirement: bool = False,
+) -> dict[str, Any]:
     path = app / relative
     if not path.is_file() or path.is_symlink():
         fail(f"manifest executable must be a non-symlink regular file: {path}")
@@ -113,7 +120,10 @@ def executable_entry(app: Path, relative: str) -> dict[str, Any]:
         "path": relative,
         "architectures": architectures(path),
         "sha256": sha256(path),
-        "signing": signing_details(path),
+        "signing": signing_details(
+            path,
+            allow_adhoc_without_requirement=allow_adhoc_without_requirement,
+        ),
     }
 
 
@@ -129,9 +139,19 @@ def collect_manifest(app: Path, expected_architectures: list[str] | None) -> dic
     executable_name = info.get("CFBundleExecutable")
     if not isinstance(executable_name, str) or not executable_name:
         fail("Info.plist is missing CFBundleExecutable")
+    signing_mode = info.get("RepoPromptSigningMode")
+    allow_adhoc_without_requirement = signing_mode == "release-candidate-adhoc"
     entries = [
-        executable_entry(app, f"Contents/MacOS/{executable_name}"),
-        executable_entry(app, "Contents/MacOS/repoprompt-mcp"),
+        executable_entry(
+            app,
+            f"Contents/MacOS/{executable_name}",
+            allow_adhoc_without_requirement=allow_adhoc_without_requirement,
+        ),
+        executable_entry(
+            app,
+            "Contents/MacOS/repoprompt-mcp",
+            allow_adhoc_without_requirement=allow_adhoc_without_requirement,
+        ),
     ]
     architecture_sets = {tuple(entry["architectures"]) for entry in entries}
     if len(architecture_sets) != 1:
@@ -143,8 +163,11 @@ def collect_manifest(app: Path, expected_architectures: list[str] | None) -> dic
             f"expected {expected_architectures}, got {actual_architectures}"
         )
 
-    bundle_signing = signing_details(app)
-    if info.get("RepoPromptSigningMode") == "developer-id" and bundle_signing["entitlements_sha256"] is None:
+    bundle_signing = signing_details(
+        app,
+        allow_adhoc_without_requirement=allow_adhoc_without_requirement,
+    )
+    if signing_mode == "developer-id" and bundle_signing["entitlements_sha256"] is None:
         fail("Developer ID app did not expose parseable signed entitlements")
     return {
         "schema_version": 1,
@@ -152,7 +175,7 @@ def collect_manifest(app: Path, expected_architectures: list[str] | None) -> dic
             "identifier": info.get("CFBundleIdentifier"),
             "marketing_version": info.get("CFBundleShortVersionString"),
             "build_number": info.get("CFBundleVersion"),
-            "signing_mode": info.get("RepoPromptSigningMode"),
+            "signing_mode": signing_mode,
             "architecture_policy": "universal-public"
             if actual_architectures == ["arm64", "x86_64"]
             else "host-native",


### PR DESCRIPTION
Fixes the v1.0.7 release candidate and protected staging failure introduced by strict artifact-manifest signing metadata validation.

- allows missing designated requirements only for `release-candidate-adhoc` bundles
- still rejects certificate-backed paths without designated requirements
- keeps Developer ID verification strict
- adds focused regression coverage

Validation: `python3 Scripts/test_release_tooling.py`, `make release-selftest`, `make guardrails`, contribution commit/push preflights.