### PR TITLE
Harden MCP concurrency and workspace switching

### DIFF
--- a/Sources/RepoPrompt/App/WindowState.swift
+++ b/Sources/RepoPrompt/App/WindowState.swift
@@ -856,7 +856,7 @@ class WindowState: ObservableObject {
 
         if workspaceManager.activeWorkspaceID != route.workspaceID {
             let switchResult = await workspaceManager.requestWorkspaceSwitch(to: targetWorkspace, saveState: true)
-            if !switchResult.didSwitch, workspaceManager.activeWorkspaceID != route.workspaceID {
+            if !switchResult.didSwitch {
                 return .workspaceSwitchBlocked(switchResult.message)
             }
         }

--- a/Sources/RepoPrompt/App/WindowStateComposition.swift
+++ b/Sources/RepoPrompt/App/WindowStateComposition.swift
@@ -29,10 +29,12 @@ enum WindowStateCompositionFactory {
         windowID: Int,
         deferredInitialAgentSystemWorkspaceRefresh: Bool,
         sharedMCPService: MCPService,
-        contextBuilderProviderFactory: ContextBuilderAgentViewModel.ProviderFactory? = nil
+        contextBuilderProviderFactory: ContextBuilderAgentViewModel.ProviderFactory? = nil,
+        workspaceFileContextStore injectedWorkspaceFileContextStore: WorkspaceFileContextStore? = nil,
+        workspaceSwitchTimingPolicy: WorkspaceSwitchTimingPolicy = .production
     ) -> WindowStateComposition {
         // 1) Workspace file context store + visible file-tree UI adapter
-        let workspaceFileContextStore = WorkspaceFileContextStore()
+        let workspaceFileContextStore = injectedWorkspaceFileContextStore ?? WorkspaceFileContextStore()
         let workspaceSearchService = WorkspaceSearchService()
         let workspaceFilesViewModel = WorkspaceFilesViewModel(workspaceFileContextStore: workspaceFileContextStore)
 
@@ -59,7 +61,8 @@ enum WindowStateCompositionFactory {
         let workspaceManager = WorkspaceManagerViewModel(
             fileManager: workspaceFilesViewModel,
             promptViewModel: promptManager,
-            workspaceSearchService: workspaceSearchService
+            workspaceSearchService: workspaceSearchService,
+            switchTimingPolicy: workspaceSwitchTimingPolicy
         )
         let selectionCoordinator = WorkspaceSelectionCoordinator(
             workspaceManager: workspaceManager,

--- a/Sources/RepoPrompt/Features/Diagnostics/MCP/MCPConnectionManager+DebugDiagnosticsReadSearchLatency.swift
+++ b/Sources/RepoPrompt/Features/Diagnostics/MCP/MCPConnectionManager+DebugDiagnosticsReadSearchLatency.swift
@@ -96,6 +96,33 @@ import MCP
                 return debugDiagnosticsError(op: op, code: "invalid_params", message: "`retry_after_ms` must be an integer between 0 and 60000.")
             }
 
+            let productionConfiguration = StoreBackedWorkspaceSearchLane.Configuration.production
+            let maxActiveLeases: Int
+            switch debugBoundedInt(
+                arguments,
+                "max_active_leases",
+                defaultValue: productionConfiguration.maxActiveLeases,
+                range: 1 ... 64
+            ) {
+            case let .value(parsed), let .defaulted(parsed):
+                maxActiveLeases = parsed
+            case .invalid:
+                return debugDiagnosticsError(op: op, code: "invalid_params", message: "`max_active_leases` must be an integer between 1 and 64.")
+            }
+
+            let maxQueuedWaiters: Int
+            switch debugBoundedInt(
+                arguments,
+                "max_queued_waiters",
+                defaultValue: productionConfiguration.maxQueuedWaiters,
+                range: 1 ... 64
+            ) {
+            case let .value(parsed), let .defaulted(parsed):
+                maxQueuedWaiters = parsed
+            case .invalid:
+                return debugDiagnosticsError(op: op, code: "invalid_params", message: "`max_queued_waiters` must be an integer between 1 and 64.")
+            }
+
             let targets = await debugSearchLaneTargets(windowID: requestedWindowID)
             guard !targets.isEmpty else {
                 let message = requestedWindowID.map { "No RepoPrompt window matched window_id \($0)." }
@@ -115,6 +142,8 @@ import MCP
             }
 
             let configuration = StoreBackedWorkspaceSearchLane.Configuration(
+                maxActiveLeases: maxActiveLeases,
+                maxQueuedWaiters: maxQueuedWaiters,
                 maxQueueWait: .milliseconds(maxQueueWaitMilliseconds),
                 retryAfterMilliseconds: retryAfterMilliseconds
             )
@@ -499,8 +528,8 @@ import MCP
                     [
                         "window_id": entry.windowID,
                         "configuration": [
-                            "active_capacity": 1,
-                            "max_queued": 1,
+                            "active_capacity": entry.snapshot.configuration.maxActiveLeases,
+                            "max_queued": entry.snapshot.configuration.maxQueuedWaiters,
                             "max_queue_wait_ms": entry.snapshot.configuration.maxQueueWaitMilliseconds,
                             "retry_after_ms": entry.snapshot.configuration.retryAfterMilliseconds
                         ],

--- a/Sources/RepoPrompt/Features/Diagnostics/MCP/MCPConnectionManager+DebugDiagnosticsReadSearchLatency.swift
+++ b/Sources/RepoPrompt/Features/Diagnostics/MCP/MCPConnectionManager+DebugDiagnosticsReadSearchLatency.swift
@@ -314,9 +314,30 @@ import MCP
             ]
         }
 
-        private func readSearchLimiterPayload(_ snapshot: AsyncLimiter.DebugSnapshot) -> [String: Any] {
+        private func readSearchLimiterPayload(
+            _ snapshot: MCPConnectionCallLimiterDebugSnapshot
+        ) -> [String: Any] {
             [
                 "found": true,
+                "lane_count": snapshot.laneCount,
+                "limit": snapshot.limit,
+                "permits": snapshot.permits,
+                "active_permit_count": snapshot.activePermitCount,
+                "waiter_count": snapshot.waiterCount,
+                "in_flight_count": snapshot.inFlight,
+                "oldest_waiter_age_ms": Self.debugOptionalValue(snapshot.oldestWaiterAgeMilliseconds),
+                "cancelled_waiter_count": snapshot.cancelledWaiterCount,
+                "is_closed": snapshot.isClosed,
+                "is_idle": snapshot.isIdle,
+                "lanes": [
+                    MCPConnectionCallLane.ordinary.rawValue: readSearchLimiterLanePayload(snapshot.ordinary),
+                    MCPConnectionCallLane.fileSearch.rawValue: readSearchLimiterLanePayload(snapshot.fileSearch)
+                ]
+            ]
+        }
+
+        private func readSearchLimiterLanePayload(_ snapshot: AsyncLimiter.DebugSnapshot) -> [String: Any] {
+            [
                 "limit": snapshot.limit,
                 "permits": snapshot.permits,
                 "active_permit_count": snapshot.activePermitCount,
@@ -379,6 +400,13 @@ import MCP
                     "age_ms": active.ageMilliseconds
                 ]
             }
+            let pending = snapshot.pending.map { pending in
+                [
+                    "target_watcher_watermark": pending.targetWatcherWatermark,
+                    "target_service_publication_sequence": pending.targetServicePublicationSequence,
+                    "age_ms": pending.ageMilliseconds
+                ]
+            }
             let completed = snapshot.lastCompleted.map { completed in
                 [
                     "token": completed.token,
@@ -394,8 +422,10 @@ import MCP
                 "launch_count": snapshot.launchCount,
                 "join_count": snapshot.joinCount,
                 "successor_count": snapshot.successorCount,
+                "coalesced_successor_count": snapshot.coalescedSuccessorCount,
                 "completion_count": snapshot.completionCount,
                 "active": Self.debugOptionalValue(active),
+                "pending": Self.debugOptionalValue(pending),
                 "last_completed": Self.debugOptionalValue(completed)
             ]
         }

--- a/Sources/RepoPrompt/Features/Diagnostics/MCP/MCPConnectionManager+DebugTransportDiagnostics.swift
+++ b/Sources/RepoPrompt/Features/Diagnostics/MCP/MCPConnectionManager+DebugTransportDiagnostics.swift
@@ -325,6 +325,7 @@ import MCP
         ) async -> CallTool.Result {
             let includeIdentity = debugBool(arguments, "include_identity") ?? false
             let snapshot = await dashboardSnapshot()
+            let activeToolScopes = debugActiveToolScopesForTesting()
             var payload: [String: Any] = [
                 "ok": true,
                 "op": op,
@@ -338,8 +339,26 @@ import MCP
                         "transport": entry.transport.rawValue,
                         "has_in_flight_calls": entry.hasInFlightCalls,
                         "active_tool_name": entry.activeToolName ?? NSNull(),
+                        "active_tool_window_id": entry.activeToolWindowID.map { $0 as Any } ?? NSNull(),
+                        "active_tool_scope_count": entry.activeToolScopeCount,
+                        "active_tool_scopes": entry.activeToolScopes.map { scope in
+                            [
+                                "window_id": scope.windowID,
+                                "tool_name": scope.toolName,
+                                "sequence": scope.sequence
+                            ] as [String: Any]
+                        },
                         "session_key_present": entry.sessionKey != nil,
                         "session_fingerprint": debugSessionFingerprint(forToken: entry.sessionKey) ?? NSNull()
+                    ] as [String: Any]
+                },
+                "active_tool_scopes": activeToolScopes.map { scope in
+                    [
+                        "scope_id": scope.scopeID.uuidString,
+                        "window_id": scope.windowID,
+                        "connection_id": scope.connectionID.uuidString,
+                        "tool_name": scope.toolName,
+                        "sequence": scope.sequence
                     ] as [String: Any]
                 }
             ]
@@ -456,11 +475,11 @@ import MCP
                 return debugDiagnosticsError(op: op, code: "invalid_params", message: "marker is required and must be <= 128 characters.")
             }
 
-            let didSeed = await MainActor.run { () -> Bool in
+            let slotToken = await MainActor.run { () -> UUID? in
                 guard let window = WindowStatesManager.shared.allWindows.first(where: { $0.windowID == windowID }) else {
-                    return false
+                    return nil
                 }
-                window.mcpServer.test_setActiveToolSlot(
+                return window.mcpServer.test_setActiveToolSlot(
                     toolName: toolName,
                     connectionID: targetID,
                     cancel: {
@@ -469,18 +488,29 @@ import MCP
                         }
                     }
                 )
-                return true
             }
-            guard didSeed else {
+            guard let slotToken else {
                 return debugDiagnosticsError(op: op, code: "invalid_params", message: "No window found for window_id \(windowID).")
             }
-            debugMarkActiveToolOwner(windowID: windowID, connectionID: targetID, toolName: toolName)
+            guard let scopeID = debugBeginActiveToolScopeForTesting(
+                windowID: windowID,
+                connectionID: targetID,
+                toolName: toolName,
+                scopeID: slotToken
+            ) else {
+                await MainActor.run {
+                    guard let window = WindowStatesManager.shared.allWindows.first(where: { $0.windowID == windowID }) else { return }
+                    window.mcpServer.test_clearActiveToolSlot(ifToken: slotToken)
+                }
+                return debugDiagnosticsError(op: op, code: "internal_error", message: "Unable to allocate an active-tool scope.")
+            }
             return debugDiagnosticsResult([
                 "ok": true,
                 "op": op,
                 "window_id": windowID,
                 "connection_id": targetID.uuidString,
                 "tool_name": toolName,
+                "scope_id": scopeID.uuidString,
                 "marker": marker
             ])
         }
@@ -520,20 +550,44 @@ import MCP
             guard let markers = debugStringArray(arguments, "markers", op: op) else {
                 return debugDiagnosticsError(op: op, code: "invalid_params", message: "markers must be a string or an array of strings.")
             }
+            let scopeID: UUID?
+            if let scopeIDString = debugString(arguments, "scope_id") {
+                guard let parsedScopeID = UUID(uuidString: scopeIDString) else {
+                    return debugDiagnosticsError(op: op, code: "invalid_params", message: "scope_id must be a UUID string.")
+                }
+                scopeID = parsedScopeID
+            } else {
+                scopeID = nil
+            }
             let didFindWindow = await MainActor.run { () -> Bool in
                 guard let window = WindowStatesManager.shared.allWindows.first(where: { $0.windowID == windowID }) else {
                     return false
                 }
-                window.mcpServer.test_clearActiveToolSlot()
+                if let scopeID {
+                    _ = window.mcpServer.test_clearActiveToolSlot(ifToken: scopeID)
+                } else {
+                    window.mcpServer.test_clearActiveToolSlot()
+                }
                 return true
             }
-            debugClearActiveToolOwner(windowID: windowID)
+            let removedScopeCount: Int
+            if let scopeID {
+                removedScopeCount = debugEndActiveToolScopeForTesting(
+                    windowID: windowID,
+                    scopeID: scopeID
+                ) ? 1 : 0
+            } else {
+                let beforeCount = debugActiveToolScopesForTesting().count
+                debugClearActiveToolOwner(windowID: windowID)
+                removedScopeCount = beforeCount - debugActiveToolScopesForTesting().count
+            }
             await MCPDebugDiagnosticsProbeStore.shared.clear(markers: markers)
             return debugDiagnosticsResult([
                 "ok": true,
                 "op": op,
                 "window_id": windowID,
-                "window_found": didFindWindow
+                "window_found": didFindWindow,
+                "removed_scope_count": removedScopeCount
             ])
         }
 

--- a/Sources/RepoPrompt/Features/Diagnostics/MCP/MCPToolDurationInventory.swift
+++ b/Sources/RepoPrompt/Features/Diagnostics/MCP/MCPToolDurationInventory.swift
@@ -6,6 +6,13 @@ import RepoPromptShared
     /// Payload-free inventory of the server-wide Codex timeout and the independent
     /// RepoPrompt dispatch-boundary execution contracts.
     enum MCPToolDurationInventory {
+        struct ConditionalExecutionOverride: Equatable {
+            let action: String
+            let condition: String
+            let executionDeadlineSeconds: Double
+            let cleanupGraceSeconds: Double
+        }
+
         struct Entry: Equatable {
             let toolName: String
             let contractKind: MCPToolExecutionContract.Kind
@@ -15,6 +22,7 @@ import RepoPromptShared
             let evidence: String
             let qualification: String
             let semanticWaitMaximumSeconds: Double?
+            let conditionalExecutionOverrides: [ConditionalExecutionOverride]
         }
 
         static let activeTimeoutSeconds = MCPTimeoutPolicy.codexServerActiveTimeoutSeconds
@@ -22,10 +30,11 @@ import RepoPromptShared
         static let perToolTimeoutOverridesSupported = false
         static let intentionalPhaseB3Deviation = true
         static let deviationReason = "Codex applies tool_timeout_sec to every tool on the RepoPromptCE server, while Oracle and Context Builder remain synchronous and can legitimately run for an hour or more."
-        static let activeTimeoutSemantics = "RepoPromptCE intentionally preserves a \(MCPTimeoutPolicy.codexServerActiveTimeoutSeconds.formatted())-active-second per-server timeout. The separate dispatch-boundary execution contract bounds only computational/local tools expected to finish within \(MCPTimeoutPolicy.boundedToolExecutionDeadlineSeconds) seconds; Oracle, Context Builder, agent lifecycles, interactive waits, and workspace/VCS lifecycles retain explicit cancellable exemptions."
+        static let activeTimeoutSemantics = "RepoPromptCE intentionally preserves a \(MCPTimeoutPolicy.codexServerActiveTimeoutSeconds.formatted())-active-second per-server timeout. The separate dispatch-boundary execution contract bounds computational/local tools expected to finish within \(MCPTimeoutPolicy.boundedToolExecutionDeadlineSeconds) seconds and switch-producing manage_workspaces calls within \(MCPTimeoutPolicy.workspaceSwitchToolExecutionDeadlineSeconds) seconds; other workspace/VCS lifecycle actions retain explicit cancellable exemptions."
         static let wallClockMayBeLongerDuringElicitation = true
         static let customUIWaitsAreElicitation = false
         static let boundedExecutionDeadlineSeconds = MCPTimeoutPolicy.boundedToolExecutionDeadline.mcpSeconds
+        static let workspaceSwitchExecutionDeadlineSeconds = MCPTimeoutPolicy.workspaceSwitchToolExecutionDeadline.mcpSeconds
         static let boundedCleanupGraceSeconds = MCPTimeoutPolicy.boundedToolCancellationCleanupGrace.mcpSeconds
 
         static let entries: [Entry] = MCPToolExecutionContractCatalog.orderedAdvertisedToolNames.map { toolName in
@@ -77,6 +86,7 @@ import RepoPromptShared
                 "wall_clock_may_be_longer_during_elicitation": wallClockMayBeLongerDuringElicitation,
                 "custom_ui_waits_are_mcp_elicitation": customUIWaitsAreElicitation,
                 "bounded_execution_deadline_seconds": boundedExecutionDeadlineSeconds,
+                "workspace_switch_execution_deadline_seconds": workspaceSwitchExecutionDeadlineSeconds,
                 "bounded_cleanup_grace_seconds": boundedCleanupGraceSeconds,
                 "preserved_long_synchronous_tools": preservedLongSynchronousToolNames,
                 "lifecycle_managed_tools": lifecycleManagedToolNames,
@@ -100,6 +110,17 @@ import RepoPromptShared
                     if let semanticWaitMaximumSeconds = entry.semanticWaitMaximumSeconds {
                         payload["semantic_wait_maximum_seconds"] = semanticWaitMaximumSeconds
                     }
+                    if !entry.conditionalExecutionOverrides.isEmpty {
+                        payload["conditional_execution_overrides"] = entry.conditionalExecutionOverrides.map { override in
+                            [
+                                "action": override.action,
+                                "condition": override.condition,
+                                "execution_contract": MCPToolExecutionContract.Kind.bounded.rawValue,
+                                "execution_deadline_seconds": override.executionDeadlineSeconds,
+                                "cleanup_grace_seconds": override.cleanupGraceSeconds
+                            ]
+                        }
+                    }
                     return payload
                 }
             ]
@@ -117,6 +138,30 @@ import RepoPromptShared
             default:
                 nil
             }
+            let conditionalExecutionOverrides: [ConditionalExecutionOverride] = if toolName == MCPGlobalToolName.manageWorkspaces {
+                [
+                    ConditionalExecutionOverride(
+                        action: "switch",
+                        condition: "always",
+                        executionDeadlineSeconds: workspaceSwitchExecutionDeadlineSeconds,
+                        cleanupGraceSeconds: boundedCleanupGraceSeconds
+                    ),
+                    ConditionalExecutionOverride(
+                        action: "create",
+                        condition: "switch_to_created omitted or true",
+                        executionDeadlineSeconds: workspaceSwitchExecutionDeadlineSeconds,
+                        cleanupGraceSeconds: boundedCleanupGraceSeconds
+                    ),
+                    ConditionalExecutionOverride(
+                        action: "delete",
+                        condition: "close_window == true",
+                        executionDeadlineSeconds: workspaceSwitchExecutionDeadlineSeconds,
+                        cleanupGraceSeconds: boundedCleanupGraceSeconds
+                    )
+                ]
+            } else {
+                []
+            }
 
             switch contract {
             case let .bounded(deadline, cancellationGrace):
@@ -128,7 +173,8 @@ import RepoPromptShared
                     expectedActiveDuration: "Ordinary dispatch must complete within \(MCPTimeoutPolicy.boundedToolExecutionDeadlineSeconds) seconds.",
                     evidence: "ServerNetworkManager applies MCPToolExecutionWatchdog at the resolved provider boundary.",
                     qualification: "Cancellation must release provider, limiter, ownership, and run-registration state; an uncooperative handler force-disconnects its connection after grace.",
-                    semanticWaitMaximumSeconds: semanticWaitMaximumSeconds
+                    semanticWaitMaximumSeconds: semanticWaitMaximumSeconds,
+                    conditionalExecutionOverrides: conditionalExecutionOverrides
                 )
             case .longSynchronousCancellable:
                 return Entry(
@@ -139,7 +185,8 @@ import RepoPromptShared
                     expectedActiveDuration: "May remain synchronously active beyond \(MCPTimeoutPolicy.boundedToolExecutionDeadlineSeconds) seconds.",
                     evidence: "The product contract explicitly exempts Oracle operations and Context Builder while preserving external cancellation.",
                     qualification: "Keep the \(MCPTimeoutPolicy.codexServerActiveTimeoutSeconds.formatted())-active-second Codex server timeout until this workflow gains a detached lifecycle or separate server.",
-                    semanticWaitMaximumSeconds: nil
+                    semanticWaitMaximumSeconds: nil,
+                    conditionalExecutionOverrides: conditionalExecutionOverrides
                 )
             case .lifecycleManagedCancellable:
                 return Entry(
@@ -150,7 +197,8 @@ import RepoPromptShared
                     expectedActiveDuration: "Long work is owned by start/poll/wait/cancel lifecycle operations.",
                     evidence: "agent_run and agent_explore expose detached lifecycle control rather than an ordinary synchronous provider contract.",
                     qualification: "Cancelling an individual control request must not implicitly destroy the detached run unless the lifecycle operation requests cancellation.",
-                    semanticWaitMaximumSeconds: nil
+                    semanticWaitMaximumSeconds: nil,
+                    conditionalExecutionOverrides: conditionalExecutionOverrides
                 )
             case .interactiveCancellable:
                 return Entry(
@@ -161,7 +209,8 @@ import RepoPromptShared
                     expectedActiveDuration: "May wait for a user interaction beyond \(MCPTimeoutPolicy.boundedToolExecutionDeadlineSeconds) seconds.",
                     evidence: "The tool exposes a cancellable UI interaction whose configured timeout remains authoritative.",
                     qualification: "User- or workspace-driven interaction waits are not clamped by the ordinary execution watchdog.",
-                    semanticWaitMaximumSeconds: semanticWaitMaximumSeconds
+                    semanticWaitMaximumSeconds: semanticWaitMaximumSeconds,
+                    conditionalExecutionOverrides: conditionalExecutionOverrides
                 )
             case .workspaceLifecycleCancellable:
                 return Entry(
@@ -171,8 +220,11 @@ import RepoPromptShared
                     cleanupGraceSeconds: nil,
                     expectedActiveDuration: "Workspace or VCS lifecycle work may legitimately exceed \(MCPTimeoutPolicy.boundedToolExecutionDeadlineSeconds) seconds.",
                     evidence: "The tool can open, switch, hydrate, create, merge, or inspect workspace/repository lifecycle state.",
-                    qualification: "External cancellation remains supported without imposing the ordinary computational-tool watchdog.",
-                    semanticWaitMaximumSeconds: semanticWaitMaximumSeconds
+                    qualification: toolName == MCPGlobalToolName.manageWorkspaces
+                        ? "Only switch-producing actions receive the \(MCPTimeoutPolicy.workspaceSwitchToolExecutionDeadlineSeconds)-second watchdog; all other manage_workspaces actions retain the workspace-lifecycle exemption."
+                        : "External cancellation remains supported without imposing the ordinary computational-tool watchdog.",
+                    semanticWaitMaximumSeconds: semanticWaitMaximumSeconds,
+                    conditionalExecutionOverrides: conditionalExecutionOverrides
                 )
             }
         }

--- a/Sources/RepoPrompt/Features/Diagnostics/MCP/MCPToolDurationInventory.swift
+++ b/Sources/RepoPrompt/Features/Diagnostics/MCP/MCPToolDurationInventory.swift
@@ -148,7 +148,7 @@ import RepoPromptShared
                     ),
                     ConditionalExecutionOverride(
                         action: "create",
-                        condition: "switch_to_created omitted or true",
+                        condition: "switch_to_created != false (handler default)",
                         executionDeadlineSeconds: workspaceSwitchExecutionDeadlineSeconds,
                         cleanupGraceSeconds: boundedCleanupGraceSeconds
                     ),

--- a/Sources/RepoPrompt/Features/Search/StoreBackedWorkspaceSearch.swift
+++ b/Sources/RepoPrompt/Features/Search/StoreBackedWorkspaceSearch.swift
@@ -49,18 +49,23 @@ enum StoreBackedWorkspaceSearch {
         try await ensureRootScopeAvailable(rootScope, store: store)
         try await ensureSearchReady(store: store, workspaceManager: workspaceManager)
 
-        let ingressFreshnessState = EditFlowPerf.begin(EditFlowPerf.Stage.Search.ingressFreshnessWait)
-        _ = await store.awaitAppliedIngress(rootScope: rootScope)
-        EditFlowPerf.end(EditFlowPerf.Stage.Search.ingressFreshnessWait, ingressFreshnessState)
-        try Task.checkCancellation()
-
         let effectiveMode = mode == .auto ? FileSearchActor.inferredAutoMode(pattern) : mode
         let admissionClass = broadSearchAdmissionClass(pattern: pattern, mode: mode, paths: paths)
         return try await store.withStoreBackedSearchAccess(
             searchMode: effectiveMode,
             admissionClass: admissionClass
         ) { fileSearchActor in
-            try await performSearch(
+            if admissionClass != nil {
+                try await ensureRootScopeAvailable(rootScope, store: store)
+                try await ensureSearchReady(store: store, workspaceManager: workspaceManager)
+            }
+
+            let ingressFreshnessState = EditFlowPerf.begin(EditFlowPerf.Stage.Search.ingressFreshnessWait)
+            _ = await store.awaitAppliedIngress(rootScope: rootScope)
+            EditFlowPerf.end(EditFlowPerf.Stage.Search.ingressFreshnessWait, ingressFreshnessState)
+            try Task.checkCancellation()
+
+            return try await performSearch(
                 pattern: pattern,
                 mode: mode,
                 effectiveMode: effectiveMode,

--- a/Sources/RepoPrompt/Features/Search/StoreBackedWorkspaceSearchLane.swift
+++ b/Sources/RepoPrompt/Features/Search/StoreBackedWorkspaceSearchLane.swift
@@ -42,14 +42,22 @@ enum StoreBackedWorkspaceSearchAdmissionError: LocalizedError, Equatable {
 /// Per-workspace execution lane for store-backed file search.
 ///
 /// Path-only and explicitly scoped searches bypass broad admission. Unscoped content-capable
-/// searches use a fixed one-active/one-queued gate so one workspace cannot monopolize another.
+/// searches use a fixed-capacity batch gate: a bounded set of active leases runs concurrently
+/// so a parallel burst (one connection's batched tool calls, or several agents on the same
+/// workspace) shares one ingress freshness flight instead of reconstructing it serially per
+/// search. Beyond the active batch, a bounded FIFO wait queue absorbs the rest of the burst;
+/// overflow still fails fast so one workspace cannot monopolize another.
 actor StoreBackedWorkspaceSearchLane {
     struct Configuration: Equatable {
         static let production = Configuration(
+            maxActiveLeases: 4,
+            maxQueuedWaiters: 4,
             maxQueueWait: .milliseconds(1500),
             retryAfterMilliseconds: 1000
         )
 
+        let maxActiveLeases: Int
+        let maxQueuedWaiters: Int
         let maxQueueWait: Duration
         let retryAfterMilliseconds: Int
 
@@ -59,9 +67,18 @@ actor StoreBackedWorkspaceSearchLane {
             return Int(clamping: milliseconds)
         }
 
-        init(maxQueueWait: Duration, retryAfterMilliseconds: Int = 1000) {
+        init(
+            maxActiveLeases: Int = 1,
+            maxQueuedWaiters: Int = 1,
+            maxQueueWait: Duration,
+            retryAfterMilliseconds: Int = 1000
+        ) {
+            precondition(maxActiveLeases >= 1)
+            precondition(maxQueuedWaiters >= 1)
             precondition(maxQueueWait > .zero)
             precondition(retryAfterMilliseconds >= 0)
+            self.maxActiveLeases = maxActiveLeases
+            self.maxQueuedWaiters = maxQueuedWaiters
             self.maxQueueWait = maxQueueWait
             self.retryAfterMilliseconds = retryAfterMilliseconds
         }
@@ -134,9 +151,9 @@ actor StoreBackedWorkspaceSearchLane {
     private let fileSearchActor = FileSearchActor()
     private var configuration: Configuration
     private let clock: AdmissionClock
-    private var activeLeaseID: UUID?
-    private var waiterID: UUID?
-    private var waiterState: WaiterState?
+    private var activeLeaseIDs: Set<UUID> = []
+    private var waiterIDsInOrder: [UUID] = []
+    private var waiterStatesByID: [UUID: WaiterState] = [:]
     private var grantCount = 0
     private var overloadCount = 0
     private var waitExpiryCount = 0
@@ -255,7 +272,7 @@ actor StoreBackedWorkspaceSearchLane {
         lifecycleCorrelation: EditFlowPerf.LifecycleCorrelation?
     ) async throws -> PermitAcquisition {
         try Task.checkCancellation()
-        if activeLeaseID == nil {
+        if activeLeaseIDs.count < configuration.maxActiveLeases {
             return allocatePermit(
                 searchMode: searchMode,
                 admissionClass: admissionClass,
@@ -263,7 +280,7 @@ actor StoreBackedWorkspaceSearchLane {
                 waited: false
             )
         }
-        guard waiterState == nil else {
+        guard waiterStatesByID.count < configuration.maxQueuedWaiters else {
             overloadCount &+= 1
             EditFlowPerf.lifecycleEvent(
                 EditFlowPerf.Lifecycle.Search.broadAdmissionOverloaded,
@@ -305,7 +322,7 @@ actor StoreBackedWorkspaceSearchLane {
         admissionClass: BroadSearchAdmissionClass,
         lifecycleCorrelation: EditFlowPerf.LifecycleCorrelation?
     ) {
-        if activeLeaseID == nil {
+        if activeLeaseIDs.count < configuration.maxActiveLeases {
             continuation.resume(returning: allocatePermit(
                 searchMode: searchMode,
                 admissionClass: admissionClass,
@@ -314,7 +331,7 @@ actor StoreBackedWorkspaceSearchLane {
             ))
             return
         }
-        guard waiterState == nil else {
+        guard waiterStatesByID.count < configuration.maxQueuedWaiters else {
             overloadCount &+= 1
             continuation.resume(throwing: StoreBackedWorkspaceSearchAdmissionError.queueFull(
                 scope: .perStore,
@@ -325,8 +342,8 @@ actor StoreBackedWorkspaceSearchLane {
 
         let enqueuedAt = clock.now()
         let deadline = enqueuedAt + configuration.maxQueueWait
-        waiterID = id
-        waiterState = WaiterState(
+        waiterIDsInOrder.append(id)
+        waiterStatesByID[id] = WaiterState(
             continuation: continuation,
             searchMode: searchMode,
             admissionClass: admissionClass,
@@ -335,7 +352,7 @@ actor StoreBackedWorkspaceSearchLane {
             deadline: deadline,
             timeoutTask: nil
         )
-        maximumWaiterCount = max(maximumWaiterCount, 1)
+        maximumWaiterCount = max(maximumWaiterCount, waiterStatesByID.count)
         EditFlowPerf.lifecycleEvent(
             EditFlowPerf.Lifecycle.Search.broadAdmissionWaitBegan,
             correlation: lifecycleCorrelation,
@@ -355,18 +372,23 @@ actor StoreBackedWorkspaceSearchLane {
                 // Grant and cancellation paths cancel the sleeper after removing the waiter.
             }
         }
-        if var current = waiterState, waiterID == id {
-            current.timeoutTask = timeoutTask
-            waiterState = current
+        if waiterStatesByID[id] != nil {
+            waiterStatesByID[id]?.timeoutTask = timeoutTask
         } else {
             timeoutTask.cancel()
         }
     }
 
+    private func removeWaiter(id: UUID) -> WaiterState? {
+        guard let state = waiterStatesByID.removeValue(forKey: id) else { return nil }
+        if let index = waiterIDsInOrder.firstIndex(of: id) {
+            waiterIDsInOrder.remove(at: index)
+        }
+        return state
+    }
+
     private func cancelWaiter(id: UUID) {
-        guard waiterID == id, let state = waiterState else { return }
-        waiterID = nil
-        waiterState = nil
+        guard let state = removeWaiter(id: id) else { return }
         state.timeoutTask?.cancel()
         queuedCancellationCount &+= 1
         EditFlowPerf.lifecycleEvent(
@@ -384,9 +406,7 @@ actor StoreBackedWorkspaceSearchLane {
     }
 
     private func expireWaiter(id: UUID) {
-        guard waiterID == id, let state = waiterState else { return }
-        waiterID = nil
-        waiterState = nil
+        guard let state = removeWaiter(id: id) else { return }
         waitExpiryCount &+= 1
         EditFlowPerf.lifecycleEvent(
             EditFlowPerf.Lifecycle.Search.broadAdmissionWaitExpired,
@@ -405,8 +425,7 @@ actor StoreBackedWorkspaceSearchLane {
     }
 
     private func release(_ acquisition: PermitAcquisition) {
-        guard activeLeaseID == acquisition.leaseID else { return }
-        activeLeaseID = nil
+        guard activeLeaseIDs.remove(acquisition.leaseID) != nil else { return }
         EditFlowPerf.lifecycleEvent(
             EditFlowPerf.Lifecycle.Search.broadAdmissionPermitReleased,
             correlation: acquisition.lifecycleCorrelation,
@@ -418,25 +437,24 @@ actor StoreBackedWorkspaceSearchLane {
                 queueAgeBucket: acquisition.queueAgeBucket
             )
         )
-        promoteWaiterIfPossible()
+        promoteWaitersIfPossible()
     }
 
-    private func promoteWaiterIfPossible() {
-        guard activeLeaseID == nil,
-              waiterID != nil,
-              let state = waiterState
-        else { return }
-        waiterID = nil
-        waiterState = nil
-        state.timeoutTask?.cancel()
-        let acquisition = allocatePermit(
-            searchMode: state.searchMode,
-            admissionClass: state.admissionClass,
-            lifecycleCorrelation: state.lifecycleCorrelation,
-            waited: true,
-            queueAgeBucket: Self.queueAgeBucket(since: state.enqueuedAtUptimeNanoseconds)
-        )
-        state.continuation.resume(returning: acquisition)
+    private func promoteWaitersIfPossible() {
+        while activeLeaseIDs.count < configuration.maxActiveLeases,
+              let id = waiterIDsInOrder.first,
+              let state = removeWaiter(id: id)
+        {
+            state.timeoutTask?.cancel()
+            let acquisition = allocatePermit(
+                searchMode: state.searchMode,
+                admissionClass: state.admissionClass,
+                lifecycleCorrelation: state.lifecycleCorrelation,
+                waited: true,
+                queueAgeBucket: Self.queueAgeBucket(since: state.enqueuedAtUptimeNanoseconds)
+            )
+            state.continuation.resume(returning: acquisition)
+        }
     }
 
     private func allocatePermit(
@@ -446,11 +464,11 @@ actor StoreBackedWorkspaceSearchLane {
         waited: Bool,
         queueAgeBucket: String = "immediate"
     ) -> PermitAcquisition {
-        precondition(activeLeaseID == nil)
+        precondition(activeLeaseIDs.count < configuration.maxActiveLeases)
         let leaseID = UUID()
-        activeLeaseID = leaseID
+        activeLeaseIDs.insert(leaseID)
         grantCount &+= 1
-        maximumActivePermitCount = max(maximumActivePermitCount, 1)
+        maximumActivePermitCount = max(maximumActivePermitCount, activeLeaseIDs.count)
         let acquisition = PermitAcquisition(
             leaseID: leaseID,
             searchMode: searchMode,
@@ -476,8 +494,8 @@ actor StoreBackedWorkspaceSearchLane {
 
     private func metrics() -> AdmissionMetrics {
         AdmissionMetrics(
-            activeCount: activeLeaseID == nil ? 0 : 1,
-            queueDepth: waiterState == nil ? 0 : 1
+            activeCount: activeLeaseIDs.count,
+            queueDepth: waiterStatesByID.count
         )
     }
 
@@ -490,7 +508,7 @@ actor StoreBackedWorkspaceSearchLane {
     ) -> EditFlowPerf.Dimensions {
         EditFlowPerf.Dimensions(
             outcome: outcome,
-            storeCapacity: 1,
+            storeCapacity: configuration.maxActiveLeases,
             globalCapacity: 0,
             storeActiveCount: metrics.activeCount,
             globalActiveCount: 0,
@@ -554,8 +572,8 @@ actor StoreBackedWorkspaceSearchLane {
         func snapshotForTesting() -> Snapshot {
             Snapshot(
                 configuration: configuration,
-                activePermitCount: activeLeaseID == nil ? 0 : 1,
-                waiterCount: waiterState == nil ? 0 : 1,
+                activePermitCount: activeLeaseIDs.count,
+                waiterCount: waiterStatesByID.count,
                 grantCount: grantCount,
                 overloadCount: overloadCount,
                 waitExpiryCount: waitExpiryCount,
@@ -566,7 +584,7 @@ actor StoreBackedWorkspaceSearchLane {
         }
 
         func configureForTesting(_ newConfiguration: Configuration) -> DebugConfigurationUpdateResult {
-            guard activeLeaseID == nil, waiterState == nil else {
+            guard activeLeaseIDs.isEmpty, waiterStatesByID.isEmpty else {
                 return .busy(snapshotForTesting())
             }
             configuration = newConfiguration

--- a/Sources/RepoPrompt/Features/Workspaces/ViewModels/WorkspaceManagerViewModel.swift
+++ b/Sources/RepoPrompt/Features/Workspaces/ViewModels/WorkspaceManagerViewModel.swift
@@ -446,9 +446,22 @@ class WorkspaceManagerViewModel: ObservableObject {
     @Published private(set) var pendingSwitchConfirmation: WorkspaceSwitchConfirmation?
     @Published private(set) var workspaceSwitchOverlayState: WorkspaceSwitchOverlayState?
     @Published private(set) var isWorkspaceSwitchOverlayVisible: Bool = false
+    @Published private(set) var activeWorkspaceSwitch: WorkspaceSwitchActivity?
+    @Published private(set) var lastWorkspaceSwitchBlockageReport: WorkspaceSwitchBlockageReport?
+    @Published private(set) var pendingWorkspaceSwitchBlockedNotice: WorkspaceSwitchBlockedNotice?
     private let instanceID = UUID()
-    private var pendingSwitchContinuation: CheckedContinuation<Bool, Never>?
+
+    private struct PendingSwitchConfirmationRequest {
+        let operationID: UUID
+        let confirmationID: UUID
+        let continuation: CheckedContinuation<Bool, Never>
+    }
+
+    private var pendingSwitchConfirmationRequest: PendingSwitchConfirmationRequest?
     private let switchSessionRegistry = WorkspaceSwitchSessionRegistry()
+    private let switchTimingPolicy: WorkspaceSwitchTimingPolicy
+    private var workspaceSwitchPhaseDidChangeHandlerForTesting: ((WorkspaceSwitchPhase) -> Void)?
+    private var workspaceSwitchRecoveryWillBeginHandlerForTesting: (@MainActor () async -> Void)?
 
     private struct WorkspaceDidSwitchListener {
         let label: String
@@ -543,7 +556,7 @@ class WorkspaceManagerViewModel: ObservableObject {
     }
 
     var hasPendingSwitchConfirmation: Bool {
-        pendingSwitchContinuation != nil
+        pendingSwitchConfirmationRequest != nil
     }
 
     func registerSwitchSessionProvider(_ provider: any WorkspaceSwitchSessionProvider) {
@@ -680,7 +693,10 @@ class WorkspaceManagerViewModel: ObservableObject {
     @Published private(set) var workspaceSearchReadinessState: WorkspaceSearchReadinessState = .idle
     private var workspaceHydrationGeneration: UInt64 = 0
     private var postCatalogRootWorkTasks: [UInt64: [Task<Void, Never>]] = [:]
-    private var shouldReturnToSystemAfterSwitchCancellation = false
+    private var returnToSystemAfterSwitchCancellationOperationID: UUID?
+    private var committedWorkspaceSwitchOperationID: UUID?
+    private var recoveringWorkspaceSwitchOperationID: UUID?
+    private var rootsUnloadedWorkspaceSwitchOperationID: UUID?
     private var postSwitchGitDataLoadTask: Task<Void, Never>?
     private var postSwitchGitDataLoadToken: UUID?
     var isRefreshing: Bool = false
@@ -1176,7 +1192,8 @@ class WorkspaceManagerViewModel: ObservableObject {
     init(
         fileManager: WorkspaceFilesViewModel,
         promptViewModel: PromptViewModel,
-        workspaceSearchService: WorkspaceSearchService = WorkspaceSearchService()
+        workspaceSearchService: WorkspaceSearchService = WorkspaceSearchService(),
+        switchTimingPolicy: WorkspaceSwitchTimingPolicy = .production
     ) {
         #if DEBUG
             let initStartMS = WorkspaceRestorePerfLog.timestampMSIfEnabled()
@@ -1184,6 +1201,7 @@ class WorkspaceManagerViewModel: ObservableObject {
         self.fileManager = fileManager
         self.promptViewModel = promptViewModel
         self.workspaceSearchService = workspaceSearchService
+        self.switchTimingPolicy = switchTimingPolicy
         self.promptViewModel.attachWorkspaceManager(self)
         self.fileManager.setWorkspaceManager(self)
 
@@ -1845,75 +1863,581 @@ class WorkspaceManagerViewModel: ObservableObject {
 
     // MARK: - Switch
 
+    private func beginWorkspaceSwitchOperation(
+        to newWorkspace: WorkspaceModel,
+        reason: String
+    ) -> UUID? {
+        guard activeWorkspaceSwitch == nil else { return nil }
+        let operationID = UUID()
+        let now = switchTimingPolicy.now()
+        activeWorkspaceSwitch = WorkspaceSwitchActivity(
+            operationID: operationID,
+            previousWorkspaceID: activeWorkspaceID,
+            previousWorkspaceName: activeWorkspace?.name,
+            targetWorkspaceID: newWorkspace.id,
+            targetWorkspaceName: newWorkspace.name,
+            reason: reason,
+            phase: .preparing,
+            startedAt: now,
+            phaseStartedAt: now
+        )
+        isSwitchingWorkspace = true
+        return operationID
+    }
+
+    private func ownsWorkspaceSwitchOperation(_ operationID: UUID) -> Bool {
+        activeWorkspaceSwitch?.operationID == operationID
+    }
+
+    private func advanceWorkspaceSwitchOperation(
+        _ operationID: UUID,
+        to phase: WorkspaceSwitchPhase
+    ) {
+        guard let activity = activeWorkspaceSwitch,
+              activity.operationID == operationID,
+              activity.phase != phase
+        else { return }
+        activeWorkspaceSwitch = WorkspaceSwitchActivity(
+            operationID: activity.operationID,
+            previousWorkspaceID: activity.previousWorkspaceID,
+            previousWorkspaceName: activity.previousWorkspaceName,
+            targetWorkspaceID: activity.targetWorkspaceID,
+            targetWorkspaceName: activity.targetWorkspaceName,
+            reason: activity.reason,
+            phase: phase,
+            startedAt: activity.startedAt,
+            phaseStartedAt: switchTimingPolicy.now()
+        )
+        workspaceSwitchPhaseDidChangeHandlerForTesting?(phase)
+    }
+
+    private func finishWorkspaceSwitchOperation(_ operationID: UUID) {
+        if let pending = pendingSwitchConfirmationRequest,
+           pending.operationID == operationID
+        {
+            pendingSwitchConfirmationRequest = nil
+            pendingSwitchConfirmation = nil
+            pending.continuation.resume(returning: false)
+        }
+        guard ownsWorkspaceSwitchOperation(operationID) else { return }
+        if returnToSystemAfterSwitchCancellationOperationID == operationID {
+            returnToSystemAfterSwitchCancellationOperationID = nil
+        }
+        if committedWorkspaceSwitchOperationID == operationID {
+            committedWorkspaceSwitchOperationID = nil
+        }
+        if recoveringWorkspaceSwitchOperationID == operationID {
+            recoveringWorkspaceSwitchOperationID = nil
+        }
+        if rootsUnloadedWorkspaceSwitchOperationID == operationID {
+            rootsUnloadedWorkspaceSwitchOperationID = nil
+        }
+        activeWorkspaceSwitch = nil
+        isSwitchingWorkspace = false
+        drainPendingRepoPathSyncIfNeeded()
+        notifySwitchingComplete()
+    }
+
+    private func markWorkspaceSwitchCommitted(_ operationID: UUID) {
+        guard ownsWorkspaceSwitchOperation(operationID) else { return }
+        committedWorkspaceSwitchOperationID = operationID
+    }
+
+    private func markWorkspaceSwitchRootsUnloaded(_ operationID: UUID) {
+        guard ownsWorkspaceSwitchOperation(operationID) else { return }
+        rootsUnloadedWorkspaceSwitchOperationID = operationID
+    }
+
+    private func clearWorkspaceSwitchBlockedNotice(blockedBy operationID: UUID) {
+        guard pendingWorkspaceSwitchBlockedNotice?.isBlocked(by: operationID) == true else { return }
+        pendingWorkspaceSwitchBlockedNotice = nil
+    }
+
+    private func retargetWorkspaceSwitchOperation(
+        _ operationID: UUID,
+        to workspace: WorkspaceModel,
+        reason: String
+    ) {
+        guard let activity = activeWorkspaceSwitch,
+              activity.operationID == operationID
+        else { return }
+        activeWorkspaceSwitch = WorkspaceSwitchActivity(
+            operationID: activity.operationID,
+            previousWorkspaceID: activity.previousWorkspaceID,
+            previousWorkspaceName: activity.previousWorkspaceName,
+            targetWorkspaceID: workspace.id,
+            targetWorkspaceName: workspace.name,
+            reason: reason,
+            phase: .preparing,
+            startedAt: activity.startedAt,
+            phaseStartedAt: switchTimingPolicy.now()
+        )
+        workspaceSwitchPhaseDidChangeHandlerForTesting?(.preparing)
+    }
+
+    private func completeWorkspaceSwitchOperation(
+        _ operationID: UUID,
+        originalResult: WorkspaceSwitchResult
+    ) async -> WorkspaceSwitchResult {
+        var finalResult = originalResult
+        let originalActivity = activeWorkspaceSwitch
+        let explicitlyRequestedRecovery = returnToSystemAfterSwitchCancellationOperationID == operationID
+        let crossedDestructiveBoundary = rootsUnloadedWorkspaceSwitchOperationID == operationID
+            || activeWorkspaceID != originalActivity?.previousWorkspaceID
+        let needsRecovery = !originalResult.didSwitch
+            && committedWorkspaceSwitchOperationID != operationID
+            && (explicitlyRequestedRecovery || crossedDestructiveBoundary)
+
+        if needsRecovery, let originalActivity {
+            returnToSystemAfterSwitchCancellationOperationID = nil
+            let recoveryResult = await recoverWorkspaceSwitch(
+                operationID: operationID,
+                originalActivity: originalActivity,
+                explicitlyReturnToSystem: explicitlyRequestedRecovery
+            )
+            if !recoveryResult.didSwitch {
+                let detail = recoveryResult.message ?? "Unknown recovery failure."
+                let message = "Workspace switch recovery could not restore a usable workspace: \(detail)"
+                pendingWorkspaceSwitchBlockedNotice = WorkspaceSwitchBlockedNotice(message: message)
+                finalResult = .blocked(message)
+            }
+        }
+        if finalResult.didSwitch, committedWorkspaceSwitchOperationID == operationID {
+            clearWorkspaceSwitchBlockedNotice(blockedBy: operationID)
+        }
+        finishWorkspaceSwitchOperation(operationID)
+        return finalResult
+    }
+
+    private func recoverWorkspaceSwitch(
+        operationID: UUID,
+        originalActivity: WorkspaceSwitchActivity,
+        explicitlyReturnToSystem: Bool
+    ) async -> WorkspaceSwitchResult {
+        guard ownsWorkspaceSwitchOperation(operationID) else {
+            return .blocked("Workspace switch recovery lost operation ownership.")
+        }
+
+        let fallback = workspaces.first(where: { $0.isSystemWorkspace }) ?? getOrCreateSystemWorkspace()
+        var recoveryTargets: [WorkspaceModel] = []
+        if !explicitlyReturnToSystem,
+           let previousWorkspaceID = originalActivity.previousWorkspaceID,
+           previousWorkspaceID != originalActivity.targetWorkspaceID,
+           let previousWorkspace = workspaces.first(where: { $0.id == previousWorkspaceID })
+        {
+            recoveryTargets.append(previousWorkspace)
+        }
+        if !recoveryTargets.contains(where: { $0.id == fallback.id }) {
+            recoveryTargets.append(fallback)
+        }
+
+        recoveringWorkspaceSwitchOperationID = operationID
+        defer {
+            if recoveringWorkspaceSwitchOperationID == operationID {
+                recoveringWorkspaceSwitchOperationID = nil
+            }
+        }
+        committedWorkspaceSwitchOperationID = nil
+        if let workspaceSwitchRecoveryWillBeginHandlerForTesting {
+            await workspaceSwitchRecoveryWillBeginHandlerForTesting()
+        }
+
+        var failures: [String] = []
+        for recoveryTarget in recoveryTargets {
+            guard ownsWorkspaceSwitchOperation(operationID) else {
+                return .blocked("Workspace switch recovery was superseded before fallback activation.")
+            }
+            if activeWorkspaceID == recoveryTarget.id,
+               rootsUnloadedWorkspaceSwitchOperationID != operationID
+            {
+                return .switched
+            }
+
+            let recoveryReason = explicitlyReturnToSystem
+                ? "returnToSystemAfterCancellation"
+                : "recoverAfterPrecommitFailure"
+            committedWorkspaceSwitchOperationID = nil
+            retargetWorkspaceSwitchOperation(
+                operationID,
+                to: recoveryTarget,
+                reason: recoveryReason
+            )
+            let recoveryTask = Task { @MainActor [weak self] in
+                guard let self else {
+                    return WorkspaceSwitchResult.blocked("Workspace switch recovery manager was released.")
+                }
+                return await performWorkspaceSwitch(
+                    to: recoveryTarget,
+                    saveState: false,
+                    reason: recoveryReason,
+                    operationID: operationID
+                )
+            }
+            let result = await recoveryTask.value
+            if result.didSwitch {
+                return result
+            }
+            failures.append("\(recoveryTarget.name): \(result.message ?? "unknown failure")")
+        }
+
+        return .blocked(failures.joined(separator: "; "))
+    }
+
+    private func blockageReport(
+        requestedWorkspace: WorkspaceModel,
+        activeSwitch: WorkspaceSwitchActivity,
+        messageOverride: String? = nil
+    ) -> WorkspaceSwitchBlockageReport {
+        let now = switchTimingPolicy.now()
+        let totalAge = max(0, now.timeIntervalSince(activeSwitch.startedAt))
+        let phaseAge = max(0, now.timeIntervalSince(activeSwitch.phaseStartedAt))
+        let isStale = totalAge >= switchTimingPolicy.staleThreshold
+        let stateLabel = isStale ? "stale" : "active"
+        let formattedTotalAge = String(format: "%.1f", totalAge)
+        let formattedPhaseAge = String(format: "%.1f", phaseAge)
+        let message = messageOverride ??
+            "Workspace switch to \"\(requestedWorkspace.name)\" is blocked by a \(stateLabel) switch to \"\(activeSwitch.targetWorkspaceName)\" (reason: \(activeSwitch.reason), phase: \(activeSwitch.phase.displayName), total age: \(formattedTotalAge)s, phase age: \(formattedPhaseAge)s)."
+        return WorkspaceSwitchBlockageReport(
+            requestedTargetWorkspaceID: requestedWorkspace.id,
+            requestedTargetWorkspaceName: requestedWorkspace.name,
+            activeSwitch: activeSwitch,
+            totalAge: totalAge,
+            phaseAge: phaseAge,
+            isStale: isStale,
+            message: message
+        )
+    }
+
+    private func publishWorkspaceSwitchBlockage(_ report: WorkspaceSwitchBlockageReport) {
+        lastWorkspaceSwitchBlockageReport = report
+        if report.isStale {
+            Self.logger.error("\(report.message, privacy: .public)")
+        } else {
+            Self.logger.info("\(report.message, privacy: .public)")
+        }
+    }
+
+    private func concurrentWorkspaceSwitchResult(
+        requestedWorkspace: WorkspaceModel
+    ) -> WorkspaceSwitchResult? {
+        guard let activeSwitch = activeWorkspaceSwitch else { return nil }
+        let report = blockageReport(
+            requestedWorkspace: requestedWorkspace,
+            activeSwitch: activeSwitch
+        )
+        publishWorkspaceSwitchBlockage(report)
+        return .blocked(report.message)
+    }
+
+    private func cancellationResult(
+        operationID: UUID,
+        targetWorkspace: WorkspaceModel,
+        boundary: String
+    ) -> WorkspaceSwitchResult? {
+        guard ownsWorkspaceSwitchOperation(operationID) else {
+            return .cancelled("Workspace switch to \"\(targetWorkspace.name)\" was superseded at \(boundary).")
+        }
+        if committedWorkspaceSwitchOperationID == operationID
+            || recoveringWorkspaceSwitchOperationID == operationID
+        {
+            return nil
+        }
+        guard Task.isCancelled || returnToSystemAfterSwitchCancellationOperationID == operationID else { return nil }
+        return .cancelled("Workspace switch to \"\(targetWorkspace.name)\" was cancelled at \(boundary).")
+    }
+
+    private func waitForChatBusyToClear() async -> Bool {
+        guard isChatBusy else { return true }
+        var remaining = switchTimingPolicy.chatBusySettleTimeoutNanoseconds
+        let pollInterval = max(1, switchTimingPolicy.chatBusyPollIntervalNanoseconds)
+        while isChatBusy, remaining > 0 {
+            let interval = min(pollInterval, remaining)
+            do {
+                try await switchTimingPolicy.sleep(interval)
+            } catch {
+                return false
+            }
+            if Task.isCancelled { return false }
+            remaining -= interval
+        }
+        return !isChatBusy
+    }
+
+    private func remainingSessionSummary() -> String {
+        let items = activeSessionSnapshot().items
+        guard !items.isEmpty else { return "no reported active sessions" }
+        return items.map { $0.formattedCount() }.joined(separator: ", ")
+    }
+
     @MainActor
     func requestWorkspaceSwitch(to newWorkspace: WorkspaceModel, saveState: Bool = true, reason: String = "userOrInternal") async -> WorkspaceSwitchResult {
+        if let concurrentResult = concurrentWorkspaceSwitchResult(requestedWorkspace: newWorkspace) {
+            return userVisibleWorkspaceSwitchResult(
+                concurrentResult,
+                blockingOperationID: activeWorkspaceSwitch?.operationID
+            )
+        }
+        if newWorkspace.id == activeWorkspaceID {
+            return userVisibleWorkspaceSwitchResult(
+                .blocked("Already on workspace \"\(newWorkspace.name)\".")
+            )
+        }
+        if isRefreshing {
+            return userVisibleWorkspaceSwitchResult(
+                .blocked("Cannot switch workspaces while refresh is in progress.")
+            )
+        }
+        guard let operationID = beginWorkspaceSwitchOperation(to: newWorkspace, reason: reason) else {
+            let result = concurrentWorkspaceSwitchResult(requestedWorkspace: newWorkspace)
+                ?? .blocked("Workspace switch already in progress.")
+            return userVisibleWorkspaceSwitchResult(
+                result,
+                blockingOperationID: activeWorkspaceSwitch?.operationID
+            )
+        }
+
+        let operationResult = await performRequestedWorkspaceSwitch(
+            to: newWorkspace,
+            saveState: saveState,
+            reason: reason,
+            operationID: operationID
+        )
+        let finalResult = await completeWorkspaceSwitchOperation(
+            operationID,
+            originalResult: operationResult
+        )
+        return userVisibleWorkspaceSwitchResult(finalResult)
+    }
+
+    private func userVisibleWorkspaceSwitchResult(
+        _ result: WorkspaceSwitchResult,
+        blockingOperationID: UUID? = nil
+    ) -> WorkspaceSwitchResult {
+        if case let .blocked(message) = result {
+            pendingWorkspaceSwitchBlockedNotice = WorkspaceSwitchBlockedNotice(
+                message: message,
+                blockingOperationID: blockingOperationID
+            )
+        }
+        return result
+    }
+
+    private func performRequestedWorkspaceSwitch(
+        to newWorkspace: WorkspaceModel,
+        saveState: Bool,
+        reason: String,
+        operationID: UUID
+    ) async -> WorkspaceSwitchResult {
+        let snapshot = activeSessionSnapshot()
+        if snapshot.hasActiveSessions {
+            advanceWorkspaceSwitchOperation(operationID, to: .awaitingConfirmation)
+            let confirmation = WorkspaceSwitchConfirmation(
+                targetWorkspaceName: newWorkspace.name,
+                items: snapshot.items
+            )
+            let approved = await requestSwitchConfirmation(confirmation, operationID: operationID)
+            if let cancellation = cancellationResult(
+                operationID: operationID,
+                targetWorkspace: newWorkspace,
+                boundary: "confirmation"
+            ) {
+                return cancellation
+            }
+            guard approved else {
+                return .cancelled(confirmation.cancelMessage)
+            }
+
+            advanceWorkspaceSwitchOperation(operationID, to: .cancellingSessions)
+            await cancelActiveSessions()
+            if let cancellation = cancellationResult(
+                operationID: operationID,
+                targetWorkspace: newWorkspace,
+                boundary: "session cancellation"
+            ) {
+                return cancellation
+            }
+
+            if isChatBusy {
+                advanceWorkspaceSwitchOperation(operationID, to: .waitingForChatIdle)
+                let settled = await waitForChatBusyToClear()
+                if let cancellation = cancellationResult(
+                    operationID: operationID,
+                    targetWorkspace: newWorkspace,
+                    boundary: "chat busy settling"
+                ) {
+                    return cancellation
+                }
+                guard settled, !isChatBusy else {
+                    guard let activeSwitch = activeWorkspaceSwitch,
+                          activeSwitch.operationID == operationID
+                    else {
+                        return .blocked("Workspace switch could not verify chat session cleanup.")
+                    }
+                    let timeoutSeconds = Double(switchTimingPolicy.chatBusySettleTimeoutNanoseconds) / 1_000_000_000
+                    let formattedTimeout = String(format: "%.1f", timeoutSeconds)
+                    let message = "Workspace switch to \"\(newWorkspace.name)\" is blocked because isChatBusy remained true for \(formattedTimeout)s after session cancellation; remaining sessions: \(remainingSessionSummary())."
+                    let report = blockageReport(
+                        requestedWorkspace: newWorkspace,
+                        activeSwitch: activeSwitch,
+                        messageOverride: message
+                    )
+                    publishWorkspaceSwitchBlockage(report)
+                    return .blocked(report.message)
+                }
+            }
+            advanceWorkspaceSwitchOperation(operationID, to: .preparing)
+        }
+
+        return await performWorkspaceSwitch(
+            to: newWorkspace,
+            saveState: saveState,
+            reason: reason,
+            operationID: operationID
+        )
+    }
+
+    private func requestSwitchConfirmation(
+        _ confirmation: WorkspaceSwitchConfirmation,
+        operationID: UUID
+    ) async -> Bool {
+        guard pendingSwitchConfirmationRequest == nil else { return false }
+        return await withTaskCancellationHandler {
+            if Task.isCancelled { return false }
+            return await withCheckedContinuation { continuation in
+                guard ownsWorkspaceSwitchOperation(operationID), !Task.isCancelled else {
+                    continuation.resume(returning: false)
+                    return
+                }
+                pendingSwitchConfirmationRequest = PendingSwitchConfirmationRequest(
+                    operationID: operationID,
+                    confirmationID: confirmation.id,
+                    continuation: continuation
+                )
+                pendingSwitchConfirmation = confirmation
+            }
+        } onCancel: {
+            Task { @MainActor [weak self] in
+                self?.cancelPendingSwitchConfirmation(
+                    operationID: operationID,
+                    confirmationID: confirmation.id
+                )
+            }
+        }
+    }
+
+    private func cancelPendingSwitchConfirmation(
+        operationID: UUID,
+        confirmationID: UUID
+    ) {
+        guard let pending = pendingSwitchConfirmationRequest,
+              pending.operationID == operationID,
+              pending.confirmationID == confirmationID
+        else { return }
+        pendingSwitchConfirmationRequest = nil
+        pendingSwitchConfirmation = nil
+        pending.continuation.resume(returning: false)
+    }
+
+    func resolveSwitchConfirmation(id confirmationID: UUID, allow: Bool) {
+        guard let pending = pendingSwitchConfirmationRequest,
+              pending.confirmationID == confirmationID
+        else { return }
+        pendingSwitchConfirmationRequest = nil
+        pendingSwitchConfirmation = nil
+        pending.continuation.resume(returning: allow)
+    }
+
+    func dismissWorkspaceSwitchBlockedNotice(id noticeID: UUID) {
+        guard pendingWorkspaceSwitchBlockedNotice?.id == noticeID else { return }
+        pendingWorkspaceSwitchBlockedNotice = nil
+    }
+
+    func setWorkspaceSwitchPhaseDidChangeHandlerForTesting(
+        _ handler: ((WorkspaceSwitchPhase) -> Void)?
+    ) {
+        workspaceSwitchPhaseDidChangeHandlerForTesting = handler
+    }
+
+    func setWorkspaceSwitchRecoveryWillBeginHandlerForTesting(
+        _ handler: (@MainActor () async -> Void)?
+    ) {
+        workspaceSwitchRecoveryWillBeginHandlerForTesting = handler
+    }
+
+    @discardableResult
+    func reactivateWorkspaceAfterReplacement(
+        _ workspace: WorkspaceModel,
+        reason: String = "restoredWorkspaceReplacement"
+    ) async -> WorkspaceSwitchResult {
+        guard workspace.id == activeWorkspaceID else {
+            return await switchWorkspace(to: workspace, saveState: false, reason: reason)
+        }
+        if let concurrentResult = concurrentWorkspaceSwitchResult(requestedWorkspace: workspace) {
+            return concurrentResult
+        }
+        if isRefreshing {
+            return .blocked("Cannot reload the active workspace while refresh is in progress.")
+        }
+        guard let operationID = beginWorkspaceSwitchOperation(to: workspace, reason: reason) else {
+            return concurrentWorkspaceSwitchResult(requestedWorkspace: workspace)
+                ?? .blocked("Workspace reload already in progress.")
+        }
+        let operationResult = await performWorkspaceSwitch(
+            to: workspace,
+            saveState: false,
+            reason: reason,
+            operationID: operationID
+        )
+        return await completeWorkspaceSwitchOperation(
+            operationID,
+            originalResult: operationResult
+        )
+    }
+
+    @discardableResult
+    func switchWorkspace(to newWorkspace: WorkspaceModel, saveState: Bool = true, reason: String = "internal") async -> WorkspaceSwitchResult {
+        if let concurrentResult = concurrentWorkspaceSwitchResult(requestedWorkspace: newWorkspace) {
+            return concurrentResult
+        }
         if newWorkspace.id == activeWorkspaceID {
             return .blocked("Already on workspace \"\(newWorkspace.name)\".")
         }
         if isRefreshing {
             return .blocked("Cannot switch workspaces while refresh is in progress.")
         }
-        if isSwitchingWorkspace {
-            return .blocked("Workspace switch already in progress.")
+        guard let operationID = beginWorkspaceSwitchOperation(to: newWorkspace, reason: reason) else {
+            return concurrentWorkspaceSwitchResult(requestedWorkspace: newWorkspace)
+                ?? .blocked("Workspace switch already in progress.")
         }
-
-        let snapshot = activeSessionSnapshot()
-        if snapshot.hasActiveSessions {
-            let confirmation = WorkspaceSwitchConfirmation(
-                targetWorkspaceName: newWorkspace.name,
-                items: snapshot.items
-            )
-            let approved = await requestSwitchConfirmation(confirmation)
-            guard approved else {
-                return .cancelled(confirmation.cancelMessage)
-            }
-            await cancelActiveSessions()
-        }
-
-        let previousID = activeWorkspaceID
-        await switchWorkspace(to: newWorkspace, saveState: saveState, reason: reason)
-
-        if activeWorkspaceID == newWorkspace.id || previousID == newWorkspace.id {
-            return .switched
-        }
-        return .blocked("Workspace switch did not complete.")
+        let operationResult = await performWorkspaceSwitch(
+            to: newWorkspace,
+            saveState: saveState,
+            reason: reason,
+            operationID: operationID
+        )
+        return await completeWorkspaceSwitchOperation(
+            operationID,
+            originalResult: operationResult
+        )
     }
 
-    private func requestSwitchConfirmation(_ confirmation: WorkspaceSwitchConfirmation) async -> Bool {
-        if pendingSwitchContinuation != nil {
-            return false
+    private func performWorkspaceSwitch(
+        to newWorkspace: WorkspaceModel,
+        saveState: Bool,
+        reason: String,
+        operationID: UUID
+    ) async -> WorkspaceSwitchResult {
+        guard ownsWorkspaceSwitchOperation(operationID) else {
+            return .cancelled("Workspace switch to \"\(newWorkspace.name)\" was superseded before preparation.")
         }
-        return await withCheckedContinuation { continuation in
-            pendingSwitchContinuation = continuation
-            pendingSwitchConfirmation = confirmation
-        }
-    }
-
-    func resolveSwitchConfirmation(allow: Bool) {
-        guard let continuation = pendingSwitchContinuation else {
-            pendingSwitchConfirmation = nil
-            return
-        }
-        pendingSwitchContinuation = nil
-        pendingSwitchConfirmation = nil
-        continuation.resume(returning: allow)
-    }
-
-    func switchWorkspace(to newWorkspace: WorkspaceModel, saveState: Bool = true, reason: String = "internal") async {
         guard !isRefreshing else {
-            print("Cannot switch workspace while refresh is in progress.")
-            return
-        }
-        guard !isSwitchingWorkspace else {
-            print("Already switching workspace—skipping")
-            return
+            return .blocked("Cannot switch workspaces while refresh is in progress.")
         }
         guard !isChatBusy else {
-            print("Cannot switch while chat is busy.")
-            return
+            return .blocked("Cannot switch workspaces while chat is busy.")
         }
 
-        let totalStart = Date()
+        let totalStart = switchTimingPolicy.now()
         var shouldSchedulePostSwitchGitDataLoad = false
         var rootsUnloadedBeforeFolderLoad = false
         let previousActiveWorkspace = activeWorkspace
@@ -1959,9 +2483,47 @@ class WorkspaceManagerViewModel: ObservableObject {
         postSwitchGitDataLoadTask = nil
         postSwitchGitDataLoadToken = nil
         stopPollTimer()
-        isSwitchingWorkspace = true
         if shouldShowWorkspaceSwitchOverlay(for: newWorkspace) {
             showWorkspaceSwitchOverlay(for: newWorkspace)
+        }
+        defer {
+            if ownsWorkspaceSwitchOperation(operationID) {
+                let shouldReturnToSystem = returnToSystemAfterSwitchCancellationOperationID == operationID
+                hideWorkspaceSwitchOverlay(reason: "switch defer cleanup")
+                promptViewModel.startTokenCountUpdateTimer()
+                startPollTimer()
+                let totalDuration = switchTimingPolicy.now().timeIntervalSince(totalStart)
+                logWorkspaceSwitch("END switch to \"\(newWorkspace.name)\" total=\(String(format: "%.3f", totalDuration))s shouldReturnToSystem=\(shouldReturnToSystem)")
+                #if DEBUG
+                    if let restorePerfStartMS {
+                        let counts = fileManager.restorePerfLoadedTreeCounts()
+                        WorkspaceRestorePerfLog.event(
+                            "workspaceSwitch.end",
+                            fields: debugWorkspaceOpenTraceFields().merging([
+                                "reason": reason,
+                                "restored": "\(reason == "restore")",
+                                "saveState": "\(saveState)",
+                                "effectiveSaveState": "\(effectiveSaveState)",
+                                "activeWorkspaceID": WorkspaceRestorePerfLog.shortID(activeWorkspaceID),
+                                "loadedRoots": "\(counts.rootCount)",
+                                "loadedFolders": "\(counts.folderCount)",
+                                "loadedFiles": "\(counts.fileCount)",
+                                "shouldReturnToSystem": "\(shouldReturnToSystem)",
+                                "total": WorkspaceRestorePerfLog.formatElapsedMS(since: restorePerfStartMS)
+                            ], uniquingKeysWith: { current, _ in current })
+                        )
+                    }
+                    debugFinishWorkspaceOpenTrace()
+                #endif
+                if shouldSchedulePostSwitchGitDataLoad,
+                   let switchedWorkspace = activeWorkspace,
+                   switchedWorkspace.id == newWorkspace.id,
+                   !switchedWorkspace.isSystemWorkspace,
+                   !shouldReturnToSystem
+                {
+                    schedulePostSwitchGitDataLoad(for: switchedWorkspace, reason: "postSwitch")
+                }
+            }
         }
         await promptViewModel.stopTokenCountUpdateTimer()
         workspaceHydrationGeneration &+= 1
@@ -1969,54 +2531,16 @@ class WorkspaceManagerViewModel: ObservableObject {
         cancelPostCatalogRootWorkTasks()
         await workspaceSearchService.reset()
         await fileManager.cancelAllScans()
-        defer {
-            let shouldReturnToSystem = shouldReturnToSystemAfterSwitchCancellation
-            shouldReturnToSystemAfterSwitchCancellation = false
-            hideWorkspaceSwitchOverlay(reason: "switch defer cleanup")
-            promptViewModel.startTokenCountUpdateTimer()
-            isSwitchingWorkspace = false
-            drainPendingRepoPathSyncIfNeeded()
-            startPollTimer()
-            notifySwitchingComplete()
-            let totalDuration = Date().timeIntervalSince(totalStart)
-            logWorkspaceSwitch("END switch to \"\(newWorkspace.name)\" total=\(String(format: "%.3f", totalDuration))s shouldReturnToSystem=\(shouldReturnToSystem)")
-            #if DEBUG
-                if let restorePerfStartMS {
-                    let counts = fileManager.restorePerfLoadedTreeCounts()
-                    WorkspaceRestorePerfLog.event(
-                        "workspaceSwitch.end",
-                        fields: debugWorkspaceOpenTraceFields().merging([
-                            "reason": reason,
-                            "restored": "\(reason == "restore")",
-                            "saveState": "\(saveState)",
-                            "effectiveSaveState": "\(effectiveSaveState)",
-                            "activeWorkspaceID": WorkspaceRestorePerfLog.shortID(activeWorkspaceID),
-                            "loadedRoots": "\(counts.rootCount)",
-                            "loadedFolders": "\(counts.folderCount)",
-                            "loadedFiles": "\(counts.fileCount)",
-                            "shouldReturnToSystem": "\(shouldReturnToSystem)",
-                            "total": WorkspaceRestorePerfLog.formatElapsedMS(since: restorePerfStartMS)
-                        ], uniquingKeysWith: { current, _ in current })
-                    )
-                }
-                debugFinishWorkspaceOpenTrace()
-            #endif
-            if shouldSchedulePostSwitchGitDataLoad,
-               let switchedWorkspace = activeWorkspace,
-               switchedWorkspace.id == newWorkspace.id,
-               !switchedWorkspace.isSystemWorkspace,
-               !shouldReturnToSystem
-            {
-                schedulePostSwitchGitDataLoad(for: switchedWorkspace, reason: "postSwitch")
-            }
-            if shouldReturnToSystem {
-                Task { @MainActor [weak self] in
-                    await self?.exitToSystemWorkspaceAfterCancellation()
-                }
-            }
+        if let cancellation = cancellationResult(
+            operationID: operationID,
+            targetWorkspace: newWorkspace,
+            boundary: "preparation"
+        ) {
+            return cancellation
         }
 
         if effectiveSaveState, let oldActive = activeWorkspace {
+            advanceWorkspaceSwitchOperation(operationID, to: .savingCurrentWorkspace)
             let saveUnloadStart = Date()
             logWorkspaceSwitch("save/unload BEGIN from \"\(oldActive.name)\"")
             #if DEBUG
@@ -2030,11 +2554,27 @@ class WorkspaceManagerViewModel: ObservableObject {
                 workspaces[index].selectedMetaPromptIDs = savedPromptIDs
             }
             await pollAndSaveStateAsync(source: .workspaceSwitchSaveState)
+            if let cancellation = cancellationResult(
+                operationID: operationID,
+                targetWorkspace: newWorkspace,
+                boundary: "saving current workspace"
+            ) {
+                return cancellation
+            }
+            advanceWorkspaceSwitchOperation(operationID, to: .unloadingRoots)
             #if DEBUG
                 let preloadUnloadStartMS = WorkspaceRestorePerfLog.timestampMSIfEnabled()
             #endif
             await fileManager.unloadAllRootFolders(cancelScans: true)
             rootsUnloadedBeforeFolderLoad = true
+            markWorkspaceSwitchRootsUnloaded(operationID)
+            if let cancellation = cancellationResult(
+                operationID: operationID,
+                targetWorkspace: newWorkspace,
+                boundary: "unloading roots"
+            ) {
+                return cancellation
+            }
             #if DEBUG
                 WorkspaceRestorePerfLog.event(
                     "workspaceSwitch.preloadUnloadRootFolders",
@@ -2049,9 +2589,16 @@ class WorkspaceManagerViewModel: ObservableObject {
             #endif
             let saveUnloadDuration = Date().timeIntervalSince(saveUnloadStart)
             logWorkspaceSwitch("save/unload END from \"\(oldActive.name)\" duration=\(String(format: "%.3f", saveUnloadDuration))s")
-            if shouldReturnToSystemAfterSwitchCancellation { return }
         }
 
+        advanceWorkspaceSwitchOperation(operationID, to: .loadingTargetWorkspace)
+        if let cancellation = cancellationResult(
+            operationID: operationID,
+            targetWorkspace: newWorkspace,
+            boundary: "loading target workspace"
+        ) {
+            return cancellation
+        }
         let diskLoadStart = Date()
         logWorkspaceSwitch("workspace disk load BEGIN target=\"\(newWorkspace.name)\"")
         if let wsIndex = workspaces.firstIndex(where: { $0.id == newWorkspace.id }) {
@@ -2069,8 +2616,9 @@ class WorkspaceManagerViewModel: ObservableObject {
         } else {
             let diskURL = workspaceFileURL(for: newWorkspace)
             guard FileManager.default.fileExists(atPath: diskURL.path) else {
-                print("‼️ switchWorkspace: workspace file missing at \(diskURL.path)")
-                return // abort – keep current active workspace
+                let message = "Workspace switch could not load \"\(newWorkspace.name)\" because its workspace file is missing at \(diskURL.path)."
+                print("‼️ switchWorkspace: \(message)")
+                return .blocked(message)
             }
 
             do {
@@ -2079,8 +2627,9 @@ class WorkspaceManagerViewModel: ObservableObject {
                 recordRepoPathBaseline(for: upgraded)
                 activeWorkspaceID = upgraded.id
             } catch {
-                print("‼️ switchWorkspace: failed to load workspace from disk: \(error)")
-                return // abort – keep current active workspace
+                let message = "Workspace switch could not load \"\(newWorkspace.name)\" from disk: \(error.localizedDescription)"
+                print("‼️ switchWorkspace: \(message)")
+                return .blocked(message)
             }
         }
         let diskLoadDuration = Date().timeIntervalSince(diskLoadStart)
@@ -2092,9 +2641,17 @@ class WorkspaceManagerViewModel: ObservableObject {
             )
         #endif
 
-        if shouldReturnToSystemAfterSwitchCancellation { return }
+        if let cancellation = cancellationResult(
+            operationID: operationID,
+            targetWorkspace: newWorkspace,
+            boundary: "loading target workspace"
+        ) {
+            return cancellation
+        }
 
-        guard let activeWS = activeWorkspace else { return }
+        guard let activeWS = activeWorkspace else {
+            return .blocked("Workspace switch to \"\(newWorkspace.name)\" did not produce an active workspace.")
+        }
         let loadSignpost = WorkspaceExitPerf.begin("switchWorkspace.loadWorkspace")
         defer { WorkspaceExitPerf.end("switchWorkspace.loadWorkspace", loadSignpost) }
         let hydrationGeneration = beginWorkspaceHydration(for: activeWS)
@@ -2102,7 +2659,15 @@ class WorkspaceManagerViewModel: ObservableObject {
 
         // Restore path-based state before catalog/search hydration. This activation phase
         // must not require root descendant UI projection.
+        advanceWorkspaceSwitchOperation(operationID, to: .restoringState)
         await Task.yield()
+        if let cancellation = cancellationResult(
+            operationID: operationID,
+            targetWorkspace: newWorkspace,
+            boundary: "restoring state"
+        ) {
+            return cancellation
+        }
         let restoreStart = Date()
         logWorkspaceSwitch("restore state BEGIN workspace=\"\(activeWS.name)\"")
         await restoreWorkspaceState(activeWS)
@@ -2113,8 +2678,16 @@ class WorkspaceManagerViewModel: ObservableObject {
                 "workspaceSwitch.restoreState managerID=\(instanceID.uuidString.prefix(8)) reason=\(reason) restored=\(reason == "restore") workspaceID=\(WorkspaceRestorePerfLog.shortID(activeWS.id)) duration=\(WorkspaceRestorePerfLog.formatMS(restoreDuration * 1000))"
             )
         #endif
-        if shouldReturnToSystemAfterSwitchCancellation { return }
-        guard isHydrationGenerationCurrent(hydrationGeneration, workspaceID: activeWS.id) else { return }
+        if let cancellation = cancellationResult(
+            operationID: operationID,
+            targetWorkspace: newWorkspace,
+            boundary: "restoring state"
+        ) {
+            return cancellation
+        }
+        guard isHydrationGenerationCurrent(hydrationGeneration, workspaceID: activeWS.id) else {
+            return .cancelled("Workspace switch to \"\(newWorkspace.name)\" was superseded during state restoration.")
+        }
         #if DEBUG
             WorkspaceRestorePerfLog.event(
                 "workspaceSwitch.activationReady",
@@ -2134,6 +2707,7 @@ class WorkspaceManagerViewModel: ObservableObject {
 
         // Hydrate primary root catalogs and build search/path lookup indexes. Root shells
         // attach as catalogs complete; watchers, slices and codemap scans are post-catalog work.
+        advanceWorkspaceSwitchOperation(operationID, to: .hydratingRoots)
         let folderLoadStart = Date()
         logWorkspaceSwitch("catalog hydration BEGIN workspace=\"\(activeWS.name)\" roots=\(activeWS.repoPaths.count)")
         await loadWorkspaceFolders(
@@ -2141,6 +2715,9 @@ class WorkspaceManagerViewModel: ObservableObject {
             hydrationGeneration: hydrationGeneration,
             gitDataRootLoadMode: .deferredAfterSwitch,
             initialUnloadMode: rootsUnloadedBeforeFolderLoad ? .skipPreviouslyCompleted : .perform(cancelScans: true),
+            onInitialRootUnloadCompleted: { [weak self] in
+                self?.markWorkspaceSwitchRootsUnloaded(operationID)
+            },
             onAllPrimaryRootsVisible: { [weak self] in
                 guard let self else { return }
                 guard !Task.isCancelled else { return }
@@ -2156,11 +2733,32 @@ class WorkspaceManagerViewModel: ObservableObject {
                 "workspaceSwitch.folderLoad managerID=\(instanceID.uuidString.prefix(8)) reason=\(reason) restored=\(reason == "restore") workspaceID=\(WorkspaceRestorePerfLog.shortID(activeWS.id)) rootCount=\(activeWS.repoPaths.count) loadedRoots=\(folderCounts.rootCount) loadedFolders=\(folderCounts.folderCount) loadedFiles=\(folderCounts.fileCount) duration=\(WorkspaceRestorePerfLog.formatMS(folderLoadDuration * 1000))"
             )
         #endif
-        if shouldReturnToSystemAfterSwitchCancellation { return }
-        guard isHydrationGenerationCurrent(hydrationGeneration, workspaceID: activeWS.id) else { return }
+        if let cancellation = cancellationResult(
+            operationID: operationID,
+            targetWorkspace: newWorkspace,
+            boundary: "hydrating roots"
+        ) {
+            return cancellation
+        }
+        guard isHydrationGenerationCurrent(hydrationGeneration, workspaceID: activeWS.id) else {
+            return .cancelled("Workspace switch to \"\(newWorkspace.name)\" was superseded during root hydration.")
+        }
 
         // Another yield after state restoration
+        advanceWorkspaceSwitchOperation(operationID, to: .notifyingListeners)
         await Task.yield()
+        if let cancellation = cancellationResult(
+            operationID: operationID,
+            targetWorkspace: newWorkspace,
+            boundary: "notifying listeners"
+        ) {
+            return cancellation
+        }
+
+        // Publishing the activated workspace to listeners is the switch commit boundary.
+        // Cancellation observed after this point cannot turn a committed activation into
+        // a cancelled result.
+        markWorkspaceSwitchCommitted(operationID)
 
         // Notify listeners that workspace switched.
         #if DEBUG
@@ -2186,22 +2784,53 @@ class WorkspaceManagerViewModel: ObservableObject {
         // Give post-switch listeners one turn to enqueue their own restore work
         // before exposing the main UI again.
         await Task.yield()
+        if let cancellation = cancellationResult(
+            operationID: operationID,
+            targetWorkspace: newWorkspace,
+            boundary: "notifying listeners"
+        ) {
+            return cancellation
+        }
         hideWorkspaceSwitchOverlay(reason: "restore seeded workspace=\"\(activeWS.name)\"")
 
         // Final yield before marking complete
+        advanceWorkspaceSwitchOperation(operationID, to: .finalizing)
         await Task.yield()
+        if let cancellation = cancellationResult(
+            operationID: operationID,
+            targetWorkspace: newWorkspace,
+            boundary: "finalizing"
+        ) {
+            return cancellation
+        }
 
         // Mark as initialized at the end
         completeInitialization()
         shouldSchedulePostSwitchGitDataLoad = true
         logWorkspaceSwitch("completeInitialization called workspace=\"\(activeWS.name)\"")
+        return .switched
     }
 
     @MainActor
     func cancelCurrentWorkspaceSwitchAndReturnToSystem() async {
         if isSwitchingWorkspace {
             hideWorkspaceSwitchOverlay(reason: "user cancel requested")
-            shouldReturnToSystemAfterSwitchCancellation = true
+            let operationID = activeWorkspaceSwitch?.operationID
+            if committedWorkspaceSwitchOperationID == operationID
+                || recoveringWorkspaceSwitchOperationID == operationID
+            {
+                return
+            }
+            returnToSystemAfterSwitchCancellationOperationID = operationID
+            if let operationID,
+               let pending = pendingSwitchConfirmationRequest,
+               pending.operationID == operationID
+            {
+                cancelPendingSwitchConfirmation(
+                    operationID: operationID,
+                    confirmationID: pending.confirmationID
+                )
+            }
             workspaceHydrationGeneration &+= 1
             workspaceSearchReadinessState = .idle
             cancelPostCatalogRootWorkTasks()
@@ -2215,6 +2844,9 @@ class WorkspaceManagerViewModel: ObservableObject {
 
     @MainActor
     private func exitToSystemWorkspaceAfterCancellation() async {
+        if let workspaceSwitchRecoveryWillBeginHandlerForTesting {
+            await workspaceSwitchRecoveryWillBeginHandlerForTesting()
+        }
         let fallback = workspaces.first(where: { $0.isSystemWorkspace }) ?? getOrCreateSystemWorkspace()
         guard activeWorkspaceID != fallback.id else { return }
         await switchWorkspace(to: fallback, saveState: false)
@@ -4650,7 +5282,7 @@ class WorkspaceManagerViewModel: ObservableObject {
     }
 
     private func isHydrationGenerationCurrent(_ generation: UInt64, workspaceID: UUID?) -> Bool {
-        workspaceHydrationGeneration == generation && activeWorkspaceID == workspaceID && !shouldReturnToSystemAfterSwitchCancellation
+        workspaceHydrationGeneration == generation && activeWorkspaceID == workspaceID && returnToSystemAfterSwitchCancellationOperationID == nil
     }
 
     private func cancelPostCatalogRootWorkTasks(generation: UInt64? = nil) {
@@ -4694,6 +5326,7 @@ class WorkspaceManagerViewModel: ObservableObject {
         skipSecurityScope: Bool = false,
         gitDataRootLoadMode: GitDataRootLoadMode = .inline,
         initialUnloadMode: WorkspaceFolderInitialUnloadMode = .perform(cancelScans: true),
+        onInitialRootUnloadCompleted: (() -> Void)? = nil,
         onAllPrimaryRootsVisible: (() -> Void)? = nil
     ) async {
         logWorkspaceSwitch("loadWorkspaceFolders BEGIN workspace=\"\(workspace.name)\" skipSecurityScope=\(skipSecurityScope) gitDataRootLoadMode=\(gitDataRootLoadMode)")
@@ -4717,6 +5350,7 @@ class WorkspaceManagerViewModel: ObservableObject {
                 let initialUnloadStartMS = WorkspaceRestorePerfLog.timestampMSIfEnabled()
             #endif
             await fileManager.unloadAllRootFolders(cancelScans: cancelScans)
+            onInitialRootUnloadCompleted?()
             #if DEBUG
                 WorkspaceRestorePerfLog.event(
                     "workspaceSwitch.loadWorkspaceFolders.initialUnload",
@@ -6764,12 +7398,14 @@ class WorkspaceManagerViewModel: ObservableObject {
     }
 
     @MainActor
-    func saveAndExitToFallback() async {
+    @discardableResult
+    func saveAndExitToFallback() async -> WorkspaceSwitchResult {
         let signpost = WorkspaceExitPerf.begin("saveAndExitToFallback")
         defer { WorkspaceExitPerf.end("saveAndExitToFallback", signpost) }
-        if let fallback = workspaces.first(where: { $0.isSystemWorkspace }) {
-            _ = await requestWorkspaceSwitch(to: fallback)
+        guard let fallback = workspaces.first(where: { $0.isSystemWorkspace }) else {
+            return .blocked("No fallback workspace is available.")
         }
+        return await requestWorkspaceSwitch(to: fallback, reason: "saveAndExitToFallback")
     }
 
     func checkIfActivePresetIsDirty(with newSelection: [FileViewModel]) {
@@ -7109,15 +7745,47 @@ class WorkspaceManagerViewModel: ObservableObject {
             userInfo: ["managerID": instanceID]
         )
 
-        // 6) Attempt to restore the previously active workspace, if still present
+        // 6) Restore a usable active workspace. Replacing the active model with the same
+        // ID must still unload and hydrate its restored root/model state.
+        let workspaceToActivate: WorkspaceModel
+        let shouldReloadSameID: Bool
         if let oldID = oldActiveID,
-           let newlyActive = workspaces.first(where: { $0.id == oldID })
+           let restoredActive = workspaces.first(where: { $0.id == oldID })
         {
-            // If the old ID is still around, re-activate it
-            await switchWorkspace(to: newlyActive, saveState: false)
-        } else if !workspaces.isEmpty {
-            // Otherwise pick the first or a "default"
-            await switchWorkspace(to: workspaces[0], saveState: false)
+            workspaceToActivate = restoredActive
+            shouldReloadSameID = activeWorkspaceID == restoredActive.id
+        } else if let firstWorkspace = workspaces.first {
+            workspaceToActivate = firstWorkspace
+            shouldReloadSameID = activeWorkspaceID == firstWorkspace.id
+        } else {
+            let fallback = getOrCreateSystemWorkspace()
+            workspaceToActivate = fallback
+            shouldReloadSameID = activeWorkspaceID == fallback.id
+        }
+
+        let activationResult = if shouldReloadSameID {
+            await reactivateWorkspaceAfterReplacement(
+                workspaceToActivate,
+                reason: "backupRestoreSameIDReload"
+            )
+        } else {
+            await switchWorkspace(
+                to: workspaceToActivate,
+                saveState: false,
+                reason: "backupRestoreActivation"
+            )
+        }
+        guard activationResult.didSwitch,
+              activeWorkspaceID == workspaceToActivate.id
+        else {
+            throw NSError(
+                domain: "WorkspaceManager.BackupRestore",
+                code: 3,
+                userInfo: [
+                    NSLocalizedDescriptionKey: activationResult.message
+                        ?? "The restored workspace could not be activated."
+                ]
+            )
         }
 
         // 7) If you have chat sessions you want to restore, do it now per workspace

--- a/Sources/RepoPrompt/Features/Workspaces/ViewModels/WorkspaceManagerViewModel.swift
+++ b/Sources/RepoPrompt/Features/Workspaces/ViewModels/WorkspaceManagerViewModel.swift
@@ -460,8 +460,10 @@ class WorkspaceManagerViewModel: ObservableObject {
     private var pendingSwitchConfirmationRequest: PendingSwitchConfirmationRequest?
     private let switchSessionRegistry = WorkspaceSwitchSessionRegistry()
     private let switchTimingPolicy: WorkspaceSwitchTimingPolicy
-    private var workspaceSwitchPhaseDidChangeHandlerForTesting: ((WorkspaceSwitchPhase) -> Void)?
-    private var workspaceSwitchRecoveryWillBeginHandlerForTesting: (@MainActor () async -> Void)?
+    #if DEBUG
+        private var workspaceSwitchPhaseDidChangeHandlerForTesting: ((WorkspaceSwitchPhase) -> Void)?
+        private var workspaceSwitchRecoveryWillBeginHandlerForTesting: (@MainActor () async -> Void)?
+    #endif
 
     private struct WorkspaceDidSwitchListener {
         let label: String
@@ -1908,7 +1910,9 @@ class WorkspaceManagerViewModel: ObservableObject {
             startedAt: activity.startedAt,
             phaseStartedAt: switchTimingPolicy.now()
         )
-        workspaceSwitchPhaseDidChangeHandlerForTesting?(phase)
+        #if DEBUG
+            workspaceSwitchPhaseDidChangeHandlerForTesting?(phase)
+        #endif
     }
 
     private func finishWorkspaceSwitchOperation(_ operationID: UUID) {
@@ -1972,7 +1976,9 @@ class WorkspaceManagerViewModel: ObservableObject {
             startedAt: activity.startedAt,
             phaseStartedAt: switchTimingPolicy.now()
         )
-        workspaceSwitchPhaseDidChangeHandlerForTesting?(.preparing)
+        #if DEBUG
+            workspaceSwitchPhaseDidChangeHandlerForTesting?(.preparing)
+        #endif
     }
 
     private func completeWorkspaceSwitchOperation(
@@ -2038,9 +2044,11 @@ class WorkspaceManagerViewModel: ObservableObject {
             }
         }
         committedWorkspaceSwitchOperationID = nil
-        if let workspaceSwitchRecoveryWillBeginHandlerForTesting {
-            await workspaceSwitchRecoveryWillBeginHandlerForTesting()
-        }
+        #if DEBUG
+            if let workspaceSwitchRecoveryWillBeginHandlerForTesting {
+                await workspaceSwitchRecoveryWillBeginHandlerForTesting()
+            }
+        #endif
 
         var failures: [String] = []
         for recoveryTarget in recoveryTargets {
@@ -2178,9 +2186,10 @@ class WorkspaceManagerViewModel: ObservableObject {
             )
         }
         if newWorkspace.id == activeWorkspaceID {
-            return userVisibleWorkspaceSwitchResult(
-                .blocked("Already on workspace \"\(newWorkspace.name)\".")
-            )
+            // Benign no-op (launch restore, save-and-exit on the system workspace, MCP
+            // switch to the current workspace): stay silent instead of raising the
+            // blocked-notice alert reserved for actionable blockages.
+            return .blocked("Already on workspace \"\(newWorkspace.name)\".")
         }
         if isRefreshing {
             return userVisibleWorkspaceSwitchResult(
@@ -2352,17 +2361,19 @@ class WorkspaceManagerViewModel: ObservableObject {
         pendingWorkspaceSwitchBlockedNotice = nil
     }
 
-    func setWorkspaceSwitchPhaseDidChangeHandlerForTesting(
-        _ handler: ((WorkspaceSwitchPhase) -> Void)?
-    ) {
-        workspaceSwitchPhaseDidChangeHandlerForTesting = handler
-    }
+    #if DEBUG
+        func setWorkspaceSwitchPhaseDidChangeHandlerForTesting(
+            _ handler: ((WorkspaceSwitchPhase) -> Void)?
+        ) {
+            workspaceSwitchPhaseDidChangeHandlerForTesting = handler
+        }
 
-    func setWorkspaceSwitchRecoveryWillBeginHandlerForTesting(
-        _ handler: (@MainActor () async -> Void)?
-    ) {
-        workspaceSwitchRecoveryWillBeginHandlerForTesting = handler
-    }
+        func setWorkspaceSwitchRecoveryWillBeginHandlerForTesting(
+            _ handler: (@MainActor () async -> Void)?
+        ) {
+            workspaceSwitchRecoveryWillBeginHandlerForTesting = handler
+        }
+    #endif
 
     @discardableResult
     func reactivateWorkspaceAfterReplacement(
@@ -2844,9 +2855,11 @@ class WorkspaceManagerViewModel: ObservableObject {
 
     @MainActor
     private func exitToSystemWorkspaceAfterCancellation() async {
-        if let workspaceSwitchRecoveryWillBeginHandlerForTesting {
-            await workspaceSwitchRecoveryWillBeginHandlerForTesting()
-        }
+        #if DEBUG
+            if let workspaceSwitchRecoveryWillBeginHandlerForTesting {
+                await workspaceSwitchRecoveryWillBeginHandlerForTesting()
+            }
+        #endif
         let fallback = workspaces.first(where: { $0.isSystemWorkspace }) ?? getOrCreateSystemWorkspace()
         guard activeWorkspaceID != fallback.id else { return }
         await switchWorkspace(to: fallback, saveState: false)

--- a/Sources/RepoPrompt/Features/Workspaces/WorkspaceSwitchingModels.swift
+++ b/Sources/RepoPrompt/Features/Workspaces/WorkspaceSwitchingModels.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftUI
 
-enum WorkspaceSwitchResult {
+enum WorkspaceSwitchResult: Equatable {
     case switched
     case cancelled(String)
     case blocked(String)
@@ -19,6 +19,107 @@ enum WorkspaceSwitchResult {
             message
         }
     }
+}
+
+enum WorkspaceSwitchPhase: String, Equatable {
+    case preparing
+    case awaitingConfirmation
+    case cancellingSessions
+    case waitingForChatIdle
+    case savingCurrentWorkspace
+    case unloadingRoots
+    case loadingTargetWorkspace
+    case restoringState
+    case hydratingRoots
+    case notifyingListeners
+    case finalizing
+
+    var displayName: String {
+        switch self {
+        case .preparing:
+            "preparing"
+        case .awaitingConfirmation:
+            "awaiting confirmation"
+        case .cancellingSessions:
+            "cancelling sessions"
+        case .waitingForChatIdle:
+            "waiting for chat idle"
+        case .savingCurrentWorkspace:
+            "saving current workspace"
+        case .unloadingRoots:
+            "unloading roots"
+        case .loadingTargetWorkspace:
+            "loading target workspace"
+        case .restoringState:
+            "restoring state"
+        case .hydratingRoots:
+            "hydrating roots"
+        case .notifyingListeners:
+            "notifying listeners"
+        case .finalizing:
+            "finalizing"
+        }
+    }
+}
+
+struct WorkspaceSwitchActivity: Equatable {
+    let operationID: UUID
+    let previousWorkspaceID: UUID?
+    let previousWorkspaceName: String?
+    let targetWorkspaceID: UUID
+    let targetWorkspaceName: String
+    let reason: String
+    let phase: WorkspaceSwitchPhase
+    let startedAt: Date
+    let phaseStartedAt: Date
+}
+
+struct WorkspaceSwitchBlockageReport: Equatable {
+    let requestedTargetWorkspaceID: UUID
+    let requestedTargetWorkspaceName: String
+    let activeSwitch: WorkspaceSwitchActivity
+    let totalAge: TimeInterval
+    let phaseAge: TimeInterval
+    let isStale: Bool
+    let message: String
+}
+
+struct WorkspaceSwitchBlockedNotice: Identifiable, Equatable {
+    let id: UUID
+    let message: String
+    let blockingOperationID: UUID?
+
+    init(
+        id: UUID = UUID(),
+        message: String,
+        blockingOperationID: UUID? = nil
+    ) {
+        self.id = id
+        self.message = message
+        self.blockingOperationID = blockingOperationID
+    }
+
+    func isBlocked(by operationID: UUID) -> Bool {
+        blockingOperationID == operationID
+    }
+}
+
+struct WorkspaceSwitchTimingPolicy: @unchecked Sendable {
+    static let production = WorkspaceSwitchTimingPolicy(
+        staleThreshold: 30,
+        chatBusySettleTimeoutNanoseconds: 2_000_000_000,
+        chatBusyPollIntervalNanoseconds: 50_000_000,
+        now: { Date() },
+        sleep: { nanoseconds in
+            try await Task.sleep(nanoseconds: nanoseconds)
+        }
+    )
+
+    let staleThreshold: TimeInterval
+    let chatBusySettleTimeoutNanoseconds: UInt64
+    let chatBusyPollIntervalNanoseconds: UInt64
+    let now: @Sendable () -> Date
+    let sleep: @Sendable (UInt64) async throws -> Void
 }
 
 struct WorkspaceSwitchSessionItem: Hashable {
@@ -82,14 +183,41 @@ struct WorkspaceSwitchOverlayState: Equatable {
 struct WorkspaceSwitchConfirmationModifier: ViewModifier {
     @ObservedObject var workspaceManager: WorkspaceManagerViewModel
 
-    private var isPresented: Binding<Bool> {
+    static func confirmationPresentationBinding(
+        manager: WorkspaceManagerViewModel,
+        confirmationID: UUID
+    ) -> Binding<Bool> {
         Binding(
-            get: { workspaceManager.pendingSwitchConfirmation != nil },
+            get: { manager.pendingSwitchConfirmation?.id == confirmationID },
             set: { newValue in
-                if !newValue, workspaceManager.hasPendingSwitchConfirmation {
-                    workspaceManager.resolveSwitchConfirmation(allow: false)
+                if !newValue {
+                    manager.resolveSwitchConfirmation(id: confirmationID, allow: false)
                 }
             }
+        )
+    }
+
+    static func blockedNoticePresentationBinding(
+        manager: WorkspaceManagerViewModel,
+        noticeID: UUID
+    ) -> Binding<Bool> {
+        Binding(
+            get: { manager.pendingWorkspaceSwitchBlockedNotice?.id == noticeID },
+            set: { newValue in
+                if !newValue {
+                    manager.dismissWorkspaceSwitchBlockedNotice(id: noticeID)
+                }
+            }
+        )
+    }
+
+    private var isPresented: Binding<Bool> {
+        guard let confirmationID = workspaceManager.pendingSwitchConfirmation?.id else {
+            return .constant(false)
+        }
+        return Self.confirmationPresentationBinding(
+            manager: workspaceManager,
+            confirmationID: confirmationID
         )
     }
 
@@ -99,15 +227,38 @@ struct WorkspaceSwitchConfirmationModifier: ViewModifier {
                 "Switch Workspace?",
                 isPresented: isPresented,
                 presenting: workspaceManager.pendingSwitchConfirmation
-            ) { _ in
+            ) { confirmation in
                 Button("Switch and End Sessions", role: .destructive) {
-                    workspaceManager.resolveSwitchConfirmation(allow: true)
+                    workspaceManager.resolveSwitchConfirmation(id: confirmation.id, allow: true)
                 }
                 Button("Cancel", role: .cancel) {
-                    workspaceManager.resolveSwitchConfirmation(allow: false)
+                    workspaceManager.resolveSwitchConfirmation(id: confirmation.id, allow: false)
                 }
             } message: { confirmation in
                 Text(confirmation.message)
+            }
+            .background {
+                if workspaceManager.pendingSwitchConfirmation == nil,
+                   let notice = workspaceManager.pendingWorkspaceSwitchBlockedNotice
+                {
+                    Color.clear
+                        .alert(
+                            "Workspace Switch Blocked",
+                            isPresented: Self.blockedNoticePresentationBinding(
+                                manager: workspaceManager,
+                                noticeID: notice.id
+                            ),
+                            presenting: notice
+                        ) { presentedNotice in
+                            Button("OK") {
+                                workspaceManager.dismissWorkspaceSwitchBlockedNotice(
+                                    id: presentedNotice.id
+                                )
+                            }
+                        } message: { presentedNotice in
+                            Text(presentedNotice.message)
+                        }
+                }
             }
     }
 }

--- a/Sources/RepoPrompt/Infrastructure/MCP/MCPConnectionManager.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/MCPConnectionManager.swift
@@ -366,6 +366,11 @@ actor ServerNetworkManager {
         toolName == MCPWindowToolName.search ? .fileSearch : .ordinary
     }
 
+    /// Bounded concurrent `file_search` permits per connection. Sized to the parallel
+    /// read-only tool batches agent clients emit, and aligned with the per-workspace
+    /// broad-search active capacity so one connection's burst cannot exceed it.
+    nonisolated static let fileSearchCallLaneLimit = 4
+
     private static func validatedLiveRunID(
         candidateRunID: UUID,
         connectionID: UUID,
@@ -1037,17 +1042,18 @@ actor ServerNetworkManager {
         #if DEBUG
             init(
                 limit: Int,
+                fileSearchLimit: Int,
                 idleWaitSleep: @escaping @Sendable (Duration) async throws -> Void = { duration in
                     try await Task.sleep(for: duration)
                 }
             ) {
                 ordinary = AsyncLimiter(limit: limit, idleWaitSleep: idleWaitSleep)
-                fileSearch = AsyncLimiter(limit: limit, idleWaitSleep: idleWaitSleep)
+                fileSearch = AsyncLimiter(limit: fileSearchLimit, idleWaitSleep: idleWaitSleep)
             }
         #else
-            init(limit: Int) {
+            init(limit: Int, fileSearchLimit: Int) {
                 ordinary = AsyncLimiter(limit: limit)
-                fileSearch = AsyncLimiter(limit: limit)
+                fileSearch = AsyncLimiter(limit: fileSearchLimit)
             }
         #endif
 
@@ -4390,7 +4396,8 @@ actor ServerNetworkManager {
 
         connections[connectionID] = manager
         callLimiters[connectionID] = MCPConnectionCallLimiters(
-            limit: limiterLimit(for: connectionID)
+            limit: limiterLimit(for: connectionID),
+            fileSearchLimit: fileSearchLimiterLimit(for: connectionID)
         )
         connectionLifecycleGenerationByID[connectionID] = lifecycleGeneration
         bindSessionToken(sessionToken, to: connectionID)
@@ -7767,6 +7774,7 @@ actor ServerNetworkManager {
             ) async -> AsyncLimiter {
                 let limiters = MCPConnectionCallLimiters(
                     limit: limiterLimit(for: connectionID),
+                    fileSearchLimit: fileSearchLimiterLimit(for: connectionID),
                     idleWaitSleep: idleWaitSleep
                 )
                 callLimiters[connectionID] = limiters
@@ -7798,7 +7806,8 @@ actor ServerNetworkManager {
                 activeConnectionsByClient[clientID, default: []].insert(connectionID)
                 clientIDByConnection[connectionID] = clientID
                 callLimiters[connectionID] = MCPConnectionCallLimiters(
-                    limit: limiterLimit(for: connectionID)
+                    limit: limiterLimit(for: connectionID),
+                    fileSearchLimit: fileSearchLimiterLimit(for: connectionID)
                 )
                 connectionStats[connectionID] = ConnectionStats(
                     createdAt: createdAt,
@@ -8117,7 +8126,8 @@ actor ServerNetworkManager {
                 bindSessionToken(sessionToken, to: connectionID)
                 if callLimiters[connectionID] == nil {
                     callLimiters[connectionID] = MCPConnectionCallLimiters(
-                        limit: limiterLimit(for: connectionID)
+                        limit: limiterLimit(for: connectionID),
+                        fileSearchLimit: fileSearchLimiterLimit(for: connectionID)
                     )
                 }
             }
@@ -11611,11 +11621,19 @@ actor ServerNetworkManager {
     }
 
     private func limiterLimit(for connectionID: UUID) -> Int {
-        // Serialize RepoPrompt MCP tool calls within each per-connection lane.
-        // Identical calls therefore cannot race and produce duplicate/mis-tracked tool cards,
-        // while file_search may overlap one ordinary call on the same connection.
+        // Serialize ordinary RepoPrompt MCP tool calls within each connection.
+        // Identical calls therefore cannot race and produce duplicate/mis-tracked tool cards.
         _ = connectionID
         return 1
+    }
+
+    private func fileSearchLimiterLimit(for connectionID: UUID) -> Int {
+        // Admit a bounded burst of concurrent file_search calls per connection. Agents batch
+        // read-only searches; running the burst concurrently lets every member share one
+        // workspace ingress freshness flight instead of reconstructing it serially per call.
+        // Per-workspace broad admission still bounds unscoped content searches downstream.
+        _ = connectionID
+        return Self.fileSearchCallLaneLimit
     }
 
     private struct ConnectionCallLimiterResolution {
@@ -11968,7 +11986,10 @@ actor ServerNetworkManager {
         // closeIfIdle() admitted no owners before closing both lanes. Replacing that exact,
         // still-registered bundle is therefore a safe rollback: stale references can only
         // observe cancellation, while all subsequent calls resolve these fresh open lanes.
-        let replacement = MCPConnectionCallLimiters(limit: limiterLimit(for: id))
+        let replacement = MCPConnectionCallLimiters(
+            limit: limiterLimit(for: id),
+            fileSearchLimit: fileSearchLimiterLimit(for: id)
+        )
         callLimiters[id] = replacement
         await closedLimiters.markTentativeCloseRestored(by: replacement)
         return true

--- a/Sources/RepoPrompt/Infrastructure/MCP/MCPConnectionManager.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/MCPConnectionManager.swift
@@ -111,6 +111,33 @@ enum ConnectionStateSnapshot: Equatable {
     }
 }
 
+private enum MCPConnectionStopRaceOutcome {
+    case stopped
+    case deadlineElapsed
+}
+
+private actor MCPConnectionStopRace {
+    private var outcome: MCPConnectionStopRaceOutcome?
+    private var waiters: [CheckedContinuation<MCPConnectionStopRaceOutcome, Never>] = []
+
+    func resolve(_ outcome: MCPConnectionStopRaceOutcome) {
+        guard case nil = self.outcome else { return }
+        self.outcome = outcome
+        let waiters = waiters
+        self.waiters.removeAll()
+        for waiter in waiters {
+            waiter.resume(returning: outcome)
+        }
+    }
+
+    func wait() async -> MCPConnectionStopRaceOutcome {
+        if let outcome { return outcome }
+        return await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+}
+
 protocol MCPServerConnection: Actor {
     func start(approvalHandler: @escaping (MCP.Client.Info) async -> Bool) async throws
     func stop() async
@@ -162,6 +189,12 @@ enum ConnectionStateSummary: String, Codable {
     case unknown
 }
 
+struct ConnectionDashboardActiveToolScope: Codable, Equatable {
+    let windowID: Int
+    let toolName: String
+    let sequence: UInt64
+}
+
 /// Dashboard entry for a single connection
 struct ConnectionDashboardEntry: Identifiable, Codable {
     let id: UUID
@@ -174,7 +207,20 @@ struct ConnectionDashboardEntry: Identifiable, Codable {
     let totalToolCalls: Int
     let idleSeconds: TimeInterval?
     let hasInFlightCalls: Bool
-    let activeToolName: String?
+    let activeToolScope: ConnectionDashboardActiveToolScope?
+    let activeToolScopes: [ConnectionDashboardActiveToolScope]
+    var activeToolScopeCount: Int {
+        activeToolScopes.count
+    }
+
+    var activeToolName: String? {
+        activeToolScope?.toolName
+    }
+
+    var activeToolWindowID: Int? {
+        activeToolScope?.windowID
+    }
+
     /// Session key (capabilityToken) for disambiguating multiple client instances
     let sessionKey: String?
 }
@@ -294,6 +340,11 @@ private final class BootstrapTransferredSocketLedger: @unchecked Sendable {
     #endif
 }
 
+enum MCPConnectionCallLane: String, CaseIterable {
+    case ordinary
+    case fileSearch = "file_search"
+}
+
 /// Manages all MCP connections using the bootstrap UNIX-domain socket.
 /// TCP/Bonjour transport has been removed.
 actor ServerNetworkManager {
@@ -309,6 +360,10 @@ actor ServerNetworkManager {
     ]
     nonisolated static func canonicalToolName(for name: String) -> String {
         toolNameAliases[name] ?? name
+    }
+
+    nonisolated static func callLane(forCanonicalToolName toolName: String) -> MCPConnectionCallLane {
+        toolName == MCPWindowToolName.search ? .fileSearch : .ordinary
     }
 
     private static func validatedLiveRunID(
@@ -732,6 +787,7 @@ actor ServerNetworkManager {
                   connectionTasks.isEmpty,
                   pendingConnections.isEmpty,
                   bootstrapReservations.isEmpty,
+                  bootstrapAdmissionClaimsBySessionToken.isEmpty,
                   transferredBootstrapSockets.isEmptyAndInactive,
                   connectionWaiters.isEmpty
             else {
@@ -962,16 +1018,241 @@ actor ServerNetworkManager {
     private var connectionWindowMap: [UUID: Int] = [:]
     private var runIDByConnectionID: [UUID: UUID] = [:]
 
+    private actor MCPConnectionCallLimiters {
+        struct AdmissionRejected: Error {}
+
+        private enum AdmissionCloseState {
+            case open
+            case tentative
+            case restored(MCPConnectionCallLimiters)
+            case committed
+        }
+
+        private let ordinary: AsyncLimiter
+        private let fileSearch: AsyncLimiter
+        private var admittedCallCount = 0
+        private var admissionCloseState: AdmissionCloseState = .open
+        private var admissionRetryWaiters: [UUID: CheckedContinuation<MCPConnectionCallLimiters?, Never>] = [:]
+
+        #if DEBUG
+            init(
+                limit: Int,
+                idleWaitSleep: @escaping @Sendable (Duration) async throws -> Void = { duration in
+                    try await Task.sleep(for: duration)
+                }
+            ) {
+                ordinary = AsyncLimiter(limit: limit, idleWaitSleep: idleWaitSleep)
+                fileSearch = AsyncLimiter(limit: limit, idleWaitSleep: idleWaitSleep)
+            }
+        #else
+            init(limit: Int) {
+                ordinary = AsyncLimiter(limit: limit)
+                fileSearch = AsyncLimiter(limit: limit)
+            }
+        #endif
+
+        func withPermit<T>(
+            lane: MCPConnectionCallLane,
+            cancellationResult: @Sendable () -> T,
+            _ operation: @Sendable () async -> T
+        ) async -> T {
+            guard case .open = admissionCloseState else { return cancellationResult() }
+            admittedCallCount += 1
+            defer { admittedCallCount -= 1 }
+            return await limiter(for: lane).withPermit(
+                cancellationResult: cancellationResult,
+                operation
+            )
+        }
+
+        func withPermit<T>(
+            lane: MCPConnectionCallLane,
+            _ operation: @Sendable () async throws -> T
+        ) async throws -> T {
+            guard case .open = admissionCloseState else { throw AdmissionRejected() }
+            admittedCallCount += 1
+            defer { admittedCallCount -= 1 }
+            return try await limiter(for: lane).withPermit(operation)
+        }
+
+        func hasInFlightCalls() -> Bool {
+            admittedCallCount > 0
+        }
+
+        func admissionRetryReplacement() async -> MCPConnectionCallLimiters? {
+            guard !Task.isCancelled else { return nil }
+            switch admissionCloseState {
+            case .open, .committed:
+                return nil
+            case let .restored(replacement):
+                return replacement
+            case .tentative:
+                return await waitForAdmissionCloseOutcome()
+            }
+        }
+
+        func markTentativeCloseRestored(by replacement: MCPConnectionCallLimiters) {
+            guard case .tentative = admissionCloseState else { return }
+            admissionCloseState = .restored(replacement)
+            resumeAdmissionRetryWaiters(with: replacement)
+        }
+
+        func markTentativeCloseCommitted() {
+            guard case .tentative = admissionCloseState else { return }
+            admissionCloseState = .committed
+            resumeAdmissionRetryWaiters(with: nil)
+        }
+
+        func cancelAll() async {
+            switch admissionCloseState {
+            case .open, .tentative:
+                admissionCloseState = .committed
+                resumeAdmissionRetryWaiters(with: nil)
+            case .restored, .committed:
+                break
+            }
+            await closeLanes()
+        }
+
+        #if DEBUG
+            func closeIfIdle(
+                afterClosingBegan: (@Sendable () async -> Void)? = nil
+            ) async -> Bool {
+                guard case .open = admissionCloseState, admittedCallCount == 0 else { return false }
+                admissionCloseState = .tentative
+                if let afterClosingBegan {
+                    await afterClosingBegan()
+                }
+                await closeLanes()
+                return true
+            }
+        #else
+            func closeIfIdle() async -> Bool {
+                guard case .open = admissionCloseState, admittedCallCount == 0 else { return false }
+                admissionCloseState = .tentative
+                await closeLanes()
+                return true
+            }
+        #endif
+
+        func waitUntilIdle(timeout: Duration) async -> [(MCPConnectionCallLane, Bool)] {
+            await withTaskGroup(of: (MCPConnectionCallLane, Bool).self) { group in
+                for (lane, limiter) in lanes {
+                    group.addTask {
+                        await (lane, limiter.waitUntilIdle(timeout: timeout))
+                    }
+                }
+                var results: [(MCPConnectionCallLane, Bool)] = []
+                for await result in group {
+                    results.append(result)
+                }
+                return results
+            }
+        }
+
+        #if DEBUG
+            func limiterForTesting(_ lane: MCPConnectionCallLane) -> AsyncLimiter {
+                limiter(for: lane)
+            }
+
+            func diagnosticsSnapshot() async -> MCPConnectionCallLimiterDebugSnapshot {
+                async let ordinarySnapshot = ordinary.debugSnapshot()
+                async let fileSearchSnapshot = fileSearch.debugSnapshot()
+                return await MCPConnectionCallLimiterDebugSnapshot(
+                    ordinary: ordinarySnapshot,
+                    fileSearch: fileSearchSnapshot
+                )
+            }
+
+            func admissionRetryWaiterCountForTesting() -> Int {
+                admissionRetryWaiters.count
+            }
+        #endif
+
+        private func waitForAdmissionCloseOutcome() async -> MCPConnectionCallLimiters? {
+            let waiterID = UUID()
+            return await withTaskCancellationHandler {
+                await withCheckedContinuation { continuation in
+                    guard !Task.isCancelled else {
+                        continuation.resume(returning: nil)
+                        return
+                    }
+                    switch admissionCloseState {
+                    case .open, .committed:
+                        continuation.resume(returning: nil)
+                    case let .restored(replacement):
+                        continuation.resume(returning: replacement)
+                    case .tentative:
+                        admissionRetryWaiters[waiterID] = continuation
+                    }
+                }
+            } onCancel: {
+                Task { await self.cancelAdmissionRetryWaiter(waiterID) }
+            }
+        }
+
+        private func cancelAdmissionRetryWaiter(_ waiterID: UUID) {
+            admissionRetryWaiters.removeValue(forKey: waiterID)?.resume(returning: nil)
+        }
+
+        private func resumeAdmissionRetryWaiters(with replacement: MCPConnectionCallLimiters?) {
+            let waiters = Array(admissionRetryWaiters.values)
+            admissionRetryWaiters.removeAll()
+            for waiter in waiters {
+                waiter.resume(returning: replacement)
+            }
+        }
+
+        private func closeLanes() async {
+            async let cancelOrdinary: Void = ordinary.cancelAll()
+            async let cancelFileSearch: Void = fileSearch.cancelAll()
+            _ = await (cancelOrdinary, cancelFileSearch)
+        }
+
+        private func limiter(for lane: MCPConnectionCallLane) -> AsyncLimiter {
+            switch lane {
+            case .ordinary:
+                ordinary
+            case .fileSearch:
+                fileSearch
+            }
+        }
+
+        private var lanes: [(MCPConnectionCallLane, AsyncLimiter)] {
+            [(.ordinary, ordinary), (.fileSearch, fileSearch)]
+        }
+    }
+
     // 🆕 Admission control
     private var activeConnectionsByClient: [String: Set<UUID>] = [:]
     private var clientIDByConnection: [UUID: String] = [:]
-    private var callLimiters: [UUID: AsyncLimiter] = [:]
+    private var callLimiters: [UUID: MCPConnectionCallLimiters] = [:]
+    #if DEBUG
+        private var debugAfterDirectAdmissionPendingPublishedForTesting: (@Sendable (UUID) async -> Void)?
+        private var debugAfterBootstrapPolicyReadinessForTesting: (@Sendable (String) async -> Void)?
+        private var debugAfterConnectionCallLimiterResolutionForTesting: (@Sendable (UUID) async -> Void)?
+        private var debugAfterConnectionCallPermitAcquiredForTesting: (@Sendable (UUID) async -> Void)?
+        private var debugAfterConnectionCallLimiterRejectionForTesting: (@Sendable (UUID) async -> Void)?
+        private var debugBeforeAdmissionEvictionCloseForTesting: (@Sendable (UUID) async -> Void)?
+        private var debugBeforeActiveToolCancellationScanForTesting: (@Sendable (UUID, [UUID]) async -> Void)?
+        private var debugAllocatedActiveToolScopeIDsForTesting: Set<UUID> = []
+        private var debugDuringAdmissionEvictionCloseForTesting: (@Sendable (UUID) async -> Void)?
+        private var debugAfterAdmissionEvictionRemovalCommittedForTesting: (@Sendable (UUID) async -> Void)?
+        private var debugBootstrapPredecessorStopGraceSleepForTesting: (@Sendable (Duration) async throws -> Void)?
+        private var debugMaxGlobalConnectionsForTesting: Int?
+        private var debugMaxConnectionsPerClientForTesting: Int?
+        private var debugPreserveOnePerClientForTesting: Bool?
+        private var debugPressureEvictIdleSecondsForTesting: Int?
+    #endif
 
     /// 🆕 Routing persistence: per-connection metadata
     /// Session key (capabilityToken) for disambiguating multiple client instances
     private var capabilityTokenByConnection: [UUID: String] = [:]
     /// Reverse lookup for session token → connection ID (bootstrap socket)
     private var connectionIDBySessionToken: [String: UUID] = [:]
+    /// Monotonic token-binding generation used to prevent replacement credit from transferring
+    /// or resurrecting after a durable session token is rebound.
+    private var sessionTokenBindingGeneration: [String: UInt64] = [:]
     /// Persisted routing state (survives app restarts)
     private var routingState: MCPRoutingState = MCPRoutingStateStore.load()
     /// In-memory last window selection per (clientID, sessionKey) for quick access
@@ -1055,9 +1336,40 @@ actor ServerNetworkManager {
 
     private var connectionWaiters: [UUID: ConnectionWaiter] = [:]
 
-    // 🔥 Track which connection owns the active tool per window
-    private var activeToolOwnerByWindow: [Int: UUID] = [:] // windowID → connectionID
-    private var activeToolNameByWindow: [Int: String] = [:] // windowID → tool name (for logging)
+    /// Exact active-tool scopes per window. Every scope has an identity so overlapping
+    /// connections, cancellation cleanup, and deferred completions cannot clear each other.
+    private struct ActiveToolScopeRecord {
+        let connectionID: UUID
+        let toolName: String
+        let sequence: UInt64
+    }
+
+    private struct ActiveToolScopeHandle {
+        let windowID: Int
+        let scopeID: UUID
+    }
+
+    struct WindowToolDispatchIdentity: @unchecked Sendable {
+        let windowID: Int
+        let windowStateIdentity: ObjectIdentifier
+        let serverViewModelIdentity: ObjectIdentifier
+        let catalogServiceIdentity: ObjectIdentifier
+    }
+
+    struct ToolDispatchAuthorization: @unchecked Sendable {
+        let connectionID: UUID
+        let connectionIdentity: ObjectIdentifier
+        let lifecycleGeneration: UInt64
+        let windowIdentity: WindowToolDispatchIdentity?
+    }
+
+    enum ToolDispatchAdmissionError: Error {
+        case connectionTerminal
+        case windowTerminal
+    }
+
+    private var activeToolScopesByWindow: [Int: [UUID: ActiveToolScopeRecord]] = [:]
+    private var activeToolScopeSequence: UInt64 = 0
     private var dashboardDidChangeHook: (@Sendable () -> Void)?
 
     /// ─────────────  Connection value/stats (for admission fairness)  ─────────────
@@ -1087,12 +1399,48 @@ actor ServerNetworkManager {
     private var toolSchemaCache: [ToolSchemaCacheKey: Value] = [:]
     /// Tracks bootstrap connections that have been accepted but not yet committed (registered).
     /// This prevents burst scenarios where multiple concurrent accepts could exceed maxGlobalConnections.
+    private struct BootstrapAdmissionClaim {
+        let connectionID: UUID
+        let lifecycleGeneration: UInt64
+        var replacementCredit: BootstrapReplacementCredit?
+    }
+
+    private struct BootstrapReplacementCredit {
+        let sessionToken: String
+        let predecessorConnectionID: UUID
+        let predecessorConnectionIdentity: ObjectIdentifier
+        let predecessorLifecycleGeneration: UInt64
+        let tokenBindingGeneration: UInt64
+    }
+
     private struct BootstrapReservation {
         let connectionID: UUID
         let lifecycleGeneration: UInt64
-        let createdAt: Date
+        let sessionToken: String
+        var createdAt: Date
+        var replacementCredit: BootstrapReplacementCredit?
+        var committingConnection: BootstrapSocketConnectionManager?
+
+        var isCommitting: Bool {
+            committingConnection != nil
+        }
     }
 
+    private struct GlobalAdmissionLoadSnapshot {
+        let registeredConnectionCount: Int
+        let reservationCount: Int
+        let creditedPredecessorConnectionIDs: Set<UUID>
+
+        var replacementCreditCount: Int {
+            creditedPredecessorConnectionIDs.count
+        }
+
+        var effectiveLoad: Int {
+            registeredConnectionCount + reservationCount - replacementCreditCount
+        }
+    }
+
+    private var bootstrapAdmissionClaimsBySessionToken: [String: BootstrapAdmissionClaim] = [:]
     private var bootstrapReservations: [UUID: BootstrapReservation] = [:]
     /// Synchronously visible ownership for transferred bootstrap sockets that are
     /// awaiting deferred actor registration.
@@ -1101,24 +1449,241 @@ actor ServerNetworkManager {
     /// Use a generous value to avoid expiring legitimate reservations under load.
     private let bootstrapReservationTTL: TimeInterval = 60.0
 
-    /// Current load including both active connections and pending reservations
-    private func bootstrapLoad() -> Int {
-        connections.count + bootstrapReservations.count
-    }
-
-    /// Reserve a slot for an incoming bootstrap connection (called before returning .accept)
-    private func reserveBootstrapSlot(connectionID: UUID, lifecycleGeneration: UInt64) {
-        bootstrapReservations[connectionID] = BootstrapReservation(
-            connectionID: connectionID,
-            lifecycleGeneration: lifecycleGeneration,
-            createdAt: Date()
+    private func captureBootstrapReplacementCredit(
+        sessionToken: String
+    ) -> BootstrapReplacementCredit? {
+        guard let predecessorConnectionID = currentBootstrapReplacementConnectionID(
+            forSessionToken: sessionToken
+        ),
+            let predecessor = connections[predecessorConnectionID],
+            !predecessor.isFilesystemBacked,
+            let predecessorLifecycleGeneration = connectionLifecycleGenerationByID[predecessorConnectionID],
+            isCurrentLifecycle(predecessorLifecycleGeneration),
+            capabilityTokenByConnection[predecessorConnectionID] == sessionToken
+        else { return nil }
+        return BootstrapReplacementCredit(
+            sessionToken: sessionToken,
+            predecessorConnectionID: predecessorConnectionID,
+            predecessorConnectionIdentity: ObjectIdentifier(predecessor as AnyObject),
+            predecessorLifecycleGeneration: predecessorLifecycleGeneration,
+            tokenBindingGeneration: sessionTokenBindingGeneration[sessionToken, default: 0]
         )
     }
 
+    private func isCurrentBootstrapAdmissionClaim(
+        sessionToken: String,
+        connectionID: UUID,
+        lifecycleGeneration: UInt64
+    ) -> Bool {
+        guard let claim = bootstrapAdmissionClaimsBySessionToken[sessionToken] else { return false }
+        return claim.connectionID == connectionID
+            && claim.lifecycleGeneration == lifecycleGeneration
+    }
+
+    private func isValidBootstrapReplacementCredit(
+        _ credit: BootstrapReplacementCredit,
+        reservationConnectionID: UUID,
+        reservationLifecycleGeneration: UInt64
+    ) -> Bool {
+        guard credit.sessionToken.isEmpty == false,
+              isCurrentLifecycle(reservationLifecycleGeneration),
+              isCurrentBootstrapAdmissionClaim(
+                  sessionToken: credit.sessionToken,
+                  connectionID: reservationConnectionID,
+                  lifecycleGeneration: reservationLifecycleGeneration
+              ),
+              sessionTokenBindingGeneration[credit.sessionToken, default: 0] == credit.tokenBindingGeneration,
+              connectionIDBySessionToken[credit.sessionToken] == credit.predecessorConnectionID,
+              capabilityTokenByConnection[credit.predecessorConnectionID] == credit.sessionToken,
+              !connectionsBeingRemoved.contains(credit.predecessorConnectionID),
+              connectionLifecycleGenerationByID[credit.predecessorConnectionID] == credit.predecessorLifecycleGeneration,
+              let predecessor = connections[credit.predecessorConnectionID],
+              !predecessor.isFilesystemBacked
+        else { return false }
+        return ObjectIdentifier(predecessor as AnyObject) == credit.predecessorConnectionIdentity
+    }
+
+    private func isLiveBootstrapReservation(_ reservation: BootstrapReservation) -> Bool {
+        // Expired reservations continue consuming capacity until cleanup atomically removes
+        // the reservation, releases its claim, and closes any transferred descriptor.
+        reservation.lifecycleGeneration == lifecycleGeneration
+    }
+
+    /// Global admission load shared by direct and bootstrap admission.
+    /// Registered predecessors and their valid replacement reservations count once.
+    /// A prospective bootstrap credit is included only for the pre-reservation capacity check;
+    /// the prospective reservation itself is represented by the caller's `< cap` requirement.
+    private func globalAdmissionLoadSnapshot(
+        prospectiveReplacementCredit: BootstrapReplacementCredit? = nil
+    ) -> GlobalAdmissionLoadSnapshot {
+        let now = Date()
+        let liveReservations = bootstrapReservations.values.filter {
+            isLiveBootstrapReservation($0)
+        }
+        var creditedPredecessorsByIdentity: [ObjectIdentifier: UUID] = [:]
+        for reservation in liveReservations {
+            guard reservation.isCommitting || now.timeIntervalSince(reservation.createdAt) < bootstrapReservationTTL,
+                  let credit = reservation.replacementCredit,
+                  isValidBootstrapReplacementCredit(
+                      credit,
+                      reservationConnectionID: reservation.connectionID,
+                      reservationLifecycleGeneration: reservation.lifecycleGeneration
+                  )
+            else { continue }
+            creditedPredecessorsByIdentity[credit.predecessorConnectionIdentity] = credit.predecessorConnectionID
+        }
+        if let prospectiveReplacementCredit,
+           let claim = bootstrapAdmissionClaimsBySessionToken[prospectiveReplacementCredit.sessionToken],
+           isValidBootstrapReplacementCredit(
+               prospectiveReplacementCredit,
+               reservationConnectionID: claim.connectionID,
+               reservationLifecycleGeneration: claim.lifecycleGeneration
+           )
+        {
+            creditedPredecessorsByIdentity[
+                prospectiveReplacementCredit.predecessorConnectionIdentity
+            ] = prospectiveReplacementCredit.predecessorConnectionID
+        }
+        return GlobalAdmissionLoadSnapshot(
+            registeredConnectionCount: effectiveRegisteredConnectionCount,
+            reservationCount: liveReservations.count,
+            creditedPredecessorConnectionIDs: Set(creditedPredecessorsByIdentity.values)
+        )
+    }
+
+    private func effectiveGlobalAdmissionLoad(
+        prospectiveReplacementCredit: BootstrapReplacementCredit? = nil
+    ) -> Int {
+        globalAdmissionLoadSnapshot(
+            prospectiveReplacementCredit: prospectiveReplacementCredit
+        ).effectiveLoad
+    }
+
+    private func creditedBootstrapPredecessorConnectionIDs(
+        prospectiveReplacementCredit: BootstrapReplacementCredit? = nil
+    ) -> Set<UUID> {
+        var protectedConnectionIDs = globalAdmissionLoadSnapshot(
+            prospectiveReplacementCredit: prospectiveReplacementCredit
+        ).creditedPredecessorConnectionIDs
+        for claim in bootstrapAdmissionClaimsBySessionToken.values {
+            guard let credit = claim.replacementCredit,
+                  isValidBootstrapReplacementCredit(
+                      credit,
+                      reservationConnectionID: claim.connectionID,
+                      reservationLifecycleGeneration: claim.lifecycleGeneration
+                  )
+            else { continue }
+            protectedConnectionIDs.insert(credit.predecessorConnectionID)
+        }
+        return protectedConnectionIDs
+    }
+
+    private func invalidateBootstrapReplacementCredits(
+        sessionToken: String? = nil,
+        predecessorConnectionID: UUID? = nil
+    ) {
+        for claimSessionToken in Array(bootstrapAdmissionClaimsBySessionToken.keys) {
+            guard var claim = bootstrapAdmissionClaimsBySessionToken[claimSessionToken],
+                  let credit = claim.replacementCredit,
+                  sessionToken == nil || credit.sessionToken == sessionToken,
+                  predecessorConnectionID == nil || credit.predecessorConnectionID == predecessorConnectionID
+            else { continue }
+            claim.replacementCredit = nil
+            bootstrapAdmissionClaimsBySessionToken[claimSessionToken] = claim
+        }
+        for reservationID in Array(bootstrapReservations.keys) {
+            guard var reservation = bootstrapReservations[reservationID],
+                  let credit = reservation.replacementCredit,
+                  sessionToken == nil || credit.sessionToken == sessionToken,
+                  predecessorConnectionID == nil || credit.predecessorConnectionID == predecessorConnectionID
+            else { continue }
+            reservation.replacementCredit = nil
+            bootstrapReservations[reservationID] = reservation
+        }
+    }
+
+    private func claimBootstrapAdmission(
+        sessionToken: String,
+        connectionID: UUID,
+        lifecycleGeneration: UInt64
+    ) -> Bool {
+        guard bootstrapAdmissionClaimsBySessionToken[sessionToken] == nil else { return false }
+        let replacementCredit = captureBootstrapReplacementCredit(sessionToken: sessionToken)
+        bootstrapAdmissionClaimsBySessionToken[sessionToken] = BootstrapAdmissionClaim(
+            connectionID: connectionID,
+            lifecycleGeneration: lifecycleGeneration,
+            replacementCredit: replacementCredit
+        )
+        return true
+    }
+
+    private func releaseBootstrapAdmissionClaim(
+        sessionToken: String,
+        connectionID: UUID,
+        lifecycleGeneration: UInt64
+    ) {
+        guard isCurrentBootstrapAdmissionClaim(
+            sessionToken: sessionToken,
+            connectionID: connectionID,
+            lifecycleGeneration: lifecycleGeneration
+        ) else { return }
+        invalidateBootstrapReplacementCredits(sessionToken: sessionToken)
+        bootstrapAdmissionClaimsBySessionToken.removeValue(forKey: sessionToken)
+    }
+
+    /// Reserve a slot for an incoming bootstrap connection (called before returning .accept).
+    /// The durable-token claim must already belong to this exact admission.
+    private func reserveBootstrapSlot(
+        connectionID: UUID,
+        lifecycleGeneration: UInt64,
+        sessionToken: String
+    ) -> Bool {
+        guard let claim = bootstrapAdmissionClaimsBySessionToken[sessionToken],
+              claim.connectionID == connectionID,
+              claim.lifecycleGeneration == lifecycleGeneration
+        else { return false }
+        let validReplacementCredit = claim.replacementCredit.flatMap { credit in
+            isValidBootstrapReplacementCredit(
+                credit,
+                reservationConnectionID: connectionID,
+                reservationLifecycleGeneration: lifecycleGeneration
+            ) ? credit : nil
+        }
+        bootstrapReservations[connectionID] = BootstrapReservation(
+            connectionID: connectionID,
+            lifecycleGeneration: lifecycleGeneration,
+            sessionToken: sessionToken,
+            createdAt: Date(),
+            replacementCredit: validReplacementCredit,
+            committingConnection: nil
+        )
+        return true
+    }
+
+    @discardableResult
+    private func takeBootstrapReservation(
+        connectionID: UUID,
+        lifecycleGeneration: UInt64
+    ) -> BootstrapReservation? {
+        guard let reservation = bootstrapReservations[connectionID],
+              reservation.lifecycleGeneration == lifecycleGeneration
+        else { return nil }
+        bootstrapReservations.removeValue(forKey: connectionID)
+        releaseBootstrapAdmissionClaim(
+            sessionToken: reservation.sessionToken,
+            connectionID: connectionID,
+            lifecycleGeneration: lifecycleGeneration
+        )
+        return reservation
+    }
+
     /// Release a bootstrap reservation when an accepted handshake aborts before commit.
-    private func rollbackBootstrapReservation(connectionID: UUID, lifecycleGeneration: UInt64, reason: String) {
-        if bootstrapReservations[connectionID]?.lifecycleGeneration == lifecycleGeneration {
-            bootstrapReservations.removeValue(forKey: connectionID)
+    private func rollbackBootstrapReservation(connectionID: UUID, lifecycleGeneration: UInt64, reason: String) async {
+        let reservation = takeBootstrapReservation(
+            connectionID: connectionID,
+            lifecycleGeneration: lifecycleGeneration
+        )
+        if reservation != nil {
             connectionLog("Bootstrap connection \(connectionID) rolled back (\(reason))")
         } else if isRunningState {
             log.warning("rollbackBootstrapReservation: no matching reservation found for \(connectionID) while running (reason=\(reason))")
@@ -1129,6 +1694,7 @@ actor ServerNetworkManager {
             connectionID: connectionID,
             lifecycleGeneration: lifecycleGeneration
         )
+        await reservation?.committingConnection?.stop()
     }
 
     private func closeTransferredBootstrapSocket(connectionID: UUID, lifecycleGeneration: UInt64) {
@@ -1147,12 +1713,20 @@ actor ServerNetworkManager {
     /// Clean up expired reservations (safety net for edge cases)
     private func cleanupExpiredBootstrapReservations() {
         let now = Date()
-        let expired = bootstrapReservations.filter { now.timeIntervalSince($0.value.createdAt) >= bootstrapReservationTTL }
+        let expired = bootstrapReservations.filter {
+            !$0.value.isCommitting
+                && now.timeIntervalSince($0.value.createdAt) >= bootstrapReservationTTL
+        }
         if !expired.isEmpty {
             let expiredIDs = expired.map(\.key.uuidString).joined(separator: ", ")
             log.warning("Cleaning up \(expired.count) expired bootstrap reservations (indicates a bug or crash): \(expiredIDs)")
             for id in expired.keys {
                 guard let reservation = bootstrapReservations.removeValue(forKey: id) else { continue }
+                releaseBootstrapAdmissionClaim(
+                    sessionToken: reservation.sessionToken,
+                    connectionID: id,
+                    lifecycleGeneration: reservation.lifecycleGeneration
+                )
                 closeTransferredBootstrapSocket(
                     connectionID: id,
                     lifecycleGeneration: reservation.lifecycleGeneration
@@ -1167,11 +1741,21 @@ actor ServerNetworkManager {
     }
 
     private var maxGlobalConnections: Int {
-        defaultsInt("mcp.maxGlobalConnections", 128)
+        #if DEBUG
+            if let debugMaxGlobalConnectionsForTesting {
+                return debugMaxGlobalConnectionsForTesting
+            }
+        #endif
+        return defaultsInt("mcp.maxGlobalConnections", 128)
     }
 
     private var maxConnectionsPerClient: Int {
-        defaultsInt("mcp.maxConnectionsPerClient", 64)
+        #if DEBUG
+            if let debugMaxConnectionsPerClientForTesting {
+                return debugMaxConnectionsPerClientForTesting
+            }
+        #endif
+        return defaultsInt("mcp.maxConnectionsPerClient", 64)
     }
 
     private var maxCallsPerConnection: Int {
@@ -1179,14 +1763,24 @@ actor ServerNetworkManager {
     }
 
     private var pressureEvictIdleSeconds: Int {
-        defaultsInt("mcp.pressureEvictIdleSeconds", 7200)
+        #if DEBUG
+            if let debugPressureEvictIdleSecondsForTesting {
+                return debugPressureEvictIdleSecondsForTesting
+            }
+        #endif
+        return defaultsInt("mcp.pressureEvictIdleSeconds", 7200)
     } // 2h
     private var connectingTimeoutSeconds: Int {
         defaultsInt("mcp.connectingTimeoutSeconds", 60)
     }
 
     private var preserveOnePerClient: Bool {
-        (UserDefaults.standard.object(forKey: "mcp.preserveOnePerClient") as? Bool) ?? true
+        #if DEBUG
+            if let debugPreserveOnePerClientForTesting {
+                return debugPreserveOnePerClientForTesting
+            }
+        #endif
+        return (UserDefaults.standard.object(forKey: "mcp.preserveOnePerClient") as? Bool) ?? true
     }
 
     /// 🆕 Task-local keys to expose current routing hints inside tool calls
@@ -1194,37 +1788,164 @@ actor ServerNetworkManager {
     static var currentConnectionID: UUID?
     @TaskLocal
     static var currentTabContextHint: MCPServerViewModel.TabContextHint?
+    @TaskLocal
+    static var currentToolDispatchAuthorization: ToolDispatchAuthorization?
 
     // ------------------------------------------------------------------
     // MARK: Tool ownership tracking helpers
 
     /// ------------------------------------------------------------------
-    private func markActiveToolOwner(windowID: Int, connectionID: UUID, toolName: String) {
-        activeToolOwnerByWindow[windowID] = connectionID
-        activeToolNameByWindow[windowID] = toolName
-        connectionLog("Tool '\(toolName)' ownership marked for connection \(connectionID) on window \(windowID)")
+    private func beginActiveToolScope(
+        windowID: Int,
+        connectionID: UUID,
+        toolName: String,
+        scopeID requestedScopeID: UUID? = nil
+    ) -> ActiveToolScopeHandle? {
+        guard !connectionsBeingRemoved.contains(connectionID) else { return nil }
+
+        let scopeID: UUID
+        if let requestedScopeID {
+            #if DEBUG
+                guard debugAllocatedActiveToolScopeIDsForTesting.insert(requestedScopeID).inserted else { return nil }
+            #else
+                guard !containsActiveToolScope(scopeID: requestedScopeID) else { return nil }
+            #endif
+            scopeID = requestedScopeID
+        } else {
+            var generatedScopeID = UUID()
+            while containsActiveToolScope(scopeID: generatedScopeID) {
+                generatedScopeID = UUID()
+            }
+            scopeID = generatedScopeID
+        }
+
+        precondition(activeToolScopeSequence < UInt64.max, "Active-tool scope sequence exhausted")
+        activeToolScopeSequence += 1
+        activeToolScopesByWindow[windowID, default: [:]][scopeID] = ActiveToolScopeRecord(
+            connectionID: connectionID,
+            toolName: toolName,
+            sequence: activeToolScopeSequence
+        )
+        connectionLog(
+            "Tool '\(toolName)' scope \(scopeID) marked for connection \(connectionID) on window \(windowID) (sequence=\(activeToolScopeSequence))"
+        )
         dashboardDidChangeHook?()
+        return ActiveToolScopeHandle(windowID: windowID, scopeID: scopeID)
     }
 
-    private func clearActiveToolOwner(windowID: Int, connectionID: UUID) {
-        // Only clear if the same connection is the current owner
-        if activeToolOwnerByWindow[windowID] == connectionID {
-            if let toolName = activeToolNameByWindow[windowID] {
-                connectionLog("Tool '\(toolName)' ownership cleared for connection \(connectionID) on window \(windowID)")
+    private func containsActiveToolScope(scopeID: UUID) -> Bool {
+        activeToolScopesByWindow.values.contains { $0[scopeID] != nil }
+    }
+
+    @discardableResult
+    private func endActiveToolScope(_ handle: ActiveToolScopeHandle) -> Bool {
+        guard var scopes = activeToolScopesByWindow[handle.windowID],
+              let removed = scopes.removeValue(forKey: handle.scopeID)
+        else { return false }
+
+        if scopes.isEmpty {
+            activeToolScopesByWindow.removeValue(forKey: handle.windowID)
+        } else {
+            activeToolScopesByWindow[handle.windowID] = scopes
+        }
+        connectionLog(
+            "Tool '\(removed.toolName)' scope \(handle.scopeID) cleared for connection \(removed.connectionID) on window \(handle.windowID)"
+        )
+        dashboardDidChangeHook?()
+        return true
+    }
+
+    @discardableResult
+    private func removeActiveToolScopes(_ scopeIDsByWindow: [Int: Set<UUID>]) -> Int {
+        var removedCount = 0
+        for (windowID, scopeIDs) in scopeIDsByWindow {
+            guard var scopes = activeToolScopesByWindow[windowID] else { continue }
+            for scopeID in scopeIDs where scopes.removeValue(forKey: scopeID) != nil {
+                removedCount += 1
             }
-            activeToolOwnerByWindow.removeValue(forKey: windowID)
-            activeToolNameByWindow.removeValue(forKey: windowID)
+            if scopes.isEmpty {
+                activeToolScopesByWindow.removeValue(forKey: windowID)
+            } else {
+                activeToolScopesByWindow[windowID] = scopes
+            }
+        }
+        if removedCount > 0 {
             dashboardDidChangeHook?()
         }
+        return removedCount
+    }
+
+    @discardableResult
+    private func removeActiveToolScopesForWindow(_ windowID: Int) -> Int {
+        guard let removed = activeToolScopesByWindow.removeValue(forKey: windowID) else { return 0 }
+        dashboardDidChangeHook?()
+        return removed.count
+    }
+
+    private func activeToolScopeIDs(ownedBy connectionID: UUID) -> [Int: Set<UUID>] {
+        var result: [Int: Set<UUID>] = [:]
+        for (windowID, scopes) in activeToolScopesByWindow {
+            for (scopeID, scope) in scopes where scope.connectionID == connectionID {
+                result[windowID, default: []].insert(scopeID)
+            }
+        }
+        return result
+    }
+
+    private func hasActiveToolScopes(ownedBy connectionID: UUID) -> Bool {
+        activeToolScopesByWindow.values.contains { scopes in
+            scopes.values.contains { $0.connectionID == connectionID }
+        }
+    }
+
+    private func preferredActiveToolScope(
+        connectionID: UUID,
+        assignedWindowID: Int?,
+        scopesByWindow: [Int: [UUID: ActiveToolScopeRecord]]
+    ) -> ConnectionDashboardActiveToolScope? {
+        if let assignedWindowID,
+           let assignedScope = scopesByWindow[assignedWindowID]?.values
+           .filter({ $0.connectionID == connectionID })
+           .max(by: { $0.sequence < $1.sequence })
+        {
+            return ConnectionDashboardActiveToolScope(
+                windowID: assignedWindowID,
+                toolName: assignedScope.toolName,
+                sequence: assignedScope.sequence
+            )
+        }
+
+        var newestScope: ConnectionDashboardActiveToolScope?
+        for (windowID, scopes) in scopesByWindow {
+            for scope in scopes.values where scope.connectionID == connectionID {
+                if newestScope == nil || scope.sequence > newestScope!.sequence {
+                    newestScope = ConnectionDashboardActiveToolScope(
+                        windowID: windowID,
+                        toolName: scope.toolName,
+                        sequence: scope.sequence
+                    )
+                }
+            }
+        }
+        return newestScope
     }
 
     private func cancelActiveToolsOwnedByConnection(
         _ connectionID: UUID,
         reason: String
     ) async -> Int {
-        let ownerWindowsToClear = activeToolOwnerByWindow.compactMap { windowID, owner in
-            owner == connectionID ? windowID : nil
-        }
+        // Capture exact scope identities before the MainActor hop. Actor reentrancy may admit
+        // newer same-connection scopes while the identity-bound VM cancellation scan runs.
+        let capturedScopeIDsByWindow = activeToolScopeIDs(ownedBy: connectionID)
+        #if DEBUG
+            if let debugBeforeActiveToolCancellationScanForTesting {
+                let capturedScopeIDs = capturedScopeIDsByWindow.values
+                    .flatMap(\.self)
+                    .sorted { $0.uuidString < $1.uuidString }
+                await debugBeforeActiveToolCancellationScanForTesting(connectionID, capturedScopeIDs)
+            }
+        #endif
+
         let cancelledCount = await MainActor.run { () -> Int in
             // The VM API is identity-bound, so it is safe to scan all windows. This avoids
             // missing tools routed via a per-call _windowID override that differs from the
@@ -1237,27 +1958,123 @@ actor ServerNetworkManager {
             }
         }
 
-        for windowID in ownerWindowsToClear {
-            clearActiveToolOwner(windowID: windowID, connectionID: connectionID)
-        }
-
+        _ = removeActiveToolScopes(capturedScopeIDsByWindow)
         return cancelledCount
     }
 
-    /// Run `op` while marking this connection as the active-tool owner for `windowID`.
-    /// Ownership is always cleared, even if `op` throws.
+    private func captureWindowToolDispatchIdentity(
+        windowID: Int,
+        catalogServiceIdentity: ObjectIdentifier
+    ) async -> WindowToolDispatchIdentity? {
+        await MainActor.run {
+            guard let window = WindowStatesManager.shared.window(withID: windowID),
+                  !window.isClosing,
+                  ServiceRegistry.services.contains(where: {
+                      ObjectIdentifier($0 as AnyObject) == catalogServiceIdentity
+                  })
+            else { return nil }
+            return WindowToolDispatchIdentity(
+                windowID: windowID,
+                windowStateIdentity: ObjectIdentifier(window),
+                serverViewModelIdentity: ObjectIdentifier(window.mcpServer),
+                catalogServiceIdentity: catalogServiceIdentity
+            )
+        }
+    }
+
+    private func isCurrentWindowToolDispatchIdentity(
+        _ identity: WindowToolDispatchIdentity,
+        expectedServerViewModelIdentity: ObjectIdentifier? = nil
+    ) async -> Bool {
+        await MainActor.run {
+            guard identity.windowID > 0,
+                  let window = WindowStatesManager.shared.window(withID: identity.windowID),
+                  !window.isClosing,
+                  ObjectIdentifier(window) == identity.windowStateIdentity,
+                  ObjectIdentifier(window.mcpServer) == identity.serverViewModelIdentity,
+                  ServiceRegistry.services.contains(where: {
+                      ObjectIdentifier($0 as AnyObject) == identity.catalogServiceIdentity
+                  })
+            else { return false }
+            if let expectedServerViewModelIdentity {
+                return ObjectIdentifier(window.mcpServer) == expectedServerViewModelIdentity
+            }
+            return true
+        }
+    }
+
+    func validateToolDispatchAuthorization(
+        _ authorization: ToolDispatchAuthorization,
+        expectedWindowID: Int,
+        expectedServerViewModelIdentity: ObjectIdentifier
+    ) async -> Bool {
+        guard authorization.connectionID == Self.currentConnectionID,
+              isCurrentToolDispatchAuthorization(authorization),
+              let windowIdentity = authorization.windowIdentity,
+              windowIdentity.windowID == expectedWindowID
+        else { return false }
+        return await isCurrentWindowToolDispatchIdentity(
+            windowIdentity,
+            expectedServerViewModelIdentity: expectedServerViewModelIdentity
+        )
+    }
+
+    private func isCurrentToolDispatchAuthorization(
+        _ authorization: ToolDispatchAuthorization
+    ) -> Bool {
+        guard !connectionsBeingRemoved.contains(authorization.connectionID),
+              !executionWatchdogTerminalConnections.contains(authorization.connectionID),
+              isCurrentLifecycle(authorization.lifecycleGeneration),
+              connectionLifecycleGenerationByID[authorization.connectionID] == authorization.lifecycleGeneration,
+              let connection = connections[authorization.connectionID]
+        else { return false }
+        return ObjectIdentifier(connection as AnyObject) == authorization.connectionIdentity
+    }
+
+    /// Run `op` while recording this exact active-tool scope for `windowID`.
+    /// The exact scope ID is always removed, even if `op` throws or broader cleanup ran first.
     func withWindowToolOwnership<T>(
         windowID: Int,
         connectionID: UUID,
         toolName: String,
+        connectionAuthorization: ToolDispatchAuthorization? = nil,
+        windowIdentity: WindowToolDispatchIdentity? = nil,
+        recordScope: Bool = true,
         _ op: @Sendable () async throws -> T
-    ) async rethrows -> T {
-        // Actor context: direct, synchronous calls (no await, no Task)
-        markActiveToolOwner(windowID: windowID, connectionID: connectionID, toolName: toolName)
-        defer {
-            clearActiveToolOwner(windowID: windowID, connectionID: connectionID)
+    ) async throws -> T {
+        guard !connectionsBeingRemoved.contains(connectionID),
+              connectionAuthorization.map(isCurrentToolDispatchAuthorization) ?? true
+        else {
+            throw ToolDispatchAdmissionError.connectionTerminal
         }
-        // Suspend actor while the body runs; resumes here to clear in defer.
+        if let windowIdentity {
+            guard windowIdentity.windowID == windowID,
+                  await isCurrentWindowToolDispatchIdentity(windowIdentity)
+            else {
+                throw ToolDispatchAdmissionError.windowTerminal
+            }
+        }
+        if !recordScope {
+            guard !connectionsBeingRemoved.contains(connectionID),
+                  connectionAuthorization.map(isCurrentToolDispatchAuthorization) ?? true
+            else {
+                throw ToolDispatchAdmissionError.connectionTerminal
+            }
+            return try await op()
+        }
+        guard !connectionsBeingRemoved.contains(connectionID),
+              connectionAuthorization.map(isCurrentToolDispatchAuthorization) ?? true,
+              let scope = beginActiveToolScope(
+                  windowID: windowID,
+                  connectionID: connectionID,
+                  toolName: toolName
+              )
+        else {
+            throw ToolDispatchAdmissionError.connectionTerminal
+        }
+        defer {
+            endActiveToolScope(scope)
+        }
         return try await op()
     }
 
@@ -1401,9 +2218,8 @@ actor ServerNetworkManager {
             runIDByConnectionID[cid] = nil
         }
 
-        // Also clear ownership for this window to avoid stale "owned by …" logs
-        activeToolOwnerByWindow.removeValue(forKey: windowID)
-        activeToolNameByWindow.removeValue(forKey: windowID)
+        // Window close authoritatively removes this bucket; deferred exact-ID completions are no-ops.
+        removeActiveToolScopesForWindow(windowID)
 
         // Remove stale run→window cache entries for the closed window.
         let staleRunIDs = windowIDByRunID.compactMap { runID, mappedWindowID in
@@ -2348,7 +3164,9 @@ actor ServerNetworkManager {
     ) -> UUID? {
         guard isCurrentLifecycle(expectedLifecycleGeneration) else { return nil }
         for (id, _) in connections {
-            guard connectionLifecycleGenerationByID[id] == expectedLifecycleGeneration else { continue }
+            guard !connectionsBeingRemoved.contains(id),
+                  connectionLifecycleGenerationByID[id] == expectedLifecycleGeneration
+            else { continue }
             guard !excluding.contains(id) else { continue }
 
             if let nameFilter = clientName {
@@ -2676,14 +3494,57 @@ actor ServerNetworkManager {
             guard isCurrentLifecycle(expectedLifecycleGeneration) else { return }
         }
         guard pressureEvictIdleSeconds > 0 else { return }
-        guard bootstrapLoad() >= maxGlobalConnections else { return }
-        if let victim = await oldestEvictableConnectionID() {
-            if let expectedLifecycleGeneration {
-                guard isCurrentLifecycle(expectedLifecycleGeneration) else { return }
-            }
-            log.warning("Pressure eviction: evicting idle connection \(victim)")
-            await removeConnection(victim)
+        guard effectiveGlobalAdmissionLoad() >= maxGlobalConnections else { return }
+        guard let victim = await oldestPressureEvictionCandidate() else { return }
+        if let expectedLifecycleGeneration {
+            guard isCurrentLifecycle(expectedLifecycleGeneration) else { return }
         }
+        guard isCurrentEvictionCandidate(victim),
+              !isCreditedBootstrapPredecessor(victim),
+              let closedLimiters = callLimiters[victim.id]
+        else { return }
+        guard await closeConnectionCallLanesIfIdleForEviction(
+            victim.id,
+            expectedConnectionIdentity: victim.connectionIdentity,
+            expectedLimiters: closedLimiters
+        ) else { return }
+        guard isCurrentEvictionCandidate(victim),
+              callLimiters[victim.id] === closedLimiters
+        else {
+            await closedLimiters.markTentativeCloseCommitted()
+            return
+        }
+
+        if isCreditedBootstrapPredecessor(victim)
+            || effectiveGlobalAdmissionLoad() < maxGlobalConnections
+        {
+            _ = await restoreConnectionCallLanesAfterAbortedIdleEviction(
+                victim.id,
+                clientID: victim.clientID,
+                connectionIdentity: victim.connectionIdentity,
+                replacing: closedLimiters,
+                requiresClientMembership: false
+            )
+            return
+        }
+
+        guard !isCreditedBootstrapPredecessor(victim),
+              let committedRemoval = commitConnectionRemoval(
+                  connectionID: victim.id,
+                  expectedIdentity: victim.connectionIdentity,
+                  expectedLifecycleGeneration: victim.lifecycleGeneration
+              )
+        else {
+            await closedLimiters.markTentativeCloseCommitted()
+            return
+        }
+        await closedLimiters.markTentativeCloseCommitted()
+        log.warning("Pressure eviction: evicting idle connection \(victim.id)")
+        _ = await removeConnection(
+            victim.id,
+            committedRemoval: committedRemoval,
+            connectionAlreadyStopped: false
+        )
     }
 
     // MARK: - Bootstrap Socket Server
@@ -2958,15 +3819,18 @@ actor ServerNetworkManager {
             return .reject(.rejected(reason: reason, errorCode: MCPBootstrapErrorCode.clientCooldown.rawValue))
         }
 
-        // If this session token already has a live connection, we will replace it after accept.
-        let replacedIDForCapacity = existingConnectionID(forSessionToken: sessionToken)
+        // This pre-await snapshot is only a policy-readiness hint. Capacity must resolve the
+        // current replacement from the durable session token after every suspension.
+        let replacementBeforePolicyReadiness = currentBootstrapReplacementConnectionID(
+            forSessionToken: sessionToken
+        )
 
         let policyReadiness = await awaitAgentBootstrapPolicyBeforeAcceptIfNeeded(
             bootstrapClientName: clientName,
             connectionID: connectionID,
             sessionKey: sessionToken,
             clientPid: clientPid,
-            isReplacementForSession: replacedIDForCapacity != nil
+            isReplacementForSession: replacementBeforePolicyReadiness != nil
         )
         if policyReadiness == .timedOut {
             return .reject(.rejected(
@@ -2977,25 +3841,57 @@ actor ServerNetworkManager {
         guard isCurrentBootstrapListener(sourceListener, lifecycleGeneration: admissionLifecycleGeneration) else {
             return rejectBootstrapAdmissionBecauseStopped(connectionID: connectionID)
         }
-
-        // Enforce capacity against bootstrapLoad() (connections + reservations)
-        // Loop eviction until we have space or no candidates remain
-        while bootstrapLoad() - (replacedIDForCapacity != nil ? 1 : 0) >= maxGlobalConnections {
-            let evicted = await evictLeastValuableGlobalForAdmission(
-                preserveOnePerClient: preserveOnePerClient,
-                sourceListener: sourceListener,
-                lifecycleGeneration: admissionLifecycleGeneration
-            )
+        #if DEBUG
+            await debugAfterBootstrapPolicyReadinessForTesting?(sessionToken)
             guard isCurrentBootstrapListener(sourceListener, lifecycleGeneration: admissionLifecycleGeneration) else {
                 return rejectBootstrapAdmissionBecauseStopped(connectionID: connectionID)
             }
-            if !evicted {
-                log.warning("At global capacity and no evictable candidate; rejecting bootstrap connection \(connectionID)")
-                return .reject(.rejected(reason: "Server at capacity", errorCode: MCPBootstrapErrorCode.capacityExceeded.rawValue))
-            }
+        #endif
+
+        guard claimBootstrapAdmission(
+            sessionToken: sessionToken,
+            connectionID: connectionID,
+            lifecycleGeneration: admissionLifecycleGeneration
+        ) else {
+            log.notice("Rejecting concurrent bootstrap admission \(connectionID) for an already-pending durable session token")
+            return .reject(.rejected(
+                reason: "Session connection already pending",
+                errorCode: MCPBootstrapErrorCode.capacityExceeded.rawValue
+            ))
+        }
+
+        let replacementCredit = bootstrapAdmissionClaimsBySessionToken[sessionToken]?.replacementCredit
+        let capacityResult = await ensureGlobalCapacityForBootstrapAdmission(
+            sourceListener: sourceListener,
+            lifecycleGeneration: admissionLifecycleGeneration,
+            prospectiveReplacementCredit: replacementCredit
+        )
+        switch capacityResult {
+        case .available:
+            break
+        case .capacityExceeded:
+            releaseBootstrapAdmissionClaim(
+                sessionToken: sessionToken,
+                connectionID: connectionID,
+                lifecycleGeneration: admissionLifecycleGeneration
+            )
+            log.warning("At global capacity and no evictable candidate; rejecting bootstrap connection \(connectionID)")
+            return .reject(.rejected(reason: "Server at capacity", errorCode: MCPBootstrapErrorCode.capacityExceeded.rawValue))
+        case .admissionContextInvalidated:
+            releaseBootstrapAdmissionClaim(
+                sessionToken: sessionToken,
+                connectionID: connectionID,
+                lifecycleGeneration: admissionLifecycleGeneration
+            )
+            return rejectBootstrapAdmissionBecauseStopped(connectionID: connectionID)
         }
 
         guard isCurrentBootstrapListener(sourceListener, lifecycleGeneration: admissionLifecycleGeneration) else {
+            releaseBootstrapAdmissionClaim(
+                sessionToken: sessionToken,
+                connectionID: connectionID,
+                lifecycleGeneration: admissionLifecycleGeneration
+            )
             return rejectBootstrapAdmissionBecauseStopped(connectionID: connectionID)
         }
         return makeAcceptedBootstrapAdmission(
@@ -3005,6 +3901,59 @@ actor ServerNetworkManager {
             clientPid: clientPid,
             clientName: clientName
         )
+    }
+
+    private enum BootstrapAdmissionCapacityResult: Equatable {
+        case available
+        case capacityExceeded
+        case admissionContextInvalidated
+    }
+
+    private func ensureGlobalCapacityForBootstrapAdmission(
+        sourceListener: BootstrapSocketServer?,
+        lifecycleGeneration admissionLifecycleGeneration: UInt64?,
+        prospectiveReplacementCredit: BootstrapReplacementCredit?
+    ) async -> BootstrapAdmissionCapacityResult {
+        guard isCurrentBootstrapAdmissionContext(
+            sourceListener: sourceListener,
+            lifecycleGeneration: admissionLifecycleGeneration
+        ) else { return .admissionContextInvalidated }
+
+        while true {
+            if effectiveGlobalAdmissionLoad(
+                prospectiveReplacementCredit: prospectiveReplacementCredit
+            ) < maxGlobalConnections {
+                return .available
+            }
+
+            let evictionResult = await evictLeastValuableGlobalForAdmission(
+                preserveOnePerClient: preserveOnePerClient,
+                sourceListener: sourceListener,
+                lifecycleGeneration: admissionLifecycleGeneration,
+                capacityPredicate: .bootstrap(
+                    prospectiveReplacementCredit: prospectiveReplacementCredit
+                )
+            )
+            guard isCurrentBootstrapAdmissionContext(
+                sourceListener: sourceListener,
+                lifecycleGeneration: admissionLifecycleGeneration
+            ) else { return .admissionContextInvalidated }
+
+            if effectiveGlobalAdmissionLoad(
+                prospectiveReplacementCredit: prospectiveReplacementCredit
+            ) < maxGlobalConnections {
+                return .available
+            }
+
+            switch evictionResult {
+            case .evicted, .capacityChanged:
+                continue
+            case .noProgress:
+                return .capacityExceeded
+            case .admissionContextInvalidated:
+                return .admissionContextInvalidated
+            }
+        }
     }
 
     private func isCurrentLifecycle(_ generation: UInt64) -> Bool {
@@ -3023,10 +3972,19 @@ actor ServerNetworkManager {
         clientPid: Int,
         clientName: String?
     ) -> BootstrapSocketServer.Admission {
-        reserveBootstrapSlot(
+        guard reserveBootstrapSlot(
             connectionID: connectionID,
-            lifecycleGeneration: admissionLifecycleGeneration
-        )
+            lifecycleGeneration: admissionLifecycleGeneration,
+            sessionToken: sessionToken
+        ) else {
+            releaseBootstrapAdmissionClaim(
+                sessionToken: sessionToken,
+                connectionID: connectionID,
+                lifecycleGeneration: admissionLifecycleGeneration
+            )
+            log.error("Bootstrap admission \(connectionID) lost its durable-token claim before reservation")
+            return .reject(.rejected(reason: "Server unavailable", errorCode: MCPBootstrapErrorCode.serverUnavailable.rawValue))
+        }
         connectionLog("handleBootstrapConnection: returning Admission.accept for \(connectionID)")
 
         // NOTE: Using strong capture [self] to ensure reservation cleanup always reaches
@@ -3067,6 +4025,7 @@ actor ServerNetworkManager {
     ) async {
         guard let reservation = bootstrapReservations[connectionID],
               reservation.lifecycleGeneration == admissionLifecycleGeneration,
+              !reservation.isCommitting,
               isCurrentLifecycle(admissionLifecycleGeneration)
         else {
             closeTransferredBootstrapSocket(
@@ -3078,31 +4037,16 @@ actor ServerNetworkManager {
             }
             return
         }
-
-        guard isCurrentBootstrapCommit(
-            connectionID: connectionID,
-            lifecycleGeneration: admissionLifecycleGeneration
-        ) else {
-            abandonPendingBootstrapCommit(
+        guard Date().timeIntervalSince(reservation.createdAt) < bootstrapReservationTTL,
+              isCurrentBootstrapCommit(
+                  connectionID: connectionID,
+                  lifecycleGeneration: admissionLifecycleGeneration
+              )
+        else {
+            await abandonPendingBootstrapCommit(
                 connectionID: connectionID,
                 lifecycleGeneration: admissionLifecycleGeneration,
-                reason: "lifecycle invalid before replacement"
-            )
-            return
-        }
-
-        if let replacedNow = existingConnectionID(forSessionToken: sessionToken) {
-            await softDisconnectConnection(replacedNow, reason: .connectionReplaced, message: "Replaced by new connection for same session")
-        }
-
-        guard isCurrentBootstrapCommit(
-            connectionID: connectionID,
-            lifecycleGeneration: admissionLifecycleGeneration
-        ) else {
-            abandonPendingBootstrapCommit(
-                connectionID: connectionID,
-                lifecycleGeneration: admissionLifecycleGeneration,
-                reason: "lifecycle invalid after replacement"
+                reason: "reservation expired or invalid before commit"
             )
             return
         }
@@ -3111,42 +4055,232 @@ actor ServerNetworkManager {
             connectionID: connectionID,
             lifecycleGeneration: admissionLifecycleGeneration
         ) else {
-            abandonPendingBootstrapCommit(
+            await abandonPendingBootstrapCommit(
                 connectionID: connectionID,
                 lifecycleGeneration: admissionLifecycleGeneration,
-                reason: "transferred fd missing before registration"
+                reason: "transferred fd missing before preparation"
             )
             return
         }
-        bootstrapReservations.removeValue(forKey: connectionID)
 
-        registerAndStartBootstrapConnection(
+        let preparedConnection: BootstrapSocketConnectionManager
+        do {
+            preparedConnection = try prepareBootstrapConnection(
+                connectionID: connectionID,
+                sessionToken: sessionToken,
+                clientPid: clientPid,
+                clientName: clientName,
+                clientFD: committedFD
+            )
+        } catch {
+            log.error("Failed to prepare bootstrap connection manager \(connectionID): \(String(describing: error))")
+            await abandonPendingBootstrapCommit(
+                connectionID: connectionID,
+                lifecycleGeneration: admissionLifecycleGeneration,
+                reason: "connection preparation failed"
+            )
+            return
+        }
+
+        guard var committingReservation = bootstrapReservations[connectionID],
+              committingReservation.lifecycleGeneration == admissionLifecycleGeneration,
+              !committingReservation.isCommitting,
+              isCurrentLifecycle(admissionLifecycleGeneration),
+              isCurrentBootstrapAdmissionClaim(
+                  sessionToken: sessionToken,
+                  connectionID: connectionID,
+                  lifecycleGeneration: admissionLifecycleGeneration
+              )
+        else {
+            await preparedConnection.stop()
+            await abandonPendingBootstrapCommit(
+                connectionID: connectionID,
+                lifecycleGeneration: admissionLifecycleGeneration,
+                reason: "reservation invalidated during preparation"
+            )
+            return
+        }
+        committingReservation.committingConnection = preparedConnection
+        bootstrapReservations[connectionID] = committingReservation
+
+        guard isCurrentBootstrapCommit(
+            connectionID: connectionID,
+            lifecycleGeneration: admissionLifecycleGeneration,
+            preparedConnection: preparedConnection
+        ) else {
+            await abandonPendingBootstrapCommit(
+                connectionID: connectionID,
+                lifecycleGeneration: admissionLifecycleGeneration,
+                reason: "commit invalidated before publication"
+            )
+            return
+        }
+
+        let committedPredecessorRemoval: CommittedConnectionRemoval?
+        if let replacementCredit = committingReservation.replacementCredit {
+            guard isValidBootstrapReplacementCredit(
+                replacementCredit,
+                reservationConnectionID: connectionID,
+                reservationLifecycleGeneration: admissionLifecycleGeneration
+            ),
+                let committedRemoval = commitConnectionRemoval(
+                    connectionID: replacementCredit.predecessorConnectionID,
+                    expectedIdentity: replacementCredit.predecessorConnectionIdentity,
+                    expectedLifecycleGeneration: replacementCredit.predecessorLifecycleGeneration
+                )
+            else {
+                await abandonPendingBootstrapCommit(
+                    connectionID: connectionID,
+                    lifecycleGeneration: admissionLifecycleGeneration,
+                    reason: "replacement predecessor fence invalidated"
+                )
+                return
+            }
+            committedPredecessorRemoval = committedRemoval
+        } else {
+            guard existingConnectionID(forSessionToken: sessionToken) == nil else {
+                await abandonPendingBootstrapCommit(
+                    connectionID: connectionID,
+                    lifecycleGeneration: admissionLifecycleGeneration,
+                    reason: "session rebound without exact replacement credit"
+                )
+                return
+            }
+            committedPredecessorRemoval = nil
+        }
+
+        // From exact predecessor-removal commitment through successor publication and
+        // reservation consumption there is no suspension. A hung predecessor stop can no
+        // longer retain the successor FD inside a non-expiring committing reservation.
+        guard registerAndStartBootstrapConnection(
             connectionID: connectionID,
             lifecycleGeneration: admissionLifecycleGeneration,
             sessionToken: sessionToken,
             clientPid: clientPid,
             clientName: clientName,
-            clientFD: committedFD
+            manager: preparedConnection
+        ) else {
+            if let committedPredecessorRemoval {
+                _ = rollbackCommittedConnectionRemoval(committedPredecessorRemoval)
+            }
+            await abandonPendingBootstrapCommit(
+                connectionID: connectionID,
+                lifecycleGeneration: admissionLifecycleGeneration,
+                reason: "registration context invalidated"
+            )
+            return
+        }
+        let consumedReservation = takeBootstrapReservation(
+            connectionID: connectionID,
+            lifecycleGeneration: admissionLifecycleGeneration
+        )
+        if consumedReservation == nil {
+            log.critical("Published bootstrap connection \(connectionID) without its exact committing reservation")
+            releaseBootstrapAdmissionClaim(
+                sessionToken: sessionToken,
+                connectionID: connectionID,
+                lifecycleGeneration: admissionLifecycleGeneration
+            )
+        }
+        if let committedPredecessorRemoval {
+            scheduleBootstrapPredecessorCleanup(committedPredecessorRemoval)
+        }
+    }
+
+    private func isCurrentBootstrapCommit(
+        connectionID: UUID,
+        lifecycleGeneration: UInt64,
+        preparedConnection: BootstrapSocketConnectionManager? = nil
+    ) -> Bool {
+        guard isCurrentLifecycle(lifecycleGeneration),
+              let reservation = bootstrapReservations[connectionID],
+              reservation.lifecycleGeneration == lifecycleGeneration,
+              isCurrentBootstrapAdmissionClaim(
+                  sessionToken: reservation.sessionToken,
+                  connectionID: connectionID,
+                  lifecycleGeneration: lifecycleGeneration
+              )
+        else { return false }
+        if let preparedConnection {
+            return reservation.committingConnection === preparedConnection
+        }
+        guard !reservation.isCommitting,
+              Date().timeIntervalSince(reservation.createdAt) < bootstrapReservationTTL
+        else { return false }
+        return transferredBootstrapSockets.contains(
+            connectionID: connectionID,
+            lifecycleGeneration: lifecycleGeneration
         )
     }
 
-    private func isCurrentBootstrapCommit(connectionID: UUID, lifecycleGeneration: UInt64) -> Bool {
-        isCurrentLifecycle(lifecycleGeneration)
-            && bootstrapReservations[connectionID]?.lifecycleGeneration == lifecycleGeneration
-            && transferredBootstrapSockets.contains(
-                connectionID: connectionID,
-                lifecycleGeneration: lifecycleGeneration
-            )
+    private func rollbackCommittedConnectionRemoval(
+        _ committedRemoval: CommittedConnectionRemoval
+    ) -> Bool {
+        guard connectionsBeingRemoved.contains(committedRemoval.connectionID),
+              connectionLifecycleGenerationByID[committedRemoval.connectionID] == committedRemoval.lifecycleGeneration,
+              let connection = connections[committedRemoval.connectionID],
+              ObjectIdentifier(connection as AnyObject) == committedRemoval.connectionIdentity
+        else { return false }
+        connectionsBeingRemoved.remove(committedRemoval.connectionID)
+        return true
     }
 
-    private func abandonPendingBootstrapCommit(connectionID: UUID, lifecycleGeneration: UInt64, reason: String) {
-        if bootstrapReservations[connectionID]?.lifecycleGeneration == lifecycleGeneration {
-            bootstrapReservations.removeValue(forKey: connectionID)
+    private func scheduleBootstrapPredecessorCleanup(
+        _ committedRemoval: CommittedConnectionRemoval
+    ) {
+        #if DEBUG
+            let graceSleep = debugBootstrapPredecessorStopGraceSleepForTesting ?? { duration in
+                try await Task.sleep(for: duration)
+            }
+        #else
+            let graceSleep: @Sendable (Duration) async throws -> Void = { duration in
+                try await Task.sleep(for: duration)
+            }
+        #endif
+        Task { [weak self] in
+            guard let self else { return }
+            let race = MCPConnectionStopRace()
+            Task {
+                await committedRemoval.connection.stop()
+                await race.resolve(.stopped)
+            }
+            Task {
+                do {
+                    try await graceSleep(MCPTimeoutPolicy.bootstrapReplacementPredecessorStopGrace)
+                } catch {
+                    return
+                }
+                await race.resolve(.deadlineElapsed)
+            }
+
+            let outcome = await race.wait()
+            if case .deadlineElapsed = outcome {
+                log.warning(
+                    "Bootstrap predecessor stop grace elapsed; detaching exact committed removal \(committedRemoval.connectionID) while its stop task continues."
+                )
+            }
+            _ = await removeConnection(
+                committedRemoval.connectionID,
+                committedRemoval: committedRemoval,
+                connectionAlreadyStopped: true
+            )
         }
+    }
+
+    private func abandonPendingBootstrapCommit(
+        connectionID: UUID,
+        lifecycleGeneration: UInt64,
+        reason: String
+    ) async {
+        let reservation = takeBootstrapReservation(
+            connectionID: connectionID,
+            lifecycleGeneration: lifecycleGeneration
+        )
         closeTransferredBootstrapSocket(
             connectionID: connectionID,
             lifecycleGeneration: lifecycleGeneration
         )
+        await reservation?.committingConnection?.stop()
         connectionLog("Abandoned pending bootstrap commit \(connectionID) (\(reason))")
     }
 
@@ -3157,8 +4291,14 @@ actor ServerNetworkManager {
             clientPid: Int,
             clientName: String?,
             clientFD: Int32
-        ) -> BootstrapSocketServer.Admission? {
-            guard isRunningState else { return nil }
+        ) async -> BootstrapSocketServer.Admission? {
+            guard isRunningState,
+                  claimBootstrapAdmission(
+                      sessionToken: sessionToken,
+                      connectionID: connectionID,
+                      lifecycleGeneration: lifecycleGeneration
+                  )
+            else { return nil }
             let admission = makeAcceptedBootstrapAdmission(
                 connectionID: connectionID,
                 lifecycleGeneration: lifecycleGeneration,
@@ -3167,7 +4307,7 @@ actor ServerNetworkManager {
                 clientName: clientName
             )
             guard admission.publishTransferredFD?(clientFD) == true else {
-                rollbackBootstrapReservation(
+                await rollbackBootstrapReservation(
                     connectionID: connectionID,
                     lifecycleGeneration: lifecycleGeneration,
                     reason: "DEBUG test publication failed"
@@ -3190,21 +4330,13 @@ actor ServerNetworkManager {
         }
     #endif
 
-    /// Registers a bootstrap connection and starts its MCP server.
-    /// Called from postAccept AFTER the "accepted" response has been successfully sent.
-    private func registerAndStartBootstrapConnection(
+    private func prepareBootstrapConnection(
         connectionID: UUID,
-        lifecycleGeneration: UInt64,
         sessionToken: String,
         clientPid: Int,
         clientName: String?,
         clientFD: Int32
-    ) {
-        guard isRunningState, self.lifecycleGeneration == lifecycleGeneration else {
-            closeUnregisteredBootstrapFD(clientFD)
-            return
-        }
-
+    ) throws -> BootstrapSocketConnectionManager {
         let purpose = purposeForNewBootstrapConnection(
             clientName: clientName,
             sessionToken: sessionToken
@@ -3214,24 +4346,31 @@ actor ServerNetworkManager {
         // The instructions resource path reads the live Code Maps setting later; defaulting
         // the initial server instructions to enabled keeps CLI initialize responsive.
         let codeMapsDisabled = false
+        return try BootstrapSocketConnectionManager(
+            connectionID: connectionID,
+            sessionToken: sessionToken,
+            clientPid: clientPid,
+            clientName: clientName,
+            purpose: purpose,
+            codeMapsDisabled: codeMapsDisabled,
+            connectedFD: clientFD,
+            parentManager: self
+        )
+    }
 
-        // Construct before publishing registry metadata. The throwing initializer consumes
-        // ownership of clientFD, including cleanup if transport construction fails.
-        let manager: BootstrapSocketConnectionManager
-        do {
-            manager = try BootstrapSocketConnectionManager(
-                connectionID: connectionID,
-                sessionToken: sessionToken,
-                clientPid: clientPid,
-                clientName: clientName,
-                purpose: purpose,
-                codeMapsDisabled: codeMapsDisabled,
-                connectedFD: clientFD,
-                parentManager: self
-            )
-        } catch {
-            log.error("Failed to construct bootstrap connection manager \(connectionID): \(String(describing: error))")
-            return
+    /// Registers a prepared bootstrap connection and starts its MCP server.
+    /// Called from postAccept AFTER the "accepted" response has been successfully sent.
+    @discardableResult
+    private func registerAndStartBootstrapConnection(
+        connectionID: UUID,
+        lifecycleGeneration: UInt64,
+        sessionToken: String,
+        clientPid: Int,
+        clientName: String?,
+        manager: BootstrapSocketConnectionManager
+    ) -> Bool {
+        guard isRunningState, self.lifecycleGeneration == lifecycleGeneration else {
+            return false
         }
 
         // Initialize identity context only after manager construction succeeds.
@@ -3250,7 +4389,9 @@ actor ServerNetworkManager {
         mcpACPLog("[MCP-ACP] registered bootstrap connection connection=\(connectionID) pendingClientName=\(clientName ?? "unknown")")
 
         connections[connectionID] = manager
-        callLimiters[connectionID] = AsyncLimiter(limit: limiterLimit(for: connectionID))
+        callLimiters[connectionID] = MCPConnectionCallLimiters(
+            limit: limiterLimit(for: connectionID)
+        )
         connectionLifecycleGenerationByID[connectionID] = lifecycleGeneration
         bindSessionToken(sessionToken, to: connectionID)
         if connectionStats[connectionID] == nil {
@@ -3295,6 +4436,7 @@ actor ServerNetworkManager {
                 count: count
             )
         }
+        return true
     }
 
     /// Sets the window count at connection time (called from MainActor task)
@@ -3347,6 +4489,7 @@ actor ServerNetworkManager {
 
     private func isCurrentConnection(_ connectionID: UUID, lifecycleGeneration expectedLifecycleGeneration: UInt64) -> Bool {
         isCurrentLifecycle(expectedLifecycleGeneration)
+            && !connectionsBeingRemoved.contains(connectionID)
             && connectionLifecycleGenerationByID[connectionID] == expectedLifecycleGeneration
             && connections[connectionID] != nil
     }
@@ -3590,6 +4733,11 @@ actor ServerNetworkManager {
             return (connectionID, connectionManager)
         }
         let limitersToStop = Array(callLimiters)
+        let committingBootstrapConnectionsToStop = bootstrapReservations.values.compactMap { reservation in
+            reservation.lifecycleGeneration == stoppedLifecycleGeneration
+                ? reservation.committingConnection
+                : nil
+        }
 
         // This synchronous invalidation boundary executes before the first await. New starts
         // receive a new generation and stale listener/restart/connection resumptions can no
@@ -3616,6 +4764,7 @@ actor ServerNetworkManager {
             closeUnregisteredBootstrapFD(fd)
         }
         bootstrapReservations.removeAll()
+        bootstrapAdmissionClaimsBySessionToken.removeAll()
         let waiterIDsToResume = connectionWaiters.compactMap { waiterID, waiter in
             waiter.lifecycleGeneration == stoppedLifecycleGeneration ? waiterID : nil
         }
@@ -3649,16 +4798,31 @@ actor ServerNetworkManager {
         identityContextByConnection.removeAll()
         capabilityTokenByConnection.removeAll()
         connectionIDBySessionToken.removeAll()
+        sessionTokenBindingGeneration.removeAll()
         resetInMemoryRoutingCachesForRestart()
 
-        for (_, limiter) in limitersToStop {
-            await limiter.cancelAll()
+        for (_, limiters) in limitersToStop {
+            await limiters.cancelAll()
+        }
+        for (connectionID, _) in limitersToStop {
+            let cancelledToolCount = await cancelActiveToolsOwnedByConnection(
+                connectionID,
+                reason: "serverShutdown"
+            )
+            if cancelledToolCount > 0 {
+                connectionLog(
+                    "Cancelled \(cancelledToolCount) active tool execution(s) owned by connection \(connectionID) during server shutdown"
+                )
+            }
         }
 
         await stopBootstrapSocketServer(server: listenerToStop, lifecycleGeneration: stoppedLifecycleGeneration)
 
         // The registry detach above was synchronous; stale resumptions below only stop the
         // captured manager objects and never mutate a replacement lifecycle's registries.
+        for connectionManager in committingBootstrapConnectionsToStop {
+            await connectionManager.stop()
+        }
         for (id, connectionManager) in connectionsToStop {
             connectionLog("Stopping connection: \(id)")
             #if DEBUG
@@ -3666,19 +4830,21 @@ actor ServerNetworkManager {
             #endif
             await connectionManager.stop()
         }
-        await withTaskGroup(of: (UUID, Bool).self) { group in
-            for (connectionID, limiter) in limitersToStop {
+        await withTaskGroup(of: (UUID, [(MCPConnectionCallLane, Bool)]).self) { group in
+            for (connectionID, limiters) in limitersToStop {
                 group.addTask {
-                    let drained = await limiter.waitUntilIdle(
+                    let results = await limiters.waitUntilIdle(
                         timeout: MCPTimeoutPolicy.boundedToolCancellationCleanupGrace
                     )
-                    return (connectionID, drained)
+                    return (connectionID, results)
                 }
             }
-            for await (connectionID, drained) in group where !drained {
-                connectionLog(
-                    "Connection limiter cleanup grace expired during server shutdown: \(connectionID)"
-                )
+            for await (connectionID, results) in group {
+                for (lane, drained) in results where !drained {
+                    connectionLog(
+                        "Connection limiter cleanup grace expired during server shutdown: \(connectionID) lane=\(lane.rawValue)"
+                    )
+                }
             }
         }
         emitDashboardUpdate()
@@ -3707,8 +4873,7 @@ actor ServerNetworkManager {
         connectionIDBySessionToken.removeAll()
         lastWindowByClientSession.removeAll()
         liveRunAffinityByClientSession.removeAll()
-        activeToolOwnerByWindow.removeAll()
-        activeToolNameByWindow.removeAll()
+        activeToolScopesByWindow.removeAll()
         connectionStats.removeAll()
     }
 
@@ -3935,9 +5100,27 @@ actor ServerNetworkManager {
         await removeConnection(id)
     }
 
+    private func currentBootstrapReplacementConnectionID(forSessionToken token: String) -> UUID? {
+        guard let connectionID = connectionIDBySessionToken[token] else { return nil }
+        guard connections[connectionID] != nil else {
+            if connectionIDBySessionToken[token] == connectionID {
+                invalidateBootstrapReplacementCredits(
+                    sessionToken: token,
+                    predecessorConnectionID: connectionID
+                )
+                sessionTokenBindingGeneration[token, default: 0] &+= 1
+                connectionIDBySessionToken.removeValue(forKey: token)
+            }
+            return nil
+        }
+        guard !connectionsBeingRemoved.contains(connectionID) else { return nil }
+        return connectionID
+    }
+
     /// Returns the existing connection ID for a given session token, if any.
     private func existingConnectionID(forSessionToken token: String) -> UUID? {
         if let id = connectionIDBySessionToken[token],
+           !connectionsBeingRemoved.contains(id),
            let mgr = connections[id],
            !mgr.isFilesystemBacked
         {
@@ -3945,19 +5128,30 @@ actor ServerNetworkManager {
         }
         // Fallback scan in case mapping got out of sync.
         for (id, mgr) in connections {
-            if mgr.isFilesystemBacked { continue }
+            if mgr.isFilesystemBacked || connectionsBeingRemoved.contains(id) { continue }
             let stored = capabilityTokenByConnection[id] ?? mgr.capabilityToken
             if stored == token {
-                connectionIDBySessionToken[token] = id
+                bindSessionToken(token, to: id)
                 return id
             }
         }
-        connectionIDBySessionToken.removeValue(forKey: token)
+        if let staleConnectionID = connectionIDBySessionToken[token] {
+            invalidateBootstrapReplacementCredits(
+                sessionToken: token,
+                predecessorConnectionID: staleConnectionID
+            )
+            sessionTokenBindingGeneration[token, default: 0] &+= 1
+            connectionIDBySessionToken.removeValue(forKey: token)
+        }
         return nil
     }
 
     /// Binds a session token to a connection for fast lookup and routing persistence.
     private func bindSessionToken(_ token: String, to connectionID: UUID) {
+        if connectionIDBySessionToken[token] != connectionID {
+            invalidateBootstrapReplacementCredits(sessionToken: token)
+            sessionTokenBindingGeneration[token, default: 0] &+= 1
+        }
         connectionIDBySessionToken[token] = connectionID
         capabilityTokenByConnection[connectionID] = token
     }
@@ -3969,6 +5163,11 @@ actor ServerNetworkManager {
             return
         }
         if connectionIDBySessionToken[token] == id {
+            invalidateBootstrapReplacementCredits(
+                sessionToken: token,
+                predecessorConnectionID: id
+            )
+            sessionTokenBindingGeneration[token, default: 0] &+= 1
             connectionIDBySessionToken.removeValue(forKey: token)
         }
         capabilityTokenByConnection.removeValue(forKey: id)
@@ -4114,19 +5313,72 @@ actor ServerNetworkManager {
         }
     }
 
+    private struct CommittedConnectionRemoval {
+        let connectionID: UUID
+        let connectionIdentity: ObjectIdentifier
+        let lifecycleGeneration: UInt64
+        let connection: any MCPServerConnection
+    }
+
+    private func commitConnectionRemoval(
+        connectionID: UUID,
+        expectedIdentity: ObjectIdentifier,
+        expectedLifecycleGeneration: UInt64
+    ) -> CommittedConnectionRemoval? {
+        guard !connectionsBeingRemoved.contains(connectionID),
+              connectionLifecycleGenerationByID[connectionID] == expectedLifecycleGeneration,
+              let connection = connections[connectionID],
+              ObjectIdentifier(connection as AnyObject) == expectedIdentity
+        else { return nil }
+        connectionsBeingRemoved.insert(connectionID)
+        invalidateBootstrapReplacementCredits(predecessorConnectionID: connectionID)
+        return CommittedConnectionRemoval(
+            connectionID: connectionID,
+            connectionIdentity: expectedIdentity,
+            lifecycleGeneration: expectedLifecycleGeneration,
+            connection: connection
+        )
+    }
+
     func removeConnection(_ id: UUID) async {
-        guard !connectionsBeingRemoved.contains(id) else {
-            connectionLog("removeConnection: \(id) cleanup already in progress; ignoring duplicate call")
-            return
+        _ = await removeConnection(id, committedRemoval: nil, connectionAlreadyStopped: false)
+    }
+
+    @discardableResult
+    private func removeConnection(
+        _ id: UUID,
+        committedRemoval: CommittedConnectionRemoval?,
+        connectionAlreadyStopped: Bool
+    ) async -> Bool {
+        if let committedRemoval {
+            guard committedRemoval.connectionID == id,
+                  connectionsBeingRemoved.contains(id),
+                  connectionLifecycleGenerationByID[id] == committedRemoval.lifecycleGeneration,
+                  let connection = connections[id],
+                  ObjectIdentifier(connection as AnyObject) == committedRemoval.connectionIdentity
+            else {
+                return false
+            }
+        } else {
+            guard !connectionsBeingRemoved.contains(id) else {
+                connectionLog("removeConnection: \(id) cleanup already in progress; ignoring duplicate call")
+                return false
+            }
         }
 
         // Always drop any lingering bootstrap reservation (commit/rollback should handle it,
         // but this is a leak safety-net for edge cases)
         if let reservation = bootstrapReservations.removeValue(forKey: id) {
+            releaseBootstrapAdmissionClaim(
+                sessionToken: reservation.sessionToken,
+                connectionID: id,
+                lifecycleGeneration: reservation.lifecycleGeneration
+            )
             closeTransferredBootstrapSocket(
                 connectionID: id,
                 lifecycleGeneration: reservation.lifecycleGeneration
             )
+            await reservation.committingConnection?.stop()
         }
 
         // Idempotent guard – if already gone, do nothing (and do not log)
@@ -4136,16 +5388,20 @@ actor ServerNetworkManager {
             || callLimiters[id] != nil
         else {
             connectionLog("removeConnection: \(id) already removed; ignoring duplicate call")
-            return
+            connectionsBeingRemoved.remove(id)
+            return false
         }
 
-        connectionsBeingRemoved.insert(id)
+        if committedRemoval == nil {
+            connectionsBeingRemoved.insert(id)
+            invalidateBootstrapReplacementCredits(predecessorConnectionID: id)
+        }
         defer { connectionsBeingRemoved.remove(id) }
 
         connectionLog("Removing connection: \(id)")
 
-        let limiter = callLimiters.removeValue(forKey: id)
-        await limiter?.cancelAll()
+        let limiters = callLimiters.removeValue(forKey: id)
+        await limiters?.cancelAll()
 
         let assignedWindowID = connectionWindowMap[id]
         let cleanupClientID = clientIDByConnection[id]
@@ -4205,8 +5461,9 @@ actor ServerNetworkManager {
         }
         connectionWindowMap[id] = nil
 
-        // Stop the connection manager
-        if let connectionManager = connections[id] {
+        // Stop the connection manager unless the exact committed owner was already stopped
+        // before entering cleanup (bootstrap predecessor handoff).
+        if !connectionAlreadyStopped, let connectionManager = connections[id] {
             await connectionManager.stop()
         }
 
@@ -4237,19 +5494,24 @@ actor ServerNetworkManager {
         // connection cannot remain discoverable while an active owner ignores cancellation.
         unbindSessionToken(sessionToken, forConnectionID: id)
 
-        if let limiter {
-            let drained = await limiter.waitUntilIdle(
+        if let limiters {
+            let results = await limiters.waitUntilIdle(
                 timeout: MCPTimeoutPolicy.boundedToolCancellationCleanupGrace
             )
-            if !drained {
+            for (lane, drained) in results where !drained {
                 connectionLog(
-                    "Connection limiter cleanup grace expired; detached active owner may settle later: \(id)"
+                    "Connection limiter cleanup grace expired; detached active owner may settle later: \(id) lane=\(lane.rawValue)"
                 )
             }
         }
 
+        // Removal is terminal for this connection ID. Sweep any scope that raced the initial
+        // cancellation snapshot; exact deferred completions remain harmless no-ops.
+        _ = removeActiveToolScopes(activeToolScopeIDs(ownedBy: id))
+
         // Notify dashboard of connection removal
         emitDashboardUpdate()
+        return true
     }
 
     /// Reads the cached TCP client name from all CLI instance cache files.
@@ -6502,13 +7764,340 @@ actor ServerNetworkManager {
                 idleWaitSleep: @escaping @Sendable (Duration) async throws -> Void = { duration in
                     try await Task.sleep(for: duration)
                 }
-            ) -> AsyncLimiter {
-                let limiter = AsyncLimiter(
+            ) async -> AsyncLimiter {
+                let limiters = MCPConnectionCallLimiters(
                     limit: limiterLimit(for: connectionID),
                     idleWaitSleep: idleWaitSleep
                 )
-                callLimiters[connectionID] = limiter
-                return limiter
+                callLimiters[connectionID] = limiters
+                return await limiters.limiterForTesting(.ordinary)
+            }
+
+            struct DebugDirectAdmissionState: Equatable {
+                let pendingClientID: String?
+                let indexedClientID: String?
+                let activeClientIDs: [String]
+                let hasStats: Bool
+                let lifecycleGeneration: UInt64
+                let connectionLifecycleGeneration: UInt64?
+            }
+
+            func debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: UUID,
+                connection: any MCPServerConnection,
+                clientID: String,
+                totalToolCalls: Int,
+                createdAt: Date
+            ) {
+                if !isRunningState {
+                    lifecycleGeneration &+= 1
+                    isRunningState = true
+                }
+                connections[connectionID] = connection
+                connectionLifecycleGenerationByID[connectionID] = lifecycleGeneration
+                activeConnectionsByClient[clientID, default: []].insert(connectionID)
+                clientIDByConnection[connectionID] = clientID
+                callLimiters[connectionID] = MCPConnectionCallLimiters(
+                    limit: limiterLimit(for: connectionID)
+                )
+                connectionStats[connectionID] = ConnectionStats(
+                    createdAt: createdAt,
+                    totalToolCalls: totalToolCalls,
+                    lastToolCallAt: nil
+                )
+            }
+
+            func debugInstallDirectAdmissionConnectionForTesting(
+                connectionID: UUID,
+                connection: any MCPServerConnection,
+                pendingClientID: String? = nil,
+                advanceLifecycleGeneration: Bool = false
+            ) {
+                if !isRunningState || advanceLifecycleGeneration {
+                    lifecycleGeneration &+= 1
+                }
+                isRunningState = true
+                connections[connectionID] = connection
+                connectionLifecycleGenerationByID[connectionID] = lifecycleGeneration
+                if let pendingClientID {
+                    pendingConnections[connectionID] = pendingClientID
+                } else {
+                    pendingConnections.removeValue(forKey: connectionID)
+                }
+                if let indexedClientID = clientIDByConnection.removeValue(forKey: connectionID) {
+                    var indexedConnections = activeConnectionsByClient[indexedClientID] ?? []
+                    indexedConnections.remove(connectionID)
+                    if indexedConnections.isEmpty {
+                        activeConnectionsByClient.removeValue(forKey: indexedClientID)
+                    } else {
+                        activeConnectionsByClient[indexedClientID] = indexedConnections
+                    }
+                }
+                connectionStats.removeValue(forKey: connectionID)
+            }
+
+            func debugDirectAdmissionStateForTesting(connectionID: UUID) -> DebugDirectAdmissionState {
+                DebugDirectAdmissionState(
+                    pendingClientID: pendingConnections[connectionID],
+                    indexedClientID: clientIDByConnection[connectionID],
+                    activeClientIDs: activeConnectionsByClient.compactMap { clientID, connectionIDs in
+                        connectionIDs.contains(connectionID) ? clientID : nil
+                    }.sorted(),
+                    hasStats: connectionStats[connectionID] != nil,
+                    lifecycleGeneration: lifecycleGeneration,
+                    connectionLifecycleGeneration: connectionLifecycleGenerationByID[connectionID]
+                )
+            }
+
+            func debugBindSessionTokenForAdmissionTesting(_ sessionToken: String, to connectionID: UUID) {
+                bindSessionToken(sessionToken, to: connectionID)
+            }
+
+            func debugUnbindSessionTokenForAdmissionTesting(_ sessionToken: String, from connectionID: UUID) {
+                unbindSessionToken(sessionToken, forConnectionID: connectionID)
+            }
+
+            func debugConnectionIDForSessionTokenForTesting(_ sessionToken: String) -> UUID? {
+                connectionIDBySessionToken[sessionToken]
+            }
+
+            func debugSetAfterDirectAdmissionPendingPublishedForTesting(
+                _ handler: (@Sendable (UUID) async -> Void)?
+            ) {
+                debugAfterDirectAdmissionPendingPublishedForTesting = handler
+            }
+
+            func debugSetAfterBootstrapPolicyReadinessForTesting(
+                _ handler: (@Sendable (String) async -> Void)?
+            ) {
+                debugAfterBootstrapPolicyReadinessForTesting = handler
+            }
+
+            func debugSetAfterConnectionCallLimiterResolutionForTesting(
+                _ handler: (@Sendable (UUID) async -> Void)?
+            ) {
+                debugAfterConnectionCallLimiterResolutionForTesting = handler
+            }
+
+            func debugSetAfterConnectionCallPermitAcquiredForTesting(
+                _ handler: (@Sendable (UUID) async -> Void)?
+            ) {
+                debugAfterConnectionCallPermitAcquiredForTesting = handler
+            }
+
+            func debugSetAfterConnectionCallLimiterRejectionForTesting(
+                _ handler: (@Sendable (UUID) async -> Void)?
+            ) {
+                debugAfterConnectionCallLimiterRejectionForTesting = handler
+            }
+
+            func debugSetBeforeAdmissionEvictionCloseForTesting(
+                _ handler: (@Sendable (UUID) async -> Void)?
+            ) {
+                debugBeforeAdmissionEvictionCloseForTesting = handler
+            }
+
+            func debugSetDuringAdmissionEvictionCloseForTesting(
+                _ handler: (@Sendable (UUID) async -> Void)?
+            ) {
+                debugDuringAdmissionEvictionCloseForTesting = handler
+            }
+
+            func debugSetAfterAdmissionEvictionRemovalCommittedForTesting(
+                _ handler: (@Sendable (UUID) async -> Void)?
+            ) {
+                debugAfterAdmissionEvictionRemovalCommittedForTesting = handler
+            }
+
+            func debugSetBootstrapPredecessorStopGraceSleepForTesting(
+                _ sleep: (@Sendable (Duration) async throws -> Void)?
+            ) {
+                debugBootstrapPredecessorStopGraceSleepForTesting = sleep
+            }
+
+            func debugEvictLeastValuableForTesting(clientID: String) async -> Bool {
+                await evictLeastValuable(for: clientID) == .evicted
+            }
+
+            func debugEvictLeastValuableGlobalForAdmissionForTesting(
+                preserveOnePerClient: Bool
+            ) async -> Bool {
+                await evictLeastValuableGlobalForAdmission(
+                    preserveOnePerClient: preserveOnePerClient
+                ) == .evicted
+            }
+
+            func debugConfigureGlobalAdmissionForTesting(
+                maxGlobalConnections: Int?,
+                preserveOnePerClient: Bool?
+            ) {
+                debugMaxGlobalConnectionsForTesting = maxGlobalConnections
+                debugPreserveOnePerClientForTesting = preserveOnePerClient
+            }
+
+            func debugConfigurePerClientAdmissionForTesting(maxConnectionsPerClient: Int?) {
+                debugMaxConnectionsPerClientForTesting = maxConnectionsPerClient
+            }
+
+            func debugConfigurePressureEvictionForTesting(idleSeconds: Int?) {
+                debugPressureEvictIdleSecondsForTesting = idleSeconds
+            }
+
+            func debugPressureEvictIdleConnectionsForTesting() async {
+                await pressureEvictIdleConnectionsIfNeeded()
+            }
+
+            func debugBootstrapAdmissionHasCapacityForTesting() async -> Bool {
+                await ensureGlobalCapacityForBootstrapAdmission(
+                    sourceListener: nil,
+                    lifecycleGeneration: nil,
+                    prospectiveReplacementCredit: nil
+                ) == .available
+            }
+
+            func debugBootstrapAdmissionHasCapacityForTesting(sessionToken: String) async -> Bool {
+                await debugAfterBootstrapPolicyReadinessForTesting?(sessionToken)
+                if !isRunningState {
+                    lifecycleGeneration &+= 1
+                    isRunningState = true
+                }
+                let connectionID = UUID()
+                guard claimBootstrapAdmission(
+                    sessionToken: sessionToken,
+                    connectionID: connectionID,
+                    lifecycleGeneration: lifecycleGeneration
+                ) else { return false }
+                let replacementCredit = bootstrapAdmissionClaimsBySessionToken[sessionToken]?.replacementCredit
+                let result = await ensureGlobalCapacityForBootstrapAdmission(
+                    sourceListener: nil,
+                    lifecycleGeneration: nil,
+                    prospectiveReplacementCredit: replacementCredit
+                ) == .available
+                releaseBootstrapAdmissionClaim(
+                    sessionToken: sessionToken,
+                    connectionID: connectionID,
+                    lifecycleGeneration: lifecycleGeneration
+                )
+                return result
+            }
+
+            func debugEffectiveRegisteredConnectionCountForTesting() -> Int {
+                effectiveRegisteredConnectionCount
+            }
+
+            func debugEffectiveGlobalAdmissionLoadForTesting() -> Int {
+                effectiveGlobalAdmissionLoad()
+            }
+
+            func debugGlobalAdmissionLoadComponentsForTesting() -> (
+                registeredConnections: Int,
+                reservations: Int,
+                replacementCredits: Int,
+                effectiveLoad: Int
+            ) {
+                let snapshot = globalAdmissionLoadSnapshot()
+                return (
+                    registeredConnections: snapshot.registeredConnectionCount,
+                    reservations: snapshot.reservationCount,
+                    replacementCredits: snapshot.replacementCreditCount,
+                    effectiveLoad: snapshot.effectiveLoad
+                )
+            }
+
+            func debugClaimBootstrapAdmissionForTesting(
+                connectionID: UUID,
+                sessionToken: String
+            ) -> Bool {
+                if !isRunningState {
+                    lifecycleGeneration &+= 1
+                    isRunningState = true
+                }
+                return claimBootstrapAdmission(
+                    sessionToken: sessionToken,
+                    connectionID: connectionID,
+                    lifecycleGeneration: lifecycleGeneration
+                )
+            }
+
+            func debugProtectedBootstrapPredecessorConnectionIDsForTesting() -> Set<UUID> {
+                creditedBootstrapPredecessorConnectionIDs()
+            }
+
+            func debugReserveBootstrapSlotForTesting(
+                connectionID: UUID,
+                sessionToken: String
+            ) -> Bool {
+                if !isRunningState {
+                    lifecycleGeneration &+= 1
+                    isRunningState = true
+                }
+                guard claimBootstrapAdmission(
+                    sessionToken: sessionToken,
+                    connectionID: connectionID,
+                    lifecycleGeneration: lifecycleGeneration
+                ) else { return false }
+                guard reserveBootstrapSlot(
+                    connectionID: connectionID,
+                    lifecycleGeneration: lifecycleGeneration,
+                    sessionToken: sessionToken
+                ) else {
+                    releaseBootstrapAdmissionClaim(
+                        sessionToken: sessionToken,
+                        connectionID: connectionID,
+                        lifecycleGeneration: lifecycleGeneration
+                    )
+                    return false
+                }
+                return true
+            }
+
+            func debugReleaseBootstrapAdmissionClaimForTesting(
+                connectionID: UUID,
+                sessionToken: String
+            ) {
+                releaseBootstrapAdmissionClaim(
+                    sessionToken: sessionToken,
+                    connectionID: connectionID,
+                    lifecycleGeneration: lifecycleGeneration
+                )
+            }
+
+            func debugRollbackBootstrapReservationForTesting(connectionID: UUID) async {
+                await rollbackBootstrapReservation(
+                    connectionID: connectionID,
+                    lifecycleGeneration: lifecycleGeneration,
+                    reason: "DEBUG test rollback"
+                )
+            }
+
+            func debugCommitBootstrapReservationAccountingForTesting(connectionID: UUID) async -> Bool {
+                guard let reservation = bootstrapReservations[connectionID],
+                      Date().timeIntervalSince(reservation.createdAt) < bootstrapReservationTTL
+                else {
+                    await abandonPendingBootstrapCommit(
+                        connectionID: connectionID,
+                        lifecycleGeneration: lifecycleGeneration,
+                        reason: "DEBUG expired commit"
+                    )
+                    return false
+                }
+                return takeBootstrapReservation(
+                    connectionID: connectionID,
+                    lifecycleGeneration: lifecycleGeneration
+                ) != nil
+            }
+
+            func debugAgeBootstrapReservationPastExpiryForTesting(connectionID: UUID) {
+                guard var reservation = bootstrapReservations[connectionID] else { return }
+                reservation.createdAt = Date(
+                    timeIntervalSinceNow: -(bootstrapReservationTTL + 1)
+                )
+                bootstrapReservations[connectionID] = reservation
+            }
+
+            func debugExpireBootstrapReservationForTesting(connectionID: UUID) {
+                debugAgeBootstrapReservationPastExpiryForTesting(connectionID: connectionID)
+                cleanupExpiredBootstrapReservations()
             }
 
             func debugRegisterConnectionForSocketFixture(
@@ -6517,11 +8106,19 @@ actor ServerNetworkManager {
                 clientName: String,
                 sessionToken: String
             ) {
-                _ = clientName
-                _ = sessionToken
+                if !isRunningState {
+                    lifecycleGeneration &+= 1
+                    isRunningState = true
+                }
                 debugExecutionWatchdogAbortTargets[connectionID] = connection
+                connections[connectionID] = connection
+                connectionLifecycleGenerationByID[connectionID] = lifecycleGeneration
+                pendingConnections[connectionID] = clientName
+                bindSessionToken(sessionToken, to: connectionID)
                 if callLimiters[connectionID] == nil {
-                    callLimiters[connectionID] = AsyncLimiter(limit: limiterLimit(for: connectionID))
+                    callLimiters[connectionID] = MCPConnectionCallLimiters(
+                        limit: limiterLimit(for: connectionID)
+                    )
                 }
             }
 
@@ -6549,8 +8146,64 @@ actor ServerNetworkManager {
             }
         #endif
 
-        func debugMarkActiveToolOwner(windowID: Int, connectionID: UUID, toolName: String) {
-            markActiveToolOwner(windowID: windowID, connectionID: connectionID, toolName: toolName)
+        struct DebugActiveToolScopeSnapshot: Equatable {
+            let scopeID: UUID
+            let windowID: Int
+            let connectionID: UUID
+            let toolName: String
+            let sequence: UInt64
+        }
+
+        func debugBeginActiveToolScopeForTesting(
+            windowID: Int,
+            connectionID: UUID,
+            toolName: String,
+            scopeID: UUID
+        ) -> UUID? {
+            beginActiveToolScope(
+                windowID: windowID,
+                connectionID: connectionID,
+                toolName: toolName,
+                scopeID: scopeID
+            )?.scopeID
+        }
+
+        func debugEndActiveToolScopeForTesting(windowID: Int, scopeID: UUID) -> Bool {
+            endActiveToolScope(ActiveToolScopeHandle(windowID: windowID, scopeID: scopeID))
+        }
+
+        func debugActiveToolScopesForTesting() -> [DebugActiveToolScopeSnapshot] {
+            activeToolScopesByWindow.flatMap { windowID, scopes in
+                scopes.map { scopeID, scope in
+                    DebugActiveToolScopeSnapshot(
+                        scopeID: scopeID,
+                        windowID: windowID,
+                        connectionID: scope.connectionID,
+                        toolName: scope.toolName,
+                        sequence: scope.sequence
+                    )
+                }
+            }
+            .sorted { lhs, rhs in
+                if lhs.sequence != rhs.sequence { return lhs.sequence < rhs.sequence }
+                return lhs.scopeID.uuidString < rhs.scopeID.uuidString
+            }
+        }
+
+        func debugSetBeforeActiveToolCancellationScanForTesting(
+            _ handler: (@Sendable (UUID, [UUID]) async -> Void)?
+        ) {
+            debugBeforeActiveToolCancellationScanForTesting = handler
+        }
+
+        func debugSetConnectionWindowForTesting(connectionID: UUID, windowID: Int?) {
+            if let windowID {
+                connectionWindowMap[connectionID] = windowID
+                windowAssignmentByConnection[connectionID] = windowID
+            } else {
+                connectionWindowMap.removeValue(forKey: connectionID)
+                windowAssignmentByConnection.removeValue(forKey: connectionID)
+            }
         }
 
         func debugCancelActiveToolsOwnedByConnection(
@@ -6673,11 +8326,7 @@ actor ServerNetworkManager {
         }
 
         func debugClearActiveToolOwner(windowID: Int) {
-            if let owner = activeToolOwnerByWindow[windowID] {
-                clearActiveToolOwner(windowID: windowID, connectionID: owner)
-            } else {
-                activeToolNameByWindow.removeValue(forKey: windowID)
-            }
+            removeActiveToolScopesForWindow(windowID)
         }
     #endif
 
@@ -7984,14 +9633,19 @@ actor ServerNetworkManager {
                     "originalName": originalName
                 ])
                 if Self.isDebugDiagnosticsToolName(toolName) {
-                    guard let limiter = await self.limiter(for: connectionID) else {
+                    guard let limiterResolution = await connectionCallLimiterResolution(
+                        for: connectionID
+                    ) else {
                         return Self.executionContractToolErrorResult(
                             rawJSON: false,
                             code: "tool_execution_connection_terminal",
                             message: "The MCP connection is closing."
                         )
                     }
-                    return await limiter.withPermit(
+                    return await withConnectionCallPermit(
+                        connectionID: connectionID,
+                        lane: .ordinary,
+                        resolution: limiterResolution,
                         cancellationResult: {
                             Self.executionContractToolErrorResult(
                                 rawJSON: false,
@@ -8239,16 +9893,17 @@ actor ServerNetworkManager {
                 EditFlowPerf.Dimensions(toolName: toolName)
             )
 
-            // Per-connection concurrency limiter with safe release pattern
-            connectionLog("tools/call \(toolName): acquiring limiter")
-            let limiter = await EditFlowPerf.measure(
+            // Per-connection call lanes preserve ordinary FIFO while isolating serialized searches.
+            let callLane = Self.callLane(forCanonicalToolName: toolName)
+            connectionLog("tools/call \(toolName): acquiring limiter lane=\(callLane.rawValue)")
+            let limiterResolution = await EditFlowPerf.measure(
                 EditFlowPerf.Stage.MCPToolCall.limiterResolution,
                 EditFlowPerf.Dimensions(toolName: toolName)
             ) {
-                await self.limiter(for: connectionID)
+                await self.connectionCallLimiterResolution(for: connectionID)
             }
             endPreLimiterEnvelopeIfNeeded()
-            guard let limiter else {
+            guard let limiterResolution else {
                 connectionLog("tools/call \(toolName): rejected because connection limiter is unavailable")
                 return Self.executionContractToolErrorResult(
                     rawJSON: capturedRawJSON,
@@ -8256,7 +9911,7 @@ actor ServerNetworkManager {
                     message: "The MCP connection is closing."
                 )
             }
-            connectionLog("tools/call \(toolName): entering limiter")
+            connectionLog("tools/call \(toolName): entering limiter lane=\(callLane.rawValue)")
             return await EditFlowPerf.measure(
                 EditFlowPerf.Stage.MCPToolCall.limiterEnvelope,
                 EditFlowPerf.Dimensions(toolName: toolName)
@@ -8271,7 +9926,10 @@ actor ServerNetworkManager {
                     EditFlowPerf.Dimensions(toolName: toolName)
                 )
                 defer { EditFlowPerf.end(EditFlowPerf.Stage.MCPToolCall.limiterWait, limiterWaitState) }
-                return await limiter.withPermit(
+                return await self.withConnectionCallPermit(
+                    connectionID: connectionID,
+                    lane: callLane,
+                    resolution: limiterResolution,
                     cancellationResult: {
                         Self.executionContractToolErrorResult(
                             rawJSON: capturedRawJSON,
@@ -8624,8 +10282,29 @@ actor ServerNetworkManager {
                                     }
                                 }
 
+                                let selectedExecutionContract = MCPToolExecutionContractCatalog.contract(
+                                    for: toolName,
+                                    arguments: capturedArguments
+                                )
+
                                 @Sendable func dispatchResolvedProvider(_ operation: @escaping @Sendable () async throws -> Value) async throws -> Value {
-                                    guard let contract = MCPToolExecutionContractCatalog.contract(for: toolName) else {
+                                    guard await self.isCurrentConnectionCallLimiterResolution(
+                                        limiterResolution,
+                                        connectionID: connectionID
+                                    ) else {
+                                        throw ToolDispatchAdmissionError.connectionTerminal
+                                    }
+                                    if let authorization = Self.currentToolDispatchAuthorization {
+                                        guard await self.isCurrentToolDispatchAuthorization(authorization) else {
+                                            throw ToolDispatchAdmissionError.connectionTerminal
+                                        }
+                                        if let windowIdentity = authorization.windowIdentity,
+                                           await !(self.isCurrentWindowToolDispatchIdentity(windowIdentity))
+                                        {
+                                            throw ToolDispatchAdmissionError.windowTerminal
+                                        }
+                                    }
+                                    guard let contract = selectedExecutionContract else {
                                         throw MCPToolExecutionDispatchError.missingContract(toolName: toolName)
                                     }
 
@@ -8666,6 +10345,22 @@ actor ServerNetworkManager {
 
                                     let tracedOperation: @Sendable () async throws -> Value = {
                                         do {
+                                            guard await self.isCurrentConnectionCallLimiterResolution(
+                                                limiterResolution,
+                                                connectionID: connectionID
+                                            ) else {
+                                                throw ToolDispatchAdmissionError.connectionTerminal
+                                            }
+                                            if let authorization = Self.currentToolDispatchAuthorization {
+                                                guard await self.isCurrentToolDispatchAuthorization(authorization) else {
+                                                    throw ToolDispatchAdmissionError.connectionTerminal
+                                                }
+                                                if let windowIdentity = authorization.windowIdentity,
+                                                   await !(self.isCurrentWindowToolDispatchIdentity(windowIdentity))
+                                                {
+                                                    throw ToolDispatchAdmissionError.windowTerminal
+                                                }
+                                            }
                                             let value = try await EditFlowPerf.measure(
                                                 EditFlowPerf.Stage.MCPToolCall.resolvedProviderDispatch,
                                                 EditFlowPerf.Dimensions(toolName: toolName),
@@ -8769,8 +10464,27 @@ actor ServerNetworkManager {
                                     let message: String
                                     let outcome: String
                                     let shouldForceDisconnect: Bool
+                                    let selectedDeadlineDescription: String = {
+                                        guard let seconds = selectedExecutionContract?.deadline?.mcpSeconds else {
+                                            return "declared"
+                                        }
+                                        if seconds.rounded() == seconds {
+                                            return String(Int(seconds))
+                                        }
+                                        return seconds.formatted()
+                                    }()
 
                                     switch error {
+                                    case ToolDispatchAdmissionError.connectionTerminal:
+                                        code = "tool_execution_connection_terminal"
+                                        message = "The MCP connection is closing."
+                                        outcome = "connectionTerminal"
+                                        shouldForceDisconnect = false
+                                    case ToolDispatchAdmissionError.windowTerminal:
+                                        code = "tool_execution_window_terminal"
+                                        message = "The selected window is closing or no longer owns this tool catalog."
+                                        outcome = "windowTerminal"
+                                        shouldForceDisconnect = false
                                     case let MCPToolExecutionDispatchError.missingContract(missingToolName):
                                         code = "tool_execution_contract_missing"
                                         message = "No declared execution contract exists for MCP tool '\(missingToolName)'."
@@ -8778,12 +10492,12 @@ actor ServerNetworkManager {
                                         shouldForceDisconnect = false
                                     case let MCPToolExecutionWatchdogError.executionTimedOut(settlement):
                                         code = "tool_execution_timeout"
-                                        message = "Tool '\(toolName)' exceeded its \(MCPTimeoutPolicy.boundedToolExecutionDeadlineSeconds)-second execution contract and settled as \(settlement.rawValue) during cancellation grace."
+                                        message = "Tool '\(toolName)' exceeded its \(selectedDeadlineDescription)-second execution contract and settled as \(settlement.rawValue) during cancellation grace."
                                         outcome = "executionTimeout"
                                         shouldForceDisconnect = false
                                     case MCPToolExecutionWatchdogError.cleanupUnresponsive:
                                         code = "tool_execution_cleanup_unresponsive"
-                                        message = "Tool '\(toolName)' exceeded its \(MCPTimeoutPolicy.boundedToolExecutionDeadlineSeconds)-second execution contract and did not stop during cancellation grace. The MCP connection was force-disconnected."
+                                        message = "Tool '\(toolName)' exceeded its \(selectedDeadlineDescription)-second execution contract and did not stop during cancellation grace. The MCP connection was force-disconnected."
                                         outcome = "executionCleanupUnresponsive"
                                         shouldForceDisconnect = true
                                     default:
@@ -8919,81 +10633,102 @@ actor ServerNetworkManager {
                                     }
 
                                     // Now dispatch. If window-scoped, wrap in ownership scope (fallback to service window).
-                                    if let wsSvc, shouldTrackToolOwnership {
+                                    if let wsSvc {
                                         let ownershipWindowID = chosenID ?? wsSvc.windowID
+                                        let catalogServiceIdentity = ObjectIdentifier(wsSvc as AnyObject)
+                                        guard let windowDispatchIdentity = await self.captureWindowToolDispatchIdentity(
+                                            windowID: ownershipWindowID,
+                                            catalogServiceIdentity: catalogServiceIdentity
+                                        ) else {
+                                            return Self.executionContractToolErrorResult(
+                                                rawJSON: capturedRawJSON,
+                                                code: "tool_execution_window_terminal",
+                                                message: "The selected window is closing or no longer owns this tool catalog."
+                                            )
+                                        }
+                                        let dispatchAuthorization = await self.toolDispatchAuthorization(
+                                            connectionID: connectionID,
+                                            resolution: limiterResolution,
+                                            windowIdentity: windowDispatchIdentity
+                                        )
                                         do {
                                             return try await self.withWindowToolOwnership(
                                                 windowID: ownershipWindowID,
                                                 connectionID: connectionID,
-                                                toolName: toolName
+                                                toolName: toolName,
+                                                connectionAuthorization: dispatchAuthorization,
+                                                windowIdentity: windowDispatchIdentity,
+                                                recordScope: shouldTrackToolOwnership
                                             ) {
-                                                let value = try await EditFlowPerf.measure(
-                                                    EditFlowPerf.Stage.MCPToolCall.dispatch,
-                                                    EditFlowPerf.Dimensions(toolName: toolName)
-                                                ) {
-                                                    try await dispatchResolvedProvider(resolvedOperation)
-                                                }
-                                                let permitPostDispatchEnvelopeState = EditFlowPerf.begin(
-                                                    EditFlowPerf.Stage.MCPToolCall.permitPostDispatchEnvelope,
-                                                    EditFlowPerf.Dimensions(toolName: toolName, outcome: "success")
-                                                )
-                                                defer { EditFlowPerf.end(EditFlowPerf.Stage.MCPToolCall.permitPostDispatchEnvelope, permitPostDispatchEnvelopeState) }
+                                                try await Self.$currentToolDispatchAuthorization.withValue(dispatchAuthorization) {
+                                                    let value = try await EditFlowPerf.measure(
+                                                        EditFlowPerf.Stage.MCPToolCall.dispatch,
+                                                        EditFlowPerf.Dimensions(toolName: toolName)
+                                                    ) {
+                                                        try await dispatchResolvedProvider(resolvedOperation)
+                                                    }
+                                                    let permitPostDispatchEnvelopeState = EditFlowPerf.begin(
+                                                        EditFlowPerf.Stage.MCPToolCall.permitPostDispatchEnvelope,
+                                                        EditFlowPerf.Dimensions(toolName: toolName, outcome: "success")
+                                                    )
+                                                    defer { EditFlowPerf.end(EditFlowPerf.Stage.MCPToolCall.permitPostDispatchEnvelope, permitPostDispatchEnvelopeState) }
 
-                                                // Build well‑structured, human‑readable content blocks for the result
-                                                let contentBlocks = EditFlowPerf.measure(
-                                                    EditFlowPerf.Stage.MCPToolCall.formatResult,
-                                                    EditFlowPerf.Dimensions(toolName: toolName)
-                                                ) {
-                                                    Self.formatToolResult(
-                                                        toolName: toolName,
-                                                        args: effectiveArgsForFormatter,
-                                                        value: value
+                                                    // Build well‑structured, human‑readable content blocks for the result
+                                                    let contentBlocks = EditFlowPerf.measure(
+                                                        EditFlowPerf.Stage.MCPToolCall.formatResult,
+                                                        EditFlowPerf.Dimensions(toolName: toolName)
+                                                    ) {
+                                                        Self.formatToolResult(
+                                                            toolName: toolName,
+                                                            args: effectiveArgsForFormatter,
+                                                            value: value
+                                                        )
+                                                    }
+                                                    EditFlowPerf.lifecycleEvent(
+                                                        EditFlowPerf.Lifecycle.MCPToolCall.formatResultReturned,
+                                                        EditFlowPerf.Dimensions(toolName: toolName)
+                                                    )
+
+                                                    // Fire completion observer with result for detailed UI rendering
+                                                    await EditFlowPerf.measure(
+                                                        EditFlowPerf.Stage.MCPToolCall.completionObservers,
+                                                        EditFlowPerf.Dimensions(toolName: toolName)
+                                                    ) {
+                                                        if let runID = await self.toolTrackingRunIDForCompletion(callTimeRunID: observerRunIDForCallbacksFinal, connectionID: connectionID, toolName: toolName, invocationID: invocationID, context: "window-scoped success") {
+                                                            let resultJSON = EditFlowPerf.measure(
+                                                                EditFlowPerf.Stage.MCPToolCall.completionObserverResultEncoding,
+                                                                EditFlowPerf.Dimensions(toolName: toolName)
+                                                            ) {
+                                                                ToolOutputFormatter.rawJSONString(value)
+                                                            }
+                                                            let eventObserverCount = await EditFlowPerf.measure(
+                                                                EditFlowPerf.Stage.MCPToolCall.completionObserverCallbacks,
+                                                                EditFlowPerf.Dimensions(toolName: toolName)
+                                                            ) {
+                                                                await self.fireToolCompletedObservers(runID: runID, invocationID: invocationID, toolName: toolName, args: capturedArguments, resultJSON: resultJSON, isError: false)
+                                                            }
+                                                            #if DEBUG
+                                                                if toolName == "agent_run" {
+                                                                    print("[ACPAgentRunToolTracking] MCP observer completion tool=\(toolName) conn=\(connectionID.uuidString) runID=\(runID.uuidString) invocation=\(invocationID.uuidString) eventObservers=\(eventObserverCount) isError=false resultChars=\(resultJSON.count)")
+                                                                }
+                                                            #endif
+                                                        }
+                                                    }
+                                                    EditFlowPerf.lifecycleEvent(
+                                                        EditFlowPerf.Lifecycle.MCPToolCall.completionObserverReturned,
+                                                        EditFlowPerf.Dimensions(toolName: toolName, status: "success")
+                                                    )
+
+                                                    // Note: context_builder caller termination is NOT done here.
+                                                    // The spawned agent connection is terminated by ContextBuilderAgentViewModel
+                                                    // when the run completes. This prevents killing the host MCP client
+                                                    // (e.g., Claude Desktop) that invoked context_builder.
+
+                                                    return handlerResult(
+                                                        CallTool.Result(content: contentBlocks, isError: false),
+                                                        outcome: "success"
                                                     )
                                                 }
-                                                EditFlowPerf.lifecycleEvent(
-                                                    EditFlowPerf.Lifecycle.MCPToolCall.formatResultReturned,
-                                                    EditFlowPerf.Dimensions(toolName: toolName)
-                                                )
-
-                                                // Fire completion observer with result for detailed UI rendering
-                                                await EditFlowPerf.measure(
-                                                    EditFlowPerf.Stage.MCPToolCall.completionObservers,
-                                                    EditFlowPerf.Dimensions(toolName: toolName)
-                                                ) {
-                                                    if let runID = await self.toolTrackingRunIDForCompletion(callTimeRunID: observerRunIDForCallbacksFinal, connectionID: connectionID, toolName: toolName, invocationID: invocationID, context: "window-scoped success") {
-                                                        let resultJSON = EditFlowPerf.measure(
-                                                            EditFlowPerf.Stage.MCPToolCall.completionObserverResultEncoding,
-                                                            EditFlowPerf.Dimensions(toolName: toolName)
-                                                        ) {
-                                                            ToolOutputFormatter.rawJSONString(value)
-                                                        }
-                                                        let eventObserverCount = await EditFlowPerf.measure(
-                                                            EditFlowPerf.Stage.MCPToolCall.completionObserverCallbacks,
-                                                            EditFlowPerf.Dimensions(toolName: toolName)
-                                                        ) {
-                                                            await self.fireToolCompletedObservers(runID: runID, invocationID: invocationID, toolName: toolName, args: capturedArguments, resultJSON: resultJSON, isError: false)
-                                                        }
-                                                        #if DEBUG
-                                                            if toolName == "agent_run" {
-                                                                print("[ACPAgentRunToolTracking] MCP observer completion tool=\(toolName) conn=\(connectionID.uuidString) runID=\(runID.uuidString) invocation=\(invocationID.uuidString) eventObservers=\(eventObserverCount) isError=false resultChars=\(resultJSON.count)")
-                                                            }
-                                                        #endif
-                                                    }
-                                                }
-                                                EditFlowPerf.lifecycleEvent(
-                                                    EditFlowPerf.Lifecycle.MCPToolCall.completionObserverReturned,
-                                                    EditFlowPerf.Dimensions(toolName: toolName, status: "success")
-                                                )
-
-                                                // Note: context_builder caller termination is NOT done here.
-                                                // The spawned agent connection is terminated by ContextBuilderAgentViewModel
-                                                // when the run completes. This prevents killing the host MCP client
-                                                // (e.g., Claude Desktop) that invoked context_builder.
-
-                                                return handlerResult(
-                                                    CallTool.Result(content: contentBlocks, isError: false),
-                                                    outcome: "success"
-                                                )
                                             }
                                         } catch {
                                             if let failure = await executionContractFailureResult(
@@ -9234,7 +10969,7 @@ actor ServerNetworkManager {
     func broadcastToolListChanged() async {
         connectionLog("Broadcasting ToolListChanged notification to all clients")
         invalidateToolSchemaCache()
-        for (_, connectionManager) in connections {
+        for (connectionID, connectionManager) in connections where !connectionsBeingRemoved.contains(connectionID) {
             Task {
                 await connectionManager.notifyToolListChanged()
             }
@@ -9248,8 +10983,12 @@ actor ServerNetworkManager {
     /// Connections without identity (haven't completed MCP handshake) are excluded.
     func dashboardSnapshot() async -> NetworkDashboardSnapshot {
         var entries: [ConnectionDashboardEntry] = []
+        // Capture ownership and assignment together before this method suspends on connection actors.
+        let activeToolScopesSnapshot = activeToolScopesByWindow
+        let assignedWindowSnapshot = connectionWindowMap
 
         for (id, manager) in connections {
+            guard !connectionsBeingRemoved.contains(id) else { continue }
             // Use known client name or placeholder for connections still completing handshake
             let admittedName = clientIDByConnection[id]
             let pendingName = pendingConnections[id]
@@ -9259,7 +10998,7 @@ actor ServerNetworkManager {
                 log.warning("Dashboard: Connection \(id) has no client name (admitted=nil, pending=nil)")
             }
 
-            let windowID = connectionWindowMap[id]
+            let windowID = assignedWindowSnapshot[id]
             let stats = connectionStats[id]
 
             // Get connection state
@@ -9275,13 +11014,26 @@ actor ServerNetworkManager {
             let idle = await manager.secondsSinceLastActivity()
             let hasInFlight = await hasInFlightCalls(for: id)
 
-            // Get active tool name if this connection owns one
-            let activeToolName: String? = if let winID = windowID, activeToolOwnerByWindow[winID] == id {
-                activeToolNameByWindow[winID]
-            } else if let ownedWindow = activeToolOwnerByWindow.first(where: { $0.value == id })?.key {
-                activeToolNameByWindow[ownedWindow]
-            } else {
-                nil
+            // Prefer the newest active scope in the assigned window, then the newest scope anywhere.
+            // Preserve the selected scope's actual window so callers never project B onto assigned A.
+            let activeToolScope = preferredActiveToolScope(
+                connectionID: id,
+                assignedWindowID: windowID,
+                scopesByWindow: activeToolScopesSnapshot
+            )
+            let activeToolScopes = activeToolScopesSnapshot.flatMap { windowID, scopes in
+                scopes.values.compactMap { scope -> ConnectionDashboardActiveToolScope? in
+                    guard scope.connectionID == id else { return nil }
+                    return ConnectionDashboardActiveToolScope(
+                        windowID: windowID,
+                        toolName: scope.toolName,
+                        sequence: scope.sequence
+                    )
+                }
+            }.sorted { lhs, rhs in
+                if lhs.sequence != rhs.sequence { return lhs.sequence > rhs.sequence }
+                if lhs.windowID != rhs.windowID { return lhs.windowID < rhs.windowID }
+                return lhs.toolName < rhs.toolName
             }
 
             // Determine transport type
@@ -9302,7 +11054,8 @@ actor ServerNetworkManager {
                     totalToolCalls: stats?.totalToolCalls ?? 0,
                     idleSeconds: idle > 0 ? idle : nil,
                     hasInFlightCalls: hasInFlight,
-                    activeToolName: activeToolName,
+                    activeToolScope: activeToolScope,
+                    activeToolScopes: activeToolScopes,
                     sessionKey: sessionKey
                 )
             )
@@ -9422,7 +11175,51 @@ actor ServerNetworkManager {
 
     // MARK: - Admission helpers
 
+    private struct DirectAdmissionFence {
+        let connectionIdentity: ObjectIdentifier
+        let lifecycleGeneration: UInt64
+    }
+
+    private func captureDirectAdmissionFence(connectionID: UUID) -> DirectAdmissionFence? {
+        guard !connectionsBeingRemoved.contains(connectionID),
+              let connection = connections[connectionID],
+              let connectionLifecycleGeneration = connectionLifecycleGenerationByID[connectionID],
+              isCurrentLifecycle(connectionLifecycleGeneration)
+        else { return nil }
+        return DirectAdmissionFence(
+            connectionIdentity: ObjectIdentifier(connection as AnyObject),
+            lifecycleGeneration: connectionLifecycleGeneration
+        )
+    }
+
+    private func isCurrentDirectAdmission(
+        connectionID: UUID,
+        fence: DirectAdmissionFence
+    ) -> Bool {
+        guard !connectionsBeingRemoved.contains(connectionID),
+              isCurrentLifecycle(fence.lifecycleGeneration),
+              connectionLifecycleGenerationByID[connectionID] == fence.lifecycleGeneration,
+              let connection = connections[connectionID]
+        else { return false }
+        return ObjectIdentifier(connection as AnyObject) == fence.connectionIdentity
+    }
+
+    private func removePendingDirectAdmissionIfOwned(
+        connectionID: UUID,
+        clientID: String,
+        fence: DirectAdmissionFence
+    ) {
+        guard isCurrentDirectAdmission(connectionID: connectionID, fence: fence),
+              pendingConnections[connectionID] == clientID
+        else { return }
+        pendingConnections.removeValue(forKey: connectionID)
+    }
+
     func tryReserveConnectionSlot(connectionID: UUID, clientID: String) async -> Bool {
+        guard let admissionFence = captureDirectAdmissionFence(connectionID: connectionID) else {
+            return false
+        }
+
         // 0a) Check if this clientID is in user-kill cooldown (prevents auto-reconnect race)
         if isClientInUserKillCooldown(clientID) {
             let remainingTTL = remainingUserKillCooldown(clientID) ?? 0
@@ -9434,45 +11231,103 @@ actor ServerNetworkManager {
         pruneDeadSlots(for: clientID)
         // Ensure the handshake name is visible even if admission blocks briefly.
         pendingConnections[connectionID] = clientID
-
-        // Ensure global headroom. Under pressure, run one explicit hygiene pass
-        // before giving up on admission.
-        if connections.count >= maxGlobalConnections {
-            await pruneNonViableConnections()
-        }
-        if connections.count >= maxGlobalConnections {
-            let evicted = await evictLeastValuableGlobalForAdmission(preserveOnePerClient: preserveOnePerClient)
-            if !evicted {
-                pendingConnections.removeValue(forKey: connectionID)
-                log.notice("Rejecting connection \(connectionID) from '\(clientID)' - global capacity full (active=\(connections.count), cap=\(maxGlobalConnections))")
+        #if DEBUG
+            await debugAfterDirectAdmissionPendingPublishedForTesting?(connectionID)
+            guard isCurrentDirectAdmission(connectionID: connectionID, fence: admissionFence) else {
                 return false
+            }
+        #endif
+
+        // Global and per-client admission may suspend independently. Stabilize both predicates
+        // before committing the direct admission so a bootstrap reservation created during a
+        // per-client await cannot be missed.
+        cleanupExpiredBootstrapReservations()
+        while true {
+            // Ensure global headroom using the same replacement-aware load as bootstrap admission.
+            if effectiveGlobalAdmissionLoad() >= maxGlobalConnections {
+                await pruneNonViableConnections()
+                guard isCurrentDirectAdmission(connectionID: connectionID, fence: admissionFence) else {
+                    return false
+                }
+            }
+            while effectiveGlobalAdmissionLoad() >= maxGlobalConnections {
+                let evictionResult = await evictLeastValuableGlobalForAdmission(
+                    preserveOnePerClient: preserveOnePerClient,
+                    capacityPredicate: .direct
+                )
+                guard isCurrentDirectAdmission(connectionID: connectionID, fence: admissionFence) else {
+                    return false
+                }
+                if effectiveGlobalAdmissionLoad() < maxGlobalConnections {
+                    break
+                }
+                switch evictionResult {
+                case .evicted, .capacityChanged:
+                    continue
+                case .noProgress, .admissionContextInvalidated:
+                    removePendingDirectAdmissionIfOwned(
+                        connectionID: connectionID,
+                        clientID: clientID,
+                        fence: admissionFence
+                    )
+                    log.notice("Rejecting connection \(connectionID) from '\(clientID)' - global capacity full (effective=\(effectiveGlobalAdmissionLoad()), cap=\(maxGlobalConnections))")
+                    return false
+                }
+            }
+
+            // Enforce per-client cap with hygiene + eviction using effective membership.
+            var effectiveSet = effectiveActiveConnectionIDs(for: clientID)
+            while effectiveSet.count >= maxConnectionsPerClient {
+                await pruneNonViableConnections()
+                guard isCurrentDirectAdmission(connectionID: connectionID, fence: admissionFence) else {
+                    return false
+                }
+                pruneDeadSlots(for: clientID)
+                effectiveSet = effectiveActiveConnectionIDs(for: clientID)
+                if effectiveSet.count < maxConnectionsPerClient { break }
+
+                let evictionResult = await evictLeastValuable(
+                    for: clientID,
+                    capacityLimit: maxConnectionsPerClient
+                )
+                guard isCurrentDirectAdmission(connectionID: connectionID, fence: admissionFence) else {
+                    return false
+                }
+                effectiveSet = effectiveActiveConnectionIDs(for: clientID)
+                if effectiveSet.count < maxConnectionsPerClient { break }
+
+                switch evictionResult {
+                case .evicted, .capacityChanged:
+                    continue
+                case .noProgress:
+                    removePendingDirectAdmissionIfOwned(
+                        connectionID: connectionID,
+                        clientID: clientID,
+                        fence: admissionFence
+                    )
+                    log.notice("Rejecting connection \(connectionID) from '\(clientID)' - per-client capacity full (active=\(effectiveSet.count), cap=\(maxConnectionsPerClient))")
+                    return false
+                }
+            }
+
+            guard isCurrentDirectAdmission(connectionID: connectionID, fence: admissionFence) else {
+                return false
+            }
+            if effectiveGlobalAdmissionLoad() < maxGlobalConnections {
+                break
             }
         }
 
-        // Enforce per-client cap with hygiene + eviction.
+        // Reserve & index without discarding any removing member that still owns cleanup identity.
         var set = activeConnectionsByClient[clientID, default: []]
-        while set.count >= maxConnectionsPerClient {
-            await pruneNonViableConnections()
-            pruneDeadSlots(for: clientID)
-            set = activeConnectionsByClient[clientID, default: []]
-            if set.count < maxConnectionsPerClient { break }
-
-            let evicted = await evictLeastValuable(for: clientID)
-            if !evicted {
-                pendingConnections.removeValue(forKey: connectionID)
-                log.notice("Rejecting connection \(connectionID) from '\(clientID)' - per-client capacity full (active=\(set.count), cap=\(maxConnectionsPerClient))")
-                return false
-            }
-            set = activeConnectionsByClient[clientID, default: []]
-        }
-
-        // Reserve & index
         set.insert(connectionID)
         activeConnectionsByClient[clientID] = set
         clientIDByConnection[connectionID] = clientID
         connectionLog("Admitted connection \(connectionID) with clientID='\(clientID)'")
-        // Once admitted, the authoritative map is set — we can drop the pending label.
-        pendingConnections.removeValue(forKey: connectionID)
+        // Once admitted, the authoritative map is set — drop only the pending label this admission owns.
+        if pendingConnections[connectionID] == clientID {
+            pendingConnections.removeValue(forKey: connectionID)
+        }
 
         // 4) Initialize stats if not already present
         if connectionStats[connectionID] == nil {
@@ -9756,66 +11611,274 @@ actor ServerNetworkManager {
     }
 
     private func limiterLimit(for connectionID: UUID) -> Int {
-        // Always serialize RepoPrompt MCP tool calls per connection.
-        // This avoids race conditions where parallel calls can produce duplicate/mis-tracked
-        // tool cards (for example identical file_action create calls showing mixed statuses).
+        // Serialize RepoPrompt MCP tool calls within each per-connection lane.
+        // Identical calls therefore cannot race and produce duplicate/mis-tracked tool cards,
+        // while file_search may overlap one ordinary call on the same connection.
         _ = connectionID
         return 1
     }
 
-    func limiter(for connectionID: UUID) -> AsyncLimiter? {
-        callLimiters[connectionID]
+    private struct ConnectionCallLimiterResolution {
+        let limiters: MCPConnectionCallLimiters
+        let connectionIdentity: ObjectIdentifier
+        let lifecycleGeneration: UInt64
+    }
+
+    private func connectionCallLimiterResolution(
+        for connectionID: UUID
+    ) -> ConnectionCallLimiterResolution? {
+        guard !connectionsBeingRemoved.contains(connectionID),
+              let connection = connections[connectionID],
+              let connectionLifecycleGeneration = connectionLifecycleGenerationByID[connectionID],
+              isCurrentLifecycle(connectionLifecycleGeneration),
+              let limiters = callLimiters[connectionID]
+        else { return nil }
+        return ConnectionCallLimiterResolution(
+            limiters: limiters,
+            connectionIdentity: ObjectIdentifier(connection as AnyObject),
+            lifecycleGeneration: connectionLifecycleGeneration
+        )
+    }
+
+    private func isCurrentConnectionCallLimiterResolution(
+        _ resolution: ConnectionCallLimiterResolution,
+        connectionID: UUID
+    ) -> Bool {
+        guard !connectionsBeingRemoved.contains(connectionID),
+              !executionWatchdogTerminalConnections.contains(connectionID),
+              isCurrentLifecycle(resolution.lifecycleGeneration),
+              connectionLifecycleGenerationByID[connectionID] == resolution.lifecycleGeneration,
+              let connection = connections[connectionID]
+        else { return false }
+        return ObjectIdentifier(connection as AnyObject) == resolution.connectionIdentity
+    }
+
+    private func toolDispatchAuthorization(
+        connectionID: UUID,
+        resolution: ConnectionCallLimiterResolution,
+        windowIdentity: WindowToolDispatchIdentity? = nil
+    ) -> ToolDispatchAuthorization {
+        ToolDispatchAuthorization(
+            connectionID: connectionID,
+            connectionIdentity: resolution.connectionIdentity,
+            lifecycleGeneration: resolution.lifecycleGeneration,
+            windowIdentity: windowIdentity
+        )
+    }
+
+    private func withConnectionCallPermit<T>(
+        connectionID: UUID,
+        lane: MCPConnectionCallLane,
+        resolution: ConnectionCallLimiterResolution,
+        _ operation: @Sendable () async -> T
+    ) async throws -> T {
+        #if DEBUG
+            await debugAfterConnectionCallLimiterResolutionForTesting?(connectionID)
+        #endif
+        var attemptedLimiters = resolution.limiters
+        var visitedLimiterIdentities: Set<ObjectIdentifier> = []
+
+        while true {
+            try Task.checkCancellation()
+            guard isCurrentConnectionCallLimiterResolution(
+                resolution,
+                connectionID: connectionID
+            ) else { throw CancellationError() }
+
+            let attemptedIdentity = ObjectIdentifier(attemptedLimiters)
+            guard visitedLimiterIdentities.insert(attemptedIdentity).inserted else {
+                throw CancellationError()
+            }
+
+            do {
+                #if DEBUG
+                    let afterPermitAcquired = debugAfterConnectionCallPermitAcquiredForTesting
+                #endif
+                return try await attemptedLimiters.withPermit(lane: lane) {
+                    #if DEBUG
+                        await afterPermitAcquired?(connectionID)
+                    #endif
+                    guard await self.isCurrentConnectionCallLimiterResolution(
+                        resolution,
+                        connectionID: connectionID
+                    ) else {
+                        throw CancellationError()
+                    }
+                    return await operation()
+                }
+            } catch is MCPConnectionCallLimiters.AdmissionRejected {
+                #if DEBUG
+                    await debugAfterConnectionCallLimiterRejectionForTesting?(connectionID)
+                #endif
+                try Task.checkCancellation()
+                guard isCurrentConnectionCallLimiterResolution(
+                    resolution,
+                    connectionID: connectionID
+                ),
+                    let replacementLimiters = await attemptedLimiters.admissionRetryReplacement(),
+                    replacementLimiters !== attemptedLimiters,
+                    !Task.isCancelled,
+                    isCurrentConnectionCallLimiterResolution(
+                        resolution,
+                        connectionID: connectionID
+                    )
+                else { throw CancellationError() }
+                attemptedLimiters = replacementLimiters
+            }
+        }
+    }
+
+    private func withConnectionCallPermit<T>(
+        connectionID: UUID,
+        lane: MCPConnectionCallLane,
+        resolution: ConnectionCallLimiterResolution,
+        cancellationResult: @Sendable () -> T,
+        _ operation: @Sendable () async -> T
+    ) async -> T {
+        do {
+            return try await withConnectionCallPermit(
+                connectionID: connectionID,
+                lane: lane,
+                resolution: resolution,
+                operation
+            )
+        } catch {
+            return cancellationResult()
+        }
     }
 
     func hasInFlightCalls(for connectionID: UUID) async -> Bool {
-        guard let limiter = callLimiters[connectionID] else { return false }
-        return await limiter.activeCount() > 0
+        guard let limiters = callLimiters[connectionID] else { return false }
+        return await limiters.hasInFlightCalls()
     }
 
     #if DEBUG
+        func limiter(
+            for connectionID: UUID,
+            lane: MCPConnectionCallLane = .ordinary
+        ) async -> AsyncLimiter? {
+            guard let limiters = callLimiters[connectionID] else { return nil }
+            return await limiters.limiterForTesting(lane)
+        }
+
         func connectionLimiterDiagnosticsSnapshot(
             connectionID: UUID
-        ) async -> AsyncLimiter.DebugSnapshot? {
-            guard let limiter = callLimiters[connectionID] else { return nil }
-            return await limiter.debugSnapshot()
+        ) async -> MCPConnectionCallLimiterDebugSnapshot? {
+            guard let limiters = callLimiters[connectionID] else { return nil }
+            return await limiters.diagnosticsSnapshot()
         }
 
         func connectionLimiterSnapshotForTesting(
-            connectionID: UUID
+            connectionID: UUID,
+            lane: MCPConnectionCallLane = .ordinary
         ) async -> AsyncLimiter.DebugSnapshot? {
-            await connectionLimiterDiagnosticsSnapshot(connectionID: connectionID)
+            guard let limiter = await limiter(for: connectionID, lane: lane) else { return nil }
+            return await limiter.debugSnapshot()
         }
 
         func setConnectionLimiterStateObserverForTesting(
             connectionID: UUID,
+            lane: MCPConnectionCallLane = .ordinary,
             observer: ((AsyncLimiter.DebugSnapshot) -> Void)?
         ) async -> Bool {
-            guard let limiter = callLimiters[connectionID] else { return false }
+            guard let limiter = await limiter(for: connectionID, lane: lane) else { return false }
             await limiter.setDebugStateObserver(observer)
             return true
         }
+
+        func withConnectionCallPermitForTesting<T>(
+            connectionID: UUID,
+            lane: MCPConnectionCallLane,
+            _ operation: @Sendable () async -> T
+        ) async throws -> T {
+            if let resolution = connectionCallLimiterResolution(for: connectionID) {
+                return try await withConnectionCallPermit(
+                    connectionID: connectionID,
+                    lane: lane,
+                    resolution: resolution,
+                    operation
+                )
+            }
+            guard let limiters = callLimiters[connectionID] else { throw CancellationError() }
+            await debugAfterConnectionCallLimiterResolutionForTesting?(connectionID)
+            return try await limiters.withPermit(lane: lane, operation)
+        }
+
+        func connectionIsEvictableForTesting(_ connectionID: UUID) async -> Bool {
+            await isEvictable(connectionID)
+        }
+
+        func closeConnectionCallLanesIfIdleForEvictionForTesting(_ connectionID: UUID) async -> Bool {
+            guard let limiters = callLimiters[connectionID],
+                  await closeConnectionCallLanesIfIdleForEviction(connectionID)
+            else { return false }
+            await limiters.markTentativeCloseCommitted()
+            return true
+        }
+
+        func beginTentativeConnectionCallLaneCloseForTesting(_ connectionID: UUID) async -> Bool {
+            await closeConnectionCallLanesIfIdleForEviction(connectionID)
+        }
+
+        func connectionCallAdmissionRetryWaiterCountForTesting(_ connectionID: UUID) async -> Int? {
+            guard let limiters = callLimiters[connectionID] else { return nil }
+            return await limiters.admissionRetryWaiterCountForTesting()
+        }
+
+        func closeAndRestoreConnectionCallLanesForTesting(_ connectionID: UUID) async -> Bool {
+            guard let connection = connections[connectionID],
+                  let clientID = clientIDByConnection[connectionID],
+                  let limiters = callLimiters[connectionID]
+            else { return false }
+            let connectionIdentity = ObjectIdentifier(connection as AnyObject)
+            guard await closeConnectionCallLanesIfIdleForEviction(
+                connectionID,
+                expectedConnectionIdentity: connectionIdentity,
+                expectedLimiters: limiters
+            ) else { return false }
+            return await restoreConnectionCallLanesAfterAbortedIdleEviction(
+                connectionID,
+                clientID: clientID,
+                connectionIdentity: connectionIdentity,
+                replacing: limiters
+            )
+        }
     #endif
 
-    private func oldestEvictableConnectionID() async -> UUID? {
+    private func oldestPressureEvictionCandidate() async -> EvictionCandidate? {
         let threshold = pressureEvictIdleSeconds
         guard threshold > 0 else { return nil }
-        var best: (id: UUID, idle: TimeInterval)? = nil
-        for (id, mgr) in connections {
-            // Skip connections doing work
-            if let lim = callLimiters[id], await lim.activeCount() > 0 {
-                continue
-            }
-            let idle = await mgr.secondsSinceLastActivity()
-            if idle >= TimeInterval(threshold) {
-                if best == nil || idle > best!.idle {
-                    best = (id, idle)
-                }
+        var best: EvictionCandidate?
+        for id in connections.keys {
+            guard !creditedBootstrapPredecessorConnectionIDs().contains(id),
+                  await isEvictable(id),
+                  let candidate = await makeCandidate(for: id),
+                  candidate.idleSeconds >= TimeInterval(threshold),
+                  !isCreditedBootstrapPredecessor(candidate)
+            else { continue }
+            if best == nil || candidate.idleSeconds > best!.idleSeconds {
+                best = candidate
             }
         }
-        return best?.id
+        return best
     }
 
     /// ─────────────  Admission fairness helpers  ─────────────
+    private var effectiveRegisteredConnectionCount: Int {
+        connections.keys.reduce(into: 0) { count, connectionID in
+            if !connectionsBeingRemoved.contains(connectionID) {
+                count += 1
+            }
+        }
+    }
+
+    private func effectiveActiveConnectionIDs(for clientID: String) -> Set<UUID> {
+        guard let indexedConnections = activeConnectionsByClient[clientID] else { return [] }
+        return indexedConnections.filter { connectionID in
+            connections[connectionID] != nil && !connectionsBeingRemoved.contains(connectionID)
+        }
+    }
+
     /// Remove client slots that are no longer backed by a live connection entry.
     private func pruneDeadSlots(for clientID: String) {
         guard var set = activeConnectionsByClient[clientID] else { return }
@@ -9827,13 +11890,120 @@ actor ServerNetworkManager {
 
     /// Connection is evictable if it has no in-flight calls and does not own an active tool.
     private func isEvictable(_ id: UUID) async -> Bool {
-        if let lim = callLimiters[id], await lim.activeCount() > 0 { return false }
-        if activeToolOwnerByWindow.values.contains(id) { return false }
+        if connectionsBeingRemoved.contains(id) { return false }
+        if let limiters = callLimiters[id], await limiters.hasInFlightCalls() { return false }
+        if hasActiveToolScopes(ownedBy: id) { return false }
         return true
+    }
+
+    private func isCurrentConnectionIdentity(
+        _ connectionID: UUID,
+        expectedIdentity: ObjectIdentifier
+    ) -> Bool {
+        guard let connection = connections[connectionID] else { return false }
+        return ObjectIdentifier(connection as AnyObject) == expectedIdentity
+    }
+
+    private func isCurrentEvictionCandidate(_ candidate: EvictionCandidate) -> Bool {
+        connectionLifecycleGenerationByID[candidate.id] == candidate.lifecycleGeneration
+            && isCurrentLifecycle(candidate.lifecycleGeneration)
+            && isCurrentConnectionIdentity(
+                candidate.id,
+                expectedIdentity: candidate.connectionIdentity
+            )
+    }
+
+    private func isCreditedBootstrapPredecessor(_ candidate: EvictionCandidate) -> Bool {
+        isCurrentEvictionCandidate(candidate)
+            && creditedBootstrapPredecessorConnectionIDs().contains(candidate.id)
+    }
+
+    private func closeConnectionCallLanesIfIdleForEviction(
+        _ id: UUID,
+        expectedConnectionIdentity: ObjectIdentifier? = nil,
+        expectedLimiters: MCPConnectionCallLimiters? = nil
+    ) async -> Bool {
+        if let expectedConnectionIdentity,
+           !isCurrentConnectionIdentity(id, expectedIdentity: expectedConnectionIdentity)
+        {
+            return false
+        }
+        guard !hasActiveToolScopes(ownedBy: id),
+              let limiters = expectedLimiters ?? callLimiters[id],
+              callLimiters[id] === limiters
+        else { return false }
+        #if DEBUG
+            let didClose = await limiters.closeIfIdle { [debugDuringAdmissionEvictionCloseForTesting] in
+                await debugDuringAdmissionEvictionCloseForTesting?(id)
+            }
+        #else
+            let didClose = await limiters.closeIfIdle()
+        #endif
+        return didClose
+    }
+
+    private func restoreConnectionCallLanesAfterAbortedIdleEviction(
+        _ id: UUID,
+        clientID: String,
+        connectionIdentity: ObjectIdentifier,
+        replacing closedLimiters: MCPConnectionCallLimiters,
+        requiresClientMembership: Bool = true
+    ) async -> Bool {
+        guard !connectionsBeingRemoved.contains(id),
+              isCurrentConnectionIdentity(id, expectedIdentity: connectionIdentity),
+              callLimiters[id] === closedLimiters
+        else {
+            await closedLimiters.markTentativeCloseCommitted()
+            return false
+        }
+        if requiresClientMembership {
+            guard clientIDByConnection[id] == clientID,
+                  activeConnectionsByClient[clientID]?.contains(id) == true
+            else {
+                await closedLimiters.markTentativeCloseCommitted()
+                return false
+            }
+        }
+
+        // closeIfIdle() admitted no owners before closing both lanes. Replacing that exact,
+        // still-registered bundle is therefore a safe rollback: stale references can only
+        // observe cancellation, while all subsequent calls resolve these fresh open lanes.
+        let replacement = MCPConnectionCallLimiters(limit: limiterLimit(for: id))
+        callLimiters[id] = replacement
+        await closedLimiters.markTentativeCloseRestored(by: replacement)
+        return true
+    }
+
+    private enum PerClientAdmissionEvictionResult: Equatable {
+        /// This invocation committed and completed removal of its selected victim.
+        case evicted
+        /// Another removal reduced this client's effective membership while this invocation awaited.
+        case capacityChanged
+        /// No victim was removed and effective membership did not change.
+        case noProgress
+    }
+
+    private enum GlobalAdmissionCapacityPredicate {
+        case none
+        case direct
+        case bootstrap(prospectiveReplacementCredit: BootstrapReplacementCredit?)
+    }
+
+    private enum GlobalAdmissionEvictionResult: Equatable {
+        /// This invocation committed and completed removal of its selected victim.
+        case evicted
+        /// Another removal made effective capacity progress while this invocation preserved its victim.
+        case capacityChanged
+        /// No victim was removed and effective live capacity did not change.
+        case noProgress
+        /// The bootstrap listener or lifecycle generation became stale.
+        case admissionContextInvalidated
     }
 
     private struct EvictionCandidate {
         let id: UUID
+        let connectionIdentity: ObjectIdentifier
+        let lifecycleGeneration: UInt64
         let clientID: String
         let everCalled: Bool
         let totalCalls: Int
@@ -9842,14 +12012,24 @@ actor ServerNetworkManager {
     }
 
     private func makeCandidate(for id: UUID) async -> EvictionCandidate? {
-        guard let clientID = clientIDByConnection[id], let mgr = connections[id] else { return nil }
+        guard let clientID = clientIDByConnection[id],
+              let mgr = connections[id],
+              let candidateLifecycleGeneration = connectionLifecycleGenerationByID[id],
+              isCurrentLifecycle(candidateLifecycleGeneration)
+        else { return nil }
+        let connectionIdentity = ObjectIdentifier(mgr as AnyObject)
         let stats = connectionStats[id]
 
-        // If not viable, force to the front by giving infinite idle
+        // If not viable, force to the front by giving infinite idle.
         let viable = await mgr.isViableForRetention()
+        guard isCurrentConnectionIdentity(id, expectedIdentity: connectionIdentity),
+              clientIDByConnection[id] == clientID
+        else { return nil }
         if !viable {
             return EvictionCandidate(
                 id: id,
+                connectionIdentity: connectionIdentity,
+                lifecycleGeneration: candidateLifecycleGeneration,
                 clientID: clientID,
                 everCalled: (stats?.totalToolCalls ?? 0) > 0,
                 totalCalls: stats?.totalToolCalls ?? 0,
@@ -9859,8 +12039,13 @@ actor ServerNetworkManager {
         }
 
         let idle = await mgr.secondsSinceLastActivity()
+        guard isCurrentConnectionIdentity(id, expectedIdentity: connectionIdentity),
+              clientIDByConnection[id] == clientID
+        else { return nil }
         return EvictionCandidate(
             id: id,
+            connectionIdentity: connectionIdentity,
+            lifecycleGeneration: candidateLifecycleGeneration,
             clientID: clientID,
             everCalled: (stats?.totalToolCalls ?? 0) > 0,
             totalCalls: stats?.totalToolCalls ?? 0,
@@ -9878,70 +12063,207 @@ actor ServerNetworkManager {
     }
 
     /// Evict least valuable eligible connection for this client.
-    private func evictLeastValuable(for clientID: String) async -> Bool {
-        guard let set = activeConnectionsByClient[clientID], !set.isEmpty else { return false }
-        var candidates: [EvictionCandidate] = []
-        for id in set {
-            guard await isEvictable(id) else { continue }
-            if let c = await makeCandidate(for: id) { candidates.append(c) }
+    private func evictLeastValuable(
+        for clientID: String,
+        capacityLimit: Int? = nil
+    ) async -> PerClientAdmissionEvictionResult {
+        let initialEffectiveConnections = effectiveActiveConnectionIDs(for: clientID)
+        guard !initialEffectiveConnections.isEmpty else { return .noProgress }
+        func noEvictionResult() -> PerClientAdmissionEvictionResult {
+            effectiveActiveConnectionIDs(for: clientID).count < initialEffectiveConnections.count
+                ? .capacityChanged
+                : .noProgress
         }
-        guard let victim = candidates.sorted(by: isLessValuable).first else { return false }
-        log.warning("Per-client eviction: evicting \(victim.id) for client \(clientID) to admit a new connection.")
-        await removeConnection(victim.id)
-        return true
+
+        var candidates: [EvictionCandidate] = []
+        for id in initialEffectiveConnections {
+            guard !creditedBootstrapPredecessorConnectionIDs().contains(id) else { continue }
+            guard await isEvictable(id) else {
+                if effectiveActiveConnectionIDs(for: clientID).count < initialEffectiveConnections.count {
+                    return .capacityChanged
+                }
+                continue
+            }
+            if effectiveActiveConnectionIDs(for: clientID).count < initialEffectiveConnections.count {
+                return .capacityChanged
+            }
+            if let candidate = await makeCandidate(for: id),
+               !isCreditedBootstrapPredecessor(candidate)
+            {
+                if effectiveActiveConnectionIDs(for: clientID).count < initialEffectiveConnections.count {
+                    return .capacityChanged
+                }
+                candidates.append(candidate)
+            }
+        }
+
+        for victim in candidates.sorted(by: isLessValuable) {
+            #if DEBUG
+                if let debugBeforeAdmissionEvictionCloseForTesting {
+                    await debugBeforeAdmissionEvictionCloseForTesting(victim.id)
+                }
+            #endif
+            if effectiveActiveConnectionIDs(for: clientID).count < initialEffectiveConnections.count {
+                return .capacityChanged
+            }
+            guard isCurrentEvictionCandidate(victim),
+                  !isCreditedBootstrapPredecessor(victim),
+                  clientIDByConnection[victim.id] == clientID,
+                  effectiveActiveConnectionIDs(for: clientID).contains(victim.id),
+                  let closedLimiters = callLimiters[victim.id]
+            else { continue }
+
+            let didClose = await closeConnectionCallLanesIfIdleForEviction(
+                victim.id,
+                expectedConnectionIdentity: victim.connectionIdentity,
+                expectedLimiters: closedLimiters
+            )
+            guard didClose else {
+                if effectiveActiveConnectionIDs(for: clientID).count < initialEffectiveConnections.count {
+                    return .capacityChanged
+                }
+                continue
+            }
+            guard isCurrentEvictionCandidate(victim),
+                  callLimiters[victim.id] === closedLimiters
+            else {
+                await closedLimiters.markTentativeCloseCommitted()
+                return noEvictionResult()
+            }
+
+            if isCreditedBootstrapPredecessor(victim) {
+                let restored = await restoreConnectionCallLanesAfterAbortedIdleEviction(
+                    victim.id,
+                    clientID: clientID,
+                    connectionIdentity: victim.connectionIdentity,
+                    replacing: closedLimiters,
+                    requiresClientMembership: false
+                )
+                if restored {
+                    log.notice(
+                        "Per-client eviction aborted because \(victim.id) became a credited bootstrap predecessor; restored idle call lanes."
+                    )
+                }
+                continue
+            }
+
+            if let capacityLimit,
+               effectiveActiveConnectionIDs(for: clientID).count < capacityLimit
+            {
+                let restored = await restoreConnectionCallLanesAfterAbortedIdleEviction(
+                    victim.id,
+                    clientID: clientID,
+                    connectionIdentity: victim.connectionIdentity,
+                    replacing: closedLimiters
+                )
+                if restored {
+                    log.notice(
+                        "Per-client eviction aborted after capacity changed during lane closure for \(victim.id); restored idle call lanes."
+                    )
+                    return .capacityChanged
+                }
+                guard isCurrentEvictionCandidate(victim),
+                      callLimiters[victim.id] === closedLimiters
+                else { return .capacityChanged }
+            }
+
+            guard !isCreditedBootstrapPredecessor(victim),
+                  let committedRemoval = commitConnectionRemoval(
+                      connectionID: victim.id,
+                      expectedIdentity: victim.connectionIdentity,
+                      expectedLifecycleGeneration: victim.lifecycleGeneration
+                  )
+            else {
+                await closedLimiters.markTentativeCloseCommitted()
+                return noEvictionResult()
+            }
+            #if DEBUG
+                await debugAfterAdmissionEvictionRemovalCommittedForTesting?(victim.id)
+            #endif
+            await closedLimiters.markTentativeCloseCommitted()
+
+            log.warning("Per-client eviction: evicting \(victim.id) for client \(clientID) to admit a new connection.")
+            _ = await removeConnection(
+                victim.id,
+                committedRemoval: committedRemoval,
+                connectionAlreadyStopped: false
+            )
+            return .evicted
+        }
+        return noEvictionResult()
     }
 
     /// Evict least valuable eligible connection across all clients.
     private func evictLeastValuableGlobalForAdmission(
         preserveOnePerClient: Bool,
         sourceListener: BootstrapSocketServer? = nil,
-        lifecycleGeneration: UInt64? = nil
-    ) async -> Bool {
+        lifecycleGeneration: UInt64? = nil,
+        capacityPredicate: GlobalAdmissionCapacityPredicate = .none
+    ) async -> GlobalAdmissionEvictionResult {
         guard isCurrentBootstrapAdmissionContext(
             sourceListener: sourceListener,
             lifecycleGeneration: lifecycleGeneration
-        ) else { return false }
+        ) else { return .admissionContextInvalidated }
+
+        let initialEffectiveLoad = globalAdmissionLoad(for: capacityPredicate)
+        func noEvictionResult() -> GlobalAdmissionEvictionResult {
+            globalAdmissionLoad(for: capacityPredicate) < initialEffectiveLoad ? .capacityChanged : .noProgress
+        }
+        func isCreditedPredecessor(_ connectionID: UUID) -> Bool {
+            let prospectiveReplacementCredit: BootstrapReplacementCredit? = switch capacityPredicate {
+            case .none, .direct:
+                nil
+            case let .bootstrap(prospectiveReplacementCredit):
+                prospectiveReplacementCredit
+            }
+            return creditedBootstrapPredecessorConnectionIDs(
+                prospectiveReplacementCredit: prospectiveReplacementCredit
+            ).contains(connectionID)
+        }
 
         var countsByClient: [String: Int] = [:]
-        for (cid, set) in activeConnectionsByClient {
-            countsByClient[cid] = set.count
+        for clientID in activeConnectionsByClient.keys {
+            countsByClient[clientID] = effectiveActiveConnectionIDs(for: clientID).count
         }
 
         var candidates: [EvictionCandidate] = []
-        for (id, _) in connections {
+        for id in connections.keys {
             guard isCurrentBootstrapAdmissionContext(
                 sourceListener: sourceListener,
                 lifecycleGeneration: lifecycleGeneration
-            ) else { return false }
+            ) else { return .admissionContextInvalidated }
+            guard !isCreditedPredecessor(id) else { continue }
             guard await isEvictable(id) else { continue }
             guard isCurrentBootstrapAdmissionContext(
                 sourceListener: sourceListener,
                 lifecycleGeneration: lifecycleGeneration
-            ) else { return false }
+            ) else { return .admissionContextInvalidated }
+            guard !isCreditedPredecessor(id) else { continue }
             if preserveOnePerClient, let cid = clientIDByConnection[id], (countsByClient[cid] ?? 0) <= 1 {
                 continue
             }
-            if let c = await makeCandidate(for: id) {
+            if let candidate = await makeCandidate(for: id) {
                 guard isCurrentBootstrapAdmissionContext(
                     sourceListener: sourceListener,
                     lifecycleGeneration: lifecycleGeneration
-                ) else { return false }
-                candidates.append(c)
+                ) else { return .admissionContextInvalidated }
+                guard !isCreditedPredecessor(id) else { continue }
+                candidates.append(candidate)
             }
         }
 
         if candidates.isEmpty, preserveOnePerClient {
             var anyHasMoreThanOne = false
-            for (_, cnt) in countsByClient {
-                if cnt > 1 { anyHasMoreThanOne = true
-                    break
-                }
+            for count in countsByClient.values where count > 1 {
+                anyHasMoreThanOne = true
+                break
             }
             if !anyHasMoreThanOne {
                 return await evictLeastValuableGlobalForAdmission(
                     preserveOnePerClient: false,
                     sourceListener: sourceListener,
-                    lifecycleGeneration: lifecycleGeneration
+                    lifecycleGeneration: lifecycleGeneration,
+                    capacityPredicate: capacityPredicate
                 )
             }
         }
@@ -9949,14 +12271,196 @@ actor ServerNetworkManager {
         guard isCurrentBootstrapAdmissionContext(
             sourceListener: sourceListener,
             lifecycleGeneration: lifecycleGeneration
-        ) else { return false }
-        guard let victim = candidates.sorted(by: isLessValuable).first else { return false }
-        log.warning("Global eviction: evicting \(victim.id) (client \(victim.clientID)) to admit a new connection.")
-        await removeConnection(victim.id)
-        return isCurrentBootstrapAdmissionContext(
-            sourceListener: sourceListener,
-            lifecycleGeneration: lifecycleGeneration
-        )
+        ) else { return .admissionContextInvalidated }
+        for victim in candidates.sorted(by: isLessValuable) {
+            guard isCurrentBootstrapAdmissionContext(
+                sourceListener: sourceListener,
+                lifecycleGeneration: lifecycleGeneration
+            ) else { return .admissionContextInvalidated }
+            guard !isCreditedPredecessor(victim.id) else { continue }
+            #if DEBUG
+                if let debugBeforeAdmissionEvictionCloseForTesting {
+                    await debugBeforeAdmissionEvictionCloseForTesting(victim.id)
+                    guard isCurrentBootstrapAdmissionContext(
+                        sourceListener: sourceListener,
+                        lifecycleGeneration: lifecycleGeneration
+                    ) else { return .admissionContextInvalidated }
+                    guard !isCreditedPredecessor(victim.id) else { continue }
+                }
+            #endif
+
+            guard isCurrentConnectionIdentity(victim.id, expectedIdentity: victim.connectionIdentity),
+                  clientIDByConnection[victim.id] == victim.clientID
+            else { continue }
+
+            if preserveOnePerClient {
+                let currentClientConnections = effectiveActiveConnectionIDs(for: victim.clientID)
+                guard currentClientConnections.contains(victim.id),
+                      currentClientConnections.count > 1
+                else { continue }
+            }
+
+            if globalAdmissionHasCapacity(for: capacityPredicate) {
+                return .capacityChanged
+            }
+
+            guard let closedLimiters = callLimiters[victim.id] else { continue }
+            let didClose = await closeConnectionCallLanesIfIdleForEviction(
+                victim.id,
+                expectedConnectionIdentity: victim.connectionIdentity,
+                expectedLimiters: closedLimiters
+            )
+            let lifecycleStillCurrentAfterClose = isCurrentBootstrapAdmissionContext(
+                sourceListener: sourceListener,
+                lifecycleGeneration: lifecycleGeneration
+            )
+            guard didClose else {
+                guard lifecycleStillCurrentAfterClose else { return .admissionContextInvalidated }
+                continue
+            }
+            guard isCurrentConnectionIdentity(victim.id, expectedIdentity: victim.connectionIdentity),
+                  callLimiters[victim.id] === closedLimiters
+            else {
+                await closedLimiters.markTentativeCloseCommitted()
+                guard lifecycleStillCurrentAfterClose else { return .admissionContextInvalidated }
+                continue
+            }
+
+            // Once the exact victim's lanes close, a stale lifecycle cannot leave it registered.
+            guard lifecycleStillCurrentAfterClose else {
+                guard let committedRemoval = commitConnectionRemoval(
+                    connectionID: victim.id,
+                    expectedIdentity: victim.connectionIdentity,
+                    expectedLifecycleGeneration: victim.lifecycleGeneration
+                ) else {
+                    await closedLimiters.markTentativeCloseCommitted()
+                    return .admissionContextInvalidated
+                }
+                await closedLimiters.markTentativeCloseCommitted()
+                log.warning("Global eviction: removing closed victim \(victim.id) after admission lifecycle invalidation.")
+                _ = await removeConnection(
+                    victim.id,
+                    committedRemoval: committedRemoval,
+                    connectionAlreadyStopped: false
+                )
+                return .admissionContextInvalidated
+            }
+
+            let currentClientConnections = effectiveActiveConnectionIDs(for: victim.clientID)
+            let becameCreditedPredecessor = isCreditedPredecessor(victim.id)
+            let becameSoleProtectedConnection = preserveOnePerClient
+                && currentClientConnections.contains(victim.id)
+                && currentClientConnections.count == 1
+            if becameCreditedPredecessor || becameSoleProtectedConnection {
+                let restored = await restoreConnectionCallLanesAfterAbortedIdleEviction(
+                    victim.id,
+                    clientID: victim.clientID,
+                    connectionIdentity: victim.connectionIdentity,
+                    replacing: closedLimiters,
+                    requiresClientMembership: !becameCreditedPredecessor
+                )
+                if restored {
+                    let reason = becameCreditedPredecessor
+                        ? "became a credited bootstrap predecessor"
+                        : "became the sole connection for client \(victim.clientID)"
+                    log.notice(
+                        "Global eviction aborted after \(victim.id) \(reason); restored idle call lanes."
+                    )
+                    continue
+                }
+
+                // Restoration failure means the exact identity or lifecycle changed; never
+                // remove a newly protected/current replacement through the stale victim ID.
+                continue
+            }
+
+            if globalAdmissionHasCapacity(for: capacityPredicate) {
+                let restored = await restoreConnectionCallLanesAfterAbortedIdleEviction(
+                    victim.id,
+                    clientID: victim.clientID,
+                    connectionIdentity: victim.connectionIdentity,
+                    replacing: closedLimiters
+                )
+                if restored {
+                    log.notice(
+                        "Global eviction aborted after capacity changed during lane closure for \(victim.id); restored idle call lanes."
+                    )
+                    return .capacityChanged
+                }
+
+                guard !isCreditedPredecessor(victim.id),
+                      let committedRemoval = commitConnectionRemoval(
+                          connectionID: victim.id,
+                          expectedIdentity: victim.connectionIdentity,
+                          expectedLifecycleGeneration: victim.lifecycleGeneration
+                      )
+                else {
+                    await closedLimiters.markTentativeCloseCommitted()
+                    return .capacityChanged
+                }
+                log.warning("Global eviction could not restore closed victim \(victim.id); removing it.")
+                _ = await removeConnection(
+                    victim.id,
+                    committedRemoval: committedRemoval,
+                    connectionAlreadyStopped: false
+                )
+                guard isCurrentBootstrapAdmissionContext(
+                    sourceListener: sourceListener,
+                    lifecycleGeneration: lifecycleGeneration
+                ) else { return .admissionContextInvalidated }
+                return .evicted
+            }
+
+            // Atomic lane closure commits this exact victim to eviction. Claim exact removal
+            // ownership before the cross-actor limiter notification so credit cannot appear in between.
+            guard !isCreditedPredecessor(victim.id),
+                  let committedRemoval = commitConnectionRemoval(
+                      connectionID: victim.id,
+                      expectedIdentity: victim.connectionIdentity,
+                      expectedLifecycleGeneration: victim.lifecycleGeneration
+                  )
+            else {
+                await closedLimiters.markTentativeCloseCommitted()
+                continue
+            }
+            await closedLimiters.markTentativeCloseCommitted()
+            log.warning("Global eviction: evicting \(victim.id) (client \(victim.clientID)) to admit a new connection.")
+            _ = await removeConnection(
+                victim.id,
+                committedRemoval: committedRemoval,
+                connectionAlreadyStopped: false
+            )
+            guard isCurrentBootstrapAdmissionContext(
+                sourceListener: sourceListener,
+                lifecycleGeneration: lifecycleGeneration
+            ) else { return .admissionContextInvalidated }
+            return .evicted
+        }
+        return noEvictionResult()
+    }
+
+    private func globalAdmissionLoad(
+        for predicate: GlobalAdmissionCapacityPredicate
+    ) -> Int {
+        switch predicate {
+        case .none, .direct:
+            effectiveGlobalAdmissionLoad()
+        case let .bootstrap(prospectiveReplacementCredit):
+            effectiveGlobalAdmissionLoad(
+                prospectiveReplacementCredit: prospectiveReplacementCredit
+            )
+        }
+    }
+
+    private func globalAdmissionHasCapacity(
+        for predicate: GlobalAdmissionCapacityPredicate
+    ) -> Bool {
+        switch predicate {
+        case .none:
+            false
+        case .direct, .bootstrap:
+            globalAdmissionLoad(for: predicate) < maxGlobalConnections
+        }
     }
 
     private func isCurrentBootstrapAdmissionContext(
@@ -9973,6 +12477,55 @@ actor ServerNetworkManager {
         }
     }
 }
+
+#if DEBUG
+    struct MCPConnectionCallLimiterDebugSnapshot: Equatable {
+        let ordinary: AsyncLimiter.DebugSnapshot
+        let fileSearch: AsyncLimiter.DebugSnapshot
+
+        var laneCount: Int {
+            MCPConnectionCallLane.allCases.count
+        }
+
+        var limit: Int {
+            ordinary.limit + fileSearch.limit
+        }
+
+        var permits: Int {
+            ordinary.permits + fileSearch.permits
+        }
+
+        var activePermitCount: Int {
+            ordinary.activePermitCount + fileSearch.activePermitCount
+        }
+
+        var waiterCount: Int {
+            ordinary.waiterCount + fileSearch.waiterCount
+        }
+
+        var inFlight: Int {
+            ordinary.inFlight + fileSearch.inFlight
+        }
+
+        var oldestWaiterAgeMilliseconds: UInt64? {
+            [ordinary.oldestWaiterAgeMilliseconds, fileSearch.oldestWaiterAgeMilliseconds]
+                .compactMap(\.self)
+                .max()
+        }
+
+        var cancelledWaiterCount: Int {
+            ordinary.cancelledWaiterCount + fileSearch.cancelledWaiterCount
+        }
+
+        var isClosed: Bool {
+            ordinary.isClosed && fileSearch.isClosed
+        }
+
+        var isIdle: Bool {
+            ordinary.isIdle && fileSearch.isIdle
+        }
+    }
+#endif
 
 /// Cancellation-aware async semaphore used to serialize calls per connection.
 actor AsyncLimiter {

--- a/Sources/RepoPrompt/Infrastructure/MCP/MCPService.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/MCPService.swift
@@ -245,7 +245,20 @@ actor MCPService: Sendable {
         let totalToolCalls: Int
         let idleSeconds: TimeInterval?
         let hasInFlightCalls: Bool
-        let activeToolName: String?
+        let activeToolScope: ConnectionDashboardActiveToolScope?
+        let activeToolScopes: [ConnectionDashboardActiveToolScope]
+        var activeToolScopeCount: Int {
+            activeToolScopes.count
+        }
+
+        var activeToolName: String? {
+            activeToolScope?.toolName
+        }
+
+        var activeToolWindowID: Int? {
+            activeToolScope?.windowID
+        }
+
         /// Session key (capabilityToken) for disambiguating multiple client instances
         let sessionKey: String?
     }
@@ -284,7 +297,8 @@ actor MCPService: Sendable {
                 totalToolCalls: $0.totalToolCalls,
                 idleSeconds: $0.idleSeconds,
                 hasInFlightCalls: $0.hasInFlightCalls,
-                activeToolName: $0.activeToolName,
+                activeToolScope: $0.activeToolScope,
+                activeToolScopes: $0.activeToolScopes,
                 sessionKey: $0.sessionKey
             )
         }

--- a/Sources/RepoPrompt/Infrastructure/MCP/Policies/MCPToolExecutionContract.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/Policies/MCPToolExecutionContract.swift
@@ -1,4 +1,5 @@
 import Foundation
+import MCP
 import RepoPromptShared
 
 enum MCPToolExecutionContract: Equatable {
@@ -47,6 +48,11 @@ enum MCPToolExecutionDispatchError: Error, Equatable {
 }
 
 enum MCPToolExecutionContractCatalog {
+    private static let workspaceSwitchContract = MCPToolExecutionContract.bounded(
+        deadline: MCPTimeoutPolicy.workspaceSwitchToolExecutionDeadline,
+        cancellationGrace: MCPTimeoutPolicy.boundedToolCancellationCleanupGrace
+    )
+
     static let orderedAdvertisedToolNames = MCPGlobalToolName.orderedToolNames + MCPWindowToolGroup.orderedToolNames
 
     static let contracts: [String: MCPToolExecutionContract] = {
@@ -96,5 +102,36 @@ enum MCPToolExecutionContractCatalog {
 
     static func contract(for toolName: String) -> MCPToolExecutionContract? {
         contracts[toolName]
+    }
+
+    static func contract(
+        for toolName: String,
+        arguments: [String: Value]
+    ) -> MCPToolExecutionContract? {
+        guard let baseContract = contract(for: toolName) else { return nil }
+        guard toolName == MCPGlobalToolName.manageWorkspaces else { return baseContract }
+        guard let rawAction = arguments["action"]?.stringValue else {
+            return baseContract
+        }
+        let action = rawAction
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+
+        let producesWorkspaceSwitch: Bool = switch action {
+        case "switch":
+            true
+        case "create":
+            if let switchToCreated = arguments["switch_to_created"] {
+                switchToCreated.boolValue == true
+            } else {
+                true
+            }
+        case "delete":
+            arguments["close_window"]?.boolValue == true
+        default:
+            false
+        }
+
+        return producesWorkspaceSwitch ? workspaceSwitchContract : baseContract
     }
 }

--- a/Sources/RepoPrompt/Infrastructure/MCP/Policies/MCPToolExecutionContract.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/Policies/MCPToolExecutionContract.swift
@@ -121,11 +121,10 @@ enum MCPToolExecutionContractCatalog {
         case "switch":
             true
         case "create":
-            if let switchToCreated = arguments["switch_to_created"] {
-                switchToCreated.boolValue == true
-            } else {
-                true
-            }
+            // Mirror the handler's `args["switch_to_created"]?.boolValue ?? true`: an
+            // omitted or malformed flag still performs the switch, so it must stay
+            // under the workspace-switch deadline.
+            arguments["switch_to_created"]?.boolValue ?? true
         case "delete":
             arguments["close_window"]?.boolValue == true
         default:

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel.swift
@@ -14,6 +14,32 @@ import MCP
 import Ontology
 import RepoPromptShared
 
+private actor MCPRunToolStartGate {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        if isOpen { return }
+        await withCheckedContinuation { continuation in
+            if isOpen {
+                continuation.resume()
+            } else {
+                waiters.append(continuation)
+            }
+        }
+    }
+
+    func open() {
+        guard !isOpen else { return }
+        isOpen = true
+        let pending = waiters
+        waiters.removeAll()
+        for waiter in pending {
+            waiter.resume()
+        }
+    }
+}
+
 private final class MCPRunToolCleanupClaim: @unchecked Sendable {
     private let lock = NSLock()
     private var claimed = false
@@ -454,20 +480,14 @@ final class MCPServerViewModel: ObservableObject {
         }
     }
 
-    /// Returns the active tool name for this window, based on dashboard ownership when available.
+    /// Returns the newest active tool name for this exact window.
     @MainActor
     var windowActiveToolName: String? {
-        if let dashboard {
-            let allowNilWindow = !isMultiWindowModeEffectivelyActive
-            for connection in dashboard.connections {
-                if connection.windowID == windowID || (allowNilWindow && connection.windowID == nil) {
-                    if let toolName = connection.activeToolName {
-                        return toolName
-                    }
-                }
-            }
-        }
-        return activeToolName
+        let dashboardScope = dashboard?.connections
+            .flatMap(\.activeToolScopes)
+            .filter { $0.windowID == windowID }
+            .max(by: { $0.sequence < $1.sequence })
+        return dashboardScope?.toolName ?? activeToolName
     }
 
     /// True when any tool is actively running for this window.
@@ -941,11 +961,13 @@ final class MCPServerViewModel: ObservableObject {
             }
         }
         let liveConnectionCount = liveConnections.count
-        var activeExecutionCount = liveConnections.reduce(into: 0) { partialResult, connection in
-            if connection.hasInFlightCalls {
-                partialResult += 1
-            }
-        }
+        let dashboardActiveExecutionCount = dashboard?.connections.reduce(into: 0) { count, connection in
+            count += connection.activeToolScopes.count(where: { $0.windowID == windowID })
+        } ?? 0
+        var activeExecutionCount = max(
+            activeToolExecutionsByID.count,
+            dashboardActiveExecutionCount
+        )
         let activeTool = windowActiveToolName
         if activeExecutionCount == 0, activeTool != nil {
             activeExecutionCount = 1
@@ -962,12 +984,13 @@ final class MCPServerViewModel: ObservableObject {
 
     // MARK: - - Cancellation support
 
-    /// Per-run active tool execution tracking — supports multiple concurrent tool calls per run.
+    /// Token-primary active tool execution tracking. Run ID is a secondary index;
+    /// executions remain connection-owned and cancellable even when no run resolves.
     @MainActor
     private struct ActiveToolExecution {
         let executionID: UUID
-        let runID: UUID
-        let connectionID: UUID
+        let runID: UUID?
+        let connectionID: UUID?
         let toolName: String
         let lifecycleCorrelation: EditFlowPerf.LifecycleCorrelation?
         let startedAt: Date
@@ -975,9 +998,11 @@ final class MCPServerViewModel: ObservableObject {
     }
 
     @MainActor
-    private var activeToolExecutionsByRunID: [UUID: [UUID: ActiveToolExecution]] = [:]
+    private var activeToolExecutionsByID: [UUID: ActiveToolExecution] = [:]
     @MainActor
-    private var runIDByToolExecutionID: [UUID: UUID] = [:]
+    private var activeToolExecutionIDsByRunID: [UUID: Set<UUID>] = [:]
+    @MainActor
+    private var activeToolExecutionIDsByConnectionID: [UUID: Set<UUID>] = [:]
 
     @MainActor
     private struct AgentRunWaitScope {
@@ -1008,9 +1033,9 @@ final class MCPServerViewModel: ObservableObject {
 
     @MainActor
     private func debugActiveTools(for runID: UUID) -> String {
-        let executions = activeToolExecutionsByRunID[runID] ?? [:]
-        guard !executions.isEmpty else { return "none" }
-        return executions.values
+        let executionIDs = activeToolExecutionIDsByRunID[runID] ?? []
+        guard !executionIDs.isEmpty else { return "none" }
+        return executionIDs.compactMap { activeToolExecutionsByID[$0] }
             .map { "\($0.toolName)#\(String($0.executionID.uuidString.prefix(8)))" }
             .sorted()
             .joined(separator: ",")
@@ -1022,10 +1047,8 @@ final class MCPServerViewModel: ObservableObject {
 
     @MainActor
     func cancelActiveTool() {
-        // Prefer cancellation via the per-run registry if the active token is tracked
         if let token = activeToolToken,
-           let runID = runIDByToolExecutionID[token],
-           activeToolExecutionsByRunID[runID]?[token] != nil
+           activeToolExecutionsByID[token] != nil
         {
             cancelToolExecution(executionID: token, reason: "cancelActiveTool")
         } else {
@@ -1049,34 +1072,19 @@ final class MCPServerViewModel: ObservableObject {
     @MainActor
     @discardableResult
     func cancelActiveToolsForRun(runID: UUID, reason: String? = nil) -> Int {
-        guard let executions = activeToolExecutionsByRunID.removeValue(forKey: runID) else {
-            // Even if there are no active tools, resume any waiters so
-            // steering flush tasks unblock and can observe cancellation.
+        let executionIDs = activeToolExecutionIDsByRunID[runID] ?? []
+        guard !executionIDs.isEmpty else {
             resumeAllToolIdleWaiters(forRunID: runID)
             toolEndedCountByRunID.removeValue(forKey: runID)
             return 0
         }
+
         var cancelledCount = 0
-        for (executionID, execution) in executions {
-            execution.cancel()
-            EditFlowPerf.lifecycleEvent(
-                EditFlowPerf.Lifecycle.MCPRunTool.unregister,
-                correlation: execution.lifecycleCorrelation,
-                EditFlowPerf.Dimensions(toolName: execution.toolName, outcome: "cancelled")
-            )
-            runIDByToolExecutionID.removeValue(forKey: executionID)
-            cancelledCount += 1
+        for executionID in executionIDs {
+            if cancelToolExecution(executionID: executionID, reason: reason) {
+                cancelledCount += 1
+            }
         }
-        // Clear single-slot UI state if it was pointing at one of the cancelled executions
-        if let token = activeToolToken, executions[token] != nil {
-            clearActiveToolSlot()
-        }
-        // Resume any steering idle-waiters since the run's tools are now gone
-        resumeAllToolIdleWaiters(
-            forRunID: runID,
-            lifecycleCorrelation: executions.values.lazy.compactMap(\.lifecycleCorrelation).first
-        )
-        // Clean up the ended-count tracker for this run since it's being torn down.
         toolEndedCountByRunID.removeValue(forKey: runID)
         return cancelledCount
     }
@@ -1087,12 +1095,7 @@ final class MCPServerViewModel: ObservableObject {
     @MainActor
     @discardableResult
     func cancelActiveToolsForConnection(connectionID: UUID, reason: String? = nil) -> Int {
-        let matchingExecutionIDs = activeToolExecutionsByRunID.values.flatMap { executions in
-            executions.values.compactMap { execution in
-                execution.connectionID == connectionID ? execution.executionID : nil
-            }
-        }
-        let matchingExecutionIDSet = Set(matchingExecutionIDs)
+        let matchingExecutionIDs = activeToolExecutionIDsByConnectionID[connectionID] ?? []
         let activeTokenBeforeCancellation = activeToolToken
 
         var cancelledCount = 0
@@ -1102,19 +1105,18 @@ final class MCPServerViewModel: ObservableObject {
             }
         }
 
-        guard activeToolConnectionID == connectionID else {
-            return cancelledCount
-        }
-
         if let activeTokenBeforeCancellation,
-           matchingExecutionIDSet.contains(activeTokenBeforeCancellation)
+           matchingExecutionIDs.contains(activeTokenBeforeCancellation)
         {
             clearActiveToolSlot()
             return cancelledCount
         }
 
-        // Legacy single-slot fallback for work that predates or bypasses the per-run registry.
-        // Only the recorded owning connection may cancel this slot.
+        guard activeToolConnectionID == connectionID else {
+            return cancelledCount
+        }
+
+        // Legacy single-slot fallback for work that predates or bypasses the token registry.
         if activeToolName != nil || cancelCurrentTool != nil || activeToolToken != nil {
             let legacyCancel = cancelCurrentTool
             legacyCancel?()
@@ -1130,8 +1132,8 @@ final class MCPServerViewModel: ObservableObject {
     @MainActor
     private func registerToolExecution(
         executionID: UUID,
-        runID: UUID,
-        connectionID: UUID,
+        runID: UUID?,
+        connectionID: UUID?,
         toolName: String,
         lifecycleCorrelation: EditFlowPerf.LifecycleCorrelation? = nil,
         cancel: @escaping () -> Void
@@ -1145,34 +1147,55 @@ final class MCPServerViewModel: ObservableObject {
             startedAt: Date(),
             cancel: cancel
         )
-        activeToolExecutionsByRunID[runID, default: [:]][executionID] = execution
-        runIDByToolExecutionID[executionID] = runID
-        steeringDebugLog("[AgentRunSteeringWake] MCP tool register runID=\(runID) executionID=\(executionID) tool=\(toolName) active=\(debugActiveTools(for: runID))")
+        activeToolExecutionsByID[executionID] = execution
+        if let runID {
+            activeToolExecutionIDsByRunID[runID, default: []].insert(executionID)
+            steeringDebugLog("[AgentRunSteeringWake] MCP tool register runID=\(runID) executionID=\(executionID) tool=\(toolName) active=\(debugActiveTools(for: runID))")
+        }
+        if let connectionID {
+            activeToolExecutionIDsByConnectionID[connectionID, default: []].insert(executionID)
+        }
+        recomputeCloseSafetyState()
     }
 
     @MainActor
-    private func unregisterToolExecution(executionID: UUID) {
-        guard let runID = runIDByToolExecutionID.removeValue(forKey: executionID) else {
-            steeringDebugLog("[AgentRunSteeringWake] MCP tool unregister ignored missing runID executionID=\(executionID)")
+    private func unregisterToolExecution(
+        executionID: UUID,
+        countAsEnded: Bool = true
+    ) {
+        guard let execution = activeToolExecutionsByID.removeValue(forKey: executionID) else {
+            steeringDebugLog("[AgentRunSteeringWake] MCP tool unregister ignored missing executionID=\(executionID)")
             return
         }
-        let execution = activeToolExecutionsByRunID[runID]?[executionID]
-        let toolName = execution?.toolName ?? "unknown"
+
         EditFlowPerf.lifecycleEvent(
             EditFlowPerf.Lifecycle.MCPRunTool.unregister,
-            correlation: execution?.lifecycleCorrelation,
-            EditFlowPerf.Dimensions(toolName: toolName)
+            correlation: execution.lifecycleCorrelation,
+            EditFlowPerf.Dimensions(toolName: execution.toolName)
         )
-        activeToolExecutionsByRunID[runID]?.removeValue(forKey: executionID)
-        // Track cumulative tool completions for steering interrupt safety gate.
-        toolEndedCountByRunID[runID, default: 0] += 1
-        if activeToolExecutionsByRunID[runID]?.isEmpty == true {
-            activeToolExecutionsByRunID.removeValue(forKey: runID)
-            steeringDebugLog("[AgentRunSteeringWake] MCP tool unregister drained runID=\(runID) executionID=\(executionID) tool=\(toolName) endedCount=\(toolEndedCountByRunID[runID] ?? 0)")
-            resumeAllToolIdleWaiters(forRunID: runID, lifecycleCorrelation: execution?.lifecycleCorrelation)
-        } else {
-            steeringDebugLog("[AgentRunSteeringWake] MCP tool unregister runID=\(runID) executionID=\(executionID) tool=\(toolName) remaining=\(debugActiveTools(for: runID)) endedCount=\(toolEndedCountByRunID[runID] ?? 0)")
+
+        if let connectionID = execution.connectionID {
+            activeToolExecutionIDsByConnectionID[connectionID]?.remove(executionID)
+            if activeToolExecutionIDsByConnectionID[connectionID]?.isEmpty == true {
+                activeToolExecutionIDsByConnectionID.removeValue(forKey: connectionID)
+            }
         }
+
+        if let runID = execution.runID {
+            activeToolExecutionIDsByRunID[runID]?.remove(executionID)
+            if countAsEnded {
+                toolEndedCountByRunID[runID, default: 0] += 1
+            }
+            if activeToolExecutionIDsByRunID[runID]?.isEmpty == true {
+                activeToolExecutionIDsByRunID.removeValue(forKey: runID)
+                steeringDebugLog("[AgentRunSteeringWake] MCP tool unregister drained runID=\(runID) executionID=\(executionID) tool=\(execution.toolName) endedCount=\(toolEndedCountByRunID[runID] ?? 0)")
+                resumeAllToolIdleWaiters(forRunID: runID, lifecycleCorrelation: execution.lifecycleCorrelation)
+            } else {
+                steeringDebugLog("[AgentRunSteeringWake] MCP tool unregister runID=\(runID) executionID=\(executionID) tool=\(execution.toolName) remaining=\(debugActiveTools(for: runID)) endedCount=\(toolEndedCountByRunID[runID] ?? 0)")
+            }
+        }
+
+        recomputeCloseSafetyState()
     }
 
     /// Returns the cumulative number of tool executions that have completed for the given runID.
@@ -1185,10 +1208,7 @@ final class MCPServerViewModel: ObservableObject {
     /// Returns whether the given run currently has any active RepoPrompt MCP tool executions.
     @MainActor
     func hasActiveToolExecutions(runID: UUID) -> Bool {
-        guard let executions = activeToolExecutionsByRunID[runID] else {
-            return false
-        }
-        return !executions.isEmpty
+        !(activeToolExecutionIDsByRunID[runID]?.isEmpty ?? true)
     }
 
     /// Returns whether the given parent run is currently blocked in an `agent_run` wait.
@@ -1215,7 +1235,7 @@ final class MCPServerViewModel: ObservableObject {
     @MainActor
     func awaitNoActiveToolExecutions(runID: UUID) async throws {
         // Fast path: already idle
-        let executions = activeToolExecutionsByRunID[runID]
+        let executions = activeToolExecutionIDsByRunID[runID]
         if executions == nil || executions!.isEmpty {
             steeringDebugLog("[AgentRunSteeringWake] MCP idle wait fast-idle runID=\(runID)")
             return
@@ -1230,7 +1250,7 @@ final class MCPServerViewModel: ObservableObject {
             await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
                 // Double-check under the same MainActor turn — tools may have
                 // drained between the fast-path check and here.
-                let stillActive = activeToolExecutionsByRunID[runID]
+                let stillActive = activeToolExecutionIDsByRunID[runID]
                 if stillActive == nil || stillActive!.isEmpty {
                     steeringDebugLog("[AgentRunSteeringWake] MCP idle wait drained before parking runID=\(runID) waiterID=\(waiterID)")
                     continuation.resume()
@@ -1284,9 +1304,7 @@ final class MCPServerViewModel: ObservableObject {
     @MainActor
     @discardableResult
     private func cancelToolExecution(executionID: UUID, reason: String?) -> Bool {
-        guard let runID = runIDByToolExecutionID[executionID],
-              let execution = activeToolExecutionsByRunID[runID]?[executionID]
-        else {
+        guard let execution = activeToolExecutionsByID[executionID] else {
             return false
         }
         execution.cancel()
@@ -1523,28 +1541,40 @@ final class MCPServerViewModel: ObservableObject {
             resolvedContext: ResolvedTabContextSnapshot?,
             toolName: String = "test_tool",
             cancel: @escaping () -> Void = {}
-        ) async -> (executionID: UUID, runID: UUID)? {
-            guard let connectionID = metadata.connectionID,
-                  let runID = await resolveRunIDForExecution(metadata: metadata, resolvedContext: resolvedContext),
-                  shouldRegisterRunToolExecution(toolName: toolName)
-            else {
+        ) async -> (executionID: UUID, runID: UUID?)? {
+            guard let connectionID = metadata.connectionID else {
                 return nil
             }
 
+            let resolvedRunID = await resolveRunIDForExecution(
+                metadata: metadata,
+                resolvedContext: resolvedContext
+            )
+            let indexedRunID = shouldRegisterRunToolExecution(toolName: toolName)
+                ? resolvedRunID
+                : nil
             let executionID = UUID()
             registerToolExecution(
                 executionID: executionID,
-                runID: runID,
+                runID: indexedRunID,
                 connectionID: connectionID,
                 toolName: toolName,
                 cancel: cancel
             )
-            return (executionID, runID)
+            return (executionID, indexedRunID)
         }
 
         @MainActor
         func test_endToolExecution(executionID: UUID) {
             unregisterToolExecution(executionID: executionID)
+        }
+
+        @MainActor
+        func test_activeToolExecutionCount(connectionID: UUID? = nil) -> Int {
+            if let connectionID {
+                return activeToolExecutionIDsByConnectionID[connectionID]?.count ?? 0
+            }
+            return activeToolExecutionsByID.count
         }
 
         @MainActor
@@ -1592,6 +1622,14 @@ final class MCPServerViewModel: ObservableObject {
         @MainActor
         func test_activeToolConnectionID() -> UUID? {
             activeToolConnectionID
+        }
+
+        @MainActor
+        @discardableResult
+        func test_clearActiveToolSlot(ifToken token: UUID) -> Bool {
+            guard activeToolToken == token else { return false }
+            clearActiveToolSlot()
+            return true
         }
 
         @MainActor
@@ -2161,10 +2199,24 @@ final class MCPServerViewModel: ObservableObject {
 
         let shouldTrackActiveTool = await shouldTrackActiveTool(for: metadata)
         let executionRunID = await resolveRunIDForExecution(metadata: metadata, resolvedContext: resolvedContext)
+        let indexedRunID = shouldRegisterRunToolExecution(toolName: name)
+            ? executionRunID
+            : nil
 
         // Generate a unique token for this tool execution to prevent cleanup races
         let toolToken = UUID()
         let capturedConnectionID = metadata.connectionID
+        let serverViewModelIdentity = ObjectIdentifier(self)
+        let dispatchAuthorization = ServerNetworkManager.currentToolDispatchAuthorization
+        if let dispatchAuthorization {
+            guard await ServerNetworkManager.shared.validateToolDispatchAuthorization(
+                dispatchAuthorization,
+                expectedWindowID: windowID,
+                expectedServerViewModelIdentity: serverViewModelIdentity
+            ) else {
+                throw ServerNetworkManager.ToolDispatchAdmissionError.windowTerminal
+            }
+        }
         EditFlowPerf.end(EditFlowPerf.Stage.MCPToolCall.runToolSetup, runToolSetupState)
 
         let runToolRegistrationState = EditFlowPerf.begin(
@@ -2190,10 +2242,22 @@ final class MCPServerViewModel: ObservableObject {
             }
         }
 
-        // 🔑 run work completely off the UI thread
-        // Propagate TaskLocal connectionID so tools can resolve tab context
+        let startGate = MCPRunToolStartGate()
+        // 🔑 run work completely off the UI thread, but do not let the provider begin
+        // until token registration and final exact dispatch validation are complete.
         let task = Task {
-            try await ServerNetworkManager.withConnectionID(capturedConnectionID) {
+            await startGate.wait()
+            try Task.checkCancellation()
+            if let dispatchAuthorization {
+                guard await ServerNetworkManager.shared.validateToolDispatchAuthorization(
+                    dispatchAuthorization,
+                    expectedWindowID: windowID,
+                    expectedServerViewModelIdentity: serverViewModelIdentity
+                ) else {
+                    throw ServerNetworkManager.ToolDispatchAdmissionError.windowTerminal
+                }
+            }
+            return try await ServerNetworkManager.withConnectionID(capturedConnectionID) {
                 EditFlowPerf.lifecycleEvent(
                     EditFlowPerf.Lifecycle.MCPRunTool.providerBegan,
                     correlation: lifecycleCorrelation,
@@ -2226,7 +2290,6 @@ final class MCPServerViewModel: ObservableObject {
             }
         }
 
-        // Register in per-run tracking and store a single-slot canceller for legacy UI
         await MainActor.run {
             if !shouldTrackActiveTool {
                 EditFlowPerf.lifecycleEvent(
@@ -2238,20 +2301,35 @@ final class MCPServerViewModel: ObservableObject {
             if shouldTrackActiveTool {
                 self.cancelCurrentTool = { task.cancel() }
             }
-            if shouldRegisterRunToolExecution(toolName: name),
-               let connectionID = capturedConnectionID,
-               let runID = executionRunID
-            {
-                self.registerToolExecution(
-                    executionID: toolToken,
-                    runID: runID,
-                    connectionID: connectionID,
-                    toolName: name,
-                    lifecycleCorrelation: lifecycleCorrelation,
-                    cancel: { task.cancel() }
-                )
-            }
+            self.registerToolExecution(
+                executionID: toolToken,
+                runID: indexedRunID,
+                connectionID: capturedConnectionID,
+                toolName: name,
+                lifecycleCorrelation: lifecycleCorrelation,
+                cancel: { task.cancel() }
+            )
         }
+
+        if let dispatchAuthorization,
+           await !(ServerNetworkManager.shared.validateToolDispatchAuthorization(
+               dispatchAuthorization,
+               expectedWindowID: windowID,
+               expectedServerViewModelIdentity: serverViewModelIdentity
+           ))
+        {
+            task.cancel()
+            await startGate.open()
+            await MainActor.run {
+                self.unregisterToolExecution(executionID: toolToken, countAsEnded: false)
+                if shouldTrackActiveTool, self.activeToolToken == toolToken {
+                    self.clearActiveToolSlot()
+                }
+            }
+            throw ServerNetworkManager.ToolDispatchAdmissionError.windowTerminal
+        }
+        await startGate.open()
+
         EditFlowPerf.end(EditFlowPerf.Stage.MCPToolCall.runToolRegistration, runToolRegistrationState)
         EditFlowPerf.lifecycleEvent(
             EditFlowPerf.Lifecycle.MCPRunTool.registrationEnded,

--- a/Sources/RepoPrompt/Infrastructure/MCP/WorkspaceApproval/WorkspaceApprovalManager.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WorkspaceApproval/WorkspaceApprovalManager.swift
@@ -56,6 +56,10 @@ public final class WorkspaceApprovalManager: ObservableObject {
 
     /// Request approval for a workspace operation.
     /// Returns the user's decision.
+    ///
+    /// The wait is cancellation-aware: if the calling task is cancelled (for example by a
+    /// tool-execution watchdog), the request resolves as `.denied` instead of parking the
+    /// caller on an unresolvable continuation while the side effect remains pending.
     public func requestApproval(for request: WorkspaceApprovalRequest) async -> WorkspaceApprovalResult {
         // Check if auto-approved
         if settings.shouldAutoApprove(operation: request.operation, clientID: request.clientID) {
@@ -65,25 +69,53 @@ public final class WorkspaceApprovalManager: ObservableObject {
         }
 
         // Need user approval
-        return await withCheckedContinuation { continuation in
-            // If there's already a pending request, queue this one
-            if pendingRequest != nil {
-                pendingQueue.append((request, continuation))
-                return
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                if Task.isCancelled {
+                    continuation.resume(returning: .denied)
+                    return
+                }
+
+                // If there's already a pending request, queue this one
+                if pendingRequest != nil {
+                    pendingQueue.append((request, continuation))
+                    return
+                }
+
+                // Show approval overlay
+                pendingRequest = request
+                currentContinuation = continuation
+                isApprovalOverlayVisible = true
+
+                // Bring window to front and request attention
+                bringWindowToFront(windowID: request.windowID)
+
+                if !NSApp.isActive {
+                    NSApp.requestUserAttention(.criticalRequest)
+                }
             }
-
-            // Show approval overlay
-            pendingRequest = request
-            currentContinuation = continuation
-            isApprovalOverlayVisible = true
-
-            // Bring window to front and request attention
-            bringWindowToFront(windowID: request.windowID)
-
-            if !NSApp.isActive {
-                NSApp.requestUserAttention(.criticalRequest)
+        } onCancel: {
+            Task { @MainActor in
+                WorkspaceApprovalManager.shared.cancelPending(requestID: request.id)
             }
         }
+    }
+
+    /// Deny and clear a specific pending approval request, whether it is the active
+    /// request or still queued. No-op if the request has already been resolved.
+    public func cancelPending(requestID: UUID) {
+        if pendingRequest?.id == requestID {
+            currentContinuation?.resume(returning: .denied)
+            currentContinuation = nil
+            pendingRequest = nil
+            isApprovalOverlayVisible = false
+            processNextQueuedRequest()
+            return
+        }
+
+        guard let index = pendingQueue.firstIndex(where: { $0.0.id == requestID }) else { return }
+        let (_, continuation) = pendingQueue.remove(at: index)
+        continuation.resume(returning: .denied)
     }
 
     /// Resolve the current pending approval request.
@@ -111,6 +143,12 @@ public final class WorkspaceApprovalManager: ObservableObject {
         // Process next queued request if any
         processNextQueuedRequest()
     }
+
+    #if DEBUG
+        var pendingQueueCountForTesting: Int {
+            pendingQueue.count
+        }
+    #endif
 
     /// Cancel all pending approvals (e.g., when window closes).
     public func cancelAllPending() {

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
@@ -110,12 +110,21 @@ struct WorkspaceDisplayRootRefsSnapshot: Equatable {
 
 actor WorkspaceFileContextStore {
     private struct RootState {
+        let lifetimeID: UUID
         let root: WorkspaceRootRecord
         let service: FileSystemService
         var folderIDsByRelativePath: [String: UUID]
         var fileIDsByRelativePath: [String: UUID]
         var childFolderIDsByFolderID: [UUID: [UUID]]
         var childFileIDsByFolderID: [UUID: [UUID]]
+    }
+
+    private struct DetachedWatcherStop {
+        let index: Int
+        let rootID: UUID
+        let rootPath: String
+        let completionLatch: WorkspaceRootUnloadCompletionLatch
+        let task: Task<Void, Never>
     }
 
     private struct RootLoadConfiguration: Hashable {
@@ -140,6 +149,16 @@ actor WorkspaceFileContextStore {
         func covers(_ other: ScopedIngressBarrierTarget) -> Bool {
             watcherAcceptedWatermark >= other.watcherAcceptedWatermark
                 && acceptedServicePublicationSequence >= other.acceptedServicePublicationSequence
+        }
+
+        func merging(_ other: ScopedIngressBarrierTarget) -> ScopedIngressBarrierTarget {
+            ScopedIngressBarrierTarget(
+                watcherAcceptedWatermark: max(watcherAcceptedWatermark, other.watcherAcceptedWatermark),
+                acceptedServicePublicationSequence: max(
+                    acceptedServicePublicationSequence,
+                    other.acceptedServicePublicationSequence
+                )
+            )
         }
     }
 
@@ -228,15 +247,55 @@ actor WorkspaceFileContextStore {
         }
     }
 
+    private final class ScopedIngressBarrierPendingFlight {
+        var target: ScopedIngressBarrierTarget
+        let join: ScopedIngressBarrierJoin
+        #if DEBUG
+            let enqueuedAtNanoseconds: UInt64
+        #endif
+
+        init(
+            target: ScopedIngressBarrierTarget,
+            join: ScopedIngressBarrierJoin,
+            enqueuedAtNanoseconds: UInt64 = 0
+        ) {
+            self.target = target
+            self.join = join
+            #if DEBUG
+                self.enqueuedAtNanoseconds = enqueuedAtNanoseconds
+            #endif
+        }
+    }
+
+    private final class ScopedIngressBarrierRootFlightState {
+        var active: ScopedIngressBarrierFlight?
+        var pending: ScopedIngressBarrierPendingFlight?
+
+        init(
+            active: ScopedIngressBarrierFlight? = nil,
+            pending: ScopedIngressBarrierPendingFlight? = nil
+        ) {
+            self.active = active
+            self.pending = pending
+        }
+    }
+
     #if DEBUG
         struct ScopedIngressBarrierStats: Equatable {
             let launchCount: Int
             let joinCount: Int
             let successorCount: Int
+            let coalescedSuccessorCount: Int
         }
 
         struct ScopedIngressBarrierDebugSnapshot: Equatable {
             struct Active: Equatable {
+                let targetWatcherWatermark: UInt64
+                let targetServicePublicationSequence: UInt64
+                let ageMilliseconds: UInt64
+            }
+
+            struct Pending: Equatable {
                 let targetWatcherWatermark: UInt64
                 let targetServicePublicationSequence: UInt64
                 let ageMilliseconds: UInt64
@@ -255,8 +314,10 @@ actor WorkspaceFileContextStore {
             let launchCount: Int
             let joinCount: Int
             let successorCount: Int
+            let coalescedSuccessorCount: Int
             let completionCount: Int
             let active: Active?
+            let pending: Pending?
             let lastCompleted: Completed?
         }
 
@@ -325,11 +386,14 @@ actor WorkspaceFileContextStore {
         private var watcherSinkWillApplyHandler: (@Sendable (UUID) async -> Void)?
         private var publisherIngressWillWaitHandler: (@Sendable (Set<UUID>) async -> Void)?
         private var watcherServiceStateWillReconcileHandler: (@Sendable (UUID, Bool) async -> Void)?
+        private var watcherStopWillBeginHandler: (@Sendable (UUID) async -> Void)?
+        private var rootUnloadTerminationDidCompleteHandler: (@Sendable (WorkspaceRootUnloadTerminationDiagnostics) async -> Void)?
         private var appliedIngressDidCaptureWatermarksHandler: (@Sendable ([UUID: UInt64]) async -> Void)?
         private var scopedIngressBarrierWillFlushHandler: (@Sendable (UUID) async -> Void)?
         private var scopedIngressBarrierLaunchCountsByRootID: [UUID: Int] = [:]
         private var scopedIngressBarrierJoinCountsByRootID: [UUID: Int] = [:]
         private var scopedIngressBarrierSuccessorCountsByRootID: [UUID: Int] = [:]
+        private var scopedIngressBarrierCoalescedSuccessorCountsByRootID: [UUID: Int] = [:]
         private var scopedIngressBarrierCompletionCountsByRootID: [UUID: Int] = [:]
         private var lastCompletedScopedIngressBarrierByRootID: [UUID: ScopedIngressBarrierDebugSnapshot.Completed] = [:]
         private var publicationInvalidationHistoryByRootID: [UUID: PublicationInvalidationHistoryState] = [:]
@@ -362,6 +426,16 @@ actor WorkspaceFileContextStore {
             watcherServiceStateWillReconcileHandler = handler
         }
 
+        func setWatcherStopWillBeginHandler(_ handler: (@Sendable (UUID) async -> Void)?) {
+            watcherStopWillBeginHandler = handler
+        }
+
+        func setRootUnloadTerminationDidCompleteHandler(
+            _ handler: (@Sendable (WorkspaceRootUnloadTerminationDiagnostics) async -> Void)?
+        ) {
+            rootUnloadTerminationDidCompleteHandler = handler
+        }
+
         func setAppliedIngressDidCaptureWatermarksHandler(_ handler: (@Sendable ([UUID: UInt64]) async -> Void)?) {
             appliedIngressDidCaptureWatermarksHandler = handler
         }
@@ -374,12 +448,15 @@ actor WorkspaceFileContextStore {
             ScopedIngressBarrierStats(
                 launchCount: scopedIngressBarrierLaunchCountsByRootID[rootID] ?? 0,
                 joinCount: scopedIngressBarrierJoinCountsByRootID[rootID] ?? 0,
-                successorCount: scopedIngressBarrierSuccessorCountsByRootID[rootID] ?? 0
+                successorCount: scopedIngressBarrierSuccessorCountsByRootID[rootID] ?? 0,
+                coalescedSuccessorCount: scopedIngressBarrierCoalescedSuccessorCountsByRootID[rootID] ?? 0
             )
         }
 
         func scopedIngressBarrierFlightCountForTesting() -> Int {
-            scopedIngressBarrierFlightsByRootID.values.reduce(0) { $0 + $1.count }
+            scopedIngressBarrierFlightStatesByRootID.values.reduce(0) { count, state in
+                count + (state.active == nil ? 0 : 1) + (state.pending == nil ? 0 : 1)
+            }
         }
 
         func fileSystemServiceForTesting(rootID: UUID) -> FileSystemService? {
@@ -410,13 +487,25 @@ actor WorkspaceFileContextStore {
         }
 
         private func scopedIngressBarrierDebugSnapshot(rootID: UUID) -> ScopedIngressBarrierDebugSnapshot {
-            let active = scopedIngressBarrierFlightsByRootID[rootID]?.last.map { flight in
+            let now = debugNowNanoseconds()
+            let state = scopedIngressBarrierFlightStatesByRootID[rootID]
+            let active = state?.active.map { flight in
                 ScopedIngressBarrierDebugSnapshot.Active(
                     targetWatcherWatermark: flight.target.watcherAcceptedWatermark.rawValue,
                     targetServicePublicationSequence: flight.target.acceptedServicePublicationSequence,
                     ageMilliseconds: Self.elapsedMilliseconds(
                         since: flight.startedAtNanoseconds,
-                        now: debugNowNanoseconds()
+                        now: now
+                    )
+                )
+            }
+            let pending = state?.pending.map { pending in
+                ScopedIngressBarrierDebugSnapshot.Pending(
+                    targetWatcherWatermark: pending.target.watcherAcceptedWatermark.rawValue,
+                    targetServicePublicationSequence: pending.target.acceptedServicePublicationSequence,
+                    ageMilliseconds: Self.elapsedMilliseconds(
+                        since: pending.enqueuedAtNanoseconds,
+                        now: now
                     )
                 )
             }
@@ -424,8 +513,10 @@ actor WorkspaceFileContextStore {
                 launchCount: scopedIngressBarrierLaunchCountsByRootID[rootID] ?? 0,
                 joinCount: scopedIngressBarrierJoinCountsByRootID[rootID] ?? 0,
                 successorCount: scopedIngressBarrierSuccessorCountsByRootID[rootID] ?? 0,
+                coalescedSuccessorCount: scopedIngressBarrierCoalescedSuccessorCountsByRootID[rootID] ?? 0,
                 completionCount: scopedIngressBarrierCompletionCountsByRootID[rootID] ?? 0,
                 active: active,
+                pending: pending,
                 lastCompleted: lastCompletedScopedIngressBarrierByRootID[rootID]
             )
         }
@@ -434,6 +525,7 @@ actor WorkspaceFileContextStore {
             Set(scopedIngressBarrierLaunchCountsByRootID.keys)
                 .union(scopedIngressBarrierJoinCountsByRootID.keys)
                 .union(scopedIngressBarrierSuccessorCountsByRootID.keys)
+                .union(scopedIngressBarrierCoalescedSuccessorCountsByRootID.keys)
                 .union(scopedIngressBarrierCompletionCountsByRootID.keys)
                 .union(lastCompletedScopedIngressBarrierByRootID.keys)
                 .union(publicationInvalidationHistoryByRootID.keys)
@@ -605,7 +697,8 @@ actor WorkspaceFileContextStore {
     private var appliedIndexGenerationsByRootID: [UUID: UInt64] = [:]
     private var watcherCancellablesByRootID: [UUID: AnyCancellable] = [:]
     private let publisherIngressCoordinator: WorkspaceFileSystemIngressCoordinator
-    private var scopedIngressBarrierFlightsByRootID: [UUID: [ScopedIngressBarrierFlight]] = [:]
+    private let unloadTerminationPolicy: WorkspaceRootUnloadTerminationPolicy
+    private var scopedIngressBarrierFlightStatesByRootID: [UUID: ScopedIngressBarrierRootFlightState] = [:]
     private var nextScopedIngressBarrierToken: UInt64 = 0
     private static let maxConcurrentScopedIngressBarriers = 8
     private var codeScanResultTask: Task<Void, Never>?
@@ -616,10 +709,12 @@ actor WorkspaceFileContextStore {
     #if DEBUG
         init(
             searchLaneConfiguration: StoreBackedWorkspaceSearchLane.Configuration = .production,
-            debugNowNanoseconds: @escaping @Sendable () -> UInt64 = { DispatchTime.now().uptimeNanoseconds }
+            debugNowNanoseconds: @escaping @Sendable () -> UInt64 = { DispatchTime.now().uptimeNanoseconds },
+            unloadTerminationPolicy: WorkspaceRootUnloadTerminationPolicy = .production
         ) {
             storeBackedSearchLane = StoreBackedWorkspaceSearchLane(configuration: searchLaneConfiguration)
             self.debugNowNanoseconds = debugNowNanoseconds
+            self.unloadTerminationPolicy = unloadTerminationPolicy
             publisherIngressCoordinator = WorkspaceFileSystemIngressCoordinator(debugNowNanoseconds: debugNowNanoseconds)
             #if os(macOS)
                 let source = DispatchSource.makeMemoryPressureSource(
@@ -634,8 +729,12 @@ actor WorkspaceFileContextStore {
             #endif
         }
     #else
-        init(searchLaneConfiguration: StoreBackedWorkspaceSearchLane.Configuration = .production) {
+        init(
+            searchLaneConfiguration: StoreBackedWorkspaceSearchLane.Configuration = .production,
+            unloadTerminationPolicy: WorkspaceRootUnloadTerminationPolicy = .production
+        ) {
             storeBackedSearchLane = StoreBackedWorkspaceSearchLane(configuration: searchLaneConfiguration)
+            self.unloadTerminationPolicy = unloadTerminationPolicy
             publisherIngressCoordinator = WorkspaceFileSystemIngressCoordinator()
             #if os(macOS)
                 let source = DispatchSource.makeMemoryPressureSource(
@@ -723,6 +822,7 @@ actor WorkspaceFileContextStore {
             return
         }
         let root = state.root
+        let lifetimeID = state.lifetimeID
         let diagnosticRootToken = state.service.diagnosticRootToken
         let publisherIngressCoordinator = publisherIngressCoordinator
         let subscription = publisherIngressCoordinator.openPublisherIngress(rootID: rootID) { [weak self] publication, publicationCorrelation in
@@ -739,12 +839,13 @@ actor WorkspaceFileContextStore {
             await self?.handleObservedPublisherFileSystemPublication(
                 publication,
                 root: root,
+                expectedLifetimeID: lifetimeID,
                 publicationCorrelation: publicationCorrelation,
                 diagnosticRootToken: diagnosticRootToken
             )
         }
         let publisher = await state.service.publisherForChanges()
-        guard rootStatesByID[rootID] != nil,
+        guard isRootLifetimeCurrent(rootID: rootID, expectedLifetimeID: lifetimeID),
               publisherIngressCoordinator.isPublisherIngressOpen(subscription)
         else {
             await reconcileWatcherServiceState(state.service, rootID: rootID)
@@ -772,7 +873,7 @@ actor WorkspaceFileContextStore {
                 lifecycleCorrelation: publicationCorrelation
             )
         }
-        guard rootStatesByID[rootID] != nil,
+        guard isRootLifetimeCurrent(rootID: rootID, expectedLifetimeID: lifetimeID),
               publisherIngressCoordinator.isPublisherIngressOpen(subscription)
         else {
             cancellable.cancel()
@@ -892,11 +993,45 @@ actor WorkspaceFileContextStore {
         func appliedIngressSnapshotForTesting(rootID: UUID) -> WorkspaceFileSystemIngressCoordinator.AppliedSnapshot {
             publisherIngressCoordinator.appliedSnapshot(rootID: rootID)
         }
+
+        func publisherIngressDebugSnapshotForTesting(
+            rootID: UUID
+        ) -> WorkspaceFileSystemIngressCoordinator.DebugSnapshot {
+            publisherIngressCoordinator.debugSnapshot(rootID: rootID)
+        }
+
+        func waitUntilPublisherIngressAppliedForTesting(
+            rootID: UUID,
+            servicePublicationSequence: UInt64
+        ) async {
+            await publisherIngressCoordinator.waitUntilApplied(
+                rootID: rootID,
+                servicePublicationSequence: servicePublicationSequence
+            )
+        }
+
+        func rootLifetimeIDForTesting(rootID: UUID) throws -> UUID {
+            try state(for: rootID).lifetimeID
+        }
+
+        func replayPublisherFileSystemPublicationForTesting(
+            rootID: UUID,
+            expectedLifetimeID: UUID,
+            deltas: [FileSystemDelta]
+        ) async {
+            guard let root = rootStatesByID[rootID]?.root else { return }
+            await handleObservedFileSystemDeltas(
+                deltas,
+                root: root,
+                expectedLifetimeID: expectedLifetimeID
+            )
+        }
     #endif
 
     private func handleObservedPublisherFileSystemPublication(
         _ publication: FileSystemDeltaPublication,
         root: WorkspaceRootRecord,
+        expectedLifetimeID: UUID,
         publicationCorrelation: EditFlowPerf.LifecycleCorrelation?,
         diagnosticRootToken: UUID
     ) async {
@@ -905,9 +1040,11 @@ actor WorkspaceFileContextStore {
                 await watcherSinkWillApplyHandler(root.id)
             }
         #endif
+        guard isRootLifetimeCurrent(rootID: root.id, expectedLifetimeID: expectedLifetimeID) else { return }
         await handleObservedFileSystemDeltas(
             publication.deltas,
             root: root,
+            expectedLifetimeID: expectedLifetimeID,
             publicationCorrelation: publicationCorrelation,
             diagnosticRootToken: diagnosticRootToken,
             watcherAcceptedWatermark: publication.watcherAcceptedWatermark,
@@ -918,14 +1055,16 @@ actor WorkspaceFileContextStore {
     private func handleObservedFileSystemDeltas(
         _ deltas: [FileSystemDelta],
         root: WorkspaceRootRecord,
+        expectedLifetimeID: UUID? = nil,
         publicationCorrelation: EditFlowPerf.LifecycleCorrelation? = nil,
         diagnosticRootToken: UUID? = nil,
         watcherAcceptedWatermark: FileSystemWatcherIngressMailbox.Watermark? = nil,
         servicePublicationSequence: UInt64? = nil
     ) async {
-        guard rootStatesByID[root.id] != nil else { return }
+        guard isRootLifetimeCurrent(rootID: root.id, expectedLifetimeID: expectedLifetimeID) else { return }
         for delta in deltas {
             guard await isDiscoveryFacingFileSystemDelta(delta, rootID: root.id) else { continue }
+            guard isRootLifetimeCurrent(rootID: root.id, expectedLifetimeID: expectedLifetimeID) else { return }
             yieldFileSystemDeltaEvent(WorkspaceFileSystemDeltaEvent(
                 rootID: root.id,
                 rootPath: root.standardizedFullPath,
@@ -937,11 +1076,16 @@ actor WorkspaceFileContextStore {
             await applyPreparedIndexDeltas(
                 rootID: root.id,
                 deltas: preparedDeltas,
+                expectedLifetimeID: expectedLifetimeID,
                 watcherAcceptedWatermark: watcherAcceptedWatermark,
                 servicePublicationSequence: servicePublicationSequence
             )
         #else
-            await applyPreparedIndexDeltas(rootID: root.id, deltas: preparedDeltas)
+            await applyPreparedIndexDeltas(
+                rootID: root.id,
+                deltas: preparedDeltas,
+                expectedLifetimeID: expectedLifetimeID
+            )
         #endif
         EditFlowPerf.lifecycleEvent(
             EditFlowPerf.Lifecycle.WorkspaceIngress.storeCanonicalApplyCompleted,
@@ -1287,16 +1431,76 @@ actor WorkspaceFileContextStore {
         rootID: UUID,
         target: ScopedIngressBarrierTarget
     ) async -> WorkspaceIngressBarrierSample? {
-        guard !Task.isCancelled, let state = rootStatesByID[rootID] else { return nil }
-        if let flight = scopedIngressBarrierFlightsByRootID[rootID]?.first(where: { $0.target.covers(target) }) {
+        guard !Task.isCancelled, rootStatesByID[rootID] != nil else { return nil }
+        let flightState = scopedIngressBarrierFlightStatesByRootID[rootID]
+            ?? ScopedIngressBarrierRootFlightState()
+
+        if let active = flightState.active, active.target.covers(target) {
             #if DEBUG
                 scopedIngressBarrierJoinCountsByRootID[rootID, default: 0] += 1
             #endif
-            guard let output = await flight.join.value() else { return nil }
+            guard let output = await active.join.value() else { return nil }
             return scopedIngressBarrierSample(from: output)
         }
 
-        let isSuccessor = scopedIngressBarrierFlightsByRootID[rootID]?.isEmpty == false
+        if let pending = flightState.pending, pending.target.covers(target) {
+            #if DEBUG
+                scopedIngressBarrierJoinCountsByRootID[rootID, default: 0] += 1
+                scopedIngressBarrierCoalescedSuccessorCountsByRootID[rootID, default: 0] += 1
+            #endif
+            guard let output = await pending.join.value() else { return nil }
+            return scopedIngressBarrierSample(from: output)
+        }
+
+        if let pending = flightState.pending {
+            pending.target = pending.target.merging(target)
+            #if DEBUG
+                scopedIngressBarrierJoinCountsByRootID[rootID, default: 0] += 1
+                scopedIngressBarrierCoalescedSuccessorCountsByRootID[rootID, default: 0] += 1
+            #endif
+            guard let output = await pending.join.value() else { return nil }
+            return scopedIngressBarrierSample(from: output)
+        }
+
+        if flightState.active != nil {
+            let join = ScopedIngressBarrierJoin()
+            #if DEBUG
+                let enqueuedAtNanoseconds = debugNowNanoseconds()
+                scopedIngressBarrierSuccessorCountsByRootID[rootID, default: 0] += 1
+            #else
+                let enqueuedAtNanoseconds: UInt64 = 0
+            #endif
+            flightState.pending = ScopedIngressBarrierPendingFlight(
+                target: target,
+                join: join,
+                enqueuedAtNanoseconds: enqueuedAtNanoseconds
+            )
+            scopedIngressBarrierFlightStatesByRootID[rootID] = flightState
+            guard let output = await join.value() else { return nil }
+            return scopedIngressBarrierSample(from: output)
+        }
+
+        let join = ScopedIngressBarrierJoin()
+        launchScopedIngressBarrier(
+            rootID: rootID,
+            target: target,
+            join: join,
+            flightState: flightState
+        )
+        guard let output = await join.value() else { return nil }
+        return scopedIngressBarrierSample(from: output)
+    }
+
+    private func launchScopedIngressBarrier(
+        rootID: UUID,
+        target: ScopedIngressBarrierTarget,
+        join: ScopedIngressBarrierJoin,
+        flightState: ScopedIngressBarrierRootFlightState
+    ) {
+        guard let state = rootStatesByID[rootID] else {
+            join.complete(with: nil)
+            return
+        }
         nextScopedIngressBarrierToken &+= 1
         let token = nextScopedIngressBarrierToken
         let publisherIngressCoordinator = publisherIngressCoordinator
@@ -1304,9 +1508,6 @@ actor WorkspaceFileContextStore {
         let service = state.service
         #if DEBUG
             scopedIngressBarrierLaunchCountsByRootID[rootID, default: 0] += 1
-            if isSuccessor {
-                scopedIngressBarrierSuccessorCountsByRootID[rootID, default: 0] += 1
-            }
             let barrierCompletionNowNanoseconds = debugNowNanoseconds
             let barrierStartedAtNanoseconds = barrierCompletionNowNanoseconds()
             let scopedIngressBarrierWillFlushHandler = scopedIngressBarrierWillFlushHandler
@@ -1319,14 +1520,14 @@ actor WorkspaceFileContextStore {
         #else
             let lifecycleCorrelation: EditFlowPerf.LifecycleCorrelation? = nil
         #endif
-        let join = ScopedIngressBarrierJoin()
         let flight = ScopedIngressBarrierFlight(
             token: token,
             target: target,
             join: join,
             startedAtNanoseconds: barrierStartedAtNanoseconds
         )
-        scopedIngressBarrierFlightsByRootID[rootID, default: []].append(flight)
+        flightState.active = flight
+        scopedIngressBarrierFlightStatesByRootID[rootID] = flightState
         flight.task = Task { [weak self] in
             #if DEBUG
                 if let scopedIngressBarrierWillFlushHandler {
@@ -1483,8 +1684,6 @@ actor WorkspaceFileContextStore {
                 join.complete(with: output)
             }
         }
-        guard let output = await join.value() else { return nil }
-        return scopedIngressBarrierSample(from: output)
     }
 
     private func finishScopedIngressBarrier(
@@ -1495,18 +1694,13 @@ actor WorkspaceFileContextStore {
         startedAtNanoseconds: UInt64,
         join: ScopedIngressBarrierJoin
     ) {
-        guard var flights = scopedIngressBarrierFlightsByRootID[rootID],
-              flights.contains(where: { $0.token == token })
+        guard let flightState = scopedIngressBarrierFlightStatesByRootID[rootID],
+              flightState.active?.token == token
         else {
             join.complete(with: output)
             return
         }
-        flights.removeAll { $0.token == token }
-        if flights.isEmpty {
-            scopedIngressBarrierFlightsByRootID.removeValue(forKey: rootID)
-        } else {
-            scopedIngressBarrierFlightsByRootID[rootID] = flights
-        }
+        flightState.active = nil
         #if DEBUG
             if let output {
                 recordScopedIngressBarrierCompletion(
@@ -1519,6 +1713,25 @@ actor WorkspaceFileContextStore {
                 )
             }
         #endif
+
+        if let output, let pending = flightState.pending {
+            flightState.pending = nil
+            launchScopedIngressBarrier(
+                rootID: rootID,
+                target: pending.target,
+                join: pending.join,
+                flightState: flightState
+            )
+            join.complete(with: output)
+            return
+        }
+
+        let pending = flightState.pending
+        flightState.pending = nil
+        scopedIngressBarrierFlightStatesByRootID.removeValue(forKey: rootID)
+        if output == nil {
+            pending?.join.complete(with: nil)
+        }
         join.complete(with: output)
     }
 
@@ -2288,6 +2501,7 @@ actor WorkspaceFileContextStore {
         #endif
 
         var state = RootState(
+            lifetimeID: UUID(),
             root: root,
             service: service,
             folderIDsByRelativePath: [:],
@@ -2427,11 +2641,10 @@ actor WorkspaceFileContextStore {
 
         var statesToUnload: [(rootID: UUID, state: RootState)] = []
         for rootID in orderedRootIDs {
-            if let flights = scopedIngressBarrierFlightsByRootID.removeValue(forKey: rootID) {
-                for flight in flights {
-                    flight.task?.cancel()
-                    flight.join.complete(with: nil)
-                }
+            if let flightState = scopedIngressBarrierFlightStatesByRootID.removeValue(forKey: rootID) {
+                flightState.active?.task?.cancel()
+                flightState.active?.join.complete(with: nil)
+                flightState.pending?.join.complete(with: nil)
             }
             watcherCancellablesByRootID.removeValue(forKey: rootID)?.cancel()
             publisherIngressCoordinator.closePublisherIngress(rootID: rootID)
@@ -2488,27 +2701,34 @@ actor WorkspaceFileContextStore {
             let stopWatchersStartMS = WorkspaceRestorePerfLog.timestampMSIfEnabled()
         #endif
 
-        // Stop watchers after the roots have been detached from actor lookup tables.
-        // This keeps stale ingress from resolving against roots being unloaded while
-        // preserving the existing awaited teardown semantics.
-        for entry in statesToUnload {
-            #if DEBUG
-                let stopWatcherRootStartMS = WorkspaceRestorePerfLog.timestampMSIfEnabled()
-            #endif
-            await reconcileWatcherServiceState(entry.state.service, rootID: entry.rootID)
-            #if DEBUG
-                WorkspaceRestorePerfLog.event(
-                    "store.rootUnload.stopWatcherRoot",
-                    fields: [
-                        "rootName": entry.state.root.name,
-                        "rootID": WorkspaceRestorePerfLog.shortID(entry.rootID),
-                        "duration": stopWatcherRootStartMS.map { WorkspaceRestorePerfLog.formatElapsedMS(since: $0) } ?? "notMeasured"
-                    ]
-                )
-            #endif
-        }
-        await waitForCurrentPublisherIngress(rootIDs: removedRootIDSet)
-        publisherIngressCoordinator.finishPublisherIngress(rootIDs: removedRootIDSet)
+        // Stop each detached service exactly once. The caller only waits through a bounded
+        // completion latch; cancellation cannot interrupt synchronous FSEvents flush work.
+        let detachedWatcherStops = startDetachedWatcherStops(statesToUnload)
+        #if DEBUG
+            if publisherIngressCoordinator.pendingPublisherIngressCount(rootIDs: removedRootIDSet) > 0,
+               let publisherIngressWillWaitHandler
+            {
+                await publisherIngressWillWaitHandler(removedRootIDSet)
+            }
+        #endif
+        let removedRootIDsInOrder = statesToUnload.map(\.rootID)
+        async let publisherIngressReports = publisherIngressCoordinator.terminateClosedPublisherIngress(
+            rootIDs: removedRootIDsInOrder,
+            gracefulDrainTimeoutNanoseconds: unloadTerminationPolicy.publisherIngressGraceNanoseconds,
+            sleep: unloadTerminationPolicy.sleep
+        )
+        let watcherStopReports = await awaitDetachedWatcherStops(detachedWatcherStops)
+        let resolvedPublisherIngressReports = await publisherIngressReports
+        let terminationDiagnostics = WorkspaceRootUnloadTerminationDiagnostics(
+            publisherIngressReports: resolvedPublisherIngressReports,
+            watcherStopReports: watcherStopReports
+        )
+        WorkspaceRootUnloadDiagnosticsLog.record(terminationDiagnostics)
+        #if DEBUG
+            if let rootUnloadTerminationDidCompleteHandler {
+                await rootUnloadTerminationDidCompleteHandler(terminationDiagnostics)
+            }
+        #endif
         #if DEBUG
             WorkspaceRestorePerfLog.event(
                 "store.rootUnload.stopWatchers",
@@ -2563,6 +2783,7 @@ actor WorkspaceFileContextStore {
                 scopedIngressBarrierLaunchCountsByRootID.removeValue(forKey: rootID)
                 scopedIngressBarrierJoinCountsByRootID.removeValue(forKey: rootID)
                 scopedIngressBarrierSuccessorCountsByRootID.removeValue(forKey: rootID)
+                scopedIngressBarrierCoalescedSuccessorCountsByRootID.removeValue(forKey: rootID)
                 scopedIngressBarrierCompletionCountsByRootID.removeValue(forKey: rootID)
                 lastCompletedScopedIngressBarrierByRootID.removeValue(forKey: rootID)
             #endif
@@ -2603,6 +2824,67 @@ actor WorkspaceFileContextStore {
                 ]
             )
         #endif
+    }
+
+    private func startDetachedWatcherStops(
+        _ statesToUnload: [(rootID: UUID, state: RootState)]
+    ) -> [DetachedWatcherStop] {
+        statesToUnload.enumerated().map { index, entry in
+            let completionLatch = WorkspaceRootUnloadCompletionLatch()
+            let service = entry.state.service
+            #if DEBUG
+                let watcherStopWillBeginHandler = watcherStopWillBeginHandler
+            #endif
+            let task = Task.detached {
+                #if DEBUG
+                    if let watcherStopWillBeginHandler {
+                        await watcherStopWillBeginHandler(entry.rootID)
+                    }
+                #endif
+                await service.stopWatchingForChanges()
+                completionLatch.complete()
+            }
+            return DetachedWatcherStop(
+                index: index,
+                rootID: entry.rootID,
+                rootPath: entry.state.root.standardizedFullPath,
+                completionLatch: completionLatch,
+                task: task
+            )
+        }
+    }
+
+    private func awaitDetachedWatcherStops(
+        _ stops: [DetachedWatcherStop]
+    ) async -> [WorkspaceRootWatcherStopReport] {
+        await withTaskGroup(of: (Int, WorkspaceRootWatcherStopReport).self) { group in
+            for stop in stops {
+                group.addTask { [unloadTerminationPolicy] in
+                    let outcome = await WorkspaceRootUnloadBoundedWait.waitForCompletion(
+                        stop.completionLatch,
+                        timeoutNanoseconds: unloadTerminationPolicy.watcherStopGraceNanoseconds,
+                        sleep: unloadTerminationPolicy.sleep
+                    )
+                    if outcome != .completed {
+                        stop.task.cancel()
+                    }
+                    return (
+                        stop.index,
+                        WorkspaceRootWatcherStopReport(
+                            rootID: stop.rootID,
+                            rootPath: stop.rootPath,
+                            outcome: outcome,
+                            graceNanoseconds: unloadTerminationPolicy.watcherStopGraceNanoseconds
+                        )
+                    )
+                }
+            }
+            var reports: [(Int, WorkspaceRootWatcherStopReport)] = []
+            for await report in group {
+                reports.append(report)
+            }
+            return reports.sorted { $0.0 < $1.0 }.map(\.1)
+        }
     }
 
     func file(rootID: UUID, relativePath: String) -> WorkspaceFileRecord? {
@@ -3617,14 +3899,24 @@ actor WorkspaceFileContextStore {
         private func applyPreparedIndexDeltas(
             rootID: UUID,
             deltas: [PreparedFileSystemDelta],
+            expectedLifetimeID: UUID? = nil,
             watcherAcceptedWatermark: FileSystemWatcherIngressMailbox.Watermark?,
             servicePublicationSequence: UInt64?
         ) async {
             guard let servicePublicationSequence else {
-                await applyPreparedIndexDeltasBody(rootID: rootID, deltas: deltas)
+                await applyPreparedIndexDeltasBody(
+                    rootID: rootID,
+                    deltas: deltas,
+                    expectedLifetimeID: expectedLifetimeID
+                )
                 return
             }
-            let recorder = await applyPreparedIndexDeltasRecordingInvalidations(rootID: rootID, deltas: deltas)
+            let recorder = await applyPreparedIndexDeltasRecordingInvalidations(
+                rootID: rootID,
+                deltas: deltas,
+                expectedLifetimeID: expectedLifetimeID
+            )
+            guard isRootLifetimeCurrent(rootID: rootID, expectedLifetimeID: expectedLifetimeID) else { return }
             recordPublicationInvalidationDiagnostics(
                 rootID: rootID,
                 servicePublicationSequence: servicePublicationSequence,
@@ -3635,41 +3927,68 @@ actor WorkspaceFileContextStore {
 
         private func applyPreparedIndexDeltasRecordingInvalidations(
             rootID: UUID,
-            deltas: [PreparedFileSystemDelta]
+            deltas: [PreparedFileSystemDelta],
+            expectedLifetimeID: UUID? = nil
         ) async -> PublicationInvalidationRecorder {
             let recorder = PublicationInvalidationRecorder(preparedDeltaCount: deltas.count)
             await Self.$activePublicationInvalidationRecorder.withValue(recorder) {
-                await applyPreparedIndexDeltasBody(rootID: rootID, deltas: deltas)
+                await applyPreparedIndexDeltasBody(
+                    rootID: rootID,
+                    deltas: deltas,
+                    expectedLifetimeID: expectedLifetimeID
+                )
             }
             return recorder
         }
     #else
-        private func applyPreparedIndexDeltas(rootID: UUID, deltas: [PreparedFileSystemDelta]) async {
-            await applyPreparedIndexDeltasBody(rootID: rootID, deltas: deltas)
+        private func applyPreparedIndexDeltas(
+            rootID: UUID,
+            deltas: [PreparedFileSystemDelta],
+            expectedLifetimeID: UUID? = nil
+        ) async {
+            await applyPreparedIndexDeltasBody(
+                rootID: rootID,
+                deltas: deltas,
+                expectedLifetimeID: expectedLifetimeID
+            )
         }
     #endif
 
-    private func applyPreparedIndexDeltasBody(rootID: UUID, deltas: [PreparedFileSystemDelta]) async {
-        let applicableDeltas = await preflightPreparedIndexDeltas(rootID: rootID, deltas: deltas)
+    private func applyPreparedIndexDeltasBody(
+        rootID: UUID,
+        deltas: [PreparedFileSystemDelta],
+        expectedLifetimeID: UUID? = nil
+    ) async {
+        let applicableDeltas = await preflightPreparedIndexDeltas(
+            rootID: rootID,
+            deltas: deltas,
+            expectedLifetimeID: expectedLifetimeID
+        )
+        guard isRootLifetimeCurrent(rootID: rootID, expectedLifetimeID: expectedLifetimeID) else { return }
         applyPreparedIndexDeltaMutations(rootID: rootID, deltas: applicableDeltas)
     }
 
     private func preflightPreparedIndexDeltas(
         rootID: UUID,
-        deltas: [PreparedFileSystemDelta]
+        deltas: [PreparedFileSystemDelta],
+        expectedLifetimeID: UUID? = nil
     ) async -> [PreparedFileSystemDelta] {
         var applicableDeltas: [PreparedFileSystemDelta] = []
         applicableDeltas.reserveCapacity(deltas.count)
         for prepared in deltas {
             switch prepared.delta {
             case .fileAdded:
-                guard let service = rootStatesByID[rootID]?.service,
-                      await service.catalogEligibleRegularFileExists(relativePath: prepared.relativePath)
+                guard isRootLifetimeCurrent(rootID: rootID, expectedLifetimeID: expectedLifetimeID),
+                      let service = rootStatesByID[rootID]?.service,
+                      await service.catalogEligibleRegularFileExists(relativePath: prepared.relativePath),
+                      isRootLifetimeCurrent(rootID: rootID, expectedLifetimeID: expectedLifetimeID)
                 else { continue }
                 applicableDeltas.append(prepared)
             case .folderAdded:
-                guard let service = rootStatesByID[rootID]?.service,
-                      await service.catalogFolderIsDiscoverable(relativePath: prepared.relativePath)
+                guard isRootLifetimeCurrent(rootID: rootID, expectedLifetimeID: expectedLifetimeID),
+                      let service = rootStatesByID[rootID]?.service,
+                      await service.catalogFolderIsDiscoverable(relativePath: prepared.relativePath),
+                      isRootLifetimeCurrent(rootID: rootID, expectedLifetimeID: expectedLifetimeID)
                 else { continue }
                 applicableDeltas.append(prepared)
             case .fileRemoved, .folderRemoved, .fileModified, .folderModified:
@@ -4740,6 +5059,12 @@ actor WorkspaceFileContextStore {
         for continuation in codemapUpdateContinuations.values {
             continuation.yield(event)
         }
+    }
+
+    private func isRootLifetimeCurrent(rootID: UUID, expectedLifetimeID: UUID?) -> Bool {
+        guard let state = rootStatesByID[rootID] else { return false }
+        guard let expectedLifetimeID else { return true }
+        return state.lifetimeID == expectedLifetimeID
     }
 
     private func state(for rootID: UUID) throws -> RootState {

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileSystemIngressCoordinator.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileSystemIngressCoordinator.swift
@@ -18,6 +18,28 @@ final class WorkspaceFileSystemIngressCoordinator: @unchecked Sendable {
         let appliedWatcherWatermark: FileSystemWatcherIngressMailbox.Watermark
     }
 
+    enum TerminationOutcome: String, Equatable {
+        case graceful
+        case forced
+        case missing
+        case superseded
+    }
+
+    struct TerminationReport: Equatable {
+        let rootID: UUID
+        let stateIdentity: UUID?
+        let outcome: TerminationOutcome
+        let graceNanoseconds: UInt64
+        let queuedPublicationCount: Int
+        let applyingPublicationCount: Int
+        let waiterCount: Int
+        let acceptedServicePublicationSequence: UInt64
+        let appliedServicePublicationSequence: UInt64
+        let acceptedAppliedSequenceGap: UInt64
+        let appliedWatcherWatermark: UInt64
+        let oldestOutstandingPublicationAgeMilliseconds: UInt64?
+    }
+
     #if DEBUG
         struct DebugSnapshot: Equatable {
             let isOpen: Bool
@@ -39,12 +61,11 @@ final class WorkspaceFileSystemIngressCoordinator: @unchecked Sendable {
         let publication: FileSystemDeltaPublication
         let lifecycleCorrelation: EditFlowPerf.LifecycleCorrelation?
         let drainHandler: DrainHandler
-        #if DEBUG
-            let acceptedAtNanoseconds: UInt64
-        #endif
+        let acceptedAtNanoseconds: UInt64
     }
 
     private final class RootState {
+        let identity = UUID()
         var generation: UInt64 = 0
         var isOpen = false
         var queue: [QueuedPublication] = []
@@ -56,20 +77,16 @@ final class WorkspaceFileSystemIngressCoordinator: @unchecked Sendable {
         var acceptedServicePublicationSequence: UInt64 = 0
         var appliedServicePublicationSequence: UInt64 = 0
         var appliedWatcherWatermark = FileSystemWatcherIngressMailbox.Watermark.zero
-        #if DEBUG
-            var applyingPublicationAcceptedAtNanoseconds: UInt64?
-        #endif
+        var applyingPublicationAcceptedAtNanoseconds: UInt64?
 
         var pendingQueueCount: Int {
             queue.count - queueHead
         }
 
-        #if DEBUG
-            var oldestOutstandingPublicationAcceptedAtNanoseconds: UInt64? {
-                let queued = queueHead < queue.count ? queue[queueHead].acceptedAtNanoseconds : nil
-                return [applyingPublicationAcceptedAtNanoseconds, queued].compactMap(\.self).min()
-            }
-        #endif
+        var oldestOutstandingPublicationAcceptedAtNanoseconds: UInt64? {
+            let queued = queueHead < queue.count ? queue[queueHead].acceptedAtNanoseconds : nil
+            return [applyingPublicationAcceptedAtNanoseconds, queued].compactMap(\.self).min()
+        }
 
         func append(_ publication: QueuedPublication) {
             queue.append(publication)
@@ -96,24 +113,40 @@ final class WorkspaceFileSystemIngressCoordinator: @unchecked Sendable {
     }
 
     private struct Waiter {
+        let stateIdentity: UUID
         let targetServicePublicationSequence: UInt64
         let continuation: CheckedContinuation<Void, Never>
+    }
+
+    private struct TerminationCapture {
+        let rootID: UUID
+        let stateIdentity: UUID?
+        let subscriptionGeneration: UInt64
+        let targetServicePublicationSequence: UInt64
     }
 
     private let lock = NSLock()
     private var rootStatesByID: [UUID: RootState] = [:]
     private var waitersByRootID: [UUID: [UUID: Waiter]] = [:]
     private var nextDrainToken: UInt64 = 0
+    private var nextSubscriptionGeneration: UInt64 = 0
+    private let nowNanoseconds: @Sendable () -> UInt64
     #if DEBUG
-        private let debugNowNanoseconds: @Sendable () -> UInt64
+        private let debugFinishApplyingHandler: (@Sendable (UUID, UInt64) -> Void)?
+    #endif
 
+    #if DEBUG
         init(
-            debugNowNanoseconds: @escaping @Sendable () -> UInt64 = { DispatchTime.now().uptimeNanoseconds }
+            debugNowNanoseconds: @escaping @Sendable () -> UInt64 = { DispatchTime.now().uptimeNanoseconds },
+            debugFinishApplyingHandler: (@Sendable (UUID, UInt64) -> Void)? = nil
         ) {
-            self.debugNowNanoseconds = debugNowNanoseconds
+            nowNanoseconds = debugNowNanoseconds
+            self.debugFinishApplyingHandler = debugFinishApplyingHandler
         }
     #else
-        init() {}
+        init() {
+            nowNanoseconds = { DispatchTime.now().uptimeNanoseconds }
+        }
     #endif
 
     func openPublisherIngress(rootID: UUID, drainHandler: @escaping DrainHandler) -> Subscription {
@@ -121,10 +154,11 @@ final class WorkspaceFileSystemIngressCoordinator: @unchecked Sendable {
         defer { lock.unlock() }
 
         let state = rootState(for: rootID)
-        state.generation &+= 1
+        nextSubscriptionGeneration &+= 1
+        state.generation = nextSubscriptionGeneration
         state.isOpen = true
         state.drainHandler = drainHandler
-        scheduleDrainIfNeeded(rootID: rootID)
+        scheduleDrainIfNeeded(rootID: rootID, stateIdentity: state.identity)
         return Subscription(rootID: rootID, generation: state.generation)
     }
 
@@ -133,7 +167,8 @@ final class WorkspaceFileSystemIngressCoordinator: @unchecked Sendable {
         defer { lock.unlock() }
 
         guard let state = rootStatesByID[rootID] else { return }
-        state.generation &+= 1
+        nextSubscriptionGeneration &+= 1
+        state.generation = nextSubscriptionGeneration
         state.isOpen = false
     }
 
@@ -157,9 +192,7 @@ final class WorkspaceFileSystemIngressCoordinator: @unchecked Sendable {
         publication: FileSystemDeltaPublication,
         lifecycleCorrelation: EditFlowPerf.LifecycleCorrelation?
     ) -> Bool {
-        #if DEBUG
-            let acceptedAtNanoseconds = debugNowNanoseconds()
-        #endif
+        let acceptedAtNanoseconds = nowNanoseconds()
         lock.lock()
         defer { lock.unlock() }
 
@@ -170,68 +203,96 @@ final class WorkspaceFileSystemIngressCoordinator: @unchecked Sendable {
         else {
             return false
         }
-        #if DEBUG
-            state.append(QueuedPublication(
-                publication: publication,
-                lifecycleCorrelation: lifecycleCorrelation,
-                drainHandler: drainHandler,
-                acceptedAtNanoseconds: acceptedAtNanoseconds
-            ))
-        #else
-            state.append(QueuedPublication(
-                publication: publication,
-                lifecycleCorrelation: lifecycleCorrelation,
-                drainHandler: drainHandler
-            ))
-        #endif
+        state.append(QueuedPublication(
+            publication: publication,
+            lifecycleCorrelation: lifecycleCorrelation,
+            drainHandler: drainHandler,
+            acceptedAtNanoseconds: acceptedAtNanoseconds
+        ))
         state.acceptedServicePublicationSequence = max(
             state.acceptedServicePublicationSequence,
             publication.servicePublicationSequence
         )
-        scheduleDrainIfNeeded(rootID: subscription.rootID)
+        scheduleDrainIfNeeded(rootID: subscription.rootID, stateIdentity: state.identity)
         return true
     }
 
     func waitUntilApplied(rootID: UUID, servicePublicationSequence: UInt64) async {
         guard servicePublicationSequence > 0 else { return }
-        let waiterID = UUID()
-        await withTaskCancellationHandler {
-            await withCheckedContinuation { continuation in
-                lock.lock()
-                guard !Task.isCancelled,
-                      let state = rootStatesByID[rootID],
-                      state.appliedServicePublicationSequence < servicePublicationSequence
-                else {
-                    lock.unlock()
-                    continuation.resume()
-                    return
-                }
-                waitersByRootID[rootID, default: [:]][waiterID] = Waiter(
-                    targetServicePublicationSequence: servicePublicationSequence,
-                    continuation: continuation
-                )
-                lock.unlock()
-            }
-        } onCancel: {
-            cancelWaiter(rootID: rootID, waiterID: waiterID)
-        }
+        let stateIdentity: UUID? = {
+            lock.lock()
+            defer { lock.unlock() }
+            return rootStatesByID[rootID]?.identity
+        }()
+        guard let stateIdentity else { return }
+        await waitUntilApplied(
+            rootID: rootID,
+            stateIdentity: stateIdentity,
+            servicePublicationSequence: servicePublicationSequence
+        )
     }
 
     func waitForCurrentPublisherIngress(rootIDs: Set<UUID>) async {
-        let targets: [(rootID: UUID, servicePublicationSequence: UInt64)] = {
+        let targets: [(rootID: UUID, stateIdentity: UUID, servicePublicationSequence: UInt64)] = {
             lock.lock()
             defer { lock.unlock() }
             return rootIDs.compactMap { rootID in
                 guard let state = rootStatesByID[rootID] else { return nil }
-                return (rootID, state.acceptedServicePublicationSequence)
+                return (rootID, state.identity, state.acceptedServicePublicationSequence)
             }
         }()
         for target in targets {
             guard !Task.isCancelled else { break }
             await waitUntilApplied(
                 rootID: target.rootID,
+                stateIdentity: target.stateIdentity,
                 servicePublicationSequence: target.servicePublicationSequence
             )
+        }
+    }
+
+    func terminateClosedPublisherIngress(
+        rootIDs: [UUID],
+        gracefulDrainTimeoutNanoseconds: UInt64,
+        sleep: @escaping @Sendable (UInt64) async -> Void
+    ) async -> [TerminationReport] {
+        let captures: [TerminationCapture] = {
+            lock.lock()
+            defer { lock.unlock() }
+            return rootIDs.map { rootID in
+                guard let state = rootStatesByID[rootID] else {
+                    return TerminationCapture(
+                        rootID: rootID,
+                        stateIdentity: nil,
+                        subscriptionGeneration: 0,
+                        targetServicePublicationSequence: 0
+                    )
+                }
+                return TerminationCapture(
+                    rootID: rootID,
+                    stateIdentity: state.identity,
+                    subscriptionGeneration: state.generation,
+                    targetServicePublicationSequence: state.acceptedServicePublicationSequence
+                )
+            }
+        }()
+
+        return await withTaskGroup(of: (Int, TerminationReport).self) { group in
+            for (index, capture) in captures.enumerated() {
+                group.addTask { [self] in
+                    let report = await terminateClosedPublisherIngress(
+                        capture: capture,
+                        gracefulDrainTimeoutNanoseconds: gracefulDrainTimeoutNanoseconds,
+                        sleep: sleep
+                    )
+                    return (index, report)
+                }
+            }
+            var reports: [(Int, TerminationReport)] = []
+            for await report in group {
+                reports.append(report)
+            }
+            return reports.sorted { $0.0 < $1.0 }.map(\.1)
         }
     }
 
@@ -263,7 +324,7 @@ final class WorkspaceFileSystemIngressCoordinator: @unchecked Sendable {
 
     #if DEBUG
         func debugSnapshot(rootID: UUID) -> DebugSnapshot {
-            let now = debugNowNanoseconds()
+            let now = nowNanoseconds()
             lock.lock()
             defer { lock.unlock() }
             guard let state = rootStatesByID[rootID] else {
@@ -280,29 +341,18 @@ final class WorkspaceFileSystemIngressCoordinator: @unchecked Sendable {
                     oldestOutstandingPublicationAgeMilliseconds: nil
                 )
             }
-            let gap = state.acceptedServicePublicationSequence >= state.appliedServicePublicationSequence
-                ? state.acceptedServicePublicationSequence - state.appliedServicePublicationSequence
-                : 0
-            let oldestAge = state.oldestOutstandingPublicationAcceptedAtNanoseconds.map { acceptedAt in
-                Self.elapsedMilliseconds(since: acceptedAt, now: now)
-            }
             return DebugSnapshot(
                 isOpen: state.isOpen,
                 queuedPublicationCount: state.pendingQueueCount,
                 applyingPublicationCount: state.applyingCount,
                 outstandingPublicationCount: state.pendingQueueCount + state.applyingCount,
-                waiterCount: waitersByRootID[rootID]?.count ?? 0,
+                waiterCount: waiterCount(rootID: rootID, stateIdentity: state.identity),
                 acceptedServicePublicationSequence: state.acceptedServicePublicationSequence,
                 appliedServicePublicationSequence: state.appliedServicePublicationSequence,
-                acceptedAppliedSequenceGap: gap,
+                acceptedAppliedSequenceGap: acceptedAppliedSequenceGap(state),
                 appliedWatcherWatermark: state.appliedWatcherWatermark.rawValue,
-                oldestOutstandingPublicationAgeMilliseconds: oldestAge
+                oldestOutstandingPublicationAgeMilliseconds: oldestOutstandingAgeMilliseconds(state, now: now)
             )
-        }
-
-        private static func elapsedMilliseconds(since start: UInt64, now: UInt64) -> UInt64 {
-            guard now >= start else { return 0 }
-            return (now - start) / 1_000_000
         }
     #endif
 
@@ -316,10 +366,175 @@ final class WorkspaceFileSystemIngressCoordinator: @unchecked Sendable {
                   state.applyingCount == 0
             else { continue }
             rootStatesByID.removeValue(forKey: rootID)
-            continuations.append(contentsOf: (waitersByRootID.removeValue(forKey: rootID) ?? [:]).values.map(\.continuation))
+            continuations.append(contentsOf: removeWaiters(rootID: rootID, stateIdentity: state.identity))
         }
         lock.unlock()
         continuations.forEach { $0.resume() }
+    }
+
+    private func waitUntilApplied(
+        rootID: UUID,
+        stateIdentity: UUID,
+        servicePublicationSequence: UInt64
+    ) async {
+        guard servicePublicationSequence > 0 else { return }
+        let waiterID = UUID()
+        await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                lock.lock()
+                guard !Task.isCancelled,
+                      let state = rootStatesByID[rootID],
+                      state.identity == stateIdentity,
+                      state.appliedServicePublicationSequence < servicePublicationSequence
+                else {
+                    lock.unlock()
+                    continuation.resume()
+                    return
+                }
+                waitersByRootID[rootID, default: [:]][waiterID] = Waiter(
+                    stateIdentity: stateIdentity,
+                    targetServicePublicationSequence: servicePublicationSequence,
+                    continuation: continuation
+                )
+                lock.unlock()
+            }
+        } onCancel: {
+            cancelWaiter(rootID: rootID, waiterID: waiterID)
+        }
+    }
+
+    private func terminateClosedPublisherIngress(
+        capture: TerminationCapture,
+        gracefulDrainTimeoutNanoseconds: UInt64,
+        sleep: @escaping @Sendable (UInt64) async -> Void
+    ) async -> TerminationReport {
+        guard let stateIdentity = capture.stateIdentity else {
+            return emptyTerminationReport(
+                rootID: capture.rootID,
+                outcome: .missing,
+                graceNanoseconds: gracefulDrainTimeoutNanoseconds
+            )
+        }
+
+        let gracefulCompleted = await withTaskGroup(of: Bool.self) { group in
+            group.addTask { [self] in
+                await waitUntilApplied(
+                    rootID: capture.rootID,
+                    stateIdentity: stateIdentity,
+                    servicePublicationSequence: capture.targetServicePublicationSequence
+                )
+                return true
+            }
+            group.addTask {
+                await sleep(gracefulDrainTimeoutNanoseconds)
+                return false
+            }
+            let result = await group.next() ?? false
+            group.cancelAll()
+            return result
+        }
+
+        if gracefulCompleted,
+           let report = finishGracefulTermination(
+               rootID: capture.rootID,
+               stateIdentity: stateIdentity,
+               subscriptionGeneration: capture.subscriptionGeneration,
+               graceNanoseconds: gracefulDrainTimeoutNanoseconds
+           )
+        {
+            return report
+        }
+        return forceTermination(
+            rootID: capture.rootID,
+            stateIdentity: stateIdentity,
+            subscriptionGeneration: capture.subscriptionGeneration,
+            graceNanoseconds: gracefulDrainTimeoutNanoseconds
+        )
+    }
+
+    private func finishGracefulTermination(
+        rootID: UUID,
+        stateIdentity: UUID,
+        subscriptionGeneration: UInt64,
+        graceNanoseconds: UInt64
+    ) -> TerminationReport? {
+        let report: TerminationReport
+        let continuations: [CheckedContinuation<Void, Never>]
+        lock.lock()
+        guard let state = rootStatesByID[rootID] else {
+            lock.unlock()
+            return emptyTerminationReport(rootID: rootID, outcome: .superseded, graceNanoseconds: graceNanoseconds)
+        }
+        guard state.identity == stateIdentity,
+              state.generation == subscriptionGeneration,
+              !state.isOpen
+        else {
+            report = makeTerminationReport(
+                rootID: rootID,
+                state: state,
+                outcome: .superseded,
+                graceNanoseconds: graceNanoseconds
+            )
+            lock.unlock()
+            return report
+        }
+        guard state.pendingQueueCount == 0, state.applyingCount == 0 else {
+            lock.unlock()
+            return nil
+        }
+        report = makeTerminationReport(
+            rootID: rootID,
+            state: state,
+            outcome: .graceful,
+            graceNanoseconds: graceNanoseconds
+        )
+        rootStatesByID.removeValue(forKey: rootID)
+        continuations = removeWaiters(rootID: rootID, stateIdentity: stateIdentity)
+        lock.unlock()
+        continuations.forEach { $0.resume() }
+        return report
+    }
+
+    private func forceTermination(
+        rootID: UUID,
+        stateIdentity: UUID,
+        subscriptionGeneration: UInt64,
+        graceNanoseconds: UInt64
+    ) -> TerminationReport {
+        let report: TerminationReport
+        let continuations: [CheckedContinuation<Void, Never>]
+        let drainTask: Task<Void, Never>?
+        lock.lock()
+        guard let state = rootStatesByID[rootID] else {
+            lock.unlock()
+            return emptyTerminationReport(rootID: rootID, outcome: .superseded, graceNanoseconds: graceNanoseconds)
+        }
+        guard state.identity == stateIdentity,
+              state.generation == subscriptionGeneration,
+              !state.isOpen
+        else {
+            report = makeTerminationReport(
+                rootID: rootID,
+                state: state,
+                outcome: .superseded,
+                graceNanoseconds: graceNanoseconds
+            )
+            lock.unlock()
+            return report
+        }
+        report = makeTerminationReport(
+            rootID: rootID,
+            state: state,
+            outcome: .forced,
+            graceNanoseconds: graceNanoseconds
+        )
+        rootStatesByID.removeValue(forKey: rootID)
+        continuations = removeWaiters(rootID: rootID, stateIdentity: stateIdentity)
+        drainTask = state.drainTask
+        lock.unlock()
+        drainTask?.cancel()
+        continuations.forEach { $0.resume() }
+        return report
     }
 
     private func rootState(for rootID: UUID) -> RootState {
@@ -329,8 +544,9 @@ final class WorkspaceFileSystemIngressCoordinator: @unchecked Sendable {
         return state
     }
 
-    private func scheduleDrainIfNeeded(rootID: UUID) {
+    private func scheduleDrainIfNeeded(rootID: UUID, stateIdentity: UUID) {
         guard let state = rootStatesByID[rootID],
+              state.identity == stateIdentity,
               state.drainTask == nil,
               state.pendingQueueCount > 0
         else { return }
@@ -338,32 +554,46 @@ final class WorkspaceFileSystemIngressCoordinator: @unchecked Sendable {
         let token = nextDrainToken
         state.activeDrainToken = token
         state.drainTask = Task { [self] in
-            await drain(rootID: rootID, token: token)
+            await drain(rootID: rootID, stateIdentity: stateIdentity, token: token)
         }
     }
 
-    private func drain(rootID: UUID, token: UInt64) async {
-        while let queued = takeNextPublication(rootID: rootID) {
+    private func drain(rootID: UUID, stateIdentity: UUID, token: UInt64) async {
+        while let queued = takeNextPublication(rootID: rootID, stateIdentity: stateIdentity, token: token) {
             await queued.drainHandler(queued.publication, queued.lifecycleCorrelation)
-            finishApplying(rootID: rootID, publication: queued.publication)
+            finishApplying(
+                rootID: rootID,
+                stateIdentity: stateIdentity,
+                token: token,
+                publication: queued.publication
+            )
         }
+        finishDrain(rootID: rootID, stateIdentity: stateIdentity, token: token)
+    }
+
+    private func finishDrain(rootID: UUID, stateIdentity: UUID, token: UInt64) {
         lock.lock()
-        if let state = rootStatesByID[rootID], state.activeDrainToken == token {
+        if let state = rootStatesByID[rootID],
+           state.identity == stateIdentity,
+           state.activeDrainToken == token
+        {
             state.drainTask = nil
             state.activeDrainToken = nil
-            scheduleDrainIfNeeded(rootID: rootID)
+            scheduleDrainIfNeeded(rootID: rootID, stateIdentity: stateIdentity)
         }
         lock.unlock()
     }
 
-    private func takeNextPublication(rootID: UUID) -> QueuedPublication? {
+    private func takeNextPublication(rootID: UUID, stateIdentity: UUID, token: UInt64) -> QueuedPublication? {
         lock.lock()
         defer { lock.unlock() }
-        guard let state = rootStatesByID[rootID], let queued = state.takeNextPublication() else { return nil }
+        guard let state = rootStatesByID[rootID],
+              state.identity == stateIdentity,
+              state.activeDrainToken == token,
+              let queued = state.takeNextPublication()
+        else { return nil }
         state.applyingCount += 1
-        #if DEBUG
-            state.applyingPublicationAcceptedAtNanoseconds = queued.acceptedAtNanoseconds
-        #endif
+        state.applyingPublicationAcceptedAtNanoseconds = queued.acceptedAtNanoseconds
         return queued
     }
 
@@ -378,14 +608,20 @@ final class WorkspaceFileSystemIngressCoordinator: @unchecked Sendable {
         continuation?.resume()
     }
 
-    private func finishApplying(rootID: UUID, publication: FileSystemDeltaPublication) {
+    private func finishApplying(
+        rootID: UUID,
+        stateIdentity: UUID,
+        token: UInt64,
+        publication: FileSystemDeltaPublication
+    ) {
         var continuations: [CheckedContinuation<Void, Never>] = []
         lock.lock()
-        if let state = rootStatesByID[rootID] {
+        if let state = rootStatesByID[rootID],
+           state.identity == stateIdentity,
+           state.activeDrainToken == token
+        {
             state.applyingCount = max(0, state.applyingCount - 1)
-            #if DEBUG
-                state.applyingPublicationAcceptedAtNanoseconds = nil
-            #endif
+            state.applyingPublicationAcceptedAtNanoseconds = nil
             state.appliedServicePublicationSequence = max(
                 state.appliedServicePublicationSequence,
                 publication.servicePublicationSequence
@@ -396,6 +632,7 @@ final class WorkspaceFileSystemIngressCoordinator: @unchecked Sendable {
             if var waiters = waitersByRootID[rootID] {
                 for waiterID in Array(waiters.keys) {
                     guard let waiter = waiters[waiterID],
+                          waiter.stateIdentity == stateIdentity,
                           waiter.targetServicePublicationSequence <= state.appliedServicePublicationSequence
                     else { continue }
                     waiters.removeValue(forKey: waiterID)
@@ -410,5 +647,90 @@ final class WorkspaceFileSystemIngressCoordinator: @unchecked Sendable {
         }
         lock.unlock()
         continuations.forEach { $0.resume() }
+        #if DEBUG
+            debugFinishApplyingHandler?(rootID, publication.servicePublicationSequence)
+        #endif
+    }
+
+    private func removeWaiters(rootID: UUID, stateIdentity: UUID) -> [CheckedContinuation<Void, Never>] {
+        guard var waiters = waitersByRootID[rootID] else { return [] }
+        var continuations: [CheckedContinuation<Void, Never>] = []
+        for waiterID in Array(waiters.keys) {
+            guard let waiter = waiters[waiterID], waiter.stateIdentity == stateIdentity else { continue }
+            waiters.removeValue(forKey: waiterID)
+            continuations.append(waiter.continuation)
+        }
+        if waiters.isEmpty {
+            waitersByRootID.removeValue(forKey: rootID)
+        } else {
+            waitersByRootID[rootID] = waiters
+        }
+        return continuations
+    }
+
+    private func waiterCount(rootID: UUID, stateIdentity: UUID) -> Int {
+        waitersByRootID[rootID]?.values.count(where: { $0.stateIdentity == stateIdentity }) ?? 0
+    }
+
+    private func makeTerminationReport(
+        rootID: UUID,
+        state: RootState,
+        outcome: TerminationOutcome,
+        graceNanoseconds: UInt64
+    ) -> TerminationReport {
+        TerminationReport(
+            rootID: rootID,
+            stateIdentity: state.identity,
+            outcome: outcome,
+            graceNanoseconds: graceNanoseconds,
+            queuedPublicationCount: state.pendingQueueCount,
+            applyingPublicationCount: state.applyingCount,
+            waiterCount: waiterCount(rootID: rootID, stateIdentity: state.identity),
+            acceptedServicePublicationSequence: state.acceptedServicePublicationSequence,
+            appliedServicePublicationSequence: state.appliedServicePublicationSequence,
+            acceptedAppliedSequenceGap: acceptedAppliedSequenceGap(state),
+            appliedWatcherWatermark: state.appliedWatcherWatermark.rawValue,
+            oldestOutstandingPublicationAgeMilliseconds: oldestOutstandingAgeMilliseconds(
+                state,
+                now: nowNanoseconds()
+            )
+        )
+    }
+
+    private func emptyTerminationReport(
+        rootID: UUID,
+        outcome: TerminationOutcome,
+        graceNanoseconds: UInt64
+    ) -> TerminationReport {
+        TerminationReport(
+            rootID: rootID,
+            stateIdentity: nil,
+            outcome: outcome,
+            graceNanoseconds: graceNanoseconds,
+            queuedPublicationCount: 0,
+            applyingPublicationCount: 0,
+            waiterCount: 0,
+            acceptedServicePublicationSequence: 0,
+            appliedServicePublicationSequence: 0,
+            acceptedAppliedSequenceGap: 0,
+            appliedWatcherWatermark: 0,
+            oldestOutstandingPublicationAgeMilliseconds: nil
+        )
+    }
+
+    private func acceptedAppliedSequenceGap(_ state: RootState) -> UInt64 {
+        guard state.acceptedServicePublicationSequence >= state.appliedServicePublicationSequence else { return 0 }
+        return state.acceptedServicePublicationSequence - state.appliedServicePublicationSequence
+    }
+
+    private func oldestOutstandingAgeMilliseconds(_ state: RootState, now: UInt64) -> UInt64? {
+        state.oldestOutstandingPublicationAcceptedAtNanoseconds.map { acceptedAt in
+            Self.elapsedMilliseconds(since: acceptedAt, now: now)
+        }
+    }
+
+    private static func elapsedMilliseconds(since start: UInt64, now: UInt64) -> UInt64 {
+        guard now >= start else { return 0 }
+        return (now - start) / 1_000_000
     }
 }

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceRootUnloadTermination.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceRootUnloadTermination.swift
@@ -1,0 +1,140 @@
+import Foundation
+import os
+
+struct WorkspaceRootUnloadTerminationPolicy: @unchecked Sendable {
+    static let productionGraceNanoseconds: UInt64 = 5_000_000_000
+
+    static let production = WorkspaceRootUnloadTerminationPolicy(
+        publisherIngressGraceNanoseconds: productionGraceNanoseconds,
+        watcherStopGraceNanoseconds: productionGraceNanoseconds,
+        sleep: { nanoseconds in
+            try? await Task.sleep(nanoseconds: nanoseconds)
+        }
+    )
+
+    let publisherIngressGraceNanoseconds: UInt64
+    let watcherStopGraceNanoseconds: UInt64
+    let sleep: @Sendable (UInt64) async -> Void
+}
+
+enum WorkspaceRootWatcherStopOutcome: String, Equatable {
+    case completed
+    case cancelled
+    case timedOut
+}
+
+struct WorkspaceRootWatcherStopReport: Equatable {
+    let rootID: UUID
+    let rootPath: String
+    let outcome: WorkspaceRootWatcherStopOutcome
+    let graceNanoseconds: UInt64
+}
+
+struct WorkspaceRootUnloadTerminationDiagnostics: Equatable {
+    let publisherIngressReports: [WorkspaceFileSystemIngressCoordinator.TerminationReport]
+    let watcherStopReports: [WorkspaceRootWatcherStopReport]
+}
+
+final class WorkspaceRootUnloadCompletionLatch: @unchecked Sendable {
+    private let lock = NSLock()
+    private var isCompleted = false
+    private var waiters: [UUID: CheckedContinuation<WorkspaceRootWatcherStopOutcome, Never>] = [:]
+    private var cancelledWaiterIDs = Set<UUID>()
+
+    func complete() {
+        let continuations: [CheckedContinuation<WorkspaceRootWatcherStopOutcome, Never>]
+        lock.lock()
+        guard !isCompleted else {
+            lock.unlock()
+            return
+        }
+        isCompleted = true
+        continuations = Array(waiters.values)
+        waiters.removeAll(keepingCapacity: false)
+        lock.unlock()
+        continuations.forEach { $0.resume(returning: .completed) }
+    }
+
+    func resolvedOutcome(after provisionalOutcome: WorkspaceRootWatcherStopOutcome) -> WorkspaceRootWatcherStopOutcome {
+        lock.lock()
+        defer { lock.unlock() }
+        return isCompleted ? .completed : provisionalOutcome
+    }
+
+    func wait() async -> WorkspaceRootWatcherStopOutcome {
+        let waiterID = UUID()
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                lock.lock()
+                if cancelledWaiterIDs.remove(waiterID) != nil {
+                    lock.unlock()
+                    continuation.resume(returning: .cancelled)
+                } else if isCompleted {
+                    lock.unlock()
+                    continuation.resume(returning: .completed)
+                } else if Task.isCancelled {
+                    lock.unlock()
+                    continuation.resume(returning: .cancelled)
+                } else {
+                    waiters[waiterID] = continuation
+                    lock.unlock()
+                }
+            }
+        } onCancel: {
+            cancel(waiterID: waiterID)
+        }
+    }
+
+    private func cancel(waiterID: UUID) {
+        let continuation: CheckedContinuation<WorkspaceRootWatcherStopOutcome, Never>?
+        lock.lock()
+        continuation = waiters.removeValue(forKey: waiterID)
+        if continuation == nil, !isCompleted {
+            cancelledWaiterIDs.insert(waiterID)
+        }
+        lock.unlock()
+        continuation?.resume(returning: .cancelled)
+    }
+}
+
+enum WorkspaceRootUnloadBoundedWait {
+    static func waitForCompletion(
+        _ latch: WorkspaceRootUnloadCompletionLatch,
+        timeoutNanoseconds: UInt64,
+        sleep: @escaping @Sendable (UInt64) async -> Void
+    ) async -> WorkspaceRootWatcherStopOutcome {
+        await withTaskGroup(of: WorkspaceRootWatcherStopOutcome.self) { group in
+            group.addTask {
+                await latch.wait()
+            }
+            group.addTask {
+                await sleep(timeoutNanoseconds)
+                return Task.isCancelled ? .cancelled : .timedOut
+            }
+            let provisionalOutcome = await group.next() ?? .cancelled
+            group.cancelAll()
+            while await group.next() != nil {}
+            return latch.resolvedOutcome(after: provisionalOutcome)
+        }
+    }
+}
+
+enum WorkspaceRootUnloadDiagnosticsLog {
+    private static let logger = Logger(
+        subsystem: "com.repoprompt.workspace",
+        category: "RootUnloadTermination"
+    )
+
+    static func record(_ diagnostics: WorkspaceRootUnloadTerminationDiagnostics) {
+        for report in diagnostics.publisherIngressReports where report.outcome == .forced || report.outcome == .superseded {
+            logger.fault(
+                "Publisher ingress termination root=\(report.rootID.uuidString, privacy: .public) outcome=\(report.outcome.rawValue, privacy: .public) graceNs=\(report.graceNanoseconds, privacy: .public) accepted=\(report.acceptedServicePublicationSequence, privacy: .public) applied=\(report.appliedServicePublicationSequence, privacy: .public) gap=\(report.acceptedAppliedSequenceGap, privacy: .public) queued=\(report.queuedPublicationCount, privacy: .public) applying=\(report.applyingPublicationCount, privacy: .public) waiters=\(report.waiterCount, privacy: .public) oldestMs=\(report.oldestOutstandingPublicationAgeMilliseconds ?? 0, privacy: .public)"
+            )
+        }
+        for report in diagnostics.watcherStopReports where report.outcome == .timedOut {
+            logger.fault(
+                "Watcher stop timed out root=\(report.rootID.uuidString, privacy: .public) path=\(report.rootPath, privacy: .private(mask: .hash)) graceNs=\(report.graceNanoseconds, privacy: .public); caller continued without claiming synchronous FSEvents interruption"
+            )
+        }
+    }
+}

--- a/Sources/RepoPromptShared/MCP/MCPTimeoutPolicy.swift
+++ b/Sources/RepoPromptShared/MCP/MCPTimeoutPolicy.swift
@@ -6,8 +6,18 @@ public enum MCPTimeoutPolicy {
     public static let boundedToolExecutionDeadlineSeconds = 30
     public static let boundedToolExecutionDeadline: Duration = .seconds(boundedToolExecutionDeadlineSeconds)
 
+    public static let workspaceSwitchToolExecutionDeadlineSeconds = 120
+    public static let workspaceSwitchToolExecutionDeadline: Duration = .seconds(
+        workspaceSwitchToolExecutionDeadlineSeconds
+    )
+
     public static let boundedToolCancellationCleanupGraceSeconds = 5
     public static let boundedToolCancellationCleanupGrace: Duration = .seconds(boundedToolCancellationCleanupGraceSeconds)
+
+    public static let bootstrapReplacementPredecessorStopGraceSeconds = 5
+    public static let bootstrapReplacementPredecessorStopGrace: Duration = .seconds(
+        bootstrapReplacementPredecessorStopGraceSeconds
+    )
 
     public static let responseSendDeadlineSeconds = 30
     public static let responseSendDeadline: Duration = .seconds(responseSendDeadlineSeconds)

--- a/Tests/RepoPromptTests/Diagnostics/MCPToolDurationInventoryTests.swift
+++ b/Tests/RepoPromptTests/Diagnostics/MCPToolDurationInventoryTests.swift
@@ -33,6 +33,10 @@ import XCTest
                 Double(MCPTimeoutPolicy.boundedToolCancellationCleanupGraceSeconds)
             )
             XCTAssertEqual(
+                MCPToolDurationInventory.workspaceSwitchExecutionDeadlineSeconds,
+                Double(MCPTimeoutPolicy.workspaceSwitchToolExecutionDeadlineSeconds)
+            )
+            XCTAssertEqual(
                 MCPToolDurationInventory.preservedLongSynchronousToolNames,
                 [
                     MCPWindowToolName.search,
@@ -90,6 +94,35 @@ import XCTest
                 manageWorktree?.semanticWaitMaximumSeconds,
                 MCPTimeoutPolicy.worktreeMergeApprovalTimeoutSeconds
             )
+            let manageWorkspaces = try? XCTUnwrap(MCPToolDurationInventory.entries.first {
+                $0.toolName == MCPGlobalToolName.manageWorkspaces
+            })
+            XCTAssertEqual(manageWorkspaces?.contractKind, .workspaceLifecycleCancellable)
+            XCTAssertNil(manageWorkspaces?.executionDeadlineSeconds)
+            XCTAssertNil(manageWorkspaces?.cleanupGraceSeconds)
+            XCTAssertEqual(
+                manageWorkspaces?.conditionalExecutionOverrides,
+                [
+                    .init(
+                        action: "switch",
+                        condition: "always",
+                        executionDeadlineSeconds: Double(MCPTimeoutPolicy.workspaceSwitchToolExecutionDeadlineSeconds),
+                        cleanupGraceSeconds: Double(MCPTimeoutPolicy.boundedToolCancellationCleanupGraceSeconds)
+                    ),
+                    .init(
+                        action: "create",
+                        condition: "switch_to_created omitted or true",
+                        executionDeadlineSeconds: Double(MCPTimeoutPolicy.workspaceSwitchToolExecutionDeadlineSeconds),
+                        cleanupGraceSeconds: Double(MCPTimeoutPolicy.boundedToolCancellationCleanupGraceSeconds)
+                    ),
+                    .init(
+                        action: "delete",
+                        condition: "close_window == true",
+                        executionDeadlineSeconds: Double(MCPTimeoutPolicy.workspaceSwitchToolExecutionDeadlineSeconds),
+                        cleanupGraceSeconds: Double(MCPTimeoutPolicy.boundedToolCancellationCleanupGraceSeconds)
+                    )
+                ]
+            )
             for toolName in [
                 MCPWindowToolName.askUser,
                 MCPWindowToolName.waitForNextInstruction,
@@ -129,6 +162,10 @@ import XCTest
                 (payload["bounded_cleanup_grace_seconds"] as? NSNumber)?.intValue,
                 MCPTimeoutPolicy.boundedToolCancellationCleanupGraceSeconds
             )
+            XCTAssertEqual(
+                (payload["workspace_switch_execution_deadline_seconds"] as? NSNumber)?.intValue,
+                MCPTimeoutPolicy.workspaceSwitchToolExecutionDeadlineSeconds
+            )
             XCTAssertEqual(payload["timeout_scope"] as? String, "per_mcp_server")
             XCTAssertEqual(payload["per_tool_timeout_overrides_supported"] as? Bool, false)
             XCTAssertEqual(payload["intentional_phase_b3_deviation"] as? Bool, true)
@@ -154,7 +191,28 @@ import XCTest
                     MCPWindowToolName.manageWorktree
                 ]
             )
-            XCTAssertEqual((payload["tools"] as? [[String: Any]])?.count, 26)
+            let tools = try XCTUnwrap(payload["tools"] as? [[String: Any]])
+            XCTAssertEqual(tools.count, 26)
+            let manageWorkspaces = try XCTUnwrap(tools.first {
+                $0["tool"] as? String == MCPGlobalToolName.manageWorkspaces
+            })
+            XCTAssertEqual(
+                manageWorkspaces["execution_contract"] as? String,
+                MCPToolExecutionContract.Kind.workspaceLifecycleCancellable.rawValue
+            )
+            XCTAssertNil(manageWorkspaces["execution_deadline_seconds"])
+            let conditionalOverrides = try XCTUnwrap(
+                manageWorkspaces["conditional_execution_overrides"] as? [[String: Any]]
+            )
+            XCTAssertEqual(conditionalOverrides.map { $0["action"] as? String }, ["switch", "create", "delete"])
+            XCTAssertEqual(
+                conditionalOverrides.map { ($0["execution_deadline_seconds"] as? NSNumber)?.intValue },
+                [120, 120, 120]
+            )
+            XCTAssertEqual(
+                conditionalOverrides.map { $0["condition"] as? String },
+                ["always", "switch_to_created omitted or true", "close_window == true"]
+            )
 
             for forbiddenKey in [
                 "prompt_text",

--- a/Tests/RepoPromptTests/Diagnostics/MCPToolDurationInventoryTests.swift
+++ b/Tests/RepoPromptTests/Diagnostics/MCPToolDurationInventoryTests.swift
@@ -111,7 +111,7 @@ import XCTest
                     ),
                     .init(
                         action: "create",
-                        condition: "switch_to_created omitted or true",
+                        condition: "switch_to_created != false (handler default)",
                         executionDeadlineSeconds: Double(MCPTimeoutPolicy.workspaceSwitchToolExecutionDeadlineSeconds),
                         cleanupGraceSeconds: Double(MCPTimeoutPolicy.boundedToolCancellationCleanupGraceSeconds)
                     ),
@@ -211,7 +211,7 @@ import XCTest
             )
             XCTAssertEqual(
                 conditionalOverrides.map { $0["condition"] as? String },
-                ["always", "switch_to_created omitted or true", "close_window == true"]
+                ["always", "switch_to_created != false (handler default)", "close_window == true"]
             )
 
             for forbiddenKey in [

--- a/Tests/RepoPromptTests/MCP/Control/AsyncLimiterTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/AsyncLimiterTests.swift
@@ -288,16 +288,22 @@ import XCTest
                     await ordinaryGate.markStartedAndWaitForRelease()
                 }
             }
-            let fileSearchHolder = Task {
-                try await manager.withConnectionCallPermitForTesting(
-                    connectionID: connectionID,
-                    lane: .fileSearch
-                ) {
-                    await fileSearchGate.markStartedAndWaitForRelease()
+            // Saturate the burst-capacity file-search lane so the next call queues.
+            let fileSearchHolders = (0 ..< ServerNetworkManager.fileSearchCallLaneLimit).map { _ in
+                Task {
+                    try await manager.withConnectionCallPermitForTesting(
+                        connectionID: connectionID,
+                        lane: .fileSearch
+                    ) {
+                        await fileSearchGate.markStartedAndWaitForRelease()
+                    }
                 }
             }
             await assertStarted(ordinaryGate, description: "ordinary holder")
             await assertStarted(fileSearchGate, description: "file-search holder")
+            let saturatedSearchSnapshot = await waitForSnapshot(of: fileSearch) {
+                $0.activePermitCount == ServerNetworkManager.fileSearchCallLaneLimit
+            }
 
             let queuedSearch = Task {
                 try await manager.withConnectionCallPermitForTesting(
@@ -310,13 +316,15 @@ import XCTest
             let queuedSearchSnapshot = await waitForSnapshot(of: fileSearch) {
                 $0.waiterCount == 1
             }
-            guard queuedSearchSnapshot != nil else {
-                XCTFail("Timed out waiting for the queued file-search call")
+            guard saturatedSearchSnapshot != nil, queuedSearchSnapshot != nil else {
+                XCTFail("Timed out waiting for the saturated lane and queued file-search call")
                 queuedSearch.cancel()
                 await ordinaryGate.release()
                 await fileSearchGate.release()
                 await assertSuccess(ordinaryHolder)
-                await assertSuccess(fileSearchHolder)
+                for holder in fileSearchHolders {
+                    await assertSuccess(holder)
+                }
                 await assertCancellation(queuedSearch)
                 window.beginClose()
                 await window.tearDown()
@@ -362,7 +370,9 @@ import XCTest
                 await ordinaryGate.release()
                 await fileSearchGate.release()
                 await assertSuccess(ordinaryHolder)
-                await assertSuccess(fileSearchHolder)
+                for holder in fileSearchHolders {
+                    await assertSuccess(holder)
+                }
                 await assertCompletion(stopTask, description: "server stop")
                 await assertCancellation(queuedSearch)
                 window.beginClose()
@@ -379,7 +389,7 @@ import XCTest
             XCTAssertTrue(ordinaryClosed.isClosed)
             XCTAssertTrue(fileSearchClosed.isClosed)
             XCTAssertEqual(ordinaryClosed.activePermitCount, 1)
-            XCTAssertEqual(fileSearchClosed.activePermitCount, 1)
+            XCTAssertEqual(fileSearchClosed.activePermitCount, ServerNetworkManager.fileSearchCallLaneLimit)
             XCTAssertEqual(fileSearchClosed.waiterCount, 0)
             XCTAssertEqual(fileSearchClosed.cancelledWaiterCount, 1)
             await assertCancellation(queuedSearch)
@@ -389,7 +399,9 @@ import XCTest
             await ordinaryGate.release()
             await fileSearchGate.release()
             await assertSuccess(ordinaryHolder)
-            await assertSuccess(fileSearchHolder)
+            for holder in fileSearchHolders {
+                await assertSuccess(holder)
+            }
             await assertCompletion(stopTask, description: "server stop")
 
             let registeredOrdinary = await manager.connectionLimiterSnapshotForTesting(
@@ -3935,7 +3947,7 @@ import XCTest
             file: StaticString = #filePath,
             line: UInt = #line
         ) {
-            XCTAssertEqual(snapshot.permits, 1, file: file, line: line)
+            XCTAssertEqual(snapshot.permits, snapshot.limit, file: file, line: line)
             XCTAssertEqual(snapshot.activePermitCount, 0, file: file, line: line)
             XCTAssertEqual(snapshot.waiterCount, 0, file: file, line: line)
             XCTAssertEqual(snapshot.inFlight, 0, file: file, line: line)

--- a/Tests/RepoPromptTests/MCP/Control/AsyncLimiterTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/AsyncLimiterTests.swift
@@ -1,5 +1,7 @@
 import Foundation
+import MCP
 @testable import RepoPrompt
+import RepoPromptShared
 import XCTest
 
 #if DEBUG
@@ -175,9 +177,3749 @@ import XCTest
             assertIdle(settled, cancelledWaiterCount: 1, isClosed: true)
         }
 
-        private func assertCancellation(_ task: Task<Void, Error>, file: StaticString = #filePath, line: UInt = #line) async {
+        func testConnectionRemovalClosesBothCallLanesAndSearchPreventsEviction() async throws {
+            let manager = ServerNetworkManager.shared
+            let connectionID = UUID()
+            let ordinary = await manager.debugInstallConnectionLimiterForTesting(connectionID: connectionID)
+            let installedFileSearch = await manager.limiter(for: connectionID, lane: .fileSearch)
+            let fileSearch = try XCTUnwrap(installedFileSearch)
+            let ordinaryGate = LimiterTestGate()
+            let fileSearchGate = LimiterTestGate()
+
+            let fileSearchHolder = Task {
+                try await manager.withConnectionCallPermitForTesting(
+                    connectionID: connectionID,
+                    lane: .fileSearch
+                ) {
+                    await fileSearchGate.markStartedAndWaitForRelease()
+                }
+            }
+            await assertStarted(fileSearchGate, description: "file-search holder")
+            let searchIsInFlight = await manager.hasInFlightCalls(for: connectionID)
+            let searchConnectionIsEvictable = await manager.connectionIsEvictableForTesting(connectionID)
+            XCTAssertTrue(searchIsInFlight)
+            XCTAssertFalse(searchConnectionIsEvictable)
+
+            let ordinaryHolder = Task {
+                try await manager.withConnectionCallPermitForTesting(
+                    connectionID: connectionID,
+                    lane: .ordinary
+                ) {
+                    await ordinaryGate.markStartedAndWaitForRelease()
+                }
+            }
+            await assertStarted(ordinaryGate, description: "ordinary holder")
+
+            let removal = Task {
+                await manager.debugRemoveConnection(connectionID)
+            }
+            async let ordinaryClosedObservation = waitForSnapshot(of: ordinary) { $0.isClosed }
+            async let fileSearchClosedObservation = waitForSnapshot(of: fileSearch) { $0.isClosed }
+            let (ordinaryClosed, fileSearchClosed) = await (
+                ordinaryClosedObservation,
+                fileSearchClosedObservation
+            )
+
+            XCTAssertNotNil(ordinaryClosed, "Timed out waiting for the ordinary lane to close")
+            XCTAssertNotNil(fileSearchClosed, "Timed out waiting for the file-search lane to close")
+            XCTAssertEqual(ordinaryClosed?.activePermitCount, 1)
+            XCTAssertEqual(fileSearchClosed?.activePermitCount, 1)
+            let registeredOrdinary = await manager.connectionLimiterSnapshotForTesting(
+                connectionID: connectionID,
+                lane: .ordinary
+            )
+            let registeredFileSearch = await manager.connectionLimiterSnapshotForTesting(
+                connectionID: connectionID,
+                lane: .fileSearch
+            )
+            XCTAssertNil(registeredOrdinary)
+            XCTAssertNil(registeredFileSearch)
+
+            await ordinaryGate.release()
+            await fileSearchGate.release()
+            await assertSuccess(ordinaryHolder)
+            await assertSuccess(fileSearchHolder)
+            await assertCompletion(removal, description: "connection removal")
+
+            let ordinarySettled = await ordinary.debugSnapshot()
+            let fileSearchSettled = await fileSearch.debugSnapshot()
+            assertIdle(ordinarySettled, cancelledWaiterCount: 0, isClosed: true)
+            assertIdle(fileSearchSettled, cancelledWaiterCount: 0, isClosed: true)
+        }
+
+        @MainActor
+        func testServerShutdownCancelsConnectionOwnedToolsBeforeConcurrentLaneDrain() async {
+            let manager = ServerNetworkManager()
+            let connectionID = UUID()
+            let runID = UUID()
+            let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
+            GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
+            let window = WindowState()
+            WindowStatesManager.shared.registerWindowState(window)
+            GlobalSettingsStore.shared.setMCPAutoStart(previousAutoStart, commit: false)
+
+            let drainStarts = LimiterTestCounter()
+            let ordinary = await manager.debugInstallConnectionLimiterForTesting(
+                connectionID: connectionID,
+                idleWaitSleep: { duration in
+                    await drainStarts.increment()
+                    try await Task.sleep(for: duration)
+                }
+            )
+            guard let fileSearch = await manager.limiter(for: connectionID, lane: .fileSearch) else {
+                XCTFail("Expected file-search limiter")
+                window.beginClose()
+                await window.tearDown()
+                WindowStatesManager.shared.unregisterWindowState(window)
+                return
+            }
+
+            let ordinaryGate = LimiterTestGate()
+            let fileSearchGate = LimiterTestGate()
+            let queuedSearchBodyRan = LimiterTestFlag()
+            let ordinaryCancelled = LimiterLockedFlag()
+            let fileSearchCancelled = LimiterLockedFlag()
+
+            let ordinaryHolder = Task {
+                try await manager.withConnectionCallPermitForTesting(
+                    connectionID: connectionID,
+                    lane: .ordinary
+                ) {
+                    await ordinaryGate.markStartedAndWaitForRelease()
+                }
+            }
+            let fileSearchHolder = Task {
+                try await manager.withConnectionCallPermitForTesting(
+                    connectionID: connectionID,
+                    lane: .fileSearch
+                ) {
+                    await fileSearchGate.markStartedAndWaitForRelease()
+                }
+            }
+            await assertStarted(ordinaryGate, description: "ordinary holder")
+            await assertStarted(fileSearchGate, description: "file-search holder")
+
+            let queuedSearch = Task {
+                try await manager.withConnectionCallPermitForTesting(
+                    connectionID: connectionID,
+                    lane: .fileSearch
+                ) {
+                    await queuedSearchBodyRan.mark()
+                }
+            }
+            let queuedSearchSnapshot = await waitForSnapshot(of: fileSearch) {
+                $0.waiterCount == 1
+            }
+            guard queuedSearchSnapshot != nil else {
+                XCTFail("Timed out waiting for the queued file-search call")
+                queuedSearch.cancel()
+                await ordinaryGate.release()
+                await fileSearchGate.release()
+                await assertSuccess(ordinaryHolder)
+                await assertSuccess(fileSearchHolder)
+                await assertCancellation(queuedSearch)
+                window.beginClose()
+                await window.tearDown()
+                WindowStatesManager.shared.unregisterWindowState(window)
+                return
+            }
+
+            XCTAssertTrue(
+                window.mcpServer.registerRunIDMapping(
+                    connectionID: connectionID,
+                    runID: runID,
+                    windowID: window.windowID
+                )
+            )
+            let metadata = MCPServerViewModel.RequestMetadata(
+                connectionID: connectionID,
+                clientName: "server-shutdown-cancellation-test",
+                windowID: window.windowID
+            )
+            let ordinaryExecution = await window.mcpServer.test_beginResolvedToolExecution(
+                metadata: metadata,
+                resolvedContext: nil,
+                toolName: MCPWindowToolName.readFile
+            ) {
+                ordinaryCancelled.mark()
+            }
+            let fileSearchExecution = await window.mcpServer.test_beginResolvedToolExecution(
+                metadata: metadata,
+                resolvedContext: nil,
+                toolName: MCPWindowToolName.search
+            ) {
+                fileSearchCancelled.mark()
+            }
+            XCTAssertNotNil(ordinaryExecution)
+            XCTAssertNotNil(fileSearchExecution)
+            XCTAssertTrue(window.mcpServer.hasActiveToolExecutions(runID: runID))
+
+            let stopTask = Task {
+                await manager.stop()
+            }
+            guard let drainStartCount = await drainStarts.waitUntil(2, timeout: .seconds(2)) else {
+                XCTFail("Timed out waiting for both limiter lanes to begin shutdown drain")
+                await ordinaryGate.release()
+                await fileSearchGate.release()
+                await assertSuccess(ordinaryHolder)
+                await assertSuccess(fileSearchHolder)
+                await assertCompletion(stopTask, description: "server stop")
+                await assertCancellation(queuedSearch)
+                window.beginClose()
+                await window.tearDown()
+                WindowStatesManager.shared.unregisterWindowState(window)
+                return
+            }
+            XCTAssertGreaterThanOrEqual(drainStartCount, 2)
+
+            XCTAssertTrue(ordinaryCancelled.isMarked())
+            XCTAssertTrue(fileSearchCancelled.isMarked())
+            let ordinaryClosed = await ordinary.debugSnapshot()
+            let fileSearchClosed = await fileSearch.debugSnapshot()
+            XCTAssertTrue(ordinaryClosed.isClosed)
+            XCTAssertTrue(fileSearchClosed.isClosed)
+            XCTAssertEqual(ordinaryClosed.activePermitCount, 1)
+            XCTAssertEqual(fileSearchClosed.activePermitCount, 1)
+            XCTAssertEqual(fileSearchClosed.waiterCount, 0)
+            XCTAssertEqual(fileSearchClosed.cancelledWaiterCount, 1)
+            await assertCancellation(queuedSearch)
+            let didRunQueuedSearchBody = await queuedSearchBodyRan.isMarked()
+            XCTAssertFalse(didRunQueuedSearchBody)
+
+            await ordinaryGate.release()
+            await fileSearchGate.release()
+            await assertSuccess(ordinaryHolder)
+            await assertSuccess(fileSearchHolder)
+            await assertCompletion(stopTask, description: "server stop")
+
+            let registeredOrdinary = await manager.connectionLimiterSnapshotForTesting(
+                connectionID: connectionID,
+                lane: .ordinary
+            )
+            let registeredFileSearch = await manager.connectionLimiterSnapshotForTesting(
+                connectionID: connectionID,
+                lane: .fileSearch
+            )
+            XCTAssertNil(registeredOrdinary)
+            XCTAssertNil(registeredFileSearch)
+            await assertIdle(ordinary.debugSnapshot(), cancelledWaiterCount: 0, isClosed: true)
+            await assertIdle(fileSearch.debugSnapshot(), cancelledWaiterCount: 1, isClosed: true)
+            XCTAssertFalse(window.mcpServer.hasActiveToolExecutions(runID: runID))
+
+            _ = window.mcpServer.cancelActiveToolsForConnection(
+                connectionID: connectionID,
+                reason: "testCleanup"
+            )
+            window.beginClose()
+            await window.tearDown()
+            WindowStatesManager.shared.unregisterWindowState(window)
+        }
+
+        func testAdmittedPermitRejectsRemovalCommittedBeforeBodyStarts() async {
+            let manager = ServerNetworkManager()
+            let connectionID = UUID()
+            let permitGate = LimiterTestGate()
+            let stopGate = LimiterTestGate()
+            let bodyRan = LimiterTestFlag()
+
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: connectionID,
+                connection: AdmissionEvictionTestConnection(
+                    idleSeconds: 0,
+                    stopGate: stopGate
+                ),
+                clientID: "post-permit-removal-\(UUID().uuidString)",
+                totalToolCalls: 0,
+                createdAt: .distantPast
+            )
+            await manager.debugSetAfterConnectionCallPermitAcquiredForTesting { acquiredConnectionID in
+                guard acquiredConnectionID == connectionID else { return }
+                await permitGate.markStartedAndWaitForRelease()
+            }
+
+            let admittedCall = Task {
+                try await manager.withConnectionCallPermitForTesting(
+                    connectionID: connectionID,
+                    lane: .ordinary
+                ) {
+                    await bodyRan.mark()
+                }
+            }
+            await assertStarted(permitGate, description: "post-permit dispatch gate")
+
+            let removal = Task {
+                await manager.debugRemoveConnection(connectionID)
+            }
+            await assertStarted(stopGate, description: "post-permit connection removal")
+            await manager.debugSetAfterConnectionCallPermitAcquiredForTesting(nil)
+            await permitGate.release()
+
+            let callSucceeded: Bool
             do {
-                try await task.value
+                try await admittedCall.value
+                callSucceeded = true
+            } catch {
+                callSucceeded = false
+            }
+            let didRunBody = await bodyRan.isMarked()
+            XCTAssertFalse(callSucceeded)
+            XCTAssertFalse(didRunBody)
+
+            await stopGate.release()
+            await assertCompletion(removal, description: "post-permit connection removal")
+        }
+
+        func testAdmittedPermitRejectsShutdownCommittedBeforeBodyStarts() async {
+            let manager = ServerNetworkManager()
+            let connectionID = UUID()
+            let permitGate = LimiterTestGate()
+            let bodyRan = LimiterTestFlag()
+
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: connectionID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 0),
+                clientID: "post-permit-shutdown-\(UUID().uuidString)",
+                totalToolCalls: 0,
+                createdAt: .distantPast
+            )
+            guard let limiter = await manager.limiter(for: connectionID, lane: .ordinary) else {
+                XCTFail("Expected ordinary limiter")
+                return
+            }
+            await manager.debugSetAfterConnectionCallPermitAcquiredForTesting { acquiredConnectionID in
+                guard acquiredConnectionID == connectionID else { return }
+                await permitGate.markStartedAndWaitForRelease()
+            }
+
+            let admittedCall = Task {
+                try await manager.withConnectionCallPermitForTesting(
+                    connectionID: connectionID,
+                    lane: .ordinary
+                ) {
+                    await bodyRan.mark()
+                }
+            }
+            await assertStarted(permitGate, description: "post-permit shutdown dispatch gate")
+
+            let shutdown = Task {
+                await manager.stop()
+            }
+            let closed = await waitForSnapshot(of: limiter) { $0.isClosed }
+            XCTAssertNotNil(closed, "Timed out waiting for shutdown to close the admitted call limiter")
+            await manager.debugSetAfterConnectionCallPermitAcquiredForTesting(nil)
+            await permitGate.release()
+
+            let callSucceeded: Bool
+            do {
+                try await admittedCall.value
+                callSucceeded = true
+            } catch {
+                callSucceeded = false
+            }
+            let didRunBody = await bodyRan.isMarked()
+            XCTAssertFalse(callSucceeded)
+            XCTAssertFalse(didRunBody)
+            await assertCompletion(shutdown, description: "post-permit server shutdown")
+        }
+
+        @MainActor
+        func testClosingWindowRejectsCapturedDispatchIdentityBeforeOwnershipOperation() async {
+            let manager = ServerNetworkManager()
+            let connectionID = UUID()
+            let bodyRan = LimiterTestFlag()
+            let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
+            GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
+            let window = WindowState()
+            WindowStatesManager.shared.registerWindowState(window)
+            GlobalSettingsStore.shared.setMCPAutoStart(previousAutoStart, commit: false)
+
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: connectionID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 0),
+                clientID: "closing-window-dispatch-\(UUID().uuidString)",
+                totalToolCalls: 0,
+                createdAt: .distantPast
+            )
+            let identity = ServerNetworkManager.WindowToolDispatchIdentity(
+                windowID: window.windowID,
+                windowStateIdentity: ObjectIdentifier(window),
+                serverViewModelIdentity: ObjectIdentifier(window.mcpServer),
+                catalogServiceIdentity: ObjectIdentifier(window.mcpServer.windowMCPToolCatalogService)
+            )
+            window.beginClose()
+
+            do {
+                try await manager.withWindowToolOwnership(
+                    windowID: window.windowID,
+                    connectionID: connectionID,
+                    toolName: MCPWindowToolName.search,
+                    windowIdentity: identity
+                ) {
+                    await bodyRan.mark()
+                }
+                XCTFail("A captured dispatch target must become terminal when its window begins closing")
+            } catch {
+                // Expected.
+            }
+            let didRunBody = await bodyRan.isMarked()
+            XCTAssertFalse(didRunBody)
+
+            await manager.debugRemoveConnection(connectionID)
+            await window.tearDown()
+            WindowStatesManager.shared.unregisterWindowState(window)
+        }
+
+        @MainActor
+        func testUnboundExecutionsRemainTokenAndConnectionOwnedWhenTheyOverlap() async {
+            let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
+            GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
+            let window = WindowState()
+            WindowStatesManager.shared.registerWindowState(window)
+            GlobalSettingsStore.shared.setMCPAutoStart(previousAutoStart, commit: false)
+            let firstConnectionID = UUID()
+            let secondConnectionID = UUID()
+            let firstCancelled = LimiterLockedFlag()
+            let secondCancelled = LimiterLockedFlag()
+
+            let first = await window.mcpServer.test_beginResolvedToolExecution(
+                metadata: MCPServerViewModel.RequestMetadata(
+                    connectionID: firstConnectionID,
+                    clientName: "unbound-first",
+                    windowID: window.windowID
+                ),
+                resolvedContext: nil,
+                toolName: MCPWindowToolName.readFile
+            ) {
+                firstCancelled.mark()
+            }
+            let second = await window.mcpServer.test_beginResolvedToolExecution(
+                metadata: MCPServerViewModel.RequestMetadata(
+                    connectionID: secondConnectionID,
+                    clientName: "unbound-second",
+                    windowID: window.windowID
+                ),
+                resolvedContext: nil,
+                toolName: MCPWindowToolName.readFile
+            ) {
+                secondCancelled.mark()
+            }
+
+            XCTAssertNotNil(first)
+            XCTAssertNotNil(second)
+            XCTAssertEqual(window.mcpServer.test_activeToolExecutionCount(), 2)
+            XCTAssertEqual(window.mcpServer.test_activeToolExecutionCount(connectionID: firstConnectionID), 1)
+            XCTAssertEqual(window.mcpServer.test_activeToolExecutionCount(connectionID: secondConnectionID), 1)
+            XCTAssertEqual(
+                window.mcpServer.cancelActiveToolsForConnection(
+                    connectionID: firstConnectionID,
+                    reason: "unbound-overlap-first"
+                ),
+                1
+            )
+            XCTAssertTrue(firstCancelled.isMarked())
+            XCTAssertFalse(secondCancelled.isMarked())
+            XCTAssertEqual(window.mcpServer.test_activeToolExecutionCount(), 1)
+            XCTAssertEqual(window.mcpServer.test_activeToolExecutionCount(connectionID: firstConnectionID), 0)
+            XCTAssertEqual(
+                window.mcpServer.cancelActiveToolsForConnection(
+                    connectionID: secondConnectionID,
+                    reason: "unbound-overlap-second"
+                ),
+                1
+            )
+            XCTAssertTrue(secondCancelled.isMarked())
+            XCTAssertEqual(window.mcpServer.test_activeToolExecutionCount(), 0)
+
+            if let first {
+                window.mcpServer.test_endToolExecution(executionID: first.executionID)
+            }
+            if let second {
+                window.mcpServer.test_endToolExecution(executionID: second.executionID)
+            }
+            window.beginClose()
+            await window.tearDown()
+            WindowStatesManager.shared.unregisterWindowState(window)
+        }
+
+        func testDiagnosticsExposeSelectedActiveScopeWindowInsteadOfAssignedWindow() async throws {
+            let manager = ServerNetworkManager()
+            let connectionID = UUID()
+            let assignedWindowID = 73013
+            let activeWindowID = 73014
+            let secondaryActiveWindowID = 73015
+            let scopeID = UUID()
+
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: connectionID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 0),
+                clientID: "active-tool-diagnostics-\(UUID().uuidString)",
+                totalToolCalls: 0,
+                createdAt: .distantPast
+            )
+            await manager.debugSetConnectionWindowForTesting(
+                connectionID: connectionID,
+                windowID: assignedWindowID
+            )
+            _ = await manager.debugBeginActiveToolScopeForTesting(
+                windowID: secondaryActiveWindowID,
+                connectionID: connectionID,
+                toolName: "secondary-cross-window-active",
+                scopeID: UUID()
+            )
+            _ = await manager.debugBeginActiveToolScopeForTesting(
+                windowID: activeWindowID,
+                connectionID: connectionID,
+                toolName: "cross-window-active",
+                scopeID: scopeID
+            )
+
+            let result = await manager.debugConnectionsPayload(op: "connections", arguments: [:])
+            let payload = try diagnosticsPayload(result)
+            let connections = try XCTUnwrap(payload["connections"] as? [[String: Any]])
+            let connection = try XCTUnwrap(connections.first(where: { $0["id"] as? String == connectionID.uuidString }))
+            XCTAssertEqual(connection["window_id"] as? Int, assignedWindowID)
+            XCTAssertEqual(connection["active_tool_name"] as? String, "cross-window-active")
+            XCTAssertEqual(connection["active_tool_window_id"] as? Int, activeWindowID)
+            XCTAssertEqual(connection["active_tool_scope_count"] as? Int, 2)
+            let scopes = try XCTUnwrap(connection["active_tool_scopes"] as? [[String: Any]])
+            XCTAssertEqual(Set(scopes.compactMap { $0["window_id"] as? Int }), [activeWindowID, secondaryActiveWindowID])
+
+            await manager.debugRemoveConnection(connectionID)
+        }
+
+        func testOverlappingSameConnectionWindowOwnershipPersistsUntilFinalCallCompletes() async {
+            let manager = ServerNetworkManager.shared
+            let connectionID = UUID()
+            let windowID = 73001
+            let firstGate = LimiterTestGate()
+            let secondGate = LimiterTestGate()
+
+            let first = Task {
+                try! await manager.withWindowToolOwnership(
+                    windowID: windowID,
+                    connectionID: connectionID,
+                    toolName: MCPWindowToolName.search
+                ) {
+                    await firstGate.markStartedAndWaitForRelease()
+                }
+            }
+            await assertStarted(firstGate, description: "first owner")
+
+            let second = Task {
+                try! await manager.withWindowToolOwnership(
+                    windowID: windowID,
+                    connectionID: connectionID,
+                    toolName: MCPWindowToolName.readFile
+                ) {
+                    await secondGate.markStartedAndWaitForRelease()
+                }
+            }
+            await assertStarted(secondGate, description: "second owner")
+
+            let evictableWhileBothActive = await manager.connectionIsEvictableForTesting(connectionID)
+            XCTAssertFalse(evictableWhileBothActive)
+
+            await firstGate.release()
+            await assertCompletion(first, description: "first ownership task")
+
+            let evictableWhileSecondRemainsActive = await manager.connectionIsEvictableForTesting(connectionID)
+            XCTAssertFalse(
+                evictableWhileSecondRemainsActive,
+                "Completing one overlapping call must not clear ownership while another remains active"
+            )
+
+            await secondGate.release()
+            await assertCompletion(second, description: "second ownership task")
+            let evictableAfterBothComplete = await manager.connectionIsEvictableForTesting(connectionID)
+            XCTAssertTrue(evictableAfterBothComplete)
+        }
+
+        func testOverlappingDifferentConnectionWindowOwnershipProtectsBothUntilEachCompletes() async {
+            let manager = ServerNetworkManager()
+            let firstConnectionID = UUID()
+            let secondConnectionID = UUID()
+            let windowID = 73002
+            let firstGate = LimiterTestGate()
+            let secondGate = LimiterTestGate()
+
+            let first = Task {
+                try! await manager.withWindowToolOwnership(
+                    windowID: windowID,
+                    connectionID: firstConnectionID,
+                    toolName: MCPWindowToolName.search
+                ) {
+                    await firstGate.markStartedAndWaitForRelease()
+                }
+            }
+            await assertStarted(firstGate, description: "first cross-connection owner")
+
+            let second = Task {
+                try! await manager.withWindowToolOwnership(
+                    windowID: windowID,
+                    connectionID: secondConnectionID,
+                    toolName: MCPWindowToolName.readFile
+                ) {
+                    await secondGate.markStartedAndWaitForRelease()
+                }
+            }
+            await assertStarted(secondGate, description: "second cross-connection owner")
+
+            let firstEvictableWhileBothActive = await manager.connectionIsEvictableForTesting(firstConnectionID)
+            let secondEvictableWhileBothActive = await manager.connectionIsEvictableForTesting(secondConnectionID)
+            XCTAssertFalse(firstEvictableWhileBothActive)
+            XCTAssertFalse(secondEvictableWhileBothActive)
+
+            await secondGate.release()
+            await assertCompletion(second, description: "second cross-connection ownership task")
+
+            let firstEvictableAfterSecondCompletion = await manager.connectionIsEvictableForTesting(firstConnectionID)
+            let secondEvictableAfterCompletion = await manager.connectionIsEvictableForTesting(secondConnectionID)
+            XCTAssertFalse(
+                firstEvictableAfterSecondCompletion,
+                "Completing the newer connection must preserve the older exact ownership scope"
+            )
+            XCTAssertTrue(secondEvictableAfterCompletion)
+
+            await firstGate.release()
+            await assertCompletion(first, description: "first cross-connection ownership task")
+            let firstEvictableAfterCompletion = await manager.connectionIsEvictableForTesting(firstConnectionID)
+            XCTAssertTrue(firstEvictableAfterCompletion)
+        }
+
+        func testConnectionCancellationRemovesOnlyScopesCapturedBeforeMainActorScan() async {
+            let manager = ServerNetworkManager()
+            let targetConnectionID = UUID()
+            let otherConnectionID = UUID()
+            let windowID = 73003
+            let capturedScopeID = UUID()
+            let newerTargetScopeID = UUID()
+            let otherScopeID = UUID()
+            let cancellationGate = LimiterTestGate()
+
+            let beganCapturedScope = await manager.debugBeginActiveToolScopeForTesting(
+                windowID: windowID,
+                connectionID: targetConnectionID,
+                toolName: MCPWindowToolName.search,
+                scopeID: capturedScopeID
+            )
+            XCTAssertEqual(beganCapturedScope, capturedScopeID)
+            await manager.debugSetBeforeActiveToolCancellationScanForTesting { connectionID, scopeIDs in
+                guard connectionID == targetConnectionID,
+                      scopeIDs == [capturedScopeID]
+                else { return }
+                await cancellationGate.markStartedAndWaitForRelease()
+            }
+
+            let cancellation = Task {
+                await manager.debugCancelActiveToolsOwnedByConnection(
+                    targetConnectionID,
+                    reason: "exactScopeCancellationRace"
+                )
+            }
+            await assertStarted(cancellationGate, description: "active-tool cancellation snapshot")
+
+            let beganNewerTargetScope = await manager.debugBeginActiveToolScopeForTesting(
+                windowID: windowID,
+                connectionID: targetConnectionID,
+                toolName: MCPWindowToolName.readFile,
+                scopeID: newerTargetScopeID
+            )
+            let beganOtherScope = await manager.debugBeginActiveToolScopeForTesting(
+                windowID: windowID,
+                connectionID: otherConnectionID,
+                toolName: MCPWindowToolName.applyEdits,
+                scopeID: otherScopeID
+            )
+            XCTAssertEqual(beganNewerTargetScope, newerTargetScopeID)
+            XCTAssertEqual(beganOtherScope, otherScopeID)
+
+            await cancellationGate.release()
+            await assertCompletion(cancellation, description: "exact-scope connection cancellation")
+            await manager.debugSetBeforeActiveToolCancellationScanForTesting(nil)
+
+            let remainingScopes = await manager.debugActiveToolScopesForTesting()
+            XCTAssertEqual(Set(remainingScopes.map(\.scopeID)), Set([newerTargetScopeID, otherScopeID]))
+            let removedCapturedScopeAgain = await manager.debugEndActiveToolScopeForTesting(
+                windowID: windowID,
+                scopeID: capturedScopeID
+            )
+            XCTAssertFalse(
+                removedCapturedScopeAgain,
+                "A deferred completion for an already-cleaned exact scope must be harmless"
+            )
+            let scopesAfterDeferredCompletion = await manager.debugActiveToolScopesForTesting()
+            XCTAssertEqual(Set(scopesAfterDeferredCompletion.map(\.scopeID)), Set([newerTargetScopeID, otherScopeID]))
+        }
+
+        func testConnectionRemovalRejectsScopeThatStartsAfterCancellationSnapshot() async {
+            let manager = ServerNetworkManager()
+            let connectionID = UUID()
+            let capturedScopeID = UUID()
+            let rejectedScopeID = UUID()
+            let windowID = 73011
+            let cancellationGate = LimiterTestGate()
+
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: connectionID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 0),
+                clientID: "active-tool-removal-race-\(UUID().uuidString)",
+                totalToolCalls: 0,
+                createdAt: .distantPast
+            )
+            _ = await manager.debugBeginActiveToolScopeForTesting(
+                windowID: windowID,
+                connectionID: connectionID,
+                toolName: MCPWindowToolName.search,
+                scopeID: capturedScopeID
+            )
+            await manager.debugSetBeforeActiveToolCancellationScanForTesting { cancelledConnectionID, _ in
+                guard cancelledConnectionID == connectionID else { return }
+                await cancellationGate.markStartedAndWaitForRelease()
+            }
+
+            let removal = Task {
+                await manager.debugRemoveConnection(connectionID)
+            }
+            await assertStarted(cancellationGate, description: "connection-removal cancellation snapshot")
+            let rejectedScope = await manager.debugBeginActiveToolScopeForTesting(
+                windowID: windowID,
+                connectionID: connectionID,
+                toolName: MCPWindowToolName.readFile,
+                scopeID: rejectedScopeID
+            )
+            XCTAssertNil(rejectedScope)
+
+            await cancellationGate.release()
+            await assertCompletion(removal, description: "connection removal after ownership race")
+            await manager.debugSetBeforeActiveToolCancellationScanForTesting(nil)
+            let remainingScopes = await manager.debugActiveToolScopesForTesting()
+            XCTAssertFalse(remainingScopes.contains { $0.connectionID == connectionID })
+        }
+
+        func testDebugScopeIDCannotBeReusedAfterExactCompletion() async {
+            let manager = ServerNetworkManager()
+            let connectionID = UUID()
+            let windowID = 73012
+            let scopeID = UUID()
+
+            let firstBegin = await manager.debugBeginActiveToolScopeForTesting(
+                windowID: windowID,
+                connectionID: connectionID,
+                toolName: MCPWindowToolName.search,
+                scopeID: scopeID
+            )
+            XCTAssertEqual(firstBegin, scopeID)
+            let firstEnd = await manager.debugEndActiveToolScopeForTesting(
+                windowID: windowID,
+                scopeID: scopeID
+            )
+            XCTAssertTrue(firstEnd)
+
+            let reusedBegin = await manager.debugBeginActiveToolScopeForTesting(
+                windowID: windowID,
+                connectionID: connectionID,
+                toolName: MCPWindowToolName.readFile,
+                scopeID: scopeID
+            )
+            XCTAssertNil(reusedBegin)
+            let remainingScopes = await manager.debugActiveToolScopesForTesting()
+            XCTAssertTrue(remainingScopes.isEmpty)
+        }
+
+        func testDashboardSelectsNewestAssignedWindowScopeThenFallsBackBySequence() async {
+            let manager = ServerNetworkManager()
+            let connectionID = UUID()
+            let assignedWindowID = 73004
+            let otherWindowID = 73005
+            let assignedOlderScopeID = UUID()
+            let otherNewerScopeID = UUID()
+            let assignedNewestScopeID = UUID()
+
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: connectionID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 0),
+                clientID: "active-tool-dashboard-\(UUID().uuidString)",
+                totalToolCalls: 0,
+                createdAt: .distantPast
+            )
+            await manager.debugSetConnectionWindowForTesting(
+                connectionID: connectionID,
+                windowID: assignedWindowID
+            )
+            _ = await manager.debugBeginActiveToolScopeForTesting(
+                windowID: assignedWindowID,
+                connectionID: connectionID,
+                toolName: "assigned-older",
+                scopeID: assignedOlderScopeID
+            )
+            _ = await manager.debugBeginActiveToolScopeForTesting(
+                windowID: otherWindowID,
+                connectionID: connectionID,
+                toolName: "other-newer",
+                scopeID: otherNewerScopeID
+            )
+
+            let preferredAssignedSnapshot = await manager.dashboardSnapshot()
+            XCTAssertEqual(
+                preferredAssignedSnapshot.connections.first(where: { $0.id == connectionID })?.activeToolName,
+                "assigned-older"
+            )
+
+            _ = await manager.debugBeginActiveToolScopeForTesting(
+                windowID: assignedWindowID,
+                connectionID: connectionID,
+                toolName: "assigned-newest",
+                scopeID: assignedNewestScopeID
+            )
+            let newestAssignedSnapshot = await manager.dashboardSnapshot()
+            XCTAssertEqual(
+                newestAssignedSnapshot.connections.first(where: { $0.id == connectionID })?.activeToolName,
+                "assigned-newest"
+            )
+
+            _ = await manager.debugEndActiveToolScopeForTesting(
+                windowID: assignedWindowID,
+                scopeID: assignedNewestScopeID
+            )
+            let olderAssignedFallbackSnapshot = await manager.dashboardSnapshot()
+            XCTAssertEqual(
+                olderAssignedFallbackSnapshot.connections.first(where: { $0.id == connectionID })?.activeToolName,
+                "assigned-older"
+            )
+
+            _ = await manager.debugEndActiveToolScopeForTesting(
+                windowID: assignedWindowID,
+                scopeID: assignedOlderScopeID
+            )
+            let crossWindowFallbackSnapshot = await manager.dashboardSnapshot()
+            XCTAssertEqual(
+                crossWindowFallbackSnapshot.connections.first(where: { $0.id == connectionID })?.activeToolName,
+                "other-newer"
+            )
+
+            _ = await manager.debugEndActiveToolScopeForTesting(
+                windowID: otherWindowID,
+                scopeID: otherNewerScopeID
+            )
+            let idleSnapshot = await manager.dashboardSnapshot()
+            XCTAssertNil(idleSnapshot.connections.first(where: { $0.id == connectionID })?.activeToolName)
+            await manager.debugRemoveConnection(connectionID)
+        }
+
+        func testWindowCloseRemovesOnlyItsScopeBucketAndStaleCompletionIsHarmless() async {
+            let manager = ServerNetworkManager()
+            let connectionID = UUID()
+            let closedWindowID = 73006
+            let retainedWindowID = 73007
+            let closedScopeID = UUID()
+            let retainedScopeID = UUID()
+
+            _ = await manager.debugBeginActiveToolScopeForTesting(
+                windowID: closedWindowID,
+                connectionID: connectionID,
+                toolName: MCPWindowToolName.search,
+                scopeID: closedScopeID
+            )
+            _ = await manager.debugBeginActiveToolScopeForTesting(
+                windowID: retainedWindowID,
+                connectionID: connectionID,
+                toolName: MCPWindowToolName.readFile,
+                scopeID: retainedScopeID
+            )
+
+            await manager.clearWindowSelectionIfClosed(closedWindowID)
+            let remainingAfterClose = await manager.debugActiveToolScopesForTesting()
+            XCTAssertEqual(remainingAfterClose.map(\.scopeID), [retainedScopeID])
+            let removedStaleScope = await manager.debugEndActiveToolScopeForTesting(
+                windowID: closedWindowID,
+                scopeID: closedScopeID
+            )
+            XCTAssertFalse(removedStaleScope)
+            let remainingAfterStaleCompletion = await manager.debugActiveToolScopesForTesting()
+            XCTAssertEqual(remainingAfterStaleCompletion.map(\.scopeID), [retainedScopeID])
+        }
+
+        func testLifecycleResetClearsAllScopesWithoutReusingSequenceOrOldIDs() async {
+            let manager = ServerNetworkManager()
+            let connectionID = UUID()
+            let windowID = 73008
+            let oldScopeID = UUID()
+            let newScopeID = UUID()
+
+            _ = await manager.debugBeginActiveToolScopeForTesting(
+                windowID: windowID,
+                connectionID: connectionID,
+                toolName: "old-lifecycle",
+                scopeID: oldScopeID
+            )
+            let oldScope = await manager.debugActiveToolScopesForTesting().first
+            await manager.stop()
+            let scopesAfterReset = await manager.debugActiveToolScopesForTesting()
+            XCTAssertTrue(scopesAfterReset.isEmpty)
+
+            _ = await manager.debugBeginActiveToolScopeForTesting(
+                windowID: windowID,
+                connectionID: connectionID,
+                toolName: "new-lifecycle",
+                scopeID: newScopeID
+            )
+            let newScope = await manager.debugActiveToolScopesForTesting().first
+            XCTAssertNotNil(oldScope)
+            XCTAssertNotNil(newScope)
+            if let oldScope, let newScope {
+                XCTAssertGreaterThan(newScope.sequence, oldScope.sequence)
+            }
+            let removedOldScope = await manager.debugEndActiveToolScopeForTesting(
+                windowID: windowID,
+                scopeID: oldScopeID
+            )
+            XCTAssertFalse(removedOldScope)
+            let remainingScopes = await manager.debugActiveToolScopesForTesting()
+            XCTAssertEqual(remainingScopes.map(\.scopeID), [newScopeID])
+        }
+
+        func testConnectionRemovalClearsOwnedScopesAcrossWindowsWithoutTouchingPeerScopes() async {
+            let manager = ServerNetworkManager()
+            let targetConnectionID = UUID()
+            let peerConnectionID = UUID()
+            let firstWindowID = 73009
+            let secondWindowID = 73010
+            let targetFirstScopeID = UUID()
+            let targetSecondScopeID = UUID()
+            let peerScopeID = UUID()
+
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: targetConnectionID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 0),
+                clientID: "active-tool-removal-target-\(UUID().uuidString)",
+                totalToolCalls: 0,
+                createdAt: .distantPast
+            )
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: peerConnectionID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 0),
+                clientID: "active-tool-removal-peer-\(UUID().uuidString)",
+                totalToolCalls: 0,
+                createdAt: .distantPast
+            )
+            _ = await manager.debugBeginActiveToolScopeForTesting(
+                windowID: firstWindowID,
+                connectionID: targetConnectionID,
+                toolName: MCPWindowToolName.search,
+                scopeID: targetFirstScopeID
+            )
+            _ = await manager.debugBeginActiveToolScopeForTesting(
+                windowID: secondWindowID,
+                connectionID: targetConnectionID,
+                toolName: MCPWindowToolName.readFile,
+                scopeID: targetSecondScopeID
+            )
+            _ = await manager.debugBeginActiveToolScopeForTesting(
+                windowID: firstWindowID,
+                connectionID: peerConnectionID,
+                toolName: MCPWindowToolName.applyEdits,
+                scopeID: peerScopeID
+            )
+
+            await manager.debugRemoveConnection(targetConnectionID)
+            let remainingScopes = await manager.debugActiveToolScopesForTesting()
+            XCTAssertEqual(remainingScopes.map(\.scopeID), [peerScopeID])
+            let peerEvictable = await manager.connectionIsEvictableForTesting(peerConnectionID)
+            XCTAssertFalse(peerEvictable)
+            await manager.debugRemoveConnection(peerConnectionID)
+        }
+
+        func testConnectionCancellationClearsAllOverlappingOwnershipReferences() async {
+            let manager = ServerNetworkManager()
+            let connectionID = UUID()
+            let windowID = 73002
+            let firstGate = LimiterTestGate()
+            let secondGate = LimiterTestGate()
+            let first = Task {
+                try! await manager.withWindowToolOwnership(
+                    windowID: windowID,
+                    connectionID: connectionID,
+                    toolName: MCPWindowToolName.search
+                ) {
+                    await firstGate.markStartedAndWaitForRelease()
+                }
+            }
+            let second = Task {
+                try! await manager.withWindowToolOwnership(
+                    windowID: windowID,
+                    connectionID: connectionID,
+                    toolName: MCPWindowToolName.readFile
+                ) {
+                    await secondGate.markStartedAndWaitForRelease()
+                }
+            }
+            await assertStarted(firstGate, description: "first owner")
+            await assertStarted(secondGate, description: "second owner")
+
+            let evictableBeforeCancellation = await manager.connectionIsEvictableForTesting(connectionID)
+            XCTAssertFalse(evictableBeforeCancellation)
+
+            _ = await manager.debugCancelActiveToolsOwnedByConnection(
+                connectionID,
+                reason: "ownershipRefcountTest"
+            )
+
+            let evictableAfterCancellation = await manager.connectionIsEvictableForTesting(connectionID)
+            XCTAssertTrue(evictableAfterCancellation)
+
+            await firstGate.release()
+            await secondGate.release()
+            await assertCompletion(first, description: "first ownership task")
+            await assertCompletion(second, description: "second ownership task")
+            let evictableAfterDeferredClears = await manager.connectionIsEvictableForTesting(connectionID)
+            XCTAssertTrue(evictableAfterDeferredClears)
+        }
+
+        func testPerClientAdmissionEvictionSkipsCandidateThatBecomesBusyBeforeAtomicClose() async {
+            await assertAdmissionEvictionFallsBackToNextCandidate(scope: .perClient)
+        }
+
+        func testGlobalAdmissionEvictionSkipsCandidateThatBecomesBusyBeforeAtomicClose() async {
+            await assertAdmissionEvictionFallsBackToNextCandidate(scope: .global)
+        }
+
+        func testGlobalAdmissionEvictionIgnoresRemovingSiblingBeforeClosingProtectedVictim() async {
+            let manager = ServerNetworkManager()
+            let firstClientID = "admission-eviction-first-\(UUID().uuidString)"
+            let protectedClientID = "admission-eviction-protected-\(UUID().uuidString)"
+            let firstCandidateID = UUID()
+            let firstSiblingID = UUID()
+            let protectedCandidateID = UUID()
+            let protectedSiblingID = UUID()
+
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: firstCandidateID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 120),
+                clientID: firstClientID,
+                totalToolCalls: 0,
+                createdAt: .distantPast
+            )
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: firstSiblingID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 10),
+                clientID: firstClientID,
+                totalToolCalls: 2,
+                createdAt: Date()
+            )
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: protectedCandidateID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 60),
+                clientID: protectedClientID,
+                totalToolCalls: 1,
+                createdAt: Date()
+            )
+            let protectedSiblingStopGate = LimiterTestGate()
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: protectedSiblingID,
+                connection: AdmissionEvictionTestConnection(
+                    idleSeconds: 10,
+                    stopGate: protectedSiblingStopGate
+                ),
+                clientID: protectedClientID,
+                totalToolCalls: 2,
+                createdAt: Date()
+            )
+
+            let firstSiblingGate = LimiterTestGate()
+            let protectedSiblingGate = LimiterTestGate()
+            let firstSiblingHolder = Task {
+                try await manager.withConnectionCallPermitForTesting(
+                    connectionID: firstSiblingID,
+                    lane: .ordinary
+                ) {
+                    await firstSiblingGate.markStartedAndWaitForRelease()
+                }
+            }
+            let protectedSiblingHolder = Task {
+                try await manager.withConnectionCallPermitForTesting(
+                    connectionID: protectedSiblingID,
+                    lane: .ordinary
+                ) {
+                    await protectedSiblingGate.markStartedAndWaitForRelease()
+                }
+            }
+            await assertStarted(firstSiblingGate, description: "first sibling holder")
+            await assertStarted(protectedSiblingGate, description: "protected sibling holder")
+
+            let firstCandidateBusyGate = LimiterTestGate()
+            let firstCandidateBusyTask = LimiterTestTaskStore()
+            let protectedSiblingRemovalTask = LimiterTestTaskStore()
+            await manager.debugSetBeforeAdmissionEvictionCloseForTesting { candidateID in
+                guard candidateID == firstCandidateID else { return }
+                await firstCandidateBusyTask.start {
+                    try? await manager.withConnectionCallPermitForTesting(
+                        connectionID: firstCandidateID,
+                        lane: .ordinary
+                    ) {
+                        await firstCandidateBusyGate.markStartedAndWaitForRelease()
+                    }
+                }
+                guard await firstCandidateBusyGate.waitUntilStarted(timeout: .seconds(2)) else { return }
+                await protectedSiblingRemovalTask.start {
+                    await manager.debugRemoveConnection(protectedSiblingID)
+                }
+                guard await protectedSiblingStopGate.waitUntilStarted(timeout: .seconds(2)) else { return }
+            }
+
+            let didEvict = await manager.debugEvictLeastValuableGlobalForAdmissionForTesting(
+                preserveOnePerClient: true
+            )
+            let retainedFirstCandidate = await manager.debugContainsConnection(firstCandidateID)
+            let retainedProtectedCandidate = await manager.debugContainsConnection(protectedCandidateID)
+            let retainedRemovingSibling = await manager.debugContainsConnection(protectedSiblingID)
+            let protectedSiblingRemovalStarted = await protectedSiblingStopGate.hasStarted()
+            XCTAssertFalse(didEvict)
+            XCTAssertTrue(
+                protectedSiblingRemovalStarted,
+                "Timed out waiting for protected sibling removal to reach stop()"
+            )
+            XCTAssertTrue(retainedFirstCandidate)
+            XCTAssertTrue(
+                retainedRemovingSibling,
+                "The fixture must observe removal after it starts but before indexed membership cleanup"
+            )
+            XCTAssertTrue(
+                retainedProtectedCandidate,
+                "A candidate that became its client's sole member must not be evicted"
+            )
+
+            await manager.debugSetBeforeAdmissionEvictionCloseForTesting(nil)
+            await firstCandidateBusyGate.release()
+            await assertCompletion(firstCandidateBusyTask, description: "first candidate task")
+            await firstSiblingGate.release()
+            await protectedSiblingGate.release()
+            await assertSuccess(firstSiblingHolder)
+            await assertSuccess(protectedSiblingHolder)
+            await protectedSiblingStopGate.release()
+            await assertCompletion(protectedSiblingRemovalTask, description: "protected sibling removal")
+            await manager.debugRemoveConnection(firstCandidateID)
+            await manager.debugRemoveConnection(firstSiblingID)
+            await manager.debugRemoveConnection(protectedCandidateID)
+        }
+
+        func testGlobalAdmissionEvictionRestoresIdleLanesWhenSiblingRemovalStartsDuringClose() async throws {
+            let manager = ServerNetworkManager()
+            let clientID = "admission-eviction-during-close-\(UUID().uuidString)"
+            let victimID = UUID()
+            let siblingID = UUID()
+
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: victimID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 120),
+                clientID: clientID,
+                totalToolCalls: 0,
+                createdAt: .distantPast
+            )
+            let siblingStopGate = LimiterTestGate()
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: siblingID,
+                connection: AdmissionEvictionTestConnection(
+                    idleSeconds: 10,
+                    stopGate: siblingStopGate
+                ),
+                clientID: clientID,
+                totalToolCalls: 1,
+                createdAt: Date()
+            )
+            let installedOrdinary = await manager.limiter(for: victimID, lane: .ordinary)
+            let installedFileSearch = await manager.limiter(for: victimID, lane: .fileSearch)
+            let originalOrdinary = try XCTUnwrap(installedOrdinary)
+            let originalFileSearch = try XCTUnwrap(installedFileSearch)
+
+            let siblingRemovalTask = LimiterTestTaskStore()
+            await manager.debugSetDuringAdmissionEvictionCloseForTesting { candidateID in
+                guard candidateID == victimID else { return }
+                await siblingRemovalTask.start {
+                    await manager.debugRemoveConnection(siblingID)
+                }
+                guard await siblingStopGate.waitUntilStarted(timeout: .seconds(2)) else { return }
+            }
+
+            let didEvict = await manager.debugEvictLeastValuableGlobalForAdmissionForTesting(
+                preserveOnePerClient: true
+            )
+            await manager.debugSetDuringAdmissionEvictionCloseForTesting(nil)
+
+            let retainedVictim = await manager.debugContainsConnection(victimID)
+            let retainedSibling = await manager.debugContainsConnection(siblingID)
+            let siblingRemovalStarted = await siblingStopGate.hasStarted()
+            let originalOrdinarySnapshot = await originalOrdinary.debugSnapshot()
+            let originalFileSearchSnapshot = await originalFileSearch.debugSnapshot()
+            XCTAssertFalse(didEvict)
+            XCTAssertTrue(
+                siblingRemovalStarted,
+                "Timed out waiting for sibling removal to reach stop() during lane closure"
+            )
+            XCTAssertTrue(retainedVictim, "The sole remaining usable connection must stay registered")
+            XCTAssertTrue(
+                retainedSibling,
+                "The fixture must observe removal after it starts but before indexed membership cleanup"
+            )
+            XCTAssertTrue(originalOrdinarySnapshot.isClosed)
+            XCTAssertTrue(originalFileSearchSnapshot.isClosed)
+
+            let registeredOrdinary = await manager.connectionLimiterSnapshotForTesting(
+                connectionID: victimID,
+                lane: .ordinary
+            )
+            let registeredFileSearch = await manager.connectionLimiterSnapshotForTesting(
+                connectionID: victimID,
+                lane: .fileSearch
+            )
+            XCTAssertNotNil(registeredOrdinary)
+            XCTAssertNotNil(registeredFileSearch)
+            XCTAssertFalse(registeredOrdinary?.isClosed ?? true)
+            XCTAssertFalse(registeredFileSearch?.isClosed ?? true)
+
+            if registeredOrdinary != nil, registeredFileSearch != nil {
+                let ordinaryRan = LimiterTestFlag()
+                let fileSearchRan = LimiterTestFlag()
+                try await manager.withConnectionCallPermitForTesting(
+                    connectionID: victimID,
+                    lane: .ordinary
+                ) {
+                    await ordinaryRan.mark()
+                }
+                try await manager.withConnectionCallPermitForTesting(
+                    connectionID: victimID,
+                    lane: .fileSearch
+                ) {
+                    await fileSearchRan.mark()
+                }
+                let didRunOrdinary = await ordinaryRan.isMarked()
+                let didRunFileSearch = await fileSearchRan.isMarked()
+                XCTAssertTrue(didRunOrdinary)
+                XCTAssertTrue(didRunFileSearch)
+            }
+
+            await siblingStopGate.release()
+            await assertCompletion(siblingRemovalTask, description: "sibling removal")
+            await manager.debugRemoveConnection(victimID)
+        }
+
+        func testDirectAdmissionRejectsActorIdentityReplacementAfterSuspension() async {
+            await assertDirectAdmissionRejectsStaleResume(
+                advanceLifecycleGeneration: false,
+                replaceConnectionActor: true
+            )
+        }
+
+        func testDirectAdmissionRejectsLifecycleGenerationReplacementAfterSuspension() async {
+            await assertDirectAdmissionRejectsStaleResume(
+                advanceLifecycleGeneration: true,
+                replaceConnectionActor: false
+            )
+        }
+
+        func testDirectAdmissionRejectsRemovalCommittedWhileSuspended() async {
+            let manager = ServerNetworkManager()
+            let connectionID = UUID()
+            let stopGate = LimiterTestGate()
+            let removalTask = LimiterTestTaskStore()
+
+            await manager.debugInstallDirectAdmissionConnectionForTesting(
+                connectionID: connectionID,
+                connection: AdmissionEvictionTestConnection(
+                    idleSeconds: 0,
+                    stopGate: stopGate
+                )
+            )
+            await manager.debugSetAfterDirectAdmissionPendingPublishedForTesting { suspendedConnectionID in
+                guard suspendedConnectionID == connectionID else { return }
+                await removalTask.start {
+                    await manager.debugRemoveConnection(connectionID)
+                }
+                _ = await stopGate.waitUntilStarted(timeout: .seconds(2))
+            }
+
+            let admitted = await manager.tryReserveConnectionSlot(
+                connectionID: connectionID,
+                clientID: "direct-removal-fence-\(UUID().uuidString)"
+            )
+            await manager.debugSetAfterDirectAdmissionPendingPublishedForTesting(nil)
+            XCTAssertFalse(
+                admitted,
+                "A direct admission must not resume after exact removal ownership is committed"
+            )
+
+            await stopGate.release()
+            await assertCompletion(removalTask, description: "direct admission removal")
+        }
+
+        func testDirectAdmissionLifecycleChangeDuringAtomicCloseStillRemovesClosedVictim() async {
+            let manager = ServerNetworkManager()
+            let incomingConnectionID = UUID()
+            let victimID = UUID()
+            let originalClientID = "close-lifecycle-original-\(UUID().uuidString)"
+            let replacementClientID = "close-lifecycle-replacement-\(UUID().uuidString)"
+            let incomingConnection = AdmissionEvictionTestConnection(idleSeconds: 0)
+
+            await manager.debugConfigureGlobalAdmissionForTesting(
+                maxGlobalConnections: 2,
+                preserveOnePerClient: false
+            )
+            await manager.debugInstallDirectAdmissionConnectionForTesting(
+                connectionID: incomingConnectionID,
+                connection: incomingConnection
+            )
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: victimID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 180),
+                clientID: "close-lifecycle-victim-\(UUID().uuidString)",
+                totalToolCalls: 0,
+                createdAt: .distantPast
+            )
+            await manager.debugSetDuringAdmissionEvictionCloseForTesting { candidateID in
+                guard candidateID == victimID else { return }
+                await manager.debugInstallDirectAdmissionConnectionForTesting(
+                    connectionID: incomingConnectionID,
+                    connection: incomingConnection,
+                    pendingClientID: replacementClientID,
+                    advanceLifecycleGeneration: true
+                )
+            }
+
+            let admitted = await manager.tryReserveConnectionSlot(
+                connectionID: incomingConnectionID,
+                clientID: originalClientID
+            )
+            await manager.debugSetDuringAdmissionEvictionCloseForTesting(nil)
+
+            XCTAssertFalse(admitted)
+            let victimRetained = await manager.debugContainsConnection(victimID)
+            XCTAssertFalse(
+                victimRetained,
+                "A successfully closed victim must be removed before stale admission is reported"
+            )
+            let incomingState = await manager.debugDirectAdmissionStateForTesting(
+                connectionID: incomingConnectionID
+            )
+            XCTAssertEqual(incomingState.pendingClientID, replacementClientID)
+            XCTAssertNil(incomingState.indexedClientID)
+            XCTAssertFalse(incomingState.hasStats)
+
+            await manager.debugRemoveConnection(incomingConnectionID)
+            await manager.debugRemoveConnection(victimID)
+            await manager.debugConfigureGlobalAdmissionForTesting(
+                maxGlobalConnections: nil,
+                preserveOnePerClient: nil
+            )
+        }
+
+        func testBootstrapAdmissionUsesReboundSessionReplacementAfterPolicyReadiness() async {
+            let manager = ServerNetworkManager()
+            let clientID = "bootstrap-rebind-\(UUID().uuidString)"
+            let sessionToken = "bootstrap-rebind-token-\(UUID().uuidString)"
+            let staleReplacementID = UUID()
+            let currentReplacementID = UUID()
+            let retainedID = UUID()
+
+            await manager.debugConfigureGlobalAdmissionForTesting(
+                maxGlobalConnections: 2,
+                preserveOnePerClient: true
+            )
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: currentReplacementID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 180),
+                clientID: clientID,
+                totalToolCalls: 0,
+                createdAt: .distantPast
+            )
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: staleReplacementID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 120),
+                clientID: clientID,
+                totalToolCalls: 1,
+                createdAt: Date(timeIntervalSince1970: 1)
+            )
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: retainedID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 60),
+                clientID: clientID,
+                totalToolCalls: 2,
+                createdAt: Date()
+            )
+            await manager.debugBindSessionTokenForAdmissionTesting(sessionToken, to: staleReplacementID)
+            await manager.debugSetAfterBootstrapPolicyReadinessForTesting { observedToken in
+                guard observedToken == sessionToken else { return }
+                await manager.debugBindSessionTokenForAdmissionTesting(
+                    sessionToken,
+                    to: currentReplacementID
+                )
+            }
+
+            let admitted = await manager.debugBootstrapAdmissionHasCapacityForTesting(
+                sessionToken: sessionToken
+            )
+            await manager.debugSetAfterBootstrapPolicyReadinessForTesting(nil)
+
+            XCTAssertTrue(admitted)
+            let retainedCurrentReplacement = await manager.debugContainsConnection(currentReplacementID)
+            let retainedStaleReplacement = await manager.debugContainsConnection(staleReplacementID)
+            let retainedOther = await manager.debugContainsConnection(retainedID)
+            XCTAssertTrue(
+                retainedCurrentReplacement,
+                "Capacity eviction must protect the replacement currently bound to the durable session token"
+            )
+            XCTAssertFalse(
+                retainedStaleReplacement,
+                "Capacity eviction should remove the least valuable non-current replacement"
+            )
+            XCTAssertTrue(retainedOther)
+
+            await manager.debugRemoveConnection(staleReplacementID)
+            await manager.debugRemoveConnection(currentReplacementID)
+            await manager.debugRemoveConnection(retainedID)
+            await manager.debugConfigureGlobalAdmissionForTesting(
+                maxGlobalConnections: nil,
+                preserveOnePerClient: nil
+            )
+        }
+
+        func testBootstrapAdmissionDoesNotResurrectFormerReplacementAfterReboundReplacementDisappears() async {
+            let manager = ServerNetworkManager()
+            let sessionToken = "bootstrap-rebound-disappeared-token-\(UUID().uuidString)"
+            let formerReplacementID = UUID()
+            let reboundReplacementID = UUID()
+            let retainedID = UUID()
+
+            await manager.debugConfigureGlobalAdmissionForTesting(
+                maxGlobalConnections: 2,
+                preserveOnePerClient: false
+            )
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: formerReplacementID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 180),
+                clientID: "bootstrap-former-replacement-\(UUID().uuidString)",
+                totalToolCalls: 0,
+                createdAt: .distantPast
+            )
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: reboundReplacementID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 60),
+                clientID: "bootstrap-rebound-replacement-\(UUID().uuidString)",
+                totalToolCalls: 1,
+                createdAt: Date()
+            )
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: retainedID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 30),
+                clientID: "bootstrap-rebound-retained-\(UUID().uuidString)",
+                totalToolCalls: 2,
+                createdAt: Date()
+            )
+            await manager.debugBindSessionTokenForAdmissionTesting(sessionToken, to: formerReplacementID)
+            await manager.debugBindSessionTokenForAdmissionTesting(sessionToken, to: reboundReplacementID)
+            await manager.debugSetAfterBootstrapPolicyReadinessForTesting { observedToken in
+                guard observedToken == sessionToken else { return }
+                await manager.debugRemoveConnection(reboundReplacementID)
+            }
+
+            let admitted = await manager.debugBootstrapAdmissionHasCapacityForTesting(
+                sessionToken: sessionToken
+            )
+            await manager.debugSetAfterBootstrapPolicyReadinessForTesting(nil)
+
+            XCTAssertTrue(admitted)
+            let retainedFormerReplacement = await manager.debugContainsConnection(formerReplacementID)
+            let retainedReboundReplacement = await manager.debugContainsConnection(reboundReplacementID)
+            let retainedOther = await manager.debugContainsConnection(retainedID)
+            XCTAssertFalse(
+                retainedFormerReplacement,
+                "A former token owner must not be resurrected after the rebound replacement disappears"
+            )
+            XCTAssertFalse(retainedReboundReplacement)
+            XCTAssertTrue(retainedOther)
+
+            await manager.debugRemoveConnection(formerReplacementID)
+            await manager.debugRemoveConnection(reboundReplacementID)
+            await manager.debugRemoveConnection(retainedID)
+            await manager.debugConfigureGlobalAdmissionForTesting(
+                maxGlobalConnections: nil,
+                preserveOnePerClient: nil
+            )
+        }
+
+        func testBootstrapAdmissionStopsDiscountingDisappearedSessionReplacementAfterPolicyReadiness() async {
+            let manager = ServerNetworkManager()
+            let sessionToken = "bootstrap-disappeared-token-\(UUID().uuidString)"
+            let disappearedReplacementID = UUID()
+            let retainedID = UUID()
+
+            await manager.debugConfigureGlobalAdmissionForTesting(
+                maxGlobalConnections: 2,
+                preserveOnePerClient: false
+            )
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: disappearedReplacementID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 180),
+                clientID: "bootstrap-disappeared-\(UUID().uuidString)",
+                totalToolCalls: 0,
+                createdAt: .distantPast
+            )
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: retainedID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 60),
+                clientID: "bootstrap-retained-\(UUID().uuidString)",
+                totalToolCalls: 1,
+                createdAt: Date()
+            )
+            await manager.debugBindSessionTokenForAdmissionTesting(sessionToken, to: disappearedReplacementID)
+            await manager.debugSetAfterBootstrapPolicyReadinessForTesting { observedToken in
+                guard observedToken == sessionToken else { return }
+                await manager.debugUnbindSessionTokenForAdmissionTesting(
+                    sessionToken,
+                    from: disappearedReplacementID
+                )
+            }
+
+            let admitted = await manager.debugBootstrapAdmissionHasCapacityForTesting(
+                sessionToken: sessionToken
+            )
+            await manager.debugSetAfterBootstrapPolicyReadinessForTesting(nil)
+
+            XCTAssertTrue(admitted)
+            let retainedDisappearedReplacement = await manager.debugContainsConnection(disappearedReplacementID)
+            let retainedOther = await manager.debugContainsConnection(retainedID)
+            XCTAssertFalse(
+                retainedDisappearedReplacement,
+                "A connection no longer bound to the durable token must not receive replacement capacity credit"
+            )
+            XCTAssertTrue(retainedOther)
+
+            await manager.debugRemoveConnection(disappearedReplacementID)
+            await manager.debugRemoveConnection(retainedID)
+            await manager.debugConfigureGlobalAdmissionForTesting(
+                maxGlobalConnections: nil,
+                preserveOnePerClient: nil
+            )
+        }
+
+        func testDirectGlobalAdmissionPreservesCandidateWhenRemovalCreatesHeadroomBeforeClose() async throws {
+            try await assertGlobalAdmissionPreservesCandidateWhenRemovalCreatesHeadroomBeforeClose(path: .direct)
+        }
+
+        func testBootstrapGlobalAdmissionPreservesCandidateWhenRemovalCreatesHeadroomBeforeClose() async throws {
+            try await assertGlobalAdmissionPreservesCandidateWhenRemovalCreatesHeadroomBeforeClose(path: .bootstrap)
+        }
+
+        func testDirectGlobalAdmissionRestoresClosedCandidateWhenRemovalCreatesHeadroomDuringClose() async throws {
+            try await assertGlobalAdmissionRestoresClosedCandidateWhenRemovalCreatesHeadroomDuringClose(path: .direct)
+        }
+
+        func testBootstrapGlobalAdmissionRestoresClosedCandidateWhenRemovalCreatesHeadroomDuringClose() async throws {
+            try await assertGlobalAdmissionRestoresClosedCandidateWhenRemovalCreatesHeadroomDuringClose(path: .bootstrap)
+        }
+
+        func testPerClientAdmissionAcceptsWhenConcurrentRemovalCreatesCapacityWithoutClosingCandidate() async {
+            let manager = ServerNetworkManager()
+            let clientID = "per-client-capacity-progress-\(UUID().uuidString)"
+            let victimID = UUID()
+            let siblingID = UUID()
+            let incomingConnectionID = UUID()
+            let incomingConnection = AdmissionEvictionTestConnection(idleSeconds: 0)
+            let siblingStopGate = LimiterTestGate()
+            let victimBusyGate = LimiterTestGate()
+            let victimBusyTask = LimiterTestTaskStore()
+            let siblingRemovalTask = LimiterTestTaskStore()
+
+            await manager.debugConfigurePerClientAdmissionForTesting(maxConnectionsPerClient: 2)
+            await manager.debugInstallDirectAdmissionConnectionForTesting(
+                connectionID: incomingConnectionID,
+                connection: incomingConnection
+            )
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: victimID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 180),
+                clientID: clientID,
+                totalToolCalls: 0,
+                createdAt: .distantPast
+            )
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: siblingID,
+                connection: AdmissionEvictionTestConnection(
+                    idleSeconds: 60,
+                    stopGate: siblingStopGate
+                ),
+                clientID: clientID,
+                totalToolCalls: 1,
+                createdAt: Date()
+            )
+            await manager.debugSetBeforeAdmissionEvictionCloseForTesting { candidateID in
+                guard candidateID == victimID else { return }
+                await victimBusyTask.start {
+                    try? await manager.withConnectionCallPermitForTesting(
+                        connectionID: victimID,
+                        lane: .ordinary
+                    ) {
+                        await victimBusyGate.markStartedAndWaitForRelease()
+                    }
+                }
+                guard await victimBusyGate.waitUntilStarted(timeout: .seconds(2)) else { return }
+                await siblingRemovalTask.start {
+                    await manager.debugRemoveConnection(siblingID)
+                }
+                _ = await siblingStopGate.waitUntilStarted(timeout: .seconds(2))
+            }
+
+            let admitted = await manager.tryReserveConnectionSlot(
+                connectionID: incomingConnectionID,
+                clientID: clientID
+            )
+            await manager.debugSetBeforeAdmissionEvictionCloseForTesting(nil)
+
+            XCTAssertTrue(
+                admitted,
+                "Per-client admission must recheck effective membership when another removal creates capacity"
+            )
+            let victimRetained = await manager.debugContainsConnection(victimID)
+            let removingSiblingRetained = await manager.debugContainsConnection(siblingID)
+            XCTAssertTrue(victimRetained)
+            XCTAssertTrue(
+                removingSiblingRetained,
+                "The fixture must observe removal after effective membership changes but before indexed cleanup"
+            )
+
+            await victimBusyGate.release()
+            await assertCompletion(victimBusyTask, description: "per-client victim busy task")
+            await siblingStopGate.release()
+            await assertCompletion(siblingRemovalTask, description: "per-client sibling removal")
+            await manager.debugRemoveConnection(incomingConnectionID)
+            await manager.debugRemoveConnection(victimID)
+            await manager.debugConfigurePerClientAdmissionForTesting(maxConnectionsPerClient: nil)
+        }
+
+        func testPerClientAdmissionRestoresClosedCandidateWhenRemovalCreatesCapacityDuringClose() async throws {
+            let manager = ServerNetworkManager()
+            let clientID = "per-client-capacity-during-close-\(UUID().uuidString)"
+            let victimID = UUID()
+            let siblingID = UUID()
+            let incomingConnectionID = UUID()
+            let siblingStopGate = LimiterTestGate()
+            let siblingRemovalTask = LimiterTestTaskStore()
+
+            await manager.debugConfigurePerClientAdmissionForTesting(maxConnectionsPerClient: 2)
+            await manager.debugInstallDirectAdmissionConnectionForTesting(
+                connectionID: incomingConnectionID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 0)
+            )
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: victimID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 180),
+                clientID: clientID,
+                totalToolCalls: 0,
+                createdAt: .distantPast
+            )
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: siblingID,
+                connection: AdmissionEvictionTestConnection(
+                    idleSeconds: 60,
+                    stopGate: siblingStopGate
+                ),
+                clientID: clientID,
+                totalToolCalls: 1,
+                createdAt: Date()
+            )
+            let installedOrdinary = await manager.limiter(for: victimID, lane: .ordinary)
+            let installedFileSearch = await manager.limiter(for: victimID, lane: .fileSearch)
+            let originalOrdinary = try XCTUnwrap(installedOrdinary)
+            let originalFileSearch = try XCTUnwrap(installedFileSearch)
+
+            await manager.debugSetDuringAdmissionEvictionCloseForTesting { candidateID in
+                guard candidateID == victimID else { return }
+                await siblingRemovalTask.start {
+                    await manager.debugRemoveConnection(siblingID)
+                }
+                _ = await siblingStopGate.waitUntilStarted(timeout: .seconds(2))
+            }
+
+            let admitted = await manager.tryReserveConnectionSlot(
+                connectionID: incomingConnectionID,
+                clientID: clientID
+            )
+            await manager.debugSetDuringAdmissionEvictionCloseForTesting(nil)
+
+            let siblingRemovalStarted = await siblingStopGate.hasStarted()
+            let victimRetained = await manager.debugContainsConnection(victimID)
+            let removingSiblingRetained = await manager.debugContainsConnection(siblingID)
+            let originalOrdinarySnapshot = await originalOrdinary.debugSnapshot()
+            let originalFileSearchSnapshot = await originalFileSearch.debugSnapshot()
+            XCTAssertTrue(admitted)
+            XCTAssertTrue(siblingRemovalStarted)
+            XCTAssertTrue(victimRetained)
+            XCTAssertTrue(
+                removingSiblingRetained,
+                "The fixture must observe effective removal before indexed cleanup completes"
+            )
+            XCTAssertTrue(originalOrdinarySnapshot.isClosed)
+            XCTAssertTrue(originalFileSearchSnapshot.isClosed)
+
+            let registeredOrdinary = await manager.connectionLimiterSnapshotForTesting(
+                connectionID: victimID,
+                lane: .ordinary
+            )
+            let registeredFileSearch = await manager.connectionLimiterSnapshotForTesting(
+                connectionID: victimID,
+                lane: .fileSearch
+            )
+            XCTAssertFalse(registeredOrdinary?.isClosed ?? true)
+            XCTAssertFalse(registeredFileSearch?.isClosed ?? true)
+
+            let ordinaryRan = LimiterTestFlag()
+            let fileSearchRan = LimiterTestFlag()
+            try await manager.withConnectionCallPermitForTesting(
+                connectionID: victimID,
+                lane: .ordinary
+            ) {
+                await ordinaryRan.mark()
+            }
+            try await manager.withConnectionCallPermitForTesting(
+                connectionID: victimID,
+                lane: .fileSearch
+            ) {
+                await fileSearchRan.mark()
+            }
+            let didRunOrdinary = await ordinaryRan.isMarked()
+            let didRunFileSearch = await fileSearchRan.isMarked()
+            XCTAssertTrue(didRunOrdinary)
+            XCTAssertTrue(didRunFileSearch)
+
+            await siblingStopGate.release()
+            await assertCompletion(siblingRemovalTask, description: "per-client during-close sibling removal")
+            await manager.debugRemoveConnection(incomingConnectionID)
+            await manager.debugRemoveConnection(victimID)
+            await manager.debugConfigurePerClientAdmissionForTesting(maxConnectionsPerClient: nil)
+        }
+
+        func testDirectAdmissionCountsLiveBootstrapReservationsInGlobalEffectiveLoad() async {
+            let manager = ServerNetworkManager()
+            let incomingConnectionID = UUID()
+            let existingConnectionID = UUID()
+            let firstReservationID = UUID()
+            let secondReservationID = UUID()
+            let busyGate = LimiterTestGate()
+
+            await manager.debugConfigureGlobalAdmissionForTesting(
+                maxGlobalConnections: 3,
+                preserveOnePerClient: false
+            )
+            await manager.debugInstallDirectAdmissionConnectionForTesting(
+                connectionID: incomingConnectionID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 0)
+            )
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: existingConnectionID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 120),
+                clientID: "reservation-aware-existing-\(UUID().uuidString)",
+                totalToolCalls: 0,
+                createdAt: .distantPast
+            )
+            let firstReserved = await manager.debugReserveBootstrapSlotForTesting(
+                connectionID: firstReservationID,
+                sessionToken: "reservation-aware-first-\(UUID().uuidString)"
+            )
+            let secondReserved = await manager.debugReserveBootstrapSlotForTesting(
+                connectionID: secondReservationID,
+                sessionToken: "reservation-aware-second-\(UUID().uuidString)"
+            )
+            XCTAssertTrue(firstReserved)
+            XCTAssertTrue(secondReserved)
+
+            let busyTask = Task {
+                try? await manager.withConnectionCallPermitForTesting(
+                    connectionID: existingConnectionID,
+                    lane: .ordinary
+                ) {
+                    await busyGate.markStartedAndWaitForRelease()
+                }
+            }
+            await assertStarted(busyGate, description: "reservation-aware existing connection")
+
+            let admitted = await manager.tryReserveConnectionSlot(
+                connectionID: incomingConnectionID,
+                clientID: "reservation-aware-incoming-\(UUID().uuidString)"
+            )
+            let state = await manager.debugDirectAdmissionStateForTesting(
+                connectionID: incomingConnectionID
+            )
+
+            XCTAssertFalse(
+                admitted,
+                "Direct admission must reserve room for all live bootstrap reservations"
+            )
+            XCTAssertNil(state.indexedClientID)
+            XCTAssertFalse(state.hasStats)
+
+            await busyGate.release()
+            await assertCompletion(busyTask, description: "reservation-aware busy connection")
+            await manager.debugRollbackBootstrapReservationForTesting(connectionID: firstReservationID)
+            await manager.debugRollbackBootstrapReservationForTesting(connectionID: secondReservationID)
+            await manager.debugRemoveConnection(incomingConnectionID)
+            await manager.debugRemoveConnection(existingConnectionID)
+            await manager.debugConfigureGlobalAdmissionForTesting(
+                maxGlobalConnections: nil,
+                preserveOnePerClient: nil
+            )
+        }
+
+        func testDirectAdmissionUsesReplacementCreditForLiveBootstrapReservations() async {
+            let manager = ServerNetworkManager()
+            let incomingConnectionID = UUID()
+            let predecessorID = UUID()
+            let replacementReservationID = UUID()
+            let ordinaryReservationID = UUID()
+            let sessionToken = "direct-replacement-credit-\(UUID().uuidString)"
+            let predecessorBusyGate = LimiterTestGate()
+
+            await manager.debugConfigureGlobalAdmissionForTesting(
+                maxGlobalConnections: 4,
+                preserveOnePerClient: false
+            )
+            await manager.debugInstallDirectAdmissionConnectionForTesting(
+                connectionID: incomingConnectionID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 0)
+            )
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: predecessorID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 120),
+                clientID: "direct-replacement-credit-predecessor",
+                totalToolCalls: 0,
+                createdAt: .distantPast
+            )
+            await manager.debugBindSessionTokenForAdmissionTesting(sessionToken, to: predecessorID)
+            let replacementReserved = await manager.debugReserveBootstrapSlotForTesting(
+                connectionID: replacementReservationID,
+                sessionToken: sessionToken
+            )
+            let ordinaryReserved = await manager.debugReserveBootstrapSlotForTesting(
+                connectionID: ordinaryReservationID,
+                sessionToken: "direct-ordinary-reservation-\(UUID().uuidString)"
+            )
+            XCTAssertTrue(replacementReserved)
+            XCTAssertTrue(ordinaryReserved)
+
+            let predecessorBusyTask = Task {
+                try? await manager.withConnectionCallPermitForTesting(
+                    connectionID: predecessorID,
+                    lane: .ordinary
+                ) {
+                    await predecessorBusyGate.markStartedAndWaitForRelease()
+                }
+            }
+            await assertStarted(predecessorBusyGate, description: "direct credited predecessor")
+
+            let admitted = await manager.tryReserveConnectionSlot(
+                connectionID: incomingConnectionID,
+                clientID: "direct-replacement-credit-incoming"
+            )
+            XCTAssertTrue(
+                admitted,
+                "Direct admission must use the reservation's valid predecessor credit"
+            )
+
+            await predecessorBusyGate.release()
+            await assertCompletion(predecessorBusyTask, description: "direct credited predecessor")
+            await manager.debugRollbackBootstrapReservationForTesting(
+                connectionID: replacementReservationID
+            )
+            await manager.debugRollbackBootstrapReservationForTesting(
+                connectionID: ordinaryReservationID
+            )
+            await manager.debugRemoveConnection(incomingConnectionID)
+            await manager.debugRemoveConnection(predecessorID)
+            await manager.debugConfigureGlobalAdmissionForTesting(
+                maxGlobalConnections: nil,
+                preserveOnePerClient: nil
+            )
+        }
+
+        func testDirectAdmissionRechecksReservationLoadAfterPerClientSuspension() async {
+            let manager = ServerNetworkManager()
+            let clientID = "direct-reservation-recheck-\(UUID().uuidString)"
+            let incomingConnectionID = UUID()
+            let victimID = UUID()
+            let busySiblingID = UUID()
+            let reservationIDs = [UUID(), UUID(), UUID()]
+            let busySiblingGate = LimiterTestGate()
+
+            await manager.debugConfigureGlobalAdmissionForTesting(
+                maxGlobalConnections: 5,
+                preserveOnePerClient: false
+            )
+            await manager.debugConfigurePerClientAdmissionForTesting(maxConnectionsPerClient: 2)
+            await manager.debugInstallDirectAdmissionConnectionForTesting(
+                connectionID: incomingConnectionID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 0)
+            )
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: victimID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 180),
+                clientID: clientID,
+                totalToolCalls: 0,
+                createdAt: .distantPast
+            )
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: busySiblingID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 60),
+                clientID: clientID,
+                totalToolCalls: 1,
+                createdAt: Date()
+            )
+            let busySiblingTask = Task {
+                try? await manager.withConnectionCallPermitForTesting(
+                    connectionID: busySiblingID,
+                    lane: .ordinary
+                ) {
+                    await busySiblingGate.markStartedAndWaitForRelease()
+                }
+            }
+            await assertStarted(busySiblingGate, description: "direct reservation recheck sibling")
+
+            await manager.debugSetBeforeAdmissionEvictionCloseForTesting { candidateID in
+                guard candidateID == victimID else { return }
+                for (index, reservationID) in reservationIDs.enumerated() {
+                    _ = await manager.debugReserveBootstrapSlotForTesting(
+                        connectionID: reservationID,
+                        sessionToken: "direct-recheck-reservation-\(index)-\(UUID().uuidString)"
+                    )
+                }
+            }
+
+            let admitted = await manager.tryReserveConnectionSlot(
+                connectionID: incomingConnectionID,
+                clientID: clientID
+            )
+            await manager.debugSetBeforeAdmissionEvictionCloseForTesting(nil)
+            XCTAssertFalse(
+                admitted,
+                "Direct admission must recheck global reservation load after per-client awaits"
+            )
+
+            await busySiblingGate.release()
+            await assertCompletion(busySiblingTask, description: "direct reservation recheck sibling")
+            for reservationID in reservationIDs {
+                await manager.debugRollbackBootstrapReservationForTesting(
+                    connectionID: reservationID
+                )
+            }
+            await manager.debugRemoveConnection(incomingConnectionID)
+            await manager.debugRemoveConnection(victimID)
+            await manager.debugRemoveConnection(busySiblingID)
+            await manager.debugConfigurePerClientAdmissionForTesting(maxConnectionsPerClient: nil)
+            await manager.debugConfigureGlobalAdmissionForTesting(
+                maxGlobalConnections: nil,
+                preserveOnePerClient: nil
+            )
+        }
+
+        func testProspectiveBootstrapClaimProtectsPredecessorFromPerClientEviction() async {
+            let manager = ServerNetworkManager()
+            let clientID = "claim-per-client-\(UUID().uuidString)"
+            let sessionToken = "claim-per-client-\(UUID().uuidString)"
+            let predecessorID = UUID()
+            let siblingID = UUID()
+            let claimID = UUID()
+
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: predecessorID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 180),
+                clientID: clientID,
+                totalToolCalls: 0,
+                createdAt: .distantPast
+            )
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: siblingID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 60),
+                clientID: clientID,
+                totalToolCalls: 1,
+                createdAt: Date()
+            )
+            await manager.debugBindSessionTokenForAdmissionTesting(sessionToken, to: predecessorID)
+            let claimed = await manager.debugClaimBootstrapAdmissionForTesting(
+                connectionID: claimID,
+                sessionToken: sessionToken
+            )
+            XCTAssertTrue(claimed)
+
+            let protectedBeforeEviction = await manager.debugProtectedBootstrapPredecessorConnectionIDsForTesting()
+            let didEvict = await manager.debugEvictLeastValuableForTesting(clientID: clientID)
+            let predecessorRetained = await manager.debugContainsConnection(predecessorID)
+            let siblingRetained = await manager.debugContainsConnection(siblingID)
+            XCTAssertTrue(protectedBeforeEviction.contains(predecessorID))
+            XCTAssertTrue(didEvict)
+            XCTAssertTrue(predecessorRetained)
+            XCTAssertFalse(siblingRetained)
+
+            await manager.debugReleaseBootstrapAdmissionClaimForTesting(
+                connectionID: claimID,
+                sessionToken: sessionToken
+            )
+            await manager.debugRemoveConnection(predecessorID)
+            await manager.debugRemoveConnection(siblingID)
+        }
+
+        func testProspectiveBootstrapClaimProtectsPredecessorFromPressureEviction() async {
+            let manager = ServerNetworkManager()
+            let sessionToken = "claim-pressure-\(UUID().uuidString)"
+            let predecessorID = UUID()
+            let siblingID = UUID()
+            let claimID = UUID()
+
+            await manager.debugConfigureGlobalAdmissionForTesting(
+                maxGlobalConnections: 2,
+                preserveOnePerClient: false
+            )
+            await manager.debugConfigurePressureEvictionForTesting(idleSeconds: 1)
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: predecessorID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 180),
+                clientID: "claim-pressure-predecessor",
+                totalToolCalls: 0,
+                createdAt: .distantPast
+            )
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: siblingID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 60),
+                clientID: "claim-pressure-sibling",
+                totalToolCalls: 1,
+                createdAt: Date()
+            )
+            await manager.debugBindSessionTokenForAdmissionTesting(sessionToken, to: predecessorID)
+            let claimed = await manager.debugClaimBootstrapAdmissionForTesting(
+                connectionID: claimID,
+                sessionToken: sessionToken
+            )
+            XCTAssertTrue(claimed)
+
+            await manager.debugPressureEvictIdleConnectionsForTesting()
+            let predecessorRetained = await manager.debugContainsConnection(predecessorID)
+            let siblingRetained = await manager.debugContainsConnection(siblingID)
+            XCTAssertTrue(predecessorRetained)
+            XCTAssertFalse(siblingRetained)
+
+            await manager.debugReleaseBootstrapAdmissionClaimForTesting(
+                connectionID: claimID,
+                sessionToken: sessionToken
+            )
+            await manager.debugRemoveConnection(predecessorID)
+            await manager.debugRemoveConnection(siblingID)
+            await manager.debugConfigurePressureEvictionForTesting(idleSeconds: nil)
+            await manager.debugConfigureGlobalAdmissionForTesting(
+                maxGlobalConnections: nil,
+                preserveOnePerClient: nil
+            )
+        }
+
+        func testProspectiveBootstrapClaimProtectsPredecessorFromGlobalEvictionWithoutDiscountingLoad() async {
+            let manager = ServerNetworkManager()
+            let sessionToken = "claim-global-\(UUID().uuidString)"
+            let predecessorID = UUID()
+            let siblingID = UUID()
+            let claimID = UUID()
+
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: predecessorID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 180),
+                clientID: "claim-global-predecessor",
+                totalToolCalls: 0,
+                createdAt: .distantPast
+            )
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: siblingID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 60),
+                clientID: "claim-global-sibling",
+                totalToolCalls: 1,
+                createdAt: Date()
+            )
+            await manager.debugBindSessionTokenForAdmissionTesting(sessionToken, to: predecessorID)
+            let claimed = await manager.debugClaimBootstrapAdmissionForTesting(
+                connectionID: claimID,
+                sessionToken: sessionToken
+            )
+            XCTAssertTrue(claimed)
+
+            let loadBeforeEviction = await manager.debugGlobalAdmissionLoadComponentsForTesting()
+            let didEvict = await manager.debugEvictLeastValuableGlobalForAdmissionForTesting(
+                preserveOnePerClient: false
+            )
+            XCTAssertEqual(loadBeforeEviction.registeredConnections, 2)
+            XCTAssertEqual(loadBeforeEviction.reservations, 0)
+            XCTAssertEqual(loadBeforeEviction.replacementCredits, 0)
+            XCTAssertEqual(loadBeforeEviction.effectiveLoad, 2)
+            let predecessorRetained = await manager.debugContainsConnection(predecessorID)
+            let siblingRetained = await manager.debugContainsConnection(siblingID)
+            XCTAssertTrue(didEvict)
+            XCTAssertTrue(predecessorRetained)
+            XCTAssertFalse(siblingRetained)
+
+            await manager.debugReleaseBootstrapAdmissionClaimForTesting(
+                connectionID: claimID,
+                sessionToken: sessionToken
+            )
+            await manager.debugRemoveConnection(predecessorID)
+            await manager.debugRemoveConnection(siblingID)
+        }
+
+        func testProspectiveBootstrapClaimCreditInvalidatesOnRebindAndReleaseWithoutResurrection() async {
+            let manager = ServerNetworkManager()
+            let sessionToken = "claim-invalidation-\(UUID().uuidString)"
+            let predecessorID = UUID()
+            let reboundID = UUID()
+            let claimID = UUID()
+
+            await manager.debugInstallDirectAdmissionConnectionForTesting(
+                connectionID: predecessorID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 120)
+            )
+            await manager.debugInstallDirectAdmissionConnectionForTesting(
+                connectionID: reboundID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 60)
+            )
+            await manager.debugBindSessionTokenForAdmissionTesting(sessionToken, to: predecessorID)
+            let claimed = await manager.debugClaimBootstrapAdmissionForTesting(
+                connectionID: claimID,
+                sessionToken: sessionToken
+            )
+            XCTAssertTrue(claimed)
+            let initiallyProtected = await manager.debugProtectedBootstrapPredecessorConnectionIDsForTesting()
+            XCTAssertTrue(initiallyProtected.contains(predecessorID))
+
+            await manager.debugBindSessionTokenForAdmissionTesting(sessionToken, to: reboundID)
+            let protectedAfterRebind = await manager.debugProtectedBootstrapPredecessorConnectionIDsForTesting()
+            XCTAssertFalse(protectedAfterRebind.contains(predecessorID))
+            await manager.debugBindSessionTokenForAdmissionTesting(sessionToken, to: predecessorID)
+            let protectedAfterRebindBack = await manager.debugProtectedBootstrapPredecessorConnectionIDsForTesting()
+            XCTAssertFalse(
+                protectedAfterRebindBack.contains(predecessorID),
+                "Invalidated claim credit must not resurrect when the token points back"
+            )
+
+            await manager.debugReleaseBootstrapAdmissionClaimForTesting(
+                connectionID: claimID,
+                sessionToken: sessionToken
+            )
+            let protectedAfterRelease = await manager.debugProtectedBootstrapPredecessorConnectionIDsForTesting()
+            XCTAssertTrue(protectedAfterRelease.isEmpty)
+            await manager.debugRemoveConnection(predecessorID)
+            await manager.debugRemoveConnection(reboundID)
+        }
+
+        func testReplacementBootstrapReservationCreditsItsExactStillBoundPredecessor() async {
+            let manager = ServerNetworkManager()
+            let predecessorID = UUID()
+            let reservationID = UUID()
+            let sessionToken = "replacement-credit-\(UUID().uuidString)"
+
+            await manager.debugInstallDirectAdmissionConnectionForTesting(
+                connectionID: predecessorID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 120)
+            )
+            await manager.debugBindSessionTokenForAdmissionTesting(sessionToken, to: predecessorID)
+            let reserved = await manager.debugReserveBootstrapSlotForTesting(
+                connectionID: reservationID,
+                sessionToken: sessionToken
+            )
+            XCTAssertTrue(reserved)
+
+            let effectiveLoad = await manager.debugEffectiveGlobalAdmissionLoadForTesting()
+            XCTAssertEqual(
+                effectiveLoad,
+                1,
+                "A replacement reservation and its exact predecessor must count as one transition"
+            )
+
+            await manager.debugRollbackBootstrapReservationForTesting(connectionID: reservationID)
+            await manager.debugRemoveConnection(predecessorID)
+        }
+
+        func testReplacementReservationCreditDoesNotResurrectAfterTokenRebind() async {
+            let manager = ServerNetworkManager()
+            let predecessorID = UUID()
+            let reboundID = UUID()
+            let reservationID = UUID()
+            let sessionToken = "replacement-credit-rebind-\(UUID().uuidString)"
+
+            await manager.debugInstallDirectAdmissionConnectionForTesting(
+                connectionID: predecessorID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 120)
+            )
+            await manager.debugInstallDirectAdmissionConnectionForTesting(
+                connectionID: reboundID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 60)
+            )
+            await manager.debugBindSessionTokenForAdmissionTesting(sessionToken, to: predecessorID)
+            let reserved = await manager.debugReserveBootstrapSlotForTesting(
+                connectionID: reservationID,
+                sessionToken: sessionToken
+            )
+            let initialLoad = await manager.debugEffectiveGlobalAdmissionLoadForTesting()
+            XCTAssertTrue(reserved)
+            XCTAssertEqual(initialLoad, 2)
+
+            await manager.debugBindSessionTokenForAdmissionTesting(sessionToken, to: reboundID)
+            let reboundLoad = await manager.debugEffectiveGlobalAdmissionLoadForTesting()
+            XCTAssertEqual(
+                reboundLoad,
+                3,
+                "Rebinding the token must invalidate the captured predecessor credit"
+            )
+            await manager.debugBindSessionTokenForAdmissionTesting(sessionToken, to: predecessorID)
+            let reboundBackLoad = await manager.debugEffectiveGlobalAdmissionLoadForTesting()
+            XCTAssertEqual(
+                reboundBackLoad,
+                3,
+                "An invalidated reservation credit must not resurrect when the token later points back"
+            )
+
+            await manager.debugRollbackBootstrapReservationForTesting(connectionID: reservationID)
+            await manager.debugRemoveConnection(predecessorID)
+            await manager.debugRemoveConnection(reboundID)
+        }
+
+        func testReplacementReservationCreditDisappearsWhenClaimIsReleased() async {
+            let manager = ServerNetworkManager()
+            let predecessorID = UUID()
+            let reservationID = UUID()
+            let sessionToken = "replacement-credit-claim-\(UUID().uuidString)"
+
+            await manager.debugInstallDirectAdmissionConnectionForTesting(
+                connectionID: predecessorID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 120)
+            )
+            await manager.debugBindSessionTokenForAdmissionTesting(sessionToken, to: predecessorID)
+            let reserved = await manager.debugReserveBootstrapSlotForTesting(
+                connectionID: reservationID,
+                sessionToken: sessionToken
+            )
+            let credited = await manager.debugGlobalAdmissionLoadComponentsForTesting()
+            XCTAssertTrue(reserved)
+            XCTAssertEqual(credited.replacementCredits, 1)
+            XCTAssertEqual(credited.effectiveLoad, 1)
+
+            await manager.debugReleaseBootstrapAdmissionClaimForTesting(
+                connectionID: reservationID,
+                sessionToken: sessionToken
+            )
+            let released = await manager.debugGlobalAdmissionLoadComponentsForTesting()
+            XCTAssertEqual(released.registeredConnections, 1)
+            XCTAssertEqual(released.reservations, 1)
+            XCTAssertEqual(released.replacementCredits, 0)
+            XCTAssertEqual(released.effectiveLoad, 2)
+
+            await manager.debugRollbackBootstrapReservationForTesting(connectionID: reservationID)
+            await manager.debugRemoveConnection(predecessorID)
+        }
+
+        func testReplacementReservationCreditDisappearsWhenPredecessorRemovalStarts() async {
+            let manager = ServerNetworkManager()
+            let predecessorID = UUID()
+            let reservationID = UUID()
+            let sessionToken = "replacement-credit-removal-\(UUID().uuidString)"
+            let stopGate = LimiterTestGate()
+
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: predecessorID,
+                connection: AdmissionEvictionTestConnection(
+                    idleSeconds: 120,
+                    stopGate: stopGate
+                ),
+                clientID: "replacement-credit-removal-client",
+                totalToolCalls: 0,
+                createdAt: .distantPast
+            )
+            await manager.debugBindSessionTokenForAdmissionTesting(sessionToken, to: predecessorID)
+            let reserved = await manager.debugReserveBootstrapSlotForTesting(
+                connectionID: reservationID,
+                sessionToken: sessionToken
+            )
+            XCTAssertTrue(reserved)
+
+            let removal = Task {
+                await manager.debugRemoveConnection(predecessorID)
+            }
+            await assertStarted(stopGate, description: "credited predecessor removal")
+            let duringRemoval = await manager.debugGlobalAdmissionLoadComponentsForTesting()
+            XCTAssertEqual(duringRemoval.registeredConnections, 0)
+            XCTAssertEqual(duringRemoval.reservations, 1)
+            XCTAssertEqual(duringRemoval.replacementCredits, 0)
+            XCTAssertEqual(duringRemoval.effectiveLoad, 1)
+
+            await stopGate.release()
+            await assertCompletion(removal, description: "credited predecessor removal")
+            await manager.debugRollbackBootstrapReservationForTesting(connectionID: reservationID)
+        }
+
+        func testReplacementReservationCleanupRemovesCreditOnExpiryRollbackAndCommit() async {
+            let manager = ServerNetworkManager()
+            let predecessorID = UUID()
+            let sessionToken = "replacement-credit-cleanup-\(UUID().uuidString)"
+
+            await manager.debugInstallDirectAdmissionConnectionForTesting(
+                connectionID: predecessorID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 120)
+            )
+            await manager.debugBindSessionTokenForAdmissionTesting(sessionToken, to: predecessorID)
+
+            let expiredReservationID = UUID()
+            let expiredReserved = await manager.debugReserveBootstrapSlotForTesting(
+                connectionID: expiredReservationID,
+                sessionToken: sessionToken
+            )
+            XCTAssertTrue(expiredReserved)
+            await manager.debugExpireBootstrapReservationForTesting(connectionID: expiredReservationID)
+            let expired = await manager.debugGlobalAdmissionLoadComponentsForTesting()
+            XCTAssertEqual(expired.reservations, 0)
+            XCTAssertEqual(expired.replacementCredits, 0)
+            XCTAssertEqual(expired.effectiveLoad, 1)
+
+            let rolledBackReservationID = UUID()
+            let rollbackReserved = await manager.debugReserveBootstrapSlotForTesting(
+                connectionID: rolledBackReservationID,
+                sessionToken: sessionToken
+            )
+            XCTAssertTrue(rollbackReserved)
+            await manager.debugRollbackBootstrapReservationForTesting(
+                connectionID: rolledBackReservationID
+            )
+            let rolledBack = await manager.debugGlobalAdmissionLoadComponentsForTesting()
+            XCTAssertEqual(rolledBack.reservations, 0)
+            XCTAssertEqual(rolledBack.replacementCredits, 0)
+
+            let committedReservationID = UUID()
+            let commitReserved = await manager.debugReserveBootstrapSlotForTesting(
+                connectionID: committedReservationID,
+                sessionToken: sessionToken
+            )
+            XCTAssertTrue(commitReserved)
+            let committed = await manager.debugCommitBootstrapReservationAccountingForTesting(
+                connectionID: committedReservationID
+            )
+            let afterCommit = await manager.debugGlobalAdmissionLoadComponentsForTesting()
+            XCTAssertTrue(committed)
+            XCTAssertEqual(afterCommit.reservations, 0)
+            XCTAssertEqual(afterCommit.replacementCredits, 0)
+
+            await manager.debugRemoveConnection(predecessorID)
+        }
+
+        func testExpiredReplacementReservationStaysCountedAndCannotCommit() async {
+            let manager = ServerNetworkManager()
+            let predecessorID = UUID()
+            let reservationID = UUID()
+            let sessionToken = "replacement-credit-expired-commit-\(UUID().uuidString)"
+
+            await manager.debugInstallDirectAdmissionConnectionForTesting(
+                connectionID: predecessorID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 120)
+            )
+            await manager.debugBindSessionTokenForAdmissionTesting(sessionToken, to: predecessorID)
+            let reserved = await manager.debugReserveBootstrapSlotForTesting(
+                connectionID: reservationID,
+                sessionToken: sessionToken
+            )
+            XCTAssertTrue(reserved)
+
+            await manager.debugAgeBootstrapReservationPastExpiryForTesting(
+                connectionID: reservationID
+            )
+            let expiredPending = await manager.debugGlobalAdmissionLoadComponentsForTesting()
+            XCTAssertEqual(expiredPending.registeredConnections, 1)
+            XCTAssertEqual(expiredPending.reservations, 1)
+            XCTAssertEqual(expiredPending.replacementCredits, 0)
+            XCTAssertEqual(expiredPending.effectiveLoad, 2)
+
+            let committed = await manager.debugCommitBootstrapReservationAccountingForTesting(
+                connectionID: reservationID
+            )
+            let afterRejectedCommit = await manager.debugGlobalAdmissionLoadComponentsForTesting()
+            XCTAssertFalse(committed)
+            XCTAssertEqual(afterRejectedCommit.reservations, 0)
+            XCTAssertEqual(afterRejectedCommit.replacementCredits, 0)
+            XCTAssertEqual(afterRejectedCommit.effectiveLoad, 1)
+
+            await manager.debugRemoveConnection(predecessorID)
+        }
+
+        func testReplacementReservationCreditIsIdentityAndLifecycleFenced() async {
+            let identityManager = ServerNetworkManager()
+            let identityPredecessorID = UUID()
+            let identityReservationID = UUID()
+            let identityToken = "replacement-credit-identity-\(UUID().uuidString)"
+
+            await identityManager.debugInstallDirectAdmissionConnectionForTesting(
+                connectionID: identityPredecessorID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 120)
+            )
+            await identityManager.debugBindSessionTokenForAdmissionTesting(
+                identityToken,
+                to: identityPredecessorID
+            )
+            let identityReserved = await identityManager.debugReserveBootstrapSlotForTesting(
+                connectionID: identityReservationID,
+                sessionToken: identityToken
+            )
+            XCTAssertTrue(identityReserved)
+            await identityManager.debugInstallDirectAdmissionConnectionForTesting(
+                connectionID: identityPredecessorID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 60)
+            )
+            let identityReplaced = await identityManager.debugGlobalAdmissionLoadComponentsForTesting()
+            XCTAssertEqual(identityReplaced.reservations, 1)
+            XCTAssertEqual(identityReplaced.replacementCredits, 0)
+            XCTAssertEqual(identityReplaced.effectiveLoad, 2)
+            await identityManager.debugRollbackBootstrapReservationForTesting(
+                connectionID: identityReservationID
+            )
+            await identityManager.debugRemoveConnection(identityPredecessorID)
+
+            let lifecycleManager = ServerNetworkManager()
+            let lifecyclePredecessorID = UUID()
+            let lifecycleReservationID = UUID()
+            let lifecycleToken = "replacement-credit-lifecycle-\(UUID().uuidString)"
+            let lifecycleConnection = AdmissionEvictionTestConnection(idleSeconds: 120)
+
+            await lifecycleManager.debugInstallDirectAdmissionConnectionForTesting(
+                connectionID: lifecyclePredecessorID,
+                connection: lifecycleConnection
+            )
+            await lifecycleManager.debugBindSessionTokenForAdmissionTesting(
+                lifecycleToken,
+                to: lifecyclePredecessorID
+            )
+            let lifecycleReserved = await lifecycleManager.debugReserveBootstrapSlotForTesting(
+                connectionID: lifecycleReservationID,
+                sessionToken: lifecycleToken
+            )
+            XCTAssertTrue(lifecycleReserved)
+            await lifecycleManager.debugInstallDirectAdmissionConnectionForTesting(
+                connectionID: lifecyclePredecessorID,
+                connection: lifecycleConnection,
+                advanceLifecycleGeneration: true
+            )
+            let lifecycleReplaced = await lifecycleManager.debugGlobalAdmissionLoadComponentsForTesting()
+            XCTAssertEqual(lifecycleReplaced.reservations, 0)
+            XCTAssertEqual(lifecycleReplaced.replacementCredits, 0)
+            XCTAssertEqual(lifecycleReplaced.effectiveLoad, 1)
+            await lifecycleManager.stop()
+        }
+
+        func testCallEnteringDuringTentativeCloseWaitsForRestoration() async {
+            let manager = ServerNetworkManager()
+            let clientID = "during-close-restoration-\(UUID().uuidString)"
+            let incomingConnectionID = UUID()
+            let victimID = UUID()
+            let siblingID = UUID()
+            let resolutionGate = LimiterTestGate()
+            let rejectionGate = LimiterTestGate()
+            let siblingStopGate = LimiterTestGate()
+            let siblingRemovalTask = LimiterTestTaskStore()
+            let lateCallTask = LimiterTestTaskStore()
+            let operationRan = LimiterTestFlag()
+
+            await manager.debugConfigurePerClientAdmissionForTesting(maxConnectionsPerClient: 2)
+            await manager.debugInstallDirectAdmissionConnectionForTesting(
+                connectionID: incomingConnectionID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 0)
+            )
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: victimID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 180),
+                clientID: clientID,
+                totalToolCalls: 0,
+                createdAt: .distantPast
+            )
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: siblingID,
+                connection: AdmissionEvictionTestConnection(
+                    idleSeconds: 60,
+                    stopGate: siblingStopGate
+                ),
+                clientID: clientID,
+                totalToolCalls: 1,
+                createdAt: Date()
+            )
+            await manager.debugSetAfterConnectionCallLimiterResolutionForTesting { resolvedID in
+                guard resolvedID == victimID else { return }
+                await resolutionGate.markStartedAndWaitForRelease()
+            }
+            await manager.debugSetAfterConnectionCallLimiterRejectionForTesting { rejectedID in
+                guard rejectedID == victimID else { return }
+                await rejectionGate.markStartedAndWaitForRelease()
+            }
+            await manager.debugSetDuringAdmissionEvictionCloseForTesting { candidateID in
+                guard candidateID == victimID else { return }
+                await lateCallTask.start {
+                    try? await manager.withConnectionCallPermitForTesting(
+                        connectionID: victimID,
+                        lane: .ordinary
+                    ) {
+                        await operationRan.mark()
+                    }
+                }
+                guard await resolutionGate.waitUntilStarted(timeout: .seconds(2)) else { return }
+                await resolutionGate.release()
+                guard await rejectionGate.waitUntilStarted(timeout: .seconds(2)) else { return }
+                await rejectionGate.release()
+                let waiterRegistered = await self.waitForAdmissionRetryWaiterCount(
+                    manager: manager,
+                    connectionID: victimID,
+                    expectedCount: 1
+                )
+                guard waiterRegistered else { return }
+                // Cross the former fixed one-second retry deadline while the exact
+                // tentative transition remains unresolved. The call must keep waiting.
+                try? await Task.sleep(for: .milliseconds(1250))
+                await siblingRemovalTask.start {
+                    await manager.debugRemoveConnection(siblingID)
+                }
+                _ = await siblingStopGate.waitUntilStarted(timeout: .seconds(2))
+            }
+
+            let admitted = await manager.tryReserveConnectionSlot(
+                connectionID: incomingConnectionID,
+                clientID: clientID
+            )
+            await manager.debugSetDuringAdmissionEvictionCloseForTesting(nil)
+            await manager.debugSetAfterConnectionCallLimiterResolutionForTesting(nil)
+            await manager.debugSetAfterConnectionCallLimiterRejectionForTesting(nil)
+
+            let lateCallCompleted = await lateCallTask.wait()
+            let didRunOperation = await operationRan.isMarked()
+            XCTAssertTrue(admitted)
+            XCTAssertTrue(lateCallCompleted)
+            XCTAssertTrue(
+                didRunOperation,
+                "A call that encounters the tentatively closed current bundle must await restoration and retry"
+            )
+
+            await siblingStopGate.release()
+            await assertCompletion(siblingRemovalTask, description: "during-close sibling removal")
+            await manager.debugRemoveConnection(incomingConnectionID)
+            await manager.debugRemoveConnection(victimID)
+            await manager.debugConfigurePerClientAdmissionForTesting(maxConnectionsPerClient: nil)
+        }
+
+        func testPerClientEvictionSkipsCreditedBootstrapPredecessor() async {
+            let manager = ServerNetworkManager()
+            let clientID = "per-client-credited-predecessor-\(UUID().uuidString)"
+            let sessionToken = "per-client-credited-predecessor-\(UUID().uuidString)"
+            let predecessorID = UUID()
+            let siblingID = UUID()
+            let reservationID = UUID()
+
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: predecessorID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 180),
+                clientID: clientID,
+                totalToolCalls: 0,
+                createdAt: .distantPast
+            )
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: siblingID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 60),
+                clientID: clientID,
+                totalToolCalls: 1,
+                createdAt: Date()
+            )
+            await manager.debugBindSessionTokenForAdmissionTesting(sessionToken, to: predecessorID)
+            let reserved = await manager.debugReserveBootstrapSlotForTesting(
+                connectionID: reservationID,
+                sessionToken: sessionToken
+            )
+            XCTAssertTrue(reserved)
+
+            let didEvict = await manager.debugEvictLeastValuableForTesting(clientID: clientID)
+            let predecessorRetained = await manager.debugContainsConnection(predecessorID)
+            let siblingRetained = await manager.debugContainsConnection(siblingID)
+            XCTAssertTrue(didEvict)
+            XCTAssertTrue(
+                predecessorRetained,
+                "Per-client eviction must not remove a predecessor carrying live bootstrap credit"
+            )
+            XCTAssertFalse(siblingRetained)
+
+            await manager.debugRollbackBootstrapReservationForTesting(connectionID: reservationID)
+            await manager.debugRemoveConnection(predecessorID)
+            await manager.debugRemoveConnection(siblingID)
+        }
+
+        func testPerClientEvictionRestoresCandidateThatBecomesCreditedDuringClose() async throws {
+            let manager = ServerNetworkManager()
+            let clientID = "per-client-credit-during-close-\(UUID().uuidString)"
+            let sessionToken = "per-client-credit-during-close-\(UUID().uuidString)"
+            let predecessorID = UUID()
+            let reservationID = UUID()
+
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: predecessorID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 180),
+                clientID: clientID,
+                totalToolCalls: 0,
+                createdAt: .distantPast
+            )
+            await manager.debugBindSessionTokenForAdmissionTesting(sessionToken, to: predecessorID)
+            let installedOriginalLimiter = await manager.limiter(
+                for: predecessorID,
+                lane: .ordinary
+            )
+            let originalLimiter = try XCTUnwrap(installedOriginalLimiter)
+            await manager.debugSetDuringAdmissionEvictionCloseForTesting { candidateID in
+                guard candidateID == predecessorID else { return }
+                _ = await manager.debugReserveBootstrapSlotForTesting(
+                    connectionID: reservationID,
+                    sessionToken: sessionToken
+                )
+            }
+
+            let didEvict = await manager.debugEvictLeastValuableForTesting(clientID: clientID)
+            await manager.debugSetDuringAdmissionEvictionCloseForTesting(nil)
+
+            let predecessorRetained = await manager.debugContainsConnection(predecessorID)
+            let originalSnapshot = await originalLimiter.debugSnapshot()
+            let restoredSnapshot = await manager.connectionLimiterSnapshotForTesting(
+                connectionID: predecessorID,
+                lane: .ordinary
+            )
+            XCTAssertFalse(didEvict)
+            XCTAssertTrue(predecessorRetained)
+            XCTAssertTrue(originalSnapshot.isClosed)
+            XCTAssertFalse(restoredSnapshot?.isClosed ?? true)
+
+            await manager.debugRollbackBootstrapReservationForTesting(connectionID: reservationID)
+            await manager.debugRemoveConnection(predecessorID)
+        }
+
+        func testPerClientRemovalCommitPreventsLateCreditFromStrandingClosedPredecessor() async {
+            let manager = ServerNetworkManager()
+            let clientID = "per-client-removal-commit-\(UUID().uuidString)"
+            let sessionToken = "per-client-removal-commit-\(UUID().uuidString)"
+            let predecessorID = UUID()
+            let reservationID = UUID()
+
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: predecessorID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 180),
+                clientID: clientID,
+                totalToolCalls: 0,
+                createdAt: .distantPast
+            )
+            await manager.debugBindSessionTokenForAdmissionTesting(sessionToken, to: predecessorID)
+            await manager.debugSetAfterAdmissionEvictionRemovalCommittedForTesting { candidateID in
+                guard candidateID == predecessorID else { return }
+                _ = await manager.debugReserveBootstrapSlotForTesting(
+                    connectionID: reservationID,
+                    sessionToken: sessionToken
+                )
+            }
+
+            let didEvict = await manager.debugEvictLeastValuableForTesting(clientID: clientID)
+            await manager.debugSetAfterAdmissionEvictionRemovalCommittedForTesting(nil)
+
+            let predecessorRetained = await manager.debugContainsConnection(predecessorID)
+            let load = await manager.debugGlobalAdmissionLoadComponentsForTesting()
+            XCTAssertTrue(didEvict)
+            XCTAssertFalse(predecessorRetained)
+            XCTAssertEqual(load.reservations, 1)
+            XCTAssertEqual(
+                load.replacementCredits,
+                0,
+                "Once exact removal is committed, a late reservation must not credit the closing predecessor"
+            )
+
+            await manager.debugRollbackBootstrapReservationForTesting(connectionID: reservationID)
+            await manager.debugRemoveConnection(predecessorID)
+        }
+
+        func testPressureEvictionSkipsCreditedBootstrapPredecessor() async {
+            let manager = ServerNetworkManager()
+            let sessionToken = "pressure-credited-predecessor-\(UUID().uuidString)"
+            let predecessorID = UUID()
+            let siblingID = UUID()
+            let reservationID = UUID()
+
+            await manager.debugConfigureGlobalAdmissionForTesting(
+                maxGlobalConnections: 2,
+                preserveOnePerClient: false
+            )
+            await manager.debugConfigurePressureEvictionForTesting(idleSeconds: 1)
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: predecessorID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 180),
+                clientID: "pressure-credited-predecessor",
+                totalToolCalls: 0,
+                createdAt: .distantPast
+            )
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: siblingID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 60),
+                clientID: "pressure-ordinary-sibling",
+                totalToolCalls: 1,
+                createdAt: Date()
+            )
+            await manager.debugBindSessionTokenForAdmissionTesting(sessionToken, to: predecessorID)
+            let reserved = await manager.debugReserveBootstrapSlotForTesting(
+                connectionID: reservationID,
+                sessionToken: sessionToken
+            )
+            XCTAssertTrue(reserved)
+
+            await manager.debugPressureEvictIdleConnectionsForTesting()
+            let predecessorRetained = await manager.debugContainsConnection(predecessorID)
+            let siblingRetained = await manager.debugContainsConnection(siblingID)
+            XCTAssertTrue(
+                predecessorRetained,
+                "Pressure eviction must not remove a predecessor carrying live bootstrap credit"
+            )
+            XCTAssertFalse(siblingRetained)
+
+            await manager.debugRollbackBootstrapReservationForTesting(connectionID: reservationID)
+            await manager.debugRemoveConnection(predecessorID)
+            await manager.debugRemoveConnection(siblingID)
+            await manager.debugConfigurePressureEvictionForTesting(idleSeconds: nil)
+            await manager.debugConfigureGlobalAdmissionForTesting(
+                maxGlobalConnections: nil,
+                preserveOnePerClient: nil
+            )
+        }
+
+        func testPressureEvictionRestoresCandidateThatBecomesCreditedDuringClose() async throws {
+            let manager = ServerNetworkManager()
+            let sessionToken = "pressure-credit-during-close-\(UUID().uuidString)"
+            let predecessorID = UUID()
+            let reservationID = UUID()
+
+            await manager.debugConfigureGlobalAdmissionForTesting(
+                maxGlobalConnections: 1,
+                preserveOnePerClient: false
+            )
+            await manager.debugConfigurePressureEvictionForTesting(idleSeconds: 1)
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: predecessorID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 180),
+                clientID: "pressure-credit-during-close",
+                totalToolCalls: 0,
+                createdAt: .distantPast
+            )
+            await manager.debugBindSessionTokenForAdmissionTesting(sessionToken, to: predecessorID)
+            let installedOriginalLimiter = await manager.limiter(
+                for: predecessorID,
+                lane: .ordinary
+            )
+            let originalLimiter = try XCTUnwrap(installedOriginalLimiter)
+            await manager.debugSetDuringAdmissionEvictionCloseForTesting { candidateID in
+                guard candidateID == predecessorID else { return }
+                _ = await manager.debugReserveBootstrapSlotForTesting(
+                    connectionID: reservationID,
+                    sessionToken: sessionToken
+                )
+            }
+
+            await manager.debugPressureEvictIdleConnectionsForTesting()
+            await manager.debugSetDuringAdmissionEvictionCloseForTesting(nil)
+
+            let predecessorRetained = await manager.debugContainsConnection(predecessorID)
+            let originalSnapshot = await originalLimiter.debugSnapshot()
+            let restoredSnapshot = await manager.connectionLimiterSnapshotForTesting(
+                connectionID: predecessorID,
+                lane: .ordinary
+            )
+            XCTAssertTrue(predecessorRetained)
+            XCTAssertTrue(originalSnapshot.isClosed)
+            XCTAssertFalse(restoredSnapshot?.isClosed ?? true)
+
+            await manager.debugRollbackBootstrapReservationForTesting(connectionID: reservationID)
+            await manager.debugRemoveConnection(predecessorID)
+            await manager.debugConfigurePressureEvictionForTesting(idleSeconds: nil)
+            await manager.debugConfigureGlobalAdmissionForTesting(
+                maxGlobalConnections: nil,
+                preserveOnePerClient: nil
+            )
+        }
+
+        func testPreResolvedCallRetriesRestoredLimiterBundleForSameConnectionLifecycle() async throws {
+            let manager = ServerNetworkManager()
+            let clientID = "pre-resolved-restoration-\(UUID().uuidString)"
+            let incomingConnectionID = UUID()
+            let victimID = UUID()
+            let siblingID = UUID()
+            let resolutionGate = LimiterTestGate()
+            let siblingStopGate = LimiterTestGate()
+            let siblingRemovalTask = LimiterTestTaskStore()
+            let operationRan = LimiterTestFlag()
+
+            await manager.debugConfigurePerClientAdmissionForTesting(maxConnectionsPerClient: 2)
+            await manager.debugInstallDirectAdmissionConnectionForTesting(
+                connectionID: incomingConnectionID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 0)
+            )
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: victimID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 180),
+                clientID: clientID,
+                totalToolCalls: 0,
+                createdAt: .distantPast
+            )
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: siblingID,
+                connection: AdmissionEvictionTestConnection(
+                    idleSeconds: 60,
+                    stopGate: siblingStopGate
+                ),
+                clientID: clientID,
+                totalToolCalls: 1,
+                createdAt: Date()
+            )
+            let installedOriginalLimiter = await manager.limiter(for: victimID, lane: .ordinary)
+            let originalLimiter = try XCTUnwrap(installedOriginalLimiter)
+            await manager.debugSetAfterConnectionCallLimiterResolutionForTesting { connectionID in
+                guard connectionID == victimID else { return }
+                await resolutionGate.markStartedAndWaitForRelease()
+            }
+
+            let preResolvedCall = Task {
+                try await manager.withConnectionCallPermitForTesting(
+                    connectionID: victimID,
+                    lane: .ordinary
+                ) {
+                    await operationRan.mark()
+                }
+            }
+            await assertStarted(resolutionGate, description: "pre-resolved limiter call")
+
+            await manager.debugSetDuringAdmissionEvictionCloseForTesting { candidateID in
+                guard candidateID == victimID else { return }
+                await siblingRemovalTask.start {
+                    await manager.debugRemoveConnection(siblingID)
+                }
+                _ = await siblingStopGate.waitUntilStarted(timeout: .seconds(2))
+            }
+            let admitted = await manager.tryReserveConnectionSlot(
+                connectionID: incomingConnectionID,
+                clientID: clientID
+            )
+            await manager.debugSetDuringAdmissionEvictionCloseForTesting(nil)
+            await manager.debugSetAfterConnectionCallLimiterResolutionForTesting(nil)
+            await resolutionGate.release()
+
+            let callSucceeded: Bool
+            do {
+                try await preResolvedCall.value
+                callSucceeded = true
+            } catch {
+                callSucceeded = false
+            }
+            let originalSnapshot = await originalLimiter.debugSnapshot()
+            let restoredSnapshot = await manager.connectionLimiterSnapshotForTesting(
+                connectionID: victimID,
+                lane: .ordinary
+            )
+            let didRunOperation = await operationRan.isMarked()
+
+            XCTAssertTrue(admitted)
+            XCTAssertTrue(originalSnapshot.isClosed)
+            XCTAssertFalse(restoredSnapshot?.isClosed ?? true)
+            XCTAssertTrue(
+                callSucceeded,
+                "A call rejected only by an exact bundle restoration must retry the registered bundle"
+            )
+            XCTAssertTrue(didRunOperation)
+
+            await siblingStopGate.release()
+            await assertCompletion(siblingRemovalTask, description: "pre-resolved sibling removal")
+            await manager.debugRemoveConnection(incomingConnectionID)
+            await manager.debugRemoveConnection(victimID)
+            await manager.debugConfigurePerClientAdmissionForTesting(maxConnectionsPerClient: nil)
+        }
+
+        func testPreResolvedCallRetriesThroughSuccessiveRestoredLimiterBundles() async throws {
+            let manager = ServerNetworkManager()
+            let connectionID = UUID()
+            let resolutionGate = LimiterTestGate()
+            let secondRestorationTriggered = LimiterTestFlag()
+            let operationRan = LimiterTestFlag()
+
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: connectionID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 120),
+                clientID: "successive-restoration-\(UUID().uuidString)",
+                totalToolCalls: 0,
+                createdAt: .distantPast
+            )
+            let installedOriginalLimiter = await manager.limiter(for: connectionID, lane: .ordinary)
+            let originalLimiter = try XCTUnwrap(installedOriginalLimiter)
+            await manager.debugSetAfterConnectionCallLimiterResolutionForTesting { resolvedID in
+                guard resolvedID == connectionID else { return }
+                await resolutionGate.markStartedAndWaitForRelease()
+            }
+
+            let preResolvedCall = Task {
+                try await manager.withConnectionCallPermitForTesting(
+                    connectionID: connectionID,
+                    lane: .ordinary
+                ) {
+                    await operationRan.mark()
+                }
+            }
+            await assertStarted(resolutionGate, description: "successive restoration call")
+
+            let firstRestored = await manager.closeAndRestoreConnectionCallLanesForTesting(connectionID)
+            let installedFirstReplacement = await manager.limiter(for: connectionID, lane: .ordinary)
+            let firstReplacement = try XCTUnwrap(installedFirstReplacement)
+            XCTAssertTrue(firstRestored)
+
+            await manager.debugSetAfterConnectionCallLimiterRejectionForTesting { rejectedID in
+                guard rejectedID == connectionID,
+                      await secondRestorationTriggered.markIfUnmarked()
+                else { return }
+                _ = await manager.closeAndRestoreConnectionCallLanesForTesting(connectionID)
+            }
+            await manager.debugSetAfterConnectionCallLimiterResolutionForTesting(nil)
+            await resolutionGate.release()
+
+            _ = try await boundedValue(
+                of: preResolvedCall,
+                description: "call through successive restored limiter bundles"
+            )
+            await manager.debugSetAfterConnectionCallLimiterRejectionForTesting(nil)
+
+            let installedCurrentLimiter = await manager.limiter(for: connectionID, lane: .ordinary)
+            let currentLimiter = try XCTUnwrap(installedCurrentLimiter)
+            let originalSnapshot = await originalLimiter.debugSnapshot()
+            let firstReplacementSnapshot = await firstReplacement.debugSnapshot()
+            let currentSnapshot = await currentLimiter.debugSnapshot()
+            XCTAssertTrue(originalSnapshot.isClosed)
+            XCTAssertTrue(firstReplacementSnapshot.isClosed)
+            XCTAssertFalse(currentSnapshot.isClosed)
+            let didRunOperation = await operationRan.isMarked()
+            XCTAssertFalse(firstReplacement === currentLimiter)
+            XCTAssertTrue(didRunOperation)
+
+            await manager.debugRemoveConnection(connectionID)
+        }
+
+        func testSuccessiveRestorationDoesNotResurrectConnectionAfterTerminalRemoval() async {
+            let manager = ServerNetworkManager()
+            let connectionID = UUID()
+            let resolutionGate = LimiterTestGate()
+            let terminalTransitionTriggered = LimiterTestFlag()
+            let operationRan = LimiterTestFlag()
+
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: connectionID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 120),
+                clientID: "successive-restoration-removal-\(UUID().uuidString)",
+                totalToolCalls: 0,
+                createdAt: .distantPast
+            )
+            await manager.debugSetAfterConnectionCallLimiterResolutionForTesting { resolvedID in
+                guard resolvedID == connectionID else { return }
+                await resolutionGate.markStartedAndWaitForRelease()
+            }
+
+            let preResolvedCall = Task {
+                try await manager.withConnectionCallPermitForTesting(
+                    connectionID: connectionID,
+                    lane: .ordinary
+                ) {
+                    await operationRan.mark()
+                }
+            }
+            await assertStarted(resolutionGate, description: "successive restoration removal call")
+            let firstRestored = await manager.closeAndRestoreConnectionCallLanesForTesting(connectionID)
+            XCTAssertTrue(firstRestored)
+
+            await manager.debugSetAfterConnectionCallLimiterRejectionForTesting { rejectedID in
+                guard rejectedID == connectionID,
+                      await terminalTransitionTriggered.markIfUnmarked()
+                else { return }
+                _ = await manager.closeAndRestoreConnectionCallLanesForTesting(connectionID)
+                await manager.debugRemoveConnection(connectionID)
+            }
+            await manager.debugSetAfterConnectionCallLimiterResolutionForTesting(nil)
+            await resolutionGate.release()
+
+            await assertCancellation(preResolvedCall)
+            await manager.debugSetAfterConnectionCallLimiterRejectionForTesting(nil)
+            let didRunOperation = await operationRan.isMarked()
+            let registeredLimiter = await manager.connectionLimiterSnapshotForTesting(connectionID: connectionID)
+            XCTAssertFalse(didRunOperation)
+            XCTAssertNil(registeredLimiter)
+        }
+
+        func testPreResolvedCallDoesNotRetryAfterGenuineConnectionRemoval() async {
+            let manager = ServerNetworkManager()
+            let connectionID = UUID()
+            let resolutionGate = LimiterTestGate()
+            let stopGate = LimiterTestGate()
+            let operationRan = LimiterTestFlag()
+
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: connectionID,
+                connection: AdmissionEvictionTestConnection(
+                    idleSeconds: 120,
+                    stopGate: stopGate
+                ),
+                clientID: "pre-resolved-removal-\(UUID().uuidString)",
+                totalToolCalls: 0,
+                createdAt: .distantPast
+            )
+            await manager.debugSetAfterConnectionCallLimiterResolutionForTesting { resolvedID in
+                guard resolvedID == connectionID else { return }
+                await resolutionGate.markStartedAndWaitForRelease()
+            }
+
+            let preResolvedCall = Task {
+                try await manager.withConnectionCallPermitForTesting(
+                    connectionID: connectionID,
+                    lane: .ordinary
+                ) {
+                    await operationRan.mark()
+                }
+            }
+            await assertStarted(resolutionGate, description: "pre-resolved removal call")
+
+            let removal = Task {
+                await manager.debugRemoveConnection(connectionID)
+            }
+            await assertStarted(stopGate, description: "genuine connection removal")
+            await manager.debugSetAfterConnectionCallLimiterResolutionForTesting(nil)
+            await resolutionGate.release()
+
+            let callSucceeded: Bool
+            do {
+                try await preResolvedCall.value
+                callSucceeded = true
+            } catch {
+                callSucceeded = false
+            }
+            let didRunOperation = await operationRan.isMarked()
+            XCTAssertFalse(callSucceeded)
+            XCTAssertFalse(didRunOperation)
+
+            await stopGate.release()
+            await assertCompletion(removal, description: "genuine connection removal")
+        }
+
+        func testDirectAdmissionRechecksEffectiveCapacityAfterPreservationRollback() async throws {
+            try await assertAdmissionRechecksEffectiveCapacityAfterPreservationRollback(path: .direct)
+        }
+
+        func testBootstrapAdmissionRechecksEffectiveCapacityAfterPreservationRollback() async throws {
+            try await assertAdmissionRechecksEffectiveCapacityAfterPreservationRollback(path: .bootstrap)
+        }
+
+        func testDirectAdmissionRejectsWhenEffectiveLiveCapacityRemainsFull() async {
+            await assertAdmissionRejectsWhenEffectiveLiveCapacityRemainsFull(path: .direct)
+        }
+
+        func testBootstrapAdmissionRejectsWhenEffectiveLiveCapacityRemainsFull() async {
+            await assertAdmissionRejectsWhenEffectiveLiveCapacityRemainsFull(path: .bootstrap)
+        }
+
+        func testPreResolvedCallDoesNotRetryRestoredBundleAfterTaskCancellation() async {
+            let manager = ServerNetworkManager()
+            let connectionID = UUID()
+            let resolutionGate = LimiterTestGate()
+            let operationRan = LimiterTestFlag()
+
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: connectionID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 120),
+                clientID: "pre-resolved-cancelled-\(UUID().uuidString)",
+                totalToolCalls: 0,
+                createdAt: .distantPast
+            )
+            await manager.debugSetAfterConnectionCallLimiterResolutionForTesting { resolvedID in
+                guard resolvedID == connectionID else { return }
+                await resolutionGate.markStartedAndWaitForRelease()
+            }
+
+            let preResolvedCall = Task {
+                try await manager.withConnectionCallPermitForTesting(
+                    connectionID: connectionID,
+                    lane: .ordinary
+                ) {
+                    await operationRan.mark()
+                }
+            }
+            await assertStarted(resolutionGate, description: "pre-resolved cancelled call")
+            preResolvedCall.cancel()
+            let restored = await manager.closeAndRestoreConnectionCallLanesForTesting(connectionID)
+            await manager.debugSetAfterConnectionCallLimiterResolutionForTesting(nil)
+            await resolutionGate.release()
+
+            let callSucceeded: Bool
+            do {
+                try await preResolvedCall.value
+                callSucceeded = true
+            } catch {
+                callSucceeded = false
+            }
+            let didRunOperation = await operationRan.isMarked()
+            XCTAssertTrue(restored)
+            XCTAssertFalse(callSucceeded)
+            XCTAssertFalse(didRunOperation)
+
+            await manager.debugRemoveConnection(connectionID)
+        }
+
+        func testEvictionCloseAtomicallyRejectsNewCallsOnBothLanes() async throws {
+            let manager = ServerNetworkManager()
+            let connectionID = UUID()
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: connectionID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 120),
+                clientID: "closed-without-replacement-\(UUID().uuidString)",
+                totalToolCalls: 0,
+                createdAt: .distantPast
+            )
+            let didClose = await manager.closeConnectionCallLanesIfIdleForEvictionForTesting(connectionID)
+            XCTAssertTrue(didClose)
+
+            for lane in MCPConnectionCallLane.allCases {
+                let bodyRan = LimiterTestFlag()
+                do {
+                    try await manager.withConnectionCallPermitForTesting(
+                        connectionID: connectionID,
+                        lane: lane
+                    ) {
+                        await bodyRan.mark()
+                    }
+                    XCTFail("Closed connection call lanes should reject \(lane.rawValue)")
+                } catch is CancellationError {
+                    // Expected.
+                } catch {
+                    XCTFail("Expected CancellationError for \(lane.rawValue), got \(error)")
+                }
+                let didRunBody = await bodyRan.isMarked()
+                XCTAssertFalse(didRunBody)
+            }
+
+            await manager.debugRemoveConnection(connectionID)
+        }
+
+        private enum GlobalAdmissionPath: Equatable {
+            case direct
+            case bootstrap
+        }
+
+        private func assertDirectAdmissionRejectsStaleResume(
+            advanceLifecycleGeneration: Bool,
+            replaceConnectionActor: Bool,
+            file: StaticString = #filePath,
+            line: UInt = #line
+        ) async {
+            let manager = ServerNetworkManager()
+            let connectionID = UUID()
+            let originalClientID = "stale-direct-original-\(UUID().uuidString)"
+            let replacementClientID = "stale-direct-replacement-\(UUID().uuidString)"
+            let originalConnection = AdmissionEvictionTestConnection(idleSeconds: 0)
+            let replacementConnection = replaceConnectionActor
+                ? AdmissionEvictionTestConnection(idleSeconds: 0)
+                : originalConnection
+
+            await manager.debugInstallDirectAdmissionConnectionForTesting(
+                connectionID: connectionID,
+                connection: originalConnection
+            )
+            await manager.debugSetAfterDirectAdmissionPendingPublishedForTesting { suspendedConnectionID in
+                guard suspendedConnectionID == connectionID else { return }
+                await manager.debugInstallDirectAdmissionConnectionForTesting(
+                    connectionID: connectionID,
+                    connection: replacementConnection,
+                    pendingClientID: replacementClientID,
+                    advanceLifecycleGeneration: advanceLifecycleGeneration
+                )
+            }
+
+            let admitted = await manager.tryReserveConnectionSlot(
+                connectionID: connectionID,
+                clientID: originalClientID
+            )
+            await manager.debugSetAfterDirectAdmissionPendingPublishedForTesting(nil)
+            let state = await manager.debugDirectAdmissionStateForTesting(connectionID: connectionID)
+
+            XCTAssertFalse(admitted, "A stale direct admission must reject after suspension", file: file, line: line)
+            XCTAssertEqual(state.pendingClientID, replacementClientID, file: file, line: line)
+            XCTAssertNil(state.indexedClientID, file: file, line: line)
+            XCTAssertTrue(state.activeClientIDs.isEmpty, file: file, line: line)
+            XCTAssertFalse(state.hasStats, file: file, line: line)
+            XCTAssertEqual(
+                state.connectionLifecycleGeneration,
+                state.lifecycleGeneration,
+                "The replacement lifecycle metadata must remain intact",
+                file: file,
+                line: line
+            )
+
+            await manager.debugRemoveConnection(connectionID)
+        }
+
+        private func assertGlobalAdmissionPreservesCandidateWhenRemovalCreatesHeadroomBeforeClose(
+            path: GlobalAdmissionPath,
+            file: StaticString = #filePath,
+            line: UInt = #line
+        ) async throws {
+            let manager = ServerNetworkManager()
+            let victimID = UUID()
+            let capacityReliefID = UUID()
+            let incomingConnectionID = UUID()
+            let capacityReliefStopGate = LimiterTestGate()
+            let capacityReliefRemovalTask = LimiterTestTaskStore()
+
+            await manager.debugConfigureGlobalAdmissionForTesting(
+                maxGlobalConnections: path == .direct ? 3 : 2,
+                preserveOnePerClient: false
+            )
+            if path == .direct {
+                await manager.debugInstallDirectAdmissionConnectionForTesting(
+                    connectionID: incomingConnectionID,
+                    connection: AdmissionEvictionTestConnection(idleSeconds: 0)
+                )
+            }
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: victimID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 180),
+                clientID: "global-preclose-victim-\(UUID().uuidString)",
+                totalToolCalls: 0,
+                createdAt: .distantPast
+            )
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: capacityReliefID,
+                connection: AdmissionEvictionTestConnection(
+                    idleSeconds: 10,
+                    stopGate: capacityReliefStopGate
+                ),
+                clientID: "global-preclose-relief-\(UUID().uuidString)",
+                totalToolCalls: 1,
+                createdAt: Date()
+            )
+            let installedOrdinary = await manager.limiter(for: victimID, lane: .ordinary)
+            let installedFileSearch = await manager.limiter(for: victimID, lane: .fileSearch)
+            let originalOrdinary = try XCTUnwrap(installedOrdinary, file: file, line: line)
+            let originalFileSearch = try XCTUnwrap(installedFileSearch, file: file, line: line)
+
+            await manager.debugSetBeforeAdmissionEvictionCloseForTesting { candidateID in
+                guard candidateID == victimID else { return }
+                await capacityReliefRemovalTask.start {
+                    await manager.debugRemoveConnection(capacityReliefID)
+                }
+                _ = await capacityReliefStopGate.waitUntilStarted(timeout: .seconds(2))
+            }
+
+            let admitted: Bool = switch path {
+            case .direct:
+                await manager.tryReserveConnectionSlot(
+                    connectionID: incomingConnectionID,
+                    clientID: "global-preclose-incoming-\(UUID().uuidString)"
+                )
+            case .bootstrap:
+                await manager.debugBootstrapAdmissionHasCapacityForTesting()
+            }
+            await manager.debugSetBeforeAdmissionEvictionCloseForTesting(nil)
+
+            let capacityReliefRemovalStarted = await capacityReliefStopGate.hasStarted()
+            let victimRetained = await manager.debugContainsConnection(victimID)
+            let originalOrdinarySnapshot = await originalOrdinary.debugSnapshot()
+            let originalFileSearchSnapshot = await originalFileSearch.debugSnapshot()
+            XCTAssertTrue(admitted, file: file, line: line)
+            XCTAssertTrue(capacityReliefRemovalStarted, file: file, line: line)
+            XCTAssertTrue(
+                victimRetained,
+                "Capacity progress before atomic closure must preserve the unrelated candidate",
+                file: file,
+                line: line
+            )
+            XCTAssertFalse(originalOrdinarySnapshot.isClosed, file: file, line: line)
+            XCTAssertFalse(originalFileSearchSnapshot.isClosed, file: file, line: line)
+
+            if path == .direct {
+                await manager.debugRemoveConnection(incomingConnectionID)
+            }
+            await capacityReliefStopGate.release()
+            await assertCompletion(capacityReliefRemovalTask, description: "global pre-close capacity relief")
+            await manager.debugRemoveConnection(victimID)
+            await manager.debugConfigureGlobalAdmissionForTesting(
+                maxGlobalConnections: nil,
+                preserveOnePerClient: nil
+            )
+        }
+
+        private func assertGlobalAdmissionRestoresClosedCandidateWhenRemovalCreatesHeadroomDuringClose(
+            path: GlobalAdmissionPath,
+            file: StaticString = #filePath,
+            line: UInt = #line
+        ) async throws {
+            let manager = ServerNetworkManager()
+            let victimID = UUID()
+            let capacityReliefID = UUID()
+            let incomingConnectionID = UUID()
+            let capacityReliefStopGate = LimiterTestGate()
+            let capacityReliefRemovalTask = LimiterTestTaskStore()
+
+            await manager.debugConfigureGlobalAdmissionForTesting(
+                maxGlobalConnections: path == .direct ? 3 : 2,
+                preserveOnePerClient: false
+            )
+            if path == .direct {
+                await manager.debugInstallDirectAdmissionConnectionForTesting(
+                    connectionID: incomingConnectionID,
+                    connection: AdmissionEvictionTestConnection(idleSeconds: 0)
+                )
+            }
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: victimID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 180),
+                clientID: "global-during-close-victim-\(UUID().uuidString)",
+                totalToolCalls: 0,
+                createdAt: .distantPast
+            )
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: capacityReliefID,
+                connection: AdmissionEvictionTestConnection(
+                    idleSeconds: 10,
+                    stopGate: capacityReliefStopGate
+                ),
+                clientID: "global-during-close-relief-\(UUID().uuidString)",
+                totalToolCalls: 1,
+                createdAt: Date()
+            )
+            let installedOrdinary = await manager.limiter(for: victimID, lane: .ordinary)
+            let installedFileSearch = await manager.limiter(for: victimID, lane: .fileSearch)
+            let originalOrdinary = try XCTUnwrap(installedOrdinary, file: file, line: line)
+            let originalFileSearch = try XCTUnwrap(installedFileSearch, file: file, line: line)
+
+            await manager.debugSetDuringAdmissionEvictionCloseForTesting { candidateID in
+                guard candidateID == victimID else { return }
+                await capacityReliefRemovalTask.start {
+                    await manager.debugRemoveConnection(capacityReliefID)
+                }
+                _ = await capacityReliefStopGate.waitUntilStarted(timeout: .seconds(2))
+            }
+
+            let admitted: Bool = switch path {
+            case .direct:
+                await manager.tryReserveConnectionSlot(
+                    connectionID: incomingConnectionID,
+                    clientID: "global-during-close-incoming-\(UUID().uuidString)"
+                )
+            case .bootstrap:
+                await manager.debugBootstrapAdmissionHasCapacityForTesting()
+            }
+            await manager.debugSetDuringAdmissionEvictionCloseForTesting(nil)
+
+            let capacityReliefRemovalStarted = await capacityReliefStopGate.hasStarted()
+            let victimRetained = await manager.debugContainsConnection(victimID)
+            let originalOrdinarySnapshot = await originalOrdinary.debugSnapshot()
+            let originalFileSearchSnapshot = await originalFileSearch.debugSnapshot()
+            let registeredOrdinary = await manager.connectionLimiterSnapshotForTesting(
+                connectionID: victimID,
+                lane: .ordinary
+            )
+            let registeredFileSearch = await manager.connectionLimiterSnapshotForTesting(
+                connectionID: victimID,
+                lane: .fileSearch
+            )
+            XCTAssertTrue(admitted, file: file, line: line)
+            XCTAssertTrue(capacityReliefRemovalStarted, file: file, line: line)
+            XCTAssertTrue(
+                victimRetained,
+                "Capacity progress during atomic closure must preserve the unrelated candidate",
+                file: file,
+                line: line
+            )
+            XCTAssertTrue(originalOrdinarySnapshot.isClosed, file: file, line: line)
+            XCTAssertTrue(originalFileSearchSnapshot.isClosed, file: file, line: line)
+            XCTAssertFalse(registeredOrdinary?.isClosed ?? true, file: file, line: line)
+            XCTAssertFalse(registeredFileSearch?.isClosed ?? true, file: file, line: line)
+
+            if path == .direct {
+                await manager.debugRemoveConnection(incomingConnectionID)
+            }
+            await capacityReliefStopGate.release()
+            await assertCompletion(capacityReliefRemovalTask, description: "global during-close capacity relief")
+            await manager.debugRemoveConnection(victimID)
+            await manager.debugConfigureGlobalAdmissionForTesting(
+                maxGlobalConnections: nil,
+                preserveOnePerClient: nil
+            )
+        }
+
+        private func assertAdmissionRechecksEffectiveCapacityAfterPreservationRollback(
+            path: GlobalAdmissionPath,
+            file: StaticString = #filePath,
+            line: UInt = #line
+        ) async throws {
+            let manager = ServerNetworkManager()
+            let clientID = "admission-capacity-race-\(UUID().uuidString)"
+            let victimID = UUID()
+            let siblingID = UUID()
+            let incomingConnectionID = UUID()
+            let siblingStopGate = LimiterTestGate()
+            let siblingRemovalTask = LimiterTestTaskStore()
+
+            await manager.debugConfigureGlobalAdmissionForTesting(
+                maxGlobalConnections: path == .direct ? 3 : 2,
+                preserveOnePerClient: true
+            )
+            if path == .direct {
+                await manager.debugInstallDirectAdmissionConnectionForTesting(
+                    connectionID: incomingConnectionID,
+                    connection: AdmissionEvictionTestConnection(idleSeconds: 0)
+                )
+            }
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: victimID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 120),
+                clientID: clientID,
+                totalToolCalls: 0,
+                createdAt: .distantPast
+            )
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: siblingID,
+                connection: AdmissionEvictionTestConnection(
+                    idleSeconds: 10,
+                    stopGate: siblingStopGate
+                ),
+                clientID: clientID,
+                totalToolCalls: 1,
+                createdAt: Date()
+            )
+            let installedOrdinary = await manager.limiter(for: victimID, lane: .ordinary)
+            let installedFileSearch = await manager.limiter(for: victimID, lane: .fileSearch)
+            let originalOrdinary = try XCTUnwrap(installedOrdinary, file: file, line: line)
+            let originalFileSearch = try XCTUnwrap(installedFileSearch, file: file, line: line)
+
+            await manager.debugSetDuringAdmissionEvictionCloseForTesting { candidateID in
+                guard candidateID == victimID else { return }
+                await siblingRemovalTask.start {
+                    await manager.debugRemoveConnection(siblingID)
+                }
+                guard await siblingStopGate.waitUntilStarted(timeout: .seconds(2)) else { return }
+            }
+
+            let admitted: Bool = switch path {
+            case .direct:
+                await manager.tryReserveConnectionSlot(
+                    connectionID: incomingConnectionID,
+                    clientID: "incoming-direct-\(UUID().uuidString)"
+                )
+            case .bootstrap:
+                await manager.debugBootstrapAdmissionHasCapacityForTesting()
+            }
+            await manager.debugSetDuringAdmissionEvictionCloseForTesting(nil)
+
+            XCTAssertTrue(
+                admitted,
+                "Admission must recheck capacity after rollback instead of rejecting on no victim eviction",
+                file: file,
+                line: line
+            )
+            let effectiveCount = await manager.debugEffectiveRegisteredConnectionCountForTesting()
+            let siblingRemovalStarted = await siblingStopGate.hasStarted()
+            XCTAssertTrue(
+                siblingRemovalStarted,
+                "Timed out waiting for sibling removal to reach stop() during admission",
+                file: file,
+                line: line
+            )
+            XCTAssertEqual(effectiveCount, path == .direct ? 2 : 1, file: file, line: line)
+            let retainedVictim = await manager.debugContainsConnection(victimID)
+            let retainedRemovingSibling = await manager.debugContainsConnection(siblingID)
+            XCTAssertTrue(retainedVictim, file: file, line: line)
+            XCTAssertTrue(retainedRemovingSibling, file: file, line: line)
+            let originalOrdinarySnapshot = await originalOrdinary.debugSnapshot()
+            let originalFileSearchSnapshot = await originalFileSearch.debugSnapshot()
+            XCTAssertTrue(originalOrdinarySnapshot.isClosed, file: file, line: line)
+            XCTAssertTrue(originalFileSearchSnapshot.isClosed, file: file, line: line)
+            let restoredOrdinary = await manager.connectionLimiterSnapshotForTesting(
+                connectionID: victimID,
+                lane: .ordinary
+            )
+            let restoredFileSearch = await manager.connectionLimiterSnapshotForTesting(
+                connectionID: victimID,
+                lane: .fileSearch
+            )
+            XCTAssertFalse(restoredOrdinary?.isClosed ?? true, file: file, line: line)
+            XCTAssertFalse(restoredFileSearch?.isClosed ?? true, file: file, line: line)
+
+            if path == .direct {
+                await manager.debugRemoveConnection(incomingConnectionID)
+            }
+            await siblingStopGate.release()
+            await assertCompletion(siblingRemovalTask, description: "sibling removal")
+            await manager.debugRemoveConnection(victimID)
+            await manager.debugConfigureGlobalAdmissionForTesting(
+                maxGlobalConnections: nil,
+                preserveOnePerClient: nil
+            )
+        }
+
+        private func assertAdmissionRejectsWhenEffectiveLiveCapacityRemainsFull(
+            path: GlobalAdmissionPath,
+            file: StaticString = #filePath,
+            line: UInt = #line
+        ) async {
+            let manager = ServerNetworkManager()
+            let existingConnectionID = UUID()
+            let incomingConnectionID = UUID()
+            let busyGate = LimiterTestGate()
+
+            await manager.debugConfigureGlobalAdmissionForTesting(
+                maxGlobalConnections: path == .direct ? 2 : 1,
+                preserveOnePerClient: true
+            )
+            if path == .direct {
+                await manager.debugInstallDirectAdmissionConnectionForTesting(
+                    connectionID: incomingConnectionID,
+                    connection: AdmissionEvictionTestConnection(idleSeconds: 0)
+                )
+            }
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: existingConnectionID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 120),
+                clientID: "admission-full-\(UUID().uuidString)",
+                totalToolCalls: 0,
+                createdAt: .distantPast
+            )
+            let busyTask = Task {
+                try? await manager.withConnectionCallPermitForTesting(
+                    connectionID: existingConnectionID,
+                    lane: .ordinary
+                ) {
+                    await busyGate.markStartedAndWaitForRelease()
+                }
+            }
+            await assertStarted(busyGate, description: "busy connection")
+
+            let admitted: Bool = switch path {
+            case .direct:
+                await manager.tryReserveConnectionSlot(
+                    connectionID: incomingConnectionID,
+                    clientID: "incoming-full-\(UUID().uuidString)"
+                )
+            case .bootstrap:
+                await manager.debugBootstrapAdmissionHasCapacityForTesting()
+            }
+
+            XCTAssertFalse(
+                admitted,
+                "Admission must reject while effective live capacity remains full",
+                file: file,
+                line: line
+            )
+            let effectiveCount = await manager.debugEffectiveRegisteredConnectionCountForTesting()
+            XCTAssertEqual(effectiveCount, path == .direct ? 2 : 1, file: file, line: line)
+            let retainedExisting = await manager.debugContainsConnection(existingConnectionID)
+            XCTAssertTrue(retainedExisting, file: file, line: line)
+
+            await busyGate.release()
+            await assertCompletion(busyTask, description: "busy connection task")
+            if path == .direct {
+                await manager.debugRemoveConnection(incomingConnectionID)
+            }
+            await manager.debugRemoveConnection(existingConnectionID)
+            await manager.debugConfigureGlobalAdmissionForTesting(
+                maxGlobalConnections: nil,
+                preserveOnePerClient: nil
+            )
+        }
+
+        private enum AdmissionEvictionScope {
+            case perClient
+            case global
+        }
+
+        private func assertAdmissionEvictionFallsBackToNextCandidate(
+            scope: AdmissionEvictionScope,
+            file: StaticString = #filePath,
+            line: UInt = #line
+        ) async {
+            let manager = ServerNetworkManager()
+            let clientID = "admission-eviction-fallback-\(UUID().uuidString)"
+            let firstCandidateID = UUID()
+            let secondCandidateID = UUID()
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: firstCandidateID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 120),
+                clientID: clientID,
+                totalToolCalls: 0,
+                createdAt: .distantPast
+            )
+            await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                connectionID: secondCandidateID,
+                connection: AdmissionEvictionTestConnection(idleSeconds: 60),
+                clientID: clientID,
+                totalToolCalls: 1,
+                createdAt: Date()
+            )
+
+            let busyGate = LimiterTestGate()
+            await manager.debugSetBeforeAdmissionEvictionCloseForTesting { candidateID in
+                guard candidateID == firstCandidateID else { return }
+                Task {
+                    try? await manager.withConnectionCallPermitForTesting(
+                        connectionID: firstCandidateID,
+                        lane: .ordinary
+                    ) {
+                        await busyGate.markStartedAndWaitForRelease()
+                    }
+                }
+                guard await busyGate.waitUntilStarted(timeout: .seconds(2)) else { return }
+            }
+
+            let didEvict: Bool = switch scope {
+            case .perClient:
+                await manager.debugEvictLeastValuableForTesting(clientID: clientID)
+            case .global:
+                await manager.debugEvictLeastValuableGlobalForAdmissionForTesting(
+                    preserveOnePerClient: false
+                )
+            }
+
+            let retainedBusyCandidate = await manager.debugContainsConnection(firstCandidateID)
+            let removedFallbackCandidate = await manager.debugContainsConnection(secondCandidateID)
+            XCTAssertTrue(didEvict, file: file, line: line)
+            XCTAssertTrue(retainedBusyCandidate, file: file, line: line)
+            XCTAssertFalse(
+                removedFallbackCandidate,
+                "Eviction should continue to the next sorted candidate when the first became busy",
+                file: file,
+                line: line
+            )
+
+            await manager.debugSetBeforeAdmissionEvictionCloseForTesting(nil)
+            await busyGate.release()
+            await manager.debugRemoveConnection(firstCandidateID)
+            await manager.debugRemoveConnection(secondCandidateID)
+        }
+
+        private func waitForAdmissionRetryWaiterCount(
+            manager: ServerNetworkManager,
+            connectionID: UUID,
+            expectedCount: Int,
+            timeout: Duration = .seconds(2)
+        ) async -> Bool {
+            let clock = ContinuousClock()
+            let deadline = clock.now.advanced(by: timeout)
+            while clock.now < deadline {
+                if await manager.connectionCallAdmissionRetryWaiterCountForTesting(connectionID) == expectedCount {
+                    return true
+                }
+                try? await Task.sleep(for: .milliseconds(5))
+            }
+            return await manager.connectionCallAdmissionRetryWaiterCountForTesting(connectionID) == expectedCount
+        }
+
+        private func waitForSnapshot(
+            of limiter: AsyncLimiter,
+            timeout: Duration = .seconds(2),
+            matching predicate: @escaping @Sendable (AsyncLimiter.DebugSnapshot) -> Bool
+        ) async -> AsyncLimiter.DebugSnapshot? {
+            let clock = ContinuousClock()
+            let deadline = clock.now.advanced(by: timeout)
+            while clock.now < deadline {
+                let snapshot = await limiter.debugSnapshot()
+                if predicate(snapshot) { return snapshot }
+                try? await Task.sleep(for: .milliseconds(5))
+            }
+            let snapshot = await limiter.debugSnapshot()
+            return predicate(snapshot) ? snapshot : nil
+        }
+
+        private func boundedValue<Success>(
+            of task: Task<Success, some Error>,
+            timeout: Duration = .seconds(2),
+            description: String
+        ) async throws -> Success {
+            let result = LimiterTaskResultBox<Success>()
+            let observer = Task {
+                do {
+                    try await result.store(.success(task.value))
+                } catch {
+                    result.store(.failure(error))
+                }
+            }
+            let clock = ContinuousClock()
+            let deadline = clock.now.advanced(by: timeout)
+            while clock.now < deadline {
+                if let completed = result.load() {
+                    observer.cancel()
+                    return try completed.get()
+                }
+                try? await Task.sleep(for: .milliseconds(5))
+            }
+            task.cancel()
+            observer.cancel()
+            throw LimiterTestTimeoutError(description: description)
+        }
+
+        private func diagnosticsPayload(_ result: CallTool.Result) throws -> [String: Any] {
+            let text = result.content.compactMap { content -> String? in
+                if case let .text(text, _, _) = content { return text }
+                return nil
+            }.joined()
+            let data = try XCTUnwrap(text.data(using: .utf8))
+            return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        }
+
+        private func assertStarted(
+            _ gate: LimiterTestGate,
+            description: String,
+            file: StaticString = #filePath,
+            line: UInt = #line
+        ) async {
+            let started = await gate.waitUntilStarted(timeout: .seconds(2))
+            XCTAssertTrue(started, "Timed out waiting for \(description)", file: file, line: line)
+        }
+
+        private func assertCompletion(
+            _ taskStore: LimiterTestTaskStore,
+            description: String,
+            file: StaticString = #filePath,
+            line: UInt = #line
+        ) async {
+            let completed = await taskStore.wait()
+            XCTAssertTrue(completed, "Timed out waiting for \(description)", file: file, line: line)
+        }
+
+        private func assertSuccess(
+            _ task: Task<Void, Error>,
+            file: StaticString = #filePath,
+            line: UInt = #line
+        ) async {
+            do {
+                _ = try await boundedValue(of: task, description: "successful task")
+            } catch {
+                XCTFail("Expected task success, got \(error)", file: file, line: line)
+            }
+        }
+
+        private func assertCompletion(
+            _ task: Task<some Any, Never>,
+            description: String,
+            file: StaticString = #filePath,
+            line: UInt = #line
+        ) async {
+            do {
+                _ = try await boundedValue(of: task, description: description)
+            } catch {
+                XCTFail("Timed out waiting for \(description): \(error)", file: file, line: line)
+            }
+        }
+
+        private func assertCancellation(
+            _ task: Task<Void, Error>,
+            file: StaticString = #filePath,
+            line: UInt = #line
+        ) async {
+            do {
+                _ = try await boundedValue(of: task, description: "task cancellation")
                 XCTFail("Expected CancellationError", file: file, line: line)
             } catch is CancellationError {
                 // Expected.
@@ -203,18 +3945,92 @@ import XCTest
         }
     }
 
+    private struct LimiterTestTimeoutError: Error, CustomStringConvertible {
+        let description: String
+    }
+
+    private final class LimiterTaskResultBox<Success>: @unchecked Sendable {
+        private let lock = NSLock()
+        private var result: Result<Success, Error>?
+
+        func store(_ result: Result<Success, Error>) {
+            lock.lock()
+            self.result = result
+            lock.unlock()
+        }
+
+        func load() -> Result<Success, Error>? {
+            lock.lock()
+            defer { lock.unlock() }
+            return result
+        }
+    }
+
+    private actor AdmissionEvictionTestConnection: MCPServerConnection {
+        private let idleSeconds: TimeInterval
+        private let stopGate: LimiterTestGate?
+
+        init(idleSeconds: TimeInterval, stopGate: LimiterTestGate? = nil) {
+            self.idleSeconds = idleSeconds
+            self.stopGate = stopGate
+        }
+
+        nonisolated var isFilesystemBacked: Bool {
+            false
+        }
+
+        nonisolated var connectionFolderURL: URL? {
+            nil
+        }
+
+        nonisolated var capabilityToken: String? {
+            nil
+        }
+
+        func start(approvalHandler _: @escaping (MCP.Client.Info) async -> Bool) async throws {}
+        func stop() async {
+            await stopGate?.markStartedAndWaitForRelease()
+        }
+
+        func abortForExecutionWatchdog() async {}
+        func notifyToolListChanged() async {}
+        func connectionState() -> ConnectionStateSnapshot {
+            .ready
+        }
+
+        func isViableForRetention() -> Bool {
+            true
+        }
+
+        func secondsSinceLastActivity() async -> TimeInterval {
+            idleSeconds
+        }
+
+        func transportIngressSnapshot() async -> MCPTransportIngressSnapshot? {
+            nil
+        }
+
+        func terminate(reason _: TerminationReason, message _: String?) async {}
+        func sendProgress(
+            tool _: String,
+            kind _: RepoPromptProgressKind,
+            stage _: String,
+            message _: String
+        ) async {}
+    }
+
     private actor LimiterTestGate {
         private var started = false
         private var released = false
-        private var startedWaiters: [CheckedContinuation<Void, Never>] = []
+        private var startedWaiters: [UUID: CheckedContinuation<Bool, Never>] = [:]
         private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
 
         func markStartedAndWaitForRelease() async {
             started = true
-            let startedWaiters = startedWaiters
+            let startedWaiters = startedWaiters.values
             self.startedWaiters.removeAll()
             for waiter in startedWaiters {
-                waiter.resume()
+                waiter.resume(returning: true)
             }
             guard !released else { return }
             await withCheckedContinuation { continuation in
@@ -222,11 +4038,27 @@ import XCTest
             }
         }
 
-        func waitUntilStarted() async {
-            guard !started else { return }
-            await withCheckedContinuation { continuation in
-                startedWaiters.append(continuation)
+        @discardableResult
+        func waitUntilStarted(timeout: Duration? = nil) async -> Bool {
+            guard !started else { return true }
+            let waiterID = UUID()
+            return await withCheckedContinuation { continuation in
+                startedWaiters[waiterID] = continuation
+                if let timeout {
+                    Task {
+                        try? await Task.sleep(for: timeout)
+                        await self.timeoutStartedWaiter(waiterID)
+                    }
+                }
             }
+        }
+
+        func hasStarted() -> Bool {
+            started
+        }
+
+        private func timeoutStartedWaiter(_ waiterID: UUID) {
+            startedWaiters.removeValue(forKey: waiterID)?.resume(returning: false)
         }
 
         func release() {
@@ -237,6 +4069,91 @@ import XCTest
             for waiter in waiters {
                 waiter.resume()
             }
+        }
+    }
+
+    private actor LimiterTestCounter {
+        private struct Waiter {
+            let target: Int
+            let continuation: CheckedContinuation<Int?, Never>
+        }
+
+        private var value = 0
+        private var waiters: [UUID: Waiter] = [:]
+
+        func increment() {
+            value += 1
+            let readyIDs = waiters.compactMap { waiterID, waiter in
+                value >= waiter.target ? waiterID : nil
+            }
+            for waiterID in readyIDs {
+                waiters.removeValue(forKey: waiterID)?.continuation.resume(returning: value)
+            }
+        }
+
+        func waitUntil(_ target: Int, timeout: Duration) async -> Int? {
+            if value >= target { return value }
+            let waiterID = UUID()
+            return await withCheckedContinuation { continuation in
+                waiters[waiterID] = Waiter(target: target, continuation: continuation)
+                Task {
+                    try? await Task.sleep(for: timeout)
+                    await self.timeoutWaiter(waiterID)
+                }
+            }
+        }
+
+        private func timeoutWaiter(_ waiterID: UUID) {
+            waiters.removeValue(forKey: waiterID)?.continuation.resume(returning: nil)
+        }
+    }
+
+    private actor LimiterTestTaskStore {
+        private var task: Task<Void, Never>?
+
+        func start(_ operation: @escaping @Sendable () async -> Void) {
+            guard task == nil else { return }
+            task = Task {
+                await operation()
+            }
+        }
+
+        func wait(timeout: Duration = .seconds(2)) async -> Bool {
+            guard let task else { return true }
+            let completed = LimiterLockedFlag()
+            let observer = Task {
+                await task.value
+                completed.mark()
+            }
+            let clock = ContinuousClock()
+            let deadline = clock.now.advanced(by: timeout)
+            while !completed.isMarked(), clock.now < deadline {
+                try? await Task.sleep(for: .milliseconds(5))
+            }
+            guard completed.isMarked() else {
+                task.cancel()
+                observer.cancel()
+                return false
+            }
+            observer.cancel()
+            return true
+        }
+    }
+
+    private final class LimiterLockedFlag: @unchecked Sendable {
+        private let lock = NSLock()
+        private var marked = false
+
+        func mark() {
+            lock.lock()
+            marked = true
+            lock.unlock()
+        }
+
+        func isMarked() -> Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            return marked
         }
     }
 
@@ -257,6 +4174,12 @@ import XCTest
 
         func mark() {
             marked = true
+        }
+
+        func markIfUnmarked() -> Bool {
+            guard !marked else { return false }
+            marked = true
+            return true
         }
 
         func isMarked() -> Bool {

--- a/Tests/RepoPromptTests/MCP/Control/MCPSocketDescriptorHardeningTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/MCPSocketDescriptorHardeningTests.swift
@@ -1,5 +1,6 @@
 import Darwin
 import Foundation
+import MCP
 @testable import RepoPrompt
 import RepoPromptShared
 import XCTest
@@ -71,6 +72,266 @@ final class MCPSocketDescriptorHardeningTests: XCTestCase {
             }
         #else
             throw XCTSkip("Bootstrap socket listener descriptor seam is DEBUG-only")
+        #endif
+    }
+
+    func testSuccessiveSameSessionBootstrapAdmissionsDoNotDoubleDiscountReplacement() async throws {
+        #if DEBUG
+            try await Self.withIsolatedManagerSocket(prefix: "same-token-reservation") { manager, socketURL in
+                await manager.setConnectionApprovalHandler { _, _ in true }
+                await manager.start()
+                let listenerReady = await Self.waitForCurrentBootstrapListener(manager, at: socketURL)
+                XCTAssertTrue(listenerReady)
+
+                let sessionToken = "same-token-reservation-\(UUID().uuidString)"
+                let replacementID = UUID()
+                let unrelatedID = UUID()
+                let replacementStopGate = SuspendedAdmissionGate()
+                await manager.debugConfigureGlobalAdmissionForTesting(
+                    maxGlobalConnections: 2,
+                    preserveOnePerClient: false
+                )
+                await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                    connectionID: replacementID,
+                    connection: BootstrapAdmissionTestConnection(
+                        idleSeconds: 180,
+                        stopGate: replacementStopGate
+                    ),
+                    clientID: "same-token-replacement",
+                    totalToolCalls: 0,
+                    createdAt: .distantPast
+                )
+                await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                    connectionID: unrelatedID,
+                    connection: BootstrapAdmissionTestConnection(idleSeconds: 60),
+                    clientID: "same-token-unrelated",
+                    totalToolCalls: 1,
+                    createdAt: Date()
+                )
+                await manager.debugBindSessionTokenForAdmissionTesting(sessionToken, to: replacementID)
+
+                let firstFD = try Self.connectRawUnixClient(to: socketURL)
+                defer { Self.closeIfOpen(firstFD) }
+                let secondFD = try Self.connectRawUnixClient(to: socketURL)
+                defer { Self.closeIfOpen(secondFD) }
+
+                do {
+                    try Self.writeBootstrapRequest(
+                        to: firstFD,
+                        sessionToken: sessionToken,
+                        clientName: "same-token-first"
+                    )
+                    let firstResponse = try Self.readBootstrapResponse(from: firstFD)
+                    let replacementRemovalStarted = await Self.waitUntil { await replacementStopGate.hasEntered }
+                    let firstCommitCompleted = await Self.waitUntil {
+                        await manager.debugBootstrapReservationCount() == 0
+                    }
+                    XCTAssertEqual(firstResponse.type, "accepted")
+                    XCTAssertTrue(replacementRemovalStarted)
+                    XCTAssertTrue(firstCommitCompleted)
+
+                    try Self.writeBootstrapRequest(
+                        to: secondFD,
+                        sessionToken: sessionToken,
+                        clientName: "same-token-second"
+                    )
+                    let secondResponse = try Self.readBootstrapResponse(from: secondFD)
+                    let unrelatedRetained = await manager.debugContainsConnection(unrelatedID)
+                    let secondCommitCompleted = await Self.waitUntil {
+                        await manager.debugBootstrapReservationCount() == 0
+                    }
+                    let reservationCountAfterSecondAdmission = await manager.debugBootstrapReservationCount()
+                    let effectiveConnectionCount = await manager.debugEffectiveRegisteredConnectionCountForTesting()
+                    XCTAssertEqual(secondResponse.type, "accepted")
+                    XCTAssertTrue(
+                        unrelatedRetained,
+                        "A successive admission for the same durable token must not evict an unrelated client"
+                    )
+                    XCTAssertTrue(secondCommitCompleted)
+                    XCTAssertEqual(reservationCountAfterSecondAdmission, 0)
+                    XCTAssertEqual(
+                        effectiveConnectionCount,
+                        2,
+                        "Only the latest same-session successor and unrelated connection may remain logically registered"
+                    )
+                } catch {
+                    await replacementStopGate.release()
+                    throw error
+                }
+
+                await replacementStopGate.release()
+                let reservationDrained = await Self.waitUntil {
+                    await manager.debugBootstrapReservationCount() == 0
+                }
+                XCTAssertTrue(reservationDrained)
+                await manager.debugRemoveConnection(unrelatedID)
+                await manager.debugRemoveConnection(replacementID)
+                await manager.debugConfigureGlobalAdmissionForTesting(
+                    maxGlobalConnections: nil,
+                    preserveOnePerClient: nil
+                )
+            }
+        #else
+            throw XCTSkip("Bootstrap admission reservation seam is DEBUG-only")
+        #endif
+    }
+
+    func testBootstrapReplacementPublishesSuccessorBeforeHungPredecessorStop() async throws {
+        #if DEBUG
+            try await Self.withIsolatedManagerSocket(prefix: "replacement-commit-expiry") { manager, _ in
+                await manager.setConnectionApprovalHandler { _, _ in true }
+                await manager.start()
+                let sessionToken = "replacement-commit-expiry-\(UUID().uuidString)"
+                let predecessorID = UUID()
+                let replacementID = UUID()
+                let predecessorStopGate = SuspendedAdmissionGate()
+                let predecessorStopDeadlineGate = SuspendedAdmissionGate()
+                await manager.debugSetBootstrapPredecessorStopGraceSleepForTesting { _ in
+                    await predecessorStopDeadlineGate.suspendUntilReleased()
+                }
+                await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                    connectionID: predecessorID,
+                    connection: BootstrapAdmissionTestConnection(
+                        idleSeconds: 120,
+                        stopGate: predecessorStopGate
+                    ),
+                    clientID: "replacement-commit-expiry-predecessor",
+                    totalToolCalls: 0,
+                    createdAt: .distantPast
+                )
+                await manager.debugBindSessionTokenForAdmissionTesting(sessionToken, to: predecessorID)
+
+                let descriptors = try Self.makeSocketPair()
+                defer { Self.closeIfOpen(descriptors[1]) }
+                let optionalAdmission = await manager.debugMakeReservedBootstrapAdmissionForShutdownTest(
+                    connectionID: replacementID,
+                    sessionToken: sessionToken,
+                    clientPid: Int(getpid()),
+                    clientName: "replacement-commit-expiry-successor",
+                    clientFD: descriptors[0]
+                )
+                let admission = try XCTUnwrap(optionalAdmission)
+                let commitCompleted = OptionalBoolRecorder()
+                let commitTask = Task {
+                    await admission.postAccept?()
+                    await commitCompleted.record(true)
+                }
+
+                let predecessorStopStarted = await Self.waitUntil {
+                    await predecessorStopGate.hasEntered
+                }
+                XCTAssertTrue(predecessorStopStarted)
+
+                let commitFinishedWhilePredecessorStopWasBlocked = await Self.waitUntil {
+                    await commitCompleted.value == true
+                }
+                let predecessorStillTracked = await manager.debugContainsConnection(predecessorID)
+                let replacementRegistered = await manager.debugContainsConnection(replacementID)
+                let boundConnectionID = await manager.debugConnectionIDForSessionTokenForTesting(sessionToken)
+                let reservationCountDuringCleanup = await manager.debugBootstrapReservationCount()
+                let transferredCountDuringCleanup = await manager.debugTransferredBootstrapSocketCountForShutdownTest()
+                XCTAssertTrue(
+                    commitFinishedWhilePredecessorStopWasBlocked,
+                    "A hung predecessor stop must not keep post-accept commit suspended"
+                )
+                XCTAssertTrue(
+                    predecessorStillTracked,
+                    "The exact predecessor may remain tracked only while identity-fenced cleanup is pending"
+                )
+                XCTAssertTrue(
+                    replacementRegistered,
+                    "The successor must register before awaiting predecessor cleanup"
+                )
+                XCTAssertEqual(boundConnectionID, replacementID)
+                XCTAssertEqual(
+                    reservationCountDuringCleanup,
+                    0,
+                    "Published successors must not retain a permanent committing reservation"
+                )
+                XCTAssertEqual(transferredCountDuringCleanup, 0)
+                XCTAssertFalse(
+                    Self.isClosed(descriptors[0]),
+                    "The registered successor must retain ownership of its transferred descriptor"
+                )
+
+                let predecessorStopDeadlineStarted = await Self.waitUntil {
+                    await predecessorStopDeadlineGate.hasEntered
+                }
+                XCTAssertTrue(predecessorStopDeadlineStarted)
+                await predecessorStopDeadlineGate.release()
+                let predecessorRemovedBeforeStopReturned = await Self.waitUntil {
+                    await manager.debugContainsConnection(predecessorID) == false
+                }
+                XCTAssertTrue(
+                    predecessorRemovedBeforeStopReturned,
+                    "The bounded handoff grace must detach exact predecessor state even if stop remains hung"
+                )
+                let predecessorStopStillBlocked = await predecessorStopGate.hasEntered
+                XCTAssertTrue(predecessorStopStillBlocked)
+
+                await predecessorStopGate.release()
+                await commitTask.value
+                await manager.debugSetBootstrapPredecessorStopGraceSleepForTesting(nil)
+                await manager.debugRemoveConnection(replacementID)
+                await manager.debugRemoveConnection(predecessorID)
+            }
+        #else
+            throw XCTSkip("Bootstrap replacement commit seam is DEBUG-only")
+        #endif
+    }
+
+    func testBootstrapReplacementPreparationFailurePreservesUsablePredecessor() async throws {
+        #if DEBUG
+            try await Self.withIsolatedManagerSocket(prefix: "replacement-prepare-rollback") { manager, _ in
+                await manager.start()
+                let sessionToken = "replacement-prepare-rollback-\(UUID().uuidString)"
+                let predecessorID = UUID()
+                let replacementID = UUID()
+                await manager.debugInstallAdmissionEvictionCandidateForTesting(
+                    connectionID: predecessorID,
+                    connection: BootstrapAdmissionTestConnection(idleSeconds: 120),
+                    clientID: "replacement-prepare-rollback-predecessor",
+                    totalToolCalls: 0,
+                    createdAt: .distantPast
+                )
+                await manager.debugBindSessionTokenForAdmissionTesting(sessionToken, to: predecessorID)
+
+                let optionalAdmission = await manager.debugMakeReservedBootstrapAdmissionForShutdownTest(
+                    connectionID: replacementID,
+                    sessionToken: sessionToken,
+                    clientPid: Int(getpid()),
+                    clientName: "replacement-prepare-rollback-successor",
+                    clientFD: -1
+                )
+                let admission = try XCTUnwrap(optionalAdmission)
+                await admission.postAccept?()
+
+                let predecessorRetained = await manager.debugContainsConnection(predecessorID)
+                let replacementRegistered = await manager.debugContainsConnection(replacementID)
+                let reservationCount = await manager.debugBootstrapReservationCount()
+                let transferredCount = await manager.debugTransferredBootstrapSocketCountForShutdownTest()
+                XCTAssertTrue(
+                    predecessorRetained,
+                    "Successor preparation must fail before disconnecting the predecessor"
+                )
+                XCTAssertFalse(replacementRegistered)
+                XCTAssertEqual(reservationCount, 0)
+                XCTAssertEqual(transferredCount, 0)
+
+                let predecessorCallRan = AsyncCounter()
+                try await manager.withConnectionCallPermitForTesting(
+                    connectionID: predecessorID,
+                    lane: .ordinary
+                ) {
+                    await predecessorCallRan.increment()
+                }
+                let callCount = await predecessorCallRan.value
+                XCTAssertEqual(callCount, 1, "Rollback must leave the predecessor usable")
+
+                await manager.debugRemoveConnection(predecessorID)
+            }
+        #else
+            throw XCTSkip("Bootstrap replacement rollback seam is DEBUG-only")
         #endif
     }
 
@@ -798,11 +1059,15 @@ final class MCPSocketDescriptorHardeningTests: XCTestCase {
         throw TestError.bootstrapResponseTimedOut
     }
 
-    private static func writeBootstrapRequest(to fd: Int32) throws {
+    private static func writeBootstrapRequest(
+        to fd: Int32,
+        sessionToken: String = "fd-hardening-\(UUID().uuidString)",
+        clientName: String = "fd-hardening-test"
+    ) throws {
         var payload = try JSONEncoder().encode(MCPBootstrapRequest(
-            sessionToken: "fd-hardening-\(UUID().uuidString)",
+            sessionToken: sessionToken,
             clientPid: Int(getpid()),
-            clientName: "fd-hardening-test"
+            clientName: clientName
         ))
         payload.append(UInt8(ascii: "\n"))
         try writeAll(payload, to: fd)
@@ -1029,6 +1294,62 @@ private actor SuspendedAdmissionGate {
         releaseWaiters.forEach { $0.resume() }
         releaseWaiters.removeAll()
     }
+}
+
+private actor BootstrapAdmissionTestConnection: MCPServerConnection {
+    private let idleSeconds: TimeInterval
+    private let stopGate: SuspendedAdmissionGate?
+
+    init(idleSeconds: TimeInterval, stopGate: SuspendedAdmissionGate? = nil) {
+        self.idleSeconds = idleSeconds
+        self.stopGate = stopGate
+    }
+
+    nonisolated var isFilesystemBacked: Bool {
+        false
+    }
+
+    nonisolated var connectionFolderURL: URL? {
+        nil
+    }
+
+    nonisolated var capabilityToken: String? {
+        nil
+    }
+
+    func start(approvalHandler _: @escaping (MCP.Client.Info) async -> Bool) async throws {}
+
+    func stop() async {
+        await stopGate?.suspendUntilReleased()
+    }
+
+    func abortForExecutionWatchdog() async {}
+    func notifyToolListChanged() async {}
+
+    func connectionState() -> ConnectionStateSnapshot {
+        .ready
+    }
+
+    func isViableForRetention() -> Bool {
+        true
+    }
+
+    func secondsSinceLastActivity() async -> TimeInterval {
+        idleSeconds
+    }
+
+    func transportIngressSnapshot() async -> MCPTransportIngressSnapshot? {
+        nil
+    }
+
+    func terminate(reason _: TerminationReason, message _: String?) async {}
+
+    func sendProgress(
+        tool _: String,
+        kind _: RepoPromptProgressKind,
+        stage _: String,
+        message _: String
+    ) async {}
 }
 
 private enum TestError: Error {

--- a/Tests/RepoPromptTests/MCP/Control/MCPToolExecutionContractTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/MCPToolExecutionContractTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import MCP
 @testable import RepoPrompt
 import RepoPromptShared
 import XCTest
@@ -6,6 +7,7 @@ import XCTest
 final class MCPToolExecutionContractTests: XCTestCase {
     func testCentralTimeoutPolicyMatchesProductContract() {
         XCTAssertEqual(MCPTimeoutPolicy.boundedToolExecutionDeadlineSeconds, 30)
+        XCTAssertEqual(MCPTimeoutPolicy.workspaceSwitchToolExecutionDeadlineSeconds, 120)
         XCTAssertEqual(MCPTimeoutPolicy.boundedToolCancellationCleanupGraceSeconds, 5)
         XCTAssertEqual(MCPTimeoutPolicy.responseSendDeadlineSeconds, 30)
         XCTAssertEqual(MCPTimeoutPolicy.codexServerActiveTimeoutSeconds, 10000)
@@ -97,6 +99,58 @@ final class MCPToolExecutionContractTests: XCTestCase {
             MCPWindowToolName.manageWorktree
         ])
         assertNoWatchdogDeadline(for: names(for: .workspaceLifecycleCancellable))
+    }
+
+    func testManageWorkspacesUsesBoundedContractOnlyForSwitchProducingArguments() {
+        let boundedCases: [(label: String, arguments: [String: Value])] = [
+            ("switch", ["action": .string("switch")]),
+            ("normalized switch", ["action": .string("  SwItCh  ")]),
+            ("create default", ["action": .string("create")]),
+            ("create true", ["action": .string("create"), "switch_to_created": .bool(true)]),
+            ("delete close window", ["action": .string("delete"), "close_window": .bool(true)])
+        ]
+
+        for testCase in boundedCases {
+            guard case let .bounded(deadline, cancellationGrace) = MCPToolExecutionContractCatalog.contract(
+                for: MCPGlobalToolName.manageWorkspaces,
+                arguments: testCase.arguments
+            ) else {
+                XCTFail("Expected bounded contract for \(testCase.label)")
+                continue
+            }
+            XCTAssertEqual(deadline, MCPTimeoutPolicy.workspaceSwitchToolExecutionDeadline, testCase.label)
+            XCTAssertEqual(cancellationGrace, MCPTimeoutPolicy.boundedToolCancellationCleanupGrace, testCase.label)
+        }
+
+        let unboundedCases: [(label: String, arguments: [String: Value])] = [
+            ("list", ["action": .string("list")]),
+            ("create false", ["action": .string("create"), "switch_to_created": .bool(false)]),
+            ("create malformed flag", ["action": .string("create"), "switch_to_created": .string("true")]),
+            ("delete default", ["action": .string("delete")]),
+            ("delete false", ["action": .string("delete"), "close_window": .bool(false)]),
+            ("delete malformed flag", ["action": .string("delete"), "close_window": .string("true")]),
+            ("missing action", [:]),
+            ("malformed action", ["action": .bool(true)])
+        ]
+
+        for testCase in unboundedCases {
+            XCTAssertEqual(
+                MCPToolExecutionContractCatalog.contract(
+                    for: MCPGlobalToolName.manageWorkspaces,
+                    arguments: testCase.arguments
+                ),
+                .workspaceLifecycleCancellable,
+                testCase.label
+            )
+        }
+
+        XCTAssertEqual(
+            MCPToolExecutionContractCatalog.contract(
+                for: MCPWindowToolName.git,
+                arguments: ["action": .string("switch")]
+            ),
+            .workspaceLifecycleCancellable
+        )
     }
 
     func testMissingClassificationIsDetectedBeforeProviderEntry() {

--- a/Tests/RepoPromptTests/MCP/Control/MCPToolExecutionContractTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/MCPToolExecutionContractTests.swift
@@ -107,6 +107,9 @@ final class MCPToolExecutionContractTests: XCTestCase {
             ("normalized switch", ["action": .string("  SwItCh  ")]),
             ("create default", ["action": .string("create")]),
             ("create true", ["action": .string("create"), "switch_to_created": .bool(true)]),
+            // The handler resolves a present-but-non-bool flag as `?? true` and switches,
+            // so the contract must keep the watchdog on that path.
+            ("create malformed flag", ["action": .string("create"), "switch_to_created": .string("true")]),
             ("delete close window", ["action": .string("delete"), "close_window": .bool(true)])
         ]
 
@@ -125,7 +128,6 @@ final class MCPToolExecutionContractTests: XCTestCase {
         let unboundedCases: [(label: String, arguments: [String: Value])] = [
             ("list", ["action": .string("list")]),
             ("create false", ["action": .string("create"), "switch_to_created": .bool(false)]),
-            ("create malformed flag", ["action": .string("create"), "switch_to_created": .string("true")]),
             ("delete default", ["action": .string("delete")]),
             ("delete false", ["action": .string("delete"), "close_window": .bool(false)]),
             ("delete malformed flag", ["action": .string("delete"), "close_window": .string("true")]),

--- a/Tests/RepoPromptTests/MCP/Control/MCPToolExecutionWatchdogIntegrationTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/MCPToolExecutionWatchdogIntegrationTests.swift
@@ -468,6 +468,383 @@ import XCTest
             }
         }
 
+        func testManageWorkspacesSwitchTimeoutReleasesPermitAndKeepsConnectionUsable() async throws {
+            try await MCPSharedServerTestLease.shared.withLease { lease in
+                let fixture = try await PersistentMCPTestFixture.make(lease: lease)
+                let clock = ExecutionWatchdogManualClock()
+                let operationGate = MCPExecutionCooperativeCancellationGate()
+                let recorder = MCPExecutionTraceRecorder()
+                let manager = fixture.networkManager
+                let clientName = "manage-workspaces-cooperative-\(UUID().uuidString)"
+                var endpoint: PersistentMCPTestEndpoint?
+                var responseTask: Task<PersistentMCPTestRPCResponse, Error>?
+
+                MCPToolExecutionTracer.setTestSink { recorder.append($0) }
+                await manager.installClientConnectionPolicy(
+                    for: clientName,
+                    windowID: fixture.contextA.window.windowID,
+                    restrictedTools: [],
+                    tabID: fixture.contextA.tabID,
+                    runID: UUID(),
+                    additionalTools: [MCPGlobalToolName.manageWorkspaces],
+                    purpose: .agentModeRun
+                )
+                await manager.debugSetToolExecutionWatchdogEnvironment(clock.environment)
+                await manager.debugSetResolvedToolOperationOverride(toolName: MCPGlobalToolName.manageWorkspaces) {
+                    try await operationGate.enterAndWait()
+                    return .null
+                }
+
+                do {
+                    let createdEndpoint = try await PersistentMCPTestEndpoint.make(
+                        label: "manage-workspaces-cooperative",
+                        networkManager: manager,
+                        clientName: clientName,
+                        requiredToolNames: [MCPGlobalToolName.manageWorkspaces]
+                    )
+                    endpoint = createdEndpoint
+                    let activeResponseTask = Task {
+                        try await createdEndpoint.callTool(
+                            name: MCPGlobalToolName.manageWorkspaces,
+                            arguments: [
+                                "action": "switch",
+                                "workspace": fixture.contextA.workspaceID.uuidString,
+                                "window_id": fixture.contextA.window.windowID
+                            ]
+                        )
+                    }
+                    responseTask = activeResponseTask
+                    try await clock.waitForSleeperCount(1)
+                    try await operationGate.waitUntilEntered()
+                    try await clock.advanceNext(expected: MCPTimeoutPolicy.workspaceSwitchToolExecutionDeadline)
+
+                    let response = try await activeResponseTask.value
+                    responseTask = nil
+                    let cancellationCount = await operationGate.observedCancellationCount()
+                    XCTAssertEqual(cancellationCount, 1)
+                    let text = try Self.toolResultText(response)
+                    XCTAssertEqual(text.components(separatedBy: "tool_execution_timeout").count - 1, 1, text)
+                    XCTAssertTrue(text.contains("120-second execution contract"), text)
+
+                    let events = recorder.snapshot().filter {
+                        $0.connectionID == createdEndpoint.connectionID
+                            && $0.toolName == MCPGlobalToolName.manageWorkspaces
+                    }
+                    let selected = try XCTUnwrap(events.first { $0.phase == .contractSelected })
+                    XCTAssertEqual(selected.contractKind, .bounded)
+                    XCTAssertEqual(
+                        selected.executionDeadlineSeconds,
+                        Double(MCPTimeoutPolicy.workspaceSwitchToolExecutionDeadlineSeconds)
+                    )
+                    XCTAssertEqual(
+                        selected.cleanupGraceSeconds,
+                        Double(MCPTimeoutPolicy.boundedToolCancellationCleanupGraceSeconds)
+                    )
+                    XCTAssertEqual(events.count(where: { $0.phase == .deadlineExpired }), 1)
+                    let isTerminal = await manager.debugIsExecutionWatchdogTerminal(
+                        connectionID: createdEndpoint.connectionID
+                    )
+                    XCTAssertFalse(isTerminal)
+
+                    await manager.debugSetResolvedToolOperationOverride(
+                        toolName: MCPGlobalToolName.manageWorkspaces,
+                        operation: nil
+                    )
+                    await manager.debugResetToolExecutionWatchdogEnvironment()
+                    MCPToolExecutionTracer.setTestSink(nil)
+
+                    let listResponse = try await createdEndpoint.callTool(
+                        name: MCPGlobalToolName.manageWorkspaces,
+                        arguments: ["action": "list"]
+                    )
+                    let listText = try Self.toolResultText(listResponse)
+                    XCTAssertFalse(listText.contains("tool_execution_timeout"), listText)
+                    _ = try await createdEndpoint.client.request(method: "tools/list", params: [:])
+                    let limiter = await manager.connectionLimiterSnapshotForTesting(
+                        connectionID: createdEndpoint.connectionID
+                    )
+                    XCTAssertEqual(limiter?.permits, 1)
+                    XCTAssertEqual(limiter?.waiterCount, 0)
+                    XCTAssertEqual(limiter?.inFlight, 0)
+
+                    await Self.cleanupEndpoint(createdEndpoint, manager: manager)
+                    endpoint = nil
+                    await fixture.cleanup()
+                    try await fixture.assertCleanedUp()
+                } catch {
+                    await operationGate.cancelForCleanup()
+                    responseTask?.cancel()
+                    if let responseTask {
+                        _ = try? await responseTask.value
+                    }
+                    MCPToolExecutionTracer.setTestSink(nil)
+                    await manager.debugSetResolvedToolOperationOverride(
+                        toolName: MCPGlobalToolName.manageWorkspaces,
+                        operation: nil
+                    )
+                    await manager.debugResetToolExecutionWatchdogEnvironment()
+                    if let endpoint {
+                        await Self.cleanupEndpoint(endpoint, manager: manager)
+                    }
+                    await fixture.cleanup()
+                    throw error
+                }
+            }
+        }
+
+        func testManageWorkspacesCreateDeleteAndListSelectExactContracts() async throws {
+            try await MCPSharedServerTestLease.shared.withLease { lease in
+                let fixture = try await PersistentMCPTestFixture.make(lease: lease)
+                let recorder = MCPExecutionTraceRecorder()
+                let manager = fixture.networkManager
+                let clientName = "manage-workspaces-classification-\(UUID().uuidString)"
+                let cases: [(label: String, arguments: [String: Any], isBounded: Bool)] = [
+                    ("create default", ["action": "create"], true),
+                    ("create true", ["action": "create", "switch_to_created": true], true),
+                    ("create false", ["action": "create", "switch_to_created": false], false),
+                    ("delete close", ["action": "delete", "close_window": true], true),
+                    ("delete default", ["action": "delete"], false),
+                    ("delete no close", ["action": "delete", "close_window": false], false),
+                    ("list", ["action": "list"], false)
+                ]
+                var endpoint: PersistentMCPTestEndpoint?
+                var activeGate: MCPExecutionIgnoringCancellationGate?
+                var activeResponseTask: Task<PersistentMCPTestRPCResponse, Error>?
+
+                MCPToolExecutionTracer.setTestSink { recorder.append($0) }
+                await manager.installClientConnectionPolicy(
+                    for: clientName,
+                    windowID: fixture.contextA.window.windowID,
+                    restrictedTools: [],
+                    tabID: fixture.contextA.tabID,
+                    runID: UUID(),
+                    additionalTools: [MCPGlobalToolName.manageWorkspaces],
+                    purpose: .agentModeRun
+                )
+                do {
+                    let createdEndpoint = try await PersistentMCPTestEndpoint.make(
+                        label: "manage-workspaces-classification",
+                        networkManager: manager,
+                        clientName: clientName,
+                        requiredToolNames: [MCPGlobalToolName.manageWorkspaces]
+                    )
+                    endpoint = createdEndpoint
+                    for (index, testCase) in cases.enumerated() {
+                        let clock = ExecutionWatchdogManualClock()
+                        let operationGate = MCPExecutionIgnoringCancellationGate()
+                        activeGate = operationGate
+                        let label = testCase.label
+                        await manager.debugSetToolExecutionWatchdogEnvironment(clock.environment)
+                        await manager.debugSetResolvedToolOperationOverride(toolName: MCPGlobalToolName.manageWorkspaces) {
+                            await operationGate.enterAndWait()
+                            return .object([
+                                "action": .string(label),
+                                "status": .string("ok")
+                            ])
+                        }
+
+                        var arguments = testCase.arguments
+                        arguments["window_id"] = fixture.contextA.window.windowID
+                        let responseTask = Task {
+                            try await createdEndpoint.callTool(
+                                name: MCPGlobalToolName.manageWorkspaces,
+                                arguments: arguments
+                            )
+                        }
+                        activeResponseTask = responseTask
+                        try await operationGate.waitUntilEntered(count: 1)
+                        if testCase.isBounded {
+                            try await clock.waitForSleeperCount(1)
+                        } else {
+                            for _ in 0 ..< 20 {
+                                await Task.yield()
+                            }
+                            let sleeperCount = await clock.sleeperCount()
+                            XCTAssertEqual(sleeperCount, 0, testCase.label)
+                        }
+
+                        let selectedEvents = recorder.snapshot().filter {
+                            $0.connectionID == createdEndpoint.connectionID
+                                && $0.toolName == MCPGlobalToolName.manageWorkspaces
+                                && $0.phase == .contractSelected
+                        }
+                        XCTAssertEqual(selectedEvents.count, index + 1, testCase.label)
+                        let selected = try XCTUnwrap(selectedEvents.last, testCase.label)
+                        XCTAssertEqual(
+                            selected.contractKind,
+                            testCase.isBounded ? .bounded : .workspaceLifecycleCancellable,
+                            testCase.label
+                        )
+                        XCTAssertEqual(
+                            selected.executionDeadlineSeconds,
+                            testCase.isBounded
+                                ? Double(MCPTimeoutPolicy.workspaceSwitchToolExecutionDeadlineSeconds)
+                                : nil,
+                            testCase.label
+                        )
+
+                        await operationGate.release()
+                        _ = try await responseTask.value
+                        activeResponseTask = nil
+                        activeGate = nil
+                        await manager.debugSetResolvedToolOperationOverride(
+                            toolName: MCPGlobalToolName.manageWorkspaces,
+                            operation: nil
+                        )
+                        await manager.debugResetToolExecutionWatchdogEnvironment()
+                    }
+
+                    MCPToolExecutionTracer.setTestSink(nil)
+                    let terminal = await manager.debugIsExecutionWatchdogTerminal(
+                        connectionID: createdEndpoint.connectionID
+                    )
+                    XCTAssertFalse(terminal)
+                    await Self.cleanupEndpoint(createdEndpoint, manager: manager)
+                    endpoint = nil
+                    await fixture.cleanup()
+                    try await fixture.assertCleanedUp()
+                } catch {
+                    await activeGate?.release()
+                    activeResponseTask?.cancel()
+                    if let activeResponseTask {
+                        _ = try? await activeResponseTask.value
+                    }
+                    MCPToolExecutionTracer.setTestSink(nil)
+                    await manager.debugSetResolvedToolOperationOverride(
+                        toolName: MCPGlobalToolName.manageWorkspaces,
+                        operation: nil
+                    )
+                    await manager.debugResetToolExecutionWatchdogEnvironment()
+                    if let endpoint {
+                        await Self.cleanupEndpoint(endpoint, manager: manager)
+                    }
+                    await fixture.cleanup()
+                    throw error
+                }
+            }
+        }
+
+        func testUncooperativeManageWorkspacesSwitchForceDisconnectsAndBlocksQueuedProviderEntry() async throws {
+            try await MCPSharedServerTestLease.shared.withLease { lease in
+                let fixture = try await PersistentMCPTestFixture.make(lease: lease)
+                let clock = ExecutionWatchdogManualClock()
+                let operationGate = MCPExecutionIgnoringCancellationGate()
+                let recorder = MCPExecutionTraceRecorder()
+                let manager = fixture.networkManager
+                let clientName = "manage-workspaces-uncooperative-\(UUID().uuidString)"
+                var endpoint: PersistentMCPTestEndpoint?
+
+                MCPToolExecutionTracer.setTestSink { recorder.append($0) }
+                await manager.installClientConnectionPolicy(
+                    for: clientName,
+                    windowID: fixture.contextA.window.windowID,
+                    restrictedTools: [],
+                    tabID: fixture.contextA.tabID,
+                    runID: UUID(),
+                    additionalTools: [MCPGlobalToolName.manageWorkspaces],
+                    purpose: .agentModeRun
+                )
+                await manager.debugSetToolExecutionWatchdogEnvironment(clock.environment)
+                await manager.debugSetResolvedToolOperationOverride(toolName: MCPGlobalToolName.manageWorkspaces) {
+                    await operationGate.enterAndWait()
+                    return .null
+                }
+
+                do {
+                    let createdEndpoint = try await PersistentMCPTestEndpoint.make(
+                        label: "manage-workspaces-uncooperative",
+                        networkManager: manager,
+                        clientName: clientName,
+                        requiredToolNames: [MCPGlobalToolName.manageWorkspaces]
+                    )
+                    endpoint = createdEndpoint
+                    let first = Task {
+                        try await createdEndpoint.callTool(
+                            name: MCPGlobalToolName.manageWorkspaces,
+                            arguments: [
+                                "action": "switch",
+                                "workspace": fixture.contextA.workspaceID.uuidString,
+                                "window_id": fixture.contextA.window.windowID
+                            ]
+                        )
+                    }
+                    try await clock.waitForSleeperCount(1)
+                    try await operationGate.waitUntilEntered(count: 1)
+
+                    let queued = Task {
+                        try await createdEndpoint.callTool(
+                            name: MCPGlobalToolName.manageWorkspaces,
+                            arguments: [
+                                "action": "list",
+                                "window_id": fixture.contextA.window.windowID
+                            ]
+                        )
+                    }
+                    for _ in 0 ..< 1000 {
+                        let waiterCount = await manager.connectionLimiterSnapshotForTesting(
+                            connectionID: createdEndpoint.connectionID
+                        )?.waiterCount
+                        if waiterCount == 1 { break }
+                        await Task.yield()
+                    }
+                    let queuedLimiter = await manager.connectionLimiterSnapshotForTesting(
+                        connectionID: createdEndpoint.connectionID
+                    )
+                    XCTAssertEqual(queuedLimiter?.waiterCount, 1)
+
+                    try await clock.advanceNext(expected: MCPTimeoutPolicy.workspaceSwitchToolExecutionDeadline)
+                    try await clock.waitForSleeperCount(1)
+                    try await clock.advanceNext(expected: MCPTimeoutPolicy.boundedToolCancellationCleanupGrace)
+
+                    await Self.assertSocketClosed(first)
+                    await Self.assertSocketClosed(queued)
+                    let enteredCount = await operationGate.enteredCount()
+                    let isTerminal = await manager.debugIsExecutionWatchdogTerminal(
+                        connectionID: createdEndpoint.connectionID
+                    )
+                    XCTAssertEqual(enteredCount, 1)
+                    XCTAssertTrue(isTerminal)
+
+                    let events = recorder.snapshot().filter {
+                        $0.connectionID == createdEndpoint.connectionID
+                            && $0.toolName == MCPGlobalToolName.manageWorkspaces
+                    }
+                    let selected = try XCTUnwrap(events.first { $0.phase == .contractSelected })
+                    XCTAssertEqual(
+                        selected.executionDeadlineSeconds,
+                        Double(MCPTimeoutPolicy.workspaceSwitchToolExecutionDeadlineSeconds)
+                    )
+                    XCTAssertFalse(events.contains { $0.phase == .handlerCompleted })
+                    XCTAssertTrue(events.contains { $0.phase == .cleanupGraceExpired })
+                    XCTAssertTrue(events.contains { $0.phase == .connectionForceDisconnectRequested })
+
+                    await operationGate.release()
+                    MCPToolExecutionTracer.setTestSink(nil)
+                    await manager.debugSetResolvedToolOperationOverride(
+                        toolName: MCPGlobalToolName.manageWorkspaces,
+                        operation: nil
+                    )
+                    await manager.debugResetToolExecutionWatchdogEnvironment()
+                    await Self.cleanupEndpoint(createdEndpoint, manager: manager)
+                    endpoint = nil
+                    await fixture.cleanup()
+                } catch {
+                    await operationGate.release()
+                    MCPToolExecutionTracer.setTestSink(nil)
+                    await manager.debugSetResolvedToolOperationOverride(
+                        toolName: MCPGlobalToolName.manageWorkspaces,
+                        operation: nil
+                    )
+                    await manager.debugResetToolExecutionWatchdogEnvironment()
+                    if let endpoint {
+                        await Self.cleanupEndpoint(endpoint, manager: manager)
+                    }
+                    await fixture.cleanup()
+                    throw error
+                }
+            }
+        }
+
         func testWindowIDInjectionAndExplicitValueReachResolvedProviderArguments() async throws {
             try await MCPSharedServerTestLease.shared.withLease { lease in
                 let fixture = try await PersistentMCPTestFixture.make(lease: lease)

--- a/Tests/RepoPromptTests/MCP/Control/PersistentAgentModeMCPReadFileConnectionTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/PersistentAgentModeMCPReadFileConnectionTests.swift
@@ -737,8 +737,11 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
                     parentManager: ServerNetworkManager.shared
                 )
                 connectionManager = resolvedConnectionManager
-                _ = await ServerNetworkManager.shared.debugInstallConnectionLimiterForTesting(
-                    connectionID: connectionID
+                await ServerNetworkManager.shared.debugRegisterConnectionForSocketFixture(
+                    connectionID: connectionID,
+                    connection: resolvedConnectionManager,
+                    clientName: AgentProviderKind.codexMCPClientID,
+                    sessionToken: sessionToken
                 )
                 let spec = MCPBootstrapLeaseSpec.agentMode(
                     tabID: tabID,

--- a/Tests/RepoPromptTests/MCP/Control/PersistentMCPDistinctConnectionConcurrencyTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/PersistentMCPDistinctConnectionConcurrencyTests.swift
@@ -425,7 +425,11 @@ final class PersistentMCPDistinctConnectionConcurrencyTests: XCTestCase {
 
             let heldStore = fixture.contextA.window.workspaceFileContextStore
             let baselineConfiguration = await heldStore.searchLaneSnapshotForTesting().configuration
+            // One active lease and two waiter slots: the same-connection burst member and the
+            // separate-connection search both wait in the store queue while the third rejects.
             let liveSweepConfiguration = StoreBackedWorkspaceSearchLane.Configuration(
+                maxActiveLeases: 1,
+                maxQueuedWaiters: 2,
                 maxQueueWait: .seconds(8),
                 retryAfterMilliseconds: 1000
             )
@@ -447,16 +451,18 @@ final class PersistentMCPDistinctConnectionConcurrencyTests: XCTestCase {
                 }
                 outstandingSearchTasks.append(firstHeldSearch)
                 await fulfillment(of: [heldSearchStarted], timeout: 1)
-                let sameConnectionSearchQueued = expectation(description: "second same-connection search queued in limiter")
+                let sameConnectionSearchAdmitted = expectation(
+                    description: "second same-connection search admitted concurrently by the file-search lane"
+                )
                 let observerInstalled = await fixture.networkManager.setConnectionLimiterStateObserverForTesting(
                     connectionID: endpointA.connectionID,
                     lane: .fileSearch
                 ) { snapshot in
-                    if snapshot.permits == 0,
-                       snapshot.waiterCount == 1,
+                    if snapshot.activePermitCount == 2,
+                       snapshot.waiterCount == 0,
                        snapshot.inFlight == 2
                     {
-                        sameConnectionSearchQueued.fulfill()
+                        sameConnectionSearchAdmitted.fulfill()
                     }
                 }
                 XCTAssertTrue(observerInstalled)
@@ -464,19 +470,21 @@ final class PersistentMCPDistinctConnectionConcurrencyTests: XCTestCase {
                     try await endpointA.callTool(name: MCPWindowToolName.search, arguments: Self.searchArguments)
                 }
                 outstandingSearchTasks.append(secondHeldSearch)
-                await fulfillment(of: [sameConnectionSearchQueued], timeout: 1)
+                await fulfillment(of: [sameConnectionSearchAdmitted], timeout: 1)
                 _ = await fixture.networkManager.setConnectionLimiterStateObserverForTesting(
                     connectionID: endpointA.connectionID,
                     lane: .fileSearch,
                     observer: nil
                 )
-                let queuedLimiterState = await fixture.networkManager.connectionLimiterSnapshotForTesting(
+                // The burst member proceeds past the connection lane and waits in the store queue.
+                await Self.waitForSearchLaneWaiter(store: heldStore, expectedCount: 1)
+                let burstLimiterState = await fixture.networkManager.connectionLimiterSnapshotForTesting(
                     connectionID: endpointA.connectionID,
                     lane: .fileSearch
                 )
-                XCTAssertEqual(queuedLimiterState?.permits, 0)
-                XCTAssertEqual(queuedLimiterState?.waiterCount, 1)
-                XCTAssertEqual(queuedLimiterState?.inFlight, 2)
+                XCTAssertEqual(burstLimiterState?.activePermitCount, 2)
+                XCTAssertEqual(burstLimiterState?.waiterCount, 0)
+                XCTAssertEqual(burstLimiterState?.inFlight, 2)
                 let hasHeldSearchInFlight = await fixture.networkManager.hasInFlightCalls(for: endpointA.connectionID)
                 XCTAssertTrue(hasHeldSearchInFlight)
 
@@ -484,12 +492,12 @@ final class PersistentMCPDistinctConnectionConcurrencyTests: XCTestCase {
                     try await endpointAQueued.callTool(name: MCPWindowToolName.search, arguments: Self.searchArguments)
                 }
                 outstandingSearchTasks.append(storeQueuedSearch)
-                await Self.waitForSearchLaneWaiter(store: heldStore, expectedCount: 1)
+                await Self.waitForSearchLaneWaiter(store: heldStore, expectedCount: 2)
                 let heldSearchStartedCount = await gate.startedCountSnapshot()
                 XCTAssertEqual(heldSearchStartedCount, 1)
                 let heldSnapshot = await heldStore.searchLaneSnapshotForTesting()
                 XCTAssertEqual(heldSnapshot.activePermitCount, 1)
-                XCTAssertEqual(heldSnapshot.waiterCount, 1)
+                XCTAssertEqual(heldSnapshot.waiterCount, 2)
 
                 let overflow = try await endpointAOverflow.callTool(name: MCPWindowToolName.search, arguments: Self.searchArguments)
                 try Self.assertSearchBackpressureResult(overflow)
@@ -524,8 +532,8 @@ final class PersistentMCPDistinctConnectionConcurrencyTests: XCTestCase {
                 let runtimePayload = try Self.debugPayload(from: runtimeResponse)
                 let runtime = try XCTUnwrap(runtimePayload["runtime"] as? [String: Any])
                 let aggregateLimiter = try XCTUnwrap(runtime["limiter"] as? [String: Any])
-                XCTAssertEqual((aggregateLimiter["active_permit_count"] as? NSNumber)?.intValue, 2)
-                XCTAssertEqual((aggregateLimiter["waiter_count"] as? NSNumber)?.intValue, 1)
+                XCTAssertEqual((aggregateLimiter["active_permit_count"] as? NSNumber)?.intValue, 3)
+                XCTAssertEqual((aggregateLimiter["waiter_count"] as? NSNumber)?.intValue, 0)
                 XCTAssertEqual((aggregateLimiter["in_flight_count"] as? NSNumber)?.intValue, 3)
                 XCTAssertEqual(aggregateLimiter["is_idle"] as? Bool, false)
                 let limiterLanes = try XCTUnwrap(aggregateLimiter["lanes"] as? [String: Any])
@@ -534,8 +542,8 @@ final class PersistentMCPDistinctConnectionConcurrencyTests: XCTestCase {
                 XCTAssertEqual((diagnosticOrdinaryLane["waiter_count"] as? NSNumber)?.intValue, 0)
                 XCTAssertEqual((diagnosticOrdinaryLane["in_flight_count"] as? NSNumber)?.intValue, 1)
                 let diagnosticSearchLane = try XCTUnwrap(limiterLanes["file_search"] as? [String: Any])
-                XCTAssertEqual((diagnosticSearchLane["active_permit_count"] as? NSNumber)?.intValue, 1)
-                XCTAssertEqual((diagnosticSearchLane["waiter_count"] as? NSNumber)?.intValue, 1)
+                XCTAssertEqual((diagnosticSearchLane["active_permit_count"] as? NSNumber)?.intValue, 2)
+                XCTAssertEqual((diagnosticSearchLane["waiter_count"] as? NSNumber)?.intValue, 0)
                 XCTAssertEqual((diagnosticSearchLane["in_flight_count"] as? NSNumber)?.intValue, 2)
 
                 let exactRead = try await endpointARead.callTool(
@@ -572,8 +580,8 @@ final class PersistentMCPDistinctConnectionConcurrencyTests: XCTestCase {
                     connectionID: endpointA.connectionID,
                     lane: .fileSearch
                 )
-                XCTAssertEqual(limiterStateAfterPeerCalls?.permits, 0)
-                XCTAssertEqual(limiterStateAfterPeerCalls?.waiterCount, 1)
+                XCTAssertEqual(limiterStateAfterPeerCalls?.activePermitCount, 2)
+                XCTAssertEqual(limiterStateAfterPeerCalls?.waiterCount, 0)
                 XCTAssertEqual(limiterStateAfterPeerCalls?.inFlight, 2)
 
                 await gate.release()
@@ -590,7 +598,8 @@ final class PersistentMCPDistinctConnectionConcurrencyTests: XCTestCase {
                     connectionID: endpointA.connectionID,
                     lane: .fileSearch
                 )
-                XCTAssertEqual(settledSearchLimiterState?.permits, 1)
+                XCTAssertEqual(settledSearchLimiterState?.permits, ServerNetworkManager.fileSearchCallLaneLimit)
+                XCTAssertEqual(settledSearchLimiterState?.activePermitCount, 0)
                 XCTAssertEqual(settledSearchLimiterState?.waiterCount, 0)
                 XCTAssertEqual(settledSearchLimiterState?.inFlight, 0)
                 let settledOrdinaryLimiterState = await fixture.networkManager.connectionLimiterSnapshotForTesting(

--- a/Tests/RepoPromptTests/MCP/Control/PersistentMCPDistinctConnectionConcurrencyTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/PersistentMCPDistinctConnectionConcurrencyTests.swift
@@ -440,14 +440,50 @@ final class PersistentMCPDistinctConnectionConcurrencyTests: XCTestCase {
             await heldStore.setSearchLanePermitAcquiredHandlerForTesting {
                 await gate.markStartedAndWaitForRelease()
             }
+            var outstandingSearchTasks: [Task<PersistentMCPTestRPCResponse, Error>] = []
             do {
                 let firstHeldSearch = Task {
                     try await endpointA.callTool(name: MCPWindowToolName.search, arguments: Self.searchArguments)
                 }
+                outstandingSearchTasks.append(firstHeldSearch)
                 await fulfillment(of: [heldSearchStarted], timeout: 1)
+                let sameConnectionSearchQueued = expectation(description: "second same-connection search queued in limiter")
+                let observerInstalled = await fixture.networkManager.setConnectionLimiterStateObserverForTesting(
+                    connectionID: endpointA.connectionID,
+                    lane: .fileSearch
+                ) { snapshot in
+                    if snapshot.permits == 0,
+                       snapshot.waiterCount == 1,
+                       snapshot.inFlight == 2
+                    {
+                        sameConnectionSearchQueued.fulfill()
+                    }
+                }
+                XCTAssertTrue(observerInstalled)
                 let secondHeldSearch = Task {
+                    try await endpointA.callTool(name: MCPWindowToolName.search, arguments: Self.searchArguments)
+                }
+                outstandingSearchTasks.append(secondHeldSearch)
+                await fulfillment(of: [sameConnectionSearchQueued], timeout: 1)
+                _ = await fixture.networkManager.setConnectionLimiterStateObserverForTesting(
+                    connectionID: endpointA.connectionID,
+                    lane: .fileSearch,
+                    observer: nil
+                )
+                let queuedLimiterState = await fixture.networkManager.connectionLimiterSnapshotForTesting(
+                    connectionID: endpointA.connectionID,
+                    lane: .fileSearch
+                )
+                XCTAssertEqual(queuedLimiterState?.permits, 0)
+                XCTAssertEqual(queuedLimiterState?.waiterCount, 1)
+                XCTAssertEqual(queuedLimiterState?.inFlight, 2)
+                let hasHeldSearchInFlight = await fixture.networkManager.hasInFlightCalls(for: endpointA.connectionID)
+                XCTAssertTrue(hasHeldSearchInFlight)
+
+                let storeQueuedSearch = Task {
                     try await endpointAQueued.callTool(name: MCPWindowToolName.search, arguments: Self.searchArguments)
                 }
+                outstandingSearchTasks.append(storeQueuedSearch)
                 await Self.waitForSearchLaneWaiter(store: heldStore, expectedCount: 1)
                 let heldSearchStartedCount = await gate.startedCountSnapshot()
                 XCTAssertEqual(heldSearchStartedCount, 1)
@@ -458,35 +494,49 @@ final class PersistentMCPDistinctConnectionConcurrencyTests: XCTestCase {
                 let overflow = try await endpointAOverflow.callTool(name: MCPWindowToolName.search, arguments: Self.searchArguments)
                 try Self.assertSearchBackpressureResult(overflow)
 
-                let sameConnectionReadQueued = expectation(description: "same-connection read queued in limiter")
-                let observerInstalled = await fixture.networkManager.setConnectionLimiterStateObserverForTesting(
-                    connectionID: endpointA.connectionID
-                ) { snapshot in
-                    if snapshot.permits == 0,
-                       snapshot.waiterCount == 1,
-                       snapshot.inFlight == 2
-                    {
-                        sameConnectionReadQueued.fulfill()
-                    }
-                }
-                XCTAssertTrue(observerInstalled)
-                let sameConnectionRead = Task {
-                    try await endpointA.callTool(
-                        name: MCPWindowToolName.readFile,
-                        arguments: ["path": fixture.contextA.fileURL.path]
-                    )
-                }
-                await fulfillment(of: [sameConnectionReadQueued], timeout: 1)
-                _ = await fixture.networkManager.setConnectionLimiterStateObserverForTesting(
+                let sameConnectionRead = try await endpointA.callTool(
+                    name: MCPWindowToolName.readFile,
+                    arguments: ["path": fixture.contextA.fileURL.path],
+                    timeoutSeconds: 1
+                )
+                try Self.assertReadResult(
+                    sameConnectionRead,
+                    contains: fixture.contextA.sentinel,
+                    excludes: fixture.contextB.sentinel
+                )
+                let ordinaryLimiterState = await fixture.networkManager.connectionLimiterSnapshotForTesting(
                     connectionID: endpointA.connectionID,
-                    observer: nil
+                    lane: .ordinary
                 )
-                let queuedLimiterState = await fixture.networkManager.connectionLimiterSnapshotForTesting(
-                    connectionID: endpointA.connectionID
+                XCTAssertEqual(ordinaryLimiterState?.permits, 1)
+                XCTAssertEqual(ordinaryLimiterState?.waiterCount, 0)
+                XCTAssertEqual(ordinaryLimiterState?.inFlight, 0)
+
+                let runtimeResponse = try await endpointA.callTool(
+                    name: ServerNetworkManager.debugDiagnosticsToolName,
+                    arguments: [
+                        "op": "mcp_read_search_runtime_snapshot",
+                        "connection_id": endpointA.connectionID.uuidString,
+                        "recent_publication_limit": 0,
+                        "root_limit": 1
+                    ]
                 )
-                XCTAssertEqual(queuedLimiterState?.permits, 0)
-                XCTAssertEqual(queuedLimiterState?.waiterCount, 1)
-                XCTAssertEqual(queuedLimiterState?.inFlight, 2)
+                let runtimePayload = try Self.debugPayload(from: runtimeResponse)
+                let runtime = try XCTUnwrap(runtimePayload["runtime"] as? [String: Any])
+                let aggregateLimiter = try XCTUnwrap(runtime["limiter"] as? [String: Any])
+                XCTAssertEqual((aggregateLimiter["active_permit_count"] as? NSNumber)?.intValue, 2)
+                XCTAssertEqual((aggregateLimiter["waiter_count"] as? NSNumber)?.intValue, 1)
+                XCTAssertEqual((aggregateLimiter["in_flight_count"] as? NSNumber)?.intValue, 3)
+                XCTAssertEqual(aggregateLimiter["is_idle"] as? Bool, false)
+                let limiterLanes = try XCTUnwrap(aggregateLimiter["lanes"] as? [String: Any])
+                let diagnosticOrdinaryLane = try XCTUnwrap(limiterLanes["ordinary"] as? [String: Any])
+                XCTAssertEqual((diagnosticOrdinaryLane["active_permit_count"] as? NSNumber)?.intValue, 1)
+                XCTAssertEqual((diagnosticOrdinaryLane["waiter_count"] as? NSNumber)?.intValue, 0)
+                XCTAssertEqual((diagnosticOrdinaryLane["in_flight_count"] as? NSNumber)?.intValue, 1)
+                let diagnosticSearchLane = try XCTUnwrap(limiterLanes["file_search"] as? [String: Any])
+                XCTAssertEqual((diagnosticSearchLane["active_permit_count"] as? NSNumber)?.intValue, 1)
+                XCTAssertEqual((diagnosticSearchLane["waiter_count"] as? NSNumber)?.intValue, 1)
+                XCTAssertEqual((diagnosticSearchLane["in_flight_count"] as? NSNumber)?.intValue, 2)
 
                 let exactRead = try await endpointARead.callTool(
                     name: MCPWindowToolName.readFile,
@@ -519,7 +569,8 @@ final class PersistentMCPDistinctConnectionConcurrencyTests: XCTestCase {
                 try Self.assertSearchResult(peerSearch, contains: fixture.contextB.fileURL.lastPathComponent, excludes: fixture.contextA.fileURL.lastPathComponent)
 
                 let limiterStateAfterPeerCalls = await fixture.networkManager.connectionLimiterSnapshotForTesting(
-                    connectionID: endpointA.connectionID
+                    connectionID: endpointA.connectionID,
+                    lane: .fileSearch
                 )
                 XCTAssertEqual(limiterStateAfterPeerCalls?.permits, 0)
                 XCTAssertEqual(limiterStateAfterPeerCalls?.waiterCount, 1)
@@ -528,16 +579,29 @@ final class PersistentMCPDistinctConnectionConcurrencyTests: XCTestCase {
                 await gate.release()
                 let firstHeld = try await firstHeldSearch.value
                 let secondHeld = try await secondHeldSearch.value
-                let serializedRead = try await sameConnectionRead.value
+                let storeQueued = try await Self.boundedTaskValue(
+                    storeQueuedSearch,
+                    description: "queued retained search"
+                )
                 try Self.assertSearchResult(firstHeld, contains: fixture.contextA.fileURL.lastPathComponent, excludes: fixture.contextB.fileURL.lastPathComponent)
                 try Self.assertSearchResult(secondHeld, contains: fixture.contextA.fileURL.lastPathComponent, excludes: fixture.contextB.fileURL.lastPathComponent)
-                try Self.assertReadResult(serializedRead, contains: fixture.contextA.sentinel, excludes: fixture.contextB.sentinel)
-                let settledLimiterState = await fixture.networkManager.connectionLimiterSnapshotForTesting(
-                    connectionID: endpointA.connectionID
+                try Self.assertSearchResult(storeQueued, contains: fixture.contextA.fileURL.lastPathComponent, excludes: fixture.contextB.fileURL.lastPathComponent)
+                let settledSearchLimiterState = await fixture.networkManager.connectionLimiterSnapshotForTesting(
+                    connectionID: endpointA.connectionID,
+                    lane: .fileSearch
                 )
-                XCTAssertEqual(settledLimiterState?.permits, 1)
-                XCTAssertEqual(settledLimiterState?.waiterCount, 0)
-                XCTAssertEqual(settledLimiterState?.inFlight, 0)
+                XCTAssertEqual(settledSearchLimiterState?.permits, 1)
+                XCTAssertEqual(settledSearchLimiterState?.waiterCount, 0)
+                XCTAssertEqual(settledSearchLimiterState?.inFlight, 0)
+                let settledOrdinaryLimiterState = await fixture.networkManager.connectionLimiterSnapshotForTesting(
+                    connectionID: endpointA.connectionID,
+                    lane: .ordinary
+                )
+                XCTAssertEqual(settledOrdinaryLimiterState?.permits, 1)
+                XCTAssertEqual(settledOrdinaryLimiterState?.waiterCount, 0)
+                XCTAssertEqual(settledOrdinaryLimiterState?.inFlight, 0)
+                let hasSettledInFlightCalls = await fixture.networkManager.hasInFlightCalls(for: endpointA.connectionID)
+                XCTAssertFalse(hasSettledInFlightCalls)
 
                 let settledRetry = try await endpointAOverflow.callTool(name: MCPWindowToolName.search, arguments: Self.searchArguments)
                 try Self.assertSearchResult(settledRetry, contains: fixture.contextA.fileURL.lastPathComponent, excludes: fixture.contextB.fileURL.lastPathComponent)
@@ -546,8 +610,15 @@ final class PersistentMCPDistinctConnectionConcurrencyTests: XCTestCase {
                 await restoreBroadSearchAdmissionConfiguration(baselineConfiguration, store: heldStore)
             } catch {
                 await gate.release()
+                for task in outstandingSearchTasks {
+                    _ = try? await Self.boundedTaskValue(
+                        task,
+                        description: "retained search cleanup"
+                    )
+                }
                 _ = await fixture.networkManager.setConnectionLimiterStateObserverForTesting(
                     connectionID: endpointA.connectionID,
+                    lane: .fileSearch,
                     observer: nil
                 )
                 await restoreBroadSearchAdmissionConfiguration(baselineConfiguration, store: heldStore)
@@ -644,7 +715,7 @@ final class PersistentMCPDistinctConnectionConcurrencyTests: XCTestCase {
                 callerID: callerID,
                 arguments: Self.exactRoutingSessionClearArguments(
                     for: fixture.sessionA,
-                    expectedLastConnectionID: UUID(uuidString: "44444444-4444-4444-8444-444444444444")!
+                    expectedLastConnectionID: UUID(uuidString: "55555555-5555-4555-8555-555555555555")!
                 ),
                 rawSessionTokens: rawSessionTokens
             )
@@ -973,6 +1044,33 @@ final class PersistentMCPDistinctConnectionConcurrencyTests: XCTestCase {
             for fileURL in searchFiles {
                 XCTAssertTrue(text.contains(fileURL.lastPathComponent), text)
             }
+        }
+
+        static func boundedTaskValue<Success>(
+            _ task: Task<Success, some Error>,
+            timeout: Duration = .seconds(12),
+            description: String
+        ) async throws -> Success {
+            let result = PersistentMCPTaskResultBox<Success>()
+            let observer = Task {
+                do {
+                    try await result.store(.success(task.value))
+                } catch {
+                    result.store(.failure(error))
+                }
+            }
+            let clock = ContinuousClock()
+            let deadline = clock.now.advanced(by: timeout)
+            while clock.now < deadline {
+                if let completed = result.load() {
+                    observer.cancel()
+                    return try completed.get()
+                }
+                try? await Task.sleep(for: .milliseconds(5))
+            }
+            task.cancel()
+            observer.cancel()
+            throw PersistentMCPTaskTimeoutError(description: description)
         }
 
         static func waitForContentReadLimiterIdle(
@@ -1831,6 +1929,27 @@ final class PersistentMCPDistinctConnectionConcurrencyTests: XCTestCase {
             stateLock.lock()
             defer { stateLock.unlock() }
             return try operation()
+        }
+    }
+
+    private struct PersistentMCPTaskTimeoutError: Error, CustomStringConvertible {
+        let description: String
+    }
+
+    private final class PersistentMCPTaskResultBox<Success>: @unchecked Sendable {
+        private let lock = NSLock()
+        private var result: Result<Success, Error>?
+
+        func store(_ result: Result<Success, Error>) {
+            lock.lock()
+            self.result = result
+            lock.unlock()
+        }
+
+        func load() -> Result<Success, Error>? {
+            lock.lock()
+            defer { lock.unlock() }
+            return result
         }
     }
 

--- a/Tests/RepoPromptTests/MCP/MCPReadSearchLatencyDiagnosticsGuardTests.swift
+++ b/Tests/RepoPromptTests/MCP/MCPReadSearchLatencyDiagnosticsGuardTests.swift
@@ -65,8 +65,8 @@
             XCTAssertTrue(configured.isIdle)
 
             let sibling = try? source("Sources/RepoPrompt/Features/Diagnostics/MCP/MCPConnectionManager+DebugDiagnosticsReadSearchLatency.swift")
-            XCTAssertTrue(sibling?.contains("\"active_capacity\": 1") == true)
-            XCTAssertTrue(sibling?.contains("\"max_queued\": 1") == true)
+            XCTAssertTrue(sibling?.contains("\"active_capacity\": entry.snapshot.configuration.maxActiveLeases") == true)
+            XCTAssertTrue(sibling?.contains("\"max_queued\": entry.snapshot.configuration.maxQueuedWaiters") == true)
             XCTAssertTrue(sibling?.contains("range: 100 ... 60000") == true)
             XCTAssertTrue(sibling?.contains("range: 0 ... 60000") == true)
             XCTAssertFalse(sibling?.contains("global_capacity") == true)
@@ -254,12 +254,13 @@
             ] {
                 XCTAssertEqual((autoSelection[key] as? NSNumber)?.intValue, 0, key)
             }
+            let fileSearchLaneLimit = ServerNetworkManager.fileSearchCallLaneLimit
             let limiter = try XCTUnwrap(runtime["limiter"] as? [String: Any])
             XCTAssertEqual(limiter["found"] as? Bool, true)
             XCTAssertEqual(limiter["connection_id"] as? String, connectionID.uuidString)
             XCTAssertEqual((limiter["lane_count"] as? NSNumber)?.intValue, 2)
-            XCTAssertEqual((limiter["limit"] as? NSNumber)?.intValue, 2)
-            XCTAssertEqual((limiter["permits"] as? NSNumber)?.intValue, 2)
+            XCTAssertEqual((limiter["limit"] as? NSNumber)?.intValue, 1 + fileSearchLaneLimit)
+            XCTAssertEqual((limiter["permits"] as? NSNumber)?.intValue, 1 + fileSearchLaneLimit)
             XCTAssertEqual((limiter["active_permit_count"] as? NSNumber)?.intValue, 0)
             XCTAssertEqual((limiter["waiter_count"] as? NSNumber)?.intValue, 0)
             XCTAssertEqual((limiter["in_flight_count"] as? NSNumber)?.intValue, 0)
@@ -267,10 +268,10 @@
             XCTAssertEqual(limiter["is_idle"] as? Bool, true)
             let lanes = try XCTUnwrap(limiter["lanes"] as? [String: Any])
             XCTAssertEqual(Set(lanes.keys), ["ordinary", "file_search"])
-            for laneName in ["ordinary", "file_search"] {
+            for (laneName, laneLimit) in [("ordinary", 1), ("file_search", fileSearchLaneLimit)] {
                 let lane = try XCTUnwrap(lanes[laneName] as? [String: Any])
-                XCTAssertEqual((lane["limit"] as? NSNumber)?.intValue, 1, laneName)
-                XCTAssertEqual((lane["permits"] as? NSNumber)?.intValue, 1, laneName)
+                XCTAssertEqual((lane["limit"] as? NSNumber)?.intValue, laneLimit, laneName)
+                XCTAssertEqual((lane["permits"] as? NSNumber)?.intValue, laneLimit, laneName)
                 XCTAssertEqual((lane["active_permit_count"] as? NSNumber)?.intValue, 0, laneName)
                 XCTAssertEqual((lane["waiter_count"] as? NSNumber)?.intValue, 0, laneName)
                 XCTAssertEqual((lane["in_flight_count"] as? NSNumber)?.intValue, 0, laneName)
@@ -2299,7 +2300,7 @@
             XCTAssertTrue(coordinator.contains("EditFlowPerf.Lifecycle.Search.broadAdmissionOverloaded"))
             XCTAssertTrue(coordinator.contains("EditFlowPerf.Lifecycle.Search.broadAdmissionWaitExpired"))
             XCTAssertTrue(coordinator.contains("EditFlowPerf.Stage.Search.broadAdmissionLeaseHold"))
-            XCTAssertTrue(coordinator.contains("storeCapacity: 1"))
+            XCTAssertTrue(coordinator.contains("storeCapacity: configuration.maxActiveLeases"))
             XCTAssertTrue(coordinator.contains("globalCapacity: 0"))
             XCTAssertTrue(coordinator.contains("storeQueueDepth: metrics.queueDepth"))
             XCTAssertTrue(coordinator.contains("globalQueueDepth: 0"))
@@ -2470,7 +2471,7 @@
             XCTAssertTrue(coordinator.contains("snapshotForTesting"))
             XCTAssertTrue(coordinator.contains("configureForTesting"))
             XCTAssertTrue(coordinator.contains("resetConfigurationForTesting"))
-            XCTAssertTrue(coordinator.contains("activeLeaseID == nil, waiterState == nil"))
+            XCTAssertTrue(coordinator.contains("activeLeaseIDs.isEmpty, waiterStatesByID.isEmpty"))
             XCTAssertTrue(coordinator.contains("let enqueuedAt = clock.now()"))
             XCTAssertTrue(coordinator.contains("maximumActivePermitCount"))
             XCTAssertTrue(coordinator.contains("maximumWaiterCount"))

--- a/Tests/RepoPromptTests/MCP/MCPReadSearchLatencyDiagnosticsGuardTests.swift
+++ b/Tests/RepoPromptTests/MCP/MCPReadSearchLatencyDiagnosticsGuardTests.swift
@@ -1,5 +1,6 @@
 #if DEBUG
     import Combine
+    import CoreServices
     import MCP
     @testable import RepoPrompt
     import XCTest
@@ -32,6 +33,9 @@
             XCTAssertTrue(sibling.contains("queued_count"))
             XCTAssertTrue(sibling.contains("window_count"))
             XCTAssertTrue(sibling.contains("\"lanes\""))
+            XCTAssertTrue(sibling.contains("\"lane_count\""))
+            XCTAssertTrue(sibling.contains("MCPConnectionCallLane.ordinary.rawValue"))
+            XCTAssertTrue(sibling.contains("MCPConnectionCallLane.fileSearch.rawValue"))
             XCTAssertTrue(sibling.contains("maximum_active_count"))
             XCTAssertTrue(sibling.contains("maximum_queued_count"))
             XCTAssertTrue(sibling.contains("max_queued_waiters"))
@@ -180,6 +184,10 @@
         func testRuntimeSnapshotHiddenOperationValidatesBoundsAndReturnsAggregateShape() async throws {
             let manager = ServerNetworkManager.shared
             let connectionID = UUID()
+            _ = await manager.debugInstallConnectionLimiterForTesting(connectionID: connectionID)
+            addTeardownBlock {
+                await manager.debugRemoveConnection(connectionID)
+            }
             let runID = UUID()
             await manager.registerToolCallObserver(for: runID) { _ in }
             await manager.registerToolEventObserver(
@@ -247,8 +255,45 @@
                 XCTAssertEqual((autoSelection[key] as? NSNumber)?.intValue, 0, key)
             }
             let limiter = try XCTUnwrap(runtime["limiter"] as? [String: Any])
-            XCTAssertEqual(limiter["found"] as? Bool, false)
+            XCTAssertEqual(limiter["found"] as? Bool, true)
             XCTAssertEqual(limiter["connection_id"] as? String, connectionID.uuidString)
+            XCTAssertEqual((limiter["lane_count"] as? NSNumber)?.intValue, 2)
+            XCTAssertEqual((limiter["limit"] as? NSNumber)?.intValue, 2)
+            XCTAssertEqual((limiter["permits"] as? NSNumber)?.intValue, 2)
+            XCTAssertEqual((limiter["active_permit_count"] as? NSNumber)?.intValue, 0)
+            XCTAssertEqual((limiter["waiter_count"] as? NSNumber)?.intValue, 0)
+            XCTAssertEqual((limiter["in_flight_count"] as? NSNumber)?.intValue, 0)
+            XCTAssertEqual(limiter["is_closed"] as? Bool, false)
+            XCTAssertEqual(limiter["is_idle"] as? Bool, true)
+            let lanes = try XCTUnwrap(limiter["lanes"] as? [String: Any])
+            XCTAssertEqual(Set(lanes.keys), ["ordinary", "file_search"])
+            for laneName in ["ordinary", "file_search"] {
+                let lane = try XCTUnwrap(lanes[laneName] as? [String: Any])
+                XCTAssertEqual((lane["limit"] as? NSNumber)?.intValue, 1, laneName)
+                XCTAssertEqual((lane["permits"] as? NSNumber)?.intValue, 1, laneName)
+                XCTAssertEqual((lane["active_permit_count"] as? NSNumber)?.intValue, 0, laneName)
+                XCTAssertEqual((lane["waiter_count"] as? NSNumber)?.intValue, 0, laneName)
+                XCTAssertEqual((lane["in_flight_count"] as? NSNumber)?.intValue, 0, laneName)
+                XCTAssertEqual(lane["is_closed"] as? Bool, false, laneName)
+                XCTAssertEqual(lane["is_idle"] as? Bool, true, laneName)
+            }
+
+            let missingConnectionID = UUID()
+            let missingResult = await manager.handleDebugDiagnosticsTool(
+                connectionID: connectionID,
+                arguments: [
+                    "op": .string("mcp_read_search_runtime_snapshot"),
+                    "connection_id": .string(missingConnectionID.uuidString),
+                    "window_id": .int(window.windowID),
+                    "recent_publication_limit": .int(0),
+                    "root_limit": .int(1)
+                ]
+            )
+            let missingPayload = try debugDiagnosticsPayload(missingResult)
+            let missingRuntime = try XCTUnwrap(missingPayload["runtime"] as? [String: Any])
+            let missingLimiter = try XCTUnwrap(missingRuntime["limiter"] as? [String: Any])
+            XCTAssertEqual(missingLimiter["found"] as? Bool, false)
+            XCTAssertEqual(missingLimiter["connection_id"] as? String, missingConnectionID.uuidString)
 
             for invalidArguments: [String: Value] in [
                 [
@@ -272,6 +317,151 @@
                 XCTAssertEqual(invalidPayload["ok"] as? Bool, false)
                 XCTAssertEqual(invalidPayload["op"] as? String, "mcp_read_search_runtime_snapshot")
                 XCTAssertEqual(invalidPayload["code"] as? String, "invalid_params")
+            }
+        }
+
+        @MainActor
+        func testRuntimeSnapshotProjectsActiveAndCoalescedPendingBarrierState() async throws {
+            let manager = ServerNetworkManager.shared
+            let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
+            GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
+            let window = WindowState()
+            WindowStatesManager.shared.registerWindowState(window)
+            GlobalSettingsStore.shared.setMCPAutoStart(previousAutoStart, commit: false)
+            addTeardownBlock { @MainActor in
+                window.beginClose()
+                await window.tearDown()
+                WindowStatesManager.shared.unregisterWindowState(window)
+            }
+
+            let root = try temporaryRoots.makeRoot(suiteName: "RuntimePendingBarrier")
+            let firstURL = root.appendingPathComponent("First.swift")
+            let secondURL = root.appendingPathComponent("Second.swift")
+            try FileSystemTestSupport.write("first", to: firstURL)
+            try FileSystemTestSupport.write("second", to: secondURL)
+            let store = window.workspaceFileContextStore
+            let record = try await store.loadRoot(path: root.path)
+            let watcherStartGate = MCPDiagnosticsGate()
+            await store.setWatcherServiceStateWillReconcileHandler { observedRootID, shouldWatch in
+                guard observedRootID == record.id, shouldWatch else { return }
+                await watcherStartGate.markStartedAndWaitForRelease()
+            }
+            let watcherStartTask = Task {
+                try await store.startWatchingRoot(id: record.id)
+            }
+            await watcherStartGate.waitUntilStarted()
+
+            let flushGate = MCPDiagnosticsGate()
+            await store.setScopedIngressBarrierWillFlushHandler { observedRootID in
+                guard observedRootID == record.id else { return }
+                await flushGate.markStartedAndWaitForRelease()
+            }
+            let activeBarrier = Task {
+                await store.awaitAppliedIngress(rootScope: .visibleWorkspace)
+            }
+            var pendingBarrier: Task<[WorkspaceIngressBarrierSample], Never>?
+            var coalescedBarrier: Task<[WorkspaceIngressBarrierSample], Never>?
+
+            do {
+                await flushGate.waitUntilStarted()
+                let createdFileFlags = FSEventStreamEventFlags(
+                    kFSEventStreamEventFlagItemCreated | kFSEventStreamEventFlagItemIsFile
+                )
+                let firstAccepted = try await store.acceptWatcherPayloadForTesting(
+                    rootID: record.id,
+                    events: [(absolutePath: firstURL.path, flags: createdFileFlags, eventId: 500)],
+                    scheduleDrain: false
+                )
+                _ = try XCTUnwrap(firstAccepted, "Expected first watcher watermark")
+                pendingBarrier = Task {
+                    await store.awaitAppliedIngress(rootScope: .visibleWorkspace)
+                }
+                for _ in 0 ..< 1000 {
+                    if await store.scopedIngressBarrierStatsForTesting(rootID: record.id).successorCount == 1 { break }
+                    await Task.yield()
+                }
+
+                let acceptedSecondWatermark = try await store.acceptWatcherPayloadForTesting(
+                    rootID: record.id,
+                    events: [(absolutePath: secondURL.path, flags: createdFileFlags, eventId: 501)],
+                    scheduleDrain: false
+                )
+                let secondAccepted = try XCTUnwrap(
+                    acceptedSecondWatermark,
+                    "Expected second watcher watermark"
+                )
+                try await store.publishSyntheticFileSystemDeltasForTesting(
+                    rootID: record.id,
+                    deltas: [.fileModified("First.swift", nil)]
+                )
+                let acceptedServicePublicationSequence = await store.appliedIngressSnapshotForTesting(rootID: record.id)
+                    .acceptedServicePublicationSequence
+                coalescedBarrier = Task {
+                    await store.awaitAppliedIngress(rootScope: .visibleWorkspace)
+                }
+                for _ in 0 ..< 1000 {
+                    if await store.scopedIngressBarrierStatsForTesting(rootID: record.id).coalescedSuccessorCount == 1 {
+                        break
+                    }
+                    await Task.yield()
+                }
+
+                let result = await manager.handleDebugDiagnosticsTool(
+                    connectionID: UUID(),
+                    arguments: [
+                        "op": .string("mcp_read_search_runtime_snapshot"),
+                        "window_id": .int(window.windowID),
+                        "recent_publication_limit": .int(0),
+                        "root_limit": .int(1)
+                    ]
+                )
+                await cleanupRuntimePendingBarrierTest(
+                    store: store,
+                    rootID: record.id,
+                    watcherStartGate: watcherStartGate,
+                    flushGate: flushGate,
+                    watcherStartTask: watcherStartTask,
+                    activeBarrier: activeBarrier,
+                    pendingBarrier: pendingBarrier,
+                    coalescedBarrier: coalescedBarrier
+                )
+
+                let payload = try debugDiagnosticsPayload(result)
+                let runtime = try XCTUnwrap(payload["runtime"] as? [String: Any])
+                let windows = try XCTUnwrap(runtime["windows"] as? [[String: Any]])
+                let windowPayload = try XCTUnwrap(windows.first)
+                let roots = try XCTUnwrap(windowPayload["roots"] as? [[String: Any]])
+                let rootPayload = try XCTUnwrap(roots.first)
+                let barrier = try XCTUnwrap(rootPayload["barrier"] as? [String: Any])
+                XCTAssertEqual((barrier["launch_count"] as? NSNumber)?.intValue, 1)
+                XCTAssertEqual((barrier["join_count"] as? NSNumber)?.intValue, 1)
+                XCTAssertEqual((barrier["successor_count"] as? NSNumber)?.intValue, 1)
+                XCTAssertEqual((barrier["coalesced_successor_count"] as? NSNumber)?.intValue, 1)
+                XCTAssertEqual((barrier["completion_count"] as? NSNumber)?.intValue, 0)
+                let active = try XCTUnwrap(barrier["active"] as? [String: Any])
+                XCTAssertEqual((active["target_watcher_watermark"] as? NSNumber)?.uint64Value, 0)
+                let pending = try XCTUnwrap(barrier["pending"] as? [String: Any])
+                XCTAssertEqual(
+                    (pending["target_watcher_watermark"] as? NSNumber)?.uint64Value,
+                    secondAccepted.rawValue
+                )
+                XCTAssertEqual(
+                    (pending["target_service_publication_sequence"] as? NSNumber)?.uint64Value,
+                    acceptedServicePublicationSequence
+                )
+                XCTAssertNotNil((pending["age_ms"] as? NSNumber)?.uint64Value)
+            } catch {
+                await cleanupRuntimePendingBarrierTest(
+                    store: store,
+                    rootID: record.id,
+                    watcherStartGate: watcherStartGate,
+                    flushGate: flushGate,
+                    watcherStartTask: watcherStartTask,
+                    activeBarrier: activeBarrier,
+                    pendingBarrier: pendingBarrier,
+                    coalescedBarrier: coalescedBarrier
+                )
+                throw error
             }
         }
 
@@ -413,7 +603,7 @@
 
             let limiterBegin = try XCTUnwrap(manager.range(of: "let limiterWaitState = EditFlowPerf.begin("))
             let limiterEnd = try XCTUnwrap(manager.range(of: "defer { EditFlowPerf.end(EditFlowPerf.Stage.MCPToolCall.limiterWait, limiterWaitState) }", range: limiterBegin.upperBound ..< manager.endIndex))
-            let withPermit = try XCTUnwrap(manager.range(of: "return await limiter.withPermit(", range: limiterEnd.upperBound ..< manager.endIndex))
+            let withPermit = try XCTUnwrap(manager.range(of: "return await self.withConnectionCallPermit(", range: limiterEnd.upperBound ..< manager.endIndex))
             XCTAssertLessThan(limiterBegin.lowerBound, limiterEnd.lowerBound)
             XCTAssertLessThan(limiterEnd.lowerBound, withPermit.lowerBound)
 
@@ -594,7 +784,7 @@
                 "EditFlowPerf.Stage.MCPToolCall.limiterEnvelope",
                 "let limiterWaitState = EditFlowPerf.begin(",
                 "defer { EditFlowPerf.end(EditFlowPerf.Stage.MCPToolCall.limiterWait, limiterWaitState) }",
-                "await limiter.withPermit(",
+                "await self.withConnectionCallPermit(",
                 "EditFlowPerf.Stage.MCPToolCall.permitBodyEnvelope",
                 "let permitPreDispatchEnvelopeState = EditFlowPerf.begin(",
                 "EditFlowPerf.Stage.MCPToolCall.enabledStateSnapshot",
@@ -1557,13 +1747,15 @@
             let unloadEnd = try XCTUnwrap(store.range(of: "    func file(rootID: UUID, relativePath: String)", range: unloadStart.upperBound ..< store.endIndex))
             let unload = String(store[unloadStart.lowerBound ..< unloadEnd.lowerBound])
             let rootDetach = try XCTUnwrap(unload.range(of: "rootStatesByID.removeValue(forKey: rootID)"))
-            let stopWatching = try XCTUnwrap(unload.range(of: "await reconcileWatcherServiceState(entry.state.service, rootID: entry.rootID)"))
+            let watcherStopStart = try XCTUnwrap(unload.range(of: "let detachedWatcherStops = startDetachedWatcherStops(statesToUnload)"))
+            let watcherStopWait = try XCTUnwrap(unload.range(of: "let watcherStopReports = await awaitDetachedWatcherStops(detachedWatcherStops)"))
             let managedOnlyCleanup = try XCTUnwrap(unload.range(of: "managedOnlyFileIDs.remove(fileID)"))
             let rootSnapshotCleanup = try XCTUnwrap(unload.range(of: "removeCodemapSnapshots(forRootID: rootID)"))
-            XCTAssertLessThan(rootDetach.lowerBound, stopWatching.lowerBound)
-            XCTAssertLessThan(stopWatching.lowerBound, managedOnlyCleanup.lowerBound)
+            XCTAssertLessThan(rootDetach.lowerBound, watcherStopStart.lowerBound)
+            XCTAssertLessThan(watcherStopStart.lowerBound, watcherStopWait.lowerBound)
+            XCTAssertLessThan(watcherStopWait.lowerBound, managedOnlyCleanup.lowerBound)
             XCTAssertLessThan(managedOnlyCleanup.lowerBound, rootSnapshotCleanup.lowerBound)
-            XCTAssertFalse(String(unload[rootDetach.lowerBound ..< stopWatching.lowerBound]).contains("invalidateAllCodemapFileAPIsCache"))
+            XCTAssertFalse(String(unload[rootDetach.lowerBound ..< watcherStopStart.lowerBound]).contains("invalidateAllCodemapFileAPIsCache"))
             XCTAssertFalse(String(unload[managedOnlyCleanup.lowerBound ..< rootSnapshotCleanup.lowerBound]).contains("await"))
 
             let provider = try source("Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPFileToolProvider.swift")
@@ -2307,6 +2499,31 @@
             XCTAssertTrue(sibling.contains("\"grant_count\": grantCount"))
         }
 
+        func testReadSearchBarrierDiagnosticsExposeBoundedPendingSuccessorState() throws {
+            let store = try source("Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift")
+            for hook in [
+                "ScopedIngressBarrierRootFlightState",
+                "ScopedIngressBarrierPendingFlight",
+                "scopedIngressBarrierFlightStatesByRootID",
+                "scopedIngressBarrierCoalescedSuccessorCountsByRootID",
+                "flightState.pending = ScopedIngressBarrierPendingFlight(",
+                "pending.target = pending.target.merging(target)",
+                "flightState.active?.task?.cancel()",
+                "flightState.pending?.join.complete(with: nil)"
+            ] {
+                XCTAssertTrue(store.contains(hook), "Missing bounded barrier-state hook: \(hook)")
+            }
+            XCTAssertFalse(store.contains("scopedIngressBarrierFlightsByRootID"))
+
+            let diagnostics = try source(
+                "Sources/RepoPrompt/Features/Diagnostics/MCP/MCPConnectionManager+DebugDiagnosticsReadSearchLatency.swift"
+            )
+            XCTAssertTrue(diagnostics.contains("\"coalesced_successor_count\": snapshot.coalescedSuccessorCount"))
+            XCTAssertTrue(diagnostics.contains("\"pending\": Self.debugOptionalValue(pending)"))
+            XCTAssertTrue(diagnostics.contains("target_service_publication_sequence"))
+            XCTAssertTrue(diagnostics.contains("\"age_ms\": pending.ageMilliseconds"))
+        }
+
         func testLifecycleSourceOrderCoversDispatchRunToolAndIngressBoundaries() throws {
             let manager = try source("Sources/RepoPrompt/Infrastructure/MCP/MCPConnectionManager.swift")
             assertSourceOrder(
@@ -2315,7 +2532,7 @@
                     "EditFlowPerf.Lifecycle.MCPToolCall.received",
                     "EditFlowPerf.Lifecycle.MCPToolCall.routingSnapshotCompleted",
                     "EditFlowPerf.Lifecycle.MCPToolCall.limiterWaitBegan",
-                    "return await limiter.withPermit(",
+                    "return await self.withConnectionCallPermit(",
                     "EditFlowPerf.Lifecycle.MCPToolCall.limiterAcquired",
                     "Self.withConnectionID(connectionID, lifecycleCorrelation: lifecycleCorrelation)"
                 ]
@@ -2434,6 +2651,31 @@
             XCTAssertTrue(fsevents.contains("source: .watcherBarrierNoop"))
             XCTAssertTrue(fsevents.contains("watcherAcceptedWatermark: publishableWatcherWatermark"))
             XCTAssertEqual(operations.components(separatedBy: "source: .syntheticMutation").count - 1, 5)
+        }
+
+        @MainActor
+        private func cleanupRuntimePendingBarrierTest(
+            store: WorkspaceFileContextStore,
+            rootID: UUID,
+            watcherStartGate: MCPDiagnosticsGate,
+            flushGate: MCPDiagnosticsGate,
+            watcherStartTask: Task<Void, Error>,
+            activeBarrier: Task<[WorkspaceIngressBarrierSample], Never>,
+            pendingBarrier: Task<[WorkspaceIngressBarrierSample], Never>?,
+            coalescedBarrier: Task<[WorkspaceIngressBarrierSample], Never>?
+        ) async {
+            await flushGate.release()
+            activeBarrier.cancel()
+            pendingBarrier?.cancel()
+            coalescedBarrier?.cancel()
+            _ = await activeBarrier.value
+            _ = await pendingBarrier?.value
+            _ = await coalescedBarrier?.value
+            await store.setScopedIngressBarrierWillFlushHandler(nil)
+            await store.setWatcherServiceStateWillReconcileHandler(nil)
+            await watcherStartGate.release()
+            _ = try? await watcherStartTask.value
+            await store.stopWatchingRoot(id: rootID)
         }
 
         private actor MCPDiagnosticsGate {

--- a/Tests/RepoPromptTests/MCP/TabContextRoutingTests.swift
+++ b/Tests/RepoPromptTests/MCP/TabContextRoutingTests.swift
@@ -342,18 +342,23 @@ final class TabContextRoutingTests: XCTestCase {
             repoPaths: [logicalRoot.path],
             ephemeral: true
         )
-        await window.workspaceManager.switchWorkspace(to: workspace, saveState: false, reason: "persistResolvedTabContextSnapshotTest")
+        let initialSwitchResult = await window.workspaceManager.switchWorkspace(
+            to: workspace,
+            saveState: false,
+            reason: "persistResolvedTabContextSnapshotTest"
+        )
+        XCTAssertEqual(initialSwitchResult, .switched)
         let workspaceIndex = try XCTUnwrap(window.workspaceManager.workspaces.firstIndex { $0.id == workspace.id })
         window.workspaceManager.workspaces[workspaceIndex].composeTabs = [
             ComposeTabState(id: activeTabID, name: "Active", selection: activeSelection),
             ComposeTabState(id: inactiveTabID, name: "Agent", selection: inactiveInitialSelection)
         ]
         window.workspaceManager.workspaces[workspaceIndex].activeComposeTabID = activeTabID
-        await window.workspaceManager.switchWorkspace(
-            to: window.workspaceManager.workspaces[workspaceIndex],
-            saveState: false,
+        let tabReloadResult = await window.workspaceManager.reactivateWorkspaceAfterReplacement(
+            window.workspaceManager.workspaces[workspaceIndex],
             reason: "persistResolvedTabContextSnapshotTestTabs"
         )
+        XCTAssertEqual(tabReloadResult, .switched)
         let activeWorkspace = try XCTUnwrap(window.workspaceManager.activeWorkspace)
         window.promptManager.loadComposeTabsFromWorkspace(activeWorkspace, syncPromptText: true)
         _ = try await window.workspaceFileContextStore.loadRoot(path: logicalRoot.path)

--- a/Tests/RepoPromptTests/MCP/WorkspaceApprovalCancellationTests.swift
+++ b/Tests/RepoPromptTests/MCP/WorkspaceApprovalCancellationTests.swift
@@ -1,0 +1,118 @@
+import AppKit
+@testable import RepoPrompt
+import XCTest
+
+/// Regression coverage for cancellation-aware workspace approval waits: a cancelled
+/// caller (for example a bounded tool-execution watchdog) must settle as `.denied`
+/// instead of parking forever on the approval continuation while the operation's
+/// side effects remain pending behind the dialog.
+@MainActor
+final class WorkspaceApprovalCancellationTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        _ = NSApplication.shared
+        WorkspaceApprovalManager.shared.cancelAllPending()
+        WorkspaceApprovalManager.shared.setAutoApproveAll(false)
+        WorkspaceApprovalManager.shared.setAutoApproveOperation(.createWorkspace, enabled: false)
+    }
+
+    override func tearDown() {
+        WorkspaceApprovalManager.shared.cancelAllPending()
+        super.tearDown()
+    }
+
+    func testCancellingAwaitedApprovalResolvesDeniedAndClearsOverlay() async throws {
+        let manager = WorkspaceApprovalManager.shared
+        let request = makeRequest(label: "active-cancel")
+
+        let approvalTask = Task { @MainActor in
+            await manager.requestApproval(for: request)
+        }
+        try await waitUntil { manager.pendingRequest?.id == request.id }
+        XCTAssertTrue(manager.isApprovalOverlayVisible)
+
+        approvalTask.cancel()
+        let result = await approvalTask.value
+
+        guard case .denied = result else {
+            return XCTFail("Expected cancelled approval wait to resolve as denied, got \(result)")
+        }
+        XCTAssertNil(manager.pendingRequest)
+        XCTAssertFalse(manager.isApprovalOverlayVisible)
+    }
+
+    func testCancellingQueuedApprovalLeavesActiveRequestPending() async throws {
+        let manager = WorkspaceApprovalManager.shared
+        let activeRequest = makeRequest(label: "active")
+        let queuedRequest = makeRequest(label: "queued")
+
+        let activeTask = Task { @MainActor in
+            await manager.requestApproval(for: activeRequest)
+        }
+        try await waitUntil { manager.pendingRequest?.id == activeRequest.id }
+
+        let queuedTask = Task { @MainActor in
+            await manager.requestApproval(for: queuedRequest)
+        }
+        try await waitUntil { manager.pendingQueueCountForTesting == 1 }
+
+        queuedTask.cancel()
+        let queuedResult = await queuedTask.value
+
+        guard case .denied = queuedResult else {
+            return XCTFail("Expected cancelled queued approval to resolve as denied, got \(queuedResult)")
+        }
+        XCTAssertEqual(manager.pendingRequest?.id, activeRequest.id)
+        XCTAssertEqual(manager.pendingQueueCountForTesting, 0)
+        XCTAssertTrue(manager.isApprovalOverlayVisible)
+
+        manager.resolveApproval(allow: false)
+        let activeResult = await activeTask.value
+        guard case .denied = activeResult else {
+            return XCTFail("Expected explicit denial for the active request, got \(activeResult)")
+        }
+    }
+
+    func testApprovalRequestedFromCancelledTaskResolvesDeniedWithoutPresentingOverlay() async {
+        let manager = WorkspaceApprovalManager.shared
+        let request = makeRequest(label: "pre-cancelled")
+
+        let approvalTask = Task { @MainActor () -> WorkspaceApprovalResult in
+            while !Task.isCancelled {
+                await Task.yield()
+            }
+            return await manager.requestApproval(for: request)
+        }
+        approvalTask.cancel()
+        let result = await approvalTask.value
+
+        guard case .denied = result else {
+            return XCTFail("Expected pre-cancelled approval request to resolve as denied, got \(result)")
+        }
+        XCTAssertNil(manager.pendingRequest)
+        XCTAssertFalse(manager.isApprovalOverlayVisible)
+    }
+
+    private func makeRequest(label: String) -> WorkspaceApprovalRequest {
+        WorkspaceApprovalRequest(
+            clientID: "approval-cancellation-tests-\(label)-\(UUID().uuidString)",
+            operation: .createWorkspace,
+            workspaceName: "Approval Cancellation \(label)",
+            windowID: nil
+        )
+    }
+
+    private func waitUntil(
+        timeout: TimeInterval = 3,
+        file: StaticString = #filePath,
+        line: UInt = #line,
+        _ condition: @escaping @MainActor () -> Bool
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if condition() { return }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTFail("Timed out waiting for condition", file: file, line: line)
+    }
+}

--- a/Tests/RepoPromptTests/WorkspaceContext/Search/StoreBackedWorkspaceSearchLaneTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/Search/StoreBackedWorkspaceSearchLaneTests.swift
@@ -3,14 +3,62 @@ import XCTest
 
 #if DEBUG
     final class StoreBackedWorkspaceSearchLaneTests: XCTestCase {
-        func testProductionPolicyIsOneActiveOneQueuedWithBoundedWait() {
+        func testProductionPolicyAdmitsBoundedBurstWithBoundedWait() {
             let configuration = StoreBackedWorkspaceSearchLane.Configuration.production
+            XCTAssertEqual(configuration.maxActiveLeases, 4)
+            XCTAssertEqual(configuration.maxQueuedWaiters, 4)
             XCTAssertEqual(configuration.maxQueueWaitMilliseconds, 1500)
             XCTAssertEqual(configuration.retryAfterMilliseconds, 1000)
         }
 
-        func testOneActiveOneQueuedAndThirdRejectedThenLaneReturnsIdle() async throws {
+        func testProductionBurstAdmitsActiveBatchQueuesOverflowAndRejectsBeyondQueue() async throws {
             let lane = StoreBackedWorkspaceSearchLane()
+            let configuration = StoreBackedWorkspaceSearchLane.Configuration.production
+            let gate = AsyncGate()
+            await lane.setPermitAcquiredHandlerForTesting {
+                await gate.markStartedAndWaitForRelease()
+            }
+
+            var activeBatch: [Task<Int, Error>] = []
+            for value in 1 ... configuration.maxActiveLeases {
+                activeBatch.append(permitTask(lane: lane, value: value))
+            }
+            await assertTrue(gate.waitUntilStartedCount(configuration.maxActiveLeases))
+
+            var queuedBatch: [Task<Int, Error>] = []
+            for value in 1 ... configuration.maxQueuedWaiters {
+                queuedBatch.append(permitTask(lane: lane, value: 100 + value))
+            }
+            await assertTrue(waitForSnapshot(lane) { $0.waiterCount == configuration.maxQueuedWaiters })
+
+            let overflow = permitTask(lane: lane, value: 999)
+            await assertQueueFull(overflow)
+
+            let held = await lane.snapshotForTesting()
+            XCTAssertEqual(held.activePermitCount, configuration.maxActiveLeases)
+            XCTAssertEqual(held.waiterCount, configuration.maxQueuedWaiters)
+            XCTAssertEqual(held.overloadCount, 1)
+            XCTAssertEqual(held.maximumActivePermitCount, configuration.maxActiveLeases)
+            XCTAssertEqual(held.maximumWaiterCount, configuration.maxQueuedWaiters)
+
+            await gate.release()
+            for (index, task) in activeBatch.enumerated() {
+                let value = try await task.value
+                XCTAssertEqual(value, index + 1)
+            }
+            for (index, task) in queuedBatch.enumerated() {
+                let value = try await task.value
+                XCTAssertEqual(value, 101 + index)
+            }
+            let settled = await lane.snapshotForTesting()
+            XCTAssertTrue(settled.isIdle)
+            XCTAssertEqual(settled.grantCount, configuration.maxActiveLeases + configuration.maxQueuedWaiters)
+        }
+
+        func testOneActiveOneQueuedAndThirdRejectedThenLaneReturnsIdle() async throws {
+            let lane = StoreBackedWorkspaceSearchLane(
+                configuration: .init(maxQueueWait: .milliseconds(1500))
+            )
             let gate = AsyncGate()
             await lane.setPermitAcquiredHandlerForTesting {
                 await gate.markStartedAndWaitForRelease()
@@ -41,7 +89,9 @@ import XCTest
         }
 
         func testQueuedCancellationRemovesWaiterWithoutLeakingLane() async throws {
-            let lane = StoreBackedWorkspaceSearchLane()
+            let lane = StoreBackedWorkspaceSearchLane(
+                configuration: .init(maxQueueWait: .milliseconds(1500))
+            )
             let gate = AsyncGate()
             await lane.setPermitAcquiredHandlerForTesting {
                 await gate.markStartedAndWaitForRelease()

--- a/Tests/RepoPromptTests/WorkspaceContext/Search/StoreBackedWorkspaceSearchTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/Search/StoreBackedWorkspaceSearchTests.swift
@@ -193,6 +193,7 @@ final class StoreBackedWorkspaceSearchTests: XCTestCase {
             try write("let gammaNeedle = true\n", to: gammaURL)
             let store = WorkspaceFileContextStore()
             _ = try await store.loadRoot(path: root.path)
+            await configureSingleLeaseSearchLane(store)
             let gate = AsyncGate()
             let freshnessCaptureCount = AsyncCounter()
             await store.setAppliedIngressDidCaptureWatermarksHandler { _ in
@@ -266,11 +267,70 @@ final class StoreBackedWorkspaceSearchTests: XCTestCase {
             await store.setAppliedIngressDidCaptureWatermarksHandler(nil)
         }
 
+        func testConcurrentBroadSearchBurstSharesOneIngressFreshnessFlight() async throws {
+            let configuration = StoreBackedWorkspaceSearchLane.Configuration.production
+            let burstSize = configuration.maxActiveLeases
+            let root = try makeTemporaryRoot(name: "BroadLaneBurstFreshness")
+            for index in 0 ..< burstSize {
+                try write("let burstNeedle\(index) = true\n", to: root.appendingPathComponent("Burst\(index).swift"))
+            }
+            let store = WorkspaceFileContextStore()
+            let record = try await store.loadRoot(path: root.path)
+            try await store.startWatchingRoot(id: record.id)
+            let sinkGate = AsyncGate()
+            let freshnessCaptureCount = AsyncCounter()
+            await store.setWatcherSinkWillApplyHandler { observedRootID in
+                guard observedRootID == record.id else { return }
+                await sinkGate.markStartedAndWaitForRelease()
+            }
+            await store.setAppliedIngressDidCaptureWatermarksHandler { _ in
+                _ = await freshnessCaptureCount.incrementAndValue()
+            }
+            addTeardownBlock {
+                await sinkGate.release()
+                await store.setWatcherSinkWillApplyHandler(nil)
+                await store.setAppliedIngressDidCaptureWatermarksHandler(nil)
+                await store.stopWatchingRoot(id: record.id)
+            }
+
+            try write("let burstHoldNeedle = true\n", to: root.appendingPathComponent("Hold.swift"))
+            try await store.publishSyntheticFileSystemDeltasForTesting(
+                rootID: record.id,
+                deltas: [.fileAdded("Hold.swift")]
+            )
+            await sinkGate.waitUntilStarted()
+            let statsBeforeBurst = await store.scopedIngressBarrierStatsForTesting(rootID: record.id)
+
+            // The production lane admits the entire burst concurrently, so every member
+            // captures the same watermark cut and shares the single blocked barrier flight.
+            let burst = (0 ..< burstSize).map { index in
+                Task { try await self.searchContent(pattern: "burstNeedle\(index)", store: store) }
+            }
+            await assertAsyncTrue(freshnessCaptureCount.waitUntilValue(atLeast: burstSize))
+            let heldStats = await store.scopedIngressBarrierStatsForTesting(rootID: record.id)
+            XCTAssertEqual(heldStats.launchCount - statsBeforeBurst.launchCount, 1)
+            XCTAssertEqual(heldStats.joinCount - statsBeforeBurst.joinCount, burstSize - 1)
+            let heldLane = await store.searchLaneSnapshotForTesting()
+            XCTAssertEqual(heldLane.activePermitCount, burstSize)
+            XCTAssertEqual(heldLane.waiterCount, 0)
+            XCTAssertEqual(heldLane.overloadCount, 0)
+
+            await sinkGate.release()
+            for (index, task) in burst.enumerated() {
+                let result = try await task.value
+                XCTAssertEqual(result.matches?.map(\.filePath), [root.appendingPathComponent("Burst\(index).swift").path])
+            }
+            let settledLane = await store.searchLaneSnapshotForTesting()
+            XCTAssertTrue(settledLane.isIdle)
+            XCTAssertEqual(settledLane.maximumActivePermitCount, burstSize)
+        }
+
         func testQueuedBroadContentSearchCancellationRemovesWaiterWithoutEnteringFreshness() async throws {
             let root = try makeTemporaryRoot(name: "BroadLaneCancellation")
             try write("let holdNeedle = true\nlet laterNeedle = true\n", to: root.appendingPathComponent("A.swift"))
             let store = WorkspaceFileContextStore()
             _ = try await store.loadRoot(path: root.path)
+            await configureSingleLeaseSearchLane(store)
             let gate = AsyncGate()
             let freshnessCaptureCount = AsyncCounter()
             await store.setAppliedIngressDidCaptureWatermarksHandler { _ in
@@ -604,6 +664,7 @@ final class StoreBackedWorkspaceSearchTests: XCTestCase {
             let store = WorkspaceFileContextStore()
             _ = try await store.loadRoot(path: root.path)
             let baseline = try await searchContent(pattern: "needle", countOnly: true, store: store)
+            await configureSingleLeaseSearchLane(store)
 
             let gate = AsyncGate()
             await store.setSearchLanePermitAcquiredHandlerForTesting {
@@ -894,6 +955,7 @@ final class StoreBackedWorkspaceSearchTests: XCTestCase {
             let store = WorkspaceFileContextStore()
             _ = try await store.loadRoot(path: logicalRoot.path)
             let physicalRecord = try await store.loadRoot(path: physicalRoot.path, kind: .sessionWorktree)
+            await configureSingleLeaseSearchLane(store)
             let gate = AsyncGate()
             await store.setSearchLanePermitAcquiredHandlerForTesting {
                 await gate.markStartedAndWaitForRelease()
@@ -1028,6 +1090,25 @@ final class StoreBackedWorkspaceSearchTests: XCTestCase {
             line: UInt = #line
         ) {
             XCTAssertTrue(value, message(), file: file, line: line)
+        }
+
+        /// Pins the store's broad-search lane to one active lease and one waiter so the
+        /// queue/overflow choreography stays deterministic under the burst-capacity production policy.
+        private func configureSingleLeaseSearchLane(
+            _ store: WorkspaceFileContextStore,
+            file: StaticString = #filePath,
+            line: UInt = #line
+        ) async {
+            let configuration = StoreBackedWorkspaceSearchLane.Configuration(
+                maxQueueWait: .milliseconds(1500)
+            )
+            guard case .applied = await store.configureSearchLaneForTesting(configuration) else {
+                return XCTFail(
+                    "Expected the idle store lane to accept the single-lease test configuration",
+                    file: file,
+                    line: line
+                )
+            }
         }
 
         private func waitForAdmissionWaiterCount(

--- a/Tests/RepoPromptTests/WorkspaceContext/Search/StoreBackedWorkspaceSearchTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/Search/StoreBackedWorkspaceSearchTests.swift
@@ -194,21 +194,61 @@ final class StoreBackedWorkspaceSearchTests: XCTestCase {
             let store = WorkspaceFileContextStore()
             _ = try await store.loadRoot(path: root.path)
             let gate = AsyncGate()
+            let freshnessCaptureCount = AsyncCounter()
+            await store.setAppliedIngressDidCaptureWatermarksHandler { _ in
+                _ = await freshnessCaptureCount.incrementAndValue()
+            }
             await store.setSearchLanePermitAcquiredHandlerForTesting {
                 await gate.markStartedAndWaitForRelease()
+            }
+            addTeardownBlock {
+                await gate.release()
+                await store.setAppliedIngressDidCaptureWatermarksHandler(nil)
+                await store.setSearchLanePermitAcquiredHandlerForTesting(nil)
             }
 
             let first = Task { try await self.searchContent(pattern: "alphaNeedle", store: store) }
             await assertAsyncTrue(gate.waitUntilStartedCount(1))
             let second = Task { try await self.searchContent(pattern: "betaNeedle", store: store) }
             await assertAsyncTrue(waitForAdmissionWaiterCount(1, store: store))
-            let third = Task { try await self.searchContent(pattern: "gammaNeedle", store: store) }
-            do {
-                _ = try await third.value
-                XCTFail("Expected third broad search to be rejected")
-            } catch let error as StoreBackedWorkspaceSearchAdmissionError {
-                XCTAssertEqual(error, .queueFull(scope: .perStore, retryAfterMilliseconds: 1000))
+            let thirdCompleted = AsyncSignal()
+            let third = Task { () -> Result<SearchResults, Error> in
+                do {
+                    let result = try await self.searchContent(pattern: "gammaNeedle", store: store)
+                    await thirdCompleted.mark()
+                    return .success(result)
+                } catch {
+                    await thirdCompleted.mark()
+                    return .failure(error)
+                }
             }
+            let thirdDidComplete = await thirdCompleted.waitUntilMarked()
+            if !thirdDidComplete {
+                third.cancel()
+                second.cancel()
+                first.cancel()
+                await gate.release()
+                _ = await third.value
+                _ = try? await second.value
+                _ = try? await first.value
+                XCTFail("Timed out waiting for third broad search overflow rejection")
+                return
+            }
+            switch await third.value {
+            case .success:
+                XCTFail("Expected third broad search to be rejected")
+            case let .failure(error):
+                guard let admissionError = error as? StoreBackedWorkspaceSearchAdmissionError else {
+                    return XCTFail("Expected broad-search admission error, got \(error)")
+                }
+                XCTAssertEqual(admissionError, .queueFull(scope: .perStore, retryAfterMilliseconds: 1000))
+            }
+            let heldFreshnessCaptureCount = await freshnessCaptureCount.currentValue()
+            XCTAssertEqual(
+                heldFreshnessCaptureCount,
+                0,
+                "No broad search may enter freshness while the active permit hook is held; the waiter and rejected overflow must remain bounded at admission"
+            )
 
             let heldSnapshot = await store.searchLaneSnapshotForTesting()
             XCTAssertEqual(heldSnapshot.activePermitCount, 1)
@@ -223,30 +263,71 @@ final class StoreBackedWorkspaceSearchTests: XCTestCase {
             XCTAssertTrue(finalSnapshot.isIdle)
             XCTAssertEqual(finalSnapshot.maximumActivePermitCount, 1)
             XCTAssertEqual(finalSnapshot.maximumWaiterCount, 1)
+            await store.setAppliedIngressDidCaptureWatermarksHandler(nil)
         }
 
-        func testQueuedBroadContentSearchCancellationRemovesWaiterAndDoesNotLeakLane() async throws {
+        func testQueuedBroadContentSearchCancellationRemovesWaiterWithoutEnteringFreshness() async throws {
             let root = try makeTemporaryRoot(name: "BroadLaneCancellation")
             try write("let holdNeedle = true\nlet laterNeedle = true\n", to: root.appendingPathComponent("A.swift"))
             let store = WorkspaceFileContextStore()
             _ = try await store.loadRoot(path: root.path)
             let gate = AsyncGate()
+            let freshnessCaptureCount = AsyncCounter()
+            await store.setAppliedIngressDidCaptureWatermarksHandler { _ in
+                _ = await freshnessCaptureCount.incrementAndValue()
+            }
             await store.setSearchLanePermitAcquiredHandlerForTesting {
                 await gate.markStartedAndWaitForRelease()
+            }
+            addTeardownBlock {
+                await gate.release()
+                await store.setAppliedIngressDidCaptureWatermarksHandler(nil)
+                await store.setSearchLanePermitAcquiredHandlerForTesting(nil)
             }
 
             let first = Task { try await self.searchContent(pattern: "holdNeedle", store: store) }
             await assertAsyncTrue(gate.waitUntilStartedCount(1))
-            let cancelled = Task { try await self.searchContent(pattern: "cancelledNeedle", store: store) }
+            let cancellationCompleted = AsyncSignal()
+            let cancelled = Task { () -> Result<SearchResults, Error> in
+                do {
+                    let result = try await self.searchContent(pattern: "cancelledNeedle", store: store)
+                    await cancellationCompleted.mark()
+                    return .success(result)
+                } catch {
+                    await cancellationCompleted.mark()
+                    return .failure(error)
+                }
+            }
             await assertAsyncTrue(waitForAdmissionWaiterCount(1, store: store))
+            let queuedFreshnessCaptureCount = await freshnessCaptureCount.currentValue()
+            XCTAssertEqual(
+                queuedFreshnessCaptureCount,
+                0,
+                "A queued broad search must not capture an applied-ingress target before admission"
+            )
             cancelled.cancel()
-            do {
-                _ = try await cancelled.value
+            let cancellationDidComplete = await cancellationCompleted.waitUntilMarked()
+            if !cancellationDidComplete {
+                first.cancel()
+                await gate.release()
+                _ = await cancelled.value
+                _ = try? await first.value
+                XCTFail("Timed out waiting for queued broad search cancellation")
+                return
+            }
+            switch await cancelled.value {
+            case .success:
                 XCTFail("Expected queued broad search cancellation")
-            } catch is CancellationError {
-                // Expected.
+            case let .failure(error):
+                XCTAssertTrue(error is CancellationError)
             }
             await assertAsyncTrue(waitForAdmissionWaiterCount(0, store: store))
+            let cancelledFreshnessCaptureCount = await freshnessCaptureCount.currentValue()
+            XCTAssertEqual(
+                cancelledFreshnessCaptureCount,
+                0,
+                "Cancelling the queued search must not start freshness work"
+            )
             let later = Task { try await self.searchContent(pattern: "laterNeedle", store: store) }
             await assertAsyncTrue(waitForAdmissionWaiterCount(1, store: store))
 
@@ -257,6 +338,9 @@ final class StoreBackedWorkspaceSearchTests: XCTestCase {
             let finalSnapshot = await store.searchLaneSnapshotForTesting()
             XCTAssertTrue(finalSnapshot.isIdle)
             XCTAssertEqual(finalSnapshot.queuedCancellationCount, 1)
+            let finalFreshnessCaptureCount = await freshnessCaptureCount.currentValue()
+            XCTAssertEqual(finalFreshnessCaptureCount, 2)
+            await store.setAppliedIngressDidCaptureWatermarksHandler(nil)
         }
 
         func testPathScopedContentAndDifferentStoreSearchesBypassHeldBroadLane() async throws {
@@ -654,7 +738,7 @@ final class StoreBackedWorkspaceSearchTests: XCTestCase {
             XCTAssertEqual(cache.latestRevision, 1)
         }
 
-        func testStoreBackedSearchAwaitsScopedFreshnessBeforeBroadPermitAndCatalogSnapshot() async throws {
+        func testStoreBackedSearchAcquiresBroadPermitBeforeAwaitingScopedFreshnessAndCatalogSnapshot() async throws {
             let root = try makeTemporaryRoot(name: "ScopedSearchFreshness")
             let addedURL = root.appendingPathComponent("Added.swift")
             let store = WorkspaceFileContextStore()
@@ -669,6 +753,12 @@ final class StoreBackedWorkspaceSearchTests: XCTestCase {
             await store.setSearchLanePermitAcquiredHandlerForTesting {
                 await permitSignal.mark()
             }
+            addTeardownBlock {
+                await sinkGate.release()
+                await store.setWatcherSinkWillApplyHandler(nil)
+                await store.setSearchLanePermitAcquiredHandlerForTesting(nil)
+                await store.stopWatchingRoot(id: record.id)
+            }
 
             try write("freshNeedle", to: addedURL)
             try await store.publishSyntheticFileSystemDeltasForTesting(rootID: record.id, deltas: [.fileAdded("Added.swift")])
@@ -676,17 +766,82 @@ final class StoreBackedWorkspaceSearchTests: XCTestCase {
             let searchTask = Task {
                 try await self.searchContent(pattern: "freshNeedle", store: store)
             }
-            let permitMarkedEarly = await permitSignal.waitUntilMarked(timeoutNanoseconds: 50_000_000)
-            XCTAssertFalse(permitMarkedEarly)
-            let preAdmissionLaneSnapshot = await store.searchLaneSnapshotForTesting()
-            XCTAssertTrue(preAdmissionLaneSnapshot.isIdle)
+            await assertAsyncTrue(permitSignal.waitUntilMarked())
+            let freshnessLaneSnapshot = await store.searchLaneSnapshotForTesting()
+            XCTAssertEqual(freshnessLaneSnapshot.activePermitCount, 1)
+            XCTAssertEqual(freshnessLaneSnapshot.waiterCount, 0)
 
             await sinkGate.release()
-            await assertAsyncTrue(permitSignal.waitUntilMarked())
             let result = try await searchTask.value
             XCTAssertEqual(result.matches?.map(\.filePath), [addedURL.path])
             let laneSnapshot = await store.searchLaneSnapshotForTesting()
             XCTAssertTrue(laneSnapshot.isIdle)
+            await store.setWatcherSinkWillApplyHandler(nil)
+            await store.setSearchLanePermitAcquiredHandlerForTesting(nil)
+            await store.stopWatchingRoot(id: record.id)
+        }
+
+        func testCancelledBroadSearchBlockedInFreshnessReleasesAdmissionPermit() async throws {
+            let root = try makeTemporaryRoot(name: "CancelledBroadSearchFreshness")
+            let store = WorkspaceFileContextStore()
+            let record = try await store.loadRoot(path: root.path)
+            try await store.startWatchingRoot(id: record.id)
+            let sinkGate = AsyncGate()
+            let permitSignal = AsyncSignal()
+            let completionSignal = AsyncSignal()
+            await store.setWatcherSinkWillApplyHandler { observedRootID in
+                guard observedRootID == record.id else { return }
+                await sinkGate.markStartedAndWaitForRelease()
+            }
+            await store.setSearchLanePermitAcquiredHandlerForTesting {
+                await permitSignal.mark()
+            }
+            addTeardownBlock {
+                await sinkGate.release()
+                await store.setWatcherSinkWillApplyHandler(nil)
+                await store.setSearchLanePermitAcquiredHandlerForTesting(nil)
+                await store.stopWatchingRoot(id: record.id)
+            }
+
+            try write("cancelNeedle", to: root.appendingPathComponent("Added.swift"))
+            try await store.publishSyntheticFileSystemDeltasForTesting(
+                rootID: record.id,
+                deltas: [.fileAdded("Added.swift")]
+            )
+            await sinkGate.waitUntilStarted()
+            let searchTask = Task { () -> Result<SearchResults, Error> in
+                do {
+                    let result = try await self.searchContent(pattern: "cancelNeedle", store: store)
+                    await completionSignal.mark()
+                    return .success(result)
+                } catch {
+                    await completionSignal.mark()
+                    return .failure(error)
+                }
+            }
+            await assertAsyncTrue(permitSignal.waitUntilMarked())
+            let heldSnapshot = await store.searchLaneSnapshotForTesting()
+            XCTAssertEqual(heldSnapshot.activePermitCount, 1)
+
+            searchTask.cancel()
+            let completedWhileIngressBlocked = await completionSignal.waitUntilMarked()
+            XCTAssertTrue(
+                completedWhileIngressBlocked,
+                "Cancellation after admission must detach from freshness without waiting for ingress application"
+            )
+            let releasedBeforeIngress = await waitForSearchLaneIdle(store: store)
+            XCTAssertTrue(
+                releasedBeforeIngress,
+                "Cancellation during freshness must release the broad-search permit before ingress unblocks"
+            )
+
+            await sinkGate.release()
+            switch await searchTask.value {
+            case .success:
+                XCTFail("Expected cancelled broad search to fail")
+            case let .failure(error):
+                XCTAssertTrue(error is CancellationError)
+            }
             await store.setWatcherSinkWillApplyHandler(nil)
             await store.setSearchLanePermitAcquiredHandlerForTesting(nil)
             await store.stopWatchingRoot(id: record.id)
@@ -780,6 +935,24 @@ final class StoreBackedWorkspaceSearchTests: XCTestCase {
         }
     #endif
 
+    func testBroadSearchOrchestrationChecksScopeAndReadinessBeforeAndAfterAdmission() throws {
+        let source = try String(
+            contentsOf: RepoRoot.url().appendingPathComponent("Sources/RepoPrompt/Features/Search/StoreBackedWorkspaceSearch.swift"),
+            encoding: .utf8
+        )
+        try assertOrdered([
+            "try await ensureRootScopeAvailable(rootScope, store: store)",
+            "try await ensureSearchReady(store: store, workspaceManager: workspaceManager)",
+            "let effectiveMode = mode == .auto ? FileSearchActor.inferredAutoMode(pattern) : mode",
+            "return try await store.withStoreBackedSearchAccess(",
+            "try await ensureRootScopeAvailable(rootScope, store: store)",
+            "try await ensureSearchReady(store: store, workspaceManager: workspaceManager)",
+            "_ = await store.awaitAppliedIngress(rootScope: rootScope)",
+            "try Task.checkCancellation()",
+            "try await performSearch("
+        ], in: source)
+    }
+
     func testSearchScopeParserKeepsRequiredResolutionOrder() throws {
         let source = try String(
             contentsOf: RepoRoot.url().appendingPathComponent("Sources/RepoPrompt/Features/Search/StoreBackedWorkspaceSearch.swift"),
@@ -869,6 +1042,19 @@ final class StoreBackedWorkspaceSearchTests: XCTestCase {
                 waited += interval
             }
             return await store.searchLaneSnapshotForTesting().waiterCount == expectedCount
+        }
+
+        private func waitForSearchLaneIdle(
+            store: WorkspaceFileContextStore,
+            timeoutNanoseconds: UInt64 = 1_000_000_000
+        ) async -> Bool {
+            let interval: UInt64 = 10_000_000
+            var waited: UInt64 = 0
+            while await !store.searchLaneSnapshotForTesting().isIdle, waited < timeoutNanoseconds {
+                try? await Task.sleep(nanoseconds: interval)
+                waited += interval
+            }
+            return await store.searchLaneSnapshotForTesting().isIdle
         }
 
         private func waitForCacheIdle(

--- a/Tests/RepoPromptTests/WorkspaceContext/WorkspaceFileContextStoreTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/WorkspaceFileContextStoreTests.swift
@@ -294,7 +294,18 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
         func testUnloadRootDrainsTrackedPublisherIngressWithoutPostDetachMutation() async throws {
             let root = try makeTemporaryRoot(name: "UnloadPublisherIngress")
             let lateFileURL = root.appendingPathComponent("Late.swift")
-            let store = WorkspaceFileContextStore()
+            let sleeper = ManualWorkspaceRootUnloadSleeper()
+            let store = WorkspaceFileContextStore(
+                unloadTerminationPolicy: WorkspaceRootUnloadTerminationPolicy(
+                    publisherIngressGraceNanoseconds: 11,
+                    watcherStopGraceNanoseconds: 22,
+                    sleep: { nanoseconds in await sleeper.sleep(nanoseconds: nanoseconds) }
+                )
+            )
+            let diagnosticsRecorder = WorkspaceRootUnloadDiagnosticsRecorder()
+            await store.setRootUnloadTerminationDidCompleteHandler { diagnostics in
+                await diagnosticsRecorder.record(diagnostics)
+            }
             let record = try await store.loadRoot(path: root.path)
             try await store.startWatchingRoot(id: record.id)
 
@@ -320,6 +331,7 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
                 await unloadCompletedSignal.mark()
             }
             await unloadWaitSignal.waitUntilMarked()
+            await sleeper.waitUntilSleeping(nanoseconds: 11)
             let unloadCompletedBeforeRelease = await unloadCompletedSignal.isMarked()
             let rootsDuringUnload = await store.roots()
             let pendingIngressCount = await store.publisherIngressCountForTesting(rootID: rootID)
@@ -331,11 +343,284 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
             await unloadTask.value
             let lateFile = await store.file(rootID: rootID, relativePath: "Late.swift")
             let remainingIngressCount = await store.publisherIngressCountForTesting(rootID: rootID)
+            let recordedDiagnostics = await diagnosticsRecorder.snapshot()
+            let diagnostics = try XCTUnwrap(recordedDiagnostics)
+            let publisherReport = try XCTUnwrap(diagnostics.publisherIngressReports.first)
             XCTAssertNil(lateFile)
             XCTAssertEqual(remainingIngressCount, 0)
+            XCTAssertEqual(publisherReport.rootID, rootID)
+            XCTAssertEqual(publisherReport.outcome, .graceful)
 
             await store.setWatcherSinkWillApplyHandler(nil)
             await store.setPublisherIngressWillWaitHandler(nil)
+            await store.setRootUnloadTerminationDidCompleteHandler(nil)
+        }
+
+        func testUnloadRootForceDiscardsWedgedPublisherIngressAndReleasesWaiters() async throws {
+            let root = try makeTemporaryRoot(name: "UnloadForcedPublisherIngress")
+            let firstURL = root.appendingPathComponent("First.swift")
+            let secondURL = root.appendingPathComponent("Second.swift")
+            let sleeper = ManualWorkspaceRootUnloadSleeper()
+            let store = WorkspaceFileContextStore(
+                unloadTerminationPolicy: WorkspaceRootUnloadTerminationPolicy(
+                    publisherIngressGraceNanoseconds: 11,
+                    watcherStopGraceNanoseconds: 22,
+                    sleep: { nanoseconds in await sleeper.sleep(nanoseconds: nanoseconds) }
+                )
+            )
+            let record = try await store.loadRoot(path: root.path)
+            try await store.startWatchingRoot(id: record.id)
+
+            let sinkGate = AsyncGate()
+            let unloadCompleted = AsyncSignal()
+            let waiterCompleted = AsyncSignal()
+            let diagnosticsRecorder = WorkspaceRootUnloadDiagnosticsRecorder()
+            let rootID = record.id
+            await store.setWatcherSinkWillApplyHandler { observedRootID in
+                guard observedRootID == rootID else { return }
+                await sinkGate.markStartedAndWaitForRelease()
+            }
+            await store.setRootUnloadTerminationDidCompleteHandler { diagnostics in
+                await diagnosticsRecorder.record(diagnostics)
+            }
+
+            try write("first", to: firstURL)
+            try await store.publishSyntheticFileSystemDeltasForTesting(
+                rootID: rootID,
+                deltas: [.fileAdded("First.swift")]
+            )
+            await sinkGate.waitUntilStarted()
+            try write("second", to: secondURL)
+            try await store.publishSyntheticFileSystemDeltasForTesting(
+                rootID: rootID,
+                deltas: [.fileAdded("Second.swift")]
+            )
+            let targetSequence = await store.appliedIngressSnapshotForTesting(rootID: rootID)
+                .acceptedServicePublicationSequence
+            let waiter = Task {
+                await store.waitUntilPublisherIngressAppliedForTesting(
+                    rootID: rootID,
+                    servicePublicationSequence: targetSequence
+                )
+                await waiterCompleted.mark()
+            }
+            let waiterRegistered = await waitForAsyncCondition {
+                await store.publisherIngressDebugSnapshotForTesting(rootID: rootID).waiterCount == 1
+            }
+            XCTAssertTrue(waiterRegistered)
+
+            let unload = Task {
+                await store.unloadRoot(id: rootID)
+                await unloadCompleted.mark()
+            }
+            await sleeper.waitUntilSleeping(nanoseconds: 11)
+            let unloadCompletedBeforeTimeout = await unloadCompleted.isMarked()
+            let waiterCompletedBeforeTimeout = await waiterCompleted.isMarked()
+            XCTAssertFalse(unloadCompletedBeforeTimeout)
+            XCTAssertFalse(waiterCompletedBeforeTimeout)
+
+            await sleeper.release(nanoseconds: 11)
+            await unload.value
+            await waiter.value
+
+            let recordedDiagnostics = await diagnosticsRecorder.snapshot()
+            let diagnostics = try XCTUnwrap(recordedDiagnostics)
+            let publisherReport = try XCTUnwrap(diagnostics.publisherIngressReports.first)
+            let unloadCompletedAfterTimeout = await unloadCompleted.isMarked()
+            let waiterCompletedAfterTimeout = await waiterCompleted.isMarked()
+            XCTAssertTrue(unloadCompletedAfterTimeout)
+            XCTAssertTrue(waiterCompletedAfterTimeout)
+            XCTAssertEqual(publisherReport.rootID, rootID)
+            XCTAssertEqual(publisherReport.outcome, .forced)
+            XCTAssertEqual(publisherReport.queuedPublicationCount, 1)
+            XCTAssertEqual(publisherReport.applyingPublicationCount, 1)
+            XCTAssertEqual(publisherReport.waiterCount, 1)
+            XCTAssertEqual(publisherReport.acceptedServicePublicationSequence, targetSequence)
+            XCTAssertEqual(publisherReport.appliedServicePublicationSequence, 0)
+            let remainingIngressCount = await store.publisherIngressCountForTesting(rootID: rootID)
+            let remainingRoots = await store.roots()
+            let sinkStartCountBeforeRelease = await sinkGate.startCount()
+            XCTAssertEqual(remainingIngressCount, 0)
+            XCTAssertTrue(remainingRoots.isEmpty)
+            XCTAssertEqual(sinkStartCountBeforeRelease, 1)
+
+            await sinkGate.release()
+            let staleDrainFinished = await waitForAsyncCondition {
+                await sinkGate.startCount() == 1
+            }
+            XCTAssertTrue(staleDrainFinished)
+            let sinkStartCountAfterRelease = await sinkGate.startCount()
+            XCTAssertEqual(sinkStartCountAfterRelease, 1)
+            await store.setWatcherSinkWillApplyHandler(nil)
+            await store.setRootUnloadTerminationDidCompleteHandler(nil)
+        }
+
+        func testWatcherBoundedWaitPrefersCompletionThatRacesTimeout() async {
+            let latch = WorkspaceRootUnloadCompletionLatch()
+
+            let outcome = await WorkspaceRootUnloadBoundedWait.waitForCompletion(
+                latch,
+                timeoutNanoseconds: 22,
+                sleep: { _ in latch.complete() }
+            )
+
+            XCTAssertEqual(outcome, .completed)
+
+            let cancellationRaceLatch = WorkspaceRootUnloadCompletionLatch()
+            cancellationRaceLatch.complete()
+            XCTAssertEqual(
+                cancellationRaceLatch.resolvedOutcome(after: .cancelled),
+                .completed
+            )
+        }
+
+        func testUnloadRootBoundsWatcherStopCallerSideWithoutInterruptClaim() async throws {
+            let root = try makeTemporaryRoot(name: "UnloadWatcherStopBound")
+            let sleeper = ManualWorkspaceRootUnloadSleeper()
+            let store = WorkspaceFileContextStore(
+                unloadTerminationPolicy: WorkspaceRootUnloadTerminationPolicy(
+                    publisherIngressGraceNanoseconds: 11,
+                    watcherStopGraceNanoseconds: 22,
+                    sleep: { nanoseconds in await sleeper.sleep(nanoseconds: nanoseconds) }
+                )
+            )
+            let record = try await store.loadRoot(path: root.path)
+            try await store.startWatchingRoot(id: record.id)
+
+            let watcherStopGate = AsyncGate()
+            let unloadCompleted = AsyncSignal()
+            let diagnosticsRecorder = WorkspaceRootUnloadDiagnosticsRecorder()
+            await store.setWatcherStopWillBeginHandler { observedRootID in
+                guard observedRootID == record.id else { return }
+                await watcherStopGate.markStartedAndWaitForRelease()
+            }
+            await store.setRootUnloadTerminationDidCompleteHandler { diagnostics in
+                await diagnosticsRecorder.record(diagnostics)
+            }
+
+            let unload = Task {
+                await store.unloadRoot(id: record.id)
+                await unloadCompleted.mark()
+            }
+            await watcherStopGate.waitUntilStarted()
+            await sleeper.waitUntilSleeping(nanoseconds: 22)
+            let unloadCompletedBeforeTimeout = await unloadCompleted.isMarked()
+            XCTAssertFalse(unloadCompletedBeforeTimeout)
+
+            await sleeper.release(nanoseconds: 22)
+            await unload.value
+
+            let recordedDiagnostics = await diagnosticsRecorder.snapshot()
+            let diagnostics = try XCTUnwrap(recordedDiagnostics)
+            let watcherReport = try XCTUnwrap(diagnostics.watcherStopReports.first)
+            let unloadCompletedAfterTimeout = await unloadCompleted.isMarked()
+            XCTAssertTrue(unloadCompletedAfterTimeout)
+            XCTAssertEqual(watcherReport.rootID, record.id)
+            XCTAssertEqual(watcherReport.outcome, .timedOut)
+            let remainingRoots = await store.roots()
+            XCTAssertTrue(remainingRoots.isEmpty)
+
+            await watcherStopGate.release()
+            await store.setWatcherStopWillBeginHandler(nil)
+            await store.setRootUnloadTerminationDidCompleteHandler(nil)
+        }
+
+        func testUnloadRootReportsCompletedWatcherStopWhenStopFinishesWithinGrace() async throws {
+            let root = try makeTemporaryRoot(name: "UnloadWatcherStopCompleted")
+            let sleeper = ManualWorkspaceRootUnloadSleeper()
+            let store = WorkspaceFileContextStore(
+                unloadTerminationPolicy: WorkspaceRootUnloadTerminationPolicy(
+                    publisherIngressGraceNanoseconds: 11,
+                    watcherStopGraceNanoseconds: 22,
+                    sleep: { nanoseconds in await sleeper.sleep(nanoseconds: nanoseconds) }
+                )
+            )
+            let record = try await store.loadRoot(path: root.path)
+            try await store.startWatchingRoot(id: record.id)
+            let diagnosticsRecorder = WorkspaceRootUnloadDiagnosticsRecorder()
+            await store.setRootUnloadTerminationDidCompleteHandler { diagnostics in
+                await diagnosticsRecorder.record(diagnostics)
+            }
+
+            await store.unloadRoot(id: record.id)
+
+            let recordedDiagnostics = await diagnosticsRecorder.snapshot()
+            let diagnostics = try XCTUnwrap(recordedDiagnostics)
+            let watcherReport = try XCTUnwrap(diagnostics.watcherStopReports.first)
+            XCTAssertEqual(watcherReport.rootID, record.id)
+            XCTAssertEqual(watcherReport.outcome, .completed)
+            let remainingRoots = await store.roots()
+            XCTAssertTrue(remainingRoots.isEmpty)
+            await store.setRootUnloadTerminationDidCompleteHandler(nil)
+        }
+
+        func testCancelledUnloadReportsWatcherStopCancelledWhileDetachedStopIsBlocked() async throws {
+            let root = try makeTemporaryRoot(name: "UnloadWatcherStopCancelled")
+            let sleeper = ManualWorkspaceRootUnloadSleeper()
+            let store = WorkspaceFileContextStore(
+                unloadTerminationPolicy: WorkspaceRootUnloadTerminationPolicy(
+                    publisherIngressGraceNanoseconds: 11,
+                    watcherStopGraceNanoseconds: 22,
+                    sleep: { nanoseconds in await sleeper.sleep(nanoseconds: nanoseconds) }
+                )
+            )
+            let record = try await store.loadRoot(path: root.path)
+            try await store.startWatchingRoot(id: record.id)
+
+            let watcherStopGate = AsyncGate()
+            let diagnosticsRecorder = WorkspaceRootUnloadDiagnosticsRecorder()
+            await store.setWatcherStopWillBeginHandler { observedRootID in
+                guard observedRootID == record.id else { return }
+                await watcherStopGate.markStartedAndWaitForRelease()
+            }
+            await store.setRootUnloadTerminationDidCompleteHandler { diagnostics in
+                await diagnosticsRecorder.record(diagnostics)
+            }
+
+            let unload = Task {
+                await store.unloadRoot(id: record.id)
+            }
+            await watcherStopGate.waitUntilStarted()
+            await sleeper.waitUntilSleeping(nanoseconds: 22)
+            unload.cancel()
+            await unload.value
+
+            let recordedDiagnostics = await diagnosticsRecorder.snapshot()
+            let diagnostics = try XCTUnwrap(recordedDiagnostics)
+            let watcherReport = try XCTUnwrap(diagnostics.watcherStopReports.first)
+            XCTAssertEqual(watcherReport.rootID, record.id)
+            XCTAssertEqual(watcherReport.outcome.rawValue, "cancelled")
+            let remainingRoots = await store.roots()
+            XCTAssertTrue(remainingRoots.isEmpty)
+
+            await watcherStopGate.release()
+            await store.setWatcherStopWillBeginHandler(nil)
+            await store.setRootUnloadTerminationDidCompleteHandler(nil)
+        }
+
+        func testStalePublisherLifetimeCannotMutateCurrentRootState() async throws {
+            let root = try makeTemporaryRoot(name: "StalePublisherLifetime")
+            let lateURL = root.appendingPathComponent("Late.swift")
+            let store = WorkspaceFileContextStore()
+            let record = try await store.loadRoot(path: root.path)
+            let currentLifetimeID = try await store.rootLifetimeIDForTesting(rootID: record.id)
+            try write("late", to: lateURL)
+
+            await store.replayPublisherFileSystemPublicationForTesting(
+                rootID: record.id,
+                expectedLifetimeID: UUID(),
+                deltas: [.fileAdded("Late.swift")]
+            )
+            let staleLifetimeFile = await store.file(rootID: record.id, relativePath: "Late.swift")
+            XCTAssertNil(staleLifetimeFile)
+
+            await store.replayPublisherFileSystemPublicationForTesting(
+                rootID: record.id,
+                expectedLifetimeID: currentLifetimeID,
+                deltas: [.fileAdded("Late.swift")]
+            )
+            let currentLifetimeFile = await store.file(rootID: record.id, relativePath: "Late.swift")
+            XCTAssertNotNil(currentLifetimeFile)
         }
 
         func testRedundantStartWatchingRootKeepsPublisherSinkAttached() async throws {
@@ -679,6 +964,271 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
             }
         #endif
 
+        func testWorkspaceIngressCoordinatorForcedTerminationDropsQueuedWorkReleasesWaitersAndReportsSnapshot() async throws {
+            let clock = LockedWorkspaceDiagnosticsClock(nowNanoseconds: 7_000_000_000)
+            let coordinator = WorkspaceFileSystemIngressCoordinator(debugNowNanoseconds: { clock.now() })
+            let rootID = UUID()
+            let firstApplyGate = AsyncGate()
+            let recorder = OrderedIngressRecorder()
+            let sleeper = ManualWorkspaceRootUnloadSleeper()
+            let subscription = coordinator.openPublisherIngress(rootID: rootID) { publication, _ in
+                await recorder.append(publication.servicePublicationSequence)
+                if publication.servicePublicationSequence == 1 {
+                    await firstApplyGate.markStartedAndWaitForRelease()
+                }
+            }
+
+            XCTAssertTrue(coordinator.accept(
+                subscription,
+                publication: FileSystemDeltaPublication(
+                    servicePublicationSequence: 1,
+                    source: .syntheticMutation,
+                    watcherAcceptedWatermark: nil,
+                    deltas: [.fileAdded("A.swift")]
+                ),
+                lifecycleCorrelation: nil
+            ))
+            await firstApplyGate.waitUntilStarted()
+            XCTAssertTrue(coordinator.accept(
+                subscription,
+                publication: FileSystemDeltaPublication(
+                    servicePublicationSequence: 2,
+                    source: .watcherBarrierNoop,
+                    watcherAcceptedWatermark: .init(rawValue: 17),
+                    deltas: []
+                ),
+                lifecycleCorrelation: nil
+            ))
+            coordinator.closePublisherIngress(rootID: rootID)
+
+            let waiterCompleted = AsyncSignal()
+            let waiter = Task {
+                await coordinator.waitUntilApplied(rootID: rootID, servicePublicationSequence: 2)
+                await waiterCompleted.mark()
+            }
+            let waiterRegistered = await waitForAsyncCondition {
+                coordinator.debugSnapshot(rootID: rootID).waiterCount == 1
+            }
+            XCTAssertTrue(waiterRegistered)
+            clock.advance(milliseconds: 625)
+
+            let termination = Task {
+                await coordinator.terminateClosedPublisherIngress(
+                    rootIDs: [rootID],
+                    gracefulDrainTimeoutNanoseconds: 11,
+                    sleep: { nanoseconds in await sleeper.sleep(nanoseconds: nanoseconds) }
+                )
+            }
+            await sleeper.waitUntilSleeping(nanoseconds: 11)
+            let waiterCompletedBeforeTimeout = await waiterCompleted.isMarked()
+            XCTAssertFalse(waiterCompletedBeforeTimeout)
+            await sleeper.release(nanoseconds: 11)
+
+            let reports = await termination.value
+            await waiter.value
+            let report = try XCTUnwrap(reports.first)
+            XCTAssertEqual(report.rootID, rootID)
+            XCTAssertEqual(report.outcome, .forced)
+            XCTAssertEqual(report.queuedPublicationCount, 1)
+            XCTAssertEqual(report.applyingPublicationCount, 1)
+            XCTAssertEqual(report.waiterCount, 1)
+            XCTAssertEqual(report.acceptedServicePublicationSequence, 2)
+            XCTAssertEqual(report.appliedServicePublicationSequence, 0)
+            XCTAssertEqual(report.acceptedAppliedSequenceGap, 2)
+            XCTAssertEqual(report.oldestOutstandingPublicationAgeMilliseconds, 625)
+            let waiterCompletedAfterTimeout = await waiterCompleted.isMarked()
+            let recordedBeforeRelease = await recorder.snapshot()
+            XCTAssertTrue(waiterCompletedAfterTimeout)
+            XCTAssertEqual(coordinator.pendingPublisherIngressCount(rootIDs: [rootID]), 0)
+            XCTAssertEqual(recordedBeforeRelease, [1])
+
+            await firstApplyGate.release()
+            let recordedAfterRelease = await recorder.snapshot()
+            XCTAssertEqual(recordedAfterRelease, [1])
+        }
+
+        func testWorkspaceIngressCoordinatorTerminationDoesNotForceReopenedIngressDuringGrace() async {
+            let coordinator = WorkspaceFileSystemIngressCoordinator()
+            let rootID = UUID()
+            let oldApplyGate = AsyncGate()
+            let sleeper = ManualWorkspaceRootUnloadSleeper()
+            let oldSubscription = coordinator.openPublisherIngress(rootID: rootID) { _, _ in
+                await oldApplyGate.markStartedAndWaitForRelease()
+            }
+            XCTAssertTrue(coordinator.accept(
+                oldSubscription,
+                publication: FileSystemDeltaPublication(
+                    servicePublicationSequence: 40,
+                    source: .syntheticMutation,
+                    watcherAcceptedWatermark: nil,
+                    deltas: []
+                ),
+                lifecycleCorrelation: nil
+            ))
+            await oldApplyGate.waitUntilStarted()
+            coordinator.closePublisherIngress(rootID: rootID)
+
+            let termination = Task {
+                await coordinator.terminateClosedPublisherIngress(
+                    rootIDs: [rootID],
+                    gracefulDrainTimeoutNanoseconds: 11,
+                    sleep: { nanoseconds in await sleeper.sleep(nanoseconds: nanoseconds) }
+                )
+            }
+            await sleeper.waitUntilSleeping(nanoseconds: 11)
+
+            let reopenedRecorder = OrderedIngressRecorder()
+            let reopenedSubscription = coordinator.openPublisherIngress(rootID: rootID) { publication, _ in
+                await reopenedRecorder.append(publication.servicePublicationSequence)
+            }
+            XCTAssertTrue(coordinator.accept(
+                reopenedSubscription,
+                publication: FileSystemDeltaPublication(
+                    servicePublicationSequence: 41,
+                    source: .syntheticMutation,
+                    watcherAcceptedWatermark: nil,
+                    deltas: []
+                ),
+                lifecycleCorrelation: nil
+            ))
+
+            await sleeper.release(nanoseconds: 11)
+            let reports = await termination.value
+            XCTAssertEqual(reports.first?.outcome, .superseded)
+            XCTAssertTrue(coordinator.isPublisherIngressOpen(reopenedSubscription))
+            XCTAssertTrue(coordinator.accept(
+                reopenedSubscription,
+                publication: FileSystemDeltaPublication(
+                    servicePublicationSequence: 42,
+                    source: .syntheticMutation,
+                    watcherAcceptedWatermark: nil,
+                    deltas: []
+                ),
+                lifecycleCorrelation: nil
+            ))
+
+            await oldApplyGate.release()
+            await coordinator.waitUntilApplied(rootID: rootID, servicePublicationSequence: 42)
+            let reopenedSequences = await reopenedRecorder.snapshot()
+            XCTAssertEqual(reopenedSequences, [41, 42])
+        }
+
+        func testWorkspaceIngressCoordinatorLateForcedDrainCannotCorruptReopenedSameRootState() async {
+            let rootID = UUID()
+            let oldFinishApplyingLatch = WorkspaceRootUnloadCompletionLatch()
+            let coordinator = WorkspaceFileSystemIngressCoordinator(
+                debugFinishApplyingHandler: { observedRootID, servicePublicationSequence in
+                    guard observedRootID == rootID, servicePublicationSequence == 40 else { return }
+                    oldFinishApplyingLatch.complete()
+                }
+            )
+            let oldApplyGate = AsyncGate()
+            let oldHandlerFinished = AsyncSignal()
+            let sleeper = ManualWorkspaceRootUnloadSleeper()
+            let oldSubscription = coordinator.openPublisherIngress(rootID: rootID) { _, _ in
+                await oldApplyGate.markStartedAndWaitForRelease()
+                await oldHandlerFinished.mark()
+            }
+            XCTAssertTrue(coordinator.accept(
+                oldSubscription,
+                publication: FileSystemDeltaPublication(
+                    servicePublicationSequence: 40,
+                    source: .syntheticMutation,
+                    watcherAcceptedWatermark: .init(rawValue: 19),
+                    deltas: []
+                ),
+                lifecycleCorrelation: nil
+            ))
+            await oldApplyGate.waitUntilStarted()
+            coordinator.closePublisherIngress(rootID: rootID)
+
+            let termination = Task {
+                await coordinator.terminateClosedPublisherIngress(
+                    rootIDs: [rootID],
+                    gracefulDrainTimeoutNanoseconds: 11,
+                    sleep: { nanoseconds in await sleeper.sleep(nanoseconds: nanoseconds) }
+                )
+            }
+            await sleeper.waitUntilSleeping(nanoseconds: 11)
+            await sleeper.release(nanoseconds: 11)
+            let reports = await termination.value
+            XCTAssertEqual(reports.first?.outcome, .forced)
+
+            let newRecorder = OrderedIngressRecorder()
+            let newSubscription = coordinator.openPublisherIngress(rootID: rootID) { publication, _ in
+                await newRecorder.append(publication.servicePublicationSequence)
+            }
+            XCTAssertFalse(coordinator.accept(
+                oldSubscription,
+                publication: FileSystemDeltaPublication(
+                    servicePublicationSequence: 41,
+                    source: .syntheticMutation,
+                    watcherAcceptedWatermark: nil,
+                    deltas: []
+                ),
+                lifecycleCorrelation: nil
+            ))
+            XCTAssertTrue(coordinator.accept(
+                newSubscription,
+                publication: FileSystemDeltaPublication(
+                    servicePublicationSequence: 1,
+                    source: .syntheticMutation,
+                    watcherAcceptedWatermark: nil,
+                    deltas: []
+                ),
+                lifecycleCorrelation: nil
+            ))
+            await coordinator.waitUntilApplied(rootID: rootID, servicePublicationSequence: 1)
+            await oldApplyGate.release()
+            await oldHandlerFinished.waitUntilMarked()
+            _ = await oldFinishApplyingLatch.wait()
+
+            XCTAssertEqual(coordinator.appliedSnapshot(rootID: rootID).appliedServicePublicationSequence, 1)
+            XCTAssertEqual(coordinator.appliedSnapshot(rootID: rootID).appliedWatcherWatermark, .zero)
+            let newRecordedSequences = await newRecorder.snapshot()
+            XCTAssertEqual(newRecordedSequences, [1])
+        }
+
+        func testWorkspaceIngressCoordinatorTerminationPreservesGracefulCompletionWithinBound() async throws {
+            let coordinator = WorkspaceFileSystemIngressCoordinator()
+            let rootID = UUID()
+            let applyGate = AsyncGate()
+            let sleeper = ManualWorkspaceRootUnloadSleeper()
+            let subscription = coordinator.openPublisherIngress(rootID: rootID) { _, _ in
+                await applyGate.markStartedAndWaitForRelease()
+            }
+            XCTAssertTrue(coordinator.accept(
+                subscription,
+                publication: FileSystemDeltaPublication(
+                    servicePublicationSequence: 1,
+                    source: .watcherBarrierNoop,
+                    watcherAcceptedWatermark: .init(rawValue: 23),
+                    deltas: []
+                ),
+                lifecycleCorrelation: nil
+            ))
+            await applyGate.waitUntilStarted()
+            coordinator.closePublisherIngress(rootID: rootID)
+
+            let termination = Task {
+                await coordinator.terminateClosedPublisherIngress(
+                    rootIDs: [rootID],
+                    gracefulDrainTimeoutNanoseconds: 11,
+                    sleep: { nanoseconds in await sleeper.sleep(nanoseconds: nanoseconds) }
+                )
+            }
+            await sleeper.waitUntilSleeping(nanoseconds: 11)
+            await applyGate.release()
+            let reports = await termination.value
+            let report = try XCTUnwrap(reports.first)
+
+            XCTAssertEqual(report.outcome, .graceful)
+            XCTAssertEqual(report.acceptedServicePublicationSequence, 1)
+            XCTAssertEqual(report.appliedServicePublicationSequence, 1)
+            XCTAssertEqual(report.appliedWatcherWatermark, 23)
+            XCTAssertEqual(coordinator.pendingPublisherIngressCount(rootIDs: [rootID]), 0)
+        }
+
         func testWorkspaceIngressCoordinatorFinishResolvesOutstandingWaiter() async {
             let coordinator = WorkspaceFileSystemIngressCoordinator()
             let rootID = UUID()
@@ -835,6 +1385,83 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
             XCTAssertNil(settledRoot.barrier.active)
             XCTAssertEqual(settledRoot.barrier.completionCount, 1)
             await store.setScopedIngressBarrierWillFlushHandler(nil)
+        }
+
+        func testScopedAppliedIngressCancelledPendingCallerDoesNotCancelLiveCoalescedJoiner() async throws {
+            let root = try makeTemporaryRoot(name: "ScopedIngressPendingCancellation")
+            let addedURL = root.appendingPathComponent("Added.swift")
+            let store = WorkspaceFileContextStore()
+            let record = try await store.loadRoot(path: root.path)
+            try await store.startWatchingRoot(id: record.id)
+            let rootID = record.id
+            let flushGate = AsyncGate()
+            await store.setScopedIngressBarrierWillFlushHandler { observedRootID in
+                guard observedRootID == rootID else { return }
+                await flushGate.markStartedAndWaitForRelease()
+            }
+
+            let activeBarrier = Task {
+                await store.awaitAppliedIngress(rootScope: .visibleWorkspace)
+            }
+            await flushGate.waitUntilStarted()
+
+            try write("added", to: addedURL)
+            let acceptedPayload = try await store.acceptWatcherPayloadForTesting(
+                rootID: rootID,
+                events: [(absolutePath: addedURL.path, flags: createdFileFlags, eventId: 250)],
+                scheduleDrain: false
+            )
+            let accepted = try XCTUnwrap(acceptedPayload)
+            let cancelledCompleted = AsyncSignal()
+            let liveCompleted = AsyncSignal()
+            let cancelledPendingCaller = Task {
+                let samples = await store.awaitAppliedIngress(rootScope: .visibleWorkspace)
+                await cancelledCompleted.mark()
+                return samples
+            }
+            let pendingCreated = await waitForAsyncCondition {
+                await store.scopedIngressBarrierStatsForTesting(rootID: rootID).successorCount == 1
+            }
+            XCTAssertTrue(pendingCreated)
+
+            let livePendingJoiner = Task {
+                let samples = await store.awaitAppliedIngress(rootScope: .visibleWorkspace)
+                await liveCompleted.mark()
+                return samples
+            }
+            let coalesced = await waitForAsyncCondition {
+                let stats = await store.scopedIngressBarrierStatsForTesting(rootID: rootID)
+                return stats.joinCount == 1 && stats.coalescedSuccessorCount == 1
+            }
+            XCTAssertTrue(coalesced)
+
+            cancelledPendingCaller.cancel()
+            let cancelledDetached = await waitForAsyncCondition {
+                await cancelledCompleted.isMarked()
+            }
+            XCTAssertTrue(cancelledDetached)
+            let liveCompletedBeforeRelease = await liveCompleted.isMarked()
+            XCTAssertFalse(liveCompletedBeforeRelease)
+            let blockedStats = await store.scopedIngressBarrierStatsForTesting(rootID: rootID)
+            XCTAssertEqual(blockedStats.launchCount, 1)
+            XCTAssertEqual(blockedStats.successorCount, 1)
+
+            await flushGate.release()
+            let activeSamples = await activeBarrier.value
+            let cancelledSamples = await cancelledPendingCaller.value
+            let liveSamples = await livePendingJoiner.value
+            let liveSample = try XCTUnwrap(liveSamples.first)
+            let settledStats = await store.scopedIngressBarrierStatsForTesting(rootID: rootID)
+
+            XCTAssertEqual(activeSamples.map(\.rootID), [rootID])
+            XCTAssertTrue(cancelledSamples.isEmpty)
+            XCTAssertEqual(liveSample.acceptedWatcherWatermark, accepted.rawValue)
+            XCTAssertGreaterThanOrEqual(liveSample.appliedWatcherWatermark, accepted.rawValue)
+            XCTAssertEqual(settledStats.launchCount, 2)
+            XCTAssertEqual(settledStats.successorCount, 1)
+            XCTAssertEqual(settledStats.coalescedSuccessorCount, 1)
+            await store.setScopedIngressBarrierWillFlushHandler(nil)
+            await store.stopWatchingRoot(id: rootID)
         }
 
         func testScopedAppliedIngressAllCancelledCallersStillReachIdleCleanup() async throws {
@@ -1026,10 +1653,12 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
             await store.setScopedIngressBarrierWillFlushHandler(nil)
         }
 
-        func testScopedAppliedIngressNewerSameRootTargetLaunchesSuccessorFlight() async throws {
+        func testScopedAppliedIngressCoalescesNewerSameRootTargetsIntoOnePendingSuccessor() async throws {
             let root = try makeTemporaryRoot(name: "ScopedIngressSuccessor")
-            let addedURL = root.appendingPathComponent("Added.swift")
-            let store = WorkspaceFileContextStore()
+            let firstAddedURL = root.appendingPathComponent("FirstAdded.swift")
+            let secondAddedURL = root.appendingPathComponent("SecondAdded.swift")
+            let clock = LockedWorkspaceDiagnosticsClock(nowNanoseconds: 4_000_000_000)
+            let store = WorkspaceFileContextStore(debugNowNanoseconds: { clock.now() })
             let record = try await store.loadRoot(path: root.path)
             try await store.startWatchingRoot(id: record.id)
             let rootID = record.id
@@ -1043,34 +1672,93 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
                 await store.awaitAppliedIngress(rootScope: .visibleWorkspace)
             }
             await flushGate.waitUntilStarted()
-            try write("added", to: addedURL)
-            let acceptedPayload = try await store.acceptWatcherPayloadForTesting(
+
+            try write("first", to: firstAddedURL)
+            let firstAcceptedPayload = try await store.acceptWatcherPayloadForTesting(
                 rootID: rootID,
-                events: [(absolutePath: addedURL.path, flags: createdFileFlags, eventId: 300)],
+                events: [(absolutePath: firstAddedURL.path, flags: createdFileFlags, eventId: 300)],
                 scheduleDrain: false
             )
-            let accepted = try XCTUnwrap(acceptedPayload)
+            let firstAccepted = try XCTUnwrap(firstAcceptedPayload)
             let secondBarrier = Task {
                 await store.awaitAppliedIngress(rootScope: .visibleWorkspace)
             }
-
-            var stats = await store.scopedIngressBarrierStatsForTesting(rootID: rootID)
-            for _ in 0 ..< 100 where stats.successorCount == 0 {
-                await Task.yield()
-                stats = await store.scopedIngressBarrierStatsForTesting(rootID: rootID)
+            let pendingSuccessorCreated = await waitForAsyncCondition {
+                await store.scopedIngressBarrierStatsForTesting(rootID: rootID).successorCount == 1
             }
+            XCTAssertTrue(pendingSuccessorCreated)
+
+            try write("second", to: secondAddedURL)
+            let secondAcceptedPayload = try await store.acceptWatcherPayloadForTesting(
+                rootID: rootID,
+                events: [(absolutePath: secondAddedURL.path, flags: createdFileFlags, eventId: 301)],
+                scheduleDrain: false
+            )
+            let secondAccepted = try XCTUnwrap(secondAcceptedPayload)
+            XCTAssertGreaterThan(secondAccepted.rawValue, firstAccepted.rawValue)
+            try await store.publishSyntheticFileSystemDeltasForTesting(
+                rootID: rootID,
+                deltas: [.fileModified("FirstAdded.swift", nil)]
+            )
+            let acceptedServicePublicationSequence = await store.appliedIngressSnapshotForTesting(rootID: rootID)
+                .acceptedServicePublicationSequence
+            XCTAssertGreaterThan(acceptedServicePublicationSequence, 0)
+            let thirdBarrier = Task {
+                await store.awaitAppliedIngress(rootScope: .visibleWorkspace)
+            }
+
+            for _ in 0 ..< 1000 {
+                let stats = await store.scopedIngressBarrierStatsForTesting(rootID: rootID)
+                if await flushGate.startCount() >= 3 || stats.coalescedSuccessorCount == 1 { break }
+                await Task.yield()
+            }
+            clock.advance(milliseconds: 175)
+            let statsWhileBlocked = await store.scopedIngressBarrierStatsForTesting(rootID: rootID)
+            let flightCountWhileBlocked = await store.scopedIngressBarrierFlightCountForTesting()
+            let flushStartCountWhileBlocked = await flushGate.startCount()
+            let blockedRoots = await store.readSearchRootDiagnosticsSnapshot()
+            let blockedRoot = try XCTUnwrap(blockedRoots.first { $0.rootID == rootID })
+            let active = try XCTUnwrap(blockedRoot.barrier.active)
+            let pending = try XCTUnwrap(blockedRoot.barrier.pending)
+
+            XCTAssertEqual(statsWhileBlocked.launchCount, 1)
+            XCTAssertEqual(statsWhileBlocked.joinCount, 1)
+            XCTAssertEqual(statsWhileBlocked.successorCount, 1)
+            XCTAssertEqual(statsWhileBlocked.coalescedSuccessorCount, 1)
+            XCTAssertEqual(flightCountWhileBlocked, 2)
+            XCTAssertEqual(flushStartCountWhileBlocked, 1)
+            XCTAssertEqual(active.targetWatcherWatermark, 0)
+            XCTAssertEqual(pending.targetWatcherWatermark, secondAccepted.rawValue)
+            XCTAssertEqual(pending.targetServicePublicationSequence, acceptedServicePublicationSequence)
+            XCTAssertEqual(pending.ageMilliseconds, 175)
+
             await flushGate.release()
             let firstSamples = await firstBarrier.value
             let secondSamples = await secondBarrier.value
-            let flushStartCount = await flushGate.startCount()
+            let thirdSamples = await thirdBarrier.value
+            let settledStats = await store.scopedIngressBarrierStatsForTesting(rootID: rootID)
+            let settledFlushStartCount = await flushGate.startCount()
             let secondSample = try XCTUnwrap(secondSamples.first)
+            let thirdSample = try XCTUnwrap(thirdSamples.first)
 
-            XCTAssertEqual(stats.launchCount, 2)
-            XCTAssertEqual(stats.successorCount, 1)
-            XCTAssertEqual(flushStartCount, 2)
+            XCTAssertEqual(settledStats.launchCount, 2)
+            XCTAssertEqual(settledStats.joinCount, 1)
+            XCTAssertEqual(settledStats.successorCount, 1)
+            XCTAssertEqual(settledStats.coalescedSuccessorCount, 1)
+            XCTAssertEqual(settledFlushStartCount, 2)
             XCTAssertEqual(firstSamples.first?.acceptedWatcherWatermark, 0)
-            XCTAssertEqual(secondSample.acceptedWatcherWatermark, accepted.rawValue)
-            XCTAssertGreaterThanOrEqual(secondSample.appliedWatcherWatermark, accepted.rawValue)
+            XCTAssertEqual(secondSample.acceptedWatcherWatermark, secondAccepted.rawValue)
+            XCTAssertEqual(thirdSample.acceptedWatcherWatermark, secondAccepted.rawValue)
+            XCTAssertGreaterThanOrEqual(secondSample.appliedWatcherWatermark, secondAccepted.rawValue)
+            XCTAssertGreaterThanOrEqual(thirdSample.appliedWatcherWatermark, secondAccepted.rawValue)
+            XCTAssertGreaterThanOrEqual(
+                secondSample.appliedServicePublicationSequence,
+                acceptedServicePublicationSequence
+            )
+            XCTAssertGreaterThanOrEqual(
+                thirdSample.appliedServicePublicationSequence,
+                acceptedServicePublicationSequence
+            )
             await store.setScopedIngressBarrierWillFlushHandler(nil)
             await store.stopWatchingRoot(id: rootID)
         }
@@ -1216,7 +1904,9 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
             XCTAssertEqual(active.targetServicePublicationSequence, 0)
             XCTAssertEqual(active.ageMilliseconds, 325)
             XCTAssertEqual(activeRoot.barrier.launchCount, 1)
+            XCTAssertEqual(activeRoot.barrier.coalescedSuccessorCount, 0)
             XCTAssertEqual(activeRoot.barrier.completionCount, 0)
+            XCTAssertNil(activeRoot.barrier.pending)
             XCTAssertNil(activeRoot.barrier.lastCompleted)
 
             await flushGate.release()
@@ -1227,6 +1917,7 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
             let completedRoot = try XCTUnwrap(completedRoots.first { $0.rootID == record.id })
             let completed = try XCTUnwrap(completedRoot.barrier.lastCompleted)
             XCTAssertNil(completedRoot.barrier.active)
+            XCTAssertNil(completedRoot.barrier.pending)
             XCTAssertEqual(completedRoot.barrier.completionCount, 1)
             XCTAssertEqual(completed.targetWatcherWatermark, 0)
             XCTAssertEqual(completed.targetServicePublicationSequence, 0)
@@ -1236,10 +1927,12 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
             await store.setScopedIngressBarrierWillFlushHandler(nil)
         }
 
-        func testRootUnloadCancelsOwnedScopedIngressFlightAndReleasesDetachedService() async throws {
+        func testRootUnloadCancelsActiveAndPendingScopedIngressFlightsAndReleasesDetachedService() async throws {
             let root = try makeTemporaryRoot(name: "ScopedIngressUnloadRelease")
+            let addedURL = root.appendingPathComponent("Pending.swift")
             let store = WorkspaceFileContextStore()
             let record = try await store.loadRoot(path: root.path)
+            try await store.startWatchingRoot(id: record.id)
             var service: FileSystemService? = await store.fileSystemServiceForTesting(rootID: record.id)
             let weakService = WeakObjectBox(service)
             let cancellationGate = CancellationAwareGate()
@@ -1248,16 +1941,32 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
                 await cancellationGate.markStartedAndWaitForCancellation()
             }
 
-            let barrierTask = Task {
+            let activeBarrier = Task {
                 await store.awaitAppliedIngress(rootScope: .visibleWorkspace)
             }
             await cancellationGate.waitUntilStarted()
-            let activeFlightCount = await store.scopedIngressBarrierFlightCountForTesting()
-            XCTAssertEqual(activeFlightCount, 1)
+
+            try write("pending", to: addedURL)
+            let acceptedPayload = try await store.acceptWatcherPayloadForTesting(
+                rootID: record.id,
+                events: [(absolutePath: addedURL.path, flags: createdFileFlags, eventId: 400)],
+                scheduleDrain: false
+            )
+            XCTAssertNotNil(acceptedPayload)
+            let pendingBarrier = Task {
+                await store.awaitAppliedIngress(rootScope: .visibleWorkspace)
+            }
+            let pendingCreated = await waitForAsyncCondition {
+                await store.scopedIngressBarrierStatsForTesting(rootID: record.id).successorCount == 1
+            }
+            XCTAssertTrue(pendingCreated)
+            let ownedFlightCount = await store.scopedIngressBarrierFlightCountForTesting()
+            XCTAssertEqual(ownedFlightCount, 2)
 
             await store.unloadRoot(id: record.id)
             service = nil
-            let samples = await barrierTask.value
+            let activeSamples = await activeBarrier.value
+            let pendingSamples = await pendingBarrier.value
             let roots = await store.roots()
             let retainedRootIDs = await store.retainedReadSearchDiagnosticRootIDsForTesting()
             let remainingFlightCount = await store.scopedIngressBarrierFlightCountForTesting()
@@ -1265,7 +1974,8 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
                 weakService.value == nil
             }
 
-            XCTAssertTrue(samples.isEmpty)
+            XCTAssertTrue(activeSamples.isEmpty)
+            XCTAssertTrue(pendingSamples.isEmpty)
             XCTAssertTrue(roots.isEmpty)
             XCTAssertEqual(remainingFlightCount, 0)
             XCTAssertFalse(retainedRootIDs.contains(record.id))
@@ -4245,6 +4955,81 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
 
         private var createdFileFlags: FSEventStreamEventFlags {
             FSEventStreamEventFlags(kFSEventStreamEventFlagItemCreated | kFSEventStreamEventFlagItemIsFile)
+        }
+
+        private actor WorkspaceRootUnloadDiagnosticsRecorder {
+            private var diagnostics: WorkspaceRootUnloadTerminationDiagnostics?
+
+            func record(_ diagnostics: WorkspaceRootUnloadTerminationDiagnostics) {
+                self.diagnostics = diagnostics
+            }
+
+            func snapshot() -> WorkspaceRootUnloadTerminationDiagnostics? {
+                diagnostics
+            }
+        }
+
+        private actor ManualWorkspaceRootUnloadSleeper {
+            private struct Waiter {
+                let id: UUID
+                let continuation: CheckedContinuation<Void, Never>
+            }
+
+            private var sleepWaitersByNanoseconds: [UInt64: [UUID: Waiter]] = [:]
+            private var registrationWaitersByNanoseconds: [UInt64: [CheckedContinuation<Void, Never>]] = [:]
+            private var releasedNanoseconds: Set<UInt64> = []
+            private var cancelledWaiterIDs: Set<UUID> = []
+
+            func sleep(nanoseconds: UInt64) async {
+                if releasedNanoseconds.contains(nanoseconds) { return }
+                let waiterID = UUID()
+                await withTaskCancellationHandler {
+                    await withCheckedContinuation { continuation in
+                        if Task.isCancelled || cancelledWaiterIDs.remove(waiterID) != nil {
+                            continuation.resume()
+                            return
+                        }
+                        if releasedNanoseconds.contains(nanoseconds) {
+                            continuation.resume()
+                            return
+                        }
+                        sleepWaitersByNanoseconds[nanoseconds, default: [:]][waiterID] = Waiter(
+                            id: waiterID,
+                            continuation: continuation
+                        )
+                        let registrationWaiters = registrationWaitersByNanoseconds.removeValue(forKey: nanoseconds) ?? []
+                        registrationWaiters.forEach { $0.resume() }
+                    }
+                } onCancel: {
+                    Task { await self.cancel(waiterID: waiterID, nanoseconds: nanoseconds) }
+                }
+            }
+
+            func waitUntilSleeping(nanoseconds: UInt64) async {
+                guard sleepWaitersByNanoseconds[nanoseconds]?.isEmpty != false else { return }
+                await withCheckedContinuation { continuation in
+                    registrationWaitersByNanoseconds[nanoseconds, default: []].append(continuation)
+                }
+            }
+
+            func release(nanoseconds: UInt64) {
+                releasedNanoseconds.insert(nanoseconds)
+                let waiters = sleepWaitersByNanoseconds.removeValue(forKey: nanoseconds) ?? [:]
+                waiters.values.forEach { $0.continuation.resume() }
+                let registrationWaiters = registrationWaitersByNanoseconds.removeValue(forKey: nanoseconds) ?? []
+                registrationWaiters.forEach { $0.resume() }
+            }
+
+            private func cancel(waiterID: UUID, nanoseconds: UInt64) {
+                guard let waiter = sleepWaitersByNanoseconds[nanoseconds]?.removeValue(forKey: waiterID) else {
+                    cancelledWaiterIDs.insert(waiterID)
+                    return
+                }
+                if sleepWaitersByNanoseconds[nanoseconds]?.isEmpty == true {
+                    sleepWaitersByNanoseconds.removeValue(forKey: nanoseconds)
+                }
+                waiter.continuation.resume()
+            }
         }
 
         private actor OrderedIngressRecorder {

--- a/Tests/RepoPromptTests/Workspaces/WorkspaceSwitchPresentationTests.swift
+++ b/Tests/RepoPromptTests/Workspaces/WorkspaceSwitchPresentationTests.swift
@@ -1,0 +1,171 @@
+import Foundation
+@testable import RepoPrompt
+import XCTest
+
+@MainActor
+final class WorkspaceSwitchPresentationTests: XCTestCase {
+    func testStaleConfirmationDismissalBindingCannotResolveReplacementConfirmation() async throws {
+        let manager = makeComposition().workspaceManager
+        await manager.awaitInitialized()
+        manager.registerSwitchSessionProvider(PresentationWorkspaceSwitchSessionProvider())
+
+        let firstTarget = manager.createWorkspace(
+            name: "Presentation First \(UUID().uuidString.prefix(8))",
+            repoPaths: [],
+            ephemeral: true
+        )
+        let firstRequest = Task { @MainActor in
+            await manager.requestWorkspaceSwitch(to: firstTarget, reason: "presentationFirst")
+        }
+        try await waitUntil { manager.pendingSwitchConfirmation != nil }
+        let firstID = try XCTUnwrap(manager.pendingSwitchConfirmation?.id)
+        let staleBinding = WorkspaceSwitchConfirmationModifier.confirmationPresentationBinding(
+            manager: manager,
+            confirmationID: firstID
+        )
+        manager.resolveSwitchConfirmation(id: firstID, allow: false)
+        _ = await firstRequest.value
+
+        let secondTarget = manager.createWorkspace(
+            name: "Presentation Second \(UUID().uuidString.prefix(8))",
+            repoPaths: [],
+            ephemeral: true
+        )
+        let secondRequest = Task { @MainActor in
+            await manager.requestWorkspaceSwitch(to: secondTarget, reason: "presentationSecond")
+        }
+        try await waitUntil { manager.pendingSwitchConfirmation != nil }
+        let secondID = try XCTUnwrap(manager.pendingSwitchConfirmation?.id)
+
+        staleBinding.wrappedValue = false
+
+        XCTAssertEqual(manager.pendingSwitchConfirmation?.id, secondID)
+        XCTAssertTrue(manager.hasPendingSwitchConfirmation)
+        manager.resolveSwitchConfirmation(id: secondID, allow: false)
+        _ = await secondRequest.value
+    }
+
+    func testBlockedResultsPublishSharedNoticeAndStaleDismissalCannotClearReplacement() async throws {
+        let manager = makeComposition().workspaceManager
+        await manager.awaitInitialized()
+        let active = try XCTUnwrap(manager.activeWorkspace)
+
+        let firstResult = await manager.requestWorkspaceSwitch(to: active, reason: "blockedNoticeFirst")
+        guard case let .blocked(firstMessage) = firstResult else {
+            return XCTFail("Expected active-workspace request to be blocked")
+        }
+        let firstNotice = try XCTUnwrap(manager.pendingWorkspaceSwitchBlockedNotice)
+        XCTAssertEqual(firstNotice.message, firstMessage)
+        let staleBinding = WorkspaceSwitchConfirmationModifier.blockedNoticePresentationBinding(
+            manager: manager,
+            noticeID: firstNotice.id
+        )
+
+        manager.isRefreshing = true
+        let target = manager.createWorkspace(
+            name: "Blocked Notice Target \(UUID().uuidString.prefix(8))",
+            repoPaths: [],
+            ephemeral: true
+        )
+        let secondResult = await manager.requestWorkspaceSwitch(to: target, reason: "blockedNoticeSecond")
+        guard case let .blocked(secondMessage) = secondResult else {
+            return XCTFail("Expected refresh-state request to be blocked")
+        }
+        let secondNotice = try XCTUnwrap(manager.pendingWorkspaceSwitchBlockedNotice)
+        XCTAssertEqual(secondNotice.message, secondMessage)
+        XCTAssertNotEqual(firstNotice.id, secondNotice.id)
+
+        staleBinding.wrappedValue = false
+
+        XCTAssertEqual(manager.pendingWorkspaceSwitchBlockedNotice?.id, secondNotice.id)
+        let currentBinding = WorkspaceSwitchConfirmationModifier.blockedNoticePresentationBinding(
+            manager: manager,
+            noticeID: secondNotice.id
+        )
+        currentBinding.wrappedValue = false
+        XCTAssertNil(manager.pendingWorkspaceSwitchBlockedNotice)
+        manager.isRefreshing = false
+    }
+
+    func testSuccessfulSwitchDoesNotClearUnrelatedBlockedNotice() async throws {
+        let manager = makeComposition().workspaceManager
+        await manager.awaitInitialized()
+        let active = try XCTUnwrap(manager.activeWorkspace)
+
+        guard case .blocked = await manager.requestWorkspaceSwitch(
+            to: active,
+            reason: "unrelatedNotice"
+        ) else {
+            return XCTFail("Expected active workspace request to publish a blocked notice")
+        }
+        let unrelatedNotice = try XCTUnwrap(manager.pendingWorkspaceSwitchBlockedNotice)
+        XCTAssertNil(unrelatedNotice.blockingOperationID)
+        let target = manager.createWorkspace(
+            name: "Unrelated Notice Target \(UUID().uuidString.prefix(8))",
+            repoPaths: [],
+            ephemeral: true
+        )
+
+        let switchResult = await manager.requestWorkspaceSwitch(
+            to: target,
+            saveState: false,
+            reason: "successfulSwitchWithUnrelatedNotice"
+        )
+        XCTAssertEqual(switchResult, .switched)
+        XCTAssertEqual(manager.pendingWorkspaceSwitchBlockedNotice?.id, unrelatedNotice.id)
+    }
+
+    func testBlockedNoticeOwnershipDoesNotMatchNewerUnrelatedNotice() {
+        let owningOperationID = UUID()
+        let relatedNotice = WorkspaceSwitchBlockedNotice(
+            message: "related",
+            blockingOperationID: owningOperationID
+        )
+        let newerUnrelatedNotice = WorkspaceSwitchBlockedNotice(
+            message: "newer unrelated",
+            blockingOperationID: UUID()
+        )
+
+        XCTAssertTrue(relatedNotice.isBlocked(by: owningOperationID))
+        XCTAssertFalse(newerUnrelatedNotice.isBlocked(by: owningOperationID))
+    }
+
+    private func makeComposition() -> WindowStateComposition {
+        let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
+        GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
+        defer { GlobalSettingsStore.shared.setMCPAutoStart(previousAutoStart, commit: false) }
+        return WindowStateCompositionFactory.make(
+            windowID: -1000 - Int.random(in: 1 ... 99),
+            deferredInitialAgentSystemWorkspaceRefresh: true,
+            sharedMCPService: MCPService()
+        )
+    }
+
+    private func waitUntil(
+        timeout: TimeInterval = 3,
+        file: StaticString = #filePath,
+        line: UInt = #line,
+        _ condition: @escaping @MainActor () -> Bool
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if condition() { return }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTFail("Timed out waiting for condition", file: file, line: line)
+    }
+}
+
+@MainActor
+private final class PresentationWorkspaceSwitchSessionProvider: WorkspaceSwitchSessionProvider {
+    func switchSessionItems() -> [WorkspaceSwitchSessionItem] {
+        [WorkspaceSwitchSessionItem(
+            id: "presentation",
+            count: 1,
+            singularLabel: "presentation session",
+            pluralLabel: "presentation sessions"
+        )]
+    }
+
+    func cancelSwitchSessions() async {}
+}

--- a/Tests/RepoPromptTests/Workspaces/WorkspaceSwitchPresentationTests.swift
+++ b/Tests/RepoPromptTests/Workspaces/WorkspaceSwitchPresentationTests.swift
@@ -48,11 +48,16 @@ final class WorkspaceSwitchPresentationTests: XCTestCase {
     func testBlockedResultsPublishSharedNoticeAndStaleDismissalCannotClearReplacement() async throws {
         let manager = makeComposition().workspaceManager
         await manager.awaitInitialized()
-        let active = try XCTUnwrap(manager.activeWorkspace)
 
-        let firstResult = await manager.requestWorkspaceSwitch(to: active, reason: "blockedNoticeFirst")
+        manager.isRefreshing = true
+        let firstTarget = manager.createWorkspace(
+            name: "Blocked Notice First Target \(UUID().uuidString.prefix(8))",
+            repoPaths: [],
+            ephemeral: true
+        )
+        let firstResult = await manager.requestWorkspaceSwitch(to: firstTarget, reason: "blockedNoticeFirst")
         guard case let .blocked(firstMessage) = firstResult else {
-            return XCTFail("Expected active-workspace request to be blocked")
+            return XCTFail("Expected refresh-state request to be blocked")
         }
         let firstNotice = try XCTUnwrap(manager.pendingWorkspaceSwitchBlockedNotice)
         XCTAssertEqual(firstNotice.message, firstMessage)
@@ -61,7 +66,6 @@ final class WorkspaceSwitchPresentationTests: XCTestCase {
             noticeID: firstNotice.id
         )
 
-        manager.isRefreshing = true
         let target = manager.createWorkspace(
             name: "Blocked Notice Target \(UUID().uuidString.prefix(8))",
             repoPaths: [],
@@ -87,17 +91,40 @@ final class WorkspaceSwitchPresentationTests: XCTestCase {
         manager.isRefreshing = false
     }
 
-    func testSuccessfulSwitchDoesNotClearUnrelatedBlockedNotice() async throws {
+    func testActiveWorkspaceRequestIsBlockedWithoutPublishingNotice() async throws {
         let manager = makeComposition().workspaceManager
         await manager.awaitInitialized()
         let active = try XCTUnwrap(manager.activeWorkspace)
 
+        let result = await manager.requestWorkspaceSwitch(to: active, reason: "sameWorkspaceNoOp")
+
+        guard case let .blocked(message) = result else {
+            return XCTFail("Expected active-workspace request to be blocked")
+        }
+        XCTAssertEqual(message, "Already on workspace \"\(active.name)\".")
+        XCTAssertNil(
+            manager.pendingWorkspaceSwitchBlockedNotice,
+            "Benign same-workspace requests (launch restore, save-and-exit on the fallback, MCP switch to current) must not raise the blocked alert"
+        )
+    }
+
+    func testSuccessfulSwitchDoesNotClearUnrelatedBlockedNotice() async throws {
+        let manager = makeComposition().workspaceManager
+        await manager.awaitInitialized()
+
+        manager.isRefreshing = true
+        let blockedTarget = manager.createWorkspace(
+            name: "Unrelated Blocked Target \(UUID().uuidString.prefix(8))",
+            repoPaths: [],
+            ephemeral: true
+        )
         guard case .blocked = await manager.requestWorkspaceSwitch(
-            to: active,
+            to: blockedTarget,
             reason: "unrelatedNotice"
         ) else {
-            return XCTFail("Expected active workspace request to publish a blocked notice")
+            return XCTFail("Expected refresh-state request to publish a blocked notice")
         }
+        manager.isRefreshing = false
         let unrelatedNotice = try XCTUnwrap(manager.pendingWorkspaceSwitchBlockedNotice)
         XCTAssertNil(unrelatedNotice.blockingOperationID)
         let target = manager.createWorkspace(

--- a/Tests/RepoPromptTests/Workspaces/WorkspaceSwitchRecoveryTests.swift
+++ b/Tests/RepoPromptTests/Workspaces/WorkspaceSwitchRecoveryTests.swift
@@ -1,0 +1,845 @@
+import Foundation
+@testable import RepoPrompt
+import XCTest
+
+@MainActor
+final class WorkspaceSwitchRecoveryTests: XCTestCase {
+    func testConcurrentStaleRequestReportsActiveSwitchAndForcedUnloadEventuallyClearsGuard() async throws {
+        let root = try makeTemporaryDirectory(named: "ForcedUnloadRecovery")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let fileURL = root.appendingPathComponent("Blocked.swift")
+        try "blocked".write(to: fileURL, atomically: true, encoding: .utf8)
+
+        let clock = WorkspaceSwitchTestClock(now: Date(timeIntervalSince1970: 1000))
+        let unloadSleeper = WorkspaceSwitchManualSleeper()
+        let store = WorkspaceFileContextStore(
+            unloadTerminationPolicy: WorkspaceRootUnloadTerminationPolicy(
+                publisherIngressGraceNanoseconds: 11,
+                watcherStopGraceNanoseconds: 22,
+                sleep: { nanoseconds in await unloadSleeper.sleep(nanoseconds: nanoseconds) }
+            )
+        )
+        let composition = makeComposition(
+            store: store,
+            timingPolicy: WorkspaceSwitchTimingPolicy(
+                staleThreshold: 30,
+                chatBusySettleTimeoutNanoseconds: 20,
+                chatBusyPollIntervalNanoseconds: 20,
+                now: { clock.now() },
+                sleep: { _ in }
+            )
+        )
+        let manager = composition.workspaceManager
+        await manager.awaitInitialized()
+
+        let source = manager.createWorkspace(
+            name: "Recovery Source \(UUID().uuidString.prefix(8))",
+            repoPaths: [root.path],
+            ephemeral: true
+        )
+        let sourceResult = await manager.switchWorkspace(
+            to: source,
+            saveState: false,
+            reason: "workspaceSwitchRecoverySource"
+        )
+        XCTAssertTrue(sourceResult.didSwitch)
+
+        let loadedRoots = await store.roots()
+        let matchingRoots = loadedRoots.filter { $0.standardizedFullPath == root.path }
+        let loadedRoot = try XCTUnwrap(matchingRoots.first)
+        try await store.startWatchingRoot(id: loadedRoot.id)
+        let sinkGate = WorkspaceSwitchRecoveryGate()
+        await store.setWatcherSinkWillApplyHandler { observedRootID in
+            guard observedRootID == loadedRoot.id else { return }
+            await sinkGate.arriveAndWait()
+        }
+        try await store.publishSyntheticFileSystemDeltasForTesting(
+            rootID: loadedRoot.id,
+            deltas: [.fileModified("Blocked.swift", nil)]
+        )
+        await sinkGate.waitUntilArrived()
+
+        let target = manager.createWorkspace(
+            name: "Recovery Target \(UUID().uuidString.prefix(8))",
+            repoPaths: [],
+            ephemeral: true
+        )
+        let firstSwitch = Task { @MainActor in
+            await manager.requestWorkspaceSwitch(
+                to: target,
+                saveState: true,
+                reason: "forcedUnloadRecovery"
+            )
+        }
+
+        try await waitUntil {
+            manager.activeWorkspaceSwitch?.phase == .unloadingRoots
+        }
+        await unloadSleeper.waitUntilSleeping(nanoseconds: 11)
+        clock.advance(by: 31)
+
+        let repeatedResult = await manager.requestWorkspaceSwitch(
+            to: target,
+            saveState: true,
+            reason: "repeatedRequest"
+        )
+        let blockage = try XCTUnwrap(manager.lastWorkspaceSwitchBlockageReport)
+        XCTAssertEqual(blockage.activeSwitch.targetWorkspaceID, target.id)
+        XCTAssertEqual(blockage.activeSwitch.targetWorkspaceName, target.name)
+        XCTAssertEqual(blockage.activeSwitch.reason, "forcedUnloadRecovery")
+        XCTAssertEqual(blockage.activeSwitch.phase, .unloadingRoots)
+        XCTAssertEqual(blockage.totalAge, 31, accuracy: 0.001)
+        XCTAssertEqual(blockage.phaseAge, 31, accuracy: 0.001)
+        XCTAssertTrue(blockage.isStale)
+        guard case let .blocked(repeatedMessage) = repeatedResult else {
+            return XCTFail("Expected repeated request to be blocked")
+        }
+        XCTAssertEqual(repeatedMessage, blockage.message)
+        XCTAssertTrue(repeatedMessage.contains(target.name))
+        XCTAssertTrue(repeatedMessage.contains("unloading roots"))
+        XCTAssertTrue(repeatedMessage.contains("stale"))
+        XCTAssertEqual(manager.pendingWorkspaceSwitchBlockedNotice?.message, repeatedMessage)
+
+        await unloadSleeper.release(nanoseconds: 11)
+        let firstResult = await firstSwitch.value
+        XCTAssertTrue(firstResult.didSwitch)
+        XCTAssertEqual(manager.activeWorkspaceID, target.id)
+        XCTAssertFalse(manager.isSwitchingWorkspace)
+        XCTAssertNil(manager.activeWorkspaceSwitch)
+
+        await sinkGate.release()
+        await sinkGate.waitUntilCompleted()
+        XCTAssertEqual(manager.activeWorkspaceID, target.id)
+        XCTAssertFalse(manager.isSwitchingWorkspace)
+        XCTAssertNil(manager.activeWorkspaceSwitch)
+        await store.setWatcherSinkWillApplyHandler(nil)
+    }
+
+    func testBusyStateThatPersistsAfterSessionCancellationReturnsExplicitBlockageWithoutStartingSwitch() async throws {
+        let clock = WorkspaceSwitchTestClock(now: Date(timeIntervalSince1970: 2000))
+        let settleSleeper = WorkspaceSwitchManualSleeper()
+        let composition = makeComposition(
+            timingPolicy: WorkspaceSwitchTimingPolicy(
+                staleThreshold: 30,
+                chatBusySettleTimeoutNanoseconds: 22,
+                chatBusyPollIntervalNanoseconds: 22,
+                now: { clock.now() },
+                sleep: { nanoseconds in
+                    await settleSleeper.sleep(nanoseconds: nanoseconds)
+                    try Task.checkCancellation()
+                }
+            )
+        )
+        let manager = composition.workspaceManager
+        await manager.awaitInitialized()
+        let previousWorkspaceID = manager.activeWorkspaceID
+        let provider = StickyBusyWorkspaceSwitchSessionProvider(workspaceManager: manager)
+        manager.registerSwitchSessionProvider(provider)
+        manager.isChatBusy = true
+
+        let target = manager.createWorkspace(
+            name: "Busy Target \(UUID().uuidString.prefix(8))",
+            repoPaths: [],
+            ephemeral: true
+        )
+        let request = Task { @MainActor in
+            await manager.requestWorkspaceSwitch(to: target, reason: "busySettle")
+        }
+        try await waitUntil { manager.pendingSwitchConfirmation != nil }
+        let confirmationID = try XCTUnwrap(manager.pendingSwitchConfirmation?.id)
+        manager.resolveSwitchConfirmation(id: confirmationID, allow: true)
+        await settleSleeper.waitUntilSleeping(nanoseconds: 22)
+        XCTAssertEqual(manager.activeWorkspaceSwitch?.phase, .waitingForChatIdle)
+
+        clock.advance(by: 2)
+        await settleSleeper.release(nanoseconds: 22)
+        let result = await request.value
+
+        guard case let .blocked(message) = result else {
+            return XCTFail("Expected persistent busy state to block the switch")
+        }
+        XCTAssertTrue(message.contains("isChatBusy remained true"))
+        XCTAssertTrue(message.contains("1 sticky session"))
+        XCTAssertEqual(manager.activeWorkspaceID, previousWorkspaceID)
+        XCTAssertFalse(manager.isSwitchingWorkspace)
+        XCTAssertNil(manager.activeWorkspaceSwitch)
+        let report = try XCTUnwrap(manager.lastWorkspaceSwitchBlockageReport)
+        XCTAssertEqual(report.activeSwitch.targetWorkspaceID, target.id)
+        XCTAssertEqual(report.activeSwitch.phase, .waitingForChatIdle)
+        XCTAssertEqual(provider.cancelCount(), 1)
+        XCTAssertEqual(manager.pendingWorkspaceSwitchBlockedNotice?.message, message)
+    }
+
+    func testConfirmationCancellationClearsOnlyOwnedContinuation() async throws {
+        let composition = makeComposition()
+        let manager = composition.workspaceManager
+        await manager.awaitInitialized()
+        let provider = StaticWorkspaceSwitchSessionProvider()
+        manager.registerSwitchSessionProvider(provider)
+
+        let firstTarget = manager.createWorkspace(
+            name: "First Confirmation Target \(UUID().uuidString.prefix(8))",
+            repoPaths: [],
+            ephemeral: true
+        )
+        let firstRequest = Task { @MainActor in
+            await manager.requestWorkspaceSwitch(to: firstTarget, reason: "firstConfirmation")
+        }
+        try await waitUntil { manager.pendingSwitchConfirmation != nil }
+        let firstConfirmationID = try XCTUnwrap(manager.pendingSwitchConfirmation?.id)
+        firstRequest.cancel()
+        let firstResult = await firstRequest.value
+        guard case .cancelled = firstResult else {
+            return XCTFail("Expected cancellation while awaiting confirmation")
+        }
+        XCTAssertNil(manager.pendingSwitchConfirmation)
+        XCTAssertFalse(manager.hasPendingSwitchConfirmation)
+        XCTAssertFalse(manager.isSwitchingWorkspace)
+
+        let secondTarget = manager.createWorkspace(
+            name: "Second Confirmation Target \(UUID().uuidString.prefix(8))",
+            repoPaths: [],
+            ephemeral: true
+        )
+        let secondRequest = Task { @MainActor in
+            await manager.requestWorkspaceSwitch(to: secondTarget, reason: "secondConfirmation")
+        }
+        try await waitUntil { manager.pendingSwitchConfirmation != nil }
+        let secondConfirmationID = try XCTUnwrap(manager.pendingSwitchConfirmation?.id)
+        XCTAssertNotEqual(secondConfirmationID, firstConfirmationID)
+
+        manager.resolveSwitchConfirmation(id: firstConfirmationID, allow: true)
+        XCTAssertEqual(manager.pendingSwitchConfirmation?.id, secondConfirmationID)
+        XCTAssertTrue(manager.hasPendingSwitchConfirmation)
+
+        manager.resolveSwitchConfirmation(id: secondConfirmationID, allow: false)
+        let secondResult = await secondRequest.value
+        guard case .cancelled = secondResult else {
+            return XCTFail("Expected the owned confirmation to cancel the request")
+        }
+        XCTAssertNil(manager.pendingSwitchConfirmation)
+        XCTAssertFalse(manager.hasPendingSwitchConfirmation)
+    }
+
+    func testExplicitSwitchCancellationResolvesOwnedConfirmation() async throws {
+        let composition = makeComposition()
+        let manager = composition.workspaceManager
+        await manager.awaitInitialized()
+        manager.registerSwitchSessionProvider(StaticWorkspaceSwitchSessionProvider())
+
+        let target = manager.createWorkspace(
+            name: "Explicit Cancellation Target \(UUID().uuidString.prefix(8))",
+            repoPaths: [],
+            ephemeral: true
+        )
+        let request = Task { @MainActor in
+            await manager.requestWorkspaceSwitch(to: target, reason: "explicitConfirmationCancellation")
+        }
+        try await waitUntil {
+            manager.activeWorkspaceSwitch?.phase == .awaitingConfirmation
+                && manager.pendingSwitchConfirmation != nil
+        }
+
+        await manager.cancelCurrentWorkspaceSwitchAndReturnToSystem()
+        let result = await request.value
+
+        guard case .cancelled = result else {
+            return XCTFail("Expected explicit switch cancellation to cancel the confirmation request")
+        }
+        XCTAssertNil(manager.pendingSwitchConfirmation)
+        XCTAssertFalse(manager.hasPendingSwitchConfirmation)
+        XCTAssertFalse(manager.isSwitchingWorkspace)
+        XCTAssertNil(manager.activeWorkspaceSwitch)
+    }
+
+    func testSaveAndExitReturnsExactRequestResult() async {
+        let composition = makeComposition()
+        let manager = composition.workspaceManager
+        await manager.awaitInitialized()
+        let activeName = manager.activeWorkspace?.name ?? ""
+
+        let result = await manager.saveAndExitToFallback()
+
+        guard case let .blocked(message) = result else {
+            return XCTFail("Expected save-and-exit on the fallback workspace to return request blockage")
+        }
+        XCTAssertEqual(message, "Already on workspace \"\(activeName)\".")
+    }
+
+    func testCancellationRequestedBySwitchListenerAfterNotificationReturnsSwitched() async {
+        let composition = makeComposition()
+        let manager = composition.workspaceManager
+        await manager.awaitInitialized()
+        let target = manager.createWorkspace(
+            name: "Listener Commit Target \(UUID().uuidString.prefix(8))",
+            repoPaths: [],
+            ephemeral: true
+        )
+        let taskBox = WorkspaceSwitchTaskBox()
+        manager.addWorkspaceDidSwitchListener(label: "cancel-after-notification") { workspace in
+            guard workspace?.id == target.id else { return }
+            taskBox.task?.cancel()
+        }
+
+        let request = Task { @MainActor in
+            await manager.requestWorkspaceSwitch(
+                to: target,
+                saveState: false,
+                reason: "listenerCommitBoundary"
+            )
+        }
+        taskBox.task = request
+        let result = await request.value
+
+        XCTAssertEqual(result, .switched)
+        XCTAssertEqual(manager.activeWorkspaceID, target.id)
+        XCTAssertFalse(manager.isSwitchingWorkspace)
+    }
+
+    func testCancellationAfterUnloadRetainsOwnershipUntilFallbackRecoveryCompletes() async throws {
+        let root = try makeTemporaryDirectory(named: "OwnedFallbackRecovery")
+        defer { try? FileManager.default.removeItem(at: root) }
+        try "source".write(
+            to: root.appendingPathComponent("Source.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let sleeper = WorkspaceSwitchManualSleeper()
+        let store = WorkspaceFileContextStore(
+            unloadTerminationPolicy: WorkspaceRootUnloadTerminationPolicy(
+                publisherIngressGraceNanoseconds: 11,
+                watcherStopGraceNanoseconds: 22,
+                sleep: { nanoseconds in await sleeper.sleep(nanoseconds: nanoseconds) }
+            )
+        )
+        let composition = makeComposition(store: store)
+        let manager = composition.workspaceManager
+        await manager.awaitInitialized()
+        let fallbackID = try XCTUnwrap(manager.activeWorkspaceID)
+
+        let source = manager.createWorkspace(
+            name: "Owned Recovery Source \(UUID().uuidString.prefix(8))",
+            repoPaths: [root.path],
+            ephemeral: true
+        )
+        let sourceSwitchResult = await manager.switchWorkspace(to: source, saveState: false)
+        XCTAssertTrue(sourceSwitchResult.didSwitch)
+        let loadedRoots = await store.roots()
+        let loadedRoot = try XCTUnwrap(loadedRoots.first)
+        try await store.startWatchingRoot(id: loadedRoot.id)
+
+        let watcherStopGate = WorkspaceSwitchRecoveryGate()
+        await store.setWatcherStopWillBeginHandler { observedRootID in
+            guard observedRootID == loadedRoot.id else { return }
+            await watcherStopGate.arriveAndWait()
+        }
+        let recoveryGate = WorkspaceSwitchRecoveryGate()
+        manager.setWorkspaceSwitchRecoveryWillBeginHandlerForTesting {
+            await recoveryGate.arriveAndWait()
+        }
+
+        let target = manager.createWorkspace(
+            name: "Owned Recovery Target \(UUID().uuidString.prefix(8))",
+            repoPaths: [],
+            ephemeral: true
+        )
+        let competingTarget = manager.createWorkspace(
+            name: "Owned Recovery Competitor \(UUID().uuidString.prefix(8))",
+            repoPaths: [],
+            ephemeral: true
+        )
+        let request = Task { @MainActor in
+            await manager.requestWorkspaceSwitch(
+                to: target,
+                saveState: true,
+                reason: "ownedFallbackRecovery"
+            )
+        }
+        try await waitUntil { manager.activeWorkspaceSwitch?.phase == .unloadingRoots }
+        let operationID = try XCTUnwrap(manager.activeWorkspaceSwitch?.operationID)
+        await watcherStopGate.waitUntilArrived()
+        await sleeper.waitUntilSleeping(nanoseconds: 22)
+
+        await manager.cancelCurrentWorkspaceSwitchAndReturnToSystem()
+        await sleeper.release(nanoseconds: 22)
+        await recoveryGate.waitUntilArrived()
+
+        XCTAssertTrue(manager.isSwitchingWorkspace)
+        XCTAssertEqual(manager.activeWorkspaceSwitch?.operationID, operationID)
+        let competingResult = await manager.requestWorkspaceSwitch(
+            to: competingTarget,
+            saveState: false,
+            reason: "competingDuringRecovery"
+        )
+        guard case .blocked = competingResult else {
+            return XCTFail("Expected recovery ownership to block a newer switch")
+        }
+
+        await recoveryGate.release()
+        let result = await request.value
+        guard case .cancelled = result else {
+            return XCTFail("Expected the original pre-commit request to report cancellation after recovery")
+        }
+        XCTAssertEqual(manager.activeWorkspaceID, fallbackID)
+        XCTAssertFalse(manager.isSwitchingWorkspace)
+        XCTAssertNil(manager.activeWorkspaceSwitch)
+
+        await watcherStopGate.release()
+        manager.setWorkspaceSwitchRecoveryWillBeginHandlerForTesting(nil)
+        await store.setWatcherStopWillBeginHandler(nil)
+    }
+
+    func testSameIDReloadCancellationAfterUnloadRecoversToFallback() async throws {
+        let rootA = try makeTemporaryDirectory(named: "SameIDCancelRootA")
+        let rootB = try makeTemporaryDirectory(named: "SameIDCancelRootB")
+        defer {
+            try? FileManager.default.removeItem(at: rootA)
+            try? FileManager.default.removeItem(at: rootB)
+        }
+        try "a".write(to: rootA.appendingPathComponent("A.swift"), atomically: true, encoding: .utf8)
+        try "b".write(to: rootB.appendingPathComponent("B.swift"), atomically: true, encoding: .utf8)
+
+        let store = WorkspaceFileContextStore()
+        let composition = makeComposition(store: store)
+        let manager = composition.workspaceManager
+        await manager.awaitInitialized()
+        let fallbackID = try XCTUnwrap(manager.activeWorkspaceID)
+        let active = manager.createWorkspace(
+            name: "Same ID Cancellation \(UUID().uuidString.prefix(8))",
+            repoPaths: [rootA.path],
+            ephemeral: true
+        )
+        let activationResult = await manager.switchWorkspace(to: active, saveState: false)
+        XCTAssertTrue(activationResult.didSwitch)
+
+        var replacement = active
+        replacement.repoPaths = [rootB.path]
+        let replacementIndex = try XCTUnwrap(manager.workspaces.firstIndex(where: { $0.id == active.id }))
+        manager.workspaces[replacementIndex] = replacement
+
+        let unloadGate = WorkspaceSwitchRecoveryGate()
+        await store.setRootUnloadDidDetachHandler { paths in
+            guard paths.contains(rootA.path) else { return }
+            await unloadGate.arriveAndWait()
+        }
+        let request = Task { @MainActor in
+            await manager.reactivateWorkspaceAfterReplacement(
+                replacement,
+                reason: "sameIDCancellationAfterUnload"
+            )
+        }
+        await unloadGate.waitUntilArrived()
+        _ = try XCTUnwrap(manager.activeWorkspaceSwitch?.operationID)
+
+        request.cancel()
+        await unloadGate.release()
+        let result = await request.value
+
+        guard case .cancelled = result else {
+            return XCTFail("Expected same-ID reload cancellation to remain the caller-visible result")
+        }
+        XCTAssertEqual(manager.activeWorkspaceID, fallbackID)
+        XCTAssertFalse(manager.isSwitchingWorkspace)
+        XCTAssertNil(manager.activeWorkspaceSwitch)
+        let roots = await store.roots()
+        XCTAssertTrue(roots.isEmpty)
+        await store.setRootUnloadDidDetachHandler(nil)
+    }
+
+    func testMissingTargetAfterUnloadRecoversPreviousWorkspaceBeforeReturningBlocked() async throws {
+        let root = try makeTemporaryDirectory(named: "BlockedAfterUnloadSource")
+        defer { try? FileManager.default.removeItem(at: root) }
+        try "source".write(
+            to: root.appendingPathComponent("Source.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let store = WorkspaceFileContextStore()
+        let composition = makeComposition(store: store)
+        let manager = composition.workspaceManager
+        await manager.awaitInitialized()
+        let source = manager.createWorkspace(
+            name: "Blocked Recovery Source \(UUID().uuidString.prefix(8))",
+            repoPaths: [root.path],
+            ephemeral: true
+        )
+        let sourceActivationResult = await manager.switchWorkspace(to: source, saveState: false)
+        XCTAssertTrue(sourceActivationResult.didSwitch)
+
+        let missingTarget = WorkspaceModel(
+            name: "Missing Recovery Target \(UUID().uuidString.prefix(8))",
+            repoPaths: [],
+            ephemeralFlag: true
+        )
+        let result = await manager.switchWorkspace(
+            to: missingTarget,
+            saveState: true,
+            reason: "missingTargetAfterUnload"
+        )
+
+        guard case let .blocked(message) = result else {
+            return XCTFail("Expected missing target to remain blocked after recovery")
+        }
+        XCTAssertTrue(message.contains("workspace file is missing"))
+        XCTAssertEqual(manager.activeWorkspaceID, source.id)
+        XCTAssertFalse(manager.isSwitchingWorkspace)
+        XCTAssertNil(manager.activeWorkspaceSwitch)
+        let roots = await store.roots()
+        XCTAssertEqual(roots.map(\.standardizedFullPath), [root.standardizedFileURL.path])
+    }
+
+    func testSuccessfulOwningSwitchClearsItsConcurrentBlockedNotice() async throws {
+        let root = try makeTemporaryDirectory(named: "OwningNoticeSource")
+        defer { try? FileManager.default.removeItem(at: root) }
+        try "source".write(
+            to: root.appendingPathComponent("Source.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let store = WorkspaceFileContextStore()
+        let composition = makeComposition(store: store)
+        let manager = composition.workspaceManager
+        await manager.awaitInitialized()
+        let source = manager.createWorkspace(
+            name: "Owning Notice Source \(UUID().uuidString.prefix(8))",
+            repoPaths: [root.path],
+            ephemeral: true
+        )
+        let sourceActivationResult = await manager.switchWorkspace(to: source, saveState: false)
+        XCTAssertTrue(sourceActivationResult.didSwitch)
+
+        let unloadGate = WorkspaceSwitchRecoveryGate()
+        await store.setRootUnloadDidDetachHandler { paths in
+            guard paths.contains(root.path) else { return }
+            await unloadGate.arriveAndWait()
+        }
+        let target = manager.createWorkspace(
+            name: "Owning Notice Target \(UUID().uuidString.prefix(8))",
+            repoPaths: [],
+            ephemeral: true
+        )
+        let owner = Task { @MainActor in
+            await manager.requestWorkspaceSwitch(
+                to: target,
+                saveState: true,
+                reason: "owningNoticeSwitch"
+            )
+        }
+        await unloadGate.waitUntilArrived()
+        let owningOperationID = try XCTUnwrap(manager.activeWorkspaceSwitch?.operationID)
+
+        let repeated = await manager.requestWorkspaceSwitch(
+            to: target,
+            saveState: false,
+            reason: "blockedByOwningNoticeSwitch"
+        )
+        guard case .blocked = repeated else {
+            return XCTFail("Expected repeated request to publish a blocked notice")
+        }
+        let relatedNotice = try XCTUnwrap(manager.pendingWorkspaceSwitchBlockedNotice)
+        XCTAssertEqual(relatedNotice.blockingOperationID, owningOperationID)
+
+        await unloadGate.release()
+        let ownerResult = await owner.value
+        XCTAssertEqual(ownerResult, .switched)
+        XCTAssertNil(manager.pendingWorkspaceSwitchBlockedNotice)
+        await store.setRootUnloadDidDetachHandler(nil)
+    }
+
+    func testReactivatingReplacedActiveWorkspaceReloadsSameIDRoots() async throws {
+        let rootA = try makeTemporaryDirectory(named: "SameIDRootA")
+        let rootB = try makeTemporaryDirectory(named: "SameIDRootB")
+        defer {
+            try? FileManager.default.removeItem(at: rootA)
+            try? FileManager.default.removeItem(at: rootB)
+        }
+        try "a".write(to: rootA.appendingPathComponent("A.swift"), atomically: true, encoding: .utf8)
+        try "b".write(to: rootB.appendingPathComponent("B.swift"), atomically: true, encoding: .utf8)
+
+        let store = WorkspaceFileContextStore()
+        let composition = makeComposition(store: store)
+        let manager = composition.workspaceManager
+        await manager.awaitInitialized()
+        let active = manager.createWorkspace(
+            name: "Same ID Reload \(UUID().uuidString.prefix(8))",
+            repoPaths: [rootA.path],
+            ephemeral: true
+        )
+        let activationResult = await manager.switchWorkspace(to: active, saveState: false)
+        XCTAssertTrue(activationResult.didSwitch)
+
+        var replacement = active
+        replacement.repoPaths = [rootB.path]
+        let replacementIndex = try XCTUnwrap(manager.workspaces.firstIndex(where: { $0.id == active.id }))
+        manager.workspaces[replacementIndex] = replacement
+
+        let result = await manager.reactivateWorkspaceAfterReplacement(replacement)
+        XCTAssertEqual(result, .switched)
+        XCTAssertEqual(manager.activeWorkspaceID, replacement.id)
+        let roots = await store.roots()
+        XCTAssertEqual(roots.map(\.standardizedFullPath), [rootB.standardizedFileURL.path])
+    }
+
+    func testSessionCancellationAdvancesBackToPreparationBeforeSwitchCleanup() async throws {
+        let composition = makeComposition()
+        let manager = composition.workspaceManager
+        await manager.awaitInitialized()
+        let cancellationGate = WorkspaceSwitchRecoveryGate()
+        manager.registerSwitchSessionProvider(GatedWorkspaceSwitchSessionProvider(gate: cancellationGate))
+        var phases: [WorkspaceSwitchPhase] = []
+        manager.setWorkspaceSwitchPhaseDidChangeHandlerForTesting { phases.append($0) }
+
+        let target = manager.createWorkspace(
+            name: "Phase Target \(UUID().uuidString.prefix(8))",
+            repoPaths: [],
+            ephemeral: true
+        )
+        let request = Task { @MainActor in
+            await manager.requestWorkspaceSwitch(
+                to: target,
+                saveState: false,
+                reason: "phaseAfterCancellation"
+            )
+        }
+        try await waitUntil { manager.pendingSwitchConfirmation != nil }
+        let confirmationID = try XCTUnwrap(manager.pendingSwitchConfirmation?.id)
+        manager.resolveSwitchConfirmation(id: confirmationID, allow: true)
+        await cancellationGate.waitUntilArrived()
+        XCTAssertEqual(manager.activeWorkspaceSwitch?.phase, .cancellingSessions)
+        await cancellationGate.release()
+
+        let switchResult = await request.value
+        XCTAssertEqual(switchResult, .switched)
+        let cancellingIndex = try XCTUnwrap(phases.firstIndex(of: .cancellingSessions))
+        XCTAssertGreaterThan(phases.count, cancellingIndex + 1)
+        XCTAssertEqual(phases[cancellingIndex + 1], .preparing)
+        manager.setWorkspaceSwitchPhaseDidChangeHandlerForTesting(nil)
+    }
+
+    private func makeComposition(
+        store: WorkspaceFileContextStore = WorkspaceFileContextStore(),
+        timingPolicy: WorkspaceSwitchTimingPolicy = .production
+    ) -> WindowStateComposition {
+        let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
+        GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
+        defer { GlobalSettingsStore.shared.setMCPAutoStart(previousAutoStart, commit: false) }
+        return WindowStateCompositionFactory.make(
+            windowID: -900 - Int.random(in: 1 ... 99),
+            deferredInitialAgentSystemWorkspaceRefresh: true,
+            sharedMCPService: MCPService(),
+            workspaceFileContextStore: store,
+            workspaceSwitchTimingPolicy: timingPolicy
+        )
+    }
+
+    private func makeTemporaryDirectory(named name: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("WorkspaceSwitchRecoveryTests-\(UUID().uuidString)")
+            .appendingPathComponent(name)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url.standardizedFileURL
+    }
+
+    private func waitUntil(
+        timeout: TimeInterval = 3,
+        file: StaticString = #filePath,
+        line: UInt = #line,
+        _ condition: @escaping @MainActor () -> Bool
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if condition() { return }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTFail("Timed out waiting for condition", file: file, line: line)
+    }
+}
+
+@MainActor
+private final class StickyBusyWorkspaceSwitchSessionProvider: WorkspaceSwitchSessionProvider {
+    private weak var workspaceManager: WorkspaceManagerViewModel?
+    private var cancellations = 0
+
+    init(workspaceManager: WorkspaceManagerViewModel) {
+        self.workspaceManager = workspaceManager
+    }
+
+    func switchSessionItems() -> [WorkspaceSwitchSessionItem] {
+        [WorkspaceSwitchSessionItem(
+            id: "sticky",
+            count: 1,
+            singularLabel: "sticky session",
+            pluralLabel: "sticky sessions"
+        )]
+    }
+
+    func cancelSwitchSessions() async {
+        cancellations += 1
+        workspaceManager?.isChatBusy = true
+    }
+
+    func cancelCount() -> Int {
+        cancellations
+    }
+}
+
+@MainActor
+private final class StaticWorkspaceSwitchSessionProvider: WorkspaceSwitchSessionProvider {
+    func switchSessionItems() -> [WorkspaceSwitchSessionItem] {
+        [WorkspaceSwitchSessionItem(
+            id: "static",
+            count: 1,
+            singularLabel: "static session",
+            pluralLabel: "static sessions"
+        )]
+    }
+
+    func cancelSwitchSessions() async {}
+}
+
+@MainActor
+private final class GatedWorkspaceSwitchSessionProvider: WorkspaceSwitchSessionProvider {
+    private let gate: WorkspaceSwitchRecoveryGate
+
+    init(gate: WorkspaceSwitchRecoveryGate) {
+        self.gate = gate
+    }
+
+    func switchSessionItems() -> [WorkspaceSwitchSessionItem] {
+        [WorkspaceSwitchSessionItem(
+            id: "gated",
+            count: 1,
+            singularLabel: "gated session",
+            pluralLabel: "gated sessions"
+        )]
+    }
+
+    func cancelSwitchSessions() async {
+        await gate.arriveAndWait()
+    }
+}
+
+@MainActor
+private final class WorkspaceSwitchTaskBox {
+    var task: Task<WorkspaceSwitchResult, Never>?
+}
+
+private final class WorkspaceSwitchTestClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: Date
+
+    init(now: Date) {
+        value = now
+    }
+
+    func now() -> Date {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
+    }
+
+    func advance(by interval: TimeInterval) {
+        lock.lock()
+        value = value.addingTimeInterval(interval)
+        lock.unlock()
+    }
+}
+
+private actor WorkspaceSwitchManualSleeper {
+    private struct Waiter {
+        let continuation: CheckedContinuation<Void, Never>
+    }
+
+    private var waitersByNanoseconds: [UInt64: [UUID: Waiter]] = [:]
+    private var registrationWaitersByNanoseconds: [UInt64: [CheckedContinuation<Void, Never>]] = [:]
+    private var releasedNanoseconds: Set<UInt64> = []
+    private var cancelledWaiterIDs: Set<UUID> = []
+
+    func sleep(nanoseconds: UInt64) async {
+        if releasedNanoseconds.contains(nanoseconds) { return }
+        let waiterID = UUID()
+        await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                if Task.isCancelled || cancelledWaiterIDs.remove(waiterID) != nil || releasedNanoseconds.contains(nanoseconds) {
+                    continuation.resume()
+                    return
+                }
+                waitersByNanoseconds[nanoseconds, default: [:]][waiterID] = Waiter(continuation: continuation)
+                let registrationWaiters = registrationWaitersByNanoseconds.removeValue(forKey: nanoseconds) ?? []
+                registrationWaiters.forEach { $0.resume() }
+            }
+        } onCancel: {
+            Task { await self.cancel(waiterID: waiterID, nanoseconds: nanoseconds) }
+        }
+    }
+
+    func waitUntilSleeping(nanoseconds: UInt64) async {
+        guard waitersByNanoseconds[nanoseconds]?.isEmpty != false else { return }
+        await withCheckedContinuation { continuation in
+            registrationWaitersByNanoseconds[nanoseconds, default: []].append(continuation)
+        }
+    }
+
+    func release(nanoseconds: UInt64) {
+        releasedNanoseconds.insert(nanoseconds)
+        let waiters = waitersByNanoseconds.removeValue(forKey: nanoseconds) ?? [:]
+        waiters.values.forEach { $0.continuation.resume() }
+        let registrationWaiters = registrationWaitersByNanoseconds.removeValue(forKey: nanoseconds) ?? []
+        registrationWaiters.forEach { $0.resume() }
+    }
+
+    private func cancel(waiterID: UUID, nanoseconds: UInt64) {
+        guard let waiter = waitersByNanoseconds[nanoseconds]?.removeValue(forKey: waiterID) else {
+            cancelledWaiterIDs.insert(waiterID)
+            return
+        }
+        if waitersByNanoseconds[nanoseconds]?.isEmpty == true {
+            waitersByNanoseconds.removeValue(forKey: nanoseconds)
+        }
+        waiter.continuation.resume()
+    }
+}
+
+private actor WorkspaceSwitchRecoveryGate {
+    private var arrived = false
+    private var completed = false
+    private var releaseContinuation: CheckedContinuation<Void, Never>?
+    private var arrivalContinuations: [CheckedContinuation<Void, Never>] = []
+    private var completionContinuations: [CheckedContinuation<Void, Never>] = []
+
+    func arriveAndWait() async {
+        arrived = true
+        let continuations = arrivalContinuations
+        arrivalContinuations.removeAll()
+        continuations.forEach { $0.resume() }
+        await withCheckedContinuation { continuation in
+            releaseContinuation = continuation
+        }
+        completed = true
+        let completionWaiters = completionContinuations
+        completionContinuations.removeAll()
+        completionWaiters.forEach { $0.resume() }
+    }
+
+    func waitUntilArrived() async {
+        if arrived { return }
+        await withCheckedContinuation { continuation in
+            arrivalContinuations.append(continuation)
+        }
+    }
+
+    func waitUntilCompleted() async {
+        if completed { return }
+        await withCheckedContinuation { continuation in
+            completionContinuations.append(continuation)
+        }
+    }
+
+    func release() {
+        releaseContinuation?.resume()
+        releaseContinuation = nil
+    }
+}

--- a/Tests/RepoPromptTests/Workspaces/WorkspaceSwitchRecoveryTests.swift
+++ b/Tests/RepoPromptTests/Workspaces/WorkspaceSwitchRecoveryTests.swift
@@ -264,6 +264,10 @@ final class WorkspaceSwitchRecoveryTests: XCTestCase {
             return XCTFail("Expected save-and-exit on the fallback workspace to return request blockage")
         }
         XCTAssertEqual(message, "Already on workspace \"\(activeName)\".")
+        XCTAssertNil(
+            manager.pendingWorkspaceSwitchBlockedNotice,
+            "Save-and-exit while already on the fallback workspace is a benign no-op and must stay silent"
+        )
     }
 
     func testCancellationRequestedBySwitchListenerAfterNotificationReturnsSwitched() async {


### PR DESCRIPTION
## Summary

- isolate `file_search` in a dedicated serialized per-connection lane so long searches no longer block unrelated same-connection tools
- harden MCP admission, eviction, replacement handoff, execution ownership, cancellation, diagnostics, and watchdog lifecycle behavior
- move broad-search admission ahead of freshness work and coalesce freshness successors to one pending maximum target
- bound workspace-root unload teardown, fence late ingress/watcher completions, and recover/report blocked or stale workspace switches
- apply an argument-aware 120-second watchdog only to switch-producing `manage_workspaces` operations

## TDD coverage

The change was developed red-first with deterministic regressions for:

- same-connection search head-of-line blocking and search serialization
- admission/eviction/replacement identity and lifecycle races
- cross-connection active-tool ownership and cancellation races
- freshness admission ordering and successor-flight coalescing
- wedged publisher ingress and late completion after root recreation
- workspace switch cancellation, recovery, stale blockage, busy settling, and presentation
- cooperative and uncooperative workspace-switch MCP watchdog behavior

## Validation

- full coordinated test suite: 1,373 passed, 1 skipped, 0 failures
- `make dev-lint`: passed, 0 violations
- `make dev-swift-build PRODUCT=RepoPrompt`: passed
- `make dev-swift-build PRODUCT=repoprompt-mcp`: passed
- `make dev-smoke`: passed
- contribution commit and push preflights: passed
- staged/outgoing secret scans: clean
