### PR TITLE
Stabilize codemap unload reentrancy test teardown

### DIFF
--- a/Tests/RepoPromptTests/WorkspaceContext/WorkspaceFileContextStoreTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/WorkspaceFileContextStoreTests.swift
@@ -6381,37 +6381,45 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
                 WorkspaceObservedCodemapResult(fullPath: retainedFile.path, modificationDate: Date(), fileAPI: makeFileAPI(path: retainedFile.path, symbolName: "retainedSymbol")),
                 WorkspaceObservedCodemapResult(fullPath: detachedFile.path, modificationDate: Date(), fileAPI: makeFileAPI(path: detachedFile.path, symbolName: "detachedSymbol"))
             ])
-            var aggregate = await store.codemapFileAPIAggregate()
-            var APIPaths = aggregate.orderedFileAPIs.map(\.filePath)
-            XCTAssertEqual(Set(APIPaths), [retainedFile.path, detachedFile.path])
-            XCTAssertEqual(Set(aggregate.firstFileAPIByStandardizedNestedPath.keys), [retainedFile.path, detachedFile.path])
+            let initialAggregate = await store.codemapFileAPIAggregate()
+            let initialAPIPaths = initialAggregate.orderedFileAPIs.map(\.filePath)
+            XCTAssertEqual(Set(initialAPIPaths), [retainedFile.path, detachedFile.path])
+            XCTAssertEqual(Set(initialAggregate.firstFileAPIByStandardizedNestedPath.keys), [retainedFile.path, detachedFile.path])
 
-            let unloadGate = AsyncGate()
+            let unloadDidDetachSignal = AsyncSignal()
+            let retainedReplacementResult = WorkspaceObservedCodemapResult(
+                fullPath: retainedFile.path,
+                modificationDate: Date(),
+                fileAPI: makeFileAPI(path: retainedFile.path, symbolName: "retainedReplacement")
+            )
             await store.setRootUnloadDidDetachHandler { _ in
-                await unloadGate.markStartedAndWaitForRelease()
+                await unloadDidDetachSignal.mark()
+                let detachedAggregate = await store.codemapFileAPIAggregate()
+                let detachedAPIPaths = detachedAggregate.orderedFileAPIs.map(\.filePath)
+                XCTAssertEqual(Set(detachedAPIPaths), [retainedFile.path, detachedFile.path])
+                XCTAssertEqual(Set(detachedAggregate.firstFileAPIByStandardizedNestedPath.keys), [retainedFile.path, detachedFile.path])
+
+                await store.applyObservedCodemapResults([
+                    retainedReplacementResult
+                ])
+                let replacementAggregate = await store.codemapFileAPIAggregate()
+                let replacementAPIPaths = replacementAggregate.orderedFileAPIs.map(\.filePath)
+                XCTAssertEqual(Set(replacementAPIPaths), [retainedFile.path, detachedFile.path])
+                XCTAssertEqual(Set(replacementAggregate.firstFileAPIByStandardizedNestedPath.keys), [retainedFile.path, detachedFile.path])
             }
-            let unloadTask = Task { await store.unloadRoot(id: detachedRecord.id) }
-            await unloadGate.waitUntilStarted()
-            aggregate = await store.codemapFileAPIAggregate()
-            APIPaths = aggregate.orderedFileAPIs.map(\.filePath)
-            XCTAssertEqual(Set(APIPaths), [retainedFile.path, detachedFile.path])
-            XCTAssertEqual(Set(aggregate.firstFileAPIByStandardizedNestedPath.keys), [retainedFile.path, detachedFile.path])
-
-            await store.applyObservedCodemapResults([
-                WorkspaceObservedCodemapResult(fullPath: retainedFile.path, modificationDate: Date(), fileAPI: makeFileAPI(path: retainedFile.path, symbolName: "retainedReplacement"))
-            ])
-            aggregate = await store.codemapFileAPIAggregate()
-            APIPaths = aggregate.orderedFileAPIs.map(\.filePath)
-            XCTAssertEqual(Set(APIPaths), [retainedFile.path, detachedFile.path])
-            XCTAssertEqual(Set(aggregate.firstFileAPIByStandardizedNestedPath.keys), [retainedFile.path, detachedFile.path])
-
-            await unloadGate.release()
-            await unloadTask.value
+            addTeardownBlock {
+                await store.setRootUnloadDidDetachHandler(nil)
+                await store.unloadRoot(id: detachedRecord.id)
+                await store.unloadRoot(id: retainedRecord.id)
+            }
+            await store.unloadRoot(id: detachedRecord.id)
             await store.setRootUnloadDidDetachHandler(nil)
-            aggregate = await store.codemapFileAPIAggregate()
-            APIPaths = aggregate.orderedFileAPIs.map(\.filePath)
-            XCTAssertEqual(APIPaths, [retainedFile.path])
-            XCTAssertEqual(Set(aggregate.firstFileAPIByStandardizedNestedPath.keys), [retainedFile.path])
+            let unloadDidDetach = await unloadDidDetachSignal.isMarked()
+            XCTAssertTrue(unloadDidDetach)
+            let finalAggregate = await store.codemapFileAPIAggregate()
+            let finalAPIPaths = finalAggregate.orderedFileAPIs.map(\.filePath)
+            XCTAssertEqual(finalAPIPaths, [retainedFile.path])
+            XCTAssertEqual(Set(finalAggregate.firstFileAPIByStandardizedNestedPath.keys), [retainedFile.path])
         }
     #endif
 


### PR DESCRIPTION
## Summary

Stabilize the codemap root-unload reentrancy regression test by removing the unstructured unload task/gate lifecycle that could survive the test boundary and stall the full XCTest process.

This is a test-harness-only change in `WorkspaceFileContextStoreTests.swift`; production behavior is unchanged.

## Hosted stall evidence from PR #201 (`98f521c0`)

- **Attempt 1:** `GitProcessPipeDrainTests` passed 4/4. `testAllCodemapFileAPIsCachePreservesRootUnloadReentrantVisibilityInterval` then reported pass, but XCTest never emitted the following reconciliation test start and the job was canceled after roughly 17 minutes.
- **Attempt 2:** the same unload test emitted its start line but never reported pass; the job was again canceled after roughly 17 minutes.

The two different boundaries are consistent with the test's unstructured `Task { await store.unloadRoot(...) }`, `AsyncGate`, and debug-hook cleanup racing the XCTest lifecycle—not a recurrence of the Git pipe issue.

## Fix

- Run the reentrant aggregate/replacement assertions directly inside the awaited `rootUnloadDidDetachHandler`.
- Await `unloadRoot` in the test body instead of spawning an unstructured task.
- Add deterministic async teardown that clears the hook and unloads both roots.
- Retain a signal assertion confirming the detach interval was actually exercised.

## Validation

All validation below used the final one-file tree now at exact head `be6a9e4465d2530c5d072d220c74fe63b0a339bb` (the merge with current main is byte-identical to the validated fix tree):

- Exact unload → canceled-create boundary: **50/50 passes**.
- Scanner → unload → reconciliation ordered chain: **25/25 passes**.
- `WorkspaceFileContextStoreTests`: **154 tests, 0 failures**.
- Full suite run 1: **1675 tests, 1 skipped, 0 failures**.
- Full suite run 2: **1675 tests, 1 skipped, 0 failures**.
- SwiftFormat/SwiftLint: **0 formatting changes, 0 violations**.
- Contribution guardrails and outgoing secret scan passed.

A later push-preflight rerun on the unchanged tree independently stalled after an unrelated Appcast test, and its single permitted rerun stalled after `testAllCodemapFileAPIsCacheInvalidatesScannerInsertionAndReplacement` had already passed, before this fixed unload test started. Both samples showed XCTest idle in its async waiter; no additional files were changed and the complete green suites/focused stress evidence above remain the validation basis.
