### PR TITLE
Fix Git pipe drain descriptor race

### DIFF
--- a/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService+FileOperations.swift
+++ b/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService+FileOperations.swift
@@ -324,8 +324,17 @@ extension FileSystemService {
         }
         let wasDirectory = isDirectory.boolValue
 
+        #if DEBUG
+            let moveItemToTrashIO = moveItemToTrashIOForTesting ?? { url in
+                _ = try Self.moveURLToTrashOffActor(url)
+            }
+        #else
+            let moveItemToTrashIO: @Sendable (URL) throws -> Void = { url in
+                _ = try Self.moveURLToTrashOffActor(url)
+            }
+        #endif
         let mutation = startUncancellableMutation(.trash) {
-            _ = try Self.moveURLToTrashOffActor(url)
+            try moveItemToTrashIO(url)
         }
         Task.detached { [weak self] in
             do {

--- a/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService.swift
+++ b/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService.swift
@@ -137,6 +137,9 @@ actor FileSystemService {
         /// Test-only gate invoked from the detached mutation worker immediately before filesystem I/O.
         var mutationIOWillBeginHandler: (@Sendable (FileSystemUncancellableMutation) async -> Void)?
 
+        /// Test-only replacement for the real Finder Trash operation.
+        var moveItemToTrashIOForTesting: (@Sendable (URL) throws -> Void)?
+
         enum WatcherActivationFailurePoint {
             case streamCreation
             case streamStart
@@ -350,6 +353,10 @@ actor FileSystemService {
             _ handler: (@Sendable (FileSystemUncancellableMutation) async -> Void)?
         ) {
             mutationIOWillBeginHandler = handler
+        }
+
+        func setMoveItemToTrashIOForTesting(_ operation: (@Sendable (URL) throws -> Void)?) {
+            moveItemToTrashIOForTesting = operation
         }
 
         func pendingMutationWaiterCountForTesting() -> Int {

--- a/Sources/RepoPrompt/Infrastructure/VCS/GitService.swift
+++ b/Sources/RepoPrompt/Infrastructure/VCS/GitService.swift
@@ -2397,8 +2397,12 @@ actor GitService {
         // Build async streams for stdout/stderr and single consumer tasks to collect data.
         // GitProcessPipeDrain serializes readability callbacks with termination/cancellation
         // so a final chunk cannot be read by a callback and then dropped after stream closure.
-        let (outStream, outDrain) = GitProcessPipeDrain.makeStream()
-        let (errStream, errDrain) = GitProcessPipeDrain.makeStream()
+        let (outStream, outDrain) = try GitProcessPipeDrain.makeStream(
+            readingFrom: outPipe.fileHandleForReading
+        )
+        let (errStream, errDrain) = try GitProcessPipeDrain.makeStream(
+            readingFrom: errPipe.fileHandleForReading
+        )
 
         let processMetrics = GitProcessMetricsBox()
         let outCollector = Task(priority: .userInitiated) { () -> Data in
@@ -2420,11 +2424,15 @@ actor GitService {
             try await withCheckedThrowingContinuation { continuation in
                 // Drain stdout
                 outPipe.fileHandleForReading.readabilityHandler = { handle in
-                    outDrain.consumeAvailableData(from: handle)
+                    if outDrain.consumeAvailableData() {
+                        handle.readabilityHandler = nil
+                    }
                 }
                 // Drain stderr
                 errPipe.fileHandleForReading.readabilityHandler = { handle in
-                    errDrain.consumeAvailableData(from: handle)
+                    if errDrain.consumeAvailableData() {
+                        handle.readabilityHandler = nil
+                    }
                 }
 
                 process.terminationHandler = { proc in
@@ -2436,8 +2444,8 @@ actor GitService {
 
                     // Drain bytes that arrived between the last readability callback and
                     // process termination, then close each stream after any in-flight callback.
-                    outDrain.finishReading(from: outPipe.fileHandleForReading)
-                    errDrain.finishReading(from: errPipe.fileHandleForReading)
+                    outDrain.finishReading()
+                    errDrain.finishReading()
 
                     Task {
                         let stdoutData = await outCollector.value
@@ -2935,31 +2943,88 @@ private final class GitProcessMetricsBox: @unchecked Sendable {
 
 ///
 /// `FileHandle.readabilityHandler` may already be executing when a process termination
-/// handler clears it. Without this lock, that callback can read the final bytes, lose the
-/// race to stream closure, and have its subsequent yield discarded.
+/// handler clears it. Foundation may also invalidate its file handle before a queued callback
+/// runs. The drain owns a close-on-exec duplicate descriptor so all reads and closure are
+/// serialized independently of the `FileHandle` lifecycle.
 final class GitProcessPipeDrain: @unchecked Sendable {
+    private enum DescriptorReadResult {
+        case data(Data)
+        case unavailable
+        case terminal
+    }
+
+    private static let readBufferSize = 64 * 1024
+
     private let lock = NSLock()
     private let continuation: AsyncStream<Data>.Continuation
+    private var ownedDescriptor: Int32?
     private var isFinished = false
 
-    private init(continuation: AsyncStream<Data>.Continuation) {
+    private init(
+        continuation: AsyncStream<Data>.Continuation,
+        ownedDescriptor: Int32? = nil
+    ) {
         self.continuation = continuation
+        self.ownedDescriptor = ownedDescriptor
+    }
+
+    deinit {
+        if let ownedDescriptor {
+            _ = Darwin.close(ownedDescriptor)
+        }
     }
 
     static func makeStream() -> (stream: AsyncStream<Data>, drain: GitProcessPipeDrain) {
+        makeStream(ownedDescriptor: nil)
+    }
+
+    static func makeStream(
+        readingFrom handle: FileHandle
+    ) throws -> (stream: AsyncStream<Data>, drain: GitProcessPipeDrain) {
+        let duplicateDescriptor = fcntl(handle.fileDescriptor, F_DUPFD_CLOEXEC, 0)
+        guard duplicateDescriptor >= 0 else {
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
+        }
+        return makeStream(ownedDescriptor: duplicateDescriptor)
+    }
+
+    private static func makeStream(
+        ownedDescriptor: Int32?
+    ) -> (stream: AsyncStream<Data>, drain: GitProcessPipeDrain) {
         var drain: GitProcessPipeDrain?
         let stream = AsyncStream<Data>(bufferingPolicy: .unbounded) { continuation in
-            drain = GitProcessPipeDrain(continuation: continuation)
+            drain = GitProcessPipeDrain(
+                continuation: continuation,
+                ownedDescriptor: ownedDescriptor
+            )
         }
         return (stream, drain!)
     }
 
-    func consumeAvailableData(from handle: FileHandle) {
-        consume { handle.availableData }
+    /// Returns true when the `FileHandle` should stop monitoring readability.
+    @discardableResult
+    func consumeAvailableData() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !isFinished, let ownedDescriptor else { return true }
+
+        switch Self.readChunk(from: ownedDescriptor) {
+        case let .data(data):
+            continuation.yield(data)
+            return false
+        case .unavailable:
+            return false
+        case .terminal:
+            finishLocked()
+            return true
+        }
     }
 
-    func finishReading(from handle: FileHandle) {
-        finish { handle.readDataToEndOfFile() }
+    func finishReading() {
+        finish { [self] in
+            guard let ownedDescriptor else { return Data() }
+            return Self.readToEnd(from: ownedDescriptor)
+        }
     }
 
     func consume(read: () -> Data) {
@@ -2986,8 +3051,7 @@ final class GitProcessPipeDrain: @unchecked Sendable {
         if !data.isEmpty {
             continuation.yield(data)
         }
-        isFinished = true
-        continuation.finish()
+        finishLocked()
     }
 
     func cancel() {
@@ -2995,8 +3059,50 @@ final class GitProcessPipeDrain: @unchecked Sendable {
         defer { lock.unlock() }
         guard !isFinished else { return }
 
+        finishLocked()
+    }
+
+    private func finishLocked() {
         isFinished = true
+        if let ownedDescriptor {
+            self.ownedDescriptor = nil
+            _ = Darwin.close(ownedDescriptor)
+        }
         continuation.finish()
+    }
+
+    private static func readToEnd(from descriptor: Int32) -> Data {
+        var result = Data()
+        while true {
+            switch readChunk(from: descriptor) {
+            case let .data(data):
+                result.append(data)
+            case .unavailable, .terminal:
+                return result
+            }
+        }
+    }
+
+    private static func readChunk(from descriptor: Int32) -> DescriptorReadResult {
+        var buffer = [UInt8](repeating: 0, count: readBufferSize)
+        while true {
+            let count = buffer.withUnsafeMutableBytes { bytes in
+                Darwin.read(descriptor, bytes.baseAddress, bytes.count)
+            }
+            if count > 0 {
+                return .data(Data(buffer.prefix(Int(count))))
+            }
+            if count == 0 {
+                return .terminal
+            }
+            if errno == EINTR {
+                continue
+            }
+            if errno == EAGAIN || errno == EWOULDBLOCK {
+                return .unavailable
+            }
+            return .terminal
+        }
     }
 }
 

--- a/Sources/RepoPrompt/Infrastructure/VCS/GitService.swift
+++ b/Sources/RepoPrompt/Infrastructure/VCS/GitService.swift
@@ -2985,6 +2985,19 @@ final class GitProcessPipeDrain: @unchecked Sendable {
         guard duplicateDescriptor >= 0 else {
             throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
         }
+
+        let statusFlags = fcntl(duplicateDescriptor, F_GETFL)
+        guard statusFlags >= 0 else {
+            let failureErrno = errno
+            _ = Darwin.close(duplicateDescriptor)
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(failureErrno))
+        }
+        guard fcntl(duplicateDescriptor, F_SETFL, statusFlags | O_NONBLOCK) >= 0 else {
+            let failureErrno = errno
+            _ = Darwin.close(duplicateDescriptor)
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(failureErrno))
+        }
+
         return makeStream(ownedDescriptor: duplicateDescriptor)
     }
 

--- a/Tests/RepoPromptTests/Services/VCS/GitProcessPipeDrainTests.swift
+++ b/Tests/RepoPromptTests/Services/VCS/GitProcessPipeDrainTests.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 @testable import RepoPrompt
 import XCTest
@@ -61,6 +62,42 @@ final class GitProcessPipeDrainTests: XCTestCase {
         XCTAssertEqual(output, expected)
     }
 
+    func testConsumeReturnsPromptlyWhenWriterRemainsOpenWithoutAvailableBytes() throws {
+        let pipe = Pipe()
+        let originalReadHandle = pipe.fileHandleForReading
+        let originalStatusFlags = fcntl(originalReadHandle.fileDescriptor, F_GETFL)
+        XCTAssertGreaterThanOrEqual(originalStatusFlags, 0)
+
+        let (_, drain) = try GitProcessPipeDrain.makeStream(readingFrom: originalReadHandle)
+        let configuredStatusFlags = fcntl(originalReadHandle.fileDescriptor, F_GETFL)
+        XCTAssertGreaterThanOrEqual(configuredStatusFlags, 0)
+        XCTAssertEqual(
+            configuredStatusFlags & ~O_NONBLOCK,
+            originalStatusFlags & ~O_NONBLOCK
+        )
+        XCTAssertNotEqual(configuredStatusFlags & O_NONBLOCK, 0)
+
+        let consumeResult = TestLockedBool()
+        let consumeCompleted = TestSemaphore()
+        DispatchQueue.global().async {
+            consumeResult.set(drain.consumeAvailableData())
+            consumeCompleted.signal()
+        }
+
+        let waitResult = consumeCompleted.wait(timeout: .now() + 1)
+        if waitResult == .timedOut {
+            pipe.fileHandleForWriting.closeFile()
+            _ = consumeCompleted.wait(timeout: .now() + 5)
+        }
+
+        XCTAssertEqual(waitResult, .success)
+        XCTAssertEqual(consumeResult.value, false)
+        drain.cancel()
+        if waitResult == .success {
+            pipe.fileHandleForWriting.closeFile()
+        }
+    }
+
     func testReadabilityCallbackAfterFinishCannotConsumeOrAppendData() async {
         let (stream, drain) = GitProcessPipeDrain.makeStream()
         let tailData = Data("tail".utf8)
@@ -83,6 +120,23 @@ final class GitProcessPipeDrainTests: XCTestCase {
             result.append(chunk)
         }
         return result
+    }
+}
+
+private final class TestLockedBool: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedValue: Bool?
+
+    var value: Bool? {
+        lock.lock()
+        defer { lock.unlock() }
+        return storedValue
+    }
+
+    func set(_ value: Bool) {
+        lock.lock()
+        storedValue = value
+        lock.unlock()
     }
 }
 

--- a/Tests/RepoPromptTests/Services/VCS/GitProcessPipeDrainTests.swift
+++ b/Tests/RepoPromptTests/Services/VCS/GitProcessPipeDrainTests.swift
@@ -43,6 +43,24 @@ final class GitProcessPipeDrainTests: XCTestCase {
         XCTAssertEqual(output, callbackData + tailData)
     }
 
+    func testOwnedDescriptorSurvivesOriginalFileHandleCloseBeforeQueuedRead() async throws {
+        let pipe = Pipe()
+        let originalReadHandle = pipe.fileHandleForReading
+        let (stream, drain) = try GitProcessPipeDrain.makeStream(readingFrom: originalReadHandle)
+        let collected = Task { await Self.collect(stream) }
+        let expected = Data("queued callback".utf8)
+
+        pipe.fileHandleForWriting.write(expected)
+        originalReadHandle.closeFile()
+
+        XCTAssertFalse(drain.consumeAvailableData())
+        pipe.fileHandleForWriting.closeFile()
+        XCTAssertTrue(drain.consumeAvailableData())
+
+        let output = await collected.value
+        XCTAssertEqual(output, expected)
+    }
+
     func testReadabilityCallbackAfterFinishCannotConsumeOrAppendData() async {
         let (stream, drain) = GitProcessPipeDrain.makeStream()
         let tailData = Data("tail".utf8)

--- a/Tests/RepoPromptTests/WorkspaceContext/WorkspaceFileContextStoreTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/WorkspaceFileContextStoreTests.swift
@@ -284,7 +284,7 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
 
             createTask.cancel()
 
-            let settledBeforeRelease = await waitForAsyncCondition(maxYields: 10000) {
+            let settledBeforeRelease = await waitForAsyncCondition(timeout: .seconds(2)) {
                 await settledSignal.isMarked()
             }
             XCTAssertTrue(settledBeforeRelease)
@@ -295,7 +295,7 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
             await mutationGate.release()
             let observedCancellation = await resultTask.value
             XCTAssertTrue(observedCancellation)
-            let reconciled = await waitForAsyncCondition(maxYields: 10000) {
+            let reconciled = await waitForAsyncCondition(timeout: .seconds(5)) {
                 guard FileManager.default.fileExists(atPath: root.appendingPathComponent("CreatedAfterCancellation.swift").path) else {
                     return false
                 }
@@ -357,7 +357,7 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
             }
 
             overwriteTask.cancel()
-            let settledBeforeRelease = await waitForAsyncCondition(maxYields: 10000) {
+            let settledBeforeRelease = await waitForAsyncCondition(timeout: .seconds(2)) {
                 await settledSignal.isMarked()
             }
             XCTAssertTrue(settledBeforeRelease)
@@ -368,7 +368,7 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
             await mutationGate.release()
             let observedCancellation = await resultTask.value
             XCTAssertTrue(observedCancellation)
-            let reconciled = await waitForAsyncCondition(maxYields: 10000) {
+            let reconciled = await waitForAsyncCondition(timeout: .seconds(5)) {
                 guard (try? String(contentsOf: fileURL, encoding: .utf8)) == "new" else { return false }
                 return await (try? store.readContent(
                     rootID: record.id,
@@ -395,6 +395,15 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
             try await store.startWatchingRoot(id: record.id)
             let loadedService = await store.fileSystemServiceForTesting(rootID: record.id)
             let service = try XCTUnwrap(loadedService)
+            await service.setMoveItemToTrashIOForTesting { url in
+                try FileManager.default.removeItem(at: url)
+            }
+            let rootID = record.id
+            addTeardownBlock {
+                await service.setMutationIOWillBeginHandlerForTesting(nil)
+                await service.setMoveItemToTrashIOForTesting(nil)
+                await store.stopWatchingRoot(id: rootID)
+            }
 
             func exercise(
                 operation: FileSystemUncancellableMutation,
@@ -427,21 +436,21 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
                 }
 
                 mutationTask.cancel()
-                let settledBeforeRelease = await waitForAsyncCondition(maxYields: 10000) {
+                let settledBeforeRelease = await waitForAsyncCondition(timeout: .seconds(2)) {
                     await settledSignal.isMarked()
                 }
-                XCTAssertTrue(settledBeforeRelease)
-                XCTAssertTrue(beforeRelease())
+                XCTAssertTrue(settledBeforeRelease, "\(operation) cancellation did not settle before I/O release")
+                XCTAssertTrue(beforeRelease(), "\(operation) performed I/O before the test gate was released")
                 let waiterCountAfterCancellation = await service.pendingMutationWaiterCountForTesting()
-                XCTAssertEqual(waiterCountAfterCancellation, 0)
+                XCTAssertEqual(waiterCountAfterCancellation, 0, "\(operation) retained a canceled mutation waiter")
 
                 await gate.release()
                 let observedCancellation = await resultTask.value
-                XCTAssertTrue(observedCancellation)
-                let didReconcile = await waitForAsyncCondition(maxYields: 10000, reconciled)
-                XCTAssertTrue(didReconcile)
+                XCTAssertTrue(observedCancellation, "\(operation) did not report request cancellation")
+                let didReconcile = await waitForAsyncCondition(timeout: .seconds(5), reconciled)
+                XCTAssertTrue(didReconcile, "\(operation) did not reconcile after uncancellable I/O completed")
                 let finalWaiterCount = await service.pendingMutationWaiterCountForTesting()
-                XCTAssertEqual(finalWaiterCount, 0)
+                XCTAssertEqual(finalWaiterCount, 0, "\(operation) retained a mutation waiter after reconciliation")
             }
 
             try await exercise(
@@ -498,9 +507,6 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
                     return await store.file(rootID: record.id, relativePath: "Trash.swift") == nil
                 }
             )
-
-            await service.setMutationIOWillBeginHandlerForTesting(nil)
-            await store.stopWatchingRoot(id: record.id)
         }
 
         func testStopWatchingRootDrainsTrackedPublisherIngress() async throws {
@@ -2409,7 +2415,7 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
             let roots = await store.roots()
             let retainedRootIDs = await store.retainedReadSearchDiagnosticRootIDsForTesting()
             let remainingFlightCount = await store.scopedIngressBarrierFlightCountForTesting()
-            let serviceReleased = await waitForAsyncCondition(maxYields: 10000) {
+            let serviceReleased = await waitForAsyncCondition(timeout: .seconds(2)) {
                 weakService.value == nil
             }
 
@@ -5997,10 +6003,12 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
         }
 
         private func waitForAsyncCondition(
-            maxYields: Int = 1000,
+            timeout: Duration = .seconds(2),
             _ condition: () async -> Bool
         ) async -> Bool {
-            for _ in 0 ..< maxYields {
+            let clock = ContinuousClock()
+            let deadline = clock.now.advanced(by: timeout)
+            while clock.now < deadline {
                 if await condition() { return true }
                 await Task.yield()
             }


### PR DESCRIPTION
## Summary

Fix the Git process output-drain race that crashed hosted CI with an uncaught `NSFileHandleOperationException` (`availableData: Bad file descriptor`), and prevent the duplicate-descriptor implementation from blocking queued readability callbacks.

The original failure was observed in Build and Test run 27485568698 while `WorktreeAPISmokeHarnessTests.testWorktreeBoundManageSelectionPersistsAcrossOneShotContextConnections` was starting. The stack reached `GitProcessPipeDrain.consumeAvailableData(from:)` through `GitService.runAdmittedGit`.

## Root causes and fixes

### Closed `FileHandle` race

`FileHandle.readabilityHandler` can already have callbacks queued when EOF clears the handler. A queued callback could subsequently call Foundation `availableData` after the original descriptor had closed, raising an Objective-C exception rather than a catchable Swift error.

- Give the drain ownership of a CLOEXEC duplicate descriptor.
- Read with POSIX `read(2)` instead of Foundation `availableData`.
- Serialize reads, cancellation, close, and the final tail drain under the drain lock.
- Unregister the readability handler at terminal EOF.
- Close the duplicate descriptor exactly once.

### Queued callback blocking on the duplicate

Readiness notifications remain registered on the original descriptor. Without `O_NONBLOCK` on the owned duplicate, callback A can consume the available bytes and callback B can then block in `read(2)` while the writer/process remains open.

- Preserve the duplicate descriptor's existing status flags and add `O_NONBLOCK`.
- Close the duplicate and preserve the setup error if either `F_GETFL` or `F_SETFL` fails.
- Add a deterministic regression proving an empty read returns promptly while the writer remains open.

## Separate CI-gate stabilization

The third commit is an independently validated test-harness fix included separately from the pipe-drain production changes. The full-suite gate exposed a deterministic failure in cancelled mutation reconciliation, unrelated to Git pipe draining.

- Add a DEBUG-only injectable Trash operation so the test does not depend on Finder Trash behavior.
- Replace scheduler-yield-count polling with monotonic `ContinuousClock` deadlines.
- Add deterministic teardown for mutation hooks and the watcher.
- Release builds continue to call the real Trash implementation; the seam exists only under `#if DEBUG`.

This commit is included so the required full-suite gate measures the pipe-drain change rather than failing in an unrelated environment-sensitive harness.

## Validation

Combined three-commit head:

- `GitProcessPipeDrainTests`: 4/4 passed.
- `WorkspaceFileContextStoreTests/testCancelledMoveDeleteAndTrashSettleBeforeIOAndReconcileAfterCompletion`: passed.
- RepoPrompt product build passed.
- Swift format/lint passed with zero violations.
- Guardrails, diff check, and staged secret scan passed.

Independent validation of the CI-gate commit before cherry-pick:

- Exact reconciliation test: 14 consecutive passes.
- Focused `WorkspaceFileContextStoreTests`: 154/154 passed.
- Format, lint, RepoPrompt build, and contribution preflight passed.
