### PR TITLE
Fix ACP mode negotiation and OpenCode routing

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/Providers/ACP/ACPAgentProvider.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Providers/ACP/ACPAgentProvider.swift
@@ -180,7 +180,7 @@ enum NormalizedAgentRuntimeEvent {
 protocol ACPAgentProvider: Sendable {
     var providerID: ACPProviderID { get }
 
-    func support(for request: ACPRunRequest) async -> ACPSupportResult
+    func support(for request: ACPRunRequest) async throws -> ACPSupportResult
     func makeLaunchConfiguration(for request: ACPRunRequest) throws -> ACPLaunchConfiguration
     func makeSessionConfiguration(
         for request: ACPRunRequest,

--- a/Sources/RepoPrompt/Features/AgentMode/Providers/ACP/ACPAgentProvider.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Providers/ACP/ACPAgentProvider.swift
@@ -134,6 +134,7 @@ struct ACPLaunchConfiguration: Equatable {
     let additionalPathHints: [String]
     let enableDebugLogging: Bool
     let cleanupArtifact: ACPLaunchCleanupArtifact?
+    let expectedExecutableIdentity: ExecutableFileIdentity?
 
     init(
         providerID: ACPProviderID,
@@ -143,7 +144,8 @@ struct ACPLaunchConfiguration: Equatable {
         workingDirectory: String?,
         additionalPathHints: [String],
         enableDebugLogging: Bool,
-        cleanupArtifact: ACPLaunchCleanupArtifact? = nil
+        cleanupArtifact: ACPLaunchCleanupArtifact? = nil,
+        expectedExecutableIdentity: ExecutableFileIdentity? = nil
     ) {
         self.providerID = providerID
         self.command = command
@@ -153,6 +155,7 @@ struct ACPLaunchConfiguration: Equatable {
         self.additionalPathHints = additionalPathHints
         self.enableDebugLogging = enableDebugLogging
         self.cleanupArtifact = cleanupArtifact
+        self.expectedExecutableIdentity = expectedExecutableIdentity
     }
 }
 

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Providers/AgentRuntimeProviderService.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Providers/AgentRuntimeProviderService.swift
@@ -275,7 +275,7 @@ final class AgentRuntimeProviderService {
                 enableDebugLogging: Self.enableDebugLogging,
                 modelString: modelString,
                 includeRepoPromptMCPServer: true,
-                cleanupProjectMCPConfig: true
+                cleanupProjectMCPApproval: true
             )
             if Self.enableDebugLogging {
                 Self.logger.debug("Created CursorACPHeadlessAgentProvider")

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/ACPIntegratedAgentModeRunner.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/ACPIntegratedAgentModeRunner.swift
@@ -166,7 +166,28 @@ final class ACPIntegratedAgentModeRunner {
             )
             return
         }
-        let support = await provider.support(for: freshRunRequest)
+        let support: ACPSupportResult
+        do {
+            support = try await provider.support(for: freshRunRequest)
+        } catch is CancellationError {
+            await cancelBeforeProviderSend(
+                session: session,
+                runID: runID,
+                runAttemptID: runAttemptID,
+                attachmentReservationID: attachmentReservationID
+            )
+            return
+        } catch {
+            await failBeforeProviderSend(
+                tabID: tabID,
+                session: session,
+                runID: runID,
+                runAttemptID: runAttemptID,
+                attachmentReservationID: attachmentReservationID,
+                errorText: "ACP support preflight failed: \(error.localizedDescription)"
+            )
+            return
+        }
         guard isStartupStillCurrent(session: session, runID: runID, runAttemptID: runAttemptID) else { return }
         guard support == .supported else {
             await failBeforeProviderSend(
@@ -358,6 +379,36 @@ final class ACPIntegratedAgentModeRunner {
             terminalState: .failed,
             source: "acp.startupFailure",
             errorText: errorText,
+            attachmentReservationID: attachmentReservationID,
+            attachmentDisposition: .deleteFiles,
+            finalizeNonCodexUsage: true,
+            supportsFollowUp: false,
+            notifyTurnComplete: false,
+            prepareProviderState: {
+                session.acpController = nil
+                AgentModeProcessRunIdentity.clearProcessRunID(for: session)
+                return nil
+            }
+        ))
+    }
+
+    private func cancelBeforeProviderSend(
+        session: AgentModeViewModel.TabSession,
+        runID: UUID,
+        runAttemptID: UUID,
+        attachmentReservationID: UUID?
+    ) async {
+        guard isStartupStillCurrent(session: session, runID: runID, runAttemptID: runAttemptID),
+              let ownership = session.activeRunOwnership,
+              ownership.attemptID == runAttemptID
+        else { return }
+        hooks.recordPendingHandoffSendOutcome(session, false)
+        await terminalCommitBarrier.commit(.init(
+            session: session,
+            ownership: ownership,
+            expectedRunID: runID,
+            terminalState: .cancelled,
+            source: "acp.startupCancelled",
             attachmentReservationID: attachmentReservationID,
             attachmentDisposition: .deleteFiles,
             finalizeNonCodexUsage: true,

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/ACPIntegratedAgentModeRunner.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/ACPIntegratedAgentModeRunner.swift
@@ -166,6 +166,19 @@ final class ACPIntegratedAgentModeRunner {
             )
             return
         }
+        let support = await provider.support(for: freshRunRequest)
+        guard isStartupStillCurrent(session: session, runID: runID, runAttemptID: runAttemptID) else { return }
+        guard support == .supported else {
+            await failBeforeProviderSend(
+                tabID: tabID,
+                session: session,
+                runID: runID,
+                runAttemptID: runAttemptID,
+                attachmentReservationID: attachmentReservationID,
+                errorText: support.reason ?? "\(runRequest.agentKind.displayName) ACP is not available."
+            )
+            return
+        }
         let controller: ACPAgentSessionController
         do {
             controller = try controllerFactory(provider, freshRunRequest)
@@ -414,9 +427,9 @@ final class ACPIntegratedAgentModeRunner {
             hooks.scheduleSave(session.tabID)
             hooks.updateBindings(session)
 
-            try await applyRequestedSessionModeIfNeeded(runRequest.sessionModeID, controller: controller, runID: runID)
-            await controller.setAutoApproveAllToolPermissions(runRequest.autoApproveAllToolPermissions)
             try await applyExplicitSelectedModelIfNeeded(runRequest, controller: controller, runID: runID)
+            await controller.setAutoApproveAllToolPermissions(runRequest.autoApproveAllToolPermissions)
+            try await applyRequestedSessionModeIfNeeded(runRequest.sessionModeID, controller: controller, runID: runID)
             setRunningStatus(waitingForConnectionStatusText(for: runRequest.agentKind), source: .transport, session: session, urgent: true)
 
             let routed = await lease.releaseWhenRouted()
@@ -505,9 +518,9 @@ final class ACPIntegratedAgentModeRunner {
                 return
             }
 
-            try await applyRequestedSessionModeIfNeeded(runRequest.sessionModeID, controller: controller, runID: runID)
-            await controller.setAutoApproveAllToolPermissions(runRequest.autoApproveAllToolPermissions)
             try await applyExplicitSelectedModelIfNeeded(runRequest, controller: controller, runID: runID)
+            await controller.setAutoApproveAllToolPermissions(runRequest.autoApproveAllToolPermissions)
+            try await applyRequestedSessionModeIfNeeded(runRequest.sessionModeID, controller: controller, runID: runID)
 
             await runPromptTurn(
                 session: session,

--- a/Sources/RepoPrompt/Features/Diagnostics/MCP/MCPConnectionManager+DebugDiagnostics.swift
+++ b/Sources/RepoPrompt/Features/Diagnostics/MCP/MCPConnectionManager+DebugDiagnostics.swift
@@ -35,6 +35,8 @@ import MCP
                 return await debugRoutingSnapshotToolPayload(op: op, connectionID: connectionID, arguments: arguments)
             case "connection_history":
                 return debugConnectionHistoryToolPayload(op: op, arguments: arguments)
+            case "run_routing_history":
+                return debugRunRoutingHistoryToolPayload(op: op, arguments: arguments)
             case "clear_connection_history":
                 return debugClearConnectionHistoryToolPayload(op: op, arguments: arguments)
             case "wait_for_reconnect":

--- a/Sources/RepoPrompt/Features/Diagnostics/MCP/MCPConnectionManager+DebugTransportDiagnostics.swift
+++ b/Sources/RepoPrompt/Features/Diagnostics/MCP/MCPConnectionManager+DebugTransportDiagnostics.swift
@@ -151,6 +151,22 @@ import MCP
             ))
         }
 
+        func debugRunRoutingHistoryToolPayload(op: String, arguments: [String: Value]) -> CallTool.Result {
+            let limit: Int
+            switch debugBoundedInt(arguments, "limit", defaultValue: 200, range: 1 ... 500) {
+            case let .value(value), let .defaulted(value): limit = value
+            case .invalid:
+                return debugDiagnosticsError(op: op, code: "invalid_params", message: "limit must be an integer in 1...500.")
+            }
+            guard let parsedRunID = debugOptionalUUID(arguments, "run_id", op: op) else {
+                return debugDiagnosticsError(op: op, code: "invalid_params", message: "run_id must be a UUID string.")
+            }
+            guard let runID = parsedRunID else {
+                return debugDiagnosticsError(op: op, code: "invalid_params", message: "run_id is required.")
+            }
+            return debugDiagnosticsResult(debugRunRoutingHistoryPayload(runID: runID, limit: limit))
+        }
+
         func debugClearConnectionHistoryToolPayload(op: String, arguments: [String: Value]) -> CallTool.Result {
             guard debugBool(arguments, "allow_destructive") == true else {
                 return debugDiagnosticsError(op: op, code: "invalid_params", message: "clear_connection_history requires allow_destructive=true.")

--- a/Sources/RepoPrompt/Features/Settings/ViewModels/APISettingsViewModel.swift
+++ b/Sources/RepoPrompt/Features/Settings/ViewModels/APISettingsViewModel.swift
@@ -294,7 +294,7 @@ public class APISettingsViewModel: ObservableObject {
     @Published var openCodeError: String? = nil
     @Published private(set) var availableOpenCodeModelOptions: [AgentModelOption] = []
     private var openCodeLogCollector: CLIProcessLogCollector?
-    // Cursor CLI / ACP
+    // Cursor Agent CLI / ACP
     @Published var isCursorConnected: Bool = UserDefaults.standard.bool(forKey: "CursorCLIConnected")
     @Published var cursorError: String? = nil
     @Published private(set) var availableCursorModelOptions: [AgentModelOption] = []
@@ -2921,7 +2921,7 @@ public class APISettingsViewModel: ObservableObject {
 
     func testCursorConnection() async throws -> Bool {
         let collector = CLIProcessLogCollector()
-        collector.append("Cursor CLI connection test started")
+        collector.append("Cursor Agent CLI connection test started")
         collector.append("Preferred Cursor model fallback: \(AgentModel.cursorAuto.rawValue)")
         cursorLogCollector = collector
 
@@ -2947,7 +2947,7 @@ public class APISettingsViewModel: ObservableObject {
             UserDefaults.standard.set(true, forKey: "CursorCLIConnected")
             startCursorModelsSubscriptionIfNeeded(workspacePath: nil)
             await updateAvailableModels()
-            collector.append("Cursor CLI marked as connected")
+            collector.append("Cursor Agent CLI marked as connected")
             cursorLogCollector = nil
             NotificationCenter.default.post(
                 name: .cursorConnectionChanged,
@@ -2995,7 +2995,7 @@ public class APISettingsViewModel: ObservableObject {
             case let .invalidConfiguration(detail):
                 return detail
             case let .apiError(source):
-                return source?.localizedDescription ?? "Unknown Cursor CLI error"
+                return source?.localizedDescription ?? "Unknown Cursor Agent CLI error"
             default:
                 return error.localizedDescription
             }
@@ -3003,16 +3003,16 @@ public class APISettingsViewModel: ObservableObject {
         let message = error.localizedDescription
         let lowered = message.lowercased()
         if lowered.contains("not installed") || lowered.contains("no such file") || lowered.contains("command not found") || lowered.contains("not found") {
-            return "Cursor CLI ACP server was not found. Install Cursor CLI and ensure `cursor-agent acp` or `cursor agent acp` is available on PATH."
+            return "Cursor Agent CLI ACP server was not found. Install Cursor Agent CLI and ensure `cursor-agent acp` is available."
         }
         if lowered.contains("permission denied") {
             return "Permission denied. Ensure the `cursor-agent` executable is accessible."
         }
         if lowered.contains("unauthorized") || lowered.contains("not authenticated") || lowered.contains("login") {
-            return "Cursor CLI is not authenticated. Set `CURSOR_API_KEY`/`CURSOR_AUTH_TOKEN` or complete Cursor login."
+            return "Cursor Agent CLI is not authenticated. Set `CURSOR_API_KEY`/`CURSOR_AUTH_TOKEN` or complete Cursor login."
         }
         if lowered.contains("does not advertise acp") || lowered.contains("acp support") {
-            return "Installed Cursor CLI does not support ACP mode. Update Cursor CLI and ensure `cursor-agent acp --help` works."
+            return "Installed Cursor Agent CLI does not support ACP mode. Update Cursor Agent CLI and ensure `cursor-agent acp --help` works."
         }
         return message
     }
@@ -3029,7 +3029,7 @@ public class APISettingsViewModel: ObservableObject {
         let exportDate = Date()
         let url = try collector.writeMarkdownToDownloads(
             baseFilename: "RepoPrompt-CursorTrace",
-            title: "Cursor CLI Connection Trace",
+            title: "Cursor Agent CLI Connection Trace",
             timestamp: exportDate
         )
         collector.append("Trace exported to \(url.lastPathComponent)")

--- a/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPAgentSessionController.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPAgentSessionController.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 
 actor ACPAgentSessionController {
@@ -222,9 +223,14 @@ actor ACPAgentSessionController {
     private let diagnosticSink: DiagnosticSink?
     private let requestTimeouts: RequestTimeouts
 
-    /// Modern configOptions are the only mode-selection authority. Mutations are serialized,
+    /// Modern configOptions are the only configuration authority. Mutations are serialized,
     /// and complete snapshots apply in inbound wire order.
     private let configurationMutationMutex = AsyncMutex()
+    #if DEBUG
+        private var debugShouldSuspendNextConfigurationMutationPostcheck = false
+        private var debugConfigurationMutationPostcheckIsSuspended = false
+        private var debugConfigurationMutationPostcheckResumeWaiters: [CheckedContinuation<Void, Never>] = []
+    #endif
 
     private var state: State = .idle
     private var process: SpawnedProcess?
@@ -377,7 +383,7 @@ actor ACPAgentSessionController {
         )
         do {
             if let expectedExecutableIdentity = launchConfiguration.expectedExecutableIdentity {
-                try expectedExecutableIdentity.validate(atPath: resolvedCommand)
+                try expectedExecutableIdentity.validateForTrustedPathLaunch(atPath: resolvedCommand)
             }
         } catch {
             await recordRunLaunchContract(
@@ -668,7 +674,7 @@ actor ACPAgentSessionController {
                     "value": configValue
                 ]
             )
-            try applyVerifiedConfigOptionsMutationResponse(
+            try await applyVerifiedConfigOptionsMutationResponse(
                 response,
                 requiredModeValue: nil,
                 requiredModelValue: configValue
@@ -714,7 +720,7 @@ actor ACPAgentSessionController {
                 "value": canonicalModeID
             ]
         )
-        try applyVerifiedConfigOptionsMutationResponse(
+        try await applyVerifiedConfigOptionsMutationResponse(
             response,
             requiredModeValue: canonicalModeID,
             requiredModelValue: nil
@@ -795,6 +801,12 @@ actor ACPAgentSessionController {
         }
         cancelPendingPermissionRequestsLocally()
     }
+
+    #if DEBUG
+        func debugPromptSettlementWaiterCount() -> Int {
+            promptSettlementWaitersByTurnID.values.reduce(0) { $0 + $1.count }
+        }
+    #endif
 
     func interruptActivePromptForSteering(timeoutSeconds: TimeInterval = 15) async throws {
         guard sessionID != nil else {
@@ -927,6 +939,15 @@ actor ACPAgentSessionController {
         waiter.continuation.resume(throwing: CancellationError())
     }
 
+    private func failAllPromptSettlementWaiters(with error: Error) {
+        activePromptTurnID = nil
+        let waiters = promptSettlementWaitersByTurnID.values.flatMap(\.self)
+        promptSettlementWaitersByTurnID.removeAll()
+        for waiter in waiters {
+            waiter.continuation.resume(throwing: error)
+        }
+    }
+
     private func settlePromptTurn(_ turnID: UUID, result: Result<Void, Error>) {
         if activePromptTurnID == turnID {
             activePromptTurnID = nil
@@ -943,11 +964,15 @@ actor ACPAgentSessionController {
     }
 
     func shutdown() async {
+        #if DEBUG
+            debugResumeConfigurationMutationPostcheck()
+        #endif
         guard state != .closed, state != .closing else { return }
         state = .closing
         log("Shutting down ACP controller")
 
         await cancelPrompt()
+        failAllPromptSettlementWaiters(with: ControllerError.transportClosed)
         failPendingRequests(with: ControllerError.transportClosed)
 
         stdoutChannel?.finish()
@@ -1303,6 +1328,7 @@ actor ACPAgentSessionController {
             emitTerminal(state: .failed, errorText: message)
         }
 
+        failAllPromptSettlementWaiters(with: ControllerError.transportClosed)
         failPendingRequests(with: ControllerError.transportClosed)
         state = .failed
         await clearExpectedAgentPIDIfNeeded()
@@ -2065,11 +2091,41 @@ actor ACPAgentSessionController {
         snapshot.availableValues.isEmpty ? "none" : snapshot.availableValues.joined(separator: ", ")
     }
 
+    #if DEBUG
+        func debugSuspendNextConfigurationMutationPostcheck() {
+            debugShouldSuspendNextConfigurationMutationPostcheck = true
+        }
+
+        func debugIsConfigurationMutationPostcheckSuspended() -> Bool {
+            debugConfigurationMutationPostcheckIsSuspended
+        }
+
+        func debugResumeConfigurationMutationPostcheck() {
+            debugShouldSuspendNextConfigurationMutationPostcheck = false
+            debugConfigurationMutationPostcheckIsSuspended = false
+            let waiters = debugConfigurationMutationPostcheckResumeWaiters
+            debugConfigurationMutationPostcheckResumeWaiters.removeAll()
+            for waiter in waiters {
+                waiter.resume()
+            }
+        }
+
+        private func debugSuspendConfigurationMutationPostcheckIfNeeded() async {
+            guard debugShouldSuspendNextConfigurationMutationPostcheck else { return }
+            debugShouldSuspendNextConfigurationMutationPostcheck = false
+            debugConfigurationMutationPostcheckIsSuspended = true
+            await withCheckedContinuation { continuation in
+                debugConfigurationMutationPostcheckResumeWaiters.append(continuation)
+            }
+            debugConfigurationMutationPostcheckIsSuspended = false
+        }
+    #endif
+
     private func applyVerifiedConfigOptionsMutationResponse(
         _ response: RequestResponse,
         requiredModeValue: String?,
         requiredModelValue: String?
-    ) throws {
+    ) async throws {
         guard let configOptions = response.result["configOptions"] as? [[String: Any]] else {
             throw ControllerError.protocolViolation("session/set_config_option response missing complete configOptions snapshot")
         }
@@ -2106,8 +2162,11 @@ actor ACPAgentSessionController {
                 inboundSequence: response.inboundSequence
             )
         }
+        #if DEBUG
+            await debugSuspendConfigurationMutationPostcheckIfNeeded()
+        #endif
         if let requiredModeValue,
-           sessionModeSnapshot?.currentValue.caseInsensitiveCompare(requiredModeValue) != .orderedSame
+           sessionModeSnapshot?.currentValue != requiredModeValue
         {
             throw ControllerError.protocolViolation("newer ACP configuration state no longer confirms requested mode '\(requiredModeValue)'")
         }
@@ -2204,7 +2263,10 @@ actor ACPAgentSessionController {
         case .absent:
             sessionModelConfigOptionID = nil
             sessionModelFailureReason = nil
-            parsed = parseLegacyModelsSnapshot(from: response["models"] as? [String: Any])
+            parsed = nil
+            if response["models"] != nil {
+                diagnose(.info("Ignoring legacy ACP models metadata because model discovery and selection require configOptions."))
+            }
         case let .malformed(reason):
             sessionModelConfigOptionID = nil
             sessionModelFailureReason = reason
@@ -2252,33 +2314,6 @@ actor ACPAgentSessionController {
         }
     }
 
-    private func parseLegacyModelsSnapshot(from models: [String: Any]?) -> ACPDiscoveredSessionModels? {
-        guard let models else { return nil }
-        let currentModelRaw = normalizedACPModelString(models["currentModelId"] as? String)
-        var options = mergeModelOptions(
-            (models["availableModels"] as? [[String: Any]] ?? []).compactMap(parseDiscoveredModelOption)
-        )
-        if let currentModelRaw,
-           !options.contains(where: { $0.rawValue.caseInsensitiveCompare(currentModelRaw) == .orderedSame })
-        {
-            options.insert(
-                AgentModelOption(
-                    rawValue: currentModelRaw,
-                    displayName: currentModelRaw,
-                    description: nil,
-                    isPlaceholderDefault: false,
-                    isProviderDefault: false
-                ),
-                at: 0
-            )
-        }
-        guard !options.isEmpty || currentModelRaw != nil else {
-            diagnose(.info("ACP session response included legacy model metadata, but no usable model entries were found."))
-            return nil
-        }
-        return ACPDiscoveredSessionModels(options: options, currentModelRaw: currentModelRaw)
-    }
-
     private func mergeModelOptions(_ rawOptions: [AgentModelOption]) -> [AgentModelOption] {
         var options: [AgentModelOption] = []
         var seenModelIDs = Set<String>()
@@ -2287,24 +2322,6 @@ actor ACPAgentSessionController {
             options.append(option)
         }
         return options
-    }
-
-    private func parseDiscoveredModelOption(from rawModel: [String: Any]) -> AgentModelOption? {
-        guard let rawValue = normalizedACPModelString(
-            (rawModel["modelId"] as? String) ?? (rawModel["id"] as? String)
-        ) else {
-            return nil
-        }
-        let displayName = normalizedACPModelString(
-            (rawModel["name"] as? String) ?? (rawModel["displayName"] as? String)
-        ) ?? rawValue
-        return AgentModelOption(
-            rawValue: rawValue,
-            displayName: displayName,
-            description: normalizedACPModelString(rawModel["description"] as? String),
-            isPlaceholderDefault: false,
-            isProviderDefault: rawModel["isDefault"] as? Bool ?? false
-        )
     }
 
     private func parseDiscoveredConfigModelOption(from rawOption: [String: Any]) -> AgentModelOption? {
@@ -2960,6 +2977,23 @@ actor ACPAgentSessionController {
             launchConfigurationTracePayload(launchConfiguration)
         }
 
+        static func debugSanitizedRawCapturePayloadForTesting(_ payload: [String: Any]) -> [String: Any] {
+            sanitizeRawCaptureDictionary(payload)
+        }
+
+        static func debugWriteRawACPEventForTesting(to url: URL, payload: [String: Any]) {
+            writeRawACPEvent(
+                to: url,
+                kind: "test",
+                payload: payload,
+                providerID: .cursor,
+                controllerState: State.idle.rawValue,
+                hasActivePromptTurn: false,
+                suppressSessionLoadReplayUpdates: false,
+                sessionID: nil
+            )
+        }
+
         private static func launchConfigurationTracePayload(_ launchConfiguration: ACPLaunchConfiguration) -> [String: Any] {
             var payload: [String: Any] = [
                 "command": launchConfiguration.command,
@@ -3247,6 +3281,8 @@ actor ACPAgentSessionController {
             )
         }
 
+        private static let rawACPCaptureWriteLock = NSLock()
+
         private static func writeRawACPEvent(
             to url: URL,
             kind: String,
@@ -3260,7 +3296,7 @@ actor ACPAgentSessionController {
             var record: [String: Any] = [
                 "capturedAt": ISO8601DateFormatter().string(from: Date()),
                 "kind": kind,
-                "payload": payload,
+                "payload": sanitizeRawCaptureDictionary(payload),
                 "providerID": providerID.rawValue,
                 "controllerState": controllerState,
                 "hasActivePromptTurn": hasActivePromptTurn,
@@ -3270,21 +3306,68 @@ actor ACPAgentSessionController {
                 record["controllerSessionID"] = sessionID
             }
             guard JSONSerialization.isValidJSONObject(record),
-                  let data = try? JSONSerialization.data(withJSONObject: record, options: [.sortedKeys])
+                  var data = try? JSONSerialization.data(withJSONObject: record, options: [.sortedKeys])
             else {
                 return
             }
-            let newline = Data([0x0A])
+            data.append(0x0A)
+
             let parent = url.deletingLastPathComponent()
             _ = try? FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true, attributes: nil)
-            if !FileManager.default.fileExists(atPath: url.path) {
-                _ = FileManager.default.createFile(atPath: url.path, contents: nil)
+
+            rawACPCaptureWriteLock.lock()
+            defer { rawACPCaptureWriteLock.unlock() }
+            let descriptor = Darwin.open(
+                url.path,
+                O_WRONLY | O_CREAT | O_APPEND | O_CLOEXEC | O_NOFOLLOW,
+                mode_t(0o600)
+            )
+            guard descriptor >= 0 else { return }
+            defer { _ = Darwin.close(descriptor) }
+            guard fchmod(descriptor, mode_t(0o600)) == 0 else { return }
+            try? FDWriteSupport.writeAll(data, to: descriptor)
+        }
+
+        private static func sanitizeRawCaptureDictionary(_ dictionary: [String: Any]) -> [String: Any] {
+            Dictionary(uniqueKeysWithValues: dictionary.map { key, value in
+                (key, sanitizeRawCaptureValue(value, key: key))
+            })
+        }
+
+        private static func sanitizeRawCaptureValue(_ value: Any, key: String?) -> Any {
+            if let key, isSensitiveRawCaptureKey(key) {
+                return "<redacted>"
             }
-            guard let handle = try? FileHandle(forWritingTo: url) else { return }
-            defer { _ = try? handle.close() }
-            _ = try? handle.seekToEnd()
-            _ = try? handle.write(contentsOf: data)
-            _ = try? handle.write(contentsOf: newline)
+            if let dictionary = value as? [String: Any] {
+                return sanitizeRawCaptureDictionary(dictionary)
+            }
+            if let array = value as? [Any] {
+                return array.map { sanitizeRawCaptureValue($0, key: nil) }
+            }
+            if let string = value as? String, looksSensitiveRawCaptureString(string) {
+                return "<redacted>"
+            }
+            return value
+        }
+
+        private static func isSensitiveRawCaptureKey(_ key: String) -> Bool {
+            let normalized = key.lowercased().filter(\.isLetter)
+            return [
+                "argument", "authorization", "command", "content", "cookie", "credential",
+                "cwd", "data", "diagnostic", "environment", "error", "key", "output",
+                "password", "path", "prompt", "rawinput", "reasoning", "response", "result",
+                "secret", "text", "token", "uri", "value", "workingdirectory"
+            ].contains { normalized.contains($0) }
+        }
+
+        private static func looksSensitiveRawCaptureString(_ value: String) -> Bool {
+            let normalized = value.lowercased()
+            return normalized.contains("bearer ")
+                || normalized.contains("api_key=")
+                || normalized.contains("apikey=")
+                || normalized.contains("access_token=")
+                || normalized.contains("password=")
+                || normalized.contains("secret=")
         }
     #endif
 

--- a/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPAgentSessionController.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPAgentSessionController.swift
@@ -130,10 +130,51 @@ actor ACPAgentSessionController {
         let request: AgentApprovalRequest
     }
 
+    private struct RequestResponse {
+        let result: [String: Any]
+        let inboundSequence: UInt64
+    }
+
     private struct PendingRequest {
         let method: String
-        let continuation: CheckedContinuation<[String: Any], Error>
+        let continuation: CheckedContinuation<RequestResponse, Error>
         var timeoutTask: Task<Void, Never>?
+    }
+
+    private struct SessionModeSnapshot {
+        let configID: String
+        let currentValue: String
+        let availableValues: [String]
+    }
+
+    private struct ParsedSelectConfigOption {
+        let id: String
+        let currentValue: String
+        let choices: [[String: Any]]
+    }
+
+    private enum ParsedSelectConfigOptionResult {
+        case absent
+        case valid(ParsedSelectConfigOption)
+        case malformed(String)
+    }
+
+    private enum ParsedModernModeSnapshot {
+        case absent
+        case valid(SessionModeSnapshot)
+        case malformed(String)
+    }
+
+    private enum ParsedModernModelSnapshot {
+        case absent
+        case valid(configID: String, models: ACPDiscoveredSessionModels)
+        case malformed(String)
+    }
+
+    private struct BufferedConfigOptionUpdate {
+        let sessionID: String
+        let update: [String: Any]
+        let inboundSequence: UInt64
     }
 
     private struct PromptSettlementWaiter {
@@ -181,6 +222,10 @@ actor ACPAgentSessionController {
     private let diagnosticSink: DiagnosticSink?
     private let requestTimeouts: RequestTimeouts
 
+    /// Modern configOptions are the only mode-selection authority. Mutations are serialized,
+    /// and complete snapshots apply in inbound wire order.
+    private let configurationMutationMutex = AsyncMutex()
+
     private var state: State = .idle
     private var process: SpawnedProcess?
     private var stdoutChannel: FileHandleChunkChannel?
@@ -199,6 +244,7 @@ actor ACPAgentSessionController {
     private var lastInvalidACPLinePreview: String?
     private var lastStderrPreview: String?
     private var nextRequestID = 1
+    private var inboundMessageSequence: UInt64 = 0
     private var pendingRequests: [String: PendingRequest] = [:]
     private var pendingPermissionRequests: [String: PendingPermissionRequest] = [:]
     private var activePromptTurnID: UUID?
@@ -215,9 +261,12 @@ actor ACPAgentSessionController {
     private var eventStreamFinished = false
     private var loadSessionSupported = false
     private var discoveredSessionModels: ACPDiscoveredSessionModels?
-    private var currentSessionModeID: String?
-    private var sessionModeSelectionSupported = false
-    private var advertisedSessionModeIDs: Set<String>?
+    private var sessionModelConfigOptionID: String?
+    private var sessionModelFailureReason: String?
+    private var sessionModeSnapshot: SessionModeSnapshot?
+    private var sessionModeFailureReason: String?
+    private var lastAppliedConfigurationSequence: UInt64 = 0
+    private var bufferedConfigOptionUpdates: [BufferedConfigOptionUpdate] = []
     private var suppressSessionLoadReplayUpdates = false
     private var fallbackResumeSessionIDForPromptClearing: String?
     private var autoApproveAllToolPermissions: Bool
@@ -326,15 +375,44 @@ actor ACPAgentSessionController {
             additionalPaths: launchConfiguration.additionalPathHints,
             preferredBasenames: [launchConfiguration.command]
         )
-        launchDescription = Self.displayCommand(command: resolvedCommand, arguments: launchConfiguration.arguments)
+        do {
+            if let expectedExecutableIdentity = launchConfiguration.expectedExecutableIdentity {
+                try expectedExecutableIdentity.validate(atPath: resolvedCommand)
+            }
+        } catch {
+            await recordRunLaunchContract(
+                event: "acp_launch_validation_failed",
+                resolvedCommand: resolvedCommand,
+                workingDirectory: workingDirectory,
+                pid: nil,
+                error: error
+            )
+            throw error
+        }
+        launchDescription = Self.displayCommand(
+            command: resolvedCommand,
+            arguments: Self.redactedLaunchArguments(launchConfiguration.arguments)
+        )
         logLaunchContract(command: resolvedCommand, workingDirectory: workingDirectory)
         diagnose(.info("Launching ACP command: \(launchDescription ?? resolvedCommand)"))
-        let spawned = try ProcessLauncher.spawn(
-            command: resolvedCommand,
-            arguments: launchConfiguration.arguments,
-            environment: environment,
-            workingDirectory: workingDirectory
-        )
+        let spawned: SpawnedProcess
+        do {
+            spawned = try ProcessLauncher.spawn(
+                command: resolvedCommand,
+                arguments: launchConfiguration.arguments,
+                environment: environment,
+                workingDirectory: workingDirectory
+            )
+        } catch {
+            await recordRunLaunchContract(
+                event: "acp_launch_spawn_failed",
+                resolvedCommand: resolvedCommand,
+                workingDirectory: workingDirectory,
+                pid: nil,
+                error: error
+            )
+            throw error
+        }
         process = spawned
         do {
             try startReaders(stdout: spawned.stdout, stderr: spawned.stderr)
@@ -349,6 +427,20 @@ actor ACPAgentSessionController {
         }
         await registerExpectedAgentPIDIfNeeded(spawned.pid)
         startProcessWaitTask(for: spawned.pid)
+        await recordRunLaunchContract(
+            event: "acp_launch_contract_resolved",
+            resolvedCommand: resolvedCommand,
+            workingDirectory: workingDirectory,
+            pid: nil,
+            error: nil
+        )
+        await recordRunLaunchContract(
+            event: "acp_process_spawned",
+            resolvedCommand: resolvedCommand,
+            workingDirectory: workingDirectory,
+            pid: spawned.pid,
+            error: nil
+        )
         diagnose(.phaseCompleted("launch"))
 
         log("ACP initialize")
@@ -534,6 +626,13 @@ actor ACPAgentSessionController {
     }
 
     func setSessionModel(_ rawModel: String) async throws {
+        try await configurationMutationMutex.withLock { [weak self] in
+            guard let self else { throw CancellationError() }
+            try await setSessionModelSerialized(rawModel)
+        }
+    }
+
+    private func setSessionModelSerialized(_ rawModel: String) async throws {
         guard let sessionID else {
             throw ControllerError.invalidState(expected: "sessionOpen or promptRunning", actual: state)
         }
@@ -545,26 +644,46 @@ actor ACPAgentSessionController {
 
         switch provider.providerID {
         case .openCode, .cursor:
-            guard let configValue = sessionModelConfigValue(forSelectedModel: model) else {
-                log("Skipping selected model \(model); no safe ACP config value is available")
-                return
+            if let sessionModelFailureReason {
+                throw ControllerError.protocolViolation("malformed modern model config option: \(sessionModelFailureReason)")
             }
+            guard let sessionModelConfigOptionID else {
+                throw ControllerError.requestFailed("ACP runtime does not advertise model switching through configOptions.")
+            }
+            guard let mappedConfigValue = sessionModelConfigValue(forSelectedModel: model) else {
+                throw ControllerError.requestFailed("ACP runtime does not advertise a safe config value for selected model '\(model)'.")
+            }
+            let configValue = try canonicalSessionModelValue(mappedConfigValue)
             if configValue != model {
                 log("Mapping selected model \(model) to ACP config value \(configValue)")
             }
-            let response = try await sendRequest(
+            if discoveredSessionModels?.currentModelRaw == configValue {
+                return
+            }
+            let response = try await sendRequestResponse(
                 method: "session/set_config_option",
                 params: [
                     "sessionId": sessionID,
-                    "configId": "model",
+                    "configId": sessionModelConfigOptionID,
                     "value": configValue
                 ]
             )
-            applyDiscoveredSessionModels(from: response)
+            try applyVerifiedConfigOptionsMutationResponse(
+                response,
+                requiredModeValue: nil,
+                requiredModelValue: configValue
+            )
         }
     }
 
     func setSessionMode(_ modeID: String) async throws {
+        try await configurationMutationMutex.withLock { [weak self] in
+            guard let self else { throw CancellationError() }
+            try await setSessionModeSerialized(modeID)
+        }
+    }
+
+    private func setSessionModeSerialized(_ modeID: String) async throws {
         guard let sessionID else {
             throw ControllerError.invalidState(expected: "sessionOpen or promptRunning", actual: state)
         }
@@ -573,27 +692,33 @@ actor ACPAgentSessionController {
         guard state == .sessionOpen || state == .promptRunning else {
             throw ControllerError.invalidState(expected: "sessionOpen or promptRunning", actual: state)
         }
-        if !sessionModeSelectionSupported {
+        guard let snapshot = sessionModeSnapshot else {
+            if let sessionModeFailureReason {
+                throw ControllerError.protocolViolation("malformed modern session mode config option: \(sessionModeFailureReason)")
+            }
             if trimmedModeID.caseInsensitiveCompare("default") == .orderedSame {
-                currentSessionModeID = trimmedModeID
                 return
             }
-            throw ControllerError.requestFailed("ACP runtime does not advertise session mode switching support.")
+            throw ControllerError.requestFailed("ACP runtime does not advertise a modern session mode configOptions selector.")
         }
-        guard isSessionModeAdvertised(trimmedModeID) else {
-            throw ControllerError.requestFailed("ACP runtime does not advertise session mode '\(trimmedModeID)'. Available modes: \(advertisedSessionModeDescription()).")
-        }
-        if currentSessionModeID?.caseInsensitiveCompare(trimmedModeID) == .orderedSame {
+        let canonicalModeID = try canonicalSessionModeValue(trimmedModeID, in: snapshot)
+        if snapshot.currentValue == canonicalModeID {
             return
         }
-        _ = try await sendRequest(
-            method: "session/set_mode",
+
+        let response = try await sendRequestResponse(
+            method: "session/set_config_option",
             params: [
                 "sessionId": sessionID,
-                "modeId": trimmedModeID
+                "configId": snapshot.configID,
+                "value": canonicalModeID
             ]
         )
-        currentSessionModeID = trimmedModeID
+        try applyVerifiedConfigOptionsMutationResponse(
+            response,
+            requiredModeValue: canonicalModeID,
+            requiredModelValue: nil
+        )
     }
 
     func respondToPermissionRequest(
@@ -848,9 +973,13 @@ actor ACPAgentSessionController {
         processWaitTask = nil
         process = nil
         discoveredSessionModels = nil
-        currentSessionModeID = nil
-        sessionModeSelectionSupported = false
-        advertisedSessionModeIDs = nil
+        sessionModelConfigOptionID = nil
+        sessionModelFailureReason = nil
+        sessionModeSnapshot = nil
+        sessionModeFailureReason = nil
+        lastAppliedConfigurationSequence = 0
+        bufferedConfigOptionUpdates.removeAll()
+        sessionID = nil
         suppressSessionLoadReplayUpdates = false
         state = .closed
         finishEventsIfNeeded()
@@ -944,6 +1073,8 @@ actor ACPAgentSessionController {
         #if DEBUG
             captureRawACPEvent(kind: "jsonrpc.inbound", payload: json)
         #endif
+        inboundMessageSequence &+= 1
+        let messageSequence = inboundMessageSequence
 
         if let id = parseJSONRPCID(json["id"]) {
             if let method = json["method"] as? String {
@@ -954,7 +1085,10 @@ actor ACPAgentSessionController {
                 guard let pendingRequest = pendingRequests.removeValue(forKey: storageKey) else { continue }
                 pendingRequest.timeoutTask?.cancel()
                 if let result = json["result"] as? [String: Any] {
-                    pendingRequest.continuation.resume(returning: result)
+                    pendingRequest.continuation.resume(returning: RequestResponse(
+                        result: result,
+                        inboundSequence: messageSequence
+                    ))
                 } else if let error = json["error"] as? [String: Any] {
                     let message = Self.responseErrorMessage(from: error)
                     let code = Self.responseErrorCode(from: error)
@@ -971,7 +1105,11 @@ actor ACPAgentSessionController {
         }
 
         if let method = json["method"] as? String {
-            handleNotification(method: method, params: json["params"] as? [String: Any] ?? [:])
+            handleNotification(
+                method: method,
+                params: json["params"] as? [String: Any] ?? [:],
+                inboundSequence: messageSequence
+            )
         }
     }
 
@@ -995,7 +1133,7 @@ actor ACPAgentSessionController {
         }
     }
 
-    private func handleNotification(method: String, params: [String: Any]) {
+    private func handleNotification(method: String, params: [String: Any], inboundSequence: UInt64) {
         guard method == "session/update" else { return }
         #if DEBUG
             captureRawACPEvent(
@@ -1006,7 +1144,7 @@ actor ACPAgentSessionController {
                 ]
             )
         #endif
-        guard var update = params["update"] as? [String: Any] else { return }
+        guard let update = params["update"] as? [String: Any] else { return }
         let sessionID = (params["sessionId"] as? String) ?? sessionID ?? ""
         #if DEBUG
             captureRawACPEvent(
@@ -1017,6 +1155,15 @@ actor ACPAgentSessionController {
                 ]
             )
         #endif
+
+        if update["sessionUpdate"] as? String == "config_option_update" {
+            handleConfigOptionUpdateNotification(
+                paramsSessionID: params["sessionId"] as? String,
+                update: update,
+                inboundSequence: inboundSequence
+            )
+            return
+        }
 
         if shouldSuppressSessionLoadReplayUpdate(update) {
             #if DEBUG
@@ -1191,9 +1338,10 @@ actor ACPAgentSessionController {
             do {
                 suppressSessionLoadReplayUpdates = true
                 defer { suppressSessionLoadReplayUpdates = false }
+                beginOpeningSessionConfiguration()
                 log("Starting ACP session/load mcpServers=\(sessionConfiguration.mcpServers.count)")
                 diagnose(.phaseStarted("session/load"))
-                let response = try await sendRequest(
+                let requestResponse = try await sendRequestResponse(
                     method: "session/load",
                     params: [
                         "sessionId": existingSessionID,
@@ -1201,8 +1349,12 @@ actor ACPAgentSessionController {
                         "mcpServers": sessionConfiguration.mcpServers.map(\.acpJSONObject)
                     ]
                 )
-                applyDiscoveredSessionModes(from: response)
-                applyDiscoveredSessionModels(from: response)
+                let response = requestResponse.result
+                applyOpenedSessionConfiguration(
+                    from: response,
+                    sessionID: existingSessionID,
+                    inboundSequence: requestResponse.inboundSequence
+                )
                 diagnose(.phaseCompleted("session/load"))
                 log("Completed ACP session/load sessionID=\(existingSessionID)")
                 let identity = ACPProviderSessionIdentity(
@@ -1238,20 +1390,25 @@ actor ACPAgentSessionController {
 
     private func openNewSession() async throws -> OpenSessionResult {
         suppressSessionLoadReplayUpdates = false
+        beginOpeningSessionConfiguration()
         log("Starting ACP session/new mcpServers=\(sessionConfiguration.mcpServers.count)")
         diagnose(.phaseStarted("session/new"))
-        let response = try await sendRequest(
+        let requestResponse = try await sendRequestResponse(
             method: "session/new",
             params: [
                 "cwd": sessionConfiguration.workingDirectory,
                 "mcpServers": sessionConfiguration.mcpServers.map(\.acpJSONObject)
             ]
         )
+        let response = requestResponse.result
         guard let sessionID = response["sessionId"] as? String else {
             throw ControllerError.protocolViolation("session/new response missing sessionId")
         }
-        applyDiscoveredSessionModes(from: response)
-        applyDiscoveredSessionModels(from: response)
+        applyOpenedSessionConfiguration(
+            from: response,
+            sessionID: sessionID,
+            inboundSequence: requestResponse.inboundSequence
+        )
         diagnose(.phaseCompleted("session/new"))
         log("Completed ACP session/new sessionID=\(sessionID)")
         let identity = ACPProviderSessionIdentity(
@@ -1272,6 +1429,13 @@ actor ACPAgentSessionController {
         method: String,
         params: [String: Any]
     ) async throws -> [String: Any] {
+        try await sendRequestResponse(method: method, params: params).result
+    }
+
+    private func sendRequestResponse(
+        method: String,
+        params: [String: Any]
+    ) async throws -> RequestResponse {
         guard process != nil else { throw ControllerError.processNotRunning }
 
         let requestID = JSONRPCID.int(nextRequestID)
@@ -1507,6 +1671,41 @@ actor ACPAgentSessionController {
         log("ACP launch command=\(resolvedCommand) args=\(safeLaunchArgumentsDescription()) cwd=\(workingDirectory)")
     }
 
+    private func recordRunLaunchContract(
+        event: String,
+        resolvedCommand: String,
+        workingDirectory: String,
+        pid: pid_t?,
+        error: Error?
+    ) async {
+        #if DEBUG
+            guard let runID = expectedMCPRunID else { return }
+            var fields: [String: String] = [
+                "provider_id": boundedRunDiagnosticField(provider.providerID.rawValue),
+                "mcp_client_name": boundedRunDiagnosticField(mcpClientNameHint ?? "nil"),
+                "configured_command": boundedRunDiagnosticField(displayRunDiagnosticPath(launchConfiguration.command)),
+                "resolved_executable": boundedRunDiagnosticField(displayRunDiagnosticPath(resolvedCommand)),
+                "canonical_executable": boundedRunDiagnosticField(displayRunDiagnosticPath(URL(fileURLWithPath: resolvedCommand).resolvingSymlinksInPath().standardizedFileURL.path)),
+                "final_args": boundedRunDiagnosticField(safeLaunchArgumentsDescription()),
+                "working_directory": boundedRunDiagnosticField(displayRunDiagnosticPath(workingDirectory)),
+                "injected_mcp_command": boundedRunDiagnosticField(injectedMCPCommandDescription())
+            ]
+            if let pid {
+                fields["acp_pid"] = String(pid)
+            }
+            if let error {
+                fields["error_kind"] = runDiagnosticErrorKind(error)
+                fields["error_type"] = boundedRunDiagnosticField(String(reflecting: type(of: error)))
+                fields["error_code"] = String((error as NSError).code)
+            }
+            await ServerNetworkManager.shared.debugRecordRunRoutingEvent(
+                runID: runID,
+                event: event,
+                fields: fields
+            )
+        #endif
+    }
+
     private func logSessionMCPInjection() {
         guard !sessionConfiguration.mcpServers.isEmpty else {
             log("ACP session mcpServers empty")
@@ -1518,29 +1717,140 @@ actor ACPAgentSessionController {
     }
 
     private func safeLaunchArgumentsDescription() -> String {
+        safeArgumentsDescription(launchConfiguration.arguments)
+    }
+
+    private func safeArgumentsDescription(_ arguments: [String]) -> String {
+        boundedRunDiagnosticField(Self.redactedLaunchArguments(arguments).joined(separator: " "))
+    }
+
+    private static func redactedLaunchArguments(_ arguments: [String]) -> [String] {
         var result: [String] = []
         var redactNext = false
-        for argument in launchConfiguration.arguments {
+        for argument in arguments {
             if redactNext {
                 result.append("<redacted>")
                 redactNext = false
                 continue
             }
-            result.append(argument)
             let lowercased = argument.lowercased()
-            if let equals = argument.firstIndex(of: "="), argument.hasPrefix("-"), shouldRedactLaunchArgumentName(String(argument[..<equals])) {
-                let name = argument[..<equals]
-                result[result.count - 1] = "\(name)=<redacted>"
-            } else if argument.hasPrefix("-"), shouldRedactLaunchArgumentName(lowercased) {
-                redactNext = true
+            if lowercased.contains("authorization:")
+                || lowercased.contains("proxy-authorization:")
+                || lowercased.hasPrefix("bearer ")
+            {
+                result.append("<redacted>")
+                continue
             }
+            if let equals = argument.firstIndex(of: "="), shouldRedactLaunchArgumentName(String(argument[..<equals])) {
+                result.append("\(argument[..<equals])=<redacted>")
+                continue
+            }
+            if argument.hasPrefix("-"), shouldRedactLaunchArgumentName(argument) {
+                result.append(argument)
+                redactNext = true
+                continue
+            }
+            result.append(redactedLaunchJSONArgument(argument) ?? argument)
         }
-        return result.joined(separator: " ")
+        return result
     }
 
-    private func shouldRedactLaunchArgumentName(_ argument: String) -> Bool {
+    private static func redactedLaunchJSONArgument(_ argument: String) -> String? {
+        let trimmed = argument.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.hasPrefix("{") || trimmed.hasPrefix("[") else { return nil }
+        guard let data = trimmed.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data),
+              let sanitizedData = try? JSONSerialization.data(
+                  withJSONObject: sanitizedLaunchJSONValue(json),
+                  options: [.sortedKeys]
+              )
+        else {
+            return nil
+        }
+        return String(data: sanitizedData, encoding: .utf8)
+    }
+
+    private static func sanitizedLaunchJSONValue(_ value: Any) -> Any {
+        if let object = value as? [String: Any] {
+            return object.reduce(into: [String: Any]()) { result, entry in
+                result[entry.key] = shouldRedactLaunchJSONFieldName(entry.key)
+                    ? "<redacted>"
+                    : sanitizedLaunchJSONValue(entry.value)
+            }
+        }
+        if let array = value as? [Any] {
+            return array.map(sanitizedLaunchJSONValue)
+        }
+        return value
+    }
+
+    private func injectedMCPCommandDescription() -> String {
+        var commands = sessionConfiguration.mcpServers.map { server in
+            let args = safeArgumentsDescription(server.args)
+            return args.isEmpty ? "\(server.name):\(server.command)" : "\(server.name):\(server.command) \(args)"
+        }
+        if let configContent = launchConfiguration.environment["OPENCODE_CONFIG_CONTENT"],
+           let data = configContent.data(using: .utf8),
+           let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+           let servers = root["mcp"] as? [String: Any]
+        {
+            for key in servers.keys.sorted() where key.caseInsensitiveCompare(RepoPromptMCPServerConfiguration.defaultServerName) == .orderedSame {
+                guard let server = servers[key] as? [String: Any],
+                      server["enabled"] as? Bool != false,
+                      let command = server["command"] as? [String],
+                      let executable = command.first
+                else { continue }
+                let args = safeArgumentsDescription(Array(command.dropFirst()))
+                commands.append(args.isEmpty ? "\(key):\(executable)" : "\(key):\(executable) \(args)")
+            }
+        }
+        return boundedRunDiagnosticField(commands.isEmpty ? "none" : commands.joined(separator: " | "))
+    }
+
+    private func boundedRunDiagnosticField(_ value: String) -> String {
+        Self.truncatedDiagnosticPreview(value, limit: 480)
+    }
+
+    private static func shouldRedactLaunchArgumentName(_ argument: String) -> Bool {
         let lowercased = argument.lowercased()
-        return ["api-key", "apikey", "auth", "bearer", "credential", "password", "secret", "token"].contains { lowercased.contains($0) }
+        return [
+            "api-key", "api_key", "apikey", "auth", "bearer", "content", "cookie", "credential",
+            "env", "header", "input", "instruction", "message", "password", "prompt", "query", "secret", "token"
+        ].contains { lowercased.contains($0) }
+            || lowercased == "--key"
+            || lowercased.hasSuffix("-key")
+            || lowercased.hasSuffix("_key")
+    }
+
+    private static func shouldRedactLaunchJSONFieldName(_ fieldName: String) -> Bool {
+        let lowercased = fieldName.lowercased()
+        return lowercased.contains("token")
+            || lowercased.contains("password")
+            || lowercased.contains("secret")
+            || lowercased.contains("credential")
+            || lowercased.hasSuffix("key")
+    }
+
+    private func displayRunDiagnosticPath(_ value: String) -> String {
+        let home = FileManager.default.homeDirectoryForCurrentUser.standardizedFileURL.path
+        guard value == home || value.hasPrefix(home + "/") else { return value }
+        return "~" + String(value.dropFirst(home.count))
+    }
+
+    private func runDiagnosticErrorKind(_ error: Error) -> String {
+        if error is ExecutableFileIdentityError {
+            return "executable_identity"
+        }
+        if error is CursorACPLaunchResolutionError || error is OpenCodeACPLaunchResolutionError {
+            return "launch_resolution"
+        }
+        if error is CLIProcessRunnerError {
+            return "process_runner"
+        }
+        if error is CancellationError {
+            return "cancelled"
+        }
+        return "other"
     }
 
     private func resolvedEnvironment() async -> [String: String] {
@@ -1554,68 +1864,400 @@ actor ACPAgentSessionController {
         return result.environment
     }
 
-    private func applyDiscoveredSessionModes(from response: [String: Any]) {
-        guard let modes = response["modes"] as? [String: Any] else {
-            currentSessionModeID = nil
-            sessionModeSelectionSupported = false
-            advertisedSessionModeIDs = nil
-            return
-        }
-        currentSessionModeID = modes["currentModeId"] as? String
-        sessionModeSelectionSupported = true
-        advertisedSessionModeIDs = parseAdvertisedSessionModeIDs(from: modes)
+    private func beginOpeningSessionConfiguration() {
+        discoveredSessionModels = nil
+        sessionModelConfigOptionID = nil
+        sessionModelFailureReason = nil
+        sessionModeSnapshot = nil
+        sessionModeFailureReason = nil
+        lastAppliedConfigurationSequence = 0
+        bufferedConfigOptionUpdates.removeAll()
     }
 
-    private func parseAdvertisedSessionModeIDs(from modes: [String: Any]) -> Set<String> {
-        let rawModes = modes["availableModes"] ?? modes["available"] ?? modes["modeOptions"]
-        let modeIDs: [String] = if let strings = rawModes as? [String] {
-            strings.compactMap(normalizedSessionModeID)
-        } else if let dicts = rawModes as? [[String: Any]] {
-            dicts.compactMap { rawMode in
-                normalizedSessionModeID(
-                    (rawMode["id"] as? String)
-                        ?? (rawMode["modeId"] as? String)
-                        ?? (rawMode["name"] as? String)
-                )
+    private func applyOpenedSessionConfiguration(
+        from response: [String: Any],
+        sessionID: String,
+        inboundSequence: UInt64
+    ) {
+        applyInitialSessionConfiguration(from: response, inboundSequence: inboundSequence)
+        let updates = bufferedConfigOptionUpdates
+            .filter { $0.sessionID == sessionID && $0.inboundSequence > inboundSequence }
+            .sorted { $0.inboundSequence < $1.inboundSequence }
+        bufferedConfigOptionUpdates.removeAll()
+        for update in updates {
+            applyConfigOptionUpdate(update.update, inboundSequence: update.inboundSequence)
+        }
+    }
+
+    private func applyInitialSessionConfiguration(from response: [String: Any], inboundSequence: UInt64) {
+        switch parseModernModeSnapshot(from: response) {
+        case let .valid(snapshot):
+            sessionModeFailureReason = nil
+            sessionModeSnapshot = snapshot
+            if response["modes"] != nil {
+                diagnose(.info("ACP session also advertised legacy modes; ignoring them because configOptions is the only supported mode authority."))
             }
-        } else {
-            []
+        case .absent:
+            sessionModeSnapshot = nil
+            sessionModeFailureReason = nil
+            if response["modes"] != nil {
+                diagnose(.info("Ignoring legacy ACP modes metadata because mode selection requires a modern configOptions selector."))
+            }
+        case let .malformed(reason):
+            sessionModeSnapshot = nil
+            sessionModeFailureReason = reason
+            diagnose(.info("ACP session advertised a malformed modern mode config option: \(reason)"))
         }
-        return Set(modeIDs.map { $0.lowercased() })
+        applyDiscoveredSessionModels(from: response)
+        lastAppliedConfigurationSequence = inboundSequence
     }
 
-    private func normalizedSessionModeID(_ value: String?) -> String? {
+    private func parseModernModeSnapshot(from response: [String: Any]) -> ParsedModernModeSnapshot {
+        guard let rawConfigOptions = response["configOptions"] else { return .absent }
+        guard let configOptions = rawConfigOptions as? [[String: Any]] else {
+            return .malformed("configOptions is not an array")
+        }
+        return parseModernModeSnapshot(fromConfigOptions: configOptions)
+    }
+
+    private func parseModernModeSnapshot(fromConfigOptions configOptions: [[String: Any]]) -> ParsedModernModeSnapshot {
+        switch parseSelectConfigOption(category: "mode", from: configOptions) {
+        case .absent:
+            return .absent
+        case let .malformed(reason):
+            return .malformed(reason)
+        case let .valid(option):
+            let values = deduplicatedExactValues(option.choices.compactMap { normalizedConfigValue($0["value"] as? String) })
+            guard !values.isEmpty else {
+                return .malformed("mode selector '\(option.id)' has no usable values")
+            }
+            guard let currentValue = canonicalAdvertisedValue(option.currentValue, in: values) else {
+                return .malformed("mode selector '\(option.id)' currentValue is not one of its advertised values")
+            }
+            return .valid(SessionModeSnapshot(
+                configID: option.id,
+                currentValue: currentValue,
+                availableValues: values
+            ))
+        }
+    }
+
+    private func parseSelectConfigOption(
+        category: String,
+        from configOptions: [[String: Any]]
+    ) -> ParsedSelectConfigOptionResult {
+        let normalizedCategory = category.lowercased()
+        let recognizedSemanticIDs: Set = ["mode", "model"]
+        let conflicting = configOptions.contains { option in
+            guard let optionID = normalizedConfigValue(option["id"] as? String)?.lowercased(),
+                  let optionCategory = normalizedConfigValue(option["category"] as? String)?.lowercased(),
+                  recognizedSemanticIDs.contains(optionID),
+                  recognizedSemanticIDs.contains(optionCategory),
+                  optionID != optionCategory
+            else {
+                return false
+            }
+            return optionID == normalizedCategory || optionCategory == normalizedCategory
+        }
+        guard !conflicting else {
+            return .malformed("\(category) config option has conflicting id/category semantics")
+        }
+
+        let candidates = configOptions.filter { option in
+            let optionCategory = normalizedConfigValue(option["category"] as? String)?.lowercased()
+            if optionCategory == normalizedCategory {
+                return true
+            }
+            guard optionCategory == nil else { return false }
+            return normalizedConfigValue(option["id"] as? String)?.lowercased() == normalizedCategory
+        }
+        guard !candidates.isEmpty else { return .absent }
+        guard candidates.count == 1, let candidate = candidates.first else {
+            return .malformed("multiple \(category) config options were advertised")
+        }
+        guard normalizedConfigValue(candidate["type"] as? String)?.lowercased() == "select" else {
+            return .malformed("\(category) config option is not a select option")
+        }
+        guard let id = normalizedConfigValue(candidate["id"] as? String) else {
+            return .malformed("\(category) config option is missing id")
+        }
+        guard let currentValue = normalizedConfigValue(candidate["currentValue"] as? String) else {
+            return .malformed("\(category) config option '\(id)' is missing currentValue")
+        }
+        guard let choices = flattenedConfigOptionChoices(from: candidate["options"]), !choices.isEmpty else {
+            return .malformed("\(category) config option '\(id)' has malformed or empty options")
+        }
+        return .valid(ParsedSelectConfigOption(id: id, currentValue: currentValue, choices: choices))
+    }
+
+    private func flattenedConfigOptionChoices(from rawValue: Any?) -> [[String: Any]]? {
+        guard let dictionaries = rawValue as? [[String: Any]] else { return nil }
+        var choices: [[String: Any]] = []
+        for dictionary in dictionaries {
+            if normalizedConfigValue(dictionary["value"] as? String) != nil {
+                choices.append(dictionary)
+                continue
+            }
+            guard let nested = flattenedConfigOptionChoices(from: dictionary["options"]), !nested.isEmpty else {
+                return nil
+            }
+            choices.append(contentsOf: nested)
+        }
+        return choices
+    }
+
+    private func normalizedConfigValue(_ value: String?) -> String? {
         guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty else {
             return nil
         }
         return trimmed
     }
 
-    private func isSessionModeAdvertised(_ modeID: String) -> Bool {
-        guard let advertisedSessionModeIDs else { return false }
-        return advertisedSessionModeIDs.contains(modeID.lowercased())
+    private func deduplicatedExactValues(_ values: [String]) -> [String] {
+        var seen = Set<String>()
+        return values.filter { seen.insert($0).inserted }
     }
 
-    private func advertisedSessionModeDescription() -> String {
-        guard let advertisedSessionModeIDs, !advertisedSessionModeIDs.isEmpty else {
-            return "none"
+    private func canonicalAdvertisedValue(_ requestedValue: String, in availableValues: [String]) -> String? {
+        if let exact = availableValues.first(where: { $0 == requestedValue }) {
+            return exact
         }
-        return advertisedSessionModeIDs.sorted().joined(separator: ", ")
+        let matches = availableValues.filter { $0.caseInsensitiveCompare(requestedValue) == .orderedSame }
+        return matches.count == 1 ? matches[0] : nil
+    }
+
+    private func canonicalSessionModelValue(_ requestedValue: String) throws -> String {
+        let availableValues = discoveredSessionModels?.options.map(\.rawValue) ?? []
+        guard !availableValues.isEmpty else {
+            throw ControllerError.protocolViolation("modern model selector has no advertised values")
+        }
+        if let exact = availableValues.first(where: { $0 == requestedValue }) {
+            return exact
+        }
+        let matches = availableValues.filter { $0.caseInsensitiveCompare(requestedValue) == .orderedSame }
+        if matches.count == 1, let canonical = matches.first {
+            return canonical
+        }
+        if matches.count > 1 {
+            throw ControllerError.requestFailed("ACP runtime advertises case-colliding models for '\(requestedValue)'. Use an exact value.")
+        }
+        throw ControllerError.requestFailed("ACP runtime does not advertise model '\(requestedValue)'.")
+    }
+
+    private func canonicalSessionModeValue(
+        _ requestedValue: String,
+        in snapshot: SessionModeSnapshot
+    ) throws -> String {
+        if let exact = snapshot.availableValues.first(where: { $0 == requestedValue }) {
+            return exact
+        }
+        let matches = snapshot.availableValues.filter { $0.caseInsensitiveCompare(requestedValue) == .orderedSame }
+        if matches.count == 1, let canonical = matches.first {
+            return canonical
+        }
+        if matches.count > 1 {
+            throw ControllerError.requestFailed("ACP runtime advertises case-colliding session modes for '\(requestedValue)'. Use an exact value. Available modes: \(advertisedSessionModeDescription(snapshot)).")
+        }
+        throw ControllerError.requestFailed("ACP runtime does not advertise session mode '\(requestedValue)'. Available modes: \(advertisedSessionModeDescription(snapshot)).")
+    }
+
+    private func advertisedSessionModeDescription(_ snapshot: SessionModeSnapshot) -> String {
+        snapshot.availableValues.isEmpty ? "none" : snapshot.availableValues.joined(separator: ", ")
+    }
+
+    private func applyVerifiedConfigOptionsMutationResponse(
+        _ response: RequestResponse,
+        requiredModeValue: String?,
+        requiredModelValue: String?
+    ) throws {
+        guard let configOptions = response.result["configOptions"] as? [[String: Any]] else {
+            throw ControllerError.protocolViolation("session/set_config_option response missing complete configOptions snapshot")
+        }
+        let parsedMode = parseModernModeSnapshot(fromConfigOptions: configOptions)
+        if requiredModeValue != nil || sessionModeSnapshot != nil {
+            guard case let .valid(modeSnapshot) = parsedMode else {
+                throw ControllerError.protocolViolation("session/set_config_option response missing a valid modern mode selector")
+            }
+            if let requiredModeValue, modeSnapshot.currentValue != requiredModeValue {
+                throw ControllerError.protocolViolation("session/set_config_option response did not confirm requested mode '\(requiredModeValue)'")
+            }
+        } else if case let .malformed(reason) = parsedMode {
+            throw ControllerError.protocolViolation("session/set_config_option response contained malformed mode metadata: \(reason)")
+        }
+
+        let parsedModel = parseModernModelSnapshot(fromConfigOptions: configOptions)
+        switch parsedModel {
+        case let .valid(_, models):
+            if let requiredModelValue, models.currentModelRaw != requiredModelValue {
+                throw ControllerError.protocolViolation("session/set_config_option response did not confirm requested model '\(requiredModelValue)'")
+            }
+        case .absent:
+            if requiredModelValue != nil || sessionModelConfigOptionID != nil {
+                throw ControllerError.protocolViolation("session/set_config_option response missing model selector")
+            }
+        case let .malformed(reason):
+            throw ControllerError.protocolViolation("session/set_config_option response contained malformed model metadata: \(reason)")
+        }
+
+        if response.inboundSequence >= lastAppliedConfigurationSequence {
+            applyConfigOptionsSnapshot(
+                configOptions,
+                parsedMode: parsedMode,
+                inboundSequence: response.inboundSequence
+            )
+        }
+        if let requiredModeValue,
+           sessionModeSnapshot?.currentValue.caseInsensitiveCompare(requiredModeValue) != .orderedSame
+        {
+            throw ControllerError.protocolViolation("newer ACP configuration state no longer confirms requested mode '\(requiredModeValue)'")
+        }
+        if let requiredModelValue,
+           discoveredSessionModels?.currentModelRaw != requiredModelValue
+        {
+            throw ControllerError.protocolViolation("newer ACP configuration state no longer confirms requested model '\(requiredModelValue)'")
+        }
+    }
+
+    private func handleConfigOptionUpdateNotification(
+        paramsSessionID: String?,
+        update: [String: Any],
+        inboundSequence: UInt64
+    ) {
+        guard let notificationSessionID = normalizedConfigValue(paramsSessionID) else {
+            diagnose(.info("Ignoring config_option_update without a sessionId."))
+            return
+        }
+        guard let currentSessionID = sessionID else {
+            guard state == .openingSession else {
+                diagnose(.info("Ignoring config_option_update for unopened session \(notificationSessionID)."))
+                return
+            }
+            bufferedConfigOptionUpdates.append(BufferedConfigOptionUpdate(
+                sessionID: notificationSessionID,
+                update: update,
+                inboundSequence: inboundSequence
+            ))
+            if bufferedConfigOptionUpdates.count > 16 {
+                bufferedConfigOptionUpdates.removeFirst(bufferedConfigOptionUpdates.count - 16)
+            }
+            diagnose(.info("Buffered config_option_update until session \(notificationSessionID) is established."))
+            return
+        }
+        guard currentSessionID == notificationSessionID else {
+            diagnose(.info("Ignoring config_option_update for non-current session \(notificationSessionID)."))
+            return
+        }
+        applyConfigOptionUpdate(update, inboundSequence: inboundSequence)
+    }
+
+    private func applyConfigOptionUpdate(_ update: [String: Any], inboundSequence: UInt64) {
+        guard let configOptions = update["configOptions"] as? [[String: Any]] else {
+            diagnose(.info("Ignoring config_option_update without a complete configOptions snapshot."))
+            return
+        }
+        guard inboundSequence >= lastAppliedConfigurationSequence else {
+            diagnose(.info("Ignoring stale config_option_update snapshot."))
+            return
+        }
+        let parsedMode = parseModernModeSnapshot(fromConfigOptions: configOptions)
+        applyConfigOptionsSnapshot(
+            configOptions,
+            parsedMode: parsedMode,
+            inboundSequence: inboundSequence
+        )
+        diagnose(.info("Processed authoritative config_option_update snapshot."))
+    }
+
+    private func applyConfigOptionsSnapshot(
+        _ configOptions: [[String: Any]],
+        parsedMode: ParsedModernModeSnapshot,
+        inboundSequence: UInt64
+    ) {
+        guard inboundSequence >= lastAppliedConfigurationSequence else { return }
+        switch parsedMode {
+        case let .valid(snapshot):
+            sessionModeSnapshot = snapshot
+            sessionModeFailureReason = nil
+        case .absent:
+            sessionModeSnapshot = nil
+            sessionModeFailureReason = nil
+        case let .malformed(reason):
+            sessionModeSnapshot = nil
+            sessionModeFailureReason = reason
+            diagnose(.info("Invalidated session mode authority after malformed modern snapshot: \(reason)"))
+        }
+        let response: [String: Any] = ["configOptions": configOptions]
+        applyDiscoveredSessionModels(from: response)
+        lastAppliedConfigurationSequence = inboundSequence
     }
 
     private func applyDiscoveredSessionModels(from response: [String: Any]) {
-        let parsed = parseDiscoveredSessionModels(from: response)
+        let parsed: ACPDiscoveredSessionModels?
+        switch parseModernModelSnapshot(from: response) {
+        case let .valid(configID, models):
+            sessionModelConfigOptionID = configID
+            sessionModelFailureReason = nil
+            parsed = models
+            if response["models"] != nil {
+                diagnose(.info("ACP session advertised both configOptions and legacy models; using authoritative configOptions model selector."))
+            }
+        case .absent:
+            sessionModelConfigOptionID = nil
+            sessionModelFailureReason = nil
+            parsed = parseLegacyModelsSnapshot(from: response["models"] as? [String: Any])
+        case let .malformed(reason):
+            sessionModelConfigOptionID = nil
+            sessionModelFailureReason = reason
+            parsed = nil
+            diagnose(.info("ACP session advertised a malformed modern model config option; legacy fallback is disabled: \(reason)"))
+        }
+
         discoveredSessionModels = parsed
         guard let parsed else { return }
         _ = AgentACPModelRegistry.shared.updateDiscoveredModels(parsed, for: provider.providerID)
     }
 
-    private func parseDiscoveredSessionModels(from response: [String: Any]) -> ACPDiscoveredSessionModels? {
-        let modelSnapshot = parseModelsSnapshot(from: response["models"] as? [String: Any])
-        let configSnapshot = parseConfigOptionsModelSnapshot(from: response["configOptions"] as? [[String: Any]])
+    private func parseModernModelSnapshot(from response: [String: Any]) -> ParsedModernModelSnapshot {
+        guard let rawConfigOptions = response["configOptions"] else { return .absent }
+        guard let configOptions = rawConfigOptions as? [[String: Any]] else {
+            return .malformed("configOptions is not an array")
+        }
+        return parseModernModelSnapshot(fromConfigOptions: configOptions)
+    }
 
-        let currentModelRaw = configSnapshot.currentModelRaw ?? modelSnapshot.currentModelRaw
-        var options = mergeModelOptions(configSnapshot.options + modelSnapshot.options)
+    private func parseModernModelSnapshot(
+        fromConfigOptions configOptions: [[String: Any]]
+    ) -> ParsedModernModelSnapshot {
+        switch parseSelectConfigOption(category: "model", from: configOptions) {
+        case .absent:
+            return .absent
+        case let .malformed(reason):
+            return .malformed(reason)
+        case let .valid(option):
+            let options = mergeModelOptions(option.choices.compactMap(parseDiscoveredConfigModelOption))
+            let availableValues = options.map(\.rawValue)
+            guard !availableValues.isEmpty else {
+                return .malformed("model selector '\(option.id)' has no usable values")
+            }
+            guard let currentModelRaw = canonicalAdvertisedValue(option.currentValue, in: availableValues) else {
+                return .malformed("model selector '\(option.id)' currentValue is not one of its advertised values")
+            }
+            return .valid(
+                configID: option.id,
+                models: ACPDiscoveredSessionModels(
+                    options: options,
+                    currentModelRaw: currentModelRaw
+                )
+            )
+        }
+    }
+
+    private func parseLegacyModelsSnapshot(from models: [String: Any]?) -> ACPDiscoveredSessionModels? {
+        guard let models else { return nil }
+        let currentModelRaw = normalizedACPModelString(models["currentModelId"] as? String)
+        var options = mergeModelOptions(
+            (models["availableModels"] as? [[String: Any]] ?? []).compactMap(parseDiscoveredModelOption)
+        )
         if let currentModelRaw,
            !options.contains(where: { $0.rawValue.caseInsensitiveCompare(currentModelRaw) == .orderedSame })
         {
@@ -1630,50 +2272,18 @@ actor ACPAgentSessionController {
                 at: 0
             )
         }
-
         guard !options.isEmpty || currentModelRaw != nil else {
-            if response["models"] != nil || response["configOptions"] != nil {
-                diagnose(.info("ACP session response included model/config option metadata, but no usable model entries were found."))
-            }
+            diagnose(.info("ACP session response included legacy model metadata, but no usable model entries were found."))
             return nil
         }
-
-        return ACPDiscoveredSessionModels(
-            options: options,
-            currentModelRaw: currentModelRaw
-        )
-    }
-
-    private func parseModelsSnapshot(from models: [String: Any]?) -> (currentModelRaw: String?, options: [AgentModelOption]) {
-        guard let models else { return (nil, []) }
-        let currentModelRaw = normalizedACPModelString(models["currentModelId"] as? String)
-        let availableModels = models["availableModels"] as? [[String: Any]] ?? []
-        let options = availableModels.compactMap(parseDiscoveredModelOption)
-        return (currentModelRaw, options)
-    }
-
-    private func parseConfigOptionsModelSnapshot(
-        from configOptions: [[String: Any]]?
-    ) -> (currentModelRaw: String?, options: [AgentModelOption]) {
-        guard let modelOption = configOptions?.first(where: { rawOption in
-            let id = normalizedACPModelString(rawOption["id"] as? String)?.lowercased()
-            let category = normalizedACPModelString(rawOption["category"] as? String)?.lowercased()
-            return id == "model" || category == "model"
-        }) else {
-            return (nil, [])
-        }
-        let currentModelRaw = normalizedACPModelString(modelOption["currentValue"] as? String)
-        let rawOptions = modelOption["options"] as? [[String: Any]] ?? []
-        let options = rawOptions.compactMap(parseDiscoveredConfigModelOption)
-        return (currentModelRaw, options)
+        return ACPDiscoveredSessionModels(options: options, currentModelRaw: currentModelRaw)
     }
 
     private func mergeModelOptions(_ rawOptions: [AgentModelOption]) -> [AgentModelOption] {
         var options: [AgentModelOption] = []
         var seenModelIDs = Set<String>()
         for option in rawOptions {
-            let storageKey = option.rawValue.lowercased()
-            guard seenModelIDs.insert(storageKey).inserted else { continue }
+            guard seenModelIDs.insert(option.rawValue).inserted else { continue }
             options.append(option)
         }
         return options
@@ -2344,10 +2954,16 @@ actor ACPAgentSessionController {
             )
         }
 
+        static func debugLaunchConfigurationTracePayloadForTesting(
+            _ launchConfiguration: ACPLaunchConfiguration
+        ) -> [String: Any] {
+            launchConfigurationTracePayload(launchConfiguration)
+        }
+
         private static func launchConfigurationTracePayload(_ launchConfiguration: ACPLaunchConfiguration) -> [String: Any] {
             var payload: [String: Any] = [
                 "command": launchConfiguration.command,
-                "arguments": launchConfiguration.arguments,
+                "arguments": redactedLaunchArguments(launchConfiguration.arguments),
                 "workingDirectory": launchConfiguration.workingDirectory ?? "",
                 "additionalPathHints": launchConfiguration.additionalPathHints,
                 "enableDebugLogging": launchConfiguration.enableDebugLogging,
@@ -2358,7 +2974,10 @@ actor ACPAgentSessionController {
                 if let data = configContent.data(using: .utf8),
                    let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
                 {
-                    payload["opencodeConfigContent"] = parsed
+                    payload["opencodeConfigKeys"] = Array(parsed.keys).sorted()
+                    if let servers = parsed["mcp"] as? [String: Any] {
+                        payload["opencodeMCPServerNames"] = Array(servers.keys).sorted()
+                    }
                 } else {
                     payload["opencodeConfigContentParseError"] = true
                 }

--- a/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPAgentSessionController.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPAgentSessionController.swift
@@ -289,13 +289,13 @@ actor ACPAgentSessionController {
             loadSessionIDConfidence: runRequest.resumeSessionID?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false ? .candidate : .unavailable
         )
         self.runRequest = runRequest
-        launchConfiguration = try provider.makeLaunchConfiguration(for: runRequest)
         let sessionConfiguration = try provider.makeSessionConfiguration(
             for: runRequest,
             mcpServer: .repoPrompt
         )
         try Self.preflightInjectedMCPServers(in: sessionConfiguration)
         self.sessionConfiguration = sessionConfiguration
+        launchConfiguration = try provider.makeLaunchConfiguration(for: runRequest)
         autoApproveAllToolPermissions = runRequest.autoApproveAllToolPermissions
         mcpClientNameHint = runRequest.agentKind.mcpClientNameHint
         logPrefix = "[ACP][\(provider.providerID.rawValue)]"

--- a/Sources/RepoPrompt/Infrastructure/AI/Agents/HeadlessAgentConnectionGate.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Agents/HeadlessAgentConnectionGate.swift
@@ -137,6 +137,16 @@ actor HeadlessAgentConnectionGate {
         }
     }
 
+    #if DEBUG
+        func debugWaitingCount() -> Int {
+            waitingContinuations.count
+        }
+
+        func debugActiveConnectionID() -> UUID? {
+            activeConnectionID
+        }
+    #endif
+
     /// Cancel all waiting agents (e.g., on app shutdown)
     func cancelAll() {
         activeConnectionID = nil

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/ACPHeadlessAgentProviderBridge.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/ACPHeadlessAgentProviderBridge.swift
@@ -95,7 +95,7 @@ final class ACPHeadlessAgentProviderBridge: HeadlessAgentProvider {
         defer { lifecycle.clearStreamTask(generation: generation) }
 
         do {
-            let support = await provider.support(for: request)
+            let support = try await provider.support(for: request)
             guard support == .supported else {
                 throw AIProviderError.invalidConfiguration(
                     detail: support.reason ?? "\(providerName) ACP is not available."

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Cursor/CursorACPAgentProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Cursor/CursorACPAgentProvider.swift
@@ -4,7 +4,6 @@ struct CursorACPAgentProvider: ACPAgentProvider {
     private let config: CursorAgentConfig
     private let repoPromptMCPConfiguration: RepoPromptMCPServerConfiguration
     private let launchResolver: CursorACPLaunchResolver
-    private let approvalEnvironmentProvider: @Sendable () -> [String: String]
 
     #if DEBUG
         var test_config: CursorAgentConfig {
@@ -15,23 +14,19 @@ struct CursorACPAgentProvider: ACPAgentProvider {
     init(
         config: CursorAgentConfig,
         repoPromptMCPConfiguration: RepoPromptMCPServerConfiguration = .repoPrompt,
-        launchResolver: CursorACPLaunchResolver = CursorACPLaunchResolver(),
-        approvalEnvironmentProvider: @escaping @Sendable () -> [String: String] = {
-            ProcessInfo.processInfo.environment
-        }
+        launchResolver: CursorACPLaunchResolver = CursorACPLaunchResolver()
     ) {
         self.config = config
         self.repoPromptMCPConfiguration = repoPromptMCPConfiguration
         self.launchResolver = launchResolver
-        self.approvalEnvironmentProvider = approvalEnvironmentProvider
     }
 
     var providerID: ACPProviderID {
         .cursor
     }
 
-    func support(for _: ACPRunRequest) async -> ACPSupportResult {
-        await launchResolver.probeSupport(for: config)
+    func support(for _: ACPRunRequest) async throws -> ACPSupportResult {
+        try await launchResolver.probeSupport(for: config)
     }
 
     func makeLaunchConfiguration(for request: ACPRunRequest) throws -> ACPLaunchConfiguration {
@@ -40,10 +35,9 @@ struct CursorACPAgentProvider: ACPAgentProvider {
         var environment: [String: String] = [:]
         var cleanupArtifact: ACPLaunchCleanupArtifact?
         if config.includeRepoPromptMCPServer {
-            let approvalEnvironment = approvalEnvironmentProvider()
             let cursorDataDirectory = CursorIntegrationConfiguration.cursorDataDirectoryURL(
                 workingDirectory: workingDirectory,
-                environment: approvalEnvironment
+                environment: resolvedLaunch.environment
             )
             environment["CURSOR_DATA_DIR"] = cursorDataDirectory.path
             cleanupArtifact = try CursorIntegrationConfiguration.prepareProjectMCPApproval(

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Cursor/CursorACPAgentProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Cursor/CursorACPAgentProvider.swift
@@ -14,7 +14,7 @@ struct CursorACPAgentProvider: ACPAgentProvider {
     init(
         config: CursorAgentConfig,
         repoPromptMCPConfiguration: RepoPromptMCPServerConfiguration = .repoPrompt,
-        launchResolver: CursorACPLaunchResolver = .shared
+        launchResolver: CursorACPLaunchResolver = CursorACPLaunchResolver()
     ) {
         self.config = config
         self.repoPromptMCPConfiguration = repoPromptMCPConfiguration
@@ -31,12 +31,7 @@ struct CursorACPAgentProvider: ACPAgentProvider {
 
     func makeLaunchConfiguration(for request: ACPRunRequest) throws -> ACPLaunchConfiguration {
         let workingDirectory = try standardizedWorkingDirectory(from: request.workspacePath)
-        let effectiveHints = CLIPathHints.nativeDefaultsSupplemented(with: config.additionalPathHints)
-        let resolvedLaunch = launchResolver.resolvedLaunch(for: config)
-            ?? CursorACPResolvedLaunch.fallback(
-                commandName: config.commandName,
-                additionalPathHints: effectiveHints
-            )
+        let resolvedLaunch = try launchResolver.resolvedLaunch(for: config)
 
         return ACPLaunchConfiguration(
             providerID: providerID,
@@ -45,7 +40,8 @@ struct CursorACPAgentProvider: ACPAgentProvider {
             environment: [:],
             workingDirectory: workingDirectory,
             additionalPathHints: resolvedLaunch.additionalPathHints,
-            enableDebugLogging: config.enableDebugLogging
+            enableDebugLogging: config.enableDebugLogging,
+            expectedExecutableIdentity: resolvedLaunch.executableIdentity
         )
     }
 
@@ -128,14 +124,20 @@ struct CursorACPAgentProvider: ACPAgentProvider {
         if let runnerError = error as? CLIProcessRunnerError,
            case .commandNotFound = runnerError
         {
-            return AIProviderError.invalidConfiguration(detail: "Cursor CLI ACP server not found. Install Cursor CLI and ensure `cursor-agent acp` or `cursor agent acp` is available on PATH.")
+            return AIProviderError.invalidConfiguration(detail: "Cursor Agent CLI ACP server not found. Install Cursor Agent CLI and ensure `cursor-agent acp` is available.")
+        }
+        if error is CursorACPLaunchResolutionError || error is ExecutableFileIdentityError {
+            return AIProviderError.invalidConfiguration(detail: error.localizedDescription)
         }
         if (error as NSError).domain == NSCocoaErrorDomain {
             return AIProviderError.invalidConfiguration(detail: "Unable to prepare Cursor ACP config: \(error.localizedDescription)")
         }
         let description = error.localizedDescription.trimmingCharacters(in: .whitespacesAndNewlines)
         let lower = description.lowercased()
-        if lower.contains("session mode") || lower.contains("session/set_mode") {
+        if lower.contains("session mode")
+            || lower.contains("session/set_config_option")
+            || lower.contains("mode config option")
+        {
             return AIProviderError.invalidConfiguration(detail: description)
         }
         return AIProviderError.apiError(source: error)

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Cursor/CursorACPAgentProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Cursor/CursorACPAgentProvider.swift
@@ -4,6 +4,7 @@ struct CursorACPAgentProvider: ACPAgentProvider {
     private let config: CursorAgentConfig
     private let repoPromptMCPConfiguration: RepoPromptMCPServerConfiguration
     private let launchResolver: CursorACPLaunchResolver
+    private let approvalEnvironmentProvider: @Sendable () -> [String: String]
 
     #if DEBUG
         var test_config: CursorAgentConfig {
@@ -14,11 +15,15 @@ struct CursorACPAgentProvider: ACPAgentProvider {
     init(
         config: CursorAgentConfig,
         repoPromptMCPConfiguration: RepoPromptMCPServerConfiguration = .repoPrompt,
-        launchResolver: CursorACPLaunchResolver = CursorACPLaunchResolver()
+        launchResolver: CursorACPLaunchResolver = CursorACPLaunchResolver(),
+        approvalEnvironmentProvider: @escaping @Sendable () -> [String: String] = {
+            ProcessInfo.processInfo.environment
+        }
     ) {
         self.config = config
         self.repoPromptMCPConfiguration = repoPromptMCPConfiguration
         self.launchResolver = launchResolver
+        self.approvalEnvironmentProvider = approvalEnvironmentProvider
     }
 
     var providerID: ACPProviderID {
@@ -32,15 +37,32 @@ struct CursorACPAgentProvider: ACPAgentProvider {
     func makeLaunchConfiguration(for request: ACPRunRequest) throws -> ACPLaunchConfiguration {
         let workingDirectory = try standardizedWorkingDirectory(from: request.workspacePath)
         let resolvedLaunch = try launchResolver.resolvedLaunch(for: config)
+        var environment: [String: String] = [:]
+        var cleanupArtifact: ACPLaunchCleanupArtifact?
+        if config.includeRepoPromptMCPServer {
+            let approvalEnvironment = approvalEnvironmentProvider()
+            let cursorDataDirectory = CursorIntegrationConfiguration.cursorDataDirectoryURL(
+                workingDirectory: workingDirectory,
+                environment: approvalEnvironment
+            )
+            environment["CURSOR_DATA_DIR"] = cursorDataDirectory.path
+            cleanupArtifact = try CursorIntegrationConfiguration.prepareProjectMCPApproval(
+                workingDirectory: workingDirectory,
+                cursorDataDirectory: cursorDataDirectory,
+                repoPromptMCPConfiguration: repoPromptMCPConfiguration,
+                cleanupAfterRun: config.cleanupProjectMCPApproval
+            )
+        }
 
         return ACPLaunchConfiguration(
             providerID: providerID,
             command: resolvedLaunch.command,
             arguments: resolvedLaunch.arguments,
-            environment: [:],
+            environment: environment,
             workingDirectory: workingDirectory,
             additionalPathHints: resolvedLaunch.additionalPathHints,
             enableDebugLogging: config.enableDebugLogging,
+            cleanupArtifact: cleanupArtifact,
             expectedExecutableIdentity: resolvedLaunch.executableIdentity
         )
     }
@@ -114,7 +136,7 @@ struct CursorACPAgentProvider: ACPAgentProvider {
         else {
             return
         }
-        CursorIntegrationConfiguration.cleanupProjectMCPConfig(leaseID: artifact.id)
+        CursorIntegrationConfiguration.cleanupProjectMCPApproval(leaseID: artifact.id)
     }
 
     func normalizeError(_ error: Error) -> Error {
@@ -130,7 +152,7 @@ struct CursorACPAgentProvider: ACPAgentProvider {
             return AIProviderError.invalidConfiguration(detail: error.localizedDescription)
         }
         if (error as NSError).domain == NSCocoaErrorDomain {
-            return AIProviderError.invalidConfiguration(detail: "Unable to prepare Cursor ACP config: \(error.localizedDescription)")
+            return AIProviderError.invalidConfiguration(detail: "Unable to prepare Cursor MCP approval: \(error.localizedDescription)")
         }
         let description = error.localizedDescription.trimmingCharacters(in: .whitespacesAndNewlines)
         let lower = description.lowercased()

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Cursor/CursorACPHeadlessAgentProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Cursor/CursorACPHeadlessAgentProvider.swift
@@ -52,11 +52,11 @@ final class CursorACPHeadlessAgentProvider: HeadlessAgentProvider {
             },
             makeController: controllerFactory,
             beforePrompt: { controller, _ in
-                if let sessionMode = Self.sessionModeToApply(config: config) {
-                    try await controller.setSessionMode(sessionMode)
-                }
                 if let model = Self.selectedModelToApply(config: config) {
                     try await controller.setSessionModel(model)
+                }
+                if let sessionMode = Self.sessionModeToApply(config: config) {
+                    try await controller.setSessionMode(sessionMode)
                 }
             },
             approvalPolicy: .declineUnsupported

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Cursor/CursorACPLaunchResolver.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Cursor/CursorACPLaunchResolver.swift
@@ -20,6 +20,7 @@ struct CursorACPResolvedLaunch: Equatable {
     let command: String
     let arguments: [String]
     let additionalPathHints: [String]
+    let environment: [String: String]
     let executableIdentity: ExecutableFileIdentity
 }
 
@@ -75,7 +76,7 @@ final class CursorACPLaunchResolver: @unchecked Sendable {
         let key = cacheKey(for: config)
         if let cached = cachedLaunch(forKey: key) {
             do {
-                try cached.executableIdentity.validate(atPath: cached.command)
+                try cached.executableIdentity.validateForTrustedPathLaunch(atPath: cached.command)
                 return cached
             } catch {
                 invalidate(key: key)
@@ -88,17 +89,13 @@ final class CursorACPLaunchResolver: @unchecked Sendable {
         return launch
     }
 
-    func probeSupport(for config: CursorAgentConfig) async -> ACPSupportResult {
-        do {
-            return try await probeMutex.withLock { [self] in
-                await probeSupportSerially(for: config)
-            }
-        } catch {
-            return .unsupported(reason: error.localizedDescription)
+    func probeSupport(for config: CursorAgentConfig) async throws -> ACPSupportResult {
+        try await probeMutex.withLock { [self] in
+            try await probeSupportSerially(for: config)
         }
     }
 
-    private func probeSupportSerially(for config: CursorAgentConfig) async -> ACPSupportResult {
+    private func probeSupportSerially(for config: CursorAgentConfig) async throws -> ACPSupportResult {
         let key = cacheKey(for: config)
         invalidate(key: key)
         do {
@@ -114,7 +111,8 @@ final class CursorACPLaunchResolver: @unchecked Sendable {
                 args: CursorACPLaunchCandidate.cursorAgentACP.helpArguments,
                 stdin: nil,
                 outputMode: .none,
-                timeout: 10
+                timeout: 10,
+                cancelChildOnTaskCancellation: true
             )
             guard result.status == 0 else {
                 return .unsupported(
@@ -133,9 +131,12 @@ final class CursorACPLaunchResolver: @unchecked Sendable {
                 )
             }
 
-            try launch.executableIdentity.validate(atPath: launch.command)
+            try launch.executableIdentity.validateForTrustedPathLaunch(atPath: launch.command)
             cache(launch, key: key)
             return .supported
+        } catch is CancellationError {
+            invalidate(key: key)
+            throw CancellationError()
         } catch {
             invalidate(key: key)
             return .unsupported(reason: error.localizedDescription)
@@ -145,6 +146,7 @@ final class CursorACPLaunchResolver: @unchecked Sendable {
     private func resolveLaunchForProbe(for config: CursorAgentConfig) async throws -> CursorACPResolvedLaunch {
         let configuredCommand = try validatedConfiguredCommand(config)
         let environment = await environmentProvider(config.enableDebugLogging)
+        try Task.checkCancellation()
         if configuredCommand.contains("/") {
             return try resolveExplicitLaunch(for: config, environment: environment)
         }
@@ -159,7 +161,8 @@ final class CursorACPLaunchResolver: @unchecked Sendable {
         return try validatedLaunch(
             entryPath: resolved,
             configuredCommand: configuredCommand,
-            additionalPathHints: effectiveHints
+            additionalPathHints: effectiveHints,
+            environment: environment
         )
     }
 
@@ -176,7 +179,8 @@ final class CursorACPLaunchResolver: @unchecked Sendable {
         return try validatedLaunch(
             entryPath: expanded,
             configuredCommand: configuredCommand,
-            additionalPathHints: effectiveHints
+            additionalPathHints: effectiveHints,
+            environment: environment
         )
     }
 
@@ -199,7 +203,8 @@ final class CursorACPLaunchResolver: @unchecked Sendable {
     private func validatedLaunch(
         entryPath: String,
         configuredCommand: String,
-        additionalPathHints: [String]
+        additionalPathHints: [String],
+        environment: [String: String]
     ) throws -> CursorACPResolvedLaunch {
         guard entryPath.hasPrefix("/"),
               URL(fileURLWithPath: entryPath).lastPathComponent.caseInsensitiveCompare(CursorACPLaunchCandidate.cursorAgentACP.command) == .orderedSame
@@ -209,7 +214,7 @@ final class CursorACPLaunchResolver: @unchecked Sendable {
 
         let identity: ExecutableFileIdentity
         do {
-            identity = try ExecutableFileIdentity.capture(atPath: entryPath)
+            identity = try ExecutableFileIdentity.captureForTrustedPathLaunch(atPath: entryPath)
         } catch {
             throw CursorACPLaunchResolutionError.exactPathNotFound(configuredCommand)
         }
@@ -226,6 +231,7 @@ final class CursorACPLaunchResolver: @unchecked Sendable {
             command: identity.canonicalPath,
             arguments: CursorACPLaunchCandidate.cursorAgentACP.launchArguments,
             additionalPathHints: additionalPathHints,
+            environment: environment,
             executableIdentity: identity
         )
     }

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Cursor/CursorACPModelPollingService.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Cursor/CursorACPModelPollingService.swift
@@ -44,7 +44,7 @@ struct CursorACPControllerModelDiscoveryClient: CursorACPModelDiscoveryClient {
             taskLabelKind: nil
         )
         guard let provider = providerFactory(.cursor, preferredModel) else { return nil }
-        let support = await provider.support(for: request)
+        let support = try await provider.support(for: request)
         guard support == .supported else {
             throw AIProviderError.invalidConfiguration(
                 detail: support.reason ?? "Cursor ACP is not available."

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Cursor/CursorACPModelPollingService.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Cursor/CursorACPModelPollingService.swift
@@ -19,7 +19,7 @@ struct CursorACPControllerModelDiscoveryClient: CursorACPModelDiscoveryClient {
                         enableDebugLogging: AgentRuntimeProviderService.enableDebugLogging,
                         modelString: modelString,
                         includeRepoPromptMCPServer: false,
-                        cleanupProjectMCPConfig: false
+                        cleanupProjectMCPApproval: false
                     )
                 )
             }

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Cursor/CursorAgentConfig.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Cursor/CursorAgentConfig.swift
@@ -8,7 +8,7 @@ struct CursorAgentConfig {
     let enableDebugLogging: Bool
     let modelString: String?
     let includeRepoPromptMCPServer: Bool
-    let cleanupProjectMCPConfig: Bool
+    let cleanupProjectMCPApproval: Bool
     let sessionModeID: String?
 
     init(
@@ -17,7 +17,7 @@ struct CursorAgentConfig {
         enableDebugLogging: Bool = false,
         modelString: String? = nil,
         includeRepoPromptMCPServer: Bool = true,
-        cleanupProjectMCPConfig: Bool = true,
+        cleanupProjectMCPApproval: Bool = true,
         sessionModeID: String? = nil
     ) {
         self.commandName = commandName
@@ -25,7 +25,7 @@ struct CursorAgentConfig {
         self.enableDebugLogging = enableDebugLogging
         self.modelString = modelString
         self.includeRepoPromptMCPServer = includeRepoPromptMCPServer
-        self.cleanupProjectMCPConfig = cleanupProjectMCPConfig
+        self.cleanupProjectMCPApproval = cleanupProjectMCPApproval
         self.sessionModeID = sessionModeID
     }
 }

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Cursor/CursorCLIProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Cursor/CursorCLIProvider.swift
@@ -121,7 +121,7 @@ final class CursorCLIProvider: AIProvider {
             enableDebugLogging: AgentRuntimeProviderService.enableDebugLogging,
             modelString: modelName,
             includeRepoPromptMCPServer: false,
-            cleanupProjectMCPConfig: true,
+            cleanupProjectMCPApproval: true,
             sessionModeID: CursorAgentConfig.promptOnlySessionModeID
         )
     }

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Cursor/CursorIntegrationConfiguration.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Cursor/CursorIntegrationConfiguration.swift
@@ -186,41 +186,12 @@ enum CursorIntegrationConfiguration {
         case .none, .deferred:
             return
         case let .final(state):
-            defer {
-                leaseStore.completeFinalCleanup(leaseID: leaseID)
-            }
             do {
-                let currentData: Data?
-                if fm.fileExists(atPath: state.approvalURL.path) {
-                    do {
-                        currentData = try Data(contentsOf: state.approvalURL)
-                    } catch {
-                        #if DEBUG
-                            print("[CursorIntegrationConfiguration] Cleanup read failed for \(state.approvalURL.path): \(error.localizedDescription)")
-                        #endif
-                        return
-                    }
-                } else {
-                    currentData = nil
-                }
-
-                guard currentData == state.latestWrittenData else {
-                    try cleanupDivergentApprovalFile(
-                        currentData: currentData,
-                        state: state,
-                        fileManager: fm
-                    )
-                    return
-                }
-
-                if let previousData = state.originalPreviousData {
-                    try previousData.write(to: state.approvalURL, options: .atomic)
-                } else if fm.fileExists(atPath: state.approvalURL.path) {
-                    try fm.removeItem(at: state.approvalURL)
-                }
-
-                removeDirectoryIfOwnedAndEmpty(state: state, fileManager: fm)
+                try cleanupInsertedApprovals(state: state, fileManager: fm)
+                leaseStore.completeFinalCleanup(leaseID: leaseID)
             } catch {
+                // Keep the final lease registered so cleanup can be retried after a transient
+                // read/parse/write failure instead of permanently orphaning our approval IDs.
                 #if DEBUG
                     print("[CursorIntegrationConfiguration] Cleanup failed for \(state.approvalURL.path): \(error.localizedDescription)")
                 #endif
@@ -228,20 +199,21 @@ enum CursorIntegrationConfiguration {
         }
     }
 
-    private static func cleanupDivergentApprovalFile(
-        currentData: Data?,
+    private static func cleanupInsertedApprovals(
         state: CursorProjectMCPApprovalLeaseStore.PathLeaseState,
         fileManager: FileManager
     ) throws {
-        guard !state.insertedApprovalIDs.isEmpty,
-              let currentData,
-              let currentApprovals = try? existingApprovals(
-                  from: currentData,
-                  approvalURL: state.approvalURL
-              )
-        else {
+        guard !state.insertedApprovalIDs.isEmpty else { return }
+        guard fileManager.fileExists(atPath: state.approvalURL.path) else {
+            removeDirectoryIfOwnedAndEmpty(state: state, fileManager: fileManager)
             return
         }
+
+        let currentData = try Data(contentsOf: state.approvalURL)
+        let currentApprovals = try existingApprovals(
+            from: currentData,
+            approvalURL: state.approvalURL
+        )
         let retainedApprovals = currentApprovals.filter {
             !state.insertedApprovalIDs.contains($0)
         }
@@ -413,7 +385,6 @@ private final class CursorProjectMCPApprovalLeaseStore: @unchecked Sendable {
         let originalPreviousData: Data?
         let originalCreatedDirectory: Bool
         var activeLeaseIDs: Set<UUID>
-        var latestWrittenData: Data
         var insertedApprovalIDs: Set<String>
     }
 
@@ -434,7 +405,6 @@ private final class CursorProjectMCPApprovalLeaseStore: @unchecked Sendable {
         approvalPathByLeaseID[lease.id] = key
         if var state = stateByApprovalPath[key] {
             state.activeLeaseIDs.insert(lease.id)
-            state.latestWrittenData = lease.writtenData
             state.insertedApprovalIDs.formUnion(lease.insertedApprovalIDs)
             stateByApprovalPath[key] = state
         } else {
@@ -444,7 +414,6 @@ private final class CursorProjectMCPApprovalLeaseStore: @unchecked Sendable {
                 originalPreviousData: lease.previousData,
                 originalCreatedDirectory: lease.createdDirectory,
                 activeLeaseIDs: [lease.id],
-                latestWrittenData: lease.writtenData,
                 insertedApprovalIDs: lease.insertedApprovalIDs
             )
         }

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Cursor/CursorIntegrationConfiguration.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Cursor/CursorIntegrationConfiguration.swift
@@ -1,86 +1,172 @@
+import CryptoKit
 import Foundation
 
 /// Cursor-specific MCP integration helpers.
 ///
-/// Cursor ACP does not reliably honor ACP `session/new` MCP injection. RepoPrompt-launched
-/// Cursor ACP runs therefore write a project-local `.cursor/mcp.json` lease before launch and
-/// restore/remove it on normal shutdown. If RepoPrompt crashes, the generated file may remain;
-/// cleanup is intentionally best effort and never overwrites user changes made during a run.
+/// Cursor Agent accepts modern ACP `session/new` MCP injection, but applies the same
+/// project-scoped approval gate used for configured MCP servers before starting an injected
+/// server. RepoPrompt therefore leases the matching approval identifier for the run while
+/// continuing to use ACP injection as the only server configuration mechanism.
 enum CursorIntegrationConfiguration {
-    static let cleanupArtifactKind = "cursorProjectMCPConfig"
-    private static let cursorDirectoryName = ".cursor"
-    private static let mcpConfigFileName = "mcp.json"
+    static let cleanupArtifactKind = "cursorProjectMCPApproval"
+    private static let approvalFileName = "mcp-approvals.json"
     private static let fileLock = NSLock()
-    private static let leaseStore = CursorProjectMCPConfigLeaseStore()
+    private static let leaseStore = CursorProjectMCPApprovalLeaseStore()
 
-    struct ProjectMCPConfigLease: Equatable {
+    struct ProjectMCPApprovalLease: Equatable {
         let id: UUID
-        let configURL: URL
+        let approvalURL: URL
         let directoryURL: URL
         let previousData: Data?
         let writtenData: Data
         let createdDirectory: Bool
+        let insertedApprovalIDs: Set<String>
     }
 
-    static func cursorDirectoryURL(workingDirectory: String) -> URL {
-        standardizedWorkingDirectoryURL(workingDirectory)
-            .appendingPathComponent(cursorDirectoryName, isDirectory: true)
+    static func cursorDataDirectoryURL(
+        workingDirectory: String,
+        environment: [String: String]
+    ) -> URL {
+        let workingDirectoryURL = standardizedWorkingDirectoryURL(workingDirectory)
+        let configuredDataDirectory = environment["CURSOR_DATA_DIR"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let rawPath: String
+        if let configuredDataDirectory, !configuredDataDirectory.isEmpty {
+            rawPath = configuredDataDirectory
+        } else {
+            let configuredHome = environment["HOME"]?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let homePath: String = if let configuredHome, !configuredHome.isEmpty {
+                configuredHome
+            } else {
+                FileManager.default.homeDirectoryForCurrentUser.path
+            }
+            rawPath = URL(fileURLWithPath: homePath, isDirectory: true)
+                .appendingPathComponent(".cursor", isDirectory: true)
+                .path
+        }
+
+        let expandedPath = expandedPath(rawPath, environment: environment)
+        if expandedPath.hasPrefix("/") {
+            return URL(fileURLWithPath: expandedPath, isDirectory: true).standardizedFileURL
+        }
+        return URL(
+            fileURLWithPath: expandedPath,
+            isDirectory: true,
+            relativeTo: workingDirectoryURL
+        ).standardizedFileURL
     }
 
-    static func projectMCPConfigURL(workingDirectory: String) -> URL {
-        cursorDirectoryURL(workingDirectory: workingDirectory)
-            .appendingPathComponent(mcpConfigFileName)
+    static func projectRootURL(workingDirectory: String) -> URL {
+        let workingDirectoryURL = standardizedWorkingDirectoryURL(workingDirectory)
+        var candidate = workingDirectoryURL
+        while true {
+            if FileManager.default.fileExists(
+                atPath: candidate.appendingPathComponent(".git").path
+            ) {
+                return candidate
+            }
+            let parent = candidate.deletingLastPathComponent()
+            guard parent.path != candidate.path else { break }
+            candidate = parent
+        }
+        return workingDirectoryURL
+    }
+
+    static func projectMCPApprovalURL(
+        workingDirectory: String,
+        cursorDataDirectory: URL
+    ) -> URL {
+        cursorProjectDirectoryURL(
+            projectRoot: projectRootURL(workingDirectory: workingDirectory),
+            cursorDataDirectory: cursorDataDirectory
+        )
+        .appendingPathComponent(approvalFileName)
+    }
+
+    static func approvalIdentifier(
+        projectRoot: String,
+        repoPromptMCPConfiguration: RepoPromptMCPServerConfiguration
+    ) throws -> String {
+        let payload = try cursorApprovalPayload(
+            projectRoot: projectRoot,
+            repoPromptMCPConfiguration: repoPromptMCPConfiguration
+        )
+        let digest = SHA256.hash(data: Data(payload.utf8))
+        let prefix = digest.prefix(8).map { String(format: "%02x", $0) }.joined()
+        return "\(repoPromptMCPConfiguration.name)-\(prefix)"
     }
 
     @discardableResult
-    static func prepareProjectMCPConfig(
+    static func prepareProjectMCPApproval(
         workingDirectory: String,
-        repoPromptMCPConfiguration: RepoPromptMCPServerConfiguration = .repoPrompt
-    ) throws -> ACPLaunchCleanupArtifact {
+        cursorDataDirectory: URL,
+        repoPromptMCPConfiguration: RepoPromptMCPServerConfiguration = .repoPrompt,
+        cleanupAfterRun: Bool = true
+    ) throws -> ACPLaunchCleanupArtifact? {
         fileLock.lock()
         defer { fileLock.unlock() }
 
         let fm = FileManager.default
-        let directoryURL = cursorDirectoryURL(workingDirectory: workingDirectory)
-        let configURL = directoryURL.appendingPathComponent(mcpConfigFileName)
+        let projectRoot = projectRootURL(workingDirectory: workingDirectory)
+        let directoryURL = cursorProjectDirectoryURL(
+            projectRoot: projectRoot,
+            cursorDataDirectory: cursorDataDirectory
+        )
+        let approvalURL = directoryURL.appendingPathComponent(approvalFileName)
 
         var isDirectory: ObjCBool = false
         let directoryExists = fm.fileExists(atPath: directoryURL.path, isDirectory: &isDirectory)
         if directoryExists, !isDirectory.boolValue {
-            throw AIProviderError.invalidConfiguration(detail: "Unable to prepare Cursor MCP config: \(directoryURL.path) exists but is not a directory.")
+            throw AIProviderError.invalidConfiguration(
+                detail: "Unable to prepare Cursor MCP approval: \(directoryURL.path) exists but is not a directory."
+            )
         }
         let createdDirectory = !directoryExists
         try fm.createDirectory(at: directoryURL, withIntermediateDirectories: true, attributes: nil)
 
         let previousData: Data?
-        if fm.fileExists(atPath: configURL.path) {
+        if fm.fileExists(atPath: approvalURL.path) {
             do {
-                previousData = try Data(contentsOf: configURL)
+                previousData = try Data(contentsOf: approvalURL)
             } catch {
-                throw AIProviderError.invalidConfiguration(detail: "Unable to read Cursor MCP config at \(configURL.path): \(error.localizedDescription)")
+                throw AIProviderError.invalidConfiguration(
+                    detail: "Unable to read Cursor MCP approvals at \(approvalURL.path): \(error.localizedDescription)"
+                )
             }
         } else {
             previousData = nil
         }
 
-        var root = try existingRootObject(from: previousData, configURL: configURL)
-        var servers = try existingMCPServers(from: root, configURL: configURL)
-        servers[repoPromptMCPConfiguration.name] = repoPromptMCPConfiguration.settingsJSONObject
-        root["mcpServers"] = servers
-
-        let writtenData = try JSONSerialization.data(
-            withJSONObject: root,
-            options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        var approvals = try existingApprovals(from: previousData, approvalURL: approvalURL)
+        let approval = try approvalIdentifier(
+            projectRoot: projectRoot.path,
+            repoPromptMCPConfiguration: repoPromptMCPConfiguration
         )
-        try writtenData.write(to: configURL, options: .atomic)
+        let insertedApprovalIDs: Set<String>
+        let writtenData: Data
+        if approvals.contains(approval), let previousData {
+            insertedApprovalIDs = []
+            writtenData = previousData
+        } else {
+            insertedApprovalIDs = [approval]
+            approvals.append(approval)
+            writtenData = try JSONSerialization.data(
+                withJSONObject: approvals,
+                options: [.prettyPrinted, .withoutEscapingSlashes]
+            )
+            try writtenData.write(to: approvalURL, options: .atomic)
+        }
 
-        let lease = ProjectMCPConfigLease(
+        guard cleanupAfterRun else { return nil }
+        let lease = ProjectMCPApprovalLease(
             id: UUID(),
-            configURL: configURL,
+            approvalURL: approvalURL,
             directoryURL: directoryURL,
             previousData: previousData,
             writtenData: writtenData,
-            createdDirectory: createdDirectory
+            createdDirectory: createdDirectory,
+            insertedApprovalIDs: insertedApprovalIDs
         )
         leaseStore.register(lease)
         return ACPLaunchCleanupArtifact(
@@ -90,7 +176,7 @@ enum CursorIntegrationConfiguration {
         )
     }
 
-    static func cleanupProjectMCPConfig(leaseID: UUID) {
+    static func cleanupProjectMCPApproval(leaseID: UUID) {
         fileLock.lock()
         defer { fileLock.unlock() }
 
@@ -99,14 +185,17 @@ enum CursorIntegrationConfiguration {
         case .none, .deferred:
             return
         case let .final(state):
+            defer {
+                leaseStore.completeFinalCleanup(leaseID: leaseID)
+            }
             do {
                 let currentData: Data?
-                if fm.fileExists(atPath: state.configURL.path) {
+                if fm.fileExists(atPath: state.approvalURL.path) {
                     do {
-                        currentData = try Data(contentsOf: state.configURL)
+                        currentData = try Data(contentsOf: state.approvalURL)
                     } catch {
                         #if DEBUG
-                            print("[CursorIntegrationConfiguration] Cleanup read failed for \(state.configURL.path): \(error.localizedDescription)")
+                            print("[CursorIntegrationConfiguration] Cleanup read failed for \(state.approvalURL.path): \(error.localizedDescription)")
                         #endif
                         return
                     }
@@ -115,51 +204,178 @@ enum CursorIntegrationConfiguration {
                 }
 
                 guard currentData == state.latestWrittenData else {
-                    leaseStore.completeFinalCleanup(leaseID: leaseID)
+                    try cleanupDivergentApprovalFile(
+                        currentData: currentData,
+                        state: state,
+                        fileManager: fm
+                    )
                     return
                 }
 
                 if let previousData = state.originalPreviousData {
-                    try previousData.write(to: state.configURL, options: .atomic)
-                } else if fm.fileExists(atPath: state.configURL.path) {
-                    try fm.removeItem(at: state.configURL)
+                    try previousData.write(to: state.approvalURL, options: .atomic)
+                } else if fm.fileExists(atPath: state.approvalURL.path) {
+                    try fm.removeItem(at: state.approvalURL)
                 }
 
-                if state.originalCreatedDirectory,
-                   let contents = try? fm.contentsOfDirectory(atPath: state.directoryURL.path),
-                   contents.isEmpty
-                {
-                    try? fm.removeItem(at: state.directoryURL)
-                }
-                leaseStore.completeFinalCleanup(leaseID: leaseID)
+                removeDirectoryIfOwnedAndEmpty(state: state, fileManager: fm)
             } catch {
                 #if DEBUG
-                    print("[CursorIntegrationConfiguration] Cleanup failed for \(state.configURL.path): \(error.localizedDescription)")
+                    print("[CursorIntegrationConfiguration] Cleanup failed for \(state.approvalURL.path): \(error.localizedDescription)")
                 #endif
             }
         }
     }
 
-    private static func existingRootObject(from data: Data?, configURL: URL) throws -> [String: Any] {
-        guard let data else { return [:] }
-        do {
-            guard let root = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-                throw AIProviderError.invalidConfiguration(detail: "Unable to merge Cursor MCP config at \(configURL.path): expected a JSON object.")
-            }
-            return root
-        } catch let error as AIProviderError {
-            throw error
-        } catch {
-            throw AIProviderError.invalidConfiguration(detail: "Unable to merge Cursor MCP config at \(configURL.path): invalid JSON.")
+    private static func cleanupDivergentApprovalFile(
+        currentData: Data?,
+        state: CursorProjectMCPApprovalLeaseStore.PathLeaseState,
+        fileManager: FileManager
+    ) throws {
+        guard !state.insertedApprovalIDs.isEmpty,
+              let currentData,
+              let currentApprovals = try? existingApprovals(
+                  from: currentData,
+                  approvalURL: state.approvalURL
+              )
+        else {
+            return
+        }
+        let retainedApprovals = currentApprovals.filter {
+            !state.insertedApprovalIDs.contains($0)
+        }
+        guard retainedApprovals.count != currentApprovals.count else { return }
+
+        if retainedApprovals.isEmpty, state.originalPreviousData == nil {
+            try fileManager.removeItem(at: state.approvalURL)
+            removeDirectoryIfOwnedAndEmpty(state: state, fileManager: fileManager)
+            return
+        }
+        let retainedData = try JSONSerialization.data(
+            withJSONObject: retainedApprovals,
+            options: [.prettyPrinted, .withoutEscapingSlashes]
+        )
+        try retainedData.write(to: state.approvalURL, options: .atomic)
+    }
+
+    private static func removeDirectoryIfOwnedAndEmpty(
+        state: CursorProjectMCPApprovalLeaseStore.PathLeaseState,
+        fileManager: FileManager
+    ) {
+        if state.originalCreatedDirectory,
+           let contents = try? fileManager.contentsOfDirectory(atPath: state.directoryURL.path),
+           contents.isEmpty
+        {
+            try? fileManager.removeItem(at: state.directoryURL)
         }
     }
 
-    private static func existingMCPServers(from root: [String: Any], configURL: URL) throws -> [String: Any] {
-        guard let existing = root["mcpServers"] else { return [:] }
-        guard let servers = existing as? [String: Any] else {
-            throw AIProviderError.invalidConfiguration(detail: "Unable to merge Cursor MCP config at \(configURL.path): `mcpServers` must be an object.")
+    private static func cursorProjectDirectoryURL(
+        projectRoot: URL,
+        cursorDataDirectory: URL
+    ) -> URL {
+        cursorDataDirectory
+            .appendingPathComponent("projects", isDirectory: true)
+            .appendingPathComponent(cursorProjectPathComponent(projectRoot.path), isDirectory: true)
+    }
+
+    private static func cursorProjectPathComponent(_ path: String) -> String {
+        path
+            .replacingOccurrences(
+                of: #"[^a-zA-Z0-9]"#,
+                with: "-",
+                options: .regularExpression
+            )
+            .replacingOccurrences(
+                of: #"-+"#,
+                with: "-",
+                options: .regularExpression
+            )
+            .trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+    }
+
+    private static func cursorApprovalPayload(
+        projectRoot: String,
+        repoPromptMCPConfiguration: RepoPromptMCPServerConfiguration
+    ) throws -> String {
+        let pathJSON = try JSONSerialization.stringFragment(projectRoot)
+        let commandJSON = try JSONSerialization.stringFragment(repoPromptMCPConfiguration.command)
+        let argsData = try JSONSerialization.data(
+            withJSONObject: repoPromptMCPConfiguration.args,
+            options: [.withoutEscapingSlashes]
+        )
+        guard let argsJSON = String(data: argsData, encoding: .utf8) else {
+            throw CocoaError(.fileWriteInapplicableStringEncoding)
         }
-        return servers
+
+        var orderedEnvironmentNames: [String] = []
+        var environmentValues: [String: String] = [:]
+        for entry in repoPromptMCPConfiguration.env {
+            if environmentValues[entry.name] == nil {
+                orderedEnvironmentNames.append(entry.name)
+            }
+            environmentValues[entry.name] = entry.value
+        }
+        let environmentJSON = try cursorJSONObjectKeyOrder(orderedEnvironmentNames).map { name in
+            let value = environmentValues[name] ?? ""
+            return try "\(JSONSerialization.stringFragment(name)):\(JSONSerialization.stringFragment(value))"
+        }.joined(separator: ",")
+
+        return #"{"path":\#(pathJSON),"server":{"command":\#(commandJSON),"args":\#(argsJSON),"env":{\#(environmentJSON)}}}"#
+    }
+
+    private static func cursorJSONObjectKeyOrder(_ keys: [String]) -> [String] {
+        let indexed = keys.compactMap { key -> (key: String, index: UInt32)? in
+            guard let index = UInt32(key),
+                  index != UInt32.max,
+                  String(index) == key
+            else {
+                return nil
+            }
+            return (key, index)
+        }
+        let indexedKeys = Set(indexed.map(\.key))
+        return indexed.sorted { $0.index < $1.index }.map(\.key)
+            + keys.filter { !indexedKeys.contains($0) }
+    }
+
+    private static func existingApprovals(
+        from data: Data?,
+        approvalURL: URL
+    ) throws -> [String] {
+        guard let data else { return [] }
+        do {
+            guard let approvals = try JSONSerialization.jsonObject(with: data) as? [String] else {
+                throw AIProviderError.invalidConfiguration(
+                    detail: "Unable to merge Cursor MCP approvals at \(approvalURL.path): expected a JSON string array."
+                )
+            }
+            return approvals
+        } catch let error as AIProviderError {
+            throw error
+        } catch {
+            throw AIProviderError.invalidConfiguration(
+                detail: "Unable to merge Cursor MCP approvals at \(approvalURL.path): invalid JSON."
+            )
+        }
+    }
+
+    private static func expandedPath(
+        _ path: String,
+        environment: [String: String]
+    ) -> String {
+        var expanded = path
+        if expanded == "~" || expanded.hasPrefix("~/") {
+            let home = environment["HOME"]?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let homePath: String = if let home, !home.isEmpty {
+                home
+            } else {
+                FileManager.default.homeDirectoryForCurrentUser.path
+            }
+            expanded = homePath + expanded.dropFirst()
+        }
+        return CommandPathResolver.expandPath(expanded, environment: environment)
     }
 
     private static func standardizedWorkingDirectoryURL(_ workingDirectory: String) -> URL {
@@ -169,14 +385,28 @@ enum CursorIntegrationConfiguration {
     }
 }
 
-private final class CursorProjectMCPConfigLeaseStore: @unchecked Sendable {
+private extension JSONSerialization {
+    static func stringFragment(_ value: String) throws -> String {
+        let data = try JSONSerialization.data(
+            withJSONObject: value,
+            options: [.fragmentsAllowed, .withoutEscapingSlashes]
+        )
+        guard let string = String(data: data, encoding: .utf8) else {
+            throw CocoaError(.fileWriteInapplicableStringEncoding)
+        }
+        return string
+    }
+}
+
+private final class CursorProjectMCPApprovalLeaseStore: @unchecked Sendable {
     struct PathLeaseState {
-        let configURL: URL
+        let approvalURL: URL
         let directoryURL: URL
         let originalPreviousData: Data?
         let originalCreatedDirectory: Bool
         var activeLeaseIDs: Set<UUID>
         var latestWrittenData: Data
+        var insertedApprovalIDs: Set<String>
     }
 
     enum CleanupDisposition {
@@ -185,27 +415,29 @@ private final class CursorProjectMCPConfigLeaseStore: @unchecked Sendable {
     }
 
     private let lock = NSLock()
-    private var configPathByLeaseID: [UUID: String] = [:]
-    private var stateByConfigPath: [String: PathLeaseState] = [:]
+    private var approvalPathByLeaseID: [UUID: String] = [:]
+    private var stateByApprovalPath: [String: PathLeaseState] = [:]
 
-    func register(_ lease: CursorIntegrationConfiguration.ProjectMCPConfigLease) {
+    func register(_ lease: CursorIntegrationConfiguration.ProjectMCPApprovalLease) {
         lock.lock()
         defer { lock.unlock() }
 
-        let key = lease.configURL.standardizedFileURL.path
-        configPathByLeaseID[lease.id] = key
-        if var state = stateByConfigPath[key] {
+        let key = lease.approvalURL.standardizedFileURL.path
+        approvalPathByLeaseID[lease.id] = key
+        if var state = stateByApprovalPath[key] {
             state.activeLeaseIDs.insert(lease.id)
             state.latestWrittenData = lease.writtenData
-            stateByConfigPath[key] = state
+            state.insertedApprovalIDs.formUnion(lease.insertedApprovalIDs)
+            stateByApprovalPath[key] = state
         } else {
-            stateByConfigPath[key] = PathLeaseState(
-                configURL: lease.configURL,
+            stateByApprovalPath[key] = PathLeaseState(
+                approvalURL: lease.approvalURL,
                 directoryURL: lease.directoryURL,
                 originalPreviousData: lease.previousData,
                 originalCreatedDirectory: lease.createdDirectory,
                 activeLeaseIDs: [lease.id],
-                latestWrittenData: lease.writtenData
+                latestWrittenData: lease.writtenData,
+                insertedApprovalIDs: lease.insertedApprovalIDs
             )
         }
     }
@@ -214,13 +446,15 @@ private final class CursorProjectMCPConfigLeaseStore: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
 
-        guard let key = configPathByLeaseID[leaseID], var state = stateByConfigPath[key] else {
+        guard let key = approvalPathByLeaseID[leaseID],
+              var state = stateByApprovalPath[key]
+        else {
             return nil
         }
         if state.activeLeaseIDs.count > 1 {
             state.activeLeaseIDs.remove(leaseID)
-            stateByConfigPath[key] = state
-            configPathByLeaseID.removeValue(forKey: leaseID)
+            stateByApprovalPath[key] = state
+            approvalPathByLeaseID.removeValue(forKey: leaseID)
             return .deferred
         }
         return .final(state)
@@ -230,7 +464,7 @@ private final class CursorProjectMCPConfigLeaseStore: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
 
-        guard let key = configPathByLeaseID.removeValue(forKey: leaseID) else { return }
-        stateByConfigPath.removeValue(forKey: key)
+        guard let key = approvalPathByLeaseID.removeValue(forKey: leaseID) else { return }
+        stateByApprovalPath.removeValue(forKey: key)
     }
 }

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Cursor/CursorIntegrationConfiguration.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Cursor/CursorIntegrationConfiguration.swift
@@ -1,4 +1,5 @@
 import CryptoKit
+import Darwin
 import Foundation
 
 /// Cursor-specific MCP integration helpers.
@@ -381,7 +382,14 @@ enum CursorIntegrationConfiguration {
     private static func standardizedWorkingDirectoryURL(_ workingDirectory: String) -> URL {
         let trimmed = workingDirectory.trimmingCharacters(in: .whitespacesAndNewlines)
         let path = trimmed.isEmpty ? FileManager.default.temporaryDirectory.path : trimmed
-        return URL(fileURLWithPath: path, isDirectory: true).standardizedFileURL
+        let standardizedURL = URL(fileURLWithPath: path, isDirectory: true).standardizedFileURL
+        let physicalPath = standardizedURL.path.withCString { cPath -> String? in
+            guard let resolved = realpath(cPath, nil) else { return nil }
+            defer { free(resolved) }
+            return String(cString: resolved)
+        }
+        return physicalPath.map { URL(fileURLWithPath: $0, isDirectory: true) }
+            ?? standardizedURL
     }
 }
 

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/OpenCode/OpenCodeACPAgentProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/OpenCode/OpenCodeACPAgentProvider.swift
@@ -29,8 +29,8 @@ struct OpenCodeACPAgentProvider: ACPAgentProvider {
         .openCode
     }
 
-    func support(for _: ACPRunRequest) async -> ACPSupportResult {
-        await launchResolver.probeSupport(for: config)
+    func support(for _: ACPRunRequest) async throws -> ACPSupportResult {
+        try await launchResolver.probeSupport(for: config)
     }
 
     func makeLaunchConfiguration(for request: ACPRunRequest) throws -> ACPLaunchConfiguration {

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/OpenCode/OpenCodeACPAgentProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/OpenCode/OpenCodeACPAgentProvider.swift
@@ -2,12 +2,12 @@ import Foundation
 
 struct OpenCodeACPAgentProvider: ACPAgentProvider {
     private enum LaunchContract {
-        static let acpSubcommand = "acp"
         static let configContentEnvironmentKey = "OPENCODE_CONFIG_CONTENT"
     }
 
     private let config: OpenCodeAgentConfig
     private let repoPromptMCPConfiguration: RepoPromptMCPServerConfiguration
+    private let launchResolver: OpenCodeACPLaunchResolver
 
     #if DEBUG
         var test_config: OpenCodeAgentConfig {
@@ -17,55 +17,25 @@ struct OpenCodeACPAgentProvider: ACPAgentProvider {
 
     init(
         config: OpenCodeAgentConfig,
-        repoPromptMCPConfiguration: RepoPromptMCPServerConfiguration = .repoPrompt
+        repoPromptMCPConfiguration: RepoPromptMCPServerConfiguration = .repoPrompt,
+        launchResolver: OpenCodeACPLaunchResolver = OpenCodeACPLaunchResolver()
     ) {
         self.config = config
         self.repoPromptMCPConfiguration = repoPromptMCPConfiguration
+        self.launchResolver = launchResolver
     }
 
     var providerID: ACPProviderID {
         .openCode
     }
 
-    func support(for request: ACPRunRequest) async -> ACPSupportResult {
-        var processConfig = CLIProcessConfiguration(
-            command: config.commandName,
-            enableDebugLogging: config.enableDebugLogging
-        )
-        processConfig.ensureAdditionalPaths(config.additionalPathHints)
-        let runner = CLIProcessRunner(config: processConfig)
-
-        do {
-            let result = try await runner.run(
-                args: [LaunchContract.acpSubcommand, "--help"],
-                stdin: nil,
-                outputMode: .none,
-                timeout: 10
-            )
-            let stdout = String(data: result.stdout, encoding: .utf8) ?? ""
-            let stderr = String(data: result.stderr, encoding: .utf8) ?? ""
-            let combined = "\(stdout)\n\(stderr)"
-            guard result.status == 0 else {
-                return .unsupported(reason: "OpenCode ACP preflight failed before startup.")
-            }
-            guard combined.localizedCaseInsensitiveContains("acp") else {
-                return .unsupported(reason: "Installed OpenCode CLI does not advertise ACP support.")
-            }
-            return .supported
-        } catch let error as CLIProcessRunnerError {
-            switch error {
-            case .commandNotFound:
-                return .unsupported(reason: "OpenCode CLI was not found for ACP preflight.")
-            default:
-                return .unsupported(reason: "OpenCode ACP preflight failed: \(error.localizedDescription)")
-            }
-        } catch {
-            return .unsupported(reason: "OpenCode ACP preflight failed: \(error.localizedDescription)")
-        }
+    func support(for _: ACPRunRequest) async -> ACPSupportResult {
+        await launchResolver.probeSupport(for: config)
     }
 
     func makeLaunchConfiguration(for request: ACPRunRequest) throws -> ACPLaunchConfiguration {
         let workingDirectory = standardizedWorkingDirectory(from: request.workspacePath)
+        let resolvedLaunch = try launchResolver.resolvedLaunch(for: config)
         var environment: [String: String] = [:]
 
         if config.includeManagedConfigOverlay {
@@ -87,12 +57,13 @@ struct OpenCodeACPAgentProvider: ACPAgentProvider {
 
         return ACPLaunchConfiguration(
             providerID: providerID,
-            command: config.commandName,
-            arguments: [LaunchContract.acpSubcommand],
+            command: resolvedLaunch.command,
+            arguments: resolvedLaunch.arguments,
             environment: environment,
             workingDirectory: workingDirectory,
-            additionalPathHints: CLIPathHints.nativeDefaultsSupplemented(with: config.additionalPathHints),
-            enableDebugLogging: config.enableDebugLogging
+            additionalPathHints: resolvedLaunch.additionalPathHints,
+            enableDebugLogging: config.enableDebugLogging,
+            expectedExecutableIdentity: resolvedLaunch.executableIdentity
         )
     }
 
@@ -153,6 +124,9 @@ struct OpenCodeACPAgentProvider: ACPAgentProvider {
            case .commandNotFound = runnerError
         {
             return AIProviderError.invalidConfiguration(detail: "OpenCode CLI not found. Install it and ensure `opencode` is available on PATH.")
+        }
+        if error is OpenCodeACPLaunchResolutionError || error is ExecutableFileIdentityError {
+            return AIProviderError.invalidConfiguration(detail: error.localizedDescription)
         }
         if (error as NSError).domain == NSCocoaErrorDomain {
             return AIProviderError.invalidConfiguration(detail: "Unable to prepare OpenCode ACP config: \(error.localizedDescription)")

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/OpenCode/OpenCodeACPHeadlessAgentProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/OpenCode/OpenCodeACPHeadlessAgentProvider.swift
@@ -52,10 +52,10 @@ final class OpenCodeACPHeadlessAgentProvider: HeadlessAgentProvider {
             },
             makeController: controllerFactory,
             beforePrompt: { controller, _ in
-                try await controller.setSessionMode(config.sessionModeID)
                 if let model = Self.selectedModelToApply(config: config) {
                     try await controller.setSessionModel(model)
                 }
+                try await controller.setSessionMode(config.sessionModeID)
             },
             approvalPolicy: .declineUnsupported
         )

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/OpenCode/OpenCodeACPLaunchResolver.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/OpenCode/OpenCodeACPLaunchResolver.swift
@@ -53,7 +53,7 @@ final class OpenCodeACPLaunchResolver: @unchecked Sendable {
         let key = cacheKey(for: config)
         if let cached = cachedLaunch(forKey: key) {
             do {
-                try cached.executableIdentity.validate(atPath: cached.command)
+                try cached.executableIdentity.validateForTrustedPathLaunch(atPath: cached.command)
                 return cached
             } catch {
                 invalidate(key: key)
@@ -66,17 +66,13 @@ final class OpenCodeACPLaunchResolver: @unchecked Sendable {
         return launch
     }
 
-    func probeSupport(for config: OpenCodeAgentConfig) async -> ACPSupportResult {
-        do {
-            return try await probeMutex.withLock { [self] in
-                await probeSupportSerially(for: config)
-            }
-        } catch {
-            return .unsupported(reason: error.localizedDescription)
+    func probeSupport(for config: OpenCodeAgentConfig) async throws -> ACPSupportResult {
+        try await probeMutex.withLock { [self] in
+            try await probeSupportSerially(for: config)
         }
     }
 
-    private func probeSupportSerially(for config: OpenCodeAgentConfig) async -> ACPSupportResult {
+    private func probeSupportSerially(for config: OpenCodeAgentConfig) async throws -> ACPSupportResult {
         let key = cacheKey(for: config)
         invalidate(key: key)
         do {
@@ -92,7 +88,8 @@ final class OpenCodeACPLaunchResolver: @unchecked Sendable {
                 args: Self.helpArguments,
                 stdin: nil,
                 outputMode: .none,
-                timeout: 10
+                timeout: 10,
+                cancelChildOnTaskCancellation: true
             )
             guard result.status == 0 else {
                 return .unsupported(
@@ -106,9 +103,12 @@ final class OpenCodeACPLaunchResolver: @unchecked Sendable {
                 return .unsupported(reason: "Installed OpenCode CLI does not advertise ACP support.")
             }
 
-            try launch.executableIdentity.validate(atPath: launch.command)
+            try launch.executableIdentity.validateForTrustedPathLaunch(atPath: launch.command)
             cache(launch, key: key)
             return .supported
+        } catch is CancellationError {
+            invalidate(key: key)
+            throw CancellationError()
         } catch {
             invalidate(key: key)
             return .unsupported(reason: error.localizedDescription)
@@ -118,6 +118,7 @@ final class OpenCodeACPLaunchResolver: @unchecked Sendable {
     private func resolveLaunchForProbe(for config: OpenCodeAgentConfig) async throws -> OpenCodeACPResolvedLaunch {
         let configuredCommand = try validatedConfiguredCommand(config)
         let environment = await environmentProvider(config.enableDebugLogging)
+        try Task.checkCancellation()
         if configuredCommand.contains("/") {
             return try resolveExplicitLaunch(for: config, environment: environment)
         }
@@ -171,7 +172,7 @@ final class OpenCodeACPLaunchResolver: @unchecked Sendable {
 
         let identity: ExecutableFileIdentity
         do {
-            identity = try ExecutableFileIdentity.capture(atPath: entryPath)
+            identity = try ExecutableFileIdentity.captureForTrustedPathLaunch(atPath: entryPath)
         } catch {
             throw OpenCodeACPLaunchResolutionError.exactPathNotFound(configuredCommand)
         }

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/OpenCode/OpenCodeACPLaunchResolver.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/OpenCode/OpenCodeACPLaunchResolver.swift
@@ -1,67 +1,45 @@
 import Foundation
 
-enum CursorACPLaunchCandidate: Equatable {
-    case cursorAgentACP
-
-    var command: String {
-        CLILaunchProfiles.cursor.commandName
-    }
-
-    var launchArguments: [String] {
-        ["--approve-mcps", "acp"]
-    }
-
-    var helpArguments: [String] {
-        ["acp", "--help"]
-    }
-}
-
-struct CursorACPResolvedLaunch: Equatable {
+struct OpenCodeACPResolvedLaunch: Equatable {
     let command: String
     let arguments: [String]
     let additionalPathHints: [String]
     let executableIdentity: ExecutableFileIdentity
 }
 
-enum CursorACPLaunchResolutionError: Error, Equatable, LocalizedError {
+enum OpenCodeACPLaunchResolutionError: Error, Equatable, LocalizedError {
     case missingConfiguredCommand
-    case unsafeConfiguredCommand(String)
     case exactPathNotFound(String)
     case environmentDiscoveryRequired(String)
-    case unsafeApplicationPath(String)
-    case unsafeCanonicalBasename(String)
 
     var errorDescription: String? {
         switch self {
         case .missingConfiguredCommand:
-            "Cursor Agent CLI launch requires an exact `cursor-agent` command or absolute path."
-        case let .unsafeConfiguredCommand(command):
-            "Refusing unsafe Cursor ACP command `\(command)`. Configure the CLI-only `cursor-agent` executable."
+            "OpenCode ACP launch requires an `opencode` command or executable path."
         case let .exactPathNotFound(command):
-            "Cursor Agent CLI was not found as a valid executable regular file for `\(command)`. Install `cursor-agent` or configure its absolute path."
+            "OpenCode CLI was not found as a valid executable regular file for `\(command)`. Install OpenCode or configure its absolute path."
         case let .environmentDiscoveryRequired(command):
-            "Cursor Agent CLI path discovery has not completed for `\(command)`. Run the Cursor ACP support preflight or configure an absolute `cursor-agent` path."
-        case let .unsafeApplicationPath(path):
-            "Refusing Cursor ACP executable inside an application bundle: \(path)"
-        case let .unsafeCanonicalBasename(path):
-            "Refusing Cursor ACP executable whose canonical basename is `cursor`: \(path)"
+            "OpenCode CLI path discovery has not completed for `\(command)`. Run the OpenCode ACP support preflight or configure an absolute executable path."
         }
     }
 }
 
-final class CursorACPLaunchResolver: @unchecked Sendable {
+final class OpenCodeACPLaunchResolver: @unchecked Sendable {
     typealias EnvironmentProvider = @Sendable (_ enableDebugLogging: Bool) async -> [String: String]
+
+    private static let launchArguments = ["acp"]
+    private static let helpArguments = ["acp", "--help"]
 
     private let environmentProvider: EnvironmentProvider
     private let probeMutex = AsyncMutex()
     private let lock = NSLock()
-    private var cachedLaunchByKey: [String: CursorACPResolvedLaunch] = [:]
+    private var cachedLaunchByKey: [String: OpenCodeACPResolvedLaunch] = [:]
 
     init(
         environmentProvider: @escaping EnvironmentProvider = { enableDebugLogging in
             let result = await ProcessEnvironmentBuilder.build(
                 ProcessEnvironmentRequest(
-                    purpose: .acpAgent(providerID: ACPProviderID.cursor.rawValue),
+                    purpose: .acpAgent(providerID: ACPProviderID.openCode.rawValue),
                     enableDebugLogging: enableDebugLogging
                 )
             )
@@ -71,7 +49,7 @@ final class CursorACPLaunchResolver: @unchecked Sendable {
         self.environmentProvider = environmentProvider
     }
 
-    func resolvedLaunch(for config: CursorAgentConfig) throws -> CursorACPResolvedLaunch {
+    func resolvedLaunch(for config: OpenCodeAgentConfig) throws -> OpenCodeACPResolvedLaunch {
         let key = cacheKey(for: config)
         if let cached = cachedLaunch(forKey: key) {
             do {
@@ -88,7 +66,7 @@ final class CursorACPLaunchResolver: @unchecked Sendable {
         return launch
     }
 
-    func probeSupport(for config: CursorAgentConfig) async -> ACPSupportResult {
+    func probeSupport(for config: OpenCodeAgentConfig) async -> ACPSupportResult {
         do {
             return try await probeMutex.withLock { [self] in
                 await probeSupportSerially(for: config)
@@ -98,7 +76,7 @@ final class CursorACPLaunchResolver: @unchecked Sendable {
         }
     }
 
-    private func probeSupportSerially(for config: CursorAgentConfig) async -> ACPSupportResult {
+    private func probeSupportSerially(for config: OpenCodeAgentConfig) async -> ACPSupportResult {
         let key = cacheKey(for: config)
         invalidate(key: key)
         do {
@@ -111,26 +89,21 @@ final class CursorACPLaunchResolver: @unchecked Sendable {
                 enableDebugLogging: config.enableDebugLogging
             )
             let result = try await CLIProcessRunner(config: processConfig).run(
-                args: CursorACPLaunchCandidate.cursorAgentACP.helpArguments,
+                args: Self.helpArguments,
                 stdin: nil,
                 outputMode: .none,
                 timeout: 10
             )
             guard result.status == 0 else {
                 return .unsupported(
-                    reason: "Cursor Agent CLI ACP preflight failed: `cursor-agent acp --help` exited with status \(result.status)."
+                    reason: "OpenCode ACP preflight failed: `opencode acp --help` exited with status \(result.status)."
                 )
             }
 
             let stdout = String(data: result.stdout, encoding: .utf8) ?? ""
             let stderr = String(data: result.stderr, encoding: .utf8) ?? ""
-            let combined = "\(stdout)\n\(stderr)"
-            guard combined.localizedCaseInsensitiveContains("acp")
-                || combined.localizedCaseInsensitiveContains("agent client protocol")
-            else {
-                return .unsupported(
-                    reason: "Cursor Agent CLI ACP preflight failed: `cursor-agent acp --help` did not advertise ACP support."
-                )
+            guard "\(stdout)\n\(stderr)".localizedCaseInsensitiveContains("acp") else {
+                return .unsupported(reason: "Installed OpenCode CLI does not advertise ACP support.")
             }
 
             try launch.executableIdentity.validate(atPath: launch.command)
@@ -142,7 +115,7 @@ final class CursorACPLaunchResolver: @unchecked Sendable {
         }
     }
 
-    private func resolveLaunchForProbe(for config: CursorAgentConfig) async throws -> CursorACPResolvedLaunch {
+    private func resolveLaunchForProbe(for config: OpenCodeAgentConfig) async throws -> OpenCodeACPResolvedLaunch {
         let configuredCommand = try validatedConfiguredCommand(config)
         let environment = await environmentProvider(config.enableDebugLogging)
         if configuredCommand.contains("/") {
@@ -151,10 +124,10 @@ final class CursorACPLaunchResolver: @unchecked Sendable {
 
         let effectiveHints = CLIPathHints.nativeDefaultsSupplemented(with: config.additionalPathHints)
         let resolved = CommandPathResolver.resolve(
-            CursorACPLaunchCandidate.cursorAgentACP.command,
+            configuredCommand,
             environment: environment,
             additionalPaths: effectiveHints,
-            preferredBasenames: CLILaunchProfiles.cursor.preferredBasenames
+            preferredBasenames: [configuredCommand]
         )
         return try validatedLaunch(
             entryPath: resolved,
@@ -164,79 +137,60 @@ final class CursorACPLaunchResolver: @unchecked Sendable {
     }
 
     private func resolveExplicitLaunch(
-        for config: CursorAgentConfig,
+        for config: OpenCodeAgentConfig,
         environment: [String: String] = ProcessInfo.processInfo.environment
-    ) throws -> CursorACPResolvedLaunch {
+    ) throws -> OpenCodeACPResolvedLaunch {
         let configuredCommand = try validatedConfiguredCommand(config)
         guard configuredCommand.contains("/") else {
-            throw CursorACPLaunchResolutionError.environmentDiscoveryRequired(configuredCommand)
+            throw OpenCodeACPLaunchResolutionError.environmentDiscoveryRequired(configuredCommand)
         }
         let effectiveHints = CLIPathHints.nativeDefaultsSupplemented(with: config.additionalPathHints)
-        let expanded = CommandPathResolver.expandPath(configuredCommand, environment: environment)
         return try validatedLaunch(
-            entryPath: expanded,
+            entryPath: CommandPathResolver.expandPath(configuredCommand, environment: environment),
             configuredCommand: configuredCommand,
             additionalPathHints: effectiveHints
         )
     }
 
-    private func validatedConfiguredCommand(_ config: CursorAgentConfig) throws -> String {
-        let configuredCommand = config.commandName.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !configuredCommand.isEmpty else {
-            throw CursorACPLaunchResolutionError.missingConfiguredCommand
+    private func validatedConfiguredCommand(_ config: OpenCodeAgentConfig) throws -> String {
+        let command = config.commandName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !command.isEmpty else {
+            throw OpenCodeACPLaunchResolutionError.missingConfiguredCommand
         }
-        let expectedCommand = CursorACPLaunchCandidate.cursorAgentACP.command
-        if configuredCommand.contains("/") {
-            guard URL(fileURLWithPath: configuredCommand).lastPathComponent.caseInsensitiveCompare(expectedCommand) == .orderedSame else {
-                throw CursorACPLaunchResolutionError.unsafeConfiguredCommand(configuredCommand)
-            }
-        } else if configuredCommand.caseInsensitiveCompare(expectedCommand) != .orderedSame {
-            throw CursorACPLaunchResolutionError.unsafeConfiguredCommand(configuredCommand)
-        }
-        return configuredCommand
+        return command
     }
 
     private func validatedLaunch(
         entryPath: String,
         configuredCommand: String,
         additionalPathHints: [String]
-    ) throws -> CursorACPResolvedLaunch {
-        guard entryPath.hasPrefix("/"),
-              URL(fileURLWithPath: entryPath).lastPathComponent.caseInsensitiveCompare(CursorACPLaunchCandidate.cursorAgentACP.command) == .orderedSame
-        else {
-            throw CursorACPLaunchResolutionError.exactPathNotFound(configuredCommand)
+    ) throws -> OpenCodeACPResolvedLaunch {
+        guard entryPath.hasPrefix("/") else {
+            throw OpenCodeACPLaunchResolutionError.exactPathNotFound(configuredCommand)
         }
 
         let identity: ExecutableFileIdentity
         do {
             identity = try ExecutableFileIdentity.capture(atPath: entryPath)
         } catch {
-            throw CursorACPLaunchResolutionError.exactPathNotFound(configuredCommand)
+            throw OpenCodeACPLaunchResolutionError.exactPathNotFound(configuredCommand)
         }
 
-        let canonicalURL = URL(fileURLWithPath: identity.canonicalPath)
-        if canonicalURL.pathComponents.contains(where: { $0.lowercased().hasSuffix(".app") }) {
-            throw CursorACPLaunchResolutionError.unsafeApplicationPath(identity.canonicalPath)
-        }
-        if canonicalURL.lastPathComponent.caseInsensitiveCompare("cursor") == .orderedSame {
-            throw CursorACPLaunchResolutionError.unsafeCanonicalBasename(identity.canonicalPath)
-        }
-
-        return CursorACPResolvedLaunch(
+        return OpenCodeACPResolvedLaunch(
             command: identity.canonicalPath,
-            arguments: CursorACPLaunchCandidate.cursorAgentACP.launchArguments,
+            arguments: Self.launchArguments,
             additionalPathHints: additionalPathHints,
             executableIdentity: identity
         )
     }
 
-    private func cachedLaunch(forKey key: String) -> CursorACPResolvedLaunch? {
+    private func cachedLaunch(forKey key: String) -> OpenCodeACPResolvedLaunch? {
         lock.lock()
         defer { lock.unlock() }
         return cachedLaunchByKey[key]
     }
 
-    private func cache(_ launch: CursorACPResolvedLaunch, key: String) {
+    private func cache(_ launch: OpenCodeACPResolvedLaunch, key: String) {
         lock.lock()
         cachedLaunchByKey[key] = launch
         lock.unlock()
@@ -248,7 +202,7 @@ final class CursorACPLaunchResolver: @unchecked Sendable {
         lock.unlock()
     }
 
-    private func cacheKey(for config: CursorAgentConfig) -> String {
+    private func cacheKey(for config: OpenCodeAgentConfig) -> String {
         ([config.commandName] + config.additionalPathHints).joined(separator: "\u{1F}")
     }
 }

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/OpenCode/OpenCodeACPModelPollingService.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/OpenCode/OpenCodeACPModelPollingService.swift
@@ -45,7 +45,7 @@ struct OpenCodeACPControllerModelDiscoveryClient: OpenCodeACPModelDiscoveryClien
             taskLabelKind: nil
         )
         guard let provider = providerFactory(.openCode, nil) else { return nil }
-        let support = await provider.support(for: request)
+        let support = try await provider.support(for: request)
         guard support == .supported else {
             throw AIProviderError.invalidConfiguration(
                 detail: support.reason ?? "OpenCode ACP is not available."

--- a/Sources/RepoPrompt/Infrastructure/MCP/MCPBootstrapLease.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/MCPBootstrapLease.swift
@@ -54,6 +54,13 @@ actor MCPBootstrapLease {
 
     private var hasAcquired = false
     private var hasReleased = false
+    private var cleanupRequested = false
+    private var ownsGate = false
+    private var routingRegistered = false
+    private var policyInstalled = false
+    private var didSignalRoutingFailure = false
+    private var didCleanupRouting = false
+    private var didClearPolicy = false
 
     /// Creates a unified bootstrap lease.
     ///
@@ -100,11 +107,20 @@ actor MCPBootstrapLease {
             acpLeaseLog("[ACP-Runner] lease run=\(spec.runID) gate=\(spec.gateID) enabling MCP server before gate acquire")
             await enabler()
             acpLeaseLog("[ACP-Runner] lease run=\(spec.runID) gate=\(spec.gateID) MCP server enabler completed")
+            if shouldAbortAcquire {
+                await cancelAndCleanup()
+                return false
+            }
         }
 
         // Register routing state before gate acquisition
         acpLeaseLog("[ACP-Runner] lease run=\(spec.runID) gate=\(spec.gateID) registering routing waiter")
         await MCPRoutingWaiter.register(runID: spec.runID)
+        routingRegistered = true
+        if shouldAbortAcquire {
+            await cancelAndCleanup()
+            return false
+        }
         #if DEBUG
             await ServerNetworkManager.shared.debugRecordRunRoutingEvent(
                 runID: spec.runID,
@@ -123,9 +139,12 @@ actor MCPBootstrapLease {
             // Atomically wait + acquire the global gate
             acpLeaseLog("[ACP-Runner] lease run=\(spec.runID) gate=\(spec.gateID) waiting to acquire global MCP gate")
             let gateAcquired = await HeadlessAgentConnectionGate.acquire(spec.gateID)
+            if gateAcquired {
+                ownsGate = true
+            }
             acpLeaseLog("[ACP-Runner] lease run=\(spec.runID) gate=\(spec.gateID) global MCP gate acquired=\(gateAcquired)")
-            if !gateAcquired || Task.isCancelled {
-                acpLeaseLog("[ACP-Runner] lease run=\(spec.runID) gate=\(spec.gateID) acquire() failed or task cancelled")
+            if !gateAcquired || shouldAbortAcquire {
+                acpLeaseLog("[ACP-Runner] lease run=\(spec.runID) gate=\(spec.gateID) acquire() failed, was released, or task cancelled")
                 await cancelAndCleanup()
                 return false
             }
@@ -133,12 +152,21 @@ actor MCPBootstrapLease {
             // Install per-run connection policy
             acpLeaseLog("[ACP-Runner] lease run=\(spec.runID) gate=\(spec.gateID) installing connection policy for client=\(spec.clientName ?? "<none>")")
             await policyInstaller(spec)
+            policyInstalled = true
+            if shouldAbortAcquire {
+                await cancelAndCleanup()
+                return false
+            }
             if spec.requiresExpectedAgentPID, let clientName = spec.clientName {
                 await ServerNetworkManager.shared.requireExpectedAgentPIDForPendingPolicy(
                     for: clientName,
                     runID: spec.runID,
                     windowID: spec.windowID
                 )
+                if shouldAbortAcquire {
+                    await cancelAndCleanup()
+                    return false
+                }
             }
             #if DEBUG
                 await ServerNetworkManager.shared.debugRecordRunRoutingEvent(
@@ -153,8 +181,8 @@ actor MCPBootstrapLease {
                 )
             #endif
             acpLeaseLog("[ACP-Runner] lease run=\(spec.runID) gate=\(spec.gateID) connection policy installed")
-            if Task.isCancelled {
-                acpLeaseLog("[ACP-Runner] lease run=\(spec.runID) gate=\(spec.gateID) task cancelled after policy install")
+            if shouldAbortAcquire {
+                acpLeaseLog("[ACP-Runner] lease run=\(spec.runID) gate=\(spec.gateID) task cancelled or lease released after policy install")
                 await cancelAndCleanup()
                 return false
             }
@@ -197,6 +225,8 @@ actor MCPBootstrapLease {
             gateID: spec.gateID,
             timeoutMs: timeoutMs
         )
+        ownsGate = false
+        didCleanupRouting = true
         acpLeaseLog("[ACP-Runner] lease run=\(spec.runID) gate=\(spec.gateID) releaseWhenRouted() completed routed=\(routed)")
         #if DEBUG
             await ServerNetworkManager.shared.debugRecordRunRoutingEvent(
@@ -228,7 +258,9 @@ actor MCPBootstrapLease {
         hasReleased = true
         acpLeaseLog("[ACP-Runner] lease run=\(spec.runID) gate=\(spec.gateID) releasing gate without waiting for routing")
         _ = await HeadlessAgentConnectionGate.completeIfActive(spec.gateID)
+        ownsGate = false
         await AgentRunCoordinator.shared.cleanupRouting(runID: spec.runID)
+        didCleanupRouting = true
     }
 
     // MARK: - Failure & Cancellation
@@ -246,49 +278,63 @@ actor MCPBootstrapLease {
 
     /// Hard failure path variant used by headless flows.
     func failAndCleanup() async {
-        if hasReleased {
-            acpLeaseLog("[ACP-Runner] lease run=\(spec.runID) gate=\(spec.gateID) failAndCleanup() ignored because lease already released")
-            return
-        }
+        cleanupRequested = true
         hasReleased = true
-
         acpLeaseLog("[ACP-Runner] lease run=\(spec.runID) gate=\(spec.gateID) failAndCleanup() signaling failure and clearing policy")
-        await MCPRoutingWaiter.notifyFailed(runID: spec.runID)
-        _ = await HeadlessAgentConnectionGate.completeIfActive(spec.gateID)
-
-        await MCPRoutingWaiter.cleanup(runID: spec.runID)
-        await policyClearer(spec)
+        await performCancellationCleanup(reason: "failed")
     }
 
-    /// Cancellation path: signal failure, release gate, clear policy, clean up routing.
+    /// Cancellation path: signal failure, release any gate ownership that materializes,
+    /// clear installed policy, and clean up routing. Cleanup remains retryable while a
+    /// queued gate acquisition is still suspended.
     func cancelAndCleanup() async {
-        if hasReleased {
-            acpLeaseLog("[ACP-Runner] lease run=\(spec.runID) gate=\(spec.gateID) cancelAndCleanup() ignored because lease already released")
-            return
-        }
+        cleanupRequested = true
         hasReleased = true
         acpLeaseLog("[ACP-Runner] lease run=\(spec.runID) gate=\(spec.gateID) cancelAndCleanup() signaling failure and releasing gate")
+        await performCancellationCleanup(reason: "cancelled")
+    }
+
+    private var shouldAbortAcquire: Bool {
+        cleanupRequested || hasReleased || Task.isCancelled
+    }
+
+    private func performCancellationCleanup(reason: String) async {
         #if DEBUG
             await ServerNetworkManager.shared.debugRecordRunRoutingEvent(
                 runID: spec.runID,
                 event: "lease_cancelled",
                 fields: [
                     "client_name": spec.clientName ?? "nil",
-                    "gate_id": spec.gateID.uuidString
+                    "gate_id": spec.gateID.uuidString,
+                    "reason": reason
                 ]
             )
         #endif
-        await MCPRoutingWaiter.notifyFailed(runID: spec.runID)
-        _ = await HeadlessAgentConnectionGate.completeIfActive(spec.gateID)
-        await AgentRunCoordinator.shared.cleanupRouting(runID: spec.runID)
-        await policyClearer(spec)
+        if routingRegistered, !didSignalRoutingFailure {
+            didSignalRoutingFailure = true
+            await MCPRoutingWaiter.notifyFailed(runID: spec.runID)
+        }
+        if ownsGate {
+            _ = await HeadlessAgentConnectionGate.completeIfActive(spec.gateID)
+            ownsGate = false
+        }
+        if routingRegistered, !didCleanupRouting {
+            didCleanupRouting = true
+            await AgentRunCoordinator.shared.cleanupRouting(runID: spec.runID)
+        }
+        if policyInstalled, !didClearPolicy {
+            didClearPolicy = true
+            await policyClearer(spec)
+        }
         #if DEBUG
             await ServerNetworkManager.shared.debugRecordRunRoutingEvent(
                 runID: spec.runID,
                 event: "lease_cleanup_completed",
                 fields: [
                     "client_name": spec.clientName ?? "nil",
-                    "reason": "cancelled"
+                    "reason": reason,
+                    "owns_gate": String(ownsGate),
+                    "policy_installed": String(policyInstalled)
                 ]
             )
         #endif

--- a/Sources/RepoPrompt/Infrastructure/MCP/MCPBootstrapLease.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/MCPBootstrapLease.swift
@@ -105,6 +105,18 @@ actor MCPBootstrapLease {
         // Register routing state before gate acquisition
         acpLeaseLog("[ACP-Runner] lease run=\(spec.runID) gate=\(spec.gateID) registering routing waiter")
         await MCPRoutingWaiter.register(runID: spec.runID)
+        #if DEBUG
+            await ServerNetworkManager.shared.debugRecordRunRoutingEvent(
+                runID: spec.runID,
+                event: "routing_waiter_registered",
+                fields: [
+                    "client_name": spec.clientName ?? "nil",
+                    "window_id": String(spec.windowID),
+                    "tab_id": spec.tabID?.uuidString ?? "nil",
+                    "gate_id": spec.gateID.uuidString
+                ]
+            )
+        #endif
         acpLeaseLog("[ACP-Runner] lease run=\(spec.runID) gate=\(spec.gateID) routing waiter registered")
 
         return await withTaskCancellationHandler {
@@ -128,6 +140,18 @@ actor MCPBootstrapLease {
                     windowID: spec.windowID
                 )
             }
+            #if DEBUG
+                await ServerNetworkManager.shared.debugRecordRunRoutingEvent(
+                    runID: spec.runID,
+                    event: "lease_policy_ready",
+                    fields: [
+                        "client_name": spec.clientName ?? "nil",
+                        "requires_expected_pid": String(spec.requiresExpectedAgentPID),
+                        "window_id": String(spec.windowID),
+                        "tab_id": spec.tabID?.uuidString ?? "nil"
+                    ]
+                )
+            #endif
             acpLeaseLog("[ACP-Runner] lease run=\(spec.runID) gate=\(spec.gateID) connection policy installed")
             if Task.isCancelled {
                 acpLeaseLog("[ACP-Runner] lease run=\(spec.runID) gate=\(spec.gateID) task cancelled after policy install")
@@ -157,12 +181,34 @@ actor MCPBootstrapLease {
         hasReleased = true
 
         acpLeaseLog("[ACP-Runner] lease run=\(spec.runID) gate=\(spec.gateID) releaseWhenRouted() waiting for routing client=\(spec.clientName ?? "<none>") timeoutMs=\(timeoutMs)")
+        #if DEBUG
+            await ServerNetworkManager.shared.debugRecordRunRoutingEvent(
+                runID: spec.runID,
+                event: "route_wait_started",
+                fields: [
+                    "client_name": spec.clientName ?? "nil",
+                    "timeout_ms": String(timeoutMs),
+                    "gate_id": spec.gateID.uuidString
+                ]
+            )
+        #endif
         let routed = await AgentRunCoordinator.shared.releaseGateWhenRouted(
             runID: spec.runID,
             gateID: spec.gateID,
             timeoutMs: timeoutMs
         )
         acpLeaseLog("[ACP-Runner] lease run=\(spec.runID) gate=\(spec.gateID) releaseWhenRouted() completed routed=\(routed)")
+        #if DEBUG
+            await ServerNetworkManager.shared.debugRecordRunRoutingEvent(
+                runID: spec.runID,
+                event: "route_wait_completed",
+                fields: [
+                    "client_name": spec.clientName ?? "nil",
+                    "routed": String(routed),
+                    "gate_id": spec.gateID.uuidString
+                ]
+            )
+        #endif
 
         if !routed {
             acpLeaseLog("[ACP-Runner] lease run=\(spec.runID) gate=\(spec.gateID) routing wait failed or timed out; clearing connection policy")
@@ -194,7 +240,7 @@ actor MCPBootstrapLease {
             return
         }
         acpLeaseLog("[ACP-Runner] lease run=\(spec.runID) gate=\(spec.gateID) failAndRelease() signaling routing failure")
-        MCPRoutingWaiter.signalFailed(spec.runID)
+        await MCPRoutingWaiter.notifyFailed(runID: spec.runID)
         _ = await releaseWhenRouted()
     }
 
@@ -207,7 +253,7 @@ actor MCPBootstrapLease {
         hasReleased = true
 
         acpLeaseLog("[ACP-Runner] lease run=\(spec.runID) gate=\(spec.gateID) failAndCleanup() signaling failure and clearing policy")
-        MCPRoutingWaiter.signalFailed(spec.runID)
+        await MCPRoutingWaiter.notifyFailed(runID: spec.runID)
         _ = await HeadlessAgentConnectionGate.completeIfActive(spec.gateID)
 
         await MCPRoutingWaiter.cleanup(runID: spec.runID)
@@ -222,10 +268,30 @@ actor MCPBootstrapLease {
         }
         hasReleased = true
         acpLeaseLog("[ACP-Runner] lease run=\(spec.runID) gate=\(spec.gateID) cancelAndCleanup() signaling failure and releasing gate")
-        MCPRoutingWaiter.signalFailed(spec.runID)
+        #if DEBUG
+            await ServerNetworkManager.shared.debugRecordRunRoutingEvent(
+                runID: spec.runID,
+                event: "lease_cancelled",
+                fields: [
+                    "client_name": spec.clientName ?? "nil",
+                    "gate_id": spec.gateID.uuidString
+                ]
+            )
+        #endif
+        await MCPRoutingWaiter.notifyFailed(runID: spec.runID)
         _ = await HeadlessAgentConnectionGate.completeIfActive(spec.gateID)
         await AgentRunCoordinator.shared.cleanupRouting(runID: spec.runID)
         await policyClearer(spec)
+        #if DEBUG
+            await ServerNetworkManager.shared.debugRecordRunRoutingEvent(
+                runID: spec.runID,
+                event: "lease_cleanup_completed",
+                fields: [
+                    "client_name": spec.clientName ?? "nil",
+                    "reason": "cancelled"
+                ]
+            )
+        #endif
     }
 
     // MARK: - Default Policy Hooks

--- a/Sources/RepoPrompt/Infrastructure/MCP/MCPConnectionManager.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/MCPConnectionManager.swift
@@ -944,6 +944,9 @@ actor ServerNetworkManager {
         private var debugShouldSuspendNextPendingPolicyRouteInstallation = false
         private var debugPendingPolicyRouteInstallationIsSuspended = false
         private var debugPendingPolicyRouteInstallationResumeWaiters: [CheckedContinuation<Void, Never>] = []
+        private var debugShouldSuspendNextPendingPolicyCommit = false
+        private var debugPendingPolicyCommitIsSuspended = false
+        private var debugPendingPolicyCommitResumeWaiters: [CheckedContinuation<Void, Never>] = []
     #endif
     private var expectedAgentPIDsByClient: [String: Set<pid_t>] = [:]
     private var expectedAgentPIDsByRunID: [UUID: Set<pid_t>] = [:]
@@ -1685,7 +1688,8 @@ actor ServerNetworkManager {
         _ connectionID: UUID,
         runID: UUID,
         windowID explicitWindowID: Int? = nil,
-        persistWindowBinding: Bool = true
+        persistWindowBinding: Bool = true,
+        signalRouting: Bool = true
     ) async -> Bool {
         let resolvedWindowID: Int? = if let explicitWindowID {
             explicitWindowID
@@ -1710,6 +1714,9 @@ actor ServerNetworkManager {
             return mappedRun == runID && mappedConnection == connectionID
         }
         if alreadyMapped {
+            if signalRouting {
+                await MCPRoutingWaiter.notifyRouted(runID: runID)
+            }
             if persistWindowBinding, connectionWindowMap[connectionID] != windowID {
                 setConnectionWindowMapping(connectionID, windowID: windowID)
             }
@@ -1730,7 +1737,8 @@ actor ServerNetworkManager {
             let didRegister = window.mcpServer.registerRunIDMapping(
                 connectionID: connectionID,
                 runID: runID,
-                windowID: windowID
+                windowID: windowID,
+                signalRouting: signalRouting
             )
             if didRegister {
                 connectionLog("mapConnectionToRunID: mapped connection \(connectionID) to runID \(runID) in window \(windowID)")
@@ -3426,7 +3434,8 @@ actor ServerNetworkManager {
                             clientName: clientInfo.name,
                             connectionID: connectionID,
                             clientPid: clientPid,
-                            bootstrapClientName: bootstrapClientName
+                            bootstrapClientName: bootstrapClientName,
+                            expectedLifecycleGeneration: expectedLifecycleGeneration
                         )
                         guard self.isCurrentConnection(connectionID, lifecycleGeneration: expectedLifecycleGeneration) else { return false }
                         if case let .rejected(runID, reason) = policyOutcome {
@@ -4827,6 +4836,26 @@ actor ServerNetworkManager {
             waiters.forEach { $0.resume() }
         }
 
+        func debugInvalidatePendingPolicyApplication(connectionID: UUID) {
+            pendingConnections.removeValue(forKey: connectionID)
+        }
+
+        func debugSuspendNextPendingPolicyCommit() {
+            debugShouldSuspendNextPendingPolicyCommit = true
+        }
+
+        func debugIsPendingPolicyCommitSuspended() -> Bool {
+            debugPendingPolicyCommitIsSuspended
+        }
+
+        func debugResumePendingPolicyCommit() {
+            debugShouldSuspendNextPendingPolicyCommit = false
+            debugPendingPolicyCommitIsSuspended = false
+            let waiters = debugPendingPolicyCommitResumeWaiters
+            debugPendingPolicyCommitResumeWaiters.removeAll()
+            waiters.forEach { $0.resume() }
+        }
+
         private func debugSuspendPendingPolicyRouteInstallationIfNeeded() async {
             guard debugShouldSuspendNextPendingPolicyRouteInstallation else { return }
             debugShouldSuspendNextPendingPolicyRouteInstallation = false
@@ -4835,6 +4864,16 @@ actor ServerNetworkManager {
                 debugPendingPolicyRouteInstallationResumeWaiters.append(continuation)
             }
             debugPendingPolicyRouteInstallationIsSuspended = false
+        }
+
+        private func debugSuspendPendingPolicyCommitIfNeeded() async {
+            guard debugShouldSuspendNextPendingPolicyCommit else { return }
+            debugShouldSuspendNextPendingPolicyCommit = false
+            debugPendingPolicyCommitIsSuspended = true
+            await withCheckedContinuation { continuation in
+                debugPendingPolicyCommitResumeWaiters.append(continuation)
+            }
+            debugPendingPolicyCommitIsSuspended = false
         }
 
         func debugPendingPolicySnapshot(for clientName: String) -> [(windowID: Int, tabID: UUID?, runID: UUID?, oneShot: Bool, purpose: MCPRunPurpose)] {
@@ -6795,7 +6834,8 @@ actor ServerNetworkManager {
         clientPid: Int? = nil,
         bootstrapClientName: String? = nil,
         pidGateTimeout: TimeInterval = 2.0,
-        requireRunRouting: Bool = true
+        requireRunRouting: Bool = true,
+        expectedLifecycleGeneration: UInt64? = nil
     ) async -> PendingPolicyApplicationOutcome {
         if let reservedEntry = oldestReservedPendingPolicyEntry(for: clientName),
            canConsumePendingPolicy(reservedEntry.policy, clientName: clientName, clientPid: clientPid)
@@ -7027,6 +7067,28 @@ actor ServerNetworkManager {
             await debugSuspendPendingPolicyRouteInstallationIfNeeded()
         #endif
 
+        guard isPendingPolicyApplicationCurrent(
+            connectionID: connectionID,
+            clientName: clientName,
+            expectedLifecycleGeneration: expectedLifecycleGeneration
+        ) else {
+            if policy.oneShot {
+                _ = rollbackOneShotPendingPolicyReservation(
+                    id: policy.id,
+                    key: matchedQueueEntry.key,
+                    connectionID: connectionID
+                )
+            }
+            await rollbackPendingPolicyApplication(
+                policy,
+                clientName: clientName,
+                connectionID: connectionID,
+                restorePoint: restorePoint,
+                signalRoutingFailure: false
+            )
+            return .rejected(runID: policy.runID, reason: "stale_connection")
+        }
+
         if requireRunRouting, let runID = policy.runID {
             let routed: Bool
             if let tabID = policy.tabID {
@@ -7036,13 +7098,15 @@ actor ServerNetworkManager {
                     clientName: clientName,
                     windowID: policy.windowID,
                     tabID: tabID,
-                    runID: runID
+                    runID: runID,
+                    signalRouting: false
                 )
             } else {
                 routed = await mapConnectionToRunID(
                     connectionID,
                     runID: runID,
-                    windowID: policy.windowID
+                    windowID: policy.windowID,
+                    signalRouting: false
                 )
             }
             #if DEBUG
@@ -7074,6 +7138,32 @@ actor ServerNetworkManager {
                     reason: reservationRolledBack ? "route_mapping_failed" : "policy_removed"
                 )
             }
+
+            #if DEBUG
+                await debugSuspendPendingPolicyCommitIfNeeded()
+            #endif
+
+            guard isPendingPolicyApplicationCurrent(
+                connectionID: connectionID,
+                clientName: clientName,
+                expectedLifecycleGeneration: expectedLifecycleGeneration
+            ) else {
+                if policy.oneShot {
+                    _ = rollbackOneShotPendingPolicyReservation(
+                        id: policy.id,
+                        key: matchedQueueEntry.key,
+                        connectionID: connectionID
+                    )
+                }
+                await rollbackPendingPolicyApplication(
+                    policy,
+                    clientName: clientName,
+                    connectionID: connectionID,
+                    restorePoint: restorePoint,
+                    signalRoutingFailure: false
+                )
+                return .rejected(runID: runID, reason: "stale_connection")
+            }
         }
 
         if policy.oneShot,
@@ -7090,6 +7180,10 @@ actor ServerNetworkManager {
                 restorePoint: restorePoint
             )
             return .rejected(runID: policy.runID, reason: "policy_removed")
+        }
+
+        if requireRunRouting, let runID = policy.runID {
+            await MCPRoutingWaiter.notifyRouted(runID: runID)
         }
 
         let grantDescription = Self.describeGrantedTools(restricted: policy.restrictedTools)
@@ -7155,11 +7249,23 @@ actor ServerNetworkManager {
         return .applied(runID: policy.runID)
     }
 
+    private func isPendingPolicyApplicationCurrent(
+        connectionID: UUID,
+        clientName: String,
+        expectedLifecycleGeneration: UInt64?
+    ) -> Bool {
+        if let expectedLifecycleGeneration {
+            return isCurrentConnection(connectionID, lifecycleGeneration: expectedLifecycleGeneration)
+        }
+        return pendingConnections[connectionID] == clientName
+    }
+
     private func rollbackPendingPolicyApplication(
         _ policy: ClientConnectionPolicy,
         clientName: String,
         connectionID: UUID,
-        restorePoint: PendingPolicyRestorePoint
+        restorePoint: PendingPolicyRestorePoint,
+        signalRoutingFailure: Bool = true
     ) async {
         if let runID = policy.runID {
             await MainActor.run {
@@ -7170,7 +7276,11 @@ actor ServerNetworkManager {
                     windowID: policy.windowID,
                     runID: runID
                 )
-                window.mcpServer.cleanupRunIDMapping(runID: runID, connectionID: connectionID)
+                window.mcpServer.cleanupRunIDMapping(
+                    runID: runID,
+                    connectionID: connectionID,
+                    signalRoutingFailure: signalRoutingFailure
+                )
             }
             restorePendingPolicyState(
                 restorePoint,
@@ -7243,7 +7353,8 @@ actor ServerNetworkManager {
         clientName: String,
         windowID: Int,
         tabID: UUID,
-        runID: UUID
+        runID: UUID,
+        signalRouting: Bool = true
     ) async -> Bool {
         let resolved = await MainActor.run { () -> (workspaceID: UUID, snapshot: ComposeTabState, routed: Bool)? in
             guard let windowState = WindowStatesManager.shared.window(withID: windowID) else {
@@ -7258,7 +7369,8 @@ actor ServerNetworkManager {
                 windowID: windowID,
                 workspaceID: resolved.workspaceID,
                 snapshot: resolved.snapshot,
-                runID: runID
+                runID: runID,
+                signalRouting: signalRouting
             )
             let routed = UUID(uuidString: clientID).map { connectionID in
                 windowState.mcpServer.connectionID(forRunID: runID) == connectionID

--- a/Sources/RepoPrompt/Infrastructure/MCP/MCPConnectionManager.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/MCPConnectionManager.swift
@@ -753,6 +753,15 @@ actor ServerNetworkManager {
             let transportIngress: MCPTransportIngressSnapshot?
         }
 
+        private struct DebugRunRoutingEvent {
+            let seq: UInt64
+            let timestamp: Date
+            let runID: UUID
+            let event: String
+            let connectionID: UUID?
+            let fields: [String: String]
+        }
+
         private struct DebugRetainedTransportIngress {
             let snapshot: MCPTransportIngressSnapshot
             let clientName: String?
@@ -768,11 +777,15 @@ actor ServerNetworkManager {
 
         private var debugConnectionHistory: [DebugConnectionEvent] = []
         private var debugConnectionHistorySeq: UInt64 = 0
+        private var debugRunRoutingHistory: [DebugRunRoutingEvent] = []
+        private var debugRunRoutingHistorySeq: UInt64 = 0
+        private var debugRunRoutingHistoryDroppedCount = 0
         private var debugRestartStatesByID: [UUID: DebugRestartStatus] = [:]
         private var debugRetainedTransportIngressByConnectionID: [UUID: DebugRetainedTransportIngress] = [:]
         private var debugRetainedTransportIngressOrder: [UUID] = []
         private var debugRecordedTransportTerminalConnectionIDs: Set<UUID> = []
         private let debugConnectionHistoryLimit = 1000
+        private let debugRunRoutingHistoryLimit = 1000
         private let debugRetainedTransportIngressLimit = 100
         private let debugRestartStatusLimit = 50
         private var debugResolvedToolOperationOverrides: [String: @Sendable () async throws -> Value] = [:]
@@ -852,6 +865,7 @@ actor ServerNetworkManager {
     /// the policy expires. This keeps Context Builder sandboxes from leaking into shared MCP sessions yet
     /// still allows intentional overrides when necessary.
     private struct ClientConnectionPolicy {
+        let id: UUID
         let windowID: Int
         let restrictedTools: Set<String>
         let oneShot: Bool
@@ -872,6 +886,8 @@ actor ServerNetworkManager {
         /// When true, only an MCP peer whose verified PID descends from a registered
         /// expected agent PID may consume this queued policy.
         var requiresExpectedAgentPID: Bool
+        /// One-shot policies stay queued but unavailable while route installation awaits.
+        var reservationConnectionID: UUID?
     }
 
     /// Run-scoped policy state captured when the first connection for a run is admitted.
@@ -904,7 +920,31 @@ actor ServerNetworkManager {
         case timedOut
     }
 
+    private enum PendingPolicyApplicationOutcome: Equatable {
+        case applied(runID: UUID?)
+        case fallback
+        case rejected(runID: UUID?, reason: String)
+    }
+
+    private struct PendingPolicyRestorePoint {
+        let restrictedTools: Set<String>?
+        let additionalTools: Set<String>?
+        let runPurpose: MCPRunPurpose?
+        let windowID: Int?
+        let windowAssignment: Int?
+        let runID: UUID?
+        let wasPreassigned: Bool
+        let wasRunAdmitted: Bool
+        let runPolicyState: RunConnectionPolicyState?
+        let runWindowID: Int?
+    }
+
     private var pendingPoliciesByClient: [String: [ClientConnectionPolicy]] = [:]
+    #if DEBUG
+        private var debugShouldSuspendNextPendingPolicyRouteInstallation = false
+        private var debugPendingPolicyRouteInstallationIsSuspended = false
+        private var debugPendingPolicyRouteInstallationResumeWaiters: [CheckedContinuation<Void, Never>] = []
+    #endif
     private var expectedAgentPIDsByClient: [String: Set<pid_t>] = [:]
     private var expectedAgentPIDsByRunID: [UUID: Set<pid_t>] = [:]
     private var runPolicyStateByRunID: [UUID: RunConnectionPolicyState] = [:]
@@ -2867,13 +2907,19 @@ actor ServerNetworkManager {
         // If this session token already has a live connection, we will replace it after accept.
         let replacedIDForCapacity = existingConnectionID(forSessionToken: sessionToken)
 
-        _ = await awaitAgentBootstrapPolicyBeforeAcceptIfNeeded(
+        let policyReadiness = await awaitAgentBootstrapPolicyBeforeAcceptIfNeeded(
             bootstrapClientName: clientName,
             connectionID: connectionID,
             sessionKey: sessionToken,
             clientPid: clientPid,
             isReplacementForSession: replacedIDForCapacity != nil
         )
+        if policyReadiness == .timedOut {
+            return .reject(.rejected(
+                reason: "Agent policy admission timed out.",
+                errorCode: MCPBootstrapErrorCode.serverNotReady.rawValue
+            ))
+        }
         guard isCurrentBootstrapListener(sourceListener, lifecycleGeneration: admissionLifecycleGeneration) else {
             return rejectBootstrapAdmissionBecauseStopped(connectionID: connectionID)
         }
@@ -3330,6 +3376,39 @@ actor ServerNetworkManager {
                     guard self.isCurrentConnection(connectionID, lifecycleGeneration: expectedLifecycleGeneration) else { return false }
                     connectionLog("Approval handler returned \(approved) for \(connectionID)")
                     if approved {
+                        #if DEBUG
+                            let diagnosticPolicy = self.oldestPendingPolicyEntry(for: clientInfo.name) { policy in
+                                self.canConsumePendingPolicy(
+                                    policy,
+                                    clientName: clientInfo.name,
+                                    clientPid: clientPid
+                                )
+                            }
+                            if let diagnosticPolicy, let runID = diagnosticPolicy.policy.runID {
+                                let expectedPIDs = self.expectedAgentPIDs(for: clientInfo.name, runID: runID)
+                                    .map(String.init)
+                                    .sorted()
+                                    .joined(separator: ",")
+                                self.debugRecordRunRoutingEvent(
+                                    runID: runID,
+                                    event: "client_identity_observed",
+                                    connectionID: connectionID,
+                                    fields: [
+                                        "bootstrap_client_name": bootstrapClientName ?? "nil",
+                                        "authoritative_client_name": clientInfo.name,
+                                        "helper_peer_pid": String(clientPid),
+                                        "ancestor_chain": self.pidAncestorChainDescription(from: pid_t(clientPid)),
+                                        "expected_pids": expectedPIDs,
+                                        "pending_policy_key": diagnosticPolicy.key,
+                                        "policy_consumable": String(self.canConsumePendingPolicy(
+                                            diagnosticPolicy.policy,
+                                            clientName: clientInfo.name,
+                                            clientPid: clientPid
+                                        ))
+                                    ]
+                                )
+                            }
+                        #endif
                         let readiness = await self.awaitAgentPolicyAdmissionIfNeeded(
                             clientName: clientInfo.name,
                             bootstrapClientName: bootstrapClientName,
@@ -3343,13 +3422,20 @@ actor ServerNetworkManager {
                             return false
                         }
 
-                        await self.applyPendingPolicyIfAvailable(
+                        let policyOutcome = await self.applyPendingPolicyIfAvailable(
                             clientName: clientInfo.name,
                             connectionID: connectionID,
                             clientPid: clientPid,
                             bootstrapClientName: bootstrapClientName
                         )
                         guard self.isCurrentConnection(connectionID, lifecycleGeneration: expectedLifecycleGeneration) else { return false }
+                        if case let .rejected(runID, reason) = policyOutcome {
+                            mcpPolicyLog(
+                                "rejected MCP initialize after pid-gated policy wait client=\(clientInfo.name) connection=\(connectionID) runID=\(runID?.uuidString ?? "nil") reason=\(reason)"
+                            )
+                            self.pendingConnections.removeValue(forKey: connectionID)
+                            return false
+                        }
                         self.notifyConnectionWaiters(
                             connectionID: connectionID,
                             clientName: clientInfo.name,
@@ -4260,6 +4346,19 @@ actor ServerNetworkManager {
         mcpPolicyLog(
             "registered expected agent pid client=\(clientName) storageKey=\(storageKey) pid=\(pid) runID=\(runID?.uuidString ?? "nil") count=\(pids.count)"
         )
+        #if DEBUG
+            if let runID {
+                debugRecordRunRoutingEvent(
+                    runID: runID,
+                    event: "expected_pid_registered",
+                    fields: [
+                        "client_name": clientName,
+                        "expected_pid": String(pid),
+                        "expected_pid_count": String((expectedAgentPIDsByRunID[runID] ?? []).count)
+                    ]
+                )
+            }
+        #endif
     }
 
     func clearExpectedAgentPID(_ pid: pid_t, for clientName: String, runID: UUID? = nil) {
@@ -4288,6 +4387,19 @@ actor ServerNetworkManager {
         mcpPolicyLog(
             "cleared expected agent pid client=\(clientName) pid=\(pid) runID=\(runID?.uuidString ?? "nil") removed=\(removedCount)"
         )
+        #if DEBUG
+            if let runID {
+                debugRecordRunRoutingEvent(
+                    runID: runID,
+                    event: "expected_pid_cleared",
+                    fields: [
+                        "client_name": clientName,
+                        "expected_pid": String(pid),
+                        "removed_count": String(removedCount)
+                    ]
+                )
+            }
+        #endif
     }
 
     private func removeExpectedAgentPID(_ pid: pid_t, forRunID runID: UUID) {
@@ -4319,7 +4431,8 @@ actor ServerNetworkManager {
         matching clientPid: Int
     ) -> (key: String, index: Int, policy: ClientConnectionPolicy)? {
         oldestPendingPolicyEntry(for: clientName) { policy in
-            policy.requiresExpectedAgentPID
+            policy.reservationConnectionID == nil
+                && policy.requiresExpectedAgentPID
                 && canConsumePendingPolicy(policy, clientName: clientName, clientPid: clientPid)
         }
     }
@@ -4366,6 +4479,11 @@ actor ServerNetworkManager {
         else {
             return .notRequired
         }
+        // Do not spend the ownership wait twice. A PID-gated policy is checked and
+        // consumed atomically after the authoritative MCP initialize identity arrives.
+        if hasPIDGatedPendingPolicy(for: bootstrapClientName) {
+            return .ready
+        }
         if let readiness = directAgentBootstrapAdmissionStatus(
             clientName: bootstrapClientName,
             sessionKey: sessionKey,
@@ -4402,10 +4520,13 @@ actor ServerNetworkManager {
             }
         }
 
-        mcpPolicyLog(
-            "allowing direct agent bootstrap without pending pid-owned policy client=\(bootstrapClientName) connection=\(connectionID) clientPid=\(clientPid) ancestorChain=[\(ancestorDescription)] timeout=\(timeout)s"
+        log.warning(
+            "Rejecting direct agent bootstrap \(connectionID) for known client '\(bootstrapClientName)' - expected policy or live run affinity did not become consumable within \(timeout)s"
         )
-        return .notRequired
+        mcpPolicyLog(
+            "rejected direct agent bootstrap client=\(bootstrapClientName) connection=\(connectionID) reason=policy_admission_timeout clientPid=\(clientPid) ancestorChain=[\(ancestorDescription)] timeout=\(timeout)s"
+        )
+        return .timedOut
     }
 
     private func awaitAgentPolicyAdmissionIfNeeded(
@@ -4420,20 +4541,11 @@ actor ServerNetworkManager {
             return .notRequired
         }
 
-        let isDirectAgentBootstrap = bootstrapClientName.map { bootstrapName in
-            Self.isKnownAgentClientName(bootstrapName) && MCPClientIdentity.matches(bootstrapName, clientName)
-        } ?? false
-        if isDirectAgentBootstrap,
-           hasPIDGatedPendingPolicy(for: clientName),
-           oldestPIDGatedPendingPolicyEntry(for: clientName, matching: clientPid) == nil
-        {
-            return await waitForDirectAgentBootstrapOwnership(
-                clientName: clientName,
-                connectionID: connectionID,
-                clientPid: clientPid,
-                timeout: timeout,
-                holdReason: "direct_agent_mcp_initialize"
-            )
+        // PID-gated ownership is resolved atomically at policy consumption. This covers
+        // helper bootstrap identities (for example repoprompt_ce_cli_debug) that transition
+        // to an authoritative provider identity before the ACP parent PID is registered.
+        if hasPIDGatedPendingPolicy(for: clientName) {
+            return .ready
         }
 
         if hasAgentPolicyAdmissionTarget(clientName: clientName, sessionKey: sessionKey, clientPid: clientPid) {
@@ -4454,36 +4566,6 @@ actor ServerNetworkManager {
             timeout: timeout,
             holdReason: "mcp_initialize"
         )
-    }
-
-    private func waitForDirectAgentBootstrapOwnership(
-        clientName: String,
-        connectionID: UUID,
-        clientPid: Int,
-        timeout: TimeInterval,
-        holdReason: String
-    ) async -> AgentPolicyAdmissionReadiness {
-        let deadline = Date().addingTimeInterval(timeout)
-        while Date() < deadline {
-            if Task.isCancelled {
-                return .timedOut
-            }
-            if oldestPIDGatedPendingPolicyEntry(for: clientName, matching: clientPid) != nil {
-                return .ready
-            }
-            if !hasPIDGatedPendingPolicy(for: clientName),
-               expectedAgentPIDs(for: clientName).isEmpty
-            {
-                return .notRequired
-            }
-            try? await Task.sleep(for: .milliseconds(50))
-        }
-
-        let ancestorDescription = pidAncestorChainDescription(from: pid_t(clientPid))
-        mcpPolicyLog(
-            "allowing direct agent MCP initialize without pid-owned policy client=\(clientName) connection=\(connectionID) holdReason=\(holdReason) clientPid=\(clientPid) ancestorChain=[\(ancestorDescription)] timeout=\(timeout)s"
-        )
-        return .notRequired
     }
 
     private func waitForAgentPolicyAdmission(
@@ -4591,6 +4673,7 @@ actor ServerNetworkManager {
         pruneExpiredPolicies(for: clientName)
         let sanitizedRestricted = Self.sanitizedRoutingRestrictedTools(restrictedTools)
         let policy = ClientConnectionPolicy(
+            id: UUID(),
             windowID: windowID,
             restrictedTools: sanitizedRestricted,
             oneShot: oneShot,
@@ -4603,7 +4686,8 @@ actor ServerNetworkManager {
             purpose: purpose,
             taskLabelKind: taskLabelKind,
             allowsAgentExternalControlTools: allowsAgentExternalControlTools,
-            requiresExpectedAgentPID: requiresExpectedAgentPID
+            requiresExpectedAgentPID: requiresExpectedAgentPID,
+            reservationConnectionID: nil
         )
         let grantDescription = Self.describeGrantedTools(restricted: sanitizedRestricted)
         let restrictedDescription = Self.describeToolList(sanitizedRestricted)
@@ -4633,6 +4717,7 @@ actor ServerNetworkManager {
             let beforeCount = queue.count
             queue.removeAll {
                 guard
+                    $0.reservationConnectionID == nil,
                     $0.oneShot,
                     $0.purpose == .agentModeRun,
                     $0.windowID == windowID
@@ -4680,6 +4765,24 @@ actor ServerNetworkManager {
         mcpPolicyLog(
             "installed policy client=\(clientName) storageKey=\(storageKey) window=\(windowID) purpose=\(purpose.rawValue) oneShot=\(oneShot) ttl=\(ttl)s runID=\(runID?.uuidString ?? "nil") tabID=\(tabID?.uuidString ?? "nil") requiresExpectedPID=\(requiresExpectedAgentPID) queueCount=\(queue.count)"
         )
+        #if DEBUG
+            if let runID {
+                debugRecordRunRoutingEvent(
+                    runID: runID,
+                    event: "policy_installed",
+                    fields: [
+                        "client_name": clientName,
+                        "pending_policy_key": storageKey,
+                        "window_id": String(windowID),
+                        "tab_id": tabID?.uuidString ?? "nil",
+                        "purpose": purpose.rawValue,
+                        "one_shot": String(oneShot),
+                        "requires_expected_pid": String(requiresExpectedAgentPID),
+                        "queue_count": String(queue.count)
+                    ]
+                )
+            }
+        #endif
     }
 
     func requireExpectedAgentPIDForPendingPolicy(
@@ -4708,6 +4811,32 @@ actor ServerNetworkManager {
     }
 
     #if DEBUG
+        func debugSuspendNextPendingPolicyRouteInstallation() {
+            debugShouldSuspendNextPendingPolicyRouteInstallation = true
+        }
+
+        func debugIsPendingPolicyRouteInstallationSuspended() -> Bool {
+            debugPendingPolicyRouteInstallationIsSuspended
+        }
+
+        func debugResumePendingPolicyRouteInstallation() {
+            debugShouldSuspendNextPendingPolicyRouteInstallation = false
+            debugPendingPolicyRouteInstallationIsSuspended = false
+            let waiters = debugPendingPolicyRouteInstallationResumeWaiters
+            debugPendingPolicyRouteInstallationResumeWaiters.removeAll()
+            waiters.forEach { $0.resume() }
+        }
+
+        private func debugSuspendPendingPolicyRouteInstallationIfNeeded() async {
+            guard debugShouldSuspendNextPendingPolicyRouteInstallation else { return }
+            debugShouldSuspendNextPendingPolicyRouteInstallation = false
+            debugPendingPolicyRouteInstallationIsSuspended = true
+            await withCheckedContinuation { continuation in
+                debugPendingPolicyRouteInstallationResumeWaiters.append(continuation)
+            }
+            debugPendingPolicyRouteInstallationIsSuspended = false
+        }
+
         func debugPendingPolicySnapshot(for clientName: String) -> [(windowID: Int, tabID: UUID?, runID: UUID?, oneShot: Bool, purpose: MCPRunPurpose)] {
             pruneExpiredPolicies(for: clientName)
             let keys = matchingClientKeys(for: clientName, in: Array(pendingPoliciesByClient.keys))
@@ -4727,16 +4856,71 @@ actor ServerNetworkManager {
             clientName: String,
             connectionID: UUID,
             clientPid: Int? = nil,
-            bootstrapClientName: String? = nil
-        ) async -> (restrictedTools: Set<String>, additionalTools: Set<String>, purpose: MCPRunPurpose, windowID: Int?) {
+            bootstrapClientName: String? = nil,
+            sessionKey: String? = nil,
+            pidGateTimeout: TimeInterval = 0.25,
+            requireRunRouting: Bool = true
+        ) async -> (restrictedTools: Set<String>, additionalTools: Set<String>, purpose: MCPRunPurpose, windowID: Int?, outcome: String, runID: UUID?) {
             pendingConnections[connectionID] = clientName
-            await applyPendingPolicyIfAvailable(
+            if let sessionKey {
+                capabilityTokenByConnection[connectionID] = sessionKey
+            }
+            let outcome = await applyPendingPolicyIfAvailable(
                 clientName: clientName,
                 connectionID: connectionID,
                 clientPid: clientPid,
-                bootstrapClientName: bootstrapClientName
+                bootstrapClientName: bootstrapClientName,
+                pidGateTimeout: pidGateTimeout,
+                requireRunRouting: requireRunRouting
             )
-            return debugConnectionPolicyState(for: connectionID)
+            let state = debugConnectionPolicyState(for: connectionID)
+            let outcomeDescription: String
+            let outcomeRunID: UUID?
+            switch outcome {
+            case let .applied(runID):
+                outcomeDescription = "applied"
+                outcomeRunID = runID
+            case .fallback:
+                outcomeDescription = "fallback"
+                outcomeRunID = nil
+            case let .rejected(runID, reason):
+                outcomeDescription = "rejected:\(reason)"
+                outcomeRunID = runID
+            }
+            return (
+                restrictedTools: state.restrictedTools,
+                additionalTools: state.additionalTools,
+                purpose: state.purpose,
+                windowID: state.windowID,
+                outcome: outcomeDescription,
+                runID: outcomeRunID
+            )
+        }
+
+        func debugBootstrapPolicyAdmissionStatus(
+            bootstrapClientName: String?,
+            connectionID: UUID,
+            sessionKey: String? = nil,
+            clientPid: Int,
+            isReplacementForSession: Bool = false,
+            timeout: TimeInterval = 0.05
+        ) async -> String {
+            let readiness = await awaitAgentBootstrapPolicyBeforeAcceptIfNeeded(
+                bootstrapClientName: bootstrapClientName,
+                connectionID: connectionID,
+                sessionKey: sessionKey,
+                clientPid: clientPid,
+                isReplacementForSession: isReplacementForSession,
+                timeout: timeout
+            )
+            switch readiness {
+            case .notRequired:
+                return "notRequired"
+            case .ready:
+                return "ready"
+            case .timedOut:
+                return "timedOut"
+            }
         }
 
         func debugAgentPolicyAdmissionStatus(
@@ -4926,6 +5110,94 @@ actor ServerNetworkManager {
                     return nil
                 }
                 return Self.clientStorageKey(clientName)
+            }
+
+            private nonisolated static func debugSanitizedRunRoutingFields(_ fields: [String: String]) -> [String: String] {
+                let sensitiveKeyFragments = [
+                    "auth", "bearer", "credential", "environment", "password", "prompt", "secret",
+                    "sessiontoken", "session_token", "token", "transcript"
+                ]
+                let sensitiveValueFragments = [
+                    "authorization:", "proxy-authorization:", "bearer ", "api-key", "api_key",
+                    "apikey", "credential", "password", "private_key", "secret", "session_token",
+                    "sessiontoken", "token="
+                ]
+                return fields.sorted { $0.key < $1.key }.prefix(32).reduce(into: [:]) { result, entry in
+                    let normalizedKey = entry.key.lowercased().replacingOccurrences(of: "-", with: "_")
+                    let normalizedValue = entry.value.lowercased()
+                    let isSensitiveKey = sensitiveKeyFragments.contains { normalizedKey.contains($0) }
+                        || normalizedKey == "api_key"
+                        || normalizedKey.hasSuffix("_api_key")
+                        || normalizedKey == "private_key"
+                        || normalizedKey.hasSuffix("_private_key")
+                    let valueComponents = normalizedValue.split { $0.isWhitespace || $0 == "|" }
+                    let containsSensitiveValue = sensitiveValueFragments.contains { fragment in
+                        if fragment.contains(" ") {
+                            return normalizedValue.contains(fragment)
+                        }
+                        return valueComponents.contains { component in
+                            component.contains(fragment) && !component.contains("<redacted>")
+                        }
+                    }
+                    let value = isSensitiveKey || containsSensitiveValue
+                        ? "<redacted>"
+                        : String(entry.value.prefix(512))
+                    result[String(entry.key.prefix(64))] = value
+                }
+            }
+
+            func debugRecordRunRoutingEvent(
+                runID: UUID,
+                event: String,
+                connectionID: UUID? = nil,
+                fields: [String: String] = [:]
+            ) {
+                debugRunRoutingHistorySeq &+= 1
+                debugRunRoutingHistory.append(DebugRunRoutingEvent(
+                    seq: debugRunRoutingHistorySeq,
+                    timestamp: Date(),
+                    runID: runID,
+                    event: String(event.prefix(96)),
+                    connectionID: connectionID,
+                    fields: Self.debugSanitizedRunRoutingFields(fields)
+                ))
+                if debugRunRoutingHistory.count > debugRunRoutingHistoryLimit {
+                    let overflow = debugRunRoutingHistory.count - debugRunRoutingHistoryLimit
+                    debugRunRoutingHistory.removeFirst(overflow)
+                    debugRunRoutingHistoryDroppedCount += overflow
+                }
+            }
+
+            private func debugRunRoutingHistoryObject(_ event: DebugRunRoutingEvent) -> [String: Any] {
+                [
+                    "seq": Int(event.seq),
+                    "timestamp_ms": debugDateMilliseconds(event.timestamp),
+                    "run_id": event.runID.uuidString,
+                    "event": event.event,
+                    "connection_id": event.connectionID?.uuidString ?? NSNull(),
+                    "fields": event.fields
+                ]
+            }
+
+            func debugRunRoutingHistoryPayload(runID: UUID, limit: Int) -> [String: Any] {
+                let matching = debugRunRoutingHistory.filter { $0.runID == runID }
+                let events = Array(matching.suffix(limit))
+                return [
+                    "ok": true,
+                    "op": "run_routing_history",
+                    "run_id": runID.uuidString,
+                    "events": events.map(debugRunRoutingHistoryObject),
+                    "oldest_available_seq": debugRunRoutingHistory.first.map { Int($0.seq) } ?? NSNull(),
+                    "latest_seq": debugRunRoutingHistory.last.map { Int($0.seq) } ?? NSNull(),
+                    "dropped_event_count": debugRunRoutingHistoryDroppedCount,
+                    "history_capacity": debugRunRoutingHistoryLimit
+                ]
+            }
+
+            func debugClearRunRoutingHistoryForTesting() {
+                debugRunRoutingHistory.removeAll()
+                debugRunRoutingHistorySeq = 0
+                debugRunRoutingHistoryDroppedCount = 0
             }
 
             private func debugRecordConnectionEvent(
@@ -6210,7 +6482,23 @@ actor ServerNetworkManager {
     ) async {
         pruneExpiredPolicies(for: clientName)
         let keys = matchingClientKeys(for: clientName, in: Array(pendingPoliciesByClient.keys))
-        guard !keys.isEmpty else { return }
+        guard !keys.isEmpty else {
+            #if DEBUG
+                if let runID {
+                    debugRecordRunRoutingEvent(
+                        runID: runID,
+                        event: "policy_cleared",
+                        fields: [
+                            "client_name": clientName,
+                            "removed_count": "0",
+                            "remaining_count": "0",
+                            "reason": "no_matching_policy"
+                        ]
+                    )
+                }
+            #endif
+            return
+        }
         var removedCount = 0
         var remainingCount = 0
         for key in keys {
@@ -6236,6 +6524,20 @@ actor ServerNetworkManager {
         mcpPolicyLog(
             "cleared policy client=\(clientName) window=\(windowID.map(String.init) ?? "all") runID=\(runID?.uuidString ?? "all") removed=\(removedCount) remaining=\(remainingCount)"
         )
+        #if DEBUG
+            if let runID {
+                debugRecordRunRoutingEvent(
+                    runID: runID,
+                    event: "policy_cleared",
+                    fields: [
+                        "client_name": clientName,
+                        "window_id": windowID.map(String.init) ?? "all",
+                        "removed_count": String(removedCount),
+                        "remaining_count": String(remainingCount)
+                    ]
+                )
+            }
+        #endif
     }
 
     func setRestrictedTools(for connectionID: UUID, tools: Set<String>) async {
@@ -6413,6 +6715,68 @@ actor ServerNetworkManager {
         return isExpectedAgentDescendant(clientName: clientName, clientPid: clientPid, runID: policy.runID) == true
     }
 
+    private func oldestReservedPendingPolicyEntry(
+        for clientName: String
+    ) -> (key: String, index: Int, policy: ClientConnectionPolicy)? {
+        oldestPendingPolicyEntry(for: clientName) { $0.reservationConnectionID != nil }
+    }
+
+    private func reserveOneShotPendingPolicy(
+        _ matchedQueueEntry: (key: String, index: Int, policy: ClientConnectionPolicy),
+        for connectionID: UUID
+    ) -> ClientConnectionPolicy? {
+        guard matchedQueueEntry.policy.oneShot,
+              var queue = pendingPoliciesByClient[matchedQueueEntry.key],
+              queue.indices.contains(matchedQueueEntry.index),
+              queue[matchedQueueEntry.index].id == matchedQueueEntry.policy.id,
+              queue[matchedQueueEntry.index].reservationConnectionID == nil
+        else {
+            return nil
+        }
+        queue[matchedQueueEntry.index].reservationConnectionID = connectionID
+        let policy = queue[matchedQueueEntry.index]
+        pendingPoliciesByClient[matchedQueueEntry.key] = queue
+        return policy
+    }
+
+    private func consumeOneShotPendingPolicy(
+        id: UUID,
+        key: String,
+        connectionID: UUID
+    ) -> Bool {
+        guard var queue = pendingPoliciesByClient[key],
+              let index = queue.firstIndex(where: {
+                  $0.id == id && $0.reservationConnectionID == connectionID
+              })
+        else {
+            return false
+        }
+        queue.remove(at: index)
+        if queue.isEmpty {
+            pendingPoliciesByClient.removeValue(forKey: key)
+        } else {
+            pendingPoliciesByClient[key] = queue
+        }
+        return true
+    }
+
+    private func rollbackOneShotPendingPolicyReservation(
+        id: UUID,
+        key: String,
+        connectionID: UUID
+    ) -> Bool {
+        guard var queue = pendingPoliciesByClient[key],
+              let index = queue.firstIndex(where: {
+                  $0.id == id && $0.reservationConnectionID == connectionID
+              })
+        else {
+            return false
+        }
+        queue[index].reservationConnectionID = nil
+        pendingPoliciesByClient[key] = queue
+        return true
+    }
+
     private func logReservedPendingPolicy(
         _ policy: ClientConnectionPolicy,
         clientName: String,
@@ -6429,10 +6793,139 @@ actor ServerNetworkManager {
         clientName: String,
         connectionID: UUID,
         clientPid: Int? = nil,
-        bootstrapClientName: String? = nil
-    ) async {
-        let matchedQueueEntry = oldestPendingPolicyEntry(for: clientName) { policy in
-            canConsumePendingPolicy(policy, clientName: clientName, clientPid: clientPid)
+        bootstrapClientName: String? = nil,
+        pidGateTimeout: TimeInterval = 2.0,
+        requireRunRouting: Bool = true
+    ) async -> PendingPolicyApplicationOutcome {
+        if let reservedEntry = oldestReservedPendingPolicyEntry(for: clientName),
+           canConsumePendingPolicy(reservedEntry.policy, clientName: clientName, clientPid: clientPid)
+        {
+            mcpPolicyLog(
+                "pending policy route installation already reserved client=\(clientName) connection=\(connectionID) reservedConnection=\(reservedEntry.policy.reservationConnectionID?.uuidString ?? "nil") runID=\(reservedEntry.policy.runID?.uuidString ?? "nil")"
+            )
+            return .rejected(runID: reservedEntry.policy.runID, reason: "policy_reserved")
+        }
+
+        if let reservedEntry = oldestPendingPolicyEntry(for: clientName, where: {
+            $0.reservationConnectionID == nil && $0.requiresExpectedAgentPID
+        }),
+            oldestPIDGatedPendingPolicyEntry(for: clientName, matching: clientPid ?? -1) == nil
+        {
+            let runID = reservedEntry.policy.runID
+            let ancestorDescription = clientPid.map { pidAncestorChainDescription(from: pid_t($0)) } ?? "nil"
+            let expectedDescription = expectedAgentPIDs(for: clientName, runID: runID)
+                .map(String.init)
+                .sorted()
+                .joined(separator: ",")
+            mcpPolicyLog(
+                "holding pid-gated policy consumption client=\(clientName) bootstrapClient=\(bootstrapClientName ?? "nil") connection=\(connectionID) clientPid=\(clientPid.map(String.init) ?? "nil") ancestorChain=[\(ancestorDescription)] expectedAgentPIDs=[\(expectedDescription)] runID=\(runID?.uuidString ?? "nil") timeout=\(pidGateTimeout)s"
+            )
+            #if DEBUG
+                if let runID {
+                    debugRecordRunRoutingEvent(
+                        runID: runID,
+                        event: "pid_gate_wait_started",
+                        connectionID: connectionID,
+                        fields: [
+                            "client_name": clientName,
+                            "bootstrap_client_name": bootstrapClientName ?? "nil",
+                            "helper_peer_pid": clientPid.map(String.init) ?? "nil",
+                            "ancestor_chain": ancestorDescription,
+                            "expected_pids": expectedDescription,
+                            "pending_policy_key": reservedEntry.key,
+                            "timeout_ms": String(Int((pidGateTimeout * 1000).rounded()))
+                        ]
+                    )
+                }
+            #endif
+
+            let deadline = Date().addingTimeInterval(pidGateTimeout)
+            while oldestPIDGatedPendingPolicyEntry(for: clientName, matching: clientPid ?? -1) == nil {
+                if Task.isCancelled {
+                    #if DEBUG
+                        if let runID {
+                            debugRecordRunRoutingEvent(
+                                runID: runID,
+                                event: "pid_gate_wait_rejected",
+                                connectionID: connectionID,
+                                fields: ["reason": "cancelled"]
+                            )
+                        }
+                    #endif
+                    return .rejected(runID: runID, reason: "cancelled")
+                }
+                guard hasPIDGatedPendingPolicy(for: clientName) else {
+                    #if DEBUG
+                        if let runID {
+                            debugRecordRunRoutingEvent(
+                                runID: runID,
+                                event: "pid_gate_wait_rejected",
+                                connectionID: connectionID,
+                                fields: ["reason": "policy_removed"]
+                            )
+                        }
+                    #endif
+                    return .rejected(runID: runID, reason: "policy_removed")
+                }
+                guard Date() < deadline else {
+                    logReservedPendingPolicy(
+                        reservedEntry.policy,
+                        clientName: clientName,
+                        connectionID: connectionID,
+                        clientPid: clientPid,
+                        bootstrapClientName: bootstrapClientName
+                    )
+                    #if DEBUG
+                        if let runID {
+                            debugRecordRunRoutingEvent(
+                                runID: runID,
+                                event: "pid_gate_wait_rejected",
+                                connectionID: connectionID,
+                                fields: [
+                                    "reason": "ownership_timeout",
+                                    "helper_peer_pid": clientPid.map(String.init) ?? "nil",
+                                    "ancestor_chain": ancestorDescription,
+                                    "expected_pids": expectedAgentPIDs(for: clientName, runID: runID)
+                                        .map(String.init)
+                                        .sorted()
+                                        .joined(separator: ",")
+                                ]
+                            )
+                        }
+                    #endif
+                    return .rejected(runID: runID, reason: "ownership_timeout")
+                }
+                try? await Task.sleep(for: .milliseconds(50))
+            }
+            #if DEBUG
+                if let matchedEntry = oldestPIDGatedPendingPolicyEntry(for: clientName, matching: clientPid ?? -1),
+                   let matchedRunID = matchedEntry.policy.runID
+                {
+                    debugRecordRunRoutingEvent(
+                        runID: matchedRunID,
+                        event: "pid_gate_wait_completed",
+                        connectionID: connectionID,
+                        fields: [
+                            "helper_peer_pid": clientPid.map(String.init) ?? "nil",
+                            "expected_pids": expectedAgentPIDs(for: clientName, runID: matchedRunID)
+                                .map(String.init)
+                                .sorted()
+                                .joined(separator: ","),
+                            "pending_policy_key": matchedEntry.key
+                        ]
+                    )
+                }
+            #endif
+        }
+
+        let hasPIDGatedPolicy = hasPIDGatedPendingPolicy(for: clientName)
+        let matchedQueueEntry = if hasPIDGatedPolicy {
+            oldestPIDGatedPendingPolicyEntry(for: clientName, matching: clientPid ?? -1)
+        } else {
+            oldestPendingPolicyEntry(for: clientName) { policy in
+                policy.reservationConnectionID == nil
+                    && canConsumePendingPolicy(policy, clientName: clientName, clientPid: clientPid)
+            }
         }
         guard let matchedQueueEntry else {
             #if DEBUG
@@ -6443,6 +6936,9 @@ actor ServerNetworkManager {
                     "reason": oldestPendingPolicyEntry(for: clientName) == nil ? "no_pending_policy" : "pending_policy_not_consumable"
                 ])
             #endif
+            if let reservedEntry = oldestReservedPendingPolicyEntry(for: clientName) {
+                return .rejected(runID: reservedEntry.policy.runID, reason: "policy_reserved")
+            }
             if let reservedEntry = oldestPendingPolicyEntry(for: clientName) {
                 logReservedPendingPolicy(
                     reservedEntry.policy,
@@ -6451,24 +6947,149 @@ actor ServerNetworkManager {
                     clientPid: clientPid,
                     bootstrapClientName: bootstrapClientName
                 )
-                await applyRoutingFallback(clientName: clientName, connectionID: connectionID, clientPid: clientPid, pendingPolicyWasReserved: true)
-            } else {
-                await applyRoutingFallback(clientName: clientName, connectionID: connectionID, clientPid: clientPid)
+                return .rejected(runID: reservedEntry.policy.runID, reason: "not_consumable")
             }
-            return
+            await applyRoutingFallback(clientName: clientName, connectionID: connectionID, clientPid: clientPid)
+            return .fallback
+        }
+        let sessionKey = connections[connectionID]?.capabilityToken ?? capabilityTokenByConnection[connectionID]
+        if let policyRunID = matchedQueueEntry.policy.runID,
+           let affinity = preferredLiveRunAffinity(for: clientName, sessionKey: sessionKey),
+           affinity.runID != policyRunID
+        {
+            #if DEBUG
+                debugRecordRunRoutingEvent(
+                    runID: policyRunID,
+                    event: "policy_rejected",
+                    connectionID: connectionID,
+                    fields: [
+                        "client_name": clientName,
+                        "reason": "session_token_bound_to_other_run",
+                        "bound_run_id": affinity.runID.uuidString
+                    ]
+                )
+            #endif
+            return .rejected(runID: policyRunID, reason: "session_token_bound_to_other_run")
         }
         var queue = pendingPoliciesByClient[matchedQueueEntry.key] ?? []
         mcpRoutingLog("Applying FIFO policy client=\(clientName) matchedKey=\(matchedQueueEntry.key) connectionID=\(connectionID) queueLength=\(queue.count) policyWindow=\(matchedQueueEntry.policy.windowID)")
-        let policy = queue.remove(at: matchedQueueEntry.index)
-        let remainingAfterPop = queue.count
-        if !policy.oneShot {
-            queue.append(policy)
-        }
-        let remainingAfterRequeue = queue.count
-        if queue.isEmpty {
-            pendingPoliciesByClient.removeValue(forKey: matchedQueueEntry.key)
+        let policy: ClientConnectionPolicy
+        let remainingAfterPop: Int
+        let remainingAfterRequeue: Int
+        if matchedQueueEntry.policy.oneShot {
+            guard let reservedPolicy = reserveOneShotPendingPolicy(matchedQueueEntry, for: connectionID) else {
+                return .rejected(runID: matchedQueueEntry.policy.runID, reason: "policy_reservation_failed")
+            }
+            policy = reservedPolicy
+            remainingAfterPop = max(0, queue.count - 1)
+            remainingAfterRequeue = remainingAfterPop
         } else {
+            policy = queue.remove(at: matchedQueueEntry.index)
+            remainingAfterPop = queue.count
+            queue.append(policy)
+            remainingAfterRequeue = queue.count
             pendingPoliciesByClient[matchedQueueEntry.key] = queue
+        }
+
+        let restorePoint = PendingPolicyRestorePoint(
+            restrictedTools: restrictedToolsByConnection[connectionID],
+            additionalTools: additionalToolsByConnection[connectionID],
+            runPurpose: runPurposeByConnection[connectionID],
+            windowID: connectionWindowMap[connectionID],
+            windowAssignment: windowAssignmentByConnection[connectionID],
+            runID: runIDByConnectionID[connectionID],
+            wasPreassigned: preassignedConnections.contains(connectionID),
+            wasRunAdmitted: policy.runID.map { admittedPolicyRunIDs.contains($0) } ?? false,
+            runPolicyState: policy.runID.flatMap { runPolicyStateByRunID[$0] },
+            runWindowID: policy.runID.flatMap { windowIDByRunID[$0] }
+        )
+
+        // Stage the complete policy before registering the run mapping. The mapping
+        // signals MCPRoutingWaiter, so restrictions and run identity must already be
+        // visible before the bootstrap gate can be released.
+        restrictedToolsByConnection[connectionID] = policy.restrictedTools
+        preassignedConnections.insert(connectionID)
+        runPurposeByConnection[connectionID] = policy.purpose
+        cacheRunPolicyStateIfNeeded(policy)
+        if let runID = policy.runID {
+            admittedPolicyRunIDs.insert(runID)
+            runIDByConnectionID[connectionID] = runID
+        }
+        if let additional = policy.additionalTools {
+            additionalToolsByConnection[connectionID] = additional
+        } else {
+            additionalToolsByConnection.removeValue(forKey: connectionID)
+        }
+        connectionWindowMap[connectionID] = policy.windowID
+        windowAssignmentByConnection[connectionID] = policy.windowID
+
+        #if DEBUG
+            await debugSuspendPendingPolicyRouteInstallationIfNeeded()
+        #endif
+
+        if requireRunRouting, let runID = policy.runID {
+            let routed: Bool
+            if let tabID = policy.tabID {
+                mcpRoutingLog("Policy includes tab context - installing for tab=\(tabID) run=\(runID)")
+                routed = await installTabContextFromPolicy(
+                    clientID: connectionID.uuidString,
+                    clientName: clientName,
+                    windowID: policy.windowID,
+                    tabID: tabID,
+                    runID: runID
+                )
+            } else {
+                routed = await mapConnectionToRunID(
+                    connectionID,
+                    runID: runID,
+                    windowID: policy.windowID
+                )
+            }
+            #if DEBUG
+                debugRecordRunRoutingEvent(
+                    runID: runID,
+                    event: routed ? "run_route_mapped" : "run_route_mapping_failed",
+                    connectionID: connectionID,
+                    fields: [
+                        "client_name": clientName,
+                        "window_id": String(policy.windowID),
+                        "tab_id": policy.tabID?.uuidString ?? "nil"
+                    ]
+                )
+            #endif
+            guard routed else {
+                let reservationRolledBack = !policy.oneShot || rollbackOneShotPendingPolicyReservation(
+                    id: policy.id,
+                    key: matchedQueueEntry.key,
+                    connectionID: connectionID
+                )
+                await rollbackPendingPolicyApplication(
+                    policy,
+                    clientName: clientName,
+                    connectionID: connectionID,
+                    restorePoint: restorePoint
+                )
+                return .rejected(
+                    runID: runID,
+                    reason: reservationRolledBack ? "route_mapping_failed" : "policy_removed"
+                )
+            }
+        }
+
+        if policy.oneShot,
+           !consumeOneShotPendingPolicy(
+               id: policy.id,
+               key: matchedQueueEntry.key,
+               connectionID: connectionID
+           )
+        {
+            await rollbackPendingPolicyApplication(
+                policy,
+                clientName: clientName,
+                connectionID: connectionID,
+                restorePoint: restorePoint
+            )
+            return .rejected(runID: policy.runID, reason: "policy_removed")
         }
 
         let grantDescription = Self.describeGrantedTools(restricted: policy.restrictedTools)
@@ -6480,6 +7101,23 @@ actor ServerNetworkManager {
             "applied policy client=\(clientName) matchedKey=\(matchedQueueEntry.key) connection=\(connectionID) window=\(policy.windowID) purpose=\(policy.purpose.rawValue) oneShot=\(policy.oneShot) runID=\(policy.runID?.uuidString ?? "nil") tabID=\(policy.tabID?.uuidString ?? "nil") queueAfterPop=\(remainingAfterPop) queueAfterStore=\(remainingAfterRequeue)"
         )
         #if DEBUG
+            if let runID = policy.runID {
+                debugRecordRunRoutingEvent(
+                    runID: runID,
+                    event: "policy_applied",
+                    connectionID: connectionID,
+                    fields: [
+                        "client_name": clientName,
+                        "bootstrap_client_name": bootstrapClientName ?? "nil",
+                        "helper_peer_pid": clientPid.map(String.init) ?? "nil",
+                        "pending_policy_key": matchedQueueEntry.key,
+                        "window_id": String(policy.windowID),
+                        "tab_id": policy.tabID?.uuidString ?? "nil",
+                        "purpose": policy.purpose.rawValue,
+                        "queue_after_store": String(remainingAfterRequeue)
+                    ]
+                )
+            }
             AgentModePerfDiagnostics.event("mcp.policy.pendingPolicyApplied", fields: [
                 "connectionID": connectionID.uuidString,
                 "clientName": clientName,
@@ -6499,15 +7137,7 @@ actor ServerNetworkManager {
                 "queueAfterStore": String(remainingAfterRequeue)
             ])
         #endif
-        restrictedToolsByConnection[connectionID] = policy.restrictedTools
-        preassignedConnections.insert(connectionID)
-
-        // Install run purpose/cache first so persisted routing snapshots capture purpose.
-        runPurposeByConnection[connectionID] = policy.purpose
-        cacheRunPolicyStateIfNeeded(policy)
         if let runID = policy.runID {
-            admittedPolicyRunIDs.insert(runID)
-            runIDByConnectionID[connectionID] = runID
             updateLiveRunAffinity(
                 clientName: clientName,
                 sessionKey: connections[connectionID]?.capabilityToken ?? capabilityTokenByConnection[connectionID],
@@ -6517,31 +7147,94 @@ actor ServerNetworkManager {
             )
         }
 
-        // Install additional tools (policy-gated tools like ask_user)
-        if let additional = policy.additionalTools {
-            additionalToolsByConnection[connectionID] = additional
-        } else {
-            additionalToolsByConnection.removeValue(forKey: connectionID)
-        }
-
         setConnectionWindowMapping(connectionID, windowID: policy.windowID)
         mcpRoutingLog("Set window mapping connectionID=\(connectionID) → window=\(policy.windowID)")
 
-        // If policy includes tab context, install it directly
-        if let tabID = policy.tabID, let runID = policy.runID {
-            mcpRoutingLog("Policy includes tab context - installing for tab=\(tabID) run=\(runID)")
-            // Note: runID mapping is stored in MCPServerViewModel.connectionIDToRunID by installTabContext
-            await installTabContextFromPolicy(
-                clientID: connectionID.uuidString,
-                clientName: clientName,
-                windowID: policy.windowID,
-                tabID: tabID,
-                runID: runID
-            )
-        }
-
         await updateRoutingRecordForConnection(connectionID, clientID: clientName)
         await notifyToolListChanged(connectionID: connectionID)
+        return .applied(runID: policy.runID)
+    }
+
+    private func rollbackPendingPolicyApplication(
+        _ policy: ClientConnectionPolicy,
+        clientName: String,
+        connectionID: UUID,
+        restorePoint: PendingPolicyRestorePoint
+    ) async {
+        if let runID = policy.runID {
+            await MainActor.run {
+                guard let window = WindowStatesManager.shared.window(withID: policy.windowID) else { return }
+                window.mcpServer.removeTabContext(
+                    forConnectionID: connectionID,
+                    clientName: clientName,
+                    windowID: policy.windowID,
+                    runID: runID
+                )
+                window.mcpServer.cleanupRunIDMapping(runID: runID, connectionID: connectionID)
+            }
+            restorePendingPolicyState(
+                restorePoint,
+                connectionID: connectionID,
+                policyRunID: runID
+            )
+        }
+    }
+
+    private func restorePendingPolicyState(
+        _ restorePoint: PendingPolicyRestorePoint,
+        connectionID: UUID,
+        policyRunID: UUID
+    ) {
+        if let restrictedTools = restorePoint.restrictedTools {
+            restrictedToolsByConnection[connectionID] = restrictedTools
+        } else {
+            restrictedToolsByConnection.removeValue(forKey: connectionID)
+        }
+        if let additionalTools = restorePoint.additionalTools {
+            additionalToolsByConnection[connectionID] = additionalTools
+        } else {
+            additionalToolsByConnection.removeValue(forKey: connectionID)
+        }
+        if let runPurpose = restorePoint.runPurpose {
+            runPurposeByConnection[connectionID] = runPurpose
+        } else {
+            runPurposeByConnection.removeValue(forKey: connectionID)
+        }
+        if let windowID = restorePoint.windowID {
+            connectionWindowMap[connectionID] = windowID
+        } else {
+            connectionWindowMap.removeValue(forKey: connectionID)
+        }
+        if let windowAssignment = restorePoint.windowAssignment {
+            windowAssignmentByConnection[connectionID] = windowAssignment
+        } else {
+            windowAssignmentByConnection.removeValue(forKey: connectionID)
+        }
+        if let runID = restorePoint.runID {
+            runIDByConnectionID[connectionID] = runID
+        } else {
+            runIDByConnectionID.removeValue(forKey: connectionID)
+        }
+        if restorePoint.wasPreassigned {
+            preassignedConnections.insert(connectionID)
+        } else {
+            preassignedConnections.remove(connectionID)
+        }
+        if restorePoint.wasRunAdmitted {
+            admittedPolicyRunIDs.insert(policyRunID)
+        } else {
+            admittedPolicyRunIDs.remove(policyRunID)
+        }
+        if let runPolicyState = restorePoint.runPolicyState {
+            runPolicyStateByRunID[policyRunID] = runPolicyState
+        } else {
+            runPolicyStateByRunID.removeValue(forKey: policyRunID)
+        }
+        if let runWindowID = restorePoint.runWindowID {
+            windowIDByRunID[policyRunID] = runWindowID
+        } else {
+            windowIDByRunID.removeValue(forKey: policyRunID)
+        }
     }
 
     /// Install tab context from a connection policy (for Context Builder agents)
@@ -6551,8 +7244,8 @@ actor ServerNetworkManager {
         windowID: Int,
         tabID: UUID,
         runID: UUID
-    ) async {
-        let resolved = await MainActor.run { () -> (workspaceID: UUID, snapshot: ComposeTabState)? in
+    ) async -> Bool {
+        let resolved = await MainActor.run { () -> (workspaceID: UUID, snapshot: ComposeTabState, routed: Bool)? in
             guard let windowState = WindowStatesManager.shared.window(withID: windowID) else {
                 return nil
             }
@@ -6567,15 +7260,18 @@ actor ServerNetworkManager {
                 snapshot: resolved.snapshot,
                 runID: runID
             )
-            return (resolved.workspaceID, resolved.snapshot)
+            let routed = UUID(uuidString: clientID).map { connectionID in
+                windowState.mcpServer.connectionID(forRunID: runID) == connectionID
+            } ?? false
+            return (resolved.workspaceID, resolved.snapshot, routed)
         }
 
         guard let resolved else {
             log.warning("installTabContextFromPolicy: tab \(tabID) could not resolve routing snapshot in window \(windowID)")
-            return
+            return false
         }
 
-        if let cached = runPolicyStateByRunID[runID] {
+        if resolved.routed, let cached = runPolicyStateByRunID[runID] {
             seedRunPolicyState(
                 runID: runID,
                 windowID: windowID,
@@ -6590,6 +7286,7 @@ actor ServerNetworkManager {
             )
         }
         connectionLog("Installed tab context from policy: tab=\(tabID) run=\(runID) window=\(windowID) workspace=\(resolved.workspaceID) client=\(clientName)")
+        return resolved.routed
     }
 
     @discardableResult

--- a/Sources/RepoPrompt/Infrastructure/MCP/MCPRoutingWaiter.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/MCPRoutingWaiter.swift
@@ -16,9 +16,14 @@ actor MCPRoutingWaiter {
     private static let terminalStateTTL: TimeInterval = 120 // 2 minutes
 
     /// State for each runID being waited on
+    private struct WaitingContinuation {
+        let id: UUID
+        let continuation: CheckedContinuation<Bool, Never>
+        let timeoutTask: Task<Void, Never>?
+    }
+
     private struct WaitState {
-        var continuations: [(id: UUID, cont: CheckedContinuation<Bool, Never>)] = []
-        var timeoutTask: Task<Void, Never>?
+        var continuations: [WaitingContinuation] = []
         var expiryTask: Task<Void, Never>? // TTL cleanup for terminal states
         var isTerminal: Bool = false // success or failure already signaled
         var didRoute: Bool = false // true if success, false if failure/timeout
@@ -40,8 +45,9 @@ actor MCPRoutingWaiter {
     /// Wait until the runID is routed to a window/connection, or timeout/failure occurs.
     /// - Parameters:
     ///   - runID: The run identifier to watch for routing.
-    ///   - timeoutSeconds: Maximum time to wait. If <= 0, waits indefinitely.
-    /// - Returns: `true` if routing succeeded, `false` on failure or timeout.
+    ///   - timeoutSeconds: Maximum time for this waiter to wait. If <= 0, waits indefinitely.
+    ///     A timeout affects only this waiter; other waiters remain pending for the run-level signal.
+    /// - Returns: `true` if routing succeeded, `false` on failure, cancellation, or this waiter's timeout.
     func waitUntilRouted(runID: UUID, timeoutSeconds: TimeInterval) async -> Bool {
         // Fast path: already resolved
         if let state = waitersByRunID[runID], state.isTerminal {
@@ -55,20 +61,7 @@ actor MCPRoutingWaiter {
             return false
         }
 
-        // Start timeout task if this is the first waiter and timeout > 0
-        if waitersByRunID[runID]!.timeoutTask == nil, timeoutSeconds > 0 {
-            let timeoutNanos = UInt64(timeoutSeconds * 1_000_000_000)
-            waitersByRunID[runID]!.timeoutTask = Task { [weak self] in
-                do {
-                    try await Task.sleep(nanoseconds: timeoutNanos)
-                    await self?.handleTimeout(runID: runID)
-                } catch {
-                    // Task cancelled, no-op
-                }
-            }
-        }
-
-        // Wait via continuation with per-waiter identity for targeted cancellation
+        // Wait via continuation with per-waiter identity for targeted timeout/cancellation.
         let waiterID = UUID()
         return await withTaskCancellationHandler {
             await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
@@ -76,7 +69,25 @@ actor MCPRoutingWaiter {
                 if let state = waitersByRunID[runID], state.isTerminal {
                     continuation.resume(returning: state.didRoute)
                 } else {
-                    waitersByRunID[runID]?.continuations.append((id: waiterID, cont: continuation))
+                    let timeoutTask: Task<Void, Never>? = if timeoutSeconds > 0 {
+                        Task { [weak self] in
+                            do {
+                                try await Task.sleep(for: .seconds(timeoutSeconds))
+                                await self?.handleTimeout(runID: runID, waiterID: waiterID)
+                            } catch {
+                                // Task cancelled, no-op
+                            }
+                        }
+                    } else {
+                        nil
+                    }
+                    waitersByRunID[runID]?.continuations.append(
+                        WaitingContinuation(
+                            id: waiterID,
+                            continuation: continuation,
+                            timeoutTask: timeoutTask
+                        )
+                    )
                 }
             }
         } onCancel: {
@@ -129,10 +140,6 @@ actor MCPRoutingWaiter {
         state.isTerminal = true
         state.didRoute = routed
 
-        // Cancel timeout task
-        state.timeoutTask?.cancel()
-        state.timeoutTask = nil
-
         // Schedule TTL cleanup for terminal state
         state.expiryTask = scheduleExpiry(runID: runID)
 
@@ -146,7 +153,8 @@ actor MCPRoutingWaiter {
         log.info("resolve: runID=\(runID.uuidString) routed=\(routed) resumingCount=\(continuations.count)")
 
         for waiter in continuations {
-            waiter.cont.resume(returning: routed)
+            waiter.timeoutTask?.cancel()
+            waiter.continuation.resume(returning: routed)
         }
         return true
     }
@@ -172,12 +180,14 @@ actor MCPRoutingWaiter {
         log.debug("TTL expiry: removed terminal state for runID=\(runID.uuidString)")
     }
 
-    private func handleTimeout(runID: UUID) {
-        guard let state = waitersByRunID[runID], !state.isTerminal else {
-            return
-        }
-        log.info("timeout: runID=\(runID.uuidString)")
-        resolve(runID: runID, routed: false)
+    /// Handles timeout of one waiter without terminally resolving the runID.
+    private func handleTimeout(runID: UUID, waiterID: UUID) {
+        guard var state = waitersByRunID[runID], !state.isTerminal else { return }
+        guard let index = state.continuations.firstIndex(where: { $0.id == waiterID }) else { return }
+        let waiter = state.continuations.remove(at: index)
+        waitersByRunID[runID] = state
+        log.info("waiter timeout: runID=\(runID.uuidString) waiterID=\(waiterID.uuidString)")
+        waiter.continuation.resume(returning: false)
     }
 
     /// Handles cancellation of a single waiter without resolving the entire runID.
@@ -188,7 +198,8 @@ actor MCPRoutingWaiter {
         guard let index = state.continuations.firstIndex(where: { $0.id == waiterID }) else { return }
         let waiter = state.continuations.remove(at: index)
         waitersByRunID[runID] = state
-        waiter.cont.resume(returning: false)
+        waiter.timeoutTask?.cancel()
+        waiter.continuation.resume(returning: false)
     }
 
     /// Clean up state for a runID that is no longer needed.
@@ -197,10 +208,10 @@ actor MCPRoutingWaiter {
     /// to free memory sooner when the run is known to be complete.
     func cleanup(runID: UUID) {
         guard let state = waitersByRunID.removeValue(forKey: runID) else { return }
-        state.timeoutTask?.cancel()
         state.expiryTask?.cancel()
         for waiter in state.continuations {
-            waiter.cont.resume(returning: false)
+            waiter.timeoutTask?.cancel()
+            waiter.continuation.resume(returning: false)
         }
         log.debug("cleanup: runID=\(runID.uuidString) resumedCount=\(state.continuations.count)")
     }

--- a/Sources/RepoPrompt/Infrastructure/MCP/MCPRoutingWaiter.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/MCPRoutingWaiter.swift
@@ -86,28 +86,43 @@ actor MCPRoutingWaiter {
 
     /// Called when a runID is successfully bound to a connection/window.
     /// Resumes all waiters with `true`.
-    func notifyRouted(runID: UUID) {
-        resolve(runID: runID, routed: true)
+    func notifyRouted(runID: UUID) async {
+        guard resolve(runID: runID, routed: true) else { return }
+        #if DEBUG
+            await ServerNetworkManager.shared.debugRecordRunRoutingEvent(
+                runID: runID,
+                event: "routing_waiter_signalled",
+                fields: ["outcome": "routed"]
+            )
+        #endif
     }
 
     /// Called when routing is known to be impossible (cleanup, cancellation, etc).
     /// Resumes all waiters with `false`.
-    func notifyFailed(runID: UUID) {
-        resolve(runID: runID, routed: false)
+    func notifyFailed(runID: UUID) async {
+        guard resolve(runID: runID, routed: false) else { return }
+        #if DEBUG
+            await ServerNetworkManager.shared.debugRecordRunRoutingEvent(
+                runID: runID,
+                event: "routing_waiter_signalled",
+                fields: ["outcome": "failed"]
+            )
+        #endif
     }
 
     // MARK: - Internal
 
-    private func resolve(runID: UUID, routed: Bool) {
+    @discardableResult
+    private func resolve(runID: UUID, routed: Bool) -> Bool {
         guard var state = waitersByRunID[runID] else {
             log.warning("resolve: unregistered runID \(runID.uuidString) routed=\(routed) - ignoring")
-            return
+            return false
         }
 
         // Already resolved - ignore duplicate
         if state.isTerminal {
             log.debug("resolve (already terminal): runID=\(runID.uuidString)")
-            return
+            return false
         }
 
         // Mark as terminal
@@ -133,6 +148,7 @@ actor MCPRoutingWaiter {
         for waiter in continuations {
             waiter.cont.resume(returning: routed)
         }
+        return true
     }
 
     /// Schedules automatic cleanup of terminal state after TTL expires
@@ -180,12 +196,20 @@ actor MCPRoutingWaiter {
     /// Note: With TTL eviction, explicit cleanup is optional but recommended
     /// to free memory sooner when the run is known to be complete.
     func cleanup(runID: UUID) {
-        if let state = waitersByRunID.removeValue(forKey: runID) {
-            state.timeoutTask?.cancel()
-            state.expiryTask?.cancel()
-            log.debug("cleanup: runID=\(runID.uuidString)")
+        guard let state = waitersByRunID.removeValue(forKey: runID) else { return }
+        state.timeoutTask?.cancel()
+        state.expiryTask?.cancel()
+        for waiter in state.continuations {
+            waiter.cont.resume(returning: false)
         }
+        log.debug("cleanup: runID=\(runID.uuidString) resumedCount=\(state.continuations.count)")
     }
+
+    #if DEBUG
+        func debugContinuationCount(runID: UUID) -> Int {
+            waitersByRunID[runID]?.continuations.count ?? 0
+        }
+    #endif
 }
 
 // MARK: - Static Async Methods (for async callers)
@@ -218,6 +242,12 @@ extension MCPRoutingWaiter {
     static func cleanup(runID: UUID) async {
         await shared.cleanup(runID: runID)
     }
+
+    #if DEBUG
+        static func debugContinuationCount(runID: UUID) async -> Int {
+            await shared.debugContinuationCount(runID: runID)
+        }
+    #endif
 }
 
 // MARK: - Fire-and-Forget Signal Methods (for sync callers)

--- a/Sources/RepoPrompt/Infrastructure/MCP/ServerController.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ServerController.swift
@@ -49,6 +49,7 @@ final actor ServerController: ObservableObject {
         "claude-code",
         "codex-mcp-client",
         "gemini-cli-mcp-client",
+        "opencode",
         "cursor",
         "cursor-mcp-client",
         "claude-ai"

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+TabContext.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+TabContext.swift
@@ -903,7 +903,8 @@ extension MCPServerViewModel {
         windowID: Int,
         workspaceID providedWorkspaceID: UUID? = nil,
         snapshot: ComposeTabState,
-        runID: UUID? = nil
+        runID: UUID? = nil,
+        signalRouting: Bool = true
     ) {
         tabContextLog("installTabContext tab=\(snapshot.id) window=\(windowID) clientID=\(clientID ?? "nil") clientName=\(clientName ?? "nil") runID=\(runID?.uuidString ?? "nil")")
         let resolvedWorkspaceID: UUID? = {
@@ -951,7 +952,12 @@ extension MCPServerViewModel {
             tabContextByConnectionID[uuid] = context
             windowIDByConnection[uuid] = context.windowID
             if let runID = context.runID {
-                _ = registerRunIDMapping(connectionID: uuid, runID: runID, windowID: context.windowID)
+                _ = registerRunIDMapping(
+                    connectionID: uuid,
+                    runID: runID,
+                    windowID: context.windowID,
+                    signalRouting: signalRouting
+                )
                 // Consume any queued intent for this exact run after direct installation.
                 if let clientName {
                     let popped = pendingRunScopedTabContexts.popByRunID(clientName: clientName, runID: runID)
@@ -1901,24 +1907,41 @@ extension MCPServerViewModel {
     }
 
     @MainActor
-    func cleanupRunIDMapping(runID: UUID, connectionID: UUID) {
-        connectionIDByRunID.removeValue(forKey: runID)
-        connectionIDToRunID.removeValue(forKey: connectionID)
+    func cleanupRunIDMapping(
+        runID: UUID,
+        connectionID: UUID,
+        signalRoutingFailure: Bool = true
+    ) {
+        if connectionIDByRunID[runID] == connectionID {
+            connectionIDByRunID.removeValue(forKey: runID)
+        }
+        if connectionIDToRunID[connectionID] == runID {
+            connectionIDToRunID.removeValue(forKey: connectionID)
+        }
         tabContextLog("cleanupRunIDMapping removed runID=\(runID) connectionID=\(connectionID)")
 
-        // Notify routing waiter that this runID will never route (enables early exit from wait)
-        MCPRoutingWaiter.signalFailed(runID)
+        // A stale generation must not fail routing for a newer replacement connection.
+        if signalRoutingFailure, liveConnectionID(forRunID: runID) == nil {
+            MCPRoutingWaiter.signalFailed(runID)
+        }
     }
 
     @MainActor
     @discardableResult
-    func registerRunIDMapping(connectionID: UUID, runID: UUID, windowID: Int) -> Bool {
+    func registerRunIDMapping(
+        connectionID: UUID,
+        runID: UUID,
+        windowID: Int,
+        signalRouting: Bool = true
+    ) -> Bool {
         // Fast path: already mapped to this exact run/connection.
         if connectionIDByRunID[runID] == connectionID,
            connectionIDToRunID[connectionID] == runID
         {
             windowIDByConnection[connectionID] = windowID
-            MCPRoutingWaiter.signalRouted(runID)
+            if signalRouting {
+                MCPRoutingWaiter.signalRouted(runID)
+            }
             return true
         }
 
@@ -1961,8 +1984,9 @@ extension MCPServerViewModel {
         connectionIDToRunID[connectionID] = runID
         tabContextLog("registerRunIDMapping connectionID=\(connectionID) runID=\(runID) windowID=\(windowID)")
 
-        // Notify routing waiter that this runID is now routed
-        MCPRoutingWaiter.signalRouted(runID)
+        if signalRouting {
+            MCPRoutingWaiter.signalRouted(runID)
+        }
 
         return true
     }
@@ -2153,10 +2177,14 @@ extension MCPServerViewModel {
                 tabContextByConnectionID.removeValue(forKey: connectionID)
                 windowIDByConnection.removeValue(forKey: connectionID)
 
-                if let boundRunID = context.runID {
+                if let boundRunID = context.runID,
+                   connectionIDByRunID[boundRunID] == connectionID
+                {
                     connectionIDByRunID.removeValue(forKey: boundRunID)
                 }
-                connectionIDToRunID.removeValue(forKey: connectionID)
+                if connectionIDToRunID[connectionID] == context.runID {
+                    connectionIDToRunID.removeValue(forKey: connectionID)
+                }
 
                 tabContextLog("removeTabContext removed bound context connectionID=\(connectionID) runID=\(runID?.uuidString ?? "nil") tab=\(context.tabID)")
             }

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+TabContext.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+TabContext.swift
@@ -1922,8 +1922,6 @@ extension MCPServerViewModel {
             return true
         }
 
-        windowIDByConnection[connectionID] = windowID
-
         // If this connection is already bound to a different run, refuse remap
         if let bound = tabContextByConnectionID[connectionID],
            let boundRun = bound.runID,
@@ -1958,6 +1956,7 @@ extension MCPServerViewModel {
             // Avoid dangling reverse mapping for stale run
             connectionIDByRunID.removeValue(forKey: previous)
         }
+        windowIDByConnection[connectionID] = windowID
         connectionIDByRunID[runID] = connectionID
         connectionIDToRunID[connectionID] = runID
         tabContextLog("registerRunIDMapping connectionID=\(connectionID) runID=\(runID) windowID=\(windowID)")

--- a/Sources/RepoPrompt/Infrastructure/Process/CLILaunchProfile.swift
+++ b/Sources/RepoPrompt/Infrastructure/Process/CLILaunchProfile.swift
@@ -54,7 +54,7 @@ enum CLILaunchProfiles {
 
     static let cursor = CLILaunchProfile(
         commandName: "cursor-agent",
-        preferredBasenames: ["cursor-agent", "cursor"],
+        preferredBasenames: ["cursor-agent"],
         supplementalSearchPaths: nativeDefaultsSupplemented(with: cursorProviderSpecificPaths)
     )
 

--- a/Sources/RepoPrompt/Infrastructure/Process/CLIProcessRunner.swift
+++ b/Sources/RepoPrompt/Infrastructure/Process/CLIProcessRunner.swift
@@ -136,7 +136,8 @@ final class CLIProcessRunner {
         outputMode: OutputFlagMode = .auto(.json),
         timeout: TimeInterval?,
         additionalEnvironment: [String: String] = [:],
-        additionalRemovedKeys: Set<String> = []
+        additionalRemovedKeys: Set<String> = [],
+        cancelChildOnTaskCancellation: Bool = false
     ) async throws -> Result {
         try await gate.withPermit { [self] in
             let environment = await resolvedEnvironment(
@@ -302,7 +303,20 @@ final class CLIProcessRunner {
                 let status: Int32
                 let timedOut: Bool
                 do {
-                    (status, timedOut) = try await waitTask.value
+                    let termination: (Int32, Bool) = if cancelChildOnTaskCancellation {
+                        try await withTaskCancellationHandler {
+                            let result = try await waitTask.value
+                            try Task.checkCancellation()
+                            return result
+                        } onCancel: {
+                            spawned.stdin?.closeFile()
+                            kill(spawned.pid, SIGTERM)
+                            waitTask.cancel()
+                        }
+                    } else {
+                        try await waitTask.value
+                    }
+                    (status, timedOut) = termination
                 } catch {
                     spawned.stdout.closeFile()
                     spawned.stderr.closeFile()

--- a/Sources/RepoPrompt/Infrastructure/Process/ExecutableFileIdentity.swift
+++ b/Sources/RepoPrompt/Infrastructure/Process/ExecutableFileIdentity.swift
@@ -43,6 +43,12 @@ struct ExecutableFileIdentity: Equatable {
         )
     }
 
+    static func captureForTrustedPathLaunch(atPath path: String) throws -> ExecutableFileIdentity {
+        let identity = try capture(atPath: path)
+        try validateTrustedOwnershipAndPermissions(atCanonicalPath: identity.canonicalPath)
+        return identity
+    }
+
     func validate(atPath path: String) throws {
         let current = try Self.capture(atPath: path)
         guard current == self else {
@@ -50,6 +56,51 @@ struct ExecutableFileIdentity: Equatable {
                 expectedPath: canonicalPath,
                 actualPath: current.canonicalPath
             )
+        }
+    }
+
+    /// Revalidates identity and rejects launch paths that another local user can replace.
+    /// This narrows pathname-spawn TOCTOU exposure to processes running as this same UID.
+    func validateForTrustedPathLaunch(atPath path: String) throws {
+        try validate(atPath: path)
+        try Self.validateTrustedOwnershipAndPermissions(atCanonicalPath: canonicalPath)
+    }
+
+    private static func validateTrustedOwnershipAndPermissions(atCanonicalPath canonicalPath: String) throws {
+        let trustedUIDs: Set<uid_t> = [0, geteuid()]
+        var executableInfo = stat()
+        guard stat(canonicalPath, &executableInfo) == 0 else {
+            throw ExecutableFileIdentityError.unavailable(canonicalPath)
+        }
+        guard trustedUIDs.contains(executableInfo.st_uid) else {
+            throw ExecutableFileIdentityError.untrustedOwner(canonicalPath, executableInfo.st_uid)
+        }
+        guard executableInfo.st_mode & mode_t(S_IWGRP | S_IWOTH) == 0 else {
+            throw ExecutableFileIdentityError.untrustedWritableFile(canonicalPath, executableInfo.st_mode)
+        }
+
+        var directory = URL(fileURLWithPath: canonicalPath).deletingLastPathComponent()
+        while true {
+            var directoryInfo = stat()
+            guard stat(directory.path, &directoryInfo) == 0,
+                  directoryInfo.st_mode & mode_t(S_IFMT) == mode_t(S_IFDIR)
+            else {
+                throw ExecutableFileIdentityError.unavailable(directory.path)
+            }
+            guard trustedUIDs.contains(directoryInfo.st_uid) else {
+                throw ExecutableFileIdentityError.untrustedOwner(directory.path, directoryInfo.st_uid)
+            }
+
+            let isGroupOrWorldWritable = directoryInfo.st_mode & mode_t(S_IWGRP | S_IWOTH) != 0
+            let isRootOwnedStickyDirectory = directoryInfo.st_uid == 0
+                && directoryInfo.st_mode & mode_t(S_ISVTX) != 0
+            guard !isGroupOrWorldWritable || isRootOwnedStickyDirectory else {
+                throw ExecutableFileIdentityError.untrustedWritableDirectory(directory.path, directoryInfo.st_mode)
+            }
+
+            let parent = directory.deletingLastPathComponent()
+            if parent.path == directory.path { break }
+            directory = parent
         }
     }
 }
@@ -60,6 +111,9 @@ enum ExecutableFileIdentityError: Error, Equatable, LocalizedError {
     case notRegularFile(String)
     case notExecutable(String)
     case identityChanged(expectedPath: String, actualPath: String)
+    case untrustedOwner(String, uid_t)
+    case untrustedWritableFile(String, mode_t)
+    case untrustedWritableDirectory(String, mode_t)
 
     var errorDescription: String? {
         switch self {
@@ -73,6 +127,12 @@ enum ExecutableFileIdentityError: Error, Equatable, LocalizedError {
             "Executable path is not executable: \(path)"
         case let .identityChanged(expectedPath, actualPath):
             "Executable identity changed before launch. Expected \(expectedPath), found \(actualPath)."
+        case let .untrustedOwner(path, uid):
+            "Executable launch path has an untrusted owner (uid \(uid)): \(path)"
+        case let .untrustedWritableFile(path, mode):
+            "Executable is group- or world-writable (mode \(String(mode & 0o7777, radix: 8))): \(path)"
+        case let .untrustedWritableDirectory(path, mode):
+            "Executable directory is replaceable by another user (mode \(String(mode & 0o7777, radix: 8))): \(path)"
         }
     }
 }

--- a/Sources/RepoPrompt/Infrastructure/Process/ExecutableFileIdentity.swift
+++ b/Sources/RepoPrompt/Infrastructure/Process/ExecutableFileIdentity.swift
@@ -1,0 +1,78 @@
+import Darwin
+import Foundation
+
+struct ExecutableFileIdentity: Equatable {
+    let canonicalPath: String
+    let device: UInt64
+    let inode: UInt64
+    let size: Int64
+    let modificationSeconds: Int64
+    let modificationNanoseconds: Int64
+    let statusChangeSeconds: Int64
+    let statusChangeNanoseconds: Int64
+
+    static func capture(atPath rawPath: String) throws -> ExecutableFileIdentity {
+        guard rawPath.hasPrefix("/") else {
+            throw ExecutableFileIdentityError.pathMustBeAbsolute(rawPath)
+        }
+
+        let canonicalPath = URL(fileURLWithPath: rawPath)
+            .resolvingSymlinksInPath()
+            .standardizedFileURL
+            .path
+        var info = stat()
+        guard stat(canonicalPath, &info) == 0 else {
+            throw ExecutableFileIdentityError.unavailable(canonicalPath)
+        }
+        guard info.st_mode & mode_t(S_IFMT) == mode_t(S_IFREG) else {
+            throw ExecutableFileIdentityError.notRegularFile(canonicalPath)
+        }
+        guard access(canonicalPath, X_OK) == 0 else {
+            throw ExecutableFileIdentityError.notExecutable(canonicalPath)
+        }
+
+        return ExecutableFileIdentity(
+            canonicalPath: canonicalPath,
+            device: UInt64(info.st_dev),
+            inode: UInt64(info.st_ino),
+            size: Int64(info.st_size),
+            modificationSeconds: Int64(info.st_mtimespec.tv_sec),
+            modificationNanoseconds: Int64(info.st_mtimespec.tv_nsec),
+            statusChangeSeconds: Int64(info.st_ctimespec.tv_sec),
+            statusChangeNanoseconds: Int64(info.st_ctimespec.tv_nsec)
+        )
+    }
+
+    func validate(atPath path: String) throws {
+        let current = try Self.capture(atPath: path)
+        guard current == self else {
+            throw ExecutableFileIdentityError.identityChanged(
+                expectedPath: canonicalPath,
+                actualPath: current.canonicalPath
+            )
+        }
+    }
+}
+
+enum ExecutableFileIdentityError: Error, Equatable, LocalizedError {
+    case pathMustBeAbsolute(String)
+    case unavailable(String)
+    case notRegularFile(String)
+    case notExecutable(String)
+    case identityChanged(expectedPath: String, actualPath: String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .pathMustBeAbsolute(path):
+            "Executable path must be absolute: \(path)"
+        case let .unavailable(path):
+            "Executable is unavailable: \(path)"
+        case let .notRegularFile(path):
+            "Executable path is not a regular file: \(path)"
+        case let .notExecutable(path):
+            "Executable path is not executable: \(path)"
+        case let .identityChanged(expectedPath, actualPath):
+            "Executable identity changed before launch. Expected \(expectedPath), found \(actualPath)."
+        }
+    }
+}

--- a/Tests/RepoPromptTests/AgentMode/ACPAgentSessionControllerModeConfigTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/ACPAgentSessionControllerModeConfigTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-@testable import RepoPrompt
+@_spi(TestSupport) @testable import RepoPrompt
 import XCTest
 
 final class ACPAgentSessionControllerModeConfigTests: XCTestCase {
@@ -312,6 +312,41 @@ final class ACPAgentSessionControllerModeConfigTests: XCTestCase {
         XCTAssertEqual(recordedRequests(at: fixture.recordURL, method: "session/set_config_option").count, 1)
     }
 
+    func testNewerCaseDistinctModeNotificationInvalidatesExactConfirmedMode() async throws {
+        #if DEBUG
+            let diagnostics = LockedStrings()
+            let fixture = try makeFixture(
+                shape: "case_collision",
+                extraEnvironment: ["ACP_AFTER_SET_NOTIFICATION_MODE": "plan"],
+                diagnostics: diagnostics
+            )
+            _ = try await fixture.controller.bootstrap()
+            await fixture.controller.debugSuspendNextConfigurationMutationPostcheck()
+            addTeardownBlock {
+                await fixture.controller.debugResumeConfigurationMutationPostcheck()
+            }
+
+            let mutation = Task {
+                try await fixture.controller.setSessionMode("Plan")
+            }
+            try await waitUntilAsync("configuration mutation postcheck suspension") {
+                await fixture.controller.debugIsConfigurationMutationPostcheckSuspended()
+            }
+            try await waitUntil("newer authoritative config update") {
+                diagnostics.values.contains("Processed authoritative config_option_update snapshot.")
+            }
+            await fixture.controller.debugResumeConfigurationMutationPostcheck()
+
+            await assertThrows(containing: "newer ACP configuration state no longer confirms requested mode 'Plan'") {
+                try await mutation.value
+            }
+            await fixture.controller.shutdown()
+            XCTAssertEqual(recordedRequests(at: fixture.recordURL, method: "session/set_config_option").count, 1)
+        #else
+            throw XCTSkip("Configuration mutation suspension is DEBUG-only.")
+        #endif
+    }
+
     func testMalformedNotificationAfterMutationInvalidatesConfirmedMode() async throws {
         let diagnostics = LockedStrings()
         let fixture = try makeFixture(
@@ -352,6 +387,29 @@ final class ACPAgentSessionControllerModeConfigTests: XCTestCase {
         let mutation = try XCTUnwrap(recordedRequests(at: fixture.recordURL, method: "session/set_config_option").first)
         XCTAssertEqual(mutation.params["configId"] as? String, "model_selector")
         XCTAssertEqual(mutation.params["value"] as? String, "model-b")
+    }
+
+    func testLegacyOnlyModelAdvertisementIsIgnored() async throws {
+        AgentACPModelRegistry.shared.test_reset(providerID: .openCode)
+        addTeardownBlock {
+            AgentACPModelRegistry.shared.test_reset(providerID: .openCode)
+        }
+        let diagnostics = LockedStrings()
+        let fixture = try makeFixture(
+            shape: "none",
+            extraEnvironment: ["ACP_INCLUDE_LEGACY_MODELS": "1"],
+            diagnostics: diagnostics
+        )
+
+        try await withBootstrappedController(fixture.controller) { controller in
+            XCTAssertNil(AgentACPModelRegistry.shared.test_snapshot(providerID: .openCode))
+            await assertThrows(containing: "does not advertise model switching through configOptions") {
+                try await controller.setSessionModel("legacy-model")
+            }
+        }
+
+        XCTAssertTrue(recordedMutationRequests(at: fixture.recordURL).isEmpty)
+        XCTAssertTrue(diagnostics.values.contains { $0.contains("Ignoring legacy ACP models metadata") })
     }
 
     func testMalformedModernModelDoesNotFallBackToLegacyModels() async throws {
@@ -539,6 +597,90 @@ final class ACPAgentSessionControllerModeConfigTests: XCTestCase {
         }
     }
 
+    func testShutdownDrainsPromptSettlementWaitersWithTransportClosed() async throws {
+        #if DEBUG
+            let fixture = try makeFixture(
+                shape: "modern",
+                extraEnvironment: ["ACP_HANG_PROMPT": "1"]
+            )
+            _ = try await fixture.controller.bootstrap()
+            let promptTask = Task {
+                try await fixture.controller.prompt(AgentMessage(userMessage: "hang"))
+            }
+            try await waitUntil("prompt request") {
+                self.recordedRequests(at: fixture.recordURL, method: "session/prompt").count == 1
+            }
+
+            let interruptTask = Task {
+                try await fixture.controller.interruptActivePromptForSteering(timeoutSeconds: 30)
+            }
+            try await waitUntilAsync("prompt settlement waiter") {
+                await fixture.controller.debugPromptSettlementWaiterCount() == 1
+            }
+
+            await fixture.controller.shutdown()
+
+            do {
+                try await interruptTask.value
+                XCTFail("Expected steering interrupt to fail when transport closes")
+            } catch {
+                XCTAssertEqual(error.localizedDescription, "ACP transport closed unexpectedly.")
+            }
+            do {
+                try await promptTask.value
+                XCTFail("Expected prompt to fail when transport closes")
+            } catch {
+                XCTAssertEqual(error.localizedDescription, "ACP transport closed unexpectedly.")
+            }
+        #else
+            throw XCTSkip("Prompt settlement waiter inspection is DEBUG-only.")
+        #endif
+    }
+
+    func testProcessExitDrainsPromptSettlementWaitersWithTransportClosed() async throws {
+        #if DEBUG
+            let releaseURL = try makeTemporaryDirectory().appendingPathComponent("exit-release")
+            let fixture = try makeFixture(
+                shape: "modern",
+                extraEnvironment: [
+                    "ACP_HANG_PROMPT": "1",
+                    "ACP_EXIT_ON_CANCEL_RELEASE_PATH": releaseURL.path
+                ]
+            )
+            _ = try await fixture.controller.bootstrap()
+            let promptTask = Task {
+                try await fixture.controller.prompt(AgentMessage(userMessage: "hang"))
+            }
+            try await waitUntil("prompt request") {
+                self.recordedRequests(at: fixture.recordURL, method: "session/prompt").count == 1
+            }
+
+            let interruptTask = Task {
+                try await fixture.controller.interruptActivePromptForSteering(timeoutSeconds: 30)
+            }
+            try await waitUntilAsync("prompt settlement waiter") {
+                await fixture.controller.debugPromptSettlementWaiterCount() == 1
+            }
+            try Data().write(to: releaseURL)
+
+            do {
+                try await interruptTask.value
+                XCTFail("Expected steering interrupt to fail after process exit")
+            } catch {
+                XCTAssertEqual(error.localizedDescription, "ACP transport closed unexpectedly.")
+            }
+            do {
+                try await promptTask.value
+                XCTFail("Expected prompt to fail after process exit")
+            } catch {
+                XCTAssertEqual(error.localizedDescription, "ACP transport closed unexpectedly.")
+            }
+            await fixture.controller.shutdown()
+        #else
+            throw XCTSkip("Prompt settlement waiter inspection is DEBUG-only.")
+        #endif
+    }
+
     func testLaunchConfigurationDiagnosticsRedactSecretFlagsAndJSONFields() throws {
         #if DEBUG
             let launchConfiguration = ACPLaunchConfiguration(
@@ -568,6 +710,46 @@ final class ACPAgentSessionControllerModeConfigTests: XCTestCase {
             }
         #else
             throw XCTSkip("Launch configuration diagnostics are DEBUG-only.")
+        #endif
+    }
+
+    func testRawDebugCaptureRedactsNestedContentAndUsesOwnerOnlyPermissions() throws {
+        #if DEBUG
+            let directory = try makeTemporaryDirectory()
+            let captureURL = directory.appendingPathComponent("raw-acp.jsonl")
+            try Data().write(to: captureURL)
+            try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: captureURL.path)
+            let payload: [String: Any] = [
+                "method": "session/update",
+                "safeLabel": "visible",
+                "params": [
+                    "token": "token-secret",
+                    "nested": [
+                        "password": "password-secret",
+                        "text": "private prompt text",
+                        "label": "nested-visible"
+                    ],
+                    "authorization": "Bearer header-secret"
+                ]
+            ]
+
+            let sanitized = ACPAgentSessionController.debugSanitizedRawCapturePayloadForTesting(payload)
+            let description = String(describing: sanitized)
+            XCTAssertTrue(description.contains("visible"))
+            for secret in ["token-secret", "password-secret", "private prompt text", "header-secret"] {
+                XCTAssertFalse(description.contains(secret), secret)
+            }
+
+            ACPAgentSessionController.debugWriteRawACPEventForTesting(to: captureURL, payload: payload)
+            let contents = try String(contentsOf: captureURL, encoding: .utf8)
+            for secret in ["token-secret", "password-secret", "private prompt text", "header-secret"] {
+                XCTAssertFalse(contents.contains(secret), secret)
+            }
+            let attributes = try FileManager.default.attributesOfItem(atPath: captureURL.path)
+            let permissions = try XCTUnwrap(attributes[.posixPermissions] as? NSNumber).intValue
+            XCTAssertEqual(permissions & 0o777, 0o600)
+        #else
+            throw XCTSkip("Raw ACP capture is DEBUG-only.")
         #endif
     }
 
@@ -704,6 +886,9 @@ final class ACPAgentSessionControllerModeConfigTests: XCTestCase {
                 }
             }
         )
+        addTeardownBlock {
+            await controller.shutdown()
+        }
         return Fixture(controller: controller, recordURL: recordURL, scriptURL: scriptURL)
     }
 
@@ -748,6 +933,19 @@ final class ACPAgentSessionControllerModeConfigTests: XCTestCase {
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
             if condition() { return }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTFail("Timed out waiting for \(description)")
+    }
+
+    private func waitUntilAsync(
+        _ description: String,
+        timeout: TimeInterval = 3,
+        condition: @escaping () async -> Bool
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if await condition() { return }
             try await Task.sleep(nanoseconds: 10_000_000)
         }
         XCTFail("Timed out waiting for \(description)")
@@ -1032,7 +1230,16 @@ final class ACPAgentSessionControllerModeConfigTests: XCTestCase {
                         )
                 else:
                     respond(request.get("id"), set_config_response())
+            elif method == "session/cancel":
+                exit_release_path = os.environ.get("ACP_EXIT_ON_CANCEL_RELEASE_PATH")
+                if exit_release_path:
+                    while not os.path.exists(exit_release_path):
+                        time.sleep(0.01)
+                    sys.exit(0)
+                continue
             elif method == "session/prompt":
+                if os.environ.get("ACP_HANG_PROMPT") == "1":
+                    continue
                 respond(request.get("id"), {"stopReason": "end_turn", "usage": {"inputTokens": 1, "outputTokens": 1}})
             else:
                 respond(request.get("id"), {})

--- a/Tests/RepoPromptTests/AgentMode/ACPAgentSessionControllerModeConfigTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/ACPAgentSessionControllerModeConfigTests.swift
@@ -186,16 +186,21 @@ final class ACPAgentSessionControllerModeConfigTests: XCTestCase {
     }
 
     func testMatchingConfigOptionUpdateReplacesStateAndSkipsSameValue() async throws {
+        let diagnostics = LockedStrings()
         let normalizedUpdates = LockedStrings()
         let fixture = try makeFixture(
             shape: "modern",
             extraEnvironment: ["ACP_NOTIFICATION_MODE": "plan"],
+            diagnostics: diagnostics,
             normalizedUpdates: normalizedUpdates
         )
-        try await withBootstrappedController(fixture.controller) { controller in
-            try await controller.setSessionMode("plan")
-            try await controller.setSessionMode("ask")
+        _ = try await fixture.controller.bootstrap()
+        try await waitUntil("authoritative config update") {
+            diagnostics.values.contains("Processed authoritative config_option_update snapshot.")
         }
+        try await fixture.controller.setSessionMode("plan")
+        try await fixture.controller.setSessionMode("ask")
+        await fixture.controller.shutdown()
 
         let mutations = recordedRequests(at: fixture.recordURL, method: "session/set_config_option")
         let mutation = try XCTUnwrap(mutations.first)
@@ -215,6 +220,9 @@ final class ACPAgentSessionControllerModeConfigTests: XCTestCase {
             diagnostics: diagnostics
         )
         _ = try await fixture.controller.bootstrap()
+        try await waitUntil("incomplete config update rejection") {
+            diagnostics.values.contains { $0.contains("Ignoring") && $0.contains("config_option_update") }
+        }
         try await fixture.controller.setSessionMode("plan")
         await fixture.controller.shutdown()
 
@@ -233,6 +241,9 @@ final class ACPAgentSessionControllerModeConfigTests: XCTestCase {
             diagnostics: diagnostics
         )
         _ = try await fixture.controller.bootstrap()
+        try await waitUntil("malformed config update invalidation") {
+            diagnostics.values.contains { $0.contains("Invalidated session mode authority") }
+        }
         await assertThrows(containing: "malformed modern session mode config option") {
             try await fixture.controller.setSessionMode("ask")
         }
@@ -243,11 +254,16 @@ final class ACPAgentSessionControllerModeConfigTests: XCTestCase {
     }
 
     func testConfigOptionUpdateStateSurvivesTurnReuse() async throws {
+        let diagnostics = LockedStrings()
         let fixture = try makeFixture(
             shape: "modern",
-            extraEnvironment: ["ACP_NOTIFICATION_MODE": "plan"]
+            extraEnvironment: ["ACP_NOTIFICATION_MODE": "plan"],
+            diagnostics: diagnostics
         )
         _ = try await fixture.controller.bootstrap()
+        try await waitUntil("authoritative config update") {
+            diagnostics.values.contains("Processed authoritative config_option_update snapshot.")
+        }
         let didPrepare = await fixture.controller.prepareForNextTurn()
         XCTAssertTrue(didPrepare)
         try await fixture.controller.setSessionMode("plan")
@@ -502,7 +518,7 @@ final class ACPAgentSessionControllerModeConfigTests: XCTestCase {
                 config: CursorAgentConfig(
                     modelString: "model-b",
                     includeRepoPromptMCPServer: false,
-                    cleanupProjectMCPConfig: false,
+                    cleanupProjectMCPApproval: false,
                     sessionModeID: CursorAgentConfig.promptOnlySessionModeID
                 ),
                 workspacePath: workspace.path,

--- a/Tests/RepoPromptTests/AgentMode/ACPAgentSessionControllerModeConfigTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/ACPAgentSessionControllerModeConfigTests.swift
@@ -1,0 +1,1105 @@
+import Foundation
+@testable import RepoPrompt
+import XCTest
+
+final class ACPAgentSessionControllerModeConfigTests: XCTestCase {
+    private var temporaryURLs: [URL] = []
+
+    override func tearDown() {
+        for url in temporaryURLs {
+            try? FileManager.default.removeItem(at: url)
+        }
+        temporaryURLs.removeAll()
+        super.tearDown()
+    }
+
+    func testNewSessionModernModeUsesAdvertisedConfigIDAndCanonicalValue() async throws {
+        let fixture = try makeFixture(shape: "custom_id")
+        try await withBootstrappedController(fixture.controller) { controller in
+            try await controller.setSessionMode("PLAN")
+        }
+
+        let mutations = recordedRequests(at: fixture.recordURL, method: "session/set_config_option")
+        let mutation = try XCTUnwrap(mutations.first)
+        XCTAssertEqual(mutations.count, 1)
+        XCTAssertEqual(mutation.params["configId"] as? String, "permission_mode")
+        XCTAssertEqual(mutation.params["value"] as? String, "plan")
+    }
+
+    func testLoadSessionModernModeUsesConfigOptionEndpoint() async throws {
+        let fixture = try makeFixture(shape: "modern", resumeSessionID: "loaded-session")
+        try await withBootstrappedController(fixture.controller) { controller in
+            try await controller.setSessionMode("plan")
+        }
+
+        XCTAssertEqual(recordedRequests(at: fixture.recordURL, method: "session/load").count, 1)
+        XCTAssertEqual(recordedRequests(at: fixture.recordURL, method: "session/set_config_option").count, 1)
+    }
+
+    func testDualAdvertisementPrefersModernSnapshot() async throws {
+        let fixture = try makeFixture(shape: "dual")
+        try await withBootstrappedController(fixture.controller) { controller in
+            try await controller.setSessionMode("plan")
+        }
+
+        let modern = recordedRequests(at: fixture.recordURL, method: "session/set_config_option")
+        let mutation = try XCTUnwrap(modern.first)
+        XCTAssertEqual(modern.count, 1)
+        XCTAssertEqual(mutation.params["value"] as? String, "plan")
+    }
+
+    func testLegacyOnlyModeAdvertisementIsIgnored() async throws {
+        let diagnostics = LockedStrings()
+        let fixture = try makeFixture(shape: "legacy", diagnostics: diagnostics)
+        _ = try await fixture.controller.bootstrap()
+        await assertThrows(containing: "does not advertise a modern session mode configOptions selector") {
+            try await fixture.controller.setSessionMode("plan")
+        }
+        await fixture.controller.shutdown()
+
+        XCTAssertTrue(recordedMutationRequests(at: fixture.recordURL).isEmpty)
+        XCTAssertTrue(diagnostics.values.contains { $0.contains("Ignoring legacy ACP modes metadata") })
+    }
+
+    func testMissingModeAdvertisementPreservesUnsupportedError() async throws {
+        let fixture = try makeFixture(shape: "none")
+        _ = try await fixture.controller.bootstrap()
+        await assertThrows(containing: "does not advertise a modern session mode configOptions selector") {
+            try await fixture.controller.setSessionMode("plan")
+        }
+        await fixture.controller.shutdown()
+        XCTAssertTrue(recordedMutationRequests(at: fixture.recordURL).isEmpty)
+    }
+
+    func testMalformedModernModeFailsWithoutMutation() async throws {
+        let diagnostics = LockedStrings()
+        let fixture = try makeFixture(shape: "malformed", diagnostics: diagnostics)
+        _ = try await fixture.controller.bootstrap()
+        await assertThrows(containing: "malformed modern session mode config option") {
+            try await fixture.controller.setSessionMode("plan")
+        }
+        await fixture.controller.shutdown()
+
+        XCTAssertTrue(recordedMutationRequests(at: fixture.recordURL).isEmpty)
+        XCTAssertTrue(diagnostics.values.contains { $0.contains("malformed modern mode config option") })
+    }
+
+    func testMalformedModernModeRejectsExplicitDefaultWithoutMutation() async throws {
+        let fixture = try makeFixture(shape: "malformed")
+        _ = try await fixture.controller.bootstrap()
+        await assertThrows(containing: "malformed modern session mode config option") {
+            try await fixture.controller.setSessionMode("default")
+        }
+        await fixture.controller.shutdown()
+
+        XCTAssertTrue(recordedMutationRequests(at: fixture.recordURL).isEmpty)
+    }
+
+    func testAbsentModernModeAllowsImplicitDefaultWithoutMutation() async throws {
+        let fixture = try makeFixture(shape: "none")
+        try await withBootstrappedController(fixture.controller) { controller in
+            try await controller.setSessionMode("default")
+        }
+
+        XCTAssertTrue(recordedMutationRequests(at: fixture.recordURL).isEmpty)
+    }
+
+    func testDuplicateModernModeSelectorsFailWithoutMutation() async throws {
+        let fixture = try makeFixture(shape: "duplicate_mode")
+        _ = try await fixture.controller.bootstrap()
+        await assertThrows(containing: "multiple mode config options") {
+            try await fixture.controller.setSessionMode("plan")
+        }
+        await fixture.controller.shutdown()
+
+        XCTAssertTrue(recordedMutationRequests(at: fixture.recordURL).isEmpty)
+    }
+
+    func testConflictingModeSelectorSemanticsFailWithoutMutation() async throws {
+        let fixture = try makeFixture(shape: "conflicting_mode")
+        _ = try await fixture.controller.bootstrap()
+        await assertThrows(containing: "conflicting id/category semantics") {
+            try await fixture.controller.setSessionMode("plan")
+        }
+        await fixture.controller.shutdown()
+
+        XCTAssertTrue(recordedMutationRequests(at: fixture.recordURL).isEmpty)
+    }
+
+    func testGroupedModeChoicesAndUniqueCaseInsensitiveMatchUseCanonicalValue() async throws {
+        let fixture = try makeFixture(shape: "grouped")
+        try await withBootstrappedController(fixture.controller) { controller in
+            try await controller.setSessionMode("PLAN")
+        }
+
+        let mutation = try XCTUnwrap(recordedRequests(at: fixture.recordURL, method: "session/set_config_option").first)
+        XCTAssertEqual(mutation.params["value"] as? String, "Plan")
+    }
+
+    func testCaseCollidingModeChoicesRequireExactValue() async throws {
+        let fixture = try makeFixture(shape: "case_collision")
+        _ = try await fixture.controller.bootstrap()
+        await assertThrows(containing: "case-colliding") {
+            try await fixture.controller.setSessionMode("PLAN")
+        }
+        try await fixture.controller.setSessionMode("plan")
+        await fixture.controller.shutdown()
+
+        let mutation = try XCTUnwrap(recordedRequests(at: fixture.recordURL, method: "session/set_config_option").first)
+        XCTAssertEqual(mutation.params["value"] as? String, "plan")
+    }
+
+    func testInvalidModeListsCanonicalAvailableValues() async throws {
+        let fixture = try makeFixture(shape: "modern")
+        _ = try await fixture.controller.bootstrap()
+        await assertThrows(containing: "Available modes: ask, plan") {
+            try await fixture.controller.setSessionMode("unknown")
+        }
+        await fixture.controller.shutdown()
+        XCTAssertTrue(recordedMutationRequests(at: fixture.recordURL).isEmpty)
+    }
+
+    func testSuccessfulModernResponseUpdatesSnapshotAndSkipsDuplicateMutation() async throws {
+        let fixture = try makeFixture(shape: "modern")
+        try await withBootstrappedController(fixture.controller) { controller in
+            try await controller.setSessionMode("plan")
+            try await controller.setSessionMode("plan")
+        }
+
+        XCTAssertEqual(recordedRequests(at: fixture.recordURL, method: "session/set_config_option").count, 1)
+    }
+
+    func testModernMutationRequiresCompleteMatchingResponseAndNeverRetriesLegacy() async throws {
+        for behavior in ["empty", "missing_mode", "mismatch", "malformed"] {
+            let fixture = try makeFixture(
+                shape: "dual",
+                extraEnvironment: ["ACP_SET_RESPONSE": behavior]
+            )
+            _ = try await fixture.controller.bootstrap()
+            await assertThrows(containing: "session/set_config_option response") {
+                try await fixture.controller.setSessionMode("plan")
+            }
+            await fixture.controller.shutdown()
+
+            XCTAssertEqual(recordedRequests(at: fixture.recordURL, method: "session/set_config_option").count, 1, behavior)
+        }
+    }
+
+    func testMatchingConfigOptionUpdateReplacesStateAndSkipsSameValue() async throws {
+        let normalizedUpdates = LockedStrings()
+        let fixture = try makeFixture(
+            shape: "modern",
+            extraEnvironment: ["ACP_NOTIFICATION_MODE": "plan"],
+            normalizedUpdates: normalizedUpdates
+        )
+        try await withBootstrappedController(fixture.controller) { controller in
+            try await controller.setSessionMode("plan")
+            try await controller.setSessionMode("ask")
+        }
+
+        let mutations = recordedRequests(at: fixture.recordURL, method: "session/set_config_option")
+        let mutation = try XCTUnwrap(mutations.first)
+        XCTAssertEqual(mutations.count, 1)
+        XCTAssertEqual(mutation.params["value"] as? String, "ask")
+        XCTAssertFalse(normalizedUpdates.values.contains("config_option_update"))
+    }
+
+    func testIncompleteConfigOptionUpdateIsIgnored() async throws {
+        let diagnostics = LockedStrings()
+        let fixture = try makeFixture(
+            shape: "modern",
+            extraEnvironment: [
+                "ACP_NOTIFICATION_MODE": "plan",
+                "ACP_NOTIFICATION_BEHAVIOR": "missing"
+            ],
+            diagnostics: diagnostics
+        )
+        _ = try await fixture.controller.bootstrap()
+        try await fixture.controller.setSessionMode("plan")
+        await fixture.controller.shutdown()
+
+        XCTAssertEqual(recordedRequests(at: fixture.recordURL, method: "session/set_config_option").count, 1)
+        XCTAssertTrue(diagnostics.values.contains { $0.contains("Ignoring") && $0.contains("config_option_update") })
+    }
+
+    func testMalformedConfigOptionUpdateInvalidatesStaleModeAuthority() async throws {
+        let diagnostics = LockedStrings()
+        let fixture = try makeFixture(
+            shape: "modern",
+            extraEnvironment: [
+                "ACP_NOTIFICATION_MODE": "plan",
+                "ACP_NOTIFICATION_BEHAVIOR": "malformed"
+            ],
+            diagnostics: diagnostics
+        )
+        _ = try await fixture.controller.bootstrap()
+        await assertThrows(containing: "malformed modern session mode config option") {
+            try await fixture.controller.setSessionMode("ask")
+        }
+        await fixture.controller.shutdown()
+
+        XCTAssertTrue(recordedMutationRequests(at: fixture.recordURL).isEmpty)
+        XCTAssertTrue(diagnostics.values.contains { $0.contains("Invalidated session mode authority") })
+    }
+
+    func testConfigOptionUpdateStateSurvivesTurnReuse() async throws {
+        let fixture = try makeFixture(
+            shape: "modern",
+            extraEnvironment: ["ACP_NOTIFICATION_MODE": "plan"]
+        )
+        _ = try await fixture.controller.bootstrap()
+        let didPrepare = await fixture.controller.prepareForNextTurn()
+        XCTAssertTrue(didPrepare)
+        try await fixture.controller.setSessionMode("plan")
+        try await fixture.controller.setSessionMode("ask")
+        await fixture.controller.shutdown()
+
+        let mutations = recordedRequests(at: fixture.recordURL, method: "session/set_config_option")
+        let mutation = try XCTUnwrap(mutations.first)
+        XCTAssertEqual(mutations.count, 1)
+        XCTAssertEqual(mutation.params["value"] as? String, "ask")
+    }
+
+    func testWrongSessionConfigOptionUpdateIsIgnored() async throws {
+        let fixture = try makeFixture(
+            shape: "modern",
+            extraEnvironment: [
+                "ACP_NOTIFICATION_MODE": "plan",
+                "ACP_NOTIFICATION_SESSION_ID": "other-session"
+            ]
+        )
+        try await withBootstrappedController(fixture.controller) { controller in
+            try await controller.setSessionMode("plan")
+        }
+
+        XCTAssertEqual(recordedRequests(at: fixture.recordURL, method: "session/set_config_option").count, 1)
+    }
+
+    func testNewerNotificationRemainsAuthoritativeAfterMutationResponse() async throws {
+        let diagnostics = LockedStrings()
+        let fixture = try makeFixture(
+            shape: "modern",
+            extraEnvironment: [
+                "ACP_AFTER_SET_NOTIFICATION_MODE": "ask",
+                "ACP_AFTER_SET_NOTIFICATION_DELAY": "0.05"
+            ],
+            diagnostics: diagnostics
+        )
+        _ = try await fixture.controller.bootstrap()
+        try await fixture.controller.setSessionMode("plan")
+        try await waitUntil("authoritative config update") {
+            diagnostics.values.contains("Processed authoritative config_option_update snapshot.")
+        }
+        try await fixture.controller.setSessionMode("ask")
+        await fixture.controller.shutdown()
+
+        XCTAssertEqual(recordedRequests(at: fixture.recordURL, method: "session/set_config_option").count, 1)
+    }
+
+    func testMalformedNotificationAfterMutationInvalidatesConfirmedMode() async throws {
+        let diagnostics = LockedStrings()
+        let fixture = try makeFixture(
+            shape: "modern",
+            extraEnvironment: [
+                "ACP_AFTER_SET_NOTIFICATION_MODE": "ask",
+                "ACP_AFTER_SET_NOTIFICATION_BEHAVIOR": "malformed",
+                "ACP_AFTER_SET_NOTIFICATION_DELAY": "0.05"
+            ],
+            diagnostics: diagnostics
+        )
+        _ = try await fixture.controller.bootstrap()
+        try await fixture.controller.setSessionMode("plan")
+        try await waitUntil("malformed authoritative config update") {
+            diagnostics.values.contains { $0.contains("Invalidated session mode authority") }
+        }
+        await assertThrows(containing: "malformed modern session mode config option") {
+            try await fixture.controller.setSessionMode("plan")
+        }
+        await fixture.controller.shutdown()
+
+        XCTAssertEqual(recordedRequests(at: fixture.recordURL, method: "session/set_config_option").count, 1)
+    }
+
+    func testModernModelSelectorOverridesConflictingLegacyModels() async throws {
+        let fixture = try makeFixture(
+            shape: "modern",
+            extraEnvironment: [
+                "ACP_INCLUDE_MODEL": "1",
+                "ACP_MODEL_CONFIG_ID": "model_selector",
+                "ACP_INCLUDE_LEGACY_MODELS": "1"
+            ]
+        )
+        try await withBootstrappedController(fixture.controller) { controller in
+            try await controller.setSessionModel("model-b")
+        }
+
+        let mutation = try XCTUnwrap(recordedRequests(at: fixture.recordURL, method: "session/set_config_option").first)
+        XCTAssertEqual(mutation.params["configId"] as? String, "model_selector")
+        XCTAssertEqual(mutation.params["value"] as? String, "model-b")
+    }
+
+    func testMalformedModernModelDoesNotFallBackToLegacyModels() async throws {
+        let diagnostics = LockedStrings()
+        let fixture = try makeFixture(
+            shape: "modern",
+            extraEnvironment: [
+                "ACP_INCLUDE_MODEL": "1",
+                "ACP_MALFORMED_MODEL": "1",
+                "ACP_INCLUDE_LEGACY_MODELS": "1"
+            ],
+            diagnostics: diagnostics
+        )
+        _ = try await fixture.controller.bootstrap()
+        await assertThrows(containing: "malformed modern model config option") {
+            try await fixture.controller.setSessionModel("legacy-model")
+        }
+        await fixture.controller.shutdown()
+
+        XCTAssertTrue(recordedMutationRequests(at: fixture.recordURL).isEmpty)
+        XCTAssertTrue(diagnostics.values.contains { $0.contains("legacy fallback is disabled") })
+    }
+
+    func testModelCanonicalizationRejectsAmbiguityAndRequiresExactResponse() async throws {
+        do {
+            let fixture = try makeFixture(
+                shape: "modern",
+                extraEnvironment: [
+                    "ACP_INCLUDE_MODEL": "1",
+                    "ACP_MODEL_CASE_COLLISION": "1"
+                ]
+            )
+            _ = try await fixture.controller.bootstrap()
+            await assertThrows(containing: "case-colliding models") {
+                try await fixture.controller.setSessionModel("FOO")
+            }
+            await fixture.controller.shutdown()
+            XCTAssertTrue(recordedMutationRequests(at: fixture.recordURL).isEmpty)
+        }
+
+        do {
+            let fixture = try makeFixture(
+                shape: "modern",
+                extraEnvironment: [
+                    "ACP_INCLUDE_MODEL": "1",
+                    "ACP_MODEL_CASE_COLLISION": "1",
+                    "ACP_MODEL_RESPONSE_MISMATCH": "1"
+                ]
+            )
+            _ = try await fixture.controller.bootstrap()
+            await assertThrows(containing: "did not confirm requested model 'foo'") {
+                try await fixture.controller.setSessionModel("foo")
+            }
+            await fixture.controller.shutdown()
+
+            let mutation = try XCTUnwrap(recordedRequests(at: fixture.recordURL, method: "session/set_config_option").first)
+            XCTAssertEqual(mutation.params["value"] as? String, "foo")
+        }
+    }
+
+    func testModelAndModeMutationsAreSerializedAndModeRunsLast() async throws {
+        let releaseURL = try makeTemporaryDirectory().appendingPathComponent("release-model")
+        let fixture = try makeFixture(
+            shape: "modern",
+            extraEnvironment: [
+                "ACP_INCLUDE_MODEL": "1",
+                "ACP_MODEL_RELEASE_PATH": releaseURL.path,
+                "ACP_MODEL_CHANGES_MODE_CONFIG_ID": "1"
+            ],
+            modelString: "model-b"
+        )
+        _ = try await fixture.controller.bootstrap()
+
+        let modelTask = Task { try await fixture.controller.setSessionModel("model-b") }
+        try await waitUntil("model mutation request") {
+            self.recordedRequests(at: fixture.recordURL, method: "session/set_config_option")
+                .contains { $0.params["configId"] as? String == "model" }
+        }
+        let modeTask = Task { try await fixture.controller.setSessionMode("plan") }
+        try Data().write(to: releaseURL)
+        try await modelTask.value
+        try await modeTask.value
+        await fixture.controller.shutdown()
+
+        let mutations = recordedRequests(at: fixture.recordURL, method: "session/set_config_option")
+        XCTAssertEqual(mutations.compactMap { $0.params["configId"] as? String }, ["model", "mode_after_model"])
+    }
+
+    func testLoadFallbackToNewSessionDoesNotLeakModeConfiguration() async throws {
+        let fixture = try makeFixture(
+            shape: "none",
+            resumeSessionID: "missing-session",
+            extraEnvironment: ["ACP_FAIL_LOAD": "1"]
+        )
+        _ = try await fixture.controller.bootstrap()
+        await assertThrows(containing: "does not advertise a modern session mode configOptions selector") {
+            try await fixture.controller.setSessionMode("plan")
+        }
+        await fixture.controller.shutdown()
+
+        XCTAssertEqual(recordedRequests(at: fixture.recordURL, method: "session/load").count, 1)
+        XCTAssertEqual(recordedRequests(at: fixture.recordURL, method: "session/new").count, 1)
+        XCTAssertTrue(recordedMutationRequests(at: fixture.recordURL).isEmpty)
+    }
+
+    func testShutdownClearsSessionConfigurationAndRejectsFurtherMutation() async throws {
+        let fixture = try makeFixture(shape: "modern")
+        _ = try await fixture.controller.bootstrap()
+        await fixture.controller.shutdown()
+        await assertThrows(containing: "expected sessionOpen or promptRunning") {
+            try await fixture.controller.setSessionMode("plan")
+        }
+        XCTAssertTrue(recordedMutationRequests(at: fixture.recordURL).isEmpty)
+    }
+
+    func testHeadlessProvidersApplyModelBeforeMode() async throws {
+        do {
+            let workspace = try makeTemporaryDirectory()
+            let scriptURL = try makeFakeACPServerScript()
+            let recordURL = workspace.appendingPathComponent("opencode-headless.jsonl")
+            let fakeProvider = ModeConfigFakeACPProvider(
+                commandPath: scriptURL.path,
+                launchArguments: [],
+                environment: ["ACP_RECORD_PATH": recordURL.path, "ACP_SHAPE": "headless", "ACP_INCLUDE_MODEL": "1"],
+                mcpServers: []
+            )
+            let provider = OpenCodeACPHeadlessAgentProvider(
+                config: OpenCodeAgentConfig(
+                    modelString: "model-b",
+                    includeRepoPromptMCPServer: false,
+                    includeManagedConfigOverlay: false,
+                    cleanupLegacyPersistentConfig: false,
+                    toolProfile: .headless
+                ),
+                workspacePath: workspace.path,
+                providerFactory: { _ in fakeProvider }
+            )
+            try await drain(provider.streamAgentMessage(AgentMessage(userMessage: "OpenCode headless")))
+            await provider.dispose()
+
+            let relevant = recordedRequests(at: recordURL).filter {
+                $0.method == "session/set_config_option" || $0.method == "session/prompt"
+            }
+            XCTAssertEqual(relevant.map(\.method), ["session/set_config_option", "session/set_config_option", "session/prompt"])
+            let modelMutation = try XCTUnwrap(relevant.first)
+            let modeMutation = try XCTUnwrap(relevant.dropFirst().first)
+            XCTAssertEqual(modelMutation.params["configId"] as? String, "model")
+            XCTAssertEqual(modeMutation.params["configId"] as? String, "mode")
+            XCTAssertEqual(modeMutation.params["value"] as? String, OpenCodeAgentConfig.managedHeadlessSessionModeID)
+        }
+
+        do {
+            let workspace = try makeTemporaryDirectory()
+            let scriptURL = try makeFakeACPServerScript()
+            let recordURL = workspace.appendingPathComponent("cursor-headless.jsonl")
+            let fakeProvider = ModeConfigFakeACPProvider(
+                commandPath: scriptURL.path,
+                launchArguments: [],
+                environment: ["ACP_RECORD_PATH": recordURL.path, "ACP_SHAPE": "headless", "ACP_INCLUDE_MODEL": "1"],
+                mcpServers: [],
+                providerID: .cursor
+            )
+            let provider = CursorACPHeadlessAgentProvider(
+                config: CursorAgentConfig(
+                    modelString: "model-b",
+                    includeRepoPromptMCPServer: false,
+                    cleanupProjectMCPConfig: false,
+                    sessionModeID: CursorAgentConfig.promptOnlySessionModeID
+                ),
+                workspacePath: workspace.path,
+                providerFactory: { _ in fakeProvider }
+            )
+            try await drain(provider.streamAgentMessage(AgentMessage(userMessage: "Cursor headless")))
+            await provider.dispose()
+
+            let relevant = recordedRequests(at: recordURL).filter {
+                $0.method == "session/set_config_option" || $0.method == "session/prompt"
+            }
+            XCTAssertEqual(relevant.map(\.method), ["session/set_config_option", "session/set_config_option", "session/prompt"])
+            let modelMutation = try XCTUnwrap(relevant.first)
+            let modeMutation = try XCTUnwrap(relevant.dropFirst().first)
+            XCTAssertEqual(modelMutation.params["configId"] as? String, "model")
+            XCTAssertEqual(modeMutation.params["configId"] as? String, "mode")
+            XCTAssertEqual(modeMutation.params["value"] as? String, CursorAgentConfig.promptOnlySessionModeID)
+        }
+    }
+
+    func testLaunchConfigurationDiagnosticsRedactSecretFlagsAndJSONFields() throws {
+        #if DEBUG
+            let launchConfiguration = ACPLaunchConfiguration(
+                providerID: .openCode,
+                command: "/bin/echo",
+                arguments: [
+                    "acp",
+                    "--api-key",
+                    "flag-secret",
+                    "--password=inline-secret",
+                    #"{"token":"json-token","nested":{"password":"json-password","apiKey":"json-key","key":"generic-json-key","label":"visible"}}"#
+                ],
+                environment: [:],
+                workingDirectory: "/tmp",
+                additionalPathHints: [],
+                enableDebugLogging: false
+            )
+
+            let payload = ACPAgentSessionController.debugLaunchConfigurationTracePayloadForTesting(launchConfiguration)
+            let arguments = try XCTUnwrap(payload["arguments"] as? [String])
+            XCTAssertEqual(Array(arguments[0 ... 3]), ["acp", "--api-key", "<redacted>", "--password=<redacted>"])
+            let jsonArgument = try XCTUnwrap(arguments.last)
+            XCTAssertTrue(jsonArgument.contains(#""label":"visible""#))
+            XCTAssertEqual(jsonArgument.components(separatedBy: "<redacted>").count - 1, 4)
+            for secret in ["flag-secret", "inline-secret", "json-token", "json-password", "json-key", "generic-json-key"] {
+                XCTAssertFalse(String(describing: payload).contains(secret), secret)
+            }
+        #else
+            throw XCTSkip("Launch configuration diagnostics are DEBUG-only.")
+        #endif
+    }
+
+    func testControllerPersistsRedactedRunCorrelatedLaunchContract() async throws {
+        #if DEBUG
+            let runID = UUID()
+            await ServerNetworkManager.shared.debugClearRunRoutingHistoryForTesting()
+            let injectedServer = RepoPromptMCPServerConfiguration(
+                name: "RepoPromptFixture",
+                command: "/bin/echo",
+                args: [
+                    "API_TOKEN=helper-secret",
+                    "--header",
+                    "Authorization: Bearer helper-header-secret",
+                    "tools"
+                ]
+            )
+            let openCodeOverlay: [String: Any] = [
+                "mcp": [
+                    RepoPromptMCPServerConfiguration.defaultServerName: [
+                        "enabled": true,
+                        "command": ["/bin/echo", "--header", "Authorization: Bearer overlay-secret", "tools"]
+                    ],
+                    "UnrelatedServer": [
+                        "enabled": true,
+                        "command": ["/bin/echo", "UNRELATED_SECRET=do-not-record"]
+                    ]
+                ]
+            ]
+            let overlayData = try JSONSerialization.data(withJSONObject: openCodeOverlay)
+            let overlayJSON = try XCTUnwrap(String(data: overlayData, encoding: .utf8))
+            let fixture = try makeFixture(
+                shape: "modern",
+                extraEnvironment: ["OPENCODE_CONFIG_CONTENT": overlayJSON],
+                launchArguments: [
+                    "OPENAI_API_KEY=launch-secret",
+                    "--header",
+                    "Authorization: Bearer launch-header-secret",
+                    "--prompt",
+                    "private user prompt",
+                    #"{"accessToken":"launch-json-token","nested":{"password":"launch-json-password","label":"visible"}}"#,
+                    String(repeating: "x", count: 600)
+                ],
+                mcpServers: [injectedServer]
+            )
+            await fixture.controller.setExpectedMCPRunID(runID)
+            try await withBootstrappedController(fixture.controller) { _ in }
+
+            let payload = await ServerNetworkManager.shared.debugRunRoutingHistoryPayload(runID: runID, limit: 20)
+            let events = try XCTUnwrap(payload["events"] as? [[String: Any]])
+            let resolved = try XCTUnwrap(events.first { $0["event"] as? String == "acp_launch_contract_resolved" })
+            let spawned = try XCTUnwrap(events.first { $0["event"] as? String == "acp_process_spawned" })
+            let fields = try XCTUnwrap(resolved["fields"] as? [String: String])
+            let spawnedFields = try XCTUnwrap(spawned["fields"] as? [String: String])
+
+            XCTAssertEqual(fields["provider_id"], ACPProviderID.openCode.rawValue)
+            XCTAssertEqual(fields["configured_command"], fixture.scriptURL.path)
+            XCTAssertEqual(fields["resolved_executable"], fixture.scriptURL.path)
+            XCTAssertTrue(fields["final_args"]?.contains("OPENAI_API_KEY=<redacted>") == true)
+            XCTAssertTrue(fields["final_args"]?.contains("--header <redacted>") == true)
+            XCTAssertTrue(fields["final_args"]?.contains("--prompt <redacted>") == true)
+            XCTAssertLessThanOrEqual(fields["final_args"]?.count ?? .max, 481)
+            XCTAssertTrue(fields["injected_mcp_command"]?.contains("API_TOKEN=<redacted>") == true)
+            XCTAssertTrue(fields["injected_mcp_command"]?.contains("--header <redacted> tools") == true)
+            XCTAssertTrue(fields["injected_mcp_command"]?.contains(RepoPromptMCPServerConfiguration.defaultServerName) == true)
+            XCTAssertFalse(fields["injected_mcp_command"]?.contains("UnrelatedServer") == true)
+            XCTAssertNotNil(Int(spawnedFields["acp_pid"] ?? ""))
+            for secret in [
+                "launch-secret",
+                "launch-header-secret",
+                "private user prompt",
+                "launch-json-token",
+                "launch-json-password",
+                "helper-secret",
+                "helper-header-secret",
+                "overlay-secret",
+                "do-not-record"
+            ] {
+                XCTAssertFalse(String(describing: events).contains(secret), secret)
+            }
+        #else
+            throw XCTSkip("Run-correlated launch history is DEBUG-only.")
+        #endif
+    }
+
+    private struct Fixture {
+        let controller: ACPAgentSessionController
+        let recordURL: URL
+        let scriptURL: URL
+    }
+
+    private struct RecordedRequest {
+        let method: String
+        let params: [String: Any]
+    }
+
+    private func makeFixture(
+        shape: String,
+        resumeSessionID: String? = nil,
+        extraEnvironment: [String: String] = [:],
+        modelString: String? = nil,
+        launchArguments: [String] = [],
+        mcpServers: [RepoPromptMCPServerConfiguration] = [],
+        diagnostics: LockedStrings? = nil,
+        normalizedUpdates: LockedStrings? = nil
+    ) throws -> Fixture {
+        let workspace = try makeTemporaryDirectory()
+        let scriptURL = try makeFakeACPServerScript()
+        let recordURL = workspace.appendingPathComponent("requests.jsonl")
+        var environment = extraEnvironment
+        environment["ACP_RECORD_PATH"] = recordURL.path
+        environment["ACP_SHAPE"] = shape
+        let request = ACPRunRequest(
+            agentKind: .openCode,
+            modelString: modelString,
+            workspacePath: workspace.path,
+            resumeSessionID: resumeSessionID,
+            attachments: [],
+            taskLabelKind: nil
+        )
+        let provider = ModeConfigFakeACPProvider(
+            commandPath: scriptURL.path,
+            launchArguments: launchArguments,
+            environment: environment,
+            mcpServers: mcpServers,
+            normalizedUpdates: normalizedUpdates
+        )
+        let controller = try ACPAgentSessionController(
+            provider: provider,
+            runRequest: request,
+            diagnosticSink: { event in
+                if case let .info(message) = event {
+                    diagnostics?.append(message)
+                }
+            }
+        )
+        return Fixture(controller: controller, recordURL: recordURL, scriptURL: scriptURL)
+    }
+
+    private func drain(_ stream: AsyncThrowingStream<AIStreamResult, Error>) async throws {
+        for try await _ in stream {}
+    }
+
+    private func withBootstrappedController(
+        _ controller: ACPAgentSessionController,
+        operation: (ACPAgentSessionController) async throws -> Void
+    ) async throws {
+        do {
+            _ = try await controller.bootstrap()
+            try await operation(controller)
+            await controller.shutdown()
+        } catch {
+            await controller.shutdown()
+            throw error
+        }
+    }
+
+    private func assertThrows(
+        containing expectedText: String,
+        operation: () async throws -> Void
+    ) async {
+        do {
+            try await operation()
+            XCTFail("Expected operation to throw an error containing: \(expectedText)")
+        } catch {
+            XCTAssertTrue(
+                error.localizedDescription.contains(expectedText),
+                "Expected '\(error.localizedDescription)' to contain '\(expectedText)'"
+            )
+        }
+    }
+
+    private func waitUntil(
+        _ description: String,
+        timeout: TimeInterval = 3,
+        condition: @escaping () -> Bool
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if condition() { return }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTFail("Timed out waiting for \(description)")
+    }
+
+    private func recordedMutationRequests(at url: URL) -> [RecordedRequest] {
+        recordedRequests(at: url).filter { request in
+            request.method == "session/set_config_option"
+        }
+    }
+
+    private func recordedRequests(at url: URL, method: String? = nil) -> [RecordedRequest] {
+        guard let data = try? Data(contentsOf: url),
+              let text = String(data: data, encoding: .utf8)
+        else { return [] }
+        return text.split(whereSeparator: { $0.isNewline }).compactMap { line in
+            guard let data = String(line).data(using: .utf8),
+                  let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let recordedMethod = object["method"] as? String,
+                  method == nil || method == recordedMethod
+            else { return nil }
+            return RecordedRequest(
+                method: recordedMethod,
+                params: object["params"] as? [String: Any] ?? [:]
+            )
+        }
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ACPAgentSessionControllerModeConfigTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        temporaryURLs.append(url)
+        return url
+    }
+
+    private func makeFakeACPServerScript() throws -> URL {
+        let directory = try makeTemporaryDirectory()
+        let scriptURL = directory.appendingPathComponent("fake_mode_config_acp_server.py")
+        let script = #"""
+        #!/usr/bin/env python3
+        import json
+        import os
+        import sys
+        import threading
+        import time
+
+        record_path = os.environ.get("ACP_RECORD_PATH")
+        shape = os.environ.get("ACP_SHAPE", "modern")
+        session_id = os.environ.get("ACP_SESSION_ID", "mode-config-session")
+        current_mode = "base" if shape == "headless" else "ask"
+        current_model = "Foo" if os.environ.get("ACP_MODEL_CASE_COLLISION") == "1" else "model-a"
+        mode_config_id = "permission_mode" if shape == "custom_id" else "mode"
+        output_lock = threading.Lock()
+
+        def record(method, params):
+            if not record_path:
+                return
+            with open(record_path, "a", encoding="utf-8") as handle:
+                handle.write(json.dumps({"method": method, "params": params}) + "\n")
+
+        def send(payload):
+            with output_lock:
+                print(json.dumps(payload), flush=True)
+
+        def respond(request_id, result=None, error=None):
+            payload = {"jsonrpc": "2.0", "id": request_id}
+            if error is not None:
+                payload["error"] = error
+            else:
+                payload["result"] = result if result is not None else {}
+            send(payload)
+
+        def choices():
+            if shape == "grouped":
+                return [{"name": "Workflow", "options": [
+                    {"value": "ask", "name": "Ask"},
+                    {"value": "Plan", "name": "Plan"}
+                ]}]
+            if shape == "headless":
+                return [
+                    {"value": "base", "name": "Base"},
+                    {"value": "ask", "name": "Ask"},
+                    {"value": "repoprompt_headless", "name": "RepoPrompt Headless"}
+                ]
+            if shape == "case_collision":
+                return [
+                    {"value": "ask", "name": "Ask"},
+                    {"value": "Plan", "name": "Plan Upper"},
+                    {"value": "plan", "name": "Plan Lower"}
+                ]
+            return [
+                {"value": "ask", "name": "Ask"},
+                {"value": "plan", "name": "Plan"}
+            ]
+
+        def mode_option(value=None, malformed=False):
+            option = {
+                "id": mode_config_id,
+                "name": "Session Mode",
+                "category": "mode",
+                "type": "text" if malformed else "select",
+                "currentValue": value if value is not None else current_mode,
+                "options": choices()
+            }
+            return option
+
+        def model_option(value=None):
+            model_choices = [
+                {"value": "Foo", "name": "Foo Upper"},
+                {"value": "foo", "name": "Foo Lower"}
+            ] if os.environ.get("ACP_MODEL_CASE_COLLISION") == "1" else [
+                {"value": "model-a", "name": "Model A"},
+                {"value": "model-b", "name": "Model B"}
+            ]
+            return {
+                "id": os.environ.get("ACP_MODEL_CONFIG_ID", "model"),
+                "name": "Model",
+                "category": "model",
+                "type": "text" if os.environ.get("ACP_MALFORMED_MODEL") == "1" else "select",
+                "currentValue": value if value is not None else current_model,
+                "options": model_choices
+            }
+
+        def config_options(mode_value=None, include_mode=True, malformed_mode=False, model_value=None):
+            result = []
+            if os.environ.get("ACP_INCLUDE_MODEL") == "1":
+                result.append(model_option(model_value))
+            if include_mode:
+                result.append(mode_option(mode_value, malformed_mode))
+            return result
+
+        def session_result(result_session_id):
+            result = {"sessionId": result_session_id}
+            if shape in ("modern", "custom_id", "grouped", "case_collision", "headless"):
+                result["configOptions"] = config_options()
+            elif shape == "duplicate_mode":
+                result["configOptions"] = [mode_option(), mode_option()]
+            elif shape == "conflicting_mode":
+                conflicting = mode_option()
+                conflicting["id"] = "mode"
+                conflicting["category"] = "model"
+                result["configOptions"] = [conflicting]
+            elif shape == "dual":
+                result["configOptions"] = config_options()
+                result["modes"] = {
+                    "currentModeId": "legacy-only",
+                    "availableModes": [{"id": "legacy-only", "name": "Legacy Only"}]
+                }
+            elif shape == "legacy":
+                result["modes"] = {
+                    "currentModeId": current_mode,
+                    "availableModes": [
+                        {"id": "ask", "name": "Ask"},
+                        {"id": "plan", "name": "Plan"}
+                    ]
+                }
+            elif shape == "malformed":
+                result["configOptions"] = config_options(malformed_mode=True)
+                result["modes"] = {
+                    "currentModeId": current_mode,
+                    "availableModes": ["ask", "plan"]
+                }
+            if os.environ.get("ACP_INCLUDE_MODEL") == "1" and "configOptions" not in result:
+                result["configOptions"] = [model_option()]
+            if os.environ.get("ACP_INCLUDE_LEGACY_MODELS") == "1":
+                result["models"] = {
+                    "currentModelId": "legacy-model",
+                    "availableModels": [{"modelId": "legacy-model", "name": "Legacy Model"}]
+                }
+            return result
+
+        def notification_payload(mode, notify_session_id=None, behavior_override=None):
+            update = {"sessionUpdate": "config_option_update"}
+            behavior = behavior_override or os.environ.get("ACP_NOTIFICATION_BEHAVIOR", "valid")
+            if behavior == "malformed":
+                update["configOptions"] = config_options(mode_value=mode, malformed_mode=True)
+            elif behavior != "missing":
+                update["configOptions"] = config_options(mode_value=mode)
+            return {
+                "jsonrpc": "2.0",
+                "method": "session/update",
+                "params": {
+                    "sessionId": notify_session_id or session_id,
+                    "update": update
+                }
+            }
+
+        def notify(mode, notify_session_id=None):
+            send(notification_payload(mode, notify_session_id))
+
+        def respond_then_notify(request_id, result, mode, notify_session_id=None, behavior_override=None):
+            response_payload = {"jsonrpc": "2.0", "id": request_id, "result": result}
+            update_payload = notification_payload(mode, notify_session_id, behavior_override)
+            with output_lock:
+                sys.stdout.write(json.dumps(response_payload) + "\n" + json.dumps(update_payload) + "\n")
+                sys.stdout.flush()
+
+        def set_config_response():
+            behavior = os.environ.get("ACP_SET_RESPONSE", "valid")
+            if behavior == "empty":
+                return {}
+            if behavior == "missing_mode":
+                return {"configOptions": [model_option()]}
+            if behavior == "mismatch":
+                return {"configOptions": config_options(mode_value="ask")}
+            if behavior == "malformed":
+                return {"configOptions": config_options(malformed_mode=True)}
+            if os.environ.get("ACP_MODEL_RESPONSE_MISMATCH") == "1":
+                return {"configOptions": config_options(model_value="Foo")}
+            return {"configOptions": config_options()}
+
+        def delayed_model_response(request_id):
+            release_path = os.environ.get("ACP_MODEL_RELEASE_PATH")
+            while release_path and not os.path.exists(release_path):
+                time.sleep(0.005)
+            respond(request_id, {"configOptions": config_options()})
+
+        for line in sys.stdin:
+            try:
+                request = json.loads(line)
+            except Exception:
+                continue
+            method = request.get("method")
+            params = request.get("params") or {}
+            record(method, params)
+            if method == "initialize":
+                respond(request.get("id"), {"agentCapabilities": {"loadSession": True}, "authMethods": []})
+            elif method == "session/load":
+                if os.environ.get("ACP_FAIL_LOAD") == "1":
+                    respond(request.get("id"), error={"code": -32602, "message": "session not found"})
+                else:
+                    opened_session_id = params.get("sessionId") or session_id
+                    notification_mode = os.environ.get("ACP_NOTIFICATION_MODE")
+                    if notification_mode:
+                        respond_then_notify(
+                            request.get("id"),
+                            session_result(opened_session_id),
+                            notification_mode,
+                            os.environ.get("ACP_NOTIFICATION_SESSION_ID") or opened_session_id
+                        )
+                    else:
+                        respond(request.get("id"), session_result(opened_session_id))
+            elif method == "session/new":
+                notification_mode = os.environ.get("ACP_NOTIFICATION_MODE")
+                if notification_mode:
+                    respond_then_notify(
+                        request.get("id"),
+                        session_result(session_id),
+                        notification_mode,
+                        os.environ.get("ACP_NOTIFICATION_SESSION_ID") or session_id
+                    )
+                else:
+                    respond(request.get("id"), session_result(session_id))
+            elif method == "session/set_config_option":
+                config_id = params.get("configId")
+                if config_id == os.environ.get("ACP_MODEL_CONFIG_ID", "model"):
+                    current_model = params.get("value")
+                    if os.environ.get("ACP_MODEL_CHANGES_MODE_CONFIG_ID") == "1":
+                        mode_config_id = "mode_after_model"
+                    if os.environ.get("ACP_MODEL_RELEASE_PATH"):
+                        threading.Thread(target=delayed_model_response, args=(request.get("id"),), daemon=True).start()
+                        continue
+                else:
+                    current_mode = params.get("value")
+                after_mode = os.environ.get("ACP_AFTER_SET_NOTIFICATION_MODE")
+                if after_mode:
+                    response_result = set_config_response()
+                    current_mode = after_mode
+                    delay = float(os.environ.get("ACP_AFTER_SET_NOTIFICATION_DELAY", "0"))
+                    after_behavior = os.environ.get("ACP_AFTER_SET_NOTIFICATION_BEHAVIOR")
+                    if delay > 0:
+                        respond(request.get("id"), response_result)
+                        time.sleep(delay)
+                        send(notification_payload(after_mode, behavior_override=after_behavior))
+                    else:
+                        respond_then_notify(
+                            request.get("id"),
+                            response_result,
+                            after_mode,
+                            behavior_override=after_behavior
+                        )
+                else:
+                    respond(request.get("id"), set_config_response())
+            elif method == "session/prompt":
+                respond(request.get("id"), {"stopReason": "end_turn", "usage": {"inputTokens": 1, "outputTokens": 1}})
+            else:
+                respond(request.get("id"), {})
+        """#
+        try script.write(to: scriptURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: scriptURL.path)
+        return scriptURL
+    }
+}
+
+private final class LockedStrings: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [String] = []
+
+    var values: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage
+    }
+
+    func append(_ value: String) {
+        lock.lock()
+        storage.append(value)
+        lock.unlock()
+    }
+}
+
+private struct ModeConfigFakeACPProvider: ACPAgentProvider {
+    let commandPath: String
+    let launchArguments: [String]
+    let environment: [String: String]
+    let mcpServers: [RepoPromptMCPServerConfiguration]
+    var providerID: ACPProviderID = .openCode
+    var normalizedUpdates: LockedStrings?
+
+    func support(for request: ACPRunRequest) async -> ACPSupportResult {
+        .supported
+    }
+
+    func makeLaunchConfiguration(for request: ACPRunRequest) throws -> ACPLaunchConfiguration {
+        ACPLaunchConfiguration(
+            providerID: providerID,
+            command: commandPath,
+            arguments: launchArguments,
+            environment: environment,
+            workingDirectory: request.workspacePath,
+            additionalPathHints: [],
+            enableDebugLogging: false
+        )
+    }
+
+    func makeSessionConfiguration(
+        for request: ACPRunRequest,
+        mcpServer: RepoPromptMCPServerConfiguration
+    ) throws -> ACPSessionConfiguration {
+        let mode: ACPSessionConfiguration.Mode = if let resume = request.resumeSessionID {
+            .load(existingSessionID: resume)
+        } else {
+            .new
+        }
+        return ACPSessionConfiguration(
+            mode: mode,
+            workingDirectory: request.workspacePath ?? FileManager.default.temporaryDirectory.path,
+            mcpServers: mcpServers
+        )
+    }
+
+    func buildPromptBlocks(
+        for message: AgentMessage,
+        request: ACPRunRequest
+    ) throws -> [[String: Any]] {
+        [["type": "text", "text": message.userMessage]]
+    }
+
+    func normalizeSessionUpdate(
+        _ payload: [String: Any],
+        sessionID: String
+    ) -> [NormalizedAgentRuntimeEvent] {
+        normalizedUpdates?.append(payload["sessionUpdate"] as? String ?? "unknown")
+        return []
+    }
+
+    func normalizeError(_ error: Error) -> Error {
+        error
+    }
+}

--- a/Tests/RepoPromptTests/AgentMode/ACPSynchronousMCPStartupTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/ACPSynchronousMCPStartupTests.swift
@@ -36,6 +36,9 @@ final class ACPSynchronousMCPStartupTests: XCTestCase {
             runRequest: request,
             requestTimeouts: .init(bootstrapSeconds: 2)
         )
+        addTeardownBlock {
+            await controller.shutdown()
+        }
 
         let bootstrap = try await controller.bootstrap()
         await controller.shutdown()
@@ -73,6 +76,9 @@ final class ACPSynchronousMCPStartupTests: XCTestCase {
             runRequest: request,
             requestTimeouts: .init(bootstrapSeconds: 2)
         )
+        addTeardownBlock {
+            await controller.shutdown()
+        }
 
         let bootstrap = try await controller.bootstrap()
         await controller.shutdown()
@@ -128,6 +134,9 @@ final class ACPSynchronousMCPStartupTests: XCTestCase {
             runRequest: request,
             requestTimeouts: .init(bootstrapSeconds: 2)
         )
+        addTeardownBlock {
+            await controller.shutdown()
+        }
 
         let bootstrap = try await controller.bootstrap()
         await controller.shutdown()

--- a/Tests/RepoPromptTests/AgentMode/ACPSynchronousMCPStartupTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/ACPSynchronousMCPStartupTests.swift
@@ -1,0 +1,309 @@
+import Foundation
+@testable import RepoPrompt
+import XCTest
+
+final class ACPSynchronousMCPStartupTests: XCTestCase {
+    private var temporaryURLs: [URL] = []
+
+    override func tearDown() {
+        for url in temporaryURLs {
+            try? FileManager.default.removeItem(at: url)
+        }
+        temporaryURLs.removeAll()
+        super.tearDown()
+    }
+
+    func testOpenCodeStyleSessionNewWaitsForMCPInitializeAndToolsList() async throws {
+        let workspace = try makeTemporaryDirectory()
+        let recordURL = workspace.appendingPathComponent("opencode-startup.jsonl")
+        let acpScriptURL = try makeACPServerScript()
+        let mcpScriptURL = try makeMCPServerScript()
+        let request = makeRunRequest(agentKind: .openCode, workspacePath: workspace.path)
+        let provider = SynchronousStartupFakeACPProvider(
+            providerID: .openCode,
+            commandPath: acpScriptURL.path,
+            environment: [
+                "ACP_STARTUP_STYLE": "opencode",
+                "ACP_RECORD_PATH": recordURL.path
+            ],
+            mcpServer: RepoPromptMCPServerConfiguration(
+                name: "RepoPromptFixture",
+                command: mcpScriptURL.path
+            )
+        )
+        let controller = try ACPAgentSessionController(
+            provider: provider,
+            runRequest: request,
+            requestTimeouts: .init(bootstrapSeconds: 2)
+        )
+
+        let bootstrap = try await controller.bootstrap()
+        await controller.shutdown()
+
+        XCTAssertEqual(bootstrap.sessionID, "opencode-session")
+        XCTAssertEqual(
+            recordedEvents(at: recordURL),
+            ["session_new_started", "mcp_initialize_completed", "mcp_tools_list_completed", "session_new_response"]
+        )
+    }
+
+    func testCursorStyleSessionNewCatchesSynchronousMCPStartupFailureAndReturns() async throws {
+        let workspace = try makeTemporaryDirectory()
+        let recordURL = workspace.appendingPathComponent("cursor-startup.jsonl")
+        let acpScriptURL = try makeACPServerScript()
+        let mcpScriptURL = try makeMCPServerScript()
+        let request = makeRunRequest(agentKind: .cursor, workspacePath: workspace.path)
+        let provider = SynchronousStartupFakeACPProvider(
+            providerID: .cursor,
+            commandPath: acpScriptURL.path,
+            environment: [
+                "ACP_STARTUP_STYLE": "cursor",
+                "ACP_RECORD_PATH": recordURL.path
+            ],
+            mcpServer: RepoPromptMCPServerConfiguration(
+                name: "RepoPromptFixture",
+                command: mcpScriptURL.path,
+                args: ["--fail"]
+            )
+        )
+        let controller = try ACPAgentSessionController(
+            provider: provider,
+            runRequest: request,
+            requestTimeouts: .init(bootstrapSeconds: 2)
+        )
+
+        let bootstrap = try await controller.bootstrap()
+        await controller.shutdown()
+
+        XCTAssertEqual(bootstrap.sessionID, "cursor-session")
+        XCTAssertEqual(
+            recordedEvents(at: recordURL),
+            ["session_new_started", "mcp_startup_failed", "session_new_response"]
+        )
+    }
+
+    private func makeRunRequest(agentKind: AgentProviderKind, workspacePath: String) -> ACPRunRequest {
+        ACPRunRequest(
+            agentKind: agentKind,
+            modelString: nil,
+            workspacePath: workspacePath,
+            resumeSessionID: nil,
+            attachments: [],
+            taskLabelKind: nil
+        )
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ACPSynchronousMCPStartupTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        temporaryURLs.append(url)
+        return url
+    }
+
+    private func makeACPServerScript() throws -> URL {
+        let directory = try makeTemporaryDirectory()
+        let scriptURL = directory.appendingPathComponent("fake_synchronous_acp.py")
+        let script = #"""
+        #!/usr/bin/env python3
+        import json
+        import os
+        import subprocess
+        import sys
+
+        style = os.environ.get("ACP_STARTUP_STYLE", "opencode")
+        record_path = os.environ["ACP_RECORD_PATH"]
+
+        def record(event):
+            with open(record_path, "a", encoding="utf-8") as handle:
+                handle.write(json.dumps({"event": event}) + "\n")
+
+        def respond(request_id, result=None, error=None):
+            payload = {"jsonrpc": "2.0", "id": request_id}
+            if error is not None:
+                payload["error"] = error
+            else:
+                payload["result"] = result or {}
+            print(json.dumps(payload), flush=True)
+
+        def start_mcp(server):
+            env = os.environ.copy()
+            for entry in server.get("env") or []:
+                env[entry["name"]] = entry["value"]
+            process = subprocess.Popen(
+                [server["command"], *(server.get("args") or [])],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                env=env,
+            )
+            try:
+                process.stdin.write(json.dumps({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "initialize",
+                    "params": {
+                        "protocolVersion": "2025-11-25",
+                        "capabilities": {},
+                        "clientInfo": {"name": style, "version": "fixture"},
+                    },
+                }) + "\n")
+                process.stdin.flush()
+                if not process.stdout.readline():
+                    raise RuntimeError("MCP initialize failed")
+                record("mcp_initialize_completed")
+                process.stdin.write(json.dumps({
+                    "jsonrpc": "2.0",
+                    "method": "notifications/initialized",
+                    "params": {},
+                }) + "\n")
+                process.stdin.write(json.dumps({
+                    "jsonrpc": "2.0",
+                    "id": 2,
+                    "method": "tools/list",
+                    "params": {},
+                }) + "\n")
+                process.stdin.flush()
+                if not process.stdout.readline():
+                    raise RuntimeError("MCP tools/list failed")
+                record("mcp_tools_list_completed")
+            finally:
+                if process.stdin:
+                    process.stdin.close()
+                process.terminate()
+                process.wait(timeout=1)
+
+        for line in sys.stdin:
+            try:
+                request = json.loads(line)
+            except Exception:
+                continue
+            method = request.get("method")
+            params = request.get("params") or {}
+            if method == "initialize":
+                respond(request.get("id"), {"agentCapabilities": {"loadSession": False}, "authMethods": []})
+            elif method == "session/new":
+                record("session_new_started")
+                try:
+                    start_mcp((params.get("mcpServers") or [])[0])
+                except Exception:
+                    record("mcp_startup_failed")
+                    if style == "opencode":
+                        respond(request.get("id"), error={"code": -32000, "message": "MCP startup failed"})
+                        continue
+                record("session_new_response")
+                respond(request.get("id"), {"sessionId": style + "-session"})
+            else:
+                respond(request.get("id"), {})
+        """#
+        try script.write(to: scriptURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: scriptURL.path)
+        return scriptURL
+    }
+
+    private func makeMCPServerScript() throws -> URL {
+        let directory = try makeTemporaryDirectory()
+        let scriptURL = directory.appendingPathComponent("fake_mcp_server.py")
+        let script = #"""
+        #!/usr/bin/env python3
+        import json
+        import sys
+
+        if "--fail" in sys.argv:
+            sys.exit(7)
+
+        for line in sys.stdin:
+            try:
+                request = json.loads(line)
+            except Exception:
+                continue
+            request_id = request.get("id")
+            method = request.get("method")
+            if request_id is None:
+                continue
+            if method == "initialize":
+                result = {
+                    "protocolVersion": "2025-11-25",
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {"name": "RepoPromptFixture", "version": "1"},
+                }
+            elif method == "tools/list":
+                result = {"tools": [{
+                    "name": "read_file",
+                    "description": "fixture",
+                    "inputSchema": {"type": "object", "properties": {}},
+                }]}
+            else:
+                result = {}
+            print(json.dumps({"jsonrpc": "2.0", "id": request_id, "result": result}), flush=True)
+        """#
+        try script.write(to: scriptURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: scriptURL.path)
+        return scriptURL
+    }
+
+    private func recordedEvents(at url: URL) -> [String] {
+        guard let data = try? Data(contentsOf: url),
+              let text = String(data: data, encoding: .utf8)
+        else { return [] }
+        return text.split(whereSeparator: { $0.isNewline }).compactMap { line in
+            guard let data = String(line).data(using: .utf8),
+                  let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+            else { return nil }
+            return object["event"] as? String
+        }
+    }
+}
+
+private struct SynchronousStartupFakeACPProvider: ACPAgentProvider {
+    let providerID: ACPProviderID
+    let commandPath: String
+    let environment: [String: String]
+    let mcpServer: RepoPromptMCPServerConfiguration
+
+    func support(for request: ACPRunRequest) async -> ACPSupportResult {
+        .supported
+    }
+
+    func makeLaunchConfiguration(for request: ACPRunRequest) throws -> ACPLaunchConfiguration {
+        ACPLaunchConfiguration(
+            providerID: providerID,
+            command: commandPath,
+            arguments: [],
+            environment: environment,
+            workingDirectory: request.workspacePath,
+            additionalPathHints: [],
+            enableDebugLogging: false
+        )
+    }
+
+    func makeSessionConfiguration(
+        for request: ACPRunRequest,
+        mcpServer _: RepoPromptMCPServerConfiguration
+    ) throws -> ACPSessionConfiguration {
+        ACPSessionConfiguration(
+            mode: .new,
+            workingDirectory: request.workspacePath ?? FileManager.default.temporaryDirectory.path,
+            mcpServers: [mcpServer]
+        )
+    }
+
+    func buildPromptBlocks(
+        for message: AgentMessage,
+        request: ACPRunRequest
+    ) throws -> [[String: Any]] {
+        [["type": "text", "text": message.userMessage]]
+    }
+
+    func normalizeSessionUpdate(
+        _ payload: [String: Any],
+        sessionID: String
+    ) -> [NormalizedAgentRuntimeEvent] {
+        []
+    }
+
+    func normalizeError(_ error: Error) -> Error {
+        error
+    }
+}

--- a/Tests/RepoPromptTests/AgentMode/ACPSynchronousMCPStartupTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/ACPSynchronousMCPStartupTests.swift
@@ -47,23 +47,25 @@ final class ACPSynchronousMCPStartupTests: XCTestCase {
         )
     }
 
-    func testCursorStyleSessionNewCatchesSynchronousMCPStartupFailureAndReturns() async throws {
+    func testCursorStyleSessionNewCatchesMissingMCPApprovalAndReturns() async throws {
         let workspace = try makeTemporaryDirectory()
         let recordURL = workspace.appendingPathComponent("cursor-startup.jsonl")
         let acpScriptURL = try makeACPServerScript()
         let mcpScriptURL = try makeMCPServerScript()
+        let missingApprovalURL = workspace.appendingPathComponent("missing-mcp-approvals.json")
         let request = makeRunRequest(agentKind: .cursor, workspacePath: workspace.path)
         let provider = SynchronousStartupFakeACPProvider(
             providerID: .cursor,
             commandPath: acpScriptURL.path,
             environment: [
                 "ACP_STARTUP_STYLE": "cursor",
-                "ACP_RECORD_PATH": recordURL.path
+                "ACP_RECORD_PATH": recordURL.path,
+                "ACP_CURSOR_APPROVAL_PATH": missingApprovalURL.path,
+                "ACP_CURSOR_PROJECT_ROOT": workspace.path
             ],
             mcpServer: RepoPromptMCPServerConfiguration(
                 name: "RepoPromptFixture",
-                command: mcpScriptURL.path,
-                args: ["--fail"]
+                command: mcpScriptURL.path
             )
         )
         let controller = try ACPAgentSessionController(
@@ -78,7 +80,66 @@ final class ACPSynchronousMCPStartupTests: XCTestCase {
         XCTAssertEqual(bootstrap.sessionID, "cursor-session")
         XCTAssertEqual(
             recordedEvents(at: recordURL),
-            ["session_new_started", "mcp_startup_failed", "session_new_response"]
+            ["session_new_started", "mcp_not_approved", "mcp_startup_failed", "session_new_response"]
+        )
+    }
+
+    func testCursorStyleSessionNewStartsModernMCPServerWithLeasedApproval() async throws {
+        let workspace = try makeTemporaryDirectory()
+        let cursorDataDirectory = try makeTemporaryDirectory()
+        let recordURL = workspace.appendingPathComponent("cursor-approved-startup.jsonl")
+        let acpScriptURL = try makeACPServerScript()
+        let mcpScriptURL = try makeMCPServerScript()
+        let mcpConfiguration = RepoPromptMCPServerConfiguration(
+            name: "RepoPromptFixture",
+            command: mcpScriptURL.path
+        )
+        let approvalURL = CursorIntegrationConfiguration.projectMCPApprovalURL(
+            workingDirectory: workspace.path,
+            cursorDataDirectory: cursorDataDirectory
+        )
+        let artifact = try XCTUnwrap(
+            CursorIntegrationConfiguration.prepareProjectMCPApproval(
+                workingDirectory: workspace.path,
+                cursorDataDirectory: cursorDataDirectory,
+                repoPromptMCPConfiguration: mcpConfiguration
+            )
+        )
+        defer {
+            CursorIntegrationConfiguration.cleanupProjectMCPApproval(leaseID: artifact.id)
+        }
+        let request = makeRunRequest(agentKind: .cursor, workspacePath: workspace.path)
+        let provider = SynchronousStartupFakeACPProvider(
+            providerID: .cursor,
+            commandPath: acpScriptURL.path,
+            environment: [
+                "ACP_STARTUP_STYLE": "cursor",
+                "ACP_RECORD_PATH": recordURL.path,
+                "ACP_CURSOR_APPROVAL_PATH": approvalURL.path,
+                "ACP_CURSOR_PROJECT_ROOT": workspace.path
+            ],
+            mcpServer: mcpConfiguration,
+            cleanupArtifact: artifact
+        )
+        let controller = try ACPAgentSessionController(
+            provider: provider,
+            runRequest: request,
+            requestTimeouts: .init(bootstrapSeconds: 2)
+        )
+
+        let bootstrap = try await controller.bootstrap()
+        await controller.shutdown()
+
+        XCTAssertEqual(bootstrap.sessionID, "cursor-session")
+        XCTAssertEqual(
+            recordedEvents(at: recordURL),
+            [
+                "session_new_started",
+                "mcp_approval_verified",
+                "mcp_initialize_completed",
+                "mcp_tools_list_completed",
+                "session_new_response"
+            ]
         )
     }
 
@@ -107,6 +168,7 @@ final class ACPSynchronousMCPStartupTests: XCTestCase {
         let script = #"""
         #!/usr/bin/env python3
         import json
+        import hashlib
         import os
         import subprocess
         import sys
@@ -174,6 +236,38 @@ final class ACPSynchronousMCPStartupTests: XCTestCase {
                 process.terminate()
                 process.wait(timeout=1)
 
+        def require_cursor_approval(server):
+            approval_path = os.environ.get("ACP_CURSOR_APPROVAL_PATH")
+            project_root = os.environ.get("ACP_CURSOR_PROJECT_ROOT")
+            if not approval_path or not project_root:
+                return
+            environment = {}
+            for entry in server.get("env") or []:
+                environment[entry["name"]] = entry["value"]
+            server_config = {
+                "command": server["command"],
+                "args": [value for value in server.get("args") or [] if isinstance(value, str)],
+                "env": environment,
+            }
+            payload = json.dumps(
+                {"path": project_root, "server": server_config},
+                separators=(",", ":"),
+            )
+            approval = (
+                server["name"]
+                + "-"
+                + hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+            )
+            try:
+                with open(approval_path, "r", encoding="utf-8") as handle:
+                    approvals = json.load(handle)
+            except Exception:
+                approvals = []
+            if approval not in approvals:
+                record("mcp_not_approved")
+                raise RuntimeError("MCP server has not been approved")
+            record("mcp_approval_verified")
+
         for line in sys.stdin:
             try:
                 request = json.loads(line)
@@ -186,7 +280,10 @@ final class ACPSynchronousMCPStartupTests: XCTestCase {
             elif method == "session/new":
                 record("session_new_started")
                 try:
-                    start_mcp((params.get("mcpServers") or [])[0])
+                    server = (params.get("mcpServers") or [])[0]
+                    if style == "cursor":
+                        require_cursor_approval(server)
+                    start_mcp(server)
                 except Exception:
                     record("mcp_startup_failed")
                     if style == "opencode":
@@ -261,6 +358,7 @@ private struct SynchronousStartupFakeACPProvider: ACPAgentProvider {
     let commandPath: String
     let environment: [String: String]
     let mcpServer: RepoPromptMCPServerConfiguration
+    var cleanupArtifact: ACPLaunchCleanupArtifact?
 
     func support(for request: ACPRunRequest) async -> ACPSupportResult {
         .supported
@@ -274,7 +372,8 @@ private struct SynchronousStartupFakeACPProvider: ACPAgentProvider {
             environment: environment,
             workingDirectory: request.workspacePath,
             additionalPathHints: [],
-            enableDebugLogging: false
+            enableDebugLogging: false,
+            cleanupArtifact: cleanupArtifact
         )
     }
 
@@ -305,5 +404,14 @@ private struct SynchronousStartupFakeACPProvider: ACPAgentProvider {
 
     func normalizeError(_ error: Error) -> Error {
         error
+    }
+
+    func cleanupLaunchArtifacts(for configuration: ACPLaunchConfiguration) async {
+        guard let artifact = configuration.cleanupArtifact,
+              artifact.kind == CursorIntegrationConfiguration.cleanupArtifactKind
+        else {
+            return
+        }
+        CursorIntegrationConfiguration.cleanupProjectMCPApproval(leaseID: artifact.id)
     }
 }

--- a/Tests/RepoPromptTests/AgentMode/ACPSynchronousMCPStartupTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/ACPSynchronousMCPStartupTests.swift
@@ -116,7 +116,9 @@ final class ACPSynchronousMCPStartupTests: XCTestCase {
                 "ACP_STARTUP_STYLE": "cursor",
                 "ACP_RECORD_PATH": recordURL.path,
                 "ACP_CURSOR_APPROVAL_PATH": approvalURL.path,
-                "ACP_CURSOR_PROJECT_ROOT": workspace.path
+                "ACP_CURSOR_PROJECT_ROOT": CursorIntegrationConfiguration.projectRootURL(
+                    workingDirectory: workspace.path
+                ).path
             ],
             mcpServer: mcpConfiguration,
             cleanupArtifact: artifact

--- a/Tests/RepoPromptTests/AgentMode/AgentModeRunServiceLifecycleTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeRunServiceLifecycleTests.swift
@@ -274,6 +274,44 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
             XCTAssertTrue(recorder.contains("provider:support"))
             XCTAssertFalse(recorder.contains("factory:acp-controller"))
         }
+
+        do {
+            let recorder = LifecycleRecorder()
+            let provider = LifecycleFakeACPProvider(
+                providerID: .openCode,
+                commandPath: "/usr/bin/true",
+                cancelSupport: true,
+                recorder: recorder
+            )
+            let harness = makeHarness(
+                recorder: recorder,
+                acpProviderFactory: { _, _ in
+                    recorder.record("factory:acp-provider")
+                    return provider
+                },
+                acpControllerFactory: { _, _ in
+                    recorder.record("factory:acp-controller")
+                    throw LifecycleTestError.unexpectedACPControllerCreation
+                }
+            )
+            let session = AgentModeViewModel.TabSession(tabID: UUID())
+            session.selectedAgent = .openCode
+
+            let outcome = await harness.service.startRun(
+                tabID: session.tabID,
+                session: session,
+                initialUserMessage: "cancelled support",
+                initialMessageForRun: "cancelled support",
+                attachments: []
+            )
+
+            XCTAssertNil(outcome)
+            XCTAssertEqual(session.runState, .cancelled)
+            XCTAssertNil(session.activeRunOwnership)
+            XCTAssertTrue(session.items.filter { $0.kind == .error }.isEmpty)
+            XCTAssertTrue(recorder.contains("provider:support"))
+            XCTAssertFalse(recorder.contains("factory:acp-controller"))
+        }
     }
 
     func testQueuedClaudeSteeringWaitsForMCPIdleThenDrainsOrRestoresDraft() async {
@@ -1565,6 +1603,7 @@ private enum LifecycleCancellationRow: String, CaseIterable {
 private enum LifecycleTestError: LocalizedError {
     case workspaceMissing
     case expectedACPDispatchStop
+    case unexpectedACPControllerCreation
     case expectedClaudeSendFailure
     case expectedCodexSendFailure
 
@@ -1574,6 +1613,8 @@ private enum LifecycleTestError: LocalizedError {
             "Lifecycle test workspace is missing."
         case .expectedACPDispatchStop:
             "Expected ACP dispatch stop."
+        case .unexpectedACPControllerCreation:
+            "ACP controller creation was not expected."
         case .expectedClaudeSendFailure:
             "Expected Claude send failure."
         case .expectedCodexSendFailure:
@@ -1866,10 +1907,14 @@ private struct LifecycleFakeACPProvider: ACPAgentProvider {
     let commandPath: String
     var environment: [String: String] = [:]
     var supportResult: ACPSupportResult = .supported
+    var cancelSupport = false
     var recorder: LifecycleRecorder?
 
-    func support(for _: ACPRunRequest) async -> ACPSupportResult {
+    func support(for _: ACPRunRequest) async throws -> ACPSupportResult {
         recorder?.record("provider:support")
+        if cancelSupport {
+            throw CancellationError()
+        }
         return supportResult
     }
 

--- a/Tests/RepoPromptTests/AgentMode/AgentModeRunServiceLifecycleTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeRunServiceLifecycleTests.swift
@@ -199,7 +199,11 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
 
         do {
             let recorder = LifecycleRecorder()
-            let provider = LifecycleFakeACPProvider(providerID: .openCode, commandPath: "/usr/bin/true")
+            let provider = LifecycleFakeACPProvider(
+                providerID: .openCode,
+                commandPath: "/usr/bin/true",
+                recorder: recorder
+            )
             let harness = makeHarness(
                 recorder: recorder,
                 acpProviderFactory: { _, _ in
@@ -226,9 +230,49 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
             XCTAssertEqual(session.runState, .failed)
             XCTAssertNil(session.activeRunOwnership)
             XCTAssertTrue(recorder.contains("factory:acp-provider"))
+            XCTAssertTrue(recorder.contains("provider:support"))
             XCTAssertTrue(recorder.contains("factory:acp-controller"))
+            assertOrderedEvents(["factory:acp-provider", "provider:support", "factory:acp-controller"], in: recorder)
             XCTAssertFalse(recorder.contains("factory:claude"))
             XCTAssertFalse(recorder.contains("factory:headless"))
+        }
+
+        do {
+            let recorder = LifecycleRecorder()
+            let provider = LifecycleFakeACPProvider(
+                providerID: .openCode,
+                commandPath: "/usr/bin/true",
+                supportResult: .unsupported(reason: "fixture unsupported"),
+                recorder: recorder
+            )
+            let harness = makeHarness(
+                recorder: recorder,
+                acpProviderFactory: { _, _ in
+                    recorder.record("factory:acp-provider")
+                    return provider
+                },
+                acpControllerFactory: { _, _ in
+                    recorder.record("factory:acp-controller")
+                    throw LifecycleTestError.expectedACPDispatchStop
+                }
+            )
+            let session = AgentModeViewModel.TabSession(tabID: UUID())
+            session.selectedAgent = .openCode
+
+            let outcome = await harness.service.startRun(
+                tabID: session.tabID,
+                session: session,
+                initialUserMessage: "unsupported acp",
+                initialMessageForRun: "unsupported acp",
+                attachments: []
+            )
+
+            XCTAssertNil(outcome)
+            XCTAssertEqual(session.runState, .failed)
+            XCTAssertNil(session.activeRunOwnership)
+            XCTAssertTrue(recorder.contains("factory:acp-provider"))
+            XCTAssertTrue(recorder.contains("provider:support"))
+            XCTAssertFalse(recorder.contains("factory:acp-controller"))
         }
     }
 
@@ -911,6 +955,88 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
         }
     }
 
+    func testOpenCodePermissionModesUseModernConfigAfterModelAndBeforePrompt() async throws {
+        let rows: [(OpenCodeAgentToolPreferences.PermissionLevel, String)] = [
+            (.managedDefault, OpenCodeAgentConfig.managedSessionModeID),
+            (.fullAccess, OpenCodeAgentConfig.managedFullAccessSessionModeID)
+        ]
+
+        for (level, expectedMode) in rows {
+            let recorder = LifecycleRecorder()
+            let directory = try makeTemporaryDirectory()
+            let recordURL = directory.appendingPathComponent("opencode-flow-\(level.rawValue).jsonl")
+            let scriptURL = try makeOpenCodeModeFlowServerScript()
+            let provider = LifecycleFakeACPProvider(
+                providerID: .openCode,
+                commandPath: scriptURL.path,
+                environment: ["ACP_RECORD_PATH": recordURL.path]
+            )
+            let harness = makeHarness(
+                recorder: recorder,
+                workspacePathProvider: { _ in directory.path },
+                acpProviderFactory: { agent, _ in
+                    XCTAssertEqual(agent, .openCode)
+                    return provider
+                },
+                autoSignalACPRouting: true
+            )
+            let session = AgentModeViewModel.TabSession(tabID: UUID())
+            session.selectedAgent = .openCode
+            session.selectedModelRaw = "model-b"
+            session.permissionProfile = .providerOverride(.openCode(level))
+
+            let outcome = await harness.service.startRun(
+                tabID: session.tabID,
+                session: session,
+                initialUserMessage: "OpenCode flow",
+                initialMessageForRun: "OpenCode flow",
+                attachments: []
+            )
+            XCTAssertNil(outcome, level.rawValue)
+            await session.agentTask?.value
+
+            let requests = recordedOpenCodeFlowRequests(at: recordURL)
+            let relevant = requests.filter { request in
+                request.method == "session/new"
+                    || request.method == "session/set_config_option"
+                    || request.method == "session/prompt"
+            }
+            XCTAssertEqual(
+                relevant.map(\.method),
+                ["session/new", "session/set_config_option", "session/set_config_option", "session/prompt"],
+                level.rawValue
+            )
+            XCTAssertEqual(relevant[1].params["configId"] as? String, "model", level.rawValue)
+            XCTAssertEqual(relevant[1].params["value"] as? String, "model-b", level.rawValue)
+            XCTAssertEqual(relevant[2].params["configId"] as? String, "mode", level.rawValue)
+            XCTAssertEqual(relevant[2].params["value"] as? String, expectedMode, level.rawValue)
+            XCTAssertFalse(session.items.contains { $0.kind == .error }, level.rawValue)
+
+            await harness.service.cancelRun(tabID: session.tabID, session: session)
+        }
+    }
+
+    private struct RecordedOpenCodeFlowRequest {
+        let method: String
+        let params: [String: Any]
+    }
+
+    private func recordedOpenCodeFlowRequests(at url: URL) -> [RecordedOpenCodeFlowRequest] {
+        guard let data = try? Data(contentsOf: url),
+              let text = String(data: data, encoding: .utf8)
+        else { return [] }
+        return text.split(whereSeparator: { $0.isNewline }).compactMap { line in
+            guard let data = String(line).data(using: .utf8),
+                  let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let method = object["method"] as? String
+            else { return nil }
+            return RecordedOpenCodeFlowRequest(
+                method: method,
+                params: object["params"] as? [String: Any] ?? [:]
+            )
+        }
+    }
+
     private func makeHarness(
         recorder: LifecycleRecorder,
         workspacePathProvider: @escaping (AgentModeViewModel.TabSession) throws -> String? = { _ in FileManager.default.currentDirectoryPath },
@@ -922,7 +1048,8 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
         acpProviderFactory: AgentModeViewModel.ACPProviderFactory? = nil,
         acpControllerFactory: AgentModeViewModel.ACPControllerFactory? = nil,
         flushPendingAssistantDelta: ((AgentModeViewModel.TabSession) -> Void)? = nil,
-        publishTerminalCommit: ((AgentModeViewModel.TabSession, AgentRunTerminalCommitRevision) async -> Void)? = nil
+        publishTerminalCommit: ((AgentModeViewModel.TabSession, AgentRunTerminalCommitRevision) async -> Void)? = nil,
+        autoSignalACPRouting: Bool = false
     ) -> LifecycleHarness {
         let codexController = codexController ?? LifecycleNoopCodexController(recorder: recorder)
         let claudeController = claudeController ?? LifecycleFakeNativeController(recorder: recorder)
@@ -938,7 +1065,11 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
             recorder.record("factory:acp-controller")
             return try ACPAgentSessionController(provider: provider, runRequest: request)
         }
-        let policyInstaller: AgentModeViewModel.ConnectionPolicyInstaller = { _, _, _, _, _, _, _, _, _, _, _, _, _ in }
+        let policyInstaller: AgentModeViewModel.ConnectionPolicyInstaller = { _, _, _, _, _, _, _, runID, _, _, _, _, _ in
+            if autoSignalACPRouting, let runID {
+                await MCPRoutingWaiter.notifyRouted(runID: runID)
+            }
+        }
         let serverEnabler: AgentModeViewModel.MCPServerEnabler = {}
         let host = AgentModeViewModel(
             testWindowID: 1,
@@ -1147,6 +1278,93 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
         try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
         temporaryURLs.append(url)
         return url
+    }
+
+    private func makeOpenCodeModeFlowServerScript() throws -> URL {
+        let directory = try makeTemporaryDirectory()
+        let scriptURL = directory.appendingPathComponent("fake_opencode_mode_flow_server.py")
+        let script = #"""
+        #!/usr/bin/env python3
+        import json
+        import os
+        import sys
+
+        record_path = os.environ.get("ACP_RECORD_PATH")
+        current_model = "model-a"
+        current_mode = "ask"
+
+        def record(method, params):
+            if not record_path:
+                return
+            with open(record_path, "a", encoding="utf-8") as handle:
+                handle.write(json.dumps({"method": method, "params": params}) + "\n")
+
+        def config_options():
+            return [
+                {
+                    "id": "model",
+                    "name": "Model",
+                    "category": "model",
+                    "type": "select",
+                    "currentValue": current_model,
+                    "options": [
+                        {"value": "model-a", "name": "Model A"},
+                        {"value": "model-b", "name": "Model B"}
+                    ]
+                },
+                {
+                    "id": "mode",
+                    "name": "Session Mode",
+                    "category": "mode",
+                    "type": "select",
+                    "currentValue": current_mode,
+                    "options": [
+                        {"value": "ask", "name": "Ask"},
+                        {"value": "repoprompt_acp", "name": "RepoPrompt"},
+                        {"value": "repoprompt_acp_full_access", "name": "RepoPrompt Full Access"}
+                    ]
+                }
+            ]
+
+        def respond(request_id, result=None):
+            print(json.dumps({
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "result": result if result is not None else {}
+            }), flush=True)
+
+        for line in sys.stdin:
+            try:
+                request = json.loads(line)
+            except Exception:
+                continue
+            method = request.get("method")
+            params = request.get("params") or {}
+            record(method, params)
+            if method == "initialize":
+                respond(request.get("id"), {"agentCapabilities": {"loadSession": True}, "authMethods": []})
+            elif method == "session/new":
+                respond(request.get("id"), {
+                    "sessionId": "opencode-mode-flow",
+                    "configOptions": config_options()
+                })
+            elif method == "session/set_config_option":
+                if params.get("configId") == "model":
+                    current_model = params.get("value")
+                elif params.get("configId") == "mode":
+                    current_mode = params.get("value")
+                respond(request.get("id"), {"configOptions": config_options()})
+            elif method == "session/prompt":
+                respond(request.get("id"), {
+                    "stopReason": "end_turn",
+                    "usage": {"inputTokens": 1, "outputTokens": 1}
+                })
+            else:
+                respond(request.get("id"), {})
+        """#
+        try script.write(to: scriptURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: scriptURL.path)
+        return scriptURL
     }
 
     private func makeFakeACPServerScript() throws -> URL {
@@ -1646,9 +1864,13 @@ private actor LifecycleFakeNativeController: NativeAgentRuntimeControlling {
 private struct LifecycleFakeACPProvider: ACPAgentProvider {
     let providerID: ACPProviderID
     let commandPath: String
+    var environment: [String: String] = [:]
+    var supportResult: ACPSupportResult = .supported
+    var recorder: LifecycleRecorder?
 
-    func support(for request: ACPRunRequest) async -> ACPSupportResult {
-        .supported
+    func support(for _: ACPRunRequest) async -> ACPSupportResult {
+        recorder?.record("provider:support")
+        return supportResult
     }
 
     func makeLaunchConfiguration(for request: ACPRunRequest) throws -> ACPLaunchConfiguration {
@@ -1656,7 +1878,7 @@ private struct LifecycleFakeACPProvider: ACPAgentProvider {
             providerID: providerID,
             command: commandPath,
             arguments: [],
-            environment: [:],
+            environment: environment,
             workingDirectory: request.workspacePath,
             additionalPathHints: [],
             enableDebugLogging: false

--- a/Tests/RepoPromptTests/AgentMode/CursorACPLaunchResolverTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/CursorACPLaunchResolverTests.swift
@@ -38,7 +38,7 @@ final class CursorACPLaunchResolverTests: XCTestCase {
             includeRepoPromptMCPServer: false
         )
 
-        let support = await resolver.probeSupport(for: config)
+        let support = try await resolver.probeSupport(for: config)
         let provider = CursorACPAgentProvider(config: config, launchResolver: resolver)
         let launch = try provider.makeLaunchConfiguration(for: makeRunRequest(workspacePath: directory.path))
         let probedPath = try String(contentsOf: probePathRecord, encoding: .utf8)
@@ -71,24 +71,24 @@ final class CursorACPLaunchResolverTests: XCTestCase {
         let originalData = Data(#"["existing-approval"]"#.utf8)
         try originalData.write(to: approvalURL)
 
+        let capturedEnvironment = [
+            "CURSOR_DATA_DIR": cursorDataDirectory.path,
+            "HOME": "/ignored-by-explicit-cursor-data-dir",
+            "PATH": executableDirectory.path
+        ]
         let provider = CursorACPAgentProvider(
             config: CursorAgentConfig(
                 commandName: executable.path,
                 additionalPathHints: []
             ),
             repoPromptMCPConfiguration: mcpConfiguration,
-            launchResolver: CursorACPLaunchResolver(),
-            approvalEnvironmentProvider: {
-                [
-                    "CURSOR_DATA_DIR": cursorDataDirectory.path,
-                    "HOME": "/ignored-by-explicit-cursor-data-dir"
-                ]
-            }
+            launchResolver: CursorACPLaunchResolver(environmentProvider: { _ in capturedEnvironment })
         )
+        let request = makeRunRequest(workspacePath: workspace.path)
 
-        let launch = try provider.makeLaunchConfiguration(
-            for: makeRunRequest(workspacePath: workspace.path)
-        )
+        let support = try await provider.support(for: request)
+        XCTAssertEqual(support, .supported)
+        let launch = try provider.makeLaunchConfiguration(for: request)
         let artifact = try XCTUnwrap(launch.cleanupArtifact)
         addTeardownBlock {
             await provider.cleanupLaunchArtifacts(for: launch)
@@ -119,7 +119,10 @@ final class CursorACPLaunchResolverTests: XCTestCase {
         )
 
         await provider.cleanupLaunchArtifacts(for: launch)
-        XCTAssertEqual(try Data(contentsOf: approvalURL), originalData)
+        let retainedApprovals = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(contentsOf: approvalURL)) as? [String]
+        )
+        XCTAssertEqual(retainedApprovals, ["existing-approval"])
     }
 
     func testApprovalIdentifierMatchesCursorCLIHashContract() throws {
@@ -263,7 +266,7 @@ final class CursorACPLaunchResolverTests: XCTestCase {
         XCTAssertEqual(retainedApprovals, ["existing-approval", "cursor-added-approval"])
     }
 
-    func testConcurrentApprovalLeasesRestoreOriginalDataAfterFinalCleanup() throws {
+    func testConcurrentApprovalLeasesRemoveOnlyRepoPromptInsertionsAfterFinalCleanup() throws {
         for cleanupFirstLeaseFirst in [true, false] {
             let workspace = try makeTemporaryDirectory()
             let cursorDataDirectory = try makeTemporaryDirectory()
@@ -285,6 +288,14 @@ final class CursorACPLaunchResolverTests: XCTestCase {
                     repoPromptMCPConfiguration: .init(command: "/tmp/repoprompt-mcp-one")
                 )
             )
+            let afterFirstLease = try XCTUnwrap(
+                JSONSerialization.jsonObject(with: Data(contentsOf: approvalURL)) as? [String]
+            )
+            try JSONSerialization.data(
+                withJSONObject: afterFirstLease + ["cursor-added-between-leases"],
+                options: [.prettyPrinted]
+            ).write(to: approvalURL, options: .atomic)
+
             let second = try XCTUnwrap(
                 CursorIntegrationConfiguration.prepareProjectMCPApproval(
                     workingDirectory: workspace.path,
@@ -303,8 +314,53 @@ final class CursorACPLaunchResolverTests: XCTestCase {
             XCTAssertNotEqual(try Data(contentsOf: approvalURL), originalData)
 
             CursorIntegrationConfiguration.cleanupProjectMCPApproval(leaseID: finalCleanup.id)
-            XCTAssertEqual(try Data(contentsOf: approvalURL), originalData)
+            let retainedApprovals = try XCTUnwrap(
+                JSONSerialization.jsonObject(with: Data(contentsOf: approvalURL)) as? [String]
+            )
+            XCTAssertEqual(retainedApprovals, ["existing-approval", "cursor-added-between-leases"])
         }
+    }
+
+    func testFailedFinalApprovalCleanupRetainsRetryBookkeeping() throws {
+        let workspace = try makeTemporaryDirectory()
+        let cursorDataDirectory = try makeTemporaryDirectory()
+        let configuration = RepoPromptMCPServerConfiguration(command: "/tmp/repoprompt-mcp")
+        let approvalURL = CursorIntegrationConfiguration.projectMCPApprovalURL(
+            workingDirectory: workspace.path,
+            cursorDataDirectory: cursorDataDirectory
+        )
+        let artifact = try XCTUnwrap(
+            CursorIntegrationConfiguration.prepareProjectMCPApproval(
+                workingDirectory: workspace.path,
+                cursorDataDirectory: cursorDataDirectory,
+                repoPromptMCPConfiguration: configuration
+            )
+        )
+        let temporaryApproval = try CursorIntegrationConfiguration.approvalIdentifier(
+            projectRoot: CursorIntegrationConfiguration.projectRootURL(
+                workingDirectory: workspace.path
+            ).path,
+            repoPromptMCPConfiguration: configuration
+        )
+        defer {
+            CursorIntegrationConfiguration.cleanupProjectMCPApproval(leaseID: artifact.id)
+        }
+
+        try FileManager.default.removeItem(at: approvalURL)
+        try FileManager.default.createDirectory(at: approvalURL, withIntermediateDirectories: false)
+        CursorIntegrationConfiguration.cleanupProjectMCPApproval(leaseID: artifact.id)
+
+        try FileManager.default.removeItem(at: approvalURL)
+        try JSONSerialization.data(
+            withJSONObject: [temporaryApproval, "cursor-added-after-failure"],
+            options: [.prettyPrinted]
+        ).write(to: approvalURL, options: .atomic)
+        CursorIntegrationConfiguration.cleanupProjectMCPApproval(leaseID: artifact.id)
+
+        let retainedApprovals = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(contentsOf: approvalURL)) as? [String]
+        )
+        XCTAssertEqual(retainedApprovals, ["cursor-added-after-failure"])
     }
 
     func testRepeatedProbeRefreshesCurrentEnvironmentBeforeSpawn() async throws {
@@ -321,7 +377,7 @@ final class CursorACPLaunchResolverTests: XCTestCase {
         })
         let config = CursorAgentConfig(commandName: "cursor-agent", additionalPathHints: [])
 
-        let firstSupport = await resolver.probeSupport(for: config)
+        let firstSupport = try await resolver.probeSupport(for: config)
         let firstLaunch = try resolver.resolvedLaunch(for: config)
         XCTAssertEqual(firstSupport, .supported)
         XCTAssertEqual(firstLaunch.command, firstExecutable.resolvingSymlinksInPath().path)
@@ -330,7 +386,7 @@ final class CursorACPLaunchResolverTests: XCTestCase {
             "PATH": secondDirectory.path,
             "SHELL": "/bin/false"
         ])
-        let secondSupport = await resolver.probeSupport(for: config)
+        let secondSupport = try await resolver.probeSupport(for: config)
         let secondLaunch = try resolver.resolvedLaunch(for: config)
         XCTAssertEqual(secondSupport, .supported)
         XCTAssertEqual(secondLaunch.command, secondExecutable.resolvingSymlinksInPath().path)
@@ -427,7 +483,7 @@ final class CursorACPLaunchResolverTests: XCTestCase {
         let resolver = CursorACPLaunchResolver()
         let config = CursorAgentConfig(commandName: executable.path, additionalPathHints: [])
 
-        let support = await resolver.probeSupport(for: config)
+        let support = try await resolver.probeSupport(for: config)
         XCTAssertEqual(support, .supported)
         try FileManager.default.removeItem(at: executable)
         _ = try makeExecutable(named: "cursor-agent", in: directory, output: "replacement ACP")
@@ -460,12 +516,57 @@ final class CursorACPLaunchResolverTests: XCTestCase {
         _ = try makeExecutable(named: "cursor", in: directory, marker: marker)
         let config = CursorAgentConfig(commandName: "cursor", additionalPathHints: [directory.path])
 
-        let support = await CursorACPLaunchResolver().probeSupport(for: config)
+        let support = try await CursorACPLaunchResolver().probeSupport(for: config)
 
         guard case let .unsupported(reason) = support else {
             return XCTFail("Expected unsupported result")
         }
         XCTAssertTrue(reason.contains("Refusing unsafe Cursor ACP command"))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: marker.path))
+    }
+
+    func testCancelledSupportProbePropagatesCancellationAndLeavesNoBareCommandCache() async throws {
+        let directory = try makeTemporaryDirectory()
+        let marker = directory.appendingPathComponent("probe-started")
+        _ = try makeExecutable(named: "cursor-agent", in: directory, marker: marker, sleepSeconds: 30)
+        var environment = ProcessInfo.processInfo.environment
+        environment["PATH"] = directory.path
+        environment["SHELL"] = "/bin/false"
+        let capturedEnvironment = environment
+        let resolver = CursorACPLaunchResolver(environmentProvider: { _ in capturedEnvironment })
+        let config = CursorAgentConfig(commandName: "cursor-agent", additionalPathHints: [])
+
+        let probe = Task { try await resolver.probeSupport(for: config) }
+        let didStartProbe = await waitUntilFileExists(marker)
+        XCTAssertTrue(didStartProbe)
+        probe.cancel()
+        do {
+            _ = try await probe.value
+            XCTFail("Expected support probe cancellation")
+        } catch is CancellationError {
+            // Expected: cancellation is not converted into an unsupported result.
+        }
+
+        XCTAssertThrowsError(try resolver.resolvedLaunch(for: config)) { error in
+            guard case CursorACPLaunchResolutionError.environmentDiscoveryRequired = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    func testWorldWritableExecutableDirectoryIsRejectedWithoutExecution() async throws {
+        let directory = try makeTemporaryDirectory()
+        let marker = directory.appendingPathComponent("probe-ran")
+        let executable = try makeExecutable(named: "cursor-agent", in: directory, marker: marker)
+        try FileManager.default.setAttributes([.posixPermissions: 0o777], ofItemAtPath: directory.path)
+
+        let support = try await CursorACPLaunchResolver().probeSupport(
+            for: CursorAgentConfig(commandName: executable.path, additionalPathHints: [])
+        )
+
+        guard case .unsupported = support else {
+            return XCTFail("Expected unsafe launch path to be unsupported")
+        }
         XCTAssertFalse(FileManager.default.fileExists(atPath: marker.path))
     }
 
@@ -479,7 +580,7 @@ final class CursorACPLaunchResolverTests: XCTestCase {
         let resolver = CursorACPLaunchResolver(environmentProvider: { _ in capturedEnvironment })
         let config = CursorAgentConfig(commandName: "cursor-agent", additionalPathHints: [])
 
-        guard case .unsupported = await resolver.probeSupport(for: config) else {
+        guard case .unsupported = try await resolver.probeSupport(for: config) else {
             return XCTFail("Expected failed support probe")
         }
         XCTAssertThrowsError(try resolver.resolvedLaunch(for: config)) { error in
@@ -490,7 +591,7 @@ final class CursorACPLaunchResolverTests: XCTestCase {
 
         try FileManager.default.removeItem(at: executable)
         let replacement = try makeExecutable(named: "cursor-agent", in: directory)
-        let replacementSupport = await resolver.probeSupport(for: config)
+        let replacementSupport = try await resolver.probeSupport(for: config)
         XCTAssertEqual(replacementSupport, .supported)
         XCTAssertEqual(
             try resolver.resolvedLaunch(for: config).command,
@@ -514,7 +615,7 @@ final class CursorACPLaunchResolverTests: XCTestCase {
             additionalPathHints: [directory.path]
         )
 
-        let support = await CursorACPLaunchResolver().probeSupport(for: config)
+        let support = try await CursorACPLaunchResolver().probeSupport(for: config)
 
         guard case .unsupported = support else {
             return XCTFail("Expected unsupported result")
@@ -646,18 +747,31 @@ final class CursorACPLaunchResolverTests: XCTestCase {
         in directory: URL,
         marker: URL? = nil,
         output: String = "Cursor Agent ACP support",
-        exitStatus: Int32 = 0
+        exitStatus: Int32 = 0,
+        sleepSeconds: Int? = nil
     ) throws -> URL {
         let executable = directory.appendingPathComponent(name)
         var lines = ["#!/bin/sh"]
         if let marker {
             lines.append("printf '%s' \"$0\" > '\(marker.path)'")
         }
+        if let sleepSeconds {
+            lines.append("exec /bin/sleep \(sleepSeconds)")
+        }
         lines.append("printf '%s\\n' '\(output)'")
         lines.append("exit \(exitStatus)")
         try lines.joined(separator: "\n").write(to: executable, atomically: true, encoding: .utf8)
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
         return executable
+    }
+
+    private func waitUntilFileExists(_ url: URL, timeout: TimeInterval = 2) async -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        repeat {
+            if FileManager.default.fileExists(atPath: url.path) { return true }
+            await Task.yield()
+        } while Date() < deadline
+        return false
     }
 }
 

--- a/Tests/RepoPromptTests/AgentMode/CursorACPLaunchResolverTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/CursorACPLaunchResolverTests.swift
@@ -1,0 +1,457 @@
+import Foundation
+@testable import RepoPrompt
+import XCTest
+
+final class CursorACPLaunchResolverTests: XCTestCase {
+    func testMakeLaunchConfigurationResolvesExactPathWithoutPriorProbe() throws {
+        let directory = try makeTemporaryDirectory()
+        let executable = try makeExecutable(named: "cursor-agent", in: directory)
+        let resolver = CursorACPLaunchResolver()
+        let provider = CursorACPAgentProvider(
+            config: CursorAgentConfig(commandName: executable.path, additionalPathHints: []),
+            launchResolver: resolver
+        )
+
+        let launch = try provider.makeLaunchConfiguration(for: makeRunRequest(workspacePath: directory.path))
+
+        XCTAssertEqual(launch.command, executable.resolvingSymlinksInPath().standardizedFileURL.path)
+        XCTAssertEqual(launch.arguments, ["--approve-mcps", "acp"])
+        XCTAssertEqual(launch.expectedExecutableIdentity?.canonicalPath, launch.command)
+    }
+
+    func testBareCursorAgentUsesCapturedEnvironmentAndCachesCanonicalPathForSpawn() async throws {
+        let directory = try makeTemporaryDirectory()
+        let probePathRecord = directory.appendingPathComponent("probe-path")
+        let executable = try makeExecutable(named: "cursor-agent", in: directory, marker: probePathRecord)
+        var environment = ProcessInfo.processInfo.environment
+        environment["PATH"] = directory.path
+        environment["SHELL"] = "/bin/false"
+        let testEnvironment = environment
+        let resolver = CursorACPLaunchResolver(environmentProvider: { _ in testEnvironment })
+        let config = CursorAgentConfig(commandName: "cursor-agent", additionalPathHints: [])
+
+        let support = await resolver.probeSupport(for: config)
+        let provider = CursorACPAgentProvider(config: config, launchResolver: resolver)
+        let launch = try provider.makeLaunchConfiguration(for: makeRunRequest(workspacePath: directory.path))
+        let probedPath = try String(contentsOf: probePathRecord, encoding: .utf8)
+
+        XCTAssertEqual(support, .supported)
+        XCTAssertEqual(launch.command, executable.resolvingSymlinksInPath().standardizedFileURL.path)
+        XCTAssertEqual(probedPath, launch.command)
+    }
+
+    func testRepeatedProbeRefreshesCurrentEnvironmentBeforeSpawn() async throws {
+        let firstDirectory = try makeTemporaryDirectory()
+        let secondDirectory = try makeTemporaryDirectory()
+        let firstExecutable = try makeExecutable(named: "cursor-agent", in: firstDirectory)
+        let secondExecutable = try makeExecutable(named: "cursor-agent", in: secondDirectory)
+        let environmentBox = TestEnvironmentBox(environment: [
+            "PATH": firstDirectory.path,
+            "SHELL": "/bin/false"
+        ])
+        let resolver = CursorACPLaunchResolver(environmentProvider: { _ in
+            await environmentBox.current()
+        })
+        let config = CursorAgentConfig(commandName: "cursor-agent", additionalPathHints: [])
+
+        let firstSupport = await resolver.probeSupport(for: config)
+        let firstLaunch = try resolver.resolvedLaunch(for: config)
+        XCTAssertEqual(firstSupport, .supported)
+        XCTAssertEqual(firstLaunch.command, firstExecutable.resolvingSymlinksInPath().path)
+
+        await environmentBox.set([
+            "PATH": secondDirectory.path,
+            "SHELL": "/bin/false"
+        ])
+        let secondSupport = await resolver.probeSupport(for: config)
+        let secondLaunch = try resolver.resolvedLaunch(for: config)
+        XCTAssertEqual(secondSupport, .supported)
+        XCTAssertEqual(secondLaunch.command, secondExecutable.resolvingSymlinksInPath().path)
+    }
+
+    func testBareCursorAgentWithoutCapturedDiscoveryFailsClosed() {
+        let resolver = CursorACPLaunchResolver(environmentProvider: { _ in [:] })
+
+        XCTAssertThrowsError(
+            try resolver.resolvedLaunch(
+                for: CursorAgentConfig(commandName: "cursor-agent", additionalPathHints: [])
+            )
+        ) { error in
+            guard case CursorACPLaunchResolutionError.environmentDiscoveryRequired = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    func testAbsoluteConfiguredPathIgnoresDecoyCursorAgentEarlierInPath() throws {
+        let trustedDirectory = try makeTemporaryDirectory()
+        let decoyDirectory = try makeTemporaryDirectory()
+        let trusted = try makeExecutable(named: "cursor-agent", in: trustedDirectory)
+        _ = try makeExecutable(named: "cursor-agent", in: decoyDirectory)
+        var environment = ProcessInfo.processInfo.environment
+        environment["PATH"] = decoyDirectory.path
+        environment["SHELL"] = "/bin/false"
+        let testEnvironment = environment
+        let resolver = CursorACPLaunchResolver(environmentProvider: { _ in testEnvironment })
+        let config = CursorAgentConfig(
+            commandName: trusted.path,
+            additionalPathHints: []
+        )
+
+        let launch = try resolver.resolvedLaunch(for: config)
+
+        XCTAssertEqual(launch.command, trusted.resolvingSymlinksInPath().standardizedFileURL.path)
+    }
+
+    func testSymlinkIsCanonicalizedAndCanonicalWrapperBasenameIsAllowed() throws {
+        let directory = try makeTemporaryDirectory()
+        let target = try makeExecutable(named: "cursor-agent-wrapper", in: directory)
+        let link = directory.appendingPathComponent("cursor-agent")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: target)
+
+        let launch = try CursorACPLaunchResolver().resolvedLaunch(
+            for: CursorAgentConfig(commandName: link.path, additionalPathHints: [])
+        )
+
+        XCTAssertEqual(launch.command, target.resolvingSymlinksInPath().standardizedFileURL.path)
+    }
+
+    func testSymlinkWhoseCanonicalBasenameIsCursorIsRejected() throws {
+        let directory = try makeTemporaryDirectory()
+        let target = try makeExecutable(named: "cursor", in: directory)
+        let link = directory.appendingPathComponent("cursor-agent")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: target)
+
+        XCTAssertThrowsError(
+            try CursorACPLaunchResolver().resolvedLaunch(
+                for: CursorAgentConfig(commandName: link.path, additionalPathHints: [])
+            )
+        ) { error in
+            guard case CursorACPLaunchResolutionError.unsafeCanonicalBasename = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    func testSymlinkIntoApplicationBundleIsRejected() throws {
+        let directory = try makeTemporaryDirectory()
+        let appExecutableDirectory = directory
+            .appendingPathComponent("Cursor.app", isDirectory: true)
+            .appendingPathComponent("Contents/MacOS", isDirectory: true)
+        try FileManager.default.createDirectory(at: appExecutableDirectory, withIntermediateDirectories: true)
+        let target = try makeExecutable(named: "cursor-agent-wrapper", in: appExecutableDirectory)
+        let link = directory.appendingPathComponent("cursor-agent")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: target)
+
+        XCTAssertThrowsError(
+            try CursorACPLaunchResolver().resolvedLaunch(
+                for: CursorAgentConfig(commandName: link.path, additionalPathHints: [])
+            )
+        ) { error in
+            guard case CursorACPLaunchResolutionError.unsafeApplicationPath = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    func testCachedIdentityDriftFailsClosed() async throws {
+        let directory = try makeTemporaryDirectory()
+        let executable = try makeExecutable(named: "cursor-agent", in: directory)
+        let resolver = CursorACPLaunchResolver()
+        let config = CursorAgentConfig(commandName: executable.path, additionalPathHints: [])
+
+        let support = await resolver.probeSupport(for: config)
+        XCTAssertEqual(support, .supported)
+        try FileManager.default.removeItem(at: executable)
+        _ = try makeExecutable(named: "cursor-agent", in: directory, output: "replacement ACP")
+
+        XCTAssertThrowsError(try resolver.resolvedLaunch(for: config)) { error in
+            guard case ExecutableFileIdentityError.identityChanged = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    func testMissingExecutableFailsClosed() throws {
+        let directory = try makeTemporaryDirectory()
+        let missing = directory.appendingPathComponent("cursor-agent")
+
+        XCTAssertThrowsError(
+            try CursorACPLaunchResolver().resolvedLaunch(
+                for: CursorAgentConfig(commandName: missing.path, additionalPathHints: [])
+            )
+        ) { error in
+            guard case CursorACPLaunchResolutionError.exactPathNotFound = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    func testCursorTokenIsRejectedWithoutExecution() async throws {
+        let directory = try makeTemporaryDirectory()
+        let marker = directory.appendingPathComponent("cursor-ran")
+        _ = try makeExecutable(named: "cursor", in: directory, marker: marker)
+        let config = CursorAgentConfig(commandName: "cursor", additionalPathHints: [directory.path])
+
+        let support = await CursorACPLaunchResolver().probeSupport(for: config)
+
+        guard case let .unsupported(reason) = support else {
+            return XCTFail("Expected unsupported result")
+        }
+        XCTAssertTrue(reason.contains("Refusing unsafe Cursor ACP command"))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: marker.path))
+    }
+
+    func testFailedBareProbeDoesNotLeaveSpawnableCacheAndReplacementCanRecover() async throws {
+        let directory = try makeTemporaryDirectory()
+        let executable = try makeExecutable(named: "cursor-agent", in: directory, exitStatus: 2)
+        var environment = ProcessInfo.processInfo.environment
+        environment["PATH"] = directory.path
+        environment["SHELL"] = "/bin/false"
+        let capturedEnvironment = environment
+        let resolver = CursorACPLaunchResolver(environmentProvider: { _ in capturedEnvironment })
+        let config = CursorAgentConfig(commandName: "cursor-agent", additionalPathHints: [])
+
+        guard case .unsupported = await resolver.probeSupport(for: config) else {
+            return XCTFail("Expected failed support probe")
+        }
+        XCTAssertThrowsError(try resolver.resolvedLaunch(for: config)) { error in
+            guard case CursorACPLaunchResolutionError.environmentDiscoveryRequired = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+
+        try FileManager.default.removeItem(at: executable)
+        let replacement = try makeExecutable(named: "cursor-agent", in: directory)
+        let replacementSupport = await resolver.probeSupport(for: config)
+        XCTAssertEqual(replacementSupport, .supported)
+        XCTAssertEqual(
+            try resolver.resolvedLaunch(for: config).command,
+            replacement.resolvingSymlinksInPath().standardizedFileURL.path
+        )
+    }
+
+    func testFailedExactProbeDoesNotExecuteCursorFallback() async throws {
+        let directory = try makeTemporaryDirectory()
+        let probeMarker = directory.appendingPathComponent("cursor-agent-probed")
+        let fallbackMarker = directory.appendingPathComponent("cursor-fallback-ran")
+        let cursorAgent = try makeExecutable(
+            named: "cursor-agent",
+            in: directory,
+            marker: probeMarker,
+            exitStatus: 2
+        )
+        _ = try makeExecutable(named: "cursor", in: directory, marker: fallbackMarker)
+        let config = CursorAgentConfig(
+            commandName: cursorAgent.path,
+            additionalPathHints: [directory.path]
+        )
+
+        let support = await CursorACPLaunchResolver().probeSupport(for: config)
+
+        guard case .unsupported = support else {
+            return XCTFail("Expected unsupported result")
+        }
+        XCTAssertTrue(FileManager.default.fileExists(atPath: probeMarker.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fallbackMarker.path))
+    }
+
+    func testControllerRejectsIdentityDriftBeforeSpawn() async throws {
+        let directory = try makeTemporaryDirectory()
+        let spawnMarker = directory.appendingPathComponent("spawned")
+        let executable = try makeExecutable(named: "cursor-agent", in: directory)
+        let identity = try ExecutableFileIdentity.capture(atPath: executable.path)
+        let launch = ACPLaunchConfiguration(
+            providerID: .cursor,
+            command: identity.canonicalPath,
+            arguments: ["--approve-mcps", "acp"],
+            environment: [:],
+            workingDirectory: directory.path,
+            additionalPathHints: [],
+            enableDebugLogging: false,
+            expectedExecutableIdentity: identity
+        )
+        let provider = FixedLaunchACPProvider(launchConfiguration: launch, workingDirectory: directory.path)
+        let controller = try ACPAgentSessionController(
+            provider: provider,
+            runRequest: makeRunRequest(workspacePath: directory.path)
+        )
+        #if DEBUG
+            let runID = UUID()
+            await ServerNetworkManager.shared.debugClearRunRoutingHistoryForTesting()
+            await controller.setExpectedMCPRunID(runID)
+        #endif
+
+        try FileManager.default.removeItem(at: executable)
+        _ = try makeExecutable(named: "cursor-agent", in: directory, marker: spawnMarker)
+
+        do {
+            _ = try await controller.bootstrap()
+            XCTFail("Expected launch identity validation to fail")
+        } catch {
+            guard case ExecutableFileIdentityError.identityChanged = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+        XCTAssertFalse(FileManager.default.fileExists(atPath: spawnMarker.path))
+        #if DEBUG
+            let payload = await ServerNetworkManager.shared.debugRunRoutingHistoryPayload(runID: runID, limit: 20)
+            let events = try XCTUnwrap(payload["events"] as? [[String: Any]])
+            let failed = try XCTUnwrap(events.first { $0["event"] as? String == "acp_launch_validation_failed" })
+            let fields = try XCTUnwrap(failed["fields"] as? [String: String])
+            XCTAssertEqual(fields["configured_command"], identity.canonicalPath)
+            XCTAssertEqual(fields["resolved_executable"], identity.canonicalPath)
+            XCTAssertEqual(fields["error_kind"], "executable_identity")
+            XCTAssertNotNil(fields["error_type"])
+            XCTAssertNotNil(Int(fields["error_code"] ?? ""))
+            XCTAssertFalse(events.contains { $0["event"] as? String == "acp_process_spawned" })
+        #endif
+        await controller.shutdown()
+    }
+
+    func testModernModeErrorNormalizationPreservesRawDetail() {
+        let provider = makeProviderForNormalization()
+        let rawDetail = "ACP request session/set_config_option failed for mode ask: upstream detail 42"
+        let rawError = NSError(
+            domain: "CursorACP",
+            code: 42,
+            userInfo: [NSLocalizedDescriptionKey: rawDetail]
+        )
+
+        let normalized = provider.normalizeError(rawError)
+
+        guard case let AIProviderError.invalidConfiguration(detail) = normalized else {
+            return XCTFail("Unexpected normalized error: \(normalized)")
+        }
+        XCTAssertEqual(detail, rawDetail)
+    }
+
+    func testUnclassifiedProviderErrorRetainsUnderlyingError() {
+        let provider = makeProviderForNormalization()
+        let rawError = NSError(
+            domain: "CursorACP.Raw",
+            code: 99,
+            userInfo: [NSLocalizedDescriptionKey: "unclassified upstream detail"]
+        )
+
+        let normalized = provider.normalizeError(rawError)
+
+        guard case let AIProviderError.apiError(source) = normalized else {
+            return XCTFail("Unexpected normalized error: \(normalized)")
+        }
+        let sourceError = source as NSError?
+        XCTAssertEqual(sourceError?.domain, rawError.domain)
+        XCTAssertEqual(sourceError?.code, rawError.code)
+        XCTAssertEqual(sourceError?.localizedDescription, rawError.localizedDescription)
+    }
+
+    private func makeProviderForNormalization() -> CursorACPAgentProvider {
+        CursorACPAgentProvider(
+            config: CursorAgentConfig(commandName: "cursor-agent"),
+            launchResolver: CursorACPLaunchResolver()
+        )
+    }
+
+    private func makeRunRequest(workspacePath: String) -> ACPRunRequest {
+        ACPRunRequest(
+            agentKind: .cursor,
+            modelString: nil,
+            workspacePath: workspacePath,
+            resumeSessionID: nil,
+            attachments: [],
+            taskLabelKind: nil
+        )
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CursorACPLaunchResolverTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: directory)
+        }
+        return directory
+    }
+
+    @discardableResult
+    private func makeExecutable(
+        named name: String,
+        in directory: URL,
+        marker: URL? = nil,
+        output: String = "Cursor Agent ACP support",
+        exitStatus: Int32 = 0
+    ) throws -> URL {
+        let executable = directory.appendingPathComponent(name)
+        var lines = ["#!/bin/sh"]
+        if let marker {
+            lines.append("printf '%s' \"$0\" > '\(marker.path)'")
+        }
+        lines.append("printf '%s\\n' '\(output)'")
+        lines.append("exit \(exitStatus)")
+        try lines.joined(separator: "\n").write(to: executable, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+        return executable
+    }
+}
+
+private actor TestEnvironmentBox {
+    private var environment: [String: String]
+
+    init(environment: [String: String]) {
+        self.environment = environment
+    }
+
+    func current() -> [String: String] {
+        environment
+    }
+
+    func set(_ environment: [String: String]) {
+        self.environment = environment
+    }
+}
+
+private struct FixedLaunchACPProvider: ACPAgentProvider {
+    let launchConfiguration: ACPLaunchConfiguration
+    let workingDirectory: String
+
+    var providerID: ACPProviderID {
+        .cursor
+    }
+
+    func support(for _: ACPRunRequest) async -> ACPSupportResult {
+        .supported
+    }
+
+    func makeLaunchConfiguration(for _: ACPRunRequest) throws -> ACPLaunchConfiguration {
+        launchConfiguration
+    }
+
+    func makeSessionConfiguration(
+        for _: ACPRunRequest,
+        mcpServer _: RepoPromptMCPServerConfiguration
+    ) throws -> ACPSessionConfiguration {
+        ACPSessionConfiguration(
+            mode: .new,
+            workingDirectory: workingDirectory,
+            mcpServers: []
+        )
+    }
+
+    func buildPromptBlocks(
+        for _: AgentMessage,
+        request _: ACPRunRequest
+    ) throws -> [[String: Any]] {
+        []
+    }
+
+    func normalizeSessionUpdate(
+        _: [String: Any],
+        sessionID _: String
+    ) -> [NormalizedAgentRuntimeEvent] {
+        []
+    }
+
+    func normalizeError(_ error: Error) -> Error {
+        error
+    }
+}

--- a/Tests/RepoPromptTests/AgentMode/CursorACPLaunchResolverTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/CursorACPLaunchResolverTests.swift
@@ -8,7 +8,11 @@ final class CursorACPLaunchResolverTests: XCTestCase {
         let executable = try makeExecutable(named: "cursor-agent", in: directory)
         let resolver = CursorACPLaunchResolver()
         let provider = CursorACPAgentProvider(
-            config: CursorAgentConfig(commandName: executable.path, additionalPathHints: []),
+            config: CursorAgentConfig(
+                commandName: executable.path,
+                additionalPathHints: [],
+                includeRepoPromptMCPServer: false
+            ),
             launchResolver: resolver
         )
 
@@ -28,7 +32,11 @@ final class CursorACPLaunchResolverTests: XCTestCase {
         environment["SHELL"] = "/bin/false"
         let testEnvironment = environment
         let resolver = CursorACPLaunchResolver(environmentProvider: { _ in testEnvironment })
-        let config = CursorAgentConfig(commandName: "cursor-agent", additionalPathHints: [])
+        let config = CursorAgentConfig(
+            commandName: "cursor-agent",
+            additionalPathHints: [],
+            includeRepoPromptMCPServer: false
+        )
 
         let support = await resolver.probeSupport(for: config)
         let provider = CursorACPAgentProvider(config: config, launchResolver: resolver)
@@ -38,6 +46,199 @@ final class CursorACPLaunchResolverTests: XCTestCase {
         XCTAssertEqual(support, .supported)
         XCTAssertEqual(launch.command, executable.resolvingSymlinksInPath().standardizedFileURL.path)
         XCTAssertEqual(probedPath, launch.command)
+    }
+
+    func testLaunchConfigurationLeasesCursorApprovalForModernSessionMCPInjection() async throws {
+        let workspace = try makeTemporaryDirectory()
+        let executableDirectory = try makeTemporaryDirectory()
+        let executable = try makeExecutable(named: "cursor-agent", in: executableDirectory)
+        let cursorDataDirectory = try makeTemporaryDirectory()
+        let mcpConfiguration = RepoPromptMCPServerConfiguration(
+            command: "/tmp/repoprompt-mcp-fixture",
+            args: ["--fixture"],
+            env: [
+                .init(name: "RP_FIXTURE", value: "1")
+            ]
+        )
+        let approvalURL = CursorIntegrationConfiguration.projectMCPApprovalURL(
+            workingDirectory: workspace.path,
+            cursorDataDirectory: cursorDataDirectory
+        )
+        try FileManager.default.createDirectory(
+            at: approvalURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let originalData = Data(#"["existing-approval"]"#.utf8)
+        try originalData.write(to: approvalURL)
+
+        let provider = CursorACPAgentProvider(
+            config: CursorAgentConfig(
+                commandName: executable.path,
+                additionalPathHints: []
+            ),
+            repoPromptMCPConfiguration: mcpConfiguration,
+            launchResolver: CursorACPLaunchResolver(),
+            approvalEnvironmentProvider: {
+                [
+                    "CURSOR_DATA_DIR": cursorDataDirectory.path,
+                    "HOME": "/ignored-by-explicit-cursor-data-dir"
+                ]
+            }
+        )
+
+        let launch = try provider.makeLaunchConfiguration(
+            for: makeRunRequest(workspacePath: workspace.path)
+        )
+        let artifact = try XCTUnwrap(launch.cleanupArtifact)
+        addTeardownBlock {
+            await provider.cleanupLaunchArtifacts(for: launch)
+        }
+        let approvalsData = try Data(contentsOf: approvalURL)
+        let approvals = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: approvalsData) as? [String]
+        )
+        let expectedApproval = try CursorIntegrationConfiguration.approvalIdentifier(
+            projectRoot: workspace.path,
+            repoPromptMCPConfiguration: mcpConfiguration
+        )
+        let session = try provider.makeSessionConfiguration(
+            for: makeRunRequest(workspacePath: workspace.path),
+            mcpServer: .repoPrompt
+        )
+
+        XCTAssertEqual(launch.environment["CURSOR_DATA_DIR"], cursorDataDirectory.path)
+        XCTAssertEqual(artifact.kind, CursorIntegrationConfiguration.cleanupArtifactKind)
+        XCTAssertEqual(approvals, ["existing-approval", expectedApproval])
+        XCTAssertEqual(session.mcpServers, [mcpConfiguration])
+        XCTAssertFalse(
+            FileManager.default.fileExists(
+                atPath: workspace.appendingPathComponent(".cursor/mcp.json").path
+            )
+        )
+
+        await provider.cleanupLaunchArtifacts(for: launch)
+        XCTAssertEqual(try Data(contentsOf: approvalURL), originalData)
+    }
+
+    func testApprovalIdentifierMatchesCursorCLIHashContract() throws {
+        let configuration = RepoPromptMCPServerConfiguration(
+            command: "/tmp/repoprompt mcp",
+            args: ["--flag", "value"],
+            env: [
+                .init(name: "A", value: "1"),
+                .init(name: "B", value: "two")
+            ]
+        )
+
+        XCTAssertEqual(
+            try CursorIntegrationConfiguration.approvalIdentifier(
+                projectRoot: "/tmp/rpce cursor",
+                repoPromptMCPConfiguration: configuration
+            ),
+            "RepoPromptCE-d23f237662b1345f"
+        )
+
+        let numericAndDuplicateEnvironmentConfiguration = RepoPromptMCPServerConfiguration(
+            command: #"/tmp/repo"prompt\mcp"#,
+            args: ["--path", "a/b", "line\nvalue"],
+            env: [
+                .init(name: "B", value: "first"),
+                .init(name: "2", value: "two"),
+                .init(name: "01", value: "leading"),
+                .init(name: "1", value: "one"),
+                .init(name: "B", value: "last"),
+                .init(name: "A", value: "line\nvalue")
+            ]
+        )
+        XCTAssertEqual(
+            try CursorIntegrationConfiguration.approvalIdentifier(
+                projectRoot: #"/tmp/rpce "cursor""#,
+                repoPromptMCPConfiguration: numericAndDuplicateEnvironmentConfiguration
+            ),
+            "RepoPromptCE-05aa1995d1d02aa0"
+        )
+    }
+
+    func testApprovalCleanupPreservesConcurrentEntriesAndRemovesTemporaryApproval() throws {
+        let workspace = try makeTemporaryDirectory()
+        let cursorDataDirectory = try makeTemporaryDirectory()
+        let configuration = RepoPromptMCPServerConfiguration(command: "/tmp/repoprompt-mcp")
+        let approvalURL = CursorIntegrationConfiguration.projectMCPApprovalURL(
+            workingDirectory: workspace.path,
+            cursorDataDirectory: cursorDataDirectory
+        )
+        try FileManager.default.createDirectory(
+            at: approvalURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data(#"["existing-approval"]"#.utf8).write(to: approvalURL)
+        let artifact = try XCTUnwrap(
+            CursorIntegrationConfiguration.prepareProjectMCPApproval(
+                workingDirectory: workspace.path,
+                cursorDataDirectory: cursorDataDirectory,
+                repoPromptMCPConfiguration: configuration
+            )
+        )
+        let temporaryApproval = try CursorIntegrationConfiguration.approvalIdentifier(
+            projectRoot: workspace.path,
+            repoPromptMCPConfiguration: configuration
+        )
+        let concurrentData = try JSONSerialization.data(
+            withJSONObject: ["existing-approval", temporaryApproval, "cursor-added-approval"],
+            options: [.prettyPrinted]
+        )
+        try concurrentData.write(to: approvalURL, options: .atomic)
+
+        CursorIntegrationConfiguration.cleanupProjectMCPApproval(leaseID: artifact.id)
+
+        let retainedApprovals = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(contentsOf: approvalURL)) as? [String]
+        )
+        XCTAssertEqual(retainedApprovals, ["existing-approval", "cursor-added-approval"])
+    }
+
+    func testConcurrentApprovalLeasesRestoreOriginalDataAfterFinalCleanup() throws {
+        for cleanupFirstLeaseFirst in [true, false] {
+            let workspace = try makeTemporaryDirectory()
+            let cursorDataDirectory = try makeTemporaryDirectory()
+            let approvalURL = CursorIntegrationConfiguration.projectMCPApprovalURL(
+                workingDirectory: workspace.path,
+                cursorDataDirectory: cursorDataDirectory
+            )
+            try FileManager.default.createDirectory(
+                at: approvalURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            let originalData = Data(#"["existing-approval"]"#.utf8)
+            try originalData.write(to: approvalURL)
+
+            let first = try XCTUnwrap(
+                CursorIntegrationConfiguration.prepareProjectMCPApproval(
+                    workingDirectory: workspace.path,
+                    cursorDataDirectory: cursorDataDirectory,
+                    repoPromptMCPConfiguration: .init(command: "/tmp/repoprompt-mcp-one")
+                )
+            )
+            let second = try XCTUnwrap(
+                CursorIntegrationConfiguration.prepareProjectMCPApproval(
+                    workingDirectory: workspace.path,
+                    cursorDataDirectory: cursorDataDirectory,
+                    repoPromptMCPConfiguration: .init(command: "/tmp/repoprompt-mcp-two")
+                )
+            )
+            defer {
+                CursorIntegrationConfiguration.cleanupProjectMCPApproval(leaseID: first.id)
+                CursorIntegrationConfiguration.cleanupProjectMCPApproval(leaseID: second.id)
+            }
+
+            let firstCleanup = cleanupFirstLeaseFirst ? first : second
+            let finalCleanup = cleanupFirstLeaseFirst ? second : first
+            CursorIntegrationConfiguration.cleanupProjectMCPApproval(leaseID: firstCleanup.id)
+            XCTAssertNotEqual(try Data(contentsOf: approvalURL), originalData)
+
+            CursorIntegrationConfiguration.cleanupProjectMCPApproval(leaseID: finalCleanup.id)
+            XCTAssertEqual(try Data(contentsOf: approvalURL), originalData)
+        }
     }
 
     func testRepeatedProbeRefreshesCurrentEnvironmentBeforeSpawn() async throws {

--- a/Tests/RepoPromptTests/AgentMode/CursorACPLaunchResolverTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/CursorACPLaunchResolverTests.swift
@@ -98,7 +98,9 @@ final class CursorACPLaunchResolverTests: XCTestCase {
             JSONSerialization.jsonObject(with: approvalsData) as? [String]
         )
         let expectedApproval = try CursorIntegrationConfiguration.approvalIdentifier(
-            projectRoot: workspace.path,
+            projectRoot: CursorIntegrationConfiguration.projectRootURL(
+                workingDirectory: workspace.path
+            ).path,
             repoPromptMCPConfiguration: mcpConfiguration
         )
         let session = try provider.makeSessionConfiguration(
@@ -159,6 +161,68 @@ final class CursorACPLaunchResolverTests: XCTestCase {
         )
     }
 
+    func testTmpAliasUsesCursorPhysicalProjectPathForApprovalDirectoryAndHash() throws {
+        let workspaceName = "CursorACPLaunchResolverTests-\(UUID().uuidString)"
+        let aliasWorkspace = URL(fileURLWithPath: "/tmp", isDirectory: true)
+            .appendingPathComponent(workspaceName, isDirectory: true)
+        let physicalWorkspace = URL(fileURLWithPath: "/private/tmp", isDirectory: true)
+            .appendingPathComponent(workspaceName, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: aliasWorkspace,
+            withIntermediateDirectories: true
+        )
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: physicalWorkspace)
+        }
+        XCTAssertNotEqual(aliasWorkspace.path, physicalWorkspace.path)
+
+        let cursorDataDirectory = try makeTemporaryDirectory()
+        let configuration = RepoPromptMCPServerConfiguration(command: "/tmp/repoprompt-mcp")
+        let aliasProjectRoot = CursorIntegrationConfiguration.projectRootURL(
+            workingDirectory: aliasWorkspace.path
+        )
+        let physicalProjectRoot = CursorIntegrationConfiguration.projectRootURL(
+            workingDirectory: physicalWorkspace.path
+        )
+        let aliasApprovalURL = CursorIntegrationConfiguration.projectMCPApprovalURL(
+            workingDirectory: aliasWorkspace.path,
+            cursorDataDirectory: cursorDataDirectory
+        )
+        let physicalApprovalURL = CursorIntegrationConfiguration.projectMCPApprovalURL(
+            workingDirectory: physicalWorkspace.path,
+            cursorDataDirectory: cursorDataDirectory
+        )
+
+        XCTAssertEqual(aliasProjectRoot, physicalWorkspace)
+        XCTAssertEqual(aliasProjectRoot, physicalProjectRoot)
+        XCTAssertEqual(aliasApprovalURL, physicalApprovalURL)
+        XCTAssertEqual(
+            aliasApprovalURL.deletingLastPathComponent().lastPathComponent,
+            "private-tmp-\(workspaceName)"
+        )
+
+        try CursorIntegrationConfiguration.prepareProjectMCPApproval(
+            workingDirectory: aliasWorkspace.path,
+            cursorDataDirectory: cursorDataDirectory,
+            repoPromptMCPConfiguration: configuration,
+            cleanupAfterRun: false
+        )
+
+        let approvals = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(contentsOf: aliasApprovalURL)) as? [String]
+        )
+        let physicalApproval = try CursorIntegrationConfiguration.approvalIdentifier(
+            projectRoot: physicalWorkspace.path,
+            repoPromptMCPConfiguration: configuration
+        )
+        let aliasApproval = try CursorIntegrationConfiguration.approvalIdentifier(
+            projectRoot: aliasWorkspace.path,
+            repoPromptMCPConfiguration: configuration
+        )
+        XCTAssertNotEqual(aliasApproval, physicalApproval)
+        XCTAssertEqual(approvals, [physicalApproval])
+    }
+
     func testApprovalCleanupPreservesConcurrentEntriesAndRemovesTemporaryApproval() throws {
         let workspace = try makeTemporaryDirectory()
         let cursorDataDirectory = try makeTemporaryDirectory()
@@ -180,7 +244,9 @@ final class CursorACPLaunchResolverTests: XCTestCase {
             )
         )
         let temporaryApproval = try CursorIntegrationConfiguration.approvalIdentifier(
-            projectRoot: workspace.path,
+            projectRoot: CursorIntegrationConfiguration.projectRootURL(
+                workingDirectory: workspace.path
+            ).path,
             repoPromptMCPConfiguration: configuration
         )
         let concurrentData = try JSONSerialization.data(

--- a/Tests/RepoPromptTests/AgentMode/OpenCodeACPLaunchResolverTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/OpenCodeACPLaunchResolverTests.swift
@@ -40,7 +40,7 @@ final class OpenCodeACPLaunchResolverTests: XCTestCase {
             includeManagedConfigOverlay: false
         )
 
-        let support = await resolver.probeSupport(for: config)
+        let support = try await resolver.probeSupport(for: config)
         let launch = try resolver.resolvedLaunch(for: config)
         let probedPath = try String(contentsOf: probePathRecord, encoding: .utf8)
 
@@ -63,7 +63,7 @@ final class OpenCodeACPLaunchResolverTests: XCTestCase {
         })
         let config = OpenCodeAgentConfig(commandName: "opencode", additionalPathHints: [])
 
-        let firstSupport = await resolver.probeSupport(for: config)
+        let firstSupport = try await resolver.probeSupport(for: config)
         let firstLaunch = try resolver.resolvedLaunch(for: config)
         XCTAssertEqual(firstSupport, .supported)
         XCTAssertEqual(firstLaunch.command, firstExecutable.resolvingSymlinksInPath().path)
@@ -72,7 +72,7 @@ final class OpenCodeACPLaunchResolverTests: XCTestCase {
             "PATH": secondDirectory.path,
             "SHELL": "/bin/false"
         ])
-        let secondSupport = await resolver.probeSupport(for: config)
+        let secondSupport = try await resolver.probeSupport(for: config)
         let secondLaunch = try resolver.resolvedLaunch(for: config)
         XCTAssertEqual(secondSupport, .supported)
         XCTAssertEqual(secondLaunch.command, secondExecutable.resolvingSymlinksInPath().path)
@@ -92,6 +92,51 @@ final class OpenCodeACPLaunchResolverTests: XCTestCase {
         }
     }
 
+    func testCancelledSupportProbePropagatesCancellationAndLeavesNoBareCommandCache() async throws {
+        let directory = try makeTemporaryDirectory()
+        let marker = directory.appendingPathComponent("probe-started")
+        _ = try makeExecutable(in: directory, marker: marker, sleepSeconds: 30)
+        var environment = ProcessInfo.processInfo.environment
+        environment["PATH"] = directory.path
+        environment["SHELL"] = "/bin/false"
+        let capturedEnvironment = environment
+        let resolver = OpenCodeACPLaunchResolver(environmentProvider: { _ in capturedEnvironment })
+        let config = OpenCodeAgentConfig(commandName: "opencode", additionalPathHints: [])
+
+        let probe = Task { try await resolver.probeSupport(for: config) }
+        let didStartProbe = await waitUntilFileExists(marker)
+        XCTAssertTrue(didStartProbe)
+        probe.cancel()
+        do {
+            _ = try await probe.value
+            XCTFail("Expected support probe cancellation")
+        } catch is CancellationError {
+            // Expected: cancellation is not converted into an unsupported result.
+        }
+
+        XCTAssertThrowsError(try resolver.resolvedLaunch(for: config)) { error in
+            guard case OpenCodeACPLaunchResolutionError.environmentDiscoveryRequired = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    func testWorldWritableExecutableDirectoryIsRejectedWithoutExecution() async throws {
+        let directory = try makeTemporaryDirectory()
+        let marker = directory.appendingPathComponent("probe-ran")
+        let executable = try makeExecutable(in: directory, marker: marker)
+        try FileManager.default.setAttributes([.posixPermissions: 0o777], ofItemAtPath: directory.path)
+
+        let support = try await OpenCodeACPLaunchResolver().probeSupport(
+            for: OpenCodeAgentConfig(commandName: executable.path, additionalPathHints: [])
+        )
+
+        guard case .unsupported = support else {
+            return XCTFail("Expected unsafe launch path to be unsupported")
+        }
+        XCTAssertFalse(FileManager.default.fileExists(atPath: marker.path))
+    }
+
     func testFailedProbeDoesNotLeaveSpawnableCacheAndReplacementCanRecover() async throws {
         let directory = try makeTemporaryDirectory()
         let executable = try makeExecutable(in: directory, exitStatus: 2)
@@ -102,7 +147,7 @@ final class OpenCodeACPLaunchResolverTests: XCTestCase {
         let resolver = OpenCodeACPLaunchResolver(environmentProvider: { _ in capturedEnvironment })
         let config = OpenCodeAgentConfig(commandName: "opencode", additionalPathHints: [])
 
-        guard case .unsupported = await resolver.probeSupport(for: config) else {
+        guard case .unsupported = try await resolver.probeSupport(for: config) else {
             return XCTFail("Expected failed support probe")
         }
         XCTAssertThrowsError(try resolver.resolvedLaunch(for: config)) { error in
@@ -113,7 +158,7 @@ final class OpenCodeACPLaunchResolverTests: XCTestCase {
 
         try FileManager.default.removeItem(at: executable)
         let replacement = try makeExecutable(in: directory)
-        let replacementSupport = await resolver.probeSupport(for: config)
+        let replacementSupport = try await resolver.probeSupport(for: config)
         XCTAssertEqual(replacementSupport, .supported)
         XCTAssertEqual(
             try resolver.resolvedLaunch(for: config).command,
@@ -127,7 +172,7 @@ final class OpenCodeACPLaunchResolverTests: XCTestCase {
         let resolver = OpenCodeACPLaunchResolver()
         let config = OpenCodeAgentConfig(commandName: executable.path, additionalPathHints: [])
 
-        let support = await resolver.probeSupport(for: config)
+        let support = try await resolver.probeSupport(for: config)
         XCTAssertEqual(support, .supported)
         try FileManager.default.removeItem(at: executable)
         _ = try makeExecutable(in: directory, output: "replacement OpenCode ACP")
@@ -165,18 +210,31 @@ final class OpenCodeACPLaunchResolverTests: XCTestCase {
         in directory: URL,
         marker: URL? = nil,
         output: String = "OpenCode ACP support",
-        exitStatus: Int32 = 0
+        exitStatus: Int32 = 0,
+        sleepSeconds: Int? = nil
     ) throws -> URL {
         let executable = directory.appendingPathComponent("opencode")
         var lines = ["#!/bin/sh"]
         if let marker {
             lines.append("printf '%s' \"$0\" > '\(marker.path)'")
         }
+        if let sleepSeconds {
+            lines.append("exec /bin/sleep \(sleepSeconds)")
+        }
         lines.append("printf '%s\\n' '\(output)'")
         lines.append("exit \(exitStatus)")
         try lines.joined(separator: "\n").write(to: executable, atomically: true, encoding: .utf8)
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
         return executable
+    }
+
+    private func waitUntilFileExists(_ url: URL, timeout: TimeInterval = 2) async -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        repeat {
+            if FileManager.default.fileExists(atPath: url.path) { return true }
+            await Task.yield()
+        } while Date() < deadline
+        return false
     }
 }
 

--- a/Tests/RepoPromptTests/AgentMode/OpenCodeACPLaunchResolverTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/OpenCodeACPLaunchResolverTests.swift
@@ -1,0 +1,197 @@
+import Foundation
+@testable import RepoPrompt
+import XCTest
+
+final class OpenCodeACPLaunchResolverTests: XCTestCase {
+    func testMakeLaunchConfigurationResolvesExplicitPathWithoutPriorProbe() throws {
+        let directory = try makeTemporaryDirectory()
+        let executable = try makeExecutable(in: directory)
+        let resolver = OpenCodeACPLaunchResolver()
+        let provider = OpenCodeACPAgentProvider(
+            config: OpenCodeAgentConfig(
+                commandName: executable.path,
+                additionalPathHints: [],
+                includeRepoPromptMCPServer: false,
+                includeManagedConfigOverlay: false
+            ),
+            launchResolver: resolver
+        )
+
+        let launch = try provider.makeLaunchConfiguration(for: makeRunRequest(workspacePath: directory.path))
+
+        XCTAssertEqual(launch.command, executable.resolvingSymlinksInPath().standardizedFileURL.path)
+        XCTAssertEqual(launch.arguments, ["acp"])
+        XCTAssertEqual(launch.expectedExecutableIdentity?.canonicalPath, launch.command)
+    }
+
+    func testBareCommandUsesCapturedEnvironmentAndCachesCanonicalPathForSpawn() async throws {
+        let directory = try makeTemporaryDirectory()
+        let probePathRecord = directory.appendingPathComponent("probe-path")
+        let executable = try makeExecutable(in: directory, marker: probePathRecord)
+        var environment = ProcessInfo.processInfo.environment
+        environment["PATH"] = directory.path
+        environment["SHELL"] = "/bin/false"
+        let capturedEnvironment = environment
+        let resolver = OpenCodeACPLaunchResolver(environmentProvider: { _ in capturedEnvironment })
+        let config = OpenCodeAgentConfig(
+            commandName: "opencode",
+            additionalPathHints: [],
+            includeRepoPromptMCPServer: false,
+            includeManagedConfigOverlay: false
+        )
+
+        let support = await resolver.probeSupport(for: config)
+        let launch = try resolver.resolvedLaunch(for: config)
+        let probedPath = try String(contentsOf: probePathRecord, encoding: .utf8)
+
+        XCTAssertEqual(support, .supported)
+        XCTAssertEqual(launch.command, executable.resolvingSymlinksInPath().standardizedFileURL.path)
+        XCTAssertEqual(probedPath, launch.command)
+    }
+
+    func testRepeatedProbeRefreshesCurrentEnvironmentBeforeSpawn() async throws {
+        let firstDirectory = try makeTemporaryDirectory()
+        let secondDirectory = try makeTemporaryDirectory()
+        let firstExecutable = try makeExecutable(in: firstDirectory)
+        let secondExecutable = try makeExecutable(in: secondDirectory)
+        let environmentBox = OpenCodeTestEnvironmentBox(environment: [
+            "PATH": firstDirectory.path,
+            "SHELL": "/bin/false"
+        ])
+        let resolver = OpenCodeACPLaunchResolver(environmentProvider: { _ in
+            await environmentBox.current()
+        })
+        let config = OpenCodeAgentConfig(commandName: "opencode", additionalPathHints: [])
+
+        let firstSupport = await resolver.probeSupport(for: config)
+        let firstLaunch = try resolver.resolvedLaunch(for: config)
+        XCTAssertEqual(firstSupport, .supported)
+        XCTAssertEqual(firstLaunch.command, firstExecutable.resolvingSymlinksInPath().path)
+
+        await environmentBox.set([
+            "PATH": secondDirectory.path,
+            "SHELL": "/bin/false"
+        ])
+        let secondSupport = await resolver.probeSupport(for: config)
+        let secondLaunch = try resolver.resolvedLaunch(for: config)
+        XCTAssertEqual(secondSupport, .supported)
+        XCTAssertEqual(secondLaunch.command, secondExecutable.resolvingSymlinksInPath().path)
+    }
+
+    func testBareCommandWithoutSuccessfulPreflightFailsClosed() {
+        let resolver = OpenCodeACPLaunchResolver(environmentProvider: { _ in [:] })
+
+        XCTAssertThrowsError(
+            try resolver.resolvedLaunch(
+                for: OpenCodeAgentConfig(commandName: "opencode", additionalPathHints: [])
+            )
+        ) { error in
+            guard case OpenCodeACPLaunchResolutionError.environmentDiscoveryRequired = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    func testFailedProbeDoesNotLeaveSpawnableCacheAndReplacementCanRecover() async throws {
+        let directory = try makeTemporaryDirectory()
+        let executable = try makeExecutable(in: directory, exitStatus: 2)
+        var environment = ProcessInfo.processInfo.environment
+        environment["PATH"] = directory.path
+        environment["SHELL"] = "/bin/false"
+        let capturedEnvironment = environment
+        let resolver = OpenCodeACPLaunchResolver(environmentProvider: { _ in capturedEnvironment })
+        let config = OpenCodeAgentConfig(commandName: "opencode", additionalPathHints: [])
+
+        guard case .unsupported = await resolver.probeSupport(for: config) else {
+            return XCTFail("Expected failed support probe")
+        }
+        XCTAssertThrowsError(try resolver.resolvedLaunch(for: config)) { error in
+            guard case OpenCodeACPLaunchResolutionError.environmentDiscoveryRequired = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+
+        try FileManager.default.removeItem(at: executable)
+        let replacement = try makeExecutable(in: directory)
+        let replacementSupport = await resolver.probeSupport(for: config)
+        XCTAssertEqual(replacementSupport, .supported)
+        XCTAssertEqual(
+            try resolver.resolvedLaunch(for: config).command,
+            replacement.resolvingSymlinksInPath().standardizedFileURL.path
+        )
+    }
+
+    func testCachedIdentityDriftFailsBeforeSpawn() async throws {
+        let directory = try makeTemporaryDirectory()
+        let executable = try makeExecutable(in: directory)
+        let resolver = OpenCodeACPLaunchResolver()
+        let config = OpenCodeAgentConfig(commandName: executable.path, additionalPathHints: [])
+
+        let support = await resolver.probeSupport(for: config)
+        XCTAssertEqual(support, .supported)
+        try FileManager.default.removeItem(at: executable)
+        _ = try makeExecutable(in: directory, output: "replacement OpenCode ACP")
+
+        XCTAssertThrowsError(try resolver.resolvedLaunch(for: config)) { error in
+            guard case ExecutableFileIdentityError.identityChanged = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    private func makeRunRequest(workspacePath: String) -> ACPRunRequest {
+        ACPRunRequest(
+            agentKind: .openCode,
+            modelString: nil,
+            workspacePath: workspacePath,
+            resumeSessionID: nil,
+            attachments: [],
+            taskLabelKind: nil
+        )
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OpenCodeACPLaunchResolverTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: directory)
+        }
+        return directory
+    }
+
+    @discardableResult
+    private func makeExecutable(
+        in directory: URL,
+        marker: URL? = nil,
+        output: String = "OpenCode ACP support",
+        exitStatus: Int32 = 0
+    ) throws -> URL {
+        let executable = directory.appendingPathComponent("opencode")
+        var lines = ["#!/bin/sh"]
+        if let marker {
+            lines.append("printf '%s' \"$0\" > '\(marker.path)'")
+        }
+        lines.append("printf '%s\\n' '\(output)'")
+        lines.append("exit \(exitStatus)")
+        try lines.joined(separator: "\n").write(to: executable, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+        return executable
+    }
+}
+
+private actor OpenCodeTestEnvironmentBox {
+    private var environment: [String: String]
+
+    init(environment: [String: String]) {
+        self.environment = environment
+    }
+
+    func current() -> [String: String] {
+        environment
+    }
+
+    func set(_ environment: [String: String]) {
+        self.environment = environment
+    }
+}

--- a/Tests/RepoPromptTests/MCP/Control/MCPAgentPolicyAdmissionRaceTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/MCPAgentPolicyAdmissionRaceTests.swift
@@ -7,6 +7,14 @@ final class MCPAgentPolicyAdmissionRaceTests: XCTestCase {
     private let manager = ServerNetworkManager.shared
     private let clientName = AgentProviderKind.openCodeMCPClientID
 
+    override func tearDown() async throws {
+        #if DEBUG
+            await manager.debugResumePendingPolicyRouteInstallation()
+            await manager.debugResumePendingPolicyCommit()
+        #endif
+        try await super.tearDown()
+    }
+
     func testHelperIdentityTransitionWaitsForLateExpectedPIDRegistration() async throws {
         #if DEBUG
             let processTree = try makeSleepingProcessTree()
@@ -438,6 +446,205 @@ final class MCPAgentPolicyAdmissionRaceTests: XCTestCase {
         #endif
     }
 
+    @MainActor
+    func testRoutingSignalWaitsForOneShotPolicyCommit() async throws {
+        #if DEBUG
+            let window = makeWindow()
+            defer { WindowStatesManager.shared.unregisterWindowState(window) }
+            let runID = UUID()
+            let connectionID = UUID()
+            let windowID = window.windowID
+            await installPolicy(runID: runID, windowID: windowID)
+            await manager.registerExpectedAgentPID(getpid(), for: clientName, runID: runID)
+            await MCPRoutingWaiter.cleanup(runID: runID)
+            await MCPRoutingWaiter.register(runID: runID)
+
+            let routeWaiter = Task {
+                await MCPRoutingWaiter.waitUntilRouted(runID: runID, timeoutSeconds: 5)
+            }
+            let didRegisterRouteWaiter = await waitUntil {
+                await MCPRoutingWaiter.debugContinuationCount(runID: runID) == 1
+            }
+            XCTAssertTrue(didRegisterRouteWaiter)
+
+            await manager.debugSuspendNextPendingPolicyCommit()
+            let application = Task {
+                await manager.debugApplyPendingPolicy(
+                    clientName: clientName,
+                    connectionID: connectionID,
+                    clientPid: Int(getpid()),
+                    bootstrapClientName: "repoprompt_ce_cli_debug",
+                    pidGateTimeout: 0.25,
+                    requireRunRouting: true
+                )
+            }
+            let didSuspendCommit = await waitUntil {
+                await self.manager.debugIsPendingPolicyCommitSuspended()
+            }
+            XCTAssertTrue(didSuspendCommit)
+
+            let pendingBeforeCommit = await manager.debugPendingPolicySnapshot(for: clientName)
+            let waiterCountBeforeCommit = await MCPRoutingWaiter.debugContinuationCount(runID: runID)
+            XCTAssertTrue(pendingBeforeCommit.contains { $0.runID == runID })
+            XCTAssertEqual(waiterCountBeforeCommit, 1)
+
+            await manager.debugResumePendingPolicyCommit()
+            let result = await application.value
+            let didRoute = await routeWaiter.value
+            XCTAssertEqual(result.outcome, "applied")
+            XCTAssertTrue(didRoute)
+
+            await cleanup(
+                runID: runID,
+                connectionID: connectionID,
+                windowID: windowID,
+                expectedPID: getpid()
+            )
+            await MCPRoutingWaiter.cleanup(runID: runID)
+        #else
+            throw XCTSkip("Pending policy commit diagnostics require DEBUG helpers.")
+        #endif
+    }
+
+    @MainActor
+    func testStaleConnectionAfterRouteInstallRollsBackWithoutConsumingOrFailingRun() async throws {
+        #if DEBUG
+            let window = makeWindow()
+            defer { WindowStatesManager.shared.unregisterWindowState(window) }
+            let runID = UUID()
+            let staleConnectionID = UUID()
+            let retryConnectionID = UUID()
+            let windowID = window.windowID
+            await installPolicy(runID: runID, windowID: windowID)
+            await manager.registerExpectedAgentPID(getpid(), for: clientName, runID: runID)
+            await MCPRoutingWaiter.cleanup(runID: runID)
+            await MCPRoutingWaiter.register(runID: runID)
+
+            let routeWaiter = Task {
+                await MCPRoutingWaiter.waitUntilRouted(runID: runID, timeoutSeconds: 5)
+            }
+            let didRegisterRouteWaiter = await waitUntil {
+                await MCPRoutingWaiter.debugContinuationCount(runID: runID) == 1
+            }
+            XCTAssertTrue(didRegisterRouteWaiter)
+
+            await manager.debugSuspendNextPendingPolicyCommit()
+            let staleApplication = Task {
+                await manager.debugApplyPendingPolicy(
+                    clientName: clientName,
+                    connectionID: staleConnectionID,
+                    clientPid: Int(getpid()),
+                    bootstrapClientName: "repoprompt_ce_cli_debug",
+                    pidGateTimeout: 0.25,
+                    requireRunRouting: true
+                )
+            }
+            let didSuspendCommit = await waitUntil {
+                await self.manager.debugIsPendingPolicyCommitSuspended()
+            }
+            XCTAssertTrue(didSuspendCommit)
+            let mappedBeforeInvalidation = await MainActor.run {
+                window.mcpServer.connectionID(forRunID: runID)
+            }
+            XCTAssertEqual(mappedBeforeInvalidation, staleConnectionID)
+
+            await manager.debugInvalidatePendingPolicyApplication(connectionID: staleConnectionID)
+            await manager.debugResumePendingPolicyCommit()
+            let staleResult = await staleApplication.value
+            XCTAssertEqual(staleResult.outcome, "rejected:stale_connection")
+
+            let pendingAfterRollback = await manager.debugPendingPolicySnapshot(for: clientName)
+            let mappedAfterRollback = await MainActor.run {
+                window.mcpServer.connectionID(forRunID: runID)
+            }
+            let waiterCountAfterRollback = await MCPRoutingWaiter.debugContinuationCount(runID: runID)
+            XCTAssertTrue(pendingAfterRollback.contains { $0.runID == runID })
+            XCTAssertNil(mappedAfterRollback)
+            XCTAssertEqual(waiterCountAfterRollback, 1)
+
+            let retryResult = await manager.debugApplyPendingPolicy(
+                clientName: clientName,
+                connectionID: retryConnectionID,
+                clientPid: Int(getpid()),
+                bootstrapClientName: "repoprompt_ce_cli_debug",
+                pidGateTimeout: 0.25,
+                requireRunRouting: true
+            )
+            let didRoute = await routeWaiter.value
+            XCTAssertEqual(retryResult.outcome, "applied")
+            XCTAssertTrue(didRoute)
+
+            await manager.removeConnection(staleConnectionID)
+            await cleanup(
+                runID: runID,
+                connectionID: retryConnectionID,
+                windowID: windowID,
+                expectedPID: getpid()
+            )
+            await MCPRoutingWaiter.cleanup(runID: runID)
+        #else
+            throw XCTSkip("Pending policy commit diagnostics require DEBUG helpers.")
+        #endif
+    }
+
+    @MainActor
+    func testStaleTabContextCleanupPreservesSilentReplacementRunMapping() async throws {
+        #if DEBUG
+            let window = makeWindow()
+            defer { WindowStatesManager.shared.unregisterWindowState(window) }
+            let runID = UUID()
+            let staleConnectionID = UUID()
+            let replacementConnectionID = UUID()
+            let snapshot = ComposeTabState()
+            await MCPRoutingWaiter.cleanup(runID: runID)
+            await MCPRoutingWaiter.register(runID: runID)
+            addTeardownBlock {
+                await MCPRoutingWaiter.cleanup(runID: runID)
+            }
+            let routeWaiter = Task {
+                await MCPRoutingWaiter.waitUntilRouted(runID: runID, timeoutSeconds: 1)
+            }
+            let didRegisterWaiter = await waitUntil {
+                await MCPRoutingWaiter.debugContinuationCount(runID: runID) == 1
+            }
+            XCTAssertTrue(didRegisterWaiter)
+
+            window.mcpServer.installTabContext(
+                clientID: staleConnectionID.uuidString,
+                clientName: clientName,
+                windowID: window.windowID,
+                workspaceID: nil,
+                snapshot: snapshot,
+                runID: runID,
+                signalRouting: false
+            )
+            let didRegisterReplacement = window.mcpServer.registerRunIDMapping(
+                connectionID: replacementConnectionID,
+                runID: runID,
+                windowID: window.windowID,
+                signalRouting: false
+            )
+            window.mcpServer.removeTabContext(
+                forConnectionID: staleConnectionID,
+                clientName: clientName,
+                windowID: window.windowID,
+                runID: runID
+            )
+
+            let waiterCount = await MCPRoutingWaiter.debugContinuationCount(runID: runID)
+            XCTAssertTrue(didRegisterReplacement)
+            XCTAssertEqual(window.mcpServer.connectionIDByRunID[runID], replacementConnectionID)
+            XCTAssertEqual(window.mcpServer.connectionIDToRunID[replacementConnectionID], runID)
+            XCTAssertEqual(waiterCount, 1)
+
+            await MCPRoutingWaiter.notifyRouted(runID: runID)
+            let didRoute = await routeWaiter.value
+            XCTAssertTrue(didRoute)
+        #else
+            throw XCTSkip("Tab-context routing diagnostics require DEBUG helpers.")
+        #endif
+    }
+
     func testPolicyCleanupWhileWaitingRejectsWithoutFallbackBinding() async throws {
         #if DEBUG
             let runID = UUID()
@@ -472,6 +679,16 @@ final class MCPAgentPolicyAdmissionRaceTests: XCTestCase {
     }
 
     #if DEBUG
+        @MainActor
+        private func makeWindow() -> WindowState {
+            let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
+            GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
+            let window = WindowState()
+            WindowStatesManager.shared.registerWindowState(window)
+            GlobalSettingsStore.shared.setMCPAutoStart(previousAutoStart, commit: false)
+            return window
+        }
+
         private func installPolicy(runID: UUID, windowID: Int) async {
             await manager.installClientConnectionPolicy(
                 for: clientName,

--- a/Tests/RepoPromptTests/MCP/Control/MCPAgentPolicyAdmissionRaceTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/MCPAgentPolicyAdmissionRaceTests.swift
@@ -1,0 +1,586 @@
+import Darwin
+import Foundation
+@testable import RepoPrompt
+import XCTest
+
+final class MCPAgentPolicyAdmissionRaceTests: XCTestCase {
+    private let manager = ServerNetworkManager.shared
+    private let clientName = AgentProviderKind.openCodeMCPClientID
+
+    func testHelperIdentityTransitionWaitsForLateExpectedPIDRegistration() async throws {
+        #if DEBUG
+            let processTree = try makeSleepingProcessTree()
+            defer { processTree.terminate() }
+            let runID = UUID()
+            let connectionID = UUID()
+            let windowID = 61001
+            await installPolicy(runID: runID, windowID: windowID)
+            await manager.debugClearRunRoutingHistoryForTesting()
+
+            let application = Task {
+                await manager.debugApplyPendingPolicy(
+                    clientName: clientName,
+                    connectionID: connectionID,
+                    clientPid: Int(processTree.childPID),
+                    bootstrapClientName: "repoprompt_ce_cli_debug",
+                    pidGateTimeout: 1.0,
+                    requireRunRouting: false
+                )
+            }
+
+            let waitStarted = await waitForEvent("pid_gate_wait_started", runID: runID)
+            XCTAssertTrue(waitStarted)
+            await manager.registerExpectedAgentPID(processTree.parentPID, for: clientName, runID: runID)
+            let result = await application.value
+
+            XCTAssertEqual(result.outcome, "applied")
+            XCTAssertEqual(result.runID, runID)
+            XCTAssertEqual(result.windowID, windowID)
+            let mappedRunID = await manager.runIDForConnection(connectionID)
+            let waitCompleted = await waitForEvent("pid_gate_wait_completed", runID: runID)
+            let policyApplied = await waitForEvent("policy_applied", runID: runID)
+            let pending = await manager.debugPendingPolicySnapshot(for: clientName)
+            XCTAssertEqual(mappedRunID, runID)
+            XCTAssertTrue(waitCompleted)
+            XCTAssertTrue(policyApplied)
+            XCTAssertFalse(pending.contains { $0.runID == runID })
+
+            await cleanup(
+                runID: runID,
+                connectionID: connectionID,
+                windowID: windowID,
+                expectedPID: processTree.parentPID
+            )
+        #else
+            throw XCTSkip("PID-gated routing diagnostics require DEBUG helpers.")
+        #endif
+    }
+
+    func testWrongPIDCannotConsumeRunPolicy() async throws {
+        #if DEBUG
+            let expectedTree = try makeSleepingProcessTree()
+            let unrelatedTree = try makeSleepingProcessTree()
+            defer {
+                expectedTree.terminate()
+                unrelatedTree.terminate()
+            }
+            let runID = UUID()
+            let connectionID = UUID()
+            let windowID = 61002
+            await installPolicy(runID: runID, windowID: windowID)
+            await manager.registerExpectedAgentPID(expectedTree.parentPID, for: clientName, runID: runID)
+
+            let result = await manager.debugApplyPendingPolicy(
+                clientName: clientName,
+                connectionID: connectionID,
+                clientPid: Int(unrelatedTree.childPID),
+                bootstrapClientName: "repoprompt_ce_cli_debug",
+                pidGateTimeout: 0.05,
+                requireRunRouting: false
+            )
+
+            XCTAssertEqual(result.outcome, "rejected:ownership_timeout")
+            let mappedRunID = await manager.runIDForConnection(connectionID)
+            let pending = await manager.debugPendingPolicySnapshot(for: clientName)
+            XCTAssertNil(mappedRunID)
+            XCTAssertTrue(pending.contains { $0.runID == runID })
+            await cleanup(
+                runID: runID,
+                connectionID: connectionID,
+                windowID: windowID,
+                expectedPID: expectedTree.parentPID
+            )
+        #else
+            throw XCTSkip("PID-gated routing diagnostics require DEBUG helpers.")
+        #endif
+    }
+
+    func testWrongClientCannotConsumeOpenCodePolicy() async throws {
+        #if DEBUG
+            let runID = UUID()
+            let connectionID = UUID()
+            let windowID = 61003
+            await installPolicy(runID: runID, windowID: windowID)
+            await manager.registerExpectedAgentPID(getpid(), for: clientName, runID: runID)
+
+            let result = await manager.debugApplyPendingPolicy(
+                clientName: "unrelated-client",
+                connectionID: connectionID,
+                clientPid: Int(getpid()),
+                bootstrapClientName: "repoprompt_ce_cli_debug",
+                pidGateTimeout: 0.05,
+                requireRunRouting: false
+            )
+
+            XCTAssertEqual(result.outcome, "fallback")
+            let mappedRunID = await manager.runIDForConnection(connectionID)
+            let pending = await manager.debugPendingPolicySnapshot(for: clientName)
+            XCTAssertNil(mappedRunID)
+            XCTAssertTrue(pending.contains { $0.runID == runID })
+            await cleanup(runID: runID, connectionID: connectionID, windowID: windowID, expectedPID: getpid())
+        #else
+            throw XCTSkip("PID-gated routing diagnostics require DEBUG helpers.")
+        #endif
+    }
+
+    func testParallelSameProviderRunsConsumeOnlyTheirRunSpecificPIDPolicy() async throws {
+        #if DEBUG
+            let firstProcess = try makeSleepingProcessTree()
+            let secondProcess = try makeSleepingProcessTree()
+            defer {
+                firstProcess.terminate()
+                secondProcess.terminate()
+            }
+
+            let firstRunID = UUID()
+            let secondRunID = UUID()
+            let firstConnectionID = UUID()
+            let secondConnectionID = UUID()
+            let firstWindowID = 61004
+            let secondWindowID = 61005
+            await installPolicy(runID: firstRunID, windowID: firstWindowID)
+            await installPolicy(runID: secondRunID, windowID: secondWindowID)
+            await manager.registerExpectedAgentPID(firstProcess.parentPID, for: clientName, runID: firstRunID)
+            await manager.registerExpectedAgentPID(secondProcess.parentPID, for: clientName, runID: secondRunID)
+
+            async let first = manager.debugApplyPendingPolicy(
+                clientName: clientName,
+                connectionID: firstConnectionID,
+                clientPid: Int(firstProcess.childPID),
+                bootstrapClientName: "repoprompt_ce_cli_debug",
+                pidGateTimeout: 0.25,
+                requireRunRouting: false
+            )
+            async let second = manager.debugApplyPendingPolicy(
+                clientName: clientName,
+                connectionID: secondConnectionID,
+                clientPid: Int(secondProcess.childPID),
+                bootstrapClientName: "repoprompt_ce_cli_debug",
+                pidGateTimeout: 0.25,
+                requireRunRouting: false
+            )
+            let (firstResult, secondResult) = await (first, second)
+
+            XCTAssertEqual(firstResult.outcome, "applied")
+            XCTAssertEqual(firstResult.runID, firstRunID)
+            XCTAssertEqual(firstResult.windowID, firstWindowID)
+            XCTAssertEqual(secondResult.outcome, "applied")
+            XCTAssertEqual(secondResult.runID, secondRunID)
+            XCTAssertEqual(secondResult.windowID, secondWindowID)
+            let mappedFirstRunID = await manager.runIDForConnection(firstConnectionID)
+            let mappedSecondRunID = await manager.runIDForConnection(secondConnectionID)
+            XCTAssertEqual(mappedFirstRunID, firstRunID)
+            XCTAssertEqual(mappedSecondRunID, secondRunID)
+
+            await cleanup(
+                runID: firstRunID,
+                connectionID: firstConnectionID,
+                windowID: firstWindowID,
+                expectedPID: firstProcess.parentPID
+            )
+            await cleanup(
+                runID: secondRunID,
+                connectionID: secondConnectionID,
+                windowID: secondWindowID,
+                expectedPID: secondProcess.parentPID
+            )
+        #else
+            throw XCTSkip("PID-gated routing diagnostics require DEBUG helpers.")
+        #endif
+    }
+
+    func testMixedQueuePrioritizesConsumablePIDGatedRunPolicy() async throws {
+        #if DEBUG
+            let runID = UUID()
+            let connectionID = UUID()
+            let windowID = 61006
+            await manager.installClientConnectionPolicy(
+                for: clientName,
+                windowID: windowID,
+                restrictedTools: [],
+                oneShot: true,
+                reason: "non-gated mixed queue fixture",
+                ttl: 10,
+                purpose: .unknown,
+                requiresExpectedAgentPID: false
+            )
+            await installPolicy(runID: runID, windowID: windowID)
+            await manager.registerExpectedAgentPID(getpid(), for: clientName, runID: runID)
+
+            let result = await manager.debugApplyPendingPolicy(
+                clientName: clientName,
+                connectionID: connectionID,
+                clientPid: Int(getpid()),
+                bootstrapClientName: "repoprompt_ce_cli_debug",
+                pidGateTimeout: 0.25,
+                requireRunRouting: false
+            )
+
+            let pending = await manager.debugPendingPolicySnapshot(for: clientName)
+            XCTAssertEqual(result.outcome, "applied")
+            XCTAssertEqual(result.runID, runID)
+            XCTAssertEqual(pending.count, 1)
+            XCTAssertNil(pending.first?.runID)
+
+            await manager.clearClientConnectionPolicy(for: clientName, windowID: windowID)
+            await cleanup(runID: runID, connectionID: connectionID, windowID: windowID, expectedPID: getpid())
+        #else
+            throw XCTSkip("PID-gated routing diagnostics require DEBUG helpers.")
+        #endif
+    }
+
+    func testKnownAgentBootstrapTimesOutInsteadOfFallingBackWhenLiveAffinityIsUnusable() async throws {
+        #if DEBUG
+            let runID = UUID()
+            let connectionID = UUID()
+            let bootstrapConnectionID = UUID()
+            let windowID = 61009
+            let sessionKey = "bootstrap-timeout-\(UUID().uuidString)"
+            await installPolicy(runID: runID, windowID: windowID)
+            await manager.registerExpectedAgentPID(getpid(), for: clientName, runID: runID)
+            let applied = await manager.debugApplyPendingPolicy(
+                clientName: clientName,
+                connectionID: connectionID,
+                clientPid: Int(getpid()),
+                bootstrapClientName: "repoprompt_ce_cli_debug",
+                sessionKey: sessionKey,
+                pidGateTimeout: 0.25,
+                requireRunRouting: false
+            )
+            XCTAssertEqual(applied.outcome, "applied")
+            await manager.clearExpectedAgentPID(getpid(), for: clientName, runID: runID)
+
+            let readiness = await manager.debugBootstrapPolicyAdmissionStatus(
+                bootstrapClientName: clientName,
+                connectionID: bootstrapConnectionID,
+                sessionKey: sessionKey,
+                clientPid: Int(getpid()),
+                timeout: 0.01
+            )
+
+            XCTAssertEqual(readiness, "timedOut")
+            await cleanup(
+                runID: runID,
+                connectionID: connectionID,
+                windowID: windowID,
+                expectedPID: nil
+            )
+            await manager.removeConnection(bootstrapConnectionID)
+        #else
+            throw XCTSkip("Bootstrap admission diagnostics require DEBUG helpers.")
+        #endif
+    }
+
+    func testSessionTokenAlreadyBoundToLiveRunCannotConsumeAnotherRunPolicy() async throws {
+        #if DEBUG
+            let firstRunID = UUID()
+            let secondRunID = UUID()
+            let firstConnectionID = UUID()
+            let secondConnectionID = UUID()
+            let firstWindowID = 61007
+            let secondWindowID = 61008
+            let sessionKey = "routing-isolation-\(UUID().uuidString)"
+            await installPolicy(runID: firstRunID, windowID: firstWindowID)
+            await manager.registerExpectedAgentPID(getpid(), for: clientName, runID: firstRunID)
+
+            let firstResult = await manager.debugApplyPendingPolicy(
+                clientName: clientName,
+                connectionID: firstConnectionID,
+                clientPid: Int(getpid()),
+                bootstrapClientName: "repoprompt_ce_cli_debug",
+                sessionKey: sessionKey,
+                pidGateTimeout: 0.25,
+                requireRunRouting: false
+            )
+            XCTAssertEqual(firstResult.outcome, "applied")
+            XCTAssertEqual(firstResult.runID, firstRunID)
+
+            await installPolicy(runID: secondRunID, windowID: secondWindowID)
+            await manager.registerExpectedAgentPID(getpid(), for: clientName, runID: secondRunID)
+            let secondResult = await manager.debugApplyPendingPolicy(
+                clientName: clientName,
+                connectionID: secondConnectionID,
+                clientPid: Int(getpid()),
+                bootstrapClientName: "repoprompt_ce_cli_debug",
+                sessionKey: sessionKey,
+                pidGateTimeout: 0.25,
+                requireRunRouting: false
+            )
+
+            XCTAssertEqual(secondResult.outcome, "rejected:session_token_bound_to_other_run")
+            XCTAssertEqual(secondResult.runID, secondRunID)
+            let secondMappedRunID = await manager.runIDForConnection(secondConnectionID)
+            XCTAssertNil(secondMappedRunID)
+            let pending = await manager.debugPendingPolicySnapshot(for: clientName)
+            XCTAssertTrue(pending.contains { $0.runID == secondRunID })
+
+            await cleanup(
+                runID: firstRunID,
+                connectionID: firstConnectionID,
+                windowID: firstWindowID,
+                expectedPID: getpid()
+            )
+            await cleanup(
+                runID: secondRunID,
+                connectionID: secondConnectionID,
+                windowID: secondWindowID,
+                expectedPID: getpid()
+            )
+        #else
+            throw XCTSkip("Token/run isolation diagnostics require DEBUG helpers.")
+        #endif
+    }
+
+    func testRouteMappingFailureRejectsAndRestoresOneShotPolicy() async throws {
+        #if DEBUG
+            let runID = UUID()
+            let connectionID = UUID()
+            let missingWindowID = 61999
+            await installPolicy(runID: runID, windowID: missingWindowID)
+            await manager.registerExpectedAgentPID(getpid(), for: clientName, runID: runID)
+
+            let result = await manager.debugApplyPendingPolicy(
+                clientName: clientName,
+                connectionID: connectionID,
+                clientPid: Int(getpid()),
+                bootstrapClientName: "repoprompt_ce_cli_debug",
+                pidGateTimeout: 0.25,
+                requireRunRouting: true
+            )
+
+            let pending = await manager.debugPendingPolicySnapshot(for: clientName)
+            let mappedRunID = await manager.runIDForConnection(connectionID)
+            XCTAssertEqual(result.outcome, "rejected:route_mapping_failed")
+            XCTAssertEqual(result.restrictedTools, [])
+            XCTAssertEqual(result.additionalTools, [])
+            XCTAssertEqual(result.purpose, .unknown)
+            XCTAssertNil(result.windowID)
+            XCTAssertNil(mappedRunID)
+            XCTAssertTrue(pending.contains { $0.runID == runID })
+
+            await cleanup(
+                runID: runID,
+                connectionID: connectionID,
+                windowID: missingWindowID,
+                expectedPID: getpid()
+            )
+        #else
+            throw XCTSkip("PID-gated routing diagnostics require DEBUG helpers.")
+        #endif
+    }
+
+    func testSuspendedRouteInstallationReservesOneShotPolicyAndRollbackRestoresIt() async throws {
+        #if DEBUG
+            let runID = UUID()
+            let firstConnectionID = UUID()
+            let competingConnectionID = UUID()
+            let retryConnectionID = UUID()
+            let missingWindowID = 61998
+            await installPolicy(runID: runID, windowID: missingWindowID)
+            await manager.registerExpectedAgentPID(getpid(), for: clientName, runID: runID)
+            await manager.debugSuspendNextPendingPolicyRouteInstallation()
+
+            let firstApplication = Task {
+                await manager.debugApplyPendingPolicy(
+                    clientName: clientName,
+                    connectionID: firstConnectionID,
+                    clientPid: Int(getpid()),
+                    bootstrapClientName: "repoprompt_ce_cli_debug",
+                    pidGateTimeout: 0.25,
+                    requireRunRouting: true
+                )
+            }
+
+            let suspended = await waitUntil {
+                await self.manager.debugIsPendingPolicyRouteInstallationSuspended()
+            }
+            XCTAssertTrue(suspended)
+
+            let competingResult = await manager.debugApplyPendingPolicy(
+                clientName: clientName,
+                connectionID: competingConnectionID,
+                clientPid: Int(getpid()),
+                bootstrapClientName: "repoprompt_ce_cli_debug",
+                pidGateTimeout: 0.25,
+                requireRunRouting: false
+            )
+            let reservedSnapshot = await manager.debugPendingPolicySnapshot(for: clientName)
+            XCTAssertEqual(competingResult.outcome, "rejected:policy_reserved")
+            XCTAssertTrue(reservedSnapshot.contains { $0.runID == runID })
+
+            await manager.debugResumePendingPolicyRouteInstallation()
+            let firstResult = await firstApplication.value
+            XCTAssertEqual(firstResult.outcome, "rejected:route_mapping_failed")
+
+            let retryResult = await manager.debugApplyPendingPolicy(
+                clientName: clientName,
+                connectionID: retryConnectionID,
+                clientPid: Int(getpid()),
+                bootstrapClientName: "repoprompt_ce_cli_debug",
+                pidGateTimeout: 0.25,
+                requireRunRouting: false
+            )
+            XCTAssertEqual(retryResult.outcome, "applied")
+            XCTAssertEqual(retryResult.runID, runID)
+            let consumedSnapshot = await manager.debugPendingPolicySnapshot(for: clientName)
+            XCTAssertFalse(consumedSnapshot.contains { $0.runID == runID })
+
+            await manager.removeConnection(firstConnectionID)
+            await manager.removeConnection(competingConnectionID)
+            await cleanup(
+                runID: runID,
+                connectionID: retryConnectionID,
+                windowID: missingWindowID,
+                expectedPID: getpid()
+            )
+        #else
+            throw XCTSkip("Pending policy reservation diagnostics require DEBUG helpers.")
+        #endif
+    }
+
+    func testPolicyCleanupWhileWaitingRejectsWithoutFallbackBinding() async throws {
+        #if DEBUG
+            let runID = UUID()
+            let connectionID = UUID()
+            let windowID = 61006
+            await installPolicy(runID: runID, windowID: windowID)
+            await manager.debugClearRunRoutingHistoryForTesting()
+
+            let application = Task {
+                await manager.debugApplyPendingPolicy(
+                    clientName: clientName,
+                    connectionID: connectionID,
+                    clientPid: Int(getpid()),
+                    bootstrapClientName: "repoprompt_ce_cli_debug",
+                    pidGateTimeout: 1.0,
+                    requireRunRouting: false
+                )
+            }
+
+            let waitStarted = await waitForEvent("pid_gate_wait_started", runID: runID)
+            XCTAssertTrue(waitStarted)
+            await manager.clearClientConnectionPolicy(for: clientName, windowID: windowID, runID: runID)
+            let result = await application.value
+
+            XCTAssertEqual(result.outcome, "rejected:policy_removed")
+            let mappedRunID = await manager.runIDForConnection(connectionID)
+            XCTAssertNil(mappedRunID)
+            await cleanup(runID: runID, connectionID: connectionID, windowID: windowID, expectedPID: nil)
+        #else
+            throw XCTSkip("PID-gated routing diagnostics require DEBUG helpers.")
+        #endif
+    }
+
+    #if DEBUG
+        private func installPolicy(runID: UUID, windowID: Int) async {
+            await manager.installClientConnectionPolicy(
+                for: clientName,
+                windowID: windowID,
+                restrictedTools: AgentModeMCPToolPolicy.restrictedTools,
+                oneShot: true,
+                reason: "OpenCode routing race test",
+                ttl: 10,
+                tabID: nil,
+                runID: runID,
+                additionalTools: nil,
+                purpose: .agentModeRun,
+                taskLabelKind: nil,
+                allowsAgentExternalControlTools: false,
+                requiresExpectedAgentPID: true
+            )
+        }
+
+        private func cleanup(
+            runID: UUID,
+            connectionID: UUID,
+            windowID: Int,
+            expectedPID: pid_t?
+        ) async {
+            if let expectedPID {
+                await manager.clearExpectedAgentPID(expectedPID, for: clientName, runID: runID)
+            }
+            await manager.clearClientConnectionPolicy(for: clientName, windowID: windowID, runID: runID)
+            await manager.removeConnection(connectionID)
+            await manager.cleanupRunRoutingState(for: runID, windowID: windowID)
+        }
+
+        private func waitUntil(
+            timeout: TimeInterval = 1.0,
+            condition: @escaping () async -> Bool
+        ) async -> Bool {
+            let deadline = Date().addingTimeInterval(timeout)
+            repeat {
+                if await condition() {
+                    return true
+                }
+                try? await Task.sleep(for: .milliseconds(10))
+            } while Date() < deadline
+            return false
+        }
+
+        private func waitForEvent(
+            _ event: String,
+            runID: UUID,
+            timeout: TimeInterval = 1.0
+        ) async -> Bool {
+            let deadline = Date().addingTimeInterval(timeout)
+            repeat {
+                let payload = await manager.debugRunRoutingHistoryPayload(runID: runID, limit: 100)
+                let events = payload["events"] as? [[String: Any]] ?? []
+                if events.contains(where: { $0["event"] as? String == event }) {
+                    return true
+                }
+                try? await Task.sleep(for: .milliseconds(10))
+            } while Date() < deadline
+            return false
+        }
+
+        private struct SleepingProcessTree {
+            let parent: Process
+            let childPID: pid_t
+
+            var parentPID: pid_t {
+                parent.processIdentifier
+            }
+
+            func terminate() {
+                _ = Darwin.kill(childPID, SIGTERM)
+                if parent.isRunning {
+                    parent.terminate()
+                }
+                parent.waitUntilExit()
+            }
+        }
+
+        private func makeSleepingProcessTree() throws -> SleepingProcessTree {
+            let process = Process()
+            let stdout = Pipe()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+            process.arguments = [
+                "python3",
+                "-c",
+                "import subprocess; child=subprocess.Popen(['/bin/sleep','30']); print(child.pid, flush=True); child.wait()"
+            ]
+            process.standardOutput = stdout
+            try process.run()
+            var data = Data()
+            while data.count < 32 {
+                guard let byte = try stdout.fileHandleForReading.read(upToCount: 1), !byte.isEmpty else { break }
+                if byte == Data([0x0A]) { break }
+                data.append(byte)
+            }
+            guard let text = String(data: data, encoding: .utf8),
+                  let childPID = pid_t(text.trimmingCharacters(in: .whitespacesAndNewlines))
+            else {
+                process.terminate()
+                process.waitUntilExit()
+                throw NSError(
+                    domain: "MCPAgentPolicyAdmissionRaceTests",
+                    code: 1,
+                    userInfo: [NSLocalizedDescriptionKey: "Failed to read child PID from process-tree fixture."]
+                )
+            }
+            return SleepingProcessTree(parent: process, childPID: childPID)
+        }
+    #endif
+}

--- a/Tests/RepoPromptTests/MCP/Control/MCPAgentPolicyAdmissionRaceTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/MCPAgentPolicyAdmissionRaceTests.swift
@@ -538,6 +538,7 @@ final class MCPAgentPolicyAdmissionRaceTests: XCTestCase {
         private struct SleepingProcessTree {
             let parent: Process
             let childPID: pid_t
+            let parentExited: DispatchSemaphore
 
             var parentPID: pid_t {
                 parent.processIdentifier
@@ -545,10 +546,17 @@ final class MCPAgentPolicyAdmissionRaceTests: XCTestCase {
 
             func terminate() {
                 _ = Darwin.kill(childPID, SIGTERM)
-                if parent.isRunning {
-                    parent.terminate()
+                _ = Darwin.kill(parentPID, SIGTERM)
+                guard parentExited.wait(timeout: .now() + 0.25) == .timedOut else {
+                    parent.waitUntilExit()
+                    return
                 }
-                parent.waitUntilExit()
+
+                _ = Darwin.kill(childPID, SIGKILL)
+                _ = Darwin.kill(parentPID, SIGKILL)
+                if parentExited.wait(timeout: .now() + 1.0) == .success {
+                    parent.waitUntilExit()
+                }
             }
         }
 
@@ -562,6 +570,8 @@ final class MCPAgentPolicyAdmissionRaceTests: XCTestCase {
                 "import subprocess; child=subprocess.Popen(['/bin/sleep','30']); print(child.pid, flush=True); child.wait()"
             ]
             process.standardOutput = stdout
+            let parentExited = DispatchSemaphore(value: 0)
+            process.terminationHandler = { _ in parentExited.signal() }
             try process.run()
             var data = Data()
             while data.count < 32 {
@@ -580,7 +590,7 @@ final class MCPAgentPolicyAdmissionRaceTests: XCTestCase {
                     userInfo: [NSLocalizedDescriptionKey: "Failed to read child PID from process-tree fixture."]
                 )
             }
-            return SleepingProcessTree(parent: process, childPID: childPID)
+            return SleepingProcessTree(parent: process, childPID: childPID, parentExited: parentExited)
         }
     #endif
 }

--- a/Tests/RepoPromptTests/MCP/Control/MCPBootstrapLeaseTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/MCPBootstrapLeaseTests.swift
@@ -1,0 +1,83 @@
+import Foundation
+@testable import RepoPrompt
+import XCTest
+
+final class MCPBootstrapLeaseTests: XCTestCase {
+    func testCleanupWhileQueuedReleasesGateOwnershipThatArrivesLater() async throws {
+        #if DEBUG
+            let blockerGateID = UUID()
+            let leaseGateID = UUID()
+            let probeGateID = UUID()
+            let runID = UUID()
+            let recorder = PolicyRecorder()
+
+            await HeadlessAgentConnectionGate.cancelAll()
+            await HeadlessAgentConnectionGate.beginConnection(blockerGateID)
+            await MCPRoutingWaiter.cleanup(runID: runID)
+
+            let lease = MCPBootstrapLease(
+                spec: MCPBootstrapLeaseSpec(
+                    runID: runID,
+                    gateID: leaseGateID,
+                    windowID: 1,
+                    tabID: nil,
+                    clientName: "bootstrap-lease-race-test",
+                    restrictedTools: [],
+                    additionalTools: nil,
+                    oneShot: true,
+                    reason: "queued cleanup regression",
+                    ttl: 10,
+                    purpose: .agentModeRun,
+                    taskLabelKind: nil,
+                    allowsAgentExternalControlTools: false,
+                    requiresExpectedAgentPID: false
+                ),
+                policyInstaller: { _ in await recorder.recordInstall() },
+                policyClearer: { _ in await recorder.recordClear() }
+            )
+
+            let acquisition = Task { await lease.acquire() }
+            var queued = false
+            let queueDeadline = Date().addingTimeInterval(2)
+            repeat {
+                queued = await HeadlessAgentConnectionGate.shared.debugWaitingCount() == 1
+                if queued { break }
+                try await Task.sleep(for: .milliseconds(10))
+            } while Date() < queueDeadline
+            let activeBeforeCleanup = await HeadlessAgentConnectionGate.shared.debugActiveConnectionID()
+            XCTAssertTrue(queued, "Expected lease acquisition to queue behind blocker; active=\(String(describing: activeBeforeCleanup))")
+
+            await lease.cancelAndCleanup()
+            let activeBlockerID = await HeadlessAgentConnectionGate.shared.debugActiveConnectionID()
+            XCTAssertEqual(activeBlockerID, blockerGateID)
+
+            await HeadlessAgentConnectionGate.completeConnection(blockerGateID)
+            let didAcquireLease = await acquisition.value
+            let installCount = await recorder.installCount
+            XCTAssertFalse(didAcquireLease)
+            XCTAssertEqual(installCount, 0)
+
+            let didAcquireProbe = await HeadlessAgentConnectionGate.acquire(probeGateID)
+            let activeProbeID = await HeadlessAgentConnectionGate.shared.debugActiveConnectionID()
+            XCTAssertTrue(didAcquireProbe)
+            XCTAssertEqual(activeProbeID, probeGateID)
+            await HeadlessAgentConnectionGate.completeConnection(probeGateID)
+            await MCPRoutingWaiter.cleanup(runID: runID)
+        #else
+            throw XCTSkip("Gate ownership inspection is DEBUG-only.")
+        #endif
+    }
+}
+
+private actor PolicyRecorder {
+    private(set) var installCount = 0
+    private(set) var clearCount = 0
+
+    func recordInstall() {
+        installCount += 1
+    }
+
+    func recordClear() {
+        clearCount += 1
+    }
+}

--- a/Tests/RepoPromptTests/MCP/Control/MCPRunRoutingDiagnosticsTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/MCPRunRoutingDiagnosticsTests.swift
@@ -144,6 +144,40 @@ final class MCPRunRoutingDiagnosticsTests: XCTestCase {
         #endif
     }
 
+    func testRoutingWaiterTimeoutIsPerWaiterAndDoesNotResolveRun() async throws {
+        #if DEBUG
+            let runID = UUID()
+            await MCPRoutingWaiter.cleanup(runID: runID)
+            await MCPRoutingWaiter.register(runID: runID)
+
+            let shortWaiter = Task {
+                await MCPRoutingWaiter.waitUntilRouted(runID: runID, timeoutSeconds: 0.01)
+            }
+            let longWaiter = Task {
+                await MCPRoutingWaiter.waitUntilRouted(runID: runID, timeoutSeconds: 5)
+            }
+            var continuationCount = 0
+            for _ in 0 ..< 100 {
+                continuationCount = await MCPRoutingWaiter.debugContinuationCount(runID: runID)
+                if continuationCount == 2 { break }
+                await Task.yield()
+            }
+            XCTAssertEqual(continuationCount, 2)
+
+            let shortResult = await shortWaiter.value
+            let remainingWaiterCount = await MCPRoutingWaiter.debugContinuationCount(runID: runID)
+            XCTAssertFalse(shortResult)
+            XCTAssertEqual(remainingWaiterCount, 1)
+
+            await MCPRoutingWaiter.notifyRouted(runID: runID)
+            let longResult = await longWaiter.value
+            XCTAssertTrue(longResult)
+            await MCPRoutingWaiter.cleanup(runID: runID)
+        #else
+            throw XCTSkip("Routing waiter continuation inspection is DEBUG-only.")
+        #endif
+    }
+
     func testRoutingWaiterCleanupResumesUnresolvedWaitersAsFailure() async throws {
         #if DEBUG
             let runID = UUID()

--- a/Tests/RepoPromptTests/MCP/Control/MCPRunRoutingDiagnosticsTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/MCPRunRoutingDiagnosticsTests.swift
@@ -1,0 +1,234 @@
+import Foundation
+import MCP
+@testable import RepoPrompt
+import XCTest
+
+final class MCPRunRoutingDiagnosticsTests: XCTestCase {
+    private let manager = ServerNetworkManager.shared
+
+    func testRunRoutingHistoryFiltersByRunAndRedactsSensitiveFields() async throws {
+        #if DEBUG
+            let firstRunID = UUID()
+            let secondRunID = UUID()
+            let connectionID = UUID()
+            await manager.debugClearRunRoutingHistoryForTesting()
+
+            await manager.debugRecordRunRoutingEvent(
+                runID: firstRunID,
+                event: "policy_installed",
+                connectionID: connectionID,
+                fields: [
+                    "client_name": "opencode",
+                    "session_token": "must-not-leak",
+                    "auth_header": "Bearer must-not-leak",
+                    "prompt_payload": "private prompt",
+                    "error": "token=must-not-leak",
+                    "safe_args": "OPENAI_API_KEY=<redacted> --header <redacted>",
+                    "unsafe_args": "OPENAI_API_KEY=must-not-leak",
+                    "pending_policy_key": "opencode",
+                    "bounded": String(repeating: "x", count: 900)
+                ]
+            )
+            await manager.debugRecordRunRoutingEvent(
+                runID: secondRunID,
+                event: "other_run_event",
+                fields: ["client_name": "opencode"]
+            )
+            await manager.debugRecordRunRoutingEvent(
+                runID: firstRunID,
+                event: "policy_applied",
+                connectionID: connectionID,
+                fields: ["expected_pids": "123,456"]
+            )
+
+            let payload = await manager.debugRunRoutingHistoryPayload(runID: firstRunID, limit: 20)
+            let events = try XCTUnwrap(payload["events"] as? [[String: Any]])
+            XCTAssertEqual(events.map { $0["event"] as? String }, ["policy_installed", "policy_applied"])
+            XCTAssertTrue(events.allSatisfy { $0["run_id"] as? String == firstRunID.uuidString })
+            XCTAssertFalse(events.contains { $0["event"] as? String == "other_run_event" })
+
+            let fields = try XCTUnwrap(events.first?["fields"] as? [String: String])
+            XCTAssertEqual(fields["session_token"], "<redacted>")
+            XCTAssertEqual(fields["auth_header"], "<redacted>")
+            XCTAssertEqual(fields["prompt_payload"], "<redacted>")
+            XCTAssertEqual(fields["error"], "<redacted>")
+            XCTAssertEqual(fields["safe_args"], "OPENAI_API_KEY=<redacted> --header <redacted>")
+            XCTAssertEqual(fields["unsafe_args"], "<redacted>")
+            XCTAssertEqual(fields["client_name"], "opencode")
+            XCTAssertEqual(fields["pending_policy_key"], "opencode")
+            XCTAssertEqual(fields["bounded"]?.count, 512)
+            XCTAssertFalse(String(describing: payload).contains("must-not-leak"))
+            XCTAssertFalse(String(describing: payload).contains("private prompt"))
+        #else
+            throw XCTSkip("Run routing history is DEBUG-only.")
+        #endif
+    }
+
+    func testRunRoutingHistoryBoundsFieldCountAndValueLength() async throws {
+        #if DEBUG
+            let runID = UUID()
+            await manager.debugClearRunRoutingHistoryForTesting()
+            let fields = Dictionary(uniqueKeysWithValues: (0 ..< 40).map { index in
+                (String(format: "field_%02d", index), String(repeating: "v", count: 900))
+            })
+
+            await manager.debugRecordRunRoutingEvent(
+                runID: runID,
+                event: String(repeating: "e", count: 200),
+                fields: fields
+            )
+
+            let payload = await manager.debugRunRoutingHistoryPayload(runID: runID, limit: 1)
+            let events = try XCTUnwrap(payload["events"] as? [[String: Any]])
+            let event = try XCTUnwrap(events.first)
+            let boundedFields = try XCTUnwrap(event["fields"] as? [String: String])
+            XCTAssertEqual((event["event"] as? String)?.count, 96)
+            XCTAssertEqual(boundedFields.count, 32)
+            XCTAssertTrue(boundedFields.values.allSatisfy { $0.count == 512 })
+            XCTAssertNotNil(boundedFields["field_00"])
+            XCTAssertNil(boundedFields["field_39"])
+        #else
+            throw XCTSkip("Run routing history is DEBUG-only.")
+        #endif
+    }
+
+    func testRunRoutingHistoryIsBoundedAndReportsDroppedEvents() async throws {
+        #if DEBUG
+            let runID = UUID()
+            await manager.debugClearRunRoutingHistoryForTesting()
+
+            for index in 0 ..< 1005 {
+                await manager.debugRecordRunRoutingEvent(
+                    runID: runID,
+                    event: "event_\(index)"
+                )
+            }
+
+            let payload = await manager.debugRunRoutingHistoryPayload(runID: runID, limit: 500)
+            let events = try XCTUnwrap(payload["events"] as? [[String: Any]])
+            XCTAssertEqual(payload["history_capacity"] as? Int, 1000)
+            XCTAssertEqual(payload["dropped_event_count"] as? Int, 5)
+            XCTAssertEqual(events.count, 500)
+            XCTAssertEqual(events.first?["event"] as? String, "event_505")
+            XCTAssertEqual(events.last?["event"] as? String, "event_1004")
+        #else
+            throw XCTSkip("Run routing history is DEBUG-only.")
+        #endif
+    }
+
+    func testRoutingWaiterRecordsOnlyAcceptedTerminalSignal() async throws {
+        #if DEBUG
+            let runID = UUID()
+            await manager.debugClearRunRoutingHistoryForTesting()
+            await MCPRoutingWaiter.cleanup(runID: runID)
+            await MCPRoutingWaiter.register(runID: runID)
+            let waitTask = Task {
+                await MCPRoutingWaiter.waitUntilRouted(runID: runID, timeoutSeconds: 1)
+            }
+
+            await MCPRoutingWaiter.notifyRouted(runID: runID)
+            await MCPRoutingWaiter.notifyRouted(runID: runID)
+            await MCPRoutingWaiter.notifyFailed(runID: runID)
+
+            let routed = await waitTask.value
+            XCTAssertTrue(routed)
+            let payload = await manager.debugRunRoutingHistoryPayload(runID: runID, limit: 20)
+            let events = try XCTUnwrap(payload["events"] as? [[String: Any]])
+            let signals = events.filter { $0["event"] as? String == "routing_waiter_signalled" }
+            XCTAssertEqual(signals.count, 1)
+            let fields = try XCTUnwrap(signals.first?["fields"] as? [String: String])
+            XCTAssertEqual(fields["outcome"], "routed")
+            await MCPRoutingWaiter.cleanup(runID: runID)
+        #else
+            throw XCTSkip("Run routing history is DEBUG-only.")
+        #endif
+    }
+
+    func testRoutingWaiterCleanupResumesUnresolvedWaitersAsFailure() async throws {
+        #if DEBUG
+            let runID = UUID()
+            await MCPRoutingWaiter.cleanup(runID: runID)
+            await MCPRoutingWaiter.register(runID: runID)
+            let firstWaiter = Task {
+                await MCPRoutingWaiter.waitUntilRouted(runID: runID, timeoutSeconds: 5)
+            }
+            let secondWaiter = Task {
+                await MCPRoutingWaiter.waitUntilRouted(runID: runID, timeoutSeconds: 5)
+            }
+            var continuationCount = 0
+            for _ in 0 ..< 100 {
+                continuationCount = await MCPRoutingWaiter.debugContinuationCount(runID: runID)
+                if continuationCount == 2 { break }
+                await Task.yield()
+            }
+            XCTAssertEqual(continuationCount, 2)
+
+            await MCPRoutingWaiter.cleanup(runID: runID)
+
+            let firstResult = await firstWaiter.value
+            let secondResult = await secondWaiter.value
+            XCTAssertFalse(firstResult)
+            XCTAssertFalse(secondResult)
+        #else
+            throw XCTSkip("Routing waiter continuation inspection is DEBUG-only.")
+        #endif
+    }
+
+    func testRunRoutingHistoryToolRequiresRunIDAndBoundsLimit() async throws {
+        #if DEBUG
+            let missingRun = await manager.debugRunRoutingHistoryToolPayload(
+                op: "run_routing_history",
+                arguments: [:]
+            )
+            let missingPayload = try diagnosticsPayload(missingRun)
+            XCTAssertEqual(missingPayload["ok"] as? Bool, false)
+            XCTAssertEqual(missingPayload["code"] as? String, "invalid_params")
+
+            let invalidLimit = await manager.debugRunRoutingHistoryToolPayload(
+                op: "run_routing_history",
+                arguments: [
+                    "run_id": .string(UUID().uuidString),
+                    "limit": .int(501)
+                ]
+            )
+            let limitPayload = try diagnosticsPayload(invalidLimit)
+            XCTAssertEqual(limitPayload["ok"] as? Bool, false)
+            XCTAssertEqual(limitPayload["code"] as? String, "invalid_params")
+        #else
+            throw XCTSkip("Run routing history is DEBUG-only.")
+        #endif
+    }
+
+    func testRunRoutingHistoryLimitReturnsNewestMatchingEventsInSequenceOrder() async throws {
+        #if DEBUG
+            let runID = UUID()
+            await manager.debugClearRunRoutingHistoryForTesting()
+
+            for event in ["routing_waiter_registered", "policy_installed", "pid_gate_wait_started", "expected_pid_registered", "policy_applied"] {
+                await manager.debugRecordRunRoutingEvent(runID: runID, event: event)
+            }
+
+            let payload = await manager.debugRunRoutingHistoryPayload(runID: runID, limit: 3)
+            let events = try XCTUnwrap(payload["events"] as? [[String: Any]])
+            XCTAssertEqual(
+                events.map { $0["event"] as? String },
+                ["pid_gate_wait_started", "expected_pid_registered", "policy_applied"]
+            )
+            let sequences = events.compactMap { $0["seq"] as? Int }
+            XCTAssertEqual(sequences, sequences.sorted())
+        #else
+            throw XCTSkip("Run routing history is DEBUG-only.")
+        #endif
+    }
+
+    #if DEBUG
+        private func diagnosticsPayload(_ result: CallTool.Result) throws -> [String: Any] {
+            let text = result.content.compactMap { content -> String? in
+                if case let .text(text, _, _) = content { return text }
+                return nil
+            }.joined()
+            let data = try XCTUnwrap(text.data(using: .utf8))
+            return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        }
+    #endif
+}

--- a/Tests/RepoPromptTests/MCP/Control/ServerControllerAdmissionTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/ServerControllerAdmissionTests.swift
@@ -26,6 +26,17 @@ final class ServerControllerAdmissionTests: XCTestCase {
         #endif
     }
 
+    func testDefaultAllowListIncludesSynchronousACPClients() throws {
+        #if DEBUG
+            let allowed = ServerController.test_defaultAlwaysAllowedClients
+
+            XCTAssertTrue(allowed.contains(AgentProviderKind.openCodeMCPClientID))
+            XCTAssertTrue(allowed.contains(AgentProviderKind.cursorMCPClientID))
+        #else
+            throw XCTSkip("DEBUG-only ServerController admission seams are unavailable in release builds")
+        #endif
+    }
+
     func testSanitizerRemovesPersistedRepoPromptCLIAllowListEntries() {
         #if DEBUG
             let sanitized = ServerController.test_sanitizedAlwaysAllowedClients([

--- a/docs/architecture/provider-plugins.md
+++ b/docs/architecture/provider-plugins.md
@@ -214,6 +214,13 @@ The associated event/session/turn types are currently `typealias`es over the Cla
 
 `ClaudeSessionControlling` is retained as a backwards-compatible alias for existing Claude call sites.
 
+## ACP provider MCP tool-call timeouts
+
+RepoPrompt CE cannot impose one MCP tool-call timeout across external ACP providers; configure the provider where supported.
+
+- **OpenCode:** Timeout values are milliseconds. For a 10,000-second call, set `"timeout": 10000000` on the existing RepoPrompt MCP server entry, preserving its `type`, `command`, and `environment` fields.
+- **Cursor Agent:** Current builds expose no supported ACP, CLI, environment, or configuration override that RepoPrompt CE can set to 10,000 seconds. Do not add a speculative CE timeout control; add one only if Cursor documents a supported configuration surface.
+
 ## How a new provider plugs in
 
 The recommended pattern when adding (for example) a hypothetical `acmeAgent` family:


### PR DESCRIPTION
## Summary
- migrate ACP session mode selection to authoritative `configOptions` / `session/set_config_option` only
- fix OpenCode helper admission and run-policy routing during synchronous `session/new`
- resolve OpenCode/Cursor CLIs through environment-aware canonical path tooling
- make Cursor launch CLI-only and fail closed: no `cursor` GUI-capable fallback and no `.app` descendants
- add bounded, redacted launch/routing diagnostics and deterministic provider startup tests
- add Cursor MCP approval leasing, including physical workspace-root canonicalization for macOS `/tmp` aliases

## Compatibility
- legacy `modes`, `modeId`, and `session/set_mode` are intentionally unsupported
- missing or malformed modern mode selectors fail closed for explicit mode requests
- executable paths are discovered from the effective environment; no user-specific installation path is hardcoded

## Live status
- **OpenCode: validated.** A disposable-workspace run completed prompt submission, `read_file`, `oracle_chat_log`, interactive `ask_user`, and resumed successfully.
- **Cursor: candidate fix pushed; live revalidation pending.** The prior disposable-workspace failure was traced to Cursor hashing/storing the physical `/private/tmp` root while RepoPrompt used the `/tmp` alias. The branch now canonicalizes the approval root with POSIX `realpath(3)` and has focused/full regression coverage. A final live MCP-tools run is still required.

Refs #117.

## Validation
- [x] independent cleanup-agent passes
- [x] focused ACP mode, provider launch, lifecycle, routing, admission, and diagnostics suites
- [x] full coordinated `make dev-test`
- [x] coordinated `make dev-lint`
- [x] coordinated RepoPrompt product/package builds
- [x] repository guardrails and `git diff --check`
- [x] staged-index and outgoing-range secret scans
- [x] OpenCode live validation in a disposable workspace
- [x] Cursor `/tmp` → `/private/tmp` approval directory/hash regression coverage
- [ ] Cursor live MCP routing validation — tracked in #117

## Notes
- The PR is intentionally open for review with the Cursor limitation documented; it does not claim to close #117.
- Production/non-debug RepoPrompt was not restarted or used for validation.
