### PR TITLE
Fix Agent Mode follow-up submission races

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+ComposerUI.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+ComposerUI.swift
@@ -55,11 +55,13 @@ extension AgentModeViewModel {
     }
 
     func makeComposerSubmitTarget(tabID: UUID?, session: TabSession?) -> AgentComposerSubmitTarget? {
-        guard let tabID,
-              session?.isPreparingInitialWorktree != true,
-              session?.isChangingExecutionLocation != true
+        guard let tabID else { return nil }
+        let resolvedSession = session ?? self.session(for: tabID)
+        guard !resolvedSession.isComposerSubmissionInFlight,
+              !resolvedSession.isPreparingInitialWorktree,
+              !resolvedSession.isChangingExecutionLocation
         else { return nil }
-        let expectedSourceAgentSessionID = composerSourceAgentSessionID(tabID: tabID, session: session)
+        let expectedSourceAgentSessionID = composerSourceAgentSessionID(tabID: tabID, session: resolvedSession)
         let hasLinkedSession = hasLinkedAgentSession(for: tabID)
         let route: AgentComposerSubmitTarget.Route
         if hasLinkedSession {
@@ -67,18 +69,16 @@ extension AgentModeViewModel {
             route = .existingAgentSession
         } else {
             guard expectedSourceAgentSessionID == nil else { return nil }
-            if let session {
-                guard !session.runState.isActive,
-                      session.runID == nil,
-                      session.activeRunAttemptID == nil
-                else { return nil }
-            }
+            guard !resolvedSession.runState.isActive,
+                  resolvedSession.runID == nil,
+                  resolvedSession.activeRunAttemptID == nil
+            else { return nil }
             route = .createAgentSessionFromSourceTab
         }
 
-        let expectedRunState = session?.runState ?? .idle
-        let expectedRunID = session?.runID
-        let expectedRunAttemptID = session?.activeRunAttemptID
+        let expectedRunState = resolvedSession.runState
+        let expectedRunID = resolvedSession.runID
+        let expectedRunAttemptID = resolvedSession.activeRunAttemptID
         guard !expectedRunState.isActive || expectedRunID != nil else { return nil }
         let expectedInitialStartLocation = initialStartLocationProps(tabID: tabID)?.selection
         return AgentComposerSubmitTarget(
@@ -88,6 +88,7 @@ extension AgentModeViewModel {
             expectedRunState: expectedRunState,
             expectedRunID: expectedRunID,
             expectedRunAttemptID: expectedRunAttemptID,
+            expectedSubmissionToken: resolvedSession.composerSubmissionToken,
             expectedInitialStartLocation: expectedInitialStartLocation
         )
     }

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+TabSession.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+TabSession.swift
@@ -96,6 +96,8 @@ extension AgentModeViewModel {
         /// Ephemeral location intent for a new manual thread. It is consumed on first send
         /// and intentionally never persisted as session state.
         var pendingInitialStartLocation: InitialStartLocation = .local
+        var composerSubmissionToken = UUID()
+        var isComposerSubmissionInFlight = false
         var isPreparingInitialWorktree: Bool = false
         var isChangingExecutionLocation: Bool = false
 

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -9957,11 +9957,27 @@ final class AgentModeViewModel: ObservableObject {
             resyncAfterRejectedSubmitTarget(target)
             return .blocked(message: Self.staleComposerSubmitTargetMessage)
         }
+        guard let claimedSourceSession = claimComposerSubmitTarget(target) else {
+            logRejectedSubmitTarget(target, session: sessions[target.tabID], reason: "submission_token_mismatch")
+            resyncAfterRejectedSubmitTarget(target)
+            return .blocked(message: Self.staleComposerSubmitTargetMessage)
+        }
+        defer {
+            claimedSourceSession.isComposerSubmissionInFlight = false
+            resyncAfterConsumedSubmitTarget(target)
+        }
 
         switch target.route {
         case .existingAgentSession:
             let preparedSession = await ensureSessionReady(tabID: target.tabID)
-            if let rejectionReason = submitTargetRejectionReason(target, session: preparedSession) {
+            guard preparedSession === claimedSourceSession else {
+                return .blocked(message: Self.staleComposerSubmitTargetMessage)
+            }
+            if let rejectionReason = submitTargetRejectionReason(
+                target,
+                session: preparedSession,
+                validateSubmissionToken: false
+            ) {
                 logRejectedSubmitTarget(target, session: preparedSession, reason: rejectionReason)
                 resyncAfterRejectedSubmitTarget(target)
                 return .blocked(message: Self.staleComposerSubmitTargetMessage)
@@ -9997,11 +10013,22 @@ final class AgentModeViewModel: ObservableObject {
                 try await prepareInitialExecutionLocation(initialLocation, for: preparedSession) {
                     !Task.isCancelled
                         && self.sessions[target.tabID] === preparedSession
+                        && self.composerSourceAgentSessionID(
+                            tabID: target.tabID,
+                            session: preparedSession
+                        ) == target.expectedSourceAgentSessionID
                         && sourceSnapshot.matches(self.sessions[target.tabID])
                         && Self.pendingUserTurnState(from: preparedSession) == pendingState
                 }
             } catch {
                 return .blocked(message: (error as? LocalizedError)?.errorDescription ?? error.localizedDescription)
+            }
+            guard composerSourceAgentSessionID(tabID: target.tabID, session: preparedSession)
+                == target.expectedSourceAgentSessionID
+            else {
+                logRejectedSubmitTarget(target, session: preparedSession, reason: "agent_session_id_mismatch")
+                resyncAfterRejectedSubmitTarget(target)
+                return .blocked(message: Self.staleComposerSubmitTargetMessage)
             }
             guard !Task.isCancelled,
                   sessions[target.tabID] === preparedSession,
@@ -10019,7 +10046,7 @@ final class AgentModeViewModel: ObservableObject {
             }
             return submitUserTurn(text: text, tabID: target.tabID)
         case .createAgentSessionFromSourceTab:
-            let sourceSession = session(for: target.tabID, createIfNeeded: false)
+            let sourceSession = claimedSourceSession
             let sourceSnapshot = FirstSendSourceSnapshot(
                 session: sourceSession,
                 fallbackSelectedAgent: selectedAgent,
@@ -10030,13 +10057,13 @@ final class AgentModeViewModel: ObservableObject {
             let pendingState = Self.pendingUserTurnState(from: sourceSession)
             let preparesExecutionLocation = pendingState.initialStartLocation != .local
             if preparesExecutionLocation {
-                sourceSession?.isPreparingInitialWorktree = true
+                sourceSession.isPreparingInitialWorktree = true
                 syncComposerUIState(tabID: target.tabID)
                 syncStatusPillsUIState()
             }
             defer {
                 if preparesExecutionLocation {
-                    sourceSession?.isPreparingInitialWorktree = false
+                    sourceSession.isPreparingInitialWorktree = false
                     if target.tabID == currentTabID {
                         syncComposerUIState(tabID: target.tabID)
                         syncStatusPillsUIState()
@@ -10050,7 +10077,15 @@ final class AgentModeViewModel: ObservableObject {
                 await discardFreshFirstSendDestinationIfPossible(destinationTabID)
                 return .blocked(message: Self.staleComposerSubmitTargetMessage)
             }
-            if let rejectionReason = submitTargetRejectionReason(target, session: sessions[target.tabID]) {
+            guard sessions[target.tabID] === sourceSession else {
+                await discardFreshFirstSendDestinationIfPossible(destinationTabID)
+                return .blocked(message: Self.staleComposerSubmitTargetMessage)
+            }
+            if let rejectionReason = submitTargetRejectionReason(
+                target,
+                session: sourceSession,
+                validateSubmissionToken: false
+            ) {
                 logRejectedSubmitTarget(target, session: sessions[target.tabID], reason: rejectionReason)
                 resyncAfterRejectedSubmitTarget(target)
                 await discardFreshFirstSendDestinationIfPossible(destinationTabID)
@@ -10101,6 +10136,7 @@ final class AgentModeViewModel: ObservableObject {
                     try await prepareInitialExecutionLocation(pendingState.initialStartLocation, for: destinationSession) {
                         !Task.isCancelled
                             && self.sessions[destinationTabID] === destinationSession
+                            && self.sessions[target.tabID] === sourceSession
                             && sourceSnapshot.matches(self.sessions[target.tabID])
                             && Self.pendingUserTurnState(from: destinationSession) == pendingState
                     }
@@ -10112,6 +10148,7 @@ final class AgentModeViewModel: ObservableObject {
             }
             guard !Task.isCancelled,
                   sessions[destinationTabID] === destinationSession,
+                  sessions[target.tabID] === sourceSession,
                   sourceSnapshot.matches(sessions[target.tabID]),
                   Self.pendingUserTurnState(from: destinationSession) == pendingState
             else {
@@ -13004,7 +13041,28 @@ final class AgentModeViewModel: ObservableObject {
         }
     }
 
-    private func submitTargetRejectionReason(_ target: AgentComposerSubmitTarget, session: TabSession?) -> String? {
+    private func claimComposerSubmitTarget(_ target: AgentComposerSubmitTarget) -> TabSession? {
+        guard let session = sessions[target.tabID],
+              !session.isComposerSubmissionInFlight,
+              session.composerSubmissionToken == target.expectedSubmissionToken
+        else { return nil }
+        session.isComposerSubmissionInFlight = true
+        session.composerSubmissionToken = UUID()
+        return session
+    }
+
+    private func resyncAfterConsumedSubmitTarget(_ target: AgentComposerSubmitTarget) {
+        if currentTabID == target.tabID {
+            syncComposerUIState(tabID: target.tabID)
+        }
+        requestUIRefresh(tabID: target.tabID, urgent: true)
+    }
+
+    private func submitTargetRejectionReason(
+        _ target: AgentComposerSubmitTarget,
+        session: TabSession?,
+        validateSubmissionToken: Bool = true
+    ) -> String? {
         let liveHasLinkedSession = hasLinkedAgentSession(for: target.tabID)
         let liveSourceAgentSessionID = composerSourceAgentSessionID(tabID: target.tabID, session: session)
         let liveRunState = session?.runState ?? .idle
@@ -13012,36 +13070,48 @@ final class AgentModeViewModel: ObservableObject {
         let liveRunAttemptID = session?.activeRunAttemptID
         let liveInitialStartLocation = initialStartLocationProps(tabID: target.tabID)?.selection
 
+        if validateSubmissionToken, session?.composerSubmissionToken != target.expectedSubmissionToken {
+            return "submission_token_mismatch"
+        }
+
         switch target.route {
         case .existingAgentSession:
             guard liveHasLinkedSession else { return "linked_state_mismatch" }
+            guard let expectedSourceAgentSessionID = target.expectedSourceAgentSessionID else {
+                return "missing_expected_agent_session_id"
+            }
+            guard liveSourceAgentSessionID == expectedSourceAgentSessionID else {
+                return "agent_session_id_mismatch"
+            }
+            guard liveInitialStartLocation == target.expectedInitialStartLocation else {
+                return "initial_start_location_mismatch"
+            }
+            return nil
         case .createAgentSessionFromSourceTab:
             guard !liveHasLinkedSession else { return "linked_state_mismatch" }
+            guard liveSourceAgentSessionID == target.expectedSourceAgentSessionID else {
+                return "agent_session_id_mismatch"
+            }
+            guard liveRunState == target.expectedRunState else {
+                return "run_state_mismatch"
+            }
+            if liveRunState.isActive, target.expectedRunID == nil {
+                return "missing_expected_run_id"
+            }
+            guard liveRunID == target.expectedRunID else {
+                return "run_id_mismatch"
+            }
+            guard liveRunAttemptID == target.expectedRunAttemptID else {
+                return "run_attempt_id_mismatch"
+            }
+            guard liveInitialStartLocation == target.expectedInitialStartLocation else {
+                return "initial_start_location_mismatch"
+            }
+            if liveSourceAgentSessionID != nil || liveRunState.isActive || liveRunID != nil || liveRunAttemptID != nil {
+                return "unlinked_source_has_run_identity"
+            }
+            return nil
         }
-        guard liveSourceAgentSessionID == target.expectedSourceAgentSessionID else {
-            return "agent_session_id_mismatch"
-        }
-        guard liveRunState == target.expectedRunState else {
-            return "run_state_mismatch"
-        }
-        if liveRunState.isActive, target.expectedRunID == nil {
-            return "missing_expected_run_id"
-        }
-        guard liveRunID == target.expectedRunID else {
-            return "run_id_mismatch"
-        }
-        guard liveRunAttemptID == target.expectedRunAttemptID else {
-            return "run_attempt_id_mismatch"
-        }
-        guard liveInitialStartLocation == target.expectedInitialStartLocation else {
-            return "initial_start_location_mismatch"
-        }
-        if target.route == .createAgentSessionFromSourceTab,
-           liveSourceAgentSessionID != nil || liveRunState.isActive || liveRunID != nil || liveRunAttemptID != nil
-        {
-            return "unlinked_source_has_run_identity"
-        }
-        return nil
     }
 
     private func logRejectedSubmitTarget(_ target: AgentComposerSubmitTarget, session: TabSession?, reason: String) {
@@ -13065,7 +13135,9 @@ final class AgentModeViewModel: ObservableObject {
                     "expectedRunID": AgentModePerfDiagnostics.shortID(target.expectedRunID),
                     "liveRunID": AgentModePerfDiagnostics.shortID(session?.runID),
                     "expectedRunAttemptID": AgentModePerfDiagnostics.shortID(target.expectedRunAttemptID),
-                    "liveRunAttemptID": AgentModePerfDiagnostics.shortID(session?.activeRunAttemptID)
+                    "liveRunAttemptID": AgentModePerfDiagnostics.shortID(session?.activeRunAttemptID),
+                    "expectedSubmissionToken": AgentModePerfDiagnostics.shortID(target.expectedSubmissionToken),
+                    "liveSubmissionToken": AgentModePerfDiagnostics.shortID(session?.composerSubmissionToken)
                 ]
             )
         #endif

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentComposerUIModels.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentComposerUIModels.swift
@@ -53,9 +53,14 @@ struct AgentComposerSubmitTarget: Equatable {
     let tabID: UUID
     let route: Route
     let expectedSourceAgentSessionID: UUID?
+    // Exact freshness guards for unlinked first-send targets. For an existing
+    // persistent session, these remain render-time diagnostics while live routing
+    // selects the current run and attempt at send time.
     let expectedRunState: AgentSessionRunState
     let expectedRunID: UUID?
     let expectedRunAttemptID: UUID?
+    /// One-shot render identity claimed before submission performs any async work.
+    let expectedSubmissionToken: UUID
     let expectedInitialStartLocation: AgentModeViewModel.InitialStartLocation?
 }
 

--- a/Tests/RepoPromptTests/AgentMode/AgentModeStopSubmitTargetTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeStopSubmitTargetTests.swift
@@ -82,7 +82,52 @@ final class AgentModeStopSubmitTargetTests: XCTestCase {
         let staleTarget = vm.makeRunCancelTarget(tabID: tabID, session: session)
         let newerRunID = UUID()
         session.runID = newerRunID
+
+        let accepted = await vm.cancelAgentRun(target: staleTarget, completion: .terminalPublished)
+
+        XCTAssertFalse(accepted)
+        XCTAssertEqual(session.runState, .running)
+        XCTAssertTrue(cancelledRunIDs.isEmpty)
+    }
+
+    func testGuardedCancelRejectsStaleTargetAfterAgentSessionReplacement() async throws {
+        var cancelledRunIDs: [UUID] = []
+        let vm = makeViewModel { runID, _ in
+            cancelledRunIDs.append(runID)
+            return 0
+        }
+        let tabID = UUID()
+        vm.ensureSession(for: tabID)
+        let session = try XCTUnwrap(vm.sessions[tabID])
+        session.runState = .running
+        session.runID = UUID()
+        session.testInstallPersistentSessionBinding(sessionID: UUID())
         session.beginRunAttempt(source: "test")
+        let staleTarget = vm.makeRunCancelTarget(tabID: tabID, session: session)
+        session.testInstallPersistentSessionBinding(sessionID: UUID())
+
+        let accepted = await vm.cancelAgentRun(target: staleTarget, completion: .terminalPublished)
+
+        XCTAssertFalse(accepted)
+        XCTAssertEqual(session.runState, .running)
+        XCTAssertTrue(cancelledRunIDs.isEmpty)
+    }
+
+    func testGuardedCancelRejectsStaleTargetAfterRunAttemptRotation() async throws {
+        var cancelledRunIDs: [UUID] = []
+        let vm = makeViewModel { runID, _ in
+            cancelledRunIDs.append(runID)
+            return 0
+        }
+        let tabID = UUID()
+        vm.ensureSession(for: tabID)
+        let session = try XCTUnwrap(vm.sessions[tabID])
+        session.runState = .running
+        session.runID = UUID()
+        session.testInstallPersistentSessionBinding(sessionID: UUID())
+        session.beginRunAttempt(source: "test")
+        let staleTarget = vm.makeRunCancelTarget(tabID: tabID, session: session)
+        session.beginRunAttempt(source: "test.rotated")
 
         let accepted = await vm.cancelAgentRun(target: staleTarget, completion: .terminalPublished)
 
@@ -103,7 +148,10 @@ final class AgentModeStopSubmitTargetTests: XCTestCase {
         otherSession.hasLoadedPersistedState = true
         targetSession.selectedAgent = .codexExec
         otherSession.selectedAgent = .codexExec
+        targetSession.testInstallPersistentSessionBinding(sessionID: UUID())
+        otherSession.testInstallPersistentSessionBinding(sessionID: UUID())
         let target = try XCTUnwrap(vm.makeComposerSubmitTarget(tabID: targetTabID, session: targetSession))
+        XCTAssertEqual(target.route, .existingAgentSession)
         vm.test_setCurrentTabIDOverride(otherTabID)
         defer { vm.test_setCurrentTabIDOverride(nil) }
 
@@ -121,36 +169,209 @@ final class AgentModeStopSubmitTargetTests: XCTestCase {
         XCTAssertTrue(otherSession.items.isEmpty)
     }
 
-    func testGuardedSubmitRejectsMismatchedRunIdentityAndPreservesDraft() async throws {
-        let vm = makeViewModel()
+    func testGuardedExistingSessionSubmitAcceptsLiveRunStartedAfterTargetCaptureExactlyOnce() async throws {
+        let recorder = StopSubmitSendRecorder()
+        let controller = StopSubmitNoopCodexController(recorder: recorder, hasActiveThread: true)
+        let vm = makeViewModel(codexController: controller)
         let tabID = UUID()
         vm.ensureSession(for: tabID)
         let session = try XCTUnwrap(vm.sessions[tabID])
+        session.hasLoadedPersistedState = true
+        session.hasSentFirstMessage = true
+        session.selectedAgent = .codexExec
+        session.testInstallPersistentSessionBinding(sessionID: UUID())
+        let target = try XCTUnwrap(vm.makeComposerSubmitTarget(tabID: tabID, session: session))
+        XCTAssertEqual(target.route, .existingAgentSession)
+        XCTAssertEqual(target.expectedRunState, .idle)
+        XCTAssertNil(target.expectedRunID)
+        XCTAssertNil(target.expectedRunAttemptID)
+        XCTAssertNil(target.expectedInitialStartLocation)
+
+        let liveRunID = UUID()
+        let liveAttemptID = UUID()
+        session.runState = .running
+        session.runID = liveRunID
+        session.beginRunAttempt(source: "test.liveRunStarted", attemptID: liveAttemptID)
+        let sendAttemptID = session.codexSteerAckTracker.beginAttempt()
+
+        let result = await vm.submitUserTurnCreatingSessionIfNeeded(text: "send to live run", target: target)
+        let sendAck = await session.codexSteerAckTracker.awaitAck(attemptID: sendAttemptID)
+
+        XCTAssertEqual(result, .submitted)
+        XCTAssertEqual(sendAck, .sendOutcome(.sent))
+        XCTAssertEqual(session.items.filter { $0.kind == .user }.map(\.text), ["send to live run"])
+        XCTAssertEqual(recorder.sentTexts(), ["send to live run"])
+        XCTAssertNotNil(session.runID)
+        XCTAssertNotNil(session.activeRunAttemptID)
+    }
+
+    func testGuardedExistingSessionSubmitAcceptsRotatedCodexAttemptExactlyOnce() async throws {
+        let recorder = StopSubmitSendRecorder()
+        let controller = StopSubmitNoopCodexController(recorder: recorder, hasActiveThread: true)
+        let vm = makeViewModel(codexController: controller)
+        let tabID = UUID()
+        vm.ensureSession(for: tabID)
+        let session = try XCTUnwrap(vm.sessions[tabID])
+        session.hasLoadedPersistedState = true
+        session.selectedAgent = .codexExec
+        session.testInstallPersistentSessionBinding(sessionID: UUID())
+        session.runState = .running
+        let liveRunID = UUID()
+        session.runID = liveRunID
+        let firstOwnership = session.beginRunAttempt(source: "test.firstAttempt", attemptID: UUID())
+        let target = try XCTUnwrap(vm.makeComposerSubmitTarget(tabID: tabID, session: session))
+        XCTAssertEqual(target.route, .existingAgentSession)
+        XCTAssertEqual(target.expectedRunAttemptID, firstOwnership.attemptID)
+
+        XCTAssertTrue(session.endRunAttempt(ifCurrent: firstOwnership, source: "test.rotateAttempt"))
+        let liveAttemptID = UUID()
+        session.beginRunAttempt(source: "test.secondAttempt", attemptID: liveAttemptID)
+        let sendAttemptID = session.codexSteerAckTracker.beginAttempt()
+
+        let result = await vm.submitUserTurnCreatingSessionIfNeeded(text: "send after attempt rotation", target: target)
+        let sendAck = await session.codexSteerAckTracker.awaitAck(attemptID: sendAttemptID)
+
+        XCTAssertEqual(result, .submitted)
+        XCTAssertEqual(sendAck, .sendOutcome(.sent))
+        XCTAssertEqual(session.items.filter { $0.kind == .user }.map(\.text), ["send after attempt rotation"])
+        XCTAssertEqual(recorder.sentTexts(), ["send after attempt rotation"])
+        XCTAssertNotNil(session.runID)
+        XCTAssertNotNil(session.activeRunAttemptID)
+        XCTAssertNotEqual(session.activeRunAttemptID, firstOwnership.attemptID)
+    }
+
+    func testGuardedExistingSessionSubmitRejectsReusedRenderTargetAfterFirstTurnIsAccepted() async throws {
+        let recorder = StopSubmitSendRecorder()
+        let controller = StopSubmitNoopCodexController(recorder: recorder, hasActiveThread: true)
+        let vm = makeViewModel(codexController: controller)
+        let tabID = UUID()
+        vm.ensureSession(for: tabID)
+        let session = try XCTUnwrap(vm.sessions[tabID])
+        session.hasLoadedPersistedState = true
+        session.hasSentFirstMessage = true
+        session.selectedAgent = .codexExec
+        session.testInstallPersistentSessionBinding(sessionID: UUID())
         session.runState = .running
         session.runID = UUID()
         session.beginRunAttempt(source: "test")
-        vm.storeDraftText(for: tabID, "stale steering")
-        let staleTarget = AgentComposerSubmitTarget(
-            tabID: tabID,
-            route: .existingAgentSession,
-            expectedSourceAgentSessionID: session.activeAgentSessionID,
-            expectedRunState: .running,
-            expectedRunID: UUID(),
-            expectedRunAttemptID: session.activeRunAttemptID,
-            expectedInitialStartLocation: nil
-        )
+        let target = try XCTUnwrap(vm.makeComposerSubmitTarget(tabID: tabID, session: session))
+        let sendAttemptID = session.codexSteerAckTracker.beginAttempt()
 
-        let result = await vm.submitUserTurnCreatingSessionIfNeeded(text: "stale steering", target: staleTarget)
+        let firstResult = await vm.submitUserTurnCreatingSessionIfNeeded(text: "send once", target: target)
+        let reusedResult = await vm.submitUserTurnCreatingSessionIfNeeded(text: "send once", target: target)
+        let sendAck = await session.codexSteerAckTracker.awaitAck(attemptID: sendAttemptID)
 
-        guard case let .blocked(message) = result else {
-            return XCTFail("Expected stale target to be blocked")
+        XCTAssertEqual(firstResult, .submitted)
+        guard case let .blocked(message) = reusedResult else {
+            return XCTFail("Expected reused render target to be blocked")
         }
         XCTAssertFalse(message.isEmpty)
-        XCTAssertEqual(vm.retrieveDraftText(for: tabID), "stale steering")
+        XCTAssertEqual(sendAck, .sendOutcome(.sent))
+        XCTAssertEqual(session.items.filter { $0.kind == .user }.map(\.text), ["send once"])
+        XCTAssertEqual(recorder.sentTexts(), ["send once"])
+    }
+
+    func testGuardedExistingSessionSubmitRejectsReusedControlCommandTargetWithoutUserBubble() async throws {
+        let recorder = StopSubmitSendRecorder()
+        let controller = StopSubmitNoopCodexController(recorder: recorder, hasActiveThread: true)
+        let vm = makeViewModel(codexController: controller)
+        let tabID = UUID()
+        vm.ensureSession(for: tabID)
+        let session = try XCTUnwrap(vm.sessions[tabID])
+        session.hasLoadedPersistedState = true
+        session.hasSentFirstMessage = true
+        session.selectedAgent = .codexExec
+        session.codexConversationID = "noop"
+        session.testInstallPersistentSessionBinding(sessionID: UUID())
+        let target = try XCTUnwrap(vm.makeComposerSubmitTarget(tabID: tabID, session: session))
+        let sendAttemptID = session.codexSteerAckTracker.beginAttempt()
+
+        let firstResult = await vm.submitUserTurnCreatingSessionIfNeeded(text: "/compact", target: target)
+        let reusedResult = await vm.submitUserTurnCreatingSessionIfNeeded(text: "/compact", target: target)
+        let sendAck = await session.codexSteerAckTracker.awaitAck(attemptID: sendAttemptID)
+
+        XCTAssertEqual(firstResult, .submitted)
+        guard case let .blocked(message) = reusedResult else {
+            return XCTFail("Expected reused control-command target to be blocked")
+        }
+        XCTAssertFalse(message.isEmpty)
+        XCTAssertEqual(sendAck, .sendOutcome(.sent))
+        XCTAssertTrue(session.items.filter { $0.kind == .user }.isEmpty)
+        XCTAssertEqual(recorder.compactionInvocationCount(), 1)
+    }
+
+    func testGuardedFirstSendRejectsReusedSourceTargetBeforeCreatingAnotherDestination() async throws {
+        let vm = makeViewModel()
+        let sourceTabID = UUID()
+        let destinationTabID = UUID()
+        let sourceSession = await vm.ensureSessionReady(tabID: sourceTabID)
+        sourceSession.selectedAgent = .codexExec
+        let target = try XCTUnwrap(vm.makeComposerSubmitTarget(tabID: sourceTabID, session: sourceSession))
+        XCTAssertEqual(target.route, .createAgentSessionFromSourceTab)
+        var createCount = 0
+
+        let firstResult = await vm.submitUserTurnCreatingSessionIfNeeded(
+            text: "create once",
+            target: target,
+            createAndActivateSessionTab: {
+                createCount += 1
+                XCTAssertNil(vm.makeComposerSubmitTarget(tabID: sourceTabID, session: sourceSession))
+                return destinationTabID
+            }
+        )
+        let reusedResult = await vm.submitUserTurnCreatingSessionIfNeeded(
+            text: "create twice",
+            target: target,
+            createAndActivateSessionTab: {
+                createCount += 1
+                return UUID()
+            }
+        )
+
+        XCTAssertEqual(firstResult, .submitted)
+        guard case let .blocked(message) = reusedResult else {
+            return XCTFail("Expected reused first-send target to be blocked")
+        }
+        XCTAssertFalse(message.isEmpty)
+        XCTAssertEqual(createCount, 1)
+        let destinationSession = try XCTUnwrap(vm.sessions[destinationTabID])
+        XCTAssertEqual(destinationSession.items.filter { $0.kind == .user }.map(\.text), ["create once"])
+    }
+
+    func testGuardedExistingSessionSubmitRejectsPersistentSessionReplacementAndPreservesDraft() async throws {
+        let recorder = StopSubmitSendRecorder()
+        let controller = StopSubmitNoopCodexController(recorder: recorder, hasActiveThread: true)
+        let vm = makeViewModel(codexController: controller)
+        let tabID = UUID()
+        vm.ensureSession(for: tabID)
+        let session = try XCTUnwrap(vm.sessions[tabID])
+        session.hasLoadedPersistedState = true
+        session.selectedAgent = .codexExec
+        let originalSessionID = UUID()
+        session.testInstallPersistentSessionBinding(sessionID: originalSessionID)
+        let staleTarget = try XCTUnwrap(vm.makeComposerSubmitTarget(tabID: tabID, session: session))
+        XCTAssertEqual(staleTarget.route, .existingAgentSession)
+        XCTAssertEqual(staleTarget.expectedSourceAgentSessionID, originalSessionID)
+        vm.storeDraftText(for: tabID, "draft survives replacement")
+
+        let replacementSessionID = UUID()
+        session.testInstallPersistentSessionBinding(sessionID: replacementSessionID)
+        let result = await vm.submitUserTurnCreatingSessionIfNeeded(
+            text: "draft survives replacement",
+            target: staleTarget
+        )
+
+        guard case let .blocked(message) = result else {
+            return XCTFail("Expected replaced persistent session target to be blocked")
+        }
+        XCTAssertFalse(message.isEmpty)
+        XCTAssertEqual(session.activeAgentSessionID, replacementSessionID)
+        XCTAssertEqual(vm.retrieveDraftText(for: tabID), "draft survives replacement")
         XCTAssertTrue(session.items.isEmpty)
         XCTAssertTrue(session.pendingInstructions.isEmpty)
         XCTAssertTrue(session.pendingClaudeSteeringInstructions.isEmpty)
         XCTAssertTrue(session.pendingACPSteeringInstructions.isEmpty)
+        XCTAssertTrue(recorder.sentTexts().isEmpty)
     }
 
     func testFreshManualThreadProjectsAndUpdatesInitialStartLocation() async {
@@ -423,24 +644,77 @@ final class AgentModeStopSubmitTargetTests: XCTestCase {
     }
 
     private func makeViewModel(
-        onCancelTools: @escaping AgentModeViewModel.MCPRunToolCanceller = { _, _ in 0 }
+        onCancelTools: @escaping AgentModeViewModel.MCPRunToolCanceller = { _, _ in 0 },
+        codexController: StopSubmitNoopCodexController? = nil
     ) -> AgentModeViewModel {
         AgentModeViewModel(
             testWindowID: 1,
             testWorkspacePath: FileManager.default.currentDirectoryPath,
-            codexControllerFactory: { _, _, _, _, _, _ in StopSubmitNoopCodexController() },
+            codexControllerFactory: { _, _, _, _, _, _ in
+                codexController ?? StopSubmitNoopCodexController()
+            },
             mcpRunToolCanceller: onCancelTools
         )
     }
 }
 
+private final class StopSubmitSendRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var texts: [String] = []
+    private var compactionInvocations = 0
+
+    func record(_ text: String) {
+        lock.lock()
+        texts.append(text)
+        lock.unlock()
+    }
+
+    func sentTexts() -> [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return texts
+    }
+
+    func recordCompaction() {
+        lock.lock()
+        compactionInvocations += 1
+        lock.unlock()
+    }
+
+    func compactionInvocationCount() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return compactionInvocations
+    }
+}
+
 private final class StopSubmitNoopCodexController: CodexSessionControlling {
+    private let recorder: StopSubmitSendRecorder?
+    private let activeThread: Bool
+    private let eventStream: AsyncStream<CodexNativeSessionController.Event>
+    private let eventContinuation: AsyncStream<CodexNativeSessionController.Event>.Continuation
+
+    init(recorder: StopSubmitSendRecorder? = nil, hasActiveThread: Bool = false) {
+        self.recorder = recorder
+        activeThread = hasActiveThread
+        var continuation: AsyncStream<CodexNativeSessionController.Event>.Continuation?
+        eventStream = AsyncStream { continuation = $0 }
+        eventContinuation = continuation!
+        if !hasActiveThread {
+            eventContinuation.finish()
+        }
+    }
+
+    deinit {
+        eventContinuation.finish()
+    }
+
     var hasActiveThread: Bool {
-        false
+        activeThread
     }
 
     var events: AsyncStream<CodexNativeSessionController.Event> {
-        AsyncStream { continuation in continuation.finish() }
+        eventStream
     }
 
     func ensureEventsStreamReady() {}
@@ -470,11 +744,26 @@ private final class StopSubmitNoopCodexController: CodexSessionControlling {
     }
 
     func setThreadName(_ name: String, threadID: String?) async throws {}
-    func sendUserMessage(_ text: String) async throws {}
-    func sendUserTurn(text: String, images: [AgentImageAttachment]) async throws {}
-    func sendUserTurn(text: String, images: [AgentImageAttachment], model: String?, reasoningEffort: String?) async throws {}
-    func sendUserTurn(text: String, images: [AgentImageAttachment], model: String?, reasoningEffort: String?, serviceTier: String?) async throws {}
-    func compactThread() async throws {}
+    func sendUserMessage(_ text: String) async throws {
+        recorder?.record(text)
+    }
+
+    func sendUserTurn(text: String, images: [AgentImageAttachment]) async throws {
+        recorder?.record(text)
+    }
+
+    func sendUserTurn(text: String, images: [AgentImageAttachment], model: String?, reasoningEffort: String?) async throws {
+        recorder?.record(text)
+    }
+
+    func sendUserTurn(text: String, images: [AgentImageAttachment], model: String?, reasoningEffort: String?, serviceTier: String?) async throws {
+        recorder?.record(text)
+    }
+
+    func compactThread() async throws {
+        recorder?.recordCompaction()
+    }
+
     func getThreadGoal() async throws -> CodexNativeSessionController.ThreadGoal? {
         nil
     }


### PR DESCRIPTION
## Summary
- keep existing-session composer sends bound to stable tab and persistent Agent session identity
- allow live run state, run ID, and Codex run-attempt identity to change between render and submission
- preserve strict first-send and exact-run cancellation validation
- add deterministic exactly-once delivery and persistent-session replacement regression tests

## Validation
- `make dev-test FILTER=AgentModeStopSubmitTargetTests` — 15 passed
- `make dev-test FILTER=AgentModeSubmitWaitWakeTests` — 3 passed
- `make dev-test` — passed
- `make dev-lint` — passed, 0 violations
- `make dev-swift-build PRODUCT=RepoPrompt` — passed
- contribution commit/push preflights — passed

## Smoke
- `make dev-smoke` was attempted non-disruptively but could not connect because the CE app was not running. No visible app launch/relaunch was performed.
