### PR TITLE
Fix test runtime lifecycle disposal

### DIFF
--- a/Sources/RepoPrompt/App/WindowState.swift
+++ b/Sources/RepoPrompt/App/WindowState.swift
@@ -277,6 +277,10 @@ class WindowState: ObservableObject {
         pendingFocusSideEffectsTask = nil
         detachTitlebarAccessoryControllers(from: nsWindow)
         clearTitlebarAccessoryRequestsForClose()
+        apiSettingsViewModel.prepareForWindowClose()
+        contextBuilderAgentViewModel.prepareForWindowClose()
+        workspaceManager.prepareForWindowClose()
+        promptManager.gitViewModel.prepareForWindowClose()
     }
 
     private var pendingRestoreEntry: WindowSessionEntry?
@@ -286,16 +290,39 @@ class WindowState: ObservableObject {
     // MARK: - Initialization
 
     convenience init() {
-        self.init(contextBuilderProviderFactory: nil)
+        self.init(
+            contextBuilderProviderFactory: nil,
+            loadStoredAPISettingsDataOnInit: true,
+            codexModelPollingService: .shared
+        )
     }
 
     #if DEBUG
         convenience init(contextBuilderProviderFactory: @escaping ContextBuilderAgentViewModel.ProviderFactory) {
-            self.init(contextBuilderProviderFactory: Optional(contextBuilderProviderFactory))
+            self.init(
+                contextBuilderProviderFactory: Optional(contextBuilderProviderFactory),
+                loadStoredAPISettingsDataOnInit: true,
+                codexModelPollingService: .shared
+            )
+        }
+
+        convenience init(
+            codexModelPollingService: CodexModelPollingService,
+            loadStoredAPISettingsDataOnInit: Bool
+        ) {
+            self.init(
+                contextBuilderProviderFactory: nil,
+                loadStoredAPISettingsDataOnInit: loadStoredAPISettingsDataOnInit,
+                codexModelPollingService: codexModelPollingService
+            )
         }
     #endif
 
-    private init(contextBuilderProviderFactory: ContextBuilderAgentViewModel.ProviderFactory?) {
+    private init(
+        contextBuilderProviderFactory: ContextBuilderAgentViewModel.ProviderFactory?,
+        loadStoredAPISettingsDataOnInit: Bool,
+        codexModelPollingService: CodexModelPollingService
+    ) {
         // Assign a unique window ID
         WindowState.windowCounter += 1
         windowID = WindowState.windowCounter
@@ -313,7 +340,9 @@ class WindowState: ObservableObject {
             windowID: windowID,
             deferredInitialAgentSystemWorkspaceRefresh: deferredInitialAgentSystemWorkspaceRefresh,
             sharedMCPService: Self.sharedMCPService,
-            contextBuilderProviderFactory: contextBuilderProviderFactory
+            contextBuilderProviderFactory: contextBuilderProviderFactory,
+            loadStoredAPISettingsDataOnInit: loadStoredAPISettingsDataOnInit,
+            codexModelPollingService: codexModelPollingService
         )
 
         workspaceFileContextStore = composition.workspaceFileContextStore

--- a/Sources/RepoPrompt/App/WindowStateComposition.swift
+++ b/Sources/RepoPrompt/App/WindowStateComposition.swift
@@ -32,7 +32,9 @@ enum WindowStateCompositionFactory {
         contextBuilderProviderFactory: ContextBuilderAgentViewModel.ProviderFactory? = nil,
         aiQueriesServiceFactory: ((_ keyManager: KeyManager) -> AIQueriesService)? = nil,
         workspaceFileContextStore injectedWorkspaceFileContextStore: WorkspaceFileContextStore? = nil,
-        workspaceSwitchTimingPolicy: WorkspaceSwitchTimingPolicy = .production
+        workspaceSwitchTimingPolicy: WorkspaceSwitchTimingPolicy = .production,
+        loadStoredAPISettingsDataOnInit: Bool = true,
+        codexModelPollingService: CodexModelPollingService = .shared
     ) -> WindowStateComposition {
         // 1) Workspace file context store + visible file-tree UI adapter
         let workspaceFileContextStore = injectedWorkspaceFileContextStore ?? WorkspaceFileContextStore()
@@ -45,7 +47,12 @@ enum WindowStateCompositionFactory {
             ?? AIQueriesService(keyManager: keyManager)
 
         // 3) API Settings
-        let apiSettingsViewModel = APISettingsViewModel(aiQueriesService: aiQueriesService, keyManager: keyManager)
+        let apiSettingsViewModel = APISettingsViewModel(
+            aiQueriesService: aiQueriesService,
+            keyManager: keyManager,
+            loadStoredDataOnInit: loadStoredAPISettingsDataOnInit,
+            codexModelPollingService: codexModelPollingService
+        )
 
         // 5) Settings Manager (per-window overlay)
         let settingsManager = WindowSettingsManager(windowID: windowID)
@@ -126,7 +133,8 @@ enum WindowStateCompositionFactory {
             workspaceManager: workspaceManager,
             mcpServer: mcpServer,
             oracleViewModel: oracleViewModel,
-            providerFactory: contextBuilderProviderFactory
+            providerFactory: contextBuilderProviderFactory,
+            codexModelPollingService: codexModelPollingService
         )
 
         // 13) Agent mode (for minimal agent UI)

--- a/Sources/RepoPrompt/App/WindowStateManager.swift
+++ b/Sources/RepoPrompt/App/WindowStateManager.swift
@@ -609,6 +609,7 @@ class WindowStatesManager: ObservableObject {
     }
 
     func unregisterWindowState(_ state: WindowState) {
+        state.beginClose()
         if let idx = allWindows.firstIndex(where: { $0 === state }) {
             allWindows.remove(at: idx)
         }

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+TabSession.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+TabSession.swift
@@ -586,6 +586,10 @@ extension AgentModeViewModel {
             self.tabID = tabID
         }
 
+        deinit {
+            applyEditsApprovalSubscriptionTask?.cancel()
+        }
+
         @discardableResult
         func beginPersistentBindingTransition() -> UInt64 {
             bindingTransitionGeneration &+= 1

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -305,7 +305,9 @@ final class AgentModeViewModel: ObservableObject {
                 isRestoringState = false
                 return
             }
-            UserDefaults.standard.set(selectedAgent.rawValue, forKey: Self.lastUsedAgentKey)
+            if usesProductionAgentDefaultsAndModelPolling {
+                UserDefaults.standard.set(selectedAgent.rawValue, forKey: Self.lastUsedAgentKey)
+            }
             if let session = activeSession {
                 let previousAgent = session.selectedAgent
                 if previousAgent != selectedAgent {
@@ -544,6 +546,7 @@ final class AgentModeViewModel: ObservableObject {
     let providerBindingService: AgentModeProviderBindingService
     private weak var runInteractionStateObserver: (any AgentModeRunInteractionStateObserving)?
     private let shouldManageCodexTooling: Bool
+    private let usesProductionAgentDefaultsAndModelPolling: Bool
     let clearConsumedAttachmentsAfterProviderConsumption: Bool
     let applyEditsApprovalStore: ApplyEditsApprovalStore
     private lazy var runService: AgentModeRunService = makeRunService()
@@ -905,6 +908,7 @@ final class AgentModeViewModel: ObservableObject {
     }
 
     private func persistLastUsedModelIfNeeded(agent: AgentProviderKind, modelRaw: String) {
+        guard usesProductionAgentDefaultsAndModelPolling else { return }
         guard shouldPersistLastUsedModel(agent: agent, modelRaw: modelRaw) else { return }
         Self.persistModelForAgent(agentRaw: agent.rawValue, modelRaw: modelRaw)
     }
@@ -1085,6 +1089,7 @@ final class AgentModeViewModel: ObservableObject {
     }
 
     private func updateDynamicModelPolling(startCursorPolling: Bool = true) {
+        guard usesProductionAgentDefaultsAndModelPolling else { return }
         codexCoordinator.updateCodexModelPolling()
         updateOpenCodeModelPolling()
         updateCursorModelPolling(startPolling: startCursorPolling)
@@ -1370,6 +1375,7 @@ final class AgentModeViewModel: ObservableObject {
             mcpServer?.cancelActiveToolsForRun(runID: runID, reason: reason) ?? 0
         }
         shouldManageCodexTooling = true
+        usesProductionAgentDefaultsAndModelPolling = true
         codexCoordinator = CodexAgentModeCoordinator(
             windowID: windowID,
             workspacePathProvider: sessionWorkspacePathProvider,
@@ -1434,9 +1440,7 @@ final class AgentModeViewModel: ObservableObject {
         setupObservers()
         updateDynamicModelPolling(startCursorPolling: false)
         syncAllActiveUIState()
-        Task { [weak self] in
-            await self?.refreshSkillCatalog(force: true)
-        }
+        scheduleInitialSkillCatalogRefresh()
     }
 
     #if DEBUG
@@ -1506,7 +1510,8 @@ final class AgentModeViewModel: ObservableObject {
             testCodexStallWatchdogProbeThreshold: TimeInterval? = nil,
             testCodexStallWatchdogRecoveryThreshold: TimeInterval? = nil,
             testCodexStallWatchdogInactivityThreshold: TimeInterval? = nil,
-            testCodexTransportClosedRecoveryGraceInterval: TimeInterval? = nil
+            testCodexTransportClosedRecoveryGraceInterval: TimeInterval? = nil,
+            testUsesProductionAgentDefaultsAndModelPolling: Bool = false
         ) {
             windowID = testWindowID
             promptManager = nil
@@ -1544,6 +1549,7 @@ final class AgentModeViewModel: ObservableObject {
                     testMCPServer?.cancelActiveToolsForRun(runID: runID, reason: reason) ?? 0
                 }
             self.shouldManageCodexTooling = shouldManageCodexTooling
+            usesProductionAgentDefaultsAndModelPolling = testUsesProductionAgentDefaultsAndModelPolling
             let legacyWatchdogThreshold = testCodexStallWatchdogInactivityThreshold
             let testWatchdogProbeThreshold = testCodexStallWatchdogProbeThreshold ?? legacyWatchdogThreshold ?? 0
             let testWatchdogRecoveryThreshold: TimeInterval = if let explicitRecoveryThreshold = testCodexStallWatchdogRecoveryThreshold {
@@ -1610,12 +1616,12 @@ final class AgentModeViewModel: ObservableObject {
                 return worktreeBindingState(forAgentSessionID: sessionID, tabID: tabID)
             }
             refreshAvailableAgents()
-            restoreLastUsedAgentSelectionIfNeeded()
-            updateDynamicModelPolling(startCursorPolling: false)
-            syncAllActiveUIState()
-            Task { [weak self] in
-                await self?.refreshSkillCatalog(force: true)
+            if usesProductionAgentDefaultsAndModelPolling {
+                restoreLastUsedAgentSelectionIfNeeded()
+                updateDynamicModelPolling(startCursorPolling: false)
             }
+            syncAllActiveUIState()
+            scheduleInitialSkillCatalogRefresh()
         }
     #endif
 
@@ -1776,6 +1782,15 @@ final class AgentModeViewModel: ObservableObject {
             return
         }
         await skillCatalog.refreshIfNeeded(workspacePaths: paths, agentKind: agent)
+    }
+
+    private func scheduleInitialSkillCatalogRefresh() {
+        let catalog = skillCatalog
+        let paths = currentWorkspacePaths()
+        let agent = activeSession?.selectedAgent ?? selectedAgent
+        Task {
+            await catalog.refresh(workspacePaths: paths, agentKind: agent)
+        }
     }
 
     private func scheduleSkillCatalogRefresh(agentKind: AgentProviderKind? = nil) {
@@ -2968,14 +2983,14 @@ final class AgentModeViewModel: ObservableObject {
         let tabID = session.tabID
         let scope = applyEditsScope(for: tabID)
         let initialAutoEditEnabled = session.autoEditEnabled
+        let approvalStore = applyEditsApprovalStore
         session.applyEditsApprovalSubscriptionTask = Task { [weak self] in
-            guard let self else { return }
-            await applyEditsApprovalStore.setAutoEditEnabled(
+            await approvalStore.setAutoEditEnabled(
                 initialAutoEditEnabled,
                 for: scope,
                 updateGlobalDefault: false
             )
-            let (subscriptionID, stream) = await applyEditsApprovalStore.subscribe(scope: scope)
+            let (subscriptionID, stream) = await approvalStore.subscribe(scope: scope)
             await MainActor.run { [weak self] in
                 guard let self, let liveSession = sessions[tabID] else { return }
                 liveSession.applyEditsApprovalSubscriptionID = subscriptionID

--- a/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderAgentViewModel.swift
+++ b/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderAgentViewModel.swift
@@ -844,6 +844,8 @@ final class ContextBuilderAgentViewModel: ObservableObject {
     private var codexModelsSubscriptionTask: Task<Void, Never>?
     private var openCodeModelsSubscriptionTask: Task<Void, Never>?
     private var cursorModelsSubscriptionTask: Task<Void, Never>?
+    private let codexModelPollingService: CodexModelPollingService
+    private var hasPreparedForWindowClose = false
 
     // MARK: - Init / Deinit
 
@@ -852,12 +854,14 @@ final class ContextBuilderAgentViewModel: ObservableObject {
         workspaceManager: WorkspaceManagerViewModel,
         mcpServer: MCPServerViewModel,
         oracleViewModel: OracleViewModel,
-        providerFactory: ProviderFactory? = nil
+        providerFactory: ProviderFactory? = nil,
+        codexModelPollingService: CodexModelPollingService = .shared
     ) {
         self.promptManager = promptManager
         self.workspaceManager = workspaceManager
         self.mcpServer = mcpServer
         self.oracleViewModel = oracleViewModel
+        self.codexModelPollingService = codexModelPollingService
         self.providerFactory = providerFactory ?? { agent, modelString, workspacePath in
             AgentRuntimeProviderService.shared.makeProvider(
                 for: agent,
@@ -926,6 +930,22 @@ final class ContextBuilderAgentViewModel: ObservableObject {
             await handleComposeTabsWillClose(tabIDs)
         }
         updateDynamicModelPolling(startCursorPolling: false)
+    }
+
+    func prepareForWindowClose() {
+        guard !hasPreparedForWindowClose else { return }
+        hasPreparedForWindowClose = true
+        backgroundPlanUIRefreshTask?.cancel()
+        backgroundPlanUIRefreshTask = nil
+        pendingBackgroundPlanRefreshTabIDs.removeAll()
+        stopCodexModelsSubscription()
+        stopOpenCodeModelsSubscription()
+        stopCursorModelsSubscription()
+        if let tabCloseListenerToken {
+            promptManager.removeComposeTabsWillCloseListener(tabCloseListenerToken)
+            self.tabCloseListenerToken = nil
+        }
+        cancellables.removeAll()
     }
 
     private var agentAvailabilityContext: AgentModelCatalog.AvailabilityContext {
@@ -1002,10 +1022,12 @@ final class ContextBuilderAgentViewModel: ObservableObject {
     }
 
     private func startCodexModelsSubscriptionIfNeeded() {
+        guard !hasPreparedForWindowClose else { return }
         guard codexModelsSubscriptionTask == nil else { return }
-        codexModelsSubscriptionTask = Task { [weak self] in
+        let codexModelPollingService = codexModelPollingService
+        codexModelsSubscriptionTask = Task { [weak self, codexModelPollingService] in
             guard let self else { return }
-            let stream = await CodexModelPollingService.shared.subscribe()
+            let stream = await codexModelPollingService.subscribe()
             for await snapshot in stream {
                 guard !Task.isCancelled else { return }
                 await MainActor.run { [weak self] in
@@ -1020,6 +1042,20 @@ final class ContextBuilderAgentViewModel: ObservableObject {
         codexModelsSubscriptionTask = nil
     }
 
+    #if DEBUG
+        func test_startCodexModelsSubscriptionIfNeeded() {
+            startCodexModelsSubscriptionIfNeeded()
+        }
+
+        var test_hasCodexModelsSubscriptionTask: Bool {
+            codexModelsSubscriptionTask != nil
+        }
+
+        func test_stopCodexModelsSubscription() {
+            stopCodexModelsSubscription()
+        }
+    #endif
+
     private func updateOpenCodeModelPolling() {
         if selectedAgent == .openCode {
             startOpenCodeModelsSubscriptionIfNeeded()
@@ -1029,6 +1065,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
     }
 
     private func startOpenCodeModelsSubscriptionIfNeeded() {
+        guard !hasPreparedForWindowClose else { return }
         guard openCodeModelsSubscriptionTask == nil else { return }
         let workspacePath = currentWorkspacePath
         openCodeModelsSubscriptionTask = Task { [weak self, workspacePath] in
@@ -1064,6 +1101,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
     }
 
     private func startCursorModelsSubscriptionIfNeeded() {
+        guard !hasPreparedForWindowClose else { return }
         guard cursorModelsSubscriptionTask == nil else { return }
         let workspacePath = currentWorkspacePath
         cursorModelsSubscriptionTask = Task { [weak self, workspacePath] in

--- a/Sources/RepoPrompt/Features/Settings/ViewModels/APISettingsViewModel.swift
+++ b/Sources/RepoPrompt/Features/Settings/ViewModels/APISettingsViewModel.swift
@@ -349,6 +349,7 @@ public class APISettingsViewModel: ObservableObject {
     private var openCodeModelsTask: Task<Void, Never>?
     private var cursorModelsTask: Task<Void, Never>?
     private var openRouterModelsTask: Task<Void, Never>?
+    private var initialLoadTask: Task<Void, Never>?
     private var cliConnectionCancellables = Set<AnyCancellable>()
     private var hasLoadedStoredData = false
     private var isLoadingStoredData = false
@@ -954,22 +955,68 @@ public class APISettingsViewModel: ObservableObject {
 
     private let aiQueriesService: AIQueriesService
     private let keyManager: KeyManager
+    private let codexModelPollingService: CodexModelPollingService
+    private let storedDataLoadBoundary: (@MainActor @Sendable () async -> Void)?
+    private let contextBuilderProviderValidationWillBegin: (@MainActor @Sendable () async -> Void)?
+    private var hasPreparedForWindowClose = false
 
-    init(aiQueriesService: AIQueriesService, keyManager: KeyManager, loadStoredDataOnInit: Bool = true) {
+    init(
+        aiQueriesService: AIQueriesService,
+        keyManager: KeyManager,
+        loadStoredDataOnInit: Bool = true,
+        codexModelPollingService: CodexModelPollingService = .shared,
+        storedDataLoadBoundary: (@MainActor @Sendable () async -> Void)? = nil,
+        contextBuilderProviderValidationWillBegin: (@MainActor @Sendable () async -> Void)? = nil
+    ) {
         self.aiQueriesService = aiQueriesService
         self.keyManager = keyManager
+        self.codexModelPollingService = codexModelPollingService
+        self.storedDataLoadBoundary = storedDataLoadBoundary
+        self.contextBuilderProviderValidationWillBegin = contextBuilderProviderValidationWillBegin
         installCLIConnectionObservers()
         installAgentAvailabilityObservers()
         refreshAgentAvailability()
         if loadStoredDataOnInit {
-            Task {
-                await self.loadStoredDataIfNeeded()
-                await self.validateCachedContextBuilderProvidersIfNeeded()
+            initialLoadTask = Task { [weak self] in
+                guard let self else { return }
+                await loadStoredDataIfNeeded()
+                guard !Task.isCancelled, !hasPreparedForWindowClose else { return }
+                await validateCachedContextBuilderProvidersIfNeeded()
             }
         }
     }
 
+    func prepareForWindowClose() {
+        guard !hasPreparedForWindowClose else { return }
+        hasPreparedForWindowClose = true
+        initialLoadTask?.cancel()
+        initialLoadTask = nil
+        openAIModelsTask?.cancel()
+        openAIModelsTask = nil
+        deepSeekModelsTask?.cancel()
+        deepSeekModelsTask = nil
+        fireworksModelsTask?.cancel()
+        fireworksModelsTask = nil
+        grokModelsTask?.cancel()
+        grokModelsTask = nil
+        groqModelsTask?.cancel()
+        groqModelsTask = nil
+        stopCodexModelsSubscription()
+        openCodeModelsTask?.cancel()
+        openCodeModelsTask = nil
+        cursorModelsTask?.cancel()
+        cursorModelsTask = nil
+        openRouterModelsTask?.cancel()
+        openRouterModelsTask = nil
+        contextBuilderProviderValidationTask?.cancel()
+        contextBuilderProviderValidationTask = nil
+        cliConnectionCancellables.removeAll()
+        agentAvailabilityCancellable?.cancel()
+        agentAvailabilityCancellable = nil
+    }
+
     deinit {
+        initialLoadTask?.cancel()
         openAIModelsTask?.cancel()
         deepSeekModelsTask?.cancel()
         fireworksModelsTask?.cancel()
@@ -1033,6 +1080,10 @@ public class APISettingsViewModel: ObservableObject {
         accessMode: KeychainAccessMode = .nonInteractive(reason: .bulkSettingsLoad)
     ) async {
         await loadAllKeys(accessMode: accessMode) // returns immediately; fetch tasks run in background
+        guard !Task.isCancelled, !hasPreparedForWindowClose else {
+            isLoadingStoredData = false
+            return
+        }
         hasLoadedStoredData = true
         isLoadingStoredData = false
     }
@@ -1044,6 +1095,10 @@ public class APISettingsViewModel: ObservableObject {
         _ completion: @escaping () -> Void
     ) async {
         await loadAllKeys(accessMode: accessMode)
+        guard !Task.isCancelled, !hasPreparedForWindowClose else {
+            isLoadingStoredData = false
+            return
+        }
         hasLoadedStoredData = true
         isLoadingStoredData = false
         completion() // fires while background fetches still run
@@ -1053,7 +1108,11 @@ public class APISettingsViewModel: ObservableObject {
     func loadStoredDataIfNeeded(
         accessMode: KeychainAccessMode = .nonInteractive(reason: .bulkSettingsLoad)
     ) async {
-        guard !hasLoadedStoredData, !isLoadingStoredData else { return }
+        guard !Task.isCancelled,
+              !hasPreparedForWindowClose,
+              !hasLoadedStoredData,
+              !isLoadingStoredData
+        else { return }
         isLoadingStoredData = true
         await loadStoredData(accessMode: accessMode)
     }
@@ -1063,6 +1122,7 @@ public class APISettingsViewModel: ObservableObject {
     /// cannot reject a saved dynamic model before discovery has had a chance to run.
     @MainActor
     func validateCachedContextBuilderProvidersIfNeeded() async {
+        guard !Task.isCancelled, !hasPreparedForWindowClose else { return }
         if isContextBuilderProviderValidationComplete { return }
         if let contextBuilderProviderValidationTask {
             await contextBuilderProviderValidationTask.value
@@ -1072,11 +1132,14 @@ public class APISettingsViewModel: ObservableObject {
         // Load persisted ACP catalogs before any provider result can trigger restoration.
         // A live refresh may legitimately omit dynamic metadata, especially for Cursor.
         await AgentACPModelRegistry.shared.warmStandardStoreIfNeeded()
+        guard !Task.isCancelled, !hasPreparedForWindowClose else { return }
         if isContextBuilderProviderValidationComplete { return }
         if let contextBuilderProviderValidationTask {
             await contextBuilderProviderValidationTask.value
             return
         }
+        await contextBuilderProviderValidationWillBegin?()
+        guard !Task.isCancelled, !hasPreparedForWindowClose else { return }
 
         let shouldValidateClaude = isClaudeCodeConnected
         let shouldValidateClaudeBinary = hasActiveClaudeCompatibleBackend
@@ -1085,7 +1148,7 @@ public class APISettingsViewModel: ObservableObject {
         let shouldValidateCursor = isCursorConnected
 
         let task = Task { @MainActor [weak self] in
-            guard let self else { return }
+            guard let self, !Task.isCancelled, !hasPreparedForWindowClose else { return }
 
             async let claudeReady = probeCachedClaudeCodeConnection(
                 ifNeeded: shouldValidateClaude,
@@ -1095,6 +1158,7 @@ public class APISettingsViewModel: ObservableObject {
             async let openCodeReady = probeCachedOpenCodeConnection(ifNeeded: shouldValidateOpenCode)
             async let cursorReady = probeCachedCursorConnection(ifNeeded: shouldValidateCursor)
             let readiness = await (claudeReady, codexReady, openCodeReady, cursorReady)
+            guard !Task.isCancelled, !hasPreparedForWindowClose else { return }
 
             applyContextBuilderProviderValidationResult(readiness.0, provider: .claudeCode)
             applyContextBuilderProviderValidationResult(readiness.1, provider: .codexExec)
@@ -1239,6 +1303,8 @@ public class APISettingsViewModel: ObservableObject {
     func loadAllKeys(
         accessMode: KeychainAccessMode = .nonInteractive(reason: .bulkSettingsLoad)
     ) async {
+        guard !Task.isCancelled, !hasPreparedForWindowClose else { return }
+
         // ── 0. Cancel previous background fetches ───────────────────────────────
         openAIModelsTask?.cancel()
         openAIModelsTask = nil
@@ -1261,6 +1327,8 @@ public class APISettingsViewModel: ObservableObject {
 
         keychainAccessDiagnostics.removeAll()
         loadNonSecretStoredData()
+        await storedDataLoadBoundary?()
+        guard !Task.isCancelled, !hasPreparedForWindowClose else { return }
 
         // ----------------------------------------------------------------
         // 1. Fetch tokens independently so one denied provider does not abort
@@ -1327,6 +1395,7 @@ public class APISettingsViewModel: ObservableObject {
             accessMode: accessMode,
             preserveExistingValueOnFailure: false
         )
+        guard !Task.isCancelled, !hasPreparedForWindowClose else { return }
 
         // ----------------------------------------------------------------
         // 2. Restore Azure configuration if it was readable. Denied/noninteractive
@@ -1394,6 +1463,7 @@ public class APISettingsViewModel: ObservableObject {
         // ----------------------------------------------------------------
         // 4. Fire-and-forget model-catalogue fetches (always refresh)
         // ----------------------------------------------------------------
+        guard !Task.isCancelled, !hasPreparedForWindowClose else { return }
         if isOpenAIKeyValid { openAIModelsTask = Task { await self.updateOpenAIModels() } }
         if isDeepSeekKeyValid { deepSeekModelsTask = Task { await self.updateDeepSeekModels() } }
         if isFireworksKeyValid { fireworksModelsTask = Task { await self.updateFireworksModels() } }
@@ -1413,6 +1483,7 @@ public class APISettingsViewModel: ObservableObject {
         // 5. Build initial UI list from whatever caches we already have
         // ----------------------------------------------------------------
         await updateAvailableModels()
+        guard !Task.isCancelled, !hasPreparedForWindowClose else { return }
 
         // ----------------------------------------------------------------
         // 6. Load Claude Code-compatible backend state (GLM/Kimi/Custom)
@@ -3190,6 +3261,7 @@ public class APISettingsViewModel: ObservableObject {
     }
 
     private func startOpenCodeModelsSubscriptionIfNeeded(workspacePath: String?) {
+        guard !hasPreparedForWindowClose else { return }
         guard openCodeModelsTask == nil else { return }
         openCodeModelsTask = Task { [weak self, workspacePath] in
             let stream = await OpenCodeACPModelPollingService.shared.subscribe(workspacePath: workspacePath)
@@ -3338,6 +3410,7 @@ public class APISettingsViewModel: ObservableObject {
     }
 
     private func startCursorModelsSubscriptionIfNeeded(workspacePath: String?) {
+        guard !hasPreparedForWindowClose else { return }
         guard cursorModelsTask == nil else { return }
         cursorModelsTask = Task { [weak self, workspacePath] in
             let stream = await CursorACPModelPollingService.shared.subscribe(workspacePath: workspacePath)
@@ -3521,14 +3594,16 @@ public class APISettingsViewModel: ObservableObject {
     /// Starts a subscription to the centralized Codex model polling service.
     /// Replaces the previous ephemeral-client one-shot refresh.
     private func startCodexModelsSubscriptionIfNeeded() {
+        guard !hasPreparedForWindowClose else { return }
         guard codexModelsTask == nil else { return }
-        codexModelsTask = Task { [weak self] in
+        let codexModelPollingService = codexModelPollingService
+        codexModelsTask = Task { [weak self, codexModelPollingService] in
             guard let self else { return }
 
             // subscribe() starts the polling loop if idle and immediately yields the latest
             // snapshot (if available). The polling loop refreshes immediately on first tick,
             // so no explicit refreshNow() is needed here.
-            let stream = await CodexModelPollingService.shared.subscribe()
+            let stream = await codexModelPollingService.subscribe()
             for await snapshot in stream {
                 guard !Task.isCancelled else { return }
                 await MainActor.run {
@@ -3543,6 +3618,36 @@ public class APISettingsViewModel: ObservableObject {
         codexModelsTask?.cancel()
         codexModelsTask = nil
     }
+
+    #if DEBUG
+        func test_startCodexModelsSubscriptionIfNeeded() {
+            startCodexModelsSubscriptionIfNeeded()
+        }
+
+        var test_hasCodexModelsSubscriptionTask: Bool {
+            codexModelsTask != nil
+        }
+
+        var test_hasPreparedForWindowClose: Bool {
+            hasPreparedForWindowClose
+        }
+
+        var test_hasFinishedInitialStoredDataLoad: Bool {
+            hasLoadedStoredData && !isLoadingStoredData
+        }
+
+        var test_initialLoadTask: Task<Void, Never>? {
+            initialLoadTask
+        }
+
+        var test_hasContextBuilderProviderValidationTask: Bool {
+            contextBuilderProviderValidationTask != nil
+        }
+
+        func test_stopCodexModelsSubscription() {
+            stopCodexModelsSubscription()
+        }
+    #endif
 
     private func updateGrokModels() async {
         guard isGrokKeyValid else { return }

--- a/Sources/RepoPrompt/Features/WorkspaceFiles/ViewModels/GitViewModel.swift
+++ b/Sources/RepoPrompt/Features/WorkspaceFiles/ViewModels/GitViewModel.swift
@@ -107,6 +107,8 @@ final class GitViewModel: ObservableObject {
     private var lastVisibleRootPaths: [String] = []
     private var lastVisibleRootRawPaths: [String] = []
     private var gitContextRefreshTask: Task<Void, Never>?
+    private let gitContextRefreshIntervalNanoseconds: UInt64
+    private let refreshGitContexts: @Sendable ([String]) async -> [GitStatusActor.RepoDetection]
     private var isRefreshingGitContexts = false
 
     private var resolvedStateTask: Task<Void, Never>?
@@ -124,10 +126,16 @@ final class GitViewModel: ObservableObject {
 
     init(
         fileManager: WorkspaceFilesViewModel? = nil,
-        statusActor: GitStatusActor = GitStatusActor()
+        statusActor: GitStatusActor = GitStatusActor(),
+        gitContextRefreshIntervalNanoseconds: UInt64 = 2_500_000_000,
+        refreshGitContexts: (@Sendable ([String]) async -> [GitStatusActor.RepoDetection])? = nil
     ) {
         self.fileManager = fileManager
         self.statusActor = statusActor
+        self.gitContextRefreshIntervalNanoseconds = gitContextRefreshIntervalNanoseconds
+        self.refreshGitContexts = refreshGitContexts ?? { roots in
+            await statusActor.updateRoots(roots)
+        }
 
         // Initialize @Published from @AppStorage
         gitDiffInclusionMode = GitDiffInclusionMode(rawValue: gitDiffInclusionModeStorage) ?? .none
@@ -425,28 +433,80 @@ final class GitViewModel: ObservableObject {
             return
         }
         guard gitContextRefreshTask == nil else { return }
-        gitContextRefreshTask = Task { [weak self] in
+        let intervalNanoseconds = gitContextRefreshIntervalNanoseconds
+        let refreshGitContexts = refreshGitContexts
+        gitContextRefreshTask = Task { [weak self, refreshGitContexts] in
             while !Task.isCancelled {
-                try? await Task.sleep(nanoseconds: 2_500_000_000)
+                if intervalNanoseconds > 0 {
+                    try? await Task.sleep(nanoseconds: intervalNanoseconds)
+                }
                 guard !Task.isCancelled else { break }
-                await self?.refreshVisibleGitContextsFromWorkspaceRoots()
+                guard let request = self?.beginPeriodicGitContextRefresh() else {
+                    if self == nil { break }
+                    continue
+                }
+                let detections = await refreshGitContexts(request.rootPaths)
+                let shouldApply = !Task.isCancelled
+                self?.finishPeriodicGitContextRefresh(
+                    request,
+                    detections: detections,
+                    shouldApply: shouldApply
+                )
             }
         }
     }
 
-    private func refreshVisibleGitContextsFromWorkspaceRoots() async {
-        guard !isRefreshingGitContexts else { return }
+    func prepareForWindowClose() {
+        statusStreamTask?.cancel()
+        searchDebounceTask?.cancel()
+        rootUpdateTask?.cancel()
+        gitContextRefreshTask?.cancel()
+        gitContextRefreshTask = nil
+        resolvedStateTask?.cancel()
+    }
+
+    #if DEBUG
+        var test_hasGitContextRefreshTask: Bool {
+            gitContextRefreshTask != nil
+        }
+
+        var test_gitContextRefreshTask: Task<Void, Never>? {
+            gitContextRefreshTask
+        }
+    #endif
+
+    private struct PeriodicGitContextRefreshRequest {
+        let rootPaths: [String]
+        let standardizedRootPaths: [String]
+        let standardizedPathByRootPath: [String: String]
+    }
+
+    private func beginPeriodicGitContextRefresh() -> PeriodicGitContextRefreshRequest? {
+        guard !isRefreshingGitContexts else { return nil }
         let rootPaths = lastVisibleRootRawPaths
-        guard !rootPaths.isEmpty else { return }
-        let standardizedRootPaths = lastVisibleRootPaths
-        let standardizedPathByRootPath = Self.standardizedPathByRootPath(for: availableRootFolders)
+        guard !rootPaths.isEmpty else { return nil }
         isRefreshingGitContexts = true
-        defer { isRefreshingGitContexts = false }
-        let detections = await statusActor.updateRoots(rootPaths)
-        guard rootPaths == lastVisibleRootRawPaths,
-              standardizedRootPaths == lastVisibleRootPaths
+        return PeriodicGitContextRefreshRequest(
+            rootPaths: rootPaths,
+            standardizedRootPaths: lastVisibleRootPaths,
+            standardizedPathByRootPath: Self.standardizedPathByRootPath(for: availableRootFolders)
+        )
+    }
+
+    private func finishPeriodicGitContextRefresh(
+        _ request: PeriodicGitContextRefreshRequest,
+        detections: [GitStatusActor.RepoDetection],
+        shouldApply: Bool
+    ) {
+        isRefreshingGitContexts = false
+        guard shouldApply,
+              request.rootPaths == lastVisibleRootRawPaths,
+              request.standardizedRootPaths == lastVisibleRootPaths
         else { return }
-        applyRootDetections(detections, standardizedPathByRootPath: standardizedPathByRootPath)
+        applyRootDetections(
+            detections,
+            standardizedPathByRootPath: request.standardizedPathByRootPath
+        )
     }
 
     // MARK: - Fetch API (delegates to actor)

--- a/Sources/RepoPrompt/Features/Workspaces/ViewModels/WorkspaceManagerViewModel.swift
+++ b/Sources/RepoPrompt/Features/Workspaces/ViewModels/WorkspaceManagerViewModel.swift
@@ -1279,7 +1279,8 @@ class WorkspaceManagerViewModel: ObservableObject {
         fileManager: WorkspaceFilesViewModel,
         promptViewModel: PromptViewModel,
         workspaceSearchService: WorkspaceSearchService = WorkspaceSearchService(),
-        switchTimingPolicy: WorkspaceSwitchTimingPolicy = .production
+        switchTimingPolicy: WorkspaceSwitchTimingPolicy = .production,
+        performInitialWorkspaceActivation: Bool = true
     ) {
         #if DEBUG
             let initStartMS = WorkspaceRestorePerfLog.timestampMSIfEnabled()
@@ -1461,7 +1462,9 @@ class WorkspaceManagerViewModel: ObservableObject {
             }
         }
 
-        if activeWorkspace == nil {
+        if !performInitialWorkspaceActivation {
+            completeInitialization()
+        } else if activeWorkspace == nil {
             if let defaultWS = findOrCreateDefaultWorkspace() {
                 Task {
                     await switchWorkspace(to: defaultWS, saveState: false)
@@ -1537,12 +1540,36 @@ class WorkspaceManagerViewModel: ObservableObject {
         postCatalogRootWorkTasks.removeAll()
     }
 
+    func prepareForWindowClose() {
+        stopPollTimer()
+        reloadWorkspacesTask?.cancel()
+        reloadWorkspacesTask = nil
+        reloadPresetsTask?.cancel()
+        reloadPresetsTask = nil
+        codeMapPurgeTask?.cancel()
+        codeMapPurgeTask = nil
+        composeTabApplyTask?.cancel()
+        composeTabApplyTask = nil
+        postSwitchGitDataLoadTask?.cancel()
+        postSwitchGitDataLoadTask = nil
+        for tasks in postCatalogRootWorkTasks.values {
+            tasks.forEach { $0.cancel() }
+        }
+        postCatalogRootWorkTasks.removeAll()
+        cancellables.removeAll()
+    }
+
+    #if DEBUG
+        var test_isPollTimerActive: Bool {
+            pollTimer?.isValid == true
+        }
+    #endif
+
     // MARK: - Private Timer Control
 
     private func startPollTimer() {
         pollTimer?.invalidate()
         pollTimer = Timer.scheduledTimer(withTimeInterval: pollInterval, repeats: true) { [weak self] _ in
-            guard let self else { return }
             Task { @MainActor [weak self] in
                 guard let self else { return }
 

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/CodexModelPollingService.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/CodexModelPollingService.swift
@@ -27,7 +27,8 @@ extension CodexAppServerClient: CodexModelListingClient {}
 actor CodexModelPollingService {
     static let shared = CodexModelPollingService(
         client: CodexProviderHelpers.makeOwnedNonAgentAppServerClient(),
-        stopClientOnShutdown: true
+        stopClientOnShutdown: true,
+        stopClientWhenIdle: true
     )
 
     struct Snapshot: Equatable {
@@ -38,27 +39,37 @@ actor CodexModelPollingService {
     private let client: any CodexModelListingClient
     private let intervalNanos: UInt64
     private let stopClientOnShutdown: Bool
+    private let stopClientWhenIdle: Bool
 
     private var pollingTask: Task<Void, Never>?
     private var inFlightRefresh: Task<Void, Never>?
     private var continuations: [UUID: AsyncStream<Snapshot>.Continuation] = [:]
     private var latest: Snapshot?
     private var isShutdown = false
+    private var isStoppingClientForIdle = false
 
     init(
         client: any CodexModelListingClient,
         intervalNanos: UInt64 = 60_000_000_000,
-        stopClientOnShutdown: Bool = false
+        stopClientOnShutdown: Bool = false,
+        stopClientWhenIdle: Bool = false
     ) {
         self.client = client
         self.intervalNanos = intervalNanos
         self.stopClientOnShutdown = stopClientOnShutdown
+        self.stopClientWhenIdle = stopClientWhenIdle
     }
 
     /// Returns the most recent snapshot if available (non-blocking).
     func latestSnapshot() -> Snapshot? {
         latest
     }
+
+    #if DEBUG
+        func test_subscriberCount() -> Int {
+            continuations.count
+        }
+    #endif
 
     /// Subscribe to model snapshot updates.
     ///
@@ -122,6 +133,7 @@ actor CodexModelPollingService {
 
     private func startPollingIfNeeded() {
         guard !isShutdown else { return }
+        guard !isStoppingClientForIdle else { return }
         guard pollingTask == nil else { return }
         pollingTask = Task { [weak self] in
             guard let self else { return }
@@ -136,15 +148,29 @@ actor CodexModelPollingService {
         }
     }
 
-    private func stopPollingIfIdle() {
+    private func stopPollingIfIdle() async {
         guard continuations.isEmpty else { return }
         pollingTask?.cancel()
         pollingTask = nil
+        guard stopClientWhenIdle else { return }
+        guard !isStoppingClientForIdle else { return }
+
+        isStoppingClientForIdle = true
+        if let inFlightRefresh {
+            inFlightRefresh.cancel()
+            await inFlightRefresh.value
+        }
+        await client.stop()
+        isStoppingClientForIdle = false
+
+        if !isShutdown, !continuations.isEmpty {
+            startPollingIfNeeded()
+        }
     }
 
-    private func removeSubscriber(_ id: UUID) {
+    private func removeSubscriber(_ id: UUID) async {
         continuations.removeValue(forKey: id)
-        stopPollingIfIdle()
+        await stopPollingIfIdle()
     }
 
     private func performRefresh() async {

--- a/Sources/RepoPrompt/Infrastructure/MCP/ApplyEdits/ApplyEditsApprovalStore.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ApplyEdits/ApplyEditsApprovalStore.swift
@@ -212,6 +212,12 @@ actor ApplyEditsApprovalStore: Sendable {
         removeSubscription(scope: scope, id: id, finishContinuation: true)
     }
 
+    #if DEBUG
+        func test_subscriptionCount() -> Int {
+            subscriptions.values.reduce(0) { $0 + $1.count }
+        }
+    #endif
+
     private func resolvePendingReviewIfMatching(
         scope: ApplyEditsApprovalScope,
         reviewID: UUID,

--- a/Tests/RepoPromptTests/AI/CodexModelPollingServiceTests.swift
+++ b/Tests/RepoPromptTests/AI/CodexModelPollingServiceTests.swift
@@ -1,0 +1,66 @@
+@testable import RepoPrompt
+import XCTest
+
+final class CodexModelPollingServiceTests: XCTestCase {
+    func testLastSubscriberStopsOwnedClientAndLaterSubscriberRestartsPolling() async throws {
+        let client = PollingClientSpy()
+        let service = CodexModelPollingService(
+            client: client,
+            intervalNanos: 60_000_000_000,
+            stopClientOnShutdown: true,
+            stopClientWhenIdle: true
+        )
+
+        let firstConsumer = await makeConsumer(service: service)
+        try await waitUntil { await client.listCallCount >= 1 }
+        firstConsumer.cancel()
+        await firstConsumer.value
+        try await waitUntil { await client.stopCallCount >= 1 }
+
+        let secondConsumer = await makeConsumer(service: service)
+        try await waitUntil { await client.listCallCount >= 2 }
+        secondConsumer.cancel()
+        await secondConsumer.value
+        try await waitUntil { await client.stopCallCount >= 2 }
+
+        await service.shutdown()
+    }
+
+    private func makeConsumer(
+        service: CodexModelPollingService
+    ) async -> Task<Void, Never> {
+        let stream = await service.subscribe()
+        return Task {
+            for await _ in stream {}
+        }
+    }
+
+    private func waitUntil(
+        timeout: Duration = .seconds(2),
+        condition: @escaping @Sendable () async -> Bool
+    ) async throws {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        while await !condition() {
+            guard clock.now < deadline else {
+                XCTFail("Timed out waiting for condition")
+                return
+            }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+    }
+}
+
+private actor PollingClientSpy: CodexModelListingClient {
+    private(set) var listCallCount = 0
+    private(set) var stopCallCount = 0
+
+    func listModels(limit: Int) async throws -> [CodexAppServerClient.RemoteModel] {
+        listCallCount += 1
+        return []
+    }
+
+    func stop() async {
+        stopCallCount += 1
+    }
+}

--- a/Tests/RepoPromptTests/AgentMode/AgentModeRunServiceLifecycleTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeRunServiceLifecycleTests.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 import XCTest
 @_spi(TestSupport) @testable import RepoPrompt
@@ -7,13 +8,16 @@ private let lifecycleAwaitTimeoutSeconds: TimeInterval = 5
 @MainActor
 final class AgentModeRunServiceLifecycleTests: XCTestCase {
     private var temporaryURLs: [URL] = []
+    private var lifecycleHosts: [AgentModeViewModel] = []
+    private var acpControllers: [ObjectIdentifier: ACPAgentSessionController] = [:]
 
-    override func tearDown() {
+    override func tearDown() async throws {
+        await cleanupRegisteredRuntime()
         for url in temporaryURLs {
             try? FileManager.default.removeItem(at: url)
         }
         temporaryURLs.removeAll()
-        super.tearDown()
+        try await super.tearDown()
     }
 
     func testTerminalCommitPreservesRebuiltToolCorrelationIndexes() async throws {
@@ -588,6 +592,64 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
         let policyEvents = recorder.events.filter { $0.hasPrefix("policy:cursor:") }
         XCTAssertEqual(policyEvents.count, 2)
         XCTAssertEqual(Set(policyEvents).count, 1)
+    }
+
+    func testLifecycleCleanupReapsCompletedReusableOpenCodeProcess() async throws {
+        let recorder = LifecycleRecorder()
+        let workspace = try makeTemporaryDirectory()
+        let processIDURL = workspace.appendingPathComponent("opencode-process-id.txt")
+        let scriptURL = try makeOpenCodeModeFlowServerScript()
+        let provider = LifecycleFakeACPProvider(
+            providerID: .openCode,
+            commandPath: scriptURL.path,
+            environment: ["ACP_PID_PATH": processIDURL.path],
+            recorder: recorder
+        )
+        let harness = makeHarness(
+            recorder: recorder,
+            workspacePathProvider: { _ in workspace.path },
+            acpProviderFactory: { agent, _ in
+                XCTAssertEqual(agent, .openCode)
+                return provider
+            },
+            autoSignalACPRouting: true
+        )
+        let session = AgentModeViewModel.TabSession(tabID: UUID())
+        session.selectedAgent = .openCode
+
+        let outcome = await harness.service.startRun(
+            tabID: session.tabID,
+            session: session,
+            initialUserMessage: "Complete and remain reusable",
+            initialMessageForRun: "Complete and remain reusable",
+            attachments: []
+        )
+
+        XCTAssertNil(outcome)
+        try await withLifecycleTimeout("OpenCode reusable-session run") {
+            await session.agentTask?.value
+        }
+        XCTAssertEqual(session.runState, .completed)
+        let controller = try XCTUnwrap(session.acpController)
+        let wasReusable = await controller.hasReusableSession
+        XCTAssertTrue(wasReusable)
+
+        try await waitUntil("OpenCode process ID should be recorded") {
+            FileManager.default.fileExists(atPath: processIDURL.path)
+        }
+        let processIDText = try String(contentsOf: processIDURL, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let processID = try XCTUnwrap(pid_t(processIDText))
+        XCTAssertTrue(Self.processIsRunning(processID))
+
+        await cleanupRegisteredRuntime()
+
+        try await waitUntil("OpenCode process should exit during lifecycle cleanup") {
+            !Self.processIsRunning(processID)
+        }
+        XCTAssertFalse(Self.processIsRunning(processID))
+        let remainsReusable = await controller.hasReusableSession
+        XCTAssertFalse(remainsReusable)
     }
 
     func testTerminalBarrierRejectsStaleOwnership() async {
@@ -1342,9 +1404,14 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
             recorder.record("factory:acp-provider")
             return nil
         }
-        let acpControllerFactory = acpControllerFactory ?? { provider, request in
+        let baseACPControllerFactory = acpControllerFactory ?? { provider, request in
             recorder.record("factory:acp-controller")
             return try ACPAgentSessionController(provider: provider, runRequest: request)
+        }
+        let trackedACPControllerFactory: AgentModeViewModel.ACPControllerFactory = { [weak self] provider, request in
+            let controller = try baseACPControllerFactory(provider, request)
+            self?.registerACPController(controller)
+            return controller
         }
         let policyInstaller: AgentModeViewModel.ConnectionPolicyInstaller = { clientName, _, _, _, _, _, _, runID, _, _, _, _, _ in
             recorder.record("policy:\(clientName):\(runID?.uuidString ?? "nil")")
@@ -1363,15 +1430,16 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
             },
             headlessProviderFactory: headlessProviderFactory,
             acpProviderFactory: acpProviderFactory,
-            acpControllerFactory: acpControllerFactory,
+            acpControllerFactory: trackedACPControllerFactory,
             connectionPolicyInstaller: policyInstaller,
             mcpServerEnabler: serverEnabler
         )
+        lifecycleHosts.append(host)
         let dependencies = AgentModeRunService.Dependencies(
             windowID: 1,
             headlessProviderFactory: headlessProviderFactory,
             acpProviderFactory: acpProviderFactory,
-            acpControllerFactory: acpControllerFactory,
+            acpControllerFactory: trackedACPControllerFactory,
             connectionPolicyInstaller: policyInstaller,
             mcpServerEnabler: serverEnabler,
             workspacePathProvider: workspacePathProvider,
@@ -1538,7 +1606,7 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
         request: ACPRunRequest,
         recorder: LifecycleRecorder
     ) throws -> ACPAgentSessionController {
-        try ACPAgentSessionController(
+        let controller = try ACPAgentSessionController(
             provider: provider,
             runRequest: request,
             diagnosticSink: { event in
@@ -1552,6 +1620,8 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
                 recorder.record("acp:\(method)")
             }
         )
+        registerACPController(controller)
+        return controller
     }
 
     private func makeTemporaryDirectory() throws -> URL {
@@ -1572,8 +1642,13 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
         import sys
 
         record_path = os.environ.get("ACP_RECORD_PATH")
+        pid_path = os.environ.get("ACP_PID_PATH")
         current_model = "model-a"
         current_mode = "ask"
+
+        if pid_path:
+            with open(pid_path, "w", encoding="utf-8") as handle:
+                handle.write(str(os.getpid()))
 
         def record(method, params):
             if not record_path:
@@ -1709,6 +1784,7 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
         try await withLifecycleTimeout("ACP controller shutdown", cancelOperationOnTimeout: false) {
             await controller.shutdown()
         }
+        acpControllers.removeValue(forKey: ObjectIdentifier(controller))
     }
 
     private func shutdownACPControllerAfterFailure(_ controller: ACPAgentSessionController) async {
@@ -1717,6 +1793,31 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
         } catch {
             XCTFail("ACP controller cleanup failed: \(error.localizedDescription)")
         }
+    }
+
+    private func registerACPController(_ controller: ACPAgentSessionController) {
+        acpControllers[ObjectIdentifier(controller)] = controller
+    }
+
+    private func cleanupRegisteredRuntime() async {
+        let hosts = lifecycleHosts.reversed()
+        lifecycleHosts.removeAll()
+        for host in hosts {
+            await host.prepareForWindowClose()
+        }
+
+        let controllers = Array(acpControllers.values)
+        acpControllers.removeAll()
+        for controller in controllers {
+            await controller.shutdown()
+        }
+    }
+
+    private nonisolated static func processIsRunning(_ processID: pid_t) -> Bool {
+        if kill(processID, 0) == 0 {
+            return true
+        }
+        return errno == EPERM
     }
 
     private func withLifecycleTimeout<Value: Sendable>(

--- a/Tests/RepoPromptTests/AgentMode/AgentModeViewModelDisposalTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeViewModelDisposalTests.swift
@@ -1,0 +1,130 @@
+import Foundation
+import XCTest
+@_spi(TestSupport) @testable import RepoPrompt
+
+@MainActor
+final class AgentModeViewModelDisposalTests: XCTestCase {
+    func testDebugInitializerDoesNotUseOrOverwriteProductionAgentDefaults() {
+        let defaults = UserDefaults.standard
+        let key = "agentMode.lastUsedAgent"
+        let previousValue = defaults.object(forKey: key)
+        defer {
+            if let previousValue {
+                defaults.set(previousValue, forKey: key)
+            } else {
+                defaults.removeObject(forKey: key)
+            }
+        }
+
+        defaults.set(AgentProviderKind.codexExec.rawValue, forKey: key)
+        let viewModel = makeViewModel()
+
+        XCTAssertEqual(viewModel.selectedAgent, .claudeCode)
+        viewModel.selectedAgent = .openCode
+        XCTAssertEqual(defaults.string(forKey: key), AgentProviderKind.codexExec.rawValue)
+    }
+
+    func testApprovalSubscriptionDoesNotRetainViewModel() async {
+        let fixture = await makeSubscribedWeakViewModel()
+
+        for _ in 0 ..< 100 {
+            let subscriptionCount = await fixture.approvalStore.test_subscriptionCount()
+            if fixture.weakViewModel.value == nil, subscriptionCount == 0 {
+                break
+            }
+            await Task.yield()
+        }
+
+        let subscriptionCount = await fixture.approvalStore.test_subscriptionCount()
+        XCTAssertNil(fixture.weakViewModel.value)
+        XCTAssertEqual(subscriptionCount, 0)
+    }
+
+    private func makeSubscribedWeakViewModel() async -> SubscribedViewModelFixture {
+        let approvalStore = ApplyEditsApprovalStore()
+        let viewModel = makeViewModel(applyEditsApprovalStore: approvalStore)
+        let session = await viewModel.ensureSessionReady(tabID: UUID())
+
+        for _ in 0 ..< 100 where session.applyEditsApprovalSubscriptionID == nil {
+            await Task.yield()
+        }
+        XCTAssertNotNil(session.applyEditsApprovalSubscriptionID)
+
+        return SubscribedViewModelFixture(
+            weakViewModel: WeakBox(viewModel),
+            approvalStore: approvalStore
+        )
+    }
+
+    private func makeViewModel(
+        applyEditsApprovalStore: ApplyEditsApprovalStore = .shared
+    ) -> AgentModeViewModel {
+        AgentModeViewModel(
+            applyEditsApprovalStore: applyEditsApprovalStore,
+            codexControllerFactory: { _, _, _, _, _, _ in DisposalFakeCodexController() }
+        )
+    }
+}
+
+private struct SubscribedViewModelFixture {
+    let weakViewModel: WeakBox<AgentModeViewModel>
+    let approvalStore: ApplyEditsApprovalStore
+}
+
+private final class WeakBox<Value: AnyObject> {
+    weak var value: Value?
+
+    init(_ value: Value) {
+        self.value = value
+    }
+}
+
+private final class DisposalFakeCodexController: CodexSessionControllerTurnDispatchTestDefaults {
+    var hasActiveThread: Bool {
+        false
+    }
+
+    var events: AsyncStream<CodexNativeSessionController.Event> {
+        AsyncStream { continuation in continuation.finish() }
+    }
+
+    func ensureEventsStreamReady() {}
+
+    func startOrResume(
+        existing: CodexNativeSessionController.SessionRef?,
+        baseInstructions: String
+    ) async throws -> CodexNativeSessionController.SessionRef {
+        CodexNativeSessionController.SessionRef(
+            conversationID: "disposal-test",
+            rolloutPath: nil,
+            model: nil,
+            reasoningEffort: nil
+        )
+    }
+
+    func readThreadSnapshot(
+        includeTurns: Bool,
+        timeout: TimeInterval?
+    ) async throws -> CodexNativeSessionController.ThreadSnapshot {
+        CodexNativeSessionController.ThreadSnapshot(
+            conversationID: "disposal-test",
+            rolloutPath: nil,
+            model: nil,
+            reasoningEffort: nil,
+            runtimeStatus: .idle,
+            currentTurnID: nil,
+            activeTurnIDs: [],
+            latestTurnStatus: nil
+        )
+    }
+
+    func setThreadName(_ name: String, threadID: String?) async throws {}
+    func compactThread() async throws {}
+    func getThreadGoal() async throws -> CodexNativeSessionController.ThreadGoal? {
+        nil
+    }
+
+    func cancelCurrentTurn() async {}
+    func shutdown() async {}
+    func respondToServerRequest(id: CodexAppServerRequestID, result: [String: Any]) async {}
+}

--- a/Tests/RepoPromptTests/App/WindowCloseCoordinatorDecisionTests.swift
+++ b/Tests/RepoPromptTests/App/WindowCloseCoordinatorDecisionTests.swift
@@ -3,6 +3,203 @@ import XCTest
 
 @MainActor
 final class WindowCloseCoordinatorDecisionTests: XCTestCase {
+    private var trackedWindows: [WindowState] = []
+    private var explicitlyUnregisteredWindowIDs: Set<ObjectIdentifier> = []
+
+    override func tearDown() async throws {
+        for window in trackedWindows.reversed() {
+            if !explicitlyUnregisteredWindowIDs.contains(ObjectIdentifier(window)) {
+                WindowStatesManager.shared.unregisterWindowState(window)
+            }
+            await window.tearDown()
+        }
+        trackedWindows.removeAll()
+        explicitlyUnregisteredWindowIDs.removeAll()
+        try await super.tearDown()
+    }
+
+    func testUnregisterStopsPeriodicWindowBackgroundWork() throws {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("WindowCloseCoordinatorDecisionTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+
+        let window = trackWindow(WindowState())
+        let manager = WindowStatesManager.shared
+        manager.registerWindowState(window)
+        let root = FolderViewModel(
+            folder: Folder(name: rootURL.lastPathComponent, path: rootURL.path, modificationDate: Date()),
+            rootPath: rootURL.path
+        )
+        window.promptManager.gitViewModel.updateRootFolders([root])
+
+        XCTAssertTrue(window.workspaceManager.test_isPollTimerActive)
+        XCTAssertTrue(window.promptManager.gitViewModel.test_hasGitContextRefreshTask)
+
+        unregisterTrackedWindow(window)
+
+        XCTAssertFalse(window.workspaceManager.test_isPollTimerActive)
+        XCTAssertFalse(window.promptManager.gitViewModel.test_hasGitContextRefreshTask)
+    }
+
+    func testSuspendedGitContextRefreshDoesNotRetainViewModel() async throws {
+        let refreshGate = GitContextRefreshGate()
+        var viewModel: GitViewModel? = GitViewModel(
+            gitContextRefreshIntervalNanoseconds: 0,
+            refreshGitContexts: { rootPaths in
+                await refreshGate.refresh(rootPaths: rootPaths)
+            }
+        )
+        let weakViewModel = WeakLifecycleReference(viewModel)
+        let root = FolderViewModel(
+            folder: Folder(name: "root", path: "/tmp/git-refresh-lifecycle", modificationDate: Date()),
+            rootPath: "/tmp/git-refresh-lifecycle"
+        )
+        viewModel?.updateRootFolders([root])
+        let refreshTask = try XCTUnwrap(viewModel?.test_gitContextRefreshTask)
+
+        await refreshGate.waitUntilEntered()
+        viewModel = nil
+        let deallocatedWithoutExplicitClose = weakViewModel.value == nil
+        weakViewModel.value?.prepareForWindowClose()
+        await refreshGate.release()
+        await refreshTask.value
+
+        let observedCancellation = await refreshGate.observedCancellation
+        XCTAssertTrue(deallocatedWithoutExplicitClose)
+        XCTAssertTrue(observedCancellation)
+    }
+
+    func testWorkspacePollTimerDoesNotRetainManager() {
+        let fileManager = WorkspaceFilesViewModel()
+        let keyManager = KeyManager(
+            secureService: SecureKeysService(secureStorage: TestSecureStorageBackend())
+        )
+        let apiSettings = APISettingsViewModel(
+            aiQueriesService: AIQueriesService(keyManager: keyManager),
+            keyManager: keyManager,
+            loadStoredDataOnInit: false
+        )
+        let prompt = PromptViewModel(
+            fileManager: fileManager,
+            apiSettingsViewModel: apiSettings,
+            windowID: -1,
+            settingsManager: WindowSettingsManager(windowID: -1)
+        )
+        var manager: WorkspaceManagerViewModel? = WorkspaceManagerViewModel(
+            fileManager: fileManager,
+            promptViewModel: prompt,
+            performInitialWorkspaceActivation: false
+        )
+        let weakManager = WeakLifecycleReference(manager)
+
+        XCTAssertTrue(manager?.test_isPollTimerActive == true)
+        manager = nil
+
+        XCTAssertNil(weakManager.value)
+    }
+
+    func testUnregisterDisposesPerWindowCodexModelSubscribersAndStopsOwnedClient() async throws {
+        let client = WindowClosePollingClientSpy()
+        let pollingService = CodexModelPollingService(
+            client: client,
+            intervalNanos: 60_000_000_000,
+            stopClientWhenIdle: true
+        )
+        let window = trackWindow(WindowState(
+            codexModelPollingService: pollingService,
+            loadStoredAPISettingsDataOnInit: false
+        ))
+        let manager = WindowStatesManager.shared
+        manager.registerWindowState(window)
+
+        try await waitUntil("initial API settings load to settle", timeout: .seconds(15)) {
+            window.apiSettingsViewModel.test_hasFinishedInitialStoredDataLoad
+        }
+        window.apiSettingsViewModel.test_stopCodexModelsSubscription()
+        window.contextBuilderAgentViewModel.test_stopCodexModelsSubscription()
+        try await waitUntil("startup model subscribers to detach") {
+            await pollingService.test_subscriberCount() == 0
+        }
+
+        window.apiSettingsViewModel.isCodexConnected = true
+        window.apiSettingsViewModel.test_completeContextBuilderProviderValidation(
+            verifiedProviders: [.codexExec]
+        )
+        XCTAssertFalse(window.isClosing)
+        XCTAssertFalse(window.apiSettingsViewModel.test_hasPreparedForWindowClose)
+        window.apiSettingsViewModel.test_startCodexModelsSubscriptionIfNeeded()
+        window.contextBuilderAgentViewModel.test_startCodexModelsSubscriptionIfNeeded()
+        try await waitUntil("two per-window subscribers to attach") {
+            await pollingService.test_subscriberCount() == 2
+        }
+        let attachedSubscriberCount = await pollingService.test_subscriberCount()
+        XCTAssertEqual(
+            attachedSubscriberCount,
+            2,
+            "apiTask=\(window.apiSettingsViewModel.test_hasCodexModelsSubscriptionTask) contextBuilderTask=\(window.contextBuilderAgentViewModel.test_hasCodexModelsSubscriptionTask)"
+        )
+        let stopCallCountBeforeClose = client.stopCallCount
+
+        unregisterTrackedWindow(window)
+
+        try await waitUntil("window-close subscriber disposal and client stop") {
+            await pollingService.test_subscriberCount() == 0
+                && client.stopCallCount > stopCallCountBeforeClose
+        }
+        let subscriberCount = await pollingService.test_subscriberCount()
+        XCTAssertTrue(window.isClosing)
+        XCTAssertEqual(subscriberCount, 0)
+        XCTAssertGreaterThan(client.stopCallCount, stopCallCountBeforeClose)
+    }
+
+    func testAPISettingsCloseDuringInitialLoadDoesNotStartProviderValidation() async throws {
+        let loadGate = APISettingsInitialLoadGate()
+        let validationProbe = APISettingsProviderValidationProbe()
+        let keyManager = KeyManager(
+            secureService: SecureKeysService(secureStorage: TestSecureStorageBackend())
+        )
+        let viewModel = APISettingsViewModel(
+            aiQueriesService: AIQueriesService(keyManager: keyManager),
+            keyManager: keyManager,
+            storedDataLoadBoundary: {
+                await loadGate.arriveAndWait()
+            },
+            contextBuilderProviderValidationWillBegin: {
+                await validationProbe.recordStart()
+            }
+        )
+        let initialLoadTask = try XCTUnwrap(viewModel.test_initialLoadTask)
+
+        await loadGate.waitUntilEntered()
+        viewModel.prepareForWindowClose()
+        await loadGate.release()
+        await initialLoadTask.value
+
+        let validationStartCount = await validationProbe.startCount
+        XCTAssertTrue(viewModel.test_hasPreparedForWindowClose)
+        XCTAssertFalse(viewModel.test_hasFinishedInitialStoredDataLoad)
+        XCTAssertFalse(viewModel.test_hasContextBuilderProviderValidationTask)
+        XCTAssertEqual(validationStartCount, 0)
+    }
+
+    private func trackWindow(_ makeWindow: @autoclosure () -> WindowState) -> WindowState {
+        let previousMCPAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
+        GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
+        defer {
+            GlobalSettingsStore.shared.setMCPAutoStart(previousMCPAutoStart, commit: false)
+        }
+
+        let window = makeWindow()
+        trackedWindows.append(window)
+        return window
+    }
+
+    private func unregisterTrackedWindow(_ window: WindowState) {
+        WindowStatesManager.shared.unregisterWindowState(window)
+        explicitlyUnregisteredWindowIDs.insert(ObjectIdentifier(window))
+    }
+
     func testTerminationAndAuthorizationAllowDespiteOtherwiseBlockingImpact() {
         let otherwiseBlockingSnapshot = makeSnapshot(
             isLastAppWindow: true,
@@ -124,6 +321,22 @@ final class WindowCloseCoordinatorDecisionTests: XCTestCase {
         }
     }
 
+    private func waitUntil(
+        _ description: String,
+        timeout: Duration = .seconds(5),
+        condition: @escaping @MainActor () async -> Bool
+    ) async throws {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        while await !condition() {
+            guard clock.now < deadline else {
+                XCTFail("Timed out waiting for \(description)")
+                return
+            }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+    }
+
     private func authorization(source: WindowCloseAuthorization.Source) -> WindowCloseAuthorization {
         WindowCloseAuthorization(
             source: source,
@@ -208,5 +421,111 @@ final class WindowCloseCoordinatorDecisionTests: XCTestCase {
             secondaryButtonTitle: "Hide and Keep Running",
             secondaryAction: .backgroundWindow
         )
+    }
+}
+
+private actor APISettingsInitialLoadGate {
+    private var hasEntered = false
+    private var hasReleased = false
+    private var entryWaiters: [CheckedContinuation<Void, Never>] = []
+    private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func arriveAndWait() async {
+        hasEntered = true
+        let waiters = entryWaiters
+        entryWaiters.removeAll()
+        waiters.forEach { $0.resume() }
+
+        guard !hasReleased else { return }
+        await withCheckedContinuation { continuation in
+            releaseWaiters.append(continuation)
+        }
+    }
+
+    func waitUntilEntered() async {
+        guard !hasEntered else { return }
+        await withCheckedContinuation { continuation in
+            entryWaiters.append(continuation)
+        }
+    }
+
+    func release() {
+        hasReleased = true
+        let waiters = releaseWaiters
+        releaseWaiters.removeAll()
+        waiters.forEach { $0.resume() }
+    }
+}
+
+private actor APISettingsProviderValidationProbe {
+    private(set) var startCount = 0
+
+    func recordStart() {
+        startCount += 1
+    }
+}
+
+private actor GitContextRefreshGate {
+    private var hasEntered = false
+    private var hasReleased = false
+    private var entryWaiters: [CheckedContinuation<Void, Never>] = []
+    private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+    private(set) var observedCancellation = false
+
+    func refresh(rootPaths _: [String]) async -> [GitStatusActor.RepoDetection] {
+        hasEntered = true
+        let waiters = entryWaiters
+        entryWaiters.removeAll()
+        waiters.forEach { $0.resume() }
+
+        if !hasReleased {
+            await withCheckedContinuation { continuation in
+                releaseWaiters.append(continuation)
+            }
+        }
+        observedCancellation = Task.isCancelled
+        return []
+    }
+
+    func waitUntilEntered() async {
+        guard !hasEntered else { return }
+        await withCheckedContinuation { continuation in
+            entryWaiters.append(continuation)
+        }
+    }
+
+    func release() {
+        hasReleased = true
+        let waiters = releaseWaiters
+        releaseWaiters.removeAll()
+        waiters.forEach { $0.resume() }
+    }
+}
+
+private final class WeakLifecycleReference<Value: AnyObject> {
+    weak var value: Value?
+
+    init(_ value: Value?) {
+        self.value = value
+    }
+}
+
+private final class WindowClosePollingClientSpy: CodexModelListingClient, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _stopCallCount = 0
+
+    var stopCallCount: Int {
+        lock.withLock { _stopCallCount }
+    }
+
+    func listModels(limit _: Int) async throws -> [CodexAppServerClient.RemoteModel] {
+        try await Task.sleep(for: .seconds(60))
+        return []
+    }
+
+    func stop() async {
+        lock.withLock {
+            _stopCallCount += 1
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fix the shared test-runtime lifecycle leaks behind the hosted full-suite stalls whose apparent boundary moved between unrelated Appcast, Workspace, Agent, and worktree-card tests.

This deliberately treats the observed test name as the victim, not the owner. Hosted evidence included main run `27490738486` attempts and PR #204 run `27490861374`: the suite stopped at different boundaries, while process samples showed XCTest waiting with surviving app runtime tasks rather than a repeat of the Git pipe issue.

## Root causes fixed

Four ownership paths could survive the test that created them:

1. **ACP / AgentMode runtime ownership** — terminal reusable fake controllers and hosts were not always prepared for window close or shut down, leaving provider runtime work alive after lifecycle tests completed.
2. **Codex polling ownership** — per-window AgentMode, API Settings, and Context Builder subscriptions could retain their owners across infinite model streams, preventing the final-subscriber client stop path from running.
3. **Window/workspace lifecycle ownership** — unregistering a test window only ran synchronous `beginClose`; tests did not consistently await the production `WindowState.tearDown()` path, so MCP/session/workspace cleanup could continue after the test.
4. **Git/workspace periodic ownership** — infinite refresh/polling tasks upgraded weak owners before entering their loops, effectively retaining `GitViewModel` / `WorkspaceManagerViewModel` while suspended or refreshing.

## Changes

- Make window close disposal explicit and idempotent for AgentMode, API Settings, Context Builder, Codex polling, workspace polling, and Git refresh work.
- Reacquire weak periodic-loop owners per iteration so suspended loops cannot own their view model indefinitely.
- Cancel API Settings load/validation between async phases after close.
- Register lifecycle-test hosts/controllers and guarantee full ACP/window teardown without relying on `cancelRun` after terminal state.
- Track real windows in `WindowCloseCoordinatorDecisionTests`, preserve unregister assertions, and await full `tearDown()` in async test teardown.
- Isolate test window construction from the developer's global MCP auto-start preference.

## Deterministic regression coverage

- Codex polling subscriber removal and owned-client stop.
- AgentMode approval-store and model-subscription disposal.
- ACP/controller process exit and lifecycle-host cleanup.
- API Settings close-during-load gating.
- Window unregister plus full async teardown.
- Git refresh and workspace polling deallocation without explicit close.

Focused stress included repeated lifecycle/window subsets, 25 final runs of `WindowCloseCoordinatorDecisionTests` (8/8 each), and earlier 50x/25x ownership stress lanes. The final 25-run window stress produced no `MCPStartup` or `lockUnavailable` lines.

## Validation

- Independent exact-commit review: no findings; full suite passed; no lingering xctest.
- Three final coordinated full-suite runs completed and exited normally:
  - 1,688 tests, 1 skipped, 0 failures in 186.853s
  - 1,688 tests, 1 skipped, 0 failures in 184.139s
  - 1,688 tests, 1 skipped, 0 failures in the immediate push preflight
- `make dev-lint`
- `make dev-swift-build PRODUCT=RepoPrompt`
- `make guardrails`
- commit and push contribution preflights, including staged/outgoing secret scans

## Residual diagnostics

Some full-suite logs still contain late/buffered `lockUnavailable` messages from other tests competing for the shared debug MCP bootstrap socket. These are harmless contention diagnostics: the relevant tests pass, the complete XCTest process exits, no child process remains, and the focused window lifecycle stress is clean. No Git pipe code is changed here.
