### PR TITLE
Synchronize CLI process output capture

### DIFF
--- a/Sources/RepoPrompt/Infrastructure/Process/CLIProcessRunner.swift
+++ b/Sources/RepoPrompt/Infrastructure/Process/CLIProcessRunner.swift
@@ -239,8 +239,7 @@ final class CLIProcessRunner {
             } operation: {
                 // 1) Immediately start draining child output (prevents cross‑pipe back‑pressure)
                 let group = DispatchGroup()
-                var stdoutData = Data()
-                var stderrData = Data()
+                let outputBuffer = LockedProcessOutputBuffer()
 
                 group.enter()
                 DispatchQueue.global(qos: .userInitiated).async {
@@ -248,7 +247,7 @@ final class CLIProcessRunner {
                     let chunkSize = 64 * 1024
                     while true {
                         guard let chunk = try? spawned.stdout.read(upToCount: chunkSize), !chunk.isEmpty else { break }
-                        stdoutData.append(chunk)
+                        outputBuffer.appendStdout(chunk)
                     }
                 }
 
@@ -258,7 +257,7 @@ final class CLIProcessRunner {
                     let chunkSize = 64 * 1024
                     while true {
                         guard let chunk = try? spawned.stderr.read(upToCount: chunkSize), !chunk.isEmpty else { break }
-                        stderrData.append(chunk)
+                        outputBuffer.appendStderr(chunk)
                     }
                 }
 
@@ -328,11 +327,14 @@ final class CLIProcessRunner {
                 spawned.stdout.closeFile()
                 spawned.stderr.closeFile()
                 await Self.waitForGroup(group)
-                if !stdoutData.isEmpty {
-                    config.logCollector?.appendDataSection(title: "STDOUT", data: stdoutData)
+                let outputSnapshot = outputBuffer.snapshot()
+                let capturedStdoutData = outputSnapshot.stdout
+                let capturedStderrData = outputSnapshot.stderr
+                if !capturedStdoutData.isEmpty {
+                    config.logCollector?.appendDataSection(title: "STDOUT", data: capturedStdoutData)
                 }
-                if !stderrData.isEmpty {
-                    config.logCollector?.appendDataSection(title: "STDERR", data: stderrData)
+                if !capturedStderrData.isEmpty {
+                    config.logCollector?.appendDataSection(title: "STDERR", data: capturedStderrData)
                 }
                 log("Process \(spawned.pid) exited with status \(status) (timed out: \(timedOut))")
                 // On success, memorize the absolute path for next time.
@@ -341,7 +343,7 @@ final class CLIProcessRunner {
                 {
                     await ResolvedCommandCache.shared.put(resolvedCommand, for: config.command)
                 }
-                return Result(stdout: stdoutData, stderr: stderrData, status: status, timedOut: timedOut)
+                return Result(stdout: capturedStdoutData, stderr: capturedStderrData, status: status, timedOut: timedOut)
             }
         }
     }
@@ -823,5 +825,30 @@ final class CLIProcessRunner {
                 throw CLIProcessRunnerError.waitFailed(message)
             }
         }
+    }
+}
+
+private final class LockedProcessOutputBuffer: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stdout = Data()
+    private var stderr = Data()
+
+    func appendStdout(_ data: Data) {
+        lock.lock()
+        stdout.append(data)
+        lock.unlock()
+    }
+
+    func appendStderr(_ data: Data) {
+        lock.lock()
+        stderr.append(data)
+        lock.unlock()
+    }
+
+    func snapshot() -> (stdout: Data, stderr: Data) {
+        lock.lock()
+        let output = (stdout, stderr)
+        lock.unlock()
+        return output
     }
 }

--- a/Tests/RepoPromptTests/AI/CLIProcessRunnerLifecycleTests.swift
+++ b/Tests/RepoPromptTests/AI/CLIProcessRunnerLifecycleTests.swift
@@ -3,6 +3,29 @@ import Foundation
 import XCTest
 
 final class CLIProcessRunnerLifecycleTests: XCTestCase {
+    func testRunCapturesFastProcessOutputReliably() async throws {
+        let scriptURL = try makeFastOutputScript()
+        let runner = CLIProcessRunner(
+            config: CLIProcessConfiguration(command: scriptURL.path, enableDebugLogging: false)
+        )
+
+        for index in 0 ..< 100 {
+            let expectedStdout = "stdout-\(index)-" + String(repeating: "x", count: 256)
+            let expectedStderr = "stderr-\(index)-" + String(repeating: "y", count: 256)
+            let result = try await runner.run(
+                args: [expectedStdout, expectedStderr],
+                stdin: nil,
+                outputMode: .none,
+                timeout: 2
+            )
+
+            XCTAssertEqual(String(data: result.stdout, encoding: .utf8), expectedStdout)
+            XCTAssertEqual(String(data: result.stderr, encoding: .utf8), expectedStderr)
+            XCTAssertEqual(result.status, 0)
+            XCTAssertFalse(result.timedOut)
+        }
+    }
+
     func testStreamingProcessLifecycleCallbacksUseSamePIDAndTerminate() async throws {
         let recorder = ProcessLifecycleRecorder()
         let runner = CLIProcessRunner(
@@ -72,6 +95,27 @@ final class CLIProcessRunnerLifecycleTests: XCTestCase {
         let snapshot = await recorder.snapshot()
         XCTAssertNotNil(snapshot.startedPID)
         XCTAssertEqual(snapshot.terminatedPID, snapshot.startedPID)
+    }
+
+    private func makeFastOutputScript() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CLIProcessRunnerLifecycleTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let scriptURL = directory.appendingPathComponent("fast_output.py")
+        let script = #"""
+        #!/usr/bin/env python3
+        import sys
+        sys.stdout.write(sys.argv[1])
+        sys.stdout.flush()
+        sys.stderr.write(sys.argv[2])
+        sys.stderr.flush()
+        """#
+        try script.write(to: scriptURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: scriptURL.path)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: directory)
+        }
+        return scriptURL
     }
 }
 


### PR DESCRIPTION
## Summary
- protects `CLIProcessRunner.run` stdout/stderr buffers while drain queues append concurrently
- snapshots captured output after drain completion before logging and returning
- adds a regression test for fast process stdout/stderr capture

## Why
Full-suite pi validation exposed an order/load-sensitive version-probe failure where a short-lived fake `pi --version` process exited successfully but stdout was sometimes observed as empty. The process runner was mutating captured stdout/stderr `Data` from drain queues without synchronization. This is a generic process-runner correctness fix and is kept separate from the pi provider PR.

## Stack note
This branch is currently stacked on #148 (`Prefer OpenCode provider path before native defaults`) because local full-suite validation needs that independent OpenCode test-isolation fix. After #148 merges, this PR can be rebased onto `main` and should show only the CLIProcessRunner changes.

## Validation
- `make dev-test FILTER=CLIProcessRunnerLifecycleTests\|PiIntegrationConfigurationTests`
- `make dev-lint`
- `make dev-swift-build PRODUCT=RepoPrompt`
- subagent reviewer: no material findings
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh commit`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh push`
