### PR TITLE
Integrate PR #146 worktree-aware Context Builder on main

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/Services/AgentWorkspaceLookupContextResolver.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Services/AgentWorkspaceLookupContextResolver.swift
@@ -35,6 +35,34 @@ struct AgentWorkspaceLookupContextIdentity: Hashable {
 }
 
 enum AgentWorkspaceLookupContextResolver {
+    static func requiredLookupContext(
+        source: AgentWorkspaceLookupContextSource,
+        store: WorkspaceFileContextStore
+    ) async throws -> WorkspaceLookupContext {
+        guard let sessionID = source.activeAgentSessionID,
+              !source.worktreeBindings.isEmpty
+        else {
+            return .visibleWorkspace
+        }
+
+        try AgentWorktreeRuntimeWorkspaceResolver.validateBindingsAvailable(source.worktreeBindings)
+        guard let projection = await WorkspaceRootBindingProjectionMaterializer(store: store).materialize(
+            sessionID: sessionID,
+            bindings: source.worktreeBindings
+        ),
+            !projection.isEmpty
+        else {
+            throw AgentWorkspaceLookupContextResolutionError.unavailableProjection
+        }
+
+        switch await store.rootScopeAvailability(projection.lookupRootScope) {
+        case .available:
+            return WorkspaceLookupContext(rootScope: projection.lookupRootScope, bindingProjection: projection)
+        case .sessionWorktreeUnavailable:
+            throw AgentWorkspaceLookupContextResolutionError.unavailableProjection
+        }
+    }
+
     static func lookupContext(
         source: AgentWorkspaceLookupContextSource,
         store: WorkspaceFileContextStore
@@ -50,5 +78,13 @@ enum AgentWorkspaceLookupContextResolver {
             return WorkspaceLookupContext.visibleWorkspace
         }
         return WorkspaceLookupContext(rootScope: projection.lookupRootScope, bindingProjection: projection)
+    }
+}
+
+enum AgentWorkspaceLookupContextResolutionError: LocalizedError {
+    case unavailableProjection
+
+    var errorDescription: String? {
+        "The Agent session worktree projection is unavailable. The operation stopped rather than falling back to the canonical checkout."
     }
 }

--- a/Sources/RepoPrompt/Features/AgentMode/Services/AgentWorkspaceLookupContextResolver.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Services/AgentWorkspaceLookupContextResolver.swift
@@ -1,31 +1,78 @@
 import Foundation
 
+enum AgentSessionWorktreeBindingState: Equatable {
+    case notApplicable
+    case hydrated([AgentSessionWorktreeBinding])
+    case unhydrated
+    case unavailable
+
+    var bindings: [AgentSessionWorktreeBinding]? {
+        guard case let .hydrated(bindings) = self else { return nil }
+        return bindings
+    }
+}
+
 struct AgentWorkspaceLookupContextSource: Equatable {
     let activeAgentSessionID: UUID?
-    let worktreeBindings: [AgentSessionWorktreeBinding]
+    let worktreeBindingState: AgentSessionWorktreeBindingState
+
+    init(
+        activeAgentSessionID: UUID?,
+        worktreeBindingState: AgentSessionWorktreeBindingState
+    ) {
+        self.activeAgentSessionID = activeAgentSessionID
+        self.worktreeBindingState = worktreeBindingState
+    }
+
+    init(
+        activeAgentSessionID: UUID?,
+        worktreeBindings: [AgentSessionWorktreeBinding]
+    ) {
+        self.init(
+            activeAgentSessionID: activeAgentSessionID,
+            worktreeBindingState: activeAgentSessionID == nil ? .notApplicable : .hydrated(worktreeBindings)
+        )
+    }
+
+    var worktreeBindings: [AgentSessionWorktreeBinding] {
+        worktreeBindingState.bindings ?? []
+    }
 
     var identity: AgentWorkspaceLookupContextIdentity {
         AgentWorkspaceLookupContextIdentity(
             activeAgentSessionID: activeAgentSessionID,
-            worktreeBindingFingerprint: Self.worktreeBindingFingerprint(worktreeBindings)
+            worktreeBindingFingerprint: Self.worktreeBindingFingerprint(worktreeBindingState)
         )
     }
 
     static func worktreeBindingFingerprint(_ bindings: [AgentSessionWorktreeBinding]) -> String {
-        bindings
-            .map { binding in
-                [
-                    binding.repositoryID,
-                    binding.repoKey,
-                    StandardizedPath.absolute((binding.logicalRootPath as NSString).expandingTildeInPath),
-                    binding.worktreeID,
-                    StandardizedPath.absolute((binding.worktreeRootPath as NSString).expandingTildeInPath),
-                    binding.branch ?? "",
-                    binding.head ?? ""
-                ].joined(separator: "\u{1F}")
-            }
-            .sorted()
-            .joined(separator: "\u{1E}")
+        worktreeBindingFingerprint(.hydrated(bindings))
+    }
+
+    static func worktreeBindingFingerprint(_ state: AgentSessionWorktreeBindingState) -> String {
+        switch state {
+        case .notApplicable:
+            "not-applicable"
+        case .unhydrated:
+            "unhydrated"
+        case .unavailable:
+            "unavailable"
+        case let .hydrated(bindings):
+            bindings
+                .map { binding in
+                    [
+                        binding.repositoryID,
+                        binding.repoKey,
+                        StandardizedPath.absolute((binding.logicalRootPath as NSString).expandingTildeInPath),
+                        binding.worktreeID,
+                        StandardizedPath.absolute((binding.worktreeRootPath as NSString).expandingTildeInPath),
+                        binding.branch ?? "",
+                        binding.head ?? ""
+                    ].joined(separator: "\u{1F}")
+                }
+                .sorted()
+                .joined(separator: "\u{1E}")
+        }
     }
 }
 
@@ -39,16 +86,34 @@ enum AgentWorkspaceLookupContextResolver {
         source: AgentWorkspaceLookupContextSource,
         store: WorkspaceFileContextStore
     ) async throws -> WorkspaceLookupContext {
-        guard let sessionID = source.activeAgentSessionID,
-              !source.worktreeBindings.isEmpty
-        else {
+        guard let sessionID = source.activeAgentSessionID else {
+            return .visibleWorkspace
+        }
+        guard case let .hydrated(bindings) = source.worktreeBindingState else {
+            throw AgentWorkspaceLookupContextResolutionError.unknownBindingState
+        }
+        guard !bindings.isEmpty else {
             return .visibleWorkspace
         }
 
-        try AgentWorktreeRuntimeWorkspaceResolver.validateBindingsAvailable(source.worktreeBindings)
+        let visibleRootPaths = await Set(store.rootRefs(scope: .visibleWorkspace).map(\.standardizedFullPath))
+        let logicalRootPaths = Set(bindings.compactMap {
+            AgentWorktreeRuntimeWorkspaceResolver.standardizedWorkspacePath($0.logicalRootPath)
+        })
+        guard logicalRootPaths.count == bindings.count,
+              logicalRootPaths.isSubset(of: visibleRootPaths)
+        else {
+            throw AgentWorkspaceLookupContextResolutionError.unavailableProjection
+        }
+
+        do {
+            try AgentWorktreeRuntimeWorkspaceResolver.validateBindingsAvailable(bindings)
+        } catch {
+            throw AgentWorkspaceLookupContextResolutionError.unavailableProjection
+        }
         guard let projection = await WorkspaceRootBindingProjectionMaterializer(store: store).materialize(
             sessionID: sessionID,
-            bindings: source.worktreeBindings
+            bindings: bindings
         ),
             !projection.isEmpty
         else {
@@ -63,15 +128,31 @@ enum AgentWorkspaceLookupContextResolver {
         }
     }
 
+    static func authoritativeLookupContextOrFailClosed(
+        source: AgentWorkspaceLookupContextSource,
+        store: WorkspaceFileContextStore
+    ) async -> WorkspaceLookupContext {
+        do {
+            return try await requiredLookupContext(source: source, store: store)
+        } catch {
+            return WorkspaceLookupContext(
+                rootScope: .sessionBoundWorkspace(canonicalRootPaths: [], physicalRootPaths: []),
+                bindingProjection: nil
+            )
+        }
+    }
+
+    /// Permissive resolution is reserved for non-authoritative UI consumers.
     static func lookupContext(
         source: AgentWorkspaceLookupContextSource,
         store: WorkspaceFileContextStore
     ) async -> WorkspaceLookupContext {
         guard let sessionID = source.activeAgentSessionID,
-              !source.worktreeBindings.isEmpty,
+              case let .hydrated(bindings) = source.worktreeBindingState,
+              !bindings.isEmpty,
               let projection = await WorkspaceRootBindingProjectionMaterializer(store: store).materialize(
                   sessionID: sessionID,
-                  bindings: source.worktreeBindings
+                  bindings: bindings
               ),
               !projection.isEmpty
         else {
@@ -83,8 +164,14 @@ enum AgentWorkspaceLookupContextResolver {
 
 enum AgentWorkspaceLookupContextResolutionError: LocalizedError {
     case unavailableProjection
+    case unknownBindingState
 
     var errorDescription: String? {
-        "The Agent session worktree projection is unavailable. The operation stopped rather than falling back to the canonical checkout."
+        switch self {
+        case .unavailableProjection:
+            "The Agent session worktree projection is unavailable. The operation stopped rather than falling back to the canonical checkout."
+        case .unknownBindingState:
+            "The Agent session worktree bindings are not hydrated or are unavailable. The operation stopped rather than falling back to the canonical checkout."
+        }
     }
 }

--- a/Sources/RepoPrompt/Features/AgentMode/Services/AgentWorktreeRuntimeWorkspaceResolver.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Services/AgentWorktreeRuntimeWorkspaceResolver.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+enum AgentWorktreeRuntimeWorkspaceResolver {
+    static func primaryExecutionBinding(
+        in bindings: [AgentSessionWorktreeBinding],
+        fallbackWorkspacePath: String?
+    ) -> AgentSessionWorktreeBinding? {
+        let primaryWorkspacePath = standardizedWorkspacePath(fallbackWorkspacePath)
+        return primaryWorkspacePath.flatMap { primaryPath in
+            bindings.first { binding in
+                standardizedWorkspacePath(binding.logicalRootPath) == primaryPath
+            }
+        } ?? (primaryWorkspacePath == nil && bindings.count == 1 ? bindings[0] : nil)
+    }
+
+    static func effectiveWorkspacePath(
+        bindings: [AgentSessionWorktreeBinding],
+        fallbackWorkspacePath: String?
+    ) throws -> String? {
+        let primaryWorkspacePath = standardizedWorkspacePath(fallbackWorkspacePath)
+        let binding = primaryExecutionBinding(
+            in: bindings,
+            fallbackWorkspacePath: fallbackWorkspacePath
+        )
+
+        guard let binding else {
+            return primaryWorkspacePath
+        }
+        let worktreePath = standardizedWorkspacePath(binding.worktreeRootPath)
+        guard let worktreePath else {
+            throw AgentWorktreeRuntimeWorkspaceError(binding: binding)
+        }
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: worktreePath, isDirectory: &isDirectory),
+              isDirectory.boolValue
+        else {
+            throw AgentWorktreeRuntimeWorkspaceError(binding: binding)
+        }
+        return worktreePath
+    }
+
+    static func validateBindingsAvailable(_ bindings: [AgentSessionWorktreeBinding]) throws {
+        for binding in bindings {
+            let worktreePath = standardizedWorkspacePath(binding.worktreeRootPath)
+            guard let worktreePath else {
+                throw AgentWorktreeRuntimeWorkspaceError(binding: binding)
+            }
+            var isDirectory: ObjCBool = false
+            guard FileManager.default.fileExists(atPath: worktreePath, isDirectory: &isDirectory),
+                  isDirectory.boolValue
+            else {
+                throw AgentWorktreeRuntimeWorkspaceError(binding: binding)
+            }
+        }
+    }
+
+    static func standardizedWorkspacePath(_ path: String?) -> String? {
+        guard let trimmed = path?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty
+        else {
+            return nil
+        }
+        return URL(fileURLWithPath: NSString(string: trimmed).expandingTildeInPath).standardizedFileURL.path
+    }
+}

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -1734,42 +1734,24 @@ final class AgentModeViewModel: ObservableObject {
         in bindings: [AgentSessionWorktreeBinding],
         fallbackWorkspacePath: String?
     ) -> AgentSessionWorktreeBinding? {
-        let primaryWorkspacePath = standardizedWorkspacePath(fallbackWorkspacePath)
-        return primaryWorkspacePath.flatMap { primaryPath in
-            bindings.first { binding in
-                standardizedWorkspacePath(binding.logicalRootPath) == primaryPath
-            }
-        } ?? (primaryWorkspacePath == nil && bindings.count == 1 ? bindings[0] : nil)
+        AgentWorktreeRuntimeWorkspaceResolver.primaryExecutionBinding(
+            in: bindings,
+            fallbackWorkspacePath: fallbackWorkspacePath
+        )
     }
 
     private static func effectiveWorkspacePath(
         for session: TabSession,
         fallbackWorkspacePath: String?
     ) throws -> String? {
-        let primaryWorkspacePath = standardizedWorkspacePath(fallbackWorkspacePath)
-        let binding = primaryExecutionBinding(in: session.worktreeBindings, fallbackWorkspacePath: fallbackWorkspacePath)
-
-        guard let binding else {
-            return primaryWorkspacePath
-        }
-        let worktreePath = standardizedWorkspacePath(binding.worktreeRootPath)
-        guard let worktreePath else {
-            throw AgentWorktreeRuntimeWorkspaceError(binding: binding)
-        }
-        var isDirectory: ObjCBool = false
-        guard FileManager.default.fileExists(atPath: worktreePath, isDirectory: &isDirectory), isDirectory.boolValue else {
-            throw AgentWorktreeRuntimeWorkspaceError(binding: binding)
-        }
-        return worktreePath
+        try AgentWorktreeRuntimeWorkspaceResolver.effectiveWorkspacePath(
+            bindings: session.worktreeBindings,
+            fallbackWorkspacePath: fallbackWorkspacePath
+        )
     }
 
     private static func standardizedWorkspacePath(_ path: String?) -> String? {
-        guard let trimmed = path?.trimmingCharacters(in: .whitespacesAndNewlines),
-              !trimmed.isEmpty
-        else {
-            return nil
-        }
-        return URL(fileURLWithPath: NSString(string: trimmed).expandingTildeInPath).standardizedFileURL.path
+        AgentWorktreeRuntimeWorkspaceResolver.standardizedWorkspacePath(path)
     }
 
     private func currentWorkspacePath() -> String? {
@@ -5262,6 +5244,14 @@ final class AgentModeViewModel: ObservableObject {
         else {
             throw ExecutionLocationTransitionError.stale
         }
+        try await materializeWorktreeBindingsForTransition(desiredBindings, sessionID: sessionID)
+        guard sessions[session.tabID] === session,
+              session.activeAgentSessionID == sessionID,
+              session.worktreeBindings == previousBindings,
+              !session.runState.isActive
+        else {
+            throw ExecutionLocationTransitionError.stale
+        }
         if !changedDuringActiveRun {
             await stageResumeRecoveryHandoffIfNeeded(for: session)
         }
@@ -5279,6 +5269,35 @@ final class AgentModeViewModel: ObservableObject {
     private func executionDestinationPath(in bindings: [AgentSessionWorktreeBinding]) -> String? {
         let binding = Self.primaryExecutionBinding(in: bindings, fallbackWorkspacePath: workspacePathProvider())
         return Self.standardizedWorkspacePath(binding?.worktreeRootPath) ?? Self.standardizedWorkspacePath(workspacePathProvider())
+    }
+
+    private func materializeWorktreeBindingsForTransition(
+        _ bindings: [AgentSessionWorktreeBinding],
+        sessionID: UUID
+    ) async throws {
+        guard !bindings.isEmpty else { return }
+        guard let promptManager else {
+            throw ExecutionLocationTransitionError.unavailable("The selected worktree roots could not be prepared for this thread.")
+        }
+        guard let projection = await WorkspaceRootBindingProjectionMaterializer(
+            store: promptManager.workspaceFileContextStore
+        ).materialize(sessionID: sessionID, bindings: bindings), !projection.isEmpty else {
+            throw ExecutionLocationTransitionError.unavailable("The selected worktree roots could not be prepared for this thread.")
+        }
+
+        let availability = await promptManager.workspaceFileContextStore.rootScopeAvailability(projection.lookupRootScope)
+        guard case .available = availability else {
+            let missingPaths: [String] = switch availability {
+            case .available:
+                []
+            case let .sessionWorktreeUnavailable(paths):
+                paths
+            }
+            let suffix = missingPaths.isEmpty ? "" : ": \(missingPaths.joined(separator: ", "))"
+            throw ExecutionLocationTransitionError.unavailable(
+                "The selected worktree roots are unavailable\(suffix). The thread was not switched to the canonical checkout."
+            )
+        }
     }
 
     private func executionLocationContext() async throws -> ExecutionLocationContext {

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -1426,8 +1426,8 @@ final class AgentModeViewModel: ObservableObject {
         claudeCoordinator.attach(viewModel: self)
         runInteractionStateObserver = codexCoordinator
         mcpServer.registerAgentWorktreeBindingsProvider { [weak self] sessionID, tabID in
-            guard let self else { return [] }
-            return worktreeBindings(forAgentSessionID: sessionID, tabID: tabID)
+            guard let self else { return .unavailable }
+            return worktreeBindingState(forAgentSessionID: sessionID, tabID: tabID)
         }
 
         refreshAvailableAgents()
@@ -1610,8 +1610,8 @@ final class AgentModeViewModel: ObservableObject {
             claudeCoordinator.attach(viewModel: self)
             runInteractionStateObserver = codexCoordinator
             testMCPServer?.registerAgentWorktreeBindingsProvider { [weak self] sessionID, tabID in
-                guard let self else { return [] }
-                return worktreeBindings(forAgentSessionID: sessionID, tabID: tabID)
+                guard let self else { return .unavailable }
+                return worktreeBindingState(forAgentSessionID: sessionID, tabID: tabID)
             }
             refreshAvailableAgents()
             restoreLastUsedAgentSelectionIfNeeded()
@@ -5034,14 +5034,30 @@ final class AgentModeViewModel: ObservableObject {
         return true
     }
 
-    func worktreeBindings(forAgentSessionID sessionID: UUID, tabID: UUID? = nil) -> [AgentSessionWorktreeBinding] {
-        if let live = try? authoritativeLiveSession(for: sessionID) {
-            return live.worktreeBindings
+    func worktreeBindingState(
+        forAgentSessionID sessionID: UUID,
+        tabID: UUID? = nil
+    ) -> AgentSessionWorktreeBindingState {
+        do {
+            if let live = try authoritativeLiveSession(for: sessionID) {
+                return live.hasLoadedPersistedState ? .hydrated(live.worktreeBindings) : .unhydrated
+            }
+        } catch {
+            return .unavailable
         }
         if let tabID, let live = sessions[tabID], live.activeAgentSessionID == sessionID {
-            return live.worktreeBindings
+            return live.hasLoadedPersistedState ? .hydrated(live.worktreeBindings) : .unhydrated
         }
-        return []
+        switch persistentBindingResolution(for: sessionID) {
+        case .unique:
+            return .unhydrated
+        case .notFound, .ambiguous:
+            return .unavailable
+        }
+    }
+
+    func worktreeBindings(forAgentSessionID sessionID: UUID, tabID: UUID? = nil) -> [AgentSessionWorktreeBinding] {
+        worktreeBindingState(forAgentSessionID: sessionID, tabID: tabID).bindings ?? []
     }
 
     @discardableResult
@@ -5209,12 +5225,39 @@ final class AgentModeViewModel: ObservableObject {
             throw MCPError.invalidParams("The requested agent session is not currently available.")
         }
         let previousBindings = session.worktreeBindings
-        let previousDestination = executionDestinationPath(in: previousBindings)
-        let nextDestination = executionDestinationPath(in: desiredBindings)
-        guard previousDestination != nextDestination else {
+        guard previousBindings != desiredBindings else { return previousBindings }
+        let previousDestination = executionDestinationIdentity(in: previousBindings)
+        let nextDestination = executionDestinationIdentity(in: desiredBindings)
+        let changedDuringActiveRun = session.runState.isActive
+
+        if changedDuringActiveRun, previousDestination != nextDestination {
+            switch intent {
+            case .userExecutionLocationChange(confirmation: .activeRunStop):
+                break
+            case .userExecutionLocationChange:
+                throw ExecutionLocationTransitionError.confirmationRequired(.activeRunStop)
+            case .externalManagement:
+                throw MCPError.invalidParams(
+                    "Stop the active Agent run before changing its execution worktree. The in-flight prompt will not be migrated or replayed automatically."
+                )
+            case .initialSend:
+                throw MCPError.invalidParams("A running Agent thread cannot apply an initial execution location.")
+            }
+        }
+
+        try await materializeWorktreeBindingsForTransition(desiredBindings, sessionID: sessionID)
+        guard sessions[session.tabID] === session,
+              session.activeAgentSessionID == sessionID,
+              session.worktreeBindings == previousBindings,
+              session.runState.isActive == changedDuringActiveRun
+        else {
+            throw ExecutionLocationTransitionError.stale
+        }
+
+        if previousDestination == nextDestination {
             return try replaceWorktreeBindings(desiredBindings, forSessionID: sessionID)
         }
-        let changedDuringActiveRun = session.runState.isActive
+
         if changedDuringActiveRun {
             switch intent {
             case .userExecutionLocationChange(confirmation: .activeRunStop):
@@ -5227,24 +5270,10 @@ final class AgentModeViewModel: ObservableObject {
                     intent: .executionLocationChange,
                     completion: .terminalPublished
                 )
-            case .userExecutionLocationChange:
-                throw ExecutionLocationTransitionError.confirmationRequired(.activeRunStop)
-            case .externalManagement:
-                throw MCPError.invalidParams(
-                    "Stop the active Agent run before changing its execution worktree. The in-flight prompt will not be migrated or replayed automatically."
-                )
-            case .initialSend:
-                throw MCPError.invalidParams("A running Agent thread cannot apply an initial execution location.")
+            case .userExecutionLocationChange, .externalManagement, .initialSend:
+                throw ExecutionLocationTransitionError.stale
             }
         }
-        guard sessions[session.tabID] === session,
-              session.activeAgentSessionID == sessionID,
-              session.worktreeBindings == previousBindings,
-              !session.runState.isActive
-        else {
-            throw ExecutionLocationTransitionError.stale
-        }
-        try await materializeWorktreeBindingsForTransition(desiredBindings, sessionID: sessionID)
         guard sessions[session.tabID] === session,
               session.activeAgentSessionID == sessionID,
               session.worktreeBindings == previousBindings,
@@ -5266,9 +5295,20 @@ final class AgentModeViewModel: ObservableObject {
         return try replaceWorktreeBindings(desiredBindings, forSessionID: sessionID)
     }
 
-    private func executionDestinationPath(in bindings: [AgentSessionWorktreeBinding]) -> String? {
+    private struct ExecutionDestinationIdentity: Equatable {
+        let repositoryID: String?
+        let worktreeID: String?
+        let path: String?
+    }
+
+    private func executionDestinationIdentity(in bindings: [AgentSessionWorktreeBinding]) -> ExecutionDestinationIdentity {
         let binding = Self.primaryExecutionBinding(in: bindings, fallbackWorkspacePath: workspacePathProvider())
-        return Self.standardizedWorkspacePath(binding?.worktreeRootPath) ?? Self.standardizedWorkspacePath(workspacePathProvider())
+        return ExecutionDestinationIdentity(
+            repositoryID: binding?.repositoryID,
+            worktreeID: binding?.worktreeID,
+            path: Self.standardizedWorkspacePath(binding?.worktreeRootPath)
+                ?? Self.standardizedWorkspacePath(workspacePathProvider())
+        )
     }
 
     private func materializeWorktreeBindingsForTransition(

--- a/Sources/RepoPrompt/Features/CodeMap/CodeScanActor.swift
+++ b/Sources/RepoPrompt/Features/CodeMap/CodeScanActor.swift
@@ -239,6 +239,7 @@ actor CodeScanActor {
     /// -------------------------------------
     enum ScanBatchPurpose {
         case initialRootLoad
+        case selfHealing
         case adhoc
     }
 
@@ -879,8 +880,8 @@ actor CodeScanActor {
         for request in requests {
             let rootKey = canonicalRoot(request.rootFolderPath)
 
-            // Skip if we have a known date >= this request (except during initial root load).
-            if purpose != .initialRootLoad,
+            // Ad hoc scans may skip unchanged files; initial loads and self-healing must requeue them.
+            if purpose == .adhoc,
                let knownDate = latestFileModDates[request.fileID],
                knownDate >= request.modificationDate
             {

--- a/Sources/RepoPrompt/Features/CodeMap/CodeScanActor.swift
+++ b/Sources/RepoPrompt/Features/CodeMap/CodeScanActor.swift
@@ -125,6 +125,11 @@ private actor CodeScanAsyncLimiter {
 }
 
 actor CodeScanActor {
+    struct SelfHealingScanRequestResult {
+        let submittedFileIDs: Set<UUID>
+        let alreadyScheduledFileIDs: Set<UUID>
+    }
+
     /// Conservative default scan concurrency: scale modestly with CPU, capped to avoid parser/generator memory spikes.
     private static var defaultMaxConcurrentScans: Int {
         let cpu = ProcessInfo.processInfo.activeProcessorCount
@@ -153,6 +158,10 @@ actor CodeScanActor {
 
     /// Tracks all active scanning tasks so we can cancel them if needed
     private var scanTasks = Set<ScanningTask>()
+
+    #if DEBUG
+        private var scanWillStartHandlerForTesting: (@Sendable (UUID) async -> Void)?
+    #endif
 
     /// Tracks how many scans remain (queued + active)
     private var outstandingScans = 0
@@ -476,6 +485,11 @@ actor CodeScanActor {
     private func rootHasQueuedOrActiveWork(forRootKey rootKey: String) -> Bool {
         queue.contains { canonicalRoot($0.rootFolderPath) == rootKey } ||
             scanTasks.contains { canonicalRoot($0.request.rootFolderPath) == rootKey }
+    }
+
+    private func hasQueuedOrActiveScan(for fileID: UUID) -> Bool {
+        queue.contains { $0.fileID == fileID } ||
+            scanTasks.contains { $0.request.fileID == fileID }
     }
 
     private func evictCleanIdleRootCachesIfNeeded() {
@@ -821,12 +835,13 @@ actor CodeScanActor {
         scheduleNextScan()
     }
 
+    @discardableResult
     func requestScans(
         _ requests: [ScanRequest],
         purpose: ScanBatchPurpose = .adhoc,
         rootFolderPaths: [String] = [],
         purgeCachesOnEmptyInitialRequests: Bool = false
-    ) async {
+    ) async -> Set<UUID> {
         let ingestStart = CodeMapPerfRuntime.sharedPipelineStats.map { _ in CodeMapPerfRuntime.currentTime() }
         defer {
             if let ingestStart {
@@ -836,7 +851,7 @@ actor CodeScanActor {
         let shouldHandleEmptyInitial = purpose == .initialRootLoad &&
             !rootFolderPaths.isEmpty &&
             purgeCachesOnEmptyInitialRequests
-        if requests.isEmpty, !shouldHandleEmptyInitial { return }
+        if requests.isEmpty, !shouldHandleEmptyInitial { return [] }
 
         let rootsFromRequests = Set(requests.map { canonicalRoot($0.rootFolderPath) })
         let rootsFromArgs = Set(rootFolderPaths.map { canonicalRoot($0) })
@@ -857,7 +872,7 @@ actor CodeScanActor {
                     startMS: cacheRebuildStartMS
                 )
             #endif
-            guard rootGenerationsStillMatch(expectedRootGenerations) else { return }
+            guard rootGenerationsStillMatch(expectedRootGenerations) else { return [] }
         } else {
             initialRootLookupByRoot = [:]
         }
@@ -872,23 +887,31 @@ actor CodeScanActor {
                 clearRebuildLookups(forRoots: rootsForRebuild)
                 if queue.isEmpty, activeScans == 0 { performCacheCleanup() }
             }
-            return
+            return []
         }
 
         var requestsToQueue = [ScanRequest]()
+        var seenSelfHealingFileIDs = Set<UUID>()
 
         for request in requests {
             let rootKey = canonicalRoot(request.rootFolderPath)
 
-            // Ad hoc scans may skip unchanged files; initial loads and self-healing must requeue them.
-            if purpose == .adhoc,
-               let knownDate = latestFileModDates[request.fileID],
-               knownDate >= request.modificationDate
-            {
-                continue
+            // Self-healing never replaces queued or active work: it only submits genuinely idle files.
+            if purpose == .selfHealing {
+                guard seenSelfHealingFileIDs.insert(request.fileID).inserted,
+                      !hasQueuedOrActiveScan(for: request.fileID)
+                else { continue }
+            } else {
+                // Ad hoc scans may skip unchanged files; initial loads must requeue them.
+                if purpose == .adhoc,
+                   let knownDate = latestFileModDates[request.fileID],
+                   knownDate >= request.modificationDate
+                {
+                    continue
+                }
+                removeQueuedRequest(for: request.fileID)
             }
 
-            removeQueuedRequest(for: request.fileID)
             latestFileModDates[request.fileID] = request.modificationDate
             trackFileID(request.fileID, forRootKey: rootKey)
             requestsToQueue.append(request)
@@ -906,8 +929,11 @@ actor CodeScanActor {
             } else if queue.isEmpty, activeScans == 0 {
                 evictCleanIdleRootCachesIfNeeded()
             }
-            return
+            return []
         }
+
+        let submittedFileIDs = Set(requestsToQueue.map(\.fileID))
+        var droppedFileIDs = Set<UUID>()
 
         // Determine how many of these requests are for new files.
         let newFilesCount = requestsToQueue.count(where: { !acceptedAPIFileIDs.contains($0.fileID) })
@@ -934,6 +960,7 @@ actor CodeScanActor {
             let expectedGeneration = expectedRootGenerations[rootKey]
             guard rootGenerationMatches(rootKey: rootKey, expected: expectedGeneration) else {
                 removeTrackingForDroppedRequest(request)
+                droppedFileIDs.insert(request.fileID)
                 droppedRequests += 1
                 continue
             }
@@ -950,6 +977,7 @@ actor CodeScanActor {
                 finalQueue.append(request)
             case .staleRoot:
                 removeTrackingForDroppedRequest(request)
+                droppedFileIDs.insert(request.fileID)
                 droppedRequests += 1
             }
         }
@@ -959,6 +987,7 @@ actor CodeScanActor {
             let shouldQueue = rootGenerationMatches(rootKey: rootKey, expected: expectedRootGenerations[rootKey])
             if !shouldQueue {
                 removeTrackingForDroppedRequest(request)
+                droppedFileIDs.insert(request.fileID)
             }
             return shouldQueue
         }
@@ -1020,6 +1049,24 @@ actor CodeScanActor {
         } else if queueableRequests.isEmpty, queue.isEmpty, activeScans == 0 {
             evictCleanIdleRootCachesIfNeeded()
         }
+        return submittedFileIDs.subtracting(droppedFileIDs)
+    }
+
+    func requestSelfHealingScans(
+        _ requests: [ScanRequest],
+        rootFolderPaths: [String] = []
+    ) async -> SelfHealingScanRequestResult {
+        let requestedFileIDs = Set(requests.map(\.fileID))
+        let alreadyScheduledFileIDs = Set(requestedFileIDs.filter { hasQueuedOrActiveScan(for: $0) })
+        let submittedFileIDs = await requestScans(
+            requests,
+            purpose: .selfHealing,
+            rootFolderPaths: rootFolderPaths
+        )
+        return SelfHealingScanRequestResult(
+            submittedFileIDs: submittedFileIDs,
+            alreadyScheduledFileIDs: alreadyScheduledFileIDs
+        )
     }
 
     // -------------------------------------------------------
@@ -1068,9 +1115,15 @@ actor CodeScanActor {
 
             let uniqueTaskID = UUID()
             let treeSitterParseLimiter = treeSitterParseLimiter
+            #if DEBUG
+                let scanWillStartHandlerForTesting = scanWillStartHandlerForTesting
+            #endif
             let scanTask = Task<Void, Never> { [request, treeSitterParseLimiter] in
                 var fileAPI: FileAPI?
                 do {
+                    #if DEBUG
+                        await scanWillStartHandlerForTesting?(request.fileID)
+                    #endif
                     try Task.checkCancellation()
                     let parseStart = CodeMapPerfRuntime.sharedPipelineStats.map { _ in CodeMapPerfRuntime.currentTime() }
                     let namedRanges = try await treeSitterParseLimiter.withPermit {
@@ -1475,6 +1528,12 @@ actor CodeScanActor {
                 resultBatchBufferFileAPICount: resultBatchBufferFileAPICount,
                 actorRetainedFileAPILikeEntryCount: actorRetainedFileAPILikeEntryCount
             )
+        }
+
+        func setScanWillStartHandlerForTesting(
+            _ handler: (@Sendable (UUID) async -> Void)?
+        ) {
+            scanWillStartHandlerForTesting = handler
         }
 
         func scanStateForTesting() -> (

--- a/Sources/RepoPrompt/Features/ContextBuilder/Services/ContextBuilderWorkspaceContext.swift
+++ b/Sources/RepoPrompt/Features/ContextBuilder/Services/ContextBuilderWorkspaceContext.swift
@@ -1,0 +1,167 @@
+import Foundation
+
+struct ContextBuilderWorkspaceContext {
+    let parentAgentSessionID: UUID
+    let parentAgentRunID: UUID
+    let tabID: UUID
+    let windowID: Int
+    let workspaceID: UUID
+    let frozenTabContext: MCPServerViewModel.TabContextSnapshot
+    let worktreeBindings: [AgentSessionWorktreeBinding]
+    let lookupContext: WorkspaceLookupContext
+    let providerWorkspacePath: String
+
+    static func resolve(
+        from snapshot: MCPServerViewModel.TabContextSnapshot,
+        workspaceRepoPaths: [String],
+        store: WorkspaceFileContextStore
+    ) async throws -> ContextBuilderWorkspaceContext {
+        guard let parentAgentSessionID = snapshot.activeAgentSessionID else {
+            throw ContextBuilderWorkspaceContextError.missingParentAgentSession
+        }
+        guard let parentAgentRunID = snapshot.runID else {
+            throw ContextBuilderWorkspaceContextError.missingParentAgentRun
+        }
+        guard let workspaceID = snapshot.workspaceID else {
+            throw ContextBuilderWorkspaceContextError.missingWorkspace
+        }
+        guard let fallbackWorkspacePath = workspaceRepoPaths.first else {
+            throw ContextBuilderWorkspaceContextError.missingWorkspaceRoot
+        }
+
+        let bindings = snapshot.worktreeBindings
+        try AgentWorktreeRuntimeWorkspaceResolver.validateBindingsAvailable(bindings)
+
+        let lookupContext: WorkspaceLookupContext
+        if bindings.isEmpty {
+            let requestedRootPaths = Set(workspaceRepoPaths.compactMap {
+                AgentWorktreeRuntimeWorkspaceResolver.standardizedWorkspacePath($0)
+            })
+            let primaryRoots = await store.roots().filter { $0.kind == .primaryWorkspace }
+            let loadedPrimaryRootPaths = Set(primaryRoots.map(\.standardizedFullPath))
+            guard !requestedRootPaths.isEmpty,
+                  requestedRootPaths.isSubset(of: loadedPrimaryRootPaths)
+            else {
+                throw ContextBuilderWorkspaceContextError.unavailableWorkspaceProjection
+            }
+            lookupContext = WorkspaceLookupContext(
+                rootScope: .sessionBoundWorkspace(
+                    logicalRootPaths: loadedPrimaryRootPaths.subtracting(requestedRootPaths),
+                    physicalRootPaths: []
+                ),
+                bindingProjection: nil
+            )
+        } else {
+            guard let projection = await WorkspaceRootBindingProjectionMaterializer(store: store).materialize(
+                sessionID: parentAgentSessionID,
+                bindings: bindings
+            ),
+                !projection.isEmpty
+            else {
+                throw ContextBuilderWorkspaceContextError.unavailableWorktreeProjection
+            }
+
+            let requestedPhysicalRootPaths = Set(bindings.compactMap {
+                AgentWorktreeRuntimeWorkspaceResolver.standardizedWorkspacePath($0.worktreeRootPath)
+            })
+            guard requestedPhysicalRootPaths.isSubset(of: projection.physicalRootPaths) else {
+                throw ContextBuilderWorkspaceContextError.unavailableWorktreeProjection
+            }
+
+            let loadedRoots = await store.rootRefs(scope: projection.lookupRootScope)
+            let loadedPaths = Set(loadedRoots.compactMap { root in
+                AgentWorktreeRuntimeWorkspaceResolver.standardizedWorkspacePath(root.standardizedFullPath)
+            })
+            guard projection.physicalRootRefs.allSatisfy({ root in
+                guard let path = AgentWorktreeRuntimeWorkspaceResolver.standardizedWorkspacePath(root.standardizedFullPath) else {
+                    return false
+                }
+                return loadedPaths.contains(path)
+            }) else {
+                throw ContextBuilderWorkspaceContextError.unavailableWorktreeProjection
+            }
+            lookupContext = WorkspaceLookupContext(
+                rootScope: projection.lookupRootScope,
+                bindingProjection: projection
+            )
+        }
+
+        guard let providerWorkspacePath = try AgentWorktreeRuntimeWorkspaceResolver.effectiveWorkspacePath(
+            bindings: bindings,
+            fallbackWorkspacePath: fallbackWorkspacePath
+        ) else {
+            throw ContextBuilderWorkspaceContextError.missingWorkspaceRoot
+        }
+
+        let context = ContextBuilderWorkspaceContext(
+            parentAgentSessionID: parentAgentSessionID,
+            parentAgentRunID: parentAgentRunID,
+            tabID: snapshot.tabID,
+            windowID: snapshot.windowID,
+            workspaceID: workspaceID,
+            frozenTabContext: snapshot,
+            worktreeBindings: bindings,
+            lookupContext: lookupContext,
+            providerWorkspacePath: providerWorkspacePath
+        )
+        try context.validateAvailability()
+        return context
+    }
+
+    func validateAvailability() throws {
+        try AgentWorktreeRuntimeWorkspaceResolver.validateBindingsAvailable(worktreeBindings)
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: providerWorkspacePath, isDirectory: &isDirectory),
+              isDirectory.boolValue
+        else {
+            throw ContextBuilderWorkspaceContextError.unavailableProviderWorkspace(providerWorkspacePath)
+        }
+    }
+
+    func nestedDiscoveryTabContext(runID: UUID) -> MCPServerViewModel.TabContextSnapshot {
+        let source = frozenTabContext
+        return MCPServerViewModel.TabContextSnapshot(
+            tabID: source.tabID,
+            windowID: source.windowID,
+            workspaceID: source.workspaceID,
+            promptText: source.promptText,
+            selection: source.selection,
+            selectedMetaPromptIDs: source.selectedMetaPromptIDs,
+            tabName: source.tabName,
+            runID: runID,
+            activeAgentSessionID: parentAgentSessionID,
+            worktreeBindings: worktreeBindings,
+            explicitlyBound: source.explicitlyBound,
+            readFileAutoSelectionGeneration: source.readFileAutoSelectionGeneration
+        )
+    }
+}
+
+enum ContextBuilderWorkspaceContextError: LocalizedError, Equatable {
+    case missingParentAgentSession
+    case missingParentAgentRun
+    case missingWorkspace
+    case missingWorkspaceRoot
+    case unavailableWorkspaceProjection
+    case unavailableWorktreeProjection
+    case unavailableProviderWorkspace(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingParentAgentSession:
+            "context_builder could not freeze the invoking Agent Mode session identity. Retry after Agent Mode routing settles."
+        case .missingParentAgentRun:
+            "context_builder could not freeze the invoking Agent Mode run identity. Retry after Agent Mode routing settles."
+        case .missingWorkspace:
+            "context_builder could not freeze the invoking workspace identity."
+        case .missingWorkspaceRoot:
+            "context_builder requires a project workspace root for the invoking Agent Mode run."
+        case .unavailableWorkspaceProjection:
+            "The invoking Agent Mode workspace roots could not be loaded. Context Builder stopped rather than using the visible workspace."
+        case .unavailableWorktreeProjection:
+            "The invoking Agent Mode worktree bindings could not be loaded. Context Builder stopped rather than falling back to the canonical checkout."
+        case let .unavailableProviderWorkspace(path):
+            "The invoking Agent Mode workspace path is unavailable: \(path). Context Builder stopped rather than falling back to another checkout."
+        }
+    }
+}

--- a/Sources/RepoPrompt/Features/ContextBuilder/Services/ContextBuilderWorkspaceContext.swift
+++ b/Sources/RepoPrompt/Features/ContextBuilder/Services/ContextBuilderWorkspaceContext.swift
@@ -2,14 +2,14 @@ import Foundation
 
 struct ContextBuilderWorkspaceContext {
     let parentAgentSessionID: UUID
-    let parentAgentRunID: UUID
-    let tabID: UUID
-    let windowID: Int
-    let workspaceID: UUID
     let frozenTabContext: MCPServerViewModel.TabContextSnapshot
     let worktreeBindings: [AgentSessionWorktreeBinding]
     let lookupContext: WorkspaceLookupContext
     let providerWorkspacePath: String
+
+    var tabID: UUID {
+        frozenTabContext.tabID
+    }
 
     static func resolve(
         from snapshot: MCPServerViewModel.TabContextSnapshot,
@@ -19,18 +19,19 @@ struct ContextBuilderWorkspaceContext {
         guard let parentAgentSessionID = snapshot.activeAgentSessionID else {
             throw ContextBuilderWorkspaceContextError.missingParentAgentSession
         }
-        guard let parentAgentRunID = snapshot.runID else {
+        guard snapshot.runID != nil else {
             throw ContextBuilderWorkspaceContextError.missingParentAgentRun
         }
-        guard let workspaceID = snapshot.workspaceID else {
+        guard snapshot.workspaceID != nil else {
             throw ContextBuilderWorkspaceContextError.missingWorkspace
         }
         guard let fallbackWorkspacePath = workspaceRepoPaths.first else {
             throw ContextBuilderWorkspaceContextError.missingWorkspaceRoot
         }
 
-        let bindings = snapshot.worktreeBindings
-        try AgentWorktreeRuntimeWorkspaceResolver.validateBindingsAvailable(bindings)
+        guard case let .hydrated(bindings) = snapshot.worktreeBindingState else {
+            throw ContextBuilderWorkspaceContextError.unavailableWorktreeBindingState
+        }
 
         let lookupContext: WorkspaceLookupContext
         if bindings.isEmpty {
@@ -46,44 +47,23 @@ struct ContextBuilderWorkspaceContext {
             }
             lookupContext = WorkspaceLookupContext(
                 rootScope: .sessionBoundWorkspace(
-                    logicalRootPaths: loadedPrimaryRootPaths.subtracting(requestedRootPaths),
+                    canonicalRootPaths: requestedRootPaths,
                     physicalRootPaths: []
                 ),
                 bindingProjection: nil
             )
         } else {
-            guard let projection = await WorkspaceRootBindingProjectionMaterializer(store: store).materialize(
-                sessionID: parentAgentSessionID,
-                bindings: bindings
-            ),
-                !projection.isEmpty
-            else {
+            do {
+                lookupContext = try await AgentWorkspaceLookupContextResolver.requiredLookupContext(
+                    source: AgentWorkspaceLookupContextSource(
+                        activeAgentSessionID: parentAgentSessionID,
+                        worktreeBindingState: .hydrated(bindings)
+                    ),
+                    store: store
+                )
+            } catch {
                 throw ContextBuilderWorkspaceContextError.unavailableWorktreeProjection
             }
-
-            let requestedPhysicalRootPaths = Set(bindings.compactMap {
-                AgentWorktreeRuntimeWorkspaceResolver.standardizedWorkspacePath($0.worktreeRootPath)
-            })
-            guard requestedPhysicalRootPaths.isSubset(of: projection.physicalRootPaths) else {
-                throw ContextBuilderWorkspaceContextError.unavailableWorktreeProjection
-            }
-
-            let loadedRoots = await store.rootRefs(scope: projection.lookupRootScope)
-            let loadedPaths = Set(loadedRoots.compactMap { root in
-                AgentWorktreeRuntimeWorkspaceResolver.standardizedWorkspacePath(root.standardizedFullPath)
-            })
-            guard projection.physicalRootRefs.allSatisfy({ root in
-                guard let path = AgentWorktreeRuntimeWorkspaceResolver.standardizedWorkspacePath(root.standardizedFullPath) else {
-                    return false
-                }
-                return loadedPaths.contains(path)
-            }) else {
-                throw ContextBuilderWorkspaceContextError.unavailableWorktreeProjection
-            }
-            lookupContext = WorkspaceLookupContext(
-                rootScope: projection.lookupRootScope,
-                bindingProjection: projection
-            )
         }
 
         guard let providerWorkspacePath = try AgentWorktreeRuntimeWorkspaceResolver.effectiveWorkspacePath(
@@ -95,10 +75,6 @@ struct ContextBuilderWorkspaceContext {
 
         let context = ContextBuilderWorkspaceContext(
             parentAgentSessionID: parentAgentSessionID,
-            parentAgentRunID: parentAgentRunID,
-            tabID: snapshot.tabID,
-            windowID: snapshot.windowID,
-            workspaceID: workspaceID,
             frozenTabContext: snapshot,
             worktreeBindings: bindings,
             lookupContext: lookupContext,
@@ -109,12 +85,16 @@ struct ContextBuilderWorkspaceContext {
     }
 
     func validateAvailability() throws {
-        try AgentWorktreeRuntimeWorkspaceResolver.validateBindingsAvailable(worktreeBindings)
+        do {
+            try AgentWorktreeRuntimeWorkspaceResolver.validateBindingsAvailable(worktreeBindings)
+        } catch {
+            throw ContextBuilderWorkspaceContextError.unavailableWorktreeProjection
+        }
         var isDirectory: ObjCBool = false
         guard FileManager.default.fileExists(atPath: providerWorkspacePath, isDirectory: &isDirectory),
               isDirectory.boolValue
         else {
-            throw ContextBuilderWorkspaceContextError.unavailableProviderWorkspace(providerWorkspacePath)
+            throw ContextBuilderWorkspaceContextError.unavailableProviderWorkspace
         }
     }
 
@@ -127,10 +107,12 @@ struct ContextBuilderWorkspaceContext {
             promptText: source.promptText,
             selection: source.selection,
             selectedMetaPromptIDs: source.selectedMetaPromptIDs,
+            selectedContextBuilderPromptIDs: source.selectedContextBuilderPromptIDs,
             tabName: source.tabName,
             runID: runID,
             activeAgentSessionID: parentAgentSessionID,
-            worktreeBindings: worktreeBindings,
+            worktreeBindingState: .hydrated(worktreeBindings),
+            frozenLookupContext: lookupContext,
             explicitlyBound: source.explicitlyBound,
             readFileAutoSelectionGeneration: source.readFileAutoSelectionGeneration
         )
@@ -143,8 +125,9 @@ enum ContextBuilderWorkspaceContextError: LocalizedError, Equatable {
     case missingWorkspace
     case missingWorkspaceRoot
     case unavailableWorkspaceProjection
+    case unavailableWorktreeBindingState
     case unavailableWorktreeProjection
-    case unavailableProviderWorkspace(String)
+    case unavailableProviderWorkspace
 
     var errorDescription: String? {
         switch self {
@@ -158,10 +141,12 @@ enum ContextBuilderWorkspaceContextError: LocalizedError, Equatable {
             "context_builder requires a project workspace root for the invoking Agent Mode run."
         case .unavailableWorkspaceProjection:
             "The invoking Agent Mode workspace roots could not be loaded. Context Builder stopped rather than using the visible workspace."
+        case .unavailableWorktreeBindingState:
+            "The invoking Agent Mode worktree bindings are not hydrated or are unavailable. Context Builder stopped rather than falling back to the canonical checkout."
         case .unavailableWorktreeProjection:
             "The invoking Agent Mode worktree bindings could not be loaded. Context Builder stopped rather than falling back to the canonical checkout."
-        case let .unavailableProviderWorkspace(path):
-            "The invoking Agent Mode workspace path is unavailable: \(path). Context Builder stopped rather than falling back to another checkout."
+        case .unavailableProviderWorkspace:
+            "The invoking Agent Mode workspace is unavailable. Context Builder stopped rather than falling back to another checkout."
         }
     }
 }

--- a/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderAgentViewModel.swift
+++ b/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderAgentViewModel.swift
@@ -1573,9 +1573,16 @@ final class ContextBuilderAgentViewModel: ObservableObject {
         modelOverrideRaw: String? = nil,
         responseType: String? = nil,
         planModelName: String? = nil,
+        workspaceContext: ContextBuilderWorkspaceContext? = nil,
         mcpControlToken: UUID,
         progressReporter: ContextBuilderMCPProgressReporter? = nil
     ) async throws -> ContextBuilderRunSnapshot {
+        if let workspaceContext {
+            guard workspaceContext.tabID == tabID else {
+                throw ContextBuilderWorkspaceContextError.missingWorkspace
+            }
+            try workspaceContext.validateAvailability()
+        }
         let session = session(for: tabID)
         if lastProcessedTabID != tabID {
             lastProcessedTabID = tabID
@@ -1705,6 +1712,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
                     origin: .mcp(controlToken: mcpControlToken),
                     agentKind: runAgent,
                     modelRaw: runModelRaw,
+                    workspaceContext: workspaceContext,
                     continuation: continuation,
                     restoreConfiguration: restoreConfiguration,
                     progressReporter: progressReporter
@@ -1723,7 +1731,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
                     return
                 }
 
-                captureRunStartState(for: session)
+                captureRunStartState(for: session, workspaceContext: workspaceContext)
                 session.resetLog()
                 session.lastRunAgentKind = runAgent
                 session.lastRunModelRaw = runModelRaw
@@ -2112,10 +2120,20 @@ final class ContextBuilderAgentViewModel: ObservableObject {
                 return .failed("Failed to start MCP server. Check Local Network permission in System Settings.")
             }
 
+            do {
+                try record.workspaceContext?.validateAvailability()
+            } catch {
+                return .failed(error.localizedDescription)
+            }
+
             let mcpPreparedMessage: AgentMessage?
             if record.origin.isMCP {
                 debugLog("Building MCP-initiated agent message before acquiring the one-shot routing policy")
-                mcpPreparedMessage = await buildAgentMessage(for: session, runID: runID)
+                mcpPreparedMessage = await buildAgentMessage(
+                    for: session,
+                    runID: runID,
+                    workspaceContext: record.workspaceContext
+                )
                 guard acceptsEvents(from: record) else { return .cancelled }
             } else {
                 mcpPreparedMessage = nil
@@ -2138,7 +2156,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
             do {
                 lease = try await AgentRunCoordinator.shared.prepareAndInstallPolicy(
                     spec,
-                    tabID: record.tabID,
+                    tabID: record.workspaceContext == nil ? record.tabID : nil,
                     additionalTools: additionalTools,
                     reason: "discover-run",
                     gateID: runID
@@ -2156,8 +2174,28 @@ final class ContextBuilderAgentViewModel: ObservableObject {
             }
 
             activeAgentRuns.insert(runID)
+            if let workspaceContext = record.workspaceContext {
+                guard let clientName = record.agentKind.mcpClientNameHint else {
+                    await lease.failAndCleanup()
+                    return .failed("Failed to identify the nested Context Builder MCP client.")
+                }
+                _ = mcpServer.installFrozenTabContext(
+                    clientID: nil,
+                    clientName: clientName,
+                    context: workspaceContext.nestedDiscoveryTabContext(runID: runID)
+                )
+            }
+
+            do {
+                try record.workspaceContext?.validateAvailability()
+            } catch {
+                await lease.failAndCleanup()
+                return .failed(error.localizedDescription)
+            }
+
             let modelString = record.modelRaw == AgentModel.defaultModel.rawValue ? nil : record.modelRaw
-            let provider = providerFactory(record.agentKind, modelString, currentWorkspacePath)
+            let providerWorkspacePath = record.workspaceContext?.providerWorkspacePath ?? currentWorkspacePath
+            let provider = providerFactory(record.agentKind, modelString, providerWorkspacePath)
             guard record.installProvider(provider) else {
                 await provider.dispose()
                 await lease.failAndCleanup()
@@ -2170,7 +2208,11 @@ final class ContextBuilderAgentViewModel: ObservableObject {
                     message = mcpPreparedMessage
                 } else {
                     debugLog("Building agent message")
-                    message = await buildAgentMessage(for: session, runID: runID)
+                    message = await buildAgentMessage(
+                        for: session,
+                        runID: runID,
+                        workspaceContext: record.workspaceContext
+                    )
                     guard acceptsEvents(from: record) else {
                         await lease.failAndCleanup()
                         return .cancelled
@@ -2605,7 +2647,11 @@ final class ContextBuilderAgentViewModel: ObservableObject {
 
     // MARK: - Agent message assembly
 
-    private func buildAgentMessage(for session: TabSession, runID: UUID) async -> AgentMessage {
+    private func buildAgentMessage(
+        for session: TabSession,
+        runID: UUID,
+        workspaceContext: ContextBuilderWorkspaceContext?
+    ) async -> AgentMessage {
         // Determine token budget:
         // - MCP runs: prefer any explicit per-run override, otherwise derive budget from response_type
         // - UI runs with auto-generate enabled: use planTokenBudget (larger budget for plan/review/question context)
@@ -2652,11 +2698,19 @@ final class ContextBuilderAgentViewModel: ObservableObject {
 
         let systemPrompt = SystemPromptService.discoverPrompt(tokenBudget: adjustedBudget, agentKind: selectedAgent, enhancementMode: enhancementMode, allowClarifyingQuestions: clarifyingEnabledForRun, responseType: responseType, instructions: session.contextBuilderInstructions, questionTimeoutSeconds: questionTimeoutSeconds)
         debugLog("System prompt includes ask_user: \(systemPrompt.contains("ask_user"))")
-        let userMessage = await buildAgentUserMessage(for: session, adjustedBudget: adjustedBudget)
+        let userMessage = await buildAgentUserMessage(
+            for: session,
+            adjustedBudget: adjustedBudget,
+            workspaceContext: workspaceContext
+        )
         return AgentMessage(systemPrompt: systemPrompt, userMessage: userMessage)
     }
 
-    private func buildAgentUserMessage(for session: TabSession, adjustedBudget: Int) async -> String {
+    private func buildAgentUserMessage(
+        for session: TabSession,
+        adjustedBudget: Int,
+        workspaceContext: ContextBuilderWorkspaceContext?
+    ) async -> String {
         // Context builder prompt IDs captured at run start from viewmodel (always set by captureRunStartState)
         let contextBuilderPromptIDs = session.runStartContextBuilderPromptIDs ?? []
 
@@ -2664,7 +2718,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
         if let promptText = session.runStartPromptText,
            let selection = session.runStartSelection
         {
-            let fileTree = await buildFileTree(from: selection)
+            let fileTree = await buildFileTree(from: selection, lookupContext: workspaceContext?.lookupContext)
             debugLog("Using run-start captured state for tab=\(session.tabID)")
             return makeUserMessage(
                 fileTree: fileTree,
@@ -2677,7 +2731,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
 
         // PRIORITY 2: Workspace snapshot (fallback, may be slightly stale)
         if let snapshot = snapshotForTab(session.tabID) {
-            let fileTree = await buildFileTree(from: snapshot.selection)
+            let fileTree = await buildFileTree(from: snapshot.selection, lookupContext: workspaceContext?.lookupContext)
             debugLog("Using workspace snapshot for tab=\(session.tabID)")
             return makeUserMessage(
                 fileTree: fileTree,
@@ -2704,7 +2758,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
         debugLog("Using live UI state (tab still active) for tab=\(session.tabID)")
         workspaceManager?.publishActiveComposeTabSnapshot(commitToMemory: true)
         let liveSelection = snapshotForTab(session.tabID)?.selection ?? StoredSelection()
-        let fileTree = await buildFileTree(from: liveSelection)
+        let fileTree = await buildFileTree(from: liveSelection, lookupContext: workspaceContext?.lookupContext)
         return makeUserMessage(
             fileTree: fileTree,
             userPrompt: promptManager.promptText,
@@ -2786,7 +2840,18 @@ final class ContextBuilderAgentViewModel: ObservableObject {
         return message
     }
 
-    private func buildFileTree(from selection: StoredSelection) async -> String {
+    private func buildFileTree(
+        from selection: StoredSelection,
+        lookupContext: WorkspaceLookupContext? = nil
+    ) async -> String {
+        if let lookupContext {
+            return await AgentProviderContextBuilder.initialFileTree(
+                selection: selection,
+                store: promptManager.workspaceFileContextStore,
+                lookupContext: lookupContext
+            )
+        }
+
         let snapshot = await promptManager.workspaceFileContextStore.makeFileTreeSelectionSnapshot(
             selection: selection,
             request: WorkspaceFileTreeSnapshotRequest(
@@ -2812,8 +2877,19 @@ final class ContextBuilderAgentViewModel: ObservableObject {
 
     /// Captures the tab's prompt and selection state at discovery run start.
     /// This prevents tab bleed when user switches tabs during a run.
-    private func captureRunStartState(for session: TabSession) {
-        // Capture context builder prompt IDs from the viewmodel (current UI state)
+    private func captureRunStartState(
+        for session: TabSession,
+        workspaceContext: ContextBuilderWorkspaceContext? = nil
+    ) {
+        if let workspaceContext {
+            session.runStartContextBuilderPromptIDs = Set(workspaceContext.frozenTabContext.selectedMetaPromptIDs)
+            session.runStartPromptText = workspaceContext.frozenTabContext.promptText
+            session.runStartSelection = workspaceContext.frozenTabContext.selection
+            debugLog("Captured run-start state from frozen Agent Mode context for tab=\(session.tabID)")
+            return
+        }
+
+        // Ordinary UI runs retain the current view-model prompt selection behavior.
         session.runStartContextBuilderPromptIDs = selectedContextBuilderPromptIDs
 
         // First try: workspace snapshot (most reliable source)
@@ -3445,6 +3521,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
         mode: HeadlessMode,
         prompt: String,
         selection: StoredSelection,
+        lookupContext: WorkspaceLookupContext? = nil,
         chatName: String,
         model: AIModel,
         chatPresetID: UUID?,
@@ -3485,7 +3562,8 @@ final class ContextBuilderAgentViewModel: ObservableObject {
                 from: HeadlessContextSnapshot(
                     tabID: tabID,
                     promptText: prompt,
-                    selection: selection
+                    selection: selection,
+                    lookupContext: lookupContext
                 ),
                 model: model,
                 mode: mode,
@@ -3534,6 +3612,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
                 overrideMode: promptMode,
                 gitInclusionOverride: mode == .review ? gitScopeOverride : nil,
                 selectionOverride: selection,
+                lookupContextOverride: lookupContext,
                 overrideAIMessage: aiMessage,
                 onProgress: { [weak self] text, reasoning in
                     guard let self,
@@ -3628,6 +3707,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
         mode: HeadlessMode,
         prompt: String,
         selection: StoredSelection,
+        lookupContext: WorkspaceLookupContext? = nil,
         gitScopeOverride: GitInclusion? = nil,
         progressReporter: ContextBuilderMCPProgressReporter? = nil,
         activityReporter: ContextBuilderMCPActivityReporter? = nil
@@ -3671,6 +3751,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
             mode: mode,
             prompt: prompt,
             selection: selection,
+            lookupContext: lookupContext,
             chatName: chatNameForTab(tabID),
             model: modelSelection.model,
             chatPresetID: modelSelection.chatPresetID,

--- a/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderAgentViewModel.swift
+++ b/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderAgentViewModel.swift
@@ -2882,7 +2882,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
         workspaceContext: ContextBuilderWorkspaceContext? = nil
     ) {
         if let workspaceContext {
-            session.runStartContextBuilderPromptIDs = Set(workspaceContext.frozenTabContext.selectedMetaPromptIDs)
+            session.runStartContextBuilderPromptIDs = Set(workspaceContext.frozenTabContext.selectedContextBuilderPromptIDs)
             session.runStartPromptText = workspaceContext.frozenTabContext.promptText
             session.runStartSelection = workspaceContext.frozenTabContext.selection
             debugLog("Captured run-start state from frozen Agent Mode context for tab=\(session.tabID)")

--- a/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderRunLifecycle.swift
+++ b/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderRunLifecycle.swift
@@ -84,6 +84,7 @@ final class ContextBuilderRunRecord {
     let agentKind: AgentProviderKind
     let modelRaw: String
     let progressReporter: ContextBuilderMCPProgressReporter?
+    let workspaceContext: ContextBuilderWorkspaceContext?
 
     var output = ContextBuilderAssistantOutputAccumulator()
     var executionTask: Task<Void, Never>?
@@ -107,6 +108,7 @@ final class ContextBuilderRunRecord {
         origin: ContextBuilderRunOrigin,
         agentKind: AgentProviderKind,
         modelRaw: String,
+        workspaceContext: ContextBuilderWorkspaceContext? = nil,
         continuation: CheckedContinuation<ContextBuilderAgentViewModel.ContextBuilderRunSnapshot, Error>? = nil,
         restoreConfiguration: (() -> Void)? = nil,
         progressReporter: ContextBuilderMCPProgressReporter? = nil
@@ -118,6 +120,7 @@ final class ContextBuilderRunRecord {
         self.origin = origin
         self.agentKind = agentKind
         self.modelRaw = modelRaw
+        self.workspaceContext = workspaceContext
         self.continuation = continuation
         self.restoreConfiguration = restoreConfiguration
         self.progressReporter = progressReporter

--- a/Sources/RepoPrompt/Features/Prompt/ViewModels/PromptViewModel+HeadlessPlan.swift
+++ b/Sources/RepoPrompt/Features/Prompt/ViewModels/PromptViewModel+HeadlessPlan.swift
@@ -22,6 +22,21 @@ struct HeadlessContextSnapshot {
 
     /// Frozen selection from ComposeTabState.selection
     let selection: StoredSelection
+
+    /// Frozen logical-to-physical workspace projection for this request.
+    let lookupContext: WorkspaceLookupContext?
+
+    init(
+        tabID: UUID,
+        promptText: String,
+        selection: StoredSelection,
+        lookupContext: WorkspaceLookupContext? = nil
+    ) {
+        self.tabID = tabID
+        self.promptText = promptText
+        self.selection = selection
+        self.lookupContext = lookupContext
+    }
 }
 
 // MARK: - Headless AIMessage Builders
@@ -58,16 +73,23 @@ extension PromptViewModel {
         let preAssembly = await preAssemblePromptContext(
             cfg: headlessConfig,
             selection: snapshot.selection,
-            lookupContext: allLoadedWorkspaceLookupContext(),
+            lookupContext: snapshot.lookupContext ?? allLoadedWorkspaceLookupContext(),
             gitBaseOverride: gitBaseOverride
         )
         let (_, codeEntries) = PromptPackagingService.partitionPromptEntriesForGitDiff(preAssembly.entries)
 
-        // 2. Generate file contents
+        // 2. Generate file contents. Preserve legacy formatting unless an authoritative
+        // Agent Mode lookup context requires physical paths to be projected logically.
+        let displayPathResolver: ((ResolvedPromptFileEntry) -> String?)? = if snapshot.lookupContext != nil {
+            { entry in preAssembly.displayPath(for: entry) }
+        } else {
+            nil
+        }
         let fileBlocks = PromptPackagingService.generateFileContents(
             codeEntries,
             filePathDisplay: filePathDisplayOption,
-            codemapSnapshots: preAssembly.codemapSnapshots
+            codemapSnapshots: preAssembly.codemapSnapshots,
+            displayPathResolver: displayPathResolver
         )
 
         // 3. Use the neutral pre-assembly file tree.

--- a/Sources/RepoPrompt/Features/WorkspaceFiles/ViewModels/WorkspaceFilesViewModel.swift
+++ b/Sources/RepoPrompt/Features/WorkspaceFiles/ViewModels/WorkspaceFilesViewModel.swift
@@ -7594,11 +7594,11 @@ class WorkspaceFilesViewModel: ObservableObject {
             visibleRootFolders + gitDataRootFolders()
         case .allLoaded:
             rootFolders
-        case let .sessionBoundWorkspace(logicalRootPaths, physicalRootPaths):
+        case let .sessionBoundWorkspace(canonicalRootPaths, physicalRootPaths):
             rootFolders.filter { root in
                 if physicalRootPaths.contains(root.standardizedFullPath) { return true }
                 return visibleRootFolders.contains(where: { $0.id == root.id })
-                    && !logicalRootPaths.contains(root.standardizedFullPath)
+                    && canonicalRootPaths.contains(root.standardizedFullPath)
             }
         }
     }

--- a/Sources/RepoPrompt/Features/Workspaces/WorkspaceCheckoutRefreshService.swift
+++ b/Sources/RepoPrompt/Features/Workspaces/WorkspaceCheckoutRefreshService.swift
@@ -98,9 +98,9 @@ struct WorkspaceCheckoutRefreshService {
     private func narrowRootScope(for targetRoots: [WorkspaceRootRecord]) async -> WorkspaceLookupRootScope {
         let allRoots = await store.roots()
         let targetRootIDs = Set(targetRoots.map(\.id))
-        let excludedPrimaryRootPaths = Set(
+        let targetPrimaryRootPaths = Set(
             allRoots.compactMap { root -> String? in
-                guard root.kind == .primaryWorkspace, !targetRootIDs.contains(root.id) else { return nil }
+                guard root.kind == .primaryWorkspace, targetRootIDs.contains(root.id) else { return nil }
                 return root.standardizedFullPath
             }
         )
@@ -111,7 +111,7 @@ struct WorkspaceCheckoutRefreshService {
             }
         )
         return .sessionBoundWorkspace(
-            logicalRootPaths: excludedPrimaryRootPaths,
+            canonicalRootPaths: targetPrimaryRootPaths,
             physicalRootPaths: targetSessionWorktreePaths
         )
     }

--- a/Sources/RepoPrompt/Infrastructure/MCP/Agent/AgentManageMCPToolService.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/Agent/AgentManageMCPToolService.swift
@@ -510,13 +510,17 @@ struct AgentManageMCPToolService {
         )
         let hadMatchingMCPControl = agentModeVM.session(for: target.tabID, createIfNeeded: false)?.mcpControlContext?.sessionID == sessionID
         do {
-            try await agentModeVM.mcpActivateControlContext(
-                forTabID: target.tabID,
-                sessionID: sessionID,
-                originatingConnectionID: metadata.connectionID,
-                taskLabelKind: selection.taskLabelKind,
-                startPending: false
-            )
+            // Resume adopts the live session's existing control registration. Re-registering the
+            // same persistent session expires in-flight waiters and splits poll state from the UI.
+            if !hadMatchingMCPControl {
+                try await agentModeVM.mcpActivateControlContext(
+                    forTabID: target.tabID,
+                    sessionID: sessionID,
+                    originatingConnectionID: metadata.connectionID,
+                    taskLabelKind: selection.taskLabelKind,
+                    startPending: false
+                )
+            }
             try await agentModeVM.mcpConfigureSession(
                 tabID: target.tabID,
                 agentRaw: resolved.agent,

--- a/Sources/RepoPrompt/Infrastructure/MCP/Agent/AgentRunMCPToolService.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/Agent/AgentRunMCPToolService.swift
@@ -11,21 +11,23 @@ struct OracleExportDestination: Equatable {
     let workspaceID: UUID
     let windowID: Int
     let tabID: UUID?
+    /// Logical/canonical primary root returned to the bound child.
     let primaryRootPath: String
-    let rootScope: WorkspaceLookupRootScope
+    /// Frozen logical-to-physical scope used for disk I/O and read-back verification.
+    let lookupContext: WorkspaceLookupContext
 
     init(
         workspaceID: UUID,
         windowID: Int,
         tabID: UUID?,
         primaryRootPath: String,
-        rootScope: WorkspaceLookupRootScope = .visibleWorkspace
+        lookupContext: WorkspaceLookupContext = .visibleWorkspace
     ) {
         self.workspaceID = workspaceID
         self.windowID = windowID
         self.tabID = tabID
         self.primaryRootPath = primaryRootPath
-        self.rootScope = rootScope
+        self.lookupContext = lookupContext
     }
 }
 

--- a/Sources/RepoPrompt/Infrastructure/MCP/MCPOracleToolService.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/MCPOracleToolService.swift
@@ -7,6 +7,11 @@ struct MCPOracleToolService {
     typealias ResolvedTabContextSnapshot = MCPServerViewModel.ResolvedTabContextSnapshot
     typealias TabScopedContext = MCPServerViewModel.TabScopedContext
     typealias ChatSendOperation = @Sendable () async throws -> [String: Value]
+    typealias SendChat = @MainActor @Sendable (
+        _ args: [String: Value],
+        _ promptVM: PromptViewModel,
+        _ tabContext: OracleViewModel.OracleSendTabContext?
+    ) async throws -> [String: Value]
     typealias ExportOracleResponse = @MainActor @Sendable (OracleExportRequest) async throws -> OracleExportFile
 
     let askOracleToolName: String
@@ -24,6 +29,7 @@ struct MCPOracleToolService {
     let rawExplicitTabID: (_ args: [String: Value]) -> String?
     let sendStageProgress: (_ connectionID: UUID?, _ tool: String, _ stage: String, _ message: String) async -> Void
     let withHeartbeat: (_ connectionID: UUID?, _ tool: String, _ stage: String, _ message: String, _ operation: @escaping ChatSendOperation) async throws -> [String: Value]
+    let sendChat: SendChat
     let exportOracleResponse: ExportOracleResponse
 
     func executeOracleUtils(args: [String: Value]) async throws -> Value {
@@ -147,7 +153,7 @@ struct MCPOracleToolService {
         let owner = resolveAgentOracleOwner(tabID: tabID, targetWindow: targetWindow, tabContext: virtualContext)
         let tabContext: OracleViewModel.OracleSendTabContext
         if let virtualContext, virtualContext.tabID == tabID {
-            tabContext = await oracleSendTabContext(from: virtualContext, owner: owner)
+            tabContext = try await oracleSendTabContext(from: virtualContext, owner: owner)
         } else {
             guard let tabSnapshot = targetWindow.workspaceManager.composeTabSnapshot(for: tabID) else {
                 throw MCPError.internalError("Unable to resolve compose tab context for ask_oracle")
@@ -155,7 +161,7 @@ struct MCPOracleToolService {
             let worktreeBindings = owner.agentSessionID.map {
                 targetWindow.agentModeViewModel.worktreeBindings(forAgentSessionID: $0, tabID: tabID)
             } ?? []
-            let lookupContext = await oraclePackagingLookupContext(
+            let lookupContext = try await oraclePackagingLookupContext(
                 agentSessionID: owner.agentSessionID,
                 worktreeBindings: worktreeBindings
             )
@@ -198,11 +204,7 @@ struct MCPOracleToolService {
             "waiting",
             "Waiting for Oracle response..."
         ) {
-            try await oracleVM.tool_chatSend(
-                args: capturedChatArgs,
-                promptVM: promptVM,
-                tabContext: tabContext
-            )
+            try await sendChat(capturedChatArgs, promptVM, tabContext)
         }
 
         if exportResponse {
@@ -265,9 +267,9 @@ struct MCPOracleToolService {
             let context = try await requireCurrentTabContext(oracleSendToolName)
             if runPurpose == .agentModeRun, let targetWindow {
                 let owner = resolveAgentOracleOwner(tabID: context.tabID, targetWindow: targetWindow, tabContext: context)
-                tabContext = await oracleSendTabContext(from: context, owner: owner)
+                tabContext = try await oracleSendTabContext(from: context, owner: owner)
             } else {
-                tabContext = await oracleSendTabContext(from: context)
+                tabContext = try await oracleSendTabContext(from: context)
             }
         }
 
@@ -295,11 +297,7 @@ struct MCPOracleToolService {
             "waiting",
             "Waiting for Oracle response..."
         ) {
-            try await oracleVM.tool_chatSend(
-                args: capturedChatArgs,
-                promptVM: promptVM,
-                tabContext: capturedTabContext
-            )
+            try await sendChat(capturedChatArgs, promptVM, capturedTabContext)
         }
 
         if exportResponse {
@@ -489,16 +487,25 @@ struct MCPOracleToolService {
         )
     }
 
-    private func oraclePackagingLookupContext(for context: TabScopedContext) async -> WorkspaceLookupContext? {
-        await resolveLookupContext(context)
+    private func oraclePackagingLookupContext(for context: TabScopedContext) async throws -> WorkspaceLookupContext {
+        if context.activeAgentSessionID != nil, !context.worktreeBindings.isEmpty {
+            return try await AgentWorkspaceLookupContextResolver.requiredLookupContext(
+                source: AgentWorkspaceLookupContextSource(
+                    activeAgentSessionID: context.activeAgentSessionID,
+                    worktreeBindings: context.worktreeBindings
+                ),
+                store: promptVM.workspaceFileContextStore
+            )
+        }
+        return await resolveLookupContext(context)
     }
 
     private func oraclePackagingLookupContext(
         agentSessionID: UUID?,
         worktreeBindings: [AgentSessionWorktreeBinding]
-    ) async -> WorkspaceLookupContext? {
-        guard let agentSessionID else { return .visibleWorkspace }
-        return await AgentWorkspaceLookupContextResolver.lookupContext(
+    ) async throws -> WorkspaceLookupContext {
+        guard let agentSessionID, !worktreeBindings.isEmpty else { return .visibleWorkspace }
+        return try await AgentWorkspaceLookupContextResolver.requiredLookupContext(
             source: AgentWorkspaceLookupContextSource(
                 activeAgentSessionID: agentSessionID,
                 worktreeBindings: worktreeBindings
@@ -510,8 +517,8 @@ struct MCPOracleToolService {
     private func oracleSendTabContext(
         from context: TabScopedContext,
         owner: AgentOracleOwner = AgentOracleOwner(agentSessionID: nil, runID: nil)
-    ) async -> OracleViewModel.OracleSendTabContext {
-        let lookupContext = await oraclePackagingLookupContext(for: context)
+    ) async throws -> OracleViewModel.OracleSendTabContext {
+        let lookupContext = try await oraclePackagingLookupContext(for: context)
         return OracleViewModel.OracleSendTabContext(
             tabID: context.tabID,
             promptText: context.promptText,

--- a/Sources/RepoPrompt/Infrastructure/MCP/MCPOracleToolService.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/MCPOracleToolService.swift
@@ -22,7 +22,6 @@ struct MCPOracleToolService {
     let captureRequestMetadata: () async -> RequestMetadata
     let resolveTabContextSnapshot: (RequestMetadata) throws -> ResolvedTabContextSnapshot
     let requireCurrentTabContext: (String) async throws -> TabScopedContext
-    let resolveLookupContext: (TabScopedContext) async -> WorkspaceLookupContext
     let rebindChatSessionIfNeeded: (_ metadata: RequestMetadata, _ chatIDString: String) throws -> Void
     let resolveTabIDForAgentMode: (_ args: [String: Value], _ connectionID: UUID?) async throws -> UUID
     let requireTargetWindow: () throws -> WindowState
@@ -92,7 +91,7 @@ struct MCPOracleToolService {
             tabContext = currentContext
         }
         let targetWindow = try requireTargetWindow()
-        let owner = resolveAgentOracleOwner(tabID: tabID, targetWindow: targetWindow, tabContext: tabContext)
+        let owner = await resolveAgentOracleOwner(tabID: tabID, targetWindow: targetWindow, tabContext: tabContext)
 
         let result = try await oracleVM.tool_oracleChatLog(
             args: args,
@@ -133,7 +132,6 @@ struct MCPOracleToolService {
         let tabID = try await resolveTabIDForAgentMode(args, connectionID)
         let requestContext = try? await requireCurrentTabContext(askOracleToolName)
         let virtualContext = (requestContext?.tabID == tabID) ? requestContext : nil
-
         if let normalizedChatID {
             guard let session = oracleVM.resolveSession(id: normalizedChatID) else {
                 throw MCPError.invalidParams("Chat with ID '\(normalizedChatID)' not found")
@@ -150,7 +148,7 @@ struct MCPOracleToolService {
             }
         }
 
-        let owner = resolveAgentOracleOwner(tabID: tabID, targetWindow: targetWindow, tabContext: virtualContext)
+        let owner = await resolveAgentOracleOwner(tabID: tabID, targetWindow: targetWindow, tabContext: virtualContext)
         let tabContext: OracleViewModel.OracleSendTabContext
         if let virtualContext, virtualContext.tabID == tabID {
             tabContext = try await oracleSendTabContext(from: virtualContext, owner: owner)
@@ -158,13 +156,7 @@ struct MCPOracleToolService {
             guard let tabSnapshot = targetWindow.workspaceManager.composeTabSnapshot(for: tabID) else {
                 throw MCPError.internalError("Unable to resolve compose tab context for ask_oracle")
             }
-            let worktreeBindings = owner.agentSessionID.map {
-                targetWindow.agentModeViewModel.worktreeBindings(forAgentSessionID: $0, tabID: tabID)
-            } ?? []
-            let lookupContext = try await oraclePackagingLookupContext(
-                agentSessionID: owner.agentSessionID,
-                worktreeBindings: worktreeBindings
-            )
+            let lookupContext = try await oraclePackagingLookupContext(owner: owner)
             tabContext = OracleViewModel.OracleSendTabContext(
                 tabID: tabID,
                 promptText: tabSnapshot.promptText,
@@ -266,7 +258,7 @@ struct MCPOracleToolService {
 
             let context = try await requireCurrentTabContext(oracleSendToolName)
             if runPurpose == .agentModeRun, let targetWindow {
-                let owner = resolveAgentOracleOwner(tabID: context.tabID, targetWindow: targetWindow, tabContext: context)
+                let owner = await resolveAgentOracleOwner(tabID: context.tabID, targetWindow: targetWindow, tabContext: context)
                 tabContext = try await oracleSendTabContext(from: context, owner: owner)
             } else {
                 tabContext = try await oracleSendTabContext(from: context)
@@ -473,50 +465,85 @@ struct MCPOracleToolService {
     private struct AgentOracleOwner {
         let agentSessionID: UUID?
         let runID: UUID?
+        let worktreeBindingState: AgentSessionWorktreeBindingState
     }
 
     private func resolveAgentOracleOwner(
         tabID: UUID,
         targetWindow: WindowState,
         tabContext: TabScopedContext?
-    ) -> AgentOracleOwner {
-        let session = targetWindow.agentModeViewModel.session(for: tabID, createIfNeeded: false)
+    ) async -> AgentOracleOwner {
+        let agentModeViewModel = targetWindow.agentModeViewModel
+        let storedSessionID = tabContext?.activeAgentSessionID
+            ?? targetWindow.workspaceManager.composeTab(with: tabID)?.activeAgentSessionID
+            ?? agentModeViewModel.session(for: tabID, createIfNeeded: false)?.activeAgentSessionID
+        guard let storedSessionID else {
+            return AgentOracleOwner(
+                agentSessionID: nil,
+                runID: tabContext?.runID,
+                worktreeBindingState: .notApplicable
+            )
+        }
+
+        let hydratedSession = await agentModeViewModel.ensureSessionReady(tabID: tabID)
+        guard hydratedSession.activeAgentSessionID == storedSessionID else {
+            return AgentOracleOwner(
+                agentSessionID: storedSessionID,
+                runID: tabContext?.runID ?? hydratedSession.runID,
+                worktreeBindingState: .unavailable
+            )
+        }
         return AgentOracleOwner(
-            agentSessionID: session?.activeAgentSessionID,
-            runID: tabContext?.runID ?? session?.runID
+            agentSessionID: storedSessionID,
+            runID: tabContext?.runID ?? hydratedSession.runID,
+            worktreeBindingState: agentModeViewModel.worktreeBindingState(
+                forAgentSessionID: storedSessionID,
+                tabID: tabID
+            )
         )
     }
 
     private func oraclePackagingLookupContext(for context: TabScopedContext) async throws -> WorkspaceLookupContext {
-        if context.activeAgentSessionID != nil, !context.worktreeBindings.isEmpty {
-            return try await AgentWorkspaceLookupContextResolver.requiredLookupContext(
-                source: AgentWorkspaceLookupContextSource(
-                    activeAgentSessionID: context.activeAgentSessionID,
-                    worktreeBindings: context.worktreeBindings
-                ),
-                store: promptVM.workspaceFileContextStore
-            )
+        if let frozenLookupContext = context.frozenLookupContext {
+            return frozenLookupContext
         }
-        return await resolveLookupContext(context)
+        return try await requiredOracleLookupContext(
+            source: AgentWorkspaceLookupContextSource(
+                activeAgentSessionID: context.activeAgentSessionID,
+                worktreeBindingState: context.worktreeBindingState
+            )
+        )
     }
 
-    private func oraclePackagingLookupContext(
-        agentSessionID: UUID?,
-        worktreeBindings: [AgentSessionWorktreeBinding]
-    ) async throws -> WorkspaceLookupContext {
-        guard let agentSessionID, !worktreeBindings.isEmpty else { return .visibleWorkspace }
-        return try await AgentWorkspaceLookupContextResolver.requiredLookupContext(
+    private func oraclePackagingLookupContext(owner: AgentOracleOwner) async throws -> WorkspaceLookupContext {
+        try await requiredOracleLookupContext(
             source: AgentWorkspaceLookupContextSource(
-                activeAgentSessionID: agentSessionID,
-                worktreeBindings: worktreeBindings
-            ),
-            store: promptVM.workspaceFileContextStore
+                activeAgentSessionID: owner.agentSessionID,
+                worktreeBindingState: owner.worktreeBindingState
+            )
         )
+    }
+
+    private func requiredOracleLookupContext(
+        source: AgentWorkspaceLookupContextSource
+    ) async throws -> WorkspaceLookupContext {
+        do {
+            return try await AgentWorkspaceLookupContextResolver.requiredLookupContext(
+                source: source,
+                store: promptVM.workspaceFileContextStore
+            )
+        } catch {
+            throw MCPError.invalidParams(error.localizedDescription)
+        }
     }
 
     private func oracleSendTabContext(
         from context: TabScopedContext,
-        owner: AgentOracleOwner = AgentOracleOwner(agentSessionID: nil, runID: nil)
+        owner: AgentOracleOwner = AgentOracleOwner(
+            agentSessionID: nil,
+            runID: nil,
+            worktreeBindingState: .notApplicable
+        )
     ) async throws -> OracleViewModel.OracleSendTabContext {
         let lookupContext = try await oraclePackagingLookupContext(for: context)
         return OracleViewModel.OracleSendTabContext(

--- a/Sources/RepoPrompt/Infrastructure/MCP/OracleExportFileWriter.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/OracleExportFileWriter.swift
@@ -6,82 +6,85 @@ struct GeneratedOracleExportFileWriter {
 
     @discardableResult
     func write(path rawPath: String, content: String, destination: OracleExportDestination) async throws -> String {
-        let resolvedPath = try resolvedAbsoluteExportPath(rawPath, destination: destination)
-        let destinationRootPath = StandardizedPath.absolute(destination.primaryRootPath)
-        let readableRoots = await store.rootRefs(scope: destination.rootScope)
-        guard let readableRoot = readableRoots.first(where: { $0.standardizedFullPath == destinationRootPath }) else {
-            let loadedRoots = readableRoots.map(\.standardizedFullPath).joined(separator: ", ")
+        let logicalPath = try resolvedAbsoluteExportPath(rawPath, destination: destination)
+        let physicalPath = StandardizedPath.absolute(destination.lookupContext.translateInputPath(logicalPath))
+        let physicalRootPath = StandardizedPath.absolute(
+            destination.lookupContext.translateInputPath(destination.primaryRootPath)
+        )
+        let scopedRoots = await store.rootRefs(scope: destination.lookupContext.rootScope)
+        guard let scopedRoot = scopedRoots.first(where: { $0.standardizedFullPath == physicalRootPath }) else {
             throw MCPError.invalidParams(
-                "Cannot create generated Oracle export at '\(resolvedPath)': workspace primary root '\(destinationRootPath)' is not loaded in the current read_file workspace scope. Loaded readable roots: \(loadedRoots.isEmpty ? "none" : loadedRoots)."
+                "Cannot create generated Oracle export at '\(logicalPath)': destination root is not loaded in the bound read_file workspace scope."
             )
         }
-        guard resolvedPath == readableRoot.standardizedFullPath
-            || StandardizedPath.isDescendant(resolvedPath, of: readableRoot.standardizedFullPath)
+        guard physicalPath == scopedRoot.standardizedFullPath
+            || StandardizedPath.isDescendant(physicalPath, of: scopedRoot.standardizedFullPath)
         else {
             throw MCPError.invalidParams(
-                "Cannot create generated Oracle export at '\(resolvedPath)': target path is outside the current read_file workspace root '\(readableRoot.standardizedFullPath)'."
+                "Cannot create generated Oracle export at '\(logicalPath)': translated target path is outside the bound workspace root."
             )
         }
 
         let fm = FileManager.default
-        guard !fm.fileExists(atPath: resolvedPath) else {
-            throw MCPError.invalidParams("Cannot create generated Oracle export at '\(resolvedPath)': path already exists.")
+        guard !fm.fileExists(atPath: physicalPath) else {
+            throw MCPError.invalidParams("Cannot create generated Oracle export at '\(logicalPath)': path already exists.")
         }
 
         let mutationService = WorkspaceFileMutationService(store: store)
         do {
             let writeResult = try await mutationService.createFileWithPostcondition(
-                userPath: resolvedPath,
+                userPath: physicalPath,
                 content: content,
-                rootScope: destination.rootScope,
+                rootScope: destination.lookupContext.rootScope,
                 pathResolutionPolicy: .literalPreferredIfStronger
             )
 
             if let reason = writeResult.catalogIneligibility {
                 throw MCPError.invalidParams(
-                    "Generated Oracle export was written to '\(resolvedPath)', but that path is not readable by read_file because \(reason.description). Remove the workspace policy/ignore exclusion for this export path and try again."
+                    "Generated Oracle export was written to '\(logicalPath)', but that path is not readable by read_file because \(reason.description). Remove the workspace policy/ignore exclusion for this export path and try again."
                 )
             }
             guard writeResult.materializedFile != nil else {
                 throw MCPError.invalidParams(
-                    "Generated Oracle export was written to '\(resolvedPath)', but RepoPrompt did not add it to the workspace catalog, so read_file cannot read it."
+                    "Generated Oracle export was written to '\(logicalPath)', but RepoPrompt did not add it to the workspace catalog, so read_file cannot read it."
                 )
             }
 
             _ = await store.awaitAppliedIngressForExplicitRequest(
-                userPath: resolvedPath,
-                fallbackScope: destination.rootScope
+                userPath: physicalPath,
+                fallbackScope: destination.lookupContext.rootScope
             )
             try await assertReadFileCanReadExport(
-                path: resolvedPath,
+                physicalPath: physicalPath,
+                logicalPath: logicalPath,
                 expectedContent: content,
-                rootScope: destination.rootScope
+                rootScope: destination.lookupContext.rootScope
             )
-            return resolvedPath
+            return logicalPath
         } catch let error as MCPError {
             await cleanupCreatedExportIfPresent(
-                path: resolvedPath,
-                root: readableRoot,
-                rootScope: destination.rootScope
+                physicalPath: physicalPath,
+                root: scopedRoot,
+                rootScope: destination.lookupContext.rootScope
             )
             throw error
-        } catch let error as FileManagerError {
+        } catch is FileManagerError {
             await cleanupCreatedExportIfPresent(
-                path: resolvedPath,
-                root: readableRoot,
-                rootScope: destination.rootScope
+                physicalPath: physicalPath,
+                root: scopedRoot,
+                rootScope: destination.lookupContext.rootScope
             )
             throw MCPError.invalidParams(
-                "Cannot create generated Oracle export at '\(resolvedPath)': \(error.localizedDescription)"
+                "Cannot create generated Oracle export at '\(logicalPath)': filesystem operation failed."
             )
         } catch {
             await cleanupCreatedExportIfPresent(
-                path: resolvedPath,
-                root: readableRoot,
-                rootScope: destination.rootScope
+                physicalPath: physicalPath,
+                root: scopedRoot,
+                rootScope: destination.lookupContext.rootScope
             )
             throw MCPError.invalidParams(
-                "Cannot create generated Oracle export at '\(resolvedPath)': \(error.localizedDescription)"
+                "Cannot create generated Oracle export at '\(logicalPath)': export creation or verification failed."
             )
         }
     }
@@ -104,59 +107,60 @@ struct GeneratedOracleExportFileWriter {
     }
 
     private func cleanupCreatedExportIfPresent(
-        path resolvedPath: String,
+        physicalPath: String,
         root: WorkspaceRootRef,
         rootScope: WorkspaceLookupRootScope
     ) async {
-        guard FileManager.default.fileExists(atPath: resolvedPath) else { return }
-        try? FileManager.default.removeItem(atPath: resolvedPath)
+        guard FileManager.default.fileExists(atPath: physicalPath) else { return }
+        try? FileManager.default.removeItem(atPath: physicalPath)
         let rootPrefix = root.standardizedFullPath.hasSuffix("/") ? root.standardizedFullPath : root.standardizedFullPath + "/"
-        guard resolvedPath.hasPrefix(rootPrefix) else { return }
-        let relativePath = StandardizedPath.relative(String(resolvedPath.dropFirst(rootPrefix.count)))
+        guard physicalPath.hasPrefix(rootPrefix) else { return }
+        let relativePath = StandardizedPath.relative(String(physicalPath.dropFirst(rootPrefix.count)))
         await store.replayObservedFileSystemDeltas(rootID: root.id, deltas: [.fileRemoved(relativePath)])
         _ = await store.awaitAppliedIngressForExplicitRequest(
-            userPath: resolvedPath,
+            userPath: physicalPath,
             fallbackScope: rootScope
         )
     }
 
     private func assertReadFileCanReadExport(
-        path resolvedPath: String,
+        physicalPath: String,
+        logicalPath: String,
         expectedContent: String,
         rootScope: WorkspaceLookupRootScope
     ) async throws {
         let readableService = WorkspaceReadableFileService(store: store)
         let readable = await readableService.resolveReadableFile(
-            resolvedPath,
+            physicalPath,
             profile: .mcpRead,
             rootScope: rootScope
         )
         guard case let .workspace(file) = readable else {
             throw MCPError.invalidParams(
-                "Generated Oracle export was written to '\(resolvedPath)', but read_file cannot resolve that exact path in the current workspace."
+                "Generated Oracle export was written to '\(logicalPath)', but read_file cannot resolve that exact path in the bound workspace."
             )
         }
-        guard file.standardizedFullPath == resolvedPath else {
+        guard file.standardizedFullPath == physicalPath else {
             throw MCPError.invalidParams(
-                "Generated Oracle export was written to '\(resolvedPath)', but read_file resolved a different workspace file ('\(file.standardizedFullPath)')."
+                "Generated Oracle export was written to '\(logicalPath)', but read_file resolved a different workspace file."
             )
         }
         do {
             guard let loadedContent = try await store.readContent(rootID: file.rootID, relativePath: file.standardizedRelativePath) else {
                 throw MCPError.invalidParams(
-                    "Generated Oracle export was written to '\(resolvedPath)', but read_file cannot load its contents."
+                    "Generated Oracle export was written to '\(logicalPath)', but read_file cannot load its contents."
                 )
             }
             guard loadedContent == expectedContent else {
                 throw MCPError.invalidParams(
-                    "Generated Oracle export was written to '\(resolvedPath)', but read_file loaded different contents."
+                    "Generated Oracle export was written to '\(logicalPath)', but read_file loaded different contents."
                 )
             }
         } catch let error as MCPError {
             throw error
         } catch {
             throw MCPError.invalidParams(
-                "Generated Oracle export was written to '\(resolvedPath)', but read_file cannot load its contents: \(error.localizedDescription)"
+                "Generated Oracle export was written to '\(logicalPath)', but read_file cannot load its contents."
             )
         }
     }

--- a/Sources/RepoPrompt/Infrastructure/MCP/ToolOutputFormatter.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ToolOutputFormatter.swift
@@ -32,6 +32,7 @@ enum ToolOutputFormatter {
     }
 
     private enum WorktreeScopeOperation {
+        case codeStructure
         case fileTree
         case search
         case readFile
@@ -44,6 +45,8 @@ enum ToolOutputFormatter {
     ) -> [String] {
         guard let scope, !scope.rootMappings.isEmpty else { return [] }
         let action = switch operation {
+        case .codeStructure:
+            "codemap scans use"
         case .fileTree:
             "filesystem reads use"
         case .search:
@@ -2573,8 +2576,9 @@ extension ToolOutputFormatter {
             let tokenBudgetOmitted = dto.tokenBudgetOmittedCount ?? 0
             let totalOmitted = dto.omittedTotal ?? (maxResultsOmitted + tokenBudgetOmitted)
             let hasRenderableResult = dto.fileCount > 0 || totalOmitted > 0
+            let hasPendingRepair = dto.pendingPaths?.isEmpty == false
             var out: [String] = []
-            out.append("## Code Structure \(statusIcon(success: hasRenderableResult))")
+            out.append("## Code Structure \(statusIcon(success: hasRenderableResult, warning: hasPendingRepair))")
             out.append("- **Files with codemap**: \(dto.fileCount)")
             switch (maxResultsOmitted, tokenBudgetOmitted) {
             case let (maxOmitted, 0) where maxOmitted > 0:
@@ -2586,6 +2590,19 @@ extension ToolOutputFormatter {
                 out.append("- **Guidance**: Increase `max_results` to consider more files, or narrow `paths` to change which files fit inside the response cap.")
             default:
                 break
+            }
+            out.append(contentsOf: worktreeScopeLines(dto.worktreeScope, operation: .codeStructure))
+            if let pending = dto.pendingPaths, !pending.isEmpty {
+                out.append("- **Codemap repair pending**: \(pending.count) (bounded wait expired; retry with narrower `paths` if needed)")
+                out.append("")
+                out.append("### Files still awaiting codemap")
+                let grouped = groupPathsByRoot(pending)
+                for (root, paths) in grouped {
+                    out.append("- **\(root)**")
+                    for p in paths {
+                        out.append("  - `\(p)`")
+                    }
+                }
             }
             if let unmapped = dto.unmappedPaths, !unmapped.isEmpty {
                 out.append("- **Without codemap**: \(unmapped.count)")

--- a/Sources/RepoPrompt/Infrastructure/MCP/ToolOutputFormatter.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ToolOutputFormatter.swift
@@ -44,21 +44,21 @@ enum ToolOutputFormatter {
         operation: WorktreeScopeOperation
     ) -> [String] {
         guard let scope, !scope.rootMappings.isEmpty else { return [] }
-        let action = switch operation {
+        let scopeDescription = switch operation {
         case .codeStructure:
-            "codemap scans use"
+            "codemap scans use that bound checkout"
         case .fileTree:
-            "filesystem reads use"
+            "filesystem reads use that bound checkout"
         case .search:
-            "filesystem searches use"
+            "filesystem searches use that bound checkout"
         case .readFile:
-            "filesystem reads use"
+            "filesystem reads use that bound checkout"
         case .workspaceContext:
-            "filesystem-derived sections use"
+            "filesystem-derived sections use that bound checkout"
         }
 
         var lines: [String] = []
-        lines.append("- **Scope**: session-bound worktree. Displayed paths use logical/canonical roots; \(action) the effective worktree roots below.")
+        lines.append("- **Scope**: session-bound worktree. Displayed paths use logical/canonical roots; \(scopeDescription).")
         lines.append("- **Root remapping**:")
         for mapping in scope.rootMappings {
             var details = ["worktree `\(mapping.worktreeID)`"]
@@ -71,7 +71,7 @@ enum ToolOutputFormatter {
             if let label = nonEmpty(mapping.label) {
                 details.append("label `\(label)`")
             }
-            lines.append("  - `\(mapping.logicalRootName)` `\(mapping.logicalRootPath)` → `\(mapping.effectiveRootName)` `\(mapping.effectiveRootPath)` (\(details.joined(separator: ", ")))")
+            lines.append("  - `\(mapping.logicalRootName)` `\(mapping.logicalRootPath)` → session-bound worktree (\(details.joined(separator: ", ")))")
         }
         return lines
     }
@@ -2593,7 +2593,7 @@ extension ToolOutputFormatter {
             }
             out.append(contentsOf: worktreeScopeLines(dto.worktreeScope, operation: .codeStructure))
             if let pending = dto.pendingPaths, !pending.isEmpty {
-                out.append("- **Codemap repair pending**: \(pending.count) (bounded wait expired; retry with narrower `paths` if needed)")
+                out.append("- **Codemap generation pending**: \(pending.count) (retry with narrower `paths` if needed)")
                 out.append("")
                 out.append("### Files still awaiting codemap")
                 let grouped = groupPathsByRoot(pending)

--- a/Sources/RepoPrompt/Infrastructure/MCP/ToolResultDTOs.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ToolResultDTOs.swift
@@ -271,6 +271,8 @@ enum ToolResultDTOs {
         let content: String
         /// Paths (display-form) that are selected but have **no codemap** available
         let unmappedPaths: [String]?
+        /// Paths whose targeted codemap repair did not finish before the bounded wait expired
+        let pendingPaths: [String]?
         /// Number of additional files with codemaps omitted due to `max_results` cap
         let omittedCount: Int?
         /// Total number of codemaps omitted due to all limits
@@ -279,33 +281,40 @@ enum ToolResultDTOs {
         let tokenBudgetOmittedCount: Int?
         /// Indicates the response token budget prevented more codemaps from being emitted
         let tokenBudgetHit: Bool?
+        let worktreeScope: WorktreeScopeDTO?
 
         init(
             fileCount: Int,
             content: String,
             unmappedPaths: [String]? = nil,
+            pendingPaths: [String]? = nil,
             omittedCount: Int? = nil,
             omittedTotal: Int? = nil,
             tokenBudgetOmittedCount: Int? = nil,
-            tokenBudgetHit: Bool? = nil
+            tokenBudgetHit: Bool? = nil,
+            worktreeScope: WorktreeScopeDTO? = nil
         ) {
             self.fileCount = fileCount
             self.content = content
             self.unmappedPaths = unmappedPaths
+            self.pendingPaths = pendingPaths
             self.omittedCount = omittedCount
             self.omittedTotal = omittedTotal
             self.tokenBudgetOmittedCount = tokenBudgetOmittedCount
             self.tokenBudgetHit = tokenBudgetHit
+            self.worktreeScope = worktreeScope
         }
 
         private enum CodingKeys: String, CodingKey {
             case fileCount = "file_count"
             case content
             case unmappedPaths = "unmapped_paths"
+            case pendingPaths = "pending_paths"
             case omittedCount = "codemaps_omitted"
             case omittedTotal = "omitted_total"
             case tokenBudgetOmittedCount = "token_budget_omitted"
             case tokenBudgetHit = "token_budget_hit"
+            case worktreeScope = "worktree_scope"
         }
     }
 

--- a/Sources/RepoPrompt/Infrastructure/MCP/ToolResultDTOs.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ToolResultDTOs.swift
@@ -271,7 +271,7 @@ enum ToolResultDTOs {
         let content: String
         /// Paths (display-form) that are selected but have **no codemap** available
         let unmappedPaths: [String]?
-        /// Paths whose targeted codemap repair did not finish before the bounded wait expired
+        /// Paths still awaiting a codemap after repair scheduling
         let pendingPaths: [String]?
         /// Number of additional files with codemaps omitted due to `max_results` cap
         let omittedCount: Int?

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+SelectionCore.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+SelectionCore.swift
@@ -733,7 +733,7 @@ extension MCPServerViewModel {
 
     struct CodeStructureBuilder {
         unowned let owner: MCPServerViewModel
-        let projection: WorkspaceRootBindingProjection?
+        let lookupContext: WorkspaceLookupContext
 
         func build(for files: [WorkspaceFileRecord]) async throws -> ToolResultDTOs.SelectedCodeStructureDTO? {
             guard !files.isEmpty else { return nil }
@@ -744,7 +744,7 @@ extension MCPServerViewModel {
                 fromRecords: files,
                 maxResults: 25,
                 includeUnmappedPaths: true,
-                projection: projection
+                lookupContext: lookupContext
             )
         }
     }

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+SelectionCore.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+SelectionCore.swift
@@ -83,14 +83,16 @@ extension MCPServerViewModel {
 
     @MainActor
     func lookupContext(for context: TabContextSnapshot) async -> WorkspaceLookupContext {
-        guard let sessionID = context.activeAgentSessionID,
-              !context.worktreeBindings.isEmpty,
-              let projection = await materializeWorkspaceBindingProjection(sessionID: sessionID, bindings: context.worktreeBindings),
-              !projection.isEmpty
-        else {
-            return .visibleWorkspace
+        if let frozenLookupContext = context.frozenLookupContext {
+            return frozenLookupContext
         }
-        return WorkspaceLookupContext(rootScope: projection.lookupRootScope, bindingProjection: projection)
+        return await AgentWorkspaceLookupContextResolver.authoritativeLookupContextOrFailClosed(
+            source: AgentWorkspaceLookupContextSource(
+                activeAgentSessionID: context.activeAgentSessionID,
+                worktreeBindingState: context.worktreeBindingState
+            ),
+            store: promptVM.workspaceFileContextStore
+        )
     }
 
     @MainActor
@@ -235,8 +237,17 @@ extension MCPServerViewModel {
             )
         }
 
-        private static func pathMetadata(for file: WorkspaceFileRecord, entry: ResolvedPromptFileEntry? = nil) -> (rootPath: String, pathWithinRoot: String) {
-            (entry?.rootFolderPath.map { StandardizedPath.absolute($0) } ?? (file.standardizedFullPath as NSString).deletingLastPathComponent, file.standardizedRelativePath)
+        private static func pathMetadata(
+            for file: WorkspaceFileRecord,
+            entry: ResolvedPromptFileEntry? = nil,
+            projection: WorkspaceRootBindingProjection? = nil
+        ) -> (rootPath: String, pathWithinRoot: String) {
+            if let projected = projection?.projectedLogicalRootMetadata(forPhysicalPath: file.standardizedFullPath) {
+                return projected
+            }
+            let rootPath = entry?.rootFolderPath.map { StandardizedPath.absolute($0) }
+                ?? (file.standardizedFullPath as NSString).deletingLastPathComponent
+            return (rootPath, file.standardizedRelativePath)
         }
 
         /// Computes how a file would render under a given codemap usage mode
@@ -337,7 +348,7 @@ extension MCPServerViewModel {
             for entry in collections.selected {
                 let file = entry.file
                 let displayPath = await formatter.displayPath(for: file)
-                let metadata = pathMetadata(for: file, entry: entry.entry)
+                let metadata = pathMetadata(for: file, entry: entry.entry, projection: formatter.projection)
                 let ranges = entry.ranges ?? []
                 let hasSlices = !ranges.isEmpty
                 let entryResult = entryResultsByFileID?[file.id]
@@ -423,7 +434,7 @@ extension MCPServerViewModel {
             for entry in collections.codemap {
                 let file = entry.file
                 let displayPath = await formatter.displayPath(for: file)
-                let metadata = pathMetadata(for: file, entry: entry.entry)
+                let metadata = pathMetadata(for: file, entry: entry.entry, projection: formatter.projection)
                 let entryResult = entryResultsByFileID?[file.id]
                 let tokenCount: Int
                 if let entryResult {
@@ -675,7 +686,7 @@ extension MCPServerViewModel {
                 guard !ranges.isEmpty else { continue }
 
                 let displayPath = await formatter.displayPath(for: file)
-                let metadata = pathMetadata(for: file, entry: entry.entry)
+                let metadata = pathMetadata(for: file, entry: entry.entry, projection: formatter.projection)
                 let dtoRanges = ranges.map { ToolResultDTOs.LineRangeDTO(range: $0) }
                 slices.append(.init(
                     path: displayPath,

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+SelectionReply.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+SelectionReply.swift
@@ -68,7 +68,8 @@ extension MCPServerViewModel {
     @MainActor
     func evaluateVirtualPromptEntries(
         for selection: StoredSelection,
-        codeMapUsage: CodeMapUsage
+        codeMapUsage: CodeMapUsage,
+        rootScope: WorkspaceLookupRootScope = .allLoaded
     ) async -> PromptEntriesEvaluation {
         let store = promptVM.workspaceFileContextStore
         let accountingService = PromptContextAccountingService()
@@ -76,7 +77,7 @@ extension MCPServerViewModel {
             selection: selection,
             codeMapUsage: codeMapUsage,
             filePathDisplay: promptVM.filePathDisplayOption,
-            rootScope: .allLoaded,
+            rootScope: rootScope,
             pathLocateProfile: .uiAssisted
         )
         let accounting = await accountingService.calculatePromptStats(request: request, store: store)
@@ -270,7 +271,8 @@ extension MCPServerViewModel {
         let collections = await SelectionReplyAssembler.collect(from: source, owner: self, rootScope: lookupContext.rootScope)
         let evaluation = await evaluateVirtualPromptEntries(
             for: effectiveSelection,
-            codeMapUsage: collections.codeMapUsage
+            codeMapUsage: collections.codeMapUsage,
+            rootScope: lookupContext.rootScope
         )
         let formatter = PathFormatter(format: display, owner: self, projection: lookupContext.bindingProjection)
         let tokens = TokenServices(owner: self)
@@ -435,7 +437,8 @@ extension MCPServerViewModel {
             fileCount: 0,
             content: "",
             unmappedPaths: unmapped,
-            omittedCount: nil
+            omittedCount: nil,
+            worktreeScope: ToolResultDTOs.WorktreeScopeDTO.sessionBound(from: projection)
         )
     }
 }

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+SelectionReply.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+SelectionReply.swift
@@ -88,22 +88,24 @@ extension MCPServerViewModel {
     @MainActor
     private func virtualSelectionFileTreeText(
         selection: StoredSelection,
-        resolvedContext: PromptContextResolved
+        resolvedContext: PromptContextResolved,
+        lookupContext: WorkspaceLookupContext
     ) async -> String {
         guard resolvedContext.rendersFileTree else { return "" }
         let store = promptVM.workspaceFileContextStore
-        let snapshot = await store.makeFileTreeSelectionSnapshot(
-            selection: selection,
+        let rawSnapshot = await store.makeFileTreeSelectionSnapshot(
+            selection: lookupContext.physicalizeSelection(selection),
             request: WorkspaceFileTreeSnapshotRequest(
                 mode: WorkspaceFileTreeSnapshotMode(fileTreeOption: resolvedContext.effectiveFileTreeMode),
                 filePathDisplay: promptVM.filePathDisplayOption,
                 onlyIncludeRootsWithSelectedFiles: promptVM.onlyIncludeRootsWithSelectedFiles,
                 includeLegend: true,
                 showCodeMapMarkers: !promptVM.codeMapsGloballyDisabled,
-                rootScope: .allLoaded
+                rootScope: lookupContext.rootScope
             ),
             profile: .uiAssisted
         )
+        let snapshot = lookupContext.bindingProjection?.logicalizeFileTreeSnapshot(rawSnapshot) ?? rawSnapshot
         return await Task.detached(priority: .userInitiated) {
             CodeMapExtractor.generateFileTree(using: snapshot)
         }.value
@@ -112,22 +114,26 @@ extension MCPServerViewModel {
     @MainActor
     private func virtualSelectionGitDiffText(
         for selection: StoredSelection,
-        resolvedContext: PromptContextResolved
+        resolvedContext: PromptContextResolved,
+        lookupContext: WorkspaceLookupContext
     ) async -> String? {
         switch resolvedContext.gitInclusion {
         case .none:
             return nil
         case .selected:
             let selectedPaths = await WorkspaceGitDiffSelectionResolver.selectedGitDiffPaths(
-                for: selection,
+                for: lookupContext.physicalizeSelection(selection),
                 store: promptVM.workspaceFileContextStore,
-                rootScope: .allLoaded,
+                rootScope: lookupContext.rootScope,
                 folderPolicy: .filesOnly,
                 profile: .mcpSelection,
-                allowFilesystemFallback: WorkspaceLookupRootScope.allLoaded.allowsSelectedGitDiffFilesystemFallback
+                allowFilesystemFallback: lookupContext.rootScope.allowsSelectedGitDiffFilesystemFallback
             )
             return await promptVM.gitViewModel.getDiffForAbsolutePaths(selectedPaths, forceRefreshStatus: true)
         case .complete:
+            guard lookupContext.bindingProjection == nil else {
+                return PromptContextGitDiffPolicy.deferredCompleteWorktreeGitDiffMessage
+            }
             return await promptVM.gitViewModel.getDiffUsing(inclusionMode: .all, forceRefreshStatus: true)
         }
     }
@@ -137,7 +143,8 @@ extension MCPServerViewModel {
         for context: TabScopedContext,
         resolvedContext: PromptContextResolved,
         selectedFiles: [WorkspaceFileRecord],
-        codemapFiles: [WorkspaceFileRecord]
+        codemapFiles: [WorkspaceFileRecord],
+        lookupContext: WorkspaceLookupContext
     ) async -> TokenComponentBreakdown {
         let selectedInstructionsText = promptVM.metaInstructions(
             for: resolvedContext,
@@ -147,10 +154,18 @@ extension MCPServerViewModel {
         .joined(separator: "\n\n")
         let isActiveWorkspaceBound = context.workspaceID == nil || context.workspaceID == workspaceManager?.activeWorkspace?.id
         let fileTreeText = isActiveWorkspaceBound
-            ? await virtualSelectionFileTreeText(selection: context.selection, resolvedContext: resolvedContext)
+            ? await virtualSelectionFileTreeText(
+                selection: context.selection,
+                resolvedContext: resolvedContext,
+                lookupContext: lookupContext
+            )
             : ""
         let gitDiffText = isActiveWorkspaceBound
-            ? await virtualSelectionGitDiffText(for: context.selection, resolvedContext: resolvedContext)
+            ? await virtualSelectionGitDiffText(
+                for: context.selection,
+                resolvedContext: resolvedContext,
+                lookupContext: lookupContext
+            )
             : nil
         let promptText = resolvedContext.includeUserPrompt ? context.promptText : ""
         let duplicateUserPrompt = resolvedContext.includeUserPrompt ? promptVM.duplicateUserInstructionsAtTop : false
@@ -170,7 +185,8 @@ extension MCPServerViewModel {
         filesReply: ToolResultDTOs.SelectedFilesReply,
         resolvedContext: PromptContextResolved,
         selectedFiles: [WorkspaceFileRecord],
-        codemapFiles: [WorkspaceFileRecord]
+        codemapFiles: [WorkspaceFileRecord],
+        lookupContext: WorkspaceLookupContext
     ) async -> ToolResultDTOs.TokenStats {
         let filesContentTokens = (filesReply.summary?.fullTokens ?? 0) + (filesReply.summary?.sliceTokens ?? 0)
         let codemapsTokens = filesReply.summary?.codemapTokens ?? 0
@@ -178,7 +194,8 @@ extension MCPServerViewModel {
             for: context,
             resolvedContext: resolvedContext,
             selectedFiles: selectedFiles,
-            codemapFiles: codemapFiles
+            codemapFiles: codemapFiles,
+            lookupContext: lookupContext
         )
         return Self.makeTokenStats(
             filesTokens: filesReply.totalTokens,
@@ -266,6 +283,7 @@ extension MCPServerViewModel {
         } else {
             WorkspaceLookupContext.visibleWorkspace
         }
+        _ = await promptVM.workspaceFileContextStore.awaitAppliedIngress(rootScope: lookupContext.rootScope)
         let effectiveSelection = lookupContext.physicalizeSelection(selection)
         let source = StoredSelectionSource(stored: effectiveSelection, codeMapUsage: effectiveOverride)
         let collections = await SelectionReplyAssembler.collect(from: source, owner: self, rootScope: lookupContext.rootScope)
@@ -301,7 +319,8 @@ extension MCPServerViewModel {
                 filesReply: filesReply,
                 resolvedContext: promptVM.resolvePromptContext(),
                 selectedFiles: selectedFiles,
-                codemapFiles: codemapFiles
+                codemapFiles: codemapFiles,
+                lookupContext: lookupContext
             )
         } else {
             tokenStatsOverride = nil

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+TabContext.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+TabContext.swift
@@ -993,7 +993,7 @@ extension MCPServerViewModel {
             return workspaceManager?.activeWorkspace?.id
         }()
 
-        var context = makeTabContextSnapshot(
+        let context = makeTabContextSnapshot(
             from: snapshot,
             workspaceID: resolvedWorkspaceID,
             windowID: windowID,
@@ -1002,7 +1002,46 @@ extension MCPServerViewModel {
             captureActiveUIState: false,
             flushActiveSelection: false
         )
+        return installTabContext(
+            clientID: clientID,
+            clientName: clientName,
+            windowID: windowID,
+            context: context,
+            signalRouting: signalRouting,
+            deferRunIDReplacementForPendingPolicy: deferRunIDReplacementForPendingPolicy
+        )
+    }
 
+    @MainActor
+    @discardableResult
+    func installFrozenTabContext(
+        clientID: String?,
+        clientName: String?,
+        context: TabContextSnapshot,
+        signalRouting: Bool = true,
+        deferRunIDReplacementForPendingPolicy: Bool = false
+    ) -> PendingPolicyRunIDMappingToken? {
+        tabContextLog("installFrozenTabContext tab=\(context.tabID) window=\(context.windowID) clientID=\(clientID ?? "nil") clientName=\(clientName ?? "nil") runID=\(context.runID?.uuidString ?? "nil")")
+        return installTabContext(
+            clientID: clientID,
+            clientName: clientName,
+            windowID: context.windowID,
+            context: context,
+            signalRouting: signalRouting,
+            deferRunIDReplacementForPendingPolicy: deferRunIDReplacementForPendingPolicy
+        )
+    }
+
+    @MainActor
+    private func installTabContext(
+        clientID: String?,
+        clientName: String?,
+        windowID: Int,
+        context initialContext: TabContextSnapshot,
+        signalRouting: Bool,
+        deferRunIDReplacementForPendingPolicy: Bool
+    ) -> PendingPolicyRunIDMappingToken? {
+        var context = initialContext
         if let clientID,
            let uuid = UUID(uuidString: clientID)
         {

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+TabContext.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+TabContext.swift
@@ -53,14 +53,23 @@ extension MCPServerViewModel {
         var selectionRevision: UInt64
         /// Selected stored prompt IDs for computing meta tokens in tab-context snapshots.
         var selectedMetaPromptIDs: [UUID]
+        /// Selected Context Builder prompt IDs. These are distinct from StoredPrompt IDs.
+        var selectedContextBuilderPromptIDs: [UUID]
         /// Tab name for MCP metadata block generation.
         var tabName: String
         /// Optional run lease associated with this snapshot.
         var runID: UUID?
         /// Active persisted Agent session bound to this tab, if any.
         var activeAgentSessionID: UUID?
-        /// Worktree bindings for the active Agent session at snapshot time.
-        var worktreeBindings: [AgentSessionWorktreeBinding]
+        /// Hydration-aware worktree binding state for the active Agent session at snapshot time.
+        var worktreeBindingState: AgentSessionWorktreeBindingState
+        var worktreeBindings: [AgentSessionWorktreeBinding] {
+            get { worktreeBindingState.bindings ?? [] }
+            set { worktreeBindingState = .hydrated(newValue) }
+        }
+
+        /// Frozen lookup context inherited by nested run-scoped tools.
+        var frozenLookupContext: WorkspaceLookupContext?
         /// True if this snapshot was created via explicit `bind_context` / `_tabID` binding.
         /// Explicit bindings should persist even when the bound tab is not the active tab.
         let explicitlyBound: Bool
@@ -76,10 +85,13 @@ extension MCPServerViewModel {
             selection: StoredSelection,
             selectionRevision: UInt64 = 0,
             selectedMetaPromptIDs: [UUID],
+            selectedContextBuilderPromptIDs: [UUID] = [],
             tabName: String,
             runID: UUID?,
             activeAgentSessionID: UUID? = nil,
             worktreeBindings: [AgentSessionWorktreeBinding] = [],
+            worktreeBindingState: AgentSessionWorktreeBindingState? = nil,
+            frozenLookupContext: WorkspaceLookupContext? = nil,
             explicitlyBound: Bool,
             readFileAutoSelectionGeneration: UInt64 = 0
         ) {
@@ -90,10 +102,13 @@ extension MCPServerViewModel {
             self.selection = selection
             self.selectionRevision = selectionRevision
             self.selectedMetaPromptIDs = selectedMetaPromptIDs
+            self.selectedContextBuilderPromptIDs = selectedContextBuilderPromptIDs
             self.tabName = tabName
             self.runID = runID
             self.activeAgentSessionID = activeAgentSessionID
-            self.worktreeBindings = worktreeBindings
+            self.worktreeBindingState = worktreeBindingState
+                ?? (activeAgentSessionID == nil ? .notApplicable : .hydrated(worktreeBindings))
+            self.frozenLookupContext = frozenLookupContext
             self.explicitlyBound = explicitlyBound
             self.readFileAutoSelectionGeneration = readFileAutoSelectionGeneration
         }
@@ -775,10 +790,10 @@ extension MCPServerViewModel {
         }
 
         let storedSnapshot = stored.snapshot
-        let worktreeBindings = storedSnapshot.activeAgentSessionID.map {
-            agentWorktreeBindingsProvider?($0, storedSnapshot.id) ?? []
-        } ?? []
-        let preserveStoredSelection = !worktreeBindings.isEmpty
+        let storedWorktreeBindingState = storedSnapshot.activeAgentSessionID.map {
+            agentWorktreeBindingStateProvider?($0, storedSnapshot.id) ?? .unhydrated
+        } ?? .notApplicable
+        let preserveStoredSelection = storedWorktreeBindingState.bindings?.isEmpty == false
         let captured = manager.collectMCPTabContextComposeSnapshot(
             tabID: tabID,
             workspaceID: stored.workspaceID,
@@ -802,10 +817,13 @@ extension MCPServerViewModel {
                 tabID: snapshot.id
             ),
             selectedMetaPromptIDs: snapshot.selectedMetaPromptIDs,
+            selectedContextBuilderPromptIDs: snapshot.contextBuilder.selectedContextBuilderPromptIDs,
             tabName: snapshot.name,
             runID: runID,
             activeAgentSessionID: snapshot.activeAgentSessionID,
-            worktreeBindings: worktreeBindings,
+            worktreeBindingState: snapshot.activeAgentSessionID.map {
+                agentWorktreeBindingStateProvider?($0, snapshot.id) ?? .unhydrated
+            } ?? .notApplicable,
             explicitlyBound: explicitlyBound
         )
     }
@@ -848,10 +866,13 @@ extension MCPServerViewModel {
                     tabID: snapshot.id
                 ) ?? 0,
                 selectedMetaPromptIDs: snapshot.selectedMetaPromptIDs,
+                selectedContextBuilderPromptIDs: snapshot.contextBuilder.selectedContextBuilderPromptIDs,
                 tabName: snapshot.name,
                 runID: runID,
                 activeAgentSessionID: snapshot.activeAgentSessionID,
-                worktreeBindings: snapshot.activeAgentSessionID.map { agentWorktreeBindingsProvider?($0, snapshot.id) ?? [] } ?? [],
+                worktreeBindingState: snapshot.activeAgentSessionID.map {
+                    agentWorktreeBindingStateProvider?($0, snapshot.id) ?? .unhydrated
+                } ?? .notApplicable,
                 explicitlyBound: explicitlyBound
             )
         }
@@ -869,10 +890,13 @@ extension MCPServerViewModel {
                 ) ?? 0
             } ?? 0,
             selectedMetaPromptIDs: composeSnapshot.selectedMetaPromptIDs,
+            selectedContextBuilderPromptIDs: composeSnapshot.contextBuilder.selectedContextBuilderPromptIDs,
             tabName: composeSnapshot.name,
             runID: runID,
             activeAgentSessionID: composeSnapshot.activeAgentSessionID,
-            worktreeBindings: composeSnapshot.activeAgentSessionID.map { agentWorktreeBindingsProvider?($0, composeSnapshot.id) ?? [] } ?? [],
+            worktreeBindingState: composeSnapshot.activeAgentSessionID.map {
+                agentWorktreeBindingStateProvider?($0, composeSnapshot.id) ?? .unhydrated
+            } ?? .notApplicable,
             explicitlyBound: explicitlyBound
         )
     }
@@ -1385,6 +1409,10 @@ extension MCPServerViewModel {
         }
         var merged = latest
         merged.selection = context.selection
+        merged.selectedContextBuilderPromptIDs = context.selectedContextBuilderPromptIDs
+        merged.activeAgentSessionID = context.activeAgentSessionID
+        merged.worktreeBindingState = context.worktreeBindingState
+        merged.frozenLookupContext = context.frozenLookupContext
         merged.readFileAutoSelectionGeneration = context.readFileAutoSelectionGeneration
         return merged
     }
@@ -1673,18 +1701,23 @@ extension MCPServerViewModel {
             policy: .allowLegacyImplicitRouting
         )
         let baseScope = Self.resolveFileToolLookupRootScope(purpose: purpose, resolvedContext: resolved)
-        guard let resolved,
-              let sessionID = resolved.snapshot.activeAgentSessionID,
-              !resolved.snapshot.worktreeBindings.isEmpty,
-              let projection = await materializeWorkspaceBindingProjection(
-                  sessionID: sessionID,
-                  bindings: resolved.snapshot.worktreeBindings
-              ),
-              !projection.isEmpty
-        else {
+        guard let resolved else {
             return WorkspaceLookupContext(rootScope: baseScope, bindingProjection: nil)
         }
-        return WorkspaceLookupContext(rootScope: projection.lookupRootScope, bindingProjection: projection)
+        if let frozenLookupContext = resolved.snapshot.frozenLookupContext {
+            return frozenLookupContext
+        }
+        let lookupContext = await AgentWorkspaceLookupContextResolver.authoritativeLookupContextOrFailClosed(
+            source: AgentWorkspaceLookupContextSource(
+                activeAgentSessionID: resolved.snapshot.activeAgentSessionID,
+                worktreeBindingState: resolved.snapshot.worktreeBindingState
+            ),
+            store: promptVM.workspaceFileContextStore
+        )
+        if lookupContext == .visibleWorkspace, baseScope != .visibleWorkspace {
+            return WorkspaceLookupContext(rootScope: baseScope, bindingProjection: nil)
+        }
+        return lookupContext
     }
 
     @MainActor
@@ -1810,8 +1843,14 @@ extension MCPServerViewModel {
         return targetWindow.agentModeViewModel.mcpSpawnParentSessionID(sourceTabID: sourceTabID)
     }
 
-    private static func tabContextRoutingErrorMessage(toolName: String) -> String {
-        "No tab context is bound for \(toolName). To resolve:\n" +
+    nonisolated static func tabContextRoutingErrorMessage(
+        toolName: String,
+        runPurpose: MCPRunPurpose? = nil
+    ) -> String {
+        if runPurpose == .agentModeRun {
+            return agentModeRoutingRecoveryMessage(toolName: toolName)
+        }
+        return "No tab context is bound for \(toolName). To resolve:\n" +
             "• Call 'bind_context' with op='list' to see available windows and context_id values\n" +
             "• Call 'bind_context' with op='bind' and a context_id to bind this connection to a tab context\n" +
             "• Or pass a matching explicit tab context hint for this tool call"
@@ -1824,7 +1863,15 @@ extension MCPServerViewModel {
             "• Or pass a matching context_id/_tabID hint on this tool call"
     }
 
-    private nonisolated static func runScopedActiveTabCompatibilityMessage(toolName: String, runPurpose: MCPRunPurpose?) -> String {
+    private nonisolated static func agentModeRoutingRecoveryMessage(toolName: String) -> String {
+        "RepoPrompt could not route \(toolName) to the active Agent Mode run. " +
+            "Retry the tool call once. If it fails again, tell the user the RepoPrompt connection failed and ask them to restart this Agent Mode run."
+    }
+
+    nonisolated static func runScopedActiveTabCompatibilityMessage(toolName: String, runPurpose: MCPRunPurpose?) -> String {
+        if runPurpose == .agentModeRun {
+            return agentModeRoutingRecoveryMessage(toolName: toolName)
+        }
         let purpose = runPurpose?.rawValue ?? "run-scoped"
         return "Active-tab compatibility fallback is not allowed for \(toolName) during \(purpose) execution. " +
             "Bind the MCP connection to its invoking tab context with bind_context/context_id, or retry after run-scoped routing is established."
@@ -2023,7 +2070,7 @@ extension MCPServerViewModel {
         }
 
         // 6) Fail closed with routing guidance.
-        throw MCPError.invalidParams(Self.tabContextRoutingErrorMessage(toolName: toolName))
+        throw MCPError.invalidParams(Self.tabContextRoutingErrorMessage(toolName: toolName, runPurpose: runPurpose))
     }
 
     @MainActor
@@ -2047,17 +2094,17 @@ extension MCPServerViewModel {
                 policy: .requireExplicitOrRunScoped
             )
             guard case let .tabContextSnapshot(context, _) = resolution else {
-                throw MCPError.invalidParams(Self.tabContextRoutingErrorMessage(toolName: toolName))
+                throw MCPError.invalidParams(Self.tabContextRoutingErrorMessage(toolName: toolName, runPurpose: purpose))
             }
             windowIDByConnection[connectionID] = context.windowID
             beginMirroringForConnection(connectionID, context: context)
             return (connectionID, context)
         } catch {
             if purpose == .agentModeRun {
-                throw MCPError.invalidParams(
-                    "RepoPrompt could not route this Agent Mode MCP call to the active run. " +
-                        "Retry the tool call once. If it fails again, tell the user the RepoPrompt connection failed and ask them to restart this Agent Mode run."
-                )
+                throw MCPError.invalidParams(Self.tabContextRoutingErrorMessage(
+                    toolName: toolName,
+                    runPurpose: purpose
+                ))
             }
             throw error
         }

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+WorkspaceContext.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+WorkspaceContext.swift
@@ -88,7 +88,7 @@ extension MCPServerViewModel {
 
         var codeStructDTO: ToolResultDTOs.SelectedCodeStructureDTO? = nil
         if include.contains("code"), !promptVM.codeMapsGloballyDisabled, let coll = collections {
-            let builder = CodeStructureBuilder(owner: self, projection: lookupContext.bindingProjection)
+            let builder = CodeStructureBuilder(owner: self, lookupContext: lookupContext)
             let combined = coll.selected.map(\.file) + coll.codemap.map(\.file)
             codeStructDTO = try await builder.build(for: combined)
         }

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+WorkspaceContext.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+WorkspaceContext.swift
@@ -53,7 +53,8 @@ extension MCPServerViewModel {
             let gathered = await SelectionReplyAssembler.collect(from: source, owner: self, rootScope: lookupContext.rootScope)
             let evaluation = await evaluateVirtualPromptEntries(
                 for: effectiveSelection,
-                codeMapUsage: gathered.codeMapUsage
+                codeMapUsage: gathered.codeMapUsage,
+                rootScope: lookupContext.rootScope
             )
             let reply = await SelectionReplyAssembler.buildSelectedFilesReply(
                 collections: gathered,
@@ -66,9 +67,6 @@ extension MCPServerViewModel {
             )
             collections = gathered
             selectionReply = reply
-        } else if includeSelection {
-            // Always use .auto mode for normalized view
-            selectionReply = await (buildTabSelectedFilesReply(from: context.selection, codeMapUsageOverride: .auto)).0
         }
 
         let selectionDTO = includeSelection ? selectionReply : nil
@@ -202,7 +200,8 @@ extension MCPServerViewModel {
                     for: context,
                     resolvedContext: resolvedCfg,
                     selectedFiles: selectedFiles,
-                    codemapFiles: codemapFiles
+                    codemapFiles: codemapFiles,
+                    lookupContext: lookupContext
                 )
                 tokenStatsDTO = Self.makeTokenStats(
                     filesTokens: fileTokens,
@@ -299,7 +298,8 @@ extension MCPServerViewModel {
         let entryResultsByFileID: [UUID: PromptEntriesEvaluation.EntryResult]? = if let evaluationSelection {
             await evaluateVirtualPromptEntries(
                 for: evaluationSelection,
-                codeMapUsage: collections.codeMapUsage
+                codeMapUsage: collections.codeMapUsage,
+                rootScope: lookupContext.rootScope
             ).entryResultsByFileID
         } else {
             nil

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel.swift
@@ -151,6 +151,7 @@ final class MCPServerViewModel: ObservableObject {
 
     // -----------------------------------------------------------------
     private nonisolated static let defaultCodeStructureMaxResults = 10
+    private nonisolated static let maxCodeStructureSelfHealingFiles = 50
     private nonisolated static let codeStructureTokenBudget = 6000
     private nonisolated static let codeStructureSeparatorTokenCost = TokenCalculationService.estimateTokens(for: "\n\n")
 
@@ -194,6 +195,37 @@ final class MCPServerViewModel: ObservableObject {
     private(set) var service: MCPService
     private let logger = Logger(label: "com.repoprompt.mcp")
 
+    #if DEBUG
+        private var oracleChatSendOverrideForTesting: MCPOracleToolService.SendChat?
+        private var oracleReadAutoSelectionDrainObserverForTesting: (() -> Void)?
+        private var contextBuilderFollowUpOverrideForTesting: MCPWindowToolDependencies.RunMCPPlanOrQuestion?
+        private var contextBuilderSelectionReplyObserverForTesting: ((
+            StoredSelection,
+            WorkspaceLookupContext?,
+            ToolResultDTOs.SelectionReply
+        ) -> Void)?
+
+        func setOracleChatSendOverrideForTesting(_ override: MCPOracleToolService.SendChat?) {
+            oracleChatSendOverrideForTesting = override
+        }
+
+        func setOracleReadAutoSelectionDrainObserverForTesting(_ observer: (() -> Void)?) {
+            oracleReadAutoSelectionDrainObserverForTesting = observer
+        }
+
+        func setContextBuilderFollowUpOverrideForTesting(
+            _ override: MCPWindowToolDependencies.RunMCPPlanOrQuestion?
+        ) {
+            contextBuilderFollowUpOverrideForTesting = override
+        }
+
+        func setContextBuilderSelectionReplyObserverForTesting(
+            _ observer: ((StoredSelection, WorkspaceLookupContext?, ToolResultDTOs.SelectionReply) -> Void)?
+        ) {
+            contextBuilderSelectionReplyObserverForTesting = observer
+        }
+    #endif
+
     private var oracleToolService: MCPOracleToolService {
         MCPOracleToolService(
             askOracleToolName: MCPWindowToolName.askOracle,
@@ -229,6 +261,18 @@ final class MCPServerViewModel: ObservableObject {
                     stage: stage,
                     message: message,
                     operation: operation
+                )
+            },
+            sendChat: { [self] args, promptVM, tabContext in
+                #if DEBUG
+                    if let override = oracleChatSendOverrideForTesting {
+                        return try await override(args, promptVM, tabContext)
+                    }
+                #endif
+                return try await oracleVM.tool_chatSend(
+                    args: args,
+                    promptVM: promptVM,
+                    tabContext: tabContext
                 )
             },
             exportOracleResponse: { [self] request in
@@ -609,7 +653,8 @@ final class MCPServerViewModel: ObservableObject {
                 tabID: resolution.tabID,
                 workspaceID: resolution.workspaceID,
                 bindCaller: resolution.bindCaller,
-                lookupContext: resolution.lookupContext
+                lookupContext: resolution.lookupContext,
+                workspaceContext: resolution.workspaceContext
             )
         },
         bindTabForConnection: { [weak self] connectionID, clientName, tabID, workspaceID, windowID in
@@ -622,14 +667,19 @@ final class MCPServerViewModel: ObservableObject {
                 windowID: windowID
             )
         },
-        buildTabSelectionReply: { [weak self] selection, includeBlocks, display, codeMapUsageOverride in
+        buildTabSelectionReply: { [weak self] selection, includeBlocks, display, codeMapUsageOverride, lookupContextOverride in
             guard let self else { throw MCPError.internalError("Window deallocated while building context_builder selection reply") }
-            return await buildTabSelectionReply(
+            let reply = await buildTabSelectionReply(
                 from: selection,
                 includeBlocks: includeBlocks,
                 display: display,
-                codeMapUsageOverride: codeMapUsageOverride
+                codeMapUsageOverride: codeMapUsageOverride,
+                lookupContextOverride: lookupContextOverride
             )
+            #if DEBUG
+                contextBuilderSelectionReplyObserverForTesting?(selection, lookupContextOverride, reply)
+            #endif
+            return reply
         },
         sendStageProgress: { [weak self] connectionID, tool, stage, message in
             guard let self else { return }
@@ -651,14 +701,20 @@ final class MCPServerViewModel: ObservableObject {
             guard let self else { throw MCPError.internalError("Window deallocated while writing Oracle export") }
             return try await writeGeneratedOracleExportFile(path: path, content: content, destination: destination)
         },
-        runMCPPlanOrQuestion: { [weak self] contextBuilderVM, tabID, mode, prompt, selection, progressReporter, activityReporter in
+        runMCPPlanOrQuestion: { [weak self] contextBuilderVM, tabID, mode, prompt, selection, lookupContext, progressReporter, activityReporter in
             guard let self else { throw MCPError.internalError("Window deallocated while generating context_builder response") }
+            #if DEBUG
+                if let override = contextBuilderFollowUpOverrideForTesting {
+                    return try await override(contextBuilderVM, tabID, mode, prompt, selection, lookupContext)
+                }
+            #endif
             return try await contextBuilderVM.runMCPPlanOrQuestion(
                 for: tabID,
                 oracleViewModel: oracleVM,
                 mode: mode,
                 prompt: prompt,
                 selection: selection,
+                lookupContext: lookupContext,
                 progressReporter: progressReporter,
                 activityReporter: activityReporter
             )
@@ -794,9 +850,14 @@ final class MCPServerViewModel: ObservableObject {
             guard let self else { throw MCPError.internalError("Window deallocated while performing file action") }
             return try await performFileAction(action: action, path: path, content: content, newPath: newPath, ifExists: ifExists)
         },
-        buildCodeStructureDTO: { [weak self] files, maxResults, includeUnmappedPaths, projection in
+        buildCodeStructureDTO: { [weak self] files, maxResults, includeUnmappedPaths, lookupContext in
             guard let self else { throw MCPError.internalError("Window deallocated while building code structure") }
-            return try await buildCodeStructureDTO(fromRecords: files, maxResults: maxResults, includeUnmappedPaths: includeUnmappedPaths, projection: projection)
+            return try await buildCodeStructureDTO(
+                fromRecords: files,
+                maxResults: maxResults,
+                includeUnmappedPaths: includeUnmappedPaths,
+                lookupContext: lookupContext
+            )
         },
         resolveFilesForCodeStructure: { [weak self] paths, lookupRootScope in
             guard let self else { throw MCPError.internalError("Window deallocated while resolving code structure files") }
@@ -2694,7 +2755,13 @@ final class MCPServerViewModel: ObservableObject {
         args: [String: Value],
         targetWindow: WindowState,
         connectionID: UUID?
-    ) async throws -> (tabID: UUID, workspaceID: UUID?, bindCaller: Bool, lookupContext: WorkspaceLookupContext) {
+    ) async throws -> (
+        tabID: UUID,
+        workspaceID: UUID?,
+        bindCaller: Bool,
+        lookupContext: WorkspaceLookupContext,
+        workspaceContext: ContextBuilderWorkspaceContext?
+    ) {
         let purpose: MCPRunPurpose = if let connectionID {
             await ServerNetworkManager.shared.runPurpose(for: connectionID)
         } else {
@@ -2713,6 +2780,9 @@ final class MCPServerViewModel: ObservableObject {
            existingBinding.tabID != explicitHint.tabID
         {
             throw MCPError.invalidParams("Explicit tab context hint for context_builder targets tab \(explicitHint.tabID), but this connection is already bound to tab \(existingBinding.tabID?.uuidString ?? "unknown"). Clear or intentionally rebind the connection before targeting a different tab context.")
+        }
+        if purpose == .agentModeRun, explicitHint != nil {
+            throw MCPError.invalidParams("Agent Mode context_builder cannot replace the invoking run-scoped tab context with an explicit context_id. Retry without an explicit context override.")
         }
 
         let clientName: String? = if let connectionID {
@@ -2738,19 +2808,39 @@ final class MCPServerViewModel: ObservableObject {
                 throw MCPError.invalidParams("Tab context '\(context.tabID.uuidString)' is not available in window \(targetWindow.windowID).")
             }
             let shouldBindCaller = source == .explicitHint && purpose != .agentModeRun && connectionID != nil
-            let lookupContext = try await targetWindow.mcpServer.resolveFileToolLookupContext(
-                tabID: context.tabID,
-                workspaceID: context.workspaceID
-            )
-            return (context.tabID, context.workspaceID, shouldBindCaller, lookupContext)
-        } catch {
-            if explicitHint != nil || existingBinding != nil {
-                throw error
-            }
+            let workspaceContext: ContextBuilderWorkspaceContext?
             if purpose == .agentModeRun {
-                throw MCPError.invalidParams(
-                    "context_builder could not resolve the invoking agent-mode tab context. Retry after routing settles, or pass context_id explicitly."
+                guard let workspaceID = context.workspaceID,
+                      let workspace = targetWindow.workspaceManager.workspaces.first(where: { $0.id == workspaceID })
+                else {
+                    throw MCPError.invalidParams("context_builder could not resolve the invoking Agent Mode workspace.")
+                }
+                do {
+                    workspaceContext = try await ContextBuilderWorkspaceContext.resolve(
+                        from: context,
+                        workspaceRepoPaths: workspace.repoPaths,
+                        store: targetWindow.promptManager.workspaceFileContextStore
+                    )
+                } catch {
+                    throw MCPError.invalidParams(error.localizedDescription)
+                }
+            } else {
+                workspaceContext = nil
+            }
+
+            let lookupContext: WorkspaceLookupContext
+            if let workspaceContext {
+                lookupContext = workspaceContext.lookupContext
+            } else {
+                lookupContext = try await targetWindow.mcpServer.resolveFileToolLookupContext(
+                    tabID: context.tabID,
+                    workspaceID: context.workspaceID
                 )
+            }
+            return (context.tabID, context.workspaceID, shouldBindCaller, lookupContext, workspaceContext)
+        } catch {
+            if explicitHint != nil || existingBinding != nil || purpose == .agentModeRun {
+                throw error
             }
         }
 
@@ -2762,7 +2852,13 @@ final class MCPServerViewModel: ObservableObject {
         ) else {
             throw MCPError.internalError("Failed to create compose tab.")
         }
-        return (createdTab.id, targetWindow.workspaceManager.activeWorkspace?.id, true, .visibleWorkspace)
+        return (
+            createdTab.id,
+            targetWindow.workspaceManager.activeWorkspace?.id,
+            true,
+            .visibleWorkspace,
+            nil
+        )
     }
 
     /// Runs an async operation with periodic heartbeat emissions to prevent agent timeouts.
@@ -3569,8 +3665,15 @@ final class MCPServerViewModel: ObservableObject {
         fromRecords files: [WorkspaceFileRecord],
         maxResults: Int,
         includeUnmappedPaths: Bool,
-        projection: WorkspaceRootBindingProjection? = nil
+        lookupContext: WorkspaceLookupContext = .visibleWorkspace,
+        selfHealTimeout: Duration = .seconds(5)
     ) async throws -> ToolResultDTOs.SelectedCodeStructureDTO {
+        struct CodeStructureFile {
+            let file: WorkspaceFileRecord
+            let key: String
+            let displayPath: String
+        }
+
         struct RenderableCodeStructure {
             let key: String
             let displayPath: String
@@ -3580,45 +3683,82 @@ final class MCPServerViewModel: ObservableObject {
 
         try Task.checkCancellation()
         let store = promptVM.workspaceFileContextStore
-        let snapshots = await store.codemapSnapshotDictionary()
-        try Task.checkCancellation()
-        let roots = await store.rootRefs(scope: .allLoaded)
-        try Task.checkCancellation()
-        var renderable: [RenderableCodeStructure] = []
-        var unmappedPaths: [String] = []
-        var seenPaths = Set<String>()
+        switch await store.rootScopeAvailability(lookupContext.rootScope) {
+        case .available:
+            break
+        case let .sessionWorktreeUnavailable(missingPhysicalRootPaths):
+            let paths = missingPhysicalRootPaths.joined(separator: ", ")
+            throw MCPError.invalidParams(
+                "The session-bound worktree root is unavailable: \(paths). get_code_structure stopped rather than reading the canonical checkout."
+            )
+        }
 
+        let roots = await store.rootRefs(scope: lookupContext.rootScope)
+        try Task.checkCancellation()
+        let scopedRootIDs = Set(roots.map(\.id))
+        let requiresScopedRootMembership = if case .sessionBoundWorkspace = lookupContext.rootScope {
+            true
+        } else {
+            false
+        }
+        var codeStructureFiles: [CodeStructureFile] = []
+        var seenPaths = Set<String>()
         for file in files {
             try Task.checkCancellation()
+            guard !requiresScopedRootMembership || scopedRootIDs.contains(file.rootID) else { continue }
             let fullPath = file.standardizedFullPath
             guard seenPaths.insert(fullPath).inserted else { continue }
-            let displayPath: String = if let projection,
-                                         let projected = projection.projectedLogicalDisplayPath(forPhysicalPath: fullPath, display: .relative)
-            {
+            let displayPath: String = if let projected = lookupContext.bindingProjection?.projectedLogicalDisplayPath(
+                forPhysicalPath: fullPath,
+                display: .relative
+            ) {
                 projected
             } else if let root = roots.first(where: { $0.id == file.rootID }) {
                 ClientPathFormatter.displayPath(root: root, relativePath: file.standardizedRelativePath, visibleRoots: roots)
             } else {
                 file.relativePath
             }
-            if let api = snapshots[file.id]?.fileAPI {
-                renderable.append(
-                    RenderableCodeStructure(
-                        key: fullPath,
-                        displayPath: displayPath,
-                        api: api,
-                        estimatedTokens: api.estimatedFullAPIDescriptionTokens(displayPath: displayPath)
-                    )
-                )
-            } else if includeUnmappedPaths {
-                unmappedPaths.append(displayPath)
-            }
+            codeStructureFiles.append(CodeStructureFile(file: file, key: fullPath, displayPath: displayPath))
         }
-
-        try Task.checkCancellation()
-        renderable.sort { lhs, rhs in
+        codeStructureFiles.sort { lhs, rhs in
             if lhs.displayPath == rhs.displayPath { return lhs.key < rhs.key }
             return lhs.displayPath < rhs.displayPath
+        }
+
+        var snapshots = await store.codemapSnapshotDictionary()
+        try Task.checkCancellation()
+        let repairLimit = min(max(0, maxResults), Self.maxCodeStructureSelfHealingFiles)
+        let repairFiles = codeStructureFiles.lazy.filter { item in
+            guard snapshots[item.file.id] == nil else { return false }
+            let ext = (item.file.name as NSString).pathExtension
+            return SyntaxManager.isSupportedFileExtension(ext)
+        }.prefix(repairLimit).map(\.file)
+        let repairResult = try await store.repairMissingCodemapSnapshots(
+            for: Array(repairFiles),
+            timeout: selfHealTimeout
+        )
+        snapshots = repairResult.snapshotsByFileID
+        try Task.checkCancellation()
+
+        var renderable: [RenderableCodeStructure] = []
+        var unmappedPaths: [String] = []
+        var pendingPaths: [String] = []
+        for item in codeStructureFiles {
+            try Task.checkCancellation()
+            if let api = snapshots[item.file.id]?.fileAPI {
+                renderable.append(
+                    RenderableCodeStructure(
+                        key: item.key,
+                        displayPath: item.displayPath,
+                        api: api,
+                        estimatedTokens: api.estimatedFullAPIDescriptionTokens(displayPath: item.displayPath)
+                    )
+                )
+            } else if repairResult.pendingFileIDs.contains(item.file.id) {
+                pendingPaths.append(item.displayPath)
+            } else if includeUnmappedPaths {
+                unmappedPaths.append(item.displayPath)
+            }
         }
 
         let budgetSelection = Self.applyCodeStructureOutputBudget(
@@ -3638,14 +3778,17 @@ final class MCPServerViewModel: ObservableObject {
         try Task.checkCancellation()
         let content = contentParts.joined(separator: "\n\n")
         let sortedUnmapped = includeUnmappedPaths && !unmappedPaths.isEmpty ? unmappedPaths.sorted() : nil
+        let sortedPending = pendingPaths.isEmpty ? nil : pendingPaths.sorted()
         return ToolResultDTOs.SelectedCodeStructureDTO(
             fileCount: budgetSelection.includedKeys.count,
             content: content,
             unmappedPaths: sortedUnmapped,
+            pendingPaths: sortedPending,
             omittedCount: budgetSelection.omittedByMaxResults > 0 ? budgetSelection.omittedByMaxResults : nil,
             omittedTotal: budgetSelection.omittedTotal > 0 ? budgetSelection.omittedTotal : nil,
             tokenBudgetOmittedCount: budgetSelection.omittedByTokenBudget > 0 ? budgetSelection.omittedByTokenBudget : nil,
-            tokenBudgetHit: budgetSelection.omittedByTokenBudget > 0 ? true : nil
+            tokenBudgetHit: budgetSelection.omittedByTokenBudget > 0 ? true : nil,
+            worktreeScope: ToolResultDTOs.WorktreeScopeDTO.sessionBound(from: lookupContext.bindingProjection)
         )
     }
 

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel.swift
@@ -178,10 +178,10 @@ final class MCPServerViewModel: ObservableObject {
     private let oracleVM: OracleViewModel
     let workspaceManager: WorkspaceManagerViewModel?
     let selectionCoordinator: WorkspaceSelectionCoordinator?
-    var agentWorktreeBindingsProvider: (@MainActor (UUID, UUID?) -> [AgentSessionWorktreeBinding])?
+    var agentWorktreeBindingStateProvider: (@MainActor (UUID, UUID?) -> AgentSessionWorktreeBindingState)?
 
-    func registerAgentWorktreeBindingsProvider(_ provider: @escaping @MainActor (UUID, UUID?) -> [AgentSessionWorktreeBinding]) {
-        agentWorktreeBindingsProvider = provider
+    func registerAgentWorktreeBindingsProvider(_ provider: @escaping @MainActor (UUID, UUID?) -> AgentSessionWorktreeBindingState) {
+        agentWorktreeBindingStateProvider = provider
     }
 
     private let workspaceSearch: WorkspaceSearchHandler
@@ -242,7 +242,6 @@ final class MCPServerViewModel: ObservableObject {
                 )
             },
             requireCurrentTabContext: { [self] toolName in try await requireCurrentTabContext(toolName: toolName) },
-            resolveLookupContext: { [self] context in await lookupContext(for: context) },
             rebindChatSessionIfNeeded: { [self] metadata, chatIDString in
                 try rebindOracleChatSessionIfNeeded(metadata: metadata, chatIDString: chatIDString)
             },
@@ -842,9 +841,9 @@ final class MCPServerViewModel: ObservableObject {
             guard let self else { return nil }
             return await persistResolvedTabContextSnapshot(resolvedContext, metadata: metadata, mutated: mutated)
         },
-        makeSelectionHintError: { [weak self] paths, operation, lookupRootScope in
+        makeSelectionHintError: { [weak self] paths, operation, lookupContext in
             guard let self else { return "Window deallocated while resolving selection inputs." }
-            return await makeSelectionHintError(paths: paths, operation: operation, lookupRootScope: lookupRootScope)
+            return await makeSelectionHintError(paths: paths, operation: operation, lookupContext: lookupContext)
         },
         performFileAction: { [weak self] action, path, content, newPath, ifExists in
             guard let self else { throw MCPError.internalError("Window deallocated while performing file action") }
@@ -985,7 +984,7 @@ final class MCPServerViewModel: ObservableObject {
             forTabID: key.tabID,
             inWorkspaceID: key.workspaceID
         ),
-            agentWorktreeBindingsProvider?(sessionID, key.tabID).isEmpty == false
+            agentWorktreeBindingStateProvider?(sessionID, key.tabID).bindings?.isEmpty == false
         {
             // Worktree-only paths cannot be represented by the logical base file tree. Their
             // canonical selection and badge presentation are already updated by persistence.
@@ -3596,21 +3595,25 @@ final class MCPServerViewModel: ObservableObject {
     private func makeSelectionHintError(
         paths: [String],
         operation: String,
-        lookupRootScope: WorkspaceLookupRootScope = .visibleWorkspace
+        lookupContext: WorkspaceLookupContext = .visibleWorkspace
     ) async -> String {
         let trimmed = paths.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }.filter { !$0.isEmpty }
-        let roots = await promptVM.workspaceFileContextStore.rootRefs(scope: lookupRootScope)
+        let roots = await promptVM.workspaceFileContextStore.rootRefs(scope: lookupContext.rootScope)
         if roots.isEmpty {
             return "No workspace is currently loaded in this window. Use the 'manage_workspaces' tool with action: 'list' to see available workspaces, then action: 'switch' to load one."
         }
 
-        let rootSummaries = roots.map { "\($0.name) → \($0.fullPath)" }.joined(separator: "; ")
+        let displayRoots = lookupContext.bindingProjection?.visibleLogicalRootRefs ?? roots
+        let rootSummaries = displayRoots.map { "\($0.name) → \($0.fullPath)" }.joined(separator: "; ")
 
         var outside: [String] = []
-        for p in trimmed where p.hasPrefix("/") {
-            let standardized = StandardizedPath.absolute(p)
-            let under = roots.contains { StandardizedPath.isDescendant(standardized, of: $0.standardizedFullPath) || standardized == $0.standardizedFullPath }
-            if !under { outside.append(p) }
+        for path in trimmed where path.hasPrefix("/") {
+            let standardized = StandardizedPath.absolute(lookupContext.translateInputPath(path))
+            let under = roots.contains {
+                standardized == $0.standardizedFullPath
+                    || StandardizedPath.isDescendant(standardized, of: $0.standardizedFullPath)
+            }
+            if !under { outside.append(path) }
         }
 
         var lines: [String] = []
@@ -3686,10 +3689,9 @@ final class MCPServerViewModel: ObservableObject {
         switch await store.rootScopeAvailability(lookupContext.rootScope) {
         case .available:
             break
-        case let .sessionWorktreeUnavailable(missingPhysicalRootPaths):
-            let paths = missingPhysicalRootPaths.joined(separator: ", ")
+        case .sessionWorktreeUnavailable:
             throw MCPError.invalidParams(
-                "The session-bound worktree root is unavailable: \(paths). get_code_structure stopped rather than reading the canonical checkout."
+                "The session-bound worktree root is unavailable. get_code_structure stopped rather than reading the canonical checkout."
             )
         }
 
@@ -3728,16 +3730,24 @@ final class MCPServerViewModel: ObservableObject {
         var snapshots = await store.codemapSnapshotDictionary()
         try Task.checkCancellation()
         let repairLimit = min(max(0, maxResults), Self.maxCodeStructureSelfHealingFiles)
-        let repairFiles = codeStructureFiles.lazy.filter { item in
+        let repairFiles = Array(codeStructureFiles.lazy.filter { item in
             guard snapshots[item.file.id] == nil else { return false }
             let ext = (item.file.name as NSString).pathExtension
             return SyntaxManager.isSupportedFileExtension(ext)
-        }.prefix(repairLimit).map(\.file)
-        let repairResult = try await store.repairMissingCodemapSnapshots(
-            for: Array(repairFiles),
-            timeout: selfHealTimeout
-        )
-        snapshots = repairResult.snapshotsByFileID
+        }.prefix(repairLimit).map(\.file))
+        let repairResult: WorkspaceCodemapRepairResult
+        if repairFiles.isEmpty {
+            repairResult = WorkspaceCodemapRepairResult(
+                snapshotsByFileID: snapshots,
+                pendingFileIDs: []
+            )
+        } else {
+            repairResult = try await store.repairMissingCodemapSnapshots(
+                for: repairFiles,
+                timeout: selfHealTimeout
+            )
+            snapshots = repairResult.snapshotsByFileID
+        }
         try Task.checkCancellation()
 
         var renderable: [RenderableCodeStructure] = []
@@ -3756,8 +3766,11 @@ final class MCPServerViewModel: ObservableObject {
                 )
             } else if repairResult.pendingFileIDs.contains(item.file.id) {
                 pendingPaths.append(item.displayPath)
-            } else if includeUnmappedPaths {
-                unmappedPaths.append(item.displayPath)
+            } else {
+                let ext = (item.file.name as NSString).pathExtension
+                if includeUnmappedPaths || SyntaxManager.isSupportedFileExtension(ext) {
+                    unmappedPaths.append(item.displayPath)
+                }
             }
         }
 
@@ -3777,7 +3790,7 @@ final class MCPServerViewModel: ObservableObject {
         }
         try Task.checkCancellation()
         let content = contentParts.joined(separator: "\n\n")
-        let sortedUnmapped = includeUnmappedPaths && !unmappedPaths.isEmpty ? unmappedPaths.sorted() : nil
+        let sortedUnmapped = unmappedPaths.isEmpty ? nil : unmappedPaths.sorted()
         let sortedPending = pendingPaths.isEmpty ? nil : pendingPaths.sorted()
         return ToolResultDTOs.SelectedCodeStructureDTO(
             fileCount: budgetSelection.includedKeys.count,
@@ -4197,17 +4210,12 @@ final class MCPServerViewModel: ObservableObject {
         }
         let standardizedRoot = (expandedRoot as NSString).standardizingPath
         try validateOracleExportPrimaryRoot(standardizedRoot)
-        // Generated handoff files must live in the same effective root that read_file uses
-        // for this context; otherwise the returned logical path is remapped to a missing file.
-        let effectiveRoot = StandardizedPath.absolute(lookupContext.translateInputPath(standardizedRoot))
-        try validateOracleExportPrimaryRoot(effectiveRoot)
-
         return OracleExportDestination(
             workspaceID: workspace.id,
             windowID: windowID,
             tabID: tabID,
-            primaryRootPath: effectiveRoot,
-            rootScope: lookupContext.rootScope
+            primaryRootPath: standardizedRoot,
+            lookupContext: lookupContext
         )
     }
 

--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPContextBuilderToolProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPContextBuilderToolProvider.swift
@@ -188,7 +188,7 @@ final class MCPContextBuilderToolProvider: MCPWindowToolProviding {
         }
 
         let targetWindow = try dependencies.requireTargetWindow()
-        guard let workspace = targetWindow.workspaceManager.activeWorkspace else {
+        guard let activeWorkspace = targetWindow.workspaceManager.activeWorkspace else {
             throw MCPError.invalidParams("No active workspace in this window. Use manage_workspaces action='list' to see available workspaces, then action='switch' to load one.")
         }
         let preferredAgent = targetWindow.promptManager.contextBuilderAgent
@@ -200,6 +200,11 @@ final class MCPContextBuilderToolProvider: MCPWindowToolProviding {
             connectionID
         )
         let finalTabID = tabResolution.tabID
+        let workspace = tabResolution.workspaceID.flatMap { workspaceID in
+            targetWindow.workspaceManager.workspaces.first(where: { $0.id == workspaceID })
+        } ?? activeWorkspace
+        let workspaceContext = tabResolution.workspaceContext
+        let lookupContext = workspaceContext?.lookupContext ?? tabResolution.lookupContext
 
         if tabResolution.bindCaller, let connectionID {
             let clientName = await ServerNetworkManager.shared.clientIdentifier(forConnection: connectionID)
@@ -221,7 +226,7 @@ final class MCPContextBuilderToolProvider: MCPWindowToolProviding {
                 workspace,
                 targetWindow.windowID,
                 finalTabID,
-                tabResolution.lookupContext
+                lookupContext
             )
         } else {
             capturedOracleExportDestination = nil
@@ -328,6 +333,7 @@ final class MCPContextBuilderToolProvider: MCPWindowToolProviding {
                             modelOverrideRaw: preferredModelRaw,
                             responseType: responseType?.rawValue,
                             planModelName: planModelName,
+                            workspaceContext: workspaceContext,
                             mcpControlToken: mcpControlToken,
                             progressReporter: progressReporter
                         )
@@ -358,6 +364,7 @@ final class MCPContextBuilderToolProvider: MCPWindowToolProviding {
                 default: "completed"
                 }
 
+                try workspaceContext?.validateAvailability()
                 let sel = resultTab.selection
                 let fileCount = sel.selectedPaths.count + sel.autoCodemapPaths.count
 
@@ -365,7 +372,8 @@ final class MCPContextBuilderToolProvider: MCPWindowToolProviding {
                     sel,
                     false,
                     .relative,
-                    .auto
+                    .auto,
+                    lookupContext
                 )
                 let formattedSelection = ToolOutputFormatter.formatSelectionReplyToString(selectionReply)
 
@@ -405,6 +413,7 @@ final class MCPContextBuilderToolProvider: MCPWindowToolProviding {
                                 mode,
                                 effectivePrompt,
                                 sel,
+                                lookupContext,
                                 progressReporter,
                                 activityReporter
                             )

--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPFileToolProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPFileToolProvider.swift
@@ -156,7 +156,7 @@ final class MCPFileToolProvider: MCPWindowToolProviding {
                     let abs = entry.file.standardizedFullPath
                     if seenPaths.insert(abs).inserted { combined.append(entry.file) }
                 }
-                let reply = try await dependencies.buildCodeStructureDTO(combined, maxResults, true, lookupContext.bindingProjection)
+                let reply = try await dependencies.buildCodeStructureDTO(combined, maxResults, true, lookupContext)
                 try Task.checkCancellation()
                 return try Value(reply)
             default:
@@ -178,7 +178,7 @@ final class MCPFileToolProvider: MCPWindowToolProviding {
                 try Task.checkCancellation()
                 let resolvedFiles = try await dependencies.resolveFilesForCodeStructure(resolvedPaths, lookupRootScope)
                 try Task.checkCancellation()
-                let reply = try await dependencies.buildCodeStructureDTO(resolvedFiles, maxResults, false, lookupContext.bindingProjection)
+                let reply = try await dependencies.buildCodeStructureDTO(resolvedFiles, maxResults, false, lookupContext)
                 try Task.checkCancellation()
                 return try Value(reply)
             }

--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPSelectionToolProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPSelectionToolProvider.swift
@@ -199,7 +199,7 @@ final class MCPSelectionToolProvider: MCPWindowToolProviding {
                             hintInputs.append(candidate)
                         }
                     }
-                    let hint = await dependencies.makeSelectionHintError(hintInputs, "preview", lookupRootScope)
+                    let hint = await dependencies.makeSelectionHintError(hintInputs, "preview", lookupContext)
                     throw MCPError.invalidParams(hint)
                 }
             }
@@ -276,14 +276,14 @@ final class MCPSelectionToolProvider: MCPWindowToolProviding {
                 let resolvedAnything = pathMutated || !resolvedMap.isEmpty || sliceResolved || sliceMutated
                 if strict, !resolvedAnything {
                     if !selectionPaths.isEmpty {
-                        let hint = await dependencies.makeSelectionHintError(rawPaths, "add", lookupRootScope)
+                        let hint = await dependencies.makeSelectionHintError(rawPaths, "add", lookupContext)
                         throw MCPError.invalidParams(hint)
                     } else if !sliceInvalid {
                         throw MCPError.invalidParams("Provided slices did not match any files")
                     }
                 }
             } else if strict, !pathMutated, resolvedMap.isEmpty {
-                let hint = await dependencies.makeSelectionHintError(rawPaths, "add", lookupRootScope)
+                let hint = await dependencies.makeSelectionHintError(rawPaths, "add", lookupContext)
                 throw MCPError.invalidParams(hint)
             }
             var combinedInvalid = invalid
@@ -335,7 +335,7 @@ final class MCPSelectionToolProvider: MCPWindowToolProviding {
                 throw MCPError.invalidParams(detail)
             }
             if strict, !(pathMutated || !resolvedMap.isEmpty || sliceResolved || sliceMutated), !selectionPaths.isEmpty {
-                let hint = await dependencies.makeSelectionHintError(rawPaths, "remove", lookupRootScope)
+                let hint = await dependencies.makeSelectionHintError(rawPaths, "remove", lookupContext)
                 throw MCPError.invalidParams(hint)
             }
             var combinedInvalid = invalid
@@ -358,7 +358,7 @@ final class MCPSelectionToolProvider: MCPWindowToolProviding {
                 combinedInvalid.append(error)
             }
             if strict, !mutated {
-                let hint = await dependencies.makeSelectionHintError(rawPaths, "promote", lookupRootScope)
+                let hint = await dependencies.makeSelectionHintError(rawPaths, "promote", lookupContext)
                 throw MCPError.invalidParams(hint)
             }
             return try await persistAndReply(resolvedContext: &resolvedContext, metadata: metadata, baseContext: context, selection: newSelection, includeBlocks: includeBlocks, display: display, extraInvalid: combinedInvalid, view: view)
@@ -377,7 +377,7 @@ final class MCPSelectionToolProvider: MCPWindowToolProviding {
                 combinedInvalid.append(msg)
             }
             if strict, !demoteResult.mutated {
-                let hint = await dependencies.makeSelectionHintError(rawPaths, "demote", lookupRootScope)
+                let hint = await dependencies.makeSelectionHintError(rawPaths, "demote", lookupContext)
                 throw MCPError.invalidParams(hint)
             }
             return try await persistAndReply(resolvedContext: &resolvedContext, metadata: metadata, baseContext: context, selection: demoteResult.selection, includeBlocks: includeBlocks, display: display, extraInvalid: combinedInvalid, view: view)

--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPWindowToolDependencies.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPWindowToolDependencies.swift
@@ -11,6 +11,7 @@ struct MCPWindowToolDependencies {
         let workspaceID: UUID?
         let bindCaller: Bool
         let lookupContext: WorkspaceLookupContext
+        let workspaceContext: ContextBuilderWorkspaceContext?
     }
 
     typealias ExecuteTool = @Sendable (_ args: [String: Value]) async throws -> Value
@@ -50,7 +51,8 @@ struct MCPWindowToolDependencies {
         _ selection: StoredSelection,
         _ includeBlocks: Bool,
         _ display: FilePathDisplay,
-        _ codeMapUsageOverride: CodeMapUsage?
+        _ codeMapUsageOverride: CodeMapUsage?,
+        _ lookupContextOverride: WorkspaceLookupContext?
     ) async throws -> ToolResultDTOs.SelectionReply
     typealias SendStageProgress = @Sendable (
         _ connectionID: UUID?,
@@ -80,6 +82,7 @@ struct MCPWindowToolDependencies {
         _ mode: HeadlessMode,
         _ prompt: String,
         _ selection: StoredSelection,
+        _ lookupContext: WorkspaceLookupContext?,
         _ progressReporter: ContextBuilderMCPProgressReporter?,
         _ activityReporter: ContextBuilderMCPActivityReporter?
     ) async throws -> ChatSendReply
@@ -177,7 +180,7 @@ struct MCPWindowToolDependencies {
     ) async -> MCPServerViewModel.MCPSelectionPersistenceVerification?
     typealias MakeSelectionHintError = @MainActor @Sendable (_ paths: [String], _ operation: String, _ lookupRootScope: WorkspaceLookupRootScope) async -> String
     typealias PerformFileAction = @MainActor @Sendable (_ action: String, _ path: String, _ content: String?, _ newPath: String?, _ ifExists: String?) async throws -> String?
-    typealias BuildCodeStructureDTO = @MainActor @Sendable (_ files: [WorkspaceFileRecord], _ maxResults: Int, _ includeUnmappedPaths: Bool, _ projection: WorkspaceRootBindingProjection?) async throws -> ToolResultDTOs.SelectedCodeStructureDTO
+    typealias BuildCodeStructureDTO = @MainActor @Sendable (_ files: [WorkspaceFileRecord], _ maxResults: Int, _ includeUnmappedPaths: Bool, _ lookupContext: WorkspaceLookupContext) async throws -> ToolResultDTOs.SelectedCodeStructureDTO
     typealias ResolveFilesForCodeStructure = @MainActor @Sendable (_ paths: [String], _ lookupRootScope: WorkspaceLookupRootScope) async throws -> [WorkspaceFileRecord]
     typealias BuildStoreBackedFileTreeResult = @MainActor @Sendable (_ mode: String, _ maxDepth: Int?, _ startPath: String?, _ lookupContext: WorkspaceLookupContext) async throws -> (result: FileTreeResult, rootCount: Int)
     typealias ReadFile = @MainActor @Sendable (_ path: String, _ startLine1Based: Int?, _ lineCount: Int?, _ lookupRootScope: WorkspaceLookupRootScope) async throws -> (reply: ToolResultDTOs.ReadFileReply, shouldAutoSelect: Bool)

--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPWindowToolDependencies.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPWindowToolDependencies.swift
@@ -178,7 +178,7 @@ struct MCPWindowToolDependencies {
         _ metadata: MCPServerViewModel.RequestMetadata,
         _ mutated: Bool
     ) async -> MCPServerViewModel.MCPSelectionPersistenceVerification?
-    typealias MakeSelectionHintError = @MainActor @Sendable (_ paths: [String], _ operation: String, _ lookupRootScope: WorkspaceLookupRootScope) async -> String
+    typealias MakeSelectionHintError = @MainActor @Sendable (_ paths: [String], _ operation: String, _ lookupContext: WorkspaceLookupContext) async -> String
     typealias PerformFileAction = @MainActor @Sendable (_ action: String, _ path: String, _ content: String?, _ newPath: String?, _ ifExists: String?) async throws -> String?
     typealias BuildCodeStructureDTO = @MainActor @Sendable (_ files: [WorkspaceFileRecord], _ maxResults: Int, _ includeUnmappedPaths: Bool, _ lookupContext: WorkspaceLookupContext) async throws -> ToolResultDTOs.SelectedCodeStructureDTO
     typealias ResolveFilesForCodeStructure = @MainActor @Sendable (_ paths: [String], _ lookupRootScope: WorkspaceLookupRootScope) async throws -> [WorkspaceFileRecord]

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/Models/WorkspaceFileContextModels.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/Models/WorkspaceFileContextModels.swift
@@ -474,6 +474,11 @@ struct WorkspaceCodemapSnapshot {
     let fileAPI: FileAPI?
 }
 
+struct WorkspaceCodemapRepairResult {
+    let snapshotsByFileID: [UUID: WorkspaceCodemapSnapshot]
+    let pendingFileIDs: Set<UUID>
+}
+
 struct WorkspaceCodemapUpdateEvent {
     let rootID: UUID
     let rootPath: String

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/Models/WorkspaceFileContextModels.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/Models/WorkspaceFileContextModels.swift
@@ -5,7 +5,7 @@ enum WorkspaceLookupRootScope: Hashable {
     case visibleWorkspace
     case visibleWorkspacePlusGitData
     case allLoaded
-    case sessionBoundWorkspace(logicalRootPaths: Set<String>, physicalRootPaths: Set<String>)
+    case sessionBoundWorkspace(canonicalRootPaths: Set<String>, physicalRootPaths: Set<String>)
 }
 
 enum WorkspaceLookupRootScopeAvailability: Equatable {

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
@@ -1100,6 +1100,7 @@ actor WorkspaceFileContextStore {
     )
     private var codemapSnapshotsByFileID: [UUID: WorkspaceCodemapSnapshot] = [:]
     private var codemapFileIDsByRootID: [UUID: Set<UUID>] = [:]
+    private var initializedSessionWorktreeCodemapRootIDs = Set<UUID>()
     private var cachedCodemapFileAPIAggregate: WorkspaceCodemapFileAPIAggregate?
     private var codemapUpdateContinuations: [UUID: AsyncStream<WorkspaceCodemapUpdateEvent>.Continuation] = [:]
     private var fileSystemDeltaContinuations: [UUID: AsyncStream<WorkspaceFileSystemDeltaEvent>.Continuation] = [:]
@@ -1112,6 +1113,7 @@ actor WorkspaceFileContextStore {
     private var completedScopedIngressBarrierCutsByRootID: [UUID: ScopedIngressBarrierCompletedCut] = [:]
     private var nextScopedIngressBarrierToken: UInt64 = 0
     private static let maxConcurrentScopedIngressBarriers = 8
+    private var codeScanResultSubscriptionTask: Task<AsyncStream<[CodeScanActor.ScanResult]>, Never>?
     private var codeScanResultTask: Task<Void, Never>?
     #if DEBUG
         private let debugNowNanoseconds: @Sendable () -> UInt64
@@ -1632,6 +1634,13 @@ actor WorkspaceFileContextStore {
         })
         let loaded = Set(rootStatesByID.values.compactMap { state -> String? in
             guard state.root.kind == .sessionWorktree else { return nil }
+            var isDirectory: ObjCBool = false
+            guard FileManager.default.fileExists(
+                atPath: state.root.standardizedFullPath,
+                isDirectory: &isDirectory
+            ), isDirectory.boolValue else {
+                return nil
+            }
             return state.root.standardizedFullPath
         })
         let missing = requested.subtracting(loaded).sorted()
@@ -3543,7 +3552,6 @@ actor WorkspaceFileContextStore {
     }
 
     func codemapUpdates() -> AsyncStream<WorkspaceCodemapUpdateEvent> {
-        ensureCodeScanResultTask()
         let id = UUID()
         return AsyncStream { continuation in
             codemapUpdateContinuations[id] = continuation
@@ -3584,6 +3592,10 @@ actor WorkspaceFileContextStore {
 
     private func removeCodemapUpdateContinuation(_ id: UUID) {
         codemapUpdateContinuations.removeValue(forKey: id)
+    }
+
+    private func clearSessionWorktreeCodemapInitialization(rootIDs: [UUID]) {
+        initializedSessionWorktreeCodemapRootIDs.subtract(rootIDs)
     }
 
     @discardableResult
@@ -3989,6 +4001,7 @@ actor WorkspaceFileContextStore {
         #endif
 
         let removedRootIDSet = Set(statesToUnload.map(\.rootID))
+        initializedSessionWorktreeCodemapRootIDs.subtract(removedRootIDSet)
         rootLoadOrder.removeAll { removedRootIDSet.contains($0) }
         for entry in statesToUnload {
             rootIDsByStandardizedPath.removeValue(forKey: entry.state.root.standardizedFullPath)
@@ -4539,11 +4552,90 @@ actor WorkspaceFileContextStore {
         try await requestCodemapScans(for: rootLoadOrder.flatMap { files(inRoot: $0) })
     }
 
+    @discardableResult
+    func initializeCodemapsForSessionWorktreeRoots(rootIDs: [UUID]) -> [UUID] {
+        var seen = Set<UUID>()
+        let pendingRootIDs = rootIDs.filter { rootID in
+            guard seen.insert(rootID).inserted,
+                  let root = rootStatesByID[rootID]?.root,
+                  root.kind == .sessionWorktree,
+                  !initializedSessionWorktreeCodemapRootIDs.contains(rootID)
+            else { return false }
+            return true
+        }
+        guard !pendingRootIDs.isEmpty else { return [] }
+
+        initializedSessionWorktreeCodemapRootIDs.formUnion(pendingRootIDs)
+        Task.detached(priority: .utility) { [store = self, pendingRootIDs] in
+            do {
+                try await store.requestInitialRootCodemapScans(rootIDs: pendingRootIDs)
+            } catch {
+                await store.clearSessionWorktreeCodemapInitialization(rootIDs: pendingRootIDs)
+            }
+        }
+        return pendingRootIDs
+    }
+
+    func repairMissingCodemapSnapshots(
+        for files: [WorkspaceFileRecord],
+        timeout: Duration = .seconds(5),
+        pollInterval: Duration = .milliseconds(25)
+    ) async throws -> WorkspaceCodemapRepairResult {
+        try Task.checkCancellation()
+        await ensureCodeScanResultTask()
+
+        var seenFileIDs = Set<UUID>()
+        let missingFiles = files.filter { file in
+            guard seenFileIDs.insert(file.id).inserted,
+                  isDiscoverableFileID(file.id),
+                  filesByID[file.id] != nil,
+                  codemapSnapshotsByFileID[file.id] == nil
+            else { return false }
+            return true
+        }
+        guard !missingFiles.isEmpty else {
+            return WorkspaceCodemapRepairResult(
+                snapshotsByFileID: codemapSnapshotDictionary(),
+                pendingFileIDs: []
+            )
+        }
+
+        let requests = try await codemapScanRequests(for: missingFiles)
+        let submittedFileIDs = Set(requests.map(\.fileID))
+        if !requests.isEmpty {
+            let rootFolderPaths = Array(Set(requests.map(\.rootFolderPath)))
+            await codeScanActor.requestScans(
+                requests,
+                purpose: .selfHealing,
+                rootFolderPaths: rootFolderPaths
+            )
+        }
+
+        if !submittedFileIDs.isEmpty, timeout > .zero {
+            let clock = ContinuousClock()
+            let deadline = clock.now.advanced(by: timeout)
+            while submittedFileIDs.contains(where: { codemapSnapshotsByFileID[$0] == nil }),
+                  clock.now < deadline
+            {
+                try Task.checkCancellation()
+                try await Task.sleep(for: pollInterval)
+            }
+        }
+
+        try Task.checkCancellation()
+        let snapshots = codemapSnapshotDictionary()
+        let targetFileIDs = Set(missingFiles.map(\.id))
+        return WorkspaceCodemapRepairResult(
+            snapshotsByFileID: snapshots,
+            pendingFileIDs: targetFileIDs.filter { snapshots[$0] == nil }
+        )
+    }
+
     func requestInitialRootCodemapScans(
         rootFolderPaths: [String],
         purgeCachesOnEmptyInitialRequests: Bool = false
     ) async throws {
-        ensureCodeScanResultTask()
+        await ensureCodeScanResultTask()
         #if DEBUG
             let collectFilesStartMS = WorkspaceRestorePerfLog.timestampMSIfEnabled()
         #endif
@@ -4605,7 +4697,7 @@ actor WorkspaceFileContextStore {
         rootIDs: [UUID],
         purgeCachesOnEmptyInitialRequests: Bool = false
     ) async throws {
-        ensureCodeScanResultTask()
+        await ensureCodeScanResultTask()
         #if DEBUG
             let collectFilesStartMS = WorkspaceRestorePerfLog.timestampMSIfEnabled()
         #endif
@@ -4684,7 +4776,7 @@ actor WorkspaceFileContextStore {
     }
 
     func requestCodemapScans(for files: [WorkspaceFileRecord]) async throws {
-        ensureCodeScanResultTask()
+        await ensureCodeScanResultTask()
         let requests = try await codemapScanRequests(for: files)
         let rootFolderPaths = Array(Set(requests.map(\.rootFolderPath)))
         guard !rootFolderPaths.isEmpty else { return }
@@ -6596,11 +6688,22 @@ actor WorkspaceFileContextStore {
         }
     }
 
-    private func ensureCodeScanResultTask() {
+    private func ensureCodeScanResultTask() async {
         guard codeScanResultTask == nil else { return }
-        let actor = codeScanActor
+        let subscriptionTask: Task<AsyncStream<[CodeScanActor.ScanResult]>, Never>
+        if let existing = codeScanResultSubscriptionTask {
+            subscriptionTask = existing
+        } else {
+            let actor = codeScanActor
+            let created = Task { actor.subscribeToScanResults() }
+            codeScanResultSubscriptionTask = created
+            subscriptionTask = created
+        }
+
+        let stream = await subscriptionTask.value
+        guard codeScanResultTask == nil else { return }
+        codeScanResultSubscriptionTask = nil
         codeScanResultTask = Task { [weak self] in
-            let stream = actor.subscribeToScanResults()
             for await results in stream {
                 guard !Task.isCancelled else { break }
                 await self?.applyCodeScanResults(results)

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
@@ -1100,6 +1100,7 @@ actor WorkspaceFileContextStore {
     )
     private var codemapSnapshotsByFileID: [UUID: WorkspaceCodemapSnapshot] = [:]
     private var codemapFileIDsByRootID: [UUID: Set<UUID>] = [:]
+    private var initializingSessionWorktreeCodemapRootIDs = Set<UUID>()
     private var initializedSessionWorktreeCodemapRootIDs = Set<UUID>()
     private var cachedCodemapFileAPIAggregate: WorkspaceCodemapFileAPIAggregate?
     private var codemapUpdateContinuations: [UUID: AsyncStream<WorkspaceCodemapUpdateEvent>.Continuation] = [:]
@@ -1632,18 +1633,14 @@ actor WorkspaceFileContextStore {
         let requested = Set(requestedPhysicalRootPaths.map {
             StandardizedPath.absolute(($0 as NSString).expandingTildeInPath)
         })
-        let loaded = Set(rootStatesByID.values.compactMap { state -> String? in
-            guard state.root.kind == .sessionWorktree else { return nil }
+        let missing = requested.filter { path in
+            guard let rootID = rootIDsByStandardizedPath[path],
+                  rootStatesByID[rootID]?.root.kind == .sessionWorktree
+            else { return true }
             var isDirectory: ObjCBool = false
-            guard FileManager.default.fileExists(
-                atPath: state.root.standardizedFullPath,
-                isDirectory: &isDirectory
-            ), isDirectory.boolValue else {
-                return nil
-            }
-            return state.root.standardizedFullPath
-        })
-        let missing = requested.subtracting(loaded).sorted()
+            return !FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory) ||
+                !isDirectory.boolValue
+        }.sorted()
         return missing.isEmpty
             ? .available
             : .sessionWorktreeUnavailable(missingPhysicalRootPaths: missing)
@@ -3588,6 +3585,12 @@ actor WorkspaceFileContextStore {
         func codemapMemoryCounters() async -> CodeScanActor.CodemapMemoryCounters {
             await codeScanActor.codemapMemoryCounters()
         }
+
+        func setCodemapScanWillStartHandlerForTesting(
+            _ handler: (@Sendable (UUID) async -> Void)?
+        ) async {
+            await codeScanActor.setScanWillStartHandlerForTesting(handler)
+        }
     #endif
 
     private func removeCodemapUpdateContinuation(_ id: UUID) {
@@ -3595,7 +3598,23 @@ actor WorkspaceFileContextStore {
     }
 
     private func clearSessionWorktreeCodemapInitialization(rootIDs: [UUID]) {
+        initializingSessionWorktreeCodemapRootIDs.subtract(rootIDs)
         initializedSessionWorktreeCodemapRootIDs.subtract(rootIDs)
+    }
+
+    private func completeSessionWorktreeCodemapInitialization(
+        requestedRootIDs: [UUID],
+        submittedRootIDs: [UUID]
+    ) {
+        initializingSessionWorktreeCodemapRootIDs.subtract(requestedRootIDs)
+        let completedRootIDs = submittedRootIDs.filter { rootID in
+            guard let root = rootStatesByID[rootID]?.root,
+                  root.kind == .sessionWorktree,
+                  !files(inRoot: rootID).isEmpty
+            else { return false }
+            return true
+        }
+        initializedSessionWorktreeCodemapRootIDs.formUnion(completedRootIDs)
     }
 
     @discardableResult
@@ -4001,6 +4020,7 @@ actor WorkspaceFileContextStore {
         #endif
 
         let removedRootIDSet = Set(statesToUnload.map(\.rootID))
+        initializingSessionWorktreeCodemapRootIDs.subtract(removedRootIDSet)
         initializedSessionWorktreeCodemapRootIDs.subtract(removedRootIDSet)
         rootLoadOrder.removeAll { removedRootIDSet.contains($0) }
         for entry in statesToUnload {
@@ -4559,16 +4579,22 @@ actor WorkspaceFileContextStore {
             guard seen.insert(rootID).inserted,
                   let root = rootStatesByID[rootID]?.root,
                   root.kind == .sessionWorktree,
+                  !files(inRoot: rootID).isEmpty,
+                  !initializingSessionWorktreeCodemapRootIDs.contains(rootID),
                   !initializedSessionWorktreeCodemapRootIDs.contains(rootID)
             else { return false }
             return true
         }
         guard !pendingRootIDs.isEmpty else { return [] }
 
-        initializedSessionWorktreeCodemapRootIDs.formUnion(pendingRootIDs)
+        initializingSessionWorktreeCodemapRootIDs.formUnion(pendingRootIDs)
         Task.detached(priority: .utility) { [store = self, pendingRootIDs] in
             do {
-                try await store.requestInitialRootCodemapScans(rootIDs: pendingRootIDs)
+                let submittedRootIDs = try await store.requestInitialRootCodemapScans(rootIDs: pendingRootIDs)
+                await store.completeSessionWorktreeCodemapInitialization(
+                    requestedRootIDs: pendingRootIDs,
+                    submittedRootIDs: submittedRootIDs
+                )
             } catch {
                 await store.clearSessionWorktreeCodemapInitialization(rootIDs: pendingRootIDs)
             }
@@ -4601,14 +4627,19 @@ actor WorkspaceFileContextStore {
         }
 
         let requests = try await codemapScanRequests(for: missingFiles)
-        let submittedFileIDs = Set(requests.map(\.fileID))
-        if !requests.isEmpty {
+        let submittedFileIDs: Set<UUID>
+        let alreadyScheduledFileIDs: Set<UUID>
+        if requests.isEmpty {
+            submittedFileIDs = []
+            alreadyScheduledFileIDs = []
+        } else {
             let rootFolderPaths = Array(Set(requests.map(\.rootFolderPath)))
-            await codeScanActor.requestScans(
+            let requestResult = await codeScanActor.requestSelfHealingScans(
                 requests,
-                purpose: .selfHealing,
                 rootFolderPaths: rootFolderPaths
             )
+            submittedFileIDs = requestResult.submittedFileIDs
+            alreadyScheduledFileIDs = requestResult.alreadyScheduledFileIDs
         }
 
         if !submittedFileIDs.isEmpty, timeout > .zero {
@@ -4624,10 +4655,11 @@ actor WorkspaceFileContextStore {
 
         try Task.checkCancellation()
         let snapshots = codemapSnapshotDictionary()
-        let targetFileIDs = Set(missingFiles.map(\.id))
         return WorkspaceCodemapRepairResult(
             snapshotsByFileID: snapshots,
-            pendingFileIDs: targetFileIDs.filter { snapshots[$0] == nil }
+            pendingFileIDs: submittedFileIDs
+                .union(alreadyScheduledFileIDs)
+                .filter { snapshots[$0] == nil }
         )
     }
 
@@ -4693,10 +4725,11 @@ actor WorkspaceFileContextStore {
         #endif
     }
 
+    @discardableResult
     func requestInitialRootCodemapScans(
         rootIDs: [UUID],
         purgeCachesOnEmptyInitialRequests: Bool = false
-    ) async throws {
+    ) async throws -> [UUID] {
         await ensureCodeScanResultTask()
         #if DEBUG
             let collectFilesStartMS = WorkspaceRestorePerfLog.timestampMSIfEnabled()
@@ -4724,7 +4757,7 @@ actor WorkspaceFileContextStore {
                 ]
             )
         #endif
-        guard !orderedRootIDs.isEmpty else { return }
+        guard !orderedRootIDs.isEmpty else { return [] }
         #if DEBUG
             let buildRequestsStartMS = WorkspaceRestorePerfLog.timestampMSIfEnabled()
         #endif
@@ -4748,7 +4781,7 @@ actor WorkspaceFileContextStore {
             currentRootIDs.insert(rootID)
             currentRootFolderPaths.append(state.root.standardizedFullPath)
         }
-        guard !currentRootFolderPaths.isEmpty else { return }
+        guard !currentRootFolderPaths.isEmpty else { return [] }
         let currentRequests = requests.filter { request in
             guard let file = filesByID[request.fileID] else { return false }
             return currentRootIDs.contains(file.rootID)
@@ -4756,7 +4789,7 @@ actor WorkspaceFileContextStore {
         #if DEBUG
             let submitStartMS = WorkspaceRestorePerfLog.timestampMSIfEnabled()
         #endif
-        await codeScanActor.requestScans(
+        let submittedFileIDs = await codeScanActor.requestScans(
             currentRequests,
             purpose: .initialRootLoad,
             rootFolderPaths: currentRootFolderPaths,
@@ -4773,6 +4806,11 @@ actor WorkspaceFileContextStore {
                 ]
             )
         #endif
+        let submittedRootIDs = Set(currentRequests.compactMap { request -> UUID? in
+            guard submittedFileIDs.contains(request.fileID) else { return nil }
+            return filesByID[request.fileID]?.rootID
+        })
+        return orderedRootIDs.filter { submittedRootIDs.contains($0) }
     }
 
     func requestCodemapScans(for files: [WorkspaceFileRecord]) async throws {
@@ -6198,10 +6236,10 @@ actor WorkspaceFileContextStore {
             return 1
         case .allLoaded:
             return 2
-        case let .sessionBoundWorkspace(logicalRootPaths, physicalRootPaths):
+        case let .sessionBoundWorkspace(canonicalRootPaths, physicalRootPaths):
             var hasher = Hasher()
             hasher.combine("sessionBoundWorkspace")
-            hasher.combine(normalizedSessionSelectorPaths(logicalRootPaths).sorted())
+            hasher.combine(normalizedSessionSelectorPaths(canonicalRootPaths).sorted())
             hasher.combine(normalizedSessionSelectorPaths(physicalRootPaths).sorted())
             return UInt64(bitPattern: Int64(hasher.finalize()))
         }
@@ -6259,13 +6297,13 @@ actor WorkspaceFileContextStore {
             return allRoots.filter { $0.kind == .primaryWorkspace || $0.kind == .workspaceGitData }
         case .allLoaded:
             return allRoots
-        case let .sessionBoundWorkspace(logicalRootPaths, physicalRootPaths):
-            let normalizedLogicalRootPaths = normalizedSessionSelectorPaths(logicalRootPaths)
+        case let .sessionBoundWorkspace(canonicalRootPaths, physicalRootPaths):
+            let normalizedCanonicalRootPaths = normalizedSessionSelectorPaths(canonicalRootPaths)
             let normalizedPhysicalRootPaths = normalizedSessionSelectorPaths(physicalRootPaths)
             return allRoots.filter { root in
                 switch root.kind {
                 case .primaryWorkspace:
-                    !normalizedLogicalRootPaths.contains(root.standardizedFullPath)
+                    normalizedCanonicalRootPaths.contains(root.standardizedFullPath)
                 case .sessionWorktree:
                     normalizedPhysicalRootPaths.contains(root.standardizedFullPath)
                 case .workspaceGitData, .supplementalSystem:

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceRootBindingProjection.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceRootBindingProjection.swift
@@ -275,6 +275,7 @@ struct WorkspaceRootBindingProjectionMaterializer {
     ) async -> WorkspaceRootBindingProjection? {
         let visibleRoots = await store.rootRefs(scope: .visibleWorkspace)
         var boundRoots: [WorkspaceRootBindingProjection.BoundRoot] = []
+        var loadedSessionWorktreeRootIDs: [UUID] = []
         for binding in bindings {
             let logicalPath = StandardizedPath.absolute((binding.logicalRootPath as NSString).expandingTildeInPath)
             let logicalRoot = visibleRoots.first { $0.standardizedFullPath == logicalPath }
@@ -297,6 +298,7 @@ struct WorkspaceRootBindingProjectionMaterializer {
                     name: logicalRoot.name,
                     fullPath: physicalRecord.standardizedFullPath
                 )
+                loadedSessionWorktreeRootIDs.append(physicalRecord.id)
             } catch {
                 // Fail closed for bound sessions: keep the logical -> physical projection so
                 // display paths and complete-diff policy still know this session is worktree-bound,
@@ -313,6 +315,7 @@ struct WorkspaceRootBindingProjectionMaterializer {
             boundRoots.append(.init(logicalRoot: logicalRoot, physicalRoot: physicalRoot, binding: binding))
         }
         guard !boundRoots.isEmpty else { return nil }
+        _ = await store.initializeCodemapsForSessionWorktreeRoots(rootIDs: loadedSessionWorktreeRootIDs)
         return WorkspaceRootBindingProjection(sessionID: sessionID, boundRoots: boundRoots, visibleLogicalRoots: visibleRoots)
     }
 }

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceRootBindingProjection.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceRootBindingProjection.swift
@@ -35,8 +35,12 @@ struct WorkspaceRootBindingProjection: Equatable {
         Set(replacementsByLogicalRootPath.values.map(\.physicalRoot.standardizedFullPath))
     }
 
+    var canonicalRootPaths: Set<String> {
+        Set(visibleLogicalRoots.map(\.standardizedFullPath)).subtracting(logicalRootPaths)
+    }
+
     var lookupRootScope: WorkspaceLookupRootScope {
-        .sessionBoundWorkspace(logicalRootPaths: logicalRootPaths, physicalRootPaths: physicalRootPaths)
+        .sessionBoundWorkspace(canonicalRootPaths: canonicalRootPaths, physicalRootPaths: physicalRootPaths)
     }
 
     var logicalRootRefs: [WorkspaceRootRef] {
@@ -113,6 +117,16 @@ struct WorkspaceRootBindingProjection: Equatable {
                 ranges: input.ranges
             )
         }
+    }
+
+    func projectedLogicalRootMetadata(forPhysicalPath rawPath: String) -> (rootPath: String, pathWithinRoot: String)? {
+        let standardized = StandardizedPath.absolute((rawPath as NSString).expandingTildeInPath)
+        guard let boundRoot = boundRoot(containingPhysicalAbsolutePath: standardized) else {
+            return nil
+        }
+        let relative = String(standardized.dropFirst(boundRoot.physicalRoot.standardizedFullPath.count))
+            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        return (boundRoot.logicalRoot.standardizedFullPath, StandardizedPath.relative(relative))
     }
 
     func projectedLogicalDisplayPath(forPhysicalPath rawPath: String, display: FilePathDisplay = .relative) -> String? {

--- a/Tests/RepoPromptTests/ContextBuilder/ContextBuilderWorkspaceContextTests.swift
+++ b/Tests/RepoPromptTests/ContextBuilder/ContextBuilderWorkspaceContextTests.swift
@@ -1,0 +1,178 @@
+import Foundation
+@testable import RepoPrompt
+import XCTest
+
+@MainActor
+final class ContextBuilderWorkspaceContextTests: XCTestCase {
+    func testResolveFreezesWorktreeProjectionProviderCWDAndNestedSnapshot() async throws {
+        let logicalRoot = try makeTemporaryDirectory(name: "ContextBuilderLogical")
+        let worktreeRoot = try makeTemporaryDirectory(name: "ContextBuilderWorktree")
+        defer {
+            try? FileManager.default.removeItem(at: logicalRoot)
+            try? FileManager.default.removeItem(at: worktreeRoot)
+        }
+
+        try write("let origin = \"base\"\n", to: logicalRoot.appendingPathComponent("Sources/App.swift"))
+        try write("let origin = \"worktree\"\n", to: worktreeRoot.appendingPathComponent("Sources/App.swift"))
+
+        let store = WorkspaceFileContextStore()
+        _ = try await store.loadRoot(path: logicalRoot.path)
+
+        let sessionID = UUID()
+        let parentRunID = UUID()
+        let tabID = UUID()
+        let workspaceID = UUID()
+        let binding = makeBinding(logicalRoot: logicalRoot, worktreeRoot: worktreeRoot)
+        let selection = StoredSelection(
+            selectedPaths: [logicalRoot.appendingPathComponent("Sources/App.swift").path],
+            codemapAutoEnabled: false
+        )
+        let snapshot = MCPServerViewModel.TabContextSnapshot(
+            tabID: tabID,
+            windowID: 41,
+            workspaceID: workspaceID,
+            promptText: "Inspect the branch implementation",
+            selection: selection,
+            selectedMetaPromptIDs: [UUID()],
+            tabName: "Agent tab",
+            runID: parentRunID,
+            activeAgentSessionID: sessionID,
+            worktreeBindings: [binding],
+            explicitlyBound: true,
+            readFileAutoSelectionGeneration: 7
+        )
+
+        let context = try await ContextBuilderWorkspaceContext.resolve(
+            from: snapshot,
+            workspaceRepoPaths: [logicalRoot.path],
+            store: store
+        )
+
+        XCTAssertEqual(context.parentAgentSessionID, sessionID)
+        XCTAssertEqual(context.parentAgentRunID, parentRunID)
+        XCTAssertEqual(context.tabID, tabID)
+        XCTAssertEqual(context.workspaceID, workspaceID)
+        XCTAssertEqual(context.providerWorkspacePath, worktreeRoot.standardizedFileURL.path)
+        XCTAssertEqual(
+            context.lookupContext.translateInputPath(logicalRoot.appendingPathComponent("Sources/App.swift").path),
+            worktreeRoot.appendingPathComponent("Sources/App.swift").standardizedFileURL.path
+        )
+
+        let nestedRunID = UUID()
+        let nested = context.nestedDiscoveryTabContext(runID: nestedRunID)
+        XCTAssertEqual(nested.runID, nestedRunID)
+        XCTAssertEqual(nested.activeAgentSessionID, sessionID)
+        XCTAssertEqual(nested.worktreeBindings, [binding])
+        XCTAssertEqual(nested.promptText, snapshot.promptText)
+        XCTAssertEqual(nested.selection, snapshot.selection)
+        XCTAssertEqual(nested.selectedMetaPromptIDs, snapshot.selectedMetaPromptIDs)
+        XCTAssertTrue(nested.explicitlyBound)
+        XCTAssertEqual(nested.readFileAutoSelectionGeneration, 7)
+    }
+
+    func testResolveWithoutBindingsFreezesCanonicalWorkspaceLookup() async throws {
+        let logicalRoot = try makeTemporaryDirectory(name: "ContextBuilderUnbound")
+        let otherWorkspaceRoot = try makeTemporaryDirectory(name: "ContextBuilderOtherWorkspace")
+        defer {
+            try? FileManager.default.removeItem(at: logicalRoot)
+            try? FileManager.default.removeItem(at: otherWorkspaceRoot)
+        }
+        try write("let value = true\n", to: logicalRoot.appendingPathComponent("App.swift"))
+        try write("let other = true\n", to: otherWorkspaceRoot.appendingPathComponent("Other.swift"))
+
+        let store = WorkspaceFileContextStore()
+        _ = try await store.loadRoot(path: logicalRoot.path)
+        _ = try await store.loadRoot(path: otherWorkspaceRoot.path)
+        let snapshot = MCPServerViewModel.TabContextSnapshot(
+            tabID: UUID(),
+            windowID: 42,
+            workspaceID: UUID(),
+            promptText: "Question",
+            selection: StoredSelection(),
+            selectedMetaPromptIDs: [],
+            tabName: "Unbound",
+            runID: UUID(),
+            activeAgentSessionID: UUID(),
+            worktreeBindings: [],
+            explicitlyBound: false
+        )
+
+        let context = try await ContextBuilderWorkspaceContext.resolve(
+            from: snapshot,
+            workspaceRepoPaths: [logicalRoot.path],
+            store: store
+        )
+
+        XCTAssertEqual(context.providerWorkspacePath, logicalRoot.standardizedFileURL.path)
+        XCTAssertNil(context.lookupContext.bindingProjection)
+        let frozenRoots = await store.rootRefs(scope: context.lookupContext.rootScope)
+        XCTAssertEqual(Set(frozenRoots.map(\.standardizedFullPath)), Set([logicalRoot.standardizedFileURL.path]))
+    }
+
+    func testResolveFailsClosedWhenInheritedWorktreeIsUnavailable() async throws {
+        let logicalRoot = try makeTemporaryDirectory(name: "ContextBuilderMissingLogical")
+        defer { try? FileManager.default.removeItem(at: logicalRoot) }
+        let missingWorktree = logicalRoot
+            .deletingLastPathComponent()
+            .appendingPathComponent("Missing-\(UUID().uuidString)")
+
+        let store = WorkspaceFileContextStore()
+        _ = try await store.loadRoot(path: logicalRoot.path)
+        let binding = makeBinding(logicalRoot: logicalRoot, worktreeRoot: missingWorktree)
+        let snapshot = MCPServerViewModel.TabContextSnapshot(
+            tabID: UUID(),
+            windowID: 43,
+            workspaceID: UUID(),
+            promptText: "Question",
+            selection: StoredSelection(),
+            selectedMetaPromptIDs: [],
+            tabName: "Missing worktree",
+            runID: UUID(),
+            activeAgentSessionID: UUID(),
+            worktreeBindings: [binding],
+            explicitlyBound: false
+        )
+
+        do {
+            _ = try await ContextBuilderWorkspaceContext.resolve(
+                from: snapshot,
+                workspaceRepoPaths: [logicalRoot.path],
+                store: store
+            )
+            XCTFail("Expected unavailable inherited worktree to fail closed")
+        } catch let error as AgentWorktreeRuntimeWorkspaceError {
+            XCTAssertEqual(error.binding, binding)
+        }
+    }
+
+    private func makeTemporaryDirectory(name: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(name)-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func write(_ content: String, to url: URL) throws {
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try content.write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    private func makeBinding(logicalRoot: URL, worktreeRoot: URL) -> AgentSessionWorktreeBinding {
+        AgentSessionWorktreeBinding(
+            id: UUID().uuidString,
+            repositoryID: "repo-id",
+            repoKey: logicalRoot.path,
+            logicalRootPath: logicalRoot.path,
+            logicalRootName: logicalRoot.lastPathComponent,
+            worktreeID: UUID().uuidString,
+            worktreeRootPath: worktreeRoot.path,
+            worktreeName: worktreeRoot.lastPathComponent,
+            branch: "feature/context-builder",
+            head: "deadbeef",
+            source: "test"
+        )
+    }
+}

--- a/Tests/RepoPromptTests/ContextBuilder/ContextBuilderWorkspaceContextTests.swift
+++ b/Tests/RepoPromptTests/ContextBuilder/ContextBuilderWorkspaceContextTests.swift
@@ -22,6 +22,8 @@ final class ContextBuilderWorkspaceContextTests: XCTestCase {
         let parentRunID = UUID()
         let tabID = UUID()
         let workspaceID = UUID()
+        let storedPromptID = UUID()
+        let contextBuilderPromptID = UUID()
         let binding = makeBinding(logicalRoot: logicalRoot, worktreeRoot: worktreeRoot)
         let selection = StoredSelection(
             selectedPaths: [logicalRoot.appendingPathComponent("Sources/App.swift").path],
@@ -33,7 +35,8 @@ final class ContextBuilderWorkspaceContextTests: XCTestCase {
             workspaceID: workspaceID,
             promptText: "Inspect the branch implementation",
             selection: selection,
-            selectedMetaPromptIDs: [UUID()],
+            selectedMetaPromptIDs: [storedPromptID],
+            selectedContextBuilderPromptIDs: [contextBuilderPromptID],
             tabName: "Agent tab",
             runID: parentRunID,
             activeAgentSessionID: sessionID,
@@ -49,9 +52,7 @@ final class ContextBuilderWorkspaceContextTests: XCTestCase {
         )
 
         XCTAssertEqual(context.parentAgentSessionID, sessionID)
-        XCTAssertEqual(context.parentAgentRunID, parentRunID)
         XCTAssertEqual(context.tabID, tabID)
-        XCTAssertEqual(context.workspaceID, workspaceID)
         XCTAssertEqual(context.providerWorkspacePath, worktreeRoot.standardizedFileURL.path)
         XCTAssertEqual(
             context.lookupContext.translateInputPath(logicalRoot.appendingPathComponent("Sources/App.swift").path),
@@ -65,7 +66,9 @@ final class ContextBuilderWorkspaceContextTests: XCTestCase {
         XCTAssertEqual(nested.worktreeBindings, [binding])
         XCTAssertEqual(nested.promptText, snapshot.promptText)
         XCTAssertEqual(nested.selection, snapshot.selection)
-        XCTAssertEqual(nested.selectedMetaPromptIDs, snapshot.selectedMetaPromptIDs)
+        XCTAssertEqual(nested.selectedMetaPromptIDs, [storedPromptID])
+        XCTAssertEqual(nested.selectedContextBuilderPromptIDs, [contextBuilderPromptID])
+        XCTAssertEqual(nested.frozenLookupContext, context.lookupContext)
         XCTAssertTrue(nested.explicitlyBound)
         XCTAssertEqual(nested.readFileAutoSelectionGeneration, 7)
     }
@@ -82,7 +85,6 @@ final class ContextBuilderWorkspaceContextTests: XCTestCase {
 
         let store = WorkspaceFileContextStore()
         _ = try await store.loadRoot(path: logicalRoot.path)
-        _ = try await store.loadRoot(path: otherWorkspaceRoot.path)
         let snapshot = MCPServerViewModel.TabContextSnapshot(
             tabID: UUID(),
             windowID: 42,
@@ -105,8 +107,66 @@ final class ContextBuilderWorkspaceContextTests: XCTestCase {
 
         XCTAssertEqual(context.providerWorkspacePath, logicalRoot.standardizedFileURL.path)
         XCTAssertNil(context.lookupContext.bindingProjection)
+
+        _ = try await store.loadRoot(path: otherWorkspaceRoot.path)
         let frozenRoots = await store.rootRefs(scope: context.lookupContext.rootScope)
         XCTAssertEqual(Set(frozenRoots.map(\.standardizedFullPath)), Set([logicalRoot.standardizedFileURL.path]))
+
+        let nested = context.nestedDiscoveryTabContext(runID: UUID())
+        XCTAssertEqual(nested.frozenLookupContext, context.lookupContext)
+        let nestedLookupContext = try XCTUnwrap(nested.frozenLookupContext)
+        let nestedRoots = await store.rootRefs(scope: nestedLookupContext.rootScope)
+        XCTAssertEqual(Set(nestedRoots.map(\.standardizedFullPath)), Set([logicalRoot.standardizedFileURL.path]))
+    }
+
+    func testResolveFailsClosedWhenWorktreeBindingStateIsUnhydrated() async throws {
+        let logicalRoot = try makeTemporaryDirectory(name: "ContextBuilderUnhydrated")
+        defer { try? FileManager.default.removeItem(at: logicalRoot) }
+        let store = WorkspaceFileContextStore()
+        _ = try await store.loadRoot(path: logicalRoot.path)
+        let snapshot = MCPServerViewModel.TabContextSnapshot(
+            tabID: UUID(),
+            windowID: 44,
+            workspaceID: UUID(),
+            promptText: "Question",
+            selection: StoredSelection(),
+            selectedMetaPromptIDs: [],
+            tabName: "Unhydrated",
+            runID: UUID(),
+            activeAgentSessionID: UUID(),
+            worktreeBindingState: .unhydrated,
+            explicitlyBound: false
+        )
+
+        do {
+            _ = try await ContextBuilderWorkspaceContext.resolve(
+                from: snapshot,
+                workspaceRepoPaths: [logicalRoot.path],
+                store: store
+            )
+            XCTFail("Expected unhydrated binding state to fail closed")
+        } catch let error as ContextBuilderWorkspaceContextError {
+            XCTAssertEqual(error, .unavailableWorktreeBindingState)
+        }
+    }
+
+    func testAuthoritativeLookupContextFailsClosedInsteadOfAdmittingCanonicalRoots() async throws {
+        let logicalRoot = try makeTemporaryDirectory(name: "ContextBuilderFailClosedLookup")
+        defer { try? FileManager.default.removeItem(at: logicalRoot) }
+        let store = WorkspaceFileContextStore()
+        _ = try await store.loadRoot(path: logicalRoot.path)
+
+        let lookupContext = await AgentWorkspaceLookupContextResolver.authoritativeLookupContextOrFailClosed(
+            source: AgentWorkspaceLookupContextSource(
+                activeAgentSessionID: UUID(),
+                worktreeBindingState: .unhydrated
+            ),
+            store: store
+        )
+
+        let roots = await store.rootRefs(scope: lookupContext.rootScope)
+        XCTAssertTrue(roots.isEmpty)
+        XCTAssertNil(lookupContext.bindingProjection)
     }
 
     func testResolveFailsClosedWhenInheritedWorktreeIsUnavailable() async throws {
@@ -140,8 +200,37 @@ final class ContextBuilderWorkspaceContextTests: XCTestCase {
                 store: store
             )
             XCTFail("Expected unavailable inherited worktree to fail closed")
-        } catch let error as AgentWorktreeRuntimeWorkspaceError {
-            XCTAssertEqual(error.binding, binding)
+        } catch let error as ContextBuilderWorkspaceContextError {
+            XCTAssertEqual(error, .unavailableWorktreeProjection)
+            XCTAssertFalse(error.localizedDescription.contains(missingWorktree.path))
+        }
+    }
+
+    func testRequiredLookupRejectsBindingOutsideVisibleWorkspace() async throws {
+        let visibleRoot = try makeTemporaryDirectory(name: "VisibleWorkspace")
+        let otherLogicalRoot = try makeTemporaryDirectory(name: "OtherLogicalWorkspace")
+        let otherWorktreeRoot = try makeTemporaryDirectory(name: "OtherWorktree")
+        defer {
+            try? FileManager.default.removeItem(at: visibleRoot)
+            try? FileManager.default.removeItem(at: otherLogicalRoot)
+            try? FileManager.default.removeItem(at: otherWorktreeRoot)
+        }
+
+        let store = WorkspaceFileContextStore()
+        _ = try await store.loadRoot(path: visibleRoot.path)
+        let binding = makeBinding(logicalRoot: otherLogicalRoot, worktreeRoot: otherWorktreeRoot)
+
+        do {
+            _ = try await AgentWorkspaceLookupContextResolver.requiredLookupContext(
+                source: AgentWorkspaceLookupContextSource(
+                    activeAgentSessionID: UUID(),
+                    worktreeBindings: [binding]
+                ),
+                store: store
+            )
+            XCTFail("Expected a binding outside the visible workspace to fail closed")
+        } catch let error as AgentWorkspaceLookupContextResolutionError {
+            XCTAssertEqual(error.localizedDescription, AgentWorkspaceLookupContextResolutionError.unavailableProjection.localizedDescription)
         }
     }
 

--- a/Tests/RepoPromptTests/ContextBuilder/ContextBuilderWorktreeInheritanceTests.swift
+++ b/Tests/RepoPromptTests/ContextBuilder/ContextBuilderWorktreeInheritanceTests.swift
@@ -1,0 +1,644 @@
+import Darwin
+import Foundation
+@testable import RepoPrompt
+import XCTest
+
+#if DEBUG
+    @MainActor
+    final class ContextBuilderWorktreeInheritanceTests: XCTestCase {
+        func testAgentModeContextBuilderUsesFrozenWorktreeAcrossNestedToolsAccountingAndFollowUps() async throws {
+            try await MCPSharedServerTestLease.shared.withLease { lease in
+                let state = ContextBuilderWorktreeProbeState()
+                let factory = ContextBuilderWorktreeProbeFactory(state: state)
+                let fixture = try await PersistentMCPTestFixture.make(
+                    lease: lease,
+                    contextBuilderProviderFactory: factory.makeProvider
+                )
+                do {
+                    try await activateWorkspace(fixture.contextA)
+                    let logicalRoot = fixture.contextA.rootURL
+                    let logicalFile = fixture.contextA.fileURL
+                    let worktreeRoot = try makeTemporaryRoot(name: "ContextBuilderWorktree")
+                    let worktreeFile = worktreeRoot
+                        .appendingPathComponent("Sources", isDirectory: true)
+                        .appendingPathComponent(logicalFile.lastPathComponent)
+                    let canonicalSentinel = "CanonicalContextBuilderType"
+                    let worktreeSentinel = "WorktreeContextBuilderType"
+                    try write(
+                        "struct \(canonicalSentinel) { func canonicalOnly() {} }\n",
+                        to: logicalFile
+                    )
+                    try write(
+                        "struct \(worktreeSentinel) { func worktreeOnly() {} }\n",
+                        to: worktreeFile
+                    )
+                    try write(
+                        "struct BranchOnlyContextBuilderType {}\n",
+                        to: worktreeRoot.appendingPathComponent("Sources/BranchOnly.swift")
+                    )
+
+                    let sessionID = UUID()
+                    let parentRunID = UUID()
+                    let binding = makeBinding(
+                        logicalRoot: logicalRoot,
+                        worktreeRoot: worktreeRoot,
+                        suffix: "context-builder"
+                    )
+                    let frozenContext = MCPServerViewModel.TabContextSnapshot(
+                        tabID: fixture.contextA.tabID,
+                        windowID: fixture.contextA.window.windowID,
+                        workspaceID: fixture.contextA.workspaceID,
+                        promptText: "Inspect the worktree implementation",
+                        selection: StoredSelection(),
+                        selectedMetaPromptIDs: [],
+                        tabName: "Agent Context Builder",
+                        runID: parentRunID,
+                        activeAgentSessionID: sessionID,
+                        worktreeBindings: [binding],
+                        explicitlyBound: false
+                    )
+                    let outerEndpoint = try fixture.endpointA()
+                    try await configureAgentModeEndpoint(
+                        outerEndpoint,
+                        context: frozenContext,
+                        fixture: fixture
+                    )
+                    var composeTab = try XCTUnwrap(
+                        fixture.contextA.window.workspaceManager.composeTab(with: fixture.contextA.tabID)
+                    )
+                    composeTab.promptText = frozenContext.promptText
+                    fixture.contextA.window.workspaceManager.updateComposeTab(composeTab, markDirty: false)
+                    factory.configure(
+                        networkManager: fixture.networkManager,
+                        logicalFilePath: logicalFile.path,
+                        searchPattern: worktreeSentinel
+                    )
+
+                    fixture.contextA.window.mcpServer.setContextBuilderSelectionReplyObserverForTesting {
+                        selection, lookupContext, reply in
+                        state.recordAccounting(
+                            selection: selection,
+                            lookupContext: lookupContext,
+                            totalTokens: reply.totalTokens ?? 0
+                        )
+                    }
+                    fixture.contextA.window.mcpServer.setContextBuilderFollowUpOverrideForTesting {
+                        _, tabID, mode, prompt, selection, lookupContext in
+                        let message = await fixture.contextA.window.promptManager.buildHeadlessAIMessage(
+                            from: HeadlessContextSnapshot(
+                                tabID: tabID,
+                                promptText: prompt,
+                                selection: selection,
+                                lookupContext: lookupContext
+                            ),
+                            model: fixture.contextA.window.promptManager.preferredAIModel,
+                            mode: mode
+                        )
+                        state.recordFollowUp(
+                            mode: mode,
+                            fileTree: message.fileTree,
+                            fileBlocks: message.fileBlocks,
+                            gitDiff: message.gitDiff,
+                            selection: selection,
+                            lookupContext: lookupContext
+                        )
+                        return ChatSendReply(
+                            chatId: UUID(),
+                            shortId: "cb-\(mode.mcpModeName)",
+                            mode: mode.mcpModeName,
+                            response: "generated \(mode.mcpModeName)",
+                            errors: nil
+                        )
+                    }
+                    defer {
+                        fixture.contextA.window.mcpServer.setContextBuilderFollowUpOverrideForTesting(nil)
+                        fixture.contextA.window.mcpServer.setContextBuilderSelectionReplyObserverForTesting(nil)
+                    }
+
+                    for responseType in ["plan", "review"] {
+                        let response = try await outerEndpoint.callTool(
+                            name: MCPWindowToolName.contextBuilder,
+                            arguments: [
+                                "instructions": "Inspect the selected implementation.",
+                                "response_type": responseType
+                            ],
+                            timeoutSeconds: 45
+                        )
+                        let text = try toolResultText(response)
+                        XCTAssertTrue(text.contains("generated \(responseType)"), text)
+                        XCTAssertTrue(text.contains(logicalFile.lastPathComponent), text)
+                        XCTAssertFalse(text.contains(canonicalSentinel), text)
+                    }
+
+                    let runs = state.runs
+                    XCTAssertEqual(runs.count, 2)
+                    for run in runs {
+                        XCTAssertEqual(run.workspacePath, worktreeRoot.standardizedFileURL.path)
+                        XCTAssertTrue(run.userMessage.contains("BranchOnly.swift"), run.userMessage)
+                        XCTAssertFalse(run.userMessage.contains(canonicalSentinel), run.userMessage)
+                        XCTAssertFalse(run.userMessage.contains(worktreeRoot.path), run.userMessage)
+                        for output in [run.tree, run.read, run.search, run.codeStructure, run.selection] {
+                            XCTAssertFalse(output.contains(canonicalSentinel), output)
+                        }
+                        XCTAssertTrue(run.tree.contains("BranchOnly.swift"), run.tree)
+                        XCTAssertTrue(run.read.contains(worktreeSentinel), run.read)
+                        XCTAssertTrue(run.search.contains(worktreeSentinel), run.search)
+                        XCTAssertTrue(run.codeStructure.contains(worktreeSentinel), run.codeStructure)
+                        XCTAssertTrue(run.selection.contains(logicalFile.lastPathComponent), run.selection)
+                    }
+
+                    let followUps = state.followUps
+                    XCTAssertEqual(followUps.map(\.mode), ["plan", "review"])
+                    for followUp in followUps {
+                        let packaged = followUp.fileBlocks.joined(separator: "\n")
+                        XCTAssertTrue(packaged.contains(worktreeSentinel), packaged)
+                        XCTAssertFalse(packaged.contains(canonicalSentinel), packaged)
+                        XCTAssertFalse(packaged.contains(worktreeRoot.path), packaged)
+                        XCTAssertFalse(followUp.fileTree.contains(worktreeRoot.path), followUp.fileTree)
+                        XCTAssertEqual(followUp.selection.selectedPaths, [logicalFile.path])
+                        XCTAssertNotNil(followUp.lookupContext?.bindingProjection)
+                    }
+
+                    let lookupContext = try await AgentWorkspaceLookupContextResolver.requiredLookupContext(
+                        source: AgentWorkspaceLookupContextSource(
+                            activeAgentSessionID: sessionID,
+                            worktreeBindings: [binding]
+                        ),
+                        store: fixture.contextA.window.workspaceFileContextStore
+                    )
+                    let finalSelection = try XCTUnwrap(
+                        fixture.contextA.window.workspaceManager.composeTab(with: fixture.contextA.tabID)?.selection
+                    )
+                    let expected = await fixture.contextA.window.mcpServer.buildTabSelectionReply(
+                        from: finalSelection,
+                        includeBlocks: false,
+                        display: .relative,
+                        codeMapUsageOverride: .auto,
+                        lookupContextOverride: lookupContext
+                    )
+                    XCTAssertEqual(state.accounting.count, 2)
+                    for accounting in state.accounting {
+                        XCTAssertEqual(accounting.totalTokens, expected.totalTokens ?? 0)
+                        XCTAssertEqual(accounting.selection.selectedPaths, [logicalFile.path])
+                        XCTAssertNotNil(accounting.lookupContext?.bindingProjection)
+                    }
+
+                    fixture.contextA.window.mcpServer.setContextBuilderSelectionReplyObserverForTesting(nil)
+                    await fixture.cleanup()
+                } catch {
+                    fixture.contextA.window.mcpServer.setContextBuilderFollowUpOverrideForTesting(nil)
+                    fixture.contextA.window.mcpServer.setContextBuilderSelectionReplyObserverForTesting(nil)
+                    await fixture.cleanup()
+                    throw error
+                }
+            }
+        }
+
+        func testAgentModeContextBuilderFailsClosedBeforeProviderCreationWhenWorktreeIsUnavailable() async throws {
+            try await MCPSharedServerTestLease.shared.withLease { lease in
+                let state = ContextBuilderWorktreeProbeState()
+                let factory = ContextBuilderWorktreeProbeFactory(state: state)
+                let fixture = try await PersistentMCPTestFixture.make(
+                    lease: lease,
+                    contextBuilderProviderFactory: factory.makeProvider
+                )
+                do {
+                    try await activateWorkspace(fixture.contextA)
+                    let canonicalSentinel = "CanonicalUnavailableContextBuilderType"
+                    try write(
+                        "struct \(canonicalSentinel) { func canonicalOnly() {} }\n",
+                        to: fixture.contextA.fileURL
+                    )
+                    let missingWorktree = fixture.rootURL.appendingPathComponent(
+                        "missing-context-builder-worktree-\(UUID().uuidString)",
+                        isDirectory: true
+                    )
+                    let binding = makeBinding(
+                        logicalRoot: fixture.contextA.rootURL,
+                        worktreeRoot: missingWorktree,
+                        suffix: "missing-context-builder"
+                    )
+                    let frozenContext = MCPServerViewModel.TabContextSnapshot(
+                        tabID: fixture.contextA.tabID,
+                        windowID: fixture.contextA.window.windowID,
+                        workspaceID: fixture.contextA.workspaceID,
+                        promptText: "Inspect the unavailable worktree",
+                        selection: StoredSelection(
+                            selectedPaths: [fixture.contextA.fileURL.path],
+                            codemapAutoEnabled: false
+                        ),
+                        selectedMetaPromptIDs: [],
+                        tabName: "Unavailable Agent Context Builder",
+                        runID: UUID(),
+                        activeAgentSessionID: UUID(),
+                        worktreeBindings: [binding],
+                        explicitlyBound: false
+                    )
+                    let endpoint = try fixture.endpointA()
+                    try await configureAgentModeEndpoint(endpoint, context: frozenContext, fixture: fixture)
+                    factory.configure(
+                        networkManager: fixture.networkManager,
+                        logicalFilePath: fixture.contextA.fileURL.path,
+                        searchPattern: canonicalSentinel
+                    )
+
+                    let response = try await endpoint.callTool(
+                        name: MCPWindowToolName.contextBuilder,
+                        arguments: ["instructions": "Inspect the unavailable worktree."],
+                        timeoutSeconds: 20
+                    )
+                    XCTAssertTrue(response.rawJSON.contains(missingWorktree.standardizedFileURL.path), response.rawJSON)
+                    XCTAssertFalse(response.rawJSON.contains(canonicalSentinel), response.rawJSON)
+                    XCTAssertEqual(state.providerCreationCount, 0)
+                    XCTAssertTrue(state.runs.isEmpty)
+
+                    await fixture.cleanup()
+                } catch {
+                    await fixture.cleanup()
+                    throw error
+                }
+            }
+        }
+
+        func testNonAgentContextBuilderKeepsCanonicalWorkspaceBehavior() async throws {
+            try await MCPSharedServerTestLease.shared.withLease { lease in
+                let state = ContextBuilderWorktreeProbeState()
+                let factory = ContextBuilderWorktreeProbeFactory(state: state)
+                let fixture = try await PersistentMCPTestFixture.make(
+                    lease: lease,
+                    contextBuilderProviderFactory: factory.makeProvider
+                )
+                do {
+                    try await activateWorkspace(fixture.contextA)
+                    let canonicalSentinel = "CanonicalNonAgentContextBuilderType"
+                    try write(
+                        "struct \(canonicalSentinel) { func canonicalMethod() {} }\n",
+                        to: fixture.contextA.fileURL
+                    )
+                    factory.configure(
+                        networkManager: fixture.networkManager,
+                        logicalFilePath: fixture.contextA.fileURL.path,
+                        searchPattern: canonicalSentinel
+                    )
+                    let endpoint = try fixture.endpointA()
+                    let response = try await endpoint.callTool(
+                        name: MCPWindowToolName.contextBuilder,
+                        arguments: [
+                            "instructions": "Inspect the canonical checkout.",
+                            "context_id": fixture.contextA.tabID.uuidString
+                        ],
+                        timeoutSeconds: 45
+                    )
+                    let text = try toolResultText(response)
+                    XCTAssertTrue(text.contains(fixture.contextA.fileURL.lastPathComponent), text)
+
+                    let run = try XCTUnwrap(state.runs.first)
+                    XCTAssertEqual(run.workspacePath, fixture.contextA.rootURL.standardizedFileURL.path)
+                    XCTAssertTrue(run.read.contains(canonicalSentinel), run.read)
+                    XCTAssertTrue(run.search.contains(canonicalSentinel), run.search)
+                    XCTAssertTrue(run.codeStructure.contains(canonicalSentinel), run.codeStructure)
+                    XCTAssertNil(state.followUps.first)
+
+                    await fixture.cleanup()
+                } catch {
+                    await fixture.cleanup()
+                    throw error
+                }
+            }
+        }
+
+        private func activateWorkspace(_ context: PersistentMCPTestContext) async throws {
+            let workspace = try XCTUnwrap(
+                context.window.workspaceManager.workspaces.first { $0.id == context.workspaceID }
+            )
+            await context.window.workspaceManager.switchWorkspace(
+                to: workspace,
+                saveState: false,
+                reason: "ContextBuilderWorktreeInheritanceTests"
+            )
+            let activeWorkspace = try XCTUnwrap(context.window.workspaceManager.activeWorkspace)
+            context.window.promptManager.loadComposeTabsFromWorkspace(activeWorkspace, syncPromptText: true)
+        }
+
+        private func configureAgentModeEndpoint(
+            _ endpoint: PersistentMCPTestEndpoint,
+            context: MCPServerViewModel.TabContextSnapshot,
+            fixture: PersistentMCPTestFixture
+        ) async throws {
+            _ = try await endpoint.callTool(
+                name: "bind_context",
+                arguments: ["op": "bind", "context_id": context.tabID.uuidString]
+            )
+            await fixture.networkManager.setRunPurpose(.agentModeRun, for: endpoint.connectionID)
+            try await fixture.networkManager.debugSeedConnectionRunRouting(
+                connectionID: endpoint.connectionID,
+                runID: XCTUnwrap(context.runID),
+                purpose: .agentModeRun,
+                windowID: context.windowID
+            )
+            fixture.contextA.window.mcpServer.installFrozenTabContext(
+                clientID: endpoint.connectionID.uuidString,
+                clientName: endpoint.clientName,
+                context: context
+            )
+        }
+
+        private func toolResultText(_ response: PersistentMCPTestRPCResponse) throws -> String {
+            let data = try XCTUnwrap(response.rawJSON.data(using: .utf8))
+            let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+            let result = try XCTUnwrap(object["result"] as? [String: Any])
+            let content = try XCTUnwrap(result["content"] as? [[String: Any]])
+            return content.compactMap { $0["text"] as? String }.joined()
+        }
+
+        private func makeBinding(
+            logicalRoot: URL,
+            worktreeRoot: URL,
+            suffix: String
+        ) -> AgentSessionWorktreeBinding {
+            AgentSessionWorktreeBinding(
+                id: "binding-\(suffix)",
+                repositoryID: "repo-\(suffix)",
+                repoKey: logicalRoot.path,
+                logicalRootPath: logicalRoot.path,
+                logicalRootName: logicalRoot.lastPathComponent,
+                worktreeID: "worktree-\(suffix)",
+                worktreeRootPath: worktreeRoot.path,
+                worktreeName: worktreeRoot.lastPathComponent,
+                branch: "feature/\(suffix)",
+                source: "test"
+            )
+        }
+
+        private func makeTemporaryRoot(name: String) throws -> URL {
+            let url = FileManager.default.temporaryDirectory
+                .appendingPathComponent("ContextBuilderWorktreeInheritanceTests", isDirectory: true)
+                .appendingPathComponent("\(name)-\(UUID().uuidString)", isDirectory: true)
+            try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+            addTeardownBlock { try? FileManager.default.removeItem(at: url) }
+            return url.standardizedFileURL
+        }
+
+        private func write(_ content: String, to url: URL) throws {
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try content.write(to: url, atomically: true, encoding: .utf8)
+        }
+    }
+
+    @MainActor
+    private final class ContextBuilderWorktreeProbeFactory {
+        private struct Configuration {
+            let networkManager: ServerNetworkManager
+            let logicalFilePath: String
+            let searchPattern: String
+        }
+
+        private let state: ContextBuilderWorktreeProbeState
+        private var configuration: Configuration?
+
+        init(state: ContextBuilderWorktreeProbeState) {
+            self.state = state
+        }
+
+        func configure(
+            networkManager: ServerNetworkManager,
+            logicalFilePath: String,
+            searchPattern: String
+        ) {
+            configuration = Configuration(
+                networkManager: networkManager,
+                logicalFilePath: logicalFilePath,
+                searchPattern: searchPattern
+            )
+        }
+
+        func makeProvider(
+            agent: AgentProviderKind,
+            modelString: String?,
+            workspacePath: String?
+        ) -> HeadlessAgentProvider {
+            _ = modelString
+            state.recordProviderCreation()
+            guard let configuration else {
+                preconditionFailure("Context Builder probe provider used before configuration")
+            }
+            guard let clientName = agent.mcpClientNameHint else {
+                preconditionFailure("Context Builder probe agent has no MCP client name")
+            }
+            return ContextBuilderWorktreeProbeProvider(
+                state: state,
+                networkManager: configuration.networkManager,
+                logicalFilePath: configuration.logicalFilePath,
+                searchPattern: configuration.searchPattern,
+                clientName: clientName,
+                workspacePath: workspacePath
+            )
+        }
+    }
+
+    private final class ContextBuilderWorktreeProbeProvider: HeadlessAgentProvider {
+        private let state: ContextBuilderWorktreeProbeState
+        private let networkManager: ServerNetworkManager
+        private let logicalFilePath: String
+        private let searchPattern: String
+        private let clientName: String
+        private let workspacePath: String?
+        private var endpoint: PersistentMCPTestEndpoint?
+        private var activeRunID: UUID?
+
+        init(
+            state: ContextBuilderWorktreeProbeState,
+            networkManager: ServerNetworkManager,
+            logicalFilePath: String,
+            searchPattern: String,
+            clientName: String,
+            workspacePath: String?
+        ) {
+            self.state = state
+            self.networkManager = networkManager
+            self.logicalFilePath = logicalFilePath
+            self.searchPattern = searchPattern
+            self.clientName = clientName
+            self.workspacePath = workspacePath
+        }
+
+        func streamAgentMessage(
+            _ message: AgentMessage,
+            runID: UUID?
+        ) async throws -> AsyncThrowingStream<AIStreamResult, Error> {
+            guard let runID else { throw CancellationError() }
+            activeRunID = runID
+            await networkManager.registerExpectedAgentPID(
+                getpid(),
+                for: clientName,
+                runID: runID
+            )
+            let endpoint = try await PersistentMCPTestEndpoint.make(
+                label: "context-builder-worktree-probe",
+                networkManager: networkManager,
+                clientName: clientName,
+                requiredToolNames: [
+                    MCPWindowToolName.getFileTree,
+                    MCPWindowToolName.readFile,
+                    MCPWindowToolName.search,
+                    MCPWindowToolName.getCodeStructure,
+                    MCPWindowToolName.manageSelection
+                ]
+            )
+            self.endpoint = endpoint
+
+            let tree = try await toolResultText(endpoint.callTool(
+                name: MCPWindowToolName.getFileTree,
+                arguments: [:],
+                timeoutSeconds: 20
+            ))
+            let read = try await toolResultText(endpoint.callTool(
+                name: MCPWindowToolName.readFile,
+                arguments: ["path": logicalFilePath],
+                timeoutSeconds: 20
+            ))
+            let search = try await toolResultText(endpoint.callTool(
+                name: MCPWindowToolName.search,
+                arguments: [
+                    "pattern": searchPattern,
+                    "mode": "content",
+                    "regex": false
+                ],
+                timeoutSeconds: 20
+            ))
+            let codeStructure = try await toolResultText(endpoint.callTool(
+                name: MCPWindowToolName.getCodeStructure,
+                arguments: [
+                    "paths": [logicalFilePath]
+                ],
+                timeoutSeconds: 30
+            ))
+            let selection = try await toolResultText(endpoint.callTool(
+                name: MCPWindowToolName.manageSelection,
+                arguments: [
+                    "op": "set",
+                    "paths": [logicalFilePath],
+                    "mode": "full"
+                ],
+                timeoutSeconds: 20
+            ))
+            await state.recordRun(ContextBuilderWorktreeProbeState.Run(
+                workspacePath: workspacePath,
+                userMessage: message.userMessage,
+                tree: tree,
+                read: read,
+                search: search,
+                codeStructure: codeStructure,
+                selection: selection
+            ))
+
+            return AsyncThrowingStream { continuation in
+                continuation.yield(AIStreamResult(type: "content", text: "Context selected."))
+                continuation.finish()
+            }
+        }
+
+        func dispose() async {
+            if let endpoint {
+                endpoint.client.close()
+                await endpoint.connectionManager.stop()
+                await networkManager.debugRemoveConnection(endpoint.connectionID)
+                await networkManager.clearClientConnectionPolicy(for: endpoint.clientName)
+                await networkManager.debugClearPersistedRoutingState(for: endpoint.clientName)
+            }
+            if let activeRunID {
+                await networkManager.clearExpectedAgentPID(
+                    getpid(),
+                    for: clientName,
+                    runID: activeRunID
+                )
+            }
+            endpoint = nil
+            activeRunID = nil
+        }
+
+        private func toolResultText(
+            _ response: PersistentMCPTestRPCResponse
+        ) throws -> String {
+            let data = try XCTUnwrap(response.rawJSON.data(using: .utf8))
+            let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+            let result = try XCTUnwrap(object["result"] as? [String: Any])
+            let content = try XCTUnwrap(result["content"] as? [[String: Any]])
+            return content.compactMap { $0["text"] as? String }.joined()
+        }
+    }
+
+    @MainActor
+    private final class ContextBuilderWorktreeProbeState {
+        struct Run {
+            let workspacePath: String?
+            let userMessage: String
+            let tree: String
+            let read: String
+            let search: String
+            let codeStructure: String
+            let selection: String
+        }
+
+        struct FollowUp {
+            let mode: String
+            let fileTree: String
+            let fileBlocks: [String]
+            let gitDiff: String?
+            let selection: StoredSelection
+            let lookupContext: WorkspaceLookupContext?
+        }
+
+        struct Accounting {
+            let selection: StoredSelection
+            let lookupContext: WorkspaceLookupContext?
+            let totalTokens: Int
+        }
+
+        private(set) var providerCreationCount = 0
+        private(set) var runs: [Run] = []
+        private(set) var followUps: [FollowUp] = []
+        private(set) var accounting: [Accounting] = []
+
+        func recordProviderCreation() {
+            providerCreationCount += 1
+        }
+
+        func recordRun(_ run: Run) {
+            runs.append(run)
+        }
+
+        func recordAccounting(
+            selection: StoredSelection,
+            lookupContext: WorkspaceLookupContext?,
+            totalTokens: Int
+        ) {
+            accounting.append(Accounting(
+                selection: selection,
+                lookupContext: lookupContext,
+                totalTokens: totalTokens
+            ))
+        }
+
+        func recordFollowUp(
+            mode: HeadlessMode,
+            fileTree: String,
+            fileBlocks: [String],
+            gitDiff: String?,
+            selection: StoredSelection,
+            lookupContext: WorkspaceLookupContext?
+        ) {
+            followUps.append(FollowUp(
+                mode: mode.mcpModeName,
+                fileTree: fileTree,
+                fileBlocks: fileBlocks,
+                gitDiff: gitDiff,
+                selection: selection,
+                lookupContext: lookupContext
+            ))
+        }
+    }
+#endif

--- a/Tests/RepoPromptTests/ContextBuilder/ContextBuilderWorktreeInheritanceTests.swift
+++ b/Tests/RepoPromptTests/ContextBuilder/ContextBuilderWorktreeInheritanceTests.swift
@@ -132,6 +132,13 @@ import XCTest
 
                     let runs = state.runs
                     XCTAssertEqual(runs.count, 2)
+                    XCTAssertEqual(runs[0].selectionBeforeRead, .empty)
+                    XCTAssertEqual(runs[0].selectionAfterRead, .empty)
+                    XCTAssertEqual(
+                        runs[1].selectionBeforeRead,
+                        .init(fullPaths: [logicalFile.path], slicePaths: [])
+                    )
+                    XCTAssertEqual(runs[1].selectionAfterRead, runs[1].selectionBeforeRead)
                     let logicalRelativeFilePath = String(
                         logicalFile.standardizedFileURL.path.dropFirst(logicalRoot.standardizedFileURL.path.count)
                     ).trimmingCharacters(in: CharacterSet(charactersIn: "/"))
@@ -545,6 +552,16 @@ import XCTest
             )
             self.endpoint = endpoint
 
+            let selectionBeforeRead = try await selectionObservation(endpoint.callTool(
+                name: MCPWindowToolName.manageSelection,
+                arguments: [
+                    "op": "get",
+                    "view": "files",
+                    "path_display": "full",
+                    "_rawJSON": true
+                ],
+                timeoutSeconds: 20
+            ))
             let tree = try await toolResultText(endpoint.callTool(
                 name: MCPWindowToolName.getFileTree,
                 arguments: [:],
@@ -553,6 +570,16 @@ import XCTest
             let read = try await toolResultText(endpoint.callTool(
                 name: MCPWindowToolName.readFile,
                 arguments: ["path": logicalFilePath],
+                timeoutSeconds: 20
+            ))
+            let selectionAfterRead = try await selectionObservation(endpoint.callTool(
+                name: MCPWindowToolName.manageSelection,
+                arguments: [
+                    "op": "get",
+                    "view": "files",
+                    "path_display": "full",
+                    "_rawJSON": true
+                ],
                 timeoutSeconds: 20
             ))
             let search = try await toolResultText(endpoint.callTool(
@@ -590,8 +617,10 @@ import XCTest
             await state.recordRun(ContextBuilderWorktreeProbeState.Run(
                 workspacePath: workspacePath,
                 userMessage: message.userMessage,
+                selectionBeforeRead: selectionBeforeRead,
                 tree: tree,
                 read: read,
+                selectionAfterRead: selectionAfterRead,
                 search: search,
                 codeStructure: codeStructure,
                 selection: selection,
@@ -623,6 +652,21 @@ import XCTest
             activeRunID = nil
         }
 
+        private func selectionObservation(
+            _ response: PersistentMCPTestRPCResponse
+        ) throws -> ContextBuilderWorktreeProbeState.SelectionObservation {
+            let text = try toolResultText(response)
+            let data = try XCTUnwrap(text.data(using: .utf8))
+            let reply = try JSONDecoder().decode(ToolResultDTOs.SelectionReply.self, from: data)
+            return ContextBuilderWorktreeProbeState.SelectionObservation(
+                fullPaths: (reply.files ?? [])
+                    .filter { $0.renderMode == "full" }
+                    .map(\.path)
+                    .sorted(),
+                slicePaths: (reply.fileSlices ?? []).map(\.path).sorted()
+            )
+        }
+
         private func toolResultText(
             _ response: PersistentMCPTestRPCResponse
         ) throws -> String {
@@ -636,11 +680,20 @@ import XCTest
 
     @MainActor
     private final class ContextBuilderWorktreeProbeState {
+        struct SelectionObservation: Equatable {
+            let fullPaths: [String]
+            let slicePaths: [String]
+
+            static let empty = SelectionObservation(fullPaths: [], slicePaths: [])
+        }
+
         struct Run {
             let workspacePath: String?
             let userMessage: String
+            let selectionBeforeRead: SelectionObservation
             let tree: String
             let read: String
+            let selectionAfterRead: SelectionObservation
             let search: String
             let codeStructure: String
             let selection: String

--- a/Tests/RepoPromptTests/ContextBuilder/ContextBuilderWorktreeInheritanceTests.swift
+++ b/Tests/RepoPromptTests/ContextBuilder/ContextBuilderWorktreeInheritanceTests.swift
@@ -132,19 +132,33 @@ import XCTest
 
                     let runs = state.runs
                     XCTAssertEqual(runs.count, 2)
+                    let logicalRelativeFilePath = String(
+                        logicalFile.standardizedFileURL.path.dropFirst(logicalRoot.standardizedFileURL.path.count)
+                    ).trimmingCharacters(in: CharacterSet(charactersIn: "/"))
                     for run in runs {
                         XCTAssertEqual(run.workspacePath, worktreeRoot.standardizedFileURL.path)
                         XCTAssertTrue(run.userMessage.contains("BranchOnly.swift"), run.userMessage)
                         XCTAssertFalse(run.userMessage.contains(canonicalSentinel), run.userMessage)
                         XCTAssertFalse(run.userMessage.contains(worktreeRoot.path), run.userMessage)
-                        for output in [run.tree, run.read, run.search, run.codeStructure, run.selection] {
+                        for output in [run.tree, run.read, run.search, run.codeStructure, run.selection, run.workspaceContext] {
                             XCTAssertFalse(output.contains(canonicalSentinel), output)
+                            XCTAssertFalse(output.contains(worktreeRoot.path), output)
                         }
                         XCTAssertTrue(run.tree.contains("BranchOnly.swift"), run.tree)
                         XCTAssertTrue(run.read.contains(worktreeSentinel), run.read)
                         XCTAssertTrue(run.search.contains(worktreeSentinel), run.search)
-                        XCTAssertTrue(run.codeStructure.contains(worktreeSentinel), run.codeStructure)
+                        if run.codeStructure.contains("Codemap generation pending") {
+                            XCTAssertTrue(run.codeStructure.contains("Files with codemap**: 0"), run.codeStructure)
+                            XCTAssertTrue(run.codeStructure.contains("### Files still awaiting codemap"), run.codeStructure)
+                            assertLogicalPath(logicalRelativeFilePath, in: run.codeStructure)
+                            XCTAssertFalse(run.codeStructure.contains(worktreeSentinel), run.codeStructure)
+                        } else {
+                            XCTAssertFalse(run.codeStructure.contains("Without codemap"), run.codeStructure)
+                            XCTAssertTrue(run.codeStructure.contains(worktreeSentinel), run.codeStructure)
+                        }
                         XCTAssertTrue(run.selection.contains(logicalFile.lastPathComponent), run.selection)
+                        XCTAssertTrue(run.workspaceContext.contains(logicalFile.lastPathComponent), run.workspaceContext)
+                        XCTAssertTrue(run.workspaceContext.contains("session-bound worktree"), run.workspaceContext)
                     }
 
                     let followUps = state.followUps
@@ -166,16 +180,43 @@ import XCTest
                         ),
                         store: fixture.contextA.window.workspaceFileContextStore
                     )
-                    let finalSelection = try XCTUnwrap(
-                        fixture.contextA.window.workspaceManager.composeTab(with: fixture.contextA.tabID)?.selection
-                    )
+                    let followUpSelection = try XCTUnwrap(followUps.first?.selection)
                     let expected = await fixture.contextA.window.mcpServer.buildTabSelectionReply(
-                        from: finalSelection,
+                        from: followUpSelection,
                         includeBlocks: false,
                         display: .relative,
                         codeMapUsageOverride: .auto,
                         lookupContextOverride: lookupContext
                     )
+                    XCTAssertEqual(
+                        Set(expected.files?.compactMap(\.rootPath) ?? []),
+                        Set([logicalRoot.standardizedFileURL.path])
+                    )
+                    let formattedSelection = ToolOutputFormatter.formatSelectionReplyToString(expected)
+                    XCTAssertTrue(formattedSelection.contains(logicalRoot.standardizedFileURL.path), formattedSelection)
+                    XCTAssertFalse(formattedSelection.contains(worktreeRoot.standardizedFileURL.path), formattedSelection)
+
+                    let slicedSelection = StoredSelection(
+                        selectedPaths: [logicalFile.path],
+                        autoCodemapPaths: [],
+                        slices: [logicalFile.path: [LineRange(start: 1, end: 1)]],
+                        codemapAutoEnabled: false
+                    )
+                    let slicedReply = await fixture.contextA.window.mcpServer.buildTabSelectionReply(
+                        from: slicedSelection,
+                        includeBlocks: false,
+                        display: .relative,
+                        codeMapUsageOverride: .none,
+                        lookupContextOverride: lookupContext
+                    )
+                    XCTAssertEqual(
+                        Set(slicedReply.fileSlices?.compactMap(\.rootPath) ?? []),
+                        Set([logicalRoot.standardizedFileURL.path])
+                    )
+                    let formattedSlices = ToolOutputFormatter.formatSelectionReplyToString(slicedReply)
+                    XCTAssertTrue(formattedSlices.contains(logicalRoot.standardizedFileURL.path), formattedSlices)
+                    XCTAssertFalse(formattedSlices.contains(worktreeRoot.standardizedFileURL.path), formattedSlices)
+
                     XCTAssertEqual(state.accounting.count, 2)
                     for accounting in state.accounting {
                         XCTAssertEqual(accounting.totalTokens, expected.totalTokens ?? 0)
@@ -247,7 +288,8 @@ import XCTest
                         arguments: ["instructions": "Inspect the unavailable worktree."],
                         timeoutSeconds: 20
                     )
-                    XCTAssertTrue(response.rawJSON.contains(missingWorktree.standardizedFileURL.path), response.rawJSON)
+                    XCTAssertTrue(response.rawJSON.contains("worktree bindings could not be loaded"), response.rawJSON)
+                    XCTAssertFalse(response.rawJSON.contains(missingWorktree.standardizedFileURL.path), response.rawJSON)
                     XCTAssertFalse(response.rawJSON.contains(canonicalSentinel), response.rawJSON)
                     XCTAssertEqual(state.providerCreationCount, 0)
                     XCTAssertTrue(state.runs.isEmpty)
@@ -349,6 +391,14 @@ import XCTest
             let result = try XCTUnwrap(object["result"] as? [String: Any])
             let content = try XCTUnwrap(result["content"] as? [[String: Any]])
             return content.compactMap { $0["text"] as? String }.joined()
+        }
+
+        private func assertLogicalPath(_ logicalPath: String, in output: String) {
+            let parts = logicalPath.split(separator: "/", maxSplits: 1).map(String.init)
+            let root = parts.first ?? logicalPath
+            let pathWithinRoot = parts.count > 1 ? parts[1] : logicalPath
+            XCTAssertTrue(output.contains("- **\(root)**"), output)
+            XCTAssertTrue(output.contains("  - `\(pathWithinRoot)`"), output)
         }
 
         private func makeBinding(
@@ -485,7 +535,8 @@ import XCTest
                     MCPWindowToolName.readFile,
                     MCPWindowToolName.search,
                     MCPWindowToolName.getCodeStructure,
-                    MCPWindowToolName.manageSelection
+                    MCPWindowToolName.manageSelection,
+                    MCPWindowToolName.workspaceContext
                 ]
             )
             self.endpoint = endpoint
@@ -525,6 +576,13 @@ import XCTest
                 ],
                 timeoutSeconds: 20
             ))
+            let workspaceContext = try await toolResultText(endpoint.callTool(
+                name: MCPWindowToolName.workspaceContext,
+                arguments: [
+                    "include": ["selection", "tree", "tokens"]
+                ],
+                timeoutSeconds: 30
+            ))
             await state.recordRun(ContextBuilderWorktreeProbeState.Run(
                 workspacePath: workspacePath,
                 userMessage: message.userMessage,
@@ -532,7 +590,8 @@ import XCTest
                 read: read,
                 search: search,
                 codeStructure: codeStructure,
-                selection: selection
+                selection: selection,
+                workspaceContext: workspaceContext
             ))
 
             return AsyncThrowingStream { continuation in
@@ -581,6 +640,7 @@ import XCTest
             let search: String
             let codeStructure: String
             let selection: String
+            let workspaceContext: String
         }
 
         struct FollowUp {

--- a/Tests/RepoPromptTests/MCP/AgentManageMCPToolServiceResumeTests.swift
+++ b/Tests/RepoPromptTests/MCP/AgentManageMCPToolServiceResumeTests.swift
@@ -1,0 +1,171 @@
+import Foundation
+import MCP
+@_spi(TestSupport) @testable import RepoPrompt
+import XCTest
+
+@MainActor
+final class AgentManageMCPToolServiceResumeTests: XCTestCase {
+    func testResumeOfControlledSessionPreservesWaitOwnershipAcrossSteering() async throws {
+        let window = try await makeWindow()
+        defer { WindowStatesManager.shared.unregisterWindowState(window) }
+
+        let viewModel = window.agentModeViewModel
+        let sessionID = UUID()
+        let initialConnectionID = UUID()
+        let resumedConnectionID = UUID()
+        let session = await viewModel.ensureSessionReady(tabID: UUID())
+        _ = viewModel.test_installPersistentSessionBinding(sessionID: sessionID, on: session)
+        try await viewModel.mcpActivateControlContext(
+            forTabID: session.tabID,
+            sessionID: sessionID,
+            originatingConnectionID: initialConnectionID,
+            taskLabelKind: .pair,
+            startPending: true
+        )
+        await viewModel.prepareMCPWaitTrackingForRunStart(session: session)
+        _ = session.beginRunAttempt(source: "test.resume.initial")
+        session.runState = .running
+        viewModel.publishMCPStateChange(for: session)
+
+        let initialContext = try XCTUnwrap(session.mcpControlContext)
+        let initialEpoch = try XCTUnwrap(initialContext.currentEpoch)
+        let initialCursor = AgentRunSessionStore.WaitCursor(
+            registration: initialContext.registration,
+            epoch: initialEpoch
+        )
+        let originalWait = Task {
+            await AgentRunSessionStore.waitUntilInteresting(
+                cursor: initialCursor,
+                timeoutSeconds: 1
+            )
+        }
+        try await waitForWaiter(registration: initialContext.registration)
+
+        let service = makeService(window: window, connectionID: resumedConnectionID)
+        _ = try await service.execute(args: [
+            "op": .string("resume_session"),
+            "session_id": .string(sessionID.uuidString)
+        ])
+
+        let resumedContext = try XCTUnwrap(session.mcpControlContext)
+        XCTAssertEqual(resumedContext.activationID, initialContext.activationID)
+        XCTAssertEqual(resumedContext.registration, initialContext.registration)
+        XCTAssertEqual(resumedContext.taskLabelKind, .pair)
+        let currentRegistration = await AgentRunSessionStore.currentRegistration(for: sessionID)
+        XCTAssertEqual(currentRegistration, initialContext.registration)
+
+        session.runState = .cancelled
+        try await viewModel.withMCPRunEpochTransition(sessionID: sessionID, kind: .steering) {
+            await viewModel.prepareMCPWaitTrackingForRunStart(session: session)
+        }
+        let steeredContext = try XCTUnwrap(session.mcpControlContext)
+        let steeredEpoch = try XCTUnwrap(steeredContext.currentEpoch)
+        XCTAssertEqual(steeredContext.registration, initialContext.registration)
+        XCTAssertEqual(steeredEpoch.transitionKind, .steering)
+
+        let firstDisposition = await originalWait.value
+        XCTAssertEqual(firstDisposition, .epochAdvanced(steeredEpoch, .steering))
+
+        let steeredCursor = AgentRunSessionStore.WaitCursor(
+            registration: initialContext.registration,
+            epoch: steeredEpoch
+        )
+        let steeredWait = Task {
+            await AgentRunSessionStore.waitUntilInteresting(
+                cursor: steeredCursor,
+                timeoutSeconds: 1
+            )
+        }
+        try await waitForWaiter(registration: initialContext.registration)
+        let cancelled = makeSnapshot(sessionID: sessionID, status: .cancelled)
+        await AgentRunSessionStore.signalSnapshot(cancelled, cursor: steeredCursor)
+        let terminalDisposition = await steeredWait.value
+        XCTAssertEqual(terminalDisposition, .snapshotReady(cancelled))
+
+        await viewModel.mcpDeactivateControlContext(
+            sessionID: sessionID,
+            cleanupSessionStore: true
+        )
+    }
+
+    private func makeWindow() async throws -> WindowState {
+        let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
+        GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
+        let window = WindowState()
+        WindowStatesManager.shared.registerWindowState(window)
+        GlobalSettingsStore.shared.setMCPAutoStart(previousAutoStart, commit: false)
+
+        let workspace = window.workspaceManager.createWorkspace(
+            name: "Resume Ownership \(UUID().uuidString.prefix(8))",
+            repoPaths: [FileManager.default.currentDirectoryPath],
+            ephemeral: true
+        )
+        await window.workspaceManager.switchWorkspace(
+            to: workspace,
+            saveState: false,
+            reason: "agentManageResumeOwnershipTests"
+        )
+        let activeWorkspace = try XCTUnwrap(window.workspaceManager.activeWorkspace)
+        window.promptManager.loadComposeTabsFromWorkspace(activeWorkspace, syncPromptText: true)
+        return window
+    }
+
+    private func makeService(
+        window: WindowState,
+        connectionID: UUID
+    ) -> AgentManageMCPToolService {
+        AgentManageMCPToolService(
+            toolName: MCPWindowToolName.agentManage,
+            captureRequestMetadata: {
+                MCPServerViewModel.RequestMetadata(
+                    connectionID: connectionID,
+                    clientName: "resume-ownership-regression",
+                    windowID: window.windowID
+                )
+            },
+            requireTargetWindow: { window },
+            resolveSpawnSourceTabID: { _ in nil },
+            resolveSpawnParentSessionID: { _, _ in nil },
+            bindCurrentRequestToTab: { _, _ in }
+        )
+    }
+
+    private func waitForWaiter(
+        registration: AgentRunSessionStore.Registration,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws {
+        for _ in 0 ..< 300 {
+            if await AgentRunSessionStore.shared.test_waiterCount(registration: registration) == 1 {
+                return
+            }
+            try await Task.sleep(nanoseconds: 5_000_000)
+        }
+        XCTFail("Timed out waiting for store waiter", file: file, line: line)
+    }
+
+    private func makeSnapshot(
+        sessionID: UUID,
+        status: AgentRunMCPSnapshot.Status
+    ) -> AgentRunMCPSnapshot {
+        AgentRunMCPSnapshot(
+            sessionID: sessionID,
+            tabID: nil,
+            sessionName: "Pair Session",
+            agentRaw: AgentProviderKind.codexExec.rawValue,
+            agentDisplayName: AgentProviderKind.codexExec.displayName,
+            modelRaw: "codex",
+            reasoningEffortRaw: nil,
+            status: status,
+            statusText: status.rawValue,
+            latestAssistantPreview: "buffered assistant text",
+            interaction: nil,
+            transcriptItemCount: 1,
+            updatedAt: Date(),
+            parentSessionID: nil,
+            failureReason: status == .cancelled ? .cancelled : nil,
+            worktreeBindings: [],
+            activeWorktreeMerges: []
+        )
+    }
+}

--- a/Tests/RepoPromptTests/MCP/AgentRunWorktreeStartTests.swift
+++ b/Tests/RepoPromptTests/MCP/AgentRunWorktreeStartTests.swift
@@ -411,6 +411,54 @@ final class AgentRunWorktreeStartTests: XCTestCase {
         XCTAssertEqual(viewModel.executionLocationProps(tabID: tabID)?.selection, .local)
     }
 
+    func testBindingTransitionMaterializesAndInitializesSessionWorktreeCodemap() async throws {
+        let root = try makeTemporaryDirectory(named: "transition-root")
+        let worktree = try makeTemporaryDirectory(named: "transition-worktree")
+        let sourceFile = worktree.appendingPathComponent("Sources/Transition.swift")
+        try FileManager.default.createDirectory(at: sourceFile.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try "struct TransitionWorktreeType {}\n".write(to: sourceFile, atomically: true, encoding: .utf8)
+        let window = try await makeWindow(root: root)
+        defer { WindowStatesManager.shared.unregisterWindowState(window) }
+        let viewModel = window.agentModeViewModel
+        let createdTabID = await viewModel.createAndActivateSessionTab()
+        let tabID = try XCTUnwrap(createdTabID)
+        let session = await viewModel.ensureSessionReady(tabID: tabID)
+        let sessionID = try XCTUnwrap(session.activeAgentSessionID)
+        session.hasLoadedPersistedState = true
+        session.hasSentFirstMessage = true
+        let binding = makeBinding(logicalRoot: root.path, worktreeRoot: worktree.path, worktreeID: "transition")
+
+        _ = try await viewModel.transitionWorktreeBindings(
+            [binding],
+            forSessionID: sessionID,
+            intent: .externalManagement
+        )
+
+        XCTAssertEqual(session.worktreeBindings, [binding])
+        let materializedProjection = await window.mcpServer.materializeWorkspaceBindingProjection(
+            sessionID: sessionID,
+            bindings: [binding]
+        )
+        let projection = try XCTUnwrap(materializedProjection)
+        let physicalRoot = try XCTUnwrap(projection.physicalRootRefs.first)
+        let redundantInitialization = await window.workspaceFileContextStore.initializeCodemapsForSessionWorktreeRoots(
+            rootIDs: [physicalRoot.id]
+        )
+        XCTAssertTrue(redundantInitialization.isEmpty)
+        let result = await window.workspaceFileContextStore.lookupPath(
+            sourceFile.path,
+            profile: .mcpRead,
+            rootScope: projection.lookupRootScope
+        )
+        let file = try XCTUnwrap(result?.file)
+        let repair = try await window.workspaceFileContextStore.repairMissingCodemapSnapshots(
+            for: [file],
+            timeout: .seconds(6)
+        )
+        XCTAssertTrue(repair.pendingFileIDs.isEmpty)
+        XCTAssertNotNil(repair.snapshotsByFileID[file.id])
+    }
+
     func testStartedThreadCanCreateNewWorktreeAndReplacePrimaryBinding() async throws {
         let fixture = try makeGitFixture()
         let window = try await makeWindow(root: fixture.repo)

--- a/Tests/RepoPromptTests/MCP/AgentRunWorktreeStartTests.swift
+++ b/Tests/RepoPromptTests/MCP/AgentRunWorktreeStartTests.swift
@@ -416,7 +416,11 @@ final class AgentRunWorktreeStartTests: XCTestCase {
         let worktree = try makeTemporaryDirectory(named: "transition-worktree")
         let sourceFile = worktree.appendingPathComponent("Sources/Transition.swift")
         try FileManager.default.createDirectory(at: sourceFile.deletingLastPathComponent(), withIntermediateDirectories: true)
-        try "struct TransitionWorktreeType {}\n".write(to: sourceFile, atomically: true, encoding: .utf8)
+        try "struct TransitionWorktreeType {\n    func transitionMethod() {}\n}\n".write(
+            to: sourceFile,
+            atomically: true,
+            encoding: .utf8
+        )
         let window = try await makeWindow(root: root)
         defer { WindowStatesManager.shared.unregisterWindowState(window) }
         let viewModel = window.agentModeViewModel
@@ -455,8 +459,114 @@ final class AgentRunWorktreeStartTests: XCTestCase {
             for: [file],
             timeout: .seconds(6)
         )
-        XCTAssertTrue(repair.pendingFileIDs.isEmpty)
-        XCTAssertNotNil(repair.snapshotsByFileID[file.id])
+        let immediateSnapshot = repair.snapshotsByFileID[file.id]
+        let snapshot: WorkspaceCodemapSnapshot
+        if immediateSnapshot == nil {
+            XCTAssertEqual(repair.pendingFileIDs, [file.id])
+            snapshot = try await waitForCodemapSnapshot(
+                store: window.workspaceFileContextStore,
+                fileID: file.id
+            )
+        } else {
+            snapshot = try XCTUnwrap(immediateSnapshot)
+        }
+        XCTAssertTrue(snapshot.fileAPI?.apiDescription.contains("TransitionWorktreeType") == true)
+    }
+
+    func testBindingTransitionMaterializesChangedSecondaryBindingWithoutRestartingUnchangedPrimaryIdentity() async throws {
+        let primaryRoot = try makeTemporaryDirectory(named: "transition-primary-root")
+        let primaryWorktree = try makeTemporaryDirectory(named: "transition-primary-worktree")
+        let secondaryRoot = try makeTemporaryDirectory(named: "transition-secondary-root")
+        let secondaryWorktree = try makeTemporaryDirectory(named: "transition-secondary-worktree")
+        try "struct SecondaryWorktreeType {}\n".write(
+            to: secondaryWorktree.appendingPathComponent("Secondary.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+        let window = try await makeWindow(root: primaryRoot)
+        defer { WindowStatesManager.shared.unregisterWindowState(window) }
+        _ = try await window.workspaceFileContextStore.loadRoot(path: secondaryRoot.path)
+        let viewModel = window.agentModeViewModel
+        let createdTabID = await viewModel.createAndActivateSessionTab()
+        let tabID = try XCTUnwrap(createdTabID)
+        let session = await viewModel.ensureSessionReady(tabID: tabID)
+        let sessionID = try XCTUnwrap(session.activeAgentSessionID)
+        session.hasLoadedPersistedState = true
+        session.runState = .running
+        session.runID = UUID()
+        session.providerSessionID = "stable-provider-identity"
+        session.codexConversationID = "stable-codex-identity"
+        let primaryBinding = makeBinding(
+            logicalRoot: primaryRoot.path,
+            worktreeRoot: primaryWorktree.path,
+            worktreeID: "primary"
+        )
+        let secondaryBinding = makeBinding(
+            logicalRoot: secondaryRoot.path,
+            worktreeRoot: secondaryWorktree.path,
+            worktreeID: "secondary"
+        )
+        session.worktreeBindings = [primaryBinding]
+
+        _ = try await viewModel.transitionWorktreeBindings(
+            [primaryBinding, secondaryBinding],
+            forSessionID: sessionID,
+            intent: .externalManagement
+        )
+
+        XCTAssertEqual(session.worktreeBindings, [primaryBinding, secondaryBinding])
+        XCTAssertEqual(session.providerSessionID, "stable-provider-identity")
+        XCTAssertEqual(session.codexConversationID, "stable-codex-identity")
+        let materializedProjection = await window.mcpServer.materializeWorkspaceBindingProjection(
+            sessionID: sessionID,
+            bindings: session.worktreeBindings
+        )
+        let projection = try XCTUnwrap(materializedProjection)
+        XCTAssertEqual(projection.physicalRootPaths, Set([
+            primaryWorktree.standardizedFileURL.path,
+            secondaryWorktree.standardizedFileURL.path
+        ]))
+    }
+
+    func testBindingTransitionRejectsUnavailableSecondaryBindingEvenWhenPrimaryIdentityIsUnchanged() async throws {
+        let primaryRoot = try makeTemporaryDirectory(named: "transition-validation-primary-root")
+        let primaryWorktree = try makeTemporaryDirectory(named: "transition-validation-primary-worktree")
+        let secondaryRoot = try makeTemporaryDirectory(named: "transition-validation-secondary-root")
+        let missingSecondaryWorktree = secondaryRoot.appendingPathComponent("missing-worktree")
+        let window = try await makeWindow(root: primaryRoot)
+        defer { WindowStatesManager.shared.unregisterWindowState(window) }
+        _ = try await window.workspaceFileContextStore.loadRoot(path: secondaryRoot.path)
+        let viewModel = window.agentModeViewModel
+        let createdTabID = await viewModel.createAndActivateSessionTab()
+        let tabID = try XCTUnwrap(createdTabID)
+        let session = await viewModel.ensureSessionReady(tabID: tabID)
+        let sessionID = try XCTUnwrap(session.activeAgentSessionID)
+        session.hasLoadedPersistedState = true
+        session.providerSessionID = "unchanged-provider-identity"
+        let primaryBinding = makeBinding(
+            logicalRoot: primaryRoot.path,
+            worktreeRoot: primaryWorktree.path,
+            worktreeID: "validation-primary"
+        )
+        let unavailableSecondary = makeBinding(
+            logicalRoot: secondaryRoot.path,
+            worktreeRoot: missingSecondaryWorktree.path,
+            worktreeID: "validation-secondary"
+        )
+        session.worktreeBindings = [primaryBinding]
+
+        do {
+            _ = try await viewModel.transitionWorktreeBindings(
+                [primaryBinding, unavailableSecondary],
+                forSessionID: sessionID,
+                intent: .externalManagement
+            )
+            XCTFail("Expected every changed binding set to be validated before commit")
+        } catch {
+            XCTAssertTrue(error.localizedDescription.contains(missingSecondaryWorktree.path), error.localizedDescription)
+        }
+        XCTAssertEqual(session.worktreeBindings, [primaryBinding])
+        XCTAssertEqual(session.providerSessionID, "unchanged-provider-identity")
     }
 
     func testStartedThreadCanCreateNewWorktreeAndReplacePrimaryBinding() async throws {
@@ -1539,6 +1649,23 @@ final class AgentRunWorktreeStartTests: XCTestCase {
 
     private func samePath(_ lhs: String, _ rhs: String) -> Bool {
         URL(fileURLWithPath: lhs).standardizedFileURL.path == URL(fileURLWithPath: rhs).standardizedFileURL.path
+    }
+
+    private func waitForCodemapSnapshot(
+        store: WorkspaceFileContextStore,
+        fileID: UUID,
+        timeout: Duration = .seconds(6)
+    ) async throws -> WorkspaceCodemapSnapshot {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        while clock.now < deadline {
+            if let snapshot = await store.codemapSnapshot(fileID: fileID) {
+                return snapshot
+            }
+            try await Task.sleep(for: .milliseconds(25))
+        }
+        XCTFail("Timed out waiting for codemap snapshot")
+        throw NSError(domain: "AgentRunWorktreeStartTests", code: 1)
     }
 
     private func makeWindow(root: URL) async throws -> WindowState {

--- a/Tests/RepoPromptTests/MCP/GeneratedOracleExportFileWriterTests.swift
+++ b/Tests/RepoPromptTests/MCP/GeneratedOracleExportFileWriterTests.swift
@@ -55,79 +55,51 @@ final class GeneratedOracleExportFileWriterTests: XCTestCase {
         }
     }
 
-    @MainActor
-    func testBoundGeneratedExportUsesWorktreeRootAndIsReadableThroughSameLookupContext() async throws {
-        let logicalRoot = try makeTemporaryRoot(name: "OracleExportBoundLogical")
-        let worktreeRoot = try makeTemporaryRoot(name: "OracleExportBoundWorktree")
+    func testGeneratedExportWriterWritesToBoundWorktreeAndReturnsLogicalPath() async throws {
+        let logicalRoot = try makeTemporaryRoot(name: "OracleExportLogical")
+        let worktreeRoot = try makeTemporaryRoot(name: "OracleExportWorktree")
         let store = WorkspaceFileContextStore()
-        let logicalRecord = try await store.loadRoot(path: logicalRoot.path)
-        let physicalRecord = try await store.loadRoot(
-            path: worktreeRoot.path,
-            kind: .sessionWorktree
+        _ = try await store.loadRoot(path: logicalRoot.path)
+        let sessionID = UUID()
+        let binding = makeBinding(logicalRoot: logicalRoot, worktreeRoot: worktreeRoot)
+        let materializedProjection = await WorkspaceRootBindingProjectionMaterializer(store: store).materialize(
+            sessionID: sessionID,
+            bindings: [binding]
         )
-        let logicalRef = WorkspaceRootRef(id: logicalRecord.id, name: "Project", fullPath: logicalRoot.path)
-        let physicalRef = WorkspaceRootRef(id: physicalRecord.id, name: "Project", fullPath: worktreeRoot.path)
-        let projection = WorkspaceRootBindingProjection(
-            sessionID: UUID(),
-            boundRoots: [
-                .init(
-                    logicalRoot: logicalRef,
-                    physicalRoot: physicalRef,
-                    binding: AgentSessionWorktreeBinding(
-                        id: "binding-id",
-                        repositoryID: "repo-id",
-                        repoKey: "repo-key",
-                        logicalRootPath: logicalRoot.path,
-                        logicalRootName: "Project",
-                        worktreeID: "worktree-id",
-                        worktreeRootPath: worktreeRoot.path,
-                        source: "test"
-                    )
-                )
-            ],
-            visibleLogicalRoots: [logicalRef]
-        )
+        let projection = try XCTUnwrap(materializedProjection)
         let lookupContext = WorkspaceLookupContext(
             rootScope: projection.lookupRootScope,
             bindingProjection: projection
         )
-        let workspace = WorkspaceModel(name: "Bound Export", repoPaths: [logicalRoot.path])
-        let destination = try MCPServerViewModel.makeOracleExportDestination(
-            workspace: workspace,
+        let destination = OracleExportDestination(
+            workspaceID: UUID(),
             windowID: 1,
-            tabID: UUID(),
+            tabID: nil,
+            primaryRootPath: logicalRoot.path,
             lookupContext: lookupContext
         )
+        let logicalExportPath = logicalRoot.appendingPathComponent("prompt-exports/oracle-plan-worktree.md").path
+        let physicalExportPath = worktreeRoot.appendingPathComponent("prompt-exports/oracle-plan-worktree.md").path
 
-        XCTAssertEqual(destination.primaryRootPath, worktreeRoot.standardizedFileURL.path)
-        XCTAssertEqual(destination.rootScope, projection.lookupRootScope)
-
-        let logicalExportPath = logicalRoot.appendingPathComponent("prompt-exports/oracle-plan-bound.md").path
-        let physicalExportPath = lookupContext.translateInputPath(logicalExportPath)
         let resolvedPath = try await GeneratedOracleExportFileWriter(store: store).write(
-            path: physicalExportPath,
-            content: "# Bound Oracle Plan\n\nRead me from the worktree",
+            path: logicalExportPath,
+            content: "# Bound Worktree Export",
             destination: destination
         )
 
-        XCTAssertEqual(
-            resolvedPath,
-            worktreeRoot.appendingPathComponent("prompt-exports/oracle-plan-bound.md").path
-        )
+        XCTAssertEqual(resolvedPath, StandardizedPath.absolute(logicalExportPath))
         XCTAssertFalse(FileManager.default.fileExists(atPath: logicalExportPath))
-        let readableService = WorkspaceReadableFileService(store: store)
-        guard case let .workspace(file) = await readableService.resolveReadableFile(
-            lookupContext.translateInputPath(logicalExportPath),
+        XCTAssertTrue(FileManager.default.fileExists(atPath: physicalExportPath))
+        XCTAssertEqual(try String(contentsOfFile: physicalExportPath), "# Bound Worktree Export")
+        let readable = await WorkspaceReadableFileService(store: store).resolveReadableFile(
+            lookupContext.translateInputPath(resolvedPath),
             profile: .mcpRead,
             rootScope: lookupContext.rootScope
-        ) else {
-            return XCTFail("Bound generated export should be readable through the originating lookup context")
-        }
-        let content = try await store.readContent(
-            rootID: file.rootID,
-            relativePath: file.standardizedRelativePath
         )
-        XCTAssertEqual(content, "# Bound Oracle Plan\n\nRead me from the worktree")
+        guard case let .workspace(file) = readable else {
+            return XCTFail("Returned logical export path should translate to a readable bound-worktree file")
+        }
+        XCTAssertEqual(file.standardizedFullPath, StandardizedPath.absolute(physicalExportPath))
     }
 
     func testGeneratedExportWriterRejectsUnloadedPrimaryRootWithoutDirectFileManagerFallback() async throws {
@@ -150,7 +122,7 @@ final class GeneratedOracleExportFileWriterTests: XCTestCase {
             XCTFail("Expected unloaded generated export root to fail")
         } catch {
             let message = String(describing: error)
-            XCTAssertTrue(message.contains("not loaded in the current read_file workspace scope"), message)
+            XCTAssertTrue(message.contains("not loaded in the bound read_file workspace scope"), message)
         }
         XCTAssertFalse(FileManager.default.fileExists(atPath: exportPath), "Generated exports must not direct-write outside loaded read_file roots")
     }
@@ -233,6 +205,21 @@ final class GeneratedOracleExportFileWriterTests: XCTestCase {
         }
 
         XCTAssertFalse(FileManager.default.fileExists(atPath: outsideTarget), "Rejected generated exports should clean up symlinked disk artifacts")
+    }
+
+    private func makeBinding(logicalRoot: URL, worktreeRoot: URL) -> AgentSessionWorktreeBinding {
+        AgentSessionWorktreeBinding(
+            id: "oracle-export-binding",
+            repositoryID: "oracle-export-repo",
+            repoKey: logicalRoot.path,
+            logicalRootPath: logicalRoot.path,
+            logicalRootName: logicalRoot.lastPathComponent,
+            worktreeID: "oracle-export-worktree",
+            worktreeRootPath: worktreeRoot.path,
+            worktreeName: worktreeRoot.lastPathComponent,
+            branch: "feature/oracle-export",
+            source: "test"
+        )
     }
 
     private func makeTemporaryRoot(name: String) throws -> URL {

--- a/Tests/RepoPromptTests/MCP/MCPAskOracleWorktreeTests.swift
+++ b/Tests/RepoPromptTests/MCP/MCPAskOracleWorktreeTests.swift
@@ -1,0 +1,493 @@
+import Foundation
+@testable import RepoPrompt
+import XCTest
+
+#if DEBUG
+    @MainActor
+    final class MCPAskOracleWorktreeTests: XCTestCase {
+        func testAskOracleWaitsForReadAutoSelectionAndPackagesWorktreeContent() async throws {
+            try await MCPSharedServerTestLease.shared.withLease { lease in
+                let fixture = try await PersistentMCPTestFixture.make(lease: lease)
+                let gate = OracleWorktreeGate()
+                let drainSignal = OracleWorktreeSignal()
+                let capture = OracleWorktreeCapture()
+                do {
+                    try await activateWorkspace(fixture.contextA)
+                    let logicalFile = fixture.contextA.fileURL
+                    let worktreeRoot = try makeTemporaryRoot(name: "OracleDrainWorktree")
+                    let worktreeFile = worktreeRoot
+                        .appendingPathComponent("Sources", isDirectory: true)
+                        .appendingPathComponent(logicalFile.lastPathComponent)
+                    let canonicalSentinel = "canonical_oracle_drain_content"
+                    let worktreeSentinel = "worktree_oracle_drain_content"
+                    try write("let value = \"\(canonicalSentinel)\"\n", to: logicalFile)
+                    try write("let value = \"\(worktreeSentinel)\"\n", to: worktreeFile)
+
+                    let binding = makeBinding(
+                        logicalRoot: fixture.contextA.rootURL,
+                        worktreeRoot: worktreeRoot,
+                        suffix: "drain"
+                    )
+                    let context = makeFrozenContext(
+                        fixture: fixture,
+                        selection: StoredSelection(),
+                        bindings: [binding]
+                    )
+                    let endpoint = try fixture.endpointA()
+                    try await configureAgentModeEndpoint(endpoint, context: context, fixture: fixture)
+                    installOracleCapture(capture, on: fixture.contextA.window)
+                    fixture.contextA.window.mcpServer.setOracleReadAutoSelectionDrainObserverForTesting {
+                        drainSignal.markStarted()
+                    }
+                    fixture.contextA.window.mcpServer.setReadFileAutoSelectionCanonicalApplyGateForTesting {
+                        await gate.markStartedAndWaitForRelease()
+                    }
+
+                    let readTask = Task {
+                        try await endpoint.callTool(
+                            name: MCPWindowToolName.readFile,
+                            arguments: ["path": logicalFile.path],
+                            timeoutSeconds: 20
+                        )
+                    }
+                    await gate.waitUntilStarted()
+                    let readResponse = try await readTask.value
+                    XCTAssertTrue(try toolResultText(readResponse).contains(worktreeSentinel))
+
+                    let askTask = Task {
+                        try await endpoint.callTool(
+                            name: MCPWindowToolName.askOracle,
+                            arguments: ["message": "Explain the selected implementation."],
+                            timeoutSeconds: 30
+                        )
+                    }
+                    await drainSignal.waitUntilStarted()
+                    XCTAssertFalse(capture.wasInvoked)
+
+                    await gate.release()
+                    let askResponse = try await askTask.value
+                    XCTAssertTrue(try toolResultText(askResponse).contains("captured oracle response"))
+                    XCTAssertTrue(capture.wasInvoked)
+                    let tabContext = try XCTUnwrap(capture.tabContext)
+                    XCTAssertEqual(tabContext.selection.selectedPaths, [logicalFile.path])
+                    let packaged = capture.fileBlocks.joined(separator: "\n")
+                    XCTAssertTrue(packaged.contains(worktreeSentinel), packaged)
+                    XCTAssertFalse(packaged.contains(canonicalSentinel), packaged)
+                    XCTAssertFalse(packaged.contains(worktreeRoot.path), packaged)
+                    XCTAssertFalse(capture.fileTree.contains(worktreeRoot.path), capture.fileTree)
+
+                    fixture.contextA.window.mcpServer.setReadFileAutoSelectionCanonicalApplyGateForTesting(nil)
+                    fixture.contextA.window.mcpServer.setOracleReadAutoSelectionDrainObserverForTesting(nil)
+                    fixture.contextA.window.mcpServer.setOracleChatSendOverrideForTesting(nil)
+                    await fixture.cleanup()
+                } catch {
+                    await gate.release()
+                    fixture.contextA.window.mcpServer.setReadFileAutoSelectionCanonicalApplyGateForTesting(nil)
+                    fixture.contextA.window.mcpServer.setOracleReadAutoSelectionDrainObserverForTesting(nil)
+                    fixture.contextA.window.mcpServer.setOracleChatSendOverrideForTesting(nil)
+                    await fixture.cleanup()
+                    throw error
+                }
+            }
+        }
+
+        func testAskOraclePackagesMultipleBoundRootsWithoutCanonicalLeak() async throws {
+            try await MCPSharedServerTestLease.shared.withLease { lease in
+                let fixture = try await PersistentMCPTestFixture.make(lease: lease)
+                let capture = OracleWorktreeCapture()
+                do {
+                    try await activateWorkspace(fixture.contextA)
+                    let logicalRootA = fixture.contextA.rootURL
+                    let logicalFileA = fixture.contextA.fileURL
+                    let logicalRootB = try makeTemporaryRoot(name: "OracleLogicalB")
+                    let logicalFileB = logicalRootB.appendingPathComponent("Sources/Second.swift")
+                    let worktreeRootA = try makeTemporaryRoot(name: "OracleWorktreeA")
+                    let worktreeRootB = try makeTemporaryRoot(name: "OracleWorktreeB")
+                    let worktreeFileA = worktreeRootA
+                        .appendingPathComponent("Sources", isDirectory: true)
+                        .appendingPathComponent(logicalFileA.lastPathComponent)
+                    let worktreeFileB = worktreeRootB.appendingPathComponent("Sources/Second.swift")
+
+                    try write("let value = \"canonical_oracle_a\"\n", to: logicalFileA)
+                    try write("let value = \"canonical_oracle_b\"\n", to: logicalFileB)
+                    try write("let value = \"worktree_oracle_a\"\n", to: worktreeFileA)
+                    try write("let value = \"worktree_oracle_b\"\n", to: worktreeFileB)
+                    _ = try await fixture.contextA.window.workspaceFileContextStore.loadRoot(path: logicalRootB.path)
+
+                    let bindings = [
+                        makeBinding(logicalRoot: logicalRootA, worktreeRoot: worktreeRootA, suffix: "multi-a"),
+                        makeBinding(logicalRoot: logicalRootB, worktreeRoot: worktreeRootB, suffix: "multi-b")
+                    ]
+                    let context = makeFrozenContext(
+                        fixture: fixture,
+                        selection: StoredSelection(
+                            selectedPaths: [logicalFileA.path, logicalFileB.path],
+                            codemapAutoEnabled: false
+                        ),
+                        bindings: bindings
+                    )
+                    let endpoint = try fixture.endpointA()
+                    try await configureAgentModeEndpoint(endpoint, context: context, fixture: fixture)
+                    installOracleCapture(capture, on: fixture.contextA.window)
+
+                    let response = try await endpoint.callTool(
+                        name: MCPWindowToolName.askOracle,
+                        arguments: ["message": "Compare both selected roots."],
+                        timeoutSeconds: 30
+                    )
+                    XCTAssertTrue(try toolResultText(response).contains("captured oracle response"))
+
+                    let packaged = capture.fileBlocks.joined(separator: "\n")
+                    XCTAssertTrue(packaged.contains("worktree_oracle_a"), packaged)
+                    XCTAssertTrue(packaged.contains("worktree_oracle_b"), packaged)
+                    XCTAssertFalse(packaged.contains("canonical_oracle_a"), packaged)
+                    XCTAssertFalse(packaged.contains("canonical_oracle_b"), packaged)
+                    XCTAssertFalse(packaged.contains(worktreeRootA.path), packaged)
+                    XCTAssertFalse(packaged.contains(worktreeRootB.path), packaged)
+                    XCTAssertEqual(capture.tabContext?.lookupContext?.bindingProjection?.boundRootsForMetadata.count, 2)
+
+                    fixture.contextA.window.mcpServer.setOracleChatSendOverrideForTesting(nil)
+                    await fixture.cleanup()
+                } catch {
+                    fixture.contextA.window.mcpServer.setOracleChatSendOverrideForTesting(nil)
+                    await fixture.cleanup()
+                    throw error
+                }
+            }
+        }
+
+        func testAskOracleFailsClosedWhenOneOfMultipleBoundRootsIsUnavailable() async throws {
+            try await MCPSharedServerTestLease.shared.withLease { lease in
+                let fixture = try await PersistentMCPTestFixture.make(lease: lease)
+                let capture = OracleWorktreeCapture()
+                do {
+                    try await activateWorkspace(fixture.contextA)
+                    let logicalRootA = fixture.contextA.rootURL
+                    let logicalFileA = fixture.contextA.fileURL
+                    let logicalRootB = try makeTemporaryRoot(name: "OracleMixedLogicalB")
+                    let logicalFileB = logicalRootB.appendingPathComponent("Sources/Second.swift")
+                    let worktreeRootA = try makeTemporaryRoot(name: "OracleMixedWorktreeA")
+                    let worktreeFileA = worktreeRootA
+                        .appendingPathComponent("Sources", isDirectory: true)
+                        .appendingPathComponent(logicalFileA.lastPathComponent)
+                    let missingWorktreeB = fixture.rootURL.appendingPathComponent(
+                        "missing-mixed-oracle-worktree-\(UUID().uuidString)",
+                        isDirectory: true
+                    )
+
+                    try write("let value = \"canonical_oracle_mixed_a\"\n", to: logicalFileA)
+                    try write("let value = \"canonical_oracle_mixed_b\"\n", to: logicalFileB)
+                    try write("let value = \"worktree_oracle_mixed_a\"\n", to: worktreeFileA)
+                    _ = try await fixture.contextA.window.workspaceFileContextStore.loadRoot(path: logicalRootB.path)
+
+                    let bindings = [
+                        makeBinding(logicalRoot: logicalRootA, worktreeRoot: worktreeRootA, suffix: "mixed-a"),
+                        makeBinding(logicalRoot: logicalRootB, worktreeRoot: missingWorktreeB, suffix: "mixed-b")
+                    ]
+                    let context = makeFrozenContext(
+                        fixture: fixture,
+                        selection: StoredSelection(
+                            selectedPaths: [logicalFileA.path, logicalFileB.path],
+                            codemapAutoEnabled: false
+                        ),
+                        bindings: bindings
+                    )
+                    let endpoint = try fixture.endpointA()
+                    try await configureAgentModeEndpoint(endpoint, context: context, fixture: fixture)
+                    installOracleCapture(capture, on: fixture.contextA.window)
+
+                    let response = try await endpoint.callTool(
+                        name: MCPWindowToolName.askOracle,
+                        arguments: ["message": "Compare the mixed-availability roots."],
+                        timeoutSeconds: 20
+                    )
+                    XCTAssertTrue(response.rawJSON.contains(missingWorktreeB.standardizedFileURL.path), response.rawJSON)
+                    XCTAssertFalse(response.rawJSON.contains("canonical_oracle_mixed_a"), response.rawJSON)
+                    XCTAssertFalse(response.rawJSON.contains("canonical_oracle_mixed_b"), response.rawJSON)
+                    XCTAssertFalse(response.rawJSON.contains("worktree_oracle_mixed_a"), response.rawJSON)
+                    XCTAssertFalse(capture.wasInvoked)
+
+                    fixture.contextA.window.mcpServer.setOracleChatSendOverrideForTesting(nil)
+                    await fixture.cleanup()
+                } catch {
+                    fixture.contextA.window.mcpServer.setOracleChatSendOverrideForTesting(nil)
+                    await fixture.cleanup()
+                    throw error
+                }
+            }
+        }
+
+        func testAskOracleUnavailableWorktreeFailsBeforeCanonicalPackaging() async throws {
+            try await MCPSharedServerTestLease.shared.withLease { lease in
+                let fixture = try await PersistentMCPTestFixture.make(lease: lease)
+                let capture = OracleWorktreeCapture()
+                do {
+                    try await activateWorkspace(fixture.contextA)
+                    let canonicalSentinel = "canonical_oracle_must_not_leak"
+                    try write("let value = \"\(canonicalSentinel)\"\n", to: fixture.contextA.fileURL)
+                    let missingWorktree = fixture.rootURL.appendingPathComponent(
+                        "missing-oracle-worktree-\(UUID().uuidString)",
+                        isDirectory: true
+                    )
+                    let binding = makeBinding(
+                        logicalRoot: fixture.contextA.rootURL,
+                        worktreeRoot: missingWorktree,
+                        suffix: "missing"
+                    )
+                    let context = makeFrozenContext(
+                        fixture: fixture,
+                        selection: StoredSelection(
+                            selectedPaths: [fixture.contextA.fileURL.path],
+                            codemapAutoEnabled: false
+                        ),
+                        bindings: [binding]
+                    )
+                    let endpoint = try fixture.endpointA()
+                    try await configureAgentModeEndpoint(endpoint, context: context, fixture: fixture)
+                    installOracleCapture(capture, on: fixture.contextA.window)
+
+                    let response = try await endpoint.callTool(
+                        name: MCPWindowToolName.askOracle,
+                        arguments: ["message": "Inspect the unavailable worktree."],
+                        timeoutSeconds: 20
+                    )
+                    XCTAssertTrue(response.rawJSON.contains(missingWorktree.standardizedFileURL.path), response.rawJSON)
+                    XCTAssertFalse(response.rawJSON.contains(canonicalSentinel), response.rawJSON)
+                    XCTAssertFalse(capture.wasInvoked)
+
+                    fixture.contextA.window.mcpServer.setOracleChatSendOverrideForTesting(nil)
+                    await fixture.cleanup()
+                } catch {
+                    fixture.contextA.window.mcpServer.setOracleChatSendOverrideForTesting(nil)
+                    await fixture.cleanup()
+                    throw error
+                }
+            }
+        }
+
+        private func installOracleCapture(
+            _ capture: OracleWorktreeCapture,
+            on window: WindowState
+        ) {
+            window.mcpServer.setOracleChatSendOverrideForTesting { args, promptVM, tabContext in
+                let context = try XCTUnwrap(tabContext)
+                let config = PromptContextResolved(
+                    includeFiles: true,
+                    includeUserPrompt: true,
+                    includeMetaPrompts: false,
+                    includeFileTree: true,
+                    fileTreeMode: .auto,
+                    codeMapUsage: .none,
+                    gitInclusion: .none,
+                    storedPromptIds: []
+                )
+                let message = await promptVM.packagePrompt(
+                    conversation: [
+                        ConversationEntry(
+                            role: .user,
+                            content: args["message"]?.stringValue ?? ""
+                        )
+                    ],
+                    overridePromptConfig: config,
+                    overrideMode: .chat,
+                    selectionOverride: context.selection,
+                    lookupContextOverride: context.lookupContext
+                )
+                capture.record(
+                    tabContext: context,
+                    fileTree: message.fileTree,
+                    fileBlocks: message.fileBlocks
+                )
+                return [
+                    "chat_id": .string(UUID().uuidString),
+                    "short_id": .string("oracle-capture"),
+                    "mode": .string("chat"),
+                    "response": .string("captured oracle response")
+                ]
+            }
+        }
+
+        private func makeFrozenContext(
+            fixture: PersistentMCPTestFixture,
+            selection: StoredSelection,
+            bindings: [AgentSessionWorktreeBinding]
+        ) -> MCPServerViewModel.TabContextSnapshot {
+            MCPServerViewModel.TabContextSnapshot(
+                tabID: fixture.contextA.tabID,
+                windowID: fixture.contextA.window.windowID,
+                workspaceID: fixture.contextA.workspaceID,
+                promptText: "Oracle worktree prompt",
+                selection: selection,
+                selectedMetaPromptIDs: [],
+                tabName: "Oracle Worktree",
+                runID: UUID(),
+                activeAgentSessionID: UUID(),
+                worktreeBindings: bindings,
+                explicitlyBound: false
+            )
+        }
+
+        private func configureAgentModeEndpoint(
+            _ endpoint: PersistentMCPTestEndpoint,
+            context: MCPServerViewModel.TabContextSnapshot,
+            fixture: PersistentMCPTestFixture
+        ) async throws {
+            _ = try await endpoint.callTool(
+                name: "bind_context",
+                arguments: ["op": "bind", "context_id": context.tabID.uuidString]
+            )
+            await fixture.networkManager.setRunPurpose(.agentModeRun, for: endpoint.connectionID)
+            try await fixture.networkManager.debugSeedConnectionRunRouting(
+                connectionID: endpoint.connectionID,
+                runID: XCTUnwrap(context.runID),
+                purpose: .agentModeRun,
+                windowID: context.windowID
+            )
+            await fixture.networkManager.debugSetAdditionalTools(
+                for: endpoint.connectionID,
+                additionalTools: [MCPWindowToolName.askOracle]
+            )
+            fixture.contextA.window.mcpServer.installFrozenTabContext(
+                clientID: endpoint.connectionID.uuidString,
+                clientName: endpoint.clientName,
+                context: context
+            )
+        }
+
+        private func activateWorkspace(_ context: PersistentMCPTestContext) async throws {
+            let workspace = try XCTUnwrap(
+                context.window.workspaceManager.workspaces.first { $0.id == context.workspaceID }
+            )
+            await context.window.workspaceManager.switchWorkspace(
+                to: workspace,
+                saveState: false,
+                reason: "MCPAskOracleWorktreeTests"
+            )
+            let activeWorkspace = try XCTUnwrap(context.window.workspaceManager.activeWorkspace)
+            context.window.promptManager.loadComposeTabsFromWorkspace(activeWorkspace, syncPromptText: true)
+        }
+
+        private func toolResultText(_ response: PersistentMCPTestRPCResponse) throws -> String {
+            let data = try XCTUnwrap(response.rawJSON.data(using: .utf8))
+            let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+            let result = try XCTUnwrap(object["result"] as? [String: Any])
+            let content = try XCTUnwrap(result["content"] as? [[String: Any]])
+            return content.compactMap { $0["text"] as? String }.joined()
+        }
+
+        private func makeBinding(
+            logicalRoot: URL,
+            worktreeRoot: URL,
+            suffix: String
+        ) -> AgentSessionWorktreeBinding {
+            AgentSessionWorktreeBinding(
+                id: "binding-\(suffix)",
+                repositoryID: "repo-\(suffix)",
+                repoKey: logicalRoot.path,
+                logicalRootPath: logicalRoot.path,
+                logicalRootName: logicalRoot.lastPathComponent,
+                worktreeID: "worktree-\(suffix)",
+                worktreeRootPath: worktreeRoot.path,
+                worktreeName: worktreeRoot.lastPathComponent,
+                branch: "feature/\(suffix)",
+                source: "test"
+            )
+        }
+
+        private func makeTemporaryRoot(name: String) throws -> URL {
+            let url = FileManager.default.temporaryDirectory
+                .appendingPathComponent("MCPAskOracleWorktreeTests", isDirectory: true)
+                .appendingPathComponent("\(name)-\(UUID().uuidString)", isDirectory: true)
+            try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+            addTeardownBlock { try? FileManager.default.removeItem(at: url) }
+            return url.standardizedFileURL
+        }
+
+        private func write(_ content: String, to url: URL) throws {
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try content.write(to: url, atomically: true, encoding: .utf8)
+        }
+    }
+
+    @MainActor
+    private final class OracleWorktreeCapture {
+        private(set) var wasInvoked = false
+        private(set) var tabContext: OracleViewModel.OracleSendTabContext?
+        private(set) var fileTree = ""
+        private(set) var fileBlocks: [String] = []
+
+        func record(
+            tabContext: OracleViewModel.OracleSendTabContext,
+            fileTree: String,
+            fileBlocks: [String]
+        ) {
+            wasInvoked = true
+            self.tabContext = tabContext
+            self.fileTree = fileTree
+            self.fileBlocks = fileBlocks
+        }
+    }
+
+    @MainActor
+    private final class OracleWorktreeSignal {
+        private var started = false
+        private var waiters: [CheckedContinuation<Void, Never>] = []
+
+        func markStarted() {
+            guard !started else { return }
+            started = true
+            let pending = waiters
+            waiters.removeAll()
+            for waiter in pending {
+                waiter.resume()
+            }
+        }
+
+        func waitUntilStarted() async {
+            guard !started else { return }
+            await withCheckedContinuation { continuation in
+                waiters.append(continuation)
+            }
+        }
+    }
+
+    private actor OracleWorktreeGate {
+        private var started = false
+        private var released = false
+        private var startWaiters: [CheckedContinuation<Void, Never>] = []
+        private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+
+        func markStartedAndWaitForRelease() async {
+            started = true
+            let waiters = startWaiters
+            startWaiters.removeAll()
+            for waiter in waiters {
+                waiter.resume()
+            }
+            guard !released else { return }
+            await withCheckedContinuation { continuation in
+                releaseWaiters.append(continuation)
+            }
+        }
+
+        func waitUntilStarted() async {
+            guard !started else { return }
+            await withCheckedContinuation { continuation in
+                startWaiters.append(continuation)
+            }
+        }
+
+        func release() {
+            guard !released else { return }
+            released = true
+            let waiters = releaseWaiters
+            releaseWaiters.removeAll()
+            for waiter in waiters {
+                waiter.resume()
+            }
+        }
+    }
+#endif

--- a/Tests/RepoPromptTests/MCP/MCPAskOracleWorktreeTests.swift
+++ b/Tests/RepoPromptTests/MCP/MCPAskOracleWorktreeTests.swift
@@ -201,7 +201,8 @@ import XCTest
                         arguments: ["message": "Compare the mixed-availability roots."],
                         timeoutSeconds: 20
                     )
-                    XCTAssertTrue(response.rawJSON.contains(missingWorktreeB.standardizedFileURL.path), response.rawJSON)
+                    XCTAssertTrue(response.rawJSON.contains("worktree projection is unavailable"), response.rawJSON)
+                    XCTAssertFalse(response.rawJSON.contains(missingWorktreeB.standardizedFileURL.path), response.rawJSON)
                     XCTAssertFalse(response.rawJSON.contains("canonical_oracle_mixed_a"), response.rawJSON)
                     XCTAssertFalse(response.rawJSON.contains("canonical_oracle_mixed_b"), response.rawJSON)
                     XCTAssertFalse(response.rawJSON.contains("worktree_oracle_mixed_a"), response.rawJSON)
@@ -251,7 +252,48 @@ import XCTest
                         arguments: ["message": "Inspect the unavailable worktree."],
                         timeoutSeconds: 20
                     )
-                    XCTAssertTrue(response.rawJSON.contains(missingWorktree.standardizedFileURL.path), response.rawJSON)
+                    XCTAssertTrue(response.rawJSON.contains("worktree projection is unavailable"), response.rawJSON)
+                    XCTAssertFalse(response.rawJSON.contains(missingWorktree.standardizedFileURL.path), response.rawJSON)
+                    XCTAssertFalse(response.rawJSON.contains(canonicalSentinel), response.rawJSON)
+                    XCTAssertFalse(capture.wasInvoked)
+
+                    fixture.contextA.window.mcpServer.setOracleChatSendOverrideForTesting(nil)
+                    await fixture.cleanup()
+                } catch {
+                    fixture.contextA.window.mcpServer.setOracleChatSendOverrideForTesting(nil)
+                    await fixture.cleanup()
+                    throw error
+                }
+            }
+        }
+
+        func testAskOracleFailsClosedWhenFrozenBindingStateIsUnhydrated() async throws {
+            try await MCPSharedServerTestLease.shared.withLease { lease in
+                let fixture = try await PersistentMCPTestFixture.make(lease: lease)
+                let capture = OracleWorktreeCapture()
+                do {
+                    try await activateWorkspace(fixture.contextA)
+                    let canonicalSentinel = "canonical_oracle_unhydrated_must_not_leak"
+                    try write("let value = \"\(canonicalSentinel)\"\n", to: fixture.contextA.fileURL)
+                    let context = makeFrozenContext(
+                        fixture: fixture,
+                        selection: StoredSelection(
+                            selectedPaths: [fixture.contextA.fileURL.path],
+                            codemapAutoEnabled: false
+                        ),
+                        bindings: [],
+                        bindingState: .unhydrated
+                    )
+                    let endpoint = try fixture.endpointA()
+                    try await configureAgentModeEndpoint(endpoint, context: context, fixture: fixture)
+                    installOracleCapture(capture, on: fixture.contextA.window)
+
+                    let response = try await endpoint.callTool(
+                        name: MCPWindowToolName.askOracle,
+                        arguments: ["message": "Inspect the unknown worktree state."],
+                        timeoutSeconds: 20
+                    )
+                    XCTAssertTrue(response.rawJSON.contains("bindings are not hydrated or are unavailable"), response.rawJSON)
                     XCTAssertFalse(response.rawJSON.contains(canonicalSentinel), response.rawJSON)
                     XCTAssertFalse(capture.wasInvoked)
 
@@ -310,7 +352,8 @@ import XCTest
         private func makeFrozenContext(
             fixture: PersistentMCPTestFixture,
             selection: StoredSelection,
-            bindings: [AgentSessionWorktreeBinding]
+            bindings: [AgentSessionWorktreeBinding],
+            bindingState: AgentSessionWorktreeBindingState? = nil
         ) -> MCPServerViewModel.TabContextSnapshot {
             MCPServerViewModel.TabContextSnapshot(
                 tabID: fixture.contextA.tabID,
@@ -323,6 +366,7 @@ import XCTest
                 runID: UUID(),
                 activeAgentSessionID: UUID(),
                 worktreeBindings: bindings,
+                worktreeBindingState: bindingState,
                 explicitlyBound: false
             )
         }

--- a/Tests/RepoPromptTests/MCP/MCPCodeStructureWorktreeTests.swift
+++ b/Tests/RepoPromptTests/MCP/MCPCodeStructureWorktreeTests.swift
@@ -1,0 +1,399 @@
+import Foundation
+@testable import RepoPrompt
+import XCTest
+
+@MainActor
+final class MCPCodeStructureWorktreeTests: XCTestCase {
+    func testStoreCanScanSessionWorktreeRoot() async throws {
+        let worktreeRootURL = try makeTemporaryRoot(name: "DirectScanWorktree")
+        try write(
+            "struct DirectSessionWorktreeType {\n    func directMethod() {}\n}\n",
+            to: worktreeRootURL.appendingPathComponent("App.swift")
+        )
+        let store = WorkspaceFileContextStore()
+        let root = try await store.loadRoot(path: worktreeRootURL.path, kind: .sessionWorktree)
+        let content = try await store.readContent(rootID: root.id, relativePath: "App.swift", workloadClass: .codemap)
+        XCTAssertTrue(content?.contains("DirectSessionWorktreeType") == true)
+        let loadedFile = await store.file(rootID: root.id, relativePath: "App.swift")
+        let file = try XCTUnwrap(loadedFile)
+
+        let repair = try await store.repairMissingCodemapSnapshots(for: [file], timeout: .seconds(6))
+        XCTAssertTrue(repair.pendingFileIDs.isEmpty)
+        XCTAssertTrue(repair.snapshotsByFileID[file.id]?.fileAPI?.apiDescription.contains("DirectSessionWorktreeType") == true)
+    }
+
+    func testMissingWorktreeSnapshotSelfHealsFromPhysicalFileAndRendersLogicalPath() async throws {
+        let logicalRootURL = try makeTemporaryRoot(name: "Logical")
+        let worktreeRootURL = try makeTemporaryRoot(name: "Worktree")
+        try write(
+            "struct CanonicalOnlyType {\n    func canonicalMethod() {}\n}\n",
+            to: logicalRootURL.appendingPathComponent("Sources/App.swift")
+        )
+        try write(
+            "struct WorktreeOnlyType {\n    func worktreeMethod() {}\n}\n",
+            to: worktreeRootURL.appendingPathComponent("Sources/App.swift")
+        )
+
+        let window = try await makeWindow(root: logicalRootURL)
+        defer { WindowStatesManager.shared.unregisterWindowState(window) }
+        let store = window.workspaceFileContextStore
+        let logicalRoot = try await store.loadRoot(path: logicalRootURL.path)
+        let worktreeRoot = try await store.loadRoot(path: worktreeRootURL.path, kind: .sessionWorktree)
+        let projection = makeProjection(logicalRoot: logicalRoot, physicalRoot: worktreeRoot, worktreeID: "worktree")
+        let lookupContext = WorkspaceLookupContext(rootScope: projection.lookupRootScope, bindingProjection: projection)
+        let file = try await fileRecord(
+            at: worktreeRootURL.appendingPathComponent("Sources/App.swift"),
+            store: store,
+            rootScope: projection.lookupRootScope
+        )
+
+        let snapshotBeforeRepair = await store.codemapSnapshot(fileID: file.id)
+        XCTAssertNil(snapshotBeforeRepair)
+        let dto = try await window.mcpServer.buildCodeStructureDTO(
+            fromRecords: [file],
+            maxResults: 10,
+            includeUnmappedPaths: true,
+            lookupContext: lookupContext,
+            selfHealTimeout: .seconds(12)
+        )
+
+        XCTAssertEqual(dto.fileCount, 1)
+        XCTAssertTrue(dto.content.contains("WorktreeOnlyType"), dto.content)
+        XCTAssertFalse(dto.content.contains("CanonicalOnlyType"), dto.content)
+        XCTAssertTrue(dto.content.contains("Sources/App.swift"), dto.content)
+        XCTAssertFalse(dto.content.contains(worktreeRoot.standardizedFullPath), dto.content)
+        XCTAssertNil(dto.pendingPaths)
+        XCTAssertEqual(dto.worktreeScope?.rootMappings.first?.logicalRootPath, logicalRoot.standardizedFullPath)
+        XCTAssertEqual(dto.worktreeScope?.rootMappings.first?.effectiveRootPath, worktreeRoot.standardizedFullPath)
+        let snapshotAfterRepair = await store.codemapSnapshot(fileID: file.id)
+        XCTAssertNotNil(snapshotAfterRepair)
+    }
+
+    func testSwitchingCodeStructureScopeFromWorktreeAToBDoesNotReuseA() async throws {
+        let logicalRootURL = try makeTemporaryRoot(name: "SwitchLogical")
+        let worktreeAURL = try makeTemporaryRoot(name: "SwitchA")
+        let worktreeBURL = try makeTemporaryRoot(name: "SwitchB")
+        try write("struct CanonicalSwitchType {}\n", to: logicalRootURL.appendingPathComponent("Sources/App.swift"))
+        try write(
+            "struct WorktreeAType {\n    func branchAMethod() {}\n}\n",
+            to: worktreeAURL.appendingPathComponent("Sources/App.swift")
+        )
+        try write(
+            "struct WorktreeBType {\n    func branchBMethod() {}\n}\n",
+            to: worktreeBURL.appendingPathComponent("Sources/App.swift")
+        )
+
+        let window = try await makeWindow(root: logicalRootURL)
+        defer { WindowStatesManager.shared.unregisterWindowState(window) }
+        let store = window.workspaceFileContextStore
+        let logicalRoot = try await store.loadRoot(path: logicalRootURL.path)
+        let logicalRef = WorkspaceRootRef(
+            id: logicalRoot.id,
+            name: logicalRoot.name,
+            fullPath: logicalRoot.standardizedFullPath
+        )
+        let sessionID = UUID()
+        let materializedA = await WorkspaceRootBindingProjectionMaterializer(store: store).materialize(
+            sessionID: sessionID,
+            bindings: [makeBinding(
+                logicalRoot: logicalRef,
+                physicalRoot: WorkspaceRootRef(id: UUID(), name: logicalRoot.name, fullPath: worktreeAURL.path),
+                worktreeID: "A"
+            )]
+        )
+        let projectionA = try XCTUnwrap(materializedA)
+        let materializedB = await WorkspaceRootBindingProjectionMaterializer(store: store).materialize(
+            sessionID: sessionID,
+            bindings: [makeBinding(
+                logicalRoot: logicalRef,
+                physicalRoot: WorkspaceRootRef(id: UUID(), name: logicalRoot.name, fullPath: worktreeBURL.path),
+                worktreeID: "B"
+            )]
+        )
+        let projectionB = try XCTUnwrap(materializedB)
+        let fileA = try await fileRecord(
+            at: worktreeAURL.appendingPathComponent("Sources/App.swift"),
+            store: store,
+            rootScope: projectionA.lookupRootScope
+        )
+        let fileB = try await fileRecord(
+            at: worktreeBURL.appendingPathComponent("Sources/App.swift"),
+            store: store,
+            rootScope: projectionB.lookupRootScope
+        )
+
+        let dtoA = try await window.mcpServer.buildCodeStructureDTO(
+            fromRecords: [fileA],
+            maxResults: 10,
+            includeUnmappedPaths: true,
+            lookupContext: WorkspaceLookupContext(rootScope: projectionA.lookupRootScope, bindingProjection: projectionA),
+            selfHealTimeout: .seconds(12)
+        )
+        XCTAssertTrue(dtoA.content.contains("WorktreeAType"), dtoA.content)
+
+        let dtoB = try await window.mcpServer.buildCodeStructureDTO(
+            fromRecords: [fileA, fileB],
+            maxResults: 10,
+            includeUnmappedPaths: true,
+            lookupContext: WorkspaceLookupContext(rootScope: projectionB.lookupRootScope, bindingProjection: projectionB),
+            selfHealTimeout: .seconds(12)
+        )
+
+        XCTAssertEqual(dtoB.fileCount, 1)
+        XCTAssertTrue(dtoB.content.contains("WorktreeBType"), dtoB.content)
+        XCTAssertFalse(dtoB.content.contains("WorktreeAType"), dtoB.content)
+        XCTAssertFalse(dtoB.content.contains("CanonicalSwitchType"), dtoB.content)
+        XCTAssertEqual(dtoB.worktreeScope?.rootMappings.first?.worktreeID, "B")
+        let snapshotA = await store.codemapSnapshot(fileID: fileA.id)
+        let snapshotB = await store.codemapSnapshot(fileID: fileB.id)
+        XCTAssertNotNil(snapshotA)
+        XCTAssertNotNil(snapshotB)
+    }
+
+    func testDeletedMaterializedWorktreeFailsClosedInsteadOfReturningCachedStructure() async throws {
+        let logicalRootURL = try makeTemporaryRoot(name: "DeletedLogical")
+        let worktreeRootURL = try makeTemporaryRoot(name: "DeletedWorktree")
+        try write(
+            "struct CanonicalDeletedType {\n    func canonicalMethod() {}\n}\n",
+            to: logicalRootURL.appendingPathComponent("Sources/App.swift")
+        )
+        try write(
+            "struct CachedDeletedWorktreeType {\n    func cachedMethod() {}\n}\n",
+            to: worktreeRootURL.appendingPathComponent("Sources/App.swift")
+        )
+
+        let window = try await makeWindow(root: logicalRootURL)
+        defer { WindowStatesManager.shared.unregisterWindowState(window) }
+        let store = window.workspaceFileContextStore
+        let logicalRoot = try await store.loadRoot(path: logicalRootURL.path)
+        let worktreeRoot = try await store.loadRoot(path: worktreeRootURL.path, kind: .sessionWorktree)
+        let projection = makeProjection(logicalRoot: logicalRoot, physicalRoot: worktreeRoot, worktreeID: "deleted")
+        let lookupContext = WorkspaceLookupContext(rootScope: projection.lookupRootScope, bindingProjection: projection)
+        let file = try await fileRecord(
+            at: worktreeRootURL.appendingPathComponent("Sources/App.swift"),
+            store: store,
+            rootScope: projection.lookupRootScope
+        )
+
+        let primed = try await window.mcpServer.buildCodeStructureDTO(
+            fromRecords: [file],
+            maxResults: 10,
+            includeUnmappedPaths: true,
+            lookupContext: lookupContext,
+            selfHealTimeout: .seconds(12)
+        )
+        XCTAssertTrue(primed.content.contains("CachedDeletedWorktreeType"), primed.content)
+        try FileManager.default.removeItem(at: worktreeRootURL)
+
+        do {
+            _ = try await window.mcpServer.buildCodeStructureDTO(
+                fromRecords: [file],
+                maxResults: 10,
+                includeUnmappedPaths: true,
+                lookupContext: lookupContext,
+                selfHealTimeout: .zero
+            )
+            XCTFail("Expected deleted worktree scope to fail closed")
+        } catch {
+            XCTAssertTrue(error.localizedDescription.contains("stopped rather than reading the canonical checkout"), error.localizedDescription)
+            XCTAssertTrue(error.localizedDescription.contains(worktreeRootURL.standardizedFileURL.path), error.localizedDescription)
+        }
+
+        let availability = await store.rootScopeAvailability(projection.lookupRootScope)
+        XCTAssertEqual(
+            availability,
+            .sessionWorktreeUnavailable(missingPhysicalRootPaths: [worktreeRootURL.standardizedFileURL.path])
+        )
+    }
+
+    func testTargetedSelfHealingIsBoundedByMaxResults() async throws {
+        let logicalRootURL = try makeTemporaryRoot(name: "BoundedLogical")
+        let worktreeRootURL = try makeTemporaryRoot(name: "BoundedWorktree")
+        for index in 1 ... 3 {
+            try write(
+                "struct BoundedType\(index) {}\n",
+                to: worktreeRootURL.appendingPathComponent("Sources/File\(index).swift")
+            )
+        }
+
+        let window = try await makeWindow(root: logicalRootURL)
+        defer { WindowStatesManager.shared.unregisterWindowState(window) }
+        let store = window.workspaceFileContextStore
+        let logicalRoot = try await store.loadRoot(path: logicalRootURL.path)
+        let worktreeRoot = try await store.loadRoot(path: worktreeRootURL.path, kind: .sessionWorktree)
+        let projection = makeProjection(logicalRoot: logicalRoot, physicalRoot: worktreeRoot, worktreeID: "bounded")
+        let files = try await (1 ... 3).asyncMap { index in
+            try await self.fileRecord(
+                at: worktreeRootURL.appendingPathComponent("Sources/File\(index).swift"),
+                store: store,
+                rootScope: projection.lookupRootScope
+            )
+        }
+
+        let dto = try await window.mcpServer.buildCodeStructureDTO(
+            fromRecords: files,
+            maxResults: 1,
+            includeUnmappedPaths: false,
+            lookupContext: WorkspaceLookupContext(rootScope: projection.lookupRootScope, bindingProjection: projection),
+            selfHealTimeout: .seconds(6)
+        )
+
+        XCTAssertLessThanOrEqual(dto.fileCount, 1)
+        XCTAssertNil(dto.pendingPaths)
+        let firstSnapshot = await store.codemapSnapshot(fileID: files[0].id)
+        let secondSnapshot = await store.codemapSnapshot(fileID: files[1].id)
+        let thirdSnapshot = await store.codemapSnapshot(fileID: files[2].id)
+        XCTAssertNotNil(firstSnapshot)
+        XCTAssertNil(secondSnapshot)
+        XCTAssertNil(thirdSnapshot)
+    }
+
+    func testUnavailableWorktreeScopeFailsClosedBeforeCanonicalScan() async throws {
+        let logicalRootURL = try makeTemporaryRoot(name: "UnavailableLogical")
+        try write("struct CanonicalUnavailableType {}\n", to: logicalRootURL.appendingPathComponent("Sources/App.swift"))
+        let missingWorktreeURL = logicalRootURL.deletingLastPathComponent()
+            .appendingPathComponent("Missing-\(UUID().uuidString)", isDirectory: true)
+
+        let window = try await makeWindow(root: logicalRootURL)
+        defer { WindowStatesManager.shared.unregisterWindowState(window) }
+        let store = window.workspaceFileContextStore
+        let logicalRoot = try await store.loadRoot(path: logicalRootURL.path)
+        let logicalRef = WorkspaceRootRef(id: logicalRoot.id, name: logicalRoot.name, fullPath: logicalRoot.standardizedFullPath)
+        let missingRef = WorkspaceRootRef(id: UUID(), name: logicalRoot.name, fullPath: missingWorktreeURL.path)
+        let projection = WorkspaceRootBindingProjection(
+            sessionID: UUID(),
+            boundRoots: [
+                .init(
+                    logicalRoot: logicalRef,
+                    physicalRoot: missingRef,
+                    binding: makeBinding(logicalRoot: logicalRef, physicalRoot: missingRef, worktreeID: "missing")
+                )
+            ],
+            visibleLogicalRoots: [logicalRef]
+        )
+
+        do {
+            _ = try await window.mcpServer.buildCodeStructureDTO(
+                fromRecords: [],
+                maxResults: 10,
+                includeUnmappedPaths: true,
+                lookupContext: WorkspaceLookupContext(rootScope: projection.lookupRootScope, bindingProjection: projection),
+                selfHealTimeout: .zero
+            )
+            XCTFail("Expected unavailable worktree scope to fail closed")
+        } catch {
+            XCTAssertTrue(error.localizedDescription.contains("stopped rather than reading the canonical checkout"), error.localizedDescription)
+            XCTAssertTrue(error.localizedDescription.contains(missingWorktreeURL.standardizedFileURL.path), error.localizedDescription)
+        }
+
+        let availability = await store.rootScopeAvailability(projection.lookupRootScope)
+        XCTAssertEqual(
+            availability,
+            .sessionWorktreeUnavailable(missingPhysicalRootPaths: [missingWorktreeURL.standardizedFileURL.path])
+        )
+    }
+
+    private func makeWindow(root: URL) async throws -> WindowState {
+        let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
+        GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
+        let window = WindowState()
+        WindowStatesManager.shared.registerWindowState(window)
+        GlobalSettingsStore.shared.setMCPAutoStart(previousAutoStart, commit: false)
+
+        let workspace = window.workspaceManager.createWorkspace(
+            name: "Code Structure Worktree \(UUID().uuidString.prefix(8))",
+            repoPaths: [root.path],
+            ephemeral: true
+        )
+        await window.workspaceManager.switchWorkspace(
+            to: workspace,
+            saveState: false,
+            reason: "mcpCodeStructureWorktreeTests"
+        )
+        let activeWorkspace = try XCTUnwrap(window.workspaceManager.activeWorkspace)
+        window.promptManager.loadComposeTabsFromWorkspace(activeWorkspace, syncPromptText: true)
+        _ = try await window.workspaceFileContextStore.loadRoot(path: root.path)
+        return window
+    }
+
+    private func makeProjection(
+        logicalRoot: WorkspaceRootRecord,
+        physicalRoot: WorkspaceRootRecord,
+        worktreeID: String
+    ) -> WorkspaceRootBindingProjection {
+        let logicalRef = WorkspaceRootRef(
+            id: logicalRoot.id,
+            name: logicalRoot.name,
+            fullPath: logicalRoot.standardizedFullPath
+        )
+        let physicalRef = WorkspaceRootRef(
+            id: physicalRoot.id,
+            name: logicalRoot.name,
+            fullPath: physicalRoot.standardizedFullPath
+        )
+        return WorkspaceRootBindingProjection(
+            sessionID: UUID(),
+            boundRoots: [
+                .init(
+                    logicalRoot: logicalRef,
+                    physicalRoot: physicalRef,
+                    binding: makeBinding(logicalRoot: logicalRef, physicalRoot: physicalRef, worktreeID: worktreeID)
+                )
+            ],
+            visibleLogicalRoots: [logicalRef]
+        )
+    }
+
+    private func makeBinding(
+        logicalRoot: WorkspaceRootRef,
+        physicalRoot: WorkspaceRootRef,
+        worktreeID: String
+    ) -> AgentSessionWorktreeBinding {
+        AgentSessionWorktreeBinding(
+            id: "binding-\(worktreeID)",
+            repositoryID: "repo-\(worktreeID)",
+            repoKey: "repo-key",
+            logicalRootPath: logicalRoot.standardizedFullPath,
+            logicalRootName: logicalRoot.name,
+            worktreeID: worktreeID,
+            worktreeRootPath: physicalRoot.standardizedFullPath,
+            worktreeName: URL(fileURLWithPath: physicalRoot.standardizedFullPath).lastPathComponent,
+            branch: "feature/\(worktreeID)",
+            source: "test"
+        )
+    }
+
+    private func fileRecord(
+        at url: URL,
+        store: WorkspaceFileContextStore,
+        rootScope: WorkspaceLookupRootScope
+    ) async throws -> WorkspaceFileRecord {
+        let result = await store.lookupPath(url.path, profile: .mcpRead, rootScope: rootScope)
+        return try XCTUnwrap(result?.file)
+    }
+
+    private func makeTemporaryRoot(name: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("MCPCodeStructureWorktreeTests", isDirectory: true)
+            .appendingPathComponent("\(name)-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: url) }
+        return url.standardizedFileURL
+    }
+
+    private func write(_ content: String, to url: URL) throws {
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try content.write(to: url, atomically: true, encoding: .utf8)
+    }
+}
+
+private extension Sequence {
+    func asyncMap<T>(_ transform: (Element) async throws -> T) async rethrows -> [T] {
+        var values: [T] = []
+        values.reserveCapacity(underestimatedCount)
+        for element in self {
+            try await values.append(transform(element))
+        }
+        return values
+    }
+}

--- a/Tests/RepoPromptTests/MCP/MCPCodeStructureWorktreeTests.swift
+++ b/Tests/RepoPromptTests/MCP/MCPCodeStructureWorktreeTests.swift
@@ -69,6 +69,72 @@ final class MCPCodeStructureWorktreeTests: XCTestCase {
         XCTAssertNotNil(snapshotAfterRepair)
     }
 
+    #if DEBUG
+        func testActiveWorktreeScanIsPreservedAndReportedPendingWithoutWaiting() async throws {
+            let logicalRootURL = try makeTemporaryRoot(name: "ActiveScanLogical")
+            let worktreeRootURL = try makeTemporaryRoot(name: "ActiveScanWorktree")
+            let fileURL = worktreeRootURL.appendingPathComponent("Sources/App.swift")
+            try write(
+                "struct OriginalActiveType {\n    func originalMethod() {}\n}\n",
+                to: fileURL
+            )
+
+            let window = try await makeWindow(root: logicalRootURL)
+            defer { WindowStatesManager.shared.unregisterWindowState(window) }
+            let store = window.workspaceFileContextStore
+            let logicalRoot = try await store.loadRoot(path: logicalRootURL.path)
+            let worktreeRoot = try await store.loadRoot(path: worktreeRootURL.path, kind: .sessionWorktree)
+            let projection = makeProjection(logicalRoot: logicalRoot, physicalRoot: worktreeRoot, worktreeID: "active")
+            let lookupContext = WorkspaceLookupContext(rootScope: projection.lookupRootScope, bindingProjection: projection)
+            let file = try await fileRecord(at: fileURL, store: store, rootScope: projection.lookupRootScope)
+            let fileID = file.id
+            let scanGate = AsyncGate()
+            await store.setCodemapScanWillStartHandlerForTesting { scannedFileID in
+                guard scannedFileID == fileID else { return }
+                await scanGate.markStartedAndWaitForRelease()
+            }
+            defer {
+                Task {
+                    await scanGate.release()
+                    await store.setCodemapScanWillStartHandlerForTesting(nil)
+                }
+            }
+
+            let submittedRootIDs = try await store.requestInitialRootCodemapScans(rootIDs: [worktreeRoot.id])
+            XCTAssertEqual(submittedRootIDs, [worktreeRoot.id])
+            await scanGate.waitUntilStarted()
+            try write(
+                "struct ReplacementMustNotCancelActiveType {\n    func replacementMethod() {}\n}\n",
+                to: fileURL
+            )
+            try FileManager.default.setAttributes(
+                [.modificationDate: Date().addingTimeInterval(2)],
+                ofItemAtPath: fileURL.path
+            )
+
+            let clock = ContinuousClock()
+            let start = clock.now
+            let dto = try await window.mcpServer.buildCodeStructureDTO(
+                fromRecords: [file],
+                maxResults: 10,
+                includeUnmappedPaths: false,
+                lookupContext: lookupContext,
+                selfHealTimeout: .seconds(4)
+            )
+            let elapsed = start.duration(to: clock.now)
+
+            XCTAssertLessThan(elapsed, .seconds(2))
+            XCTAssertNil(dto.unmappedPaths)
+            XCTAssertEqual(dto.pendingPaths, ["Sources/App.swift"])
+
+            await scanGate.release()
+            let snapshot = try await waitForCodemapSnapshot(store: store, fileID: fileID)
+            await store.setCodemapScanWillStartHandlerForTesting(nil)
+            XCTAssertTrue(snapshot.fileAPI?.apiDescription.contains("OriginalActiveType") == true)
+            XCTAssertFalse(snapshot.fileAPI?.apiDescription.contains("ReplacementMustNotCancelActiveType") == true)
+        }
+    #endif
+
     func testSwitchingCodeStructureScopeFromWorktreeAToBDoesNotReuseA() async throws {
         let logicalRootURL = try makeTemporaryRoot(name: "SwitchLogical")
         let worktreeAURL = try makeTemporaryRoot(name: "SwitchA")
@@ -196,7 +262,7 @@ final class MCPCodeStructureWorktreeTests: XCTestCase {
             XCTFail("Expected deleted worktree scope to fail closed")
         } catch {
             XCTAssertTrue(error.localizedDescription.contains("stopped rather than reading the canonical checkout"), error.localizedDescription)
-            XCTAssertTrue(error.localizedDescription.contains(worktreeRootURL.standardizedFileURL.path), error.localizedDescription)
+            XCTAssertFalse(error.localizedDescription.contains(worktreeRootURL.standardizedFileURL.path), error.localizedDescription)
         }
 
         let availability = await store.rootScopeAvailability(projection.lookupRootScope)
@@ -211,7 +277,7 @@ final class MCPCodeStructureWorktreeTests: XCTestCase {
         let worktreeRootURL = try makeTemporaryRoot(name: "BoundedWorktree")
         for index in 1 ... 3 {
             try write(
-                "struct BoundedType\(index) {}\n",
+                "struct BoundedType\(index) {\n    func boundedMethod\(index)() {}\n}\n",
                 to: worktreeRootURL.appendingPathComponent("Sources/File\(index).swift")
             )
         }
@@ -240,6 +306,7 @@ final class MCPCodeStructureWorktreeTests: XCTestCase {
 
         XCTAssertLessThanOrEqual(dto.fileCount, 1)
         XCTAssertNil(dto.pendingPaths)
+        XCTAssertEqual(dto.unmappedPaths, ["Sources/File2.swift", "Sources/File3.swift"])
         let firstSnapshot = await store.codemapSnapshot(fileID: files[0].id)
         let secondSnapshot = await store.codemapSnapshot(fileID: files[1].id)
         let thirdSnapshot = await store.codemapSnapshot(fileID: files[2].id)
@@ -283,7 +350,7 @@ final class MCPCodeStructureWorktreeTests: XCTestCase {
             XCTFail("Expected unavailable worktree scope to fail closed")
         } catch {
             XCTAssertTrue(error.localizedDescription.contains("stopped rather than reading the canonical checkout"), error.localizedDescription)
-            XCTAssertTrue(error.localizedDescription.contains(missingWorktreeURL.standardizedFileURL.path), error.localizedDescription)
+            XCTAssertFalse(error.localizedDescription.contains(missingWorktreeURL.standardizedFileURL.path), error.localizedDescription)
         }
 
         let availability = await store.rootScopeAvailability(projection.lookupRootScope)
@@ -291,6 +358,23 @@ final class MCPCodeStructureWorktreeTests: XCTestCase {
             availability,
             .sessionWorktreeUnavailable(missingPhysicalRootPaths: [missingWorktreeURL.standardizedFileURL.path])
         )
+    }
+
+    private func waitForCodemapSnapshot(
+        store: WorkspaceFileContextStore,
+        fileID: UUID,
+        timeout: Duration = .seconds(6)
+    ) async throws -> WorkspaceCodemapSnapshot {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        while clock.now < deadline {
+            if let snapshot = await store.codemapSnapshot(fileID: fileID) {
+                return snapshot
+            }
+            try await Task.sleep(for: .milliseconds(25))
+        }
+        XCTFail("Timed out waiting for codemap snapshot")
+        throw NSError(domain: "MCPCodeStructureWorktreeTests", code: 1)
     }
 
     private func makeWindow(root: URL) async throws -> WindowState {
@@ -386,6 +470,41 @@ final class MCPCodeStructureWorktreeTests: XCTestCase {
         try content.write(to: url, atomically: true, encoding: .utf8)
     }
 }
+
+#if DEBUG
+    private actor AsyncGate {
+        private var started = false
+        private var released = false
+        private var startWaiters: [CheckedContinuation<Void, Never>] = []
+        private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+
+        func markStartedAndWaitForRelease() async {
+            started = true
+            let waiters = startWaiters
+            startWaiters.removeAll()
+            waiters.forEach { $0.resume() }
+
+            guard !released else { return }
+            await withCheckedContinuation { continuation in
+                releaseWaiters.append(continuation)
+            }
+        }
+
+        func waitUntilStarted() async {
+            guard !started else { return }
+            await withCheckedContinuation { continuation in
+                startWaiters.append(continuation)
+            }
+        }
+
+        func release() {
+            released = true
+            let waiters = releaseWaiters
+            releaseWaiters.removeAll()
+            waiters.forEach { $0.resume() }
+        }
+    }
+#endif
 
 private extension Sequence {
     func asyncMap<T>(_ transform: (Element) async throws -> T) async rethrows -> [T] {

--- a/Tests/RepoPromptTests/MCP/MCPCodeStructureWorktreeTests.swift
+++ b/Tests/RepoPromptTests/MCP/MCPCodeStructureWorktreeTests.swift
@@ -187,6 +187,12 @@ final class MCPCodeStructureWorktreeTests: XCTestCase {
             store: store,
             rootScope: projectionB.lookupRootScope
         )
+        // Materialization starts codemap scans asynchronously. Prime both snapshots so this test isolates scope filtering;
+        // active-scan pending behavior is covered separately.
+        let snapshotA = try await waitForCodemapSnapshot(store: store, fileID: fileA.id, timeout: .seconds(12))
+        let snapshotB = try await waitForCodemapSnapshot(store: store, fileID: fileB.id, timeout: .seconds(12))
+        XCTAssertTrue(snapshotA.fileAPI?.apiDescription.contains("WorktreeAType") == true)
+        XCTAssertTrue(snapshotB.fileAPI?.apiDescription.contains("WorktreeBType") == true)
 
         let dtoA = try await window.mcpServer.buildCodeStructureDTO(
             fromRecords: [fileA],
@@ -210,10 +216,6 @@ final class MCPCodeStructureWorktreeTests: XCTestCase {
         XCTAssertFalse(dtoB.content.contains("WorktreeAType"), dtoB.content)
         XCTAssertFalse(dtoB.content.contains("CanonicalSwitchType"), dtoB.content)
         XCTAssertEqual(dtoB.worktreeScope?.rootMappings.first?.worktreeID, "B")
-        let snapshotA = await store.codemapSnapshot(fileID: fileA.id)
-        let snapshotB = await store.codemapSnapshot(fileID: fileB.id)
-        XCTAssertNotNil(snapshotA)
-        XCTAssertNotNil(snapshotB)
     }
 
     func testDeletedMaterializedWorktreeFailsClosedInsteadOfReturningCachedStructure() async throws {

--- a/Tests/RepoPromptTests/MCP/MCPReadFileExactAbsoluteCatalogFastPathTests.swift
+++ b/Tests/RepoPromptTests/MCP/MCPReadFileExactAbsoluteCatalogFastPathTests.swift
@@ -228,7 +228,7 @@ final class MCPReadFileExactAbsoluteCatalogFastPathTests: XCTestCase {
         let visibleWorktreeHit = await service.resolveExactWorkspaceCatalogHit(worktreeFile.path, rootScope: .visibleWorkspace)
         XCTAssertNil(visibleWorktreeHit)
         let sessionScope = WorkspaceLookupRootScope.sessionBoundWorkspace(
-            logicalRootPaths: [logicalRoot.path],
+            canonicalRootPaths: [],
             physicalRootPaths: [worktreeRoot.path]
         )
         let worktreeHit = await service.resolveExactWorkspaceCatalogHit(worktreeFile.path, rootScope: sessionScope)

--- a/Tests/RepoPromptTests/MCP/TabContextRoutingTests.swift
+++ b/Tests/RepoPromptTests/MCP/TabContextRoutingTests.swift
@@ -508,6 +508,31 @@ final class TabContextRoutingTests: XCTestCase {
         XCTAssertTrue(message.contains("disabled"), message)
     }
 
+    func testAgentModeRoutingRecoveryDoesNotRecommendRejectedExplicitContextOverrides() {
+        for message in [
+            MCPServerViewModel.tabContextRoutingErrorMessage(
+                toolName: "context_builder",
+                runPurpose: .agentModeRun
+            ),
+            MCPServerViewModel.runScopedActiveTabCompatibilityMessage(
+                toolName: "context_builder",
+                runPurpose: .agentModeRun
+            )
+        ] {
+            XCTAssertTrue(message.contains("Retry"), message)
+            XCTAssertTrue(message.contains("restart this Agent Mode run"), message)
+            XCTAssertFalse(message.contains("bind_context"), message)
+            XCTAssertFalse(message.contains("context_id"), message)
+        }
+
+        let ordinary = MCPServerViewModel.tabContextRoutingErrorMessage(
+            toolName: "workspace_context",
+            runPurpose: .unknown
+        )
+        XCTAssertTrue(ordinary.contains("bind_context"), ordinary)
+        XCTAssertTrue(ordinary.contains("context_id"), ordinary)
+    }
+
     func testConnectionManagerRoutingPoliciesKeepRunScopedToolsOutOfLegacyGenericBinding() {
         XCTAssertFalse(ServerNetworkManager.shouldUseGenericTabBindingCompatibility(for: "agent_run"))
         XCTAssertFalse(ServerNetworkManager.shouldUseGenericTabBindingCompatibility(for: "ask_oracle"))

--- a/Tests/RepoPromptTests/MCP/ToolOutputFormatterWorktreeTests.swift
+++ b/Tests/RepoPromptTests/MCP/ToolOutputFormatterWorktreeTests.swift
@@ -239,6 +239,24 @@ final class ToolOutputFormatterWorktreeTests: XCTestCase {
         }
     }
 
+    func testCodeStructureOutputShowsPendingLogicalPathsAndWorktreeScope() throws {
+        let dto = ToolResultDTOs.SelectedCodeStructureDTO(
+            fileCount: 0,
+            content: "",
+            pendingPaths: ["Project/Sources/App.swift"],
+            worktreeScope: Self.scope()
+        )
+
+        let text = try Self.onlyText(ToolOutputFormatter.formatCodeStructure(value: Self.value(dto)))
+
+        XCTAssertTrue(text.contains("## Code Structure ⚠️"), text)
+        XCTAssertTrue(text.contains("Codemap repair pending**: 1"), text)
+        XCTAssertTrue(text.contains("- **Project**"), text)
+        XCTAssertTrue(text.contains("`Sources/App.swift`"), text)
+        XCTAssertTrue(text.contains("codemap scans use"), text)
+        Self.assertScopeBlock(in: text)
+    }
+
     func testWorkspaceContextOutputShowsSingleWorktreeScopeBlock() throws {
         let scope = Self.scope()
         let dto = ToolResultDTOs.PromptContextDTO(

--- a/Tests/RepoPromptTests/MCP/ToolOutputFormatterWorktreeTests.swift
+++ b/Tests/RepoPromptTests/MCP/ToolOutputFormatterWorktreeTests.swift
@@ -250,14 +250,19 @@ final class ToolOutputFormatterWorktreeTests: XCTestCase {
         let text = try Self.onlyText(ToolOutputFormatter.formatCodeStructure(value: Self.value(dto)))
 
         XCTAssertTrue(text.contains("## Code Structure ⚠️"), text)
-        XCTAssertTrue(text.contains("Codemap repair pending**: 1"), text)
+        XCTAssertTrue(text.contains("Codemap generation pending**: 1"), text)
         XCTAssertTrue(text.contains("- **Project**"), text)
         XCTAssertTrue(text.contains("`Sources/App.swift`"), text)
         XCTAssertTrue(text.contains("codemap scans use"), text)
-        Self.assertScopeBlock(in: text)
+        XCTAssertTrue(text.contains("Displayed paths use logical/canonical roots"), text)
+        XCTAssertTrue(text.contains("/repo/project"), text)
+        XCTAssertFalse(text.contains("/tmp/worktrees/project-agent"), text)
+        XCTAssertTrue(text.contains("wt_123"), text)
+        XCTAssertTrue(text.contains("branch `feature/demo`"), text)
+        XCTAssertTrue(text.contains("label `Demo Worktree`"), text)
     }
 
-    func testWorkspaceContextOutputShowsSingleWorktreeScopeBlock() throws {
+    func testWorkspaceContextOutputHidesPhysicalRootInScopeBlocks() throws {
         let scope = Self.scope()
         let dto = ToolResultDTOs.PromptContextDTO(
             prompt: "",
@@ -280,8 +285,13 @@ final class ToolOutputFormatterWorktreeTests: XCTestCase {
 
         let text = try Self.onlyText(ToolOutputFormatter.formatPromptState(value: Self.value(dto)))
 
-        Self.assertScopeBlock(in: text)
-        XCTAssertEqual(Self.occurrences(of: "session-bound worktree", in: text), 1, text)
+        XCTAssertTrue(text.contains("Displayed paths use logical/canonical roots"), text)
+        XCTAssertTrue(text.contains("/repo/project"), text)
+        XCTAssertFalse(text.contains("/tmp/worktrees/project-agent"), text)
+        XCTAssertTrue(text.contains("wt_123"), text)
+        XCTAssertTrue(text.contains("branch `feature/demo`"), text)
+        XCTAssertTrue(text.contains("label `Demo Worktree`"), text)
+        XCTAssertEqual(Self.occurrences(of: "session-bound worktree", in: text), 2, text)
         XCTAssertTrue(text.contains("### Selected File Tree"), text)
     }
 
@@ -367,7 +377,7 @@ final class ToolOutputFormatterWorktreeTests: XCTestCase {
         XCTAssertTrue(text.contains("session-bound worktree"), text)
         XCTAssertTrue(text.contains("Displayed paths use logical/canonical roots"), text)
         XCTAssertTrue(text.contains("/repo/project"), text)
-        XCTAssertTrue(text.contains("/tmp/worktrees/project-agent"), text)
+        XCTAssertFalse(text.contains("/tmp/worktrees/project-agent"), text)
         XCTAssertTrue(text.contains("wt_123"), text)
         XCTAssertTrue(text.contains("branch `feature/demo`"), text)
         XCTAssertTrue(text.contains("label `Demo Worktree`"), text)

--- a/Tests/RepoPromptTests/MCP/WorktreeAPISmokeHarnessTests.swift
+++ b/Tests/RepoPromptTests/MCP/WorktreeAPISmokeHarnessTests.swift
@@ -422,9 +422,9 @@ final class WorktreeAPISmokeHarnessTests: XCTestCase {
             XCTAssertNotNil(exportObject["plan"]?.objectValue, String(describing: exportObject))
             let exportPath = try XCTUnwrap(exportObject["oracle_export_path"]?.stringValue)
             let exportInstruction = try XCTUnwrap(exportObject["oracle_export_instruction"]?.stringValue)
-            let standardizedWorktreePath = StandardizedPath.absolute(worktreePath)
+            let standardizedLogicalPath = fixture.repo.standardizedFileURL.path
             XCTAssertTrue(
-                exportPath.hasPrefix(standardizedWorktreePath + "/prompt-exports/"),
+                exportPath.hasPrefix(standardizedLogicalPath + "/prompt-exports/"),
                 exportPath
             )
             let exportPathLiteral = try XCTUnwrap(
@@ -434,12 +434,14 @@ final class WorktreeAPISmokeHarnessTests: XCTestCase {
                 exportInstruction.contains("{\"path\": \(exportPathLiteral)}"),
                 exportInstruction
             )
-            XCTAssertTrue(FileManager.default.fileExists(atPath: exportPath), exportPath)
+            XCTAssertFalse(FileManager.default.fileExists(atPath: exportPath), exportPath)
 
-            let relativeExportPath = String(exportPath.dropFirst(standardizedWorktreePath.count))
+            let relativeExportPath = String(exportPath.dropFirst(standardizedLogicalPath.count))
                 .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
-            let logicalExportPath = fixture.repo.appendingPathComponent(relativeExportPath).path
-            XCTAssertFalse(FileManager.default.fileExists(atPath: logicalExportPath), logicalExportPath)
+            let physicalExportPath = URL(fileURLWithPath: worktreePath)
+                .appendingPathComponent(relativeExportPath)
+                .path
+            XCTAssertTrue(FileManager.default.fileExists(atPath: physicalExportPath), physicalExportPath)
 
             let readConnectionID = UUID()
             let contextHint = MCPServerViewModel.TabContextHint(

--- a/Tests/RepoPromptTests/MCP/WorktreeAPISmokeHarnessTests.swift
+++ b/Tests/RepoPromptTests/MCP/WorktreeAPISmokeHarnessTests.swift
@@ -570,7 +570,7 @@ final class WorktreeAPISmokeHarnessTests: XCTestCase {
         )
         let formattedTree = try Self.onlyText(ToolOutputFormatter.formatFileTree(value: treeValue))
         XCTAssertTrue(formattedTree.contains(logicalRootPath), formattedTree)
-        XCTAssertTrue(formattedTree.contains(effectiveRootPath), formattedTree)
+        XCTAssertFalse(formattedTree.contains(effectiveRootPath), formattedTree)
         XCTAssertTrue(formattedTree.contains("session-bound worktree"), formattedTree)
 
         let readValue = try await readFile(["path": .string("Tracked.txt")])
@@ -582,7 +582,7 @@ final class WorktreeAPISmokeHarnessTests: XCTestCase {
         )
         let formattedRead = try Self.onlyText(ToolOutputFormatter.formatReadFile(args: ["path": .string("Tracked.txt")], value: readValue))
         XCTAssertTrue(formattedRead.contains(logicalRootPath), formattedRead)
-        XCTAssertTrue(formattedRead.contains(effectiveRootPath), formattedRead)
+        XCTAssertFalse(formattedRead.contains(effectiveRootPath), formattedRead)
         XCTAssertTrue(formattedRead.contains("session-bound worktree"), formattedRead)
 
         let searchValue = try await fileSearch(["pattern": .string("original"), "mode": .string("content"), "max_results": .int(5)])
@@ -594,7 +594,7 @@ final class WorktreeAPISmokeHarnessTests: XCTestCase {
         )
         let formattedSearch = try Self.onlyText(ToolOutputFormatter.formatSearch(value: searchValue))
         XCTAssertTrue(formattedSearch.contains(logicalRootPath), formattedSearch)
-        XCTAssertTrue(formattedSearch.contains(effectiveRootPath), formattedSearch)
+        XCTAssertFalse(formattedSearch.contains(effectiveRootPath), formattedSearch)
         XCTAssertTrue(formattedSearch.contains("session-bound worktree"), formattedSearch)
     }
 

--- a/Tests/RepoPromptTests/Prompt/PromptContextAccountingServiceTests.swift
+++ b/Tests/RepoPromptTests/Prompt/PromptContextAccountingServiceTests.swift
@@ -39,6 +39,85 @@ final class PromptContextAccountingServiceTests: XCTestCase {
         XCTAssertEqual(resolution.invalidPaths, [])
     }
 
+    func testPhysicalizedSelectionRefreshesSessionBoundBatchLookupAfterWorktreeLoad() async throws {
+        let logicalRoot = try makeTemporaryRoot(name: "AccountingLogical")
+        let worktreeRoot = try makeTemporaryRoot(name: "AccountingWorktree")
+        let logicalFile = logicalRoot.appendingPathComponent("Sources/App.swift")
+        let worktreeFile = worktreeRoot.appendingPathComponent("Sources/App.swift")
+        try write("canonical", to: logicalFile)
+        try write("worktree", to: worktreeFile)
+
+        let store = WorkspaceFileContextStore()
+        let logicalRootRecord = try await store.loadRoot(path: logicalRoot.path)
+        let logicalRootRef = WorkspaceRootRef(
+            id: logicalRootRecord.id,
+            name: logicalRootRecord.name,
+            fullPath: logicalRootRecord.standardizedFullPath
+        )
+        let physicalRootRef = WorkspaceRootRef(
+            id: UUID(),
+            name: logicalRootRecord.name,
+            fullPath: worktreeRoot.path
+        )
+        let projection = WorkspaceRootBindingProjection(
+            sessionID: UUID(),
+            boundRoots: [
+                .init(
+                    logicalRoot: logicalRootRef,
+                    physicalRoot: physicalRootRef,
+                    binding: AgentSessionWorktreeBinding(
+                        id: "accounting-binding",
+                        repositoryID: "accounting-repository",
+                        repoKey: "accounting-repo",
+                        logicalRootPath: logicalRoot.path,
+                        logicalRootName: logicalRootRecord.name,
+                        worktreeID: "accounting-worktree",
+                        worktreeRootPath: worktreeRoot.path,
+                        source: "test"
+                    )
+                )
+            ],
+            visibleLogicalRoots: [logicalRootRef]
+        )
+        let lookupContext = WorkspaceLookupContext(
+            rootScope: projection.lookupRootScope,
+            bindingProjection: projection
+        )
+        let logicalSelection = StoredSelection(
+            selectedPaths: [logicalFile.path],
+            codemapAutoEnabled: false
+        )
+        let physicalSelection = lookupContext.physicalizeSelection(logicalSelection)
+        XCTAssertEqual(physicalSelection.selectedPaths, [worktreeFile.path])
+
+        let request = WorkspacePathLookupRequest(
+            userPath: worktreeFile.path,
+            profile: .uiAssisted,
+            rootScope: lookupContext.rootScope
+        )
+        let generationBeforeWorktreeLoad = await store.catalogGeneration(rootScope: lookupContext.rootScope)
+        let lookupBeforeWorktreeLoad = await store.lookupPaths([request])
+        XCTAssertTrue(lookupBeforeWorktreeLoad.isEmpty)
+
+        let worktreeRootRecord = try await store.loadRoot(path: worktreeRoot.path, kind: .sessionWorktree)
+        let generationAfterWorktreeLoad = await store.catalogGeneration(rootScope: lookupContext.rootScope)
+        XCTAssertNotEqual(generationAfterWorktreeLoad, generationBeforeWorktreeLoad)
+        let resolution = await PromptContextAccountingService().resolveEntries(
+            selection: physicalSelection,
+            store: store,
+            rootScope: lookupContext.rootScope,
+            codeMapUsage: .none
+        )
+
+        let entry = try XCTUnwrap(resolution.entries.first)
+        XCTAssertEqual(resolution.entries.count, 1)
+        XCTAssertEqual(entry.file.rootID, worktreeRootRecord.id)
+        XCTAssertEqual(entry.file.standardizedRelativePath, "Sources/App.swift")
+        XCTAssertEqual(entry.loadedContent, "worktree")
+        XCTAssertEqual(resolution.missingPaths, [])
+        XCTAssertEqual(resolution.invalidPaths, [])
+    }
+
     func testDuplicateSelectedPathsPreserveExistingEntryDedupOrder() async throws {
         let root = try makeTemporaryRoot(name: "AccountingDuplicates")
         let fileA = root.appendingPathComponent("A.swift")

--- a/Tests/RepoPromptTests/WorkspaceContext/Search/StoreBackedWorkspaceSearchTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/Search/StoreBackedWorkspaceSearchTests.swift
@@ -112,7 +112,7 @@ final class StoreBackedWorkspaceSearchTests: XCTestCase {
         let visibleWorktreeHit = await store.lookupDiscoverableCatalogPathForExactAbsoluteSearchScope(worktreeFile.path, rootScope: .visibleWorkspace)
         XCTAssertNil(visibleWorktreeHit)
         let sessionScope = WorkspaceLookupRootScope.sessionBoundWorkspace(
-            logicalRootPaths: [logicalRoot.path],
+            canonicalRootPaths: [],
             physicalRootPaths: [worktreeRoot.path]
         )
         let worktreeHit = await store.lookupDiscoverableCatalogPathForExactAbsoluteSearchScope(worktreeFile.path, rootScope: sessionScope)
@@ -936,7 +936,7 @@ final class StoreBackedWorkspaceSearchTests: XCTestCase {
                 await permitSignal.mark()
             }
             let scope = WorkspaceLookupRootScope.sessionBoundWorkspace(
-                logicalRootPaths: [logicalRoot.standardizedFileURL.path],
+                canonicalRootPaths: [],
                 physicalRootPaths: [missingPhysicalRoot.standardizedFileURL.path]
             )
 
@@ -979,7 +979,7 @@ final class StoreBackedWorkspaceSearchTests: XCTestCase {
             let held = Task { try await self.searchContent(pattern: "baseNeedle", store: store) }
             await assertAsyncTrue(gate.waitUntilStartedCount(1))
             let scope = WorkspaceLookupRootScope.sessionBoundWorkspace(
-                logicalRootPaths: [logicalRoot.standardizedFileURL.path],
+                canonicalRootPaths: [],
                 physicalRootPaths: [physicalRoot.standardizedFileURL.path]
             )
             let queued = Task {

--- a/Tests/RepoPromptTests/WorkspaceContext/WorkspaceFileContextStoreTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/WorkspaceFileContextStoreTests.swift
@@ -2840,8 +2840,8 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
         _ = try await store.loadRoot(path: logicalRoot.path)
         let recordA = try await store.loadRoot(path: worktreeA.path, kind: .sessionWorktree)
         let recordB = try await store.loadRoot(path: worktreeB.path, kind: .sessionWorktree)
-        let scopeA = WorkspaceLookupRootScope.sessionBoundWorkspace(logicalRootPaths: [logicalRoot.path], physicalRootPaths: [worktreeA.path])
-        let scopeB = WorkspaceLookupRootScope.sessionBoundWorkspace(logicalRootPaths: [logicalRoot.path], physicalRootPaths: [worktreeB.path])
+        let scopeA = WorkspaceLookupRootScope.sessionBoundWorkspace(canonicalRootPaths: [], physicalRootPaths: [worktreeA.path])
+        let scopeB = WorkspaceLookupRootScope.sessionBoundWorkspace(canonicalRootPaths: [], physicalRootPaths: [worktreeB.path])
 
         let initialA = await store.searchCatalogSnapshot(rootScope: scopeA)
         let initialB = await store.searchCatalogSnapshot(rootScope: scopeB)
@@ -3002,7 +3002,7 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
             let store = WorkspaceFileContextStore()
             let scopes = (0 ... 16).map { index in
                 WorkspaceLookupRootScope.sessionBoundWorkspace(
-                    logicalRootPaths: ["/logical/\(index)"],
+                    canonicalRootPaths: ["/canonical/\(index)"],
                     physicalRootPaths: ["/physical/\(index)"]
                 )
             }

--- a/Tests/RepoPromptTests/WorkspaceContext/WorkspaceRootBindingProjectionTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/WorkspaceRootBindingProjectionTests.swift
@@ -276,6 +276,47 @@ final class WorkspaceRootBindingProjectionTests: XCTestCase {
         )
     }
 
+    func testMaterializerInitializesSessionWorktreeCodemapsIdempotently() async throws {
+        let logicalRootURL = try makeTemporaryRoot(name: "ProjectionCodemapLogical")
+        let physicalRootURL = try makeTemporaryRoot(name: "ProjectionCodemapPhysical")
+        try write(
+            "struct WorktreeInitializedType {\n    func initializedMethod() {}\n}\n",
+            to: physicalRootURL.appendingPathComponent("Sources/App.swift")
+        )
+        let store = WorkspaceFileContextStore()
+        let loadedLogicalRoot = try await store.loadRoot(path: logicalRootURL.path)
+        let logicalRoot = WorkspaceRootRef(
+            id: loadedLogicalRoot.id,
+            name: loadedLogicalRoot.name,
+            fullPath: loadedLogicalRoot.standardizedFullPath
+        )
+        let physicalRoot = WorkspaceRootRef(id: UUID(), name: logicalRoot.name, fullPath: physicalRootURL.path)
+        let binding = Self.binding(logicalRoot: logicalRoot, physicalRoot: physicalRoot, worktreeID: "codemap")
+
+        let materializedProjection = await WorkspaceRootBindingProjectionMaterializer(store: store).materialize(
+            sessionID: UUID(),
+            bindings: [binding]
+        )
+        let firstProjection = try XCTUnwrap(materializedProjection)
+        let physicalRootID = try XCTUnwrap(firstProjection.physicalRootRefs.first?.id)
+
+        let firstRedundantInitialization = await store.initializeCodemapsForSessionWorktreeRoots(rootIDs: [physicalRootID])
+        XCTAssertTrue(firstRedundantInitialization.isEmpty)
+        let snapshot = try await waitForCodemapSnapshot(
+            store: store,
+            rootID: physicalRootID,
+            relativePath: "Sources/App.swift"
+        )
+        XCTAssertTrue(snapshot.fileAPI?.apiDescription.contains("WorktreeInitializedType") == true)
+
+        _ = await WorkspaceRootBindingProjectionMaterializer(store: store).materialize(
+            sessionID: UUID(),
+            bindings: [binding]
+        )
+        let secondRedundantInitialization = await store.initializeCodemapsForSessionWorktreeRoots(rootIDs: [physicalRootID])
+        XCTAssertTrue(secondRedundantInitialization.isEmpty)
+    }
+
     func testMaterializedSessionWorktreeScopeReportsAvailable() async throws {
         let logicalRootURL = try makeTemporaryRoot(name: "ProjectionAvailableLogical")
         let physicalRootURL = try makeTemporaryRoot(name: "ProjectionAvailablePhysical")
@@ -300,6 +341,24 @@ final class WorkspaceRootBindingProjectionTests: XCTestCase {
         XCTAssertTrue(scopedRoots.contains {
             $0.standardizedFullPath == physicalRootURL.standardizedFileURL.path
         })
+    }
+
+    private func waitForCodemapSnapshot(
+        store: WorkspaceFileContextStore,
+        rootID: UUID,
+        relativePath: String,
+        timeout: Duration = .seconds(6)
+    ) async throws -> WorkspaceCodemapSnapshot {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        while clock.now < deadline {
+            if let snapshot = await store.codemapSnapshot(rootID: rootID, relativePath: relativePath) {
+                return snapshot
+            }
+            try await Task.sleep(for: .milliseconds(25))
+        }
+        XCTFail("Timed out waiting for codemap snapshot")
+        throw NSError(domain: "WorkspaceRootBindingProjectionTests", code: 1)
     }
 
     private static func binding(

--- a/Tests/RepoPromptTests/WorkspaceContext/WorkspaceRootBindingProjectionTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/WorkspaceRootBindingProjectionTests.swift
@@ -317,6 +317,46 @@ final class WorkspaceRootBindingProjectionTests: XCTestCase {
         XCTAssertTrue(secondRedundantInitialization.isEmpty)
     }
 
+    func testMaterializerRetriesCodemapInitializationAfterZeroFileIngress() async throws {
+        let logicalRootURL = try makeTemporaryRoot(name: "ProjectionRetryLogical")
+        let physicalRootURL = try makeTemporaryRoot(name: "ProjectionRetryPhysical")
+        let store = WorkspaceFileContextStore()
+        let loadedLogicalRoot = try await store.loadRoot(path: logicalRootURL.path)
+        let logicalRoot = WorkspaceRootRef(
+            id: loadedLogicalRoot.id,
+            name: loadedLogicalRoot.name,
+            fullPath: loadedLogicalRoot.standardizedFullPath
+        )
+        let physicalRoot = WorkspaceRootRef(id: UUID(), name: logicalRoot.name, fullPath: physicalRootURL.path)
+        let binding = Self.binding(logicalRoot: logicalRoot, physicalRoot: physicalRoot, worktreeID: "retry")
+
+        let materializedProjection = await WorkspaceRootBindingProjectionMaterializer(store: store).materialize(
+            sessionID: UUID(),
+            bindings: [binding]
+        )
+        let projection = try XCTUnwrap(materializedProjection)
+        let physicalRootID = try XCTUnwrap(projection.physicalRootRefs.first?.id)
+        let emptyRetry = await store.initializeCodemapsForSessionWorktreeRoots(rootIDs: [physicalRootID])
+        XCTAssertTrue(emptyRetry.isEmpty)
+
+        _ = try await store.createFile(
+            rootID: physicalRootID,
+            relativePath: "Sources/App.swift",
+            content: "struct RetryAfterIngressType {\n    func retryMethod() {}\n}\n"
+        )
+        let submittedRetry = await store.initializeCodemapsForSessionWorktreeRoots(rootIDs: [physicalRootID])
+        XCTAssertEqual(submittedRetry, [physicalRootID])
+        let redundantRetry = await store.initializeCodemapsForSessionWorktreeRoots(rootIDs: [physicalRootID])
+        XCTAssertTrue(redundantRetry.isEmpty)
+
+        let snapshot = try await waitForCodemapSnapshot(
+            store: store,
+            rootID: physicalRootID,
+            relativePath: "Sources/App.swift"
+        )
+        XCTAssertTrue(snapshot.fileAPI?.apiDescription.contains("RetryAfterIngressType") == true)
+    }
+
     func testMaterializedSessionWorktreeScopeReportsAvailable() async throws {
         let logicalRootURL = try makeTemporaryRoot(name: "ProjectionAvailableLogical")
         let physicalRootURL = try makeTemporaryRoot(name: "ProjectionAvailablePhysical")


### PR DESCRIPTION
## Summary

Replacement integration for #146 onto current `main` after the original branch became substantially stale.

This preserves the original goal—Context Builder and nested MCP tools inherit the parent Agent Mode worktree projection—while resolving current-main API and fixture changes and incorporating the original review feedback.

Closes #146 after this replacement lands.

## Behavior

- Freeze inherited worktree/root routing for a Context Builder invocation:
  - physical root scope
  - logical↔physical path projection
  - provider working directory
- Thread that projection through nested MCP tools, Context Builder planning/review, Oracle export, prompt accounting, and code-structure/search/read paths.
- Keep compose-tab selection live and shared:
  - Context Builder `read_file` does **not** auto-select
  - explicit `manage_selection` does mutate the live tab selection
  - later Context Builder invocations observe the persisted selection
  - ordinary Agent Mode `read_file` continues to auto-select full files/slices
  - stale asynchronous selection writes remain revision-fenced
- Fail closed until agent worktree binding state is hydrated.
- Preserve logical display paths while reading/scanning physical worktree content.

## Integration cleanup

- Updated stale Context Builder test override calls for progress/activity reporting.
- Removed a dead Oracle test observer that could hang suites.
- Updated hydration-aware worktree fixtures and current `canonicalRootPaths` semantics.
- Updated provider test returns to current hydration result types.
- Corrected stale codemap synchronization and logical-vs-physical export assertions.
- Added explicit selection-contract regression coverage without changing production selection behavior.

## Validation

Passed locally:

- contribution commit preflights and secret scans
- repository guardrails and conductor self-tests
- SwiftFormat and strict SwiftLint
- `RepoPrompt` and `repoprompt-mcp` product builds
- 48 final selection/routing focused tests
- Context Builder, Oracle, worktree routing, persistent MCP reads, catalog shards, and affected context-store focused suites
- long-running external CE debug integration using RepoPrompt tools; no file/search/selection stalls or inconsistent state

Host caveat: broad local watcher suites currently encounter machine-level FSEvent stream exhaustion and reproduce identically on clean `main`; exact-head hosted CI is the authoritative clean-environment full-suite gate.

## Commit structure

The integration includes merge commit `7d693cc` joining the reviewed PR branch with `main` at `7d08002e`, followed by a test-only contract clarification commit.
