### PR TITLE
Harden pending policy replacement rollback

### DIFF
--- a/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPAgentSessionController.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPAgentSessionController.swift
@@ -653,6 +653,12 @@ actor ACPAgentSessionController {
             if let sessionModelFailureReason {
                 throw ControllerError.protocolViolation("malformed modern model config option: \(sessionModelFailureReason)")
             }
+            if provider.providerID == .cursor,
+               normalizedCursorModelAlias(model) == AgentModel.cursorAuto.rawValue,
+               sessionModelConfigOptionID == nil
+            {
+                return
+            }
             guard let sessionModelConfigOptionID else {
                 throw ControllerError.requestFailed("ACP runtime does not advertise model switching through configOptions.")
             }

--- a/Sources/RepoPrompt/Infrastructure/MCP/MCPConnectionManager.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/MCPConnectionManager.swift
@@ -947,12 +947,15 @@ actor ServerNetworkManager {
         private var debugShouldSuspendNextPendingPolicyCommit = false
         private var debugPendingPolicyCommitIsSuspended = false
         private var debugPendingPolicyCommitResumeWaiters: [CheckedContinuation<Void, Never>] = []
+        private var debugPendingPolicyReplacementSchedules: [(existing: UUID, replacement: UUID, runID: UUID)] = []
     #endif
     private var expectedAgentPIDsByClient: [String: Set<pid_t>] = [:]
     private var expectedAgentPIDsByRunID: [UUID: Set<pid_t>] = [:]
     private var runPolicyStateByRunID: [UUID: RunConnectionPolicyState] = [:]
     private var admittedPolicyRunIDs: Set<UUID> = []
     private var windowIDByRunID: [UUID: Int] = [:]
+    private var pendingPolicyApplicationIDByConnectionID: [UUID: UUID] = [:]
+    private var pendingPolicyApplicationIDByRunID: [UUID: UUID] = [:]
 
     // 🆕 Per-connection → windowID routing map
     private var connectionWindowMap: [UUID: Int] = [:]
@@ -1774,6 +1777,47 @@ actor ServerNetworkManager {
         return true
     }
 
+    private func mapConnectionToRunIDForPendingPolicy(
+        _ connectionID: UUID,
+        runID: UUID,
+        windowID: Int
+    ) async -> MCPServerViewModel.PendingPolicyRunIDMappingToken? {
+        let token = await MainActor.run { () -> MCPServerViewModel.PendingPolicyRunIDMappingToken? in
+            guard let window = WindowStatesManager.shared.window(withID: windowID) else {
+                log.warning("mapConnectionToRunIDForPendingPolicy: window \(windowID) not found for connection \(connectionID)")
+                return nil
+            }
+            return window.mcpServer.registerPendingPolicyRunIDMapping(
+                connectionID: connectionID,
+                runID: runID,
+                windowID: windowID
+            )
+        }
+        guard let token else {
+            log.warning("mapConnectionToRunIDForPendingPolicy: registration refused connection \(connectionID) run \(runID) window \(windowID)")
+            return nil
+        }
+
+        if connectionWindowMap[connectionID] != windowID {
+            setConnectionWindowMapping(connectionID, windowID: windowID)
+        }
+        runIDByConnectionID[connectionID] = runID
+        windowIDByRunID[runID] = windowID
+        updateLiveRunAffinity(
+            clientName: clientIdentifier(forConnection: connectionID) ?? "",
+            sessionKey: connections[connectionID]?.capabilityToken ?? capabilityTokenByConnection[connectionID],
+            runID: runID,
+            windowID: windowID,
+            purpose: runPurposeByConnection[connectionID] ?? runPolicyStateByRunID[runID]?.purpose
+        )
+        await applyRunPolicyStateIfAvailable(
+            runID: runID,
+            connectionID: connectionID,
+            persistWindowBinding: true
+        )
+        return token
+    }
+
     private func seedRunPolicyState(
         runID: UUID,
         windowID: Int,
@@ -2154,6 +2198,7 @@ actor ServerNetworkManager {
         runPolicyStateByRunID.removeValue(forKey: runID)
         admittedPolicyRunIDs.remove(runID)
         windowIDByRunID.removeValue(forKey: runID)
+        pendingPolicyApplicationIDByRunID.removeValue(forKey: runID)
         clearLiveRunAffinity(for: runID)
         let connectionIDsForRun = runIDByConnectionID.compactMap { connectionID, mappedRunID in
             mappedRunID == runID ? connectionID : nil
@@ -3631,6 +3676,8 @@ actor ServerNetworkManager {
         runPolicyStateByRunID.removeAll()
         admittedPolicyRunIDs.removeAll()
         windowIDByRunID.removeAll()
+        pendingPolicyApplicationIDByConnectionID.removeAll()
+        pendingPolicyApplicationIDByRunID.removeAll()
         activeConnectionsByClient.removeAll()
         clientIDByConnection.removeAll()
         callLimiters.removeAll()
@@ -3939,6 +3986,48 @@ actor ServerNetworkManager {
         await terminateConnection(oldID, reason: .connectionReplaced, message: message, semanticsOverride: hardSemantics)
     }
 
+    private func schedulePendingPolicyConnectionReplacement(
+        _ token: MCPServerViewModel.PendingPolicyRunIDMappingToken,
+        windowID: Int
+    ) {
+        guard let displacedConnectionID = token.displacedConnectionID else { return }
+        #if DEBUG
+            debugPendingPolicyReplacementSchedules.append((
+                existing: displacedConnectionID,
+                replacement: token.connectionID,
+                runID: token.runID
+            ))
+        #endif
+        Task {
+            await ServerNetworkManager.shared.handlePendingPolicyConnectionReplacement(
+                token,
+                windowID: windowID
+            )
+        }
+    }
+
+    private func handlePendingPolicyConnectionReplacement(
+        _ token: MCPServerViewModel.PendingPolicyRunIDMappingToken,
+        windowID: Int
+    ) async {
+        guard let displacedConnectionID = token.displacedConnectionID else { return }
+        let replacementStillOwnsRun = await MainActor.run {
+            guard let window = WindowStatesManager.shared.window(withID: windowID) else { return false }
+            return window.mcpServer.isCurrentPendingPolicyRunIDMapping(token)
+                && window.mcpServer.connectionIDToRunID[displacedConnectionID] == nil
+        }
+        guard replacementStillOwnsRun else {
+            connectionLog("Skipping stale pending-policy replacement old=\(displacedConnectionID) new=\(token.connectionID) runID=\(token.runID)")
+            return
+        }
+        await handleConnectionReplaced(
+            existing: displacedConnectionID,
+            by: token.connectionID,
+            runID: token.runID,
+            message: "Connection replaced by new connection for same runID"
+        )
+    }
+
     func recordTransportIngressTerminal(
         connectionID: UUID,
         clientName: String?,
@@ -4051,6 +4140,7 @@ actor ServerNetworkManager {
         additionalToolsByConnection.removeValue(forKey: id)
         runPurposeByConnection.removeValue(forKey: id)
         runIDByConnectionID.removeValue(forKey: id)
+        pendingPolicyApplicationIDByConnectionID.removeValue(forKey: id)
         windowAssignmentByConnection.removeValue(forKey: id)
         preassignedConnections.remove(id)
         windowCountAtConnectionTime.removeValue(forKey: id)
@@ -4840,6 +4930,12 @@ actor ServerNetworkManager {
             pendingConnections.removeValue(forKey: connectionID)
         }
 
+        func debugSupersedePendingPolicyApplicationOwnership(connectionID: UUID, runID: UUID) {
+            let applicationID = UUID()
+            pendingPolicyApplicationIDByConnectionID[connectionID] = applicationID
+            pendingPolicyApplicationIDByRunID[runID] = applicationID
+        }
+
         func debugSuspendNextPendingPolicyCommit() {
             debugShouldSuspendNextPendingPolicyCommit = true
         }
@@ -4874,6 +4970,20 @@ actor ServerNetworkManager {
                 debugPendingPolicyCommitResumeWaiters.append(continuation)
             }
             debugPendingPolicyCommitIsSuspended = false
+        }
+
+        func debugPendingPolicyReplacementScheduleCount(
+            existing: UUID,
+            replacement: UUID,
+            runID: UUID
+        ) -> Int {
+            debugPendingPolicyReplacementSchedules.count {
+                $0.existing == existing && $0.replacement == replacement && $0.runID == runID
+            }
+        }
+
+        func debugClearPendingPolicyReplacementSchedules() {
+            debugPendingPolicyReplacementSchedules.removeAll()
         }
 
         func debugPendingPolicySnapshot(for clientName: String) -> [(windowID: Int, tabID: UUID?, runID: UUID?, oneShot: Bool, purpose: MCPRunPurpose)] {
@@ -5028,6 +5138,10 @@ actor ServerNetworkManager {
                 purpose: runPurposeByConnection[connectionID] ?? .unknown,
                 windowID: connectionWindowMap[connectionID]
             )
+        }
+
+        func debugCachedRunID(for connectionID: UUID) -> UUID? {
+            runIDByConnectionID[connectionID]
         }
 
         func debugSeedConnectionRunRouting(
@@ -7043,6 +7157,11 @@ actor ServerNetworkManager {
             runPolicyState: policy.runID.flatMap { runPolicyStateByRunID[$0] },
             runWindowID: policy.runID.flatMap { windowIDByRunID[$0] }
         )
+        let pendingPolicyApplicationID = UUID()
+        pendingPolicyApplicationIDByConnectionID[connectionID] = pendingPolicyApplicationID
+        if let runID = policy.runID {
+            pendingPolicyApplicationIDByRunID[runID] = pendingPolicyApplicationID
+        }
 
         // Stage the complete policy before registering the run mapping. The mapping
         // signals MCPRoutingWaiter, so restrictions and run identity must already be
@@ -7067,11 +7186,17 @@ actor ServerNetworkManager {
             await debugSuspendPendingPolicyRouteInstallationIfNeeded()
         #endif
 
-        guard isPendingPolicyApplicationCurrent(
+        guard isPendingPolicyApplicationOwner(
+            pendingPolicyApplicationID,
             connectionID: connectionID,
-            clientName: clientName,
-            expectedLifecycleGeneration: expectedLifecycleGeneration
-        ) else {
+            runID: policy.runID
+        ),
+            isPendingPolicyApplicationCurrent(
+                connectionID: connectionID,
+                clientName: clientName,
+                expectedLifecycleGeneration: expectedLifecycleGeneration
+            )
+        else {
             if policy.oneShot {
                 _ = rollbackOneShotPendingPolicyReservation(
                     id: policy.id,
@@ -7084,16 +7209,18 @@ actor ServerNetworkManager {
                 clientName: clientName,
                 connectionID: connectionID,
                 restorePoint: restorePoint,
+                applicationID: pendingPolicyApplicationID,
                 signalRoutingFailure: false
             )
             return .rejected(runID: policy.runID, reason: "stale_connection")
         }
 
+        var pendingPolicyRunIDMappingToken: MCPServerViewModel.PendingPolicyRunIDMappingToken?
         if requireRunRouting, let runID = policy.runID {
             let routed: Bool
             if let tabID = policy.tabID {
                 mcpRoutingLog("Policy includes tab context - installing for tab=\(tabID) run=\(runID)")
-                routed = await installTabContextFromPolicy(
+                let installation = await installTabContextFromPolicy(
                     clientID: connectionID.uuidString,
                     clientName: clientName,
                     windowID: policy.windowID,
@@ -7101,13 +7228,15 @@ actor ServerNetworkManager {
                     runID: runID,
                     signalRouting: false
                 )
+                routed = installation.routed
+                pendingPolicyRunIDMappingToken = installation.replacementToken
             } else {
-                routed = await mapConnectionToRunID(
+                pendingPolicyRunIDMappingToken = await mapConnectionToRunIDForPendingPolicy(
                     connectionID,
                     runID: runID,
-                    windowID: policy.windowID,
-                    signalRouting: false
+                    windowID: policy.windowID
                 )
+                routed = pendingPolicyRunIDMappingToken != nil
             }
             #if DEBUG
                 debugRecordRunRoutingEvent(
@@ -7131,7 +7260,9 @@ actor ServerNetworkManager {
                     policy,
                     clientName: clientName,
                     connectionID: connectionID,
-                    restorePoint: restorePoint
+                    restorePoint: restorePoint,
+                    applicationID: pendingPolicyApplicationID,
+                    pendingPolicyRunIDMappingToken: pendingPolicyRunIDMappingToken
                 )
                 return .rejected(
                     runID: runID,
@@ -7143,11 +7274,27 @@ actor ServerNetworkManager {
                 await debugSuspendPendingPolicyCommitIfNeeded()
             #endif
 
-            guard isPendingPolicyApplicationCurrent(
-                connectionID: connectionID,
-                clientName: clientName,
-                expectedLifecycleGeneration: expectedLifecycleGeneration
-            ) else {
+            let routeMappingToken = pendingPolicyRunIDMappingToken
+            let routeMappingIsCurrent = await MainActor.run {
+                routeMappingToken.map { token in
+                    guard let window = WindowStatesManager.shared.window(withID: policy.windowID) else {
+                        return false
+                    }
+                    return window.mcpServer.isCurrentPendingPolicyRunIDMapping(token)
+                } ?? true
+            }
+            guard routeMappingIsCurrent,
+                  isPendingPolicyApplicationOwner(
+                      pendingPolicyApplicationID,
+                      connectionID: connectionID,
+                      runID: policy.runID
+                  ),
+                  isPendingPolicyApplicationCurrent(
+                      connectionID: connectionID,
+                      clientName: clientName,
+                      expectedLifecycleGeneration: expectedLifecycleGeneration
+                  )
+            else {
                 if policy.oneShot {
                     _ = rollbackOneShotPendingPolicyReservation(
                         id: policy.id,
@@ -7160,6 +7307,8 @@ actor ServerNetworkManager {
                     clientName: clientName,
                     connectionID: connectionID,
                     restorePoint: restorePoint,
+                    applicationID: pendingPolicyApplicationID,
+                    pendingPolicyRunIDMappingToken: pendingPolicyRunIDMappingToken,
                     signalRoutingFailure: false
                 )
                 return .rejected(runID: runID, reason: "stale_connection")
@@ -7177,11 +7326,24 @@ actor ServerNetworkManager {
                 policy,
                 clientName: clientName,
                 connectionID: connectionID,
-                restorePoint: restorePoint
+                restorePoint: restorePoint,
+                applicationID: pendingPolicyApplicationID,
+                pendingPolicyRunIDMappingToken: pendingPolicyRunIDMappingToken
             )
             return .rejected(runID: policy.runID, reason: "policy_removed")
         }
 
+        finishPendingPolicyApplication(
+            pendingPolicyApplicationID,
+            connectionID: connectionID,
+            runID: policy.runID
+        )
+        if let pendingPolicyRunIDMappingToken {
+            schedulePendingPolicyConnectionReplacement(
+                pendingPolicyRunIDMappingToken,
+                windowID: policy.windowID
+            )
+        }
         if requireRunRouting, let runID = policy.runID {
             await MCPRoutingWaiter.notifyRouted(runID: runID)
         }
@@ -7249,6 +7411,15 @@ actor ServerNetworkManager {
         return .applied(runID: policy.runID)
     }
 
+    private func isPendingPolicyApplicationOwner(
+        _ applicationID: UUID,
+        connectionID: UUID,
+        runID: UUID?
+    ) -> Bool {
+        guard pendingPolicyApplicationIDByConnectionID[connectionID] == applicationID else { return false }
+        return runID.map { pendingPolicyApplicationIDByRunID[$0] == applicationID } ?? true
+    }
+
     private func isPendingPolicyApplicationCurrent(
         connectionID: UUID,
         clientName: String,
@@ -7265,11 +7436,22 @@ actor ServerNetworkManager {
         clientName: String,
         connectionID: UUID,
         restorePoint: PendingPolicyRestorePoint,
+        applicationID: UUID,
+        pendingPolicyRunIDMappingToken: MCPServerViewModel.PendingPolicyRunIDMappingToken? = nil,
         signalRoutingFailure: Bool = true
     ) async {
+        var mappingRollbackResult: MCPServerViewModel.PendingPolicyRunIDMappingRollbackResult?
         if let runID = policy.runID {
-            await MainActor.run {
-                guard let window = WindowStatesManager.shared.window(withID: policy.windowID) else { return }
+            mappingRollbackResult = await MainActor.run {
+                guard let window = WindowStatesManager.shared.window(withID: policy.windowID) else { return nil }
+                if let pendingPolicyRunIDMappingToken {
+                    return window.mcpServer.rollbackPendingPolicyRunIDMapping(
+                        pendingPolicyRunIDMappingToken,
+                        clientName: clientName,
+                        windowID: policy.windowID,
+                        signalRoutingFailure: signalRoutingFailure
+                    )
+                }
                 window.mcpServer.removeTabContext(
                     forConnectionID: connectionID,
                     clientName: clientName,
@@ -7281,55 +7463,94 @@ actor ServerNetworkManager {
                     connectionID: connectionID,
                     signalRoutingFailure: signalRoutingFailure
                 )
+                return .restored
             }
-            restorePendingPolicyState(
-                restorePoint,
-                connectionID: connectionID,
-                policyRunID: runID
-            )
+        }
+
+        var ownsConnectionState = pendingPolicyApplicationIDByConnectionID[connectionID] == applicationID
+        var ownsRunState = policy.runID.map { pendingPolicyApplicationIDByRunID[$0] == applicationID } ?? false
+        switch mappingRollbackResult {
+        case .supersededBySameConnection:
+            ownsConnectionState = false
+            ownsRunState = false
+        case .supersededByOtherConnection:
+            ownsRunState = false
+        case .restored, nil:
+            break
+        }
+        restorePendingPolicyState(
+            restorePoint,
+            connectionID: connectionID,
+            policyRunID: policy.runID,
+            restoreConnectionScopedState: ownsConnectionState,
+            restoreRunScopedState: ownsRunState
+        )
+        finishPendingPolicyApplication(
+            applicationID,
+            connectionID: connectionID,
+            runID: policy.runID
+        )
+    }
+
+    private func finishPendingPolicyApplication(
+        _ applicationID: UUID,
+        connectionID: UUID,
+        runID: UUID?
+    ) {
+        if pendingPolicyApplicationIDByConnectionID[connectionID] == applicationID {
+            pendingPolicyApplicationIDByConnectionID.removeValue(forKey: connectionID)
+        }
+        if let runID, pendingPolicyApplicationIDByRunID[runID] == applicationID {
+            pendingPolicyApplicationIDByRunID.removeValue(forKey: runID)
         }
     }
 
     private func restorePendingPolicyState(
         _ restorePoint: PendingPolicyRestorePoint,
         connectionID: UUID,
-        policyRunID: UUID
+        policyRunID: UUID?,
+        restoreConnectionScopedState: Bool,
+        restoreRunScopedState: Bool
     ) {
-        if let restrictedTools = restorePoint.restrictedTools {
-            restrictedToolsByConnection[connectionID] = restrictedTools
-        } else {
-            restrictedToolsByConnection.removeValue(forKey: connectionID)
+        if restoreConnectionScopedState {
+            if let restrictedTools = restorePoint.restrictedTools {
+                restrictedToolsByConnection[connectionID] = restrictedTools
+            } else {
+                restrictedToolsByConnection.removeValue(forKey: connectionID)
+            }
+            if let additionalTools = restorePoint.additionalTools {
+                additionalToolsByConnection[connectionID] = additionalTools
+            } else {
+                additionalToolsByConnection.removeValue(forKey: connectionID)
+            }
+            if let runPurpose = restorePoint.runPurpose {
+                runPurposeByConnection[connectionID] = runPurpose
+            } else {
+                runPurposeByConnection.removeValue(forKey: connectionID)
+            }
+            if let windowID = restorePoint.windowID {
+                connectionWindowMap[connectionID] = windowID
+            } else {
+                connectionWindowMap.removeValue(forKey: connectionID)
+            }
+            if let windowAssignment = restorePoint.windowAssignment {
+                windowAssignmentByConnection[connectionID] = windowAssignment
+            } else {
+                windowAssignmentByConnection.removeValue(forKey: connectionID)
+            }
+            if let runID = restorePoint.runID {
+                runIDByConnectionID[connectionID] = runID
+            } else {
+                runIDByConnectionID.removeValue(forKey: connectionID)
+            }
+            if restorePoint.wasPreassigned {
+                preassignedConnections.insert(connectionID)
+            } else {
+                preassignedConnections.remove(connectionID)
+            }
         }
-        if let additionalTools = restorePoint.additionalTools {
-            additionalToolsByConnection[connectionID] = additionalTools
-        } else {
-            additionalToolsByConnection.removeValue(forKey: connectionID)
-        }
-        if let runPurpose = restorePoint.runPurpose {
-            runPurposeByConnection[connectionID] = runPurpose
-        } else {
-            runPurposeByConnection.removeValue(forKey: connectionID)
-        }
-        if let windowID = restorePoint.windowID {
-            connectionWindowMap[connectionID] = windowID
-        } else {
-            connectionWindowMap.removeValue(forKey: connectionID)
-        }
-        if let windowAssignment = restorePoint.windowAssignment {
-            windowAssignmentByConnection[connectionID] = windowAssignment
-        } else {
-            windowAssignmentByConnection.removeValue(forKey: connectionID)
-        }
-        if let runID = restorePoint.runID {
-            runIDByConnectionID[connectionID] = runID
-        } else {
-            runIDByConnectionID.removeValue(forKey: connectionID)
-        }
-        if restorePoint.wasPreassigned {
-            preassignedConnections.insert(connectionID)
-        } else {
-            preassignedConnections.remove(connectionID)
-        }
+
+        guard restoreRunScopedState, let policyRunID else { return }
         if restorePoint.wasRunAdmitted {
             admittedPolicyRunIDs.insert(policyRunID)
         } else {
@@ -7355,32 +7576,37 @@ actor ServerNetworkManager {
         tabID: UUID,
         runID: UUID,
         signalRouting: Bool = true
-    ) async -> Bool {
-        let resolved = await MainActor.run { () -> (workspaceID: UUID, snapshot: ComposeTabState, routed: Bool)? in
+    ) async -> (routed: Bool, replacementToken: MCPServerViewModel.PendingPolicyRunIDMappingToken?) {
+        let resolved = await MainActor.run {
+            () -> (
+                workspaceID: UUID,
+                snapshot: ComposeTabState,
+                routed: Bool,
+                replacementToken: MCPServerViewModel.PendingPolicyRunIDMappingToken?
+            )? in
             guard let windowState = WindowStatesManager.shared.window(withID: windowID) else {
                 return nil
             }
             guard let resolved = windowState.workspaceManager.resolveComposeTabRoutingSnapshot(for: tabID) else {
                 return nil
             }
-            windowState.mcpServer.installTabContext(
+            let replacementToken = windowState.mcpServer.installTabContext(
                 clientID: clientID,
                 clientName: clientName,
                 windowID: windowID,
                 workspaceID: resolved.workspaceID,
                 snapshot: resolved.snapshot,
                 runID: runID,
-                signalRouting: signalRouting
+                signalRouting: signalRouting,
+                deferRunIDReplacementForPendingPolicy: true
             )
-            let routed = UUID(uuidString: clientID).map { connectionID in
-                windowState.mcpServer.connectionID(forRunID: runID) == connectionID
-            } ?? false
-            return (resolved.workspaceID, resolved.snapshot, routed)
+            let routed = replacementToken != nil
+            return (resolved.workspaceID, resolved.snapshot, routed, replacementToken)
         }
 
         guard let resolved else {
             log.warning("installTabContextFromPolicy: tab \(tabID) could not resolve routing snapshot in window \(windowID)")
-            return false
+            return (false, nil)
         }
 
         if resolved.routed, let cached = runPolicyStateByRunID[runID] {
@@ -7398,7 +7624,7 @@ actor ServerNetworkManager {
             )
         }
         connectionLog("Installed tab context from policy: tab=\(tabID) run=\(runID) window=\(windowID) workspace=\(resolved.workspaceID) client=\(clientName)")
-        return resolved.routed
+        return (resolved.routed, resolved.replacementToken)
     }
 
     @discardableResult

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+TabContext.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+TabContext.swift
@@ -11,6 +11,25 @@ import MCP
 #endif
 
 extension MCPServerViewModel {
+    struct PendingPolicyRunIDMappingToken {
+        let id: UUID
+        let connectionID: UUID
+        let runID: UUID
+        let displacedConnectionID: UUID?
+        let displacedConnectionRunID: UUID?
+        let displacedPendingPolicyTokenID: UUID?
+        let previousRunID: UUID?
+        let previousRunPrimaryConnectionID: UUID?
+        let previousPendingPolicyTokenID: UUID?
+        let previousWindowID: Int?
+    }
+
+    enum PendingPolicyRunIDMappingRollbackResult: Equatable {
+        case restored
+        case supersededBySameConnection
+        case supersededByOtherConnection
+    }
+
     /// Value snapshot of a compose tab plus MCP routing metadata.
     ///
     /// This is the tab-first runtime model for MCP/Agent work. It intentionally
@@ -897,6 +916,7 @@ extension MCPServerViewModel {
     }
 
     @MainActor
+    @discardableResult
     func installTabContext(
         clientID: String?,
         clientName: String?,
@@ -904,8 +924,9 @@ extension MCPServerViewModel {
         workspaceID providedWorkspaceID: UUID? = nil,
         snapshot: ComposeTabState,
         runID: UUID? = nil,
-        signalRouting: Bool = true
-    ) {
+        signalRouting: Bool = true,
+        deferRunIDReplacementForPendingPolicy: Bool = false
+    ) -> PendingPolicyRunIDMappingToken? {
         tabContextLog("installTabContext tab=\(snapshot.id) window=\(windowID) clientID=\(clientID ?? "nil") clientName=\(clientName ?? "nil") runID=\(runID?.uuidString ?? "nil")")
         let resolvedWorkspaceID: UUID? = {
             if let providedWorkspaceID {
@@ -940,7 +961,11 @@ extension MCPServerViewModel {
                 } else {
                     tabContextLog("[warning] installTabContext conflict but no clientName provided; cannot queue")
                 }
-                return
+                return nil
+            }
+            if deferRunIDReplacementForPendingPolicy, tabContextByConnectionID[uuid] != nil {
+                tabContextLog("installTabContext declined pending-policy overwrite of existing context connectionID=\(uuid)")
+                return nil
             }
 
             tabContextLog("installTabContext immediate bind connectionID=\(uuid)")
@@ -951,13 +976,22 @@ extension MCPServerViewModel {
             activateReadFileAutoSelection(&context)
             tabContextByConnectionID[uuid] = context
             windowIDByConnection[uuid] = context.windowID
+            var pendingPolicyToken: PendingPolicyRunIDMappingToken?
             if let runID = context.runID {
-                _ = registerRunIDMapping(
-                    connectionID: uuid,
-                    runID: runID,
-                    windowID: context.windowID,
-                    signalRouting: signalRouting
-                )
+                if deferRunIDReplacementForPendingPolicy {
+                    pendingPolicyToken = registerPendingPolicyRunIDMapping(
+                        connectionID: uuid,
+                        runID: runID,
+                        windowID: context.windowID
+                    )
+                } else {
+                    _ = registerRunIDMapping(
+                        connectionID: uuid,
+                        runID: runID,
+                        windowID: context.windowID,
+                        signalRouting: signalRouting
+                    )
+                }
                 // Consume any queued intent for this exact run after direct installation.
                 if let clientName {
                     let popped = pendingRunScopedTabContexts.popByRunID(clientName: clientName, runID: runID)
@@ -970,15 +1004,16 @@ extension MCPServerViewModel {
                 recordLastContext(clientName: clientName, context: context)
             }
             beginMirroringForConnection(uuid, context: context)
-            return
+            return pendingPolicyToken
         }
 
         guard let clientName else {
             tabContextLog("[warning] installTabContext missing client identifier; context cannot be queued.")
-            return
+            return nil
         }
 
         enqueuePendingContext(context, clientName: clientName, windowID: windowID)
+        return nil
     }
 
     @MainActor
@@ -1914,6 +1949,7 @@ extension MCPServerViewModel {
     ) {
         if connectionIDByRunID[runID] == connectionID {
             connectionIDByRunID.removeValue(forKey: runID)
+            pendingPolicyRunIDMappingTokenIDByRunID.removeValue(forKey: runID)
         }
         if connectionIDToRunID[connectionID] == runID {
             connectionIDToRunID.removeValue(forKey: connectionID)
@@ -1938,6 +1974,7 @@ extension MCPServerViewModel {
         if connectionIDByRunID[runID] == connectionID,
            connectionIDToRunID[connectionID] == runID
         {
+            pendingPolicyRunIDMappingTokenIDByRunID.removeValue(forKey: runID)
             windowIDByConnection[connectionID] = windowID
             if signalRouting {
                 MCPRoutingWaiter.signalRouted(runID)
@@ -1982,6 +2019,7 @@ extension MCPServerViewModel {
         windowIDByConnection[connectionID] = windowID
         connectionIDByRunID[runID] = connectionID
         connectionIDToRunID[connectionID] = runID
+        pendingPolicyRunIDMappingTokenIDByRunID.removeValue(forKey: runID)
         tabContextLog("registerRunIDMapping connectionID=\(connectionID) runID=\(runID) windowID=\(windowID)")
 
         if signalRouting {
@@ -1989,6 +2027,155 @@ extension MCPServerViewModel {
         }
 
         return true
+    }
+
+    @MainActor
+    func registerPendingPolicyRunIDMapping(
+        connectionID: UUID,
+        runID: UUID,
+        windowID: Int
+    ) -> PendingPolicyRunIDMappingToken? {
+        if let bound = tabContextByConnectionID[connectionID],
+           let boundRun = bound.runID,
+           boundRun != runID
+        {
+            tabContextLog("registerPendingPolicyRunIDMapping refused: connectionID=\(connectionID) already bound to runID=\(boundRun), new=\(runID)")
+            return nil
+        }
+
+        let displacedConnectionID = connectionIDByRunID[runID]
+        if let displacedConnectionID,
+           displacedConnectionID != connectionID,
+           let existingWindow = windowIDByConnection[displacedConnectionID],
+           existingWindow != windowID
+        {
+            tabContextLog("registerPendingPolicyRunIDMapping refused window mismatch runID=\(runID) existingWindow=\(existingWindow) newWindow=\(windowID)")
+            return nil
+        }
+
+        let previousRunID = connectionIDToRunID[connectionID]
+        let token = PendingPolicyRunIDMappingToken(
+            id: UUID(),
+            connectionID: connectionID,
+            runID: runID,
+            displacedConnectionID: displacedConnectionID == connectionID ? nil : displacedConnectionID,
+            displacedConnectionRunID: displacedConnectionID.flatMap { connectionIDToRunID[$0] },
+            displacedPendingPolicyTokenID: pendingPolicyRunIDMappingTokenIDByRunID[runID],
+            previousRunID: previousRunID,
+            previousRunPrimaryConnectionID: previousRunID.flatMap { connectionIDByRunID[$0] },
+            previousPendingPolicyTokenID: previousRunID.flatMap { pendingPolicyRunIDMappingTokenIDByRunID[$0] },
+            previousWindowID: windowIDByConnection[connectionID]
+        )
+
+        if let displacedConnectionID = token.displacedConnectionID,
+           connectionIDToRunID[displacedConnectionID] == runID
+        {
+            connectionIDToRunID.removeValue(forKey: displacedConnectionID)
+        }
+        if let previousRunID, previousRunID != runID,
+           connectionIDByRunID[previousRunID] == connectionID
+        {
+            connectionIDByRunID.removeValue(forKey: previousRunID)
+            pendingPolicyRunIDMappingTokenIDByRunID.removeValue(forKey: previousRunID)
+        }
+        windowIDByConnection[connectionID] = windowID
+        connectionIDByRunID[runID] = connectionID
+        connectionIDToRunID[connectionID] = runID
+        pendingPolicyRunIDMappingTokenIDByRunID[runID] = token.id
+        tabContextLog("registerPendingPolicyRunIDMapping connectionID=\(connectionID) runID=\(runID) windowID=\(windowID)")
+        return token
+    }
+
+    @MainActor
+    func isCurrentPendingPolicyRunIDMapping(_ token: PendingPolicyRunIDMappingToken) -> Bool {
+        pendingPolicyRunIDMappingTokenIDByRunID[token.runID] == token.id
+            && connectionIDByRunID[token.runID] == token.connectionID
+            && connectionIDToRunID[token.connectionID] == token.runID
+    }
+
+    @MainActor
+    func rollbackPendingPolicyRunIDMapping(
+        _ token: PendingPolicyRunIDMappingToken,
+        clientName: String?,
+        windowID: Int?,
+        signalRoutingFailure: Bool
+    ) -> PendingPolicyRunIDMappingRollbackResult {
+        guard isCurrentPendingPolicyRunIDMapping(token) else {
+            let supersededBySameConnection = connectionIDByRunID[token.runID] == token.connectionID
+            if connectionIDToRunID[token.connectionID] != token.runID {
+                removeTabContext(
+                    forConnectionID: token.connectionID,
+                    clientName: clientName,
+                    windowID: windowID,
+                    runID: token.runID,
+                    removeQueuedPendingContext: false
+                )
+            }
+            if signalRoutingFailure, liveConnectionID(forRunID: token.runID) == nil {
+                MCPRoutingWaiter.signalFailed(token.runID)
+            }
+            return supersededBySameConnection
+                ? .supersededBySameConnection
+                : .supersededByOtherConnection
+        }
+
+        pendingPolicyRunIDMappingTokenIDByRunID.removeValue(forKey: token.runID)
+        removeTabContext(
+            forConnectionID: token.connectionID,
+            clientName: clientName,
+            windowID: windowID,
+            runID: token.runID,
+            removeQueuedPendingContext: false
+        )
+        if connectionIDByRunID[token.runID] == token.connectionID {
+            connectionIDByRunID.removeValue(forKey: token.runID)
+        }
+        if connectionIDToRunID[token.connectionID] == token.runID {
+            connectionIDToRunID.removeValue(forKey: token.connectionID)
+        }
+
+        if let displacedConnectionID = token.displacedConnectionID,
+           token.displacedPendingPolicyTokenID == nil,
+           token.displacedConnectionRunID == token.runID,
+           connectionIDByRunID[token.runID] == nil,
+           connectionIDToRunID[displacedConnectionID] == nil
+        {
+            connectionIDByRunID[token.runID] = displacedConnectionID
+            connectionIDToRunID[displacedConnectionID] = token.runID
+        } else if token.displacedConnectionID == nil {
+            connectionIDByRunID.removeValue(forKey: token.runID)
+        }
+
+        if let previousRunID = token.previousRunID,
+           token.previousPendingPolicyTokenID == nil
+        {
+            let currentPrimaryConnectionID = connectionIDByRunID[previousRunID]
+            let previousPrimaryIsUnchanged = currentPrimaryConnectionID == token.previousRunPrimaryConnectionID
+            let canRestorePreviousPrimary = token.previousRunPrimaryConnectionID == token.connectionID
+                && currentPrimaryConnectionID == nil
+            if previousPrimaryIsUnchanged || canRestorePreviousPrimary {
+                connectionIDToRunID[token.connectionID] = previousRunID
+                if canRestorePreviousPrimary {
+                    connectionIDByRunID[previousRunID] = token.connectionID
+                }
+            }
+        } else {
+            connectionIDToRunID.removeValue(forKey: token.connectionID)
+        }
+
+        let restoredPreviousRun = token.previousRunID.map {
+            connectionIDToRunID[token.connectionID] == $0
+        } ?? true
+        if restoredPreviousRun, let previousWindowID = token.previousWindowID {
+            windowIDByConnection[token.connectionID] = previousWindowID
+        } else {
+            windowIDByConnection.removeValue(forKey: token.connectionID)
+        }
+
+        if signalRoutingFailure, liveConnectionID(forRunID: token.runID) == nil {
+            MCPRoutingWaiter.signalFailed(token.runID)
+        }
+        return .restored
     }
 
     @MainActor
@@ -2166,7 +2353,8 @@ extension MCPServerViewModel {
         forConnectionID connectionID: UUID?,
         clientName: String?,
         windowID: Int?,
-        runID: UUID? = nil
+        runID: UUID? = nil,
+        removeQueuedPendingContext: Bool = true
     ) {
         if let connectionID,
            let context = tabContextByConnectionID[connectionID]
@@ -2181,6 +2369,7 @@ extension MCPServerViewModel {
                    connectionIDByRunID[boundRunID] == connectionID
                 {
                     connectionIDByRunID.removeValue(forKey: boundRunID)
+                    pendingPolicyRunIDMappingTokenIDByRunID.removeValue(forKey: boundRunID)
                 }
                 if connectionIDToRunID[connectionID] == context.runID {
                     connectionIDToRunID.removeValue(forKey: connectionID)
@@ -2197,10 +2386,12 @@ extension MCPServerViewModel {
                 windowIDByConnection.removeValue(forKey: mappedConnection)
             }
             connectionIDByRunID.removeValue(forKey: runID)
+            pendingPolicyRunIDMappingTokenIDByRunID.removeValue(forKey: runID)
         }
 
-        // CHANGE: only remove pending contexts when a specific runID is provided
-        if let clientName, let runID {
+        // Only explicit run cleanup owns queued intent. Mapping rollback must not
+        // consume a newer pending context for the same client/run generation.
+        if removeQueuedPendingContext, let clientName, let runID {
             removePendingContext(clientName: clientName, windowID: windowID, runID: runID)
         }
     }

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel.swift
@@ -897,6 +897,8 @@ final class MCPServerViewModel: ObservableObject {
     @MainActor
     var connectionIDToRunID: [UUID: UUID] = [:]
     @MainActor
+    var pendingPolicyRunIDMappingTokenIDByRunID: [UUID: UUID] = [:]
+    @MainActor
     var windowIDByConnection: [UUID: Int] = [:]
     @MainActor
     var tabContextCancellablesByConnectionID: [UUID: Set<AnyCancellable>] = [:]

--- a/Tests/RepoPromptTests/AgentMode/ACPAgentSessionControllerModeConfigTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/ACPAgentSessionControllerModeConfigTests.swift
@@ -389,6 +389,34 @@ final class ACPAgentSessionControllerModeConfigTests: XCTestCase {
         XCTAssertEqual(mutation.params["value"] as? String, "model-b")
     }
 
+    func testCursorAutoWithoutModernModelSelectorUsesProviderDefault() async throws {
+        let fixture = try makeFixture(shape: "none", providerID: .cursor)
+
+        try await withBootstrappedController(fixture.controller) { controller in
+            try await controller.setSessionModel(AgentModel.cursorAuto.rawValue)
+        }
+
+        XCTAssertTrue(recordedMutationRequests(at: fixture.recordURL).isEmpty)
+    }
+
+    func testCursorAutoWithMalformedModernModelSelectorFailsWithoutMutation() async throws {
+        let fixture = try makeFixture(
+            shape: "modern",
+            extraEnvironment: [
+                "ACP_INCLUDE_MODEL": "1",
+                "ACP_MALFORMED_MODEL": "1"
+            ],
+            providerID: .cursor
+        )
+        _ = try await fixture.controller.bootstrap()
+        await assertThrows(containing: "malformed modern model config option") {
+            try await fixture.controller.setSessionModel(AgentModel.cursorAuto.rawValue)
+        }
+        await fixture.controller.shutdown()
+
+        XCTAssertTrue(recordedMutationRequests(at: fixture.recordURL).isEmpty)
+    }
+
     func testLegacyOnlyModelAdvertisementIsIgnored() async throws {
         AgentACPModelRegistry.shared.test_reset(providerID: .openCode)
         addTeardownBlock {
@@ -854,7 +882,8 @@ final class ACPAgentSessionControllerModeConfigTests: XCTestCase {
         launchArguments: [String] = [],
         mcpServers: [RepoPromptMCPServerConfiguration] = [],
         diagnostics: LockedStrings? = nil,
-        normalizedUpdates: LockedStrings? = nil
+        normalizedUpdates: LockedStrings? = nil,
+        providerID: ACPProviderID = .openCode
     ) throws -> Fixture {
         let workspace = try makeTemporaryDirectory()
         let scriptURL = try makeFakeACPServerScript()
@@ -863,7 +892,7 @@ final class ACPAgentSessionControllerModeConfigTests: XCTestCase {
         environment["ACP_RECORD_PATH"] = recordURL.path
         environment["ACP_SHAPE"] = shape
         let request = ACPRunRequest(
-            agentKind: .openCode,
+            agentKind: providerID == .cursor ? .cursor : .openCode,
             modelString: modelString,
             workspacePath: workspace.path,
             resumeSessionID: resumeSessionID,
@@ -875,6 +904,7 @@ final class ACPAgentSessionControllerModeConfigTests: XCTestCase {
             launchArguments: launchArguments,
             environment: environment,
             mcpServers: mcpServers,
+            providerID: providerID,
             normalizedUpdates: normalizedUpdates
         )
         let controller = try ACPAgentSessionController(

--- a/Tests/RepoPromptTests/MCP/Control/MCPAgentPolicyAdmissionRaceTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/MCPAgentPolicyAdmissionRaceTests.swift
@@ -507,26 +507,24 @@ final class MCPAgentPolicyAdmissionRaceTests: XCTestCase {
     }
 
     @MainActor
-    func testStaleConnectionAfterRouteInstallRollsBackWithoutConsumingOrFailingRun() async throws {
+    func testStaleReplacementAdmissionRestoresDisplacedConnectionWithoutSchedulingReplacement() async throws {
         #if DEBUG
             let window = makeWindow()
             defer { WindowStatesManager.shared.unregisterWindowState(window) }
             let runID = UUID()
+            let displacedConnectionID = UUID()
             let staleConnectionID = UUID()
-            let retryConnectionID = UUID()
             let windowID = window.windowID
+            await manager.debugClearPendingPolicyReplacementSchedules()
+            let didRegisterDisplacedConnection = window.mcpServer.registerRunIDMapping(
+                connectionID: displacedConnectionID,
+                runID: runID,
+                windowID: windowID,
+                signalRouting: false
+            )
+            XCTAssertTrue(didRegisterDisplacedConnection)
             await installPolicy(runID: runID, windowID: windowID)
             await manager.registerExpectedAgentPID(getpid(), for: clientName, runID: runID)
-            await MCPRoutingWaiter.cleanup(runID: runID)
-            await MCPRoutingWaiter.register(runID: runID)
-
-            let routeWaiter = Task {
-                await MCPRoutingWaiter.waitUntilRouted(runID: runID, timeoutSeconds: 5)
-            }
-            let didRegisterRouteWaiter = await waitUntil {
-                await MCPRoutingWaiter.debugContinuationCount(runID: runID) == 1
-            }
-            XCTAssertTrue(didRegisterRouteWaiter)
 
             await manager.debugSuspendNextPendingPolicyCommit()
             let staleApplication = Task {
@@ -543,10 +541,15 @@ final class MCPAgentPolicyAdmissionRaceTests: XCTestCase {
                 await self.manager.debugIsPendingPolicyCommitSuspended()
             }
             XCTAssertTrue(didSuspendCommit)
-            let mappedBeforeInvalidation = await MainActor.run {
-                window.mcpServer.connectionID(forRunID: runID)
-            }
+            let mappedBeforeInvalidation = window.mcpServer.connectionID(forRunID: runID)
+            let replacementSchedulesBeforeInvalidation = await manager
+                .debugPendingPolicyReplacementScheduleCount(
+                    existing: displacedConnectionID,
+                    replacement: staleConnectionID,
+                    runID: runID
+                )
             XCTAssertEqual(mappedBeforeInvalidation, staleConnectionID)
+            XCTAssertEqual(replacementSchedulesBeforeInvalidation, 0)
 
             await manager.debugInvalidatePendingPolicyApplication(connectionID: staleConnectionID)
             await manager.debugResumePendingPolicyCommit()
@@ -554,36 +557,412 @@ final class MCPAgentPolicyAdmissionRaceTests: XCTestCase {
             XCTAssertEqual(staleResult.outcome, "rejected:stale_connection")
 
             let pendingAfterRollback = await manager.debugPendingPolicySnapshot(for: clientName)
-            let mappedAfterRollback = await MainActor.run {
-                window.mcpServer.connectionID(forRunID: runID)
-            }
-            let waiterCountAfterRollback = await MCPRoutingWaiter.debugContinuationCount(runID: runID)
+            let mappedAfterRollback = window.mcpServer.connectionID(forRunID: runID)
+            let replacementSchedulesAfterRollback = await manager
+                .debugPendingPolicyReplacementScheduleCount(
+                    existing: displacedConnectionID,
+                    replacement: staleConnectionID,
+                    runID: runID
+                )
             XCTAssertTrue(pendingAfterRollback.contains { $0.runID == runID })
-            XCTAssertNil(mappedAfterRollback)
-            XCTAssertEqual(waiterCountAfterRollback, 1)
+            XCTAssertEqual(mappedAfterRollback, displacedConnectionID)
+            XCTAssertEqual(window.mcpServer.connectionIDToRunID[displacedConnectionID], runID)
+            XCTAssertNil(window.mcpServer.connectionIDToRunID[staleConnectionID])
+            XCTAssertEqual(replacementSchedulesAfterRollback, 0)
 
-            let retryResult = await manager.debugApplyPendingPolicy(
+            await cleanup(
+                runID: runID,
+                connectionID: staleConnectionID,
+                windowID: windowID,
+                expectedPID: getpid()
+            )
+            await manager.debugClearPendingPolicyReplacementSchedules()
+        #else
+            throw XCTSkip("Pending policy commit diagnostics require DEBUG helpers.")
+        #endif
+    }
+
+    @MainActor
+    func testSuccessfulReplacementAdmissionSchedulesDisplacedConnectionExactlyOnce() async throws {
+        #if DEBUG
+            let window = makeWindow()
+            defer { WindowStatesManager.shared.unregisterWindowState(window) }
+            let runID = UUID()
+            let displacedConnectionID = UUID()
+            let replacementConnectionID = UUID()
+            let windowID = window.windowID
+            await manager.debugClearPendingPolicyReplacementSchedules()
+            let didRegisterDisplacedConnection = window.mcpServer.registerRunIDMapping(
+                connectionID: displacedConnectionID,
+                runID: runID,
+                windowID: windowID,
+                signalRouting: false
+            )
+            XCTAssertTrue(didRegisterDisplacedConnection)
+            await installPolicy(runID: runID, windowID: windowID)
+            await manager.registerExpectedAgentPID(getpid(), for: clientName, runID: runID)
+
+            let result = await manager.debugApplyPendingPolicy(
                 clientName: clientName,
-                connectionID: retryConnectionID,
+                connectionID: replacementConnectionID,
                 clientPid: Int(getpid()),
                 bootstrapClientName: "repoprompt_ce_cli_debug",
                 pidGateTimeout: 0.25,
                 requireRunRouting: true
             )
-            let didRoute = await routeWaiter.value
-            XCTAssertEqual(retryResult.outcome, "applied")
-            XCTAssertTrue(didRoute)
 
-            await manager.removeConnection(staleConnectionID)
+            let replacementScheduleCount = await manager.debugPendingPolicyReplacementScheduleCount(
+                existing: displacedConnectionID,
+                replacement: replacementConnectionID,
+                runID: runID
+            )
+            let pendingAfterCommit = await manager.debugPendingPolicySnapshot(for: clientName)
+            XCTAssertEqual(result.outcome, "applied")
+            XCTAssertEqual(window.mcpServer.connectionID(forRunID: runID), replacementConnectionID)
+            XCTAssertEqual(window.mcpServer.connectionIDToRunID[replacementConnectionID], runID)
+            XCTAssertNil(window.mcpServer.connectionIDToRunID[displacedConnectionID])
+            XCTAssertEqual(replacementScheduleCount, 1)
+            XCTAssertFalse(pendingAfterCommit.contains { $0.runID == runID })
+
             await cleanup(
                 runID: runID,
-                connectionID: retryConnectionID,
+                connectionID: replacementConnectionID,
                 windowID: windowID,
                 expectedPID: getpid()
             )
-            await MCPRoutingWaiter.cleanup(runID: runID)
+            await manager.debugClearPendingPolicyReplacementSchedules()
         #else
-            throw XCTSkip("Pending policy commit diagnostics require DEBUG helpers.")
+            throw XCTSkip("Pending policy replacement diagnostics require DEBUG helpers.")
+        #endif
+    }
+
+    @MainActor
+    func testSupersededStaleReplacementRollbackDoesNotOverwriteNewerOwner() async throws {
+        #if DEBUG
+            let window = makeWindow()
+            defer { WindowStatesManager.shared.unregisterWindowState(window) }
+            let runID = UUID()
+            let displacedConnectionID = UUID()
+            let staleConnectionID = UUID()
+            let newerConnectionID = UUID()
+            let windowID = window.windowID
+            await manager.debugClearPendingPolicyReplacementSchedules()
+            XCTAssertTrue(window.mcpServer.registerRunIDMapping(
+                connectionID: displacedConnectionID,
+                runID: runID,
+                windowID: windowID,
+                signalRouting: false
+            ))
+            await installPolicy(runID: runID, windowID: windowID)
+            await manager.registerExpectedAgentPID(getpid(), for: clientName, runID: runID)
+            await manager.debugSuspendNextPendingPolicyCommit()
+
+            let staleApplication = Task {
+                await manager.debugApplyPendingPolicy(
+                    clientName: clientName,
+                    connectionID: staleConnectionID,
+                    clientPid: Int(getpid()),
+                    bootstrapClientName: "repoprompt_ce_cli_debug",
+                    pidGateTimeout: 0.25,
+                    requireRunRouting: true
+                )
+            }
+            let didSuspendCommit = await waitUntil {
+                await self.manager.debugIsPendingPolicyCommitSuspended()
+            }
+            XCTAssertTrue(didSuspendCommit)
+            XCTAssertEqual(window.mcpServer.connectionID(forRunID: runID), staleConnectionID)
+            XCTAssertTrue(window.mcpServer.registerRunIDMapping(
+                connectionID: newerConnectionID,
+                runID: runID,
+                windowID: windowID,
+                signalRouting: false
+            ))
+
+            await manager.debugInvalidatePendingPolicyApplication(connectionID: staleConnectionID)
+            await manager.debugResumePendingPolicyCommit()
+            let staleResult = await staleApplication.value
+            let pendingAfterRollback = await manager.debugPendingPolicySnapshot(for: clientName)
+            let staleCachedRunID = await manager.debugCachedRunID(for: staleConnectionID)
+            let retainedRunPolicy = await manager.debugRunPolicyState(for: runID)
+            let deferredReplacementScheduleCount = await manager
+                .debugPendingPolicyReplacementScheduleCount(
+                    existing: displacedConnectionID,
+                    replacement: staleConnectionID,
+                    runID: runID
+                )
+
+            XCTAssertEqual(staleResult.outcome, "rejected:stale_connection")
+            XCTAssertTrue(pendingAfterRollback.contains { $0.runID == runID })
+            XCTAssertEqual(window.mcpServer.connectionID(forRunID: runID), newerConnectionID)
+            XCTAssertEqual(window.mcpServer.connectionIDToRunID[newerConnectionID], runID)
+            XCTAssertNil(window.mcpServer.connectionIDToRunID[displacedConnectionID])
+            XCTAssertNil(window.mcpServer.connectionIDToRunID[staleConnectionID])
+            XCTAssertNil(staleCachedRunID)
+            XCTAssertNotNil(retainedRunPolicy)
+            XCTAssertEqual(deferredReplacementScheduleCount, 0)
+
+            await cleanup(
+                runID: runID,
+                connectionID: staleConnectionID,
+                windowID: windowID,
+                expectedPID: getpid()
+            )
+            await manager.debugClearPendingPolicyReplacementSchedules()
+        #else
+            throw XCTSkip("Pending policy replacement diagnostics require DEBUG helpers.")
+        #endif
+    }
+
+    @MainActor
+    func testStaleReplacementRollbackDoesNotUndoNewerSameConnectionGeneration() async throws {
+        #if DEBUG
+            let window = makeWindow()
+            defer { WindowStatesManager.shared.unregisterWindowState(window) }
+            let runID = UUID()
+            let displacedConnectionID = UUID()
+            let replacementConnectionID = UUID()
+            let windowID = window.windowID
+            await manager.debugClearPendingPolicyReplacementSchedules()
+            XCTAssertTrue(window.mcpServer.registerRunIDMapping(
+                connectionID: displacedConnectionID,
+                runID: runID,
+                windowID: windowID,
+                signalRouting: false
+            ))
+            await installPolicy(runID: runID, windowID: windowID)
+            await manager.registerExpectedAgentPID(getpid(), for: clientName, runID: runID)
+            await manager.debugSuspendNextPendingPolicyCommit()
+
+            let staleApplication = Task {
+                await manager.debugApplyPendingPolicy(
+                    clientName: clientName,
+                    connectionID: replacementConnectionID,
+                    clientPid: Int(getpid()),
+                    bootstrapClientName: "repoprompt_ce_cli_debug",
+                    pidGateTimeout: 0.25,
+                    requireRunRouting: true
+                )
+            }
+            let didSuspendCommit = await waitUntil {
+                await self.manager.debugIsPendingPolicyCommitSuspended()
+            }
+            XCTAssertTrue(didSuspendCommit)
+            XCTAssertEqual(window.mcpServer.connectionID(forRunID: runID), replacementConnectionID)
+
+            let newerToken = try XCTUnwrap(window.mcpServer.registerPendingPolicyRunIDMapping(
+                connectionID: replacementConnectionID,
+                runID: runID,
+                windowID: windowID
+            ))
+            XCTAssertTrue(window.mcpServer.isCurrentPendingPolicyRunIDMapping(newerToken))
+
+            await manager.debugInvalidatePendingPolicyApplication(connectionID: replacementConnectionID)
+            await manager.debugResumePendingPolicyCommit()
+            let staleResult = await staleApplication.value
+            let cachedRunID = await manager.debugCachedRunID(for: replacementConnectionID)
+            let retainedRunPolicy = await manager.debugRunPolicyState(for: runID)
+
+            XCTAssertEqual(staleResult.outcome, "rejected:stale_connection")
+            XCTAssertEqual(window.mcpServer.connectionID(forRunID: runID), replacementConnectionID)
+            XCTAssertEqual(window.mcpServer.connectionIDToRunID[replacementConnectionID], runID)
+            XCTAssertTrue(window.mcpServer.isCurrentPendingPolicyRunIDMapping(newerToken))
+            XCTAssertEqual(cachedRunID, runID)
+            XCTAssertNotNil(retainedRunPolicy)
+
+            await cleanup(
+                runID: runID,
+                connectionID: replacementConnectionID,
+                windowID: windowID,
+                expectedPID: getpid()
+            )
+            await manager.debugClearPendingPolicyReplacementSchedules()
+        #else
+            throw XCTSkip("Pending policy replacement diagnostics require DEBUG helpers.")
+        #endif
+    }
+
+    @MainActor
+    func testSupersededPendingPolicyApplicationOwnershipCannotCommitCurrentRouteToken() async throws {
+        #if DEBUG
+            let window = makeWindow()
+            defer { WindowStatesManager.shared.unregisterWindowState(window) }
+            let runID = UUID()
+            let connectionID = UUID()
+            let windowID = window.windowID
+            await installPolicy(runID: runID, windowID: windowID)
+            await manager.registerExpectedAgentPID(getpid(), for: clientName, runID: runID)
+            await manager.debugSuspendNextPendingPolicyCommit()
+
+            let application = Task {
+                await manager.debugApplyPendingPolicy(
+                    clientName: clientName,
+                    connectionID: connectionID,
+                    clientPid: Int(getpid()),
+                    bootstrapClientName: "repoprompt_ce_cli_debug",
+                    pidGateTimeout: 0.25,
+                    requireRunRouting: true
+                )
+            }
+            let didSuspendCommit = await waitUntil {
+                await self.manager.debugIsPendingPolicyCommitSuspended()
+            }
+            XCTAssertTrue(didSuspendCommit)
+            XCTAssertEqual(window.mcpServer.connectionID(forRunID: runID), connectionID)
+
+            await manager.debugSupersedePendingPolicyApplicationOwnership(
+                connectionID: connectionID,
+                runID: runID
+            )
+            await manager.debugResumePendingPolicyCommit()
+            let result = await application.value
+            let pendingAfterRollback = await manager.debugPendingPolicySnapshot(for: clientName)
+
+            XCTAssertEqual(result.outcome, "rejected:stale_connection")
+            XCTAssertTrue(pendingAfterRollback.contains { $0.runID == runID })
+            XCTAssertNil(window.mcpServer.connectionID(forRunID: runID))
+
+            await cleanup(
+                runID: runID,
+                connectionID: connectionID,
+                windowID: windowID,
+                expectedPID: getpid()
+            )
+        #else
+            throw XCTSkip("Pending policy replacement diagnostics require DEBUG helpers.")
+        #endif
+    }
+
+    @MainActor
+    func testSupersededPendingTokenDoesNotBecomeCurrentAgainAfterNestedRollback() throws {
+        #if DEBUG
+            let window = makeWindow()
+            defer { WindowStatesManager.shared.unregisterWindowState(window) }
+            let firstRunID = UUID()
+            let secondRunID = UUID()
+            let connectionID = UUID()
+            let windowID = window.windowID
+            let firstToken = try XCTUnwrap(window.mcpServer.registerPendingPolicyRunIDMapping(
+                connectionID: connectionID,
+                runID: firstRunID,
+                windowID: windowID
+            ))
+            let secondToken = try XCTUnwrap(window.mcpServer.registerPendingPolicyRunIDMapping(
+                connectionID: connectionID,
+                runID: secondRunID,
+                windowID: windowID
+            ))
+            XCTAssertFalse(window.mcpServer.isCurrentPendingPolicyRunIDMapping(firstToken))
+            XCTAssertTrue(window.mcpServer.isCurrentPendingPolicyRunIDMapping(secondToken))
+
+            let rollbackResult = window.mcpServer.rollbackPendingPolicyRunIDMapping(
+                secondToken,
+                clientName: clientName,
+                windowID: windowID,
+                signalRoutingFailure: false
+            )
+
+            XCTAssertEqual(rollbackResult, .restored)
+            XCTAssertNil(window.mcpServer.connectionID(forRunID: firstRunID))
+            XCTAssertNil(window.mcpServer.connectionIDToRunID[connectionID])
+            XCTAssertFalse(window.mcpServer.isCurrentPendingPolicyRunIDMapping(firstToken))
+        #else
+            throw XCTSkip("Pending policy replacement diagnostics require DEBUG helpers.")
+        #endif
+    }
+
+    @MainActor
+    func testPendingPolicyRollbackPreservesNewerQueuedContext() throws {
+        #if DEBUG
+            let window = makeWindow()
+            defer { WindowStatesManager.shared.unregisterWindowState(window) }
+            let runID = UUID()
+            let connectionID = UUID()
+            let windowID = window.windowID
+            let token = try XCTUnwrap(window.mcpServer.registerPendingPolicyRunIDMapping(
+                connectionID: connectionID,
+                runID: runID,
+                windowID: windowID
+            ))
+
+            window.mcpServer.installTabContext(
+                clientID: nil,
+                clientName: clientName,
+                windowID: windowID,
+                workspaceID: nil,
+                snapshot: ComposeTabState(),
+                runID: runID,
+                signalRouting: false
+            )
+            XCTAssertEqual(window.mcpServer.pendingContextQueueLength(clientName: clientName, windowID: windowID), 1)
+
+            let rollbackResult = window.mcpServer.rollbackPendingPolicyRunIDMapping(
+                token,
+                clientName: clientName,
+                windowID: windowID,
+                signalRoutingFailure: false
+            )
+
+            XCTAssertEqual(rollbackResult, .restored)
+            XCTAssertEqual(window.mcpServer.pendingContextQueueLength(clientName: clientName, windowID: windowID), 1)
+            window.mcpServer.removeTabContext(
+                forConnectionID: nil,
+                clientName: clientName,
+                windowID: windowID,
+                runID: runID
+            )
+        #else
+            throw XCTSkip("Pending policy replacement diagnostics require DEBUG helpers.")
+        #endif
+    }
+
+    @MainActor
+    func testPendingPolicyRollbackDoesNotRestorePreviousRunAfterPrimaryGenerationChanges() throws {
+        #if DEBUG
+            let window = makeWindow()
+            defer { WindowStatesManager.shared.unregisterWindowState(window) }
+            let previousRunID = UUID()
+            let pendingRunID = UUID()
+            let connectionID = UUID()
+            let newerPrimaryConnectionID = UUID()
+            let windowID = window.windowID
+            XCTAssertTrue(window.mcpServer.registerRunIDMapping(
+                connectionID: connectionID,
+                runID: previousRunID,
+                windowID: windowID,
+                signalRouting: false
+            ))
+            let token = try XCTUnwrap(window.mcpServer.registerPendingPolicyRunIDMapping(
+                connectionID: connectionID,
+                runID: pendingRunID,
+                windowID: windowID
+            ))
+            XCTAssertTrue(window.mcpServer.registerRunIDMapping(
+                connectionID: newerPrimaryConnectionID,
+                runID: previousRunID,
+                windowID: windowID,
+                signalRouting: false
+            ))
+
+            let rollbackResult = window.mcpServer.rollbackPendingPolicyRunIDMapping(
+                token,
+                clientName: clientName,
+                windowID: windowID,
+                signalRoutingFailure: false
+            )
+
+            XCTAssertEqual(rollbackResult, .restored)
+            XCTAssertNil(window.mcpServer.connectionID(forRunID: pendingRunID))
+            XCTAssertEqual(window.mcpServer.connectionID(forRunID: previousRunID), newerPrimaryConnectionID)
+            XCTAssertEqual(window.mcpServer.connectionIDToRunID[newerPrimaryConnectionID], previousRunID)
+            XCTAssertNil(window.mcpServer.connectionIDToRunID[connectionID])
+            window.mcpServer.cleanupRunIDMapping(
+                runID: previousRunID,
+                connectionID: newerPrimaryConnectionID,
+                signalRoutingFailure: false
+            )
+        #else
+            throw XCTSkip("Pending policy replacement diagnostics require DEBUG helpers.")
         #endif
     }
 


### PR DESCRIPTION
## Summary
- preserve displaced run owners when pending policy admission goes stale
- add generation ownership across manager and tab-context routing state
- keep newer queued tab intents and same-connection replacements intact
- allow Cursor auto to use the provider default when modern model selection is absent

## Validation
- full suite: 1,218 tests, 1 skipped, 0 failed
- focused routing race suite: 20 passed
- ACP configuration suite: 38 passed
- strict lint: 0 violations
- guardrails and provider tests passed
- RepoPrompt and repoprompt-mcp builds passed
- no `.help(` usage