### PR TITLE
Keep CLI provider disclosures user-controlled

### DIFF
--- a/Sources/RepoPrompt/Features/Settings/Views/CLIProvidersSettingsView.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/CLIProvidersSettingsView.swift
@@ -48,7 +48,8 @@ struct CLIProvidersSettingsView: View {
     @State private var isClaudePromptSettingsExpanded = false
     @State private var claudeNativePromptMode = ClaudeAgentToolPreferences.agentModePromptDelivery()
 
-    // Progressive disclosure state — disconnected providers start expanded
+    // Progressive disclosure state stays user-controlled. Async provider refreshes must not
+    // expand or collapse cards after the user starts interacting with this view.
     @State private var isClaudeCodeExpanded: Bool = false
     @State private var isClaudeCodeGLMExpanded: Bool = false
     @State private var isKimiCodeExpanded: Bool = false
@@ -56,7 +57,6 @@ struct CLIProvidersSettingsView: View {
     @State private var isCodexExpanded: Bool = false
     @State private var isOpenCodeExpanded: Bool = false
     @State private var isCursorExpanded: Bool = false
-    @State private var hasSetInitialExpansion = false
 
     // Per-backend secret text entry buffers (GLM uses viewModel.zaiApiKey directly).
     // SEARCH-HELPER: Claude-Compatible Backends settings, Kimi API key entry, Custom backend key entry
@@ -137,23 +137,9 @@ struct CLIProvidersSettingsView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .onAppear {
-            // Load backend state, then probe the Claude CLI binary before first expansion
-            // so a missing launcher opens the compatible-backend cards that need attention.
             Task {
                 await viewModel.loadCompatibleBackendState()
                 await viewModel.refreshClaudeCodeBinaryStatus()
-                await MainActor.run {
-                    if !hasSetInitialExpansion {
-                        isClaudeCodeExpanded = !viewModel.isClaudeCodeConnected
-                        isClaudeCodeGLMExpanded = shouldExpandCompatibleBackendInitially(.glmZAI)
-                        isKimiCodeExpanded = shouldExpandCompatibleBackendInitially(.kimi)
-                        isCustomCompatibleExpanded = shouldExpandCompatibleBackendInitially(.custom)
-                        isCodexExpanded = !viewModel.isCodexConnected
-                        isOpenCodeExpanded = !viewModel.isOpenCodeConnected
-                        isCursorExpanded = !viewModel.isCursorConnected
-                        hasSetInitialExpansion = true
-                    }
-                }
             }
         }
         .alert(isPresented: $showAlert) {
@@ -207,13 +193,6 @@ struct CLIProvidersSettingsView: View {
         if let url = URL(string: urlString) {
             NSWorkspace.shared.open(url)
         }
-    }
-
-    private func shouldExpandCompatibleBackendInitially(_ backendID: ClaudeCodeCompatibleBackendID) -> Bool {
-        let config = viewModel.compatibleBackendConfig(for: backendID)
-        if backendID == .custom, !config.isEnabled { return false }
-        if viewModel.claudeCodeCLIStatus.isKnownMissing { return true }
-        return !viewModel.compatibleBackendIsActive(backendID)
     }
 
     private var claudeCodeCLIUnavailableDetail: String {


### PR DESCRIPTION
## Summary

Rebases and validates #154 on the current `main` integration line.

This keeps CLI provider disclosure groups under user control: asynchronous provider refreshes now update availability without reopening sections the user intentionally collapsed. The stale one-shot auto-expansion state and helper are removed, leaving the existing stable tab identity and per-section SwiftUI state to own disclosure behavior.

Closes #154 when merged.

## Validation

Local, exact head `b51c0a86612aa6db842c1970b4702cdfb0ad7d17`:

- repository contribution preflight passed
  - staged/outgoing secret scans
  - source-layout and repository guardrails
  - `make dev-lint` (0 violations)
  - full `make dev-test`
  - `make dev-swift-build PRODUCT=RepoPrompt`
- focused `PromptAgentAvailabilityRefreshTests` passed
- clean pair-agent review through the CE debug app built from exact `origin/main`

## Live CE Agent Mode stress

The integration was reviewed by a pair agent launched through `rpce-cli-debug agent_run` while an independent monitor watched routing and tool execution.

- no target approval waits, routing failures, timeouts, or file/Git tool errors
- `read_file`: 8 calls, p95 31.3 ms
- `file_search`: 10 calls, p95 1.14 s
- Git tools: 6 calls, p95 243 ms
- `agent_run`: 13 calls, p95 55.3 ms
- 40,297 diagnostic samples retained, 0 sample drops

The lifecycle-event ring reached its retention cap during the stress run (1,471 older lifecycle events dropped), but request samples were not dropped and the target agent remained responsive. One monitor-only attempt to invoke a hidden diagnostic surface was correctly rejected by tool admission; it was unrelated to the target review and was not retried.

## Integration notes

The first two local full-suite attempts were canceled after stale/orphaned test-run state caused the conductor job to stop making progress at different tests. After terminating the orphaned prior-worktree `xctest` process and restarting the developer daemon, the clean full suite completed successfully. No product or test changes were required.
