### PR TITLE
Fix MCP transport timeout recovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,7 +157,7 @@ Daemon output defaults are intentionally concise for agent use: synchronous `dev
 
 Behavior notes:
 
-- `make dev-run` (daemon `run`) still delegates to the debug launch flow and stops any existing `RepoPrompt`, same as `make run`; it remains FIFO and does not supersede older lifecycle work.
+- `make dev-run` (daemon `run`) still delegates to the debug launch flow and stops only the running process whose resolved executable matches the target CE debug app, same as `make run`; it remains FIFO and does not supersede older lifecycle work.
 - `./conductor app relaunch` is the overriding interactive relaunch used by the Finder launcher; like `app stop`, it can cancel older active or queued `liveApp` work. It builds/packages before replacing the visible app, so a failure before lifecycle work begins does not itself stop or reopen an already-running app.
 - Do not assume an in-flight `run`, `smoke`, or diagnostics job will complete if another operator issues `app stop` or interactive `app relaunch`.
 - `make dev-smoke` is the non-disruptive live-only check: it assumes the CE debug app is already running and the debug CLI is installed/resolvable.
@@ -166,7 +166,7 @@ Behavior notes:
 - Style checks (`make dev-format-check`, `make dev-lint`) are non-mutating and do not auto-install tools; `make dev-install-format-tools` is the explicit install path.
 - Do not run `make dev-format` unless formatting mutation is intended. If a format job is canceled after starting, inspect `git diff` and rerun format or restore files as needed.
 
-Direct / uncoordinated commands — use only when the daemon is unavailable (for example, no `python3`):
+Direct / uncoordinated commands — use only when the daemon is unavailable but required tooling, including `python3`, remains available:
 
 ```bash
 make build
@@ -174,7 +174,7 @@ make run
 make test
 ```
 
-These do not claim daemon lanes or lifecycle supersession, so when multiple agents are active they can build, launch, or run style tooling over each other; a direct launch may reopen the app after a coordinated stop. The Finder launcher also falls back to this direct behavior when `python3` is unavailable, with process-only status/stop controls. Prefer the `dev-*` aliases when the daemon is available. The manual `rpce-cli-debug` commands above remain valid for direct live MCP validation.
+These do not claim daemon lanes or lifecycle supersession, so when multiple agents are active they can build, launch, or run style tooling over each other; a direct launch may reopen the app after a coordinated stop. The Finder launcher requires `python3` and does not provide an uncoordinated no-Python fallback because safe lifecycle actions require exact debug-executable identity checks. Prefer the `dev-*` aliases when the daemon is available. The manual `rpce-cli-debug` commands above remain valid for direct live MCP validation.
 
 ## Source placement rules
 

--- a/Launch RepoPrompt CE.command
+++ b/Launch RepoPrompt CE.command
@@ -3,20 +3,15 @@ set -uo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONDUCTOR="$ROOT_DIR/conductor"
-RUN_SCRIPT="$ROOT_DIR/Scripts/run.sh"
 APP_ARGS=("$@")
-LAUNCH_MODE="coordinated"
 
 if ! command -v python3 >/dev/null 2>&1; then
-    LAUNCH_MODE="direct"
-    if [[ ! -x "$RUN_SCRIPT" ]]; then
-        echo "Python 3 isn't available, and the direct launcher script is missing:"
-        echo "$RUN_SCRIPT"
-        echo
-        echo "Make sure this file is still in the repoprompt-ce folder and that Scripts/run.sh is executable."
-        read -r -p "Press Return to close this window..." || true
-        exit 1
-    fi
+    echo "RepoPrompt CE's safe coordinated launcher requires Python 3."
+    echo "No uncoordinated fallback is provided because app lifecycle actions must validate the exact debug executable path."
+    echo
+    echo "Install Python 3, then reopen this launcher."
+    read -r -p "Press Return to close this window..." || true
+    exit 1
 elif [[ ! -x "$CONDUCTOR" ]]; then
     echo "Couldn't find the coordinated launcher:"
     echo "$CONDUCTOR"
@@ -28,22 +23,11 @@ fi
 
 launch_app() {
     echo
-    if [[ "$LAUNCH_MODE" == "coordinated" ]]; then
-        echo "Building and relaunching RepoPrompt CE..."
-        echo "This run becomes the active launch; any older build or launch jobs still in flight are canceled."
-        echo
-        if (( ${#APP_ARGS[@]} > 0 )); then
-            if "$CONDUCTOR" app relaunch -- "${APP_ARGS[@]}"; then
-                echo
-                echo "RepoPrompt CE has been relaunched."
-            else
-                echo
-                echo "RepoPrompt CE was not relaunched."
-                echo "Check the result above to see whether the build failed or this run was canceled/replaced."
-                echo "If the build failed, fix the errors (or let in-flight edits settle), then press r to retry."
-                echo "Press s to check the current app and job state."
-            fi
-        elif "$CONDUCTOR" app relaunch; then
+    echo "Building and relaunching RepoPrompt CE..."
+    echo "This run becomes the active launch; any older build or launch jobs still in flight are canceled."
+    echo
+    if (( ${#APP_ARGS[@]} > 0 )); then
+        if "$CONDUCTOR" app relaunch -- "${APP_ARGS[@]}"; then
             echo
             echo "RepoPrompt CE has been relaunched."
         else
@@ -53,70 +37,44 @@ launch_app() {
             echo "If the build failed, fix the errors (or let in-flight edits settle), then press r to retry."
             echo "Press s to check the current app and job state."
         fi
-    else
-        echo "Building and launching RepoPrompt CE directly (no daemon)..."
-        echo "This launch isn't coordinated and can't replace daemon-managed builds or launches."
+    elif "$CONDUCTOR" app relaunch; then
         echo
-        if "$RUN_SCRIPT" "${APP_ARGS[@]}"; then
-            echo
-            echo "RepoPrompt CE has been launched directly."
-        else
-            echo
-            echo "Direct rebuild/launch failed. Review the output above, then press r to retry."
-            echo "Direct mode can't classify failures or supersede daemon-managed work."
-        fi
+        echo "RepoPrompt CE has been relaunched."
+    else
+        echo
+        echo "RepoPrompt CE was not relaunched."
+        echo "Check the result above to see whether the build failed or this run was canceled/replaced."
+        echo "If the build failed, fix the errors (or let in-flight edits settle), then press r to retry."
+        echo "Press s to check the current app and job state."
     fi
 }
 
 show_status() {
     echo
-    if [[ "$LAUNCH_MODE" == "coordinated" ]]; then
-        echo "Current RepoPrompt CE app status:"
+    echo "Current RepoPrompt CE app status:"
+    echo
+    if ! "$CONDUCTOR" app status --full-log; then
         echo
-        if ! "$CONDUCTOR" app status --full-log; then
-            echo
-            echo "Couldn't read app status. Review the daemon output above and try again."
-        fi
+        echo "Couldn't read app status. Review the daemon output above and try again."
+    fi
+    echo
+    echo "Pending daemon jobs that may change the app next:"
+    echo "Only daemon-managed jobs show up here; direct commands and source edits aren't tracked."
+    echo
+    if ! "$CONDUCTOR" status; then
         echo
-        echo "Pending daemon jobs that may change the app next:"
-        echo "Only daemon-managed jobs show up here; direct commands and source edits aren't tracked."
-        echo
-        if ! "$CONDUCTOR" status; then
-            echo
-            echo "Couldn't read daemon activity. Review the daemon output above and try again."
-        fi
-    else
-        echo "RepoPrompt CE process status (direct mode):"
-        echo "Daemon jobs aren't visible here because python3 is unavailable."
-        echo
-        local pids
-        if pids="$(pgrep -x RepoPrompt 2>/dev/null)"; then
-            echo "RepoPrompt is running (PID(s): ${pids//$'\n'/, })."
-        else
-            echo "No running RepoPrompt process found."
-        fi
+        echo "Couldn't read daemon activity. Review the daemon output above and try again."
     fi
 }
 
 stop_app() {
     echo
-    if [[ "$LAUNCH_MODE" == "coordinated" ]]; then
-        echo "Stopping RepoPrompt CE..."
-        echo "Older build or launch jobs that could reopen it are canceled too."
+    echo "Stopping RepoPrompt CE..."
+    echo "Older build or launch jobs that could reopen it are canceled too."
+    echo
+    if ! "$CONDUCTOR" app stop --full-log; then
         echo
-        if ! "$CONDUCTOR" app stop --full-log; then
-            echo
-            echo "Couldn't stop RepoPrompt. Review the daemon output above, or press s to check status."
-        fi
-    else
-        echo "Requesting a direct stop of RepoPrompt CE (no daemon)..."
-        echo "This can't cancel daemon-managed or other launch jobs that may reopen the app."
-        echo
-        if pkill -x RepoPrompt 2>/dev/null; then
-            echo "Sent a stop request to RepoPrompt."
-        else
-            echo "No running RepoPrompt process found."
-        fi
+        echo "Couldn't stop RepoPrompt. Review the daemon output above, or press s to check status."
     fi
 }
 
@@ -151,12 +109,7 @@ clear 2>/dev/null || true
 echo "RepoPrompt CE — local debug launcher"
 echo
 echo "Project: $ROOT_DIR"
-if [[ "$LAUNCH_MODE" == "coordinated" ]]; then
-    echo "Mode:    coordinated (builds and launches run through the dev daemon)"
-else
-    echo "Mode:    direct (python3 unavailable — running without the dev daemon)"
-    echo "         Job coordination and status are off, so launches may conflict with other runs."
-fi
+echo "Mode:    coordinated (builds and launches run through the dev daemon)"
 
 cd "$ROOT_DIR" || exit 1
 launch_app
@@ -164,17 +117,10 @@ launch_app
 while true; do
     echo
     echo "Choose an action:"
-    if [[ "$LAUNCH_MODE" == "coordinated" ]]; then
-        echo "  r  Rebuild and relaunch RepoPrompt CE"
-        echo "  s  Show app status and pending daemon jobs"
-        echo "  x  Stop the app (also cancels older build/launch jobs)"
-        echo "  q  Close this launcher tab only (leaves the app running)"
-    else
-        echo "  r  Rebuild and relaunch directly (no daemon)"
-        echo "  s  Show process status only (daemon jobs unavailable)"
-        echo "  x  Request a direct app stop (can't cancel other jobs)"
-        echo "  q  Close this launcher tab only (leaves the app running)"
-    fi
+    echo "  r  Rebuild and relaunch RepoPrompt CE"
+    echo "  s  Show app status and pending daemon jobs"
+    echo "  x  Stop the app (also cancels older build/launch jobs)"
+    echo "  q  Close this launcher tab only (leaves the app running)"
     echo
 
     if ! IFS= read -r -n 1 -p "Action [r/s/x/q]: " choice; then

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ guardrails:
 	./Scripts/swiftpm_notice_guardrails.sh
 
 conductor-selftest:
+	python3 Scripts/test_debug_app_process.py
 	python3 Scripts/test_conductor_output.py
 	python3 Scripts/test_conductor_lifecycle.py
 	python3 Scripts/test_local_production_installer.py

--- a/README.md
+++ b/README.md
@@ -41,8 +41,11 @@ and local development.
 For development and quick evaluation, double-click
 [`Launch RepoPrompt CE.command`](Launch%20RepoPrompt%20CE.command) in Finder.
 
-The launcher builds RepoPrompt CE from source, opens the debug app, and keeps a
-small terminal window available for rebuild, status, and stop controls.
+The launcher requires Python 3, builds RepoPrompt CE through the coordinated
+developer daemon, opens the debug app, and keeps a small terminal window
+available for rebuild, status, and stop controls. It does not provide an
+uncoordinated no-Python fallback because lifecycle actions validate the exact
+debug executable path.
 
 The debug launcher uses an available `Apple Development:` signing identity. If
 your Mac does not have one, run the same debug app from Terminal with explicit

--- a/Scripts/conductor.py
+++ b/Scripts/conductor.py
@@ -31,7 +31,9 @@ from collections import deque
 from pathlib import Path
 from typing import Any, Deque, Dict, List, Optional, Sequence, Tuple
 
-PROTOCOL_VERSION = 4
+from debug_app_process import ProcessIdentityError, matching_processes, terminate_matching_processes
+
+PROTOCOL_VERSION = 5
 TERMINAL_STATES = {"completed", "failed", "canceled"}
 LANE_NAMES = {"build", "debugArtifact", "liveApp", "release", "style"}
 LOG_TAIL_LINES = 30
@@ -449,7 +451,7 @@ class OutputSummarizer:
         r"^(Created:|APP_BUNDLE=|COMPAT_APP_BUNDLE=|CLI_PATH=|Output written to:|Agent Mode diagnostics enabled|Resolved rpce-cli-debug:)"
     )
     APP_LIFECYCLE_RE = re.compile(
-        r"(Stopping existing RepoPrompt instance|Waiting for existing RepoPrompt process to exit|Launching .*RepoPrompt\.app|Confirming launched RepoPrompt process|Observed launched RepoPrompt PID|Guarding against a delayed RepoPrompt launch|Delayed launch guard confirmed|RepoPrompt stop confirmed|RepoPrompt was (not running|already stopped))"
+        r"(Stopping existing RepoPrompt|Waiting for existing RepoPrompt|Launching .*RepoPrompt\.app|Confirming launched RepoPrompt|Observed launched RepoPrompt|Guarding against a delayed RepoPrompt|Delayed launch guard confirmed|RepoPrompt(?: CE debug app)? stop confirmed|RepoPrompt was (not running|already stopped))"
     )
     SOURCE_CHANGED_DURING_BUILD_RE = re.compile(r"input file .* was modified during the build", re.IGNORECASE)
 
@@ -515,12 +517,12 @@ class OutputSummarizer:
             line = clean_summary_line(str(raw_line))
             tail.append(line)
 
-            if "Stopping existing RepoPrompt instance" in line:
+            if "Stopping existing RepoPrompt" in line:
                 launch_lifecycle["transitionStarted"] = True
             if "Launching " in line and "RepoPrompt.app" in line:
                 launch_lifecycle["transitionStarted"] = True
                 launch_lifecycle["launchRequested"] = True
-            if "Observed launched RepoPrompt PID" in line:
+            if "Observed launched RepoPrompt" in line:
                 launch_lifecycle["launchConfirmed"] = True
             if cls.SOURCE_CHANGED_DURING_BUILD_RE.search(line):
                 launch_lifecycle["sourceChangedDuringBuild"] = True
@@ -2578,18 +2580,30 @@ def debug_app_bundle_path() -> Path:
     return Path(os.environ.get("REPOPROMPT_DEBUG_APP_BUNDLE", str(Path(root) / "RepoPrompt.app")))
 
 
-def find_repoprompt_pids() -> List[str]:
-    pgrep = subprocess.run(["pgrep", "-x", "RepoPrompt"], text=True, capture_output=True)
-    return [line.strip() for line in pgrep.stdout.splitlines() if line.strip()]
+def debug_app_executable_path() -> Path:
+    return debug_app_bundle_path() / "Contents" / "MacOS" / "RepoPrompt"
+
+
+def find_debug_app_pids() -> List[str]:
+    return [str(pid) for pid in matching_processes(debug_app_executable_path())]
+
+
+def terminate_debug_app_processes() -> List[str]:
+    return [str(pid) for pid in terminate_matching_processes(debug_app_executable_path())]
 
 
 def operation_app_status(repo_root: Path) -> int:
     bundle = debug_app_bundle_path()
     print("RepoPrompt CE debug app status")
-    print(f"  Running RepoPrompt PIDs: ", end="")
-    pids = find_repoprompt_pids()
-    print(", ".join(pids) if pids else "none")
     print(f"  Debug app bundle: {bundle}")
+    print("  Running matching debug app PIDs: ", end="")
+    try:
+        pids = find_debug_app_pids()
+    except ProcessIdentityError as exc:
+        print("unknown")
+        print(f"ERROR: could not safely identify the debug app process: {exc}")
+        return 1
+    print(", ".join(pids) if pids else "none")
     print(f"  Bundle exists: {'yes' if bundle.exists() else 'no'}")
     if bundle.exists():
         # Keep the signing/storage probes aligned with Scripts/run.sh launch diagnostics.
@@ -2624,18 +2638,22 @@ def operation_app_stop(repo_root: Path, args: Dict[str, Any]) -> int:
     quiet_since: Optional[float] = None
     observed_process = False
     if guard_delayed_launch:
-        print("Guarding against a delayed RepoPrompt launch from superseded app work.", flush=True)
+        print("Guarding against a delayed RepoPrompt CE debug app launch from superseded app work.", flush=True)
     while True:
-        pids = find_repoprompt_pids()
+        try:
+            pids = find_debug_app_pids()
+        except ProcessIdentityError as exc:
+            print(f"ERROR: could not safely identify the debug app process: {exc}", flush=True)
+            return 1
         if pids:
             observed_process = True
             quiet_since = None
-            print(f"Observed running RepoPrompt PID(s): {', '.join(pids)}", flush=True)
-            code, _stdout, _stderr = run_operation_command(
-                "stop RepoPrompt", ["pkill", "-x", "RepoPrompt"], repo_root, allow_exit_codes={0, 1}
-            )
-            if code not in {0, 1}:
-                return code
+            print(f"Observed running RepoPrompt CE debug PID(s): {', '.join(pids)}", flush=True)
+            try:
+                terminate_debug_app_processes()
+            except ProcessIdentityError as exc:
+                print(f"ERROR: refused to signal a process without validated debug app identity: {exc}", flush=True)
+                return 1
         else:
             if quiet_since is None:
                 quiet_since = now()

--- a/Scripts/debug_app_process.py
+++ b/Scripts/debug_app_process.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Identify and terminate only the configured RepoPrompt CE debug executable."""
+
+from __future__ import annotations
+
+import argparse
+import ctypes
+import errno
+import os
+import signal
+import stat
+import sys
+from pathlib import Path
+from typing import Callable, Protocol
+
+PROC_ALL_PIDS = 1
+PROC_PIDPATHINFO_MAXSIZE = 4096
+
+
+class ProcessIdentityError(RuntimeError):
+    pass
+
+
+class TargetExecutableMissing(ProcessIdentityError):
+    pass
+
+
+class ProcessGone(ProcessIdentityError):
+    pass
+
+
+class ProcessInspector(Protocol):
+    def list_pids(self) -> list[int]: ...
+
+    def process_name(self, pid: int) -> str | None: ...
+
+    def process_path(self, pid: int) -> Path: ...
+
+
+class LibProcInspector:
+    def __init__(self) -> None:
+        if sys.platform != "darwin":
+            raise ProcessIdentityError("debug app process checks require macOS")
+        self.libproc = ctypes.CDLL("/usr/lib/libproc.dylib", use_errno=True)
+        self.libproc.proc_listpids.argtypes = [ctypes.c_uint32, ctypes.c_uint32, ctypes.c_void_p, ctypes.c_int]
+        self.libproc.proc_listpids.restype = ctypes.c_int
+        self.libproc.proc_name.argtypes = [ctypes.c_int, ctypes.c_void_p, ctypes.c_uint32]
+        self.libproc.proc_name.restype = ctypes.c_int
+        self.libproc.proc_pidpath.argtypes = [ctypes.c_int, ctypes.c_void_p, ctypes.c_uint32]
+        self.libproc.proc_pidpath.restype = ctypes.c_int
+
+    def list_pids(self) -> list[int]:
+        capacity = 4096
+        while capacity <= 1_048_576:
+            buffer = (ctypes.c_int * capacity)()
+            byte_count = self.libproc.proc_listpids(PROC_ALL_PIDS, 0, buffer, ctypes.sizeof(buffer))
+            if byte_count <= 0:
+                error = ctypes.get_errno()
+                detail = os.strerror(error) if error else "process enumeration failed"
+                raise ProcessIdentityError(f"could not enumerate processes: {detail}")
+            count = byte_count // ctypes.sizeof(ctypes.c_int)
+            if count < capacity:
+                return [pid for pid in buffer[:count] if pid > 0]
+            capacity *= 2
+        raise ProcessIdentityError("process enumeration exceeded the supported capacity")
+
+    def process_name(self, pid: int) -> str | None:
+        buffer = ctypes.create_string_buffer(PROC_PIDPATHINFO_MAXSIZE)
+        length = self.libproc.proc_name(pid, buffer, len(buffer))
+        if length <= 0:
+            return None
+        return os.fsdecode(buffer.value)
+
+    def process_path(self, pid: int) -> Path:
+        buffer = ctypes.create_string_buffer(PROC_PIDPATHINFO_MAXSIZE)
+        length = self.libproc.proc_pidpath(pid, buffer, len(buffer))
+        if length <= 0:
+            error = ctypes.get_errno()
+            if error in {errno.ENOENT, errno.ESRCH}:
+                raise ProcessGone(f"process {pid} exited before its executable could be resolved")
+            detail = os.strerror(error) if error else "process is unavailable"
+            raise ProcessIdentityError(f"could not resolve executable for pid {pid}: {detail}")
+        try:
+            return Path(os.fsdecode(buffer.value)).resolve(strict=True)
+        except OSError as exc:
+            raise ProcessIdentityError(f"could not resolve executable path for pid {pid}: {exc}") from exc
+
+
+def expected_executable_path(path: Path) -> Path:
+    try:
+        resolved = path.expanduser().resolve(strict=True)
+        metadata = resolved.stat()
+    except FileNotFoundError as exc:
+        raise TargetExecutableMissing(f"target debug app executable is not installed: {path}") from exc
+    except OSError as exc:
+        raise ProcessIdentityError(f"target debug app executable is unavailable: {path}: {exc}") from exc
+    if not stat.S_ISREG(metadata.st_mode) or not metadata.st_mode & 0o111:
+        raise ProcessIdentityError(f"target debug app executable is not executable: {resolved}")
+    return resolved
+
+
+def matching_processes(expected_executable: Path, inspector: ProcessInspector | None = None) -> list[int]:
+    try:
+        expected = expected_executable_path(expected_executable)
+    except TargetExecutableMissing:
+        return []
+    active_inspector = inspector or LibProcInspector()
+    matches: list[int] = []
+    for pid in active_inspector.list_pids():
+        if active_inspector.process_name(pid) != expected.name:
+            continue
+        try:
+            actual = active_inspector.process_path(pid)
+        except ProcessGone:
+            continue
+        if actual == expected:
+            matches.append(pid)
+    return matches
+
+
+def terminate_matching_processes(
+    expected_executable: Path,
+    inspector: ProcessInspector | None = None,
+    signaler: Callable[[int, int], None] = os.kill,
+) -> list[int]:
+    try:
+        expected = expected_executable_path(expected_executable)
+    except TargetExecutableMissing:
+        return []
+    active_inspector = inspector or LibProcInspector()
+    signaled: list[int] = []
+    for pid in matching_processes(expected, active_inspector):
+        try:
+            actual = active_inspector.process_path(pid)
+        except ProcessGone:
+            continue
+        if actual != expected:
+            raise ProcessIdentityError(
+                f"refusing to signal pid {pid}: executable changed during identity revalidation "
+                f"(expected {expected}, got {actual})"
+            )
+        try:
+            signaler(pid, signal.SIGTERM)
+        except ProcessLookupError:
+            continue
+        except OSError as exc:
+            raise ProcessIdentityError(f"could not signal debug app pid {pid}: {exc}") from exc
+        signaled.append(pid)
+    return signaled
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("operation", choices=["list", "terminate"])
+    parser.add_argument("--executable", required=True, type=Path)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    try:
+        if args.operation == "list":
+            pids = matching_processes(args.executable)
+        else:
+            pids = terminate_matching_processes(args.executable)
+    except ProcessIdentityError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    for pid in pids:
+        print(pid)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/Scripts/run.sh
+++ b/Scripts/run.sh
@@ -13,22 +13,29 @@ phase(){
 }
 run(){ printf '+ '; printf '%q ' "$@"; printf '\n'; "$@"; }
 DELAYED_LAUNCH_GUARD_SECONDS=12
-find_repoprompt_pids(){ pgrep -x RepoPrompt 2>/dev/null || true; }
-wait_for_no_repoprompt_process(){
+find_debug_app_pids(){ python3 "$PROCESS_HELPER" list --executable "$APP_EXECUTABLE"; }
+terminate_debug_app_processes(){ python3 "$PROCESS_HELPER" terminate --executable "$APP_EXECUTABLE"; }
+wait_for_no_debug_app_process(){
     local deadline pids
     deadline=$(( $(date +%s) + 5 ))
     while (( $(date +%s) <= deadline )); do
-        pids="$(find_repoprompt_pids)"
+        if ! pids="$(find_debug_app_pids)"; then
+            echo "ERROR: could not safely identify the RepoPrompt CE debug app process."
+            return 1
+        fi
         [[ -z "$pids" ]] && return 0
         sleep 0.2
     done
     return 1
 }
-wait_for_repoprompt_process(){
+wait_for_debug_app_process(){
     local deadline pids
     deadline=$(( $(date +%s) + 10 ))
     while (( $(date +%s) <= deadline )); do
-        pids="$(find_repoprompt_pids)"
+        if ! pids="$(find_debug_app_pids)"; then
+            echo "ERROR: could not safely identify the launched RepoPrompt CE debug app process." >&2
+            return 1
+        fi
         if [[ -n "$pids" ]]; then
             printf '%s\n' "$pids"
             return 0
@@ -37,26 +44,34 @@ wait_for_repoprompt_process(){
     done
     return 1
 }
-guard_delayed_repoprompt_launch(){
-    local deadline pids
+guard_delayed_debug_app_launch(){
+    local deadline pids terminated_pids
     deadline=$(( $(date +%s) + DELAYED_LAUNCH_GUARD_SECONDS ))
     while (( $(date +%s) <= deadline )); do
-        pids="$(find_repoprompt_pids)"
+        if ! pids="$(find_debug_app_pids)"; then
+            echo "ERROR: could not safely identify a delayed RepoPrompt CE debug app process."
+            return 1
+        fi
         if [[ -n "$pids" ]]; then
-            printf 'Observed delayed RepoPrompt PID(s): %s\n' "$(printf '%s' "$pids" | paste -sd ', ' -)"
-            run pkill -x RepoPrompt 2>/dev/null || true
+            printf 'Observed delayed RepoPrompt CE debug PID(s): %s\n' "$(printf '%s' "$pids" | paste -sd ', ' -)"
+            if ! terminated_pids="$(terminate_debug_app_processes)"; then
+                echo "ERROR: refused to signal a delayed process without validated debug app identity."
+                return 1
+            fi
         fi
         sleep 0.2
     done
-    if ! wait_for_no_repoprompt_process; then
-        echo "ERROR: RepoPrompt remained running after delayed-launch guard."
+    if ! wait_for_no_debug_app_process; then
+        echo "ERROR: RepoPrompt CE debug app remained running after delayed-launch guard."
         return 1
     fi
-    echo "Delayed launch guard confirmed RepoPrompt stopped."
+    echo "Delayed launch guard confirmed RepoPrompt CE debug app stopped."
 }
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PROCESS_HELPER="$ROOT_DIR/Scripts/debug_app_process.py"
 DEBUG_APP_ROOT="${REPOPROMPT_DEBUG_APP_ROOT:-$HOME/Library/Application Support/RepoPrompt CE/DebugApps}"
 APP_BUNDLE="${REPOPROMPT_DEBUG_APP_BUNDLE:-$DEBUG_APP_ROOT/RepoPrompt.app}"
+APP_EXECUTABLE="$APP_BUNDLE/Contents/MacOS/RepoPrompt"
 export REPOPROMPT_DEBUG_APP_BUNDLE="$APP_BUNDLE"
 phase "Packaging debug app"
 run "$ROOT_DIR/Scripts/package_app.sh" debug
@@ -74,25 +89,28 @@ if [[ "$DEBUG_STORAGE_BACKEND_MARKER" != "keychain" ]]; then
 elif [[ -z "$TEAM_ID" || "$TEAM_ID" == "not set" ]]; then
     echo "WARNING: Launching a keychain-marked debug app without a team identifier; runtime will fall back to in-memory secure storage."
 fi
-phase "Stopping existing RepoPrompt instance"
-run pkill -x RepoPrompt 2>/dev/null || true
-phase "Waiting for existing RepoPrompt process to exit"
-if ! wait_for_no_repoprompt_process; then
-    echo "ERROR: existing RepoPrompt process did not exit within 5 seconds; refusing to open another instance."
+phase "Stopping existing RepoPrompt CE debug app instance"
+if ! TERMINATED_PIDS="$(terminate_debug_app_processes)"; then
+    echo "ERROR: refused to stop a process without validated RepoPrompt CE debug app identity."
     exit 1
 fi
-echo "RepoPrompt stop confirmed."
+phase "Waiting for existing RepoPrompt CE debug app process to exit"
+if ! wait_for_no_debug_app_process; then
+    echo "ERROR: existing RepoPrompt CE debug app process did not exit within 5 seconds; refusing to open another instance."
+    exit 1
+fi
+echo "RepoPrompt CE debug app stop confirmed."
 if [[ "${REPOPROMPT_GUARD_DELAYED_LAUNCH:-0}" == "1" ]]; then
-    phase "Guarding against a delayed RepoPrompt launch from superseded app work"
-    guard_delayed_repoprompt_launch
+    phase "Guarding against a delayed RepoPrompt CE debug app launch from superseded app work"
+    guard_delayed_debug_app_launch
 fi
 phase "Launching $APP_BUNDLE"
 if (( $# > 0 )); then run open -n "$APP_BUNDLE" --args "$@"; else run open -n "$APP_BUNDLE"; fi
-phase "Confirming launched RepoPrompt process"
-if ! LAUNCHED_PIDS="$(wait_for_repoprompt_process)"; then
-    echo "ERROR: launch request returned, but no RepoPrompt process appeared within 10 seconds."
-    phase "Guarding against a delayed RepoPrompt launch after launch confirmation failure"
-    guard_delayed_repoprompt_launch || true
+phase "Confirming launched RepoPrompt CE debug app process"
+if ! LAUNCHED_PIDS="$(wait_for_debug_app_process)"; then
+    echo "ERROR: launch request returned, but no matching RepoPrompt CE debug app process appeared within 10 seconds."
+    phase "Guarding against a delayed RepoPrompt CE debug app launch after launch confirmation failure"
+    guard_delayed_debug_app_launch || true
     exit 1
 fi
-printf 'Observed launched RepoPrompt PID(s): %s\n' "$(printf '%s' "$LAUNCHED_PIDS" | paste -sd ', ' -)"
+printf 'Observed launched RepoPrompt CE debug PID(s): %s\n' "$(printf '%s' "$LAUNCHED_PIDS" | paste -sd ', ' -)"

--- a/Scripts/test_conductor_lifecycle.py
+++ b/Scripts/test_conductor_lifecycle.py
@@ -72,8 +72,8 @@ class LifecycleTestCase(unittest.TestCase):
 
 
 class LifecycleQueueTests(LifecycleTestCase):
-    def test_protocol_version_bump_replaces_protocol_3_daemons(self) -> None:
-        self.assertEqual(conductor.PROTOCOL_VERSION, 4)
+    def test_protocol_version_bump_replaces_older_daemons(self) -> None:
+        self.assertEqual(conductor.PROTOCOL_VERSION, 5)
 
     def test_ensure_daemon_stops_and_replaces_idle_protocol_3_daemon(self) -> None:
         tmp, state = self.make_state()
@@ -634,7 +634,7 @@ class SmokeOperationTests(unittest.TestCase):
 
 
 class RunScriptTransitionTests(unittest.TestCase):
-    def test_guarded_failed_relaunch_does_not_stop_existing_app_before_packaging_succeeds(self) -> None:
+    def test_guarded_failed_relaunch_does_not_inspect_or_stop_before_packaging_succeeds(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             scripts = root / "Scripts"
@@ -645,29 +645,148 @@ class RunScriptTransitionTests(unittest.TestCase):
             package_script = scripts / "package_app.sh"
             package_script.write_text("#!/usr/bin/env bash\necho package failed\nexit 23\n", encoding="utf-8")
             package_script.chmod(0o755)
-            bin_dir = root / "bin"
-            bin_dir.mkdir()
-            (bin_dir / "pgrep").write_text("#!/usr/bin/env bash\necho 4242\n", encoding="utf-8")
-            (bin_dir / "pkill").write_text("#!/usr/bin/env bash\necho invoked > \"$PKILL_MARKER\"\n", encoding="utf-8")
-            (bin_dir / "pgrep").chmod(0o755)
-            (bin_dir / "pkill").chmod(0o755)
-            marker = root / "pkill-invoked"
+            marker = root / "process-helper-invoked"
+            helper = scripts / "debug_app_process.py"
+            helper.write_text(
+                "from pathlib import Path\nimport os\nPath(os.environ['PROCESS_HELPER_MARKER']).write_text('invoked')\n",
+                encoding="utf-8",
+            )
             env = os.environ.copy()
             env.update(
                 {
-                    "PATH": f"{bin_dir}:{env.get('PATH', '')}",
-                    "PKILL_MARKER": str(marker),
+                    "PROCESS_HELPER_MARKER": str(marker),
                     "REPOPROMPT_GUARD_DELAYED_LAUNCH": "1",
                 }
             )
 
             result = subprocess.run(["bash", str(run_script)], env=env, text=True, capture_output=True, timeout=2)
-            pkill_invoked = marker.exists()
+            helper_invoked = marker.exists()
 
         self.assertEqual(result.returncode, 23)
         self.assertIn("Packaging debug app", result.stdout)
-        self.assertNotIn("Stopping existing RepoPrompt instance", result.stdout)
-        self.assertFalse(pkill_invoked)
+        self.assertNotIn("Stopping existing RepoPrompt CE debug app instance", result.stdout)
+        self.assertFalse(helper_invoked)
+
+    def test_successful_relaunch_uses_debug_executable_for_stop_and_readiness(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            scripts = root / "Scripts"
+            scripts.mkdir()
+            run_script = scripts / "run.sh"
+            shutil.copy2(SCRIPT_DIR / "run.sh", run_script)
+            run_script.chmod(0o755)
+            event_log = root / "events.log"
+            launched_marker = root / "launched"
+            app_bundle = root / "DebugApps" / "RepoPrompt.app"
+            app_executable = app_bundle / "Contents" / "MacOS" / "RepoPrompt"
+            package_script = scripts / "package_app.sh"
+            package_script.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/usr/bin/env bash
+                    set -e
+                    echo package >> "$EVENT_LOG"
+                    mkdir -p "$REPOPROMPT_DEBUG_APP_BUNDLE/Contents/MacOS"
+                    printf binary > "$REPOPROMPT_DEBUG_APP_BUNDLE/Contents/MacOS/RepoPrompt"
+                    chmod +x "$REPOPROMPT_DEBUG_APP_BUNDLE/Contents/MacOS/RepoPrompt"
+                    """
+                ),
+                encoding="utf-8",
+            )
+            package_script.chmod(0o755)
+            helper = scripts / "debug_app_process.py"
+            helper.write_text(
+                textwrap.dedent(
+                    """\
+                    import os
+                    import sys
+                    from pathlib import Path
+
+                    operation = sys.argv[1]
+                    executable = sys.argv[sys.argv.index("--executable") + 1]
+                    state = "launched" if Path(os.environ["LAUNCHED_MARKER"]).exists() else "stopped"
+                    with Path(os.environ["EVENT_LOG"]).open("a", encoding="utf-8") as handle:
+                        handle.write(f"{operation}:{state}:{executable}\\n")
+                    if operation == "list" and state == "launched":
+                        print("4242")
+                    """
+                ),
+                encoding="utf-8",
+            )
+            bin_dir = root / "bin"
+            bin_dir.mkdir()
+            (bin_dir / "codesign").write_text("#!/usr/bin/env bash\necho TeamIdentifier=TEST >&2\n", encoding="utf-8")
+            (bin_dir / "plutil").write_text("#!/usr/bin/env bash\necho memory\n", encoding="utf-8")
+            (bin_dir / "open").write_text(
+                "#!/usr/bin/env bash\necho open >> \"$EVENT_LOG\"\ntouch \"$LAUNCHED_MARKER\"\n",
+                encoding="utf-8",
+            )
+            for command in ["codesign", "plutil", "open"]:
+                (bin_dir / command).chmod(0o755)
+            env = os.environ.copy()
+            env.update(
+                {
+                    "PATH": f"{bin_dir}:{env.get('PATH', '')}",
+                    "EVENT_LOG": str(event_log),
+                    "LAUNCHED_MARKER": str(launched_marker),
+                    "REPOPROMPT_DEBUG_APP_BUNDLE": str(app_bundle),
+                }
+            )
+
+            result = subprocess.run(["bash", str(run_script), "--demo"], env=env, text=True, capture_output=True, timeout=5)
+            events = event_log.read_text(encoding="utf-8").splitlines()
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        expected_suffix = f":{app_executable}"
+        self.assertEqual(events[0], "package")
+        self.assertEqual(events[1], f"terminate:stopped:{app_executable}")
+        self.assertEqual(events[2], f"list:stopped:{app_executable}")
+        self.assertEqual(events[3], "open")
+        self.assertEqual(events[4], f"list:launched:{app_executable}")
+        self.assertTrue(all(event.endswith(expected_suffix) for event in events if event.startswith(("list:", "terminate:"))))
+        source = (SCRIPT_DIR / "run.sh").read_text(encoding="utf-8")
+        self.assertIn("Observed launched RepoPrompt CE debug PID(s): 4242", result.stdout)
+        self.assertNotIn("pgrep", source)
+        self.assertNotIn("pkill", source)
+
+
+class AppStatusIdentityTests(unittest.TestCase):
+    def test_status_treats_missing_debug_executable_as_not_installed(self) -> None:
+        output = io.StringIO()
+        with tempfile.TemporaryDirectory() as tmp, mock.patch.dict(
+            os.environ,
+            {"REPOPROMPT_DEBUG_APP_BUNDLE": str(Path(tmp) / "missing" / "RepoPrompt.app")},
+        ), mock.patch.object(conductor, "run_operation_command", return_value=(0, "", "")), contextlib.redirect_stdout(output):
+            code = conductor.operation_app_status(Path("/tmp/repo"))
+
+        self.assertEqual(code, 0)
+        self.assertIn("Running matching debug app PIDs: none", output.getvalue())
+        self.assertIn("Bundle exists: no", output.getvalue())
+
+    def test_status_reports_only_path_validated_debug_pids(self) -> None:
+        output = io.StringIO()
+        with mock.patch.object(conductor, "find_debug_app_pids", return_value=["501"]), mock.patch.object(
+            conductor, "run_operation_command", return_value=(0, "", "")
+        ), mock.patch.dict(os.environ, {"REPOPROMPT_DEBUG_APP_BUNDLE": "/tmp/missing-debug/RepoPrompt.app"}), contextlib.redirect_stdout(
+            output
+        ):
+            code = conductor.operation_app_status(Path("/tmp/repo"))
+
+        self.assertEqual(code, 0)
+        self.assertIn("Running matching debug app PIDs: 501", output.getvalue())
+
+    def test_status_identity_failure_is_reported_as_unknown(self) -> None:
+        output = io.StringIO()
+        with mock.patch.object(
+            conductor,
+            "find_debug_app_pids",
+            side_effect=conductor.ProcessIdentityError("identity unavailable"),
+        ), mock.patch.object(conductor, "run_operation_command") as cli_status, contextlib.redirect_stdout(output):
+            code = conductor.operation_app_status(Path("/tmp/repo"))
+
+        self.assertEqual(code, 1)
+        self.assertIn("Running matching debug app PIDs: unknown", output.getvalue())
+        cli_status.assert_not_called()
 
 
 class StopConfirmationTests(unittest.TestCase):
@@ -697,9 +816,19 @@ class StopConfirmationTests(unittest.TestCase):
         ), mock.patch.object(conductor.time, "sleep", side_effect=fake_sleep):
             yield
 
+    def test_missing_debug_executable_is_confirmed_already_stopped(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp, self.patched_timing(), mock.patch.dict(
+            os.environ,
+            {"REPOPROMPT_DEBUG_APP_BUNDLE": str(Path(tmp) / "missing" / "RepoPrompt.app")},
+        ), contextlib.redirect_stdout(io.StringIO()) as output:
+            code = conductor.operation_app_stop(Path.cwd(), {})
+
+        self.assertEqual(code, 0)
+        self.assertIn("already stopped", output.getvalue())
+
     def test_already_stopped_is_confirmed_without_termination(self) -> None:
-        with self.patched_timing(), mock.patch.object(conductor, "find_repoprompt_pids", return_value=[]), mock.patch.object(
-            conductor, "run_operation_command"
+        with self.patched_timing(), mock.patch.object(conductor, "find_debug_app_pids", return_value=[]), mock.patch.object(
+            conductor, "terminate_debug_app_processes"
         ) as terminate, contextlib.redirect_stdout(io.StringIO()):
             code = conductor.operation_app_stop(Path.cwd(), {})
 
@@ -708,13 +837,13 @@ class StopConfirmationTests(unittest.TestCase):
 
     def test_running_process_is_terminated_then_confirmed_absent(self) -> None:
         probes = iter([["101"], [], [], [], []])
-        with self.patched_timing(), mock.patch.object(conductor, "find_repoprompt_pids", side_effect=lambda: next(probes, [])), mock.patch.object(
-            conductor, "run_operation_command", return_value=(0, "", "")
+        with self.patched_timing(), mock.patch.object(conductor, "find_debug_app_pids", side_effect=lambda: next(probes, [])), mock.patch.object(
+            conductor, "terminate_debug_app_processes", return_value=["101"]
         ) as terminate, contextlib.redirect_stdout(io.StringIO()):
             code = conductor.operation_app_stop(Path.cwd(), {})
 
         self.assertEqual(code, 0)
-        terminate.assert_called_once()
+        terminate.assert_called_once_with()
 
     def test_guarded_stop_terminates_delayed_process_appearance(self) -> None:
         calls = 0
@@ -724,17 +853,28 @@ class StopConfirmationTests(unittest.TestCase):
             calls += 1
             return ["202"] if calls == 2 else []
 
-        with self.patched_timing(), mock.patch.object(conductor, "find_repoprompt_pids", side_effect=probe), mock.patch.object(
-            conductor, "run_operation_command", return_value=(0, "", "")
+        with self.patched_timing(), mock.patch.object(conductor, "find_debug_app_pids", side_effect=probe), mock.patch.object(
+            conductor, "terminate_debug_app_processes", return_value=["202"]
         ) as terminate, contextlib.redirect_stdout(io.StringIO()):
             code = conductor.operation_app_stop(Path.cwd(), {"guardDelayedLaunch": True})
 
         self.assertEqual(code, 0)
-        terminate.assert_called_once()
+        terminate.assert_called_once_with()
+
+    def test_identity_failure_aborts_without_name_based_fallback(self) -> None:
+        with self.patched_timing(), mock.patch.object(
+            conductor,
+            "find_debug_app_pids",
+            side_effect=conductor.ProcessIdentityError("identity unavailable"),
+        ), mock.patch.object(conductor, "terminate_debug_app_processes") as terminate, contextlib.redirect_stdout(io.StringIO()):
+            code = conductor.operation_app_stop(Path.cwd(), {})
+
+        self.assertEqual(code, 1)
+        terminate.assert_not_called()
 
     def test_persistent_process_fails_confirmation_without_force_kill(self) -> None:
-        with self.patched_timing(), mock.patch.object(conductor, "find_repoprompt_pids", return_value=["303"]), mock.patch.object(
-            conductor, "run_operation_command", return_value=(0, "", "")
+        with self.patched_timing(), mock.patch.object(conductor, "find_debug_app_pids", return_value=["303"]), mock.patch.object(
+            conductor, "terminate_debug_app_processes", return_value=["303"]
         ) as terminate, contextlib.redirect_stdout(io.StringIO()):
             code = conductor.operation_app_stop(Path.cwd(), {})
 

--- a/Scripts/test_conductor_output.py
+++ b/Scripts/test_conductor_output.py
@@ -140,27 +140,30 @@ class OutputSummarizerTests(unittest.TestCase):
 
     def test_app_lifecycle_summary_and_progress_prioritize_confirmed_transition(self) -> None:
         lines = [
-            "==> Stopping existing RepoPrompt instance\n",
-            "==> Waiting for existing RepoPrompt process to exit\n",
-            "RepoPrompt stop confirmed.\n",
+            "==> Stopping existing RepoPrompt CE debug app instance\n",
+            "==> Waiting for existing RepoPrompt CE debug app process to exit\n",
+            "RepoPrompt CE debug app stop confirmed.\n",
             "==> Launching /tmp/RepoPrompt.app\n",
-            "==> Confirming launched RepoPrompt process\n",
-            "Observed launched RepoPrompt PID(s): 123\n",
+            "==> Confirming launched RepoPrompt CE debug app process\n",
+            "Observed launched RepoPrompt CE debug PID(s): 123\n",
         ]
 
         summary = summarize("run", "completed", 0, lines)
         lifecycle = section(summary, "App lifecycle")
         titles = [item["title"] for item in summary["sections"]]
-        progress = conductor.select_progress_lines("run", ["RepoPrompt stop confirmed.\n", "Observed launched RepoPrompt PID(s): 123\n"])
+        progress = conductor.select_progress_lines(
+            "run",
+            ["RepoPrompt CE debug app stop confirmed.\n", "Observed launched RepoPrompt CE debug PID(s): 123\n"],
+        )
 
-        self.assertIn("RepoPrompt stop confirmed.", lifecycle)
-        self.assertIn("Observed launched RepoPrompt PID(s): 123", lifecycle)
+        self.assertIn("RepoPrompt CE debug app stop confirmed.", lifecycle)
+        self.assertIn("Observed launched RepoPrompt CE debug PID(s): 123", lifecycle)
         self.assertTrue(summary["launchLifecycle"]["transitionStarted"])
         self.assertTrue(summary["launchLifecycle"]["launchRequested"])
         self.assertTrue(summary["launchLifecycle"]["launchConfirmed"])
         self.assertLess(titles.index("App lifecycle"), titles.index("Phases"))
-        self.assertIn("RepoPrompt stop confirmed.", progress)
-        self.assertIn("Observed launched RepoPrompt PID(s): 123", progress)
+        self.assertIn("RepoPrompt CE debug app stop confirmed.", progress)
+        self.assertIn("Observed launched RepoPrompt CE debug PID(s): 123", progress)
 
     def test_app_operation_display_name_is_precise(self) -> None:
         self.assertEqual(conductor.operation_display_name("app", {"subcommand": "stop"}), "app stop")
@@ -195,7 +198,7 @@ class OutputSummarizerTests(unittest.TestCase):
             1,
             [
                 "==> Packaging debug app\n",
-                "==> Stopping existing RepoPrompt instance\n",
+                "==> Stopping existing RepoPrompt CE debug app instance\n",
                 "ERROR: open failed\n",
             ],
         )

--- a/Scripts/test_debug_app_process.py
+++ b/Scripts/test_debug_app_process.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Hermetic tests for RepoPrompt CE debug app process identity checks."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import debug_app_process  # noqa: E402
+
+
+class FakeInspector:
+    def __init__(self, names: dict[int, str], paths: dict[int, Path | list[Path] | Exception]) -> None:
+        self.names = names
+        self.paths = paths
+
+    def list_pids(self) -> list[int]:
+        return list(self.names)
+
+    def process_name(self, pid: int) -> str | None:
+        return self.names.get(pid)
+
+    def process_path(self, pid: int) -> Path:
+        value = self.paths[pid]
+        if isinstance(value, Exception):
+            raise value
+        if isinstance(value, list):
+            current = value.pop(0) if len(value) > 1 else value[0]
+            return current.resolve(strict=True)
+        return value.resolve(strict=True)
+
+
+class DebugAppProcessTests(unittest.TestCase):
+    def make_executable(self, root: Path, relative_path: str) -> Path:
+        executable = root / relative_path
+        executable.parent.mkdir(parents=True, exist_ok=True)
+        executable.write_text("binary", encoding="utf-8")
+        executable.chmod(0o755)
+        return executable.resolve(strict=True)
+
+    def test_only_exact_debug_executable_is_included(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            debug = self.make_executable(root, "Library/Application Support/RepoPrompt CE/DebugApps/RepoPrompt.app/Contents/MacOS/RepoPrompt")
+            production = self.make_executable(root, "Applications/RepoPrompt.app/Contents/MacOS/RepoPrompt")
+            ce_release = self.make_executable(root, "Applications/RepoPrompt CE.app/Contents/MacOS/RepoPrompt")
+            inspector = FakeInspector(
+                {101: "RepoPrompt", 102: "RepoPrompt", 103: "RepoPrompt", 104: "Other"},
+                {101: debug, 102: production, 103: ce_release, 104: debug},
+            )
+
+            matches = debug_app_process.matching_processes(debug, inspector)
+
+        self.assertEqual(matches, [101])
+
+    def test_termination_revalidates_identity_and_rejects_pid_reuse(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            debug = self.make_executable(root, "Debug/RepoPrompt.app/Contents/MacOS/RepoPrompt")
+            production = self.make_executable(root, "Production/RepoPrompt.app/Contents/MacOS/RepoPrompt")
+            inspector = FakeInspector({201: "RepoPrompt"}, {201: [debug, production]})
+            signals: list[tuple[int, int]] = []
+
+            with self.assertRaisesRegex(debug_app_process.ProcessIdentityError, "executable changed"):
+                debug_app_process.terminate_matching_processes(
+                    debug,
+                    inspector,
+                    signaler=lambda pid, sent_signal: signals.append((pid, sent_signal)),
+                )
+
+        self.assertEqual(signals, [])
+
+    def test_matching_identity_is_revalidated_then_signaled(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            debug = self.make_executable(Path(tmp), "Debug/RepoPrompt.app/Contents/MacOS/RepoPrompt")
+            inspector = FakeInspector({301: "RepoPrompt"}, {301: [debug, debug]})
+            signals: list[tuple[int, int]] = []
+
+            signaled = debug_app_process.terminate_matching_processes(
+                debug,
+                inspector,
+                signaler=lambda pid, sent_signal: signals.append((pid, sent_signal)),
+            )
+
+        self.assertEqual(signaled, [301])
+        self.assertEqual(signals, [(301, signal.SIGTERM)])
+
+    def test_missing_target_is_normal_not_installed_state(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            missing = Path(tmp) / "DebugApps" / "RepoPrompt.app" / "Contents" / "MacOS" / "RepoPrompt"
+            inspector = FakeInspector({101: "RepoPrompt"}, {})
+            signals: list[tuple[int, int]] = []
+
+            matches = debug_app_process.matching_processes(missing, inspector)
+            signaled = debug_app_process.terminate_matching_processes(
+                missing,
+                inspector,
+                signaler=lambda pid, sent_signal: signals.append((pid, sent_signal)),
+            )
+
+        self.assertEqual(matches, [])
+        self.assertEqual(signaled, [])
+        self.assertEqual(signals, [])
+
+    def test_unresolvable_named_candidate_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            debug = self.make_executable(Path(tmp), "Debug/RepoPrompt.app/Contents/MacOS/RepoPrompt")
+            inspector = FakeInspector(
+                {401: "RepoPrompt"},
+                {401: debug_app_process.ProcessIdentityError("identity unavailable")},
+            )
+
+            with self.assertRaisesRegex(debug_app_process.ProcessIdentityError, "identity unavailable"):
+                debug_app_process.matching_processes(debug, inspector)
+
+
+class LifecycleSurfaceTests(unittest.TestCase):
+    def test_lifecycle_surfaces_have_no_process_name_kill_fallback(self) -> None:
+        run_script = (SCRIPT_DIR / "run.sh").read_text(encoding="utf-8")
+        conductor_script = (SCRIPT_DIR / "conductor.py").read_text(encoding="utf-8")
+        finder_launcher = (SCRIPT_DIR.parent / "Launch RepoPrompt CE.command").read_text(encoding="utf-8")
+
+        for source in [run_script, conductor_script, finder_launcher]:
+            self.assertNotIn("pgrep -x RepoPrompt", source)
+            self.assertNotIn("pkill -x RepoPrompt", source)
+        self.assertIn('python3 "$PROCESS_HELPER" list --executable "$APP_EXECUTABLE"', run_script)
+        self.assertIn("terminate_matching_processes(debug_app_executable_path())", conductor_script)
+        self.assertIn("safe coordinated launcher requires Python 3", finder_launcher)
+        self.assertIn("No uncoordinated fallback is provided", finder_launcher)
+        self.assertNotIn("LAUNCH_MODE", finder_launcher)
+        self.assertNotIn("direct mode", finder_launcher.lower())
+        agents = (SCRIPT_DIR.parent / "AGENTS.md").read_text(encoding="utf-8")
+        readme = (SCRIPT_DIR.parent / "README.md").read_text(encoding="utf-8")
+        self.assertIn("does not provide an uncoordinated no-Python fallback", agents)
+        self.assertIn("does not provide an", readme)
+        self.assertIn("uncoordinated no-Python fallback", readme)
+
+    def test_conductor_selftest_includes_process_helper_suite(self) -> None:
+        makefile = (SCRIPT_DIR.parent / "Makefile").read_text(encoding="utf-8")
+        target = makefile.split("conductor-selftest:", 1)[1].split("\n\n", 1)[0]
+        self.assertIn("python3 Scripts/test_debug_app_process.py", target)
+
+    def test_finder_launcher_without_python_exits_before_any_lifecycle_action(self) -> None:
+        dirname = shutil.which("dirname")
+        self.assertIsNotNone(dirname)
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            launcher = root / "Launch RepoPrompt CE.command"
+            launcher.write_text((SCRIPT_DIR.parent / launcher.name).read_text(encoding="utf-8"), encoding="utf-8")
+            bin_dir = root / "bin"
+            bin_dir.mkdir()
+            (bin_dir / "dirname").symlink_to(dirname)
+            env = os.environ.copy()
+            env["PATH"] = str(bin_dir)
+
+            result = subprocess.run(
+                ["/bin/bash", str(launcher)],
+                env=env,
+                input="",
+                text=True,
+                capture_output=True,
+                timeout=2,
+            )
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("safe coordinated launcher requires Python 3", result.stdout)
+        self.assertIn("No uncoordinated fallback is provided", result.stdout)
+        self.assertNotIn("Building and relaunching", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Sources/RepoPrompt/App/WindowStateComposition.swift
+++ b/Sources/RepoPrompt/App/WindowStateComposition.swift
@@ -30,6 +30,7 @@ enum WindowStateCompositionFactory {
         deferredInitialAgentSystemWorkspaceRefresh: Bool,
         sharedMCPService: MCPService,
         contextBuilderProviderFactory: ContextBuilderAgentViewModel.ProviderFactory? = nil,
+        aiQueriesServiceFactory: ((_ keyManager: KeyManager) -> AIQueriesService)? = nil,
         workspaceFileContextStore injectedWorkspaceFileContextStore: WorkspaceFileContextStore? = nil,
         workspaceSwitchTimingPolicy: WorkspaceSwitchTimingPolicy = .production
     ) -> WindowStateComposition {
@@ -40,7 +41,8 @@ enum WindowStateCompositionFactory {
 
         // 2) AI queries
         let keyManager = KeyManager()
-        let aiQueriesService = AIQueriesService(keyManager: keyManager)
+        let aiQueriesService = aiQueriesServiceFactory?(keyManager)
+            ?? AIQueriesService(keyManager: keyManager)
 
         // 3) API Settings
         let apiSettingsViewModel = APISettingsViewModel(aiQueriesService: aiQueriesService, keyManager: keyManager)

--- a/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel.swift
+++ b/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel.swift
@@ -183,32 +183,125 @@ class EphemeralMessageState {
 
 // MARK: - Message Finalisation Hub
 
+struct OracleMessageLifecycleActivityEvent: Equatable {
+    enum Kind: String {
+        case streamActivity = "stream_activity"
+        case streamInactivityWatchdogFired = "stream_inactivity_watchdog_fired"
+        case finalizationWatchdogArmed = "finalization_watchdog_armed"
+        case finalizationWatchdogFired = "finalization_watchdog_fired"
+        case finalizationWatchdogCancelled = "finalization_watchdog_cancelled"
+        case providerStopObserved = "provider_stop_observed"
+        case finalizationStarted = "finalization_started"
+        case finalizationCompleted = "finalization_completed"
+        case streamCancelled = "stream_cancelled"
+        case streamFailed = "stream_failed"
+    }
+
+    let kind: Kind
+
+    var resetsInactivityTimeout: Bool {
+        switch kind {
+        case .streamActivity,
+             .streamInactivityWatchdogFired,
+             .providerStopObserved,
+             .finalizationStarted,
+             .finalizationCompleted,
+             .streamCancelled,
+             .streamFailed:
+            true
+        case .finalizationWatchdogArmed,
+             .finalizationWatchdogFired,
+             .finalizationWatchdogCancelled:
+            false
+        }
+    }
+
+    var entersFinalization: Bool {
+        switch kind {
+        case .streamInactivityWatchdogFired,
+             .providerStopObserved,
+             .finalizationStarted,
+             .finalizationCompleted,
+             .streamCancelled,
+             .streamFailed:
+            true
+        case .streamActivity,
+             .finalizationWatchdogArmed,
+             .finalizationWatchdogFired,
+             .finalizationWatchdogCancelled:
+            false
+        }
+    }
+
+    var message: String {
+        switch kind {
+        case .streamActivity:
+            "Oracle stream activity observed"
+        case .streamInactivityWatchdogFired:
+            "Oracle stream inactivity watchdog fired"
+        case .finalizationWatchdogArmed:
+            "Oracle finalization watchdog armed"
+        case .finalizationWatchdogFired:
+            "Oracle finalization watchdog fired"
+        case .finalizationWatchdogCancelled:
+            "Oracle finalization watchdog cancelled"
+        case .providerStopObserved:
+            "Oracle provider stop observed"
+        case .finalizationStarted:
+            "Oracle message finalization started"
+        case .finalizationCompleted:
+            "Oracle message finalization completed"
+        case .streamCancelled:
+            "Oracle stream cancellation entered finalization"
+        case .streamFailed:
+            "Oracle stream failure entered finalization"
+        }
+    }
+}
+
 actor MessageFinalisationHub {
-    private var waiters: [UUID: [CheckedContinuation<Void, Never>]] = [:]
+    private struct WaiterKey: Hashable {
+        let messageID: UUID
+        let waiterID: UUID
+    }
+
+    private var waiters: [UUID: [UUID: CheckedContinuation<Void, Never>]] = [:]
+    private var cancelledWaiters: Set<WaiterKey> = []
     private var completed: Set<UUID> = []
 
-    func register(_ id: UUID, cont: CheckedContinuation<Void, Never>) {
-        if completed.contains(id) {
+    func register(
+        _ id: UUID,
+        waiterID: UUID,
+        cont: CheckedContinuation<Void, Never>
+    ) {
+        let key = WaiterKey(messageID: id, waiterID: waiterID)
+        if completed.contains(id) || cancelledWaiters.remove(key) != nil {
             cont.resume()
             return
         }
-        waiters[id, default: []].append(cont)
+        waiters[id, default: [:]][waiterID] = cont
     }
 
     func fulfil(_ id: UUID) {
         completed.insert(id)
+        cancelledWaiters = Set(cancelledWaiters.filter { $0.messageID != id })
         guard let list = waiters.removeValue(forKey: id) else { return }
-        for c in list {
-            c.resume()
+        for continuation in list.values {
+            continuation.resume()
         }
     }
 
-    /// Cancel all waiters for a specific message ID
-    func cancel(_ id: UUID) {
-        let list = waiters.removeValue(forKey: id) ?? []
-        completed.insert(id)
-        for c in list {
-            c.resume()
+    /// Cancels only the requesting task's waiter. Message completion remains authoritative
+    /// for every other current or future waiter.
+    func cancel(_ id: UUID, waiterID: UUID) {
+        guard !completed.contains(id) else { return }
+        if let continuation = waiters[id]?.removeValue(forKey: waiterID) {
+            if waiters[id]?.isEmpty == true {
+                waiters.removeValue(forKey: id)
+            }
+            continuation.resume()
+        } else {
+            cancelledWaiters.insert(WaiterKey(messageID: id, waiterID: waiterID))
         }
     }
 
@@ -218,10 +311,11 @@ actor MessageFinalisationHub {
 
     /// Clean up any orphaned waiters (safety mechanism)
     func cleanup() {
-        let allWaiters = waiters.values.flatMap(\.self)
+        let allWaiters = waiters.values.flatMap(\.values)
         waiters.removeAll()
-        for c in allWaiters {
-            c.resume()
+        cancelledWaiters.removeAll()
+        for continuation in allWaiters {
+            continuation.resume()
         }
     }
 }
@@ -788,6 +882,10 @@ class OracleViewModel: ObservableObject {
     private var finalizationWatchdogs: [UUID: Task<Void, Never>] = [:]
     private var finalizationWatchdogTokens: [UUID: UUID] = [:]
     private var streamInactivityWatchdogs: [UUID: Task<Void, Never>] = [:]
+    typealias MessageLifecycleActivityObserver = @MainActor @Sendable (
+        _ event: OracleMessageLifecycleActivityEvent
+    ) -> Void
+    private var messageLifecycleActivityObservers: [UUID: [UUID: MessageLifecycleActivityObserver]] = [:]
     /// Prevents duplicate concurrent finalisers for the same assistant message.
     private var finalizingAIResponses: Set<UUID> = []
     private var lastAnyStreamActivityAt: [UUID: Date] = [:]
@@ -920,6 +1018,36 @@ class OracleViewModel: ObservableObject {
     // MARK: - Finalization Watchdog (prevents 'stuck in progress' state)
 
     @MainActor
+    func addMessageLifecycleActivityObserver(
+        for queryId: UUID,
+        observer: @escaping MessageLifecycleActivityObserver
+    ) -> UUID {
+        let observerID = UUID()
+        messageLifecycleActivityObservers[queryId, default: [:]][observerID] = observer
+        return observerID
+    }
+
+    @MainActor
+    func removeMessageLifecycleActivityObserver(for queryId: UUID, observerID: UUID) {
+        messageLifecycleActivityObservers[queryId]?.removeValue(forKey: observerID)
+        if messageLifecycleActivityObservers[queryId]?.isEmpty == true {
+            messageLifecycleActivityObservers.removeValue(forKey: queryId)
+        }
+    }
+
+    @MainActor
+    private func emitMessageLifecycleActivity(
+        _ kind: OracleMessageLifecycleActivityEvent.Kind,
+        for queryId: UUID
+    ) {
+        let event = OracleMessageLifecycleActivityEvent(kind: kind)
+        guard let observers = messageLifecycleActivityObservers[queryId] else { return }
+        for observer in observers.values {
+            observer(event)
+        }
+    }
+
+    @MainActor
     private func currentInactivityGrace(for queryId: UUID) -> TimeInterval {
         let seenText = hasSeenNonReasoningText.contains(queryId)
         return seenText ? postContentGrace : preContentGrace
@@ -1005,6 +1133,8 @@ class OracleViewModel: ObservableObject {
             return
         }
 
+        emitMessageLifecycleActivity(.streamInactivityWatchdogFired, for: queryId)
+
         // Targeted cancel for this specific stream
         if let streamId = streamIDsByQueryId[queryId] {
             await aiQueriesService.cancelStream(id: streamId)
@@ -1070,6 +1200,7 @@ class OracleViewModel: ObservableObject {
             await finalizationWatchdogFired(for: queryId)
         }
         finalizationWatchdogs[queryId] = task
+        emitMessageLifecycleActivity(.finalizationWatchdogArmed, for: queryId)
         EditFlowPerf.event(
             EditFlowPerf.Stage.Finalization.watchdogArm,
             finalizationWatchdogDimensions(for: queryId, status: "armed")
@@ -1092,6 +1223,9 @@ class OracleViewModel: ObservableObject {
         }
         finalizationWatchdogs[queryId] = nil
         finalizationWatchdogTokens[queryId] = nil
+        if shouldFire {
+            emitMessageLifecycleActivity(.finalizationWatchdogFired, for: queryId)
+        }
         EditFlowPerf.event(
             EditFlowPerf.Stage.Finalization.watchdogComplete,
             finalizationWatchdogDimensions(for: queryId, status: status)
@@ -1104,6 +1238,7 @@ class OracleViewModel: ObservableObject {
         guard let task = finalizationWatchdogs.removeValue(forKey: queryId) else { return }
         task.cancel()
         finalizationWatchdogTokens[queryId] = nil
+        emitMessageLifecycleActivity(.finalizationWatchdogCancelled, for: queryId)
         EditFlowPerf.event(
             EditFlowPerf.Stage.Finalization.watchdogCancel,
             finalizationWatchdogDimensions(for: queryId, status: "cancelled")
@@ -1188,14 +1323,19 @@ class OracleViewModel: ObservableObject {
             return
         }
 
-        // Use withTaskCancellationHandler to properly handle cancellation
+        let waiterID = UUID()
         await withTaskCancellationHandler {
             await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
-                Task { await finalisationHub.register(id, cont: cont) }
+                Task {
+                    await finalisationHub.register(
+                        id,
+                        waiterID: waiterID,
+                        cont: cont
+                    )
+                }
             }
         } onCancel: {
-            // If cancelled, notify the hub to clean up this waiter
-            Task { await finalisationHub.cancel(id) }
+            Task { await finalisationHub.cancel(id, waiterID: waiterID) }
         }
         try Task.checkCancellation()
     }
@@ -2694,6 +2834,7 @@ class OracleViewModel: ObservableObject {
                         let now = Date()
                         if sawText || sawReasoning {
                             self.lastAnyStreamActivityAt[aiResponseId] = now
+                            self.emitMessageLifecycleActivity(.streamActivity, for: aiResponseId)
                             // Use throttled arm to reduce Task churn during fast streaming
                             self.armStreamInactivityWatchdogThrottled(for: aiResponseId, now: now)
                         }
@@ -2735,6 +2876,7 @@ class OracleViewModel: ObservableObject {
 
                         await MainActor.run {
                             self.providerStopSeen.insert(aiResponseId)
+                            self.emitMessageLifecycleActivity(.providerStopObserved, for: aiResponseId)
                             self.cancelStreamInactivityWatchdog(for: aiResponseId)
                         }
 
@@ -2777,6 +2919,7 @@ class OracleViewModel: ObservableObject {
             return
         }
         finalizingAIResponses.insert(aiResponseId)
+        emitMessageLifecycleActivity(.finalizationStarted, for: aiResponseId)
         defer { finalizingAIResponses.remove(aiResponseId) }
 
         // Cancel any watchdog to prevent duplicate finalization
@@ -2821,7 +2964,8 @@ class OracleViewModel: ObservableObject {
         let shouldForceAutosave = (activeRetryTask != nil)
         autosaveChatHistory(for: sessionID, force: shouldForceAutosave)
 
-        // 5️⃣ Notify any waiters that this message is finalised
+        // 5️⃣ Notify observers and any waiters that this message is finalised
+        emitMessageLifecycleActivity(.finalizationCompleted, for: aiResponseId)
         Task { await finalisationHub.fulfil(aiResponseId) }
     }
 
@@ -2838,6 +2982,7 @@ class OracleViewModel: ObservableObject {
         streamIDsByQueryId.removeValue(forKey: aiResponseId)
 
         if error is CancellationError {
+            emitMessageLifecycleActivity(.streamCancelled, for: aiResponseId)
             print("AI response was cancelled.")
             guard let index = messageStore[sessionID]?.firstIndex(where: { $0.id == aiResponseId }) else {
                 clearSessionStreaming(sessionID)
@@ -2870,6 +3015,8 @@ class OracleViewModel: ObservableObject {
             }
             return
         }
+
+        emitMessageLifecycleActivity(.streamFailed, for: aiResponseId)
 
         // Pass token count to error message handler for non-cancellation errors
         let tokenCount = promptViewModel.totalTokenCount

--- a/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderAgentViewModel.swift
+++ b/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderAgentViewModel.swift
@@ -411,9 +411,36 @@ final class ContextBuilderAgentViewModel: ObservableObject {
 
     #if DEBUG
         struct RunTestHooks {
+            typealias MCPFollowUpModelSelection = (
+                model: AIModel,
+                chatPresetID: UUID?,
+                mcpControlInfo: String?
+            )
+            typealias MCPFollowUpRunner = @MainActor @Sendable (
+                _ mode: HeadlessMode,
+                _ prompt: String,
+                _ selection: StoredSelection
+            ) async throws -> ChatSendReply
+
             let beforeProcessingProviderEvent: ((_ result: AIStreamResult, _ runID: UUID) async -> Void)?
             let providerEventDisposition: ((_ result: AIStreamResult, _ runID: UUID, _ accepted: Bool) -> Void)?
             let teardownCompleted: ((_ runID: UUID) -> Void)?
+            let resolveMCPFollowUpModel: ((_ mode: String) async throws -> MCPFollowUpModelSelection)?
+            let runMCPFollowUp: MCPFollowUpRunner?
+
+            init(
+                beforeProcessingProviderEvent: ((_ result: AIStreamResult, _ runID: UUID) async -> Void)?,
+                providerEventDisposition: ((_ result: AIStreamResult, _ runID: UUID, _ accepted: Bool) -> Void)?,
+                teardownCompleted: ((_ runID: UUID) -> Void)?,
+                resolveMCPFollowUpModel: ((_ mode: String) async throws -> MCPFollowUpModelSelection)? = nil,
+                runMCPFollowUp: MCPFollowUpRunner? = nil
+            ) {
+                self.beforeProcessingProviderEvent = beforeProcessingProviderEvent
+                self.providerEventDisposition = providerEventDisposition
+                self.teardownCompleted = teardownCompleted
+                self.resolveMCPFollowUpModel = resolveMCPFollowUpModel
+                self.runMCPFollowUp = runMCPFollowUp
+            }
         }
 
         private var runTestHooks: RunTestHooks?
@@ -1546,7 +1573,8 @@ final class ContextBuilderAgentViewModel: ObservableObject {
         modelOverrideRaw: String? = nil,
         responseType: String? = nil,
         planModelName: String? = nil,
-        mcpControlToken: UUID
+        mcpControlToken: UUID,
+        progressReporter: ContextBuilderMCPProgressReporter? = nil
     ) async throws -> ContextBuilderRunSnapshot {
         let session = session(for: tabID)
         if lastProcessedTabID != tabID {
@@ -1678,7 +1706,8 @@ final class ContextBuilderAgentViewModel: ObservableObject {
                     agentKind: runAgent,
                     modelRaw: runModelRaw,
                     continuation: continuation,
-                    restoreConfiguration: restoreConfiguration
+                    restoreConfiguration: restoreConfiguration,
+                    progressReporter: progressReporter
                 )
 
                 guard runRegistry.register(record) else {
@@ -1749,6 +1778,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
         let task = Task { @MainActor [weak self, weak record] in
             guard let self, let record else { return }
             let outcome = await performContextBuilderAgentRun(record: record)
+            await record.reportProgress(.runFinalization)
             finalizeContextBuilderRun(
                 record,
                 outcome: outcome,
@@ -2461,32 +2491,55 @@ final class ContextBuilderAgentViewModel: ObservableObject {
         let agentConnections = await agentConnectionIDs(for: runID, agent: agent)
         guard activeAgentRuns.contains(runID), acceptsEvents(from: record) else { return false }
 
-        for cid in agentConnections {
-            guard activeAgentRuns.contains(runID), acceptsEvents(from: record) else { return false }
-            debugLog("commitTabContextForAgent: terminating agent connection \(cid) runID=\(runID)")
-            await ServerNetworkManager.shared.terminateConnection(
-                cid,
-                reason: .runCompleted,
-                message: "context builder run completed successfully"
-            )
-            guard activeAgentRuns.contains(runID), acceptsEvents(from: record) else { return false }
-
-            await mcpServer.commitAndClearTabContext(
-                connectionID: cid,
-                expectedRunID: runID,
-                isStillCurrent: { [weak self, weak record] in
-                    guard let self, let record else { return false }
-                    return acceptsEvents(from: record)
+        let finalizedConnections = await ContextBuilderChildConnectionFinalizer.finalize(
+            connectionIDs: agentConnections,
+            commitContext: { [weak self, weak record] cid in
+                guard let self, let record,
+                      activeAgentRuns.contains(runID),
+                      acceptsEvents(from: record)
+                else {
+                    return false
                 }
-            )
-            guard activeAgentRuns.contains(runID), acceptsEvents(from: record) else { return false }
-            mcpServer.removeTabContext(
-                forConnectionID: cid,
-                clientName: agentClientName,
-                windowID: nil,
-                runID: runID
-            )
-        }
+                let committed = await mcpServer.commitAndClearTabContext(
+                    connectionID: cid,
+                    expectedRunID: runID,
+                    isStillCurrent: { [weak self, weak record] in
+                        guard let self, let record else { return false }
+                        return acceptsEvents(from: record)
+                    },
+                    progressReporter: record.progressReporter,
+                    deferRunMappingCleanupUntilCaller: true
+                )
+                return committed && activeAgentRuns.contains(runID) && acceptsEvents(from: record)
+            },
+            beforeTerminationRequest: {
+                await record.reportProgress(.childConnectionTermination)
+            },
+            requestTermination: { [weak self] cid in
+                guard let self else { return Task {} }
+                debugLog("commitTabContextForAgent: requesting termination for agent connection \(cid) runID=\(runID)")
+                return Task {
+                    await ServerNetworkManager.shared.terminateConnection(
+                        cid,
+                        reason: .runCompleted,
+                        message: "context builder run completed successfully"
+                    )
+                }
+            },
+            beforeTerminationJoin: {
+                await record.reportProgress(.childConnectionTerminationJoin)
+            },
+            cleanupMapping: { [weak self] cid in
+                guard let self else { return }
+                mcpServer.removeTabContext(
+                    forConnectionID: cid,
+                    clientName: agentClientName,
+                    windowID: nil,
+                    runID: runID
+                )
+            }
+        )
+        guard finalizedConnections else { return false }
 
         guard activeAgentRuns.remove(runID) != nil, acceptsEvents(from: record) else { return false }
         if let clientName = agentClientName {
@@ -3348,54 +3401,39 @@ final class ContextBuilderAgentViewModel: ObservableObject {
         }
     }
 
-    private enum FollowUpFinalizationResult {
-        case finalised
-        case timedOut
-        case cancelled
-    }
-
     private func waitForFollowUpFinalization(
         in oracleViewModel: OracleViewModel,
         queryID: UUID,
         sessionID: UUID,
-        timeout: Duration = .seconds(4 * 60 * 60)
+        progressReporter: ContextBuilderMCPProgressReporter?,
+        activityReporter: ContextBuilderMCPActivityReporter?
     ) async throws {
-        let result = await withTaskGroup(of: FollowUpFinalizationResult.self) { group in
-            group.addTask {
-                do {
-                    try await oracleViewModel.waitUntilMessageFinalised(queryID)
-                    return .finalised
-                } catch is CancellationError {
-                    return .cancelled
-                } catch {
-                    return .cancelled
-                }
-            }
-            group.addTask {
-                do {
-                    try await Task.sleep(for: timeout)
-                    await oracleViewModel.cancelStreaming(in: sessionID)
-                    return .timedOut
-                } catch is CancellationError {
-                    return .cancelled
-                } catch {
-                    return .cancelled
-                }
-            }
-
-            let firstResult = await group.next() ?? .cancelled
-            group.cancelAll()
-            return firstResult
+        let (activityEvents, activityContinuation) = AsyncStream<OracleMessageLifecycleActivityEvent>.makeStream(
+            bufferingPolicy: .bufferingNewest(32)
+        )
+        let observerID = oracleViewModel.addMessageLifecycleActivityObserver(for: queryID) { event in
+            activityContinuation.yield(event)
+        }
+        defer {
+            oracleViewModel.removeMessageLifecycleActivityObserver(for: queryID, observerID: observerID)
+            activityContinuation.finish()
         }
 
-        switch result {
-        case .finalised:
-            return
-        case .timedOut:
-            throw ChatToolError.internalError("Follow-up response timed out before finalization")
-        case .cancelled:
-            try Task.checkCancellation()
-        }
+        try await ContextBuilderFollowUpFinalizationMonitor.wait(
+            activityEvents: activityEvents,
+            waitForFinalization: {
+                try await oracleViewModel.waitUntilMessageFinalised(queryID)
+            },
+            cancelStreaming: {
+                await oracleViewModel.cancelStreaming(in: sessionID)
+            },
+            reportPhase: { phase in
+                await progressReporter?(phase)
+            },
+            reportActivity: { phase, message in
+                await activityReporter?(phase, message)
+            }
+        )
     }
 
     /// Unified follow-up generator that always streams in a real chat session.
@@ -3412,7 +3450,9 @@ final class ContextBuilderAgentViewModel: ObservableObject {
         chatPresetID: UUID?,
         mcpSessionUIState: OracleViewModel.MCPSessionUIState? = nil,
         gitScopeOverride: GitInclusion? = nil,
-        onProgress: ((_ text: String, _ reasoning: String?) -> Void)? = nil
+        onProgress: ((_ text: String, _ reasoning: String?) -> Void)? = nil,
+        progressReporter: ContextBuilderMCPProgressReporter? = nil,
+        activityReporter: ContextBuilderMCPActivityReporter? = nil
     ) async throws -> ChatSendReply {
         let session = session(for: tabID)
 
@@ -3440,6 +3480,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
                 throw CancellationError()
             }
 
+            await progressReporter?(.payloadPackaging)
             let aiMessage = await promptManager.buildHeadlessAIMessage(
                 from: HeadlessContextSnapshot(
                     tabID: tabID,
@@ -3456,6 +3497,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
                 throw CancellationError()
             }
 
+            await progressReporter?(.sessionCreationAndPersist)
             let createdSession = try await oracleViewModel.createSession(
                 named: chatName,
                 tabID: tabID,
@@ -3483,6 +3525,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
                 throw CancellationError()
             }
 
+            await progressReporter?(.messageSend)
             await oracleViewModel.sendMessage(
                 prompt,
                 sessionID: createdSession.id,
@@ -3507,13 +3550,17 @@ final class ContextBuilderAgentViewModel: ObservableObject {
             guard session.isBackgroundPlanGenerating else {
                 throw CancellationError()
             }
+            await progressReporter?(.activeQueryAcquisition)
             guard let queryId = oracleViewModel.activeQueryId(for: createdSession.id) else {
                 throw ChatToolError.internalError("Failed to start follow-up stream")
             }
+            await progressReporter?(.streaming)
             try await waitForFollowUpFinalization(
                 in: oracleViewModel,
                 queryID: queryId,
-                sessionID: createdSession.id
+                sessionID: createdSession.id,
+                progressReporter: progressReporter,
+                activityReporter: activityReporter
             )
             guard session.isBackgroundPlanGenerating else {
                 throw CancellationError()
@@ -3581,10 +3628,32 @@ final class ContextBuilderAgentViewModel: ObservableObject {
         mode: HeadlessMode,
         prompt: String,
         selection: StoredSelection,
-        gitScopeOverride: GitInclusion? = nil
+        gitScopeOverride: GitInclusion? = nil,
+        progressReporter: ContextBuilderMCPProgressReporter? = nil,
+        activityReporter: ContextBuilderMCPActivityReporter? = nil
     ) async throws -> ChatSendReply {
+        #if DEBUG
+            if let runner = runTestHooks?.runMCPFollowUp {
+                return try await runner(mode, prompt, selection)
+            }
+        #endif
+
         let modeName = mode.mcpModeName
-        let modelSelection = try await oracleViewModel.resolveMCPFollowUpModel(mode: modeName)
+        await progressReporter?(.modelResolution)
+        let modelSelection: (
+            model: AIModel,
+            chatPresetID: UUID?,
+            mcpControlInfo: String?
+        )
+        #if DEBUG
+            if let resolver = runTestHooks?.resolveMCPFollowUpModel {
+                modelSelection = try await resolver(modeName)
+            } else {
+                modelSelection = try await oracleViewModel.resolveMCPFollowUpModel(mode: modeName)
+            }
+        #else
+            modelSelection = try await oracleViewModel.resolveMCPFollowUpModel(mode: modeName)
+        #endif
         let mcpSessionUIState: OracleViewModel.MCPSessionUIState? = {
             guard let mcpModelInfo = modelSelection.mcpControlInfo else { return nil }
             let overrideChatPresetName = modelSelection.chatPresetID
@@ -3606,7 +3675,9 @@ final class ContextBuilderAgentViewModel: ObservableObject {
             model: modelSelection.model,
             chatPresetID: modelSelection.chatPresetID,
             mcpSessionUIState: mcpSessionUIState,
-            gitScopeOverride: gitScopeOverride
+            gitScopeOverride: gitScopeOverride,
+            progressReporter: progressReporter,
+            activityReporter: activityReporter
         )
     }
 

--- a/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderFollowUpFinalizationMonitor.swift
+++ b/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderFollowUpFinalizationMonitor.swift
@@ -1,0 +1,218 @@
+import Foundation
+
+struct ContextBuilderFollowUpFinalizationConfiguration: Equatable {
+    let overallTimeout: TimeInterval
+    let inactivityTimeout: TimeInterval
+    let checkInterval: TimeInterval
+
+    static let production = ContextBuilderFollowUpFinalizationConfiguration(
+        overallTimeout: 4 * 60 * 60,
+        inactivityTimeout: 10 * 60,
+        checkInterval: 5
+    )
+}
+
+struct ContextBuilderFollowUpTimeoutSnapshot: Equatable {
+    enum Kind: String {
+        case inactivity
+        case overall
+    }
+
+    let kind: Kind
+    let elapsed: TimeInterval
+    let inactiveFor: TimeInterval
+    let lastKnownSubphase: String
+    let lastEvent: String
+
+    var message: String {
+        switch kind {
+        case .inactivity:
+            "Follow-up response stalled for \(Self.format(inactiveFor)) with no streaming/finalization activity during \(lastKnownSubphase). Last event: \(lastEvent)."
+        case .overall:
+            "Follow-up response exceeded the overall \(Self.format(elapsed)) ceiling during \(lastKnownSubphase). Last event: \(lastEvent)."
+        }
+    }
+
+    private static func format(_ interval: TimeInterval) -> String {
+        String(format: "%.1fs", max(0, interval))
+    }
+}
+
+actor ContextBuilderFollowUpFinalizationState {
+    struct ActivityUpdate: Equatable {
+        let phase: ContextBuilderMCPProgressPhase
+        let message: String
+        let shouldTransitionToFinalization: Bool
+    }
+
+    private let startedAt: TimeInterval
+    private var lastMeaningfulActivityAt: TimeInterval
+    private var lastKnownSubphase = ContextBuilderMCPProgressPhase.streaming.displayName
+    private var lastEvent = "waiting for Oracle stream activity"
+    private var hasEnteredFinalization = false
+
+    init(startedAt: TimeInterval) {
+        self.startedAt = startedAt
+        lastMeaningfulActivityAt = startedAt
+    }
+
+    func record(
+        _ event: OracleMessageLifecycleActivityEvent,
+        at now: TimeInterval
+    ) -> ActivityUpdate {
+        if event.resetsInactivityTimeout {
+            lastMeaningfulActivityAt = now
+        }
+
+        let shouldTransition = event.entersFinalization && !hasEnteredFinalization
+        if event.entersFinalization {
+            hasEnteredFinalization = true
+        }
+        let phase: ContextBuilderMCPProgressPhase = hasEnteredFinalization ? .messageFinalization : .streaming
+        lastKnownSubphase = phase.displayName
+        lastEvent = event.message
+
+        return ActivityUpdate(
+            phase: phase,
+            message: event.message,
+            shouldTransitionToFinalization: shouldTransition
+        )
+    }
+
+    func claimFinalizationTransitionOnCompletion() -> Bool {
+        guard !hasEnteredFinalization else { return false }
+        hasEnteredFinalization = true
+        lastKnownSubphase = ContextBuilderMCPProgressPhase.messageFinalization.displayName
+        lastEvent = "Oracle message finalization completed"
+        return true
+    }
+
+    func timeoutSnapshot(
+        at now: TimeInterval,
+        configuration: ContextBuilderFollowUpFinalizationConfiguration
+    ) -> ContextBuilderFollowUpTimeoutSnapshot? {
+        let elapsed = max(0, now - startedAt)
+        let inactiveFor = max(0, now - lastMeaningfulActivityAt)
+        if elapsed >= configuration.overallTimeout {
+            return ContextBuilderFollowUpTimeoutSnapshot(
+                kind: .overall,
+                elapsed: elapsed,
+                inactiveFor: inactiveFor,
+                lastKnownSubphase: lastKnownSubphase,
+                lastEvent: lastEvent
+            )
+        }
+        if inactiveFor >= configuration.inactivityTimeout {
+            return ContextBuilderFollowUpTimeoutSnapshot(
+                kind: .inactivity,
+                elapsed: elapsed,
+                inactiveFor: inactiveFor,
+                lastKnownSubphase: lastKnownSubphase,
+                lastEvent: lastEvent
+            )
+        }
+        return nil
+    }
+}
+
+enum ContextBuilderFollowUpFinalizationMonitor {
+    typealias Clock = @Sendable () -> TimeInterval
+    typealias Sleep = @Sendable (_ seconds: TimeInterval) async throws -> Void
+    typealias WaitForFinalization = @Sendable () async throws -> Void
+    typealias CancelStreaming = @Sendable () async -> Void
+    typealias ReportPhase = @Sendable (_ phase: ContextBuilderMCPProgressPhase) async -> Void
+    typealias ReportActivity = @Sendable (
+        _ phase: ContextBuilderMCPProgressPhase,
+        _ message: String
+    ) async -> Void
+
+    private enum MonitorResult {
+        case finalised
+        case timedOut(ContextBuilderFollowUpTimeoutSnapshot)
+        case failed(String)
+        case cancelled
+        case observerEnded
+    }
+
+    static func wait(
+        activityEvents: AsyncStream<OracleMessageLifecycleActivityEvent>,
+        configuration: ContextBuilderFollowUpFinalizationConfiguration = .production,
+        clock: @escaping Clock = { ProcessInfo.processInfo.systemUptime },
+        sleep: @escaping Sleep = { seconds in
+            try await Task.sleep(for: .seconds(seconds))
+        },
+        waitForFinalization: @escaping WaitForFinalization,
+        cancelStreaming: @escaping CancelStreaming,
+        reportPhase: ReportPhase? = nil,
+        reportActivity: ReportActivity? = nil
+    ) async throws {
+        let state = ContextBuilderFollowUpFinalizationState(startedAt: clock())
+        let result = await withTaskGroup(of: MonitorResult.self) { group in
+            group.addTask {
+                do {
+                    try await waitForFinalization()
+                    return .finalised
+                } catch is CancellationError {
+                    return .cancelled
+                } catch {
+                    return .failed(error.localizedDescription)
+                }
+            }
+            group.addTask {
+                for await event in activityEvents {
+                    if Task.isCancelled { return .cancelled }
+                    let update = await state.record(event, at: clock())
+                    if update.shouldTransitionToFinalization {
+                        await reportPhase?(.messageFinalization)
+                    }
+                    await reportActivity?(update.phase, update.message)
+                }
+                return .observerEnded
+            }
+            group.addTask {
+                do {
+                    while !Task.isCancelled {
+                        try await sleep(configuration.checkInterval)
+                        try Task.checkCancellation()
+                        if let timeout = await state.timeoutSnapshot(
+                            at: clock(),
+                            configuration: configuration
+                        ) {
+                            return .timedOut(timeout)
+                        }
+                    }
+                    return .cancelled
+                } catch is CancellationError {
+                    return .cancelled
+                } catch {
+                    return .failed(error.localizedDescription)
+                }
+            }
+
+            while let next = await group.next() {
+                if case .observerEnded = next {
+                    continue
+                }
+                group.cancelAll()
+                return next
+            }
+            return .cancelled
+        }
+
+        switch result {
+        case .finalised:
+            if await state.claimFinalizationTransitionOnCompletion() {
+                await reportPhase?(.messageFinalization)
+            }
+            return
+        case let .timedOut(timeout):
+            // The timeout outcome is already fixed before cancellation can trigger finalization.
+            await cancelStreaming()
+            throw ChatToolError.internalError(timeout.message)
+        case let .failed(message):
+            throw ChatToolError.internalError("Follow-up finalization monitoring failed: \(message)")
+        case .cancelled, .observerEnded:
+            throw CancellationError()
+        }
+    }
+}

--- a/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderRunLifecycle.swift
+++ b/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderRunLifecycle.swift
@@ -32,6 +32,43 @@ enum ContextBuilderRunWaiterResolution {
     case cancellationError
 }
 
+/// Coordinates successful child-connection finalization. Each tab-context snapshot must be
+/// positively committed before transport termination can trigger connection-backed cleanup.
+/// Termination completion is joined before connection/run mappings are removed.
+@MainActor
+enum ContextBuilderChildConnectionFinalizer {
+    typealias RequestTermination = @MainActor (_ connectionID: UUID) -> Task<Void, Never>
+    typealias CommitContext = @MainActor (_ connectionID: UUID) async -> Bool
+    typealias BeforeTerminationRequest = @MainActor () async -> Void
+    typealias BeforeTerminationJoin = @MainActor () async -> Void
+    typealias CleanupMapping = @MainActor (_ connectionID: UUID) -> Void
+
+    static func finalize(
+        connectionIDs: [UUID],
+        commitContext: CommitContext,
+        beforeTerminationRequest: BeforeTerminationRequest,
+        requestTermination: RequestTermination,
+        beforeTerminationJoin: BeforeTerminationJoin,
+        cleanupMapping: CleanupMapping
+    ) async -> Bool {
+        for connectionID in connectionIDs {
+            guard await commitContext(connectionID) else { return false }
+        }
+
+        await beforeTerminationRequest()
+        let terminationTasks = connectionIDs.map(requestTermination)
+        await beforeTerminationJoin()
+        for task in terminationTasks {
+            await task.value
+        }
+
+        for connectionID in connectionIDs {
+            cleanupMapping(connectionID)
+        }
+        return true
+    }
+}
+
 @MainActor
 final class ContextBuilderRunRecord {
     struct TeardownPayload {
@@ -46,6 +83,7 @@ final class ContextBuilderRunRecord {
     let origin: ContextBuilderRunOrigin
     let agentKind: AgentProviderKind
     let modelRaw: String
+    let progressReporter: ContextBuilderMCPProgressReporter?
 
     var output = ContextBuilderAssistantOutputAccumulator()
     var executionTask: Task<Void, Never>?
@@ -70,7 +108,8 @@ final class ContextBuilderRunRecord {
         agentKind: AgentProviderKind,
         modelRaw: String,
         continuation: CheckedContinuation<ContextBuilderAgentViewModel.ContextBuilderRunSnapshot, Error>? = nil,
-        restoreConfiguration: (() -> Void)? = nil
+        restoreConfiguration: (() -> Void)? = nil,
+        progressReporter: ContextBuilderMCPProgressReporter? = nil
     ) {
         self.runID = runID
         self.tabID = tabID
@@ -81,6 +120,11 @@ final class ContextBuilderRunRecord {
         self.modelRaw = modelRaw
         self.continuation = continuation
         self.restoreConfiguration = restoreConfiguration
+        self.progressReporter = progressReporter
+    }
+
+    func reportProgress(_ phase: ContextBuilderMCPProgressPhase) async {
+        await progressReporter?(phase)
     }
 
     var isTerminal: Bool {

--- a/Sources/RepoPrompt/Features/Diagnostics/MCP/MCPReadFileAutoSelectionDiagnostics.swift
+++ b/Sources/RepoPrompt/Features/Diagnostics/MCP/MCPReadFileAutoSelectionDiagnostics.swift
@@ -1,0 +1,102 @@
+import Foundation
+import RepoPromptShared
+
+struct MCPReadFileAutoSelectionDiagnosticEvent: Equatable, CustomStringConvertible {
+    enum Kind: String {
+        case acceptedHighWaterAdvanced = "accepted_high_water_advanced"
+        case drainHighWaterCaptured = "drain_high_water_captured"
+        case waiterRegistered = "waiter_registered"
+        case waiterResumed = "waiter_resumed"
+        case workerStarted = "worker_started"
+        case workerStopped = "worker_stopped"
+    }
+
+    enum Lane: String {
+        case canonical
+        case mirror
+    }
+
+    let kind: Kind
+    let lane: Lane
+    let windowID: Int
+    let workspaceID: UUID?
+    let tabID: UUID
+    let routeScope: String?
+    let bindingGeneration: UInt64?
+    let target: UInt64?
+    let previousAcceptedHighWater: UInt64?
+    let acceptedHighWater: UInt64
+    let completedHighWater: UInt64
+    let waiterCount: Int
+    let workerActive: Bool
+    let pendingWork: Bool
+    let waiterID: UUID?
+    let workerID: UUID?
+    let requiredMirrorTicket: UInt64?
+
+    var description: String {
+        var fields = [
+            "event=\(kind.rawValue)",
+            "lane=\(lane.rawValue)",
+            "window_id=\(windowID)",
+            "tab_id=\(tabID.uuidString)",
+            "accepted_high_water=\(acceptedHighWater)",
+            "completed_high_water=\(completedHighWater)",
+            "waiter_count=\(waiterCount)",
+            "worker_active=\(workerActive)",
+            "pending_work=\(pendingWork)"
+        ]
+        if let workspaceID { fields.append("workspace_id=\(workspaceID.uuidString)") }
+        if let routeScope { fields.append("route=\(routeScope)") }
+        if let bindingGeneration { fields.append("binding_generation=\(bindingGeneration)") }
+        if let target { fields.append("target=\(target)") }
+        if let previousAcceptedHighWater { fields.append("previous_accepted_high_water=\(previousAcceptedHighWater)") }
+        if let waiterID { fields.append("waiter_id=\(waiterID.uuidString)") }
+        if let workerID { fields.append("worker_id=\(workerID.uuidString)") }
+        if let requiredMirrorTicket { fields.append("required_mirror_ticket=\(requiredMirrorTicket)") }
+        return fields.joined(separator: " ")
+    }
+}
+
+/// Structured diagnostics for the read/search auto-selection coordinator. Events are
+/// available to tests unconditionally and are written to stderr only when MCP execution
+/// or auto-selection tracing is enabled.
+enum MCPReadFileAutoSelectionDiagnosticTracer {
+    private final class State: @unchecked Sendable {
+        let lock = NSLock()
+        var testSink: (@Sendable (MCPReadFileAutoSelectionDiagnosticEvent) -> Void)?
+    }
+
+    private static let state = State()
+
+    private static var tracingEnabled: Bool {
+        #if DEBUG
+            ProcessInfo.processInfo.environment["REPOPROMPT_MCP_AUTO_SELECTION_TRACE"] == "1"
+                || MCPToolExecutionTracer.successTracingEnabled
+        #else
+            UserDefaults.standard.bool(forKey: "enableMCPToolExecutionTrace")
+        #endif
+    }
+
+    static func emit(_ event: MCPReadFileAutoSelectionDiagnosticEvent) {
+        let sink: (@Sendable (MCPReadFileAutoSelectionDiagnosticEvent) -> Void)?
+        state.lock.lock()
+        sink = state.testSink
+        state.lock.unlock()
+        sink?(event)
+
+        guard tracingEnabled else { return }
+        guard let data = "[MCPAutoSelection] \(event)\n".data(using: .utf8) else { return }
+        state.lock.lock()
+        defer { state.lock.unlock() }
+        BestEffortStderrWriter.write(data)
+    }
+
+    #if DEBUG
+        static func setTestSink(_ sink: (@Sendable (MCPReadFileAutoSelectionDiagnosticEvent) -> Void)?) {
+            state.lock.lock()
+            state.testSink = sink
+            state.lock.unlock()
+        }
+    #endif
+}

--- a/Sources/RepoPrompt/Features/Diagnostics/MCP/MCPToolExecutionDiagnostics.swift
+++ b/Sources/RepoPrompt/Features/Diagnostics/MCP/MCPToolExecutionDiagnostics.swift
@@ -1,6 +1,85 @@
 import Foundation
 import RepoPromptShared
 
+enum MCPToolExecutionHandlerPhase: String, Equatable {
+    case manageSelectionAutoSelectionDrain = "manage_selection.auto_selection_drain"
+    case manageSelectionIngressWait = "manage_selection.ingress_wait"
+    case manageSelectionConstruction = "manage_selection.selection_construction"
+    case manageSelectionPersistence = "manage_selection.persistence"
+    case manageSelectionReplyConstruction = "manage_selection.reply_construction"
+    case fileActionsPreMutationChecks = "file_actions.pre_mutation_checks"
+    case fileActionsCatalogEligibility = "file_actions.catalog_eligibility"
+    case fileActionsMutationIO = "file_actions.mutation_io"
+    case fileActionsPostMutationCatalog = "file_actions.post_mutation_catalog"
+    case fileActionsPostMutationSelection = "file_actions.post_mutation_selection"
+    case fileActionsReplyConstruction = "file_actions.reply_construction"
+}
+
+enum MCPToolExecutionHandlerPhaseTransition: String, Equatable {
+    case started
+    case completed
+}
+
+struct MCPToolExecutionHandlerPhaseSnapshot: Equatable {
+    let phase: MCPToolExecutionHandlerPhase
+    let transition: MCPToolExecutionHandlerPhaseTransition
+    let elapsedMilliseconds: Double
+}
+
+/// Per-invocation progress state. Providers use the task-local accessor while the
+/// connection manager retains this recorder explicitly for watchdog escalation.
+final class MCPToolExecutionHandlerPhaseRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private let origin: Duration
+    private let now: @Sendable () async -> Duration
+    private var latest: MCPToolExecutionHandlerPhaseSnapshot?
+
+    init(
+        origin: Duration,
+        now: @escaping @Sendable () async -> Duration
+    ) {
+        self.origin = origin
+        self.now = now
+    }
+
+    func report(
+        _ phase: MCPToolExecutionHandlerPhase,
+        transition: MCPToolExecutionHandlerPhaseTransition
+    ) async {
+        let current = await now()
+        store(MCPToolExecutionHandlerPhaseSnapshot(
+            phase: phase,
+            transition: transition,
+            elapsedMilliseconds: max(0, current.mcpMilliseconds - origin.mcpMilliseconds)
+        ))
+    }
+
+    func snapshot() -> MCPToolExecutionHandlerPhaseSnapshot? {
+        lock.lock()
+        defer { lock.unlock() }
+        return latest
+    }
+
+    private func store(_ snapshot: MCPToolExecutionHandlerPhaseSnapshot) {
+        lock.lock()
+        latest = snapshot
+        lock.unlock()
+    }
+}
+
+enum MCPToolExecutionHandlerPhaseContext {
+    @TaskLocal
+    static var recorder: MCPToolExecutionHandlerPhaseRecorder?
+
+    static func report(
+        _ phase: MCPToolExecutionHandlerPhase,
+        transition: MCPToolExecutionHandlerPhaseTransition = .started
+    ) async {
+        guard let recorder else { return }
+        await recorder.report(phase, transition: transition)
+    }
+}
+
 struct MCPToolExecutionTraceEvent: Equatable, CustomStringConvertible {
     enum Phase: String {
         case contractSelected = "execution_contract_selected"
@@ -26,6 +105,8 @@ struct MCPToolExecutionTraceEvent: Equatable, CustomStringConvertible {
     let cancellationOutcome: String?
     let graceOutcome: String?
     let escalationReason: String?
+    let handlerPhase: MCPToolExecutionHandlerPhaseSnapshot?
+    let handlerPhaseAgeMilliseconds: Double?
 
     var isAlwaysEmitted: Bool {
         switch phase {
@@ -53,6 +134,14 @@ struct MCPToolExecutionTraceEvent: Equatable, CustomStringConvertible {
         if let cancellationOutcome { fields.append("cancellation_outcome=\(cancellationOutcome)") }
         if let graceOutcome { fields.append("grace_outcome=\(graceOutcome)") }
         if let escalationReason { fields.append("escalation_reason=\(escalationReason)") }
+        if let handlerPhase {
+            fields.append("handler_phase=\(handlerPhase.phase.rawValue)")
+            fields.append("handler_phase_transition=\(handlerPhase.transition.rawValue)")
+            fields.append("handler_phase_elapsed_ms=\(String(format: "%.3f", handlerPhase.elapsedMilliseconds))")
+        }
+        if let handlerPhaseAgeMilliseconds {
+            fields.append("handler_phase_age_ms=\(String(format: "%.3f", handlerPhaseAgeMilliseconds))")
+        }
         return fields.joined(separator: " ")
     }
 }

--- a/Sources/RepoPrompt/Features/WorkspaceFiles/ViewModels/WorkspaceFilesViewModel.swift
+++ b/Sources/RepoPrompt/Features/WorkspaceFiles/ViewModels/WorkspaceFilesViewModel.swift
@@ -1087,7 +1087,7 @@ class WorkspaceFilesViewModel: ObservableObject {
         selectionCoordinatorCancellable?.cancel()
         selectionCoordinatorCancellable = coordinator.changes
             .sink { [weak self, weak coordinator] change in
-                guard change.source != .uiFlush else { return }
+                guard change.source != .uiFlush, change.source != .mcpTabContext else { return }
                 Task { @MainActor [weak self, weak coordinator] in
                     guard let self, let coordinator else { return }
                     guard change.tabID == nil || change.tabID == currentTabID else { return }

--- a/Sources/RepoPrompt/Features/Workspaces/ViewModels/WorkspaceManagerViewModel.swift
+++ b/Sources/RepoPrompt/Features/Workspaces/ViewModels/WorkspaceManagerViewModel.swift
@@ -231,10 +231,17 @@ class WorkspaceManagerViewModel: ObservableObject {
                 workspaces.enumerated().map { ($1.id, $0) },
                 uniquingKeysWith: { _, last in last }
             )
+            refreshSelectionMirrorContextRevision()
         }
     }
 
-    @Published private(set) var activeWorkspaceID: UUID? = nil // New property to track the active workspace ID
+    @Published private(set) var activeWorkspaceID: UUID? = nil {
+        didSet {
+            guard oldValue != activeWorkspaceID else { return }
+            refreshSelectionMirrorContextRevision()
+        }
+    }
+
     #if DEBUG
         private var restoreTokenRecountWatchdogIDs: Set<UUID> = []
     #endif
@@ -255,6 +262,28 @@ class WorkspaceManagerViewModel: ObservableObject {
     private static var nextWorkspaceSelectionRevision: UInt64 = 1
     private var selectionRevisionByWorkspaceTab: [WorkspaceTabSelectionKey: UInt64] = [:]
     private var revisedSelectionByWorkspaceTab: [WorkspaceTabSelectionKey: StoredSelection] = [:]
+
+    private struct SelectionMirrorContext: Equatable {
+        let workspaceID: UUID
+        let tabID: UUID
+    }
+
+    private var lastSelectionMirrorContext: SelectionMirrorContext?
+    private(set) var selectionMirrorContextRevision: UInt64 = 0
+
+    private func refreshSelectionMirrorContextRevision() {
+        let context: SelectionMirrorContext? = if let activeWorkspaceID,
+                                                  let workspace = workspaces.first(where: { $0.id == activeWorkspaceID }),
+                                                  let tabID = workspace.activeComposeTabID ?? workspace.composeTabs.first?.id
+        {
+            SelectionMirrorContext(workspaceID: activeWorkspaceID, tabID: tabID)
+        } else {
+            nil
+        }
+        guard context != lastSelectionMirrorContext else { return }
+        lastSelectionMirrorContext = context
+        selectionMirrorContextRevision &+= 1
+    }
 
     private func bumpStateVersion(for id: UUID?) {
         guard let id else { return }
@@ -3806,25 +3835,40 @@ class WorkspaceManagerViewModel: ObservableObject {
         }
     }
 
-    /// Applies the newest stored selection to the active file-selector UI without replaying
-    /// prompt text or other compose-tab state. Used by deferred `read_file` auto-selection.
+    /// Performs one selection mirror attempt. The coordinator owns identity fencing and repair.
+    @MainActor
+    func applySelectionMirrorAttempt(
+        _ selection: StoredSelection,
+        forTabID tabID: UUID,
+        workspaceID: UUID
+    ) async {
+        guard let active = activeWorkspace,
+              active.id == workspaceID,
+              active.activeComposeTabID == tabID
+        else { return }
+
+        beginApplyingTabContext(forTabID: tabID)
+        defer { endApplyingTabContext(forTabID: tabID) }
+        await fileManager.applyStoredSelection(selection)
+        await promptViewModel.tokenCountingViewModel.forceImmediateRecount()
+    }
+
+    /// Applies the newest stored selection after deferred `read_file` auto-selection.
     @MainActor
     func applyStoredSelectionMirrorForReadFileAutoSelection(tabID: UUID) async {
         guard let active = activeWorkspace,
               active.activeComposeTabID == tabID,
               let tab = composeTab(with: tabID)
         else { return }
-
-        beginApplyingTabContext(forTabID: tabID)
-        defer { endApplyingTabContext(forTabID: tabID) }
         if let selectionCoordinator {
-            await selectionCoordinator.withApplyingSelectionMirror {
-                await fileManager.applyStoredSelection(tab.selection)
-            }
+            await selectionCoordinator.mirrorSelectionToActiveUI(tab.selection, forTabID: tabID)
         } else {
-            await fileManager.applyStoredSelection(tab.selection)
+            await applySelectionMirrorAttempt(
+                tab.selection,
+                forTabID: tabID,
+                workspaceID: active.id
+            )
         }
-        await promptViewModel.tokenCountingViewModel.forceImmediateRecount()
     }
 
     /// Silent "stored-only" update: updates the compose tab in the backing store

--- a/Sources/RepoPrompt/Infrastructure/AI/AIQueriesService.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/AIQueriesService.swift
@@ -230,16 +230,26 @@ actor TaskManager {
 }
 
 public class AIQueriesService {
+    typealias SendPromptOverride = @Sendable (
+        _ message: AIMessage,
+        _ model: AIModel
+    ) async throws -> (id: ChatStreamID, stream: AsyncThrowingStream<ChatStreamOutput, Error>)
+
     private let taskManager = TaskManager()
     private let chunkSizeThreshold = 8000 // e.g. 8KB
     private let timeThreshold: TimeInterval = 0.7 // 0.4 seconds
     private let providerPool: DisposableProviderPool
     private let keyManager: KeyManager
+    private let sendPromptOverride: SendPromptOverride?
     private var currentModel: AIModel
 
-    init(keyManager: KeyManager) {
+    init(
+        keyManager: KeyManager,
+        sendPromptOverride: SendPromptOverride? = nil
+    ) {
         currentModel = .claude4Sonnet
         self.keyManager = keyManager
+        self.sendPromptOverride = sendPromptOverride
         providerPool = DisposableProviderPool(keyManager: keyManager)
     }
 
@@ -247,10 +257,12 @@ public class AIQueriesService {
         model: AIModel,
         ollamaURL: URL? = nil,
         azureConfiguration: AzureOpenAIConfiguration? = nil,
-        keyManager: KeyManager
+        keyManager: KeyManager,
+        sendPromptOverride: SendPromptOverride? = nil
     ) {
         currentModel = model
         self.keyManager = keyManager
+        self.sendPromptOverride = sendPromptOverride
         providerPool = DisposableProviderPool(keyManager: keyManager)
     }
 
@@ -290,6 +302,10 @@ public class AIQueriesService {
         _ aiMessage: AIMessage,
         model: AIModel
     ) async throws -> (id: ChatStreamID, stream: AsyncThrowingStream<ChatStreamOutput, Error>) {
+        if let sendPromptOverride {
+            return try await sendPromptOverride(aiMessage, model)
+        }
+
         let taskId = UUID()
         await taskManager.createPartialBuffer(for: taskId)
 

--- a/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService+FileOperations.swift
+++ b/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService+FileOperations.swift
@@ -66,98 +66,163 @@ extension FileSystemService {
         }
     }
 
+    /// Starts filesystem I/O that cannot be cancelled safely once handed to Foundation.
+    ///
+    /// Reconciliation contract: request cancellation only removes and resumes the actor-owned
+    /// waiter. The detached monitor remains the sole completion owner and always reconciles the
+    /// service caches plus synthetic delta publication against the eventual on-disk result.
+    private func startUncancellableMutation(
+        _ operation: FileSystemUncancellableMutation,
+        io: @escaping @Sendable () throws -> Void
+    ) -> (id: UUID, task: Task<Void, any Error>) {
+        let id = UUID()
+        #if DEBUG
+            let willBegin = mutationIOWillBeginHandler
+        #else
+            let willBegin: (@Sendable (FileSystemUncancellableMutation) async -> Void)? = nil
+        #endif
+        let task = Task.detached(priority: .utility) {
+            if let willBegin {
+                await willBegin(operation)
+            }
+            try io()
+        }
+        return (id, task)
+    }
+
+    private func awaitUncancellableMutation(_ id: UUID) async throws {
+        try Task.checkCancellation()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
+                if Task.isCancelled {
+                    continuation.resume(throwing: CancellationError())
+                } else {
+                    mutationWaiters[id] = FileSystemMutationWaiter(continuation: continuation)
+                }
+            }
+        } onCancel: {
+            Task { [weak self] in
+                await self?.cancelMutationWaiter(id)
+            }
+        }
+    }
+
+    private func cancelMutationWaiter(_ id: UUID) {
+        guard let waiter = mutationWaiters.removeValue(forKey: id) else { return }
+        waiter.continuation.resume(throwing: CancellationError())
+    }
+
+    private func completeMutationWaiter(_ id: UUID, error: (any Error)? = nil) {
+        guard let waiter = mutationWaiters.removeValue(forKey: id) else { return }
+        if let error {
+            waiter.continuation.resume(throwing: error)
+        } else {
+            waiter.continuation.resume()
+        }
+    }
+
     /// Atomically move/rename a **file** inside the same root.
     func moveFile(
         atRelativePath oldRelPath: String,
         toRelativePath newRelPath: String
     ) async throws {
-        let fm = fm // Cache for multiple calls in this method
-
-        // --- prepare -----------------------------------------------------
-        // ── 0. Validate that both paths stay inside the loaded root ─────────────
+        try Task.checkCancellation()
+        let fm = fm
         let oldTarget = try mutationTarget(forRelativePath: oldRelPath)
         let newTarget = try mutationTarget(forRelativePath: newRelPath)
         let oldFull = oldTarget.url.path
         let newFull = newTarget.url.path
         try await requireRegularMutationSource(relativePath: oldTarget.relativePath)
+        try Task.checkCancellation()
 
-        // 1) Source must exist
         guard fm.fileExists(atPath: oldFull, isDirectory: nil) else {
             throw FileSystemError.fileNotFound
         }
-
-        // 2) Destination must not exist
         guard !fm.fileExists(atPath: newFull, isDirectory: nil) else {
             throw FileSystemError.fileAlreadyExists
         }
 
-        // 3) Ensure parent folder exists (this is fast, keep it in-actor)
         let destDir = (newFull as NSString).deletingLastPathComponent
-        try fm.createDirectory(
-            atPath: destDir,
-            withIntermediateDirectories: true,
-            attributes: nil
-        )
+        try fm.createDirectory(atPath: destDir, withIntermediateDirectories: true, attributes: nil)
         _ = try mutationTarget(forRelativePath: newTarget.relativePath)
 
-        // --- 1. do I/O off-actor ----------------------------------------
-        // 4) Perform the move on disk
-        do {
-            try await Task.detached(priority: .utility) {
-                try FileManager.default.moveItem(atPath: oldFull, toPath: newFull)
-            }.value // bubbles error
-        } catch {
-            throw FileSystemError.failedToCreateFile(error)
+        let mutation = startUncancellableMutation(.move) {
+            try FileManager.default.moveItem(atPath: oldFull, toPath: newFull)
         }
+        Task.detached { [weak self] in
+            do {
+                try await mutation.task.value
+                await self?.reconcileMovedFile(
+                    mutationID: mutation.id,
+                    oldRelativePath: oldTarget.relativePath,
+                    newRelativePath: newTarget.relativePath,
+                    oldFullPath: oldFull,
+                    newFullPath: newFull
+                )
+            } catch {
+                await self?.completeMutationWaiter(
+                    mutation.id,
+                    error: FileSystemError.failedToCreateFile(error)
+                )
+            }
+        }
+        try await awaitUncancellableMutation(mutation.id)
+    }
 
-        let destinationEligibility = await catalogRegularFileEligibility(relativePath: newTarget.relativePath)
-        switch destinationEligibility {
+    private func reconcileMovedFile(
+        mutationID: UUID,
+        oldRelativePath: String,
+        newRelativePath: String,
+        oldFullPath: String,
+        newFullPath: String
+    ) async {
+        switch await catalogRegularFileEligibility(relativePath: newRelativePath) {
         case .eligible, .ineligible(.ignored):
             break
         case .ineligible:
-            try? FileManager.default.moveItem(atPath: newFull, toPath: oldFull)
-            throw FileSystemError.invalidRelativePath
+            do {
+                try await Task.detached(priority: .utility) {
+                    try FileManager.default.moveItem(atPath: newFullPath, toPath: oldFullPath)
+                }.value
+            } catch {
+                forgetTrackedPath(oldRelativePath)
+                publishFileSystemDeltas(
+                    [.fileRemoved(oldRelativePath), .fileAdded(newRelativePath)],
+                    source: .syntheticMutation
+                )
+            }
+            completeMutationWaiter(mutationID, error: FileSystemError.invalidRelativePath)
+            return
         }
 
-        // --- 2. in-memory bookkeeping (still inside actor) --------------
-        // 5) Immediate in‑memory bookkeeping (fixes race window) ───────────────
-        let stdOld = oldTarget.relativePath
-        let stdNew = newTarget.relativePath
-
-        if let wasDir = visitedItems.removeValue(forKey: stdOld) {
-            visitedItems[stdNew] = wasDir // will be 'false' for files
+        if let wasDirectory = visitedItems.removeValue(forKey: oldRelativePath) {
+            visitedItems[newRelativePath] = wasDirectory
         }
-        visitedPaths.remove(stdOld)
-        visitedPaths.insert(stdNew)
-
-        // Transfer encoding if we have it
-        if let encoding = encodingMap[stdOld] {
-            encodingMap.removeValue(forKey: stdOld)
-            encodingMap[stdNew] = encoding
+        visitedPaths.remove(oldRelativePath)
+        visitedPaths.insert(newRelativePath)
+        if let encoding = encodingMap.removeValue(forKey: oldRelativePath) {
+            encodingMap[newRelativePath] = encoding
         }
-
-        // 6) Emit synthetic deltas so the UI updates before FSEvents arrive
-        publishFileSystemDeltas([.fileRemoved(stdOld), .fileAdded(stdNew)], source: .syntheticMutation)
+        publishFileSystemDeltas(
+            [.fileRemoved(oldRelativePath), .fileAdded(newRelativePath)],
+            source: .syntheticMutation
+        )
+        completeMutationWaiter(mutationID)
     }
 
     func createFile(atRelativePath relativePath: String, content: String) async throws {
-        let fm = fm // Cache for multiple calls in this method
-        // --- prepare -----------------------------------------------------
+        try Task.checkCancellation()
+        let fm = fm
         let target = try mutationTarget(forRelativePath: relativePath)
         let fullPath = target.url.path
         let fullURL = target.url
 
-        // Ensure directory exists (this is fast, keep it in-actor)
         let directoryURL = fullURL.deletingLastPathComponent()
         try fm.createDirectory(at: directoryURL, withIntermediateDirectories: true, attributes: nil)
         _ = try mutationTarget(forRelativePath: target.relativePath)
-
-        // Check if file already exists
-        if fm.fileExists(atPath: fullPath, isDirectory: nil) {
+        guard !fm.fileExists(atPath: fullPath, isDirectory: nil) else {
             throw FileSystemError.fileAlreadyExists
         }
-
-        // Prepare data with UTF-8 encoding
         guard let data = content.data(using: .utf8) else {
             throw FileSystemError.failedToCreateFile(
                 NSError(
@@ -168,85 +233,139 @@ extension FileSystemService {
             )
         }
 
-        // --- 1. do I/O off-actor ----------------------------------------
-        do {
-            try await Task.detached(priority: .utility) {
-                try FileSystemService.writeFileRobust(to: fullURL, data: data)
-            }.value // bubbles error
-            fileSystemDebugLog("File created at \(fullURL.path)")
-        } catch {
-            throw FileSystemError.failedToCreateFile(error)
+        let mutation = startUncancellableMutation(.create) {
+            try FileSystemService.writeFileRobust(to: fullURL, data: data)
         }
+        Task.detached { [weak self] in
+            do {
+                try await mutation.task.value
+                await self?.reconcileCreatedFile(
+                    mutationID: mutation.id,
+                    relativePath: target.relativePath,
+                    url: fullURL
+                )
+            } catch {
+                await self?.completeMutationWaiter(
+                    mutation.id,
+                    error: FileSystemError.failedToCreateFile(error)
+                )
+            }
+        }
+        try await awaitUncancellableMutation(mutation.id)
+    }
 
-        switch await catalogRegularFileEligibility(relativePath: target.relativePath) {
+    private func reconcileCreatedFile(
+        mutationID: UUID,
+        relativePath: String,
+        url: URL
+    ) async {
+        fileSystemDebugLog("File created at \(url.path)")
+        switch await catalogRegularFileEligibility(relativePath: relativePath) {
         case .eligible, .ineligible(.ignored):
             break
         case .ineligible:
-            try? fm.removeItem(at: fullURL)
-            forgetTrackedPath(target.relativePath)
-            throw FileSystemError.invalidRelativePath
+            _ = try? await Task.detached(priority: .utility) {
+                try FileManager.default.removeItem(at: url)
+            }.value
+            forgetTrackedPath(relativePath)
+            completeMutationWaiter(mutationID, error: FileSystemError.invalidRelativePath)
+            return
         }
 
-        // --- 2. in-memory bookkeeping (still inside actor) --------------
-        // update encoding cache (new files default to UTF-8)
-        encodingMap[target.relativePath] = .utf8
-
-        // update visited* sets
-        if !visitedPaths.contains(target.relativePath) {
-            visitedPaths.insert(target.relativePath)
-            visitedItems[target.relativePath] = false
-        }
-
-        // emit a *synthetic* delta so the UI updates immediately
-        publishFileSystemDeltas([.fileAdded(target.relativePath)], source: .syntheticMutation)
+        encodingMap[relativePath] = .utf8
+        visitedPaths.insert(relativePath)
+        visitedItems[relativePath] = false
+        publishFileSystemDeltas([.fileAdded(relativePath)], source: .syntheticMutation)
+        completeMutationWaiter(mutationID)
     }
 
     func deleteFile(atRelativePath relativePath: String) async throws {
+        try Task.checkCancellation()
         let target = try mutationTarget(forRelativePath: relativePath)
         try await requireRegularMutationSource(relativePath: target.relativePath)
+        try Task.checkCancellation()
         let url = target.url
-        do {
-            try fm.removeItem(at: url)
-            fileSystemDebugLog("File deleted at \(url.path)")
-        } catch {
-            throw FileSystemError.failedToDeleteFile(error)
+        let mutation = startUncancellableMutation(.delete) {
+            try FileManager.default.removeItem(at: url)
         }
-        forgetTrackedPath(target.relativePath)
-        publishFileSystemDeltas([.fileRemoved(target.relativePath)], source: .syntheticMutation)
+        Task.detached { [weak self] in
+            do {
+                try await mutation.task.value
+                await self?.reconcileDeletedFile(
+                    mutationID: mutation.id,
+                    relativePath: target.relativePath,
+                    url: url
+                )
+            } catch {
+                await self?.completeMutationWaiter(
+                    mutation.id,
+                    error: FileSystemError.failedToDeleteFile(error)
+                )
+            }
+        }
+        try await awaitUncancellableMutation(mutation.id)
+    }
+
+    private func reconcileDeletedFile(mutationID: UUID, relativePath: String, url: URL) {
+        fileSystemDebugLog("File deleted at \(url.path)")
+        forgetTrackedPath(relativePath)
+        publishFileSystemDeltas([.fileRemoved(relativePath)], source: .syntheticMutation)
+        completeMutationWaiter(mutationID)
     }
 
     func moveItemToTrash(atRelativePath relativePath: String) async throws {
+        try Task.checkCancellation()
         let target = try mutationTarget(forRelativePath: relativePath)
         let normalizedRelativePath = target.relativePath
         let url = target.url
-        let fullPath = url.path
-
         var isDirectory = ObjCBool(false)
-        guard fm.fileExists(atPath: fullPath, isDirectory: &isDirectory) else {
+        guard fm.fileExists(atPath: url.path, isDirectory: &isDirectory) else {
             throw FileSystemError.fileNotFound
         }
+        let wasDirectory = isDirectory.boolValue
 
-        do {
-            _ = try moveURLToTrash(url)
-            fileSystemDebugLog("File moved to Trash at \(url.path)")
-        } catch {
-            throw FileSystemError.failedToDeleteFile(error)
+        let mutation = startUncancellableMutation(.trash) {
+            _ = try Self.moveURLToTrashOffActor(url)
         }
+        Task.detached { [weak self] in
+            do {
+                try await mutation.task.value
+                await self?.reconcileTrashedItem(
+                    mutationID: mutation.id,
+                    relativePath: normalizedRelativePath,
+                    url: url,
+                    wasDirectory: wasDirectory
+                )
+            } catch {
+                await self?.completeMutationWaiter(
+                    mutation.id,
+                    error: FileSystemError.failedToDeleteFile(error)
+                )
+            }
+        }
+        try await awaitUncancellableMutation(mutation.id)
+    }
 
+    private func reconcileTrashedItem(
+        mutationID: UUID,
+        relativePath: String,
+        url: URL,
+        wasDirectory: Bool
+    ) {
+        fileSystemDebugLog("File moved to Trash at \(url.path)")
         let keysToForget = encodingMap.keys.filter {
-            $0 == normalizedRelativePath || $0.hasPrefix(normalizedRelativePath + "/")
+            $0 == relativePath || $0.hasPrefix(relativePath + "/")
         }
         for key in keysToForget {
             encodingMap.removeValue(forKey: key)
         }
 
-        var deltas = removeSubtree(for: normalizedRelativePath)
+        var deltas = removeSubtree(for: relativePath)
         if deltas.isEmpty {
-            deltas = [isDirectory.boolValue ? .folderRemoved(normalizedRelativePath) : .fileRemoved(normalizedRelativePath)]
+            deltas = [wasDirectory ? .folderRemoved(relativePath) : .fileRemoved(relativePath)]
         }
-        if !deltas.isEmpty {
-            publishFileSystemDeltas(deltas, source: .syntheticMutation)
-        }
+        publishFileSystemDeltas(deltas, source: .syntheticMutation)
+        completeMutationWaiter(mutationID)
     }
 
     private func forgetTrackedPath(_ relativePath: String) {
@@ -255,19 +374,14 @@ extension FileSystemService {
         visitedItems.removeValue(forKey: relativePath)
     }
 
-    private func moveURLToTrash(_ url: URL) throws -> URL? {
-        #if DEBUG
-            return try fm.moveItemToTrash(at: url)
-        #else
-            var resultingItemURL: NSURL?
-            try fm.trashItem(at: url, resultingItemURL: &resultingItemURL)
-            return resultingItemURL as URL?
-        #endif
+    private nonisolated static func moveURLToTrashOffActor(_ url: URL) throws -> URL? {
+        var resultingItemURL: NSURL?
+        try FileManager.default.trashItem(at: url, resultingItemURL: &resultingItemURL)
+        return resultingItemURL as URL?
     }
 
-    /// Re-written non-blocking version
     func editFile(atRelativePath relativePath: String, newContent: String) async throws {
-        // --- prepare -----------------------------------------------------
+        try Task.checkCancellation()
         let target = try mutationTarget(forRelativePath: relativePath)
         let fullPath = target.url.path
         let fullURL = target.url
@@ -282,46 +396,61 @@ extension FileSystemService {
         case .ineligible:
             throw FileSystemError.invalidRelativePath
         }
-        let enc = encodingMap[target.relativePath] ?? .utf8
-        guard let data = newContent.data(using: enc) else {
+        try Task.checkCancellation()
+
+        let encoding = encodingMap[target.relativePath] ?? .utf8
+        guard let data = newContent.data(using: encoding) else {
             throw FileSystemError.failedToEditFile(
                 NSError(
                     domain: "encoding",
                     code: -1,
-                    userInfo: [NSLocalizedDescriptionKey: "Unable to encode text as \(enc)"]
+                    userInfo: [NSLocalizedDescriptionKey: "Unable to encode text as \(encoding)"]
                 )
             )
         }
 
-        // --- 1. do I/O off-actor ----------------------------------------
-        do {
-            try await Task.detached(priority: .utility) {
-                try FileSystemService.writeFileRobust(to: fullURL, data: data)
-            }.value // bubbles error
-        } catch {
-            throw FileSystemError.failedToEditFile(error)
+        let mutation = startUncancellableMutation(.edit) {
+            try FileSystemService.writeFileRobust(to: fullURL, data: data)
         }
+        Task.detached { [weak self] in
+            do {
+                try await mutation.task.value
+                await self?.reconcileEditedFile(
+                    mutationID: mutation.id,
+                    relativePath: target.relativePath,
+                    encoding: encoding
+                )
+            } catch {
+                await self?.completeMutationWaiter(
+                    mutation.id,
+                    error: FileSystemError.failedToEditFile(error)
+                )
+            }
+        }
+        try await awaitUncancellableMutation(mutation.id)
+    }
 
-        switch await catalogRegularFileEligibility(relativePath: target.relativePath) {
+    private func reconcileEditedFile(
+        mutationID: UUID,
+        relativePath: String,
+        encoding: String.Encoding
+    ) async {
+        switch await catalogRegularFileEligibility(relativePath: relativePath) {
         case .eligible, .ineligible(.ignored):
             break
         case .ineligible:
-            throw FileSystemError.invalidRelativePath
+            forgetTrackedPath(relativePath)
+            publishFileSystemDeltas([.fileRemoved(relativePath)], source: .syntheticMutation)
+            completeMutationWaiter(mutationID, error: FileSystemError.invalidRelativePath)
+            return
         }
 
-        // --- 2. in-memory bookkeeping (still inside actor) --------------
-        // refresh encoding cache
-        encodingMap[target.relativePath] = enc
-
-        // update visited* sets so later FSEvents don't look "new"
-        if !visitedPaths.contains(target.relativePath) {
-            visitedPaths.insert(target.relativePath)
-            visitedItems[target.relativePath] = false
-        }
-
-        // emit a *synthetic* delta so the UI updates immediately, with mtime if available
-        let mdate = try? await getFileModificationDate(atRelativePath: target.relativePath)
-        publishFileSystemDeltas([.fileModified(target.relativePath, mdate)], source: .syntheticMutation)
+        encodingMap[relativePath] = encoding
+        visitedPaths.insert(relativePath)
+        visitedItems[relativePath] = false
+        let modificationDate = try? await getFileModificationDate(atRelativePath: relativePath)
+        publishFileSystemDeltas([.fileModified(relativePath, modificationDate)], source: .syntheticMutation)
+        completeMutationWaiter(mutationID)
     }
 
     func checkFilePermissions(atRelativePath relativePath: String) -> Bool {

--- a/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService.swift
+++ b/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService.swift
@@ -14,6 +14,18 @@ import UniversalCharsetDetection
     import Glibc
 #endif
 
+enum FileSystemUncancellableMutation: Equatable {
+    case create
+    case edit
+    case move
+    case delete
+    case trash
+}
+
+struct FileSystemMutationWaiter {
+    let continuation: CheckedContinuation<Void, any Error>
+}
+
 actor FileSystemService {
     // Internal for FileSystemService same-target extensions only.
     // These are not public API; preserve actor isolation when accessing them.
@@ -115,7 +127,13 @@ actor FileSystemService {
 
         /// Test-only hook invoked inside the real-filesystem off-actor content worker before each read.
         var contentReadChunkHandler: (@Sendable (String) async -> Void)?
+
+        /// Test-only gate invoked from the detached mutation worker immediately before filesystem I/O.
+        var mutationIOWillBeginHandler: (@Sendable (FileSystemUncancellableMutation) async -> Void)?
     #endif
+
+    /// Request waiters are actor-owned and may be cancelled independently from detached filesystem I/O.
+    var mutationWaiters: [UUID: FileSystemMutationWaiter] = [:]
 
     /// Tracks paths we know about, to detect additions/removals
     var visitedPaths = Set<String>()
@@ -274,6 +292,16 @@ actor FileSystemService {
     }
 
     #if DEBUG
+        func setMutationIOWillBeginHandlerForTesting(
+            _ handler: (@Sendable (FileSystemUncancellableMutation) async -> Void)?
+        ) {
+            mutationIOWillBeginHandler = handler
+        }
+
+        func pendingMutationWaiterCountForTesting() -> Int {
+            mutationWaiters.count
+        }
+
         /// Test-only initializer that allows injecting initial state
         init(
             path: String,

--- a/Sources/RepoPrompt/Infrastructure/MCP/MCPConnectionManager.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/MCPConnectionManager.swift
@@ -1023,6 +1023,10 @@ actor ServerNetworkManager {
     private var connectionWindowMap: [UUID: Int] = [:]
     private var runIDByConnectionID: [UUID: UUID] = [:]
 
+    private struct MCPConnectionCallLimiterWatchdogDiagnostics {
+        let admittedCallCount: Int
+    }
+
     private actor MCPConnectionCallLimiters {
         struct AdmissionRejected: Error {}
 
@@ -1083,6 +1087,10 @@ actor ServerNetworkManager {
 
         func hasInFlightCalls() -> Bool {
             admittedCallCount > 0
+        }
+
+        func executionWatchdogDiagnostics() -> MCPConnectionCallLimiterWatchdogDiagnostics {
+            MCPConnectionCallLimiterWatchdogDiagnostics(admittedCallCount: admittedCallCount)
         }
 
         func admissionRetryReplacement() async -> MCPConnectionCallLimiters? {
@@ -5293,8 +5301,23 @@ actor ServerNetworkManager {
         #endif
     }
 
-    private func abortConnectionForExecutionWatchdog(_ id: UUID) async {
+    private func abortConnectionForExecutionWatchdog(
+        _ id: UUID,
+        toolName: String,
+        invocationID: UUID,
+        elapsedMilliseconds: Double,
+        handlerPhase: MCPToolExecutionHandlerPhaseSnapshot?,
+        handlerPhaseAgeMilliseconds: Double?
+    ) async {
         guard executionWatchdogTerminalConnections.insert(id).inserted else { return }
+        let activeToolExecutionScopeCount = activeToolScopeIDs(ownedBy: id).values.reduce(0) { $0 + $1.count }
+        let limiterDiagnostics = await callLimiters[id]?.executionWatchdogDiagnostics()
+        let phaseDescription = handlerPhase.map {
+            "\($0.phase.rawValue):\($0.transition.rawValue) entered_ms=\(String(format: "%.3f", $0.elapsedMilliseconds)) age_ms=\(String(format: "%.3f", handlerPhaseAgeMilliseconds ?? 0))"
+        } ?? "unreported"
+        log.error(
+            "MCP execution watchdog abort connection_id=\(id) tool=\(toolName) invocation_id=\(invocationID) elapsed_ms=\(String(format: "%.3f", elapsedMilliseconds)) handler_phase=\(phaseDescription) connection_in_flight_request_count=\(limiterDiagnostics?.admittedCallCount ?? 0) active_tool_execution_scope_count=\(activeToolExecutionScopeCount)"
+        )
         connectionLog("Execution watchdog marked connection terminal: \(id)")
         #if DEBUG
             debugRecordConnectionEvent(
@@ -10296,6 +10319,12 @@ actor ServerNetworkManager {
                                     for: toolName,
                                     arguments: capturedArguments
                                 )
+                                let executionWatchdogEnvironment = await self.toolExecutionWatchdogEnvironment
+                                let executionTraceOrigin = await executionWatchdogEnvironment.now()
+                                let handlerPhaseRecorder = MCPToolExecutionHandlerPhaseRecorder(
+                                    origin: executionTraceOrigin,
+                                    now: { await executionWatchdogEnvironment.now() }
+                                )
 
                                 @Sendable func dispatchResolvedProvider(_ operation: @escaping @Sendable () async throws -> Value) async throws -> Value {
                                     guard await self.isCurrentConnectionCallLimiterResolution(
@@ -10318,8 +10347,6 @@ actor ServerNetworkManager {
                                         throw MCPToolExecutionDispatchError.missingContract(toolName: toolName)
                                     }
 
-                                    let environment = await self.toolExecutionWatchdogEnvironment
-                                    let traceOrigin = await environment.now()
                                     @Sendable func emitExecutionTrace(
                                         _ phase: MCPToolExecutionTraceEvent.Phase,
                                         cancellationRequested: Bool? = nil,
@@ -10327,7 +10354,11 @@ actor ServerNetworkManager {
                                         graceOutcome: String? = nil,
                                         escalationReason: String? = nil
                                     ) async {
-                                        let now = await environment.now()
+                                        let now = await executionWatchdogEnvironment.now()
+                                        let handlerPhase = handlerPhaseRecorder.snapshot()
+                                        let handlerPhaseAgeMilliseconds = handlerPhase.map {
+                                            max(0, now.mcpMilliseconds - executionTraceOrigin.mcpMilliseconds - $0.elapsedMilliseconds)
+                                        }
                                         MCPToolExecutionTracer.emit(MCPToolExecutionTraceEvent(
                                             toolName: toolName,
                                             connectionID: connectionID,
@@ -10337,11 +10368,13 @@ actor ServerNetworkManager {
                                             executionDeadlineSeconds: contract.deadline?.mcpSeconds,
                                             cleanupGraceSeconds: contract.cancellationGrace?.mcpSeconds,
                                             phase: phase,
-                                            elapsedMilliseconds: max(0, now.mcpMilliseconds - traceOrigin.mcpMilliseconds),
+                                            elapsedMilliseconds: max(0, now.mcpMilliseconds - executionTraceOrigin.mcpMilliseconds),
                                             cancellationRequested: cancellationRequested,
                                             cancellationOutcome: cancellationOutcome,
                                             graceOutcome: graceOutcome,
-                                            escalationReason: escalationReason
+                                            escalationReason: escalationReason,
+                                            handlerPhase: handlerPhase,
+                                            handlerPhaseAgeMilliseconds: handlerPhaseAgeMilliseconds
                                         ))
                                     }
 
@@ -10371,11 +10404,13 @@ actor ServerNetworkManager {
                                                     throw ToolDispatchAdmissionError.windowTerminal
                                                 }
                                             }
-                                            let value = try await EditFlowPerf.measure(
-                                                EditFlowPerf.Stage.MCPToolCall.resolvedProviderDispatch,
-                                                EditFlowPerf.Dimensions(toolName: toolName),
-                                                operation: operation
-                                            )
+                                            let value = try await MCPToolExecutionHandlerPhaseContext.$recorder.withValue(handlerPhaseRecorder) {
+                                                try await EditFlowPerf.measure(
+                                                    EditFlowPerf.Stage.MCPToolCall.resolvedProviderDispatch,
+                                                    EditFlowPerf.Dimensions(toolName: toolName),
+                                                    operation: operation
+                                                )
+                                            }
                                             await emitExecutionTrace(.handlerCompleted, cancellationOutcome: "success")
                                             EditFlowPerf.lifecycleEvent(
                                                 EditFlowPerf.Lifecycle.MCPToolCall.resolvedProviderEnded,
@@ -10401,7 +10436,7 @@ actor ServerNetworkManager {
                                             return try await MCPToolExecutionWatchdog.execute(
                                                 deadline: deadline,
                                                 cancellationGrace: cancellationGrace,
-                                                environment: environment,
+                                                environment: executionWatchdogEnvironment,
                                                 onEvent: { event in
                                                     switch event {
                                                     case .deadlineExpired:
@@ -10543,7 +10578,19 @@ actor ServerNetworkManager {
                                         message: message
                                     )
                                     if shouldForceDisconnect {
-                                        await self.abortConnectionForExecutionWatchdog(connectionID)
+                                        let abortNow = await executionWatchdogEnvironment.now()
+                                        let handlerPhase = handlerPhaseRecorder.snapshot()
+                                        let handlerPhaseAgeMilliseconds = handlerPhase.map {
+                                            max(0, abortNow.mcpMilliseconds - executionTraceOrigin.mcpMilliseconds - $0.elapsedMilliseconds)
+                                        }
+                                        await self.abortConnectionForExecutionWatchdog(
+                                            connectionID,
+                                            toolName: toolName,
+                                            invocationID: invocationID,
+                                            elapsedMilliseconds: max(0, abortNow.mcpMilliseconds - executionTraceOrigin.mcpMilliseconds),
+                                            handlerPhase: handlerPhase,
+                                            handlerPhaseAgeMilliseconds: handlerPhaseAgeMilliseconds
+                                        )
                                         // The transport is already severed. Deliberately skip handlerResult so
                                         // execution-completion tracing cannot be mistaken for response delivery.
                                         return result

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPReadFileAutoSelectionCoordinator.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPReadFileAutoSelectionCoordinator.swift
@@ -13,6 +13,11 @@ final class MCPReadFileAutoSelectionCoordinator {
         case mirroredSelectionAndMetrics = "mirrored"
     }
 
+    enum DrainResult: Equatable {
+        case completed
+        case cancelled
+    }
+
     enum Route: Hashable {
         case bound(connectionID: UUID, runID: UUID?)
         case activeTabCompatibility
@@ -122,6 +127,8 @@ final class MCPReadFileAutoSelectionCoordinator {
             let closingContextCount: Int
             let pendingCanonicalBatchCount: Int
             let pendingMirrorBatchCount: Int
+            let canonicalWaiterCount: Int
+            let mirrorWaiterCount: Int
         }
     #endif
 
@@ -137,14 +144,24 @@ final class MCPReadFileAutoSelectionCoordinator {
         let queueWaitState: EditFlowPerf.IntervalState?
     }
 
+    private enum CanonicalWaitResult {
+        case completed(requiredMirrorTicket: UInt64?)
+        case cancelled
+    }
+
+    private enum SequenceWaitResult {
+        case completed
+        case cancelled
+    }
+
     private struct CanonicalSequenceWaiter {
         let target: UInt64
-        let continuation: CheckedContinuation<UInt64?, Never>
+        let continuation: CheckedContinuation<CanonicalWaitResult, Never>
     }
 
     private struct SequenceWaiter {
         let target: UInt64
-        let continuation: CheckedContinuation<Void, Never>
+        let continuation: CheckedContinuation<SequenceWaitResult, Never>
     }
 
     private struct CanonicalLane {
@@ -174,8 +191,10 @@ final class MCPReadFileAutoSelectionCoordinator {
     private var nextSequence: UInt64 = 0
     private var canonicalLanes: [ContextKey: CanonicalLane] = [:]
     private var canonicalWorkers = Set<ContextKey>()
+    private var canonicalWorkerIDs: [ContextKey: UUID] = [:]
     private var mirrorLanes: [TabMirrorKey: MirrorLane] = [:]
     private var mirrorWorkers = Set<TabMirrorKey>()
+    private var mirrorWorkerIDs: [TabMirrorKey: UUID] = [:]
     private var closingContexts = Set<ContextKey>()
     private var invalidatedContexts = Set<ContextKey>()
     private var retiringContexts = Set<ContextKey>()
@@ -220,6 +239,7 @@ final class MCPReadFileAutoSelectionCoordinator {
         nextSequence &+= 1
         let sequence = nextSequence
         var lane = canonicalLanes[key] ?? CanonicalLane()
+        let previousAcceptedSequence = lane.acceptedSequence
         lane.acceptedSequence = sequence
         if var pending = lane.pending {
             pending.batch.merge(intent)
@@ -251,6 +271,13 @@ final class MCPReadFileAutoSelectionCoordinator {
         }
         canonicalLanes[key] = lane
         scheduleCanonicalWorkerIfNeeded(for: key)
+        emitCanonicalDiagnostic(
+            .acceptedHighWaterAdvanced,
+            for: key,
+            lane: lane,
+            target: sequence,
+            previousAcceptedHighWater: previousAcceptedSequence
+        )
         return true
     }
 
@@ -258,9 +285,15 @@ final class MCPReadFileAutoSelectionCoordinator {
         _ requirement: DrainRequirement,
         for key: ContextKey,
         lifecycleCorrelation: EditFlowPerf.LifecycleCorrelation? = EditFlowPerf.currentLifecycleCorrelation
-    ) async {
+    ) async -> DrainResult {
+        guard !Task.isCancelled else { return .cancelled }
         let target = canonicalLanes[key]?.acceptedSequence ?? 0
-        guard target > 0 else { return }
+        guard target > 0 else { return .completed }
+        emitCanonicalDiagnostic(
+            .drainHighWaterCaptured,
+            for: key,
+            target: target
+        )
         let drainState = EditFlowPerf.begin(
             EditFlowPerf.Stage.ReadFile.AutoSelect.drainWait,
             EditFlowPerf.Dimensions(status: requirement.rawValue)
@@ -270,32 +303,52 @@ final class MCPReadFileAutoSelectionCoordinator {
             correlation: lifecycleCorrelation,
             EditFlowPerf.Dimensions(status: requirement.rawValue)
         )
-        let mirrorTicket = await waitForCanonicalSequence(target, for: key)
+        var outcome = "completed"
+        defer {
+            EditFlowPerf.lifecycleEvent(
+                EditFlowPerf.Lifecycle.ReadFileAutoSelect.drainEnded,
+                correlation: lifecycleCorrelation,
+                EditFlowPerf.Dimensions(status: requirement.rawValue, outcome: outcome)
+            )
+            EditFlowPerf.end(
+                EditFlowPerf.Stage.ReadFile.AutoSelect.drainWait,
+                drainState,
+                EditFlowPerf.Dimensions(status: requirement.rawValue, outcome: outcome)
+            )
+        }
+
+        let canonicalResult = await waitForCanonicalSequence(target, for: key)
+        guard case let .completed(mirrorTicket) = canonicalResult, !Task.isCancelled else {
+            outcome = "cancelled"
+            return .cancelled
+        }
         if requirement == .mirroredSelectionAndMetrics,
            let mirrorTicket
         {
-            await waitForMirrorTicket(mirrorTicket, for: key.mirrorKey)
+            emitMirrorDiagnostic(
+                .drainHighWaterCaptured,
+                for: key.mirrorKey,
+                target: mirrorTicket
+            )
+            guard case .completed = await waitForMirrorTicket(mirrorTicket, for: key.mirrorKey),
+                  !Task.isCancelled
+            else {
+                outcome = "cancelled"
+                return .cancelled
+            }
         }
-        EditFlowPerf.lifecycleEvent(
-            EditFlowPerf.Lifecycle.ReadFileAutoSelect.drainEnded,
-            correlation: lifecycleCorrelation,
-            EditFlowPerf.Dimensions(status: requirement.rawValue)
-        )
-        EditFlowPerf.end(
-            EditFlowPerf.Stage.ReadFile.AutoSelect.drainWait,
-            drainState,
-            EditFlowPerf.Dimensions(status: requirement.rawValue, outcome: "completed")
-        )
+        return .completed
     }
 
     func finish(
         context key: ContextKey,
         lifecycleCorrelation: EditFlowPerf.LifecycleCorrelation? = EditFlowPerf.currentLifecycleCorrelation
-    ) async {
+    ) async -> DrainResult {
         closingContexts.insert(key)
-        await drain(.mirroredSelectionAndMetrics, for: key, lifecycleCorrelation: lifecycleCorrelation)
+        let result = await drain(.mirroredSelectionAndMetrics, for: key, lifecycleCorrelation: lifecycleCorrelation)
         retiringContexts.insert(key)
         cleanupRetiredContextIfSettled(key)
+        return result
     }
 
     func invalidate(context key: ContextKey) {
@@ -320,21 +373,36 @@ final class MCPReadFileAutoSelectionCoordinator {
                 mirrorWorkerCount: mirrorWorkers.count,
                 closingContextCount: closingContexts.union(retiringContexts).count,
                 pendingCanonicalBatchCount: canonicalLanes.values.count(where: { $0.pending != nil }),
-                pendingMirrorBatchCount: mirrorLanes.values.count(where: { $0.pending != nil })
+                pendingMirrorBatchCount: mirrorLanes.values.count(where: { $0.pending != nil }),
+                canonicalWaiterCount: canonicalLanes.values.reduce(0) { $0 + $1.waiters.count },
+                mirrorWaiterCount: mirrorLanes.values.reduce(0) { $0 + $1.waiters.count }
             )
         }
     #endif
 
     private func scheduleCanonicalWorkerIfNeeded(for key: ContextKey) {
         guard canonicalWorkers.insert(key).inserted else { return }
+        let workerID = UUID()
+        canonicalWorkerIDs[key] = workerID
+        emitCanonicalDiagnostic(
+            .workerStarted,
+            for: key,
+            workerID: workerID
+        )
         Task { @MainActor [weak self] in
-            await self?.runCanonicalWorker(for: key)
+            await self?.runCanonicalWorker(for: key, workerID: workerID)
         }
     }
 
-    private func runCanonicalWorker(for key: ContextKey) async {
+    private func runCanonicalWorker(for key: ContextKey, workerID: UUID) async {
         defer {
             canonicalWorkers.remove(key)
+            canonicalWorkerIDs.removeValue(forKey: key)
+            emitCanonicalDiagnostic(
+                .workerStopped,
+                for: key,
+                workerID: workerID
+            )
             cleanupRetiredContextIfSettled(key)
         }
         while var lane = canonicalLanes[key], let queued = lane.pending {
@@ -402,11 +470,20 @@ final class MCPReadFileAutoSelectionCoordinator {
             lane.latestRequiredMirrorTicket = max(lane.latestRequiredMirrorTicket ?? 0, mirrorTicket)
         }
         let satisfied = lane.waiters.filter { $0.value.target <= lane.completedSequence }
-        for (id, waiter) in satisfied {
+        for (id, _) in satisfied {
             lane.waiters.removeValue(forKey: id)
-            waiter.continuation.resume(returning: lane.latestRequiredMirrorTicket)
         }
         canonicalLanes[key] = lane
+        for (id, waiter) in satisfied {
+            emitCanonicalDiagnostic(
+                .waiterResumed,
+                for: key,
+                lane: lane,
+                target: waiter.target,
+                waiterID: id
+            )
+            waiter.continuation.resume(returning: .completed(requiredMirrorTicket: lane.latestRequiredMirrorTicket))
+        }
     }
 
     @discardableResult
@@ -417,6 +494,7 @@ final class MCPReadFileAutoSelectionCoordinator {
         let enqueueState = EditFlowPerf.begin(EditFlowPerf.Stage.ReadFile.AutoSelect.mirrorEnqueue)
         defer { EditFlowPerf.end(EditFlowPerf.Stage.ReadFile.AutoSelect.mirrorEnqueue, enqueueState) }
         var lane = mirrorLanes[key] ?? MirrorLane()
+        let previousAcceptedTicket = lane.acceptedTicket
         lane.acceptedTicket &+= 1
         let ticket = lane.acceptedTicket
         if var pending = lane.pending {
@@ -445,18 +523,40 @@ final class MCPReadFileAutoSelectionCoordinator {
         }
         mirrorLanes[key] = lane
         scheduleMirrorWorkerIfNeeded(for: key)
+        emitMirrorDiagnostic(
+            .acceptedHighWaterAdvanced,
+            for: key,
+            lane: lane,
+            target: ticket,
+            previousAcceptedHighWater: previousAcceptedTicket
+        )
         return ticket
     }
 
     private func scheduleMirrorWorkerIfNeeded(for key: TabMirrorKey) {
         guard mirrorWorkers.insert(key).inserted else { return }
+        let workerID = UUID()
+        mirrorWorkerIDs[key] = workerID
+        emitMirrorDiagnostic(
+            .workerStarted,
+            for: key,
+            workerID: workerID
+        )
         Task { @MainActor [weak self] in
-            await self?.runMirrorWorker(for: key)
+            await self?.runMirrorWorker(for: key, workerID: workerID)
         }
     }
 
-    private func runMirrorWorker(for key: TabMirrorKey) async {
-        defer { mirrorWorkers.remove(key) }
+    private func runMirrorWorker(for key: TabMirrorKey, workerID: UUID) async {
+        defer {
+            mirrorWorkers.remove(key)
+            mirrorWorkerIDs.removeValue(forKey: key)
+            emitMirrorDiagnostic(
+                .workerStopped,
+                for: key,
+                workerID: workerID
+            )
+        }
         while var lane = mirrorLanes[key], let queued = lane.pending {
             lane.pending = nil
             mirrorLanes[key] = lane
@@ -486,36 +586,182 @@ final class MCPReadFileAutoSelectionCoordinator {
     private func completeMirrorBatch(for key: TabMirrorKey, throughTicket: UInt64) {
         guard var lane = mirrorLanes[key] else { return }
         lane.completedTicket = max(lane.completedTicket, throughTicket)
-        resumeSatisfiedWaiters(&lane.waiters, completedSequence: lane.completedTicket)
+        let satisfied = lane.waiters.filter { $0.value.target <= lane.completedTicket }
+        for (id, _) in satisfied {
+            lane.waiters.removeValue(forKey: id)
+        }
         mirrorLanes[key] = lane
+        for (id, waiter) in satisfied {
+            emitMirrorDiagnostic(
+                .waiterResumed,
+                for: key,
+                lane: lane,
+                target: waiter.target,
+                waiterID: id
+            )
+            waiter.continuation.resume(returning: .completed)
+        }
     }
 
-    private func waitForCanonicalSequence(_ target: UInt64, for key: ContextKey) async -> UInt64? {
+    private func waitForCanonicalSequence(_ target: UInt64, for key: ContextKey) async -> CanonicalWaitResult {
+        if Task.isCancelled {
+            return .cancelled
+        }
         if let lane = canonicalLanes[key], lane.completedSequence >= target {
-            return lane.latestRequiredMirrorTicket
+            return .completed(requiredMirrorTicket: lane.latestRequiredMirrorTicket)
         }
-        return await withCheckedContinuation { continuation in
-            var lane = canonicalLanes[key] ?? CanonicalLane()
-            if lane.completedSequence >= target {
-                continuation.resume(returning: lane.latestRequiredMirrorTicket)
-                return
+
+        let waiterID = UUID()
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                var lane = canonicalLanes[key] ?? CanonicalLane()
+                if Task.isCancelled {
+                    continuation.resume(returning: .cancelled)
+                } else if lane.completedSequence >= target {
+                    continuation.resume(returning: .completed(requiredMirrorTicket: lane.latestRequiredMirrorTicket))
+                } else {
+                    lane.waiters[waiterID] = CanonicalSequenceWaiter(target: target, continuation: continuation)
+                    canonicalLanes[key] = lane
+                    emitCanonicalDiagnostic(
+                        .waiterRegistered,
+                        for: key,
+                        lane: lane,
+                        target: target,
+                        waiterID: waiterID
+                    )
+                }
             }
-            lane.waiters[UUID()] = CanonicalSequenceWaiter(target: target, continuation: continuation)
-            canonicalLanes[key] = lane
+        } onCancel: {
+            Task { @MainActor [weak self] in
+                self?.cancelCanonicalWaiter(waiterID, for: key)
+            }
         }
     }
 
-    private func waitForMirrorTicket(_ target: UInt64, for key: TabMirrorKey) async {
-        guard (mirrorLanes[key]?.completedTicket ?? 0) < target else { return }
-        await withCheckedContinuation { continuation in
-            var lane = mirrorLanes[key] ?? MirrorLane()
-            if lane.completedTicket >= target {
-                continuation.resume()
-                return
-            }
-            lane.waiters[UUID()] = SequenceWaiter(target: target, continuation: continuation)
-            mirrorLanes[key] = lane
+    private func waitForMirrorTicket(_ target: UInt64, for key: TabMirrorKey) async -> SequenceWaitResult {
+        if Task.isCancelled {
+            return .cancelled
         }
+        guard (mirrorLanes[key]?.completedTicket ?? 0) < target else { return .completed }
+
+        let waiterID = UUID()
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                var lane = mirrorLanes[key] ?? MirrorLane()
+                if Task.isCancelled {
+                    continuation.resume(returning: .cancelled)
+                } else if lane.completedTicket >= target {
+                    continuation.resume(returning: .completed)
+                } else {
+                    lane.waiters[waiterID] = SequenceWaiter(target: target, continuation: continuation)
+                    mirrorLanes[key] = lane
+                    emitMirrorDiagnostic(
+                        .waiterRegistered,
+                        for: key,
+                        lane: lane,
+                        target: target,
+                        waiterID: waiterID
+                    )
+                }
+            }
+        } onCancel: {
+            Task { @MainActor [weak self] in
+                self?.cancelMirrorWaiter(waiterID, for: key)
+            }
+        }
+    }
+
+    private func cancelCanonicalWaiter(_ waiterID: UUID, for key: ContextKey) {
+        guard var lane = canonicalLanes[key],
+              let waiter = lane.waiters.removeValue(forKey: waiterID)
+        else { return }
+        canonicalLanes[key] = lane
+        emitCanonicalDiagnostic(
+            .waiterResumed,
+            for: key,
+            lane: lane,
+            target: waiter.target,
+            waiterID: waiterID
+        )
+        waiter.continuation.resume(returning: .cancelled)
+        cleanupRetiredContextIfSettled(key)
+    }
+
+    private func cancelMirrorWaiter(_ waiterID: UUID, for key: TabMirrorKey) {
+        guard var lane = mirrorLanes[key],
+              let waiter = lane.waiters.removeValue(forKey: waiterID)
+        else { return }
+        mirrorLanes[key] = lane
+        emitMirrorDiagnostic(
+            .waiterResumed,
+            for: key,
+            lane: lane,
+            target: waiter.target,
+            waiterID: waiterID
+        )
+        waiter.continuation.resume(returning: .cancelled)
+    }
+
+    private func emitCanonicalDiagnostic(
+        _ kind: MCPReadFileAutoSelectionDiagnosticEvent.Kind,
+        for key: ContextKey,
+        lane: CanonicalLane? = nil,
+        target: UInt64? = nil,
+        previousAcceptedHighWater: UInt64? = nil,
+        waiterID: UUID? = nil,
+        workerID: UUID? = nil
+    ) {
+        let lane = lane ?? canonicalLanes[key] ?? CanonicalLane()
+        MCPReadFileAutoSelectionDiagnosticTracer.emit(MCPReadFileAutoSelectionDiagnosticEvent(
+            kind: kind,
+            lane: .canonical,
+            windowID: key.windowID,
+            workspaceID: key.workspaceID,
+            tabID: key.tabID,
+            routeScope: key.route.diagnosticScope,
+            bindingGeneration: key.bindingGeneration,
+            target: target,
+            previousAcceptedHighWater: previousAcceptedHighWater,
+            acceptedHighWater: lane.acceptedSequence,
+            completedHighWater: lane.completedSequence,
+            waiterCount: lane.waiters.count,
+            workerActive: canonicalWorkers.contains(key),
+            pendingWork: lane.pending != nil,
+            waiterID: waiterID,
+            workerID: workerID ?? canonicalWorkerIDs[key],
+            requiredMirrorTicket: lane.latestRequiredMirrorTicket
+        ))
+    }
+
+    private func emitMirrorDiagnostic(
+        _ kind: MCPReadFileAutoSelectionDiagnosticEvent.Kind,
+        for key: TabMirrorKey,
+        lane: MirrorLane? = nil,
+        target: UInt64? = nil,
+        previousAcceptedHighWater: UInt64? = nil,
+        waiterID: UUID? = nil,
+        workerID: UUID? = nil
+    ) {
+        let lane = lane ?? mirrorLanes[key] ?? MirrorLane()
+        MCPReadFileAutoSelectionDiagnosticTracer.emit(MCPReadFileAutoSelectionDiagnosticEvent(
+            kind: kind,
+            lane: .mirror,
+            windowID: key.windowID,
+            workspaceID: key.workspaceID,
+            tabID: key.tabID,
+            routeScope: nil,
+            bindingGeneration: nil,
+            target: target,
+            previousAcceptedHighWater: previousAcceptedHighWater,
+            acceptedHighWater: lane.acceptedTicket,
+            completedHighWater: lane.completedTicket,
+            waiterCount: lane.waiters.count,
+            workerActive: mirrorWorkers.contains(key),
+            pendingWork: lane.pending != nil,
+            waiterID: waiterID,
+            workerID: workerID ?? mirrorWorkerIDs[key],
+            requiredMirrorTicket: nil
+        ))
     }
 
     private func cleanupRetiredContextIfSettled(_ key: ContextKey) {
@@ -528,13 +774,5 @@ final class MCPReadFileAutoSelectionCoordinator {
         closingContexts.remove(key)
         invalidatedContexts.remove(key)
         retiringContexts.remove(key)
-    }
-
-    private func resumeSatisfiedWaiters(_ waiters: inout [UUID: SequenceWaiter], completedSequence: UInt64) {
-        let satisfied = waiters.filter { $0.value.target <= completedSequence }
-        for (id, waiter) in satisfied {
-            waiters.removeValue(forKey: id)
-            waiter.continuation.resume()
-        }
     }
 }

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+TabContext.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+TabContext.swift
@@ -1431,8 +1431,26 @@ extension MCPServerViewModel {
             selection: selection,
             contextKey: contextKey
         ) else { return selection }
+        #if DEBUG
+            if let handler = readFileAutoSelectionPersistenceWillResolveHandlerForTesting {
+                await handler()
+            }
+        #endif
         let persistedContext = await persistenceSafeTabContext(persistenceContext)
         return persistedContext.selection
+    }
+
+    @MainActor
+    private func currentReadFileAutoSelectionTab(
+        for contextKey: MCPReadFileAutoSelectionCoordinator.ContextKey
+    ) -> (manager: WorkspaceManagerViewModel, tab: ComposeTabState)? {
+        guard isReadFileAutoSelectionContextCurrent(contextKey),
+              let manager = workspaceManager,
+              let workspaceID = contextKey.workspaceID,
+              let workspace = manager.workspaces.first(where: { $0.id == workspaceID }),
+              let tab = workspace.composeTabs.first(where: { $0.id == contextKey.tabID })
+        else { return nil }
+        return (manager, tab)
     }
 
     @MainActor
@@ -1440,17 +1458,13 @@ extension MCPServerViewModel {
         selection: StoredSelection,
         contextKey: MCPReadFileAutoSelectionCoordinator.ContextKey
     ) async -> Bool {
-        guard isReadFileAutoSelectionContextCurrent(contextKey),
-              let manager = workspaceManager,
-              let workspaceID = contextKey.workspaceID,
-              let workspaceIndex = manager.workspaces.firstIndex(where: { $0.id == workspaceID }),
-              let tabIndex = manager.workspaces[workspaceIndex].composeTabs.firstIndex(where: { $0.id == contextKey.tabID })
-        else { return false }
+        guard isReadFileAutoSelectionContextCurrent(contextKey) else { return false }
 
         let persistedSelection = await persistedSelectionForReadFileAutoSelection(
             selection: selection,
             contextKey: contextKey
         )
+        guard let target = currentReadFileAutoSelectionTab(for: contextKey) else { return false }
 
         if case let .bound(connectionID, _) = contextKey.route,
            var latest = tabContextByConnectionID[connectionID]
@@ -1459,8 +1473,7 @@ extension MCPServerViewModel {
             tabContextByConnectionID[connectionID] = latest
         }
 
-        let currentTab = manager.workspaces[workspaceIndex].composeTabs[tabIndex]
-        guard currentTab.selection != persistedSelection else { return false }
+        guard target.tab.selection != persistedSelection else { return false }
         let persistenceResult = await EditFlowPerf.measure(EditFlowPerf.Stage.ReadFile.AutoSelect.canonicalStoredCommit) {
             await Self.persistMCPSelectionThroughCoordinator(
                 persistedSelection,
@@ -1468,12 +1481,13 @@ extension MCPServerViewModel {
                 selectionCoordinator: selectionCoordinator
             )
         }
+        guard let refreshedTarget = currentReadFileAutoSelectionTab(for: contextKey) else { return false }
         if persistenceResult == .unavailable {
-            var updatedTab = currentTab
+            var updatedTab = refreshedTarget.tab
             updatedTab.selection = persistedSelection
             updatedTab.lastModified = Date()
             await EditFlowPerf.measure(EditFlowPerf.Stage.ReadFile.AutoSelect.canonicalStoredCommit) {
-                manager.updateComposeTabStoredOnly(updatedTab)
+                refreshedTarget.manager.updateComposeTabStoredOnly(updatedTab)
             }
         }
         return true
@@ -2324,12 +2338,18 @@ extension MCPServerViewModel {
     }
 
     @MainActor
+    @discardableResult
     func commitAndClearTabContext(
         connectionID: UUID,
         expectedRunID: UUID? = nil,
-        isStillCurrent: @MainActor () -> Bool = { true }
-    ) async {
-        guard var context = tabContextByConnectionID[connectionID] else { return }
+        isStillCurrent: @MainActor () -> Bool = { true },
+        progressReporter: ContextBuilderMCPProgressReporter? = nil,
+        deferRunMappingCleanupUntilCaller: Bool = false
+    ) async -> Bool {
+        // Capture the authoritative snapshot on the main actor before the first suspension.
+        // Connection cleanup may remove the dictionary entry while draining auto-selection,
+        // but it cannot invalidate this locally owned snapshot.
+        guard var context = tabContextByConnectionID[connectionID] else { return false }
 
         // Decide whether we will commit stored UI state for this context.
         // Mismatch or logical cancellation => clear binding only.
@@ -2341,7 +2361,11 @@ extension MCPServerViewModel {
 
         if shouldCommit {
             let key = readFileAutoSelectionContextKey(connectionID: connectionID, context: context)
-            await readFileAutoSelectionCoordinator.finish(context: key)
+            await progressReporter?(.readFileAutoSelectionFinish)
+            let finishResult = await readFileAutoSelectionCoordinator.finish(context: key)
+            if finishResult == .cancelled {
+                shouldCommit = false
+            }
             if let latest = tabContextByConnectionID[connectionID], latest.runID == context.runID {
                 context = latest
             }
@@ -2352,24 +2376,28 @@ extension MCPServerViewModel {
             invalidateReadFileAutoSelection(connectionID: connectionID, context: context)
         }
 
-        // Clear binding regardless of mismatch so future runs can rebind
+        // Clear the mutable tab snapshot regardless of mismatch so future calls cannot
+        // mutate state being committed. Successful Context Builder completion may retain
+        // the connection/run routing maps until its independently-owned transport teardown joins.
         endMirroringForConnection(connectionID)
         tabContextByConnectionID.removeValue(forKey: connectionID)
-        windowIDByConnection.removeValue(forKey: connectionID)
-
-        if let runID = context.runID {
-            connectionIDByRunID.removeValue(forKey: runID)
+        if !deferRunMappingCleanupUntilCaller {
+            windowIDByConnection.removeValue(forKey: connectionID)
+            if let runID = context.runID {
+                connectionIDByRunID.removeValue(forKey: runID)
+            }
+            connectionIDToRunID.removeValue(forKey: connectionID)
         }
-        connectionIDToRunID.removeValue(forKey: connectionID)
 
-        guard shouldCommit, isStillCurrent(), !Task.isCancelled else { return }
+        guard shouldCommit, isStillCurrent(), !Task.isCancelled else { return false }
 
         tabContextLog("commitAndClearTabContext committing tab=\(context.tabID) connectionID=\(connectionID) runID=\(context.runID?.uuidString ?? "nil")")
 
         // IMPORTANT: Await the commit to ensure tab state is written before caller reads it.
         // This fixes a race condition where context_builder would read stale tab state.
-        await commitTabContext(context, isStillCurrent: isStillCurrent)
-        guard isStillCurrent(), !Task.isCancelled else { return }
+        await progressReporter?(.tabContextCommit)
+        let didCommit = await commitTabContext(context, isStillCurrent: isStillCurrent)
+        guard didCommit, isStillCurrent(), !Task.isCancelled else { return false }
 
         var discoveredTabName: String?
         if let manager = workspaceManager,
@@ -2387,9 +2415,10 @@ extension MCPServerViewModel {
         }
 
         // End-of-run flush: persist this run's final state to disk (coalesced by DiskWriter)
-        if let manager = workspaceManager {
-            await manager.pollAndSaveStateAsync(source: .mcpTabContextEndOfRun)
-        }
+        guard let manager = workspaceManager else { return false }
+        await progressReporter?(.statePersistence)
+        await manager.pollAndSaveStateAsync(source: .mcpTabContextEndOfRun)
+        return isStillCurrent() && !Task.isCancelled
     }
 
     @MainActor
@@ -2400,10 +2429,10 @@ extension MCPServerViewModel {
         runID: UUID? = nil,
         removeQueuedPendingContext: Bool = true
     ) {
-        if let connectionID,
-           let context = tabContextByConnectionID[connectionID]
-        {
-            if runID == nil || context.runID == runID {
+        if let connectionID {
+            if let context = tabContextByConnectionID[connectionID],
+               runID == nil || context.runID == runID
+            {
                 invalidateReadFileAutoSelection(connectionID: connectionID, context: context)
                 endMirroringForConnection(connectionID)
                 tabContextByConnectionID.removeValue(forKey: connectionID)
@@ -2420,6 +2449,24 @@ extension MCPServerViewModel {
                 }
 
                 tabContextLog("removeTabContext removed bound context connectionID=\(connectionID) runID=\(runID?.uuidString ?? "nil") tab=\(context.tabID)")
+            } else if let runID {
+                // A successful Context Builder commit may already have consumed the mutable
+                // tab snapshot while deliberately retaining routing maps for a live child
+                // connection. The caller owns removing those maps after termination joins.
+                var removedDeferredMapping = false
+                if connectionIDByRunID[runID] == connectionID {
+                    connectionIDByRunID.removeValue(forKey: runID)
+                    pendingPolicyRunIDMappingTokenIDByRunID.removeValue(forKey: runID)
+                    removedDeferredMapping = true
+                }
+                if connectionIDToRunID[connectionID] == runID {
+                    connectionIDToRunID.removeValue(forKey: connectionID)
+                    removedDeferredMapping = true
+                }
+                if removedDeferredMapping {
+                    windowIDByConnection.removeValue(forKey: connectionID)
+                    tabContextLog("removeTabContext removed deferred mapping connectionID=\(connectionID) runID=\(runID.uuidString)")
+                }
             }
         }
 
@@ -2462,11 +2509,11 @@ extension MCPServerViewModel {
     private func commitTabContext(
         _ context: TabScopedContext,
         isStillCurrent: @MainActor () -> Bool = { true }
-    ) async {
-        guard isStillCurrent(), !Task.isCancelled else { return }
+    ) async -> Bool {
+        guard isStillCurrent(), !Task.isCancelled else { return false }
         guard let manager = workspaceManager else {
             tabContextLog("[warning] commitTabContext missing workspace manager for windowID \(context.windowID); skipping commit.")
-            return
+            return false
         }
         tabContextLog("commitTabContext using workspaceManager \(ObjectIdentifier(manager)) for context.windowID=\(context.windowID) self.windowID=\(windowID)")
         let targetWorkspaceID = context.workspaceID ?? manager.activeWorkspace?.id
@@ -2475,7 +2522,7 @@ extension MCPServerViewModel {
               let tabIndex = manager.workspaces[workspaceIndex].composeTabs.firstIndex(where: { $0.id == context.tabID })
         else {
             tabContextLog("[warning] commitTabContext skipping commit for tab \(context.tabID) – workspace unavailable.")
-            return
+            return false
         }
 
         var updatedTab = manager.workspaces[workspaceIndex].composeTabs[tabIndex]
@@ -2495,15 +2542,16 @@ extension MCPServerViewModel {
         }
 
         // 1) Persist to backing store without publishing UI snapshots (prevents tool echo)
-        guard isStillCurrent(), !Task.isCancelled else { return }
+        guard isStillCurrent(), !Task.isCancelled else { return false }
         manager.updateComposeTabStoredOnly(updatedTab)
         tabContextLog("commitTabContext stored selection/prompt tab=\(context.tabID) window=\(context.windowID) runID=\(context.runID?.uuidString ?? "nil") workspaceID=\(workspaceID)")
 
         // 2) Apply to live UI ONLY if this tab is the active tab and the run still owns commit.
-        guard isActive, isStillCurrent(), !Task.isCancelled else {
+        guard isActive else {
             tabContextLog("commitTabContext skipping live UI apply (tab not active) tab=\(updatedTab.id)")
-            return
+            return true
         }
+        guard isStillCurrent(), !Task.isCancelled else { return false }
 
         let applyTab = updatedTab
 
@@ -2513,5 +2561,6 @@ extension MCPServerViewModel {
         await manager.applyComposeTabState(applyTab)
         manager.endApplyingTabContext(forTabID: context.tabID)
         tabContextLog("commitTabContext UI applied: tab=\(applyTab.id)")
+        return isStillCurrent() && !Task.isCancelled
     }
 }

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+TabContext.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+TabContext.swift
@@ -1316,31 +1316,34 @@ extension MCPServerViewModel {
     static func persistMCPSelectionThroughCoordinator(
         _ selection: StoredSelection,
         for tabID: UUID,
-        selectionCoordinator: WorkspaceSelectionCoordinator?
+        selectionCoordinator: WorkspaceSelectionCoordinator?,
+        mirrorToUIIfActive: Bool = true
     ) async -> MCPSelectionCoordinatorPersistenceResult {
         guard let selectionCoordinator,
               let current = selectionCoordinator.selectionSnapshot(for: tabID, flushPendingUIIfActive: false)
         else { return .unavailable }
-        guard current.selection != selection else { return .unchanged }
+        let outcome: MCPSelectionCoordinatorPersistenceResult = current.selection == selection ? .unchanged : .persisted
         _ = await selectionCoordinator.persistSelection(
             selection,
             for: tabID,
             source: .mcpTabContext,
-            mirrorToUIIfActive: true
+            mirrorToUIIfActive: mirrorToUIIfActive
         )
-        return .persisted
+        return outcome
     }
 
     @MainActor
     static func persistMCPSelectionAndVerifyThroughCoordinator(
         _ selection: StoredSelection,
         for tabID: UUID,
-        selectionCoordinator: WorkspaceSelectionCoordinator?
+        selectionCoordinator: WorkspaceSelectionCoordinator?,
+        mirrorToUIIfActive: Bool = true
     ) async -> MCPSelectionPersistenceVerification {
         let outcome = await persistMCPSelectionThroughCoordinator(
             selection,
             for: tabID,
-            selectionCoordinator: selectionCoordinator
+            selectionCoordinator: selectionCoordinator,
+            mirrorToUIIfActive: mirrorToUIIfActive
         )
         let canonicalSelection = selectionCoordinator?
             .selectionSnapshot(for: tabID, flushPendingUIIfActive: false)?
@@ -1478,7 +1481,8 @@ extension MCPServerViewModel {
             await Self.persistMCPSelectionThroughCoordinator(
                 persistedSelection,
                 for: contextKey.tabID,
-                selectionCoordinator: selectionCoordinator
+                selectionCoordinator: selectionCoordinator,
+                mirrorToUIIfActive: false
             )
         }
         guard let refreshedTarget = currentReadFileAutoSelectionTab(for: contextKey) else { return false }

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel.swift
@@ -545,13 +545,19 @@ final class MCPServerViewModel: ObservableObject {
         executeAskOracle: { [weak self] args in
             guard let self else { throw MCPError.internalError("Window deallocated while executing ask_oracle") }
             let metadata = await captureRequestMetadata()
-            await drainReadFileAutoSelection(metadata: metadata, requirement: .mirroredSelectionAndMetrics)
+            guard await drainReadFileAutoSelection(
+                metadata: metadata,
+                requirement: .mirroredSelectionAndMetrics
+            ) == .completed else { throw CancellationError() }
             return try await oracleToolService.executeAskOracle(args: args)
         },
         executeOracleSend: { [weak self] args in
             guard let self else { throw MCPError.internalError("Window deallocated while executing oracle_send") }
             let metadata = await captureRequestMetadata()
-            await drainReadFileAutoSelection(metadata: metadata, requirement: .mirroredSelectionAndMetrics)
+            guard await drainReadFileAutoSelection(
+                metadata: metadata,
+                requirement: .mirroredSelectionAndMetrics
+            ) == .completed else { throw CancellationError() }
             return try await oracleToolService.executeOracleSend(args: args)
         },
         executeOracleChatLog: { [weak self] args in
@@ -643,14 +649,16 @@ final class MCPServerViewModel: ObservableObject {
             guard let self else { throw MCPError.internalError("Window deallocated while writing Oracle export") }
             return try await writeGeneratedOracleExportFile(path: path, content: content, destination: destination)
         },
-        runMCPPlanOrQuestion: { [weak self] contextBuilderVM, tabID, mode, prompt, selection in
+        runMCPPlanOrQuestion: { [weak self] contextBuilderVM, tabID, mode, prompt, selection, progressReporter, activityReporter in
             guard let self else { throw MCPError.internalError("Window deallocated while generating context_builder response") }
             return try await contextBuilderVM.runMCPPlanOrQuestion(
                 for: tabID,
                 oracleViewModel: oracleVM,
                 mode: mode,
                 prompt: prompt,
-                selection: selection
+                selection: selection,
+                progressReporter: progressReporter,
+                activityReporter: activityReporter
             )
         },
         windowID: windowID,
@@ -805,8 +813,8 @@ final class MCPServerViewModel: ObservableObject {
             await enqueueReadFileAutoSelection(reply: reply, requestedPath: requestedPath, metadata: metadata)
         },
         drainReadFileAutoSelection: { [weak self] metadata, requirement in
-            guard let self else { return }
-            await drainReadFileAutoSelection(metadata: metadata, requirement: requirement)
+            guard let self else { return .cancelled }
+            return await drainReadFileAutoSelection(metadata: metadata, requirement: requirement)
         },
         enqueueFileSearchAutoSelection: { [weak self] mode, contextLines, reply, metadata in
             guard let self else { return }
@@ -910,6 +918,10 @@ final class MCPServerViewModel: ObservableObject {
     var tabContextByConnectionID: [UUID: TabScopedContext] = [:]
     @MainActor
     var nextReadFileAutoSelectionBindingGeneration: UInt64 = 0
+    #if DEBUG
+        @MainActor
+        var readFileAutoSelectionPersistenceWillResolveHandlerForTesting: (() async -> Void)?
+    #endif
     @MainActor
     var pendingRunScopedTabContexts = PendingRunScopedContextStore()
     @MainActor
@@ -2768,8 +2780,21 @@ final class MCPServerViewModel: ObservableObject {
         }
     }
 
+    #if DEBUG
+        private var stageProgressSinkForTesting: MCPWindowToolDependencies.SendStageProgress?
+
+        func installStageProgressSinkForTesting(
+            _ sink: MCPWindowToolDependencies.SendStageProgress?
+        ) {
+            stageProgressSinkForTesting = sink
+        }
+    #endif
+
     /// Sends a stage progress notification for the current connection.
     private func sendStageProgress(connectionID: UUID?, tool: String, stage: String, message: String) async {
+        #if DEBUG
+            await stageProgressSinkForTesting?(connectionID, tool, stage, message)
+        #endif
         guard let connectionID else { return }
         await ServerNetworkManager.shared.sendProgress(
             for: connectionID,
@@ -2994,20 +3019,25 @@ final class MCPServerViewModel: ObservableObject {
     func drainReadFileAutoSelection(
         metadata: RequestMetadata,
         requirement: MCPReadFileAutoSelectionCoordinator.DrainRequirement
-    ) async {
+    ) async -> MCPReadFileAutoSelectionCoordinator.DrainResult {
         guard let resolvedContext = try? resolveTabContextSnapshot(
             from: metadata,
             toolName: "drainReadFileAutoSelection",
             policy: .allowLegacyImplicitRouting
-        ) else { return }
+        ) else { return Task.isCancelled ? .cancelled : .completed }
         let key = readFileAutoSelectionContextKey(resolvedContext: resolvedContext, metadata: metadata)
-        await readFileAutoSelectionCoordinator.drain(requirement, for: key)
+        return await readFileAutoSelectionCoordinator.drain(requirement, for: key)
     }
 
     #if DEBUG
         @MainActor
         func setReadFileAutoSelectionCanonicalApplyGateForTesting(_ gate: (() async -> Void)?) {
             readFileAutoSelectionCoordinator.setCanonicalApplyGateForTesting(gate)
+        }
+
+        @MainActor
+        func setReadFileAutoSelectionPersistenceGateForTesting(_ gate: (() async -> Void)?) {
+            readFileAutoSelectionPersistenceWillResolveHandlerForTesting = gate
         }
 
         @MainActor
@@ -3813,8 +3843,11 @@ final class MCPServerViewModel: ObservableObject {
         newPath: String? = nil,
         ifExists: String? = nil
     ) async throws -> String? {
+        try Task.checkCancellation()
+        await MCPToolExecutionHandlerPhaseContext.report(.fileActionsPreMutationChecks)
         // Enforce workspace presence in multi-window mode
         try await requireWorkspaceForTool(MCPWindowToolName.fileActions)
+        try Task.checkCancellation()
         let metadata = await captureRequestMetadata()
         var resolvedContext = try resolveTabContextSnapshot(
             from: metadata,
@@ -3822,10 +3855,14 @@ final class MCPServerViewModel: ObservableObject {
             policy: .allowLegacyImplicitRouting
         )
         let lookupContext = await resolveFileToolLookupContext(from: metadata)
+        try Task.checkCancellation()
         let effectivePath = lookupContext.translateInputPath(path)
         let effectiveNewPath = newPath.map { lookupContext.translateInputPath($0) }
         let shouldSelectCreatedFileInActiveUI = resolvedContext.usesActiveTabCompatibility
         let store = promptVM.workspaceFileContextStore
+        await MCPToolExecutionHandlerPhaseContext.report(.fileActionsPreMutationChecks, transition: .completed)
+        try Task.checkCancellation()
+        await MCPToolExecutionHandlerPhaseContext.report(.fileActionsCatalogEligibility)
         _ = await store.awaitAppliedIngressForExplicitRequest(
             userPath: effectivePath,
             fallbackScope: lookupContext.rootScope
@@ -3836,8 +3873,11 @@ final class MCPServerViewModel: ObservableObject {
                 fallbackScope: lookupContext.rootScope
             )
         }
+        await MCPToolExecutionHandlerPhaseContext.report(.fileActionsCatalogEligibility, transition: .completed)
+        try Task.checkCancellation()
 
         do {
+            await MCPToolExecutionHandlerPhaseContext.report(.fileActionsMutationIO)
             switch action.lowercased() {
             case "create":
                 guard let content else {
@@ -3869,17 +3909,27 @@ final class MCPServerViewModel: ObservableObject {
             default:
                 throw MCPError.invalidParams("invalid action: \(action). Must be 'create', 'delete', or 'move'")
             }
+            try Task.checkCancellation()
+            await MCPToolExecutionHandlerPhaseContext.report(.fileActionsMutationIO, transition: .completed)
+        } catch is CancellationError {
+            await MCPToolExecutionHandlerPhaseContext.report(.fileActionsMutationIO, transition: .completed)
+            throw CancellationError()
         } catch let fmErr as FileManagerError {
+            await MCPToolExecutionHandlerPhaseContext.report(.fileActionsMutationIO, transition: .completed)
             // Convert internal file-manager errors to friendly, contextual MCP errors
             throw await mapFileManagerErrorToMCP(fmErr, action: action, path: path)
         } catch let mcpErr as MCPError {
+            await MCPToolExecutionHandlerPhaseContext.report(.fileActionsMutationIO, transition: .completed)
             throw mcpErr
         } catch {
+            await MCPToolExecutionHandlerPhaseContext.report(.fileActionsMutationIO, transition: .completed)
             // Generic fallback
             throw MCPError.invalidParams("File action '\(action)' failed: \(error.localizedDescription)")
         }
 
         // Ensure resulting synthetic publications are canonical before returning.
+        try Task.checkCancellation()
+        await MCPToolExecutionHandlerPhaseContext.report(.fileActionsPostMutationCatalog)
         _ = await store.awaitAppliedIngressForExplicitRequest(
             userPath: effectivePath,
             fallbackScope: lookupContext.rootScope
@@ -3890,7 +3940,10 @@ final class MCPServerViewModel: ObservableObject {
                 fallbackScope: lookupContext.rootScope
             )
         }
+        await MCPToolExecutionHandlerPhaseContext.report(.fileActionsPostMutationCatalog, transition: .completed)
+        try Task.checkCancellation()
         if action.lowercased() == "create", !resolvedContext.usesActiveTabCompatibility {
+            await MCPToolExecutionHandlerPhaseContext.report(.fileActionsPostMutationSelection)
             let addResult = await addStoredSelectionPaths(
                 existing: resolvedContext.snapshot.selection,
                 paths: [effectivePath],
@@ -3898,9 +3951,14 @@ final class MCPServerViewModel: ObservableObject {
                 mode: "full",
                 lookupRootScope: lookupContext.rootScope
             )
-            guard addResult.selection != resolvedContext.snapshot.selection else { return nil }
+            try Task.checkCancellation()
+            guard addResult.selection != resolvedContext.snapshot.selection else {
+                await MCPToolExecutionHandlerPhaseContext.report(.fileActionsPostMutationSelection, transition: .completed)
+                return nil
+            }
             resolvedContext.snapshot.selection = addResult.selection
             let verification = await persistResolvedTabContextSnapshot(resolvedContext, metadata: metadata, mutated: true)
+            try Task.checkCancellation()
             do {
                 _ = try MCPSelectionToolProvider.requireCanonicalSelection(
                     verification,
@@ -3909,9 +3967,14 @@ final class MCPServerViewModel: ObservableObject {
                     operation: "file_actions create selection update",
                     recovery: "Retry manage_selection for the same context_id."
                 )
+            } catch is CancellationError {
+                await MCPToolExecutionHandlerPhaseContext.report(.fileActionsPostMutationSelection, transition: .completed)
+                throw CancellationError()
             } catch {
+                await MCPToolExecutionHandlerPhaseContext.report(.fileActionsPostMutationSelection, transition: .completed)
                 return "The file was created, but its selection was not confirmed. \(error)"
             }
+            await MCPToolExecutionHandlerPhaseContext.report(.fileActionsPostMutationSelection, transition: .completed)
         }
         return nil
     }
@@ -3935,6 +3998,8 @@ final class MCPServerViewModel: ObservableObject {
                 selectCreatedFiles: addToSelection
             )
             try await host.writeText(path: path, content: content, overwrite: overwrite)
+        } catch is CancellationError {
+            throw CancellationError()
         } catch let fmErr as FileManagerError {
             throw await mapFileManagerErrorToMCP(fmErr, action: "create", path: path)
         } catch let mcpErr as MCPError {

--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPContextBuilderProgressTimeline.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPContextBuilderProgressTimeline.swift
@@ -1,0 +1,361 @@
+import Foundation
+
+enum ContextBuilderMCPProgressPhase: String, CaseIterable {
+    case readFileAutoSelectionFinish = "read_file_auto_selection_finish"
+    case tabContextCommit = "tab_context_commit"
+    case statePersistence = "state_persistence"
+    case childConnectionTermination = "child_connection_termination"
+    case childConnectionTerminationJoin = "child_connection_termination_join"
+    case runFinalization = "run_finalization"
+    case modelResolution = "model_resolution"
+    case payloadPackaging = "payload_packaging"
+    case sessionCreationAndPersist = "session_creation_and_persist"
+    case messageSend = "message_send"
+    case activeQueryAcquisition = "active_query_acquisition"
+    case streaming
+    case messageFinalization = "message_finalization"
+
+    var stage: String {
+        switch self {
+        case .childConnectionTermination,
+             .readFileAutoSelectionFinish,
+             .tabContextCommit,
+             .statePersistence,
+             .childConnectionTerminationJoin,
+             .runFinalization:
+            "discovering"
+        case .modelResolution,
+             .payloadPackaging,
+             .sessionCreationAndPersist,
+             .messageSend,
+             .activeQueryAcquisition,
+             .streaming,
+             .messageFinalization:
+            "generating"
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .childConnectionTermination:
+            "child MCP connection termination request"
+        case .readFileAutoSelectionFinish:
+            "read-file auto-selection finish"
+        case .tabContextCommit:
+            "tab-context commit"
+        case .statePersistence:
+            "workspace state persistence"
+        case .childConnectionTerminationJoin:
+            "child MCP connection termination join"
+        case .runFinalization:
+            "Context Builder run finalization"
+        case .modelResolution:
+            "follow-up model resolution"
+        case .payloadPackaging:
+            "follow-up payload packaging"
+        case .sessionCreationAndPersist:
+            "Oracle session creation/persist"
+        case .messageSend:
+            "Oracle message send"
+        case .activeQueryAcquisition:
+            "active-query acquisition"
+        case .streaming:
+            "Oracle response streaming"
+        case .messageFinalization:
+            "Oracle message finalization"
+        }
+    }
+
+    /// Diagnostic-only threshold. Exceeding this bound reports progress but does not fail the run.
+    var softBoundSeconds: TimeInterval? {
+        switch self {
+        case .childConnectionTermination:
+            1
+        case .readFileAutoSelectionFinish:
+            30
+        case .tabContextCommit:
+            15
+        case .statePersistence:
+            30
+        case .childConnectionTerminationJoin:
+            10
+        case .runFinalization:
+            5
+        case .modelResolution:
+            2
+        case .payloadPackaging:
+            5
+        case .sessionCreationAndPersist:
+            30
+        case .messageSend:
+            10
+        case .activeQueryAcquisition:
+            5
+        case .streaming, .messageFinalization:
+            nil
+        }
+    }
+}
+
+typealias ContextBuilderMCPProgressReporter = @MainActor @Sendable (
+    _ phase: ContextBuilderMCPProgressPhase
+) async -> Void
+
+typealias ContextBuilderMCPActivityReporter = @MainActor @Sendable (
+    _ phase: ContextBuilderMCPProgressPhase,
+    _ message: String
+) async -> Void
+
+struct ContextBuilderMCPProgressEvent: Equatable {
+    enum Kind: String {
+        case started
+        case completed
+        case heartbeat
+        case activity
+        case softBoundExceeded = "soft_bound_exceeded"
+    }
+
+    let kind: Kind
+    let phase: ContextBuilderMCPProgressPhase
+    let stage: String
+    let message: String
+    let timestamp: TimeInterval
+    let phaseElapsed: TimeInterval
+    let totalElapsed: TimeInterval
+}
+
+actor ContextBuilderMCPProgressTimeline {
+    typealias Clock = @Sendable () -> TimeInterval
+    typealias Sleep = @Sendable (_ seconds: TimeInterval) async throws -> Void
+    typealias Sink = @Sendable (ContextBuilderMCPProgressEvent) async -> Void
+
+    private let clock: Clock
+    private let sleep: Sleep
+    private let sink: Sink
+    private let startedAt: TimeInterval
+    private var currentPhase: ContextBuilderMCPProgressPhase?
+    private var currentPhaseStartedAt: TimeInterval?
+    private var phaseGeneration = 0
+    private var didReportSoftBound = false
+    private var softBoundTask: Task<Void, Never>?
+    private var pendingEvents: [ContextBuilderMCPProgressEvent] = []
+    private var eventDeliveryTask: Task<Void, Never>?
+
+    init(
+        clock: @escaping Clock = { ProcessInfo.processInfo.systemUptime },
+        sleep: @escaping Sleep = { seconds in
+            try await Task.sleep(for: .seconds(seconds))
+        },
+        sink: @escaping Sink
+    ) {
+        self.clock = clock
+        self.sleep = sleep
+        self.sink = sink
+        startedAt = clock()
+    }
+
+    func transition(to phase: ContextBuilderMCPProgressPhase) async {
+        let now = clock()
+        let completion = completionEvent(at: now)
+
+        // Commit actor state and enqueue the old completion/new start as one ordered batch
+        // before the sink can suspend. Reentrant transitions append behind this batch, so a
+        // phase completion can never overtake or suppress its corresponding start.
+        cancelSoftBoundTask()
+        phaseGeneration += 1
+        let generation = phaseGeneration
+        currentPhase = phase
+        currentPhaseStartedAt = now
+        didReportSoftBound = false
+        let started = event(
+            kind: .started,
+            phase: phase,
+            at: now,
+            phaseElapsed: 0,
+            message: "\(phase.displayName) started (total \(Self.format(now - startedAt)))"
+        )
+        scheduleSoftBoundCheck(for: phase, generation: generation)
+
+        var events: [ContextBuilderMCPProgressEvent] = []
+        if let completion {
+            events.append(completion)
+        }
+        events.append(started)
+        if let deliveryTask = enqueueForDelivery(events) {
+            await deliveryTask.value
+        }
+    }
+
+    func finishCurrentPhase() async {
+        let now = clock()
+        let completion = completionEvent(at: now)
+        cancelSoftBoundTask()
+        phaseGeneration += 1
+        currentPhase = nil
+        currentPhaseStartedAt = nil
+        didReportSoftBound = false
+        if let completion,
+           let deliveryTask = enqueueForDelivery([completion])
+        {
+            await deliveryTask.value
+        }
+    }
+
+    func reportActivity(
+        phase: ContextBuilderMCPProgressPhase,
+        message: String
+    ) async {
+        let now = clock()
+        let phaseStartedAt = currentPhase == phase ? currentPhaseStartedAt : nil
+        let activity = event(
+            kind: .activity,
+            phase: phase,
+            at: now,
+            phaseElapsed: phaseStartedAt.map { max(0, now - $0) } ?? 0,
+            message: "\(message) (total \(Self.format(now - startedAt)))"
+        )
+        if let deliveryTask = enqueueForDelivery([activity]) {
+            await deliveryTask.value
+        }
+    }
+
+    func flush() async {
+        while let eventDeliveryTask {
+            await eventDeliveryTask.value
+        }
+    }
+
+    func heartbeat(
+        fallbackStage: String,
+        fallbackMessage: String
+    ) -> (stage: String, message: String) {
+        guard let phase = currentPhase,
+              let phaseStartedAt = currentPhaseStartedAt
+        else {
+            return (fallbackStage, fallbackMessage)
+        }
+
+        let now = clock()
+        return (
+            phase.stage,
+            "Still in \(phase.displayName) (phase \(Self.format(now - phaseStartedAt)), total \(Self.format(now - startedAt)))"
+        )
+    }
+
+    /// Exposed for deterministic injected-clock tests; production also schedules this automatically.
+    func checkSoftBound() async {
+        guard let phase = currentPhase,
+              let phaseStartedAt = currentPhaseStartedAt,
+              let bound = phase.softBoundSeconds,
+              !didReportSoftBound
+        else {
+            return
+        }
+        let now = clock()
+        let phaseElapsed = max(0, now - phaseStartedAt)
+        guard phaseElapsed >= bound else { return }
+
+        didReportSoftBound = true
+        let exceeded = event(
+            kind: .softBoundExceeded,
+            phase: phase,
+            at: now,
+            phaseElapsed: phaseElapsed,
+            message: "\(phase.displayName) exceeded soft bound \(Self.format(bound)); still running at \(Self.format(phaseElapsed)) (total \(Self.format(now - startedAt)))"
+        )
+        if let deliveryTask = enqueueForDelivery([exceeded]) {
+            await deliveryTask.value
+        }
+    }
+
+    private func scheduleSoftBoundCheck(
+        for phase: ContextBuilderMCPProgressPhase,
+        generation: Int
+    ) {
+        guard let bound = phase.softBoundSeconds else { return }
+        let sleep = sleep
+        softBoundTask = Task { [weak self] in
+            do {
+                try await sleep(bound)
+            } catch {
+                return
+            }
+            guard !Task.isCancelled, let self else { return }
+            await reportSoftBoundIfCurrent(phase: phase, generation: generation)
+        }
+    }
+
+    private func reportSoftBoundIfCurrent(
+        phase: ContextBuilderMCPProgressPhase,
+        generation: Int
+    ) async {
+        guard phaseGeneration == generation, currentPhase == phase else { return }
+        await checkSoftBound()
+    }
+
+    private func cancelSoftBoundTask() {
+        softBoundTask?.cancel()
+        softBoundTask = nil
+    }
+
+    private func enqueueForDelivery(
+        _ events: [ContextBuilderMCPProgressEvent]
+    ) -> Task<Void, Never>? {
+        guard !events.isEmpty else { return nil }
+        pendingEvents.append(contentsOf: events)
+        guard eventDeliveryTask == nil else { return nil }
+
+        let task = Task { [weak self] in
+            guard let self else { return }
+            await drainPendingEvents()
+        }
+        eventDeliveryTask = task
+        return task
+    }
+
+    private func drainPendingEvents() async {
+        while !pendingEvents.isEmpty {
+            let event = pendingEvents.removeFirst()
+            await sink(event)
+        }
+        eventDeliveryTask = nil
+    }
+
+    private func completionEvent(at now: TimeInterval) -> ContextBuilderMCPProgressEvent? {
+        guard let phase = currentPhase,
+              let phaseStartedAt = currentPhaseStartedAt
+        else {
+            return nil
+        }
+        let phaseElapsed = max(0, now - phaseStartedAt)
+        return event(
+            kind: .completed,
+            phase: phase,
+            at: now,
+            phaseElapsed: phaseElapsed,
+            message: "\(phase.displayName) completed in \(Self.format(phaseElapsed)) (total \(Self.format(now - startedAt)))"
+        )
+    }
+
+    private func event(
+        kind: ContextBuilderMCPProgressEvent.Kind,
+        phase: ContextBuilderMCPProgressPhase,
+        at timestamp: TimeInterval,
+        phaseElapsed: TimeInterval,
+        message: String
+    ) -> ContextBuilderMCPProgressEvent {
+        ContextBuilderMCPProgressEvent(
+            kind: kind,
+            phase: phase,
+            stage: phase.stage,
+            message: message,
+            timestamp: timestamp,
+            phaseElapsed: max(0, phaseElapsed),
+            totalElapsed: max(0, timestamp - startedAt)
+        )
+    }
+
+    private static func format(_ interval: TimeInterval) -> String {
+        String(format: "%.3fs", max(0, interval))
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPContextBuilderToolProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPContextBuilderToolProvider.swift
@@ -170,7 +170,9 @@ final class MCPContextBuilderToolProvider: MCPWindowToolProviding {
     ) async throws -> ContextBuilderToolResult {
         let instructions = args["instructions"]?.stringValue ?? ""
         let metadata = await dependencies.captureRequestMetadata()
-        await dependencies.drainReadFileAutoSelection(metadata, .mirroredSelectionAndMetrics)
+        guard await dependencies.drainReadFileAutoSelection(metadata, .mirroredSelectionAndMetrics) == .completed else {
+            throw CancellationError()
+        }
         let responseType = try ContextBuilderResponseType.parse(from: args["response_type"])
         let exportResponse: Bool
         if let value = args["export_response"] {
@@ -271,6 +273,22 @@ final class MCPContextBuilderToolProvider: MCPWindowToolProviding {
                 return promptManager.planningModel.displayName
             } : nil
 
+            let sendStageProgress = dependencies.sendStageProgress
+            let progressTimeline = ContextBuilderMCPProgressTimeline { event in
+                await sendStageProgress(
+                    connectionID,
+                    MCPWindowToolName.contextBuilder,
+                    event.stage,
+                    event.message
+                )
+            }
+            let progressReporter: ContextBuilderMCPProgressReporter = { phase in
+                await progressTimeline.transition(to: phase)
+            }
+            let activityReporter: ContextBuilderMCPActivityReporter = { phase, message in
+                await progressTimeline.reportActivity(phase: phase, message: message)
+            }
+
             func runContextBuilderAndPlan() async throws -> ContextBuilderToolResult {
                 await dependencies.sendStageProgress(
                     connectionID,
@@ -285,24 +303,28 @@ final class MCPContextBuilderToolProvider: MCPWindowToolProviding {
                     "discovering",
                     "Running Context Builder agent..."
                 )
-                let snapshot = try await withHeartbeat(
-                    connectionID: connectionID,
-                    tool: MCPWindowToolName.contextBuilder,
-                    stage: "discovering",
-                    message: "Still building context..."
-                ) {
-                    try await contextBuilderVM.runContextBuilderForMCP(
-                        tabID: finalTabID,
-                        instructionsOverride: instructions.isEmpty ? nil : instructions,
-                        tokenBudgetOverride: tokenBudgetOverride,
-                        persistTokenBudget: false,
-                        enhancementModeOverride: .fullRewrite,
-                        agentOverride: preferredAgent,
-                        modelOverrideRaw: preferredModelRaw,
-                        responseType: responseType?.rawValue,
-                        planModelName: planModelName,
-                        mcpControlToken: mcpControlToken
-                    )
+                let snapshot = try await withTimelinePhaseCompletion(progressTimeline) {
+                    try await withHeartbeat(
+                        connectionID: connectionID,
+                        tool: MCPWindowToolName.contextBuilder,
+                        stage: "discovering",
+                        message: "Still building context...",
+                        timeline: progressTimeline
+                    ) {
+                        try await contextBuilderVM.runContextBuilderForMCP(
+                            tabID: finalTabID,
+                            instructionsOverride: instructions.isEmpty ? nil : instructions,
+                            tokenBudgetOverride: tokenBudgetOverride,
+                            persistTokenBudget: false,
+                            enhancementModeOverride: .fullRewrite,
+                            agentOverride: preferredAgent,
+                            modelOverrideRaw: preferredModelRaw,
+                            responseType: responseType?.rawValue,
+                            planModelName: planModelName,
+                            mcpControlToken: mcpControlToken,
+                            progressReporter: progressReporter
+                        )
+                    }
                 }
 
                 await dependencies.sendStageProgress(
@@ -362,19 +384,24 @@ final class MCPContextBuilderToolProvider: MCPWindowToolProviding {
                         "Generating \(modeLabel)..."
                     )
 
-                    let reply = try await withHeartbeat(
-                        connectionID: connectionID,
-                        tool: MCPWindowToolName.contextBuilder,
-                        stage: "generating",
-                        message: "Still generating \(modeLabel)..."
-                    ) {
-                        try await dependencies.runMCPPlanOrQuestion(
-                            contextBuilderVM,
-                            resultTab.id,
-                            mode,
-                            effectivePrompt,
-                            sel
-                        )
+                    let reply = try await withTimelinePhaseCompletion(progressTimeline) {
+                        try await withHeartbeat(
+                            connectionID: connectionID,
+                            tool: MCPWindowToolName.contextBuilder,
+                            stage: "generating",
+                            message: "Still generating \(modeLabel)...",
+                            timeline: progressTimeline
+                        ) {
+                            try await dependencies.runMCPPlanOrQuestion(
+                                contextBuilderVM,
+                                resultTab.id,
+                                mode,
+                                effectivePrompt,
+                                sel,
+                                progressReporter,
+                                activityReporter
+                            )
+                        }
                     }
 
                     if mode == .review {
@@ -476,6 +503,7 @@ final class MCPContextBuilderToolProvider: MCPWindowToolProviding {
         tool: String,
         stage: String,
         message: String,
+        timeline: ContextBuilderMCPProgressTimeline? = nil,
         interval: Duration = .seconds(30),
         operation: @escaping @Sendable () async throws -> T
     ) async throws -> T {
@@ -492,12 +520,20 @@ final class MCPContextBuilderToolProvider: MCPWindowToolProviding {
                 while !Task.isCancelled {
                     try await Task.sleep(for: interval)
                     try Task.checkCancellation()
+                    let heartbeat: (stage: String, message: String) = if let timeline {
+                        await timeline.heartbeat(
+                            fallbackStage: stage,
+                            fallbackMessage: message
+                        )
+                    } else {
+                        (stage, message)
+                    }
                     await ServerNetworkManager.shared.sendProgress(
                         for: connectionID,
                         tool: tool,
                         kind: .heartbeat,
-                        stage: stage,
-                        message: message
+                        stage: heartbeat.stage,
+                        message: heartbeat.message
                     )
                 }
             } catch {
@@ -506,5 +542,21 @@ final class MCPContextBuilderToolProvider: MCPWindowToolProviding {
         }
         defer { heartbeatTask.cancel() }
         return try await operation()
+    }
+
+    private static func withTimelinePhaseCompletion<T: Sendable>(
+        _ timeline: ContextBuilderMCPProgressTimeline,
+        operation: @escaping @Sendable () async throws -> T
+    ) async throws -> T {
+        do {
+            let result = try await operation()
+            await timeline.finishCurrentPhase()
+            await timeline.flush()
+            return result
+        } catch {
+            await timeline.finishCurrentPhase()
+            await timeline.flush()
+            throw error
+        }
     }
 }

--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPFileToolProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPFileToolProvider.swift
@@ -62,6 +62,8 @@ final class MCPFileToolProvider: MCPWindowToolProviding {
                 required: ["action", "path"]
             )
         ) { [self] _, args in
+            try Task.checkCancellation()
+            await MCPToolExecutionHandlerPhaseContext.report(.fileActionsPreMutationChecks)
             guard let action = args["action"]?.stringValue,
                   let path = args["path"]?.stringValue
             else { throw MCPError.invalidParams("missing required fields") }
@@ -69,15 +71,22 @@ final class MCPFileToolProvider: MCPWindowToolProviding {
             let content = args["content"]?.stringValue
             let newPath = args["new_path"]?.stringValue
             let ifExists = args["if_exists"]?.stringValue?.lowercased() ?? "error"
+            await MCPToolExecutionHandlerPhaseContext.report(.fileActionsPreMutationChecks, transition: .completed)
+            try Task.checkCancellation()
 
             let warning = try await dependencies.performFileAction(action, path, content, newPath, ifExists)
-            return try Value(ToolResultDTOs.FileActionReply(
+            try Task.checkCancellation()
+            await MCPToolExecutionHandlerPhaseContext.report(.fileActionsReplyConstruction)
+            let value = try Value(ToolResultDTOs.FileActionReply(
                 status: "ok",
                 action: action,
                 path: path,
                 newPath: newPath,
                 warning: warning
             ))
+            await MCPToolExecutionHandlerPhaseContext.report(.fileActionsReplyConstruction, transition: .completed)
+            try Task.checkCancellation()
+            return value
         }
     }
 
@@ -129,7 +138,9 @@ final class MCPFileToolProvider: MCPWindowToolProviding {
 
             switch scope {
             case "selected":
-                await dependencies.drainReadFileAutoSelection(metadata, .canonicalSelection)
+                guard await dependencies.drainReadFileAutoSelection(metadata, .canonicalSelection) == .completed else {
+                    throw CancellationError()
+                }
                 try Task.checkCancellation()
                 let collections = try await dependencies.selectionCollectionsForCurrentTabContext()
                 try Task.checkCancellation()
@@ -250,7 +261,9 @@ final class MCPFileToolProvider: MCPWindowToolProviding {
                 let lookupContext = await dependencies.resolveFileToolLookupContext(metadata)
                 _ = await dependencies.promptVM.workspaceFileContextStore.awaitAppliedIngress(rootScope: lookupContext.rootScope)
                 if mode.lowercased() == "selected" {
-                    await dependencies.drainReadFileAutoSelection(metadata, .canonicalSelection)
+                    guard await dependencies.drainReadFileAutoSelection(metadata, .canonicalSelection) == .completed else {
+                        throw CancellationError()
+                    }
                 }
                 let worktreeScope = ToolResultDTOs.WorktreeScopeDTO.sessionBound(from: lookupContext.bindingProjection)
                 let resultAndRootCount = try await dependencies.buildStoreBackedFileTreeResult(mode, maxDepth, args["path"]?.stringValue, lookupContext)

--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPPromptContextToolProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPPromptContextToolProvider.swift
@@ -88,7 +88,9 @@ final class MCPPromptContextToolProvider: MCPWindowToolProviding {
             let display: FilePathDisplay = ((args["path_display"]?.stringValue ?? "relative").lowercased() == "full") ? .full : .relative
             let overridePreset = try await resolveCopyPresetOverride(args["copy_preset"])
             let metadata = await dependencies.captureRequestMetadata()
-            await dependencies.drainReadFileAutoSelection(metadata, .mirroredSelectionAndMetrics)
+            guard await dependencies.drainReadFileAutoSelection(metadata, .mirroredSelectionAndMetrics) == .completed else {
+                throw CancellationError()
+            }
             let lookupContext = await dependencies.resolveFileToolLookupContext(metadata)
             _ = await dependencies.promptVM.workspaceFileContextStore.awaitAppliedIngress(rootScope: lookupContext.rootScope)
             let resolvedTabContext = try await dependencies.resolveTabContextSnapshot(metadata, MCPWindowToolName.workspaceContext, .allowLegacyImplicitRouting)
@@ -154,7 +156,9 @@ final class MCPPromptContextToolProvider: MCPWindowToolProviding {
         }
         let metadata = await dependencies.captureRequestMetadata()
         if op == "export" {
-            await dependencies.drainReadFileAutoSelection(metadata, .mirroredSelectionAndMetrics)
+            guard await dependencies.drainReadFileAutoSelection(metadata, .mirroredSelectionAndMetrics) == .completed else {
+                throw CancellationError()
+            }
         }
         let resolvedContext = try await dependencies.resolveTabContextSnapshot(metadata, MCPWindowToolName.prompt, .allowLegacyImplicitRouting)
         if !resolvedContext.usesActiveTabCompatibility {

--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPSelectionToolProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPSelectionToolProvider.swift
@@ -102,6 +102,7 @@ final class MCPSelectionToolProvider: MCPWindowToolProviding {
     }
 
     private func executeManageSelection(args: [String: Value]) async throws -> ToolResultDTOs.SelectionReply {
+        try Task.checkCancellation()
         let op = (args["op"]?.stringValue ?? "get").lowercased()
         let rawPaths = args["paths"]?.arrayValue?.compactMap(\.stringValue) ?? []
         let parsedInputs = dependencies.parseManageSelectionInputs(rawPaths, args["slices"])
@@ -112,18 +113,31 @@ final class MCPSelectionToolProvider: MCPWindowToolProviding {
         if await dependencies.promptVM.codeMapsGloballyDisabled, mode == "codemap_only" || op == "demote" {
             throw MCPError.invalidParams(MCPServerViewModel.codeMapsGloballyDisabledMCPMessage)
         }
+        try Task.checkCancellation()
         let view = (args["view"]?.stringValue ?? "summary").lowercased()
         let strict = args["strict"]?.boolValue ?? false
         let display: FilePathDisplay = ((args["path_display"]?.stringValue ?? "relative").lowercased() == "full") ? .full : .relative
         let includeBlocks = view == "content"
         let metadata = await dependencies.captureRequestMetadata()
-        await dependencies.drainReadFileAutoSelection(metadata, .mirroredSelectionAndMetrics)
+        try Task.checkCancellation()
+        await MCPToolExecutionHandlerPhaseContext.report(.manageSelectionAutoSelectionDrain)
+        guard await dependencies.drainReadFileAutoSelection(metadata, .mirroredSelectionAndMetrics) == .completed else {
+            throw CancellationError()
+        }
+        await MCPToolExecutionHandlerPhaseContext.report(.manageSelectionAutoSelectionDrain, transition: .completed)
+        try Task.checkCancellation()
         var resolvedContext = try dependencies.resolveTabContextSnapshot(metadata, MCPWindowToolName.manageSelection, .allowLegacyImplicitRouting)
         let lookupContext = await dependencies.resolveFileToolLookupContext(metadata)
+        try Task.checkCancellation()
         let lookupRootScope = lookupContext.rootScope
+        await MCPToolExecutionHandlerPhaseContext.report(.manageSelectionIngressWait)
         _ = await dependencies.promptVM.workspaceFileContextStore.awaitAppliedIngress(rootScope: lookupRootScope)
+        await MCPToolExecutionHandlerPhaseContext.report(.manageSelectionIngressWait, transition: .completed)
+        try Task.checkCancellation()
+        await MCPToolExecutionHandlerPhaseContext.report(.manageSelectionConstruction)
         if !resolvedContext.usesActiveTabCompatibility {
             resolvedContext.snapshot.selection = await dependencies.stabilizedVirtualSelection(resolvedContext.snapshot)
+            try Task.checkCancellation()
         }
         resolvedContext.snapshot.selection = lookupContext.physicalizeSelection(resolvedContext.snapshot.selection)
         let physicalParsedInputs = MCPServerViewModel.ManageSelectionInputs(
@@ -140,13 +154,20 @@ final class MCPSelectionToolProvider: MCPWindowToolProviding {
         case "get":
             let ctx = resolvedContext.snapshot
             selectionLog("[Virtual] manage_selection op=get tab=\(ctx.tabID) selected=\(ctx.selection.selectedPaths.count) codemap=\(ctx.selection.autoCodemapPaths.count) slices=\(ctx.selection.slices.count)")
-            return try await dependencies.buildCurrentSelectionReply(includeBlocks, display, extraInvalid, view, resolvedContext)
+            await MCPToolExecutionHandlerPhaseContext.report(.manageSelectionConstruction, transition: .completed)
+            try Task.checkCancellation()
+            await MCPToolExecutionHandlerPhaseContext.report(.manageSelectionReplyConstruction)
+            let reply = try await dependencies.buildCurrentSelectionReply(includeBlocks, display, extraInvalid, view, resolvedContext)
+            await MCPToolExecutionHandlerPhaseContext.report(.manageSelectionReplyConstruction, transition: .completed)
+            try Task.checkCancellation()
+            return reply
         case "preview":
             let context = resolvedContext.snapshot
             if mode == "codemap_only", !physicalSliceInputs.isEmpty {
                 throw MCPError.invalidParams("mode 'codemap_only' cannot be used with slices")
             }
             let buildResult = await dependencies.buildManageSelectionSetSelection(physicalParsedInputs, mode, context.selection, lookupRootScope)
+            try Task.checkCancellation()
             let previewSelectionFinal: StoredSelection = if mode == "codemap_only" {
                 StoredSelection(selectedPaths: buildResult.selection.selectedPaths, autoCodemapPaths: buildResult.selection.autoCodemapPaths, slices: buildResult.selection.slices, codemapAutoEnabled: false)
             } else {
@@ -160,7 +181,12 @@ final class MCPSelectionToolProvider: MCPWindowToolProviding {
                 combinedInvalid.append(error)
             }
             let previewCodeMapOverride: CodeMapUsage? = (!resolvedContext.usesActiveTabCompatibility && context.runID != nil) ? .auto : nil
+            await MCPToolExecutionHandlerPhaseContext.report(.manageSelectionConstruction, transition: .completed)
+            try Task.checkCancellation()
+            await MCPToolExecutionHandlerPhaseContext.report(.manageSelectionReplyConstruction)
             let previewReply = try await dependencies.buildSelectionPreviewReply(previewSelectionFinal, includeBlocks, display, combinedInvalid, view, previewCodeMapOverride, lookupContext)
+            await MCPToolExecutionHandlerPhaseContext.report(.manageSelectionReplyConstruction, transition: .completed)
+            try Task.checkCancellation()
             if strict {
                 let resolvedAny = (previewReply.files?.isEmpty == false) || (previewReply.fileSlices?.isEmpty == false)
                 if !resolvedAny {
@@ -185,6 +211,7 @@ final class MCPSelectionToolProvider: MCPWindowToolProviding {
                 throw MCPError.invalidParams("mode 'codemap_only' cannot be used with slices")
             }
             let setBuildResult = await dependencies.buildManageSelectionSetSelection(physicalParsedInputs, mode, context.selection, lookupRootScope)
+            try Task.checkCancellation()
             let currentSelection = setBuildResult.selection
             var combinedInvalid = setBuildResult.invalidPaths
             for error in extraInvalid where !combinedInvalid.contains(error) {
@@ -221,6 +248,7 @@ final class MCPSelectionToolProvider: MCPWindowToolProviding {
             }
             if !physicalSelectionPaths.isEmpty {
                 let addResult = await dependencies.addStoredSelectionPaths(currentSelection, physicalSelectionPaths, rawPaths, mode, lookupRootScope)
+                try Task.checkCancellation()
                 currentSelection = addResult.selection
                 invalid.append(contentsOf: addResult.invalidPaths)
                 codemapUnavailableMsgs.append(contentsOf: addResult.codemapUnavailable)
@@ -235,6 +263,7 @@ final class MCPSelectionToolProvider: MCPWindowToolProviding {
                 var sliceInvalid = false
                 if !physicalSliceInputs.isEmpty {
                     let sliceResult = await dependencies.computeSelectionSlicesVirtual(currentSelection, physicalSliceInputs, .add, lookupRootScope)
+                    try Task.checkCancellation()
                     currentSelection = sliceResult.selection
                     invalid.append(contentsOf: sliceResult.result.invalidPaths)
                     sliceResolved = !sliceResult.result.resolvedMap.isEmpty
@@ -279,6 +308,7 @@ final class MCPSelectionToolProvider: MCPWindowToolProviding {
             var currentSelection = context.selection
             if !physicalSelectionPaths.isEmpty {
                 let result = await dependencies.removeStoredSelectionPaths(currentSelection, physicalSelectionPaths, rawPaths, mode, lookupRootScope)
+                try Task.checkCancellation()
                 currentSelection = result.0
                 invalid.append(contentsOf: result.1)
                 for (key, value) in result.2 where resolvedMap[key] == nil {
@@ -291,6 +321,7 @@ final class MCPSelectionToolProvider: MCPWindowToolProviding {
             var sliceInvalid = false
             if !physicalSliceInputs.isEmpty {
                 let sliceResult = await dependencies.computeSelectionSlicesVirtual(currentSelection, physicalSliceInputs, .remove, lookupRootScope)
+                try Task.checkCancellation()
                 currentSelection = sliceResult.selection
                 invalid.append(contentsOf: sliceResult.result.invalidPaths)
                 sliceResolved = !sliceResult.result.resolvedMap.isEmpty
@@ -321,6 +352,7 @@ final class MCPSelectionToolProvider: MCPWindowToolProviding {
             if physicalSelectionPaths.isEmpty { throw MCPError.invalidParams("paths required for promote") }
             if !physicalSliceInputs.isEmpty { throw MCPError.invalidParams("promote does not support slices") }
             let (newSelection, invalid, mutated) = await dependencies.promoteStoredSelectionPaths(context.selection, physicalSelectionPaths, rawPaths, strict, lookupRootScope)
+            try Task.checkCancellation()
             var combinedInvalid = invalid
             for error in extraInvalid where !combinedInvalid.contains(error) {
                 combinedInvalid.append(error)
@@ -336,6 +368,7 @@ final class MCPSelectionToolProvider: MCPWindowToolProviding {
             if physicalSelectionPaths.isEmpty { throw MCPError.invalidParams("paths required for demote") }
             if !physicalSliceInputs.isEmpty { throw MCPError.invalidParams("demote does not support slices") }
             let demoteResult = await dependencies.demoteStoredSelectionPaths(context.selection, physicalSelectionPaths, rawPaths, strict, lookupRootScope)
+            try Task.checkCancellation()
             var combinedInvalid = demoteResult.invalidPaths
             for error in extraInvalid where !combinedInvalid.contains(error) {
                 combinedInvalid.append(error)
@@ -373,7 +406,12 @@ final class MCPSelectionToolProvider: MCPWindowToolProviding {
         view: String
     ) async throws -> ToolResultDTOs.SelectionReply {
         resolvedContext.snapshot.selection = selection
+        await MCPToolExecutionHandlerPhaseContext.report(.manageSelectionConstruction, transition: .completed)
+        try Task.checkCancellation()
+        await MCPToolExecutionHandlerPhaseContext.report(.manageSelectionPersistence)
         let verification = await dependencies.persistResolvedTabContextSnapshot(resolvedContext, metadata, true)
+        await MCPToolExecutionHandlerPhaseContext.report(.manageSelectionPersistence, transition: .completed)
+        try Task.checkCancellation()
         let canonicalSelection = try Self.requireCanonicalSelection(
             verification,
             requested: selection,
@@ -384,7 +422,8 @@ final class MCPSelectionToolProvider: MCPWindowToolProviding {
         let codeMapOverride: CodeMapUsage? = (!resolvedContext.usesActiveTabCompatibility && baseContext.runID != nil) ? .auto : nil
         var replyContext = baseContext
         replyContext.selection = canonicalSelection
-        return try await dependencies.buildSelectionMutationReply(
+        await MCPToolExecutionHandlerPhaseContext.report(.manageSelectionReplyConstruction)
+        let reply = try await dependencies.buildSelectionMutationReply(
             canonicalSelection,
             includeBlocks,
             display,
@@ -393,6 +432,9 @@ final class MCPSelectionToolProvider: MCPWindowToolProviding {
             codeMapOverride,
             resolvedContext.usesActiveTabCompatibility ? nil : replyContext
         )
+        await MCPToolExecutionHandlerPhaseContext.report(.manageSelectionReplyConstruction, transition: .completed)
+        try Task.checkCancellation()
+        return reply
     }
 
     static func requireCanonicalSelection(

--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPWindowToolDependencies.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPWindowToolDependencies.swift
@@ -77,7 +77,9 @@ struct MCPWindowToolDependencies {
         _ tabID: UUID,
         _ mode: HeadlessMode,
         _ prompt: String,
-        _ selection: StoredSelection
+        _ selection: StoredSelection,
+        _ progressReporter: ContextBuilderMCPProgressReporter?,
+        _ activityReporter: ContextBuilderMCPActivityReporter?
     ) async throws -> ChatSendReply
     typealias CaptureRequestMetadata = @MainActor @Sendable () async -> MCPServerViewModel.RequestMetadata
     typealias ResolveTabContextSnapshot = @MainActor @Sendable (
@@ -178,7 +180,7 @@ struct MCPWindowToolDependencies {
     typealias BuildStoreBackedFileTreeResult = @MainActor @Sendable (_ mode: String, _ maxDepth: Int?, _ startPath: String?, _ lookupContext: WorkspaceLookupContext) async throws -> (result: FileTreeResult, rootCount: Int)
     typealias ReadFile = @MainActor @Sendable (_ path: String, _ startLine1Based: Int?, _ lineCount: Int?, _ lookupRootScope: WorkspaceLookupRootScope) async throws -> (reply: ToolResultDTOs.ReadFileReply, shouldAutoSelect: Bool)
     typealias EnqueueReadFileAutoSelection = @MainActor @Sendable (_ reply: ToolResultDTOs.ReadFileReply, _ requestedPath: String, _ metadata: MCPServerViewModel.RequestMetadata) async -> Void
-    typealias DrainReadFileAutoSelection = @MainActor @Sendable (_ metadata: MCPServerViewModel.RequestMetadata, _ requirement: MCPReadFileAutoSelectionCoordinator.DrainRequirement) async -> Void
+    typealias DrainReadFileAutoSelection = @MainActor @Sendable (_ metadata: MCPServerViewModel.RequestMetadata, _ requirement: MCPReadFileAutoSelectionCoordinator.DrainRequirement) async -> MCPReadFileAutoSelectionCoordinator.DrainResult
     typealias EnqueueFileSearchAutoSelection = @MainActor @Sendable (_ mode: SearchMode, _ contextLines: Int, _ reply: ToolResultDTOs.SearchResultDTO, _ metadata: MCPServerViewModel.RequestMetadata) async -> Void
     typealias WorkspaceContextMessage = @MainActor @Sendable (_ operation: String?, _ path: String?) async -> String
     typealias ParseCopyPresetSelector = @Sendable (_ value: Value?) -> MCPServerViewModel.CopyPresetSelector?

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/Selection/WorkspaceSelectionCoordinator.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/Selection/WorkspaceSelectionCoordinator.swift
@@ -1,12 +1,40 @@
 import Combine
 import Foundation
 
+private struct WorkspaceSelectionMirrorTarget: Equatable {
+    let workspaceID: UUID
+    let tabID: UUID
+    let selection: StoredSelection
+    let contextRevision: UInt64
+}
+
 @MainActor
 protocol WorkspaceSelectionHost: AnyObject {
     var activeWorkspace: WorkspaceModel? { get }
+    var selectionMirrorContextRevision: UInt64 { get }
     func composeTab(with id: UUID) -> ComposeTabState?
     func publishActiveComposeTabSnapshot(commitToMemory: Bool, touchModified: Bool)
     func updateComposeTabStoredOnly(_ tab: ComposeTabState)
+    func applySelectionMirrorAttempt(
+        _ selection: StoredSelection,
+        forTabID tabID: UUID,
+        workspaceID: UUID
+    ) async
+}
+
+private extension WorkspaceSelectionHost {
+    func activeSelectionMirrorTarget() -> WorkspaceSelectionMirrorTarget? {
+        guard let workspace = activeWorkspace,
+              let tabID = workspace.activeComposeTabID ?? workspace.composeTabs.first?.id,
+              let tab = workspace.composeTabs.first(where: { $0.id == tabID })
+        else { return nil }
+        return WorkspaceSelectionMirrorTarget(
+            workspaceID: workspace.id,
+            tabID: tabID,
+            selection: tab.selection,
+            contextRevision: selectionMirrorContextRevision
+        )
+    }
 }
 
 extension WorkspaceManagerViewModel: WorkspaceSelectionHost {}
@@ -40,6 +68,17 @@ final class WorkspaceSelectionCoordinator {
     let mutationService: WorkspaceSelectionMutationService
     private let changeSubject = PassthroughSubject<Change, Never>()
     private var applyingSelectionMirrorDepth = 0
+    private struct MCPSelectionMirrorTail {
+        let id: UInt64
+        /// `nil` denotes a coalesced repair that resolves the latest active target when it runs.
+        let target: WorkspaceSelectionMirrorTarget?
+        let task: Task<Void, Never>
+    }
+
+    private var nextSelectionRevision: UInt64 = 0
+    private var selectionRevisionByTabID: [UUID: UInt64] = [:]
+    private var nextSelectionMirrorTaskID: UInt64 = 0
+    private var mcpSelectionMirrorTail: MCPSelectionMirrorTail?
 
     var changes: AnyPublisher<Change, Never> {
         changeSubject.eraseToAnyPublisher()
@@ -102,6 +141,9 @@ final class WorkspaceSelectionCoordinator {
         workspaceManager.publishActiveComposeTabSnapshot(commitToMemory: true, touchModified: false)
         let snapshot = activeSelectionSnapshot(flushPendingUI: false)
         guard snapshot.tabID != previousTabID || snapshot.selection != previousSelection else { return }
+        if let tabID = snapshot.tabID {
+            recordSelectionRevision(for: tabID)
+        }
         changeSubject.send(Change(tabID: snapshot.tabID, selection: snapshot.selection, source: .uiFlush))
     }
 
@@ -111,10 +153,21 @@ final class WorkspaceSelectionCoordinator {
         source: Source = .runtimeMutation,
         mirrorToUI: Bool = true
     ) async -> StoredSelection {
-        guard workspaceManager != nil, let tabID = activeTabID() else { return selection }
-        guard persist(selection, for: tabID, markDirty: true) else { return selection }
+        guard let workspaceManager, let tabID = activeTabID() else { return selection }
+        if workspaceManager.composeTab(with: tabID)?.selection == selection {
+            if mirrorToUI, source == .mcpTabContext {
+                let revision = recordSelectionRevision(for: tabID)
+                await enqueueMCPSelectionMirror(selection, forTabID: tabID, revision: revision)
+            }
+            return selection
+        }
+
+        guard let revision = persist(selection, for: tabID, markDirty: true) else { return selection }
         let change = Change(tabID: tabID, selection: selection, source: source)
-        if mirrorToUI {
+        if mirrorToUI, source == .mcpTabContext {
+            changeSubject.send(change)
+            await enqueueMCPSelectionMirror(selection, forTabID: tabID, revision: revision)
+        } else if mirrorToUI {
             await applySelectionMirror {
                 changeSubject.send(change)
             }
@@ -143,7 +196,7 @@ final class WorkspaceSelectionCoordinator {
         for tabID: UUID,
         source: Source = .virtual
     ) -> StoredSelection {
-        guard persist(selection, for: tabID, markDirty: true) else { return selection }
+        guard persist(selection, for: tabID, markDirty: true) != nil else { return selection }
         changeSubject.send(Change(tabID: tabID, selection: selection, source: source))
         return selection
     }
@@ -205,12 +258,127 @@ final class WorkspaceSelectionCoordinator {
         }
     }
 
-    private func persist(_ selection: StoredSelection, for tabID: UUID, markDirty: Bool) -> Bool {
-        guard let workspaceManager, var tab = workspaceManager.composeTab(with: tabID) else { return false }
-        guard tab.selection != selection else { return false }
+    func mirrorSelectionToActiveUI(_ selection: StoredSelection, forTabID tabID: UUID) async {
+        guard let workspaceManager,
+              let target = workspaceManager.activeSelectionMirrorTarget(),
+              target.tabID == tabID,
+              target.selection == selection
+        else { return }
+        let revision = selectionRevisionByTabID[tabID]
+        await enqueueSelectionMirror(target, selectionRevision: revision == 0 ? nil : revision)
+    }
+
+    private func enqueueMCPSelectionMirror(
+        _ selection: StoredSelection,
+        forTabID tabID: UUID,
+        revision: UInt64
+    ) async {
+        guard let workspaceManager,
+              let target = workspaceManager.activeSelectionMirrorTarget(),
+              target.tabID == tabID,
+              target.selection == selection
+        else { return }
+        await enqueueSelectionMirror(target, selectionRevision: revision)
+    }
+
+    private func enqueueSelectionMirror(
+        _ target: WorkspaceSelectionMirrorTarget,
+        selectionRevision: UInt64?
+    ) async {
+        let predecessor = mcpSelectionMirrorTail?.task
+        let taskID = allocateSelectionMirrorTaskID()
+        // The internal task owns its completion after canonical persistence, even if the
+        // originating request is cancelled. Each task performs at most one suppressed apply.
+        let task = Task { @MainActor [weak self, weak workspaceManager] in
+            await predecessor?.value
+            guard let self, let workspaceManager else { return }
+
+            let revisionIsCurrent = selectionRevision.map {
+                selectionRevisionByTabID[target.tabID] == $0
+            } ?? true
+            var attemptedTarget: WorkspaceSelectionMirrorTarget?
+            if revisionIsCurrent,
+               workspaceManager.activeSelectionMirrorTarget() == target
+            {
+                attemptedTarget = target
+                await applySelectionMirror {
+                    await workspaceManager.applySelectionMirrorAttempt(
+                        target.selection,
+                        forTabID: target.tabID,
+                        workspaceID: target.workspaceID
+                    )
+                }
+            }
+            finishSelectionMirrorTask(taskID, attemptedTarget: attemptedTarget)
+        }
+        mcpSelectionMirrorTail = MCPSelectionMirrorTail(id: taskID, target: target, task: task)
+        await task.value
+    }
+
+    /// Coalesces post-suspension churn into one latest-target successor. The completed request
+    /// does not await this repair, so sustained switching cannot wedge the MCP drain.
+    private func scheduleSelectionMirrorRepair(after predecessor: Task<Void, Never>?) {
+        let taskID = allocateSelectionMirrorTaskID()
+        let task = Task { @MainActor [weak self, weak workspaceManager] in
+            await predecessor?.value
+            guard let self, let workspaceManager else { return }
+
+            let target = workspaceManager.activeSelectionMirrorTarget()
+            if let target {
+                await applySelectionMirror {
+                    await workspaceManager.applySelectionMirrorAttempt(
+                        target.selection,
+                        forTabID: target.tabID,
+                        workspaceID: target.workspaceID
+                    )
+                }
+            }
+            finishSelectionMirrorTask(taskID, attemptedTarget: target)
+        }
+        mcpSelectionMirrorTail = MCPSelectionMirrorTail(id: taskID, target: nil, task: task)
+    }
+
+    private func finishSelectionMirrorTask(
+        _ taskID: UInt64,
+        attemptedTarget: WorkspaceSelectionMirrorTarget?
+    ) {
+        let currentTarget = workspaceManager?.activeSelectionMirrorTarget()
+        if currentTarget == attemptedTarget {
+            if mcpSelectionMirrorTail?.id == taskID {
+                mcpSelectionMirrorTail = nil
+            }
+            return
+        }
+
+        if let successor = mcpSelectionMirrorTail, successor.id != taskID {
+            // An exact canonical successor or an existing latest-target repair already owns it.
+            guard successor.target != currentTarget, successor.target != nil else { return }
+            scheduleSelectionMirrorRepair(after: successor.task)
+        } else if currentTarget != nil {
+            scheduleSelectionMirrorRepair(after: nil)
+        } else if mcpSelectionMirrorTail?.id == taskID {
+            mcpSelectionMirrorTail = nil
+        }
+    }
+
+    private func allocateSelectionMirrorTaskID() -> UInt64 {
+        nextSelectionMirrorTaskID &+= 1
+        return nextSelectionMirrorTaskID
+    }
+
+    @discardableResult
+    private func recordSelectionRevision(for tabID: UUID) -> UInt64 {
+        nextSelectionRevision &+= 1
+        selectionRevisionByTabID[tabID] = nextSelectionRevision
+        return nextSelectionRevision
+    }
+
+    private func persist(_ selection: StoredSelection, for tabID: UUID, markDirty: Bool) -> UInt64? {
+        guard let workspaceManager, var tab = workspaceManager.composeTab(with: tabID) else { return nil }
+        guard tab.selection != selection else { return nil }
         tab.selection = selection
         tab.lastModified = Date()
         workspaceManager.updateComposeTabStoredOnly(tab)
-        return true
+        return recordSelectionRevision(for: tabID)
     }
 }

--- a/Sources/RepoPromptMCP/main.swift
+++ b/Sources/RepoPromptMCP/main.swift
@@ -669,6 +669,7 @@ private actor BridgeDrainState {
 
     private let clock: Clock
     private var stdinClosedAt: TimeInterval?
+    private var lastVisibilityLogAt: TimeInterval?
 
     init(clock: @escaping Clock) {
         self.clock = clock
@@ -680,8 +681,21 @@ private actor BridgeDrainState {
         }
     }
 
-    func isStdinClosed() -> Bool {
-        stdinClosedAt != nil
+    func elapsedSinceStdinClosed() -> TimeInterval? {
+        guard let stdinClosedAt else { return nil }
+        return max(0, clock() - stdinClosedAt)
+    }
+
+    func claimVisibilityLog(interval: TimeInterval) -> TimeInterval? {
+        guard let stdinClosedAt else { return nil }
+        let now = clock()
+        if let lastVisibilityLogAt,
+           now - lastVisibilityLogAt < max(0.001, interval)
+        {
+            return nil
+        }
+        lastVisibilityLogAt = now
+        return max(0, now - stdinClosedAt)
     }
 }
 
@@ -695,6 +709,9 @@ extension BootstrapSocketProxy {
         faultRule: JSONRPCBridgeFaultRule?,
         socketPoller: BridgeSocketPoller? = nil,
         drainClock: @escaping @Sendable () -> TimeInterval = { ProcessInfo.processInfo.systemUptime },
+        drainDeadline: TimeInterval = TimeInterval(MCPTimeoutPolicy.postStdinHalfCloseBridgeDrainDeadlineSeconds),
+        drainVisibilityInterval: TimeInterval = 30,
+        drainLogDescriptor: Int32 = STDERR_FILENO,
         onStdinClosed: @escaping @Sendable () async -> Void = {}
     ) async throws {
         let drainState = BridgeDrainState(clock: drainClock)
@@ -718,7 +735,10 @@ extension BootstrapSocketProxy {
                     drainState: drainState,
                     bridgeLedger: bridgeLedger,
                     faultRule: faultRule,
-                    socketPoller: socketPoller
+                    socketPoller: socketPoller,
+                    drainDeadline: drainDeadline,
+                    drainVisibilityInterval: drainVisibilityInterval,
+                    drainLogDescriptor: drainLogDescriptor
                 )
                 return .socketClosed
             }
@@ -738,7 +758,12 @@ extension BootstrapSocketProxy {
                     }
                 }
             } catch {
-                log.error("BootstrapSocketProxy: Bridge task failed: \(error)")
+                let message = "[MCPBridge] task_failed error=\(error)\n"
+                BestEffortStderrWriter.writeNonBlocking(
+                    Data(message.utf8),
+                    to: drainLogDescriptor
+                )
+                debugLog("BootstrapSocketProxy: Bridge task failed: \(error)")
                 group.cancelAll()
                 throw error
             }
@@ -945,7 +970,10 @@ extension BootstrapSocketProxy {
         drainState: BridgeDrainState,
         bridgeLedger: JSONRPCBridgeLedger,
         faultRule: JSONRPCBridgeFaultRule?,
-        socketPoller: BridgeSocketPoller? = nil
+        socketPoller: BridgeSocketPoller? = nil,
+        drainDeadline: TimeInterval,
+        drainVisibilityInterval: TimeInterval,
+        drainLogDescriptor: Int32
     ) async throws {
         var buffer = [UInt8](repeating: 0, count: 8192)
         var pending = Data()
@@ -980,10 +1008,13 @@ extension BootstrapSocketProxy {
             }
 
             guard case let .events(rawEvents) = readiness else {
-                if await shouldFinishSocketDrain(
+                if try await shouldFinishSocketDrain(
                     drainState: drainState,
                     ledger: bridgeLedger,
-                    pendingByteCount: pending.count
+                    pendingByteCount: pending.count,
+                    deadline: drainDeadline,
+                    visibilityInterval: drainVisibilityInterval,
+                    logDescriptor: drainLogDescriptor
                 ) {
                     debugLog("BootstrapSocketProxy: socket→stdout drained after stdin close")
                     return
@@ -1046,7 +1077,7 @@ extension BootstrapSocketProxy {
                     // line and keep the stdout transport alive rather than raising an ObjC
                     // exception that would abort the helper mid-ledger-transaction.
                     if let progressMessage = Self.extractProgressMessage(from: framed) {
-                        let delivered = BestEffortStderrWriter.write(
+                        let delivered = BestEffortStderrWriter.writeNonBlocking(
                             Data("[progress] \(progressMessage)\n".utf8)
                         )
                         if !delivered {
@@ -1089,10 +1120,13 @@ extension BootstrapSocketProxy {
                 )
                 return
             }
-            if await shouldFinishSocketDrain(
+            if try await shouldFinishSocketDrain(
                 drainState: drainState,
                 ledger: bridgeLedger,
-                pendingByteCount: pending.count
+                pendingByteCount: pending.count,
+                deadline: drainDeadline,
+                visibilityInterval: drainVisibilityInterval,
+                logDescriptor: drainLogDescriptor
             ) {
                 debugLog("BootstrapSocketProxy: socket→stdout drained after stdin close")
                 return
@@ -1103,13 +1137,34 @@ extension BootstrapSocketProxy {
     private static func shouldFinishSocketDrain(
         drainState: BridgeDrainState,
         ledger: JSONRPCBridgeLedger,
-        pendingByteCount: Int
-    ) async -> Bool {
-        guard pendingByteCount == 0, await drainState.isStdinClosed() else { return false }
+        pendingByteCount: Int,
+        deadline: TimeInterval,
+        visibilityInterval: TimeInterval,
+        logDescriptor: Int32
+    ) async throws -> Bool {
+        guard let elapsed = await drainState.elapsedSinceStdinClosed() else { return false }
         let snapshot = await ledger.snapshot()
-        return snapshot.terminalReason == nil
-            && snapshot.activeRequestCount == 0
-            && snapshot.pendingTransactionCount == 0
+        if snapshot.canFinishSocketDrain(partialByteCount: pendingByteCount) {
+            return true
+        }
+
+        let effectiveDeadline = max(0.001, deadline)
+        if elapsed >= effectiveDeadline {
+            let terminalReason = await ledger.terminalizePostStdinHalfCloseDrainDeadline()
+            let elapsedText = String(format: "%.3fs", elapsed)
+            let deadlineText = String(format: "%.3fs", effectiveDeadline)
+            let blockers = snapshot.socketDrainBlockerDescription(partialByteCount: pendingByteCount)
+            let message = "[MCPBridgeDrain] deadline_exceeded elapsed=\(elapsedText) deadline=\(deadlineText) \(blockers) terminalized_reason=\(terminalReason)\n"
+            BestEffortStderrWriter.writeNonBlocking(Data(message.utf8), to: logDescriptor)
+            throw JSONRPCBridgeLedgerError.terminal(terminalReason)
+        }
+
+        if let visibleElapsed = await drainState.claimVisibilityLog(interval: visibilityInterval) {
+            let elapsedText = String(format: "%.3fs", visibleElapsed)
+            let message = "[MCPBridgeDrain] waiting elapsed=\(elapsedText) \(snapshot.socketDrainBlockerDescription(partialByteCount: pendingByteCount))\n"
+            BestEffortStderrWriter.writeNonBlocking(Data(message.utf8), to: logDescriptor)
+        }
+        return false
     }
 
     private static func requireCleanBridgeStop(
@@ -1672,7 +1727,21 @@ actor MCPService: Service {
 
 // MARK: - Error Handlers
 
+func mcpCLIExitCode(for error: CLIRuntimeError) -> MCPCLIExitCode {
+    switch error {
+    case .connectionFailed:
+        .connectionFailed
+    case .approvalDenied:
+        .approvalDenied
+    case .terminatedByServer:
+        .terminatedByServer
+    case .hostDisconnected:
+        .ok
+    }
+}
+
 func handleRuntimeError(_ err: CLIRuntimeError) -> Never {
+    let exitCode = mcpCLIExitCode(for: err)
     // Log error event to disk for app to surface (respects shouldPersistEvent policy)
     CLIEventLogger.logRuntimeError(err)
 
@@ -1680,20 +1749,20 @@ func handleRuntimeError(_ err: CLIRuntimeError) -> Never {
     case let .connectionFailed(underlying):
         log.error("Connection failed: \(underlying)")
         fputs("RepoPrompt MCP: connection failed – \(underlying)\n", stderr)
-        exit(MCPCLIExitCode.connectionFailed.rawValue)
+        exit(exitCode.rawValue)
     case .approvalDenied:
         fputs("RepoPrompt MCP: connection closed immediately. Approval was likely denied or the server is disabled. Check the RepoPrompt approval dialog or MCP settings.\n", stderr)
-        exit(MCPCLIExitCode.approvalDenied.rawValue)
+        exit(exitCode.rawValue)
     case let .terminatedByServer(reason):
         // Clean exit - server explicitly terminated this connection
         let message = reason ?? "Connection terminated by server"
         log.notice("CLI exiting: \(message)")
         fputs("RepoPrompt MCP: \(message)\n", stderr)
-        exit(MCPCLIExitCode.terminatedByServer.rawValue)
+        exit(exitCode.rawValue)
     case .hostDisconnected:
         // Host process died - exit cleanly without retry
         log.notice("CLI exiting: host disconnected")
-        exit(MCPCLIExitCode.ok.rawValue)
+        exit(exitCode.rawValue)
     }
 }
 

--- a/Sources/RepoPromptShared/MCP/BestEffortStderrWriter.swift
+++ b/Sources/RepoPromptShared/MCP/BestEffortStderrWriter.swift
@@ -10,21 +10,24 @@ import Foundation
 /// is broken, and Swift `do/catch` cannot intercept that exception, so a
 /// failed diagnostic write aborts the whole process. Transport diagnostics
 /// must never be able to crash the MCP helper, so this writer uses
-/// `Darwin.write` directly, loops on partial writes, and silently drops the
-/// payload when the destination is unavailable (`EPIPE`, `EBADF`, `EINVAL`,
-/// or any other write failure).
+/// `Darwin.write` directly and silently drops the payload when the destination
+/// is unavailable (`EPIPE`, `EBADF`, `EINVAL`, or any other write failure).
 public enum BestEffortStderrWriter {
+    private static let writeLock = NSLock()
+
     /// Writes `data` to `descriptor`, returning `true` only when every byte
     /// was delivered. Never throws and never raises: any failure other than
     /// an interrupted write drops the remaining payload.
+    ///
+    /// This legacy variant can block when the destination is a full pipe. Use
+    /// `writeNonBlocking(_:to:)` from terminal or deadline-enforcement paths.
     @discardableResult
     public static func write(_ data: Data, to descriptor: Int32 = STDERR_FILENO) -> Bool {
         guard descriptor >= 0 else { return false }
         guard !data.isEmpty else { return true }
-        // Suppress SIGPIPE on this descriptor so a peer-closed pipe surfaces
-        // as EPIPE from write(2) instead of terminating the process. Failure
-        // is acceptable: the write below still fails softly.
-        _ = fcntl(descriptor, F_SETNOSIGPIPE, 1)
+        writeLock.lock()
+        defer { writeLock.unlock() }
+        suppressSIGPIPE(on: descriptor)
         return data.withUnsafeBytes { rawBuffer in
             guard let baseAddress = rawBuffer.baseAddress else { return false }
             var offset = 0
@@ -39,5 +42,106 @@ public enum BestEffortStderrWriter {
             }
             return true
         }
+    }
+
+    /// Attempts one nonblocking write and drops any unwritten bytes.
+    ///
+    /// File-status flags belong to the shared open-file description, so even
+    /// a duplicated descriptor cannot isolate `O_NONBLOCK`. Serialize our
+    /// writers from this helper, keep the mutation window to one write syscall,
+    /// and restore the original status flags before returning. If another helper
+    /// writer owns the window, drop this payload rather than waiting. Writers
+    /// outside this helper can still observe the brief nonblocking window; no
+    /// POSIX primitive can make this transition private for pipes. Locking the C
+    /// `stderr` stream on its exact descriptor also avoids racing stdio writers
+    /// when that lock is immediately available.
+    @discardableResult
+    public static func writeNonBlocking(_ data: Data, to descriptor: Int32 = STDERR_FILENO) -> Bool {
+        guard descriptor >= 0 else { return false }
+        guard !data.isEmpty else { return true }
+        guard writeLock.try() else { return false }
+        defer { writeLock.unlock() }
+
+        let lockedStandardError = descriptor == STDERR_FILENO
+        if lockedStandardError, ftrylockfile(stderr) != 0 {
+            return false
+        }
+        defer {
+            if lockedStandardError { funlockfile(stderr) }
+        }
+
+        let originalFlags = fcntl(descriptor, F_GETFL)
+        guard originalFlags >= 0 else { return false }
+        let rawNoSIGPIPE = fcntl(descriptor, F_GETNOSIGPIPE)
+        let originalNoSIGPIPE = rawNoSIGPIPE >= 0 ? rawNoSIGPIPE : nil
+        let needsNoSIGPIPE = originalNoSIGPIPE == 0
+        if needsNoSIGPIPE,
+           fcntl(descriptor, F_SETNOSIGPIPE, 1) < 0
+        {
+            return false
+        }
+
+        let needsNonBlocking = originalFlags & O_NONBLOCK == 0
+        if needsNonBlocking,
+           fcntl(descriptor, F_SETFL, originalFlags | O_NONBLOCK) < 0
+        {
+            _ = restoreDiagnosticState(
+                descriptor: descriptor,
+                originalFlags: originalFlags,
+                restoreNonBlocking: false,
+                noSIGPIPE: needsNoSIGPIPE ? originalNoSIGPIPE : nil
+            )
+            return false
+        }
+
+        let writeSucceeded = data.withUnsafeBytes { rawBuffer in
+            guard let baseAddress = rawBuffer.baseAddress else { return false }
+            let written = Darwin.write(descriptor, baseAddress, rawBuffer.count)
+            return written == rawBuffer.count
+        }
+
+        // Restore every state bit we changed while holding our writer lock. Darwin may
+        // expose kernel-maintained bits through F_GETFL after a write. Read the
+        // latest flags and replace only O_NONBLOCK so unrelated concurrent flag
+        // changes are not clobbered. Restore the independently queried SIGPIPE
+        // setting too. Code that mutates O_NONBLOCK or F_SETNOSIGPIPE without
+        // this lock remains inherently racy at the POSIX open-description level.
+        let restoredState = restoreDiagnosticState(
+            descriptor: descriptor,
+            originalFlags: originalFlags,
+            restoreNonBlocking: needsNonBlocking,
+            noSIGPIPE: needsNoSIGPIPE ? originalNoSIGPIPE : nil
+        )
+        return writeSucceeded && restoredState
+    }
+
+    private static func restoreDiagnosticState(
+        descriptor: Int32,
+        originalFlags: Int32,
+        restoreNonBlocking: Bool,
+        noSIGPIPE: Int32?
+    ) -> Bool {
+        let restoredFlags: Bool
+        if restoreNonBlocking {
+            let latestFlags = fcntl(descriptor, F_GETFL)
+            if latestFlags >= 0 {
+                let flags = (latestFlags & ~O_NONBLOCK) | (originalFlags & O_NONBLOCK)
+                restoredFlags = fcntl(descriptor, F_SETFL, flags) >= 0
+            } else {
+                restoredFlags = false
+            }
+        } else {
+            restoredFlags = true
+        }
+
+        guard let noSIGPIPE else { return restoredFlags }
+        let restoredSIGPIPE = fcntl(descriptor, F_SETNOSIGPIPE, noSIGPIPE) >= 0
+        return restoredFlags && restoredSIGPIPE
+    }
+
+    private static func suppressSIGPIPE(on descriptor: Int32) {
+        // Failure is acceptable: callers also ignore SIGPIPE process-wide, and
+        // the write still fails softly when descriptor configuration is unavailable.
+        _ = fcntl(descriptor, F_SETNOSIGPIPE, 1)
     }
 }

--- a/Sources/RepoPromptShared/MCP/JSONRPCBridgeLedger.swift
+++ b/Sources/RepoPromptShared/MCP/JSONRPCBridgeLedger.swift
@@ -159,13 +159,12 @@ public enum MCPResponseDeliveryTracer {
     ) {
         guard event.terminalReason != nil || successTracingEnabled else { return }
         guard let data = "[MCPResponseDelivery] \(event)\n".data(using: .utf8) else { return }
-        lock.lock()
+        // Terminal tracing must not wait behind another diagnostic emitter or
+        // a full stderr pipe. Dropping a contended/unwritable trace is safer
+        // than delaying the transport's required terminal exit.
+        guard lock.try() else { return }
         defer { lock.unlock() }
-        // Terminal events are emitted even with success tracing disabled, so
-        // this path runs during transport failure handling when stderr may
-        // already be closed. Best-effort raw write; never FileHandle.write,
-        // whose ObjC exception on a broken pipe would abort the process.
-        BestEffortStderrWriter.write(data, to: descriptor)
+        BestEffortStderrWriter.writeNonBlocking(data, to: descriptor)
     }
 
     public static func sha256Hex(_ data: Data) -> String {
@@ -302,6 +301,23 @@ public struct JSONRPCBridgeLedgerSnapshot: Equatable, Sendable {
             && pendingTransactionCount == 0
             && terminalReason == nil
     }
+
+    public func canFinishSocketDrain(partialByteCount: Int) -> Bool {
+        terminalReason == nil
+            && activeRequestCount == 0
+            && pendingTransactionCount == 0
+            && partialByteCount == 0
+    }
+
+    public func socketDrainBlockerDescription(partialByteCount: Int) -> String {
+        [
+            "active_requests=\(activeRequestCount)",
+            "pending_transactions=\(pendingTransactionCount)",
+            "partial_bytes=\(max(0, partialByteCount))",
+            "response_in_delivery=\(responseInDeliveryCount)",
+            "terminal_reason=\(terminalReason ?? "none")"
+        ].joined(separator: " ")
+    }
 }
 
 public enum JSONRPCBridgeLedgerError: Swift.Error, Equatable, CustomStringConvertible {
@@ -331,6 +347,8 @@ public enum JSONRPCBridgeLedgerError: Swift.Error, Equatable, CustomStringConver
 }
 
 public actor JSONRPCBridgeLedger {
+    public static let postStdinHalfCloseDrainDeadlineExceededReason = "post_stdin_half_close_drain_deadline_exceeded"
+
     public struct Configuration: Equatable, Sendable {
         public var cancellationTombstoneTTL: TimeInterval
         public var maximumCancellationTombstones: Int
@@ -845,6 +863,24 @@ public actor JSONRPCBridgeLedger {
         }
         emit(phase: "clean_eof", direction: direction, messages: [], prepared: nil, terminalReason: nil)
         return .clean
+    }
+
+    @discardableResult
+    public func terminalizePostStdinHalfCloseDrainDeadline() -> String {
+        if let terminalReason {
+            return terminalReason
+        }
+
+        let reason = Self.postStdinHalfCloseDrainDeadlineExceededReason
+        _ = failTerminal(reason)
+        emit(
+            phase: "post_stdin_half_close_drain_deadline_exceeded",
+            direction: .serverToClient,
+            messages: [],
+            prepared: nil,
+            terminalReason: reason
+        )
+        return reason
     }
 
     public func recordConnectionFailure(_ reason: String) -> Bool {

--- a/Sources/RepoPromptShared/MCP/MCPTimeoutPolicy.swift
+++ b/Sources/RepoPromptShared/MCP/MCPTimeoutPolicy.swift
@@ -11,6 +11,9 @@ public enum MCPTimeoutPolicy {
         workspaceSwitchToolExecutionDeadlineSeconds
     )
 
+    /// Allows the 120-second workspace-switch window, 5-second cleanup grace, and 25 seconds of transport margin.
+    public static let postStdinHalfCloseBridgeDrainDeadlineSeconds = 150
+
     public static let boundedToolCancellationCleanupGraceSeconds = 5
     public static let boundedToolCancellationCleanupGrace: Duration = .seconds(boundedToolCancellationCleanupGraceSeconds)
 

--- a/Tests/RepoPromptTests/Chat/OracleMessageFinalisationHubTests.swift
+++ b/Tests/RepoPromptTests/Chat/OracleMessageFinalisationHubTests.swift
@@ -1,0 +1,127 @@
+import Foundation
+@testable import RepoPrompt
+import XCTest
+
+final class OracleMessageFinalisationHubTests: XCTestCase {
+    func testWaiterCancellationIsLocalAndDoesNotCompleteMessage() async {
+        let hub = MessageFinalisationHub()
+        let messageID = UUID()
+        let cancelledWaiterID = UUID()
+        let retainedWaiterID = UUID()
+        let futureWaiterID = UUID()
+        let cancelledSignal = OracleFinalisationWaiterSignal()
+        let retainedSignal = OracleFinalisationWaiterSignal()
+        let futureSignal = OracleFinalisationWaiterSignal()
+
+        let cancelledWaiter = makeWaiter(
+            hub: hub,
+            messageID: messageID,
+            waiterID: cancelledWaiterID,
+            signal: cancelledSignal
+        )
+        let retainedWaiter = makeWaiter(
+            hub: hub,
+            messageID: messageID,
+            waiterID: retainedWaiterID,
+            signal: retainedSignal
+        )
+
+        await Task.yield()
+        await hub.cancel(messageID, waiterID: cancelledWaiterID)
+        await cancelledWaiter.value
+
+        let completedAfterCancellation = await hub.isCompleted(messageID)
+        let retainedResumedAfterCancellation = await retainedSignal.isMarked()
+        XCTAssertFalse(completedAfterCancellation)
+        XCTAssertFalse(retainedResumedAfterCancellation)
+
+        let futureWaiter = makeWaiter(
+            hub: hub,
+            messageID: messageID,
+            waiterID: futureWaiterID,
+            signal: futureSignal
+        )
+        await Task.yield()
+        let futureResumedBeforeFulfilment = await futureSignal.isMarked()
+        XCTAssertFalse(futureResumedBeforeFulfilment)
+
+        await hub.fulfil(messageID)
+        await retainedWaiter.value
+        await futureWaiter.value
+
+        let completedAfterFulfilment = await hub.isCompleted(messageID)
+        let retainedResumedAfterFulfilment = await retainedSignal.isMarked()
+        let futureResumedAfterFulfilment = await futureSignal.isMarked()
+        XCTAssertTrue(completedAfterFulfilment)
+        XCTAssertTrue(retainedResumedAfterFulfilment)
+        XCTAssertTrue(futureResumedAfterFulfilment)
+    }
+
+    func testCancellationBeforeRegistrationResumesOnlyMatchingWaiter() async {
+        let hub = MessageFinalisationHub()
+        let messageID = UUID()
+        let cancelledWaiterID = UUID()
+        let retainedWaiterID = UUID()
+        let cancelledSignal = OracleFinalisationWaiterSignal()
+        let retainedSignal = OracleFinalisationWaiterSignal()
+
+        await hub.cancel(messageID, waiterID: cancelledWaiterID)
+        let cancelledWaiter = makeWaiter(
+            hub: hub,
+            messageID: messageID,
+            waiterID: cancelledWaiterID,
+            signal: cancelledSignal
+        )
+        let retainedWaiter = makeWaiter(
+            hub: hub,
+            messageID: messageID,
+            waiterID: retainedWaiterID,
+            signal: retainedSignal
+        )
+
+        await cancelledWaiter.value
+        let cancelledResumed = await cancelledSignal.isMarked()
+        let retainedResumedBeforeFulfilment = await retainedSignal.isMarked()
+        let completedBeforeFulfilment = await hub.isCompleted(messageID)
+        XCTAssertTrue(cancelledResumed)
+        XCTAssertFalse(retainedResumedBeforeFulfilment)
+        XCTAssertFalse(completedBeforeFulfilment)
+
+        await hub.fulfil(messageID)
+        await retainedWaiter.value
+        let retainedResumedAfterFulfilment = await retainedSignal.isMarked()
+        XCTAssertTrue(retainedResumedAfterFulfilment)
+    }
+
+    private func makeWaiter(
+        hub: MessageFinalisationHub,
+        messageID: UUID,
+        waiterID: UUID,
+        signal: OracleFinalisationWaiterSignal
+    ) -> Task<Void, Never> {
+        Task {
+            await withCheckedContinuation { continuation in
+                Task {
+                    await hub.register(
+                        messageID,
+                        waiterID: waiterID,
+                        cont: continuation
+                    )
+                }
+            }
+            await signal.mark()
+        }
+    }
+}
+
+private actor OracleFinalisationWaiterSignal {
+    private var marked = false
+
+    func mark() {
+        marked = true
+    }
+
+    func isMarked() -> Bool {
+        marked
+    }
+}

--- a/Tests/RepoPromptTests/ContextBuilder/ContextBuilderFollowUpFinalizationMonitorTests.swift
+++ b/Tests/RepoPromptTests/ContextBuilder/ContextBuilderFollowUpFinalizationMonitorTests.swift
@@ -1,0 +1,322 @@
+import Foundation
+@testable import RepoPrompt
+import XCTest
+
+final class ContextBuilderFollowUpFinalizationMonitorTests: XCTestCase {
+    func testInjectedClockResetsInactivityOnlyForMeaningfulActivity() async {
+        let configuration = ContextBuilderFollowUpFinalizationConfiguration(
+            overallTimeout: 100,
+            inactivityTimeout: 10,
+            checkInterval: 1
+        )
+        let state = ContextBuilderFollowUpFinalizationState(startedAt: 0)
+
+        let initialTimeout = await state.timeoutSnapshot(at: 9, configuration: configuration)
+        XCTAssertNil(initialTimeout)
+
+        let watchdogUpdate = await state.record(
+            OracleMessageLifecycleActivityEvent(kind: .finalizationWatchdogFired),
+            at: 9
+        )
+        XCTAssertEqual(watchdogUpdate.phase, .streaming)
+        let timeoutBeforeDeadline = await state.timeoutSnapshot(at: 9.5, configuration: configuration)
+        XCTAssertNil(timeoutBeforeDeadline)
+
+        let timeoutWithoutMeaningfulActivity = await state.timeoutSnapshot(
+            at: 10,
+            configuration: configuration
+        )
+        XCTAssertEqual(timeoutWithoutMeaningfulActivity?.kind, .inactivity)
+        XCTAssertEqual(timeoutWithoutMeaningfulActivity?.lastEvent, "Oracle finalization watchdog fired")
+
+        let finalizationUpdate = await state.record(
+            OracleMessageLifecycleActivityEvent(kind: .providerStopObserved),
+            at: 10
+        )
+        XCTAssertTrue(finalizationUpdate.shouldTransitionToFinalization)
+        XCTAssertEqual(finalizationUpdate.phase, .messageFinalization)
+        let timeoutBeforeFinalizationDeadline = await state.timeoutSnapshot(
+            at: 19.9,
+            configuration: configuration
+        )
+        XCTAssertNil(timeoutBeforeFinalizationDeadline)
+
+        let timeoutAfterFinalizationStalls = await state.timeoutSnapshot(
+            at: 20,
+            configuration: configuration
+        )
+        XCTAssertEqual(timeoutAfterFinalizationStalls?.kind, .inactivity)
+        XCTAssertEqual(
+            timeoutAfterFinalizationStalls?.lastKnownSubphase,
+            ContextBuilderMCPProgressPhase.messageFinalization.displayName
+        )
+    }
+
+    func testStalledFakeQueryTimesOutWithAttributedSubphaseAndCancelsStream() async {
+        let clock = ContextBuilderFinalizationTestClock()
+        let cancellationRecorder = ContextBuilderFinalizationCancellationRecorder()
+        let (events, continuation) = AsyncStream<OracleMessageLifecycleActivityEvent>.makeStream()
+        defer { continuation.finish() }
+
+        do {
+            try await ContextBuilderFollowUpFinalizationMonitor.wait(
+                activityEvents: events,
+                configuration: ContextBuilderFollowUpFinalizationConfiguration(
+                    overallTimeout: 100,
+                    inactivityTimeout: 10,
+                    checkInterval: 5
+                ),
+                clock: { clock.now() },
+                sleep: { seconds in
+                    clock.advance(by: seconds)
+                    await Task.yield()
+                },
+                waitForFinalization: {
+                    try await Task.sleep(for: .seconds(60))
+                },
+                cancelStreaming: {
+                    await cancellationRecorder.recordCancellation()
+                }
+            )
+            XCTFail("Expected an inactivity timeout")
+        } catch is CancellationError {
+            XCTFail("Expected an attributed timeout, not cancellation")
+        } catch {
+            let description = error.localizedDescription
+            XCTAssertTrue(description.contains("no streaming/finalization activity"), description)
+            XCTAssertTrue(description.contains("Oracle response streaming"), description)
+        }
+
+        let cancellationCount = await cancellationRecorder.count()
+        XCTAssertEqual(cancellationCount, 1)
+    }
+
+    func testTimeoutOutcomeWinsWhenCancellationAlsoCompletesFinalization() async {
+        let clock = ContextBuilderFinalizationTestClock()
+        let finalizationGate = ContextBuilderCancellableFinalizationGate()
+        let cancellationDelay = ContextBuilderFinalizationTestGate()
+        let cancellationStarted = expectation(description: "stream cancellation started")
+        let (events, continuation) = AsyncStream<OracleMessageLifecycleActivityEvent>.makeStream()
+        defer { continuation.finish() }
+
+        let monitor = Task { () -> Result<Void, Error> in
+            do {
+                try await ContextBuilderFollowUpFinalizationMonitor.wait(
+                    activityEvents: events,
+                    configuration: ContextBuilderFollowUpFinalizationConfiguration(
+                        overallTimeout: 100,
+                        inactivityTimeout: 10,
+                        checkInterval: 10
+                    ),
+                    clock: { clock.now() },
+                    sleep: { seconds in
+                        clock.advance(by: seconds)
+                        await Task.yield()
+                    },
+                    waitForFinalization: {
+                        try await finalizationGate.wait()
+                    },
+                    cancelStreaming: {
+                        await finalizationGate.complete()
+                        cancellationStarted.fulfill()
+                        await cancellationDelay.arriveAndWait()
+                    }
+                )
+                return .success(())
+            } catch {
+                return .failure(error)
+            }
+        }
+
+        await fulfillment(of: [cancellationStarted], timeout: 1)
+        await cancellationDelay.release()
+
+        switch await monitor.value {
+        case .success:
+            XCTFail("Timeout must remain authoritative after cancellation completes finalization")
+        case let .failure(error):
+            let description = error.localizedDescription
+            XCTAssertTrue(description.contains("no streaming/finalization activity"), description)
+        }
+    }
+
+    func testFastFinalizationStillReportsMessageFinalizationPhase() async throws {
+        let recorder = ContextBuilderFinalizationProgressRecorder()
+        let (events, continuation) = AsyncStream<OracleMessageLifecycleActivityEvent>.makeStream()
+        defer { continuation.finish() }
+
+        try await ContextBuilderFollowUpFinalizationMonitor.wait(
+            activityEvents: events,
+            configuration: ContextBuilderFollowUpFinalizationConfiguration(
+                overallTimeout: 100,
+                inactivityTimeout: 10,
+                checkInterval: 60
+            ),
+            waitForFinalization: {},
+            cancelStreaming: {},
+            reportPhase: { phase in
+                await recorder.recordPhase(phase)
+            }
+        )
+
+        let snapshot = await recorder.snapshot()
+        XCTAssertEqual(snapshot.phases, [.messageFinalization])
+    }
+
+    func testOracleWatchdogAndFinalizationEventsReachProgressCallbacks() async throws {
+        let activityExpectation = expectation(description: "Oracle activity events reported")
+        activityExpectation.expectedFulfillmentCount = 2
+        let finalizationPhaseExpectation = expectation(description: "Finalization phase reported")
+        let recorder = ContextBuilderFinalizationProgressRecorder()
+        let finalizationGate = ContextBuilderFinalizationTestGate()
+        let (events, continuation) = AsyncStream<OracleMessageLifecycleActivityEvent>.makeStream()
+        continuation.yield(OracleMessageLifecycleActivityEvent(kind: .finalizationWatchdogArmed))
+        continuation.yield(OracleMessageLifecycleActivityEvent(kind: .providerStopObserved))
+
+        let monitor = Task {
+            try await ContextBuilderFollowUpFinalizationMonitor.wait(
+                activityEvents: events,
+                configuration: ContextBuilderFollowUpFinalizationConfiguration(
+                    overallTimeout: 100,
+                    inactivityTimeout: 10,
+                    checkInterval: 60
+                ),
+                waitForFinalization: {
+                    await finalizationGate.arriveAndWait()
+                },
+                cancelStreaming: {},
+                reportPhase: { phase in
+                    await recorder.recordPhase(phase)
+                    finalizationPhaseExpectation.fulfill()
+                },
+                reportActivity: { phase, message in
+                    await recorder.recordActivity(phase: phase, message: message)
+                    activityExpectation.fulfill()
+                }
+            )
+        }
+
+        await fulfillment(of: [activityExpectation, finalizationPhaseExpectation], timeout: 1)
+        await finalizationGate.release()
+        continuation.finish()
+        try await monitor.value
+
+        let snapshot = await recorder.snapshot()
+        XCTAssertEqual(snapshot.phases, [.messageFinalization])
+        XCTAssertEqual(snapshot.activities.map(\.phase), [.streaming, .messageFinalization])
+        XCTAssertEqual(snapshot.activities.map(\.message), [
+            "Oracle finalization watchdog armed",
+            "Oracle provider stop observed"
+        ])
+    }
+}
+
+private final class ContextBuilderFinalizationTestClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: TimeInterval = 0
+
+    func now() -> TimeInterval {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
+    }
+
+    func advance(by interval: TimeInterval) {
+        lock.lock()
+        value += interval
+        lock.unlock()
+    }
+}
+
+private actor ContextBuilderFinalizationCancellationRecorder {
+    private var cancellationCount = 0
+
+    func recordCancellation() {
+        cancellationCount += 1
+    }
+
+    func count() -> Int {
+        cancellationCount
+    }
+}
+
+private actor ContextBuilderFinalizationProgressRecorder {
+    struct Activity: Equatable {
+        let phase: ContextBuilderMCPProgressPhase
+        let message: String
+    }
+
+    private var phases: [ContextBuilderMCPProgressPhase] = []
+    private var activities: [Activity] = []
+
+    func recordPhase(_ phase: ContextBuilderMCPProgressPhase) {
+        phases.append(phase)
+    }
+
+    func recordActivity(phase: ContextBuilderMCPProgressPhase, message: String) {
+        activities.append(Activity(phase: phase, message: message))
+    }
+
+    func snapshot() -> (phases: [ContextBuilderMCPProgressPhase], activities: [Activity]) {
+        (phases, activities)
+    }
+}
+
+private actor ContextBuilderCancellableFinalizationGate {
+    private var completed = false
+    private var cancelled = false
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    func wait() async throws {
+        await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                Task { await self.register(continuation) }
+            }
+        } onCancel: {
+            Task { await self.cancel() }
+        }
+        try Task.checkCancellation()
+    }
+
+    func complete() {
+        completed = true
+        continuation?.resume()
+        continuation = nil
+    }
+
+    private func register(_ continuation: CheckedContinuation<Void, Never>) {
+        if completed || cancelled {
+            continuation.resume()
+        } else {
+            self.continuation = continuation
+        }
+    }
+
+    private func cancel() {
+        cancelled = true
+        continuation?.resume()
+        continuation = nil
+    }
+}
+
+private actor ContextBuilderFinalizationTestGate {
+    private var released = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func arriveAndWait() async {
+        guard !released else { return }
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+
+    func release() {
+        guard !released else { return }
+        released = true
+        let currentWaiters = waiters
+        waiters.removeAll()
+        for waiter in currentWaiters {
+            waiter.resume()
+        }
+    }
+}

--- a/Tests/RepoPromptTests/ContextBuilder/ContextBuilderMCPProgressTimelineTests.swift
+++ b/Tests/RepoPromptTests/ContextBuilder/ContextBuilderMCPProgressTimelineTests.swift
@@ -1,0 +1,659 @@
+import Foundation
+@testable import RepoPrompt
+import XCTest
+
+final class ContextBuilderMCPProgressTimelineTests: XCTestCase {
+    func testPhaseCatalogCoversExpectedDiscoveryAndGenerationSequence() {
+        XCTAssertEqual(ContextBuilderMCPProgressPhase.allCases, [
+            .readFileAutoSelectionFinish,
+            .tabContextCommit,
+            .statePersistence,
+            .childConnectionTermination,
+            .childConnectionTerminationJoin,
+            .runFinalization,
+            .modelResolution,
+            .payloadPackaging,
+            .sessionCreationAndPersist,
+            .messageSend,
+            .activeQueryAcquisition,
+            .streaming,
+            .messageFinalization
+        ])
+        XCTAssertEqual(
+            ContextBuilderMCPProgressPhase.allCases.map(\.stage),
+            Array(repeating: "discovering", count: 6) + Array(repeating: "generating", count: 7)
+        )
+    }
+
+    func testTimelineEmitsTimedTransitionsAndUsesCurrentSubphaseForHeartbeat() async {
+        let clock = ContextBuilderProgressTestClock()
+        let recorder = ContextBuilderProgressEventRecorder()
+        let timeline = ContextBuilderMCPProgressTimeline(
+            clock: { clock.now() },
+            sink: { event in await recorder.record(event) }
+        )
+
+        await timeline.transition(to: .modelResolution)
+        clock.advance(by: 1.25)
+
+        let heartbeat = await timeline.heartbeat(
+            fallbackStage: "generating",
+            fallbackMessage: "Still generating plan..."
+        )
+        XCTAssertEqual(heartbeat.stage, "generating")
+        XCTAssertTrue(heartbeat.message.contains("follow-up model resolution"), heartbeat.message)
+        XCTAssertTrue(heartbeat.message.contains("phase 1.250s"), heartbeat.message)
+
+        await timeline.transition(to: .payloadPackaging)
+        clock.advance(by: 0.5)
+        await timeline.finishCurrentPhase()
+
+        let events = await recorder.snapshot()
+        XCTAssertEqual(events.map(\.kind), [.started, .completed, .started, .completed])
+        XCTAssertEqual(events.map(\.phase), [
+            .modelResolution,
+            .modelResolution,
+            .payloadPackaging,
+            .payloadPackaging
+        ])
+        XCTAssertEqual(events.map(\.stage), ["generating", "generating", "generating", "generating"])
+        XCTAssertEqual(events[1].phaseElapsed, 1.25, accuracy: 0.000_1)
+        XCTAssertEqual(events[3].phaseElapsed, 0.5, accuracy: 0.000_1)
+        XCTAssertTrue(events[1].message.contains("completed in 1.250s"), events[1].message)
+        XCTAssertTrue(events[3].message.contains("total 1.750s"), events[3].message)
+    }
+
+    func testSuspendingSinkPreservesEveryTimedTransitionWhenItReentersTimeline() async {
+        let clock = ContextBuilderProgressTestClock()
+        let timelineReference = ContextBuilderProgressTimelineReference()
+        let sink = ContextBuilderSuspendingProgressSink(
+            suspendedKind: .completed,
+            suspendedPhase: .modelResolution,
+            reentrantAction: {
+                clock.advance(by: 0.75)
+                guard let timeline = timelineReference.timeline() else { return }
+                await timeline.transition(to: .sessionCreationAndPersist)
+            }
+        )
+        let timeline = ContextBuilderMCPProgressTimeline(
+            clock: { clock.now() },
+            sink: { event in await sink.receive(event) }
+        )
+        timelineReference.setTimeline(timeline)
+
+        await timeline.transition(to: .modelResolution)
+        clock.advance(by: 1.25)
+        let payloadTransition = Task {
+            await timeline.transition(to: .payloadPackaging)
+        }
+        await sink.waitUntilSuspended()
+
+        let heartbeat = await timeline.heartbeat(
+            fallbackStage: "generating",
+            fallbackMessage: "fallback"
+        )
+        XCTAssertTrue(
+            heartbeat.message.contains(ContextBuilderMCPProgressPhase.sessionCreationAndPersist.displayName),
+            heartbeat.message
+        )
+
+        await sink.release()
+        await payloadTransition.value
+        await timeline.flush()
+
+        let events = await sink.snapshot()
+        XCTAssertEqual(events.map(\.kind), [
+            .started,
+            .completed,
+            .started,
+            .completed,
+            .started
+        ])
+        XCTAssertEqual(events.map(\.phase), [
+            .modelResolution,
+            .modelResolution,
+            .payloadPackaging,
+            .payloadPackaging,
+            .sessionCreationAndPersist
+        ])
+        XCTAssertEqual(events[1].phaseElapsed, 1.25, accuracy: 0.000_1)
+        XCTAssertEqual(events[3].phaseElapsed, 0.75, accuracy: 0.000_1)
+        for phase in [
+            ContextBuilderMCPProgressPhase.modelResolution,
+            .payloadPackaging
+        ] {
+            guard let startIndex = events.firstIndex(where: {
+                $0.kind == .started && $0.phase == phase
+            }),
+                let completionIndex = events.firstIndex(where: {
+                    $0.kind == .completed && $0.phase == phase
+                })
+            else {
+                XCTFail("Missing start/completion pair for \(phase)")
+                continue
+            }
+            XCTAssertLessThan(startIndex, completionIndex)
+        }
+    }
+
+    func testSoftStageBoundEmitsOnceWithoutFailingTimeline() async {
+        let clock = ContextBuilderProgressTestClock()
+        let recorder = ContextBuilderProgressEventRecorder()
+        let timeline = ContextBuilderMCPProgressTimeline(
+            clock: { clock.now() },
+            sleep: { _ in try await Task.sleep(for: .seconds(60)) },
+            sink: { event in await recorder.record(event) }
+        )
+
+        await timeline.transition(to: .modelResolution)
+        clock.advance(by: 2.5)
+        await timeline.checkSoftBound()
+        await timeline.checkSoftBound()
+        await timeline.reportActivity(
+            phase: .modelResolution,
+            message: "Model registry lookup still running"
+        )
+        await timeline.finishCurrentPhase()
+
+        let events = await recorder.snapshot()
+        XCTAssertEqual(events.map(\.kind), [.started, .softBoundExceeded, .activity, .completed])
+        XCTAssertEqual(events.count { $0.kind == .softBoundExceeded }, 1)
+        XCTAssertTrue(events[1].message.contains("soft bound 2.000s"), events[1].message)
+        XCTAssertEqual(events.last?.phaseElapsed ?? 0, 2.5, accuracy: 0.000_1)
+    }
+
+    @MainActor
+    func testRunMCPPlanOrQuestionReportsProductionPhaseSequenceThroughFinalization() async throws {
+        #if DEBUG
+            let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
+            GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
+            let composition = WindowStateCompositionFactory.make(
+                windowID: -76,
+                deferredInitialAgentSystemWorkspaceRefresh: true,
+                sharedMCPService: MCPService(),
+                aiQueriesServiceFactory: { keyManager in
+                    AIQueriesService(
+                        keyManager: keyManager,
+                        sendPromptOverride: { _, _ in
+                            let stream = AsyncThrowingStream<ChatStreamOutput, Error> { continuation in
+                                continuation.yield(ChatStreamOutput(
+                                    text: "deterministic follow-up",
+                                    reasoning: nil,
+                                    tokens: ChatTokenInfo(),
+                                    isFinal: true
+                                ))
+                                continuation.finish()
+                            }
+                            return (UUID(), stream)
+                        }
+                    )
+                }
+            )
+            GlobalSettingsStore.shared.setMCPAutoStart(previousAutoStart, commit: false)
+            await composition.workspaceManager.awaitInitialized()
+
+            let root = FileManager.default.temporaryDirectory
+                .appendingPathComponent("ContextBuilderMCPFollowUpTimelineTests-\(UUID().uuidString)")
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: root) }
+
+            let workspace = composition.workspaceManager.createWorkspace(
+                name: "Context Builder follow-up timeline test",
+                repoPaths: [root.path],
+                ephemeral: true
+            )
+            await composition.workspaceManager.switchWorkspace(
+                to: workspace,
+                saveState: false,
+                reason: "ContextBuilderMCPProgressTimelineTests.runMCPPlanOrQuestion"
+            )
+            let activeWorkspace = try XCTUnwrap(composition.workspaceManager.activeWorkspace)
+            let tabID = try XCTUnwrap(
+                activeWorkspace.activeComposeTabID ?? activeWorkspace.composeTabs.first?.id
+            )
+
+            let viewModel = composition.contextBuilderAgentViewModel
+            viewModel.installRunTestHooks(
+                ContextBuilderAgentViewModel.RunTestHooks(
+                    beforeProcessingProviderEvent: nil,
+                    providerEventDisposition: nil,
+                    teardownCompleted: nil,
+                    resolveMCPFollowUpModel: { _ in
+                        (
+                            model: .customProvider(
+                                name: "Unconfigured test provider",
+                                provider: "custom",
+                                model: "unconfigured-test-model"
+                            ),
+                            chatPresetID: nil,
+                            mcpControlInfo: nil
+                        )
+                    }
+                )
+            )
+            defer { viewModel.installRunTestHooks(nil) }
+
+            let recorder = ContextBuilderProgressPhaseRecorder()
+            let reply = try await viewModel.runMCPPlanOrQuestion(
+                for: tabID,
+                oracleViewModel: composition.oracleViewModel,
+                mode: .plan,
+                prompt: "Summarize the selected context.",
+                selection: StoredSelection(),
+                progressReporter: { phase in
+                    await recorder.record(phase)
+                }
+            )
+
+            XCTAssertEqual(reply.mode, "plan")
+            XCTAssertEqual(reply.response, "deterministic follow-up")
+            let phases = await recorder.snapshot()
+            XCTAssertEqual(phases, [
+                .modelResolution,
+                .payloadPackaging,
+                .sessionCreationAndPersist,
+                .messageSend,
+                .activeQueryAcquisition,
+                .streaming,
+                .messageFinalization
+            ])
+        #else
+            throw XCTSkip("Production follow-up phase injection is DEBUG-only.")
+        #endif
+    }
+
+    @MainActor
+    func testContextBuilderToolProviderReportsDiscoveryAndGenerationStageEnvelope() async throws {
+        #if DEBUG
+            let provider = ContextBuilderImmediateCompletionProvider()
+            let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
+            GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
+            let window = WindowState { _, _, _ in provider }
+            GlobalSettingsStore.shared.setMCPAutoStart(previousAutoStart, commit: false)
+            WindowStatesManager.shared.registerWindowState(window)
+            defer { WindowStatesManager.shared.unregisterWindowState(window) }
+            await window.workspaceManager.awaitInitialized()
+
+            let root = FileManager.default.temporaryDirectory
+                .appendingPathComponent("ContextBuilderProviderTimelineTests-\(UUID().uuidString)")
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: root) }
+
+            let workspace = window.workspaceManager.createWorkspace(
+                name: "Context Builder provider timeline test",
+                repoPaths: [root.path],
+                ephemeral: true
+            )
+            await window.workspaceManager.switchWorkspace(
+                to: workspace,
+                saveState: false,
+                reason: "ContextBuilderMCPProgressTimelineTests.providerPath"
+            )
+
+            let activeWorkspace = try XCTUnwrap(window.workspaceManager.activeWorkspace)
+            let tabID = try XCTUnwrap(
+                activeWorkspace.activeComposeTabID ?? activeWorkspace.composeTabs.first?.id
+            )
+            var tab = try XCTUnwrap(window.workspaceManager.composeTab(with: tabID))
+            tab.promptText = "Provider-path follow-up prompt"
+            window.workspaceManager.updateComposeTab(tab, markDirty: false)
+            window.promptManager.promptText = tab.promptText
+
+            let stageRecorder = ContextBuilderProviderStageRecorder()
+            window.mcpServer.installStageProgressSinkForTesting { _, tool, stage, message in
+                guard tool == MCPWindowToolName.contextBuilder else { return }
+                await stageRecorder.record(stage: stage, message: message)
+            }
+            defer { window.mcpServer.installStageProgressSinkForTesting(nil) }
+
+            let followUpRecorder = ContextBuilderFollowUpInvocationRecorder()
+            window.contextBuilderAgentViewModel.installRunTestHooks(
+                ContextBuilderAgentViewModel.RunTestHooks(
+                    beforeProcessingProviderEvent: nil,
+                    providerEventDisposition: nil,
+                    teardownCompleted: nil,
+                    runMCPFollowUp: { mode, prompt, selection in
+                        await followUpRecorder.record(
+                            mode: mode,
+                            prompt: prompt,
+                            selection: selection
+                        )
+                        let chatID = UUID()
+                        return ChatSendReply(
+                            chatId: chatID,
+                            shortId: String(chatID.uuidString.prefix(8)).lowercased(),
+                            mode: mode.mcpModeName,
+                            response: "deterministic provider follow-up",
+                            errors: nil
+                        )
+                    }
+                )
+            )
+            defer { window.contextBuilderAgentViewModel.installRunTestHooks(nil) }
+
+            let tools = await window.mcpServer.windowMCPTools
+            let contextBuilder = try XCTUnwrap(
+                tools.first { $0.name == MCPWindowToolName.contextBuilder }
+            )
+            _ = try await contextBuilder([
+                "instructions": .string("Inspect the test workspace."),
+                "response_type": .string("plan"),
+                "context_id": .string(tabID.uuidString)
+            ])
+
+            let recordedInvocation = await followUpRecorder.snapshot()
+            let invocation = try XCTUnwrap(recordedInvocation)
+            XCTAssertEqual(invocation.mode, .plan)
+            XCTAssertEqual(invocation.prompt, "Provider-path follow-up prompt")
+            XCTAssertTrue(invocation.selection.selectedPaths.isEmpty)
+
+            let stages = await stageRecorder.snapshot()
+            let envelopeStages = stages
+                .map(\.stage)
+                .filter { ["discovering", "discovered", "generating", "complete"].contains($0) }
+                .reduce(into: [String]()) { collapsed, stage in
+                    if collapsed.last != stage {
+                        collapsed.append(stage)
+                    }
+                }
+            XCTAssertEqual(envelopeStages, [
+                "discovering",
+                "discovered",
+                "generating",
+                "complete"
+            ])
+        #else
+            throw XCTSkip("Provider-path Context Builder injection is DEBUG-only.")
+        #endif
+    }
+
+    @MainActor
+    func testCommitAndClearTabContextReportsPersistenceSubphasesInOrder() async throws {
+        let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
+        GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
+        let window = WindowState()
+        GlobalSettingsStore.shared.setMCPAutoStart(previousAutoStart, commit: false)
+        WindowStatesManager.shared.registerWindowState(window)
+        defer { WindowStatesManager.shared.unregisterWindowState(window) }
+
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ContextBuilderMCPProgressTimelineTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let workspace = window.workspaceManager.createWorkspace(
+            name: "Context Builder progress test",
+            repoPaths: [root.path],
+            ephemeral: true
+        )
+        await window.workspaceManager.switchWorkspace(
+            to: workspace,
+            saveState: false,
+            reason: "ContextBuilderMCPProgressTimelineTests"
+        )
+
+        let activeWorkspace = try XCTUnwrap(window.workspaceManager.activeWorkspace)
+        let tabID = try XCTUnwrap(
+            activeWorkspace.activeComposeTabID ?? activeWorkspace.composeTabs.first?.id
+        )
+        let connectionID = UUID()
+        try window.mcpServer.bindTabForConnection(
+            connectionID: connectionID,
+            clientName: "context-builder-progress-test",
+            tabID: tabID,
+            workspaceID: activeWorkspace.id,
+            windowID: window.windowID
+        )
+
+        let recorder = ContextBuilderProgressPhaseRecorder()
+        await window.mcpServer.commitAndClearTabContext(
+            connectionID: connectionID,
+            progressReporter: { phase in
+                await recorder.record(phase)
+            }
+        )
+
+        let phases = await recorder.snapshot()
+        XCTAssertEqual(phases, [
+            .readFileAutoSelectionFinish,
+            .tabContextCommit,
+            .statePersistence
+        ])
+    }
+
+    @MainActor
+    func testDeferredRunMappingSurvivesCommitUntilCallerCleanup() async throws {
+        let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
+        GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
+        let window = WindowState()
+        GlobalSettingsStore.shared.setMCPAutoStart(previousAutoStart, commit: false)
+        WindowStatesManager.shared.registerWindowState(window)
+        defer { WindowStatesManager.shared.unregisterWindowState(window) }
+
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ContextBuilderDeferredMappingTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let workspace = window.workspaceManager.createWorkspace(
+            name: "Context Builder deferred mapping test",
+            repoPaths: [root.path],
+            ephemeral: true
+        )
+        await window.workspaceManager.switchWorkspace(
+            to: workspace,
+            saveState: false,
+            reason: "ContextBuilderMCPProgressTimelineTests.deferredMapping"
+        )
+
+        let activeWorkspace = try XCTUnwrap(window.workspaceManager.activeWorkspace)
+        let tabID = try XCTUnwrap(
+            activeWorkspace.activeComposeTabID ?? activeWorkspace.composeTabs.first?.id
+        )
+        let connectionID = UUID()
+        let runID = UUID()
+        try window.mcpServer.bindTabForConnection(
+            connectionID: connectionID,
+            clientName: "context-builder-deferred-mapping-test",
+            tabID: tabID,
+            workspaceID: activeWorkspace.id,
+            windowID: window.windowID,
+            runID: runID
+        )
+        XCTAssertTrue(window.mcpServer.hasRunID(runID))
+
+        await window.mcpServer.commitAndClearTabContext(
+            connectionID: connectionID,
+            expectedRunID: runID,
+            deferRunMappingCleanupUntilCaller: true
+        )
+        XCTAssertTrue(window.mcpServer.hasRunID(runID))
+
+        window.mcpServer.removeTabContext(
+            forConnectionID: connectionID,
+            clientName: "context-builder-deferred-mapping-test",
+            windowID: window.windowID,
+            runID: runID
+        )
+        XCTAssertFalse(window.mcpServer.hasRunID(runID))
+    }
+}
+
+private final class ContextBuilderImmediateCompletionProvider: HeadlessAgentProvider {
+    func streamAgentMessage(
+        _ message: AgentMessage,
+        runID: UUID?
+    ) async throws -> AsyncThrowingStream<AIStreamResult, Error> {
+        _ = message
+        let stream = AsyncThrowingStream<AIStreamResult, Error> { continuation in
+            continuation.yield(AIStreamResult(type: "content", text: "Discovery complete"))
+            continuation.finish()
+        }
+        if let runID {
+            await MCPRoutingWaiter.notifyRouted(runID: runID)
+        }
+        return stream
+    }
+
+    func dispose() async {}
+}
+
+private actor ContextBuilderProviderStageRecorder {
+    struct Entry {
+        let stage: String
+        let message: String
+    }
+
+    private var entries: [Entry] = []
+
+    func record(stage: String, message: String) {
+        entries.append(Entry(stage: stage, message: message))
+    }
+
+    func snapshot() -> [Entry] {
+        entries
+    }
+}
+
+private actor ContextBuilderFollowUpInvocationRecorder {
+    struct Invocation {
+        let mode: HeadlessMode
+        let prompt: String
+        let selection: StoredSelection
+    }
+
+    private var invocation: Invocation?
+
+    func record(mode: HeadlessMode, prompt: String, selection: StoredSelection) {
+        invocation = Invocation(mode: mode, prompt: prompt, selection: selection)
+    }
+
+    func snapshot() -> Invocation? {
+        invocation
+    }
+}
+
+private final class ContextBuilderProgressTestClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: TimeInterval = 0
+
+    func now() -> TimeInterval {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
+    }
+
+    func advance(by interval: TimeInterval) {
+        lock.lock()
+        value += interval
+        lock.unlock()
+    }
+}
+
+private actor ContextBuilderSuspendingProgressSink {
+    private let suspendedKind: ContextBuilderMCPProgressEvent.Kind
+    private let suspendedPhase: ContextBuilderMCPProgressPhase
+    private let reentrantAction: (@Sendable () async -> Void)?
+    private var events: [ContextBuilderMCPProgressEvent] = []
+    private var isSuspending = false
+    private var didSuspend = false
+    private var isReleased = false
+    private var suspensionWaiters: [CheckedContinuation<Void, Never>] = []
+    private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+
+    init(
+        suspendedKind: ContextBuilderMCPProgressEvent.Kind,
+        suspendedPhase: ContextBuilderMCPProgressPhase,
+        reentrantAction: (@Sendable () async -> Void)? = nil
+    ) {
+        self.suspendedKind = suspendedKind
+        self.suspendedPhase = suspendedPhase
+        self.reentrantAction = reentrantAction
+    }
+
+    func receive(_ event: ContextBuilderMCPProgressEvent) async {
+        events.append(event)
+        guard !isSuspending,
+              !didSuspend,
+              event.kind == suspendedKind,
+              event.phase == suspendedPhase
+        else {
+            return
+        }
+
+        isSuspending = true
+        await reentrantAction?()
+        didSuspend = true
+        let waiters = suspensionWaiters
+        suspensionWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
+        }
+        guard !isReleased else { return }
+        await withCheckedContinuation { continuation in
+            releaseWaiters.append(continuation)
+        }
+    }
+
+    func waitUntilSuspended() async {
+        guard !didSuspend else { return }
+        await withCheckedContinuation { continuation in
+            suspensionWaiters.append(continuation)
+        }
+    }
+
+    func release() {
+        guard !isReleased else { return }
+        isReleased = true
+        let waiters = releaseWaiters
+        releaseWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
+        }
+    }
+
+    func snapshot() -> [ContextBuilderMCPProgressEvent] {
+        events
+    }
+}
+
+private final class ContextBuilderProgressTimelineReference: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedTimeline: ContextBuilderMCPProgressTimeline?
+
+    func setTimeline(_ timeline: ContextBuilderMCPProgressTimeline) {
+        lock.lock()
+        storedTimeline = timeline
+        lock.unlock()
+    }
+
+    func timeline() -> ContextBuilderMCPProgressTimeline? {
+        lock.lock()
+        defer { lock.unlock() }
+        return storedTimeline
+    }
+}
+
+private actor ContextBuilderProgressEventRecorder {
+    private var events: [ContextBuilderMCPProgressEvent] = []
+
+    func record(_ event: ContextBuilderMCPProgressEvent) {
+        events.append(event)
+    }
+
+    func snapshot() -> [ContextBuilderMCPProgressEvent] {
+        events
+    }
+}
+
+private actor ContextBuilderProgressPhaseRecorder {
+    private var phases: [ContextBuilderMCPProgressPhase] = []
+
+    func record(_ phase: ContextBuilderMCPProgressPhase) {
+        phases.append(phase)
+    }
+
+    func snapshot() -> [ContextBuilderMCPProgressPhase] {
+        phases
+    }
+}

--- a/Tests/RepoPromptTests/ContextBuilder/ContextBuilderRunLifecycleTests.swift
+++ b/Tests/RepoPromptTests/ContextBuilder/ContextBuilderRunLifecycleTests.swift
@@ -1,6 +1,8 @@
 import Darwin
 import Foundation
+import MCP
 @testable import RepoPrompt
+import RepoPromptShared
 import XCTest
 
 @MainActor
@@ -47,6 +49,197 @@ final class ContextBuilderRunLifecycleTests: XCTestCase {
         let snapshot = try await waiter.value
         XCTAssertEqual(snapshot.runID, record.runID)
         XCTAssertEqual(snapshot.agentOutput, "done")
+    }
+
+    func testSuccessfulCommitPrecedesChildTerminationAndCleanupWaitsForJoin() async {
+        let connectionID = UUID()
+        let terminationGate = LifecycleTestGate()
+        var events: [String] = []
+        var cleanupCount = 0
+
+        let finalization = Task { @MainActor in
+            await ContextBuilderChildConnectionFinalizer.finalize(
+                connectionIDs: [connectionID],
+                commitContext: { committedID in
+                    XCTAssertEqual(committedID, connectionID)
+                    events.append("context_committed")
+                    return true
+                },
+                beforeTerminationRequest: {
+                    events.append("before_termination_request")
+                },
+                requestTermination: { requestedID in
+                    XCTAssertEqual(requestedID, connectionID)
+                    events.append("termination_requested")
+                    return Task { @MainActor in
+                        await terminationGate.arriveAndWait()
+                    }
+                },
+                beforeTerminationJoin: {
+                    events.append("termination_join")
+                },
+                cleanupMapping: { cleanedID in
+                    XCTAssertEqual(cleanedID, connectionID)
+                    cleanupCount += 1
+                    events.append("mapping_cleaned")
+                }
+            )
+        }
+
+        await terminationGate.waitUntilArrived()
+        XCTAssertEqual(events, [
+            "context_committed",
+            "before_termination_request",
+            "termination_requested",
+            "termination_join"
+        ])
+        XCTAssertEqual(cleanupCount, 0)
+
+        await terminationGate.release()
+        let didFinalize = await finalization.value
+        XCTAssertTrue(didFinalize)
+        XCTAssertEqual(cleanupCount, 1)
+        XCTAssertEqual(events, [
+            "context_committed",
+            "before_termination_request",
+            "termination_requested",
+            "termination_join",
+            "mapping_cleaned"
+        ])
+    }
+
+    func testMissingCommitOwnershipDoesNotRequestTermination() async {
+        let connectionID = UUID()
+        var didRequestTermination = false
+        var didCleanupMapping = false
+
+        let didFinalize = await ContextBuilderChildConnectionFinalizer.finalize(
+            connectionIDs: [connectionID],
+            commitContext: { _ in false },
+            beforeTerminationRequest: {
+                XCTFail("Termination phase must not start without committed context ownership")
+            },
+            requestTermination: { _ in
+                didRequestTermination = true
+                return Task {}
+            },
+            beforeTerminationJoin: {
+                XCTFail("Termination join must not start without committed context ownership")
+            },
+            cleanupMapping: { _ in
+                didCleanupMapping = true
+            }
+        )
+
+        XCTAssertFalse(didFinalize)
+        XCTAssertFalse(didRequestTermination)
+        XCTAssertFalse(didCleanupMapping)
+    }
+
+    func testRealConnectionCleanupCannotEraseContextBeforeCommit() async throws {
+        #if DEBUG
+            let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
+            GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
+            let window = WindowState()
+            GlobalSettingsStore.shared.setMCPAutoStart(previousAutoStart, commit: false)
+            WindowStatesManager.shared.registerWindowState(window)
+            defer { WindowStatesManager.shared.unregisterWindowState(window) }
+
+            let root = FileManager.default.temporaryDirectory
+                .appendingPathComponent("ContextBuilderCleanupCommitTests-\(UUID().uuidString)")
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: root) }
+
+            let workspace = window.workspaceManager.createWorkspace(
+                name: "Context Builder cleanup commit test",
+                repoPaths: [root.path],
+                ephemeral: true
+            )
+            await window.workspaceManager.switchWorkspace(
+                to: workspace,
+                saveState: false,
+                reason: "ContextBuilderRunLifecycleTests.realCleanup"
+            )
+
+            let activeWorkspace = try XCTUnwrap(window.workspaceManager.activeWorkspace)
+            let tabID = try XCTUnwrap(
+                activeWorkspace.activeComposeTabID ?? activeWorkspace.composeTabs.first?.id
+            )
+            let connectionID = UUID()
+            let runID = UUID()
+            let clientName = "context-builder-cleanup-commit-test"
+            let expectedPrompt = "context captured before real connection cleanup"
+            try window.mcpServer.bindTabForConnection(
+                connectionID: connectionID,
+                clientName: clientName,
+                tabID: tabID,
+                workspaceID: activeWorkspace.id,
+                windowID: window.windowID,
+                runID: runID
+            )
+            var context = try XCTUnwrap(window.mcpServer.tabContextByConnectionID[connectionID])
+            context.promptText = expectedPrompt
+            window.mcpServer.tabContextByConnectionID[connectionID] = context
+
+            let connection = ContextBuilderCleanupTestConnection()
+            await ServerNetworkManager.shared.debugRegisterConnectionForSocketFixture(
+                connectionID: connectionID,
+                connection: connection,
+                clientName: clientName,
+                sessionToken: UUID().uuidString
+            )
+            await ServerNetworkManager.shared.debugSetConnectionWindowForTesting(
+                connectionID: connectionID,
+                windowID: window.windowID
+            )
+            defer {
+                Task { await ServerNetworkManager.shared.debugRemoveConnection(connectionID) }
+            }
+
+            let didFinalize = await ContextBuilderChildConnectionFinalizer.finalize(
+                connectionIDs: [connectionID],
+                commitContext: { committedID in
+                    await window.mcpServer.commitAndClearTabContext(
+                        connectionID: committedID,
+                        expectedRunID: runID,
+                        deferRunMappingCleanupUntilCaller: true
+                    )
+                },
+                beforeTerminationRequest: {},
+                requestTermination: { requestedID in
+                    Task {
+                        await ServerNetworkManager.shared.terminateConnection(
+                            requestedID,
+                            reason: .runCompleted,
+                            message: "test successful completion"
+                        )
+                    }
+                },
+                beforeTerminationJoin: {},
+                cleanupMapping: { cleanedID in
+                    window.mcpServer.removeTabContext(
+                        forConnectionID: cleanedID,
+                        clientName: clientName,
+                        windowID: window.windowID,
+                        runID: runID
+                    )
+                }
+            )
+
+            XCTAssertTrue(didFinalize)
+            XCTAssertEqual(
+                window.workspaceManager.composeTab(with: tabID)?.promptText,
+                expectedPrompt
+            )
+            XCTAssertNil(window.mcpServer.tabContextByConnectionID[connectionID])
+            XCTAssertFalse(window.mcpServer.hasRunID(runID))
+            let terminationCount = await connection.terminationCount()
+            let stopCount = await connection.stopCount()
+            XCTAssertEqual(terminationCount, 1)
+            XCTAssertGreaterThanOrEqual(stopCount, 1)
+        #else
+            throw XCTSkip("Real MCP connection cleanup fixture is DEBUG-only.")
+        #endif
     }
 
     func testLogicalReleaseAdmitsSuccessorAndRejectsOldEvents() {
@@ -993,6 +1186,76 @@ private actor CodexShapedBlockedRoutingTestState {
 
     func recordDisposalFinished() {
         disposalFinished = true
+    }
+}
+
+private actor ContextBuilderCleanupTestConnection: MCPServerConnection {
+    private var terminations = 0
+    private var stops = 0
+
+    nonisolated var isFilesystemBacked: Bool {
+        false
+    }
+
+    nonisolated var connectionFolderURL: URL? {
+        nil
+    }
+
+    nonisolated var capabilityToken: String? {
+        nil
+    }
+
+    func start(approvalHandler _: @escaping (MCP.Client.Info) async -> Bool) async throws {
+        // No transport startup is required for the cleanup fixture.
+    }
+
+    func stop() async {
+        stops += 1
+    }
+
+    func abortForExecutionWatchdog() async {
+        // The fixture does not execute tools.
+    }
+
+    func notifyToolListChanged() async {
+        // The fixture has no client transport.
+    }
+
+    func connectionState() -> ConnectionStateSnapshot {
+        .ready
+    }
+
+    func isViableForRetention() -> Bool {
+        true
+    }
+
+    func secondsSinceLastActivity() async -> TimeInterval {
+        0
+    }
+
+    func transportIngressSnapshot() async -> MCPTransportIngressSnapshot? {
+        nil
+    }
+
+    func terminate(reason _: TerminationReason, message _: String?) async {
+        terminations += 1
+    }
+
+    func sendProgress(
+        tool _: String,
+        kind _: RepoPromptProgressKind,
+        stage _: String,
+        message _: String
+    ) async {
+        // The fixture has no client transport.
+    }
+
+    func terminationCount() -> Int {
+        terminations
+    }
+
+    func stopCount() -> Int {
+        stops
     }
 }
 

--- a/Tests/RepoPromptTests/MCP/Control/JSONRPCBridgeLedgerTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/JSONRPCBridgeLedgerTests.swift
@@ -335,6 +335,25 @@ final class JSONRPCBridgeLedgerTests: XCTestCase {
         XCTAssertTrue(activeFailureWasTerminal)
         reconnectSnapshot = await ledger.snapshot()
         XCTAssertFalse(reconnectSnapshot.canReconnect)
+
+        let preparedLedger = try await makeLedger()
+        _ = try await preparedLedger.prepare(
+            frame: line(#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#),
+            direction: .clientToServer
+        )
+        let preparedSnapshot = await preparedLedger.snapshot()
+        XCTAssertEqual(preparedSnapshot.activeRequestCount, 0)
+        XCTAssertEqual(preparedSnapshot.pendingTransactionCount, 1)
+        XCTAssertFalse(preparedSnapshot.hasForwardedProtocolFrame)
+        XCTAssertFalse(preparedSnapshot.canReconnect)
+
+        let preparedFailureWasTerminal = await preparedLedger.recordConnectionFailure(
+            "socket_reset_with_prepared_transaction"
+        )
+        XCTAssertTrue(preparedFailureWasTerminal)
+        let terminalPreparedSnapshot = await preparedLedger.snapshot()
+        XCTAssertEqual(terminalPreparedSnapshot.terminalReason, "socket_reset_with_prepared_transaction")
+        XCTAssertFalse(terminalPreparedSnapshot.canReconnect)
     }
 
     func testTraceMetadataContainsHashAndNeverPayload() async throws {

--- a/Tests/RepoPromptTests/MCP/Control/MCPResponseDeliveryTracerSafetyTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/MCPResponseDeliveryTracerSafetyTests.swift
@@ -33,6 +33,71 @@ final class MCPResponseDeliveryTracerSafetyTests: XCTestCase {
         XCTAssertEqual(received, payload)
     }
 
+    func testNonBlockingWriterRestoresBlockingAndSIGPIPEFlagsAfterSuccessfulWrite() throws {
+        var pipe = try makePipe()
+        let duplicateWriteFD = dup(pipe.writeFD)
+        guard duplicateWriteFD >= 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        defer {
+            closeIfOpen(duplicateWriteFD)
+            closeIfOpen(pipe.readFD)
+            closeIfOpen(pipe.writeFD)
+        }
+
+        let originalNonBlocking = try descriptorIsNonBlocking(pipe.writeFD)
+        let originalNoSIGPIPE = try descriptorNoSIGPIPE(pipe.writeFD)
+        XCTAssertFalse(originalNonBlocking)
+
+        let payload = Data("diagnostic\n".utf8)
+        XCTAssertTrue(BestEffortStderrWriter.writeNonBlocking(payload, to: pipe.writeFD))
+        XCTAssertEqual(try descriptorIsNonBlocking(pipe.writeFD), originalNonBlocking)
+        XCTAssertEqual(try descriptorIsNonBlocking(duplicateWriteFD), originalNonBlocking)
+        XCTAssertEqual(try descriptorNoSIGPIPE(pipe.writeFD), originalNoSIGPIPE)
+
+        var buffer = [UInt8](repeating: 0, count: payload.count)
+        XCTAssertEqual(read(pipe.readFD, &buffer, buffer.count), payload.count)
+        XCTAssertEqual(Data(buffer), payload)
+    }
+
+    func testNonBlockingWriterRestoresFlagsWhenPipeIsFull() throws {
+        var pipe = try makePipe()
+        defer {
+            closeIfOpen(pipe.readFD)
+            closeIfOpen(pipe.writeFD)
+        }
+
+        let originalNonBlocking = try descriptorIsNonBlocking(pipe.writeFD)
+        let originalNoSIGPIPE = try descriptorNoSIGPIPE(pipe.writeFD)
+        XCTAssertFalse(originalNonBlocking)
+        try fillPipeToCapacity(pipe.writeFD)
+        XCTAssertEqual(try descriptorIsNonBlocking(pipe.writeFD), originalNonBlocking)
+
+        let writeFD = pipe.writeFD
+        let writeQueue = DispatchQueue(label: "tracer-safety-test-full-pipe-writer")
+        let writeDone = DispatchGroup()
+        nonisolated(unsafe) var writeResult: Bool?
+        writeDone.enter()
+        writeQueue.async {
+            writeResult = BestEffortStderrWriter.writeNonBlocking(
+                Data("dropped\n".utf8),
+                to: writeFD
+            )
+            writeDone.leave()
+        }
+
+        let completed = writeDone.wait(timeout: .now() + 1) == .success
+        if !completed {
+            closeIfOpen(pipe.readFD)
+            pipe.readFD = -1
+            writeDone.wait()
+        }
+        XCTAssertTrue(completed, "Nonblocking diagnostic write hung on a full unread pipe")
+        XCTAssertEqual(writeResult, false)
+        XCTAssertEqual(try descriptorIsNonBlocking(writeFD), originalNonBlocking)
+        XCTAssertEqual(try descriptorNoSIGPIPE(writeFD), originalNoSIGPIPE)
+    }
+
     func testWriterDropsDataOnBrokenPipeWithoutRaising() throws {
         let writeFD = try makeBrokenPipeWriteEnd()
         defer { close(writeFD) }
@@ -120,6 +185,49 @@ private extension MCPResponseDeliveryTracerSafetyTests {
             throw XCTSkip("pipe(2) failed with errno \(errno)")
         }
         return (fds[0], fds[1])
+    }
+
+    func descriptorFlags(_ fd: Int32) throws -> Int32 {
+        let flags = fcntl(fd, F_GETFL)
+        guard flags >= 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        return flags
+    }
+
+    func descriptorIsNonBlocking(_ fd: Int32) throws -> Bool {
+        try descriptorFlags(fd) & O_NONBLOCK != 0
+    }
+
+    func descriptorNoSIGPIPE(_ fd: Int32) throws -> Int32 {
+        let value = fcntl(fd, F_GETNOSIGPIPE)
+        guard value >= 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        return value
+    }
+
+    func fillPipeToCapacity(_ fd: Int32) throws {
+        let originalFlags = try descriptorFlags(fd)
+        guard fcntl(fd, F_SETFL, originalFlags | O_NONBLOCK) >= 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        defer { _ = fcntl(fd, F_SETFL, originalFlags) }
+
+        let payload = [UInt8](repeating: 0x58, count: 4096)
+        while true {
+            let result = payload.withUnsafeBytes { bytes in
+                write(fd, bytes.baseAddress, bytes.count)
+            }
+            if result > 0 { continue }
+            if result < 0, errno == EINTR { continue }
+            if result < 0, errno == EAGAIN || errno == EWOULDBLOCK { return }
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+    }
+
+    func closeIfOpen(_ fd: Int32) {
+        if fd >= 0 { close(fd) }
     }
 
     func makeBrokenPipeWriteEnd() throws -> Int32 {

--- a/Tests/RepoPromptTests/MCP/Control/MCPToolExecutionWatchdogIntegrationTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/MCPToolExecutionWatchdogIntegrationTests.swift
@@ -64,6 +64,59 @@ import XCTest
             }
         }
 
+        func testManageSelectionAndFileActionsReportReplyConstructionPhase() async throws {
+            try await MCPSharedServerTestLease.shared.withLease { lease in
+                let fixture = try await PersistentMCPTestFixture.make(lease: lease)
+                let recorder = MCPExecutionTraceRecorder()
+                let createdFileURL = fixture.contextA.fileURL
+                    .deletingLastPathComponent()
+                    .appendingPathComponent("watchdog-phase-\(UUID().uuidString).txt")
+                MCPToolExecutionTracer.setTestSink { recorder.append($0) }
+                do {
+                    let endpoint = try fixture.endpointA()
+                    _ = try await endpoint.callTool(
+                        name: MCPWindowToolName.manageSelection,
+                        arguments: [
+                            "op": "get",
+                            "context_id": fixture.contextA.tabID.uuidString
+                        ]
+                    )
+                    _ = try await endpoint.callTool(
+                        name: MCPWindowToolName.fileActions,
+                        arguments: [
+                            "action": "create",
+                            "path": createdFileURL.path,
+                            "content": "watchdog phase fixture\n",
+                            "context_id": fixture.contextA.tabID.uuidString
+                        ]
+                    )
+
+                    let events = recorder.snapshot().filter { $0.connectionID == endpoint.connectionID }
+                    let selectionCompleted = try XCTUnwrap(events.last {
+                        $0.toolName == MCPWindowToolName.manageSelection && $0.phase == .handlerCompleted
+                    })
+                    XCTAssertEqual(selectionCompleted.handlerPhase?.phase, .manageSelectionReplyConstruction)
+                    XCTAssertEqual(selectionCompleted.handlerPhase?.transition, .completed)
+
+                    let fileActionCompleted = try XCTUnwrap(events.last {
+                        $0.toolName == MCPWindowToolName.fileActions && $0.phase == .handlerCompleted
+                    })
+                    XCTAssertEqual(fileActionCompleted.handlerPhase?.phase, .fileActionsReplyConstruction)
+                    XCTAssertEqual(fileActionCompleted.handlerPhase?.transition, .completed)
+
+                    MCPToolExecutionTracer.setTestSink(nil)
+                    try? FileManager.default.removeItem(at: createdFileURL)
+                    await fixture.cleanup()
+                    try await fixture.assertCleanedUp()
+                } catch {
+                    MCPToolExecutionTracer.setTestSink(nil)
+                    try? FileManager.default.removeItem(at: createdFileURL)
+                    await fixture.cleanup()
+                    throw error
+                }
+            }
+        }
+
         func testAskUserLifecycleExemptionDoesNotInstallExecutionWatchdog() async throws {
             try await MCPSharedServerTestLease.shared.withLease { lease in
                 let fixture = try await PersistentMCPTestFixture.make(lease: lease)
@@ -845,6 +898,474 @@ import XCTest
             }
         }
 
+        func testRealManageSelectionDrainTimeoutSettlesDuringGraceAndKeepsQueuedCallUsable() async throws {
+            try await MCPSharedServerTestLease.shared.withLease { lease in
+                let fixture = try await PersistentMCPTestFixture.make(lease: lease)
+                let clock = ExecutionWatchdogManualClock()
+                let gate = MCPExecutionIgnoringCancellationGate()
+                let recorder = MCPExecutionTraceRecorder()
+                let manager = fixture.networkManager
+                let server = fixture.contextA.window.mcpServer
+                var endpoint: PersistentMCPTestEndpoint?
+                var manageTask: Task<PersistentMCPTestRPCResponse, Error>?
+                var queuedReadTask: Task<PersistentMCPTestRPCResponse, Error>?
+
+                MCPToolExecutionTracer.setTestSink { recorder.append($0) }
+                server.setReadFileAutoSelectionCanonicalApplyGateForTesting {
+                    await gate.enterAndWait()
+                }
+                do {
+                    let clientName = "real-manage-selection-watchdog-\(UUID().uuidString)"
+                    await manager.installClientConnectionPolicy(
+                        for: clientName,
+                        windowID: fixture.contextA.window.windowID,
+                        restrictedTools: [],
+                        tabID: fixture.contextA.tabID,
+                        runID: UUID(),
+                        additionalTools: [],
+                        purpose: .agentModeRun
+                    )
+                    let createdEndpoint = try await PersistentMCPTestEndpoint.make(
+                        label: "real-manage-selection-watchdog",
+                        networkManager: manager,
+                        clientName: clientName,
+                        requiredToolNames: [
+                            MCPWindowToolName.readFile,
+                            MCPWindowToolName.manageSelection
+                        ]
+                    )
+                    endpoint = createdEndpoint
+                    let readTask = Task {
+                        try await createdEndpoint.callTool(
+                            name: MCPWindowToolName.readFile,
+                            arguments: ["path": fixture.contextA.fileURL.path]
+                        )
+                    }
+                    try await gate.waitUntilEntered(count: 1)
+                    _ = try await readTask.value
+
+                    await manager.debugSetToolExecutionWatchdogEnvironment(clock.environment)
+                    let activeManageTask = Task {
+                        try await createdEndpoint.callTool(
+                            name: MCPWindowToolName.manageSelection,
+                            arguments: ["op": "get"]
+                        )
+                    }
+                    manageTask = activeManageTask
+                    try await clock.waitForSleeperCount(1)
+                    let waiterRegistered = await Self.waitUntil {
+                        server.readFileAutoSelectionDiagnosticsSnapshot().canonicalWaiterCount == 1
+                    }
+                    XCTAssertTrue(waiterRegistered)
+
+                    let activeQueuedReadTask = Task {
+                        try await createdEndpoint.callTool(
+                            name: MCPWindowToolName.readFile,
+                            arguments: ["path": fixture.contextA.fileURL.path]
+                        )
+                    }
+                    queuedReadTask = activeQueuedReadTask
+                    let queuedAtLimiter = await Self.waitUntil {
+                        await manager.connectionLimiterSnapshotForTesting(
+                            connectionID: createdEndpoint.connectionID
+                        )?.waiterCount == 1
+                    }
+                    XCTAssertTrue(queuedAtLimiter)
+
+                    try await clock.advanceNext(expected: MCPTimeoutPolicy.boundedToolExecutionDeadline)
+                    let timeoutResponse = try await activeManageTask.value
+                    manageTask = nil
+                    let timeoutText = try Self.toolResultText(timeoutResponse)
+                    XCTAssertEqual(timeoutText.components(separatedBy: "tool_execution_timeout").count - 1, 1, timeoutText)
+                    XCTAssertEqual(server.readFileAutoSelectionDiagnosticsSnapshot().canonicalWaiterCount, 0)
+                    XCTAssertEqual(server.readFileAutoSelectionDiagnosticsSnapshot().canonicalWorkerCount, 1)
+
+                    let queuedReadResponse = try await activeQueuedReadTask.value
+                    queuedReadTask = nil
+                    let queuedReadText = try Self.toolResultText(queuedReadResponse)
+                    XCTAssertTrue(queuedReadText.contains(fixture.contextA.sentinel), queuedReadText)
+                    let isTerminal = await manager.debugIsExecutionWatchdogTerminal(connectionID: createdEndpoint.connectionID)
+                    XCTAssertFalse(isTerminal)
+                    let events = recorder.snapshot().filter {
+                        $0.connectionID == createdEndpoint.connectionID
+                            && $0.toolName == MCPWindowToolName.manageSelection
+                    }
+                    XCTAssertTrue(events.contains { $0.phase == .deadlineExpired })
+                    XCTAssertFalse(events.contains { $0.phase == .cleanupGraceExpired })
+                    XCTAssertFalse(events.contains { $0.phase == .connectionForceDisconnectRequested })
+
+                    await gate.release()
+                    server.setReadFileAutoSelectionCanonicalApplyGateForTesting(nil)
+                    await manager.debugResetToolExecutionWatchdogEnvironment()
+                    _ = try await createdEndpoint.callTool(
+                        name: MCPWindowToolName.manageSelection,
+                        arguments: ["op": "get"]
+                    )
+                    _ = try await createdEndpoint.client.request(method: "tools/list", params: [:])
+
+                    MCPToolExecutionTracer.setTestSink(nil)
+                    await Self.cleanupEndpoint(createdEndpoint, manager: manager)
+                    endpoint = nil
+                    await fixture.cleanup()
+                    try await fixture.assertCleanedUp()
+                } catch {
+                    manageTask?.cancel()
+                    queuedReadTask?.cancel()
+                    await gate.release()
+                    server.setReadFileAutoSelectionCanonicalApplyGateForTesting(nil)
+                    MCPToolExecutionTracer.setTestSink(nil)
+                    await manager.debugResetToolExecutionWatchdogEnvironment()
+                    if let manageTask { _ = try? await manageTask.value }
+                    if let queuedReadTask { _ = try? await queuedReadTask.value }
+                    if let endpoint { await Self.cleanupEndpoint(endpoint, manager: manager) }
+                    await fixture.cleanup()
+                    throw error
+                }
+            }
+        }
+
+        func testRealFileActionTimeoutDetachesIOReconcilesCatalogAndKeepsQueuedCallUsable() async throws {
+            try await MCPSharedServerTestLease.shared.withLease { lease in
+                let fixture = try await PersistentMCPTestFixture.make(lease: lease)
+                let clock = ExecutionWatchdogManualClock()
+                let gate = MCPExecutionIgnoringCancellationGate()
+                let recorder = MCPExecutionTraceRecorder()
+                let manager = fixture.networkManager
+                let store = fixture.contextA.window.workspaceFileContextStore
+                try await store.startWatchingRoot(id: fixture.contextA.rootID)
+                let loadedService = await store.fileSystemServiceForTesting(rootID: fixture.contextA.rootID)
+                let service = try XCTUnwrap(loadedService)
+                let createdURL = fixture.contextA.rootURL.appendingPathComponent("CreatedAfterWatchdog.swift")
+                var fileActionTask: Task<PersistentMCPTestRPCResponse, Error>?
+                var queuedReadTask: Task<PersistentMCPTestRPCResponse, Error>?
+
+                MCPToolExecutionTracer.setTestSink { recorder.append($0) }
+                await service.setMutationIOWillBeginHandlerForTesting { operation in
+                    guard operation == .create else { return }
+                    await gate.enterAndWait()
+                }
+                do {
+                    let endpoint = try fixture.endpointA()
+                    _ = try await endpoint.callTool(
+                        name: "bind_context",
+                        arguments: [
+                            "op": "bind",
+                            "context_id": fixture.contextA.tabID.uuidString
+                        ]
+                    )
+                    await manager.debugSetToolExecutionWatchdogEnvironment(clock.environment)
+                    let activeFileActionTask = Task {
+                        try await endpoint.callTool(
+                            name: MCPWindowToolName.fileActions,
+                            arguments: [
+                                "action": "create",
+                                "path": createdURL.path,
+                                "content": "struct CreatedAfterWatchdog {}\n"
+                            ]
+                        )
+                    }
+                    fileActionTask = activeFileActionTask
+                    try await clock.waitForSleeperCount(1)
+                    try await gate.waitUntilEntered(count: 1)
+
+                    let activeQueuedReadTask = Task {
+                        try await endpoint.callTool(
+                            name: MCPWindowToolName.readFile,
+                            arguments: ["path": fixture.contextA.fileURL.path]
+                        )
+                    }
+                    queuedReadTask = activeQueuedReadTask
+                    let queuedAtLimiter = await Self.waitUntil {
+                        await manager.connectionLimiterSnapshotForTesting(
+                            connectionID: endpoint.connectionID
+                        )?.waiterCount == 1
+                    }
+                    XCTAssertTrue(queuedAtLimiter)
+
+                    try await clock.advanceNext(expected: MCPTimeoutPolicy.boundedToolExecutionDeadline)
+                    let timeoutResponse = try await activeFileActionTask.value
+                    fileActionTask = nil
+                    let timeoutText = try Self.toolResultText(timeoutResponse)
+                    XCTAssertEqual(timeoutText.components(separatedBy: "tool_execution_timeout").count - 1, 1, timeoutText)
+                    let pendingWaiters = await service.pendingMutationWaiterCountForTesting()
+                    XCTAssertEqual(pendingWaiters, 0)
+                    XCTAssertFalse(FileManager.default.fileExists(atPath: createdURL.path))
+
+                    let queuedReadResponse = try await activeQueuedReadTask.value
+                    queuedReadTask = nil
+                    let queuedReadText = try Self.toolResultText(queuedReadResponse)
+                    XCTAssertTrue(queuedReadText.contains(fixture.contextA.sentinel), queuedReadText)
+                    let isTerminal = await manager.debugIsExecutionWatchdogTerminal(connectionID: endpoint.connectionID)
+                    XCTAssertFalse(isTerminal)
+                    let events = recorder.snapshot().filter {
+                        $0.connectionID == endpoint.connectionID
+                            && $0.toolName == MCPWindowToolName.fileActions
+                    }
+                    XCTAssertTrue(events.contains { $0.phase == .deadlineExpired })
+                    XCTAssertFalse(events.contains { $0.phase == .cleanupGraceExpired })
+                    XCTAssertFalse(events.contains { $0.phase == .connectionForceDisconnectRequested })
+
+                    await gate.release()
+                    let reconciled = await Self.waitUntil {
+                        guard FileManager.default.fileExists(atPath: createdURL.path) else { return false }
+                        return await store.file(
+                            rootID: fixture.contextA.rootID,
+                            relativePath: "CreatedAfterWatchdog.swift"
+                        ) != nil
+                    }
+                    XCTAssertTrue(reconciled)
+                    let finalWaiters = await service.pendingMutationWaiterCountForTesting()
+                    XCTAssertEqual(finalWaiters, 0)
+
+                    await service.setMutationIOWillBeginHandlerForTesting(nil)
+                    await manager.debugResetToolExecutionWatchdogEnvironment()
+                    _ = try await endpoint.client.request(method: "tools/list", params: [:])
+                    MCPToolExecutionTracer.setTestSink(nil)
+                    await fixture.cleanup()
+                    try await fixture.assertCleanedUp()
+                } catch {
+                    fileActionTask?.cancel()
+                    queuedReadTask?.cancel()
+                    await gate.release()
+                    await service.setMutationIOWillBeginHandlerForTesting(nil)
+                    MCPToolExecutionTracer.setTestSink(nil)
+                    await manager.debugResetToolExecutionWatchdogEnvironment()
+                    if let fileActionTask { _ = try? await fileActionTask.value }
+                    if let queuedReadTask { _ = try? await queuedReadTask.value }
+                    await fixture.cleanup()
+                    throw error
+                }
+            }
+        }
+
+        func testRealFileActionOverwriteTimeoutDetachesIOReconcilesCatalogAndKeepsQueuedCallUsable() async throws {
+            try await MCPSharedServerTestLease.shared.withLease { lease in
+                let fixture = try await PersistentMCPTestFixture.make(lease: lease)
+                let clock = ExecutionWatchdogManualClock()
+                let gate = MCPExecutionIgnoringCancellationGate()
+                let recorder = MCPExecutionTraceRecorder()
+                let manager = fixture.networkManager
+                let store = fixture.contextA.window.workspaceFileContextStore
+                let relativePath = "OverwriteAfterWatchdog.swift"
+                let fileURL = fixture.contextA.rootURL.appendingPathComponent(relativePath)
+                _ = try await store.createFile(
+                    rootID: fixture.contextA.rootID,
+                    relativePath: relativePath,
+                    content: "old"
+                )
+                try await store.startWatchingRoot(id: fixture.contextA.rootID)
+                let loadedService = await store.fileSystemServiceForTesting(rootID: fixture.contextA.rootID)
+                let service = try XCTUnwrap(loadedService)
+                var fileActionTask: Task<PersistentMCPTestRPCResponse, Error>?
+                var queuedReadTask: Task<PersistentMCPTestRPCResponse, Error>?
+
+                MCPToolExecutionTracer.setTestSink { recorder.append($0) }
+                await service.setMutationIOWillBeginHandlerForTesting { operation in
+                    guard operation == .edit else { return }
+                    await gate.enterAndWait()
+                }
+                do {
+                    let endpoint = try fixture.endpointA()
+                    _ = try await endpoint.callTool(
+                        name: "bind_context",
+                        arguments: [
+                            "op": "bind",
+                            "context_id": fixture.contextA.tabID.uuidString
+                        ]
+                    )
+                    await manager.debugSetToolExecutionWatchdogEnvironment(clock.environment)
+                    let activeFileActionTask = Task {
+                        try await endpoint.callTool(
+                            name: MCPWindowToolName.fileActions,
+                            arguments: [
+                                "action": "create",
+                                "path": fileURL.path,
+                                "content": "new",
+                                "if_exists": "overwrite"
+                            ]
+                        )
+                    }
+                    fileActionTask = activeFileActionTask
+                    try await clock.waitForSleeperCount(1)
+                    try await gate.waitUntilEntered(count: 1)
+
+                    let activeQueuedReadTask = Task {
+                        try await endpoint.callTool(
+                            name: MCPWindowToolName.readFile,
+                            arguments: ["path": fixture.contextA.fileURL.path]
+                        )
+                    }
+                    queuedReadTask = activeQueuedReadTask
+                    let queuedAtLimiter = await Self.waitUntil {
+                        await manager.connectionLimiterSnapshotForTesting(
+                            connectionID: endpoint.connectionID
+                        )?.waiterCount == 1
+                    }
+                    XCTAssertTrue(queuedAtLimiter)
+
+                    try await clock.advanceNext(expected: MCPTimeoutPolicy.boundedToolExecutionDeadline)
+                    let timeoutResponse = try await activeFileActionTask.value
+                    fileActionTask = nil
+                    let timeoutText = try Self.toolResultText(timeoutResponse)
+                    XCTAssertEqual(timeoutText.components(separatedBy: "tool_execution_timeout").count - 1, 1, timeoutText)
+                    let pendingWaiters = await service.pendingMutationWaiterCountForTesting()
+                    XCTAssertEqual(pendingWaiters, 0)
+                    XCTAssertEqual(try String(contentsOf: fileURL, encoding: .utf8), "old")
+
+                    let queuedReadResponse = try await activeQueuedReadTask.value
+                    queuedReadTask = nil
+                    let queuedReadText = try Self.toolResultText(queuedReadResponse)
+                    XCTAssertTrue(queuedReadText.contains(fixture.contextA.sentinel), queuedReadText)
+                    let isTerminal = await manager.debugIsExecutionWatchdogTerminal(connectionID: endpoint.connectionID)
+                    XCTAssertFalse(isTerminal)
+                    let events = recorder.snapshot().filter {
+                        $0.connectionID == endpoint.connectionID
+                            && $0.toolName == MCPWindowToolName.fileActions
+                    }
+                    XCTAssertTrue(events.contains { $0.phase == .deadlineExpired })
+                    XCTAssertFalse(events.contains { $0.phase == .cleanupGraceExpired })
+                    XCTAssertFalse(events.contains { $0.phase == .connectionForceDisconnectRequested })
+
+                    await gate.release()
+                    let reconciled = await Self.waitUntil {
+                        guard (try? String(contentsOf: fileURL, encoding: .utf8)) == "new" else { return false }
+                        return await (try? store.readContent(
+                            rootID: fixture.contextA.rootID,
+                            relativePath: relativePath
+                        )) == "new"
+                    }
+                    XCTAssertTrue(reconciled)
+                    let finalWaiters = await service.pendingMutationWaiterCountForTesting()
+                    XCTAssertEqual(finalWaiters, 0)
+
+                    await service.setMutationIOWillBeginHandlerForTesting(nil)
+                    await manager.debugResetToolExecutionWatchdogEnvironment()
+                    _ = try await endpoint.client.request(method: "tools/list", params: [:])
+                    MCPToolExecutionTracer.setTestSink(nil)
+                    await fixture.cleanup()
+                    try await fixture.assertCleanedUp()
+                } catch {
+                    fileActionTask?.cancel()
+                    queuedReadTask?.cancel()
+                    await gate.release()
+                    await service.setMutationIOWillBeginHandlerForTesting(nil)
+                    MCPToolExecutionTracer.setTestSink(nil)
+                    await manager.debugResetToolExecutionWatchdogEnvironment()
+                    if let fileActionTask { _ = try? await fileActionTask.value }
+                    if let queuedReadTask { _ = try? await queuedReadTask.value }
+                    await fixture.cleanup()
+                    throw error
+                }
+            }
+        }
+
+        func testReadAutoSelectionThenImmediateManageSelectionAddAndGetPreservesCanonicalOwnership() async throws {
+            try await MCPSharedServerTestLease.shared.withLease { lease in
+                let fixture = try await PersistentMCPTestFixture.make(lease: lease)
+                let gate = MCPExecutionIgnoringCancellationGate()
+                let server = fixture.contextA.window.mcpServer
+                let store = fixture.contextA.window.workspaceFileContextStore
+                let manager = fixture.networkManager
+                let secondRelativePath = "Sources/ImmediateOwnership.swift"
+                let secondURL = fixture.contextA.rootURL.appendingPathComponent(secondRelativePath)
+                var endpoint: PersistentMCPTestEndpoint?
+                _ = try await store.createFile(
+                    rootID: fixture.contextA.rootID,
+                    relativePath: secondRelativePath,
+                    content: "struct ImmediateOwnership {}\n"
+                )
+                server.setReadFileAutoSelectionCanonicalApplyGateForTesting {
+                    await gate.enterAndWait()
+                }
+                do {
+                    let clientName = "selection-ownership-\(UUID().uuidString)"
+                    await manager.installClientConnectionPolicy(
+                        for: clientName,
+                        windowID: fixture.contextA.window.windowID,
+                        restrictedTools: [],
+                        tabID: fixture.contextA.tabID,
+                        runID: UUID(),
+                        additionalTools: [],
+                        purpose: .agentModeRun
+                    )
+                    let createdEndpoint = try await PersistentMCPTestEndpoint.make(
+                        label: "selection-ownership",
+                        networkManager: manager,
+                        clientName: clientName,
+                        requiredToolNames: [
+                            MCPWindowToolName.readFile,
+                            MCPWindowToolName.manageSelection
+                        ]
+                    )
+                    endpoint = createdEndpoint
+                    _ = try await createdEndpoint.callTool(
+                        name: MCPWindowToolName.manageSelection,
+                        arguments: ["op": "clear"]
+                    )
+                    let readTask = Task {
+                        try await createdEndpoint.callTool(
+                            name: MCPWindowToolName.readFile,
+                            arguments: ["path": fixture.contextA.fileURL.path]
+                        )
+                    }
+                    try await gate.waitUntilEntered(count: 1)
+                    _ = try await readTask.value
+
+                    let addTask = Task {
+                        try await createdEndpoint.callTool(
+                            name: MCPWindowToolName.manageSelection,
+                            arguments: [
+                                "op": "add",
+                                "paths": [secondURL.path],
+                                "view": "files"
+                            ]
+                        )
+                    }
+                    let waiterRegistered = await Self.waitUntil {
+                        server.readFileAutoSelectionDiagnosticsSnapshot().canonicalWaiterCount == 1
+                    }
+                    XCTAssertTrue(waiterRegistered)
+                    await gate.release()
+                    server.setReadFileAutoSelectionCanonicalApplyGateForTesting(nil)
+                    _ = try await addTask.value
+
+                    let getResponse = try await createdEndpoint.callTool(
+                        name: MCPWindowToolName.manageSelection,
+                        arguments: [
+                            "op": "get",
+                            "view": "files"
+                        ]
+                    )
+                    let getText = try Self.toolResultText(getResponse)
+                    XCTAssertTrue(getText.contains(fixture.contextA.fileURL.lastPathComponent), getText)
+                    XCTAssertTrue(getText.contains(secondURL.lastPathComponent), getText)
+
+                    let canonical = try XCTUnwrap(
+                        server.tabContextByConnectionID[createdEndpoint.connectionID]?.selection
+                    )
+                    XCTAssertEqual(
+                        Set(canonical.selectedPaths),
+                        Set([fixture.contextA.fileURL.path, secondURL.path])
+                    )
+                    let mirrored = try XCTUnwrap(
+                        fixture.contextA.window.workspaceManager.composeTab(with: fixture.contextA.tabID)?.selection
+                    )
+                    XCTAssertEqual(Set(mirrored.selectedPaths), Set(canonical.selectedPaths))
+
+                    await Self.cleanupEndpoint(createdEndpoint, manager: manager)
+                    endpoint = nil
+                    await fixture.cleanup()
+                    try await fixture.assertCleanedUp()
+                } catch {
+                    await gate.release()
+                    server.setReadFileAutoSelectionCanonicalApplyGateForTesting(nil)
+                    if let endpoint { await Self.cleanupEndpoint(endpoint, manager: manager) }
+                    await fixture.cleanup()
+                    throw error
+                }
+            }
+        }
+
         func testWindowIDInjectionAndExplicitValueReachResolvedProviderArguments() async throws {
             try await MCPSharedServerTestLease.shared.withLease { lease in
                 let fixture = try await PersistentMCPTestFixture.make(lease: lease)
@@ -905,7 +1426,8 @@ import XCTest
                 let manager = fixture.networkManager
                 MCPToolExecutionTracer.setTestSink { recorder.append($0) }
                 await manager.debugSetToolExecutionWatchdogEnvironment(clock.environment)
-                await manager.debugSetResolvedToolOperationOverride(toolName: MCPWindowToolName.readFile) {
+                await manager.debugSetResolvedToolOperationOverride(toolName: MCPWindowToolName.manageSelection) {
+                    await MCPToolExecutionHandlerPhaseContext.report(.manageSelectionAutoSelectionDrain)
                     await operationGate.enterAndWait()
                     return .null
                 }
@@ -913,9 +1435,9 @@ import XCTest
                     let endpoint = try fixture.endpointA()
                     let first = Task {
                         try await endpoint.callTool(
-                            name: MCPWindowToolName.readFile,
+                            name: MCPWindowToolName.manageSelection,
                             arguments: [
-                                "path": fixture.contextA.fileURL.path,
+                                "op": "get",
                                 "context_id": fixture.contextA.tabID.uuidString
                             ]
                         )
@@ -925,9 +1447,9 @@ import XCTest
 
                     let queued = Task {
                         try await endpoint.callTool(
-                            name: MCPWindowToolName.readFile,
+                            name: MCPWindowToolName.manageSelection,
                             arguments: [
-                                "path": fixture.contextA.fileURL.path,
+                                "op": "get",
                                 "context_id": fixture.contextA.tabID.uuidString
                             ]
                         )
@@ -944,26 +1466,50 @@ import XCTest
                     XCTAssertTrue(isTerminal)
 
                     let events = recorder.snapshot().filter {
-                        $0.connectionID == endpoint.connectionID && $0.toolName == MCPWindowToolName.readFile
+                        $0.connectionID == endpoint.connectionID && $0.toolName == MCPWindowToolName.manageSelection
                     }
                     XCTAssertFalse(events.contains { $0.phase == .handlerCompleted })
-                    XCTAssertTrue(events.contains { $0.phase == .cleanupGraceExpired })
-                    XCTAssertTrue(events.contains { $0.phase == .connectionForceDisconnectRequested })
+                    for phase in [
+                        MCPToolExecutionTraceEvent.Phase.deadlineExpired,
+                        .cancellationRequested,
+                        .cleanupGraceExpired,
+                        .connectionForceDisconnectRequested
+                    ] {
+                        let event = try XCTUnwrap(events.first { $0.phase == phase })
+                        XCTAssertEqual(event.handlerPhase?.phase, .manageSelectionAutoSelectionDrain)
+                        XCTAssertEqual(event.handlerPhase?.transition, .started)
+                        XCTAssertGreaterThanOrEqual(event.handlerPhaseAgeMilliseconds ?? -1, 0)
+                    }
 
                     await operationGate.release()
                     MCPToolExecutionTracer.setTestSink(nil)
-                    await manager.debugSetResolvedToolOperationOverride(toolName: MCPWindowToolName.readFile, operation: nil)
+                    await manager.debugSetResolvedToolOperationOverride(toolName: MCPWindowToolName.manageSelection, operation: nil)
                     await manager.debugResetToolExecutionWatchdogEnvironment()
                     await fixture.cleanup()
                 } catch {
                     await operationGate.release()
                     MCPToolExecutionTracer.setTestSink(nil)
-                    await manager.debugSetResolvedToolOperationOverride(toolName: MCPWindowToolName.readFile, operation: nil)
+                    await manager.debugSetResolvedToolOperationOverride(toolName: MCPWindowToolName.manageSelection, operation: nil)
                     await manager.debugResetToolExecutionWatchdogEnvironment()
                     await fixture.cleanup()
                     throw error
                 }
             }
+        }
+
+        private static func waitUntil(
+            timeout: Duration = .seconds(10),
+            condition: () async -> Bool
+        ) async -> Bool {
+            let clock = ContinuousClock()
+            let deadline = clock.now.advanced(by: timeout)
+            while clock.now < deadline {
+                if await condition() {
+                    return true
+                }
+                try? await Task.sleep(for: .milliseconds(10))
+            }
+            return await condition()
         }
 
         private static func cleanupEndpoint(

--- a/Tests/RepoPromptTests/MCP/Control/MCPToolExecutionWatchdogTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/MCPToolExecutionWatchdogTests.swift
@@ -157,6 +157,45 @@ final class MCPToolExecutionWatchdogTests: XCTestCase {
         _ = try? await sleeper.value
     }
 
+    func testHandlerPhaseRecorderUsesWatchdogClockAndFormatsEscalationContext() async throws {
+        let clock = ExecutionWatchdogManualClock()
+        let origin = await clock.currentTime()
+        let recorder = MCPToolExecutionHandlerPhaseRecorder(
+            origin: origin,
+            now: { await clock.environment.now() }
+        )
+
+        await recorder.report(.manageSelectionAutoSelectionDrain, transition: .started)
+        try await clock.advanceWithoutSleepers(by: .seconds(2))
+        let phase = try XCTUnwrap(recorder.snapshot())
+        let invocationID = UUID()
+        let event = MCPToolExecutionTraceEvent(
+            toolName: MCPWindowToolName.manageSelection,
+            connectionID: UUID(),
+            invocationID: invocationID,
+            runID: nil,
+            contractKind: .bounded,
+            executionDeadlineSeconds: 30,
+            cleanupGraceSeconds: 5,
+            phase: .deadlineExpired,
+            elapsedMilliseconds: 2000,
+            cancellationRequested: nil,
+            cancellationOutcome: nil,
+            graceOutcome: nil,
+            escalationReason: nil,
+            handlerPhase: phase,
+            handlerPhaseAgeMilliseconds: 2000
+        )
+
+        XCTAssertEqual(phase.phase, .manageSelectionAutoSelectionDrain)
+        XCTAssertEqual(phase.transition, .started)
+        XCTAssertEqual(phase.elapsedMilliseconds, 0)
+        XCTAssertTrue(event.description.contains("invocation_id=\(invocationID.uuidString)"))
+        XCTAssertTrue(event.description.contains("handler_phase=manage_selection.auto_selection_drain"))
+        XCTAssertTrue(event.description.contains("handler_phase_transition=started"))
+        XCTAssertTrue(event.description.contains("handler_phase_age_ms=2000.000"))
+    }
+
     func testExternalCancellationCancelsOwnedTasksAndPropagatesCancellation() async throws {
         let clock = ExecutionWatchdogManualClock()
         let gate = ExecutionWatchdogUncooperativeGate()

--- a/Tests/RepoPromptTests/MCP/Control/PersistentAgentModeMCPReadFileConnectionTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/PersistentAgentModeMCPReadFileConnectionTests.swift
@@ -64,6 +64,36 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
             throw XCTSkip("Persistent Agent Mode MCP socketpair integration requires DEBUG inspection helpers.")
         #endif
     }
+
+    func testReadAutoSelectionDeclinesWhenBoundTabClosesDuringPersistenceSuspension() async throws {
+        #if DEBUG
+            try await withFixture { fixture in
+                try await runCheckpoint(fixture: fixture, scenario: .tabCloseDuringPersistence)
+            }
+        #else
+            throw XCTSkip("Persistent Agent Mode MCP socketpair integration requires DEBUG inspection helpers.")
+        #endif
+    }
+
+    func testReadAutoSelectionResolvesWorkspaceAndTabAgainAfterWorkspaceReorder() async throws {
+        #if DEBUG
+            try await withFixture { fixture in
+                try await runCheckpoint(fixture: fixture, scenario: .workspaceReorderDuringPersistence)
+            }
+        #else
+            throw XCTSkip("Persistent Agent Mode MCP socketpair integration requires DEBUG inspection helpers.")
+        #endif
+    }
+
+    func testReadAutoSelectionDeclinesWhenConnectionRebindsDuringPersistenceSuspension() async throws {
+        #if DEBUG
+            try await withFixture { fixture in
+                try await runCheckpoint(fixture: fixture, scenario: .rebindDuringPersistence)
+            }
+        #else
+            throw XCTSkip("Persistent Agent Mode MCP socketpair integration requires DEBUG inspection helpers.")
+        #endif
+    }
 }
 
 #if DEBUG
@@ -75,6 +105,9 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
             case manageSelectionClear
             case endOfRun
             case searchWorkspaceContextDrain
+            case tabCloseDuringPersistence
+            case workspaceReorderDuringPersistence
+            case rebindDuringPersistence
         }
 
         func withFixture(_ operation: (Fixture) async throws -> Void) async throws {
@@ -225,6 +258,12 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
                 try await assertEndOfRunFinish(fixture: fixture)
             case .searchWorkspaceContextDrain:
                 try await assertSearchWorkspaceContextDrain(fixture: fixture)
+            case .tabCloseDuringPersistence:
+                try await assertTabCloseDuringAutoSelectionPersistence(fixture: fixture)
+            case .workspaceReorderDuringPersistence:
+                try await assertWorkspaceReorderDuringAutoSelectionPersistence(fixture: fixture)
+            case .rebindDuringPersistence:
+                try await assertRebindDuringAutoSelectionPersistence(fixture: fixture)
             }
         }
 
@@ -468,6 +507,145 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
             let contextResponse = try await contextTask.value
             try Self.assertSuccessfulResponse(contextResponse, id: 7)
             XCTAssertTrue(contextResponse.contains("PersistentAgentModeFixture.swift"), contextResponse)
+        }
+
+        func assertTabCloseDuringAutoSelectionPersistence(fixture: Fixture) async throws {
+            try await clearSelection(fixture: fixture, id: 6)
+            let gate = PersistentAsyncGate()
+            fixture.window.mcpServer.setReadFileAutoSelectionPersistenceGateForTesting {
+                await gate.markStartedAndWaitForRelease()
+            }
+            defer {
+                fixture.window.mcpServer.setReadFileAutoSelectionPersistenceGateForTesting(nil)
+                Task { await gate.release() }
+            }
+
+            let read = gatedReadTask(fixture: fixture, id: 7)
+            await gate.waitUntilStarted()
+            try await assertReadReplyReturned(read, gate: gate, id: 7)
+
+            let manager = fixture.window.workspaceManager
+            let workspaceIndex = try XCTUnwrap(manager.workspaces.firstIndex { $0.id == fixture.workspaceID })
+            let originalWorkspace = manager.workspaces[workspaceIndex]
+            var workspaceWithoutTab = originalWorkspace
+            workspaceWithoutTab.composeTabs.removeAll { $0.id == Fixture.tabID }
+            if workspaceWithoutTab.activeComposeTabID == Fixture.tabID {
+                workspaceWithoutTab.activeComposeTabID = workspaceWithoutTab.composeTabs.first?.id
+            }
+            manager.workspaces[workspaceIndex] = workspaceWithoutTab
+
+            await gate.release()
+            let settled = await waitForCanonicalWorkerToSettle(fixture: fixture)
+            XCTAssertTrue(settled)
+            let boundSelection = fixture.window.mcpServer.tabContextByConnectionID[Fixture.connectionID]?.selection
+            XCTAssertEqual(boundSelection?.selectedPaths, [])
+            XCTAssertEqual(boundSelection?.slices, [:])
+
+            manager.workspaces[workspaceIndex] = originalWorkspace
+        }
+
+        func assertWorkspaceReorderDuringAutoSelectionPersistence(fixture: Fixture) async throws {
+            try await clearSelection(fixture: fixture, id: 6)
+            let gate = PersistentAsyncGate()
+            fixture.window.mcpServer.setReadFileAutoSelectionPersistenceGateForTesting {
+                await gate.markStartedAndWaitForRelease()
+            }
+            defer {
+                fixture.window.mcpServer.setReadFileAutoSelectionPersistenceGateForTesting(nil)
+                Task { await gate.release() }
+            }
+
+            let read = gatedReadTask(fixture: fixture, id: 7)
+            await gate.waitUntilStarted()
+            try await assertReadReplyReturned(read, gate: gate, id: 7)
+
+            let manager = fixture.window.workspaceManager
+            let originalIndex = try XCTUnwrap(manager.workspaces.firstIndex { $0.id == fixture.workspaceID })
+            var decoy = WorkspaceModel(
+                name: "Read Auto-Selection Reorder Decoy",
+                repoPaths: []
+            )
+            decoy.composeTabs = []
+            let decoyID = decoy.id
+            manager.workspaces.insert(decoy, at: originalIndex)
+            defer { manager.workspaces.removeAll { $0.id == decoyID } }
+
+            await gate.release()
+            let settled = await waitForCanonicalWorkerToSettle(fixture: fixture)
+            XCTAssertTrue(settled)
+            let storedSelection = manager.workspaces
+                .first(where: { $0.id == fixture.workspaceID })?
+                .composeTabs.first(where: { $0.id == Fixture.tabID })?
+                .selection
+            XCTAssertEqual(storedSelection?.selectedPaths, [fixture.fileURL.path])
+            XCTAssertEqual(storedSelection?.slices, [:])
+        }
+
+        func assertRebindDuringAutoSelectionPersistence(fixture: Fixture) async throws {
+            try await clearSelection(fixture: fixture, id: 6)
+            let manager = fixture.window.workspaceManager
+            let workspaceIndex = try XCTUnwrap(manager.workspaces.firstIndex { $0.id == fixture.workspaceID })
+            let replacementTabID = UUID()
+            manager.workspaces[workspaceIndex].composeTabs.append(
+                ComposeTabState(id: replacementTabID, name: "Replacement Auto-Selection Owner")
+            )
+
+            let gate = PersistentAsyncGate()
+            fixture.window.mcpServer.setReadFileAutoSelectionPersistenceGateForTesting {
+                await gate.markStartedAndWaitForRelease()
+            }
+            defer {
+                fixture.window.mcpServer.setReadFileAutoSelectionPersistenceGateForTesting(nil)
+                Task { await gate.release() }
+            }
+
+            let read = gatedReadTask(fixture: fixture, id: 7)
+            await gate.waitUntilStarted()
+            try await assertReadReplyReturned(read, gate: gate, id: 7)
+
+            try fixture.window.mcpServer.bindTabForConnection(
+                connectionID: Fixture.connectionID,
+                clientName: AgentProviderKind.codexMCPClientID,
+                tabID: replacementTabID,
+                workspaceID: fixture.workspaceID,
+                windowID: fixture.windowID,
+                runID: Fixture.runID,
+                explicitlyBound: false
+            )
+            await gate.release()
+            let settled = await waitForCanonicalWorkerToSettle(fixture: fixture)
+            XCTAssertTrue(settled)
+
+            let replacementBinding = fixture.window.mcpServer.tabContextByConnectionID[Fixture.connectionID]
+            XCTAssertEqual(replacementBinding?.tabID, replacementTabID)
+            XCTAssertEqual(replacementBinding?.selection.selectedPaths, [])
+            XCTAssertEqual(replacementBinding?.selection.slices, [:])
+            let originalSelection = manager.composeTab(with: Fixture.tabID)?.selection
+            XCTAssertEqual(originalSelection?.selectedPaths, [])
+            XCTAssertEqual(originalSelection?.slices, [:])
+        }
+
+        func clearSelection(fixture: Fixture, id: Int) async throws {
+            let response = try await fixture.socketClient.request(
+                id: id,
+                method: "tools/call",
+                params: [
+                    "name": MCPWindowToolName.manageSelection,
+                    "arguments": ["op": "clear"]
+                ]
+            )
+            try Self.assertSuccessfulResponse(response, id: id)
+        }
+
+        func waitForCanonicalWorkerToSettle(fixture: Fixture) async -> Bool {
+            let deadline = ContinuousClock.now + .seconds(2)
+            while ContinuousClock.now < deadline {
+                if fixture.window.mcpServer.readFileAutoSelectionDiagnosticsSnapshot().canonicalWorkerCount == 0 {
+                    return true
+                }
+                try? await Task.sleep(for: .milliseconds(10))
+            }
+            return fixture.window.mcpServer.readFileAutoSelectionDiagnosticsSnapshot().canonicalWorkerCount == 0
         }
 
         func gatedReadTask(fixture: Fixture, id: Int) -> Task<String, Error> {

--- a/Tests/RepoPromptTests/MCP/Control/PersistentAgentModeMCPReadFileConnectionTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/PersistentAgentModeMCPReadFileConnectionTests.swift
@@ -278,7 +278,7 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
             }
 
             let firstRead = gatedReadTask(fixture: fixture, id: 6)
-            await gate.waitUntilStarted()
+            try await requireGateStarted(gate)
             try await assertReadReplyReturned(firstRead, gate: gate, id: 6)
             let secondRead = gatedReadTask(fixture: fixture, id: 7)
             try await assertReadReplyReturned(secondRead, gate: gate, id: 7)
@@ -319,7 +319,7 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
             }
 
             let read = gatedReadTask(fixture: fixture, id: 6)
-            await gate.waitUntilStarted()
+            try await requireGateStarted(gate)
             try await assertReadReplyReturned(read, gate: gate, id: 6)
 
             let exportURL = fixture.rootURL.appendingPathComponent("prompt-export.txt")
@@ -373,7 +373,7 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
             }
 
             let read = gatedReadTask(fixture: fixture, id: 7)
-            await gate.waitUntilStarted()
+            try await requireGateStarted(gate)
             try await assertReadReplyReturned(read, gate: gate, id: 7)
 
             let clearFinished = PersistentAsyncSignal()
@@ -395,9 +395,19 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
 
             await gate.release()
             try await Self.assertSuccessfulResponse(clearTask.value, id: 8)
+
+            fixture.window.workspaceManager.publishActiveComposeTabSnapshot(
+                commitToMemory: true,
+                touchModified: false
+            )
+            await Task.yield()
+
             let finalSelection = fixture.window.mcpServer.tabContextByConnectionID[Fixture.connectionID]?.selection
             XCTAssertEqual(finalSelection?.selectedPaths, [])
             XCTAssertEqual(finalSelection?.slices, [:])
+            let storedSelection = fixture.window.workspaceManager.composeTab(with: Fixture.tabID)?.selection
+            XCTAssertEqual(storedSelection?.selectedPaths, [])
+            XCTAssertEqual(storedSelection?.slices, [:])
             let current = await fixture.retainedConnectionSnapshot()
             Self.assertStableAgentModeSnapshot(current, fixture: fixture)
         }
@@ -423,7 +433,7 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
             }
 
             let read = gatedReadTask(fixture: fixture, id: 7)
-            await gate.waitUntilStarted()
+            try await requireGateStarted(gate)
             try await assertReadReplyReturned(read, gate: gate, id: 7)
 
             let finishCompleted = PersistentAsyncSignal()
@@ -470,7 +480,7 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
                     ]
                 )
             }
-            await gate.waitUntilStarted()
+            try await requireGateStarted(gate)
             let searchFinished = PersistentAsyncSignal()
             let searchObserver = Task {
                 let result = await searchTask.result
@@ -521,7 +531,7 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
             }
 
             let read = gatedReadTask(fixture: fixture, id: 7)
-            await gate.waitUntilStarted()
+            try await requireGateStarted(gate)
             try await assertReadReplyReturned(read, gate: gate, id: 7)
 
             let manager = fixture.window.workspaceManager
@@ -556,7 +566,7 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
             }
 
             let read = gatedReadTask(fixture: fixture, id: 7)
-            await gate.waitUntilStarted()
+            try await requireGateStarted(gate)
             try await assertReadReplyReturned(read, gate: gate, id: 7)
 
             let manager = fixture.window.workspaceManager
@@ -600,7 +610,7 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
             }
 
             let read = gatedReadTask(fixture: fixture, id: 7)
-            await gate.waitUntilStarted()
+            try await requireGateStarted(gate)
             try await assertReadReplyReturned(read, gate: gate, id: 7)
 
             try fixture.window.mcpServer.bindTabForConnection(
@@ -676,6 +686,13 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
             let response = try await observer.value.get()
             let formattedRead = try Self.readFileText(from: response, id: id)
             XCTAssertTrue(formattedRead.contains(Fixture.sentinelContent), formattedRead)
+        }
+
+        func requireGateStarted(_ gate: PersistentAsyncGate) async throws {
+            guard await gate.waitUntilStarted() else {
+                XCTFail("Timed out waiting for the persistent async gate to start")
+                throw PersistentAsyncGateTimeoutError()
+            }
         }
 
         func waitUntilMarked(_ signal: PersistentAsyncSignal, timeout: Duration) async -> Bool {
@@ -1158,33 +1175,30 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
         }
     }
 
+    private struct PersistentAsyncGateTimeoutError: Error {}
+
     private actor PersistentAsyncGate {
         private var started = false
         private var released = false
-        private var startWaiters: [CheckedContinuation<Void, Never>] = []
-        private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
 
-        func markStartedAndWaitForRelease() async {
+        func markStartedAndWaitForRelease(timeout: Duration = .seconds(10)) async {
             started = true
-            startWaiters.forEach { $0.resume() }
-            startWaiters.removeAll()
-            guard !released else { return }
-            await withCheckedContinuation { continuation in
-                releaseWaiters.append(continuation)
+            let deadline = ContinuousClock.now + timeout
+            while !released, ContinuousClock.now < deadline {
+                try? await Task.sleep(for: .milliseconds(10))
             }
         }
 
-        func waitUntilStarted() async {
-            guard !started else { return }
-            await withCheckedContinuation { continuation in
-                startWaiters.append(continuation)
+        func waitUntilStarted(timeout: Duration = .seconds(2)) async -> Bool {
+            let deadline = ContinuousClock.now + timeout
+            while !started, ContinuousClock.now < deadline {
+                try? await Task.sleep(for: .milliseconds(10))
             }
+            return started
         }
 
         func release() {
             released = true
-            releaseWaiters.forEach { $0.resume() }
-            releaseWaiters.removeAll()
         }
     }
 

--- a/Tests/RepoPromptTests/MCP/Control/PersistentMCPResponseDeliveryTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/PersistentMCPResponseDeliveryTests.swift
@@ -1,5 +1,6 @@
 import Darwin
 import Foundation
+@testable import RepoPrompt
 @testable import RepoPromptMCP
 import RepoPromptShared
 import XCTest
@@ -74,6 +75,447 @@ final class PersistentMCPResponseDeliveryTests: XCTestCase {
         let snapshot = await ledger.snapshot()
         XCTAssertEqual(snapshot.activeRequestCount, 0)
         XCTAssertNil(snapshot.terminalReason)
+    }
+
+    func testProxyHalfClosePeriodicallyReportsBlockingDrainCounters() async throws {
+        var sockets = [Int32](repeating: -1, count: 2)
+        var stdinPipe = [Int32](repeating: -1, count: 2)
+        var stdoutPipe = [Int32](repeating: -1, count: 2)
+        var drainLogPipe = [Int32](repeating: -1, count: 2)
+        XCTAssertEqual(Darwin.socketpair(AF_UNIX, SOCK_STREAM, 0, &sockets), 0)
+        XCTAssertEqual(Darwin.pipe(&stdinPipe), 0)
+        XCTAssertEqual(Darwin.pipe(&stdoutPipe), 0)
+        XCTAssertEqual(Darwin.pipe(&drainLogPipe), 0)
+        defer {
+            (sockets + stdinPipe + stdoutPipe + drainLogPipe).forEach(Self.closeIfOpen)
+        }
+
+        let ledger = JSONRPCBridgeLedger()
+        _ = try await ledger.beginConnection()
+        let poller = ManualBridgeSocketPoller()
+        let drainClock = ManualBridgeDrainClock()
+        let bridgeTask = Task {
+            do {
+                try await BootstrapSocketProxy.runBridge(
+                    socketFD: sockets[0],
+                    stdinFD: stdinPipe[0],
+                    stdoutFD: stdoutPipe[1],
+                    identityCache: ClientIdentityCache(),
+                    bridgeLedger: ledger,
+                    faultRule: nil,
+                    socketPoller: { _ in try await poller.next() },
+                    drainClock: { drainClock.now() },
+                    drainVisibilityInterval: 1,
+                    drainLogDescriptor: drainLogPipe[1],
+                    onStdinClosed: {
+                        await poller.markStdinClosed()
+                    }
+                )
+                await poller.markBridgeCompleted()
+            } catch {
+                await poller.markBridgeCompleted()
+                throw error
+            }
+        }
+
+        let requestFrame = request(id: 402)
+        try Self.writeAll(requestFrame, to: stdinPipe[1])
+        Self.closeIfOpen(stdinPipe[1])
+        stdinPipe[1] = -1
+        let forwardedRequest = try await Task.detached {
+            try Self.readLine(from: sockets[1])
+        }.value
+        XCTAssertEqual(forwardedRequest, requestFrame)
+        let observedStdinClose = await poller.waitUntilStdinClosed()
+        XCTAssertTrue(observedStdinClose)
+
+        let reachedInitialWait = await poller.waitUntilWaiting(count: 1)
+        XCTAssertTrue(reachedInitialWait)
+        await poller.resumeNext(.timedOut)
+        let reachedSecondWait = await poller.waitUntilWaiting(count: 2)
+        XCTAssertTrue(reachedSecondWait)
+
+        drainClock.advance(by: 0.5)
+        await poller.resumeNext(.timedOut)
+        let reachedThirdWait = await poller.waitUntilWaiting(count: 3)
+        XCTAssertTrue(reachedThirdWait)
+
+        drainClock.advance(by: 0.5)
+        await poller.resumeNext(.timedOut)
+        let reachedFourthWait = await poller.waitUntilWaiting(count: 4)
+        XCTAssertTrue(reachedFourthWait)
+
+        let responseFrame = response(id: 402)
+        try Self.writeAll(responseFrame, to: sockets[1])
+        await poller.resumeNext(.events(Int16(POLLIN)))
+        try await bridgeTask.value
+
+        Self.closeIfOpen(drainLogPipe[1])
+        drainLogPipe[1] = -1
+        let logData = try Self.readToEOF(from: drainLogPipe[0])
+        let log = try XCTUnwrap(String(data: logData, encoding: .utf8))
+        XCTAssertEqual(log.components(separatedBy: "[MCPBridgeDrain] waiting").count - 1, 2, log)
+        XCTAssertTrue(log.contains("active_requests=1"), log)
+        XCTAssertTrue(log.contains("pending_transactions=0"), log)
+        XCTAssertTrue(log.contains("partial_bytes=0"), log)
+        XCTAssertTrue(log.contains("response_in_delivery=0"), log)
+    }
+
+    @MainActor
+    func testExecutionWatchdogTransportAbortTerminatesBridgeWithoutReconnectAndMapsToNonzeroStdioExit() async throws {
+        #if DEBUG
+            try await MCPSharedServerTestLease.shared.withLease { lease in
+                let fixture = try await PersistentMCPTestFixture.make(lease: lease)
+                let manager = fixture.networkManager
+                let clock = ExecutionWatchdogManualClock()
+                let operationGate = WatchdogIgnoringCancellationGate()
+                let traceRecorder = WatchdogExecutionTraceRecorder()
+                let clientName = "bridge-watchdog-terminal-\(UUID().uuidString)"
+                var harness: ExecutionWatchdogBridgeHarness?
+                var toolCall: Task<PersistentMCPTestRPCResponse, Error>?
+
+                MCPToolExecutionTracer.setTestSink { traceRecorder.append($0) }
+                await manager.installClientConnectionPolicy(
+                    for: clientName,
+                    windowID: fixture.contextA.window.windowID,
+                    restrictedTools: [],
+                    tabID: fixture.contextA.tabID,
+                    runID: UUID(),
+                    additionalTools: [MCPGlobalToolName.manageWorkspaces],
+                    purpose: .agentModeRun
+                )
+                await manager.debugSetToolExecutionWatchdogEnvironment(clock.environment)
+                await manager.debugSetResolvedToolOperationOverride(toolName: MCPGlobalToolName.manageWorkspaces) {
+                    await operationGate.enterAndWait()
+                    return .null
+                }
+
+                do {
+                    let createdHarness = try await ExecutionWatchdogBridgeHarness.make(
+                        networkManager: manager,
+                        clientName: clientName
+                    )
+                    harness = createdHarness
+                    let activeToolCall = Task {
+                        try await createdHarness.callTool(
+                            name: MCPGlobalToolName.manageWorkspaces,
+                            arguments: [
+                                "action": "switch",
+                                "workspace": fixture.contextA.workspaceID.uuidString,
+                                "window_id": fixture.contextA.window.windowID
+                            ]
+                        )
+                    }
+                    toolCall = activeToolCall
+                    try await clock.waitForSleeperCount(1)
+                    try await operationGate.waitUntilEntered()
+
+                    try await clock.advanceNext(expected: MCPTimeoutPolicy.workspaceSwitchToolExecutionDeadline)
+                    try await clock.waitForSleeperCount(1)
+                    try await clock.advanceNext(expected: MCPTimeoutPolicy.boundedToolCancellationCleanupGrace)
+
+                    let bridgeResult = try await createdHarness.waitForBridgeResult(timeout: .seconds(10))
+                    guard case let .failure(rawBridgeError) = bridgeResult,
+                          let bridgeError = rawBridgeError as? JSONRPCBridgeLedgerError
+                    else {
+                        XCTFail("Expected execution watchdog to terminate the bridge with a ledger error")
+                        throw WatchdogBridgeFixtureError.unexpectedBridgeResult
+                    }
+
+                    do {
+                        _ = try await activeToolCall.value
+                        XCTFail("Expected watchdog bridge termination to close the stdio client")
+                    } catch PersistentMCPTestSocketClient.ClientError.closed {
+                        // Expected: the bridge-owned stdio descriptor closed on terminal exit.
+                    }
+                    toolCall = nil
+
+                    let terminalSnapshot = await createdHarness.ledger.snapshot()
+                    let terminalReason = try XCTUnwrap(terminalSnapshot.terminalReason)
+                    XCTAssertTrue(
+                        ["socket_eof_with_outstanding_work", "socket_hangup_with_outstanding_work"]
+                            .contains(terminalReason),
+                        terminalReason
+                    )
+                    XCTAssertEqual(bridgeError, .terminal(terminalReason))
+                    XCTAssertEqual(terminalSnapshot.activeRequestCount, 1)
+                    XCTAssertFalse(terminalSnapshot.canReconnect)
+                    XCTAssertEqual(createdHarness.traces.count(phase: "terminal_eof"), 1)
+                    let watchdogMarkedTerminal = await manager.debugIsExecutionWatchdogTerminal(
+                        connectionID: createdHarness.connectionID
+                    )
+                    let enteredCount = await operationGate.enteredCount()
+                    XCTAssertTrue(watchdogMarkedTerminal)
+                    XCTAssertEqual(enteredCount, 1)
+
+                    let watchdogEvents = traceRecorder.snapshot().filter {
+                        $0.connectionID == createdHarness.connectionID
+                            && $0.toolName == MCPGlobalToolName.manageWorkspaces
+                    }
+                    XCTAssertTrue(watchdogEvents.contains { $0.phase == .cleanupGraceExpired })
+                    XCTAssertTrue(watchdogEvents.contains { $0.phase == .connectionForceDisconnectRequested })
+
+                    // The XCTest target imports the executable module in-process, so invoking
+                    // handleRuntimeError would terminate the test runner. The production mapping
+                    // reached after this real watchdog→transport→bridge failure is asserted here;
+                    // the pending request's `.closed` result above covers observable stdio EOF.
+                    XCTAssertEqual(
+                        mcpCLIExitCode(for: .connectionFailed(underlying: bridgeError)),
+                        .connectionFailed
+                    )
+                    XCTAssertNotEqual(MCPCLIExitCode.connectionFailed.rawValue, MCPCLIExitCode.ok.rawValue)
+
+                    await operationGate.release()
+                    MCPToolExecutionTracer.setTestSink(nil)
+                    await manager.debugSetResolvedToolOperationOverride(
+                        toolName: MCPGlobalToolName.manageWorkspaces,
+                        operation: nil
+                    )
+                    await manager.debugResetToolExecutionWatchdogEnvironment()
+                    await createdHarness.cleanup()
+                    harness = nil
+                    await fixture.cleanup()
+                } catch {
+                    toolCall?.cancel()
+                    if let toolCall {
+                        _ = try? await toolCall.value
+                    }
+                    await operationGate.release()
+                    MCPToolExecutionTracer.setTestSink(nil)
+                    await manager.debugSetResolvedToolOperationOverride(
+                        toolName: MCPGlobalToolName.manageWorkspaces,
+                        operation: nil
+                    )
+                    await manager.debugResetToolExecutionWatchdogEnvironment()
+                    if let harness {
+                        await harness.cleanup()
+                    } else {
+                        await manager.clearClientConnectionPolicy(for: clientName)
+                        await manager.debugClearPersistedRoutingState(for: clientName)
+                    }
+                    await fixture.cleanup()
+                    throw error
+                }
+            }
+        #else
+            throw XCTSkip("Execution watchdog socket integration requires DEBUG diagnostics helpers.")
+        #endif
+    }
+
+    func testPendingResponseTransactionHalfCloseExpiresDrainDeadlineExactlyOnce() async throws {
+        var sockets = [Int32](repeating: -1, count: 2)
+        var stdinPipe = [Int32](repeating: -1, count: 2)
+        var stdoutPipe = [Int32](repeating: -1, count: 2)
+        var drainLogPipe = [Int32](repeating: -1, count: 2)
+        XCTAssertEqual(Darwin.socketpair(AF_UNIX, SOCK_STREAM, 0, &sockets), 0)
+        XCTAssertEqual(Darwin.pipe(&stdinPipe), 0)
+        XCTAssertEqual(Darwin.pipe(&stdoutPipe), 0)
+        XCTAssertEqual(Darwin.pipe(&drainLogPipe), 0)
+        defer {
+            (sockets + stdinPipe + stdoutPipe + drainLogPipe).forEach(Self.closeIfOpen)
+        }
+
+        let traces = BridgeTraceRecorder()
+        let ledger = JSONRPCBridgeLedger(traceSink: { traces.append($0) })
+        _ = try await ledger.beginConnection()
+        let preparedRequest = try await ledger.prepare(
+            frame: request(id: 404),
+            direction: .clientToServer
+        )
+        try await ledger.commit(preparedRequest)
+        _ = try await ledger.prepare(
+            frame: response(id: 404),
+            direction: .serverToClient
+        )
+        let pendingSnapshot = await ledger.snapshot()
+        XCTAssertEqual(pendingSnapshot.activeRequestCount, 1)
+        XCTAssertEqual(pendingSnapshot.responseInDeliveryCount, 1)
+        XCTAssertEqual(pendingSnapshot.pendingTransactionCount, 1)
+
+        let poller = ManualBridgeSocketPoller()
+        let drainClock = ManualBridgeDrainClock()
+        let bridgeTask = Task {
+            do {
+                try await BootstrapSocketProxy.runBridge(
+                    socketFD: sockets[0],
+                    stdinFD: stdinPipe[0],
+                    stdoutFD: stdoutPipe[1],
+                    identityCache: ClientIdentityCache(),
+                    bridgeLedger: ledger,
+                    faultRule: nil,
+                    socketPoller: { _ in try await poller.next() },
+                    drainClock: { drainClock.now() },
+                    drainDeadline: 1,
+                    drainLogDescriptor: drainLogPipe[1],
+                    onStdinClosed: {
+                        drainClock.advance(by: 2)
+                        await poller.markStdinClosed()
+                    }
+                )
+                await poller.markBridgeCompleted()
+            } catch {
+                await poller.markBridgeCompleted()
+                throw error
+            }
+        }
+
+        Self.closeIfOpen(stdinPipe[1])
+        stdinPipe[1] = -1
+        let observedStdinClose = await poller.waitUntilStdinClosed()
+        XCTAssertTrue(observedStdinClose)
+        let reachedDrainWait = await poller.waitUntilWaiting(count: 1)
+        XCTAssertTrue(reachedDrainWait)
+        await poller.resumeNext(.timedOut)
+
+        var observedBridgeError: JSONRPCBridgeLedgerError?
+        do {
+            try await bridgeTask.value
+            XCTFail("Expected pending response transaction to expire the bridge drain deadline")
+        } catch let error as JSONRPCBridgeLedgerError {
+            observedBridgeError = error
+        }
+        let bridgeError = try XCTUnwrap(observedBridgeError)
+        let deadlineReason = JSONRPCBridgeLedger.postStdinHalfCloseDrainDeadlineExceededReason
+        XCTAssertEqual(bridgeError, .terminal(deadlineReason))
+
+        Self.closeIfOpen(drainLogPipe[1])
+        drainLogPipe[1] = -1
+        let logData = try Self.readToEOF(from: drainLogPipe[0])
+        let log = try XCTUnwrap(String(data: logData, encoding: .utf8))
+        XCTAssertTrue(log.contains("[MCPBridgeDrain] deadline_exceeded"), log)
+        XCTAssertTrue(log.contains("deadline=1.000s"), log)
+        XCTAssertTrue(log.contains("active_requests=1"), log)
+        XCTAssertTrue(log.contains("pending_transactions=1"), log)
+        XCTAssertTrue(log.contains("partial_bytes=0"), log)
+        XCTAssertTrue(log.contains("response_in_delivery=1"), log)
+        XCTAssertTrue(log.contains("terminalized_reason=\(deadlineReason)"), log)
+
+        let terminalSnapshot = await ledger.snapshot()
+        XCTAssertEqual(terminalSnapshot.terminalReason, deadlineReason)
+        XCTAssertEqual(terminalSnapshot.pendingTransactionCount, 1)
+        XCTAssertFalse(terminalSnapshot.canReconnect)
+        XCTAssertEqual(
+            traces.count(phase: "post_stdin_half_close_drain_deadline_exceeded"),
+            1
+        )
+        let repeatedTerminalReason = await ledger.terminalizePostStdinHalfCloseDrainDeadline()
+        XCTAssertEqual(repeatedTerminalReason, deadlineReason)
+        XCTAssertEqual(
+            traces.count(phase: "post_stdin_half_close_drain_deadline_exceeded"),
+            1
+        )
+        let deadlineFailureWasTerminal = await ledger.recordConnectionFailure("bridge_drain_deadline")
+        XCTAssertTrue(deadlineFailureWasTerminal)
+        XCTAssertEqual(
+            mcpCLIExitCode(for: .connectionFailed(underlying: bridgeError)),
+            .connectionFailed
+        )
+        XCTAssertGreaterThan(
+            MCPTimeoutPolicy.postStdinHalfCloseBridgeDrainDeadlineSeconds,
+            MCPTimeoutPolicy.workspaceSwitchToolExecutionDeadlineSeconds
+        )
+
+        let freshLedger = JSONRPCBridgeLedger()
+        let freshGeneration = try await freshLedger.beginConnection()
+        XCTAssertEqual(freshGeneration, 1)
+        let freshSnapshot = await freshLedger.snapshot()
+        XCTAssertTrue(freshSnapshot.canReconnect)
+    }
+
+    func testDrainDeadlineRemainsBoundedWhenDiagnosticPipeIsFullAndUnread() async throws {
+        var sockets = [Int32](repeating: -1, count: 2)
+        var stdinPipe = [Int32](repeating: -1, count: 2)
+        var stdoutPipe = [Int32](repeating: -1, count: 2)
+        var drainLogPipe = [Int32](repeating: -1, count: 2)
+        XCTAssertEqual(Darwin.socketpair(AF_UNIX, SOCK_STREAM, 0, &sockets), 0)
+        XCTAssertEqual(Darwin.pipe(&stdinPipe), 0)
+        XCTAssertEqual(Darwin.pipe(&stdoutPipe), 0)
+        XCTAssertEqual(Darwin.pipe(&drainLogPipe), 0)
+        defer {
+            (sockets + stdinPipe + stdoutPipe + drainLogPipe).forEach(Self.closeIfOpen)
+        }
+
+        let traces = BridgeTraceRecorder()
+        let drainLogWriteFD = drainLogPipe[1]
+        let ledger = JSONRPCBridgeLedger(traceSink: { event in
+            traces.append(event)
+            MCPResponseDeliveryTracer.emit(event, to: drainLogWriteFD)
+        })
+        _ = try await ledger.beginConnection()
+        let preparedRequest = try await ledger.prepare(
+            frame: request(id: 405),
+            direction: .clientToServer
+        )
+        try await ledger.commit(preparedRequest)
+        _ = try await ledger.prepare(
+            frame: response(id: 405),
+            direction: .serverToClient
+        )
+        try Self.fillPipeToCapacity(drainLogPipe[1])
+
+        let poller = ManualBridgeSocketPoller()
+        let drainClock = ManualBridgeDrainClock()
+        let resultBox = BridgeTaskResultBox()
+        let bridgeTask = Task {
+            do {
+                try await BootstrapSocketProxy.runBridge(
+                    socketFD: sockets[0],
+                    stdinFD: stdinPipe[0],
+                    stdoutFD: stdoutPipe[1],
+                    identityCache: ClientIdentityCache(),
+                    bridgeLedger: ledger,
+                    faultRule: nil,
+                    socketPoller: { _ in try await poller.next() },
+                    drainClock: { drainClock.now() },
+                    drainDeadline: 1,
+                    drainVisibilityInterval: 0.1,
+                    drainLogDescriptor: drainLogPipe[1],
+                    onStdinClosed: {
+                        drainClock.advance(by: 2)
+                        await poller.markStdinClosed()
+                    }
+                )
+                resultBox.store(.success(()))
+            } catch {
+                resultBox.store(.failure(error))
+            }
+            await poller.markBridgeCompleted()
+        }
+
+        Self.closeIfOpen(stdinPipe[1])
+        stdinPipe[1] = -1
+        let observedStdinClose = await poller.waitUntilStdinClosed()
+        let reachedDrainWait = await poller.waitUntilWaiting(count: 1)
+        XCTAssertTrue(observedStdinClose)
+        XCTAssertTrue(reachedDrainWait)
+        await poller.resumeNext(.timedOut)
+
+        let completedWhilePipeRemainedFull = await resultBox.waitUntilStored(timeout: .seconds(1))
+        if !completedWhilePipeRemainedFull {
+            Self.closeIfOpen(drainLogPipe[0])
+            drainLogPipe[0] = -1
+        }
+        await bridgeTask.value
+        XCTAssertTrue(
+            completedWhilePipeRemainedFull,
+            "Drain deadline diagnostics blocked on a full unread pipe"
+        )
+
+        guard case let .failure(rawError) = resultBox.load(),
+              let bridgeError = rawError as? JSONRPCBridgeLedgerError
+        else {
+            XCTFail("Expected the full-pipe deadline path to terminate with a ledger error")
+            return
+        }
+        let deadlineReason = JSONRPCBridgeLedger.postStdinHalfCloseDrainDeadlineExceededReason
+        XCTAssertEqual(bridgeError, .terminal(deadlineReason))
+        let snapshot = await ledger.snapshot()
+        XCTAssertEqual(snapshot.terminalReason, deadlineReason)
+        XCTAssertFalse(snapshot.canReconnect)
+        XCTAssertEqual(
+            traces.count(phase: "post_stdin_half_close_drain_deadline_exceeded"),
+            1
+        )
     }
 
     func testFiveIndependentCallsDeliverExactlyFiveMatchingResponses() async throws {
@@ -330,6 +772,314 @@ private actor ManualBridgeSocketPoller {
     }
 }
 
+private final class BridgeTraceRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var events: [MCPResponseDeliveryTraceEvent] = []
+
+    func append(_ event: MCPResponseDeliveryTraceEvent) {
+        lock.lock()
+        events.append(event)
+        lock.unlock()
+    }
+
+    func count(phase: String) -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return events.count { $0.phase == phase }
+    }
+}
+
+private final class BridgeTaskResultBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var result: Result<Void, Error>?
+
+    func store(_ result: Result<Void, Error>) {
+        lock.lock()
+        self.result = result
+        lock.unlock()
+    }
+
+    func load() -> Result<Void, Error>? {
+        lock.lock()
+        defer { lock.unlock() }
+        return result
+    }
+
+    func waitUntilStored(timeout: Duration) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        while load() == nil, clock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return load() != nil
+    }
+}
+
+#if DEBUG
+    private final class WatchdogExecutionTraceRecorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var events: [MCPToolExecutionTraceEvent] = []
+
+        func append(_ event: MCPToolExecutionTraceEvent) {
+            lock.lock()
+            events.append(event)
+            lock.unlock()
+        }
+
+        func snapshot() -> [MCPToolExecutionTraceEvent] {
+            lock.lock()
+            defer { lock.unlock() }
+            return events
+        }
+    }
+
+    private actor WatchdogIgnoringCancellationGate {
+        private var count = 0
+        private var released = false
+        private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+
+        func enterAndWait() async {
+            count += 1
+            guard !released else { return }
+            await withCheckedContinuation { releaseWaiters.append($0) }
+        }
+
+        func waitUntilEntered(timeout: Duration = .seconds(10)) async throws {
+            let clock = ContinuousClock()
+            let deadline = clock.now.advanced(by: timeout)
+            while count == 0 {
+                guard clock.now < deadline else {
+                    throw WatchdogBridgeFixtureError.operationDidNotEnter
+                }
+                try await Task.sleep(for: .milliseconds(10))
+            }
+        }
+
+        func enteredCount() -> Int {
+            count
+        }
+
+        func release() {
+            released = true
+            releaseWaiters.forEach { $0.resume() }
+            releaseWaiters.removeAll()
+        }
+    }
+
+    private final class ExecutionWatchdogBridgeHarness: @unchecked Sendable {
+        let connectionID: UUID
+        let ledger: JSONRPCBridgeLedger
+        let traces: BridgeTraceRecorder
+
+        private let clientName: String
+        private let networkManager: ServerNetworkManager
+        private let connectionManager: BootstrapSocketConnectionManager
+        private let client: PersistentMCPTestSocketClient
+        private let startTask: Task<Void, Error>
+        private let bridgeTask: Task<Void, Never>
+        private let bridgeResult: BridgeTaskResultBox
+        private var cleanedUp = false
+
+        private init(
+            connectionID: UUID,
+            clientName: String,
+            networkManager: ServerNetworkManager,
+            connectionManager: BootstrapSocketConnectionManager,
+            client: PersistentMCPTestSocketClient,
+            ledger: JSONRPCBridgeLedger,
+            traces: BridgeTraceRecorder,
+            startTask: Task<Void, Error>,
+            bridgeTask: Task<Void, Never>,
+            bridgeResult: BridgeTaskResultBox
+        ) {
+            self.connectionID = connectionID
+            self.clientName = clientName
+            self.networkManager = networkManager
+            self.connectionManager = connectionManager
+            self.client = client
+            self.ledger = ledger
+            self.traces = traces
+            self.startTask = startTask
+            self.bridgeTask = bridgeTask
+            self.bridgeResult = bridgeResult
+        }
+
+        @MainActor
+        static func make(
+            networkManager: ServerNetworkManager,
+            clientName: String
+        ) async throws -> ExecutionWatchdogBridgeHarness {
+            var sockets = [Int32](repeating: -1, count: 2)
+            var stdioSockets = [Int32](repeating: -1, count: 2)
+            guard Darwin.socketpair(AF_UNIX, SOCK_STREAM, 0, &sockets) == 0 else {
+                throw WatchdogBridgeFixtureError.posix(operation: "app socketpair", code: errno)
+            }
+            guard Darwin.socketpair(AF_UNIX, SOCK_STREAM, 0, &stdioSockets) == 0 else {
+                sockets.forEach(PersistentMCPResponseDeliveryTests.closeIfOpen)
+                throw WatchdogBridgeFixtureError.posix(operation: "stdio socketpair", code: errno)
+            }
+            var noSigPipe: Int32 = 1
+            guard Darwin.setsockopt(
+                stdioSockets[0],
+                SOL_SOCKET,
+                SO_NOSIGPIPE,
+                &noSigPipe,
+                socklen_t(MemoryLayout.size(ofValue: noSigPipe))
+            ) == 0 else {
+                let code = errno
+                (sockets + stdioSockets).forEach(PersistentMCPResponseDeliveryTests.closeIfOpen)
+                throw WatchdogBridgeFixtureError.posix(operation: "setsockopt(SO_NOSIGPIPE)", code: code)
+            }
+
+            let connectionID = UUID()
+            let sessionToken = "bridge-watchdog-\(UUID().uuidString)"
+            await networkManager.debugClearPersistedRoutingState(for: clientName)
+            let connectionManager: BootstrapSocketConnectionManager
+            do {
+                connectionManager = try BootstrapSocketConnectionManager(
+                    connectionID: connectionID,
+                    sessionToken: sessionToken,
+                    clientPid: Int(getpid()),
+                    clientName: clientName,
+                    purpose: .agentModeRun,
+                    codeMapsDisabled: false,
+                    connectedFD: sockets[1],
+                    parentManager: networkManager
+                )
+                sockets[1] = -1
+            } catch {
+                (sockets + stdioSockets).forEach(PersistentMCPResponseDeliveryTests.closeIfOpen)
+                throw error
+            }
+
+            await networkManager.debugRegisterConnectionForSocketFixture(
+                connectionID: connectionID,
+                connection: connectionManager,
+                clientName: clientName,
+                sessionToken: sessionToken
+            )
+
+            let traces = BridgeTraceRecorder()
+            let ledger = JSONRPCBridgeLedger(traceSink: { traces.append($0) })
+            _ = try await ledger.beginConnection()
+            let bridgeResult = BridgeTaskResultBox()
+            let client = PersistentMCPTestSocketClient(fd: stdioSockets[0])
+            stdioSockets[0] = -1
+            let bridgeSocketFD = sockets[0]
+            sockets[0] = -1
+            let bridgeStdioFD = stdioSockets[1]
+            stdioSockets[1] = -1
+            let bridgeTask = Task {
+                defer {
+                    PersistentMCPResponseDeliveryTests.closeIfOpen(bridgeSocketFD)
+                    PersistentMCPResponseDeliveryTests.closeIfOpen(bridgeStdioFD)
+                }
+                do {
+                    try await BootstrapSocketProxy.runBridge(
+                        socketFD: bridgeSocketFD,
+                        stdinFD: bridgeStdioFD,
+                        stdoutFD: bridgeStdioFD,
+                        identityCache: ClientIdentityCache(),
+                        bridgeLedger: ledger,
+                        faultRule: nil
+                    )
+                    bridgeResult.store(.success(()))
+                } catch {
+                    bridgeResult.store(.failure(error))
+                }
+            }
+            let startTask = Task {
+                try await connectionManager.start { clientInfo in
+                    guard clientInfo.name == clientName else { return false }
+                    _ = await networkManager.debugApplyPendingPolicy(
+                        clientName: clientName,
+                        connectionID: connectionID,
+                        clientPid: Int(getpid()),
+                        bootstrapClientName: clientInfo.name
+                    )
+                    return true
+                }
+            }
+            let harness = ExecutionWatchdogBridgeHarness(
+                connectionID: connectionID,
+                clientName: clientName,
+                networkManager: networkManager,
+                connectionManager: connectionManager,
+                client: client,
+                ledger: ledger,
+                traces: traces,
+                startTask: startTask,
+                bridgeTask: bridgeTask,
+                bridgeResult: bridgeResult
+            )
+
+            do {
+                _ = try await client.request(
+                    method: "initialize",
+                    params: [
+                        "protocolVersion": "2025-11-25",
+                        "capabilities": [:],
+                        "clientInfo": [
+                            "name": clientName,
+                            "version": "bridge-watchdog-terminal-test"
+                        ]
+                    ]
+                )
+                try await startTask.value
+                try client.sendNotification(method: "notifications/initialized", params: [:])
+                return harness
+            } catch {
+                await harness.cleanup()
+                throw error
+            }
+        }
+
+        func callTool(
+            name: String,
+            arguments: [String: Any]
+        ) async throws -> PersistentMCPTestRPCResponse {
+            try await client.request(
+                method: "tools/call",
+                params: [
+                    "name": name,
+                    "arguments": arguments
+                ]
+            )
+        }
+
+        func waitForBridgeResult(timeout: Duration) async throws -> Result<Void, Error> {
+            guard await bridgeResult.waitUntilStored(timeout: timeout),
+                  let result = bridgeResult.load()
+            else {
+                throw WatchdogBridgeFixtureError.bridgeDidNotTerminate
+            }
+            return result
+        }
+
+        @MainActor
+        func cleanup() async {
+            guard !cleanedUp else { return }
+            cleanedUp = true
+            client.close()
+            bridgeTask.cancel()
+            startTask.cancel()
+            await connectionManager.stop()
+            await networkManager.debugRemoveConnection(connectionID)
+            await networkManager.clearClientConnectionPolicy(for: clientName)
+            await networkManager.debugClearPersistedRoutingState(for: clientName)
+            _ = try? await startTask.value
+            _ = await bridgeResult.waitUntilStored(timeout: .seconds(2))
+        }
+    }
+
+    private enum WatchdogBridgeFixtureError: Error {
+        case bridgeDidNotTerminate
+        case operationDidNotEnter
+        case posix(operation: String, code: Int32)
+        case unexpectedBridgeResult
+    }
+#endif
+
 private actor WriteRecorder {
     private(set) var frames: [Data] = []
 
@@ -395,6 +1145,45 @@ private extension PersistentMCPResponseDeliveryTests {
                 written += result
             } else if result < 0, errno == EINTR {
                 continue
+            } else {
+                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+            }
+        }
+    }
+
+    static func fillPipeToCapacity(_ fd: Int32) throws {
+        let originalFlags = fcntl(fd, F_GETFL)
+        guard originalFlags >= 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        guard fcntl(fd, F_SETFL, originalFlags | O_NONBLOCK) >= 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        defer { _ = fcntl(fd, F_SETFL, originalFlags) }
+
+        let payload = [UInt8](repeating: 0x58, count: 4096)
+        while true {
+            let result = payload.withUnsafeBytes { bytes in
+                Darwin.write(fd, bytes.baseAddress, bytes.count)
+            }
+            if result > 0 { continue }
+            if result < 0, errno == EINTR { continue }
+            if result < 0, errno == EAGAIN || errno == EWOULDBLOCK { return }
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+    }
+
+    static func readToEOF(from fd: Int32) throws -> Data {
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 1024)
+        while true {
+            let result = Darwin.read(fd, &buffer, buffer.count)
+            if result > 0 {
+                data.append(contentsOf: buffer[0 ..< result])
+            } else if result < 0, errno == EINTR {
+                continue
+            } else if result == 0 {
+                return data
             } else {
                 throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
             }

--- a/Tests/RepoPromptTests/MCP/MCPReadFileAutoSelectionCoordinatorTests.swift
+++ b/Tests/RepoPromptTests/MCP/MCPReadFileAutoSelectionCoordinatorTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 @testable import RepoPrompt
 import XCTest
 
@@ -121,7 +122,7 @@ final class MCPReadFileAutoSelectionCoordinatorTests: XCTestCase {
         await firstGate.waitUntilStarted()
         let drainFinished = CoordinatorAsyncSignal()
         let drainTask = Task { @MainActor in
-            await coordinator.drain(.canonicalSelection, for: key)
+            _ = await coordinator.drain(.canonicalSelection, for: key)
             await drainFinished.mark()
         }
         await Task.yield()
@@ -135,6 +136,201 @@ final class MCPReadFileAutoSelectionCoordinatorTests: XCTestCase {
         await secondGate.release()
         await drainTask.value
         await coordinator.drain(.canonicalSelection, for: key)
+    }
+
+    func testCancelledCanonicalDrainResumesPromptlyWithoutStoppingWorker() async {
+        let gate = CoordinatorAsyncGate()
+        let coordinator = makeCoordinator(recorder: CoordinatorRecorder()) { _, _ in
+            await gate.markStartedAndWaitForRelease()
+            return .unchanged
+        }
+        let key = contextKey()
+
+        XCTAssertTrue(coordinator.enqueue(intent: .full(paths: ["/tmp/A.swift"]), for: key))
+        await gate.waitUntilStarted()
+        let drainTask = Task { @MainActor in
+            await coordinator.drain(.canonicalSelection, for: key)
+        }
+        let canonicalWaiterRegistered = await waitUntil {
+            coordinator.debugSnapshot().canonicalWaiterCount == 1
+        }
+        XCTAssertTrue(canonicalWaiterRegistered)
+
+        drainTask.cancel()
+
+        let canonicalResult = await drainTask.value
+        XCTAssertEqual(canonicalResult, .cancelled)
+        XCTAssertEqual(coordinator.debugSnapshot().canonicalWaiterCount, 0)
+        XCTAssertEqual(coordinator.debugSnapshot().canonicalWorkerCount, 1)
+
+        await gate.release()
+        let settledCanonicalResult = await coordinator.drain(.canonicalSelection, for: key)
+        XCTAssertEqual(settledCanonicalResult, .completed)
+        let canonicalWorkerStopped = await waitUntil {
+            coordinator.debugSnapshot().canonicalWorkerCount == 0
+        }
+        XCTAssertTrue(canonicalWorkerStopped)
+    }
+
+    func testCancelledMirrorDrainResumesPromptlyWithoutStoppingWorker() async {
+        let mirrorGate = CoordinatorAsyncGate()
+        let coordinator = MCPReadFileAutoSelectionCoordinator(
+            isContextCurrent: { _ in true },
+            applyCanonical: { key, _ in
+                MCPReadFileAutoSelectionCoordinator.CanonicalApplyResult(mirrorKey: key.mirrorKey)
+            },
+            applyMirror: { _ in
+                await mirrorGate.markStartedAndWaitForRelease()
+            }
+        )
+        let key = contextKey()
+
+        XCTAssertTrue(coordinator.enqueue(intent: .full(paths: ["/tmp/A.swift"]), for: key))
+        await mirrorGate.waitUntilStarted()
+        let drainTask = Task { @MainActor in
+            await coordinator.drain(.mirroredSelectionAndMetrics, for: key)
+        }
+        let mirrorWaiterRegistered = await waitUntil {
+            coordinator.debugSnapshot().mirrorWaiterCount == 1
+        }
+        XCTAssertTrue(mirrorWaiterRegistered)
+
+        drainTask.cancel()
+
+        let mirrorResult = await drainTask.value
+        XCTAssertEqual(mirrorResult, .cancelled)
+        XCTAssertEqual(coordinator.debugSnapshot().mirrorWaiterCount, 0)
+        XCTAssertEqual(coordinator.debugSnapshot().mirrorWorkerCount, 1)
+
+        await mirrorGate.release()
+        let settledMirrorResult = await coordinator.drain(.mirroredSelectionAndMetrics, for: key)
+        XCTAssertEqual(settledMirrorResult, .completed)
+        let mirrorWorkerStopped = await waitUntil {
+            coordinator.debugSnapshot().mirrorWorkerCount == 0
+        }
+        XCTAssertTrue(mirrorWorkerStopped)
+    }
+
+    func testCanonicalCompletionCancellationRaceResumesWaiterExactlyOnce() async {
+        for iteration in 0 ..< 20 {
+            let gate = CoordinatorAsyncGate()
+            let coordinator = makeCoordinator(recorder: CoordinatorRecorder()) { _, _ in
+                await gate.markStartedAndWaitForRelease()
+                return .unchanged
+            }
+            let key = contextKey()
+
+            XCTAssertTrue(coordinator.enqueue(intent: .full(paths: ["/tmp/\(iteration).swift"]), for: key))
+            await gate.waitUntilStarted()
+            let drainTask = Task { @MainActor in
+                await coordinator.drain(.canonicalSelection, for: key)
+            }
+            let waiterRegistered = await waitUntil {
+                coordinator.debugSnapshot().canonicalWaiterCount == 1
+            }
+            XCTAssertTrue(waiterRegistered)
+
+            let releaseTask = Task {
+                await gate.release()
+            }
+            drainTask.cancel()
+            await releaseTask.value
+            await drainTask.value
+            await coordinator.drain(.canonicalSelection, for: key)
+            let workerStopped = await waitUntil {
+                coordinator.debugSnapshot().canonicalWorkerCount == 0
+            }
+
+            let snapshot = coordinator.debugSnapshot()
+            XCTAssertTrue(workerStopped, "iteration \(iteration)")
+            XCTAssertEqual(snapshot.canonicalWaiterCount, 0, "iteration \(iteration)")
+        }
+    }
+
+    func testDiagnosticsExposeCanonicalAndMirrorHighWaterWaitersAndWorkers() async throws {
+        let canonicalGate = CoordinatorAsyncGate()
+        let mirrorGate = CoordinatorAsyncGate()
+        let diagnostics = CoordinatorDiagnosticRecorder()
+        let key = contextKey()
+        let coordinator = MCPReadFileAutoSelectionCoordinator(
+            isContextCurrent: { _ in true },
+            applyCanonical: { key, _ in
+                await canonicalGate.markStartedAndWaitForRelease()
+                return MCPReadFileAutoSelectionCoordinator.CanonicalApplyResult(mirrorKey: key.mirrorKey)
+            },
+            applyMirror: { _ in
+                await mirrorGate.markStartedAndWaitForRelease()
+            }
+        )
+        MCPReadFileAutoSelectionDiagnosticTracer.setTestSink { diagnostics.append($0) }
+        defer { MCPReadFileAutoSelectionDiagnosticTracer.setTestSink(nil) }
+
+        XCTAssertTrue(coordinator.enqueue(intent: .full(paths: ["/tmp/A.swift"]), for: key))
+        await canonicalGate.waitUntilStarted()
+        let drainTask = Task { @MainActor in
+            await coordinator.drain(.mirroredSelectionAndMetrics, for: key)
+        }
+
+        let canonicalRegistered = try await diagnostics.waitFor(kind: .waiterRegistered, lane: .canonical)
+        XCTAssertEqual(canonicalRegistered.target, 1)
+        XCTAssertEqual(canonicalRegistered.acceptedHighWater, 1)
+        XCTAssertEqual(canonicalRegistered.completedHighWater, 0)
+        XCTAssertEqual(canonicalRegistered.waiterCount, 1)
+        XCTAssertTrue(canonicalRegistered.workerActive)
+
+        await canonicalGate.release()
+        await mirrorGate.waitUntilStarted()
+        let mirrorRegistered = try await diagnostics.waitFor(kind: .waiterRegistered, lane: .mirror)
+        XCTAssertEqual(mirrorRegistered.target, 1)
+        XCTAssertEqual(mirrorRegistered.acceptedHighWater, 1)
+        XCTAssertEqual(mirrorRegistered.completedHighWater, 0)
+        XCTAssertEqual(mirrorRegistered.waiterCount, 1)
+        XCTAssertTrue(mirrorRegistered.workerActive)
+
+        await mirrorGate.release()
+        await drainTask.value
+        XCTAssertEqual(coordinator.debugSnapshot().canonicalWaiterCount, 0)
+        XCTAssertEqual(coordinator.debugSnapshot().mirrorWaiterCount, 0)
+        _ = try await diagnostics.waitFor(kind: .workerStopped, lane: .canonical)
+        _ = try await diagnostics.waitFor(kind: .workerStopped, lane: .mirror)
+
+        let events = diagnostics.snapshot()
+        let canonicalResumed = try XCTUnwrap(events.first {
+            $0.kind == .waiterResumed && $0.lane == .canonical
+        })
+        XCTAssertEqual(canonicalResumed.waiterID, canonicalRegistered.waiterID)
+        XCTAssertEqual(canonicalResumed.target, canonicalRegistered.target)
+        XCTAssertEqual(canonicalResumed.completedHighWater, 1)
+        XCTAssertEqual(canonicalResumed.requiredMirrorTicket, 1)
+
+        let mirrorResumed = try XCTUnwrap(events.first {
+            $0.kind == .waiterResumed && $0.lane == .mirror
+        })
+        XCTAssertEqual(mirrorResumed.waiterID, mirrorRegistered.waiterID)
+        XCTAssertEqual(mirrorResumed.target, mirrorRegistered.target)
+        XCTAssertEqual(mirrorResumed.completedHighWater, 1)
+
+        for lane in [
+            MCPReadFileAutoSelectionDiagnosticEvent.Lane.canonical,
+            .mirror
+        ] {
+            let started = try XCTUnwrap(events.first { $0.kind == .workerStarted && $0.lane == lane })
+            let stopped = try XCTUnwrap(events.first { $0.kind == .workerStopped && $0.lane == lane })
+            XCTAssertEqual(started.workerID, stopped.workerID)
+            XCTAssertTrue(started.workerActive)
+            XCTAssertFalse(stopped.workerActive)
+            XCTAssertTrue(events.contains {
+                $0.kind == .acceptedHighWaterAdvanced
+                    && $0.lane == lane
+                    && $0.previousAcceptedHighWater == 0
+                    && $0.acceptedHighWater == 1
+            })
+            XCTAssertTrue(events.contains {
+                $0.kind == .drainHighWaterCaptured
+                    && $0.lane == lane
+                    && $0.target == 1
+            })
+        }
     }
 
     func testInvalidationDropsPendingWorkBeforeStoredCommit() async {
@@ -182,7 +378,8 @@ final class MCPReadFileAutoSelectionCoordinatorTests: XCTestCase {
         XCTAssertFalse(coordinator.enqueue(intent: .full(paths: ["/tmp/B.swift"]), for: key))
 
         await gate.release()
-        await finishTask.value
+        let finishResult = await finishTask.value
+        XCTAssertEqual(finishResult, .completed)
         let recordedBatches = await recorder.canonicalBatches()
         XCTAssertEqual(recordedBatches.count, 1)
         await Task.yield()
@@ -292,6 +489,21 @@ final class MCPReadFileAutoSelectionCoordinatorTests: XCTestCase {
         XCTAssertTrue(recordedBatches.isEmpty)
     }
 
+    private func waitUntil(
+        timeout: Duration = .seconds(2),
+        condition: @MainActor () -> Bool
+    ) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        while clock.now < deadline {
+            if condition() {
+                return true
+            }
+            try? await Task.sleep(for: .milliseconds(1))
+        }
+        return condition()
+    }
+
     private func makeCoordinator(
         recorder: CoordinatorRecorder,
         applyCanonical: MCPReadFileAutoSelectionCoordinator.ApplyCanonical? = nil
@@ -360,6 +572,46 @@ private actor CoordinatorRecorder {
     }
 }
 
+private final class CoordinatorDiagnosticRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var events: [MCPReadFileAutoSelectionDiagnosticEvent] = []
+
+    func append(_ event: MCPReadFileAutoSelectionDiagnosticEvent) {
+        lock.lock()
+        events.append(event)
+        lock.unlock()
+    }
+
+    func snapshot() -> [MCPReadFileAutoSelectionDiagnosticEvent] {
+        lock.lock()
+        defer { lock.unlock() }
+        return events
+    }
+
+    func waitFor(
+        kind: MCPReadFileAutoSelectionDiagnosticEvent.Kind,
+        lane: MCPReadFileAutoSelectionDiagnosticEvent.Lane,
+        timeout: Duration = .seconds(10)
+    ) async throws -> MCPReadFileAutoSelectionDiagnosticEvent {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        while clock.now < deadline {
+            if let event = snapshot().first(where: { $0.kind == kind && $0.lane == lane }) {
+                return event
+            }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        throw CoordinatorDiagnosticRecorderError.timedOut(kind: kind, lane: lane)
+    }
+
+    private enum CoordinatorDiagnosticRecorderError: Error {
+        case timedOut(
+            kind: MCPReadFileAutoSelectionDiagnosticEvent.Kind,
+            lane: MCPReadFileAutoSelectionDiagnosticEvent.Lane
+        )
+    }
+}
+
 private actor CoordinatorAsyncGate {
     private var started = false
     private var released = false
@@ -399,5 +651,17 @@ private actor CoordinatorAsyncSignal {
 
     func isMarked() -> Bool {
         marked
+    }
+
+    func waitUntilMarked(timeout: Duration = .seconds(2)) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        while clock.now < deadline {
+            if marked {
+                return true
+            }
+            try? await Task.sleep(for: .milliseconds(1))
+        }
+        return marked
     }
 }

--- a/Tests/RepoPromptTests/MCP/MCPReadSearchLatencyDiagnosticsGuardTests.swift
+++ b/Tests/RepoPromptTests/MCP/MCPReadSearchLatencyDiagnosticsGuardTests.swift
@@ -2651,7 +2651,28 @@
             XCTAssertFalse(operations.contains("changePublisher.send"))
             XCTAssertTrue(fsevents.contains("source: .watcherBarrierNoop"))
             XCTAssertTrue(fsevents.contains("watcherAcceptedWatermark: publishableWatcherWatermark"))
-            XCTAssertEqual(operations.components(separatedBy: "source: .syntheticMutation").count - 1, 5)
+            let mutationPublicationCount = operations.components(separatedBy: "publishFileSystemDeltas(").count - 1
+            let syntheticMutationSourceCount = operations.components(separatedBy: "source: .syntheticMutation").count - 1
+            XCTAssertGreaterThan(mutationPublicationCount, 0)
+            XCTAssertEqual(syntheticMutationSourceCount, mutationPublicationCount)
+        }
+
+        func testCancellationSafeReadAutoSelectionDrainResultsArePropagated() throws {
+            let coordinator = try source("Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPReadFileAutoSelectionCoordinator.swift")
+            let server = try source("Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel.swift")
+            let tabContext = try source("Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+TabContext.swift")
+            let contextBuilder = try source("Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPContextBuilderToolProvider.swift")
+            let promptContext = try source("Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPPromptContextToolProvider.swift")
+
+            XCTAssertTrue(coordinator.contains("enum DrainResult: Equatable"))
+            XCTAssertTrue(coordinator.contains("async -> DrainResult"))
+            XCTAssertTrue(server.contains("executeAskOracle"))
+            XCTAssertTrue(server.contains("executeOracleSend"))
+            XCTAssertEqual(server.components(separatedBy: "guard await drainReadFileAutoSelection(").count - 1, 2)
+            XCTAssertTrue(contextBuilder.contains("drainReadFileAutoSelection(metadata, .mirroredSelectionAndMetrics) == .completed else"))
+            XCTAssertEqual(promptContext.components(separatedBy: "drainReadFileAutoSelection(metadata, .mirroredSelectionAndMetrics) == .completed else").count - 1, 2)
+            XCTAssertTrue(tabContext.contains("if finishResult == .cancelled"))
+            XCTAssertTrue(tabContext.contains("shouldCommit = false"))
         }
 
         @MainActor

--- a/Tests/RepoPromptTests/MCP/TabContextRoutingTests.swift
+++ b/Tests/RepoPromptTests/MCP/TabContextRoutingTests.swift
@@ -492,6 +492,39 @@ final class TabContextRoutingTests: XCTestCase {
     }
 
     @MainActor
+    func testMCPSelectionPersistenceUnchangedActiveSelectionReconcilesStaleUI() async {
+        let activeTabID = UUID()
+        let canonical = StoredSelection(selectedPaths: ["/tmp/canonical.swift"], codemapAutoEnabled: false)
+        let staleUI = StoredSelection(selectedPaths: ["/tmp/stale-ui.swift"])
+        let manager = FakeMCPSelectionManager(
+            tabs: [ComposeTabState(id: activeTabID, name: "Active", selection: canonical)],
+            activeTabID: activeTabID
+        )
+        manager.mirroredSelection = staleUI
+        let coordinator = WorkspaceSelectionCoordinator(
+            workspaceManager: manager,
+            store: WorkspaceFileContextStore()
+        )
+        var changes: [WorkspaceSelectionCoordinator.Change] = []
+        coordinator.changes
+            .sink { changes.append($0) }
+            .store(in: &cancellables)
+
+        let result = await MCPServerViewModel.persistMCPSelectionThroughCoordinator(
+            canonical,
+            for: activeTabID,
+            selectionCoordinator: coordinator,
+            mirrorToUIIfActive: true
+        )
+
+        XCTAssertEqual(result, .unchanged)
+        XCTAssertEqual(manager.composeTab(with: activeTabID)?.selection, canonical)
+        XCTAssertEqual(manager.mirrorAttempts, [canonical])
+        XCTAssertEqual(manager.mirroredSelection, canonical)
+        XCTAssertTrue(changes.isEmpty)
+    }
+
+    @MainActor
     func testMCPSelectionPersistenceRereadsCanonicalSelectionAndReportsMismatch() async {
         let activeTabID = UUID()
         let inactiveTabID = UUID()
@@ -862,8 +895,11 @@ final class TabContextRoutingTests: XCTestCase {
 @MainActor
 private final class FakeMCPSelectionManager: WorkspaceSelectionHost {
     var activeWorkspace: WorkspaceModel?
+    private(set) var selectionMirrorContextRevision: UInt64 = 0
 
     private let ignoreStoredOnlyUpdates: Bool
+    private(set) var mirrorAttempts: [StoredSelection] = []
+    var mirroredSelection: StoredSelection?
 
     init(tabs: [ComposeTabState], activeTabID: UUID, ignoreStoredOnlyUpdates: Bool = false) {
         self.ignoreStoredOnlyUpdates = ignoreStoredOnlyUpdates
@@ -880,6 +916,18 @@ private final class FakeMCPSelectionManager: WorkspaceSelectionHost {
     }
 
     func publishActiveComposeTabSnapshot(commitToMemory: Bool, touchModified: Bool) {}
+
+    func applySelectionMirrorAttempt(
+        _ selection: StoredSelection,
+        forTabID tabID: UUID,
+        workspaceID: UUID
+    ) async {
+        guard activeWorkspace?.id == workspaceID,
+              activeWorkspace?.activeComposeTabID == tabID
+        else { return }
+        mirrorAttempts.append(selection)
+        mirroredSelection = selection
+    }
 
     func updateComposeTabStoredOnly(_ tab: ComposeTabState) {
         guard !ignoreStoredOnlyUpdates else { return }

--- a/Tests/RepoPromptTests/WorkspaceContext/WorkspaceFileContextStoreTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/WorkspaceFileContextStoreTests.swift
@@ -246,6 +246,263 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
             await store.stopWatchingRoot(id: rootID)
         }
 
+        func testCancelledCreateSettlesBeforeUncancellableIOAndReconcilesCatalogAfterCompletion() async throws {
+            let root = try makeTemporaryRoot(name: "CancelledCreateReconciliation")
+            let store = WorkspaceFileContextStore()
+            let record = try await store.loadRoot(path: root.path)
+            try await store.startWatchingRoot(id: record.id)
+            let loadedService = await store.fileSystemServiceForTesting(rootID: record.id)
+            let service = try XCTUnwrap(loadedService)
+            let mutationGate = AsyncGate()
+            await service.setMutationIOWillBeginHandlerForTesting { operation in
+                guard operation == .create else { return }
+                await mutationGate.markStartedAndWaitForRelease()
+            }
+
+            let createTask = Task {
+                try await store.createFile(
+                    rootID: record.id,
+                    relativePath: "CreatedAfterCancellation.swift",
+                    content: "struct CreatedAfterCancellation {}"
+                )
+            }
+            await mutationGate.waitUntilStarted()
+            let settledSignal = AsyncSignal()
+            let resultTask = Task {
+                do {
+                    _ = try await createTask.value
+                    await settledSignal.mark()
+                    return false
+                } catch is CancellationError {
+                    await settledSignal.mark()
+                    return true
+                } catch {
+                    await settledSignal.mark()
+                    return false
+                }
+            }
+
+            createTask.cancel()
+
+            let settledBeforeRelease = await waitForAsyncCondition(maxYields: 10000) {
+                await settledSignal.isMarked()
+            }
+            XCTAssertTrue(settledBeforeRelease)
+            let waiterCountAfterCancellation = await service.pendingMutationWaiterCountForTesting()
+            XCTAssertEqual(waiterCountAfterCancellation, 0)
+            XCTAssertFalse(FileManager.default.fileExists(atPath: root.appendingPathComponent("CreatedAfterCancellation.swift").path))
+
+            await mutationGate.release()
+            let observedCancellation = await resultTask.value
+            XCTAssertTrue(observedCancellation)
+            let reconciled = await waitForAsyncCondition(maxYields: 10000) {
+                guard FileManager.default.fileExists(atPath: root.appendingPathComponent("CreatedAfterCancellation.swift").path) else {
+                    return false
+                }
+                return await store.file(
+                    rootID: record.id,
+                    relativePath: "CreatedAfterCancellation.swift"
+                ) != nil
+            }
+            XCTAssertTrue(reconciled)
+            let finalWaiterCount = await service.pendingMutationWaiterCountForTesting()
+            XCTAssertEqual(finalWaiterCount, 0)
+
+            await service.setMutationIOWillBeginHandlerForTesting(nil)
+            await store.stopWatchingRoot(id: record.id)
+        }
+
+        func testCancelledOverwriteSettlesBeforeUncancellableIOAndReconcilesCatalogAfterCompletion() async throws {
+            let root = try makeTemporaryRoot(name: "CancelledOverwriteReconciliation")
+            let fileURL = root.appendingPathComponent("OverwriteAfterCancellation.swift")
+            try write("old", to: fileURL)
+            let store = WorkspaceFileContextStore()
+            let record = try await store.loadRoot(path: root.path)
+            try await store.startWatchingRoot(id: record.id)
+            let loadedService = await store.fileSystemServiceForTesting(rootID: record.id)
+            let service = try XCTUnwrap(loadedService)
+            let mutationGate = AsyncGate()
+            await service.setMutationIOWillBeginHandlerForTesting { operation in
+                guard operation == .edit else { return }
+                await mutationGate.markStartedAndWaitForRelease()
+            }
+            let host = WorkspaceFileEditHost(
+                store: store,
+                lookupRootScope: .visibleWorkspace,
+                createPathResolutionPolicy: .literalPreferredIfStronger,
+                selectCreatedFiles: false
+            )
+
+            let overwriteTask = Task {
+                try await host.writeText(
+                    path: fileURL.path,
+                    content: "new",
+                    overwrite: true
+                )
+            }
+            await mutationGate.waitUntilStarted()
+            let settledSignal = AsyncSignal()
+            let resultTask = Task {
+                do {
+                    try await overwriteTask.value
+                    await settledSignal.mark()
+                    return false
+                } catch is CancellationError {
+                    await settledSignal.mark()
+                    return true
+                } catch {
+                    await settledSignal.mark()
+                    return false
+                }
+            }
+
+            overwriteTask.cancel()
+            let settledBeforeRelease = await waitForAsyncCondition(maxYields: 10000) {
+                await settledSignal.isMarked()
+            }
+            XCTAssertTrue(settledBeforeRelease)
+            XCTAssertEqual(try String(contentsOf: fileURL, encoding: .utf8), "old")
+            let waiterCountAfterCancellation = await service.pendingMutationWaiterCountForTesting()
+            XCTAssertEqual(waiterCountAfterCancellation, 0)
+
+            await mutationGate.release()
+            let observedCancellation = await resultTask.value
+            XCTAssertTrue(observedCancellation)
+            let reconciled = await waitForAsyncCondition(maxYields: 10000) {
+                guard (try? String(contentsOf: fileURL, encoding: .utf8)) == "new" else { return false }
+                return await (try? store.readContent(
+                    rootID: record.id,
+                    relativePath: "OverwriteAfterCancellation.swift"
+                )) == "new"
+            }
+            XCTAssertTrue(reconciled)
+            let catalogFile = await store.file(rootID: record.id, relativePath: "OverwriteAfterCancellation.swift")
+            XCTAssertNotNil(catalogFile)
+            let finalWaiterCount = await service.pendingMutationWaiterCountForTesting()
+            XCTAssertEqual(finalWaiterCount, 0)
+
+            await service.setMutationIOWillBeginHandlerForTesting(nil)
+            await store.stopWatchingRoot(id: record.id)
+        }
+
+        func testCancelledMoveDeleteAndTrashSettleBeforeIOAndReconcileAfterCompletion() async throws {
+            let root = try makeTemporaryRoot(name: "CancelledMutationReconciliation")
+            try write("move", to: root.appendingPathComponent("MoveSource.swift"))
+            try write("delete", to: root.appendingPathComponent("Delete.swift"))
+            try write("trash", to: root.appendingPathComponent("Trash.swift"))
+            let store = WorkspaceFileContextStore()
+            let record = try await store.loadRoot(path: root.path)
+            try await store.startWatchingRoot(id: record.id)
+            let loadedService = await store.fileSystemServiceForTesting(rootID: record.id)
+            let service = try XCTUnwrap(loadedService)
+
+            func exercise(
+                operation: FileSystemUncancellableMutation,
+                mutation: @escaping () async throws -> Void,
+                beforeRelease: () -> Bool,
+                reconciled: @escaping () async -> Bool
+            ) async throws {
+                let gate = AsyncGate()
+                await service.setMutationIOWillBeginHandlerForTesting { observed in
+                    guard observed == operation else { return }
+                    await gate.markStartedAndWaitForRelease()
+                }
+                let mutationTask = Task {
+                    try await mutation()
+                }
+                await gate.waitUntilStarted()
+                let settledSignal = AsyncSignal()
+                let resultTask = Task {
+                    do {
+                        try await mutationTask.value
+                        await settledSignal.mark()
+                        return false
+                    } catch is CancellationError {
+                        await settledSignal.mark()
+                        return true
+                    } catch {
+                        await settledSignal.mark()
+                        return false
+                    }
+                }
+
+                mutationTask.cancel()
+                let settledBeforeRelease = await waitForAsyncCondition(maxYields: 10000) {
+                    await settledSignal.isMarked()
+                }
+                XCTAssertTrue(settledBeforeRelease)
+                XCTAssertTrue(beforeRelease())
+                let waiterCountAfterCancellation = await service.pendingMutationWaiterCountForTesting()
+                XCTAssertEqual(waiterCountAfterCancellation, 0)
+
+                await gate.release()
+                let observedCancellation = await resultTask.value
+                XCTAssertTrue(observedCancellation)
+                let didReconcile = await waitForAsyncCondition(maxYields: 10000, reconciled)
+                XCTAssertTrue(didReconcile)
+                let finalWaiterCount = await service.pendingMutationWaiterCountForTesting()
+                XCTAssertEqual(finalWaiterCount, 0)
+            }
+
+            try await exercise(
+                operation: .move,
+                mutation: {
+                    try await store.moveFile(
+                        rootID: record.id,
+                        from: "MoveSource.swift",
+                        to: "MoveDestination.swift"
+                    )
+                },
+                beforeRelease: {
+                    FileManager.default.fileExists(atPath: root.appendingPathComponent("MoveSource.swift").path)
+                        && !FileManager.default.fileExists(atPath: root.appendingPathComponent("MoveDestination.swift").path)
+                },
+                reconciled: {
+                    guard !FileManager.default.fileExists(atPath: root.appendingPathComponent("MoveSource.swift").path),
+                          FileManager.default.fileExists(atPath: root.appendingPathComponent("MoveDestination.swift").path)
+                    else { return false }
+                    let source = await store.file(rootID: record.id, relativePath: "MoveSource.swift")
+                    let destination = await store.file(rootID: record.id, relativePath: "MoveDestination.swift")
+                    return source == nil && destination != nil
+                }
+            )
+
+            try await exercise(
+                operation: .delete,
+                mutation: {
+                    try await store.deleteFile(rootID: record.id, relativePath: "Delete.swift")
+                },
+                beforeRelease: {
+                    FileManager.default.fileExists(atPath: root.appendingPathComponent("Delete.swift").path)
+                },
+                reconciled: {
+                    guard !FileManager.default.fileExists(atPath: root.appendingPathComponent("Delete.swift").path) else {
+                        return false
+                    }
+                    return await store.file(rootID: record.id, relativePath: "Delete.swift") == nil
+                }
+            )
+
+            try await exercise(
+                operation: .trash,
+                mutation: {
+                    try await store.moveItemToTrash(rootID: record.id, relativePath: "Trash.swift")
+                },
+                beforeRelease: {
+                    FileManager.default.fileExists(atPath: root.appendingPathComponent("Trash.swift").path)
+                },
+                reconciled: {
+                    guard !FileManager.default.fileExists(atPath: root.appendingPathComponent("Trash.swift").path) else {
+                        return false
+                    }
+                    return await store.file(rootID: record.id, relativePath: "Trash.swift") == nil
+                }
+            )
+
+            await service.setMutationIOWillBeginHandlerForTesting(nil)
+            await store.stopWatchingRoot(id: record.id)
+        }
+
         func testStopWatchingRootDrainsTrackedPublisherIngress() async throws {
             let root = try makeTemporaryRoot(name: "StopWatcherPublisherIngress")
             let lateFileURL = root.appendingPathComponent("Late.swift")

--- a/Tests/RepoPromptTests/WorkspaceContext/WorkspaceSelectionCoordinatorTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/WorkspaceSelectionCoordinatorTests.swift
@@ -65,6 +65,231 @@ final class WorkspaceSelectionCoordinatorTests: XCTestCase {
         XCTAssertFalse(coordinator.isApplyingSelectionMirror)
     }
 
+    func testMCPActiveSelectionMirrorsAreAwaitedSerializedAndSkipSupersededRevision() async {
+        let initial = StoredSelection(selectedPaths: ["/tmp/initial.swift"])
+        let first = StoredSelection(selectedPaths: ["/tmp/first.swift"])
+        let superseded = StoredSelection(selectedPaths: ["/tmp/superseded.swift"])
+        let latest = StoredSelection(selectedPaths: ["/tmp/latest.swift"])
+        let harness = CoordinatorHarness(initialSelection: initial)
+        let firstMirrorGate = SelectionMirrorGate()
+        harness.manager.firstMirrorGate = firstMirrorGate
+        let coordinator = WorkspaceSelectionCoordinator(workspaceManager: harness.manager, store: harness.store)
+        var changes: [WorkspaceSelectionCoordinator.Change] = []
+        coordinator.changes
+            .sink { changes.append($0) }
+            .store(in: &cancellables)
+
+        let firstTask = Task { @MainActor in
+            await coordinator.persistActiveSelection(first, source: .mcpTabContext)
+        }
+        let firstMirrorStarted = await firstMirrorGate.waitUntilStarted()
+        XCTAssertTrue(firstMirrorStarted)
+        guard firstMirrorStarted else { return }
+
+        let supersededTask = Task { @MainActor in
+            await coordinator.persistActiveSelection(superseded, source: .mcpTabContext)
+        }
+        await waitForSelection(superseded, in: harness)
+        let latestTask = Task { @MainActor in
+            await coordinator.persistActiveSelection(latest, source: .mcpTabContext)
+        }
+        await waitForSelection(latest, in: harness)
+
+        XCTAssertEqual(harness.manager.mirrorStartedSelections, [first])
+        XCTAssertTrue(harness.manager.mirrorCompletedSelections.isEmpty)
+        XCTAssertEqual(changes, [
+            .init(tabID: harness.tabID, selection: first, source: .mcpTabContext),
+            .init(tabID: harness.tabID, selection: superseded, source: .mcpTabContext),
+            .init(tabID: harness.tabID, selection: latest, source: .mcpTabContext)
+        ])
+
+        await firstMirrorGate.release()
+        _ = await firstTask.value
+        _ = await supersededTask.value
+        _ = await latestTask.value
+
+        XCTAssertEqual(harness.manager.mirrorStartedSelections, [first, latest])
+        XCTAssertEqual(harness.manager.mirrorCompletedSelections, [first, latest])
+        XCTAssertEqual(harness.manager.mirroredSelection, latest)
+        XCTAssertEqual(harness.manager.composeTab(with: harness.tabID)?.selection, latest)
+    }
+
+    func testMCPMirrorRequestCompletesWhileChurnRepairsCoalesceToLatest() async {
+        let initial = StoredSelection(selectedPaths: ["/tmp/initial.swift"])
+        let requested = StoredSelection(selectedPaths: ["/tmp/requested.swift"])
+        let secondSelection = StoredSelection(selectedPaths: ["/tmp/second.swift"])
+        let latestSelection = StoredSelection(selectedPaths: ["/tmp/latest.swift"])
+        let secondTabID = UUID()
+        let latestTabID = UUID()
+        let harness = CoordinatorHarness(initialSelection: initial)
+        harness.manager.appendTab(ComposeTabState(id: secondTabID, name: "Second", selection: secondSelection))
+        harness.manager.appendTab(ComposeTabState(id: latestTabID, name: "Latest", selection: latestSelection))
+        let firstGate = SelectionMirrorGate()
+        let repairGate = SelectionMirrorGate()
+        harness.manager.mirrorGatesByAttempt = [1: firstGate, 2: repairGate]
+        let coordinator = WorkspaceSelectionCoordinator(workspaceManager: harness.manager, store: harness.store)
+        let requestCompletion = SelectionMirrorCompletion(expectedCount: 1)
+
+        let mirrorTask = Task { @MainActor in
+            await coordinator.persistActiveSelection(requested, source: .mcpTabContext)
+            await requestCompletion.markCompleted()
+        }
+        let firstAttemptStarted = await firstGate.waitUntilStarted()
+        XCTAssertTrue(firstAttemptStarted)
+
+        harness.manager.setActiveTab(secondTabID)
+        await firstGate.release()
+        let repairAttemptStarted = await repairGate.waitUntilStarted()
+        XCTAssertTrue(repairAttemptStarted)
+        let requestCompleted = await requestCompletion.waitUntilComplete()
+        XCTAssertTrue(requestCompleted)
+
+        harness.manager.setActiveTab(latestTabID)
+        await repairGate.release()
+        let repairedLatest = await waitForMirrorAttempts(3, in: harness)
+        XCTAssertTrue(repairedLatest)
+        _ = await mirrorTask.value
+
+        XCTAssertEqual(harness.manager.mirrorStartedSelections, [requested, secondSelection, latestSelection])
+        XCTAssertEqual(harness.manager.mirrorCompletedSelections, [requested, secondSelection, latestSelection])
+        XCTAssertEqual(harness.manager.mirroredSelection, latestSelection)
+        XCTAssertEqual(harness.manager.activeWorkspace?.activeComposeTabID, latestTabID)
+    }
+
+    func testMCPMirrorRepairsAfterABATabTransitionDuringSuspension() async {
+        let requested = StoredSelection(selectedPaths: ["/tmp/requested.swift"])
+        let alternate = StoredSelection(selectedPaths: ["/tmp/alternate.swift"])
+        let alternateTabID = UUID()
+        let harness = CoordinatorHarness(initialSelection: requested)
+        harness.manager.appendTab(ComposeTabState(id: alternateTabID, name: "Alternate", selection: alternate))
+        let gate = SelectionMirrorGate()
+        harness.manager.mirrorGatesByAttempt = [1: gate]
+        let coordinator = WorkspaceSelectionCoordinator(workspaceManager: harness.manager, store: harness.store)
+
+        let mirrorTask = Task { @MainActor in
+            await coordinator.persistActiveSelection(requested, source: .mcpTabContext)
+        }
+        let firstAttemptStarted = await gate.waitUntilStarted()
+        XCTAssertTrue(firstAttemptStarted)
+
+        harness.manager.setActiveTab(alternateTabID)
+        harness.manager.setActiveTab(harness.tabID)
+        await gate.release()
+        _ = await mirrorTask.value
+        let repairedABA = await waitForMirrorAttempts(2, in: harness)
+        XCTAssertTrue(repairedABA)
+
+        XCTAssertEqual(harness.manager.mirrorStartedSelections, [requested, requested])
+        XCTAssertEqual(harness.manager.mirrorCompletedSelections, [requested, requested])
+        XCTAssertEqual(harness.manager.mirroredSelection, requested)
+        XCTAssertEqual(harness.manager.activeWorkspace?.activeComposeTabID, harness.tabID)
+    }
+
+    func testMCPActiveSelectionNoOpReconcilesStaleMirroredUIWithoutPublishingChange() async {
+        let canonical = StoredSelection(selectedPaths: ["/tmp/canonical.swift"])
+        let staleUI = StoredSelection(selectedPaths: ["/tmp/stale-ui.swift"])
+        let harness = CoordinatorHarness(initialSelection: canonical)
+        harness.manager.mirroredSelection = staleUI
+        let coordinator = WorkspaceSelectionCoordinator(workspaceManager: harness.manager, store: harness.store)
+        var changes: [WorkspaceSelectionCoordinator.Change] = []
+        coordinator.changes
+            .sink { changes.append($0) }
+            .store(in: &cancellables)
+
+        _ = await coordinator.persistActiveSelection(canonical, source: .mcpTabContext)
+
+        XCTAssertEqual(harness.manager.updateStoredOnlyCallCount, 0)
+        XCTAssertTrue(changes.isEmpty)
+        XCTAssertEqual(harness.manager.mirrorStartedSelections, [canonical])
+        XCTAssertEqual(harness.manager.mirrorCompletedSelections, [canonical])
+        XCTAssertEqual(harness.manager.mirroredSelection, canonical)
+    }
+
+    func testCancelledMCPMirrorRequestDoesNotCancelBlockedPredecessorOrLatestSuccessor() async {
+        let initial = StoredSelection(selectedPaths: ["/tmp/initial.swift"])
+        let first = StoredSelection(selectedPaths: ["/tmp/first.swift"])
+        let latest = StoredSelection(selectedPaths: ["/tmp/latest.swift"])
+        let harness = CoordinatorHarness(initialSelection: initial)
+        let gate = SelectionMirrorGate()
+        harness.manager.firstMirrorGate = gate
+        let coordinator = WorkspaceSelectionCoordinator(workspaceManager: harness.manager, store: harness.store)
+        let completion = SelectionMirrorCompletion(expectedCount: 2)
+
+        let firstTask = Task { @MainActor in
+            await coordinator.persistActiveSelection(first, source: .mcpTabContext)
+            await completion.markCompleted()
+        }
+        let mirrorStarted = await gate.waitUntilStarted()
+        XCTAssertTrue(mirrorStarted)
+        guard mirrorStarted else { return }
+
+        firstTask.cancel()
+        let latestTask = Task { @MainActor in
+            await coordinator.persistActiveSelection(latest, source: .mcpTabContext)
+            await completion.markCompleted()
+        }
+        await waitForSelection(latest, in: harness)
+        XCTAssertEqual(harness.manager.mirrorStartedSelections, [first])
+
+        await gate.release()
+        let completed = await completion.waitUntilComplete()
+        XCTAssertTrue(completed)
+        guard completed else {
+            latestTask.cancel()
+            return
+        }
+        _ = await firstTask.value
+        _ = await latestTask.value
+
+        XCTAssertEqual(harness.manager.mirrorStartedSelections, [first, latest])
+        XCTAssertEqual(harness.manager.mirrorCompletedSelections, [first, latest])
+        XCTAssertEqual(harness.manager.mirroredSelection, latest)
+    }
+
+    private func waitForSelection(_ selection: StoredSelection, in harness: CoordinatorHarness) async {
+        let deadline = ContinuousClock.now + .seconds(1)
+        while ContinuousClock.now < deadline,
+              harness.manager.composeTab(with: harness.tabID)?.selection != selection
+        {
+            await Task.yield()
+        }
+        XCTAssertEqual(harness.manager.composeTab(with: harness.tabID)?.selection, selection)
+    }
+
+    private func waitForMirrorAttempts(_ count: Int, in harness: CoordinatorHarness) async -> Bool {
+        let deadline = ContinuousClock.now + .seconds(2)
+        while harness.manager.mirrorCompletedSelections.count < count,
+              ContinuousClock.now < deadline
+        {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return harness.manager.mirrorCompletedSelections.count == count
+    }
+
+    func testMCPActiveSelectionCanDeferMirrorToReadFileAutoSelectionLane() async {
+        let initial = StoredSelection(selectedPaths: ["/tmp/initial.swift"])
+        let next = StoredSelection(selectedPaths: ["/tmp/next.swift"])
+        let harness = CoordinatorHarness(initialSelection: initial)
+        let coordinator = WorkspaceSelectionCoordinator(workspaceManager: harness.manager, store: harness.store)
+        var changes: [WorkspaceSelectionCoordinator.Change] = []
+        coordinator.changes
+            .sink { changes.append($0) }
+            .store(in: &cancellables)
+
+        _ = await coordinator.persistActiveSelection(
+            next,
+            source: .mcpTabContext,
+            mirrorToUI: false
+        )
+
+        XCTAssertEqual(harness.manager.composeTab(with: harness.tabID)?.selection, next)
+        XCTAssertTrue(harness.manager.mirrorStartedSelections.isEmpty)
+        XCTAssertTrue(harness.manager.mirrorCompletedSelections.isEmpty)
+        XCTAssertEqual(changes, [
+            .init(tabID: harness.tabID, selection: next, source: .mcpTabContext)
+        ])
+    }
+
     func testPersistActiveSelectionNoOpsWhenSelectionIsUnchanged() async {
         let initial = StoredSelection(selectedPaths: ["/tmp/initial.swift"])
         let harness = CoordinatorHarness(initialSelection: initial)
@@ -272,13 +497,65 @@ private final class CoordinatorHarness {
     }
 }
 
+private actor SelectionMirrorGate {
+    private var started = false
+    private var released = false
+
+    func markStartedAndWaitForRelease(timeout: Duration = .seconds(5)) async {
+        started = true
+        let deadline = ContinuousClock.now + timeout
+        while !released, ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+    }
+
+    func waitUntilStarted(timeout: Duration = .seconds(2)) async -> Bool {
+        let deadline = ContinuousClock.now + timeout
+        while !started, ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return started
+    }
+
+    func release() {
+        released = true
+    }
+}
+
+private actor SelectionMirrorCompletion {
+    private let expectedCount: Int
+    private var completedCount = 0
+
+    init(expectedCount: Int) {
+        self.expectedCount = expectedCount
+    }
+
+    func markCompleted() {
+        completedCount += 1
+    }
+
+    func waitUntilComplete(timeout: Duration = .seconds(2)) async -> Bool {
+        let deadline = ContinuousClock.now + timeout
+        while completedCount < expectedCount, ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return completedCount == expectedCount
+    }
+}
+
 @MainActor
 private final class FakeWorkspaceSelectionManager: WorkspaceSelectionHost {
     var activeWorkspace: WorkspaceModel?
+    private(set) var selectionMirrorContextRevision: UInt64 = 0
     let fileManager: WorkspaceFilesViewModel
     var pendingUISelection: StoredSelection?
     private(set) var publishSnapshotCallCount = 0
     private(set) var updateStoredOnlyCallCount = 0
+    var firstMirrorGate: SelectionMirrorGate?
+    var mirrorGatesByAttempt: [Int: SelectionMirrorGate] = [:]
+    private(set) var mirrorStartedSelections: [StoredSelection] = []
+    private(set) var mirrorCompletedSelections: [StoredSelection] = []
+    var mirroredSelection: StoredSelection?
 
     init(workspace: WorkspaceModel, fileManager: WorkspaceFilesViewModel) {
         activeWorkspace = workspace
@@ -304,10 +581,39 @@ private final class FakeWorkspaceSelectionManager: WorkspaceSelectionHost {
         activeWorkspace = workspace
     }
 
+    func applySelectionMirrorAttempt(
+        _ selection: StoredSelection,
+        forTabID tabID: UUID,
+        workspaceID: UUID
+    ) async {
+        guard activeWorkspace?.id == workspaceID,
+              activeWorkspace?.activeComposeTabID == tabID
+        else { return }
+        mirrorStartedSelections.append(selection)
+        let attempt = mirrorStartedSelections.count
+        if let gate = mirrorGatesByAttempt[attempt] {
+            await gate.markStartedAndWaitForRelease()
+        } else if attempt == 1, let firstMirrorGate {
+            await firstMirrorGate.markStartedAndWaitForRelease()
+        }
+        mirroredSelection = selection
+        mirrorCompletedSelections.append(selection)
+    }
+
     func appendTab(_ tab: ComposeTabState) {
         guard var workspace = activeWorkspace else { return }
         workspace.composeTabs.append(tab)
         activeWorkspace = workspace
+    }
+
+    func setActiveTab(_ tabID: UUID) {
+        guard var workspace = activeWorkspace,
+              workspace.activeComposeTabID != tabID,
+              workspace.composeTabs.contains(where: { $0.id == tabID })
+        else { return }
+        workspace.activeComposeTabID = tabID
+        activeWorkspace = workspace
+        selectionMirrorContextRevision &+= 1
     }
 
     func updateComposeTabStoredOnly(_ tab: ComposeTabState) {


### PR DESCRIPTION
## Summary

- add correlated MCP watchdog, handler-phase, auto-selection coordinator, Context Builder timeline, and bridge-drain diagnostics
- make bounded selection and file handlers cancellation-safe, with detached filesystem reconciliation rather than holding request cleanup hostage to uncancellable OS work
- make Context Builder finalization ordering explicit, add activity/overall timeout policy, and bound bridge half-close drain while preserving fail-closed watchdog and reconnect invariants
- harden debug app relaunch/stop scripts to target the exact executable path instead of killing processes by broad app name
- add regression coverage across watchdog handling, transactions, bridge terminal behavior, Context Builder lifecycle, selection ownership, and relaunch identity

## Tracking and rationale

Related to #170, which contains the full June 11 investigation and remediation plan.

This PR implements the transport-closure remediation and defensive post-discovery hardening. The instrumented live reproduction still exposed a separate discovery-only 300-second Context Builder stall; that remaining bottleneck stays tracked in #170 rather than being conflated with the transport failure.

## Validation

- repository contribution preflight (`push` mode)
- `make dev-lint` / SwiftFormat check: 0 violations, 0/1,126 files require formatting
- `make dev-test`: 1,492 passed, 1 benchmark skipped, 0 failures
- `make dev-swift-build PRODUCT=RepoPrompt`
- `make dev-swift-build PRODUCT=repoprompt-mcp`
- repository guardrails and outgoing-range secret scan
- conductor/relaunch script tests: 98 passed
- `make dev-smoke`: live CE MCP smoke passed

## Live attribution result

The Context Builder reproduction timed out after 300 seconds while remaining entirely in discovery (ten 30-second heartbeats). Follow-up `manage_selection` and `file_actions` calls succeeded and no bridge-drain blocker appeared. The new instrumentation therefore narrows the unresolved work to discovery while this PR removes the transport-wide failure amplification and opaque post-discovery lifecycle hazards.
