### PR TITLE
Fix Context Builder model restoration on launch

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/Recommendations/AutoRecommendationEngine.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Recommendations/AutoRecommendationEngine.swift
@@ -55,12 +55,7 @@ final class AutoRecommendationEngine {
             )
         }
 
-        return ProviderStatusSnapshot(
-            claudeCodeCLI: vm.isClaudeCodeConnected ? .ready : .notConfigured,
-            codexCLI: vm.isCodexConnected ? .ready : .notConfigured,
-            cursorCLI: vm.isCursorConnected ? .ready : .notConfigured,
-            openAI: vm.isOpenAIKeyValid ? .ready : (!vm.openAIApiKey.isEmpty ? .configured : .notConfigured)
-        )
+        return vm.recommendationProviderStatusSnapshot
     }
 
     /// Get provider flags from APISettingsViewModel.
@@ -338,14 +333,15 @@ final class AutoRecommendationEngine {
     static func resolveContextBuilderSelection(
         persistedAgentRaw: String?,
         persistedModelRaw: String?,
-        availability: AgentModelCatalog.AvailabilityContext
+        availability: AgentModelCatalog.AvailabilityContext,
+        enabledRecommendationProviders: Set<RecommendationProviderKind> = Set(RecommendationProviderKind.allCases)
     ) -> AgentModelCatalog.NormalizedAgentSelection? {
         if let agentRaw = persistedAgentRaw?.trimmingCharacters(in: .whitespacesAndNewlines),
            let modelRaw = persistedModelRaw?.trimmingCharacters(in: .whitespacesAndNewlines),
            let agent = AgentProviderKind(rawValue: agentRaw),
            !modelRaw.isEmpty,
            AgentModelCatalog.isAgentAvailable(agent, availability: availability),
-           AgentModelCatalog.isValid(rawModel: modelRaw, for: agent, availability: availability)
+           isValidPersistedContextBuilderModel(modelRaw, for: agent, availability: availability)
         {
             return AgentModelCatalog.normalizeSelection(
                 agentRaw: agent.rawValue,
@@ -359,7 +355,7 @@ final class AutoRecommendationEngine {
             codexCLI: availability.codexAvailable ? .ready : .notConfigured,
             cursorCLI: availability.cursorAvailable ? .ready : .notConfigured,
             openAI: .notConfigured
-        )
+        ).filtered(to: enabledRecommendationProviders)
         if let recommendation = contextBuilderRecommendation(status: status) {
             return AgentModelCatalog.normalizeSelection(
                 agentRaw: recommendation.recommendedAgent.rawValue,
@@ -368,7 +364,18 @@ final class AutoRecommendationEngine {
             )
         }
 
-        guard let availableAgent = AgentModelCatalog.selectableAgents(availability: availability).first else {
+        guard let availableAgent = AgentModelCatalog.selectableAgents(availability: availability).first(where: {
+            switch $0 {
+            case .claudeCode:
+                enabledRecommendationProviders.contains(.claudeCode)
+            case .codexExec:
+                enabledRecommendationProviders.contains(.codex)
+            case .cursor:
+                enabledRecommendationProviders.contains(.cursor)
+            case .openCode, .claudeCodeGLM, .kimiCode, .customClaudeCompatible:
+                true
+            }
+        }) else {
             return nil
         }
         return AgentModelCatalog.normalizeSelection(
@@ -376,6 +383,20 @@ final class AutoRecommendationEngine {
             modelRaw: nil,
             availability: availability
         )
+    }
+
+    private static func isValidPersistedContextBuilderModel(
+        _ rawModel: String,
+        for agent: AgentProviderKind,
+        availability: AgentModelCatalog.AvailabilityContext
+    ) -> Bool {
+        if agent == .openCode,
+           rawModel.trimmingCharacters(in: .whitespacesAndNewlines)
+           .caseInsensitiveCompare(AgentModel.defaultModel.rawValue) == .orderedSame
+        {
+            return true
+        }
+        return AgentModelCatalog.isValid(rawModel: rawModel, for: agent, availability: availability)
     }
 
     // MARK: - MCP Preset Exposure Recommendation

--- a/Sources/RepoPrompt/Features/AgentMode/Recommendations/AutoRecommendationEngine.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Recommendations/AutoRecommendationEngine.swift
@@ -295,12 +295,19 @@ final class AutoRecommendationEngine {
 
     private func computeContextBuilderRecommendation(
         status: ProviderStatusSnapshot,
-        settings: ChatGlobalSettings
+        settings _: ChatGlobalSettings
+    ) -> ContextBuilderRecommendation? {
+        Self.contextBuilderRecommendation(status: status)
+    }
+
+    /// Shared Context Builder recommendation ranking used by both the wizard and startup restore.
+    /// Keeping this pure prevents startup fallback behavior from drifting from the recommendation UI.
+    static func contextBuilderRecommendation(
+        status: ProviderStatusSnapshot
     ) -> ContextBuilderRecommendation? {
         // Priority: Codex CLI (requires CLI) > Claude Code > Cursor CLI
         // Cursor is a fallback only; it does not take priority over existing recommended providers.
         // Note: codexExec agent requires Codex CLI specifically, not just OpenAI API key
-
         if status.codexCLI == .ready {
             return ContextBuilderRecommendation(
                 recommendedAgent: .codexExec,
@@ -324,6 +331,51 @@ final class AutoRecommendationEngine {
         }
 
         return nil
+    }
+
+    /// Restores a saved Context Builder selection only when both provider and model are currently usable.
+    /// Invalid or unavailable persisted values fall back through the same recommendation ranking as the wizard.
+    static func resolveContextBuilderSelection(
+        persistedAgentRaw: String?,
+        persistedModelRaw: String?,
+        availability: AgentModelCatalog.AvailabilityContext
+    ) -> AgentModelCatalog.NormalizedAgentSelection? {
+        if let agentRaw = persistedAgentRaw?.trimmingCharacters(in: .whitespacesAndNewlines),
+           let modelRaw = persistedModelRaw?.trimmingCharacters(in: .whitespacesAndNewlines),
+           let agent = AgentProviderKind(rawValue: agentRaw),
+           !modelRaw.isEmpty,
+           AgentModelCatalog.isAgentAvailable(agent, availability: availability),
+           AgentModelCatalog.isValid(rawModel: modelRaw, for: agent, availability: availability)
+        {
+            return AgentModelCatalog.normalizeSelection(
+                agentRaw: agent.rawValue,
+                modelRaw: modelRaw,
+                availability: availability
+            )
+        }
+
+        let status = ProviderStatusSnapshot(
+            claudeCodeCLI: availability.claudeCodeAvailable ? .ready : .notConfigured,
+            codexCLI: availability.codexAvailable ? .ready : .notConfigured,
+            cursorCLI: availability.cursorAvailable ? .ready : .notConfigured,
+            openAI: .notConfigured
+        )
+        if let recommendation = contextBuilderRecommendation(status: status) {
+            return AgentModelCatalog.normalizeSelection(
+                agentRaw: recommendation.recommendedAgent.rawValue,
+                modelRaw: recommendation.recommendedModel.rawValue,
+                availability: availability
+            )
+        }
+
+        guard let availableAgent = AgentModelCatalog.selectableAgents(availability: availability).first else {
+            return nil
+        }
+        return AgentModelCatalog.normalizeSelection(
+            agentRaw: availableAgent.rawValue,
+            modelRaw: nil,
+            availability: availability
+        )
     }
 
     // MARK: - MCP Preset Exposure Recommendation

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/Recommendations/RecommendationWizardViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/Recommendations/RecommendationWizardViewModel.swift
@@ -263,6 +263,18 @@ final class RecommendationWizardViewModel: ObservableObject {
                 self?.refresh(navigation: .preserveCurrentStep)
             }
             .store(in: &cancellables)
+
+            // Startup verification changes effective readiness, but must never auto-apply a
+            // transient fallback into persisted recommendation settings.
+            Publishers.Merge(
+                api.$isContextBuilderProviderValidationComplete.map { _ in () },
+                api.$contextBuilderVerifiedCLIProviders.map { _ in () }
+            )
+            .debounce(for: .milliseconds(100), scheduler: RunLoop.main)
+            .sink { [weak self] _ in
+                self?.refresh(navigation: .preserveCurrentStep)
+            }
+            .store(in: &cancellables)
         }
 
         // Subscribe to recommendation-related setting changes

--- a/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderAgentViewModel.swift
+++ b/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderAgentViewModel.swift
@@ -904,12 +904,14 @@ final class ContextBuilderAgentViewModel: ObservableObject {
             .store(in: &cancellables)
 
         if let apiSettingsViewModel = promptManager.apiSettingsViewModel {
-            Publishers.MergeMany(
-                apiSettingsViewModel.$isClaudeCodeConnected.dropFirst().map { _ in () },
-                apiSettingsViewModel.$isCodexConnected.dropFirst().map { _ in () },
-                apiSettingsViewModel.$isOpenCodeConnected.dropFirst().map { _ in () },
-                apiSettingsViewModel.$isCursorConnected.dropFirst().map { _ in () }
-            )
+            Publishers.MergeMany([
+                apiSettingsViewModel.$isClaudeCodeConnected.dropFirst().map { _ in () }.eraseToAnyPublisher(),
+                apiSettingsViewModel.$isCodexConnected.dropFirst().map { _ in () }.eraseToAnyPublisher(),
+                apiSettingsViewModel.$isOpenCodeConnected.dropFirst().map { _ in () }.eraseToAnyPublisher(),
+                apiSettingsViewModel.$isCursorConnected.dropFirst().map { _ in () }.eraseToAnyPublisher(),
+                apiSettingsViewModel.$isContextBuilderProviderValidationComplete.dropFirst().map { _ in () }.eraseToAnyPublisher(),
+                apiSettingsViewModel.$contextBuilderVerifiedCLIProviders.dropFirst().map { _ in () }.eraseToAnyPublisher()
+            ])
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 self?.handleAgentProviderAvailabilityChanged()
@@ -951,11 +953,17 @@ final class ContextBuilderAgentViewModel: ObservableObject {
     }
 
     private func resolvedPersistedContextBuilderSelection() -> AgentModelCatalog.NormalizedAgentSelection? {
+        guard let apiSettingsViewModel = promptManager.apiSettingsViewModel,
+              apiSettingsViewModel.isContextBuilderProviderValidationComplete
+        else {
+            return nil
+        }
         let persisted = settingsManager.persistedGlobalContextBuilderAgentSelection()
         return AutoRecommendationEngine.resolveContextBuilderSelection(
             persistedAgentRaw: persisted.agentRaw,
             persistedModelRaw: persisted.modelRaw,
-            availability: agentAvailabilityContext
+            availability: apiSettingsViewModel.contextBuilderRestorationAvailabilityContext,
+            enabledRecommendationProviders: settingsManager.globalRecommendationProviderFilter()
         )
     }
 
@@ -1041,6 +1049,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
                 await MainActor.run { [weak self] in
                     guard let self else { return }
                     acpDynamicModelRevision &+= 1
+                    handleAgentProviderAvailabilityChanged()
                     syncSelectedACPModelFromRegistryIfNeeded(for: .openCode)
                 }
             }
@@ -1075,6 +1084,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
                 await MainActor.run { [weak self] in
                     guard let self else { return }
                     acpDynamicModelRevision &+= 1
+                    handleAgentProviderAvailabilityChanged()
                     syncSelectedACPModelFromRegistryIfNeeded(for: .cursor)
                 }
             }

--- a/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderAgentViewModel.swift
+++ b/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderAgentViewModel.swift
@@ -950,6 +950,15 @@ final class ContextBuilderAgentViewModel: ObservableObject {
         )
     }
 
+    private func resolvedPersistedContextBuilderSelection() -> AgentModelCatalog.NormalizedAgentSelection? {
+        let persisted = settingsManager.persistedGlobalContextBuilderAgentSelection()
+        return AutoRecommendationEngine.resolveContextBuilderSelection(
+            persistedAgentRaw: persisted.agentRaw,
+            persistedModelRaw: persisted.modelRaw,
+            availability: agentAvailabilityContext
+        )
+    }
+
     private func refreshAvailableAgents() {
         availableAgents = AgentModelCatalog.selectableAgents(availability: agentAvailabilityContext)
     }
@@ -969,7 +978,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
 
     private func handleAgentProviderAvailabilityChanged() {
         refreshAvailableAgents()
-        let normalized = normalizedSelection(agentRaw: selectedAgent.rawValue, modelRaw: selectedModelRaw)
+        guard let normalized = resolvedPersistedContextBuilderSelection() else { return }
         guard normalized.agent != selectedAgent || normalized.modelRaw.caseInsensitiveCompare(selectedModelRaw) != .orderedSame else {
             return
         }
@@ -1158,8 +1167,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
 
         // Agent/model selection: always from GLOBAL settings (not workspace, not tab)
         // This ensures consistent behavior across all workspaces and tabs
-        let (globalAgentRaw, globalModelRaw) = settingsManager.globalContextBuilderAgentSelection()
-        let normalizedAgentSelection = normalizedSelection(agentRaw: globalAgentRaw, modelRaw: globalModelRaw)
+        let normalizedAgentSelection = resolvedPersistedContextBuilderSelection()
 
         // Load workspace-scoped settings (tokenBudget, enhancementMode, etc.)
         let workspaceSettings = settingsManager.chatSettings(for: manager.activeWorkspace?.id ?? currentWorkspaceID ?? UUID())
@@ -1202,10 +1210,12 @@ final class ContextBuilderAgentViewModel: ObservableObject {
         // Plan token budget: workspace setting only, defaults to 120k
         planTokenBudget = workspaceSettings.discoveryPlanTokenBudget ?? 120_000
 
-        // Apply agent/model from global settings
-        selectedAgent = normalizedAgentSelection.agent
-        selectedModelRaw = normalizedAgentSelection.modelRaw
-        selectedModel = AgentModel.resolvedModel(forRaw: selectedModelRaw, agentKind: selectedAgent) ?? .defaultModel
+        // Apply agent/model from global settings when a configured provider is currently available.
+        if let normalizedAgentSelection {
+            selectedAgent = normalizedAgentSelection.agent
+            selectedModelRaw = normalizedAgentSelection.modelRaw
+            selectedModel = AgentModel.resolvedModel(forRaw: selectedModelRaw, agentKind: selectedAgent) ?? .defaultModel
+        }
 
         isRestoringState = false
         updateDynamicModelPolling(startCursorPolling: false)
@@ -1261,10 +1271,11 @@ final class ContextBuilderAgentViewModel: ObservableObject {
         mcpResponseType = nil
         // Per-tab clarifying questions state
         pendingAskUser = nil
-        let normalized = normalizedSelection(agentRaw: nil, modelRaw: nil)
-        selectedAgent = normalized.agent
-        selectedModelRaw = normalized.modelRaw
-        selectedModel = AgentModel.resolvedModel(forRaw: normalized.modelRaw, agentKind: normalized.agent) ?? .defaultModel
+        if let normalized = resolvedPersistedContextBuilderSelection() {
+            selectedAgent = normalized.agent
+            selectedModelRaw = normalized.modelRaw
+            selectedModel = AgentModel.resolvedModel(forRaw: normalized.modelRaw, agentKind: normalized.agent) ?? .defaultModel
+        }
         contextBuilderInstructions = ""
         selectedContextBuilderPromptIDs = []
         tokenBudget = ContextBuilderDefaults.discoveryTokenBudget
@@ -1406,8 +1417,10 @@ final class ContextBuilderAgentViewModel: ObservableObject {
     /// Used during workspace switch to initialize agent/model from global settings.
     private func applyGlobalAgentModel() {
         // Agent/model are now GLOBAL (not workspace-scoped)
-        let (globalAgentRaw, globalModelRaw) = settingsManager.globalContextBuilderAgentSelection()
-        let normalized = normalizedSelection(agentRaw: globalAgentRaw, modelRaw: globalModelRaw)
+        guard let normalized = resolvedPersistedContextBuilderSelection() else {
+            refreshAvailableAgents()
+            return
+        }
 
         isRestoringState = true
         selectedAgent = normalized.agent

--- a/Sources/RepoPrompt/Features/Prompt/ViewModels/PromptViewModel.swift
+++ b/Sources/RepoPrompt/Features/Prompt/ViewModels/PromptViewModel.swift
@@ -469,11 +469,17 @@ class PromptViewModel: ObservableObject {
     }
 
     private func resolvedPersistedContextBuilderSelection() -> AgentModelCatalog.NormalizedAgentSelection? {
+        guard let apiSettingsViewModel,
+              apiSettingsViewModel.isContextBuilderProviderValidationComplete
+        else {
+            return nil
+        }
         let persisted = settingsManager.persistedGlobalContextBuilderAgentSelection()
         return AutoRecommendationEngine.resolveContextBuilderSelection(
             persistedAgentRaw: persisted.agentRaw,
             persistedModelRaw: persisted.modelRaw,
-            availability: agentAvailabilityContext
+            availability: apiSettingsViewModel.contextBuilderRestorationAvailabilityContext,
+            enabledRecommendationProviders: settingsManager.globalRecommendationProviderFilter()
         )
     }
 
@@ -3601,10 +3607,14 @@ class PromptViewModel: ObservableObject {
             }
 
         Publishers.MergeMany([
-            apiSettingsViewModel.$isClaudeCodeConnected.dropFirst().map { _ in () },
-            apiSettingsViewModel.$isCodexConnected.dropFirst().map { _ in () },
-            apiSettingsViewModel.$isOpenCodeConnected.dropFirst().map { _ in () },
-            apiSettingsViewModel.$isCursorConnected.dropFirst().map { _ in () }
+            apiSettingsViewModel.$isClaudeCodeConnected.dropFirst().map { _ in () }.eraseToAnyPublisher(),
+            apiSettingsViewModel.$isCodexConnected.dropFirst().map { _ in () }.eraseToAnyPublisher(),
+            apiSettingsViewModel.$isOpenCodeConnected.dropFirst().map { _ in () }.eraseToAnyPublisher(),
+            apiSettingsViewModel.$isCursorConnected.dropFirst().map { _ in () }.eraseToAnyPublisher(),
+            apiSettingsViewModel.$isContextBuilderProviderValidationComplete.dropFirst().map { _ in () }.eraseToAnyPublisher(),
+            apiSettingsViewModel.$contextBuilderVerifiedCLIProviders.dropFirst().map { _ in () }.eraseToAnyPublisher(),
+            apiSettingsViewModel.$availableOpenCodeModelOptions.dropFirst().map { _ in () }.eraseToAnyPublisher(),
+            apiSettingsViewModel.$availableCursorModelOptions.dropFirst().map { _ in () }.eraseToAnyPublisher()
         ])
         .receive(on: DispatchQueue.main)
         .sink { [weak self] _ in

--- a/Sources/RepoPrompt/Features/Prompt/ViewModels/PromptViewModel.swift
+++ b/Sources/RepoPrompt/Features/Prompt/ViewModels/PromptViewModel.swift
@@ -468,8 +468,13 @@ class PromptViewModel: ObservableObject {
         availableAgentKinds = AgentModelCatalog.selectableAgents(availability: agentAvailabilityContext)
     }
 
-    private func normalizedPersistedAgentSelection(agentRaw: String?, modelRaw: String?) -> AgentModelCatalog.NormalizedAgentSelection {
-        AgentModelCatalog.normalizePersistedSelection(agentRaw: agentRaw, modelRaw: modelRaw, availability: agentAvailabilityContext)
+    private func resolvedPersistedContextBuilderSelection() -> AgentModelCatalog.NormalizedAgentSelection? {
+        let persisted = settingsManager.persistedGlobalContextBuilderAgentSelection()
+        return AutoRecommendationEngine.resolveContextBuilderSelection(
+            persistedAgentRaw: persisted.agentRaw,
+            persistedModelRaw: persisted.modelRaw,
+            availability: agentAvailabilityContext
+        )
     }
 
     func selectContextBuilderAgentModel(rawModel: String) {
@@ -486,10 +491,7 @@ class PromptViewModel: ObservableObject {
 
     private func handleAgentProviderAvailabilityChanged(reason: String) {
         refreshAvailableAgentKinds()
-        let normalizedContextBuilder = normalizedPersistedAgentSelection(
-            agentRaw: contextBuilderAgent.rawValue,
-            modelRaw: contextBuilderAgentModelRaw
-        )
+        guard let normalizedContextBuilder = resolvedPersistedContextBuilderSelection() else { return }
         if normalizedContextBuilder.agent != contextBuilderAgent ||
             normalizedContextBuilder.modelRaw.caseInsensitiveCompare(contextBuilderAgentModelRaw) != .orderedSame
         {
@@ -873,12 +875,12 @@ class PromptViewModel: ObservableObject {
 
         // Sync Context Builder agent/model from global Context Builder settings (single source of truth)
         refreshAvailableAgentKinds()
-        let (globalAgentRaw, globalModelRaw) = settingsManager.globalContextBuilderAgentSelection()
-        let normalizedContextBuilder = normalizedPersistedAgentSelection(agentRaw: globalAgentRaw, modelRaw: globalModelRaw)
-        if Self.debugLoggingEnabled { print("[PromptVM] syncSettings - normalized context builder agent: \(normalizedContextBuilder.agent.rawValue)") }
-        contextBuilderAgent = normalizedContextBuilder.agent
-        contextBuilderAgentModelRaw = normalizedContextBuilder.modelRaw
-        if Self.debugLoggingEnabled { print("[PromptVM] syncSettings - contextBuilderAgentModelRaw set to: \(contextBuilderAgentModelRaw)") }
+        if let normalizedContextBuilder = resolvedPersistedContextBuilderSelection() {
+            if Self.debugLoggingEnabled { print("[PromptVM] syncSettings - normalized context builder agent: \(normalizedContextBuilder.agent.rawValue)") }
+            contextBuilderAgent = normalizedContextBuilder.agent
+            contextBuilderAgentModelRaw = normalizedContextBuilder.modelRaw
+            if Self.debugLoggingEnabled { print("[PromptVM] syncSettings - contextBuilderAgentModelRaw set to: \(contextBuilderAgentModelRaw)") }
+        }
 
         // Sync model selection from the global settings store (may have been set by recommendation engine).
         syncModelSelectionFromSettingsManager()

--- a/Sources/RepoPrompt/Features/Settings/Models/GlobalSettingsManager.swift
+++ b/Sources/RepoPrompt/Features/Settings/Models/GlobalSettingsManager.swift
@@ -1316,17 +1316,29 @@ class GlobalSettingsStore: ObservableObject {
 
     // MARK: - Global Context Builder Agent Selection (Single Source of Truth)
 
-    /// Returns the global Context Builder agent and model selection.
-    /// This is the single source of truth for Context Builder agent/model across all workspaces.
-    /// - Returns: Tuple of (agentRaw, modelRaw) where modelRaw is the model for the selected agent
-    func globalContextBuilderAgentSelection() -> (agentRaw: String?, modelRaw: String?) {
-        let agentRaw = globalDefaults.discoverAgentRaw
-        let storedModelRaw: String? = if let agent = agentRaw {
-            globalDefaults.discoverModelsByAgent?[agent]
-        } else {
-            nil
+    /// Returns the raw persisted global Context Builder selection without synthesizing a fallback.
+    /// Startup restoration needs to distinguish a real saved value from the catalog's historical
+    /// Claude Code / Opus default so it can validate availability and use recommendations instead.
+    func persistedGlobalContextBuilderAgentSelection() -> (agentRaw: String?, modelRaw: String?) {
+        guard let agentRaw = globalDefaults.discoverAgentRaw?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !agentRaw.isEmpty
+        else {
+            return (nil, nil)
         }
-        let normalized = AgentModelCatalog.normalizeSelection(agentRaw: agentRaw, modelRaw: storedModelRaw)
+        let modelRaw = globalDefaults.discoverModelsByAgent?[agentRaw]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return (agentRaw, modelRaw?.isEmpty == false ? modelRaw : nil)
+    }
+
+    /// Returns a normalized global Context Builder agent and model selection.
+    /// Callers performing startup restoration should use
+    /// `persistedGlobalContextBuilderAgentSelection()` and validate against current availability.
+    func globalContextBuilderAgentSelection() -> (agentRaw: String?, modelRaw: String?) {
+        let persisted = persistedGlobalContextBuilderAgentSelection()
+        let normalized = AgentModelCatalog.normalizeSelection(
+            agentRaw: persisted.agentRaw,
+            modelRaw: persisted.modelRaw
+        )
         return (normalized.agent.rawValue, normalized.modelRaw)
     }
 

--- a/Sources/RepoPrompt/Features/Settings/Models/WindowSettingsManager.swift
+++ b/Sources/RepoPrompt/Features/Settings/Models/WindowSettingsManager.swift
@@ -14,6 +14,7 @@ protocol SettingsManaging {
     func globalContextBuilderAgentSelection() -> (agentRaw: String?, modelRaw: String?)
     func persistedGlobalContextBuilderAgentSelection() -> (agentRaw: String?, modelRaw: String?)
     func setGlobalContextBuilderAgentSelection(agentRaw: String, modelRaw: String, markUserDefined: Bool)
+    func globalRecommendationProviderFilter() -> Set<RecommendationProviderKind>
     func promptSectionsOrderRaw() -> String
     func setPromptSectionsOrderRaw(_ raw: String, commit: Bool)
     func duplicateUserInstructionsAtTop() -> Bool
@@ -122,6 +123,10 @@ final class WindowSettingsManager: ObservableObject, SettingsManaging {
             modelRaw: modelRaw,
             markUserDefined: markUserDefined
         )
+    }
+
+    func globalRecommendationProviderFilter() -> Set<RecommendationProviderKind> {
+        store.globalRecommendationProviderFilter()
     }
 
     // MARK: - Scalar global settings

--- a/Sources/RepoPrompt/Features/Settings/Models/WindowSettingsManager.swift
+++ b/Sources/RepoPrompt/Features/Settings/Models/WindowSettingsManager.swift
@@ -12,6 +12,7 @@ protocol SettingsManaging {
     func updateCopySettings(_ settings: CopyGlobalSettings, commit: Bool?)
     func updateChatSettings(_ settings: ChatGlobalSettings, commit: Bool?)
     func globalContextBuilderAgentSelection() -> (agentRaw: String?, modelRaw: String?)
+    func persistedGlobalContextBuilderAgentSelection() -> (agentRaw: String?, modelRaw: String?)
     func setGlobalContextBuilderAgentSelection(agentRaw: String, modelRaw: String, markUserDefined: Bool)
     func promptSectionsOrderRaw() -> String
     func setPromptSectionsOrderRaw(_ raw: String, commit: Bool)
@@ -109,6 +110,10 @@ final class WindowSettingsManager: ObservableObject, SettingsManaging {
 
     func globalContextBuilderAgentSelection() -> (agentRaw: String?, modelRaw: String?) {
         store.globalContextBuilderAgentSelection()
+    }
+
+    func persistedGlobalContextBuilderAgentSelection() -> (agentRaw: String?, modelRaw: String?) {
+        store.persistedGlobalContextBuilderAgentSelection()
     }
 
     func setGlobalContextBuilderAgentSelection(agentRaw: String, modelRaw: String, markUserDefined: Bool = true) {

--- a/Sources/RepoPrompt/Features/Settings/ViewModels/APISettingsViewModel.swift
+++ b/Sources/RepoPrompt/Features/Settings/ViewModels/APISettingsViewModel.swift
@@ -300,6 +300,13 @@ public class APISettingsViewModel: ObservableObject {
     @Published private(set) var availableCursorModelOptions: [AgentModelOption] = []
     private var cursorLogCollector: CLIProcessLogCollector?
 
+    /// CLI connection flags are persisted configuration hints, not proof that the provider is
+    /// usable in the current process. Context Builder restoration waits for this validation pass
+    /// before accepting or replacing a saved provider/model selection.
+    @Published private(set) var isContextBuilderProviderValidationComplete = false
+    @Published private(set) var contextBuilderVerifiedCLIProviders: Set<AgentProviderKind> = []
+    private var contextBuilderProviderValidationTask: Task<Void, Never>?
+
     @Published var openRouterApiKey: String = ""
     @Published var isOpenRouterKeyValid: Bool = false
     @Published var customOpenRouterModels: [String] = []
@@ -375,6 +382,86 @@ public class APISettingsViewModel: ObservableObject {
         )
     }
 
+    /// Availability safe for restoring persisted Context Builder selections. A persisted
+    /// "connected" bit is treated as configured-but-unverified until a current-process health
+    /// check succeeds. Compatible backends are loaded from their actual config/secret state
+    /// before the validation pass completes.
+    var contextBuilderRestorationAvailabilityContext: AgentModelCatalog.AvailabilityContext {
+        AgentModelCatalog.AvailabilityContext(
+            claudeCodeAvailable: isVerifiedContextBuilderProvider(.claudeCode) && isClaudeCodeConnected,
+            codexAvailable: isVerifiedContextBuilderProvider(.codexExec) && isCodexConnected,
+            openCodeAvailable: isVerifiedContextBuilderProvider(.openCode) && isOpenCodeConnected,
+            cursorAvailable: isVerifiedContextBuilderProvider(.cursor) && isCursorConnected,
+            zaiConfigured: compatibleBackendIsActive(.glmZAI),
+            kimiConfigured: compatibleBackendIsActive(.kimi),
+            customClaudeCompatibleConfigured: compatibleBackendIsActive(.custom)
+        )
+    }
+
+    var recommendationProviderStatusSnapshot: ProviderStatusSnapshot {
+        ProviderStatusSnapshot(
+            claudeCodeCLI: recommendationAvailability(isConnected: isClaudeCodeConnected, provider: .claudeCode),
+            codexCLI: recommendationAvailability(isConnected: isCodexConnected, provider: .codexExec),
+            cursorCLI: recommendationAvailability(isConnected: isCursorConnected, provider: .cursor),
+            openAI: isOpenAIKeyValid ? .ready : (!openAIApiKey.isEmpty ? .configured : .notConfigured)
+        )
+    }
+
+    private func recommendationAvailability(
+        isConnected: Bool,
+        provider: AgentProviderKind
+    ) -> ProviderStatusSnapshot.Availability {
+        guard isConnected else { return .notConfigured }
+        if isVerifiedContextBuilderProvider(provider) { return .ready }
+        return isContextBuilderProviderValidationComplete ? .notConfigured : .configured
+    }
+
+    private func isVerifiedContextBuilderProvider(_ provider: AgentProviderKind) -> Bool {
+        contextBuilderVerifiedCLIProviders.contains(provider)
+    }
+
+    private func setContextBuilderProviderVerified(
+        _ provider: AgentProviderKind,
+        verified: Bool
+    ) {
+        var updated = contextBuilderVerifiedCLIProviders
+        if verified {
+            updated.insert(provider)
+        } else {
+            updated.remove(provider)
+        }
+        guard updated != contextBuilderVerifiedCLIProviders else { return }
+        contextBuilderVerifiedCLIProviders = updated
+    }
+
+    private func contextBuilderProviderIsConnected(_ provider: AgentProviderKind) -> Bool {
+        switch provider {
+        case .claudeCode:
+            isClaudeCodeConnected
+        case .codexExec:
+            isCodexConnected
+        case .openCode:
+            isOpenCodeConnected
+        case .cursor:
+            isCursorConnected
+        case .claudeCodeGLM, .kimiCode, .customClaudeCompatible:
+            false
+        }
+    }
+
+    private func applyContextBuilderProviderValidationResult(
+        _ verified: Bool,
+        provider: AgentProviderKind
+    ) {
+        let isConnected = contextBuilderProviderIsConnected(provider)
+        if verified, isConnected {
+            setContextBuilderProviderVerified(provider, verified: true)
+        } else if !isConnected || !isVerifiedContextBuilderProvider(provider) {
+            // Preserve a newer successful manual/live verification that raced this startup check.
+            setContextBuilderProviderVerified(provider, verified: false)
+        }
+    }
+
     var isCodexExecutableUnavailable: Bool {
         if case .executableUnavailable = codexConnectionPhase {
             return true
@@ -400,14 +487,19 @@ public class APISettingsViewModel: ObservableObject {
 
     private func installCLIConnectionObservers() {
         Publishers.MergeMany([
-            NotificationCenter.default.publisher(for: .claudeCodeConnectionChanged).map { _ in () },
-            NotificationCenter.default.publisher(for: .codexConnectionChanged).map { _ in () },
-            NotificationCenter.default.publisher(for: .openCodeConnectionChanged).map { _ in () },
-            NotificationCenter.default.publisher(for: .cursorConnectionChanged).map { _ in () }
+            NotificationCenter.default.publisher(for: .claudeCodeConnectionChanged).map { _ in AgentProviderKind.claudeCode },
+            NotificationCenter.default.publisher(for: .codexConnectionChanged).map { _ in AgentProviderKind.codexExec },
+            NotificationCenter.default.publisher(for: .openCodeConnectionChanged).map { _ in AgentProviderKind.openCode },
+            NotificationCenter.default.publisher(for: .cursorConnectionChanged).map { _ in AgentProviderKind.cursor }
         ])
         .receive(on: DispatchQueue.main)
-        .sink { [weak self] _ in
-            self?.reloadCLIConnectionFlagsFromDefaults()
+        .sink { [weak self] provider in
+            guard let self else { return }
+            reloadCLIConnectionFlagsFromDefaults()
+            setContextBuilderProviderVerified(
+                provider,
+                verified: contextBuilderProviderIsConnected(provider)
+            )
         }
         .store(in: &cliConnectionCancellables)
     }
@@ -482,7 +574,10 @@ public class APISettingsViewModel: ObservableObject {
     }
 
     @discardableResult
-    func refreshClaudeCodeBinaryStatus(timeout: TimeInterval = 10) async -> Bool {
+    func refreshClaudeCodeBinaryStatus(
+        timeout: TimeInterval = 10,
+        forceProbe: Bool = false
+    ) async -> Bool {
         let previousAvailability = isClaudeFamilyModelProviderAvailable
         let previousStatus = claudeCodeCLIStatus
         if case .probing = claudeCodeCLIStatus {
@@ -490,7 +585,7 @@ public class APISettingsViewModel: ObservableObject {
             // concrete launch/test attempt will still surface command-not-found if needed.
             return true
         }
-        if isClaudeCodeConnected {
+        if isClaudeCodeConnected, !forceProbe {
             claudeCodeCLIStatus = .binaryPresent
             notifyClaudeCompatibleBackendRuntimeAvailabilityIfNeeded(previousStatus: previousStatus)
             return true
@@ -861,6 +956,7 @@ public class APISettingsViewModel: ObservableObject {
         if loadStoredDataOnInit {
             Task {
                 await self.loadStoredDataIfNeeded()
+                await self.validateCachedContextBuilderProvidersIfNeeded()
             }
         }
     }
@@ -875,6 +971,7 @@ public class APISettingsViewModel: ObservableObject {
         openCodeModelsTask?.cancel()
         cursorModelsTask?.cancel()
         openRouterModelsTask?.cancel()
+        contextBuilderProviderValidationTask?.cancel()
     }
 
     @MainActor
@@ -951,6 +1048,136 @@ public class APISettingsViewModel: ObservableObject {
         guard !hasLoadedStoredData, !isLoadingStoredData else { return }
         isLoadingStoredData = true
         await loadStoredData(accessMode: accessMode)
+    }
+
+    /// Revalidates persisted CLI connection hints once per view-model lifetime. Startup uses
+    /// bounded, non-generation checks and the shared single-flight ACP pollers, so restoration
+    /// cannot reject a saved dynamic model before discovery has had a chance to run.
+    @MainActor
+    func validateCachedContextBuilderProvidersIfNeeded() async {
+        if isContextBuilderProviderValidationComplete { return }
+        if let contextBuilderProviderValidationTask {
+            await contextBuilderProviderValidationTask.value
+            return
+        }
+
+        // Load persisted ACP catalogs before any provider result can trigger restoration.
+        // A live refresh may legitimately omit dynamic metadata, especially for Cursor.
+        await AgentACPModelRegistry.shared.warmStandardStoreIfNeeded()
+        if isContextBuilderProviderValidationComplete { return }
+        if let contextBuilderProviderValidationTask {
+            await contextBuilderProviderValidationTask.value
+            return
+        }
+
+        let shouldValidateClaude = isClaudeCodeConnected
+        let shouldValidateClaudeBinary = hasActiveClaudeCompatibleBackend
+        let shouldValidateCodex = isCodexConnected
+        let shouldValidateOpenCode = isOpenCodeConnected
+        let shouldValidateCursor = isCursorConnected
+
+        let task = Task { @MainActor [weak self] in
+            guard let self else { return }
+
+            async let claudeReady = probeCachedClaudeCodeConnection(
+                ifNeeded: shouldValidateClaude,
+                verifyBinaryForCompatibleBackends: shouldValidateClaudeBinary
+            )
+            async let codexReady = probeCachedCodexConnection(ifNeeded: shouldValidateCodex)
+            async let openCodeReady = probeCachedOpenCodeConnection(ifNeeded: shouldValidateOpenCode)
+            async let cursorReady = probeCachedCursorConnection(ifNeeded: shouldValidateCursor)
+            let readiness = await (claudeReady, codexReady, openCodeReady, cursorReady)
+
+            applyContextBuilderProviderValidationResult(readiness.0, provider: .claudeCode)
+            applyContextBuilderProviderValidationResult(readiness.1, provider: .codexExec)
+            applyContextBuilderProviderValidationResult(readiness.2, provider: .openCode)
+            applyContextBuilderProviderValidationResult(readiness.3, provider: .cursor)
+            if isCodexConnected, isVerifiedContextBuilderProvider(.codexExec) {
+                startCodexModelsSubscriptionIfNeeded()
+            }
+            isContextBuilderProviderValidationComplete = true
+            contextBuilderProviderValidationTask = nil
+        }
+        contextBuilderProviderValidationTask = task
+        await task.value
+    }
+
+    private func probeCachedClaudeCodeConnection(
+        ifNeeded: Bool,
+        verifyBinaryForCompatibleBackends: Bool
+    ) async -> Bool {
+        guard ifNeeded || verifyBinaryForCompatibleBackends else { return false }
+        guard ifNeeded else {
+            _ = await refreshClaudeCodeBinaryStatus(timeout: 10, forceProbe: true)
+            return false
+        }
+
+        var config = CLIProcessConfiguration(
+            captureStdoutTailBytes: 8 * 1024,
+            captureStderrTailBytes: 8 * 1024
+        )
+        config.ensureAdditionalPaths(CLIPathHints.claudeCode)
+        let runner = CLIProcessRunner(config: config)
+        do {
+            let result = try await runner.run(
+                args: ["auth", "status", "--json"],
+                stdin: nil,
+                outputMode: .none,
+                timeout: 10
+            )
+            await runner.cancelAll()
+
+            if !result.timedOut,
+               let object = try? JSONSerialization.jsonObject(with: result.stdout),
+               let payload = object as? [String: Any],
+               let loggedIn = payload["loggedIn"] as? Bool
+            {
+                let previousStatus = claudeCodeCLIStatus
+                claudeCodeCLIStatus = .binaryPresent
+                notifyClaudeCompatibleBackendRuntimeAvailabilityIfNeeded(previousStatus: previousStatus)
+                return loggedIn
+            }
+
+            let diagnostic = String(data: result.stderr + result.stdout, encoding: .utf8)?.lowercased() ?? ""
+            if diagnostic.contains("unknown command") || diagnostic.contains("unknown option") {
+                return await refreshClaudeCodeBinaryStatus(timeout: 10, forceProbe: true)
+            }
+            return false
+        } catch {
+            await runner.cancelAll()
+            _ = await refreshClaudeCodeBinaryStatus(timeout: 10, forceProbe: true)
+            return false
+        }
+    }
+
+    private func probeCachedCodexConnection(ifNeeded: Bool) async -> Bool {
+        guard ifNeeded else { return false }
+        switch await CodexManagedAuthRecoveryService.shared.refreshManagedAccount() {
+        case .recovered:
+            return true
+        case .requiresUserLogin, .executableUnavailable:
+            return false
+        }
+    }
+
+    private func probeCachedOpenCodeConnection(ifNeeded: Bool) async -> Bool {
+        guard ifNeeded else { return false }
+        if let latest = await OpenCodeACPModelPollingService.shared.latestSnapshot(),
+           latest.isLiveDiscovery
+        {
+            return true
+        }
+        return await OpenCodeACPModelPollingService.shared.refreshNow(workspacePath: nil)
+    }
+
+    private func probeCachedCursorConnection(ifNeeded: Bool) async -> Bool {
+        guard ifNeeded else { return false }
+        if let latest = await CursorACPModelPollingService.shared.latestSnapshot(),
+           latest.isLiveDiscovery
+        {
+            return true
+        }
+        return await CursorACPModelPollingService.shared.refreshNow(workspacePath: nil)
     }
 
     private func diagnosticReason(for error: Error) -> APIKeychainAccessDiagnostic.Reason {
@@ -1164,7 +1391,11 @@ public class APISettingsViewModel: ObservableObject {
         if isFireworksKeyValid { fireworksModelsTask = Task { await self.updateFireworksModels() } }
         if isGrokKeyValid { grokModelsTask = Task { await self.updateGrokModels() } }
         if isGroqKeyValid { groqModelsTask = Task { await self.updateGroqModels() } }
-        if isCodexConnected { startCodexModelsSubscriptionIfNeeded() } else { stopCodexModelsSubscription() }
+        if isCodexConnected, isVerifiedContextBuilderProvider(.codexExec) {
+            startCodexModelsSubscriptionIfNeeded()
+        } else {
+            stopCodexModelsSubscription()
+        }
         if isOpenCodeConnected { startOpenCodeModelsSubscriptionIfNeeded(workspacePath: nil) } else { stopOpenCodeModelsSubscription(clearModels: true) }
         if isCursorConnected { startCursorModelsSubscriptionIfNeeded(workspacePath: nil) } else { stopCursorModelsSubscription(clearModels: true) }
         if isOpenRouterKeyValid { openRouterModelsTask = Task { await self.fetchOpenRouterModels() } }
@@ -1692,6 +1923,13 @@ public class APISettingsViewModel: ObservableObject {
             let previousStatus = claudeCodeCLIStatus
             claudeCodeCLIStatus = status
             notifyClaudeCompatibleBackendRuntimeAvailabilityIfNeeded(previousStatus: previousStatus)
+        }
+
+        func test_completeContextBuilderProviderValidation(
+            verifiedProviders: Set<AgentProviderKind>
+        ) {
+            contextBuilderVerifiedCLIProviders = verifiedProviders
+            isContextBuilderProviderValidationComplete = true
         }
     #endif
 
@@ -2429,6 +2667,7 @@ public class APISettingsViewModel: ObservableObject {
             await provider.dispose()
             collector.append("Claude Code provider disposed")
             isClaudeCodeConnected = ok
+            setContextBuilderProviderVerified(.claudeCode, verified: ok)
             if ok {
                 claudeCodeCLIStatus = .binaryPresent
             }
@@ -2452,6 +2691,7 @@ public class APISettingsViewModel: ObservableObject {
             await provider.dispose()
             collector.append("Claude Code provider disposed")
             isClaudeCodeConnected = false
+            setContextBuilderProviderVerified(.claudeCode, verified: false)
             claudeCodeCLIStatus = Self.errorLooksLikeClaudeCodeBinaryMissing(error)
                 ? .binaryMissing(message: "Claude Code CLI isn't installed or isn't on PATH.")
                 : .binaryPresent
@@ -2505,6 +2745,7 @@ public class APISettingsViewModel: ObservableObject {
         windowID: Int = 0
     ) async {
         isCodexConnected = connected
+        setContextBuilderProviderVerified(.codexExec, verified: connected)
         codexError = error
         codexConnectionPhase = phase
         UserDefaults.standard.set(connected, forKey: "CodexCLIConnected")
@@ -2816,6 +3057,7 @@ public class APISettingsViewModel: ObservableObject {
             collector.append("Discovered \(snapshot.models.options.count) OpenCode model option(s)")
             availableOpenCodeModelOptions = snapshot.models.options
             isOpenCodeConnected = true
+            setContextBuilderProviderVerified(.openCode, verified: true)
             openCodeError = nil
             UserDefaults.standard.set(true, forKey: "OpenCodeCLIConnected")
             startOpenCodeModelsSubscriptionIfNeeded(workspacePath: nil)
@@ -2831,6 +3073,7 @@ public class APISettingsViewModel: ObservableObject {
         } catch {
             collector.append("Connection test threw error: \(error.localizedDescription)")
             isOpenCodeConnected = false
+            setContextBuilderProviderVerified(.openCode, verified: false)
             openCodeError = friendlyOpenCodeMessage(for: error)
             UserDefaults.standard.set(false, forKey: "OpenCodeCLIConnected")
             stopOpenCodeModelsSubscription(clearModels: true)
@@ -2848,6 +3091,7 @@ public class APISettingsViewModel: ObservableObject {
 
     func disconnectOpenCode() {
         isOpenCodeConnected = false
+        setContextBuilderProviderVerified(.openCode, verified: false)
         openCodeError = nil
         UserDefaults.standard.set(false, forKey: "OpenCodeCLIConnected")
         stopOpenCodeModelsSubscription(clearModels: true)
@@ -2913,7 +3157,11 @@ public class APISettingsViewModel: ObservableObject {
             for await snapshot in stream {
                 guard !Task.isCancelled else { return }
                 await MainActor.run { [weak self] in
-                    self?.availableOpenCodeModelOptions = snapshot.models.options
+                    guard let self else { return }
+                    availableOpenCodeModelOptions = snapshot.models.options
+                    if snapshot.isLiveDiscovery {
+                        setContextBuilderProviderVerified(.openCode, verified: true)
+                    }
                 }
                 await self?.updateAvailableModels()
             }
@@ -2954,6 +3202,7 @@ public class APISettingsViewModel: ObservableObject {
                 availableCursorModelOptions = cursorOptions
             }
             isCursorConnected = true
+            setContextBuilderProviderVerified(.cursor, verified: true)
             cursorError = nil
             UserDefaults.standard.set(true, forKey: "CursorCLIConnected")
             startCursorModelsSubscriptionIfNeeded(workspacePath: nil)
@@ -2969,6 +3218,7 @@ public class APISettingsViewModel: ObservableObject {
         } catch {
             collector.append("Connection test threw error: \(error.localizedDescription)")
             isCursorConnected = false
+            setContextBuilderProviderVerified(.cursor, verified: false)
             cursorError = friendlyCursorMessage(for: error)
             UserDefaults.standard.set(false, forKey: "CursorCLIConnected")
             stopCursorModelsSubscription(clearModels: true)
@@ -2986,6 +3236,7 @@ public class APISettingsViewModel: ObservableObject {
 
     func disconnectCursor() {
         isCursorConnected = false
+        setContextBuilderProviderVerified(.cursor, verified: false)
         cursorError = nil
         UserDefaults.standard.set(false, forKey: "CursorCLIConnected")
         stopCursorModelsSubscription(clearModels: true)
@@ -3051,13 +3302,17 @@ public class APISettingsViewModel: ObservableObject {
         guard cursorModelsTask == nil else { return }
         cursorModelsTask = Task { [weak self, workspacePath] in
             let stream = await CursorACPModelPollingService.shared.subscribe(workspacePath: workspacePath)
-            for await _ in stream {
+            for await snapshot in stream {
                 guard !Task.isCancelled else { return }
                 await MainActor.run { [weak self] in
-                    self?.availableCursorModelOptions = AgentModelCatalog.options(
+                    guard let self else { return }
+                    availableCursorModelOptions = AgentModelCatalog.options(
                         for: .cursor,
                         availability: AgentModelCatalog.AvailabilityContext(cursorAvailable: true, zaiConfigured: false)
                     )
+                    if snapshot.isLiveDiscovery {
+                        setContextBuilderProviderVerified(.cursor, verified: true)
+                    }
                 }
                 await self?.updateAvailableModels()
             }

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Cursor/CursorACPModelPollingService.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Cursor/CursorACPModelPollingService.swift
@@ -79,13 +79,14 @@ actor CursorACPModelPollingService {
     struct Snapshot: Equatable {
         let models: ACPDiscoveredSessionModels
         let fetchedAt: Date
+        let isLiveDiscovery: Bool
     }
 
     private let client: any CursorACPModelDiscoveryClient
     private let intervalNanos: UInt64
 
     private var pollingTask: Task<Void, Never>?
-    private var inFlightRefresh: Task<Void, Never>?
+    private var inFlightRefresh: Task<Bool, Never>?
     private var continuations: [UUID: AsyncStream<Snapshot>.Continuation] = [:]
     private var latest: Snapshot?
     private var preferredWorkspacePath: String?
@@ -147,14 +148,14 @@ actor CursorACPModelPollingService {
         return stream
     }
 
-    func refreshNow(workspacePath: String?) async {
-        guard !isShutdown else { return }
+    @discardableResult
+    func refreshNow(workspacePath: String?) async -> Bool {
+        guard !isShutdown else { return false }
         preferredWorkspacePath = normalizedWorkspacePath(workspacePath)
         if let existing = inFlightRefresh {
-            await existing.value
-            return
+            return await existing.value
         }
-        await performRefresh()
+        return await performRefresh()
     }
 
     func shutdown(finishSubscribers: Bool = true) async {
@@ -178,7 +179,7 @@ actor CursorACPModelPollingService {
         pollingTask = Task { [weak self] in
             guard let self else { return }
             while !Task.isCancelled {
-                await performRefresh()
+                _ = await performRefresh()
                 do {
                     try await Task.sleep(nanoseconds: intervalNanos)
                 } catch {
@@ -199,35 +200,53 @@ actor CursorACPModelPollingService {
         stopPollingIfIdle()
     }
 
-    private func performRefresh() async {
-        guard !isShutdown else { return }
+    private func performRefresh() async -> Bool {
+        guard !isShutdown else { return false }
         if let existing = inFlightRefresh {
-            await existing.value
-            return
+            return await existing.value
         }
 
         let workspacePath = preferredWorkspacePath
-        let task = Task { [weak self, workspacePath] in
-            guard let self else { return }
+        let task = Task<Bool, Never> { [weak self, workspacePath] in
+            guard let self else { return false }
             do {
-                guard let discovered = try await client.discoverModels(workspacePath: workspacePath) else { return }
-                guard !Task.isCancelled else { return }
-                await applyRefreshResult(discovered)
+                let discovered = try await client.discoverModels(workspacePath: workspacePath)
+                guard !Task.isCancelled else { return false }
+                if let discovered {
+                    await applyRefreshResult(discovered)
+                } else {
+                    await publishLiveReadinessWithoutModels()
+                }
+                return true
             } catch {
                 // Keep the last registry/cache snapshot when preflight or ACP discovery fails.
+                return false
             }
         }
         inFlightRefresh = task
         defer { inFlightRefresh = nil }
-        await task.value
+        return await task.value
+    }
+
+    private func publishLiveReadinessWithoutModels() {
+        guard !isShutdown else { return }
+        let models = latest?.models
+            ?? AgentACPModelRegistry.shared.resolvedSnapshot(for: .cursor)
+            ?? ACPDiscoveredSessionModels(options: [], currentModelRaw: nil)
+        let snapshot = Snapshot(models: models, fetchedAt: Date(), isLiveDiscovery: true)
+        guard latest?.models != snapshot.models || latest?.isLiveDiscovery == false else { return }
+        latest = snapshot
+        for continuation in continuations.values {
+            continuation.yield(snapshot)
+        }
     }
 
     private func applyRefreshResult(_ discovered: ACPDiscoveredSessionModels) {
         guard !isShutdown else { return }
         _ = AgentACPModelRegistry.shared.updateDiscoveredModels(discovered, for: .cursor)
         guard let normalized = AgentACPModelRegistry.shared.resolvedSnapshot(for: .cursor) else { return }
-        let snapshot = Snapshot(models: normalized, fetchedAt: Date())
-        guard latest?.models != snapshot.models else { return }
+        let snapshot = Snapshot(models: normalized, fetchedAt: Date(), isLiveDiscovery: true)
+        guard latest?.models != snapshot.models || latest?.isLiveDiscovery == false else { return }
         latest = snapshot
         for continuation in continuations.values {
             continuation.yield(snapshot)
@@ -238,7 +257,7 @@ actor CursorACPModelPollingService {
         guard let models = await AgentACPModelRegistry.shared.resolvedSnapshotAfterWarmingStandardStore(for: .cursor) else {
             return nil
         }
-        return Snapshot(models: models, fetchedAt: Date())
+        return Snapshot(models: models, fetchedAt: Date(), isLiveDiscovery: false)
     }
 
     private func normalizedWorkspacePath(_ path: String?) -> String? {

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/OpenCode/OpenCodeACPModelPollingService.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/OpenCode/OpenCodeACPModelPollingService.swift
@@ -79,13 +79,14 @@ actor OpenCodeACPModelPollingService {
     struct Snapshot: Equatable {
         let models: ACPDiscoveredSessionModels
         let fetchedAt: Date
+        let isLiveDiscovery: Bool
     }
 
     private let client: any OpenCodeACPModelDiscoveryClient
     private let intervalNanos: UInt64
 
     private var pollingTask: Task<Void, Never>?
-    private var inFlightRefresh: Task<Void, Never>?
+    private var inFlightRefresh: Task<Bool, Never>?
     private var continuations: [UUID: AsyncStream<Snapshot>.Continuation] = [:]
     private var latest: Snapshot?
     private var preferredWorkspacePath: String?
@@ -156,14 +157,14 @@ actor OpenCodeACPModelPollingService {
         return stream
     }
 
-    func refreshNow(workspacePath: String?) async {
-        guard !isShutdown else { return }
+    @discardableResult
+    func refreshNow(workspacePath: String?) async -> Bool {
+        guard !isShutdown else { return false }
         preferredWorkspacePath = normalizedWorkspacePath(workspacePath)
         if let existing = inFlightRefresh {
-            await existing.value
-            return
+            return await existing.value
         }
-        await performRefresh()
+        return await performRefresh()
     }
 
     func shutdown(finishSubscribers: Bool = true) async {
@@ -187,7 +188,7 @@ actor OpenCodeACPModelPollingService {
         pollingTask = Task { [weak self] in
             guard let self else { return }
             while !Task.isCancelled {
-                await performRefresh()
+                _ = await performRefresh()
                 do {
                     try await Task.sleep(nanoseconds: intervalNanos)
                 } catch {
@@ -208,35 +209,36 @@ actor OpenCodeACPModelPollingService {
         stopPollingIfIdle()
     }
 
-    private func performRefresh() async {
-        guard !isShutdown else { return }
+    private func performRefresh() async -> Bool {
+        guard !isShutdown else { return false }
         if let existing = inFlightRefresh {
-            await existing.value
-            return
+            return await existing.value
         }
 
         let workspacePath = preferredWorkspacePath
-        let task = Task { [weak self, workspacePath] in
-            guard let self else { return }
+        let task = Task<Bool, Never> { [weak self, workspacePath] in
+            guard let self else { return false }
             do {
-                guard let discovered = try await client.discoverModels(workspacePath: workspacePath) else { return }
-                guard !Task.isCancelled else { return }
+                guard let discovered = try await client.discoverModels(workspacePath: workspacePath) else { return false }
+                guard !Task.isCancelled else { return false }
                 await applyRefreshResult(discovered)
+                return true
             } catch {
                 // Keep the last registry/cache snapshot when preflight or ACP discovery fails.
+                return false
             }
         }
         inFlightRefresh = task
         defer { inFlightRefresh = nil }
-        await task.value
+        return await task.value
     }
 
     private func applyRefreshResult(_ discovered: ACPDiscoveredSessionModels) {
         guard !isShutdown else { return }
         _ = AgentACPModelRegistry.shared.updateDiscoveredModels(discovered, for: .openCode)
         guard let normalized = AgentACPModelRegistry.shared.resolvedSnapshot(for: .openCode) else { return }
-        let snapshot = Snapshot(models: normalized, fetchedAt: Date())
-        guard latest?.models != snapshot.models else { return }
+        let snapshot = Snapshot(models: normalized, fetchedAt: Date(), isLiveDiscovery: true)
+        guard latest?.models != snapshot.models || latest?.isLiveDiscovery == false else { return }
         latest = snapshot
         for continuation in continuations.values {
             continuation.yield(snapshot)
@@ -247,7 +249,7 @@ actor OpenCodeACPModelPollingService {
         guard let models = await AgentACPModelRegistry.shared.resolvedSnapshotAfterWarmingStandardStore(for: .openCode) else {
             return nil
         }
-        return Snapshot(models: models, fetchedAt: Date())
+        return Snapshot(models: models, fetchedAt: Date(), isLiveDiscovery: false)
     }
 
     private func normalizedWorkspacePath(_ path: String?) -> String? {

--- a/Tests/RepoPromptTests/ContextBuilder/ContextBuilderModelStartupSelectionTests.swift
+++ b/Tests/RepoPromptTests/ContextBuilder/ContextBuilderModelStartupSelectionTests.swift
@@ -71,6 +71,276 @@ final class ContextBuilderModelStartupSelectionTests: XCTestCase {
         ))
     }
 
+    func testFallbackUsesWizardRecommendationProviderFilter() throws {
+        let resolved = try XCTUnwrap(AutoRecommendationEngine.resolveContextBuilderSelection(
+            persistedAgentRaw: AgentProviderKind.openCode.rawValue,
+            persistedModelRaw: "removed/model",
+            availability: .init(
+                claudeCodeAvailable: true,
+                codexAvailable: true,
+                openCodeAvailable: false,
+                cursorAvailable: false
+            ),
+            enabledRecommendationProviders: [.claudeCode]
+        ))
+
+        XCTAssertEqual(resolved.agent, .claudeCode)
+        XCTAssertEqual(resolved.modelRaw, AgentModel.claudeSonnet.rawValue)
+    }
+
+    func testFilteredRecommendationProvidersDoNotReappearThroughGenericFallback() throws {
+        let resolved = try XCTUnwrap(AutoRecommendationEngine.resolveContextBuilderSelection(
+            persistedAgentRaw: nil,
+            persistedModelRaw: nil,
+            availability: .init(
+                claudeCodeAvailable: false,
+                codexAvailable: true,
+                openCodeAvailable: true,
+                cursorAvailable: false
+            ),
+            enabledRecommendationProviders: [.claudeCode]
+        ))
+
+        XCTAssertEqual(resolved.agent, .openCode)
+        XCTAssertEqual(resolved.modelRaw, AgentModel.defaultModel.rawValue)
+    }
+
+    func testStaticOpenCodeDefaultSurvivesAfterACPDiscovery() throws {
+        let providerID = ACPProviderID.openCode
+        AgentACPModelRegistry.shared.test_reset(providerID: providerID)
+        addTeardownBlock {
+            AgentACPModelRegistry.shared.test_reset(providerID: providerID)
+        }
+
+        let preferredModelRaw = "openai/gpt-dynamic"
+        XCTAssertTrue(AgentACPModelRegistry.shared.updateDiscoveredModels(
+            ACPDiscoveredSessionModels(
+                options: [AgentModelOption(
+                    rawValue: preferredModelRaw,
+                    displayName: "GPT Dynamic",
+                    description: nil,
+                    isPlaceholderDefault: false,
+                    isProviderDefault: true
+                )],
+                currentModelRaw: preferredModelRaw
+            ),
+            for: providerID
+        ))
+
+        let resolved = try XCTUnwrap(AutoRecommendationEngine.resolveContextBuilderSelection(
+            persistedAgentRaw: AgentProviderKind.openCode.rawValue,
+            persistedModelRaw: AgentModel.defaultModel.rawValue,
+            availability: .init(
+                claudeCodeAvailable: false,
+                codexAvailable: true,
+                openCodeAvailable: true,
+                cursorAvailable: false
+            )
+        ))
+
+        XCTAssertEqual(resolved.agent, .openCode)
+        XCTAssertEqual(resolved.modelRaw, preferredModelRaw)
+    }
+
+    func testDynamicPersistedSelectionSurvivesAfterACPDiscovery() throws {
+        let providerID = ACPProviderID.openCode
+        AgentACPModelRegistry.shared.test_reset(providerID: providerID)
+        addTeardownBlock {
+            AgentACPModelRegistry.shared.test_reset(providerID: providerID)
+        }
+
+        let dynamicModelRaw = "openai/gpt-dynamic"
+        XCTAssertTrue(AgentACPModelRegistry.shared.updateDiscoveredModels(
+            ACPDiscoveredSessionModels(
+                options: [AgentModelOption(
+                    rawValue: dynamicModelRaw,
+                    displayName: "GPT Dynamic",
+                    description: nil,
+                    isPlaceholderDefault: false,
+                    isProviderDefault: true
+                )],
+                currentModelRaw: dynamicModelRaw
+            ),
+            for: providerID
+        ))
+
+        let resolved = try XCTUnwrap(AutoRecommendationEngine.resolveContextBuilderSelection(
+            persistedAgentRaw: AgentProviderKind.openCode.rawValue,
+            persistedModelRaw: dynamicModelRaw,
+            availability: .init(
+                claudeCodeAvailable: false,
+                codexAvailable: true,
+                openCodeAvailable: true,
+                cursorAvailable: false
+            )
+        ))
+
+        XCTAssertEqual(resolved.agent, .openCode)
+        XCTAssertEqual(resolved.modelRaw, dynamicModelRaw)
+    }
+
+    func testPersistedDynamicSelectionSurvivesStandardCatalogWarmup() async throws {
+        let providerID = ACPProviderID.openCode
+        AgentACPModelRegistry.shared.test_reset(providerID: providerID)
+        addTeardownBlock {
+            AgentACPModelRegistry.shared.test_reset(providerID: providerID)
+        }
+
+        let dynamicModelRaw = "openai/gpt-persisted"
+        XCTAssertTrue(AgentACPModelRegistry.shared.updateDiscoveredModels(
+            ACPDiscoveredSessionModels(
+                options: [AgentModelOption(
+                    rawValue: dynamicModelRaw,
+                    displayName: "GPT Persisted",
+                    description: nil,
+                    isPlaceholderDefault: false,
+                    isProviderDefault: true
+                )],
+                currentModelRaw: dynamicModelRaw
+            ),
+            for: providerID
+        ))
+        AgentACPModelRegistry.shared.test_clearMemoryPreservingStore(providerID: providerID)
+        XCTAssertNil(AgentACPModelRegistry.shared.test_snapshot(providerID: providerID))
+
+        await AgentACPModelRegistry.shared.test_warmStandardStore()
+
+        let resolved = try XCTUnwrap(AutoRecommendationEngine.resolveContextBuilderSelection(
+            persistedAgentRaw: AgentProviderKind.openCode.rawValue,
+            persistedModelRaw: dynamicModelRaw,
+            availability: .init(
+                claudeCodeAvailable: false,
+                codexAvailable: false,
+                openCodeAvailable: true,
+                cursorAvailable: false
+            )
+        ))
+        XCTAssertEqual(resolved.agent, .openCode)
+        XCTAssertEqual(resolved.modelRaw, dynamicModelRaw)
+    }
+
+    func testOpenCodeStartupReadinessJoinsRunningPollAndEmitsLiveSnapshot() async throws {
+        let providerID = ACPProviderID.openCode
+        AgentACPModelRegistry.shared.test_reset(providerID: providerID)
+        addTeardownBlock {
+            AgentACPModelRegistry.shared.test_reset(providerID: providerID)
+        }
+
+        let dynamicModelRaw = "openai/gpt-live"
+        let discovered = ACPDiscoveredSessionModels(
+            options: [AgentModelOption(
+                rawValue: dynamicModelRaw,
+                displayName: "GPT Live",
+                description: nil,
+                isPlaceholderDefault: false,
+                isProviderDefault: true
+            )],
+            currentModelRaw: dynamicModelRaw
+        )
+        let client = DelayedOpenCodeDiscoveryClient(result: discovered)
+        let service = OpenCodeACPModelPollingService(client: client, intervalNanos: 60_000_000_000)
+        let stream = await service.subscribe(workspacePath: nil)
+        await client.waitUntilCalled()
+
+        async let readiness = service.refreshNow(workspacePath: nil)
+        var iterator = stream.makeAsyncIterator()
+        let emittedSnapshot = await iterator.next()
+        let snapshot = try XCTUnwrap(emittedSnapshot)
+        let isReady = await readiness
+        let discoveryCallCount = await client.callCount()
+
+        XCTAssertTrue(isReady)
+        XCTAssertTrue(snapshot.isLiveDiscovery)
+        XCTAssertEqual(snapshot.models.currentModelRaw, dynamicModelRaw)
+        XCTAssertEqual(discoveryCallCount, 1)
+        await service.shutdown()
+    }
+
+    func testCursorStartupReadinessJoinsRunningPollWithoutDynamicMetadata() async {
+        let client = DelayedCursorDiscoveryClient(result: nil)
+        let service = CursorACPModelPollingService(client: client, intervalNanos: 60_000_000_000)
+        let stream = await service.subscribe(workspacePath: nil)
+        await client.waitUntilCalled()
+
+        async let readiness = service.refreshNow(workspacePath: nil)
+        var iterator = stream.makeAsyncIterator()
+        var liveSnapshot: CursorACPModelPollingService.Snapshot?
+        while liveSnapshot == nil, let snapshot = await iterator.next() {
+            if snapshot.isLiveDiscovery {
+                liveSnapshot = snapshot
+            }
+        }
+        let isReady = await readiness
+        let discoveryCallCount = await client.callCount()
+
+        XCTAssertTrue(isReady)
+        XCTAssertEqual(liveSnapshot?.isLiveDiscovery, true)
+        XCTAssertEqual(discoveryCallCount, 1)
+        await service.shutdown()
+    }
+
+    func testTransientFallbackResolutionDoesNotMutatePersistedSelection() throws {
+        let fixture = try makeStoreFixture()
+        fixture.store.setGlobalContextBuilderAgentSelection(
+            agentRaw: AgentProviderKind.openCode.rawValue,
+            modelRaw: "openai/gpt-dynamic",
+            markUserDefined: true
+        )
+        let before = fixture.store.persistedGlobalContextBuilderAgentSelection()
+
+        let fallback = try XCTUnwrap(AutoRecommendationEngine.resolveContextBuilderSelection(
+            persistedAgentRaw: before.agentRaw,
+            persistedModelRaw: before.modelRaw,
+            availability: .init(
+                claudeCodeAvailable: false,
+                codexAvailable: true,
+                openCodeAvailable: false,
+                cursorAvailable: false
+            )
+        ))
+
+        XCTAssertEqual(fallback.agent, .codexExec)
+        XCTAssertEqual(fixture.store.persistedGlobalContextBuilderAgentSelection().agentRaw, before.agentRaw)
+        XCTAssertEqual(fixture.store.persistedGlobalContextBuilderAgentSelection().modelRaw, before.modelRaw)
+    }
+
+    func testCachedCLIFlagIsNotReadyUntilCurrentProcessVerification() {
+        let keys = ["ClaudeCodeConnected", "CodexCLIConnected", "OpenCodeCLIConnected", "CursorCLIConnected"]
+        let previous = Dictionary(uniqueKeysWithValues: keys.map { ($0, UserDefaults.standard.object(forKey: $0)) })
+        defer {
+            for (key, value) in previous {
+                if let value {
+                    UserDefaults.standard.set(value, forKey: key)
+                } else {
+                    UserDefaults.standard.removeObject(forKey: key)
+                }
+            }
+        }
+
+        UserDefaults.standard.set(true, forKey: "ClaudeCodeConnected")
+        UserDefaults.standard.set(false, forKey: "CodexCLIConnected")
+        UserDefaults.standard.set(false, forKey: "OpenCodeCLIConnected")
+        UserDefaults.standard.set(false, forKey: "CursorCLIConnected")
+
+        let keyManager = KeyManager(secureService: SecureKeysService(secureStorage: TestSecureStorageBackend()))
+        let viewModel = APISettingsViewModel(
+            aiQueriesService: AIQueriesService(keyManager: keyManager),
+            keyManager: keyManager,
+            loadStoredDataOnInit: false
+        )
+
+        XCTAssertEqual(viewModel.recommendationProviderStatusSnapshot.claudeCodeCLI, .configured)
+        XCTAssertFalse(viewModel.contextBuilderRestorationAvailabilityContext.claudeCodeAvailable)
+
+        viewModel.test_completeContextBuilderProviderValidation(verifiedProviders: [])
+        XCTAssertEqual(viewModel.recommendationProviderStatusSnapshot.claudeCodeCLI, .notConfigured)
+        XCTAssertTrue(UserDefaults.standard.bool(forKey: "ClaudeCodeConnected"))
+
+        viewModel.test_completeContextBuilderProviderValidation(verifiedProviders: [.claudeCode])
+        XCTAssertEqual(viewModel.recommendationProviderStatusSnapshot.claudeCodeCLI, .ready)
+        XCTAssertTrue(viewModel.contextBuilderRestorationAvailabilityContext.claudeCodeAvailable)
+    }
+
     private func makeStoreFixture() throws -> (
         store: GlobalSettingsStore,
         defaults: UserDefaults,
@@ -94,5 +364,55 @@ final class ContextBuilderModelStartupSelectionTests: XCTestCase {
             fileURL: temp.appendingPathComponent("Settings/globalSettings.json")
         )
         return (GlobalSettingsStore(defaults: defaults, fileStore: fileStore), defaults, fileStore)
+    }
+}
+
+private actor DelayedOpenCodeDiscoveryClient: OpenCodeACPModelDiscoveryClient {
+    private let result: ACPDiscoveredSessionModels?
+    private var calls = 0
+
+    init(result: ACPDiscoveredSessionModels?) {
+        self.result = result
+    }
+
+    func discoverModels(workspacePath _: String?) async throws -> ACPDiscoveredSessionModels? {
+        calls += 1
+        try await Task.sleep(nanoseconds: 100_000_000)
+        return result
+    }
+
+    func waitUntilCalled() async {
+        while calls == 0 {
+            await Task.yield()
+        }
+    }
+
+    func callCount() -> Int {
+        calls
+    }
+}
+
+private actor DelayedCursorDiscoveryClient: CursorACPModelDiscoveryClient {
+    private let result: ACPDiscoveredSessionModels?
+    private var calls = 0
+
+    init(result: ACPDiscoveredSessionModels?) {
+        self.result = result
+    }
+
+    func discoverModels(workspacePath _: String?) async throws -> ACPDiscoveredSessionModels? {
+        calls += 1
+        try await Task.sleep(nanoseconds: 100_000_000)
+        return result
+    }
+
+    func waitUntilCalled() async {
+        while calls == 0 {
+            await Task.yield()
+        }
+    }
+
+    func callCount() -> Int {
+        calls
     }
 }

--- a/Tests/RepoPromptTests/ContextBuilder/ContextBuilderModelStartupSelectionTests.swift
+++ b/Tests/RepoPromptTests/ContextBuilder/ContextBuilderModelStartupSelectionTests.swift
@@ -1,0 +1,98 @@
+import Foundation
+import XCTest
+@_spi(TestSupport) @testable import RepoPrompt
+
+@MainActor
+final class ContextBuilderModelStartupSelectionTests: XCTestCase {
+    func testValidPersistedSelectionSurvivesStoreReloadAndStartupResolution() throws {
+        let fixture = try makeStoreFixture()
+        fixture.store.setGlobalContextBuilderAgentSelection(
+            agentRaw: AgentProviderKind.codexExec.rawValue,
+            modelRaw: AgentModel.gpt55CodexLow.rawValue,
+            markUserDefined: true
+        )
+
+        let reloadedStore = GlobalSettingsStore(defaults: fixture.defaults, fileStore: fixture.fileStore)
+        let persisted = reloadedStore.persistedGlobalContextBuilderAgentSelection()
+        let resolved = try XCTUnwrap(AutoRecommendationEngine.resolveContextBuilderSelection(
+            persistedAgentRaw: persisted.agentRaw,
+            persistedModelRaw: persisted.modelRaw,
+            availability: .init(
+                claudeCodeAvailable: false,
+                codexAvailable: true,
+                openCodeAvailable: false,
+                cursorAvailable: false
+            )
+        ))
+
+        XCTAssertEqual(resolved.agent, .codexExec)
+        XCTAssertEqual(resolved.modelRaw, AgentModel.gpt55CodexLow.rawValue)
+    }
+
+    func testUnavailablePersistedSelectionFallsBackToRecommendedAvailableProvider() throws {
+        let resolved = try XCTUnwrap(AutoRecommendationEngine.resolveContextBuilderSelection(
+            persistedAgentRaw: AgentProviderKind.claudeCode.rawValue,
+            persistedModelRaw: AgentModel.claudeOpus.rawValue,
+            availability: .init(
+                claudeCodeAvailable: false,
+                codexAvailable: true,
+                openCodeAvailable: true,
+                cursorAvailable: true
+            )
+        ))
+
+        XCTAssertEqual(resolved.agent, .codexExec)
+        XCTAssertEqual(resolved.modelRaw, AgentModel.gpt55CodexLow.rawValue)
+    }
+
+    func testUnconfiguredClaudeCodeCannotBecomeEffectiveStartupSelection() throws {
+        let resolved = try XCTUnwrap(AutoRecommendationEngine.resolveContextBuilderSelection(
+            persistedAgentRaw: nil,
+            persistedModelRaw: nil,
+            availability: .init(
+                claudeCodeAvailable: false,
+                codexAvailable: true,
+                openCodeAvailable: false,
+                cursorAvailable: false
+            )
+        ))
+
+        XCTAssertNotEqual(resolved.agent, .claudeCode)
+        XCTAssertNotEqual(resolved.modelRaw, AgentModel.claudeOpus.rawValue)
+        XCTAssertTrue(AgentModelCatalog.isValid(
+            rawModel: resolved.modelRaw,
+            for: resolved.agent,
+            availability: .init(
+                claudeCodeAvailable: false,
+                codexAvailable: true,
+                openCodeAvailable: false,
+                cursorAvailable: false
+            )
+        ))
+    }
+
+    private func makeStoreFixture() throws -> (
+        store: GlobalSettingsStore,
+        defaults: UserDefaults,
+        fileStore: GlobalSettingsFileStore
+    ) {
+        let temp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ContextBuilderModelStartupSelectionTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: temp, withIntermediateDirectories: true)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: temp)
+        }
+
+        let suiteName = "ContextBuilderModelStartupSelectionTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        addTeardownBlock {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        let fileStore = GlobalSettingsFileStore(
+            fileURL: temp.appendingPathComponent("Settings/globalSettings.json")
+        )
+        return (GlobalSettingsStore(defaults: defaults, fileStore: fileStore), defaults, fileStore)
+    }
+}


### PR DESCRIPTION
## Summary

- restore the persisted Context Builder provider/model only after current-process provider readiness is verified
- fall back through the same recommendation/provider-filter policy used by the wizard when a saved provider is unavailable
- preserve dynamic OpenCode/Cursor model selections by joining bounded single-flight catalog refreshes instead of validating against an unwarmed cache
- keep transient startup fallbacks in memory so they cannot overwrite the user's persisted selection
- add startup lifecycle regression coverage for stale cached readiness, ACP catalog timing, filtering, and persistence mutation

## Validation

- `ContextBuilderModelStartupSelectionTests`: 12 passed
- `ContextBuilderWorktreeInheritanceTests`: 3 passed
- `AgentProviderContextBuilderTests`: 3 passed
- `RecommendationProviderFilterNormalizationTests`: passed
- strict Swift lint: 0 violations
- coordinated `RepoPrompt` product build: passed
- live debug launch + second clean relaunch: `context_builder.agent=codexExec`, `context_builder.model=kindle-alpha-medium` preserved both times

## Local full-suite note

The mandatory push preflight was run. Guardrails, outgoing secret scan, and lint passed. The broad local `swift test` lane then reproduced the existing host-level FSEvents stream exhaustion (`streamStartFailed`) across unrelated watcher/search suites. This is the same machine resource failure already observed on clean `main`; the focused changed-boundary suites above pass. Hosted exact-head CI is the final clean-runner gate.
