### PR TITLE
Narrow test quality skill trigger

### DIFF
--- a/.agents/skills/rpce-test-quality/SKILL.md
+++ b/.agents/skills/rpce-test-quality/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rpce-test-quality
-description: Select, design, review, consolidate, or delete RepoPrompt CE tests and diagnostics by regression value and maintenance cost. Use for bug fixes or features that may need coverage, test-adequacy reviews, XCTest or provider-package changes, runtime diagnostic harnesses, live or packaged smoke, core migrations, and decisions about whether a test is worth committing.
+description: Deep test-coverage engineering for RepoPrompt CE, including test-adequacy audits, multi-layer test strategy, suite consolidation or redesign, diagnostics and smoke-harness design, and decisions to commit or delete tests based on regression value and maintenance cost. Use only when test coverage or diagnostics is an explicit primary deliverable involving substantial analysis, multiple scenarios or layers, or broad existing-test review. Do not use for routine bug fixes or features with incidental tests, running normal validation, adding one obvious regression test, or fixing a single failing test.
 ---
 
 # RepoPrompt CE Test Quality

--- a/.agents/skills/rpce-test-quality/SKILL.md
+++ b/.agents/skills/rpce-test-quality/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rpce-test-quality
-description: Deep test-coverage engineering for RepoPrompt CE, including test-adequacy audits, multi-layer test strategy, suite consolidation or redesign, diagnostics and smoke-harness design, and decisions to commit or delete tests based on regression value and maintenance cost. Use only when test coverage or diagnostics is an explicit primary deliverable involving substantial analysis, multiple scenarios or layers, or broad existing-test review. Do not use for routine bug fixes or features with incidental tests, running normal validation, adding one obvious regression test, or fixing a single failing test.
+description: Select, design, review, consolidate, or remove RepoPrompt CE tests, diagnostic harnesses, and smoke checks by regression value and maintenance cost. Use when the task centers on test, diagnostic, or smoke coverage, including whether a single regression test is worth committing. Do not use for feature or bug-fix work merely because it may need coverage, or for routine test or validation execution.
 ---
 
 # RepoPrompt CE Test Quality


### PR DESCRIPTION
## Summary
- trigger `rpce-test-quality` whenever the task is specifically about proposing, adding, modifying, reviewing, or committing tests
- keep the quality gate active even for a single regression test so weak or redundant tests are challenged
- do not trigger merely because feature or bug-fix implementation may need coverage, or for routine validation runs

## Validation
- contribution commit preflight
- contribution push preflight
- YAML frontmatter validation
- repository guardrails