### PR TITLE
Stabilize watcher restart barrier coverage

### DIFF
--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
@@ -1236,6 +1236,20 @@ actor WorkspaceFileContextStore {
             await waitForCurrentPublisherIngress(rootIDs: [rootID])
             return
         }
+        guard try await attachPublisherIngress(state: state, rootID: rootID) else { return }
+        do {
+            try await reconcileWatcherServiceState(state.service, rootID: rootID)
+            await waitForCurrentPublisherIngress(rootIDs: [rootID])
+        } catch {
+            watcherCancellablesByRootID.removeValue(forKey: rootID)?.cancel()
+            publisherIngressCoordinator.closePublisherIngress(rootID: rootID)
+            try? await reconcileWatcherServiceState(state.service, rootID: rootID)
+            await waitForCurrentPublisherIngress(rootIDs: [rootID])
+            throw error
+        }
+    }
+
+    private func attachPublisherIngress(state: RootState, rootID: UUID) async throws -> Bool {
         let root = state.root
         let lifetimeID = state.lifetimeID
         let diagnosticRootToken = state.service.diagnosticRootToken
@@ -1264,7 +1278,7 @@ actor WorkspaceFileContextStore {
               publisherIngressCoordinator.isPublisherIngressOpen(subscription)
         else {
             try await reconcileWatcherServiceState(state.service, rootID: rootID)
-            return
+            return false
         }
         let cancellable = publisher.sink { publication in
             #if DEBUG || EDIT_FLOW_PERF
@@ -1293,20 +1307,19 @@ actor WorkspaceFileContextStore {
         else {
             cancellable.cancel()
             try await reconcileWatcherServiceState(state.service, rootID: rootID)
-            return
+            return false
         }
         watcherCancellablesByRootID[rootID] = cancellable
-        do {
-            try await reconcileWatcherServiceState(state.service, rootID: rootID)
-            await waitForCurrentPublisherIngress(rootIDs: [rootID])
-        } catch {
-            watcherCancellablesByRootID.removeValue(forKey: rootID)?.cancel()
-            publisherIngressCoordinator.closePublisherIngress(rootID: rootID)
-            try? await reconcileWatcherServiceState(state.service, rootID: rootID)
-            await waitForCurrentPublisherIngress(rootIDs: [rootID])
-            throw error
-        }
+        return true
     }
+
+    #if DEBUG
+        func attachPublisherIngressWithoutStartingWatcherForTesting(rootID: UUID) async throws -> Bool {
+            if watcherCancellablesByRootID[rootID] != nil { return true }
+            let state = try state(for: rootID)
+            return try await attachPublisherIngress(state: state, rootID: rootID)
+        }
+    #endif
 
     func stopWatchingRoot(id rootID: UUID) async {
         watcherCancellablesByRootID.removeValue(forKey: rootID)?.cancel()

--- a/Tests/RepoPromptTests/WorkspaceContext/WorkspaceFileContextStoreTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/WorkspaceFileContextStoreTests.swift
@@ -1099,19 +1099,83 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
             let root = try makeTemporaryRoot(name: "DetachedPublicationRestartBarrier")
             let store = WorkspaceFileContextStore()
             let record = try await store.loadRoot(path: root.path)
-            try await store.startWatchingRoot(id: record.id)
-            await store.stopWatchingRoot(id: record.id)
+            let rootID = record.id
+            let loadedService = await store.fileSystemServiceForTesting(rootID: rootID)
+            let service = try XCTUnwrap(loadedService)
+            addTeardownBlock {
+                await store.setScopedIngressBarrierWillFlushHandler(nil)
+                await store.stopWatchingRoot(id: rootID)
+            }
 
-            try await store.publishSyntheticFileSystemDeltasForTesting(rootID: record.id, deltas: [.fileAdded("Detached.swift")])
-            try await store.startWatchingRoot(id: record.id)
-            let restartBaseline = await store.appliedIngressSnapshotForTesting(rootID: record.id)
-            let samples = await store.awaitAppliedIngressForAllRoots()
+            let initialServiceState = await service.publicationStateForTesting()
+            let initialIngress = await store.appliedIngressSnapshotForTesting(rootID: rootID)
+            try await store.publishSyntheticFileSystemDeltasForTesting(
+                rootID: rootID,
+                deltas: [.fileAdded("Detached.swift")]
+            )
+            let detachedServiceState = await service.publicationStateForTesting()
+            let detachedIngress = await store.appliedIngressSnapshotForTesting(rootID: rootID)
+
+            XCTAssertEqual(
+                detachedServiceState.lastServicePublicationSequence,
+                initialServiceState.lastServicePublicationSequence + 1
+            )
+            XCTAssertEqual(detachedIngress, initialIngress)
+            let fileAfterDetachedPublication = await store.file(rootID: rootID, relativePath: "Detached.swift")
+            XCTAssertNil(fileAfterDetachedPublication)
+
+            // Exercise the same publisher-ingress attachment used by watcher restart without
+            // introducing nondeterministic macOS FSEvents into this sequence-gap contract.
+            let attached = try await store.attachPublisherIngressWithoutStartingWatcherForTesting(rootID: rootID)
+            XCTAssertTrue(attached)
+
+            let flushGate = AsyncGate()
+            await store.setScopedIngressBarrierWillFlushHandler { observedRootID in
+                guard observedRootID == rootID else { return }
+                await flushGate.markStartedAndWaitForRelease()
+            }
+            let barrierTask = Task {
+                await store.awaitAppliedIngressForAllRoots()
+            }
+            await flushGate.waitUntilStarted()
+
+            let diagnostics = await store.readSearchRootDiagnosticsSnapshot()
+            guard let active = diagnostics.first(where: { $0.rootID == rootID })?.barrier.active else {
+                barrierTask.cancel()
+                await flushGate.release()
+                _ = await barrierTask.value
+                return XCTFail("Expected an active barrier while the deterministic flush gate was held")
+            }
+            guard active.targetServicePublicationSequence == detachedIngress.acceptedServicePublicationSequence else {
+                barrierTask.cancel()
+                await flushGate.release()
+                _ = await barrierTask.value
+                return XCTFail(
+                    "Barrier targeted detached service sequence \(active.targetServicePublicationSequence); " +
+                        "expected accepted ingress cut \(detachedIngress.acceptedServicePublicationSequence)"
+                )
+            }
+            XCTAssertLessThan(
+                active.targetServicePublicationSequence,
+                detachedServiceState.lastServicePublicationSequence
+            )
+
+            await flushGate.release()
+            let samples = await barrierTask.value
             let sample = try XCTUnwrap(samples.first)
 
-            XCTAssertGreaterThan(sample.publishedServicePublicationSequence, 0)
-            XCTAssertEqual(sample.appliedServicePublicationSequence, restartBaseline.appliedServicePublicationSequence)
-            XCTAssertEqual(sample.appliedWatcherWatermark, restartBaseline.appliedWatcherWatermark.rawValue)
-            await store.stopWatchingRoot(id: record.id)
+            XCTAssertEqual(
+                sample.acceptedWatcherWatermark,
+                initialServiceState.lastPublishedWatcherAcceptedWatermark.rawValue
+            )
+            XCTAssertEqual(
+                sample.publishedServicePublicationSequence,
+                detachedServiceState.lastServicePublicationSequence
+            )
+            XCTAssertEqual(sample.appliedServicePublicationSequence, detachedIngress.appliedServicePublicationSequence)
+            XCTAssertEqual(sample.appliedWatcherWatermark, detachedIngress.appliedWatcherWatermark.rawValue)
+            let fileAfterBarrier = await store.file(rootID: rootID, relativePath: "Detached.swift")
+            XCTAssertNil(fileAfterBarrier)
         }
 
         func testWorkspaceIngressCoordinatorDrainsPublicationsInAcceptedOrder() async {


### PR DESCRIPTION
## Summary
- extract publisher-ingress attachment into a behavior-preserving helper
- add a narrow DEBUG-only test entry point that attaches ingress without starting macOS FSEvents
- make the watcher-restart barrier regression deterministic by creating a real detached service-sequence gap and asserting the barrier targets the accepted ingress cut

## Validation
- focused regression: 10/10 passed
- ingress coordinator tests: 8/8 passed
- `RepoPrompt` product build passed
- SwiftFormat and strict SwiftLint passed
- guardrails and secret scans passed

## Broad-suite note
The local full class/suite is blocked by the known host-level FSEvents `streamStartFailed` exhaustion in unrelated watcher tests. The remediated regression itself passes deterministically without starting an OS watcher.

Fixes the flaky expectation failure observed in CI run 27470414567.
