### PR TITLE
Improve long-run file-tool freshness performance

### DIFF
--- a/Sources/RepoPrompt/Features/Diagnostics/MCP/MCPConnectionManager+DebugDiagnostics.swift
+++ b/Sources/RepoPrompt/Features/Diagnostics/MCP/MCPConnectionManager+DebugDiagnostics.swift
@@ -153,6 +153,16 @@ import MCP
                 #else
                     return debugDiagnosticsError(op: op, code: "unavailable", message: "`mcp_read_search_content_read_scheduler_snapshot` is only available in DEBUG builds.")
                 #endif
+            case "mcp_read_search_runtime_snapshot":
+                #if DEBUG
+                    return await debugMCPReadSearchRuntimeSnapshotPayload(
+                        op: op,
+                        connectionID: connectionID,
+                        arguments: arguments
+                    )
+                #else
+                    return debugDiagnosticsError(op: op, code: "unavailable", message: "`mcp_read_search_runtime_snapshot` is only available in DEBUG builds.")
+                #endif
             case "bootstrap_diagnostics":
                 return await debugBootstrapDiagnosticsPayload(op: op)
             case "sparkle_status":

--- a/Sources/RepoPrompt/Features/Diagnostics/MCP/MCPConnectionManager+DebugDiagnosticsReadSearchLatency.swift
+++ b/Sources/RepoPrompt/Features/Diagnostics/MCP/MCPConnectionManager+DebugDiagnosticsReadSearchLatency.swift
@@ -154,6 +154,114 @@ import MCP
             ])
         }
 
+        func debugMCPReadSearchRuntimeSnapshotPayload(
+            op: String,
+            connectionID: UUID,
+            arguments: [String: Value]
+        ) async -> CallTool.Result {
+            guard let requestedConnectionID = debugOptionalUUID(arguments, "connection_id", op: op) else {
+                return debugDiagnosticsError(
+                    op: op,
+                    code: "invalid_params",
+                    message: "`connection_id` must be a UUID string when provided."
+                )
+            }
+
+            let requestedWindowID: Int?
+            switch debugSearchLaneWindowID(arguments, op: op) {
+            case let .success(windowID):
+                requestedWindowID = windowID
+            case let .failure(result):
+                return result
+            }
+
+            let recentPublicationLimit: Int
+            switch debugBoundedInt(arguments, "recent_publication_limit", defaultValue: 8, range: 0 ... 32) {
+            case let .value(parsed), let .defaulted(parsed):
+                recentPublicationLimit = parsed
+            case .invalid:
+                return debugDiagnosticsError(
+                    op: op,
+                    code: "invalid_params",
+                    message: "`recent_publication_limit` must be an integer between 0 and 32."
+                )
+            }
+
+            let rootLimit: Int
+            switch debugBoundedInt(arguments, "root_limit", defaultValue: 64, range: 1 ... 256) {
+            case let .value(parsed), let .defaulted(parsed):
+                rootLimit = parsed
+            case .invalid:
+                return debugDiagnosticsError(
+                    op: op,
+                    code: "invalid_params",
+                    message: "`root_limit` must be an integer between 1 and 256."
+                )
+            }
+
+            let targets = await debugReadSearchRuntimeTargets(windowID: requestedWindowID)
+            if let requestedWindowID, targets.isEmpty {
+                return debugDiagnosticsError(
+                    op: op,
+                    code: "no_window",
+                    message: "No RepoPrompt window matched window_id \(requestedWindowID)."
+                )
+            }
+
+            var windows: [[String: Any]] = []
+            windows.reserveCapacity(targets.count)
+            for target in targets {
+                let snapshots = await target.store.readSearchRootDiagnosticsSnapshot(
+                    recentPublicationLimit: recentPublicationLimit
+                )
+                let ordered = snapshots.sorted { $0.rootToken.uuidString < $1.rootToken.uuidString }
+                let included = Array(ordered.prefix(rootLimit))
+                windows.append([
+                    "window_id": target.windowID,
+                    "root_count": ordered.count,
+                    "omitted_root_count": max(0, ordered.count - included.count),
+                    "handled_projection_event_count": target.projection.handledEventCount,
+                    "projection_direct_file_id_lookup_count": target.projection.directFileIDLookupCount,
+                    "projection_direct_folder_id_lookup_count": target.projection.directFolderIDLookupCount,
+                    "projection_direct_id_lookup_miss_count": target.projection.directIDLookupMissCount,
+                    "projection_canonical_resync_count": target.projection.canonicalResyncCount,
+                    "read_file_auto_selection": readFileAutoSelectionPayload(target.readFileAutoSelection),
+                    "roots": included.map { root in
+                        readSearchRuntimeRootPayload(
+                            root,
+                            handledGeneration: target.projection.handledGenerationByRootID[root.rootID] ?? 0
+                        )
+                    }
+                ])
+            }
+
+            let targetConnectionID = requestedConnectionID ?? connectionID
+            let limiter = await connectionLimiterDiagnosticsSnapshot(connectionID: targetConnectionID)
+            var limiterPayload = limiter.map { readSearchLimiterPayload($0) } ?? ["found": false]
+            limiterPayload["connection_id"] = targetConnectionID.uuidString
+            return debugDiagnosticsResult([
+                "ok": true,
+                "op": op,
+                "runtime": [
+                    "consistency": "best_effort",
+                    "limiter": limiterPayload,
+                    "observers": [
+                        "tool_call_observer_count": toolCallObserverCount(),
+                        "tool_event_observer_count": toolEventObserverCount()
+                    ],
+                    "window_count": windows.count,
+                    "windows": windows
+                ]
+            ])
+        }
+
+        private struct DebugReadSearchRuntimeTarget {
+            let windowID: Int
+            let store: WorkspaceFileContextStore
+            let projection: WorkspaceFilesViewModel.AppliedIndexProjectionDiagnosticsSnapshot
+            let readFileAutoSelection: MCPReadFileAutoSelectionCoordinator.DebugSnapshot
+        }
+
         private enum DebugSearchLaneWindowIDResult {
             case success(Int?)
             case failure(CallTool.Result)
@@ -174,6 +282,153 @@ import MCP
                     message: "`window_id` must be a positive integer."
                 ))
             }
+        }
+
+        private func debugReadSearchRuntimeTargets(windowID: Int?) async -> [DebugReadSearchRuntimeTarget] {
+            await MainActor.run {
+                WindowStatesManager.shared.allWindows
+                    .filter { windowID == nil || $0.windowID == windowID }
+                    .sorted { $0.windowID < $1.windowID }
+                    .map { window in
+                        DebugReadSearchRuntimeTarget(
+                            windowID: window.windowID,
+                            store: window.workspaceFileContextStore,
+                            projection: window.workspaceFilesViewModel.appliedIndexProjectionDiagnosticsSnapshot(),
+                            readFileAutoSelection: window.mcpServer.readFileAutoSelectionDiagnosticsSnapshot()
+                        )
+                    }
+            }
+        }
+
+        private func readFileAutoSelectionPayload(
+            _ snapshot: MCPReadFileAutoSelectionCoordinator.DebugSnapshot
+        ) -> [String: Any] {
+            [
+                "canonical_lane_count": snapshot.canonicalLaneCount,
+                "canonical_worker_count": snapshot.canonicalWorkerCount,
+                "mirror_lane_count": snapshot.mirrorLaneCount,
+                "mirror_worker_count": snapshot.mirrorWorkerCount,
+                "closing_context_count": snapshot.closingContextCount,
+                "pending_canonical_batch_count": snapshot.pendingCanonicalBatchCount,
+                "pending_mirror_batch_count": snapshot.pendingMirrorBatchCount
+            ]
+        }
+
+        private func readSearchLimiterPayload(_ snapshot: AsyncLimiter.DebugSnapshot) -> [String: Any] {
+            [
+                "found": true,
+                "limit": snapshot.limit,
+                "permits": snapshot.permits,
+                "active_permit_count": snapshot.activePermitCount,
+                "waiter_count": snapshot.waiterCount,
+                "in_flight_count": snapshot.inFlight,
+                "oldest_waiter_age_ms": Self.debugOptionalValue(snapshot.oldestWaiterAgeMilliseconds),
+                "cancelled_waiter_count": snapshot.cancelledWaiterCount,
+                "is_closed": snapshot.isClosed,
+                "is_idle": snapshot.isIdle
+            ]
+        }
+
+        private func readSearchRuntimeRootPayload(
+            _ root: WorkspaceFileContextStore.ReadSearchRootDiagnosticsSnapshot,
+            handledGeneration: UInt64
+        ) -> [String: Any] {
+            let producedGeneration = root.producedAppliedIndexGeneration
+            let generationLag = producedGeneration >= handledGeneration
+                ? producedGeneration - handledGeneration
+                : 0
+            return [
+                "root_token": root.rootToken.uuidString,
+                "ingress": readSearchIngressPayload(root.ingress),
+                "barrier": readSearchBarrierPayload(root.barrier),
+                "invalidation": readSearchInvalidationPayload(root.invalidation),
+                "projection": [
+                    "produced_generation": producedGeneration,
+                    "handled_generation": handledGeneration,
+                    "generation_lag": generationLag
+                ]
+            ]
+        }
+
+        private func readSearchIngressPayload(
+            _ snapshot: WorkspaceFileSystemIngressCoordinator.DebugSnapshot
+        ) -> [String: Any] {
+            [
+                "is_open": snapshot.isOpen,
+                "queued_publication_count": snapshot.queuedPublicationCount,
+                "applying_publication_count": snapshot.applyingPublicationCount,
+                "outstanding_publication_count": snapshot.outstandingPublicationCount,
+                "waiter_count": snapshot.waiterCount,
+                "accepted_service_publication_sequence": snapshot.acceptedServicePublicationSequence,
+                "applied_service_publication_sequence": snapshot.appliedServicePublicationSequence,
+                "accepted_applied_sequence_gap": snapshot.acceptedAppliedSequenceGap,
+                "applied_watcher_watermark": snapshot.appliedWatcherWatermark,
+                "oldest_outstanding_publication_age_ms": Self.debugOptionalValue(
+                    snapshot.oldestOutstandingPublicationAgeMilliseconds
+                )
+            ]
+        }
+
+        private func readSearchBarrierPayload(
+            _ snapshot: WorkspaceFileContextStore.ScopedIngressBarrierDebugSnapshot
+        ) -> [String: Any] {
+            let active = snapshot.active.map { active in
+                [
+                    "target_watcher_watermark": active.targetWatcherWatermark,
+                    "target_service_publication_sequence": active.targetServicePublicationSequence,
+                    "age_ms": active.ageMilliseconds
+                ]
+            }
+            let completed = snapshot.lastCompleted.map { completed in
+                [
+                    "token": completed.token,
+                    "target_watcher_watermark": completed.targetWatcherWatermark,
+                    "target_service_publication_sequence": completed.targetServicePublicationSequence,
+                    "published_service_publication_sequence": completed.publishedServicePublicationSequence,
+                    "applied_service_publication_sequence": completed.appliedServicePublicationSequence,
+                    "applied_watcher_watermark": completed.appliedWatcherWatermark,
+                    "duration_ms": completed.durationMilliseconds
+                ]
+            }
+            return [
+                "launch_count": snapshot.launchCount,
+                "join_count": snapshot.joinCount,
+                "successor_count": snapshot.successorCount,
+                "completion_count": snapshot.completionCount,
+                "active": Self.debugOptionalValue(active),
+                "last_completed": Self.debugOptionalValue(completed)
+            ]
+        }
+
+        private func readSearchInvalidationPayload(
+            _ snapshot: WorkspaceFileContextStore.PublicationInvalidationHistoryDebugSnapshot
+        ) -> [String: Any] {
+            [
+                "retained_sample_limit": snapshot.retainedSampleLimit,
+                "total_observed_publication_count": snapshot.totalObservedPublicationCount,
+                "dropped_publication_sample_count": snapshot.droppedPublicationSampleCount,
+                "returned_sample_count": snapshot.samples.count,
+                "recent_publications": snapshot.samples.map(readSearchInvalidationSamplePayload)
+            ]
+        }
+
+        private func readSearchInvalidationSamplePayload(
+            _ sample: WorkspaceFileContextStore.PublicationInvalidationDebugSample
+        ) -> [String: Any] {
+            [
+                "service_publication_sequence": Self.debugOptionalValue(sample.servicePublicationSequence),
+                "watcher_accepted_watermark": Self.debugOptionalValue(sample.watcherAcceptedWatermark),
+                "prepared_delta_count": sample.preparedDeltaCount,
+                "topology_invalidation_count": sample.topologyInvalidationCount,
+                "catalog_generation_advance_count": sample.catalogGenerationAdvanceCount,
+                "search_catalog_cache_clear_count": sample.searchCatalogCacheClearCount,
+                "path_worker_invalidation_request_count": sample.pathWorkerInvalidationRequestCount,
+                "content_invalidation_count": sample.contentInvalidationCount,
+                "distinct_content_key_count": sample.distinctContentKeyCount,
+                "decoded_cache_invalidation_request_count": sample.decodedCacheInvalidationRequestCount,
+                "codemap_invalidation_request_count": sample.codemapInvalidationRequestCount,
+                "applied_index_event_yield_count": sample.appliedIndexEventYieldCount
+            ]
         }
 
         private func debugSearchLaneTargets(

--- a/Sources/RepoPrompt/Features/WorkspaceFiles/ViewModels/WorkspaceFilesViewModel.swift
+++ b/Sources/RepoPrompt/Features/WorkspaceFiles/ViewModels/WorkspaceFilesViewModel.swift
@@ -79,15 +79,19 @@ struct FileHierarchyIndex {
         let scanInvocationCount: Int
     }
 
-    // New: Store file & folder ViewModels by their fullPath.
+    // Store file & folder ViewModels by canonical path and store-backed identity.
     var filesByFullPath: [String: FileViewModel] = [:]
     var foldersByFullPath: [String: FolderViewModel] = [:]
+    var filesByID: [UUID: FileViewModel] = [:]
+    var foldersByID: [UUID: FolderViewModel] = [:]
     var filePathsByRoot: [String: Set<String>] = [:]
     var folderPathsByRoot: [String: Set<String>] = [:]
 
     mutating func clearAll() {
         filesByFullPath.removeAll()
         foldersByFullPath.removeAll()
+        filesByID.removeAll()
+        foldersByID.removeAll()
         filePathsByRoot.removeAll()
         folderPathsByRoot.removeAll()
     }
@@ -112,21 +116,35 @@ struct FileHierarchyIndex {
         let path = folder.standardizedFullPath
         let ownerRootKey = rootKey.map(StandardizedPath.absolute) ?? StandardizedPath.absolute(folder.rootPath)
         if let existing = foldersByFullPath.updateValue(folder, forKey: path) {
+            if foldersByID[existing.id] === existing {
+                foldersByID.removeValue(forKey: existing.id)
+            }
             let previousRootKey = StandardizedPath.absolute(existing.rootPath)
             if previousRootKey != ownerRootKey {
                 Self.removePath(path, from: &folderPathsByRoot, rootKey: previousRootKey)
             }
         }
+        foldersByID[folder.id] = folder
         folderPathsByRoot[ownerRootKey, default: []].insert(path)
         if path == ownerRootKey {
             _ = filePathsByRoot[ownerRootKey, default: []]
         }
     }
 
+    mutating func rekeyFolder(_ folder: FolderViewModel, from oldID: UUID) {
+        if foldersByID[oldID] === folder {
+            foldersByID.removeValue(forKey: oldID)
+        }
+        foldersByID[folder.id] = folder
+    }
+
     @discardableResult
     mutating func removeFolder(forKey path: String, expectedRootKey: String? = nil) -> FolderViewModel? {
         let standardizedPath = StandardizedPath.absolute(path)
         let removed = foldersByFullPath.removeValue(forKey: standardizedPath)
+        if let removed, foldersByID[removed.id] === removed {
+            foldersByID.removeValue(forKey: removed.id)
+        }
         let ownerRootKey = removed.map { StandardizedPath.absolute($0.rootPath) }
             ?? expectedRootKey.map(StandardizedPath.absolute)
         if let ownerRootKey {
@@ -139,11 +157,15 @@ struct FileHierarchyIndex {
         let path = file.standardizedFullPath
         let ownerRootKey = rootKey.map(StandardizedPath.absolute) ?? file.standardizedRootFolderPath
         if let existing = filesByFullPath.updateValue(file, forKey: path) {
+            if filesByID[existing.id] === existing {
+                filesByID.removeValue(forKey: existing.id)
+            }
             let previousRootKey = existing.standardizedRootFolderPath
             if previousRootKey != ownerRootKey {
                 Self.removePath(path, from: &filePathsByRoot, rootKey: previousRootKey)
             }
         }
+        filesByID[file.id] = file
         filePathsByRoot[ownerRootKey, default: []].insert(path)
     }
 
@@ -151,6 +173,9 @@ struct FileHierarchyIndex {
     mutating func removeFile(forKey path: String, expectedRootKey: String? = nil) -> FileViewModel? {
         let standardizedPath = StandardizedPath.absolute(path)
         let removed = filesByFullPath.removeValue(forKey: standardizedPath)
+        if let removed, filesByID[removed.id] === removed {
+            filesByID.removeValue(forKey: removed.id)
+        }
         let ownerRootKey = removed?.standardizedRootFolderPath
             ?? expectedRootKey.map(StandardizedPath.absolute)
         if let ownerRootKey {
@@ -173,10 +198,18 @@ struct FileHierarchyIndex {
         folderPathsByRoot.removeValue(forKey: rootKey)
         filePathsByRoot.removeValue(forKey: rootKey)
         for folderPath in folderPaths {
-            foldersByFullPath.removeValue(forKey: folderPath)
+            if let removed = foldersByFullPath.removeValue(forKey: folderPath),
+               foldersByID[removed.id] === removed
+            {
+                foldersByID.removeValue(forKey: removed.id)
+            }
         }
         for filePath in filePaths {
-            filesByFullPath.removeValue(forKey: filePath)
+            if let removed = filesByFullPath.removeValue(forKey: filePath),
+               filesByID[removed.id] === removed
+            {
+                filesByID.removeValue(forKey: removed.id)
+            }
         }
     }
 
@@ -267,10 +300,18 @@ struct FileHierarchyIndex {
             filePathsByRoot[standardizedRootKey] = []
         }
         for folderPath in folderPaths {
-            foldersByFullPath.removeValue(forKey: folderPath)
+            if let removed = foldersByFullPath.removeValue(forKey: folderPath),
+               foldersByID[removed.id] === removed
+            {
+                foldersByID.removeValue(forKey: removed.id)
+            }
         }
         for filePath in filePaths {
-            filesByFullPath.removeValue(forKey: filePath)
+            if let removed = filesByFullPath.removeValue(forKey: filePath),
+               filesByID[removed.id] === removed
+            {
+                filesByID.removeValue(forKey: removed.id)
+            }
         }
     }
 }
@@ -518,6 +559,7 @@ class WorkspaceFilesViewModel: ObservableObject {
     func removeRootFolder(_ folder: FolderViewModel) {
         let stdPath = folder.standardizedFullPath
         let rootKey = rootKey(forPath: folder.fullPath)
+        appliedIndexProjectionHandledGenerationByRootID.removeValue(forKey: folder.id)
         unregisterExpansionTracking(for: folder)
         rootFolders.removeAll { $0.id == folder.id }
         rootShellPersistenceKeysByRootKey.removeValue(forKey: rootKey)
@@ -771,6 +813,8 @@ class WorkspaceFilesViewModel: ObservableObject {
         typealias RootReplayPassPerfSample = Never
     #endif
 
+    private var appliedIndexProjectionHandledGenerationByRootID: [UUID: UInt64] = [:]
+
     #if DEBUG
         struct IndexRebuildPerfSample: Equatable {
             let rootKey: String
@@ -932,6 +976,57 @@ class WorkspaceFilesViewModel: ObservableObject {
         private var currentReplayParentLookupCount = 0
         private var deltaReplayChunkSizeOverride: Int?
         private var deltaReplayInterChunkDelayNanosecondsOverride: UInt64?
+
+        struct AppliedIndexProjectionDiagnosticsSnapshot: Equatable {
+            let handledEventCount: Int
+            let handledGenerationByRootID: [UUID: UInt64]
+            let directFileIDLookupCount: Int
+            let directFolderIDLookupCount: Int
+            let directIDLookupMissCount: Int
+            let canonicalResyncCount: Int
+        }
+
+        private var appliedIndexProjectionHandledEventCount = 0
+        private var appliedIndexProjectionDirectFileIDLookupCount = 0
+        private var appliedIndexProjectionDirectFolderIDLookupCount = 0
+        private var appliedIndexProjectionDirectIDLookupMissCount = 0
+        private var appliedIndexProjectionCanonicalResyncCount = 0
+        private var appliedIndexProjectionWillHandleHandler: (@Sendable (UUID, UInt64) async -> Void)?
+        private var appliedIndexProjectionStateObserver: ((AppliedIndexProjectionDiagnosticsSnapshot) -> Void)?
+
+        func setAppliedIndexProjectionWillHandleHandlerForTesting(
+            _ handler: (@Sendable (UUID, UInt64) async -> Void)?
+        ) {
+            appliedIndexProjectionWillHandleHandler = handler
+        }
+
+        func setAppliedIndexProjectionStateObserverForTesting(
+            _ observer: ((AppliedIndexProjectionDiagnosticsSnapshot) -> Void)?
+        ) {
+            appliedIndexProjectionStateObserver = observer
+            observer?(appliedIndexProjectionDiagnosticsSnapshot())
+        }
+
+        func appliedIndexProjectionDiagnosticsSnapshot() -> AppliedIndexProjectionDiagnosticsSnapshot {
+            AppliedIndexProjectionDiagnosticsSnapshot(
+                handledEventCount: appliedIndexProjectionHandledEventCount,
+                handledGenerationByRootID: appliedIndexProjectionHandledGenerationByRootID,
+                directFileIDLookupCount: appliedIndexProjectionDirectFileIDLookupCount,
+                directFolderIDLookupCount: appliedIndexProjectionDirectFolderIDLookupCount,
+                directIDLookupMissCount: appliedIndexProjectionDirectIDLookupMissCount,
+                canonicalResyncCount: appliedIndexProjectionCanonicalResyncCount
+            )
+        }
+
+        private func notifyAppliedIndexProjectionStateChanged() {
+            appliedIndexProjectionStateObserver?(appliedIndexProjectionDiagnosticsSnapshot())
+        }
+
+        func resetAppliedIndexProjectionLookupDiagnosticsForTesting() {
+            appliedIndexProjectionDirectFileIDLookupCount = 0
+            appliedIndexProjectionDirectFolderIDLookupCount = 0
+            appliedIndexProjectionDirectIDLookupMissCount = 0
+        }
     #endif
     private var workspaceStoreDeltaBridgeTask: Task<Void, Never>?
     private var workspaceStoreCodemapBridgeTask: Task<Void, Never>?
@@ -1137,25 +1232,441 @@ class WorkspaceFilesViewModel: ObservableObject {
         }
     }
 
+    private struct WorkspaceAppliedIndexModificationTargets {
+        let filesByID: [UUID: FileViewModel]
+        let foldersByID: [UUID: FolderViewModel]
+    }
+
+    private enum WorkspaceAppliedIndexModificationResolution {
+        case targets(WorkspaceAppliedIndexModificationTargets)
+        case requiresCanonicalResync
+        case rootNoLongerCurrent
+    }
+
     @MainActor
     private func handleWorkspaceAppliedIndexEvent(_ event: WorkspaceAppliedIndexBatchEvent) async {
-        let rootKey = rootKey(forPath: event.rootPath)
-        guard let targetRootVM = rootFolders.first(where: { $0.id == event.rootID || $0.standardizedFullPath == rootKey }) else { return }
+        #if DEBUG
+            if let appliedIndexProjectionWillHandleHandler {
+                await appliedIndexProjectionWillHandleHandler(event.rootID, event.generation)
+            }
+        #endif
+
+        guard !Task.isCancelled,
+              let (rootKey, targetRootVM) = currentWorkspaceAppliedIndexRoot(for: event)
+        else { return }
+        let handledGeneration = appliedIndexProjectionHandledGenerationByRootID[event.rootID] ?? 0
+        guard event.generation > handledGeneration else { return }
+
         if event.isRootUnload {
-            guard rootFolders.contains(where: { $0.id == targetRootVM.id }) else { return }
             _ = detachRootShellReferences(targetRootVM)
+            recordHandledWorkspaceAppliedIndexEvent()
             return
+        }
+
+        let nextExpectedGeneration = handledGeneration &+ 1
+        if event.requiresFullResync || event.generation != nextExpectedGeneration {
+            _ = await resyncAndRecordWorkspaceAppliedIndexProjection(
+                for: event,
+                rootKey: rootKey,
+                targetRootVM: targetRootVM
+            )
+            return
+        }
+
+        let modificationTargets: WorkspaceAppliedIndexModificationTargets
+        switch await resolveContiguousWorkspaceAppliedIndexModificationTargets(
+            for: event,
+            rootKey: rootKey,
+            targetRootVM: targetRootVM
+        ) {
+        case let .targets(resolvedTargets):
+            modificationTargets = resolvedTargets
+        case .requiresCanonicalResync:
+            _ = await resyncAndRecordWorkspaceAppliedIndexProjection(
+                for: event,
+                rootKey: rootKey,
+                targetRootVM: targetRootVM
+            )
+            return
+        case .rootNoLongerCurrent:
+            return
+        }
+
+        guard await applyWorkspaceAppliedIndexEvent(
+            event,
+            rootKey: rootKey,
+            targetRootVM: targetRootVM,
+            useCanonicalSnapshotMetadata: false,
+            modificationTargets: modificationTargets
+        ) else { return }
+        appliedIndexProjectionHandledGenerationByRootID[event.rootID] = event.generation
+        recordHandledWorkspaceAppliedIndexEvent()
+    }
+
+    @MainActor
+    private func currentWorkspaceAppliedIndexRoot(
+        for event: WorkspaceAppliedIndexBatchEvent
+    ) -> (rootKey: RootKey, root: FolderViewModel)? {
+        let rootKey = rootKey(forPath: event.rootPath)
+        guard workspaceFileContextRootsByRootKey[rootKey]?.id == event.rootID,
+              let root = rootFolders.first(where: { $0.id == event.rootID }),
+              root.standardizedFullPath == rootKey,
+              fileHierarchyIndex.foldersByID[event.rootID] === root
+        else {
+            return nil
+        }
+        return (rootKey, root)
+    }
+
+    @MainActor
+    private func isCurrentWorkspaceAppliedIndexRoot(
+        for event: WorkspaceAppliedIndexBatchEvent,
+        targetRootVM: FolderViewModel
+    ) -> Bool {
+        guard !Task.isCancelled,
+              let current = currentWorkspaceAppliedIndexRoot(for: event)
+        else {
+            return false
+        }
+        return current.root === targetRootVM
+    }
+
+    @MainActor
+    private func isCurrentAttachedRoot(
+        _ root: FolderViewModel,
+        expectedRootID: UUID? = nil
+    ) -> Bool {
+        guard !Task.isCancelled else { return false }
+        let rootKey = StandardizedPath.absolute(root.standardizedFullPath)
+        let rootID = expectedRootID ?? root.id
+        return root.id == rootID
+            && workspaceFileContextRootsByRootKey[rootKey]?.id == rootID
+            && rootFolders.contains(where: { $0 === root })
+            && fileHierarchyIndex.foldersByID[rootID] === root
+            && fileHierarchyIndex.foldersByFullPath[rootKey] === root
+    }
+
+    @MainActor
+    private func recordHandledWorkspaceAppliedIndexEvent() {
+        #if DEBUG
+            appliedIndexProjectionHandledEventCount += 1
+            notifyAppliedIndexProjectionStateChanged()
+        #endif
+    }
+
+    @MainActor
+    private func resyncAndRecordWorkspaceAppliedIndexProjection(
+        for event: WorkspaceAppliedIndexBatchEvent,
+        rootKey: RootKey,
+        targetRootVM: FolderViewModel
+    ) async -> Bool {
+        guard let resyncedGeneration = await resyncWorkspaceAppliedIndexProjection(
+            for: event,
+            rootKey: rootKey,
+            targetRootVM: targetRootVM
+        ) else {
+            return false
+        }
+        appliedIndexProjectionHandledGenerationByRootID[event.rootID] = resyncedGeneration
+        #if DEBUG
+            appliedIndexProjectionCanonicalResyncCount += 1
+        #endif
+        recordHandledWorkspaceAppliedIndexEvent()
+        return true
+    }
+
+    @MainActor
+    private func resolveContiguousWorkspaceAppliedIndexModificationTargets(
+        for event: WorkspaceAppliedIndexBatchEvent,
+        rootKey: RootKey,
+        targetRootVM: FolderViewModel
+    ) async -> WorkspaceAppliedIndexModificationResolution {
+        var filesByID: [UUID: FileViewModel] = [:]
+        filesByID.reserveCapacity(event.modifiedFileIDs.count)
+        var missingFileIDs: [UUID] = []
+        missingFileIDs.reserveCapacity(event.modifiedFileIDs.count)
+        for fileID in event.modifiedFileIDs {
+            guard let file = projectedFileForAppliedIndexModification(id: fileID) else {
+                missingFileIDs.append(fileID)
+                continue
+            }
+            guard isConsistentProjectedFile(file, id: fileID, rootKey: rootKey) else {
+                return .requiresCanonicalResync
+            }
+            filesByID[fileID] = file
+        }
+
+        var foldersByID: [UUID: FolderViewModel] = [:]
+        foldersByID.reserveCapacity(event.modifiedFolderIDs.count)
+        var missingFolderIDs: [UUID] = []
+        missingFolderIDs.reserveCapacity(event.modifiedFolderIDs.count)
+        for folderID in event.modifiedFolderIDs {
+            guard let folder = projectedFolderForAppliedIndexModification(id: folderID) else {
+                missingFolderIDs.append(folderID)
+                continue
+            }
+            guard isConsistentProjectedFolder(folder, id: folderID, rootKey: rootKey) else {
+                return .requiresCanonicalResync
+            }
+            foldersByID[folderID] = folder
+        }
+
+        guard !missingFileIDs.isEmpty || !missingFolderIDs.isEmpty else {
+            return .targets(WorkspaceAppliedIndexModificationTargets(
+                filesByID: filesByID,
+                foldersByID: foldersByID
+            ))
+        }
+
+        guard let snapshot = await workspaceFileContextStore.appliedIndexRootSnapshot(rootID: event.rootID),
+              snapshot.root.id == event.rootID,
+              snapshot.root.standardizedFullPath == rootKey,
+              snapshot.generation >= event.generation
+        else {
+            return .requiresCanonicalResync
+        }
+        guard !Task.isCancelled,
+              let current = currentWorkspaceAppliedIndexRoot(for: event),
+              current.root === targetRootVM
+        else {
+            return .rootNoLongerCurrent
+        }
+
+        for (fileID, file) in filesByID {
+            guard isConsistentProjectedFile(file, id: fileID, rootKey: rootKey) else {
+                return .requiresCanonicalResync
+            }
+        }
+        for (folderID, folder) in foldersByID {
+            guard isConsistentProjectedFolder(folder, id: folderID, rootKey: rootKey) else {
+                return .requiresCanonicalResync
+            }
+        }
+
+        let canonicalFilesByID = Dictionary(uniqueKeysWithValues: snapshot.files.map { ($0.id, $0) })
+        for fileID in missingFileIDs {
+            guard let record = canonicalFilesByID[fileID] else {
+                return .requiresCanonicalResync
+            }
+            let fileByID = fileHierarchyIndex.filesByID[fileID]
+            let fileByPath = fileHierarchyIndex.filesByFullPath[record.standardizedFullPath]
+            switch (fileByID, fileByPath) {
+            case (nil, nil):
+                continue
+            case let (idFile?, pathFile?) where idFile === pathFile
+                && isConsistentProjectedFile(
+                    idFile,
+                    id: fileID,
+                    rootKey: rootKey,
+                    expectedFullPath: record.standardizedFullPath
+                ):
+                filesByID[fileID] = idFile
+            default:
+                return .requiresCanonicalResync
+            }
+        }
+
+        let canonicalFoldersByID = Dictionary(uniqueKeysWithValues: snapshot.folders.map { ($0.id, $0) })
+        for folderID in missingFolderIDs {
+            guard let record = canonicalFoldersByID[folderID] else {
+                return .requiresCanonicalResync
+            }
+            let folderByID = fileHierarchyIndex.foldersByID[folderID]
+            let folderByPath = fileHierarchyIndex.foldersByFullPath[record.standardizedFullPath]
+            switch (folderByID, folderByPath) {
+            case (nil, nil):
+                continue
+            case let (idFolder?, pathFolder?) where idFolder === pathFolder
+                && isConsistentProjectedFolder(
+                    idFolder,
+                    id: folderID,
+                    rootKey: rootKey,
+                    expectedFullPath: record.standardizedFullPath
+                ):
+                foldersByID[folderID] = idFolder
+            default:
+                return .requiresCanonicalResync
+            }
+        }
+
+        return .targets(WorkspaceAppliedIndexModificationTargets(
+            filesByID: filesByID,
+            foldersByID: foldersByID
+        ))
+    }
+
+    @MainActor
+    private func resolveStrictWorkspaceAppliedIndexModificationTargets(
+        for event: WorkspaceAppliedIndexBatchEvent,
+        rootKey: RootKey
+    ) -> WorkspaceAppliedIndexModificationTargets? {
+        var filesByID: [UUID: FileViewModel] = [:]
+        filesByID.reserveCapacity(event.modifiedFileIDs.count)
+        for fileID in event.modifiedFileIDs {
+            guard let file = projectedFileForAppliedIndexModification(id: fileID),
+                  isConsistentProjectedFile(file, id: fileID, rootKey: rootKey)
+            else {
+                return nil
+            }
+            filesByID[fileID] = file
+        }
+
+        var foldersByID: [UUID: FolderViewModel] = [:]
+        foldersByID.reserveCapacity(event.modifiedFolderIDs.count)
+        for folderID in event.modifiedFolderIDs {
+            guard let folder = projectedFolderForAppliedIndexModification(id: folderID),
+                  isConsistentProjectedFolder(folder, id: folderID, rootKey: rootKey)
+            else {
+                return nil
+            }
+            foldersByID[folderID] = folder
+        }
+        return WorkspaceAppliedIndexModificationTargets(filesByID: filesByID, foldersByID: foldersByID)
+    }
+
+    @MainActor
+    private func isConsistentProjectedFile(
+        _ file: FileViewModel,
+        id: UUID,
+        rootKey: RootKey,
+        expectedFullPath: String? = nil
+    ) -> Bool {
+        file.id == id
+            && file.standardizedRootFolderPath == rootKey
+            && (expectedFullPath.map { file.standardizedFullPath == $0 } ?? true)
+            && fileHierarchyIndex.filesByID[id] === file
+            && fileHierarchyIndex.filesByFullPath[file.standardizedFullPath] === file
+    }
+
+    @MainActor
+    private func isConsistentProjectedFolder(
+        _ folder: FolderViewModel,
+        id: UUID,
+        rootKey: RootKey,
+        expectedFullPath: String? = nil
+    ) -> Bool {
+        folder.id == id
+            && StandardizedPath.absolute(folder.rootPath) == rootKey
+            && (expectedFullPath.map { folder.standardizedFullPath == $0 } ?? true)
+            && fileHierarchyIndex.foldersByID[id] === folder
+            && fileHierarchyIndex.foldersByFullPath[folder.standardizedFullPath] === folder
+    }
+
+    @MainActor
+    private func resyncWorkspaceAppliedIndexProjection(
+        for event: WorkspaceAppliedIndexBatchEvent,
+        rootKey: RootKey,
+        targetRootVM: FolderViewModel
+    ) async -> UInt64? {
+        guard let snapshot = await workspaceFileContextStore.appliedIndexRootSnapshot(rootID: event.rootID),
+              snapshot.root.id == event.rootID,
+              snapshot.root.standardizedFullPath == rootKey,
+              snapshot.generation >= event.generation,
+              let current = currentWorkspaceAppliedIndexRoot(for: event),
+              current.root === targetRootVM
+        else {
+            return nil
+        }
+
+        rebuildFileHierarchyIndex(for: targetRootVM)
+
+        let canonicalFilePaths = Set(snapshot.files.map(\.standardizedFullPath))
+        let canonicalFolderPaths = Set(snapshot.folders.map(\.standardizedFullPath)).union([rootKey])
+        let currentFilePaths = fileHierarchyIndex.filePathsByRoot[rootKey]
+            ?? Set(fileHierarchyIndex.filesByFullPath.keys.filter { StandardizedPath.isDescendant($0, of: rootKey) })
+        let currentFolderPaths = fileHierarchyIndex.folderPathsByRoot[rootKey]
+            ?? Set(fileHierarchyIndex.foldersByFullPath.keys.filter { StandardizedPath.isDescendant($0, of: rootKey) })
+
+        let upsertedFiles = snapshot.files.filter { record in
+            fileHierarchyIndex.filesByFullPath[record.standardizedFullPath]?.id != record.id
+        }
+        let upsertedFolders = snapshot.folders.filter { record in
+            !record.standardizedRelativePath.isEmpty
+                && fileHierarchyIndex.foldersByFullPath[record.standardizedFullPath]?.id != record.id
+        }
+        let modifiedFileIDs = snapshot.files.compactMap { record -> UUID? in
+            guard let modificationDate = record.modificationDate,
+                  let currentFile = fileHierarchyIndex.filesByFullPath[record.standardizedFullPath],
+                  currentFile.id == record.id,
+                  currentFile.modificationDate != modificationDate
+            else {
+                return nil
+            }
+            return record.id
+        }
+        let modifiedFolderIDs = snapshot.folders.compactMap { record -> UUID? in
+            guard !record.standardizedRelativePath.isEmpty,
+                  let modificationDate = record.modificationDate,
+                  let currentFolder = fileHierarchyIndex.foldersByFullPath[record.standardizedFullPath],
+                  currentFolder.id == record.id,
+                  currentFolder.modificationDate != modificationDate
+            else {
+                return nil
+            }
+            return record.id
+        }
+        let removedFilePaths = currentFilePaths.subtracting(canonicalFilePaths).map {
+            StandardizedPath.relative(String($0.dropFirst(rootKey.count)))
+        }
+        let removedFolderPaths = currentFolderPaths.subtracting(canonicalFolderPaths).map {
+            StandardizedPath.relative(String($0.dropFirst(rootKey.count)))
+        }
+
+        guard !upsertedFiles.isEmpty || !upsertedFolders.isEmpty
+            || !removedFilePaths.isEmpty || !removedFolderPaths.isEmpty
+            || !modifiedFileIDs.isEmpty || !modifiedFolderIDs.isEmpty
+        else {
+            return snapshot.generation
+        }
+
+        let resyncEvent = WorkspaceAppliedIndexBatchEvent(
+            rootID: event.rootID,
+            rootPath: rootKey,
+            generation: snapshot.generation,
+            upsertedFiles: upsertedFiles,
+            upsertedFolders: upsertedFolders,
+            removedFilePaths: removedFilePaths,
+            removedFolderPaths: removedFolderPaths,
+            modifiedFileIDs: modifiedFileIDs,
+            modifiedFolderIDs: modifiedFolderIDs
+        )
+        guard let modificationTargets = resolveStrictWorkspaceAppliedIndexModificationTargets(
+            for: resyncEvent,
+            rootKey: rootKey
+        ), await applyWorkspaceAppliedIndexEvent(
+            resyncEvent,
+            rootKey: rootKey,
+            targetRootVM: targetRootVM,
+            useCanonicalSnapshotMetadata: true,
+            modificationTargets: modificationTargets
+        ) else {
+            return nil
+        }
+        return snapshot.generation
+    }
+
+    @MainActor
+    private func applyWorkspaceAppliedIndexEvent(
+        _ event: WorkspaceAppliedIndexBatchEvent,
+        rootKey: RootKey,
+        targetRootVM: FolderViewModel,
+        useCanonicalSnapshotMetadata: Bool,
+        modificationTargets: WorkspaceAppliedIndexModificationTargets
+    ) async -> Bool {
+        guard isCurrentWorkspaceAppliedIndexRoot(for: event, targetRootVM: targetRootVM) else {
+            return false
         }
 
         var topologyChanged = false
         var dirtyFolders: [UUID: FolderViewModel] = [:]
+        var removedSubtrees: [RemovedFolderSubtree] = []
         let sortedFolders = event.upsertedFolders.sorted { lhs, rhs in
             let lhsDepth = lhs.standardizedRelativePath.split(separator: "/").count
             let rhsDepth = rhs.standardizedRelativePath.split(separator: "/").count
             if lhsDepth != rhsDepth { return lhsDepth < rhsDepth }
             return lhs.standardizedRelativePath < rhs.standardizedRelativePath
         }
-        for folder in sortedFolders where !folder.standardizedRelativePath.isEmpty {
+        for folder in sortedFolders where folder.rootID == event.rootID && !folder.standardizedRelativePath.isEmpty {
             if let outcome = handleNewFolder(record: folder, onRootFolder: targetRootVM) {
                 topologyChanged = true
                 if let parent = outcome.parentFolderForStateRecompute {
@@ -1163,47 +1674,104 @@ class WorkspaceFilesViewModel: ObservableObject {
                 }
             }
         }
-        for file in event.upsertedFiles {
-            if let outcome = await handleNewFile(record: file, onRootFolder: targetRootVM) {
+        for file in event.upsertedFiles where file.rootID == event.rootID {
+            guard isCurrentWorkspaceAppliedIndexRoot(for: event, targetRootVM: targetRootVM) else {
+                return false
+            }
+            let outcome = await handleNewFile(
+                record: file,
+                onRootFolder: targetRootVM,
+                useRecordModificationDateForExistingFile: useCanonicalSnapshotMetadata
+            )
+            guard isCurrentWorkspaceAppliedIndexRoot(for: event, targetRootVM: targetRootVM) else {
+                return false
+            }
+            if let outcome {
                 topologyChanged = true
                 if let parent = outcome.parentFolderForStateRecompute {
                     dirtyFolders[parent.id] = parent
                 }
             }
         }
-        for path in event.removedFilePaths {
-            let fullPath = StandardizedPath.join(standardizedRoot: rootKey, standardizedRelativePath: path)
+
+        var removedFileFullPaths = Set(event.removedFilePaths.map {
+            StandardizedPath.join(standardizedRoot: rootKey, standardizedRelativePath: $0)
+        })
+        for fileID in event.removedFileIDs {
+            if let file = fileHierarchyIndex.filesByID[fileID], file.standardizedRootFolderPath == rootKey {
+                removedFileFullPaths.insert(file.standardizedFullPath)
+            }
+        }
+        for fullPath in removedFileFullPaths {
             guard let fileVM = findFileByFullPath(fullPath) else { continue }
-            let formerParent = fileVM.parentFolder ?? parentFolderForRelativePath(path, under: targetRootVM)
+            let formerParent = fileVM.parentFolder ?? parentFolderForRelativePath(fileVM.relativePath, under: targetRootVM)
             removeFileFromParentChildrenArray(fileVM)
             fileHierarchyIndex.removeFile(forKey: fullPath, expectedRootKey: rootKey)
             topologyChanged = true
             if let formerParent { dirtyFolders[formerParent.id] = formerParent }
         }
-        for path in event.removedFolderPaths.sorted(by: { $0.count > $1.count }) where !path.isEmpty {
+
+        var removedFolderRelativePaths = Set(event.removedFolderPaths.map(StandardizedPath.relative))
+        for folderID in event.removedFolderIDs {
+            if let folder = fileHierarchyIndex.foldersByID[folderID],
+               folder !== targetRootVM,
+               StandardizedPath.absolute(folder.rootPath) == rootKey
+            {
+                removedFolderRelativePaths.insert(folder.relativePath)
+            }
+        }
+        for path in removedFolderRelativePaths.sorted(by: { $0.count > $1.count }) where !path.isEmpty {
             if let removed = removeFolderRecursive(in: targetRootVM, relativePath: path) {
+                removedSubtrees.append(removed)
                 topologyChanged = true
                 if let parent = removed.formerParentFolder ?? parentFolderForRelativePath(path, under: targetRootVM) {
                     dirtyFolders[parent.id] = parent
                 }
             }
         }
+        if !removedSubtrees.isEmpty {
+            _ = performBatchedIncrementalRemovedSubtreeCleanup(removedSubtrees, rootKey: rootKey)
+        }
+
         for fileID in event.modifiedFileIDs {
-            guard let fileVM = fileHierarchyIndex.filesByFullPath.values.first(where: { $0.id == fileID }) else { continue }
+            guard let fileVM = modificationTargets.filesByID[fileID] else { continue }
+            let date: Date
             do {
-                let date = try await workspaceFileContextStore.fileModificationDate(rootID: event.rootID, relativePath: fileVM.relativePath)
-                await fileVM.setModificationDate(date, forceInvalidation: true)
+                date = try await workspaceFileContextStore.fileModificationDate(
+                    rootID: event.rootID,
+                    relativePath: fileVM.relativePath
+                )
             } catch {
-                await fileVM.setModificationDate(Date(), forceInvalidation: true)
+                date = Date()
+            }
+            guard isCurrentWorkspaceAppliedIndexRoot(for: event, targetRootVM: targetRootVM) else {
+                return false
+            }
+            await fileVM.setModificationDate(date, forceInvalidation: true)
+            guard isCurrentWorkspaceAppliedIndexRoot(for: event, targetRootVM: targetRootVM) else {
+                return false
             }
             requestCodeScan(for: fileVM)
-            scheduleSliceRebasesForModifiedFiles([ReplaySliceRebaseRequest(file: fileVM, relativePath: fileVM.relativePath)])
+            scheduleSliceRebasesForModifiedFiles([
+                ReplaySliceRebaseRequest(file: fileVM, relativePath: fileVM.relativePath)
+            ])
         }
         for folderID in event.modifiedFolderIDs {
-            guard let folderVM = fileHierarchyIndex.foldersByFullPath.values.first(where: { $0.id == folderID }) else { continue }
-            if let date = try? await workspaceFileContextStore.itemModificationDateIfAvailable(rootID: event.rootID, relativePath: folderVM.relativePath) {
+            guard let folderVM = modificationTargets.foldersByID[folderID] else { continue }
+            let date = try? await workspaceFileContextStore.itemModificationDateIfAvailable(
+                rootID: event.rootID,
+                relativePath: folderVM.relativePath
+            )
+            guard isCurrentWorkspaceAppliedIndexRoot(for: event, targetRootVM: targetRootVM) else {
+                return false
+            }
+            if let date {
                 folderVM.setModificationDate(date)
             }
+        }
+
+        guard isCurrentWorkspaceAppliedIndexRoot(for: event, targetRootVM: targetRootVM) else {
+            return false
         }
         flushPendingInserts()
         if topologyChanged {
@@ -1217,6 +1785,31 @@ class WorkspaceFilesViewModel: ObservableObject {
         onRootFoldersChanged?()
         fileSystemDeltasAppliedPublisher.send(FileSystemDeltasAppliedEvent(rootKey: rootKey, deltas: []))
         invalidateStaticSnapshot(forRootFullPath: targetRootVM.standardizedFullPath)
+        return true
+    }
+
+    @MainActor
+    private func projectedFileForAppliedIndexModification(id: UUID) -> FileViewModel? {
+        #if DEBUG
+            appliedIndexProjectionDirectFileIDLookupCount += 1
+        #endif
+        let file = fileHierarchyIndex.filesByID[id]
+        #if DEBUG
+            if file == nil { appliedIndexProjectionDirectIDLookupMissCount += 1 }
+        #endif
+        return file
+    }
+
+    @MainActor
+    private func projectedFolderForAppliedIndexModification(id: UUID) -> FolderViewModel? {
+        #if DEBUG
+            appliedIndexProjectionDirectFolderIDLookupCount += 1
+        #endif
+        let folder = fileHierarchyIndex.foldersByID[id]
+        #if DEBUG
+            if folder == nil { appliedIndexProjectionDirectIDLookupMissCount += 1 }
+        #endif
+        return folder
     }
 
     @MainActor
@@ -1371,7 +1964,16 @@ class WorkspaceFilesViewModel: ObservableObject {
         if let subscription = expansionSubscriptions.removeValue(forKey: oldID) {
             subscription.cancel()
         }
+        let pendingChildren = pendingChildInserts.removeValue(forKey: oldID)
+        let pendingParent = pendingInsertParents.removeValue(forKey: oldID)
         folder.adoptCanonicalIDForStoreCorrelation(canonicalID)
+        fileHierarchyIndex.rekeyFolder(folder, from: oldID)
+        if let pendingChildren {
+            pendingChildInserts[canonicalID, default: []].append(contentsOf: pendingChildren)
+        }
+        if let pendingParent {
+            pendingInsertParents[canonicalID] = pendingParent
+        }
         registerExpansionTracking(for: folder)
     }
 
@@ -1627,6 +2229,7 @@ class WorkspaceFilesViewModel: ObservableObject {
     private func detachRootShellReferences(_ folder: FolderViewModel) -> WorkspaceRootRecord? {
         let stdRoot = folder.standardizedFullPath
         let rootKey = rootKey(forPath: folder.fullPath)
+        appliedIndexProjectionHandledGenerationByRootID.removeValue(forKey: folder.id)
         removeDeferredInitialRootLoadScanRoot(stdRoot)
         unregisterExpansionTracking(for: folder)
         dropSelections(underFolderFullPath: folder.fullPath)
@@ -3550,7 +4153,8 @@ class WorkspaceFilesViewModel: ObservableObject {
     private func handleNewFile(
         record: WorkspaceFileRecord,
         onRootFolder root: FolderViewModel,
-        requestCodeScanImmediately: Bool = true
+        requestCodeScanImmediately: Bool = true,
+        useRecordModificationDateForExistingFile: Bool = false
     ) async -> FileAdditionApplyOutcome? {
         let metadata = FileViewModel.PrecomputedPathMetadata.preparedReplay(
             standardizedAbsolutePath: record.standardizedFullPath,
@@ -3564,7 +4168,9 @@ class WorkspaceFilesViewModel: ObservableObject {
             preparedReplayPathMetadata: metadata,
             recordID: record.id,
             parentFolderID: record.parentFolderID,
-            modificationDate: record.modificationDate ?? Date()
+            modificationDate: record.modificationDate ?? Date(),
+            useProvidedModificationDateForExistingFile: useRecordModificationDateForExistingFile,
+            expectedRootID: record.rootID
         )
     }
 
@@ -3660,8 +4266,12 @@ class WorkspaceFilesViewModel: ObservableObject {
         preparedReplayPathMetadata: FileViewModel.PrecomputedPathMetadata? = nil,
         recordID: UUID? = nil,
         parentFolderID: UUID? = nil,
-        modificationDate: Date = Date()
+        modificationDate: Date = Date(),
+        useProvidedModificationDateForExistingFile: Bool = false,
+        expectedRootID: UUID? = nil
     ) async -> FileAdditionApplyOutcome? {
+        guard isCurrentAttachedRoot(root, expectedRootID: expectedRootID) else { return nil }
+
         let stdAbs: String
         if let preparedReplayPathMetadata {
             stdAbs = preparedReplayPathMetadata.standardizedFullPath
@@ -3679,11 +4289,16 @@ class WorkspaceFilesViewModel: ObservableObject {
             adoptCanonicalFolderIDForStoreCorrelation(intendedParentFolder, canonicalID: parentFolderID)
         } else if !parentRelativePath.isEmpty,
                   let intendedParentFolder,
-                  let workspaceRoot = workspaceFileContextRootsByRootKey[root.standardizedFullPath],
-                  let parentRecord = await workspaceFileContextStore.folder(rootID: workspaceRoot.id, relativePath: parentRelativePath),
-                  intendedParentFolder.id != parentRecord.id
+                  let workspaceRoot = workspaceFileContextRootsByRootKey[root.standardizedFullPath]
         {
-            adoptCanonicalFolderIDForStoreCorrelation(intendedParentFolder, canonicalID: parentRecord.id)
+            let parentRecord = await workspaceFileContextStore.folder(
+                rootID: workspaceRoot.id,
+                relativePath: parentRelativePath
+            )
+            guard isCurrentAttachedRoot(root, expectedRootID: expectedRootID) else { return nil }
+            if let parentRecord, intendedParentFolder.id != parentRecord.id {
+                adoptCanonicalFolderIDForStoreCorrelation(intendedParentFolder, canonicalID: parentRecord.id)
+            }
         }
 
         // If already tracked, only refresh m-date & scan. If store replay later supplies
@@ -3694,18 +4309,25 @@ class WorkspaceFilesViewModel: ObservableObject {
                 removeFileFromParentChildrenArray(existing)
                 fileHierarchyIndex.removeFile(forKey: stdAbs, expectedRootKey: root.standardizedFullPath)
             } else {
-                do {
-                    guard let workspaceRoot = workspaceFileContextRootsByRootKey[root.standardizedFullPath] else {
-                        throw FileManagerError.fileSystemServiceNotFoundWithContext("Workspace store root unavailable for '\(root.standardizedFullPath)'.")
+                let resolvedModificationDate: Date
+                if useProvidedModificationDateForExistingFile {
+                    resolvedModificationDate = modificationDate
+                } else {
+                    do {
+                        guard let workspaceRoot = workspaceFileContextRootsByRootKey[root.standardizedFullPath] else {
+                            throw FileManagerError.fileSystemServiceNotFoundWithContext("Workspace store root unavailable for '\(root.standardizedFullPath)'.")
+                        }
+                        resolvedModificationDate = try await workspaceFileContextStore.fileModificationDate(
+                            rootID: workspaceRoot.id,
+                            relativePath: relativePath
+                        )
+                    } catch {
+                        resolvedModificationDate = Date()
                     }
-                    let diskDate = try await workspaceFileContextStore.fileModificationDate(
-                        rootID: workspaceRoot.id,
-                        relativePath: relativePath
-                    )
-                    await existing.setModificationDate(diskDate, forceInvalidation: true)
-                } catch {
-                    await existing.setModificationDate(Date(), forceInvalidation: true)
                 }
+                guard isCurrentAttachedRoot(root, expectedRootID: expectedRootID) else { return nil }
+                await existing.setModificationDate(resolvedModificationDate, forceInvalidation: true)
+                guard isCurrentAttachedRoot(root, expectedRootID: expectedRootID) else { return nil }
                 if requestCodeScanImmediately {
                     requestCodeScan(for: existing)
                 }
@@ -3718,6 +4340,8 @@ class WorkspaceFilesViewModel: ObservableObject {
                 )
             }
         }
+
+        guard isCurrentAttachedRoot(root, expectedRootID: expectedRootID) else { return nil }
 
         let newFile = File(
             id: recordID ?? UUID(),
@@ -4364,6 +4988,7 @@ class WorkspaceFilesViewModel: ObservableObject {
     @MainActor
     func unloadRootFolder(_ folder: FolderViewModel) async {
         let signpost = WorkspaceExitPerf.begin("unloadRootFolder")
+        appliedIndexProjectionHandledGenerationByRootID.removeValue(forKey: folder.id)
         defer { WorkspaceExitPerf.end("unloadRootFolder", signpost) }
         let stdRoot = folder.standardizedFullPath
         removeDeferredInitialRootLoadScanRoot(stdRoot)
@@ -4997,6 +5622,7 @@ class WorkspaceFilesViewModel: ObservableObject {
         error = nil
         fileHierarchyIndex.clearAll()
         fileHierarchyIndex = FileHierarchyIndex()
+        appliedIndexProjectionHandledGenerationByRootID.removeAll(keepingCapacity: true)
         autoCodemapSyncTask?.cancel()
         autoCodemapSyncTask = nil
         resetAutoCodemapFiles([])
@@ -5027,6 +5653,7 @@ class WorkspaceFilesViewModel: ObservableObject {
         resetSelection()
         fileHierarchyIndex.clearAll()
         fileHierarchyIndex = FileHierarchyIndex()
+        appliedIndexProjectionHandledGenerationByRootID.removeAll(keepingCapacity: true)
         rootShellLoadedPaths.removeAll()
         rootHierarchyGenerations.removeAll()
         invalidateStaticSnapshot(forRootFullPath: nil)
@@ -7503,6 +8130,32 @@ class WorkspaceFilesViewModel: ObservableObject {
             let matchedFileKeys: Int
             let cleanupCandidateFileKeys: Int
             let usedFallbackGlobalScan: Bool
+        }
+
+        struct AppliedIndexProjectionIndexSnapshot: Equatable {
+            let filePathsByID: [UUID: String]
+            let folderPathsByID: [UUID: String]
+            let fileIDsByPath: [String: UUID]
+            let folderIDsByPath: [String: UUID]
+        }
+
+        @MainActor
+        func applyWorkspaceAppliedIndexEventForTesting(_ event: WorkspaceAppliedIndexBatchEvent) async {
+            await handleWorkspaceAppliedIndexEvent(event)
+        }
+
+        @MainActor
+        func appliedIndexProjectedFileForTesting(id: UUID) -> FileViewModel? {
+            fileHierarchyIndex.filesByID[id]
+        }
+
+        func appliedIndexProjectionIndexSnapshotForTesting() -> AppliedIndexProjectionIndexSnapshot {
+            AppliedIndexProjectionIndexSnapshot(
+                filePathsByID: fileHierarchyIndex.filesByID.mapValues(\.standardizedFullPath),
+                folderPathsByID: fileHierarchyIndex.foldersByID.mapValues(\.standardizedFullPath),
+                fileIDsByPath: fileHierarchyIndex.filesByFullPath.mapValues(\.id),
+                folderIDsByPath: fileHierarchyIndex.foldersByFullPath.mapValues(\.id)
+            )
         }
 
         @MainActor

--- a/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService+DirectoryEnumeration.swift
+++ b/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService+DirectoryEnumeration.swift
@@ -3,6 +3,11 @@ import Foundation
 extension FileSystemService {
     // MARK: - Parallel scanning support
 
+    struct FolderScanBatchResult {
+        let deltas: [FileSystemDelta]
+        let scannedFolders: Set<String>
+    }
+
     /// Result of scanning a single folder (Sendable for cross-task usage)
     struct ScanResult {
         let folderRel: String
@@ -74,28 +79,30 @@ extension FileSystemService {
 
     /// Scan multiple folders in parallel for better I/O performance.
     /// Uses configurable caps to prevent CPU saturation.
-    func scanFoldersInParallel(_ folders: Set<String>) async throws -> [FileSystemDelta] {
-        guard !folders.isEmpty else { return [] }
+    func scanFoldersInParallel(_ folders: Set<String>) async throws -> FolderScanBatchResult {
+        guard !folders.isEmpty else {
+            return FolderScanBatchResult(deltas: [], scannedFolders: [])
+        }
 
-        // In test mode, always use serial scanning to avoid thread safety issues with SpyFS
-        #if DEBUG
-            if isTestMode {
-                var deltas: [FileSystemDelta] = []
-                for folder in folders {
-                    let folderDeltas = try await scanOneLevelAndDiff(folder)
-                    deltas.append(contentsOf: folderDeltas)
-                }
-                return deltas
-            }
-        #endif
-
-        // Apply batch cap to limit per-tick work in high-churn scenarios
+        // Apply batch cap to limit per-tick work in high-churn scenarios.
         let cappedFolders: Set<String> = if folders.count > maxFoldersPerBatch {
-            // Take a subset; remaining folders will be picked up in subsequent batches
+            // Take a subset; remaining folders stay pending for a subsequent batch.
             Set(folders.prefix(maxFoldersPerBatch))
         } else {
             folders
         }
+
+        // In test mode, use the same cap but scan serially to avoid SpyFS thread-safety issues.
+        #if DEBUG
+            if isTestMode {
+                var deltas: [FileSystemDelta] = []
+                for folder in cappedFolders {
+                    let folderDeltas = try await scanOneLevelAndDiff(folder)
+                    deltas.append(contentsOf: folderDeltas)
+                }
+                return FolderScanBatchResult(deltas: deltas, scannedFolders: cappedFolders)
+            }
+        #endif
 
         // For small sets, just use serial scanning
         if cappedFolders.count <= 2 {
@@ -104,7 +111,7 @@ extension FileSystemService {
                 let folderDeltas = try await scanOneLevelAndDiff(folder)
                 deltas.append(contentsOf: folderDeltas)
             }
-            return deltas
+            return FolderScanBatchResult(deltas: deltas, scannedFolders: cappedFolders)
         }
 
         // Use parallel scanning for larger sets with BOUNDED CONCURRENCY
@@ -211,7 +218,7 @@ extension FileSystemService {
             }
         }
 
-        return aggregatedDeltas
+        return FolderScanBatchResult(deltas: aggregatedDeltas, scannedFolders: cappedFolders)
     }
 
     // MARK: - Single-level scanning & removal

--- a/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService+DirectoryEnumeration.swift
+++ b/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService+DirectoryEnumeration.swift
@@ -79,18 +79,20 @@ extension FileSystemService {
 
     /// Scan multiple folders in parallel for better I/O performance.
     /// Uses configurable caps to prevent CPU saturation.
-    func scanFoldersInParallel(_ folders: Set<String>) async throws -> FolderScanBatchResult {
+    func scanFoldersInParallel(_ folders: [String]) async throws -> FolderScanBatchResult {
         guard !folders.isEmpty else {
             return FolderScanBatchResult(deltas: [], scannedFolders: [])
         }
 
-        // Apply batch cap to limit per-tick work in high-churn scenarios.
-        let cappedFolders: Set<String> = if folders.count > maxFoldersPerBatch {
-            // Take a subset; remaining folders stay pending for a subsequent batch.
-            Set(folders.prefix(maxFoldersPerBatch))
-        } else {
-            folders
-        }
+        // Apply the cap without discarding caller-provided scheduling priority.
+        let cappedFolders = Array(folders.prefix(maxFoldersPerBatch))
+        let scannedFolders = Set(cappedFolders)
+
+        #if DEBUG
+            if isTestMode {
+                processedFolderBatches.append(cappedFolders)
+            }
+        #endif
 
         // In test mode, use the same cap but scan serially to avoid SpyFS thread-safety issues.
         #if DEBUG
@@ -100,7 +102,7 @@ extension FileSystemService {
                     let folderDeltas = try await scanOneLevelAndDiff(folder)
                     deltas.append(contentsOf: folderDeltas)
                 }
-                return FolderScanBatchResult(deltas: deltas, scannedFolders: cappedFolders)
+                return FolderScanBatchResult(deltas: deltas, scannedFolders: scannedFolders)
             }
         #endif
 
@@ -111,7 +113,7 @@ extension FileSystemService {
                 let folderDeltas = try await scanOneLevelAndDiff(folder)
                 deltas.append(contentsOf: folderDeltas)
             }
-            return FolderScanBatchResult(deltas: deltas, scannedFolders: cappedFolders)
+            return FolderScanBatchResult(deltas: deltas, scannedFolders: scannedFolders)
         }
 
         // Use parallel scanning for larger sets with BOUNDED CONCURRENCY
@@ -120,7 +122,7 @@ extension FileSystemService {
         // Use configured parallelism cap (prevents CPU saturation)
         let maxParallel = min(cappedFolders.count, maxParallelScansPerActor)
 
-        let targetParents = cappedFolders
+        let targetParents = scannedFolders
         var preservedChildrenByFolder: [String: Set<String>] = [:]
         preservedChildrenByFolder.reserveCapacity(targetParents.count)
         for path in visitedPaths {
@@ -218,7 +220,7 @@ extension FileSystemService {
             }
         }
 
-        return FolderScanBatchResult(deltas: aggregatedDeltas, scannedFolders: cappedFolders)
+        return FolderScanBatchResult(deltas: aggregatedDeltas, scannedFolders: scannedFolders)
     }
 
     // MARK: - Single-level scanning & removal

--- a/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService+FSEvents.swift
+++ b/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService+FSEvents.swift
@@ -540,7 +540,9 @@ extension FileSystemService {
     func startProcessingPendingWatcherBatchIfNeeded() -> Bool {
         guard watcherBatchProcessingTask == nil else { return true }
         let batch = takePendingFSEventsForProcessing()
-        guard !batch.isEmpty || batch.watcherAcceptedHighWatermark != nil else { return false }
+        guard !batch.isEmpty || batch.watcherAcceptedHighWatermark != nil
+            || !pendingQuietFolderScanTargets.isEmpty
+        else { return false }
 
         nextWatcherBatchProcessingToken &+= 1
         let token = nextWatcherBatchProcessingToken
@@ -571,6 +573,8 @@ extension FileSystemService {
         watcherBatchProcessingToken = nil
         if !pendingFSEvents.isEmpty {
             scheduleCoalescingIfNeeded()
+        } else if !pendingQuietFolderScanTargets.isEmpty {
+            _ = startProcessingPendingWatcherBatchIfNeeded()
         }
     }
 
@@ -625,6 +629,7 @@ extension FileSystemService {
         hasPendingOverflowRescan = false
         overflowChangedIgnoreDirs.removeAll(keepingCapacity: false)
         pendingScanTargets.removeAll(keepingCapacity: false)
+        pendingQuietFolderScanTargets.removeAll(keepingCapacity: false)
         lastScannedEventIdByFolder.removeAll(keepingCapacity: false)
         lastVerifiedAtByFolder.removeAll(keepingCapacity: false)
         fileEventCountSinceLastScan.removeAll(keepingCapacity: false)
@@ -797,7 +802,7 @@ extension FileSystemService {
             return testMode ? [] : nil
         }
         let events = batch.events
-        guard !events.isEmpty else {
+        guard !events.isEmpty || !pendingQuietFolderScanTargets.isEmpty else {
             if let watermark = batch.watcherAcceptedHighWatermark {
                 publishFileSystemDeltas([], source: .watcherBarrierNoop, watcherAcceptedWatermark: watermark)
             }
@@ -1254,7 +1259,8 @@ extension FileSystemService {
         // Build eligible set: folders that need scanning
         // - nil lastScannedId means "never scanned" → always eligible
         // - Otherwise, only rescan if pendingId > lastScannedId
-        let eligibleFolders = Set(foldersToScan.filter { folder in
+        let scanCandidates = foldersToScan.union(pendingQuietFolderScanTargets)
+        let eligibleFolders = Set(scanCandidates.filter { folder in
             guard let pendingId = pendingScanTargets[folder] else {
                 return false // No pending scan target (shouldn't happen, but be defensive)
             }
@@ -1267,15 +1273,6 @@ extension FileSystemService {
         // Use parallel scanning for better I/O performance
         if !eligibleFolders.isEmpty {
             do {
-                #if DEBUG
-                    if isTestMode {
-                        // Track all folders being processed
-                        for folder in eligibleFolders {
-                            processedFolders.insert(folder)
-                        }
-                    }
-                #endif
-
                 // Ensure all folders have their ignore rules loaded before parallel scan
                 if enableHierarchicalIgnores {
                     for folderRelPath in eligibleFolders {
@@ -1283,11 +1280,17 @@ extension FileSystemService {
                     }
                 }
 
-                let folderDeltas = try await scanFoldersInParallel(eligibleFolders)
-                allDeltas.append(contentsOf: folderDeltas)
+                let scanResult = try await scanFoldersInParallel(eligibleFolders)
+                allDeltas.append(contentsOf: scanResult.deltas)
 
-                // Update tracking for successfully scanned folders
-                for folder in eligibleFolders {
+                #if DEBUG
+                    if isTestMode {
+                        processedFolders.formUnion(scanResult.scannedFolders)
+                    }
+                #endif
+
+                // Update tracking only for folders actually scanned after applying the cap.
+                for folder in scanResult.scannedFolders {
                     if let pendingId = pendingScanTargets[folder] {
                         lastScannedEventIdByFolder[folder] = pendingId
                         pendingScanTargets.removeValue(forKey: folder)
@@ -1295,8 +1298,18 @@ extension FileSystemService {
                     // Record verification time for safety-net tracking
                     recordFolderVerified(folder)
                 }
+                pendingQuietFolderScanTargets.subtract(scanResult.scannedFolders)
+                if watcherBatchBelongsToCurrentIngressGeneration(batch) {
+                    pendingQuietFolderScanTargets.formUnion(
+                        eligibleFolders.subtracting(scanResult.scannedFolders)
+                    )
+                    pendingQuietFolderScanTargets.formIntersection(Set(pendingScanTargets.keys))
+                }
             } catch {
                 print("Error during parallel folder scanning: \(error)")
+                // A failed scan remains pending for a future event, but must not create a
+                // tight quiet-retry loop. The serial fallback gets one immediate attempt.
+                pendingQuietFolderScanTargets.subtract(eligibleFolders)
                 // Fallback to serial scanning if parallel fails
                 for folderRelPath in eligibleFolders {
                     do {
@@ -1372,6 +1385,21 @@ extension FileSystemService {
             #endif
         }
 
+        let hasPendingQuietFolderScans = !pendingQuietFolderScanTargets.isEmpty
+        let publishableWatcherWatermark: FileSystemWatcherIngressMailbox.Watermark?
+        if hasPendingQuietFolderScans, let acceptedHighWatermark = batch.watcherAcceptedHighWatermark {
+            pendingWatcherAcceptedHighWatermark = max(
+                pendingWatcherAcceptedHighWatermark ?? .zero,
+                acceptedHighWatermark
+            )
+            if batch.publicationSource == .overflowRootRescan {
+                pendingWatcherPublicationSource = .overflowRootRescan
+            }
+            publishableWatcherWatermark = nil
+        } else {
+            publishableWatcherWatermark = batch.watcherAcceptedHighWatermark
+        }
+
         let publicationSource: FileSystemDeltaPublicationSource = if batch.publicationSource == .overflowRootRescan {
             .overflowRootRescan
         } else if publishableDeltas.isEmpty {
@@ -1379,11 +1407,11 @@ extension FileSystemService {
         } else {
             batch.publicationSource
         }
-        if !publishableDeltas.isEmpty || batch.watcherAcceptedHighWatermark != nil {
+        if !publishableDeltas.isEmpty || publishableWatcherWatermark != nil {
             publishFileSystemDeltas(
                 publishableDeltas,
                 source: publicationSource,
-                watcherAcceptedWatermark: batch.watcherAcceptedHighWatermark
+                watcherAcceptedWatermark: publishableWatcherWatermark
             )
         }
         FileSystemPublishPerf.end("coalesceAndPublishFileSystemDeltas", publishSignpost)

--- a/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService+FSEvents.swift
+++ b/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService+FSEvents.swift
@@ -182,17 +182,21 @@ extension FileSystemService {
     func flushPendingEventsNow(
         throughAcceptedWatcherWatermark target: FileSystemWatcherIngressMailbox.Watermark
     ) async -> UInt64 {
+        guard !Task.isCancelled else { return lastServicePublicationSequence }
         drainAcceptedWatcherIngressMailboxPayloads(through: target)
         cancelScheduledCoalescingDelay()
 
         while lastPublishedWatcherAcceptedWatermark < target {
+            guard !Task.isCancelled else { return lastServicePublicationSequence }
             if let watcherBatchProcessingTask {
                 await watcherBatchProcessingTask.value
+                guard !Task.isCancelled else { return lastServicePublicationSequence }
                 drainAcceptedWatcherIngressMailboxPayloads(through: target)
                 cancelScheduledCoalescingDelay()
                 continue
             }
 
+            guard !Task.isCancelled else { return lastServicePublicationSequence }
             guard startProcessingPendingWatcherBatchIfNeeded() else {
                 // A callback cut must remain representable even if accepted payloads
                 // were explicitly abandoned during watcher teardown or produced no deltas.
@@ -1260,7 +1264,7 @@ extension FileSystemService {
         // - nil lastScannedId means "never scanned" → always eligible
         // - Otherwise, only rescan if pendingId > lastScannedId
         let scanCandidates = foldersToScan.union(pendingQuietFolderScanTargets)
-        let eligibleFolders = Set(scanCandidates.filter { folder in
+        let eligibleFolderSet = Set(scanCandidates.filter { folder in
             guard let pendingId = pendingScanTargets[folder] else {
                 return false // No pending scan target (shouldn't happen, but be defensive)
             }
@@ -1269,6 +1273,11 @@ extension FileSystemService {
             }
             return pendingId > lastScannedId // Only rescan if newer events arrived
         })
+        // Carry-over work always precedes newly arrived work. Once a carried folder is
+        // scanned it leaves this set, so capped batches advance through the backlog.
+        let carriedFolders = pendingQuietFolderScanTargets.intersection(eligibleFolderSet).sorted()
+        let newlyEligibleFolders = eligibleFolderSet.subtracting(pendingQuietFolderScanTargets).sorted()
+        let eligibleFolders = carriedFolders + newlyEligibleFolders
 
         // Use parallel scanning for better I/O performance
         if !eligibleFolders.isEmpty {
@@ -1301,7 +1310,7 @@ extension FileSystemService {
                 pendingQuietFolderScanTargets.subtract(scanResult.scannedFolders)
                 if watcherBatchBelongsToCurrentIngressGeneration(batch) {
                     pendingQuietFolderScanTargets.formUnion(
-                        eligibleFolders.subtracting(scanResult.scannedFolders)
+                        eligibleFolderSet.subtracting(scanResult.scannedFolders)
                     )
                     pendingQuietFolderScanTargets.formIntersection(Set(pendingScanTargets.keys))
                 }
@@ -1309,7 +1318,7 @@ extension FileSystemService {
                 print("Error during parallel folder scanning: \(error)")
                 // A failed scan remains pending for a future event, but must not create a
                 // tight quiet-retry loop. The serial fallback gets one immediate attempt.
-                pendingQuietFolderScanTargets.subtract(eligibleFolders)
+                pendingQuietFolderScanTargets.subtract(Set(eligibleFolders))
                 // Fallback to serial scanning if parallel fails
                 for folderRelPath in eligibleFolders {
                     do {

--- a/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService+Testing.swift
+++ b/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService+Testing.swift
@@ -104,6 +104,7 @@ import Foundation
         ) async -> [FileSystemDelta] {
             // Clear any previous deltas
             processedFolders.removeAll()
+            processedFolderBatches.removeAll()
 
             // Process the events and get deltas directly
             let formattedEvents = events.map { ($0.absolutePath, $0.flags, $0.eventId) }
@@ -115,6 +116,10 @@ import Foundation
         /// Test-only method to get processed folders
         func getProcessedFolders() -> Set<String> {
             processedFolders
+        }
+
+        func getProcessedFolderBatches() -> [[String]] {
+            processedFolderBatches
         }
 
         /// Test-only method to get current state

--- a/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService.swift
+++ b/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService.swift
@@ -189,6 +189,8 @@ actor FileSystemService {
     var pendingScanTargets: [String: FSEventStreamEventId] = [:]
     /// Maps folder relative path → highest FSEvent ID that has already been scanned
     var lastScannedEventIdByFolder: [String: FSEventStreamEventId] = [:]
+    /// Cap-omitted folders that must be scanned by quiet follow-up watcher batches.
+    var pendingQuietFolderScanTargets: Set<String> = []
 
     /// Short-lived cache
     /// results during a directory walk to avoid repeated allocations.

--- a/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService.swift
+++ b/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService.swift
@@ -105,6 +105,7 @@ actor FileSystemService {
 
         /// Test-only tracking of processed events
         var processedFolders: Set<String> = []
+        var processedFolderBatches: [[String]] = []
 
         /// Test-only method to mock directory contents
         var mockDirectoryContents: ((String) -> [String])?

--- a/Sources/RepoPrompt/Infrastructure/MCP/MCPConnectionManager.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/MCPConnectionManager.swift
@@ -1,6 +1,7 @@
 // MARK: - Connection Management Components
 
 import Darwin
+import Dispatch
 import Foundation
 import JSONSchema
 import Logging
@@ -3249,6 +3250,7 @@ actor ServerNetworkManager {
         mcpACPLog("[MCP-ACP] registered bootstrap connection connection=\(connectionID) pendingClientName=\(clientName ?? "unknown")")
 
         connections[connectionID] = manager
+        callLimiters[connectionID] = AsyncLimiter(limit: limiterLimit(for: connectionID))
         connectionLifecycleGenerationByID[connectionID] = lifecycleGeneration
         bindSessionToken(sessionToken, to: connectionID)
         if connectionStats[connectionID] == nil {
@@ -3587,6 +3589,7 @@ actor ServerNetworkManager {
             guard connectionLifecycleGenerationByID[connectionID] == stoppedLifecycleGeneration else { return nil }
             return (connectionID, connectionManager)
         }
+        let limitersToStop = Array(callLimiters)
 
         // This synchronous invalidation boundary executes before the first await. New starts
         // receive a new generation and stale listener/restart/connection resumptions can no
@@ -3637,6 +3640,7 @@ actor ServerNetworkManager {
             capabilityTokenByConnection.removeValue(forKey: id)
             connectionStats.removeValue(forKey: id)
         }
+        callLimiters.removeAll()
 
         // Clear shared in-memory routing caches before yielding. A replacement lifecycle
         // may repopulate them while this shutdown awaits, so stale teardown must never
@@ -3646,6 +3650,10 @@ actor ServerNetworkManager {
         capabilityTokenByConnection.removeAll()
         connectionIDBySessionToken.removeAll()
         resetInMemoryRoutingCachesForRestart()
+
+        for (_, limiter) in limitersToStop {
+            await limiter.cancelAll()
+        }
 
         await stopBootstrapSocketServer(server: listenerToStop, lifecycleGeneration: stoppedLifecycleGeneration)
 
@@ -3657,6 +3665,21 @@ actor ServerNetworkManager {
                 debugRecordConnectionEvent("removed", connectionID: id, reason: "serverShutdown")
             #endif
             await connectionManager.stop()
+        }
+        await withTaskGroup(of: (UUID, Bool).self) { group in
+            for (connectionID, limiter) in limitersToStop {
+                group.addTask {
+                    let drained = await limiter.waitUntilIdle(
+                        timeout: MCPTimeoutPolicy.boundedToolCancellationCleanupGrace
+                    )
+                    return (connectionID, drained)
+                }
+            }
+            for await (connectionID, drained) in group where !drained {
+                connectionLog(
+                    "Connection limiter cleanup grace expired during server shutdown: \(connectionID)"
+                )
+            }
         }
         emitDashboardUpdate()
     }
@@ -3680,7 +3703,6 @@ actor ServerNetworkManager {
         pendingPolicyApplicationIDByRunID.removeAll()
         activeConnectionsByClient.removeAll()
         clientIDByConnection.removeAll()
-        callLimiters.removeAll()
         capabilityTokenByConnection.removeAll()
         connectionIDBySessionToken.removeAll()
         lastWindowByClientSession.removeAll()
@@ -4111,6 +4133,7 @@ actor ServerNetworkManager {
         guard connections[id] != nil
             || connectionTasks[id] != nil
             || pendingConnections[id] != nil
+            || callLimiters[id] != nil
         else {
             connectionLog("removeConnection: \(id) already removed; ignoring duplicate call")
             return
@@ -4120,6 +4143,9 @@ actor ServerNetworkManager {
         defer { connectionsBeingRemoved.remove(id) }
 
         connectionLog("Removing connection: \(id)")
+
+        let limiter = callLimiters.removeValue(forKey: id)
+        await limiter?.cancelAll()
 
         let assignedWindowID = connectionWindowMap[id]
         let cleanupClientID = clientIDByConnection[id]
@@ -4207,10 +4233,20 @@ actor ServerNetworkManager {
             else { activeConnectionsByClient[clientID] = set }
             clientIDByConnection.removeValue(forKey: id)
         }
-        callLimiters[id] = nil
-
-        // Clean up routing metadata
+        // Clean up routing metadata before any bounded drain wait so the disconnected
+        // connection cannot remain discoverable while an active owner ignores cancellation.
         unbindSessionToken(sessionToken, forConnectionID: id)
+
+        if let limiter {
+            let drained = await limiter.waitUntilIdle(
+                timeout: MCPTimeoutPolicy.boundedToolCancellationCleanupGrace
+            )
+            if !drained {
+                connectionLog(
+                    "Connection limiter cleanup grace expired; detached active owner may settle later: \(id)"
+                )
+            }
+        }
 
         // Notify dashboard of connection removal
         emitDashboardUpdate()
@@ -6461,6 +6497,20 @@ actor ServerNetworkManager {
         }
 
         #if DEBUG
+            func debugInstallConnectionLimiterForTesting(
+                connectionID: UUID,
+                idleWaitSleep: @escaping @Sendable (Duration) async throws -> Void = { duration in
+                    try await Task.sleep(for: duration)
+                }
+            ) -> AsyncLimiter {
+                let limiter = AsyncLimiter(
+                    limit: limiterLimit(for: connectionID),
+                    idleWaitSleep: idleWaitSleep
+                )
+                callLimiters[connectionID] = limiter
+                return limiter
+            }
+
             func debugRegisterConnectionForSocketFixture(
                 connectionID: UUID,
                 connection: any MCPServerConnection,
@@ -6470,6 +6520,9 @@ actor ServerNetworkManager {
                 _ = clientName
                 _ = sessionToken
                 debugExecutionWatchdogAbortTargets[connectionID] = connection
+                if callLimiters[connectionID] == nil {
+                    callLimiters[connectionID] = AsyncLimiter(limit: limiterLimit(for: connectionID))
+                }
             }
 
             func debugSetToolExecutionWatchdogEnvironment(_ environment: MCPToolExecutionWatchdogEnvironment) {
@@ -7931,8 +7984,22 @@ actor ServerNetworkManager {
                     "originalName": originalName
                 ])
                 if Self.isDebugDiagnosticsToolName(toolName) {
-                    let limiter = await self.limiter(for: connectionID)
-                    return await limiter.withPermit {
+                    guard let limiter = await self.limiter(for: connectionID) else {
+                        return Self.executionContractToolErrorResult(
+                            rawJSON: false,
+                            code: "tool_execution_connection_terminal",
+                            message: "The MCP connection is closing."
+                        )
+                    }
+                    return await limiter.withPermit(
+                        cancellationResult: {
+                            Self.executionContractToolErrorResult(
+                                rawJSON: false,
+                                code: "tool_execution_connection_terminal",
+                                message: "The MCP connection is closing."
+                            )
+                        }
+                    ) {
                         await self.handleDebugDiagnosticsTool(
                             connectionID: connectionID,
                             arguments: params.arguments ?? [:]
@@ -8181,6 +8248,14 @@ actor ServerNetworkManager {
                 await self.limiter(for: connectionID)
             }
             endPreLimiterEnvelopeIfNeeded()
+            guard let limiter else {
+                connectionLog("tools/call \(toolName): rejected because connection limiter is unavailable")
+                return Self.executionContractToolErrorResult(
+                    rawJSON: capturedRawJSON,
+                    code: "tool_execution_connection_terminal",
+                    message: "The MCP connection is closing."
+                )
+            }
             connectionLog("tools/call \(toolName): entering limiter")
             return await EditFlowPerf.measure(
                 EditFlowPerf.Stage.MCPToolCall.limiterEnvelope,
@@ -8195,8 +8270,16 @@ actor ServerNetworkManager {
                     correlation: lifecycleCorrelation,
                     EditFlowPerf.Dimensions(toolName: toolName)
                 )
-                return await limiter.withPermit {
-                    EditFlowPerf.end(EditFlowPerf.Stage.MCPToolCall.limiterWait, limiterWaitState)
+                defer { EditFlowPerf.end(EditFlowPerf.Stage.MCPToolCall.limiterWait, limiterWaitState) }
+                return await limiter.withPermit(
+                    cancellationResult: {
+                        Self.executionContractToolErrorResult(
+                            rawJSON: capturedRawJSON,
+                            code: "tool_execution_connection_terminal",
+                            message: "The MCP connection is closing."
+                        )
+                    }
+                ) {
                     guard !Task.isCancelled,
                           await !(self.executionWatchdogTerminalConnections.contains(connectionID))
                     else {
@@ -9680,11 +9763,8 @@ actor ServerNetworkManager {
         return 1
     }
 
-    func limiter(for connectionID: UUID) -> AsyncLimiter {
-        if let l = callLimiters[connectionID] { return l }
-        let l = AsyncLimiter(limit: limiterLimit(for: connectionID))
-        callLimiters[connectionID] = l
-        return l
+    func limiter(for connectionID: UUID) -> AsyncLimiter? {
+        callLimiters[connectionID]
     }
 
     func hasInFlightCalls(for connectionID: UUID) async -> Bool {
@@ -9693,11 +9773,17 @@ actor ServerNetworkManager {
     }
 
     #if DEBUG
-        func connectionLimiterSnapshotForTesting(
+        func connectionLimiterDiagnosticsSnapshot(
             connectionID: UUID
         ) async -> AsyncLimiter.DebugSnapshot? {
             guard let limiter = callLimiters[connectionID] else { return nil }
             return await limiter.debugSnapshot()
+        }
+
+        func connectionLimiterSnapshotForTesting(
+            connectionID: UUID
+        ) async -> AsyncLimiter.DebugSnapshot? {
+            await connectionLimiterDiagnosticsSnapshot(connectionID: connectionID)
         }
 
         func setConnectionLimiterStateObserverForTesting(
@@ -9888,60 +9974,241 @@ actor ServerNetworkManager {
     }
 }
 
-/// Simple async semaphore (backpressure per connection)
+/// Cancellation-aware async semaphore used to serialize calls per connection.
 actor AsyncLimiter {
+    private struct Waiter {
+        let id: UUID
+        let continuation: CheckedContinuation<Void, Error>
+        let enqueuedAtNanoseconds: UInt64
+        var previousID: UUID?
+        var nextID: UUID?
+    }
+
     private let limit: Int
     private var permits: Int
-    private var waiters: [CheckedContinuation<Void, Never>] = []
-
-    /// Tracks the number of tasks currently inside withPermit (including queued ones)
-    private var inFlight: Int = 0
+    private var activePermitCount = 0
+    private var inFlight = 0
+    private var isClosed = false
+    private var waiterByID: [UUID: Waiter] = [:]
+    private var firstWaiterID: UUID?
+    private var lastWaiterID: UUID?
+    private var idleWaiters: [UUID: CheckedContinuation<Bool, Never>] = [:]
+    private var cancelledWaiterCount = 0
+    private let idleWaitSleep: @Sendable (Duration) async throws -> Void
 
     #if DEBUG
         struct DebugSnapshot: Equatable {
+            let limit: Int
             let permits: Int
+            let activePermitCount: Int
             let waiterCount: Int
             let inFlight: Int
+            let oldestWaiterAgeMilliseconds: UInt64?
+            let cancelledWaiterCount: Int
+            let isClosed: Bool
+            let isIdle: Bool
         }
 
+        private let debugNowNanoseconds: @Sendable () -> UInt64
         private var debugStateObserver: ((DebugSnapshot) -> Void)?
+        private var debugQueuedPermitHandoffHandler: (@Sendable () async -> Void)?
     #endif
 
-    init(limit: Int) {
-        self.limit = max(1, limit)
-        permits = max(1, limit)
-    }
+    #if DEBUG
+        init(
+            limit: Int,
+            debugNowNanoseconds: @escaping @Sendable () -> UInt64 = { DispatchTime.now().uptimeNanoseconds },
+            idleWaitSleep: @escaping @Sendable (Duration) async throws -> Void = { duration in
+                try await Task.sleep(for: duration)
+            }
+        ) {
+            self.limit = max(1, limit)
+            permits = max(1, limit)
+            self.debugNowNanoseconds = debugNowNanoseconds
+            self.idleWaitSleep = idleWaitSleep
+        }
+    #else
+        init(limit: Int) {
+            self.limit = max(1, limit)
+            permits = max(1, limit)
+            idleWaitSleep = { duration in
+                try await Task.sleep(for: duration)
+            }
+        }
+    #endif
 
-    /// Acquires a permit, waiting if none are available.
-    private func acquirePermit() async {
+    private func acquirePermit() async throws {
+        try Task.checkCancellation()
+        guard !isClosed else { throw CancellationError() }
+
         if permits > 0 {
             permits -= 1
+            activePermitCount += 1
             notifyDebugStateChanged()
             return
         }
-        await withCheckedContinuation {
-            waiters.append($0)
-            notifyDebugStateChanged()
+
+        let waiterID = UUID()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                guard !isClosed else {
+                    continuation.resume(throwing: CancellationError())
+                    return
+                }
+                appendWaiter(Waiter(
+                    id: waiterID,
+                    continuation: continuation,
+                    enqueuedAtNanoseconds: currentDebugNanoseconds(),
+                    previousID: lastWaiterID,
+                    nextID: nil
+                ))
+                notifyDebugStateChanged()
+            }
+        } onCancel: {
+            Task { await self.cancelWaiter(waiterID) }
         }
-        // When resumed, the caller now has a permit (recycled from a release)
+
+        #if DEBUG
+            if let debugQueuedPermitHandoffHandler {
+                await debugQueuedPermitHandoffHandler()
+            }
+        #endif
+        guard !isClosed else {
+            releasePermit()
+            throw CancellationError()
+        }
     }
 
-    /// Releases a permit, resuming a waiter if any are queued.
-    private func releasePermit() {
-        if !waiters.isEmpty {
-            let c = waiters.removeFirst()
-            c.resume()
-            // No permit count change: we just hand the freed permit to the next waiter
+    private func appendWaiter(_ waiter: Waiter) {
+        if let lastWaiterID, var lastWaiter = waiterByID[lastWaiterID] {
+            lastWaiter.nextID = waiter.id
+            waiterByID[lastWaiterID] = lastWaiter
         } else {
+            firstWaiterID = waiter.id
+        }
+        waiterByID[waiter.id] = waiter
+        lastWaiterID = waiter.id
+    }
+
+    @discardableResult
+    private func removeWaiter(_ waiterID: UUID) -> Waiter? {
+        guard let waiter = waiterByID.removeValue(forKey: waiterID) else { return nil }
+        if let previousID = waiter.previousID, var previous = waiterByID[previousID] {
+            previous.nextID = waiter.nextID
+            waiterByID[previousID] = previous
+        } else {
+            firstWaiterID = waiter.nextID
+        }
+        if let nextID = waiter.nextID, var next = waiterByID[nextID] {
+            next.previousID = waiter.previousID
+            waiterByID[nextID] = next
+        } else {
+            lastWaiterID = waiter.previousID
+        }
+        return waiter
+    }
+
+    private func popFirstWaiter() -> Waiter? {
+        guard let firstWaiterID else { return nil }
+        return removeWaiter(firstWaiterID)
+    }
+
+    private func cancelWaiter(_ waiterID: UUID) {
+        guard let waiter = removeWaiter(waiterID) else { return }
+        cancelledWaiterCount += 1
+        waiter.continuation.resume(throwing: CancellationError())
+        notifyDebugStateChanged()
+    }
+
+    private func releasePermit() {
+        if let waiter = popFirstWaiter() {
+            waiter.continuation.resume()
+        } else {
+            activePermitCount = max(0, activePermitCount - 1)
             permits = min(permits + 1, limit)
         }
         notifyDebugStateChanged()
     }
 
-    /// Number of in-flight operations (0 means idle).
-    /// This counts all tasks inside withPermit, including those waiting for a permit.
+    /// Rejects new acquisitions and promptly cancels every queued waiter.
+    func cancelAll() {
+        isClosed = true
+        while let waiter = popFirstWaiter() {
+            cancelledWaiterCount += 1
+            waiter.continuation.resume(throwing: CancellationError())
+        }
+        notifyDebugStateChanged()
+        resumeIdleWaitersIfNeeded()
+    }
+
+    /// Waits until active owners and cancelled queued callers have left `withPermit`.
+    /// Returns `false` when the caller cancels its join; active owners are never force-released.
+    func waitUntilIdle() async -> Bool {
+        guard !Task.isCancelled else { return false }
+        guard !isIdle else { return true }
+        let waiterID = UUID()
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                guard !Task.isCancelled else {
+                    continuation.resume(returning: false)
+                    return
+                }
+                guard !isIdle else {
+                    continuation.resume(returning: true)
+                    return
+                }
+                idleWaiters[waiterID] = continuation
+            }
+        } onCancel: {
+            Task { await self.cancelIdleWaiter(waiterID) }
+        }
+    }
+
+    /// Gives active owners a bounded cooperative cleanup grace. A timed-out owner remains
+    /// attached only to this closed limiter and may settle later without blocking teardown.
+    func waitUntilIdle(timeout: Duration) async -> Bool {
+        guard !Task.isCancelled else { return false }
+        guard !isIdle else { return true }
+        let sleep = idleWaitSleep
+        return await withTaskGroup(of: Bool?.self) { group in
+            group.addTask { [weak self] in
+                guard let self else { return true }
+                return await waitUntilIdle()
+            }
+            group.addTask {
+                do {
+                    try await sleep(timeout)
+                    return false
+                } catch {
+                    return nil
+                }
+            }
+            let first = await group.next() ?? false
+            group.cancelAll()
+            return first ?? false
+        }
+    }
+
+    /// Number of active and queued operations (0 means idle).
     func activeCount() -> Int {
         inFlight
+    }
+
+    private var isIdle: Bool {
+        inFlight == 0 && activePermitCount == 0 && waiterByID.isEmpty
+    }
+
+    private func cancelIdleWaiter(_ waiterID: UUID) {
+        idleWaiters.removeValue(forKey: waiterID)?.resume(returning: false)
+    }
+
+    private func resumeIdleWaitersIfNeeded() {
+        guard isIdle, !idleWaiters.isEmpty else { return }
+        let continuations = Array(idleWaiters.values)
+        idleWaiters.removeAll()
+        for continuation in continuations {
+            continuation.resume(returning: true)
+        }
     }
 
     #if DEBUG
@@ -9956,33 +10223,78 @@ actor AsyncLimiter {
             observer?(makeDebugSnapshot())
         }
 
+        func setDebugQueuedPermitHandoffHandler(
+            _ handler: (@Sendable () async -> Void)?
+        ) {
+            debugQueuedPermitHandoffHandler = handler
+        }
+
         private func makeDebugSnapshot() -> DebugSnapshot {
-            DebugSnapshot(
+            let now = debugNowNanoseconds()
+            let oldestWaiterAgeMilliseconds = firstWaiterID
+                .flatMap { waiterByID[$0] }
+                .map { Self.elapsedMilliseconds(since: $0.enqueuedAtNanoseconds, now: now) }
+            return DebugSnapshot(
+                limit: limit,
                 permits: permits,
-                waiterCount: waiters.count,
-                inFlight: inFlight
+                activePermitCount: activePermitCount,
+                waiterCount: waiterByID.count,
+                inFlight: inFlight,
+                oldestWaiterAgeMilliseconds: oldestWaiterAgeMilliseconds,
+                cancelledWaiterCount: cancelledWaiterCount,
+                isClosed: isClosed,
+                isIdle: isIdle
             )
+        }
+
+        private static func elapsedMilliseconds(since start: UInt64, now: UInt64) -> UInt64 {
+            guard now >= start else { return 0 }
+            return (now - start) / 1_000_000
+        }
+
+        private func currentDebugNanoseconds() -> UInt64 {
+            debugNowNanoseconds()
         }
 
         private func notifyDebugStateChanged() {
             debugStateObserver?(makeDebugSnapshot())
         }
     #else
+        private func currentDebugNanoseconds() -> UInt64 {
+            0
+        }
+
         private func notifyDebugStateChanged() {}
     #endif
 
     /// Executes an operation with a permit, limiting concurrency.
     func withPermit<T>(
         _ op: @Sendable () async throws -> T
-    ) async rethrows -> T {
+    ) async throws -> T {
         inFlight += 1
         notifyDebugStateChanged()
         defer {
             inFlight -= 1
             notifyDebugStateChanged()
+            resumeIdleWaitersIfNeeded()
         }
-        await acquirePermit()
+
+        try await acquirePermit()
         defer { releasePermit() }
+        try Task.checkCancellation()
         return try await op()
+    }
+
+    func withPermit<T>(
+        cancellationResult: @Sendable () -> T,
+        _ op: @Sendable () async -> T
+    ) async -> T {
+        do {
+            return try await withPermit {
+                await op()
+            }
+        } catch {
+            return cancellationResult()
+        }
     }
 }

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel.swift
@@ -2932,6 +2932,10 @@ final class MCPServerViewModel: ObservableObject {
             readFileAutoSelectionCoordinator.setCanonicalApplyGateForTesting(gate)
         }
 
+        @MainActor
+        func readFileAutoSelectionDiagnosticsSnapshot() -> MCPReadFileAutoSelectionCoordinator.DebugSnapshot {
+            readFileAutoSelectionCoordinator.debugSnapshot()
+        }
     #endif
 
     @MainActor
@@ -3512,7 +3516,7 @@ final class MCPServerViewModel: ObservableObject {
         try Task.checkCancellation()
         let store = promptVM.workspaceFileContextStore
         let readableService = WorkspaceReadableFileService(store: store)
-        await readableService.awaitFreshnessForExplicitRequest(path, fallbackScope: lookupRootScope)
+        try await readableService.awaitFreshnessForExplicitRequest(path, fallbackScope: lookupRootScope)
         try Task.checkCancellation()
         let (roots, readableFile): ([WorkspaceRootRef], WorkspaceReadableFileHandle?) = try await EditFlowPerf.measure(EditFlowPerf.Stage.ReadFile.resolveReadableFile) {
             let exactPathIssueDetection = EditFlowPerf.begin(EditFlowPerf.Stage.ReadFile.exactPathIssueDetection)

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/Models/WorkspaceFileContextModels.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/Models/WorkspaceFileContextModels.swift
@@ -371,6 +371,13 @@ struct WorkspaceIngressBarrierSample: Equatable {
     let appliedWatcherWatermark: UInt64
 }
 
+struct WorkspaceAppliedIndexRootSnapshot: Equatable {
+    let root: WorkspaceRootRecord
+    let generation: UInt64
+    let files: [WorkspaceFileRecord]
+    let folders: [WorkspaceFolderRecord]
+}
+
 struct WorkspaceAppliedIndexBatchEvent: Equatable {
     let rootID: UUID
     let rootPath: String

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
@@ -445,7 +445,26 @@ actor WorkspaceFileContextStore {
             recorder: PublicationInvalidationRecorder
         ) {
             guard rootStatesByID[rootID] != nil else { return }
-            let sample = PublicationInvalidationDebugSample(
+            let sample = makePublicationInvalidationDebugSample(
+                servicePublicationSequence: servicePublicationSequence,
+                watcherAcceptedWatermark: watcherAcceptedWatermark,
+                recorder: recorder
+            )
+            var history = publicationInvalidationHistoryByRootID[rootID] ?? PublicationInvalidationHistoryState()
+            history.totalObservedPublicationCount += 1
+            history.samples.append(sample)
+            if history.samples.count > Self.publicationInvalidationSampleLimit {
+                history.samples.removeFirst(history.samples.count - Self.publicationInvalidationSampleLimit)
+            }
+            publicationInvalidationHistoryByRootID[rootID] = history
+        }
+
+        private func makePublicationInvalidationDebugSample(
+            servicePublicationSequence: UInt64,
+            watcherAcceptedWatermark: FileSystemWatcherIngressMailbox.Watermark?,
+            recorder: PublicationInvalidationRecorder
+        ) -> PublicationInvalidationDebugSample {
+            PublicationInvalidationDebugSample(
                 servicePublicationSequence: servicePublicationSequence,
                 watcherAcceptedWatermark: watcherAcceptedWatermark?.rawValue,
                 preparedDeltaCount: recorder.preparedDeltaCount,
@@ -459,13 +478,6 @@ actor WorkspaceFileContextStore {
                 codemapInvalidationRequestCount: recorder.codemapInvalidationRequestCount,
                 appliedIndexEventYieldCount: recorder.appliedIndexEventYieldCount
             )
-            var history = publicationInvalidationHistoryByRootID[rootID] ?? PublicationInvalidationHistoryState()
-            history.totalObservedPublicationCount += 1
-            history.samples.append(sample)
-            if history.samples.count > Self.publicationInvalidationSampleLimit {
-                history.samples.removeFirst(history.samples.count - Self.publicationInvalidationSampleLimit)
-            }
-            publicationInvalidationHistoryByRootID[rootID] = history
         }
 
         private static func elapsedMilliseconds(since start: UInt64, now: UInt64) -> UInt64 {
@@ -811,6 +823,23 @@ actor WorkspaceFileContextStore {
     }
 
     #if DEBUG
+        func replayFileSystemPublicationForInvalidationDiagnosticsForTesting(
+            rootID: UUID,
+            deltas: [FileSystemDelta]
+        ) async throws -> PublicationInvalidationDebugSample {
+            let root = try state(for: rootID).root
+            let preparedDeltas = prepareObservedFileSystemDeltas(deltas, root: root)
+            let recorder = await applyPreparedIndexDeltasRecordingInvalidations(
+                rootID: rootID,
+                deltas: preparedDeltas
+            )
+            return makePublicationInvalidationDebugSample(
+                servicePublicationSequence: 0,
+                watcherAcceptedWatermark: nil,
+                recorder: recorder
+            )
+        }
+
         func publishSyntheticFileSystemDeltasForTesting(rootID: UUID, deltas: [FileSystemDelta]) async throws {
             let state = try state(for: rootID)
             await state.service.publishFileSystemDeltas(deltas, source: .syntheticMutation)
@@ -877,8 +906,7 @@ actor WorkspaceFileContextStore {
                 delta: delta
             ))
         }
-        let preparedDeltas = FileSystemDeltaPreparation.coalesce(deltas, inRoot: root.standardizedFullPath)
-            .compactMap { FileSystemDeltaPreparation.prepare($0, inRoot: root.standardizedFullPath) }
+        let preparedDeltas = prepareObservedFileSystemDeltas(deltas, root: root)
         #if DEBUG
             await applyPreparedIndexDeltas(
                 rootID: root.id,
@@ -899,6 +927,14 @@ actor WorkspaceFileContextStore {
                 barrierSequence: servicePublicationSequence
             )
         )
+    }
+
+    private func prepareObservedFileSystemDeltas(
+        _ deltas: [FileSystemDelta],
+        root: WorkspaceRootRecord
+    ) -> [PreparedFileSystemDelta] {
+        FileSystemDeltaPreparation.coalesce(deltas, inRoot: root.standardizedFullPath)
+            .compactMap { FileSystemDeltaPreparation.prepare($0, inRoot: root.standardizedFullPath) }
     }
 
     private func isDiscoveryFacingFileSystemDelta(_ delta: FileSystemDelta, rootID: UUID) async -> Bool {
@@ -3478,16 +3514,24 @@ actor WorkspaceFileContextStore {
                 await applyPreparedIndexDeltasBody(rootID: rootID, deltas: deltas)
                 return
             }
-            let recorder = PublicationInvalidationRecorder(preparedDeltaCount: deltas.count)
-            await Self.$activePublicationInvalidationRecorder.withValue(recorder) {
-                await applyPreparedIndexDeltasBody(rootID: rootID, deltas: deltas)
-            }
+            let recorder = await applyPreparedIndexDeltasRecordingInvalidations(rootID: rootID, deltas: deltas)
             recordPublicationInvalidationDiagnostics(
                 rootID: rootID,
                 servicePublicationSequence: servicePublicationSequence,
                 watcherAcceptedWatermark: watcherAcceptedWatermark,
                 recorder: recorder
             )
+        }
+
+        private func applyPreparedIndexDeltasRecordingInvalidations(
+            rootID: UUID,
+            deltas: [PreparedFileSystemDelta]
+        ) async -> PublicationInvalidationRecorder {
+            let recorder = PublicationInvalidationRecorder(preparedDeltaCount: deltas.count)
+            await Self.$activePublicationInvalidationRecorder.withValue(recorder) {
+                await applyPreparedIndexDeltasBody(rootID: rootID, deltas: deltas)
+            }
+            return recorder
         }
     #else
         private func applyPreparedIndexDeltas(rootID: UUID, deltas: [PreparedFileSystemDelta]) async {

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
@@ -127,6 +127,12 @@ actor WorkspaceFileContextStore {
         let enableHierarchicalIgnores: Bool
     }
 
+    private final class PublicationInvalidationBatch {
+        var topologyInvalidationRequested = false
+        var affectedRootKinds = Set<WorkspaceRootKind>()
+        var searchContentInvalidations = WorkspaceSearchContentInvalidationBatch()
+    }
+
     private struct ScopedIngressBarrierTarget {
         let watcherAcceptedWatermark: FileSystemWatcherIngressMailbox.Watermark
         let acceptedServicePublicationSequence: UInt64
@@ -137,10 +143,71 @@ actor WorkspaceFileContextStore {
         }
     }
 
+    #if DEBUG
+        private struct ScopedIngressBarrierTaskOutput {
+            let sample: WorkspaceIngressBarrierSample
+            let completedAtNanoseconds: UInt64
+        }
+    #else
+        private typealias ScopedIngressBarrierTaskOutput = WorkspaceIngressBarrierSample
+    #endif
+
+    private final class ScopedIngressBarrierJoin: @unchecked Sendable {
+        private let lock = NSLock()
+        private var completedOutput: ScopedIngressBarrierTaskOutput?
+        private var waiters: [UUID: CheckedContinuation<ScopedIngressBarrierTaskOutput?, Never>] = [:]
+
+        func value() async -> ScopedIngressBarrierTaskOutput? {
+            let waiterID = UUID()
+            return await withTaskCancellationHandler {
+                await withCheckedContinuation { continuation in
+                    lock.lock()
+                    if Task.isCancelled {
+                        lock.unlock()
+                        continuation.resume(returning: nil)
+                    } else if let completedOutput {
+                        lock.unlock()
+                        continuation.resume(returning: completedOutput)
+                    } else {
+                        waiters[waiterID] = continuation
+                        lock.unlock()
+                    }
+                }
+            } onCancel: {
+                cancelWaiter(id: waiterID)
+            }
+        }
+
+        func complete(with output: ScopedIngressBarrierTaskOutput) {
+            let continuations: [CheckedContinuation<ScopedIngressBarrierTaskOutput?, Never>]
+            lock.lock()
+            guard completedOutput == nil else {
+                lock.unlock()
+                return
+            }
+            completedOutput = output
+            continuations = Array(waiters.values)
+            waiters.removeAll(keepingCapacity: false)
+            lock.unlock()
+            continuations.forEach { $0.resume(returning: output) }
+        }
+
+        private func cancelWaiter(id waiterID: UUID) {
+            let continuation: CheckedContinuation<ScopedIngressBarrierTaskOutput?, Never>?
+            lock.lock()
+            continuation = waiters.removeValue(forKey: waiterID)
+            lock.unlock()
+            continuation?.resume(returning: nil)
+        }
+    }
+
     private struct ScopedIngressBarrierFlight {
         let token: UInt64
         let target: ScopedIngressBarrierTarget
-        let task: Task<WorkspaceIngressBarrierSample, Never>
+        let join: ScopedIngressBarrierJoin
+        #if DEBUG
+            let startedAtNanoseconds: UInt64
+        #endif
     }
 
     #if DEBUG
@@ -149,6 +216,87 @@ actor WorkspaceFileContextStore {
             let joinCount: Int
             let successorCount: Int
         }
+
+        struct ScopedIngressBarrierDebugSnapshot: Equatable {
+            struct Active: Equatable {
+                let targetWatcherWatermark: UInt64
+                let targetServicePublicationSequence: UInt64
+                let ageMilliseconds: UInt64
+            }
+
+            struct Completed: Equatable {
+                let token: UInt64
+                let targetWatcherWatermark: UInt64
+                let targetServicePublicationSequence: UInt64
+                let publishedServicePublicationSequence: UInt64
+                let appliedServicePublicationSequence: UInt64
+                let appliedWatcherWatermark: UInt64
+                let durationMilliseconds: UInt64
+            }
+
+            let launchCount: Int
+            let joinCount: Int
+            let successorCount: Int
+            let completionCount: Int
+            let active: Active?
+            let lastCompleted: Completed?
+        }
+
+        struct PublicationInvalidationDebugSample: Equatable {
+            let servicePublicationSequence: UInt64
+            let watcherAcceptedWatermark: UInt64?
+            let preparedDeltaCount: Int
+            let topologyInvalidationCount: Int
+            let catalogGenerationAdvanceCount: Int
+            let searchCatalogCacheClearCount: Int
+            let pathWorkerInvalidationRequestCount: Int
+            let contentInvalidationCount: Int
+            let distinctContentKeyCount: Int
+            let decodedCacheInvalidationRequestCount: Int
+            let codemapInvalidationRequestCount: Int
+            let appliedIndexEventYieldCount: Int
+        }
+
+        struct PublicationInvalidationHistoryDebugSnapshot: Equatable {
+            let retainedSampleLimit: Int
+            let totalObservedPublicationCount: Int
+            let droppedPublicationSampleCount: Int
+            let samples: [PublicationInvalidationDebugSample]
+        }
+
+        struct ReadSearchRootDiagnosticsSnapshot: Equatable {
+            let rootID: UUID
+            let rootToken: UUID
+            let ingress: WorkspaceFileSystemIngressCoordinator.DebugSnapshot
+            let barrier: ScopedIngressBarrierDebugSnapshot
+            let invalidation: PublicationInvalidationHistoryDebugSnapshot
+            let producedAppliedIndexGeneration: UInt64
+        }
+
+        private final class PublicationInvalidationRecorder: @unchecked Sendable {
+            let preparedDeltaCount: Int
+            var topologyInvalidationCount = 0
+            var catalogGenerationAdvanceCount = 0
+            var searchCatalogCacheClearCount = 0
+            var pathWorkerInvalidationRequestCount = 0
+            var contentInvalidationCount = 0
+            var decodedCacheInvalidationRequestCount = 0
+            var codemapInvalidationRequestCount = 0
+            var appliedIndexEventYieldCount = 0
+            var distinctContentKeys = Set<WorkspaceSearchContentCacheKey>()
+
+            init(preparedDeltaCount: Int) {
+                self.preparedDeltaCount = preparedDeltaCount
+            }
+        }
+
+        private struct PublicationInvalidationHistoryState {
+            var totalObservedPublicationCount = 0
+            var samples: [PublicationInvalidationDebugSample] = []
+        }
+
+        @TaskLocal private static var activePublicationInvalidationRecorder: PublicationInvalidationRecorder?
+        private static let publicationInvalidationSampleLimit = 32
     #endif
 
     #if DEBUG
@@ -164,6 +312,9 @@ actor WorkspaceFileContextStore {
         private var scopedIngressBarrierLaunchCountsByRootID: [UUID: Int] = [:]
         private var scopedIngressBarrierJoinCountsByRootID: [UUID: Int] = [:]
         private var scopedIngressBarrierSuccessorCountsByRootID: [UUID: Int] = [:]
+        private var scopedIngressBarrierCompletionCountsByRootID: [UUID: Int] = [:]
+        private var lastCompletedScopedIngressBarrierByRootID: [UUID: ScopedIngressBarrierDebugSnapshot.Completed] = [:]
+        private var publicationInvalidationHistoryByRootID: [UUID: PublicationInvalidationHistoryState] = [:]
 
         func setRootLoadWillStartHandler(_ handler: (@Sendable (String) async -> Void)?) {
             rootLoadWillStartHandler = handler
@@ -207,6 +358,119 @@ actor WorkspaceFileContextStore {
                 joinCount: scopedIngressBarrierJoinCountsByRootID[rootID] ?? 0,
                 successorCount: scopedIngressBarrierSuccessorCountsByRootID[rootID] ?? 0
             )
+        }
+
+        func readSearchRootDiagnosticsSnapshot(
+            recentPublicationLimit: Int = 8
+        ) -> [ReadSearchRootDiagnosticsSnapshot] {
+            let requestedLimit = min(max(0, recentPublicationLimit), Self.publicationInvalidationSampleLimit)
+            return rootLoadOrder.compactMap { rootID in
+                guard let state = rootStatesByID[rootID] else { return nil }
+                let history = publicationInvalidationHistoryByRootID[rootID] ?? PublicationInvalidationHistoryState()
+                return ReadSearchRootDiagnosticsSnapshot(
+                    rootID: rootID,
+                    rootToken: state.service.diagnosticRootToken,
+                    ingress: publisherIngressCoordinator.debugSnapshot(rootID: rootID),
+                    barrier: scopedIngressBarrierDebugSnapshot(rootID: rootID),
+                    invalidation: PublicationInvalidationHistoryDebugSnapshot(
+                        retainedSampleLimit: Self.publicationInvalidationSampleLimit,
+                        totalObservedPublicationCount: history.totalObservedPublicationCount,
+                        droppedPublicationSampleCount: max(0, history.totalObservedPublicationCount - history.samples.count),
+                        samples: requestedLimit == 0 ? [] : Array(history.samples.suffix(requestedLimit))
+                    ),
+                    producedAppliedIndexGeneration: appliedIndexGenerationsByRootID[rootID] ?? 0
+                )
+            }
+        }
+
+        private func scopedIngressBarrierDebugSnapshot(rootID: UUID) -> ScopedIngressBarrierDebugSnapshot {
+            let active = scopedIngressBarrierFlightsByRootID[rootID].map { flight in
+                ScopedIngressBarrierDebugSnapshot.Active(
+                    targetWatcherWatermark: flight.target.watcherAcceptedWatermark.rawValue,
+                    targetServicePublicationSequence: flight.target.acceptedServicePublicationSequence,
+                    ageMilliseconds: Self.elapsedMilliseconds(
+                        since: flight.startedAtNanoseconds,
+                        now: debugNowNanoseconds()
+                    )
+                )
+            }
+            return ScopedIngressBarrierDebugSnapshot(
+                launchCount: scopedIngressBarrierLaunchCountsByRootID[rootID] ?? 0,
+                joinCount: scopedIngressBarrierJoinCountsByRootID[rootID] ?? 0,
+                successorCount: scopedIngressBarrierSuccessorCountsByRootID[rootID] ?? 0,
+                completionCount: scopedIngressBarrierCompletionCountsByRootID[rootID] ?? 0,
+                active: active,
+                lastCompleted: lastCompletedScopedIngressBarrierByRootID[rootID]
+            )
+        }
+
+        func retainedReadSearchDiagnosticRootIDsForTesting() -> Set<UUID> {
+            Set(scopedIngressBarrierLaunchCountsByRootID.keys)
+                .union(scopedIngressBarrierJoinCountsByRootID.keys)
+                .union(scopedIngressBarrierSuccessorCountsByRootID.keys)
+                .union(scopedIngressBarrierCompletionCountsByRootID.keys)
+                .union(lastCompletedScopedIngressBarrierByRootID.keys)
+                .union(publicationInvalidationHistoryByRootID.keys)
+        }
+
+        private func recordScopedIngressBarrierCompletion(
+            rootID: UUID,
+            token: UInt64,
+            target: ScopedIngressBarrierTarget,
+            sample: WorkspaceIngressBarrierSample,
+            startedAtNanoseconds: UInt64,
+            completedAtNanoseconds: UInt64
+        ) {
+            guard rootStatesByID[rootID] != nil else { return }
+            scopedIngressBarrierCompletionCountsByRootID[rootID, default: 0] += 1
+            guard token > (lastCompletedScopedIngressBarrierByRootID[rootID]?.token ?? 0) else { return }
+            lastCompletedScopedIngressBarrierByRootID[rootID] = ScopedIngressBarrierDebugSnapshot.Completed(
+                token: token,
+                targetWatcherWatermark: target.watcherAcceptedWatermark.rawValue,
+                targetServicePublicationSequence: target.acceptedServicePublicationSequence,
+                publishedServicePublicationSequence: sample.publishedServicePublicationSequence,
+                appliedServicePublicationSequence: sample.appliedServicePublicationSequence,
+                appliedWatcherWatermark: sample.appliedWatcherWatermark,
+                durationMilliseconds: Self.elapsedMilliseconds(
+                    since: startedAtNanoseconds,
+                    now: completedAtNanoseconds
+                )
+            )
+        }
+
+        private func recordPublicationInvalidationDiagnostics(
+            rootID: UUID,
+            servicePublicationSequence: UInt64,
+            watcherAcceptedWatermark: FileSystemWatcherIngressMailbox.Watermark?,
+            recorder: PublicationInvalidationRecorder
+        ) {
+            guard rootStatesByID[rootID] != nil else { return }
+            let sample = PublicationInvalidationDebugSample(
+                servicePublicationSequence: servicePublicationSequence,
+                watcherAcceptedWatermark: watcherAcceptedWatermark?.rawValue,
+                preparedDeltaCount: recorder.preparedDeltaCount,
+                topologyInvalidationCount: recorder.topologyInvalidationCount,
+                catalogGenerationAdvanceCount: recorder.catalogGenerationAdvanceCount,
+                searchCatalogCacheClearCount: recorder.searchCatalogCacheClearCount,
+                pathWorkerInvalidationRequestCount: recorder.pathWorkerInvalidationRequestCount,
+                contentInvalidationCount: recorder.contentInvalidationCount,
+                distinctContentKeyCount: recorder.distinctContentKeys.count,
+                decodedCacheInvalidationRequestCount: recorder.decodedCacheInvalidationRequestCount,
+                codemapInvalidationRequestCount: recorder.codemapInvalidationRequestCount,
+                appliedIndexEventYieldCount: recorder.appliedIndexEventYieldCount
+            )
+            var history = publicationInvalidationHistoryByRootID[rootID] ?? PublicationInvalidationHistoryState()
+            history.totalObservedPublicationCount += 1
+            history.samples.append(sample)
+            if history.samples.count > Self.publicationInvalidationSampleLimit {
+                history.samples.removeFirst(history.samples.count - Self.publicationInvalidationSampleLimit)
+            }
+            publicationInvalidationHistoryByRootID[rootID] = history
+        }
+
+        private static func elapsedMilliseconds(since start: UInt64, now: UInt64) -> UInt64 {
+            guard now >= start else { return 0 }
+            return (now - start) / 1_000_000
         }
 
         func searchDecodedContentCacheSnapshotForTesting() async -> WorkspaceSearchDecodedContentCache.Snapshot {
@@ -286,6 +550,7 @@ actor WorkspaceFileContextStore {
     #endif
     private var searchContentInvalidationEpochsByFileID: [UUID: UInt64] = [:]
     private var nextSearchContentInvalidationEpoch: UInt64 = 0
+    private var activePublicationInvalidationBatch: PublicationInvalidationBatch?
     private static let maxCachedSearchCatalogSnapshotScopes = 16
     private static let defaultMaxPendingDeltasPerRoot = 10000
     private let pathMatchWorker = PathMatchWorker()
@@ -301,26 +566,52 @@ actor WorkspaceFileContextStore {
     private var appliedIndexContinuations: [UUID: AsyncStream<WorkspaceAppliedIndexBatchEvent>.Continuation] = [:]
     private var appliedIndexGenerationsByRootID: [UUID: UInt64] = [:]
     private var watcherCancellablesByRootID: [UUID: AnyCancellable] = [:]
-    private let publisherIngressCoordinator = WorkspaceFileSystemIngressCoordinator()
+    private let publisherIngressCoordinator: WorkspaceFileSystemIngressCoordinator
     private var scopedIngressBarrierFlightsByRootID: [UUID: ScopedIngressBarrierFlight] = [:]
     private var nextScopedIngressBarrierToken: UInt64 = 0
     private static let maxConcurrentScopedIngressBarriers = 8
     private var codeScanResultTask: Task<Void, Never>?
+    #if DEBUG
+        private let debugNowNanoseconds: @Sendable () -> UInt64
+    #endif
 
-    init(searchLaneConfiguration: StoreBackedWorkspaceSearchLane.Configuration = .production) {
-        storeBackedSearchLane = StoreBackedWorkspaceSearchLane(configuration: searchLaneConfiguration)
-        #if os(macOS)
-            let source = DispatchSource.makeMemoryPressureSource(
-                eventMask: [.warning, .critical],
-                queue: .global(qos: .utility)
-            )
-            searchContentMemoryPressureSource = source
-            source.setEventHandler { [weak self] in
-                Task { await self?.clearSearchDecodedContentCache() }
-            }
-            source.activate()
-        #endif
-    }
+    #if DEBUG
+        init(
+            searchLaneConfiguration: StoreBackedWorkspaceSearchLane.Configuration = .production,
+            debugNowNanoseconds: @escaping @Sendable () -> UInt64 = { DispatchTime.now().uptimeNanoseconds }
+        ) {
+            storeBackedSearchLane = StoreBackedWorkspaceSearchLane(configuration: searchLaneConfiguration)
+            self.debugNowNanoseconds = debugNowNanoseconds
+            publisherIngressCoordinator = WorkspaceFileSystemIngressCoordinator(debugNowNanoseconds: debugNowNanoseconds)
+            #if os(macOS)
+                let source = DispatchSource.makeMemoryPressureSource(
+                    eventMask: [.warning, .critical],
+                    queue: .global(qos: .utility)
+                )
+                searchContentMemoryPressureSource = source
+                source.setEventHandler { [weak self] in
+                    Task { await self?.clearSearchDecodedContentCache() }
+                }
+                source.activate()
+            #endif
+        }
+    #else
+        init(searchLaneConfiguration: StoreBackedWorkspaceSearchLane.Configuration = .production) {
+            storeBackedSearchLane = StoreBackedWorkspaceSearchLane(configuration: searchLaneConfiguration)
+            publisherIngressCoordinator = WorkspaceFileSystemIngressCoordinator()
+            #if os(macOS)
+                let source = DispatchSource.makeMemoryPressureSource(
+                    eventMask: [.warning, .critical],
+                    queue: .global(qos: .utility)
+                )
+                searchContentMemoryPressureSource = source
+                source.setEventHandler { [weak self] in
+                    Task { await self?.clearSearchDecodedContentCache() }
+                }
+                source.activate()
+            #endif
+        }
+    #endif
 
     deinit {
         #if os(macOS)
@@ -500,6 +791,9 @@ actor WorkspaceFileContextStore {
     }
 
     private func yieldAppliedIndexEvent(_ event: WorkspaceAppliedIndexBatchEvent) {
+        #if DEBUG
+            Self.activePublicationInvalidationRecorder?.appliedIndexEventYieldCount += 1
+        #endif
         for continuation in appliedIndexContinuations.values {
             continuation.yield(event)
         }
@@ -585,7 +879,16 @@ actor WorkspaceFileContextStore {
         }
         let preparedDeltas = FileSystemDeltaPreparation.coalesce(deltas, inRoot: root.standardizedFullPath)
             .compactMap { FileSystemDeltaPreparation.prepare($0, inRoot: root.standardizedFullPath) }
-        await applyPreparedIndexDeltas(rootID: root.id, deltas: preparedDeltas)
+        #if DEBUG
+            await applyPreparedIndexDeltas(
+                rootID: root.id,
+                deltas: preparedDeltas,
+                watcherAcceptedWatermark: watcherAcceptedWatermark,
+                servicePublicationSequence: servicePublicationSequence
+            )
+        #else
+            await applyPreparedIndexDeltas(rootID: root.id, deltas: preparedDeltas)
+        #endif
         EditFlowPerf.lifecycleEvent(
             EditFlowPerf.Lifecycle.WorkspaceIngress.storeCanonicalApplyCompleted,
             correlation: publicationCorrelation,
@@ -628,6 +931,16 @@ actor WorkspaceFileContextStore {
             .filter(isDiscoverableFolderID)
             .compactMap { foldersByID[$0] }
             .sorted { $0.standardizedRelativePath < $1.standardizedRelativePath }
+    }
+
+    func appliedIndexRootSnapshot(rootID: UUID) -> WorkspaceAppliedIndexRootSnapshot? {
+        guard let root = rootStatesByID[rootID]?.root else { return nil }
+        return WorkspaceAppliedIndexRootSnapshot(
+            root: root,
+            generation: appliedIndexGenerationsByRootID[rootID] ?? 0,
+            files: files(inRoot: rootID),
+            folders: folders(inRoot: rootID)
+        )
     }
 
     func catalogGeneration(rootScope: WorkspaceLookupRootScope = .visibleWorkspace) -> UInt64 {
@@ -888,13 +1201,16 @@ actor WorkspaceFileContextStore {
 
         var samplesByIndex: [Int: WorkspaceIngressBarrierSample] = [:]
         for chunkStart in stride(from: 0, to: orderedRootIDs.count, by: Self.maxConcurrentScopedIngressBarriers) {
+            guard !Task.isCancelled else { break }
             let chunkEnd = min(chunkStart + Self.maxConcurrentScopedIngressBarriers, orderedRootIDs.count)
             await withTaskGroup(of: (Int, WorkspaceIngressBarrierSample?).self) { group in
                 for index in chunkStart ..< chunkEnd {
                     let rootID = orderedRootIDs[index]
                     guard let target = targetsByRootID[rootID] else { continue }
                     group.addTask { [weak self] in
-                        await (index, self?.awaitAppliedIngress(rootID: rootID, target: target))
+                        guard !Task.isCancelled, let self else { return (index, nil) }
+                        let sample = await awaitAppliedIngress(rootID: rootID, target: target)
+                        return (index, sample)
                     }
                 }
                 for await (index, sample) in group {
@@ -909,12 +1225,13 @@ actor WorkspaceFileContextStore {
         rootID: UUID,
         target: ScopedIngressBarrierTarget
     ) async -> WorkspaceIngressBarrierSample? {
-        guard let state = rootStatesByID[rootID] else { return nil }
+        guard !Task.isCancelled, let state = rootStatesByID[rootID] else { return nil }
         if let flight = scopedIngressBarrierFlightsByRootID[rootID], flight.target.covers(target) {
             #if DEBUG
                 scopedIngressBarrierJoinCountsByRootID[rootID, default: 0] += 1
             #endif
-            return await flight.task.value
+            guard let output = await flight.join.value() else { return nil }
+            return scopedIngressBarrierSample(from: output)
         }
 
         let isSuccessor = scopedIngressBarrierFlightsByRootID[rootID] != nil
@@ -928,8 +1245,12 @@ actor WorkspaceFileContextStore {
             if isSuccessor {
                 scopedIngressBarrierSuccessorCountsByRootID[rootID, default: 0] += 1
             }
+            let barrierCompletionNowNanoseconds = debugNowNanoseconds
+            let barrierStartedAtNanoseconds = barrierCompletionNowNanoseconds()
             let scopedIngressBarrierWillFlushHandler = scopedIngressBarrierWillFlushHandler
             let publisherIngressWillWaitHandler = publisherIngressWillWaitHandler
+        #else
+            let barrierStartedAtNanoseconds: UInt64 = 0
         #endif
         #if DEBUG || EDIT_FLOW_PERF
             let lifecycleCorrelation = EditFlowPerf.currentLifecycleCorrelation
@@ -985,7 +1306,7 @@ actor WorkspaceFileContextStore {
                     barrierSequence: applied.appliedServicePublicationSequence
                 )
             )
-            return WorkspaceIngressBarrierSample(
+            let sample = WorkspaceIngressBarrierSample(
                 rootID: rootID,
                 rootPath: root.standardizedFullPath,
                 pendingRawEventCountBeforeFlush: pendingCount,
@@ -994,17 +1315,81 @@ actor WorkspaceFileContextStore {
                 appliedServicePublicationSequence: applied.appliedServicePublicationSequence,
                 appliedWatcherWatermark: applied.appliedWatcherWatermark.rawValue
             )
+            #if DEBUG
+                return ScopedIngressBarrierTaskOutput(
+                    sample: sample,
+                    completedAtNanoseconds: barrierCompletionNowNanoseconds()
+                )
+            #else
+                return sample
+            #endif
         }
-        scopedIngressBarrierFlightsByRootID[rootID] = ScopedIngressBarrierFlight(
-            token: token,
-            target: target,
-            task: task
-        )
-        let sample = await task.value
+        let join = ScopedIngressBarrierJoin()
+        #if DEBUG
+            scopedIngressBarrierFlightsByRootID[rootID] = ScopedIngressBarrierFlight(
+                token: token,
+                target: target,
+                join: join,
+                startedAtNanoseconds: barrierStartedAtNanoseconds
+            )
+        #else
+            scopedIngressBarrierFlightsByRootID[rootID] = ScopedIngressBarrierFlight(
+                token: token,
+                target: target,
+                join: join
+            )
+        #endif
+        Task { [weak self, join] in
+            let output = await task.value
+            guard let self else {
+                join.complete(with: output)
+                return
+            }
+            await finishScopedIngressBarrier(
+                rootID: rootID,
+                token: token,
+                target: target,
+                output: output,
+                startedAtNanoseconds: barrierStartedAtNanoseconds,
+                join: join
+            )
+        }
+        guard let output = await join.value() else { return nil }
+        return scopedIngressBarrierSample(from: output)
+    }
+
+    private func finishScopedIngressBarrier(
+        rootID: UUID,
+        token: UInt64,
+        target: ScopedIngressBarrierTarget,
+        output: ScopedIngressBarrierTaskOutput,
+        startedAtNanoseconds: UInt64,
+        join: ScopedIngressBarrierJoin
+    ) {
+        #if DEBUG
+            recordScopedIngressBarrierCompletion(
+                rootID: rootID,
+                token: token,
+                target: target,
+                sample: output.sample,
+                startedAtNanoseconds: startedAtNanoseconds,
+                completedAtNanoseconds: output.completedAtNanoseconds
+            )
+        #endif
         if scopedIngressBarrierFlightsByRootID[rootID]?.token == token {
             scopedIngressBarrierFlightsByRootID.removeValue(forKey: rootID)
         }
-        return sample
+        join.complete(with: output)
+    }
+
+    private func scopedIngressBarrierSample(
+        from output: ScopedIngressBarrierTaskOutput
+    ) -> WorkspaceIngressBarrierSample {
+        #if DEBUG
+            output.sample
+        #else
+            output
+        #endif
     }
 
     /// Compatibility wrapper for callers that still consume the original diagnostic shape.
@@ -1256,7 +1641,7 @@ actor WorkspaceFileContextStore {
 
         let deltas: [FileSystemDelta]
         do {
-            deltas = try await state.service.scanFoldersInParallel(folderPaths)
+            deltas = try await state.service.scanFoldersInParallel(folderPaths).deltas
         } catch {
             return []
         }
@@ -2027,6 +2412,14 @@ actor WorkspaceFileContextStore {
                 isRootUnload: true
             ))
             appliedIndexGenerationsByRootID.removeValue(forKey: rootID)
+            #if DEBUG
+                publicationInvalidationHistoryByRootID.removeValue(forKey: rootID)
+                scopedIngressBarrierLaunchCountsByRootID.removeValue(forKey: rootID)
+                scopedIngressBarrierJoinCountsByRootID.removeValue(forKey: rootID)
+                scopedIngressBarrierSuccessorCountsByRootID.removeValue(forKey: rootID)
+                scopedIngressBarrierCompletionCountsByRootID.removeValue(forKey: rootID)
+                lastCompletedScopedIngressBarrierByRootID.removeValue(forKey: rootID)
+            #endif
         }
 
         let unloadedRootKinds = Set(statesToUnload.map(\.state.root.kind))
@@ -3019,6 +3412,17 @@ actor WorkspaceFileContextStore {
         return true
     }
 
+    private func directoryAppearsPresentOnDisk(root: WorkspaceRootRecord, relativePath: String) -> Bool {
+        let fullPath = StandardizedPath.join(standardizedRoot: root.standardizedFullPath, standardizedRelativePath: StandardizedPath.relative(relativePath))
+        var isDirectory = ObjCBool(false)
+        guard FileManager.default.fileExists(atPath: fullPath, isDirectory: &isDirectory), isDirectory.boolValue else { return false }
+        if let values = try? URL(fileURLWithPath: fullPath).resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey]) {
+            if values.isSymbolicLink == true { return false }
+            if values.isDirectory == false { return false }
+        }
+        return true
+    }
+
     @discardableResult
     private func pruneCatalogFileMissingOnDisk(
         rootID: UUID,
@@ -3063,8 +3467,71 @@ actor WorkspaceFileContextStore {
         return true
     }
 
-    private func applyPreparedIndexDeltas(rootID: UUID, deltas: [PreparedFileSystemDelta]) async {
+    #if DEBUG
+        private func applyPreparedIndexDeltas(
+            rootID: UUID,
+            deltas: [PreparedFileSystemDelta],
+            watcherAcceptedWatermark: FileSystemWatcherIngressMailbox.Watermark?,
+            servicePublicationSequence: UInt64?
+        ) async {
+            guard let servicePublicationSequence else {
+                await applyPreparedIndexDeltasBody(rootID: rootID, deltas: deltas)
+                return
+            }
+            let recorder = PublicationInvalidationRecorder(preparedDeltaCount: deltas.count)
+            await Self.$activePublicationInvalidationRecorder.withValue(recorder) {
+                await applyPreparedIndexDeltasBody(rootID: rootID, deltas: deltas)
+            }
+            recordPublicationInvalidationDiagnostics(
+                rootID: rootID,
+                servicePublicationSequence: servicePublicationSequence,
+                watcherAcceptedWatermark: watcherAcceptedWatermark,
+                recorder: recorder
+            )
+        }
+    #else
+        private func applyPreparedIndexDeltas(rootID: UUID, deltas: [PreparedFileSystemDelta]) async {
+            await applyPreparedIndexDeltasBody(rootID: rootID, deltas: deltas)
+        }
+    #endif
+
+    private func applyPreparedIndexDeltasBody(rootID: UUID, deltas: [PreparedFileSystemDelta]) async {
+        let applicableDeltas = await preflightPreparedIndexDeltas(rootID: rootID, deltas: deltas)
+        applyPreparedIndexDeltaMutations(rootID: rootID, deltas: applicableDeltas)
+    }
+
+    private func preflightPreparedIndexDeltas(
+        rootID: UUID,
+        deltas: [PreparedFileSystemDelta]
+    ) async -> [PreparedFileSystemDelta] {
+        var applicableDeltas: [PreparedFileSystemDelta] = []
+        applicableDeltas.reserveCapacity(deltas.count)
+        for prepared in deltas {
+            switch prepared.delta {
+            case .fileAdded:
+                guard let service = rootStatesByID[rootID]?.service,
+                      await service.catalogEligibleRegularFileExists(relativePath: prepared.relativePath)
+                else { continue }
+                applicableDeltas.append(prepared)
+            case .folderAdded:
+                guard let service = rootStatesByID[rootID]?.service,
+                      await service.catalogFolderIsDiscoverable(relativePath: prepared.relativePath)
+                else { continue }
+                applicableDeltas.append(prepared)
+            case .fileRemoved, .folderRemoved, .fileModified, .folderModified:
+                applicableDeltas.append(prepared)
+            }
+        }
+        return applicableDeltas
+    }
+
+    private func applyPreparedIndexDeltaMutations(rootID: UUID, deltas: [PreparedFileSystemDelta]) {
         guard let root = rootStatesByID[rootID]?.root else { return }
+        precondition(activePublicationInvalidationBatch == nil)
+        let invalidationBatch = PublicationInvalidationBatch()
+        activePublicationInvalidationBatch = invalidationBatch
+        defer { activePublicationInvalidationBatch = nil }
+
         var upsertedFiles: [WorkspaceFileRecord] = []
         var upsertedFolders: [WorkspaceFolderRecord] = []
         var removedFileIDs: [UUID] = []
@@ -3077,10 +3544,7 @@ actor WorkspaceFileContextStore {
             let relativePath = prepared.relativePath
             switch prepared.delta {
             case .fileAdded:
-                guard let state = rootStatesByID[rootID],
-                      await state.service.catalogEligibleRegularFileExists(relativePath: relativePath),
-                      regularFileAppearsPresentOnDisk(root: root, relativePath: relativePath)
-                else { continue }
+                guard regularFileAppearsPresentOnDisk(root: root, relativePath: relativePath) else { continue }
                 let existingFile = file(rootID: rootID, relativePath: relativePath)
                 let existed = existingFile != nil
                 if let existingFile {
@@ -3099,9 +3563,7 @@ actor WorkspaceFileContextStore {
                     upsertedFolders.append(contentsOf: discoverableParentFolders(for: relativePath, rootID: rootID))
                 }
             case .folderAdded:
-                guard let state = rootStatesByID[rootID],
-                      await state.service.catalogFolderIsDiscoverable(relativePath: relativePath)
-                else { continue }
+                guard directoryAppearsPresentOnDisk(root: root, relativePath: relativePath) else { continue }
                 indexFolder(relativePath: relativePath, root: root)
                 if let folder = folder(rootID: rootID, relativePath: relativePath) {
                     // Same upsert semantics as files: repeated folder add deltas are
@@ -3138,6 +3600,8 @@ actor WorkspaceFileContextStore {
                 }
             }
         }
+
+        finalizePublicationInvalidations(invalidationBatch)
         publishAppliedIndexEvent(
             root: root,
             upsertedFiles: upsertedFiles,
@@ -3641,6 +4105,9 @@ actor WorkspaceFileContextStore {
         for scope in WorkspaceFileContextStore.catalogGenerationScopes {
             guard scopeIncludesAnyRootKind(scope, affectedRootKinds) else { continue }
             catalogGenerationsByScope[scope] = (catalogGenerationsByScope[scope] ?? 0) &+ 1
+            #if DEBUG
+                Self.activePublicationInvalidationRecorder?.catalogGenerationAdvanceCount += 1
+            #endif
         }
     }
 
@@ -3694,6 +4161,9 @@ actor WorkspaceFileContextStore {
     }
 
     private func clearSearchCatalogSnapshotCache() {
+        #if DEBUG
+            Self.activePublicationInvalidationRecorder?.searchCatalogCacheClearCount += 1
+        #endif
         searchCatalogSnapshotsByScope.removeAll(keepingCapacity: true)
     }
 
@@ -3728,26 +4198,65 @@ actor WorkspaceFileContextStore {
     }
 
     private func invalidateSearchContent(_ file: WorkspaceFileRecord) {
-        nextSearchContentInvalidationEpoch &+= 1
-        let invalidationEpoch = nextSearchContentInvalidationEpoch
-        searchContentInvalidationEpochsByFileID[file.id] = invalidationEpoch
         let key = WorkspaceSearchContentCacheKey(
             rootID: file.rootID,
             fileID: file.id,
             standardizedRelativePath: file.standardizedRelativePath
         )
+        #if DEBUG
+            if let recorder = Self.activePublicationInvalidationRecorder {
+                recorder.contentInvalidationCount += 1
+                recorder.distinctContentKeys.insert(key)
+            }
+        #endif
+        nextSearchContentInvalidationEpoch &+= 1
+        let invalidationEpoch = nextSearchContentInvalidationEpoch
+        searchContentInvalidationEpochsByFileID[file.id] = invalidationEpoch
+        if let activePublicationInvalidationBatch {
+            activePublicationInvalidationBatch.searchContentInvalidations.record(key, through: invalidationEpoch)
+            return
+        }
         Task {
             await searchDecodedContentCache.invalidate(key, through: invalidationEpoch)
         }
     }
 
+    private func finalizePublicationInvalidations(_ batch: PublicationInvalidationBatch) {
+        if batch.topologyInvalidationRequested {
+            performPathMatchSnapshotInvalidation(affectedRootKinds: batch.affectedRootKinds)
+        }
+        guard !batch.searchContentInvalidations.isEmpty else { return }
+        #if DEBUG
+            Self.activePublicationInvalidationRecorder?.decodedCacheInvalidationRequestCount += 1
+        #endif
+        let searchContentInvalidations = batch.searchContentInvalidations
+        Task {
+            await searchDecodedContentCache.invalidate(searchContentInvalidations)
+        }
+    }
+
     private func invalidatePathMatchSnapshot(affectedRootKinds: Set<WorkspaceRootKind>) {
+        if let activePublicationInvalidationBatch {
+            activePublicationInvalidationBatch.topologyInvalidationRequested = true
+            activePublicationInvalidationBatch.affectedRootKinds.formUnion(affectedRootKinds)
+            return
+        }
+        performPathMatchSnapshotInvalidation(affectedRootKinds: affectedRootKinds)
+    }
+
+    private func performPathMatchSnapshotInvalidation(affectedRootKinds: Set<WorkspaceRootKind>) {
+        #if DEBUG
+            Self.activePublicationInvalidationRecorder?.topologyInvalidationCount += 1
+        #endif
         bumpCatalogGenerations(affectedRootKinds: affectedRootKinds)
         clearSearchCatalogSnapshotCache()
         invalidatePathMatchCache()
     }
 
     private func invalidatePathMatchCache() {
+        #if DEBUG
+            Self.activePublicationInvalidationRecorder?.pathWorkerInvalidationRequestCount += 1
+        #endif
         Task { await pathMatchWorker.invalidateCache() }
     }
 
@@ -3874,6 +4383,9 @@ actor WorkspaceFileContextStore {
     }
 
     private func invalidateCodemapSnapshot(rootID: UUID, relativePath: String) {
+        #if DEBUG
+            Self.activePublicationInvalidationRecorder?.codemapInvalidationRequestCount += 1
+        #endif
         guard let state = rootStatesByID[rootID],
               let fileID = state.fileIDsByRelativePath[StandardizedPath.relative(relativePath)],
               codemapSnapshotsByFileID.removeValue(forKey: fileID) != nil

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
@@ -154,6 +154,7 @@ actor WorkspaceFileContextStore {
 
     private final class ScopedIngressBarrierJoin: @unchecked Sendable {
         private let lock = NSLock()
+        private var isCompleted = false
         private var completedOutput: ScopedIngressBarrierTaskOutput?
         private var waiters: [UUID: CheckedContinuation<ScopedIngressBarrierTaskOutput?, Never>] = [:]
 
@@ -165,9 +166,10 @@ actor WorkspaceFileContextStore {
                     if Task.isCancelled {
                         lock.unlock()
                         continuation.resume(returning: nil)
-                    } else if let completedOutput {
+                    } else if isCompleted {
+                        let output = completedOutput
                         lock.unlock()
-                        continuation.resume(returning: completedOutput)
+                        continuation.resume(returning: output)
                     } else {
                         waiters[waiterID] = continuation
                         lock.unlock()
@@ -178,13 +180,14 @@ actor WorkspaceFileContextStore {
             }
         }
 
-        func complete(with output: ScopedIngressBarrierTaskOutput) {
+        func complete(with output: ScopedIngressBarrierTaskOutput?) {
             let continuations: [CheckedContinuation<ScopedIngressBarrierTaskOutput?, Never>]
             lock.lock()
-            guard completedOutput == nil else {
+            guard !isCompleted else {
                 lock.unlock()
                 return
             }
+            isCompleted = true
             completedOutput = output
             continuations = Array(waiters.values)
             waiters.removeAll(keepingCapacity: false)
@@ -201,13 +204,28 @@ actor WorkspaceFileContextStore {
         }
     }
 
-    private struct ScopedIngressBarrierFlight {
+    private final class ScopedIngressBarrierFlight {
         let token: UInt64
         let target: ScopedIngressBarrierTarget
         let join: ScopedIngressBarrierJoin
+        var task: Task<Void, Never>?
         #if DEBUG
             let startedAtNanoseconds: UInt64
         #endif
+
+        init(
+            token: UInt64,
+            target: ScopedIngressBarrierTarget,
+            join: ScopedIngressBarrierJoin,
+            startedAtNanoseconds: UInt64 = 0
+        ) {
+            self.token = token
+            self.target = target
+            self.join = join
+            #if DEBUG
+                self.startedAtNanoseconds = startedAtNanoseconds
+            #endif
+        }
     }
 
     #if DEBUG
@@ -360,6 +378,14 @@ actor WorkspaceFileContextStore {
             )
         }
 
+        func scopedIngressBarrierFlightCountForTesting() -> Int {
+            scopedIngressBarrierFlightsByRootID.values.reduce(0) { $0 + $1.count }
+        }
+
+        func fileSystemServiceForTesting(rootID: UUID) -> FileSystemService? {
+            rootStatesByID[rootID]?.service
+        }
+
         func readSearchRootDiagnosticsSnapshot(
             recentPublicationLimit: Int = 8
         ) -> [ReadSearchRootDiagnosticsSnapshot] {
@@ -384,7 +410,7 @@ actor WorkspaceFileContextStore {
         }
 
         private func scopedIngressBarrierDebugSnapshot(rootID: UUID) -> ScopedIngressBarrierDebugSnapshot {
-            let active = scopedIngressBarrierFlightsByRootID[rootID].map { flight in
+            let active = scopedIngressBarrierFlightsByRootID[rootID]?.last.map { flight in
                 ScopedIngressBarrierDebugSnapshot.Active(
                     targetWatcherWatermark: flight.target.watcherAcceptedWatermark.rawValue,
                     targetServicePublicationSequence: flight.target.acceptedServicePublicationSequence,
@@ -579,7 +605,7 @@ actor WorkspaceFileContextStore {
     private var appliedIndexGenerationsByRootID: [UUID: UInt64] = [:]
     private var watcherCancellablesByRootID: [UUID: AnyCancellable] = [:]
     private let publisherIngressCoordinator: WorkspaceFileSystemIngressCoordinator
-    private var scopedIngressBarrierFlightsByRootID: [UUID: ScopedIngressBarrierFlight] = [:]
+    private var scopedIngressBarrierFlightsByRootID: [UUID: [ScopedIngressBarrierFlight]] = [:]
     private var nextScopedIngressBarrierToken: UInt64 = 0
     private static let maxConcurrentScopedIngressBarriers = 8
     private var codeScanResultTask: Task<Void, Never>?
@@ -1262,7 +1288,7 @@ actor WorkspaceFileContextStore {
         target: ScopedIngressBarrierTarget
     ) async -> WorkspaceIngressBarrierSample? {
         guard !Task.isCancelled, let state = rootStatesByID[rootID] else { return nil }
-        if let flight = scopedIngressBarrierFlightsByRootID[rootID], flight.target.covers(target) {
+        if let flight = scopedIngressBarrierFlightsByRootID[rootID]?.first(where: { $0.target.covers(target) }) {
             #if DEBUG
                 scopedIngressBarrierJoinCountsByRootID[rootID, default: 0] += 1
             #endif
@@ -1270,7 +1296,7 @@ actor WorkspaceFileContextStore {
             return scopedIngressBarrierSample(from: output)
         }
 
-        let isSuccessor = scopedIngressBarrierFlightsByRootID[rootID] != nil
+        let isSuccessor = scopedIngressBarrierFlightsByRootID[rootID]?.isEmpty == false
         nextScopedIngressBarrierToken &+= 1
         let token = nextScopedIngressBarrierToken
         let publisherIngressCoordinator = publisherIngressCoordinator
@@ -1293,11 +1319,36 @@ actor WorkspaceFileContextStore {
         #else
             let lifecycleCorrelation: EditFlowPerf.LifecycleCorrelation? = nil
         #endif
-        let task = Task {
+        let join = ScopedIngressBarrierJoin()
+        let flight = ScopedIngressBarrierFlight(
+            token: token,
+            target: target,
+            join: join,
+            startedAtNanoseconds: barrierStartedAtNanoseconds
+        )
+        scopedIngressBarrierFlightsByRootID[rootID, default: []].append(flight)
+        flight.task = Task { [weak self] in
             #if DEBUG
                 if let scopedIngressBarrierWillFlushHandler {
                     await scopedIngressBarrierWillFlushHandler(rootID)
                 }
+            #endif
+            guard !Task.isCancelled else {
+                if let self {
+                    await finishScopedIngressBarrier(
+                        rootID: rootID,
+                        token: token,
+                        target: target,
+                        output: nil,
+                        startedAtNanoseconds: barrierStartedAtNanoseconds,
+                        join: join
+                    )
+                } else {
+                    join.complete(with: nil)
+                }
+                return
+            }
+            #if DEBUG
                 let pendingCount = await service.pendingRawEventCountForDiagnostics()
             #else
                 let pendingCount = 0
@@ -1318,19 +1369,79 @@ actor WorkspaceFileContextStore {
                     await publisherIngressWillWaitHandler([rootID])
                 }
             #endif
+            guard !Task.isCancelled else {
+                if let self {
+                    await finishScopedIngressBarrier(
+                        rootID: rootID,
+                        token: token,
+                        target: target,
+                        output: nil,
+                        startedAtNanoseconds: barrierStartedAtNanoseconds,
+                        join: join
+                    )
+                } else {
+                    join.complete(with: nil)
+                }
+                return
+            }
             await publisherIngressCoordinator.waitUntilApplied(
                 rootID: rootID,
                 servicePublicationSequence: target.acceptedServicePublicationSequence
             )
+            guard !Task.isCancelled else {
+                if let self {
+                    await finishScopedIngressBarrier(
+                        rootID: rootID,
+                        token: token,
+                        target: target,
+                        output: nil,
+                        startedAtNanoseconds: barrierStartedAtNanoseconds,
+                        join: join
+                    )
+                } else {
+                    join.complete(with: nil)
+                }
+                return
+            }
             let publishedSequence = await service.flushPendingEventsNow(
                 throughAcceptedWatcherWatermark: target.watcherAcceptedWatermark
             )
+            guard !Task.isCancelled else {
+                if let self {
+                    await finishScopedIngressBarrier(
+                        rootID: rootID,
+                        token: token,
+                        target: target,
+                        output: nil,
+                        startedAtNanoseconds: barrierStartedAtNanoseconds,
+                        join: join
+                    )
+                } else {
+                    join.complete(with: nil)
+                }
+                return
+            }
             let acceptedDownstreamCut = publisherIngressCoordinator.appliedSnapshot(rootID: rootID)
                 .acceptedServicePublicationSequence
             await publisherIngressCoordinator.waitUntilApplied(
                 rootID: rootID,
                 servicePublicationSequence: max(target.acceptedServicePublicationSequence, acceptedDownstreamCut)
             )
+            guard !Task.isCancelled else {
+                if let self {
+                    await finishScopedIngressBarrier(
+                        rootID: rootID,
+                        token: token,
+                        target: target,
+                        output: nil,
+                        startedAtNanoseconds: barrierStartedAtNanoseconds,
+                        join: join
+                    )
+                } else {
+                    join.complete(with: nil)
+                }
+                return
+            }
             let applied = publisherIngressCoordinator.appliedSnapshot(rootID: rootID)
             EditFlowPerf.lifecycleEvent(
                 EditFlowPerf.Lifecycle.WorkspaceIngress.rootFlushEnded,
@@ -1352,43 +1463,25 @@ actor WorkspaceFileContextStore {
                 appliedWatcherWatermark: applied.appliedWatcherWatermark.rawValue
             )
             #if DEBUG
-                return ScopedIngressBarrierTaskOutput(
+                let output = ScopedIngressBarrierTaskOutput(
                     sample: sample,
                     completedAtNanoseconds: barrierCompletionNowNanoseconds()
                 )
             #else
-                return sample
+                let output = sample
             #endif
-        }
-        let join = ScopedIngressBarrierJoin()
-        #if DEBUG
-            scopedIngressBarrierFlightsByRootID[rootID] = ScopedIngressBarrierFlight(
-                token: token,
-                target: target,
-                join: join,
-                startedAtNanoseconds: barrierStartedAtNanoseconds
-            )
-        #else
-            scopedIngressBarrierFlightsByRootID[rootID] = ScopedIngressBarrierFlight(
-                token: token,
-                target: target,
-                join: join
-            )
-        #endif
-        Task { [weak self, join] in
-            let output = await task.value
-            guard let self else {
+            if let self {
+                await finishScopedIngressBarrier(
+                    rootID: rootID,
+                    token: token,
+                    target: target,
+                    output: output,
+                    startedAtNanoseconds: barrierStartedAtNanoseconds,
+                    join: join
+                )
+            } else {
                 join.complete(with: output)
-                return
             }
-            await finishScopedIngressBarrier(
-                rootID: rootID,
-                token: token,
-                target: target,
-                output: output,
-                startedAtNanoseconds: barrierStartedAtNanoseconds,
-                join: join
-            )
         }
         guard let output = await join.value() else { return nil }
         return scopedIngressBarrierSample(from: output)
@@ -1398,23 +1491,34 @@ actor WorkspaceFileContextStore {
         rootID: UUID,
         token: UInt64,
         target: ScopedIngressBarrierTarget,
-        output: ScopedIngressBarrierTaskOutput,
+        output: ScopedIngressBarrierTaskOutput?,
         startedAtNanoseconds: UInt64,
         join: ScopedIngressBarrierJoin
     ) {
-        #if DEBUG
-            recordScopedIngressBarrierCompletion(
-                rootID: rootID,
-                token: token,
-                target: target,
-                sample: output.sample,
-                startedAtNanoseconds: startedAtNanoseconds,
-                completedAtNanoseconds: output.completedAtNanoseconds
-            )
-        #endif
-        if scopedIngressBarrierFlightsByRootID[rootID]?.token == token {
-            scopedIngressBarrierFlightsByRootID.removeValue(forKey: rootID)
+        guard var flights = scopedIngressBarrierFlightsByRootID[rootID],
+              flights.contains(where: { $0.token == token })
+        else {
+            join.complete(with: output)
+            return
         }
+        flights.removeAll { $0.token == token }
+        if flights.isEmpty {
+            scopedIngressBarrierFlightsByRootID.removeValue(forKey: rootID)
+        } else {
+            scopedIngressBarrierFlightsByRootID[rootID] = flights
+        }
+        #if DEBUG
+            if let output {
+                recordScopedIngressBarrierCompletion(
+                    rootID: rootID,
+                    token: token,
+                    target: target,
+                    sample: output.sample,
+                    startedAtNanoseconds: startedAtNanoseconds,
+                    completedAtNanoseconds: output.completedAtNanoseconds
+                )
+            }
+        #endif
         join.complete(with: output)
     }
 
@@ -1677,7 +1781,7 @@ actor WorkspaceFileContextStore {
 
         let deltas: [FileSystemDelta]
         do {
-            deltas = try await state.service.scanFoldersInParallel(folderPaths).deltas
+            deltas = try await state.service.scanFoldersInParallel(folderPaths.sorted()).deltas
         } catch {
             return []
         }
@@ -2323,6 +2427,12 @@ actor WorkspaceFileContextStore {
 
         var statesToUnload: [(rootID: UUID, state: RootState)] = []
         for rootID in orderedRootIDs {
+            if let flights = scopedIngressBarrierFlightsByRootID.removeValue(forKey: rootID) {
+                for flight in flights {
+                    flight.task?.cancel()
+                    flight.join.complete(with: nil)
+                }
+            }
             watcherCancellablesByRootID.removeValue(forKey: rootID)?.cancel()
             publisherIngressCoordinator.closePublisherIngress(rootID: rootID)
             guard let state = rootStatesByID.removeValue(forKey: rootID) else { continue }

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileSystemIngressCoordinator.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileSystemIngressCoordinator.swift
@@ -1,3 +1,4 @@
+import Dispatch
 import Foundation
 
 /// Owns ordered publisher-to-store ingress synchronously at the Combine sink boundary.
@@ -17,12 +18,30 @@ final class WorkspaceFileSystemIngressCoordinator: @unchecked Sendable {
         let appliedWatcherWatermark: FileSystemWatcherIngressMailbox.Watermark
     }
 
+    #if DEBUG
+        struct DebugSnapshot: Equatable {
+            let isOpen: Bool
+            let queuedPublicationCount: Int
+            let applyingPublicationCount: Int
+            let outstandingPublicationCount: Int
+            let waiterCount: Int
+            let acceptedServicePublicationSequence: UInt64
+            let appliedServicePublicationSequence: UInt64
+            let acceptedAppliedSequenceGap: UInt64
+            let appliedWatcherWatermark: UInt64
+            let oldestOutstandingPublicationAgeMilliseconds: UInt64?
+        }
+    #endif
+
     typealias DrainHandler = @Sendable (FileSystemDeltaPublication, EditFlowPerf.LifecycleCorrelation?) async -> Void
 
     private struct QueuedPublication {
         let publication: FileSystemDeltaPublication
         let lifecycleCorrelation: EditFlowPerf.LifecycleCorrelation?
         let drainHandler: DrainHandler
+        #if DEBUG
+            let acceptedAtNanoseconds: UInt64
+        #endif
     }
 
     private final class RootState {
@@ -37,10 +56,20 @@ final class WorkspaceFileSystemIngressCoordinator: @unchecked Sendable {
         var acceptedServicePublicationSequence: UInt64 = 0
         var appliedServicePublicationSequence: UInt64 = 0
         var appliedWatcherWatermark = FileSystemWatcherIngressMailbox.Watermark.zero
+        #if DEBUG
+            var applyingPublicationAcceptedAtNanoseconds: UInt64?
+        #endif
 
         var pendingQueueCount: Int {
             queue.count - queueHead
         }
+
+        #if DEBUG
+            var oldestOutstandingPublicationAcceptedAtNanoseconds: UInt64? {
+                let queued = queueHead < queue.count ? queue[queueHead].acceptedAtNanoseconds : nil
+                return [applyingPublicationAcceptedAtNanoseconds, queued].compactMap(\.self).min()
+            }
+        #endif
 
         func append(_ publication: QueuedPublication) {
             queue.append(publication)
@@ -75,6 +104,17 @@ final class WorkspaceFileSystemIngressCoordinator: @unchecked Sendable {
     private var rootStatesByID: [UUID: RootState] = [:]
     private var waitersByRootID: [UUID: [UUID: Waiter]] = [:]
     private var nextDrainToken: UInt64 = 0
+    #if DEBUG
+        private let debugNowNanoseconds: @Sendable () -> UInt64
+
+        init(
+            debugNowNanoseconds: @escaping @Sendable () -> UInt64 = { DispatchTime.now().uptimeNanoseconds }
+        ) {
+            self.debugNowNanoseconds = debugNowNanoseconds
+        }
+    #else
+        init() {}
+    #endif
 
     func openPublisherIngress(rootID: UUID, drainHandler: @escaping DrainHandler) -> Subscription {
         lock.lock()
@@ -117,6 +157,9 @@ final class WorkspaceFileSystemIngressCoordinator: @unchecked Sendable {
         publication: FileSystemDeltaPublication,
         lifecycleCorrelation: EditFlowPerf.LifecycleCorrelation?
     ) -> Bool {
+        #if DEBUG
+            let acceptedAtNanoseconds = debugNowNanoseconds()
+        #endif
         lock.lock()
         defer { lock.unlock() }
 
@@ -127,11 +170,20 @@ final class WorkspaceFileSystemIngressCoordinator: @unchecked Sendable {
         else {
             return false
         }
-        state.append(QueuedPublication(
-            publication: publication,
-            lifecycleCorrelation: lifecycleCorrelation,
-            drainHandler: drainHandler
-        ))
+        #if DEBUG
+            state.append(QueuedPublication(
+                publication: publication,
+                lifecycleCorrelation: lifecycleCorrelation,
+                drainHandler: drainHandler,
+                acceptedAtNanoseconds: acceptedAtNanoseconds
+            ))
+        #else
+            state.append(QueuedPublication(
+                publication: publication,
+                lifecycleCorrelation: lifecycleCorrelation,
+                drainHandler: drainHandler
+            ))
+        #endif
         state.acceptedServicePublicationSequence = max(
             state.acceptedServicePublicationSequence,
             publication.servicePublicationSequence
@@ -142,20 +194,26 @@ final class WorkspaceFileSystemIngressCoordinator: @unchecked Sendable {
 
     func waitUntilApplied(rootID: UUID, servicePublicationSequence: UInt64) async {
         guard servicePublicationSequence > 0 else { return }
-        await withCheckedContinuation { continuation in
-            lock.lock()
-            guard let state = rootStatesByID[rootID],
-                  state.appliedServicePublicationSequence < servicePublicationSequence
-            else {
+        let waiterID = UUID()
+        await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                lock.lock()
+                guard !Task.isCancelled,
+                      let state = rootStatesByID[rootID],
+                      state.appliedServicePublicationSequence < servicePublicationSequence
+                else {
+                    lock.unlock()
+                    continuation.resume()
+                    return
+                }
+                waitersByRootID[rootID, default: [:]][waiterID] = Waiter(
+                    targetServicePublicationSequence: servicePublicationSequence,
+                    continuation: continuation
+                )
                 lock.unlock()
-                continuation.resume()
-                return
             }
-            waitersByRootID[rootID, default: [:]][UUID()] = Waiter(
-                targetServicePublicationSequence: servicePublicationSequence,
-                continuation: continuation
-            )
-            lock.unlock()
+        } onCancel: {
+            cancelWaiter(rootID: rootID, waiterID: waiterID)
         }
     }
 
@@ -169,6 +227,7 @@ final class WorkspaceFileSystemIngressCoordinator: @unchecked Sendable {
             }
         }()
         for target in targets {
+            guard !Task.isCancelled else { break }
             await waitUntilApplied(
                 rootID: target.rootID,
                 servicePublicationSequence: target.servicePublicationSequence
@@ -201,6 +260,51 @@ final class WorkspaceFileSystemIngressCoordinator: @unchecked Sendable {
             count += state.pendingQueueCount + state.applyingCount
         }
     }
+
+    #if DEBUG
+        func debugSnapshot(rootID: UUID) -> DebugSnapshot {
+            let now = debugNowNanoseconds()
+            lock.lock()
+            defer { lock.unlock() }
+            guard let state = rootStatesByID[rootID] else {
+                return DebugSnapshot(
+                    isOpen: false,
+                    queuedPublicationCount: 0,
+                    applyingPublicationCount: 0,
+                    outstandingPublicationCount: 0,
+                    waiterCount: 0,
+                    acceptedServicePublicationSequence: 0,
+                    appliedServicePublicationSequence: 0,
+                    acceptedAppliedSequenceGap: 0,
+                    appliedWatcherWatermark: 0,
+                    oldestOutstandingPublicationAgeMilliseconds: nil
+                )
+            }
+            let gap = state.acceptedServicePublicationSequence >= state.appliedServicePublicationSequence
+                ? state.acceptedServicePublicationSequence - state.appliedServicePublicationSequence
+                : 0
+            let oldestAge = state.oldestOutstandingPublicationAcceptedAtNanoseconds.map { acceptedAt in
+                Self.elapsedMilliseconds(since: acceptedAt, now: now)
+            }
+            return DebugSnapshot(
+                isOpen: state.isOpen,
+                queuedPublicationCount: state.pendingQueueCount,
+                applyingPublicationCount: state.applyingCount,
+                outstandingPublicationCount: state.pendingQueueCount + state.applyingCount,
+                waiterCount: waitersByRootID[rootID]?.count ?? 0,
+                acceptedServicePublicationSequence: state.acceptedServicePublicationSequence,
+                appliedServicePublicationSequence: state.appliedServicePublicationSequence,
+                acceptedAppliedSequenceGap: gap,
+                appliedWatcherWatermark: state.appliedWatcherWatermark.rawValue,
+                oldestOutstandingPublicationAgeMilliseconds: oldestAge
+            )
+        }
+
+        private static func elapsedMilliseconds(since start: UInt64, now: UInt64) -> UInt64 {
+            guard now >= start else { return 0 }
+            return (now - start) / 1_000_000
+        }
+    #endif
 
     func finishPublisherIngress(rootIDs: Set<UUID>) {
         var continuations: [CheckedContinuation<Void, Never>] = []
@@ -257,7 +361,21 @@ final class WorkspaceFileSystemIngressCoordinator: @unchecked Sendable {
         defer { lock.unlock() }
         guard let state = rootStatesByID[rootID], let queued = state.takeNextPublication() else { return nil }
         state.applyingCount += 1
+        #if DEBUG
+            state.applyingPublicationAcceptedAtNanoseconds = queued.acceptedAtNanoseconds
+        #endif
         return queued
+    }
+
+    private func cancelWaiter(rootID: UUID, waiterID: UUID) {
+        let continuation: CheckedContinuation<Void, Never>?
+        lock.lock()
+        continuation = waitersByRootID[rootID]?.removeValue(forKey: waiterID)?.continuation
+        if waitersByRootID[rootID]?.isEmpty == true {
+            waitersByRootID.removeValue(forKey: rootID)
+        }
+        lock.unlock()
+        continuation?.resume()
     }
 
     private func finishApplying(rootID: UUID, publication: FileSystemDeltaPublication) {
@@ -265,6 +383,9 @@ final class WorkspaceFileSystemIngressCoordinator: @unchecked Sendable {
         lock.lock()
         if let state = rootStatesByID[rootID] {
             state.applyingCount = max(0, state.applyingCount - 1)
+            #if DEBUG
+                state.applyingPublicationAcceptedAtNanoseconds = nil
+            #endif
             state.appliedServicePublicationSequence = max(
                 state.appliedServicePublicationSequence,
                 publication.servicePublicationSequence

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceReadableFileService.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceReadableFileService.swift
@@ -15,7 +15,7 @@ struct WorkspaceReadableFileService {
     func awaitFreshnessForExplicitRequest(
         _ userPath: String,
         fallbackScope: WorkspaceLookupRootScope
-    ) async {
+    ) async throws {
         let lifecycleCorrelation = EditFlowPerf.currentLifecycleCorrelation
         EditFlowPerf.lifecycleEvent(
             EditFlowPerf.Lifecycle.ReadFile.explicitFreshnessBegan,
@@ -26,6 +26,7 @@ struct WorkspaceReadableFileService {
             userPath: userPath,
             fallbackScope: fallbackScope
         )
+        try Task.checkCancellation()
         EditFlowPerf.end(
             EditFlowPerf.Stage.ReadFile.explicitIngressFreshnessWait,
             freshnessState,

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceSearchDecodedContentCache.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceSearchDecodedContentCache.swift
@@ -6,6 +6,26 @@ struct WorkspaceSearchContentCacheKey: Hashable {
     let standardizedRelativePath: String
 }
 
+struct WorkspaceSearchContentInvalidationBatch {
+    private(set) var maximumEpochsByKey: [WorkspaceSearchContentCacheKey: UInt64] = [:]
+
+    var isEmpty: Bool {
+        maximumEpochsByKey.isEmpty
+    }
+
+    var count: Int {
+        maximumEpochsByKey.count
+    }
+
+    mutating func record(_ key: WorkspaceSearchContentCacheKey, through invalidationEpoch: UInt64) {
+        maximumEpochsByKey[key] = max(maximumEpochsByKey[key] ?? 0, invalidationEpoch)
+    }
+
+    func maximumEpoch(for key: WorkspaceSearchContentCacheKey) -> UInt64? {
+        maximumEpochsByKey[key]
+    }
+}
+
 struct WorkspaceSearchDecodedContentEntry {
     let content: String?
     let modificationDate: Date
@@ -114,11 +134,21 @@ actor WorkspaceSearchDecodedContentCache {
     }
 
     func invalidate(_ key: WorkspaceSearchContentCacheKey, through invalidationEpoch: UInt64) {
-        if let entry = entries[key], entry.invalidationEpoch <= invalidationEpoch {
-            removeEntry(for: key)
+        var batch = WorkspaceSearchContentInvalidationBatch()
+        batch.record(key, through: invalidationEpoch)
+        invalidate(batch)
+    }
+
+    func invalidate(_ batch: WorkspaceSearchContentInvalidationBatch) {
+        guard !batch.isEmpty else { return }
+        for (key, invalidationEpoch) in batch.maximumEpochsByKey {
+            if let entry = entries[key], entry.invalidationEpoch <= invalidationEpoch {
+                removeEntry(for: key)
+            }
         }
-        markFlightsNonPublishable {
-            $0.cacheKey == key && $0.invalidationEpoch <= invalidationEpoch
+        markFlightsNonPublishable { flightKey in
+            guard let invalidationEpoch = batch.maximumEpoch(for: flightKey.cacheKey) else { return false }
+            return flightKey.invalidationEpoch <= invalidationEpoch
         }
     }
 

--- a/Sources/RepoPromptMCP/Interactive/InteractiveMCPClientSession.swift
+++ b/Sources/RepoPromptMCP/Interactive/InteractiveMCPClientSession.swift
@@ -72,11 +72,43 @@ enum ToolCallTimeoutPolicy: Equatable {
     case none
 }
 
+private final class ToolCallSettlementState: @unchecked Sendable {
+    enum Outcome {
+        case pending
+        case completed
+        case timedOut
+        case callerCancelled
+    }
+
+    private let lock = NSLock()
+    private var outcome: Outcome = .pending
+
+    func claim(_ candidate: Outcome) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard case .pending = outcome else { return false }
+        outcome = candidate
+        return true
+    }
+
+    func finish() -> Outcome {
+        lock.lock()
+        defer { lock.unlock() }
+        if case .pending = outcome {
+            outcome = .completed
+        }
+        return outcome
+    }
+}
+
 /// Manages an interactive MCP client session with the RepoPrompt app.
 actor InteractiveMCPClientSession {
+    typealias TimeoutSleep = @Sendable (UInt64) async throws -> Void
+
     private let sessionToken: String
     private let clientName: String
     private let logger: Logger
+    private let timeoutSleep: TimeoutSleep
 
     private var client: MCP.Client?
     private var transport: BootstrapSocketMCPTransport?
@@ -107,7 +139,27 @@ actor InteractiveMCPClientSession {
         self.logger = logger ?? Logger(label: "mcp.interactive.session") { _ in
             SwiftLogNoOpLogHandler()
         }
+        timeoutSleep = { nanoseconds in
+            try await Task.sleep(nanoseconds: nanoseconds)
+        }
     }
+
+    #if DEBUG
+        init(
+            connectedClientForTesting client: MCP.Client,
+            timeoutSleep: @escaping TimeoutSleep = { nanoseconds in
+                try await Task.sleep(nanoseconds: nanoseconds)
+            }
+        ) {
+            sessionToken = "test-session"
+            clientName = "test-client"
+            logger = Logger(label: "mcp.interactive.session.tests") { _ in
+                SwiftLogNoOpLogHandler()
+            }
+            self.timeoutSleep = timeoutSleep
+            self.client = client
+        }
+    #endif
 
     // MARK: - Connection
 
@@ -294,32 +346,104 @@ actor InteractiveMCPClientSession {
         }
 
         logger.debug("Calling tool: \(name)")
+        try Task.checkCancellation()
+        let context: RequestContext<CallTool.Result> = try await client.callTool(
+            name: name,
+            arguments: args.isEmpty ? nil : args
+        )
         let effectiveTimeout = resolvedTimeout(timeout)
-        let result: (content: [Tool.Content], isError: Bool?) = if let seconds = effectiveTimeout {
-            try await withThrowingTaskGroup(of: (content: [Tool.Content], isError: Bool?).self) { group in
-                group.addTask {
-                    try await client.callTool(name: name, arguments: args.isEmpty ? nil : args)
-                }
-                group.addTask {
-                    try await Task.sleep(nanoseconds: Self.nanoseconds(forTimeoutSeconds: seconds))
-                    throw InteractiveSessionError.toolCallTimeout(toolName: name, seconds: seconds)
-                }
-                guard let result = try await group.next() else {
-                    throw InteractiveSessionError.toolCallTimeout(toolName: name, seconds: seconds)
-                }
-                group.cancelAll()
-                return result
-            }
-        } else {
-            try await client.callTool(name: name, arguments: args.isEmpty ? nil : args)
-        }
+        let result = try await awaitToolCallResult(
+            context,
+            client: client,
+            toolName: name,
+            timeoutSeconds: effectiveTimeout
+        )
 
         if result.isError != true, shouldClearWindowSelectionAfterCall(toolName: name, args: args) {
             selectedWindowID = nil
             logger.debug("Cleared window selection after open-in-new-window switch")
         }
 
-        return CallTool.Result(content: result.content, isError: result.isError)
+        return result
+    }
+
+    private func awaitToolCallResult(
+        _ context: RequestContext<CallTool.Result>,
+        client: MCP.Client,
+        toolName: String,
+        timeoutSeconds: TimeInterval?
+    ) async throws -> CallTool.Result {
+        let settlement = ToolCallSettlementState()
+        let timeoutTask = timeoutSeconds.map { seconds in
+            Task { [timeoutSleep] in
+                do {
+                    try await timeoutSleep(Self.nanoseconds(forTimeoutSeconds: seconds))
+                } catch {
+                    return
+                }
+                guard settlement.claim(.timedOut) else { return }
+                Task.detached {
+                    try? await client.cancelRequest(
+                        context.requestID,
+                        reason: "CLI tool call timed out after \(seconds) seconds"
+                    )
+                }
+            }
+        }
+        defer { timeoutTask?.cancel() }
+
+        do {
+            let result = try await withTaskCancellationHandler {
+                try await context.value
+            } onCancel: {
+                guard settlement.claim(.callerCancelled) else { return }
+                Task.detached {
+                    try? await client.cancelRequest(
+                        context.requestID,
+                        reason: "CLI caller cancelled tool request"
+                    )
+                }
+            }
+            return try Self.resolveToolCallSettlement(
+                settlement.finish(),
+                result: result,
+                toolName: toolName,
+                timeoutSeconds: timeoutSeconds
+            )
+        } catch {
+            switch settlement.finish() {
+            case .timedOut:
+                throw InteractiveSessionError.toolCallTimeout(
+                    toolName: toolName,
+                    seconds: timeoutSeconds ?? 0
+                )
+            case .callerCancelled:
+                throw CancellationError()
+            case .pending, .completed:
+                throw error
+            }
+        }
+    }
+
+    private static func resolveToolCallSettlement(
+        _ outcome: ToolCallSettlementState.Outcome,
+        result: CallTool.Result,
+        toolName: String,
+        timeoutSeconds: TimeInterval?
+    ) throws -> CallTool.Result {
+        switch outcome {
+        case .completed:
+            result
+        case .timedOut:
+            throw InteractiveSessionError.toolCallTimeout(
+                toolName: toolName,
+                seconds: timeoutSeconds ?? 0
+            )
+        case .callerCancelled:
+            throw CancellationError()
+        case .pending:
+            result
+        }
     }
 
     private static func nanoseconds(forTimeoutSeconds seconds: TimeInterval) -> UInt64 {

--- a/Sources/RepoPromptMCP/Interactive/InteractiveMCPClientSession.swift
+++ b/Sources/RepoPromptMCP/Interactive/InteractiveMCPClientSession.swift
@@ -82,12 +82,19 @@ private final class ToolCallSettlementState: @unchecked Sendable {
 
     private let lock = NSLock()
     private var outcome: Outcome = .pending
+    private var cancellationDeliveryTask: Task<Void, Never>?
 
-    func claim(_ candidate: Outcome) -> Bool {
+    func claim(
+        _ candidate: Outcome,
+        deliverCancellation: @escaping @Sendable () async -> Void
+    ) -> Bool {
         lock.lock()
         defer { lock.unlock() }
         guard case .pending = outcome else { return false }
         outcome = candidate
+        cancellationDeliveryTask = Task.detached {
+            await deliverCancellation()
+        }
         return true
     }
 
@@ -98,6 +105,24 @@ private final class ToolCallSettlementState: @unchecked Sendable {
             outcome = .completed
         }
         return outcome
+    }
+
+    func waitForCancellationDelivery() async {
+        await cancellationDeliveryTaskSnapshot()?.value
+    }
+
+    private func cancellationDeliveryTaskSnapshot() -> Task<Void, Never>? {
+        lock.lock()
+        defer { lock.unlock() }
+        return cancellationDeliveryTask
+    }
+}
+
+private struct RegisteredToolCall {
+    let context: RequestContext<CallTool.Result>
+
+    var requestID: ID {
+        context.requestID
     }
 }
 
@@ -111,11 +136,16 @@ actor InteractiveMCPClientSession {
     private let timeoutSleep: TimeoutSleep
 
     private var client: MCP.Client?
-    private var transport: BootstrapSocketMCPTransport?
+    private var transport: (any Transport)?
+    private var requestSendBarrier: MCPRequestSendBarrier?
     private var cachedTools: [MCP.Tool] = []
     private var toolListFetched = false
     private var defaultToolCallTimeout: ToolCallTimeoutPolicy = .seconds(300)
     private(set) var toolsDirty = false
+
+    #if DEBUG
+        private let requestSendWillStart: (@Sendable () async -> Void)?
+    #endif
 
     /// Server info from initialization
     private(set) var serverName: String?
@@ -142,11 +172,16 @@ actor InteractiveMCPClientSession {
         timeoutSleep = { nanoseconds in
             try await Task.sleep(nanoseconds: nanoseconds)
         }
+        #if DEBUG
+            requestSendWillStart = nil
+        #endif
     }
 
     #if DEBUG
         init(
             connectedClientForTesting client: MCP.Client,
+            requestSendBarrier: MCPRequestSendBarrier,
+            requestSendWillStart: (@Sendable () async -> Void)? = nil,
             timeoutSleep: @escaping TimeoutSleep = { nanoseconds in
                 try await Task.sleep(nanoseconds: nanoseconds)
             }
@@ -158,6 +193,8 @@ actor InteractiveMCPClientSession {
             }
             self.timeoutSleep = timeoutSleep
             self.client = client
+            self.requestSendBarrier = requestSendBarrier
+            self.requestSendWillStart = requestSendWillStart
         }
     #endif
 
@@ -174,13 +211,19 @@ actor InteractiveMCPClientSession {
         let connectedFD = try await performBootstrapHandshake()
         logger.debug("Bootstrap handshake complete, FD=\(connectedFD)")
 
-        // Create transport with the connected FD
-        let transport: BootstrapSocketMCPTransport
+        // Create transport with the connected FD and observe completed request writes.
+        let socketTransport: BootstrapSocketMCPTransport
         do {
-            transport = try BootstrapSocketMCPTransport(connectedFD: connectedFD, logger: logger)
+            socketTransport = try BootstrapSocketMCPTransport(connectedFD: connectedFD, logger: logger)
         } catch let error as POSIXDescriptorConfigurationError {
             throw InteractiveSessionError.descriptorConfigurationFailed(errno: error.errnoValue)
         }
+        let requestSendBarrier = MCPRequestSendBarrier()
+        let transport = OrderedMCPTransport(
+            underlying: socketTransport,
+            requestSendBarrier: requestSendBarrier,
+            logger: logger
+        )
 
         // Create MCP client
         let client = MCP.Client(
@@ -188,6 +231,7 @@ actor InteractiveMCPClientSession {
             version: "1.0"
         )
         self.transport = transport
+        self.requestSendBarrier = requestSendBarrier
         self.client = client
         logger.debug("Created MCP client '\(clientName)'")
 
@@ -240,6 +284,7 @@ actor InteractiveMCPClientSession {
             await transport.disconnect()
             self.client = nil
             self.transport = nil
+            self.requestSendBarrier = nil
             cachedTools = []
             toolListFetched = false
             toolsDirty = false
@@ -255,6 +300,7 @@ actor InteractiveMCPClientSession {
         await transport?.disconnect()
         client = nil
         transport = nil
+        requestSendBarrier = nil
         cachedTools = []
         toolListFetched = false
         toolsDirty = false
@@ -325,7 +371,7 @@ actor InteractiveMCPClientSession {
         arguments: [String: Value]?,
         timeout: ToolCallTimeoutPolicy = .default
     ) async throws -> CallTool.Result {
-        guard let client else {
+        guard let client, let requestSendBarrier else {
             throw InteractiveSessionError.notConnected
         }
 
@@ -346,14 +392,15 @@ actor InteractiveMCPClientSession {
         }
 
         logger.debug("Calling tool: \(name)")
-        try Task.checkCancellation()
-        let context: RequestContext<CallTool.Result> = try await client.callTool(
+        let registeredCall = try await registerAndSendToolCall(
+            client: client,
+            requestSendBarrier: requestSendBarrier,
             name: name,
             arguments: args.isEmpty ? nil : args
         )
         let effectiveTimeout = resolvedTimeout(timeout)
         let result = try await awaitToolCallResult(
-            context,
+            registeredCall,
             client: client,
             toolName: name,
             timeoutSeconds: effectiveTimeout
@@ -367,8 +414,31 @@ actor InteractiveMCPClientSession {
         return result
     }
 
+    private func registerAndSendToolCall(
+        client: MCP.Client,
+        requestSendBarrier: MCPRequestSendBarrier,
+        name: String,
+        arguments: [String: Value]?
+    ) async throws -> RegisteredToolCall {
+        #if DEBUG
+            if let requestSendWillStart {
+                await requestSendWillStart()
+            }
+        #endif
+        let request = CallTool.request(.init(name: name, arguments: arguments))
+        await requestSendBarrier.register(requestID: request.id)
+        do {
+            let context = try await client.send(request)
+            try await requestSendBarrier.waitUntilSent(requestID: request.id)
+            return RegisteredToolCall(context: context)
+        } catch {
+            await requestSendBarrier.cancel(requestID: request.id)
+            throw error
+        }
+    }
+
     private func awaitToolCallResult(
-        _ context: RequestContext<CallTool.Result>,
+        _ registeredCall: RegisteredToolCall,
         client: MCP.Client,
         toolName: String,
         timeoutSeconds: TimeInterval?
@@ -381,10 +451,9 @@ actor InteractiveMCPClientSession {
                 } catch {
                     return
                 }
-                guard settlement.claim(.timedOut) else { return }
-                Task.detached {
+                _ = settlement.claim(.timedOut) {
                     try? await client.cancelRequest(
-                        context.requestID,
+                        registeredCall.requestID,
                         reason: "CLI tool call timed out after \(seconds) seconds"
                     )
                 }
@@ -394,24 +463,27 @@ actor InteractiveMCPClientSession {
 
         do {
             let result = try await withTaskCancellationHandler {
-                try await context.value
+                try await registeredCall.context.value
             } onCancel: {
-                guard settlement.claim(.callerCancelled) else { return }
-                Task.detached {
+                _ = settlement.claim(.callerCancelled) {
                     try? await client.cancelRequest(
-                        context.requestID,
+                        registeredCall.requestID,
                         reason: "CLI caller cancelled tool request"
                     )
                 }
             }
+            let outcome = settlement.finish()
+            await settlement.waitForCancellationDelivery()
             return try Self.resolveToolCallSettlement(
-                settlement.finish(),
+                outcome,
                 result: result,
                 toolName: toolName,
                 timeoutSeconds: timeoutSeconds
             )
         } catch {
-            switch settlement.finish() {
+            let outcome = settlement.finish()
+            await settlement.waitForCancellationDelivery()
+            switch outcome {
             case .timedOut:
                 throw InteractiveSessionError.toolCallTimeout(
                     toolName: toolName,

--- a/Sources/RepoPromptMCP/Transports/OrderedMCPTransport.swift
+++ b/Sources/RepoPromptMCP/Transports/OrderedMCPTransport.swift
@@ -1,0 +1,148 @@
+import Foundation
+import Logging
+import MCP
+
+/// Tracks completion of the actual transport send for registered JSON-RPC request IDs.
+/// The SDK's `Client.send` returns before its internally spawned request task necessarily starts.
+actor MCPRequestSendBarrier {
+    private enum Completion {
+        case sent
+        case failed(String)
+    }
+
+    private struct State {
+        var completion: Completion?
+        var waiters: [CheckedContinuation<Completion, Never>] = []
+    }
+
+    private var states: [ID: State] = [:]
+
+    func register(requestID: ID) {
+        states[requestID] = State()
+    }
+
+    func waitUntilSent(requestID: ID) async throws {
+        let completion = await withCheckedContinuation { (continuation: CheckedContinuation<Completion, Never>) in
+            guard var state = states[requestID] else {
+                continuation.resume(returning: .failed("MCP request send barrier was not registered"))
+                return
+            }
+            if let completion = state.completion {
+                states.removeValue(forKey: requestID)
+                continuation.resume(returning: completion)
+            } else {
+                state.waiters.append(continuation)
+                states[requestID] = state
+            }
+        }
+
+        switch completion {
+        case .sent:
+            return
+        case let .failed(reason):
+            throw MCPRequestSendBarrierError.sendFailed(reason)
+        }
+    }
+
+    func cancel(requestID: ID) {
+        guard let state = states.removeValue(forKey: requestID) else { return }
+        for waiter in state.waiters {
+            waiter.resume(returning: .failed("MCP request send was abandoned before delivery"))
+        }
+    }
+
+    func didSend(requestIDs: [ID]) {
+        complete(requestIDs: requestIDs, with: .sent)
+    }
+
+    func didFailToSend(requestIDs: [ID], error: Error) {
+        complete(requestIDs: requestIDs, with: .failed(String(describing: error)))
+    }
+
+    private func complete(requestIDs: [ID], with completion: Completion) {
+        for requestID in requestIDs {
+            guard var state = states[requestID] else { continue }
+            if state.waiters.isEmpty {
+                state.completion = completion
+                states[requestID] = state
+            } else {
+                states.removeValue(forKey: requestID)
+                state.waiters.forEach { $0.resume(returning: completion) }
+            }
+        }
+    }
+}
+
+enum MCPRequestSendBarrierError: Error {
+    case sendFailed(String)
+}
+
+/// Observes request writes through the SDK's public transport seam so cancellation can be ordered after them.
+actor OrderedMCPTransport: Transport {
+    nonisolated let logger: Logger
+
+    private struct OutboundEnvelope: Decodable {
+        let id: ID?
+        let method: String?
+    }
+
+    private let underlying: any Transport
+    private let requestSendBarrier: MCPRequestSendBarrier
+    private var receiveStream: AsyncThrowingStream<Data, Error>?
+
+    init(
+        underlying: any Transport,
+        requestSendBarrier: MCPRequestSendBarrier,
+        logger: Logger
+    ) {
+        self.underlying = underlying
+        self.requestSendBarrier = requestSendBarrier
+        self.logger = logger
+    }
+
+    func connect() async throws {
+        try await underlying.connect()
+        receiveStream = await underlying.receive()
+    }
+
+    func disconnect() async {
+        await underlying.disconnect()
+    }
+
+    func send(_ data: Data) async throws {
+        let requestIDs = Self.requestIDs(in: data)
+        do {
+            try await underlying.send(data)
+            await requestSendBarrier.didSend(requestIDs: requestIDs)
+        } catch {
+            await requestSendBarrier.didFailToSend(requestIDs: requestIDs, error: error)
+            throw error
+        }
+    }
+
+    func receive() -> AsyncThrowingStream<Data, Error> {
+        guard let receiveStream else {
+            return AsyncThrowingStream { continuation in
+                continuation.finish(throwing: MCPError.internalError("Ordered MCP transport is not connected"))
+            }
+        }
+        return receiveStream
+    }
+
+    private nonisolated static func requestIDs(in data: Data) -> [ID] {
+        let decoder = JSONDecoder()
+        if let envelope = try? decoder.decode(OutboundEnvelope.self, from: data),
+           envelope.method != nil,
+           let id = envelope.id
+        {
+            return [id]
+        }
+        if let envelopes = try? decoder.decode([OutboundEnvelope].self, from: data) {
+            return envelopes.compactMap { envelope in
+                guard envelope.method != nil else { return nil }
+                return envelope.id
+            }
+        }
+        return []
+    }
+}

--- a/Tests/RepoPromptTests/MCP/Control/AsyncLimiterTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/AsyncLimiterTests.swift
@@ -1,0 +1,294 @@
+import Foundation
+@testable import RepoPrompt
+import XCTest
+
+#if DEBUG
+    final class AsyncLimiterTests: XCTestCase {
+        func testCancelledMiddleWaiterDetachesPromptlyAndLiveWaitersRemainFIFO() async throws {
+            let limiter = AsyncLimiter(limit: 1)
+            let holderGate = LimiterTestGate()
+            let recorder = LimiterOrderRecorder()
+            let snapshots = LimiterSnapshotSignal()
+            await limiter.setDebugStateObserver { snapshot in
+                Task { await snapshots.record(snapshot) }
+            }
+
+            let holder = Task {
+                try await limiter.withPermit {
+                    await holderGate.markStartedAndWaitForRelease()
+                }
+            }
+            await holderGate.waitUntilStarted()
+
+            let first = Task {
+                try await limiter.withPermit {
+                    await recorder.append(1)
+                }
+            }
+            _ = await snapshots.waitUntil { $0.waiterCount == 1 }
+
+            let cancelled = Task {
+                try await limiter.withPermit {
+                    await recorder.append(2)
+                }
+            }
+            _ = await snapshots.waitUntil { $0.waiterCount == 2 }
+
+            let third = Task {
+                try await limiter.withPermit {
+                    await recorder.append(3)
+                }
+            }
+            _ = await snapshots.waitUntil { $0.waiterCount == 3 }
+
+            cancelled.cancel()
+            let afterCancellation = await snapshots.waitUntil {
+                $0.waiterCount == 2 && $0.inFlight == 3 && $0.cancelledWaiterCount == 1
+            }
+            XCTAssertEqual(afterCancellation.activePermitCount, 1)
+            await assertCancellation(cancelled)
+
+            await holderGate.release()
+            try await holder.value
+            try await first.value
+            try await third.value
+
+            let values = await recorder.values()
+            XCTAssertEqual(values, [1, 3])
+            let settled = await snapshots.waitUntil { $0.isIdle }
+            assertIdle(settled, cancelledWaiterCount: 1, isClosed: false)
+        }
+
+        func testCloseDuringQueuedPermitHandoffRejectsResumedBodyAndRestoresPermit() async throws {
+            let limiter = AsyncLimiter(limit: 1)
+            let holderGate = LimiterTestGate()
+            let handoffGate = LimiterTestGate()
+            let waiterBodyRan = LimiterTestFlag()
+            await limiter.setDebugQueuedPermitHandoffHandler {
+                await handoffGate.markStartedAndWaitForRelease()
+            }
+
+            let holder = Task {
+                try await limiter.withPermit {
+                    await holderGate.markStartedAndWaitForRelease()
+                }
+            }
+            await holderGate.waitUntilStarted()
+
+            let waiter = Task {
+                try await limiter.withPermit {
+                    await waiterBodyRan.mark()
+                }
+            }
+            let snapshots = LimiterSnapshotSignal()
+            await limiter.setDebugStateObserver { snapshot in
+                Task { await snapshots.record(snapshot) }
+            }
+            _ = await snapshots.waitUntil { $0.waiterCount == 1 }
+
+            await holderGate.release()
+            try await holder.value
+            await handoffGate.waitUntilStarted()
+
+            let close = Task {
+                await limiter.cancelAll()
+                return await limiter.waitUntilIdle()
+            }
+            _ = await snapshots.waitUntil { $0.isClosed && $0.activePermitCount == 1 }
+            await handoffGate.release()
+
+            await assertCancellation(waiter)
+            let closeDrained = await close.value
+            XCTAssertTrue(closeDrained)
+            let didRunWaiterBody = await waiterBodyRan.isMarked()
+            XCTAssertFalse(didRunWaiterBody)
+            let settled = await limiter.debugSnapshot()
+            assertIdle(settled, cancelledWaiterCount: 0, isClosed: true)
+            await limiter.setDebugQueuedPermitHandoffHandler(nil)
+        }
+
+        func testConnectionRemovalBoundsCancellationInsensitiveOwnerAndDropsLimiter() async throws {
+            let manager = ServerNetworkManager.shared
+            let connectionID = UUID()
+            let cleanupDeadlineGate = LimiterTestGate()
+            let limiter = await manager.debugInstallConnectionLimiterForTesting(
+                connectionID: connectionID,
+                idleWaitSleep: { _ in
+                    await cleanupDeadlineGate.markStartedAndWaitForRelease()
+                }
+            )
+            let holderGate = LimiterTestGate()
+            let queuedBodyRan = LimiterTestFlag()
+            let removalCompleted = LimiterTestFlag()
+            let snapshots = LimiterSnapshotSignal()
+            await limiter.setDebugStateObserver { snapshot in
+                Task { await snapshots.record(snapshot) }
+            }
+
+            let holder = Task {
+                try await limiter.withPermit {
+                    await holderGate.markStartedAndWaitForRelease()
+                }
+            }
+            await holderGate.waitUntilStarted()
+
+            let queued = Task {
+                try await limiter.withPermit {
+                    await queuedBodyRan.mark()
+                }
+            }
+            _ = await snapshots.waitUntil { $0.waiterCount == 1 }
+
+            let removal = Task {
+                await manager.debugRemoveConnection(connectionID)
+                await removalCompleted.mark()
+            }
+
+            let closed = await snapshots.waitUntil {
+                $0.isClosed && $0.waiterCount == 0 && $0.cancelledWaiterCount == 1
+            }
+            XCTAssertEqual(closed.activePermitCount, 1)
+            await assertCancellation(queued)
+            let didRunQueuedBody = await queuedBodyRan.isMarked()
+            XCTAssertFalse(didRunQueuedBody)
+            await cleanupDeadlineGate.waitUntilStarted()
+            let didFinishRemovalBeforeDeadline = await removalCompleted.isMarked()
+            XCTAssertFalse(didFinishRemovalBeforeDeadline)
+            let registeredSnapshot = await manager.connectionLimiterSnapshotForTesting(connectionID: connectionID)
+            XCTAssertNil(registeredSnapshot)
+
+            await cleanupDeadlineGate.release()
+            await removal.value
+            let didFinishRemoval = await removalCompleted.isMarked()
+            XCTAssertTrue(didFinishRemoval)
+            let detached = await limiter.debugSnapshot()
+            XCTAssertTrue(detached.isClosed)
+            XCTAssertEqual(detached.activePermitCount, 1)
+            XCTAssertEqual(detached.inFlight, 1)
+            XCTAssertFalse(detached.isIdle)
+
+            await holderGate.release()
+            try await holder.value
+            let eventuallyDrained = await limiter.waitUntilIdle()
+            XCTAssertTrue(eventuallyDrained)
+            let settled = await limiter.debugSnapshot()
+            assertIdle(settled, cancelledWaiterCount: 1, isClosed: true)
+        }
+
+        private func assertCancellation(_ task: Task<Void, Error>, file: StaticString = #filePath, line: UInt = #line) async {
+            do {
+                try await task.value
+                XCTFail("Expected CancellationError", file: file, line: line)
+            } catch is CancellationError {
+                // Expected.
+            } catch {
+                XCTFail("Expected CancellationError, got \(error)", file: file, line: line)
+            }
+        }
+
+        private func assertIdle(
+            _ snapshot: AsyncLimiter.DebugSnapshot,
+            cancelledWaiterCount: Int,
+            isClosed: Bool,
+            file: StaticString = #filePath,
+            line: UInt = #line
+        ) {
+            XCTAssertEqual(snapshot.permits, 1, file: file, line: line)
+            XCTAssertEqual(snapshot.activePermitCount, 0, file: file, line: line)
+            XCTAssertEqual(snapshot.waiterCount, 0, file: file, line: line)
+            XCTAssertEqual(snapshot.inFlight, 0, file: file, line: line)
+            XCTAssertEqual(snapshot.cancelledWaiterCount, cancelledWaiterCount, file: file, line: line)
+            XCTAssertEqual(snapshot.isClosed, isClosed, file: file, line: line)
+            XCTAssertTrue(snapshot.isIdle, file: file, line: line)
+        }
+    }
+
+    private actor LimiterTestGate {
+        private var started = false
+        private var released = false
+        private var startedWaiters: [CheckedContinuation<Void, Never>] = []
+        private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+
+        func markStartedAndWaitForRelease() async {
+            started = true
+            let startedWaiters = startedWaiters
+            self.startedWaiters.removeAll()
+            for waiter in startedWaiters {
+                waiter.resume()
+            }
+            guard !released else { return }
+            await withCheckedContinuation { continuation in
+                releaseWaiters.append(continuation)
+            }
+        }
+
+        func waitUntilStarted() async {
+            guard !started else { return }
+            await withCheckedContinuation { continuation in
+                startedWaiters.append(continuation)
+            }
+        }
+
+        func release() {
+            guard !released else { return }
+            released = true
+            let waiters = releaseWaiters
+            releaseWaiters.removeAll()
+            for waiter in waiters {
+                waiter.resume()
+            }
+        }
+    }
+
+    private actor LimiterOrderRecorder {
+        private var recordedValues: [Int] = []
+
+        func append(_ value: Int) {
+            recordedValues.append(value)
+        }
+
+        func values() -> [Int] {
+            recordedValues
+        }
+    }
+
+    private actor LimiterTestFlag {
+        private var marked = false
+
+        func mark() {
+            marked = true
+        }
+
+        func isMarked() -> Bool {
+            marked
+        }
+    }
+
+    private actor LimiterSnapshotSignal {
+        typealias Snapshot = AsyncLimiter.DebugSnapshot
+
+        private var latest: Snapshot?
+        private var waiter: (
+            predicate: @Sendable (Snapshot) -> Bool,
+            continuation: CheckedContinuation<Snapshot, Never>
+        )?
+
+        func record(_ snapshot: Snapshot) {
+            latest = snapshot
+            guard let waiter, waiter.predicate(snapshot) else { return }
+            self.waiter = nil
+            waiter.continuation.resume(returning: snapshot)
+        }
+
+        func waitUntil(
+            _ predicate: @escaping @Sendable (Snapshot) -> Bool
+        ) async -> Snapshot {
+            if let latest, predicate(latest) {
+                return latest
+            }
+            return await withCheckedContinuation { continuation in
+                waiter = (predicate, continuation)
+            }
+        }
+    }
+#endif

--- a/Tests/RepoPromptTests/MCP/Control/InteractiveMCPClientSessionCancellationTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/InteractiveMCPClientSessionCancellationTests.swift
@@ -1,0 +1,201 @@
+import Foundation
+import MCP
+@testable import RepoPromptMCP
+import XCTest
+
+#if DEBUG
+    final class InteractiveMCPClientSessionCancellationTests: XCTestCase {
+        func testTimeoutSendsMCPRequestCancellationAndReturnsTimeout() async throws {
+            let timeoutTrigger = CLIAsyncSignal()
+            let fixture = try await makeFixture(
+                cancellationBehavior: .ignoreUntilReleased,
+                timeoutSleep: { _ in
+                    await timeoutTrigger.wait()
+                }
+            )
+            do {
+                let call = Task {
+                    try await fixture.session.callTool(
+                        name: "slow_tool",
+                        arguments: nil,
+                        timeout: .seconds(42)
+                    )
+                }
+                await fixture.handlerStarted.wait()
+                await timeoutTrigger.signal()
+
+                do {
+                    _ = try await call.value
+                    XCTFail("Expected tool timeout")
+                } catch let error as InteractiveSessionError {
+                    guard case let .toolCallTimeout(toolName, seconds) = error else {
+                        XCTFail("Expected tool timeout, got \(error)")
+                        await fixture.cleanup()
+                        return
+                    }
+                    XCTAssertEqual(toolName, "slow_tool")
+                    XCTAssertEqual(seconds, 42)
+                }
+
+                await fixture.handlerCancelled.wait()
+                await fixture.ignoredCancellationRelease.signal()
+                await fixture.cleanup()
+            } catch {
+                await fixture.cleanup()
+                throw error
+            }
+        }
+
+        func testCallerCancellationSendsMCPRequestCancellationAndReturnsCancellation() async throws {
+            let fixture = try await makeFixture()
+            do {
+                let call = Task {
+                    try await fixture.session.callTool(
+                        name: "slow_tool",
+                        arguments: nil,
+                        timeout: .none
+                    )
+                }
+                await fixture.handlerStarted.wait()
+                call.cancel()
+
+                do {
+                    _ = try await call.value
+                    XCTFail("Expected caller cancellation")
+                } catch is CancellationError {
+                    // Expected.
+                }
+
+                await fixture.handlerCancelled.wait()
+                await fixture.cleanup()
+            } catch {
+                await fixture.cleanup()
+                throw error
+            }
+        }
+
+        private func makeFixture(
+            cancellationBehavior: CLICancellationBehavior = .cooperative,
+            timeoutSleep: @escaping @Sendable (UInt64) async throws -> Void = { nanoseconds in
+                try await Task.sleep(nanoseconds: nanoseconds)
+            }
+        ) async throws -> CLISessionCancellationFixture {
+            let transports = await InMemoryTransport.createConnectedPair()
+            let handlerStarted = CLIAsyncSignal()
+            let handlerCancelled = CLIAsyncSignal()
+            let ignoredCancellationRelease = CLIAsyncSignal()
+            let cancellationSuspension = CLICancellationSuspension()
+            let server = Server(
+                name: "CLI cancellation test server",
+                version: "1.0",
+                capabilities: .init(tools: .init())
+            )
+            await server.withMethodHandler(CallTool.self) { _ in
+                await handlerStarted.signal()
+                do {
+                    try await cancellationSuspension.wait()
+                    return .init(
+                        content: [.text(text: "unexpected", annotations: nil, _meta: nil)],
+                        isError: false
+                    )
+                } catch is CancellationError {
+                    await handlerCancelled.signal()
+                    switch cancellationBehavior {
+                    case .cooperative:
+                        throw CancellationError()
+                    case .ignoreUntilReleased:
+                        await ignoredCancellationRelease.wait()
+                        return .init(
+                            content: [.text(text: "late result", annotations: nil, _meta: nil)],
+                            isError: false
+                        )
+                    }
+                }
+            }
+            try await server.start(transport: transports.server)
+
+            let client = Client(name: "CLI cancellation test client", version: "1.0")
+            _ = try await client.connect(transport: transports.client)
+            let session = InteractiveMCPClientSession(
+                connectedClientForTesting: client,
+                timeoutSleep: timeoutSleep
+            )
+            return CLISessionCancellationFixture(
+                client: client,
+                server: server,
+                session: session,
+                handlerStarted: handlerStarted,
+                handlerCancelled: handlerCancelled,
+                ignoredCancellationRelease: ignoredCancellationRelease
+            )
+        }
+    }
+
+    private enum CLICancellationBehavior {
+        case cooperative
+        case ignoreUntilReleased
+    }
+
+    private struct CLISessionCancellationFixture {
+        let client: Client
+        let server: Server
+        let session: InteractiveMCPClientSession
+        let handlerStarted: CLIAsyncSignal
+        let handlerCancelled: CLIAsyncSignal
+        let ignoredCancellationRelease: CLIAsyncSignal
+
+        func cleanup() async {
+            await ignoredCancellationRelease.signal()
+            await client.disconnect()
+            await server.stop()
+        }
+    }
+
+    private actor CLIAsyncSignal {
+        private var signalled = false
+        private var waiters: [CheckedContinuation<Void, Never>] = []
+
+        func signal() {
+            guard !signalled else { return }
+            signalled = true
+            let waiters = waiters
+            self.waiters.removeAll()
+            for waiter in waiters {
+                waiter.resume()
+            }
+        }
+
+        func wait() async {
+            guard !signalled else { return }
+            await withCheckedContinuation { continuation in
+                waiters.append(continuation)
+            }
+        }
+    }
+
+    private actor CLICancellationSuspension {
+        private struct Waiter {
+            let id: UUID
+            let continuation: CheckedContinuation<Void, Error>
+        }
+
+        private var waiter: Waiter?
+
+        func wait() async throws {
+            let waiterID = UUID()
+            try await withTaskCancellationHandler {
+                try await withCheckedThrowingContinuation { continuation in
+                    waiter = Waiter(id: waiterID, continuation: continuation)
+                }
+            } onCancel: {
+                Task { await self.cancel(waiterID) }
+            }
+        }
+
+        private func cancel(_ waiterID: UUID) {
+            guard let waiter, waiter.id == waiterID else { return }
+            self.waiter = nil
+            waiter.continuation.resume(throwing: CancellationError())
+        }
+    }
+#endif

--- a/Tests/RepoPromptTests/MCP/Control/InteractiveMCPClientSessionCancellationTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/InteractiveMCPClientSessionCancellationTests.swift
@@ -5,13 +5,10 @@ import XCTest
 
 #if DEBUG
     final class InteractiveMCPClientSessionCancellationTests: XCTestCase {
-        func testTimeoutSendsMCPRequestCancellationAndReturnsTimeout() async throws {
-            let timeoutTrigger = CLIAsyncSignal()
+        func testImmediateTimeoutRegistersAndSendsBeforeCancellationWithoutWaitingForHandlerStartup() async throws {
             let fixture = try await makeFixture(
                 cancellationBehavior: .ignoreUntilReleased,
-                timeoutSleep: { _ in
-                    await timeoutTrigger.wait()
-                }
+                timeoutSleep: { _ in }
             )
             do {
                 let call = Task {
@@ -21,9 +18,6 @@ import XCTest
                         timeout: .seconds(42)
                     )
                 }
-                await fixture.handlerStarted.wait()
-                await timeoutTrigger.signal()
-
                 do {
                     _ = try await call.value
                     XCTFail("Expected tool timeout")
@@ -46,8 +40,13 @@ import XCTest
             }
         }
 
-        func testCallerCancellationSendsMCPRequestCancellationAndReturnsCancellation() async throws {
-            let fixture = try await makeFixture()
+        func testCallerCancellationBeforeRequestTaskStartupStillSendsThenCancels() async throws {
+            let requestStartGate = CLIAsyncGate()
+            let fixture = try await makeFixture(
+                requestSendWillStart: {
+                    await requestStartGate.arriveAndWait()
+                }
+            )
             do {
                 let call = Task {
                     try await fixture.session.callTool(
@@ -56,8 +55,9 @@ import XCTest
                         timeout: .none
                     )
                 }
-                await fixture.handlerStarted.wait()
+                await requestStartGate.waitUntilArrived()
                 call.cancel()
+                await requestStartGate.release()
 
                 do {
                     _ = try await call.value
@@ -76,12 +76,12 @@ import XCTest
 
         private func makeFixture(
             cancellationBehavior: CLICancellationBehavior = .cooperative,
+            requestSendWillStart: (@Sendable () async -> Void)? = nil,
             timeoutSleep: @escaping @Sendable (UInt64) async throws -> Void = { nanoseconds in
                 try await Task.sleep(nanoseconds: nanoseconds)
             }
         ) async throws -> CLISessionCancellationFixture {
             let transports = await InMemoryTransport.createConnectedPair()
-            let handlerStarted = CLIAsyncSignal()
             let handlerCancelled = CLIAsyncSignal()
             let ignoredCancellationRelease = CLIAsyncSignal()
             let cancellationSuspension = CLICancellationSuspension()
@@ -91,7 +91,6 @@ import XCTest
                 capabilities: .init(tools: .init())
             )
             await server.withMethodHandler(CallTool.self) { _ in
-                await handlerStarted.signal()
                 do {
                     try await cancellationSuspension.wait()
                     return .init(
@@ -114,17 +113,24 @@ import XCTest
             }
             try await server.start(transport: transports.server)
 
+            let requestSendBarrier = MCPRequestSendBarrier()
+            let clientTransport = OrderedMCPTransport(
+                underlying: transports.client,
+                requestSendBarrier: requestSendBarrier,
+                logger: transports.client.logger
+            )
             let client = Client(name: "CLI cancellation test client", version: "1.0")
-            _ = try await client.connect(transport: transports.client)
+            _ = try await client.connect(transport: clientTransport)
             let session = InteractiveMCPClientSession(
                 connectedClientForTesting: client,
+                requestSendBarrier: requestSendBarrier,
+                requestSendWillStart: requestSendWillStart,
                 timeoutSleep: timeoutSleep
             )
             return CLISessionCancellationFixture(
                 client: client,
                 server: server,
                 session: session,
-                handlerStarted: handlerStarted,
                 handlerCancelled: handlerCancelled,
                 ignoredCancellationRelease: ignoredCancellationRelease
             )
@@ -140,7 +146,6 @@ import XCTest
         let client: Client
         let server: Server
         let session: InteractiveMCPClientSession
-        let handlerStarted: CLIAsyncSignal
         let handlerCancelled: CLIAsyncSignal
         let ignoredCancellationRelease: CLIAsyncSignal
 
@@ -148,6 +153,43 @@ import XCTest
             await ignoredCancellationRelease.signal()
             await client.disconnect()
             await server.stop()
+        }
+    }
+
+    private actor CLIAsyncGate {
+        private var arrived = false
+        private var released = false
+        private var arrivalWaiters: [CheckedContinuation<Void, Never>] = []
+        private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+
+        func arriveAndWait() async {
+            arrived = true
+            let arrivalWaiters = arrivalWaiters
+            self.arrivalWaiters.removeAll()
+            for waiter in arrivalWaiters {
+                waiter.resume()
+            }
+            guard !released else { return }
+            await withCheckedContinuation { continuation in
+                releaseWaiters.append(continuation)
+            }
+        }
+
+        func waitUntilArrived() async {
+            guard !arrived else { return }
+            await withCheckedContinuation { continuation in
+                arrivalWaiters.append(continuation)
+            }
+        }
+
+        func release() {
+            guard !released else { return }
+            released = true
+            let releaseWaiters = releaseWaiters
+            self.releaseWaiters.removeAll()
+            for waiter in releaseWaiters {
+                waiter.resume()
+            }
         }
     }
 
@@ -180,12 +222,17 @@ import XCTest
         }
 
         private var waiter: Waiter?
+        private var cancelledWaiterIDs: Set<UUID> = []
 
         func wait() async throws {
             let waiterID = UUID()
             try await withTaskCancellationHandler {
-                try await withCheckedThrowingContinuation { continuation in
-                    waiter = Waiter(id: waiterID, continuation: continuation)
+                try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                    if Task.isCancelled || cancelledWaiterIDs.remove(waiterID) != nil {
+                        continuation.resume(throwing: CancellationError())
+                    } else {
+                        waiter = Waiter(id: waiterID, continuation: continuation)
+                    }
                 }
             } onCancel: {
                 Task { await self.cancel(waiterID) }
@@ -193,7 +240,10 @@ import XCTest
         }
 
         private func cancel(_ waiterID: UUID) {
-            guard let waiter, waiter.id == waiterID else { return }
+            guard let waiter, waiter.id == waiterID else {
+                cancelledWaiterIDs.insert(waiterID)
+                return
+            }
             self.waiter = nil
             waiter.continuation.resume(throwing: CancellationError())
         }

--- a/Tests/RepoPromptTests/MCP/Control/PersistentAgentModeMCPReadFileConnectionTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/PersistentAgentModeMCPReadFileConnectionTests.swift
@@ -551,6 +551,14 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
             )
             XCTAssertEqual(snapshot.handshake.appliedPolicy?.purpose, .agentModeRun)
             XCTAssertEqual(snapshot.handshake.appliedPolicy?.windowID, fixture.windowID)
+            XCTAssertEqual(snapshot.limiter?.limit, 1)
+            XCTAssertEqual(snapshot.limiter?.permits, 1)
+            XCTAssertEqual(snapshot.limiter?.activePermitCount, 0)
+            XCTAssertEqual(snapshot.limiter?.waiterCount, 0)
+            XCTAssertEqual(snapshot.limiter?.inFlight, 0)
+            XCTAssertEqual(snapshot.limiter?.cancelledWaiterCount, 0)
+            XCTAssertEqual(snapshot.limiter?.isClosed, false)
+            XCTAssertEqual(snapshot.limiter?.isIdle, true)
         }
 
         static func assertSuccessfulResponse(_ rawJSON: String, id: Int) throws {
@@ -729,6 +737,9 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
                     parentManager: ServerNetworkManager.shared
                 )
                 connectionManager = resolvedConnectionManager
+                _ = await ServerNetworkManager.shared.debugInstallConnectionLimiterForTesting(
+                    connectionID: connectionID
+                )
                 let spec = MCPBootstrapLeaseSpec.agentMode(
                     tabID: tabID,
                     runID: runID,
@@ -801,6 +812,9 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
             let pendingPolicyCount = await networkManager.debugPendingPolicySnapshot(
                 for: AgentProviderKind.codexMCPClientID
             ).count
+            let limiter = await networkManager.connectionLimiterSnapshotForTesting(
+                connectionID: Self.connectionID
+            )
             return await RetainedConnectionSnapshot(
                 connectionID: Self.connectionID,
                 capabilityToken: connectionManager.capabilityToken,
@@ -827,7 +841,8 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
                 pendingPolicyCount: pendingPolicyCount,
                 binding: window.mcpServer.connectionBindingSnapshot(forConnection: Self.connectionID),
                 mappedConnectionID: window.mcpServer.connectionID(forRunID: Self.runID),
-                handshake: handshakeRecorder.snapshot()
+                handshake: handshakeRecorder.snapshot(),
+                limiter: limiter
             )
         }
 
@@ -838,6 +853,10 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
             await connectionManager.stop()
             socketClient.close()
             await networkManager.removeConnection(Self.connectionID)
+            let limiterAfterRemoval = await networkManager.connectionLimiterSnapshotForTesting(
+                connectionID: Self.connectionID
+            )
+            XCTAssertNil(limiterAfterRemoval)
             await networkManager.clearExpectedAgentPID(
                 getpid(),
                 for: AgentProviderKind.codexMCPClientID,
@@ -883,6 +902,7 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
         let binding: MCPServerViewModel.ConnectionBindingSnapshot
         let mappedConnectionID: UUID?
         let handshake: HandshakeRecorder.Snapshot
+        let limiter: AsyncLimiter.DebugSnapshot?
     }
 
     private struct ConnectionPolicySnapshot: Equatable {

--- a/Tests/RepoPromptTests/MCP/Control/PersistentMCPDistinctConnectionConcurrencyTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/PersistentMCPDistinctConnectionConcurrencyTests.swift
@@ -61,19 +61,6 @@ final class PersistentMCPDistinctConnectionConcurrencyTests: XCTestCase {
             throw XCTSkip("Exact persisted routing session cleanup diagnostics require DEBUG helpers.")
         #endif
     }
-
-    func testRemoveConnectionSourceStillDropsPerConnectionLimiter() throws {
-        let sourceURL = try RepoRoot.url()
-            .appendingPathComponent("Sources/RepoPrompt/Infrastructure/MCP/MCPConnectionManager.swift")
-        let source = try String(contentsOf: sourceURL, encoding: .utf8)
-        let start = try XCTUnwrap(source.range(of: "func removeConnection(_ id: UUID) async {"))
-        let end = try XCTUnwrap(source.range(
-            of: "/// Reads the cached TCP client name",
-            range: start.upperBound ..< source.endIndex
-        ))
-        let body = String(source[start.lowerBound ..< end.lowerBound])
-        XCTAssertTrue(body.contains("callLimiters[id] = nil"), body)
-    }
 }
 
 #if DEBUG

--- a/Tests/RepoPromptTests/MCP/MCPReadSearchLatencyDiagnosticsGuardTests.swift
+++ b/Tests/RepoPromptTests/MCP/MCPReadSearchLatencyDiagnosticsGuardTests.swift
@@ -106,6 +106,175 @@
             XCTAssertNotNil(scheduler["overload_count"])
         }
 
+        func testLimiterDiagnosticsReportPromptQueuedCancellationAndIdleState() async {
+            let clock = LockedMCPDiagnosticsClock(nowNanoseconds: 1_000_000_000)
+            let limiter = AsyncLimiter(limit: 1, debugNowNanoseconds: { clock.now() })
+            let holderGate = MCPDiagnosticsGate()
+            let waiterBodyRan = MCPDiagnosticsSignal()
+            let snapshotSignal = MCPDiagnosticsSnapshotSignal()
+            await limiter.setDebugStateObserver { snapshot in
+                Task { await snapshotSignal.record(snapshot) }
+            }
+
+            let holder = Task {
+                try await limiter.withPermit {
+                    await holderGate.markStartedAndWaitForRelease()
+                }
+            }
+            await holderGate.waitUntilStarted()
+
+            let waiter = Task {
+                do {
+                    try await limiter.withPermit {
+                        await waiterBodyRan.mark()
+                    }
+                    return false
+                } catch is CancellationError {
+                    return true
+                } catch {
+                    return false
+                }
+            }
+
+            let queued = await snapshotSignal.waitUntil { $0.waiterCount == 1 }
+            XCTAssertEqual(queued.limit, 1)
+            XCTAssertEqual(queued.permits, 0)
+            XCTAssertEqual(queued.activePermitCount, 1)
+            XCTAssertEqual(queued.waiterCount, 1)
+            XCTAssertEqual(queued.inFlight, 2)
+            XCTAssertEqual(queued.oldestWaiterAgeMilliseconds, 0)
+            XCTAssertFalse(queued.isClosed)
+            XCTAssertFalse(queued.isIdle)
+
+            clock.advance(milliseconds: 275)
+            let aged = await limiter.debugSnapshot()
+            XCTAssertEqual(aged.oldestWaiterAgeMilliseconds, 275)
+
+            waiter.cancel()
+            let cancelled = await snapshotSignal.waitUntil {
+                $0.cancelledWaiterCount == 1 && $0.waiterCount == 0 && $0.inFlight == 1
+            }
+            XCTAssertEqual(cancelled.waiterCount, 0)
+            XCTAssertEqual(cancelled.cancelledWaiterCount, 1)
+            let waiterWasCancelled = await waiter.value
+            let didRunWaiterBody = await waiterBodyRan.isMarked()
+            XCTAssertTrue(waiterWasCancelled)
+            XCTAssertFalse(didRunWaiterBody)
+
+            await holderGate.release()
+            try? await holder.value
+
+            let settled = await snapshotSignal.waitUntil { $0.isIdle }
+            XCTAssertEqual(settled.permits, 1)
+            XCTAssertEqual(settled.activePermitCount, 0)
+            XCTAssertEqual(settled.waiterCount, 0)
+            XCTAssertEqual(settled.inFlight, 0)
+            XCTAssertNil(settled.oldestWaiterAgeMilliseconds)
+            XCTAssertEqual(settled.cancelledWaiterCount, 1)
+            XCTAssertFalse(settled.isClosed)
+            XCTAssertTrue(settled.isIdle)
+            await limiter.setDebugStateObserver(nil)
+        }
+
+        @MainActor
+        func testRuntimeSnapshotHiddenOperationValidatesBoundsAndReturnsAggregateShape() async throws {
+            let manager = ServerNetworkManager.shared
+            let connectionID = UUID()
+            let runID = UUID()
+            await manager.registerToolCallObserver(for: runID) { _ in }
+            await manager.registerToolEventObserver(
+                for: runID,
+                observer: ServerNetworkManager.ToolEventObserver(onCalled: { _, _, _ in }, onCompleted: nil)
+            )
+            addTeardownBlock {
+                await manager.unregisterToolObservers(for: runID)
+            }
+
+            let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
+            GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
+            let window = WindowState()
+            WindowStatesManager.shared.registerWindowState(window)
+            GlobalSettingsStore.shared.setMCPAutoStart(previousAutoStart, commit: false)
+            addTeardownBlock { @MainActor in
+                window.beginClose()
+                await window.tearDown()
+                WindowStatesManager.shared.unregisterWindowState(window)
+            }
+
+            let expectedToolCallObserverCount = await manager.toolCallObserverCount()
+            let expectedToolEventObserverCount = await manager.toolEventObserverCount()
+            let result = await manager.handleDebugDiagnosticsTool(
+                connectionID: connectionID,
+                arguments: [
+                    "op": .string("mcp_read_search_runtime_snapshot"),
+                    "window_id": .int(window.windowID),
+                    "recent_publication_limit": .int(0),
+                    "root_limit": .int(1)
+                ]
+            )
+            let payload = try debugDiagnosticsPayload(result)
+            XCTAssertEqual(payload["ok"] as? Bool, true)
+            XCTAssertEqual(payload["op"] as? String, "mcp_read_search_runtime_snapshot")
+            let runtime = try XCTUnwrap(payload["runtime"] as? [String: Any])
+            XCTAssertEqual(runtime["consistency"] as? String, "best_effort")
+            XCTAssertEqual((runtime["window_count"] as? NSNumber)?.intValue, 1)
+            let observers = try XCTUnwrap(runtime["observers"] as? [String: Any])
+            XCTAssertEqual(
+                (observers["tool_call_observer_count"] as? NSNumber)?.intValue,
+                expectedToolCallObserverCount
+            )
+            XCTAssertEqual(
+                (observers["tool_event_observer_count"] as? NSNumber)?.intValue,
+                expectedToolEventObserverCount
+            )
+            let windows = try XCTUnwrap(runtime["windows"] as? [[String: Any]])
+            let windowPayload = try XCTUnwrap(windows.first)
+            XCTAssertEqual((windowPayload["window_id"] as? NSNumber)?.intValue, window.windowID)
+            XCTAssertNotNil(windowPayload["projection_direct_file_id_lookup_count"])
+            XCTAssertNotNil(windowPayload["projection_direct_folder_id_lookup_count"])
+            XCTAssertNotNil(windowPayload["projection_direct_id_lookup_miss_count"])
+            XCTAssertNotNil(windowPayload["projection_canonical_resync_count"])
+            let autoSelection = try XCTUnwrap(windowPayload["read_file_auto_selection"] as? [String: Any])
+            for key in [
+                "canonical_lane_count",
+                "canonical_worker_count",
+                "mirror_lane_count",
+                "mirror_worker_count",
+                "closing_context_count",
+                "pending_canonical_batch_count",
+                "pending_mirror_batch_count"
+            ] {
+                XCTAssertEqual((autoSelection[key] as? NSNumber)?.intValue, 0, key)
+            }
+            let limiter = try XCTUnwrap(runtime["limiter"] as? [String: Any])
+            XCTAssertEqual(limiter["found"] as? Bool, false)
+            XCTAssertEqual(limiter["connection_id"] as? String, connectionID.uuidString)
+
+            for invalidArguments: [String: Value] in [
+                [
+                    "op": .string("mcp_read_search_runtime_snapshot"),
+                    "connection_id": .string("not-a-uuid")
+                ],
+                [
+                    "op": .string("mcp_read_search_runtime_snapshot"),
+                    "recent_publication_limit": .int(33)
+                ],
+                [
+                    "op": .string("mcp_read_search_runtime_snapshot"),
+                    "root_limit": .int(0)
+                ]
+            ] {
+                let invalidResult = await manager.handleDebugDiagnosticsTool(
+                    connectionID: connectionID,
+                    arguments: invalidArguments
+                )
+                let invalidPayload = try debugDiagnosticsPayload(invalidResult)
+                XCTAssertEqual(invalidPayload["ok"] as? Bool, false)
+                XCTAssertEqual(invalidPayload["op"] as? String, "mcp_read_search_runtime_snapshot")
+                XCTAssertEqual(invalidPayload["code"] as? String, "invalid_params")
+            }
+        }
+
         func testExpectedAttributionStagesRemainPresent() throws {
             let perf = try source("Sources/RepoPrompt/Infrastructure/Diffing/EditFlowPerf.swift")
             for stage in [
@@ -243,10 +412,10 @@
             }
 
             let limiterBegin = try XCTUnwrap(manager.range(of: "let limiterWaitState = EditFlowPerf.begin("))
-            let withPermit = try XCTUnwrap(manager.range(of: "return await limiter.withPermit {", range: limiterBegin.upperBound ..< manager.endIndex))
-            let limiterEnd = try XCTUnwrap(manager.range(of: "EditFlowPerf.end(EditFlowPerf.Stage.MCPToolCall.limiterWait, limiterWaitState)", range: withPermit.upperBound ..< manager.endIndex))
-            XCTAssertLessThan(limiterBegin.lowerBound, withPermit.lowerBound)
-            XCTAssertLessThan(withPermit.lowerBound, limiterEnd.lowerBound)
+            let limiterEnd = try XCTUnwrap(manager.range(of: "defer { EditFlowPerf.end(EditFlowPerf.Stage.MCPToolCall.limiterWait, limiterWaitState) }", range: limiterBegin.upperBound ..< manager.endIndex))
+            let withPermit = try XCTUnwrap(manager.range(of: "return await limiter.withPermit(", range: limiterEnd.upperBound ..< manager.endIndex))
+            XCTAssertLessThan(limiterBegin.lowerBound, limiterEnd.lowerBound)
+            XCTAssertLessThan(limiterEnd.lowerBound, withPermit.lowerBound)
 
             let lookupBegin = try XCTUnwrap(manager.range(of: "let serviceToolLookupState = EditFlowPerf.begin("))
             let directInvocation = try XCTUnwrap(manager.range(of: "toolDef.callAsFunction(effectiveArgs)", range: lookupBegin.upperBound ..< manager.endIndex))
@@ -424,8 +593,8 @@
                 "endPreLimiterEnvelopeIfNeeded()",
                 "EditFlowPerf.Stage.MCPToolCall.limiterEnvelope",
                 "let limiterWaitState = EditFlowPerf.begin(",
-                "await limiter.withPermit {",
-                "EditFlowPerf.end(EditFlowPerf.Stage.MCPToolCall.limiterWait, limiterWaitState)",
+                "defer { EditFlowPerf.end(EditFlowPerf.Stage.MCPToolCall.limiterWait, limiterWaitState) }",
+                "await limiter.withPermit(",
                 "EditFlowPerf.Stage.MCPToolCall.permitBodyEnvelope",
                 "let permitPreDispatchEnvelopeState = EditFlowPerf.begin(",
                 "EditFlowPerf.Stage.MCPToolCall.enabledStateSnapshot",
@@ -1501,7 +1670,6 @@
             XCTAssertTrue(store.contains("private static let maxCachedSearchCatalogSnapshotScopes = 16"))
             XCTAssertTrue(store.contains("private var searchCatalogSnapshotsByScope: [WorkspaceLookupRootScope: SearchCatalogSnapshotCacheEntry] = [:]"))
             XCTAssertTrue(store.contains("case .sessionBoundWorkspace:\n            scopedSnapshotGeneration(scope: .allLoaded)"))
-            XCTAssertTrue(store.contains("private func clearSearchCatalogSnapshotCache() {\n        searchCatalogSnapshotsByScope.removeAll(keepingCapacity: true)\n    }"))
             XCTAssertTrue(store.contains("rootStatesByID[originalRootID] = state\n            clearSearchCatalogSnapshotCache()\n            indexed.append(fullPath)"))
             assertSourceOrder(
                 in: store,
@@ -2147,7 +2315,7 @@
                     "EditFlowPerf.Lifecycle.MCPToolCall.received",
                     "EditFlowPerf.Lifecycle.MCPToolCall.routingSnapshotCompleted",
                     "EditFlowPerf.Lifecycle.MCPToolCall.limiterWaitBegan",
-                    "return await limiter.withPermit {",
+                    "return await limiter.withPermit(",
                     "EditFlowPerf.Lifecycle.MCPToolCall.limiterAcquired",
                     "Self.withConnectionID(connectionID, lifecycleCorrelation: lifecycleCorrelation)"
                 ]
@@ -2183,7 +2351,7 @@
                     "EditFlowPerf.Lifecycle.FileSystem.callbackAccepted",
                     "func drainAcceptedWatcherIngressMailbox()",
                     "EditFlowPerf.Lifecycle.FileSystem.serviceEnqueueEntered",
-                    "watcherAcceptedWatermark: batch.watcherAcceptedHighWatermark"
+                    "watcherAcceptedWatermark: publishableWatcherWatermark"
                 ]
             )
 
@@ -2238,7 +2406,7 @@
                 in: server,
                 hooks: [
                     "let readableService = WorkspaceReadableFileService(store: store)",
-                    "await readableService.awaitFreshnessForExplicitRequest(path, fallbackScope: lookupRootScope)",
+                    "try await readableService.awaitFreshnessForExplicitRequest(path, fallbackScope: lookupRootScope)",
                     "let exactPathIssueDetection = EditFlowPerf.begin(EditFlowPerf.Stage.ReadFile.exactPathIssueDetection)"
                 ]
             )
@@ -2264,8 +2432,98 @@
             XCTAssertFalse(fsevents.contains("changePublisher.send"))
             XCTAssertFalse(operations.contains("changePublisher.send"))
             XCTAssertTrue(fsevents.contains("source: .watcherBarrierNoop"))
-            XCTAssertTrue(fsevents.contains("watcherAcceptedWatermark: batch.watcherAcceptedHighWatermark"))
+            XCTAssertTrue(fsevents.contains("watcherAcceptedWatermark: publishableWatcherWatermark"))
             XCTAssertEqual(operations.components(separatedBy: "source: .syntheticMutation").count - 1, 5)
+        }
+
+        private actor MCPDiagnosticsGate {
+            private var started = false
+            private var released = false
+            private var startWaiters: [CheckedContinuation<Void, Never>] = []
+            private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+
+            func markStartedAndWaitForRelease() async {
+                started = true
+                let pendingStartWaiters = startWaiters
+                startWaiters.removeAll()
+                pendingStartWaiters.forEach { $0.resume() }
+                guard !released else { return }
+                await withCheckedContinuation { continuation in
+                    releaseWaiters.append(continuation)
+                }
+            }
+
+            func waitUntilStarted() async {
+                guard !started else { return }
+                await withCheckedContinuation { continuation in
+                    startWaiters.append(continuation)
+                }
+            }
+
+            func release() {
+                released = true
+                let pendingReleaseWaiters = releaseWaiters
+                releaseWaiters.removeAll()
+                pendingReleaseWaiters.forEach { $0.resume() }
+            }
+        }
+
+        private actor MCPDiagnosticsSignal {
+            private var marked = false
+
+            func mark() {
+                marked = true
+            }
+
+            func isMarked() -> Bool {
+                marked
+            }
+        }
+
+        private actor MCPDiagnosticsSnapshotSignal {
+            typealias Snapshot = AsyncLimiter.DebugSnapshot
+            private var latest: Snapshot?
+            private var waiter: (
+                predicate: @Sendable (Snapshot) -> Bool,
+                continuation: CheckedContinuation<Snapshot, Never>
+            )?
+
+            func record(_ snapshot: Snapshot) {
+                latest = snapshot
+                guard let waiter, waiter.predicate(snapshot) else { return }
+                self.waiter = nil
+                waiter.continuation.resume(returning: snapshot)
+            }
+
+            func waitUntil(
+                _ predicate: @escaping @Sendable (Snapshot) -> Bool
+            ) async -> Snapshot {
+                if let latest, predicate(latest) { return latest }
+                return await withCheckedContinuation { continuation in
+                    waiter = (predicate, continuation)
+                }
+            }
+        }
+
+        private final class LockedMCPDiagnosticsClock: @unchecked Sendable {
+            private let lock = NSLock()
+            private var value: UInt64
+
+            init(nowNanoseconds: UInt64) {
+                value = nowNanoseconds
+            }
+
+            func now() -> UInt64 {
+                lock.lock()
+                defer { lock.unlock() }
+                return value
+            }
+
+            func advance(milliseconds: UInt64) {
+                lock.lock()
+                value &+= milliseconds * 1_000_000
+                lock.unlock()
+            }
         }
 
         private final class LockedCorrelationIDs: @unchecked Sendable {

--- a/Tests/RepoPromptTests/Services/FileSystem/FileSystemServiceRecoveryTests.swift
+++ b/Tests/RepoPromptTests/Services/FileSystem/FileSystemServiceRecoveryTests.swift
@@ -131,12 +131,13 @@ final class FileSystemServiceRecoveryTests: XCTestCase {
             }
             var latestWatermark = initialWatermark
             for eventID in 2 ... 4 {
+                // Keep churn paths absent so every accepted event deterministically requires parent verification.
                 let churnURL = root.appendingPathComponent("A/churn-\(eventID).txt")
-                try "churn".write(to: churnURL, atomically: true, encoding: .utf8)
                 let churnWatermark = await service.acceptWatcherPayloadForTesting([
                     (absolutePath: churnURL.path, flags: flags, eventId: FSEventStreamEventId(eventID))
-                ])
+                ], scheduleDrain: false)
                 latestWatermark = try XCTUnwrap(churnWatermark)
+                await service.drainAcceptedWatcherIngressMailbox()
                 await batchGate.releaseNext()
                 if eventID < 4 {
                     await batchGate.waitUntilStartCount(Int(eventID))
@@ -152,8 +153,11 @@ final class FileSystemServiceRecoveryTests: XCTestCase {
             let state = await service.getCoalescingState()
             let publication = await service.publicationStateForTesting()
 
-            XCTAssertEqual(Array(batches.prefix(3)).flatMap(\.self), folders)
-            XCTAssertGreaterThanOrEqual(batches.flatMap(\.self).count(where: { $0 == "A" }), 2)
+            let processedFolders = batches.flatMap(\.self)
+            XCTAssertEqual(Array(processedFolders.prefix(2)), ["A", "B"])
+            let firstCBatchIndex = try XCTUnwrap(batches.firstIndex(where: { $0.contains("C") }))
+            XCTAssertLessThanOrEqual(firstCBatchIndex, 3)
+            XCTAssertGreaterThanOrEqual(processedFolders.count(where: { $0 == "A" }), 2)
             XCTAssertGreaterThan(intermediateSequence, 0)
             XCTAssertGreaterThanOrEqual(finalSequence, intermediateSequence)
             XCTAssertTrue(state.pendingScanTargets.isEmpty)

--- a/Tests/RepoPromptTests/Services/FileSystem/FileSystemServiceRecoveryTests.swift
+++ b/Tests/RepoPromptTests/Services/FileSystem/FileSystemServiceRecoveryTests.swift
@@ -1,3 +1,4 @@
+import CoreServices
 @testable import RepoPrompt
 import XCTest
 
@@ -30,4 +31,57 @@ final class FileSystemServiceRecoveryTests: XCTestCase {
         XCTAssertEqual(loaded.content, "second")
         XCTAssertGreaterThan(loaded.modificationDate.timeIntervalSince1970, 0)
     }
+
+    #if DEBUG
+        func testFolderScanCapSchedulesQuietFollowUpBatchesThroughAcceptedWatermark() async throws {
+            let root = try temporaryRoots.makeRoot(suiteName: "FileSystemFolderScanCap")
+            let folders = ["A", "B", "C"]
+            for folder in folders {
+                let folderURL = root.appendingPathComponent(folder, isDirectory: true)
+                try FileManager.default.createDirectory(at: folderURL, withIntermediateDirectories: true)
+                try "new".write(
+                    to: folderURL.appendingPathComponent("new.txt"),
+                    atomically: true,
+                    encoding: .utf8
+                )
+            }
+
+            let service = try await FileSystemService(
+                path: root.path,
+                respectGitignore: false,
+                respectRepoIgnore: false,
+                respectCursorignore: false,
+                skipSymlinks: true,
+                enableHierarchicalIgnores: false,
+                testVisitedPaths: Set(folders),
+                testVisitedItems: Dictionary(uniqueKeysWithValues: folders.map { ($0, true) }),
+                isTestMode: true,
+                maxFoldersPerBatchOverride: 2
+            )
+            let flags = FSEventStreamEventFlags(
+                kFSEventStreamEventFlagItemCreated | kFSEventStreamEventFlagItemIsFile
+            )
+            let watermarkValue = await service.acceptWatcherPayloadForTesting(folders.map { folder in
+                (
+                    absolutePath: root.appendingPathComponent("\(folder)/new.txt").path,
+                    flags: flags,
+                    eventId: 1
+                )
+            })
+            let watermark = try XCTUnwrap(watermarkValue)
+
+            _ = await service.flushPendingEventsNow(throughAcceptedWatcherWatermark: watermark)
+
+            let processed = await service.getProcessedFolders()
+            let state = await service.getCoalescingState()
+            let publication = await service.publicationStateForTesting()
+            XCTAssertEqual(processed, Set(folders))
+            XCTAssertTrue(state.pendingScanTargets.isEmpty)
+            XCTAssertEqual(
+                state.lastScannedEventIdByFolder,
+                Dictionary(uniqueKeysWithValues: folders.map { ($0, FSEventStreamEventId(1)) })
+            )
+            XCTAssertEqual(publication.lastPublishedWatcherAcceptedWatermark, watermark)
+        }
+    #endif
 }

--- a/Tests/RepoPromptTests/Services/FileSystem/FileSystemServiceRecoveryTests.swift
+++ b/Tests/RepoPromptTests/Services/FileSystem/FileSystemServiceRecoveryTests.swift
@@ -83,5 +83,131 @@ final class FileSystemServiceRecoveryTests: XCTestCase {
             )
             XCTAssertEqual(publication.lastPublishedWatcherAcceptedWatermark, watermark)
         }
+
+        func testCarryOverFolderScansPreserveIntermediateWatermarkUnderContinuousChurn() async throws {
+            let root = try temporaryRoots.makeRoot(suiteName: "FileSystemFolderScanFairness")
+            let folders = ["A", "B", "C"]
+            for folder in folders {
+                let folderURL = root.appendingPathComponent(folder, isDirectory: true)
+                try FileManager.default.createDirectory(at: folderURL, withIntermediateDirectories: true)
+                try "initial".write(
+                    to: folderURL.appendingPathComponent("initial.txt"),
+                    atomically: true,
+                    encoding: .utf8
+                )
+            }
+
+            let service = try await FileSystemService(
+                path: root.path,
+                respectGitignore: false,
+                respectRepoIgnore: false,
+                respectCursorignore: false,
+                skipSymlinks: true,
+                enableHierarchicalIgnores: false,
+                testVisitedPaths: Set(folders),
+                testVisitedItems: Dictionary(uniqueKeysWithValues: folders.map { ($0, true) }),
+                isTestMode: true,
+                maxFoldersPerBatchOverride: 1
+            )
+            let batchGate = SteppedBatchGate()
+            await service.setWatcherBatchWillProcessHandlerForTesting {
+                await batchGate.markStartedAndWaitForRelease()
+            }
+            let flags = FSEventStreamEventFlags(
+                kFSEventStreamEventFlagItemCreated | kFSEventStreamEventFlagItemIsFile
+            )
+            let initialWatermarkValue = await service.acceptWatcherPayloadForTesting(folders.map { folder in
+                (
+                    absolutePath: root.appendingPathComponent("\(folder)/initial.txt").path,
+                    flags: flags,
+                    eventId: 1
+                )
+            })
+            let initialWatermark = try XCTUnwrap(initialWatermarkValue)
+            await batchGate.waitUntilStartCount(1)
+
+            let intermediateFlush = Task {
+                await service.flushPendingEventsNow(throughAcceptedWatcherWatermark: initialWatermark)
+            }
+            var latestWatermark = initialWatermark
+            for eventID in 2 ... 4 {
+                let churnURL = root.appendingPathComponent("A/churn-\(eventID).txt")
+                try "churn".write(to: churnURL, atomically: true, encoding: .utf8)
+                let churnWatermark = await service.acceptWatcherPayloadForTesting([
+                    (absolutePath: churnURL.path, flags: flags, eventId: FSEventStreamEventId(eventID))
+                ])
+                latestWatermark = try XCTUnwrap(churnWatermark)
+                await batchGate.releaseNext()
+                if eventID < 4 {
+                    await batchGate.waitUntilStartCount(Int(eventID))
+                }
+            }
+            await batchGate.releaseAll()
+
+            let intermediateSequence = await intermediateFlush.value
+            let finalSequence = await service.flushPendingEventsNow(
+                throughAcceptedWatcherWatermark: latestWatermark
+            )
+            let batches = await service.getProcessedFolderBatches()
+            let state = await service.getCoalescingState()
+            let publication = await service.publicationStateForTesting()
+
+            XCTAssertEqual(Array(batches.prefix(3)).flatMap(\.self), folders)
+            XCTAssertGreaterThanOrEqual(batches.flatMap(\.self).count(where: { $0 == "A" }), 2)
+            XCTAssertGreaterThan(intermediateSequence, 0)
+            XCTAssertGreaterThanOrEqual(finalSequence, intermediateSequence)
+            XCTAssertTrue(state.pendingScanTargets.isEmpty)
+            XCTAssertEqual(state.lastScannedEventIdByFolder["A"], 4)
+            XCTAssertEqual(state.lastScannedEventIdByFolder["B"], 1)
+            XCTAssertEqual(state.lastScannedEventIdByFolder["C"], 1)
+            XCTAssertEqual(publication.lastPublishedWatcherAcceptedWatermark, latestWatermark)
+            await service.setWatcherBatchWillProcessHandlerForTesting(nil)
+        }
+
+        private actor SteppedBatchGate {
+            private var startCount = 0
+            private var releasePermits = 0
+            private var releasesAllBatches = false
+            private var startWaiters: [(target: Int, continuation: CheckedContinuation<Void, Never>)] = []
+            private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+
+            func markStartedAndWaitForRelease() async {
+                startCount += 1
+                let readyWaiters = startWaiters.filter { $0.target <= startCount }
+                startWaiters.removeAll { $0.target <= startCount }
+                readyWaiters.forEach { $0.continuation.resume() }
+
+                if releasesAllBatches { return }
+                if releasePermits > 0 {
+                    releasePermits -= 1
+                    return
+                }
+                await withCheckedContinuation { continuation in
+                    releaseWaiters.append(continuation)
+                }
+            }
+
+            func waitUntilStartCount(_ target: Int) async {
+                guard startCount < target else { return }
+                await withCheckedContinuation { continuation in
+                    startWaiters.append((target, continuation))
+                }
+            }
+
+            func releaseNext() {
+                if releaseWaiters.isEmpty {
+                    releasePermits += 1
+                } else {
+                    releaseWaiters.removeFirst().resume()
+                }
+            }
+
+            func releaseAll() {
+                releasesAllBatches = true
+                let waiters = releaseWaiters
+                releaseWaiters.removeAll()
+                waiters.forEach { $0.resume() }
+            }
+        }
     #endif
 }

--- a/Tests/RepoPromptTests/WorkspaceContext/ReplayEvidenceHarnessTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/ReplayEvidenceHarnessTests.swift
@@ -5,30 +5,49 @@ import XCTest
     final class ReplayEvidenceHarnessTests: XCTestCase {
         @MainActor
         func testFocusedLargeBurstRoutesImmediateWithCappedDefaultChunks() async {
-            let root = makeRootFolder(name: "ImmediateRoute")
-            let vm = WorkspaceFilesViewModel()
-            vm.registerRootFolderForTesting(root)
-            _ = await vm.ensureReplayIngressRegistrationForTesting(forRootFolder: root)
-            vm.resetReplayPerfSamplesForTesting()
+            let rootKey = makeRootFolder(name: "ImmediateRoute").standardizedFullPath
+            let buffer = DeferredReplayBufferActor(maxPendingDeltasPerRoot: 10000)
+            let rootGeneration: UInt64 = 1
+            await buffer.registerActiveRootGeneration(rootGeneration, forRootKey: rootKey)
+            await buffer.updateRoutingState(
+                isWindowFocused: true,
+                isReplayActive: false,
+                routingVersion: 1
+            )
 
             let deltas = (0 ..< 600).map { FileSystemDelta.fileAdded("file-\($0).swift") }
-            await vm.receiveLiveFileSystemDeltasForTesting(deltas, forRootFolder: root)
+            let ingress = await buffer.ingestLiveDeltas(
+                deltas,
+                forRootKey: rootKey,
+                rootGeneration: rootGeneration
+            )
+            let immediate: PreparedImmediateReplay
+            switch ingress {
+            case let .preparedImmediate(prepared):
+                immediate = prepared
+            case .queued, .overflowRequiresRefresh, .droppedWhileOverflowed, .droppedStaleGeneration:
+                XCTFail("Expected focused burst to prepare immediate replay work")
+                return
+            }
 
-            let diagnostics = await vm.deferredReplayBufferDiagnosticsForTesting()
-            let sample = vm.latestImmediateReplayPerfSampleForTesting()
+            XCTAssertEqual(immediate.rootKey, rootKey)
+            XCTAssertEqual(immediate.rootGeneration, rootGeneration)
+            XCTAssertEqual(immediate.sourceDeltas.count, 600)
+            XCTAssertEqual(immediate.preparedBatch.queuedDeltaCount, 600)
+            XCTAssertEqual(immediate.preparedBatch.coalescedDeltaCount, 600)
+            XCTAssertEqual(immediate.preparedBatch.preparedDeltas.count, 600)
+            XCTAssertEqual(immediate.preparedBatch.chunks.map(\.deltaCount), [100, 100, 100, 100, 100, 100])
+            XCTAssertEqual(immediate.preparedBatch.chunks.reduce(0) { $0 + $1.summary.fileAddedCount }, 600)
+
+            var diagnostics = await buffer.diagnosticsSnapshot()
+            XCTAssertTrue(diagnostics.immediatePreparedIngressInFlight)
             XCTAssertEqual(diagnostics.immediateIngressCount, 1)
             XCTAssertEqual(diagnostics.deferredIngressCount, 0)
-            XCTAssertEqual(sample?.queuedDeltaCount, 600)
-            XCTAssertEqual(sample?.coalescedDeltaCount, 600)
-            XCTAssertEqual(sample?.chunkCount, 6)
-            XCTAssertEqual(sample?.replayedChunks.map(\.chunkDeltaCount), [100, 100, 100, 100, 100, 100])
-            XCTAssertEqual(sample?.replayedChunks.reduce(0) { $0 + $1.fileAddedCount }, 600)
-            XCTAssertEqual(sample?.replayedChunks.reduce(0) { $0 + $1.parentLookupCount }, 1200)
-            XCTAssertEqual(sample?.replayedChunks.dropLast().count, 5)
-            XCTAssertEqual(sample?.replayedChunks.dropLast().filter(\.yieldedAfterChunk).count, 5)
-            XCTAssertEqual(sample?.replayedChunks.last?.yieldedAfterChunk, false)
-            XCTAssertEqual(sample?.replayedChunks.last?.yieldDurationMSAfterChunk, 0)
-            XCTAssertGreaterThanOrEqual(sample?.totalDurationMS ?? 0, 0)
+            XCTAssertEqual(diagnostics.pendingDeltaCount, 0)
+
+            await buffer.finishPreparedImmediateIngress(immediate)
+            diagnostics = await buffer.diagnosticsSnapshot()
+            XCTAssertFalse(diagnostics.immediatePreparedIngressInFlight)
         }
 
         @MainActor

--- a/Tests/RepoPromptTests/WorkspaceContext/WorkspaceFileContextStoreTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/WorkspaceFileContextStoreTests.swift
@@ -1270,49 +1270,46 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
             for relativePath in relativePaths {
                 try write(relativePath, to: root.appendingPathComponent(relativePath))
             }
-            let appliedIndexEvents = await store.appliedIndexEvents()
-            let appliedIndexEventRecorder = AppliedIndexEventRecorder()
-            let appliedIndexConsumer = Task {
-                for await event in appliedIndexEvents {
-                    guard event.rootID == record.id,
-                          event.upsertedFiles.map(\.standardizedRelativePath) == relativePaths
-                    else { continue }
-                    await appliedIndexEventRecorder.record(event)
-                    return
-                }
-            }
-            defer { appliedIndexConsumer.cancel() }
-            try await store.startWatchingRoot(id: record.id)
+            var appliedIndexEvents = await store.appliedIndexEvents().makeAsyncIterator()
 
-            try await store.publishSyntheticFileSystemDeltasForTesting(
+            let sample = try await store.replayFileSystemPublicationForInvalidationDiagnosticsForTesting(
                 rootID: record.id,
                 deltas: relativePaths.map { .fileAdded($0) }
             )
-            _ = await store.awaitAppliedIngressForAllRoots()
 
-            let eventDeadline = ContinuousClock.now + .seconds(2)
-            var appliedIndexEvent = await appliedIndexEventRecorder.snapshot()
-            while appliedIndexEvent == nil, ContinuousClock.now < eventDeadline {
-                await Task.yield()
-                appliedIndexEvent = await appliedIndexEventRecorder.snapshot()
-            }
-            let observedAppliedIndexEvent = try XCTUnwrap(appliedIndexEvent)
-            XCTAssertTrue(observedAppliedIndexEvent.upsertedFolders.isEmpty)
-
-            let rootSnapshots = await store.readSearchRootDiagnosticsSnapshot()
-            let rootSnapshot = try XCTUnwrap(rootSnapshots.first { $0.rootID == record.id })
-            let sample = try XCTUnwrap(rootSnapshot.invalidation.samples.last {
-                $0.preparedDeltaCount == fileCount
-            })
-            XCTAssertGreaterThan(sample.servicePublicationSequence, 0)
+            XCTAssertEqual(sample.servicePublicationSequence, 0)
+            XCTAssertNil(sample.watcherAcceptedWatermark)
+            XCTAssertEqual(sample.preparedDeltaCount, fileCount)
             XCTAssertEqual(sample.topologyInvalidationCount, 1)
+            XCTAssertEqual(sample.catalogGenerationAdvanceCount, 3)
             XCTAssertEqual(sample.searchCatalogCacheClearCount, 1)
             XCTAssertEqual(sample.pathWorkerInvalidationRequestCount, 1)
             XCTAssertEqual(sample.contentInvalidationCount, 0)
             XCTAssertEqual(sample.distinctContentKeyCount, 0)
             XCTAssertEqual(sample.decodedCacheInvalidationRequestCount, 0)
             XCTAssertEqual(sample.codemapInvalidationRequestCount, 0)
-            XCTAssertEqual(sample.appliedIndexEventYieldCount, 1)
+            guard sample.appliedIndexEventYieldCount == 1 else {
+                XCTFail("Expected exactly one applied-index event, got \(sample.appliedIndexEventYieldCount)")
+                return
+            }
+
+            let appliedIndexEvent = await appliedIndexEvents.next()
+            let observedAppliedIndexEvent = try XCTUnwrap(appliedIndexEvent)
+            XCTAssertEqual(observedAppliedIndexEvent.rootID, record.id)
+            XCTAssertEqual(observedAppliedIndexEvent.generation, 1)
+            XCTAssertEqual(observedAppliedIndexEvent.upsertedFiles.map(\.standardizedRelativePath), relativePaths)
+            XCTAssertTrue(observedAppliedIndexEvent.upsertedFolders.isEmpty)
+            XCTAssertTrue(observedAppliedIndexEvent.removedFileIDs.isEmpty)
+            XCTAssertTrue(observedAppliedIndexEvent.removedFolderIDs.isEmpty)
+            XCTAssertTrue(observedAppliedIndexEvent.removedFilePaths.isEmpty)
+            XCTAssertTrue(observedAppliedIndexEvent.removedFolderPaths.isEmpty)
+            XCTAssertTrue(observedAppliedIndexEvent.modifiedFileIDs.isEmpty)
+            XCTAssertTrue(observedAppliedIndexEvent.modifiedFolderIDs.isEmpty)
+
+            let rootSnapshots = await store.readSearchRootDiagnosticsSnapshot()
+            let rootSnapshot = try XCTUnwrap(rootSnapshots.first { $0.rootID == record.id })
+            XCTAssertEqual(rootSnapshot.invalidation.totalObservedPublicationCount, 0)
+            XCTAssertTrue(rootSnapshot.invalidation.samples.isEmpty)
 
             let catalog = await store.searchCatalogSnapshot(rootScope: .visibleWorkspace)
             XCTAssertEqual(catalog.files.map(\.standardizedRelativePath), relativePaths)
@@ -4605,18 +4602,6 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
     #endif
 
     #if DEBUG
-        private actor AppliedIndexEventRecorder {
-            private var event: WorkspaceAppliedIndexBatchEvent?
-
-            func record(_ event: WorkspaceAppliedIndexBatchEvent) {
-                self.event = event
-            }
-
-            func snapshot() -> WorkspaceAppliedIndexBatchEvent? {
-                event
-            }
-        }
-
         private final class LockedWorkspaceDiagnosticsClock: @unchecked Sendable {
             private let lock = NSLock()
             private var value: UInt64

--- a/Tests/RepoPromptTests/WorkspaceContext/WorkspaceFileContextStoreTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/WorkspaceFileContextStoreTests.swift
@@ -562,6 +562,123 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
             XCTAssertEqual(applied.appliedWatcherWatermark.rawValue, 7)
         }
 
+        #if DEBUG
+            func testWorkspaceIngressCoordinatorCancelledWaiterDetachesWhileLiveWaiterCompletes() async {
+                let coordinator = WorkspaceFileSystemIngressCoordinator()
+                let rootID = UUID()
+                let applyGate = AsyncGate()
+                let subscription = coordinator.openPublisherIngress(rootID: rootID) { publication, _ in
+                    guard publication.servicePublicationSequence == 1 else { return }
+                    await applyGate.markStartedAndWaitForRelease()
+                }
+
+                XCTAssertTrue(coordinator.accept(
+                    subscription,
+                    publication: FileSystemDeltaPublication(
+                        servicePublicationSequence: 1,
+                        source: .watcherBarrierNoop,
+                        watcherAcceptedWatermark: .init(rawValue: 13),
+                        deltas: []
+                    ),
+                    lifecycleCorrelation: nil
+                ))
+                await applyGate.waitUntilStarted()
+
+                let cancelledCompleted = AsyncSignal()
+                let liveCompleted = AsyncSignal()
+                let cancelledWaiter = Task {
+                    await coordinator.waitUntilApplied(rootID: rootID, servicePublicationSequence: 1)
+                    await cancelledCompleted.mark()
+                }
+                let liveWaiter = Task {
+                    await coordinator.waitUntilApplied(rootID: rootID, servicePublicationSequence: 1)
+                    await liveCompleted.mark()
+                }
+                let bothRegistered = await waitForAsyncCondition {
+                    coordinator.debugSnapshot(rootID: rootID).waiterCount == 2
+                }
+                XCTAssertTrue(bothRegistered)
+
+                cancelledWaiter.cancel()
+                let cancelledPromptly = await waitForAsyncCondition {
+                    await cancelledCompleted.isMarked()
+                }
+                XCTAssertTrue(cancelledPromptly)
+                let liveCompletedBeforeRelease = await liveCompleted.isMarked()
+                XCTAssertFalse(liveCompletedBeforeRelease)
+                let afterCancellation = coordinator.debugSnapshot(rootID: rootID)
+                XCTAssertEqual(afterCancellation.waiterCount, 1)
+                XCTAssertEqual(afterCancellation.appliedServicePublicationSequence, 0)
+                XCTAssertEqual(afterCancellation.appliedWatcherWatermark, 0)
+
+                await applyGate.release()
+                await cancelledWaiter.value
+                await liveWaiter.value
+                let settled = coordinator.debugSnapshot(rootID: rootID)
+                XCTAssertEqual(settled.waiterCount, 0)
+                XCTAssertEqual(settled.appliedServicePublicationSequence, 1)
+                XCTAssertEqual(settled.appliedWatcherWatermark, 13)
+            }
+
+            func testWorkspaceIngressCoordinatorDebugSnapshotReportsDepthGapAndOldestAge() async {
+                let clock = LockedWorkspaceDiagnosticsClock(nowNanoseconds: 2_000_000_000)
+                let coordinator = WorkspaceFileSystemIngressCoordinator(debugNowNanoseconds: { clock.now() })
+                let rootID = UUID()
+                let firstApplyGate = AsyncGate()
+                let subscription = coordinator.openPublisherIngress(rootID: rootID) { publication, _ in
+                    if publication.servicePublicationSequence == 1 {
+                        await firstApplyGate.markStartedAndWaitForRelease()
+                    }
+                }
+
+                XCTAssertTrue(coordinator.accept(
+                    subscription,
+                    publication: FileSystemDeltaPublication(
+                        servicePublicationSequence: 1,
+                        source: .syntheticMutation,
+                        watcherAcceptedWatermark: nil,
+                        deltas: [.fileAdded("A.swift")]
+                    ),
+                    lifecycleCorrelation: nil
+                ))
+                await firstApplyGate.waitUntilStarted()
+                XCTAssertTrue(coordinator.accept(
+                    subscription,
+                    publication: FileSystemDeltaPublication(
+                        servicePublicationSequence: 2,
+                        source: .watcherBarrierNoop,
+                        watcherAcceptedWatermark: .init(rawValue: 9),
+                        deltas: []
+                    ),
+                    lifecycleCorrelation: nil
+                ))
+
+                clock.advance(milliseconds: 450)
+                let blocked = coordinator.debugSnapshot(rootID: rootID)
+                XCTAssertTrue(blocked.isOpen)
+                XCTAssertEqual(blocked.queuedPublicationCount, 1)
+                XCTAssertEqual(blocked.applyingPublicationCount, 1)
+                XCTAssertEqual(blocked.outstandingPublicationCount, 2)
+                XCTAssertEqual(blocked.acceptedServicePublicationSequence, 2)
+                XCTAssertEqual(blocked.appliedServicePublicationSequence, 0)
+                XCTAssertEqual(blocked.acceptedAppliedSequenceGap, 2)
+                XCTAssertEqual(blocked.appliedWatcherWatermark, 0)
+                XCTAssertEqual(blocked.oldestOutstandingPublicationAgeMilliseconds, 450)
+
+                await firstApplyGate.release()
+                await coordinator.waitUntilApplied(rootID: rootID, servicePublicationSequence: 2)
+                let settled = coordinator.debugSnapshot(rootID: rootID)
+                XCTAssertEqual(settled.queuedPublicationCount, 0)
+                XCTAssertEqual(settled.applyingPublicationCount, 0)
+                XCTAssertEqual(settled.outstandingPublicationCount, 0)
+                XCTAssertEqual(settled.acceptedServicePublicationSequence, 2)
+                XCTAssertEqual(settled.appliedServicePublicationSequence, 2)
+                XCTAssertEqual(settled.acceptedAppliedSequenceGap, 0)
+                XCTAssertEqual(settled.appliedWatcherWatermark, 9)
+                XCTAssertNil(settled.oldestOutstandingPublicationAgeMilliseconds)
+            }
+        #endif
+
         func testWorkspaceIngressCoordinatorFinishResolvesOutstandingWaiter() async {
             let coordinator = WorkspaceFileSystemIngressCoordinator()
             let rootID = UUID()
@@ -617,6 +734,295 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
             XCTAssertEqual(firstSamples.map(\.rootID), [rootID])
             XCTAssertEqual(secondSamples.map(\.rootID), [rootID])
             XCTAssertEqual(flushStartCount, 1)
+            await store.setScopedIngressBarrierWillFlushHandler(nil)
+        }
+
+        func testScopedAppliedIngressCancelledFollowerDetachesWhileLeaderCompletes() async throws {
+            let root = try makeTemporaryRoot(name: "ScopedIngressFollowerCancellation")
+            let store = WorkspaceFileContextStore()
+            let record = try await store.loadRoot(path: root.path)
+            let rootID = record.id
+            let flushGate = AsyncGate()
+            await store.setScopedIngressBarrierWillFlushHandler { observedRootID in
+                guard observedRootID == rootID else { return }
+                await flushGate.markStartedAndWaitForRelease()
+            }
+
+            let leaderCompleted = AsyncSignal()
+            let followerCompleted = AsyncSignal()
+            let leader = Task {
+                let samples = await store.awaitAppliedIngress(rootScope: .visibleWorkspace)
+                await leaderCompleted.mark()
+                return samples
+            }
+            await flushGate.waitUntilStarted()
+            let follower = Task {
+                let samples = await store.awaitAppliedIngress(rootScope: .visibleWorkspace)
+                await followerCompleted.mark()
+                return samples
+            }
+            let joined = await waitForAsyncCondition {
+                await store.scopedIngressBarrierStatsForTesting(rootID: rootID).joinCount == 1
+            }
+            XCTAssertTrue(joined)
+
+            follower.cancel()
+            let followerDetached = await waitForAsyncCondition {
+                await followerCompleted.isMarked()
+            }
+            XCTAssertTrue(followerDetached)
+            let leaderCompletedBeforeRelease = await leaderCompleted.isMarked()
+            XCTAssertFalse(leaderCompletedBeforeRelease)
+            let activeBeforeRelease = await store.readSearchRootDiagnosticsSnapshot()
+            XCTAssertNotNil(activeBeforeRelease.first { $0.rootID == rootID }?.barrier.active)
+
+            await flushGate.release()
+            let followerSamples = await follower.value
+            let leaderSamples = await leader.value
+            let settled = await store.readSearchRootDiagnosticsSnapshot()
+            let settledRoot = try XCTUnwrap(settled.first { $0.rootID == rootID })
+            XCTAssertTrue(followerSamples.isEmpty)
+            XCTAssertEqual(leaderSamples.map(\.rootID), [rootID])
+            XCTAssertNil(settledRoot.barrier.active)
+            XCTAssertEqual(settledRoot.barrier.completionCount, 1)
+            await store.setScopedIngressBarrierWillFlushHandler(nil)
+        }
+
+        func testScopedAppliedIngressCancelledLauncherDoesNotCancelLiveJoiner() async throws {
+            let root = try makeTemporaryRoot(name: "ScopedIngressLauncherCancellation")
+            let store = WorkspaceFileContextStore()
+            let record = try await store.loadRoot(path: root.path)
+            let rootID = record.id
+            let flushGate = AsyncGate()
+            await store.setScopedIngressBarrierWillFlushHandler { observedRootID in
+                guard observedRootID == rootID else { return }
+                await flushGate.markStartedAndWaitForRelease()
+            }
+
+            let launcherCompleted = AsyncSignal()
+            let joinerCompleted = AsyncSignal()
+            let launcher = Task {
+                let samples = await store.awaitAppliedIngress(rootScope: .visibleWorkspace)
+                await launcherCompleted.mark()
+                return samples
+            }
+            await flushGate.waitUntilStarted()
+            let joiner = Task {
+                let samples = await store.awaitAppliedIngress(rootScope: .visibleWorkspace)
+                await joinerCompleted.mark()
+                return samples
+            }
+            let joined = await waitForAsyncCondition {
+                await store.scopedIngressBarrierStatsForTesting(rootID: rootID).joinCount == 1
+            }
+            XCTAssertTrue(joined)
+
+            launcher.cancel()
+            let launcherDetached = await waitForAsyncCondition {
+                await launcherCompleted.isMarked()
+            }
+            XCTAssertTrue(launcherDetached)
+            let joinerCompletedBeforeRelease = await joinerCompleted.isMarked()
+            XCTAssertFalse(joinerCompletedBeforeRelease)
+
+            await flushGate.release()
+            let launcherSamples = await launcher.value
+            let joinerSamples = await joiner.value
+            let settled = await store.readSearchRootDiagnosticsSnapshot()
+            let settledRoot = try XCTUnwrap(settled.first { $0.rootID == rootID })
+            XCTAssertTrue(launcherSamples.isEmpty)
+            XCTAssertEqual(joinerSamples.map(\.rootID), [rootID])
+            XCTAssertNil(settledRoot.barrier.active)
+            XCTAssertEqual(settledRoot.barrier.completionCount, 1)
+            await store.setScopedIngressBarrierWillFlushHandler(nil)
+        }
+
+        func testScopedAppliedIngressAllCancelledCallersStillReachIdleCleanup() async throws {
+            let root = try makeTemporaryRoot(name: "ScopedIngressAllCancellation")
+            let addedURL = root.appendingPathComponent("Added.swift")
+            let store = WorkspaceFileContextStore()
+            let record = try await store.loadRoot(path: root.path)
+            try await store.startWatchingRoot(id: record.id)
+            let rootID = record.id
+            let sinkGate = AsyncGate()
+            let publisherWaitStarted = AsyncSignal()
+            await store.setWatcherSinkWillApplyHandler { observedRootID in
+                guard observedRootID == rootID else { return }
+                await sinkGate.markStartedAndWaitForRelease()
+            }
+            await store.setPublisherIngressWillWaitHandler { rootIDs in
+                guard rootIDs.contains(rootID) else { return }
+                await publisherWaitStarted.mark()
+            }
+
+            try write("added", to: addedURL)
+            try await store.publishSyntheticFileSystemDeltasForTesting(
+                rootID: rootID,
+                deltas: [.fileAdded("Added.swift")]
+            )
+            await sinkGate.waitUntilStarted()
+            let initialRoots = await store.readSearchRootDiagnosticsSnapshot()
+            let initialIngress = initialRoots.first { $0.rootID == rootID }?.ingress
+            XCTAssertGreaterThan(initialIngress?.acceptedServicePublicationSequence ?? 0, 0)
+            XCTAssertEqual(initialIngress?.appliedServicePublicationSequence, 0)
+
+            let firstCompleted = AsyncSignal()
+            let secondCompleted = AsyncSignal()
+            let first = Task {
+                let samples = await store.awaitAppliedIngress(rootScope: .visibleWorkspace)
+                await firstCompleted.mark()
+                return samples
+            }
+            await publisherWaitStarted.waitUntilMarked()
+            let canonicalWaitRegistered = await waitForAsyncCondition {
+                let roots = await store.readSearchRootDiagnosticsSnapshot()
+                return roots.first { $0.rootID == rootID }?.ingress.waiterCount == 1
+            }
+            XCTAssertTrue(canonicalWaitRegistered)
+            let second = Task {
+                let samples = await store.awaitAppliedIngress(rootScope: .visibleWorkspace)
+                await secondCompleted.mark()
+                return samples
+            }
+            let joined = await waitForAsyncCondition {
+                await store.scopedIngressBarrierStatsForTesting(rootID: rootID).joinCount == 1
+            }
+            XCTAssertTrue(joined)
+
+            first.cancel()
+            second.cancel()
+            let bothDetached = await waitForAsyncCondition {
+                let firstIsCompleted = await firstCompleted.isMarked()
+                let secondIsCompleted = await secondCompleted.isMarked()
+                return firstIsCompleted && secondIsCompleted
+            }
+            XCTAssertTrue(bothDetached)
+            let firstSamples = await first.value
+            let secondSamples = await second.value
+            XCTAssertTrue(firstSamples.isEmpty)
+            XCTAssertTrue(secondSamples.isEmpty)
+            let activeBeforeRelease = await store.readSearchRootDiagnosticsSnapshot()
+            let activeRoot = activeBeforeRelease.first { $0.rootID == rootID }
+            XCTAssertNotNil(activeRoot?.barrier.active)
+            XCTAssertEqual(activeRoot?.barrier.completionCount, 0)
+            XCTAssertEqual(activeRoot?.ingress.waiterCount, 1)
+            XCTAssertGreaterThan(activeRoot?.ingress.outstandingPublicationCount ?? 0, 0)
+            XCTAssertEqual(activeRoot?.ingress.appliedServicePublicationSequence, 0)
+
+            await sinkGate.release()
+            let reachedIdle = await waitForAsyncCondition {
+                let roots = await store.readSearchRootDiagnosticsSnapshot()
+                guard let root = roots.first(where: { $0.rootID == rootID }) else { return false }
+                return root.barrier.active == nil
+                    && root.barrier.completionCount == 1
+                    && root.ingress.waiterCount == 0
+                    && root.ingress.outstandingPublicationCount == 0
+            }
+            XCTAssertTrue(reachedIdle)
+            let settledRoots = await store.readSearchRootDiagnosticsSnapshot()
+            let settledRoot = try XCTUnwrap(settledRoots.first { $0.rootID == rootID })
+            XCTAssertEqual(
+                settledRoot.ingress.appliedServicePublicationSequence,
+                settledRoot.ingress.acceptedServicePublicationSequence
+            )
+            XCTAssertGreaterThanOrEqual(
+                settledRoot.ingress.appliedServicePublicationSequence,
+                initialIngress?.acceptedServicePublicationSequence ?? 0
+            )
+            XCTAssertEqual(settledRoot.ingress.appliedWatcherWatermark, 0)
+            XCTAssertEqual(settledRoot.barrier.lastCompleted?.appliedWatcherWatermark, 0)
+            XCTAssertEqual(
+                settledRoot.barrier.lastCompleted?.appliedServicePublicationSequence,
+                settledRoot.ingress.appliedServicePublicationSequence
+            )
+            await store.setWatcherSinkWillApplyHandler(nil)
+            await store.setPublisherIngressWillWaitHandler(nil)
+            await store.stopWatchingRoot(id: rootID)
+        }
+
+        func testCancelledReadFreshnessJoinThrowsBeforeCanonicalFlightCompletes() async throws {
+            let root = try makeTemporaryRoot(name: "ReadFreshnessCancellation")
+            let fileURL = root.appendingPathComponent("Seed.swift")
+            try write("seed", to: fileURL)
+            let store = WorkspaceFileContextStore()
+            let record = try await store.loadRoot(path: root.path)
+            let flushGate = AsyncGate()
+            await store.setScopedIngressBarrierWillFlushHandler { observedRootID in
+                guard observedRootID == record.id else { return }
+                await flushGate.markStartedAndWaitForRelease()
+            }
+
+            let completed = AsyncSignal()
+            let request = Task { () -> Bool in
+                let wasCancelled: Bool
+                do {
+                    let service = WorkspaceReadableFileService(store: store)
+                    try await service.awaitFreshnessForExplicitRequest(
+                        fileURL.path,
+                        fallbackScope: .visibleWorkspace
+                    )
+                    wasCancelled = false
+                } catch is CancellationError {
+                    wasCancelled = true
+                } catch {
+                    wasCancelled = false
+                }
+                await completed.mark()
+                return wasCancelled
+            }
+            await flushGate.waitUntilStarted()
+            request.cancel()
+            let cancelledPromptly = await waitForAsyncCondition {
+                await completed.isMarked()
+            }
+            XCTAssertTrue(cancelledPromptly)
+
+            await flushGate.release()
+            let wasCancelled = await request.value
+            XCTAssertTrue(wasCancelled)
+            await store.setScopedIngressBarrierWillFlushHandler(nil)
+        }
+
+        func testCancelledFileSearchJoinThrowsBeforeCanonicalFlightCompletes() async throws {
+            let root = try makeTemporaryRoot(name: "SearchFreshnessCancellation")
+            try write("needle", to: root.appendingPathComponent("Seed.swift"))
+            let store = WorkspaceFileContextStore()
+            let record = try await store.loadRoot(path: root.path)
+            let flushGate = AsyncGate()
+            await store.setScopedIngressBarrierWillFlushHandler { observedRootID in
+                guard observedRootID == record.id else { return }
+                await flushGate.markStartedAndWaitForRelease()
+            }
+
+            let completed = AsyncSignal()
+            let request = Task { () -> Bool in
+                let wasCancelled: Bool
+                do {
+                    _ = try await StoreBackedWorkspaceSearch.search(
+                        pattern: "needle",
+                        mode: .content,
+                        store: store,
+                        workspaceManager: nil
+                    )
+                    wasCancelled = false
+                } catch is CancellationError {
+                    wasCancelled = true
+                } catch {
+                    wasCancelled = false
+                }
+                await completed.mark()
+                return wasCancelled
+            }
+            await flushGate.waitUntilStarted()
+            request.cancel()
+            let cancelledPromptly = await waitForAsyncCondition {
+                await completed.isMarked()
+            }
+            XCTAssertTrue(cancelledPromptly)
+
+            await flushGate.release()
+            let wasCancelled = await request.value
+            XCTAssertTrue(wasCancelled)
             await store.setScopedIngressBarrierWillFlushHandler(nil)
         }
 
@@ -784,6 +1190,220 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
             XCTAssertEqual(Set(samples.map(\.rootID)), Set([recordA.id, recordB.id]))
             XCTAssertEqual(statsA.launchCount, 1)
             XCTAssertEqual(statsB.launchCount, 1)
+        }
+
+        func testScopedIngressBarrierDiagnosticsReportActiveTargetAndCompletedTiming() async throws {
+            let root = try makeTemporaryRoot(name: "ScopedIngressDiagnostics")
+            let clock = LockedWorkspaceDiagnosticsClock(nowNanoseconds: 3_000_000_000)
+            let store = WorkspaceFileContextStore(debugNowNanoseconds: { clock.now() })
+            let record = try await store.loadRoot(path: root.path)
+            let flushGate = AsyncGate()
+            await store.setScopedIngressBarrierWillFlushHandler { observedRootID in
+                guard observedRootID == record.id else { return }
+                await flushGate.markStartedAndWaitForRelease()
+            }
+
+            let barrierTask = Task {
+                await store.awaitAppliedIngress(rootScope: .visibleWorkspace)
+            }
+            await flushGate.waitUntilStarted()
+            clock.advance(milliseconds: 325)
+
+            let activeRoots = await store.readSearchRootDiagnosticsSnapshot()
+            let activeRoot = try XCTUnwrap(activeRoots.first { $0.rootID == record.id })
+            let active = try XCTUnwrap(activeRoot.barrier.active)
+            XCTAssertEqual(active.targetWatcherWatermark, 0)
+            XCTAssertEqual(active.targetServicePublicationSequence, 0)
+            XCTAssertEqual(active.ageMilliseconds, 325)
+            XCTAssertEqual(activeRoot.barrier.launchCount, 1)
+            XCTAssertEqual(activeRoot.barrier.completionCount, 0)
+            XCTAssertNil(activeRoot.barrier.lastCompleted)
+
+            await flushGate.release()
+            let samples = await barrierTask.value
+            XCTAssertEqual(samples.map(\.rootID), [record.id])
+
+            let completedRoots = await store.readSearchRootDiagnosticsSnapshot()
+            let completedRoot = try XCTUnwrap(completedRoots.first { $0.rootID == record.id })
+            let completed = try XCTUnwrap(completedRoot.barrier.lastCompleted)
+            XCTAssertNil(completedRoot.barrier.active)
+            XCTAssertEqual(completedRoot.barrier.completionCount, 1)
+            XCTAssertEqual(completed.targetWatcherWatermark, 0)
+            XCTAssertEqual(completed.targetServicePublicationSequence, 0)
+            XCTAssertEqual(completed.appliedServicePublicationSequence, samples[0].appliedServicePublicationSequence)
+            XCTAssertEqual(completed.appliedWatcherWatermark, samples[0].appliedWatcherWatermark)
+            XCTAssertEqual(completed.durationMilliseconds, 325)
+            await store.setScopedIngressBarrierWillFlushHandler(nil)
+        }
+
+        func testScopedIngressBarrierDiagnosticsDoNotReappearAfterRootUnload() async throws {
+            let root = try makeTemporaryRoot(name: "ScopedIngressDiagnosticsUnload")
+            let store = WorkspaceFileContextStore()
+            let record = try await store.loadRoot(path: root.path)
+            let flushGate = AsyncGate()
+            await store.setScopedIngressBarrierWillFlushHandler { observedRootID in
+                guard observedRootID == record.id else { return }
+                await flushGate.markStartedAndWaitForRelease()
+            }
+
+            let barrierTask = Task {
+                await store.awaitAppliedIngress(rootScope: .visibleWorkspace)
+            }
+            await flushGate.waitUntilStarted()
+            await store.unloadRoot(id: record.id)
+            var retainedRootIDs = await store.retainedReadSearchDiagnosticRootIDsForTesting()
+            XCTAssertFalse(retainedRootIDs.contains(record.id))
+
+            await flushGate.release()
+            _ = await barrierTask.value
+            retainedRootIDs = await store.retainedReadSearchDiagnosticRootIDsForTesting()
+            XCTAssertFalse(retainedRootIDs.contains(record.id))
+            await store.setScopedIngressBarrierWillFlushHandler(nil)
+        }
+
+        func testLargePublicationUsesOneGlobalInvalidationCycleAndPreservesFinalCatalog() async throws {
+            let root = try makeTemporaryRoot(name: "PublicationInvalidationBatch")
+            let store = WorkspaceFileContextStore()
+            let record = try await store.loadRoot(path: root.path)
+            let fileCount = 600
+            let relativePaths = (0 ..< fileCount).map { String(format: "Batch-%03d.swift", $0) }
+            for relativePath in relativePaths {
+                try write(relativePath, to: root.appendingPathComponent(relativePath))
+            }
+            let appliedIndexEvents = await store.appliedIndexEvents()
+            let appliedIndexEventRecorder = AppliedIndexEventRecorder()
+            let appliedIndexConsumer = Task {
+                for await event in appliedIndexEvents {
+                    guard event.rootID == record.id,
+                          event.upsertedFiles.map(\.standardizedRelativePath) == relativePaths
+                    else { continue }
+                    await appliedIndexEventRecorder.record(event)
+                    return
+                }
+            }
+            defer { appliedIndexConsumer.cancel() }
+            try await store.startWatchingRoot(id: record.id)
+
+            try await store.publishSyntheticFileSystemDeltasForTesting(
+                rootID: record.id,
+                deltas: relativePaths.map { .fileAdded($0) }
+            )
+            _ = await store.awaitAppliedIngressForAllRoots()
+
+            let eventDeadline = ContinuousClock.now + .seconds(2)
+            var appliedIndexEvent = await appliedIndexEventRecorder.snapshot()
+            while appliedIndexEvent == nil, ContinuousClock.now < eventDeadline {
+                await Task.yield()
+                appliedIndexEvent = await appliedIndexEventRecorder.snapshot()
+            }
+            let observedAppliedIndexEvent = try XCTUnwrap(appliedIndexEvent)
+            XCTAssertTrue(observedAppliedIndexEvent.upsertedFolders.isEmpty)
+
+            let rootSnapshots = await store.readSearchRootDiagnosticsSnapshot()
+            let rootSnapshot = try XCTUnwrap(rootSnapshots.first { $0.rootID == record.id })
+            let sample = try XCTUnwrap(rootSnapshot.invalidation.samples.last {
+                $0.preparedDeltaCount == fileCount
+            })
+            XCTAssertGreaterThan(sample.servicePublicationSequence, 0)
+            XCTAssertEqual(sample.topologyInvalidationCount, 1)
+            XCTAssertEqual(sample.searchCatalogCacheClearCount, 1)
+            XCTAssertEqual(sample.pathWorkerInvalidationRequestCount, 1)
+            XCTAssertEqual(sample.contentInvalidationCount, 0)
+            XCTAssertEqual(sample.distinctContentKeyCount, 0)
+            XCTAssertEqual(sample.decodedCacheInvalidationRequestCount, 0)
+            XCTAssertEqual(sample.codemapInvalidationRequestCount, 0)
+            XCTAssertEqual(sample.appliedIndexEventYieldCount, 1)
+
+            let catalog = await store.searchCatalogSnapshot(rootScope: .visibleWorkspace)
+            XCTAssertEqual(catalog.files.map(\.standardizedRelativePath), relativePaths)
+        }
+
+        func testLargeModificationPublicationUsesOneDecodedCacheInvalidationAndPreservesFreshContent() async throws {
+            let root = try makeTemporaryRoot(name: "PublicationContentInvalidationBatch")
+            let fileCount = 64
+            let relativePaths = (0 ..< fileCount).map { String(format: "Content-%03d.swift", $0) }
+            let fixedDate = Date(timeIntervalSince1970: 1_700_000_000)
+            for (index, relativePath) in relativePaths.enumerated() {
+                let fileURL = root.appendingPathComponent(relativePath)
+                try write(String(format: "old-%03d", index), to: fileURL)
+                try setDiskModificationDate(fixedDate, for: fileURL)
+            }
+
+            let store = WorkspaceFileContextStore()
+            let record = try await store.loadRoot(path: root.path)
+            var files: [WorkspaceFileRecord] = []
+            var initialRevisionsByFileID: [UUID: UInt64] = [:]
+            for (index, relativePath) in relativePaths.enumerated() {
+                let loadedFile = await store.file(rootID: record.id, relativePath: relativePath)
+                let file = try XCTUnwrap(loadedFile)
+                let snapshot = try await store.searchContentSnapshot(for: file)
+                XCTAssertEqual(snapshot.content, String(format: "old-%03d", index))
+                files.append(file)
+                initialRevisionsByFileID[file.id] = try XCTUnwrap(snapshot.contentRevision)
+            }
+            try await store.startWatchingRoot(id: record.id)
+
+            for (index, relativePath) in relativePaths.enumerated() {
+                let fileURL = root.appendingPathComponent(relativePath)
+                try write(String(format: "new-%03d", index), to: fileURL)
+                try setDiskModificationDate(fixedDate, for: fileURL)
+            }
+            try await store.publishSyntheticFileSystemDeltasForTesting(
+                rootID: record.id,
+                deltas: relativePaths.map { .fileModified($0, fixedDate) }
+            )
+            _ = await store.awaitAppliedIngressForAllRoots()
+
+            let rootSnapshots = await store.readSearchRootDiagnosticsSnapshot(recentPublicationLimit: 32)
+            let rootSnapshot = try XCTUnwrap(rootSnapshots.first { $0.rootID == record.id })
+            let sample = try XCTUnwrap(rootSnapshot.invalidation.samples.last {
+                $0.preparedDeltaCount == fileCount && $0.contentInvalidationCount == fileCount
+            })
+            XCTAssertEqual(sample.topologyInvalidationCount, 0)
+            XCTAssertEqual(sample.catalogGenerationAdvanceCount, 0)
+            XCTAssertEqual(sample.searchCatalogCacheClearCount, 0)
+            XCTAssertEqual(sample.pathWorkerInvalidationRequestCount, 0)
+            XCTAssertEqual(sample.distinctContentKeyCount, fileCount)
+            XCTAssertEqual(sample.decodedCacheInvalidationRequestCount, 1)
+            XCTAssertEqual(sample.codemapInvalidationRequestCount, fileCount)
+            XCTAssertEqual(sample.appliedIndexEventYieldCount, 1)
+
+            for (index, file) in files.enumerated() {
+                let refreshed = try await store.searchContentSnapshot(for: file)
+                XCTAssertTrue(refreshed.isFresh)
+                XCTAssertEqual(refreshed.content, String(format: "new-%03d", index))
+                let refreshedRevision = try XCTUnwrap(refreshed.contentRevision)
+                XCTAssertGreaterThan(refreshedRevision, try XCTUnwrap(initialRevisionsByFileID[file.id]))
+            }
+        }
+
+        func testPublicationInvalidationDiagnosticsRetainOnlyLatestThirtyTwoSamples() async throws {
+            let root = try makeTemporaryRoot(name: "PublicationInvalidationRetention")
+            try write("seed", to: root.appendingPathComponent("Seed.swift"))
+            let store = WorkspaceFileContextStore()
+            let record = try await store.loadRoot(path: root.path)
+            try await store.startWatchingRoot(id: record.id)
+
+            for _ in 0 ..< 40 {
+                try await store.publishSyntheticFileSystemDeltasForTesting(
+                    rootID: record.id,
+                    deltas: [.fileModified("Seed.swift", nil)]
+                )
+                _ = await store.awaitAppliedIngressForAllRoots()
+            }
+
+            let rootSnapshots = await store.readSearchRootDiagnosticsSnapshot(recentPublicationLimit: 32)
+            let rootSnapshot = try XCTUnwrap(rootSnapshots.first { $0.rootID == record.id })
+            XCTAssertEqual(rootSnapshot.invalidation.retainedSampleLimit, 32)
+            XCTAssertEqual(rootSnapshot.invalidation.totalObservedPublicationCount, 40)
+            XCTAssertEqual(rootSnapshot.invalidation.droppedPublicationSampleCount, 8)
+            XCTAssertEqual(rootSnapshot.invalidation.samples.count, 32)
+            XCTAssertTrue(rootSnapshot.invalidation.samples.allSatisfy { $0.preparedDeltaCount == 1 })
+            let retainedSequences = rootSnapshot.invalidation.samples.map(\.servicePublicationSequence)
+            XCTAssertTrue(retainedSequences.allSatisfy { $0 > 0 })
+            XCTAssertTrue(zip(retainedSequences, retainedSequences.dropFirst()).allSatisfy { pair in
+                pair.0 < pair.1
+            })
         }
 
         func testSearchCatalogSnapshotCacheReusesUnchangedScopeAndPreservesOrderingDiagnostics() async throws {
@@ -2373,6 +2993,64 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
         await manager.unloadAllRootFolders()
     }
 
+    #if DEBUG
+        @MainActor
+        func testAppliedIndexProjectionDiagnosticsReportProducedHandledLag() async throws {
+            let root = try makeTemporaryRoot(name: "AppliedIndexProjectionLag")
+            try write("seed", to: root.appendingPathComponent("Seed.swift"))
+            let store = WorkspaceFileContextStore()
+            let manager = WorkspaceFilesViewModel(workspaceFileContextStore: store)
+            await manager.setCodeScanEnabled(false)
+            let workspace = WorkspaceModel(name: "AppliedIndexProjectionLag", repoPaths: [root.path])
+            try await manager.loadFolder(at: root, for: workspace)
+            let roots = await store.roots()
+            let rootRecord = try XCTUnwrap(roots.first)
+            let projectionGate = AsyncGate()
+            manager.setAppliedIndexProjectionWillHandleHandlerForTesting { rootID, _ in
+                guard rootID == rootRecord.id else { return }
+                await projectionGate.markStartedAndWaitForRelease()
+            }
+
+            let addedURL = root.appendingPathComponent("Added.swift")
+            try write("added", to: addedURL)
+            let replayCompleted = AsyncSignal()
+            let replayTask = Task {
+                await store.replayObservedFileSystemDeltas(
+                    rootID: rootRecord.id,
+                    deltas: [.fileAdded("Added.swift")]
+                )
+                await replayCompleted.mark()
+            }
+            await projectionGate.waitUntilStarted()
+            let producerCompletedBeforeProjectionRelease = await waitForAsyncCondition {
+                await replayCompleted.isMarked()
+            }
+            XCTAssertTrue(producerCompletedBeforeProjectionRelease)
+
+            let producedRoots = await store.readSearchRootDiagnosticsSnapshot()
+            let producedRoot = try XCTUnwrap(producedRoots.first { $0.rootID == rootRecord.id })
+            let blockedProjection = manager.appliedIndexProjectionDiagnosticsSnapshot()
+            XCTAssertEqual(producedRoot.producedAppliedIndexGeneration, 1)
+            XCTAssertEqual(blockedProjection.handledGenerationByRootID[rootRecord.id] ?? 0, 0)
+            XCTAssertEqual(
+                producedRoot.producedAppliedIndexGeneration - (blockedProjection.handledGenerationByRootID[rootRecord.id] ?? 0),
+                1
+            )
+
+            await projectionGate.release()
+            await replayTask.value
+            let projectionSettled = await waitForAsyncCondition {
+                manager.appliedIndexProjectionDiagnosticsSnapshot().handledGenerationByRootID[rootRecord.id] == 1
+            }
+            XCTAssertTrue(projectionSettled)
+            let settledProjection = manager.appliedIndexProjectionDiagnosticsSnapshot()
+            XCTAssertEqual(settledProjection.handledEventCount, 1)
+            XCTAssertEqual(settledProjection.handledGenerationByRootID[rootRecord.id], 1)
+            manager.setAppliedIndexProjectionWillHandleHandlerForTesting(nil)
+            await manager.unloadAllRootFolders()
+        }
+    #endif
+
     @MainActor
     func testCancelledRootLoadDoesNotCommitUIOrStoreRoot() async throws {
         #if DEBUG
@@ -2566,6 +3244,159 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
             XCTAssertNotNil(value?.revision)
             XCTAssertEqual(snapshot.entryCount, 1)
             XCTAssertEqual(snapshot.acceptedLoadCount, 1)
+        }
+
+        func testBulkSearchContentInvalidationEvictsEveryDistinctKeyAtUnchangedFingerprint() async throws {
+            let cache = WorkspaceSearchDecodedContentCache(maxEntryCount: 8, maxEstimatedCost: 1000)
+            let rootID = UUID()
+            let fingerprint = FileContentFingerprint(
+                deviceID: 1,
+                fileNumber: 1,
+                byteSize: 1,
+                modificationSeconds: 1,
+                modificationNanoseconds: 0,
+                statusChangeSeconds: 1,
+                statusChangeNanoseconds: 0
+            )
+            let keys = (0 ..< 4).map { index in
+                WorkspaceSearchContentCacheKey(
+                    rootID: rootID,
+                    fileID: UUID(),
+                    standardizedRelativePath: "\(index).swift"
+                )
+            }
+            var initialRevisions: [WorkspaceSearchContentCacheKey: UInt64] = [:]
+            for (index, key) in keys.enumerated() {
+                let value = try await cache.snapshot(for: key, fingerprint: fingerprint, invalidationEpoch: 1) {
+                    ValidatedFileContentSnapshot(
+                        content: "old-\(index)",
+                        detectedEncodingRawValue: String.Encoding.utf8.rawValue,
+                        modificationDate: fingerprint.modificationDate,
+                        fingerprint: fingerprint
+                    )
+                }
+                initialRevisions[key] = try XCTUnwrap(value?.revision)
+            }
+
+            var batch = WorkspaceSearchContentInvalidationBatch()
+            for key in keys {
+                batch.record(key, through: 1)
+            }
+            await cache.invalidate(batch)
+
+            for (index, key) in keys.enumerated() {
+                let refreshed = try await cache.snapshot(for: key, fingerprint: fingerprint, invalidationEpoch: 1) {
+                    ValidatedFileContentSnapshot(
+                        content: "new-\(index)",
+                        detectedEncodingRawValue: String.Encoding.utf8.rawValue,
+                        modificationDate: fingerprint.modificationDate,
+                        fingerprint: fingerprint
+                    )
+                }
+                XCTAssertEqual(refreshed?.content, "new-\(index)")
+                XCTAssertGreaterThan(try XCTUnwrap(refreshed?.revision), try XCTUnwrap(initialRevisions[key]))
+            }
+            let snapshot = await cache.snapshotForTesting()
+
+            XCTAssertEqual(batch.count, keys.count)
+            XCTAssertEqual(snapshot.entryCount, keys.count)
+            XCTAssertEqual(snapshot.loadCount, keys.count * 2)
+            XCTAssertEqual(snapshot.acceptedLoadCount, keys.count * 2)
+            XCTAssertEqual(snapshot.hitCount, 0)
+        }
+
+        func testBulkSearchContentInvalidationRetainsMaximumEpochAndProtectsNewerFlight() async throws {
+            let cache = WorkspaceSearchDecodedContentCache(maxEntryCount: 2, maxEstimatedCost: 1000)
+            let key = WorkspaceSearchContentCacheKey(
+                rootID: UUID(),
+                fileID: UUID(),
+                standardizedRelativePath: "A.swift"
+            )
+            let oldFingerprint = FileContentFingerprint(
+                deviceID: 1,
+                fileNumber: 1,
+                byteSize: 9,
+                modificationSeconds: 9,
+                modificationNanoseconds: 0,
+                statusChangeSeconds: 9,
+                statusChangeNanoseconds: 0
+            )
+            let newFingerprint = FileContentFingerprint(
+                deviceID: 1,
+                fileNumber: 1,
+                byteSize: 10,
+                modificationSeconds: 10,
+                modificationNanoseconds: 0,
+                statusChangeSeconds: 10,
+                statusChangeNanoseconds: 0
+            )
+            let oldGate = AsyncGate()
+            let newGate = AsyncGate()
+            let oldFlight = Task {
+                try await cache.snapshot(for: key, fingerprint: oldFingerprint, invalidationEpoch: 9) {
+                    await oldGate.markStartedAndWaitForRelease()
+                    return ValidatedFileContentSnapshot(
+                        content: "old",
+                        detectedEncodingRawValue: String.Encoding.utf8.rawValue,
+                        modificationDate: oldFingerprint.modificationDate,
+                        fingerprint: oldFingerprint
+                    )
+                }
+            }
+            let newFlight = Task {
+                try await cache.snapshot(for: key, fingerprint: newFingerprint, invalidationEpoch: 10) {
+                    await newGate.markStartedAndWaitForRelease()
+                    return ValidatedFileContentSnapshot(
+                        content: "new",
+                        detectedEncodingRawValue: String.Encoding.utf8.rawValue,
+                        modificationDate: newFingerprint.modificationDate,
+                        fingerprint: newFingerprint
+                    )
+                }
+            }
+            await oldGate.waitUntilStarted()
+            await newGate.waitUntilStarted()
+
+            var batch = WorkspaceSearchContentInvalidationBatch()
+            batch.record(key, through: 7)
+            batch.record(key, through: 3)
+            batch.record(key, through: 9)
+            batch.record(key, through: 5)
+            XCTAssertEqual(batch.count, 1)
+            XCTAssertEqual(batch.maximumEpoch(for: key), 9)
+            await cache.invalidate(batch)
+
+            await oldGate.release()
+            await newGate.release()
+            let oldValue = try await oldFlight.value
+            let newValue = try await newFlight.value
+            XCTAssertNil(oldValue)
+            XCTAssertEqual(newValue?.content, "new")
+            let acceptedRevision = try XCTUnwrap(newValue?.revision)
+
+            var delayedOlderBatch = WorkspaceSearchContentInvalidationBatch()
+            delayedOlderBatch.record(key, through: 5)
+            await cache.invalidate(delayedOlderBatch)
+            let cachedNewValue = try await cache.snapshot(
+                for: key,
+                fingerprint: newFingerprint,
+                invalidationEpoch: 10
+            ) {
+                XCTFail("A delayed older invalidation must not evict the newer entry")
+                return ValidatedFileContentSnapshot(
+                    content: "unexpected",
+                    detectedEncodingRawValue: String.Encoding.utf8.rawValue,
+                    modificationDate: newFingerprint.modificationDate,
+                    fingerprint: newFingerprint
+                )
+            }
+            let snapshot = await cache.snapshotForTesting()
+
+            XCTAssertEqual(cachedNewValue?.content, "new")
+            XCTAssertEqual(cachedNewValue?.revision, acceptedRevision)
+            XCTAssertEqual(snapshot.entryCount, 1)
+            XCTAssertEqual(snapshot.acceptedLoadCount, 1)
+            XCTAssertEqual(snapshot.hitCount, 1)
         }
 
         func testSearchContentSnapshotWarmHitKeepsRevisionAndAvoidsSecondRead() async throws {
@@ -2928,10 +3759,12 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
         try setDiskModificationDate(staleDate, for: fileURL)
 
         let store = WorkspaceFileContextStore()
+        let rootRecord = try await store.loadRoot(path: root.path)
         let manager = WorkspaceFilesViewModel(workspaceFileContextStore: store)
         await manager.setCodeScanEnabled(false)
         let workspace = WorkspaceModel(name: "StrictSearchFreshness", repoPaths: [root.path])
-        try await manager.loadFolder(at: root, for: workspace)
+        manager.registerPreloadedWorkspaceRoot(rootRecord)
+        _ = try manager.attachRootShell(for: rootRecord, workspaceID: workspace.id)
         XCTAssertNil(manager.findFileByFullPath(fileURL.path))
 
         try write("struct A { let freshSearchToken = true }\n", to: fileURL)
@@ -3416,6 +4249,17 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
             return final
         }
 
+        private func waitForAsyncCondition(
+            maxYields: Int = 1000,
+            _ condition: () async -> Bool
+        ) async -> Bool {
+            for _ in 0 ..< maxYields {
+                if await condition() { return true }
+                await Task.yield()
+            }
+            return await condition()
+        }
+
         private actor AsyncGate {
             private var started = false
             private var startedCount = 0
@@ -3757,6 +4601,41 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
             APIPaths = aggregate.orderedFileAPIs.map(\.filePath)
             XCTAssertEqual(APIPaths, [retainedFile.path])
             XCTAssertEqual(Set(aggregate.firstFileAPIByStandardizedNestedPath.keys), [retainedFile.path])
+        }
+    #endif
+
+    #if DEBUG
+        private actor AppliedIndexEventRecorder {
+            private var event: WorkspaceAppliedIndexBatchEvent?
+
+            func record(_ event: WorkspaceAppliedIndexBatchEvent) {
+                self.event = event
+            }
+
+            func snapshot() -> WorkspaceAppliedIndexBatchEvent? {
+                event
+            }
+        }
+
+        private final class LockedWorkspaceDiagnosticsClock: @unchecked Sendable {
+            private let lock = NSLock()
+            private var value: UInt64
+
+            init(nowNanoseconds: UInt64) {
+                value = nowNanoseconds
+            }
+
+            func now() -> UInt64 {
+                lock.lock()
+                defer { lock.unlock() }
+                return value
+            }
+
+            func advance(milliseconds: UInt64) {
+                lock.lock()
+                value &+= milliseconds * 1_000_000
+                lock.unlock()
+            }
         }
     #endif
 

--- a/Tests/RepoPromptTests/WorkspaceContext/WorkspaceFileContextStoreTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/WorkspaceFileContextStoreTests.swift
@@ -1236,28 +1236,40 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
             await store.setScopedIngressBarrierWillFlushHandler(nil)
         }
 
-        func testScopedIngressBarrierDiagnosticsDoNotReappearAfterRootUnload() async throws {
-            let root = try makeTemporaryRoot(name: "ScopedIngressDiagnosticsUnload")
+        func testRootUnloadCancelsOwnedScopedIngressFlightAndReleasesDetachedService() async throws {
+            let root = try makeTemporaryRoot(name: "ScopedIngressUnloadRelease")
             let store = WorkspaceFileContextStore()
             let record = try await store.loadRoot(path: root.path)
-            let flushGate = AsyncGate()
+            var service: FileSystemService? = await store.fileSystemServiceForTesting(rootID: record.id)
+            let weakService = WeakObjectBox(service)
+            let cancellationGate = CancellationAwareGate()
             await store.setScopedIngressBarrierWillFlushHandler { observedRootID in
                 guard observedRootID == record.id else { return }
-                await flushGate.markStartedAndWaitForRelease()
+                await cancellationGate.markStartedAndWaitForCancellation()
             }
 
             let barrierTask = Task {
                 await store.awaitAppliedIngress(rootScope: .visibleWorkspace)
             }
-            await flushGate.waitUntilStarted()
-            await store.unloadRoot(id: record.id)
-            var retainedRootIDs = await store.retainedReadSearchDiagnosticRootIDsForTesting()
-            XCTAssertFalse(retainedRootIDs.contains(record.id))
+            await cancellationGate.waitUntilStarted()
+            let activeFlightCount = await store.scopedIngressBarrierFlightCountForTesting()
+            XCTAssertEqual(activeFlightCount, 1)
 
-            await flushGate.release()
-            _ = await barrierTask.value
-            retainedRootIDs = await store.retainedReadSearchDiagnosticRootIDsForTesting()
+            await store.unloadRoot(id: record.id)
+            service = nil
+            let samples = await barrierTask.value
+            let roots = await store.roots()
+            let retainedRootIDs = await store.retainedReadSearchDiagnosticRootIDsForTesting()
+            let remainingFlightCount = await store.scopedIngressBarrierFlightCountForTesting()
+            let serviceReleased = await waitForAsyncCondition(maxYields: 10000) {
+                weakService.value == nil
+            }
+
+            XCTAssertTrue(samples.isEmpty)
+            XCTAssertTrue(roots.isEmpty)
+            XCTAssertEqual(remainingFlightCount, 0)
             XCTAssertFalse(retainedRootIDs.contains(record.id))
+            XCTAssertTrue(serviceReleased)
             await store.setScopedIngressBarrierWillFlushHandler(nil)
         }
 
@@ -4293,6 +4305,62 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
 
             func startCount() -> Int {
                 startedCount
+            }
+        }
+
+        private actor CancellationAwareGate {
+            private struct Waiter {
+                let id: UUID
+                let continuation: CheckedContinuation<Void, Never>
+            }
+
+            private var started = false
+            private var startWaiters: [CheckedContinuation<Void, Never>] = []
+            private var cancellationWaiter: Waiter?
+            private var cancelledWaiterIDs: Set<UUID> = []
+
+            func markStartedAndWaitForCancellation() async {
+                started = true
+                let waiters = startWaiters
+                startWaiters.removeAll()
+                waiters.forEach { $0.resume() }
+
+                let waiterID = UUID()
+                await withTaskCancellationHandler {
+                    await withCheckedContinuation { continuation in
+                        if Task.isCancelled || cancelledWaiterIDs.remove(waiterID) != nil {
+                            continuation.resume()
+                        } else {
+                            cancellationWaiter = Waiter(id: waiterID, continuation: continuation)
+                        }
+                    }
+                } onCancel: {
+                    Task { await self.cancel(waiterID) }
+                }
+            }
+
+            func waitUntilStarted() async {
+                guard !started else { return }
+                await withCheckedContinuation { continuation in
+                    startWaiters.append(continuation)
+                }
+            }
+
+            private func cancel(_ waiterID: UUID) {
+                guard let cancellationWaiter, cancellationWaiter.id == waiterID else {
+                    cancelledWaiterIDs.insert(waiterID)
+                    return
+                }
+                self.cancellationWaiter = nil
+                cancellationWaiter.continuation.resume()
+            }
+        }
+
+        private final class WeakObjectBox<T: AnyObject>: @unchecked Sendable {
+            weak var value: T?
+
+            init(_ value: T?) {
+                self.value = value
             }
         }
 

--- a/Tests/RepoPromptTests/WorkspaceContext/WorkspaceFilesAppliedIndexProjectionTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/WorkspaceFilesAppliedIndexProjectionTests.swift
@@ -1,0 +1,587 @@
+@testable import RepoPrompt
+import XCTest
+
+#if DEBUG
+    @MainActor
+    final class WorkspaceFilesAppliedIndexProjectionTests: XCTestCase {
+        private var temporaryRoots = FileSystemTemporaryRoots()
+
+        override func tearDownWithError() throws {
+            temporaryRoots.removeAll()
+            try super.tearDownWithError()
+        }
+
+        func testModifiedIDsUseDirectIndexesAndTopologyRemovalClearsUUIDMaps() async throws {
+            let rootURL = try temporaryRoots.makeRoot(suiteName: "AppliedIndexDirectIDs")
+            let store = WorkspaceFileContextStore()
+            let root = try await store.loadRoot(path: rootURL.path)
+            let manager = WorkspaceFilesViewModel(workspaceFileContextStore: store)
+            await manager.setCodeScanEnabled(false)
+            _ = try manager.attachRootShell(for: root, workspaceID: UUID())
+
+            let folderURL = rootURL.appendingPathComponent("Sources", isDirectory: true)
+            let fileURL = folderURL.appendingPathComponent("A.swift")
+            try FileManager.default.createDirectory(at: folderURL, withIntermediateDirectories: true)
+            try "struct A {}".write(to: fileURL, atomically: true, encoding: .utf8)
+
+            let folderID = UUID()
+            let fileID = UUID()
+            let folder = WorkspaceFolderRecord(
+                id: folderID,
+                rootID: root.id,
+                name: "Sources",
+                relativePath: "Sources",
+                fullPath: folderURL.path,
+                parentFolderID: root.id,
+                modificationDate: Date(timeIntervalSince1970: 10)
+            )
+            let file = WorkspaceFileRecord(
+                id: fileID,
+                rootID: root.id,
+                name: "A.swift",
+                relativePath: "Sources/A.swift",
+                fullPath: fileURL.path,
+                parentFolderID: folderID,
+                modificationDate: Date(timeIntervalSince1970: 20)
+            )
+
+            await manager.applyWorkspaceAppliedIndexEventForTesting(WorkspaceAppliedIndexBatchEvent(
+                rootID: root.id,
+                rootPath: root.standardizedFullPath,
+                generation: 1,
+                upsertedFiles: [file],
+                upsertedFolders: [folder]
+            ))
+
+            var index = manager.appliedIndexProjectionIndexSnapshotForTesting()
+            XCTAssertEqual(index.filePathsByID[fileID], file.standardizedFullPath)
+            XCTAssertEqual(index.folderPathsByID[folderID], folder.standardizedFullPath)
+            XCTAssertEqual(index.fileIDsByPath[file.standardizedFullPath], fileID)
+            XCTAssertEqual(index.folderIDsByPath[folder.standardizedFullPath], folderID)
+
+            manager.resetAppliedIndexProjectionLookupDiagnosticsForTesting()
+            await manager.applyWorkspaceAppliedIndexEventForTesting(WorkspaceAppliedIndexBatchEvent(
+                rootID: root.id,
+                rootPath: root.standardizedFullPath,
+                generation: 2,
+                modifiedFileIDs: [fileID],
+                modifiedFolderIDs: [folderID]
+            ))
+
+            let lookupDiagnostics = manager.appliedIndexProjectionDiagnosticsSnapshot()
+            XCTAssertEqual(lookupDiagnostics.directFileIDLookupCount, 1)
+            XCTAssertEqual(lookupDiagnostics.directFolderIDLookupCount, 1)
+            XCTAssertEqual(lookupDiagnostics.directIDLookupMissCount, 0)
+            XCTAssertEqual(lookupDiagnostics.handledGenerationByRootID[root.id], 2)
+
+            await manager.applyWorkspaceAppliedIndexEventForTesting(WorkspaceAppliedIndexBatchEvent(
+                rootID: root.id,
+                rootPath: root.standardizedFullPath,
+                generation: 3,
+                removedFolderIDs: [folderID]
+            ))
+
+            index = manager.appliedIndexProjectionIndexSnapshotForTesting()
+            XCTAssertNil(index.filePathsByID[fileID])
+            XCTAssertNil(index.folderPathsByID[folderID])
+            XCTAssertNil(index.fileIDsByPath[file.standardizedFullPath])
+            XCTAssertNil(index.folderIDsByPath[folder.standardizedFullPath])
+            XCTAssertEqual(index.folderPathsByID[root.id], root.standardizedFullPath)
+
+            await manager.unloadAllRootFolders()
+        }
+
+        func testContiguousModifiedIDsSkipCanonicalRecordsThatAreNotProjected() async throws {
+            let rootURL = try temporaryRoots.makeRoot(suiteName: "AppliedIndexLazyModification")
+            let folderURL = rootURL.appendingPathComponent("Sources", isDirectory: true)
+            let fileURL = folderURL.appendingPathComponent("A.swift")
+            try FileManager.default.createDirectory(at: folderURL, withIntermediateDirectories: true)
+            try "let stale = true".write(to: fileURL, atomically: true, encoding: .utf8)
+
+            let store = WorkspaceFileContextStore()
+            let root = try await store.loadRoot(path: rootURL.path)
+            let freshDate = Date(timeIntervalSince1970: 1_700_000_100)
+            try "let fresh = true".write(to: fileURL, atomically: true, encoding: .utf8)
+            await store.replayObservedFileSystemDeltas(
+                rootID: root.id,
+                deltas: [
+                    .fileModified("Sources/A.swift", freshDate),
+                    .folderModified("Sources", freshDate)
+                ]
+            )
+            let canonicalValue = await store.appliedIndexRootSnapshot(rootID: root.id)
+            let canonical = try XCTUnwrap(canonicalValue)
+            let canonicalFile = try XCTUnwrap(canonical.files.first { $0.standardizedRelativePath == "Sources/A.swift" })
+            let canonicalFolder = try XCTUnwrap(canonical.folders.first { $0.standardizedRelativePath == "Sources" })
+
+            let manager = WorkspaceFilesViewModel(workspaceFileContextStore: store)
+            await manager.setCodeScanEnabled(false)
+            _ = try manager.attachRootShell(for: root, workspaceID: UUID())
+            manager.resetAppliedIndexProjectionLookupDiagnosticsForTesting()
+
+            await manager.applyWorkspaceAppliedIndexEventForTesting(WorkspaceAppliedIndexBatchEvent(
+                rootID: root.id,
+                rootPath: root.standardizedFullPath,
+                generation: canonical.generation,
+                modifiedFileIDs: [canonicalFile.id],
+                modifiedFolderIDs: [canonicalFolder.id]
+            ))
+
+            let index = manager.appliedIndexProjectionIndexSnapshotForTesting()
+            XCTAssertNil(index.filePathsByID[canonicalFile.id])
+            XCTAssertNil(index.folderPathsByID[canonicalFolder.id])
+            XCTAssertNil(index.fileIDsByPath[canonicalFile.standardizedFullPath])
+            XCTAssertNil(index.folderIDsByPath[canonicalFolder.standardizedFullPath])
+            let diagnostics = manager.appliedIndexProjectionDiagnosticsSnapshot()
+            XCTAssertEqual(diagnostics.directFileIDLookupCount, 1)
+            XCTAssertEqual(diagnostics.directFolderIDLookupCount, 1)
+            XCTAssertEqual(diagnostics.directIDLookupMissCount, 2)
+            XCTAssertEqual(diagnostics.canonicalResyncCount, 0)
+            XCTAssertEqual(diagnostics.handledGenerationByRootID[root.id], canonical.generation)
+            await manager.unloadAllRootFolders()
+        }
+
+        func testContiguousModifiedIDPathConflictRequiresCanonicalResync() async throws {
+            let rootURL = try temporaryRoots.makeRoot(suiteName: "AppliedIndexModificationConflict")
+            let folderURL = rootURL.appendingPathComponent("Sources", isDirectory: true)
+            let fileURL = folderURL.appendingPathComponent("A.swift")
+            try FileManager.default.createDirectory(at: folderURL, withIntermediateDirectories: true)
+            try "let value = 0".write(to: fileURL, atomically: true, encoding: .utf8)
+
+            let store = WorkspaceFileContextStore()
+            let root = try await store.loadRoot(path: rootURL.path)
+            await store.replayObservedFileSystemDeltas(
+                rootID: root.id,
+                deltas: [.fileModified("Sources/A.swift", Date(timeIntervalSince1970: 10))]
+            )
+            await store.replayObservedFileSystemDeltas(
+                rootID: root.id,
+                deltas: [.fileModified("Sources/A.swift", Date(timeIntervalSince1970: 20))]
+            )
+            let canonicalValue = await store.appliedIndexRootSnapshot(rootID: root.id)
+            let canonical = try XCTUnwrap(canonicalValue)
+            let canonicalFile = try XCTUnwrap(canonical.files.first { $0.standardizedRelativePath == "Sources/A.swift" })
+            let canonicalFolder = try XCTUnwrap(canonical.folders.first { $0.standardizedRelativePath == "Sources" })
+            XCTAssertEqual(canonical.generation, 2)
+
+            let manager = WorkspaceFilesViewModel(workspaceFileContextStore: store)
+            await manager.setCodeScanEnabled(false)
+            _ = try manager.attachRootShell(for: root, workspaceID: UUID())
+            let conflictingFolderID = UUID()
+            let conflictingFileID = UUID()
+            await manager.applyWorkspaceAppliedIndexEventForTesting(WorkspaceAppliedIndexBatchEvent(
+                rootID: root.id,
+                rootPath: root.standardizedFullPath,
+                generation: 1,
+                upsertedFiles: [
+                    WorkspaceFileRecord(
+                        id: conflictingFileID,
+                        rootID: root.id,
+                        name: "A.swift",
+                        relativePath: "Sources/A.swift",
+                        fullPath: fileURL.path,
+                        parentFolderID: conflictingFolderID
+                    )
+                ],
+                upsertedFolders: [
+                    WorkspaceFolderRecord(
+                        id: conflictingFolderID,
+                        rootID: root.id,
+                        name: "Sources",
+                        relativePath: "Sources",
+                        fullPath: folderURL.path,
+                        parentFolderID: root.id
+                    )
+                ]
+            ))
+            manager.resetAppliedIndexProjectionLookupDiagnosticsForTesting()
+
+            await manager.applyWorkspaceAppliedIndexEventForTesting(WorkspaceAppliedIndexBatchEvent(
+                rootID: root.id,
+                rootPath: root.standardizedFullPath,
+                generation: canonical.generation,
+                modifiedFileIDs: [canonicalFile.id],
+                modifiedFolderIDs: [canonicalFolder.id]
+            ))
+
+            let index = manager.appliedIndexProjectionIndexSnapshotForTesting()
+            XCTAssertEqual(index.filePathsByID[canonicalFile.id], canonicalFile.standardizedFullPath)
+            XCTAssertEqual(index.folderPathsByID[canonicalFolder.id], canonicalFolder.standardizedFullPath)
+            XCTAssertNil(index.filePathsByID[conflictingFileID])
+            XCTAssertNil(index.folderPathsByID[conflictingFolderID])
+            XCTAssertEqual(index.fileIDsByPath[canonicalFile.standardizedFullPath], canonicalFile.id)
+            XCTAssertEqual(index.folderIDsByPath[canonicalFolder.standardizedFullPath], canonicalFolder.id)
+            let diagnostics = manager.appliedIndexProjectionDiagnosticsSnapshot()
+            XCTAssertEqual(diagnostics.directFileIDLookupCount, 1)
+            XCTAssertEqual(diagnostics.directFolderIDLookupCount, 1)
+            XCTAssertEqual(diagnostics.directIDLookupMissCount, 1)
+            XCTAssertEqual(diagnostics.canonicalResyncCount, 1)
+            XCTAssertEqual(diagnostics.handledGenerationByRootID[root.id], canonical.generation)
+            await manager.unloadAllRootFolders()
+        }
+
+        func testContiguousModifiedIDMissingFromCanonicalSnapshotRequiresResync() async throws {
+            let rootURL = try temporaryRoots.makeRoot(suiteName: "AppliedIndexMissingCanonicalModification")
+            let fileURL = rootURL.appendingPathComponent("Seed.swift")
+            try "let seed = true".write(to: fileURL, atomically: true, encoding: .utf8)
+
+            let store = WorkspaceFileContextStore()
+            let root = try await store.loadRoot(path: rootURL.path)
+            await store.replayObservedFileSystemDeltas(
+                rootID: root.id,
+                deltas: [.fileModified("Seed.swift", Date(timeIntervalSince1970: 30))]
+            )
+            let canonicalValue = await store.appliedIndexRootSnapshot(rootID: root.id)
+            let canonical = try XCTUnwrap(canonicalValue)
+            let canonicalFile = try XCTUnwrap(canonical.files.first { $0.standardizedRelativePath == "Seed.swift" })
+
+            let manager = WorkspaceFilesViewModel(workspaceFileContextStore: store)
+            await manager.setCodeScanEnabled(false)
+            _ = try manager.attachRootShell(for: root, workspaceID: UUID())
+            manager.resetAppliedIndexProjectionLookupDiagnosticsForTesting()
+
+            await manager.applyWorkspaceAppliedIndexEventForTesting(WorkspaceAppliedIndexBatchEvent(
+                rootID: root.id,
+                rootPath: root.standardizedFullPath,
+                generation: canonical.generation,
+                modifiedFileIDs: [UUID()]
+            ))
+
+            let index = manager.appliedIndexProjectionIndexSnapshotForTesting()
+            XCTAssertEqual(index.filePathsByID[canonicalFile.id], canonicalFile.standardizedFullPath)
+            let diagnostics = manager.appliedIndexProjectionDiagnosticsSnapshot()
+            XCTAssertEqual(diagnostics.directFileIDLookupCount, 1)
+            XCTAssertEqual(diagnostics.directIDLookupMissCount, 1)
+            XCTAssertEqual(diagnostics.canonicalResyncCount, 1)
+            XCTAssertEqual(diagnostics.handledGenerationByRootID[root.id], canonical.generation)
+            await manager.unloadAllRootFolders()
+        }
+
+        func testFullResyncDiffPreservesUnchangedLoadedFileState() async throws {
+            let rootURL = try temporaryRoots.makeRoot(suiteName: "AppliedIndexDiffedResync")
+            let store = WorkspaceFileContextStore()
+            let root = try await store.loadRoot(path: rootURL.path)
+            let keepURL = rootURL.appendingPathComponent("Keep.swift")
+            try "let keep = true".write(to: keepURL, atomically: true, encoding: .utf8)
+            await store.replayObservedFileSystemDeltas(rootID: root.id, deltas: [.fileAdded("Keep.swift")])
+            let initialCanonicalValue = await store.appliedIndexRootSnapshot(rootID: root.id)
+            let initialCanonical = try XCTUnwrap(initialCanonicalValue)
+            let keepRecord = try XCTUnwrap(initialCanonical.files.first { $0.standardizedRelativePath == "Keep.swift" })
+
+            let manager = WorkspaceFilesViewModel(workspaceFileContextStore: store)
+            await manager.setCodeScanEnabled(false)
+            _ = try manager.attachRootShell(for: root, workspaceID: UUID())
+            await manager.applyWorkspaceAppliedIndexEventForTesting(WorkspaceAppliedIndexBatchEvent(
+                rootID: root.id,
+                rootPath: root.standardizedFullPath,
+                generation: initialCanonical.generation,
+                upsertedFiles: [keepRecord]
+            ))
+            let keepBefore = try XCTUnwrap(manager.appliedIndexProjectedFileForTesting(id: keepRecord.id))
+            let keepContent = await keepBefore.latestContent
+            XCTAssertEqual(keepContent, "let keep = true")
+            guard case .loaded = keepBefore.loadingState else {
+                XCTFail("Expected unchanged file content to be loaded before resync")
+                await manager.unloadAllRootFolders()
+                return
+            }
+
+            let addedURL = rootURL.appendingPathComponent("Added.swift")
+            try "let added = true".write(to: addedURL, atomically: true, encoding: .utf8)
+            await store.replayObservedFileSystemDeltas(rootID: root.id, deltas: [.fileAdded("Added.swift")])
+            let latestCanonicalValue = await store.appliedIndexRootSnapshot(rootID: root.id)
+            let latestCanonical = try XCTUnwrap(latestCanonicalValue)
+            await manager.applyWorkspaceAppliedIndexEventForTesting(WorkspaceAppliedIndexBatchEvent(
+                rootID: root.id,
+                rootPath: root.standardizedFullPath,
+                generation: latestCanonical.generation,
+                requiresFullResync: true
+            ))
+
+            let keepAfter = try XCTUnwrap(manager.appliedIndexProjectedFileForTesting(id: keepRecord.id))
+            XCTAssertTrue(keepAfter === keepBefore)
+            guard case .loaded = keepAfter.loadingState else {
+                XCTFail("Diffed resync must not invalidate unchanged loaded files")
+                await manager.unloadAllRootFolders()
+                return
+            }
+            let index = manager.appliedIndexProjectionIndexSnapshotForTesting()
+            let addedRecord = try XCTUnwrap(latestCanonical.files.first { $0.standardizedRelativePath == "Added.swift" })
+            XCTAssertEqual(index.filePathsByID[addedRecord.id], addedRecord.standardizedFullPath)
+            XCTAssertEqual(
+                manager.appliedIndexProjectionDiagnosticsSnapshot().handledGenerationByRootID[root.id],
+                latestCanonical.generation
+            )
+            await manager.unloadAllRootFolders()
+        }
+
+        func testStaleAndSamePathWrongRootEventsCannotMutateCurrentProjection() async throws {
+            let rootURL = try temporaryRoots.makeRoot(suiteName: "AppliedIndexStaleRoot")
+            let fileURL = rootURL.appendingPathComponent("Keep.swift")
+            try "let keep = true".write(to: fileURL, atomically: true, encoding: .utf8)
+
+            let store = WorkspaceFileContextStore()
+            let root = try await store.loadRoot(path: rootURL.path)
+            let manager = WorkspaceFilesViewModel(workspaceFileContextStore: store)
+            await manager.setCodeScanEnabled(false)
+            _ = try manager.attachRootShell(for: root, workspaceID: UUID())
+
+            let fileID = UUID()
+            let file = WorkspaceFileRecord(
+                id: fileID,
+                rootID: root.id,
+                name: "Keep.swift",
+                relativePath: "Keep.swift",
+                fullPath: fileURL.path,
+                parentFolderID: root.id
+            )
+            await manager.applyWorkspaceAppliedIndexEventForTesting(WorkspaceAppliedIndexBatchEvent(
+                rootID: root.id,
+                rootPath: root.standardizedFullPath,
+                generation: 1,
+                upsertedFiles: [file]
+            ))
+
+            await manager.applyWorkspaceAppliedIndexEventForTesting(WorkspaceAppliedIndexBatchEvent(
+                rootID: root.id,
+                rootPath: root.standardizedFullPath,
+                generation: 0,
+                removedFileIDs: [fileID],
+                removedFilePaths: ["Keep.swift"]
+            ))
+            await manager.applyWorkspaceAppliedIndexEventForTesting(WorkspaceAppliedIndexBatchEvent(
+                rootID: UUID(),
+                rootPath: root.standardizedFullPath,
+                generation: 2,
+                removedFilePaths: ["Keep.swift"],
+                isRootUnload: true
+            ))
+
+            let index = manager.appliedIndexProjectionIndexSnapshotForTesting()
+            XCTAssertEqual(index.filePathsByID[fileID], file.standardizedFullPath)
+            XCTAssertEqual(index.folderPathsByID[root.id], root.standardizedFullPath)
+            XCTAssertEqual(manager.rootFolders.map(\.id), [root.id])
+            let diagnostics = manager.appliedIndexProjectionDiagnosticsSnapshot()
+            XCTAssertEqual(diagnostics.handledEventCount, 1)
+            XCTAssertEqual(diagnostics.handledGenerationByRootID[root.id], 1)
+
+            await manager.unloadAllRootFolders()
+        }
+
+        func testFullResyncUsesCanonicalSnapshotAndAdvancesToSnapshotGeneration() async throws {
+            let rootURL = try temporaryRoots.makeRoot(suiteName: "AppliedIndexCanonicalResync")
+            try "seed".write(
+                to: rootURL.appendingPathComponent("Seed.swift"),
+                atomically: true,
+                encoding: .utf8
+            )
+
+            let store = WorkspaceFileContextStore()
+            let root = try await store.loadRoot(path: rootURL.path)
+            for name in ["One.swift", "Two.swift", "Three.swift"] {
+                try name.write(
+                    to: rootURL.appendingPathComponent(name),
+                    atomically: true,
+                    encoding: .utf8
+                )
+                await store.replayObservedFileSystemDeltas(
+                    rootID: root.id,
+                    deltas: [.fileAdded(name)]
+                )
+            }
+            let canonicalSnapshot = await store.appliedIndexRootSnapshot(rootID: root.id)
+            let canonical = try XCTUnwrap(canonicalSnapshot)
+            XCTAssertEqual(canonical.generation, 3)
+
+            let manager = WorkspaceFilesViewModel(workspaceFileContextStore: store)
+            await manager.setCodeScanEnabled(false)
+            _ = try manager.attachRootShell(for: root, workspaceID: UUID())
+
+            let ghostFolderID = UUID()
+            let ghostFileID = UUID()
+            let ghostFolderPath = rootURL.appendingPathComponent("Ghost", isDirectory: true).path
+            let ghostFilePath = rootURL.appendingPathComponent("Ghost/Only.swift").path
+            await manager.applyWorkspaceAppliedIndexEventForTesting(WorkspaceAppliedIndexBatchEvent(
+                rootID: root.id,
+                rootPath: root.standardizedFullPath,
+                generation: 1,
+                upsertedFiles: [
+                    WorkspaceFileRecord(
+                        id: ghostFileID,
+                        rootID: root.id,
+                        name: "Only.swift",
+                        relativePath: "Ghost/Only.swift",
+                        fullPath: ghostFilePath,
+                        parentFolderID: ghostFolderID
+                    )
+                ],
+                upsertedFolders: [
+                    WorkspaceFolderRecord(
+                        id: ghostFolderID,
+                        rootID: root.id,
+                        name: "Ghost",
+                        relativePath: "Ghost",
+                        fullPath: ghostFolderPath,
+                        parentFolderID: root.id
+                    )
+                ]
+            ))
+
+            await manager.applyWorkspaceAppliedIndexEventForTesting(WorkspaceAppliedIndexBatchEvent(
+                rootID: root.id,
+                rootPath: root.standardizedFullPath,
+                generation: 2,
+                requiresFullResync: true
+            ))
+
+            var index = manager.appliedIndexProjectionIndexSnapshotForTesting()
+            XCTAssertNil(index.filePathsByID[ghostFileID])
+            XCTAssertNil(index.folderPathsByID[ghostFolderID])
+            XCTAssertNil(index.fileIDsByPath[StandardizedPath.absolute(ghostFilePath)])
+            XCTAssertNil(index.folderIDsByPath[StandardizedPath.absolute(ghostFolderPath)])
+            for file in canonical.files {
+                XCTAssertEqual(index.filePathsByID[file.id], file.standardizedFullPath)
+                XCTAssertEqual(index.fileIDsByPath[file.standardizedFullPath], file.id)
+            }
+            for folder in canonical.folders where !folder.standardizedRelativePath.isEmpty {
+                XCTAssertEqual(index.folderPathsByID[folder.id], folder.standardizedFullPath)
+                XCTAssertEqual(index.folderIDsByPath[folder.standardizedFullPath], folder.id)
+            }
+            var diagnostics = manager.appliedIndexProjectionDiagnosticsSnapshot()
+            XCTAssertEqual(diagnostics.canonicalResyncCount, 1)
+            XCTAssertEqual(diagnostics.handledEventCount, 2)
+            XCTAssertEqual(diagnostics.handledGenerationByRootID[root.id], canonical.generation)
+
+            let canonicalFile = try XCTUnwrap(canonical.files.first)
+            await manager.applyWorkspaceAppliedIndexEventForTesting(WorkspaceAppliedIndexBatchEvent(
+                rootID: root.id,
+                rootPath: root.standardizedFullPath,
+                generation: canonical.generation,
+                removedFileIDs: [canonicalFile.id],
+                removedFilePaths: [canonicalFile.standardizedRelativePath]
+            ))
+            index = manager.appliedIndexProjectionIndexSnapshotForTesting()
+            XCTAssertEqual(index.filePathsByID[canonicalFile.id], canonicalFile.standardizedFullPath)
+            diagnostics = manager.appliedIndexProjectionDiagnosticsSnapshot()
+            XCTAssertEqual(diagnostics.handledEventCount, 2)
+            XCTAssertEqual(diagnostics.handledGenerationByRootID[root.id], canonical.generation)
+
+            await manager.unloadAllRootFolders()
+        }
+
+        func testGenerationGapResyncUsesLatestCanonicalSnapshot() async throws {
+            let rootURL = try temporaryRoots.makeRoot(suiteName: "AppliedIndexGenerationGap")
+            let store = WorkspaceFileContextStore()
+            let root = try await store.loadRoot(path: rootURL.path)
+            for name in ["One.swift", "Two.swift", "Three.swift"] {
+                try name.write(
+                    to: rootURL.appendingPathComponent(name),
+                    atomically: true,
+                    encoding: .utf8
+                )
+                await store.replayObservedFileSystemDeltas(rootID: root.id, deltas: [.fileAdded(name)])
+            }
+            let canonicalValue = await store.appliedIndexRootSnapshot(rootID: root.id)
+            let canonical = try XCTUnwrap(canonicalValue)
+            XCTAssertEqual(canonical.generation, 3)
+
+            let manager = WorkspaceFilesViewModel(workspaceFileContextStore: store)
+            _ = try manager.attachRootShell(for: root, workspaceID: UUID())
+            await manager.applyWorkspaceAppliedIndexEventForTesting(WorkspaceAppliedIndexBatchEvent(
+                rootID: root.id,
+                rootPath: root.standardizedFullPath,
+                generation: 1
+            ))
+            await manager.applyWorkspaceAppliedIndexEventForTesting(WorkspaceAppliedIndexBatchEvent(
+                rootID: root.id,
+                rootPath: root.standardizedFullPath,
+                generation: 3
+            ))
+
+            let index = manager.appliedIndexProjectionIndexSnapshotForTesting()
+            for file in canonical.files {
+                XCTAssertEqual(index.filePathsByID[file.id], file.standardizedFullPath)
+            }
+            let diagnostics = manager.appliedIndexProjectionDiagnosticsSnapshot()
+            XCTAssertEqual(diagnostics.canonicalResyncCount, 1)
+            XCTAssertEqual(diagnostics.handledEventCount, 2)
+            XCTAssertEqual(diagnostics.handledGenerationByRootID[root.id], 3)
+
+            await manager.unloadAllRootFolders()
+        }
+
+        func testValidRootUnloadClearsUUIDPathIndexesAndHandledGeneration() async throws {
+            let rootURL = try temporaryRoots.makeRoot(suiteName: "AppliedIndexValidUnload")
+            let store = WorkspaceFileContextStore()
+            let root = try await store.loadRoot(path: rootURL.path)
+            let manager = WorkspaceFilesViewModel(workspaceFileContextStore: store)
+            _ = try manager.attachRootShell(for: root, workspaceID: UUID())
+
+            let fileID = UUID()
+            let filePath = rootURL.appendingPathComponent("Unload.swift").path
+            await manager.applyWorkspaceAppliedIndexEventForTesting(WorkspaceAppliedIndexBatchEvent(
+                rootID: root.id,
+                rootPath: root.standardizedFullPath,
+                generation: 1,
+                upsertedFiles: [
+                    WorkspaceFileRecord(
+                        id: fileID,
+                        rootID: root.id,
+                        name: "Unload.swift",
+                        relativePath: "Unload.swift",
+                        fullPath: filePath,
+                        parentFolderID: root.id
+                    )
+                ]
+            ))
+            await manager.applyWorkspaceAppliedIndexEventForTesting(WorkspaceAppliedIndexBatchEvent(
+                rootID: root.id,
+                rootPath: root.standardizedFullPath,
+                generation: 2,
+                isRootUnload: true
+            ))
+
+            XCTAssertTrue(manager.rootFolders.isEmpty)
+            let index = manager.appliedIndexProjectionIndexSnapshotForTesting()
+            XCTAssertNil(index.filePathsByID[fileID])
+            XCTAssertNil(index.folderPathsByID[root.id])
+            XCTAssertNil(index.fileIDsByPath[StandardizedPath.absolute(filePath)])
+            XCTAssertNil(index.folderIDsByPath[root.standardizedFullPath])
+            let diagnostics = manager.appliedIndexProjectionDiagnosticsSnapshot()
+            XCTAssertEqual(diagnostics.handledEventCount, 2)
+            XCTAssertNil(diagnostics.handledGenerationByRootID[root.id])
+        }
+
+        func testOldRootUnloadCannotDetachReplacementAtSamePath() async throws {
+            let rootURL = try temporaryRoots.makeRoot(suiteName: "AppliedIndexRootReplacement")
+            let store = WorkspaceFileContextStore()
+            let oldRoot = try await store.loadRoot(path: rootURL.path)
+            let manager = WorkspaceFilesViewModel(workspaceFileContextStore: store)
+            _ = try manager.attachRootShell(for: oldRoot, workspaceID: UUID())
+            let detachedOldRoot = await manager.detachRootShell(forRootPath: rootURL.path, unloadStoreRoot: false)
+            XCTAssertTrue(detachedOldRoot)
+
+            let replacement = WorkspaceRootRecord(
+                id: UUID(),
+                name: oldRoot.name,
+                fullPath: oldRoot.fullPath,
+                kind: oldRoot.kind
+            )
+            _ = try manager.attachRootShell(for: replacement, workspaceID: UUID())
+            await manager.applyWorkspaceAppliedIndexEventForTesting(WorkspaceAppliedIndexBatchEvent(
+                rootID: oldRoot.id,
+                rootPath: oldRoot.standardizedFullPath,
+                generation: 1,
+                isRootUnload: true
+            ))
+
+            XCTAssertEqual(manager.rootFolders.map(\.id), [replacement.id])
+            let index = manager.appliedIndexProjectionIndexSnapshotForTesting()
+            XCTAssertEqual(index.folderPathsByID[replacement.id], replacement.standardizedFullPath)
+            XCTAssertNil(index.folderPathsByID[oldRoot.id])
+            XCTAssertEqual(manager.appliedIndexProjectionDiagnosticsSnapshot().handledEventCount, 0)
+
+            _ = await manager.detachRootShell(forRootPath: replacement.fullPath, unloadStoreRoot: false)
+        }
+    }
+#endif


### PR DESCRIPTION
## Summary
- add bounded DEBUG diagnostics for MCP limiter, filesystem ingress, freshness barriers, invalidation batching, and applied-index lag
- batch topology and decoded-content invalidation once per filesystem publication
- make ingress waits, shared freshness joins, per-connection limiting, and CLI MCP requests cancellation-aware
- replace projection dictionary scans with maintained UUID indexes and generation-gap canonical reconciliation
- fix capped folder-scan continuation and harden persistent-connection/replay test fixtures

## Validation
- `make dev-lint`
- `make dev-test` (full coordinated suite)
- `make dev-swift-build PRODUCT=RepoPrompt`
- `make dev-swift-build PRODUCT=repoprompt-mcp`
- focused store, projection, ingress, limiter, persistent connection, CLI cancellation, diagnostics, filesystem recovery, replay, and search suites
- commit and push contribution preflights, including staged/outgoing secret scans and guardrails

## Live smoke
- `make dev-smoke` was attempted non-disruptively, but the CE app was not running or MCP-enabled. No app launch/relaunch was performed.

## Deferred pending telemetry
- bounded/collapsed publisher ingress
- applied-index event coalescing
- catalog/path warm-cache optimization
- path-index cancellation checkpoints and mirror-lane retirement

The local investigation report was intentionally not committed.
