### PR TITLE
Fix composer binding after chat handoff

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -10113,7 +10113,7 @@ final class AgentModeViewModel: ObservableObject {
             noticeRevision: 0,
             rawDraftSnapshot: text
         )
-        switch claimComposerSubmitAttempt(attempt) {
+        switch claimComposerSubmitAttempt(attempt, requireActiveTabOwnership: false) {
         case let .claimed(claim):
             return await executeComposerSubmitAttempt(
                 text: text,
@@ -13315,7 +13315,25 @@ final class AgentModeViewModel: ObservableObject {
     }
 
     func claimComposerSubmitAttempt(_ attempt: AgentComposerSubmitAttempt) -> AgentComposerSubmitClaimResult {
+        claimComposerSubmitAttempt(attempt, requireActiveTabOwnership: true)
+    }
+
+    private func claimComposerSubmitAttempt(
+        _ attempt: AgentComposerSubmitAttempt,
+        requireActiveTabOwnership: Bool
+    ) -> AgentComposerSubmitClaimResult {
         let target = attempt.target
+        if requireActiveTabOwnership, currentTabID != target.tabID {
+            let rejection = AgentComposerSubmitClaimRejection.targetRejected(reason: "inactive_composer_tab")
+            logRejectedSubmitTarget(
+                target,
+                session: sessions[target.tabID],
+                reason: rejection.diagnosticReason,
+                attempt: attempt
+            )
+            resyncAfterRejectedSubmitTarget(target)
+            return .rejected(rejection)
+        }
         guard let session = sessions[target.tabID] else {
             let rejection = AgentComposerSubmitClaimRejection.missingSession
             logRejectedSubmitTarget(target, session: nil, reason: rejection.diagnosticReason, attempt: attempt)
@@ -13567,12 +13585,11 @@ final class AgentModeViewModel: ObservableObject {
     }
 
     private func resyncAfterRejectedSubmitTarget(_ target: AgentComposerSubmitTarget) {
-        if let currentTabID, currentTabID == target.tabID {
+        if let currentTabID {
             syncActiveUIState(tabID: currentTabID, invalidation: [.composer, .runInteraction])
         }
-        requestUIRefresh(tabID: target.tabID, urgent: true)
-        if let currentTabID, currentTabID != target.tabID {
-            requestUIRefresh(tabID: currentTabID, urgent: true)
+        if currentTabID != target.tabID {
+            requestUIRefresh(tabID: target.tabID, urgent: true)
         }
     }
 

--- a/Sources/RepoPrompt/Features/AgentMode/Views/AgentInputBar.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/AgentInputBar.swift
@@ -253,6 +253,12 @@ enum AgentFileMentionText {
     }
 }
 
+struct AgentComposerRenderIdentity: Equatable {
+    let props: AgentComposerProps
+    let placeholderText: String
+    let currentTabID: UUID?
+}
+
 struct AgentComposerView: View, Equatable {
     let props: AgentComposerProps
     let placeholderText: String
@@ -293,8 +299,16 @@ struct AgentComposerView: View, Equatable {
     private let imageInputAdapter = AgentImageInputAdapter()
     private static let staleSubmitTargetMessage = "This composer changed before the message could be sent. Please try again."
 
+    private var renderIdentity: AgentComposerRenderIdentity {
+        AgentComposerRenderIdentity(
+            props: props,
+            placeholderText: placeholderText,
+            currentTabID: currentTabID
+        )
+    }
+
     static func == (lhs: AgentComposerView, rhs: AgentComposerView) -> Bool {
-        lhs.props == rhs.props && lhs.placeholderText == rhs.placeholderText
+        lhs.renderIdentity == rhs.renderIdentity
     }
 
     private var hasPendingImageAttachments: Bool {

--- a/Sources/RepoPrompt/Features/AgentMode/Views/AgentInputBar.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/AgentInputBar.swift
@@ -253,12 +253,6 @@ enum AgentFileMentionText {
     }
 }
 
-struct AgentComposerRenderIdentity: Equatable {
-    let props: AgentComposerProps
-    let placeholderText: String
-    let currentTabID: UUID?
-}
-
 struct AgentComposerView: View, Equatable {
     let props: AgentComposerProps
     let placeholderText: String
@@ -299,16 +293,28 @@ struct AgentComposerView: View, Equatable {
     private let imageInputAdapter = AgentImageInputAdapter()
     private static let staleSubmitTargetMessage = "This composer changed before the message could be sent. Please try again."
 
-    private var renderIdentity: AgentComposerRenderIdentity {
-        AgentComposerRenderIdentity(
-            props: props,
-            placeholderText: placeholderText,
-            currentTabID: currentTabID
-        )
+    static func hasEquivalentRenderIdentity(
+        lhsProps: AgentComposerProps,
+        lhsPlaceholderText: String,
+        lhsCurrentTabID: UUID?,
+        rhsProps: AgentComposerProps,
+        rhsPlaceholderText: String,
+        rhsCurrentTabID: UUID?
+    ) -> Bool {
+        lhsProps == rhsProps &&
+            lhsPlaceholderText == rhsPlaceholderText &&
+            lhsCurrentTabID == rhsCurrentTabID
     }
 
     static func == (lhs: AgentComposerView, rhs: AgentComposerView) -> Bool {
-        lhs.renderIdentity == rhs.renderIdentity
+        hasEquivalentRenderIdentity(
+            lhsProps: lhs.props,
+            lhsPlaceholderText: lhs.placeholderText,
+            lhsCurrentTabID: lhs.currentTabID,
+            rhsProps: rhs.props,
+            rhsPlaceholderText: rhs.placeholderText,
+            rhsCurrentTabID: rhs.currentTabID
+        )
     }
 
     private var hasPendingImageAttachments: Bool {

--- a/Tests/RepoPromptTests/AgentMode/AgentComposerSubmissionAttemptTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentComposerSubmissionAttemptTests.swift
@@ -4,6 +4,23 @@ import XCTest
 
 @MainActor
 final class AgentComposerSubmissionAttemptTests: XCTestCase {
+    func testComposerRenderIdentityChangesWhenLiveTabChangesBeforePropsCatchUp() {
+        let sourceTabID = UUID()
+        let destinationTabID = UUID()
+        let sourceIdentity = AgentComposerRenderIdentity(
+            props: .empty,
+            placeholderText: "Send a message...",
+            currentTabID: sourceTabID
+        )
+        let destinationIdentity = AgentComposerRenderIdentity(
+            props: .empty,
+            placeholderText: "Send a message...",
+            currentTabID: destinationTabID
+        )
+
+        XCTAssertNotEqual(sourceIdentity, destinationIdentity)
+    }
+
     func testLatchSuppressesRapidSameTabCallbacksButAllowsAnotherTab() throws {
         var latch = AgentComposerSubmissionLatch()
         let firstSession = AgentModeViewModel.TabSession(tabID: UUID())

--- a/Tests/RepoPromptTests/AgentMode/AgentComposerSubmissionAttemptTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentComposerSubmissionAttemptTests.swift
@@ -4,21 +4,30 @@ import XCTest
 
 @MainActor
 final class AgentComposerSubmissionAttemptTests: XCTestCase {
-    func testComposerRenderIdentityChangesWhenLiveTabChangesBeforePropsCatchUp() {
+    func testComposerProductionEqualityRejectsLiveTabChangeBeforePropsCatchUp() {
         let sourceTabID = UUID()
         let destinationTabID = UUID()
-        let sourceIdentity = AgentComposerRenderIdentity(
-            props: .empty,
-            placeholderText: "Send a message...",
-            currentTabID: sourceTabID
-        )
-        let destinationIdentity = AgentComposerRenderIdentity(
-            props: .empty,
-            placeholderText: "Send a message...",
-            currentTabID: destinationTabID
-        )
 
-        XCTAssertNotEqual(sourceIdentity, destinationIdentity)
+        XCTAssertTrue(
+            AgentComposerView.hasEquivalentRenderIdentity(
+                lhsProps: .empty,
+                lhsPlaceholderText: "Send a message...",
+                lhsCurrentTabID: sourceTabID,
+                rhsProps: .empty,
+                rhsPlaceholderText: "Send a message...",
+                rhsCurrentTabID: sourceTabID
+            )
+        )
+        XCTAssertFalse(
+            AgentComposerView.hasEquivalentRenderIdentity(
+                lhsProps: .empty,
+                lhsPlaceholderText: "Send a message...",
+                lhsCurrentTabID: sourceTabID,
+                rhsProps: .empty,
+                rhsPlaceholderText: "Send a message...",
+                rhsCurrentTabID: destinationTabID
+            )
+        )
     }
 
     func testLatchSuppressesRapidSameTabCallbacksButAllowsAnotherTab() throws {

--- a/Tests/RepoPromptTests/AgentMode/AgentModeChatSwitchActivationTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeChatSwitchActivationTests.swift
@@ -4,6 +4,76 @@ import XCTest
 
 @MainActor
 final class AgentModeChatSwitchActivationTests: XCTestCase {
+    func testHandoffRebindsComposerAndRejectsStaleSourceSubmitTarget() async throws {
+        try await withFixture { fixture in
+            let sourceTarget = try XCTUnwrap(fixture.viewModel.ui.composer.props.submitTarget)
+            XCTAssertEqual(sourceTarget.tabID, fixture.tabAID)
+            let cutoffItemID = try XCTUnwrap(fixture.sessionA.items.last?.id)
+
+            let destinationTabID = try await fixture.viewModel.prepareHandoffToNewTab(
+                upToItemID: cutoffItemID,
+                destinationAgent: fixture.sessionA.selectedAgent,
+                destinationModelRaw: fixture.sessionA.selectedModelRaw,
+                destinationReasoningEffortRaw: fixture.sessionA.selectedReasoningEffortRaw
+            )
+
+            let destinationSession = try XCTUnwrap(fixture.viewModel.sessions[destinationTabID])
+            let destinationSessionID = try XCTUnwrap(destinationSession.activeAgentSessionID)
+            XCTAssertEqual(fixture.window.promptManager.activeComposeTabID, destinationTabID)
+            XCTAssertEqual(fixture.window.workspaceManager.activeAgentSessionID(forTabID: destinationTabID), destinationSessionID)
+            XCTAssertNotEqual(destinationSessionID, fixture.sessionAID)
+            XCTAssertEqual(destinationSession.items.map(\.text), fixture.tabATexts)
+            XCTAssertTrue(destinationSession.pendingHandoff.hasPayload)
+            XCTAssertEqual(destinationSession.pendingHandoff.sourceItemID, cutoffItemID)
+
+            let composerProps = fixture.viewModel.ui.composer.props
+            XCTAssertEqual(composerProps.currentTabID, destinationTabID)
+            let destinationTarget = try XCTUnwrap(composerProps.submitTarget)
+            XCTAssertEqual(destinationTarget.tabID, destinationTabID)
+            XCTAssertEqual(destinationTarget.expectedSourceAgentSessionID, destinationSessionID)
+            XCTAssertEqual(
+                destinationTarget.expectedSourceTabSessionIdentity,
+                ObjectIdentifier(destinationSession)
+            )
+
+            let staleAttempt = AgentComposerSubmitAttempt(
+                id: UUID(),
+                target: sourceTarget,
+                inputRevision: 0,
+                noticeRevision: 0,
+                rawDraftSnapshot: "must not reach the source"
+            )
+            switch fixture.viewModel.claimComposerSubmitAttempt(staleAttempt) {
+            case .claimed:
+                XCTFail("The source composer target must not survive destination activation")
+            case let .rejected(rejection):
+                XCTAssertEqual(
+                    rejection,
+                    .targetRejected(reason: "inactive_composer_tab")
+                )
+            }
+            XCTAssertNil(fixture.sessionA.activeComposerSubmitAttempt)
+            XCTAssertEqual(fixture.viewModel.ui.composer.props.currentTabID, destinationTabID)
+
+            let destinationAttempt = try AgentComposerSubmitAttempt(
+                id: UUID(),
+                target: XCTUnwrap(fixture.viewModel.ui.composer.props.submitTarget),
+                inputRevision: 0,
+                noticeRevision: 0,
+                rawDraftSnapshot: "destination draft"
+            )
+            let destinationClaim: AgentModeViewModel.AgentComposerSubmitClaim
+            switch fixture.viewModel.claimComposerSubmitAttempt(destinationAttempt) {
+            case let .claimed(claim):
+                destinationClaim = claim
+            case let .rejected(rejection):
+                return XCTFail("Expected destination composer recovery, got \(rejection)")
+            }
+            XCTAssertTrue(fixture.viewModel.releaseComposerSubmitClaim(destinationClaim))
+            XCTAssertNotNil(fixture.viewModel.ui.composer.props.submitTarget)
+        }
+    }
+
     func testWarmSwitchPublishesDestinationTranscriptBeforeSwitchReturns() async throws {
         try await withFixture { fixture in
             assertPresentation(

--- a/Tests/RepoPromptTests/AgentMode/AgentModeStopSubmitTargetTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeStopSubmitTargetTests.swift
@@ -471,6 +471,8 @@ final class AgentModeStopSubmitTargetTests: XCTestCase {
         let controller = StopSubmitNoopCodexController(hasActiveThread: true)
         let vm = makeViewModel(codexController: controller)
         let tabID = UUID()
+        vm.test_setCurrentTabIDOverride(tabID)
+        defer { vm.test_setCurrentTabIDOverride(nil) }
         vm.ensureSession(for: tabID)
         let session = try XCTUnwrap(vm.sessions[tabID])
         session.hasLoadedPersistedState = true


### PR DESCRIPTION
## Summary

Fix the Agent Mode composer remaining bound to the source thread after a chat handoff.

## Root cause

- `AgentComposerView`'s equatable reuse boundary did not include the live active tab ID, so SwiftUI could retain source-thread local composer state while handoff activation moved to the destination tab.
- UI submit claims validated the captured session target but did not require that target to still own the active tab, allowing a stale source composer callback to claim against the old session.
- Rejected stale targets did not always synchronously republish the active destination composer, leaving recovery dependent on later refresh timing.

## Fix

- Include the live tab ID in the production composer equality/reuse decision.
- Require active-tab ownership for UI composer submit claims while preserving explicit programmatic target routing.
- Resync the active composer/run-interaction state after stale-target rejection.
- Add end-to-end handoff coverage for migrated transcript/session binding, stale source rejection, and destination recovery.
- Expose and directly test the exact production equality function used by `AgentComposerView.==`, addressing the independent review finding.

## Review evidence

The follow-up regression test calls the production equality seam itself and proves both same-tab reuse and changed-tab invalidation. The final outgoing diff remains limited to the five Agent Mode handoff/composer files; latest `origin/main` (PR #203) was merged normally with no conflicts or file overlap.

## Validation

- Focused handoff/submit-target + Workspace teardown suites: passed (`9f4a8044-09e7-4a8e-aa7c-8d5a2b9a683d`)
- Full coordinated root tests: passed (`7fcee2eb-6971-4f81-a987-4e7cff846172`)
- Strict SwiftFormat/SwiftLint: passed (`b3f03529-d532-4941-9edd-8bb3de6384cc`)
- RepoPrompt product build: passed (`6f363833-9902-4645-9bd6-311080eaa18a`)
- Repository guardrails and contribution push preflight: passed
- Outgoing-range secret scan: clean

A prior non-disruptive live smoke attempt reached the running CE app but was inconclusive because that app window had zero loaded repository roots; no visible app relaunch was performed.
