### PR TITLE
Add expanded file mention picker style

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/Views/AgentInputBar.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/AgentInputBar.swift
@@ -280,6 +280,7 @@ struct AgentComposerView: View, Equatable {
     @State private var modelMenuSnapshotReleaseTask: Task<Void, Never>? = nil
 
     @ObservedObject private var fontScale = FontScaleManager.shared
+    @ObservedObject private var globalSettings = GlobalSettingsStore.shared
     private var fontPreset: FontScalePreset {
         fontScale.preset
     }
@@ -570,6 +571,7 @@ struct AgentComposerView: View, Equatable {
                     fileTagLookupContextProvider: { [tabID = props.currentTabID] in
                         await actions.agentWorkspaceLookupContext(tabID)
                     },
+                    fileMentionPickerConfiguration: globalSettings.fileMentionPickerConfiguration(),
                     onFileTagCommitted: handleFileTagCommitted(_:),
                     slashSkillSuggestionsProvider: { query in
                         await actions.slashSkillSuggestions(query)

--- a/Sources/RepoPrompt/Features/Settings/Models/GlobalSettingsDocument.swift
+++ b/Sources/RepoPrompt/Features/Settings/Models/GlobalSettingsDocument.swift
@@ -165,6 +165,7 @@ struct GlobalScalarPreferences: Codable, Equatable {
         var collapseLatestFileChanges: Bool?
         var showTooltips: Bool?
         var experimentalAttributedTextEditor: Bool?
+        var fileMentionPickerStyle: String?
         var enableKeyboardShortcuts: Bool?
         var fontScaleBodySize: Double?
 
@@ -174,6 +175,7 @@ struct GlobalScalarPreferences: Codable, Equatable {
             collapseLatestFileChanges: Bool? = nil,
             showTooltips: Bool? = nil,
             experimentalAttributedTextEditor: Bool? = nil,
+            fileMentionPickerStyle: String? = nil,
             enableKeyboardShortcuts: Bool? = nil,
             fontScaleBodySize: Double? = nil
         ) {
@@ -182,6 +184,7 @@ struct GlobalScalarPreferences: Codable, Equatable {
             self.collapseLatestFileChanges = collapseLatestFileChanges
             self.showTooltips = showTooltips
             self.experimentalAttributedTextEditor = experimentalAttributedTextEditor
+            self.fileMentionPickerStyle = fileMentionPickerStyle
             self.enableKeyboardShortcuts = enableKeyboardShortcuts
             self.fontScaleBodySize = fontScaleBodySize
         }

--- a/Sources/RepoPrompt/Features/Settings/Models/GlobalSettingsManager.swift
+++ b/Sources/RepoPrompt/Features/Settings/Models/GlobalSettingsManager.swift
@@ -467,10 +467,6 @@ class GlobalSettingsStore: ObservableObject {
         FileMentionPickerStyle.normalized(rawValue: scalarPreferences.ui?.fileMentionPickerStyle)
     }
 
-    func fileMentionPickerStyleRaw() -> String {
-        fileMentionPickerStyle().rawValue
-    }
-
     func fileMentionPickerConfiguration() -> FileMentionPickerConfiguration {
         fileMentionPickerStyle().configuration
     }
@@ -479,10 +475,6 @@ class GlobalSettingsStore: ObservableObject {
         updateUIScalar(commit: commit) { settings in
             settings.fileMentionPickerStyle = style.rawValue
         }
-    }
-
-    func setFileMentionPickerStyleRaw(_ rawValue: String?, commit: Bool = true) {
-        setFileMentionPickerStyle(FileMentionPickerStyle.normalized(rawValue: rawValue), commit: commit)
     }
 
     func enableKeyboardShortcuts() -> Bool {

--- a/Sources/RepoPrompt/Features/Settings/Models/GlobalSettingsManager.swift
+++ b/Sources/RepoPrompt/Features/Settings/Models/GlobalSettingsManager.swift
@@ -463,6 +463,28 @@ class GlobalSettingsStore: ObservableObject {
         }
     }
 
+    func fileMentionPickerStyle() -> FileMentionPickerStyle {
+        FileMentionPickerStyle.normalized(rawValue: scalarPreferences.ui?.fileMentionPickerStyle)
+    }
+
+    func fileMentionPickerStyleRaw() -> String {
+        fileMentionPickerStyle().rawValue
+    }
+
+    func fileMentionPickerConfiguration() -> FileMentionPickerConfiguration {
+        fileMentionPickerStyle().configuration
+    }
+
+    func setFileMentionPickerStyle(_ style: FileMentionPickerStyle, commit: Bool = true) {
+        updateUIScalar(commit: commit) { settings in
+            settings.fileMentionPickerStyle = style.rawValue
+        }
+    }
+
+    func setFileMentionPickerStyleRaw(_ rawValue: String?, commit: Bool = true) {
+        setFileMentionPickerStyle(FileMentionPickerStyle.normalized(rawValue: rawValue), commit: commit)
+    }
+
     func enableKeyboardShortcuts() -> Bool {
         scalarPreferences.ui?.enableKeyboardShortcuts ?? true
     }

--- a/Sources/RepoPrompt/Features/Settings/Views/General/AppearanceSettingsView.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/General/AppearanceSettingsView.swift
@@ -50,6 +50,13 @@ struct AppearanceSettingsView: View {
         )
     }
 
+    private var fileMentionPickerStyleBinding: Binding<FileMentionPickerStyle> {
+        Binding(
+            get: { globalSettings.fileMentionPickerStyle() },
+            set: { globalSettings.setFileMentionPickerStyle($0) }
+        )
+    }
+
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
@@ -130,18 +137,38 @@ struct AppearanceSettingsView: View {
                     title: "Text Editing",
                     description: "Configure text editing behavior"
                 ) {
-                    SettingToggle(
-                        title: "Enable Spell Checking in Instructions",
-                        description: "Check for spelling mistakes in the instructions text area",
-                        isOn: $promptViewModel.spellCheckInstructions
-                    )
+                    VStack(alignment: .leading, spacing: 8) {
+                        SettingToggle(
+                            title: "Enable Spell Checking in Instructions",
+                            description: "Check for spelling mistakes in the instructions text area",
+                            isOn: $promptViewModel.spellCheckInstructions
+                        )
 
-                    // Experimental toggle for the @-mention menu
-                    SettingToggle(
-                        title: "Enable @-Mention Menu (Experimental)",
-                        description: "Allows you to tag files directly in the compose prompt box using \"@file\" suggestions.",
-                        isOn: experimentalAttributedTextEditorBinding
-                    )
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("@ File Picker Style")
+                                .font(fontPreset.swiftUIFont(sizeAtNormal: 13))
+
+                            Picker("@ File Picker Style", selection: fileMentionPickerStyleBinding) {
+                                ForEach(FileMentionPickerStyle.allCases) { style in
+                                    Text(style.displayName).tag(style)
+                                }
+                            }
+                            .pickerStyle(.segmented)
+                            .labelsHidden()
+                            .frame(width: fontPreset.scaledClamped(240, max: 320), alignment: .leading)
+
+                            Text("Choose Compact or Expanded density for file @ mention suggestions.")
+                                .font(fontPreset.swiftUIFont(sizeAtNormal: 11))
+                                .foregroundColor(.secondary)
+                        }
+
+                        // Experimental toggle for the @-mention menu
+                        SettingToggle(
+                            title: "Enable @-Mention Menu (Experimental)",
+                            description: "Allows you to tag files directly in the compose prompt box using \"@file\" suggestions.",
+                            isOn: experimentalAttributedTextEditorBinding
+                        )
+                    }
                 }
                 .padding(.horizontal, fontPreset.scaledClamped(16, max: 24))
                 .padding(.bottom, fontPreset.scaledClamped(16, max: 24))

--- a/Sources/RepoPrompt/Infrastructure/UI/Mentions/AgentFileTagSuggestionService.swift
+++ b/Sources/RepoPrompt/Infrastructure/UI/Mentions/AgentFileTagSuggestionService.swift
@@ -12,6 +12,7 @@ final class AgentFileTagSuggestionService {
         let nameLower: String
         let scorePathLower: String
         let standardizedFullPath: String
+        let expandedSubtitle: String?
     }
 
     private nonisolated static let excludedPathComponent = "_git_data"
@@ -24,6 +25,7 @@ final class AgentFileTagSuggestionService {
     private weak var selectionCoordinator: WorkspaceSelectionCoordinator?
     private let lookupContextProvider: (() async -> WorkspaceLookupContext)?
     private let maxResults: Int
+    private let showsFileSubtitles: Bool
 
     private var cachedCandidates: [FileCandidate] = []
     private var cachedLookupContext: WorkspaceLookupContext = .visibleWorkspace
@@ -34,13 +36,15 @@ final class AgentFileTagSuggestionService {
         searchService: WorkspaceSearchService?,
         selectionCoordinator: WorkspaceSelectionCoordinator?,
         lookupContextProvider: (() async -> WorkspaceLookupContext)? = nil,
-        maxResults: Int = 5
+        maxResults: Int = 5,
+        showsFileSubtitles: Bool = false
     ) {
         self.store = store
         self.searchService = searchService
         self.selectionCoordinator = selectionCoordinator
         self.lookupContextProvider = lookupContextProvider
         self.maxResults = maxResults
+        self.showsFileSubtitles = showsFileSubtitles
     }
 
     func suggestions(for rawQuery: String) async -> [MentionSuggestion] {
@@ -62,7 +66,7 @@ final class AgentFileTagSuggestionService {
             if !cachedCandidates.isEmpty,
                cachedGenerationSignature == currentGeneration
             {
-                return Array(cachedCandidates.prefix(maxResults)).map(Self.makeSuggestion(from:))
+                return Array(cachedCandidates.prefix(maxResults)).map { makeSuggestion(from: $0) }
             }
             cachedCandidates.removeAll()
             cachedGenerationSignature = nil
@@ -189,7 +193,11 @@ final class AgentFileTagSuggestionService {
                 scoreRelativePath: scoreRelativePath,
                 nameLower: entry.name.lowercased(),
                 scorePathLower: scoreRelativePath.lowercased(),
-                standardizedFullPath: entry.standardizedFullPath
+                standardizedFullPath: entry.standardizedFullPath,
+                expandedSubtitle: Self.expandedSubtitleLabel(
+                    for: tokenRelativePath,
+                    fallbackRootLabel: rootLabel
+                )
             )
         }
         candidates.sort { lhs, rhs in
@@ -280,7 +288,7 @@ final class AgentFileTagSuggestionService {
 
         return scored
             .prefix(maxResults)
-            .map { Self.makeSuggestion(from: $0.candidate) }
+            .map { makeSuggestion(from: $0.candidate) }
     }
 
     /// Build the suggestion list for a bare `@` from the active stored selection.
@@ -313,12 +321,16 @@ final class AgentFileTagSuggestionService {
                 lookupContext: lookupContext
             )
             if let candidate = candidateByPath[tokenRelativePath] {
-                suggestions.append(Self.makeSuggestion(from: candidate))
+                suggestions.append(makeSuggestion(from: candidate))
             } else {
+                let rootLabel = visibleRoots
+                    .first(where: { $0.id == file.rootID })?
+                    .name
                 suggestions.append(MentionSuggestion(
                     displayName: file.name,
                     relativePath: tokenRelativePath,
                     kind: .file,
+                    subtitle: expandedSubtitleLabel(for: tokenRelativePath, fallbackRootLabel: rootLabel),
                     commitDisplayText: file.name
                 ))
             }
@@ -337,14 +349,19 @@ final class AgentFileTagSuggestionService {
         )
     }
 
-    private static func makeSuggestion(from candidate: FileCandidate) -> MentionSuggestion {
+    private func makeSuggestion(from candidate: FileCandidate) -> MentionSuggestion {
         MentionSuggestion(
             displayName: candidate.displayName,
             relativePath: candidate.tokenRelativePath,
             kind: .file,
-            subtitle: candidate.disambiguationLabel,
+            subtitle: showsFileSubtitles ? candidate.expandedSubtitle : candidate.disambiguationLabel,
             commitDisplayText: candidate.commitDisplayText
         )
+    }
+
+    private func expandedSubtitleLabel(for tokenRelativePath: String, fallbackRootLabel: String?) -> String? {
+        guard showsFileSubtitles else { return nil }
+        return Self.expandedSubtitleLabel(for: tokenRelativePath, fallbackRootLabel: fallbackRootLabel)
     }
 
     nonisolated static func commitDisplayText(
@@ -374,6 +391,17 @@ final class AgentFileTagSuggestionService {
         return parentComponents.joined(separator: "/")
     }
 
+    private nonisolated static func expandedSubtitleLabel(
+        for tokenRelativePath: String,
+        fallbackRootLabel: String?
+    ) -> String? {
+        if let parentLabel = parentDirectoryLabel(for: tokenRelativePath), !parentLabel.isEmpty {
+            return parentLabel
+        }
+        let rootLabel = fallbackRootLabel?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return rootLabel.isEmpty ? nil : rootLabel
+    }
+
     #if DEBUG
 
         // MARK: - Testing support
@@ -390,7 +418,11 @@ final class AgentFileTagSuggestionService {
                     scoreRelativePath: tokenPath,
                     nameLower: basename.lowercased(),
                     scorePathLower: tokenPath.lowercased(),
-                    standardizedFullPath: tokenPath
+                    standardizedFullPath: tokenPath,
+                    expandedSubtitle: Self.expandedSubtitleLabel(
+                        for: tokenPath,
+                        fallbackRootLabel: nil
+                    )
                 )
             }
         }

--- a/Sources/RepoPrompt/Infrastructure/UI/Mentions/FileMentionPickerStyle.swift
+++ b/Sources/RepoPrompt/Infrastructure/UI/Mentions/FileMentionPickerStyle.swift
@@ -54,7 +54,7 @@ struct FileMentionPickerConfiguration: Equatable {
     static let expanded = FileMentionPickerConfiguration(
         maxResults: 99,
         visibleRows: 15,
-        overlayWidth: 720,
+        overlayWidth: 480,
         showsFileSubtitles: true
     )
 }

--- a/Sources/RepoPrompt/Infrastructure/UI/Mentions/FileMentionPickerStyle.swift
+++ b/Sources/RepoPrompt/Infrastructure/UI/Mentions/FileMentionPickerStyle.swift
@@ -54,7 +54,7 @@ struct FileMentionPickerConfiguration: Equatable {
     static let expanded = FileMentionPickerConfiguration(
         maxResults: 99,
         visibleRows: 15,
-        overlayWidth: 480,
+        overlayWidth: 720,
         showsFileSubtitles: true
     )
 }

--- a/Sources/RepoPrompt/Infrastructure/UI/Mentions/FileMentionPickerStyle.swift
+++ b/Sources/RepoPrompt/Infrastructure/UI/Mentions/FileMentionPickerStyle.swift
@@ -53,7 +53,7 @@ struct FileMentionPickerConfiguration: Equatable {
 
     static let expanded = FileMentionPickerConfiguration(
         maxResults: 99,
-        visibleRows: 15,
+        visibleRows: 10,
         overlayWidth: 480,
         showsFileSubtitles: true
     )

--- a/Sources/RepoPrompt/Infrastructure/UI/Mentions/FileMentionPickerStyle.swift
+++ b/Sources/RepoPrompt/Infrastructure/UI/Mentions/FileMentionPickerStyle.swift
@@ -1,0 +1,60 @@
+import CoreGraphics
+import Foundation
+
+/// User-facing display mode for file @ mention pickers.
+enum FileMentionPickerStyle: String, CaseIterable, Codable, Identifiable {
+    case compact
+    case expanded
+
+    static let defaultStyle: FileMentionPickerStyle = .compact
+
+    var id: String {
+        rawValue
+    }
+
+    var displayName: String {
+        switch self {
+        case .compact: "Compact"
+        case .expanded: "Expanded"
+        }
+    }
+
+    var configuration: FileMentionPickerConfiguration {
+        switch self {
+        case .compact: .compact
+        case .expanded: .expanded
+        }
+    }
+
+    static func normalized(rawValue: String?) -> FileMentionPickerStyle {
+        guard let rawValue = rawValue?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !rawValue.isEmpty,
+              let style = FileMentionPickerStyle(rawValue: rawValue)
+        else {
+            return defaultStyle
+        }
+        return style
+    }
+}
+
+/// Derived behavior values for file @ mention pickers.
+struct FileMentionPickerConfiguration: Equatable {
+    let maxResults: Int
+    let visibleRows: Int
+    let overlayWidth: CGFloat
+    let showsFileSubtitles: Bool
+
+    static let compact = FileMentionPickerConfiguration(
+        maxResults: 5,
+        visibleRows: 5,
+        overlayWidth: 240,
+        showsFileSubtitles: false
+    )
+
+    static let expanded = FileMentionPickerConfiguration(
+        maxResults: 99,
+        visibleRows: 15,
+        overlayWidth: 480,
+        showsFileSubtitles: true
+    )
+}

--- a/Sources/RepoPrompt/Infrastructure/UI/Mentions/MentionSuggestionService.swift
+++ b/Sources/RepoPrompt/Infrastructure/UI/Mentions/MentionSuggestionService.swift
@@ -13,6 +13,7 @@ final class MentionSuggestionService {
     // MARK: – Stored refs
 
     private weak var fileManager: WorkspaceFilesViewModel?
+    private var trackedFileManagerIdentity: ObjectIdentifier?
     private var configuration: FileMentionPickerConfiguration
 
     private var maxResults: Int {
@@ -24,11 +25,17 @@ final class MentionSuggestionService {
         configuration: FileMentionPickerConfiguration = .compact
     ) {
         self.fileManager = fileManager
+        trackedFileManagerIdentity = fileManager.map(ObjectIdentifier.init)
         self.configuration = configuration
     }
 
-    func updateFileManager(_ manager: WorkspaceFilesViewModel?) {
+    @discardableResult
+    func updateFileManager(_ manager: WorkspaceFilesViewModel?) -> Bool {
+        let previousManagerWasDeallocated = fileManager == nil && trackedFileManagerIdentity != nil
+        let changed = previousManagerWasDeallocated || fileManager !== manager
         fileManager = manager
+        trackedFileManagerIdentity = manager.map(ObjectIdentifier.init)
+        return changed
     }
 
     func updateConfiguration(_ configuration: FileMentionPickerConfiguration) {

--- a/Sources/RepoPrompt/Infrastructure/UI/Mentions/MentionSuggestionService.swift
+++ b/Sources/RepoPrompt/Infrastructure/UI/Mentions/MentionSuggestionService.swift
@@ -13,15 +13,26 @@ final class MentionSuggestionService {
     // MARK: – Stored refs
 
     private weak var fileManager: WorkspaceFilesViewModel?
-    private let maxResults: Int
+    private var configuration: FileMentionPickerConfiguration
 
-    init(fileManager: WorkspaceFilesViewModel?, maxResults: Int = 5) {
+    private var maxResults: Int {
+        configuration.maxResults
+    }
+
+    init(
+        fileManager: WorkspaceFilesViewModel?,
+        configuration: FileMentionPickerConfiguration = .compact
+    ) {
         self.fileManager = fileManager
-        self.maxResults = maxResults
+        self.configuration = configuration
     }
 
     func updateFileManager(_ manager: WorkspaceFilesViewModel?) {
         fileManager = manager
+    }
+
+    func updateConfiguration(_ configuration: FileMentionPickerConfiguration) {
+        self.configuration = configuration
     }
 
     // MARK: – Public entry-point
@@ -136,11 +147,7 @@ final class MentionSuggestionService {
                     file.relativePath.range(of: searchQuery, options: .caseInsensitive) != nil
                 {
                     selectedMatches.append(
-                        MentionSuggestion(
-                            displayName: file.name,
-                            relativePath: file.relativePath,
-                            kind: .file
-                        )
+                        suggestion(for: file)
                     )
                 }
             }
@@ -176,11 +183,7 @@ final class MentionSuggestionService {
         }
 
         return files.map {
-            MentionSuggestion(
-                displayName: $0.name,
-                relativePath: $0.relativePath,
-                kind: .file
-            )
+            suggestion(for: $0)
         }
     }
 
@@ -204,15 +207,41 @@ final class MentionSuggestionService {
         }
         for file in folder.files where rows.count < limit {
             rows.append(
-                MentionSuggestion(
-                    displayName: file.name,
-                    relativePath: file.relativePath,
-                    kind: .file
-                )
+                suggestion(for: file)
             )
             if rows.count >= limit { break }
         }
         return rows
+    }
+
+    // MARK: – Helper: row construction
+
+    private func suggestion(for file: FileViewModel) -> MentionSuggestion {
+        MentionSuggestion(
+            displayName: file.name,
+            relativePath: file.relativePath,
+            kind: .file,
+            subtitle: subtitle(for: file)
+        )
+    }
+
+    private func subtitle(for file: FileViewModel) -> String? {
+        guard configuration.showsFileSubtitles else { return nil }
+
+        if let parent = parentDirectoryLabel(for: file.relativePath) {
+            return parent
+        }
+
+        let rootLabel = file.rootFolderName.trimmingCharacters(in: .whitespacesAndNewlines)
+        return rootLabel.isEmpty ? nil : rootLabel
+    }
+
+    private func parentDirectoryLabel(for relativePath: String) -> String? {
+        let normalized = StandardizedPath.relative(relativePath)
+        let parent = (normalized as NSString).deletingLastPathComponent
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !parent.isEmpty, parent != "." else { return nil }
+        return parent
     }
 
     // MARK: – Helper: recursive search
@@ -244,11 +273,7 @@ final class MentionSuggestionService {
         for file in folder.files where results.count < maxResults {
             if file.name.range(of: query, options: .caseInsensitive) != nil {
                 results.append(
-                    MentionSuggestion(
-                        displayName: file.name,
-                        relativePath: file.relativePath,
-                        kind: .file
-                    )
+                    suggestion(for: file)
                 )
                 if results.count >= maxResults { return }
             }

--- a/Sources/RepoPrompt/Infrastructure/UI/TextField/AttributedTextKitView.swift
+++ b/Sources/RepoPrompt/Infrastructure/UI/TextField/AttributedTextKitView.swift
@@ -50,6 +50,7 @@ struct AttributedTextKitView: NSViewRepresentable {
     class Coordinator: NSObject, NSTextViewDelegate {
         private let parent: AttributedTextKitView
         private let undoMgr = UndoManager()
+        private weak var fileManager: WorkspaceFilesViewModel?
         var mentionCoord: MentionCoordinator?
         fileprivate weak var mentionTV: MentionTextView?
 
@@ -76,6 +77,7 @@ struct AttributedTextKitView: NSViewRepresentable {
 
         init(_ parent: AttributedTextKitView) {
             self.parent = parent
+            fileManager = parent.fileManager
             internalText = parent.text
             wasEmpty = parent.text.isEmpty
             undoMgr.levelsOfUndo = 100
@@ -121,11 +123,11 @@ struct AttributedTextKitView: NSViewRepresentable {
         }
 
         /// Called by MentionCoordinator via closure
-        fileprivate func commit(_ suggestion: MentionSuggestion) {
+        func commit(_ suggestion: MentionSuggestion) {
             guard isActive else { return }
             let path = suggestion.relativePath
             tokenCounts[path] = (tokenCounts[path] ?? 0) + 1
-            parent.fileManager?.selectPath(path, kind: suggestion.kind)
+            fileManager?.selectPath(path, kind: suggestion.kind)
         }
 
         /// Called by MentionCoordinator via closure
@@ -135,8 +137,13 @@ struct AttributedTextKitView: NSViewRepresentable {
             let newCount = max((tokenCounts[path] ?? 1) - 1, 0)
             tokenCounts[path] = newCount
             if newCount == 0 {
-                parent.fileManager?.deselectPath(path, kind: payload.kind)
+                fileManager?.deselectPath(path, kind: payload.kind)
             }
+        }
+
+        func updateFileManager(_ manager: WorkspaceFilesViewModel?) {
+            fileManager = manager
+            mentionCoord?.updateFileManager(manager)
         }
 
         /// Syncs the internal token-count table with a freshly computed set of counts.
@@ -314,7 +321,7 @@ struct AttributedTextKitView: NSViewRepresentable {
         guard let textView = nsView.documentView as? NSTextView else { return }
 
         let fileMentionPickerConfiguration = globalSettings.fileMentionPickerConfiguration()
-        context.coordinator.mentionCoord?.updateFileManager(fileManager)
+        context.coordinator.updateFileManager(fileManager)
         context.coordinator.mentionCoord?.updateConfiguration(fileMentionPickerConfiguration)
 
         // Ensure non-contiguous layout stays disabled (fixes Intel Mac issues)

--- a/Sources/RepoPrompt/Infrastructure/UI/TextField/AttributedTextKitView.swift
+++ b/Sources/RepoPrompt/Infrastructure/UI/TextField/AttributedTextKitView.swift
@@ -27,6 +27,7 @@ struct AttributedTextKitView: NSViewRepresentable {
     weak var fileManager: WorkspaceFilesViewModel?
 
     @ObservedObject private var fontScale = FontScaleManager.shared
+    @ObservedObject private var globalSettings = GlobalSettingsStore.shared
 
     private var resolvedFontSize: CGFloat {
         if let fontSize {
@@ -244,13 +245,15 @@ struct AttributedTextKitView: NSViewRepresentable {
         // ------------------------------------------------------------------
         // Mention system wiring
         // ------------------------------------------------------------------
+        let fileMentionPickerConfiguration = globalSettings.fileMentionPickerConfiguration()
         let svc = MentionSuggestionService(
             fileManager: fileManager,
-            maxResults: 5
+            configuration: fileMentionPickerConfiguration
         )
         let mc = MentionCoordinator(
             textView: textView,
             suggestionService: svc,
+            configuration: fileMentionPickerConfiguration,
             commitHandler: { [weak c = context.coordinator] sugg in
                 c?.commit(sugg)
             },
@@ -309,6 +312,10 @@ struct AttributedTextKitView: NSViewRepresentable {
 
     func updateNSView(_ nsView: NSScrollView, context: Context) {
         guard let textView = nsView.documentView as? NSTextView else { return }
+
+        let fileMentionPickerConfiguration = globalSettings.fileMentionPickerConfiguration()
+        context.coordinator.mentionCoord?.updateFileManager(fileManager)
+        context.coordinator.mentionCoord?.updateConfiguration(fileMentionPickerConfiguration)
 
         // Ensure non-contiguous layout stays disabled (fixes Intel Mac issues)
         if let layoutManager = textView.layoutManager,

--- a/Sources/RepoPrompt/Infrastructure/UI/TextField/MentionCoordinator.swift
+++ b/Sources/RepoPrompt/Infrastructure/UI/TextField/MentionCoordinator.swift
@@ -4,7 +4,20 @@ import Foundation
 
 @MainActor
 final class MentionCoordinator: MentionTextViewDelegate {
-    // MARK: – Init & stored refs
+    private struct LevelState {
+        let parent: MentionSuggestion?
+        var suggestions: [MentionSuggestion]
+        var highlightedIndex: Int
+    }
+
+    private struct QueryRequest {
+        let query: String
+        let parent: MentionSuggestion?
+        let preserveIndex: Bool
+        let epoch: UInt64
+    }
+
+    // MARK: - Init & stored refs
 
     private unowned let textView: MentionTextView
     private let suggestionService: MentionSuggestionService
@@ -27,32 +40,28 @@ final class MentionCoordinator: MentionTextViewDelegate {
         self.tokenRemovedHandler = tokenRemovedHandler
         applyConfiguration(configuration)
 
-        // ------------------------------------------------------------------
-        // Debounce search queries (80 ms) so the UI remains responsive while
-        // the user is typing fast.  The subscription is stored in
-        // `cancellables`, so it is cancelled automatically on deinit.
-        // ------------------------------------------------------------------
         querySubject
             .debounce(for: .milliseconds(80), scheduler: RunLoop.main)
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] q, parent, preserve in
-                self?.runQuery(q, parent: parent, preserveIndex: preserve)
+            .sink { [weak self] request in
+                self?.runQuery(request)
             }
             .store(in: &cancellables)
+
+        overlay.onRowClicked = { [weak self] level, index in
+            self?.selectSuggestion(at: index, inLevel: level)
+        }
     }
 
     func updateFileManager(_ manager: WorkspaceFilesViewModel?) {
-        suggestionService.updateFileManager(manager)
+        guard suggestionService.updateFileManager(manager) else { return }
+        resetMentionSession(endTextViewSession: true)
     }
 
     func updateConfiguration(_ configuration: FileMentionPickerConfiguration) {
         guard self.configuration != configuration else { return }
         self.configuration = configuration
-        textView.endMentionSession()
-        suggestions.removeAll()
-        highlighted = 0
-        parentStack = [nil]
-        highlightStack = [0]
+        resetMentionSession(endTextViewSession: true)
         applyConfiguration(configuration)
     }
 
@@ -62,150 +71,106 @@ final class MentionCoordinator: MentionTextViewDelegate {
         overlay.visibleRowLimit = configuration.visibleRows
     }
 
-    // MARK: – Internal state
+    // MARK: - Internal state
 
-    private var parentStack: [MentionSuggestion?] = [nil]
-    // Mirrors `parentStack` – keeps the highlighted row for every depth
-    private var highlightStack: [Int] = [0]
-    private var suggestions: [MentionSuggestion] = []
-    private var highlighted: Int = 0
+    private var levels = [LevelState(parent: nil, suggestions: [], highlightedIndex: 0)]
 
-    // Combine-based debounce ------------------------------------------------
-    private let querySubject = PassthroughSubject<(String, MentionSuggestion?, Bool), Never>()
+    private var currentParent: MentionSuggestion? {
+        guard let level = levels.last else { return nil }
+        return level.parent
+    }
+
+    private var currentSuggestions: [MentionSuggestion] {
+        levels.last?.suggestions ?? []
+    }
+
+    private var currentHighlightedIndex: Int {
+        levels.last?.highlightedIndex ?? 0
+    }
+
+    private let querySubject = PassthroughSubject<QueryRequest, Never>()
     private var cancellables = Set<AnyCancellable>()
+    private var queryEpoch: UInt64 = 0
     private var pendingReanchorTask: Task<Void, Never>?
     private var reanchorGeneration: UInt64 = 0
 
-    // MARK: – Delegate entry-points (will be wired later)
+    // MARK: - MentionTextViewDelegate
 
     func mentionStarted(at caret: NSRect) {
-        parentStack = [nil]
-        highlightStack = [0]
-        highlighted = 0
+        invalidatePendingQueries()
 
-        // Pre-compute the default suggestion list (empty query at repo root)
-        let initialItems = suggestionService.suggestions(for: "", under: nil)
-        suggestions = initialItems
+        let initialSuggestions = suggestionService.suggestions(for: "", under: nil)
+        levels = [LevelState(parent: nil, suggestions: initialSuggestions, highlightedIndex: 0)]
 
         guard !textView.hasMarkedText(), let host = textView.window else {
             overlay.hide()
             return
         }
-        // Pass the real items right away so the table never displays the
-        // "No results found" placeholder.
-        overlay.show(at: caret, owner: host, items: initialItems)
+        overlay.show(at: caret, owner: host, items: initialSuggestions)
         scheduleOverlayReanchor()
     }
 
-    /// ------------------------------------------------------------------
-    /// Overload required by `MentionTextViewDelegate` for protocol conformance
-    /// ------------------------------------------------------------------
-    func mentionQueryChanged(_ q: String, parent: MentionSuggestion?) {
-        mentionQueryChanged(q, parent: parent, preserveIndex: false)
+    func mentionQueryChanged(_ query: String, parent: MentionSuggestion?) {
+        mentionQueryChanged(query, parent: parent, preserveIndex: false)
     }
 
     func mentionQueryChanged(
-        _ q: String,
+        _ query: String,
         parent: MentionSuggestion?,
         preserveIndex: Bool = false
     ) {
-        // Push every change through the Combine pipeline; the subscriber
-        // will receive debounced updates on the main run-loop.
-        querySubject.send((q, parent, preserveIndex))
+        querySubject.send(QueryRequest(
+            query: query,
+            parent: parent,
+            preserveIndex: preserveIndex,
+            epoch: queryEpoch
+        ))
     }
 
-    // ------------------------------------------------------------------
-    // MARK: – Private helpers
+    func mentionNavigate(_ command: MentionNavigationCommand) {
+        guard let currentLevelIndex = levels.indices.last else { return }
 
-    /// ------------------------------------------------------------------
-    private func runQuery(
-        _ q: String,
-        parent: MentionSuggestion?,
-        preserveIndex: Bool
-    ) {
-        guard !textView.hasMarkedText() else {
-            overlay.hide()
-            return
-        }
-        // Resolve `nil` parent to the current folder context so searches stay
-        // properly scoped after the user has drilled into a sub-folder.
-        let effectiveParent = parent ?? parentStack.last ?? nil
-        let items = suggestionService.suggestions(for: q, under: effectiveParent)
-        suggestions = items
-
-        // Decide which row should be highlighted first
-        let desired = preserveIndex
-            ? (highlightStack.last ?? 0)
-            : 0
-        // Clamp in case the list shrunk; avoid negative when list is empty
-        highlighted = items.isEmpty ? 0 : min(max(desired, 0), items.count - 1)
-
-        // Sync per-level cache
-        if !highlightStack.isEmpty {
-            highlightStack[highlightStack.count - 1] = highlighted
-        }
-
-        overlay.update(items: items, highlighted: highlighted)
-        guard textView.window != nil else {
-            overlay.hide()
-            return
-        }
-        scheduleOverlayReanchor()
-    }
-
-    func mentionNavigate(_ cmd: MentionNavigationCommand) {
-        // Ensure stacks are initialized
-        if highlightStack.isEmpty {
-            highlightStack = [0]
-        }
-        if parentStack.isEmpty {
-            parentStack = [nil]
-        }
-        switch cmd {
+        switch command {
         case .up:
-            highlighted = (highlighted - 1 + suggestions.count) % max(suggestions.count, 1)
+            let count = levels[currentLevelIndex].suggestions.count
+            levels[currentLevelIndex].highlightedIndex =
+                (levels[currentLevelIndex].highlightedIndex - 1 + count) % max(count, 1)
             overlay.moveHighlight(by: -1)
-            if !highlightStack.isEmpty {
-                highlightStack[highlightStack.count - 1] = highlighted
-            }
         case .down:
-            highlighted = (highlighted + 1) % max(suggestions.count, 1)
-            overlay.moveHighlight(by: +1)
-            if !highlightStack.isEmpty {
-                highlightStack[highlightStack.count - 1] = highlighted
-            }
+            let count = levels[currentLevelIndex].suggestions.count
+            levels[currentLevelIndex].highlightedIndex =
+                (levels[currentLevelIndex].highlightedIndex + 1) % max(count, 1)
+            overlay.moveHighlight(by: 1)
         case .left:
-            guard parentStack.count > 1 else { return }
-            parentStack.removeLast()
-            highlightStack.removeLast()
-            highlighted = highlightStack.last ?? 0
-
+            guard levels.count > 1 else { return }
+            levels.removeLast()
             overlay.popLevel()
-            // Refresh suggestions for the new parent folder but keep index
-            mentionQueryChanged("", parent: parentStack.last ?? nil, preserveIndex: true)
+            mentionQueryChanged("", parent: currentParent, preserveIndex: true)
         case .right:
-            guard highlighted >= 0,
-                  highlighted < suggestions.count,
-                  suggestions[highlighted].kind == .folder
-            else { return }
-            parentStack.append(suggestions[highlighted])
-            // Store current selection, start child level at 0
-            highlightStack.append(0)
+            guard currentSuggestions.indices.contains(currentHighlightedIndex) else { return }
+            let selectedSuggestion = currentSuggestions[currentHighlightedIndex]
+            guard selectedSuggestion.kind == .folder else { return }
+
+            levels.append(LevelState(
+                parent: selectedSuggestion,
+                suggestions: [],
+                highlightedIndex: 0
+            ))
             overlay.pushLevel()
-            // clear query for new level
-            mentionQueryChanged("", parent: parentStack.last ?? nil)
+            mentionQueryChanged("", parent: selectedSuggestion)
         }
     }
 
     func mentionAccept() {
-        guard highlighted >= 0, highlighted < suggestions.count else { return }
-        let sugg = suggestions[highlighted]
-        overlay.hide() // Tear down UI first
-        textView.insertMentionToken(sugg) // Then mutate text
-        commitHandler(sugg)
+        guard currentSuggestions.indices.contains(currentHighlightedIndex) else { return }
+        let suggestion = currentSuggestions[currentHighlightedIndex]
+        overlay.hide()
+        textView.insertMentionToken(suggestion)
+        commitHandler(suggestion)
     }
 
     func mentionAbort() {
+        invalidatePendingQueries()
         pendingReanchorTask?.cancel()
         overlay.hide()
     }
@@ -214,16 +179,70 @@ final class MentionCoordinator: MentionTextViewDelegate {
         tokenRemovedHandler(payload)
     }
 
-    /// ------------------------------------------------------------------
-    /// Ensure no suggestion window survives the lifetime of the coordinator
-    /// ------------------------------------------------------------------
     deinit {
         pendingReanchorTask?.cancel()
-        // Capture overlay in a local so we don't rebuild self-access after
-        // the object is partially de-initialised.
-        let overlayRef = self.overlay
+        let overlay = self.overlay
         Task { @MainActor in
-            overlayRef.hide()
+            overlay.hide()
+        }
+    }
+
+    // MARK: - Private helpers
+
+    private func runQuery(_ request: QueryRequest) {
+        guard request.epoch == queryEpoch else { return }
+        guard !textView.hasMarkedText() else {
+            overlay.hide()
+            return
+        }
+
+        let parent = request.parent ?? currentParent
+        let suggestions = suggestionService.suggestions(for: request.query, under: parent)
+        let desiredIndex = request.preserveIndex ? currentHighlightedIndex : 0
+        let highlightedIndex = suggestions.isEmpty
+            ? 0
+            : min(max(desiredIndex, 0), suggestions.count - 1)
+
+        if let currentLevelIndex = levels.indices.last {
+            levels[currentLevelIndex].suggestions = suggestions
+            levels[currentLevelIndex].highlightedIndex = highlightedIndex
+        } else {
+            levels = [LevelState(
+                parent: parent,
+                suggestions: suggestions,
+                highlightedIndex: highlightedIndex
+            )]
+        }
+
+        overlay.update(items: suggestions, highlighted: highlightedIndex)
+        guard textView.window != nil else {
+            overlay.hide()
+            return
+        }
+        scheduleOverlayReanchor()
+    }
+
+    private func selectSuggestion(at index: Int, inLevel level: Int) {
+        guard levels.indices.contains(level),
+              levels[level].suggestions.indices.contains(index)
+        else { return }
+
+        invalidatePendingQueries()
+        levels = Array(levels.prefix(level + 1))
+        levels[level].highlightedIndex = index
+    }
+
+    private func invalidatePendingQueries() {
+        queryEpoch &+= 1
+    }
+
+    private func resetMentionSession(endTextViewSession: Bool) {
+        invalidatePendingQueries()
+        pendingReanchorTask?.cancel()
+        levels = [LevelState(parent: nil, suggestions: [], highlightedIndex: 0)]
+        overlay.hide()
+        if endTextViewSession {
+            textView.endMentionSession()
         }
     }
 
@@ -245,12 +264,36 @@ final class MentionCoordinator: MentionTextViewDelegate {
                 overlay.hide()
                 return
             }
-            let selection = textView.clampSelectionToCurrentString()
+            let displaySelectionRange = textView.clampSelectionToCurrentString()
             let caretRect = textView.firstRect(
-                forCharacterRange: selection,
+                forCharacterRange: displaySelectionRange,
                 actualRange: nil
             )
             overlay.repositionRoot(to: caretRect)
         }
     }
+
+    #if DEBUG
+        var testSuggestions: [MentionSuggestion] {
+            currentSuggestions
+        }
+
+        var testOverlayWindowCount: Int {
+            overlay.testWindowCount
+        }
+
+        func testSuggestions(atLevel level: Int) -> [MentionSuggestion] {
+            guard levels.indices.contains(level) else { return [] }
+            return levels[level].suggestions
+        }
+
+        func testHighlightedIndex(atLevel level: Int) -> Int? {
+            guard levels.indices.contains(level) else { return nil }
+            return levels[level].highlightedIndex
+        }
+
+        func testClickOverlayRow(level: Int, index: Int) {
+            overlay.clickRowForTesting(level: level, index: index)
+        }
+    #endif
 }

--- a/Sources/RepoPrompt/Infrastructure/UI/TextField/MentionCoordinator.swift
+++ b/Sources/RepoPrompt/Infrastructure/UI/TextField/MentionCoordinator.swift
@@ -9,19 +9,23 @@ final class MentionCoordinator: MentionTextViewDelegate {
     private unowned let textView: MentionTextView
     private let suggestionService: MentionSuggestionService
     private let overlay = MentionOverlayController()
+    private var configuration: FileMentionPickerConfiguration
     private let commitHandler: (MentionSuggestion) -> Void
     private let tokenRemovedHandler: (MentionTokenPayload) -> Void
 
     init(
         textView: MentionTextView,
         suggestionService: MentionSuggestionService,
+        configuration: FileMentionPickerConfiguration = .compact,
         commitHandler: @escaping (MentionSuggestion) -> Void,
         tokenRemovedHandler: @escaping (MentionTokenPayload) -> Void
     ) {
         self.textView = textView
         self.suggestionService = suggestionService
+        self.configuration = configuration
         self.commitHandler = commitHandler
         self.tokenRemovedHandler = tokenRemovedHandler
+        applyConfiguration(configuration)
 
         // ------------------------------------------------------------------
         // Debounce search queries (80 ms) so the UI remains responsive while
@@ -35,6 +39,22 @@ final class MentionCoordinator: MentionTextViewDelegate {
                 self?.runQuery(q, parent: parent, preserveIndex: preserve)
             }
             .store(in: &cancellables)
+    }
+
+    func updateFileManager(_ manager: WorkspaceFilesViewModel?) {
+        suggestionService.updateFileManager(manager)
+    }
+
+    func updateConfiguration(_ configuration: FileMentionPickerConfiguration) {
+        guard self.configuration != configuration else { return }
+        self.configuration = configuration
+        applyConfiguration(configuration)
+    }
+
+    private func applyConfiguration(_ configuration: FileMentionPickerConfiguration) {
+        suggestionService.updateConfiguration(configuration)
+        overlay.suggestedWidth = configuration.overlayWidth
+        overlay.visibleRowLimit = configuration.visibleRows
     }
 
     // MARK: – Internal state

--- a/Sources/RepoPrompt/Infrastructure/UI/TextField/MentionCoordinator.swift
+++ b/Sources/RepoPrompt/Infrastructure/UI/TextField/MentionCoordinator.swift
@@ -48,6 +48,11 @@ final class MentionCoordinator: MentionTextViewDelegate {
     func updateConfiguration(_ configuration: FileMentionPickerConfiguration) {
         guard self.configuration != configuration else { return }
         self.configuration = configuration
+        textView.endMentionSession()
+        suggestions.removeAll()
+        highlighted = 0
+        parentStack = [nil]
+        highlightStack = [0]
         applyConfiguration(configuration)
     }
 

--- a/Sources/RepoPrompt/Infrastructure/UI/TextField/MentionOverlayController.swift
+++ b/Sources/RepoPrompt/Infrastructure/UI/TextField/MentionOverlayController.swift
@@ -10,7 +10,18 @@ final class MentionOverlayController {
         case below
     }
 
+    struct ScreenGeometry: Equatable {
+        let frame: NSRect
+        let visibleFrame: NSRect
+    }
+
+    struct RootPlacementResult: Equatable {
+        let frame: NSRect
+        let placement: Placement
+    }
+
     var placement: Placement = .below
+    var onRowClicked: ((_ level: Int, _ index: Int) -> Void)?
     var suggestedWidth: CGFloat = 240
     var visibleRowLimit: Int = 5 {
         didSet {
@@ -27,6 +38,7 @@ final class MentionOverlayController {
 
     /// Remember latest caret rect so we can re-anchor after every resize.
     private var latestCaretRect: NSRect?
+    private var resolvedPlacement: Placement?
 
     // MARK: – Public API -----------------------------------------------------
 
@@ -72,10 +84,11 @@ final class MentionOverlayController {
         guard let previous = windows.last else { return }
         let w = SuggestionWindow(
             parent: previous.parentTextView,
-            placement: placement,
+            placement: resolvedPlacement ?? placement,
             width: suggestedWidth,
             visibleRowLimit: Self.normalizedVisibleRowLimit(visibleRowLimit)
         )
+        wireRowClick(for: w)
         windows.append(w)
         chainWindow(w, after: previous)
         enforceScreenBounds()
@@ -98,6 +111,7 @@ final class MentionOverlayController {
         windows.removeAll()
         ownerWindow = nil
         latestCaretRect = nil
+        resolvedPlacement = nil
     }
 
     // MARK: – Private --------------------------------------------------------
@@ -114,6 +128,7 @@ final class MentionOverlayController {
             width: suggestedWidth,
             visibleRowLimit: Self.normalizedVisibleRowLimit(visibleRowLimit)
         )
+        wireRowClick(for: root)
         owner.addChildWindow(root, ordered: .above)
         windows.append(root)
     }
@@ -128,40 +143,119 @@ final class MentionOverlayController {
         placement: Placement,
         visibleFrame: NSRect?
     ) -> NSRect {
-        var frame = NSRect(origin: .zero, size: popupSize)
-        switch placement {
-        case .above:
-            frame.origin = NSPoint(x: caret.minX, y: caret.maxY + 4)
-        case .below:
-            frame.origin = NSPoint(x: caret.minX, y: caret.minY - 2 - popupSize.height)
+        resolvedRootPlacement(
+            caret: caret,
+            popupSize: popupSize,
+            placement: placement,
+            visibleFrame: visibleFrame
+        ).frame
+    }
+
+    static func resolvedRootPlacement(
+        caret: NSRect,
+        popupSize: NSSize,
+        placement: Placement,
+        visibleFrame: NSRect?
+    ) -> RootPlacementResult {
+        let preferred = rootFrame(caret: caret, popupSize: popupSize, placement: placement)
+        guard let visibleFrame else {
+            return RootPlacementResult(frame: preferred, placement: placement)
         }
-        return clampedFrame(frame, to: visibleFrame)
+
+        if fitsVertically(preferred, in: visibleFrame) {
+            return RootPlacementResult(
+                frame: clampedFrame(preferred, to: visibleFrame),
+                placement: placement
+            )
+        }
+
+        let alternatePlacement: Placement = placement == .above ? .below : .above
+        let alternate = rootFrame(caret: caret, popupSize: popupSize, placement: alternatePlacement)
+        if fitsVertically(alternate, in: visibleFrame) {
+            return RootPlacementResult(
+                frame: clampedFrame(alternate, to: visibleFrame),
+                placement: alternatePlacement
+            )
+        }
+
+        let preferredArea = visibleIntersectionArea(preferred, visibleFrame)
+        let alternateArea = visibleIntersectionArea(alternate, visibleFrame)
+        if alternateArea > preferredArea {
+            return RootPlacementResult(
+                frame: clampedFrame(alternate, to: visibleFrame),
+                placement: alternatePlacement
+            )
+        }
+        return RootPlacementResult(
+            frame: clampedFrame(preferred, to: visibleFrame),
+            placement: placement
+        )
     }
 
     static func positionedChildFrame(
         after previousFrame: NSRect,
         popupSize: NSSize,
         placement: Placement,
-        visibleFrame: NSRect?
+        visibleFrame: NSRect?,
+        avoiding occupiedFrames: [NSRect] = []
     ) -> NSRect {
-        var frame = NSRect(origin: .zero, size: popupSize)
-        switch placement {
-        case .above:
-            frame.origin = NSPoint(x: previousFrame.maxX + 4, y: previousFrame.minY)
-        case .below:
-            frame.origin = NSPoint(x: previousFrame.maxX - 1, y: previousFrame.maxY - popupSize.height)
-        }
+        let verticalOrigin = placement == .above
+            ? previousFrame.minY
+            : previousFrame.maxY - popupSize.height
+        let gap: CGFloat = 4
+        let occupied = occupiedFrames.isEmpty ? [previousFrame] : occupiedFrames
+        let occupiedUnion = occupied.dropFirst().reduce(occupied[0]) { $0.union($1) }
+        let candidateXPositions = [
+            previousFrame.maxX + gap,
+            previousFrame.minX - popupSize.width - gap,
+            occupiedUnion.maxX + gap,
+            occupiedUnion.minX - popupSize.width - gap
+        ]
 
-        if let visibleFrame,
-           frame.maxX > visibleFrame.maxX
-        {
-            let leftX = previousFrame.minX - popupSize.width - 4
-            if leftX >= visibleFrame.minX {
-                frame.origin.x = leftX
+        var candidates: [NSRect] = []
+        for x in candidateXPositions {
+            let candidate = clampedFrame(
+                NSRect(
+                    x: x,
+                    y: verticalOrigin,
+                    width: popupSize.width,
+                    height: popupSize.height
+                ),
+                to: visibleFrame
+            )
+            if !candidates.contains(candidate) {
+                candidates.append(candidate)
             }
         }
 
-        return clampedFrame(frame, to: visibleFrame)
+        return candidates.enumerated().min { lhs, rhs in
+            let leftOverlap = overlapArea(lhs.element, frames: occupied)
+            let rightOverlap = overlapArea(rhs.element, frames: occupied)
+            return leftOverlap == rightOverlap ? lhs.offset < rhs.offset : leftOverlap < rightOverlap
+        }?.element ?? clampedFrame(NSRect(origin: .zero, size: popupSize), to: visibleFrame)
+    }
+
+    static func selectedVisibleFrame(
+        for caret: NSRect,
+        screens: [ScreenGeometry]
+    ) -> NSRect? {
+        guard !screens.isEmpty else { return nil }
+
+        let intersecting = screens.enumerated().map { index, screen in
+            (index, screen, visibleIntersectionArea(caret, screen.frame))
+        }
+        if let best = intersecting.max(by: { lhs, rhs in
+            lhs.2 == rhs.2 ? lhs.0 > rhs.0 : lhs.2 < rhs.2
+        }), best.2 > 0 {
+            return best.1.visibleFrame
+        }
+
+        let caretCenter = NSPoint(x: caret.midX, y: caret.midY)
+        return screens.enumerated().min { lhs, rhs in
+            let leftDistance = squaredDistance(from: caretCenter, to: lhs.element.frame)
+            let rightDistance = squaredDistance(from: caretCenter, to: rhs.element.frame)
+            return leftDistance == rightDistance ? lhs.offset < rhs.offset : leftDistance < rightDistance
+        }?.element.visibleFrame
     }
 
     static func clampedFrame(_ frame: NSRect, to visibleFrame: NSRect?) -> NSRect {
@@ -174,61 +268,161 @@ final class MentionOverlayController {
             clamped.origin.x = visibleFrame.minX
         }
 
+        return clampedVertically(clamped, to: visibleFrame)
+    }
+
+    private static func rootFrame(
+        caret: NSRect,
+        popupSize: NSSize,
+        placement: Placement
+    ) -> NSRect {
+        let origin = switch placement {
+        case .above:
+            NSPoint(x: caret.minX, y: caret.maxY + 4)
+        case .below:
+            NSPoint(x: caret.minX, y: caret.minY - 2 - popupSize.height)
+        }
+        return NSRect(origin: origin, size: popupSize)
+    }
+
+    private static func fitsVertically(_ frame: NSRect, in visibleFrame: NSRect) -> Bool {
+        frame.minY >= visibleFrame.minY && frame.maxY <= visibleFrame.maxY
+    }
+
+    private static func clampedVertically(_ frame: NSRect, to visibleFrame: NSRect?) -> NSRect {
+        guard let visibleFrame else { return frame }
+        var clamped = frame
         if clamped.height <= visibleFrame.height {
             clamped.origin.y = min(max(clamped.minY, visibleFrame.minY), visibleFrame.maxY - clamped.height)
         } else {
             clamped.origin.y = visibleFrame.minY
         }
-
         return clamped
+    }
+
+    private static func overlapArea(_ frame: NSRect, frames: [NSRect]) -> CGFloat {
+        frames.reduce(0) { $0 + visibleIntersectionArea(frame, $1) }
+    }
+
+    private static func visibleIntersectionArea(_ lhs: NSRect, _ rhs: NSRect) -> CGFloat {
+        let intersection = lhs.intersection(rhs)
+        guard !intersection.isNull else { return 0 }
+        return max(intersection.width, 0) * max(intersection.height, 0)
+    }
+
+    private static func squaredDistance(from point: NSPoint, to rect: NSRect) -> CGFloat {
+        let dx = max(max(rect.minX - point.x, 0), point.x - rect.maxX)
+        let dy = max(max(rect.minY - point.y, 0), point.y - rect.maxY)
+        return dx * dx + dy * dy
     }
 
     private func chainWindow(_ w: SuggestionWindow, after prev: NSWindow) {
         let parentWin = prev.parent ?? prev
+        let childPlacement = resolvedPlacement ?? placement
         parentWin.addChildWindow(w, ordered: .above)
         w.orderFront(nil)
+        w.setPlacement(childPlacement)
         w.setFrame(
             Self.positionedChildFrame(
                 after: prev.frame,
                 popupSize: w.frame.size,
-                placement: placement,
-                visibleFrame: visibleFrame
+                placement: childPlacement,
+                visibleFrame: visibleFrame,
+                avoiding: windows.dropLast().map(\.frame)
             ),
             display: true
         )
         w.alphaValue = 1
     }
 
-    private var visibleFrame: NSRect? {
-        ownerWindow?.screen?.visibleFrame
+    private func wireRowClick(for window: SuggestionWindow) {
+        window.onRowClicked = { [weak self, weak window] index in
+            guard let self, let window,
+                  let level = windows.firstIndex(where: { $0 === window })
+            else { return }
+            popToLevel(level)
+            onRowClicked?(level, index)
+        }
     }
+
+    private func popToLevel(_ level: Int) {
+        guard windows.indices.contains(level) else { return }
+        while windows.count > level + 1 {
+            let window = windows.removeLast()
+            window.orderOut(nil)
+            window.parent?.removeChildWindow(window)
+        }
+    }
+
+    private var visibleFrame: NSRect? {
+        #if DEBUG
+            if let visibleFrameOverrideForTesting {
+                return visibleFrameOverrideForTesting
+            }
+        #endif
+        if let caret = latestCaretRect,
+           let selected = Self.selectedVisibleFrame(
+               for: caret,
+               screens: NSScreen.screens.map {
+                   ScreenGeometry(frame: $0.frame, visibleFrame: $0.visibleFrame)
+               }
+           )
+        {
+            return selected
+        }
+        return ownerWindow?.screen?.visibleFrame
+    }
+
+    #if DEBUG
+        var visibleFrameOverrideForTesting: NSRect?
+
+        var testWindowCount: Int {
+            windows.count
+        }
+
+        var testWindowFrames: [NSRect] {
+            windows.map(\.frame)
+        }
+
+        var testWindowPlacements: [Placement] {
+            windows.map(\.placement)
+        }
+
+        func clickRowForTesting(level: Int, index: Int) {
+            guard windows.indices.contains(level) else { return }
+            windows[level].clickRowForTesting(index)
+        }
+    #endif
 
     private func enforceScreenBounds() {
         guard !windows.isEmpty else { return }
         if let root = windows.first,
            let caret = latestCaretRect
         {
-            root.setFrame(
-                Self.positionedRootFrame(
-                    caret: caret,
-                    popupSize: root.frame.size,
-                    placement: placement,
-                    visibleFrame: visibleFrame
-                ),
-                display: true
+            let result = Self.resolvedRootPlacement(
+                caret: caret,
+                popupSize: root.frame.size,
+                placement: placement,
+                visibleFrame: visibleFrame
             )
+            resolvedPlacement = result.placement
+            root.setPlacement(result.placement)
+            root.setFrame(result.frame, display: true)
         }
 
         guard windows.count > 1 else { return }
+        let childPlacement = resolvedPlacement ?? placement
         for idx in 1 ..< windows.count {
             let previous = windows[idx - 1]
             let current = windows[idx]
+            current.setPlacement(childPlacement)
             current.setFrame(
                 Self.positionedChildFrame(
                     after: previous.frame,
                     popupSize: current.frame.size,
-                    placement: placement,
-                    visibleFrame: visibleFrame
+                    placement: childPlacement,
+                    visibleFrame: visibleFrame,
+                    avoiding: windows[..<idx].map(\.frame)
                 ),
                 display: true
             )
@@ -247,11 +441,12 @@ extension MentionOverlayController {
     /// system vibrancy / popover material.
     final class SuggestionWindow: NSWindow {
         weak var parentTextView: MentionTextView?
-        let placement: MentionOverlayController.Placement
+        private(set) var placement: MentionOverlayController.Placement
 
         // SwiftUI bridge
         private let model = MentionSuggestionListModel()
         private var hostingView: NSHostingView<MentionSuggestionListView>?
+        var onRowClicked: ((Int) -> Void)?
 
         // MARK: – Init
 
@@ -311,6 +506,7 @@ extension MentionOverlayController {
             model.onRowClicked = { [weak self] index in
                 guard let self else { return }
                 model.highlightedIndex = index
+                onRowClicked?(index)
             }
         }
 
@@ -336,11 +532,21 @@ extension MentionOverlayController {
                 % model.suggestions.count
         }
 
+        func setPlacement(_ placement: MentionOverlayController.Placement) {
+            self.placement = placement
+        }
+
         func setVisibleRowLimit(_ limit: Int) {
             visibleRowLimit = MentionOverlayController.normalizedVisibleRowLimit(limit)
             model.visibleRowLimit = visibleRowLimit
             resizeWindow(for: max(model.suggestions.count, 1))
         }
+
+        #if DEBUG
+            func clickRowForTesting(_ index: Int) {
+                model.onRowClicked?(index)
+            }
+        #endif
 
         // MARK: – Layout
 

--- a/Sources/RepoPrompt/Infrastructure/UI/TextField/MentionOverlayController.swift
+++ b/Sources/RepoPrompt/Infrastructure/UI/TextField/MentionOverlayController.swift
@@ -21,11 +21,12 @@ final class MentionOverlayController {
             for window in windows {
                 window.setVisibleRowLimit(normalizedLimit)
             }
+            enforceScreenBounds()
         }
     }
 
-    /// Remember latest caret anchor so we can re-anchor after every resize
-    private var caretAnchor: NSPoint?
+    /// Remember latest caret rect so we can re-anchor after every resize.
+    private var latestCaretRect: NSRect?
 
     // MARK: – Public API -----------------------------------------------------
 
@@ -39,17 +40,8 @@ final class MentionOverlayController {
         prepareRootWindowIfNeeded(owner: owner)
         guard let root = windows.first else { return }
 
-        if placement == .above {
-            caretAnchor = NSPoint(x: caret.minX, y: caret.maxY + 4)
-            if let anchor = caretAnchor {
-                root.setFrameOrigin(anchor)
-            }
-        } else {
-            caretAnchor = NSPoint(x: caret.minX, y: caret.minY - 2)
-            if let anchor = caretAnchor {
-                root.setFrameTopLeftPoint(anchor)
-            }
-        }
+        latestCaretRect = caret
+        enforceScreenBounds()
 
         root.orderFront(nil)
         root.alphaValue = 1
@@ -59,43 +51,15 @@ final class MentionOverlayController {
     /// Re-aligns the root window to the current caret (call after each resize
     /// or when the caret moved horizontally while typing).
     func repositionRoot(to caret: NSRect) {
-        if placement == .above {
-            caretAnchor = NSPoint(x: caret.minX, y: caret.maxY + 4)
-        } else {
-            caretAnchor = NSPoint(x: caret.minX, y: caret.minY - 2)
-        }
-
-        guard let root = windows.first,
-              let anchor = caretAnchor
-        else { return }
-
-        // 1. Move root
-        if placement == .above {
-            root.setFrameOrigin(anchor)
-        } else {
-            root.setFrameTopLeftPoint(anchor)
-        }
-
-        // 2. Chain children horizontally, preserving gaps
-        if windows.count > 1 {
-            for idx in 1 ..< windows.count {
-                let prev = windows[idx - 1]
-                let current = windows[idx]
-                if placement == .above {
-                    let bottomLeft = NSPoint(x: prev.frame.maxX + 4, y: prev.frame.minY)
-                    current.setFrameOrigin(bottomLeft)
-                } else {
-                    let topLeft = NSPoint(x: prev.frame.maxX - 1, y: prev.frame.maxY)
-                    current.setFrameTopLeftPoint(topLeft)
-                }
-            }
-        }
+        latestCaretRect = caret
+        enforceScreenBounds()
     }
 
     /// Replace the list of rows in the *current* level.
     func update(items: [MentionSuggestion], highlighted: Int) {
         guard let win = windows.last else { return }
         win.updateSuggestions(items, highlighted: highlighted)
+        enforceScreenBounds()
     }
 
     /// Move selection by ±delta in the *current* level.
@@ -114,6 +78,7 @@ final class MentionOverlayController {
         )
         windows.append(w)
         chainWindow(w, after: previous)
+        enforceScreenBounds()
     }
 
     /// Pop the deepest overlay level (go up one folder).
@@ -132,6 +97,7 @@ final class MentionOverlayController {
         }
         windows.removeAll()
         ownerWindow = nil
+        latestCaretRect = nil
     }
 
     // MARK: – Private --------------------------------------------------------
@@ -156,20 +122,117 @@ final class MentionOverlayController {
         max(limit, 1)
     }
 
+    static func positionedRootFrame(
+        caret: NSRect,
+        popupSize: NSSize,
+        placement: Placement,
+        visibleFrame: NSRect?
+    ) -> NSRect {
+        var frame = NSRect(origin: .zero, size: popupSize)
+        switch placement {
+        case .above:
+            frame.origin = NSPoint(x: caret.minX, y: caret.maxY + 4)
+        case .below:
+            frame.origin = NSPoint(x: caret.minX, y: caret.minY - 2 - popupSize.height)
+        }
+        return clampedFrame(frame, to: visibleFrame)
+    }
+
+    static func positionedChildFrame(
+        after previousFrame: NSRect,
+        popupSize: NSSize,
+        placement: Placement,
+        visibleFrame: NSRect?
+    ) -> NSRect {
+        var frame = NSRect(origin: .zero, size: popupSize)
+        switch placement {
+        case .above:
+            frame.origin = NSPoint(x: previousFrame.maxX + 4, y: previousFrame.minY)
+        case .below:
+            frame.origin = NSPoint(x: previousFrame.maxX - 1, y: previousFrame.maxY - popupSize.height)
+        }
+
+        if let visibleFrame,
+           frame.maxX > visibleFrame.maxX
+        {
+            let leftX = previousFrame.minX - popupSize.width - 4
+            if leftX >= visibleFrame.minX {
+                frame.origin.x = leftX
+            }
+        }
+
+        return clampedFrame(frame, to: visibleFrame)
+    }
+
+    static func clampedFrame(_ frame: NSRect, to visibleFrame: NSRect?) -> NSRect {
+        guard let visibleFrame else { return frame }
+        var clamped = frame
+
+        if clamped.width <= visibleFrame.width {
+            clamped.origin.x = min(max(clamped.minX, visibleFrame.minX), visibleFrame.maxX - clamped.width)
+        } else {
+            clamped.origin.x = visibleFrame.minX
+        }
+
+        if clamped.height <= visibleFrame.height {
+            clamped.origin.y = min(max(clamped.minY, visibleFrame.minY), visibleFrame.maxY - clamped.height)
+        } else {
+            clamped.origin.y = visibleFrame.minY
+        }
+
+        return clamped
+    }
+
     private func chainWindow(_ w: SuggestionWindow, after prev: NSWindow) {
         let parentWin = prev.parent ?? prev
         parentWin.addChildWindow(w, ordered: .above)
         w.orderFront(nil)
-
-        // Position to the right of previous
-        if placement == .above {
-            let bottomLeft = NSPoint(x: prev.frame.maxX + 4, y: prev.frame.minY)
-            w.setFrameOrigin(bottomLeft)
-        } else {
-            let topLeft = NSPoint(x: prev.frame.maxX - 1, y: prev.frame.maxY)
-            w.setFrameTopLeftPoint(topLeft)
-        }
+        w.setFrame(
+            Self.positionedChildFrame(
+                after: prev.frame,
+                popupSize: w.frame.size,
+                placement: placement,
+                visibleFrame: visibleFrame
+            ),
+            display: true
+        )
         w.alphaValue = 1
+    }
+
+    private var visibleFrame: NSRect? {
+        ownerWindow?.screen?.visibleFrame
+    }
+
+    private func enforceScreenBounds() {
+        guard !windows.isEmpty else { return }
+        if let root = windows.first,
+           let caret = latestCaretRect
+        {
+            root.setFrame(
+                Self.positionedRootFrame(
+                    caret: caret,
+                    popupSize: root.frame.size,
+                    placement: placement,
+                    visibleFrame: visibleFrame
+                ),
+                display: true
+            )
+        }
+
+        guard windows.count > 1 else { return }
+        for idx in 1 ..< windows.count {
+            let previous = windows[idx - 1]
+            let current = windows[idx]
+            current.setFrame(
+                Self.positionedChildFrame(
+                    after: previous.frame,
+                    popupSize: current.frame.size,
+                    placement: placement,
+                    visibleFrame: visibleFrame
+                ),
+                display: true
+            )
+        }
     }
 }
 

--- a/Sources/RepoPrompt/Infrastructure/UI/TextField/MentionOverlayController.swift
+++ b/Sources/RepoPrompt/Infrastructure/UI/TextField/MentionOverlayController.swift
@@ -213,7 +213,7 @@ extension MentionOverlayController {
 
             isOpaque = false
             backgroundColor = .clear
-            hasShadow = true
+            hasShadow = false
             level = .floating
 
             // Vibrancy background -----------------------------------------------

--- a/Sources/RepoPrompt/Infrastructure/UI/TextField/MentionOverlayController.swift
+++ b/Sources/RepoPrompt/Infrastructure/UI/TextField/MentionOverlayController.swift
@@ -12,6 +12,17 @@ final class MentionOverlayController {
 
     var placement: Placement = .below
     var suggestedWidth: CGFloat = 240
+    var visibleRowLimit: Int = 5 {
+        didSet {
+            let normalizedLimit = Self.normalizedVisibleRowLimit(visibleRowLimit)
+            if visibleRowLimit != normalizedLimit {
+                visibleRowLimit = normalizedLimit
+            }
+            for window in windows {
+                window.setVisibleRowLimit(normalizedLimit)
+            }
+        }
+    }
 
     /// Remember latest caret anchor so we can re-anchor after every resize
     private var caretAnchor: NSPoint?
@@ -95,7 +106,12 @@ final class MentionOverlayController {
     /// Push a new level (drill-down into folder). Automatically positioned.
     func pushLevel() {
         guard let previous = windows.last else { return }
-        let w = SuggestionWindow(parent: previous.parentTextView, placement: placement, width: suggestedWidth)
+        let w = SuggestionWindow(
+            parent: previous.parentTextView,
+            placement: placement,
+            width: suggestedWidth,
+            visibleRowLimit: Self.normalizedVisibleRowLimit(visibleRowLimit)
+        )
         windows.append(w)
         chainWindow(w, after: previous)
     }
@@ -126,9 +142,18 @@ final class MentionOverlayController {
     private func prepareRootWindowIfNeeded(owner: NSWindow) {
         guard windows.isEmpty else { return }
         ownerWindow = owner
-        let root = SuggestionWindow(parent: nil, placement: placement, width: suggestedWidth)
+        let root = SuggestionWindow(
+            parent: nil,
+            placement: placement,
+            width: suggestedWidth,
+            visibleRowLimit: Self.normalizedVisibleRowLimit(visibleRowLimit)
+        )
         owner.addChildWindow(root, ordered: .above)
         windows.append(root)
+    }
+
+    private static func normalizedVisibleRowLimit(_ limit: Int) -> Int {
+        max(limit, 1)
     }
 
     private func chainWindow(_ w: SuggestionWindow, after prev: NSWindow) {
@@ -167,13 +192,17 @@ extension MentionOverlayController {
 
         // MARK: – Init
 
+        private var visibleRowLimit: Int
+
         init(
             parent: MentionTextView?,
             placement: MentionOverlayController.Placement,
-            width: CGFloat = 240
+            width: CGFloat = 240,
+            visibleRowLimit: Int = 5
         ) {
             parentTextView = parent
             self.placement = placement
+            self.visibleRowLimit = MentionOverlayController.normalizedVisibleRowLimit(visibleRowLimit)
             let rect = NSRect(x: 0, y: 0, width: width, height: 1)
             super.init(
                 contentRect: rect,
@@ -199,6 +228,7 @@ extension MentionOverlayController {
             visualEffect.layer?.borderColor = NSColor.separatorColor.cgColor
 
             // SwiftUI content ---------------------------------------------------
+            model.visibleRowLimit = self.visibleRowLimit
             let listView = MentionSuggestionListView(model: model)
             let hosting = NSHostingView(rootView: listView)
             hosting.frame = visualEffect.bounds
@@ -243,10 +273,16 @@ extension MentionOverlayController {
                 % model.suggestions.count
         }
 
+        func setVisibleRowLimit(_ limit: Int) {
+            visibleRowLimit = MentionOverlayController.normalizedVisibleRowLimit(limit)
+            model.visibleRowLimit = visibleRowLimit
+            resizeWindow(for: max(model.suggestions.count, 1))
+        }
+
         // MARK: – Layout
 
         private func resizeWindow(for itemCount: Int) {
-            let visibleRows = min(itemCount, 5)
+            let visibleRows = min(itemCount, visibleRowLimit)
             let rowH = FontScalePreset.current.rowHeight + 4
             // 4pt padding top/bottom inside the VStack, plus 2pt spacing per gap
             let spacing = max(CGFloat(visibleRows - 1), 0) * 2

--- a/Sources/RepoPrompt/Infrastructure/UI/TextField/MentionSuggestionView.swift
+++ b/Sources/RepoPrompt/Infrastructure/UI/TextField/MentionSuggestionView.swift
@@ -19,8 +19,8 @@ final class MentionSuggestionListModel: ObservableObject {
     @Published var highlightedIndex: Int = 0
     @Published var visibleRowLimit: Int = 5
 
-    /// Called when the user clicks a row. The overlay controller wires this up
-    /// to update the highlight and optionally commit the selection.
+    /// Called when the user clicks a row. The overlay controller uses it to
+    /// make that row the current keyboard selection.
     var onRowClicked: ((Int) -> Void)?
 }
 
@@ -33,6 +33,10 @@ struct MentionSuggestionRowView: View {
 
     private var rowHeight: CGFloat {
         FontScalePreset.current.rowHeight + 4
+    }
+
+    static func accessibilityTraits(isHighlighted: Bool) -> AccessibilityTraits {
+        isHighlighted ? .isSelected : []
     }
 
     var body: some View {
@@ -75,6 +79,7 @@ struct MentionSuggestionRowView: View {
                 .fill(isHighlighted ? Color.accentColor.opacity(0.25) : Color.clear)
         )
         .contentShape(Rectangle())
+        .accessibilityAddTraits(Self.accessibilityTraits(isHighlighted: isHighlighted))
         .onTapGesture {
             onTap?()
         }

--- a/Sources/RepoPrompt/Infrastructure/UI/TextField/MentionSuggestionView.swift
+++ b/Sources/RepoPrompt/Infrastructure/UI/TextField/MentionSuggestionView.swift
@@ -146,9 +146,9 @@ struct MentionSuggestionListView: View {
                         .id(index)
                     }
                 }
-                .padding(.vertical, 4)
                 .padding(.horizontal, 4)
             }
+            .contentMargins(.vertical, 4, for: .scrollContent)
             .onChange(of: model.highlightedIndex) { _, newValue in
                 proxy.scrollTo(newValue)
             }

--- a/Sources/RepoPrompt/Infrastructure/UI/TextField/MentionSuggestionView.swift
+++ b/Sources/RepoPrompt/Infrastructure/UI/TextField/MentionSuggestionView.swift
@@ -17,6 +17,7 @@ import SwiftUI
 final class MentionSuggestionListModel: ObservableObject {
     @Published var suggestions: [MentionSuggestion] = []
     @Published var highlightedIndex: Int = 0
+    @Published var visibleRowLimit: Int = 5
 
     /// Called when the user clicks a row. The overlay controller wires this up
     /// to update the highlight and optionally commit the selection.
@@ -131,7 +132,7 @@ struct MentionSuggestionListView: View {
 
     private var suggestionList: some View {
         ScrollViewReader { proxy in
-            ScrollView(.vertical, showsIndicators: model.suggestions.count > 5) {
+            ScrollView(.vertical, showsIndicators: model.suggestions.count > model.visibleRowLimit) {
                 VStack(spacing: 2) {
                     ForEach(
                         Array(model.suggestions.enumerated()),

--- a/Sources/RepoPrompt/Infrastructure/UI/TextField/ResizableTextField.swift
+++ b/Sources/RepoPrompt/Infrastructure/UI/TextField/ResizableTextField.swift
@@ -141,6 +141,7 @@ struct ResizableTextFieldFeatures {
     var fileTagSelectionCoordinator: WorkspaceSelectionCoordinator?
     var fileTagLookupContextIdentity: AnyHashable?
     var fileTagLookupContextProvider: (() async -> WorkspaceLookupContext)?
+    var fileTagPickerConfiguration: FileMentionPickerConfiguration = .compact
     var onFileTagCommitted: ((MentionSuggestion) -> Void)?
     var enableSlashSkillOverlay: Bool = false
     var slashSkillSuggestionsProvider: ((String) async -> [MentionSuggestion])?
@@ -153,6 +154,7 @@ struct ResizableTextFieldFeatures {
         fileTagSelectionCoordinator: WorkspaceSelectionCoordinator?,
         fileTagLookupContextIdentity: AnyHashable? = nil,
         fileTagLookupContextProvider: (() async -> WorkspaceLookupContext)? = nil,
+        fileMentionPickerConfiguration: FileMentionPickerConfiguration = .compact,
         onFileTagCommitted: ((MentionSuggestion) -> Void)?,
         slashSkillSuggestionsProvider: ((String) async -> [MentionSuggestion])?
     ) -> ResizableTextFieldFeatures {
@@ -163,6 +165,7 @@ struct ResizableTextFieldFeatures {
             fileTagSelectionCoordinator: fileTagSelectionCoordinator,
             fileTagLookupContextIdentity: fileTagLookupContextIdentity,
             fileTagLookupContextProvider: fileTagLookupContextProvider,
+            fileTagPickerConfiguration: fileMentionPickerConfiguration,
             onFileTagCommitted: onFileTagCommitted,
             enableSlashSkillOverlay: true,
             slashSkillSuggestionsProvider: slashSkillSuggestionsProvider
@@ -339,7 +342,8 @@ struct CustomTextField: NSViewRepresentable {
             searchService: features.fileTagSearchService,
             selectionCoordinator: features.fileTagSelectionCoordinator,
             lookupContextIdentity: features.fileTagLookupContextIdentity,
-            lookupContextProvider: features.fileTagLookupContextProvider
+            lookupContextProvider: features.fileTagLookupContextProvider,
+            configuration: features.fileTagPickerConfiguration
         )
         context.coordinator.configureSlashSkillSupport(
             textView: textView,
@@ -375,7 +379,8 @@ struct CustomTextField: NSViewRepresentable {
             searchService: features.fileTagSearchService,
             selectionCoordinator: features.fileTagSelectionCoordinator,
             lookupContextIdentity: features.fileTagLookupContextIdentity,
-            lookupContextProvider: features.fileTagLookupContextProvider
+            lookupContextProvider: features.fileTagLookupContextProvider,
+            configuration: features.fileTagPickerConfiguration
         )
         context.coordinator.configureSlashSkillSupport(
             textView: textView,
@@ -544,7 +549,8 @@ struct CustomTextField: NSViewRepresentable {
             searchService: WorkspaceSearchService?,
             selectionCoordinator: WorkspaceSelectionCoordinator?,
             lookupContextIdentity: AnyHashable?,
-            lookupContextProvider: (() async -> WorkspaceLookupContext)?
+            lookupContextProvider: (() async -> WorkspaceLookupContext)?,
+            configuration: FileMentionPickerConfiguration
         ) {
             fileTagHelper.configure(
                 textView: textView,
@@ -553,7 +559,8 @@ struct CustomTextField: NSViewRepresentable {
                 searchService: searchService,
                 selectionCoordinator: selectionCoordinator,
                 lookupContextIdentity: lookupContextIdentity,
-                lookupContextProvider: lookupContextProvider
+                lookupContextProvider: lookupContextProvider,
+                configuration: configuration
             )
         }
 

--- a/Sources/RepoPrompt/Infrastructure/UI/TextField/TextFieldMentionHelpers.swift
+++ b/Sources/RepoPrompt/Infrastructure/UI/TextField/TextFieldMentionHelpers.swift
@@ -26,6 +26,12 @@ final class FileTagMentionHelper {
     private var isFinalizingCommittedMention = false
     private static let typingDebounceNanoseconds: UInt64 = 45_000_000
 
+    init() {
+        overlay.onRowClicked = { [weak self] _, index in
+            self?.selectSuggestion(at: index)
+        }
+    }
+
     func configure(
         textView: ImageAwareTextView,
         enabled: Bool,
@@ -140,6 +146,32 @@ final class FileTagMentionHelper {
         }
         return false
     }
+
+    private func selectSuggestion(at index: Int) {
+        guard suggestions.indices.contains(index) else { return }
+        refreshTask?.cancel()
+        refreshTask = nil
+        suggestionTask?.cancel()
+        suggestionTask = nil
+        suggestionRequestID &+= 1
+        highlightedIndex = index
+    }
+
+    #if DEBUG
+        func setSelectionStateForTesting(
+            suggestions: [MentionSuggestion],
+            highlightedIndex: Int,
+            triggerRange: NSRange
+        ) {
+            self.suggestions = suggestions
+            self.highlightedIndex = highlightedIndex
+            self.triggerRange = triggerRange
+        }
+
+        func clickSuggestionForTesting(at index: Int) {
+            overlay.onRowClicked?(0, index)
+        }
+    #endif
 
     func dismiss() {
         refreshTask?.cancel()
@@ -401,6 +433,12 @@ final class SlashSkillMentionHelper {
     private var suggestionRequestID: UInt64 = 0
     private static let typingDebounceNanoseconds: UInt64 = 45_000_000
 
+    init() {
+        overlay.onRowClicked = { [weak self] _, index in
+            self?.selectSuggestion(at: index)
+        }
+    }
+
     func configure(
         textView: ImageAwareTextView,
         enabled: Bool,
@@ -468,6 +506,26 @@ final class SlashSkillMentionHelper {
         }
         return false
     }
+
+    private func selectSuggestion(at index: Int) {
+        guard suggestions.indices.contains(index) else { return }
+        refreshTask?.cancel()
+        refreshTask = nil
+        suggestionTask?.cancel()
+        suggestionTask = nil
+        suggestionRequestID &+= 1
+        highlightedIndex = index
+    }
+
+    #if DEBUG
+        var suggestionsForTesting: [MentionSuggestion] {
+            suggestions
+        }
+
+        func clickSuggestionForTesting(at index: Int) {
+            overlay.onRowClicked?(0, index)
+        }
+    #endif
 
     func dismiss() {
         refreshTask?.cancel()

--- a/Sources/RepoPrompt/Infrastructure/UI/TextField/TextFieldMentionHelpers.swift
+++ b/Sources/RepoPrompt/Infrastructure/UI/TextField/TextFieldMentionHelpers.swift
@@ -54,12 +54,12 @@ final class FileTagMentionHelper {
         var shouldRefreshNow = false
         let lookupContextChanged = lookupContextIdentity != fileTagLookupContextIdentity
         let configurationChanged = configuration != self.configuration
+        if lookupContextChanged || configurationChanged {
+            dismiss()
+        }
         overlay.suggestedWidth = configuration.overlayWidth
         overlay.visibleRowLimit = configuration.visibleRows
         if service == nil || store !== fileTagStore || searchService !== fileTagSearchService || selectionCoordinator !== fileTagSelectionCoordinator || lookupContextChanged || configurationChanged {
-            if lookupContextChanged {
-                dismiss()
-            }
             service = AgentFileTagSuggestionService(
                 store: store,
                 searchService: searchService,

--- a/Sources/RepoPrompt/Infrastructure/UI/TextField/TextFieldMentionHelpers.swift
+++ b/Sources/RepoPrompt/Infrastructure/UI/TextField/TextFieldMentionHelpers.swift
@@ -18,6 +18,7 @@ final class FileTagMentionHelper {
     private weak var fileTagSelectionCoordinator: WorkspaceSelectionCoordinator?
     private var fileTagLookupContextIdentity: AnyHashable?
     private var fileTagLookupContextProvider: (() async -> WorkspaceLookupContext)?
+    private var configuration: FileMentionPickerConfiguration = .compact
     private var refreshTask: Task<Void, Never>?
     private var suggestionTask: Task<Void, Never>?
     private var commitFinalizationTask: Task<Void, Never>?
@@ -32,7 +33,8 @@ final class FileTagMentionHelper {
         searchService: WorkspaceSearchService?,
         selectionCoordinator: WorkspaceSelectionCoordinator?,
         lookupContextIdentity: AnyHashable?,
-        lookupContextProvider: (() async -> WorkspaceLookupContext)?
+        lookupContextProvider: (() async -> WorkspaceLookupContext)?,
+        configuration: FileMentionPickerConfiguration
     ) {
         guard enabled else {
             let hadState = (service != nil || fileTagStore != nil || triggerRange != nil || refreshTask != nil || suggestionTask != nil)
@@ -42,6 +44,7 @@ final class FileTagMentionHelper {
             fileTagSelectionCoordinator = nil
             fileTagLookupContextIdentity = nil
             fileTagLookupContextProvider = nil
+            self.configuration = .compact
             if hadState {
                 dismiss()
             }
@@ -50,7 +53,10 @@ final class FileTagMentionHelper {
 
         var shouldRefreshNow = false
         let lookupContextChanged = lookupContextIdentity != fileTagLookupContextIdentity
-        if service == nil || store !== fileTagStore || searchService !== fileTagSearchService || selectionCoordinator !== fileTagSelectionCoordinator || lookupContextChanged {
+        let configurationChanged = configuration != self.configuration
+        overlay.suggestedWidth = configuration.overlayWidth
+        overlay.visibleRowLimit = configuration.visibleRows
+        if service == nil || store !== fileTagStore || searchService !== fileTagSearchService || selectionCoordinator !== fileTagSelectionCoordinator || lookupContextChanged || configurationChanged {
             if lookupContextChanged {
                 dismiss()
             }
@@ -59,13 +65,15 @@ final class FileTagMentionHelper {
                 searchService: searchService,
                 selectionCoordinator: selectionCoordinator,
                 lookupContextProvider: lookupContextProvider,
-                maxResults: 5
+                maxResults: configuration.maxResults,
+                showsFileSubtitles: configuration.showsFileSubtitles
             )
             fileTagStore = store
             fileTagSearchService = searchService
             fileTagSelectionCoordinator = selectionCoordinator
             fileTagLookupContextIdentity = lookupContextIdentity
             fileTagLookupContextProvider = lookupContextProvider
+            self.configuration = configuration
             shouldRefreshNow = true
         }
         if shouldRefreshNow {

--- a/Tests/RepoPromptTests/AgentMode/AgentFileTagWorktreeResolutionTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentFileTagWorktreeResolutionTests.swift
@@ -13,20 +13,23 @@ final class AgentFileTagWorktreeResolutionTests: XCTestCase {
     }
 
     @MainActor
-    func testBoundWorktreeSuggestionIncludesBranchOnlyFileWithLogicalPath() async throws {
+    func testExpandedBoundWorktreeSuggestionUsesLogicalPathAndSubtitle() async throws {
         let fixture = try await makeBoundFixture(includeBranchOnly: true)
         let lookupContext = await makeLookupContext(fixture: fixture)
+        let configuration = FileMentionPickerConfiguration.expanded
         let service = AgentFileTagSuggestionService(
             store: fixture.store,
             searchService: nil,
             selectionCoordinator: nil,
             lookupContextProvider: { lookupContext },
-            maxResults: 5
+            maxResults: configuration.maxResults,
+            showsFileSubtitles: configuration.showsFileSubtitles
         )
 
         let suggestions = await service.suggestions(for: "BranchOnly")
+        let suggestion = try XCTUnwrap(suggestions.first { $0.relativePath == "Sources/BranchOnly.swift" })
 
-        XCTAssertTrue(suggestions.contains { $0.relativePath == "Sources/BranchOnly.swift" }, String(describing: suggestions))
+        XCTAssertEqual(suggestion.subtitle, "Sources")
         XCTAssertFalse(suggestions.contains { $0.relativePath.contains(".worktrees") }, String(describing: suggestions))
         XCTAssertFalse(suggestions.contains { $0.relativePath.contains(fixture.worktreeRoot.path) }, String(describing: suggestions))
     }

--- a/Tests/RepoPromptTests/AgentMode/AgentFileTagWorktreeResolutionTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentFileTagWorktreeResolutionTests.swift
@@ -94,6 +94,65 @@ final class AgentFileTagWorktreeResolutionTests: XCTestCase {
     }
 
     @MainActor
+    func testExpandedAgentFileTagsReturnMoreThanCompactCapWithParentSubtitles() async throws {
+        let root = try makeTemporaryRoot(name: "AgentFileTagExpanded")
+        let matchingFileCount = 80
+        for index in 0 ..< matchingFileCount {
+            let name = String(format: "Match%02d.swift", index)
+            try write("let match\(index) = true\n", to: root.appendingPathComponent("Sources/\(name)"))
+        }
+        let store = WorkspaceFileContextStore()
+        _ = try await store.loadRoot(path: root.path)
+        let config = FileMentionPickerConfiguration.expanded
+        let service = AgentFileTagSuggestionService(
+            store: store,
+            searchService: nil,
+            selectionCoordinator: nil,
+            lookupContextProvider: { .visibleWorkspace },
+            maxResults: config.maxResults,
+            showsFileSubtitles: config.showsFileSubtitles
+        )
+
+        let suggestions = await service.suggestions(for: "Match")
+
+        XCTAssertEqual(suggestions.count, matchingFileCount, String(describing: suggestions))
+        XCTAssertTrue(suggestions.count > FileMentionPickerConfiguration.compact.maxResults)
+        XCTAssertTrue(suggestions.count > 64)
+        XCTAssertTrue(suggestions.allSatisfy { $0.kind == .file })
+        XCTAssertEqual(Set(suggestions.compactMap(\.subtitle)), ["Sources"])
+        XCTAssertTrue(suggestions.allSatisfy { $0.commitDisplayText?.hasPrefix("Match") == true })
+        XCTAssertTrue(suggestions.allSatisfy { $0.commitDisplayText?.contains("Sources/") == false })
+    }
+
+    @MainActor
+    func testCompactAgentFileTagsPreserveDuplicateDisambiguationSubtitles() async throws {
+        let firstRoot = try makeTemporaryRoot(name: "AgentFileTagDuplicateA")
+        let secondRoot = try makeTemporaryRoot(name: "AgentFileTagDuplicateB")
+        try write("let duplicate = \"a\"\n", to: firstRoot.appendingPathComponent("Sources/Shared.swift"))
+        try write("let duplicate = \"b\"\n", to: secondRoot.appendingPathComponent("Sources/Shared.swift"))
+        let store = WorkspaceFileContextStore()
+        _ = try await store.loadRoot(path: firstRoot.path)
+        _ = try await store.loadRoot(path: secondRoot.path)
+        let service = AgentFileTagSuggestionService(
+            store: store,
+            searchService: nil,
+            selectionCoordinator: nil,
+            lookupContextProvider: { .visibleWorkspace },
+            maxResults: FileMentionPickerConfiguration.compact.maxResults,
+            showsFileSubtitles: FileMentionPickerConfiguration.compact.showsFileSubtitles
+        )
+
+        let suggestions = await service.suggestions(for: "Shared")
+
+        XCTAssertEqual(suggestions.count, 2, String(describing: suggestions))
+        XCTAssertEqual(
+            Set(suggestions.compactMap(\.subtitle)),
+            [firstRoot.lastPathComponent, secondRoot.lastPathComponent]
+        )
+        XCTAssertTrue(suggestions.allSatisfy { $0.commitDisplayText?.hasSuffix("Sources/Shared.swift") == true })
+    }
+
+    @MainActor
     func testPartiallyBoundWorkspaceKeepsUnboundRootSuggestionDisplayRelative() async throws {
         let fixture = try await makeBoundFixture(includeBranchOnly: false)
         let unboundRoot = try makeTemporaryRoot(name: "AgentFileTagUnbound")

--- a/Tests/RepoPromptTests/Mentions/FileMentionPickerStyleTests.swift
+++ b/Tests/RepoPromptTests/Mentions/FileMentionPickerStyleTests.swift
@@ -19,7 +19,7 @@ final class FileMentionPickerStyleTests: XCTestCase {
         let configuration = FileMentionPickerStyle.expanded.configuration
         XCTAssertEqual(configuration.maxResults, 99)
         XCTAssertEqual(configuration.visibleRows, 15)
-        XCTAssertEqual(configuration.overlayWidth, 480)
+        XCTAssertEqual(configuration.overlayWidth, 720)
         XCTAssertTrue(configuration.showsFileSubtitles)
     }
 

--- a/Tests/RepoPromptTests/Mentions/FileMentionPickerStyleTests.swift
+++ b/Tests/RepoPromptTests/Mentions/FileMentionPickerStyleTests.swift
@@ -19,7 +19,7 @@ final class FileMentionPickerStyleTests: XCTestCase {
         let configuration = FileMentionPickerStyle.expanded.configuration
         XCTAssertEqual(configuration.maxResults, 99)
         XCTAssertEqual(configuration.visibleRows, 15)
-        XCTAssertEqual(configuration.overlayWidth, 720)
+        XCTAssertEqual(configuration.overlayWidth, 480)
         XCTAssertTrue(configuration.showsFileSubtitles)
     }
 

--- a/Tests/RepoPromptTests/Mentions/FileMentionPickerStyleTests.swift
+++ b/Tests/RepoPromptTests/Mentions/FileMentionPickerStyleTests.swift
@@ -1,0 +1,33 @@
+@testable import RepoPrompt
+import XCTest
+
+final class FileMentionPickerStyleTests: XCTestCase {
+    func testCompactConfigurationPreservesExistingDefaults() {
+        XCTAssertEqual(FileMentionPickerStyle.defaultStyle, .compact)
+        XCTAssertEqual(FileMentionPickerStyle.compact.displayName, "Compact")
+
+        let configuration = FileMentionPickerStyle.compact.configuration
+        XCTAssertEqual(configuration.maxResults, 5)
+        XCTAssertEqual(configuration.visibleRows, 5)
+        XCTAssertEqual(configuration.overlayWidth, 240)
+        XCTAssertFalse(configuration.showsFileSubtitles)
+    }
+
+    func testExpandedConfigurationUsesRoomierFilePickerValues() {
+        XCTAssertEqual(FileMentionPickerStyle.expanded.displayName, "Expanded")
+
+        let configuration = FileMentionPickerStyle.expanded.configuration
+        XCTAssertEqual(configuration.maxResults, 99)
+        XCTAssertEqual(configuration.visibleRows, 15)
+        XCTAssertEqual(configuration.overlayWidth, 480)
+        XCTAssertTrue(configuration.showsFileSubtitles)
+    }
+
+    func testNormalizationDefaultsMissingEmptyAndInvalidRawValuesToCompact() {
+        XCTAssertEqual(FileMentionPickerStyle.normalized(rawValue: nil), .compact)
+        XCTAssertEqual(FileMentionPickerStyle.normalized(rawValue: ""), .compact)
+        XCTAssertEqual(FileMentionPickerStyle.normalized(rawValue: "   \n"), .compact)
+        XCTAssertEqual(FileMentionPickerStyle.normalized(rawValue: "wide"), .compact)
+        XCTAssertEqual(FileMentionPickerStyle.normalized(rawValue: "expanded"), .expanded)
+    }
+}

--- a/Tests/RepoPromptTests/Mentions/FileMentionPickerStyleTests.swift
+++ b/Tests/RepoPromptTests/Mentions/FileMentionPickerStyleTests.swift
@@ -18,7 +18,7 @@ final class FileMentionPickerStyleTests: XCTestCase {
 
         let configuration = FileMentionPickerStyle.expanded.configuration
         XCTAssertEqual(configuration.maxResults, 99)
-        XCTAssertEqual(configuration.visibleRows, 15)
+        XCTAssertEqual(configuration.visibleRows, 10)
         XCTAssertEqual(configuration.overlayWidth, 480)
         XCTAssertTrue(configuration.showsFileSubtitles)
     }

--- a/Tests/RepoPromptTests/Mentions/MentionCoordinatorTests.swift
+++ b/Tests/RepoPromptTests/Mentions/MentionCoordinatorTests.swift
@@ -1,0 +1,202 @@
+import AppKit
+@testable import RepoPrompt
+import SwiftUI
+import XCTest
+
+@MainActor
+final class MentionCoordinatorTests: XCTestCase {
+    func testWorkspaceReuseKeepsSuggestionsAndCommitRemovalOnNewFileManager() {
+        let first = makeFixture(rootName: "FirstWorkspace")
+        let second = makeFixture(rootName: "SecondWorkspace")
+        var text = ""
+        let view = AttributedTextKitView(
+            text: Binding(
+                get: { text },
+                set: { text = $0 }
+            ),
+            fileManager: first.fileManager
+        )
+        let attributedCoordinator = AttributedTextKitView.Coordinator(view)
+        let textView = MentionTextView(frame: NSRect(x: 0, y: 0, width: 200, height: 80))
+        let mentionCoordinator = MentionCoordinator(
+            textView: textView,
+            suggestionService: MentionSuggestionService(fileManager: first.fileManager),
+            commitHandler: { _ in },
+            tokenRemovedHandler: { _ in }
+        )
+        attributedCoordinator.mentionCoord = mentionCoordinator
+
+        attributedCoordinator.updateFileManager(second.fileManager)
+        mentionCoordinator.mentionStarted(at: .zero)
+
+        XCTAssertTrue(mentionCoordinator.testSuggestions.contains { $0.displayName == "SecondWorkspace" })
+        XCTAssertFalse(mentionCoordinator.testSuggestions.contains { $0.displayName == "FirstWorkspace" })
+
+        let suggestion = MentionSuggestion(
+            displayName: second.file.name,
+            relativePath: second.file.relativePath,
+            kind: .file
+        )
+        attributedCoordinator.commit(suggestion)
+
+        XCTAssertTrue(second.file.isChecked)
+        XCTAssertFalse(first.file.isChecked)
+
+        attributedCoordinator.tokenRemoved(
+            MentionTokenPayload(relativePath: suggestion.relativePath, kind: .file)
+        )
+
+        XCTAssertFalse(second.file.isChecked)
+    }
+
+    func testClickingAncestorWindowMakesThatLevelCurrentForFurtherNavigation() async throws {
+        let fixture = makeFixture(rootName: "ClickedWorkspace")
+        let owner = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 600, height: 400),
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: false
+        )
+        defer { owner.orderOut(nil) }
+        let contentView = NSView(frame: owner.contentView?.bounds ?? .zero)
+        let textView = MentionTextView(frame: NSRect(x: 20, y: 20, width: 200, height: 80))
+        contentView.addSubview(textView)
+        owner.contentView = contentView
+        var committed: MentionSuggestion?
+        let coordinator = MentionCoordinator(
+            textView: textView,
+            suggestionService: MentionSuggestionService(fileManager: fixture.fileManager),
+            commitHandler: { committed = $0 },
+            tokenRemovedHandler: { _ in }
+        )
+
+        coordinator.mentionStarted(at: NSRect(x: 100, y: 100, width: 1, height: 18))
+        coordinator.mentionNavigate(.down)
+        coordinator.mentionNavigate(.right)
+        try await Task.sleep(nanoseconds: 120_000_000)
+        coordinator.mentionNavigate(.right)
+        try await Task.sleep(nanoseconds: 120_000_000)
+        XCTAssertEqual(coordinator.testOverlayWindowCount, 3)
+
+        let ancestorSuggestions = coordinator.testSuggestions(atLevel: 1)
+        let previousHighlight = try XCTUnwrap(coordinator.testHighlightedIndex(atLevel: 1))
+        let clickedIndex = try XCTUnwrap(
+            ancestorSuggestions.indices.first {
+                $0 != previousHighlight && ancestorSuggestions[$0].kind == .folder
+            }
+        )
+        let clickedFolder = ancestorSuggestions[clickedIndex]
+
+        coordinator.testClickOverlayRow(level: 1, index: clickedIndex)
+
+        XCTAssertEqual(coordinator.testOverlayWindowCount, 2)
+        coordinator.mentionNavigate(.right)
+        try await Task.sleep(nanoseconds: 120_000_000)
+        XCTAssertEqual(coordinator.testOverlayWindowCount, 3)
+
+        coordinator.mentionAccept()
+        let expectedFileName = clickedFolder.displayName == "Sources"
+            ? fixture.file.name
+            : fixture.alternateFile.name
+        XCTAssertEqual(committed?.displayName, expectedFileName)
+    }
+
+    func testDeallocatedManagerUpdatingToNilInvalidatesActiveMentionState() async {
+        var manager: WorkspaceFilesViewModel? = makeFixture(rootName: "ReleasedWorkspace").fileManager
+        let textView = MentionTextView(frame: NSRect(x: 0, y: 0, width: 200, height: 80))
+        let coordinator = MentionCoordinator(
+            textView: textView,
+            suggestionService: MentionSuggestionService(fileManager: manager),
+            commitHandler: { _ in },
+            tokenRemovedHandler: { _ in }
+        )
+
+        coordinator.mentionStarted(at: .zero)
+        XCTAssertFalse(coordinator.testSuggestions.isEmpty)
+        coordinator.mentionQueryChanged("Released", parent: nil)
+        manager = nil
+
+        coordinator.updateFileManager(nil)
+        try? await Task.sleep(nanoseconds: 150_000_000)
+
+        XCTAssertTrue(coordinator.testSuggestions.isEmpty)
+    }
+
+    func testWorkspaceSwitchInvalidatesStaleDebouncedQuery() async {
+        let first = makeFixture(rootName: "FirstWorkspace")
+        let second = makeFixture(rootName: "SecondWorkspace", fileName: "SecondOnly.swift")
+        let textView = MentionTextView(frame: NSRect(x: 0, y: 0, width: 200, height: 80))
+        let coordinator = MentionCoordinator(
+            textView: textView,
+            suggestionService: MentionSuggestionService(fileManager: first.fileManager),
+            commitHandler: { _ in },
+            tokenRemovedHandler: { _ in }
+        )
+
+        coordinator.mentionStarted(at: .zero)
+        coordinator.mentionQueryChanged("SecondOnly", parent: nil)
+        coordinator.updateFileManager(second.fileManager)
+
+        try? await Task.sleep(nanoseconds: 150_000_000)
+
+        XCTAssertTrue(coordinator.testSuggestions.isEmpty)
+    }
+
+    private func makeFixture(
+        rootName: String,
+        fileName: String = "Shared.swift"
+    ) -> (fileManager: WorkspaceFilesViewModel, file: FileViewModel, alternateFile: FileViewModel) {
+        let rootURL = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("MentionCoordinatorTests", isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let sourceURL = rootURL.appendingPathComponent("Sources", isDirectory: true)
+        let alternateURL = rootURL.appendingPathComponent("Alternate", isDirectory: true)
+        let date = Date(timeIntervalSince1970: 1000)
+        let root = FolderViewModel(
+            folder: Folder(name: rootName, path: rootURL.path, modificationDate: date),
+            rootPath: rootURL.path,
+            isExpanded: true
+        )
+        let sources = FolderViewModel(
+            folder: Folder(name: "Sources", path: sourceURL.path, modificationDate: date),
+            rootPath: rootURL.path,
+            hierarchyLevel: 1,
+            isExpanded: true
+        )
+        let file = FileViewModel(
+            file: File(name: fileName, path: sourceURL.appendingPathComponent(fileName).path, modificationDate: date),
+            rootPath: rootURL.path,
+            hierarchyLevel: 2,
+            rootIdentifier: root.id,
+            rootFolderPath: rootURL.path,
+            fileSystemService: nil,
+            parentFolder: sources
+        )
+        let alternateFolder = FolderViewModel(
+            folder: Folder(name: "Alternate", path: alternateURL.path, modificationDate: date),
+            rootPath: rootURL.path,
+            hierarchyLevel: 1,
+            isExpanded: true
+        )
+        let alternateFile = FileViewModel(
+            file: File(
+                name: "Alternate.swift",
+                path: alternateURL.appendingPathComponent("Alternate.swift").path,
+                modificationDate: date
+            ),
+            rootPath: rootURL.path,
+            hierarchyLevel: 2,
+            rootIdentifier: root.id,
+            rootFolderPath: rootURL.path,
+            fileSystemService: nil,
+            parentFolder: alternateFolder
+        )
+        sources.addChildrenBatch([.file(file)])
+        alternateFolder.addChildrenBatch([.file(alternateFile)])
+        root.addChildrenBatch([.folder(sources), .folder(alternateFolder)])
+
+        let fileManager = WorkspaceFilesViewModel()
+        fileManager.registerRootFolderForTesting(root)
+        return (fileManager, file, alternateFile)
+    }
+}

--- a/Tests/RepoPromptTests/Mentions/MentionCoordinatorTests.swift
+++ b/Tests/RepoPromptTests/Mentions/MentionCoordinatorTests.swift
@@ -73,10 +73,15 @@ final class MentionCoordinatorTests: XCTestCase {
         coordinator.mentionStarted(at: NSRect(x: 100, y: 100, width: 1, height: 18))
         coordinator.mentionNavigate(.down)
         coordinator.mentionNavigate(.right)
-        try await Task.sleep(nanoseconds: 120_000_000)
+        try await waitUntil {
+            coordinator.testOverlayWindowCount == 2
+                && !coordinator.testSuggestions(atLevel: 1).isEmpty
+        }
         coordinator.mentionNavigate(.right)
-        try await Task.sleep(nanoseconds: 120_000_000)
-        XCTAssertEqual(coordinator.testOverlayWindowCount, 3)
+        try await waitUntil {
+            coordinator.testOverlayWindowCount == 3
+                && !coordinator.testSuggestions(atLevel: 2).isEmpty
+        }
 
         let ancestorSuggestions = coordinator.testSuggestions(atLevel: 1)
         let previousHighlight = try XCTUnwrap(coordinator.testHighlightedIndex(atLevel: 1))
@@ -91,8 +96,10 @@ final class MentionCoordinatorTests: XCTestCase {
 
         XCTAssertEqual(coordinator.testOverlayWindowCount, 2)
         coordinator.mentionNavigate(.right)
-        try await Task.sleep(nanoseconds: 120_000_000)
-        XCTAssertEqual(coordinator.testOverlayWindowCount, 3)
+        try await waitUntil {
+            coordinator.testOverlayWindowCount == 3
+                && !coordinator.testSuggestions(atLevel: 2).isEmpty
+        }
 
         coordinator.mentionAccept()
         let expectedFileName = clickedFolder.displayName == "Sources"
@@ -140,6 +147,16 @@ final class MentionCoordinatorTests: XCTestCase {
         try? await Task.sleep(nanoseconds: 150_000_000)
 
         XCTAssertTrue(coordinator.testSuggestions.isEmpty)
+    }
+
+    private func waitUntil(
+        _ condition: @escaping @MainActor () -> Bool
+    ) async throws {
+        for _ in 0 ..< 200 {
+            if condition() { return }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTFail("Timed out waiting for condition")
     }
 
     private func makeFixture(

--- a/Tests/RepoPromptTests/Mentions/MentionOverlayControllerTests.swift
+++ b/Tests/RepoPromptTests/Mentions/MentionOverlayControllerTests.swift
@@ -19,6 +19,49 @@ final class MentionOverlayControllerTests: XCTestCase {
         XCTAssertEqual(overlay.visibleRowLimit, 1)
     }
 
+    func testHighlightedRowAddsOnlySelectedAccessibilityTrait() {
+        XCTAssertEqual(
+            MentionSuggestionRowView.accessibilityTraits(isHighlighted: true),
+            .isSelected
+        )
+        XCTAssertEqual(
+            MentionSuggestionRowView.accessibilityTraits(isHighlighted: false),
+            []
+        )
+    }
+
+    func testSuggestionWindowResizesForExpandedRowsWithoutMovingAnchorEdge() {
+        let suggestions = (0 ..< 12).map { index in
+            MentionSuggestion(
+                displayName: "File\(index).swift",
+                relativePath: "Sources/File\(index).swift",
+                kind: .file
+            )
+        }
+
+        for placement in [MentionOverlayController.Placement.above, .below] {
+            let window = MentionOverlayController.SuggestionWindow(
+                parent: nil,
+                placement: placement
+            )
+            window.setFrame(NSRect(x: 40, y: 100, width: 240, height: 1), display: false)
+            window.updateSuggestions(suggestions, highlighted: 0)
+            let compactFrame = window.frame
+
+            window.setVisibleRowLimit(FileMentionPickerConfiguration.expanded.visibleRows)
+            let expandedFrame = window.frame
+
+            XCTAssertGreaterThan(expandedFrame.height, compactFrame.height)
+            XCTAssertEqual(expandedFrame.width, compactFrame.width)
+            switch placement {
+            case .above:
+                XCTAssertEqual(expandedFrame.minY, compactFrame.minY)
+            case .below:
+                XCTAssertEqual(expandedFrame.maxY, compactFrame.maxY)
+            }
+        }
+    }
+
     func testSuggestionWindowDisablesNativeShadowForRoundedPopup() {
         let window = MentionOverlayController.SuggestionWindow(
             parent: nil,
@@ -51,6 +94,92 @@ final class MentionOverlayControllerTests: XCTestCase {
         XCTAssertLessThanOrEqual(frame.maxY, visibleFrame.maxY)
     }
 
+    func testRootFrameFlipsAboveWhenPreferredBelowSideDoesNotFit() {
+        let visibleFrame = NSRect(x: 0, y: 0, width: 1000, height: 800)
+        let caret = NSRect(x: 400, y: 20, width: 1, height: 18)
+        let popupSize = NSSize(width: 240, height: 200)
+
+        let frame = MentionOverlayController.positionedRootFrame(
+            caret: caret,
+            popupSize: popupSize,
+            placement: .below,
+            visibleFrame: visibleFrame
+        )
+
+        XCTAssertEqual(frame.minY, caret.maxY + 4)
+        XCTAssertFalse(frame.intersects(caret))
+    }
+
+    func testRootFrameFlipsBelowWhenPreferredAboveSideDoesNotFit() {
+        let visibleFrame = NSRect(x: 0, y: 0, width: 1000, height: 800)
+        let caret = NSRect(x: 400, y: 770, width: 1, height: 18)
+        let popupSize = NSSize(width: 240, height: 200)
+
+        let frame = MentionOverlayController.positionedRootFrame(
+            caret: caret,
+            popupSize: popupSize,
+            placement: .above,
+            visibleFrame: visibleFrame
+        )
+
+        XCTAssertEqual(frame.maxY, caret.minY - 2)
+        XCTAssertFalse(frame.intersects(caret))
+    }
+
+    func testNestedUnequalHeightLevelsStayOnResolvedFlippedSideOfCaret() {
+        let visibleFrame = NSRect(x: 0, y: 0, width: 1000, height: 800)
+        let caret = NSRect(x: 400, y: 20, width: 1, height: 18)
+        let owner = NSWindow(
+            contentRect: visibleFrame,
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: false
+        )
+        let overlay = MentionOverlayController()
+        overlay.placement = .below
+        overlay.visibleRowLimit = 12
+        overlay.visibleFrameOverrideForTesting = visibleFrame
+        defer {
+            overlay.hide()
+            owner.orderOut(nil)
+        }
+
+        overlay.show(at: caret, owner: owner, items: suggestions(count: 4))
+        overlay.pushLevel()
+        overlay.update(items: suggestions(count: 12), highlighted: 0)
+        overlay.pushLevel()
+        overlay.update(items: suggestions(count: 2), highlighted: 0)
+        overlay.repositionRoot(to: caret)
+
+        let frames = overlay.testWindowFrames
+        XCTAssertEqual(frames.count, 3)
+        XCTAssertEqual(overlay.testWindowPlacements, [.above, .above, .above])
+        XCTAssertNotEqual(frames[0].height, frames[1].height)
+        XCTAssertNotEqual(frames[1].height, frames[2].height)
+        for frame in frames {
+            XCTAssertGreaterThan(frame.minY, caret.maxY)
+            XCTAssertFalse(frame.intersects(caret))
+        }
+    }
+
+    func testRootFrameUsesSideWithMoreVisibleAreaWhenNeitherSideFits() {
+        let visibleFrame = NSRect(x: 0, y: 0, width: 1000, height: 300)
+        let caret = NSRect(x: 400, y: 80, width: 1, height: 18)
+        let popupSize = NSSize(width: 240, height: 200)
+
+        let frame = MentionOverlayController.positionedRootFrame(
+            caret: caret,
+            popupSize: popupSize,
+            placement: .below,
+            visibleFrame: visibleFrame
+        )
+
+        XCTAssertEqual(frame.maxY, visibleFrame.maxY)
+        XCTAssertGreaterThan(frame.minY, caret.minY)
+        XCTAssertGreaterThanOrEqual(frame.minX, visibleFrame.minX)
+        XCTAssertLessThanOrEqual(frame.maxX, visibleFrame.maxX)
+    }
+
     func testChildFrameOpensLeftWhenRightSideWouldOverflow() {
         let visibleFrame = NSRect(x: 0, y: 0, width: 1000, height: 800)
         let parentFrame = NSRect(x: 700, y: 300, width: 240, height: 240)
@@ -66,5 +195,120 @@ final class MentionOverlayControllerTests: XCTestCase {
         XCTAssertLessThan(childFrame.maxX, parentFrame.minX)
         XCTAssertGreaterThanOrEqual(childFrame.minX, visibleFrame.minX)
         XCTAssertLessThanOrEqual(childFrame.maxX, visibleFrame.maxX)
+    }
+
+    func testThreeLevelPlacementDoesNotOverlapEarlierLevelsAfterDirectionChange() {
+        let visibleFrame = NSRect(x: 0, y: 0, width: 1000, height: 800)
+        let popupSize = NSSize(width: 240, height: 240)
+        let root = NSRect(x: 700, y: 300, width: popupSize.width, height: popupSize.height)
+        let second = MentionOverlayController.positionedChildFrame(
+            after: root,
+            popupSize: popupSize,
+            placement: .below,
+            visibleFrame: visibleFrame,
+            avoiding: [root]
+        )
+        let third = MentionOverlayController.positionedChildFrame(
+            after: second,
+            popupSize: popupSize,
+            placement: .below,
+            visibleFrame: visibleFrame,
+            avoiding: [root, second]
+        )
+
+        XCTAssertFalse(second.intersects(root))
+        XCTAssertFalse(third.intersects(root))
+        XCTAssertFalse(third.intersects(second))
+    }
+
+    func testThreeExpandedLevelsChooseLowestOverlapAfterHorizontalClamping() throws {
+        let visibleFrame = NSRect(x: 0, y: 0, width: 1000, height: 800)
+        let popupSize = NSSize(width: 480, height: 240)
+        let root = NSRect(x: 520, y: 300, width: popupSize.width, height: popupSize.height)
+        let second = MentionOverlayController.positionedChildFrame(
+            after: root,
+            popupSize: popupSize,
+            placement: .below,
+            visibleFrame: visibleFrame,
+            avoiding: [root]
+        )
+        let third = MentionOverlayController.positionedChildFrame(
+            after: second,
+            popupSize: popupSize,
+            placement: .below,
+            visibleFrame: visibleFrame,
+            avoiding: [root, second]
+        )
+
+        let occupied = [root, second]
+        let occupiedUnion = root.union(second)
+        let candidateOrigins = [
+            second.maxX + 4,
+            second.minX - popupSize.width - 4,
+            occupiedUnion.maxX + 4,
+            occupiedUnion.minX - popupSize.width - 4
+        ]
+        let candidateFrames = candidateOrigins.map { x in
+            MentionOverlayController.clampedFrame(
+                NSRect(x: x, y: second.minY, width: popupSize.width, height: popupSize.height),
+                to: visibleFrame
+            )
+        }
+        let minimumCandidateOverlap = try XCTUnwrap(candidateFrames.map { overlapArea($0, with: occupied) }.min())
+
+        XCTAssertEqual(overlapArea(third, with: occupied), minimumCandidateOverlap)
+        XCTAssertEqual(overlapArea(third, with: [root]), 0)
+        XCTAssertGreaterThan(overlapArea(third, with: [second]), 0)
+        XCTAssertLessThan(overlapArea(third, with: [second]), popupSize.width * popupSize.height)
+        XCTAssertGreaterThanOrEqual(third.minX, visibleFrame.minX)
+        XCTAssertLessThanOrEqual(third.maxX, visibleFrame.maxX)
+    }
+
+    private func suggestions(count: Int) -> [MentionSuggestion] {
+        (0 ..< count).map { index in
+            MentionSuggestion(
+                displayName: "Item \(index)",
+                relativePath: "Item\(index)",
+                kind: .folder
+            )
+        }
+    }
+
+    private func overlapArea(_ frame: NSRect, with occupiedFrames: [NSRect]) -> CGFloat {
+        occupiedFrames.reduce(0) { total, occupied in
+            let intersection = frame.intersection(occupied)
+            guard !intersection.isNull else { return total }
+            return total + intersection.width * intersection.height
+        }
+    }
+
+    func testScreenSelectionUsesCaretIntersectionInsteadOfOwnerScreen() {
+        let firstVisible = NSRect(x: 0, y: 0, width: 1000, height: 760)
+        let secondVisible = NSRect(x: 1000, y: 0, width: 1000, height: 780)
+        let screens = [
+            MentionOverlayController.ScreenGeometry(
+                frame: NSRect(x: 0, y: 0, width: 1000, height: 800),
+                visibleFrame: firstVisible
+            ),
+            MentionOverlayController.ScreenGeometry(
+                frame: NSRect(x: 1000, y: 0, width: 1000, height: 800),
+                visibleFrame: secondVisible
+            )
+        ]
+
+        XCTAssertEqual(
+            MentionOverlayController.selectedVisibleFrame(
+                for: NSRect(x: 1500, y: 300, width: 1, height: 18),
+                screens: screens
+            ),
+            secondVisible
+        )
+        XCTAssertEqual(
+            MentionOverlayController.selectedVisibleFrame(
+                for: NSRect(x: 900, y: 300, width: 300, height: 18),
+                screens: screens
+            ),
+            secondVisible
+        )
     }
 }

--- a/Tests/RepoPromptTests/Mentions/MentionOverlayControllerTests.swift
+++ b/Tests/RepoPromptTests/Mentions/MentionOverlayControllerTests.swift
@@ -1,0 +1,20 @@
+@testable import RepoPrompt
+import XCTest
+
+@MainActor
+final class MentionOverlayControllerTests: XCTestCase {
+    func testVisibleRowLimitDefaultsToFiveAndNormalizesInvalidValues() {
+        let overlay = MentionOverlayController()
+
+        XCTAssertEqual(overlay.visibleRowLimit, 5)
+
+        overlay.visibleRowLimit = FileMentionPickerStyle.expanded.configuration.visibleRows
+        XCTAssertEqual(overlay.visibleRowLimit, 15)
+
+        overlay.visibleRowLimit = 0
+        XCTAssertEqual(overlay.visibleRowLimit, 1)
+
+        overlay.visibleRowLimit = -4
+        XCTAssertEqual(overlay.visibleRowLimit, 1)
+    }
+}

--- a/Tests/RepoPromptTests/Mentions/MentionOverlayControllerTests.swift
+++ b/Tests/RepoPromptTests/Mentions/MentionOverlayControllerTests.swift
@@ -29,4 +29,41 @@ final class MentionOverlayControllerTests: XCTestCase {
             "Native NSWindow shadows are rectangular and can show through around the rounded mention popup."
         )
     }
+
+    func testExpandedRootFrameClampsToVisibleScreenArea() {
+        let visibleFrame = NSRect(x: 0, y: 0, width: 1000, height: 800)
+        let caret = NSRect(x: 900, y: 10, width: 1, height: 18)
+        let popupSize = NSSize(width: 480, height: 400)
+
+        let frame = MentionOverlayController.positionedRootFrame(
+            caret: caret,
+            popupSize: popupSize,
+            placement: .below,
+            visibleFrame: visibleFrame
+        )
+
+        XCTAssertEqual(frame.width, popupSize.width)
+        XCTAssertEqual(frame.height, popupSize.height)
+        XCTAssertGreaterThanOrEqual(frame.minX, visibleFrame.minX)
+        XCTAssertLessThanOrEqual(frame.maxX, visibleFrame.maxX)
+        XCTAssertGreaterThanOrEqual(frame.minY, visibleFrame.minY)
+        XCTAssertLessThanOrEqual(frame.maxY, visibleFrame.maxY)
+    }
+
+    func testChildFrameOpensLeftWhenRightSideWouldOverflow() {
+        let visibleFrame = NSRect(x: 0, y: 0, width: 1000, height: 800)
+        let parentFrame = NSRect(x: 700, y: 300, width: 240, height: 240)
+        let childSize = NSSize(width: 240, height: 240)
+
+        let childFrame = MentionOverlayController.positionedChildFrame(
+            after: parentFrame,
+            popupSize: childSize,
+            placement: .below,
+            visibleFrame: visibleFrame
+        )
+
+        XCTAssertLessThan(childFrame.maxX, parentFrame.minX)
+        XCTAssertGreaterThanOrEqual(childFrame.minX, visibleFrame.minX)
+        XCTAssertLessThanOrEqual(childFrame.maxX, visibleFrame.maxX)
+    }
 }

--- a/Tests/RepoPromptTests/Mentions/MentionOverlayControllerTests.swift
+++ b/Tests/RepoPromptTests/Mentions/MentionOverlayControllerTests.swift
@@ -17,4 +17,16 @@ final class MentionOverlayControllerTests: XCTestCase {
         overlay.visibleRowLimit = -4
         XCTAssertEqual(overlay.visibleRowLimit, 1)
     }
+
+    func testSuggestionWindowDisablesNativeShadowForRoundedPopup() {
+        let window = MentionOverlayController.SuggestionWindow(
+            parent: nil,
+            placement: .below
+        )
+
+        XCTAssertFalse(
+            window.hasShadow,
+            "Native NSWindow shadows are rectangular and can show through around the rounded mention popup."
+        )
+    }
 }

--- a/Tests/RepoPromptTests/Mentions/MentionOverlayControllerTests.swift
+++ b/Tests/RepoPromptTests/Mentions/MentionOverlayControllerTests.swift
@@ -8,8 +8,9 @@ final class MentionOverlayControllerTests: XCTestCase {
 
         XCTAssertEqual(overlay.visibleRowLimit, 5)
 
-        overlay.visibleRowLimit = FileMentionPickerStyle.expanded.configuration.visibleRows
-        XCTAssertEqual(overlay.visibleRowLimit, 15)
+        let expandedVisibleRows = FileMentionPickerStyle.expanded.configuration.visibleRows
+        overlay.visibleRowLimit = expandedVisibleRows
+        XCTAssertEqual(overlay.visibleRowLimit, expandedVisibleRows)
 
         overlay.visibleRowLimit = 0
         XCTAssertEqual(overlay.visibleRowLimit, 1)

--- a/Tests/RepoPromptTests/Mentions/MentionSuggestionServiceTests.swift
+++ b/Tests/RepoPromptTests/Mentions/MentionSuggestionServiceTests.swift
@@ -31,6 +31,21 @@ final class MentionSuggestionServiceTests: XCTestCase {
         XCTAssertTrue(rows.allSatisfy { $0.commitDisplayText == nil })
     }
 
+    func testUpdateFileManagerTracksIdentityAndDeallocation() {
+        let first = WorkspaceFilesViewModel()
+        let service = MentionSuggestionService(fileManager: first)
+
+        XCTAssertFalse(service.updateFileManager(first))
+
+        var second: WorkspaceFilesViewModel? = WorkspaceFilesViewModel()
+        XCTAssertTrue(service.updateFileManager(second))
+        XCTAssertFalse(service.updateFileManager(second))
+
+        second = nil
+        XCTAssertTrue(service.updateFileManager(nil))
+        XCTAssertFalse(service.updateFileManager(nil))
+    }
+
     func testSelectedFolderReturnsAllSelectedFilesWithoutCompactCap() throws {
         let fixture = makeFixture(fileCount: 7)
         for file in fixture.files {
@@ -49,7 +64,6 @@ final class MentionSuggestionServiceTests: XCTestCase {
 
     private func makeFixture(fileCount: Int) -> (
         fileManager: WorkspaceFilesViewModel,
-        root: FolderViewModel,
         files: [FileViewModel]
     ) {
         let rootURL = URL(fileURLWithPath: NSTemporaryDirectory())
@@ -86,6 +100,6 @@ final class MentionSuggestionServiceTests: XCTestCase {
 
         let fileManager = WorkspaceFilesViewModel()
         fileManager.addRootFolder(root)
-        return (fileManager, root, files)
+        return (fileManager, files)
     }
 }

--- a/Tests/RepoPromptTests/Mentions/MentionSuggestionServiceTests.swift
+++ b/Tests/RepoPromptTests/Mentions/MentionSuggestionServiceTests.swift
@@ -1,0 +1,91 @@
+@testable import RepoPrompt
+import XCTest
+
+@MainActor
+final class MentionSuggestionServiceTests: XCTestCase {
+    func testCompactSearchCapsResultsAndKeepsFileRowsUnsubtitled() {
+        let fixture = makeFixture(fileCount: 8)
+        let service = MentionSuggestionService(fileManager: fixture.fileManager)
+
+        let rows = service.suggestions(for: "Match")
+
+        XCTAssertEqual(rows.count, 5)
+        XCTAssertTrue(rows.allSatisfy { $0.kind == .file })
+        XCTAssertTrue(rows.allSatisfy { $0.subtitle == nil })
+        XCTAssertTrue(rows.allSatisfy { $0.commitDisplayText == nil })
+    }
+
+    func testExpandedSearchUsesLargerResultCapAndParentPathSubtitles() {
+        let fixture = makeFixture(fileCount: 12)
+        let service = MentionSuggestionService(
+            fileManager: fixture.fileManager,
+            configuration: .expanded
+        )
+
+        let rows = service.suggestions(for: "Match")
+
+        XCTAssertEqual(rows.count, 12)
+        XCTAssertTrue(rows.allSatisfy { $0.kind == .file })
+        XCTAssertEqual(Set(rows.compactMap(\.subtitle)), ["Sources"])
+        XCTAssertTrue(rows.allSatisfy { $0.relativePath.hasPrefix("Sources/") })
+        XCTAssertTrue(rows.allSatisfy { $0.commitDisplayText == nil })
+    }
+
+    func testSelectedFolderReturnsAllSelectedFilesWithoutCompactCap() throws {
+        let fixture = makeFixture(fileCount: 7)
+        for file in fixture.files {
+            fixture.fileManager.selectFileForTesting(file)
+        }
+        let service = MentionSuggestionService(fileManager: fixture.fileManager)
+
+        let rootRows = service.suggestions(for: "")
+        let selectedFolder = try XCTUnwrap(rootRows.first(where: { $0.displayName == "Selected" }))
+        let selectedRows = service.suggestions(for: "", under: selectedFolder)
+
+        XCTAssertEqual(selectedRows.count, 7)
+        XCTAssertTrue(selectedRows.allSatisfy { $0.kind == .file })
+        XCTAssertTrue(selectedRows.allSatisfy { $0.subtitle == nil })
+    }
+
+    private func makeFixture(fileCount: Int) -> (
+        fileManager: WorkspaceFilesViewModel,
+        root: FolderViewModel,
+        files: [FileViewModel]
+    ) {
+        let rootURL = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("MentionSuggestionServiceTests", isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let sourceURL = rootURL.appendingPathComponent("Sources", isDirectory: true)
+        let date = Date(timeIntervalSince1970: 1000)
+        let root = FolderViewModel(
+            folder: Folder(name: "FixtureRoot", path: rootURL.path, modificationDate: date),
+            rootPath: rootURL.path,
+            isExpanded: true
+        )
+        let sources = FolderViewModel(
+            folder: Folder(name: "Sources", path: sourceURL.path, modificationDate: date),
+            rootPath: rootURL.path,
+            hierarchyLevel: 1,
+            isExpanded: true
+        )
+
+        let files = (0 ..< fileCount).map { index in
+            let name = String(format: "Match%02d.swift", index)
+            return FileViewModel(
+                file: File(name: name, path: sourceURL.appendingPathComponent(name).path, modificationDate: date),
+                rootPath: rootURL.path,
+                hierarchyLevel: 2,
+                rootIdentifier: root.id,
+                rootFolderPath: rootURL.path,
+                fileSystemService: nil,
+                parentFolder: sources
+            )
+        }
+        sources.addChildrenBatch(files.map(FileSystemItemType.file))
+        root.addChildrenBatch([.folder(sources)])
+
+        let fileManager = WorkspaceFilesViewModel()
+        fileManager.addRootFolder(root)
+        return (fileManager, root, files)
+    }
+}

--- a/Tests/RepoPromptTests/Mentions/TextFieldMentionHelpersTests.swift
+++ b/Tests/RepoPromptTests/Mentions/TextFieldMentionHelpersTests.swift
@@ -1,0 +1,131 @@
+import AppKit
+@testable import RepoPrompt
+import XCTest
+
+@MainActor
+final class TextFieldMentionHelpersTests: XCTestCase {
+    func testFileTagClickThenAcceptCommitsClickedSuggestion() {
+        let first = MentionSuggestion(
+            displayName: "First.swift",
+            relativePath: "Sources/First.swift",
+            kind: .file
+        )
+        let second = MentionSuggestion(
+            displayName: "Second.swift",
+            relativePath: "Sources/Second.swift",
+            kind: .file
+        )
+        let textView = ImageAwareTextView(frame: NSRect(x: 0, y: 0, width: 200, height: 80))
+        textView.string = "@s"
+        textView.setSelectedRange(NSRange(location: 2, length: 0))
+        let helper = FileTagMentionHelper()
+        helper.setSelectionStateForTesting(
+            suggestions: [first, second],
+            highlightedIndex: 0,
+            triggerRange: NSRange(location: 0, length: 2)
+        )
+        var committed: MentionSuggestion?
+
+        helper.clickSuggestionForTesting(at: 1)
+        let handled = helper.handleCommandIfNeeded(
+            textView: textView,
+            commandSelector: #selector(NSResponder.insertTab(_:)),
+            enabled: true,
+            onCommit: { committed = $0 }
+        )
+
+        XCTAssertTrue(handled)
+        XCTAssertEqual(committed, second)
+        XCTAssertEqual(textView.string, "@Sources/Second.swift ")
+    }
+
+    func testSlashSkillClickSurvivesDelayedRefreshCompletionBeforeAccept() async throws {
+        let first = MentionSuggestion(
+            displayName: "/first",
+            relativePath: "first",
+            kind: .skill
+        )
+        let clicked = MentionSuggestion(
+            displayName: "/clicked",
+            relativePath: "clicked",
+            kind: .skill
+        )
+        let refreshed = MentionSuggestion(
+            displayName: "/refreshed",
+            relativePath: "refreshed",
+            kind: .skill
+        )
+        let provider = DelayedSuggestionProvider(initial: [first, clicked], refreshed: [refreshed])
+        let owner = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 600, height: 400),
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: false
+        )
+        defer { owner.orderOut(nil) }
+        let textView = ImageAwareTextView(frame: NSRect(x: 20, y: 20, width: 300, height: 80))
+        textView.string = "/c"
+        textView.setSelectedRange(NSRange(location: 2, length: 0))
+        owner.contentView = textView
+        let helper = SlashSkillMentionHelper()
+        helper.configure(
+            textView: textView,
+            enabled: true,
+            suggestionsProvider: { query in await provider.suggestions(for: query) }
+        )
+        try await waitUntil { helper.suggestionsForTesting == [first, clicked] }
+
+        helper.scheduleRefresh(for: textView, immediate: true, enabled: true, isActive: true)
+        try await waitUntil { provider.callCount == 2 }
+        helper.clickSuggestionForTesting(at: 1)
+        provider.completeRefresh()
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        let handled = helper.handleCommandIfNeeded(
+            textView: textView,
+            commandSelector: #selector(NSResponder.insertNewline(_:)),
+            enabled: true
+        )
+
+        XCTAssertTrue(handled)
+        XCTAssertEqual(textView.string, "/clicked ")
+    }
+
+    private func waitUntil(
+        _ condition: @escaping @MainActor () -> Bool
+    ) async throws {
+        for _ in 0 ..< 100 {
+            if condition() { return }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTFail("Timed out waiting for condition")
+    }
+}
+
+@MainActor
+private final class DelayedSuggestionProvider {
+    let initial: [MentionSuggestion]
+    let refreshed: [MentionSuggestion]
+    private var continuation: CheckedContinuation<[MentionSuggestion], Never>?
+    private(set) var callCount = 0
+
+    init(initial: [MentionSuggestion], refreshed: [MentionSuggestion]) {
+        self.initial = initial
+        self.refreshed = refreshed
+    }
+
+    func suggestions(for _: String) async -> [MentionSuggestion] {
+        callCount += 1
+        if callCount == 1 {
+            return initial
+        }
+        return await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func completeRefresh() {
+        continuation?.resume(returning: refreshed)
+        continuation = nil
+    }
+}

--- a/Tests/RepoPromptTests/SettingsJSONOnlyPersistenceTests.swift
+++ b/Tests/RepoPromptTests/SettingsJSONOnlyPersistenceTests.swift
@@ -251,7 +251,6 @@ final class SettingsJSONOnlyPersistenceTests: XCTestCase {
         let before = try String(contentsOf: fileURL, encoding: .utf8)
 
         XCTAssertEqual(store.fileMentionPickerStyle(), .compact)
-        XCTAssertEqual(store.fileMentionPickerStyleRaw(), "compact")
         XCTAssertEqual(store.fileMentionPickerConfiguration(), .compact)
         XCTAssertNil(try fileStore.load().scalarPreferences?.ui?.fileMentionPickerStyle)
         XCTAssertEqual(try String(contentsOf: fileURL, encoding: .utf8), before)
@@ -294,22 +293,6 @@ final class SettingsJSONOnlyPersistenceTests: XCTestCase {
         XCTAssertEqual(store.fileMentionPickerStyle(), .compact)
         XCTAssertEqual(store.fileMentionPickerConfiguration(), .compact)
         XCTAssertEqual(try fileStore.load().scalarPreferences?.ui?.fileMentionPickerStyle, "wide")
-    }
-
-    func testFileMentionPickerStyleRawSetterPersistsNormalizedValue() throws {
-        let temp = try makeTempDirectory()
-        defer { try? FileManager.default.removeItem(at: temp) }
-        let fileURL = temp.appendingPathComponent("Settings/globalSettings.json")
-        let fileStore = GlobalSettingsFileStore(fileURL: fileURL)
-        let store = try GlobalSettingsStore(
-            defaults: XCTUnwrap(UserDefaults(suiteName: "SettingsJSONOnlyPersistenceTests.\(UUID().uuidString)")),
-            fileStore: fileStore
-        )
-
-        store.setFileMentionPickerStyleRaw("wide")
-
-        XCTAssertEqual(store.fileMentionPickerStyle(), .compact)
-        XCTAssertEqual(try fileStore.load().scalarPreferences?.ui?.fileMentionPickerStyle, "compact")
     }
 
     private func makeTempDirectory() throws -> URL {

--- a/Tests/RepoPromptTests/SettingsJSONOnlyPersistenceTests.swift
+++ b/Tests/RepoPromptTests/SettingsJSONOnlyPersistenceTests.swift
@@ -239,6 +239,79 @@ final class SettingsJSONOnlyPersistenceTests: XCTestCase {
         XCTAssertEqual(try String(contentsOf: fileURL, encoding: .utf8), futureJSON)
     }
 
+    func testFileMentionPickerStyleDefaultsToCompactWithoutPersistingRawSetting() throws {
+        let temp = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: temp) }
+        let fileURL = temp.appendingPathComponent("Settings/globalSettings.json")
+        let fileStore = GlobalSettingsFileStore(fileURL: fileURL)
+        let store = try GlobalSettingsStore(
+            defaults: XCTUnwrap(UserDefaults(suiteName: "SettingsJSONOnlyPersistenceTests.\(UUID().uuidString)")),
+            fileStore: fileStore
+        )
+        let before = try String(contentsOf: fileURL, encoding: .utf8)
+
+        XCTAssertEqual(store.fileMentionPickerStyle(), .compact)
+        XCTAssertEqual(store.fileMentionPickerStyleRaw(), "compact")
+        XCTAssertEqual(store.fileMentionPickerConfiguration(), .compact)
+        XCTAssertNil(try fileStore.load().scalarPreferences?.ui?.fileMentionPickerStyle)
+        XCTAssertEqual(try String(contentsOf: fileURL, encoding: .utf8), before)
+    }
+
+    func testFileMentionPickerStyleSavesAndLoadsExpandedRawValue() throws {
+        let temp = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: temp) }
+        let fileURL = temp.appendingPathComponent("Settings/globalSettings.json")
+        let fileStore = GlobalSettingsFileStore(fileURL: fileURL)
+        let suiteName = "SettingsJSONOnlyPersistenceTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = GlobalSettingsStore(defaults: defaults, fileStore: fileStore)
+
+        store.setFileMentionPickerStyle(.expanded)
+
+        XCTAssertEqual(try fileStore.load().scalarPreferences?.ui?.fileMentionPickerStyle, "expanded")
+        let reloaded = GlobalSettingsStore(defaults: defaults, fileStore: fileStore)
+        XCTAssertEqual(reloaded.fileMentionPickerStyle(), .expanded)
+        XCTAssertEqual(reloaded.fileMentionPickerConfiguration(), .expanded)
+    }
+
+    func testInvalidFileMentionPickerStyleRawDefaultsToCompactWithoutReadTimeMutation() throws {
+        let temp = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: temp) }
+        let fileURL = temp.appendingPathComponent("Settings/globalSettings.json")
+        let fileStore = GlobalSettingsFileStore(fileURL: fileURL)
+        try fileStore.save(GlobalSettingsDocument(
+            scalarPreferences: GlobalScalarPreferences(
+                ui: .init(fileMentionPickerStyle: "wide")
+            )
+        ))
+
+        let store = try GlobalSettingsStore(
+            defaults: XCTUnwrap(UserDefaults(suiteName: "SettingsJSONOnlyPersistenceTests.\(UUID().uuidString)")),
+            fileStore: fileStore
+        )
+
+        XCTAssertEqual(store.fileMentionPickerStyle(), .compact)
+        XCTAssertEqual(store.fileMentionPickerConfiguration(), .compact)
+        XCTAssertEqual(try fileStore.load().scalarPreferences?.ui?.fileMentionPickerStyle, "wide")
+    }
+
+    func testFileMentionPickerStyleRawSetterPersistsNormalizedValue() throws {
+        let temp = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: temp) }
+        let fileURL = temp.appendingPathComponent("Settings/globalSettings.json")
+        let fileStore = GlobalSettingsFileStore(fileURL: fileURL)
+        let store = try GlobalSettingsStore(
+            defaults: XCTUnwrap(UserDefaults(suiteName: "SettingsJSONOnlyPersistenceTests.\(UUID().uuidString)")),
+            fileStore: fileStore
+        )
+
+        store.setFileMentionPickerStyleRaw("wide")
+
+        XCTAssertEqual(store.fileMentionPickerStyle(), .compact)
+        XCTAssertEqual(try fileStore.load().scalarPreferences?.ui?.fileMentionPickerStyle, "compact")
+    }
+
     private func makeTempDirectory() throws -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("SettingsJSONOnlyPersistenceTests-\(UUID().uuidString)", isDirectory: true)


### PR DESCRIPTION
## Summary

Users can now opt into an expanded file mention picker that shows more results and includes path subtitles to disambiguate files with the same name. The compact picker remains the default.

## Changes

- New `FileMentionPickerStyle` setting (compact / expanded) persisted in global settings and surfaced in Appearance preferences.
- Expanded mode widens the picker, increases visible results, and adds path-based subtitles.
- Mention popup frames clamped to visible screen bounds so the wider picker doesn't overflow off-screen.
- Native NSWindow shadow disabled on the rounded picker popup to eliminate rectangular halo artifacts.
- Active mention sessions reset when picker configuration changes.

Fixes https://github.com/repoprompt/repoprompt-ce/issues/90
