### PR TITLE
Fix Codex steering and composer submission races

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentModeRunService.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentModeRunService.swift
@@ -158,7 +158,8 @@ final class AgentModeRunService {
         session: AgentModeViewModel.TabSession,
         initialUserMessage: String,
         initialMessageForRun: String,
-        attachments: [AgentImageAttachment]
+        attachments: [AgentImageAttachment],
+        codexFallbackContext: AgentModeViewModel.TabSession.CodexFallbackSubmissionContext? = nil
     ) async -> CodexAgentModeCoordinator.NativeSendOutcome? {
         assert(session.tabID == tabID, "AgentModeRunService.startRun requires the originating tab ID to match the TabSession tab ID")
         let selectedAgent = session.selectedAgent
@@ -180,7 +181,8 @@ final class AgentModeRunService {
                 tabID: tabID,
                 session: session,
                 initialMessageForRun: initialMessageForRun,
-                attachments: attachments
+                attachments: attachments,
+                fallbackContext: codexFallbackContext
             )
         }
 
@@ -1014,6 +1016,12 @@ final class AgentModeRunService {
         let provider = session.provider
         let acpController = session.acpController
         let hasAttemptTerminalResources = session.runAttemptTerminalResources?.ownership == ownership
+        let codexCancellationTarget = session.selectedAgent == .codexExec
+            ? dependencies.codexCoordinator.captureCodexCancellationTarget(
+                session,
+                expectedRunID: expectedRunID
+            )
+            : nil
         session.agentTask?.cancel()
 
         if session.selectedAgent == .codexExec {
@@ -1040,7 +1048,8 @@ final class AgentModeRunService {
                 if session.selectedAgent == .codexExec {
                     return dependencies.codexCoordinator.prepareCodexCancellationTeardown(
                         session,
-                        expectedRunID: expectedRunID
+                        expectedRunID: expectedRunID,
+                        capturedTarget: codexCancellationTarget
                     )
                 }
                 if session.selectedAgent.usesClaudeNativeRuntime {

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentRunTerminalCommitBarrier.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentRunTerminalCommitBarrier.swift
@@ -15,10 +15,20 @@ struct AgentRunTerminalCommitRevision: Equatable {
     let providerDrainGeneration: UInt64
     let mcpPublicationEnvelope: AgentRunTerminalPublicationEnvelope?
     let successorKind: AgentRunEpochTransitionKind?
+    let providerSuccessorID: UUID?
 }
 
 @MainActor
 final class AgentRunTerminalCommitBarrier {
+    struct ProviderSuccessor {
+        let id: UUID
+        let transitionKind: AgentRunEpochTransitionKind
+        let consumeAfterPublication: (
+            AgentRunTerminalCommitRevision,
+            AgentRunTerminalPublicationResult
+        ) -> Bool
+    }
+
     struct Request {
         let session: AgentModeViewModel.TabSession
         let ownership: AgentRunOwnership
@@ -31,6 +41,7 @@ final class AgentRunTerminalCommitBarrier {
         let attachmentDisposition: AgentModeViewModel.AttachmentTurnDisposition
         let finalizeNonCodexUsage: Bool
         let supportsFollowUp: Bool
+        let providerSuccessor: ProviderSuccessor?
         let notifyTurnComplete: Bool
         let providerDrainGeneration: UInt64
         let providerBuffersAreDrained: () -> Bool
@@ -49,6 +60,7 @@ final class AgentRunTerminalCommitBarrier {
             attachmentDisposition: AgentModeViewModel.AttachmentTurnDisposition,
             finalizeNonCodexUsage: Bool,
             supportsFollowUp: Bool,
+            providerSuccessor: ProviderSuccessor? = nil,
             notifyTurnComplete: Bool,
             providerDrainGeneration: UInt64 = 0,
             providerBuffersAreDrained: @escaping () -> Bool = { true },
@@ -66,6 +78,7 @@ final class AgentRunTerminalCommitBarrier {
             self.attachmentDisposition = attachmentDisposition
             self.finalizeNonCodexUsage = finalizeNonCodexUsage
             self.supportsFollowUp = supportsFollowUp
+            self.providerSuccessor = providerSuccessor
             self.notifyTurnComplete = notifyTurnComplete
             self.providerDrainGeneration = providerDrainGeneration
             self.providerBuffersAreDrained = providerBuffersAreDrained
@@ -76,6 +89,9 @@ final class AgentRunTerminalCommitBarrier {
 
     private let hooks: AgentModeRunService.Hooks
     private var terminalTeardownTasks: [AgentRunOwnership: Task<Void, Never>] = [:]
+    private var consumedProviderSuccessorIDs: Set<UUID> = []
+    private var consumedProviderSuccessorOrder: [UUID] = []
+    private let maxConsumedProviderSuccessorTombstones = 512
 
     init(hooks: AgentModeRunService.Hooks) {
         self.hooks = hooks
@@ -113,6 +129,16 @@ final class AgentRunTerminalCommitBarrier {
             ) {
                 hooks.startFollowUpRun(session.tabID, followUpInstruction)
             }
+            if let providerSuccessor = request.providerSuccessor,
+               providerSuccessor.id == existingRevision.providerSuccessorID,
+               let publicationResult = session.lastTerminalPublicationResult
+            {
+                notifyProviderSuccessor(
+                    providerSuccessor,
+                    revision: existingRevision,
+                    publicationResult: publicationResult
+                )
+            }
             return existingRevision
         }
         guard validatesOwnership(request) else {
@@ -146,7 +172,14 @@ final class AgentRunTerminalCommitBarrier {
         let queuedInstruction = request.terminalState == .completed && request.supportsFollowUp
             ? session.pendingInstructions.first
             : nil
-        if queuedInstruction != nil {
+        let providerSuccessor = request.terminalState == .completed
+            ? request.providerSuccessor
+            : nil
+        assert(
+            queuedInstruction == nil || providerSuccessor == nil,
+            "Generic and provider-specific successors must not drain from the same terminal commit"
+        )
+        if queuedInstruction != nil || providerSuccessor != nil {
             session.mcpFollowUpRunPending = true
         }
 
@@ -207,7 +240,11 @@ final class AgentRunTerminalCommitBarrier {
         hooks.setAgentRunActive(session.tabID, false)
         hooks.prepareTerminalPublication(session)
 
-        let successorKind: AgentRunEpochTransitionKind? = queuedInstruction == nil ? nil : .relatedFollowUp
+        let successorKind: AgentRunEpochTransitionKind? = if queuedInstruction != nil {
+            .relatedFollowUp
+        } else {
+            providerSuccessor?.transitionKind
+        }
         let revision = AgentRunTerminalCommitRevision(
             commitID: UUID(),
             ownership: request.ownership,
@@ -220,7 +257,8 @@ final class AgentRunTerminalCommitBarrier {
                 request.ownership,
                 request.terminalState
             ),
-            successorKind: successorKind
+            successorKind: successorKind,
+            providerSuccessorID: providerSuccessor?.id
         )
         session.lastTerminalCommitRevision = revision
         session.lastTerminalPublicationResult = nil
@@ -240,6 +278,15 @@ final class AgentRunTerminalCommitBarrier {
             revision: revision,
             publicationResult: session.lastTerminalPublicationResult
         )
+        if let providerSuccessor,
+           let publicationResult = session.lastTerminalPublicationResult
+        {
+            notifyProviderSuccessor(
+                providerSuccessor,
+                revision: revision,
+                publicationResult: publicationResult
+            )
+        }
         let teardownTask = registerTerminalTeardown(
             teardown,
             ownership: request.ownership,
@@ -265,12 +312,36 @@ final class AgentRunTerminalCommitBarrier {
         return revision
     }
 
+    private func notifyProviderSuccessor(
+        _ providerSuccessor: ProviderSuccessor,
+        revision: AgentRunTerminalCommitRevision,
+        publicationResult: AgentRunTerminalPublicationResult
+    ) {
+        if case .accepted = publicationResult {
+            guard !consumedProviderSuccessorIDs.contains(providerSuccessor.id) else {
+                return
+            }
+            guard providerSuccessor.consumeAfterPublication(revision, publicationResult) else {
+                return
+            }
+            consumedProviderSuccessorIDs.insert(providerSuccessor.id)
+            consumedProviderSuccessorOrder.append(providerSuccessor.id)
+            while consumedProviderSuccessorOrder.count > maxConsumedProviderSuccessorTombstones {
+                let expiredID = consumedProviderSuccessorOrder.removeFirst()
+                consumedProviderSuccessorIDs.remove(expiredID)
+            }
+            return
+        }
+        _ = providerSuccessor.consumeAfterPublication(revision, publicationResult)
+    }
+
     private func takeQueuedFollowUpIfReady(
         session: AgentModeViewModel.TabSession,
         revision: AgentRunTerminalCommitRevision,
         publicationResult: AgentRunTerminalPublicationResult?
     ) -> String? {
         guard revision.successorKind != nil,
+              revision.providerSuccessorID == nil,
               let publicationResult
         else { return nil }
         switch publicationResult {

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Codex/CodexAgentModeCoordinator.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Codex/CodexAgentModeCoordinator.swift
@@ -1888,6 +1888,42 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
         session.codexPendingSteerLifecycleReconciliation = nil
     }
 
+    /// A steer the server accepted into a different turn already delivered the
+    /// user's input, so this rebinds lifecycle identity without resending.
+    private func reconcileAcceptedCodexSteerMismatch(
+        from identity: AgentModeViewModel.TabSession.CodexAuthoritativeTurnIdentity,
+        acceptedTurnID: String,
+        controller: any CodexSessionControlling,
+        session: AgentModeViewModel.TabSession
+    ) async {
+        guard session.codexAuthoritativeActiveTurn == identity,
+              authoritativeCodexTurnIsCurrent(identity, session: session),
+              session.codexController.map(ObjectIdentifier.init) == ObjectIdentifier(controller)
+        else { return }
+        logCodex(
+            "[AgentModeVM] sendCodexNativeMessage: steer accepted into different turn expected=\(identity.turnID) actual=\(acceptedTurnID); reconciling without resend"
+        )
+        let reconciliation = AgentModeViewModel.TabSession.CodexPendingSteerLifecycleReconciliation(
+            priorIdentity: identity,
+            acceptedDispatchTurnID: acceptedTurnID
+        )
+        session.codexPendingSteerLifecycleReconciliation = reconciliation
+        let prepared = await controller.prepareLifecycleAuthorityReconciliationAfterAcceptedMismatch(
+            expectedCurrentTurnID: identity.turnID,
+            acceptedDispatchTurnID: acceptedTurnID
+        )
+        if !prepared {
+            logCodex(
+                "[AgentModeVM] sendCodexNativeMessage: controller lifecycle authority unavailable for accepted steer turn=\(acceptedTurnID); relying on session-level reconciliation"
+            )
+        }
+        if session.codexPendingSteerLifecycleReconciliation == reconciliation,
+           session.codexAuthoritativeActiveTurn != identity
+        {
+            session.codexPendingSteerLifecycleReconciliation = nil
+        }
+    }
+
     private func codexFallbackBlockingTurn(
         for identity: AgentModeViewModel.TabSession.CodexAuthoritativeTurnIdentity
     ) -> AgentModeViewModel.TabSession.CodexFallbackBlockingTurn {
@@ -4236,11 +4272,19 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
             case let .steer(identity):
                 logCodex("[AgentModeVM] sendCodexNativeMessage: calling controller.steerUserTurn expectedTurnID=\(identity.turnID)")
                 do {
-                    _ = try await controller.steerUserTurn(
+                    let receipt = try await controller.steerUserTurn(
                         text: text,
                         images: attachments,
                         expectedTurnID: identity.turnID
                     )
+                    if receipt.acceptedTurnID != identity.turnID {
+                        await reconcileAcceptedCodexSteerMismatch(
+                            from: identity,
+                            acceptedTurnID: receipt.acceptedTurnID,
+                            controller: controller,
+                            session: session
+                        )
+                    }
                 } catch let mismatch as CodexTurnSteerError {
                     guard case let .expectedTurnMismatch(expectedTurnID, actualTurnID, failure) = mismatch,
                           let actualTurnID = actualTurnID?.trimmingCharacters(in: .whitespacesAndNewlines),

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Codex/CodexAgentModeCoordinator.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Codex/CodexAgentModeCoordinator.swift
@@ -185,24 +185,29 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
         return String(output.reversed())
     }
 
+    typealias CodexTurnFallbackDecision = AgentModeViewModel.TabSession.CodexFallbackReason
+
     enum NativeSendOutcome: Equatable {
         case sent
+        case queuedFallback(queueID: UUID, reason: CodexTurnFallbackDecision)
         case stale(reason: String)
         case cancelled
         case failed(message: String)
 
         var didSend: Bool {
-            if case .sent = self {
-                return true
+            switch self {
+            case .sent, .queuedFallback:
+                true
+            case .stale, .cancelled, .failed:
+                false
             }
-            return false
         }
     }
 
     func isCodexCompactionInFlight(session: AgentModeViewModel.TabSession) -> Bool {
         session.codexPendingTurnKind == .compact
-            || session.codexCurrentTurnKind == .compact
-            || session.codexTurnKindsByID.values.contains(.compact)
+            || session.codexAuthoritativeActiveTurn?.turnKind == .compact
+            || session.codexAnonymousActiveTurn?.turnKind == .compact
     }
 
     private weak var viewModel: AgentModeViewModel?
@@ -1397,8 +1402,16 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
             try await controller.compactThread()
             return .succeeded("Requested Codex context compaction.")
         } catch {
-            restoreQueuedCodexCompactionInstructionsToDraft(session)
             resetTrackedCodexTurns(session)
+            if !session.codexFallbackQueue.isEmpty || session.codexFallbackDispatchInFlight != nil {
+                abandonCodexFallbackQueue(
+                    session: session,
+                    reason: "Codex queued follow-ups were cancelled because context compaction failed to start."
+                )
+            }
+            if let ownership = session.activeRunOwnership {
+                _ = session.endRunAttempt(ifCurrent: ownership, source: "codex.compaction.startFailed")
+            }
             viewModel?.setAgentRunActive(session.tabID, isActive: false)
             session.runState = .idle
             setRunningStatus(nil, source: nil, session: session)
@@ -1550,6 +1563,9 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
     }
 
     private func beginCodexCompaction(_ session: AgentModeViewModel.TabSession) {
+        if session.activeRunOwnership == nil {
+            _ = session.beginRunAttempt(source: "codex.compaction")
+        }
         session.codexPendingTurnKind = .compact
         session.runState = .running
         setRunningStatus("Compacting context…", source: .transport, session: session, urgent: true)
@@ -1562,42 +1578,168 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
         session.codexPendingTurnKind = .user
     }
 
-    private func trackedCodexTurnKindForStart(
+    private func installAuthoritativeCodexTurnForStart(
         turnID: String?,
-        session: AgentModeViewModel.TabSession
-    ) -> AgentModeViewModel.TabSession.CodexTurnKind {
-        let kind = session.codexPendingTurnKind ?? .user
-        if let turnID {
-            session.codexTurnKindsByID[turnID] = kind
-        }
-        session.codexPendingTurnKind = nil
-        session.codexCurrentTurnID = turnID
-        session.codexCurrentTurnKind = kind
-        return kind
-    }
-
-    private func correlatedCodexTurnKindForCompletion(
-        turnID: String?,
-        session: AgentModeViewModel.TabSession
+        session: AgentModeViewModel.TabSession,
+        sourceController: (any CodexSessionControlling)?
     ) -> AgentModeViewModel.TabSession.CodexTurnKind? {
-        guard let kind = session.codexCurrentTurnKind else {
-            recordRejectedCodexTurnCompletion(
-                reason: "no_observed_start",
+        guard let controller = sourceController ?? session.codexController,
+              let activeController = session.codexController,
+              Self.sameCodexControllerInstance(activeController, controller),
+              let threadID = session.codexConversationID,
+              let runID = session.runID,
+              let runAttemptID = session.activeRunAttemptID
+        else {
+            recordRejectedCodexTurnStart(
+                reason: "missing_scope",
                 eventTurnID: turnID,
                 session: session
             )
             return nil
         }
-        if let turnID {
-            guard let currentTurnID = session.codexCurrentTurnID else {
-                recordRejectedCodexTurnCompletion(
-                    reason: "missing_current_id",
+        let kind = session.codexPendingTurnKind ?? .unknown
+        let controllerInstanceID = ObjectIdentifier(controller)
+        if let turnID = turnID?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !turnID.isEmpty
+        {
+            if let current = session.codexAuthoritativeActiveTurn,
+               current.turnID == turnID,
+               authoritativeCodexTurnIsCurrent(current, session: session)
+            {
+                session.codexPendingTurnKind = nil
+                session.codexRoutingObservedTurnID = turnID
+                return current.turnKind
+            }
+            let candidate = AgentModeViewModel.TabSession.CodexAuthoritativeTurnIdentity(
+                threadID: threadID,
+                turnID: turnID,
+                turnKind: kind,
+                controllerInstanceID: controllerInstanceID,
+                controllerGeneration: session.codexControllerGeneration,
+                runID: runID,
+                runAttemptID: runAttemptID
+            )
+            if let current = session.codexAuthoritativeActiveTurn {
+                if let reconciliation = session.codexPendingSteerLifecycleReconciliation,
+                   reconciliation.priorIdentity == current,
+                   reconciliation.acceptedDispatchTurnID == turnID,
+                   authoritativeCodexTurnIsCurrent(current, session: session)
+                {
+                    let reconciled = AgentModeViewModel.TabSession.CodexAuthoritativeTurnIdentity(
+                        threadID: current.threadID,
+                        turnID: turnID,
+                        turnKind: current.turnKind,
+                        controllerInstanceID: current.controllerInstanceID,
+                        controllerGeneration: current.controllerGeneration,
+                        runID: current.runID,
+                        runAttemptID: current.runAttemptID
+                    )
+                    rebindCodexFallbackBlockers(
+                        from: codexFallbackBlockingTurn(for: current),
+                        to: codexFallbackBlockingTurn(for: reconciled),
+                        session: session
+                    )
+                    session.codexAuthoritativeActiveTurn = reconciled
+                    session.codexPendingSteerLifecycleReconciliation = nil
+                    session.codexPendingTurnKind = nil
+                    session.codexRoutingObservedTurnID = turnID
+                    return reconciled.turnKind
+                }
+                recordRejectedCodexTurnStart(
+                    reason: "authoritative_identity_mismatch",
                     eventTurnID: turnID,
                     session: session
                 )
                 return nil
             }
-            guard turnID == currentTurnID else {
+            session.codexAnonymousActiveTurn = nil
+            session.codexAuthoritativeActiveTurn = candidate
+            session.codexPendingTurnKind = nil
+            session.codexRoutingObservedTurnID = turnID
+            return kind
+        }
+
+        let candidate = AgentModeViewModel.TabSession.CodexAnonymousTurnLiveness(
+            threadID: threadID,
+            turnKind: kind,
+            controllerInstanceID: controllerInstanceID,
+            controllerGeneration: session.codexControllerGeneration,
+            runID: runID,
+            runAttemptID: runAttemptID
+        )
+        guard session.codexAuthoritativeActiveTurn == nil else {
+            recordRejectedCodexTurnStart(
+                reason: "nil_id_with_authoritative_turn",
+                eventTurnID: nil,
+                session: session
+            )
+            return nil
+        }
+        if let current = session.codexAnonymousActiveTurn,
+           current != candidate
+        {
+            recordRejectedCodexTurnStart(
+                reason: "anonymous_identity_mismatch",
+                eventTurnID: nil,
+                session: session
+            )
+            return nil
+        }
+        session.codexAnonymousActiveTurn = candidate
+        session.codexPendingTurnKind = nil
+        return kind
+    }
+
+    private struct CorrelatedCodexTurnCompletion {
+        let turnKind: AgentModeViewModel.TabSession.CodexTurnKind
+        let authoritativeIdentity: AgentModeViewModel.TabSession.CodexAuthoritativeTurnIdentity?
+    }
+
+    private func correlatedCodexTurnKindForCompletion(
+        turnID: String?,
+        session: AgentModeViewModel.TabSession
+    ) -> CorrelatedCodexTurnCompletion? {
+        if let turnID = turnID?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !turnID.isEmpty
+        {
+            guard let identity = session.codexAuthoritativeActiveTurn else {
+                recordRejectedCodexTurnCompletion(
+                    reason: "missing_authoritative_identity",
+                    eventTurnID: turnID,
+                    session: session
+                )
+                return nil
+            }
+            guard authoritativeCodexTurnIsCurrent(identity, session: session) else {
+                recordRejectedCodexTurnCompletion(
+                    reason: "stale_authoritative_identity",
+                    eventTurnID: turnID,
+                    session: session
+                )
+                return nil
+            }
+            let completedIdentity: AgentModeViewModel.TabSession.CodexAuthoritativeTurnIdentity
+            if identity.turnID == turnID {
+                completedIdentity = identity
+            } else if let reconciliation = session.codexPendingSteerLifecycleReconciliation,
+                      reconciliation.priorIdentity == identity,
+                      reconciliation.acceptedDispatchTurnID == turnID
+            {
+                completedIdentity = .init(
+                    threadID: identity.threadID,
+                    turnID: turnID,
+                    turnKind: identity.turnKind,
+                    controllerInstanceID: identity.controllerInstanceID,
+                    controllerGeneration: identity.controllerGeneration,
+                    runID: identity.runID,
+                    runAttemptID: identity.runAttemptID
+                )
+                rebindCodexFallbackBlockers(
+                    from: codexFallbackBlockingTurn(for: identity),
+                    to: codexFallbackBlockingTurn(for: completedIdentity),
+                    session: session
+                )
+            } else {
                 recordRejectedCodexTurnCompletion(
                     reason: "turn_id_mismatch",
                     eventTurnID: turnID,
@@ -1605,13 +1747,107 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
                 )
                 return nil
             }
+            session.codexAuthoritativeActiveTurn = nil
+            session.codexPendingSteerLifecycleReconciliation = nil
+            if session.codexRoutingObservedTurnID == identity.turnID
+                || session.codexRoutingObservedTurnID == turnID
+            {
+                session.codexRoutingObservedTurnID = nil
+            }
+            return .init(
+                turnKind: completedIdentity.turnKind,
+                authoritativeIdentity: completedIdentity
+            )
         }
-        if let currentTurnID = session.codexCurrentTurnID {
-            session.codexTurnKindsByID.removeValue(forKey: currentTurnID)
+
+        if let identity = session.codexAuthoritativeActiveTurn,
+           session.codexAnonymousActiveTurn == nil,
+           authoritativeCodexTurnIsCurrent(identity, session: session)
+        {
+            let blocker = codexFallbackBlockingTurn(for: identity)
+            let queueDependsOnExactIdentity = session.codexFallbackQueue.contains {
+                $0.blockingTurn == blocker
+            } || session.codexFallbackDispatchInFlight?.blockingTurn == blocker
+            guard !queueDependsOnExactIdentity else {
+                recordRejectedCodexTurnCompletion(
+                    reason: "nil_id_would_destroy_fifo_recovery",
+                    eventTurnID: nil,
+                    session: session
+                )
+                return nil
+            }
+            session.codexAuthoritativeActiveTurn = nil
+            session.codexPendingSteerLifecycleReconciliation = nil
+            if session.codexRoutingObservedTurnID == identity.turnID {
+                session.codexRoutingObservedTurnID = nil
+            }
+            return .init(
+                turnKind: identity.turnKind,
+                authoritativeIdentity: identity
+            )
         }
-        session.codexCurrentTurnID = nil
-        session.codexCurrentTurnKind = nil
-        return kind
+        if let anonymous = session.codexAnonymousActiveTurn,
+           session.codexAuthoritativeActiveTurn == nil,
+           anonymousCodexTurnIsCurrent(anonymous, session: session)
+        {
+            session.codexAnonymousActiveTurn = nil
+            return .init(
+                turnKind: anonymous.turnKind,
+                authoritativeIdentity: nil
+            )
+        }
+        recordRejectedCodexTurnCompletion(
+            reason: "no_single_active_turn",
+            eventTurnID: nil,
+            session: session
+        )
+        return nil
+    }
+
+    private func authoritativeCodexTurnIsCurrent(
+        _ identity: AgentModeViewModel.TabSession.CodexAuthoritativeTurnIdentity,
+        session: AgentModeViewModel.TabSession
+    ) -> Bool {
+        guard let controller = session.codexController else { return false }
+        return identity.threadID == session.codexConversationID
+            && identity.controllerInstanceID == ObjectIdentifier(controller)
+            && identity.controllerGeneration == session.codexControllerGeneration
+            && identity.runID == session.runID
+            && identity.runAttemptID == session.activeRunAttemptID
+    }
+
+    private func anonymousCodexTurnIsCurrent(
+        _ identity: AgentModeViewModel.TabSession.CodexAnonymousTurnLiveness,
+        session: AgentModeViewModel.TabSession
+    ) -> Bool {
+        guard let controller = session.codexController else { return false }
+        return identity.threadID == session.codexConversationID
+            && identity.controllerInstanceID == ObjectIdentifier(controller)
+            && identity.controllerGeneration == session.codexControllerGeneration
+            && identity.runID == session.runID
+            && identity.runAttemptID == session.activeRunAttemptID
+    }
+
+    private func recordRejectedCodexTurnStart(
+        reason: String,
+        eventTurnID: String?,
+        session: AgentModeViewModel.TabSession
+    ) {
+        #if DEBUG
+            AgentModePerfDiagnostics.increment(
+                "codex.turn_start.rejected.\(reason)",
+                tabID: session.tabID
+            )
+            AgentModePerfDiagnostics.event(
+                "codex.turnStartRejected",
+                tabID: session.tabID,
+                fields: [
+                    "reason": reason,
+                    "eventTurnID": eventTurnID ?? "nil",
+                    "authoritativeTurnID": session.codexAuthoritativeActiveTurn?.turnID ?? "nil"
+                ]
+            )
+        #endif
     }
 
     private func recordRejectedCodexTurnCompletion(
@@ -1630,7 +1866,7 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
                 fields: [
                     "reason": reason,
                     "eventTurnID": eventTurnID ?? "nil",
-                    "currentTurnID": session.codexCurrentTurnID ?? "nil"
+                    "currentTurnID": session.codexAuthoritativeActiveTurn?.turnID ?? "nil"
                 ]
             )
         #endif
@@ -1646,59 +1882,614 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
 
     private func resetTrackedCodexTurns(_ session: AgentModeViewModel.TabSession) {
         session.codexPendingTurnKind = nil
-        session.codexCurrentTurnID = nil
-        session.codexCurrentTurnKind = nil
-        session.codexTurnKindsByID.removeAll()
+        session.codexAuthoritativeActiveTurn = nil
+        session.codexAnonymousActiveTurn = nil
+        session.codexRoutingObservedTurnID = nil
+        session.codexPendingSteerLifecycleReconciliation = nil
     }
 
-    private func restoreQueuedCodexCompactionInstructionsToDraft(_ session: AgentModeViewModel.TabSession) {
-        guard !session.pendingCodexCompactionInstructions.isEmpty else { return }
-        let restoredText = session.pendingCodexCompactionInstructions.joined(separator: "\n\n")
-        session.pendingCodexCompactionInstructions.removeAll()
-        if !restoredText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            viewModel?.storeDraftText(for: session.tabID, restoredText)
-        }
-        viewModel?.requestUIRefresh(tabID: session.tabID, urgent: true)
-        viewModel?.scheduleSave(for: session.tabID)
+    private func codexFallbackBlockingTurn(
+        for identity: AgentModeViewModel.TabSession.CodexAuthoritativeTurnIdentity
+    ) -> AgentModeViewModel.TabSession.CodexFallbackBlockingTurn {
+        .init(
+            threadID: identity.threadID,
+            turnID: identity.turnID,
+            controllerInstanceID: identity.controllerInstanceID,
+            controllerGeneration: identity.controllerGeneration,
+            runID: identity.runID,
+            runAttemptID: identity.runAttemptID
+        )
     }
 
-    private func settleCodexCompaction(
-        _ session: AgentModeViewModel.TabSession,
-        status: CodexNativeSessionController.TurnStatus,
-        reason: String
-    ) async {
-        if status == .completed {
-            markCodexContextCompacted(session)
+    private func recoverableCodexFallbackBlockingTurn(
+        session: AgentModeViewModel.TabSession
+    ) -> AgentModeViewModel.TabSession.CodexFallbackBlockingTurn? {
+        if let identity = session.codexAuthoritativeActiveTurn {
+            return codexFallbackBlockingTurn(for: identity)
         }
-        if status == .completed,
-           !session.pendingCodexCompactionInstructions.isEmpty
+        guard let inFlight = session.codexFallbackDispatchInFlight else {
+            return nil
+        }
+        switch inFlight.state {
+        case .dispatching, .awaitingLifecycleStart, .lifecycleStarted:
+            return inFlight.blockingTurn
+        case .queued, .eligibleForSuccessor:
+            return nil
+        }
+    }
+
+    private func fallbackSubmissionContext(
+        _ context: AgentModeViewModel.TabSession.CodexFallbackSubmissionContext?,
+        text: String,
+        images: [AgentImageAttachment]
+    ) -> AgentModeViewModel.TabSession.CodexFallbackSubmissionContext {
+        context ?? .init(
+            queueID: UUID(),
+            providerText: text,
+            images: images,
+            taggedFileAttachments: [],
+            draftText: text,
+            optimisticUserItemID: nil,
+            origin: .manual,
+            dispatchTicket: nil
+        )
+    }
+
+    private func detachCodexFallbackAttachmentReservation(
+        _ reservationID: UUID?,
+        session: AgentModeViewModel.TabSession
+    ) {
+        guard let reservationID else { return }
+        switch session.attachmentTurnState {
+        case .idle:
+            return
+        case let .reserved(storedID, _), let .consumed(storedID, _):
+            guard storedID == reservationID else { return }
+            session.attachmentTurnState = .idle
+        }
+    }
+
+    private func enqueueCodexFallback(
+        session: AgentModeViewModel.TabSession,
+        context: AgentModeViewModel.TabSession.CodexFallbackSubmissionContext?,
+        text: String,
+        images: [AgentImageAttachment],
+        selection: (model: String?, reasoningEffort: String?, serviceTier: String?),
+        attachmentReservationID: UUID?,
+        reason: CodexTurnFallbackDecision,
+        controller: any CodexSessionControlling
+    ) -> NativeSendOutcome {
+        guard let threadID = session.codexConversationID,
+              let runID = session.runID,
+              let runAttemptID = session.activeRunAttemptID
+        else {
+            return .stale(reason: "Codex could not queue fallback delivery because its run lineage changed.")
+        }
+        let submission = fallbackSubmissionContext(context, text: text, images: images)
+        if session.codexFallbackQueue.contains(where: { $0.id == submission.queueID })
+            || session.codexFallbackDispatchInFlight?.id == submission.queueID
         {
-            let queuedInstruction = session.pendingCodexCompactionInstructions.joined(separator: "\n\n")
-            session.pendingCodexCompactionInstructions.removeAll()
-            if !queuedInstruction.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                resetTrackedCodexTurns(session)
-                viewModel?.scheduleSave(for: session.tabID)
-                await viewModel?.startAgentRun(tabID: session.tabID, initialMessage: queuedInstruction)
-                return
+            return .queuedFallback(queueID: submission.queueID, reason: reason)
+        }
+        let entry = AgentModeViewModel.TabSession.CodexFallbackQueueEntry(
+            id: submission.queueID,
+            providerText: submission.providerText,
+            images: submission.images,
+            taggedFileAttachments: submission.taggedFileAttachments,
+            model: selection.model,
+            reasoningEffort: selection.reasoningEffort,
+            serviceTier: selection.serviceTier,
+            attachmentReservationID: attachmentReservationID,
+            optimisticUserItemID: submission.optimisticUserItemID,
+            draftText: submission.draftText,
+            origin: submission.origin,
+            fallbackReason: reason,
+            originThreadID: threadID,
+            originControllerInstanceID: ObjectIdentifier(controller),
+            originControllerGeneration: session.codexControllerGeneration,
+            originRunID: runID,
+            originRunAttemptID: runAttemptID,
+            blockingTurn: recoverableCodexFallbackBlockingTurn(session: session),
+            state: .queued
+        )
+        detachCodexFallbackAttachmentReservation(attachmentReservationID, session: session)
+        session.codexFallbackQueue.append(entry)
+        if case let .mcp(attemptID) = submission.origin {
+            session.codexSteerAckTracker.resolve(
+                attemptID: attemptID,
+                state: .durablyQueued(queueID: submission.queueID)
+            )
+        } else if session.mcpControlContext != nil {
+            Task { @MainActor [weak viewModel, weak session] in
+                guard let viewModel, let session else { return }
+                await viewModel.signalCodexInstructionDelivered(for: session)
             }
         }
-        resetTrackedCodexTurns(session)
-        if status != .completed {
-            restoreQueuedCodexCompactionInstructionsToDraft(session)
-        }
-        viewModel?.setAgentRunActive(session.tabID, isActive: false)
-        session.runState = switch status {
-        case .completed:
-            .completed
-        case .interrupted:
-            .cancelled
-        case .failed:
-            .failed
-        }
-        setRunningStatus(nil, source: nil, session: session)
+        session.isDirty = true
         viewModel?.requestUIRefresh(tabID: session.tabID, urgent: true)
         viewModel?.scheduleSave(for: session.tabID)
-        scheduleCodexIdleShutdownIfNeeded(for: session, reason: reason)
+        if case .noActiveTurn = reason {
+            scheduleCodexFallbackIdlePump(session: session, queueID: submission.queueID)
+        }
+        return .queuedFallback(queueID: submission.queueID, reason: reason)
+    }
+
+    private func scheduleCodexFallbackIdlePump(
+        session: AgentModeViewModel.TabSession,
+        queueID: UUID
+    ) {
+        guard session.codexFallbackPumpTask == nil else { return }
+        session.codexFallbackPumpTask = Task { @MainActor [weak self, weak session] in
+            defer { session?.codexFallbackPumpTask = nil }
+            guard let self, let session else { return }
+            await pumpCodexFallbackIfAuthoritativelyIdle(session: session, queueID: queueID)
+        }
+    }
+
+    private func pumpCodexFallbackIfAuthoritativelyIdle(
+        session: AgentModeViewModel.TabSession,
+        queueID: UUID
+    ) async {
+        var retryDelayNanos: UInt64 = 100_000_000
+        while !Task.isCancelled {
+            guard session.codexFallbackDispatchInFlight == nil,
+                  let head = session.codexFallbackQueue.first,
+                  head.id == queueID,
+                  head.state == .queued,
+                  case .noActiveTurn = head.fallbackReason,
+                  let controller = session.codexController,
+                  ObjectIdentifier(controller) == head.originControllerInstanceID,
+                  session.codexControllerGeneration == head.originControllerGeneration,
+                  session.codexConversationID == head.originThreadID,
+                  session.runID == head.originRunID,
+                  session.activeRunAttemptID == head.originRunAttemptID
+            else { return }
+            do {
+                let snapshot = try await controller.readThreadSnapshot(includeTurns: true, timeout: 2)
+                if snapshot.conversationID == head.originThreadID,
+                   snapshot.runtimeStatus == .idle,
+                   snapshot.currentTurnID == nil,
+                   snapshot.activeTurnIDs.isEmpty
+                {
+                    if let blockingTurn = head.blockingTurn,
+                       session.codexAuthoritativeActiveTurn?.turnID == blockingTurn.turnID
+                    {
+                        session.codexAuthoritativeActiveTurn = nil
+                    }
+                    session.codexAnonymousActiveTurn = nil
+                    _ = await dispatchCodexFallbackHead(
+                        session: session,
+                        expectedQueueID: queueID,
+                        beginsSuccessorAttempt: false
+                    )
+                    return
+                }
+            } catch {
+                // Snapshot failures are transient; keep one bounded-backoff pump for this head.
+            }
+            try? await Task.sleep(nanoseconds: retryDelayNanos)
+            retryDelayNanos = min(retryDelayNanos * 2, 1_000_000_000)
+        }
+    }
+
+    private func activateCodexFallbackAttachmentReservation(
+        _ entry: AgentModeViewModel.TabSession.CodexFallbackQueueEntry,
+        session: AgentModeViewModel.TabSession
+    ) -> Bool {
+        guard !entry.images.isEmpty else { return true }
+        guard let reservationID = entry.attachmentReservationID else { return false }
+        guard case .idle = session.attachmentTurnState else { return false }
+        session.attachmentTurnState = .reserved(
+            reservationID: reservationID,
+            attachments: entry.images
+        )
+        return true
+    }
+
+    private func claimCodexFallbackHead(
+        session: AgentModeViewModel.TabSession,
+        expectedQueueID: UUID,
+        beginsSuccessorAttempt: Bool
+    ) -> AgentModeViewModel.TabSession.CodexFallbackQueueEntry? {
+        guard session.codexFallbackDispatchInFlight == nil,
+              var head = session.codexFallbackQueue.first,
+              head.id == expectedQueueID,
+              let controller = session.codexController,
+              ObjectIdentifier(controller) == head.originControllerInstanceID,
+              session.codexControllerGeneration == head.originControllerGeneration,
+              session.codexConversationID == head.originThreadID,
+              session.runID == head.originRunID
+        else { return nil }
+        if beginsSuccessorAttempt {
+            guard !session.runState.isActive else { return nil }
+        } else {
+            guard session.activeRunAttemptID == head.originRunAttemptID else { return nil }
+        }
+        guard activateCodexFallbackAttachmentReservation(head, session: session) else { return nil }
+        if beginsSuccessorAttempt {
+            _ = session.beginRunAttempt(source: "codex.fallback.successor")
+        }
+        _ = session.codexFallbackQueue.removeFirst()
+        head.state = .dispatching
+        session.codexFallbackDispatchInFlight = head
+        session.runState = .running
+        if beginsSuccessorAttempt {
+            session.mcpFollowUpRunPending = false
+        }
+        viewModel?.setAgentRunActive(session.tabID, isActive: true)
+        viewModel?.publishMCPStateChange(for: session)
+        beginTrackedCodexUserTurn(session)
+        setRunningStatus("Sending queued message…", source: .transport, session: session, urgent: true)
+        return head
+    }
+
+    @discardableResult
+    private func dispatchCodexFallbackHead(
+        session: AgentModeViewModel.TabSession,
+        expectedQueueID: UUID,
+        beginsSuccessorAttempt: Bool
+    ) async -> Bool {
+        guard let head = claimCodexFallbackHead(
+            session: session,
+            expectedQueueID: expectedQueueID,
+            beginsSuccessorAttempt: beginsSuccessorAttempt
+        ) else {
+            return false
+        }
+        await dispatchClaimedCodexFallback(head, session: session)
+        return true
+    }
+
+    private func dispatchClaimedCodexFallback(
+        _ head: AgentModeViewModel.TabSession.CodexFallbackQueueEntry,
+        session: AgentModeViewModel.TabSession
+    ) async {
+        guard let controller = session.codexController,
+              ObjectIdentifier(controller) == head.originControllerInstanceID
+        else {
+            await failCodexFallbackDispatch(
+                session: session,
+                entry: head,
+                message: "Codex queued follow-up lost its controller before dispatch."
+            )
+            return
+        }
+        do {
+            _ = try await controller.startUserTurn(
+                text: head.providerText,
+                images: head.images,
+                model: head.model,
+                reasoningEffort: head.reasoningEffort,
+                serviceTier: head.serviceTier
+            )
+            guard var inFlight = session.codexFallbackDispatchInFlight,
+                  inFlight.id == head.id,
+                  session.codexController.map(ObjectIdentifier.init) == head.originControllerInstanceID
+            else { return }
+            if case .lifecycleStarted = inFlight.state {
+                session.codexFallbackDispatchInFlight = nil
+            } else {
+                inFlight.state = .awaitingLifecycleStart
+                session.codexFallbackDispatchInFlight = inFlight
+            }
+            await applySuccessfulCodexNativeSend(
+                for: session,
+                runID: session.runID ?? head.originRunID,
+                attachments: head.images,
+                attachmentReservationID: head.attachmentReservationID
+            )
+            if let ownership = session.activeRunOwnership {
+                session.recordRunProgress(
+                    ownership: ownership,
+                    kind: .stageTransition,
+                    stage: .running
+                )
+            }
+        } catch {
+            await failCodexFallbackDispatch(
+                session: session,
+                entry: head,
+                message: "Codex queued follow-up failed to start: \(error.localizedDescription)"
+            )
+        }
+    }
+
+    private func failCodexFallbackDispatch(
+        session: AgentModeViewModel.TabSession,
+        entry: AgentModeViewModel.TabSession.CodexFallbackQueueEntry,
+        message: String
+    ) async {
+        if session.codexFallbackQueue.first?.id == entry.id {
+            session.codexFallbackQueue.removeFirst()
+        }
+        if session.codexFallbackDispatchInFlight?.id == entry.id {
+            session.codexFallbackDispatchInFlight = nil
+        }
+        session.mcpFollowUpRunPending = false
+        session.codexPendingTurnKind = nil
+        viewModel?.finalizeAttachmentsForTurn(
+            for: session,
+            reservationID: entry.attachmentReservationID,
+            disposition: .restoreToPending
+        )
+        session.appendItem(.error(message, sequenceIndex: session.nextSequenceIndex))
+        if session.activeRunOwnership != nil {
+            await finalizeCodexRun(
+                session,
+                turnStatus: .failed,
+                reason: "fallback-dispatch-failed",
+                errorMessage: nil,
+                notifyOnCompleted: false
+            )
+        } else {
+            session.runState = .failed
+            viewModel?.setAgentRunActive(session.tabID, isActive: false)
+        }
+        if !session.codexFallbackQueue.isEmpty {
+            abandonCodexFallbackQueue(
+                session: session,
+                reason: "Codex queued follow-ups were cancelled after an earlier queued dispatch failed."
+            )
+        }
+        viewModel?.requestUIRefresh(tabID: session.tabID, urgent: true)
+        viewModel?.scheduleSave(for: session.tabID)
+    }
+
+    private enum CodexFallbackAbandonmentMode: Equatable {
+        case restoreInput
+        case discardInput
+    }
+
+    private func abandonCodexFallbackQueue(
+        session: AgentModeViewModel.TabSession,
+        reason: String,
+        mode: CodexFallbackAbandonmentMode = .restoreInput
+    ) {
+        session.codexFallbackPumpTask?.cancel()
+        session.codexFallbackPumpTask = nil
+        session.codexFallbackSuccessorRetryTask?.cancel()
+        session.codexFallbackSuccessorRetryTask = nil
+        session.mcpFollowUpRunPending = false
+        let queued = session.codexFallbackQueue
+        session.codexFallbackQueue.removeAll()
+        for entry in queued {
+            if case let .mcp(attemptID) = entry.origin {
+                session.codexSteerAckTracker.markStale(attemptID: attemptID, reason: reason)
+            }
+            if let optimisticUserItemID = entry.optimisticUserItemID,
+               let index = session.items.firstIndex(where: { $0.id == optimisticUserItemID })
+            {
+                _ = session.removeItem(at: index)
+            }
+            if mode == .restoreInput {
+                let pendingImageIDs = Set(session.pendingImageAttachments.map(\.id))
+                session.pendingImageAttachments.append(contentsOf: entry.images.filter {
+                    !pendingImageIDs.contains($0.id)
+                })
+                let pendingTaggedIDs = Set(session.pendingTaggedFileAttachments.map(\.id))
+                session.pendingTaggedFileAttachments.append(contentsOf: entry.taggedFileAttachments.filter {
+                    !pendingTaggedIDs.contains($0.id)
+                })
+                if case .manual = entry.origin,
+                   !entry.draftText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                {
+                    viewModel?.restoreCodexFallbackDraft(
+                        tabID: session.tabID,
+                        text: entry.draftText,
+                        message: reason
+                    )
+                }
+            }
+        }
+        if let inFlight = session.codexFallbackDispatchInFlight {
+            if case let .mcp(attemptID) = inFlight.origin {
+                session.codexSteerAckTracker.markStale(attemptID: attemptID, reason: reason)
+            }
+            viewModel?.finalizeAttachmentsForTurn(
+                for: session,
+                reservationID: inFlight.attachmentReservationID,
+                disposition: .keepFiles
+            )
+            session.codexFallbackDispatchInFlight = nil
+            if mode == .restoreInput {
+                session.appendItem(.error(reason, sequenceIndex: session.nextSequenceIndex))
+            }
+        }
+        viewModel?.publishMCPStateChange(for: session)
+        viewModel?.requestUIRefresh(tabID: session.tabID, urgent: true)
+        viewModel?.scheduleSave(for: session.tabID)
+    }
+
+    func handleMCPControlReset(
+        for session: AgentModeViewModel.TabSession,
+        reason: String
+    ) {
+        guard session.codexFallbackSuccessorRetryTask != nil
+            || !session.codexFallbackQueue.isEmpty
+            || session.codexFallbackDispatchInFlight != nil
+        else {
+            return
+        }
+        abandonCodexFallbackQueue(session: session, reason: reason)
+    }
+
+    private func rebindCodexFallbackBlockers(
+        from previousBlockingTurn: AgentModeViewModel.TabSession.CodexFallbackBlockingTurn?,
+        to blockingTurn: AgentModeViewModel.TabSession.CodexFallbackBlockingTurn,
+        session: AgentModeViewModel.TabSession
+    ) {
+        if var inFlight = session.codexFallbackDispatchInFlight,
+           inFlight.blockingTurn == previousBlockingTurn
+        {
+            inFlight.blockingTurn = blockingTurn
+            session.codexFallbackDispatchInFlight = inFlight
+        }
+        for index in session.codexFallbackQueue.indices {
+            guard session.codexFallbackQueue[index].state == .queued,
+                  session.codexFallbackQueue[index].blockingTurn == previousBlockingTurn
+            else { continue }
+            session.codexFallbackQueue[index].blockingTurn = blockingTurn
+        }
+    }
+
+    private func bindCodexFallbackQueueToStartedTurn(
+        _ identity: AgentModeViewModel.TabSession.CodexAuthoritativeTurnIdentity,
+        session: AgentModeViewModel.TabSession
+    ) {
+        guard var inFlight = session.codexFallbackDispatchInFlight else { return }
+        let previousBlockingTurn = inFlight.blockingTurn
+        let blockingTurn = codexFallbackBlockingTurn(for: identity)
+        switch inFlight.state {
+        case .awaitingLifecycleStart:
+            session.codexFallbackDispatchInFlight = nil
+        case .dispatching:
+            inFlight.state = .lifecycleStarted
+            session.codexFallbackDispatchInFlight = inFlight
+        case .lifecycleStarted:
+            return
+        case .queued, .eligibleForSuccessor:
+            return
+        }
+        rebindCodexFallbackBlockers(
+            from: previousBlockingTurn,
+            to: blockingTurn,
+            session: session
+        )
+    }
+
+    private func codexFallbackSuccessorForCompletion(
+        turnID: String?,
+        status: CodexNativeSessionController.TurnStatus,
+        completedIdentity: AgentModeViewModel.TabSession.CodexAuthoritativeTurnIdentity?,
+        session: AgentModeViewModel.TabSession
+    ) -> AgentRunTerminalCommitBarrier.ProviderSuccessor? {
+        guard status == .completed,
+              let turnID,
+              let completedIdentity,
+              completedIdentity.turnID == turnID,
+              var head = session.codexFallbackQueue.first,
+              head.state == .queued,
+              head.blockingTurn == codexFallbackBlockingTurn(for: completedIdentity)
+        else { return nil }
+        head.state = .eligibleForSuccessor(completedTurnID: turnID)
+        session.codexFallbackQueue[0] = head
+        return .init(
+            id: head.id,
+            transitionKind: .relatedFollowUp,
+            consumeAfterPublication: { [weak self, weak session] revision, publicationResult in
+                guard let self, let session,
+                      revision.providerSuccessorID == head.id
+                else { return false }
+                switch publicationResult {
+                case .accepted:
+                    break
+                case let .rejected(reason):
+                    guard Self.codexFallbackPublicationRejectionIsRetryable(reason) else {
+                        abandonCodexFallbackQueue(
+                            session: session,
+                            reason: "Codex queued follow-up was cancelled because terminal publication was permanently rejected (\(reason))."
+                        )
+                        return false
+                    }
+                    viewModel?.publishMCPStateChange(for: session)
+                    return false
+                case .stale:
+                    session.mcpFollowUpRunPending = false
+                    abandonCodexFallbackQueue(
+                        session: session,
+                        reason: "Codex queued follow-up was cancelled because terminal publication became stale."
+                    )
+                    viewModel?.publishMCPStateChange(for: session)
+                    return false
+                }
+                guard session.codexFallbackQueue.first?.id == head.id,
+                      session.codexFallbackQueue.first?.state == .eligibleForSuccessor(completedTurnID: turnID)
+                else {
+                    session.mcpFollowUpRunPending = false
+                    viewModel?.publishMCPStateChange(for: session)
+                    return false
+                }
+                guard let claimedHead = claimCodexFallbackHead(
+                    session: session,
+                    expectedQueueID: head.id,
+                    beginsSuccessorAttempt: true
+                ) else {
+                    viewModel?.publishMCPStateChange(for: session)
+                    return false
+                }
+                Task { @MainActor [weak self, weak session, claimedHead] in
+                    guard let self, let session else { return }
+                    await dispatchClaimedCodexFallback(claimedHead, session: session)
+                }
+                return true
+            }
+        )
+    }
+
+    private static func codexFallbackPublicationRejectionIsRetryable(_ reason: String) -> Bool {
+        switch reason {
+        case "activation_replaced",
+             "different_commit_already_published",
+             "missing_successor_epoch",
+             "missing_terminal_publication_envelope",
+             "session_or_activation_mismatch",
+             "stale_activation",
+             "unknown_epoch",
+             "view_model_deallocated":
+            false
+        default:
+            true
+        }
+    }
+
+    private func scheduleCodexFallbackSuccessorRetryIfNeeded(
+        session: AgentModeViewModel.TabSession,
+        request: AgentRunTerminalCommitBarrier.Request,
+        providerSuccessor: AgentRunTerminalCommitBarrier.ProviderSuccessor
+    ) {
+        guard session.codexFallbackSuccessorRetryTask == nil,
+              let head = session.codexFallbackQueue.first,
+              head.id == providerSuccessor.id,
+              case .eligibleForSuccessor = head.state
+        else { return }
+        session.codexFallbackSuccessorRetryTask = Task { @MainActor [weak self, weak session] in
+            defer { session?.codexFallbackSuccessorRetryTask = nil }
+            var retryDelayNanos: UInt64 = 10_000_000
+            while !Task.isCancelled {
+                guard let self, let session,
+                      let head = session.codexFallbackQueue.first,
+                      head.id == providerSuccessor.id,
+                      case .eligibleForSuccessor = head.state,
+                      let terminalCommitBarrier
+                else { return }
+                _ = await terminalCommitBarrier.commit(request)
+                guard session.codexFallbackQueue.first?.id == providerSuccessor.id,
+                      session.codexFallbackQueue.first?.state == head.state
+                else { return }
+                try? await Task.sleep(nanoseconds: retryDelayNanos)
+                retryDelayNanos = min(retryDelayNanos * 2, 1_000_000_000)
+            }
+        }
+    }
+
+    private func abandonCodexFallbackQueueBlockedByTerminalTurn(
+        _ completedIdentity: AgentModeViewModel.TabSession.CodexAuthoritativeTurnIdentity?,
+        status: CodexNativeSessionController.TurnStatus,
+        session: AgentModeViewModel.TabSession
+    ) {
+        guard status != .completed,
+              let completedIdentity
+        else { return }
+        let blocker = codexFallbackBlockingTurn(for: completedIdentity)
+        let queuedDependsOnCompletedTurn = session.codexFallbackQueue.contains {
+            $0.blockingTurn == blocker
+        }
+        let inFlightDependsOnCompletedTurn = session.codexFallbackDispatchInFlight?.blockingTurn == blocker
+        guard queuedDependsOnCompletedTurn || inFlightDependsOnCompletedTurn else { return }
+        abandonCodexFallbackQueue(
+            session: session,
+            reason: "Codex queued follow-ups were cancelled because the turn they followed ended with \(status)."
+        )
     }
 
     private static func normalizedCodexSelectionModelRaw(from raw: String?) -> String {
@@ -2243,7 +3034,7 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
             session.codexReasoningEffort = ref.reasoningEffort
             // Always clear the reconnect flag after a successful start/resume.
             // If preferences changed during the async startOrResume (generation mismatch),
-            // do NOT re-trigger a reconnect: sendUserTurn() already sends the latest
+            // do NOT re-trigger a reconnect: the typed turn dispatch already sends the latest
             // configOverrides and turn-scoped policy on every call, so the updated
             // preferences take effect on the next turn without a costly reconnect.
             session.codexNeedsReconnect = false
@@ -2555,7 +3346,10 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
         }
 
         do {
-            try await controller.sendUserTurn(
+            guard replayTurn.expectedTurnID == nil else {
+                return false
+            }
+            _ = try await controller.startUserTurn(
                 text: replayTurn.text,
                 images: replayTurn.images,
                 model: replayTurn.model,
@@ -2633,6 +3427,10 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
         session.codexEventTaskRunID = nil
         session.codexLastEventAt = nil
         resetCodexWatchdogState(session)
+        abandonCodexFallbackQueue(
+            session: session,
+            reason: "Codex queued follow-up was cancelled because the controller was replaced."
+        )
         session.codexController = nil
         session.codexControllerPermissionProfile = nil
         session.codexControllerTaskLabelKind = nil
@@ -3228,11 +4026,41 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
         }
     }
 
+    private enum CodexTurnDispatchPlan {
+        case start
+        case steer(AgentModeViewModel.TabSession.CodexAuthoritativeTurnIdentity)
+        case fallback(CodexTurnFallbackDecision)
+    }
+
+    private func codexTurnDispatchPlan(
+        wasRunAlreadyActive: Bool,
+        session: AgentModeViewModel.TabSession
+    ) -> CodexTurnDispatchPlan {
+        guard wasRunAlreadyActive else { return .start }
+        guard let identity = session.codexAuthoritativeActiveTurn else {
+            if let anonymous = session.codexAnonymousActiveTurn {
+                return .fallback(.nonSteerableTurn(kind: anonymous.turnKind))
+            }
+            return .fallback(.activeWithoutAuthoritativeIdentity)
+        }
+        guard authoritativeCodexTurnIsCurrent(identity, session: session) else {
+            return .fallback(.staleAuthoritativeIdentity)
+        }
+        if session.codexPendingSteerLifecycleReconciliation?.priorIdentity == identity {
+            return .fallback(.staleAuthoritativeIdentity)
+        }
+        guard identity.turnKind == .user else {
+            return .fallback(.nonSteerableTurn(kind: identity.turnKind))
+        }
+        return .steer(identity)
+    }
+
     @discardableResult
     func sendCodexNativeMessage(
         session: AgentModeViewModel.TabSession,
         text: String,
         attachments: [AgentImageAttachment],
+        fallbackContext: AgentModeViewModel.TabSession.CodexFallbackSubmissionContext? = nil,
         attachmentReservationID: UUID? = nil,
         policyAlreadyInstalled: Bool = false,
         terminalizeRejectedSend: Bool = true
@@ -3294,7 +4122,10 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
             model: selection.model,
             reasoningEffort: selection.reasoningEffort,
             serviceTier: selection.serviceTier,
-            attachmentReservationID: attachmentReservationID
+            attachmentReservationID: attachmentReservationID,
+            expectedTurnID: wasRunAlreadyActive
+                ? session.codexAuthoritativeActiveTurn?.turnID
+                : nil
         )
 
         await ensureCodexNativeSession(
@@ -3364,33 +4195,182 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
             return .failed(message: message)
         }
 
-        do {
-            beginTrackedCodexUserTurn(session)
-            setRunningStatus("Sending message…", source: .transport, session: session, urgent: true)
-            logCodex("[AgentModeVM] sendCodexNativeMessage: calling controller.sendUserTurn")
-            try await controller.sendUserTurn(
+        let dispatchPlan = codexTurnDispatchPlan(
+            wasRunAlreadyActive: wasRunAlreadyActive,
+            session: session
+        )
+        if case let .fallback(decision) = dispatchPlan {
+            clearCodexPendingAuthRetryTurn(session)
+            return enqueueCodexFallback(
+                session: session,
+                context: fallbackContext,
                 text: text,
                 images: attachments,
-                model: selection.model,
-                reasoningEffort: selection.reasoningEffort,
-                serviceTier: selection.serviceTier
+                selection: selection,
+                attachmentReservationID: attachmentReservationID,
+                reason: decision,
+                controller: controller
             )
+        }
+
+        do {
+            setRunningStatus("Sending message…", source: .transport, session: session, urgent: true)
+            switch dispatchPlan {
+            case .start:
+                beginTrackedCodexUserTurn(session)
+                logCodex("[AgentModeVM] sendCodexNativeMessage: calling controller.startUserTurn")
+                _ = try await controller.startUserTurn(
+                    text: text,
+                    images: attachments,
+                    model: selection.model,
+                    reasoningEffort: selection.reasoningEffort,
+                    serviceTier: selection.serviceTier
+                )
+            case let .steer(identity):
+                logCodex("[AgentModeVM] sendCodexNativeMessage: calling controller.steerUserTurn expectedTurnID=\(identity.turnID)")
+                do {
+                    _ = try await controller.steerUserTurn(
+                        text: text,
+                        images: attachments,
+                        expectedTurnID: identity.turnID
+                    )
+                } catch let mismatch as CodexTurnSteerError {
+                    guard case let .expectedTurnMismatch(expectedTurnID, actualTurnID, failure) = mismatch,
+                          let actualTurnID = actualTurnID?.trimmingCharacters(in: .whitespacesAndNewlines),
+                          !actualTurnID.isEmpty,
+                          session.codexAuthoritativeActiveTurn == identity,
+                          authoritativeCodexTurnIsCurrent(identity, session: session),
+                          session.codexController.map(ObjectIdentifier.init) == ObjectIdentifier(controller)
+                    else {
+                        throw mismatch
+                    }
+                    logCodex(
+                        "[AgentModeVM] sendCodexNativeMessage: retrying turn/steer once expected=\(expectedTurnID) actual=\(actualTurnID)"
+                    )
+                    let reconciliation = AgentModeViewModel.TabSession.CodexPendingSteerLifecycleReconciliation(
+                        priorIdentity: identity,
+                        acceptedDispatchTurnID: actualTurnID
+                    )
+                    session.codexPendingSteerLifecycleReconciliation = reconciliation
+                    do {
+                        let receipt = try await controller.steerUserTurn(
+                            text: text,
+                            images: attachments,
+                            expectedTurnID: actualTurnID
+                        )
+                        guard receipt.acceptedTurnID == actualTurnID else {
+                            throw CodexTurnSteerError.expectedTurnMismatch(
+                                expectedTurnID: expectedTurnID,
+                                actualTurnID: actualTurnID,
+                                failure: failure
+                            )
+                        }
+                        guard await controller.prepareLifecycleAuthorityReconciliationAfterAcceptedMismatch(
+                            expectedCurrentTurnID: identity.turnID,
+                            acceptedDispatchTurnID: actualTurnID
+                        ) else {
+                            throw CodexTurnSteerError.expectedTurnMismatch(
+                                expectedTurnID: expectedTurnID,
+                                actualTurnID: actualTurnID,
+                                failure: failure
+                            )
+                        }
+                        if session.codexPendingSteerLifecycleReconciliation == reconciliation,
+                           session.codexAuthoritativeActiveTurn != identity
+                        {
+                            session.codexPendingSteerLifecycleReconciliation = nil
+                        }
+                    } catch {
+                        if session.codexPendingSteerLifecycleReconciliation == reconciliation {
+                            session.codexPendingSteerLifecycleReconciliation = nil
+                        }
+                        throw CodexTurnSteerError.expectedTurnMismatch(
+                            expectedTurnID: expectedTurnID,
+                            actualTurnID: actualTurnID,
+                            failure: failure
+                        )
+                    }
+                }
+            case .fallback:
+                preconditionFailure("Fallback dispatch plans return before provider dispatch")
+            }
             guard session.runID == sendRunID,
                   session.runState.isActive,
                   let activeController = session.codexController,
                   Self.sameCodexControllerInstance(activeController, controller)
             else {
-                logCodex("[AgentModeVM] sendCodexNativeMessage: ignoring late send success for stale controller")
-                return .stale(reason: "Codex ignored a late send success because the active run/controller changed.")
+                if case let .mcp(attemptID) = fallbackContext?.origin {
+                    let state: CodexSteerAckTracker.TerminalState = switch dispatchPlan {
+                    case .start:
+                        .startAccepted
+                    case .steer:
+                        .steerAccepted
+                    case .fallback:
+                        preconditionFailure("Fallback dispatch plans return before provider dispatch")
+                    }
+                    session.codexSteerAckTracker.resolve(attemptID: attemptID, state: state)
+                } else if fallbackContext?.origin == .manual,
+                          session.mcpControlContext != nil
+                {
+                    await viewModel?.signalCodexInstructionDelivered(for: session)
+                }
+                logCodex("[AgentModeVM] sendCodexNativeMessage: provider accepted typed dispatch after the local run/controller changed")
+                return .sent
             }
-            logCodex("[AgentModeVM] sendCodexNativeMessage: sendUserTurn returned successfully")
+            logCodex("[AgentModeVM] sendCodexNativeMessage: typed turn dispatch returned successfully")
             await applySuccessfulCodexNativeSend(
                 for: session,
                 runID: sendRunID,
                 attachments: attachments,
                 attachmentReservationID: attachmentReservationID
             )
+            if case let .mcp(attemptID) = fallbackContext?.origin {
+                let state: CodexSteerAckTracker.TerminalState = switch dispatchPlan {
+                case .start:
+                    .startAccepted
+                case .steer:
+                    .steerAccepted
+                case .fallback:
+                    preconditionFailure("Fallback dispatch plans return before provider dispatch")
+                }
+                session.codexSteerAckTracker.resolve(attemptID: attemptID, state: state)
+            } else if fallbackContext?.origin == .manual,
+                      session.mcpControlContext != nil
+            {
+                await viewModel?.signalCodexInstructionDelivered(for: session)
+            }
             return .sent
+        } catch let steerError as CodexTurnSteerError {
+            session.codexPendingTurnKind = nil
+            guard session.runID == sendRunID,
+                  let activeController = session.codexController,
+                  Self.sameCodexControllerInstance(activeController, controller)
+            else {
+                return .stale(reason: "Codex ignored a late steer rejection because the active run/controller changed.")
+            }
+            let decision: CodexTurnFallbackDecision = switch steerError {
+            case let .noActiveTurn(failure):
+                .noActiveTurn(failure: failure)
+            case let .expectedTurnMismatch(expectedTurnID, actualTurnID, failure):
+                .expectedTurnMismatch(
+                    expectedTurnID: expectedTurnID,
+                    actualTurnID: actualTurnID,
+                    failure: failure
+                )
+            case let .activeTurnNotSteerable(turnKind, failure):
+                .activeTurnNotSteerable(turnKind: turnKind, failure: failure)
+            }
+            clearCodexPendingAuthRetryTurn(session)
+            return enqueueCodexFallback(
+                session: session,
+                context: fallbackContext,
+                text: text,
+                images: attachments,
+                selection: selection,
+                attachmentReservationID: attachmentReservationID,
+                reason: decision,
+                controller: controller
+            )
         } catch {
             session.codexPendingTurnKind = nil
             guard session.runID == sendRunID,
@@ -3945,7 +4925,8 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
         reason: String,
         errorMessage: String? = nil,
         notifyOnCompleted: Bool = true,
-        deleteDeferredFilesWhenFailureHasNoInFlight: Bool = false
+        deleteDeferredFilesWhenFailureHasNoInFlight: Bool = false,
+        providerSuccessor: AgentRunTerminalCommitBarrier.ProviderSuccessor? = nil
     ) async {
         guard let ownership = session.activeRunOwnership,
               let terminalCommitBarrier
@@ -3991,7 +4972,7 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
         } else {
             .deleteFiles
         }
-        await terminalCommitBarrier.commit(.init(
+        let request = AgentRunTerminalCommitBarrier.Request(
             session: session,
             ownership: ownership,
             expectedRunID: expectedRunID,
@@ -4001,6 +4982,7 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
             attachmentDisposition: attachmentDisposition,
             finalizeNonCodexUsage: false,
             supportsFollowUp: false,
+            providerSuccessor: providerSuccessor,
             notifyTurnComplete: turnStatus == .completed && notifyOnCompleted,
             providerDrainGeneration: session.providerTerminalDrainGeneration,
             providerBuffersAreDrained: { [weak self] in
@@ -4014,7 +4996,15 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
                     scheduleCodexIdleShutdownIfNeeded(for: session, reason: reason)
                 }
             }
-        ))
+        )
+        _ = await terminalCommitBarrier.commit(request)
+        if let providerSuccessor {
+            scheduleCodexFallbackSuccessorRetryIfNeeded(
+                session: session,
+                request: request,
+                providerSuccessor: providerSuccessor
+            )
+        }
     }
 
     private func settleCodexComputerUseActivationAfterTurn(
@@ -4054,13 +5044,15 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
             return false
         }
         if let turnID = scope.turnID?.trimmingCharacters(in: .whitespacesAndNewlines),
-           !turnID.isEmpty,
-           turnID != session.codexCurrentTurnID
+           !turnID.isEmpty
         {
-            return false
+            guard turnID == session.codexAuthoritativeActiveTurn?.turnID else {
+                return false
+            }
         }
         if scope.itemID?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false,
-           session.codexCurrentTurnID == nil
+           session.codexAuthoritativeActiveTurn == nil,
+           session.codexAnonymousActiveTurn == nil
         {
             return false
         }
@@ -4467,24 +5459,50 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
         case let .turnStarted(turnID):
             cancelCodexIdleShutdown(for: session.tabID)
             clearStaleCodexPendingInteractionsForNewTurn(turnID, session: session)
-            let turnKind = trackedCodexTurnKindForStart(turnID: turnID, session: session)
+            guard let turnKind = installAuthoritativeCodexTurnForStart(
+                turnID: turnID,
+                session: session,
+                sourceController: sourceController
+            ) else {
+                return
+            }
+            if let identity = session.codexAuthoritativeActiveTurn {
+                bindCodexFallbackQueueToStartedTurn(identity, session: session)
+            }
             let statusText = turnKind == .compact ? "Compacting context…" : "Thinking…"
             setRunningStatus(statusText, source: .transport, session: session, urgent: true)
             session.runState = .running
             viewModel?.setAgentRunActive(session.tabID, isActive: true)
             viewModel?.requestUIRefresh(tabID: session.tabID, urgent: true)
         case let .turnCompleted(turnID, status):
-            guard let turnKind = correlatedCodexTurnKindForCompletion(
+            guard let completion = correlatedCodexTurnKindForCompletion(
                 turnID: turnID,
                 session: session
             ) else {
                 return
             }
+            let turnKind = completion.turnKind
+            let completedIdentity = completion.authoritativeIdentity
+            let providerSuccessor = codexFallbackSuccessorForCompletion(
+                turnID: turnID,
+                status: status,
+                completedIdentity: completedIdentity,
+                session: session
+            )
+            abandonCodexFallbackQueueBlockedByTerminalTurn(
+                completedIdentity,
+                status: status,
+                session: session
+            )
             if turnKind == .compact {
-                await settleCodexCompaction(
+                if status == .completed {
+                    markCodexContextCompacted(session)
+                }
+                await finalizeCodexRun(
                     session,
-                    status: status,
-                    reason: "compact-turn-completed-\(status)"
+                    turnStatus: status,
+                    reason: "compact-turn-completed-\(status)",
+                    providerSuccessor: providerSuccessor
                 )
                 AgentModeViewModel.logCodexDebug("[AgentModeVM][CodexUI] compact turnCompleted turnID=\(turnID ?? "nil") status=\(status) runState=\(session.runState)")
                 return
@@ -4494,7 +5512,8 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
             await finalizeCodexRun(
                 session,
                 turnStatus: status,
-                reason: "turn-completed-\(status)"
+                reason: "turn-completed-\(status)",
+                providerSuccessor: providerSuccessor
             )
             AgentModeViewModel.logCodexDebug("[AgentModeVM][CodexUI] turnCompleted turnID=\(turnID ?? "nil") status=\(status) items=\(session.items.count) runState=\(session.runState)")
         case .contextCompacted:
@@ -6393,10 +7412,13 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
         viewModel?.reconcileInteractiveRunState(session)
         handleRunInteractionStateChange(for: session, reason: .permissionsResponseSubmitted)
         viewModel?.requestUIRefresh(tabID: session.tabID, urgent: true)
+        let authoritativeTurnID = session.codexAuthoritativeActiveTurn?.turnID
         Task { [controller] in
             await controller.respondToServerRequest(id: request.requestID, result: result)
-            if case .cancel = decision {
-                await controller.cancelCurrentTurn()
+            if case .cancel = decision, let authoritativeTurnID {
+                _ = try? await controller.interruptUserTurn(expectedTurnID: authoritativeTurnID)
+            } else if case .cancel = decision {
+                _ = try? await controller.reconcileAndInterruptCurrentTurn()
             }
         }
     }
@@ -6419,10 +7441,13 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
         handleRunInteractionStateChange(for: session, reason: .mcpElicitationResponseSubmitted)
         viewModel?.requestUIRefresh(tabID: session.tabID, urgent: true)
         viewModel?.publishMCPStateChange(for: session)
+        let authoritativeTurnID = session.codexAuthoritativeActiveTurn?.turnID
         Task { [controller] in
             await controller.respondToServerRequest(id: request.requestID, result: response.jsonObject)
-            if response.action == .cancel {
-                await controller.cancelCurrentTurn()
+            if response.action == .cancel, let authoritativeTurnID {
+                _ = try? await controller.interruptUserTurn(expectedTurnID: authoritativeTurnID)
+            } else if response.action == .cancel {
+                _ = try? await controller.reconcileAndInterruptCurrentTurn()
             }
         }
     }
@@ -6537,8 +7562,12 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
         clearPendingAssistantDelta(session)
         session.codexModel = nil
         session.codexReasoningEffort = nil
+        abandonCodexFallbackQueue(
+            session: session,
+            reason: "Codex queued follow-up was cancelled because the session was cleared.",
+            mode: .discardInput
+        )
         resetTrackedCodexTurns(session)
-        session.pendingCodexCompactionInstructions.removeAll()
         session.codexNeedsReconnect = false
         session.pendingCodexComputerUseActivation = nil
         clearCodexPendingInteractions(in: session)
@@ -6569,8 +7598,11 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
         finalizePendingToolCalls(in: session, turnStatus: .interrupted)
         finalizeLingeringRunningBashResults(in: session, turnStatus: .interrupted)
         reconcilePersistedCodexCommandStatusIfNeeded(session: session, force: true)
+        abandonCodexFallbackQueue(
+            session: session,
+            reason: "Codex queued follow-up was cancelled with the active run."
+        )
         resetTrackedCodexTurns(session)
-        session.pendingCodexCompactionInstructions.removeAll()
         session.providerTerminalDrainGeneration &+= 1
     }
 
@@ -6579,12 +7611,41 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
             && session.pendingCommandRunningFlushTask == nil
     }
 
-    func prepareCodexCancellationTeardown(
+    struct CodexCancellationTarget {
+        let controller: any CodexSessionControlling
+        let authoritativeTurnIdentity: AgentModeViewModel.TabSession.CodexAuthoritativeTurnIdentity?
+    }
+
+    func captureCodexCancellationTarget(
         _ session: AgentModeViewModel.TabSession,
         expectedRunID: UUID?
+    ) -> CodexCancellationTarget? {
+        guard session.selectedAgent == .codexExec,
+              let controller = session.codexController
+        else { return nil }
+        let authoritativeTurnIdentity: AgentModeViewModel.TabSession.CodexAuthoritativeTurnIdentity? = if let identity = session.codexAuthoritativeActiveTurn,
+                                                                                                          identity.runID == expectedRunID,
+                                                                                                          authoritativeCodexTurnIsCurrent(identity, session: session),
+                                                                                                          identity.controllerInstanceID == ObjectIdentifier(controller)
+        {
+            identity
+        } else {
+            nil
+        }
+        return .init(
+            controller: controller,
+            authoritativeTurnIdentity: authoritativeTurnIdentity
+        )
+    }
+
+    func prepareCodexCancellationTeardown(
+        _ session: AgentModeViewModel.TabSession,
+        expectedRunID: UUID?,
+        capturedTarget: CodexCancellationTarget?
     ) -> (@MainActor () async -> Void)? {
         guard session.selectedAgent == .codexExec else { return nil }
-        let controller = session.codexController
+        let controller = capturedTarget?.controller ?? session.codexController
+        let authoritativeTurnIdentity = capturedTarget?.authoritativeTurnIdentity
         if session.codexConversationID != nil || session.codexRolloutPath != nil {
             markCodexReconnectNeeded(for: session, source: "user-cancel-detached", scheduleSave: false)
         }
@@ -6609,7 +7670,25 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
         settleCodexComputerUseActivationAfterTurn(session, reason: "user-cancel")
         return { [weak self] in
             if let controller {
-                await controller.cancelCurrentTurn()
+                if let authoritativeTurnIdentity {
+                    do {
+                        _ = try await controller.interruptUserTurn(
+                            expectedTurnID: authoritativeTurnIdentity.turnID
+                        )
+                    } catch {
+                        AgentModeViewModel.logCodexDebug(
+                            "[AgentModeVM][CodexCancel] interrupt reconciliation failed: \(error.localizedDescription)"
+                        )
+                    }
+                } else {
+                    do {
+                        _ = try await controller.reconcileAndInterruptCurrentTurn()
+                    } catch {
+                        AgentModeViewModel.logCodexDebug(
+                            "[AgentModeVM][CodexCancel] active-turn reconciliation failed: \(error.localizedDescription)"
+                        )
+                    }
+                }
                 await controller.shutdown()
             }
             await self?.stopCodexToolTrackingAndWait(for: session, matchingRunID: expectedRunID)
@@ -6619,8 +7698,16 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
     func cancelCodexRun(_ session: AgentModeViewModel.TabSession) async {
         guard session.selectedAgent == .codexExec else { return }
         let expectedRunID = session.runID
+        let capturedTarget = captureCodexCancellationTarget(
+            session,
+            expectedRunID: expectedRunID
+        )
         drainCodexTerminalBuffersForCancellation(session)
-        let teardown = prepareCodexCancellationTeardown(session, expectedRunID: expectedRunID)
+        let teardown = prepareCodexCancellationTeardown(
+            session,
+            expectedRunID: expectedRunID,
+            capturedTarget: capturedTarget
+        )
         await teardown?()
     }
 
@@ -6642,8 +7729,11 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
         session.pendingCommandRunningFlushTask = nil
         session.pendingCommandRunningByKey.removeAll()
         session.attachmentTurnState = .idle
+        abandonCodexFallbackQueue(
+            session: session,
+            reason: "Codex queued follow-up was cancelled because the session shut down."
+        )
         resetTrackedCodexTurns(session)
-        session.pendingCodexCompactionInstructions.removeAll()
         session.pendingCodexComputerUseActivation = nil
         if let controller = session.codexController {
             await controller.shutdown()

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Codex/CodexAgentModeCoordinator.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Codex/CodexAgentModeCoordinator.swift
@@ -2337,6 +2337,13 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
         session: AgentModeViewModel.TabSession
     ) {
         guard var inFlight = session.codexFallbackDispatchInFlight else { return }
+        // Successor dispatches begin a new run attempt, so lineage deliberately
+        // excludes runAttemptID.
+        guard identity.threadID == inFlight.originThreadID,
+              identity.controllerInstanceID == inFlight.originControllerInstanceID,
+              identity.controllerGeneration == inFlight.originControllerGeneration,
+              identity.runID == inFlight.originRunID
+        else { return }
         let previousBlockingTurn = inFlight.blockingTurn
         let blockingTurn = codexFallbackBlockingTurn(for: identity)
         switch inFlight.state {

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Codex/CodexSteerAckTracker.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Codex/CodexSteerAckTracker.swift
@@ -1,111 +1,193 @@
 import Foundation
 
-/// Tracks MCP-initiated Codex steer dispatch attempts and delivers send acknowledgements
-/// back to the awaiting `mcpDispatchInstruction` caller.
+/// Correlates MCP-initiated Codex dispatch attempts with their explicit submit path.
 ///
-/// **Lifecycle:**
-/// 1. `mcpDispatchInstruction` calls `beginAttempt()` before `submitUserTurn`
-/// 2. `submitPreparedUserTurn` calls `takePendingAttempt()` to claim the attempt ID
-/// 3. After the Codex send completes, it calls `resolve(attemptID:ack:)` with the outcome
-/// 4. Meanwhile, `mcpDispatchInstruction` awaits the result via `awaitAck(attemptID:)`
-///
-/// If the attempt is resolved before `awaitAck` is called, the ack is buffered.
-/// If `awaitAck` is called first, a continuation is parked until resolution or timeout.
-///
-/// Related:
-/// - MCP dispatch: AgentModeViewModel.mcpDispatchInstruction
-/// - Codex send: AgentModeViewModel.submitPreparedUserTurn (Codex branch)
-/// - Send outcome type: CodexAgentModeCoordinator.NativeSendOutcome
+/// Attempts are independent: dispatch authorization, delivery resolution, timeout, and
+/// cancellation are all keyed by attempt ID. Terminal attempts remain tombstoned so a late
+/// provider result cannot be buffered for, or accidentally resolve, a newer attempt.
 @MainActor
 final class CodexSteerAckTracker {
     nonisolated static let defaultTimeoutSeconds: TimeInterval = 2.5
 
-    enum Ack: Equatable {
-        case queuedFollowUp
-        case sendOutcome(CodexAgentModeCoordinator.NativeSendOutcome)
+    private final class CancellationFlag: @unchecked Sendable {
+        private let lock = NSLock()
+        private var value = false
+
+        func cancel() {
+            lock.lock()
+            value = true
+            lock.unlock()
+        }
+
+        var isCancelled: Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            return value
+        }
+    }
+
+    enum TerminalState: Equatable {
+        case steerAccepted
+        case startAccepted
+        case controlAccepted
+        case durablyQueued(queueID: UUID)
+        case failed(message: String)
+        case cancelled
+        case stale(reason: String)
         case timedOut
     }
 
-    // MARK: - State
+    private struct AttemptRecord {
+        let cancellationFlag = CancellationFlag()
+        var isDispatchAuthorized = false
+        var dispatchContinuation: CheckedContinuation<Bool, Never>?
+        var terminalState: TerminalState?
+        var terminalContinuation: CheckedContinuation<TerminalState, Never>?
+        var timeoutTask: Task<Void, Never>?
+    }
 
-    /// The attempt ID set by `beginAttempt` and consumed by `takePendingAttempt`.
-    private var pendingAttemptID: UUID?
-    /// Buffered acks for attempts resolved before `awaitAck` was called.
-    private var ackBuffer: [UUID: Ack] = [:]
-    /// Parked continuations for attempts where `awaitAck` was called before resolution.
-    private var continuations: [UUID: CheckedContinuation<Ack, Never>] = [:]
-    /// Timeout tasks that auto-resolve with `.timedOut` if no ack arrives in time.
-    private var timeoutTasks: [UUID: Task<Void, Never>] = [:]
+    private var attempts: [UUID: AttemptRecord] = [:]
+    private var terminalAttemptOrder: [UUID] = []
+    private let maxTerminalTombstones = 512
+    #if DEBUG
+        private(set) var test_latestAttemptID: UUID?
+    #endif
 
-    // MARK: - Public API
-
-    /// Creates a new dispatch attempt. Called by `mcpDispatchInstruction` before `submitUserTurn`.
     func beginAttempt() -> UUID {
         let attemptID = UUID()
-        pendingAttemptID = attemptID
+        attempts[attemptID] = AttemptRecord()
+        #if DEBUG
+            test_latestAttemptID = attemptID
+        #endif
         return attemptID
     }
 
-    /// Claims the pending attempt ID. Called by `submitPreparedUserTurn` to associate
-    /// the fire-and-forget `startAgentRun` task with the MCP dispatch attempt.
-    func takePendingAttempt() -> UUID? {
-        let id = pendingAttemptID
-        pendingAttemptID = nil
-        return id
+    func authorizeDispatch(attemptID: UUID) {
+        guard var record = attempts[attemptID],
+              record.terminalState == nil
+        else { return }
+        if record.cancellationFlag.isCancelled {
+            resolve(attemptID: attemptID, state: .cancelled)
+            return
+        }
+        record.isDispatchAuthorized = true
+        let continuation = record.dispatchContinuation
+        record.dispatchContinuation = nil
+        attempts[attemptID] = record
+        continuation?.resume(returning: true)
     }
 
-    /// Delivers an ack for the given attempt. Resumes the parked continuation if one exists,
-    /// otherwise buffers the ack for a subsequent `awaitAck` call.
-    func resolve(attemptID: UUID, ack: Ack) {
-        if pendingAttemptID == attemptID {
-            pendingAttemptID = nil
+    func awaitDispatchAuthorization(attemptID: UUID) async -> Bool {
+        guard let cancellationFlag = attempts[attemptID]?.cancellationFlag else {
+            return false
         }
-        timeoutTasks.removeValue(forKey: attemptID)?.cancel()
-        if let continuation = continuations.removeValue(forKey: attemptID) {
-            continuation.resume(returning: ack)
-        } else {
-            ackBuffer[attemptID] = ack
+        if Task.isCancelled {
+            cancellationFlag.cancel()
+            cancel(attemptID: attemptID)
+            return false
+        }
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                guard var record = attempts[attemptID],
+                      record.terminalState == nil
+                else {
+                    continuation.resume(returning: false)
+                    return
+                }
+                if record.isDispatchAuthorized {
+                    continuation.resume(returning: true)
+                    return
+                }
+                record.dispatchContinuation = continuation
+                attempts[attemptID] = record
+            }
+        } onCancel: {
+            cancellationFlag.cancel()
+            Task { @MainActor [weak self] in
+                self?.cancel(attemptID: attemptID)
+            }
         }
     }
 
-    /// Cancels a pending attempt, resuming any parked continuation with a failure.
-    func cancel(
-        attemptID: UUID,
-        failureMessage: String = "Codex steer was superseded before send acknowledgement."
-    ) {
-        if pendingAttemptID == attemptID {
-            pendingAttemptID = nil
-        }
-        timeoutTasks.removeValue(forKey: attemptID)?.cancel()
-        ackBuffer.removeValue(forKey: attemptID)
-        if let continuation = continuations.removeValue(forKey: attemptID) {
-            continuation.resume(returning: .sendOutcome(.failed(message: failureMessage)))
-        }
+    func resolve(attemptID: UUID, state: TerminalState) {
+        guard var record = attempts[attemptID],
+              record.terminalState == nil
+        else { return }
+        let resolvedState: TerminalState = record.cancellationFlag.isCancelled
+            ? .cancelled
+            : state
+        record.terminalState = resolvedState
+        record.timeoutTask?.cancel()
+        record.timeoutTask = nil
+        let dispatchContinuation = record.dispatchContinuation
+        record.dispatchContinuation = nil
+        let terminalContinuation = record.terminalContinuation
+        record.terminalContinuation = nil
+        attempts[attemptID] = record
+        terminalAttemptOrder.append(attemptID)
+        pruneTerminalTombstonesIfNeeded()
+        dispatchContinuation?.resume(returning: false)
+        terminalContinuation?.resume(returning: resolvedState)
     }
 
-    /// Awaits the ack for a dispatch attempt. Returns immediately if already buffered,
-    /// otherwise parks a continuation with a timeout safety net.
-    func awaitAck(
+    func cancel(attemptID: UUID) {
+        attempts[attemptID]?.cancellationFlag.cancel()
+        resolve(attemptID: attemptID, state: .cancelled)
+    }
+
+    func markStale(attemptID: UUID, reason: String) {
+        resolve(attemptID: attemptID, state: .stale(reason: reason))
+    }
+
+    func awaitTerminalState(
         attemptID: UUID,
         timeoutSeconds: TimeInterval = CodexSteerAckTracker.defaultTimeoutSeconds
-    ) async -> Ack {
-        if let ack = ackBuffer.removeValue(forKey: attemptID) {
-            return ack
+    ) async -> TerminalState {
+        guard let cancellationFlag = attempts[attemptID]?.cancellationFlag else {
+            return .stale(reason: "Codex dispatch attempt was not registered.")
         }
-        return await withCheckedContinuation { continuation in
-            continuations[attemptID] = continuation
-            let timeout = max(0.1, timeoutSeconds)
-            timeoutTasks[attemptID] = Task { @MainActor [weak self] in
-                try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
-                guard let self,
-                      let continuation = continuations.removeValue(forKey: attemptID)
-                else { return }
-                timeoutTasks.removeValue(forKey: attemptID)
-                if pendingAttemptID == attemptID {
-                    pendingAttemptID = nil
+        if Task.isCancelled {
+            cancellationFlag.cancel()
+            cancel(attemptID: attemptID)
+            return .cancelled
+        }
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                guard var record = attempts[attemptID] else {
+                    continuation.resume(returning: .stale(
+                        reason: "Codex dispatch attempt was not registered."
+                    ))
+                    return
                 }
-                continuation.resume(returning: .timedOut)
+                if let terminalState = record.terminalState {
+                    continuation.resume(returning: terminalState)
+                    return
+                }
+                record.terminalContinuation = continuation
+                let timeout = max(0.1, timeoutSeconds)
+                record.timeoutTask = Task { @MainActor [weak self] in
+                    try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+                    self?.resolve(attemptID: attemptID, state: .timedOut)
+                }
+                attempts[attemptID] = record
             }
+        } onCancel: {
+            cancellationFlag.cancel()
+            Task { @MainActor [weak self] in
+                self?.cancel(attemptID: attemptID)
+            }
+        }
+    }
+
+    private func pruneTerminalTombstonesIfNeeded() {
+        while terminalAttemptOrder.count > maxTerminalTombstones {
+            let expiredID = terminalAttemptOrder.removeFirst()
+            guard let record = attempts[expiredID],
+                  record.terminalState != nil,
+                  record.dispatchContinuation == nil,
+                  record.terminalContinuation == nil
+            else { continue }
+            attempts.removeValue(forKey: expiredID)
         }
     }
 }

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Codex/CodexSteerAckTracker.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Codex/CodexSteerAckTracker.swift
@@ -180,14 +180,20 @@ final class CodexSteerAckTracker {
     }
 
     private func pruneTerminalTombstonesIfNeeded() {
-        while terminalAttemptOrder.count > maxTerminalTombstones {
-            let expiredID = terminalAttemptOrder.removeFirst()
-            guard let record = attempts[expiredID],
-                  record.terminalState != nil,
-                  record.dispatchContinuation == nil,
-                  record.terminalContinuation == nil
-            else { continue }
+        var index = 0
+        while terminalAttemptOrder.count > maxTerminalTombstones, index < terminalAttemptOrder.count {
+            let expiredID = terminalAttemptOrder[index]
+            if let record = attempts[expiredID],
+               record.terminalState == nil
+               || record.dispatchContinuation != nil
+               || record.terminalContinuation != nil
+            {
+                // Keep attempts with live waiters tracked so a later prune can still remove them.
+                index += 1
+                continue
+            }
             attempts.removeValue(forKey: expiredID)
+            terminalAttemptOrder.remove(at: index)
         }
     }
 }

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/CodexIntegratedAgentModeRunner.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/CodexIntegratedAgentModeRunner.swift
@@ -20,7 +20,8 @@ final class CodexIntegratedAgentModeRunner {
         tabID: UUID,
         session: AgentModeViewModel.TabSession,
         initialMessageForRun: String,
-        attachments: [AgentImageAttachment]
+        attachments: [AgentImageAttachment],
+        fallbackContext: AgentModeViewModel.TabSession.CodexFallbackSubmissionContext?
     ) async -> CodexAgentModeCoordinator.NativeSendOutcome {
         let ownership: AgentRunOwnership
         let createdOwnership: Bool
@@ -51,6 +52,7 @@ final class CodexIntegratedAgentModeRunner {
                 session: session,
                 text: initialMessageForRun,
                 attachments: attachments,
+                fallbackContext: fallbackContext,
                 attachmentReservationID: attachmentReservationID,
                 terminalizeRejectedSend: createdOwnership
             )
@@ -62,6 +64,8 @@ final class CodexIntegratedAgentModeRunner {
                 if createdOwnership {
                     session.endRunAttempt(ifCurrent: ownership, source: "codex.sendRejected")
                 }
+            case .queuedFallback:
+                break
             }
             return outcome
         }

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+ComposerUI.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+ComposerUI.swift
@@ -84,7 +84,10 @@ extension AgentModeViewModel {
         return AgentComposerSubmitTarget(
             tabID: tabID,
             route: route,
+            expectedSourceTabSessionIdentity: ObjectIdentifier(resolvedSession),
             expectedSourceAgentSessionID: expectedSourceAgentSessionID,
+            expectedPersistentBindingIdentity: resolvedSession.persistentSessionBindingIdentity,
+            expectedBindingTransitionGeneration: resolvedSession.bindingTransitionGeneration,
             expectedRunState: expectedRunState,
             expectedRunID: expectedRunID,
             expectedRunAttemptID: expectedRunAttemptID,

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+TabSession.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+TabSession.swift
@@ -97,7 +97,11 @@ extension AgentModeViewModel {
         /// and intentionally never persisted as session state.
         var pendingInitialStartLocation: InitialStartLocation = .local
         var composerSubmissionToken = UUID()
-        var isComposerSubmissionInFlight = false
+        var activeComposerSubmitAttempt: AgentComposerSubmitAttempt?
+        var isComposerSubmissionInFlight: Bool {
+            activeComposerSubmitAttempt != nil
+        }
+
         var isPreparingInitialWorktree: Bool = false
         var isChangingExecutionLocation: Bool = false
 
@@ -223,18 +227,172 @@ extension AgentModeViewModel {
             var reasoningEffort: String?
             var serviceTier: String?
             var attachmentReservationID: UUID?
+            var expectedTurnID: String?
             var retryAttempted: Bool = false
         }
 
         enum CodexTurnKind: String {
             case user
             case compact
+            case review
+            case unknown
+        }
+
+        struct CodexAuthoritativeTurnIdentity: Equatable {
+            let threadID: String
+            let turnID: String
+            let turnKind: CodexTurnKind
+            let controllerInstanceID: ObjectIdentifier
+            let controllerGeneration: UUID
+            let runID: UUID
+            let runAttemptID: UUID
+        }
+
+        struct CodexAnonymousTurnLiveness: Equatable {
+            let threadID: String
+            let turnKind: CodexTurnKind
+            let controllerInstanceID: ObjectIdentifier
+            let controllerGeneration: UUID
+            let runID: UUID
+            let runAttemptID: UUID
+        }
+
+        enum CodexFallbackOrigin: Equatable {
+            case manual
+            case mcp(attemptID: UUID)
+        }
+
+        @MainActor
+        final class CodexDispatchSerialGate {
+            private var nextTicket: UInt64 = 0
+            private var servingTicket: UInt64 = 0
+            private var cancelledTickets: Set<UInt64> = []
+            private var waiters: [UInt64: CheckedContinuation<Bool, Never>] = [:]
+
+            func issueTicket() -> UInt64 {
+                defer { nextTicket &+= 1 }
+                return nextTicket
+            }
+
+            func awaitTurn(_ ticket: UInt64) async -> Bool {
+                if cancelledTickets.remove(ticket) != nil {
+                    advancePastCancelledTickets()
+                    return false
+                }
+                if ticket == servingTicket {
+                    return true
+                }
+                return await withCheckedContinuation { continuation in
+                    waiters[ticket] = continuation
+                }
+            }
+
+            func finish(_ ticket: UInt64) {
+                guard ticket == servingTicket else { return }
+                servingTicket &+= 1
+                advancePastCancelledTickets()
+                waiters.removeValue(forKey: servingTicket)?.resume(returning: true)
+            }
+
+            func cancel(_ ticket: UInt64) {
+                if let waiter = waiters.removeValue(forKey: ticket) {
+                    waiter.resume(returning: false)
+                }
+                cancelledTickets.insert(ticket)
+                guard ticket == servingTicket else { return }
+                advancePastCancelledTickets()
+                waiters.removeValue(forKey: servingTicket)?.resume(returning: true)
+            }
+
+            private func advancePastCancelledTickets() {
+                while cancelledTickets.remove(servingTicket) != nil {
+                    servingTicket &+= 1
+                }
+            }
+        }
+
+        enum CodexFallbackReason: Equatable {
+            case activeWithoutAuthoritativeIdentity
+            case staleAuthoritativeIdentity
+            case nonSteerableTurn(kind: CodexTurnKind)
+            case noActiveTurn(failure: CodexAppServerClient.RequestFailure)
+            case expectedTurnMismatch(
+                expectedTurnID: String,
+                actualTurnID: String?,
+                failure: CodexAppServerClient.RequestFailure
+            )
+            case activeTurnNotSteerable(
+                turnKind: String?,
+                failure: CodexAppServerClient.RequestFailure
+            )
+        }
+
+        struct CodexFallbackSubmissionContext: Equatable {
+            let queueID: UUID
+            let providerText: String
+            let images: [AgentImageAttachment]
+            let taggedFileAttachments: [AgentTaggedFileAttachment]
+            let draftText: String
+            let optimisticUserItemID: UUID?
+            let origin: CodexFallbackOrigin
+            let dispatchTicket: UInt64?
+        }
+
+        struct CodexFallbackBlockingTurn: Equatable {
+            let threadID: String
+            let turnID: String
+            let controllerInstanceID: ObjectIdentifier
+            let controllerGeneration: UUID
+            let runID: UUID
+            let runAttemptID: UUID
+        }
+
+        struct CodexPendingSteerLifecycleReconciliation: Equatable {
+            let priorIdentity: CodexAuthoritativeTurnIdentity
+            let acceptedDispatchTurnID: String
+        }
+
+        enum CodexFallbackQueueState: Equatable {
+            case queued
+            case eligibleForSuccessor(completedTurnID: String)
+            case dispatching
+            case awaitingLifecycleStart
+            case lifecycleStarted
+        }
+
+        struct CodexFallbackQueueEntry: Equatable, Identifiable {
+            let id: UUID
+            let providerText: String
+            let images: [AgentImageAttachment]
+            let taggedFileAttachments: [AgentTaggedFileAttachment]
+            let model: String?
+            let reasoningEffort: String?
+            let serviceTier: String?
+            let attachmentReservationID: UUID?
+            let optimisticUserItemID: UUID?
+            let draftText: String
+            let origin: CodexFallbackOrigin
+            let fallbackReason: CodexFallbackReason
+            let originThreadID: String
+            let originControllerInstanceID: ObjectIdentifier
+            let originControllerGeneration: UUID
+            let originRunID: UUID
+            let originRunAttemptID: UUID
+            var blockingTurn: CodexFallbackBlockingTurn?
+            var state: CodexFallbackQueueState
         }
 
         var codexPendingTurnKind: CodexTurnKind?
         var codexPendingAuthRetryTurn: CodexPendingAuthRetryTurn?
-        var codexTurnKindsByID: [String: CodexTurnKind] = [:]
-        var pendingCodexCompactionInstructions: [String] = []
+        var codexAuthoritativeActiveTurn: CodexAuthoritativeTurnIdentity?
+        var codexAnonymousActiveTurn: CodexAnonymousTurnLiveness?
+        var codexRoutingObservedTurnID: String?
+        var codexPendingSteerLifecycleReconciliation: CodexPendingSteerLifecycleReconciliation?
+        var codexFallbackQueue: [CodexFallbackQueueEntry] = []
+        var codexFallbackDispatchInFlight: CodexFallbackQueueEntry?
+        var codexFallbackPumpTask: Task<Void, Never>?
+        var codexFallbackSuccessorRetryTask: Task<Void, Never>?
+        let codexDispatchSerialGate = CodexDispatchSerialGate()
 
         // Instruction steering coordination state
         var instructionContinuation: CheckedContinuation<UserInstructionResponse, Error>?
@@ -270,7 +428,14 @@ extension AgentModeViewModel {
         }
 
         /// Draft text for input field
-        var draftText: String = ""
+        var draftText: String = "" {
+            didSet {
+                guard draftText != oldValue else { return }
+                draftMutationGeneration &+= 1
+            }
+        }
+
+        private(set) var draftMutationGeneration: UInt64 = 0
 
         /// Selected workflow template for next message
         var selectedWorkflow: AgentWorkflowDefinition?
@@ -298,7 +463,19 @@ extension AgentModeViewModel {
         var codexNeedsReconnect: Bool = false
         var codexResumeTimeoutState: CodexResumeTimeoutState = .init()
         var codexToolPreferencesGeneration: Int = 0
-        var codexController: (any CodexSessionControlling)?
+        var codexController: (any CodexSessionControlling)? {
+            didSet {
+                let oldIdentity = oldValue.map { ObjectIdentifier($0) }
+                let newIdentity = codexController.map { ObjectIdentifier($0) }
+                guard oldIdentity != newIdentity else { return }
+                codexControllerGeneration = UUID()
+                codexAuthoritativeActiveTurn = nil
+                codexAnonymousActiveTurn = nil
+                codexRoutingObservedTurnID = nil
+            }
+        }
+
+        private(set) var codexControllerGeneration = UUID()
         /// The permission profile the current Codex controller was created with.
         /// Used to detect when MCP control changes require controller recycling.
         var codexControllerPermissionProfile: AgentPermissionProfile?
@@ -348,9 +525,6 @@ extension AgentModeViewModel {
         var lastTerminalCommitRevision: AgentRunTerminalCommitRevision?
         var lastTerminalPublicationResult: AgentRunTerminalPublicationResult?
         var runAttemptTerminalResources: AgentRunAttemptTerminalResources?
-        var codexCurrentTurnID: String?
-        var codexCurrentTurnKind: CodexTurnKind?
-
         /// Handoff payload (injected into provider-facing text on first user send).
         /// Cleared only after the provider accepts the turn.
         var pendingHandoff: PendingHandoffState = .init()
@@ -509,8 +683,10 @@ extension AgentModeViewModel {
             lastTerminalCommitRevision = nil
             lastTerminalPublicationResult = nil
             providerTerminalDrainGeneration = 0
-            codexCurrentTurnID = nil
-            codexCurrentTurnKind = nil
+            codexAuthoritativeActiveTurn = nil
+            codexAnonymousActiveTurn = nil
+            codexRoutingObservedTurnID = nil
+            codexPendingSteerLifecycleReconciliation = nil
             var turnEpoch: AgentRunTurnEpoch?
             if var context = mcpControlContext {
                 turnEpoch = context.preparedEpoch ?? context.currentEpoch

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+Types.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+Types.swift
@@ -39,6 +39,43 @@ extension AgentModeViewModel {
         case blocked(message: String)
     }
 
+    struct AgentComposerSubmitClaim {
+        let attempt: AgentComposerSubmitAttempt
+        let sourceSession: TabSession
+        let draftMutationGeneration: UInt64
+    }
+
+    enum AgentComposerSubmitClaimRejection: Equatable {
+        case missingSession
+        case sourceSessionIdentityMismatch
+        case activeAttemptExists(activeAttemptID: UUID)
+        case targetRejected(reason: String)
+        case initialWorktreePreparationInProgress
+        case executionLocationChangeInProgress
+
+        var diagnosticReason: String {
+            switch self {
+            case .missingSession:
+                "missing_session"
+            case .sourceSessionIdentityMismatch:
+                "source_session_identity_mismatch"
+            case .activeAttemptExists:
+                "existing_claim"
+            case let .targetRejected(reason):
+                reason
+            case .initialWorktreePreparationInProgress:
+                "initial_worktree_preparation_in_progress"
+            case .executionLocationChangeInProgress:
+                "execution_location_change_in_progress"
+            }
+        }
+    }
+
+    enum AgentComposerSubmitClaimResult {
+        case claimed(AgentComposerSubmitClaim)
+        case rejected(AgentComposerSubmitClaimRejection)
+    }
+
     enum RunInteractionStateChangeReason: String, Equatable {
         case userInputResponseSubmitted
         case pendingQuestionCancelled

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -596,6 +596,11 @@ final class AgentModeViewModel: ObservableObject {
         private var test_currentTabIDOverride: UUID?
         private var test_allowsScheduledDerivedTranscriptRefreshWithoutPromptManager = false
         private var test_afterMCPStoreEpochBegan: (@MainActor () async -> Void)?
+        private var test_terminalPublicationOverride: ((
+            AgentRunTerminalCommitRevision,
+            AgentRunEpochTransitionKind?,
+            TabSession
+        ) async -> AgentRunTerminalPublicationResult)?
     #endif
     private var hasPreparedForWindowClose = false
     private static let uiRefreshCoalesceDelayNanos: UInt64 = 75_000_000
@@ -646,6 +651,16 @@ final class AgentModeViewModel: ObservableObject {
 
         func test_setAfterMCPStoreEpochBegan(_ hook: (@MainActor () async -> Void)?) {
             test_afterMCPStoreEpochBegan = hook
+        }
+
+        func test_setTerminalPublicationOverride(
+            _ hook: ((
+                AgentRunTerminalCommitRevision,
+                AgentRunEpochTransitionKind?,
+                TabSession
+            ) async -> AgentRunTerminalPublicationResult)?
+        ) {
+            test_terminalPublicationOverride = hook
         }
 
         func test_makeTerminalPublicationEnvelope(
@@ -4015,6 +4030,10 @@ final class AgentModeViewModel: ObservableObject {
         publishChanges: Bool = true,
         deactivateLiveControlContext: Bool = true
     ) async {
+        codexCoordinator.handleMCPControlReset(
+            for: session,
+            reason: "Codex queued follow-up was cancelled because MCP control was torn down."
+        )
         session.mcpControlActivationGeneration &+= 1
         if let context = session.mcpControlContext {
             if deactivateLiveControlContext {
@@ -4041,6 +4060,19 @@ final class AgentModeViewModel: ObservableObject {
 
     func publishMCPStateChange(for session: TabSession) {
         handleObservedMCPStateChange(for: session)
+    }
+
+    func signalCodexInstructionDelivered(for session: TabSession) async {
+        await signalMCPInstructionDelivered(for: session)
+    }
+
+    func restoreCodexFallbackDraft(tabID: UUID, text: String, message: String) {
+        restoreComposerDraft(
+            tabID: tabID,
+            text: text,
+            message: message,
+            strategy: .prependAlways
+        )
     }
 
     func publishRunInteractionStateChange(
@@ -4126,6 +4158,15 @@ final class AgentModeViewModel: ObservableObject {
         successorKind: AgentRunEpochTransitionKind?,
         for session: TabSession
     ) async -> AgentRunTerminalPublicationResult {
+        #if DEBUG
+            if let test_terminalPublicationOverride {
+                return await test_terminalPublicationOverride(
+                    revision,
+                    successorKind,
+                    session
+                )
+            }
+        #endif
         guard let envelope = revision.mcpPublicationEnvelope else {
             return session.mcpControlContext == nil
                 ? .accepted(successorEpoch: nil)
@@ -5636,6 +5677,12 @@ final class AgentModeViewModel: ObservableObject {
         }
         let existingContext = session.mcpControlContext
         let activationID = UUID()
+        if existingContext != nil {
+            codexCoordinator.handleMCPControlReset(
+                for: session,
+                reason: "Codex queued follow-up was cancelled because MCP control was replaced."
+            )
+        }
         if let existingSessionID = existingContext?.sessionID,
            existingSessionID != sessionID
         {
@@ -5746,6 +5793,10 @@ final class AgentModeViewModel: ObservableObject {
             return
         }
 
+        codexCoordinator.handleMCPControlReset(
+            for: session,
+            reason: "Codex queued follow-up was cancelled because MCP control was deactivated."
+        )
         session.mcpControlActivationGeneration &+= 1
         session.mcpControlCleanupTask?.cancel()
         session.mcpControlCleanupTask = nil
@@ -5797,29 +5848,29 @@ final class AgentModeViewModel: ObservableObject {
         session: TabSession,
         attemptID: UUID
     ) async throws -> MCPInstructionDispatch {
-        let ack = await session.codexSteerAckTracker.awaitAck(attemptID: attemptID)
-        switch ack {
-        case .queuedFollowUp:
+        let state = await session.codexSteerAckTracker.awaitTerminalState(attemptID: attemptID)
+        switch state {
+        case .durablyQueued:
             return .queuedFollowUp
-        case let .sendOutcome(outcome):
-            switch outcome {
-            case .sent:
-                return .dispatchedCodexTurn
-            case let .stale(reason):
-                throw MCPError.internalError(
-                    reason.isEmpty
-                        ? "Codex steer was dropped because the active run changed before delivery."
-                        : reason
-                )
-            case .cancelled:
-                throw MCPError.invalidParams("Codex steer was cancelled before it reached the active run.")
-            case let .failed(message):
-                throw MCPError.internalError(
-                    message.isEmpty
-                        ? "Codex steer failed before reaching the active run."
-                        : message
-                )
+        case .steerAccepted, .startAccepted, .controlAccepted:
+            return .dispatchedCodexTurn
+        case let .failed(message):
+            throw MCPError.internalError(
+                message.isEmpty
+                    ? "Codex steer failed before reaching the active run."
+                    : message
+            )
+        case .cancelled:
+            if Task.isCancelled {
+                throw CancellationError()
             }
+            throw MCPError.invalidParams("Codex steer was cancelled before it reached the active run.")
+        case let .stale(reason):
+            throw MCPError.internalError(
+                reason.isEmpty
+                    ? "Codex steer was dropped because the active run changed before delivery."
+                    : reason
+            )
         case .timedOut:
             throw MCPError.internalError(
                 "Timed out waiting for Codex to acknowledge the steer message. The run may have changed state."
@@ -5946,6 +5997,11 @@ final class AgentModeViewModel: ObservableObject {
             codexAttemptID = nil
             signalsDeliveryAfterDispatch = false
         }
+        defer {
+            if Task.isCancelled, let codexAttemptID {
+                session.codexSteerAckTracker.cancel(attemptID: codexAttemptID)
+            }
+        }
 
         let submission: UserTurnSubmissionResult
         session.isMCPInstructionDispatchInProgress = true
@@ -5961,10 +6017,15 @@ final class AgentModeViewModel: ObservableObject {
                     attachmentsToSend: [],
                     taggedFilesToSend: [],
                     activeWorkflow: nativePreparedTurn.bubbleWorkflow,
-                    nativePreparedTurn: nativePreparedTurn
+                    nativePreparedTurn: nativePreparedTurn,
+                    codexAttemptID: codexAttemptID
                 )
             }
-            return submitUserTurn(text: trimmedText, tabID: session.tabID)
+            return submitUserTurn(
+                text: trimmedText,
+                tabID: session.tabID,
+                codexAttemptID: codexAttemptID
+            )
         }
         switch submission {
         case .submitted:
@@ -5977,6 +6038,7 @@ final class AgentModeViewModel: ObservableObject {
                 await wakeMCPWaitersForActiveDispatch(delivery: delivery, session: session, sessionID: sessionID)
             }
             if let codexAttemptID {
+                session.codexSteerAckTracker.authorizeDispatch(attemptID: codexAttemptID)
                 delivery = try await awaitCodexSteerAck(session: session, attemptID: codexAttemptID)
             }
             if signalsDeliveryAfterDispatch {
@@ -9947,30 +10009,60 @@ final class AgentModeViewModel: ObservableObject {
         target: AgentComposerSubmitTarget,
         createAndActivateSessionTab: () async -> UUID?
     ) async -> UserTurnSubmissionResult {
-        if let rejectionReason = submitTargetRejectionReason(target, session: sessions[target.tabID]) {
-            logRejectedSubmitTarget(target, session: sessions[target.tabID], reason: rejectionReason)
-            resyncAfterRejectedSubmitTarget(target)
+        let attempt = AgentComposerSubmitAttempt(
+            id: UUID(),
+            target: target,
+            inputRevision: 0,
+            noticeRevision: 0,
+            rawDraftSnapshot: text
+        )
+        switch claimComposerSubmitAttempt(attempt) {
+        case let .claimed(claim):
+            return await executeComposerSubmitAttempt(
+                text: text,
+                claim: claim,
+                createAndActivateSessionTab: createAndActivateSessionTab
+            )
+        case .rejected:
             return .blocked(message: Self.staleComposerSubmitTargetMessage)
         }
-        if sessions[target.tabID]?.isPreparingInitialWorktree == true {
-            logRejectedSubmitTarget(target, session: sessions[target.tabID], reason: "initial_worktree_preparation_in_progress")
-            resyncAfterRejectedSubmitTarget(target)
-            return .blocked(message: Self.staleComposerSubmitTargetMessage)
-        }
-        guard let claimedSourceSession = claimComposerSubmitTarget(target) else {
-            logRejectedSubmitTarget(target, session: sessions[target.tabID], reason: "submission_token_mismatch")
-            resyncAfterRejectedSubmitTarget(target)
+    }
+
+    @discardableResult
+    func executeComposerSubmitAttempt(
+        text: String,
+        claim: AgentComposerSubmitClaim
+    ) async -> UserTurnSubmissionResult {
+        await executeComposerSubmitAttempt(
+            text: text,
+            claim: claim,
+            createAndActivateSessionTab: { [weak self] in
+                await self?.createAndActivateSessionTab()
+            }
+        )
+    }
+
+    @discardableResult
+    func executeComposerSubmitAttempt(
+        text: String,
+        claim: AgentComposerSubmitClaim,
+        createAndActivateSessionTab: () async -> UUID?
+    ) async -> UserTurnSubmissionResult {
+        let target = claim.attempt.target
+        let claimedSourceSession = claim.sourceSession
+        guard composerSubmitClaimIsCurrent(claim) else {
             return .blocked(message: Self.staleComposerSubmitTargetMessage)
         }
         defer {
-            claimedSourceSession.isComposerSubmissionInFlight = false
-            resyncAfterConsumedSubmitTarget(target)
+            releaseComposerSubmitClaim(claim)
         }
 
         switch target.route {
         case .existingAgentSession:
             let preparedSession = await ensureSessionReady(tabID: target.tabID)
-            guard preparedSession === claimedSourceSession else {
+            guard preparedSession === claimedSourceSession,
+                  composerSubmitClaimIsCurrent(claim)
+            else {
                 return .blocked(message: Self.staleComposerSubmitTargetMessage)
             }
             if let rejectionReason = submitTargetRejectionReason(
@@ -9987,7 +10079,11 @@ final class AgentModeViewModel: ObservableObject {
                   initialLocation != .local,
                   pendingState.initialStartLocation == initialLocation
             else {
-                return submitUserTurn(text: text, tabID: target.tabID)
+                let result = submitUserTurn(text: text, tabID: target.tabID)
+                if result == .submitted {
+                    clearComposerDraftIfUnchanged(for: claim)
+                }
+                return result
             }
             let sourceSnapshot = FirstSendSourceSnapshot(
                 session: preparedSession,
@@ -10012,6 +10108,7 @@ final class AgentModeViewModel: ObservableObject {
             do {
                 try await prepareInitialExecutionLocation(initialLocation, for: preparedSession) {
                     !Task.isCancelled
+                        && self.composerSubmitClaimIsCurrent(claim)
                         && self.sessions[target.tabID] === preparedSession
                         && self.composerSourceAgentSessionID(
                             tabID: target.tabID,
@@ -10031,6 +10128,7 @@ final class AgentModeViewModel: ObservableObject {
                 return .blocked(message: Self.staleComposerSubmitTargetMessage)
             }
             guard !Task.isCancelled,
+                  composerSubmitClaimIsCurrent(claim),
                   sessions[target.tabID] === preparedSession,
                   sourceSnapshot.matches(sessions[target.tabID]),
                   Self.pendingUserTurnState(from: preparedSession) == pendingState
@@ -10044,7 +10142,11 @@ final class AgentModeViewModel: ObservableObject {
             if target.tabID == currentTabID {
                 applySessionToBindings(preparedSession)
             }
-            return submitUserTurn(text: text, tabID: target.tabID)
+            let result = submitUserTurn(text: text, tabID: target.tabID)
+            if result == .submitted {
+                clearComposerDraftIfUnchanged(for: claim)
+            }
+            return result
         case .createAgentSessionFromSourceTab:
             let sourceSession = claimedSourceSession
             let sourceSnapshot = FirstSendSourceSnapshot(
@@ -10073,7 +10175,9 @@ final class AgentModeViewModel: ObservableObject {
             guard let destinationTabID = await createAndActivateSessionTab() else {
                 return .blocked(message: "Failed to create a new agent session.")
             }
-            guard !Task.isCancelled else {
+            guard !Task.isCancelled,
+                  composerSubmitClaimIsCurrent(claim)
+            else {
                 await discardFreshFirstSendDestinationIfPossible(destinationTabID)
                 return .blocked(message: Self.staleComposerSubmitTargetMessage)
             }
@@ -10091,7 +10195,9 @@ final class AgentModeViewModel: ObservableObject {
                 await discardFreshFirstSendDestinationIfPossible(destinationTabID)
                 return .blocked(message: Self.staleComposerSubmitTargetMessage)
             }
-            guard sourceSnapshot.matches(sessions[target.tabID]) else {
+            guard composerSubmitClaimIsCurrent(claim),
+                  sourceSnapshot.matches(sessions[target.tabID])
+            else {
                 logRejectedSubmitTarget(target, session: sessions[target.tabID], reason: "source_pending_state_changed")
                 resyncAfterRejectedSubmitTarget(target)
                 await discardFreshFirstSendDestinationIfPossible(destinationTabID)
@@ -10135,6 +10241,7 @@ final class AgentModeViewModel: ObservableObject {
                 do {
                     try await prepareInitialExecutionLocation(pendingState.initialStartLocation, for: destinationSession) {
                         !Task.isCancelled
+                            && self.composerSubmitClaimIsCurrent(claim)
                             && self.sessions[destinationTabID] === destinationSession
                             && self.sessions[target.tabID] === sourceSession
                             && sourceSnapshot.matches(self.sessions[target.tabID])
@@ -10147,6 +10254,7 @@ final class AgentModeViewModel: ObservableObject {
                 }
             }
             guard !Task.isCancelled,
+                  composerSubmitClaimIsCurrent(claim),
                   sessions[destinationTabID] === destinationSession,
                   sessions[target.tabID] === sourceSession,
                   sourceSnapshot.matches(sessions[target.tabID]),
@@ -10169,7 +10277,7 @@ final class AgentModeViewModel: ObservableObject {
                 return result
             }
             clearPendingUserTurnState(on: sourceSession)
-            storeDraftText(for: target.tabID, "")
+            clearComposerDraftIfUnchanged(for: claim)
             return result
         }
     }
@@ -10278,12 +10386,6 @@ final class AgentModeViewModel: ObservableObject {
            let validationFailure = validateSlashSkillUsage(in: trimmedText, activeWorkflow: workflow)
         {
             return validationFailure
-        }
-        if session.selectedAgent == .codexExec,
-           codexCoordinator.isCodexCompactionInFlight(session: session),
-           !session.pendingCodexCompactionInstructions.isEmpty
-        {
-            return .blocked(message: "Wait for Codex compaction to finish before sending another follow-up.")
         }
         return nil
     }
@@ -10474,7 +10576,11 @@ final class AgentModeViewModel: ObservableObject {
     }
 
     @discardableResult
-    func submitUserTurn(text: String, tabID: UUID) -> UserTurnSubmissionResult {
+    func submitUserTurn(
+        text: String,
+        tabID: UUID,
+        codexAttemptID: UUID? = nil
+    ) -> UserTurnSubmissionResult {
         let session = session(for: tabID)
         let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
         let attachmentsToSend = session.pendingImageAttachments
@@ -10502,9 +10608,6 @@ final class AgentModeViewModel: ObservableObject {
             }
             switch nativeSlashCommand.command.behavior {
             case .controlPlane:
-                let codexAttemptID = session.selectedAgent == .codexExec
-                    ? session.codexSteerAckTracker.takePendingAttempt()
-                    : nil
                 let goalAction: CodexAgentModeCoordinator.GoalSlashAction? = nativeSlashCommand.command == .goal
                     ? CodexAgentModeCoordinator.goalSlashAction(from: nativeSlashCommand.argumentsText)
                     : nil
@@ -10520,6 +10623,11 @@ final class AgentModeViewModel: ObservableObject {
                 )
                 Task { [weak self] in
                     guard let self else { return }
+                    if let codexAttemptID {
+                        guard await session.codexSteerAckTracker.awaitDispatchAuthorization(
+                            attemptID: codexAttemptID
+                        ) else { return }
+                    }
                     let result = await submitNativeSlashCommandAfterHydration(
                         tabID: tabID,
                         invocation: nativeSlashCommand,
@@ -10527,15 +10635,15 @@ final class AgentModeViewModel: ObservableObject {
                         progressRestoreState: progressRestoreState
                     )
                     guard let codexAttemptID else { return }
-                    let ack: CodexSteerAckTracker.Ack = switch result {
+                    let state: CodexSteerAckTracker.TerminalState = switch result {
                     case .succeeded:
-                        .sendOutcome(.sent)
+                        .controlAccepted
                     case let .failed(message):
-                        .sendOutcome(.failed(message: message))
+                        .failed(message: message)
                     case nil:
-                        .sendOutcome(.failed(message: "Native Codex slash command could not be delivered because the session changed before execution."))
+                        .stale(reason: "Native Codex slash command could not be delivered because the session changed before execution.")
                     }
-                    session.codexSteerAckTracker.resolve(attemptID: codexAttemptID, ack: ack)
+                    session.codexSteerAckTracker.resolve(attemptID: codexAttemptID, state: state)
                 }
                 return .submitted
             case .userTurnWrapper:
@@ -10561,15 +10669,6 @@ final class AgentModeViewModel: ObservableObject {
             return invocation.definition.asBubbleWorkflowDefinition()
         }()
 
-        let codexCompactionInFlight = session.selectedAgent == .codexExec
-            && codexCoordinator.isCodexCompactionInFlight(session: session)
-        if codexCompactionInFlight,
-           !session.pendingCodexCompactionInstructions.isEmpty
-        {
-            storeDraftText(for: tabID, trimmedText)
-            return .blocked(message: "Wait for Codex compaction to finish before sending another follow-up.")
-        }
-
         // Capture and clear workflow before sending
         session.selectedWorkflow = nil
         selectedWorkflow = nil
@@ -10586,7 +10685,8 @@ final class AgentModeViewModel: ObservableObject {
                     attachmentsToSend: attachmentsToSend,
                     taggedFilesToSend: taggedFilesToSend,
                     activeWorkflow: bubbleWorkflow,
-                    nativePreparedTurn: nativePreparedTurn
+                    nativePreparedTurn: nativePreparedTurn,
+                    codexAttemptID: codexAttemptID
                 )
             }
             return .submitted
@@ -10599,7 +10699,8 @@ final class AgentModeViewModel: ObservableObject {
             attachmentsToSend: attachmentsToSend,
             taggedFilesToSend: taggedFilesToSend,
             activeWorkflow: bubbleWorkflow,
-            nativePreparedTurn: nativePreparedTurn
+            nativePreparedTurn: nativePreparedTurn,
+            codexAttemptID: codexAttemptID
         )
     }
 
@@ -10609,7 +10710,8 @@ final class AgentModeViewModel: ObservableObject {
         attachmentsToSend: [AgentImageAttachment],
         taggedFilesToSend: [AgentTaggedFileAttachment],
         activeWorkflow: AgentWorkflowDefinition?,
-        nativePreparedTurn: NativeSlashPreparedUserTurn? = nil
+        nativePreparedTurn: NativeSlashPreparedUserTurn? = nil,
+        codexAttemptID: UUID? = nil
     ) async {
         guard let session = sessions[tabID] else { return }
         await prepareSessionForRunStart(tabID: tabID, session: session)
@@ -10621,7 +10723,8 @@ final class AgentModeViewModel: ObservableObject {
             attachmentsToSend: attachmentsToSend,
             taggedFilesToSend: taggedFilesToSend,
             activeWorkflow: activeWorkflow,
-            nativePreparedTurn: nativePreparedTurn
+            nativePreparedTurn: nativePreparedTurn,
+            codexAttemptID: codexAttemptID
         )
     }
 
@@ -10652,7 +10755,8 @@ final class AgentModeViewModel: ObservableObject {
         attachmentsToSend: [AgentImageAttachment],
         taggedFilesToSend: [AgentTaggedFileAttachment],
         activeWorkflow: AgentWorkflowDefinition?,
-        nativePreparedTurn: NativeSlashPreparedUserTurn? = nil
+        nativePreparedTurn: NativeSlashPreparedUserTurn? = nil,
+        codexAttemptID: UUID? = nil
     ) -> UserTurnSubmissionResult {
         Self.logCodexDebug("[AgentModeVM] submitUserTurn: tabID=\(tabID), selectedAgent=\(session.selectedAgent), attachments=\(attachmentsToSend.count), taggedFiles=\(taggedFilesToSend.count), workflow=\(activeWorkflow?.displayName ?? "none")")
 
@@ -10774,20 +10878,36 @@ final class AgentModeViewModel: ObservableObject {
         }
 
         if session.selectedAgent == .codexExec {
-            let codexAttemptID = session.codexSteerAckTracker.takePendingAttempt()
-            if codexCompactionInFlight {
-                session.pendingCodexCompactionInstructions = [wrappedText]
-                if let codexAttemptID {
-                    session.codexSteerAckTracker.resolve(attemptID: codexAttemptID, ack: .queuedFollowUp)
-                }
-                return UserTurnSubmissionResult.submitted
-            }
+            let dispatchTicket = session.codexDispatchSerialGate.issueTicket()
+            let fallbackContext = TabSession.CodexFallbackSubmissionContext(
+                queueID: UUID(),
+                providerText: wrappedText,
+                images: attachmentsToSend,
+                taggedFileAttachments: taggedFilesToSend,
+                draftText: trimmedText,
+                optimisticUserItemID: userItem.id,
+                origin: codexAttemptID.map(TabSession.CodexFallbackOrigin.mcp) ?? .manual,
+                dispatchTicket: dispatchTicket
+            )
             Task {
+                var handedOffToSerialDispatch = false
+                defer {
+                    if !handedOffToSerialDispatch {
+                        session.codexDispatchSerialGate.cancel(dispatchTicket)
+                    }
+                }
+                if let codexAttemptID {
+                    guard await session.codexSteerAckTracker.awaitDispatchAuthorization(
+                        attemptID: codexAttemptID
+                    ) else { return }
+                }
+                handedOffToSerialDispatch = true
                 let sendOutcome = await self.startAgentRun(
                     tabID: tabID,
                     initialMessage: wrappedText,
                     attachments: attachmentsToSend,
-                    taggedFileAttachments: taggedFilesToSend
+                    taggedFileAttachments: taggedFilesToSend,
+                    codexFallbackContext: fallbackContext
                 )
                 if sendOutcome?.didSend != true {
                     self.clearPendingCodexComputerUseActivationIfMatched(
@@ -10796,9 +10916,24 @@ final class AgentModeViewModel: ObservableObject {
                     )
                 }
                 guard let codexAttemptID else { return }
-                let resolvedOutcome = sendOutcome
-                    ?? .failed(message: "Codex steer could not be delivered because the runtime changed before send started.")
-                session.codexSteerAckTracker.resolve(attemptID: codexAttemptID, ack: .sendOutcome(resolvedOutcome))
+                let terminalState: CodexSteerAckTracker.TerminalState = switch sendOutcome {
+                case .sent:
+                    .steerAccepted
+                case let .queuedFallback(queueID, _):
+                    .durablyQueued(queueID: queueID)
+                case let .stale(reason):
+                    .stale(reason: reason)
+                case .cancelled:
+                    .cancelled
+                case let .failed(message):
+                    .failed(message: message)
+                case nil:
+                    .stale(reason: "Codex steer could not be delivered because the runtime changed before send started.")
+                }
+                session.codexSteerAckTracker.resolve(
+                    attemptID: codexAttemptID,
+                    state: terminalState
+                )
             }
             return UserTurnSubmissionResult.submitted
         }
@@ -11389,9 +11524,25 @@ final class AgentModeViewModel: ObservableObject {
         case .claudeNativeInterrupt, .acpPrompt:
             .afterProviderSend
         case nil:
-            .afterOptimisticSubmit
+            session.selectedAgent == .codexExec
+                ? .afterProviderSend
+                : .afterOptimisticSubmit
         }
     }
+
+    #if DEBUG
+        static func test_mcpActiveInstructionDeliverySignalTiming(
+            selectedAgent: AgentProviderKind,
+            hasNativeSteeringRoute: Bool
+        ) -> MCPActiveInstructionDeliverySignalTiming {
+            if hasNativeSteeringRoute {
+                return .afterProviderSend
+            }
+            return selectedAgent == .codexExec
+                ? .afterProviderSend
+                : .afterOptimisticSubmit
+        }
+    #endif
 
     func renderProviderMessage(
         text: String,
@@ -12091,9 +12242,21 @@ final class AgentModeViewModel: ObservableObject {
         tabID: UUID,
         initialMessage: String,
         attachments: [AgentImageAttachment] = [],
-        taggedFileAttachments: [AgentTaggedFileAttachment] = []
+        taggedFileAttachments: [AgentTaggedFileAttachment] = [],
+        codexFallbackContext: TabSession.CodexFallbackSubmissionContext? = nil
     ) async -> CodexAgentModeCoordinator.NativeSendOutcome? {
         let session = session(for: tabID)
+        let codexDispatchTicket = codexFallbackContext?.dispatchTicket
+        if let codexDispatchTicket {
+            guard await session.codexDispatchSerialGate.awaitTurn(codexDispatchTicket) else {
+                return .cancelled
+            }
+        }
+        defer {
+            if let codexDispatchTicket {
+                session.codexDispatchSerialGate.finish(codexDispatchTicket)
+            }
+        }
         guard AgentModelCatalog.isAgentAvailable(session.selectedAgent, availability: agentAvailabilityContext) else {
             if session.mcpFollowUpRunPending {
                 session.mcpFollowUpRunPending = false
@@ -12123,13 +12286,26 @@ final class AgentModeViewModel: ObservableObject {
             session: session,
             initialMessage: augmentedInitialMessage
         )
+        let preparedCodexFallbackContext = codexFallbackContext.map { context in
+            TabSession.CodexFallbackSubmissionContext(
+                queueID: context.queueID,
+                providerText: initialMessageForRun,
+                images: context.images,
+                taggedFileAttachments: context.taggedFileAttachments,
+                draftText: context.draftText,
+                optimisticUserItemID: context.optimisticUserItemID,
+                origin: context.origin,
+                dispatchTicket: context.dispatchTicket
+            )
+        }
 
         return await runService.startRun(
             tabID: tabID,
             session: session,
             initialUserMessage: augmentedInitialMessage,
             initialMessageForRun: initialMessageForRun,
-            attachments: attachments
+            attachments: attachments,
+            codexFallbackContext: preparedCodexFallbackContext
         )
     }
 
@@ -13041,21 +13217,103 @@ final class AgentModeViewModel: ObservableObject {
         }
     }
 
-    private func claimComposerSubmitTarget(_ target: AgentComposerSubmitTarget) -> TabSession? {
-        guard let session = sessions[target.tabID],
-              !session.isComposerSubmissionInFlight,
-              session.composerSubmissionToken == target.expectedSubmissionToken
-        else { return nil }
-        session.isComposerSubmissionInFlight = true
-        session.composerSubmissionToken = UUID()
-        return session
-    }
+    func claimComposerSubmitAttempt(_ attempt: AgentComposerSubmitAttempt) -> AgentComposerSubmitClaimResult {
+        let target = attempt.target
+        guard let session = sessions[target.tabID] else {
+            let rejection = AgentComposerSubmitClaimRejection.missingSession
+            logRejectedSubmitTarget(target, session: nil, reason: rejection.diagnosticReason, attempt: attempt)
+            resyncAfterRejectedSubmitTarget(target)
+            return .rejected(rejection)
+        }
+        guard ObjectIdentifier(session) == attempt.sourceTabSessionIdentity else {
+            let rejection = AgentComposerSubmitClaimRejection.sourceSessionIdentityMismatch
+            logRejectedSubmitTarget(target, session: session, reason: rejection.diagnosticReason, attempt: attempt)
+            resyncAfterRejectedSubmitTarget(target)
+            return .rejected(rejection)
+        }
+        if let activeAttempt = session.activeComposerSubmitAttempt {
+            let rejection = AgentComposerSubmitClaimRejection.activeAttemptExists(activeAttemptID: activeAttempt.id)
+            logRejectedSubmitTarget(
+                target,
+                session: session,
+                reason: rejection.diagnosticReason,
+                attempt: attempt,
+                activeAttempt: activeAttempt
+            )
+            resyncAfterRejectedSubmitTarget(target)
+            return .rejected(rejection)
+        }
+        if let rejectionReason = submitTargetRejectionReason(target, session: session) {
+            let rejection = AgentComposerSubmitClaimRejection.targetRejected(reason: rejectionReason)
+            logRejectedSubmitTarget(target, session: session, reason: rejectionReason, attempt: attempt)
+            resyncAfterRejectedSubmitTarget(target)
+            return .rejected(rejection)
+        }
+        if session.isPreparingInitialWorktree {
+            let rejection = AgentComposerSubmitClaimRejection.initialWorktreePreparationInProgress
+            logRejectedSubmitTarget(target, session: session, reason: rejection.diagnosticReason, attempt: attempt)
+            resyncAfterRejectedSubmitTarget(target)
+            return .rejected(rejection)
+        }
+        if session.isChangingExecutionLocation {
+            let rejection = AgentComposerSubmitClaimRejection.executionLocationChangeInProgress
+            logRejectedSubmitTarget(target, session: session, reason: rejection.diagnosticReason, attempt: attempt)
+            resyncAfterRejectedSubmitTarget(target)
+            return .rejected(rejection)
+        }
 
-    private func resyncAfterConsumedSubmitTarget(_ target: AgentComposerSubmitTarget) {
+        session.activeComposerSubmitAttempt = attempt
+        session.composerSubmissionToken = UUID()
+        let claim = AgentComposerSubmitClaim(
+            attempt: attempt,
+            sourceSession: session,
+            draftMutationGeneration: session.draftMutationGeneration
+        )
         if currentTabID == target.tabID {
             syncComposerUIState(tabID: target.tabID)
         }
         requestUIRefresh(tabID: target.tabID, urgent: true)
+        logComposerSubmitClaimAccepted(claim)
+        return .claimed(claim)
+    }
+
+    private func composerSubmitClaimIsCurrent(_ claim: AgentComposerSubmitClaim) -> Bool {
+        let attempt = claim.attempt
+        return ObjectIdentifier(claim.sourceSession) == attempt.sourceTabSessionIdentity
+            && sessions[attempt.sourceTabID] === claim.sourceSession
+            && claim.sourceSession.activeComposerSubmitAttempt?.id == attempt.id
+    }
+
+    @discardableResult
+    func releaseComposerSubmitClaim(_ claim: AgentComposerSubmitClaim) -> Bool {
+        let attempt = claim.attempt
+        let sourceSession = claim.sourceSession
+        guard ObjectIdentifier(sourceSession) == attempt.sourceTabSessionIdentity,
+              sourceSession.activeComposerSubmitAttempt?.id == attempt.id
+        else {
+            logComposerSubmitClaimRelease(claim, accepted: false)
+            return false
+        }
+
+        sourceSession.activeComposerSubmitAttempt = nil
+        if sessions[attempt.sourceTabID] === sourceSession,
+           currentTabID == attempt.sourceTabID
+        {
+            syncComposerUIState(tabID: attempt.sourceTabID)
+        }
+        requestUIRefresh(tabID: attempt.sourceTabID, urgent: true)
+        logComposerSubmitClaimRelease(claim, accepted: true)
+        return true
+    }
+
+    private func clearComposerDraftIfUnchanged(for claim: AgentComposerSubmitClaim) {
+        let attempt = claim.attempt
+        let session = claim.sourceSession
+        guard ObjectIdentifier(session) == attempt.sourceTabSessionIdentity,
+              session.draftMutationGeneration == claim.draftMutationGeneration,
+              session.draftText == attempt.rawDraftSnapshot
+        else { return }
+        storeDraftText(for: attempt.sourceTabID, "")
     }
 
     private func submitTargetRejectionReason(
@@ -13070,6 +13328,11 @@ final class AgentModeViewModel: ObservableObject {
         let liveRunAttemptID = session?.activeRunAttemptID
         let liveInitialStartLocation = initialStartLocationProps(tabID: target.tabID)?.selection
 
+        if let session,
+           ObjectIdentifier(session) != target.expectedSourceTabSessionIdentity
+        {
+            return "source_session_identity_mismatch"
+        }
         if validateSubmissionToken, session?.composerSubmissionToken != target.expectedSubmissionToken {
             return "submission_token_mismatch"
         }
@@ -13114,10 +13377,18 @@ final class AgentModeViewModel: ObservableObject {
         }
     }
 
-    private func logRejectedSubmitTarget(_ target: AgentComposerSubmitTarget, session: TabSession?, reason: String) {
+    private func logRejectedSubmitTarget(
+        _ target: AgentComposerSubmitTarget,
+        session: TabSession?,
+        reason: String,
+        attempt: AgentComposerSubmitAttempt? = nil,
+        activeAttempt: AgentComposerSubmitAttempt? = nil
+    ) {
         let liveSourceAgentSessionID = composerSourceAgentSessionID(tabID: target.tabID, session: session)
+        let reportedAttempt = attempt ?? session?.activeComposerSubmitAttempt
+        let reportedActiveAttempt = activeAttempt ?? session?.activeComposerSubmitAttempt
         Self.steeringDebugLog(
-            "[AgentSubmitTarget] rejected reason=\(reason) route=\(target.route.rawValue) targetTab=\(target.tabID) expectedRun=\(target.expectedRunID?.uuidString ?? "nil") liveRun=\(session?.runID?.uuidString ?? "nil")"
+            "[AgentSubmitTarget] rejected reason=\(reason) attempt=\(reportedAttempt?.id.uuidString ?? "nil") activeClaim=\(reportedActiveAttempt?.id.uuidString ?? "nil") route=\(target.route.rawValue) targetTab=\(target.tabID) expectedRun=\(target.expectedRunID?.uuidString ?? "nil") liveRun=\(session?.runID?.uuidString ?? "nil")"
         )
         #if DEBUG
             AgentModePerfDiagnostics.event(
@@ -13125,11 +13396,22 @@ final class AgentModeViewModel: ObservableObject {
                 tabID: target.tabID,
                 fields: [
                     "reason": reason,
+                    "attemptID": AgentModePerfDiagnostics.shortID(reportedAttempt?.id),
+                    "activeClaimID": AgentModePerfDiagnostics.shortID(reportedActiveAttempt?.id),
                     "route": target.route.rawValue,
                     "targetTabID": AgentModePerfDiagnostics.shortID(target.tabID),
                     "currentTabID": AgentModePerfDiagnostics.shortID(currentTabID),
+                    "expectedSourceTabSessionIdentity": String(describing: target.expectedSourceTabSessionIdentity),
+                    "liveSourceTabSessionIdentity": session.map { String(describing: ObjectIdentifier($0)) } ?? "nil",
                     "expectedSourceAgentSessionID": AgentModePerfDiagnostics.shortID(target.expectedSourceAgentSessionID),
                     "liveSourceAgentSessionID": AgentModePerfDiagnostics.shortID(liveSourceAgentSessionID),
+                    "expectedPersistentBindingSessionID": AgentModePerfDiagnostics.shortID(target.expectedPersistentBindingIdentity?.sessionID),
+                    "livePersistentBindingSessionID": AgentModePerfDiagnostics.shortID(session?.persistentSessionBindingIdentity?.sessionID),
+                    "expectedPersistentBindingGeneration": AgentModePerfDiagnostics.shortID(target.expectedPersistentBindingIdentity?.generation),
+                    "livePersistentBindingGeneration": AgentModePerfDiagnostics.shortID(session?.persistentSessionBindingIdentity?.generation),
+                    "expectedBindingTransitionGeneration": String(target.expectedBindingTransitionGeneration),
+                    "liveBindingTransitionGeneration": session.map { String($0.bindingTransitionGeneration) } ?? "nil",
+                    "liveBindingTransitionInProgress": String(session?.bindingTransitionInProgress ?? false),
                     "expectedRunState": target.expectedRunState.rawValue,
                     "liveRunState": session?.runState.rawValue ?? "idle",
                     "expectedRunID": AgentModePerfDiagnostics.shortID(target.expectedRunID),
@@ -13138,6 +13420,50 @@ final class AgentModeViewModel: ObservableObject {
                     "liveRunAttemptID": AgentModePerfDiagnostics.shortID(session?.activeRunAttemptID),
                     "expectedSubmissionToken": AgentModePerfDiagnostics.shortID(target.expectedSubmissionToken),
                     "liveSubmissionToken": AgentModePerfDiagnostics.shortID(session?.composerSubmissionToken)
+                ]
+            )
+        #endif
+    }
+
+    private func logComposerSubmitClaimAccepted(_ claim: AgentComposerSubmitClaim) {
+        let attempt = claim.attempt
+        Self.steeringDebugLog(
+            "[AgentSubmitClaim] accepted attempt=\(attempt.id) targetTab=\(attempt.sourceTabID) token=\(attempt.capturedSubmissionToken)"
+        )
+        #if DEBUG
+            AgentModePerfDiagnostics.event(
+                "agent.submitClaim.accepted",
+                tabID: attempt.sourceTabID,
+                fields: [
+                    "attemptID": AgentModePerfDiagnostics.shortID(attempt.id),
+                    "sourceTabSessionIdentity": String(describing: attempt.sourceTabSessionIdentity),
+                    "capturedSubmissionToken": AgentModePerfDiagnostics.shortID(attempt.capturedSubmissionToken),
+                    "liveSubmissionToken": AgentModePerfDiagnostics.shortID(claim.sourceSession.composerSubmissionToken),
+                    "inputRevision": String(attempt.inputRevision),
+                    "persistentBindingSessionID": AgentModePerfDiagnostics.shortID(claim.sourceSession.persistentSessionBindingIdentity?.sessionID),
+                    "persistentBindingGeneration": AgentModePerfDiagnostics.shortID(claim.sourceSession.persistentSessionBindingIdentity?.generation),
+                    "bindingTransitionGeneration": String(claim.sourceSession.bindingTransitionGeneration),
+                    "composerTargetPublishedNil": String(currentTabID != attempt.sourceTabID || ui.composer.props.submitTarget == nil)
+                ]
+            )
+        #endif
+    }
+
+    private func logComposerSubmitClaimRelease(_ claim: AgentComposerSubmitClaim, accepted: Bool) {
+        let attempt = claim.attempt
+        Self.steeringDebugLog(
+            "[AgentSubmitClaim] release accepted=\(accepted) attempt=\(attempt.id) targetTab=\(attempt.sourceTabID) activeClaim=\(claim.sourceSession.activeComposerSubmitAttempt?.id.uuidString ?? "nil")"
+        )
+        #if DEBUG
+            AgentModePerfDiagnostics.event(
+                accepted ? "agent.submitClaim.released" : "agent.submitClaim.releaseSkipped",
+                tabID: attempt.sourceTabID,
+                fields: [
+                    "attemptID": AgentModePerfDiagnostics.shortID(attempt.id),
+                    "activeClaimID": AgentModePerfDiagnostics.shortID(claim.sourceSession.activeComposerSubmitAttempt?.id),
+                    "sourceTabSessionIdentity": String(describing: attempt.sourceTabSessionIdentity),
+                    "liveSourceTabSessionIdentity": String(describing: ObjectIdentifier(claim.sourceSession)),
+                    "currentTabID": AgentModePerfDiagnostics.shortID(currentTabID)
                 ]
             )
         #endif
@@ -13928,9 +14254,6 @@ final class AgentModeViewModel: ObservableObject {
         session.activeNonCodexTurnTokenAccumulator = nil
         session.contextUsageSnapshot = nil
         session.contextCompactedAt = nil
-        session.codexPendingTurnKind = nil
-        session.codexTurnKindsByID.removeAll()
-        session.pendingCodexCompactionInstructions.removeAll()
         session.activeReasoningItemID = nil
         session.reasoningItemIDsByGroupID.removeAll()
         session.clearClaudeReasoningStatus(clearDisplayedStatus: true)

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentComposerUIModels.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentComposerUIModels.swift
@@ -52,7 +52,10 @@ struct AgentComposerSubmitTarget: Equatable {
 
     let tabID: UUID
     let route: Route
+    let expectedSourceTabSessionIdentity: ObjectIdentifier
     let expectedSourceAgentSessionID: UUID?
+    let expectedPersistentBindingIdentity: AgentPersistentSessionBindingIdentity?
+    let expectedBindingTransitionGeneration: UInt64
     // Exact freshness guards for unlinked first-send targets. For an existing
     // persistent session, these remain render-time diagnostics while live routing
     // selects the current run and attempt at send time.
@@ -62,6 +65,117 @@ struct AgentComposerSubmitTarget: Equatable {
     /// One-shot render identity claimed before submission performs any async work.
     let expectedSubmissionToken: UUID
     let expectedInitialStartLocation: AgentModeViewModel.InitialStartLocation?
+}
+
+struct AgentComposerSubmitAttempt: Equatable {
+    let id: UUID
+    let target: AgentComposerSubmitTarget
+    let inputRevision: UInt64
+    let noticeRevision: UInt64
+    let rawDraftSnapshot: String
+
+    var sourceTabID: UUID {
+        target.tabID
+    }
+
+    var sourceTabSessionIdentity: ObjectIdentifier {
+        target.expectedSourceTabSessionIdentity
+    }
+
+    var capturedSubmissionToken: UUID {
+        target.expectedSubmissionToken
+    }
+}
+
+struct AgentComposerSubmissionLatch {
+    struct CompletionEffects: Equatable {
+        let matchedAttempt: Bool
+        let shouldClearInput: Bool
+        let blockedMessage: String?
+
+        static let stale = CompletionEffects(
+            matchedAttempt: false,
+            shouldClearInput: false,
+            blockedMessage: nil
+        )
+    }
+
+    private(set) var activeAttemptsByTabID: [UUID: AgentComposerSubmitAttempt] = [:]
+    private(set) var inputRevision: UInt64 = 0
+    private(set) var noticeRevision: UInt64 = 0
+
+    func isLatched(for tabID: UUID?) -> Bool {
+        guard let tabID else { return false }
+        return activeAttemptsByTabID[tabID] != nil
+    }
+
+    func activeAttemptID(for tabID: UUID?) -> UUID? {
+        guard let tabID else { return nil }
+        return activeAttemptsByTabID[tabID]?.id
+    }
+
+    mutating func advanceInputRevision() {
+        inputRevision &+= 1
+    }
+
+    mutating func advanceNoticeRevision() {
+        noticeRevision &+= 1
+    }
+
+    mutating func begin(
+        target: AgentComposerSubmitTarget,
+        rawDraftSnapshot: String,
+        attemptID: UUID = UUID()
+    ) -> AgentComposerSubmitAttempt? {
+        guard activeAttemptsByTabID[target.tabID] == nil else { return nil }
+        let attempt = AgentComposerSubmitAttempt(
+            id: attemptID,
+            target: target,
+            inputRevision: inputRevision,
+            noticeRevision: noticeRevision,
+            rawDraftSnapshot: rawDraftSnapshot
+        )
+        activeAttemptsByTabID[target.tabID] = attempt
+        return attempt
+    }
+
+    @discardableResult
+    mutating func cancel(_ attempt: AgentComposerSubmitAttempt) -> Bool {
+        guard activeAttemptsByTabID[attempt.sourceTabID]?.id == attempt.id else { return false }
+        activeAttemptsByTabID.removeValue(forKey: attempt.sourceTabID)
+        return true
+    }
+
+    mutating func complete(
+        _ attempt: AgentComposerSubmitAttempt,
+        result: AgentModeViewModel.UserTurnSubmissionResult,
+        currentTabID: UUID?,
+        currentRawDraft: String
+    ) -> CompletionEffects {
+        guard activeAttemptsByTabID[attempt.sourceTabID]?.id == attempt.id else {
+            return .stale
+        }
+        activeAttemptsByTabID.removeValue(forKey: attempt.sourceTabID)
+
+        let inputStillMatches = currentTabID == attempt.sourceTabID
+            && inputRevision == attempt.inputRevision
+            && currentRawDraft == attempt.rawDraftSnapshot
+        switch result {
+        case .submitted:
+            return CompletionEffects(
+                matchedAttempt: true,
+                shouldClearInput: inputStillMatches,
+                blockedMessage: nil
+            )
+        case let .blocked(message):
+            let mayPublishNotice = inputStillMatches && noticeRevision == attempt.noticeRevision
+            return CompletionEffects(
+                matchedAttempt: true,
+                shouldClearInput: false,
+                blockedMessage: mayPublishNotice ? message : nil
+            )
+        }
+    }
 }
 
 struct AgentComposerProps: Equatable {

--- a/Sources/RepoPrompt/Features/AgentMode/Views/AgentInputBar.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/AgentInputBar.swift
@@ -13,7 +13,8 @@ import UniformTypeIdentifiers
 struct AgentComposerActions {
     let storeDraft: (_ tabID: UUID, _ text: String) -> Void
     let retrieveDraft: (_ tabID: UUID) -> String
-    let submit: (_ target: AgentComposerSubmitTarget, _ text: String) async -> AgentModeViewModel.UserTurnSubmissionResult
+    let claimSubmit: (_ attempt: AgentComposerSubmitAttempt) -> AgentModeViewModel.AgentComposerSubmitClaimResult
+    let executeSubmit: (_ claim: AgentModeViewModel.AgentComposerSubmitClaim, _ text: String) async -> AgentModeViewModel.UserTurnSubmissionResult
     let cancelRun: (_ target: AgentRunCancelTarget) async -> Void
     let attachImages: (_ tabID: UUID, _ urls: [URL]) -> Void
     let removeImage: (_ tabID: UUID, _ attachmentID: UUID) -> Void
@@ -112,7 +113,10 @@ struct AgentInputBar: View {
         AgentComposerActions(
             storeDraft: { tabID, text in agentModeVM.storeDraftText(for: tabID, text) },
             retrieveDraft: { tabID in agentModeVM.retrieveDraftText(for: tabID) },
-            submit: { target, text in await agentModeVM.submitUserTurnCreatingSessionIfNeeded(text: text, target: target) },
+            claimSubmit: { attempt in agentModeVM.claimComposerSubmitAttempt(attempt) },
+            executeSubmit: { claim, text in
+                await agentModeVM.executeComposerSubmitAttempt(text: text, claim: claim)
+            },
             cancelRun: { target in _ = await agentModeVM.cancelAgentRun(target: target) },
             attachImages: { tabID, urls in agentModeVM.attachImages(tabID: tabID, urls: urls) },
             removeImage: { tabID, attachmentID in agentModeVM.removePendingImage(tabID: tabID, attachmentID: attachmentID) },
@@ -266,6 +270,7 @@ struct AgentComposerView: View, Equatable {
     @FocusState var isFocused: Bool
 
     @State private var localInputText: String = ""
+    @State private var submissionLatch = AgentComposerSubmissionLatch()
     @State private var editorTextFieldHeight: CGFloat = ResizableTextField.height(forPresetIndex: 0, preset: .normal)
     @State private var isInputEmpty: Bool = true
     @State private var chromeOcclusion: CGFloat = 0
@@ -325,7 +330,16 @@ struct AgentComposerView: View, Equatable {
     }
 
     private var canSubmitToRenderedTarget: Bool {
-        props.canSendWithCurrentProvider && renderedSubmitTarget != nil
+        props.canSendWithCurrentProvider
+            && renderedSubmitTarget != nil
+            && !submissionLatch.isLatched(for: currentTabID)
+    }
+
+    private var localInputTextBinding: Binding<String> {
+        Binding(
+            get: { localInputText },
+            set: { setLocalInputText($0) }
+        )
     }
 
     private var isCurrentTabMCPControlled: Bool {
@@ -482,6 +496,7 @@ struct AgentComposerView: View, Equatable {
         .onChange(of: props.draftRestorationEvent) { _, event in
             guard let event, event.tabID == currentTabID else { return }
             isSyncingDraftFromSession = true
+            let restoredText: String
             switch event.strategy {
             case .replaceIfEmpty:
                 let trimmed = localInputText.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -489,16 +504,17 @@ struct AgentComposerView: View, Equatable {
                     isSyncingDraftFromSession = false
                     return
                 }
-                localInputText = event.text
+                restoredText = event.text
             case .prependAlways:
                 let existing = localInputText.trimmingCharacters(in: .whitespacesAndNewlines)
                 if existing.isEmpty {
-                    localInputText = event.text
+                    restoredText = event.text
                 } else {
-                    localInputText = event.text + "\n" + existing
+                    restoredText = event.text + "\n" + existing
                 }
             }
-            isInputEmpty = localInputText.isEmpty
+            setLocalInputText(restoredText, forceRevision: true)
+            actions.storeDraft(event.tabID, restoredText)
             DispatchQueue.main.async {
                 isSyncingDraftFromSession = false
             }
@@ -558,7 +574,7 @@ struct AgentComposerView: View, Equatable {
             }
 
             ResizableTextField(
-                text: $localInputText,
+                text: localInputTextBinding,
                 placeholder: placeholderText,
                 onReturn: sendMessage,
                 resetTrigger: $resetTextFieldTrigger,
@@ -1384,6 +1400,10 @@ struct AgentComposerView: View, Equatable {
     // MARK: - Actions
 
     private func sendMessage() {
+        guard !submissionLatch.isLatched(for: currentTabID) else {
+            logViewSubmitRejection(reason: "local_attempt_latched", target: renderedSubmitTarget)
+            return
+        }
         guard props.canSendWithCurrentProvider else {
             if props.hasAvailableAgentProviders {
                 showSteeringUnsupportedNotice(props.unavailableSelectedAgentMessage ?? "Connect this agent provider in Settings before sending.")
@@ -1392,27 +1412,58 @@ struct AgentComposerView: View, Equatable {
             }
             return
         }
-        let trimmed = localInputText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let rawDraftSnapshot = localInputText
+        let trimmed = rawDraftSnapshot.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty || hasPendingAttachments else { return }
         guard let submitTarget = renderedSubmitTarget else {
+            logViewSubmitRejection(reason: "view_nil_target", target: props.submitTarget)
             showSteeringUnsupportedNotice(Self.staleSubmitTargetMessage)
             return
         }
+        guard let attempt = submissionLatch.begin(
+            target: submitTarget,
+            rawDraftSnapshot: rawDraftSnapshot
+        ) else {
+            logViewSubmitRejection(reason: "local_attempt_latched", target: submitTarget)
+            return
+        }
 
-        Task { @MainActor in
-            let submissionResult = await actions.submit(submitTarget, trimmed)
-            switch submissionResult {
-            case .submitted:
-                localInputText = ""
-                resetTextFieldTrigger.toggle()
-            case let .blocked(message):
-                showSteeringUnsupportedNotice(message)
+        actions.storeDraft(attempt.sourceTabID, rawDraftSnapshot)
+        switch actions.claimSubmit(attempt) {
+        case let .claimed(claim):
+            Task { @MainActor in
+                let submissionResult = await actions.executeSubmit(claim, trimmed)
+                let effects = submissionLatch.complete(
+                    attempt,
+                    result: submissionResult,
+                    currentTabID: currentTabID,
+                    currentRawDraft: localInputText
+                )
+                guard effects.matchedAttempt else {
+                    logViewSubmitRejection(reason: "stale_completion", target: attempt.target)
+                    return
+                }
+                if effects.shouldClearInput {
+                    setLocalInputText("")
+                    resetTextFieldTrigger.toggle()
+                }
+                if let blockedMessage = effects.blockedMessage {
+                    showSteeringUnsupportedNotice(blockedMessage)
+                }
             }
+        case let .rejected(rejection):
+            submissionLatch.cancel(attempt)
+            if case .activeAttemptExists = rejection {
+                return
+            }
+            showSteeringUnsupportedNotice(Self.staleSubmitTargetMessage)
         }
     }
 
     private func showSteeringUnsupportedNotice(_ message: String) {
         guard !message.isEmpty else { return }
+        submissionLatch.advanceNoticeRevision()
+        let noticeRevision = submissionLatch.noticeRevision
         steeringUnsupportedDismissTask?.cancel()
         withAnimation(.easeInOut(duration: 0.15)) {
             steeringUnsupportedMessage = message
@@ -1421,12 +1472,36 @@ struct AgentComposerView: View, Equatable {
             try? await Task.sleep(nanoseconds: 3_000_000_000)
             guard !Task.isCancelled else { return }
             await MainActor.run {
+                guard submissionLatch.noticeRevision == noticeRevision,
+                      steeringUnsupportedMessage == message
+                else { return }
                 withAnimation(.easeInOut(duration: 0.2)) {
                     steeringUnsupportedMessage = nil
                 }
                 steeringUnsupportedDismissTask = nil
             }
         }
+    }
+
+    private func logViewSubmitRejection(reason: String, target: AgentComposerSubmitTarget?) {
+        #if DEBUG
+            AgentModePerfDiagnostics.event(
+                "agent.composer.submit.rejected",
+                tabID: currentTabID,
+                fields: [
+                    "reason": reason,
+                    "currentTabID": AgentModePerfDiagnostics.shortID(currentTabID),
+                    "propsTabID": AgentModePerfDiagnostics.shortID(props.currentTabID),
+                    "targetTabID": AgentModePerfDiagnostics.shortID(target?.tabID),
+                    "attemptID": AgentModePerfDiagnostics.shortID(submissionLatch.activeAttemptID(for: currentTabID)),
+                    "inputRevision": String(submissionLatch.inputRevision),
+                    "expectedSubmissionToken": AgentModePerfDiagnostics.shortID(target?.expectedSubmissionToken),
+                    "expectedSourceAgentSessionID": AgentModePerfDiagnostics.shortID(target?.expectedSourceAgentSessionID),
+                    "expectedPersistentBindingGeneration": AgentModePerfDiagnostics.shortID(target?.expectedPersistentBindingIdentity?.generation),
+                    "expectedBindingTransitionGeneration": target.map { String($0.expectedBindingTransitionGeneration) } ?? "nil"
+                ]
+            )
+        #endif
     }
 
     private func cancelRun(_ target: AgentRunCancelTarget) {
@@ -1465,10 +1540,12 @@ struct AgentComposerView: View, Equatable {
             .first(where: { $0.id == attachmentID })
         actions.removeTaggedFile(tabID, attachmentID)
         if let attachment {
-            localInputText = AgentFileMentionText.removingTaggedMention(
-                displayName: attachment.displayName,
-                relativePath: attachment.relativePath,
-                from: localInputText
+            setLocalInputText(
+                AgentFileMentionText.removingTaggedMention(
+                    displayName: attachment.displayName,
+                    relativePath: attachment.relativePath,
+                    from: localInputText
+                )
             )
         }
     }
@@ -1510,10 +1587,19 @@ struct AgentComposerView: View, Equatable {
         value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     }
 
+    private func setLocalInputText(_ newValue: String, forceRevision: Bool = false) {
+        guard forceRevision || localInputText != newValue else {
+            isInputEmpty = newValue.isEmpty
+            return
+        }
+        submissionLatch.advanceInputRevision()
+        localInputText = newValue
+        isInputEmpty = newValue.isEmpty
+    }
+
     private func loadDraftFromSession(for tabID: UUID) {
         isSyncingDraftFromSession = true
-        localInputText = actions.retrieveDraft(tabID)
-        isInputEmpty = localInputText.isEmpty
+        setLocalInputText(actions.retrieveDraft(tabID), forceRevision: true)
         DispatchQueue.main.async {
             isSyncingDraftFromSession = false
         }

--- a/Sources/RepoPrompt/Features/Diagnostics/AgentMode/Stress/AgentModeViewModel+StressHarnessSupport.swift
+++ b/Sources/RepoPrompt/Features/Diagnostics/AgentMode/Stress/AgentModeViewModel+StressHarnessSupport.swift
@@ -93,9 +93,14 @@
             session.pendingInstructions = []
             session.pendingClaudeSteeringInstructions = []
             session.pendingACPSteeringInstructions = []
-            session.pendingCodexCompactionInstructions = []
+            session.codexFallbackPumpTask?.cancel()
+            session.codexFallbackPumpTask = nil
+            session.codexFallbackQueue = []
+            session.codexFallbackDispatchInFlight = nil
             session.codexPendingTurnKind = nil
-            session.codexTurnKindsByID = [:]
+            session.codexAuthoritativeActiveTurn = nil
+            session.codexAnonymousActiveTurn = nil
+            session.codexRoutingObservedTurnID = nil
             session.pendingCommandRunningByKey = [:]
             session.pendingCommandRunningFlushTask?.cancel()
             session.pendingCommandRunningFlushTask = nil

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexAppServerClient.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexAppServerClient.swift
@@ -2,7 +2,7 @@ import Darwin
 import Darwin.POSIX.fcntl
 import Foundation
 
-enum CodexJSONValue {
+enum CodexJSONValue: Equatable {
     case string(String)
     case number(Double)
     case bool(Bool)
@@ -91,6 +91,13 @@ enum CodexAppServerRequestID: Hashable {
 }
 
 actor CodexAppServerClient {
+    struct RequestFailure: Equatable {
+        let method: String
+        let code: Int?
+        let message: String
+        let data: CodexJSONValue?
+    }
+
     struct RemoteReasoningEffort: Hashable {
         let reasoningEffort: String
         let description: String
@@ -148,7 +155,7 @@ actor CodexAppServerClient {
         case processNotRunning
         case invalidResponse
         case jsonDecodeFailed
-        case requestFailed(String)
+        case requestFailed(RequestFailure)
         case executableUnavailable(String)
         case transportWriteFailed(message: String, errno: Int32?)
         case transportReadSetupFailed(message: String, errno: Int32?)
@@ -161,8 +168,8 @@ actor CodexAppServerClient {
                 "Codex app-server returned an invalid response."
             case .jsonDecodeFailed:
                 "Failed to decode Codex app-server JSON response."
-            case let .requestFailed(message):
-                message
+            case let .requestFailed(failure):
+                failure.message
             case let .executableUnavailable(message):
                 message
             case let .transportWriteFailed(message, _):
@@ -220,9 +227,9 @@ actor CodexAppServerClient {
 
     static func isTimeoutError(_ error: Error) -> Bool {
         if let clientError = error as? ClientError,
-           case let .requestFailed(message) = clientError
+           case let .requestFailed(failure) = clientError
         {
-            return isTimeoutErrorMessage(message)
+            return isTimeoutErrorMessage(failure.message)
         }
 
         let nsError = error as NSError
@@ -241,6 +248,26 @@ actor CodexAppServerClient {
         guard !normalized.isEmpty else { return false }
         return normalized.contains("request timed out after")
             || normalized.contains("timed out after")
+    }
+
+    static func requestFailure(
+        method: String,
+        errorObject: [String: Any]
+    ) -> RequestFailure? {
+        guard let message = errorObject["message"] as? String else { return nil }
+        let code: Int? = if let value = errorObject["code"] as? Int {
+            value
+        } else if let value = errorObject["code"] as? NSNumber {
+            value.intValue
+        } else {
+            nil
+        }
+        return RequestFailure(
+            method: method,
+            code: code,
+            message: message,
+            data: errorObject["data"].flatMap(CodexJSONValue.from)
+        )
     }
 
     private static func shouldPoisonTransportOnTimeout(method: String) -> Bool {
@@ -1034,16 +1061,21 @@ actor CodexAppServerClient {
                 return
             }
             if let error = json["error"] as? [String: Any],
-               let message = error["message"] as? String
+               let continuation = pendingRequests.removeValue(forKey: idString)
             {
-                if let continuation = pendingRequests.removeValue(forKey: idString) {
-                    pendingRequestMetadata.removeValue(forKey: idString)
-                    cancelTimeout(for: idString)
-                    if config.enableDebugLogging {
-                        print("[CodexAppServer] Error for request \(idString): \(message)")
-                    }
-                    continuation.resume(throwing: ClientError.requestFailed(message))
+                let metadata = pendingRequestMetadata.removeValue(forKey: idString)
+                cancelTimeout(for: idString)
+                guard let failure = Self.requestFailure(
+                    method: metadata?.method ?? "<unknown>",
+                    errorObject: error
+                ) else {
+                    continuation.resume(throwing: ClientError.invalidResponse)
+                    return
                 }
+                if config.enableDebugLogging {
+                    print("[CodexAppServer] Error for request \(idString): \(failure.message)")
+                }
+                continuation.resume(throwing: ClientError.requestFailed(failure))
                 return
             }
             if let method = json["method"] as? String,
@@ -1403,7 +1435,12 @@ actor CodexAppServerClient {
             )
             scheduleTransportCleanup(terminatingTransport)
         }
-        continuation.resume(throwing: ClientError.requestFailed("Request timed out after \(timeout)s"))
+        continuation.resume(throwing: ClientError.requestFailed(.init(
+            method: metadata?.method ?? "<unknown>",
+            code: nil,
+            message: "Request timed out after \(timeout)s",
+            data: nil
+        )))
     }
 
     private func cancelTimeout(for requestID: String) {

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexNativeSessionController.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexNativeSessionController.swift
@@ -1254,18 +1254,8 @@ final class CodexNativeSessionController {
             ) else {
                 throw CodexAppServerClient.ClientError.invalidResponse
             }
-            guard acceptedTurnID == expectedTurnID else {
-                throw CodexTurnSteerError.expectedTurnMismatch(
-                    expectedTurnID: expectedTurnID,
-                    actualTurnID: acceptedTurnID,
-                    failure: CodexAppServerClient.RequestFailure(
-                        method: "turn/steer",
-                        code: nil,
-                        message: "Codex accepted turn/steer for turn \(acceptedTurnID) instead of expected turn \(expectedTurnID).",
-                        data: nil
-                    )
-                )
-            }
+            // An accepted steer with a different turn ID still delivered the input;
+            // callers reconcile identity from the receipt instead of retrying.
             return CodexTurnSteerReceipt(acceptedTurnID: acceptedTurnID)
         } catch let error as CodexAppServerClient.ClientError {
             throw Self.mapSteerRequestError(error, expectedTurnID: expectedTurnID)

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexNativeSessionController.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexNativeSessionController.swift
@@ -1,5 +1,55 @@
 import Foundation
 
+struct CodexTurnStartReceipt: Equatable {
+    let provisionalSubmissionID: String
+}
+
+struct CodexTurnSteerReceipt: Equatable {
+    let acceptedTurnID: String
+}
+
+struct CodexTurnInterruptReceipt: Equatable {
+    let interruptedTurnID: String
+}
+
+enum CodexTurnSteerError: Error, LocalizedError, Equatable {
+    case noActiveTurn(CodexAppServerClient.RequestFailure)
+    case expectedTurnMismatch(
+        expectedTurnID: String,
+        actualTurnID: String?,
+        failure: CodexAppServerClient.RequestFailure
+    )
+    case activeTurnNotSteerable(
+        turnKind: String?,
+        failure: CodexAppServerClient.RequestFailure
+    )
+
+    var errorDescription: String? {
+        switch self {
+        case let .noActiveTurn(failure):
+            failure.message
+        case let .expectedTurnMismatch(_, _, failure):
+            failure.message
+        case let .activeTurnNotSteerable(_, failure):
+            failure.message
+        }
+    }
+}
+
+enum CodexTurnInterruptError: Error, LocalizedError, Equatable {
+    case reconciliationFailed(expectedTurnID: String, authoritativeTurnID: String?)
+    case noUniqueActiveTurn(authoritativeTurnID: String?, observedTurnIDs: [String])
+
+    var errorDescription: String? {
+        switch self {
+        case let .reconciliationFailed(expectedTurnID, authoritativeTurnID):
+            "Codex interrupt identity reconciliation failed: expected \(expectedTurnID), authoritative \(authoritativeTurnID ?? "nil")."
+        case let .noUniqueActiveTurn(authoritativeTurnID, observedTurnIDs):
+            "Codex interrupt identity reconciliation failed: authoritative \(authoritativeTurnID ?? "nil"), observed active turns \(observedTurnIDs)."
+        }
+    }
+}
+
 protocol CodexSessionControlling: AnyObject {
     var hasActiveThread: Bool { get }
     var events: AsyncStream<CodexNativeSessionController.Event> { get }
@@ -27,21 +77,24 @@ protocol CodexSessionControlling: AnyObject {
         timeout: TimeInterval?
     ) async throws -> CodexNativeSessionController.ThreadSnapshot
     func setThreadName(_ name: String, threadID: String?) async throws
-    func sendUserMessage(_ text: String) async throws
-    func sendUserTurn(text: String, images: [AgentImageAttachment]) async throws
-    func sendUserTurn(
-        text: String,
-        images: [AgentImageAttachment],
-        model: String?,
-        reasoningEffort: String?
-    ) async throws
-    func sendUserTurn(
+    func startUserTurn(
         text: String,
         images: [AgentImageAttachment],
         model: String?,
         reasoningEffort: String?,
         serviceTier: String?
-    ) async throws
+    ) async throws -> CodexTurnStartReceipt
+    func steerUserTurn(
+        text: String,
+        images: [AgentImageAttachment],
+        expectedTurnID: String
+    ) async throws -> CodexTurnSteerReceipt
+    func prepareLifecycleAuthorityReconciliationAfterAcceptedMismatch(
+        expectedCurrentTurnID: String,
+        acceptedDispatchTurnID: String
+    ) async -> Bool
+    func interruptUserTurn(expectedTurnID: String) async throws -> CodexTurnInterruptReceipt
+    func reconcileAndInterruptCurrentTurn() async throws -> CodexTurnInterruptReceipt
     func compactThread() async throws
     func getThreadGoal() async throws -> CodexNativeSessionController.ThreadGoal?
     func setThreadGoalObjective(_ objective: String) async throws -> CodexNativeSessionController.ThreadGoal
@@ -388,6 +441,21 @@ final class CodexNativeSessionController {
         case serverRequests
     }
 
+    private struct LifecycleAuthorityReconciliationLineage: Equatable {
+        let expectedCurrentTurnID: String
+        let acceptedDispatchTurnID: String
+    }
+
+    private enum LifecycleAuthorityObservationKind: Equatable {
+        case started
+        case completed
+    }
+
+    private struct LifecycleAuthorityObservation: Equatable {
+        let lineage: LifecycleAuthorityReconciliationLineage
+        let kind: LifecycleAuthorityObservationKind
+    }
+
     private let client: CodexAppServerClient
     private let runID: UUID
     private let tabID: UUID
@@ -396,6 +464,7 @@ final class CodexNativeSessionController {
     private let options: Options
     private let clientShutdownBehavior: ClientShutdownBehavior
     private let expectedMCPClientName: String?
+    private let requestExecutor: (@Sendable (String, [String: Any]?, TimeInterval?) async throws -> [String: Any])?
     private let rawEventFileLoggingEnabled: Bool
     private var rawEventLogFileURL: URL?
     private var rawEventLogFileThreadID: String?
@@ -403,10 +472,13 @@ final class CodexNativeSessionController {
 
     private var threadID: String?
     private var threadPath: String?
-    private var currentTurnID: String?
+    private var routingCurrentTurnID: String?
+    private var authoritativeLifecycleTurnID: String?
     private var activeTurnIDs: Set<String> = []
     private var activeTurnOrder: [String] = []
     private var activeTurnIDsWithObservedActivity: Set<String> = []
+    private var pendingLifecycleAuthorityReconciliation: LifecycleAuthorityReconciliationLineage?
+    private var lifecycleAuthorityObservations: [LifecycleAuthorityObservation] = []
     private var assistantDeltaSeenTurnIDs: Set<String> = []
     private var fileChangeStateByItemID: [String: FileChangeStreamState] = [:]
     /// Item IDs whose fileChange lifecycle has reached terminal (completed) state.
@@ -506,7 +578,7 @@ final class CodexNativeSessionController {
     ) async throws -> [String: Any] {
         let attemptedStyle = appServerRequestValueStyle
         do {
-            return try await client.request(
+            return try await performRequest(
                 method: method,
                 params: paramsBuilder(attemptedStyle),
                 timeout: timeout
@@ -519,7 +591,7 @@ final class CodexNativeSessionController {
             Self.logCodexDebug(
                 "[CodexNativeController] retrying \(method) with alternate request value style=\(String(describing: fallbackStyle)) after error=\(error.localizedDescription)"
             )
-            let result = try await client.request(
+            let result = try await performRequest(
                 method: method,
                 params: paramsBuilder(fallbackStyle),
                 timeout: timeout
@@ -527,6 +599,17 @@ final class CodexNativeSessionController {
             appServerRequestValueStyle = fallbackStyle
             return result
         }
+    }
+
+    private func performRequest(
+        method: String,
+        params: [String: Any]?,
+        timeout: TimeInterval?
+    ) async throws -> [String: Any] {
+        if let requestExecutor {
+            return try await requestExecutor(method, params, timeout)
+        }
+        return try await client.request(method: method, params: params, timeout: timeout)
     }
 
     init(
@@ -538,7 +621,8 @@ final class CodexNativeSessionController {
         forceExperimentalSteering: Bool = false,
         options: Options? = nil,
         clientShutdownBehavior: ClientShutdownBehavior = .none,
-        expectedMCPClientName: String? = nil
+        expectedMCPClientName: String? = nil,
+        requestExecutor: (@Sendable (String, [String: Any]?, TimeInterval?) async throws -> [String: Any])? = nil
     ) {
         self.client = client
         self.runID = runID
@@ -548,6 +632,7 @@ final class CodexNativeSessionController {
         self.options = options ?? Self.Options.agentModeDefault(forceExperimentalSteering: forceExperimentalSteering)
         self.clientShutdownBehavior = clientShutdownBehavior
         self.expectedMCPClientName = expectedMCPClientName
+        self.requestExecutor = requestExecutor
         rawEventFileLoggingEnabled = Self.isRawEventFileLoggingEnabled()
         rawEventLogFileURL = nil
         rawEventLogFileThreadID = nil
@@ -796,7 +881,7 @@ final class CodexNativeSessionController {
             "runID": runID.uuidString,
             "tabID": tabID.uuidString,
             "threadID": threadID ?? "",
-            "turnID": currentTurnID ?? ""
+            "turnID": routingCurrentTurnID ?? ""
         ]
         if let method {
             record["method"] = method
@@ -985,7 +1070,7 @@ final class CodexNativeSessionController {
         else {
             throw CodexAppServerClient.ClientError.invalidResponse
         }
-        let result = try await client.request(
+        let result = try await performRequest(
             method: "thread/read",
             params: [
                 "threadId": threadID,
@@ -1091,70 +1176,15 @@ final class CodexNativeSessionController {
         return resolvedThreadID
     }
 
-    func sendUserMessage(_ text: String) async throws {
-        try await sendUserTurn(text: text, images: [], model: nil, reasoningEffort: nil, serviceTier: nil)
-    }
-
-    func sendUserTurn(text: String, images: [AgentImageAttachment]) async throws {
-        try await sendUserTurn(text: text, images: images, model: nil, reasoningEffort: nil, serviceTier: nil)
-    }
-
-    func sendUserTurn(
-        text: String,
-        images: [AgentImageAttachment],
-        model: String?,
-        reasoningEffort: String?
-    ) async throws {
-        try await sendUserTurn(
-            text: text,
-            images: images,
-            model: model,
-            reasoningEffort: reasoningEffort,
-            serviceTier: nil
-        )
-    }
-
-    func sendUserTurn(
+    func startUserTurn(
         text: String,
         images: [AgentImageAttachment],
         model: String?,
         reasoningEffort: String?,
         serviceTier: String?
-    ) async throws {
+    ) async throws -> CodexTurnStartReceipt {
         guard let threadID else { throw CodexAppServerClient.ClientError.invalidResponse }
-        let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        var input: [[String: Any]] = []
-
-        for image in images {
-            switch image.source {
-            case let .localFile(path):
-                let trimmedPath = path.trimmingCharacters(in: .whitespacesAndNewlines)
-                guard !trimmedPath.isEmpty else { continue }
-                input.append([
-                    "type": "localImage",
-                    "path": trimmedPath
-                ])
-            case let .url(rawURL):
-                let trimmedURL = rawURL.trimmingCharacters(in: .whitespacesAndNewlines)
-                guard !trimmedURL.isEmpty else { continue }
-                input.append([
-                    "type": "image",
-                    "url": trimmedURL
-                ])
-            }
-        }
-
-        if !trimmedText.isEmpty {
-            input.append([
-                "type": "text",
-                "text": trimmedText,
-                "textElements": []
-            ])
-        }
-
-        guard !input.isEmpty else {
-            throw CodexAppServerClient.ClientError.invalidResponse
-        }
+        let input = try Self.turnInput(text: text, images: images)
 
         var params: [String: Any] = [
             "threadId": threadID,
@@ -1190,11 +1220,137 @@ final class CodexNativeSessionController {
             // Thread-level config changes take effect on thread/start or thread/resume.
             return requestParams
         }
-        if let turn = result["turn"] as? [String: Any],
-           let turnID = turn["id"] as? String
-        {
-            registerActiveTurn(turnID)
+        guard let turn = result["turn"] as? [String: Any],
+              let submissionID = Self.nonEmptyString(turn["id"] as? String)
+        else {
+            throw CodexAppServerClient.ClientError.invalidResponse
         }
+        return CodexTurnStartReceipt(provisionalSubmissionID: submissionID)
+    }
+
+    func steerUserTurn(
+        text: String,
+        images: [AgentImageAttachment],
+        expectedTurnID: String
+    ) async throws -> CodexTurnSteerReceipt {
+        guard let threadID else { throw CodexAppServerClient.ClientError.invalidResponse }
+        guard let expectedTurnID = Self.nonEmptyString(expectedTurnID) else {
+            throw CodexAppServerClient.ClientError.invalidResponse
+        }
+        let input = try Self.turnInput(text: text, images: images)
+        do {
+            let result = try await performRequest(
+                method: "turn/steer",
+                params: [
+                    "threadId": threadID,
+                    "input": input,
+                    "expectedTurnId": expectedTurnID
+                ],
+                timeout: options.requestTimeout
+            )
+            guard let acceptedTurnID = Self.nonEmptyString(
+                (result["turnId"] as? String)
+                    ?? ((result["turn"] as? [String: Any])?["id"] as? String)
+            ),
+                acceptedTurnID == expectedTurnID
+            else {
+                throw CodexAppServerClient.ClientError.invalidResponse
+            }
+            return CodexTurnSteerReceipt(acceptedTurnID: acceptedTurnID)
+        } catch let error as CodexAppServerClient.ClientError {
+            throw Self.mapSteerRequestError(error, expectedTurnID: expectedTurnID)
+        }
+    }
+
+    func prepareLifecycleAuthorityReconciliationAfterAcceptedMismatch(
+        expectedCurrentTurnID: String,
+        acceptedDispatchTurnID: String
+    ) async -> Bool {
+        guard let expectedCurrentTurnID = Self.nonEmptyString(expectedCurrentTurnID),
+              let acceptedDispatchTurnID = Self.nonEmptyString(acceptedDispatchTurnID),
+              expectedCurrentTurnID != acceptedDispatchTurnID
+        else {
+            return false
+        }
+        do {
+            return try await eventHandlingMutex.withLock {
+                if authoritativeLifecycleTurnID == acceptedDispatchTurnID {
+                    return true
+                }
+                guard authoritativeLifecycleTurnID == expectedCurrentTurnID else {
+                    return false
+                }
+                let lineage = LifecycleAuthorityReconciliationLineage(
+                    expectedCurrentTurnID: expectedCurrentTurnID,
+                    acceptedDispatchTurnID: acceptedDispatchTurnID
+                )
+                pendingLifecycleAuthorityReconciliation = lineage
+                if let observation = lifecycleAuthorityObservations.last(where: {
+                    $0.lineage == lineage
+                }) {
+                    applyLifecycleAuthorityReconciliation(observation)
+                }
+                return true
+            }
+        } catch {
+            return false
+        }
+    }
+
+    func interruptUserTurn(expectedTurnID: String) async throws -> CodexTurnInterruptReceipt {
+        guard let threadID else { throw CodexAppServerClient.ClientError.invalidResponse }
+        guard let expectedTurnID = Self.nonEmptyString(expectedTurnID) else {
+            throw CodexAppServerClient.ClientError.invalidResponse
+        }
+        guard authoritativeLifecycleTurnID == expectedTurnID else {
+            throw CodexTurnInterruptError.reconciliationFailed(
+                expectedTurnID: expectedTurnID,
+                authoritativeTurnID: authoritativeLifecycleTurnID
+            )
+        }
+        do {
+            _ = try await performRequest(
+                method: "turn/interrupt",
+                params: [
+                    "threadId": threadID,
+                    "turnId": expectedTurnID
+                ],
+                timeout: options.requestTimeout
+            )
+            return CodexTurnInterruptReceipt(interruptedTurnID: expectedTurnID)
+        } catch let error as CodexAppServerClient.ClientError {
+            throw Self.mapSteerRequestError(error, expectedTurnID: expectedTurnID)
+        }
+    }
+
+    func reconcileAndInterruptCurrentTurn() async throws -> CodexTurnInterruptReceipt {
+        if let authoritativeLifecycleTurnID {
+            return try await interruptUserTurn(expectedTurnID: authoritativeLifecycleTurnID)
+        }
+        let snapshot = try await readThreadSnapshot(
+            includeTurns: true,
+            timeout: min(options.requestTimeout ?? 5, 5)
+        )
+        let observedTurnIDs = Array(
+            Set(snapshot.activeTurnIDs + [snapshot.currentTurnID].compactMap(\.self))
+        ).sorted()
+        guard observedTurnIDs.count == 1,
+              let reconciledTurnID = observedTurnIDs.first
+        else {
+            throw CodexTurnInterruptError.noUniqueActiveTurn(
+                authoritativeTurnID: authoritativeLifecycleTurnID,
+                observedTurnIDs: observedTurnIDs
+            )
+        }
+        _ = try await performRequest(
+            method: "turn/interrupt",
+            params: [
+                "threadId": snapshot.conversationID,
+                "turnId": reconciledTurnID
+            ],
+            timeout: options.requestTimeout
+        )
+        return CodexTurnInterruptReceipt(interruptedTurnID: reconciledTurnID)
     }
 
     func compactThread() async throws {
@@ -1209,37 +1365,11 @@ final class CodexNativeSessionController {
     }
 
     func cancelCurrentTurn() async {
-        guard threadID != nil else { return }
-        let cachedTurnID = currentTurnID
-        let refreshResult = await refreshActiveTurnForInterruptIfPossible()
-        guard let threadID,
-              let turnID = Self.resolvedInterruptTurnID(cachedTurnID: cachedTurnID, refreshResult: refreshResult) else { return }
         do {
-            try await interruptTurn(threadID: threadID, turnID: turnID)
+            _ = try await reconcileAndInterruptCurrentTurn()
         } catch {
-            guard let actualTurnID = Self.activeTurnMismatchActualTurnID(from: error), actualTurnID != turnID else {
-                await emit(.error("Codex native interrupt failed: \(error.localizedDescription)"))
-                return
-            }
-            unregisterActiveTurn(turnID)
-            registerActiveTurn(actualTurnID)
-            do {
-                try await interruptTurn(threadID: threadID, turnID: actualTurnID)
-            } catch {
-                if let retryActualTurnID = Self.activeTurnMismatchActualTurnID(from: error) {
-                    unregisterActiveTurn(actualTurnID)
-                    registerActiveTurn(retryActualTurnID)
-                }
-                await emit(.error("Codex native interrupt failed: \(error.localizedDescription)"))
-            }
+            await emit(.error("Codex native interrupt failed: \(error.localizedDescription)"))
         }
-    }
-
-    private func interruptTurn(threadID: String, turnID: String) async throws {
-        _ = try await client.request(method: "turn/interrupt", params: [
-            "threadId": threadID,
-            "turnId": turnID
-        ])
     }
 
     enum InterruptActiveTurnRefreshResult: Equatable {
@@ -1281,7 +1411,7 @@ final class CodexNativeSessionController {
     private func reconcileActiveTurnRoutingState(from snapshot: ThreadSnapshot) {
         threadID = snapshot.conversationID
         threadPath = snapshot.rolloutPath
-        currentTurnID = snapshot.currentTurnID
+        routingCurrentTurnID = snapshot.currentTurnID
         activeTurnIDs = Set(snapshot.activeTurnIDs)
         activeTurnOrder = snapshot.activeTurnIDs
         activeTurnIDsWithObservedActivity = Set(snapshot.activeTurnIDs)
@@ -1299,9 +1429,150 @@ final class CodexNativeSessionController {
         return actual.isEmpty ? nil : actual
     }
 
-    private static func activeTurnMismatchActualTurnID(from error: Error) -> String? {
-        activeTurnMismatchActualTurnID(fromErrorDescription: error.localizedDescription)
-            ?? activeTurnMismatchActualTurnID(fromErrorDescription: String(describing: error))
+    private static func turnInput(
+        text: String,
+        images: [AgentImageAttachment]
+    ) throws -> [[String: Any]] {
+        let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        var input: [[String: Any]] = []
+        for image in images {
+            switch image.source {
+            case let .localFile(path):
+                guard let path = nonEmptyString(path) else { continue }
+                input.append([
+                    "type": "localImage",
+                    "path": path
+                ])
+            case let .url(rawURL):
+                guard let rawURL = nonEmptyString(rawURL) else { continue }
+                input.append([
+                    "type": "image",
+                    "url": rawURL
+                ])
+            }
+        }
+        if !trimmedText.isEmpty {
+            input.append([
+                "type": "text",
+                "text": trimmedText,
+                "textElements": []
+            ])
+        }
+        guard !input.isEmpty else {
+            throw CodexAppServerClient.ClientError.invalidResponse
+        }
+        return input
+    }
+
+    private static func nonEmptyString(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty
+        else { return nil }
+        return trimmed
+    }
+
+    private static func mapSteerRequestError(
+        _ error: CodexAppServerClient.ClientError,
+        expectedTurnID: String
+    ) -> Error {
+        guard case let .requestFailed(failure) = error else { return error }
+        if let turnKind = structuredNonSteerableTurnKind(from: failure.data) {
+            return CodexTurnSteerError.activeTurnNotSteerable(
+                turnKind: turnKind,
+                failure: failure
+            )
+        }
+        if structuredNoActiveTurn(from: failure.data) {
+            return CodexTurnSteerError.noActiveTurn(failure)
+        }
+        if let actualTurnID = structuredActualTurnID(from: failure.data) {
+            return CodexTurnSteerError.expectedTurnMismatch(
+                expectedTurnID: expectedTurnID,
+                actualTurnID: actualTurnID,
+                failure: failure
+            )
+        }
+
+        let normalizedMessage = failure.message
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        if normalizedMessage == "no active turn to steer" {
+            return CodexTurnSteerError.noActiveTurn(failure)
+        }
+        if normalizedMessage == "cannot steer a review turn" {
+            return CodexTurnSteerError.activeTurnNotSteerable(
+                turnKind: "review",
+                failure: failure
+            )
+        }
+        if normalizedMessage == "cannot steer a compact turn" {
+            return CodexTurnSteerError.activeTurnNotSteerable(
+                turnKind: "compact",
+                failure: failure
+            )
+        }
+        if let actualTurnID = activeTurnMismatchActualTurnID(fromErrorDescription: failure.message) {
+            return CodexTurnSteerError.expectedTurnMismatch(
+                expectedTurnID: expectedTurnID,
+                actualTurnID: actualTurnID,
+                failure: failure
+            )
+        }
+        return error
+    }
+
+    private static func structuredNonSteerableTurnKind(from data: CodexJSONValue?) -> String? {
+        guard case let .object(root) = data else { return nil }
+        if case let .string(kind) = root["turnKind"] {
+            return nonEmptyString(kind)
+        }
+        if case let .object(info) = root["codexErrorInfo"],
+           case let .object(nonSteerable) = info["activeTurnNotSteerable"],
+           case let .string(kind) = nonSteerable["turnKind"]
+        {
+            return nonEmptyString(kind)
+        }
+        if case let .object(nonSteerable) = root["activeTurnNotSteerable"],
+           case let .string(kind) = nonSteerable["turnKind"]
+        {
+            return nonEmptyString(kind)
+        }
+        return nil
+    }
+
+    private static func structuredNoActiveTurn(from data: CodexJSONValue?) -> Bool {
+        guard case let .object(root) = data else { return false }
+        if root["noActiveTurn"] != nil {
+            return true
+        }
+        if case let .string(type) = root["type"] {
+            return type == "noActiveTurn"
+        }
+        if case let .string(code) = root["code"] {
+            return code == "noActiveTurn"
+        }
+        return false
+    }
+
+    private static func structuredActualTurnID(from data: CodexJSONValue?) -> String? {
+        guard case let .object(root) = data else { return nil }
+        for key in ["actualTurnId", "actualTurnID", "activeTurnId", "activeTurnID"] {
+            if case let .string(value) = root[key],
+               let value = nonEmptyString(value)
+            {
+                return value
+            }
+        }
+        if case let .object(mismatch) = root["expectedTurnMismatch"] {
+            for key in ["actualTurnId", "actualTurnID", "activeTurnId", "activeTurnID"] {
+                if case let .string(value) = mismatch[key],
+                   let value = nonEmptyString(value)
+                {
+                    return value
+                }
+            }
+        }
+        return nil
     }
 
     func shutdown() async {
@@ -1329,7 +1600,7 @@ final class CodexNativeSessionController {
     private func restoreThreadSnapshot(_ snapshot: ThreadSnapshot) {
         threadID = snapshot.conversationID
         threadPath = snapshot.rolloutPath
-        currentTurnID = snapshot.currentTurnID
+        routingCurrentTurnID = snapshot.currentTurnID
         activeTurnIDs = Set(snapshot.activeTurnIDs)
         activeTurnOrder = snapshot.activeTurnIDs
         activeTurnIDsWithObservedActivity = Set(snapshot.activeTurnIDs)
@@ -1691,12 +1962,12 @@ final class CodexNativeSessionController {
         activeTurnOrder.removeAll(where: { $0 == trimmed })
         activeTurnOrder.append(trimmed)
         if makeCurrent {
-            currentTurnID = trimmed
+            routingCurrentTurnID = trimmed
         }
     }
 
     /// Lightweight pre-registration: ensures the turn ID is known to the routing filter
-    /// without mutating `activeTurnOrder` or `currentTurnID`. This prevents cascade drops
+    /// without mutating `activeTurnOrder` or `routingCurrentTurnID`. This prevents cascade drops
     /// when a lifecycle event (`turn/started`) was missed upstream.
     ///
     /// Related:
@@ -1705,7 +1976,7 @@ final class CodexNativeSessionController {
     private func observeTurnIDForRouting(_ turnID: String) {
         let trimmed = turnID.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
-        // Only insert into activeTurnIDs — don't touch activeTurnOrder or currentTurnID
+        // Only insert into activeTurnIDs — don't touch activeTurnOrder or routingCurrentTurnID
         // to minimize side effects from pre-registration.
         activeTurnIDs.insert(trimmed)
     }
@@ -1717,14 +1988,65 @@ final class CodexNativeSessionController {
         activeTurnOrder.removeAll(where: { $0 == trimmed })
         activeTurnIDsWithObservedActivity.remove(trimmed)
         assistantDeltaSeenTurnIDs.remove(trimmed)
-        if currentTurnID == trimmed {
-            currentTurnID = activeTurnOrder.last(where: { activeTurnIDsWithObservedActivity.contains($0) })
+        if routingCurrentTurnID == trimmed {
+            routingCurrentTurnID = activeTurnOrder.last(where: { activeTurnIDsWithObservedActivity.contains($0) })
         }
     }
 
     private func markTurnActivity(_ turnID: String, makeCurrent: Bool) {
         registerActiveTurn(turnID, makeCurrent: makeCurrent)
         activeTurnIDsWithObservedActivity.insert(turnID)
+    }
+
+    private func recordLifecycleAuthorityObservation(
+        turnID: String,
+        kind: LifecycleAuthorityObservationKind
+    ) {
+        guard let authoritativeLifecycleTurnID,
+              authoritativeLifecycleTurnID != turnID
+        else {
+            return
+        }
+        let lineage = LifecycleAuthorityReconciliationLineage(
+            expectedCurrentTurnID: authoritativeLifecycleTurnID,
+            acceptedDispatchTurnID: turnID
+        )
+        let observation = LifecycleAuthorityObservation(lineage: lineage, kind: kind)
+        lifecycleAuthorityObservations.removeAll(where: { $0 == observation })
+        lifecycleAuthorityObservations.append(observation)
+        if lifecycleAuthorityObservations.count > 8 {
+            lifecycleAuthorityObservations.removeFirst(lifecycleAuthorityObservations.count - 8)
+        }
+        if pendingLifecycleAuthorityReconciliation == lineage {
+            applyLifecycleAuthorityReconciliation(observation)
+        }
+    }
+
+    private func applyLifecycleAuthorityReconciliation(
+        _ observation: LifecycleAuthorityObservation
+    ) {
+        let lineage = observation.lineage
+        guard pendingLifecycleAuthorityReconciliation == lineage,
+              authoritativeLifecycleTurnID == lineage.expectedCurrentTurnID
+        else {
+            return
+        }
+        switch observation.kind {
+        case .started:
+            let expectedWasRoutingCurrent = routingCurrentTurnID == lineage.expectedCurrentTurnID
+            unregisterActiveTurn(lineage.expectedCurrentTurnID)
+            registerActiveTurn(
+                lineage.acceptedDispatchTurnID,
+                makeCurrent: expectedWasRoutingCurrent
+            )
+            authoritativeLifecycleTurnID = lineage.acceptedDispatchTurnID
+        case .completed:
+            unregisterActiveTurn(lineage.expectedCurrentTurnID)
+            unregisterActiveTurn(lineage.acceptedDispatchTurnID)
+            authoritativeLifecycleTurnID = nil
+        }
+        pendingLifecycleAuthorityReconciliation = nil
+        lifecycleAuthorityObservations.removeAll(where: { $0.lineage == lineage })
     }
 
     private func handleNotification(_ notification: CodexAppServerClient.Notification) async {
@@ -1754,7 +2076,7 @@ final class CodexNativeSessionController {
             method: notification.method,
             params: params,
             activeThreadID: threadID,
-            currentTurnID: currentTurnID,
+            currentTurnID: routingCurrentTurnID,
             activeTurnIDs: activeTurnIDs
         ) {
             #if DEBUG
@@ -1767,7 +2089,7 @@ final class CodexNativeSessionController {
            Self.shouldPromoteCurrentTurn(
                method: notification.method,
                notifiedTurnID: notifiedTurnID,
-               currentTurnID: currentTurnID
+               currentTurnID: routingCurrentTurnID
            )
         {
             markTurnActivity(notifiedTurnID, makeCurrent: true)
@@ -1780,11 +2102,21 @@ final class CodexNativeSessionController {
                 turnID = (turn["id"] as? String) ?? (turn["turn_id"] as? String)
                 if let turnID {
                     registerActiveTurn(turnID, makeCurrent: false)
+                    if authoritativeLifecycleTurnID == nil || authoritativeLifecycleTurnID == turnID {
+                        authoritativeLifecycleTurnID = turnID
+                    } else {
+                        recordLifecycleAuthorityObservation(turnID: turnID, kind: .started)
+                    }
                 }
             } else {
                 turnID = notifiedTurnID
                 if let notifiedTurnID {
                     registerActiveTurn(notifiedTurnID, makeCurrent: false)
+                    if authoritativeLifecycleTurnID == nil || authoritativeLifecycleTurnID == notifiedTurnID {
+                        authoritativeLifecycleTurnID = notifiedTurnID
+                    } else {
+                        recordLifecycleAuthorityObservation(turnID: notifiedTurnID, kind: .started)
+                    }
                 }
             }
             await emit(.turnStarted(turnID: turnID))
@@ -1797,18 +2129,32 @@ final class CodexNativeSessionController {
                     ?? notifiedTurnID
             let turnID = parsedTurnID?.trimmingCharacters(in: .whitespacesAndNewlines)
             let wasActive = turnID.map { activeTurnIDs.contains($0) } ?? false
-            let trackingWasUncertain = activeTurnIDs.isEmpty || currentTurnID == nil
-            let matchesCurrentTurn = turnID != nil && turnID == currentTurnID
+            let trackingWasUncertain = activeTurnIDs.isEmpty || routingCurrentTurnID == nil
+            let matchesCurrentTurn = turnID != nil && turnID == routingCurrentTurnID
+            let nilCompletionHasSingleActiveTurn = turnID == nil
+                && activeTurnIDs.count <= 1
+                && authoritativeLifecycleTurnID != nil
             if let turnID {
+                recordLifecycleAuthorityObservation(turnID: turnID, kind: .completed)
                 unregisterActiveTurn(turnID)
-            } else if let currentTurnID {
-                unregisterActiveTurn(currentTurnID)
+                if authoritativeLifecycleTurnID == turnID {
+                    authoritativeLifecycleTurnID = nil
+                }
+            } else if nilCompletionHasSingleActiveTurn,
+                      let authoritativeLifecycleTurnID
+            {
+                unregisterActiveTurn(authoritativeLifecycleTurnID)
+                self.authoritativeLifecycleTurnID = nil
+            } else if authoritativeLifecycleTurnID == nil,
+                      let routingCurrentTurnID
+            {
+                unregisterActiveTurn(routingCurrentTurnID)
             }
-            if wasActive || matchesCurrentTurn || trackingWasUncertain || turnID == nil {
+            if wasActive || matchesCurrentTurn || trackingWasUncertain || nilCompletionHasSingleActiveTurn {
                 await emit(.turnCompleted(turnID: turnID, status: mapTurnStatus(statusRaw ?? "completed")))
             } else {
                 Self.logCodexDebug(
-                    "[CodexNativeController] ignoring turnCompleted for non-active turnID=\(turnID ?? "nil") currentTurnID=\(currentTurnID ?? "nil") activeTurnIDs=\(Array(activeTurnIDs).joined(separator: ","))"
+                    "[CodexNativeController] ignoring turnCompleted for non-active turnID=\(turnID ?? "nil") currentTurnID=\(routingCurrentTurnID ?? "nil") activeTurnIDs=\(Array(activeTurnIDs).joined(separator: ","))"
                 )
             }
         case "codex/event/task_complete":
@@ -2504,6 +2850,37 @@ final class CodexNativeSessionController {
     }
 
     #if DEBUG
+        func test_installThreadState(
+            threadID: String,
+            authoritativeTurnID: String? = nil,
+            routingTurnID: String? = nil
+        ) {
+            self.threadID = threadID
+            authoritativeLifecycleTurnID = authoritativeTurnID
+            routingCurrentTurnID = routingTurnID
+            activeTurnIDs = Set([authoritativeTurnID, routingTurnID].compactMap(\.self))
+            activeTurnOrder = [authoritativeTurnID, routingTurnID].compactMap(\.self)
+            pendingLifecycleAuthorityReconciliation = nil
+            lifecycleAuthorityObservations.removeAll()
+        }
+
+        func test_handleNotification(
+            method: String,
+            params: [String: CodexJSONValue]
+        ) async {
+            try? await eventHandlingMutex.withLock {
+                await handleNotification(.init(method: method, params: params))
+            }
+        }
+
+        var test_authoritativeLifecycleTurnID: String? {
+            authoritativeLifecycleTurnID
+        }
+
+        var test_routingCurrentTurnID: String? {
+            routingCurrentTurnID
+        }
+
         static func test_shouldDropNotificationForRouting(
             method: String,
             params: [String: Any],
@@ -2715,7 +3092,7 @@ final class CodexNativeSessionController {
                 method: method,
                 params: params,
                 activeThreadID: threadID,
-                currentTurnID: currentTurnID
+                currentTurnID: routingCurrentTurnID
             ) else {
                 await emitServerRequestIssue(
                     requestID: request.id,
@@ -2750,7 +3127,7 @@ final class CodexNativeSessionController {
                 method: method,
                 params: params,
                 activeThreadID: threadID,
-                currentTurnID: currentTurnID
+                currentTurnID: routingCurrentTurnID
             ) else {
                 await emitServerRequestIssue(
                     requestID: request.id,
@@ -2772,7 +3149,7 @@ final class CodexNativeSessionController {
                 method: method,
                 params: params,
                 activeThreadID: threadID,
-                currentTurnID: currentTurnID
+                currentTurnID: routingCurrentTurnID
             ) else {
                 await emitServerRequestIssue(
                     requestID: request.id,
@@ -2831,7 +3208,7 @@ final class CodexNativeSessionController {
             method: method,
             params: params,
             activeThreadID: threadID,
-            currentTurnID: currentTurnID
+            currentTurnID: routingCurrentTurnID
         )
     }
 
@@ -7112,6 +7489,13 @@ enum CodexSessionControllerError: LocalizedError {
 }
 
 extension CodexSessionControlling {
+    func prepareLifecycleAuthorityReconciliationAfterAcceptedMismatch(
+        expectedCurrentTurnID _: String,
+        acceptedDispatchTurnID _: String
+    ) async -> Bool {
+        true
+    }
+
     func readThreadSnapshot(
         includeTurns _: Bool,
         timeout _: TimeInterval?
@@ -7121,6 +7505,11 @@ extension CodexSessionControlling {
     }
 
     func setThreadName(_: String, threadID _: String?) async throws {}
+
+    func reconcileAndInterruptCurrentTurn() async throws -> CodexTurnInterruptReceipt {
+        await cancelCurrentTurn()
+        return CodexTurnInterruptReceipt(interruptedTurnID: "<legacy-cancel>")
+    }
 
     func startOrResume(
         existing: CodexNativeSessionController.SessionRef?,
@@ -7141,37 +7530,6 @@ extension CodexSessionControlling {
         try await startOrResume(
             existing: existing,
             baseInstructions: baseInstructions,
-            model: model,
-            reasoningEffort: reasoningEffort
-        )
-    }
-
-    func sendUserTurn(
-        text: String,
-        images: [AgentImageAttachment],
-        model: String?,
-        reasoningEffort: String?
-    ) async throws {
-        guard images.isEmpty else {
-            throw CodexSessionControllerError.imageAttachmentsUnsupported
-        }
-        let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmedText.isEmpty else {
-            throw CodexSessionControllerError.emptyUserTurn
-        }
-        try await sendUserMessage(trimmedText)
-    }
-
-    func sendUserTurn(
-        text: String,
-        images: [AgentImageAttachment],
-        model: String?,
-        reasoningEffort: String?,
-        serviceTier _: String?
-    ) async throws {
-        try await sendUserTurn(
-            text: text,
-            images: images,
             model: model,
             reasoningEffort: reasoningEffort
         )

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexNativeSessionController.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexNativeSessionController.swift
@@ -1251,10 +1251,20 @@ final class CodexNativeSessionController {
             guard let acceptedTurnID = Self.nonEmptyString(
                 (result["turnId"] as? String)
                     ?? ((result["turn"] as? [String: Any])?["id"] as? String)
-            ),
-                acceptedTurnID == expectedTurnID
-            else {
+            ) else {
                 throw CodexAppServerClient.ClientError.invalidResponse
+            }
+            guard acceptedTurnID == expectedTurnID else {
+                throw CodexTurnSteerError.expectedTurnMismatch(
+                    expectedTurnID: expectedTurnID,
+                    actualTurnID: acceptedTurnID,
+                    failure: CodexAppServerClient.RequestFailure(
+                        method: "turn/steer",
+                        code: nil,
+                        message: "Codex accepted turn/steer for turn \(acceptedTurnID) instead of expected turn \(expectedTurnID).",
+                        data: nil
+                    )
+                )
             }
             return CodexTurnSteerReceipt(acceptedTurnID: acceptedTurnID)
         } catch let error as CodexAppServerClient.ClientError {

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/CodexCLIProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/CodexCLIProvider.swift
@@ -396,7 +396,7 @@ final class CodexCLIProvider: AIProvider {
                     reasoningEffort: selection.reasoningEffort,
                     serviceTier: selection.serviceTier
                 )
-                try await controller.sendUserTurn(
+                _ = try await controller.startUserTurn(
                     text: prompt,
                     images: [],
                     model: selection.model,
@@ -540,7 +540,7 @@ final class CodexCLIProvider: AIProvider {
                     reasoningEffort: selection.reasoningEffort,
                     serviceTier: selection.serviceTier
                 )
-                try await controller.sendUserTurn(
+                _ = try await controller.startUserTurn(
                     text: prompt,
                     images: [],
                     model: selection.model,
@@ -934,8 +934,8 @@ final class CodexCLIProvider: AIProvider {
         }
         if let clientError = error as? CodexAppServerClient.ClientError {
             switch clientError {
-            case let .requestFailed(message):
-                return message
+            case let .requestFailed(failure):
+                return failure.message
             case let .executableUnavailable(message):
                 return message
             case let .transportWriteFailed(message, _):

--- a/Tests/RepoPromptTests/AI/CodexNativeSessionControllerTurnDispatchTests.swift
+++ b/Tests/RepoPromptTests/AI/CodexNativeSessionControllerTurnDispatchTests.swift
@@ -65,7 +65,7 @@ final class CodexNativeSessionControllerTurnDispatchTests: XCTestCase {
         XCTAssertEqual(controller.test_authoritativeLifecycleTurnID, "turn-1")
     }
 
-    func testTurnSteerAcceptedMismatchThrowsTypedMismatchError() async throws {
+    func testTurnSteerAcceptedMismatchReturnsAcceptedReceiptWithoutResend() async throws {
         let recorder = TurnRequestRecorder(result: [
             "turnId": "turn-2"
         ])
@@ -76,17 +76,14 @@ final class CodexNativeSessionControllerTurnDispatchTests: XCTestCase {
             routingTurnID: "turn-1"
         )
 
-        do {
-            _ = try await controller.steerUserTurn(
-                text: "adjust course",
-                images: [],
-                expectedTurnID: "turn-1"
-            )
-            XCTFail("Expected steer to throw on accepted turn mismatch")
-        } catch let CodexTurnSteerError.expectedTurnMismatch(expected, actual, _) {
-            XCTAssertEqual(expected, "turn-1")
-            XCTAssertEqual(actual, "turn-2")
-        }
+        let receipt = try await controller.steerUserTurn(
+            text: "adjust course",
+            images: [],
+            expectedTurnID: "turn-1"
+        )
+
+        XCTAssertEqual(receipt.acceptedTurnID, "turn-2")
+        XCTAssertEqual(recorder.requests().count, 1)
     }
 
     func testStructuredSteerErrorsMapWithoutLosingJSONRPCPayload() async throws {

--- a/Tests/RepoPromptTests/AI/CodexNativeSessionControllerTurnDispatchTests.swift
+++ b/Tests/RepoPromptTests/AI/CodexNativeSessionControllerTurnDispatchTests.swift
@@ -1,0 +1,326 @@
+import Foundation
+import XCTest
+@_spi(TestSupport) @testable import RepoPrompt
+
+final class CodexNativeSessionControllerTurnDispatchTests: XCTestCase {
+    func testTurnStartReturnsProvisionalReceiptWithoutInstallingActiveIdentity() async throws {
+        let recorder = TurnRequestRecorder(result: [
+            "turn": ["id": "submission-1"]
+        ])
+        let controller = makeController(recorder: recorder)
+        controller.test_installThreadState(threadID: "thread-1")
+
+        let receipt = try await controller.startUserTurn(
+            text: "hello",
+            images: [],
+            model: "gpt-test",
+            reasoningEffort: "high",
+            serviceTier: "fast"
+        )
+
+        XCTAssertEqual(receipt.provisionalSubmissionID, "submission-1")
+        let request = try XCTUnwrap(recorder.requests().only)
+        XCTAssertEqual(request.method, "turn/start")
+        XCTAssertEqual(request.params["threadId"] as? String, "thread-1")
+        XCTAssertEqual(request.params["model"] as? String, "gpt-test")
+        XCTAssertEqual(request.params["effort"] as? String, "high")
+        XCTAssertEqual(request.params["serviceTier"] as? String, "fast")
+        XCTAssertNotNil(request.params["approvalPolicy"])
+        XCTAssertNotNil(request.params["approvalsReviewer"])
+        XCTAssertNotNil(request.params["sandboxPolicy"])
+        XCTAssertNil(controller.test_authoritativeLifecycleTurnID)
+        XCTAssertNil(controller.test_routingCurrentTurnID)
+    }
+
+    func testTurnSteerUsesExactExpectedIDAndOmitsStartOnlySettings() async throws {
+        let recorder = TurnRequestRecorder(result: [
+            "turnId": "turn-1"
+        ])
+        let controller = makeController(recorder: recorder)
+        controller.test_installThreadState(
+            threadID: "thread-1",
+            authoritativeTurnID: "turn-1",
+            routingTurnID: "turn-1"
+        )
+
+        let receipt = try await controller.steerUserTurn(
+            text: "adjust course",
+            images: [],
+            expectedTurnID: "turn-1"
+        )
+
+        XCTAssertEqual(receipt.acceptedTurnID, "turn-1")
+        let request = try XCTUnwrap(recorder.requests().only)
+        XCTAssertEqual(request.method, "turn/steer")
+        XCTAssertEqual(Set(request.params.keys), Set(["threadId", "input", "expectedTurnId"]))
+        XCTAssertEqual(request.params["threadId"] as? String, "thread-1")
+        XCTAssertEqual(request.params["expectedTurnId"] as? String, "turn-1")
+        XCTAssertNil(request.params["model"])
+        XCTAssertNil(request.params["effort"])
+        XCTAssertNil(request.params["serviceTier"])
+        XCTAssertNil(request.params["cwd"])
+        XCTAssertNil(request.params["approvalPolicy"])
+        XCTAssertNil(request.params["approvalsReviewer"])
+        XCTAssertNil(request.params["sandboxPolicy"])
+        XCTAssertEqual(controller.test_authoritativeLifecycleTurnID, "turn-1")
+    }
+
+    func testStructuredSteerErrorsMapWithoutLosingJSONRPCPayload() async throws {
+        let cases: [(failure: CodexAppServerClient.RequestFailure, assertion: (Error) -> Void)] = [
+            (
+                CodexAppServerClient.RequestFailure(
+                    method: "turn/steer",
+                    code: -32602,
+                    message: "future no-active wording",
+                    data: .object(["type": .string("noActiveTurn")])
+                ),
+                { error in
+                    guard case let CodexTurnSteerError.noActiveTurn(failure) = error else {
+                        return XCTFail("Expected no-active error, got \(error)")
+                    }
+                    XCTAssertEqual(failure.code, -32602)
+                    XCTAssertEqual(failure.data, .object(["type": .string("noActiveTurn")]))
+                }
+            ),
+            (
+                CodexAppServerClient.RequestFailure(
+                    method: "turn/steer",
+                    code: -32602,
+                    message: "future mismatch wording",
+                    data: .object(["actualTurnId": .string("turn-2")])
+                ),
+                { error in
+                    guard case let CodexTurnSteerError.expectedTurnMismatch(expected, actual, failure) = error else {
+                        return XCTFail("Expected mismatch error, got \(error)")
+                    }
+                    XCTAssertEqual(expected, "turn-1")
+                    XCTAssertEqual(actual, "turn-2")
+                    XCTAssertEqual(failure.code, -32602)
+                }
+            ),
+            (
+                CodexAppServerClient.RequestFailure(
+                    method: "turn/steer",
+                    code: -32602,
+                    message: "cannot steer a review turn",
+                    data: .object([
+                        "codexErrorInfo": .object([
+                            "activeTurnNotSteerable": .object([
+                                "turnKind": .string("review")
+                            ])
+                        ])
+                    ])
+                ),
+                { error in
+                    guard case let CodexTurnSteerError.activeTurnNotSteerable(turnKind, failure) = error else {
+                        return XCTFail("Expected non-steerable error, got \(error)")
+                    }
+                    XCTAssertEqual(turnKind, "review")
+                    XCTAssertEqual(failure.code, -32602)
+                }
+            )
+        ]
+
+        for testCase in cases {
+            let recorder = TurnRequestRecorder(error: CodexAppServerClient.ClientError.requestFailed(testCase.failure))
+            let controller = makeController(recorder: recorder)
+            controller.test_installThreadState(
+                threadID: "thread-1",
+                authoritativeTurnID: "turn-1",
+                routingTurnID: "turn-1"
+            )
+            do {
+                _ = try await controller.steerUserTurn(
+                    text: "hello",
+                    images: [],
+                    expectedTurnID: "turn-1"
+                )
+                XCTFail("Expected steer error")
+            } catch {
+                testCase.assertion(error)
+            }
+            XCTAssertEqual(controller.test_authoritativeLifecycleTurnID, "turn-1")
+        }
+    }
+
+    func testStrictMessageFallbackMapsCurrentMismatchShapeWithoutPromotingActualID() async throws {
+        let failure = CodexAppServerClient.RequestFailure(
+            method: "turn/steer",
+            code: -32602,
+            message: "expected active turn id `turn-1` but found `turn-2`",
+            data: nil
+        )
+        let recorder = TurnRequestRecorder(error: CodexAppServerClient.ClientError.requestFailed(failure))
+        let controller = makeController(recorder: recorder)
+        controller.test_installThreadState(
+            threadID: "thread-1",
+            authoritativeTurnID: "turn-1",
+            routingTurnID: "turn-1"
+        )
+
+        do {
+            _ = try await controller.steerUserTurn(
+                text: "hello",
+                images: [],
+                expectedTurnID: "turn-1"
+            )
+            XCTFail("Expected mismatch error")
+        } catch let CodexTurnSteerError.expectedTurnMismatch(expected, actual, retainedFailure) {
+            XCTAssertEqual(expected, "turn-1")
+            XCTAssertEqual(actual, "turn-2")
+            XCTAssertEqual(retainedFailure, failure)
+        }
+
+        XCTAssertEqual(controller.test_authoritativeLifecycleTurnID, "turn-1")
+        XCTAssertEqual(controller.test_routingCurrentTurnID, "turn-1")
+    }
+
+    func testInterruptRequiresSameAuthoritativeLifecycleIdentity() async throws {
+        let recorder = TurnRequestRecorder(result: [:])
+        let controller = makeController(recorder: recorder)
+        controller.test_installThreadState(
+            threadID: "thread-1",
+            authoritativeTurnID: "turn-1",
+            routingTurnID: "turn-2"
+        )
+
+        do {
+            _ = try await controller.interruptUserTurn(expectedTurnID: "turn-2")
+            XCTFail("Expected reconciliation failure")
+        } catch let error as CodexTurnInterruptError {
+            XCTAssertEqual(
+                error,
+                .reconciliationFailed(
+                    expectedTurnID: "turn-2",
+                    authoritativeTurnID: "turn-1"
+                )
+            )
+        }
+        XCTAssertTrue(recorder.requests().isEmpty)
+
+        let receipt = try await controller.interruptUserTurn(expectedTurnID: "turn-1")
+        XCTAssertEqual(receipt.interruptedTurnID, "turn-1")
+        let request = try XCTUnwrap(recorder.requests().only)
+        XCTAssertEqual(request.method, "turn/interrupt")
+        XCTAssertEqual(request.params["turnId"] as? String, "turn-1")
+    }
+
+    func testCancellationReconciliationInterruptsUniqueSnapshotTurnWithoutPromotingIt() async throws {
+        let recorder = TurnRequestRecorder(resultsByMethod: [
+            "thread/read": [
+                "thread": [
+                    "id": "thread-1",
+                    "status": ["type": "active"],
+                    "turns": [
+                        ["id": "turn-snapshot", "status": "inProgress"]
+                    ]
+                ]
+            ],
+            "turn/interrupt": [:]
+        ])
+        let controller = makeController(recorder: recorder)
+        controller.test_installThreadState(threadID: "thread-1")
+
+        let receipt = try await controller.reconcileAndInterruptCurrentTurn()
+
+        XCTAssertEqual(receipt.interruptedTurnID, "turn-snapshot")
+        XCTAssertNil(controller.test_authoritativeLifecycleTurnID)
+        XCTAssertEqual(recorder.requests().map(\.method), ["thread/read", "turn/interrupt"])
+        XCTAssertEqual(recorder.requests().last?.params["turnId"] as? String, "turn-snapshot")
+    }
+
+    func testJSONRPCFailureParserPreservesMethodCodeMessageAndData() {
+        let failure = CodexAppServerClient.requestFailure(
+            method: "turn/steer",
+            errorObject: [
+                "code": -32602,
+                "message": "cannot steer",
+                "data": [
+                    "actualTurnId": "turn-2",
+                    "retryable": false
+                ]
+            ]
+        )
+
+        XCTAssertEqual(
+            failure,
+            CodexAppServerClient.RequestFailure(
+                method: "turn/steer",
+                code: -32602,
+                message: "cannot steer",
+                data: .object([
+                    "actualTurnId": .string("turn-2"),
+                    "retryable": .bool(false)
+                ])
+            )
+        )
+    }
+
+    private func makeController(recorder: TurnRequestRecorder) -> CodexNativeSessionController {
+        CodexNativeSessionController(
+            client: CodexAppServerClient(),
+            runID: UUID(),
+            tabID: UUID(),
+            windowID: 1,
+            workspacePath: "/tmp/workspace",
+            requestExecutor: { method, params, timeout in
+                try recorder.handle(method: method, params: params, timeout: timeout)
+            }
+        )
+    }
+}
+
+private final class TurnRequestRecorder: @unchecked Sendable {
+    struct Request {
+        let method: String
+        let params: [String: Any]
+        let timeout: TimeInterval?
+    }
+
+    private let lock = NSLock()
+    private var recordedRequests: [Request] = []
+    private let result: [String: Any]
+    private let resultsByMethod: [String: [String: Any]]?
+    private let error: Error?
+
+    init(result: [String: Any] = [:], error: Error? = nil) {
+        self.result = result
+        resultsByMethod = nil
+        self.error = error
+    }
+
+    init(resultsByMethod: [String: [String: Any]]) {
+        result = [:]
+        self.resultsByMethod = resultsByMethod
+        error = nil
+    }
+
+    func handle(
+        method: String,
+        params: [String: Any]?,
+        timeout: TimeInterval?
+    ) throws -> [String: Any] {
+        lock.lock()
+        recordedRequests.append(Request(method: method, params: params ?? [:], timeout: timeout))
+        let result = resultsByMethod?[method] ?? result
+        let error = error
+        lock.unlock()
+        if let error {
+            throw error
+        }
+        return result
+    }
+
+    func requests() -> [Request] {
+        lock.lock()
+        let requests = recordedRequests
+        lock.unlock()
+        return requests
+    }
+}
+
+private extension Array {
+    var only: Element? {
+        count == 1 ? first : nil
+    }
+}

--- a/Tests/RepoPromptTests/AI/CodexNativeSessionControllerTurnDispatchTests.swift
+++ b/Tests/RepoPromptTests/AI/CodexNativeSessionControllerTurnDispatchTests.swift
@@ -65,6 +65,30 @@ final class CodexNativeSessionControllerTurnDispatchTests: XCTestCase {
         XCTAssertEqual(controller.test_authoritativeLifecycleTurnID, "turn-1")
     }
 
+    func testTurnSteerAcceptedMismatchThrowsTypedMismatchError() async throws {
+        let recorder = TurnRequestRecorder(result: [
+            "turnId": "turn-2"
+        ])
+        let controller = makeController(recorder: recorder)
+        controller.test_installThreadState(
+            threadID: "thread-1",
+            authoritativeTurnID: "turn-1",
+            routingTurnID: "turn-1"
+        )
+
+        do {
+            _ = try await controller.steerUserTurn(
+                text: "adjust course",
+                images: [],
+                expectedTurnID: "turn-1"
+            )
+            XCTFail("Expected steer to throw on accepted turn mismatch")
+        } catch let CodexTurnSteerError.expectedTurnMismatch(expected, actual, _) {
+            XCTAssertEqual(expected, "turn-1")
+            XCTAssertEqual(actual, "turn-2")
+        }
+    }
+
     func testStructuredSteerErrorsMapWithoutLosingJSONRPCPayload() async throws {
         let cases: [(failure: CodexAppServerClient.RequestFailure, assertion: (Error) -> Void)] = [
             (

--- a/Tests/RepoPromptTests/AgentMode/AgentComposerSubmissionAttemptTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentComposerSubmissionAttemptTests.swift
@@ -1,0 +1,141 @@
+import Foundation
+@testable import RepoPrompt
+import XCTest
+
+@MainActor
+final class AgentComposerSubmissionAttemptTests: XCTestCase {
+    func testLatchSuppressesRapidSameTabCallbacksButAllowsAnotherTab() throws {
+        var latch = AgentComposerSubmissionLatch()
+        let firstSession = AgentModeViewModel.TabSession(tabID: UUID())
+        let secondSession = AgentModeViewModel.TabSession(tabID: UUID())
+        let firstTarget = makeTarget(session: firstSession)
+        let secondTarget = makeTarget(session: secondSession)
+
+        let firstAttempt = try XCTUnwrap(latch.begin(target: firstTarget, rawDraftSnapshot: "first"))
+
+        XCTAssertTrue(latch.isLatched(for: firstSession.tabID))
+        XCTAssertEqual(latch.activeAttemptID(for: firstSession.tabID), firstAttempt.id)
+        XCTAssertNil(latch.begin(target: firstTarget, rawDraftSnapshot: "duplicate"))
+        XCTAssertNotNil(latch.begin(target: secondTarget, rawDraftSnapshot: "second"))
+    }
+
+    func testMatchingCompletionClearsOnlyUnchangedInput() throws {
+        var latch = AgentComposerSubmissionLatch()
+        let session = AgentModeViewModel.TabSession(tabID: UUID())
+        latch.advanceInputRevision()
+        let attempt = try XCTUnwrap(
+            latch.begin(target: makeTarget(session: session), rawDraftSnapshot: "submitted draft")
+        )
+
+        let effects = latch.complete(
+            attempt,
+            result: .submitted,
+            currentTabID: session.tabID,
+            currentRawDraft: "submitted draft"
+        )
+
+        XCTAssertTrue(effects.matchedAttempt)
+        XCTAssertTrue(effects.shouldClearInput)
+        XCTAssertNil(effects.blockedMessage)
+        XCTAssertFalse(latch.isLatched(for: session.tabID))
+    }
+
+    func testNewerTypingAndDraftRestorationSurviveCompletion() throws {
+        var latch = AgentComposerSubmissionLatch()
+        let session = AgentModeViewModel.TabSession(tabID: UUID())
+        latch.advanceInputRevision()
+        let attempt = try XCTUnwrap(
+            latch.begin(target: makeTarget(session: session), rawDraftSnapshot: "submitted draft")
+        )
+
+        // A programmatic restoration must advance the same revision even when the
+        // resulting text happens to match the submitted text.
+        latch.advanceInputRevision()
+        let effects = latch.complete(
+            attempt,
+            result: .submitted,
+            currentTabID: session.tabID,
+            currentRawDraft: "submitted draft"
+        )
+
+        XCTAssertTrue(effects.matchedAttempt)
+        XCTAssertFalse(effects.shouldClearInput)
+    }
+
+    func testTabSwitchPreventsOldCompletionFromClearingCurrentDraft() throws {
+        var latch = AgentComposerSubmissionLatch()
+        let sourceSession = AgentModeViewModel.TabSession(tabID: UUID())
+        let currentSession = AgentModeViewModel.TabSession(tabID: UUID())
+        let attempt = try XCTUnwrap(
+            latch.begin(target: makeTarget(session: sourceSession), rawDraftSnapshot: "same text")
+        )
+
+        let effects = latch.complete(
+            attempt,
+            result: .submitted,
+            currentTabID: currentSession.tabID,
+            currentRawDraft: "same text"
+        )
+
+        XCTAssertTrue(effects.matchedAttempt)
+        XCTAssertFalse(effects.shouldClearInput)
+    }
+
+    func testStaleCompletionCannotReleaseNewerAttempt() throws {
+        var latch = AgentComposerSubmissionLatch()
+        let session = AgentModeViewModel.TabSession(tabID: UUID())
+        let target = makeTarget(session: session)
+        let oldAttempt = try XCTUnwrap(
+            latch.begin(target: target, rawDraftSnapshot: "old", attemptID: UUID())
+        )
+        XCTAssertTrue(latch.cancel(oldAttempt))
+        let newAttempt = try XCTUnwrap(
+            latch.begin(target: target, rawDraftSnapshot: "new", attemptID: UUID())
+        )
+
+        let staleEffects = latch.complete(
+            oldAttempt,
+            result: .submitted,
+            currentTabID: session.tabID,
+            currentRawDraft: "new"
+        )
+
+        XCTAssertEqual(staleEffects, .stale)
+        XCTAssertEqual(latch.activeAttemptID(for: session.tabID), newAttempt.id)
+    }
+
+    func testBlockedCompletionCannotOverwriteNewerNotice() throws {
+        var latch = AgentComposerSubmissionLatch()
+        let session = AgentModeViewModel.TabSession(tabID: UUID())
+        let attempt = try XCTUnwrap(
+            latch.begin(target: makeTarget(session: session), rawDraftSnapshot: "draft")
+        )
+        latch.advanceNoticeRevision()
+
+        let effects = latch.complete(
+            attempt,
+            result: .blocked(message: "older notice"),
+            currentTabID: session.tabID,
+            currentRawDraft: "draft"
+        )
+
+        XCTAssertTrue(effects.matchedAttempt)
+        XCTAssertNil(effects.blockedMessage)
+    }
+
+    private func makeTarget(session: AgentModeViewModel.TabSession) -> AgentComposerSubmitTarget {
+        AgentComposerSubmitTarget(
+            tabID: session.tabID,
+            route: .createAgentSessionFromSourceTab,
+            expectedSourceTabSessionIdentity: ObjectIdentifier(session),
+            expectedSourceAgentSessionID: nil,
+            expectedPersistentBindingIdentity: nil,
+            expectedBindingTransitionGeneration: session.bindingTransitionGeneration,
+            expectedRunState: .idle,
+            expectedRunID: nil,
+            expectedRunAttemptID: nil,
+            expectedSubmissionToken: session.composerSubmissionToken,
+            expectedInitialStartLocation: .local
+        )
+    }
+}

--- a/Tests/RepoPromptTests/AgentMode/AgentModeMCPWaitEpochTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeMCPWaitEpochTests.swift
@@ -54,7 +54,8 @@ final class AgentModeMCPWaitEpochTests: XCTestCase {
             assistantDeltaFlushGeneration: session.assistantDeltaFlushGeneration,
             providerDrainGeneration: session.providerTerminalDrainGeneration,
             mcpPublicationEnvelope: envelope,
-            successorKind: nil
+            successorKind: nil,
+            providerSuccessorID: nil
         )
         let oldPublication = await viewModel.test_publishTerminalCommit(
             revision,
@@ -239,7 +240,8 @@ final class AgentModeMCPWaitEpochTests: XCTestCase {
             assistantDeltaFlushGeneration: session.assistantDeltaFlushGeneration,
             providerDrainGeneration: session.providerTerminalDrainGeneration,
             mcpPublicationEnvelope: nil,
-            successorKind: nil
+            successorKind: nil,
+            providerSuccessorID: nil
         )
 
         let result = await viewModel.test_publishTerminalCommit(
@@ -335,7 +337,7 @@ private actor EpochBeginGate {
     }
 }
 
-private final class EpochTestCodexController: CodexSessionControlling {
+private final class EpochTestCodexController: CodexSessionControllerTurnDispatchTestDefaults {
     var hasActiveThread: Bool {
         false
     }
@@ -371,10 +373,6 @@ private final class EpochTestCodexController: CodexSessionControlling {
     }
 
     func setThreadName(_ name: String, threadID: String?) async throws {}
-    func sendUserMessage(_ text: String) async throws {}
-    func sendUserTurn(text: String, images: [AgentImageAttachment]) async throws {}
-    func sendUserTurn(text: String, images: [AgentImageAttachment], model: String?, reasoningEffort: String?) async throws {}
-    func sendUserTurn(text: String, images: [AgentImageAttachment], model: String?, reasoningEffort: String?, serviceTier: String?) async throws {}
     func compactThread() async throws {}
     func getThreadGoal() async throws -> CodexNativeSessionController.ThreadGoal? {
         nil

--- a/Tests/RepoPromptTests/AgentMode/AgentModeRunServiceLifecycleTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeRunServiceLifecycleTests.swift
@@ -94,7 +94,7 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
         session.endRunAttempt(ifCurrent: reusedOwnership, source: "test.cleanup")
     }
 
-    func testCodexRejectedSendVariantsPreserveReusedOwnership() async {
+    func testCodexFallbackAndRejectedSendVariantsPreserveReusedOwnership() async {
         let rows: [(LifecycleNoopCodexController.SendBehavior, Bool)] = [
             (.failure, true),
             (.cancellation, true),
@@ -123,10 +123,11 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
                 attachments: []
             )
 
-            switch behavior {
-            case .cancellation:
-                XCTAssertEqual(outcome, .cancelled)
-            case .failure, .success:
+            if activatesThread {
+                guard case .queuedFallback? = outcome else {
+                    return XCTFail("Expected durable Codex fallback for \(behavior)")
+                }
+            } else {
                 guard case .failed? = outcome else {
                     return XCTFail("Expected rejected Codex send for \(behavior)")
                 }
@@ -657,6 +658,60 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
         XCTAssertEqual(session.lastTerminalPublicationResult, .accepted(successorEpoch: successor))
     }
 
+    func testProviderSuccessorConsumesOnceAfterAcceptedPublicationWithoutTouchingGenericQueue() async {
+        let recorder = LifecycleRecorder()
+        var publicationAttempts = 0
+        var consumedRevisions: [UUID] = []
+        let hooks = makeHooks(
+            recorder: recorder,
+            publishTerminalCommitResult: { _, _, _ in
+                publicationAttempts += 1
+                return publicationAttempts == 1
+                    ? .rejected(reason: "transient")
+                    : .accepted(successorEpoch: nil)
+            }
+        )
+        let barrier = AgentRunTerminalCommitBarrier(hooks: hooks)
+        let session = AgentModeViewModel.TabSession(tabID: UUID())
+        session.runID = UUID()
+        session.runState = .running
+        session.pendingInstructions = ["unrelated generic instruction"]
+        let ownership = session.beginRunAttempt(source: "test.providerSuccessor")
+        let successorID = UUID()
+        let request = AgentRunTerminalCommitBarrier.Request(
+            session: session,
+            ownership: ownership,
+            expectedRunID: session.runID,
+            terminalState: .completed,
+            source: "test.providerSuccessor",
+            attachmentDisposition: .deleteFiles,
+            finalizeNonCodexUsage: false,
+            supportsFollowUp: false,
+            providerSuccessor: .init(
+                id: successorID,
+                transitionKind: .relatedFollowUp,
+                consumeAfterPublication: { revision, result in
+                    if case .accepted = result {
+                        consumedRevisions.append(revision.commitID)
+                        return true
+                    }
+                    return false
+                }
+            ),
+            notifyTurnComplete: false
+        )
+
+        _ = await barrier.commit(request)
+        XCTAssertTrue(consumedRevisions.isEmpty)
+        XCTAssertEqual(session.pendingInstructions, ["unrelated generic instruction"])
+
+        _ = await barrier.commit(request)
+        _ = await barrier.commit(request)
+        XCTAssertEqual(consumedRevisions.count, 1)
+        XCTAssertEqual(session.pendingInstructions, ["unrelated generic instruction"])
+        XCTAssertEqual(session.lastTerminalCommitRevision?.providerSuccessorID, successorID)
+    }
+
     func testConcurrentPublicationOnlyCancellationWaitsForCanonicalPublication() async throws {
         let recorder = LifecycleRecorder()
         let publicationGate = LifecyclePublicationGate()
@@ -991,6 +1046,47 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
                 : "attachments:deleteFiles"
             XCTAssertTrue(recorder.contains(expectedAttachmentDisposition), row.rawValue)
         }
+    }
+
+    func testCancelRunInterruptsCapturedSessionOwnedCodexTurnByExactID() async throws {
+        let recorder = LifecycleRecorder()
+        let controller = LifecycleNoopCodexController(recorder: recorder)
+        let harness = makeHarness(
+            recorder: recorder,
+            codexController: controller
+        )
+        let session = AgentModeViewModel.TabSession(tabID: UUID())
+        let runID = UUID()
+        session.selectedAgent = .codexExec
+        session.runID = runID
+        session.runState = .running
+        session.codexConversationID = "lifecycle"
+        session.codexController = controller
+        session.beginRunAttempt(source: "test.codexExactCancellation")
+        session.codexAuthoritativeActiveTurn = try .init(
+            threadID: "lifecycle",
+            turnID: "owned-turn",
+            turnKind: .user,
+            controllerInstanceID: ObjectIdentifier(controller),
+            controllerGeneration: session.codexControllerGeneration,
+            runID: runID,
+            runAttemptID: XCTUnwrap(session.activeRunAttemptID)
+        )
+
+        await harness.service.cancelRun(
+            tabID: session.tabID,
+            session: session,
+            completion: .terminalTeardownCompleted
+        )
+
+        XCTAssertTrue(recorder.contains("codex:interrupt:owned-turn"))
+        XCTAssertFalse(recorder.contains("codex:cancel"))
+        XCTAssertNil(session.codexAuthoritativeActiveTurn)
+        assertOrderedEvents(
+            ["commit:", "codex:interrupt:owned-turn", "codex:shutdown"],
+            in: recorder,
+            prefixMatches: true
+        )
     }
 
     func testOpenCodePermissionModesUseModernConfigAfterModelAndBeforePrompt() async throws {
@@ -1777,20 +1873,19 @@ private final class LifecycleNoopCodexController: CodexSessionControlling {
     }
 
     func setThreadName(_ name: String, threadID: String?) async throws {}
-    func sendUserMessage(_ text: String) async throws {
+    func startUserTurn(text: String, images: [AgentImageAttachment], model: String?, reasoningEffort: String?, serviceTier: String?) async throws -> CodexTurnStartReceipt {
         try recordCodexSend()
+        return CodexTurnStartReceipt(provisionalSubmissionID: "lifecycle-submission")
     }
 
-    func sendUserTurn(text: String, images: [AgentImageAttachment]) async throws {
+    func steerUserTurn(text: String, images: [AgentImageAttachment], expectedTurnID: String) async throws -> CodexTurnSteerReceipt {
         try recordCodexSend()
+        return CodexTurnSteerReceipt(acceptedTurnID: expectedTurnID)
     }
 
-    func sendUserTurn(text: String, images: [AgentImageAttachment], model: String?, reasoningEffort: String?) async throws {
-        try recordCodexSend()
-    }
-
-    func sendUserTurn(text: String, images: [AgentImageAttachment], model: String?, reasoningEffort: String?, serviceTier: String?) async throws {
-        try recordCodexSend()
+    func interruptUserTurn(expectedTurnID: String) async throws -> CodexTurnInterruptReceipt {
+        recorder.record("codex:interrupt:\(expectedTurnID)")
+        return CodexTurnInterruptReceipt(interruptedTurnID: expectedTurnID)
     }
 
     private func recordCodexSend() throws {

--- a/Tests/RepoPromptTests/AgentMode/AgentModeStopSubmitTargetTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeStopSubmitTargetTests.swift
@@ -192,15 +192,10 @@ final class AgentModeStopSubmitTargetTests: XCTestCase {
         session.runState = .running
         session.runID = liveRunID
         session.beginRunAttempt(source: "test.liveRunStarted", attemptID: liveAttemptID)
-        let sendAttemptID = session.codexSteerAckTracker.beginAttempt()
-
         let result = await vm.submitUserTurnCreatingSessionIfNeeded(text: "send to live run", target: target)
-        let sendAck = await session.codexSteerAckTracker.awaitAck(attemptID: sendAttemptID)
 
         XCTAssertEqual(result, .submitted)
-        XCTAssertEqual(sendAck, .sendOutcome(.sent))
         XCTAssertEqual(session.items.filter { $0.kind == .user }.map(\.text), ["send to live run"])
-        XCTAssertEqual(recorder.sentTexts(), ["send to live run"])
         XCTAssertNotNil(session.runID)
         XCTAssertNotNil(session.activeRunAttemptID)
     }
@@ -226,15 +221,10 @@ final class AgentModeStopSubmitTargetTests: XCTestCase {
         XCTAssertTrue(session.endRunAttempt(ifCurrent: firstOwnership, source: "test.rotateAttempt"))
         let liveAttemptID = UUID()
         session.beginRunAttempt(source: "test.secondAttempt", attemptID: liveAttemptID)
-        let sendAttemptID = session.codexSteerAckTracker.beginAttempt()
-
         let result = await vm.submitUserTurnCreatingSessionIfNeeded(text: "send after attempt rotation", target: target)
-        let sendAck = await session.codexSteerAckTracker.awaitAck(attemptID: sendAttemptID)
 
         XCTAssertEqual(result, .submitted)
-        XCTAssertEqual(sendAck, .sendOutcome(.sent))
         XCTAssertEqual(session.items.filter { $0.kind == .user }.map(\.text), ["send after attempt rotation"])
-        XCTAssertEqual(recorder.sentTexts(), ["send after attempt rotation"])
         XCTAssertNotNil(session.runID)
         XCTAssertNotNil(session.activeRunAttemptID)
         XCTAssertNotEqual(session.activeRunAttemptID, firstOwnership.attemptID)
@@ -255,20 +245,15 @@ final class AgentModeStopSubmitTargetTests: XCTestCase {
         session.runID = UUID()
         session.beginRunAttempt(source: "test")
         let target = try XCTUnwrap(vm.makeComposerSubmitTarget(tabID: tabID, session: session))
-        let sendAttemptID = session.codexSteerAckTracker.beginAttempt()
-
         let firstResult = await vm.submitUserTurnCreatingSessionIfNeeded(text: "send once", target: target)
         let reusedResult = await vm.submitUserTurnCreatingSessionIfNeeded(text: "send once", target: target)
-        let sendAck = await session.codexSteerAckTracker.awaitAck(attemptID: sendAttemptID)
 
         XCTAssertEqual(firstResult, .submitted)
         guard case let .blocked(message) = reusedResult else {
             return XCTFail("Expected reused render target to be blocked")
         }
         XCTAssertFalse(message.isEmpty)
-        XCTAssertEqual(sendAck, .sendOutcome(.sent))
         XCTAssertEqual(session.items.filter { $0.kind == .user }.map(\.text), ["send once"])
-        XCTAssertEqual(recorder.sentTexts(), ["send once"])
     }
 
     func testGuardedExistingSessionSubmitRejectsReusedControlCommandTargetWithoutUserBubble() async throws {
@@ -284,20 +269,29 @@ final class AgentModeStopSubmitTargetTests: XCTestCase {
         session.codexConversationID = "noop"
         session.testInstallPersistentSessionBinding(sessionID: UUID())
         let target = try XCTUnwrap(vm.makeComposerSubmitTarget(tabID: tabID, session: session))
-        let sendAttemptID = session.codexSteerAckTracker.beginAttempt()
-
         let firstResult = await vm.submitUserTurnCreatingSessionIfNeeded(text: "/compact", target: target)
         let reusedResult = await vm.submitUserTurnCreatingSessionIfNeeded(text: "/compact", target: target)
-        let sendAck = await session.codexSteerAckTracker.awaitAck(attemptID: sendAttemptID)
+        try await waitUntil { recorder.compactionInvocationCount() == 1 }
 
         XCTAssertEqual(firstResult, .submitted)
         guard case let .blocked(message) = reusedResult else {
             return XCTFail("Expected reused control-command target to be blocked")
         }
         XCTAssertFalse(message.isEmpty)
-        XCTAssertEqual(sendAck, .sendOutcome(.sent))
         XCTAssertTrue(session.items.filter { $0.kind == .user }.isEmpty)
         XCTAssertEqual(recorder.compactionInvocationCount(), 1)
+    }
+
+    private func waitUntil(
+        timeout: TimeInterval = 2,
+        _ predicate: @escaping () -> Bool
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if predicate() { return }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTFail("Timed out waiting for asynchronous Codex submission")
     }
 
     func testGuardedFirstSendRejectsReusedSourceTargetBeforeCreatingAnotherDestination() async throws {
@@ -372,6 +366,186 @@ final class AgentModeStopSubmitTargetTests: XCTestCase {
         XCTAssertTrue(session.pendingClaudeSteeringInstructions.isEmpty)
         XCTAssertTrue(session.pendingACPSteeringInstructions.isEmpty)
         XCTAssertTrue(recorder.sentTexts().isEmpty)
+    }
+
+    func testComposerClaimPublishesNilImmediatelyAndRejectsSecondClaimAsExisting() async throws {
+        let vm = makeViewModel()
+        let tabID = UUID()
+        let session = await vm.ensureSessionReady(tabID: tabID)
+        vm.test_setCurrentTabIDOverride(tabID)
+        defer { vm.test_setCurrentTabIDOverride(nil) }
+        vm.storeDraftText(for: tabID, "claim draft")
+        vm.syncComposerUIState(tabID: tabID)
+        let target = try XCTUnwrap(vm.ui.composer.props.submitTarget)
+        let originalToken = target.expectedSubmissionToken
+        let originalRevision = vm.ui.composer.revision
+        let attempt = AgentComposerSubmitAttempt(
+            id: UUID(),
+            target: target,
+            inputRevision: 42,
+            noticeRevision: 7,
+            rawDraftSnapshot: "claim draft"
+        )
+
+        let claim: AgentModeViewModel.AgentComposerSubmitClaim
+        switch vm.claimComposerSubmitAttempt(attempt) {
+        case let .claimed(acceptedClaim):
+            claim = acceptedClaim
+        case let .rejected(rejection):
+            return XCTFail("Expected claim, got rejection: \(rejection)")
+        }
+
+        XCTAssertEqual(session.activeComposerSubmitAttempt?.id, attempt.id)
+        XCTAssertTrue(session.isComposerSubmissionInFlight)
+        XCTAssertNotEqual(session.composerSubmissionToken, originalToken)
+        XCTAssertNil(vm.ui.composer.props.submitTarget)
+        XCTAssertGreaterThan(vm.ui.composer.revision, originalRevision)
+        XCTAssertEqual(claim.attempt.inputRevision, 42)
+        XCTAssertEqual(claim.attempt.capturedSubmissionToken, originalToken)
+
+        let duplicateAttempt = AgentComposerSubmitAttempt(
+            id: UUID(),
+            target: target,
+            inputRevision: 42,
+            noticeRevision: 7,
+            rawDraftSnapshot: "claim draft"
+        )
+        switch vm.claimComposerSubmitAttempt(duplicateAttempt) {
+        case .claimed:
+            XCTFail("Expected the active claim to reject a duplicate")
+        case let .rejected(rejection):
+            XCTAssertEqual(rejection, .activeAttemptExists(activeAttemptID: attempt.id))
+        }
+
+        XCTAssertTrue(vm.releaseComposerSubmitClaim(claim))
+        XCTAssertFalse(session.isComposerSubmissionInFlight)
+        XCTAssertNotNil(vm.ui.composer.props.submitTarget)
+    }
+
+    func testStaleComposerClaimReleaseCannotClearNewerClaim() async throws {
+        let vm = makeViewModel()
+        let tabID = UUID()
+        let session = await vm.ensureSessionReady(tabID: tabID)
+        vm.test_setCurrentTabIDOverride(tabID)
+        defer { vm.test_setCurrentTabIDOverride(nil) }
+
+        let firstTarget = try XCTUnwrap(vm.makeComposerSubmitTarget(tabID: tabID, session: session))
+        let firstAttempt = AgentComposerSubmitAttempt(
+            id: UUID(),
+            target: firstTarget,
+            inputRevision: 1,
+            noticeRevision: 0,
+            rawDraftSnapshot: "first"
+        )
+        let firstClaim: AgentModeViewModel.AgentComposerSubmitClaim
+        switch vm.claimComposerSubmitAttempt(firstAttempt) {
+        case let .claimed(claim):
+            firstClaim = claim
+        case let .rejected(rejection):
+            return XCTFail("Expected first claim, got rejection: \(rejection)")
+        }
+        XCTAssertTrue(vm.releaseComposerSubmitClaim(firstClaim))
+
+        let secondTarget = try XCTUnwrap(vm.makeComposerSubmitTarget(tabID: tabID, session: session))
+        let secondAttempt = AgentComposerSubmitAttempt(
+            id: UUID(),
+            target: secondTarget,
+            inputRevision: 2,
+            noticeRevision: 0,
+            rawDraftSnapshot: "second"
+        )
+        let secondClaim: AgentModeViewModel.AgentComposerSubmitClaim
+        switch vm.claimComposerSubmitAttempt(secondAttempt) {
+        case let .claimed(claim):
+            secondClaim = claim
+        case let .rejected(rejection):
+            return XCTFail("Expected second claim, got rejection: \(rejection)")
+        }
+
+        XCTAssertFalse(vm.releaseComposerSubmitClaim(firstClaim))
+        XCTAssertEqual(session.activeComposerSubmitAttempt?.id, secondAttempt.id)
+        XCTAssertTrue(vm.releaseComposerSubmitClaim(secondClaim))
+    }
+
+    func testComposerClaimedSubmitPreservesNewerStoredDraft() async throws {
+        let controller = StopSubmitNoopCodexController(hasActiveThread: true)
+        let vm = makeViewModel(codexController: controller)
+        let tabID = UUID()
+        vm.ensureSession(for: tabID)
+        let session = try XCTUnwrap(vm.sessions[tabID])
+        session.hasLoadedPersistedState = true
+        session.hasSentFirstMessage = true
+        session.selectedAgent = .codexExec
+        session.testInstallPersistentSessionBinding(sessionID: UUID())
+        session.runState = .running
+        session.runID = UUID()
+        session.beginRunAttempt(source: "test")
+        vm.storeDraftText(for: tabID, "submitted draft")
+        let target = try XCTUnwrap(vm.makeComposerSubmitTarget(tabID: tabID, session: session))
+        let attempt = AgentComposerSubmitAttempt(
+            id: UUID(),
+            target: target,
+            inputRevision: 1,
+            noticeRevision: 0,
+            rawDraftSnapshot: "submitted draft"
+        )
+        let claim: AgentModeViewModel.AgentComposerSubmitClaim
+        switch vm.claimComposerSubmitAttempt(attempt) {
+        case let .claimed(acceptedClaim):
+            claim = acceptedClaim
+        case let .rejected(rejection):
+            return XCTFail("Expected claim, got rejection: \(rejection)")
+        }
+        vm.storeDraftText(for: tabID, "newer draft")
+
+        let result = await vm.executeComposerSubmitAttempt(text: "submitted draft", claim: claim)
+
+        XCTAssertEqual(result, .submitted)
+        XCTAssertEqual(vm.retrieveDraftText(for: tabID), "newer draft")
+    }
+
+    func testGuardedFirstSendRejectsUnprovenCreateToExistingTransitionAndPreservesDraft() async throws {
+        let vm = makeViewModel()
+        let sourceTabID = UUID()
+        let sourceSession = await vm.ensureSessionReady(tabID: sourceTabID)
+        sourceSession.selectedAgent = .codexExec
+        sourceSession.pendingImageAttachments = [
+            AgentImageAttachment(
+                source: .localFile(path: "/tmp/create-to-existing.png"),
+                title: "create-to-existing.png"
+            )
+        ]
+        vm.storeDraftText(for: sourceTabID, "draft must survive")
+        let staleCreateTarget = try XCTUnwrap(
+            vm.makeComposerSubmitTarget(tabID: sourceTabID, session: sourceSession)
+        )
+        XCTAssertEqual(staleCreateTarget.route, .createAgentSessionFromSourceTab)
+
+        let linkedSessionID = UUID()
+        sourceSession.testInstallPersistentSessionBinding(sessionID: linkedSessionID)
+        sourceSession.runState = .running
+        sourceSession.runID = UUID()
+        sourceSession.beginRunAttempt(source: "test.linked")
+        var createCalled = false
+
+        let result = await vm.submitUserTurnCreatingSessionIfNeeded(
+            text: "draft must survive",
+            target: staleCreateTarget,
+            createAndActivateSessionTab: {
+                createCalled = true
+                return UUID()
+            }
+        )
+
+        guard case let .blocked(message) = result else {
+            return XCTFail("Expected unproven create-to-existing transition to remain blocked")
+        }
+        XCTAssertFalse(message.isEmpty)
+        XCTAssertFalse(createCalled)
+        XCTAssertEqual(sourceSession.activeAgentSessionID, linkedSessionID)
+        XCTAssertEqual(vm.retrieveDraftText(for: sourceTabID), "draft must survive")
+        XCTAssertEqual(sourceSession.pendingImageAttachments.count, 1)
+        XCTAssertTrue(sourceSession.items.isEmpty)
     }
 
     func testFreshManualThreadProjectsAndUpdatesInitialStartLocation() async {
@@ -744,20 +918,18 @@ private final class StopSubmitNoopCodexController: CodexSessionControlling {
     }
 
     func setThreadName(_ name: String, threadID: String?) async throws {}
-    func sendUserMessage(_ text: String) async throws {
+    func startUserTurn(text: String, images: [AgentImageAttachment], model: String?, reasoningEffort: String?, serviceTier: String?) async throws -> CodexTurnStartReceipt {
         recorder?.record(text)
+        return CodexTurnStartReceipt(provisionalSubmissionID: "stop-submit-submission")
     }
 
-    func sendUserTurn(text: String, images: [AgentImageAttachment]) async throws {
+    func steerUserTurn(text: String, images: [AgentImageAttachment], expectedTurnID: String) async throws -> CodexTurnSteerReceipt {
         recorder?.record(text)
+        return CodexTurnSteerReceipt(acceptedTurnID: expectedTurnID)
     }
 
-    func sendUserTurn(text: String, images: [AgentImageAttachment], model: String?, reasoningEffort: String?) async throws {
-        recorder?.record(text)
-    }
-
-    func sendUserTurn(text: String, images: [AgentImageAttachment], model: String?, reasoningEffort: String?, serviceTier: String?) async throws {
-        recorder?.record(text)
+    func interruptUserTurn(expectedTurnID: String) async throws -> CodexTurnInterruptReceipt {
+        CodexTurnInterruptReceipt(interruptedTurnID: expectedTurnID)
     }
 
     func compactThread() async throws {

--- a/Tests/RepoPromptTests/AgentMode/AgentModeSubmitWaitWakeTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeSubmitWaitWakeTests.swift
@@ -23,4 +23,14 @@ final class AgentModeSubmitWaitWakeTests: XCTestCase {
             codexCompactionInFlight: false
         ))
     }
+
+    func testCodexDeliverySignalWaitsForProviderAcceptanceOrDurableQueueInsertion() {
+        XCTAssertEqual(
+            AgentModeViewModel.test_mcpActiveInstructionDeliverySignalTiming(
+                selectedAgent: .codexExec,
+                hasNativeSteeringRoute: false
+            ),
+            .afterProviderSend
+        )
+    }
 }

--- a/Tests/RepoPromptTests/AgentMode/AgentModeViewModelInactiveRefreshTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeViewModelInactiveRefreshTests.swift
@@ -658,7 +658,7 @@ final class AgentModeViewModelInactiveRefreshTests: XCTestCase {
     }
 }
 
-private final class InactiveRefreshFakeCodexController: CodexSessionControlling {
+private final class InactiveRefreshFakeCodexController: CodexSessionControllerTurnDispatchTestDefaults {
     var hasActiveThread: Bool {
         false
     }
@@ -694,10 +694,6 @@ private final class InactiveRefreshFakeCodexController: CodexSessionControlling 
     }
 
     func setThreadName(_ name: String, threadID: String?) async throws {}
-    func sendUserMessage(_ text: String) async throws {}
-    func sendUserTurn(text: String, images: [AgentImageAttachment]) async throws {}
-    func sendUserTurn(text: String, images: [AgentImageAttachment], model: String?, reasoningEffort: String?) async throws {}
-    func sendUserTurn(text: String, images: [AgentImageAttachment], model: String?, reasoningEffort: String?, serviceTier: String?) async throws {}
     func compactThread() async throws {}
     func getThreadGoal() async throws -> CodexNativeSessionController.ThreadGoal? {
         nil

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexAgentModeCoordinatorLivenessTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexAgentModeCoordinatorLivenessTests.swift
@@ -168,6 +168,29 @@ final class CodexAgentModeCoordinatorLivenessTests: XCTestCase {
         XCTAssertEqual(session.items, baselineItems)
     }
 
+    func testScopedErrorWithoutAuthoritativeIdentityFailsClosed() async {
+        let controller = LivenessFakeCodexController(snapshot: .active(activeFlags: []))
+        let viewModel = makeViewModel(controller: controller)
+        let session = preparedCodexSession(in: viewModel, controller: controller)
+        session.codexAuthoritativeActiveTurn = nil
+        let baselineItems = session.items
+        let baselineOwnership = session.activeRunOwnership
+
+        await viewModel.test_codexCoordinator.test_handleCodexNativeEvent(
+            .errorNotification(.init(
+                message: "stale fatal error",
+                willRetry: false,
+                threadID: "fake",
+                turnID: "untrusted-routing-turn"
+            )),
+            session: session
+        )
+
+        XCTAssertEqual(session.runState, .running)
+        XCTAssertEqual(session.activeRunOwnership, baselineOwnership)
+        XCTAssertEqual(session.items, baselineItems)
+    }
+
     func testWatchdogPauseRemainsRunningAndDoesNotAppendTranscriptFailure() async throws {
         let controller = LivenessFakeCodexController(snapshot: .idle, activeTurnIDs: [])
         let viewModel = makeViewModel(controller: controller)
@@ -241,9 +264,9 @@ final class CodexAgentModeCoordinatorLivenessTests: XCTestCase {
         let viewModel = makeViewModel(controller: controller)
         let session = preparedCodexSession(in: viewModel, controller: controller)
         let ownership = session.activeRunOwnership
-        session.codexCurrentTurnID = nil
-        session.codexCurrentTurnKind = nil
-        session.codexTurnKindsByID.removeAll()
+        session.codexAuthoritativeActiveTurn = nil
+        session.codexAnonymousActiveTurn = nil
+        session.codexRoutingObservedTurnID = nil
         session.codexPendingTurnKind = .user
 
         await viewModel.test_codexCoordinator.test_handleCodexNativeEvent(
@@ -254,8 +277,8 @@ final class CodexAgentModeCoordinatorLivenessTests: XCTestCase {
         XCTAssertEqual(session.runState, .running)
         XCTAssertEqual(session.activeRunOwnership, ownership)
         XCTAssertEqual(session.codexPendingTurnKind, .user)
-        XCTAssertNil(session.codexCurrentTurnID)
-        XCTAssertNil(session.codexCurrentTurnKind)
+        XCTAssertNil(session.codexAuthoritativeActiveTurn)
+        XCTAssertNil(session.codexAnonymousActiveTurn)
         XCTAssertNil(session.lastTerminalCommitRevision)
 
         await viewModel.test_codexCoordinator.test_handleCodexNativeEvent(
@@ -264,8 +287,8 @@ final class CodexAgentModeCoordinatorLivenessTests: XCTestCase {
         )
 
         XCTAssertNil(session.codexPendingTurnKind)
-        XCTAssertEqual(session.codexCurrentTurnID, "current-turn")
-        XCTAssertEqual(session.codexCurrentTurnKind, .user)
+        XCTAssertEqual(session.codexAuthoritativeActiveTurn?.turnID, "current-turn")
+        XCTAssertEqual(session.codexAuthoritativeActiveTurn?.turnKind, .user)
 
         await viewModel.test_codexCoordinator.test_handleCodexNativeEvent(
             .turnCompleted(turnID: "current-turn", status: .completed),
@@ -290,10 +313,31 @@ final class CodexAgentModeCoordinatorLivenessTests: XCTestCase {
 
         XCTAssertEqual(session.runState, .running)
         XCTAssertEqual(session.activeRunOwnership, ownership)
-        XCTAssertEqual(session.codexCurrentTurnID, "turn")
-        XCTAssertEqual(session.codexCurrentTurnKind, .user)
-        XCTAssertEqual(session.codexTurnKindsByID["turn"], .user)
+        XCTAssertEqual(session.codexAuthoritativeActiveTurn?.turnID, "turn")
+        XCTAssertEqual(session.codexAuthoritativeActiveTurn?.turnKind, .user)
         XCTAssertNil(session.lastTerminalCommitRevision)
+    }
+
+    func testMismatchedStartCannotReplaceAuthoritativeIdentityAndDuplicateIsIdempotent() async {
+        let controller = LivenessFakeCodexController(snapshot: .active(activeFlags: []))
+        let viewModel = makeViewModel(controller: controller)
+        let session = preparedCodexSession(in: viewModel, controller: controller)
+        let originalIdentity = session.codexAuthoritativeActiveTurn
+
+        await viewModel.test_codexCoordinator.test_handleCodexNativeEvent(
+            .turnStarted(turnID: "different-turn"),
+            session: session
+        )
+
+        XCTAssertEqual(session.codexAuthoritativeActiveTurn, originalIdentity)
+
+        await viewModel.test_codexCoordinator.test_handleCodexNativeEvent(
+            .turnStarted(turnID: "turn"),
+            session: session
+        )
+
+        XCTAssertEqual(session.codexAuthoritativeActiveTurn, originalIdentity)
+        XCTAssertEqual(session.runState, .running)
     }
 
     func testNilCompletionAfterIdentifiedStartCompletesCurrentTurn() async {
@@ -308,8 +352,8 @@ final class CodexAgentModeCoordinatorLivenessTests: XCTestCase {
 
         XCTAssertEqual(session.runState, .completed)
         XCTAssertNil(session.activeRunOwnership)
-        XCTAssertNil(session.codexCurrentTurnID)
-        XCTAssertNil(session.codexCurrentTurnKind)
+        XCTAssertNil(session.codexAuthoritativeActiveTurn)
+        XCTAssertNil(session.codexAnonymousActiveTurn)
         XCTAssertNotNil(session.lastTerminalCommitRevision)
     }
 
@@ -317,9 +361,9 @@ final class CodexAgentModeCoordinatorLivenessTests: XCTestCase {
         let controller = LivenessFakeCodexController(snapshot: .active(activeFlags: []))
         let viewModel = makeViewModel(controller: controller)
         let session = preparedCodexSession(in: viewModel, controller: controller)
-        session.codexCurrentTurnID = nil
-        session.codexCurrentTurnKind = nil
-        session.codexTurnKindsByID.removeAll()
+        session.codexAuthoritativeActiveTurn = nil
+        session.codexAnonymousActiveTurn = nil
+        session.codexRoutingObservedTurnID = nil
         session.codexPendingTurnKind = .user
 
         await viewModel.test_codexCoordinator.test_handleCodexNativeEvent(
@@ -327,8 +371,8 @@ final class CodexAgentModeCoordinatorLivenessTests: XCTestCase {
             session: session
         )
 
-        XCTAssertNil(session.codexCurrentTurnID)
-        XCTAssertEqual(session.codexCurrentTurnKind, .user)
+        XCTAssertNil(session.codexAuthoritativeActiveTurn)
+        XCTAssertEqual(session.codexAnonymousActiveTurn?.turnKind, .user)
         XCTAssertNil(session.codexPendingTurnKind)
 
         await viewModel.test_codexCoordinator.test_handleCodexNativeEvent(
@@ -338,6 +382,7 @@ final class CodexAgentModeCoordinatorLivenessTests: XCTestCase {
 
         XCTAssertEqual(session.runState, .completed)
         XCTAssertNil(session.activeRunOwnership)
+        XCTAssertNil(session.codexAnonymousActiveTurn)
         XCTAssertNotNil(session.lastTerminalCommitRevision)
     }
 
@@ -346,9 +391,9 @@ final class CodexAgentModeCoordinatorLivenessTests: XCTestCase {
         let viewModel = makeViewModel(controller: controller)
         let session = preparedCodexSession(in: viewModel, controller: controller)
         let ownership = session.activeRunOwnership
-        session.codexCurrentTurnID = nil
-        session.codexCurrentTurnKind = nil
-        session.codexTurnKindsByID.removeAll()
+        session.codexAuthoritativeActiveTurn = nil
+        session.codexAnonymousActiveTurn = nil
+        session.codexRoutingObservedTurnID = nil
         session.codexPendingTurnKind = .user
 
         await viewModel.test_codexCoordinator.test_handleCodexNativeEvent(
@@ -359,8 +404,8 @@ final class CodexAgentModeCoordinatorLivenessTests: XCTestCase {
         XCTAssertEqual(session.runState, .running)
         XCTAssertEqual(session.activeRunOwnership, ownership)
         XCTAssertEqual(session.codexPendingTurnKind, .user)
-        XCTAssertNil(session.codexCurrentTurnID)
-        XCTAssertNil(session.codexCurrentTurnKind)
+        XCTAssertNil(session.codexAuthoritativeActiveTurn)
+        XCTAssertNil(session.codexAnonymousActiveTurn)
         XCTAssertNil(session.lastTerminalCommitRevision)
     }
 
@@ -389,6 +434,7 @@ final class CodexAgentModeCoordinatorLivenessTests: XCTestCase {
                 controller: controller,
                 runID: harness.parentRunID
             )
+            session.codexRoutingObservedTurnID = "routing-hint-only"
 
             let outcome = await viewModel.test_codexCoordinator.sendCodexNativeMessage(
                 session: session,
@@ -408,7 +454,9 @@ final class CodexAgentModeCoordinatorLivenessTests: XCTestCase {
                 interruptedObject["wait"]?.objectValue?["result"]?.stringValue,
                 "interrupted_by_steering"
             )
-            XCTAssertEqual(controller.sendUserTurnCountSync(), 1)
+            XCTAssertEqual(controller.startUserTurnCountSync(), 0)
+            XCTAssertEqual(controller.steerUserTurnIDsSync(), ["turn"])
+            XCTAssertEqual(session.codexAuthoritativeActiveTurn?.turnID, "turn")
             XCTAssertTrue(orderingSnapshot.drainSucceeded)
             XCTAssertEqual(orderingSnapshot.activeScopeCountAtDrainCompletion, 0)
             XCTAssertTrue(orderingSnapshot.sendObservedAfterDrain)
@@ -434,8 +482,135 @@ final class CodexAgentModeCoordinatorLivenessTests: XCTestCase {
             return XCTFail("Expected failed outcome, got \(outcome)")
         }
         XCTAssertTrue(message.contains("agent_run.wait"))
-        XCTAssertEqual(controller.sendUserTurnCountSync(), 0)
+        XCTAssertEqual(controller.startUserTurnCountSync(), 0)
+        XCTAssertTrue(controller.steerUserTurnIDsSync().isEmpty)
         XCTAssertEqual(session.runState, .running)
+    }
+
+    func testInactiveCodexNativeSendStartsTurnWithoutInstallingLifecycleIdentity() async {
+        let controller = LivenessFakeCodexController(snapshot: .idle, activeTurnIDs: [])
+        let viewModel = makeViewModel(controller: controller)
+        let session = preparedCodexSession(in: viewModel, controller: controller)
+        session.runState = .idle
+        session.codexAuthoritativeActiveTurn = nil
+        session.codexRoutingObservedTurnID = nil
+
+        let outcome = await viewModel.test_codexCoordinator.sendCodexNativeMessage(
+            session: session,
+            text: "hello",
+            attachments: []
+        )
+
+        XCTAssertEqual(outcome, .sent)
+        XCTAssertEqual(controller.startUserTurnCountSync(), 1)
+        XCTAssertTrue(controller.steerUserTurnIDsSync().isEmpty)
+        XCTAssertNil(session.codexAuthoritativeActiveTurn)
+        XCTAssertEqual(session.codexPendingTurnKind, .user)
+    }
+
+    func testActiveCodexNativeSendWithoutExactIdentityQueuesWithoutStarting() async {
+        let controller = LivenessFakeCodexController(snapshot: .active(activeFlags: []))
+        let viewModel = makeViewModel(controller: controller)
+        let session = preparedCodexSession(in: viewModel, controller: controller)
+        session.codexAuthoritativeActiveTurn = nil
+        session.codexRoutingObservedTurnID = "routing-only-turn"
+
+        let outcome = await viewModel.test_codexCoordinator.sendCodexNativeMessage(
+            session: session,
+            text: "hello",
+            attachments: []
+        )
+
+        guard case .queuedFallback(_, .activeWithoutAuthoritativeIdentity) = outcome else {
+            return XCTFail("Expected missing-identity fallback queue, got \(outcome)")
+        }
+        XCTAssertEqual(controller.startUserTurnCountSync(), 0)
+        XCTAssertTrue(controller.steerUserTurnIDsSync().isEmpty)
+        XCTAssertEqual(session.codexFallbackQueue.count, 1)
+    }
+
+    func testTypedSteerRejectionReturnsFallbackWithoutReplacingAuthoritativeIdentity() async {
+        let failure = CodexAppServerClient.RequestFailure(
+            method: "turn/steer",
+            code: -32602,
+            message: "no active turn to steer",
+            data: nil
+        )
+        let controller = LivenessFakeCodexController(
+            snapshot: .active(activeFlags: []),
+            steerError: CodexTurnSteerError.noActiveTurn(failure)
+        )
+        let viewModel = makeViewModel(controller: controller)
+        let session = preparedCodexSession(in: viewModel, controller: controller)
+        let identity = session.codexAuthoritativeActiveTurn
+
+        let outcome = await viewModel.test_codexCoordinator.sendCodexNativeMessage(
+            session: session,
+            text: "hello",
+            attachments: []
+        )
+
+        guard case .queuedFallback(_, .noActiveTurn(failure: failure)) = outcome else {
+            return XCTFail("Expected no-active fallback queue, got \(outcome)")
+        }
+        XCTAssertEqual(controller.steerUserTurnIDsSync(), ["turn"])
+        XCTAssertEqual(session.codexAuthoritativeActiveTurn, identity)
+        XCTAssertEqual(session.codexFallbackQueue.count, 1)
+    }
+
+    func testManualTypedFallbackKeepsOptimisticBubbleAndDraft() async throws {
+        let failure = CodexAppServerClient.RequestFailure(
+            method: "turn/steer",
+            code: -32602,
+            message: "no active turn to steer",
+            data: nil
+        )
+        let controller = LivenessFakeCodexController(
+            snapshot: .active(activeFlags: []),
+            steerError: CodexTurnSteerError.noActiveTurn(failure)
+        )
+        let viewModel = makeViewModel(controller: controller)
+        let session = preparedCodexSession(in: viewModel, controller: controller)
+        viewModel.storeDraftText(for: session.tabID, "restore me")
+
+        let result = viewModel.submitUserTurn(text: "restore me", tabID: session.tabID)
+
+        XCTAssertEqual(result, .submitted)
+        try await waitUntil {
+            controller.steerUserTurnIDsSync() == ["turn"]
+                && session.codexFallbackQueue.count == 1
+        }
+        XCTAssertEqual(session.items.filter { $0.kind == .user }.map(\.text), ["restore me"])
+        XCTAssertEqual(viewModel.retrieveDraftText(for: session.tabID), "restore me")
+        XCTAssertEqual(session.codexAuthoritativeActiveTurn?.turnID, "turn")
+    }
+
+    func testAcceptedSteerRemainsSentWhenMatchingTurnCompletesBeforeReceiptResumes() async throws {
+        let controller = LivenessFakeCodexController(
+            snapshot: .active(activeFlags: []),
+            steerDelayNanos: 50_000_000
+        )
+        let viewModel = makeViewModel(controller: controller)
+        let session = preparedCodexSession(in: viewModel, controller: controller)
+        let sendTask = Task {
+            await viewModel.test_codexCoordinator.sendCodexNativeMessage(
+                session: session,
+                text: "hello",
+                attachments: []
+            )
+        }
+        try await waitUntil {
+            controller.steerUserTurnIDsSync() == ["turn"]
+        }
+
+        await viewModel.test_codexCoordinator.test_handleCodexNativeEvent(
+            .turnCompleted(turnID: "turn", status: .completed),
+            session: session
+        )
+
+        let outcome = await sendTask.value
+        XCTAssertEqual(outcome, .sent)
+        XCTAssertEqual(session.runState, .completed)
     }
 
     private func makeViewModel(
@@ -465,9 +640,16 @@ final class CodexAgentModeCoordinatorLivenessTests: XCTestCase {
         session.beginRunAttempt(source: "test.codexLiveness")
         session.codexController = controller
         session.codexConversationID = "fake"
-        session.codexCurrentTurnID = "turn"
-        session.codexCurrentTurnKind = .user
-        session.codexTurnKindsByID["turn"] = .user
+        session.codexAuthoritativeActiveTurn = .init(
+            threadID: "fake",
+            turnID: "turn",
+            turnKind: .user,
+            controllerInstanceID: ObjectIdentifier(controller),
+            controllerGeneration: session.codexControllerGeneration,
+            runID: runID,
+            runAttemptID: session.activeRunAttemptID!
+        )
+        session.codexRoutingObservedTurnID = "turn"
         session.codexControllerGoalSupportEnabled = CodexGoalSupport.isEnabled
         return session
     }
@@ -546,19 +728,26 @@ private final class CodexDrainSendOrderingRecorder: @unchecked Sendable {
 
 private final class LivenessFakeCodexController: CodexSessionControlling {
     private var readSnapshotCount = 0
-    private var sendUserTurnCount = 0
+    private var startUserTurnCount = 0
+    private var steerUserTurnIDs: [String] = []
     private let snapshotStatus: CodexNativeSessionController.ThreadSnapshot.RuntimeStatus
     private let snapshotActiveTurnIDs: [String]
     private let onSendUserTurn: (() -> Void)?
+    private let steerError: Error?
+    private let steerDelayNanos: UInt64
 
     init(
         snapshot: CodexNativeSessionController.ThreadSnapshot.RuntimeStatus,
         activeTurnIDs: [String] = ["turn"],
-        onSendUserTurn: (() -> Void)? = nil
+        onSendUserTurn: (() -> Void)? = nil,
+        steerError: Error? = nil,
+        steerDelayNanos: UInt64 = 0
     ) {
         snapshotStatus = snapshot
         snapshotActiveTurnIDs = activeTurnIDs
         self.onSendUserTurn = onSendUserTurn
+        self.steerError = steerError
+        self.steerDelayNanos = steerDelayNanos
     }
 
     var hasActiveThread: Bool {
@@ -566,7 +755,7 @@ private final class LivenessFakeCodexController: CodexSessionControlling {
     }
 
     var events: AsyncStream<CodexNativeSessionController.Event> {
-        AsyncStream { continuation in continuation.finish() }
+        AsyncStream { _ in }
     }
 
     func ensureEventsStreamReady() {}
@@ -575,8 +764,12 @@ private final class LivenessFakeCodexController: CodexSessionControlling {
         readSnapshotCount
     }
 
-    func sendUserTurnCountSync() -> Int {
-        sendUserTurnCount
+    func startUserTurnCountSync() -> Int {
+        startUserTurnCount
+    }
+
+    func steerUserTurnIDsSync() -> [String] {
+        steerUserTurnIDs
     }
 
     func startOrResume(existing: CodexNativeSessionController.SessionRef?, baseInstructions: String) async throws -> CodexNativeSessionController.SessionRef {
@@ -622,9 +815,40 @@ private final class LivenessFakeCodexController: CodexSessionControlling {
         recordSendUserTurn()
     }
 
+    func startUserTurn(
+        text _: String,
+        images _: [AgentImageAttachment],
+        model _: String?,
+        reasoningEffort _: String?,
+        serviceTier _: String?
+    ) async throws -> CodexTurnStartReceipt {
+        recordSendUserTurn()
+        startUserTurnCount += 1
+        return CodexTurnStartReceipt(provisionalSubmissionID: "liveness-submission-\(startUserTurnCount)")
+    }
+
+    func steerUserTurn(
+        text _: String,
+        images _: [AgentImageAttachment],
+        expectedTurnID: String
+    ) async throws -> CodexTurnSteerReceipt {
+        recordSendUserTurn()
+        steerUserTurnIDs.append(expectedTurnID)
+        if let steerError {
+            throw steerError
+        }
+        if steerDelayNanos > 0 {
+            try await Task.sleep(nanoseconds: steerDelayNanos)
+        }
+        return CodexTurnSteerReceipt(acceptedTurnID: expectedTurnID)
+    }
+
+    func interruptUserTurn(expectedTurnID: String) async throws -> CodexTurnInterruptReceipt {
+        CodexTurnInterruptReceipt(interruptedTurnID: expectedTurnID)
+    }
+
     private func recordSendUserTurn() {
         onSendUserTurn?()
-        sendUserTurnCount += 1
     }
 
     func compactThread() async throws {}

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexFallbackFIFOTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexFallbackFIFOTests.swift
@@ -39,6 +39,29 @@ final class CodexFallbackFIFOTests: XCTestCase {
         XCTAssertEqual(session.codexAuthoritativeActiveTurn?.turnID, "turn")
     }
 
+    func testSteerAcceptedIntoDifferentTurnReconcilesWithoutResend() async {
+        let controller = FallbackFIFOController(
+            steerResults: [.success(.init(acceptedTurnID: "actual-turn"))]
+        )
+        let (viewModel, session) = makeRunningSession(controller: controller)
+
+        let outcome = await viewModel.test_codexCoordinator.sendCodexNativeMessage(
+            session: session,
+            text: "steer me",
+            attachments: []
+        )
+
+        XCTAssertEqual(outcome, .sent)
+        XCTAssertEqual(controller.steerTurnIDs, ["turn"])
+        XCTAssertEqual(controller.startCount, 0)
+        XCTAssertTrue(session.codexFallbackQueue.isEmpty)
+        XCTAssertEqual(session.codexPendingSteerLifecycleReconciliation?.priorIdentity.turnID, "turn")
+        XCTAssertEqual(
+            session.codexPendingSteerLifecycleReconciliation?.acceptedDispatchTurnID,
+            "actual-turn"
+        )
+    }
+
     func testMismatchRetrySuccessReconcilesOnlyWhenActualLifecycleCompletes() async {
         let mismatch = requestFailure(message: "expected turn mismatch")
         let controller = FallbackFIFOController(

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexFallbackFIFOTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexFallbackFIFOTests.swift
@@ -1,0 +1,1116 @@
+import Foundation
+import XCTest
+@_spi(TestSupport) @testable import RepoPrompt
+
+@MainActor
+final class CodexFallbackFIFOTests: XCTestCase {
+    func testMismatchRetriesOnceWithActualIDThenQueuesExactlyOnce() async {
+        let firstFailure = requestFailure(
+            message: "expected turn mismatch",
+            data: .object(["actualTurnId": .string("actual-turn")])
+        )
+        let controller = FallbackFIFOController(
+            steerResults: [
+                .failure(CodexTurnSteerError.expectedTurnMismatch(
+                    expectedTurnID: "turn",
+                    actualTurnID: "actual-turn",
+                    failure: firstFailure
+                )),
+                .failure(CodexTurnSteerError.activeTurnNotSteerable(
+                    turnKind: "review",
+                    failure: requestFailure(message: "cannot steer a review turn")
+                ))
+            ]
+        )
+        let (viewModel, session) = makeRunningSession(controller: controller)
+
+        let outcome = await viewModel.test_codexCoordinator.sendCodexNativeMessage(
+            session: session,
+            text: "retry me",
+            attachments: []
+        )
+
+        guard case let .queuedFallback(queueID, reason) = outcome else {
+            return XCTFail("Expected durable fallback queue insertion, got \(outcome)")
+        }
+        XCTAssertEqual(controller.steerTurnIDs, ["turn", "actual-turn"])
+        XCTAssertEqual(session.codexFallbackQueue.map(\.id), [queueID])
+        XCTAssertEqual(session.codexFallbackQueue.first?.fallbackReason, reason)
+        XCTAssertEqual(session.codexAuthoritativeActiveTurn?.turnID, "turn")
+    }
+
+    func testMismatchRetrySuccessReconcilesOnlyWhenActualLifecycleCompletes() async {
+        let mismatch = requestFailure(message: "expected turn mismatch")
+        let controller = FallbackFIFOController(
+            steerResults: [
+                .failure(CodexTurnSteerError.expectedTurnMismatch(
+                    expectedTurnID: "turn",
+                    actualTurnID: "actual-turn",
+                    failure: mismatch
+                )),
+                .success(CodexTurnSteerReceipt(acceptedTurnID: "actual-turn"))
+            ]
+        )
+        let (viewModel, session) = makeRunningSession(controller: controller)
+
+        let outcome = await viewModel.test_codexCoordinator.sendCodexNativeMessage(
+            session: session,
+            text: "retry succeeds",
+            attachments: []
+        )
+
+        XCTAssertEqual(outcome, .sent)
+        XCTAssertEqual(controller.steerTurnIDs, ["turn", "actual-turn"])
+        XCTAssertEqual(session.codexAuthoritativeActiveTurn?.turnID, "turn")
+        XCTAssertEqual(
+            session.codexPendingSteerLifecycleReconciliation?.acceptedDispatchTurnID,
+            "actual-turn"
+        )
+        XCTAssertTrue(session.codexFallbackQueue.isEmpty)
+
+        await viewModel.test_codexCoordinator.test_handleCodexNativeEvent(
+            .turnCompleted(turnID: "actual-turn", status: .completed),
+            session: session
+        )
+
+        XCTAssertEqual(session.runState, .completed)
+        XCTAssertNil(session.activeRunOwnership)
+        XCTAssertNil(session.codexAuthoritativeActiveTurn)
+        XCTAssertNil(session.codexPendingSteerLifecycleReconciliation)
+        XCTAssertNotNil(session.lastTerminalCommitRevision)
+    }
+
+    func testMismatchRetryAcceptedThenActualStartReconcilesRealControllerForExactCancellation() async {
+        let recorder = MismatchRetryNativeControllerRecorder()
+        let controller = makeNativeController(recorder: recorder)
+        controller.test_installThreadState(
+            threadID: "thread",
+            authoritativeTurnID: "turn",
+            routingTurnID: "turn"
+        )
+        let (viewModel, session) = makeRunningSession(controller: controller)
+
+        let outcome = await viewModel.test_codexCoordinator.sendCodexNativeMessage(
+            session: session,
+            text: "retry against actual",
+            attachments: []
+        )
+
+        XCTAssertEqual(outcome, .sent)
+        XCTAssertEqual(controller.test_authoritativeLifecycleTurnID, "turn")
+        await controller.test_handleNotification(
+            method: "turn/started",
+            params: lifecycleParams(turnID: "actual-turn")
+        )
+        await viewModel.test_codexCoordinator.test_handleCodexNativeEvent(
+            .turnStarted(turnID: "actual-turn"),
+            session: session
+        )
+
+        XCTAssertEqual(session.codexAuthoritativeActiveTurn?.turnID, "actual-turn")
+        XCTAssertEqual(controller.test_authoritativeLifecycleTurnID, "actual-turn")
+
+        await viewModel.test_codexCoordinator.cancelCodexRun(session)
+
+        XCTAssertEqual(recorder.interruptedTurnIDs, ["actual-turn"])
+    }
+
+    func testMismatchRetryAcceptedThenActualCompletionClearsRealControllerForReuse() async throws {
+        let recorder = MismatchRetryNativeControllerRecorder()
+        let controller = makeNativeController(recorder: recorder)
+        controller.test_installThreadState(
+            threadID: "thread",
+            authoritativeTurnID: "turn",
+            routingTurnID: "turn"
+        )
+        let (viewModel, session) = makeRunningSession(controller: controller)
+
+        let outcome = await viewModel.test_codexCoordinator.sendCodexNativeMessage(
+            session: session,
+            text: "complete actual",
+            attachments: []
+        )
+        XCTAssertEqual(outcome, .sent)
+
+        await controller.test_handleNotification(
+            method: "turn/completed",
+            params: lifecycleParams(turnID: "actual-turn", status: "completed")
+        )
+        await viewModel.test_codexCoordinator.test_handleCodexNativeEvent(
+            .turnCompleted(turnID: "actual-turn", status: .completed),
+            session: session
+        )
+
+        XCTAssertNil(session.codexAuthoritativeActiveTurn)
+        XCTAssertNil(controller.test_authoritativeLifecycleTurnID)
+
+        let nextRunID = UUID()
+        session.runID = nextRunID
+        session.runState = .running
+        session.beginRunAttempt(source: "test.codexFallback.reuse")
+        session.codexPendingTurnKind = .user
+        await controller.test_handleNotification(
+            method: "turn/started",
+            params: lifecycleParams(turnID: "next-turn")
+        )
+        await viewModel.test_codexCoordinator.test_handleCodexNativeEvent(
+            .turnStarted(turnID: "next-turn"),
+            session: session
+        )
+
+        XCTAssertEqual(session.codexAuthoritativeActiveTurn?.turnID, "next-turn")
+        XCTAssertEqual(controller.test_authoritativeLifecycleTurnID, "next-turn")
+        let receipt = try await controller.interruptUserTurn(expectedTurnID: "next-turn")
+        XCTAssertEqual(receipt.interruptedTurnID, "next-turn")
+        XCTAssertEqual(recorder.interruptedTurnIDs, ["next-turn"])
+    }
+
+    func testNoActiveFallbackAcknowledgesQueueThenIdlePumpStartsHead() async throws {
+        let controller = FallbackFIFOController(
+            snapshot: .idle,
+            activeTurnIDs: [],
+            steerResults: [
+                .failure(CodexTurnSteerError.noActiveTurn(
+                    requestFailure(message: "no active turn to steer")
+                ))
+            ]
+        )
+        let (viewModel, session) = makeRunningSession(controller: controller)
+        let attemptID = session.codexSteerAckTracker.beginAttempt()
+        let queueID = UUID()
+        let context = fallbackContext(
+            queueID: queueID,
+            origin: .mcp(attemptID: attemptID),
+            text: "start after idle"
+        )
+
+        let outcome = await viewModel.test_codexCoordinator.sendCodexNativeMessage(
+            session: session,
+            text: context.providerText,
+            attachments: [],
+            fallbackContext: context
+        )
+
+        let ackState = await session.codexSteerAckTracker.awaitTerminalState(
+            attemptID: attemptID
+        )
+        XCTAssertEqual(ackState, .durablyQueued(queueID: queueID))
+        guard case .queuedFallback(queueID: queueID, reason: .noActiveTurn) = outcome else {
+            return XCTFail("Expected typed no-active queue outcome, got \(outcome)")
+        }
+        try await waitUntil {
+            controller.startCount == 1
+                && session.codexFallbackQueue.isEmpty
+                && session.codexFallbackDispatchInFlight?.id == queueID
+        }
+        XCTAssertNil(session.codexAuthoritativeActiveTurn)
+    }
+
+    func testNoActiveFallbackRetriesTransientSnapshotFailure() async throws {
+        let idleSnapshot = CodexNativeSessionController.ThreadSnapshot(
+            conversationID: "thread",
+            rolloutPath: nil,
+            model: nil,
+            reasoningEffort: nil,
+            runtimeStatus: .idle,
+            currentTurnID: nil,
+            activeTurnIDs: [],
+            latestTurnStatus: nil
+        )
+        let controller = FallbackFIFOController(
+            snapshotResults: [
+                .failure(FallbackFIFOTestError.transientSnapshotFailure),
+                .success(idleSnapshot)
+            ],
+            steerResults: [
+                .failure(CodexTurnSteerError.noActiveTurn(
+                    requestFailure(message: "no active turn to steer")
+                ))
+            ]
+        )
+        let (viewModel, session) = makeRunningSession(controller: controller)
+
+        _ = await viewModel.test_codexCoordinator.sendCodexNativeMessage(
+            session: session,
+            text: "retry snapshot",
+            attachments: []
+        )
+
+        try await waitUntil { controller.startCount == 1 }
+        XCTAssertTrue(session.codexFallbackQueue.isEmpty)
+    }
+
+    func testMatchingCompletionAndPublicationDrainExactlyOneThenTailWaitsForSuccessor() async throws {
+        let nonSteerable = CodexTurnSteerError.activeTurnNotSteerable(
+            turnKind: "compact",
+            failure: requestFailure(message: "cannot steer a compact turn")
+        )
+        let controller = FallbackFIFOController(
+            steerResults: [.failure(nonSteerable), .failure(nonSteerable)]
+        )
+        let (viewModel, session) = makeRunningSession(controller: controller)
+
+        _ = await viewModel.test_codexCoordinator.sendCodexNativeMessage(
+            session: session,
+            text: "first",
+            attachments: []
+        )
+        _ = await viewModel.test_codexCoordinator.sendCodexNativeMessage(
+            session: session,
+            text: "second",
+            attachments: []
+        )
+        XCTAssertEqual(session.codexFallbackQueue.count, 2)
+
+        await viewModel.test_codexCoordinator.test_handleCodexNativeEvent(
+            .turnCompleted(turnID: "turn", status: .completed),
+            session: session
+        )
+        try await waitUntil { controller.startCount == 1 }
+        XCTAssertEqual(session.codexFallbackQueue.count, 1)
+        XCTAssertNotNil(session.codexFallbackDispatchInFlight)
+
+        await viewModel.test_codexCoordinator.test_handleCodexNativeEvent(
+            .turnCompleted(turnID: "turn", status: .completed),
+            session: session
+        )
+        XCTAssertEqual(controller.startCount, 1)
+
+        await viewModel.test_codexCoordinator.test_handleCodexNativeEvent(
+            .turnStarted(turnID: "successor-1"),
+            session: session
+        )
+        XCTAssertNil(session.codexFallbackDispatchInFlight)
+        XCTAssertEqual(session.codexFallbackQueue.first?.blockingTurn?.turnID, "successor-1")
+
+        await viewModel.test_codexCoordinator.test_handleCodexNativeEvent(
+            .turnCompleted(turnID: "successor-1", status: .completed),
+            session: session
+        )
+        try await waitUntil { controller.startCount == 2 }
+        XCTAssertTrue(session.codexFallbackQueue.isEmpty)
+    }
+
+    func testPublishedSuccessorClaimsHeadBeforeProviderStartReturns() async throws {
+        let startGate = FallbackStartGate()
+        let nonSteerable = CodexTurnSteerError.activeTurnNotSteerable(
+            turnKind: "compact",
+            failure: requestFailure(message: "cannot steer a compact turn")
+        )
+        let controller = FallbackFIFOController(
+            steerResults: [.failure(nonSteerable), .failure(nonSteerable)],
+            startGate: startGate
+        )
+        let (viewModel, session) = makeRunningSession(controller: controller)
+
+        _ = await viewModel.test_codexCoordinator.sendCodexNativeMessage(
+            session: session,
+            text: "claim before await",
+            attachments: []
+        )
+        _ = await viewModel.test_codexCoordinator.sendCodexNativeMessage(
+            session: session,
+            text: "tail",
+            attachments: []
+        )
+        await viewModel.test_codexCoordinator.test_handleCodexNativeEvent(
+            .turnCompleted(turnID: "turn", status: .completed),
+            session: session
+        )
+
+        try await waitUntil { controller.startCount == 1 }
+        XCTAssertEqual(session.codexFallbackQueue.count, 1)
+        XCTAssertEqual(session.codexFallbackDispatchInFlight?.state, .dispatching)
+
+        await viewModel.test_codexCoordinator.test_handleCodexNativeEvent(
+            .turnStarted(turnID: "successor-before-receipt"),
+            session: session
+        )
+        XCTAssertEqual(session.codexFallbackQueue.first?.blockingTurn?.turnID, "successor-before-receipt")
+
+        await viewModel.test_codexCoordinator.test_handleCodexNativeEvent(
+            .turnCompleted(turnID: "successor-before-receipt", status: .completed),
+            session: session
+        )
+        XCTAssertEqual(controller.startCount, 1)
+
+        await startGate.release()
+        try await waitUntil { controller.startCount == 2 }
+        XCTAssertTrue(session.codexFallbackQueue.isEmpty)
+    }
+
+    func testManualFallbackQueuedDuringDispatchingRebindsToObservedSuccessor() async throws {
+        let startGate = FallbackStartGate()
+        let nonSteerable = CodexTurnSteerError.activeTurnNotSteerable(
+            turnKind: "compact",
+            failure: requestFailure(message: "cannot steer a compact turn")
+        )
+        let controller = FallbackFIFOController(
+            steerResults: [.failure(nonSteerable)],
+            startGate: startGate
+        )
+        let (viewModel, session) = makeRunningSession(controller: controller)
+
+        _ = await viewModel.test_codexCoordinator.sendCodexNativeMessage(
+            session: session,
+            text: "first",
+            attachments: []
+        )
+        await viewModel.test_codexCoordinator.test_handleCodexNativeEvent(
+            .turnCompleted(turnID: "turn", status: .completed),
+            session: session
+        )
+        try await waitUntil {
+            session.codexFallbackDispatchInFlight?.state == .dispatching
+        }
+
+        _ = await viewModel.test_codexCoordinator.sendCodexNativeMessage(
+            session: session,
+            text: "manual during dispatch",
+            attachments: []
+        )
+        XCTAssertEqual(session.codexFallbackQueue.first?.blockingTurn?.turnID, "turn")
+
+        await viewModel.test_codexCoordinator.test_handleCodexNativeEvent(
+            .turnStarted(turnID: "successor-dispatching"),
+            session: session
+        )
+        XCTAssertEqual(session.codexFallbackQueue.first?.blockingTurn?.turnID, "successor-dispatching")
+
+        await startGate.release()
+        await viewModel.test_codexCoordinator.test_handleCodexNativeEvent(
+            .turnCompleted(turnID: "successor-dispatching", status: .completed),
+            session: session
+        )
+        try await waitUntil { controller.startCount == 2 }
+    }
+
+    func testMCPFallbackQueuedWhileAwaitingLifecycleStartRebindsAndDrains() async throws {
+        let startGate = FallbackStartGate()
+        let nonSteerable = CodexTurnSteerError.activeTurnNotSteerable(
+            turnKind: "compact",
+            failure: requestFailure(message: "cannot steer a compact turn")
+        )
+        let controller = FallbackFIFOController(
+            steerResults: [.failure(nonSteerable)],
+            startGate: startGate
+        )
+        let (viewModel, session) = makeRunningSession(controller: controller)
+
+        _ = await viewModel.test_codexCoordinator.sendCodexNativeMessage(
+            session: session,
+            text: "first",
+            attachments: []
+        )
+        await viewModel.test_codexCoordinator.test_handleCodexNativeEvent(
+            .turnCompleted(turnID: "turn", status: .completed),
+            session: session
+        )
+        try await waitUntil { controller.startCount == 1 }
+        await startGate.release()
+        try await waitUntil {
+            session.codexFallbackDispatchInFlight?.state == .awaitingLifecycleStart
+        }
+
+        let attemptID = session.codexSteerAckTracker.beginAttempt()
+        let queueID = UUID()
+        let context = fallbackContext(
+            queueID: queueID,
+            origin: .mcp(attemptID: attemptID),
+            text: "mcp while awaiting lifecycle"
+        )
+        _ = await viewModel.test_codexCoordinator.sendCodexNativeMessage(
+            session: session,
+            text: context.providerText,
+            attachments: [],
+            fallbackContext: context
+        )
+        let terminalState = await session.codexSteerAckTracker.awaitTerminalState(
+            attemptID: attemptID
+        )
+        XCTAssertEqual(terminalState, .durablyQueued(queueID: queueID))
+        XCTAssertEqual(session.codexFallbackQueue.first?.blockingTurn?.turnID, "turn")
+
+        await viewModel.test_codexCoordinator.test_handleCodexNativeEvent(
+            .turnStarted(turnID: "successor-awaiting"),
+            session: session
+        )
+        XCTAssertEqual(session.codexFallbackQueue.first?.blockingTurn?.turnID, "successor-awaiting")
+
+        await viewModel.test_codexCoordinator.test_handleCodexNativeEvent(
+            .turnCompleted(turnID: "successor-awaiting", status: .completed),
+            session: session
+        )
+        try await waitUntil { controller.startCount == 2 }
+    }
+
+    func testRejectedTerminalPublicationRetriesAndThenStartsEligibleSuccessor() async throws {
+        let nonSteerable = CodexTurnSteerError.activeTurnNotSteerable(
+            turnKind: "compact",
+            failure: requestFailure(message: "cannot steer a compact turn")
+        )
+        let controller = FallbackFIFOController(
+            steerResults: [.failure(nonSteerable)]
+        )
+        let (viewModel, session) = makeRunningSession(controller: controller)
+        var publicationAttempts = 0
+        viewModel.test_setTerminalPublicationOverride { _, _, _ in
+            publicationAttempts += 1
+            return publicationAttempts == 1
+                ? .rejected(reason: "transient")
+                : .accepted(successorEpoch: nil)
+        }
+
+        _ = await viewModel.test_codexCoordinator.sendCodexNativeMessage(
+            session: session,
+            text: "publish then retry",
+            attachments: []
+        )
+        await viewModel.test_codexCoordinator.test_handleCodexNativeEvent(
+            .turnCompleted(turnID: "turn", status: .completed),
+            session: session
+        )
+
+        try await waitUntil {
+            publicationAttempts == 2 && controller.startCount == 1
+        }
+        XCTAssertTrue(session.codexFallbackQueue.isEmpty)
+    }
+
+    func testTransientPublicationRetryStopsAndAbandonsQueueWhenMCPControlDeactivates() async throws {
+        let controller = FallbackFIFOController(
+            steerResults: [
+                .failure(CodexTurnSteerError.activeTurnNotSteerable(
+                    turnKind: "compact",
+                    failure: requestFailure(message: "cannot steer a compact turn")
+                ))
+            ]
+        )
+        let (viewModel, session, sessionID) = try await makeMCPRunningSession(controller: controller)
+        var publicationAttempts = 0
+        viewModel.test_setTerminalPublicationOverride { _, _, _ in
+            publicationAttempts += 1
+            return .rejected(reason: "transient")
+        }
+
+        let attemptID = session.codexSteerAckTracker.beginAttempt()
+        let context = fallbackContext(
+            queueID: UUID(),
+            origin: .mcp(attemptID: attemptID),
+            text: "deactivate while retrying"
+        )
+        _ = await viewModel.test_codexCoordinator.sendCodexNativeMessage(
+            session: session,
+            text: context.providerText,
+            attachments: [],
+            fallbackContext: context
+        )
+        await viewModel.test_codexCoordinator.test_handleCodexNativeEvent(
+            .turnCompleted(turnID: "turn", status: .completed),
+            session: session
+        )
+        try await waitUntil {
+            publicationAttempts >= 2 && session.codexFallbackSuccessorRetryTask != nil
+        }
+
+        await viewModel.mcpDeactivateControlContext(
+            sessionID: sessionID,
+            cleanupSessionStore: true
+        )
+        let attemptsAfterDeactivation = publicationAttempts
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        XCTAssertEqual(publicationAttempts, attemptsAfterDeactivation)
+        XCTAssertNil(session.codexFallbackSuccessorRetryTask)
+        XCTAssertTrue(session.codexFallbackQueue.isEmpty)
+        XCTAssertNil(session.codexFallbackDispatchInFlight)
+        XCTAssertNil(session.mcpControlContext)
+        XCTAssertEqual(controller.startCount, 0)
+    }
+
+    func testTransientPublicationRetryStopsAndAbandonsQueueWhenMCPControlIsReplaced() async throws {
+        let controller = FallbackFIFOController(
+            steerResults: [
+                .failure(CodexTurnSteerError.activeTurnNotSteerable(
+                    turnKind: "compact",
+                    failure: requestFailure(message: "cannot steer a compact turn")
+                ))
+            ]
+        )
+        let (viewModel, session, sessionID) = try await makeMCPRunningSession(controller: controller)
+        let originalActivationID = try XCTUnwrap(session.mcpControlContext?.activationID)
+        var publicationAttempts = 0
+        viewModel.test_setTerminalPublicationOverride { _, _, _ in
+            publicationAttempts += 1
+            return .rejected(reason: "transient")
+        }
+
+        _ = await viewModel.test_codexCoordinator.sendCodexNativeMessage(
+            session: session,
+            text: "replace while retrying",
+            attachments: []
+        )
+        await viewModel.test_codexCoordinator.test_handleCodexNativeEvent(
+            .turnCompleted(turnID: "turn", status: .completed),
+            session: session
+        )
+        try await waitUntil {
+            publicationAttempts >= 2 && session.codexFallbackSuccessorRetryTask != nil
+        }
+
+        try await viewModel.mcpActivateControlContext(
+            forTabID: session.tabID,
+            sessionID: sessionID,
+            originatingConnectionID: nil
+        )
+        let attemptsAfterReplacement = publicationAttempts
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        XCTAssertNotEqual(session.mcpControlContext?.activationID, originalActivationID)
+        XCTAssertEqual(publicationAttempts, attemptsAfterReplacement)
+        XCTAssertNil(session.codexFallbackSuccessorRetryTask)
+        XCTAssertTrue(session.codexFallbackQueue.isEmpty)
+        XCTAssertNil(session.codexFallbackDispatchInFlight)
+        XCTAssertEqual(controller.startCount, 0)
+        await viewModel.mcpDeactivateControlContext(
+            sessionID: sessionID,
+            cleanupSessionStore: true
+        )
+    }
+
+    func testMissingTerminalPublicationEnvelopePermanentlyAbandonsEligibleQueue() async throws {
+        let controller = FallbackFIFOController(
+            steerResults: [
+                .failure(CodexTurnSteerError.activeTurnNotSteerable(
+                    turnKind: "compact",
+                    failure: requestFailure(message: "cannot steer a compact turn")
+                ))
+            ]
+        )
+        let (viewModel, session, sessionID) = try await makeMCPRunningSession(
+            controller: controller,
+            prepareEpoch: false
+        )
+
+        let attemptID = session.codexSteerAckTracker.beginAttempt()
+        let context = fallbackContext(
+            queueID: UUID(),
+            origin: .mcp(attemptID: attemptID),
+            text: "missing envelope"
+        )
+        _ = await viewModel.test_codexCoordinator.sendCodexNativeMessage(
+            session: session,
+            text: context.providerText,
+            attachments: [],
+            fallbackContext: context
+        )
+        await viewModel.test_codexCoordinator.test_handleCodexNativeEvent(
+            .turnCompleted(turnID: "turn", status: .completed),
+            session: session
+        )
+
+        XCTAssertEqual(
+            session.lastTerminalPublicationResult,
+            .rejected(reason: "missing_terminal_publication_envelope")
+        )
+        XCTAssertNil(session.codexFallbackSuccessorRetryTask)
+        XCTAssertTrue(session.codexFallbackQueue.isEmpty)
+        XCTAssertNil(session.codexFallbackDispatchInFlight)
+        XCTAssertEqual(controller.startCount, 0)
+        await viewModel.mcpDeactivateControlContext(
+            sessionID: sessionID,
+            cleanupSessionStore: true
+        )
+    }
+
+    func testNilCompletionDoesNotDrainAndFailedCompletionAbandonsBlockedHead() async throws {
+        let controller = FallbackFIFOController(
+            steerResults: [
+                .failure(CodexTurnSteerError.activeTurnNotSteerable(
+                    turnKind: "review",
+                    failure: requestFailure(message: "cannot steer a review turn")
+                ))
+            ]
+        )
+        let (nilViewModel, nilSession) = makeRunningSession(controller: controller)
+        _ = await nilViewModel.test_codexCoordinator.sendCodexNativeMessage(
+            session: nilSession,
+            text: "nil completion",
+            attachments: []
+        )
+
+        await nilViewModel.test_codexCoordinator.test_handleCodexNativeEvent(
+            .turnCompleted(turnID: nil, status: .completed),
+            session: nilSession
+        )
+        XCTAssertEqual(controller.startCount, 0)
+        XCTAssertEqual(nilSession.codexFallbackQueue.count, 1)
+        XCTAssertEqual(nilSession.runState, .running)
+        XCTAssertEqual(nilSession.codexAuthoritativeActiveTurn?.turnID, "turn")
+
+        await nilViewModel.test_codexCoordinator.test_handleCodexNativeEvent(
+            .turnCompleted(turnID: "turn", status: .completed),
+            session: nilSession
+        )
+        try await waitUntil { controller.startCount == 1 }
+        XCTAssertTrue(nilSession.codexFallbackQueue.isEmpty)
+
+        let failedController = FallbackFIFOController(
+            steerResults: [
+                .failure(CodexTurnSteerError.activeTurnNotSteerable(
+                    turnKind: "review",
+                    failure: requestFailure(message: "cannot steer a review turn")
+                )),
+                .failure(CodexTurnSteerError.activeTurnNotSteerable(
+                    turnKind: "review",
+                    failure: requestFailure(message: "cannot steer a review turn")
+                ))
+            ]
+        )
+        let (failedViewModel, failedSession) = makeRunningSession(controller: failedController)
+        _ = await failedViewModel.test_codexCoordinator.sendCodexNativeMessage(
+            session: failedSession,
+            text: "failed completion",
+            attachments: []
+        )
+        _ = await failedViewModel.test_codexCoordinator.sendCodexNativeMessage(
+            session: failedSession,
+            text: "failed completion tail",
+            attachments: []
+        )
+        XCTAssertEqual(failedSession.codexFallbackQueue.count, 2)
+
+        await failedViewModel.test_codexCoordinator.test_handleCodexNativeEvent(
+            .turnCompleted(turnID: "turn", status: .failed),
+            session: failedSession
+        )
+        XCTAssertEqual(failedController.startCount, 0)
+        XCTAssertTrue(failedSession.codexFallbackQueue.isEmpty)
+    }
+
+    func testManualFallbackKeepsSingleOptimisticBubbleAndDoesNotRestoreDraft() async throws {
+        let controller = FallbackFIFOController(
+            steerResults: [
+                .failure(CodexTurnSteerError.activeTurnNotSteerable(
+                    turnKind: "review",
+                    failure: requestFailure(message: "cannot steer a review turn")
+                ))
+            ]
+        )
+        let (viewModel, session) = makeRunningSession(controller: controller)
+        viewModel.storeDraftText(for: session.tabID, "queued manual")
+        let userItem = AgentChatItem.user(
+            "queued manual",
+            sequenceIndex: session.nextSequenceIndex
+        )
+        session.appendItem(userItem)
+        let context = AgentModeViewModel.TabSession.CodexFallbackSubmissionContext(
+            queueID: UUID(),
+            providerText: "queued manual",
+            images: [],
+            taggedFileAttachments: [],
+            draftText: "queued manual",
+            optimisticUserItemID: userItem.id,
+            origin: .manual,
+            dispatchTicket: nil
+        )
+
+        _ = await viewModel.test_codexCoordinator.sendCodexNativeMessage(
+            session: session,
+            text: "queued manual",
+            attachments: [],
+            fallbackContext: context
+        )
+
+        XCTAssertEqual(session.items.filter { $0.kind == .user }.map(\.text), ["queued manual"])
+        XCTAssertEqual(viewModel.retrieveDraftText(for: session.tabID), "queued manual")
+
+        await viewModel.test_codexCoordinator.test_handleCodexNativeEvent(
+            .turnCompleted(turnID: "turn", status: .completed),
+            session: session
+        )
+        try await waitUntil { controller.startCount == 1 }
+        XCTAssertEqual(session.items.filter { $0.kind == .user }.map(\.text), ["queued manual"])
+    }
+
+    func testClearChatDiscardsFallbackInputWithoutReversingDeliveryAcknowledgement() async {
+        let controller = FallbackFIFOController(
+            steerResults: [
+                .failure(CodexTurnSteerError.activeTurnNotSteerable(
+                    turnKind: "review",
+                    failure: requestFailure(message: "cannot steer a review turn")
+                ))
+            ]
+        )
+        let (viewModel, session) = makeRunningSession(controller: controller)
+        let attemptID = session.codexSteerAckTracker.beginAttempt()
+        let queueID = UUID()
+        let context = fallbackContext(
+            queueID: queueID,
+            origin: .mcp(attemptID: attemptID),
+            text: "discarded queued input"
+        )
+
+        _ = await viewModel.test_codexCoordinator.sendCodexNativeMessage(
+            session: session,
+            text: "discarded queued input",
+            attachments: [],
+            fallbackContext: context
+        )
+        XCTAssertEqual(session.codexFallbackQueue.count, 1)
+
+        viewModel.clearChat(tabID: session.tabID)
+
+        let terminalState = await session.codexSteerAckTracker.awaitTerminalState(
+            attemptID: attemptID,
+            timeoutSeconds: 0.1
+        )
+        XCTAssertEqual(terminalState, .durablyQueued(queueID: queueID))
+        XCTAssertTrue(session.codexFallbackQueue.isEmpty)
+        XCTAssertNil(session.codexFallbackDispatchInFlight)
+        XCTAssertTrue(session.items.isEmpty)
+        XCTAssertNil(viewModel.draftRestorationEvent)
+    }
+
+    private func makeRunningSession(
+        controller: any CodexSessionControlling
+    ) -> (AgentModeViewModel, AgentModeViewModel.TabSession) {
+        let viewModel = AgentModeViewModel(
+            codexControllerFactory: { _, _, _, _, _, _ in controller }
+        )
+        viewModel.test_initializeRunService()
+        let session = viewModel.session(for: UUID())
+        let runID = UUID()
+        session.selectedAgent = .codexExec
+        session.runID = runID
+        session.runState = .running
+        session.beginRunAttempt(source: "test.codexFallback")
+        session.codexController = controller
+        session.codexConversationID = "thread"
+        session.codexAuthoritativeActiveTurn = .init(
+            threadID: "thread",
+            turnID: "turn",
+            turnKind: .user,
+            controllerInstanceID: ObjectIdentifier(controller),
+            controllerGeneration: session.codexControllerGeneration,
+            runID: runID,
+            runAttemptID: session.activeRunAttemptID!
+        )
+        session.codexRoutingObservedTurnID = "turn"
+        session.codexControllerGoalSupportEnabled = CodexGoalSupport.isEnabled
+        return (viewModel, session)
+    }
+
+    private func makeMCPRunningSession(
+        controller: any CodexSessionControlling,
+        prepareEpoch: Bool = true
+    ) async throws -> (AgentModeViewModel, AgentModeViewModel.TabSession, UUID) {
+        let viewModel = AgentModeViewModel(
+            codexControllerFactory: { _, _, _, _, _, _ in controller }
+        )
+        viewModel.test_initializeRunService()
+        let sessionID = UUID()
+        let session = await viewModel.ensureSessionReady(tabID: UUID())
+        _ = viewModel.test_installPersistentSessionBinding(sessionID: sessionID, on: session)
+        try await viewModel.mcpActivateControlContext(
+            forTabID: session.tabID,
+            sessionID: sessionID,
+            originatingConnectionID: nil,
+            startPending: true
+        )
+        if prepareEpoch {
+            await viewModel.prepareMCPWaitTrackingForRunStart(session: session)
+        }
+        let runID = UUID()
+        session.selectedAgent = .codexExec
+        session.runID = runID
+        session.runState = .running
+        session.beginRunAttempt(source: "test.codexFallback.mcp")
+        session.codexController = controller
+        session.codexConversationID = "thread"
+        session.codexAuthoritativeActiveTurn = .init(
+            threadID: "thread",
+            turnID: "turn",
+            turnKind: .user,
+            controllerInstanceID: ObjectIdentifier(controller),
+            controllerGeneration: session.codexControllerGeneration,
+            runID: runID,
+            runAttemptID: session.activeRunAttemptID!
+        )
+        session.codexRoutingObservedTurnID = "turn"
+        session.codexControllerGoalSupportEnabled = CodexGoalSupport.isEnabled
+        return (viewModel, session, sessionID)
+    }
+
+    private func makeNativeController(
+        recorder: MismatchRetryNativeControllerRecorder
+    ) -> CodexNativeSessionController {
+        CodexNativeSessionController(
+            client: CodexAppServerClient(),
+            runID: UUID(),
+            tabID: UUID(),
+            windowID: 1,
+            workspacePath: "/tmp/workspace",
+            requestExecutor: { method, params, timeout in
+                try recorder.handle(method: method, params: params, timeout: timeout)
+            }
+        )
+    }
+
+    private func lifecycleParams(
+        turnID: String,
+        status: String? = nil
+    ) -> [String: CodexJSONValue] {
+        var turn: [String: CodexJSONValue] = ["id": .string(turnID)]
+        if let status {
+            turn["status"] = .string(status)
+        }
+        return [
+            "threadId": .string("thread"),
+            "turn": .object(turn)
+        ]
+    }
+
+    private func fallbackContext(
+        queueID: UUID,
+        origin: AgentModeViewModel.TabSession.CodexFallbackOrigin,
+        text: String
+    ) -> AgentModeViewModel.TabSession.CodexFallbackSubmissionContext {
+        .init(
+            queueID: queueID,
+            providerText: text,
+            images: [],
+            taggedFileAttachments: [],
+            draftText: text,
+            optimisticUserItemID: nil,
+            origin: origin,
+            dispatchTicket: nil
+        )
+    }
+
+    private func requestFailure(
+        message: String,
+        data: CodexJSONValue? = nil
+    ) -> CodexAppServerClient.RequestFailure {
+        .init(method: "turn/steer", code: -32602, message: message, data: data)
+    }
+
+    private func waitUntil(
+        timeout: TimeInterval = 2,
+        _ predicate: @escaping () -> Bool
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if predicate() { return }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTFail("Timed out waiting for Codex fallback FIFO state")
+    }
+}
+
+private final class FallbackFIFOController: CodexSessionControlling {
+    private let snapshot: CodexNativeSessionController.ThreadSnapshot.RuntimeStatus
+    private let activeTurnIDs: [String]
+    private var snapshotResults: [Result<CodexNativeSessionController.ThreadSnapshot, Error>]
+    private var steerResults: [Result<CodexTurnSteerReceipt, Error>]
+    private let startGate: FallbackStartGate?
+
+    private(set) var steerTurnIDs: [String] = []
+    private(set) var startCount = 0
+    private(set) var hasActiveThread = true
+
+    init(
+        snapshot: CodexNativeSessionController.ThreadSnapshot.RuntimeStatus = .active(activeFlags: []),
+        activeTurnIDs: [String] = ["turn"],
+        snapshotResults: [Result<CodexNativeSessionController.ThreadSnapshot, Error>] = [],
+        steerResults: [Result<CodexTurnSteerReceipt, Error>],
+        startGate: FallbackStartGate? = nil
+    ) {
+        self.snapshot = snapshot
+        self.activeTurnIDs = activeTurnIDs
+        self.snapshotResults = snapshotResults
+        self.steerResults = steerResults
+        self.startGate = startGate
+    }
+
+    var events: AsyncStream<CodexNativeSessionController.Event> {
+        AsyncStream { _ in }
+    }
+
+    func ensureEventsStreamReady() {}
+
+    func startOrResume(
+        existing: CodexNativeSessionController.SessionRef?,
+        baseInstructions: String
+    ) async throws -> CodexNativeSessionController.SessionRef {
+        try await startOrResume(
+            existing: existing,
+            baseInstructions: baseInstructions,
+            model: nil,
+            reasoningEffort: nil,
+            serviceTier: nil
+        )
+    }
+
+    func startOrResume(
+        existing: CodexNativeSessionController.SessionRef?,
+        baseInstructions: String,
+        model: String?,
+        reasoningEffort: String?
+    ) async throws -> CodexNativeSessionController.SessionRef {
+        try await startOrResume(
+            existing: existing,
+            baseInstructions: baseInstructions,
+            model: model,
+            reasoningEffort: reasoningEffort,
+            serviceTier: nil
+        )
+    }
+
+    func startOrResume(
+        existing _: CodexNativeSessionController.SessionRef?,
+        baseInstructions _: String,
+        model: String?,
+        reasoningEffort: String?,
+        serviceTier _: String?
+    ) async throws -> CodexNativeSessionController.SessionRef {
+        .init(
+            conversationID: "thread",
+            rolloutPath: nil,
+            model: model,
+            reasoningEffort: reasoningEffort
+        )
+    }
+
+    func readThreadSnapshot(
+        includeTurns _: Bool,
+        timeout _: TimeInterval?
+    ) async throws -> CodexNativeSessionController.ThreadSnapshot {
+        if !snapshotResults.isEmpty {
+            return try snapshotResults.removeFirst().get()
+        }
+        return .init(
+            conversationID: "thread",
+            rolloutPath: nil,
+            model: nil,
+            reasoningEffort: nil,
+            runtimeStatus: snapshot,
+            currentTurnID: activeTurnIDs.first,
+            activeTurnIDs: activeTurnIDs,
+            latestTurnStatus: nil
+        )
+    }
+
+    func startUserTurn(
+        text _: String,
+        images _: [AgentImageAttachment],
+        model _: String?,
+        reasoningEffort _: String?,
+        serviceTier _: String?
+    ) async throws -> CodexTurnStartReceipt {
+        startCount += 1
+        await startGate?.wait()
+        return .init(provisionalSubmissionID: "submission-\(startCount)")
+    }
+
+    func steerUserTurn(
+        text _: String,
+        images _: [AgentImageAttachment],
+        expectedTurnID: String
+    ) async throws -> CodexTurnSteerReceipt {
+        steerTurnIDs.append(expectedTurnID)
+        guard !steerResults.isEmpty else {
+            return .init(acceptedTurnID: expectedTurnID)
+        }
+        return try steerResults.removeFirst().get()
+    }
+
+    func interruptUserTurn(expectedTurnID: String) async throws -> CodexTurnInterruptReceipt {
+        .init(interruptedTurnID: expectedTurnID)
+    }
+
+    func compactThread() async throws {}
+    func getThreadGoal() async throws -> CodexNativeSessionController.ThreadGoal? {
+        nil
+    }
+
+    func setThreadGoalObjective(_: String) async throws -> CodexNativeSessionController.ThreadGoal {
+        throw CancellationError()
+    }
+
+    func setThreadGoalStatus(
+        _: CodexNativeSessionController.ThreadGoalStatus
+    ) async throws -> CodexNativeSessionController.ThreadGoal {
+        throw CancellationError()
+    }
+
+    func clearThreadGoal() async throws -> Bool {
+        false
+    }
+
+    func cancelCurrentTurn() async {}
+    func shutdown() async {}
+    func respondToServerRequest(id _: CodexAppServerRequestID, result _: [String: Any]) async {}
+}
+
+private enum FallbackFIFOTestError: Error {
+    case transientSnapshotFailure
+}
+
+private final class MismatchRetryNativeControllerRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var steerAttemptCount = 0
+    private var recordedInterruptedTurnIDs: [String] = []
+
+    var interruptedTurnIDs: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return recordedInterruptedTurnIDs
+    }
+
+    func handle(
+        method: String,
+        params: [String: Any]?,
+        timeout _: TimeInterval?
+    ) throws -> [String: Any] {
+        lock.lock()
+        defer { lock.unlock() }
+        switch method {
+        case "turn/steer":
+            steerAttemptCount += 1
+            if steerAttemptCount == 1 {
+                let failure = CodexAppServerClient.RequestFailure(
+                    method: method,
+                    code: -32602,
+                    message: "expected active turn id `turn` but found `actual-turn`",
+                    data: .object(["actualTurnId": .string("actual-turn")])
+                )
+                throw CodexAppServerClient.ClientError.requestFailed(failure)
+            }
+            return ["turnId": params?["expectedTurnId"] as? String ?? ""]
+        case "turn/interrupt":
+            if let turnID = params?["turnId"] as? String {
+                recordedInterruptedTurnIDs.append(turnID)
+            }
+            return [:]
+        default:
+            return [:]
+        }
+    }
+}
+
+private actor FallbackStartGate {
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var released = false
+
+    func wait() async {
+        guard !released else { return }
+        await withCheckedContinuation { continuation = $0 }
+    }
+
+    func release() {
+        released = true
+        continuation?.resume()
+        continuation = nil
+    }
+}

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexSteerAckTrackerTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexSteerAckTrackerTests.swift
@@ -1,0 +1,350 @@
+@testable import RepoPrompt
+import XCTest
+
+@MainActor
+final class CodexSteerAckTrackerTests: XCTestCase {
+    func testOverlappingAttemptsAuthorizeAndResolveIndependently() async {
+        let tracker = CodexSteerAckTracker()
+        let first = tracker.beginAttempt()
+        let second = tracker.beginAttempt()
+
+        let firstDispatch = Task { await tracker.awaitDispatchAuthorization(attemptID: first) }
+        let secondDispatch = Task { await tracker.awaitDispatchAuthorization(attemptID: second) }
+        tracker.authorizeDispatch(attemptID: second)
+
+        let secondAuthorized = await secondDispatch.value
+        XCTAssertTrue(secondAuthorized)
+        XCTAssertFalse(firstDispatch.isCancelled)
+
+        tracker.resolve(attemptID: second, state: .durablyQueued(queueID: UUID()))
+        tracker.authorizeDispatch(attemptID: first)
+        tracker.resolve(attemptID: first, state: .steerAccepted)
+
+        let firstAuthorized = await firstDispatch.value
+        let firstState = await tracker.awaitTerminalState(attemptID: first)
+        let secondState = await tracker.awaitTerminalState(attemptID: second)
+        XCTAssertTrue(firstAuthorized)
+        XCTAssertEqual(firstState, .steerAccepted)
+        guard case .durablyQueued = secondState else {
+            return XCTFail("Expected the second attempt to retain its own queued resolution")
+        }
+    }
+
+    func testTimeoutTombstoneIgnoresLateResolution() async {
+        let tracker = CodexSteerAckTracker()
+        let attemptID = tracker.beginAttempt()
+        tracker.authorizeDispatch(attemptID: attemptID)
+
+        let result = await tracker.awaitTerminalState(
+            attemptID: attemptID,
+            timeoutSeconds: 0.1
+        )
+        XCTAssertEqual(result, .timedOut)
+
+        tracker.resolve(attemptID: attemptID, state: .steerAccepted)
+        let lateState = await tracker.awaitTerminalState(attemptID: attemptID)
+        XCTAssertEqual(lateState, .timedOut)
+    }
+
+    func testCancellationUnblocksDispatchAndTombstonesAttempt() async {
+        let tracker = CodexSteerAckTracker()
+        let attemptID = tracker.beginAttempt()
+        let dispatch = Task { await tracker.awaitDispatchAuthorization(attemptID: attemptID) }
+
+        tracker.cancel(attemptID: attemptID)
+
+        let authorized = await dispatch.value
+        let cancelledState = await tracker.awaitTerminalState(attemptID: attemptID)
+        XCTAssertFalse(authorized)
+        XCTAssertEqual(cancelledState, .cancelled)
+        tracker.resolve(attemptID: attemptID, state: .startAccepted)
+        let lateState = await tracker.awaitTerminalState(attemptID: attemptID)
+        XCTAssertEqual(lateState, .cancelled)
+    }
+
+    func testCancellingAwaitTombstonesOnlyMatchingAttemptAndIgnoresLateResolution() async {
+        let tracker = CodexSteerAckTracker()
+        let cancelledAttempt = tracker.beginAttempt()
+        let survivingAttempt = tracker.beginAttempt()
+
+        let cancelledWait = Task {
+            await tracker.awaitTerminalState(
+                attemptID: cancelledAttempt,
+                timeoutSeconds: 10
+            )
+        }
+        let survivingWait = Task {
+            await tracker.awaitTerminalState(
+                attemptID: survivingAttempt,
+                timeoutSeconds: 10
+            )
+        }
+        await Task.yield()
+        cancelledWait.cancel()
+
+        let cancelledState = await cancelledWait.value
+        XCTAssertEqual(cancelledState, .cancelled)
+        tracker.resolve(attemptID: cancelledAttempt, state: .steerAccepted)
+        tracker.resolve(attemptID: survivingAttempt, state: .startAccepted)
+
+        let lateCancelledState = await tracker.awaitTerminalState(
+            attemptID: cancelledAttempt
+        )
+        let survivingState = await survivingWait.value
+        XCTAssertEqual(lateCancelledState, .cancelled)
+        XCTAssertEqual(survivingState, .startAccepted)
+    }
+
+    func testCancellingMCPDispatchTombstonesItsAttemptBeforeLateProviderAcceptance() async throws {
+        let gate = AckTrackerSteerGate()
+        let controller = AckTrackerCodexController(gate: gate)
+        let viewModel = AgentModeViewModel(
+            codexControllerFactory: { _, _, _, _, _, _ in controller }
+        )
+        viewModel.test_initializeRunService()
+        let tabID = UUID()
+        let sessionID = UUID()
+        let session = viewModel.session(for: tabID)
+        let runID = UUID()
+        session.testInstallPersistentSessionBinding(sessionID: sessionID)
+        session.hasLoadedPersistedState = true
+        let registration = await AgentRunSessionStore.register(sessionID: sessionID)
+        defer {
+            Task {
+                await AgentRunSessionStore.cleanup(registration: registration)
+            }
+        }
+        session.mcpControlContext = .init(
+            sessionID: sessionID,
+            activationID: UUID(),
+            registration: registration,
+            currentEpoch: nil,
+            preparedEpoch: nil,
+            pendingEpochTransition: nil,
+            originatingConnectionID: nil,
+            interactionTransport: .mcp(
+                sessionID: sessionID,
+                originatingConnectionID: nil
+            ),
+            suppressUserNotifications: true,
+            forceAutoEditEnabled: false,
+            autoEditEnabledBeforeOverride: true,
+            taskLabelKind: nil
+        )
+        viewModel.test_setMCPControlledTabIDs([tabID])
+        session.selectedAgent = .codexExec
+        session.runID = runID
+        session.runState = .running
+        session.beginRunAttempt(source: "test.mcpAckCancellation")
+        session.codexController = controller
+        session.codexConversationID = "thread"
+        session.codexAuthoritativeActiveTurn = try .init(
+            threadID: "thread",
+            turnID: "turn",
+            turnKind: .user,
+            controllerInstanceID: ObjectIdentifier(controller),
+            controllerGeneration: session.codexControllerGeneration,
+            runID: runID,
+            runAttemptID: XCTUnwrap(session.activeRunAttemptID)
+        )
+        session.codexRoutingObservedTurnID = "turn"
+        session.codexControllerGoalSupportEnabled = CodexGoalSupport.isEnabled
+        controller.onEnsureEventsStreamReady = { [weak session, weak controller] in
+            guard let session, let controller,
+                  let runID = session.runID,
+                  let runAttemptID = session.activeRunAttemptID
+            else { return }
+            session.codexAuthoritativeActiveTurn = .init(
+                threadID: "thread",
+                turnID: "turn",
+                turnKind: .user,
+                controllerInstanceID: ObjectIdentifier(controller),
+                controllerGeneration: session.codexControllerGeneration,
+                runID: runID,
+                runAttemptID: runAttemptID
+            )
+            session.codexRoutingObservedTurnID = "turn"
+        }
+
+        let dispatch = Task {
+            try await viewModel.mcpDispatchInstruction(
+                sessionID: sessionID,
+                text: "cancel this dispatch",
+                allowStartingRun: false
+            )
+        }
+        guard await gate.waitUntilStarted() else {
+            dispatch.cancel()
+            do {
+                let result = try await dispatch.value
+                return XCTFail(
+                    """
+                    MCP dispatch completed before provider steering: \(result); \
+                    fallback=\(String(describing: session.codexFallbackQueue.first?.fallbackReason)); \
+                    authority=\(String(describing: session.codexAuthoritativeActiveTurn)); \
+                    runState=\(session.runState); runAttempt=\(String(describing: session.activeRunAttemptID))
+                    """
+                )
+            } catch {
+                return XCTFail("MCP dispatch failed before provider steering: \(error)")
+            }
+        }
+        let attemptID = try XCTUnwrap(session.codexSteerAckTracker.test_latestAttemptID)
+
+        dispatch.cancel()
+        do {
+            _ = try await dispatch.value
+            XCTFail("Expected MCP dispatch cancellation")
+        } catch is CancellationError {
+            // Expected.
+        } catch {
+            XCTFail("Expected CancellationError, got \(error)")
+        }
+        let cancelledState = await session.codexSteerAckTracker.awaitTerminalState(
+            attemptID: attemptID
+        )
+        XCTAssertEqual(cancelledState, .cancelled)
+
+        await gate.release()
+        let providerCompleted = await gate.waitUntilCompleted()
+        XCTAssertTrue(providerCompleted)
+        let lateState = await session.codexSteerAckTracker.awaitTerminalState(
+            attemptID: attemptID
+        )
+        XCTAssertEqual(lateState, .cancelled)
+    }
+
+    func testSerialDispatchGatePreservesIssuedOrderAcrossSuspension() async {
+        let gate = AgentModeViewModel.TabSession.CodexDispatchSerialGate()
+        let first = gate.issueTicket()
+        let second = gate.issueTicket()
+        let firstEntered = await gate.awaitTurn(first)
+        XCTAssertTrue(firstEntered)
+
+        var secondEntered = false
+        let secondTask = Task { @MainActor in
+            guard await gate.awaitTurn(second) else { return }
+            secondEntered = true
+        }
+        await Task.yield()
+        XCTAssertFalse(secondEntered)
+
+        gate.finish(first)
+        _ = await secondTask.value
+        XCTAssertTrue(secondEntered)
+        gate.finish(second)
+    }
+}
+
+private final class AckTrackerCodexController: CodexSessionControlling {
+    private let gate: AckTrackerSteerGate
+    private(set) var hasActiveThread = true
+    var onEnsureEventsStreamReady: (() -> Void)?
+
+    init(gate: AckTrackerSteerGate) {
+        self.gate = gate
+    }
+
+    var events: AsyncStream<CodexNativeSessionController.Event> {
+        AsyncStream { _ in }
+    }
+
+    func ensureEventsStreamReady() {
+        MainActor.assumeIsolated {
+            onEnsureEventsStreamReady?()
+        }
+    }
+
+    func startOrResume(
+        existing _: CodexNativeSessionController.SessionRef?,
+        baseInstructions _: String
+    ) async throws -> CodexNativeSessionController.SessionRef {
+        .init(
+            conversationID: "thread",
+            rolloutPath: nil,
+            model: nil,
+            reasoningEffort: nil
+        )
+    }
+
+    func startUserTurn(
+        text _: String,
+        images _: [AgentImageAttachment],
+        model _: String?,
+        reasoningEffort _: String?,
+        serviceTier _: String?
+    ) async throws -> CodexTurnStartReceipt {
+        .init(provisionalSubmissionID: "submission")
+    }
+
+    func steerUserTurn(
+        text _: String,
+        images _: [AgentImageAttachment],
+        expectedTurnID: String
+    ) async throws -> CodexTurnSteerReceipt {
+        await gate.block()
+        return .init(acceptedTurnID: expectedTurnID)
+    }
+
+    func interruptUserTurn(expectedTurnID: String) async throws -> CodexTurnInterruptReceipt {
+        .init(interruptedTurnID: expectedTurnID)
+    }
+
+    func compactThread() async throws {}
+    func getThreadGoal() async throws -> CodexNativeSessionController.ThreadGoal? {
+        nil
+    }
+
+    func setThreadGoalObjective(_: String) async throws -> CodexNativeSessionController.ThreadGoal {
+        throw CancellationError()
+    }
+
+    func setThreadGoalStatus(
+        _: CodexNativeSessionController.ThreadGoalStatus
+    ) async throws -> CodexNativeSessionController.ThreadGoal {
+        throw CancellationError()
+    }
+
+    func clearThreadGoal() async throws -> Bool {
+        false
+    }
+
+    func cancelCurrentTurn() async {}
+    func shutdown() async {}
+    func respondToServerRequest(id _: CodexAppServerRequestID, result _: [String: Any]) async {}
+}
+
+private actor AckTrackerSteerGate {
+    private var started = false
+    private var completed = false
+    private var releaseContinuation: CheckedContinuation<Void, Never>?
+
+    func block() async {
+        started = true
+        await withCheckedContinuation { continuation in
+            releaseContinuation = continuation
+        }
+        completed = true
+    }
+
+    func waitUntilStarted() async -> Bool {
+        for _ in 0 ..< 500 {
+            if started { return true }
+            try? await Task.sleep(nanoseconds: 1_000_000)
+        }
+        return started
+    }
+
+    func release() {
+        releaseContinuation?.resume()
+        releaseContinuation = nil
+    }
+
+    func waitUntilCompleted() async -> Bool {
+        for _ in 0 ..< 500 {
+            if completed { return true }
+            try? await Task.sleep(nanoseconds: 1_000_000)
+        }
+        return completed
+    }
+}

--- a/Tests/RepoPromptTests/AgentMode/Transcript/AgentTranscriptCrawlRefreshBenchmarkTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Transcript/AgentTranscriptCrawlRefreshBenchmarkTests.swift
@@ -674,7 +674,7 @@
         }
     }
 
-    private final class CrawlRefreshFakeCodexController: CodexSessionControlling {
+    private final class CrawlRefreshFakeCodexController: CodexSessionControllerTurnDispatchTestDefaults {
         var hasActiveThread = false
         var events: AsyncStream<CodexNativeSessionController.Event> {
             AsyncStream { continuation in continuation.finish() }
@@ -711,10 +711,6 @@
         }
 
         func setThreadName(_: String, threadID _: String?) async throws {}
-        func sendUserMessage(_: String) async throws {}
-        func sendUserTurn(text _: String, images _: [AgentImageAttachment]) async throws {}
-        func sendUserTurn(text _: String, images _: [AgentImageAttachment], model _: String?, reasoningEffort _: String?) async throws {}
-        func sendUserTurn(text _: String, images _: [AgentImageAttachment], model _: String?, reasoningEffort _: String?, serviceTier _: String?) async throws {}
         func compactThread() async throws {}
         func getThreadGoal() async throws -> CodexNativeSessionController.ThreadGoal? {
             nil

--- a/Tests/RepoPromptTests/AgentMode/WorkspaceSwitchCleanupTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/WorkspaceSwitchCleanupTests.swift
@@ -207,7 +207,7 @@ private final class RoutingRecorder: @unchecked Sendable {
     }
 }
 
-private final class FakeCodexSessionController: CodexSessionControlling {
+private final class FakeCodexSessionController: CodexSessionControllerTurnDispatchTestDefaults {
     var hasActiveThread: Bool {
         false
     }
@@ -261,10 +261,6 @@ private final class FakeCodexSessionController: CodexSessionControlling {
     }
 
     func setThreadName(_ name: String, threadID: String?) async throws {}
-    func sendUserMessage(_ text: String) async throws {}
-    func sendUserTurn(text: String, images: [AgentImageAttachment]) async throws {}
-    func sendUserTurn(text: String, images: [AgentImageAttachment], model: String?, reasoningEffort: String?) async throws {}
-    func sendUserTurn(text: String, images: [AgentImageAttachment], model: String?, reasoningEffort: String?, serviceTier: String?) async throws {}
     func compactThread() async throws {}
     func getThreadGoal() async throws -> CodexNativeSessionController.ThreadGoal? {
         nil

--- a/Tests/RepoPromptTests/Helpers/CodexSessionControllerTestDefaults.swift
+++ b/Tests/RepoPromptTests/Helpers/CodexSessionControllerTestDefaults.swift
@@ -1,0 +1,27 @@
+@testable import RepoPrompt
+
+protocol CodexSessionControllerTurnDispatchTestDefaults: CodexSessionControlling {}
+
+extension CodexSessionControllerTurnDispatchTestDefaults {
+    func startUserTurn(
+        text _: String,
+        images _: [AgentImageAttachment],
+        model _: String?,
+        reasoningEffort _: String?,
+        serviceTier _: String?
+    ) async throws -> CodexTurnStartReceipt {
+        CodexTurnStartReceipt(provisionalSubmissionID: "<test-submission>")
+    }
+
+    func steerUserTurn(
+        text _: String,
+        images _: [AgentImageAttachment],
+        expectedTurnID: String
+    ) async throws -> CodexTurnSteerReceipt {
+        CodexTurnSteerReceipt(acceptedTurnID: expectedTurnID)
+    }
+
+    func interruptUserTurn(expectedTurnID: String) async throws -> CodexTurnInterruptReceipt {
+        CodexTurnInterruptReceipt(interruptedTurnID: expectedTurnID)
+    }
+}

--- a/Tests/RepoPromptTests/MCP/AgentRunMCPToolServiceWaitTests.swift
+++ b/Tests/RepoPromptTests/MCP/AgentRunMCPToolServiceWaitTests.swift
@@ -469,7 +469,7 @@ private actor LiveSnapshots {
     }
 }
 
-private final class WaitTestCodexController: CodexSessionControlling {
+private final class WaitTestCodexController: CodexSessionControllerTurnDispatchTestDefaults {
     var hasActiveThread: Bool {
         false
     }
@@ -525,23 +525,6 @@ private final class WaitTestCodexController: CodexSessionControlling {
     }
 
     func setThreadName(_: String, threadID _: String?) async throws {}
-    func sendUserMessage(_: String) async throws {}
-    func sendUserTurn(text _: String, images _: [AgentImageAttachment]) async throws {}
-    func sendUserTurn(
-        text _: String,
-        images _: [AgentImageAttachment],
-        model _: String?,
-        reasoningEffort _: String?
-    ) async throws {}
-
-    func sendUserTurn(
-        text _: String,
-        images _: [AgentImageAttachment],
-        model _: String?,
-        reasoningEffort _: String?,
-        serviceTier _: String?
-    ) async throws {}
-
     func compactThread() async throws {}
     func getThreadGoal() async throws -> CodexNativeSessionController.ThreadGoal? {
         nil

--- a/Tests/RepoPromptTests/MCP/AgentRunWaitDrainIntegrationTests.swift
+++ b/Tests/RepoPromptTests/MCP/AgentRunWaitDrainIntegrationTests.swift
@@ -391,7 +391,7 @@ private enum AgentRunWaitDrainHarnessError: Error {
     case missingControlContext
 }
 
-private final class AgentRunWaitDrainCodexController: CodexSessionControlling {
+private final class AgentRunWaitDrainCodexController: CodexSessionControllerTurnDispatchTestDefaults {
     var hasActiveThread: Bool {
         false
     }
@@ -445,23 +445,6 @@ private final class AgentRunWaitDrainCodexController: CodexSessionControlling {
     }
 
     func setThreadName(_: String, threadID _: String?) async throws {}
-    func sendUserMessage(_: String) async throws {}
-    func sendUserTurn(text _: String, images _: [AgentImageAttachment]) async throws {}
-    func sendUserTurn(
-        text _: String,
-        images _: [AgentImageAttachment],
-        model _: String?,
-        reasoningEffort _: String?
-    ) async throws {}
-
-    func sendUserTurn(
-        text _: String,
-        images _: [AgentImageAttachment],
-        model _: String?,
-        reasoningEffort _: String?,
-        serviceTier _: String?
-    ) async throws {}
-
     func compactThread() async throws {}
     func getThreadGoal() async throws -> CodexNativeSessionController.ThreadGoal? {
         nil

--- a/Tests/RepoPromptTests/MCP/AgentRunWorktreeStartTests.swift
+++ b/Tests/RepoPromptTests/MCP/AgentRunWorktreeStartTests.swift
@@ -1550,7 +1550,7 @@ final class AgentRunWorktreeStartTests: XCTestCase {
     }
 }
 
-private final class WorktreeStartFakeCodexController: CodexSessionControlling {
+private final class WorktreeStartFakeCodexController: CodexSessionControllerTurnDispatchTestDefaults {
     var hasActiveThread: Bool {
         false
     }
@@ -1604,10 +1604,6 @@ private final class WorktreeStartFakeCodexController: CodexSessionControlling {
     }
 
     func setThreadName(_ name: String, threadID: String?) async throws {}
-    func sendUserMessage(_ text: String) async throws {}
-    func sendUserTurn(text: String, images: [AgentImageAttachment]) async throws {}
-    func sendUserTurn(text: String, images: [AgentImageAttachment], model: String?, reasoningEffort: String?) async throws {}
-    func sendUserTurn(text: String, images: [AgentImageAttachment], model: String?, reasoningEffort: String?, serviceTier: String?) async throws {}
     func compactThread() async throws {}
     func getThreadGoal() async throws -> CodexNativeSessionController.ThreadGoal? {
         nil


### PR DESCRIPTION
## Summary

- make composer submission claims attempt-scoped and publish in-flight state synchronously
- use typed exact-ID Codex `turn/steer` instead of implicit active-turn `turn/start`
- separate provisional submission IDs from authoritative lifecycle turn identity
- add a correlated Codex fallback FIFO with matching completion drain and reset-safe retries
- correct acknowledgement, waiter, cancellation, and late-resolution ordering
- add focused regression coverage for composer races, steering transport, lifecycle reconciliation, FIFO draining, and acknowledgement cancellation

## Validation

- commit and push contribution preflights passed
- staged and outgoing secret scans passed
- repository guardrails passed
- `make dev-lint` passed with 0 violations
- full coordinated `make dev-test` passed
- `make dev-swift-build PRODUCT=RepoPrompt` passed
- debug package build passed
- coordinated `make dev-smoke-launch` passed
- independent post-fix review found no blocking findings

## Notes

- create-to-existing composer route promotion remains intentionally deferred pending lineage-safe runtime evidence
- local investigation reports and prompt exports were not included in this PR
