### PR TITLE
Fix resumed agent ownership and file-search tail latency

### DIFF
--- a/Scripts/conductor.py
+++ b/Scripts/conductor.py
@@ -2503,6 +2503,12 @@ def is_already_on_workspace(stderr: str, workspace: str) -> bool:
     return expected in lines or f"Error: [-32600] Invalid Request: {expected}." in lines
 
 
+def routed_structured_cli_argv(cli: str, window_id: int, command: str, payload: Dict[str, Any]) -> List[str]:
+    routed_payload = dict(payload)
+    routed_payload["_windowID"] = window_id
+    return [cli, "-w", str(window_id), "-c", command, "-j", json.dumps(routed_payload)]
+
+
 def resolve_debug_cli() -> Optional[str]:
     install_override = os.environ.get("REPOPROMPT_DEBUG_CLI_INSTALL_PATH")
     if install_override:
@@ -2702,7 +2708,7 @@ def operation_smoke(repo_root: Path, args: Dict[str, Any]) -> int:
         )
         return code
 
-    window_id = str(args.get("windowId") or 1)
+    window_id = int(args.get("windowId") or 1)
     workspace = str(args.get("workspace") or "repoprompt-ce")
     operation_timeout = float(args.get("operationTimeout") or MEDIUM_TIMEOUT_SECONDS)
     deadline = now() + operation_timeout
@@ -2738,12 +2744,12 @@ def operation_smoke(repo_root: Path, args: Dict[str, Any]) -> int:
 
     stages = [
         ("windows", [cli, "-e", "windows"]),
-        ("workspace switch", [cli, "-w", window_id, "-e", f"workspace switch {workspace}"]),
-        ("tree roots", [cli, "-w", window_id, "-e", "tree --type roots"]),
-        ("manage_worktree list", [cli, "-w", window_id, "-e", "manage_worktree op=list"]),
+        ("workspace switch", [cli, "-w", str(window_id), "-e", f"workspace switch {workspace}"]),
+        ("tree roots", [cli, "-w", str(window_id), "-e", "tree --type roots"]),
+        ("manage_worktree list", [cli, "-w", str(window_id), "-e", "manage_worktree op=list"]),
         (
             "agent_manage roles",
-            [cli, "-w", window_id, "-c", "agent_manage", "-j", json.dumps({"op": "list_agents", "roles_only": True})],
+            routed_structured_cli_argv(cli, window_id, "agent_manage", {"op": "list_agents", "roles_only": True}),
         ),
     ]
     for name, argv in stages:
@@ -2768,7 +2774,7 @@ def operation_smoke(repo_root: Path, args: Dict[str, Any]) -> int:
         }
         code, stdout, _stderr = run_operation_command(
             "agent_run start",
-            [cli, "-w", window_id, "-c", "agent_run", "-j", json.dumps(start_payload)],
+            routed_structured_cli_argv(cli, window_id, "agent_run", start_payload),
             repo_root,
             env=env,
         )
@@ -2786,7 +2792,7 @@ def operation_smoke(repo_root: Path, args: Dict[str, Any]) -> int:
         wait_payload = {"op": "wait", "session_id": session_id, "timeout": agent_timeout}
         code, _stdout, _stderr = run_operation_command(
             "agent_run wait",
-            [cli, "-w", window_id, "-c", "agent_run", "-j", json.dumps(wait_payload)],
+            routed_structured_cli_argv(cli, window_id, "agent_run", wait_payload),
             repo_root,
             env=env,
             timeout=agent_timeout + 10.0,
@@ -2800,7 +2806,7 @@ def operation_diagnostics_agent_mode_on(repo_root: Path, args: Dict[str, Any]) -
     cli = require_debug_cli()
     if not cli:
         return 1
-    window_id = str(args.get("windowId") or 1)
+    window_id = int(args.get("windowId") or 1)
     log_file = str(args.get("logFile") or "/tmp/repoprompt-ce-claude-raw-events")
     settings = [
         {"op": "list", "group": "agent_mode", "detailed": True},
@@ -2811,7 +2817,7 @@ def operation_diagnostics_agent_mode_on(repo_root: Path, args: Dict[str, Any]) -
     for payload in settings:
         code, _stdout, _stderr = run_operation_command(
             f"app_settings {payload.get('op')} {payload.get('key') or payload.get('group')}",
-            [cli, "-w", window_id, "-c", "app_settings", "-j", json.dumps(payload)],
+            routed_structured_cli_argv(cli, window_id, "app_settings", payload),
             repo_root,
         )
         if code != 0:

--- a/Scripts/test_conductor_lifecycle.py
+++ b/Scripts/test_conductor_lifecycle.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import contextlib
 import io
+import json
 import os
 import shutil
 import subprocess
@@ -573,11 +574,74 @@ class SmokeOperationTests(unittest.TestCase):
                 ("manage_worktree list", ["/tmp/rpce-cli-debug", "-w", "7", "-e", "manage_worktree op=list"]),
                 (
                     "agent_manage roles",
-                    ["/tmp/rpce-cli-debug", "-w", "7", "-c", "agent_manage", "-j", '{"op": "list_agents", "roles_only": true}'],
+                    [
+                        "/tmp/rpce-cli-debug",
+                        "-w",
+                        "7",
+                        "-c",
+                        "agent_manage",
+                        "-j",
+                        '{"op": "list_agents", "roles_only": true, "_windowID": 7}',
+                    ],
                 ),
             ],
         )
 
+    def test_structured_smoke_calls_route_to_requested_window_with_fake_cli(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            log_path = root / "cli-calls.jsonl"
+            fake_cli = root / "rpce-cli-debug"
+            fake_cli.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/usr/bin/env python3
+                    import json
+                    import os
+                    import sys
+
+                    args = sys.argv[1:]
+                    with open(os.environ["FAKE_CLI_LOG"], "a", encoding="utf-8") as log:
+                        log.write(json.dumps(args) + "\\n")
+                    if "-c" in args and args[args.index("-c") + 1] == "agent_run":
+                        payload = json.loads(args[args.index("-j") + 1])
+                        if payload["op"] == "start":
+                            print(json.dumps({"session_id": "smoke-session"}))
+                    """
+                ),
+                encoding="utf-8",
+            )
+            fake_cli.chmod(0o755)
+
+            with mock.patch.dict(os.environ, {"FAKE_CLI_LOG": str(log_path)}), mock.patch.object(
+                conductor, "require_debug_cli", return_value=str(fake_cli)
+            ):
+                code = conductor.operation_smoke(
+                    root,
+                    {"windowId": 7, "workspace": "test-workspace", "agentRun": True, "agentTimeout": 5},
+                )
+
+            calls = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines()]
+
+        self.assertEqual(code, 0)
+        self.assertEqual(
+            calls[:4],
+            [
+                ["-e", "windows"],
+                ["-w", "7", "-e", "workspace switch test-workspace"],
+                ["-w", "7", "-e", "tree --type roots"],
+                ["-w", "7", "-e", "manage_worktree op=list"],
+            ],
+        )
+        structured_calls = calls[4:]
+        self.assertEqual(
+            [(call[call.index("-c") + 1], json.loads(call[call.index("-j") + 1])["op"]) for call in structured_calls],
+            [("agent_manage", "list_agents"), ("agent_run", "start"), ("agent_run", "wait")],
+        )
+        for call in structured_calls:
+            self.assertEqual(call[:3], ["-w", "7", "-c"])
+            payload = json.loads(call[call.index("-j") + 1])
+            self.assertEqual(payload["_windowID"], 7)
 
     def test_launch_smoke_uses_exact_embedded_helper_and_ignores_other_resolvers(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/Sources/RepoPrompt/Features/AgentMode/Services/AgentContextExportResolver.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Services/AgentContextExportResolver.swift
@@ -16,6 +16,7 @@ struct AgentContextExportSource: Equatable {
     var exportContextIdentity: AgentContextExportIdentity {
         AgentContextExportIdentity(
             tabID: tabID,
+            selection: selection,
             activeAgentSessionID: activeAgentSessionID,
             worktreeBindingFingerprint: Self.worktreeBindingFingerprint(worktreeBindings)
         )
@@ -28,6 +29,7 @@ struct AgentContextExportSource: Equatable {
 
 struct AgentContextExportIdentity: Equatable {
     let tabID: UUID?
+    let selection: StoredSelection
     let activeAgentSessionID: UUID?
     let worktreeBindingFingerprint: String
 }
@@ -149,12 +151,9 @@ enum AgentContextExportResolver {
         let canRemove: Bool
     }
 
-    static func selectionFileCount(_ selection: StoredSelection) -> Int {
+    static func explicitSelectionFileCount(_ selection: StoredSelection) -> Int {
         var seen = Set<String>()
         for path in selection.selectedPaths {
-            seen.insert(normalizedSelectionKey(path))
-        }
-        for path in selection.autoCodemapPaths {
             seen.insert(normalizedSelectionKey(path))
         }
         for (path, ranges) in selection.slices where !ranges.isEmpty {
@@ -164,13 +163,10 @@ enum AgentContextExportResolver {
     }
 
     static func displayFileCount(
-        resolvedModel: AgentContextExportModel?,
+        resolvedModel _: AgentContextExportModel?,
         sourceSelection: StoredSelection
     ) -> Int {
-        if let resolvedModel {
-            return resolvedModel.fileCount
-        }
-        return selectionFileCount(sourceSelection)
+        explicitSelectionFileCount(sourceSelection)
     }
 
     static func lookupContext(
@@ -397,8 +393,19 @@ enum AgentContextExportResolver {
             }
         }
 
+        let slicePaths = selection.slices.compactMap { path, ranges in
+            ranges.isEmpty || selectedLookupResults[path] != nil ? nil : path
+        }
+        let sliceLookupRequests = slicePaths.map {
+            WorkspacePathLookupRequest(userPath: $0, profile: profile, rootScope: rootScope)
+        }
+        let sliceLookupResults: [String: WorkspacePathLookupResult] = if sliceLookupRequests.isEmpty {
+            [:]
+        } else {
+            await store.lookupPaths(sliceLookupRequests)
+        }
         for (path, ranges) in selection.slices where !ranges.isEmpty {
-            guard let result = await store.lookupPath(path, profile: profile, rootScope: rootScope) else {
+            guard let result = selectedLookupResults[path] ?? sliceLookupResults[path] else {
                 missingPaths.append(path)
                 continue
             }
@@ -435,8 +442,16 @@ enum AgentContextExportResolver {
             }
         }
 
+        let codemapLookupRequests = codemapPaths.map {
+            WorkspacePathLookupRequest(userPath: $0, profile: profile, rootScope: rootScope)
+        }
+        let codemapLookupResults: [String: WorkspacePathLookupResult] = if codemapLookupRequests.isEmpty {
+            [:]
+        } else {
+            await store.lookupPaths(codemapLookupRequests)
+        }
         for path in codemapPaths {
-            guard let result = await store.lookupPath(path, profile: profile, rootScope: rootScope) else {
+            guard let result = codemapLookupResults[path] else {
                 missingPaths.append(path)
                 continue
             }

--- a/Sources/RepoPrompt/Features/AgentMode/Views/AgentModeDetailWithSidebarView.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/AgentModeDetailWithSidebarView.swift
@@ -263,7 +263,7 @@ struct AgentModeDetailWithSidebarView: View {
 
     private func syncRuntimeMetricsSelectionCount(selection: StoredSelection) {
         agentModeVM.syncRuntimeMetricsUIState(
-            liveSelectedFileCount: AgentContextExportResolver.selectionFileCount(selection)
+            liveSelectedFileCount: AgentContextExportResolver.explicitSelectionFileCount(selection)
         )
     }
 }

--- a/Sources/RepoPrompt/Features/Prompt/Services/PromptContextAccountingService.swift
+++ b/Sources/RepoPrompt/Features/Prompt/Services/PromptContextAccountingService.swift
@@ -657,8 +657,12 @@ actor PromptContextAccountingService {
                 fields: ["codemapPaths": "\(codemapPaths.count)"]
             )
         #endif
+        let codemapPathLookupRequests = codemapPaths.map {
+            WorkspacePathLookupRequest(userPath: $0, profile: profile, rootScope: rootScope)
+        }
+        let codemapPathLookupResults = await store.lookupPaths(codemapPathLookupRequests)
         for path in codemapPaths {
-            guard let result = await store.lookupPath(path, profile: profile, rootScope: rootScope) else {
+            guard let result = codemapPathLookupResults[path] else {
                 missingPaths.append(path)
                 continue
             }

--- a/Sources/RepoPrompt/Infrastructure/MCP/Agent/AgentManageMCPToolService.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/Agent/AgentManageMCPToolService.swift
@@ -510,13 +510,17 @@ struct AgentManageMCPToolService {
         )
         let hadMatchingMCPControl = agentModeVM.session(for: target.tabID, createIfNeeded: false)?.mcpControlContext?.sessionID == sessionID
         do {
-            try await agentModeVM.mcpActivateControlContext(
-                forTabID: target.tabID,
-                sessionID: sessionID,
-                originatingConnectionID: metadata.connectionID,
-                taskLabelKind: selection.taskLabelKind,
-                startPending: false
-            )
+            // Resume adopts the live session's existing control registration. Re-registering the
+            // same persistent session expires in-flight waiters and splits poll state from the UI.
+            if !hadMatchingMCPControl {
+                try await agentModeVM.mcpActivateControlContext(
+                    forTabID: target.tabID,
+                    sessionID: sessionID,
+                    originatingConnectionID: metadata.connectionID,
+                    taskLabelKind: selection.taskLabelKind,
+                    startPending: false
+                )
+            }
             try await agentModeVM.mcpConfigureSession(
                 tabID: target.tabID,
                 agentRaw: resolved.agent,

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel.swift
@@ -3180,7 +3180,14 @@ final class MCPServerViewModel: ObservableObject {
             windowID: key.windowID
         )
         let lookupRootScope = await resolveFileToolLookupContext(from: metadata).rootScope
-        let initialSelection = context.selection
+        guard let workspaceID = key.workspaceID,
+              let initialSelection = workspaceManager?.composeTab(
+                  for: WorkspaceSelectionIdentity(workspaceID: workspaceID, tabID: key.tabID)
+              )?.selection
+        else { return .unchanged }
+        // The bound tab context is a routable working snapshot, not canonical selection authority.
+        // Handoffs and delayed mirrors can leave it behind the stored compose-tab selection, so
+        // every additive read/search batch must rebase on the latest canonical value.
         var selection = initialSelection
 
         if !batch.fullPaths.isEmpty {

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/Selection/WorkspaceSelectionCoordinator.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/Selection/WorkspaceSelectionCoordinator.swift
@@ -532,6 +532,7 @@ final class WorkspaceSelectionCoordinator {
                         workspaceID: target.workspaceID
                     )
                 }
+                refreshDeferredUISelectionFence(forTabID: target.tabID)
             }
             finishSelectionMirrorTask(
                 taskID,
@@ -567,6 +568,7 @@ final class WorkspaceSelectionCoordinator {
                         workspaceID: target.workspaceID
                     )
                 }
+                refreshDeferredUISelectionFence(forTabID: target.tabID)
             }
             finishSelectionMirrorTask(
                 taskID,

--- a/Tests/RepoPromptTests/AgentMode/AgentContextExportResolverTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentContextExportResolverTests.swift
@@ -12,18 +12,106 @@ final class AgentContextExportResolverTests: XCTestCase {
         try super.tearDownWithError()
     }
 
-    func testDisplayFileCountUsesSourceSelectionBeforeModelLoads() {
+    func testDisplayFileCountUsesExplicitSelectionAndExcludesAutoCodemaps() {
         let selection = StoredSelection(
             selectedPaths: ["A.swift", "B.swift", "C.swift", "D.swift", "E.swift"],
-            autoCodemapPaths: ["G.swift"],
-            slices: ["F.swift": [LineRange(start: 1, end: 2)]],
-            codemapAutoEnabled: false
+            autoCodemapPaths: ["G.swift", "H.swift"],
+            slices: [
+                "E.swift": [LineRange(start: 1, end: 2)],
+                "F.swift": [LineRange(start: 3, end: 4)]
+            ],
+            codemapAutoEnabled: true
         )
 
+        XCTAssertEqual(AgentContextExportResolver.explicitSelectionFileCount(selection), 6)
         XCTAssertEqual(
             AgentContextExportResolver.displayFileCount(resolvedModel: nil, sourceSelection: selection),
-            7
+            6
         )
+    }
+
+    func testAutoCodemapExportResolutionBatchesPopoverPathLookups() async throws {
+        #if DEBUG
+            let root = try makeTemporaryRoot(name: "AgentExportAutoCodemapBatch")
+            let explicitFileCount = 7
+            var selectedPaths: [String] = []
+            var slices: [String: [LineRange]] = [:]
+            for index in 0 ..< explicitFileCount {
+                let fileURL = root.appendingPathComponent("Selected\(index).swift")
+                try write("struct Selected\(index) {}", to: fileURL)
+                selectedPaths.append(fileURL.path)
+                if index >= 3 {
+                    slices[fileURL.path] = [LineRange(start: 1, end: 1)]
+                }
+            }
+
+            let codemapCount = 44
+            var codemapPaths: [String] = []
+            var observed: [WorkspaceObservedCodemapResult] = []
+            for index in 0 ..< codemapCount {
+                let fileURL = root.appendingPathComponent("Dependency\(index).swift")
+                try write("struct Dependency\(index) {}", to: fileURL)
+                codemapPaths.append(fileURL.path)
+                observed.append(
+                    WorkspaceObservedCodemapResult(
+                        fullPath: fileURL.path,
+                        modificationDate: Date(),
+                        fileAPI: makeFileAPI(path: fileURL.path, symbol: "dependency\(index)")
+                    )
+                )
+            }
+
+            let store = WorkspaceFileContextStore()
+            _ = try await store.loadRoot(path: root.path)
+            await store.applyObservedCodemapResults(observed)
+            let source = AgentContextExportSource(
+                tabID: UUID(),
+                promptText: "Review",
+                selection: StoredSelection(
+                    selectedPaths: selectedPaths,
+                    autoCodemapPaths: codemapPaths,
+                    slices: slices,
+                    codemapAutoEnabled: true
+                ),
+                selectedMetaPromptIDs: [],
+                tabName: "Agent Tab",
+                activeAgentSessionID: nil,
+                worktreeBindings: []
+            )
+
+            EditFlowPerf.resetDebugCaptureForTesting()
+            defer { EditFlowPerf.resetDebugCaptureForTesting() }
+            switch EditFlowPerf.beginDebugCapture(label: "agent-export-auto-codemap-batch", maxSamples: 200) {
+            case .started:
+                break
+            case .busy:
+                XCTFail("Performance capture should start")
+            }
+
+            let model = await AgentContextExportResolver.resolveModel(
+                source: source,
+                store: store,
+                filePathDisplay: .relative,
+                codeMapUsage: .auto
+            )
+            let capture = EditFlowPerf.debugCaptureSnapshot(finish: true)
+            let snapshotBuildCount = capture.stages
+                .filter { $0.stageName == String(describing: EditFlowPerf.Stage.ReadFile.pathLookupStaticSnapshotBuild) }
+                .reduce(0) { $0 + $1.sampleCount }
+
+            XCTAssertEqual(model.rows.count(where: { $0.kind != .codemap }), explicitFileCount)
+            XCTAssertEqual(model.rows.count(where: { $0.kind == .slices }), 4)
+            XCTAssertEqual(model.rows.count(where: { $0.kind == .codemap }), codemapCount)
+            XCTAssertEqual(
+                AgentContextExportResolver.displayFileCount(
+                    resolvedModel: model,
+                    sourceSelection: source.selection
+                ),
+                explicitFileCount
+            )
+            XCTAssertEqual(snapshotBuildCount, 2)
+            XCTAssertEqual(capture.droppedSampleCount, 0)
+        #endif
     }
 
     func testWorktreeExportUsesPhysicalContentWhileDisplayingLogicalPath() async throws {
@@ -194,6 +282,14 @@ final class AgentContextExportResolverTests: XCTestCase {
 
         XCTAssertNotEqual(firstSource.exportContextIdentity, secondSource.exportContextIdentity)
         XCTAssertEqual(firstSource.exportContextIdentity, visualOnlySource.exportContextIdentity)
+
+        let changedSelectionSource = makeSource(
+            tabID: tabID,
+            sessionID: sessionID,
+            selection: StoredSelection(selectedPaths: ["Sources/Keep.swift"], codemapAutoEnabled: false),
+            bindings: [firstBinding]
+        )
+        XCTAssertNotEqual(firstSource.exportContextIdentity, changedSelectionSource.exportContextIdentity)
     }
 
     func testRemoveRowRebasedOntoLatestSelectionPreservesNewlyAddedFiles() async throws {
@@ -368,7 +464,7 @@ final class AgentContextExportResolverTests: XCTestCase {
 
         XCTAssertEqual(source.tabID, requestedTabID)
         XCTAssertEqual(source.selection, coordinatorSelection)
-        XCTAssertEqual(AgentContextExportResolver.selectionFileCount(source.selection), 2)
+        XCTAssertEqual(AgentContextExportResolver.explicitSelectionFileCount(source.selection), 2)
         XCTAssertEqual(source.promptText, "requested prompt")
     }
 
@@ -523,6 +619,27 @@ final class AgentContextExportResolverTests: XCTestCase {
             visualColorHex: "#3366FF",
             boundAt: Date(timeIntervalSinceReferenceDate: 123),
             source: "test"
+        )
+    }
+
+    private func makeFileAPI(path: String, symbol: String) -> FileAPI {
+        FileAPI(
+            filePath: path,
+            imports: [],
+            classes: [],
+            functions: [
+                FunctionInfo(
+                    name: symbol,
+                    parameters: [],
+                    returnType: nil,
+                    definitionLine: "func \(symbol)()",
+                    lineNumber: 1
+                )
+            ],
+            enums: [],
+            globalVars: [],
+            macros: [],
+            referencedTypes: []
         )
     }
 

--- a/Tests/RepoPromptTests/MCP/AgentManageMCPToolServiceResumeTests.swift
+++ b/Tests/RepoPromptTests/MCP/AgentManageMCPToolServiceResumeTests.swift
@@ -1,0 +1,171 @@
+import Foundation
+import MCP
+@_spi(TestSupport) @testable import RepoPrompt
+import XCTest
+
+@MainActor
+final class AgentManageMCPToolServiceResumeTests: XCTestCase {
+    func testResumeOfControlledSessionPreservesWaitOwnershipAcrossSteering() async throws {
+        let window = try await makeWindow()
+        defer { WindowStatesManager.shared.unregisterWindowState(window) }
+
+        let viewModel = window.agentModeViewModel
+        let sessionID = UUID()
+        let initialConnectionID = UUID()
+        let resumedConnectionID = UUID()
+        let session = await viewModel.ensureSessionReady(tabID: UUID())
+        _ = viewModel.test_installPersistentSessionBinding(sessionID: sessionID, on: session)
+        try await viewModel.mcpActivateControlContext(
+            forTabID: session.tabID,
+            sessionID: sessionID,
+            originatingConnectionID: initialConnectionID,
+            taskLabelKind: .pair,
+            startPending: true
+        )
+        await viewModel.prepareMCPWaitTrackingForRunStart(session: session)
+        _ = session.beginRunAttempt(source: "test.resume.initial")
+        session.runState = .running
+        viewModel.publishMCPStateChange(for: session)
+
+        let initialContext = try XCTUnwrap(session.mcpControlContext)
+        let initialEpoch = try XCTUnwrap(initialContext.currentEpoch)
+        let initialCursor = AgentRunSessionStore.WaitCursor(
+            registration: initialContext.registration,
+            epoch: initialEpoch
+        )
+        let originalWait = Task {
+            await AgentRunSessionStore.waitUntilInteresting(
+                cursor: initialCursor,
+                timeoutSeconds: 1
+            )
+        }
+        try await waitForWaiter(registration: initialContext.registration)
+
+        let service = makeService(window: window, connectionID: resumedConnectionID)
+        _ = try await service.execute(args: [
+            "op": .string("resume_session"),
+            "session_id": .string(sessionID.uuidString)
+        ])
+
+        let resumedContext = try XCTUnwrap(session.mcpControlContext)
+        XCTAssertEqual(resumedContext.activationID, initialContext.activationID)
+        XCTAssertEqual(resumedContext.registration, initialContext.registration)
+        XCTAssertEqual(resumedContext.taskLabelKind, .pair)
+        let currentRegistration = await AgentRunSessionStore.currentRegistration(for: sessionID)
+        XCTAssertEqual(currentRegistration, initialContext.registration)
+
+        session.runState = .cancelled
+        try await viewModel.withMCPRunEpochTransition(sessionID: sessionID, kind: .steering) {
+            await viewModel.prepareMCPWaitTrackingForRunStart(session: session)
+        }
+        let steeredContext = try XCTUnwrap(session.mcpControlContext)
+        let steeredEpoch = try XCTUnwrap(steeredContext.currentEpoch)
+        XCTAssertEqual(steeredContext.registration, initialContext.registration)
+        XCTAssertEqual(steeredEpoch.transitionKind, .steering)
+
+        let firstDisposition = await originalWait.value
+        XCTAssertEqual(firstDisposition, .epochAdvanced(steeredEpoch, .steering))
+
+        let steeredCursor = AgentRunSessionStore.WaitCursor(
+            registration: initialContext.registration,
+            epoch: steeredEpoch
+        )
+        let steeredWait = Task {
+            await AgentRunSessionStore.waitUntilInteresting(
+                cursor: steeredCursor,
+                timeoutSeconds: 1
+            )
+        }
+        try await waitForWaiter(registration: initialContext.registration)
+        let cancelled = makeSnapshot(sessionID: sessionID, status: .cancelled)
+        await AgentRunSessionStore.signalSnapshot(cancelled, cursor: steeredCursor)
+        let terminalDisposition = await steeredWait.value
+        XCTAssertEqual(terminalDisposition, .snapshotReady(cancelled))
+
+        await viewModel.mcpDeactivateControlContext(
+            sessionID: sessionID,
+            cleanupSessionStore: true
+        )
+    }
+
+    private func makeWindow() async throws -> WindowState {
+        let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
+        GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
+        let window = WindowState()
+        WindowStatesManager.shared.registerWindowState(window)
+        GlobalSettingsStore.shared.setMCPAutoStart(previousAutoStart, commit: false)
+
+        let workspace = window.workspaceManager.createWorkspace(
+            name: "Resume Ownership \(UUID().uuidString.prefix(8))",
+            repoPaths: [FileManager.default.currentDirectoryPath],
+            ephemeral: true
+        )
+        await window.workspaceManager.switchWorkspace(
+            to: workspace,
+            saveState: false,
+            reason: "agentManageResumeOwnershipTests"
+        )
+        let activeWorkspace = try XCTUnwrap(window.workspaceManager.activeWorkspace)
+        window.promptManager.loadComposeTabsFromWorkspace(activeWorkspace, syncPromptText: true)
+        return window
+    }
+
+    private func makeService(
+        window: WindowState,
+        connectionID: UUID
+    ) -> AgentManageMCPToolService {
+        AgentManageMCPToolService(
+            toolName: MCPWindowToolName.agentManage,
+            captureRequestMetadata: {
+                MCPServerViewModel.RequestMetadata(
+                    connectionID: connectionID,
+                    clientName: "resume-ownership-regression",
+                    windowID: window.windowID
+                )
+            },
+            requireTargetWindow: { window },
+            resolveSpawnSourceTabID: { _ in nil },
+            resolveSpawnParentSessionID: { _, _ in nil },
+            bindCurrentRequestToTab: { _, _ in }
+        )
+    }
+
+    private func waitForWaiter(
+        registration: AgentRunSessionStore.Registration,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws {
+        for _ in 0 ..< 300 {
+            if await AgentRunSessionStore.shared.test_waiterCount(registration: registration) == 1 {
+                return
+            }
+            try await Task.sleep(nanoseconds: 5_000_000)
+        }
+        XCTFail("Timed out waiting for store waiter", file: file, line: line)
+    }
+
+    private func makeSnapshot(
+        sessionID: UUID,
+        status: AgentRunMCPSnapshot.Status
+    ) -> AgentRunMCPSnapshot {
+        AgentRunMCPSnapshot(
+            sessionID: sessionID,
+            tabID: nil,
+            sessionName: "Pair Session",
+            agentRaw: AgentProviderKind.codexExec.rawValue,
+            agentDisplayName: AgentProviderKind.codexExec.displayName,
+            modelRaw: "codex",
+            reasoningEffortRaw: nil,
+            status: status,
+            statusText: status.rawValue,
+            latestAssistantPreview: "buffered assistant text",
+            interaction: nil,
+            transcriptItemCount: 1,
+            updatedAt: Date(),
+            parentSessionID: nil,
+            failureReason: status == .cancelled ? .cancelled : nil,
+            worktreeBindings: [],
+            activeWorktreeMerges: []
+        )
+    }
+}

--- a/Tests/RepoPromptTests/MCP/Control/PersistentAgentModeMCPReadFileConnectionTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/PersistentAgentModeMCPReadFileConnectionTests.swift
@@ -15,6 +15,16 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
         #endif
     }
 
+    func testPairAgentOwnedSequentialFullAndSlicedReadsUnionCanonicalSelection() async throws {
+        #if DEBUG
+            try await withFixture(agentOwned: true) { fixture in
+                try await runCheckpoint(fixture: fixture, scenario: .agentOwnedSequentialReadUnion)
+            }
+        #else
+            throw XCTSkip("Persistent Agent Mode MCP socketpair integration requires DEBUG inspection helpers.")
+        #endif
+    }
+
     func testAgentOwnedExplicitSetPersistsForIndependentCanonicalLookup() async throws {
         #if DEBUG
             try await withFixture(agentOwned: true) { fixture in
@@ -140,12 +150,13 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
             case workspaceReorderDuringPersistence
             case rebindDuringPersistence
             case agentOwnedCanonicalSelection
+            case agentOwnedSequentialReadUnion
             case agentOwnedExplicitSetIndependentLookup
             case agentOwnedNoRangeNonEmptyWorktreeFile
 
             var requiresSerialReadPrelude: Bool {
                 switch self {
-                case .agentOwnedNoRangeNonEmptyWorktreeFile:
+                case .agentOwnedNoRangeNonEmptyWorktreeFile, .agentOwnedSequentialReadUnion:
                     false
                 default:
                     true
@@ -320,11 +331,68 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
                 try await assertRebindDuringAutoSelectionPersistence(fixture: fixture)
             case .agentOwnedCanonicalSelection:
                 try await assertAgentOwnedCanonicalSelection(fixture: fixture)
+            case .agentOwnedSequentialReadUnion:
+                try await assertAgentOwnedSequentialReadUnion(fixture: fixture)
             case .agentOwnedExplicitSetIndependentLookup:
                 try await assertAgentOwnedExplicitSetIndependentLookup(fixture: fixture)
             case .agentOwnedNoRangeNonEmptyWorktreeFile:
                 try await assertAgentOwnedNoRangeNonEmptyWorktreeFile(fixture: fixture)
             }
+        }
+
+        func assertAgentOwnedSequentialReadUnion(fixture: Fixture) async throws {
+            try await clearSelection(fixture: fixture, id: 3)
+
+            let fullRead = try await fixture.socketClient.request(
+                id: 4,
+                method: "tools/call",
+                params: [
+                    "name": MCPWindowToolName.readFile,
+                    "arguments": ["path": fixture.fileURL.path]
+                ]
+            )
+            let fullText = try Self.readFileText(from: fullRead, id: 4)
+            XCTAssertTrue(fullText.contains(Fixture.sentinelContent), fullText)
+            let firstSettled = await waitForReadFileAutoSelectionToSettle(fixture: fixture)
+            XCTAssertTrue(firstSettled, "First read auto-selection did not converge without manage_selection get")
+            assertCanonicalSelection(
+                fixture: fixture,
+                selectedPaths: [fixture.fileURL.path],
+                slices: [:]
+            )
+
+            // Reproduce the production failure boundary: routing/handoff/mirror state may retain
+            // an older working snapshot even though canonical persistence and its mirror completed.
+            // The next additive read must merge from canonical storage, never this cache.
+            fixture.window.mcpServer.tabContextByConnectionID[Fixture.connectionID]?.selection = StoredSelection()
+
+            let slicedRead = try await fixture.socketClient.request(
+                id: 5,
+                method: "tools/call",
+                params: [
+                    "name": MCPWindowToolName.readFile,
+                    "arguments": [
+                        "path": fixture.liveFileURL.path,
+                        "start_line": 2,
+                        "limit": 2
+                    ]
+                ]
+            )
+            let slicedText = try Self.readFileText(from: slicedRead, id: 5)
+            XCTAssertTrue(slicedText.contains("**Lines**: 2–3"), slicedText)
+            let finalSettled = await waitForReadFileAutoSelectionToSettle(fixture: fixture)
+            XCTAssertTrue(finalSettled, "Cumulative read auto-selection did not converge without manage_selection get")
+
+            let expectedPaths = [fixture.fileURL.path, fixture.liveFileURL.path]
+            let expectedSlices = [fixture.liveFileURL.path: [LineRange(start: 2, end: 3)]]
+            assertCanonicalSelection(
+                fixture: fixture,
+                selectedPaths: expectedPaths,
+                slices: expectedSlices
+            )
+            let liveSelection = fixture.window.workspaceFilesViewModel.snapshotSelection()
+            XCTAssertEqual(Set(liveSelection.selectedPaths), Set(expectedPaths))
+            XCTAssertEqual(liveSelection.slices, expectedSlices)
         }
 
         func assertAgentOwnedExplicitSetIndependentLookup(fixture: Fixture) async throws {
@@ -1149,6 +1217,26 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
                 ]
             )
             try Self.assertSuccessfulResponse(response, id: id)
+        }
+
+        func waitForReadFileAutoSelectionToSettle(fixture: Fixture) async -> Bool {
+            let deadline = ContinuousClock.now + .seconds(3)
+            while ContinuousClock.now < deadline {
+                let snapshot = fixture.window.mcpServer.readFileAutoSelectionDiagnosticsSnapshot()
+                if snapshot.canonicalWorkerCount == 0,
+                   snapshot.mirrorWorkerCount == 0,
+                   snapshot.pendingCanonicalBatchCount == 0,
+                   snapshot.pendingMirrorBatchCount == 0
+                {
+                    return true
+                }
+                try? await Task.sleep(for: .milliseconds(10))
+            }
+            let snapshot = fixture.window.mcpServer.readFileAutoSelectionDiagnosticsSnapshot()
+            return snapshot.canonicalWorkerCount == 0
+                && snapshot.mirrorWorkerCount == 0
+                && snapshot.pendingCanonicalBatchCount == 0
+                && snapshot.pendingMirrorBatchCount == 0
         }
 
         func waitForCanonicalWorkerToSettle(fixture: Fixture) async -> Bool {

--- a/Tests/RepoPromptTests/MCP/MCPReadSearchLatencyDiagnosticsGuardTests.swift
+++ b/Tests/RepoPromptTests/MCP/MCPReadSearchLatencyDiagnosticsGuardTests.swift
@@ -1752,6 +1752,66 @@
             XCTAssertFalse(workspaceManager.contains("EditFlowPerf.Dimensions(path:"))
         }
 
+        func testAgentExportPopoverResolvesSlicesAndCodemapsWithBatchedLookups() throws {
+            let resolver = try source("Sources/RepoPrompt/Features/AgentMode/Services/AgentContextExportResolver.swift")
+            let resolveStart = try XCTUnwrap(resolver.range(of: "    private static func resolveRows("))
+            let resolveEnd = try XCTUnwrap(
+                resolver.range(
+                    of: "    private static func row(",
+                    range: resolveStart.upperBound ..< resolver.endIndex
+                )
+            )
+            let resolveRows = String(resolver[resolveStart.lowerBound ..< resolveEnd.lowerBound])
+
+            XCTAssertTrue(resolveRows.contains("await store.lookupPaths(sliceLookupRequests)"))
+            XCTAssertTrue(resolveRows.contains("await store.lookupPaths(codemapLookupRequests)"))
+            XCTAssertFalse(resolveRows.contains("await store.lookupPath(path, profile: profile, rootScope: rootScope)"))
+        }
+
+        func testCanonicalSelectionRebaseRemainsInsideDeferredAutoSelectionWorker() throws {
+            let viewModel = try source("Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel.swift")
+            let applyStart = try XCTUnwrap(viewModel.range(of: "    private func applyReadFileAutoSelectionBatch("))
+            let applyEnd = try XCTUnwrap(
+                viewModel.range(
+                    of: "    @MainActor\n    func readFileAutoSelectionContext(",
+                    range: applyStart.upperBound ..< viewModel.endIndex
+                )
+            )
+            let applyMethod = String(viewModel[applyStart.lowerBound ..< applyEnd.lowerBound])
+            XCTAssertTrue(applyMethod.contains("workspaceManager?.composeTab("))
+
+            let readEnqueueStart = try XCTUnwrap(viewModel.range(of: "    private func enqueueReadFileAutoSelection("))
+            let readEnqueueEnd = try XCTUnwrap(
+                viewModel.range(
+                    of: "    @MainActor\n    func drainReadFileAutoSelection(",
+                    range: readEnqueueStart.upperBound ..< viewModel.endIndex
+                )
+            )
+            let readEnqueue = String(viewModel[readEnqueueStart.lowerBound ..< readEnqueueEnd.lowerBound])
+            XCTAssertFalse(readEnqueue.contains("composeTab("))
+
+            let searchEnqueueStart = try XCTUnwrap(viewModel.range(of: "    private func enqueueFileSearchAutoSelection("))
+            let searchEnqueueEnd = try XCTUnwrap(
+                viewModel.range(
+                    of: "    private func applySelectionSlices(",
+                    range: searchEnqueueStart.upperBound ..< viewModel.endIndex
+                )
+            )
+            let searchEnqueue = String(viewModel[searchEnqueueStart.lowerBound ..< searchEnqueueEnd.lowerBound])
+            XCTAssertFalse(searchEnqueue.contains("composeTab("))
+
+            let coordinator = try source("Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPReadFileAutoSelectionCoordinator.swift")
+            let workerStart = try XCTUnwrap(coordinator.range(of: "    private func runCanonicalWorker("))
+            let workerEnd = try XCTUnwrap(
+                coordinator.range(
+                    of: "    private func completeCanonicalBatch(",
+                    range: workerStart.upperBound ..< coordinator.endIndex
+                )
+            )
+            let worker = String(coordinator[workerStart.lowerBound ..< workerEnd.lowerBound])
+            XCTAssertTrue(worker.contains("await applyCanonical(key, queued.batch)"))
+        }
+
         func testReadFileAutoSelectionQueueRecorderCapturesSanitizedStagesAndLifecycle() throws {
             _ = startedCapture(label: "read-file-auto-selection-queue", maxSamples: 100)
             let correlation = try XCTUnwrap(EditFlowPerf.makeLifecycleCorrelationIfActive())

--- a/Tests/RepoPromptTests/Prompt/PromptContextAccountingServiceTests.swift
+++ b/Tests/RepoPromptTests/Prompt/PromptContextAccountingServiceTests.swift
@@ -154,6 +154,61 @@ final class PromptContextAccountingServiceTests: XCTestCase {
         XCTAssertEqual(resolution.invalidPaths, [])
     }
 
+    func testCompleteCodemapResolutionBuildsSingleStaticPathSnapshot() async throws {
+        #if DEBUG
+            let root = try makeTemporaryRoot(name: "AccountingCompleteCodemapBatch")
+            let fileCount = 24
+            var observed: [WorkspaceObservedCodemapResult] = []
+            observed.reserveCapacity(fileCount)
+            for index in 0 ..< fileCount {
+                let fileURL = root.appendingPathComponent("File\(index).swift")
+                try write("struct File\(index) {}", to: fileURL)
+                observed.append(
+                    WorkspaceObservedCodemapResult(
+                        fullPath: fileURL.path,
+                        modificationDate: Date(),
+                        fileAPI: makeFileAPI(path: fileURL.path)
+                    )
+                )
+            }
+
+            let store = WorkspaceFileContextStore()
+            _ = try await store.loadRoot(path: root.path)
+            await store.applyObservedCodemapResults(observed)
+            let service = PromptContextAccountingService()
+            let selection = StoredSelection(
+                selectedPaths: [],
+                autoCodemapPaths: [],
+                slices: [:],
+                codemapAutoEnabled: false
+            )
+
+            EditFlowPerf.resetDebugCaptureForTesting()
+            defer { EditFlowPerf.resetDebugCaptureForTesting() }
+            switch EditFlowPerf.beginDebugCapture(label: "complete-codemap-batch", maxSamples: 200) {
+            case .started:
+                break
+            case .busy:
+                XCTFail("Performance capture should start")
+            }
+
+            let resolution = await service.resolveEntries(
+                selection: selection,
+                store: store,
+                codeMapUsage: .complete
+            )
+            let capture = EditFlowPerf.debugCaptureSnapshot(finish: true)
+            let snapshotBuildCount = capture.stages
+                .filter { $0.stageName == String(describing: EditFlowPerf.Stage.ReadFile.pathLookupStaticSnapshotBuild) }
+                .reduce(0) { $0 + $1.sampleCount }
+
+            XCTAssertEqual(resolution.entries.count, fileCount)
+            XCTAssertTrue(resolution.entries.allSatisfy { $0.mode == .codemap })
+            XCTAssertEqual(snapshotBuildCount, 1)
+            XCTAssertEqual(capture.droppedSampleCount, 0)
+        #endif
+    }
+
     private func makeTemporaryRoot(name: String) throws -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("RepoPromptTests", isDirectory: true)

--- a/Tests/RepoPromptTests/WorkspaceContext/WorkspaceSelectionCoordinatorTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/WorkspaceSelectionCoordinatorTests.swift
@@ -351,6 +351,64 @@ final class WorkspaceSelectionCoordinatorTests: XCTestCase {
         XCTAssertEqual(coordinator.selectionForActiveUISnapshot(staleUI, tabID: harness.tabID), staleUI)
     }
 
+    func testDeferredMCPMirrorRefreshesFenceBeforeQueuedCatalogSnapshotPublishes() async {
+        let first = StoredSelection(
+            selectedPaths: ["/tmp/Full.swift"],
+            autoCodemapPaths: ["/tmp/DependencyA.swift", "/tmp/DependencyB.swift"],
+            codemapAutoEnabled: true
+        )
+        let latest = StoredSelection(
+            selectedPaths: ["/tmp/Full.swift", "/tmp/Sliced.swift"],
+            autoCodemapPaths: [
+                "/tmp/DependencyA.swift",
+                "/tmp/DependencyB.swift",
+                "/tmp/DependencyC.swift",
+                "/tmp/DependencyD.swift"
+            ],
+            slices: ["/tmp/Sliced.swift": [LineRange(start: 4, end: 7)]],
+            codemapAutoEnabled: true
+        )
+        let completeCatalog = StoredSelection(
+            selectedPaths: ["/tmp/Full.swift", "/tmp/Sliced.swift"],
+            autoCodemapPaths: (0 ..< 300).map { "/tmp/Catalog/\($0).swift" },
+            codemapAutoEnabled: true
+        )
+        let harness = CoordinatorHarness(initialSelection: StoredSelection())
+        let coordinator = WorkspaceSelectionCoordinator(workspaceManager: harness.manager, store: harness.store)
+        harness.manager.activeUISnapshotResolver = { selection, tabID in
+            coordinator.selectionForActiveUISnapshot(selection, tabID: tabID)
+        }
+        harness.manager.advanceLiveUISelectionRevisionDuringMirror = true
+
+        for expected in [first, latest] {
+            _ = await coordinator.persistActiveSelection(
+                expected,
+                source: .mcpTabContext,
+                mirrorToUI: false
+            )
+            harness.manager.pendingUISelection = completeCatalog
+
+            await coordinator.mirrorSelectionToActiveUI(expected, forTabID: harness.tabID)
+
+            // Model the already-enqueued selected-files debounce. This is not a read-file
+            // drain or manage_selection get; it is the ordinary UI publication that runs
+            // after the programmatic mirror has advanced the live selection revision.
+            harness.manager.publishActiveComposeTabSnapshot(
+                commitToMemory: true,
+                touchModified: false
+            )
+
+            XCTAssertEqual(harness.manager.composeTab(for: harness.identity)?.selection, expected)
+        }
+
+        XCTAssertEqual(harness.manager.mirroredSelection, latest)
+        XCTAssertEqual(harness.manager.publishedSelections, [first, latest])
+        XCTAssertTrue(harness.manager.publishedSelections.allSatisfy {
+            $0.selectedPaths.count + $0.autoCodemapPaths.count <= 6
+        })
+        XCTAssertFalse(harness.manager.publishedSelections.contains(completeCatalog))
+    }
+
     func testTwoSourceWindowsRejectDelayedOlderPropagationAfterNewerLocalMutation() async {
         let initial = StoredSelection(selectedPaths: ["/tmp/initial.swift"])
         let older = StoredSelection(selectedPaths: ["/tmp/older.swift"])
@@ -807,6 +865,8 @@ private final class FakeWorkspaceSelectionManager: WorkspaceSelectionHost {
     var pendingUISelection: StoredSelection?
     var activeUISnapshotResolver: ((StoredSelection, UUID) -> StoredSelection)?
     var presentationHandler: (() -> Void)?
+    var advanceLiveUISelectionRevisionDuringMirror = false
+    private(set) var publishedSelections: [StoredSelection] = []
     private(set) var publishSnapshotCallCount = 0
     private(set) var updateStoredOnlyCallCount = 0
     var firstMirrorGate: SelectionMirrorGate?
@@ -853,7 +913,9 @@ private final class FakeWorkspaceSelectionManager: WorkspaceSelectionHost {
               let activeID = workspace.activeComposeTabID,
               let index = workspace.composeTabs.firstIndex(where: { $0.id == activeID })
         else { return }
-        workspace.composeTabs[index].selection = activeUISnapshotResolver?(pendingUISelection, activeID) ?? pendingUISelection
+        let publishedSelection = activeUISnapshotResolver?(pendingUISelection, activeID) ?? pendingUISelection
+        workspace.composeTabs[index].selection = publishedSelection
+        publishedSelections.append(publishedSelection)
         if touchModified {
             workspace.composeTabs[index].lastModified = Date()
         }
@@ -877,6 +939,9 @@ private final class FakeWorkspaceSelectionManager: WorkspaceSelectionHost {
         }
         mirroredSelection = selection
         mirrorCompletedSelections.append(selection)
+        if advanceLiveUISelectionRevisionDuringMirror {
+            liveUISelectionRevision &+= 1
+        }
     }
 
     func appendTab(_ tab: ComposeTabState) {


### PR DESCRIPTION
## Summary

This PR fixes two production issues discovered while using the CE debug app to integrate PR #146:

1. **Steered/resumed Agent Mode sessions could split control ownership.** `agent_manage.resume_session` re-registered an already-controlled persistent session, expiring the original wait registration while the UI session remained live. The next steer could remain indefinitely in `Connecting…` with tool transport closed.
2. **Concurrent file searches developed 10–50 second tails.** Complete-codemap prompt recounting resolved every codemap path individually; each singular lookup rebuilt and sorted the complete static workspace path snapshot, contending with content search on the workspace store actor.

## Fixes

- Reuse a matching live MCP control registration during `resume_session`; activate a new control only when ownership does not already match.
- Resolve complete-codemap paths with one batched `lookupPaths` request instead of one full snapshot build per path.

Both changes preserve existing freshness, missing-path, ordering, and provider-affinity semantics.

## Live debug evidence

A concurrent external-debug workload used one pair agent to alternate `apply_edits`/Bash mutations and another pair agent to alternate 10 `file_search` and 10 `read_file` calls in the PR #146 workspace.

### Before

- Search calls degraded from ~0.5–0.7s to **11.93s**, then **50.10s**.
- Capture: 37,962 samples / 3,925 lifecycle events / 103 request timelines / zero drops.
- 50.10s request:
  - provider workspace search: 49.94s
  - content scan: 48.49s
  - one mid-scan gap: 31.36s
  - admission and response publication were effectively immediate
- Aggregate capture showed **1,209** static path snapshot builds, p50 **125.67ms**, total **152.4s**.

### After

The identical reader sequence completed all 20 calls:

- Ten searches: **18.8ms–1.53s**
- Ten reads: approximately **12–20ms**
- No calls over 10 seconds
- No sustained degradation or tool failures
- Capture: 90,256 samples / 5,517 lifecycle events / 47 request timelines / zero drops

The separate Codex Bash-wrapper lifecycle issue remains: commands can print correct output immediately while their shell wrapper stays open past 30 seconds. It is not present in app MCP request timelines and is not addressed here.

## Regression coverage

- Production `resume_session` → steering ordering with a parked waiter; verifies the original registration advances epochs and receives terminal state instead of expiring.
- Complete-codemap accounting using the real workspace store and performance capture; verifies 24 paths build one static snapshot.
  - Before: 24 snapshot builds, 1.151s
  - After: 1 snapshot build, 0.020s

## Validation

- Full `swift test`: passed
- `swift build --product RepoPrompt`: passed
- SwiftFormat / SwiftLint strict: passed
- Focused wait-epoch, session-store, prompt-accounting, store-backed search, latency-diagnostics, and role-agnostic affinity suites: passed
- External `rpce-cli-debug` steering smoke: same pair session completed `read_file`, resumed, and completed `file_search` without `Connecting…` or transport closure
- External concurrent read/search + mutation stress: passed as documented above


## Selection correctness and UI follow-up

Live `rpce-cli-debug` testing also exposed a split-brain selection path after successful `read_file` calls:

- additive read batches rebased on a stale connection snapshot, so later reads could replace earlier selections;
- programmatic mirrors advanced the live UI revision without refreshing the deferred stale-UI fence, allowing a queued UI snapshot to overwrite canonical state;
- the export footer counted hidden auto-codemap dependencies as explicit files;
- the Agent Files popover cache identity omitted selection state and resolved slice/codemap rows one path at a time, so it could remain at `Files 0 / Codemaps 0` with a spinner while the footer showed 51 files.

The follow-up fixes:

- rebase deferred read-selection batches on canonical compose-tab selection;
- refresh the deferred UI fence after normal and repair mirrors;
- count only unique explicit full/sliced files in the footer badge;
- include selection state in export-model identity;
- batch slice and codemap path resolution.

`AGENTS.md` remains intentionally excluded from read auto-selection. In the final live smoke, seven selectable reads produced a footer count of **7**, while the detailed popover resolved **Files 7 / Codemaps 44** and stopped loading. The agent issued no `manage_selection get`, so convergence no longer depends on readback as a synchronization barrier.

## Debug smoke harness routing

The same validation found that `make dev-smoke` failed whenever multiple RepoPrompt windows were open: structured `-c/-j` calls passed `-w` but omitted the hidden `_windowID` payload field required for unbound multi-window routing. The smoke runner now injects the requested runtime window into all structured `agent_manage`, `agent_run`, and diagnostics payloads through one helper. An executable fake-CLI regression proves a non-default window is propagated while shell-expression calls remain unchanged.

## Additional validation

- Selection-focused suites: **115 tests passed**
- Full Swift suite: passed on the final Swift selection commit
- Final `RepoPrompt` product build: passed
- Conductor self-tests: **99 passed**
- `make dev-smoke`: passed with two app windows present
- Live external pair-agent smoke: seven selectable reads accumulated without `manage_selection get`; footer and popover matched expected explicit/codemap counts
- Strict SwiftFormat and SwiftLint: passed

A subsequent redundant full-suite push-preflight rerun hit host-level FSEvent stream exhaustion (`streamStartFailed`) across unrelated watcher-backed watchdog/search fixtures, even after stopping the CE debug app. The same Swift tree had already completed the full suite successfully; the isolated transient Context Builder assertion also passed immediately when rerun. Hosted exact-head CI remains the final clean-environment gate.
