### PR TITLE
Use RepoPrompt CE filesystem identity consistently

### DIFF
--- a/Packages/RepoPromptAgentProviders/Sources/RepoPromptClaudeCompatibleProvider/ClaudeReasoningDiagnostics.swift
+++ b/Packages/RepoPromptAgentProviders/Sources/RepoPromptClaudeCompatibleProvider/ClaudeReasoningDiagnostics.swift
@@ -6,7 +6,9 @@ enum ClaudeReasoningExtractionFeature {
 
 #if DEBUG
     enum ClaudeReasoningDebugLog {
-        static let fileURL = URL(fileURLWithPath: "/tmp/repoprompt-claude-reasoning-debug.log")
+        static let fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("RepoPrompt CE", isDirectory: true)
+            .appendingPathComponent("claude-reasoning-debug.log", isDirectory: false)
         private static let lock = NSLock()
 
         static func emit(_ line: String) {
@@ -20,7 +22,12 @@ enum ClaudeReasoningExtractionFeature {
             let timestamp = ISO8601DateFormatter().string(from: Date())
             let payload = "\(timestamp) \(line)\n"
             guard let data = payload.data(using: .utf8) else { return }
-            if FileManager.default.fileExists(atPath: fileURL.path),
+            let fileManager = FileManager.default
+            try? fileManager.createDirectory(
+                at: fileURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            if fileManager.fileExists(atPath: fileURL.path),
                let handle = try? FileHandle(forWritingTo: fileURL)
             {
                 defer { try? handle.close() }

--- a/Sources/RepoPrompt/Features/AgentMode/Models/AgentWorkflow.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Models/AgentWorkflow.swift
@@ -198,7 +198,7 @@ public enum AgentWorkflow: String, Codable, CaseIterable, Sendable, Identifiable
 ///
 /// Related:
 /// - Built-in catalog: `AgentWorkflow` enum (above)
-/// - Storage: `AgentWorkflowStore` loads custom workflows from `~/Library/Application Support/RepoPrompt/Workflows/`
+/// - Storage: `AgentWorkflowStore` loads custom workflows from `~/Library/Application Support/RepoPrompt CE/Workflows/`
 /// - UI: `AgentWorkflowsPopoverView` displays both built-in and custom workflows
 public struct AgentWorkflowDefinition: Sendable, Identifiable, Equatable, Hashable {
     // MARK: Source

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentSessionDataService.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentSessionDataService.swift
@@ -1381,9 +1381,7 @@ actor AgentSessionDataService {
         if let customURL = workspace.customStoragePath {
             return customURL
         } else {
-            let supportDir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-            let root = supportDir
-                .appendingPathComponent("RepoPrompt CE", isDirectory: true)
+            let root = MCPFilesystemConstants.identity.applicationSupportRootURL()
                 .appendingPathComponent("Workspaces", isDirectory: true)
             if !FileManager.default.fileExists(atPath: root.path) {
                 try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentWorkflowStore.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentWorkflowStore.swift
@@ -126,14 +126,9 @@ final class AgentWorkflowStore: ObservableObject {
 
     // MARK: Filesystem paths
 
-    /// `~/Library/Application Support/RepoPrompt/Workflows/`
+    /// `~/Library/Application Support/RepoPrompt CE/Workflows/`
     static var workflowsDirectoryURL: URL {
-        let appSupport = FileManager.default.urls(
-            for: .applicationSupportDirectory,
-            in: .userDomainMask
-        ).first!
-        return appSupport
-            .appendingPathComponent("RepoPrompt", isDirectory: true)
+        MCPFilesystemConstants.identity.applicationSupportRootURL()
             .appendingPathComponent("Workflows", isDirectory: true)
     }
 

--- a/Sources/RepoPrompt/Features/AgentMode/Views/AgentInputBar.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/AgentInputBar.swift
@@ -1544,8 +1544,8 @@ struct AgentImageInputAdapter {
     init(fileManager: FileManager = .default, temporaryRoot: URL? = nil) {
         self.fileManager = fileManager
         self.temporaryRoot = temporaryRoot
-            ?? fileManager.temporaryDirectory
-            .appendingPathComponent("RepoPromptAgentImageInput", isDirectory: true)
+            ?? MCPFilesystemConstants.identity.temporaryRootURL(fileManager: fileManager)
+            .appendingPathComponent("AgentImageInput", isDirectory: true)
             .standardizedFileURL
     }
 

--- a/Sources/RepoPrompt/Features/CodeMap/CodeMapCacheManager.swift
+++ b/Sources/RepoPrompt/Features/CodeMap/CodeMapCacheManager.swift
@@ -313,13 +313,10 @@ class CodeMapCacheManager {
 
     // MARK: - Private Helpers
 
-    /// Returns the base directory: ~/Library/Application Support/RepoPrompt/CodeMapCaches
+    /// Returns the base directory: ~/Library/Application Support/RepoPrompt CE/CodeMapCaches
     private func baseCacheDirectory() -> URL {
-        guard let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
-            // Fallback to home directory if something unexpected
-            return FileManager.default.homeDirectoryForCurrentUser
-        }
-        let codeMapDir = appSupport.appendingPathComponent("RepoPrompt/CodeMapCaches", isDirectory: true)
+        let codeMapDir = MCPFilesystemConstants.identity.applicationSupportRootURL()
+            .appendingPathComponent("CodeMapCaches", isDirectory: true)
         try? FileManager.default.createDirectory(at: codeMapDir, withIntermediateDirectories: true)
         return codeMapDir
     }

--- a/Sources/RepoPrompt/Features/CodeMap/CodeMapPerfStats.swift
+++ b/Sources/RepoPrompt/Features/CodeMap/CodeMapPerfStats.swift
@@ -461,7 +461,8 @@ enum CodeMapPerfRuntime {
     static let instrumentationEnvironmentKey = "REPOPROMPT_CODEMAP_PERF"
     static let benchmarkEnvironmentKey = "REPOPROMPT_RUN_CODEMAP_BENCHMARKS"
     static let benchmarkIterationsEnvironmentKey = "REPOPROMPT_CODEMAP_BENCHMARK_ITERATIONS"
-    static let benchmarkMarkerPath = "/tmp/repoprompt-run-codemap-benchmarks"
+    static let benchmarkMarkerURL = MCPFilesystemConstants.identity.temporaryRootURL()
+        .appendingPathComponent("run-codemap-benchmarks", isDirectory: false)
 
     #if DEBUG || CODEMAP_PERF
         static let isCompiledIn = true
@@ -471,7 +472,7 @@ enum CodeMapPerfRuntime {
 
     private static var benchmarkMarkerEnabled: Bool {
         guard isCompiledIn else { return false }
-        return !isRunningInCI && FileManager.default.fileExists(atPath: benchmarkMarkerPath)
+        return !isRunningInCI && FileManager.default.fileExists(atPath: benchmarkMarkerURL.path)
     }
 
     private static var benchmarkRequested: Bool {

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/ClaudeCode/SDK/ClaudeNativeProcessSessionController.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/ClaudeCode/SDK/ClaudeNativeProcessSessionController.swift
@@ -2186,8 +2186,7 @@ final actor ClaudeNativeProcessSessionController {
                 let expanded = NSString(string: overridePath).expandingTildeInPath
                 return URL(fileURLWithPath: expanded, isDirectory: true)
             }
-            return FileManager.default.temporaryDirectory
-                .appendingPathComponent("RepoPrompt", isDirectory: true)
+            return MCPFilesystemConstants.identity.temporaryRootURL()
                 .appendingPathComponent("ClaudeRawEvents", isDirectory: true)
         }()
         do {

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/ClaudeCode/SDK/ClaudeSDKNDJSONTranslator.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/ClaudeCode/SDK/ClaudeSDKNDJSONTranslator.swift
@@ -6,7 +6,8 @@ enum ClaudeReasoningExtractionFeature {
 
 #if DEBUG
     enum ClaudeReasoningDebugLog {
-        static let fileURL = URL(fileURLWithPath: "/tmp/repoprompt-claude-reasoning-debug.log")
+        static let fileURL = MCPFilesystemConstants.identity.temporaryRootURL()
+            .appendingPathComponent("claude-reasoning-debug.log", isDirectory: false)
         private static let lock = NSLock()
 
         static func append(_ line: String) {
@@ -15,7 +16,12 @@ enum ClaudeReasoningExtractionFeature {
             let timestamp = ISO8601DateFormatter().string(from: Date())
             let payload = "\(timestamp) \(line)\n"
             guard let data = payload.data(using: .utf8) else { return }
-            if FileManager.default.fileExists(atPath: fileURL.path),
+            let fileManager = FileManager.default
+            try? fileManager.createDirectory(
+                at: fileURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            if fileManager.fileExists(atPath: fileURL.path),
                let handle = try? FileHandle(forWritingTo: fileURL)
             {
                 defer { try? handle.close() }

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexNativeSessionController.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexNativeSessionController.swift
@@ -709,8 +709,8 @@ final class CodexNativeSessionController {
                 return URL(fileURLWithPath: workspacePath, isDirectory: true)
                     .appendingPathComponent(".codexlogs", isDirectory: true)
             }
-            return FileManager.default.temporaryDirectory
-                .appendingPathComponent("RepoPrompt/.codexlogs", isDirectory: true)
+            return MCPFilesystemConstants.identity.temporaryRootURL()
+                .appendingPathComponent(".codexlogs", isDirectory: true)
         }()
         do {
             try FileManager.default.createDirectory(at: baseDirectory, withIntermediateDirectories: true)

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/Slices/PartitionStore.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/Slices/PartitionStore.swift
@@ -43,10 +43,10 @@ actor PartitionStore {
     static let notifSourceIDKey = "sourceID"
     nonisolated let notificationSourceID = UUID()
 
-    /// <AppSupport>/RepoPrompt/Partitions
+    /// <AppSupport>/RepoPrompt CE/Partitions
     private static func partitionsBaseURL() -> URL {
-        let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-        return base.appendingPathComponent("RepoPrompt/Partitions", isDirectory: true)
+        MCPFilesystemConstants.identity.applicationSupportRootURL()
+            .appendingPathComponent("Partitions", isDirectory: true)
     }
 
     /// repoKey = "<leafName>-<sha256(stdPath)[0..12]>"
@@ -156,7 +156,7 @@ actor PartitionStore {
     func save(forRoot rootPath: String, scope: PartitionScope, data: PartitionData) async throws {
         let url = partitionURL(forRoot: rootPath, scope: scope)
 
-        // Ensure directories exist: .../Application Support/RepoPrompt/Partitions/<repoKey>/
+        // Ensure directories exist: .../Application Support/RepoPrompt CE/Partitions/<repoKey>/
         let dirURL = url.deletingLastPathComponent()
         try FileManager.default.createDirectory(at: dirURL, withIntermediateDirectories: true, attributes: nil)
 

--- a/Sources/RepoPromptShared/MCP/MCPFilesystemIdentity.swift
+++ b/Sources/RepoPromptShared/MCP/MCPFilesystemIdentity.swift
@@ -143,6 +143,11 @@ public struct MCPFilesystemIdentity: Equatable, Sendable {
             .appendingPathComponent(applicationSupportDirectoryName, isDirectory: true)
     }
 
+    public func temporaryRootURL(fileManager: FileManager = .default) -> URL {
+        fileManager.temporaryDirectory
+            .appendingPathComponent(applicationSupportDirectoryName, isDirectory: true)
+    }
+
     public func configDirectoryURL(fileManager: FileManager = .default) -> URL {
         applicationSupportRootURL(fileManager: fileManager)
             .appendingPathComponent("MCP", isDirectory: true)

--- a/Tests/RepoPromptTests/MCP/MCPFilesystemIdentityTests.swift
+++ b/Tests/RepoPromptTests/MCP/MCPFilesystemIdentityTests.swift
@@ -39,6 +39,21 @@ final class MCPFilesystemIdentityTests: XCTestCase {
         XCTAssertEqual(release.claudeWrapperCommandName, "claude-rpce")
     }
 
+    func testCETemporaryRootUsesCanonicalProductDirectoryForBothBuildFlavors() {
+        let fileManager = FileManager.default
+        let expected = fileManager.temporaryDirectory
+            .appendingPathComponent("RepoPrompt CE", isDirectory: true)
+
+        XCTAssertEqual(
+            MCPFilesystemIdentity.repoPromptCE(.debug).temporaryRootURL(fileManager: fileManager),
+            expected
+        )
+        XCTAssertEqual(
+            MCPFilesystemIdentity.repoPromptCE(.release).temporaryRootURL(fileManager: fileManager),
+            expected
+        )
+    }
+
     func testAppConstantsDelegateToSharedIdentity() {
         #if DEBUG
             let expected = MCPFilesystemIdentity.repoPromptCE(.debug)


### PR DESCRIPTION
## Summary

- route affected Application Support paths through the shared RepoPrompt CE filesystem identity
- centralize RepoPrompt CE temporary roots for image input, diagnostics, code-map markers, and provider logs
- remove the proposed legacy-directory migration and fallback behavior entirely
- cover debug and release temporary-root identity behavior

This is the maintainer-reviewed replacement for #125 and preserves the original branding fix without carrying migration logic or migration history.

## Validation

- `make dev-format-check`
- `make dev-test FILTER=MCPFilesystemIdentityTests`
- `make dev-provider-test`
- full coordinated root tests
- strict lint
- `RepoPrompt` and `repoprompt-mcp` product builds
- contribution commit and push preflights

Closes #124