### PR TITLE
Fix warm file_search validation stalls

### DIFF
--- a/Sources/RepoPrompt/Features/Search/SearchMatch.swift
+++ b/Sources/RepoPrompt/Features/Search/SearchMatch.swift
@@ -488,7 +488,10 @@ private struct SearchFileDescriptor {
                 )
             }
             do {
-                let snapshot = try await store.searchContentSnapshot(for: record)
+                let snapshot = try await store.searchContentSnapshot(
+                    for: record,
+                    freshnessPolicy: policy
+                )
                 outcome = snapshot.isFresh ? "current" : "missing"
                 return snapshot
             } catch is CancellationError {

--- a/Sources/RepoPrompt/Features/Search/StoreBackedWorkspaceSearch.swift
+++ b/Sources/RepoPrompt/Features/Search/StoreBackedWorkspaceSearch.swift
@@ -61,8 +61,13 @@ enum StoreBackedWorkspaceSearch {
             }
 
             let ingressFreshnessState = EditFlowPerf.begin(EditFlowPerf.Stage.Search.ingressFreshnessWait)
-            _ = await store.awaitAppliedIngress(rootScope: rootScope)
+            let appliedIngressSamples = await store.awaitAppliedIngress(rootScope: rootScope)
             EditFlowPerf.end(EditFlowPerf.Stage.Search.ingressFreshnessWait, ingressFreshnessState)
+            try Task.checkCancellation()
+            let contentFreshnessPolicy = await store.contentSearchFreshnessPolicy(
+                rootScope: rootScope,
+                appliedIngressSamples: appliedIngressSamples
+            )
             try Task.checkCancellation()
 
             return try await performSearch(
@@ -81,6 +86,7 @@ enum StoreBackedWorkspaceSearch {
                 countOnly: countOnly,
                 fuzzySpaceMatching: fuzzySpaceMatching,
                 allowLiteralUnescapeFallback: allowLiteralUnescapeFallback,
+                contentFreshnessPolicy: contentFreshnessPolicy,
                 rootScope: rootScope,
                 store: store,
                 fileSearchActor: fileSearchActor
@@ -132,6 +138,7 @@ enum StoreBackedWorkspaceSearch {
         countOnly: Bool,
         fuzzySpaceMatching: Bool,
         allowLiteralUnescapeFallback: Bool,
+        contentFreshnessPolicy: FileContentFreshnessPolicy,
         rootScope: WorkspaceLookupRootScope,
         store: WorkspaceFileContextStore,
         fileSearchActor: FileSearchActor
@@ -234,9 +241,10 @@ enum StoreBackedWorkspaceSearch {
             EditFlowPerf.Dimensions(status: (paths?.isEmpty == false) ? "explicit" : "all", fileCount: filesToSearch.count)
         )
 
-        let contentFreshnessPolicy: FileContentFreshnessPolicy = (effectiveMode == .content || effectiveMode == .both)
-            ? .validateDiskMetadata
-            : .cachedMetadata
+        let effectiveContentFreshnessPolicy: FileContentFreshnessPolicy =
+            (effectiveMode == .content || effectiveMode == .both)
+                ? contentFreshnessPolicy
+                : .cachedMetadata
         let aliasByRootPath = pathSearchAliasByRootPath(roots: visibleRootRecords)
         var wasAutoCorrected: Bool? = nil
         var results: SearchResults
@@ -269,7 +277,7 @@ enum StoreBackedWorkspaceSearch {
                         countOnly: countOnly,
                         fuzzySpaceMatching: fuzzySpaceMatching,
                         allowLiteralUnescapeFallback: allowLiteralUnescapeFallback,
-                        contentFreshnessPolicy: contentFreshnessPolicy
+                        contentFreshnessPolicy: effectiveContentFreshnessPolicy
                     ),
                     in: filesToSearch,
                     rootsByID: rootsByID,

--- a/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService+ContentLoading.swift
+++ b/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService+ContentLoading.swift
@@ -507,6 +507,9 @@ extension FileSystemService {
     #endif
 
     func contentFingerprint(ofRelativePath relativePath: String) async throws -> FileContentFingerprint {
+        #if DEBUG
+            contentFingerprintRequestCountForTesting += 1
+        #endif
         let request = try makeContentReadRequest(
             cacheKey: relativePath,
             chunkSize: 1_048_576,

--- a/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService+FSEvents.swift
+++ b/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService+FSEvents.swift
@@ -179,6 +179,32 @@ extension FileSystemService {
         watcherIngressMailbox.captureAcceptedWatermark()
     }
 
+    /// Qualifies cache reuse against the store's accepted-ingress freshness contract.
+    /// Undelivered macOS FSEvents remain outside that contract, matching `awaitAppliedIngress`.
+    func canUseCachedSearchContent(afterAppliedWatcherWatermark appliedWatcherWatermark: UInt64) -> Bool {
+        #if DEBUG
+            let watcherIsActive = cachedSearchContentWatcherActiveOverrideForTesting ?? (fseventStreamRef != nil)
+        #else
+            let watcherIsActive = fseventStreamRef != nil
+        #endif
+        guard watcherIsActive,
+              captureAcceptedWatcherWatermark().rawValue <= appliedWatcherWatermark,
+              pendingFSEvents.isEmpty,
+              pendingWatcherAcceptedHighWatermark == nil,
+              !hasPendingOverflowRescan,
+              coalescingTask == nil,
+              watcherBatchProcessingTask == nil,
+              pendingScanTargets.isEmpty,
+              pendingQuietFolderScanTargets.isEmpty,
+              dirtyRecoveryScanTargets.isEmpty,
+              recoveryScanFailureCountByFolder.isEmpty,
+              recoveryScanRetryTask == nil
+        else {
+            return false
+        }
+        return true
+    }
+
     public func flushPendingEventsNow() async {
         _ = await flushPendingEventsNow(throughAcceptedWatcherWatermark: captureAcceptedWatcherWatermark())
     }

--- a/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService+Testing.swift
+++ b/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService+Testing.swift
@@ -207,6 +207,18 @@ import Foundation
             contentReadChunkHandler = handler
         }
 
+        func resetContentFingerprintRequestCountForTesting() {
+            contentFingerprintRequestCountForTesting = 0
+        }
+
+        func contentFingerprintRequestCountSnapshotForTesting() -> Int {
+            contentFingerprintRequestCountForTesting
+        }
+
+        func setCachedSearchContentWatcherActiveOverrideForTesting(_ isActive: Bool?) {
+            cachedSearchContentWatcherActiveOverrideForTesting = isActive
+        }
+
         func setParallelFolderEnumerationHookForTesting(
             _ handler: (@Sendable (String) async throws -> Void)?
         ) {

--- a/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService.swift
+++ b/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService.swift
@@ -130,6 +130,8 @@ actor FileSystemService {
 
         /// Test-only hook invoked inside the real-filesystem off-actor content worker before each read.
         var contentReadChunkHandler: (@Sendable (String) async -> Void)?
+        var contentFingerprintRequestCountForTesting = 0
+        var cachedSearchContentWatcherActiveOverrideForTesting: Bool?
 
         /// Test-only hook invoked inside each real-filesystem parallel folder enumeration worker.
         var parallelFolderEnumerationHookForTesting: (@Sendable (String) async throws -> Void)?

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
@@ -1511,6 +1511,10 @@ actor WorkspaceFileContextStore {
             }
         #endif
         guard isRootLifetimeCurrent(rootID: root.id, expectedLifetimeID: expectedLifetimeID) else { return }
+        if publication.source == .overflowRootRescan || publication.source == .recoveryFullResync {
+            await invalidateRetainedSearchContentForRecoveryUncertainty(rootID: root.id)
+            guard isRootLifetimeCurrent(rootID: root.id, expectedLifetimeID: expectedLifetimeID) else { return }
+        }
         await handleObservedFileSystemDeltas(
             publication.deltas,
             root: root,
@@ -6487,6 +6491,26 @@ actor WorkspaceFileContextStore {
             await searchDecodedContentCache.invalidate(key, through: invalidationEpoch)
             await interactiveReadCache.invalidate(key, through: invalidationEpoch)
         }
+    }
+
+    private func invalidateRetainedSearchContentForRecoveryUncertainty(rootID: UUID) async {
+        guard let state = rootStatesByID[rootID] else { return }
+        var invalidations = WorkspaceSearchContentInvalidationBatch()
+        for fileID in state.fileIDsByRelativePath.values {
+            guard let file = filesByID[fileID] else { continue }
+            let key = WorkspaceSearchContentCacheKey(
+                rootID: file.rootID,
+                fileID: file.id,
+                standardizedRelativePath: file.standardizedRelativePath
+            )
+            nextSearchContentInvalidationEpoch &+= 1
+            let invalidationEpoch = nextSearchContentInvalidationEpoch
+            searchContentInvalidationEpochsByFileID[file.id] = invalidationEpoch
+            invalidations.record(key, through: invalidationEpoch)
+        }
+        guard !invalidations.isEmpty else { return }
+        await searchDecodedContentCache.invalidate(invalidations)
+        await interactiveReadCache.invalidate(invalidations)
     }
 
     private func finalizePublicationInvalidations(_ batch: PublicationInvalidationBatch) {

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
@@ -904,6 +904,24 @@ actor WorkspaceFileContextStore {
             let state = try state(for: rootID)
             await state.service.setContentReadChunkHandlerForTesting(handler)
         }
+
+        func resetSearchContentFingerprintRequestCountForTesting(rootID: UUID) async throws {
+            let state = try state(for: rootID)
+            await state.service.resetContentFingerprintRequestCountForTesting()
+        }
+
+        func searchContentFingerprintRequestCountForTesting(rootID: UUID) async throws -> Int {
+            let state = try state(for: rootID)
+            return await state.service.contentFingerprintRequestCountSnapshotForTesting()
+        }
+
+        func setCachedSearchContentWatcherActiveOverrideForTesting(
+            rootID: UUID,
+            _ isActive: Bool?
+        ) async throws {
+            let state = try state(for: rootID)
+            await state.service.setCachedSearchContentWatcherActiveOverrideForTesting(isActive)
+        }
     #endif
 
     private enum ExplicitDiskLookupCandidatesResult {
@@ -2604,6 +2622,32 @@ actor WorkspaceFileContextStore {
         await awaitAppliedIngress(rootIDs: rootsForPathLookup(scope: rootScope).map(\.id))
     }
 
+    func contentSearchFreshnessPolicy(
+        rootScope: WorkspaceLookupRootScope,
+        appliedIngressSamples: [WorkspaceIngressBarrierSample]
+    ) async -> FileContentFreshnessPolicy {
+        let scopedRoots = rootsForPathLookup(scope: rootScope)
+        guard !scopedRoots.isEmpty,
+              appliedIngressSamples.count == scopedRoots.count
+        else {
+            return .validateDiskMetadata
+        }
+        let samplesByRootID = Dictionary(uniqueKeysWithValues: appliedIngressSamples.map { ($0.rootID, $0) })
+        for root in scopedRoots {
+            guard let state = rootStatesByID[root.id],
+                  let sample = samplesByRootID[root.id],
+                  await state.service.canUseCachedSearchContent(
+                      afterAppliedWatcherWatermark: sample.appliedWatcherWatermark
+                  ),
+                  publisherIngressCoordinator.appliedSnapshot(rootID: root.id)
+                  .acceptedServicePublicationSequence <= sample.appliedServicePublicationSequence
+            else {
+                return .validateDiskMetadata
+            }
+        }
+        return .cachedMetadata
+    }
+
     /// Resolves the narrowest safe workspace freshness scope for an explicit request.
     /// Absolute paths await only their containing loaded root. Absolute paths outside all
     /// loaded roots (including always-readable support files) do not pay a workspace barrier.
@@ -4253,7 +4297,10 @@ actor WorkspaceFileContextStore {
         return foldersByID[folderID]
     }
 
-    func searchContentSnapshot(for expectedRecord: WorkspaceFileRecord) async throws -> FileSearchContentSnapshot {
+    func searchContentSnapshot(
+        for expectedRecord: WorkspaceFileRecord,
+        freshnessPolicy: FileContentFreshnessPolicy = .validateDiskMetadata
+    ) async throws -> FileSearchContentSnapshot {
         for attempt in 0 ..< 2 {
             try Task.checkCancellation()
             guard let state = rootStatesByID[expectedRecord.rootID],
@@ -4270,6 +4317,23 @@ actor WorkspaceFileContextStore {
                 fileID: current.id,
                 standardizedRelativePath: current.standardizedRelativePath
             )
+            if case .cachedMetadata = freshnessPolicy,
+               let cached = await searchDecodedContentCache.cachedSnapshot(
+                   for: cacheKey,
+                   invalidationEpoch: epoch
+               )
+            {
+                guard searchContentRecordIsCurrent(current, invalidationEpoch: epoch) else {
+                    if attempt == 0 { continue }
+                    return staleSearchContentSnapshot(for: current)
+                }
+                return FileSearchContentSnapshot(
+                    content: cached.content,
+                    contentRevision: cached.revision,
+                    modificationDate: cached.modificationDate,
+                    isFresh: true
+                )
+            }
             let fingerprint: FileContentFingerprint
             do {
                 fingerprint = try await service.contentFingerprint(

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceSearchDecodedContentCache.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceSearchDecodedContentCache.swift
@@ -92,6 +92,24 @@ actor WorkspaceSearchDecodedContentCache {
         self.maxEstimatedCost = maxEstimatedCost
     }
 
+    func cachedSnapshot(
+        for key: WorkspaceSearchContentCacheKey,
+        invalidationEpoch: UInt64
+    ) -> WorkspaceSearchDecodedContentEntry? {
+        guard var cached = entries[key],
+              cached.invalidationEpoch == invalidationEpoch
+        else {
+            return nil
+        }
+        nextAccessOrdinal &+= 1
+        cached.accessOrdinal = nextAccessOrdinal
+        entries[key] = cached
+        #if DEBUG
+            hitCount += 1
+        #endif
+        return cached.value
+    }
+
     func snapshot(
         for key: WorkspaceSearchContentCacheKey,
         fingerprint: FileContentFingerprint,

--- a/Tests/RepoPromptTests/MCP/MCPReadSearchLatencyDiagnosticsGuardTests.swift
+++ b/Tests/RepoPromptTests/MCP/MCPReadSearchLatencyDiagnosticsGuardTests.swift
@@ -2929,7 +2929,8 @@
             assertSourceOrder(
                 in: search,
                 hooks: [
-                    "_ = await store.awaitAppliedIngress(rootScope: rootScope)",
+                    "let appliedIngressSamples = await store.awaitAppliedIngress(rootScope: rootScope)",
+                    "let contentFreshnessPolicy = await store.contentSearchFreshnessPolicy(",
                     "switch await store.searchCatalogAccess(rootScope: rootScope)"
                 ]
             )

--- a/Tests/RepoPromptTests/WorkspaceContext/Search/StoreBackedWorkspaceSearchTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/Search/StoreBackedWorkspaceSearchTests.swift
@@ -282,6 +282,68 @@ final class StoreBackedWorkspaceSearchTests: XCTestCase {
             XCTAssertEqual(fingerprintRequestCount, 1)
         }
 
+        func testOverflowCompletionInvalidatesRetainedWarmContentBeforeWatermarkReuse() async throws {
+            let root = try makeTemporaryRoot(name: "OverflowRetainedContent")
+            let fileURL = root.appendingPathComponent("A.swift")
+            try write("let oldOverflowNeedle = true\n", to: fileURL)
+            let store = WorkspaceFileContextStore()
+            let record = try await store.loadRoot(path: root.path)
+            let attachedPublisherIngress = try await store
+                .attachPublisherIngressWithoutStartingWatcherForTesting(rootID: record.id)
+            XCTAssertTrue(attachedPublisherIngress)
+            try await store.setCachedSearchContentWatcherActiveOverrideForTesting(rootID: record.id, true)
+            addTeardownBlock {
+                try? await store.setCachedSearchContentWatcherActiveOverrideForTesting(rootID: record.id, nil)
+                await store.stopWatchingRoot(id: record.id)
+            }
+
+            let cold = try await searchContent(pattern: "oldOverflowNeedle", store: store)
+            XCTAssertEqual(cold.matches?.map(\.filePath), [fileURL.path])
+            try await store.resetSearchContentFingerprintRequestCountForTesting(rootID: record.id)
+            let warm = try await searchContent(pattern: "oldOverflowNeedle", store: store)
+            let warmFingerprintRequestCount = try await store
+                .searchContentFingerprintRequestCountForTesting(rootID: record.id)
+            XCTAssertEqual(warm.matches?.map(\.filePath), [fileURL.path])
+            XCTAssertEqual(warmFingerprintRequestCount, 0)
+
+            try write("let newOverflowNeedle = true\n", to: fileURL)
+            let optionalService = await store.fileSystemServiceForTesting(rootID: record.id)
+            let service = try XCTUnwrap(optionalService)
+            let eventID: FSEventStreamEventId = 1
+            let optionalAccepted = await service.acceptWatcherPayloadForTesting(
+                [(
+                    absolutePath: fileURL.path,
+                    flags: FSEventStreamEventFlags(
+                        kFSEventStreamEventFlagItemModified | kFSEventStreamEventFlagItemIsFile
+                    ),
+                    eventId: eventID
+                )],
+                scheduleDrain: false
+            )
+            let accepted = try XCTUnwrap(optionalAccepted)
+            await service.collapsePendingEventsToRootRescan(
+                upTo: eventID,
+                acceptedHighWatermark: accepted
+            )
+            _ = await store.awaitAppliedIngress(rootScope: .visibleWorkspace)
+
+            try await store.resetSearchContentFingerprintRequestCountForTesting(rootID: record.id)
+            let refreshed = try await searchContent(pattern: "newOverflowNeedle", store: store)
+            let stale = try await searchContent(pattern: "oldOverflowNeedle", store: store)
+            let refreshedFingerprintRequestCount = try await store
+                .searchContentFingerprintRequestCountForTesting(rootID: record.id)
+            XCTAssertEqual(refreshed.matches?.map(\.filePath), [fileURL.path])
+            XCTAssertTrue((stale.matches ?? []).isEmpty)
+            XCTAssertEqual(refreshedFingerprintRequestCount, 1)
+
+            try await store.resetSearchContentFingerprintRequestCountForTesting(rootID: record.id)
+            let rewarmed = try await searchContent(pattern: "newOverflowNeedle", store: store)
+            let rewarmedFingerprintRequestCount = try await store
+                .searchContentFingerprintRequestCountForTesting(rootID: record.id)
+            XCTAssertEqual(rewarmed.matches?.map(\.filePath), [fileURL.path])
+            XCTAssertEqual(rewarmedFingerprintRequestCount, 0)
+        }
+
         func testWatcherAcceptedAfterBarrierForcesStrictMetadataFallback() async throws {
             let root = try makeTemporaryRoot(name: "WatcherFreshnessGap")
             let fileURL = root.appendingPathComponent("A.swift")

--- a/Tests/RepoPromptTests/WorkspaceContext/Search/StoreBackedWorkspaceSearchTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/Search/StoreBackedWorkspaceSearchTests.swift
@@ -1,3 +1,4 @@
+import CoreServices
 @testable import RepoPrompt
 import XCTest
 
@@ -198,6 +199,167 @@ final class StoreBackedWorkspaceSearchTests: XCTestCase {
     }
 
     #if DEBUG
+        func testWatcherQualifiedWarmSearchSkipsPerFileMetadataValidation() async throws {
+            let root = try makeTemporaryRoot(name: "WatcherQualifiedWarmSearch")
+            let fileCount = 48
+            for index in 0 ..< fileCount {
+                try write(
+                    "let watcherQualifiedNeedle\(index) = true\n",
+                    to: root.appendingPathComponent(String(format: "Sources/File-%03d.swift", index))
+                )
+            }
+            let store = WorkspaceFileContextStore()
+            let record = try await store.loadRoot(path: root.path)
+            let attachedPublisherIngress = try await store
+                .attachPublisherIngressWithoutStartingWatcherForTesting(rootID: record.id)
+            XCTAssertTrue(attachedPublisherIngress)
+            try await store.setCachedSearchContentWatcherActiveOverrideForTesting(rootID: record.id, true)
+            addTeardownBlock {
+                try? await store.setCachedSearchContentWatcherActiveOverrideForTesting(rootID: record.id, nil)
+                await store.stopWatchingRoot(id: record.id)
+            }
+
+            let cold = try await searchContent(pattern: "watcherQualifiedNeedle", store: store)
+            let cacheAfterCold = await store.searchDecodedContentCacheSnapshotForTesting()
+            try await store.resetSearchContentFingerprintRequestCountForTesting(rootID: record.id)
+            _ = startedCapture(label: "watcher-qualified-warm-search", maxSamples: 2000)
+
+            let warm = try await searchContent(pattern: "watcherQualifiedNeedle", store: store)
+            let capture = EditFlowPerf.debugCaptureSnapshot(finish: true)
+            let fingerprintRequestCount = try await store.searchContentFingerprintRequestCountForTesting(rootID: record.id)
+            let cacheAfterWarm = await store.searchDecodedContentCacheSnapshotForTesting()
+            let freshnessRows = capture.stages.filter {
+                $0.stageName == String(describing: EditFlowPerf.Stage.Search.contentFreshnessValidation)
+            }
+
+            XCTAssertEqual(cold.matches?.count, fileCount)
+            XCTAssertEqual(warm.matches, cold.matches)
+            XCTAssertEqual(fingerprintRequestCount, 0)
+            XCTAssertEqual(cacheAfterWarm.loadCount, cacheAfterCold.loadCount)
+            XCTAssertEqual(cacheAfterWarm.acceptedLoadCount, cacheAfterCold.acceptedLoadCount)
+            XCTAssertFalse(freshnessRows.isEmpty)
+            XCTAssertTrue(freshnessRows.allSatisfy {
+                $0.sanitizedDimensions.contains("freshnessPolicy=cachedMetadata")
+            })
+            XCTAssertEqual(
+                capture.stages
+                    .filter { $0.stageName == String(describing: EditFlowPerf.Stage.FileSystem.contentReadWorkerBody) }
+                    .reduce(0) { $0 + $1.sampleCount },
+                0
+            )
+        }
+
+        func testWatcherQualifiedWarmSearchReloadsAppliedModificationBeforeMatching() async throws {
+            let root = try makeTemporaryRoot(name: "WatcherQualifiedModification")
+            let fileURL = root.appendingPathComponent("A.swift")
+            try write("let oldWatcherNeedle = true\n", to: fileURL)
+            let store = WorkspaceFileContextStore()
+            let record = try await store.loadRoot(path: root.path)
+            let attachedPublisherIngress = try await store
+                .attachPublisherIngressWithoutStartingWatcherForTesting(rootID: record.id)
+            XCTAssertTrue(attachedPublisherIngress)
+            try await store.setCachedSearchContentWatcherActiveOverrideForTesting(rootID: record.id, true)
+            addTeardownBlock {
+                try? await store.setCachedSearchContentWatcherActiveOverrideForTesting(rootID: record.id, nil)
+                await store.stopWatchingRoot(id: record.id)
+            }
+
+            let cold = try await searchContent(pattern: "oldWatcherNeedle", store: store)
+            XCTAssertEqual(cold.matches?.map(\.filePath), [fileURL.path])
+            try await store.resetSearchContentFingerprintRequestCountForTesting(rootID: record.id)
+
+            try write("let newWatcherNeedle = true\n", to: fileURL)
+            try await store.publishSyntheticFileSystemDeltasForTesting(
+                rootID: record.id,
+                deltas: [.fileModified("A.swift", Date())]
+            )
+            let refreshed = try await searchContent(pattern: "newWatcherNeedle", store: store)
+            let old = try await searchContent(pattern: "oldWatcherNeedle", store: store)
+            let fingerprintRequestCount = try await store.searchContentFingerprintRequestCountForTesting(rootID: record.id)
+
+            XCTAssertEqual(refreshed.matches?.map(\.filePath), [fileURL.path])
+            XCTAssertTrue((old.matches ?? []).isEmpty)
+            XCTAssertEqual(fingerprintRequestCount, 1)
+        }
+
+        func testWatcherAcceptedAfterBarrierForcesStrictMetadataFallback() async throws {
+            let root = try makeTemporaryRoot(name: "WatcherFreshnessGap")
+            let fileURL = root.appendingPathComponent("A.swift")
+            try write("let watcherGapNeedle = true\n", to: fileURL)
+            let store = WorkspaceFileContextStore()
+            let record = try await store.loadRoot(path: root.path)
+            let attachedPublisherIngress = try await store
+                .attachPublisherIngressWithoutStartingWatcherForTesting(rootID: record.id)
+            XCTAssertTrue(attachedPublisherIngress)
+            try await store.setCachedSearchContentWatcherActiveOverrideForTesting(rootID: record.id, true)
+            addTeardownBlock {
+                _ = await store.awaitAppliedIngress(rootScope: .visibleWorkspace)
+                try? await store.setCachedSearchContentWatcherActiveOverrideForTesting(rootID: record.id, nil)
+                await store.stopWatchingRoot(id: record.id)
+            }
+
+            let samples = await store.awaitAppliedIngress(rootScope: .visibleWorkspace)
+            let accepted = try await store.acceptWatcherPayloadForTesting(
+                rootID: record.id,
+                events: [(
+                    absolutePath: fileURL.path,
+                    flags: FSEventStreamEventFlags(
+                        kFSEventStreamEventFlagItemModified | kFSEventStreamEventFlagItemIsFile
+                    ),
+                    eventId: 1
+                )],
+                scheduleDrain: false
+            )
+            XCTAssertNotNil(accepted)
+
+            let policy = await store.contentSearchFreshnessPolicy(
+                rootScope: .visibleWorkspace,
+                appliedIngressSamples: samples
+            )
+            guard case .validateDiskMetadata = policy else {
+                return XCTFail("Accepted watcher ingress beyond the applied barrier must retain strict metadata validation")
+            }
+        }
+
+        func testPublisherIngressAcceptedAfterBarrierForcesStrictMetadataFallback() async throws {
+            let root = try makeTemporaryRoot(name: "PublisherFreshnessGap")
+            let fileURL = root.appendingPathComponent("A.swift")
+            try write("let publisherGapNeedle = true\n", to: fileURL)
+            let store = WorkspaceFileContextStore()
+            let record = try await store.loadRoot(path: root.path)
+            let attachedPublisherIngress = try await store
+                .attachPublisherIngressWithoutStartingWatcherForTesting(rootID: record.id)
+            XCTAssertTrue(attachedPublisherIngress)
+            try await store.setCachedSearchContentWatcherActiveOverrideForTesting(rootID: record.id, true)
+
+            let sinkGate = AsyncGate()
+            await store.setWatcherSinkWillApplyHandler { observedRootID in
+                guard observedRootID == record.id else { return }
+                await sinkGate.markStartedAndWaitForRelease()
+            }
+            addTeardownBlock {
+                await sinkGate.release()
+                await store.setWatcherSinkWillApplyHandler(nil)
+                try? await store.setCachedSearchContentWatcherActiveOverrideForTesting(rootID: record.id, nil)
+                await store.stopWatchingRoot(id: record.id)
+            }
+
+            let samples = await store.awaitAppliedIngress(rootScope: .visibleWorkspace)
+            try await store.publishSyntheticFileSystemDeltasForTesting(
+                rootID: record.id,
+                deltas: [.fileModified("A.swift", Date())]
+            )
+            await sinkGate.waitUntilStarted()
+
+            let policy = await store.contentSearchFreshnessPolicy(
+                rootScope: .visibleWorkspace,
+                appliedIngressSamples: samples
+            )
+            guard case .validateDiskMetadata = policy else {
+                return XCTFail("Publisher ingress beyond the applied barrier must retain strict metadata validation")
+            }
+        }
+
         func testSameStoreBroadLaneRunsOneQueuesOneAndRejectsThirdWhilePreservingResults() async throws {
             let root = try makeTemporaryRoot(name: "BroadLaneOneActiveOneQueued")
             let alphaURL = root.appendingPathComponent("A.swift")
@@ -1024,7 +1186,9 @@ final class StoreBackedWorkspaceSearchTests: XCTestCase {
             "return try await store.withStoreBackedSearchAccess(",
             "try await ensureRootScopeAvailable(rootScope, store: store)",
             "try await ensureSearchReady(store: store, workspaceManager: workspaceManager)",
-            "_ = await store.awaitAppliedIngress(rootScope: rootScope)",
+            "let appliedIngressSamples = await store.awaitAppliedIngress(rootScope: rootScope)",
+            "try Task.checkCancellation()",
+            "let contentFreshnessPolicy = await store.contentSearchFreshnessPolicy(",
             "try Task.checkCancellation()",
             "try await performSearch("
         ], in: source)


### PR DESCRIPTION
## Summary

- avoid redundant per-file filesystem metadata validation when watcher state and the accepted ingress watermark qualify decoded search content for warm reuse
- preserve strict metadata validation for cold, uncertain, or otherwise unqualified searches
- invalidate retained decoded content synchronously for true overflow/recovery root rescans before their accepted watermark can qualify warm reuse
- preserve cancellation and search result correctness; Codex reasoning-summary defaults are intentionally unchanged

## Root cause

Warm content searches were still issuing one serialized metadata probe per candidate file even when the workspace watcher and accepted watermark already proved the decoded cache generation current. Under disk pressure, the O(N) validation path could turn an ordinary 1,269-file Agent Mode source trace into a multi-minute apparent stall.

The initial optimization required a correctness follow-up: an overflow root rescan can retain a modified file while watcher history is uncertain. The recovery path now invalidates the retained root's decoded-search cache before publishing the accepted overflow/recovery watermark, preventing stale warm reuse without globally invalidating ordinary rescans.

## Timing evidence

Controlled `rpce-cli-debug` search for `activeComposerSubmitAttempt` over Sources plus Tests:

| Run | Wall | Freshness diagnostics | Scan behavior |
| --- | ---: | ---: | --- |
| low-disk reproduction | 197.7094s | — | 1,269 files, 13 matches |
| prior warm path | 0.666189s | 441.643ms | 1,269 strict metadata probes; provider 593.360ms |
| patched cold path | 0.749928s | expected cold reads | 1,269 reads |
| patched warm path | 0.656327s | 146.934ms (-66.7%) | zero scheduler grants/reads; provider 568.783ms |

The primary production benefit is removing O(N) disk probes from watcher-qualified warm searches; the low-pressure wall-clock delta understates the original failure mode.

## Codex event-boundary separation

The provider trace did not show reasoning-summary chunks withholding tool calls:

- pre-rollout queue/start: ~29.44s; message-to-function: 1.418s; search backend: 0.568s
- patched rollout queue/start: 29.823s; message-to-function: 2.391s; search backend: 0.604s
- an empty reasoning-summary item was followed by the tool call 460ms later

Search latency and Agent Mode startup/event timing are distinct. No Codex reasoning-summary configuration or default changes are included.

## Correctness and regression coverage

- warms decoded content, mutates a retained file on disk, completes a true overflow rescan, and verifies the next search observes new content
- verifies only a later search returns to the watcher-qualified zero-probe path
- covers strict fallback, watermark qualification, concurrency, and cancellation behavior
- ordinary rescans do not trigger global invalidation

## Validation

Exact merged head `05c452e951ae73b2bf0cd905ebf448de61a0e1f9` on base `3440617ba83b047474c4837d4c2f1f767fc841fa`:

- `make dev-test FILTER=StoreBackedWorkspaceSearchTests` — 32/32 passed
- contribution push preflight — passed
  - full coordinated root suite
  - strict SwiftFormat/SwiftLint (0 violations)
  - repository guardrails and outgoing secret scan
  - `swift build --product RepoPrompt`
- `git diff --check origin/main...HEAD` — passed

A later non-disruptive app smoke encountered an unhydrated window catalog (zero loaded roots/tools) and failed fast rather than entering the search backend. It is environmental and does not supersede the controlled patched `rpce-cli-debug` measurements above.

## Scope

No handoff/composer, GitService pipe-drain, PR #200 helper, Workspace teardown, or Codex-provider files are changed by this branch-relative diff.
