### PR TITLE
Add docstring to PromptFileEntry struct

### DIFF
--- a/Sources/RepoPrompt/Features/Prompt/Models/PromptFileEntry.swift
+++ b/Sources/RepoPrompt/Features/Prompt/Models/PromptFileEntry.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+/// Represents an entry in a prompt file, containing a file view model, a flag for codemap, and optional line ranges.
 struct PromptFileEntry {
     let file: FileViewModel
     let isCodemap: Bool


### PR DESCRIPTION
## Problem
The `PromptFileEntry` struct lacks a docstring, which reduces code readability and maintainability, especially if it's part of the public API. This makes it harder for developers to understand the struct's purpose and usage without inspecting the code.

## Solution
Added a Swift documentation comment (`///`) to the `PromptFileEntry` struct, describing its role as an entry in a prompt file and its properties (file view model, codemap flag, and optional line ranges). This aligns with Swift documentation best practices and improves code clarity.

## Verification
- Ensure the code compiles successfully without errors.
- Review the docstring in the codebase to confirm it accurately describes the struct.
- Optionally, use documentation tools (e.g., Xcode Quick Help) to verify the comment displays correctly.