### PR TITLE
Fix local self-signed production packaging

### DIFF
--- a/Scripts/package_app.sh
+++ b/Scripts/package_app.sh
@@ -29,6 +29,21 @@ run(){
     "$@"
 }
 fail(){ echo "ERROR: $*" >&2; exit 1; }
+paths_same(){
+    python3 - "$1" "$2" <<'PY'
+from pathlib import Path
+import sys
+
+left = Path(sys.argv[1])
+right = Path(sys.argv[2])
+try:
+    print("1" if left.samefile(right) else "0")
+except OSError:
+    left_resolved = str(left.resolve(strict=False)).lower()
+    right_resolved = str(right.resolve(strict=False)).lower()
+    print("1" if left_resolved == right_resolved else "0")
+PY
+}
 finish(){
     local status="$1" now total
     [[ -z "${APP_ENTITLEMENTS:-}" ]] || rm -f "$APP_ENTITLEMENTS"
@@ -208,12 +223,7 @@ run rm -rf "$APP_BUNDLE"
 if (( PUBLIC_UNIVERSAL_RELEASE )); then
     run rm -f "$ARTIFACT_MANIFEST"
 fi
-if [[ "$(python3 - <<PY
-from pathlib import Path
-import os
-print(Path('$APP_BUNDLE').resolve(strict=False) == Path('$COMPAT_APP_BUNDLE').resolve(strict=False))
-PY
-)" != "True" ]]; then
+if [[ "$(paths_same "$APP_BUNDLE" "$COMPAT_APP_BUNDLE")" != "1" ]]; then
     run rm -rf "$COMPAT_APP_BUNDLE"
 fi
 run mkdir -p "$APP_BUNDLE/Contents/MacOS" "$APP_BUNDLE/Contents/Resources/bin" "$APP_BUNDLE/Contents/Frameworks"
@@ -327,7 +337,7 @@ verify_signed_app_identity(){
         run codesign --verify --deep --strict --verbose=2 -R="$LOCAL_SELF_SIGNED_REQUIREMENT" "$APP_BUNDLE"
         certificate_dir="$(mktemp -d)"
         certificate_prefix="$certificate_dir/leaf"
-        codesign -d --extract-certificates "$certificate_prefix" "$APP_BUNDLE" >/dev/null 2>&1 || {
+        codesign -d --extract-certificates="$certificate_prefix" "$APP_BUNDLE" >/dev/null 2>&1 || {
             rm -rf "$certificate_dir"
             fail "Could not extract the local signing certificate from the packaged app."
         }
@@ -358,7 +368,7 @@ if (( IS_RELEASE )) && (( ! USE_ADHOC_SIGNING )); then
     APP_SIGN_ARGS+=(--entitlements "$APP_ENTITLEMENTS")
 fi
 if (( USE_LOCAL_SELF_SIGNED_RELEASE )); then
-    APP_SIGN_ARGS+=(--requirements "designated => $LOCAL_SELF_SIGNED_REQUIREMENT")
+    APP_SIGN_ARGS+=(--requirements "=designated => $LOCAL_SELF_SIGNED_REQUIREMENT")
 fi
 if (( ${#APP_SIGN_ARGS[@]} )); then
     sign_path "$APP_BUNDLE" "${APP_SIGN_ARGS[@]}"
@@ -376,11 +386,7 @@ if (( PUBLIC_UNIVERSAL_RELEASE )); then
 fi
 run "$CONTROL_PLANE_SCRIPTS_DIR/validate_embedded_mcp_helper_layout.sh" "$APP_BUNDLE" "Packaged app MCP helper layout"
 run "$RUN_WITHOUT_GITHUB_TOKENS" "$CONTROL_PLANE_SCRIPTS_DIR/smoke_embedded_mcp_helper.sh" "$APP_BUNDLE" "Packaged app MCP helper"
-if [[ "$(python3 - <<PY
-from pathlib import Path
-print(Path('$APP_BUNDLE').resolve(strict=False) == Path('$COMPAT_APP_BUNDLE').resolve(strict=False))
-PY
-)" != "True" ]]; then
+if [[ "$(paths_same "$APP_BUNDLE" "$COMPAT_APP_BUNDLE")" != "1" ]]; then
     phase "Updating compatibility app bundle link"
     run mkdir -p "$(dirname "$COMPAT_APP_BUNDLE")"
     if (( USE_ADHOC_SIGNING )); then

--- a/Scripts/package_app.sh
+++ b/Scripts/package_app.sh
@@ -29,6 +29,15 @@ run(){
     "$@"
 }
 fail(){ echo "ERROR: $*" >&2; exit 1; }
+remove_stale_artifact_manifests(){
+    local manifests=()
+    shopt -s nullglob
+    manifests=("$ROOT_DIR"/.build/release/*-artifact-manifest.json)
+    shopt -u nullglob
+    if (( ${#manifests[@]} )); then
+        run rm -f -- "${manifests[@]}"
+    fi
+}
 paths_same(){
     python3 - "$1" "$2" <<'PY'
 from pathlib import Path
@@ -39,8 +48,8 @@ right = Path(sys.argv[2])
 try:
     print("1" if left.samefile(right) else "0")
 except OSError:
-    left_resolved = str(left.resolve(strict=False)).lower()
-    right_resolved = str(right.resolve(strict=False)).lower()
+    left_resolved = left.resolve(strict=False)
+    right_resolved = right.resolve(strict=False)
     print("1" if left_resolved == right_resolved else "0")
 PY
 }
@@ -59,9 +68,13 @@ finish(){
 trap 'finish $?' EXIT
 
 BUNDLE_ID_OVERRIDE="${BUNDLE_ID:-}"
+# Invalidate public-release manifests before metadata parsing, checks, or builds
+# so failed non-public packaging cannot leave stale release metadata behind.
+remove_stale_artifact_manifests
 source "$CONTROL_PLANE_SCRIPTS_DIR/load_release_metadata.sh"
 load_release_metadata "$ROOT_DIR"
 APP_NAME="${APP_NAME:-RepoPrompt}"; DISPLAY_NAME="${DISPLAY_NAME:-RepoPrompt CE}"; BASE_BUNDLE_ID="${BUNDLE_ID:-com.pvncher.repoprompt.ce}"; MARKETING_VERSION="${MARKETING_VERSION:-0.1.0}"; BUILD_NUMBER="${BUILD_NUMBER:-1}"; SIGNING_TEAM_ID="${SIGNING_TEAM_ID:-648A27MST5}"
+ARTIFACT_MANIFEST="$ROOT_DIR/.build/release/$APP_NAME-artifact-manifest.json"
 
 IS_RELEASE=0
 [[ "$CONF" == "release" ]] && IS_RELEASE=1
@@ -215,14 +228,10 @@ else
 fi
 COMPAT_APP_BUNDLE="$ROOT_DIR/.build/$CONF/$APP_NAME.app"
 CLI_PATH="$BUILD_DIR/repoprompt-mcp"
-ARTIFACT_MANIFEST="$ROOT_DIR/.build/release/$APP_NAME-artifact-manifest.json"
 printf 'BUILD_DIR=%s\nAPP_BUNDLE=%s\nCOMPAT_APP_BUNDLE=%s\nCLI_PATH=%s\nAD_HOC_SIGNING=%s\nARCHITECTURE_POLICY=%s\n' "$BUILD_DIR" "$APP_BUNDLE" "$COMPAT_APP_BUNDLE" "$CLI_PATH" "$USE_ADHOC_SIGNING" "$ARCHITECTURE_POLICY"
 
 phase "Creating app bundle layout"
 run rm -rf "$APP_BUNDLE"
-if (( PUBLIC_UNIVERSAL_RELEASE )); then
-    run rm -f "$ARTIFACT_MANIFEST"
-fi
 if [[ "$(paths_same "$APP_BUNDLE" "$COMPAT_APP_BUNDLE")" != "1" ]]; then
     run rm -rf "$COMPAT_APP_BUNDLE"
 fi

--- a/Scripts/test_local_production_installer.py
+++ b/Scripts/test_local_production_installer.py
@@ -268,7 +268,7 @@ class LocalProductionInstallerTests(unittest.TestCase):
         info_template = (ROOT_DIR / "AppBundle" / "Info.plist.template").read_text(encoding="utf-8")
         self.assertIn("RepoPromptLocalSigningCertificateSHA256", info_template)
         self.assertIn("RepoPromptLocalSecureStorageGeneration", info_template)
-        self.assertIn("--extract-certificates", package_script)
+        self.assertIn("--extract-certificates=\"$certificate_prefix\"", package_script)
         self.assertIn("Extracted designated requirement", package_script)
 
     def test_first_use_adopts_sole_identity_and_writes_registry(self) -> None:

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -62,7 +62,7 @@ class ReleaseToolingTests(unittest.TestCase):
             policy,
         )
         package_script = (SCRIPT_DIR / "package_app.sh").read_text(encoding="utf-8")
-        requirement_arg = 'APP_SIGN_ARGS+=(--requirements "designated => $LOCAL_SELF_SIGNED_REQUIREMENT")'
+        requirement_arg = 'APP_SIGN_ARGS+=(--requirements "=designated => $LOCAL_SELF_SIGNED_REQUIREMENT")'
         self.assertIn(requirement_arg, package_script)
         self.assertLess(package_script.index(requirement_arg), package_script.index('sign_path "$APP_BUNDLE"'))
 

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import base64
+import hashlib
 import json
 import os
 import plistlib
@@ -526,6 +527,113 @@ esac
         )
         self.assertNotEqual(rejected.returncode, 0)
         self.assertIn("does not match app bundle", rejected.stderr)
+
+    def test_artifact_manifest_records_certificate_from_equals_form_extraction(self) -> None:
+        app, fake_lipo = self.make_universal_architecture_fixture()
+        info = {
+            "CFBundleExecutable": "RepoPrompt",
+            "CFBundleIdentifier": "com.pvncher.repoprompt.ce",
+            "CFBundleShortVersionString": "1.0.0",
+            "CFBundleVersion": "1",
+            "RepoPromptSigningMode": "developer-id",
+        }
+        (app / "Contents" / "Info.plist").write_bytes(plistlib.dumps(info))
+        certificate = b"fixture leaf certificate\n"
+        fake_codesign = app.parent / "codesign"
+        fake_codesign.write_text(
+            """#!/usr/bin/env bash
+set -euo pipefail
+certificate_prefix=""
+for argument in "$@"; do
+  case "$argument" in
+    --extract-certificates=*) certificate_prefix="${argument#*=}" ;;
+    --extract-certificates)
+      printf 'certificate prefix must use the equals form\n' >&2
+      exit 64
+      ;;
+  esac
+done
+if [[ -n "$certificate_prefix" ]]; then
+  printf 'fixture leaf certificate\n' > "${certificate_prefix}0"
+  exit 0
+fi
+case "$*" in
+  *--entitlements*)
+    printf '<?xml version="1.0"?><plist version="1.0"><dict/></plist>\n'
+    ;;
+  *-r-*)
+    printf 'designated => identifier "fixture"\n' >&2
+    ;;
+  *)
+    printf 'Identifier=fixture\nTeamIdentifier=TEAMID\nAuthority=Developer ID Application: Fixture\n' >&2
+    ;;
+esac
+""",
+            encoding="utf-8",
+        )
+        fake_codesign.chmod(0o755)
+        manifest = app.parent / "certificate-manifest.json"
+        env = os.environ.copy()
+        env.update({"LIPO": str(fake_lipo), "CODESIGN": str(fake_codesign)})
+
+        result = subprocess.run(
+            [
+                str(SCRIPT_DIR / "write_app_artifact_manifest.py"),
+                "write",
+                "--app",
+                str(app),
+                "--output",
+                str(manifest),
+                "--expected-architectures",
+                "arm64,x86_64",
+            ],
+            env=env,
+            text=True,
+            capture_output=True,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        content = json.loads(manifest.read_text(encoding="utf-8"))
+        expected_fingerprint = hashlib.sha256(certificate).hexdigest()
+        self.assertEqual(content["bundle_signing"]["leaf_certificate_sha256"], expected_fingerprint)
+        for executable in content["executables"]:
+            self.assertEqual(executable["signing"]["leaf_certificate_sha256"], expected_fingerprint)
+
+    def test_packaging_path_identity_skips_nested_compatibility_link(self) -> None:
+        temp_dir = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, temp_dir, True)
+        architecture_release = temp_dir / ".build" / "arm64-apple-macosx" / "release"
+        architecture_release.mkdir(parents=True)
+        compatibility_release = temp_dir / ".build" / "release"
+        compatibility_release.symlink_to(Path("arm64-apple-macosx") / "release")
+        app_bundle = architecture_release / "RepoPrompt.app"
+        app_bundle.mkdir()
+        compatibility_app_bundle = compatibility_release / "RepoPrompt.app"
+
+        package_script = (SCRIPT_DIR / "package_app.sh").read_text(encoding="utf-8")
+        function_body = package_script.split("paths_same(){", 1)[1].split("\n}\nfinish(){", 1)[0]
+        probe = temp_dir / "path-identity-probe.sh"
+        probe.write_text(
+            f"""#!/usr/bin/env bash
+set -euo pipefail
+paths_same(){{{function_body}
+}}
+if [[ "$(paths_same "$1" "$2")" != "1" ]]; then
+  ln -sfn "$1" "$2"
+fi
+""",
+            encoding="utf-8",
+        )
+        probe.chmod(0o755)
+
+        result = subprocess.run(
+            [str(probe), str(app_bundle), str(compatibility_app_bundle)],
+            text=True,
+            capture_output=True,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertFalse((app_bundle / "RepoPrompt.app").exists())
 
     def test_packaged_roundtrip_source_uses_exact_pid_and_isolated_cleanup_without_global_kill(self) -> None:
         source = (SCRIPT_DIR / "smoke_packaged_mcp_roundtrip.sh").read_text(encoding="utf-8")

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -62,10 +62,69 @@ class ReleaseToolingTests(unittest.TestCase):
             'static let localSelfSignedCertificateName = "RepoPrompt CE Local Self-Signed Code Signing"',
             policy,
         )
+
+    def test_local_self_signed_outer_codesign_uses_equals_requirement_argv(self) -> None:
         package_script = (SCRIPT_DIR / "package_app.sh").read_text(encoding="utf-8")
-        requirement_arg = 'APP_SIGN_ARGS+=(--requirements "=designated => $LOCAL_SELF_SIGNED_REQUIREMENT")'
-        self.assertIn(requirement_arg, package_script)
-        self.assertLess(package_script.index(requirement_arg), package_script.index('sign_path "$APP_BUNDLE"'))
+        sign_path_body = package_script.split("sign_path(){", 1)[1].split("\n}\nsign_sparkle_framework(){", 1)[0]
+        app_signing_body = package_script.split("APP_SIGN_ARGS=()", 1)[1].split(
+            'run codesign --verify --deep --strict --verbose=2 "$APP_BUNDLE"',
+            1,
+        )[0]
+        temp_dir = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, temp_dir, True)
+        capture = temp_dir / "codesign-argv.bin"
+        fake_codesign = temp_dir / "codesign"
+        fake_codesign.write_text(
+            "#!/usr/bin/env bash\nset -euo pipefail\nprintf '%s\\0' \"$@\" > \"$CODESIGN_CAPTURE\"\n",
+            encoding="utf-8",
+        )
+        fake_codesign.chmod(0o755)
+        probe = temp_dir / "codesign-argv-probe.sh"
+        probe.write_text(
+            f"""#!/usr/bin/env bash
+set -euo pipefail
+run() {{ "$@"; }}
+sign_path() {{{sign_path_body}
+}}
+IS_RELEASE=1
+USE_ADHOC_SIGNING=0
+USE_LOCAL_SELF_SIGNED_RELEASE=1
+SIGN_IDENTITY='RepoPrompt CE Local Self-Signed Code Signing'
+APP_BUNDLE='/tmp/RepoPrompt.app'
+APP_ENTITLEMENTS='/tmp/RepoPrompt.entitlements'
+LOCAL_SELF_SIGNED_REQUIREMENT='identifier "com.pvncher.repoprompt.ce" and certificate leaf = H"{'1' * 40}"'
+APP_SIGN_ARGS=(){app_signing_body}
+""",
+            encoding="utf-8",
+        )
+        probe.chmod(0o755)
+        env = os.environ.copy()
+        env.update(
+            {
+                "CODESIGN_CAPTURE": str(capture),
+                "PATH": f"{temp_dir}:{env.get('PATH', '')}",
+            }
+        )
+
+        result = subprocess.run([str(probe)], env=env, text=True, capture_output=True)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            capture.read_bytes().rstrip(b"\0").decode().split("\0"),
+            [
+                "--force",
+                "--sign",
+                "RepoPrompt CE Local Self-Signed Code Signing",
+                "--timestamp=none",
+                "--options",
+                "runtime",
+                "--entitlements",
+                "/tmp/RepoPrompt.entitlements",
+                "--requirements",
+                '=designated => identifier "com.pvncher.repoprompt.ce" and certificate leaf = H"' + "1" * 40 + '"',
+                "/tmp/RepoPrompt.app",
+            ],
+        )
 
     def test_custom_packaging_resigns_sparkle_helpers_without_recursive_entitlement_propagation(self) -> None:
         package_script = (SCRIPT_DIR / "package_app.sh").read_text(encoding="utf-8")
@@ -371,7 +430,14 @@ printf 'arm64 x86_64\\n' > "$output"
             """#!/usr/bin/env bash
 set -euo pipefail
 case "$*" in
-  *--extract-certificates*) exit 1 ;;
+  *--extract-certificates*)
+    [[ "${FAKE_CERTIFICATE_AVAILABLE:-0}" == "1" ]] || exit 1
+    for argument in "$@"; do
+      case "$argument" in
+        --extract-certificates=*) printf 'fixture certificate\n' > "${argument#*=}0" ;;
+      esac
+    done
+    ;;
   *--entitlements*)
     [[ "${FAKE_MISSING_ENTITLEMENTS:-0}" != "1" ]] || exit 1
     cat <<'PLIST'
@@ -420,6 +486,10 @@ esac
         content = manifest.read_text(encoding="utf-8")
         self.assertNotIn(str(app.parent), content)
         self.assertNotIn("generated_at", content)
+        manifest_content = json.loads(content)
+        self.assertIsNone(manifest_content["bundle_signing"]["leaf_certificate_sha256"])
+        for executable in manifest_content["executables"]:
+            self.assertIsNone(executable["signing"]["leaf_certificate_sha256"])
         accepted = subprocess.run(
             [
                 str(writer),
@@ -471,10 +541,30 @@ esac
             "certificate-backed signed path did not expose a designated requirement",
             certificate_backed_missing_requirement.stderr,
         )
+        env.pop("FAKE_MISSING_REQUIREMENT")
+        certificate_backed_missing_certificate = subprocess.run(
+            [
+                str(writer),
+                "write",
+                "--app",
+                str(app),
+                "--output",
+                str(app.parent / "certificate-backed-missing-certificate.json"),
+            ],
+            env=env,
+            text=True,
+            capture_output=True,
+        )
+        self.assertNotEqual(certificate_backed_missing_certificate.returncode, 0)
+        self.assertIn(
+            "certificate-backed signed path did not expose an extractable leaf certificate",
+            certificate_backed_missing_certificate.stderr,
+        )
         env.pop("FAKE_CERTIFICATE_BACKED")
 
         info["RepoPromptSigningMode"] = "developer-id"
         (app / "Contents" / "Info.plist").write_bytes(plistlib.dumps(info))
+        env["FAKE_MISSING_REQUIREMENT"] = "1"
         developer_id_missing_requirement = subprocess.run(
             [
                 str(writer),
@@ -494,7 +584,49 @@ esac
             developer_id_missing_requirement.stderr,
         )
         env.pop("FAKE_MISSING_REQUIREMENT")
+        developer_id_missing_certificate = subprocess.run(
+            [
+                str(writer),
+                "write",
+                "--app",
+                str(app),
+                "--output",
+                str(app.parent / "developer-id-missing-certificate.json"),
+            ],
+            env=env,
+            text=True,
+            capture_output=True,
+        )
+        self.assertNotEqual(developer_id_missing_certificate.returncode, 0)
+        self.assertIn(
+            "certificate-backed signed path did not expose an extractable leaf certificate",
+            developer_id_missing_certificate.stderr,
+        )
 
+        info["RepoPromptSigningMode"] = "local-self-signed"
+        (app / "Contents" / "Info.plist").write_bytes(plistlib.dumps(info))
+        local_self_signed_missing_certificate = subprocess.run(
+            [
+                str(writer),
+                "write",
+                "--app",
+                str(app),
+                "--output",
+                str(app.parent / "local-self-signed-missing-certificate.json"),
+            ],
+            env=env,
+            text=True,
+            capture_output=True,
+        )
+        self.assertNotEqual(local_self_signed_missing_certificate.returncode, 0)
+        self.assertIn(
+            "certificate-backed signed path did not expose an extractable leaf certificate",
+            local_self_signed_missing_certificate.stderr,
+        )
+
+        info["RepoPromptSigningMode"] = "developer-id"
+        (app / "Contents" / "Info.plist").write_bytes(plistlib.dumps(info))
+        env["FAKE_CERTIFICATE_AVAILABLE"] = "1"
         env["FAKE_MISSING_ENTITLEMENTS"] = "1"
         missing_entitlements = subprocess.run(
             [str(writer), "write", "--app", str(app), "--output", str(app.parent / "missing-entitlements.json")],
@@ -505,6 +637,7 @@ esac
         self.assertNotEqual(missing_entitlements.returncode, 0)
         self.assertIn("did not expose parseable signed entitlements", missing_entitlements.stderr)
         env.pop("FAKE_MISSING_ENTITLEMENTS")
+        env.pop("FAKE_CERTIFICATE_AVAILABLE")
         info["RepoPromptSigningMode"] = "release-candidate-adhoc"
         (app / "Contents" / "Info.plist").write_bytes(plistlib.dumps(info))
 
@@ -543,6 +676,9 @@ esac
         fake_codesign.write_text(
             """#!/usr/bin/env bash
 set -euo pipefail
+printf '%s' "$1" >> "$CODESIGN_CAPTURE"
+for argument in "${@:2}"; do printf '\t%s' "$argument" >> "$CODESIGN_CAPTURE"; done
+printf '\n' >> "$CODESIGN_CAPTURE"
 certificate_prefix=""
 for argument in "$@"; do
   case "$argument" in
@@ -554,6 +690,7 @@ for argument in "$@"; do
   esac
 done
 if [[ -n "$certificate_prefix" ]]; then
+  [[ "${FAKE_MISSING_CERTIFICATE_FOR:-}" != "${@: -1}" ]] || exit 1
   printf 'fixture leaf certificate\n' > "${certificate_prefix}0"
   exit 0
 fi
@@ -573,8 +710,15 @@ esac
         )
         fake_codesign.chmod(0o755)
         manifest = app.parent / "certificate-manifest.json"
+        codesign_capture = app.parent / "codesign-argv.txt"
         env = os.environ.copy()
-        env.update({"LIPO": str(fake_lipo), "CODESIGN": str(fake_codesign)})
+        env.update(
+            {
+                "LIPO": str(fake_lipo),
+                "CODESIGN": str(fake_codesign),
+                "CODESIGN_CAPTURE": str(codesign_capture),
+            }
+        )
 
         result = subprocess.run(
             [
@@ -598,6 +742,40 @@ esac
         self.assertEqual(content["bundle_signing"]["leaf_certificate_sha256"], expected_fingerprint)
         for executable in content["executables"]:
             self.assertEqual(executable["signing"]["leaf_certificate_sha256"], expected_fingerprint)
+        extraction_calls = [
+            line.split("\t")
+            for line in codesign_capture.read_text(encoding="utf-8").splitlines()
+            if any(argument.startswith("--extract-certificates=") for argument in line.split("\t"))
+        ]
+        self.assertEqual(len(extraction_calls), 3)
+        for arguments in extraction_calls:
+            self.assertEqual(arguments[:2], ["-d", next(item for item in arguments if item.startswith("--extract-certificates="))])
+            self.assertNotIn("--extract-certificates", arguments)
+
+        covered_paths = [app / "Contents" / "MacOS" / "RepoPrompt", app / "Contents" / "MacOS" / "repoprompt-mcp", app]
+        for index, covered_path in enumerate(covered_paths):
+            with self.subTest(covered_path=covered_path):
+                failure_env = env | {"FAKE_MISSING_CERTIFICATE_FOR": str(covered_path)}
+                rejected = subprocess.run(
+                    [
+                        str(SCRIPT_DIR / "write_app_artifact_manifest.py"),
+                        "write",
+                        "--app",
+                        str(app),
+                        "--output",
+                        str(app.parent / f"missing-certificate-{index}.json"),
+                        "--expected-architectures",
+                        "arm64,x86_64",
+                    ],
+                    env=failure_env,
+                    text=True,
+                    capture_output=True,
+                )
+                self.assertNotEqual(rejected.returncode, 0)
+                self.assertIn(
+                    f"certificate-backed signed path did not expose an extractable leaf certificate: {covered_path}",
+                    rejected.stderr,
+                )
 
     def test_packaging_path_identity_skips_nested_compatibility_link(self) -> None:
         temp_dir = Path(tempfile.mkdtemp())
@@ -607,7 +785,6 @@ esac
         compatibility_release = temp_dir / ".build" / "release"
         compatibility_release.symlink_to(Path("arm64-apple-macosx") / "release")
         app_bundle = architecture_release / "RepoPrompt.app"
-        app_bundle.mkdir()
         compatibility_app_bundle = compatibility_release / "RepoPrompt.app"
 
         package_script = (SCRIPT_DIR / "package_app.sh").read_text(encoding="utf-8")
@@ -633,7 +810,104 @@ fi
         )
 
         self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertFalse(compatibility_app_bundle.is_symlink())
         self.assertFalse((app_bundle / "RepoPrompt.app").exists())
+
+    def test_packaging_path_identity_keeps_case_distinct_missing_paths_separate(self) -> None:
+        temp_dir = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, temp_dir, True)
+
+        package_script = (SCRIPT_DIR / "package_app.sh").read_text(encoding="utf-8")
+        function_body = package_script.split("paths_same(){", 1)[1].split("\n}\nfinish(){", 1)[0]
+        probe = temp_dir / "path-identity-case-probe.sh"
+        probe.write_text(
+            f"""#!/usr/bin/env bash
+set -euo pipefail
+paths_same(){{{function_body}
+}}
+paths_same "$1" "$2"
+""",
+            encoding="utf-8",
+        )
+        probe.chmod(0o755)
+
+        result = subprocess.run(
+            [str(probe), str(temp_dir / "RepoPrompt.app"), str(temp_dir / "repoprompt.app")],
+            text=True,
+            capture_output=True,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "0")
+
+    def test_packaging_removes_stale_public_manifest_before_non_public_preflight(self) -> None:
+        package_script = (SCRIPT_DIR / "package_app.sh").read_text(encoding="utf-8")
+        cleanup_before_metadata = """remove_stale_artifact_manifests
+source "$CONTROL_PLANE_SCRIPTS_DIR/load_release_metadata.sh"""
+        manifest_write_block = package_script.split(
+            'run "$CONTROL_PLANE_SCRIPTS_DIR/validate_app_architectures.sh" "$APP_BUNDLE" "$ARCHITECTURE_POLICY" "Post-sign packaged app"',
+            1,
+        )[1].split(
+            'run "$CONTROL_PLANE_SCRIPTS_DIR/validate_embedded_mcp_helper_layout.sh"',
+            1,
+        )[0]
+
+        self.assertIn('manifests=("$ROOT_DIR"/.build/release/*-artifact-manifest.json)', package_script)
+        self.assertIn(cleanup_before_metadata, package_script)
+        self.assertIn("if (( PUBLIC_UNIVERSAL_RELEASE )); then", manifest_write_block)
+        self.assertIn('write_app_artifact_manifest.py" write', manifest_write_block)
+        self.assertIn('--output "$ARTIFACT_MANIFEST"', manifest_write_block)
+
+        temp_dir = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, temp_dir, True)
+        root = temp_dir / "repo"
+        scripts = root / "Scripts"
+        scripts.mkdir(parents=True)
+        shutil.copy2(SCRIPT_DIR / "load_release_metadata.sh", scripts / "load_release_metadata.sh")
+        doctor = scripts / "doctor.sh"
+        doctor.write_text("#!/usr/bin/env bash\nexit 42\n", encoding="utf-8")
+        doctor.chmod(0o755)
+        metadata = root / "version.env"
+        artifact_manifest = root / ".build" / "release" / "RepoPrompt-artifact-manifest.json"
+        artifact_manifest.parent.mkdir(parents=True)
+        env = os.environ.copy()
+        env.update(
+            {
+                "REPOPROMPT_CONTROL_PLANE_SCRIPTS_DIR": str(scripts),
+                "REPOPROMPT_RELEASE_SOURCE_ROOT": str(root),
+            }
+        )
+
+        metadata.write_text("invalid metadata\n", encoding="utf-8")
+        artifact_manifest.write_text("stale\n", encoding="utf-8")
+        metadata_failure = subprocess.run(
+            [str(SCRIPT_DIR / "package_app.sh"), "debug"],
+            env=env,
+            text=True,
+            capture_output=True,
+        )
+        self.assertNotEqual(metadata_failure.returncode, 0)
+        self.assertFalse(artifact_manifest.exists())
+
+        metadata.write_text(
+            """APP_NAME=RepoPrompt
+DISPLAY_NAME="RepoPrompt CE"
+MARKETING_VERSION=1.0.0
+BUILD_NUMBER=1
+BUNDLE_ID=com.pvncher.repoprompt.ce
+SIGNING_TEAM_ID=648A27MST5
+""",
+            encoding="utf-8",
+        )
+        artifact_manifest.write_text("stale\n", encoding="utf-8")
+        preflight_failure = subprocess.run(
+            [str(SCRIPT_DIR / "package_app.sh"), "debug"],
+            env=env,
+            text=True,
+            capture_output=True,
+        )
+        self.assertEqual(preflight_failure.returncode, 42, preflight_failure.stderr)
+        self.assertFalse(artifact_manifest.exists())
 
     def test_packaged_roundtrip_source_uses_exact_pid_and_isolated_cleanup_without_global_kill(self) -> None:
         source = (SCRIPT_DIR / "smoke_packaged_mcp_roundtrip.sh").read_text(encoding="utf-8")

--- a/Scripts/write_app_artifact_manifest.py
+++ b/Scripts/write_app_artifact_manifest.py
@@ -83,7 +83,7 @@ def signing_details(path: Path, *, allow_adhoc_without_requirement: bool = False
     certificate_sha256 = None
     with tempfile.TemporaryDirectory() as temp_dir:
         prefix = Path(temp_dir) / "certificate"
-        extraction = run([codesign, "-d", "--extract-certificates", str(prefix), str(path)])
+        extraction = run([codesign, "-d", f"--extract-certificates={prefix}", str(path)])
         leaf = Path(f"{prefix}0")
         if extraction.returncode == 0 and leaf.is_file():
             certificate_sha256 = sha256(leaf)

--- a/Scripts/write_app_artifact_manifest.py
+++ b/Scripts/write_app_artifact_manifest.py
@@ -38,7 +38,12 @@ def architectures(path: Path) -> list[str]:
     return sorted(set((result.stdout or "").split()))
 
 
-def signing_details(path: Path, *, allow_adhoc_without_requirement: bool = False) -> dict[str, Any]:
+def signing_details(
+    path: Path,
+    *,
+    allow_adhoc_without_requirement: bool = False,
+    require_leaf_certificate: bool = False,
+) -> dict[str, Any]:
     codesign = os.environ.get("CODESIGN", "codesign")
     details = run([codesign, "-dv", "--verbose=4", str(path)])
     if details.returncode != 0:
@@ -97,6 +102,8 @@ def signing_details(path: Path, *, allow_adhoc_without_requirement: bool = False
             fail(f"signed path did not expose a designated requirement: {path}")
         if team is not None or authorities or certificate_sha256 is not None:
             fail(f"certificate-backed signed path did not expose a designated requirement: {path}")
+    if certificate_sha256 is None and (require_leaf_certificate or team is not None or authorities):
+        fail(f"certificate-backed signed path did not expose an extractable leaf certificate: {path}")
     return {
         "identifier": (values.get("Identifier") or [None])[0],
         "team_identifier": team,
@@ -112,6 +119,7 @@ def executable_entry(
     relative: str,
     *,
     allow_adhoc_without_requirement: bool = False,
+    require_leaf_certificate: bool = False,
 ) -> dict[str, Any]:
     path = app / relative
     if not path.is_file() or path.is_symlink():
@@ -123,6 +131,7 @@ def executable_entry(
         "signing": signing_details(
             path,
             allow_adhoc_without_requirement=allow_adhoc_without_requirement,
+            require_leaf_certificate=require_leaf_certificate,
         ),
     }
 
@@ -141,16 +150,19 @@ def collect_manifest(app: Path, expected_architectures: list[str] | None) -> dic
         fail("Info.plist is missing CFBundleExecutable")
     signing_mode = info.get("RepoPromptSigningMode")
     allow_adhoc_without_requirement = signing_mode == "release-candidate-adhoc"
+    require_leaf_certificate = signing_mode in {"developer-id", "local-self-signed"}
     entries = [
         executable_entry(
             app,
             f"Contents/MacOS/{executable_name}",
             allow_adhoc_without_requirement=allow_adhoc_without_requirement,
+            require_leaf_certificate=require_leaf_certificate,
         ),
         executable_entry(
             app,
             "Contents/MacOS/repoprompt-mcp",
             allow_adhoc_without_requirement=allow_adhoc_without_requirement,
+            require_leaf_certificate=require_leaf_certificate,
         ),
     ]
     architecture_sets = {tuple(entry["architectures"]) for entry in entries}
@@ -166,6 +178,7 @@ def collect_manifest(app: Path, expected_architectures: list[str] | None) -> dic
     bundle_signing = signing_details(
         app,
         allow_adhoc_without_requirement=allow_adhoc_without_requirement,
+        require_leaf_certificate=require_leaf_certificate,
     )
     if signing_mode == "developer-id" and bundle_signing["entitlements_sha256"] is None:
         fail("Developer ID app did not expose parseable signed entitlements")


### PR DESCRIPTION
## Summary
- Fix the local self-signed production install path.
- Keep the compatibility app link from being written inside the signed app bundle.
- Use the `codesign` argument forms macOS expects for inline requirements and certificate extraction.
- Add behavioral regressions for certificate fingerprint extraction and SwiftPM path aliasing.

## Why
I hit this while trying to install RepoPrompt CE alongside the official app with persistent settings. Packaging completed, but the install path failed during signing/verification for a few small command-shape/path-resolution reasons:

- `codesign --requirements` treated the designated requirement as a file path unless it was prefixed with `=`.
- `codesign --extract-certificates` needed the `--extract-certificates=<prefix>` form.
- `.build/release` can resolve to the same SwiftPM output directory as the packaged app, so the compatibility link step could create `RepoPrompt.app/RepoPrompt.app` inside the signed bundle and trigger `unsealed contents present in the bundle root`.

## Validation
- `make guardrails`
- `make release-selftest`
- `python3 Scripts/test_local_production_installer.py`
- `python3 -m unittest Scripts.test_release_tooling.ReleaseToolingTests.test_artifact_manifest_records_certificate_from_equals_form_extraction Scripts.test_release_tooling.ReleaseToolingTests.test_packaging_path_identity_skips_nested_compatibility_link`
- `git diff --check`

Original end-to-end validation from the contributor:
- `make dev-lint`
- `CONFIRM_LOCAL_PRODUCTION_INSTALL=1 make dev-install-local-production`