### PR TITLE
chore: update approved contributor handles

### DIFF
--- a/.github/APPROVED_CONTRIBUTORS
+++ b/.github/APPROVED_CONTRIBUTORS
@@ -227,7 +227,7 @@ eclipsology pr
 eddiekollar pr
 eichert12 pr
 emigal pr
-emil pr
+EmilMN pr
 Empedoclez pr
 ENY66 pr
 enzodesena pr

--- a/.github/APPROVED_CONTRIBUTORS
+++ b/.github/APPROVED_CONTRIBUTORS
@@ -547,6 +547,7 @@ redrumkev pr
 redwhitblack pr
 regismesquita pr
 Reksa97 pr
+remarkz007 pr
 resolutionathens pr
 richardreeze pr
 riddhish143 pr


### PR DESCRIPTION
## Summary
- approve `remarkz007` for future issues and pull requests, as requested via `lgtm` on #177
- correct the existing contributor handle from `emil` to `EmilMN`

## Context
The `Approve Contributor` workflow triggered by the exact `lgtm` comment could not update `main` because repository rules now require a pull request and the `Style` status check. This PR applies the intended allowlist update through the protected-branch path.

## Validation
- `git diff --check`
- `make guardrails`
- contribution-check commit preflight
- contribution-check push preflight