### PR TITLE
Add local Developer ID production install path

### DIFF
--- a/AppBundle/Info.plist.template
+++ b/AppBundle/Info.plist.template
@@ -19,13 +19,13 @@
   <key>RepoPromptLocalSigningCertificateSHA256</key><string>__LOCAL_SIGNING_CERTIFICATE_SHA256__</string>
   <key>RepoPromptLocalSecureStorageGeneration</key><string>__LOCAL_SECURE_STORAGE_GENERATION__</string>
   <key>LSEnvironment</key><dict><key>REPOPROMPT_LAUNCH_SOURCE</key><string>launchservices</string></dict>
-  <key>CFBundleURLTypes</key><array><dict><key>CFBundleTypeRole</key><string>Viewer</string><key>CFBundleURLName</key><string>com.pvncher.repoprompt.ce</string><key>CFBundleURLSchemes</key><array><string>repoprompt-ce</string></array><key>CFBundleURLIconFile</key><string>AppIcon</string></dict></array>
+  <key>CFBundleURLTypes</key><array><dict><key>CFBundleTypeRole</key><string>Viewer</string><key>CFBundleURLName</key><string>__BUNDLE_ID__</string><key>CFBundleURLSchemes</key><array><string>__URL_SCHEME__</string></array><key>CFBundleURLIconFile</key><string>AppIcon</string></dict></array>
   <key>NSAppTransportSecurity</key><dict><key>NSAllowsArbitraryLoads</key><true/></dict>
-  <key>CFBundleDocumentTypes</key><array><dict><key>CFBundleTypeName</key><string>RepoPrompt CE Document</string><key>CFBundleTypeRole</key><string>Viewer</string><key>LSHandlerRank</key><string>Default</string><key>LSItemContentTypes</key><array><string>com.pvncher.repoprompt.ce.document</string></array></dict></array>
-  <key>UTExportedTypeDeclarations</key><array><dict><key>UTTypeIdentifier</key><string>com.pvncher.repoprompt.ce.document</string><key>UTTypeDescription</key><string>RepoPrompt CE Document</string><key>UTTypeConformsTo</key><array><string>public.data</string></array></dict></array>
+  <key>CFBundleDocumentTypes</key><array><dict><key>CFBundleTypeName</key><string>__DISPLAY_NAME__ Document</string><key>CFBundleTypeRole</key><string>Viewer</string><key>LSHandlerRank</key><string>Default</string><key>LSItemContentTypes</key><array><string>__BUNDLE_ID__.document</string></array></dict></array>
+  <key>UTExportedTypeDeclarations</key><array><dict><key>UTTypeIdentifier</key><string>__BUNDLE_ID__.document</string><key>UTTypeDescription</key><string>__DISPLAY_NAME__ Document</string><key>UTTypeConformsTo</key><array><string>public.data</string></array></dict></array>
   <key>SUFeedURL</key><string>https://github.com/repoprompt/repoprompt-ce-updates/releases/latest/download/appcast.xml</string>
   <key>SUPublicEDKey</key><string>845kp9v5+kp4U6no85H53cUdnbfN3NmE1PJHKwH8Pd4=</string>
-  <key>SUBundleName</key><string>RepoPrompt CE.app</string>
+  <key>SUBundleName</key><string>__DISPLAY_NAME__.app</string>
   <key>NSLocalNetworkUsageDescription</key><string>RepoPrompt CE needs local network access to enable MCP server functionality, allowing external tools to connect and interact with your workspace.</string>
   <key>NSBonjourServices</key><array><string>_preflight_check._tcp</string><string>_mcp._tcp</string></array>
 </dict>

--- a/README.md
+++ b/README.md
@@ -64,8 +64,9 @@ SIGN_IDENTITY="Apple Development: Your Name (TEAMID)" ./conductor app relaunch
 ```
 
 For a stable locally signed app under `/Applications`, use the local production
-installer below. Its self-signed identity is separate from the debug launcher's
-Apple Development signing path.
+installer below. It supports either the repository-managed self-signed local
+identity or your own paid Apple Developer `Developer ID Application` identity
+with a personal bundle identifier.
 
 > **Note:** If you use the debug app to modify RepoPrompt CE itself, validation
 > flows that launch the app or run live smoke checks may rebuild and relaunch it.
@@ -84,12 +85,33 @@ For a release-mode app under `/Applications`, install Python 3 and double-click
 [`Install RepoPrompt CE Local Production.command`](Install%20RepoPrompt%20CE%20Local%20Production.command)
 in Finder. The Finder launcher uses the coordinated developer daemon.
 
-The installer builds RepoPrompt CE from source and replaces any existing
+The default installer builds RepoPrompt CE from source and replaces any existing
 `/Applications/RepoPrompt CE.app` using a dedicated self-signed certificate
 trusted only on your Mac. macOS may ask you to approve the certificate.
 
-The resulting app is local-only. It is not notarized and should not be copied to
-another Mac or redistributed.
+Contributors with a paid Apple Developer account can instead install a personal
+Developer ID build with their own app name, bundle identifier, signing team, and
+persistent Keychain service. The installer requires a personal display name and
+bundle identifier so the installed app stays separate from debug builds and from
+upstream's public `com.pvncher.repoprompt.ce` identity:
+
+```bash
+CONFIRM_LOCAL_PRODUCTION_INSTALL=1 \
+LOCAL_PRODUCTION_SIGNING_MODE=developer-id \
+DISPLAY_NAME="My RepoPrompt CE" \
+BUNDLE_ID=com.example.repoprompt.ce \
+SIGNING_TEAM_ID=TEAMID1234 \
+SIGN_IDENTITY="Developer ID Application: Your Name (TEAMID1234)" \
+./Scripts/install_local_production.sh
+```
+
+Custom bundle identifiers receive a derived URL scheme so the personal app does
+not compete with the public app for `repoprompt-ce:` links. Set
+`REPOPROMPT_URL_SCHEME=my-repoprompt-ce` if you need a specific unique local
+scheme; local Developer ID packaging rejects the public `repoprompt-ce` scheme.
+
+Both local production modes are local-only. They are not notarized and should not
+be copied to another Mac or redistributed.
 
 ### Source-build requirements
 

--- a/Scripts/install_local_production.sh
+++ b/Scripts/install_local_production.sh
@@ -4,9 +4,20 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
+DISPLAY_NAME_OVERRIDE="${DISPLAY_NAME:-}"
+BUNDLE_ID_OVERRIDE="${BUNDLE_ID:-}"
+SIGNING_TEAM_ID_OVERRIDE="${SIGNING_TEAM_ID:-}"
+
 set -a
 source "$ROOT_DIR/version.env"
 set +a
+
+DEFAULT_DISPLAY_NAME="$DISPLAY_NAME"
+DEFAULT_BUNDLE_ID="$BUNDLE_ID"
+DISPLAY_NAME="${DISPLAY_NAME_OVERRIDE:-$DISPLAY_NAME}"
+BUNDLE_ID="${BUNDLE_ID_OVERRIDE:-$BUNDLE_ID}"
+SIGNING_TEAM_ID="${SIGNING_TEAM_ID_OVERRIDE:-$SIGNING_TEAM_ID}"
+LOCAL_PRODUCTION_SIGNING_MODE="${LOCAL_PRODUCTION_SIGNING_MODE:-self-signed}"
 
 LOCAL_SELF_SIGNED_CERTIFICATE_NAME="RepoPrompt CE Local Self-Signed Code Signing"
 LOCAL_PRODUCTION_INSTALL_DIR="${LOCAL_PRODUCTION_INSTALL_DIR:-/Applications}"
@@ -17,6 +28,7 @@ LOCAL_SIGNING_IDENTITY_SHA256="${LOCAL_SIGNING_IDENTITY_SHA256:-}"
 ROTATE_LOCAL_SIGNING_IDENTITY="${ROTATE_LOCAL_SIGNING_IDENTITY:-0}"
 LOCAL_SIGNING_IDENTITY_TOOL="$ROOT_DIR/Scripts/local_signing_identity.py"
 TMP_DIR=""
+APP_INSTALL_LOCK_DIR=""
 STAGED_DIR=""
 STAGED_APP=""
 BACKUP_DIR=""
@@ -62,6 +74,10 @@ cleanup() {
         rm -f "$REGISTRY_LOCK_DIR/pid"
         rmdir "$REGISTRY_LOCK_DIR" 2>/dev/null || true
     fi
+    if [[ -n "$APP_INSTALL_LOCK_DIR" ]]; then
+        rm -f "$APP_INSTALL_LOCK_DIR/pid"
+        rmdir "$APP_INSTALL_LOCK_DIR" 2>/dev/null || true
+    fi
     exit "$status"
 }
 trap cleanup EXIT
@@ -81,6 +97,17 @@ if isinstance(value, bool):
 elif value is not None:
     print(value)
 PY
+}
+
+running_local_production_app_exists() {
+    local expected_command="$LOCAL_PRODUCTION_APP/Contents/MacOS/$APP_NAME"
+    local command
+    while IFS= read -r command; do
+        case "$command" in
+            "$expected_command"|"$expected_command "*) return 0 ;;
+        esac
+    done < <(ps -axo command=)
+    return 1
 }
 
 inventory_local_identities() {
@@ -200,15 +227,99 @@ rollback_transaction() {
 [[ "${CONFIRM_LOCAL_PRODUCTION_INSTALL:-}" == "1" ]] ||
     fail "Set CONFIRM_LOCAL_PRODUCTION_INSTALL=1 to build and replace the local production app in $LOCAL_PRODUCTION_INSTALL_DIR."
 
+TRIMMED_DISPLAY_NAME="$(sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//' <<< "$DISPLAY_NAME")"
+NORMALIZED_BUNDLE_ID="$(tr '[:upper:]' '[:lower:]' <<< "$BUNDLE_ID")"
+NORMALIZED_DEFAULT_BUNDLE_ID="$(tr '[:upper:]' '[:lower:]' <<< "$DEFAULT_BUNDLE_ID")"
+NORMALIZED_DISPLAY_NAME="$(tr '[:upper:]' '[:lower:]' <<< "$TRIMMED_DISPLAY_NAME")"
+NORMALIZED_DEFAULT_DISPLAY_NAME="$(tr '[:upper:]' '[:lower:]' <<< "$DEFAULT_DISPLAY_NAME")"
+
+[[ "$APP_NAME" =~ ^[A-Za-z0-9._\ -]+$ ]] || fail "APP_NAME contains unsupported characters: $APP_NAME"
+[[ -n "$DISPLAY_NAME" && "$DISPLAY_NAME" == "$TRIMMED_DISPLAY_NAME" && "$DISPLAY_NAME" != */* ]] || fail "DISPLAY_NAME must be non-empty, trimmed, and must not contain '/'."
+[[ "$BUNDLE_ID" =~ ^[A-Za-z0-9]+([.-][A-Za-z0-9]+)*$ ]] || fail "BUNDLE_ID is not a valid bundle identifier: $BUNDLE_ID"
+[[ "$SIGNING_TEAM_ID" =~ ^[A-Z0-9]+$ ]] || fail "SIGNING_TEAM_ID must contain only uppercase letters and digits: $SIGNING_TEAM_ID"
+
 for command in codesign ditto openssl plutil python3 security shasum swift; do
     require_command "$command"
 done
-[[ -f "$LOCAL_SIGNING_IDENTITY_TOOL" ]] || fail "Missing local signing identity tool: $LOCAL_SIGNING_IDENTITY_TOOL"
+if [[ "$LOCAL_PRODUCTION_SIGNING_MODE" != "self-signed" && "$LOCAL_PRODUCTION_SIGNING_MODE" != "developer-id" ]]; then
+    fail "LOCAL_PRODUCTION_SIGNING_MODE must be 'self-signed' or 'developer-id', got '$LOCAL_PRODUCTION_SIGNING_MODE'."
+fi
+[[ "$LOCAL_PRODUCTION_SIGNING_MODE" != "self-signed" || -f "$LOCAL_SIGNING_IDENTITY_TOOL" ]] || fail "Missing local signing identity tool: $LOCAL_SIGNING_IDENTITY_TOOL"
 
 LOGIN_KEYCHAIN="$(security default-keychain -d user | sed -e 's/^[[:space:]]*"//' -e 's/"[[:space:]]*$//')"
 [[ -n "$LOGIN_KEYCHAIN" && -f "$LOGIN_KEYCHAIN" ]] || fail "Could not resolve the user's default login keychain."
 
 TMP_DIR="$(mktemp -d)"
+mkdir -p "$LOCAL_PRODUCTION_INSTALL_DIR"
+APP_INSTALL_LOCK_CANDIDATE="$LOCAL_PRODUCTION_INSTALL_DIR/.$DISPLAY_NAME.app.install.lock"
+mkdir "$APP_INSTALL_LOCK_CANDIDATE" 2>/dev/null || fail "Another local production install is active, or a stale lock must be inspected: $APP_INSTALL_LOCK_CANDIDATE"
+APP_INSTALL_LOCK_DIR="$APP_INSTALL_LOCK_CANDIDATE"
+chmod 700 "$APP_INSTALL_LOCK_DIR"
+printf '%s\n' "$$" > "$APP_INSTALL_LOCK_DIR/pid"
+chmod 600 "$APP_INSTALL_LOCK_DIR/pid"
+
+if [[ "$LOCAL_PRODUCTION_SIGNING_MODE" == "developer-id" ]]; then
+    [[ -n "${SIGN_IDENTITY:-}" ]] || fail "Developer ID local production install requires SIGN_IDENTITY."
+    [[ -n "$SIGNING_TEAM_ID" ]] || fail "Developer ID local production install requires SIGNING_TEAM_ID."
+    [[ "$NORMALIZED_BUNDLE_ID" != "$NORMALIZED_DEFAULT_BUNDLE_ID" && "$NORMALIZED_BUNDLE_ID" != "$NORMALIZED_DEFAULT_BUNDLE_ID.debug" ]] || fail "Developer ID local production installs require a personal BUNDLE_ID, not an upstream public/debug bundle identifier."
+    [[ "$NORMALIZED_DISPLAY_NAME" != "$NORMALIZED_DEFAULT_DISPLAY_NAME" ]] || fail "Developer ID local production installs require a personal DISPLAY_NAME, not the upstream public app name '$DEFAULT_DISPLAY_NAME'."
+    LOCAL_DEVELOPER_ID_RELEASE=1 \
+        DISPLAY_NAME="$DISPLAY_NAME" \
+        BUNDLE_ID="$BUNDLE_ID" \
+        SIGNING_TEAM_ID="$SIGNING_TEAM_ID" \
+        SIGN_IDENTITY="$SIGN_IDENTITY" \
+        "$ROOT_DIR/Scripts/package_app.sh" release
+
+    BUILD_DIR="$(swift build -c release --show-bin-path)"
+    SOURCE_APP="$BUILD_DIR/$APP_NAME.app"
+    [[ -d "$SOURCE_APP" ]] || fail "Missing packaged local Developer ID app: $SOURCE_APP"
+    [[ "$(plutil -extract CFBundleIdentifier raw "$SOURCE_APP/Contents/Info.plist")" == "$BUNDLE_ID" ]] ||
+        fail "Packaged app bundle identifier mismatch."
+    [[ "$(plutil -extract RepoPromptSigningMode raw "$SOURCE_APP/Contents/Info.plist")" == "local-developer-id" ]] ||
+        fail "Packaged app is missing the local Developer ID signing-mode marker."
+    LOCAL_DEVELOPER_ID_REQUIREMENT="anchor apple generic and identifier \"$BUNDLE_ID\" and certificate leaf[subject.OU] = \"$SIGNING_TEAM_ID\" and certificate leaf[field.1.2.840.113635.100.6.1.13] exists"
+    codesign --verify --deep --strict --verbose=2 "$SOURCE_APP"
+    codesign --verify --deep --strict --verbose=2 -R="$LOCAL_DEVELOPER_ID_REQUIREMENT" "$SOURCE_APP"
+
+    if running_local_production_app_exists; then
+        fail "Quit $DISPLAY_NAME before replacing $LOCAL_PRODUCTION_APP."
+    fi
+
+    STAGED_DIR="$(mktemp -d "$LOCAL_PRODUCTION_INSTALL_DIR/.$DISPLAY_NAME.app.installing.XXXXXX")"
+    STAGED_APP="$STAGED_DIR/$DISPLAY_NAME.app"
+    ditto "$SOURCE_APP" "$STAGED_APP"
+    codesign --verify --deep --strict --verbose=2 "$STAGED_APP"
+    codesign --verify --deep --strict --verbose=2 -R="$LOCAL_DEVELOPER_ID_REQUIREMENT" "$STAGED_APP"
+    TRANSACTION_ACTIVE=1
+    if [[ -e "$LOCAL_PRODUCTION_APP" ]]; then
+        BACKUP_DIR="$(mktemp -d "$LOCAL_PRODUCTION_INSTALL_DIR/.$DISPLAY_NAME.app.backup.XXXXXX")"
+        BACKUP_APP="$BACKUP_DIR/$DISPLAY_NAME.app"
+        mv "$LOCAL_PRODUCTION_APP" "$BACKUP_APP"
+        APP_BACKED_UP=1
+    fi
+    mv "$STAGED_APP" "$LOCAL_PRODUCTION_APP"
+    APP_INSTALLED=1
+    STAGED_APP=""
+    rmdir "$STAGED_DIR"
+    STAGED_DIR=""
+    TRANSACTION_ACTIVE=0
+
+    if [[ -n "$BACKUP_APP" ]]; then
+        rm -rf "$BACKUP_APP"
+        rmdir "$BACKUP_DIR"
+        BACKUP_APP=""
+        BACKUP_DIR=""
+        APP_BACKED_UP=0
+    fi
+    APP_INSTALLED=0
+
+    printf 'Installed local Developer ID production app: %s\n' "$LOCAL_PRODUCTION_APP"
+    printf 'Bundle identifier: %s\n' "$BUNDLE_ID"
+    printf 'Signing team: %s\n' "$SIGNING_TEAM_ID"
+    printf 'This app is local-only and must not be uploaded to GitHub Releases.\n'
+    exit 0
+fi
+
 mkdir -p "$(dirname "$LOCAL_SIGNING_IDENTITY_REGISTRY_PATH")"
 chmod 700 "$(dirname "$LOCAL_SIGNING_IDENTITY_REGISTRY_PATH")"
 REGISTRY_LOCK_CANDIDATE="$LOCAL_SIGNING_IDENTITY_REGISTRY_PATH.lock"
@@ -296,11 +407,10 @@ grep -F -i -- "$SIGN_IDENTITY" <<< "$DESIGNATED_REQUIREMENT" >/dev/null ||
     fail "Packaged app designated requirement is not pinned to the selected certificate."
 printf 'Packaged designated requirement: %s\n' "$DESIGNATED_REQUIREMENT"
 
-if pgrep -f "$LOCAL_PRODUCTION_APP/Contents/MacOS/$APP_NAME" >/dev/null 2>&1; then
+if running_local_production_app_exists; then
     fail "Quit $DISPLAY_NAME before replacing $LOCAL_PRODUCTION_APP."
 fi
 
-mkdir -p "$LOCAL_PRODUCTION_INSTALL_DIR"
 STAGED_DIR="$(mktemp -d "$LOCAL_PRODUCTION_INSTALL_DIR/.$DISPLAY_NAME.app.installing.XXXXXX")"
 STAGED_APP="$STAGED_DIR/$DISPLAY_NAME.app"
 ditto "$SOURCE_APP" "$STAGED_APP"

--- a/Scripts/package_app.sh
+++ b/Scripts/package_app.sh
@@ -67,14 +67,26 @@ finish(){
 }
 trap 'finish $?' EXIT
 
+DISPLAY_NAME_OVERRIDE="${DISPLAY_NAME:-}"
 BUNDLE_ID_OVERRIDE="${BUNDLE_ID:-}"
+SIGNING_TEAM_ID_OVERRIDE="${SIGNING_TEAM_ID:-}"
+URL_SCHEME_OVERRIDE="${REPOPROMPT_URL_SCHEME:-${URL_SCHEME:-}}"
 # Invalidate public-release manifests before metadata parsing, checks, or builds
 # so failed non-public packaging cannot leave stale release metadata behind.
 remove_stale_artifact_manifests
 source "$CONTROL_PLANE_SCRIPTS_DIR/load_release_metadata.sh"
 load_release_metadata "$ROOT_DIR"
-APP_NAME="${APP_NAME:-RepoPrompt}"; DISPLAY_NAME="${DISPLAY_NAME:-RepoPrompt CE}"; BASE_BUNDLE_ID="${BUNDLE_ID:-com.pvncher.repoprompt.ce}"; MARKETING_VERSION="${MARKETING_VERSION:-0.1.0}"; BUILD_NUMBER="${BUILD_NUMBER:-1}"; SIGNING_TEAM_ID="${SIGNING_TEAM_ID:-648A27MST5}"
+BASE_DISPLAY_NAME="${DISPLAY_NAME:-RepoPrompt CE}"
+APP_NAME="${APP_NAME:-RepoPrompt}"; DISPLAY_NAME="${DISPLAY_NAME_OVERRIDE:-${DISPLAY_NAME:-RepoPrompt CE}}"; BASE_BUNDLE_ID="${BUNDLE_ID:-com.pvncher.repoprompt.ce}"; MARKETING_VERSION="${MARKETING_VERSION:-0.1.0}"; BUILD_NUMBER="${BUILD_NUMBER:-1}"; SIGNING_TEAM_ID="${SIGNING_TEAM_ID_OVERRIDE:-${SIGNING_TEAM_ID:-648A27MST5}}"
 ARTIFACT_MANIFEST="$ROOT_DIR/.build/release/$APP_NAME-artifact-manifest.json"
+
+url_scheme_from_bundle_id(){
+    local lower sanitized
+    lower="$(tr '[:upper:]' '[:lower:]' <<< "$1")"
+    sanitized="$(sed -E 's/[^a-z0-9+.-]+/-/g; s/^[^a-z]+//; s/[.-]+$//' <<< "$lower")"
+    [[ -n "$sanitized" ]] || sanitized="local"
+    printf 'repoprompt-ce-%s\n' "$sanitized"
+}
 
 IS_RELEASE=0
 [[ "$CONF" == "release" ]] && IS_RELEASE=1
@@ -83,6 +95,26 @@ if (( IS_RELEASE )); then
 else
     BUNDLE_ID="${BUNDLE_ID_OVERRIDE:-${DEBUG_BUNDLE_ID:-$BASE_BUNDLE_ID.debug}}"
 fi
+if [[ -n "$URL_SCHEME_OVERRIDE" ]]; then
+    URL_SCHEME="$URL_SCHEME_OVERRIDE"
+elif [[ "$BUNDLE_ID" == "$BASE_BUNDLE_ID" || "$BUNDLE_ID" == "$BASE_BUNDLE_ID.debug" ]]; then
+    URL_SCHEME="repoprompt-ce"
+else
+    URL_SCHEME="$(url_scheme_from_bundle_id "$BUNDLE_ID")"
+fi
+
+TRIMMED_DISPLAY_NAME="$(sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//' <<< "$DISPLAY_NAME")"
+NORMALIZED_BUNDLE_ID="$(tr '[:upper:]' '[:lower:]' <<< "$BUNDLE_ID")"
+NORMALIZED_BASE_BUNDLE_ID="$(tr '[:upper:]' '[:lower:]' <<< "$BASE_BUNDLE_ID")"
+NORMALIZED_URL_SCHEME="$(tr '[:upper:]' '[:lower:]' <<< "$URL_SCHEME")"
+NORMALIZED_DISPLAY_NAME="$(tr '[:upper:]' '[:lower:]' <<< "$TRIMMED_DISPLAY_NAME")"
+NORMALIZED_BASE_DISPLAY_NAME="$(tr '[:upper:]' '[:lower:]' <<< "$BASE_DISPLAY_NAME")"
+
+[[ "$APP_NAME" =~ ^[A-Za-z0-9._\ -]+$ ]] || fail "APP_NAME contains unsupported characters: $APP_NAME"
+[[ -n "$DISPLAY_NAME" && "$DISPLAY_NAME" == "$TRIMMED_DISPLAY_NAME" && "$DISPLAY_NAME" != */* ]] || fail "DISPLAY_NAME must be non-empty, trimmed, and must not contain '/'."
+[[ "$BUNDLE_ID" =~ ^[A-Za-z0-9]+([.-][A-Za-z0-9]+)*$ ]] || fail "BUNDLE_ID is not a valid bundle identifier: $BUNDLE_ID"
+[[ "$SIGNING_TEAM_ID" =~ ^[A-Z0-9]+$ ]] || fail "SIGNING_TEAM_ID must contain only uppercase letters and digits: $SIGNING_TEAM_ID"
+[[ "$URL_SCHEME" =~ ^[A-Za-z][A-Za-z0-9+.-]*$ ]] || fail "URL scheme is invalid: $URL_SCHEME"
 
 phase "Checking build environment"
 run "$CONTROL_PLANE_SCRIPTS_DIR/doctor.sh" --quiet
@@ -94,6 +126,7 @@ SIGN_IDENTITY="${SIGN_IDENTITY:-}"
 ALLOW_ADHOC_SIGNING="${ALLOW_ADHOC_SIGNING:-0}"
 RELEASE_ALLOW_ADHOC_SIGNING="${RELEASE_ALLOW_ADHOC_SIGNING:-0}"
 LOCAL_SELF_SIGNED_RELEASE="${LOCAL_SELF_SIGNED_RELEASE:-0}"
+LOCAL_DEVELOPER_ID_RELEASE="${LOCAL_DEVELOPER_ID_RELEASE:-0}"
 LOCAL_SELF_SIGNED_CERTIFICATE_NAME="RepoPrompt CE Local Self-Signed Code Signing"
 LOCAL_SIGNING_CERTIFICATE_SHA1="${LOCAL_SIGNING_CERTIFICATE_SHA1:-}"
 LOCAL_SIGNING_CERTIFICATE_SHA256="${LOCAL_SIGNING_CERTIFICATE_SHA256:-}"
@@ -107,6 +140,7 @@ LOCAL_SELF_SIGNED_ENTITLEMENTS_TEMPLATE="$ROOT_DIR/AppBundle/RepoPrompt.local-se
 APP_ENTITLEMENTS=""
 USE_ADHOC_SIGNING=0
 USE_LOCAL_SELF_SIGNED_RELEASE=0
+USE_LOCAL_DEVELOPER_ID_RELEASE=0
 DEBUG_STORAGE_BACKEND_MARKER="alternate-in-memory"
 SIGNING_MODE_MARKER="debug-apple-development"
 warn_adhoc_signing(){
@@ -121,6 +155,7 @@ warn_release_candidate_signing(){
 }
 if [[ "$LOCAL_SELF_SIGNED_RELEASE" == "1" || "$LOCAL_SELF_SIGNED_RELEASE" == "true" ]]; then
     (( IS_RELEASE )) || fail "LOCAL_SELF_SIGNED_RELEASE is only supported for release packaging."
+    [[ "$LOCAL_DEVELOPER_ID_RELEASE" != "1" && "$LOCAL_DEVELOPER_ID_RELEASE" != "true" ]] || fail "LOCAL_SELF_SIGNED_RELEASE and LOCAL_DEVELOPER_ID_RELEASE are mutually exclusive."
     [[ -n "$SIGN_IDENTITY" ]] || fail "LOCAL_SELF_SIGNED_RELEASE requires SIGN_IDENTITY pointing at the user-local self-signed code-signing identity."
     [[ "$LOCAL_SIGNING_CERTIFICATE_SHA1" =~ ^[[:xdigit:]]{40}$ ]] || fail "LOCAL_SELF_SIGNED_RELEASE requires LOCAL_SIGNING_CERTIFICATE_SHA1 with the selected certificate SHA-1 fingerprint."
     [[ "$LOCAL_SIGNING_CERTIFICATE_SHA256" =~ ^[[:xdigit:]]{64}$ ]] || fail "LOCAL_SELF_SIGNED_RELEASE requires LOCAL_SIGNING_CERTIFICATE_SHA256 with the selected certificate SHA-256 fingerprint."
@@ -130,6 +165,16 @@ if [[ "$LOCAL_SELF_SIGNED_RELEASE" == "1" || "$LOCAL_SELF_SIGNED_RELEASE" == "tr
     LOCAL_SELF_SIGNED_REQUIREMENT="identifier \"$BUNDLE_ID\" and certificate leaf = H\"$LOCAL_SIGNING_CERTIFICATE_SHA1\""
     USE_LOCAL_SELF_SIGNED_RELEASE=1
     echo "WARNING: Building a local-only self-signed production app."
+    echo "WARNING: This app is for installation on this Mac only. It is not notarized and must not be uploaded to GitHub Releases."
+elif [[ "$LOCAL_DEVELOPER_ID_RELEASE" == "1" || "$LOCAL_DEVELOPER_ID_RELEASE" == "true" ]]; then
+    (( IS_RELEASE )) || fail "LOCAL_DEVELOPER_ID_RELEASE is only supported for release packaging."
+    [[ -n "$SIGN_IDENTITY" ]] || fail "LOCAL_DEVELOPER_ID_RELEASE requires SIGN_IDENTITY pointing at the user's Developer ID Application identity."
+    [[ -n "$SIGNING_TEAM_ID" ]] || fail "LOCAL_DEVELOPER_ID_RELEASE requires SIGNING_TEAM_ID."
+    [[ "$NORMALIZED_BUNDLE_ID" != "$NORMALIZED_BASE_BUNDLE_ID" && "$NORMALIZED_BUNDLE_ID" != "$NORMALIZED_BASE_BUNDLE_ID.debug" ]] || fail "LOCAL_DEVELOPER_ID_RELEASE requires a personal BUNDLE_ID, not an upstream public/debug bundle identifier."
+    [[ "$NORMALIZED_DISPLAY_NAME" != "$NORMALIZED_BASE_DISPLAY_NAME" ]] || fail "LOCAL_DEVELOPER_ID_RELEASE requires a personal DISPLAY_NAME, not the upstream public app name '$BASE_DISPLAY_NAME'."
+    [[ "$NORMALIZED_URL_SCHEME" != "repoprompt-ce" ]] || fail "LOCAL_DEVELOPER_ID_RELEASE requires a URL scheme that does not collide with the public app."
+    USE_LOCAL_DEVELOPER_ID_RELEASE=1
+    echo "WARNING: Building a local-only Developer ID production app."
     echo "WARNING: This app is for installation on this Mac only. It is not notarized and must not be uploaded to GitHub Releases."
 fi
 if [[ -z "$SIGN_IDENTITY" ]] && (( ! IS_RELEASE )) && [[ "$PREFER_STABLE_DEBUG_SIGNING" == "1" || "$PREFER_STABLE_DEBUG_SIGNING" == "true" ]]; then
@@ -169,6 +214,9 @@ fi
 if (( USE_LOCAL_SELF_SIGNED_RELEASE )); then
     DEBUG_STORAGE_BACKEND_MARKER="keychain"
     SIGNING_MODE_MARKER="local-self-signed"
+elif (( USE_LOCAL_DEVELOPER_ID_RELEASE )); then
+    DEBUG_STORAGE_BACKEND_MARKER="keychain"
+    SIGNING_MODE_MARKER="local-developer-id"
 elif (( IS_RELEASE )) && (( ! USE_ADHOC_SIGNING )); then
     DEBUG_STORAGE_BACKEND_MARKER="keychain"
     SIGNING_MODE_MARKER="developer-id"
@@ -190,7 +238,7 @@ printf 'Signing mode marker: %s\n' "$SIGNING_MODE_MARKER"
 SWIFT_BUILD_ARGS=(-c "$CONF")
 PUBLIC_UNIVERSAL_RELEASE=0
 ARCHITECTURE_POLICY="matching"
-if (( IS_RELEASE )) && (( ! USE_LOCAL_SELF_SIGNED_RELEASE )); then
+if (( IS_RELEASE )) && (( ! USE_LOCAL_SELF_SIGNED_RELEASE )) && (( ! USE_LOCAL_DEVELOPER_ID_RELEASE )); then
     PUBLIC_UNIVERSAL_RELEASE=1
     ARCHITECTURE_POLICY="arm64,x86_64"
 fi
@@ -253,23 +301,90 @@ shopt -u nullglob
 run "$CONTROL_PLANE_SCRIPTS_DIR/validate_required_swiftpm_resource_bundles.sh" "$APP_BUNDLE" "Packaged app SwiftPM resource bundle layout"
 
 phase "Writing Info.plist"
-run python3 - <<PY
+run env \
+    APP_BUNDLE="$APP_BUNDLE" \
+    APP_NAME="$APP_NAME" \
+    DISPLAY_NAME="$DISPLAY_NAME" \
+    BUNDLE_ID="$BUNDLE_ID" \
+    URL_SCHEME="$URL_SCHEME" \
+    MARKETING_VERSION="$MARKETING_VERSION" \
+    BUILD_NUMBER="$BUILD_NUMBER" \
+    SIGNING_TEAM_ID="$SIGNING_TEAM_ID" \
+    DEBUG_STORAGE_BACKEND_MARKER="$DEBUG_STORAGE_BACKEND_MARKER" \
+    SIGNING_MODE_MARKER="$SIGNING_MODE_MARKER" \
+    LOCAL_SIGNING_CERTIFICATE_SHA256="$LOCAL_SIGNING_CERTIFICATE_SHA256" \
+    LOCAL_SIGNING_SERVICE_GENERATION="$LOCAL_SIGNING_SERVICE_GENERATION" \
+    python3 - <<'PY'
+import os
+import plistlib
 from pathlib import Path
-s=Path('AppBundle/Info.plist.template').read_text()
-for k,v in {'__APP_NAME__':'$APP_NAME','__DISPLAY_NAME__':'$DISPLAY_NAME','__BUNDLE_ID__':'$BUNDLE_ID','__MARKETING_VERSION__':'$MARKETING_VERSION','__BUILD_NUMBER__':'$BUILD_NUMBER','__DEBUG_SECURE_STORAGE_BACKEND__':'$DEBUG_STORAGE_BACKEND_MARKER','__SIGNING_MODE__':'$SIGNING_MODE_MARKER','__LOCAL_SIGNING_CERTIFICATE_SHA256__':'$LOCAL_SIGNING_CERTIFICATE_SHA256','__LOCAL_SECURE_STORAGE_GENERATION__':'$LOCAL_SIGNING_SERVICE_GENERATION'}.items(): s=s.replace(k,v)
-Path('$APP_BUNDLE/Contents/Info.plist').write_text(s)
+
+replacements = {
+    "__APP_NAME__": os.environ["APP_NAME"],
+    "__DISPLAY_NAME__": os.environ["DISPLAY_NAME"],
+    "__BUNDLE_ID__": os.environ["BUNDLE_ID"],
+    "__URL_SCHEME__": os.environ["URL_SCHEME"],
+    "__MARKETING_VERSION__": os.environ["MARKETING_VERSION"],
+    "__BUILD_NUMBER__": os.environ["BUILD_NUMBER"],
+    "__SIGNING_TEAM_ID__": os.environ["SIGNING_TEAM_ID"],
+    "__DEBUG_SECURE_STORAGE_BACKEND__": os.environ["DEBUG_STORAGE_BACKEND_MARKER"],
+    "__SIGNING_MODE__": os.environ["SIGNING_MODE_MARKER"],
+    "__LOCAL_SIGNING_CERTIFICATE_SHA256__": os.environ["LOCAL_SIGNING_CERTIFICATE_SHA256"],
+    "__LOCAL_SECURE_STORAGE_GENERATION__": os.environ["LOCAL_SIGNING_SERVICE_GENERATION"],
+}
+
+def render(value):
+    if isinstance(value, str):
+        for placeholder, replacement in replacements.items():
+            value = value.replace(placeholder, replacement)
+        return value
+    if isinstance(value, list):
+        return [render(item) for item in value]
+    if isinstance(value, dict):
+        return {render(key): render(item) for key, item in value.items()}
+    return value
+
+plist = render(plistlib.loads(Path("AppBundle/Info.plist.template").read_bytes()))
+Path(os.environ["APP_BUNDLE"], "Contents", "Info.plist").write_bytes(plistlib.dumps(plist, sort_keys=False))
 PY
 run plutil -lint "$APP_BUNDLE/Contents/Info.plist"
 
-if (( USE_LOCAL_SELF_SIGNED_RELEASE )); then
-    phase "Rendering local self-signed entitlements"
-    [[ -f "$LOCAL_SELF_SIGNED_ENTITLEMENTS_TEMPLATE" ]] || fail "Missing local self-signed entitlements template: $LOCAL_SELF_SIGNED_ENTITLEMENTS_TEMPLATE"
+if (( USE_LOCAL_SELF_SIGNED_RELEASE || USE_LOCAL_DEVELOPER_ID_RELEASE )); then
+    if (( USE_LOCAL_SELF_SIGNED_RELEASE )); then
+        phase "Rendering local self-signed entitlements"
+    else
+        phase "Rendering local Developer ID entitlements"
+    fi
+    [[ -f "$LOCAL_SELF_SIGNED_ENTITLEMENTS_TEMPLATE" ]] || fail "Missing local entitlements template: $LOCAL_SELF_SIGNED_ENTITLEMENTS_TEMPLATE"
     APP_ENTITLEMENTS="$(mktemp)"
-    run python3 - <<PY
+    run env \
+        ENTITLEMENTS_TEMPLATE="$LOCAL_SELF_SIGNED_ENTITLEMENTS_TEMPLATE" \
+        ENTITLEMENTS_OUTPUT="$APP_ENTITLEMENTS" \
+        BUNDLE_ID="$BUNDLE_ID" \
+        SIGNING_TEAM_ID="$SIGNING_TEAM_ID" \
+        python3 - <<'PY'
+import os
+import plistlib
 from pathlib import Path
-s=Path('$LOCAL_SELF_SIGNED_ENTITLEMENTS_TEMPLATE').read_text()
-s=s.replace('__BUNDLE_ID__', '$BUNDLE_ID')
-Path('$APP_ENTITLEMENTS').write_text(s)
+
+replacements = {
+    "__BUNDLE_ID__": os.environ["BUNDLE_ID"],
+    "__SIGNING_TEAM_ID__": os.environ["SIGNING_TEAM_ID"],
+}
+
+def render(value):
+    if isinstance(value, str):
+        for placeholder, replacement in replacements.items():
+            value = value.replace(placeholder, replacement)
+        return value
+    if isinstance(value, list):
+        return [render(item) for item in value]
+    if isinstance(value, dict):
+        return {render(key): render(item) for key, item in value.items()}
+    return value
+
+plist = render(plistlib.loads(Path(os.environ["ENTITLEMENTS_TEMPLATE"]).read_bytes()))
+Path(os.environ["ENTITLEMENTS_OUTPUT"]).write_bytes(plistlib.dumps(plist, sort_keys=False))
 PY
     run plutil -lint "$APP_ENTITLEMENTS"
 elif (( IS_RELEASE )) && (( ! USE_ADHOC_SIGNING )); then
@@ -283,11 +398,34 @@ elif (( IS_RELEASE )) && (( ! USE_ADHOC_SIGNING )); then
     [[ "$PROFILE_APP_IDENTIFIER" == "$SIGNING_TEAM_ID.$BUNDLE_ID" ]] || fail "Provisioning profile app identifier mismatch: expected $SIGNING_TEAM_ID.$BUNDLE_ID, got ${PROFILE_APP_IDENTIFIER:-<missing>}."
     run cp "$REPOPROMPT_PROVISIONING_PROFILE" "$APP_BUNDLE/Contents/embedded.provisionprofile"
     APP_ENTITLEMENTS="$(mktemp)"
-    run python3 - <<PY
+    run env \
+        ENTITLEMENTS_TEMPLATE="$APP_ENTITLEMENTS_TEMPLATE" \
+        ENTITLEMENTS_OUTPUT="$APP_ENTITLEMENTS" \
+        BUNDLE_ID="$BUNDLE_ID" \
+        SIGNING_TEAM_ID="$SIGNING_TEAM_ID" \
+        python3 - <<'PY'
+import os
+import plistlib
 from pathlib import Path
-s=Path('$APP_ENTITLEMENTS_TEMPLATE').read_text()
-for k,v in {'__BUNDLE_ID__':'$BUNDLE_ID','__SIGNING_TEAM_ID__':'$SIGNING_TEAM_ID'}.items(): s=s.replace(k,v)
-Path('$APP_ENTITLEMENTS').write_text(s)
+
+replacements = {
+    "__BUNDLE_ID__": os.environ["BUNDLE_ID"],
+    "__SIGNING_TEAM_ID__": os.environ["SIGNING_TEAM_ID"],
+}
+
+def render(value):
+    if isinstance(value, str):
+        for placeholder, replacement in replacements.items():
+            value = value.replace(placeholder, replacement)
+        return value
+    if isinstance(value, list):
+        return [render(item) for item in value]
+    if isinstance(value, dict):
+        return {render(key): render(item) for key, item in value.items()}
+    return value
+
+plist = render(plistlib.loads(Path(os.environ["ENTITLEMENTS_TEMPLATE"]).read_bytes()))
+Path(os.environ["ENTITLEMENTS_OUTPUT"]).write_bytes(plistlib.dumps(plist, sort_keys=False))
 PY
     run plutil -lint "$APP_ENTITLEMENTS"
 fi
@@ -309,6 +447,8 @@ sign_path(){
     if (( USE_ADHOC_SIGNING )); then
         args+=(--timestamp=none)
     elif (( USE_LOCAL_SELF_SIGNED_RELEASE )); then
+        args+=(--timestamp=none --options runtime)
+    elif (( USE_LOCAL_DEVELOPER_ID_RELEASE )); then
         args+=(--timestamp=none --options runtime)
     elif (( IS_RELEASE )); then
         args+=(--timestamp --options runtime)
@@ -363,6 +503,9 @@ verify_signed_app_identity(){
         printf 'Selected local certificate SHA-256: %s\n' "$LOCAL_SIGNING_CERTIFICATE_SHA256"
         printf 'Local secure-storage service generation: v%s\n' "$LOCAL_SIGNING_SERVICE_GENERATION"
         printf 'Extracted designated requirement: %s\n' "$designated_requirement"
+    elif (( USE_LOCAL_DEVELOPER_ID_RELEASE )); then
+        [[ "$team" == "$SIGNING_TEAM_ID" ]] || fail "Local Developer ID app team mismatch: expected $SIGNING_TEAM_ID, got ${team:-<missing>}"
+        run codesign --verify --deep --strict --verbose=2 -R="anchor apple generic and identifier \"$BUNDLE_ID\" and certificate leaf[subject.OU] = \"$SIGNING_TEAM_ID\" and certificate leaf[field.1.2.840.113635.100.6.1.13] exists" "$APP_BUNDLE"
     elif (( IS_RELEASE )); then
         [[ "$team" == "$SIGNING_TEAM_ID" ]] || fail "Signed app team mismatch: expected $SIGNING_TEAM_ID, got ${team:-<missing>}"
     else

--- a/Scripts/test_local_production_installer.py
+++ b/Scripts/test_local_production_installer.py
@@ -271,6 +271,138 @@ class LocalProductionInstallerTests(unittest.TestCase):
         self.assertIn("--extract-certificates=\"$certificate_prefix\"", package_script)
         self.assertIn("Extracted designated requirement", package_script)
 
+    def test_developer_id_mode_installs_personal_bundle_without_self_signed_registry(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            temp_dir = Path(tmp)
+            root = temp_dir / "repo"
+            scripts = root / "Scripts"
+            scripts.mkdir(parents=True)
+            shutil.copy2(SCRIPT_DIR / "install_local_production.sh", scripts / "install_local_production.sh")
+            (root / "version.env").write_text(
+                'APP_NAME=RepoPrompt\nDISPLAY_NAME="RepoPrompt CE"\nBUNDLE_ID=com.pvncher.repoprompt.ce\nSIGNING_TEAM_ID=648A27MST5\n',
+                encoding="utf-8",
+            )
+            package_capture = temp_dir / "package-capture.txt"
+            (scripts / "package_app.sh").write_text(
+                textwrap.dedent(
+                    """\
+                    #!/usr/bin/env bash
+                    set -euo pipefail
+                    app="$FAKE_BUILD_DIR/RepoPrompt.app"
+                    mkdir -p "$app/Contents/MacOS"
+                    printf '%s|%s|%s|%s|%s\n' "$LOCAL_DEVELOPER_ID_RELEASE" "$DISPLAY_NAME" "$BUNDLE_ID" "$SIGNING_TEAM_ID" "$SIGN_IDENTITY" > "$PACKAGE_CAPTURE"
+                    cat > "$app/Contents/Info.plist" <<EOF
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <plist version="1.0"><dict>
+                      <key>CFBundleIdentifier</key><string>$BUNDLE_ID</string>
+                      <key>CFBundleDisplayName</key><string>$DISPLAY_NAME</string>
+                      <key>RepoPromptSigningMode</key><string>local-developer-id</string>
+                    </dict></plist>
+                    EOF
+                    """
+                ),
+                encoding="utf-8",
+            )
+            (scripts / "package_app.sh").chmod(0o755)
+
+            bin_dir = temp_dir / "bin"
+            bin_dir.mkdir()
+            install_dir = temp_dir / "Applications"
+            build_dir = temp_dir / "build"
+            keychain = temp_dir / "login.keychain-db"
+            keychain.touch()
+            codesign_log = temp_dir / "codesign.log"
+            registry_path = temp_dir / "Application Support" / "RepoPrompt CE" / "local-signing-identity-v1.json"
+
+            self.write_stub(bin_dir, "security", 'printf "    \\\"%s\\\"\\n" "$FAKE_KEYCHAIN"\n')
+            self.write_stub(bin_dir, "swift", 'printf "%s\\n" "$FAKE_BUILD_DIR"\n')
+            self.write_stub(bin_dir, "codesign", 'printf "%s\\n" "$*" >> "$CODESIGN_LOG"\n')
+            self.write_stub(bin_dir, "ditto", 'cp -R "$1" "$2"\n')
+            self.write_stub(bin_dir, "pgrep", "exit 1\n")
+            self.write_stub(bin_dir, "ps", '[[ -z "${FAKE_RUNNING_COMMAND:-}" ]] || printf "%s\\n" "$FAKE_RUNNING_COMMAND"\n')
+            self.write_stub(bin_dir, "openssl", "exit 0\n")
+
+            env = os.environ.copy()
+            env.pop("BASH_ENV", None)
+            env.update(
+                {
+                    "PATH": f"{bin_dir}:{env.get('PATH', '')}",
+                    "CONFIRM_LOCAL_PRODUCTION_INSTALL": "1",
+                    "LOCAL_PRODUCTION_SIGNING_MODE": "developer-id",
+                    "LOCAL_PRODUCTION_INSTALL_DIR": str(install_dir),
+                    "LOCAL_SIGNING_IDENTITY_REGISTRY_PATH": str(registry_path),
+                    "DISPLAY_NAME": "My RepoPrompt CE (Local)",
+                    "BUNDLE_ID": "com.example.repoprompt.ce",
+                    "SIGNING_TEAM_ID": "TEAM123456",
+                    "SIGN_IDENTITY": "Developer ID Application: Person (TEAM123456)",
+                    "FAKE_BUILD_DIR": str(build_dir),
+                    "FAKE_KEYCHAIN": str(keychain),
+                    "PACKAGE_CAPTURE": str(package_capture),
+                    "CODESIGN_LOG": str(codesign_log),
+                }
+            )
+
+            default_identity_env = env.copy()
+            default_identity_env.pop("DISPLAY_NAME")
+            default_identity_env.pop("BUNDLE_ID")
+            default_identity_result = subprocess.run(
+                ["bash", str(scripts / "install_local_production.sh")],
+                env=default_identity_env,
+                text=True,
+                capture_output=True,
+                timeout=15,
+            )
+            self.assertNotEqual(default_identity_result.returncode, 0)
+            self.assertIn("require a personal BUNDLE_ID", default_identity_result.stderr)
+            self.assertFalse(package_capture.exists())
+
+            display_collision_env = env.copy()
+            display_collision_env["DISPLAY_NAME"] = "repoprompt ce"
+            display_collision_result = subprocess.run(
+                ["bash", str(scripts / "install_local_production.sh")],
+                env=display_collision_env,
+                text=True,
+                capture_output=True,
+                timeout=15,
+            )
+            self.assertNotEqual(display_collision_result.returncode, 0)
+            self.assertIn("require a personal DISPLAY_NAME", display_collision_result.stderr)
+            self.assertFalse(package_capture.exists())
+
+            running_env = env.copy()
+            running_env["FAKE_RUNNING_COMMAND"] = str(install_dir / "My RepoPrompt CE (Local).app" / "Contents" / "MacOS" / "RepoPrompt")
+            running_result = subprocess.run(
+                ["bash", str(scripts / "install_local_production.sh")],
+                env=running_env,
+                text=True,
+                capture_output=True,
+                timeout=15,
+            )
+            self.assertNotEqual(running_result.returncode, 0)
+            self.assertIn("Quit My RepoPrompt CE (Local)", running_result.stderr)
+            self.assertFalse((install_dir / "My RepoPrompt CE (Local).app").exists())
+            package_capture.unlink()
+
+            result = subprocess.run(
+                ["bash", str(scripts / "install_local_production.sh")],
+                env=env,
+                text=True,
+                capture_output=True,
+                timeout=15,
+            )
+
+            installed_app = install_dir / "My RepoPrompt CE (Local).app"
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertTrue(installed_app.exists())
+            self.assertEqual(
+                package_capture.read_text(encoding="utf-8").strip(),
+                "1|My RepoPrompt CE (Local)|com.example.repoprompt.ce|TEAM123456|Developer ID Application: Person (TEAM123456)",
+            )
+            self.assertFalse(registry_path.exists())
+            self.assertIn("Installed local Developer ID production app", result.stdout)
+            self.assertIn('identifier "com.example.repoprompt.ce"', codesign_log.read_text(encoding="utf-8"))
+            self.assertIn('certificate leaf[subject.OU] = "TEAM123456"', codesign_log.read_text(encoding="utf-8"))
+
     def test_first_use_adopts_sole_identity_and_writes_registry(self) -> None:
         result, context = self.run_installer([certificate(SHA1_A, SHA256_A)], expected_sha1=SHA1_A)
         self.assertEqual(result.returncode, 0, result.stderr)
@@ -544,7 +676,7 @@ class LocalProductionInstallerTests(unittest.TestCase):
                 encoding="utf-8",
             )
         (root / "version.env").write_text(
-            'APP_NAME=RepoPrompt\nDISPLAY_NAME="RepoPrompt CE"\nBUNDLE_ID=com.pvncher.repoprompt.ce\n',
+            'APP_NAME=RepoPrompt\nDISPLAY_NAME="RepoPrompt CE"\nBUNDLE_ID=com.pvncher.repoprompt.ce\nSIGNING_TEAM_ID=648A27MST5\n',
             encoding="utf-8",
         )
 

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -54,6 +54,7 @@ class ReleaseToolingTests(unittest.TestCase):
         self.assertIn("__SIGNING_TEAM_ID__.__BUNDLE_ID__", entitlements)
         self.assertIn("<string>__SIGNING_TEAM_ID__</string>", entitlements)
         self.assertEqual(info_plist["CFBundleIdentifier"], "__BUNDLE_ID__")
+        self.assertEqual(info_plist["CFBundleURLTypes"][0]["CFBundleURLSchemes"], ["__URL_SCHEME__"])
         self.assertIn("RepoPromptSigningMode", info_plist)
         self.assertIn("RepoPromptDebugSecureStorageBackend", info_plist)
         self.assertIn("RepoPromptLocalSigningCertificateSHA256", info_plist)
@@ -1896,6 +1897,7 @@ SIGNING_TEAM_ID=648A27MST5
             "__APP_NAME__": "RepoPrompt",
             "__DISPLAY_NAME__": "RepoPrompt CE",
             "__BUNDLE_ID__": "com.pvncher.repoprompt.ce",
+            "__URL_SCHEME__": "repoprompt-ce",
             "__MARKETING_VERSION__": "1.0.0",
             "__BUILD_NUMBER__": "1",
             "__DEBUG_SECURE_STORAGE_BACKEND__": "alternate-in-memory",

--- a/Scripts/validate_staged_release.sh
+++ b/Scripts/validate_staged_release.sh
@@ -133,6 +133,7 @@ for key, value in {
     "__APP_NAME__": app_name,
     "__DISPLAY_NAME__": display_name,
     "__BUNDLE_ID__": bundle_id,
+    "__URL_SCHEME__": "repoprompt-ce",
     "__MARKETING_VERSION__": version,
     "__BUILD_NUMBER__": build,
     "__DEBUG_SECURE_STORAGE_BACKEND__": "alternate-in-memory",

--- a/Sources/RepoPrompt/Infrastructure/Security/KeychainService.swift
+++ b/Sources/RepoPrompt/Infrastructure/Security/KeychainService.swift
@@ -60,6 +60,7 @@ final class KeychainService: SecureKeyValueStorageBackend, @unchecked Sendable {
     static let legacyCanonicalServiceName = "com.pvncher.repoprompt.ce.keychain"
     static let officialV2ServiceName = "com.pvncher.repoprompt.ce.developer-id.keychain.v2"
     static let localSelfSignedServiceNamePrefix = "com.pvncher.repoprompt.ce.local-self-signed."
+    static let localDeveloperIDServiceNamePrefix = "repoprompt.ce.local-developer-id."
     static let debugServiceName = "com.pvncher.repoprompt.ce.debug.keychain"
 
     static let officialV2Shared = KeychainService(serviceName: officialV2ServiceName)
@@ -76,8 +77,45 @@ final class KeychainService: SecureKeyValueStorageBackend, @unchecked Sendable {
         KeychainService(serviceName: localSelfSignedServiceName(fingerprint: fingerprint, generation: generation))
     }
 
+    static func localDeveloperIDServiceName(bundleIdentifier: String, teamIdentifier: String) -> String {
+        let normalizedBundle = normalizedServiceComponent(bundleIdentifier)
+        let normalizedTeam = normalizedServiceComponent(teamIdentifier)
+        precondition(!normalizedBundle.isEmpty, "Local Developer ID bundle identifier must not be empty")
+        precondition(!normalizedTeam.isEmpty, "Local Developer ID team identifier must not be empty")
+        return "\(localDeveloperIDServiceNamePrefix)\(normalizedTeam).\(normalizedBundle).keychain.v1"
+    }
+
+    static func localDeveloperID(bundleIdentifier: String, teamIdentifier: String) -> KeychainService {
+        KeychainService(serviceName: localDeveloperIDServiceName(
+            bundleIdentifier: bundleIdentifier,
+            teamIdentifier: teamIdentifier
+        ))
+    }
+
     static func legacyRepairSource(secItemClient: SecItemClient = SystemSecItemClient()) -> KeychainService {
         KeychainService(serviceName: legacyCanonicalServiceName, secItemClient: secItemClient)
+    }
+
+    private static func normalizedServiceComponent(_ value: String) -> String {
+        value
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .unicodeScalars
+            .map { scalar -> Character in
+                switch scalar.value {
+                case 48 ... 57, 97 ... 122:
+                    Character(scalar)
+                case 45, 46:
+                    Character(scalar)
+                default:
+                    "-"
+                }
+            }
+            .reduce(into: "") { result, character in
+                if character == "-", result.last == "-" { return }
+                result.append(character)
+            }
+            .trimmingCharacters(in: CharacterSet(charactersIn: ".-"))
     }
 
     let serviceName: String

--- a/Sources/RepoPrompt/Infrastructure/Security/RuntimeCodeSigningDetector.swift
+++ b/Sources/RepoPrompt/Infrastructure/Security/RuntimeCodeSigningDetector.swift
@@ -96,6 +96,12 @@ enum RuntimeCodeSigningDetector {
         if SecCodeCheckValidity(code, SecCSFlags(rawValue: kSecCSStrictValidate), debugRequirement) == errSecSuccess {
             validatedDomains.insert(.appleDevelopmentDebug)
         }
+        if let localDeveloperIDRequirement = localDeveloperIDRequirement(
+            codeIdentifier: codeIdentifier,
+            teamIdentifier: teamIdentifier
+        ), SecCodeCheckValidity(code, SecCSFlags(rawValue: kSecCSStrictValidate), localDeveloperIDRequirement) == errSecSuccess {
+            validatedDomains.insert(.localDeveloperID)
+        }
         if let expectedFingerprint = localSigningExpectation?.validatedIdentity?.fingerprint,
            !isAdHoc,
            codeIdentifier == RuntimeCodeSigningPolicy.developerIDBundleIdentifier,
@@ -120,6 +126,28 @@ enum RuntimeCodeSigningDetector {
         let status = SecRequirementCreateWithString(source as CFString, [], &requirement)
         guard status == errSecSuccess else { return nil }
         return requirement
+    }
+
+    private static func localDeveloperIDRequirement(
+        codeIdentifier: String?,
+        teamIdentifier: String?
+    ) -> SecRequirement? {
+        guard let codeIdentifier = normalizedString(codeIdentifier),
+              let teamIdentifier = normalizedString(teamIdentifier)
+        else {
+            return nil
+        }
+        return requirement(
+            from: "anchor apple generic and identifier \"\(requirementStringLiteral(codeIdentifier))\" "
+                + "and certificate leaf[subject.OU] = \"\(requirementStringLiteral(teamIdentifier))\" "
+                + "and certificate leaf[field.1.2.840.113635.100.6.1.13] exists"
+        )
+    }
+
+    private static func requirementStringLiteral(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
     }
 
     private static func leafCertificateFingerprint(from dictionary: [String: Any]) -> String? {

--- a/Sources/RepoPrompt/Infrastructure/Security/RuntimeCodeSigningPolicy.swift
+++ b/Sources/RepoPrompt/Infrastructure/Security/RuntimeCodeSigningPolicy.swift
@@ -3,6 +3,7 @@ import Foundation
 enum RuntimeCodeSigningDomain: Hashable {
     case developerID
     case appleDevelopmentDebug
+    case localDeveloperID
     case localSelfSigned
 }
 
@@ -55,6 +56,7 @@ enum RuntimeSecureStorageDomain: Equatable {
     case officialDeveloperID
     case localSelfSigned
     case appleDevelopmentDebug
+    case localDeveloperID
     case ephemeral
 }
 
@@ -88,17 +90,23 @@ struct RuntimeSecureStorageDecision: Equatable {
     let rejectionReason: RuntimeSecureStorageRejectionReason?
     let localCertificateFingerprint: String?
     let localServiceGeneration: Int?
+    let localBundleIdentifier: String?
+    let localTeamIdentifier: String?
 
     init(
         domain: RuntimeSecureStorageDomain,
         rejectionReason: RuntimeSecureStorageRejectionReason?,
         localCertificateFingerprint: String? = nil,
-        localServiceGeneration: Int? = nil
+        localServiceGeneration: Int? = nil,
+        localBundleIdentifier: String? = nil,
+        localTeamIdentifier: String? = nil
     ) {
         self.domain = domain
         self.rejectionReason = rejectionReason
         self.localCertificateFingerprint = localCertificateFingerprint
         self.localServiceGeneration = localServiceGeneration
+        self.localBundleIdentifier = localBundleIdentifier
+        self.localTeamIdentifier = localTeamIdentifier
     }
 }
 
@@ -222,6 +230,19 @@ enum RuntimeCodeSigningPolicy {
                 localCertificateFingerprint: validatedIdentity.fingerprint,
                 localServiceGeneration: validatedIdentity.serviceGeneration
             )
+        case "local-developer-id":
+            guard let codeIdentifier = signingInfo.codeIdentifier,
+                  let teamIdentifier = signingInfo.teamIdentifier,
+                  matchesLocalDeveloperID(signingInfo)
+            else {
+                return ephemeral(.markerSignatureMismatch)
+            }
+            return RuntimeSecureStorageDecision(
+                domain: .localDeveloperID,
+                rejectionReason: nil,
+                localBundleIdentifier: codeIdentifier,
+                localTeamIdentifier: teamIdentifier
+            )
         case "release-candidate-adhoc":
             return ephemeral(.releaseCandidate)
         case "debug-adhoc":
@@ -267,6 +288,17 @@ enum RuntimeCodeSigningPolicy {
               signingInfo.codeIdentifier == identifier,
               signingInfo.teamIdentifier == teamIdentifier,
               signingInfo.validationResult.validates(domain)
+        else {
+            return false
+        }
+        return true
+    }
+
+    private static func matchesLocalDeveloperID(_ signingInfo: RuntimeCodeSigningInfo) -> Bool {
+        guard !signingInfo.isAdHoc,
+              normalized(signingInfo.codeIdentifier) != nil,
+              normalized(signingInfo.teamIdentifier) != nil,
+              signingInfo.validationResult.validates(.localDeveloperID)
         else {
             return false
         }

--- a/Sources/RepoPrompt/Infrastructure/Security/SecureKeyValueStorageBackend.swift
+++ b/Sources/RepoPrompt/Infrastructure/Security/SecureKeyValueStorageBackend.swift
@@ -62,6 +62,14 @@ enum SecureKeyValueStorageFactory {
             }
         case .appleDevelopmentDebug:
             KeychainService.debugShared
+        case .localDeveloperID:
+            if let bundleIdentifier = decision.localBundleIdentifier,
+               let teamIdentifier = decision.localTeamIdentifier
+            {
+                KeychainService.localDeveloperID(bundleIdentifier: bundleIdentifier, teamIdentifier: teamIdentifier)
+            } else {
+                EphemeralSecureKeyValueStore.shared
+            }
         case .ephemeral:
             EphemeralSecureKeyValueStore.shared
         }

--- a/Tests/RepoPromptTests/Security/DebugSecureStorageRuntimePolicyTests.swift
+++ b/Tests/RepoPromptTests/Security/DebugSecureStorageRuntimePolicyTests.swift
@@ -25,6 +25,11 @@ final class RuntimeCodeSigningPolicyTests: XCTestCase {
             teamIdentifier: RuntimeCodeSigningPolicy.signingTeamIdentifier,
             validatedDomains: [.appleDevelopmentDebug]
         )
+        let localDeveloperID = RuntimeCodeSigningInfo.synthetic(
+            codeIdentifier: "com.example.repoprompt.ce",
+            teamIdentifier: "TEAM123456",
+            validatedDomains: [.localDeveloperID]
+        )
 
         assertDecision(
             marker: "developer-id",
@@ -46,6 +51,14 @@ final class RuntimeCodeSigningPolicyTests: XCTestCase {
             debugMarker: "keychain",
             signingInfo: debug,
             expectedDomain: .appleDevelopmentDebug
+        )
+        assertDecision(
+            marker: "local-developer-id",
+            debugMarker: "keychain",
+            signingInfo: localDeveloperID,
+            expectedDomain: .localDeveloperID,
+            expectedLocalBundleIdentifier: "com.example.repoprompt.ce",
+            expectedLocalTeamIdentifier: "TEAM123456"
         )
 
         XCTAssertTrue(
@@ -70,6 +83,20 @@ final class RuntimeCodeSigningPolicyTests: XCTestCase {
                 for: RuntimeSecureStorageDecision(domain: .appleDevelopmentDebug, rejectionReason: nil)
             ).backend === KeychainService.debugShared
         )
+        XCTAssertEqual(
+            (SecureKeyValueStorageFactory.selection(
+                for: RuntimeSecureStorageDecision(
+                    domain: .localDeveloperID,
+                    rejectionReason: nil,
+                    localBundleIdentifier: "com.example.repoprompt.ce",
+                    localTeamIdentifier: "TEAM123456"
+                )
+            ).backend as? KeychainService)?.serviceName,
+            KeychainService.localDeveloperIDServiceName(
+                bundleIdentifier: "com.example.repoprompt.ce",
+                teamIdentifier: "TEAM123456"
+            )
+        )
     }
 
     func testRejectedModesExhaustivelyFailClosedToEphemeralStorage() {
@@ -83,12 +110,28 @@ final class RuntimeCodeSigningPolicyTests: XCTestCase {
             teamIdentifier: RuntimeCodeSigningPolicy.signingTeamIdentifier,
             validatedDomains: [.appleDevelopmentDebug]
         )
+        let localDeveloperIDWithoutValidatedDomain = RuntimeCodeSigningInfo.synthetic(
+            codeIdentifier: "com.example.repoprompt.ce",
+            teamIdentifier: "TEAM123456"
+        )
+        let localDeveloperIDWithoutTeam = RuntimeCodeSigningInfo.synthetic(
+            codeIdentifier: "com.example.repoprompt.ce",
+            validatedDomains: [.localDeveloperID]
+        )
+        let localDeveloperIDWithoutBundleIdentifier = RuntimeCodeSigningInfo.synthetic(
+            teamIdentifier: "TEAM123456",
+            validatedDomains: [.localDeveloperID]
+        )
         let invalid = RuntimeCodeSigningInfo.synthetic(failure: .signatureInvalid)
 
         let cases: [(String?, String?, RuntimeCodeSigningInfo, RuntimeSecureStorageRejectionReason)] = [
             (nil, nil, official, .missingSigningModeMarker),
             ("", nil, official, .missingSigningModeMarker),
             ("unknown", nil, official, .unknownSigningModeMarker),
+            ("local-developer-id", "keychain", debug, .markerSignatureMismatch),
+            ("local-developer-id", "keychain", localDeveloperIDWithoutValidatedDomain, .markerSignatureMismatch),
+            ("local-developer-id", "keychain", localDeveloperIDWithoutTeam, .markerSignatureMismatch),
+            ("local-developer-id", "keychain", localDeveloperIDWithoutBundleIdentifier, .markerSignatureMismatch),
             ("release-candidate-adhoc", nil, official, .releaseCandidate),
             ("debug-adhoc", "alternate-in-memory", debug, .adHocDebug),
             ("debug-apple-development", "alternate-in-memory", debug, .debugEphemeralRequested),
@@ -210,7 +253,9 @@ final class RuntimeCodeSigningPolicyTests: XCTestCase {
         expectedDomain: RuntimeSecureStorageDomain,
         expectedReason: RuntimeSecureStorageRejectionReason? = nil,
         expectedLocalCertificateFingerprint: String? = nil,
-        expectedLocalServiceGeneration: Int? = nil
+        expectedLocalServiceGeneration: Int? = nil,
+        expectedLocalBundleIdentifier: String? = nil,
+        expectedLocalTeamIdentifier: String? = nil
     ) {
         XCTAssertEqual(
             RuntimeCodeSigningPolicy.decision(
@@ -223,7 +268,9 @@ final class RuntimeCodeSigningPolicyTests: XCTestCase {
                 domain: expectedDomain,
                 rejectionReason: expectedReason,
                 localCertificateFingerprint: expectedLocalCertificateFingerprint,
-                localServiceGeneration: expectedLocalServiceGeneration
+                localServiceGeneration: expectedLocalServiceGeneration,
+                localBundleIdentifier: expectedLocalBundleIdentifier,
+                localTeamIdentifier: expectedLocalTeamIdentifier
             )
         )
     }

--- a/Tests/RepoPromptTests/Security/KeychainServiceTests.swift
+++ b/Tests/RepoPromptTests/Security/KeychainServiceTests.swift
@@ -162,9 +162,14 @@ final class KeychainServiceTests: XCTestCase {
             KeychainService.localSelfSignedServiceName(fingerprint: fingerprintA, generation: 1),
             KeychainService.localSelfSignedServiceName(fingerprint: fingerprintA, generation: 2),
             KeychainService.localSelfSignedServiceName(fingerprint: fingerprintB, generation: 1),
+            KeychainService.localDeveloperIDServiceName(bundleIdentifier: "com.example.RepoPrompt CE", teamIdentifier: "TEAM123456"),
             KeychainService.debugServiceName
         ])
-        XCTAssertEqual(names.count, 6)
+        XCTAssertEqual(names.count, 7)
+        XCTAssertEqual(
+            KeychainService.localDeveloperIDServiceName(bundleIdentifier: "com.example.RepoPrompt CE", teamIdentifier: "TEAM123456"),
+            "repoprompt.ce.local-developer-id.team123456.com.example.repoprompt-ce.keychain.v1"
+        )
 
         let fake = FakeSecItemClient { _, _ in errSecItemNotFound }
         let legacy = KeychainService.legacyRepairSource(secItemClient: fake)


### PR DESCRIPTION
## Summary
- add a local-only Developer ID production packaging/install mode for contributors with their own Apple Developer ID Application identity
- require personal display/bundle identity and derive an isolated URL scheme so local installs do not collide with public/debug app identity
- add local Developer ID runtime signing validation and a Keychain namespace derived from team ID + bundle ID

## Validation
- Subagent reviewer loop completed with no blockers or simplification findings worth fixing before commit
- `bash -n Scripts/package_app.sh Scripts/install_local_production.sh Scripts/validate_staged_release.sh`
- `python3 Scripts/test_local_production_installer.py`
- `python3 Scripts/test_release_tooling.py`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh commit`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh push`
