### PR TITLE
fix(mcp): make diagnostic stderr writes best-effort

### DIFF
--- a/Sources/RepoPrompt/Features/Diagnostics/MCP/MCPToolExecutionDiagnostics.swift
+++ b/Sources/RepoPrompt/Features/Diagnostics/MCP/MCPToolExecutionDiagnostics.swift
@@ -1,4 +1,5 @@
 import Foundation
+import RepoPromptShared
 
 struct MCPToolExecutionTraceEvent: Equatable, CustomStringConvertible {
     enum Phase: String {
@@ -81,10 +82,8 @@ enum MCPToolExecutionTracer {
         sink?(event)
 
         guard event.isAlwaysEmitted || successTracingEnabled else { return }
-        guard let data = "[MCPToolExecution] \(event)\n".data(using: .utf8) else { return }
-        state.lock.lock()
-        FileHandle.standardError.write(data)
-        state.lock.unlock()
+        let data = Data("[MCPToolExecution] \(event)\n".utf8)
+        MCPBestEffortRawFDWriter.write(data)
     }
 
     #if DEBUG

--- a/Sources/RepoPromptMCP/main.swift
+++ b/Sources/RepoPromptMCP/main.swift
@@ -1043,7 +1043,7 @@ extension BootstrapSocketProxy {
                 ) { framed in
                     // Progress notifications are an intentional stderr-only control surface.
                     if let progressMessage = Self.extractProgressMessage(from: framed) {
-                        FileHandle.standardError.write("[progress] \(progressMessage)\n".data(using: .utf8)!)
+                        MCPBestEffortRawFDWriter.write(Data("[progress] \(progressMessage)\n".utf8))
                         return
                     }
                     do {

--- a/Sources/RepoPromptShared/MCP/JSONRPCBridgeLedger.swift
+++ b/Sources/RepoPromptShared/MCP/JSONRPCBridgeLedger.swift
@@ -142,8 +142,6 @@ public struct MCPResponseDeliveryTraceEvent: Equatable, Sendable, CustomStringCo
 }
 
 public enum MCPResponseDeliveryTracer {
-    private static let lock = NSLock()
-
     public static var successTracingEnabled: Bool {
         #if DEBUG
             ProcessInfo.processInfo.environment["REPOPROMPT_MCP_RESPONSE_TRACE"] == "1"
@@ -155,10 +153,8 @@ public enum MCPResponseDeliveryTracer {
 
     public static func emit(_ event: MCPResponseDeliveryTraceEvent) {
         guard event.terminalReason != nil || successTracingEnabled else { return }
-        guard let data = "[MCPResponseDelivery] \(event)\n".data(using: .utf8) else { return }
-        lock.lock()
-        FileHandle.standardError.write(data)
-        lock.unlock()
+        let data = Data("[MCPResponseDelivery] \(event)\n".utf8)
+        MCPBestEffortRawFDWriter.write(data)
     }
 
     public static func sha256Hex(_ data: Data) -> String {

--- a/Sources/RepoPromptShared/MCP/MCPBestEffortRawFDWriter.swift
+++ b/Sources/RepoPromptShared/MCP/MCPBestEffortRawFDWriter.swift
@@ -1,18 +1,38 @@
-import Darwin
 import Foundation
+#if canImport(Darwin)
+    import Darwin
+#elseif canImport(Glibc)
+    import Glibc
+#endif
 
+/// Best-effort raw file-descriptor writer for small MCP diagnostic messages.
+///
+/// This is intentionally for stderr-style diagnostics only, not protocol payload
+/// delivery. It serializes writes so diagnostic lines do not interleave, retries a
+/// bounded number of `EINTR` failures, and drops the remaining data on any other
+/// write failure or closed descriptor.
 public enum MCPBestEffortRawFDWriter {
     typealias RawWrite = (Int32, UnsafeRawPointer?, Int) -> Int
 
+    // Keep the lock around the whole small diagnostic write to preserve line
+    // ordering. Callers should use protocol-specific writers for large payloads.
     private static let lock = NSLock()
     private static let maxConsecutiveInterrupts = 16
 
+    /// Writes diagnostic data to stderr on a best-effort basis.
+    ///
+    /// The call never throws. If stderr is unavailable or a write fails, remaining
+    /// bytes are dropped after bounded `EINTR` retries.
     public static func write(_ data: Data) {
         write(data, to: STDERR_FILENO)
     }
 
+    /// Writes diagnostic data to the supplied file descriptor on a best-effort basis.
+    ///
+    /// This is intended for small diagnostic stderr-style output. Partial writes are
+    /// completed when possible; closed or failing descriptors drop remaining bytes.
     public static func write(_ data: Data, to fd: Int32) {
-        write(data, to: fd, rawWrite: Darwin.write)
+        write(data, to: fd, rawWrite: platformWrite)
     }
 
     static func write(
@@ -25,7 +45,7 @@ public enum MCPBestEffortRawFDWriter {
         lock.lock()
         defer { lock.unlock() }
 
-        _ = fcntl(fd, F_SETNOSIGPIPE, 1)
+        configureNoSigPipeIfAvailable(fd)
 
         data.withUnsafeBytes { buffer in
             guard let baseAddress = buffer.baseAddress else { return }
@@ -59,5 +79,23 @@ public enum MCPBestEffortRawFDWriter {
                 return
             }
         }
+    }
+
+    private static func platformWrite(_ fd: Int32, _ pointer: UnsafeRawPointer?, _ count: Int) -> Int {
+        #if canImport(Darwin)
+            Darwin.write(fd, pointer, count)
+        #elseif canImport(Glibc)
+            Glibc.write(fd, pointer, count)
+        #else
+            -1
+        #endif
+    }
+
+    private static func configureNoSigPipeIfAvailable(_ fd: Int32) {
+        #if canImport(Darwin)
+            _ = fcntl(fd, F_SETNOSIGPIPE, 1)
+        #else
+            _ = fd
+        #endif
     }
 }

--- a/Sources/RepoPromptShared/MCP/MCPBestEffortRawFDWriter.swift
+++ b/Sources/RepoPromptShared/MCP/MCPBestEffortRawFDWriter.swift
@@ -1,0 +1,63 @@
+import Darwin
+import Foundation
+
+public enum MCPBestEffortRawFDWriter {
+    typealias RawWrite = (Int32, UnsafeRawPointer?, Int) -> Int
+
+    private static let lock = NSLock()
+    private static let maxConsecutiveInterrupts = 16
+
+    public static func write(_ data: Data) {
+        write(data, to: STDERR_FILENO)
+    }
+
+    public static func write(_ data: Data, to fd: Int32) {
+        write(data, to: fd, rawWrite: Darwin.write)
+    }
+
+    static func write(
+        _ data: Data,
+        to fd: Int32,
+        rawWrite: RawWrite
+    ) {
+        guard fd >= 0, !data.isEmpty else { return }
+
+        lock.lock()
+        defer { lock.unlock() }
+
+        _ = fcntl(fd, F_SETNOSIGPIPE, 1)
+
+        data.withUnsafeBytes { buffer in
+            guard let baseAddress = buffer.baseAddress else { return }
+
+            var offset = 0
+            var consecutiveInterrupts = 0
+
+            while offset < data.count {
+                let written = rawWrite(
+                    fd,
+                    baseAddress.advanced(by: offset),
+                    data.count - offset
+                )
+
+                if written > 0 {
+                    offset += written
+                    consecutiveInterrupts = 0
+                    continue
+                }
+
+                if written == 0 {
+                    return
+                }
+
+                let err = errno
+                if err == EINTR, consecutiveInterrupts < maxConsecutiveInterrupts {
+                    consecutiveInterrupts += 1
+                    continue
+                }
+
+                return
+            }
+        }
+    }
+}

--- a/Tests/RepoPromptTests/MCP/Control/MCPDiagnosticStderrSafetyTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/MCPDiagnosticStderrSafetyTests.swift
@@ -1,0 +1,93 @@
+import Darwin
+import Foundation
+@testable import RepoPromptShared
+import XCTest
+
+final class MCPDiagnosticStderrSafetyTests: XCTestCase {
+    func testMCPDiagnosticStderrPathsUseBestEffortRawFDWriter() throws {
+        let rootURL = try RepoRoot.url()
+        let diagnosticSourcePaths = [
+            "Sources/RepoPromptShared/MCP/JSONRPCBridgeLedger.swift",
+            "Sources/RepoPromptMCP/main.swift"
+        ]
+
+        for relativePath in diagnosticSourcePaths {
+            let sourceURL = rootURL.appendingPathComponent(relativePath)
+            let source = try String(contentsOf: sourceURL, encoding: .utf8)
+
+            XCTAssertFalse(
+                source.contains("FileHandle.standardError.write"),
+                "\(relativePath) must not use FileHandle.standardError.write for MCP diagnostics; ObjC exceptions from closed stderr bypass Swift error handling."
+            )
+            XCTAssertTrue(
+                source.contains("MCPBestEffortRawFDWriter.write"),
+                "\(relativePath) should route MCP diagnostic stderr output through the best-effort raw FD writer."
+            )
+        }
+    }
+
+    func testClosedDiagnosticDescriptorIsDropped() {
+        var pipeFDs = [Int32](repeating: -1, count: 2)
+        XCTAssertEqual(pipe(&pipeFDs), 0)
+        defer { closeIfOpen(pipeFDs[0]) }
+
+        closeIfOpen(pipeFDs[1])
+
+        MCPBestEffortRawFDWriter.write(Data("dropped diagnostic\n".utf8), to: pipeFDs[1])
+    }
+
+    func testPartialDiagnosticWritesAreLooped() {
+        let payload = Data([1, 2, 3, 4, 5])
+        var observedFirstBytes: [UInt8] = []
+        var observedCounts: [Int] = []
+        let scriptedWrites = [2, 2, 1]
+
+        MCPBestEffortRawFDWriter.write(payload, to: 42) { _, pointer, count in
+            guard let pointer else {
+                XCTFail("Expected a non-nil write pointer")
+                return -1
+            }
+            let bytePointer = pointer.assumingMemoryBound(to: UInt8.self)
+            observedFirstBytes.append(bytePointer.pointee)
+            observedCounts.append(count)
+            return scriptedWrites[observedFirstBytes.count - 1]
+        }
+
+        XCTAssertEqual(observedFirstBytes, [1, 3, 5])
+        XCTAssertEqual(observedCounts, [5, 3, 1])
+    }
+
+    func testDiagnosticWriterRetriesEINTRThenDropsOnEPIPE() {
+        let payload = Data([1, 2, 3, 4, 5, 6])
+        var callKinds: [String] = []
+
+        MCPBestEffortRawFDWriter.write(payload, to: 42) { _, _, _ in
+            switch callKinds.count {
+            case 0:
+                callKinds.append("partial")
+                return 2
+            case 1:
+                callKinds.append("eintr")
+                errno = EINTR
+                return -1
+            case 2:
+                callKinds.append("success-after-eintr")
+                return 2
+            case 3:
+                callKinds.append("epipe")
+                errno = EPIPE
+                return -1
+            default:
+                XCTFail("Writer should stop after EPIPE")
+                return -1
+            }
+        }
+
+        XCTAssertEqual(callKinds, ["partial", "eintr", "success-after-eintr", "epipe"])
+    }
+
+    private func closeIfOpen(_ fd: Int32) {
+        guard fd >= 0 else { return }
+        _ = close(fd)
+    }
+}

--- a/Tests/RepoPromptTests/MCP/Control/MCPDiagnosticStderrSafetyTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/MCPDiagnosticStderrSafetyTests.swift
@@ -11,6 +11,7 @@ final class MCPDiagnosticStderrSafetyTests: XCTestCase {
     func testMCPDiagnosticStderrPathsUseBestEffortRawFDWriter() throws {
         let rootURL = try RepoRoot.url()
         let diagnosticSourcePaths = [
+            "Sources/RepoPrompt/Features/Diagnostics/MCP/MCPToolExecutionDiagnostics.swift",
             "Sources/RepoPromptShared/MCP/JSONRPCBridgeLedger.swift",
             "Sources/RepoPromptMCP/main.swift"
         ]

--- a/Tests/RepoPromptTests/MCP/Control/MCPDiagnosticStderrSafetyTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/MCPDiagnosticStderrSafetyTests.swift
@@ -1,7 +1,11 @@
-import Darwin
 import Foundation
 @testable import RepoPromptShared
 import XCTest
+#if canImport(Darwin)
+    import Darwin
+#elseif canImport(Glibc)
+    import Glibc
+#endif
 
 final class MCPDiagnosticStderrSafetyTests: XCTestCase {
     func testMCPDiagnosticStderrPathsUseBestEffortRawFDWriter() throws {
@@ -43,6 +47,11 @@ final class MCPDiagnosticStderrSafetyTests: XCTestCase {
         let scriptedWrites = [2, 2, 1]
 
         MCPBestEffortRawFDWriter.write(payload, to: 42) { _, pointer, count in
+            let callIndex = observedFirstBytes.count
+            guard callIndex < scriptedWrites.count else {
+                XCTFail("Writer should stop after scripted partial writes")
+                return -1
+            }
             guard let pointer else {
                 XCTFail("Expected a non-nil write pointer")
                 return -1
@@ -50,7 +59,7 @@ final class MCPDiagnosticStderrSafetyTests: XCTestCase {
             let bytePointer = pointer.assumingMemoryBound(to: UInt8.self)
             observedFirstBytes.append(bytePointer.pointee)
             observedCounts.append(count)
-            return scriptedWrites[observedFirstBytes.count - 1]
+            return scriptedWrites[callIndex]
         }
 
         XCTAssertEqual(observedFirstBytes, [1, 3, 5])


### PR DESCRIPTION
## Summary

- add `MCPBestEffortRawFDWriter`, a nonthrowing `Darwin.write`-based diagnostic FD writer for MCP stderr output
- route MCP response-delivery tracing and progress notifications through the best-effort writer instead of `FileHandle.standardError.write`
- add regression coverage for the unsafe callsites, closed descriptors, partial writes, and `EINTR`/`EPIPE` handling

Closes #157.

## Testing

- TDD red: added the source-invariant regression first; the repo `make dev-test FILTER=MCPDiagnosticStderrSafetyTests` path initially could not run because the default local toolchain hit Sparkle XCFramework `dSYMs` planning failure, and a source check confirmed the new invariant failed before production changes because both issue paths still used `FileHandle.standardError.write`.
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter MCPDiagnosticStderrSafetyTests`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter 'JSONRPCBridgeLedgerTests|PersistentMCPResponseDeliveryTests|MCPResponseSendDeadlineConfigurationTests|MCPSocketDescriptorHardeningTests'`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./conductor test --filter MCPDiagnosticStderrSafetyTests`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./conductor test --filter 'JSONRPCBridgeLedgerTests|PersistentMCPResponseDeliveryTests|MCPResponseSendDeadlineConfigurationTests|MCPSocketDescriptorHardeningTests'`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer make dev-swift-build PRODUCT=repoprompt-mcp`
- `make dev-format`
- `make dev-lint`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh commit`

Push preflight note: with `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer`, the scripted push preflight passed guardrails, outgoing gitleaks, and lint, then failed in the full root suite on unrelated Agent Mode/worktree tests (`AgentRunWorktreeStartTests` reports `rootAlreadyLoadedWithDifferentConfiguration` for temp roots; one `AgentModeStopSubmitTargetTests` timeout passed when rerun directly). The focused MCP suites above pass.