### PR TITLE
Route repoprompt-ce:// deep links

### DIFF
--- a/Sources/RepoPrompt/App/AppDeepLinkRoute.swift
+++ b/Sources/RepoPrompt/App/AppDeepLinkRoute.swift
@@ -31,7 +31,7 @@ struct AgentSessionDeepLinkRoute: Equatable {
 
     var url: URL {
         var components = URLComponents()
-        components.scheme = "repoprompt"
+        components.scheme = AppDeepLinkScheme.canonical
         components.host = "agent"
         components.path = "/session"
 
@@ -47,7 +47,7 @@ struct AgentSessionDeepLinkRoute: Equatable {
         }
         components.queryItems = queryItems
 
-        return components.url ?? URL(string: "repoprompt://agent/session")!
+        return components.url ?? URL(string: "\(AppDeepLinkScheme.canonical)://agent/session")!
     }
 
     static func parse(notificationUserInfo userInfo: [AnyHashable: Any]) -> AgentSessionDeepLinkRoute? {
@@ -83,7 +83,7 @@ struct AgentSessionDeepLinkRoute: Equatable {
 
     static func parse(url: URL) -> AgentSessionDeepLinkRoute? {
         guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
-              components.scheme?.lowercased() == "repoprompt",
+              AppDeepLinkScheme.isAccepted(components.scheme),
               components.host?.lowercased() == "agent",
               components.path == "/session"
         else {
@@ -177,7 +177,7 @@ enum AppDeepLinkRoute: Equatable {
 
     static func parse(url: URL) -> AppDeepLinkURLParseResult {
         guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
-              components.scheme?.lowercased() == "repoprompt"
+              AppDeepLinkScheme.isAccepted(components.scheme)
         else {
             return .unsupported
         }
@@ -224,6 +224,25 @@ enum AgentSessionRouteResult: Equatable {
     case sessionUnavailable
     case sessionMismatch
     case blockedByActiveDifferentSession
+}
+
+/// URL schemes recognized by the app's deep-link parser.
+///
+/// `repoprompt-ce` is the scheme RepoPrompt CE registers in its app bundle
+/// (`CFBundleURLSchemes`) and is the canonical scheme used when generating
+/// links. The legacy `repoprompt` scheme is still accepted on parse so links
+/// emitted by older builds (or referenced in existing docs/tests) keep
+/// resolving.
+enum AppDeepLinkScheme {
+    static let canonical = "repoprompt-ce"
+    static let legacy = "repoprompt"
+
+    static let accepted: Set<String> = [canonical, legacy]
+
+    static func isAccepted(_ scheme: String?) -> Bool {
+        guard let scheme = scheme?.lowercased() else { return false }
+        return accepted.contains(scheme)
+    }
 }
 
 enum AppDeepLinkRouteUserInfoKey {

--- a/Tests/RepoPromptTests/App/AppDeepLinkRouteSchemeTests.swift
+++ b/Tests/RepoPromptTests/App/AppDeepLinkRouteSchemeTests.swift
@@ -1,0 +1,69 @@
+@testable import RepoPrompt
+import XCTest
+
+final class AppDeepLinkRouteSchemeTests: XCTestCase {
+    func testCanonicalSchemeOpenURLRoutesAsLegacyURL() throws {
+        let url = try XCTUnwrap(URL(string: "repoprompt-ce://open//tmp/x"))
+        guard case let .route(.legacyURL(routedURL)) = AppDeepLinkRoute.parse(url: url) else {
+            return XCTFail("Expected canonical scheme open URL to route as a legacy URL")
+        }
+        XCTAssertEqual(routedURL, url)
+    }
+
+    func testLegacySchemeOpenURLStillRoutesAsLegacyURL() throws {
+        let url = try XCTUnwrap(URL(string: "repoprompt://open//tmp/x"))
+        guard case let .route(.legacyURL(routedURL)) = AppDeepLinkRoute.parse(url: url) else {
+            return XCTFail("Expected legacy scheme open URL to keep routing as a legacy URL")
+        }
+        XCTAssertEqual(routedURL, url)
+    }
+
+    func testCanonicalSchemeAgentSessionRoutes() throws {
+        let route = try AgentSessionDeepLinkRoute(
+            windowID: 4,
+            workspaceID: XCTUnwrap(UUID(uuidString: "44444444-4444-4444-4444-444444444444")),
+            tabID: XCTUnwrap(UUID(uuidString: "55555555-5555-5555-5555-555555555555")),
+            sessionID: XCTUnwrap(UUID(uuidString: "66666666-6666-6666-6666-666666666666"))
+        )
+        let url = try XCTUnwrap(URL(
+            string:
+            "repoprompt-ce://agent/session?workspace_id=\(route.workspaceID.uuidString)&tab_id=\(route.tabID.uuidString)&session_id=\(route.sessionID!.uuidString)&window_id=\(route.windowID!)"
+        ))
+        XCTAssertEqual(AppDeepLinkRoute.parse(url: url), .route(.agentSession(route)))
+    }
+
+    func testCanonicalSchemeAgentSessionWithInvalidPayloadIsInvalidScopedRoute() throws {
+        let url = try XCTUnwrap(URL(
+            string:
+            "repoprompt-ce://agent/session?tab_id=\(UUID().uuidString)"
+        ))
+        XCTAssertEqual(AppDeepLinkRoute.parse(url: url), .invalidScopedRoute)
+    }
+
+    func testForeignSchemeIsUnsupported() throws {
+        let url = try XCTUnwrap(URL(string: "https://example.com"))
+        XCTAssertEqual(AppDeepLinkRoute.parse(url: url), .unsupported)
+    }
+
+    func testAgentSessionBuilderEmitsCanonicalSchemeAndRoundTrips() throws {
+        let route = try AgentSessionDeepLinkRoute(
+            windowID: 9,
+            workspaceID: XCTUnwrap(UUID(uuidString: "77777777-7777-7777-7777-777777777777")),
+            tabID: XCTUnwrap(UUID(uuidString: "88888888-8888-8888-8888-888888888888")),
+            sessionID: XCTUnwrap(UUID(uuidString: "99999999-9999-9999-9999-999999999999"))
+        )
+
+        XCTAssertEqual(route.url.scheme, AppDeepLinkScheme.canonical)
+        XCTAssertEqual(AppDeepLinkScheme.canonical, "repoprompt-ce")
+
+        let roundTripped = try XCTUnwrap(URL(string: route.url.absoluteString))
+        XCTAssertEqual(AppDeepLinkRoute.parse(url: roundTripped), .route(.agentSession(route)))
+    }
+
+    func testSchemeMatchingIsCaseInsensitive() throws {
+        let url = try XCTUnwrap(URL(string: "REPOPROMPT-CE://open//tmp/x"))
+        guard case .route(.legacyURL) = AppDeepLinkRoute.parse(url: url) else {
+            return XCTFail("Expected uppercased canonical scheme to be accepted")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

RepoPrompt CE registers `repoprompt-ce://` in its app bundle (`CFBundleURLSchemes`), but `AppDeepLinkRoute.parse(url:)` only accepted the legacy `repoprompt` scheme, so valid CE links like `repoprompt-ce://open//Users/.../repo` were parsed as `.unsupported` and dropped. The agent-session URL builder also emitted `repoprompt://...`, a scheme the CE bundle does not register. This change makes `repoprompt-ce` the canonical scheme while still accepting the legacy `repoprompt` scheme for back-compat:

- Add `AppDeepLinkScheme` with `canonical = "repoprompt-ce"`, `legacy = "repoprompt"`, and an `isAccepted(_:)` membership check (case-insensitive).
- `AppDeepLinkRoute.parse(url:)` and `AgentSessionDeepLinkRoute.parse(url:)` now gate on `AppDeepLinkScheme.isAccepted` instead of the hard-coded `"repoprompt"` string.
- The agent-session URL builder and its fallback string now emit `AppDeepLinkScheme.canonical`, so builder and parser share one source of truth.

`AppDeepLinkRouter` needs no change: once `parse` returns `.route(.legacyURL(...))` / `.route(.agentSession(...))` for the CE scheme, the existing router branches and the `open` opener in `WindowState.swift` handle it.

## Why this matters

LaunchServices delivers `repoprompt-ce://...` to CE, but the app was ignoring both inbound and self-generated CE links, so deep links registered by the CE bundle silently did nothing. See https://github.com/repoprompt/repoprompt-ce/issues/77

## Testing

- `swift build --product RepoPrompt` — clean build.
- `swift test --filter AppDeepLinkRouteSchemeTests` — 7 new tests pass (canonical-scheme open + agent-session routing, legacy-scheme compatibility, invalid scoped payload, foreign-scheme rejection, builder/parser round-trip on `repoprompt-ce`, case-insensitive matching).
- `swift test --filter AppPlatformUtilityRecoveryTests` — existing legacy-scheme tests still pass (no regression).

Fixes #77
