### PR TITLE
Fix expired Agent Mode wait tracking after steering

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+Types.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+Types.swift
@@ -207,6 +207,23 @@ extension AgentModeViewModel {
         /// The task label kind for this MCP-controlled run (e.g. explore, engineer).
         /// Used to customize tool advertisement and system prompts for role-specific behavior.
         let taskLabelKind: AgentModelCatalog.TaskLabelKind?
+
+        func replacingRegistration(_ registration: AgentRunSessionStore.Registration) -> Self {
+            Self(
+                sessionID: sessionID,
+                activationID: activationID,
+                registration: registration,
+                currentEpoch: currentEpoch,
+                preparedEpoch: preparedEpoch,
+                pendingEpochTransition: pendingEpochTransition,
+                originatingConnectionID: originatingConnectionID,
+                interactionTransport: interactionTransport,
+                suppressUserNotifications: suppressUserNotifications,
+                forceAutoEditEnabled: forceAutoEditEnabled,
+                autoEditEnabledBeforeOverride: autoEditEnabledBeforeOverride,
+                taskLabelKind: taskLabelKind
+            )
+        }
     }
 
     /// Internal for cross-file AgentModeViewModel extension access after the mechanical file split.

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -4403,23 +4403,61 @@ final class AgentModeViewModel: ObservableObject {
         } else {
             .unrelated
         }
-        let result = await AgentRunSessionStore.beginEpoch(
-            registration: originalContext.registration,
+        let activationGeneration = session.mcpControlActivationGeneration
+        var registration = originalContext.registration
+        var result = await AgentRunSessionStore.beginEpoch(
+            registration: registration,
             activationID: originalContext.activationID,
             expectedCurrentEpoch: originalContext.currentEpoch,
             transitionKind: transitionKind
         )
+        // A stale result means the existing record advanced to another epoch; only rejected
+        // results are eligible for missing-record recovery through registerIfMissing.
+        if case .rejected = result {
+            guard session.mcpControlActivationGeneration == activationGeneration,
+                  let context = session.mcpControlContext,
+                  context.activationID == originalContext.activationID,
+                  context.registration == originalContext.registration,
+                  context.currentEpoch == originalContext.currentEpoch,
+                  let recoveredRegistration = await AgentRunSessionStore.registerIfMissing(
+                      sessionID: originalContext.sessionID
+                  )
+            else {
+                return
+            }
+            guard session.mcpControlActivationGeneration == activationGeneration,
+                  let context = session.mcpControlContext,
+                  context.activationID == originalContext.activationID,
+                  context.registration == originalContext.registration,
+                  context.currentEpoch == originalContext.currentEpoch
+            else {
+                await AgentRunSessionStore.cleanup(registration: recoveredRegistration)
+                return
+            }
+            registration = recoveredRegistration
+            result = await AgentRunSessionStore.beginEpoch(
+                registration: registration,
+                activationID: originalContext.activationID,
+                expectedCurrentEpoch: nil,
+                transitionKind: transitionKind
+            )
+        }
         #if DEBUG
             await test_afterMCPStoreEpochBegan?()
         #endif
         guard case let .accepted(epoch) = result,
+              session.mcpControlActivationGeneration == activationGeneration,
               var context = session.mcpControlContext,
               context.activationID == originalContext.activationID,
               context.registration == originalContext.registration,
               context.currentEpoch == originalContext.currentEpoch || context.currentEpoch == epoch
         else {
+            if registration != originalContext.registration {
+                await AgentRunSessionStore.cleanup(registration: registration)
+            }
             return
         }
+        context = context.replacingRegistration(registration)
         context.currentEpoch = epoch
         context.preparedEpoch = epoch
         let pendingTransitionToken = context.pendingEpochTransition?.token

--- a/Sources/RepoPrompt/Infrastructure/MCP/Agent/AgentRunSessionStore.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/Agent/AgentRunSessionStore.swift
@@ -89,6 +89,13 @@ actor AgentRunSessionStore {
         return registration
     }
 
+    func registerIfMissing(sessionID: UUID) -> Registration? {
+        guard records[sessionID] == nil else { return nil }
+        let registration = makeRegistration(sessionID: sessionID)
+        records[sessionID] = Record(registration: registration)
+        return registration
+    }
+
     func beginEpoch(
         registration: Registration,
         activationID: UUID,
@@ -677,6 +684,10 @@ actor AgentRunSessionStore {
 extension AgentRunSessionStore {
     static func register(sessionID: UUID) async -> Registration {
         await shared.register(sessionID: sessionID)
+    }
+
+    static func registerIfMissing(sessionID: UUID) async -> Registration? {
+        await shared.registerIfMissing(sessionID: sessionID)
     }
 
     static func beginEpoch(

--- a/Tests/RepoPromptTests/AgentMode/AgentModeMCPWaitEpochTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeMCPWaitEpochTests.swift
@@ -196,6 +196,181 @@ final class AgentModeMCPWaitEpochTests: XCTestCase {
         await viewModel.mcpDeactivateControlContext(sessionID: sessionID, cleanupSessionStore: true)
     }
 
+    func testInactiveSteeringReRegistersWaitTrackingAfterTerminalRecordExpires() async throws {
+        let viewModel = makeViewModel()
+        let sessionID = UUID()
+        let session = await viewModel.ensureSessionReady(tabID: UUID())
+        _ = viewModel.test_installPersistentSessionBinding(sessionID: sessionID, on: session)
+        try await viewModel.mcpActivateControlContext(
+            forTabID: session.tabID,
+            sessionID: sessionID,
+            originatingConnectionID: nil,
+            startPending: true
+        )
+        await viewModel.prepareMCPWaitTrackingForRunStart(session: session)
+        _ = session.beginRunAttempt(source: "test.expiredSteering")
+        let initialContext = try XCTUnwrap(session.mcpControlContext)
+        let initialEpoch = try XCTUnwrap(initialContext.currentEpoch)
+        session.runState = .completed
+        session.mcpFollowUpRunPending = false
+
+        let terminal = makeSnapshot(sessionID: sessionID, status: .completed)
+        let publication = await AgentRunSessionStore.publishTerminal(
+            .init(epoch: initialEpoch, snapshot: terminal),
+            registration: initialContext.registration,
+            commitID: UUID(),
+            successorKind: nil
+        )
+        XCTAssertEqual(publication, .accepted(successorEpoch: nil))
+        await AgentRunSessionStore.shared.test_expire(
+            cursor: .init(registration: initialContext.registration, epoch: initialEpoch)
+        )
+        let hasExpiredRegistration = await AgentRunSessionStore.hasActiveRegistration(sessionID: sessionID)
+        XCTAssertFalse(hasExpiredRegistration)
+
+        try await viewModel.withMCPRunEpochTransition(sessionID: sessionID, kind: .steering) {
+            await viewModel.prepareMCPWaitTrackingForRunStart(session: session)
+        }
+
+        let steeringContext = try XCTUnwrap(session.mcpControlContext)
+        let steeringEpoch = try XCTUnwrap(steeringContext.currentEpoch)
+        XCTAssertEqual(steeringContext.activationID, initialContext.activationID)
+        XCTAssertNotEqual(steeringContext.registration, initialContext.registration)
+        XCTAssertEqual(steeringEpoch.transitionKind, .steering)
+        XCTAssertEqual(steeringEpoch.registrationGeneration, steeringContext.registration.generation)
+        XCTAssertNil(steeringContext.pendingEpochTransition)
+
+        let steeringCursor = AgentRunSessionStore.WaitCursor(
+            registration: steeringContext.registration,
+            epoch: steeringEpoch
+        )
+        let waitTask = Task {
+            await AgentRunMCPToolService.test_waitUntilActionableDisposition(
+                sessionID: sessionID,
+                timeoutSeconds: 1
+            )
+        }
+        try await waitForWaiter(registration: steeringContext.registration)
+        let actionable = makeSnapshot(sessionID: sessionID, status: .waitingForInput)
+        await AgentRunSessionStore.signalSnapshot(actionable, cursor: steeringCursor)
+        let waitResult = await waitTask.value
+        XCTAssertEqual(waitResult.disposition, "actionable")
+        XCTAssertEqual(waitResult.snapshotStatus, AgentRunMCPSnapshot.Status.waitingForInput.rawValue)
+        await viewModel.mcpDeactivateControlContext(sessionID: sessionID, cleanupSessionStore: true)
+    }
+
+    func testExpiredRegistrationRecoveryCannotOverwriteReplacementActivation() async throws {
+        let viewModel = makeViewModel()
+        let sessionID = UUID()
+        let session = await viewModel.ensureSessionReady(tabID: UUID())
+        _ = viewModel.test_installPersistentSessionBinding(sessionID: sessionID, on: session)
+        try await viewModel.mcpActivateControlContext(
+            forTabID: session.tabID,
+            sessionID: sessionID,
+            originatingConnectionID: nil,
+            startPending: true
+        )
+        await viewModel.prepareMCPWaitTrackingForRunStart(session: session)
+        _ = session.beginRunAttempt(source: "test.expiredActivationRace")
+        let initialContext = try XCTUnwrap(session.mcpControlContext)
+        let initialEpoch = try XCTUnwrap(initialContext.currentEpoch)
+        session.runState = .completed
+        session.mcpFollowUpRunPending = false
+        _ = await AgentRunSessionStore.publishTerminal(
+            .init(
+                epoch: initialEpoch,
+                snapshot: makeSnapshot(sessionID: sessionID, status: .completed)
+            ),
+            registration: initialContext.registration,
+            commitID: UUID(),
+            successorKind: nil
+        )
+        await AgentRunSessionStore.shared.test_expire(
+            cursor: .init(registration: initialContext.registration, epoch: initialEpoch)
+        )
+
+        let gate = EpochBeginGate()
+        viewModel.test_setAfterMCPStoreEpochBegan {
+            await gate.pause()
+        }
+        defer { viewModel.test_setAfterMCPStoreEpochBegan(nil) }
+        let recoveryTask = Task {
+            try await viewModel.withMCPRunEpochTransition(sessionID: sessionID, kind: .steering) {
+                await viewModel.prepareMCPWaitTrackingForRunStart(session: session)
+            }
+        }
+        await gate.waitUntilPaused()
+
+        try await viewModel.mcpActivateControlContext(
+            forTabID: session.tabID,
+            sessionID: sessionID,
+            originatingConnectionID: UUID()
+        )
+        let replacementContext = try XCTUnwrap(session.mcpControlContext)
+        XCTAssertNotEqual(replacementContext.activationID, initialContext.activationID)
+        XCTAssertNotEqual(replacementContext.registration, initialContext.registration)
+
+        await gate.open()
+        try await recoveryTask.value
+
+        let finalContext = try XCTUnwrap(session.mcpControlContext)
+        let currentRegistration = await AgentRunSessionStore.currentRegistration(for: sessionID)
+        XCTAssertEqual(finalContext, replacementContext)
+        XCTAssertEqual(currentRegistration, replacementContext.registration)
+        await viewModel.mcpDeactivateControlContext(sessionID: sessionID, cleanupSessionStore: true)
+    }
+
+    func testExpiredRegistrationRecoveryCleansStoreRecordAfterDeactivation() async throws {
+        let viewModel = makeViewModel()
+        let sessionID = UUID()
+        let session = await viewModel.ensureSessionReady(tabID: UUID())
+        _ = viewModel.test_installPersistentSessionBinding(sessionID: sessionID, on: session)
+        try await viewModel.mcpActivateControlContext(
+            forTabID: session.tabID,
+            sessionID: sessionID,
+            originatingConnectionID: nil,
+            startPending: true
+        )
+        await viewModel.prepareMCPWaitTrackingForRunStart(session: session)
+        _ = session.beginRunAttempt(source: "test.expiredDeactivationRace")
+        let initialContext = try XCTUnwrap(session.mcpControlContext)
+        let initialEpoch = try XCTUnwrap(initialContext.currentEpoch)
+        session.runState = .completed
+        session.mcpFollowUpRunPending = false
+        _ = await AgentRunSessionStore.publishTerminal(
+            .init(
+                epoch: initialEpoch,
+                snapshot: makeSnapshot(sessionID: sessionID, status: .completed)
+            ),
+            registration: initialContext.registration,
+            commitID: UUID(),
+            successorKind: nil
+        )
+        await AgentRunSessionStore.shared.test_expire(
+            cursor: .init(registration: initialContext.registration, epoch: initialEpoch)
+        )
+
+        let gate = EpochBeginGate()
+        viewModel.test_setAfterMCPStoreEpochBegan {
+            await gate.pause()
+        }
+        defer { viewModel.test_setAfterMCPStoreEpochBegan(nil) }
+        let recoveryTask = Task {
+            try await viewModel.withMCPRunEpochTransition(sessionID: sessionID, kind: .steering) {
+                await viewModel.prepareMCPWaitTrackingForRunStart(session: session)
+            }
+        }
+        await gate.waitUntilPaused()
+
+        await viewModel.mcpDeactivateControlContext(sessionID: sessionID, cleanupSessionStore: true)
+        await gate.open()
+        try await recoveryTask.value
+
+        XCTAssertNil(session.mcpControlContext)
+        let hasActiveRegistration = await AgentRunSessionStore.hasActiveRegistration(sessionID: sessionID)
+        XCTAssertFalse(hasActiveRegistration)
+    }
+
     func testActiveRunPreparationDoesNotCreateSteeringEpoch() async throws {
         let viewModel = makeViewModel()
         let sessionID = UUID()

--- a/Tests/RepoPromptTests/MCP/AgentRunSessionStoreRegistrationTests.swift
+++ b/Tests/RepoPromptTests/MCP/AgentRunSessionStoreRegistrationTests.swift
@@ -30,6 +30,18 @@ final class AgentRunSessionStoreRegistrationTests: XCTestCase {
         await AgentRunSessionStore.cleanup(registration: replacement)
     }
 
+    func testRegisterIfMissingDoesNotReplaceExistingRegistration() async {
+        let sessionID = UUID()
+        let registration = await AgentRunSessionStore.register(sessionID: sessionID)
+
+        let recovered = await AgentRunSessionStore.registerIfMissing(sessionID: sessionID)
+        let current = await AgentRunSessionStore.currentRegistration(for: sessionID)
+
+        XCTAssertNil(recovered)
+        XCTAssertEqual(current, registration)
+        await AgentRunSessionStore.cleanup(registration: registration)
+    }
+
     func testPreEpochWaiterAdvancesWithoutRotatingActivationRegistration() async throws {
         let sessionID = UUID()
         let registration = await AgentRunSessionStore.register(sessionID: sessionID)


### PR DESCRIPTION
## Summary
- recover `AgentRunSessionStore` tracking when inactive steering resumes after the terminal-record TTL expires
- preserve newer MCP activations across recovery races and clean orphaned recovered registrations during teardown
- add deterministic regression coverage for expired waits, activation replacement, deactivation, and atomic registration recovery

## Testing
- `make dev-test`
- `make dev-lint`
- `make dev-swift-build PRODUCT=RepoPrompt`
- `make dev-test FILTER=AgentModeMCPWaitEpochTests`
- `make dev-test FILTER=AgentRunSessionStoreRegistrationTests`
- commit and push contribution preflights, including staged/outgoing secret scans and repository guardrails

## Live smoke
- `make dev-smoke` was attempted non-disruptively, but the currently running CE app only exposed the Default workspace and failed at workspace switching because MCP routing was unavailable for window 1.
- No app launch, relaunch, or stop was performed.
