### PR TITLE
Fix Agent Mode wait recovery and Codex managed defaults

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentPermissionSecureStore.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentPermissionSecureStore.swift
@@ -119,7 +119,7 @@ struct SecureCodexPermissionDocument: Codable, Equatable {
         updatedAt: Date = Date(),
         approvalPolicyRaw: String? = CodexAgentToolPreferences.ApprovalPolicy.onRequest.persistedValue,
         sandboxModeRaw: String? = CodexAgentToolPreferences.SandboxMode.workspaceWrite.persistedValue,
-        approvalReviewerRaw: String? = CodexAgentToolPreferences.ApprovalReviewer.user.persistedValue,
+        approvalReviewerRaw: String? = CodexAgentToolPreferences.ApprovalReviewer.autoReview.persistedValue,
         bashToolEnabled: Bool? = true,
         mcpServerTogglesByNormalizedName: [String: Bool]? = nil
     ) {
@@ -133,7 +133,11 @@ struct SecureCodexPermissionDocument: Codable, Equatable {
     }
 
     static func failClosedDocument(now: Date = Date()) -> SecureCodexPermissionDocument {
-        SecureCodexPermissionDocument(updatedAt: now, bashToolEnabled: false)
+        SecureCodexPermissionDocument(
+            updatedAt: now,
+            approvalReviewerRaw: CodexAgentToolPreferences.ApprovalReviewer.user.persistedValue,
+            bashToolEnabled: false
+        )
     }
 
     func approvalPolicy() -> CodexAgentToolPreferences.ApprovalPolicy {
@@ -145,7 +149,8 @@ struct SecureCodexPermissionDocument: Codable, Equatable {
     }
 
     func approvalReviewer() -> CodexAgentToolPreferences.ApprovalReviewer {
-        CodexAgentToolPreferences.ApprovalReviewer(storedValue: approvalReviewerRaw ?? "") ?? .user
+        guard let approvalReviewerRaw else { return .autoReview }
+        return CodexAgentToolPreferences.ApprovalReviewer(storedValue: approvalReviewerRaw) ?? .user
     }
 
     func permissionLevel() -> CodexAgentToolPreferences.PermissionLevel {
@@ -359,7 +364,7 @@ final class AgentPermissionSecureStore {
             _ = normalizeSubagent(&subagent)
             record(.subagent, resetLocked(subagent, domain: .subagent, cache: &subagentCache, deferred: &effects))
 
-            var codex = SecureCodexPermissionDocument.failClosedDocument(now: resetDate)
+            var codex = SecureCodexPermissionDocument(updatedAt: resetDate)
             _ = normalizeCodex(&codex)
             record(.codex, resetLocked(codex, domain: .codex, cache: &codexCache, deferred: &effects))
 
@@ -525,6 +530,7 @@ final class AgentPermissionSecureStore {
         loadLocked(
             domain: .codex,
             cache: &codexCache,
+            missingDocument: SecureCodexPermissionDocument(updatedAt: now()),
             failClosedDocument: SecureCodexPermissionDocument.failClosedDocument(now: now()),
             normalize: normalizeCodex,
             deferred: &effects
@@ -574,6 +580,7 @@ final class AgentPermissionSecureStore {
     private func loadLocked<Document: Codable>(
         domain: AgentPermissionSecureDomain,
         cache: inout Document?,
+        missingDocument: Document? = nil,
         failClosedDocument: Document,
         normalize: (inout Document) -> Bool,
         deferred effects: inout DeferredSideEffects
@@ -600,7 +607,7 @@ final class AgentPermissionSecureStore {
         }
 
         guard let payload = plainPayload else {
-            var document = failClosedDocument
+            var document = missingDocument ?? failClosedDocument
             _ = normalize(&document)
             do {
                 try saveDocument(document, domain: domain, accessMode: permissionDecisionAccessMode)
@@ -734,7 +741,7 @@ final class AgentPermissionSecureStore {
             recordDiagnostic(domain: domain, kind: keychainFailureKind(for: error, fallback: .keychainWriteFailed), error: error)
             effects.requestDiagnosticsNotification(for: domain)
             try? secureStrings.deletePlainValue(for: domain.secureStorageAccount, accessMode: .interactive)
-            cache = document
+            cache = failClosedDocument(for: domain) as? Document
             effects.requestChangeNotification(domain: domain, writeSucceeded: false)
             return false
         }
@@ -800,13 +807,17 @@ final class AgentPermissionSecureStore {
             document.sandboxModeRaw = sandbox.persistedValue
             changed = true
         }
-        let reviewer = CodexAgentToolPreferences.ApprovalReviewer(storedValue: document.approvalReviewerRaw ?? "") ?? .user
+        let reviewer: CodexAgentToolPreferences.ApprovalReviewer = if let raw = document.approvalReviewerRaw {
+            CodexAgentToolPreferences.ApprovalReviewer(storedValue: raw) ?? .user
+        } else {
+            .autoReview
+        }
         if document.approvalReviewerRaw != reviewer.persistedValue {
             document.approvalReviewerRaw = reviewer.persistedValue
             changed = true
         }
         if document.bashToolEnabled == nil {
-            document.bashToolEnabled = false
+            document.bashToolEnabled = true
             changed = true
         }
         let originalToggles = document.mcpServerTogglesByNormalizedName ?? [:]

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentProviderPermissionProfile.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentProviderPermissionProfile.swift
@@ -20,7 +20,7 @@ extension AgentProviderPermissionProfile {
         case .userConfigured:
             CodexAgentToolPreferences.sandboxMode()
         case .mcpSafeDefaults:
-            CodexAgentToolPreferences.PermissionLevel.defaultPermission.sandboxMode
+            CodexAgentToolPreferences.PermissionLevel.autoReview.sandboxMode
         case let .providerOverride(.codex(level)):
             level.sandboxMode
         case .providerOverride:
@@ -33,7 +33,7 @@ extension AgentProviderPermissionProfile {
         case .userConfigured:
             CodexAgentToolPreferences.approvalPolicy()
         case .mcpSafeDefaults:
-            CodexAgentToolPreferences.PermissionLevel.defaultPermission.approvalPolicy
+            CodexAgentToolPreferences.PermissionLevel.autoReview.approvalPolicy
         case let .providerOverride(.codex(level)):
             level.approvalPolicy
         case .providerOverride:
@@ -46,11 +46,31 @@ extension AgentProviderPermissionProfile {
         case .userConfigured:
             CodexAgentToolPreferences.approvalReviewer()
         case .mcpSafeDefaults:
-            CodexAgentToolPreferences.PermissionLevel.defaultPermission.approvalReviewer
+            CodexAgentToolPreferences.PermissionLevel.autoReview.approvalReviewer
         case let .providerOverride(.codex(level)):
             level.approvalReviewer
         case .providerOverride:
             CodexAgentToolPreferences.PermissionLevel.defaultPermission.approvalReviewer
+        }
+    }
+
+    func codexBashToolEnabled(
+        userConfigured: Bool = CodexAgentToolPreferences.bashToolEnabled()
+    ) -> Bool {
+        switch self {
+        case .mcpSafeDefaults:
+            true
+        case .userConfigured, .providerOverride:
+            userConfigured
+        }
+    }
+
+    var codexSuppressesThirdPartyMCPServers: Bool {
+        switch self {
+        case .mcpSafeDefaults:
+            true
+        case .userConfigured, .providerOverride:
+            false
         }
     }
 
@@ -59,7 +79,7 @@ extension AgentProviderPermissionProfile {
     ) -> CodexAgentToolPreferences.PermissionLevel {
         switch self {
         case .userConfigured: userConfigured
-        case .mcpSafeDefaults: .defaultPermission
+        case .mcpSafeDefaults: .autoReview
         case let .providerOverride(.codex(level)): level
         case .providerOverride: .defaultPermission
         }

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentProviderPreferenceSnapshotStore.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentProviderPreferenceSnapshotStore.swift
@@ -90,7 +90,7 @@ final class AgentProviderPreferenceSnapshotStore {
                 approvalPolicy = CodexAgentToolPreferences.approvalPolicy(defaults: defaults, secureStore: securePermissions)
                 approvalReviewer = CodexAgentToolPreferences.approvalReviewer(defaults: defaults, secureStore: securePermissions)
             case .mcpSafeDefaults:
-                let level = CodexAgentToolPreferences.PermissionLevel.defaultPermission
+                let level = CodexAgentToolPreferences.PermissionLevel.autoReview
                 sandboxMode = level.sandboxMode
                 approvalPolicy = level.approvalPolicy
                 approvalReviewer = level.approvalReviewer
@@ -346,15 +346,14 @@ final class AgentProviderPreferenceSnapshotStore {
                 mcpServerStatesByNormalizedName: states
             )
         case .mcpSafeDefaults:
-            // Safe Managed: force Bash off and suppress every user-toggled MCP server.
-            // Search stays available — it is read-only and helps sub-agents without granting
-            // shell/tool execution.
+            // Codex Safe Managed keeps its product-default Bash capability while suppressing
+            // every user-toggled third-party MCP server. Search remains user-configurable.
             var states: [String: Bool] = [:]
             for entry in entries {
                 states[normalizedServerToggleKey(entry.normalizedName)] = false
             }
             return CodexToolSettingsBinding(
-                bashToolEnabled: false,
+                bashToolEnabled: true,
                 searchToolEnabled: CodexAgentToolPreferences.searchToolEnabled(defaults: defaults),
                 goalSupportEnabled: codexGoalSupportEnabled(),
                 mcpServerEntries: entries,
@@ -424,7 +423,7 @@ final class AgentProviderPreferenceSnapshotStore {
         case .userConfigured:
             CodexAgentToolPreferences.permissionLevel(defaults: defaults, secureStore: securePermissions)
         case .mcpSafeDefaults:
-            .defaultPermission
+            .autoReview
         case let .providerOverride(.codex(level)):
             level
         case .providerOverride:

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+Types.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+Types.swift
@@ -244,6 +244,23 @@ extension AgentModeViewModel {
         /// The task label kind for this MCP-controlled run (e.g. explore, engineer).
         /// Used to customize tool advertisement and system prompts for role-specific behavior.
         let taskLabelKind: AgentModelCatalog.TaskLabelKind?
+
+        func replacingRegistration(_ registration: AgentRunSessionStore.Registration) -> Self {
+            Self(
+                sessionID: sessionID,
+                activationID: activationID,
+                registration: registration,
+                currentEpoch: currentEpoch,
+                preparedEpoch: preparedEpoch,
+                pendingEpochTransition: pendingEpochTransition,
+                originatingConnectionID: originatingConnectionID,
+                interactionTransport: interactionTransport,
+                suppressUserNotifications: suppressUserNotifications,
+                forceAutoEditEnabled: forceAutoEditEnabled,
+                autoEditEnabledBeforeOverride: autoEditEnabledBeforeOverride,
+                taskLabelKind: taskLabelKind
+            )
+        }
     }
 
     /// Internal for cross-file AgentModeViewModel extension access after the mechanical file split.

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -1308,7 +1308,8 @@ final class AgentModeViewModel: ObservableObject {
                 approvalPolicyProvider: { permissionProfile.codexApprovalPolicy },
                 sandboxModeProvider: { permissionProfile.codexSandboxMode },
                 approvalReviewerProvider: { permissionProfile.codexApprovalReviewer },
-                shellToolEnabled: nil,
+                shellToolEnabled: permissionProfile.codexBashToolEnabled(),
+                suppressThirdPartyMCPServers: permissionProfile.codexSuppressesThirdPartyMCPServers,
                 goalSupportEnabledProvider: { CodexGoalSupport.isEnabled },
                 computerUseEnabledProvider: { computerUseEnabled }
             )

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -4443,23 +4443,61 @@ final class AgentModeViewModel: ObservableObject {
         } else {
             .unrelated
         }
-        let result = await AgentRunSessionStore.beginEpoch(
-            registration: originalContext.registration,
+        let activationGeneration = session.mcpControlActivationGeneration
+        var registration = originalContext.registration
+        var result = await AgentRunSessionStore.beginEpoch(
+            registration: registration,
             activationID: originalContext.activationID,
             expectedCurrentEpoch: originalContext.currentEpoch,
             transitionKind: transitionKind
         )
+        // A stale result means the existing record advanced to another epoch; only rejected
+        // results are eligible for missing-record recovery through registerIfMissing.
+        if case .rejected = result {
+            guard session.mcpControlActivationGeneration == activationGeneration,
+                  let context = session.mcpControlContext,
+                  context.activationID == originalContext.activationID,
+                  context.registration == originalContext.registration,
+                  context.currentEpoch == originalContext.currentEpoch,
+                  let recoveredRegistration = await AgentRunSessionStore.registerIfMissing(
+                      sessionID: originalContext.sessionID
+                  )
+            else {
+                return
+            }
+            guard session.mcpControlActivationGeneration == activationGeneration,
+                  let context = session.mcpControlContext,
+                  context.activationID == originalContext.activationID,
+                  context.registration == originalContext.registration,
+                  context.currentEpoch == originalContext.currentEpoch
+            else {
+                await AgentRunSessionStore.cleanup(registration: recoveredRegistration)
+                return
+            }
+            registration = recoveredRegistration
+            result = await AgentRunSessionStore.beginEpoch(
+                registration: registration,
+                activationID: originalContext.activationID,
+                expectedCurrentEpoch: nil,
+                transitionKind: transitionKind
+            )
+        }
         #if DEBUG
             await test_afterMCPStoreEpochBegan?()
         #endif
         guard case let .accepted(epoch) = result,
+              session.mcpControlActivationGeneration == activationGeneration,
               var context = session.mcpControlContext,
               context.activationID == originalContext.activationID,
               context.registration == originalContext.registration,
               context.currentEpoch == originalContext.currentEpoch || context.currentEpoch == epoch
         else {
+            if registration != originalContext.registration {
+                await AgentRunSessionStore.cleanup(registration: registration)
+            }
             return
         }
+        context = context.replacingRegistration(registration)
         context.currentEpoch = epoch
         context.preparedEpoch = epoch
         let pendingTransitionToken = context.pendingEpochTransition?.token

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentPermissionCapabilitySummaryBuilder.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentPermissionCapabilitySummaryBuilder.swift
@@ -68,9 +68,10 @@ struct AgentPermissionCapabilitySummaryBuilder {
                     ? ["Sandbox is Danger Full Access — agents can modify files outside the workspace."]
                     : []
             case .mcpSafeDefaults:
-                bash = false
-                approval = CodexAgentToolPreferences.PermissionLevel.defaultPermission.approvalPolicy.displayName
-                sandbox = CodexAgentToolPreferences.PermissionLevel.defaultPermission.sandboxMode.displayName
+                let level = CodexAgentToolPreferences.PermissionLevel.autoReview
+                bash = true
+                approval = level.displayName
+                sandbox = level.sandboxMode.displayName
                 warnings = []
             case .providerOverride:
                 let level = codexPermissionLevel(profile: profile)
@@ -207,7 +208,7 @@ struct AgentPermissionCapabilitySummaryBuilder {
         case .userConfigured:
             CodexAgentToolPreferences.permissionLevel(defaults: defaults, secureStore: securePermissions)
         case .mcpSafeDefaults:
-            .defaultPermission
+            .autoReview
         case let .providerOverride(.codex(level)):
             level
         case .providerOverride:

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexNativeSessionController.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexNativeSessionController.swift
@@ -386,6 +386,7 @@ final class CodexNativeSessionController {
             sandboxModeProvider: @escaping () -> CodexAgentToolPreferences.SandboxMode = { CodexAgentToolPreferences.sandboxMode() },
             approvalReviewerProvider: @escaping () -> CodexAgentToolPreferences.ApprovalReviewer = { CodexAgentToolPreferences.approvalReviewer() },
             shellToolEnabled: Bool? = nil,
+            suppressThirdPartyMCPServers: Bool = false,
             goalSupportEnabledProvider: @escaping @MainActor () -> Bool = { CodexGoalSupport.isEnabled },
             computerUseEnabledProvider: @escaping @MainActor () -> Bool = { false }
         ) -> Options {
@@ -404,6 +405,7 @@ final class CodexNativeSessionController {
                         sandboxMode: sandboxModeProvider(),
                         approvalReviewer: approvalReviewerProvider(),
                         shellToolEnabled: shellToolEnabled,
+                        suppressThirdPartyMCPServers: suppressThirdPartyMCPServers,
                         goalSupportEnabled: featurePolicy.goalSupportEnabled,
                         computerUseEnabled: featurePolicy.computerUseEnabled
                     )
@@ -7322,6 +7324,7 @@ final class CodexNativeSessionController {
         sandboxMode: CodexAgentToolPreferences.SandboxMode? = nil,
         approvalReviewer: CodexAgentToolPreferences.ApprovalReviewer? = nil,
         shellToolEnabled: Bool? = nil,
+        suppressThirdPartyMCPServers: Bool = false,
         goalSupportEnabled: Bool = false,
         computerUseEnabled: Bool = false
     ) -> [String: Any] {
@@ -7342,19 +7345,11 @@ final class CodexNativeSessionController {
             toolPolicy: toolPolicy,
             featurePolicy: .resolved(goalsEnabled: goalSupportEnabled, computerUseEnabled: computerUseEnabled)
         )
-        var enabledMCPServerNames = preferences.enabledMCPServerNames
-        if computerUseEnabled,
-           serverEntries.contains(where: { $0.normalizedName.caseInsensitiveCompare(Self.computerUseMCPServerName) == .orderedSame })
-        {
-            enabledMCPServerNames.insert(Self.computerUseMCPServerName)
-        }
-        let mcpOverrides = CodexOverrides.appServerMCPServerMap(
-            entries: serverEntries,
-            policy: .enableSelected(
-                enabledNormalizedNames: enabledMCPServerNames,
-                repoPromptNormalizedName: MCPIntegrationHelper.repoPromptMCPServerName,
-                exceptBroken: []
-            )
+        let mcpOverrides = appServerMCPServerOverrides(
+            serverEntries: serverEntries,
+            enabledMCPServerNames: preferences.enabledMCPServerNames,
+            suppressThirdPartyMCPServers: suppressThirdPartyMCPServers,
+            computerUseEnabled: computerUseEnabled
         )
         for (key, value) in mcpOverrides {
             overrides[key] = value
@@ -7366,6 +7361,32 @@ final class CodexNativeSessionController {
         overrides["sandbox_mode"] = effectiveSandboxMode.appServerConfigOverrideValue
         overrides["approvals_reviewer"] = effectiveApprovalReviewer.appServerConfigOverrideValue
         return overrides
+    }
+
+    static func appServerMCPServerOverrides(
+        serverEntries: [MCPIntegrationHelper.CodexServerEntry],
+        enabledMCPServerNames: Set<String>,
+        suppressThirdPartyMCPServers: Bool,
+        computerUseEnabled: Bool
+    ) -> [String: Any] {
+        var effectiveEnabledNames = suppressThirdPartyMCPServers
+            ? Set([MCPIntegrationHelper.repoPromptMCPServerName])
+            : enabledMCPServerNames
+        if computerUseEnabled,
+           serverEntries.contains(where: {
+               $0.normalizedName.caseInsensitiveCompare(Self.computerUseMCPServerName) == .orderedSame
+           })
+        {
+            effectiveEnabledNames.insert(Self.computerUseMCPServerName)
+        }
+        return CodexOverrides.appServerMCPServerMap(
+            entries: serverEntries,
+            policy: .enableSelected(
+                enabledNormalizedNames: effectiveEnabledNames,
+                repoPromptNormalizedName: MCPIntegrationHelper.repoPromptMCPServerName,
+                exceptBroken: []
+            )
+        )
     }
 }
 

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/Shared/CodexAgentToolPreferences.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/Shared/CodexAgentToolPreferences.swift
@@ -422,7 +422,7 @@ enum CodexAgentToolPreferences {
         guard let raw = defaults.string(forKey: approvalReviewerKey),
               let reviewer = ApprovalReviewer(storedValue: raw)
         else {
-            return .user
+            return .autoReview
         }
         return reviewer
     }

--- a/Sources/RepoPrompt/Infrastructure/MCP/Agent/AgentRunSessionStore.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/Agent/AgentRunSessionStore.swift
@@ -89,6 +89,13 @@ actor AgentRunSessionStore {
         return registration
     }
 
+    func registerIfMissing(sessionID: UUID) -> Registration? {
+        guard records[sessionID] == nil else { return nil }
+        let registration = makeRegistration(sessionID: sessionID)
+        records[sessionID] = Record(registration: registration)
+        return registration
+    }
+
     func beginEpoch(
         registration: Registration,
         activationID: UUID,
@@ -677,6 +684,10 @@ actor AgentRunSessionStore {
 extension AgentRunSessionStore {
     static func register(sessionID: UUID) async -> Registration {
         await shared.register(sessionID: sessionID)
+    }
+
+    static func registerIfMissing(sessionID: UUID) async -> Registration? {
+        await shared.registerIfMissing(sessionID: sessionID)
     }
 
     static func beginEpoch(

--- a/Tests/RepoPromptTests/AgentMode/AgentModeMCPWaitEpochTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeMCPWaitEpochTests.swift
@@ -197,6 +197,181 @@ final class AgentModeMCPWaitEpochTests: XCTestCase {
         await viewModel.mcpDeactivateControlContext(sessionID: sessionID, cleanupSessionStore: true)
     }
 
+    func testInactiveSteeringReRegistersWaitTrackingAfterTerminalRecordExpires() async throws {
+        let viewModel = makeViewModel()
+        let sessionID = UUID()
+        let session = await viewModel.ensureSessionReady(tabID: UUID())
+        _ = viewModel.test_installPersistentSessionBinding(sessionID: sessionID, on: session)
+        try await viewModel.mcpActivateControlContext(
+            forTabID: session.tabID,
+            sessionID: sessionID,
+            originatingConnectionID: nil,
+            startPending: true
+        )
+        await viewModel.prepareMCPWaitTrackingForRunStart(session: session)
+        _ = session.beginRunAttempt(source: "test.expiredSteering")
+        let initialContext = try XCTUnwrap(session.mcpControlContext)
+        let initialEpoch = try XCTUnwrap(initialContext.currentEpoch)
+        session.runState = .completed
+        session.mcpFollowUpRunPending = false
+
+        let terminal = makeSnapshot(sessionID: sessionID, status: .completed)
+        let publication = await AgentRunSessionStore.publishTerminal(
+            .init(epoch: initialEpoch, snapshot: terminal),
+            registration: initialContext.registration,
+            commitID: UUID(),
+            successorKind: nil
+        )
+        XCTAssertEqual(publication, .accepted(successorEpoch: nil))
+        await AgentRunSessionStore.shared.test_expire(
+            cursor: .init(registration: initialContext.registration, epoch: initialEpoch)
+        )
+        let hasExpiredRegistration = await AgentRunSessionStore.hasActiveRegistration(sessionID: sessionID)
+        XCTAssertFalse(hasExpiredRegistration)
+
+        try await viewModel.withMCPRunEpochTransition(sessionID: sessionID, kind: .steering) {
+            await viewModel.prepareMCPWaitTrackingForRunStart(session: session)
+        }
+
+        let steeringContext = try XCTUnwrap(session.mcpControlContext)
+        let steeringEpoch = try XCTUnwrap(steeringContext.currentEpoch)
+        XCTAssertEqual(steeringContext.activationID, initialContext.activationID)
+        XCTAssertNotEqual(steeringContext.registration, initialContext.registration)
+        XCTAssertEqual(steeringEpoch.transitionKind, .steering)
+        XCTAssertEqual(steeringEpoch.registrationGeneration, steeringContext.registration.generation)
+        XCTAssertNil(steeringContext.pendingEpochTransition)
+
+        let steeringCursor = AgentRunSessionStore.WaitCursor(
+            registration: steeringContext.registration,
+            epoch: steeringEpoch
+        )
+        let waitTask = Task {
+            await AgentRunMCPToolService.test_waitUntilActionableDisposition(
+                sessionID: sessionID,
+                timeoutSeconds: 1
+            )
+        }
+        try await waitForWaiter(registration: steeringContext.registration)
+        let actionable = makeSnapshot(sessionID: sessionID, status: .waitingForInput)
+        await AgentRunSessionStore.signalSnapshot(actionable, cursor: steeringCursor)
+        let waitResult = await waitTask.value
+        XCTAssertEqual(waitResult.disposition, "actionable")
+        XCTAssertEqual(waitResult.snapshotStatus, AgentRunMCPSnapshot.Status.waitingForInput.rawValue)
+        await viewModel.mcpDeactivateControlContext(sessionID: sessionID, cleanupSessionStore: true)
+    }
+
+    func testExpiredRegistrationRecoveryCannotOverwriteReplacementActivation() async throws {
+        let viewModel = makeViewModel()
+        let sessionID = UUID()
+        let session = await viewModel.ensureSessionReady(tabID: UUID())
+        _ = viewModel.test_installPersistentSessionBinding(sessionID: sessionID, on: session)
+        try await viewModel.mcpActivateControlContext(
+            forTabID: session.tabID,
+            sessionID: sessionID,
+            originatingConnectionID: nil,
+            startPending: true
+        )
+        await viewModel.prepareMCPWaitTrackingForRunStart(session: session)
+        _ = session.beginRunAttempt(source: "test.expiredActivationRace")
+        let initialContext = try XCTUnwrap(session.mcpControlContext)
+        let initialEpoch = try XCTUnwrap(initialContext.currentEpoch)
+        session.runState = .completed
+        session.mcpFollowUpRunPending = false
+        _ = await AgentRunSessionStore.publishTerminal(
+            .init(
+                epoch: initialEpoch,
+                snapshot: makeSnapshot(sessionID: sessionID, status: .completed)
+            ),
+            registration: initialContext.registration,
+            commitID: UUID(),
+            successorKind: nil
+        )
+        await AgentRunSessionStore.shared.test_expire(
+            cursor: .init(registration: initialContext.registration, epoch: initialEpoch)
+        )
+
+        let gate = EpochBeginGate()
+        viewModel.test_setAfterMCPStoreEpochBegan {
+            await gate.pause()
+        }
+        defer { viewModel.test_setAfterMCPStoreEpochBegan(nil) }
+        let recoveryTask = Task {
+            try await viewModel.withMCPRunEpochTransition(sessionID: sessionID, kind: .steering) {
+                await viewModel.prepareMCPWaitTrackingForRunStart(session: session)
+            }
+        }
+        await gate.waitUntilPaused()
+
+        try await viewModel.mcpActivateControlContext(
+            forTabID: session.tabID,
+            sessionID: sessionID,
+            originatingConnectionID: UUID()
+        )
+        let replacementContext = try XCTUnwrap(session.mcpControlContext)
+        XCTAssertNotEqual(replacementContext.activationID, initialContext.activationID)
+        XCTAssertNotEqual(replacementContext.registration, initialContext.registration)
+
+        await gate.open()
+        try await recoveryTask.value
+
+        let finalContext = try XCTUnwrap(session.mcpControlContext)
+        let currentRegistration = await AgentRunSessionStore.currentRegistration(for: sessionID)
+        XCTAssertEqual(finalContext, replacementContext)
+        XCTAssertEqual(currentRegistration, replacementContext.registration)
+        await viewModel.mcpDeactivateControlContext(sessionID: sessionID, cleanupSessionStore: true)
+    }
+
+    func testExpiredRegistrationRecoveryCleansStoreRecordAfterDeactivation() async throws {
+        let viewModel = makeViewModel()
+        let sessionID = UUID()
+        let session = await viewModel.ensureSessionReady(tabID: UUID())
+        _ = viewModel.test_installPersistentSessionBinding(sessionID: sessionID, on: session)
+        try await viewModel.mcpActivateControlContext(
+            forTabID: session.tabID,
+            sessionID: sessionID,
+            originatingConnectionID: nil,
+            startPending: true
+        )
+        await viewModel.prepareMCPWaitTrackingForRunStart(session: session)
+        _ = session.beginRunAttempt(source: "test.expiredDeactivationRace")
+        let initialContext = try XCTUnwrap(session.mcpControlContext)
+        let initialEpoch = try XCTUnwrap(initialContext.currentEpoch)
+        session.runState = .completed
+        session.mcpFollowUpRunPending = false
+        _ = await AgentRunSessionStore.publishTerminal(
+            .init(
+                epoch: initialEpoch,
+                snapshot: makeSnapshot(sessionID: sessionID, status: .completed)
+            ),
+            registration: initialContext.registration,
+            commitID: UUID(),
+            successorKind: nil
+        )
+        await AgentRunSessionStore.shared.test_expire(
+            cursor: .init(registration: initialContext.registration, epoch: initialEpoch)
+        )
+
+        let gate = EpochBeginGate()
+        viewModel.test_setAfterMCPStoreEpochBegan {
+            await gate.pause()
+        }
+        defer { viewModel.test_setAfterMCPStoreEpochBegan(nil) }
+        let recoveryTask = Task {
+            try await viewModel.withMCPRunEpochTransition(sessionID: sessionID, kind: .steering) {
+                await viewModel.prepareMCPWaitTrackingForRunStart(session: session)
+            }
+        }
+        await gate.waitUntilPaused()
+
+        await viewModel.mcpDeactivateControlContext(sessionID: sessionID, cleanupSessionStore: true)
+        await gate.open()
+        try await recoveryTask.value
+
+        XCTAssertNil(session.mcpControlContext)
+        let hasActiveRegistration = await AgentRunSessionStore.hasActiveRegistration(sessionID: sessionID)
+        XCTAssertFalse(hasActiveRegistration)
+    }
+
     func testActiveRunPreparationDoesNotCreateSteeringEpoch() async throws {
         let viewModel = makeViewModel()
         let sessionID = UUID()

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexNativeSessionControllerGoalConfigTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexNativeSessionControllerGoalConfigTests.swift
@@ -57,6 +57,47 @@ final class CodexNativeSessionControllerGoalConfigTests: XCTestCase {
         )
     }
 
+    func testSafeManagedMCPOverridesSuppressThirdPartyServers() {
+        let repoPromptName = MCPIntegrationHelper.repoPromptMCPServerName
+        let entries = [
+            MCPIntegrationHelper.CodexServerEntry(
+                rawName: repoPromptName,
+                normalizedName: repoPromptName,
+                cliPathComponent: repoPromptName
+            ),
+            MCPIntegrationHelper.CodexServerEntry(
+                rawName: "external-tools",
+                normalizedName: "external-tools",
+                cliPathComponent: "external-tools"
+            ),
+            MCPIntegrationHelper.CodexServerEntry(
+                rawName: "computer-use",
+                normalizedName: "computer-use",
+                cliPathComponent: "computer-use"
+            )
+        ]
+        let enabledNames: Set<String> = [repoPromptName, "external-tools"]
+
+        let safeManaged = CodexNativeSessionController.appServerMCPServerOverrides(
+            serverEntries: entries,
+            enabledMCPServerNames: enabledNames,
+            suppressThirdPartyMCPServers: true,
+            computerUseEnabled: false
+        )
+        XCTAssertEqual(safeManaged["mcp_servers.\(repoPromptName).enabled"] as? Bool, true)
+        XCTAssertEqual(safeManaged["mcp_servers.external-tools.enabled"] as? Bool, false)
+        XCTAssertEqual(safeManaged["mcp_servers.computer-use.enabled"] as? Bool, false)
+
+        let safeManagedComputerUse = CodexNativeSessionController.appServerMCPServerOverrides(
+            serverEntries: entries,
+            enabledMCPServerNames: enabledNames,
+            suppressThirdPartyMCPServers: true,
+            computerUseEnabled: true
+        )
+        XCTAssertEqual(safeManagedComputerUse["mcp_servers.external-tools.enabled"] as? Bool, false)
+        XCTAssertEqual(safeManagedComputerUse["mcp_servers.computer-use.enabled"] as? Bool, true)
+    }
+
     private func assertStartAndResumeGoalConfig(
         options: CodexNativeSessionController.Options,
         expectedGoalSupportEnabled: Bool

--- a/Tests/RepoPromptTests/MCP/AgentRunMCPToolServiceStartDefaultTests.swift
+++ b/Tests/RepoPromptTests/MCP/AgentRunMCPToolServiceStartDefaultTests.swift
@@ -25,6 +25,145 @@ final class AgentRunMCPToolServiceStartDefaultTests: XCTestCase {
         XCTAssertEqual(resolved.modelRaw, "pair-default-model")
     }
 
+    func testFreshPairEngineerAndExploreStartsUseCodexSafeManagedDefaults() throws {
+        let suiteName = "AgentRunMCPToolServiceStartDefaultTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.removePersistentDomain(forName: suiteName)
+        CodexAgentToolPreferences.setBashToolEnabled(false, defaults: defaults)
+        CodexAgentToolPreferences.setMCPServerEnabled(
+            normalizedName: "external-tools",
+            isEnabled: true,
+            defaults: defaults
+        )
+        let service = makeBindingService(defaults: defaults)
+
+        for role in [AgentModelCatalog.TaskLabelKind.pair, .engineer, .explore] {
+            let selection = try AgentMCPSelectionResolver.resolve(
+                modelID: role.rawValue,
+                defaultTaskLabel: nil,
+                availability: .current,
+                roleSelectionProvider: { requestedRole, _ in
+                    XCTAssertEqual(requestedRole, role)
+                    return AgentModelCatalog.NormalizedAgentSelection(
+                        agent: .codexExec,
+                        modelRaw: "\(role.rawValue)-codex-model"
+                    )
+                }
+            )
+            XCTAssertEqual(selection.agentRaw, AgentProviderKind.codexExec.rawValue)
+
+            let profile = service.permissionProfileForMCPActivation(
+                isSubagent: true,
+                provider: .codex
+            )
+            XCTAssertEqual(profile, .mcpSafeDefaults)
+
+            let snapshot = service.controlsBinding(
+                selectedAgent: .codexExec,
+                selectedModelRaw: selection.modelRaw,
+                permissionProfile: profile,
+                isSubagent: true,
+                externallyManagedReason: nil
+            )
+            XCTAssertEqual(snapshot.permission.displayName, CodexAgentToolPreferences.PermissionLevel.autoReview.displayName)
+            XCTAssertEqual(snapshot.runtimePermission.codexSandboxMode, .workspaceWrite)
+            XCTAssertEqual(snapshot.runtimePermission.codexApprovalPolicy, .onRequest)
+            XCTAssertEqual(snapshot.runtimePermission.codexApprovalReviewer, .autoReview)
+            XCTAssertEqual(snapshot.codexTools?.bashToolEnabled, true)
+            XCTAssertEqual(snapshot.codexTools?.mcpServerStatesByNormalizedName["external-tools"], false)
+            XCTAssertTrue(profile.codexBashToolEnabled(userConfigured: false))
+            XCTAssertTrue(profile.codexSuppressesThirdPartyMCPServers)
+        }
+    }
+
+    func testInheritedRestrictiveCodexSettingsRemainRestrictive() throws {
+        let suiteName = "AgentRunMCPToolServiceStartDefaultTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.removePersistentDomain(forName: suiteName)
+        AgentModePermissionPreferences.setSubagentPermissionPolicy(.inheritProviderSettings, defaults: defaults)
+        CodexAgentToolPreferences.setPermissionLevel(.readOnly, defaults: defaults)
+        CodexAgentToolPreferences.setBashToolEnabled(false, defaults: defaults)
+        let service = makeBindingService(defaults: defaults)
+
+        let profile = service.permissionProfileForMCPActivation(isSubagent: true, provider: .codex)
+        let snapshot = service.controlsBinding(
+            selectedAgent: .codexExec,
+            permissionProfile: profile,
+            isSubagent: true,
+            externallyManagedReason: nil
+        )
+
+        XCTAssertEqual(profile, .userConfigured)
+        XCTAssertEqual(snapshot.permission.displayName, CodexAgentToolPreferences.PermissionLevel.readOnly.displayName)
+        XCTAssertEqual(snapshot.runtimePermission.codexSandboxMode, .readOnly)
+        XCTAssertEqual(snapshot.runtimePermission.codexApprovalReviewer, .user)
+        XCTAssertEqual(snapshot.codexTools?.bashToolEnabled, false)
+        XCTAssertFalse(profile.codexBashToolEnabled(userConfigured: false))
+        XCTAssertFalse(profile.codexSuppressesThirdPartyMCPServers)
+    }
+
+    func testCustomRestrictiveCodexOverrideWinsOverSafeManagedDefaults() throws {
+        let suiteName = "AgentRunMCPToolServiceStartDefaultTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.removePersistentDomain(forName: suiteName)
+        AgentModePermissionPreferences.setSubagentPermissionPolicy(.custom, defaults: defaults)
+        AgentModePermissionPreferences.setProviderSubagentPermissionLevel(
+            .codex(.readOnly),
+            for: .codex,
+            defaults: defaults
+        )
+        CodexAgentToolPreferences.setBashToolEnabled(false, defaults: defaults)
+        let service = makeBindingService(defaults: defaults)
+
+        let profile = service.permissionProfileForMCPActivation(isSubagent: true, provider: .codex)
+        let snapshot = service.controlsBinding(
+            selectedAgent: .codexExec,
+            permissionProfile: profile,
+            isSubagent: true,
+            externallyManagedReason: nil
+        )
+
+        XCTAssertEqual(profile, .providerOverride(.codex(.readOnly)))
+        XCTAssertEqual(snapshot.permission.displayName, CodexAgentToolPreferences.PermissionLevel.readOnly.displayName)
+        XCTAssertEqual(snapshot.runtimePermission.codexSandboxMode, .readOnly)
+        XCTAssertEqual(snapshot.runtimePermission.codexApprovalReviewer, .user)
+        XCTAssertEqual(snapshot.codexTools?.bashToolEnabled, false)
+        XCTAssertFalse(profile.codexBashToolEnabled(userConfigured: false))
+        XCTAssertFalse(profile.codexSuppressesThirdPartyMCPServers)
+    }
+
+    func testSubagentPolicyStorageFailureUsesCodexSafeManagedSnapshot() throws {
+        let suiteName = "AgentRunMCPToolServiceStartDefaultTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.removePersistentDomain(forName: suiteName)
+        let secureStore = AgentPermissionSecureStore(
+            secureStrings: AgentRunFailingSecurePlainStringStore(),
+            notificationCenter: NotificationCenter()
+        )
+        let service = makeBindingService(defaults: defaults, secureStore: secureStore)
+
+        let profile = service.permissionProfileForMCPActivation(isSubagent: true, provider: .codex)
+        let snapshot = service.controlsBinding(
+            selectedAgent: .codexExec,
+            permissionProfile: profile,
+            isSubagent: true,
+            externallyManagedReason: nil
+        )
+
+        XCTAssertEqual(profile, .mcpSafeDefaults)
+        XCTAssertEqual(snapshot.permission.displayName, CodexAgentToolPreferences.PermissionLevel.autoReview.displayName)
+        XCTAssertEqual(snapshot.runtimePermission.codexApprovalReviewer, .autoReview)
+        XCTAssertEqual(snapshot.codexTools?.bashToolEnabled, true)
+        XCTAssertEqual(snapshot.codexTools?.mcpServerStatesByNormalizedName["external-tools"], false)
+        XCTAssertTrue(profile.codexBashToolEnabled(userConfigured: false))
+        XCTAssertTrue(profile.codexSuppressesThirdPartyMCPServers)
+        XCTAssertEqual(secureStore.diagnostic(for: .subagent)?.kind, .keychainInteractionNotAllowed)
+    }
+
     func testExplicitTargetTabWithOmittedModelIDPreservesCurrentSelection() {
         let targetTabID = UUID()
 
@@ -42,6 +181,27 @@ final class AgentRunMCPToolServiceStartDefaultTests: XCTestCase {
         XCTAssertEqual(defaultLabel, .pair)
     }
 
+    private func makeBindingService(
+        defaults: UserDefaults,
+        secureStore: AgentPermissionSecureStore? = nil
+    ) -> AgentModeProviderBindingService {
+        AgentModeProviderBindingService(
+            preferences: AgentProviderPreferenceSnapshotStore(
+                defaults: defaults,
+                securePermissions: secureStore,
+                codexMCPServerEntries: {
+                    [
+                        MCPIntegrationHelper.CodexServerEntry(
+                            rawName: "external-tools",
+                            normalizedName: "external-tools",
+                            cliPathComponent: "external-tools"
+                        )
+                    ]
+                }
+            )
+        )
+    }
+
     func testExplicitModelIDTakesPrecedenceOverStartPairDefault() throws {
         let defaultLabel = AgentRunMCPToolService.defaultTaskLabelForStart(resolvedTabID: nil)
 
@@ -54,5 +214,21 @@ final class AgentRunMCPToolServiceStartDefaultTests: XCTestCase {
         XCTAssertNil(resolved.taskLabelKind)
         XCTAssertEqual(resolved.agentRaw, AgentProviderKind.codexExec.rawValue)
         XCTAssertEqual(resolved.modelRaw, "explicit-model")
+    }
+}
+
+private final class AgentRunFailingSecurePlainStringStore: SecurePlainStringStoring {
+    let persistsValuesAcrossLaunches = true
+
+    func getPlainValue(for account: SecureStorageAccount, accessMode: KeychainAccessMode) throws -> String? {
+        throw KeychainService.KeychainError.interactionNotAllowed
+    }
+
+    func savePlainValue(_ value: String, for account: SecureStorageAccount, accessMode: KeychainAccessMode) throws {
+        throw KeychainService.KeychainError.interactionNotAllowed
+    }
+
+    func deletePlainValue(for account: SecureStorageAccount, accessMode: KeychainAccessMode) throws {
+        throw KeychainService.KeychainError.interactionNotAllowed
     }
 }

--- a/Tests/RepoPromptTests/MCP/AgentRunSessionStoreRegistrationTests.swift
+++ b/Tests/RepoPromptTests/MCP/AgentRunSessionStoreRegistrationTests.swift
@@ -30,6 +30,18 @@ final class AgentRunSessionStoreRegistrationTests: XCTestCase {
         await AgentRunSessionStore.cleanup(registration: replacement)
     }
 
+    func testRegisterIfMissingDoesNotReplaceExistingRegistration() async {
+        let sessionID = UUID()
+        let registration = await AgentRunSessionStore.register(sessionID: sessionID)
+
+        let recovered = await AgentRunSessionStore.registerIfMissing(sessionID: sessionID)
+        let current = await AgentRunSessionStore.currentRegistration(for: sessionID)
+
+        XCTAssertNil(recovered)
+        XCTAssertEqual(current, registration)
+        await AgentRunSessionStore.cleanup(registration: registration)
+    }
+
     func testPreEpochWaiterAdvancesWithoutRotatingActivationRegistration() async throws {
         let sessionID = UUID()
         let registration = await AgentRunSessionStore.register(sessionID: sessionID)

--- a/Tests/RepoPromptTests/Security/AgentPermissionSecureStoreTests.swift
+++ b/Tests/RepoPromptTests/Security/AgentPermissionSecureStoreTests.swift
@@ -33,23 +33,178 @@ final class AgentPermissionSecureStoreTests: XCTestCase {
         XCTAssertNil(store.diagnostic(for: .codex))
     }
 
-    func testMissingPlainDocumentCreatesAndSavesFailClosedPlainDocument() throws {
+    func testMissingSubagentDocumentCreatesAndSavesSafeManagedPolicy() throws {
+        let secureStrings = FakeSecurePlainStringStore()
+        let key = AgentPermissionSecureDomain.subagent.storageKey
+        let store = makeStore(secureStrings: secureStrings)
+
+        XCTAssertEqual(store.subagentPolicy(), .safeManaged)
+        XCTAssertEqual(secureStrings.plainGetAccessModes, [.nonInteractive(reason: .permissionDecision)])
+        XCTAssertEqual(secureStrings.plainSaveAccessModes, [.nonInteractive(reason: .permissionDecision)])
+
+        let saved = try decode(SecureSubagentPermissionDocument.self, from: secureStrings.plainValues[key])
+        XCTAssertEqual(saved.globalPolicy(), .safeManaged)
+        XCTAssertNil(store.diagnostic(for: .subagent))
+    }
+
+    func testMissingSubagentPolicyFieldNormalizesToSafeManagedPolicy() throws {
+        let secureStrings = FakeSecurePlainStringStore()
+        let key = AgentPermissionSecureDomain.subagent.storageKey
+        secureStrings.plainValues[key] = try encode(
+            SecureSubagentPermissionDocument(globalPolicyRaw: nil)
+        )
+        let store = makeStore(secureStrings: secureStrings)
+
+        XCTAssertEqual(store.subagentPolicy(), .safeManaged)
+
+        let saved = try decode(SecureSubagentPermissionDocument.self, from: secureStrings.plainValues[key])
+        XCTAssertEqual(saved.globalPolicy(), .safeManaged)
+        XCTAssertNil(store.diagnostic(for: .subagent))
+    }
+
+    func testMissingPlainDocumentCreatesAndSavesProductDefaults() throws {
         let secureStrings = FakeSecurePlainStringStore()
         let key = AgentPermissionSecureDomain.codex.storageKey
         let store = makeStore(secureStrings: secureStrings)
 
         let permissions = store.codexPermissions()
 
-        XCTAssertEqual(permissions.permissionLevel(), .defaultPermission)
-        XCTAssertEqual(permissions.bashToolEnabled, false)
+        XCTAssertEqual(permissions.permissionLevel(), .autoReview)
+        XCTAssertEqual(permissions.bashToolEnabled, true)
         XCTAssertEqual(secureStrings.plainGetAccessModes, [.nonInteractive(reason: .permissionDecision)])
         XCTAssertEqual(secureStrings.plainSaveAccessModes, [.nonInteractive(reason: .permissionDecision)])
         XCTAssertTrue(secureStrings.savedPlainValues.contains { $0.key == key })
 
         let saved = try decode(SecureCodexPermissionDocument.self, from: secureStrings.plainValues[key])
-        XCTAssertEqual(saved.permissionLevel(), .defaultPermission)
-        XCTAssertEqual(saved.bashToolEnabled, false)
+        XCTAssertEqual(saved.permissionLevel(), .autoReview)
+        XCTAssertEqual(saved.bashToolEnabled, true)
         XCTAssertNil(store.diagnostic(for: .codex))
+    }
+
+    func testMissingCodexFieldsNormalizeToProductDefaults() throws {
+        let secureStrings = FakeSecurePlainStringStore()
+        let key = AgentPermissionSecureDomain.codex.storageKey
+        secureStrings.plainValues[key] = try encode(
+            SecureCodexPermissionDocument(
+                approvalReviewerRaw: nil,
+                bashToolEnabled: nil
+            )
+        )
+        let store = makeStore(secureStrings: secureStrings)
+
+        let permissions = store.codexPermissions()
+
+        XCTAssertEqual(permissions.permissionLevel(), .autoReview)
+        XCTAssertEqual(permissions.bashToolEnabled, true)
+        XCTAssertNil(store.diagnostic(for: .codex))
+
+        let saved = try decode(SecureCodexPermissionDocument.self, from: secureStrings.plainValues[key])
+        XCTAssertEqual(saved.permissionLevel(), .autoReview)
+        XCTAssertEqual(saved.bashToolEnabled, true)
+    }
+
+    func testNoSecureStoreFallbackUsesProductDefaults() throws {
+        let suiteName = "AgentPermissionSecureStoreTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.removePersistentDomain(forName: suiteName)
+
+        XCTAssertEqual(AgentModePermissionPreferences.subagentPermissionPolicy(defaults: defaults), .safeManaged)
+        XCTAssertTrue(CodexAgentToolPreferences.bashToolEnabled(defaults: defaults))
+        XCTAssertEqual(CodexAgentToolPreferences.permissionLevel(defaults: defaults), .autoReview)
+    }
+
+    @MainActor
+    func testProductDefaultsFlowThroughTopLevelSettingsSnapshot() throws {
+        let suiteName = "AgentPermissionSecureStoreTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.removePersistentDomain(forName: suiteName)
+
+        let secureStrings = FakeSecurePlainStringStore()
+        let secureStore = makeStore(secureStrings: secureStrings)
+        let snapshots = AgentProviderPreferenceSnapshotStore(
+            defaults: defaults,
+            securePermissions: secureStore,
+            codexMCPServerEntries: { [] }
+        )
+
+        let binding = snapshots.topLevelSettingsControlsBinding(providerID: .codex)
+
+        XCTAssertEqual(binding.permission.displayName, CodexAgentToolPreferences.PermissionLevel.autoReview.displayName)
+        XCTAssertEqual(binding.runtimePermission.codexApprovalReviewer, .autoReview)
+        XCTAssertEqual(binding.codexTools?.bashToolEnabled, true)
+    }
+
+    func testSuccessfulResetPersistsProductDefaultsAcrossRelaunch() throws {
+        let secureStrings = FakeSecurePlainStringStore()
+        let key = AgentPermissionSecureDomain.codex.storageKey
+        secureStrings.plainValues[key] = try encode(
+            SecureCodexPermissionDocument(
+                approvalPolicyRaw: CodexAgentToolPreferences.ApprovalPolicy.never.persistedValue,
+                sandboxModeRaw: CodexAgentToolPreferences.SandboxMode.dangerFullAccess.persistedValue,
+                approvalReviewerRaw: CodexAgentToolPreferences.ApprovalReviewer.user.persistedValue,
+                bashToolEnabled: false
+            )
+        )
+        let store = makeStore(secureStrings: secureStrings)
+
+        XCTAssertTrue(store.resetAgentPermissionsToSafeDefaults().succeeded)
+        XCTAssertEqual(store.subagentPolicy(), .safeManaged)
+        XCTAssertEqual(store.codexPermissions().permissionLevel(), .autoReview)
+        XCTAssertEqual(store.codexPermissions().bashToolEnabled, true)
+
+        let saved = try decode(SecureCodexPermissionDocument.self, from: secureStrings.plainValues[key])
+        XCTAssertEqual(saved.permissionLevel(), .autoReview)
+        XCTAssertEqual(saved.bashToolEnabled, true)
+
+        let restartedStore = makeStore(secureStrings: secureStrings)
+        XCTAssertEqual(restartedStore.codexPermissions().permissionLevel(), .autoReview)
+        XCTAssertEqual(restartedStore.codexPermissions().bashToolEnabled, true)
+    }
+
+    func testMissingPlainDocumentWriteFailureFailsClosed() {
+        let secureStrings = FakeSecurePlainStringStore(saveError: KeychainService.KeychainError.invalidData)
+        let store = makeStore(secureStrings: secureStrings)
+
+        let permissions = store.codexPermissions()
+
+        XCTAssertEqual(permissions.permissionLevel(), .defaultPermission)
+        XCTAssertEqual(permissions.bashToolEnabled, false)
+        XCTAssertEqual(store.diagnostic(for: .codex)?.kind, .keychainWriteFailed)
+    }
+
+    func testMalformedSubagentPlainDocumentFailsClosed() {
+        let secureStrings = FakeSecurePlainStringStore()
+        let key = AgentPermissionSecureDomain.subagent.storageKey
+        secureStrings.plainValues[key] = "{not-json"
+        let store = makeStore(secureStrings: secureStrings)
+
+        XCTAssertEqual(store.subagentPolicy(), .safeManaged)
+        XCTAssertTrue(secureStrings.savedPlainValues.isEmpty)
+        XCTAssertEqual(store.diagnostic(for: .subagent)?.kind, .decodeFailed)
+    }
+
+    func testSubagentReadFailureFailsClosed() {
+        let secureStrings = FakeSecurePlainStringStore(plainGetError: KeychainService.KeychainError.interactionNotAllowed)
+        let store = makeStore(secureStrings: secureStrings)
+
+        XCTAssertEqual(store.subagentPolicy(), .safeManaged)
+        XCTAssertEqual(store.diagnostic(for: .subagent)?.kind, .keychainInteractionNotAllowed)
+    }
+
+    func testMalformedCodexPlainDocumentFailsClosed() {
+        let secureStrings = FakeSecurePlainStringStore()
+        let key = AgentPermissionSecureDomain.codex.storageKey
+        secureStrings.plainValues[key] = "{not-json"
+        let store = makeStore(secureStrings: secureStrings)
+
+        let permissions = store.codexPermissions()
+
+        XCTAssertEqual(permissions.permissionLevel(), .defaultPermission)
+        XCTAssertEqual(permissions.bashToolEnabled, false)
+        XCTAssertTrue(secureStrings.savedPlainValues.isEmpty)
+        XCTAssertEqual(store.diagnostic(for: .codex)?.kind, .decodeFailed)
     }
 
     func testMalformedPlainDocumentFailsClosed() {
@@ -95,6 +250,7 @@ final class AgentPermissionSecureStoreTests: XCTestCase {
 
         let permissions = store.codexPermissions()
 
+        XCTAssertEqual(permissions.permissionLevel(), .defaultPermission)
         XCTAssertEqual(permissions.bashToolEnabled, false)
         XCTAssertEqual(secureStrings.plainGetAccessModes, [.nonInteractive(reason: .permissionDecision)])
 
@@ -132,12 +288,16 @@ final class AgentPermissionSecureStoreTests: XCTestCase {
         XCTAssertFalse(resetResult.succeeded)
         XCTAssertEqual(Set(resetResult.failedDomains), Set(AgentPermissionSecureDomain.allCases))
         XCTAssertEqual(secureStrings.plainDeleteAccessModes, Array(repeating: .interactive, count: AgentPermissionSecureDomain.allCases.count))
+        XCTAssertEqual(store.codexPermissions().permissionLevel(), .defaultPermission)
+        XCTAssertEqual(store.codexPermissions().bashToolEnabled, false)
+        XCTAssertEqual(store.diagnostic(for: .codex)?.kind, .keychainWriteFailed)
 
         secureStrings.failSaveKeys.removeAll()
         let restartedStore = makeStore(secureStrings: secureStrings)
         let restartedPermissions = restartedStore.codexPermissions()
-        XCTAssertEqual(restartedPermissions.permissionLevel(), .defaultPermission)
-        XCTAssertEqual(restartedPermissions.bashToolEnabled, false)
+        XCTAssertEqual(restartedPermissions.permissionLevel(), .autoReview)
+        XCTAssertEqual(restartedPermissions.bashToolEnabled, true)
+        XCTAssertNil(restartedStore.diagnostic(for: .codex))
     }
 
     func testUpdateWriteFailureForcesEffectiveCacheFailClosed() throws {


### PR DESCRIPTION
## Summary

Supersedes and integrates #151 onto current `main`, preserving its original commit and authorship, then adds the Codex permission behavior required for reliable MCP-started Agent Mode runs.

- recover expired MCP wait tracking after steering without allowing stale epochs to republish
- default new/missing Codex permission state to **Auto Review** with **Bash enabled** in debug and release
- apply those Codex defaults to Safe Managed `agent_run` sessions (pair, engineer, and explore)
- keep explicit restrictive overrides and secure-storage failures fail-closed
- keep user-toggled third-party MCP servers suppressed for Safe Managed sessions, including native Codex app-server launch configuration
- align UI capability summaries with runtime behavior

## Validation

Local coordinated validation on exact head `2a82f3fb4feed6490d087fa808ff8ef08b906a77`:

- `AgentModeMCPWaitEpochTests` — 9 passed
- `AgentRunSessionStoreRegistrationTests` — 15 passed
- `AgentPermissionSecureStoreTests` — 17 passed
- `AgentRunMCPToolServiceStartDefaultTests` — 8 passed
- `CodexNativeSessionControllerGoalConfigTests` — 4 passed
- `make dev-lint` — 0 violations
- `make dev-swift-build PRODUCT=RepoPrompt` — passed
- `make dev-test` — passed
- contribution commit and push preflights — passed

The first local full-suite attempt stopped making progress in the unrelated `WorkspaceFileContextStoreTests.testAttachRootShellFromPreloadedStoreRecordDoesNotMaterializeDescendants` case and was canceled with its log preserved. The required push-preflight rerun completed the full suite successfully.

## Live CE debug smoke

Built and relaunched the CE debug app from this exact branch, then drove fresh pair agents through `rpce-cli-debug agent_run`.

- Bash-default smoke completed with `RPCE_CODEX_DEFAULTS_SMOKE_OK`
- final PR integration/review agent completed with no edits, approval interaction, routing rejection, timeout, or tool error
- measured MCP tool latency during the integration run:
  - `read_file`: p95 56.8 ms (7 calls)
  - `file_search`: p95 975.8 ms (4 calls)
  - `git`: p95 236.0 ms (7 calls)
- lifecycle diagnostic drops: 0

The high-volume parallel monitor saturated the bounded 20,000-sample diagnostic capture and the structured diagnostics ring, so aggregate diagnostic history is incomplete; request execution itself remained responsive and the target run completed successfully.

Closes #151 when merged.
