### PR TITLE
Fix release helper initialization timeout crash

### DIFF
--- a/Sources/RepoPromptMCP/Interactive/InteractiveMCPClientSession.swift
+++ b/Sources/RepoPromptMCP/Interactive/InteractiveMCPClientSession.swift
@@ -72,6 +72,35 @@ enum ToolCallTimeoutPolicy: Equatable {
     case none
 }
 
+private final class MCPInitializationSettlementState: @unchecked Sendable {
+    enum Outcome {
+        case pending
+        case completed
+        case timedOut
+        case callerCancelled
+    }
+
+    private let lock = NSLock()
+    private var outcome: Outcome = .pending
+
+    func claim(_ candidate: Outcome) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard case .pending = outcome else { return false }
+        outcome = candidate
+        return true
+    }
+
+    func finish() -> Outcome {
+        lock.lock()
+        defer { lock.unlock() }
+        if case .pending = outcome {
+            outcome = .completed
+        }
+        return outcome
+    }
+}
+
 private final class ToolCallSettlementState: @unchecked Sendable {
     enum Outcome {
         case pending
@@ -249,22 +278,14 @@ actor InteractiveMCPClientSession {
             }
 
             logger.debug("Calling MCP client.connect(transport)...")
-            // Connect and initialize. Bound this wait so exec mode can surface
-            // bootstrap/initialize stalls instead of hanging indefinitely.
-            let initResult = try await withThrowingTaskGroup(of: Initialize.Result.self) { group in
-                group.addTask {
-                    try await client.connect(transport: transport)
-                }
-                group.addTask {
-                    try await Task.sleep(for: .seconds(10))
-                    throw InteractiveSessionError.bootstrapResponseTimeout
-                }
-
-                guard let result = try await group.next() else {
-                    throw InteractiveSessionError.bootstrapResponseTimeout
-                }
-                group.cancelAll()
-                return result
+            // Connect and initialize. Avoid returning Initialize.Result through a
+            // throwing task group: Swift 6.2 release builds can abort in
+            // swift_task_dealloc when that timeout race tears down a child task.
+            let initResult = try await Self.awaitInitialization(
+                timeoutNanoseconds: 10_000_000_000,
+                timeoutSleep: timeoutSleep
+            ) {
+                try await client.connect(transport: transport)
             }
             logger.debug("MCP client connected successfully")
 
@@ -293,6 +314,70 @@ actor InteractiveMCPClientSession {
             throw error
         }
     }
+
+    private static func awaitInitialization(
+        timeoutNanoseconds: UInt64,
+        timeoutSleep: @escaping TimeoutSleep,
+        operation: @escaping @Sendable () async throws -> Initialize.Result
+    ) async throws -> Initialize.Result {
+        let settlement = MCPInitializationSettlementState()
+        let connectionTask = Task {
+            try await operation()
+        }
+        let timeoutTask = Task {
+            do {
+                try await timeoutSleep(timeoutNanoseconds)
+            } catch {
+                return
+            }
+            if settlement.claim(.timedOut) {
+                connectionTask.cancel()
+            }
+        }
+
+        return try await withTaskCancellationHandler {
+            let connectionResult: Result<Initialize.Result, Error>
+            do {
+                connectionResult = try await .success(connectionTask.value)
+            } catch {
+                connectionResult = .failure(error)
+            }
+
+            let outcome = settlement.finish()
+            timeoutTask.cancel()
+            await timeoutTask.value
+
+            switch outcome {
+            case .completed:
+                return try connectionResult.get()
+            case .timedOut:
+                throw InteractiveSessionError.bootstrapResponseTimeout
+            case .callerCancelled:
+                throw CancellationError()
+            case .pending:
+                preconditionFailure("Connection task completion must settle initialization state")
+            }
+        } onCancel: {
+            if settlement.claim(.callerCancelled) {
+                connectionTask.cancel()
+            }
+            timeoutTask.cancel()
+        }
+    }
+
+    #if DEBUG
+        static func debugAwaitInitialization(
+            timeoutNanoseconds: UInt64,
+            timeoutSleep: @escaping TimeoutSleep,
+            operation: @escaping @Sendable () async throws -> Initialize.Result
+        ) async throws -> Initialize.Result {
+            try await awaitInitialization(
+                timeoutNanoseconds: timeoutNanoseconds,
+                timeoutSleep: timeoutSleep,
+                operation: operation
+            )
+        }
+    #endif
 
     /// Disconnects from the MCP server.
     func disconnect() async {

--- a/Tests/RepoPromptTests/MCP/Control/InteractiveMCPClientSessionConnectTimeoutTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/InteractiveMCPClientSessionConnectTimeoutTests.swift
@@ -1,0 +1,167 @@
+import Foundation
+import MCP
+@testable import RepoPromptMCP
+import XCTest
+
+#if DEBUG
+    final class InteractiveMCPClientSessionConnectTimeoutTests: XCTestCase {
+        func testInitializationReturnsConnectResultAndDrainsCancelledTimeoutTask() async throws {
+            let fixture = try await makeFixture()
+            let timeoutCancelled = CLIConnectSignal()
+            do {
+                let result = try await InteractiveMCPClientSession.debugAwaitInitialization(
+                    timeoutNanoseconds: UInt64.max,
+                    timeoutSleep: { _ in
+                        do {
+                            try await Task.sleep(nanoseconds: UInt64.max)
+                        } catch {
+                            await timeoutCancelled.signal()
+                            throw error
+                        }
+                    }
+                ) {
+                    try await fixture.client.connect(transport: fixture.clientTransport)
+                }
+
+                XCTAssertEqual(result.serverInfo.name, "CLI connect timeout test server")
+                let didCancelTimeout = await timeoutCancelled.isSignalled()
+                XCTAssertTrue(didCancelTimeout)
+                await fixture.cleanup()
+            } catch {
+                await fixture.cleanup()
+                throw error
+            }
+        }
+
+        func testInitializationTimeoutCancelsConnectOperation() async throws {
+            let operationStarted = CLIConnectSignal()
+            let operationCancelled = CLIConnectSignal()
+
+            do {
+                _ = try await InteractiveMCPClientSession.debugAwaitInitialization(
+                    timeoutNanoseconds: 1,
+                    timeoutSleep: { _ in
+                        await operationStarted.wait()
+                    }
+                ) {
+                    await operationStarted.signal()
+                    do {
+                        try await Task.sleep(nanoseconds: UInt64.max)
+                    } catch {
+                        await operationCancelled.signal()
+                        throw error
+                    }
+                    fatalError("Cancelled initialization operation unexpectedly returned")
+                }
+                XCTFail("Expected initialization timeout")
+            } catch let error as InteractiveSessionError {
+                guard case .bootstrapResponseTimeout = error else {
+                    XCTFail("Expected bootstrap response timeout, got \(error)")
+                    return
+                }
+            }
+
+            let didStartOperation = await operationStarted.isSignalled()
+            let didCancelOperation = await operationCancelled.isSignalled()
+            XCTAssertTrue(didStartOperation)
+            XCTAssertTrue(didCancelOperation)
+        }
+
+        func testCallerCancellationCancelsConnectAndTimeoutTasks() async throws {
+            let operationStarted = CLIConnectSignal()
+            let operationCancelled = CLIConnectSignal()
+            let timeoutCancelled = CLIConnectSignal()
+
+            let initialization = Task {
+                try await InteractiveMCPClientSession.debugAwaitInitialization(
+                    timeoutNanoseconds: UInt64.max,
+                    timeoutSleep: { _ in
+                        do {
+                            try await Task.sleep(nanoseconds: UInt64.max)
+                        } catch {
+                            await timeoutCancelled.signal()
+                            throw error
+                        }
+                    }
+                ) {
+                    await operationStarted.signal()
+                    do {
+                        try await Task.sleep(nanoseconds: UInt64.max)
+                    } catch {
+                        await operationCancelled.signal()
+                        throw error
+                    }
+                    fatalError("Cancelled initialization operation unexpectedly returned")
+                }
+            }
+
+            await operationStarted.wait()
+            initialization.cancel()
+
+            do {
+                _ = try await initialization.value
+                XCTFail("Expected caller cancellation")
+            } catch is CancellationError {
+                // Expected.
+            }
+
+            let didCancelOperation = await operationCancelled.isSignalled()
+            let didCancelTimeout = await timeoutCancelled.isSignalled()
+            XCTAssertTrue(didCancelOperation)
+            XCTAssertTrue(didCancelTimeout)
+        }
+
+        private func makeFixture() async throws -> CLIConnectFixture {
+            let transports = await InMemoryTransport.createConnectedPair()
+            let server = Server(
+                name: "CLI connect timeout test server",
+                version: "1.0",
+                capabilities: .init()
+            )
+            try await server.start(transport: transports.server)
+            let client = Client(name: "CLI connect timeout test client", version: "1.0")
+            return CLIConnectFixture(
+                client: client,
+                server: server,
+                clientTransport: transports.client
+            )
+        }
+    }
+
+    private struct CLIConnectFixture {
+        let client: Client
+        let server: Server
+        let clientTransport: InMemoryTransport
+
+        func cleanup() async {
+            await client.disconnect()
+            await server.stop()
+        }
+    }
+
+    private actor CLIConnectSignal {
+        private var signalled = false
+        private var waiters: [CheckedContinuation<Void, Never>] = []
+
+        func signal() {
+            guard !signalled else { return }
+            signalled = true
+            let waiters = waiters
+            self.waiters.removeAll()
+            for waiter in waiters {
+                waiter.resume()
+            }
+        }
+
+        func wait() async {
+            guard !signalled else { return }
+            await withCheckedContinuation { continuation in
+                waiters.append(continuation)
+            }
+        }
+
+        func isSignalled() -> Bool {
+            signalled
+        }
+    }
+#endif


### PR DESCRIPTION
## Summary
- replace the `Initialize.Result` throwing-task-group timeout race that aborts optimized helpers in `swift_task_dealloc`
- preserve timeout and caller-cancellation semantics while draining both child tasks
- add deterministic behavioral coverage for success, timeout cancellation, and caller cancellation

## Release blocker
The signed/notarized v1.0.12 draft helper passed `--version` but aborted before writing its bootstrap handshake during the packaged roundtrip smoke. The crash report symbolized the failure to `InteractiveMCPClientSession.connect(fetchInitialTools:)`.

## Validation
- pair diagnosis and independent pair cleanup review
- `make dev-test FILTER=InteractiveMCPClientSessionConnectTimeoutTests` (3 passed)
- full `make dev-test`
- `make dev-lint`
- `make dev-swift-build PRODUCT=repoprompt-mcp`
- token-scrubbed release build of `repoprompt-mcp`
- exact env-isolated optimized helper `-e windows` probe against the existing app socket: exit 0, empty stderr

No app launch, install, relaunch, or local replacement was performed.