### PR TITLE
Make MCP transport stderr diagnostics crash-safe on closed pipes

### DIFF
--- a/Sources/RepoPrompt/Features/Diagnostics/MCP/MCPToolExecutionDiagnostics.swift
+++ b/Sources/RepoPrompt/Features/Diagnostics/MCP/MCPToolExecutionDiagnostics.swift
@@ -1,4 +1,5 @@
 import Foundation
+import RepoPromptShared
 
 struct MCPToolExecutionTraceEvent: Equatable, CustomStringConvertible {
     enum Phase: String {
@@ -83,8 +84,10 @@ enum MCPToolExecutionTracer {
         guard event.isAlwaysEmitted || successTracingEnabled else { return }
         guard let data = "[MCPToolExecution] \(event)\n".data(using: .utf8) else { return }
         state.lock.lock()
-        FileHandle.standardError.write(data)
-        state.lock.unlock()
+        defer { state.lock.unlock() }
+        // Best-effort raw write; FileHandle.write raises an uncatchable ObjC
+        // exception if stderr's pipe is already closed.
+        BestEffortStderrWriter.write(data)
     }
 
     #if DEBUG

--- a/Sources/RepoPromptMCP/main.swift
+++ b/Sources/RepoPromptMCP/main.swift
@@ -1042,8 +1042,16 @@ extension BootstrapSocketProxy {
                     faultRule: faultRule
                 ) { framed in
                     // Progress notifications are an intentional stderr-only control surface.
+                    // Delivery is best-effort: if the host closed stderr, drop the progress
+                    // line and keep the stdout transport alive rather than raising an ObjC
+                    // exception that would abort the helper mid-ledger-transaction.
                     if let progressMessage = Self.extractProgressMessage(from: framed) {
-                        FileHandle.standardError.write("[progress] \(progressMessage)\n".data(using: .utf8)!)
+                        let delivered = BestEffortStderrWriter.write(
+                            Data("[progress] \(progressMessage)\n".utf8)
+                        )
+                        if !delivered {
+                            debugLog("BootstrapSocketProxy: dropped progress output, stderr unavailable")
+                        }
                         return
                     }
                     do {

--- a/Sources/RepoPromptShared/MCP/BestEffortStderrWriter.swift
+++ b/Sources/RepoPromptShared/MCP/BestEffortStderrWriter.swift
@@ -1,0 +1,43 @@
+import Darwin
+import Darwin.POSIX.fcntl
+import Foundation
+
+/// Best-effort raw file-descriptor writer for diagnostic output on MCP stdio
+/// transports.
+///
+/// Foundation's `FileHandle.write(_:)` raises an Objective-C
+/// `NSFileHandleOperationException` when the descriptor is closed or the pipe
+/// is broken, and Swift `do/catch` cannot intercept that exception, so a
+/// failed diagnostic write aborts the whole process. Transport diagnostics
+/// must never be able to crash the MCP helper, so this writer uses
+/// `Darwin.write` directly, loops on partial writes, and silently drops the
+/// payload when the destination is unavailable (`EPIPE`, `EBADF`, `EINVAL`,
+/// or any other write failure).
+public enum BestEffortStderrWriter {
+    /// Writes `data` to `descriptor`, returning `true` only when every byte
+    /// was delivered. Never throws and never raises: any failure other than
+    /// an interrupted write drops the remaining payload.
+    @discardableResult
+    public static func write(_ data: Data, to descriptor: Int32 = STDERR_FILENO) -> Bool {
+        guard descriptor >= 0 else { return false }
+        guard !data.isEmpty else { return true }
+        // Suppress SIGPIPE on this descriptor so a peer-closed pipe surfaces
+        // as EPIPE from write(2) instead of terminating the process. Failure
+        // is acceptable: the write below still fails softly.
+        _ = fcntl(descriptor, F_SETNOSIGPIPE, 1)
+        return data.withUnsafeBytes { rawBuffer in
+            guard let baseAddress = rawBuffer.baseAddress else { return false }
+            var offset = 0
+            while offset < rawBuffer.count {
+                let written = Darwin.write(descriptor, baseAddress + offset, rawBuffer.count - offset)
+                if written > 0 {
+                    offset += written
+                    continue
+                }
+                if written < 0, errno == EINTR { continue }
+                return false
+            }
+            return true
+        }
+    }
+}

--- a/Sources/RepoPromptShared/MCP/JSONRPCBridgeLedger.swift
+++ b/Sources/RepoPromptShared/MCP/JSONRPCBridgeLedger.swift
@@ -153,12 +153,19 @@ public enum MCPResponseDeliveryTracer {
         #endif
     }
 
-    public static func emit(_ event: MCPResponseDeliveryTraceEvent) {
+    public static func emit(
+        _ event: MCPResponseDeliveryTraceEvent,
+        to descriptor: Int32 = STDERR_FILENO
+    ) {
         guard event.terminalReason != nil || successTracingEnabled else { return }
         guard let data = "[MCPResponseDelivery] \(event)\n".data(using: .utf8) else { return }
         lock.lock()
-        FileHandle.standardError.write(data)
-        lock.unlock()
+        defer { lock.unlock() }
+        // Terminal events are emitted even with success tracing disabled, so
+        // this path runs during transport failure handling when stderr may
+        // already be closed. Best-effort raw write; never FileHandle.write,
+        // whose ObjC exception on a broken pipe would abort the process.
+        BestEffortStderrWriter.write(data, to: descriptor)
     }
 
     public static func sha256Hex(_ data: Data) -> String {

--- a/Tests/RepoPromptTests/MCP/Control/MCPResponseDeliveryTracerSafetyTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/MCPResponseDeliveryTracerSafetyTests.swift
@@ -1,0 +1,134 @@
+import Darwin
+import Foundation
+import RepoPromptShared
+import XCTest
+
+/// Regression coverage for repoprompt-ce#157: diagnostic and progress stderr
+/// writes during transport failure handling must never abort the MCP helper,
+/// even when the host has already closed the pipe.
+final class MCPResponseDeliveryTracerSafetyTests: XCTestCase {
+    func testWriterDeliversAllBytesAcrossPartialWrites() throws {
+        let pipe = try makePipe()
+        // Larger than the kernel pipe buffer (64 KiB) so write(2) must return
+        // short counts and the writer has to loop.
+        let payload = Data(repeating: UInt8(ascii: "x"), count: 256 * 1024)
+
+        let readQueue = DispatchQueue(label: "tracer-safety-test-reader")
+        let readDone = expectation(description: "reader drained pipe")
+        nonisolated(unsafe) var received = Data()
+        readQueue.async {
+            var buffer = [UInt8](repeating: 0, count: 64 * 1024)
+            while received.count < payload.count {
+                let count = read(pipe.readFD, &buffer, buffer.count)
+                guard count > 0 else { break }
+                received.append(contentsOf: buffer[0 ..< count])
+            }
+            readDone.fulfill()
+        }
+
+        XCTAssertTrue(BestEffortStderrWriter.write(payload, to: pipe.writeFD))
+        wait(for: [readDone], timeout: 10)
+        close(pipe.readFD)
+        close(pipe.writeFD)
+        XCTAssertEqual(received, payload)
+    }
+
+    func testWriterDropsDataOnBrokenPipeWithoutRaising() throws {
+        let writeFD = try makeBrokenPipeWriteEnd()
+        defer { close(writeFD) }
+        XCTAssertFalse(BestEffortStderrWriter.write(Data("dropped\n".utf8), to: writeFD))
+    }
+
+    func testWriterDropsDataOnClosedDescriptorWithoutRaising() throws {
+        let pipe = try makePipe()
+        close(pipe.readFD)
+        close(pipe.writeFD)
+        XCTAssertFalse(BestEffortStderrWriter.write(Data("dropped\n".utf8), to: pipe.writeFD))
+    }
+
+    func testTerminalEmitWithBrokenStderrSinkDoesNotAbort() throws {
+        let writeFD = try makeBrokenPipeWriteEnd()
+        defer { close(writeFD) }
+        // Terminal events bypass the success-tracing gate, so this is the
+        // exact release-build path that previously crashed in
+        // FileHandle.writeData on a host disconnect.
+        MCPResponseDeliveryTracer.emit(
+            MCPResponseDeliveryTraceEvent(
+                layer: "proxy_ledger",
+                phase: "connection_terminal",
+                terminalReason: "host_disconnected"
+            ),
+            to: writeFD
+        )
+    }
+
+    func testRecordConnectionFailureWithFailingTraceOutputReturnsCleanly() async throws {
+        let writeFD = try makeBrokenPipeWriteEnd()
+        defer { close(writeFD) }
+
+        let ledger = JSONRPCBridgeLedger(traceSink: { event in
+            MCPResponseDeliveryTracer.emit(event, to: writeFD)
+        })
+        _ = try await ledger.beginConnection()
+        let prepared = try await ledger.prepare(
+            frame: line(#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#),
+            direction: .clientToServer
+        )
+        try await ledger.commit(prepared)
+
+        // Protocol-active connection failure emits a terminal trace event;
+        // with a broken sink it must return instead of crashing the process.
+        let isTerminal = await ledger.recordConnectionFailure("host_disconnected")
+        XCTAssertTrue(isTerminal)
+        let snapshot = await ledger.snapshot()
+        XCTAssertEqual(snapshot.terminalReason, "host_disconnected")
+    }
+
+    func testProgressWriteFailureDoesNotBypassLedgerAccounting() async throws {
+        let writeFD = try makeBrokenPipeWriteEnd()
+        defer { close(writeFD) }
+
+        let ledger = JSONRPCBridgeLedger()
+        _ = try await ledger.beginConnection()
+        let progressFrame =
+            line(#"{"jsonrpc":"2.0","method":"notifications/progress","params":{"progressToken":"t","progress":1}}"#)
+
+        // Mirrors the BootstrapSocketProxy progress branch: the stderr write
+        // fails best-effort and the writer returns normally, so forward(...)
+        // must still commit the frame instead of aborting the transaction.
+        let prepared = try await JSONRPCBridgeDelivery.forward(
+            frame: progressFrame,
+            direction: .serverToClient,
+            ledger: ledger
+        ) { framed in
+            XCTAssertFalse(BestEffortStderrWriter.write(framed, to: writeFD))
+        }
+        XCTAssertEqual(prepared.messages.map(\.kind), [.notification])
+
+        let snapshot = await ledger.snapshot()
+        XCTAssertNil(snapshot.terminalReason)
+        XCTAssertEqual(snapshot.pendingTransactionCount, 0)
+        XCTAssertEqual(snapshot.activeRequestCount, 0)
+        XCTAssertTrue(snapshot.hasForwardedProtocolFrame)
+    }
+}
+
+private extension MCPResponseDeliveryTracerSafetyTests {
+    func makePipe() throws -> (readFD: Int32, writeFD: Int32) {
+        var fds: [Int32] = [-1, -1]
+        guard pipe(&fds) == 0 else {
+            throw XCTSkip("pipe(2) failed with errno \(errno)")
+        }
+        return (fds[0], fds[1])
+    }
+
+    func makeBrokenPipeWriteEnd() throws -> Int32 {
+        let pipe = try makePipe()
+        close(pipe.readFD)
+        return pipe.writeFD
+    }
+
+    func line(_ string: String) -> Data {
+        Data((string + "\n").utf8)
+    }
+}


### PR DESCRIPTION
Fixes #157

## Problem

The per-connection `repoprompt-mcp` helper could abort with `SIGABRT` while handling transport failures: `MCPResponseDeliveryTracer.emit(_:)` and the `BootstrapSocketProxy` progress branch wrote diagnostics via `FileHandle.standardError.write(...)`, which raises an Objective-C `NSFileHandleOperationException` when the host has already closed the stderr pipe. Swift `do/catch` cannot intercept that exception, so the helper crashed instead of failing the transport cleanly — surfacing upstream only as a generic `transport closed`.

Terminal trace events bypass the success-tracing gate (`guard event.terminalReason != nil || successTracingEnabled`), so release builds hit this path during ordinary host-disconnect handling, e.g. `JSONRPCBridgeLedger.recordConnectionFailure` from `MCPService.runTransport()`.

## Fix

- **New `BestEffortStderrWriter`** in `Sources/RepoPromptShared/MCP`: a raw `Darwin.write`-based writer that loops on partial writes, retries `EINTR`, sets `F_SETNOSIGPIPE` on the descriptor, and drops the payload on `EPIPE`/`EBADF`/`EINVAL`/any other failure. It never throws and never raises.
- **`MCPResponseDeliveryTracer.emit`** now uses the safe writer and `defer`-based unlocking, with an injectable descriptor (default `STDERR_FILENO`) for regression testing.
- **Progress-notification branch** in `BootstrapSocketProxy.pumpSocketToStdout` is now explicitly best-effort: a failed stderr write drops the progress line (logged via the opt-in socket debug log) and keeps the stdout transport and ledger commit path intact, rather than aborting mid-`JSONRPCBridgeDelivery.forward(...)` transaction. Treating broken stderr as a transport failure was deliberately rejected: progress output is advisory, and the stdout response channel may still be fully healthy.
- **`MCPToolExecutionTracer`** (app-side) had the same hazard class and gets the same treatment.

## Tests

New `MCPResponseDeliveryTracerSafetyTests` covers the regression scenarios from the issue:

- writer delivers all bytes across partial writes (256 KiB through a 64 KiB pipe)
- writer drops data on broken pipe and closed descriptor without raising or SIGPIPE
- terminal `emit` with a broken stderr sink does not abort
- `recordConnectionFailure` in protocol-active state with failing trace output returns cleanly and records the terminal reason
- a failed progress-style stderr write does not bypass `JSONRPCBridgeDelivery.forward(...)` ledger accounting (frame still commits, no terminal reason)

## Validation

- `make dev-format` (no changes), `make dev-lint` (0 violations)
- `make dev-test FILTER=MCPResponseDeliveryTracerSafetyTests` — 6/6 pass
- `make dev-test FILTER=JSONRPCBridgeLedgerTests` — 21/21 pass
- Contribution preflight `commit` + `push` modes, including the full coordinated `swift test` suite and `RepoPrompt` / `repoprompt-mcp` product builds