### PR TITLE
Fix Context Builder MCP handoff and startup stalls

### DIFF
--- a/Sources/RepoPrompt/Features/ContextBuilder/Services/ContextBuilderDefaults.swift
+++ b/Sources/RepoPrompt/Features/ContextBuilder/Services/ContextBuilderDefaults.swift
@@ -35,6 +35,12 @@ enum ContextBuilderDefaults {
     /// Default timeout (in seconds) for user responses to clarifying questions
     static let questionTimeoutSeconds = MCPTimeoutPolicy.askUserDefaultTimeoutSeconds
 
+    /// Deadline for the provider's run-scoped MCP client to route after stream creation.
+    static let mcpRoutingTimeoutMilliseconds = 10000
+
+    /// Keeps the one-shot routing policy alive through the routing deadline, with a five-second margin.
+    static let mcpBootstrapConnectionTTL = TimeInterval((mcpRoutingTimeoutMilliseconds / 1000) + 5)
+
     // MARK: - Plan Generation
 
     /// Whether to auto-generate a plan after Context Builder completes

--- a/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderAgentViewModel.swift
+++ b/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderAgentViewModel.swift
@@ -93,6 +93,21 @@ enum ContextBuilderFollowUpType: String, CaseIterable, Codable {
     }
 }
 
+private enum ContextBuilderMCPRoutingError: LocalizedError {
+    case routingFailed(agentDisplayName: String, clientName: String, timeoutSeconds: TimeInterval)
+
+    var errorDescription: String? {
+        switch self {
+        case let .routingFailed(agentDisplayName, clientName, timeoutSeconds):
+            "mcp_routing_failed: \(agentDisplayName) did not route the expected MCP client '\(clientName)' to this Context Builder run within \(Self.format(timeoutSeconds))s. The run was terminated and MCP bootstrap state was released."
+        }
+    }
+
+    private static func format(_ seconds: TimeInterval) -> String {
+        String(format: "%.1f", seconds)
+    }
+}
+
 @MainActor
 final class ContextBuilderAgentViewModel: ObservableObject {
     typealias ProviderFactory = (
@@ -777,6 +792,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
     private weak var workspaceManager: WorkspaceManagerViewModel?
     private let mcpServer: MCPServerViewModel
     private let providerFactory: ProviderFactory
+
     /// Chat VM used for headless plan generation from discovery.
     /// Weak to avoid accidental strong cycles with the view layer.
     private weak var oracleViewModel: OracleViewModel?
@@ -2066,6 +2082,15 @@ final class ContextBuilderAgentViewModel: ObservableObject {
                 return .failed("Failed to start MCP server. Check Local Network permission in System Settings.")
             }
 
+            let mcpPreparedMessage: AgentMessage?
+            if record.origin.isMCP {
+                debugLog("Building MCP-initiated agent message before acquiring the one-shot routing policy")
+                mcpPreparedMessage = await buildAgentMessage(for: session, runID: runID)
+                guard acceptsEvents(from: record) else { return .cancelled }
+            } else {
+                mcpPreparedMessage = nil
+            }
+
             debugLog("Acquiring headless run lease (gate + policy)...")
             let additionalTools = additionalToolsForContextBuilderAgent(tabID: record.tabID)
             let windowID = mcpServer.windowID
@@ -2076,7 +2101,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
                 modelString: nil,
                 windowID: windowID,
                 restrictedTools: DiscoverMCPToolPolicy.restrictedTools,
-                connectionTTL: 15
+                connectionTTL: ContextBuilderDefaults.mcpBootstrapConnectionTTL
             )
 
             let lease: MCPBootstrapLease
@@ -2110,11 +2135,16 @@ final class ContextBuilderAgentViewModel: ObservableObject {
             }
 
             do {
-                debugLog("Building agent message")
-                let message = await buildAgentMessage(for: session, runID: runID)
-                guard acceptsEvents(from: record) else {
-                    await lease.failAndCleanup()
-                    return .cancelled
+                let message: AgentMessage
+                if let mcpPreparedMessage {
+                    message = mcpPreparedMessage
+                } else {
+                    debugLog("Building agent message")
+                    message = await buildAgentMessage(for: session, runID: runID)
+                    guard acceptsEvents(from: record) else {
+                        await lease.failAndCleanup()
+                        return .cancelled
+                    }
                 }
 
                 debugLog("System prompt length: \(message.systemPrompt.count)")
@@ -2130,9 +2160,23 @@ final class ContextBuilderAgentViewModel: ObservableObject {
                     stage: .running
                 )
 
-                let routed = await lease.releaseWhenRouted(timeoutMs: 10000)
-                guard acceptsEvents(from: record) else { return .cancelled }
+                let routed = await lease.releaseWhenRouted(
+                    timeoutMs: ContextBuilderDefaults.mcpRoutingTimeoutMilliseconds
+                )
+                guard !Task.isCancelled, acceptsEvents(from: record) else { return .cancelled }
                 debugLog("Routing result for run \(runID): routed=\(routed)")
+
+                if !routed, record.origin.isMCP {
+                    let timeoutSeconds = TimeInterval(ContextBuilderDefaults.mcpRoutingTimeoutMilliseconds) / 1000
+                    let clientName = record.agentKind.mcpClientNameHint ?? record.agentKind.displayName
+                    return .failed(
+                        ContextBuilderMCPRoutingError.routingFailed(
+                            agentDisplayName: record.agentKind.displayName,
+                            clientName: clientName,
+                            timeoutSeconds: timeoutSeconds
+                        ).localizedDescription
+                    )
+                }
 
                 let connectionMessage = if routed {
                     record.origin.isMCP
@@ -2755,6 +2799,10 @@ final class ContextBuilderAgentViewModel: ObservableObject {
     // MARK: - Error handling
 
     private func extractVerboseErrorMessage(from error: Error) -> String {
+        if error is ContextBuilderMCPRoutingError {
+            return error.localizedDescription
+        }
+
         let errorMessage: String = if let providerError = error as? AIProviderError {
             switch providerError {
             case let .invalidConfiguration(detail):

--- a/Sources/RepoPrompt/Infrastructure/AI/Agents/AgentRunCoordinator.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Agents/AgentRunCoordinator.swift
@@ -77,7 +77,8 @@ final class AgentRunCoordinator {
             reason: reason ?? "\(spec.type)",
             ttl: spec.connectionTTL,
             tabID: tabID,
-            purpose: runPurpose(for: spec.type)
+            purpose: runPurpose(for: spec.type),
+            requiresExpectedAgentPID: spec.agentKind.requiresExpectedPIDOwnedAgentModeMCPRouting
         )
 
         let lease = MCPBootstrapLease(spec: leaseSpec)

--- a/Sources/RepoPrompt/Infrastructure/AI/Agents/HeadlessAgentRunLease.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Agents/HeadlessAgentRunLease.swift
@@ -13,7 +13,8 @@ extension MCPBootstrapLeaseSpec {
         reason: String? = nil,
         ttl: TimeInterval,
         tabID: UUID? = nil,
-        purpose: MCPRunPurpose
+        purpose: MCPRunPurpose,
+        requiresExpectedAgentPID: Bool = false
     ) -> MCPBootstrapLeaseSpec {
         MCPBootstrapLeaseSpec(
             runID: runID,
@@ -29,7 +30,7 @@ extension MCPBootstrapLeaseSpec {
             purpose: purpose,
             taskLabelKind: nil,
             allowsAgentExternalControlTools: false,
-            requiresExpectedAgentPID: false
+            requiresExpectedAgentPID: requiresExpectedAgentPID
         )
     }
 }

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/ClaudeCodeAgentProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/ClaudeCodeAgentProvider.swift
@@ -374,13 +374,31 @@ final class ClaudeCodeAgentProvider: HeadlessAgentProvider {
                             let additionalEnvironment = self.config.effortEnvironmentOverrides.merging(
                                 context.launchEnvironment?.environmentOverrides ?? [:]
                             ) { _, resolverValue in resolverValue }
+                            let expectedPIDRunID = context.runID
+                            let expectedPIDClientName = self.config.runtimeVariant.agentKind.mcpClientNameHint
                             let stream = try await self.runner.runStreaming(
                                 args: args,
                                 stdin: userMessage, // Pass the user message via stdin
                                 outputMode: .auto(.streamJson),
                                 timeout: 6000, // 100 minute timeout (matches Codex)
                                 additionalEnvironment: additionalEnvironment,
-                                additionalRemovedKeys: context.launchEnvironment?.removedEnvironmentKeys ?? []
+                                additionalRemovedKeys: context.launchEnvironment?.removedEnvironmentKeys ?? [],
+                                onProcessStarted: { pid in
+                                    guard let expectedPIDClientName else { return }
+                                    await ServerNetworkManager.shared.registerExpectedAgentPID(
+                                        pid,
+                                        for: expectedPIDClientName,
+                                        runID: expectedPIDRunID
+                                    )
+                                },
+                                onProcessTerminated: { pid in
+                                    guard let expectedPIDClientName else { return }
+                                    await ServerNetworkManager.shared.clearExpectedAgentPID(
+                                        pid,
+                                        for: expectedPIDClientName,
+                                        runID: expectedPIDRunID
+                                    )
+                                }
                             )
                             try await AsyncScope.withCleanup({}, cleanup: {
                                 await self.runner.cancelAll()

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/CodexExecAgentProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/CodexExecAgentProvider.swift
@@ -221,11 +221,26 @@ final class CodexExecAgentProvider: HeadlessAgentProvider {
                                         print("[DEBUG] CodexExec: Starting stream with timeout 6000s")
                                     }
 
+                                    let expectedPIDRunID = context.runID
                                     let stream = try await self.runner.runStreaming(
                                         args: args,
                                         stdin: combinedPrompt,
                                         outputMode: .none,
-                                        timeout: 6000
+                                        timeout: 6000,
+                                        onProcessStarted: { pid in
+                                            await ServerNetworkManager.shared.registerExpectedAgentPID(
+                                                pid,
+                                                for: Self.codexMCPClientID,
+                                                runID: expectedPIDRunID
+                                            )
+                                        },
+                                        onProcessTerminated: { pid in
+                                            await ServerNetworkManager.shared.clearExpectedAgentPID(
+                                                pid,
+                                                for: Self.codexMCPClientID,
+                                                runID: expectedPIDRunID
+                                            )
+                                        }
                                     )
 
                                     var framer = LineFramer()

--- a/Sources/RepoPrompt/Infrastructure/MCP/ToolOutputFormatter.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ToolOutputFormatter.swift
@@ -3599,6 +3599,7 @@ extension ToolOutputFormatter {
             out.append("- Path: `\(dto.path)`")
             if let np = dto.newPath { out.append("- New path: `\(np)`") }
             if dto.action.lowercased() == "delete" { out.append("- Result: Moved to macOS Trash") }
+            if let warning = dto.warning, !warning.isEmpty { out.append("- Warning: \(warning)") }
             return [.text(out.joined(separator: "\n"))]
         }
         if case let .object(obj) = value {

--- a/Sources/RepoPrompt/Infrastructure/MCP/ToolResultDTOs.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ToolResultDTOs.swift
@@ -933,12 +933,28 @@ enum ToolResultDTOs {
         let action: String // "create", "delete", "move"
         let path: String
         let newPath: String? // present for move/rename
+        let warning: String?
+
+        init(
+            status: String,
+            action: String,
+            path: String,
+            newPath: String?,
+            warning: String? = nil
+        ) {
+            self.status = status
+            self.action = action
+            self.path = path
+            self.newPath = newPath
+            self.warning = warning
+        }
 
         private enum CodingKeys: String, CodingKey {
             case status
             case action
             case path
             case newPath = "new_path"
+            case warning
         }
     }
 

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+TabContext.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+TabContext.swift
@@ -1284,6 +1284,7 @@ extension MCPServerViewModel {
         }
         var merged = latest
         merged.selection = context.selection
+        merged.readFileAutoSelectionGeneration = context.readFileAutoSelectionGeneration
         return merged
     }
 
@@ -1291,6 +1292,16 @@ extension MCPServerViewModel {
         case persisted
         case unchanged
         case unavailable
+    }
+
+    struct MCPSelectionPersistenceVerification: Equatable {
+        let outcome: MCPSelectionCoordinatorPersistenceResult
+        let expectedSelection: StoredSelection
+        let canonicalSelection: StoredSelection?
+
+        var isVerified: Bool {
+            canonicalSelection == expectedSelection
+        }
     }
 
     static func logicalizeSelectionForPersistence(
@@ -1321,6 +1332,35 @@ extension MCPServerViewModel {
     }
 
     @MainActor
+    static func persistMCPSelectionAndVerifyThroughCoordinator(
+        _ selection: StoredSelection,
+        for tabID: UUID,
+        selectionCoordinator: WorkspaceSelectionCoordinator?
+    ) async -> MCPSelectionPersistenceVerification {
+        let outcome = await persistMCPSelectionThroughCoordinator(
+            selection,
+            for: tabID,
+            selectionCoordinator: selectionCoordinator
+        )
+        let canonicalSelection = selectionCoordinator?
+            .selectionSnapshot(for: tabID, flushPendingUIIfActive: false)?
+            .selection
+        return MCPSelectionPersistenceVerification(
+            outcome: outcome,
+            expectedSelection: selection,
+            canonicalSelection: canonicalSelection
+        )
+    }
+
+    @MainActor
+    private func canonicalPersistedSelection(for tabID: UUID) -> StoredSelection? {
+        if let selection = selectionCoordinator?.selectionSnapshot(for: tabID, flushPendingUIIfActive: false)?.selection {
+            return selection
+        }
+        return workspaceManager?.composeTab(with: tabID)?.selection
+    }
+
+    @MainActor
     private func persistenceSafeTabContext(_ context: TabContextSnapshot) async -> TabContextSnapshot {
         let lookupContext = await lookupContext(for: context)
         var persisted = context
@@ -1329,41 +1369,45 @@ extension MCPServerViewModel {
     }
 
     @MainActor
+    @discardableResult
     func persistResolvedTabContextSnapshot(
         _ resolved: ResolvedTabContextSnapshot,
         metadata: RequestMetadata,
         mutated: Bool
-    ) async {
-        guard mutated else { return }
+    ) async -> MCPSelectionPersistenceVerification? {
+        guard mutated else { return nil }
         let context = await persistenceSafeTabContext(resolved.snapshot)
-        if !resolved.usesActiveTabCompatibility,
-           let connectionID = metadata.connectionID,
-           var latest = tabContextByConnectionID[connectionID],
-           latest.tabID == context.tabID
-        {
-            let persistenceResult = await Self.persistMCPSelectionThroughCoordinator(
-                context.selection,
-                for: context.tabID,
-                selectionCoordinator: selectionCoordinator
+        var verification = await Self.persistMCPSelectionAndVerifyThroughCoordinator(
+            context.selection,
+            for: context.tabID,
+            selectionCoordinator: selectionCoordinator
+        )
+        if verification.outcome == .unavailable {
+            await commitTabContext(selectionOnlyCommitContext(from: context))
+            verification = MCPSelectionPersistenceVerification(
+                outcome: .unavailable,
+                expectedSelection: context.selection,
+                canonicalSelection: canonicalPersistedSelection(for: context.tabID)
             )
-            if latest.selection != context.selection {
-                latest.selection = context.selection
-                tabContextByConnectionID[connectionID] = latest
-                await pushVirtualContextToUI(latest)
-            }
-            if persistenceResult == .unavailable {
-                await commitTabContext(selectionOnlyCommitContext(from: context))
-            }
-        } else {
-            let persistenceResult = await Self.persistMCPSelectionThroughCoordinator(
-                context.selection,
-                for: context.tabID,
-                selectionCoordinator: selectionCoordinator
-            )
-            if persistenceResult == .unavailable {
-                await commitTabContext(selectionOnlyCommitContext(from: context))
-            }
         }
+
+        if !resolved.usesActiveTabCompatibility,
+           let canonicalSelection = verification.canonicalSelection,
+           canonicalSelection == verification.expectedSelection,
+           let connectionID = metadata.connectionID,
+           let latest = tabContextByConnectionID[connectionID],
+           latest.tabID == context.tabID,
+           latest.windowID == context.windowID,
+           latest.workspaceID == context.workspaceID,
+           latest.runID == context.runID,
+           latest.readFileAutoSelectionGeneration == context.readFileAutoSelectionGeneration
+        {
+            var refreshed = selectionOnlyCommitContext(from: context)
+            refreshed.selection = canonicalSelection
+            refreshed.readFileAutoSelectionGeneration = latest.readFileAutoSelectionGeneration
+            tabContextByConnectionID[connectionID] = refreshed
+        }
+        return verification
     }
 
     @MainActor

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel.swift
@@ -753,8 +753,8 @@ final class MCPServerViewModel: ObservableObject {
             return await computeSelectionSlicesVirtual(base: base, entries: entries, mode: mode, lookupRootScope: lookupRootScope)
         },
         persistResolvedTabContextSnapshot: { [weak self] resolvedContext, metadata, mutated in
-            guard let self else { return }
-            await persistResolvedTabContextSnapshot(resolvedContext, metadata: metadata, mutated: mutated)
+            guard let self else { return nil }
+            return await persistResolvedTabContextSnapshot(resolvedContext, metadata: metadata, mutated: mutated)
         },
         makeSelectionHintError: { [weak self] paths, operation, lookupRootScope in
             guard let self else { return "Window deallocated while resolving selection inputs." }
@@ -2816,12 +2816,19 @@ final class MCPServerViewModel: ObservableObject {
                 return
             }
             resolvedContext.snapshot.selection = clearedSelection
-            await EditFlowPerf.measure(
+            let verification = await EditFlowPerf.measure(
                 EditFlowPerf.Stage.ReadFile.AutoSelect.persistence,
                 EditFlowPerf.Dimensions(outcome: "attempted")
             ) {
                 await persistResolvedTabContextSnapshot(resolvedContext, metadata: metadata, mutated: true)
             }
+            _ = try MCPSelectionToolProvider.requireCanonicalSelection(
+                verification,
+                requested: clearedSelection,
+                tabID: resolvedContext.snapshot.tabID,
+                operation: "read_file auto-selection",
+                recovery: "Retry the read or manage_selection for the same context_id before relying on the selection."
+            )
             #if DEBUG || EDIT_FLOW_PERF
                 fullFlowOutcome = "changed"
             #endif
@@ -3248,7 +3255,14 @@ final class MCPServerViewModel: ObservableObject {
         )
         if computed.mutated {
             resolvedContext.snapshot.selection = computed.selection
-            await persistResolvedTabContextSnapshot(resolvedContext, metadata: metadata, mutated: true)
+            let verification = await persistResolvedTabContextSnapshot(resolvedContext, metadata: metadata, mutated: true)
+            _ = try MCPSelectionToolProvider.requireCanonicalSelection(
+                verification,
+                requested: computed.selection,
+                tabID: resolvedContext.snapshot.tabID,
+                operation: "selection slice update",
+                recovery: "Retry the selection slice mutation for the same context_id before continuing."
+            )
         }
         return computed.result
     }
@@ -3804,7 +3818,14 @@ final class MCPServerViewModel: ObservableObject {
             )
             guard addResult.selection != resolvedContext.snapshot.selection else { return }
             resolvedContext.snapshot.selection = addResult.selection
-            await persistResolvedTabContextSnapshot(resolvedContext, metadata: metadata, mutated: true)
+            let verification = await persistResolvedTabContextSnapshot(resolvedContext, metadata: metadata, mutated: true)
+            _ = try MCPSelectionToolProvider.requireCanonicalSelection(
+                verification,
+                requested: addResult.selection,
+                tabID: resolvedContext.snapshot.tabID,
+                operation: "file_actions create selection update",
+                recovery: "The file was created, but its selection was not confirmed; retry manage_selection for the same context_id."
+            )
         }
     }
 

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel.swift
@@ -762,7 +762,7 @@ final class MCPServerViewModel: ObservableObject {
         },
         performFileAction: { [weak self] action, path, content, newPath, ifExists in
             guard let self else { throw MCPError.internalError("Window deallocated while performing file action") }
-            try await performFileAction(action: action, path: path, content: content, newPath: newPath, ifExists: ifExists)
+            return try await performFileAction(action: action, path: path, content: content, newPath: newPath, ifExists: ifExists)
         },
         buildCodeStructureDTO: { [weak self] files, maxResults, includeUnmappedPaths, projection in
             guard let self else { throw MCPError.internalError("Window deallocated while building code structure") }
@@ -3730,7 +3730,7 @@ final class MCPServerViewModel: ObservableObject {
         content: String? = nil,
         newPath: String? = nil,
         ifExists: String? = nil
-    ) async throws {
+    ) async throws -> String? {
         // Enforce workspace presence in multi-window mode
         try await requireWorkspaceForTool(MCPWindowToolName.fileActions)
         let metadata = await captureRequestMetadata()
@@ -3816,17 +3816,22 @@ final class MCPServerViewModel: ObservableObject {
                 mode: "full",
                 lookupRootScope: lookupContext.rootScope
             )
-            guard addResult.selection != resolvedContext.snapshot.selection else { return }
+            guard addResult.selection != resolvedContext.snapshot.selection else { return nil }
             resolvedContext.snapshot.selection = addResult.selection
             let verification = await persistResolvedTabContextSnapshot(resolvedContext, metadata: metadata, mutated: true)
-            _ = try MCPSelectionToolProvider.requireCanonicalSelection(
-                verification,
-                requested: addResult.selection,
-                tabID: resolvedContext.snapshot.tabID,
-                operation: "file_actions create selection update",
-                recovery: "The file was created, but its selection was not confirmed; retry manage_selection for the same context_id."
-            )
+            do {
+                _ = try MCPSelectionToolProvider.requireCanonicalSelection(
+                    verification,
+                    requested: addResult.selection,
+                    tabID: resolvedContext.snapshot.tabID,
+                    operation: "file_actions create selection update",
+                    recovery: "Retry manage_selection for the same context_id."
+                )
+            } catch {
+                return "The file was created, but its selection was not confirmed. \(error)"
+            }
         }
+        return nil
     }
 
     /// Creates a **new** file, with optional overwrite behavior.

--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPFileToolProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPFileToolProvider.swift
@@ -70,8 +70,14 @@ final class MCPFileToolProvider: MCPWindowToolProviding {
             let newPath = args["new_path"]?.stringValue
             let ifExists = args["if_exists"]?.stringValue?.lowercased() ?? "error"
 
-            try await dependencies.performFileAction(action, path, content, newPath, ifExists)
-            return try Value(ToolResultDTOs.FileActionReply(status: "ok", action: action, path: path, newPath: newPath))
+            let warning = try await dependencies.performFileAction(action, path, content, newPath, ifExists)
+            return try Value(ToolResultDTOs.FileActionReply(
+                status: "ok",
+                action: action,
+                path: path,
+                newPath: newPath,
+                warning: warning
+            ))
         }
     }
 

--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPSelectionToolProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPSelectionToolProvider.swift
@@ -373,12 +373,19 @@ final class MCPSelectionToolProvider: MCPWindowToolProviding {
         view: String
     ) async throws -> ToolResultDTOs.SelectionReply {
         resolvedContext.snapshot.selection = selection
-        await dependencies.persistResolvedTabContextSnapshot(resolvedContext, metadata, true)
+        let verification = await dependencies.persistResolvedTabContextSnapshot(resolvedContext, metadata, true)
+        let canonicalSelection = try Self.requireCanonicalSelection(
+            verification,
+            requested: selection,
+            tabID: resolvedContext.snapshot.tabID,
+            operation: "manage_selection",
+            recovery: "Retry manage_selection for the same context_id or rebind the tab context before continuing."
+        )
         let codeMapOverride: CodeMapUsage? = (!resolvedContext.usesActiveTabCompatibility && baseContext.runID != nil) ? .auto : nil
         var replyContext = baseContext
-        replyContext.selection = selection
+        replyContext.selection = canonicalSelection
         return try await dependencies.buildSelectionMutationReply(
-            selection,
+            canonicalSelection,
             includeBlocks,
             display,
             extraInvalid,
@@ -386,5 +393,42 @@ final class MCPSelectionToolProvider: MCPWindowToolProviding {
             codeMapOverride,
             resolvedContext.usesActiveTabCompatibility ? nil : replyContext
         )
+    }
+
+    static func requireCanonicalSelection(
+        _ verification: MCPServerViewModel.MCPSelectionPersistenceVerification?,
+        requested: StoredSelection,
+        tabID: UUID,
+        operation: String,
+        recovery: String
+    ) throws -> StoredSelection {
+        guard let verification,
+              let canonicalSelection = verification.canonicalSelection,
+              verification.isVerified
+        else {
+            throw MCPError.internalError(selectionPersistenceMismatchMessage(
+                expected: verification?.expectedSelection ?? requested,
+                canonical: verification?.canonicalSelection,
+                tabID: tabID,
+                operation: operation,
+                recovery: recovery
+            ))
+        }
+        return canonicalSelection
+    }
+
+    private static func selectionPersistenceMismatchMessage(
+        expected: StoredSelection,
+        canonical: StoredSelection?,
+        tabID: UUID,
+        operation: String,
+        recovery: String
+    ) -> String {
+        let canonicalSummary = canonical.map(selectionSummary) ?? "unavailable"
+        return "Selection persistence handoff failed for \(operation) on tab \(tabID.uuidString): canonical selection did not match the requested mutation (expected \(selectionSummary(expected)); canonical \(canonicalSummary)). \(recovery)"
+    }
+
+    private static func selectionSummary(_ selection: StoredSelection) -> String {
+        "selected=\(selection.selectedPaths.count), codemap=\(selection.autoCodemapPaths.count), slices=\(selection.slices.count), auto=\(selection.codemapAutoEnabled)"
     }
 }

--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPWindowToolDependencies.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPWindowToolDependencies.swift
@@ -172,7 +172,7 @@ struct MCPWindowToolDependencies {
         _ mutated: Bool
     ) async -> MCPServerViewModel.MCPSelectionPersistenceVerification?
     typealias MakeSelectionHintError = @MainActor @Sendable (_ paths: [String], _ operation: String, _ lookupRootScope: WorkspaceLookupRootScope) async -> String
-    typealias PerformFileAction = @MainActor @Sendable (_ action: String, _ path: String, _ content: String?, _ newPath: String?, _ ifExists: String?) async throws -> Void
+    typealias PerformFileAction = @MainActor @Sendable (_ action: String, _ path: String, _ content: String?, _ newPath: String?, _ ifExists: String?) async throws -> String?
     typealias BuildCodeStructureDTO = @MainActor @Sendable (_ files: [WorkspaceFileRecord], _ maxResults: Int, _ includeUnmappedPaths: Bool, _ projection: WorkspaceRootBindingProjection?) async throws -> ToolResultDTOs.SelectedCodeStructureDTO
     typealias ResolveFilesForCodeStructure = @MainActor @Sendable (_ paths: [String], _ lookupRootScope: WorkspaceLookupRootScope) async throws -> [WorkspaceFileRecord]
     typealias BuildStoreBackedFileTreeResult = @MainActor @Sendable (_ mode: String, _ maxDepth: Int?, _ startPath: String?, _ lookupContext: WorkspaceLookupContext) async throws -> (result: FileTreeResult, rootCount: Int)

--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPWindowToolDependencies.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPWindowToolDependencies.swift
@@ -170,7 +170,7 @@ struct MCPWindowToolDependencies {
         _ resolvedContext: MCPServerViewModel.ResolvedTabContextSnapshot,
         _ metadata: MCPServerViewModel.RequestMetadata,
         _ mutated: Bool
-    ) async -> Void
+    ) async -> MCPServerViewModel.MCPSelectionPersistenceVerification?
     typealias MakeSelectionHintError = @MainActor @Sendable (_ paths: [String], _ operation: String, _ lookupRootScope: WorkspaceLookupRootScope) async -> String
     typealias PerformFileAction = @MainActor @Sendable (_ action: String, _ path: String, _ content: String?, _ newPath: String?, _ ifExists: String?) async throws -> Void
     typealias BuildCodeStructureDTO = @MainActor @Sendable (_ files: [WorkspaceFileRecord], _ maxResults: Int, _ includeUnmappedPaths: Bool, _ projection: WorkspaceRootBindingProjection?) async throws -> ToolResultDTOs.SelectedCodeStructureDTO

--- a/Sources/RepoPrompt/Infrastructure/Process/CLIProcessRunner.swift
+++ b/Sources/RepoPrompt/Infrastructure/Process/CLIProcessRunner.swift
@@ -352,7 +352,9 @@ final class CLIProcessRunner {
         outputMode: OutputFlagMode = .auto(.streamJson),
         timeout: TimeInterval?,
         additionalEnvironment: [String: String] = [:],
-        additionalRemovedKeys: Set<String> = []
+        additionalRemovedKeys: Set<String> = [],
+        onProcessStarted: (@Sendable (pid_t) async -> Void)? = nil,
+        onProcessTerminated: (@Sendable (pid_t) async -> Void)? = nil
     ) async throws -> AsyncThrowingStream<StreamEvent, Error> {
         // Hold the permit for the entire lifetime of the child process
         ProcessDiagnostics.log("🔵 [GATE] Acquiring gate...")
@@ -469,6 +471,7 @@ final class CLIProcessRunner {
         }
 
         await registry.add(spawned)
+        await onProcessStarted?(spawned.pid)
 
         let collector = config.logCollector
 
@@ -603,7 +606,9 @@ final class CLIProcessRunner {
                     continuation.finish(throwing: error)
                 }
                 ProcessDiagnostics.log("🧹 [CLEANUP] Cleaning up pid=\(spawned.pid)")
-                await cleanupProcess(pid: spawned.pid)
+                if await cleanupProcess(pid: spawned.pid) {
+                    await onProcessTerminated?(spawned.pid)
+                }
                 ProcessDiagnostics.log("🔴 [GATE] Releasing gate for pid=\(spawned.pid)")
                 if await gateCoordinator.markReleased() {
                     await gate.release()
@@ -634,7 +639,9 @@ final class CLIProcessRunner {
                         let _ = await Self.waitForGroup(group, timeout: 2.0, pid: spawned.pid) { msg in
                             ProcessDiagnostics.log(msg)
                         }
-                        await cleanupProcess(pid: spawned.pid)
+                        if await cleanupProcess(pid: spawned.pid) {
+                            await onProcessTerminated?(spawned.pid)
+                        }
 
                         if await gateCoordinator.markReleased() {
                             ProcessDiagnostics.log("🟠 [CANCEL] Releasing gate (onTermination) pid=\(spawned.pid)")
@@ -708,12 +715,13 @@ final class CLIProcessRunner {
         }
     }
 
-    private func cleanupProcess(pid: pid_t) async {
-        if let process = await registry.remove(pid: pid) {
-            process.stdin?.closeFile()
-            process.stdout.closeFile()
-            process.stderr.closeFile()
-        }
+    @discardableResult
+    private func cleanupProcess(pid: pid_t) async -> Bool {
+        guard let process = await registry.remove(pid: pid) else { return false }
+        process.stdin?.closeFile()
+        process.stdout.closeFile()
+        process.stderr.closeFile()
+        return true
     }
 
     private func mapLauncherError(

--- a/Tests/RepoPromptTests/AI/CLIProcessRunnerLifecycleTests.swift
+++ b/Tests/RepoPromptTests/AI/CLIProcessRunnerLifecycleTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+@testable import RepoPrompt
+import XCTest
+
+final class CLIProcessRunnerLifecycleTests: XCTestCase {
+    func testStreamingProcessLifecycleCallbacksUseSamePIDAndTerminate() async throws {
+        let recorder = ProcessLifecycleRecorder()
+        let runner = CLIProcessRunner(
+            config: CLIProcessConfiguration(command: "/bin/cat", enableDebugLogging: false)
+        )
+
+        let stream = try await runner.runStreaming(
+            args: [],
+            stdin: "callback-test",
+            outputMode: .none,
+            timeout: 2,
+            onProcessStarted: { pid in
+                await recorder.recordStarted(pid)
+            },
+            onProcessTerminated: { pid in
+                await recorder.recordTerminated(pid)
+            }
+        )
+
+        var sawTermination = false
+        for try await event in stream {
+            if case .terminated = event {
+                sawTermination = true
+            }
+        }
+
+        XCTAssertTrue(sawTermination)
+        let callbacksCompleted = await recorder.waitForTermination()
+        XCTAssertTrue(callbacksCompleted)
+        let snapshot = await recorder.snapshot()
+        XCTAssertNotNil(snapshot.startedPID)
+        XCTAssertEqual(snapshot.terminatedPID, snapshot.startedPID)
+    }
+
+    func testStreamingProcessTerminationCallbackRunsAfterRunnerCancellation() async throws {
+        let recorder = ProcessLifecycleRecorder()
+        let runner = CLIProcessRunner(
+            config: CLIProcessConfiguration(command: "/bin/sleep", enableDebugLogging: false)
+        )
+
+        let stream = try await runner.runStreaming(
+            args: ["5"],
+            stdin: nil,
+            outputMode: .none,
+            timeout: 10,
+            onProcessStarted: { pid in
+                await recorder.recordStarted(pid)
+            },
+            onProcessTerminated: { pid in
+                await recorder.recordTerminated(pid)
+            }
+        )
+        let consumer = Task {
+            do {
+                for try await _ in stream {}
+            } catch {}
+        }
+
+        let processStarted = await recorder.waitForStart()
+        XCTAssertTrue(processStarted)
+        consumer.cancel()
+        await runner.cancelAll()
+        _ = await consumer.result
+
+        let processTerminated = await recorder.waitForTermination()
+        XCTAssertTrue(processTerminated)
+        let snapshot = await recorder.snapshot()
+        XCTAssertNotNil(snapshot.startedPID)
+        XCTAssertEqual(snapshot.terminatedPID, snapshot.startedPID)
+    }
+}
+
+private actor ProcessLifecycleRecorder {
+    private var startedPID: pid_t?
+    private var terminatedPID: pid_t?
+
+    func recordStarted(_ pid: pid_t) {
+        startedPID = pid
+    }
+
+    func recordTerminated(_ pid: pid_t) {
+        terminatedPID = pid
+    }
+
+    func waitForStart() async -> Bool {
+        for _ in 0 ..< 100 {
+            if startedPID != nil { return true }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return false
+    }
+
+    func waitForTermination() async -> Bool {
+        for _ in 0 ..< 300 {
+            if terminatedPID != nil { return true }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return false
+    }
+
+    func snapshot() -> (startedPID: pid_t?, terminatedPID: pid_t?) {
+        (startedPID, terminatedPID)
+    }
+}

--- a/Tests/RepoPromptTests/ContextBuilder/ContextBuilderRunLifecycleTests.swift
+++ b/Tests/RepoPromptTests/ContextBuilder/ContextBuilderRunLifecycleTests.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 @testable import RepoPrompt
 import XCTest
@@ -315,8 +316,19 @@ final class ContextBuilderRunLifecycleTests: XCTestCase {
 
     func testMCPRoutingFailureAfterImmediateStreamReturnCleansBootstrapAndAllowsImmediateRetry() async throws {
         #if DEBUG
+            let oldProcess = try makeSleepingProcessTree()
+            let retryProcess = try makeSleepingProcessTree()
+            defer {
+                oldProcess.terminate()
+                retryProcess.terminate()
+            }
+            let clientName = AgentProviderKind.codexExec.mcpClientNameHint ?? AgentProviderKind.codexMCPClientID
             let blockedProvider = CodexShapedBlockedRoutingTestProvider()
-            let retryProvider = ImmediateSuccessRoutingTestProvider()
+            let retryProvider = PIDOwnedRetryRoutingTestProvider(
+                clientName: clientName,
+                expectedParentPID: retryProcess.parentPID,
+                connectionPID: retryProcess.childPID
+            )
             let providers = LifecycleTestProviderQueue([blockedProvider, retryProvider])
             let previousMCPEnabled = await ServerNetworkManager.shared.debugIsEnabledForBootstrapSocketURLOverride()
 
@@ -331,6 +343,9 @@ final class ContextBuilderRunLifecycleTests: XCTestCase {
             )
             GlobalSettingsStore.shared.setMCPAutoStart(previousMCPAutoStart, commit: false)
             await composition.workspaceManager.awaitInitialized()
+            var firstRunID: UUID?
+            var retryRunID: UUID?
+            let lateConnectionID = UUID()
 
             do {
                 let workspaceRoot = FileManager.default.temporaryDirectory
@@ -368,7 +383,6 @@ final class ContextBuilderRunLifecycleTests: XCTestCase {
                 }
 
                 let firstTeardownCompleted = expectation(description: "failed provider teardown completed")
-                var firstRunID: UUID?
                 viewModel.installRunTestHooks(
                     ContextBuilderAgentViewModel.RunTestHooks(
                         beforeProcessingProviderEvent: nil,
@@ -399,6 +413,11 @@ final class ContextBuilderRunLifecycleTests: XCTestCase {
                 await blockedProvider.waitUntilInternalStartupEntered()
                 firstRunID = try XCTUnwrap(viewModel.activeRunIDForTesting(tabID: tabID))
                 let failedRunID = try XCTUnwrap(firstRunID)
+                await ServerNetworkManager.shared.registerExpectedAgentPID(
+                    oldProcess.parentPID,
+                    for: clientName,
+                    runID: failedRunID
+                )
                 let routingWaiterRegistered = await waitForRoutingWaiter(runID: failedRunID)
                 XCTAssertTrue(routingWaiterRegistered)
                 await MCPRoutingWaiter.notifyFailed(runID: failedRunID)
@@ -428,25 +447,52 @@ final class ContextBuilderRunLifecycleTests: XCTestCase {
                 XCTAssertNil(activeGateID)
                 XCTAssertEqual(waitingGateCount, 0)
                 XCTAssertEqual(routingWaiterCount, 0)
-                if let clientName = AgentProviderKind.codexExec.mcpClientNameHint {
-                    let pendingPolicies = await ServerNetworkManager.shared.debugPendingPolicySnapshot(
-                        for: clientName
-                    )
-                    XCTAssertFalse(pendingPolicies.contains { $0.runID == failedRunID })
-                }
+                let pendingPoliciesAfterFailure = await ServerNetworkManager.shared.debugPendingPolicySnapshot(
+                    for: clientName
+                )
+                XCTAssertFalse(pendingPoliciesAfterFailure.contains { $0.runID == failedRunID })
 
                 let retryToken = try viewModel.beginMCPControlledRun(
                     forTabID: tabID,
                     responseType: nil,
                     planModelName: nil
                 )
-                let retrySnapshot = try await viewModel.runContextBuilderForMCP(
-                    tabID: tabID,
-                    mcpControlToken: retryToken
-                )
+                let retryWaiter = Task { @MainActor in
+                    try await viewModel.runContextBuilderForMCP(
+                        tabID: tabID,
+                        mcpControlToken: retryToken
+                    )
+                }
 
+                await retryProvider.waitUntilConnectionAttemptReady()
+                retryRunID = try XCTUnwrap(viewModel.activeRunIDForTesting(tabID: tabID))
+                let successorRunID = try XCTUnwrap(retryRunID)
+                let lateOldProviderConnection = await ServerNetworkManager.shared.debugApplyPendingPolicy(
+                    clientName: clientName,
+                    connectionID: lateConnectionID,
+                    clientPid: Int(oldProcess.childPID),
+                    bootstrapClientName: "repoprompt_ce_cli_debug",
+                    pidGateTimeout: 0.05,
+                    requireRunRouting: false
+                )
+                XCTAssertEqual(lateOldProviderConnection.outcome, "rejected:ownership_timeout")
+                XCTAssertEqual(lateOldProviderConnection.runID, successorRunID)
+                let lateMappedRunID = await ServerNetworkManager.shared.runIDForConnection(lateConnectionID)
+                XCTAssertNil(lateMappedRunID)
+                let pendingPoliciesAfterLateOldConnection = await ServerNetworkManager.shared.debugPendingPolicySnapshot(
+                    for: clientName
+                )
+                XCTAssertTrue(pendingPoliciesAfterLateOldConnection.contains { $0.runID == successorRunID })
+
+                await retryProvider.releaseConnectionAttempt()
+                let retrySnapshot = try await retryWaiter.value
+                let retryPolicyApplication = await retryProvider.policyApplicationResult()
+
+                XCTAssertEqual(retryPolicyApplication?.outcome, "applied")
+                XCTAssertEqual(retryPolicyApplication?.runID, successorRunID)
                 XCTAssertEqual(retrySnapshot.runState, .completed)
                 XCTAssertEqual(retrySnapshot.agentOutput, "retry-success")
+                XCTAssertEqual(retrySnapshot.runID, successorRunID)
                 XCTAssertNotEqual(retrySnapshot.runID, failedRunID)
                 XCTAssertTrue(viewModel.isRunTeardownPendingForTesting(runID: failedRunID))
                 let disposeCallCountAfterRetry = await blockedProvider.disposeCallCount()
@@ -457,12 +503,41 @@ final class ContextBuilderRunLifecycleTests: XCTestCase {
                 await fulfillment(of: [firstTeardownCompleted], timeout: 1)
                 XCTAssertFalse(viewModel.isRunTeardownPendingForTesting(runID: failedRunID))
 
+                await ServerNetworkManager.shared.clearExpectedAgentPID(
+                    oldProcess.parentPID,
+                    for: clientName,
+                    runID: failedRunID
+                )
+                await ServerNetworkManager.shared.clearExpectedAgentPID(
+                    retryProcess.parentPID,
+                    for: clientName,
+                    runID: successorRunID
+                )
+                await ServerNetworkManager.shared.removeConnection(lateConnectionID)
+                await ServerNetworkManager.shared.removeConnection(retryProvider.connectionID)
                 await composition.mcpServer.stopServer()
                 await composition.mcpServer.shutdownListener()
                 await ServerNetworkManager.shared.setEnabled(previousMCPEnabled)
             } catch {
                 await blockedProvider.releaseInternalStartup()
                 await blockedProvider.releaseDisposal()
+                await retryProvider.releaseConnectionAttempt()
+                if let firstRunID {
+                    await ServerNetworkManager.shared.clearExpectedAgentPID(
+                        oldProcess.parentPID,
+                        for: clientName,
+                        runID: firstRunID
+                    )
+                }
+                if let retryRunID {
+                    await ServerNetworkManager.shared.clearExpectedAgentPID(
+                        retryProcess.parentPID,
+                        for: clientName,
+                        runID: retryRunID
+                    )
+                }
+                await ServerNetworkManager.shared.removeConnection(lateConnectionID)
+                await ServerNetworkManager.shared.removeConnection(retryProvider.connectionID)
                 await composition.mcpServer.stopServer()
                 await composition.mcpServer.shutdownListener()
                 await ServerNetworkManager.shared.setEnabled(previousMCPEnabled)
@@ -482,6 +557,66 @@ final class ContextBuilderRunLifecycleTests: XCTestCase {
         }
         return false
     }
+
+    #if DEBUG
+        private struct SleepingProcessTree {
+            let parent: Process
+            let childPID: pid_t
+            let parentExited: DispatchSemaphore
+
+            var parentPID: pid_t {
+                parent.processIdentifier
+            }
+
+            func terminate() {
+                _ = Darwin.kill(childPID, SIGTERM)
+                _ = Darwin.kill(parentPID, SIGTERM)
+                guard parentExited.wait(timeout: .now() + 0.25) == .timedOut else {
+                    parent.waitUntilExit()
+                    return
+                }
+
+                _ = Darwin.kill(childPID, SIGKILL)
+                _ = Darwin.kill(parentPID, SIGKILL)
+                if parentExited.wait(timeout: .now() + 1.0) == .success {
+                    parent.waitUntilExit()
+                }
+            }
+        }
+
+        private func makeSleepingProcessTree() throws -> SleepingProcessTree {
+            let process = Process()
+            let stdout = Pipe()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+            process.arguments = [
+                "python3",
+                "-c",
+                "import subprocess; child=subprocess.Popen(['/bin/sleep','30']); print(child.pid, flush=True); child.wait()"
+            ]
+            process.standardOutput = stdout
+            let parentExited = DispatchSemaphore(value: 0)
+            process.terminationHandler = { _ in parentExited.signal() }
+            try process.run()
+            var data = Data()
+            while data.count < 32 {
+                guard let byte = try stdout.fileHandleForReading.read(upToCount: 1), !byte.isEmpty else { break }
+                if byte == Data([0x0A]) { break }
+                data.append(byte)
+            }
+            guard let text = String(data: data, encoding: .utf8),
+                  let childPID = pid_t(text.trimmingCharacters(in: .whitespacesAndNewlines))
+            else {
+                process.terminate()
+                process.waitUntilExit()
+                throw NSError(
+                    domain: "ContextBuilderRunLifecycleTests",
+                    code: 1,
+                    userInfo: [NSLocalizedDescriptionKey: "Failed to read child PID from process-tree fixture."]
+                )
+            }
+            return SleepingProcessTree(parent: process, childPID: childPID, parentExited: parentExited)
+        }
+    #endif
 
     private func makeRecord(
         tabID: UUID,
@@ -756,14 +891,59 @@ private final class CodexShapedBlockedRoutingTestProvider: HeadlessAgentProvider
     }
 }
 
-private final class ImmediateSuccessRoutingTestProvider: HeadlessAgentProvider {
+private final class PIDOwnedRetryRoutingTestProvider: HeadlessAgentProvider {
+    struct PolicyApplicationResult {
+        let outcome: String
+        let runID: UUID?
+    }
+
+    let connectionID = UUID()
+    private let clientName: String
+    private let expectedParentPID: pid_t
+    private let connectionPID: pid_t
+    private let connectionAttemptReady = LifecycleTestGate()
+    private let connectionAttemptRelease = LifecycleTestGate()
+    private let state = PIDOwnedRetryRoutingTestState()
+
+    init(clientName: String, expectedParentPID: pid_t, connectionPID: pid_t) {
+        self.clientName = clientName
+        self.expectedParentPID = expectedParentPID
+        self.connectionPID = connectionPID
+    }
+
     func streamAgentMessage(
         _ message: AgentMessage,
         runID: UUID?
     ) async throws -> AsyncThrowingStream<AIStreamResult, Error> {
         _ = message
         guard let runID else { throw CancellationError() }
-        await MCPRoutingWaiter.notifyRouted(runID: runID)
+        await connectionAttemptReady.arrive()
+        await connectionAttemptRelease.arriveAndWait()
+        #if DEBUG
+            await ServerNetworkManager.shared.registerExpectedAgentPID(
+                expectedParentPID,
+                for: clientName,
+                runID: runID
+            )
+            let result = await ServerNetworkManager.shared.debugApplyPendingPolicy(
+                clientName: clientName,
+                connectionID: connectionID,
+                clientPid: Int(connectionPID),
+                bootstrapClientName: "repoprompt_ce_cli_debug",
+                pidGateTimeout: 0.25,
+                requireRunRouting: false
+            )
+            await state.record(
+                PolicyApplicationResult(outcome: result.outcome, runID: result.runID)
+            )
+            if result.outcome == "applied", result.runID == runID {
+                await MCPRoutingWaiter.notifyRouted(runID: runID)
+            } else {
+                await MCPRoutingWaiter.notifyFailed(runID: runID)
+            }
+        #else
+            throw CancellationError()
+        #endif
         return AsyncThrowingStream { continuation in
             continuation.yield(AIStreamResult(type: "content", text: "retry-success"))
             continuation.finish()
@@ -771,6 +951,26 @@ private final class ImmediateSuccessRoutingTestProvider: HeadlessAgentProvider {
     }
 
     func dispose() async {}
+
+    func waitUntilConnectionAttemptReady() async {
+        await connectionAttemptReady.waitUntilArrived()
+    }
+
+    func releaseConnectionAttempt() async {
+        await connectionAttemptRelease.release()
+    }
+
+    func policyApplicationResult() async -> PolicyApplicationResult? {
+        await state.result
+    }
+}
+
+private actor PIDOwnedRetryRoutingTestState {
+    private(set) var result: PIDOwnedRetryRoutingTestProvider.PolicyApplicationResult?
+
+    func record(_ result: PIDOwnedRetryRoutingTestProvider.PolicyApplicationResult) {
+        self.result = result
+    }
 }
 
 private actor CodexShapedBlockedRoutingTestState {

--- a/Tests/RepoPromptTests/ContextBuilder/ContextBuilderRunLifecycleTests.swift
+++ b/Tests/RepoPromptTests/ContextBuilder/ContextBuilderRunLifecycleTests.swift
@@ -313,6 +313,176 @@ final class ContextBuilderRunLifecycleTests: XCTestCase {
         }
     }
 
+    func testMCPRoutingFailureAfterImmediateStreamReturnCleansBootstrapAndAllowsImmediateRetry() async throws {
+        #if DEBUG
+            let blockedProvider = CodexShapedBlockedRoutingTestProvider()
+            let retryProvider = ImmediateSuccessRoutingTestProvider()
+            let providers = LifecycleTestProviderQueue([blockedProvider, retryProvider])
+            let previousMCPEnabled = await ServerNetworkManager.shared.debugIsEnabledForBootstrapSocketURLOverride()
+
+            await HeadlessAgentConnectionGate.cancelAll()
+            let previousMCPAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
+            GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
+            let composition = WindowStateCompositionFactory.make(
+                windowID: -75,
+                deferredInitialAgentSystemWorkspaceRefresh: true,
+                sharedMCPService: MCPService(),
+                contextBuilderProviderFactory: { _, _, _ in providers.next() }
+            )
+            GlobalSettingsStore.shared.setMCPAutoStart(previousMCPAutoStart, commit: false)
+            await composition.workspaceManager.awaitInitialized()
+
+            do {
+                let workspaceRoot = FileManager.default.temporaryDirectory
+                    .appendingPathComponent("ContextBuilderMCPRoutingFailureTests-\(UUID().uuidString)")
+                try FileManager.default.createDirectory(
+                    at: workspaceRoot,
+                    withIntermediateDirectories: true
+                )
+                defer {
+                    try? FileManager.default.removeItem(at: workspaceRoot)
+                }
+
+                let workspace = composition.workspaceManager.createWorkspace(
+                    name: "Context Builder MCP routing failure test",
+                    repoPaths: [workspaceRoot.path],
+                    ephemeral: true
+                )
+                await composition.workspaceManager.switchWorkspace(
+                    to: workspace,
+                    saveState: false,
+                    reason: "ContextBuilderRunLifecycleTests.mcpRoutingFailure"
+                )
+
+                let activeWorkspace = try XCTUnwrap(composition.workspaceManager.activeWorkspace)
+                let tabID = try XCTUnwrap(
+                    activeWorkspace.activeComposeTabID ?? activeWorkspace.composeTabs.first?.id
+                )
+                let viewModel = composition.contextBuilderAgentViewModel
+                let savedAgent = viewModel.selectedAgent
+                let savedModelRaw = viewModel.selectedModelRaw
+                viewModel.selectedAgent = .codexExec
+                defer {
+                    viewModel.selectedAgent = savedAgent
+                    viewModel.selectModel(rawModel: savedModelRaw)
+                }
+
+                let firstTeardownCompleted = expectation(description: "failed provider teardown completed")
+                var firstRunID: UUID?
+                viewModel.installRunTestHooks(
+                    ContextBuilderAgentViewModel.RunTestHooks(
+                        beforeProcessingProviderEvent: nil,
+                        providerEventDisposition: nil,
+                        teardownCompleted: { runID in
+                            if runID == firstRunID {
+                                firstTeardownCompleted.fulfill()
+                            }
+                        }
+                    )
+                )
+                defer {
+                    viewModel.installRunTestHooks(nil)
+                }
+
+                let firstToken = try viewModel.beginMCPControlledRun(
+                    forTabID: tabID,
+                    responseType: nil,
+                    planModelName: nil
+                )
+                let firstWaiter = Task { @MainActor in
+                    try await viewModel.runContextBuilderForMCP(
+                        tabID: tabID,
+                        mcpControlToken: firstToken
+                    )
+                }
+
+                await blockedProvider.waitUntilInternalStartupEntered()
+                firstRunID = try XCTUnwrap(viewModel.activeRunIDForTesting(tabID: tabID))
+                let failedRunID = try XCTUnwrap(firstRunID)
+                let routingWaiterRegistered = await waitForRoutingWaiter(runID: failedRunID)
+                XCTAssertTrue(routingWaiterRegistered)
+                await MCPRoutingWaiter.notifyFailed(runID: failedRunID)
+
+                let firstSnapshot = try await firstWaiter.value
+                guard case let .failed(firstError) = firstSnapshot.runState else {
+                    XCTFail("Expected MCP routing failure, got \(firstSnapshot.runState)")
+                    throw MCPRoutingFailureTestError.unexpectedRunState
+                }
+                XCTAssertTrue(firstError.hasPrefix("mcp_routing_failed:"))
+                XCTAssertTrue(firstError.contains("codex-mcp-client"))
+                XCTAssertEqual(firstSnapshot.runID, failedRunID)
+
+                await blockedProvider.waitUntilInternalStartupCancellationObserved()
+                await blockedProvider.waitUntilDisposalStarted()
+                let startupCancellationCount = await blockedProvider.internalStartupCancellationCount()
+                let disposeCallCount = await blockedProvider.disposeCallCount()
+                let internalStartupCompleted = await blockedProvider.internalStartupCompleted()
+                let activeGateID = await HeadlessAgentConnectionGate.shared.debugActiveConnectionID()
+                let waitingGateCount = await HeadlessAgentConnectionGate.shared.debugWaitingCount()
+                let routingWaiterCount = await MCPRoutingWaiter.debugContinuationCount(runID: failedRunID)
+                XCTAssertEqual(startupCancellationCount, 1)
+                XCTAssertEqual(disposeCallCount, 1)
+                XCTAssertFalse(internalStartupCompleted)
+                XCTAssertNil(viewModel.activeRunIDForTesting(tabID: tabID))
+                XCTAssertTrue(viewModel.isRunTeardownPendingForTesting(runID: failedRunID))
+                XCTAssertNil(activeGateID)
+                XCTAssertEqual(waitingGateCount, 0)
+                XCTAssertEqual(routingWaiterCount, 0)
+                if let clientName = AgentProviderKind.codexExec.mcpClientNameHint {
+                    let pendingPolicies = await ServerNetworkManager.shared.debugPendingPolicySnapshot(
+                        for: clientName
+                    )
+                    XCTAssertFalse(pendingPolicies.contains { $0.runID == failedRunID })
+                }
+
+                let retryToken = try viewModel.beginMCPControlledRun(
+                    forTabID: tabID,
+                    responseType: nil,
+                    planModelName: nil
+                )
+                let retrySnapshot = try await viewModel.runContextBuilderForMCP(
+                    tabID: tabID,
+                    mcpControlToken: retryToken
+                )
+
+                XCTAssertEqual(retrySnapshot.runState, .completed)
+                XCTAssertEqual(retrySnapshot.agentOutput, "retry-success")
+                XCTAssertNotEqual(retrySnapshot.runID, failedRunID)
+                XCTAssertTrue(viewModel.isRunTeardownPendingForTesting(runID: failedRunID))
+                let disposeCallCountAfterRetry = await blockedProvider.disposeCallCount()
+                XCTAssertEqual(disposeCallCountAfterRetry, 1)
+
+                await blockedProvider.releaseDisposal()
+                await blockedProvider.waitUntilDisposalFinished()
+                await fulfillment(of: [firstTeardownCompleted], timeout: 1)
+                XCTAssertFalse(viewModel.isRunTeardownPendingForTesting(runID: failedRunID))
+
+                await composition.mcpServer.stopServer()
+                await composition.mcpServer.shutdownListener()
+                await ServerNetworkManager.shared.setEnabled(previousMCPEnabled)
+            } catch {
+                await blockedProvider.releaseInternalStartup()
+                await blockedProvider.releaseDisposal()
+                await composition.mcpServer.stopServer()
+                await composition.mcpServer.shutdownListener()
+                await ServerNetworkManager.shared.setEnabled(previousMCPEnabled)
+                throw error
+            }
+        #else
+            throw XCTSkip("MCP routing failure lifecycle inspection is DEBUG-only.")
+        #endif
+    }
+
+    private func waitForRoutingWaiter(runID: UUID) async -> Bool {
+        for _ in 0 ..< 1000 {
+            if await MCPRoutingWaiter.debugContinuationCount(runID: runID) == 1 {
+                return true
+            }
+            await Task.yield()
+        }
+        return false
+    }
+
     private func makeRecord(
         tabID: UUID,
         session: ContextBuilderAgentViewModel.TabSession,
@@ -489,4 +659,143 @@ private actor LifecycleTestGate {
             waiter.resume()
         }
     }
+}
+
+private final class CodexShapedBlockedRoutingTestProvider: HeadlessAgentProvider {
+    private let internalStartupEntered = LifecycleTestGate()
+    private let internalStartupBlock = LifecycleTestGate()
+    private let internalStartupCancellationObserved = LifecycleTestGate()
+    private let disposalStarted = LifecycleTestGate()
+    private let disposalBlock = LifecycleTestGate()
+    private let disposalFinished = LifecycleTestGate()
+    private let state = CodexShapedBlockedRoutingTestState()
+    private var internalStartupTask: Task<Void, Never>?
+    private var streamContinuation: AsyncThrowingStream<AIStreamResult, Error>.Continuation?
+
+    func streamAgentMessage(
+        _ message: AgentMessage,
+        runID: UUID?
+    ) async throws -> AsyncThrowingStream<AIStreamResult, Error> {
+        _ = message
+        _ = runID
+        return AsyncThrowingStream { continuation in
+            streamContinuation = continuation
+            internalStartupTask = Task { [weak self] in
+                guard let self else { return }
+                await withTaskCancellationHandler {
+                    await internalStartupEntered.arrive()
+                    await internalStartupBlock.arriveAndWait()
+                    guard !Task.isCancelled else { return }
+                    await state.recordInternalStartupCompleted()
+                    continuation.finish()
+                } onCancel: {
+                    Task { [weak self] in
+                        guard let self else { return }
+                        await state.recordInternalStartupCancellation()
+                        await internalStartupCancellationObserved.arrive()
+                        continuation.finish()
+                    }
+                }
+            }
+            continuation.onTermination = { [weak self] _ in
+                self?.internalStartupTask?.cancel()
+            }
+        }
+    }
+
+    func dispose() async {
+        await state.recordDisposeCall()
+        internalStartupTask?.cancel()
+        await internalStartupCancellationObserved.waitUntilArrived()
+        await internalStartupBlock.release()
+        await disposalStarted.arrive()
+        await disposalBlock.arriveAndWait()
+        streamContinuation?.finish()
+        streamContinuation = nil
+        await internalStartupTask?.value
+        internalStartupTask = nil
+        await state.recordDisposalFinished()
+        await disposalFinished.arrive()
+    }
+
+    func waitUntilInternalStartupEntered() async {
+        await internalStartupEntered.waitUntilArrived()
+    }
+
+    func waitUntilInternalStartupCancellationObserved() async {
+        await internalStartupCancellationObserved.waitUntilArrived()
+    }
+
+    func waitUntilDisposalStarted() async {
+        await disposalStarted.waitUntilArrived()
+    }
+
+    func waitUntilDisposalFinished() async {
+        await disposalFinished.waitUntilArrived()
+    }
+
+    func releaseInternalStartup() async {
+        internalStartupTask?.cancel()
+        await internalStartupBlock.release()
+    }
+
+    func releaseDisposal() async {
+        await disposalBlock.release()
+    }
+
+    func internalStartupCancellationCount() async -> Int {
+        await state.internalStartupCancellationCount
+    }
+
+    func internalStartupCompleted() async -> Bool {
+        await state.internalStartupCompleted
+    }
+
+    func disposeCallCount() async -> Int {
+        await state.disposeCallCount
+    }
+}
+
+private final class ImmediateSuccessRoutingTestProvider: HeadlessAgentProvider {
+    func streamAgentMessage(
+        _ message: AgentMessage,
+        runID: UUID?
+    ) async throws -> AsyncThrowingStream<AIStreamResult, Error> {
+        _ = message
+        guard let runID else { throw CancellationError() }
+        await MCPRoutingWaiter.notifyRouted(runID: runID)
+        return AsyncThrowingStream { continuation in
+            continuation.yield(AIStreamResult(type: "content", text: "retry-success"))
+            continuation.finish()
+        }
+    }
+
+    func dispose() async {}
+}
+
+private actor CodexShapedBlockedRoutingTestState {
+    private(set) var internalStartupCancellationCount = 0
+    private(set) var internalStartupCompleted = false
+    private(set) var disposeCallCount = 0
+    private(set) var disposalFinished = false
+
+    func recordInternalStartupCancellation() {
+        internalStartupCancellationCount += 1
+    }
+
+    func recordInternalStartupCompleted() {
+        internalStartupCompleted = true
+    }
+
+    func recordDisposeCall() {
+        disposeCallCount += 1
+    }
+
+    func recordDisposalFinished() {
+        disposalFinished = true
+    }
+}
+
+private enum MCPRoutingFailureTestError: Error {
+    case unexpectedRunState
 }

--- a/Tests/RepoPromptTests/MCP/MCPFileActionPartialSuccessTests.swift
+++ b/Tests/RepoPromptTests/MCP/MCPFileActionPartialSuccessTests.swift
@@ -1,0 +1,39 @@
+import MCP
+@testable import RepoPrompt
+import XCTest
+
+final class MCPFileActionPartialSuccessTests: XCTestCase {
+    func testCreateSelectionPersistenceWarningPreservesSuccessfulFileAction() throws {
+        let warning = "The file was created, but its selection was not confirmed. Retry manage_selection."
+        let dto = ToolResultDTOs.FileActionReply(
+            status: "ok",
+            action: "create",
+            path: "/tmp/Created.swift",
+            newPath: nil,
+            warning: warning
+        )
+        let value = try Self.value(dto)
+
+        let decoded = try XCTUnwrap(value.decode(ToolResultDTOs.FileActionReply.self))
+        XCTAssertEqual(decoded.status, "ok")
+        XCTAssertEqual(decoded.warning, warning)
+
+        let text = try Self.onlyText(ToolOutputFormatter.formatFileAction(value: value))
+        XCTAssertTrue(text.contains("## File Action ✅"), text)
+        XCTAssertTrue(text.contains("- Warning: \(warning)"), text)
+    }
+
+    private static func value(_ value: some Encodable) throws -> Value {
+        let data = try JSONEncoder().encode(value)
+        return try JSONDecoder().decode(Value.self, from: data)
+    }
+
+    private static func onlyText(_ blocks: [MCP.Tool.Content]) throws -> String {
+        let first = try XCTUnwrap(blocks.first)
+        guard case let .text(text, _, _) = first else {
+            XCTFail("Expected text content")
+            return ""
+        }
+        return text
+    }
+}

--- a/Tests/RepoPromptTests/MCP/TabContextRoutingTests.swift
+++ b/Tests/RepoPromptTests/MCP/TabContextRoutingTests.swift
@@ -487,6 +487,160 @@ final class TabContextRoutingTests: XCTestCase {
     }
 
     @MainActor
+    func testMCPSelectionPersistenceRereadsCanonicalSelectionAndReportsMismatch() async {
+        let activeTabID = UUID()
+        let inactiveTabID = UUID()
+        let staleSelection = StoredSelection(selectedPaths: ["/tmp/old-agent.swift"])
+        let requestedSelection = StoredSelection(
+            selectedPaths: ["/tmp/new-agent.swift"],
+            autoCodemapPaths: ["/tmp/new-dependency.swift"],
+            codemapAutoEnabled: false
+        )
+        let manager = FakeMCPSelectionManager(
+            tabs: [
+                ComposeTabState(id: activeTabID, name: "Active", selection: StoredSelection()),
+                ComposeTabState(id: inactiveTabID, name: "Agent", selection: staleSelection)
+            ],
+            activeTabID: activeTabID,
+            ignoreStoredOnlyUpdates: true
+        )
+        let coordinator = WorkspaceSelectionCoordinator(
+            workspaceManager: manager,
+            store: WorkspaceFileContextStore()
+        )
+
+        let result = await MCPServerViewModel.persistMCPSelectionAndVerifyThroughCoordinator(
+            requestedSelection,
+            for: inactiveTabID,
+            selectionCoordinator: coordinator
+        )
+
+        XCTAssertEqual(result.outcome, .persisted)
+        XCTAssertEqual(result.expectedSelection, requestedSelection)
+        XCTAssertEqual(result.canonicalSelection, staleSelection)
+        XCTAssertFalse(result.isVerified)
+        XCTAssertEqual(manager.composeTab(with: inactiveTabID)?.selection, staleSelection)
+    }
+
+    @MainActor
+    func testSelectionMutationRejectsCanonicalPersistenceMismatchWithActionableError() {
+        let tabID = UUID()
+        let requestedSelection = StoredSelection(selectedPaths: ["/tmp/requested.swift"])
+        let canonicalSelection = StoredSelection(selectedPaths: ["/tmp/stale.swift"])
+        let verification = MCPServerViewModel.MCPSelectionPersistenceVerification(
+            outcome: .persisted,
+            expectedSelection: requestedSelection,
+            canonicalSelection: canonicalSelection
+        )
+
+        XCTAssertThrowsError(try MCPSelectionToolProvider.requireCanonicalSelection(
+            verification,
+            requested: requestedSelection,
+            tabID: tabID,
+            operation: "manage_selection",
+            recovery: "Retry manage_selection for the same context_id or rebind the tab context before continuing."
+        )) { error in
+            let message = String(describing: error)
+            XCTAssertTrue(message.contains("Selection persistence handoff failed"), message)
+            XCTAssertTrue(message.contains(tabID.uuidString), message)
+            XCTAssertTrue(message.contains("Retry manage_selection for the same context_id"), message)
+        }
+    }
+
+    @MainActor
+    func testManageSelectionSetPersistsAcrossConnectionRebindAndWorkspaceSerialization() async throws {
+        let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
+        GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
+        let window = WindowState()
+        WindowStatesManager.shared.registerWindowState(window)
+        GlobalSettingsStore.shared.setMCPAutoStart(previousAutoStart, commit: false)
+        defer { WindowStatesManager.shared.unregisterWindowState(window) }
+
+        let root = try makeTemporaryDirectory(named: "tool-persistence-root")
+        let storageRoot = try makeTemporaryDirectory(named: "serialized-workspace")
+        defer {
+            try? FileManager.default.removeItem(at: root.deletingLastPathComponent())
+            try? FileManager.default.removeItem(at: storageRoot.deletingLastPathComponent())
+        }
+        let sources = root.appendingPathComponent("Sources", isDirectory: true)
+        try FileManager.default.createDirectory(at: sources, withIntermediateDirectories: true)
+        let selectedFile = sources.appendingPathComponent("App.swift")
+        try "struct App {}\n".write(to: selectedFile, atomically: true, encoding: .utf8)
+
+        let activeTabID = UUID()
+        let tabID = UUID()
+        let workspace = window.workspaceManager.createWorkspace(
+            name: "Selection Tool Persistence \(UUID().uuidString.prefix(8))",
+            repoPaths: [root.path],
+            ephemeral: true
+        )
+        let workspaceIndex = try XCTUnwrap(window.workspaceManager.workspaces.firstIndex { $0.id == workspace.id })
+        window.workspaceManager.workspaces[workspaceIndex].composeTabs = [
+            ComposeTabState(id: activeTabID, name: "Active"),
+            ComposeTabState(id: tabID, name: "Agent")
+        ]
+        window.workspaceManager.workspaces[workspaceIndex].activeComposeTabID = activeTabID
+        await window.workspaceManager.switchWorkspace(
+            to: window.workspaceManager.workspaces[workspaceIndex],
+            saveState: false,
+            reason: "manageSelectionPersistenceTestTabs"
+        )
+        _ = try await window.workspaceFileContextStore.loadRoot(path: root.path)
+        let tools = await window.mcpServer.windowMCPTools
+        let manageSelection = try XCTUnwrap(
+            tools.first { $0.name == MCPWindowToolName.manageSelection }
+        )
+
+        let firstConnectionID = UUID()
+        try window.mcpServer.bindTabForConnection(
+            connectionID: firstConnectionID,
+            clientName: "first-selection-client",
+            tabID: tabID,
+            workspaceID: workspace.id,
+            windowID: window.windowID
+        )
+        let setValue = try await ServerNetworkManager.withConnectionID(firstConnectionID) {
+            try await manageSelection([
+                "op": .string("set"),
+                "paths": .array([.string(selectedFile.path)]),
+                "mode": .string("full"),
+                "view": .string("files"),
+                "path_display": .string("full"),
+                "strict": .bool(true)
+            ])
+        }
+        XCTAssertEqual(try selectedPaths(from: setValue), [selectedFile.path])
+
+        await window.mcpServer.commitAndClearTabContext(connectionID: firstConnectionID)
+        let secondConnectionID = UUID()
+        try window.mcpServer.bindTabForConnection(
+            connectionID: secondConnectionID,
+            clientName: "second-selection-client",
+            tabID: tabID,
+            workspaceID: workspace.id,
+            windowID: window.windowID
+        )
+        let getValue = try await ServerNetworkManager.withConnectionID(secondConnectionID) {
+            try await manageSelection([
+                "op": .string("get"),
+                "view": .string("files"),
+                "path_display": .string("full")
+            ])
+        }
+        XCTAssertEqual(try selectedPaths(from: getValue), [selectedFile.path])
+
+        let canonicalTab = try XCTUnwrap(window.workspaceManager.composeTab(with: tabID))
+        XCTAssertEqual(canonicalTab.selection.selectedPaths, [selectedFile.path])
+
+        var workspaceToSave = try XCTUnwrap(window.workspaceManager.workspace(withID: workspace.id))
+        workspaceToSave.customStoragePath = storageRoot
+        let savedURL = try window.workspaceManager.saveWorkspaceToFile(workspaceToSave, source: .directUnknown)
+        let serializedWorkspace = try JSONDecoder().decode(WorkspaceModel.self, from: Data(contentsOf: savedURL))
+        let serializedTab = try XCTUnwrap(serializedWorkspace.composeTabs.first { $0.id == tabID })
+        XCTAssertEqual(serializedTab.selection.selectedPaths, [selectedFile.path])
+    }
+
+    @MainActor
     func testMCPLogicalizeSelectionForPersistenceConvertsWorktreePhysicalPaths() {
         let logicalRoot = WorkspaceRootRef(id: UUID(), name: "Project", fullPath: "/repo/project")
         let physicalRoot = WorkspaceRootRef(id: UUID(), name: "Project", fullPath: "/tmp/worktrees/project-agent")
@@ -617,6 +771,14 @@ final class TabContextRoutingTests: XCTestCase {
         ))
     }
 
+    private func selectedPaths(from value: Value) throws -> [String] {
+        let object = try XCTUnwrap(value.objectValue)
+        let files = try XCTUnwrap(object["files"]?.arrayValue)
+        return try files.map { file in
+            try XCTUnwrap(file.objectValue?["path"]?.stringValue)
+        }
+    }
+
     private func makeResolver(
         matchesByContextID: [UUID: [MCPContextBindingMatch]],
         existingWindowID: Int? = nil,
@@ -696,7 +858,10 @@ final class TabContextRoutingTests: XCTestCase {
 private final class FakeMCPSelectionManager: WorkspaceSelectionHost {
     var activeWorkspace: WorkspaceModel?
 
-    init(tabs: [ComposeTabState], activeTabID: UUID) {
+    private let ignoreStoredOnlyUpdates: Bool
+
+    init(tabs: [ComposeTabState], activeTabID: UUID, ignoreStoredOnlyUpdates: Bool = false) {
+        self.ignoreStoredOnlyUpdates = ignoreStoredOnlyUpdates
         activeWorkspace = WorkspaceModel(
             name: "Test Workspace",
             repoPaths: [],
@@ -712,6 +877,7 @@ private final class FakeMCPSelectionManager: WorkspaceSelectionHost {
     func publishActiveComposeTabSnapshot(commitToMemory: Bool, touchModified: Bool) {}
 
     func updateComposeTabStoredOnly(_ tab: ComposeTabState) {
+        guard !ignoreStoredOnlyUpdates else { return }
         guard var workspace = activeWorkspace,
               let index = workspace.composeTabs.firstIndex(where: { $0.id == tab.id })
         else { return }


### PR DESCRIPTION
## Summary
- verify MCP selection mutations against canonical persisted tab state and fail closed on handoff mismatches
- refresh bound tab snapshots without overwriting newer prompt/meta state
- make missing run-scoped MCP routing terminal for MCP-initiated Context Builder runs after provider stream creation
- cancel and clean bootstrap/provider state on routing failure so an immediate retry can proceed
- add regression coverage for selection set/get across connection rebinding and Codex-shaped blocked startup cleanup/retry

## Validation
- commit preflight: whitespace, staged-index gitleaks scan, repository guardrails
- push preflight: outgoing-range gitleaks scan, strict Swift lint, full `swift test`, RepoPrompt product build
- focused Context Builder, routing, lease, selection persistence, and tab routing suites

No visible or live CE app was launched, stopped, or contacted during final validation.
