### PR TITLE
Fix Codex submit during agent wait drain

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -10588,6 +10588,25 @@ final class AgentModeViewModel: ObservableObject {
         )
     }
 
+    private static func shouldWakeParentAgentRunWaitersForActiveSubmit(
+        selectedAgent: AgentProviderKind,
+        codexCompactionInFlight: Bool
+    ) -> Bool {
+        selectedAgent != .codexExec || codexCompactionInFlight
+    }
+
+    #if DEBUG
+        static func test_shouldWakeParentAgentRunWaitersForActiveSubmit(
+            selectedAgent: AgentProviderKind,
+            codexCompactionInFlight: Bool
+        ) -> Bool {
+            shouldWakeParentAgentRunWaitersForActiveSubmit(
+                selectedAgent: selectedAgent,
+                codexCompactionInFlight: codexCompactionInFlight
+            )
+        }
+    #endif
+
     @discardableResult
     private func submitPreparedUserTurn(
         tabID: UUID,
@@ -10691,7 +10710,12 @@ final class AgentModeViewModel: ObservableObject {
            !session.isMCPInstructionDispatchInProgress
         {
             Self.steeringDebugLog("[AgentRunSteeringWake] manual active submit accepted tab=\(tabID) runState=\(session.runState.rawValue) agent=\(session.selectedAgent.displayName) runID=\(String(describing: session.runID)) hasMCPContext=\(session.mcpControlContext != nil)")
-            if let runID = session.runID {
+            if let runID = session.runID,
+               Self.shouldWakeParentAgentRunWaitersForActiveSubmit(
+                   selectedAgent: session.selectedAgent,
+                   codexCompactionInFlight: codexCompactionInFlight
+               )
+            {
                 Task { @MainActor [weak self] in
                     guard let self, let mcpServer else { return }
                     await mcpServer.wakeAgentRunWaitersOwnedByActiveRun(

--- a/Sources/RepoPrompt/Infrastructure/MCP/Agent/AgentRunMCPToolService.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/Agent/AgentRunMCPToolService.swift
@@ -95,6 +95,7 @@ struct AgentRunWaitScopeCompletion: Equatable {
 
 private enum MultiWaitDisposition {
     case actionable(AgentRunMCPSnapshot)
+    case steeringInterrupted(AgentRunMCPSnapshot)
     case superseded(AgentRunMCPSnapshot)
     case terminalPublicationRejected(String)
     case timedOut
@@ -105,6 +106,11 @@ private enum MultiWaitDisposition {
 private struct WaitAnyResult {
     let sessionID: UUID
     let disposition: MultiWaitDisposition
+}
+
+private struct TimestampedWaitAnyResult {
+    let result: WaitAnyResult
+    let completedAt: ContinuousClock.Instant
 }
 
 private struct CancelledSingleWaitResolution {
@@ -193,6 +199,9 @@ struct AgentRunMCPToolService {
     var endAgentRunWait: (_ token: UUID, _ completion: AgentRunWaitScopeCompletion) async -> Void = { _, _ in }
     let startRun: StartRun
     var currentSnapshotProvider: (@Sendable (_ sessionID: UUID, _ agentModeVM: AgentModeViewModel) async -> AgentRunMCPSnapshot?)?
+    #if DEBUG
+        var testAgentModeViewModel: AgentModeViewModel?
+    #endif
     var vcsService: VCSService = .shared
     var gitTargetResolver: GitRepoTargetResolver = .init()
 
@@ -369,7 +378,7 @@ struct AgentRunMCPToolService {
         }
 
         let targetWindow = try requireTargetWindow()
-        let agentModeVM = targetWindow.agentModeViewModel
+        let agentModeVM = resolvedAgentModeViewModel(targetWindow)
         let sessionID = try await resolveControlSessionID(args, targetWindow: targetWindow, agentModeVM: agentModeVM)
         let timeoutSeconds = try forcePoll ? 0 : Self.resolvedWaitTimeoutSeconds(args["timeout"])
         let metadata = await captureRequestMetadata()
@@ -391,7 +400,7 @@ struct AgentRunMCPToolService {
     private func executeWaitAny(args: [String: Value]) async throws -> Value {
         let references = try parseSessionIDArray(args)
         let targetWindow = try requireTargetWindow()
-        let agentModeVM = targetWindow.agentModeViewModel
+        let agentModeVM = resolvedAgentModeViewModel(targetWindow)
         let sessionIDs = try await resolveControlSessionIDs(references, targetWindow: targetWindow, agentModeVM: agentModeVM)
 
         // Single-element waits should preserve the existing single-session response shape.
@@ -446,7 +455,7 @@ struct AgentRunMCPToolService {
             }
             return value
         } catch is CancellationError {
-            if let value = await waitAnyCancellationInterruptValueIfResumable(
+            if let value = await waitAnyCancellationValueIfActionable(
                 sessionIDs: sessionIDs,
                 agentModeVM: agentModeVM,
                 fallbackSnapshots: initialSnapshots
@@ -469,6 +478,15 @@ struct AgentRunMCPToolService {
             }
             throw error
         }
+    }
+
+    private func resolvedAgentModeViewModel(_ targetWindow: WindowState) -> AgentModeViewModel {
+        #if DEBUG
+            if let testAgentModeViewModel {
+                return testAgentModeViewModel
+            }
+        #endif
+        return targetWindow.agentModeViewModel
     }
 
     private func executePollMany(args: [String: Value]) async throws -> Value {
@@ -678,7 +696,7 @@ struct AgentRunMCPToolService {
                             errorDescription: nil
                         ))
                         return triggeringSnapshot.toValue()
-                    case let .noteworthySnapshot(triggeringSnapshot, _):
+                    case let .noteworthySnapshot(triggeringSnapshot, reason):
                         if triggeringSnapshot.isActionableForMCPWait {
                             completionBox.set(AgentRunWaitScopeCompletion(
                                 reason: .snapshotReady,
@@ -688,6 +706,16 @@ struct AgentRunMCPToolService {
                                 errorDescription: nil
                             ))
                             return triggeringSnapshot.toValue()
+                        }
+                        if reason == .steeringRequested {
+                            completionBox.set(AgentRunWaitScopeCompletion(
+                                reason: .cancelled,
+                                result: "interrupted_by_steering",
+                                winnerSessionID: nil,
+                                pendingSessionIDs: [sessionID],
+                                errorDescription: nil
+                            ))
+                            return Self.steeringInterruptedSingleWaitValue(triggeringSnapshot)
                         }
                         continue
                     case let .epochAdvanced(epoch, transitionKind):
@@ -729,7 +757,10 @@ struct AgentRunMCPToolService {
             }
         } catch {
             if error is CancellationError,
-               let resolution = await cancelledSingleWaitResolution(sessionID: sessionID, agentModeVM: agentModeVM)
+               let resolution = await cancelledSingleWaitResolutionIfActionable(
+                   sessionID: sessionID,
+                   agentModeVM: agentModeVM
+               )
             {
                 if let waitScopeToken {
                     await endAgentRunWait(waitScopeToken, resolution.completion)
@@ -796,31 +827,26 @@ struct AgentRunMCPToolService {
         return .object(object)
     }
 
-    private func cancelledSingleWaitResolution(
+    private nonisolated static func steeringInterruptedSingleWaitValue(
+        _ snapshot: AgentRunMCPSnapshot
+    ) -> Value {
+        var object = snapshot.asObject()
+        object["_meta"] = .object([
+            "wake_reason": .string(AgentRunSessionStore.WakeReason.steeringRequested.rawValue)
+        ])
+        return .object(object)
+    }
+
+    private func cancelledSingleWaitResolutionIfActionable(
         sessionID: UUID,
         agentModeVM: AgentModeViewModel
     ) async -> CancelledSingleWaitResolution? {
         let snapshot = await currentSnapshot(sessionID: sessionID, agentModeVM: agentModeVM)
-        guard snapshot.status != .expired else { return nil }
-
-        if snapshot.status == .running, snapshot.interaction == nil {
-            var object = snapshot.asObject()
-            object["_meta"] = .object(["wake_reason": .string(AgentRunSessionStore.WakeReason.steeringRequested.rawValue)])
-            return CancelledSingleWaitResolution(
-                rawValue: .object(object),
-                completion: AgentRunWaitScopeCompletion(
-                    reason: .cancelled,
-                    result: "interrupted_by_steering",
-                    winnerSessionID: nil,
-                    pendingSessionIDs: [sessionID],
-                    errorDescription: nil
-                )
-            )
-        }
-
+        guard snapshot.status != .expired, snapshot.isActionableForMCPWait else { return nil }
+        let value = snapshot.toValue()
         return CancelledSingleWaitResolution(
-            rawValue: snapshot.toValue(),
-            completion: singleWaitScopeCompletion(from: snapshot.toValue(), sessionID: sessionID)
+            rawValue: value,
+            completion: singleWaitScopeCompletion(from: value, sessionID: sessionID)
         )
     }
 
@@ -857,7 +883,7 @@ struct AgentRunMCPToolService {
         return .object(object)
     }
 
-    private func waitAnyCancellationInterruptValueIfResumable(
+    private func waitAnyCancellationValueIfActionable(
         sessionIDs: [UUID],
         agentModeVM: AgentModeViewModel,
         fallbackSnapshots: [AgentRunMCPSnapshot]
@@ -876,14 +902,7 @@ struct AgentRunMCPToolService {
             )
         }
 
-        let runningIDs = snapshots.filter { $0.status == .running }.map(\.sessionID)
-        guard runningIDs.isEmpty == false else { return nil }
-        let pendingIDs = snapshots.filter { !isInterestingSnapshot($0) && $0.status != .expired }.map(\.sessionID)
-        return Self.decoratedMultiWaitInterruptValue(
-            sessionIDs: sessionIDs,
-            snapshots: snapshots,
-            pendingSessionIDs: pendingIDs.isEmpty ? runningIDs : pendingIDs
-        )
+        return nil
     }
 
     private func waitAnySteeringInterruptValue(
@@ -903,20 +922,21 @@ struct AgentRunMCPToolService {
         let runningIDs = snapshots.filter { $0.status == .running }.map(\.sessionID)
         return Self.decoratedMultiWaitInterruptValue(
             sessionIDs: sessionIDs,
+            representativeSnapshot: triggeringSnapshot,
             snapshots: snapshots,
-            pendingSessionIDs: pendingIDs.isEmpty && !runningIDs.isEmpty ? runningIDs : pendingIDs
+            pendingSessionIDs: pendingIDs.isEmpty && !runningIDs.isEmpty ? runningIDs : pendingIDs,
+            interruptedSessionID: triggeringSnapshot.sessionID
         )
     }
 
     private nonisolated static func decoratedMultiWaitInterruptValue(
         sessionIDs: [UUID],
+        representativeSnapshot: AgentRunMCPSnapshot,
         snapshots: [AgentRunMCPSnapshot],
-        pendingSessionIDs: [UUID]
+        pendingSessionIDs: [UUID],
+        interruptedSessionID: UUID
     ) -> Value {
-        let representative = sessionIDs.compactMap { sessionID in
-            snapshots.first { $0.sessionID == sessionID && $0.status == .running }
-        }.first ?? snapshots.first ?? AgentRunMCPSnapshot.expired(sessionID: sessionIDs[0])
-        var object = representative.asObject()
+        var object = representativeSnapshot.asObject()
         object.removeValue(forKey: "assistant_text")
         object["status_text"] = .string("Wait interrupted by a new steering instruction; the agent run is still running.")
         object["_meta"] = .object([
@@ -927,6 +947,7 @@ struct AgentRunMCPToolService {
             "mode": .string("any"),
             "result": .string("interrupted_by_steering"),
             "winner_session_id": .null,
+            "interrupted_session_id": .string(interruptedSessionID.uuidString),
             "session_ids": .array(sessionIDs.map { .string($0.uuidString) }),
             "waited_count": .int(sessionIDs.count),
             "pending_session_ids": .array(pendingSessionIDs.map { .string($0.uuidString) }),
@@ -959,7 +980,7 @@ struct AgentRunMCPToolService {
                 pendingSessionIDs: sessionIDs
             )
         }
-        let result = await waitUntilFirstActionable(
+        let result = await Self.waitUntilFirstActionable(
             cursors: cursors,
             fallbackSessionID: sessionIDs[0],
             timeoutSeconds: timeoutSeconds
@@ -973,6 +994,13 @@ struct AgentRunMCPToolService {
                 result: snapshot.status == .expired ? "expired" : "snapshot_ready",
                 snapshots: snapshots,
                 pendingSessionIDs: pendingSessionIDs(from: snapshots).filter { $0 != snapshot.sessionID }
+            )
+        case let .steeringInterrupted(snapshot):
+            return await waitAnySteeringInterruptValue(
+                sessionIDs: sessionIDs,
+                agentModeVM: agentModeVM,
+                triggeringSnapshot: snapshot,
+                latestSnapshots: snapshots
             )
         case let .superseded(snapshot):
             return decoratedMultiWaitSupersededValue(
@@ -1000,7 +1028,7 @@ struct AgentRunMCPToolService {
                 pendingSessionIDs: pendingSessionIDs(from: snapshots)
             )
         case .cancelled:
-            if let value = await waitAnyCancellationInterruptValueIfResumable(
+            if let value = await waitAnyCancellationValueIfActionable(
                 sessionIDs: sessionIDs,
                 agentModeVM: agentModeVM,
                 fallbackSnapshots: snapshots
@@ -1011,31 +1039,51 @@ struct AgentRunMCPToolService {
         }
     }
 
-    private nonisolated func waitUntilFirstActionable(
+    private nonisolated static func waitUntilFirstActionable(
         cursors: [AgentRunSessionStore.WaitCursor],
         fallbackSessionID: UUID,
         timeoutSeconds: TimeInterval
     ) async -> WaitAnyResult {
-        await withTaskGroup(of: WaitAnyResult.self) { group in
-            for cursor in cursors {
+        let operations: [@Sendable () async -> WaitAnyResult] = cursors.map { cursor in
+            { await Self.waitUntilActionable(cursor: cursor, timeoutSeconds: timeoutSeconds) }
+        }
+        return await resolveFirstWaitAny(
+            operations: operations,
+            sessionOrder: cursors.map(\.registration.sessionID),
+            fallbackSessionID: fallbackSessionID
+        )
+    }
+
+    private nonisolated static func resolveFirstWaitAny(
+        operations: [@Sendable () async -> WaitAnyResult],
+        sessionOrder: [UUID],
+        fallbackSessionID: UUID,
+        afterCancelAll: (@Sendable () async -> Void)? = nil
+    ) async -> WaitAnyResult {
+        let clock = ContinuousClock()
+        return await withTaskGroup(of: TimestampedWaitAnyResult.self) { group in
+            for operation in operations {
                 group.addTask {
-                    await Self.waitUntilActionable(cursor: cursor, timeoutSeconds: timeoutSeconds)
+                    let result = await operation()
+                    return TimestampedWaitAnyResult(result: result, completedAt: clock.now)
                 }
             }
-            guard let result = await group.next() else {
+            guard let first = await group.next() else {
                 return WaitAnyResult(sessionID: fallbackSessionID, disposition: .expired)
             }
-            if isTimedOutDisposition(result.disposition) {
-                while let nextResult = await group.next() {
-                    guard isTimedOutDisposition(nextResult.disposition) else {
-                        group.cancelAll()
-                        return nextResult
-                    }
-                }
-                return result
-            }
+            let cutoff = clock.now
+            var resolvedResults = [first.result]
             group.cancelAll()
-            return result
+            await afterCancelAll?()
+            while let candidate = await group.next() {
+                guard candidate.completedAt <= cutoff else { continue }
+                resolvedResults.append(candidate.result)
+            }
+            return Self.arbitrateWaitAnyResults(
+                resolvedResults,
+                sessionOrder: sessionOrder,
+                fallbackSessionID: fallbackSessionID
+            )
         }
     }
 
@@ -1064,9 +1112,12 @@ struct AgentRunMCPToolService {
                 if snapshot.isActionableForMCPWait {
                     return WaitAnyResult(sessionID: sessionID, disposition: .actionable(snapshot))
                 }
-            case let .noteworthySnapshot(snapshot, _):
+            case let .noteworthySnapshot(snapshot, reason):
                 if snapshot.isActionableForMCPWait {
                     return WaitAnyResult(sessionID: sessionID, disposition: .actionable(snapshot))
+                }
+                if reason == .steeringRequested {
+                    return WaitAnyResult(sessionID: sessionID, disposition: .steeringInterrupted(snapshot))
                 }
             case let .epochAdvanced(epoch, transitionKind):
                 if transitionKind == .unrelated {
@@ -1088,17 +1139,100 @@ struct AgentRunMCPToolService {
         }
     }
 
+    private nonisolated static func arbitrateWaitAnyResults(
+        _ results: [WaitAnyResult],
+        sessionOrder: [UUID],
+        fallbackSessionID: UUID
+    ) -> WaitAnyResult {
+        guard !results.isEmpty else {
+            return WaitAnyResult(sessionID: fallbackSessionID, disposition: .expired)
+        }
+        let order = Dictionary(uniqueKeysWithValues: sessionOrder.enumerated().map { ($1, $0) })
+        return results.min { lhs, rhs in
+            let lhsPriority = arbitrationPriority(lhs.disposition)
+            let rhsPriority = arbitrationPriority(rhs.disposition)
+            if lhsPriority != rhsPriority {
+                return lhsPriority < rhsPriority
+            }
+            return order[lhs.sessionID, default: Int.max] < order[rhs.sessionID, default: Int.max]
+        } ?? results[0]
+    }
+
+    private nonisolated static func arbitrationPriority(_ disposition: MultiWaitDisposition) -> Int {
+        switch disposition {
+        case .terminalPublicationRejected:
+            0
+        case .steeringInterrupted:
+            1
+        case .actionable:
+            2
+        case .superseded:
+            3
+        case .expired:
+            4
+        case .timedOut:
+            5
+        case .cancelled:
+            6
+        }
+    }
+
     #if DEBUG
         static func test_decoratedMultiWaitInterruptValue(
             sessionIDs: [UUID],
+            representativeSnapshot: AgentRunMCPSnapshot? = nil,
             snapshots: [AgentRunMCPSnapshot],
-            pendingSessionIDs: [UUID]
+            pendingSessionIDs: [UUID],
+            interruptedSessionID: UUID
         ) -> Value {
             decoratedMultiWaitInterruptValue(
                 sessionIDs: sessionIDs,
+                representativeSnapshot: representativeSnapshot
+                    ?? snapshots.first { $0.sessionID == interruptedSessionID }
+                    ?? AgentRunMCPSnapshot.expired(sessionID: interruptedSessionID),
                 snapshots: snapshots,
-                pendingSessionIDs: pendingSessionIDs
+                pendingSessionIDs: pendingSessionIDs,
+                interruptedSessionID: interruptedSessionID
             )
+        }
+
+        static func test_waitAnyCutoffExcludesPostCancellationSteering(
+            actionableSessionID: UUID,
+            steeringSessionID: UUID
+        ) async -> (sessionID: UUID, disposition: String) {
+            let (stream, continuation) = AsyncStream<Void>.makeStream()
+            let operations: [@Sendable () async -> WaitAnyResult] = [
+                {
+                    WaitAnyResult(
+                        sessionID: actionableSessionID,
+                        disposition: .actionable(.expired(sessionID: actionableSessionID))
+                    )
+                },
+                {
+                    for await _ in stream {
+                        break
+                    }
+                    return WaitAnyResult(
+                        sessionID: steeringSessionID,
+                        disposition: .steeringInterrupted(.expired(sessionID: steeringSessionID))
+                    )
+                }
+            ]
+            let result = await resolveFirstWaitAny(
+                operations: operations,
+                sessionOrder: [actionableSessionID, steeringSessionID],
+                fallbackSessionID: actionableSessionID,
+                afterCancelAll: {
+                    continuation.yield()
+                    continuation.finish()
+                }
+            )
+            let disposition = switch result.disposition {
+            case .actionable: "actionable"
+            case .steeringInterrupted: "steering_interrupted"
+            default: "other"
+            }
+            return (result.sessionID, disposition)
         }
 
         static func test_expiredWaitValue(sessionID: UUID) -> Value {
@@ -1118,6 +1252,13 @@ struct AgentRunMCPToolService {
             switch result.disposition {
             case let .actionable(snapshot):
                 return ("actionable", nil, result.sessionID, snapshot.status.rawValue)
+            case let .steeringInterrupted(snapshot):
+                return (
+                    "steering_interrupted",
+                    AgentRunSessionStore.WakeReason.steeringRequested.rawValue,
+                    result.sessionID,
+                    snapshot.status.rawValue
+                )
             case let .superseded(snapshot):
                 return ("superseded", "superseded_turn", result.sessionID, snapshot.status.rawValue)
             case .terminalPublicationRejected:
@@ -1130,16 +1271,84 @@ struct AgentRunMCPToolService {
                 return ("cancelled", nil, result.sessionID, nil)
             }
         }
+
+        static func test_waitUntilFirstActionableDisposition(
+            sessionIDs: [UUID],
+            timeoutSeconds: TimeInterval
+        ) async -> (sessionID: UUID, disposition: String) {
+            var cursors: [AgentRunSessionStore.WaitCursor] = []
+            for sessionID in sessionIDs {
+                guard let registration = await AgentRunSessionStore.currentRegistration(for: sessionID),
+                      let cursor = await AgentRunSessionStore.currentCursor(for: registration)
+                else { continue }
+                cursors.append(cursor)
+            }
+            let result = await waitUntilFirstActionable(
+                cursors: cursors,
+                fallbackSessionID: sessionIDs[0],
+                timeoutSeconds: timeoutSeconds
+            )
+            let disposition = switch result.disposition {
+            case .terminalPublicationRejected: "publication_rejected"
+            case .steeringInterrupted: "steering_interrupted"
+            case .actionable: "actionable"
+            case .superseded: "superseded"
+            case .expired: "expired"
+            case .timedOut: "timed_out"
+            case .cancelled: "cancelled"
+            }
+            return (result.sessionID, disposition)
+        }
+
+        static func test_arbitrateWaitAnyDisposition(
+            sessionIDs: [UUID],
+            candidates: [(sessionID: UUID, disposition: String)]
+        ) -> (sessionID: UUID, disposition: String) {
+            let results = candidates.compactMap { candidate -> WaitAnyResult? in
+                let snapshot = AgentRunMCPSnapshot.expired(sessionID: candidate.sessionID)
+                let disposition: MultiWaitDisposition
+                switch candidate.disposition {
+                case "publication_rejected":
+                    disposition = .terminalPublicationRejected("test")
+                case "steering_interrupted":
+                    disposition = .steeringInterrupted(snapshot)
+                case "actionable":
+                    disposition = .actionable(snapshot)
+                case "superseded":
+                    disposition = .superseded(snapshot)
+                case "expired":
+                    disposition = .expired
+                case "timed_out":
+                    disposition = .timedOut
+                case "cancelled":
+                    disposition = .cancelled
+                default:
+                    return nil
+                }
+                return WaitAnyResult(sessionID: candidate.sessionID, disposition: disposition)
+            }
+            let fallbackSessionID = sessionIDs.first ?? candidates.first?.sessionID ?? UUID()
+            let result = arbitrateWaitAnyResults(
+                results,
+                sessionOrder: sessionIDs,
+                fallbackSessionID: fallbackSessionID
+            )
+            let disposition = switch result.disposition {
+            case .terminalPublicationRejected: "publication_rejected"
+            case .steeringInterrupted: "steering_interrupted"
+            case .actionable: "actionable"
+            case .superseded: "superseded"
+            case .expired: "expired"
+            case .timedOut: "timed_out"
+            case .cancelled: "cancelled"
+            }
+            return (result.sessionID, disposition)
+        }
     #endif
 
     private nonisolated static func timeInterval(from duration: Duration) -> TimeInterval {
         let components = duration.components
         return TimeInterval(components.seconds) + TimeInterval(components.attoseconds) / 1_000_000_000_000_000_000
-    }
-
-    private nonisolated func isTimedOutDisposition(_ disposition: MultiWaitDisposition) -> Bool {
-        if case .timedOut = disposition { return true }
-        return false
     }
 
     private nonisolated func waitScopeCompletion(from value: Value, fallbackSessionIDs: [UUID]) -> AgentRunWaitScopeCompletion {

--- a/Sources/RepoPrompt/Infrastructure/MCP/Agent/AgentRunSessionStore.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/Agent/AgentRunSessionStore.swift
@@ -280,8 +280,6 @@ actor AgentRunSessionStore {
         let waiters = takeWaiters(from: &record) { $0.cursor == cursor }
         if acceptedSnapshot.isActionableForMCPWait {
             clearPendingWake(in: &record, cursor: cursor)
-        } else if waiters.isEmpty {
-            setPendingWake(snapshot: acceptedSnapshot, reason: reason, in: &record, cursor: cursor)
         }
         records[snapshot.sessionID] = record
         guard !waiters.isEmpty else { return }

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel.swift
@@ -1546,6 +1546,33 @@ final class MCPServerViewModel: ObservableObject {
         }
 
         @MainActor
+        func test_beginAgentRunWaitScope(
+            metadata: RequestMetadata,
+            sessionIDs: Set<UUID>,
+            timeoutSeconds: TimeInterval?
+        ) async -> UUID? {
+            await beginAgentRunWaitScope(
+                metadata: metadata,
+                sessionIDs: sessionIDs,
+                timeoutSeconds: timeoutSeconds
+            )
+        }
+
+        @MainActor
+        func test_endAgentRunWaitScope(
+            _ token: UUID,
+            completion: AgentRunWaitScopeCompletion
+        ) {
+            endAgentRunWaitScope(token, completion: completion)
+        }
+
+        @MainActor
+        func test_agentRunWaitScopeCount(parentRunID: UUID) -> Int {
+            purgeStaleAgentRunWaitScopes(source: "test-count")
+            return agentRunWaitScopesByToken.values.count { $0.parentRunID == parentRunID }
+        }
+
+        @MainActor
         @discardableResult
         func test_setActiveToolSlot(
             toolName: String,

--- a/Tests/RepoPromptTests/AgentMode/AgentModeSubmitWaitWakeTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeSubmitWaitWakeTests.swift
@@ -1,0 +1,26 @@
+@testable import RepoPrompt
+import XCTest
+
+@MainActor
+final class AgentModeSubmitWaitWakeTests: XCTestCase {
+    func testNormalActiveCodexSubmitSkipsParentFireAndForgetWake() {
+        XCTAssertFalse(AgentModeViewModel.test_shouldWakeParentAgentRunWaitersForActiveSubmit(
+            selectedAgent: .codexExec,
+            codexCompactionInFlight: false
+        ))
+    }
+
+    func testCodexCompactionSubmitPreservesParentFireAndForgetWake() {
+        XCTAssertTrue(AgentModeViewModel.test_shouldWakeParentAgentRunWaitersForActiveSubmit(
+            selectedAgent: .codexExec,
+            codexCompactionInFlight: true
+        ))
+    }
+
+    func testNonCodexActiveSubmitPreservesParentFireAndForgetWake() {
+        XCTAssertTrue(AgentModeViewModel.test_shouldWakeParentAgentRunWaitersForActiveSubmit(
+            selectedAgent: .claudeCode,
+            codexCompactionInFlight: false
+        ))
+    }
+}

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexAgentModeCoordinatorLivenessTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexAgentModeCoordinatorLivenessTests.swift
@@ -364,36 +364,59 @@ final class CodexAgentModeCoordinatorLivenessTests: XCTestCase {
         XCTAssertNil(session.lastTerminalCommitRevision)
     }
 
-    func testActiveCodexNativeSendWaitsForAgentRunDrainBeforeSending() async throws {
-        let controller = LivenessFakeCodexController(snapshot: .active(activeFlags: []))
-        var drainStarted = false
-        var drainContinuation: CheckedContinuation<Bool, Never>?
-        let viewModel = makeViewModel(controller: controller) { _, source in
-            XCTAssertEqual(source, "codex-native-active-send")
-            drainStarted = true
-            return await withCheckedContinuation { continuation in
-                drainContinuation = continuation
-            }
-        }
-        let session = preparedCodexSession(in: viewModel, controller: controller)
-        let runID = try XCTUnwrap(session.runID)
+    func testActiveCodexNativeSendUsesRealAgentRunDrainBeforeSending() async throws {
+        try await AgentRunWaitDrainTestHarness.withHarness { harness in
+            let waitTask = harness.startWait()
+            try await harness.waitUntilBlocked()
 
-        let sendTask = Task {
-            await viewModel.test_codexCoordinator.sendCodexNativeMessage(
+            let ordering = CodexDrainSendOrderingRecorder()
+            let controller = LivenessFakeCodexController(
+                snapshot: .active(activeFlags: []),
+                onSendUserTurn: { ordering.recordSend() }
+            )
+            let viewModel = makeViewModel(controller: controller) { runID, source in
+                XCTAssertEqual(runID, harness.parentRunID)
+                XCTAssertEqual(source, "codex-native-active-send")
+                let drained = await harness.drain(source: source)
+                ordering.recordDrainCompletion(
+                    succeeded: drained,
+                    activeScopeCount: harness.activeScopeCount()
+                )
+                return drained
+            }
+            let session = preparedCodexSession(
+                in: viewModel,
+                controller: controller,
+                runID: harness.parentRunID
+            )
+
+            let outcome = await viewModel.test_codexCoordinator.sendCodexNativeMessage(
                 session: session,
                 text: "hello",
                 attachments: []
             )
+            let interruptedValue = try await waitTask.value
+            let interruptedObject = try XCTUnwrap(interruptedValue.objectValue)
+            let completions = await harness.completionRecorder.completions()
+            let registrationRemainsActive = await AgentRunSessionStore.hasActiveRegistration(
+                sessionID: harness.fixture.sessionID
+            )
+            let orderingSnapshot = ordering.snapshot()
+
+            XCTAssertEqual(outcome, .sent)
+            XCTAssertEqual(
+                interruptedObject["wait"]?.objectValue?["result"]?.stringValue,
+                "interrupted_by_steering"
+            )
+            XCTAssertEqual(controller.sendUserTurnCountSync(), 1)
+            XCTAssertTrue(orderingSnapshot.drainSucceeded)
+            XCTAssertEqual(orderingSnapshot.activeScopeCountAtDrainCompletion, 0)
+            XCTAssertTrue(orderingSnapshot.sendObservedAfterDrain)
+            XCTAssertEqual(harness.activeScopeCount(), 0)
+            XCTAssertEqual(completions.count, 1)
+            XCTAssertEqual(completions.first?.result, "interrupted_by_steering")
+            XCTAssertTrue(registrationRemainsActive)
         }
-
-        try await waitUntil { drainStarted }
-        XCTAssertEqual(controller.sendUserTurnCountSync(), 0)
-        XCTAssertEqual(session.runID, runID)
-
-        drainContinuation?.resume(returning: true)
-        let outcome = await sendTask.value
-        XCTAssertEqual(outcome, .sent)
-        XCTAssertEqual(controller.sendUserTurnCountSync(), 1)
     }
 
     func testActiveCodexNativeSendFailsWithoutSendingWhenAgentRunDrainFails() async {
@@ -432,11 +455,12 @@ final class CodexAgentModeCoordinatorLivenessTests: XCTestCase {
 
     private func preparedCodexSession(
         in viewModel: AgentModeViewModel,
-        controller: LivenessFakeCodexController
+        controller: LivenessFakeCodexController,
+        runID: UUID = UUID()
     ) -> AgentModeViewModel.TabSession {
         let session = viewModel.session(for: UUID())
         session.selectedAgent = .codexExec
-        session.runID = UUID()
+        session.runID = runID
         session.runState = .running
         session.beginRunAttempt(source: "test.codexLiveness")
         session.codexController = controller
@@ -483,18 +507,58 @@ final class CodexAgentModeCoordinatorLivenessTests: XCTestCase {
     }
 }
 
+private final class CodexDrainSendOrderingRecorder: @unchecked Sendable {
+    struct Snapshot {
+        let drainSucceeded: Bool
+        let activeScopeCountAtDrainCompletion: Int?
+        let sendObservedAfterDrain: Bool
+    }
+
+    private let lock = NSLock()
+    private var drainSucceeded = false
+    private var activeScopeCountAtDrainCompletion: Int?
+    private var sendObservedAfterDrain = false
+
+    func recordDrainCompletion(succeeded: Bool, activeScopeCount: Int) {
+        lock.lock()
+        drainSucceeded = succeeded
+        activeScopeCountAtDrainCompletion = activeScopeCount
+        lock.unlock()
+    }
+
+    func recordSend() {
+        lock.lock()
+        sendObservedAfterDrain = drainSucceeded && activeScopeCountAtDrainCompletion == 0
+        lock.unlock()
+    }
+
+    func snapshot() -> Snapshot {
+        lock.lock()
+        let snapshot = Snapshot(
+            drainSucceeded: drainSucceeded,
+            activeScopeCountAtDrainCompletion: activeScopeCountAtDrainCompletion,
+            sendObservedAfterDrain: sendObservedAfterDrain
+        )
+        lock.unlock()
+        return snapshot
+    }
+}
+
 private final class LivenessFakeCodexController: CodexSessionControlling {
     private var readSnapshotCount = 0
     private var sendUserTurnCount = 0
     private let snapshotStatus: CodexNativeSessionController.ThreadSnapshot.RuntimeStatus
     private let snapshotActiveTurnIDs: [String]
+    private let onSendUserTurn: (() -> Void)?
 
     init(
         snapshot: CodexNativeSessionController.ThreadSnapshot.RuntimeStatus,
-        activeTurnIDs: [String] = ["turn"]
+        activeTurnIDs: [String] = ["turn"],
+        onSendUserTurn: (() -> Void)? = nil
     ) {
         snapshotStatus = snapshot
         snapshotActiveTurnIDs = activeTurnIDs
+        self.onSendUserTurn = onSendUserTurn
     }
 
     var hasActiveThread: Bool {
@@ -547,14 +611,19 @@ private final class LivenessFakeCodexController: CodexSessionControlling {
     func setThreadName(_ name: String, threadID: String?) async throws {}
     func sendUserMessage(_ text: String) async throws {}
     func sendUserTurn(text: String, images: [AgentImageAttachment]) async throws {
-        sendUserTurnCount += 1
+        recordSendUserTurn()
     }
 
     func sendUserTurn(text: String, images: [AgentImageAttachment], model: String?, reasoningEffort: String?) async throws {
-        sendUserTurnCount += 1
+        recordSendUserTurn()
     }
 
     func sendUserTurn(text: String, images: [AgentImageAttachment], model: String?, reasoningEffort: String?, serviceTier: String?) async throws {
+        recordSendUserTurn()
+    }
+
+    private func recordSendUserTurn() {
+        onSendUserTurn?()
         sendUserTurnCount += 1
     }
 

--- a/Tests/RepoPromptTests/MCP/AgentRunMCPToolServiceWaitAnyTests.swift
+++ b/Tests/RepoPromptTests/MCP/AgentRunMCPToolServiceWaitAnyTests.swift
@@ -8,7 +8,7 @@ final class AgentRunMCPToolServiceWaitAnyTests: XCTestCase {
         case missingEpoch
     }
 
-    func testWaitAnyConsumesSteeringWakeAndContinuesToTerminalSnapshot() async throws {
+    func testWaitAnySteeringWakeInterruptsAndFreshWaitCanResume() async throws {
         let sessionID = UUID()
         let activationID = UUID()
         let registration = await AgentRunSessionStore.register(sessionID: sessionID)
@@ -20,7 +20,7 @@ final class AgentRunMCPToolServiceWaitAnyTests: XCTestCase {
         )
         let cursor = AgentRunSessionStore.WaitCursor(registration: registration, epoch: epoch)
 
-        let waitTask = Task {
+        let firstWait = Task {
             await AgentRunMCPToolService.test_waitUntilActionableDisposition(
                 sessionID: sessionID,
                 timeoutSeconds: 1
@@ -33,6 +33,58 @@ final class AgentRunMCPToolServiceWaitAnyTests: XCTestCase {
             cursor: cursor,
             reason: .steeringRequested
         )
+
+        let interrupted = await firstWait.value
+        XCTAssertEqual(interrupted.sessionID, sessionID)
+        XCTAssertEqual(interrupted.disposition, "steering_interrupted")
+        XCTAssertEqual(interrupted.wakeReason, AgentRunSessionStore.WakeReason.steeringRequested.rawValue)
+        XCTAssertEqual(interrupted.snapshotStatus, AgentRunMCPSnapshot.Status.running.rawValue)
+
+        let secondWait = Task {
+            await AgentRunMCPToolService.test_waitUntilActionableDisposition(
+                sessionID: sessionID,
+                timeoutSeconds: 1
+            )
+        }
+        try await waitForWaiter(registration: registration)
+        let terminal = makeSnapshot(sessionID: sessionID, status: .completed)
+        _ = await AgentRunSessionStore.publishTerminal(
+            .init(epoch: epoch, snapshot: terminal),
+            registration: registration,
+            commitID: UUID(),
+            successorKind: nil
+        )
+
+        let resumed = await secondWait.value
+        XCTAssertEqual(resumed.disposition, "actionable")
+        XCTAssertNil(resumed.wakeReason)
+        XCTAssertEqual(resumed.snapshotStatus, AgentRunMCPSnapshot.Status.completed.rawValue)
+        await AgentRunSessionStore.cleanup(registration: registration)
+    }
+
+    func testWaitAnyInstructionDeliveredContinuesToTerminalSnapshot() async throws {
+        let sessionID = UUID()
+        let registration = await AgentRunSessionStore.register(sessionID: sessionID)
+        let epoch = try await beginEpoch(
+            registration: registration,
+            activationID: UUID(),
+            expected: nil,
+            kind: .initial
+        )
+        let cursor = AgentRunSessionStore.WaitCursor(registration: registration, epoch: epoch)
+        let waitTask = Task {
+            await AgentRunMCPToolService.test_waitUntilActionableDisposition(
+                sessionID: sessionID,
+                timeoutSeconds: 1
+            )
+        }
+        try await waitForWaiter(registration: registration)
+
+        await AgentRunSessionStore.wakeCurrentWaiters(
+            makeRunningSnapshot(sessionID: sessionID),
+            cursor: cursor,
+            reason: .instructionDelivered
+        )
         try await waitForWaiter(registration: registration)
         let terminal = makeSnapshot(sessionID: sessionID, status: .completed)
         _ = await AgentRunSessionStore.publishTerminal(
@@ -43,11 +95,51 @@ final class AgentRunMCPToolServiceWaitAnyTests: XCTestCase {
         )
 
         let result = await waitTask.value
-        XCTAssertEqual(result.sessionID, sessionID)
         XCTAssertEqual(result.disposition, "actionable")
         XCTAssertNil(result.wakeReason)
         XCTAssertEqual(result.snapshotStatus, AgentRunMCPSnapshot.Status.completed.rawValue)
         await AgentRunSessionStore.cleanup(registration: registration)
+    }
+
+    func testWaitAnyMultiEngineReturnsSteeringInterruption() async throws {
+        let firstID = UUID()
+        let secondID = UUID()
+        let firstRegistration = await AgentRunSessionStore.register(sessionID: firstID)
+        let secondRegistration = await AgentRunSessionStore.register(sessionID: secondID)
+        let firstEpoch = try await beginEpoch(
+            registration: firstRegistration,
+            activationID: UUID(),
+            expected: nil,
+            kind: .initial
+        )
+        let secondEpoch = try await beginEpoch(
+            registration: secondRegistration,
+            activationID: UUID(),
+            expected: nil,
+            kind: .initial
+        )
+        let waitTask = Task {
+            await AgentRunMCPToolService.test_waitUntilFirstActionableDisposition(
+                sessionIDs: [firstID, secondID],
+                timeoutSeconds: 1
+            )
+        }
+        try await waitForWaiter(registration: firstRegistration)
+        try await waitForWaiter(registration: secondRegistration)
+
+        await AgentRunSessionStore.wakeCurrentWaiters(
+            makeRunningSnapshot(sessionID: secondID),
+            cursor: .init(registration: secondRegistration, epoch: secondEpoch),
+            reason: .steeringRequested
+        )
+
+        let result = await waitTask.value
+        XCTAssertEqual(result.sessionID, secondID)
+        XCTAssertEqual(result.disposition, "steering_interrupted")
+        let retainedFirstEpoch = await AgentRunSessionStore.currentEpoch(for: firstRegistration)
+        XCTAssertEqual(retainedFirstEpoch, firstEpoch)
+        await AgentRunSessionStore.cleanup(registration: firstRegistration)
+        await AgentRunSessionStore.cleanup(registration: secondRegistration)
     }
 
     func testWaitAnyRebindsRelatedEpochAndSurfacesUnrelatedSupersession() async throws {
@@ -68,10 +160,17 @@ final class AgentRunMCPToolServiceWaitAnyTests: XCTestCase {
         }
         try await waitForWaiter(registration: registration)
 
-        let related = try await beginEpoch(
+        let steering = try await beginEpoch(
             registration: registration,
             activationID: activationID,
             expected: first,
+            kind: .steering
+        )
+        try await waitForWaiter(registration: registration)
+        let related = try await beginEpoch(
+            registration: registration,
+            activationID: activationID,
+            expected: steering,
             kind: .relatedFollowUp
         )
         try await waitForWaiter(registration: registration)
@@ -109,7 +208,7 @@ final class AgentRunMCPToolServiceWaitAnyTests: XCTestCase {
             registration: registration,
             activationID: activationID,
             expected: first,
-            kind: .relatedFollowUp
+            kind: .steering
         )
         try await waitForWaiter(registration: registration)
         _ = try await beginEpoch(
@@ -133,6 +232,19 @@ final class AgentRunMCPToolServiceWaitAnyTests: XCTestCase {
         XCTAssertNil(meta["wake_reason"])
     }
 
+    func testWaitAnyCutoffExcludesSteeringProducedAfterSiblingCancellation() async {
+        let actionableSessionID = UUID()
+        let steeringSessionID = UUID()
+
+        let result = await AgentRunMCPToolService.test_waitAnyCutoffExcludesPostCancellationSteering(
+            actionableSessionID: actionableSessionID,
+            steeringSessionID: steeringSessionID
+        )
+
+        XCTAssertEqual(result.sessionID, actionableSessionID)
+        XCTAssertEqual(result.disposition, "actionable")
+    }
+
     func testWaitAnySteeringInterruptValueShapeOmitsNonTerminalAssistantText() throws {
         let firstID = UUID()
         let secondID = UUID()
@@ -142,25 +254,102 @@ final class AgentRunMCPToolServiceWaitAnyTests: XCTestCase {
                 makeRunningSnapshot(sessionID: firstID),
                 makeRunningSnapshot(sessionID: secondID)
             ],
-            pendingSessionIDs: [firstID, secondID]
+            pendingSessionIDs: [firstID, secondID],
+            interruptedSessionID: secondID
         )
 
         let object = try XCTUnwrap(value.objectValue)
         let meta = try XCTUnwrap(object["_meta"]?.objectValue)
         let wait = try XCTUnwrap(object["wait"]?.objectValue)
         XCTAssertEqual(meta["wake_reason"]?.stringValue, AgentRunSessionStore.WakeReason.steeringRequested.rawValue)
+        XCTAssertEqual(object["session_id"]?.stringValue, secondID.uuidString)
         XCTAssertEqual(wait["mode"]?.stringValue, "any")
         XCTAssertEqual(wait["result"]?.stringValue, "interrupted_by_steering")
         XCTAssertNil(wait["winner_session_id"]?.stringValue)
+        XCTAssertEqual(wait["interrupted_session_id"]?.stringValue, secondID.uuidString)
         XCTAssertEqual(
-            Set(wait["pending_session_ids"]?.arrayValue?.compactMap(\.stringValue) ?? []),
-            Set([firstID.uuidString, secondID.uuidString])
+            wait["pending_session_ids"]?.arrayValue?.compactMap(\.stringValue),
+            [firstID.uuidString, secondID.uuidString]
         )
         XCTAssertNil(object["assistant_text"])
         let snapshots = try XCTUnwrap(object["snapshots"]?.arrayValue)
         for snapshot in snapshots {
             XCTAssertNil(snapshot.objectValue?["assistant_text"])
         }
+    }
+
+    func testWaitAnySteeringInterruptKeepsRunningTriggerAsRepresentativeWhenFreshSnapshotIsTerminal() throws {
+        let interruptedID = UUID()
+        let siblingID = UUID()
+        let triggeringSnapshot = makeRunningSnapshot(sessionID: interruptedID)
+        let terminalSnapshot = makeSnapshot(sessionID: interruptedID, status: .completed)
+        let value = AgentRunMCPToolService.test_decoratedMultiWaitInterruptValue(
+            sessionIDs: [interruptedID, siblingID],
+            representativeSnapshot: triggeringSnapshot,
+            snapshots: [terminalSnapshot, makeRunningSnapshot(sessionID: siblingID)],
+            pendingSessionIDs: [siblingID],
+            interruptedSessionID: interruptedID
+        )
+
+        let object = try XCTUnwrap(value.objectValue)
+        XCTAssertEqual(object["session_id"]?.stringValue, interruptedID.uuidString)
+        XCTAssertEqual(object["status"]?.stringValue, AgentRunMCPSnapshot.Status.running.rawValue)
+        XCTAssertEqual(
+            object["status_text"]?.stringValue,
+            "Wait interrupted by a new steering instruction; the agent run is still running."
+        )
+        let snapshots = try XCTUnwrap(object["snapshots"]?.arrayValue)
+        let interruptedAggregate = try XCTUnwrap(snapshots.first { snapshot in
+            snapshot.objectValue?["session_id"]?.stringValue == interruptedID.uuidString
+        }?.objectValue)
+        XCTAssertEqual(interruptedAggregate["status"]?.stringValue, AgentRunMCPSnapshot.Status.completed.rawValue)
+    }
+
+    func testWaitAnyArbitrationLetsSteeringDominateCrossSessionActionableResult() {
+        let firstID = UUID()
+        let secondID = UUID()
+        let result = AgentRunMCPToolService.test_arbitrateWaitAnyDisposition(
+            sessionIDs: [firstID, secondID],
+            candidates: [
+                (firstID, "actionable"),
+                (secondID, "steering_interrupted")
+            ]
+        )
+
+        XCTAssertEqual(result.sessionID, secondID)
+        XCTAssertEqual(result.disposition, "steering_interrupted")
+    }
+
+    func testWaitAnyArbitrationPrioritizesPublicationRejectionAndIgnoresCancellationArtifacts() {
+        let firstID = UUID()
+        let secondID = UUID()
+        let thirdID = UUID()
+        let result = AgentRunMCPToolService.test_arbitrateWaitAnyDisposition(
+            sessionIDs: [firstID, secondID, thirdID],
+            candidates: [
+                (firstID, "cancelled"),
+                (secondID, "steering_interrupted"),
+                (thirdID, "publication_rejected")
+            ]
+        )
+
+        XCTAssertEqual(result.sessionID, thirdID)
+        XCTAssertEqual(result.disposition, "publication_rejected")
+    }
+
+    func testWaitAnyArbitrationBreaksEqualPriorityTiesByInputOrder() {
+        let firstID = UUID()
+        let secondID = UUID()
+        let result = AgentRunMCPToolService.test_arbitrateWaitAnyDisposition(
+            sessionIDs: [firstID, secondID],
+            candidates: [
+                (secondID, "actionable"),
+                (firstID, "actionable")
+            ]
+        )
+
+        XCTAssertEqual(result.sessionID, firstID)
+        XCTAssertEqual(result.disposition, "actionable")
     }
 
     private func beginEpoch(

--- a/Tests/RepoPromptTests/MCP/AgentRunMCPToolServiceWaitTests.swift
+++ b/Tests/RepoPromptTests/MCP/AgentRunMCPToolServiceWaitTests.swift
@@ -1,0 +1,589 @@
+import Foundation
+import MCP
+import XCTest
+@_spi(TestSupport) @testable import RepoPrompt
+
+@MainActor
+final class AgentRunMCPToolServiceWaitTests: XCTestCase {
+    func testSingleWaitSteeringInterruptCompletesOnceAndKeepsRegistrationActive() async throws {
+        let window = makeWindow()
+        defer { WindowStatesManager.shared.unregisterWindowState(window) }
+        let liveSnapshots = LiveSnapshots()
+        let recorder = WaitScopeRecorder()
+        let viewModel = makeViewModel(windowID: window.windowID)
+        let fixture = try await installRunningSession(in: viewModel, liveSnapshots: liveSnapshots)
+        defer { Task { await AgentRunSessionStore.cleanup(registration: fixture.registration) } }
+        let service = makeService(
+            window: window,
+            viewModel: viewModel,
+            liveSnapshots: liveSnapshots,
+            recorder: recorder
+        )
+
+        let firstWait = Task { @MainActor in
+            try await service.execute(args: [
+                "op": .string("wait"),
+                "session_id": .string(fixture.sessionID.uuidString),
+                "timeout": .double(2)
+            ])
+        }
+        try await waitForWaiter(registration: fixture.registration)
+
+        await AgentRunSessionStore.wakeCurrentWaiters(
+            fixture.runningSnapshot,
+            cursor: fixture.cursor,
+            reason: .steeringRequested
+        )
+
+        let interruptedValue = try await firstWait.value
+        let interruptedObject = try XCTUnwrap(interruptedValue.objectValue)
+        let interruptedMeta = try XCTUnwrap(interruptedObject["_meta"]?.objectValue)
+        let interruptedWait = try XCTUnwrap(interruptedObject["wait"]?.objectValue)
+        XCTAssertEqual(
+            interruptedMeta["wake_reason"]?.stringValue,
+            AgentRunSessionStore.WakeReason.steeringRequested.rawValue
+        )
+        XCTAssertEqual(interruptedWait["result"]?.stringValue, "interrupted_by_steering")
+        XCTAssertTrue(interruptedWait["instruction"]?.stringValue?.contains("agent_run.wait") == true)
+        XCTAssertNil(interruptedObject["assistant_text"])
+        let registrationRemainsActive = await AgentRunSessionStore.hasActiveRegistration(
+            sessionID: fixture.sessionID
+        )
+        XCTAssertTrue(registrationRemainsActive)
+
+        let firstCompletions = await recorder.completions()
+        XCTAssertEqual(firstCompletions.count, 1)
+        XCTAssertEqual(firstCompletions[0].reason, .cancelled)
+        XCTAssertEqual(firstCompletions[0].result, "interrupted_by_steering")
+        XCTAssertNil(firstCompletions[0].winnerSessionID)
+        XCTAssertEqual(firstCompletions[0].pendingSessionIDs, [fixture.sessionID])
+
+        let secondWait = Task { @MainActor in
+            try await service.execute(args: [
+                "op": .string("wait"),
+                "session_id": .string(fixture.sessionID.uuidString),
+                "timeout": .double(2)
+            ])
+        }
+        try await waitForWaiter(registration: fixture.registration)
+        let terminal = makeSnapshot(sessionID: fixture.sessionID, status: .completed)
+        await liveSnapshots.set(terminal)
+        _ = await AgentRunSessionStore.publishTerminal(
+            .init(epoch: fixture.epoch, snapshot: terminal),
+            registration: fixture.registration,
+            commitID: UUID(),
+            successorKind: nil
+        )
+
+        let resumedValue = try await secondWait.value
+        XCTAssertEqual(resumedValue.objectValue?["status"]?.stringValue, AgentRunMCPSnapshot.Status.completed.rawValue)
+        XCTAssertNil(resumedValue.objectValue?["_meta"]?.objectValue?["wake_reason"])
+        let allCompletions = await recorder.completions()
+        XCTAssertEqual(allCompletions.count, 2)
+        XCTAssertEqual(allCompletions[1].reason, .snapshotReady)
+        XCTAssertEqual(allCompletions[1].winnerSessionID, fixture.sessionID)
+    }
+
+    func testSingleWaitCancellationDoesNotFabricateSteering() async throws {
+        let window = makeWindow()
+        defer { WindowStatesManager.shared.unregisterWindowState(window) }
+        let liveSnapshots = LiveSnapshots()
+        let recorder = WaitScopeRecorder()
+        let viewModel = makeViewModel(windowID: window.windowID)
+        let fixture = try await installRunningSession(in: viewModel, liveSnapshots: liveSnapshots)
+        defer { Task { await AgentRunSessionStore.cleanup(registration: fixture.registration) } }
+        let service = makeService(
+            window: window,
+            viewModel: viewModel,
+            liveSnapshots: liveSnapshots,
+            recorder: recorder
+        )
+
+        let waitTask = Task { @MainActor in
+            try await service.execute(args: [
+                "op": .string("wait"),
+                "session_id": .string(fixture.sessionID.uuidString),
+                "timeout": .double(2)
+            ])
+        }
+        try await waitForWaiter(registration: fixture.registration)
+        waitTask.cancel()
+
+        do {
+            _ = try await waitTask.value
+            XCTFail("Expected cancellation")
+        } catch is CancellationError {}
+
+        let completions = await recorder.completions()
+        XCTAssertEqual(completions.count, 1)
+        XCTAssertEqual(completions[0].reason, .cancelled)
+        XCTAssertEqual(completions[0].result, "cancelled")
+        XCTAssertNil(completions[0].winnerSessionID)
+        XCTAssertEqual(completions[0].pendingSessionIDs, [fixture.sessionID])
+    }
+
+    func testMultiWaitSteeringInterruptReturnsAllPendingIDsAndCompletesAggregateScopeOnce() async throws {
+        let window = makeWindow()
+        defer { WindowStatesManager.shared.unregisterWindowState(window) }
+        let liveSnapshots = LiveSnapshots()
+        let recorder = WaitScopeRecorder()
+        let viewModel = makeViewModel(windowID: window.windowID)
+        let first = try await installRunningSession(in: viewModel, liveSnapshots: liveSnapshots)
+        let second = try await installRunningSession(in: viewModel, liveSnapshots: liveSnapshots)
+        defer {
+            Task {
+                await AgentRunSessionStore.cleanup(registration: first.registration)
+                await AgentRunSessionStore.cleanup(registration: second.registration)
+            }
+        }
+        let service = makeService(
+            window: window,
+            viewModel: viewModel,
+            liveSnapshots: liveSnapshots,
+            recorder: recorder
+        )
+
+        let waitTask = Task { @MainActor in
+            try await service.execute(args: [
+                "op": .string("wait"),
+                "session_ids": .array([
+                    .string(first.sessionID.uuidString),
+                    .string(second.sessionID.uuidString)
+                ]),
+                "timeout": .double(2)
+            ])
+        }
+        try await waitForWaiter(registration: first.registration)
+        try await waitForWaiter(registration: second.registration)
+
+        await AgentRunSessionStore.wakeCurrentWaiters(
+            second.runningSnapshot,
+            cursor: second.cursor,
+            reason: .steeringRequested
+        )
+
+        let value = try await waitTask.value
+        let object = try XCTUnwrap(value.objectValue)
+        let meta = try XCTUnwrap(object["_meta"]?.objectValue)
+        let wait = try XCTUnwrap(object["wait"]?.objectValue)
+        XCTAssertEqual(
+            meta["wake_reason"]?.stringValue,
+            AgentRunSessionStore.WakeReason.steeringRequested.rawValue
+        )
+        XCTAssertEqual(object["session_id"]?.stringValue, second.sessionID.uuidString)
+        XCTAssertEqual(wait["result"]?.stringValue, "interrupted_by_steering")
+        XCTAssertNil(wait["winner_session_id"]?.stringValue)
+        XCTAssertEqual(wait["interrupted_session_id"]?.stringValue, second.sessionID.uuidString)
+        XCTAssertEqual(
+            wait["pending_session_ids"]?.arrayValue?.compactMap(\.stringValue),
+            [first.sessionID.uuidString, second.sessionID.uuidString]
+        )
+        let firstRegistrationRemainsActive = await AgentRunSessionStore.hasActiveRegistration(
+            sessionID: first.sessionID
+        )
+        let secondRegistrationRemainsActive = await AgentRunSessionStore.hasActiveRegistration(
+            sessionID: second.sessionID
+        )
+        XCTAssertTrue(firstRegistrationRemainsActive)
+        XCTAssertTrue(secondRegistrationRemainsActive)
+
+        let beginRecords = await recorder.beginRecords()
+        let completions = await recorder.completions()
+        XCTAssertEqual(beginRecords.count, 1)
+        XCTAssertEqual(beginRecords[0], Set([first.sessionID, second.sessionID]))
+        XCTAssertEqual(completions.count, 1)
+        XCTAssertEqual(completions[0].reason, .cancelled)
+        XCTAssertEqual(completions[0].result, "interrupted_by_steering")
+        XCTAssertEqual(completions[0].pendingSessionIDs, Set([first.sessionID, second.sessionID]))
+    }
+
+    func testMultiWaitCancellationDoesNotFabricateSteering() async throws {
+        let window = makeWindow()
+        defer { WindowStatesManager.shared.unregisterWindowState(window) }
+        let liveSnapshots = LiveSnapshots()
+        let recorder = WaitScopeRecorder()
+        let viewModel = makeViewModel(windowID: window.windowID)
+        let first = try await installRunningSession(in: viewModel, liveSnapshots: liveSnapshots)
+        let second = try await installRunningSession(in: viewModel, liveSnapshots: liveSnapshots)
+        defer {
+            Task {
+                await AgentRunSessionStore.cleanup(registration: first.registration)
+                await AgentRunSessionStore.cleanup(registration: second.registration)
+            }
+        }
+        let service = makeService(
+            window: window,
+            viewModel: viewModel,
+            liveSnapshots: liveSnapshots,
+            recorder: recorder
+        )
+
+        let waitTask = Task { @MainActor in
+            try await service.execute(args: [
+                "op": .string("wait"),
+                "session_ids": .array([
+                    .string(first.sessionID.uuidString),
+                    .string(second.sessionID.uuidString)
+                ]),
+                "timeout": .double(2)
+            ])
+        }
+        try await waitForWaiter(registration: first.registration)
+        try await waitForWaiter(registration: second.registration)
+        waitTask.cancel()
+
+        do {
+            _ = try await waitTask.value
+            XCTFail("Expected cancellation")
+        } catch is CancellationError {}
+
+        let completions = await recorder.completions()
+        XCTAssertEqual(completions.count, 1)
+        XCTAssertEqual(completions[0].reason, .cancelled)
+        XCTAssertEqual(completions[0].result, "cancelled")
+        XCTAssertNil(completions[0].winnerSessionID)
+        XCTAssertEqual(completions[0].pendingSessionIDs, Set([first.sessionID, second.sessionID]))
+    }
+
+    func testMultiWaitInstructionDeliveredContinuesUntilActionableAndCompletesOnce() async throws {
+        let window = makeWindow()
+        defer { WindowStatesManager.shared.unregisterWindowState(window) }
+        let liveSnapshots = LiveSnapshots()
+        let recorder = WaitScopeRecorder()
+        let viewModel = makeViewModel(windowID: window.windowID)
+        let first = try await installRunningSession(in: viewModel, liveSnapshots: liveSnapshots)
+        let second = try await installRunningSession(in: viewModel, liveSnapshots: liveSnapshots)
+        defer {
+            Task {
+                await AgentRunSessionStore.cleanup(registration: first.registration)
+                await AgentRunSessionStore.cleanup(registration: second.registration)
+            }
+        }
+        let service = makeService(
+            window: window,
+            viewModel: viewModel,
+            liveSnapshots: liveSnapshots,
+            recorder: recorder
+        )
+
+        let waitTask = Task { @MainActor in
+            try await service.execute(args: [
+                "op": .string("wait"),
+                "session_ids": .array([
+                    .string(first.sessionID.uuidString),
+                    .string(second.sessionID.uuidString)
+                ]),
+                "timeout": .double(2)
+            ])
+        }
+        try await waitForWaiter(registration: first.registration)
+        try await waitForWaiter(registration: second.registration)
+
+        await AgentRunSessionStore.wakeCurrentWaiters(
+            second.runningSnapshot,
+            cursor: second.cursor,
+            reason: .instructionDelivered
+        )
+        try await waitForWaiter(registration: second.registration)
+
+        let terminal = makeSnapshot(sessionID: first.sessionID, status: .completed)
+        await liveSnapshots.set(terminal)
+        _ = await AgentRunSessionStore.publishTerminal(
+            .init(epoch: first.epoch, snapshot: terminal),
+            registration: first.registration,
+            commitID: UUID(),
+            successorKind: nil
+        )
+
+        let value = try await waitTask.value
+        let object = try XCTUnwrap(value.objectValue)
+        let wait = try XCTUnwrap(object["wait"]?.objectValue)
+        XCTAssertEqual(object["session_id"]?.stringValue, first.sessionID.uuidString)
+        XCTAssertEqual(wait["result"]?.stringValue, "snapshot_ready")
+        XCTAssertEqual(wait["winner_session_id"]?.stringValue, first.sessionID.uuidString)
+        XCTAssertEqual(
+            wait["pending_session_ids"]?.arrayValue?.compactMap(\.stringValue),
+            [second.sessionID.uuidString]
+        )
+        XCTAssertNil(object["_meta"]?.objectValue?["wake_reason"])
+
+        let completions = await recorder.completions()
+        XCTAssertEqual(completions.count, 1)
+        XCTAssertEqual(completions[0].reason, .snapshotReady)
+        XCTAssertEqual(completions[0].winnerSessionID, first.sessionID)
+        XCTAssertEqual(completions[0].pendingSessionIDs, [second.sessionID])
+    }
+
+    private func makeWindow() -> WindowState {
+        let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
+        GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
+        let window = WindowState()
+        WindowStatesManager.shared.registerWindowState(window)
+        GlobalSettingsStore.shared.setMCPAutoStart(previousAutoStart, commit: false)
+        return window
+    }
+
+    private func makeViewModel(windowID: Int) -> AgentModeViewModel {
+        AgentModeViewModel(
+            testWindowID: windowID,
+            testWorkspacePath: FileManager.default.currentDirectoryPath,
+            codexControllerFactory: { _, _, _, _, _, _ in WaitTestCodexController() }
+        )
+    }
+
+    private func installRunningSession(
+        in viewModel: AgentModeViewModel,
+        liveSnapshots: LiveSnapshots
+    ) async throws -> RunningSessionFixture {
+        let sessionID = UUID()
+        let session = await viewModel.ensureSessionReady(tabID: UUID())
+        _ = viewModel.test_installPersistentSessionBinding(sessionID: sessionID, on: session)
+        try await viewModel.mcpActivateControlContext(
+            forTabID: session.tabID,
+            sessionID: sessionID,
+            originatingConnectionID: nil,
+            startPending: true
+        )
+        await viewModel.prepareMCPWaitTrackingForRunStart(session: session)
+        let context = try XCTUnwrap(session.mcpControlContext)
+        let epoch = try XCTUnwrap(context.currentEpoch)
+        let cursor = AgentRunSessionStore.WaitCursor(
+            registration: context.registration,
+            epoch: epoch
+        )
+        let runningSnapshot = makeSnapshot(
+            sessionID: sessionID,
+            status: .running,
+            latestAssistantPreview: "stale assistant text"
+        )
+        await liveSnapshots.set(runningSnapshot)
+        await AgentRunSessionStore.signalSnapshot(runningSnapshot, cursor: cursor)
+        return RunningSessionFixture(
+            sessionID: sessionID,
+            registration: context.registration,
+            epoch: epoch,
+            cursor: cursor,
+            runningSnapshot: runningSnapshot
+        )
+    }
+
+    private func makeService(
+        window: WindowState,
+        viewModel: AgentModeViewModel,
+        liveSnapshots: LiveSnapshots,
+        recorder: WaitScopeRecorder
+    ) -> AgentRunMCPToolService {
+        var service = AgentRunMCPToolService(
+            toolName: MCPWindowToolName.agentRun,
+            captureRequestMetadata: {
+                MCPServerViewModel.RequestMetadata(
+                    connectionID: nil,
+                    clientName: "agent-run-wait-tests",
+                    windowID: window.windowID
+                )
+            },
+            requireTargetWindow: { window },
+            resolveRequestedTabID: { _ in nil },
+            resolveSpawnSourceTabID: { _ in nil },
+            resolveSpawnParentSessionID: { _, _ in nil },
+            bindCurrentRequestToTab: { _, _ in },
+            withHeartbeat: { _, _, _, _, operation in try await operation() },
+            startRun: { _, _, _, _, _, _, _, _, _, _ in
+                throw MCPError.internalError("startRun should not be used by wait tests")
+            }
+        )
+        service.beginAgentRunWait = {
+            (_: MCPServerViewModel.RequestMetadata, sessionIDs: Set<UUID>, _: TimeInterval?) async -> UUID? in
+            await recorder.begin(sessionIDs: sessionIDs)
+        }
+        service.endAgentRunWait = {
+            (token: UUID, completion: AgentRunWaitScopeCompletion) async in
+            await recorder.end(token: token, completion: completion)
+        }
+        service.currentSnapshotProvider = {
+            (sessionID: UUID, _: AgentModeViewModel) async -> AgentRunMCPSnapshot? in
+            await liveSnapshots.snapshot(for: sessionID)
+        }
+        service.testAgentModeViewModel = viewModel
+        return service
+    }
+
+    private func waitForWaiter(
+        registration: AgentRunSessionStore.Registration,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws {
+        for _ in 0 ..< 300 {
+            if await AgentRunSessionStore.shared.test_waiterCount(registration: registration) == 1 {
+                return
+            }
+            try await Task.sleep(nanoseconds: 5_000_000)
+        }
+        XCTFail("Timed out waiting for store waiter", file: file, line: line)
+    }
+
+    private func makeSnapshot(
+        sessionID: UUID,
+        status: AgentRunMCPSnapshot.Status,
+        latestAssistantPreview: String? = nil
+    ) -> AgentRunMCPSnapshot {
+        AgentRunMCPSnapshot(
+            sessionID: sessionID,
+            tabID: nil,
+            sessionName: "Child Agent",
+            agentRaw: AgentProviderKind.codexExec.rawValue,
+            agentDisplayName: AgentProviderKind.codexExec.displayName,
+            modelRaw: "codex",
+            reasoningEffortRaw: nil,
+            status: status,
+            statusText: status.rawValue,
+            latestAssistantPreview: latestAssistantPreview,
+            interaction: nil,
+            transcriptItemCount: 1,
+            updatedAt: Date(),
+            parentSessionID: nil,
+            failureReason: nil,
+            worktreeBindings: [],
+            activeWorktreeMerges: []
+        )
+    }
+}
+
+private struct RunningSessionFixture {
+    let sessionID: UUID
+    let registration: AgentRunSessionStore.Registration
+    let epoch: AgentRunTurnEpoch
+    let cursor: AgentRunSessionStore.WaitCursor
+    let runningSnapshot: AgentRunMCPSnapshot
+}
+
+private actor LiveSnapshots {
+    private var snapshots: [UUID: AgentRunMCPSnapshot] = [:]
+
+    func set(_ snapshot: AgentRunMCPSnapshot) {
+        snapshots[snapshot.sessionID] = snapshot
+    }
+
+    func snapshot(for sessionID: UUID) -> AgentRunMCPSnapshot? {
+        snapshots[sessionID]
+    }
+}
+
+private final class WaitTestCodexController: CodexSessionControlling {
+    var hasActiveThread: Bool {
+        false
+    }
+
+    var events: AsyncStream<CodexNativeSessionController.Event> {
+        AsyncStream { continuation in
+            continuation.finish()
+        }
+    }
+
+    func ensureEventsStreamReady() {}
+
+    func startOrResume(
+        existing _: CodexNativeSessionController.SessionRef?,
+        baseInstructions _: String
+    ) async throws -> CodexNativeSessionController.SessionRef {
+        .init(conversationID: "wait-test", rolloutPath: nil, model: nil, reasoningEffort: nil)
+    }
+
+    func startOrResume(
+        existing _: CodexNativeSessionController.SessionRef?,
+        baseInstructions _: String,
+        model: String?,
+        reasoningEffort: String?
+    ) async throws -> CodexNativeSessionController.SessionRef {
+        .init(conversationID: "wait-test", rolloutPath: nil, model: model, reasoningEffort: reasoningEffort)
+    }
+
+    func startOrResume(
+        existing _: CodexNativeSessionController.SessionRef?,
+        baseInstructions _: String,
+        model: String?,
+        reasoningEffort: String?,
+        serviceTier _: String?
+    ) async throws -> CodexNativeSessionController.SessionRef {
+        .init(conversationID: "wait-test", rolloutPath: nil, model: model, reasoningEffort: reasoningEffort)
+    }
+
+    func readThreadSnapshot(
+        includeTurns _: Bool,
+        timeout _: TimeInterval?
+    ) async throws -> CodexNativeSessionController.ThreadSnapshot {
+        .init(
+            conversationID: "wait-test",
+            rolloutPath: nil,
+            model: nil,
+            reasoningEffort: nil,
+            runtimeStatus: .idle,
+            currentTurnID: nil,
+            activeTurnIDs: [],
+            latestTurnStatus: nil
+        )
+    }
+
+    func setThreadName(_: String, threadID _: String?) async throws {}
+    func sendUserMessage(_: String) async throws {}
+    func sendUserTurn(text _: String, images _: [AgentImageAttachment]) async throws {}
+    func sendUserTurn(
+        text _: String,
+        images _: [AgentImageAttachment],
+        model _: String?,
+        reasoningEffort _: String?
+    ) async throws {}
+
+    func sendUserTurn(
+        text _: String,
+        images _: [AgentImageAttachment],
+        model _: String?,
+        reasoningEffort _: String?,
+        serviceTier _: String?
+    ) async throws {}
+
+    func compactThread() async throws {}
+    func getThreadGoal() async throws -> CodexNativeSessionController.ThreadGoal? {
+        nil
+    }
+
+    func setThreadGoalObjective(_: String) async throws -> CodexNativeSessionController.ThreadGoal {
+        throw CancellationError()
+    }
+
+    func setThreadGoalStatus(
+        _: CodexNativeSessionController.ThreadGoalStatus
+    ) async throws -> CodexNativeSessionController.ThreadGoal {
+        throw CancellationError()
+    }
+
+    func clearThreadGoal() async throws -> Bool {
+        false
+    }
+
+    func cancelCurrentTurn() async {}
+    func shutdown() async {}
+    func respondToServerRequest(id _: CodexAppServerRequestID, result _: [String: Any]) async {}
+}
+
+private actor WaitScopeRecorder {
+    private var startedSessionIDs: [Set<UUID>] = []
+    private var recordedCompletions: [AgentRunWaitScopeCompletion] = []
+
+    func begin(sessionIDs: Set<UUID>) -> UUID {
+        startedSessionIDs.append(sessionIDs)
+        return UUID()
+    }
+
+    func end(token _: UUID, completion: AgentRunWaitScopeCompletion) {
+        recordedCompletions.append(completion)
+    }
+
+    func beginRecords() -> [Set<UUID>] {
+        startedSessionIDs
+    }
+
+    func completions() -> [AgentRunWaitScopeCompletion] {
+        recordedCompletions
+    }
+}

--- a/Tests/RepoPromptTests/MCP/AgentRunSessionStoreRegistrationTests.swift
+++ b/Tests/RepoPromptTests/MCP/AgentRunSessionStoreRegistrationTests.swift
@@ -212,6 +212,130 @@ final class AgentRunSessionStoreRegistrationTests: XCTestCase {
         await AgentRunSessionStore.cleanup(registration: registration)
     }
 
+    func testDirectNoWaiterSteeringWakeIsEdgeTriggered() async throws {
+        let sessionID = UUID()
+        let registration = await AgentRunSessionStore.register(sessionID: sessionID)
+        let epoch = try await beginEpoch(
+            registration: registration,
+            activationID: UUID(),
+            expected: nil,
+            kind: .initial
+        )
+        let cursor = AgentRunSessionStore.WaitCursor(registration: registration, epoch: epoch)
+        let running = makeSnapshot(sessionID: sessionID, status: .running)
+        await AgentRunSessionStore.signalSnapshot(running, cursor: cursor)
+
+        await AgentRunSessionStore.wakeCurrentWaiters(
+            running,
+            cursor: cursor,
+            reason: .steeringRequested
+        )
+
+        let disposition = await AgentRunSessionStore.waitUntilInteresting(cursor: cursor, timeoutSeconds: 0)
+        XCTAssertEqual(disposition, .timedOut)
+        await AgentRunSessionStore.cleanup(registration: registration)
+    }
+
+    func testDuplicateDirectWakeCannotPoisonFreshWait() async throws {
+        let sessionID = UUID()
+        let registration = await AgentRunSessionStore.register(sessionID: sessionID)
+        let epoch = try await beginEpoch(
+            registration: registration,
+            activationID: UUID(),
+            expected: nil,
+            kind: .initial
+        )
+        let cursor = AgentRunSessionStore.WaitCursor(registration: registration, epoch: epoch)
+        let running = makeSnapshot(sessionID: sessionID, status: .running)
+        await AgentRunSessionStore.signalSnapshot(running, cursor: cursor)
+        let firstWait = Task {
+            await AgentRunSessionStore.waitUntilInteresting(cursor: cursor, timeoutSeconds: 1)
+        }
+        try await waitForWaiter(registration: registration)
+
+        await AgentRunSessionStore.wakeCurrentWaiters(
+            running,
+            cursor: cursor,
+            reason: .steeringRequested
+        )
+        let firstDisposition = await firstWait.value
+        XCTAssertEqual(firstDisposition, .noteworthySnapshot(running, .steeringRequested))
+
+        await AgentRunSessionStore.wakeCurrentWaiters(
+            running,
+            cursor: cursor,
+            reason: .steeringRequested
+        )
+        await AgentRunSessionStore.wakeCurrentWaiters(
+            running,
+            cursor: cursor,
+            reason: .steeringRequested
+        )
+
+        let freshDisposition = await AgentRunSessionStore.waitUntilInteresting(
+            cursor: cursor,
+            timeoutSeconds: 0
+        )
+        XCTAssertEqual(freshDisposition, .timedOut)
+        await AgentRunSessionStore.cleanup(registration: registration)
+    }
+
+    func testSignaledNoteworthySnapshotRemainsStickyForNextWaitOnly() async throws {
+        let sessionID = UUID()
+        let registration = await AgentRunSessionStore.register(sessionID: sessionID)
+        let epoch = try await beginEpoch(
+            registration: registration,
+            activationID: UUID(),
+            expected: nil,
+            kind: .initial
+        )
+        let cursor = AgentRunSessionStore.WaitCursor(registration: registration, epoch: epoch)
+        let running = makeSnapshot(sessionID: sessionID, status: .running)
+
+        await AgentRunSessionStore.signalSnapshotAndWakeWaiters(
+            running,
+            cursor: cursor,
+            reason: .instructionDelivered
+        )
+
+        let firstDisposition = await AgentRunSessionStore.waitUntilInteresting(
+            cursor: cursor,
+            timeoutSeconds: 0
+        )
+        let secondDisposition = await AgentRunSessionStore.waitUntilInteresting(
+            cursor: cursor,
+            timeoutSeconds: 0
+        )
+        XCTAssertEqual(firstDisposition, .noteworthySnapshot(running, .instructionDelivered))
+        XCTAssertEqual(secondDisposition, .timedOut)
+        await AgentRunSessionStore.cleanup(registration: registration)
+    }
+
+    func testActionablePublicationDominatesPendingSteeringWake() async throws {
+        let sessionID = UUID()
+        let registration = await AgentRunSessionStore.register(sessionID: sessionID)
+        let epoch = try await beginEpoch(
+            registration: registration,
+            activationID: UUID(),
+            expected: nil,
+            kind: .initial
+        )
+        let cursor = AgentRunSessionStore.WaitCursor(registration: registration, epoch: epoch)
+        let running = makeSnapshot(sessionID: sessionID, status: .running)
+        let actionable = makeSnapshot(sessionID: sessionID, status: .waitingForInput)
+
+        await AgentRunSessionStore.signalSnapshotAndWakeWaiters(
+            running,
+            cursor: cursor,
+            reason: .steeringRequested
+        )
+        await AgentRunSessionStore.signalSnapshot(actionable, cursor: cursor)
+
+        let disposition = await AgentRunSessionStore.waitUntilInteresting(cursor: cursor, timeoutSeconds: 0)
+        XCTAssertEqual(disposition, .snapshotReady(actionable))
+        await AgentRunSessionStore.cleanup(registration: registration)
+    }
+
     func testInteractionSnapshotWakesImmediatelyAndIsNotHiddenByEpochState() async throws {
         let sessionID = UUID()
         let registration = await AgentRunSessionStore.register(sessionID: sessionID)

--- a/Tests/RepoPromptTests/MCP/AgentRunWaitDrainIntegrationTests.swift
+++ b/Tests/RepoPromptTests/MCP/AgentRunWaitDrainIntegrationTests.swift
@@ -1,0 +1,487 @@
+import Foundation
+import MCP
+import XCTest
+@_spi(TestSupport) @testable import RepoPrompt
+
+@MainActor
+final class AgentRunWaitDrainIntegrationTests: XCTestCase {
+    func testRealParentWaitScopeDrainInterruptsOnceAndAllowsCleanRewait() async throws {
+        try await AgentRunWaitDrainTestHarness.withHarness { harness in
+            let firstWait = harness.startWait()
+            try await harness.waitUntilBlocked()
+
+            XCTAssertTrue(harness.server.hasActiveChildAgentRunWaits(runID: harness.parentRunID))
+            XCTAssertEqual(harness.activeScopeCount(), 1)
+
+            let drained = await harness.drain(source: "test-real-wait-scope-drain")
+            XCTAssertTrue(drained)
+
+            let interruptedValue = try await firstWait.value
+            let interruptedObject = try XCTUnwrap(interruptedValue.objectValue)
+            XCTAssertEqual(
+                interruptedObject["wait"]?.objectValue?["result"]?.stringValue,
+                "interrupted_by_steering"
+            )
+            XCTAssertEqual(
+                interruptedObject["_meta"]?.objectValue?["wake_reason"]?.stringValue,
+                AgentRunSessionStore.WakeReason.steeringRequested.rawValue
+            )
+            XCTAssertFalse(harness.server.hasActiveChildAgentRunWaits(runID: harness.parentRunID))
+            XCTAssertEqual(harness.activeScopeCount(), 0)
+            let firstCompletions = await harness.completionRecorder.completions()
+            let registrationRemainsActive = await AgentRunSessionStore.hasActiveRegistration(
+                sessionID: harness.fixture.sessionID
+            )
+            XCTAssertEqual(firstCompletions.count, 1)
+            XCTAssertEqual(firstCompletions.first?.result, "interrupted_by_steering")
+            XCTAssertTrue(registrationRemainsActive)
+
+            let secondWait = harness.startWait()
+            try await harness.waitUntilBlocked()
+            try await Task.sleep(nanoseconds: 50_000_000)
+
+            XCTAssertTrue(harness.server.hasActiveChildAgentRunWaits(runID: harness.parentRunID))
+            XCTAssertEqual(harness.activeScopeCount(), 1)
+            let secondWaiterCount = await AgentRunSessionStore.shared.test_waiterCount(
+                registration: harness.fixture.registration
+            )
+            XCTAssertEqual(
+                secondWaiterCount,
+                1,
+                "A stale steering wake must not complete the subsequent wait"
+            )
+
+            try await harness.publishTerminal()
+            let terminalValue = try await secondWait.value
+            XCTAssertEqual(terminalValue.objectValue?["status"]?.stringValue, AgentRunMCPSnapshot.Status.completed.rawValue)
+            XCTAssertFalse(harness.server.hasActiveChildAgentRunWaits(runID: harness.parentRunID))
+            XCTAssertEqual(harness.activeScopeCount(), 0)
+            let allCompletions = await harness.completionRecorder.completions()
+            XCTAssertEqual(allCompletions.count, 2)
+            XCTAssertEqual(allCompletions.last?.reason, .snapshotReady)
+        }
+    }
+}
+
+@MainActor
+final class AgentRunWaitDrainTestHarness {
+    struct Fixture {
+        let sessionID: UUID
+        let registration: AgentRunSessionStore.Registration
+        let epoch: AgentRunTurnEpoch
+        let cursor: AgentRunSessionStore.WaitCursor
+        let runningSnapshot: AgentRunMCPSnapshot
+    }
+
+    let window: WindowState
+    let server: MCPServerViewModel
+    let parentRunID: UUID
+    let connectionID: UUID
+    let fixture: Fixture
+    let completionRecorder: AgentRunWaitDrainCompletionRecorder
+
+    private let service: AgentRunMCPToolService
+    private let liveSnapshots: AgentRunWaitDrainLiveSnapshots
+    private var waitTasks: [Task<Value, Error>] = []
+    private var didCleanup = false
+
+    private init(
+        window: WindowState,
+        parentRunID: UUID,
+        connectionID: UUID,
+        fixture: Fixture,
+        completionRecorder: AgentRunWaitDrainCompletionRecorder,
+        service: AgentRunMCPToolService,
+        liveSnapshots: AgentRunWaitDrainLiveSnapshots
+    ) {
+        self.window = window
+        server = window.mcpServer
+        self.parentRunID = parentRunID
+        self.connectionID = connectionID
+        self.fixture = fixture
+        self.completionRecorder = completionRecorder
+        self.service = service
+        self.liveSnapshots = liveSnapshots
+    }
+
+    static func withHarness<T>(
+        parentRunID: UUID = UUID(),
+        operation: @MainActor (AgentRunWaitDrainTestHarness) async throws -> T
+    ) async throws -> T {
+        let harness = try await make(parentRunID: parentRunID)
+        do {
+            let result = try await operation(harness)
+            await harness.cleanup()
+            return result
+        } catch {
+            await harness.cleanup()
+            throw error
+        }
+    }
+
+    static func make(parentRunID: UUID = UUID()) async throws -> AgentRunWaitDrainTestHarness {
+        let window = makeWindow()
+        let connectionID = UUID()
+        let liveSnapshots = AgentRunWaitDrainLiveSnapshots()
+        let completionRecorder = AgentRunWaitDrainCompletionRecorder()
+        let childViewModel = makeChildViewModel(windowID: window.windowID)
+        let fixture: Fixture
+        do {
+            fixture = try await installRunningSession(
+                in: childViewModel,
+                liveSnapshots: liveSnapshots
+            )
+        } catch {
+            WindowStatesManager.shared.unregisterWindowState(window)
+            throw error
+        }
+
+        guard window.mcpServer.registerRunIDMapping(
+            connectionID: connectionID,
+            runID: parentRunID,
+            windowID: window.windowID
+        ) else {
+            await AgentRunSessionStore.cleanup(registration: fixture.registration)
+            WindowStatesManager.shared.unregisterWindowState(window)
+            throw AgentRunWaitDrainHarnessError.failedToRegisterRunMapping
+        }
+
+        var service = AgentRunMCPToolService(
+            toolName: MCPWindowToolName.agentRun,
+            captureRequestMetadata: {
+                MCPServerViewModel.RequestMetadata(
+                    connectionID: connectionID,
+                    clientName: "agent-run-wait-drain-tests",
+                    windowID: window.windowID
+                )
+            },
+            requireTargetWindow: { window },
+            resolveRequestedTabID: { _ in nil },
+            resolveSpawnSourceTabID: { _ in nil },
+            resolveSpawnParentSessionID: { _, _ in nil },
+            bindCurrentRequestToTab: { _, _ in },
+            withHeartbeat: { _, _, _, _, operation in try await operation() },
+            startRun: { _, _, _, _, _, _, _, _, _, _ in
+                throw MCPError.internalError("startRun should not be used by wait-drain tests")
+            }
+        )
+        service.beginAgentRunWait = { metadata, sessionIDs, timeoutSeconds in
+            await window.mcpServer.test_beginAgentRunWaitScope(
+                metadata: metadata,
+                sessionIDs: sessionIDs,
+                timeoutSeconds: timeoutSeconds
+            )
+        }
+        service.endAgentRunWait = { token, completion in
+            await window.mcpServer.test_endAgentRunWaitScope(token, completion: completion)
+            await completionRecorder.record(completion)
+        }
+        service.currentSnapshotProvider = { sessionID, _ in
+            await liveSnapshots.snapshot(for: sessionID)
+        }
+        service.testAgentModeViewModel = childViewModel
+
+        return AgentRunWaitDrainTestHarness(
+            window: window,
+            parentRunID: parentRunID,
+            connectionID: connectionID,
+            fixture: fixture,
+            completionRecorder: completionRecorder,
+            service: service,
+            liveSnapshots: liveSnapshots
+        )
+    }
+
+    func startWait(timeoutSeconds: TimeInterval = 2) -> Task<Value, Error> {
+        let task = Task { @MainActor [service, fixture] in
+            try await service.execute(args: [
+                "op": .string("wait"),
+                "session_id": .string(fixture.sessionID.uuidString),
+                "timeout": .double(timeoutSeconds)
+            ])
+        }
+        waitTasks.append(task)
+        return task
+    }
+
+    func waitUntilBlocked(timeout: TimeInterval = 2) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            let waiterCount = await AgentRunSessionStore.shared.test_waiterCount(
+                registration: fixture.registration
+            )
+            if waiterCount == 1,
+               activeScopeCount() == 1,
+               server.hasActiveChildAgentRunWaits(runID: parentRunID)
+            {
+                return
+            }
+            try await Task.sleep(nanoseconds: 5_000_000)
+        }
+        throw AgentRunWaitDrainHarnessError.timedOutWaitingForBlockedScope
+    }
+
+    func drain(source: String) async -> Bool {
+        await server.wakeAndDrainAgentRunWaitersOwnedByActiveRun(
+            runID: parentRunID,
+            source: source,
+            timeoutSeconds: 1
+        ) { [fixture] sessionID in
+            guard sessionID == fixture.sessionID else { return nil }
+            return (fixture.runningSnapshot, fixture.cursor)
+        }
+    }
+
+    func activeScopeCount() -> Int {
+        server.test_agentRunWaitScopeCount(parentRunID: parentRunID)
+    }
+
+    func publishTerminal() async throws {
+        let terminal = Self.makeSnapshot(sessionID: fixture.sessionID, status: .completed)
+        await liveSnapshots.set(terminal)
+        let result = await AgentRunSessionStore.publishTerminal(
+            .init(epoch: fixture.epoch, snapshot: terminal),
+            registration: fixture.registration,
+            commitID: UUID(),
+            successorKind: nil
+        )
+        guard case .accepted = result else {
+            throw AgentRunWaitDrainHarnessError.failedToPublishTerminal
+        }
+    }
+
+    func cleanup() async {
+        guard !didCleanup else { return }
+        didCleanup = true
+        let tasks = waitTasks
+        waitTasks.removeAll()
+        for task in tasks {
+            task.cancel()
+        }
+        for task in tasks {
+            _ = try? await task.value
+        }
+        server.cleanupRunIDMapping(runID: parentRunID, connectionID: connectionID)
+        await AgentRunSessionStore.cleanup(registration: fixture.registration)
+        WindowStatesManager.shared.unregisterWindowState(window)
+    }
+
+    private static func makeWindow() -> WindowState {
+        let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
+        GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
+        let window = WindowState()
+        WindowStatesManager.shared.registerWindowState(window)
+        GlobalSettingsStore.shared.setMCPAutoStart(previousAutoStart, commit: false)
+        return window
+    }
+
+    private static func makeChildViewModel(windowID: Int) -> AgentModeViewModel {
+        AgentModeViewModel(
+            testWindowID: windowID,
+            testWorkspacePath: FileManager.default.currentDirectoryPath,
+            codexControllerFactory: { _, _, _, _, _, _ in AgentRunWaitDrainCodexController() }
+        )
+    }
+
+    private static func installRunningSession(
+        in viewModel: AgentModeViewModel,
+        liveSnapshots: AgentRunWaitDrainLiveSnapshots
+    ) async throws -> Fixture {
+        let sessionID = UUID()
+        let session = await viewModel.ensureSessionReady(tabID: UUID())
+        _ = viewModel.test_installPersistentSessionBinding(sessionID: sessionID, on: session)
+        do {
+            try await viewModel.mcpActivateControlContext(
+                forTabID: session.tabID,
+                sessionID: sessionID,
+                originatingConnectionID: nil,
+                startPending: true
+            )
+            await viewModel.prepareMCPWaitTrackingForRunStart(session: session)
+            guard let context = session.mcpControlContext,
+                  let epoch = context.currentEpoch
+            else {
+                throw AgentRunWaitDrainHarnessError.missingControlContext
+            }
+            let cursor = AgentRunSessionStore.WaitCursor(
+                registration: context.registration,
+                epoch: epoch
+            )
+            let runningSnapshot = makeSnapshot(
+                sessionID: sessionID,
+                status: .running,
+                latestAssistantPreview: "stale assistant text"
+            )
+            await liveSnapshots.set(runningSnapshot)
+            await AgentRunSessionStore.signalSnapshot(runningSnapshot, cursor: cursor)
+            return Fixture(
+                sessionID: sessionID,
+                registration: context.registration,
+                epoch: epoch,
+                cursor: cursor,
+                runningSnapshot: runningSnapshot
+            )
+        } catch {
+            if let registration = session.mcpControlContext?.registration {
+                await AgentRunSessionStore.cleanup(registration: registration)
+            }
+            throw error
+        }
+    }
+
+    private static func makeSnapshot(
+        sessionID: UUID,
+        status: AgentRunMCPSnapshot.Status,
+        latestAssistantPreview: String? = nil
+    ) -> AgentRunMCPSnapshot {
+        AgentRunMCPSnapshot(
+            sessionID: sessionID,
+            tabID: nil,
+            sessionName: "Child Agent",
+            agentRaw: AgentProviderKind.codexExec.rawValue,
+            agentDisplayName: AgentProviderKind.codexExec.displayName,
+            modelRaw: "codex",
+            reasoningEffortRaw: nil,
+            status: status,
+            statusText: status.rawValue,
+            latestAssistantPreview: latestAssistantPreview,
+            interaction: nil,
+            transcriptItemCount: 1,
+            updatedAt: Date(),
+            parentSessionID: nil,
+            failureReason: nil,
+            worktreeBindings: [],
+            activeWorktreeMerges: []
+        )
+    }
+}
+
+actor AgentRunWaitDrainCompletionRecorder {
+    private var recordedCompletions: [AgentRunWaitScopeCompletion] = []
+
+    func record(_ completion: AgentRunWaitScopeCompletion) {
+        recordedCompletions.append(completion)
+    }
+
+    func count() -> Int {
+        recordedCompletions.count
+    }
+
+    func completions() -> [AgentRunWaitScopeCompletion] {
+        recordedCompletions
+    }
+}
+
+actor AgentRunWaitDrainLiveSnapshots {
+    private var snapshots: [UUID: AgentRunMCPSnapshot] = [:]
+
+    func set(_ snapshot: AgentRunMCPSnapshot) {
+        snapshots[snapshot.sessionID] = snapshot
+    }
+
+    func snapshot(for sessionID: UUID) -> AgentRunMCPSnapshot? {
+        snapshots[sessionID]
+    }
+}
+
+private enum AgentRunWaitDrainHarnessError: Error {
+    case failedToRegisterRunMapping
+    case timedOutWaitingForBlockedScope
+    case failedToPublishTerminal
+    case missingControlContext
+}
+
+private final class AgentRunWaitDrainCodexController: CodexSessionControlling {
+    var hasActiveThread: Bool {
+        false
+    }
+
+    var events: AsyncStream<CodexNativeSessionController.Event> {
+        AsyncStream { continuation in continuation.finish() }
+    }
+
+    func ensureEventsStreamReady() {}
+
+    func startOrResume(
+        existing _: CodexNativeSessionController.SessionRef?,
+        baseInstructions _: String
+    ) async throws -> CodexNativeSessionController.SessionRef {
+        .init(conversationID: "wait-drain-test", rolloutPath: nil, model: nil, reasoningEffort: nil)
+    }
+
+    func startOrResume(
+        existing _: CodexNativeSessionController.SessionRef?,
+        baseInstructions _: String,
+        model: String?,
+        reasoningEffort: String?
+    ) async throws -> CodexNativeSessionController.SessionRef {
+        .init(conversationID: "wait-drain-test", rolloutPath: nil, model: model, reasoningEffort: reasoningEffort)
+    }
+
+    func startOrResume(
+        existing _: CodexNativeSessionController.SessionRef?,
+        baseInstructions _: String,
+        model: String?,
+        reasoningEffort: String?,
+        serviceTier _: String?
+    ) async throws -> CodexNativeSessionController.SessionRef {
+        .init(conversationID: "wait-drain-test", rolloutPath: nil, model: model, reasoningEffort: reasoningEffort)
+    }
+
+    func readThreadSnapshot(
+        includeTurns _: Bool,
+        timeout _: TimeInterval?
+    ) async throws -> CodexNativeSessionController.ThreadSnapshot {
+        .init(
+            conversationID: "wait-drain-test",
+            rolloutPath: nil,
+            model: nil,
+            reasoningEffort: nil,
+            runtimeStatus: .idle,
+            currentTurnID: nil,
+            activeTurnIDs: [],
+            latestTurnStatus: nil
+        )
+    }
+
+    func setThreadName(_: String, threadID _: String?) async throws {}
+    func sendUserMessage(_: String) async throws {}
+    func sendUserTurn(text _: String, images _: [AgentImageAttachment]) async throws {}
+    func sendUserTurn(
+        text _: String,
+        images _: [AgentImageAttachment],
+        model _: String?,
+        reasoningEffort _: String?
+    ) async throws {}
+
+    func sendUserTurn(
+        text _: String,
+        images _: [AgentImageAttachment],
+        model _: String?,
+        reasoningEffort _: String?,
+        serviceTier _: String?
+    ) async throws {}
+
+    func compactThread() async throws {}
+    func getThreadGoal() async throws -> CodexNativeSessionController.ThreadGoal? {
+        nil
+    }
+
+    func setThreadGoalObjective(_: String) async throws -> CodexNativeSessionController.ThreadGoal {
+        throw CancellationError()
+    }
+
+    func setThreadGoalStatus(
+        _: CodexNativeSessionController.ThreadGoalStatus
+    ) async throws -> CodexNativeSessionController.ThreadGoal {
+        throw CancellationError()
+    }
+
+    func clearThreadGoal() async throws -> Bool {
+        false
+    }
+
+    func cancelCurrentTurn() async {}
+    func shutdown() async {}
+    func respondToServerRequest(id _: CodexAppServerRequestID, result _: [String: Any]) async {}
+}


### PR DESCRIPTION
## Summary
- make agent-run waits explicitly drainable when a parent Codex turn is steered
- prevent stale wake events from poisoning subsequent waits
- track wait scopes across MCP server and session lifecycle boundaries
- add focused unit and integration coverage for drain, re-wait, and terminal publication behavior

## Validation
- repository contribution push preflight
- `make dev-lint`
- `make dev-test`
- `make dev-swift-build PRODUCT=RepoPrompt`