### PR TITLE
Fix branch popover scroll containment

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/Views/Components/GitContextBranchSwitchCapsule.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Components/GitContextBranchSwitchCapsule.swift
@@ -114,24 +114,16 @@ struct GitContextBranchSwitchCapsule: View {
         context.branchDisplayText ?? "unknown branch"
     }
 
-    private var branchRowEstimatedHeight: CGFloat {
-        fontPreset.scaledClamped(34, min: 28, max: 44)
-    }
-
-    private var branchListMaxHeight: CGFloat {
-        fontPreset.scaledClamped(224, min: 168, max: 300)
-    }
-
     private var capsuleLabelMaxWidth: CGFloat {
         fontPreset.scaledClamped(88, min: 56, max: 128)
     }
 
-    private var popoverMinHeight: CGFloat {
-        fontPreset.scaledClamped(310, min: 260, max: 390)
+    private var popoverWidth: CGFloat {
+        fontPreset.scaledClamped(300, min: 280, max: 380)
     }
 
-    private var branchSectionHeaderEstimatedHeight: CGFloat {
-        fontPreset.scaledClamped(18, min: 14, max: 22)
+    private var popoverHeight: CGFloat {
+        fontPreset.scaledClamped(410, min: 360, max: 540)
     }
 
     private var branchSectionSpacing: CGFloat {
@@ -140,19 +132,6 @@ struct GitContextBranchSwitchCapsule: View {
 
     private var branchSectionContentSpacing: CGFloat {
         2
-    }
-
-    private func branchListViewportHeight(for presentation: BranchSwitchBranchListPresentation) -> CGFloat {
-        let visibleRowCount = min(CGFloat(presentation.branchCount), 8)
-        let visibleSectionCount = min(CGFloat(presentation.sections.count), max(1, visibleRowCount))
-        let sectionHeaderHeight = visibleSectionCount * branchSectionHeaderEstimatedHeight
-        let sectionSpacing = max(0, visibleSectionCount - 1) * branchSectionSpacing
-        let headerContentSpacing = visibleRowCount * branchSectionContentSpacing
-        let estimatedHeight = visibleRowCount * branchRowEstimatedHeight
-            + sectionHeaderHeight
-            + sectionSpacing
-            + headerContentSpacing
-        return min(branchListMaxHeight, estimatedHeight)
     }
 
     var body: some View {
@@ -233,41 +212,43 @@ struct GitContextBranchSwitchCapsule: View {
 
             Divider()
 
-            if isLoading {
-                ProgressView().controlSize(.small)
-            }
+            VStack(alignment: .leading, spacing: 8) {
+                if isLoading {
+                    ProgressView().controlSize(.small)
+                }
 
-            if let actionErrorMessage {
-                Text(actionErrorMessage)
-                    .font(fontPreset.swiftUIFont(sizeAtNormal: 11))
-                    .foregroundStyle(.orange)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
+                if let actionErrorMessage {
+                    Text(actionErrorMessage)
+                        .font(fontPreset.swiftUIFont(sizeAtNormal: 11))
+                        .foregroundStyle(.orange)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
 
-            if isLoading {
-                EmptyView()
-            } else if let optionErrorMessage {
-                VStack(alignment: .leading, spacing: 6) {
-                    Text(optionErrorMessage)
+                if isLoading {
+                    EmptyView()
+                } else if let optionErrorMessage {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text(optionErrorMessage)
+                            .font(fontPreset.swiftUIFont(sizeAtNormal: 11))
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                        Button("Reload branches") {
+                            startUITask { await reloadOptions() }
+                        }
+                        .font(fontPreset.swiftUIFont(sizeAtNormal: 11))
+                    }
+                } else if let options {
+                    branchList(options)
+                } else {
+                    Text("Open the menu to load local branches.")
                         .font(fontPreset.swiftUIFont(sizeAtNormal: 11))
                         .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                    Button("Reload branches") {
-                        startUITask { await reloadOptions() }
-                    }
-                    .font(fontPreset.swiftUIFont(sizeAtNormal: 11))
                 }
-            } else if let options {
-                branchList(options)
-            } else {
-                Text("Open the menu to load local branches.")
-                    .font(fontPreset.swiftUIFont(sizeAtNormal: 11))
-                    .foregroundStyle(.secondary)
             }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         }
         .padding(12)
-        .frame(width: fontPreset.scaledClamped(300, min: 280, max: 380), alignment: .leading)
-        .frame(minHeight: popoverMinHeight, alignment: .topLeading)
+        .frame(width: popoverWidth, height: popoverHeight, alignment: .topLeading)
     }
 
     private func branchList(_ options: GitBranchSwitchOptions) -> some View {
@@ -315,11 +296,13 @@ struct GitContextBranchSwitchCapsule: View {
                             }
                         }
                     }
+                    .frame(maxWidth: .infinity, alignment: .leading)
                 }
-                .frame(height: branchListViewportHeight(for: presentation))
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
                 .scrollIndicators(.automatic)
             }
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
 
     private struct BranchSwitchBranchRow: View {

--- a/Sources/RepoPrompt/Features/AgentMode/Views/Components/GitContextBranchSwitchCapsule.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Components/GitContextBranchSwitchCapsule.swift
@@ -213,10 +213,6 @@ struct GitContextBranchSwitchCapsule: View {
             Divider()
 
             VStack(alignment: .leading, spacing: 8) {
-                if isLoading {
-                    ProgressView().controlSize(.small)
-                }
-
                 if let actionErrorMessage {
                     Text(actionErrorMessage)
                         .font(fontPreset.swiftUIFont(sizeAtNormal: 11))
@@ -225,7 +221,7 @@ struct GitContextBranchSwitchCapsule: View {
                 }
 
                 if isLoading {
-                    EmptyView()
+                    ProgressView().controlSize(.small)
                 } else if let optionErrorMessage {
                     VStack(alignment: .leading, spacing: 6) {
                         Text(optionErrorMessage)

--- a/Sources/RepoPrompt/Features/AgentMode/Views/Components/GitContextBranchSwitchCapsule.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Components/GitContextBranchSwitchCapsule.swift
@@ -159,7 +159,7 @@ struct GitContextBranchSwitchCapsule: View {
         }
         .buttonStyle(.plain)
         .disabled(isSwitching)
-        .hoverTooltip(context.tooltipText + "\nClick to switch local branches in this checkout.", .top)
+        .hoverTooltip(context.tooltipText, .top)
         .accessibilityLabel(context.accessibilityText)
         .popover(isPresented: $showPopover, arrowEdge: .trailing) {
             popoverContent

--- a/Sources/RepoPrompt/Features/AgentMode/Views/Components/GitContextBranchSwitchCapsule.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Components/GitContextBranchSwitchCapsule.swift
@@ -271,7 +271,7 @@ struct GitContextBranchSwitchCapsule: View {
                     .foregroundStyle(.secondary)
             } else {
                 ScrollView(.vertical) {
-                    LazyVStack(alignment: .leading, spacing: branchSectionSpacing) {
+                    VStack(alignment: .leading, spacing: branchSectionSpacing) {
                         ForEach(presentation.sections) { section in
                             VStack(alignment: .leading, spacing: branchSectionContentSpacing) {
                                 Text(section.title)

--- a/Sources/RepoPrompt/Features/AgentMode/Views/Components/GitContextBranchSwitchCapsule.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Components/GitContextBranchSwitchCapsule.swift
@@ -126,6 +126,10 @@ struct GitContextBranchSwitchCapsule: View {
         fontPreset.scaledClamped(410, min: 360, max: 540)
     }
 
+    private var branchListMinimumHeight: CGFloat {
+        fontPreset.scaledClamped(168, min: 150, max: 220)
+    }
+
     private var branchSectionSpacing: CGFloat {
         6
     }
@@ -204,11 +208,11 @@ struct GitContextBranchSwitchCapsule: View {
             Text(context.tooltipText)
                 .font(fontPreset.swiftUIFont(sizeAtNormal: 10))
                 .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
+                .lineLimit(6)
             Text("Switches this checkout in place. It does not create or select another worktree.")
                 .font(fontPreset.swiftUIFont(sizeAtNormal: 10))
                 .foregroundStyle(.tertiary)
-                .fixedSize(horizontal: false, vertical: true)
+                .lineLimit(2)
 
             Divider()
 
@@ -217,7 +221,9 @@ struct GitContextBranchSwitchCapsule: View {
                     Text(actionErrorMessage)
                         .font(fontPreset.swiftUIFont(sizeAtNormal: 11))
                         .foregroundStyle(.orange)
-                        .fixedSize(horizontal: false, vertical: true)
+                        .lineLimit(2)
+                        .help(actionErrorMessage)
+                        .accessibilityLabel(actionErrorMessage)
                 }
 
                 if isLoading {
@@ -227,7 +233,9 @@ struct GitContextBranchSwitchCapsule: View {
                         Text(optionErrorMessage)
                             .font(fontPreset.swiftUIFont(sizeAtNormal: 11))
                             .foregroundStyle(.secondary)
-                            .fixedSize(horizontal: false, vertical: true)
+                            .lineLimit(3)
+                            .help(optionErrorMessage)
+                            .accessibilityLabel(optionErrorMessage)
                         Button("Reload branches") {
                             startUITask { await reloadOptions() }
                         }
@@ -298,7 +306,12 @@ struct GitContextBranchSwitchCapsule: View {
                 .scrollIndicators(.automatic)
             }
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .frame(
+            maxWidth: .infinity,
+            minHeight: branchListMinimumHeight,
+            maxHeight: .infinity,
+            alignment: .topLeading
+        )
     }
 
     private struct BranchSwitchBranchRow: View {

--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPGitToolProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPGitToolProvider.swift
@@ -15,6 +15,28 @@ final class MCPGitToolProvider: MCPWindowToolProviding {
         self.dependencies = dependencies
     }
 
+    nonisolated static func worktreeWarning(from worktree: ToolResultDTOs.GitToolReplyDTO.WorktreeDTO?) -> String? {
+        guard let worktree, worktree.isWorktree else { return nil }
+        var parts: [String] = []
+        parts.append("[Worktree] Git operations are scoped to this checkout.")
+        if let branch = worktree.worktreeBranch {
+            let head = worktree.worktreeHead.map { "@\($0)" } ?? ""
+            parts.append("This: \(branch)\(head).")
+        }
+        if let mainRoot = worktree.mainWorktreeRoot {
+            var mainLabel = "Main: \(mainRoot)"
+            if let mainBranch = worktree.mainBranch {
+                let head = worktree.mainHead.map { "@\($0)" } ?? ""
+                mainLabel += " (\(mainBranch)\(head))"
+            }
+            parts.append(mainLabel + ".")
+            parts.append("Use repo_root=\"@main\" for main checkout, repo_root=\"@main:<branch>\" to target a worktree by branch, or compare=\"main\" for trunk diff.")
+        } else {
+            parts.append("The primary checkout path could not be resolved. Pass its full path as repo_root to target it; compare=\"main\" still selects the trunk comparison base.")
+        }
+        return parts.joined(separator: " ")
+    }
+
     func buildTools() -> [Tool] {
         [gitTool()]
     }
@@ -266,12 +288,15 @@ final class MCPGitToolProvider: MCPWindowToolProviding {
         func buildWorktreeDTO(for repoURL: URL) async -> Reply.WorktreeDTO? {
             let backend = await vcsService.backend(forRepoRoot: repoURL)
             guard backend.kind == .git else { return nil }
-            guard let layout = GitRepositoryLayoutResolver.resolve(atWorkTreeRoot: repoURL), layout.isWorktree else { return nil }
+            guard let layout = GitRepositoryLayoutResolver.resolve(atWorkTreeRoot: repoURL), layout.isLinkedWorktree else { return nil }
 
             let worktreeRoot = layout.workTreeRoot.path
             let worktreeName = layout.gitDir.lastPathComponent.isEmpty ? nil : layout.gitDir.lastPathComponent
             let commonGitDir = layout.commonDir.path
-            let mainRoot = GitRepoTargetResolver.resolveMainWorktreeRoot(for: layout)
+            let listedMainRoot = try? await vcsService.listGitWorktrees(at: repoURL)
+                .first(where: \.isMain)
+                .map { URL(fileURLWithPath: $0.path).standardizedFileURL }
+            let mainRoot = listedMainRoot ?? GitRepoTargetResolver.resolveMainWorktreeRoot(for: layout)
 
             let wtBranch = try? await backend.getCurrentBranch(at: repoURL)
             let wtHead = await (try? backend.getHeadID(at: repoURL)).map { String($0.prefix(7)) }
@@ -298,23 +323,7 @@ final class MCPGitToolProvider: MCPWindowToolProviding {
         }
 
         func buildWorktreeWarning(from worktree: Reply.WorktreeDTO?) -> String? {
-            guard let worktree, worktree.isWorktree else { return nil }
-            var parts: [String] = []
-            parts.append("[Worktree] Git operations are scoped to this checkout.")
-            if let branch = worktree.worktreeBranch {
-                let head = worktree.worktreeHead.map { "@\($0)" } ?? ""
-                parts.append("This: \(branch)\(head).")
-            }
-            if let mainRoot = worktree.mainWorktreeRoot {
-                var mainLabel = "Main: \(mainRoot)"
-                if let mainBranch = worktree.mainBranch {
-                    let head = worktree.mainHead.map { "@\($0)" } ?? ""
-                    mainLabel += " (\(mainBranch)\(head))"
-                }
-                parts.append(mainLabel + ".")
-            }
-            parts.append("Use repo_root=\"@main\" for main checkout, repo_root=\"@main:<branch>\" to target a worktree by branch, or compare=\"main\" for trunk diff.")
-            return parts.joined(separator: " ")
+            Self.worktreeWarning(from: worktree)
         }
 
         func combineWarnings(_ warnings: [String?]) -> String? {

--- a/Sources/RepoPrompt/Infrastructure/VCS/GitDiff/GitDiffSnapshotStore.swift
+++ b/Sources/RepoPrompt/Infrastructure/VCS/GitDiff/GitDiffSnapshotStore.swift
@@ -778,22 +778,22 @@ struct GitDiffSnapshotStore {
         return url.path
     }
 
-    private func worktreeMetadata(for repoRoot: String?) -> (isWorktree: Bool?, worktreeName: String?, worktreeRoot: String?, mainWorktreeRoot: String?, commonGitDir: String?) {
+    func worktreeMetadata(for repoRoot: String?) -> (isWorktree: Bool?, worktreeName: String?, worktreeRoot: String?, mainWorktreeRoot: String?, commonGitDir: String?) {
         guard let repoRoot, !repoRoot.isEmpty else {
             return (nil, nil, nil, nil, nil)
         }
         let rootURL = URL(fileURLWithPath: repoRoot)
-        guard let layout = GitRepositoryLayoutResolver.resolve(atWorkTreeRoot: rootURL), layout.isWorktree else {
+        guard let layout = GitRepositoryLayoutResolver.resolve(atWorkTreeRoot: rootURL), layout.isLinkedWorktree else {
             return (nil, nil, nil, nil, nil)
         }
-        let candidate: URL = if layout.commonDir.lastPathComponent == ".git" {
-            layout.commonDir.deletingLastPathComponent()
-        } else {
-            layout.commonDir
-        }
-        let mainRoot = FileManager.default.fileExists(atPath: candidate.path) ? candidate.path : nil
         let worktreeName = layout.gitDir.lastPathComponent.isEmpty ? nil : layout.gitDir.lastPathComponent
-        return (true, worktreeName, layout.workTreeRoot.path, mainRoot, layout.commonDir.path)
+        return (
+            true,
+            worktreeName,
+            layout.workTreeRoot.path,
+            layout.knownMainWorktreeRoot?.path,
+            layout.commonDir.path
+        )
     }
 
     private func buildHunkIndex(for diffText: String) -> [DiffHunkIndex]? {

--- a/Sources/RepoPrompt/Infrastructure/VCS/GitRepoTargetResolver.swift
+++ b/Sources/RepoPrompt/Infrastructure/VCS/GitRepoTargetResolver.swift
@@ -297,13 +297,17 @@ struct GitRepoTargetResolver {
                 }
                 throw GitRepoTargetResolverError.invalidParams("No worktree found for branch '\(branch)'. Use repo_root=\"@main\" for the main checkout or pass a full worktree path.")
             }
-            if let layout = GitRepositoryLayoutResolver.resolve(atWorkTreeRoot: repo.rootURL), layout.isWorktree,
-               let mainRoot = Self.resolveMainWorktreeRoot(for: layout)
-            {
-                return GitRepoDescriptor(rootURL: mainRoot)
-            }
-            if GitRepositoryLayoutResolver.resolve(atWorkTreeRoot: repo.rootURL) != nil {
-                return repo
+            if let layout = GitRepositoryLayoutResolver.resolve(atWorkTreeRoot: repo.rootURL) {
+                if !layout.isLinkedWorktree {
+                    return repo
+                }
+                if let mainRoot = Self.resolveMainWorktreeRoot(for: layout) {
+                    return GitRepoDescriptor(rootURL: mainRoot)
+                }
+                if let main = try await mainWorktree(for: repo) {
+                    return GitRepoDescriptor(rootURL: URL(fileURLWithPath: main.path))
+                }
+                throw GitRepoTargetResolverError.invalidParams("The main checkout path could not be resolved for repo: \(repo.rootPath)")
             }
             if let main = try await mainWorktree(for: repo), !samePath(main.path, repo.rootPath) {
                 return GitRepoDescriptor(rootURL: URL(fileURLWithPath: main.path))
@@ -438,12 +442,7 @@ struct GitRepoTargetResolver {
     // MARK: - Legacy worktree layout helpers
 
     static func resolveMainWorktreeRoot(for layout: GitRepositoryLayout) -> URL? {
-        let candidate: URL = if layout.commonDir.lastPathComponent == ".git" {
-            layout.commonDir.deletingLastPathComponent()
-        } else {
-            layout.commonDir
-        }
-        return FileManager.default.fileExists(atPath: candidate.path) ? candidate : nil
+        layout.knownMainWorktreeRoot
     }
 
     private func readHeadRef(from headURL: URL) -> String? {

--- a/Sources/RepoPrompt/Infrastructure/VCS/GitRepositoryLayout.swift
+++ b/Sources/RepoPrompt/Infrastructure/VCS/GitRepositoryLayout.swift
@@ -23,8 +23,38 @@ public struct GitRepositoryLayout: Sendable, Equatable {
     /// For worktrees: the main repo's `.git` directory
     public let commonDir: URL
 
-    /// Whether this is a gitfile-based worktree (`.git` is a file, not a directory).
+    /// Whether this checkout uses a gitfile (`.git` is a file, not a directory).
+    ///
+    /// A gitfile can represent either a linked worktree or a primary checkout created with
+    /// `git init --separate-git-dir`; use `isLinkedWorktree` when that distinction matters.
     public let isWorktree: Bool
+
+    /// Whether this checkout has a per-worktree git directory distinct from the shared common directory.
+    public var isLinkedWorktree: Bool {
+        gitDir.standardizedFileURL.path != commonDir.standardizedFileURL.path
+    }
+
+    /// The primary checkout root when it can be established without invoking Git.
+    ///
+    /// Primary checkouts, including `--separate-git-dir`, are authoritative for themselves.
+    /// Linked worktrees can only infer the main checkout from a conventional `<root>/.git`
+    /// common directory. External common directories require structured Git metadata.
+    public var knownMainWorktreeRoot: URL? {
+        if !isLinkedWorktree {
+            return workTreeRoot.standardizedFileURL
+        }
+        guard commonDir.lastPathComponent == ".git" else {
+            return nil
+        }
+        let candidate = commonDir.deletingLastPathComponent().standardizedFileURL
+        guard let candidateLayout = GitRepositoryLayoutResolver.resolve(atWorkTreeRoot: candidate),
+              !candidateLayout.isLinkedWorktree,
+              candidateLayout.commonDir.standardizedFileURL.path == commonDir.standardizedFileURL.path
+        else {
+            return nil
+        }
+        return candidate
+    }
 }
 
 // MARK: - Git Repository Layout Resolver

--- a/Sources/RepoPrompt/Infrastructure/VCS/GitService.swift
+++ b/Sources/RepoPrompt/Infrastructure/VCS/GitService.swift
@@ -121,7 +121,7 @@ actor GitService {
 
         if exitCode == 0 {
             let records = try GitWorktreePorcelainParser.parse(stdout, format: .nulTerminated)
-            return try makeWorktreeDescriptors(from: records, currentRepoURL: repoURL)
+            return try await makeWorktreeDescriptors(from: records, currentRepoURL: repoURL)
         }
 
         guard Self.shouldFallbackFromWorktreeListZError(stderr) else {
@@ -137,7 +137,7 @@ actor GitService {
         }
 
         let records = try GitWorktreePorcelainParser.parse(fallbackStdout, format: .newlineTerminated)
-        return try makeWorktreeDescriptors(from: records, currentRepoURL: repoURL)
+        return try await makeWorktreeDescriptors(from: records, currentRepoURL: repoURL)
     }
 
     /// Create a Git worktree using the existing Git subprocess plumbing.
@@ -2437,15 +2437,87 @@ actor GitService {
             || lowercased.contains("usage: git worktree")
     }
 
+    private func resolveMainWorktreeRoot(
+        for layout: GitRepositoryLayout,
+        at repoURL: URL
+    ) async -> URL? {
+        if let knownRoot = layout.knownMainWorktreeRoot {
+            return knownRoot
+        }
+
+        let queries: [(arguments: [String], directory: URL, requiresRepoContext: Bool)] = [
+            (["config", "--path", "--get", "core.worktree"], repoURL, true),
+            (["--git-dir", layout.commonDir.path, "config", "--worktree", "--path", "--get", "core.worktree"], layout.commonDir, false)
+        ]
+        for query in queries {
+            guard let result = try? await runGit(
+                query.arguments,
+                at: query.directory,
+                requiresRepoContext: query.requiresRepoContext
+            ), result.2 == 0
+            else {
+                continue
+            }
+            let rawPath = result.0.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !rawPath.isEmpty else { continue }
+
+            let candidate = if rawPath.hasPrefix("/") {
+                URL(fileURLWithPath: rawPath).standardizedFileURL
+            } else {
+                layout.commonDir.appendingPathComponent(rawPath).standardizedFileURL
+            }
+            guard let candidateLayout = getLayout(for: candidate),
+                  !candidateLayout.isLinkedWorktree,
+                  candidateLayout.commonDir.standardizedFileURL.path == layout.commonDir.standardizedFileURL.path
+            else {
+                continue
+            }
+            return candidate
+        }
+        return nil
+    }
+
+    private func normalizedWorktreeRecords(
+        _ records: [GitWorktreePorcelainRecord],
+        currentLayout: GitRepositoryLayout?,
+        resolvedMainRoot: URL?
+    ) -> [GitWorktreePorcelainRecord] {
+        guard let currentLayout else { return records }
+        let commonGitDirPath = currentLayout.commonDir.standardizedFileURL.path
+
+        return records.compactMap { record in
+            let recordPath = URL(fileURLWithPath: record.path).standardizedFileURL.path
+            guard recordPath == commonGitDirPath else {
+                return record
+            }
+            guard let resolvedMainRoot else {
+                return nil
+            }
+            var normalized = record
+            normalized.path = resolvedMainRoot.standardizedFileURL.path
+            return normalized
+        }
+    }
+
     private func makeWorktreeDescriptors(
         from records: [GitWorktreePorcelainRecord],
         currentRepoURL: URL
-    ) throws -> [GitWorktreeDescriptor] {
-        let worktreeRecords = records.filter { !$0.isBare }
+    ) async throws -> [GitWorktreeDescriptor] {
+        let currentLayout = getLayout(for: currentRepoURL)
+        let resolvedMainRoot: URL? = if let currentLayout {
+            await resolveMainWorktreeRoot(for: currentLayout, at: currentRepoURL)
+        } else {
+            nil
+        }
+        let worktreeRecords = normalizedWorktreeRecords(
+            records.filter { !$0.isBare },
+            currentLayout: currentLayout,
+            resolvedMainRoot: resolvedMainRoot
+        )
         guard !worktreeRecords.isEmpty else { return [] }
 
         let layoutsByPath: [String: GitRepositoryLayout] = Dictionary(
-            uniqueKeysWithValues: worktreeRecords.compactMap { record in
+            uniqueKeysWithValues: worktreeRecords.compactMap { record -> (String, GitRepositoryLayout)? in
                 let pathURL = URL(fileURLWithPath: record.path)
                 guard let layout = GitRepositoryLayoutResolver.resolve(atWorkTreeRoot: pathURL) else {
                     return nil
@@ -2454,22 +2526,17 @@ actor GitService {
             }
         )
 
-        let currentLayout = getLayout(for: currentRepoURL)
         let commonGitDir = currentLayout?.commonDir
             ?? layoutsByPath.values.first?.commonDir
         guard let commonGitDir else {
             throw GitError(message: "git worktree list succeeded but repository layout could not be resolved")
         }
 
-        let mainPath = worktreeRecords.first { record in
+        let discoveredMainRoot = worktreeRecords.first { record in
             let path = URL(fileURLWithPath: record.path).standardizedFileURL.path
-            if let layout = layoutsByPath[path] {
-                return !layout.isWorktree && layout.gitDir.standardizedFileURL == layout.commonDir.standardizedFileURL
-            }
-            return false
-        }?.path
-
-        let mainURL = mainPath.map { URL(fileURLWithPath: $0).standardizedFileURL }
+            return layoutsByPath[path].map { !$0.isLinkedWorktree } ?? false
+        }.map { URL(fileURLWithPath: $0.path).standardizedFileURL }
+        let mainURL = resolvedMainRoot ?? discoveredMainRoot
         let repository = GitWorktreeIdentity.repositoryIdentity(
             commonGitDir: commonGitDir,
             mainWorktreeRoot: mainURL
@@ -2482,7 +2549,7 @@ actor GitService {
             let layout = layoutsByPath[path]
             let gitDir = layout?.gitDir.standardizedFileURL
             let isMain: Bool = if let layout {
-                !layout.isWorktree && layout.gitDir.standardizedFileURL == layout.commonDir.standardizedFileURL
+                !layout.isLinkedWorktree
             } else {
                 mainURL?.path == path && !record.isBare
             }

--- a/Sources/RepoPrompt/Infrastructure/VCS/GitWorktreeModels.swift
+++ b/Sources/RepoPrompt/Infrastructure/VCS/GitWorktreeModels.swift
@@ -81,6 +81,7 @@ public struct GitWorktreeContextSummary: Sendable, Equatable, Hashable {
     public let worktreeID: String?
     public let worktreePath: String
     public let worktreeName: String
+    public let isMain: Bool
     public let branch: String?
     public let head: String?
     public let isDetached: Bool
@@ -92,6 +93,7 @@ public struct GitWorktreeContextSummary: Sendable, Equatable, Hashable {
         worktreeID: String?,
         worktreePath: String,
         worktreeName: String,
+        isMain: Bool,
         branch: String?,
         head: String?,
         isDetached: Bool
@@ -102,6 +104,7 @@ public struct GitWorktreeContextSummary: Sendable, Equatable, Hashable {
         self.worktreeID = worktreeID
         self.worktreePath = worktreePath
         self.worktreeName = worktreeName
+        self.isMain = isMain
         self.branch = Self.normalizedOptional(branch)
         self.head = Self.normalizedOptional(head)
         self.isDetached = isDetached
@@ -115,6 +118,7 @@ public struct GitWorktreeContextSummary: Sendable, Equatable, Hashable {
             worktreeID: descriptor.worktreeID,
             worktreePath: descriptor.path,
             worktreeName: descriptor.name ?? Self.fallbackWorktreeName(from: descriptor.path),
+            isMain: descriptor.isMain,
             branch: descriptor.branch,
             head: descriptor.head,
             isDetached: descriptor.isDetached
@@ -141,23 +145,25 @@ public struct GitWorktreeContextSummary: Sendable, Equatable, Hashable {
             .joined(separator: " / ")
     }
 
+    public var checkoutDisplayText: String {
+        isMain ? "main repository checkout" : "linked worktree"
+    }
+
     public var tooltipText: String {
         let branchText = branchDisplayText ?? "unknown branch"
-        var parts = [
+        let parts = [
             "Repository: \(repositoryDisplayName)",
+            "Checkout: \(checkoutDisplayText)",
             "Worktree: \(worktreeName)",
             "Branch: \(branchText)",
             "Path: \(worktreePath)"
         ]
-        if let head {
-            parts.insert("HEAD: \(head)", at: 3)
-        }
         return parts.joined(separator: "\n")
     }
 
     public var accessibilityText: String {
         let branchText = branchDisplayText ?? "unknown branch"
-        return "Git repository \(repositoryDisplayName), worktree \(worktreeName), branch \(branchText)"
+        return "Git repository \(repositoryDisplayName), \(checkoutDisplayText) \(worktreeName), branch \(branchText)"
     }
 
     private var shortHead: String? {

--- a/Sources/RepoPrompt/Infrastructure/VCS/VCSService.swift
+++ b/Sources/RepoPrompt/Infrastructure/VCS/VCSService.swift
@@ -549,11 +549,10 @@ public extension VCSService {
         guard let layout = gitRepositoryLayout(forRepoRoot: repoURL) else {
             return nil
         }
-        let mainWorktreeRoot = layout.commonDir.deletingLastPathComponent()
-        let isMain = !layout.isWorktree
+        let isMain = !layout.isLinkedWorktree
         let identity = GitWorktreeIdentity.repositoryIdentity(
             commonGitDir: layout.commonDir,
-            mainWorktreeRoot: mainWorktreeRoot
+            mainWorktreeRoot: layout.knownMainWorktreeRoot
         )
         let branch = try? await gitBackend().getCurrentBranch(at: repoURL)
         let head = try? await gitBackend().getHeadID(at: repoURL)

--- a/Sources/RepoPrompt/Infrastructure/VCS/VCSService.swift
+++ b/Sources/RepoPrompt/Infrastructure/VCS/VCSService.swift
@@ -550,6 +550,7 @@ public extension VCSService {
             return nil
         }
         let mainWorktreeRoot = layout.commonDir.deletingLastPathComponent()
+        let isMain = !layout.isWorktree
         let identity = GitWorktreeIdentity.repositoryIdentity(
             commonGitDir: layout.commonDir,
             mainWorktreeRoot: mainWorktreeRoot
@@ -560,7 +561,7 @@ public extension VCSService {
         let worktreeID = GitWorktreeIdentity.worktreeID(
             repositoryID: identity.repositoryID,
             gitDir: layout.gitDir,
-            isMain: !layout.isWorktree,
+            isMain: isMain,
             path: layout.workTreeRoot
         )
         return GitWorktreeContextSummary(
@@ -570,6 +571,7 @@ public extension VCSService {
             worktreeID: worktreeID,
             worktreePath: repoRootPath,
             worktreeName: worktreeName,
+            isMain: isMain,
             branch: branch,
             head: head,
             isDetached: branch == nil && head != nil

--- a/Tests/RepoPromptTests/AgentMode/AgentWorkspaceRootsSidebarStoreTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentWorkspaceRootsSidebarStoreTests.swift
@@ -54,6 +54,7 @@ final class AgentWorkspaceRootsSidebarStoreTests: XCTestCase {
         XCTAssertNil(rows[0].gitContext)
         XCTAssertEqual(rows[1].gitContext, contextB)
         XCTAssertEqual(rows[1].gitContext?.breadcrumbText, "Repo / B / feature/b")
+        XCTAssertTrue(rows[1].gitContext?.isMain == true)
     }
 
     // MARK: - Worktree indicators (Item 10)
@@ -212,7 +213,8 @@ final class AgentWorkspaceRootsSidebarStoreTests: XCTestCase {
     private func makeGitContext(
         repository: String,
         worktree: String,
-        branch: String?
+        branch: String?,
+        isMain: Bool = true
     ) -> GitWorktreeContextSummary {
         GitWorktreeContextSummary(
             repositoryID: "gitrepo-test",
@@ -221,6 +223,7 @@ final class AgentWorkspaceRootsSidebarStoreTests: XCTestCase {
             worktreeID: "wt-test",
             worktreePath: "/tmp/\(worktree)",
             worktreeName: worktree,
+            isMain: isMain,
             branch: branch,
             head: "1234567890abcdef",
             isDetached: false

--- a/Tests/RepoPromptTests/MCP/ToolOutputFormatterWorktreeTests.swift
+++ b/Tests/RepoPromptTests/MCP/ToolOutputFormatterWorktreeTests.swift
@@ -4,6 +4,43 @@ import XCTest
 
 @MainActor
 final class ToolOutputFormatterWorktreeTests: XCTestCase {
+    func testGitWorktreeWarningRecommendsMainSelectorsOnlyWhenMainRootIsKnown() {
+        let warning = MCPGitToolProvider.worktreeWarning(from: .init(
+            isWorktree: true,
+            worktreeName: "feature",
+            worktreeRoot: "/tmp/repo-feature",
+            commonGitDir: "/tmp/repo/.git",
+            mainWorktreeRoot: "/tmp/repo",
+            worktreeBranch: "feature/demo",
+            mainBranch: "main",
+            worktreeHead: "abcdef1",
+            mainHead: "1234567"
+        ))
+
+        XCTAssertTrue(warning?.contains("repo_root=\"@main\"") == true)
+        XCTAssertTrue(warning?.contains("repo_root=\"@main:<branch>\"") == true)
+        XCTAssertFalse(warning?.contains("could not be resolved") == true)
+    }
+
+    func testGitWorktreeWarningUsesFullPathGuidanceWhenMainRootIsUnknown() {
+        let warning = MCPGitToolProvider.worktreeWarning(from: .init(
+            isWorktree: true,
+            worktreeName: "feature",
+            worktreeRoot: "/tmp/repo-feature",
+            commonGitDir: "/tmp/external-git-dir",
+            mainWorktreeRoot: nil,
+            worktreeBranch: "feature/demo",
+            mainBranch: nil,
+            worktreeHead: "abcdef1",
+            mainHead: nil
+        ))
+
+        XCTAssertTrue(warning?.contains("primary checkout path could not be resolved") == true)
+        XCTAssertTrue(warning?.contains("full path as repo_root") == true)
+        XCTAssertFalse(warning?.contains("repo_root=\"@main\"") == true)
+        XCTAssertFalse(warning?.contains("repo_root=\"@main:<branch>\"") == true)
+    }
+
     func testCreateOutputIncludesUsefulNextStepCommands() throws {
         let dto = ToolResultDTOs.ManageWorktreeReplyDTO(
             op: "create",

--- a/Tests/RepoPromptTests/Services/VCS/GitRepoTargetResolverTests.swift
+++ b/Tests/RepoPromptTests/Services/VCS/GitRepoTargetResolverTests.swift
@@ -2,6 +2,16 @@
 import XCTest
 
 final class GitRepoTargetResolverTests: XCTestCase {
+    private var temporaryRoots: [URL] = []
+
+    override func tearDownWithError() throws {
+        for root in temporaryRoots {
+            try? FileManager.default.removeItem(at: root)
+        }
+        temporaryRoots = []
+        try super.tearDownWithError()
+    }
+
     func testResolvesSupportedRepositorySelectorSyntax() async throws {
         let fixture = ResolverFixture()
         let scenarios = [
@@ -92,6 +102,42 @@ final class GitRepoTargetResolverTests: XCTestCase {
         XCTAssertEqual(repos.map(\.rootPath), [fixture.repoA.mainRepo.rootPath])
     }
 
+    func testSeparateGitDirPrimaryMainSpecifierKeepsCheckoutRoot() async throws {
+        let fixture = try makeSeparateGitDirFixture(addLinkedWorktree: false)
+        let resolver = makeLiveFixtureResolver(repo: fixture.repo, linked: nil)
+        let repo = GitRepoDescriptor(rootURL: fixture.repo)
+
+        let resolved = try await resolver.resolveRepoRoots(
+            explicitRootTokens: ["@main"],
+            allRepos: [repo],
+            visibleRoots: [WorkspaceRootRef(id: UUID(), name: "repo", fullPath: repo.rootPath)],
+            defaultRepo: repo
+        )
+
+        XCTAssertEqual(resolved.map(\.rootPath), [fixture.repo.standardizedFileURL.path])
+        XCTAssertNotEqual(resolved.first?.rootPath, fixture.gitDir.standardizedFileURL.path)
+    }
+
+    func testExternalCommonDirLinkedMainSpecifierFailsInsteadOfReturningGitDirectory() async throws {
+        let fixture = try makeSeparateGitDirFixture(addLinkedWorktree: true)
+        let linked = try XCTUnwrap(fixture.linked)
+        let resolver = makeLiveFixtureResolver(repo: fixture.repo, linked: linked)
+        let linkedRepo = GitRepoDescriptor(rootURL: linked)
+
+        do {
+            _ = try await resolver.resolveRepoRoots(
+                explicitRootTokens: ["@main"],
+                allRepos: [linkedRepo],
+                visibleRoots: [WorkspaceRootRef(id: UUID(), name: "linked", fullPath: linkedRepo.rootPath)],
+                defaultRepo: linkedRepo
+            )
+            XCTFail("Expected unresolved external main checkout to fail safely")
+        } catch let error as GitRepoTargetResolverError {
+            XCTAssertTrue(error.message.contains("main checkout path could not be resolved"))
+            XCTAssertFalse(error.message.contains(fixture.gitDir.standardizedFileURL.path))
+        }
+    }
+
     func testDuplicateWorktreeIDsAcrossReposRemainAmbiguous() async throws {
         let fixture = MultiRepoResolverFixture(duplicateLinkedWorktreeID: true)
 
@@ -105,6 +151,66 @@ final class GitRepoTargetResolverTests: XCTestCase {
             XCTFail("Expected duplicate cross-repo worktree IDs to be ambiguous")
         } catch let error as GitRepoTargetResolverError {
             XCTAssertTrue(error.message.contains("Ambiguous worktree selector"))
+        }
+    }
+
+    private func makeSeparateGitDirFixture(addLinkedWorktree: Bool) throws -> (repo: URL, gitDir: URL, linked: URL?) {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("GitRepoTargetResolverSeparateGitDirTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        temporaryRoots.append(root)
+
+        let repo = root.appendingPathComponent("repo", isDirectory: true)
+        let gitDir = root.appendingPathComponent("repo-git", isDirectory: true)
+        try runGit(["init", "-b", "main", "--separate-git-dir", gitDir.path, repo.path], cwd: root)
+        try runGit(["config", "user.email", "test@example.com"], cwd: repo)
+        try runGit(["config", "user.name", "Test User"], cwd: repo)
+        try "hello\n".write(to: repo.appendingPathComponent("README.md"), atomically: true, encoding: .utf8)
+        try runGit(["add", "."], cwd: repo)
+        try runGit(["commit", "-m", "Initial commit"], cwd: repo)
+
+        guard addLinkedWorktree else {
+            return (repo, gitDir, nil)
+        }
+        let linked = root.appendingPathComponent("repo-linked", isDirectory: true)
+        try runGit(["worktree", "add", "-b", "feature/linked", linked.path], cwd: repo)
+        return (repo, gitDir, linked)
+    }
+
+    private func makeLiveFixtureResolver(repo: URL, linked: URL?) -> GitRepoTargetResolver {
+        let service = VCSService()
+        let roots = [repo, linked].compactMap(\.self).map(\.standardizedFileURL)
+        return GitRepoTargetResolver(dependencies: .init(
+            resolveRepo: { url in
+                let path = url.standardizedFileURL.path
+                guard let root = roots.first(where: { path == $0.path || path.hasPrefix($0.path + "/") }) else {
+                    return nil
+                }
+                return GitRepoDescriptor(rootURL: root)
+            },
+            listWorktrees: { descriptor in
+                try await service.listGitWorktrees(at: descriptor.rootURL)
+            }
+        ))
+    }
+
+    private func runGit(_ arguments: [String], cwd: URL) throws {
+        var environment = ProcessInfo.processInfo.environment
+        environment["GIT_CONFIG_NOSYSTEM"] = "1"
+        environment["GIT_CONFIG_GLOBAL"] = "/dev/null"
+        environment["GIT_TERMINAL_PROMPT"] = "0"
+        let result = try TestProcessRunner.run(
+            executableURL: URL(fileURLWithPath: "/usr/bin/git"),
+            arguments: arguments,
+            currentDirectoryURL: cwd,
+            environment: environment
+        )
+        guard result.terminationStatus == 0 else {
+            throw NSError(
+                domain: "GitRepoTargetResolverTests",
+                code: Int(result.terminationStatus),
+                userInfo: [NSLocalizedDescriptionKey: result.outputText]
+            )
         }
     }
 }

--- a/Tests/RepoPromptTests/Services/VCS/GitWorktreeContextSummaryTests.swift
+++ b/Tests/RepoPromptTests/Services/VCS/GitWorktreeContextSummaryTests.swift
@@ -49,6 +49,120 @@ final class GitWorktreeContextResolverTests: XCTestCase {
         XCTAssertTrue(context.isMain)
         XCTAssertEqual(context.checkoutDisplayText, "main repository checkout")
         XCTAssertTrue(context.tooltipText.contains("Checkout: main repository checkout"))
+
+        let layout = try XCTUnwrap(GitRepositoryLayoutResolver.resolve(atWorkTreeRoot: repo))
+        XCTAssertFalse(layout.isWorktree)
+        XCTAssertFalse(layout.isLinkedWorktree)
+    }
+
+    func testSeparateGitDirPrimaryCheckoutIsNotTreatedAsLinkedWorktree() async throws {
+        let fixture = try makeSeparateGitDirFixture()
+        let service = VCSService()
+        let resolved = VCSResolvedRepo(rootURL: fixture.repo, backendKind: .git)
+
+        let layout = try XCTUnwrap(GitRepositoryLayoutResolver.resolve(atWorkTreeRoot: fixture.repo))
+        XCTAssertTrue(layout.isWorktree)
+        XCTAssertFalse(layout.isLinkedWorktree)
+        XCTAssertEqual(layout.gitDir.standardizedFileURL, fixture.gitDir.standardizedFileURL)
+        XCTAssertEqual(layout.commonDir.standardizedFileURL, fixture.gitDir.standardizedFileURL)
+        XCTAssertEqual(layout.knownMainWorktreeRoot, fixture.repo.standardizedFileURL)
+
+        let metadata = GitDiffSnapshotStore().worktreeMetadata(for: fixture.repo.path)
+        XCTAssertNil(metadata.isWorktree)
+        XCTAssertNil(metadata.mainWorktreeRoot)
+
+        let resolvedFallbackContext = await service.gitWorktreeContext(
+            for: fixture.repo,
+            resolved: resolved,
+            worktrees: nil
+        )
+        let fallbackContext = try XCTUnwrap(resolvedFallbackContext)
+        XCTAssertTrue(fallbackContext.isMain)
+        XCTAssertEqual(fallbackContext.repositoryDisplayName, fixture.repo.lastPathComponent)
+        XCTAssertEqual(fallbackContext.checkoutDisplayText, "main repository checkout")
+
+        let descriptors = try await service.listGitWorktrees(at: fixture.repo)
+        let descriptor = try XCTUnwrap(descriptors.first)
+        XCTAssertEqual(descriptors.count, 1)
+        XCTAssertEqual(URL(fileURLWithPath: descriptor.path).standardizedFileURL, fixture.repo.standardizedFileURL)
+        XCTAssertEqual(descriptor.gitDir.map { URL(fileURLWithPath: $0).standardizedFileURL }, fixture.gitDir.standardizedFileURL)
+        XCTAssertTrue(descriptor.isMain)
+        XCTAssertTrue(descriptor.isCurrent)
+        XCTAssertEqual(descriptor.repository.mainWorktreeRoot, fixture.repo.standardizedFileURL.path)
+        XCTAssertEqual(descriptor.repository.displayName, fixture.repo.lastPathComponent)
+
+        let resolvedListedContext = await service.gitWorktreeContext(for: fixture.repo)
+        let listedContext = try XCTUnwrap(resolvedListedContext)
+        XCTAssertTrue(listedContext.isMain)
+        XCTAssertEqual(listedContext.worktreePath, fixture.repo.standardizedFileURL.path)
+        XCTAssertEqual(listedContext.repositoryDisplayName, fixture.repo.lastPathComponent)
+    }
+
+    func testExternalCommonDirLinkedWorktreeOmitsUnresolvablePrimaryRecord() async throws {
+        let fixture = try makeSeparateGitDirFixture()
+        let linkedWorktree = fixture.repo.deletingLastPathComponent()
+            .appendingPathComponent("repo-linked", isDirectory: true)
+        try runGit(["worktree", "add", "-b", "feature/linked", linkedWorktree.path], cwd: fixture.repo)
+        let service = VCSService()
+
+        let descriptors = try await service.listGitWorktrees(at: linkedWorktree)
+        XCTAssertFalse(descriptors.contains { URL(fileURLWithPath: $0.path).standardizedFileURL == fixture.gitDir.standardizedFileURL })
+        XCTAssertFalse(descriptors.contains(where: \.isMain))
+        let linkedDescriptor = try XCTUnwrap(descriptors.first { $0.isCurrent })
+        XCTAssertEqual(URL(fileURLWithPath: linkedDescriptor.path).standardizedFileURL, linkedWorktree.standardizedFileURL)
+        XCTAssertFalse(linkedDescriptor.isMain)
+        XCTAssertNil(linkedDescriptor.repository.mainWorktreeRoot)
+
+        let resolved = VCSResolvedRepo(rootURL: linkedWorktree, backendKind: .git)
+        let resolvedFallback = await service.gitWorktreeContext(
+            for: linkedWorktree,
+            resolved: resolved,
+            worktrees: nil
+        )
+        let fallback = try XCTUnwrap(resolvedFallback)
+        XCTAssertFalse(fallback.isMain)
+        XCTAssertEqual(fallback.checkoutDisplayText, "linked worktree")
+
+        let metadata = GitDiffSnapshotStore().worktreeMetadata(for: linkedWorktree.path)
+        XCTAssertEqual(metadata.isWorktree, true)
+        XCTAssertEqual(metadata.worktreeRoot, linkedWorktree.standardizedFileURL.path)
+        XCTAssertNil(metadata.mainWorktreeRoot)
+    }
+
+    func testExternalCommonDirLinkedWorktreeUsesConfiguredCoreWorktree() async throws {
+        let fixture = try makeSeparateGitDirFixture()
+        let linkedWorktree = fixture.repo.deletingLastPathComponent()
+            .appendingPathComponent("repo-linked", isDirectory: true)
+        try runGit(["worktree", "add", "-b", "feature/linked", linkedWorktree.path], cwd: fixture.repo)
+        try runGit(["config", "core.worktree", fixture.repo.path], cwd: fixture.repo)
+
+        let descriptors = try await VCSService().listGitWorktrees(at: linkedWorktree)
+        let main = try XCTUnwrap(descriptors.first(where: \.isMain))
+        XCTAssertEqual(URL(fileURLWithPath: main.path).standardizedFileURL, fixture.repo.standardizedFileURL)
+        XCTAssertEqual(main.repository.mainWorktreeRoot, fixture.repo.standardizedFileURL.path)
+        XCTAssertTrue(descriptors.contains { $0.isCurrent && URL(fileURLWithPath: $0.path).standardizedFileURL == linkedWorktree.standardizedFileURL })
+    }
+
+    func testExternalCommonDirLinkedWorktreeUsesWorktreeConfigCoreWorktree() async throws {
+        let fixture = try makeSeparateGitDirFixture()
+        let linkedWorktree = fixture.repo.deletingLastPathComponent()
+            .appendingPathComponent("repo-linked", isDirectory: true)
+        try runGit(["worktree", "add", "-b", "feature/linked", linkedWorktree.path], cwd: fixture.repo)
+        try runGit(["config", "extensions.worktreeConfig", "true"], cwd: fixture.repo)
+        try runGit(["config", "--worktree", "core.worktree", fixture.repo.path], cwd: fixture.repo)
+
+        let normalQuery = try runGitResult(
+            ["config", "--path", "--get", "core.worktree"],
+            cwd: linkedWorktree,
+            requireSuccess: false
+        )
+        XCTAssertTrue(normalQuery.outputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+
+        let descriptors = try await VCSService().listGitWorktrees(at: linkedWorktree)
+        let main = try XCTUnwrap(descriptors.first(where: \.isMain))
+        XCTAssertEqual(URL(fileURLWithPath: main.path).standardizedFileURL, fixture.repo.standardizedFileURL)
+        XCTAssertEqual(main.repository.mainWorktreeRoot, fixture.repo.standardizedFileURL.path)
+        XCTAssertTrue(descriptors.contains { $0.isCurrent && URL(fileURLWithPath: $0.path).standardizedFileURL == linkedWorktree.standardizedFileURL })
     }
 
     func testFallbackContextMarksLinkedWorktree() async throws {
@@ -66,6 +180,16 @@ final class GitWorktreeContextResolverTests: XCTestCase {
         XCTAssertEqual(context.checkoutDisplayText, "linked worktree")
         XCTAssertEqual(context.branchDisplayText, "feature/linked")
         XCTAssertTrue(context.tooltipText.contains("Checkout: linked worktree"))
+
+        let layout = try XCTUnwrap(GitRepositoryLayoutResolver.resolve(atWorkTreeRoot: linkedWorktree))
+        XCTAssertTrue(layout.isWorktree)
+        XCTAssertTrue(layout.isLinkedWorktree)
+        XCTAssertNotEqual(layout.gitDir.standardizedFileURL, layout.commonDir.standardizedFileURL)
+        XCTAssertEqual(layout.knownMainWorktreeRoot, repo.standardizedFileURL)
+
+        let metadata = GitDiffSnapshotStore().worktreeMetadata(for: linkedWorktree.path)
+        XCTAssertEqual(metadata.isWorktree, true)
+        XCTAssertEqual(metadata.mainWorktreeRoot, repo.standardizedFileURL.path)
     }
 
     func testGitStatusActorRefreshesCachedContextForUnchangedRootList() async throws {
@@ -132,6 +256,24 @@ final class GitWorktreeContextResolverTests: XCTestCase {
         return repo
     }
 
+    private func makeSeparateGitDirFixture() throws -> (repo: URL, gitDir: URL) {
+        let root = try makeTemporaryDirectory()
+        let repo = root.appendingPathComponent("repo", isDirectory: true)
+        let gitDir = root.appendingPathComponent("repo-git", isDirectory: true)
+        try runGit([
+            "init",
+            "-b", "main",
+            "--separate-git-dir", gitDir.path,
+            repo.path
+        ], cwd: root)
+        try runGit(["config", "user.email", "test@example.com"], cwd: repo)
+        try runGit(["config", "user.name", "Test User"], cwd: repo)
+        try "hello\n".write(to: repo.appendingPathComponent("README.md"), atomically: true, encoding: .utf8)
+        try runGit(["add", "."], cwd: repo)
+        try runGit(["commit", "-m", "Initial commit"], cwd: repo)
+        return (repo, gitDir)
+    }
+
     private func makeTemporaryDirectory() throws -> URL {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("GitWorktreeContextResolverTests-\(UUID().uuidString)", isDirectory: true)
@@ -141,6 +283,14 @@ final class GitWorktreeContextResolverTests: XCTestCase {
     }
 
     private func runGit(_ arguments: [String], cwd: URL) throws {
+        _ = try runGitResult(arguments, cwd: cwd)
+    }
+
+    private func runGitResult(
+        _ arguments: [String],
+        cwd: URL,
+        requireSuccess: Bool = true
+    ) throws -> TestProcessResult {
         var environment = ProcessInfo.processInfo.environment
         environment["GIT_CONFIG_NOSYSTEM"] = "1"
         environment["GIT_CONFIG_GLOBAL"] = "/dev/null"
@@ -151,13 +301,14 @@ final class GitWorktreeContextResolverTests: XCTestCase {
             currentDirectoryURL: cwd,
             environment: environment
         )
-        guard result.terminationStatus == 0 else {
+        guard !requireSuccess || result.terminationStatus == 0 else {
             throw NSError(
                 domain: "GitWorktreeContextResolverTests",
                 code: Int(result.terminationStatus),
                 userInfo: [NSLocalizedDescriptionKey: "git \(arguments.joined(separator: " ")) failed: \(result.outputText)"]
             )
         }
+        return result
     }
 }
 

--- a/Tests/RepoPromptTests/Services/VCS/GitWorktreeContextSummaryTests.swift
+++ b/Tests/RepoPromptTests/Services/VCS/GitWorktreeContextSummaryTests.swift
@@ -33,7 +33,39 @@ final class GitWorktreeContextResolverTests: XCTestCase {
         XCTAssertEqual(context.worktreeName, "repo")
         XCTAssertEqual(context.branchDisplayText, "main")
         XCTAssertEqual(context.breadcrumbText, "repo / repo / main")
+        XCTAssertTrue(context.isMain)
+        XCTAssertEqual(context.checkoutDisplayText, "main repository checkout")
         XCTAssertEqual(URL(fileURLWithPath: context.worktreePath).standardizedFileURL.path, repo.standardizedFileURL.path)
+    }
+
+    func testFallbackContextMarksMainRepositoryCheckout() async throws {
+        let repo = try makeGitFixture()
+        let service = VCSService()
+        let resolved = VCSResolvedRepo(rootURL: repo, backendKind: .git)
+
+        let resolvedContext = await service.gitWorktreeContext(for: repo, resolved: resolved, worktrees: nil)
+        let context = try XCTUnwrap(resolvedContext)
+
+        XCTAssertTrue(context.isMain)
+        XCTAssertEqual(context.checkoutDisplayText, "main repository checkout")
+        XCTAssertTrue(context.tooltipText.contains("Checkout: main repository checkout"))
+    }
+
+    func testFallbackContextMarksLinkedWorktree() async throws {
+        let root = try makeTemporaryDirectory()
+        let repo = try makeGitFixture(in: root)
+        let linkedWorktree = root.appendingPathComponent("repo-linked", isDirectory: true)
+        try runGit(["worktree", "add", "-b", "feature/linked", linkedWorktree.path], cwd: repo)
+        let service = VCSService()
+        let resolved = VCSResolvedRepo(rootURL: linkedWorktree, backendKind: .git)
+
+        let resolvedContext = await service.gitWorktreeContext(for: linkedWorktree, resolved: resolved, worktrees: nil)
+        let context = try XCTUnwrap(resolvedContext)
+
+        XCTAssertFalse(context.isMain)
+        XCTAssertEqual(context.checkoutDisplayText, "linked worktree")
+        XCTAssertEqual(context.branchDisplayText, "feature/linked")
+        XCTAssertTrue(context.tooltipText.contains("Checkout: linked worktree"))
     }
 
     func testGitStatusActorRefreshesCachedContextForUnchangedRootList() async throws {
@@ -135,7 +167,18 @@ final class GitWorktreeContextSummaryTests: XCTestCase {
 
         XCTAssertEqual(summary.branchDisplayText, "main")
         XCTAssertEqual(summary.breadcrumbText, "Repo / repo / main")
-        XCTAssertTrue(summary.tooltipText.contains("Branch: main"))
+        XCTAssertEqual(summary.checkoutDisplayText, "main repository checkout")
+        XCTAssertEqual(summary.tooltipText, """
+        Repository: Repo
+        Checkout: main repository checkout
+        Worktree: repo
+        Branch: main
+        Path: /tmp/repo
+        """)
+        XCTAssertFalse(summary.tooltipText.contains("HEAD:"))
+        XCTAssertFalse(summary.tooltipText.contains("1234567890abcdef"))
+        XCTAssertFalse(summary.tooltipText.contains("Click to switch local branches"))
+        XCTAssertTrue(summary.accessibilityText.contains("main repository checkout repo"))
         XCTAssertTrue(summary.accessibilityText.contains("branch main"))
     }
 
@@ -145,6 +188,8 @@ final class GitWorktreeContextSummaryTests: XCTestCase {
         XCTAssertEqual(summary.branchDisplayText, "detached @ abcdef1")
         XCTAssertEqual(summary.breadcrumbText, "Repo / repo / detached @ abcdef1")
         XCTAssertTrue(summary.tooltipText.contains("Branch: detached @ abcdef1"))
+        XCTAssertFalse(summary.tooltipText.contains("HEAD:"))
+        XCTAssertFalse(summary.tooltipText.contains("abcdef1234567890"))
     }
 
     func testMissingBranchWithKnownHeadUsesHeadFallback() {
@@ -153,6 +198,8 @@ final class GitWorktreeContextSummaryTests: XCTestCase {
         XCTAssertEqual(summary.branchDisplayText, "HEAD @ fedcba9")
         XCTAssertEqual(summary.breadcrumbText, "Repo / repo / HEAD @ fedcba9")
         XCTAssertTrue(summary.tooltipText.contains("Branch: HEAD @ fedcba9"))
+        XCTAssertFalse(summary.tooltipText.contains("HEAD:"))
+        XCTAssertFalse(summary.tooltipText.contains("fedcba9876543210"))
     }
 
     func testUnknownBranchIsOnlySurfacedInTooltipAndAccessibility() {
@@ -160,11 +207,34 @@ final class GitWorktreeContextSummaryTests: XCTestCase {
 
         XCTAssertNil(summary.branchDisplayText)
         XCTAssertEqual(summary.breadcrumbText, "Repo / repo")
+        XCTAssertTrue(summary.tooltipText.contains("Checkout: main repository checkout"))
         XCTAssertTrue(summary.tooltipText.contains("Branch: unknown branch"))
         XCTAssertTrue(summary.accessibilityText.contains("branch unknown branch"))
     }
 
+    func testLinkedWorktreeCheckoutTextIsSurfacedInTooltipAndAccessibility() {
+        let summary = makeSummary(isMain: false, branch: "feature/x", head: "1234567890abcdef", isDetached: false)
+
+        XCTAssertFalse(summary.isMain)
+        XCTAssertEqual(summary.checkoutDisplayText, "linked worktree")
+        XCTAssertTrue(summary.tooltipText.contains("Checkout: linked worktree"))
+        XCTAssertTrue(summary.accessibilityText.contains("linked worktree repo"))
+    }
+
+    func testDescriptorConversionPreservesMainAndLinkedWorktreeStatus() {
+        let mainSummary = GitWorktreeContextSummary(descriptor: makeDescriptor(isMain: true, name: "repo", branch: "main"))
+        let linkedSummary = GitWorktreeContextSummary(descriptor: makeDescriptor(isMain: false, name: "repo-feature", branch: "feature/x"))
+
+        XCTAssertTrue(mainSummary.isMain)
+        XCTAssertEqual(mainSummary.checkoutDisplayText, "main repository checkout")
+        XCTAssertTrue(mainSummary.tooltipText.contains("Checkout: main repository checkout"))
+        XCTAssertFalse(linkedSummary.isMain)
+        XCTAssertEqual(linkedSummary.checkoutDisplayText, "linked worktree")
+        XCTAssertTrue(linkedSummary.tooltipText.contains("Checkout: linked worktree"))
+    }
+
     private func makeSummary(
+        isMain: Bool = true,
         branch: String?,
         head: String?,
         isDetached: Bool
@@ -176,9 +246,40 @@ final class GitWorktreeContextSummaryTests: XCTestCase {
             worktreeID: "wt-test",
             worktreePath: "/tmp/repo",
             worktreeName: "repo",
+            isMain: isMain,
             branch: branch,
             head: head,
             isDetached: isDetached
+        )
+    }
+
+    private func makeDescriptor(
+        isMain: Bool,
+        name: String,
+        branch: String?
+    ) -> GitWorktreeDescriptor {
+        let repository = GitWorktreeRepositoryIdentity(
+            repositoryID: "gitrepo-test",
+            repoKey: "repo-test",
+            displayName: "Repo",
+            commonGitDir: "/tmp/repo/.git",
+            mainWorktreeRoot: "/tmp/repo"
+        )
+        return GitWorktreeDescriptor(
+            worktreeID: isMain ? "wt-main" : "wt-linked",
+            repository: repository,
+            path: isMain ? "/tmp/repo" : "/tmp/repo-feature",
+            gitDir: isMain ? "/tmp/repo/.git" : "/tmp/repo/.git/worktrees/repo-feature",
+            name: name,
+            branch: branch,
+            head: "1234567890abcdef",
+            isMain: isMain,
+            isCurrent: true,
+            isDetached: false,
+            isLocked: false,
+            lockReason: nil,
+            isPrunable: false,
+            prunableReason: nil
         )
     }
 }


### PR DESCRIPTION
## Summary
- Give the Agent Mode branch switch popover a single scaled root height so loaded branch rows stay inside the popover boundary.
- Let the branch row list scroll within the remaining popover space instead of using an independently estimated scroll height.
- Use a regular `VStack` inside the finite branch list scroll view so the scrollbar range is measured up front and does not shrink/recalibrate after the first scroll.

Additional notes:
- `make dev-test` initially had one unrelated failure in `UnixSocketMCPTerminalCleanupTests`; rerunning `make dev-test FILTER=UnixSocketMCPTerminalCleanupTests` passed, and push preflight's full root test run passed afterward.
