### PR TITLE
[codex] Avoid stale descriptor assertions in socket cleanup tests

### DIFF
--- a/Tests/RepoPromptTests/MCP/Control/UnixSocketMCPTerminalCleanupTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/UnixSocketMCPTerminalCleanupTests.swift
@@ -49,7 +49,6 @@ final class UnixSocketMCPTerminalCleanupTests: XCTestCase {
                     && !snapshot.socketIsOwned
             }
             XCTAssertTrue(cleanupCompleted)
-            XCTAssertTrue(Self.isClosed(descriptors[0]))
             XCTAssertTrue(Self.peerObservedEOF(on: descriptors[1]))
 
             await connectedTransport.disconnect()
@@ -110,7 +109,6 @@ final class UnixSocketMCPTerminalCleanupTests: XCTestCase {
                     && !snapshot.socketIsOwned
             }
             XCTAssertTrue(cleanupCompleted)
-            XCTAssertTrue(Self.isClosed(descriptors[0]))
             XCTAssertTrue(Self.peerObservedEOF(on: descriptors[1]))
 
             await connectedTransport.disconnect()
@@ -409,7 +407,6 @@ final class UnixSocketMCPTerminalCleanupTests: XCTestCase {
                     && !snapshot.socketIsOwned
             }
             XCTAssertTrue(cleanupCompleted)
-            XCTAssertTrue(isClosed(descriptors[0]))
             XCTAssertTrue(peerObservedEOF(on: descriptors[1]))
 
             await transport.disconnect()
@@ -512,6 +509,7 @@ final class UnixSocketMCPTerminalCleanupTests: XCTestCase {
     }
 
     private static func isClosed(_ fd: Int32) -> Bool {
+        // Only use while the test still owns the descriptor; closed descriptor numbers can be reused.
         errno = 0
         return fcntl(fd, F_GETFD) == -1 && errno == EBADF
     }


### PR DESCRIPTION
## Summary

- remove post-cleanup assertions that query an already-closed numeric file descriptor
- retain the transport finalizer, ownership, reader-retention, and peer EOF assertions
- document that closed descriptor numbers can be reused process-wide

## Root cause

The full test process can reuse the socket's numeric file descriptor after the transport closes it and before the test calls `fcntl`. That makes the stale descriptor number appear open even though the original socket was finalized correctly, producing an unrelated failure on docs-only PRs such as #88.

## Validation

- `make dev-format`
- `make dev-lint`
- `make dev-test FILTER=UnixSocketMCPTerminalCleanupTests`
- `make dev-test`
- `make guardrails`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh commit`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh push`
