### PR TITLE
Stabilize worktree tests against file settings

### DIFF
--- a/Tests/RepoPromptTests/Helpers/WorkspaceRootLoadTestSupport.swift
+++ b/Tests/RepoPromptTests/Helpers/WorkspaceRootLoadTestSupport.swift
@@ -1,0 +1,19 @@
+@testable import RepoPrompt
+
+@MainActor
+enum WorkspaceRootLoadTestSupport {
+    static func loadRootMatchingCurrentFileSystemSettings(
+        in window: WindowState,
+        path: String
+    ) async throws -> WorkspaceRootRecord {
+        let settings = GlobalSettingsStore.shared.fileSystemSettingsSnapshot()
+        return try await window.workspaceFileContextStore.loadRoot(
+            path: path,
+            respectGitignore: settings.respectGitignore,
+            respectRepoIgnore: settings.respectRepoIgnore,
+            respectCursorignore: settings.respectCursorignore,
+            skipSymlinks: settings.skipSymlinks,
+            enableHierarchicalIgnores: settings.enableHierarchicalIgnores
+        )
+    }
+}

--- a/Tests/RepoPromptTests/Helpers/WorkspaceRootLoadTestSupport.swift
+++ b/Tests/RepoPromptTests/Helpers/WorkspaceRootLoadTestSupport.swift
@@ -4,11 +4,13 @@
 enum WorkspaceRootLoadTestSupport {
     static func loadRootMatchingCurrentFileSystemSettings(
         in window: WindowState,
-        path: String
+        path: String,
+        kind: WorkspaceRootKind = .primaryWorkspace
     ) async throws -> WorkspaceRootRecord {
         let settings = GlobalSettingsStore.shared.fileSystemSettingsSnapshot()
         return try await window.workspaceFileContextStore.loadRoot(
             path: path,
+            kind: kind,
             respectGitignore: settings.respectGitignore,
             respectRepoIgnore: settings.respectRepoIgnore,
             respectCursorignore: settings.respectCursorignore,

--- a/Tests/RepoPromptTests/MCP/AgentRunWorktreeStartTests.swift
+++ b/Tests/RepoPromptTests/MCP/AgentRunWorktreeStartTests.swift
@@ -1683,7 +1683,7 @@ final class AgentRunWorktreeStartTests: XCTestCase {
         await window.workspaceManager.switchWorkspace(to: workspace, saveState: false, reason: "agentRunWorktreeStartTests")
         let activeWorkspace = try XCTUnwrap(window.workspaceManager.activeWorkspace)
         window.promptManager.loadComposeTabsFromWorkspace(activeWorkspace, syncPromptText: true)
-        _ = try await window.workspaceFileContextStore.loadRoot(path: root.path)
+        _ = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(in: window, path: root.path)
         return window
     }
 

--- a/Tests/RepoPromptTests/MCP/Control/MCPBootstrapLeaseTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/MCPBootstrapLeaseTests.swift
@@ -211,7 +211,7 @@ final class MCPBootstrapLeaseTests: XCTestCase {
                 )
                 let activeWorkspace = try XCTUnwrap(window.workspaceManager.activeWorkspace)
                 window.promptManager.loadComposeTabsFromWorkspace(activeWorkspace, syncPromptText: true)
-                let loadedRoot = try await window.workspaceFileContextStore.loadRoot(path: rootURL.path)
+                let loadedRoot = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(in: window, path: rootURL.path)
                 loadedRootID = loadedRoot.id
 
                 ServiceRegistry.register(catalogService)

--- a/Tests/RepoPromptTests/MCP/Control/PersistentAgentModeMCPReadFileConnectionTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/PersistentAgentModeMCPReadFileConnectionTests.swift
@@ -1621,7 +1621,7 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
                 )
                 let activeWorkspace = try XCTUnwrap(window.workspaceManager.activeWorkspace)
                 window.promptManager.loadComposeTabsFromWorkspace(activeWorkspace, syncPromptText: true)
-                let rootRecord = try await window.workspaceFileContextStore.loadRoot(path: rootURL.path)
+                let rootRecord = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(in: window, path: rootURL.path)
                 rootID = rootRecord.id
                 let exactHit = await WorkspaceReadableFileService(store: window.workspaceFileContextStore)
                     .resolveExactAbsoluteWorkspaceCatalogHit(fileURL.path, rootScope: .visibleWorkspace)
@@ -1799,7 +1799,7 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
                 atomically: true,
                 encoding: .utf8
             )
-            let auxiliaryRoot = try await window.workspaceFileContextStore.loadRoot(path: auxiliaryRootURL.path)
+            let auxiliaryRoot = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(in: window, path: auxiliaryRootURL.path)
             auxiliaryRootID = auxiliaryRoot.id
 
             let worktreeRootURL = FileManager.default.temporaryDirectory
@@ -1898,7 +1898,7 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
                 )
             )
 
-            let root = try await routingGuardWindow.workspaceFileContextStore.loadRoot(path: rootURL.path)
+            let root = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(in: routingGuardWindow, path: rootURL.path)
             peerRootID = root.id
             peerTargetStateVersionBeforeSelection = routingGuardWindow.workspaceManager
                 .debugStateVersionForWorkspace(workspaceID)

--- a/Tests/RepoPromptTests/MCP/Control/PersistentMCPDistinctConnectionConcurrencyTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/PersistentMCPDistinctConnectionConcurrencyTests.swift
@@ -1597,7 +1597,10 @@ final class PersistentMCPDistinctConnectionConcurrencyTests: XCTestCase {
             ]
             configuredWorkspace.activeComposeTabID = tabID
             window.workspaceManager.workspaces.append(configuredWorkspace)
-            let rootRecord = try await window.workspaceFileContextStore.loadRoot(path: rootURL.path)
+            let rootRecord = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(
+                in: window,
+                path: rootURL.path
+            )
             let exactHit = await WorkspaceReadableFileService(store: window.workspaceFileContextStore)
                 .resolveExactAbsoluteWorkspaceCatalogHit(fileURL.path, rootScope: .visibleWorkspace)
             guard exactHit?.standardizedFullPath == fileURL.path else {

--- a/Tests/RepoPromptTests/MCP/MCPCodeStructureWorktreeTests.swift
+++ b/Tests/RepoPromptTests/MCP/MCPCodeStructureWorktreeTests.swift
@@ -37,8 +37,8 @@ final class MCPCodeStructureWorktreeTests: XCTestCase {
         let window = try await makeWindow(root: logicalRootURL)
         defer { WindowStatesManager.shared.unregisterWindowState(window) }
         let store = window.workspaceFileContextStore
-        let logicalRoot = try await store.loadRoot(path: logicalRootURL.path)
-        let worktreeRoot = try await store.loadRoot(path: worktreeRootURL.path, kind: .sessionWorktree)
+        let logicalRoot = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(in: window, path: logicalRootURL.path)
+        let worktreeRoot = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(in: window, path: worktreeRootURL.path, kind: .sessionWorktree)
         let projection = makeProjection(logicalRoot: logicalRoot, physicalRoot: worktreeRoot, worktreeID: "worktree")
         let lookupContext = WorkspaceLookupContext(rootScope: projection.lookupRootScope, bindingProjection: projection)
         let file = try await fileRecord(
@@ -82,8 +82,8 @@ final class MCPCodeStructureWorktreeTests: XCTestCase {
             let window = try await makeWindow(root: logicalRootURL)
             defer { WindowStatesManager.shared.unregisterWindowState(window) }
             let store = window.workspaceFileContextStore
-            let logicalRoot = try await store.loadRoot(path: logicalRootURL.path)
-            let worktreeRoot = try await store.loadRoot(path: worktreeRootURL.path, kind: .sessionWorktree)
+            let logicalRoot = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(in: window, path: logicalRootURL.path)
+            let worktreeRoot = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(in: window, path: worktreeRootURL.path, kind: .sessionWorktree)
             let projection = makeProjection(logicalRoot: logicalRoot, physicalRoot: worktreeRoot, worktreeID: "active")
             let lookupContext = WorkspaceLookupContext(rootScope: projection.lookupRootScope, bindingProjection: projection)
             let file = try await fileRecord(at: fileURL, store: store, rootScope: projection.lookupRootScope)
@@ -152,7 +152,7 @@ final class MCPCodeStructureWorktreeTests: XCTestCase {
         let window = try await makeWindow(root: logicalRootURL)
         defer { WindowStatesManager.shared.unregisterWindowState(window) }
         let store = window.workspaceFileContextStore
-        let logicalRoot = try await store.loadRoot(path: logicalRootURL.path)
+        let logicalRoot = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(in: window, path: logicalRootURL.path)
         let logicalRef = WorkspaceRootRef(
             id: logicalRoot.id,
             name: logicalRoot.name,
@@ -233,8 +233,8 @@ final class MCPCodeStructureWorktreeTests: XCTestCase {
         let window = try await makeWindow(root: logicalRootURL)
         defer { WindowStatesManager.shared.unregisterWindowState(window) }
         let store = window.workspaceFileContextStore
-        let logicalRoot = try await store.loadRoot(path: logicalRootURL.path)
-        let worktreeRoot = try await store.loadRoot(path: worktreeRootURL.path, kind: .sessionWorktree)
+        let logicalRoot = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(in: window, path: logicalRootURL.path)
+        let worktreeRoot = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(in: window, path: worktreeRootURL.path, kind: .sessionWorktree)
         let projection = makeProjection(logicalRoot: logicalRoot, physicalRoot: worktreeRoot, worktreeID: "deleted")
         let lookupContext = WorkspaceLookupContext(rootScope: projection.lookupRootScope, bindingProjection: projection)
         let file = try await fileRecord(
@@ -287,8 +287,8 @@ final class MCPCodeStructureWorktreeTests: XCTestCase {
         let window = try await makeWindow(root: logicalRootURL)
         defer { WindowStatesManager.shared.unregisterWindowState(window) }
         let store = window.workspaceFileContextStore
-        let logicalRoot = try await store.loadRoot(path: logicalRootURL.path)
-        let worktreeRoot = try await store.loadRoot(path: worktreeRootURL.path, kind: .sessionWorktree)
+        let logicalRoot = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(in: window, path: logicalRootURL.path)
+        let worktreeRoot = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(in: window, path: worktreeRootURL.path, kind: .sessionWorktree)
         let projection = makeProjection(logicalRoot: logicalRoot, physicalRoot: worktreeRoot, worktreeID: "bounded")
         let files = try await (1 ... 3).asyncMap { index in
             try await self.fileRecord(
@@ -326,7 +326,7 @@ final class MCPCodeStructureWorktreeTests: XCTestCase {
         let window = try await makeWindow(root: logicalRootURL)
         defer { WindowStatesManager.shared.unregisterWindowState(window) }
         let store = window.workspaceFileContextStore
-        let logicalRoot = try await store.loadRoot(path: logicalRootURL.path)
+        let logicalRoot = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(in: window, path: logicalRootURL.path)
         let logicalRef = WorkspaceRootRef(id: logicalRoot.id, name: logicalRoot.name, fullPath: logicalRoot.standardizedFullPath)
         let missingRef = WorkspaceRootRef(id: UUID(), name: logicalRoot.name, fullPath: missingWorktreeURL.path)
         let projection = WorkspaceRootBindingProjection(
@@ -398,7 +398,7 @@ final class MCPCodeStructureWorktreeTests: XCTestCase {
         )
         let activeWorkspace = try XCTUnwrap(window.workspaceManager.activeWorkspace)
         window.promptManager.loadComposeTabsFromWorkspace(activeWorkspace, syncPromptText: true)
-        _ = try await window.workspaceFileContextStore.loadRoot(path: root.path)
+        _ = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(in: window, path: root.path)
         return window
     }
 

--- a/Tests/RepoPromptTests/MCP/TabContextRoutingTests.swift
+++ b/Tests/RepoPromptTests/MCP/TabContextRoutingTests.swift
@@ -664,7 +664,7 @@ final class TabContextRoutingTests: XCTestCase {
         XCTAssertEqual(tabReloadResult, .switched)
         let activeWorkspace = try XCTUnwrap(window.workspaceManager.activeWorkspace)
         window.promptManager.loadComposeTabsFromWorkspace(activeWorkspace, syncPromptText: true)
-        _ = try await window.workspaceFileContextStore.loadRoot(path: logicalRoot.path)
+        _ = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(in: window, path: logicalRoot.path)
 
         var changes: [WorkspaceSelectionCoordinator.Change] = []
         window.selectionCoordinator.changes
@@ -1151,7 +1151,7 @@ final class TabContextRoutingTests: XCTestCase {
             saveState: false,
             reason: "manageSelectionPersistenceTestTabs"
         )
-        _ = try await window.workspaceFileContextStore.loadRoot(path: root.path)
+        _ = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(in: window, path: root.path)
         let tools = await window.mcpServer.windowMCPTools
         let manageSelection = try XCTUnwrap(
             tools.first { $0.name == MCPWindowToolName.manageSelection }

--- a/Tests/RepoPromptTests/MCP/WorktreeAPISmokeHarnessTests.swift
+++ b/Tests/RepoPromptTests/MCP/WorktreeAPISmokeHarnessTests.swift
@@ -707,7 +707,7 @@ final class WorktreeAPISmokeHarnessTests: XCTestCase {
         await window.workspaceManager.switchWorkspace(to: workspace, saveState: false, reason: "worktreeAPISmokeHarness")
         let activeWorkspace = try XCTUnwrap(window.workspaceManager.activeWorkspace)
         window.promptManager.loadComposeTabsFromWorkspace(activeWorkspace, syncPromptText: true)
-        _ = try await window.workspaceFileContextStore.loadRoot(path: root.path)
+        _ = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(in: window, path: root.path)
         return window
     }
 


### PR DESCRIPTION
## Summary
- add a shared test helper that loads workspace roots with the current GlobalSettingsStore file-system preferences
- update worktree/MCP test fixtures that manually preload roots before window services reuse them
- harden the shared persistent MCP fixture used by Context Builder worktree tests
- prevents developer-local file-system preferences from causing rootAlreadyLoadedWithDifferentConfiguration failures or empty local selection state in focused and full-suite runs

## Validation
- make dev-test FILTER=AgentRunWorktreeStartTests
- make dev-test FILTER=PersistentAgentModeMCPReadFileConnectionTests
- make dev-test FILTER=MCPBootstrapLeaseTests
- make dev-test FILTER=TabContextRoutingTests
- make dev-test FILTER=WorktreeAPISmokeHarnessTests
- make dev-test FILTER=ContextBuilderWorktreeInheritanceTests
- make dev-test FILTER=AsyncLimiterTests
- make dev-lint

Note: full local make dev-test is currently unreliable on this machine due unrelated long-running/full-suite singleton contamination; focused affected suites pass.