### PR TITLE
Simplify worktree tooltip metadata

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/Views/Components/GitContextBranchSwitchCapsule.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Components/GitContextBranchSwitchCapsule.swift
@@ -159,7 +159,7 @@ struct GitContextBranchSwitchCapsule: View {
         }
         .buttonStyle(.plain)
         .disabled(isSwitching)
-        .hoverTooltip(context.tooltipText + "\nClick to switch local branches in this checkout.", .top)
+        .hoverTooltip(context.tooltipText, .top)
         .accessibilityLabel(context.accessibilityText)
         .popover(isPresented: $showPopover, arrowEdge: .trailing) {
             popoverContent

--- a/Sources/RepoPrompt/Infrastructure/VCS/GitWorktreeModels.swift
+++ b/Sources/RepoPrompt/Infrastructure/VCS/GitWorktreeModels.swift
@@ -81,6 +81,7 @@ public struct GitWorktreeContextSummary: Sendable, Equatable, Hashable {
     public let worktreeID: String?
     public let worktreePath: String
     public let worktreeName: String
+    public let isMain: Bool
     public let branch: String?
     public let head: String?
     public let isDetached: Bool
@@ -92,6 +93,7 @@ public struct GitWorktreeContextSummary: Sendable, Equatable, Hashable {
         worktreeID: String?,
         worktreePath: String,
         worktreeName: String,
+        isMain: Bool,
         branch: String?,
         head: String?,
         isDetached: Bool
@@ -102,6 +104,7 @@ public struct GitWorktreeContextSummary: Sendable, Equatable, Hashable {
         self.worktreeID = worktreeID
         self.worktreePath = worktreePath
         self.worktreeName = worktreeName
+        self.isMain = isMain
         self.branch = Self.normalizedOptional(branch)
         self.head = Self.normalizedOptional(head)
         self.isDetached = isDetached
@@ -115,6 +118,7 @@ public struct GitWorktreeContextSummary: Sendable, Equatable, Hashable {
             worktreeID: descriptor.worktreeID,
             worktreePath: descriptor.path,
             worktreeName: descriptor.name ?? Self.fallbackWorktreeName(from: descriptor.path),
+            isMain: descriptor.isMain,
             branch: descriptor.branch,
             head: descriptor.head,
             isDetached: descriptor.isDetached
@@ -141,23 +145,25 @@ public struct GitWorktreeContextSummary: Sendable, Equatable, Hashable {
             .joined(separator: " / ")
     }
 
+    public var checkoutDisplayText: String {
+        isMain ? "main repository checkout" : "linked worktree"
+    }
+
     public var tooltipText: String {
         let branchText = branchDisplayText ?? "unknown branch"
-        var parts = [
+        let parts = [
             "Repository: \(repositoryDisplayName)",
+            "Checkout: \(checkoutDisplayText)",
             "Worktree: \(worktreeName)",
             "Branch: \(branchText)",
             "Path: \(worktreePath)"
         ]
-        if let head {
-            parts.insert("HEAD: \(head)", at: 3)
-        }
         return parts.joined(separator: "\n")
     }
 
     public var accessibilityText: String {
         let branchText = branchDisplayText ?? "unknown branch"
-        return "Git repository \(repositoryDisplayName), worktree \(worktreeName), branch \(branchText)"
+        return "Git repository \(repositoryDisplayName), \(checkoutDisplayText) \(worktreeName), branch \(branchText)"
     }
 
     private var shortHead: String? {

--- a/Sources/RepoPrompt/Infrastructure/VCS/VCSService.swift
+++ b/Sources/RepoPrompt/Infrastructure/VCS/VCSService.swift
@@ -550,6 +550,7 @@ public extension VCSService {
             return nil
         }
         let mainWorktreeRoot = layout.commonDir.deletingLastPathComponent()
+        let isMain = !layout.isWorktree
         let identity = GitWorktreeIdentity.repositoryIdentity(
             commonGitDir: layout.commonDir,
             mainWorktreeRoot: mainWorktreeRoot
@@ -560,7 +561,7 @@ public extension VCSService {
         let worktreeID = GitWorktreeIdentity.worktreeID(
             repositoryID: identity.repositoryID,
             gitDir: layout.gitDir,
-            isMain: !layout.isWorktree,
+            isMain: isMain,
             path: layout.workTreeRoot
         )
         return GitWorktreeContextSummary(
@@ -570,6 +571,7 @@ public extension VCSService {
             worktreeID: worktreeID,
             worktreePath: repoRootPath,
             worktreeName: worktreeName,
+            isMain: isMain,
             branch: branch,
             head: head,
             isDetached: branch == nil && head != nil

--- a/Tests/RepoPromptTests/AgentMode/AgentWorkspaceRootsSidebarStoreTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentWorkspaceRootsSidebarStoreTests.swift
@@ -54,6 +54,7 @@ final class AgentWorkspaceRootsSidebarStoreTests: XCTestCase {
         XCTAssertNil(rows[0].gitContext)
         XCTAssertEqual(rows[1].gitContext, contextB)
         XCTAssertEqual(rows[1].gitContext?.breadcrumbText, "Repo / B / feature/b")
+        XCTAssertTrue(rows[1].gitContext?.isMain == true)
     }
 
     // MARK: - Worktree indicators (Item 10)
@@ -212,7 +213,8 @@ final class AgentWorkspaceRootsSidebarStoreTests: XCTestCase {
     private func makeGitContext(
         repository: String,
         worktree: String,
-        branch: String?
+        branch: String?,
+        isMain: Bool = true
     ) -> GitWorktreeContextSummary {
         GitWorktreeContextSummary(
             repositoryID: "gitrepo-test",
@@ -221,6 +223,7 @@ final class AgentWorkspaceRootsSidebarStoreTests: XCTestCase {
             worktreeID: "wt-test",
             worktreePath: "/tmp/\(worktree)",
             worktreeName: worktree,
+            isMain: isMain,
             branch: branch,
             head: "1234567890abcdef",
             isDetached: false

--- a/Tests/RepoPromptTests/Services/VCS/GitWorktreeContextSummaryTests.swift
+++ b/Tests/RepoPromptTests/Services/VCS/GitWorktreeContextSummaryTests.swift
@@ -33,7 +33,39 @@ final class GitWorktreeContextResolverTests: XCTestCase {
         XCTAssertEqual(context.worktreeName, "repo")
         XCTAssertEqual(context.branchDisplayText, "main")
         XCTAssertEqual(context.breadcrumbText, "repo / repo / main")
+        XCTAssertTrue(context.isMain)
+        XCTAssertEqual(context.checkoutDisplayText, "main repository checkout")
         XCTAssertEqual(URL(fileURLWithPath: context.worktreePath).standardizedFileURL.path, repo.standardizedFileURL.path)
+    }
+
+    func testFallbackContextMarksMainRepositoryCheckout() async throws {
+        let repo = try makeGitFixture()
+        let service = VCSService()
+        let resolved = VCSResolvedRepo(rootURL: repo, backendKind: .git)
+
+        let resolvedContext = await service.gitWorktreeContext(for: repo, resolved: resolved, worktrees: nil)
+        let context = try XCTUnwrap(resolvedContext)
+
+        XCTAssertTrue(context.isMain)
+        XCTAssertEqual(context.checkoutDisplayText, "main repository checkout")
+        XCTAssertTrue(context.tooltipText.contains("Checkout: main repository checkout"))
+    }
+
+    func testFallbackContextMarksLinkedWorktree() async throws {
+        let root = try makeTemporaryDirectory()
+        let repo = try makeGitFixture(in: root)
+        let linkedWorktree = root.appendingPathComponent("repo-linked", isDirectory: true)
+        try runGit(["worktree", "add", "-b", "feature/linked", linkedWorktree.path], cwd: repo)
+        let service = VCSService()
+        let resolved = VCSResolvedRepo(rootURL: linkedWorktree, backendKind: .git)
+
+        let resolvedContext = await service.gitWorktreeContext(for: linkedWorktree, resolved: resolved, worktrees: nil)
+        let context = try XCTUnwrap(resolvedContext)
+
+        XCTAssertFalse(context.isMain)
+        XCTAssertEqual(context.checkoutDisplayText, "linked worktree")
+        XCTAssertEqual(context.branchDisplayText, "feature/linked")
+        XCTAssertTrue(context.tooltipText.contains("Checkout: linked worktree"))
     }
 
     func testGitStatusActorRefreshesCachedContextForUnchangedRootList() async throws {
@@ -135,7 +167,18 @@ final class GitWorktreeContextSummaryTests: XCTestCase {
 
         XCTAssertEqual(summary.branchDisplayText, "main")
         XCTAssertEqual(summary.breadcrumbText, "Repo / repo / main")
-        XCTAssertTrue(summary.tooltipText.contains("Branch: main"))
+        XCTAssertEqual(summary.checkoutDisplayText, "main repository checkout")
+        XCTAssertEqual(summary.tooltipText, """
+        Repository: Repo
+        Checkout: main repository checkout
+        Worktree: repo
+        Branch: main
+        Path: /tmp/repo
+        """)
+        XCTAssertFalse(summary.tooltipText.contains("HEAD:"))
+        XCTAssertFalse(summary.tooltipText.contains("1234567890abcdef"))
+        XCTAssertFalse(summary.tooltipText.contains("Click to switch local branches"))
+        XCTAssertTrue(summary.accessibilityText.contains("main repository checkout repo"))
         XCTAssertTrue(summary.accessibilityText.contains("branch main"))
     }
 
@@ -145,6 +188,8 @@ final class GitWorktreeContextSummaryTests: XCTestCase {
         XCTAssertEqual(summary.branchDisplayText, "detached @ abcdef1")
         XCTAssertEqual(summary.breadcrumbText, "Repo / repo / detached @ abcdef1")
         XCTAssertTrue(summary.tooltipText.contains("Branch: detached @ abcdef1"))
+        XCTAssertFalse(summary.tooltipText.contains("HEAD:"))
+        XCTAssertFalse(summary.tooltipText.contains("abcdef1234567890"))
     }
 
     func testMissingBranchWithKnownHeadUsesHeadFallback() {
@@ -153,6 +198,8 @@ final class GitWorktreeContextSummaryTests: XCTestCase {
         XCTAssertEqual(summary.branchDisplayText, "HEAD @ fedcba9")
         XCTAssertEqual(summary.breadcrumbText, "Repo / repo / HEAD @ fedcba9")
         XCTAssertTrue(summary.tooltipText.contains("Branch: HEAD @ fedcba9"))
+        XCTAssertFalse(summary.tooltipText.contains("HEAD:"))
+        XCTAssertFalse(summary.tooltipText.contains("fedcba9876543210"))
     }
 
     func testUnknownBranchIsOnlySurfacedInTooltipAndAccessibility() {
@@ -160,11 +207,34 @@ final class GitWorktreeContextSummaryTests: XCTestCase {
 
         XCTAssertNil(summary.branchDisplayText)
         XCTAssertEqual(summary.breadcrumbText, "Repo / repo")
+        XCTAssertTrue(summary.tooltipText.contains("Checkout: main repository checkout"))
         XCTAssertTrue(summary.tooltipText.contains("Branch: unknown branch"))
         XCTAssertTrue(summary.accessibilityText.contains("branch unknown branch"))
     }
 
+    func testLinkedWorktreeCheckoutTextIsSurfacedInTooltipAndAccessibility() {
+        let summary = makeSummary(isMain: false, branch: "feature/x", head: "1234567890abcdef", isDetached: false)
+
+        XCTAssertFalse(summary.isMain)
+        XCTAssertEqual(summary.checkoutDisplayText, "linked worktree")
+        XCTAssertTrue(summary.tooltipText.contains("Checkout: linked worktree"))
+        XCTAssertTrue(summary.accessibilityText.contains("linked worktree repo"))
+    }
+
+    func testDescriptorConversionPreservesMainAndLinkedWorktreeStatus() {
+        let mainSummary = GitWorktreeContextSummary(descriptor: makeDescriptor(isMain: true, name: "repo", branch: "main"))
+        let linkedSummary = GitWorktreeContextSummary(descriptor: makeDescriptor(isMain: false, name: "repo-feature", branch: "feature/x"))
+
+        XCTAssertTrue(mainSummary.isMain)
+        XCTAssertEqual(mainSummary.checkoutDisplayText, "main repository checkout")
+        XCTAssertTrue(mainSummary.tooltipText.contains("Checkout: main repository checkout"))
+        XCTAssertFalse(linkedSummary.isMain)
+        XCTAssertEqual(linkedSummary.checkoutDisplayText, "linked worktree")
+        XCTAssertTrue(linkedSummary.tooltipText.contains("Checkout: linked worktree"))
+    }
+
     private func makeSummary(
+        isMain: Bool = true,
         branch: String?,
         head: String?,
         isDetached: Bool
@@ -176,9 +246,40 @@ final class GitWorktreeContextSummaryTests: XCTestCase {
             worktreeID: "wt-test",
             worktreePath: "/tmp/repo",
             worktreeName: "repo",
+            isMain: isMain,
             branch: branch,
             head: head,
             isDetached: isDetached
+        )
+    }
+
+    private func makeDescriptor(
+        isMain: Bool,
+        name: String,
+        branch: String?
+    ) -> GitWorktreeDescriptor {
+        let repository = GitWorktreeRepositoryIdentity(
+            repositoryID: "gitrepo-test",
+            repoKey: "repo-test",
+            displayName: "Repo",
+            commonGitDir: "/tmp/repo/.git",
+            mainWorktreeRoot: "/tmp/repo"
+        )
+        return GitWorktreeDescriptor(
+            worktreeID: isMain ? "wt-main" : "wt-linked",
+            repository: repository,
+            path: isMain ? "/tmp/repo" : "/tmp/repo-feature",
+            gitDir: isMain ? "/tmp/repo/.git" : "/tmp/repo/.git/worktrees/repo-feature",
+            name: name,
+            branch: branch,
+            head: "1234567890abcdef",
+            isMain: isMain,
+            isCurrent: true,
+            isDetached: false,
+            isLocked: false,
+            lockReason: nil,
+            isPrunable: false,
+            prunableReason: nil
         )
     }
 }


### PR DESCRIPTION
## Summary
- preserve main-vs-linked worktree state on `GitWorktreeContextSummary`
- simplify branch/worktree tooltip metadata by removing full `HEAD` SHA and hover-only click help
- surface checkout kind as `main repository checkout` / `linked worktree`
- add focused coverage for tooltip text, descriptor propagation, fallback resolver behavior, and sidebar context preservation

## Validation
- `make dev-test FILTER=GitWorktreeContextSummaryTests`
- `make dev-test FILTER=AgentWorkspaceRootsSidebarStoreTests`
- `make dev-test FILTER=GitWorktreeContextResolverTests`
- `make dev-format`
- `make dev-lint`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh commit`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh push`
  - includes guardrails, outgoing secret scan, `make dev-lint`, full coordinated root tests, and `make dev-swift-build PRODUCT=RepoPrompt`

## Notes
- This PR is stacked on `fix/popover-scroll-cutoff` to keep the diff focused to the tooltip fix.
