### PR TITLE
Integrate PR #195 worktree test settings stabilization

### DIFF
--- a/Tests/RepoPromptTests/Helpers/WorkspaceRootLoadTestSupport.swift
+++ b/Tests/RepoPromptTests/Helpers/WorkspaceRootLoadTestSupport.swift
@@ -1,0 +1,19 @@
+@testable import RepoPrompt
+
+@MainActor
+enum WorkspaceRootLoadTestSupport {
+    static func loadRootMatchingCurrentFileSystemSettings(
+        in window: WindowState,
+        path: String
+    ) async throws -> WorkspaceRootRecord {
+        let settings = GlobalSettingsStore.shared.fileSystemSettingsSnapshot()
+        return try await window.workspaceFileContextStore.loadRoot(
+            path: path,
+            respectGitignore: settings.respectGitignore,
+            respectRepoIgnore: settings.respectRepoIgnore,
+            respectCursorignore: settings.respectCursorignore,
+            skipSymlinks: settings.skipSymlinks,
+            enableHierarchicalIgnores: settings.enableHierarchicalIgnores
+        )
+    }
+}

--- a/Tests/RepoPromptTests/MCP/AgentRunWorktreeStartTests.swift
+++ b/Tests/RepoPromptTests/MCP/AgentRunWorktreeStartTests.swift
@@ -1683,7 +1683,7 @@ final class AgentRunWorktreeStartTests: XCTestCase {
         await window.workspaceManager.switchWorkspace(to: workspace, saveState: false, reason: "agentRunWorktreeStartTests")
         let activeWorkspace = try XCTUnwrap(window.workspaceManager.activeWorkspace)
         window.promptManager.loadComposeTabsFromWorkspace(activeWorkspace, syncPromptText: true)
-        _ = try await window.workspaceFileContextStore.loadRoot(path: root.path)
+        _ = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(in: window, path: root.path)
         return window
     }
 

--- a/Tests/RepoPromptTests/MCP/Control/MCPBootstrapLeaseTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/MCPBootstrapLeaseTests.swift
@@ -211,7 +211,7 @@ final class MCPBootstrapLeaseTests: XCTestCase {
                 )
                 let activeWorkspace = try XCTUnwrap(window.workspaceManager.activeWorkspace)
                 window.promptManager.loadComposeTabsFromWorkspace(activeWorkspace, syncPromptText: true)
-                let loadedRoot = try await window.workspaceFileContextStore.loadRoot(path: rootURL.path)
+                let loadedRoot = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(in: window, path: rootURL.path)
                 loadedRootID = loadedRoot.id
 
                 ServiceRegistry.register(catalogService)

--- a/Tests/RepoPromptTests/MCP/Control/PersistentAgentModeMCPReadFileConnectionTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/PersistentAgentModeMCPReadFileConnectionTests.swift
@@ -1621,7 +1621,7 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
                 )
                 let activeWorkspace = try XCTUnwrap(window.workspaceManager.activeWorkspace)
                 window.promptManager.loadComposeTabsFromWorkspace(activeWorkspace, syncPromptText: true)
-                let rootRecord = try await window.workspaceFileContextStore.loadRoot(path: rootURL.path)
+                let rootRecord = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(in: window, path: rootURL.path)
                 rootID = rootRecord.id
                 let exactHit = await WorkspaceReadableFileService(store: window.workspaceFileContextStore)
                     .resolveExactAbsoluteWorkspaceCatalogHit(fileURL.path, rootScope: .visibleWorkspace)
@@ -1799,7 +1799,7 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
                 atomically: true,
                 encoding: .utf8
             )
-            let auxiliaryRoot = try await window.workspaceFileContextStore.loadRoot(path: auxiliaryRootURL.path)
+            let auxiliaryRoot = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(in: window, path: auxiliaryRootURL.path)
             auxiliaryRootID = auxiliaryRoot.id
 
             let worktreeRootURL = FileManager.default.temporaryDirectory
@@ -1898,7 +1898,7 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
                 )
             )
 
-            let root = try await routingGuardWindow.workspaceFileContextStore.loadRoot(path: rootURL.path)
+            let root = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(in: routingGuardWindow, path: rootURL.path)
             peerRootID = root.id
             peerTargetStateVersionBeforeSelection = routingGuardWindow.workspaceManager
                 .debugStateVersionForWorkspace(workspaceID)

--- a/Tests/RepoPromptTests/MCP/Control/PersistentMCPDistinctConnectionConcurrencyTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/PersistentMCPDistinctConnectionConcurrencyTests.swift
@@ -1597,7 +1597,10 @@ final class PersistentMCPDistinctConnectionConcurrencyTests: XCTestCase {
             ]
             configuredWorkspace.activeComposeTabID = tabID
             window.workspaceManager.workspaces.append(configuredWorkspace)
-            let rootRecord = try await window.workspaceFileContextStore.loadRoot(path: rootURL.path)
+            let rootRecord = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(
+                in: window,
+                path: rootURL.path
+            )
             let exactHit = await WorkspaceReadableFileService(store: window.workspaceFileContextStore)
                 .resolveExactAbsoluteWorkspaceCatalogHit(fileURL.path, rootScope: .visibleWorkspace)
             guard exactHit?.standardizedFullPath == fileURL.path else {

--- a/Tests/RepoPromptTests/MCP/MCPCodeStructureWorktreeTests.swift
+++ b/Tests/RepoPromptTests/MCP/MCPCodeStructureWorktreeTests.swift
@@ -37,7 +37,10 @@ final class MCPCodeStructureWorktreeTests: XCTestCase {
         let window = try await makeWindow(root: logicalRootURL)
         defer { WindowStatesManager.shared.unregisterWindowState(window) }
         let store = window.workspaceFileContextStore
-        let logicalRoot = try await store.loadRoot(path: logicalRootURL.path)
+        let logicalRoot = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(
+            in: window,
+            path: logicalRootURL.path
+        )
         let worktreeRoot = try await store.loadRoot(path: worktreeRootURL.path, kind: .sessionWorktree)
         let projection = makeProjection(logicalRoot: logicalRoot, physicalRoot: worktreeRoot, worktreeID: "worktree")
         let lookupContext = WorkspaceLookupContext(rootScope: projection.lookupRootScope, bindingProjection: projection)
@@ -82,7 +85,10 @@ final class MCPCodeStructureWorktreeTests: XCTestCase {
             let window = try await makeWindow(root: logicalRootURL)
             defer { WindowStatesManager.shared.unregisterWindowState(window) }
             let store = window.workspaceFileContextStore
-            let logicalRoot = try await store.loadRoot(path: logicalRootURL.path)
+            let logicalRoot = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(
+                in: window,
+                path: logicalRootURL.path
+            )
             let worktreeRoot = try await store.loadRoot(path: worktreeRootURL.path, kind: .sessionWorktree)
             let projection = makeProjection(logicalRoot: logicalRoot, physicalRoot: worktreeRoot, worktreeID: "active")
             let lookupContext = WorkspaceLookupContext(rootScope: projection.lookupRootScope, bindingProjection: projection)
@@ -152,7 +158,10 @@ final class MCPCodeStructureWorktreeTests: XCTestCase {
         let window = try await makeWindow(root: logicalRootURL)
         defer { WindowStatesManager.shared.unregisterWindowState(window) }
         let store = window.workspaceFileContextStore
-        let logicalRoot = try await store.loadRoot(path: logicalRootURL.path)
+        let logicalRoot = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(
+            in: window,
+            path: logicalRootURL.path
+        )
         let logicalRef = WorkspaceRootRef(
             id: logicalRoot.id,
             name: logicalRoot.name,
@@ -233,7 +242,10 @@ final class MCPCodeStructureWorktreeTests: XCTestCase {
         let window = try await makeWindow(root: logicalRootURL)
         defer { WindowStatesManager.shared.unregisterWindowState(window) }
         let store = window.workspaceFileContextStore
-        let logicalRoot = try await store.loadRoot(path: logicalRootURL.path)
+        let logicalRoot = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(
+            in: window,
+            path: logicalRootURL.path
+        )
         let worktreeRoot = try await store.loadRoot(path: worktreeRootURL.path, kind: .sessionWorktree)
         let projection = makeProjection(logicalRoot: logicalRoot, physicalRoot: worktreeRoot, worktreeID: "deleted")
         let lookupContext = WorkspaceLookupContext(rootScope: projection.lookupRootScope, bindingProjection: projection)
@@ -287,7 +299,10 @@ final class MCPCodeStructureWorktreeTests: XCTestCase {
         let window = try await makeWindow(root: logicalRootURL)
         defer { WindowStatesManager.shared.unregisterWindowState(window) }
         let store = window.workspaceFileContextStore
-        let logicalRoot = try await store.loadRoot(path: logicalRootURL.path)
+        let logicalRoot = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(
+            in: window,
+            path: logicalRootURL.path
+        )
         let worktreeRoot = try await store.loadRoot(path: worktreeRootURL.path, kind: .sessionWorktree)
         let projection = makeProjection(logicalRoot: logicalRoot, physicalRoot: worktreeRoot, worktreeID: "bounded")
         let files = try await (1 ... 3).asyncMap { index in
@@ -326,7 +341,10 @@ final class MCPCodeStructureWorktreeTests: XCTestCase {
         let window = try await makeWindow(root: logicalRootURL)
         defer { WindowStatesManager.shared.unregisterWindowState(window) }
         let store = window.workspaceFileContextStore
-        let logicalRoot = try await store.loadRoot(path: logicalRootURL.path)
+        let logicalRoot = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(
+            in: window,
+            path: logicalRootURL.path
+        )
         let logicalRef = WorkspaceRootRef(id: logicalRoot.id, name: logicalRoot.name, fullPath: logicalRoot.standardizedFullPath)
         let missingRef = WorkspaceRootRef(id: UUID(), name: logicalRoot.name, fullPath: missingWorktreeURL.path)
         let projection = WorkspaceRootBindingProjection(
@@ -398,7 +416,10 @@ final class MCPCodeStructureWorktreeTests: XCTestCase {
         )
         let activeWorkspace = try XCTUnwrap(window.workspaceManager.activeWorkspace)
         window.promptManager.loadComposeTabsFromWorkspace(activeWorkspace, syncPromptText: true)
-        _ = try await window.workspaceFileContextStore.loadRoot(path: root.path)
+        _ = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(
+            in: window,
+            path: root.path
+        )
         return window
     }
 

--- a/Tests/RepoPromptTests/MCP/TabContextRoutingTests.swift
+++ b/Tests/RepoPromptTests/MCP/TabContextRoutingTests.swift
@@ -664,7 +664,7 @@ final class TabContextRoutingTests: XCTestCase {
         XCTAssertEqual(tabReloadResult, .switched)
         let activeWorkspace = try XCTUnwrap(window.workspaceManager.activeWorkspace)
         window.promptManager.loadComposeTabsFromWorkspace(activeWorkspace, syncPromptText: true)
-        _ = try await window.workspaceFileContextStore.loadRoot(path: logicalRoot.path)
+        _ = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(in: window, path: logicalRoot.path)
 
         var changes: [WorkspaceSelectionCoordinator.Change] = []
         window.selectionCoordinator.changes
@@ -1151,7 +1151,7 @@ final class TabContextRoutingTests: XCTestCase {
             saveState: false,
             reason: "manageSelectionPersistenceTestTabs"
         )
-        _ = try await window.workspaceFileContextStore.loadRoot(path: root.path)
+        _ = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(in: window, path: root.path)
         let tools = await window.mcpServer.windowMCPTools
         let manageSelection = try XCTUnwrap(
             tools.first { $0.name == MCPWindowToolName.manageSelection }

--- a/Tests/RepoPromptTests/MCP/WorktreeAPISmokeHarnessTests.swift
+++ b/Tests/RepoPromptTests/MCP/WorktreeAPISmokeHarnessTests.swift
@@ -707,7 +707,7 @@ final class WorktreeAPISmokeHarnessTests: XCTestCase {
         await window.workspaceManager.switchWorkspace(to: workspace, saveState: false, reason: "worktreeAPISmokeHarness")
         let activeWorkspace = try XCTUnwrap(window.workspaceManager.activeWorkspace)
         window.promptManager.loadComposeTabsFromWorkspace(activeWorkspace, syncPromptText: true)
-        _ = try await window.workspaceFileContextStore.loadRoot(path: root.path)
+        _ = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(in: window, path: root.path)
         return window
     }
 


### PR DESCRIPTION
## Summary
- preserve the worktree test-settings stabilization from #195 on current `main`
- centralize deterministic workspace-root loading for tests that require file settings
- cover the review-found `MCPCodeStructureWorktreeTests` gap so all seven worktree-root loads avoid ambient user settings
- retain an eight-file, test-only net delta after normal merges of current `main`, including lifecycle/harness fixes and PR #204

This replacement integration PR supersedes #195 while retaining its intent and contributor patch, with a small follow-up cleanup found during review.

## Validation
- exact remote head: `fc10a792acf5f13f28c19bdecb9baacd74bf021f`
- merged base: `5a29a1cf773b4758c39618091063e8e2e373eed2`
- directly modified focused suites: 93/93 passed
- isolated `WorkspaceCatalogShardTests` after canceling the stalled coordinated full-suite job: 7/7 passed
- debug package build: passed
- strict Swift format/lint: passed
- source-layout/allowlist guardrails and diff checks: passed
- outgoing-range secret scan: passed (5 commits, no leaks)
- final net delta: exactly eight files, all under `Tests/RepoPromptTests`

The final local full-suite attempt stopped making progress at the `WorkspaceCatalogShardTests` boundary. The coordinated job was canceled, its logs were preserved under `/tmp/pr200-local-stall-bf730484`, and the surviving exact-worktree test process tree was terminated. The victim suite then passed immediately in isolation. Per the coordinated unrelated-stall exception, no second full-suite loop was started and no unrelated production files were changed; fresh exact-head hosted **Build and Test** is the clean-environment full-suite gate.

Closes #195 after merge.
