### PR TITLE
Prefer OpenCode provider path before native defaults

### DIFF
--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/OpenCode/OpenCodeACPLaunchResolver.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/OpenCode/OpenCodeACPLaunchResolver.swift
@@ -123,7 +123,7 @@ final class OpenCodeACPLaunchResolver: @unchecked Sendable {
             return try resolveExplicitLaunch(for: config, environment: environment)
         }
 
-        let effectiveHints = CLIPathHints.nativeDefaultsSupplemented(with: config.additionalPathHints)
+        let effectiveHints = Self.effectiveSearchPaths(providerSpecificPaths: config.additionalPathHints)
         let resolved = CommandPathResolver.resolve(
             configuredCommand,
             environment: environment,
@@ -145,7 +145,7 @@ final class OpenCodeACPLaunchResolver: @unchecked Sendable {
         guard configuredCommand.contains("/") else {
             throw OpenCodeACPLaunchResolutionError.environmentDiscoveryRequired(configuredCommand)
         }
-        let effectiveHints = CLIPathHints.nativeDefaultsSupplemented(with: config.additionalPathHints)
+        let effectiveHints = Self.effectiveSearchPaths(providerSpecificPaths: config.additionalPathHints)
         return try validatedLaunch(
             entryPath: CommandPathResolver.expandPath(configuredCommand, environment: environment),
             configuredCommand: configuredCommand,
@@ -205,5 +205,9 @@ final class OpenCodeACPLaunchResolver: @unchecked Sendable {
 
     private func cacheKey(for config: OpenCodeAgentConfig) -> String {
         ([config.commandName] + config.additionalPathHints).joined(separator: "\u{1F}")
+    }
+
+    private static func effectiveSearchPaths(providerSpecificPaths: [String]) -> [String] {
+        CLILaunchProfiles.providerSpecificPathsSupplementedWithNativeDefaults(providerSpecificPaths)
     }
 }

--- a/Sources/RepoPrompt/Infrastructure/Process/CLILaunchProfile.swift
+++ b/Sources/RepoPrompt/Infrastructure/Process/CLILaunchProfile.swift
@@ -51,7 +51,7 @@ enum CLILaunchProfiles {
     static let openCode = CLILaunchProfile(
         commandName: "opencode",
         preferredBasenames: ["opencode"],
-        supplementalSearchPaths: nativeDefaultsSupplemented(with: openCodeProviderSpecificPaths)
+        supplementalSearchPaths: providerSpecificPathsSupplementedWithNativeDefaults(openCodeProviderSpecificPaths)
     )
 
     static let cursor = CLILaunchProfile(
@@ -62,6 +62,10 @@ enum CLILaunchProfiles {
 
     static func nativeDefaultsSupplemented(with providerSpecificPaths: [String]) -> [String] {
         orderedUnique(CLINativePathDefaults.defaultAdditionalPaths + providerSpecificPaths)
+    }
+
+    static func providerSpecificPathsSupplementedWithNativeDefaults(_ providerSpecificPaths: [String]) -> [String] {
+        orderedUnique(providerSpecificPaths + CLINativePathDefaults.defaultAdditionalPaths)
     }
 
     private static func orderedUnique(_ paths: [String]) -> [String] {

--- a/Tests/RepoPromptTests/AgentMode/OpenCodeACPLaunchResolverTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/OpenCodeACPLaunchResolverTests.swift
@@ -53,8 +53,11 @@ final class OpenCodeACPLaunchResolverTests: XCTestCase {
         let fakeHome = try makeTemporaryDirectory()
         let minimalPath = try makeTemporaryDirectory()
         let openCodeBin = fakeHome.appendingPathComponent(".opencode/bin", isDirectory: true)
+        let nativeFallbackBin = fakeHome.appendingPathComponent(".local/bin", isDirectory: true)
         try FileManager.default.createDirectory(at: openCodeBin, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: nativeFallbackBin, withIntermediateDirectories: true)
         let executable = try makeExecutable(in: openCodeBin)
+        _ = try makeExecutable(in: nativeFallbackBin, output: "Native fallback OpenCode ACP support")
         let environment = [
             "HOME": fakeHome.path,
             "PATH": minimalPath.path,

--- a/Tests/RepoPromptTests/AgentMode/OpenCodeACPLaunchResolverTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/OpenCodeACPLaunchResolverTests.swift
@@ -77,7 +77,7 @@ final class OpenCodeACPLaunchResolverTests: XCTestCase {
         let openCodeHomeBin = "~/.opencode/bin"
 
         XCTAssertEqual(CLILaunchProfiles.openCodeProviderSpecificPaths, [openCodeHomeBin])
-        XCTAssertTrue(CLILaunchProfiles.openCode.supplementalSearchPaths.contains(openCodeHomeBin))
+        XCTAssertEqual(CLILaunchProfiles.openCode.supplementalSearchPaths.first, openCodeHomeBin)
         XCTAssertFalse(CLINativePathDefaults.defaultAdditionalPaths.contains(openCodeHomeBin))
         XCTAssertFalse(CLILaunchProfiles.claudeCode.supplementalSearchPaths.contains(openCodeHomeBin))
         XCTAssertFalse(CLILaunchProfiles.codex.supplementalSearchPaths.contains(openCodeHomeBin))


### PR DESCRIPTION
## Summary
- searches OpenCode provider-specific paths before generic native defaults when resolving ACP launches
- keeps the shared OpenCode launch profile in the same provider-first order
- adds a regression assertion that `~/.opencode/bin` is first for OpenCode supplemental paths

## Why
When a machine has a real `opencode` in a native/default location, resolver tests and user installs can resolve that binary before the provider-specific `~/.opencode/bin` path. OpenCode should prefer its provider-owned install location before generic fallbacks.

## Validation
- `make dev-test FILTER=OpenCodeACPLaunchResolverTests`
- `make dev-lint`
- `make dev-swift-build PRODUCT=RepoPrompt`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh commit`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh push`

## Review
- Subagent reviewer pass: no material findings after moving the ordering into `CLILaunchProfile` and adding the regression assertion.
