### PR TITLE
Enforce custom hover tooltips

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -51,6 +51,9 @@ only_rules:
   # Imports and diagnostics hygiene.
   - unused_import
 
+  # UI quality gates.
+  - no_swiftui_help_modifier
+
 # Deferred for later cleanup plans: line/file/type/function length, complexity,
 # force unwrap/try/cast, implicitly unwrapped optionals, unowned captures,
 # strict naming rules, broad optional-binding/empty-count idiom cleanup,
@@ -58,5 +61,16 @@ only_rules:
 # fatalError message cleanup, prompt-string leading/trailing whitespace, and
 # SwiftLint brace/statement-position rules that currently conflict with
 # SwiftFormat wrapping.
+
+custom_rules:
+  no_swiftui_help_modifier:
+    name: "SwiftUI .help Modifier"
+    included:
+      - 'Sources/RepoPrompt/.*\.swift$'
+    regex: '\.help\s*\('
+    match_kinds:
+      - identifier
+    message: "Use .hoverTooltip(...) instead of .help(...)."
+    severity: error
 
 reporter: "xcode"

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -52,7 +52,7 @@ only_rules:
   - unused_import
 
   # UI quality gates.
-  - no_swiftui_help_modifier
+  - custom_rules
 
 # Deferred for later cleanup plans: line/file/type/function length, complexity,
 # force unwrap/try/cast, implicitly unwrapped optionals, unowned captures,

--- a/Sources/RepoPrompt/Features/AgentMode/Views/AgentAttachmentsStrip.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/AgentAttachmentsStrip.swift
@@ -216,6 +216,7 @@ struct AgentAttachmentsStrip: View, Equatable {
                 .lineLimit(1)
                 .truncationMode(.tail)
                 .frame(maxWidth: fontPreset.scaledMetric(170), alignment: .leading)
+                .accessibilityLabel(attachment.relativePath)
 
             if allowsRemoval, let onRemoveTaggedFile {
                 Button {
@@ -234,7 +235,7 @@ struct AgentAttachmentsStrip: View, Equatable {
         .padding(.vertical, 6)
         .background(Color.secondary.opacity(0.08))
         .clipShape(Capsule())
-        .help(attachment.relativePath)
+        .hoverTooltip(attachment.relativePath)
     }
 
     private func title(for attachment: AgentImageAttachment) -> String {

--- a/Sources/RepoPrompt/Features/AgentMode/Views/AgentMessageBubble.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/AgentMessageBubble.swift
@@ -383,8 +383,9 @@ struct AgentMessageBubble: View {
         .padding(.vertical, 3)
         .background(Color.green.opacity(0.15))
         .clipShape(Capsule())
-        .help(tooltip)
+        .hoverTooltip(tooltip)
         .accessibilityLabel(Text(labelText))
+        .accessibilityHint(Text(tooltip))
     }
 
     private func workflowBadge(_ workflow: AgentWorkflowDefinition) -> some View {

--- a/Sources/RepoPrompt/Features/AgentMode/Views/AgentPermissionsPopoverView.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/AgentPermissionsPopoverView.swift
@@ -100,7 +100,7 @@ struct AgentPermissionsPopoverView: View {
                     .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
-                .help("Open Agent Permissions → Sub-Agents")
+                .hoverTooltip("Open Agent Permissions → Sub-Agents")
                 .accessibilityLabel(
                     "\(deepLinkTitle(for: subagentVM.globalPolicy)) in Agent Permissions settings"
                 )

--- a/Sources/RepoPrompt/Features/AgentMode/Views/Components/GitContextBranchSwitchCapsule.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Components/GitContextBranchSwitchCapsule.swift
@@ -222,7 +222,7 @@ struct GitContextBranchSwitchCapsule: View {
                         .font(fontPreset.swiftUIFont(sizeAtNormal: 11))
                         .foregroundStyle(.orange)
                         .lineLimit(2)
-                        .help(actionErrorMessage)
+                        .hoverTooltip(actionErrorMessage)
                         .accessibilityLabel(actionErrorMessage)
                 }
 
@@ -234,7 +234,7 @@ struct GitContextBranchSwitchCapsule: View {
                             .font(fontPreset.swiftUIFont(sizeAtNormal: 11))
                             .foregroundStyle(.secondary)
                             .lineLimit(3)
-                            .help(optionErrorMessage)
+                            .hoverTooltip(optionErrorMessage)
                             .accessibilityLabel(optionErrorMessage)
                         Button("Reload branches") {
                             startUITask { await reloadOptions() }
@@ -363,7 +363,8 @@ struct GitContextBranchSwitchCapsule: View {
             .onHover { hovered in
                 isHovered = hovered
             }
-            .help(helpText)
+            .hoverTooltip(helpText)
+            .accessibilityHint(helpText)
         }
 
         private var iconName: String {

--- a/Sources/RepoPrompt/Features/AgentMode/Views/RecommendationWizardPopoverView.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/RecommendationWizardPopoverView.swift
@@ -540,7 +540,8 @@ private struct IntroStepView: View {
                         .foregroundColor(.secondary)
                 }
                 .buttonStyle(.plain)
-                .help("Dismiss this recommendation")
+                .hoverTooltip("Dismiss this recommendation")
+                .accessibilityLabel("Dismiss this recommendation")
             }
         }
         .opacity(isMuted ? 0.7 : 1)

--- a/Sources/RepoPrompt/Features/AgentMode/Views/RuntimeSidebar/AgentRuntimeExportCard.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/RuntimeSidebar/AgentRuntimeExportCard.swift
@@ -481,7 +481,8 @@ private struct AgentSelectedFilesPopover: View {
             }
             .buttonStyle(CustomButtonStyle(verticalPadding: 3, horizontalPadding: 8))
             .disabled(split.rows.isEmpty || !canMutate || model == nil)
-            .help(canMutate ? (split.rows.isEmpty ? "No Agent context files to clear" : "Clear the displayed Agent selection") : "Selection mutation is unavailable for this Agent context")
+            .hoverTooltip(canMutate ? (split.rows.isEmpty ? "No Agent context files to clear" : "Clear the displayed Agent selection") : "Selection mutation is unavailable for this Agent context")
+            .accessibilityHint(canMutate ? (split.rows.isEmpty ? "No Agent context files to clear" : "Clear the displayed Agent selection") : "Selection mutation is unavailable for this Agent context")
         }
     }
 
@@ -650,7 +651,8 @@ private struct AgentSelectedFileRow: View {
                         .font(.system(size: 12, weight: .medium))
                         .foregroundColor(.secondary)
                         .padding(6)
-                        .help(disabledRemoveExplanation)
+                        .hoverTooltip(disabledRemoveExplanation)
+                        .accessibilityLabel(disabledRemoveExplanation)
                 }
 
                 Button { onRemove(row) } label: {

--- a/Sources/RepoPrompt/Features/AgentMode/Views/Titlebar/AgentModeTitlebarAccessoryViewController.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Titlebar/AgentModeTitlebarAccessoryViewController.swift
@@ -36,7 +36,8 @@ private struct AgentModeTitlebarNewSessionView: View {
                 isHovering = hovering
             }
         }
-        .help("New Session")
+        .hoverTooltip("New Session", .bottom)
+        .accessibilityLabel("New Session")
     }
 }
 

--- a/Sources/RepoPrompt/Features/ContextBuilder/Views/ContextBuilderPromptsOverlay.swift
+++ b/Sources/RepoPrompt/Features/ContextBuilder/Views/ContextBuilderPromptsOverlay.swift
@@ -286,7 +286,8 @@ struct ContextBuilderPromptsOverlay: View {
                     .foregroundColor(.secondary)
             }
             .buttonStyle(.plain)
-            .help("Close")
+            .hoverTooltip("Close")
+            .accessibilityLabel("Close")
         }
     }
 
@@ -415,7 +416,8 @@ struct ContextBuilderPromptRow: View {
                 Image(systemName: "pin.fill")
                     .font(.caption2)
                     .foregroundColor(.orange)
-                    .help("Pinned - auto-selected in new tabs")
+                    .hoverTooltip("Pinned - auto-selected in new tabs")
+                    .accessibilityLabel("Pinned, auto-selected in new tabs")
             }
 
             Text(prompt.title)
@@ -439,7 +441,8 @@ struct ContextBuilderPromptRow: View {
                         .onHover { hovering in
                             hoveringButton = hovering ? "pin" : nil
                         }
-                        .help(prompt.isPinned ? "Unpin from new tabs" : "Pin to auto-select in new tabs")
+                        .hoverTooltip(prompt.isPinned ? "Unpin from new tabs" : "Pin to auto-select in new tabs")
+                        .accessibilityLabel(prompt.isPinned ? "Unpin from new tabs" : "Pin to auto-select in new tabs")
                     }
 
                     if showsCopyAction {
@@ -641,6 +644,8 @@ struct ContextBuilderPromptsButton: View {
             )
         }
         .buttonStyle(.plain)
-        .help(selectedCount > 0 ? "\(selectedCount) prompt\(selectedCount == 1 ? "" : "s") selected" : "Add custom prompts")
+        .hoverTooltip(selectedCount > 0 ? "\(selectedCount) prompt\(selectedCount == 1 ? "" : "s") selected" : "Add custom prompts")
+        .accessibilityLabel("Context Builder prompts")
+        .accessibilityHint(selectedCount > 0 ? "\(selectedCount) prompt\(selectedCount == 1 ? "" : "s") selected" : "Add custom prompts")
     }
 }

--- a/Sources/RepoPrompt/Features/Prompt/Views/Components/SelectedFilesGrid.swift
+++ b/Sources/RepoPrompt/Features/Prompt/Views/Components/SelectedFilesGrid.swift
@@ -158,7 +158,8 @@ struct SelectedFilesGrid: View {
             }
             .buttonStyle(CustomButtonStyle(verticalPadding: 3, horizontalPadding: 8))
             .disabled(entries.isEmpty)
-            .help(entries.isEmpty ? "No files to clear" : "Remove all selected files and codemaps")
+            .hoverTooltip(entries.isEmpty ? "No files to clear" : "Remove all selected files and codemaps")
+            .accessibilityHint(entries.isEmpty ? "No files to clear" : "Remove all selected files and codemaps")
         }
     }
 

--- a/Sources/RepoPrompt/Features/Settings/Views/AgentModeGeneralSettingsView.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/AgentModeGeneralSettingsView.swift
@@ -220,7 +220,7 @@ struct AgentModeGeneralSettingsView: View {
             Capsule()
                 .fill(connected ? Color.green.opacity(0.12) : Color.secondary.opacity(0.08))
         )
-        .help(
+        .hoverTooltip(
             connected
                 ? "\(provider.displayName) is connected. Open CLI Providers to review auth, installs, or models."
                 : "\(provider.displayName) is not connected. Open CLI Providers to configure it."

--- a/Sources/RepoPrompt/Features/Settings/Views/AgentModeWorkflowsSettingsView.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/AgentModeWorkflowsSettingsView.swift
@@ -200,7 +200,8 @@ struct AgentModeWorkflowsSettingsView: View {
                 Image(systemName: "arrow.up")
             }
             .disabled(index == 0)
-            .help("Move earlier")
+            .hoverTooltip("Move earlier")
+            .accessibilityLabel("Move earlier")
 
             Button {
                 workflowStore.moveFeaturedWorkflow(withID: workflow.id, direction: 1)
@@ -208,14 +209,15 @@ struct AgentModeWorkflowsSettingsView: View {
                 Image(systemName: "arrow.down")
             }
             .disabled(index == workflowStore.featuredWorkflows.count - 1)
-            .help("Move later")
+            .hoverTooltip("Move later")
+            .accessibilityLabel("Move later")
 
             Button {
                 workflowStore.removeFeaturedWorkflow(withID: workflow.id)
             } label: {
                 Label("Remove", systemImage: "minus.circle")
             }
-            .help("Remove from featured workflows")
+            .hoverTooltip("Remove from featured workflows")
         }
     }
 
@@ -230,7 +232,7 @@ struct AgentModeWorkflowsSettingsView: View {
             ))
             .toggleStyle(.switch)
             .controlSize(.small)
-            .help(isHidden ? "Show this built-in workflow" : "Hide this built-in workflow")
+            .hoverTooltip(isHidden ? "Show this built-in workflow" : "Hide this built-in workflow")
 
             featureButton(for: definition, isEnabled: !isHidden)
 
@@ -241,7 +243,7 @@ struct AgentModeWorkflowsSettingsView: View {
             } label: {
                 Label("Clone", systemImage: "plus.square.on.square")
             }
-            .help("Clone as a custom markdown workflow")
+            .hoverTooltip("Clone as a custom markdown workflow")
         }
     }
 
@@ -254,14 +256,14 @@ struct AgentModeWorkflowsSettingsView: View {
             } label: {
                 Label("Reveal", systemImage: "doc.text.magnifyingglass")
             }
-            .help("Reveal in Finder")
+            .hoverTooltip("Reveal in Finder")
 
             Button(role: .destructive) {
                 workflowPendingDeletion = workflow
             } label: {
                 Label("Delete", systemImage: "trash")
             }
-            .help("Delete custom workflow")
+            .hoverTooltip("Delete custom workflow")
         }
     }
 
@@ -314,7 +316,8 @@ struct AgentModeWorkflowsSettingsView: View {
             Label("Add Featured Workflow", systemImage: "plus")
         }
         .disabled(workflowStore.featuredWorkflowIDs.count >= AgentWorkflowStore.maxFeaturedWorkflowCount || addableFeaturedWorkflows.isEmpty)
-        .help(addFeaturedHelpText)
+        .hoverTooltip(addFeaturedHelpText)
+        .accessibilityHint(addFeaturedHelpText)
     }
 
     private var customToolbar: some View {
@@ -353,7 +356,8 @@ struct AgentModeWorkflowsSettingsView: View {
             Label(isFeatured ? "Featured" : "Feature", systemImage: isFeatured ? "star.fill" : "star")
         }
         .disabled(!isActionEnabled)
-        .help(featureHelpText(isFeatured: isFeatured, canFeature: canFeature, isEnabled: isEnabled))
+        .hoverTooltip(featureHelpText(isFeatured: isFeatured, canFeature: canFeature, isEnabled: isEnabled))
+        .accessibilityHint(featureHelpText(isFeatured: isFeatured, canFeature: canFeature, isEnabled: isEnabled))
     }
 
     // MARK: - Helpers

--- a/Sources/RepoPrompt/Features/Settings/Views/CLIProvidersSettingsView.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/CLIProvidersSettingsView.swift
@@ -999,7 +999,8 @@ struct CLIProvidersSettingsView: View {
                         .foregroundColor(.secondary)
                 }
                 .buttonStyle(PlainButtonStyle())
-                .help("Open the Kimi Code console to create or manage a Kimi API key")
+                .hoverTooltip("Open the Kimi Code console to create or manage a Kimi API key")
+                .accessibilityLabel("Open the Kimi Code console to create or manage a Kimi API key")
                 Spacer()
                 if isSavingKimiSecret {
                     ProgressView()
@@ -1077,7 +1078,7 @@ struct CLIProvidersSettingsView: View {
                 .foregroundColor(.accentColor)
             }
             .buttonStyle(PlainButtonStyle())
-            .help("Open \(provider)'s pricing page")
+            .hoverTooltip("Open \(provider)'s pricing page")
             Spacer(minLength: 0)
         }
         .fixedSize(horizontal: false, vertical: true)

--- a/Sources/RepoPrompt/Features/Settings/Views/ChatPresetsSettingsView.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/ChatPresetsSettingsView.swift
@@ -313,7 +313,8 @@ private struct ChatPresetRow: View {
             .labelsHidden()
             .toggleStyle(.switch)
             .controlSize(.small)
-            .help(isShown ? "Shown in quick menu" : "Hidden from quick menu")
+            .hoverTooltip(isShown ? "Shown in quick menu" : "Hidden from quick menu")
+            .accessibilityLabel("Show \(preset.name) in quick menu")
 
             // 2) Title area: icon inline with name, then Built-in/Custom badge, then compact readable chips
             VStack(alignment: .leading, spacing: 2) {

--- a/Sources/RepoPrompt/Features/Settings/Views/CopyPresetsSettingsView.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/CopyPresetsSettingsView.swift
@@ -347,7 +347,8 @@ private struct CopyPresetRow: View {
             .labelsHidden()
             .toggleStyle(.switch)
             .controlSize(.small)
-            .help(isShown ? "Shown in quick menu" : "Hidden from quick menu")
+            .hoverTooltip(isShown ? "Shown in quick menu" : "Hidden from quick menu")
+            .accessibilityLabel("Show \(preset.name) in quick menu")
 
             // 2) Title area: icon inline with name, then Built-in/Custom badge, then compact readable chips
             VStack(alignment: .leading, spacing: 2) {

--- a/Sources/RepoPrompt/Features/Settings/Views/MCPToolsSettingsView.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/MCPToolsSettingsView.swift
@@ -42,7 +42,8 @@ struct MCPToolsSettingsView: View {
     private var controlsSection: some View {
         VStack(alignment: .leading, spacing: 12) {
             Toggle("Enable MCP tools for this window", isOn: $server.windowToolsEnabled)
-                .help("Allow external tools to interact with this window's workspace")
+                .hoverTooltip("Allow external tools to interact with this window's workspace")
+                .accessibilityHint("Allow external tools to interact with this window's workspace")
 
             if !server.windowToolsEnabled {
                 HStack(spacing: 8) {

--- a/Sources/RepoPrompt/Features/Settings/Views/PermissionsSettingsView.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/PermissionsSettingsView.swift
@@ -424,7 +424,8 @@ private struct TrustedClientRow: View {
                         .foregroundColor(.secondary.opacity(isHovering ? 1 : 0.5))
                 }
                 .buttonStyle(PlainButtonStyle())
-                .help("Remove all permissions for this client")
+                .hoverTooltip("Remove all permissions for this client")
+                .accessibilityLabel("Remove all permissions for this client")
             }
             .padding(12)
             .background(Color.primary.opacity(0.03))

--- a/Sources/RepoPrompt/Features/Settings/Views/SettingsView.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/SettingsView.swift
@@ -181,7 +181,7 @@ struct SettingsView: View {
             Spacer(minLength: 0)
         }
         .contentShape(Rectangle())
-        .help(tab.title)
+        .hoverTooltip(tab.title)
         .accessibilityHint(Text(""))
     }
 

--- a/Sources/RepoPrompt/Features/Workspaces/Views/ManageWorkspacesView.swift
+++ b/Sources/RepoPrompt/Features/Workspaces/Views/ManageWorkspacesView.swift
@@ -335,7 +335,8 @@ struct ManageWorkspacesView: View {
                         .font(fontPreset.captionFont)
                         .foregroundColor(.secondary)
                         .textSelection(.enabled)
-                        .help(path)
+                        .hoverTooltip(path)
+                        .accessibilityLabel(path)
                 }
             }
         }

--- a/Sources/RepoPrompt/Infrastructure/UI/Components/MCPServerToggleView.swift
+++ b/Sources/RepoPrompt/Infrastructure/UI/Components/MCPServerToggleView.swift
@@ -106,7 +106,8 @@ struct MCPServerToggleView: View {
         .buttonStyle(CustomButtonStyle())
         .padding(.leading, 8)
         .padding(.trailing, 8)
-        .help(toolbarStateObserver.visualState.helpText)
+        .hoverTooltip(toolbarStateObserver.visualState.helpText, .bottom)
+        .accessibilityHint(toolbarStateObserver.visualState.helpText)
         .popover(isPresented: $showPopover, attachmentAnchor: .rect(.bounds), arrowEdge: .top) {
             popoverContent()
         }
@@ -553,7 +554,8 @@ struct MCPServerPopoverContent: View {
                                 Image(systemName: "info.circle.fill")
                                     .foregroundColor(.orange)
                                     .font(.system(size: 12))
-                                    .help("Setup Wizard hid presets so you can use the model dropdown above directly. Click 'Show presets' to restore them.")
+                                    .hoverTooltip("Setup Wizard hid presets so you can use the model dropdown above directly. Click 'Show presets' to restore them.")
+                                    .accessibilityLabel("Setup Wizard hid presets so you can use the model dropdown above directly. Click Show presets to restore them.")
                                 Text("Presets hidden by Setup Wizard.")
                                     .font(fontPreset.captionFont)
                                     .foregroundColor(.secondary)

--- a/Sources/RepoPrompt/Infrastructure/UI/Components/UpdateAvailableToolbarPill.swift
+++ b/Sources/RepoPrompt/Infrastructure/UI/Components/UpdateAvailableToolbarPill.swift
@@ -91,7 +91,7 @@ struct UpdateAvailableToolbarPill: View {
             .buttonStyle(.plain)
             .padding(.trailing, 8)
             .disabled(!canCheckForUpdates)
-            .help(helpText(displayVersion: displayVersion, canCheckForUpdates: canCheckForUpdates))
+            .hoverTooltip(helpText(displayVersion: displayVersion, canCheckForUpdates: canCheckForUpdates), .bottom)
             .accessibilityLabel(accessibilityLabel(displayVersion: displayVersion))
             .accessibilityHint(accessibilityHint(canCheckForUpdates: canCheckForUpdates))
         }


### PR DESCRIPTION
## Summary
- replace all first-party SwiftUI `.help(...)` modifiers with the shared `.hoverTooltip(...)` API
- preserve accessibility labels and hints for icon-only and disabled controls
- add a strict SwiftLint rule preventing `.help(...)` from returning under `Sources/RepoPrompt`

## Validation
- `make dev-format`
- `make dev-lint`
- `make guardrails`
- `make dev-test`
- `make dev-swift-build PRODUCT=RepoPrompt`
- temporary violating fixture rejected by SwiftLint 0.63.2
- zero first-party `.help(` matches