### PR TITLE
Improve Cursor Agent CLI launch resolution diagnostics

### DIFF
--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Cursor/CursorACPLaunchResolver.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Cursor/CursorACPLaunchResolver.swift
@@ -157,7 +157,6 @@ final class CursorACPLaunchResolver: @unchecked Sendable {
         let effectiveHints = CLILaunchProfiles.providerSpecificPathsSupplementedWithNativeDefaults(config.additionalPathHints)
         return try firstValidLaunch(
             candidates: launchCandidates(
-                configuredCommand: configuredCommand,
                 additionalPathHints: effectiveHints,
                 environment: environment
             ),
@@ -239,7 +238,6 @@ final class CursorACPLaunchResolver: @unchecked Sendable {
     }
 
     private func launchCandidates(
-        configuredCommand: String,
         additionalPathHints: [String],
         environment: [String: String]
     ) -> [String] {
@@ -269,9 +267,6 @@ final class CursorACPLaunchResolver: @unchecked Sendable {
             additionalPaths: additionalPathHints
         ) {
             append((directory as NSString).appendingPathComponent(CursorACPLaunchCandidate.cursorAgentACP.command))
-        }
-        if configuredCommand.contains("/") {
-            append(configuredCommand)
         }
         return candidates
     }

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Cursor/CursorACPLaunchResolver.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Cursor/CursorACPLaunchResolver.swift
@@ -28,6 +28,7 @@ enum CursorACPLaunchResolutionError: Error, Equatable, LocalizedError {
     case missingConfiguredCommand
     case unsafeConfiguredCommand(String)
     case exactPathNotFound(String)
+    case noValidLaunchCandidate(String, [String])
     case environmentDiscoveryRequired(String)
     case unsafeApplicationPath(String)
     case unsafeCanonicalBasename(String)
@@ -40,6 +41,8 @@ enum CursorACPLaunchResolutionError: Error, Equatable, LocalizedError {
             "Refusing unsafe Cursor ACP command `\(command)`. Configure the CLI-only `cursor-agent` executable."
         case let .exactPathNotFound(command):
             "Cursor Agent CLI was not found as a valid executable regular file for `\(command)`. Install `cursor-agent` or configure its absolute path."
+        case let .noValidLaunchCandidate(command, failures):
+            "Cursor Agent CLI was not found as a valid executable regular file for `\(command)`. Tried: \(failures.joined(separator: "; "))"
         case let .environmentDiscoveryRequired(command):
             "Cursor Agent CLI path discovery has not completed for `\(command)`. Run the Cursor ACP support preflight or configure an absolute `cursor-agent` path."
         case let .unsafeApplicationPath(path):
@@ -151,15 +154,13 @@ final class CursorACPLaunchResolver: @unchecked Sendable {
             return try resolveExplicitLaunch(for: config, environment: environment)
         }
 
-        let effectiveHints = CLIPathHints.nativeDefaultsSupplemented(with: config.additionalPathHints)
-        let resolved = CommandPathResolver.resolve(
-            CursorACPLaunchCandidate.cursorAgentACP.command,
-            environment: environment,
-            additionalPaths: effectiveHints,
-            preferredBasenames: CLILaunchProfiles.cursor.preferredBasenames
-        )
-        return try validatedLaunch(
-            entryPath: resolved,
+        let effectiveHints = CLILaunchProfiles.providerSpecificPathsSupplementedWithNativeDefaults(config.additionalPathHints)
+        return try firstValidLaunch(
+            candidates: launchCandidates(
+                configuredCommand: configuredCommand,
+                additionalPathHints: effectiveHints,
+                environment: environment
+            ),
             configuredCommand: configuredCommand,
             additionalPathHints: effectiveHints,
             environment: environment
@@ -174,7 +175,7 @@ final class CursorACPLaunchResolver: @unchecked Sendable {
         guard configuredCommand.contains("/") else {
             throw CursorACPLaunchResolutionError.environmentDiscoveryRequired(configuredCommand)
         }
-        let effectiveHints = CLIPathHints.nativeDefaultsSupplemented(with: config.additionalPathHints)
+        let effectiveHints = CLILaunchProfiles.providerSpecificPathsSupplementedWithNativeDefaults(config.additionalPathHints)
         let expanded = CommandPathResolver.expandPath(configuredCommand, environment: environment)
         return try validatedLaunch(
             entryPath: expanded,
@@ -191,7 +192,7 @@ final class CursorACPLaunchResolver: @unchecked Sendable {
         }
         let expectedCommand = CursorACPLaunchCandidate.cursorAgentACP.command
         if configuredCommand.contains("/") {
-            guard URL(fileURLWithPath: configuredCommand).lastPathComponent.caseInsensitiveCompare(expectedCommand) == .orderedSame else {
+            guard (configuredCommand as NSString).lastPathComponent.caseInsensitiveCompare(expectedCommand) == .orderedSame else {
                 throw CursorACPLaunchResolutionError.unsafeConfiguredCommand(configuredCommand)
             }
         } else if configuredCommand.caseInsensitiveCompare(expectedCommand) != .orderedSame {
@@ -204,10 +205,11 @@ final class CursorACPLaunchResolver: @unchecked Sendable {
         entryPath: String,
         configuredCommand: String,
         additionalPathHints: [String],
-        environment: [String: String]
+        environment: [String: String],
+        preserveValidationError: Bool = false
     ) throws -> CursorACPResolvedLaunch {
         guard entryPath.hasPrefix("/"),
-              URL(fileURLWithPath: entryPath).lastPathComponent.caseInsensitiveCompare(CursorACPLaunchCandidate.cursorAgentACP.command) == .orderedSame
+              (entryPath as NSString).lastPathComponent.caseInsensitiveCompare(CursorACPLaunchCandidate.cursorAgentACP.command) == .orderedSame
         else {
             throw CursorACPLaunchResolutionError.exactPathNotFound(configuredCommand)
         }
@@ -216,14 +218,14 @@ final class CursorACPLaunchResolver: @unchecked Sendable {
         do {
             identity = try ExecutableFileIdentity.captureForTrustedPathLaunch(atPath: entryPath)
         } catch {
+            if preserveValidationError { throw error }
             throw CursorACPLaunchResolutionError.exactPathNotFound(configuredCommand)
         }
 
-        let canonicalURL = URL(fileURLWithPath: identity.canonicalPath)
-        if canonicalURL.pathComponents.contains(where: { $0.lowercased().hasSuffix(".app") }) {
+        if identity.canonicalPath.split(separator: "/").contains(where: { $0.lowercased().hasSuffix(".app") }) {
             throw CursorACPLaunchResolutionError.unsafeApplicationPath(identity.canonicalPath)
         }
-        if canonicalURL.lastPathComponent.caseInsensitiveCompare("cursor") == .orderedSame {
+        if (identity.canonicalPath as NSString).lastPathComponent.caseInsensitiveCompare("cursor") == .orderedSame {
             throw CursorACPLaunchResolutionError.unsafeCanonicalBasename(identity.canonicalPath)
         }
 
@@ -234,6 +236,70 @@ final class CursorACPLaunchResolver: @unchecked Sendable {
             environment: environment,
             executableIdentity: identity
         )
+    }
+
+    private func launchCandidates(
+        configuredCommand: String,
+        additionalPathHints: [String],
+        environment: [String: String]
+    ) -> [String] {
+        var candidates: [String] = []
+        var seen = Set<String>()
+
+        func append(_ candidate: String) {
+            let expanded = CommandPathResolver.expandPath(candidate, environment: environment)
+            guard !expanded.isEmpty,
+                  expanded.hasPrefix("/"),
+                  FileManager.default.fileExists(atPath: expanded),
+                  seen.insert(expanded).inserted
+            else { return }
+            candidates.append(expanded)
+        }
+
+        append(
+            CommandPathResolver.resolve(
+                CursorACPLaunchCandidate.cursorAgentACP.command,
+                environment: environment,
+                additionalPaths: additionalPathHints,
+                preferredBasenames: CLILaunchProfiles.cursor.preferredBasenames
+            )
+        )
+        for directory in CommandPathResolver.mergedPathComponents(
+            environment: environment,
+            additionalPaths: additionalPathHints
+        ) {
+            append((directory as NSString).appendingPathComponent(CursorACPLaunchCandidate.cursorAgentACP.command))
+        }
+        if configuredCommand.contains("/") {
+            append(configuredCommand)
+        }
+        return candidates
+    }
+
+    private func firstValidLaunch(
+        candidates: [String],
+        configuredCommand: String,
+        additionalPathHints: [String],
+        environment: [String: String]
+    ) throws -> CursorACPResolvedLaunch {
+        var failures: [String] = []
+        for candidate in candidates {
+            do {
+                return try validatedLaunch(
+                    entryPath: candidate,
+                    configuredCommand: configuredCommand,
+                    additionalPathHints: additionalPathHints,
+                    environment: environment,
+                    preserveValidationError: true
+                )
+            } catch {
+                failures.append("\(candidate): \(error.localizedDescription)")
+            }
+        }
+        if failures.isEmpty {
+            throw CursorACPLaunchResolutionError.exactPathNotFound(configuredCommand)
+        }
+        throw CursorACPLaunchResolutionError.noValidLaunchCandidate(configuredCommand, failures)
     }
 
     private func cachedLaunch(forKey key: String) -> CursorACPResolvedLaunch? {

--- a/Sources/RepoPrompt/Infrastructure/Process/ExecutableFileIdentity.swift
+++ b/Sources/RepoPrompt/Infrastructure/Process/ExecutableFileIdentity.swift
@@ -16,8 +16,9 @@ struct ExecutableFileIdentity: Equatable {
             throw ExecutableFileIdentityError.pathMustBeAbsolute(rawPath)
         }
 
-        let canonicalPath = FileSystemService.realpathString(rawPath)
-            ?? (rawPath as NSString).standardizingPath
+        guard let canonicalPath = FileSystemService.realpathString(rawPath) else {
+            throw ExecutableFileIdentityError.unavailable((rawPath as NSString).standardizingPath)
+        }
         var info = stat()
         guard stat(canonicalPath, &info) == 0 else {
             throw ExecutableFileIdentityError.unavailable(canonicalPath)

--- a/Sources/RepoPrompt/Infrastructure/Process/ExecutableFileIdentity.swift
+++ b/Sources/RepoPrompt/Infrastructure/Process/ExecutableFileIdentity.swift
@@ -16,10 +16,7 @@ struct ExecutableFileIdentity: Equatable {
             throw ExecutableFileIdentityError.pathMustBeAbsolute(rawPath)
         }
 
-        let canonicalPath = URL(fileURLWithPath: rawPath)
-            .resolvingSymlinksInPath()
-            .standardizedFileURL
-            .path
+        let canonicalPath = canonicalizePath(rawPath)
         var info = stat()
         guard stat(canonicalPath, &info) == 0 else {
             throw ExecutableFileIdentityError.unavailable(canonicalPath)
@@ -41,6 +38,19 @@ struct ExecutableFileIdentity: Equatable {
             statusChangeSeconds: Int64(info.st_ctimespec.tv_sec),
             statusChangeNanoseconds: Int64(info.st_ctimespec.tv_nsec)
         )
+    }
+
+    private static func canonicalizePath(_ rawPath: String) -> String {
+        var buffer = [CChar](repeating: 0, count: Int(PATH_MAX))
+        let didResolve = rawPath.withCString { rawPathPointer in
+            buffer.withUnsafeMutableBufferPointer { bufferPointer in
+                realpath(rawPathPointer, bufferPointer.baseAddress) != nil
+            }
+        }
+        if didResolve {
+            return String(cString: buffer)
+        }
+        return (rawPath as NSString).standardizingPath
     }
 
     static func captureForTrustedPathLaunch(atPath path: String) throws -> ExecutableFileIdentity {
@@ -79,28 +89,28 @@ struct ExecutableFileIdentity: Equatable {
             throw ExecutableFileIdentityError.untrustedWritableFile(canonicalPath, executableInfo.st_mode)
         }
 
-        var directory = URL(fileURLWithPath: canonicalPath).deletingLastPathComponent()
+        var directoryPath = (canonicalPath as NSString).deletingLastPathComponent
         while true {
             var directoryInfo = stat()
-            guard stat(directory.path, &directoryInfo) == 0,
+            guard stat(directoryPath, &directoryInfo) == 0,
                   directoryInfo.st_mode & mode_t(S_IFMT) == mode_t(S_IFDIR)
             else {
-                throw ExecutableFileIdentityError.unavailable(directory.path)
+                throw ExecutableFileIdentityError.unavailable(directoryPath)
             }
             guard trustedUIDs.contains(directoryInfo.st_uid) else {
-                throw ExecutableFileIdentityError.untrustedOwner(directory.path, directoryInfo.st_uid)
+                throw ExecutableFileIdentityError.untrustedOwner(directoryPath, directoryInfo.st_uid)
             }
 
             let isGroupOrWorldWritable = directoryInfo.st_mode & mode_t(S_IWGRP | S_IWOTH) != 0
             let isRootOwnedStickyDirectory = directoryInfo.st_uid == 0
                 && directoryInfo.st_mode & mode_t(S_ISVTX) != 0
             guard !isGroupOrWorldWritable || isRootOwnedStickyDirectory else {
-                throw ExecutableFileIdentityError.untrustedWritableDirectory(directory.path, directoryInfo.st_mode)
+                throw ExecutableFileIdentityError.untrustedWritableDirectory(directoryPath, directoryInfo.st_mode)
             }
 
-            let parent = directory.deletingLastPathComponent()
-            if parent.path == directory.path { break }
-            directory = parent
+            let parent = (directoryPath as NSString).deletingLastPathComponent
+            if parent == directoryPath || parent.isEmpty { break }
+            directoryPath = parent
         }
     }
 }

--- a/Sources/RepoPrompt/Infrastructure/Process/ExecutableFileIdentity.swift
+++ b/Sources/RepoPrompt/Infrastructure/Process/ExecutableFileIdentity.swift
@@ -16,7 +16,8 @@ struct ExecutableFileIdentity: Equatable {
             throw ExecutableFileIdentityError.pathMustBeAbsolute(rawPath)
         }
 
-        let canonicalPath = canonicalizePath(rawPath)
+        let canonicalPath = FileSystemService.realpathString(rawPath)
+            ?? (rawPath as NSString).standardizingPath
         var info = stat()
         guard stat(canonicalPath, &info) == 0 else {
             throw ExecutableFileIdentityError.unavailable(canonicalPath)
@@ -38,19 +39,6 @@ struct ExecutableFileIdentity: Equatable {
             statusChangeSeconds: Int64(info.st_ctimespec.tv_sec),
             statusChangeNanoseconds: Int64(info.st_ctimespec.tv_nsec)
         )
-    }
-
-    private static func canonicalizePath(_ rawPath: String) -> String {
-        var buffer = [CChar](repeating: 0, count: Int(PATH_MAX))
-        let didResolve = rawPath.withCString { rawPathPointer in
-            buffer.withUnsafeMutableBufferPointer { bufferPointer in
-                realpath(rawPathPointer, bufferPointer.baseAddress) != nil
-            }
-        }
-        if didResolve {
-            return String(cString: buffer)
-        }
-        return (rawPath as NSString).standardizingPath
     }
 
     static func captureForTrustedPathLaunch(atPath path: String) throws -> ExecutableFileIdentity {

--- a/Tests/RepoPromptTests/AgentMode/CursorACPLaunchResolverTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/CursorACPLaunchResolverTests.swift
@@ -18,7 +18,7 @@ final class CursorACPLaunchResolverTests: XCTestCase {
 
         let launch = try provider.makeLaunchConfiguration(for: makeRunRequest(workspacePath: directory.path))
 
-        XCTAssertEqual(launch.command, executable.resolvingSymlinksInPath().standardizedFileURL.path)
+        XCTAssertEqual(launch.command, try canonicalExecutablePath(executable))
         XCTAssertEqual(launch.arguments, ["--approve-mcps", "acp"])
         XCTAssertEqual(launch.expectedExecutableIdentity?.canonicalPath, launch.command)
     }
@@ -44,7 +44,7 @@ final class CursorACPLaunchResolverTests: XCTestCase {
         let probedPath = try String(contentsOf: probePathRecord, encoding: .utf8)
 
         XCTAssertEqual(support, .supported)
-        XCTAssertEqual(launch.command, executable.resolvingSymlinksInPath().standardizedFileURL.path)
+        XCTAssertEqual(launch.command, try canonicalExecutablePath(executable))
         XCTAssertEqual(probedPath, launch.command)
     }
 
@@ -380,7 +380,7 @@ final class CursorACPLaunchResolverTests: XCTestCase {
         let firstSupport = try await resolver.probeSupport(for: config)
         let firstLaunch = try resolver.resolvedLaunch(for: config)
         XCTAssertEqual(firstSupport, .supported)
-        XCTAssertEqual(firstLaunch.command, firstExecutable.resolvingSymlinksInPath().path)
+        XCTAssertEqual(firstLaunch.command, try canonicalExecutablePath(firstExecutable))
 
         await environmentBox.set([
             "PATH": secondDirectory.path,
@@ -389,7 +389,7 @@ final class CursorACPLaunchResolverTests: XCTestCase {
         let secondSupport = try await resolver.probeSupport(for: config)
         let secondLaunch = try resolver.resolvedLaunch(for: config)
         XCTAssertEqual(secondSupport, .supported)
-        XCTAssertEqual(secondLaunch.command, secondExecutable.resolvingSymlinksInPath().path)
+        XCTAssertEqual(secondLaunch.command, try canonicalExecutablePath(secondExecutable))
     }
 
     func testBareCursorAgentWithoutCapturedDiscoveryFailsClosed() {
@@ -405,6 +405,27 @@ final class CursorACPLaunchResolverTests: XCTestCase {
             }
         }
     }
+
+    func testBareCursorAgentFallsBackToAdditionalHintWhenShellCandidateIsUnsafe() async throws {
+        let unsafeDirectory = try makePrivateTemporaryDirectory()
+        let trustedDirectory = try makePrivateTemporaryDirectory()
+        _ = try makeExecutable(named: "cursor-agent", in: unsafeDirectory)
+        try FileManager.default.setAttributes([.posixPermissions: 0o777], ofItemAtPath: unsafeDirectory.path)
+        let trusted = try makeExecutable(named: "cursor-agent", in: trustedDirectory)
+        let environment = [
+            "PATH": unsafeDirectory.path,
+            "SHELL": "/bin/false"
+        ]
+        let resolver = CursorACPLaunchResolver(environmentProvider: { _ in environment })
+        let config = CursorAgentConfig(commandName: "cursor-agent", additionalPathHints: [trustedDirectory.path])
+
+        let support = try await resolver.probeSupport(for: config)
+        XCTAssertEqual(support, .supported)
+        let launch = try resolver.resolvedLaunch(for: config)
+
+        XCTAssertEqual(launch.command, try canonicalExecutablePath(trusted))
+    }
+
 
     func testAbsoluteConfiguredPathIgnoresDecoyCursorAgentEarlierInPath() throws {
         let trustedDirectory = try makeTemporaryDirectory()
@@ -423,7 +444,7 @@ final class CursorACPLaunchResolverTests: XCTestCase {
 
         let launch = try resolver.resolvedLaunch(for: config)
 
-        XCTAssertEqual(launch.command, trusted.resolvingSymlinksInPath().standardizedFileURL.path)
+        XCTAssertEqual(launch.command, try canonicalExecutablePath(trusted))
     }
 
     func testSymlinkIsCanonicalizedAndCanonicalWrapperBasenameIsAllowed() throws {
@@ -436,7 +457,7 @@ final class CursorACPLaunchResolverTests: XCTestCase {
             for: CursorAgentConfig(commandName: link.path, additionalPathHints: [])
         )
 
-        XCTAssertEqual(launch.command, target.resolvingSymlinksInPath().standardizedFileURL.path)
+        XCTAssertEqual(launch.command, try canonicalExecutablePath(target))
     }
 
     func testSymlinkWhoseCanonicalBasenameIsCursorIsRejected() throws {
@@ -595,7 +616,7 @@ final class CursorACPLaunchResolverTests: XCTestCase {
         XCTAssertEqual(replacementSupport, .supported)
         XCTAssertEqual(
             try resolver.resolvedLaunch(for: config).command,
-            replacement.resolvingSymlinksInPath().standardizedFileURL.path
+            try canonicalExecutablePath(replacement)
         )
     }
 
@@ -736,6 +757,21 @@ final class CursorACPLaunchResolverTests: XCTestCase {
             .appendingPathComponent("CursorACPLaunchResolverTests-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         addTeardownBlock {
+            try? FileManager.default.removeItem(at: directory)
+        }
+        return directory
+    }
+
+    private func canonicalExecutablePath(_ url: URL) throws -> String {
+        try ExecutableFileIdentity.capture(atPath: url.path).canonicalPath
+    }
+
+    private func makePrivateTemporaryDirectory() throws -> URL {
+        let directory = URL(fileURLWithPath: "/private/tmp", isDirectory: true)
+            .appendingPathComponent("CursorACPLaunchResolverTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        addTeardownBlock {
+            try? FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: directory.path)
             try? FileManager.default.removeItem(at: directory)
         }
         return directory

--- a/Tests/RepoPromptTests/AgentMode/CursorACPLaunchResolverTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/CursorACPLaunchResolverTests.swift
@@ -406,7 +406,7 @@ final class CursorACPLaunchResolverTests: XCTestCase {
         }
     }
 
-    func testBareCursorAgentFallsBackToAdditionalHintWhenShellCandidateIsUnsafe() async throws {
+    func testBareCursorAgentFallsBackToAdditionalHintWhenPathCandidateIsUnsafe() async throws {
         let unsafeDirectory = try makePrivateTemporaryDirectory()
         let trustedDirectory = try makePrivateTemporaryDirectory()
         _ = try makeExecutable(named: "cursor-agent", in: unsafeDirectory)
@@ -426,6 +426,18 @@ final class CursorACPLaunchResolverTests: XCTestCase {
         XCTAssertEqual(launch.command, try canonicalExecutablePath(trusted))
     }
 
+    func testNoValidLaunchCandidateDiagnosticsPreserveCandidateOrder() {
+        let failures = [
+            "/first/cursor-agent: first failure",
+            "/second/cursor-agent: second failure"
+        ]
+        let error = CursorACPLaunchResolutionError.noValidLaunchCandidate("cursor-agent", failures)
+
+        XCTAssertEqual(
+            error.errorDescription,
+            "Cursor Agent CLI was not found as a valid executable regular file for `cursor-agent`. Tried: \(failures.joined(separator: "; "))"
+        )
+    }
 
     func testAbsoluteConfiguredPathIgnoresDecoyCursorAgentEarlierInPath() throws {
         let trustedDirectory = try makeTemporaryDirectory()
@@ -763,13 +775,14 @@ final class CursorACPLaunchResolverTests: XCTestCase {
     }
 
     private func canonicalExecutablePath(_ url: URL) throws -> String {
-        try ExecutableFileIdentity.capture(atPath: url.path).canonicalPath
+        try XCTUnwrap(FileSystemService.realpathString(url.path))
     }
 
     private func makePrivateTemporaryDirectory() throws -> URL {
         let directory = URL(fileURLWithPath: "/private/tmp", isDirectory: true)
             .appendingPathComponent("CursorACPLaunchResolverTests-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: directory.path)
         addTeardownBlock {
             try? FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: directory.path)
             try? FileManager.default.removeItem(at: directory)

--- a/Tests/RepoPromptTests/AgentMode/OpenCodeACPLaunchResolverTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/OpenCodeACPLaunchResolverTests.swift
@@ -19,7 +19,7 @@ final class OpenCodeACPLaunchResolverTests: XCTestCase {
 
         let launch = try provider.makeLaunchConfiguration(for: makeRunRequest(workspacePath: directory.path))
 
-        XCTAssertEqual(launch.command, executable.resolvingSymlinksInPath().standardizedFileURL.path)
+        XCTAssertEqual(launch.command, try canonicalExecutablePath(executable))
         XCTAssertEqual(launch.arguments, ["acp"])
         XCTAssertEqual(launch.expectedExecutableIdentity?.canonicalPath, launch.command)
     }
@@ -45,7 +45,7 @@ final class OpenCodeACPLaunchResolverTests: XCTestCase {
         let probedPath = try String(contentsOf: probePathRecord, encoding: .utf8)
 
         XCTAssertEqual(support, .supported)
-        XCTAssertEqual(launch.command, executable.resolvingSymlinksInPath().standardizedFileURL.path)
+        XCTAssertEqual(launch.command, try canonicalExecutablePath(executable))
         XCTAssertEqual(probedPath, launch.command)
     }
 
@@ -73,7 +73,7 @@ final class OpenCodeACPLaunchResolverTests: XCTestCase {
         let launch = try resolver.resolvedLaunch(for: config)
 
         XCTAssertEqual(support, .supported)
-        XCTAssertEqual(launch.command, executable.resolvingSymlinksInPath().standardizedFileURL.path)
+        XCTAssertEqual(launch.command, try canonicalExecutablePath(executable))
     }
 
     func testOpenCodeHomeBinHintDoesNotLeakIntoNativeDefaultsOrOtherProviders() {
@@ -104,7 +104,7 @@ final class OpenCodeACPLaunchResolverTests: XCTestCase {
         let firstSupport = try await resolver.probeSupport(for: config)
         let firstLaunch = try resolver.resolvedLaunch(for: config)
         XCTAssertEqual(firstSupport, .supported)
-        XCTAssertEqual(firstLaunch.command, firstExecutable.resolvingSymlinksInPath().path)
+        XCTAssertEqual(firstLaunch.command, try canonicalExecutablePath(firstExecutable))
 
         await environmentBox.set([
             "PATH": secondDirectory.path,
@@ -113,7 +113,7 @@ final class OpenCodeACPLaunchResolverTests: XCTestCase {
         let secondSupport = try await resolver.probeSupport(for: config)
         let secondLaunch = try resolver.resolvedLaunch(for: config)
         XCTAssertEqual(secondSupport, .supported)
-        XCTAssertEqual(secondLaunch.command, secondExecutable.resolvingSymlinksInPath().path)
+        XCTAssertEqual(secondLaunch.command, try canonicalExecutablePath(secondExecutable))
     }
 
     func testBareCommandWithoutSuccessfulPreflightFailsClosed() {
@@ -200,7 +200,7 @@ final class OpenCodeACPLaunchResolverTests: XCTestCase {
         XCTAssertEqual(replacementSupport, .supported)
         XCTAssertEqual(
             try resolver.resolvedLaunch(for: config).command,
-            replacement.resolvingSymlinksInPath().standardizedFileURL.path
+            try canonicalExecutablePath(replacement)
         )
     }
 
@@ -231,6 +231,10 @@ final class OpenCodeACPLaunchResolverTests: XCTestCase {
             attachments: [],
             taskLabelKind: nil
         )
+    }
+
+    private func canonicalExecutablePath(_ url: URL) throws -> String {
+        try XCTUnwrap(FileSystemService.realpathString(url.path))
     }
 
     private func makeTemporaryDirectory() throws -> URL {


### PR DESCRIPTION
## Summary

• preserve Cursor CLI-only launch policy: still requires `cursor-agent` and still rejects `cursor`/.app descendants
• canonicalize executable paths with POSIX path APIs instead of Foundation URL path normalization
• try discovered `cursor-agent` candidates instead of failing on the first invalid one
• surface candidate-specific validation failures instead of collapsing all failures to "not found"
• replace remaining Foundation URL path usage in `CursorACPLaunchResolver` with `NSString` methods

Refs #156.

## Non-goals

• does not restore Classic `cursor agent acp` fallback
• does not relax Homebrew trust policy
• does not address Cursor MCP injection tracked separately

## Validation

• `make guardrails` ✅
• `make dev-test FILTER=CursorACPLaunchResolverTests` (18 non-MCP tests pass) ✅
• `make dev-lint` ❌ — fails due to Python 3.7 typing.Protocol incompatibility in Scripts/conductor.py (pre-existing environment issue,not caused by this change)
• `git diff --check` ✅

## Notes

• 5 MCP-related tests hang (pre-existing issue, not caused by this change)
• Ad-hoc signed debug build tested locally: Cursor CLI launches successfully