### PR TITLE
Add Claude Fable and Opus 4.8 model targets

### DIFF
--- a/Packages/RepoPromptAgentProviders/Sources/RepoPromptClaudeCompatibleProvider/ClaudeCompatibleProviderPlugin.swift
+++ b/Packages/RepoPromptAgentProviders/Sources/RepoPromptClaudeCompatibleProvider/ClaudeCompatibleProviderPlugin.swift
@@ -234,7 +234,10 @@ public enum ClaudeCompatibleModelCatalog {
     private static let haikuRaw = "haiku"
     private static let sonnetRaw = "sonnet"
     private static let opusRaw = "opus"
+    private static let fableRaw = "fable"
+    private static let fable5Raw = "claude-fable-5"
     private static let opus1mRaw = "opus[1m]"
+    private static let opus48Raw = "claude-opus-4-8"
     private static let opus47Raw = "claude-opus-4-7"
     private static let opus46Raw = "claude-opus-4-6"
     private static let opus45Raw = "claude-opus-4-5"
@@ -244,6 +247,18 @@ public enum ClaudeCompatibleModelCatalog {
 
     private static let claudeModels: [StaticModel] = [
         StaticModel(
+            rawValue: fableRaw,
+            displayName: "Fable Latest",
+            description: "Most capable Claude model. Best for ambitious coding projects, long-horizon reasoning, and complex agentic work.",
+            supportsXHigh: true
+        ),
+        StaticModel(
+            rawValue: fable5Raw,
+            displayName: "Fable 5",
+            description: "Pinned Claude Fable 5. Most capable tier for ambitious coding projects and long-running agentic work.",
+            supportsXHigh: true
+        ),
+        StaticModel(
             rawValue: opus1mRaw,
             displayName: "Opus Latest (1M)",
             description: "Claude Opus with 1M token context. Best for large codebases and tasks requiring extensive context.",
@@ -252,7 +267,13 @@ public enum ClaudeCompatibleModelCatalog {
         StaticModel(
             rawValue: opusRaw,
             displayName: "Opus Latest",
-            description: "Strongest Claude model. Best for open-ended tasks, architecture, and complex reasoning.",
+            description: "Strongest Claude Opus model. Best for open-ended tasks, architecture, and complex reasoning.",
+            supportsXHigh: true
+        ),
+        StaticModel(
+            rawValue: opus48Raw,
+            displayName: "Opus 4.8",
+            description: "Pinned Claude Opus 4.8. Strongest Opus tier for complex reasoning and architecture.",
             supportsXHigh: true
         ),
         StaticModel(

--- a/Packages/RepoPromptAgentProviders/Tests/RepoPromptClaudeCompatibleProviderTests/Runtime/ClaudeCompatibleRuntimeSupportTests.swift
+++ b/Packages/RepoPromptAgentProviders/Tests/RepoPromptClaudeCompatibleProviderTests/Runtime/ClaudeCompatibleRuntimeSupportTests.swift
@@ -149,7 +149,21 @@ final class ClaudeCompatibleRuntimeSupportTests: XCTestCase {
         XCTAssertEqual(claude.defaultModelRaw, "opus")
         XCTAssertEqual(claude.options.first?.rawValue, "default")
         XCTAssertEqual(claude.options.first?.isPlaceholderDefault, true)
+        XCTAssertEqual(Array(claude.options.map(\.rawValue).prefix(8)), [
+            "default",
+            "fable",
+            "claude-fable-5",
+            "opus[1m]",
+            "opus",
+            "claude-opus-4-8",
+            "claude-opus-4-7",
+            "claude-opus-4-6"
+        ])
+        XCTAssertTrue(claude.options.contains { $0.rawValue == "fable" && $0.supportedEffortLevels.contains("xhigh") })
+        XCTAssertTrue(claude.options.contains { $0.rawValue == "claude-fable-5" && $0.supportedEffortLevels.contains("xhigh") })
+        XCTAssertTrue(claude.options.contains { $0.rawValue == "opus" && $0.supportedEffortLevels.contains("xhigh") })
         XCTAssertTrue(claude.options.contains { $0.rawValue == "opus[1m]" && $0.supportedEffortLevels.contains("xhigh") })
+        XCTAssertTrue(claude.options.contains { $0.rawValue == "claude-opus-4-8" && $0.supportedEffortLevels.contains("xhigh") })
 
         let zai = ClaudeCompatibleModelCatalog.snapshot(pluginID: .zaiClaudeCode, includeEffortVariants: false)
         XCTAssertEqual(zai.defaultModelRaw, "sonnet")

--- a/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentModel.swift
@@ -55,14 +55,17 @@ enum AgentModel: String, CaseIterable, Codable {
     case gpt54MiniHigh = "gpt-5.4-mini-high"
 
     // Claude Code models
+    case claudeFable = "fable"
     case claudeSonnet = "sonnet"
     case claudeOpus = "opus"
     case claudeHaiku = "haiku"
     case claudeOpus1m = "opus[1m]"
 
     // Claude Code full model IDs (static known versions; no dynamic probing)
+    case claudeFable5 = "claude-fable-5"
     case claudeSonnet46 = "claude-sonnet-4-6"
     case claudeSonnet45 = "claude-sonnet-4-5"
+    case claudeOpus48 = "claude-opus-4-8"
     case claudeOpus47 = "claude-opus-4-7"
     case claudeOpus46 = "claude-opus-4-6"
     case claudeOpus45 = "claude-opus-4-5"
@@ -106,12 +109,15 @@ enum AgentModel: String, CaseIterable, Codable {
         case .gpt54MiniLow: "GPT-5.4 Mini Low"
         case .gpt54MiniMedium: "GPT-5.4 Mini Medium"
         case .gpt54MiniHigh: "GPT-5.4 Mini High"
+        case .claudeFable: "Fable Latest"
         case .claudeSonnet: "Sonnet Latest"
         case .claudeOpus: "Opus Latest"
         case .claudeHaiku: "Haiku Latest"
         case .claudeOpus1m: "Opus Latest (1M)"
+        case .claudeFable5: "Fable 5"
         case .claudeSonnet46: "Sonnet 4.6"
         case .claudeSonnet45: "Sonnet 4.5"
+        case .claudeOpus48: "Opus 4.8"
         case .claudeOpus47: "Opus 4.7"
         case .claudeOpus46: "Opus 4.6"
         case .claudeOpus45: "Opus 4.5"
@@ -149,12 +155,15 @@ enum AgentModel: String, CaseIterable, Codable {
         case .gpt54MiniLow: "Fast GPT-5.4 Mini. Good for quick exploration and lookups."
         case .gpt54MiniMedium: "GPT-5.4 Mini with balanced reasoning. Best exploration sub-agent for context gathering."
         case .gpt54MiniHigh: "GPT-5.4 Mini with deep reasoning. Good for complex exploration and analysis."
+        case .claudeFable: "Most capable Claude model. Best for ambitious coding projects, long-horizon reasoning, and complex agentic work."
         case .claudeSonnet: "Balanced speed and capability. Good for general coding, analysis, and everyday work."
-        case .claudeOpus: "Strongest Claude model. Best for open-ended tasks, architecture, and complex reasoning."
+        case .claudeOpus: "Strongest Claude Opus model. Best for open-ended tasks, architecture, and complex reasoning."
         case .claudeHaiku: "Fast and lightweight. Good for exploration, quick edits, and mapping codebases."
         case .claudeOpus1m: "Claude Opus with 1M token context. Best for large codebases and tasks requiring extensive context."
+        case .claudeFable5: "Pinned Claude Fable 5. Most capable tier for ambitious coding projects and long-running agentic work."
         case .claudeSonnet46: "Pinned Claude Sonnet 4.6. Balanced speed and capability for everyday engineering."
         case .claudeSonnet45: "Pinned Claude Sonnet 4.5. Balanced speed and capability for everyday engineering."
+        case .claudeOpus48: "Pinned Claude Opus 4.8. Strongest Opus tier for complex reasoning and architecture."
         case .claudeOpus47: "Pinned Claude Opus 4.7. Strongest Claude tier for complex reasoning and architecture."
         case .claudeOpus46: "Pinned Claude Opus 4.6. Strongest Claude tier for complex reasoning and architecture."
         case .claudeOpus45: "Pinned Claude Opus 4.5. Strongest Claude tier for complex reasoning and architecture."
@@ -199,12 +208,13 @@ enum AgentModel: String, CaseIterable, Codable {
             ]
         case .claudeCode:
             // Family priority matches the Claude Code picker catalog:
-            // Opus[1M] → Opus → Sonnet → Haiku. Within each family,
+            // Fable → Opus[1M] → Opus → Sonnet → Haiku. Within each family,
             // latest aliases come first, then pinned full IDs by descending version.
             [
                 .defaultModel,
+                .claudeFable, .claudeFable5,
                 .claudeOpus1m,
-                .claudeOpus, .claudeOpus47, .claudeOpus46, .claudeOpus45,
+                .claudeOpus, .claudeOpus48, .claudeOpus47, .claudeOpus46, .claudeOpus45,
                 .claudeSonnet, .claudeSonnet46, .claudeSonnet45,
                 .claudeHaiku, .claudeHaiku45
             ]
@@ -395,16 +405,6 @@ enum AgentModel: String, CaseIterable, Codable {
         try container.encode(rawValue)
     }
 
-    /// Whether this model uses the 1M extended context window.
-    var isExtendedContext: Bool {
-        switch self {
-        case .claudeOpus1m:
-            true
-        default:
-            false
-        }
-    }
-
     /// Returns the release date for models with staged rollouts
     var availableFrom: Date? {
         nil
@@ -426,26 +426,40 @@ enum AgentModel: String, CaseIterable, Codable {
             [.fast, .exploration, .engineering]
         case .gpt55CodexHigh:
             [.complex, .engineering, .pair]
-        case .claudeOpus:
+        case .claudeFable, .claudeOpus:
             [.complex, .engineering, .pair]
         default:
             []
         }
     }
 
-    /// Known context window size in tokens, when verified.
-    /// Returns `nil` for models where the context window is unknown or unverified.
+    /// Known context window size in tokens for unambiguous, pinned model IDs.
+    /// Provider aliases use `contextWindowTokens(for:)` because the same raw
+    /// values can represent unrelated models in Claude-compatible backends.
     var contextWindowTokens: Int? {
         switch self {
-        case .claudeOpus1m:
+        case .claudeFable5, .claudeOpus1m, .claudeOpus48:
             1_000_000
-        case .claudeSonnet, .claudeOpus, .claudeHaiku,
-             .claudeSonnet46, .claudeSonnet45,
+        case .claudeSonnet46, .claudeSonnet45,
              .claudeOpus47, .claudeOpus46, .claudeOpus45,
              .claudeHaiku45:
             200_000
         default:
             nil
         }
+    }
+
+    func contextWindowTokens(for agentKind: AgentProviderKind) -> Int? {
+        if agentKind == .claudeCode {
+            switch self {
+            case .claudeFable, .claudeOpus:
+                return 1_000_000
+            case .claudeSonnet, .claudeHaiku:
+                return 200_000
+            default:
+                break
+            }
+        }
+        return contextWindowTokens
     }
 }

--- a/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentModelCatalog.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentModelCatalog.swift
@@ -1010,11 +1010,14 @@ enum AgentModelCatalog {
     }
 
     /// Base model raw values (lowercased) that support the XHigh effort tier.
-    /// Opus Latest, Opus 1M, and pinned Opus full IDs support XHigh.
+    /// Fable, Opus Latest, Opus 1M, and pinned Fable/Opus full IDs support XHigh.
     /// Sonnet, Haiku, and GLM deliberately do not support XHigh.
     private static let claudeXHighEligibleBaseRaws: Set<String> = [
+        AgentModel.claudeFable.rawValue.lowercased(),
+        AgentModel.claudeFable5.rawValue.lowercased(),
         AgentModel.claudeOpus.rawValue.lowercased(),
         AgentModel.claudeOpus1m.rawValue.lowercased(),
+        AgentModel.claudeOpus48.rawValue.lowercased(),
         AgentModel.claudeOpus47.rawValue.lowercased(),
         AgentModel.claudeOpus46.rawValue.lowercased(),
         AgentModel.claudeOpus45.rawValue.lowercased()
@@ -2080,7 +2083,7 @@ enum AgentModelCatalog {
                 let specifier = ClaudeModelSpecifier(raw: option.rawValue)
                 let effortDisplayName = specifier.effortLevel?.displayName
                 let targetNameSuffix = effortDisplayName.map { "\(group.displayName) \($0)" } ?? option.displayName
-                let contextWindow = AgentModel.resolvedModel(forRaw: option.rawValue, agentKind: agent)?.contextWindowTokens
+                let contextWindow = AgentModel.resolvedModel(forRaw: option.rawValue, agentKind: agent)?.contextWindowTokens(for: agent)
                 return DiscoveryStartTarget(
                     selectionID: selectionID,
                     modelRaw: option.rawValue,
@@ -2107,7 +2110,7 @@ enum AgentModelCatalog {
                 description: representative?.description,
                 available: true,
                 tags: tags,
-                contextWindowTokens: representativeModel?.contextWindowTokens,
+                contextWindowTokens: representativeModel?.contextWindowTokens(for: agent),
                 supportedReasoningEfforts: [],
                 defaultReasoningEffort: nil,
                 startTargets: targets
@@ -2124,7 +2127,7 @@ enum AgentModelCatalog {
     ) -> DiscoveryModel {
         let selectionID = AgentModelSelectionID(agentRaw: agent.rawValue, modelRaw: option.rawValue)
         let staticModel = AgentModel(rawValue: option.rawValue)
-        let contextWindow = staticModel?.contextWindowTokens
+        let contextWindow = staticModel?.contextWindowTokens(for: agent)
         let tags = staticModel?.discoveryTags ?? AgentModelDiscoveryTag.infer(from: option.rawValue)
 
         let target = DiscoveryStartTarget(

--- a/Sources/RepoPrompt/Features/AgentMode/Providers/ClaudeCompatible/ClaudeCompatibleModelCatalogAdapter.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Providers/ClaudeCompatible/ClaudeCompatibleModelCatalogAdapter.swift
@@ -325,8 +325,11 @@ enum ClaudeCompatibleModelCatalogAdapter {
 
     /// Base model raw values (lowercased) that support the XHigh effort tier.
     private static let claudeXHighEligibleBaseRaws: Set<String> = [
+        AgentModel.claudeFable.rawValue.lowercased(),
+        AgentModel.claudeFable5.rawValue.lowercased(),
         AgentModel.claudeOpus.rawValue.lowercased(),
         AgentModel.claudeOpus1m.rawValue.lowercased(),
+        AgentModel.claudeOpus48.rawValue.lowercased(),
         AgentModel.claudeOpus47.rawValue.lowercased(),
         AgentModel.claudeOpus46.rawValue.lowercased(),
         AgentModel.claudeOpus45.rawValue.lowercased()

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentRuntimeSidebarViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentRuntimeSidebarViewModel.swift
@@ -37,11 +37,12 @@ final class AgentRuntimeSidebarViewModel: ObservableObject {
         /// Context window with agent-specific fallback when the provider hasn't reported one yet.
         var effectiveContextWindowTokens: Int {
             if let contextWindowTokens { return contextWindowTokens }
-            if let selectedModelRaw,
-               let model = AgentModel(rawValue: selectedModelRaw),
-               model.isExtendedContext
+            if let selectedAgent,
+               let selectedModelRaw,
+               let model = AgentModel.resolvedModel(forRaw: selectedModelRaw, agentKind: selectedAgent),
+               let modelContextWindow = model.contextWindowTokens(for: selectedAgent)
             {
-                return 1_000_000
+                return modelContextWindow
             }
             switch selectedAgent {
             case .claudeCode, .claudeCodeGLM, .kimiCode, .customClaudeCompatible: return 200_000

--- a/Tests/RepoPromptTests/AgentMode/AgentRuntimeSidebarViewModelTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentRuntimeSidebarViewModelTests.swift
@@ -4,6 +4,18 @@ import XCTest
 
 @MainActor
 final class AgentRuntimeSidebarViewModelTests: XCTestCase {
+    func testContextWindowFallbackScopesClaudeAliasesToProvider() {
+        var claude = AgentRuntimeSidebarViewModel.ContextSnapshot()
+        claude.selectedAgent = .claudeCode
+        claude.selectedModelRaw = "fable:xhigh"
+        XCTAssertEqual(claude.effectiveContextWindowTokens, 1_000_000)
+
+        var glm = AgentRuntimeSidebarViewModel.ContextSnapshot()
+        glm.selectedAgent = .claudeCodeGLM
+        glm.selectedModelRaw = "opus"
+        XCTAssertEqual(glm.effectiveContextWindowTokens, 200_000)
+    }
+
     func testStaleLiveZeroDoesNotMaskNewerManageSelectionCount() throws {
         let store = AgentRuntimeMetricsUIStore()
         store.update(

--- a/Tests/RepoPromptTests/AgentMode/ClaudeCompatible/ClaudeCompatiblePluginBridgeTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/ClaudeCompatible/ClaudeCompatiblePluginBridgeTests.swift
@@ -70,16 +70,42 @@ final class ClaudeCompatiblePluginBridgeTests: XCTestCase {
         XCTAssertEqual(snapshot.defaultModelRaw, "opus")
         XCTAssertEqual(snapshot.options.first?.rawValue, "default")
         XCTAssertEqual(snapshot.options.first?.isPlaceholderDefault, true)
+        XCTAssertTrue(snapshot.options.contains { $0.rawValue == "fable" && $0.supportedEffortLevels.contains("xhigh") })
+        XCTAssertTrue(snapshot.options.contains { $0.rawValue == "claude-fable-5" && $0.supportedEffortLevels.contains("xhigh") })
         XCTAssertTrue(snapshot.options.contains { $0.rawValue == "opus" && $0.supportedEffortLevels.contains("xhigh") })
+        XCTAssertTrue(snapshot.options.contains { $0.rawValue == "claude-opus-4-8" && $0.supportedEffortLevels.contains("xhigh") })
 
         let options = AgentModelCatalog.options(for: .claudeCode, availability: availability)
         let menu = AgentModelCatalog.claudeMenu(for: options, agentKind: .claudeCode)
         XCTAssertEqual(AgentModelCatalog.defaultModelRaw(for: .claudeCode, availability: availability), "opus")
         XCTAssertEqual(menu.defaultOption?.rawValue, "default")
         let groupRaws = Set(menu.groups.map(\.baseModelRaw))
+        XCTAssertTrue(groupRaws.contains("fable"))
+        XCTAssertTrue(groupRaws.contains("claude-fable-5"))
         XCTAssertTrue(groupRaws.contains("opus[1m]"))
         XCTAssertTrue(groupRaws.contains("opus"))
+        XCTAssertTrue(groupRaws.contains("claude-opus-4-8"))
         XCTAssertTrue(groupRaws.contains("sonnet"))
+        XCTAssertEqual(Array(AgentModel.modelsForAgent(.claudeCode).map(\.rawValue).prefix(7)), [
+            "default",
+            "fable",
+            "claude-fable-5",
+            "opus[1m]",
+            "opus",
+            "claude-opus-4-8",
+            "claude-opus-4-7"
+        ])
+        XCTAssertEqual(
+            AgentModelCatalog.supportedClaudeEfforts(forSelectedModelRaw: "fable", agentKind: .claudeCode),
+            [.low, .medium, .high, .max, .xhigh]
+        )
+        XCTAssertNil(AgentModel.claudeFable.contextWindowTokens)
+        XCTAssertEqual(AgentModel.claudeFable.contextWindowTokens(for: .claudeCode), 1_000_000)
+        XCTAssertEqual(AgentModel.claudeFable5.contextWindowTokens, 1_000_000)
+        XCTAssertNil(AgentModel.claudeOpus.contextWindowTokens)
+        XCTAssertEqual(AgentModel.claudeOpus.contextWindowTokens(for: .claudeCode), 1_000_000)
+        XCTAssertNil(AgentModel.claudeOpus.contextWindowTokens(for: .claudeCodeGLM))
+        XCTAssertEqual(AgentModel.claudeOpus48.contextWindowTokens, 1_000_000)
 
         let discovery = try XCTUnwrap(AgentModelCatalog.discoveryAgents(availability: availability).first { $0.agent == .claudeCode })
         XCTAssertEqual(discovery.defaults.modelRaw, "opus")
@@ -87,6 +113,17 @@ final class ClaudeCompatiblePluginBridgeTests: XCTestCase {
         XCTAssertEqual(discovery.runtime, "claude_native")
         XCTAssertTrue(discovery.models.contains { $0.id == "default" })
         XCTAssertTrue(discovery.models.contains { $0.id == "opus" })
+        let fableDiscovery = try XCTUnwrap(discovery.models.first { $0.id == "fable" })
+        XCTAssertEqual(fableDiscovery.contextWindowTokens, 1_000_000)
+        XCTAssertTrue(fableDiscovery.startTargets.contains { $0.modelRaw == "fable:xhigh" })
+
+        let compatibleAvailability = AgentModelCatalog.AvailabilityContext(claudeCodeAvailable: true, zaiConfigured: true)
+        let glmDiscovery = try XCTUnwrap(
+            AgentModelCatalog.discoveryAgents(availability: compatibleAvailability).first { $0.agent == .claudeCodeGLM }
+        )
+        let glmOpusDiscovery = try XCTUnwrap(glmDiscovery.models.first { $0.id == "opus" })
+        XCTAssertNil(glmOpusDiscovery.contextWindowTokens)
+        XCTAssertTrue(glmOpusDiscovery.startTargets.allSatisfy { $0.contextWindowTokens == nil })
 
         let compatiblePluginOptions = [
             ClaudeCompatiblePluginModelOption(


### PR DESCRIPTION
## Summary
- add Claude Code `fable` and pinned `claude-fable-5` model targets
- add pinned `claude-opus-4-8` ahead of older Opus versions
- expose XHigh effort and provider-scoped 1M context metadata without leaking Claude alias metadata into GLM
- add catalog, discovery, sidebar fallback, ordering, and compatibility isolation coverage

## Validation
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh commit`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh push`
- `make dev-lint`
- `make dev-test`
- `make dev-provider-test`
- `make dev-swift-build PRODUCT=RepoPrompt`
- Claude Code 2.1.170 CLI smoke: `haiku`, `sonnet`, `opus`, `fable`, `claude-fable-5`, and `claude-opus-4-8`
- 1M CLI smoke: `sonnet[1m]`, `opus[1m]`, and `fable[1m]`; `haiku[1m]` returns an authentication/long-context-beta 400 and is not exposed

## Live smoke
- not rerun because the existing CE app lacked an MCP workspace/window context; no app lifecycle operation was performed
