### PR TITLE
Fix Git cancellation output-drain stall

### DIFF
--- a/Sources/RepoPrompt/Infrastructure/VCS/GitProcessAdmissionController.swift
+++ b/Sources/RepoPrompt/Infrastructure/VCS/GitProcessAdmissionController.swift
@@ -17,6 +17,13 @@ actor GitProcessAdmissionController {
         let queueWaitMicroseconds: Int
     }
 
+    struct Snapshot: Equatable {
+        let activeGlobal: Int
+        let activeByRepository: [String: Int]
+        let activeLeaseCount: Int
+        let waiterCount: Int
+    }
+
     private struct Waiter {
         let id: UUID
         let repositoryKey: String
@@ -74,6 +81,15 @@ actor GitProcessAdmissionController {
         let repositoryCount = max(0, (activeByRepository[lease.repositoryKey] ?? 1) - 1)
         activeByRepository[lease.repositoryKey] = repositoryCount == 0 ? nil : repositoryCount
         drainWaiters()
+    }
+
+    func snapshot() -> Snapshot {
+        Snapshot(
+            activeGlobal: activeGlobal,
+            activeByRepository: activeByRepository,
+            activeLeaseCount: activeLeaseIDs.count,
+            waiterCount: waiters.count
+        )
     }
 
     private func canAcquire(repositoryKey: String) -> Bool {

--- a/Sources/RepoPrompt/Infrastructure/VCS/GitService.swift
+++ b/Sources/RepoPrompt/Infrastructure/VCS/GitService.swift
@@ -49,7 +49,17 @@ actor GitService {
 
     private let worktreeMutationCoordinator = GitWorktreeMutationCoordinator()
     private let inheritedProcessEnvironment = ProcessInfo.processInfo.environment
+    private let gitExecutableURL: URL
+    private let processAdmissionController: GitProcessAdmissionController
     private var preparedBaseProcessEnvironment: [String: String]?
+
+    init(
+        gitExecutableURL: URL = URL(fileURLWithPath: "/usr/bin/git"),
+        processAdmissionController: GitProcessAdmissionController = .shared
+    ) {
+        self.gitExecutableURL = gitExecutableURL
+        self.processAdmissionController = processAdmissionController
+    }
 
     struct UncommittedFile: Equatable {
         let path: String
@@ -2344,7 +2354,7 @@ actor GitService {
         let budgetURL = budgetRepoURL ?? repoURL
         let repositoryKey = getLayout(for: budgetURL)?.commonDir.standardizedFileURL.path
             ?? budgetURL.standardizedFileURL.path
-        let lease = try await GitProcessAdmissionController.shared.acquire(repositoryKey: repositoryKey)
+        let lease = try await processAdmissionController.acquire(repositoryKey: repositoryKey)
         do {
             try Task.checkCancellation()
             let result = try await runAdmittedGit(
@@ -2355,10 +2365,10 @@ actor GitService {
                 diagnosticRepositoryPath: budgetURL.standardizedFileURL.path,
                 processQueueWaitMicroseconds: lease.queueWaitMicroseconds
             )
-            await GitProcessAdmissionController.shared.release(lease)
+            await processAdmissionController.release(lease)
             return result
         } catch {
-            await GitProcessAdmissionController.shared.release(lease)
+            await processAdmissionController.release(lease)
             throw error
         }
     }
@@ -2374,7 +2384,7 @@ actor GitService {
         let process = Process()
         let timeoutController = GitProcessTimeoutController()
         let commandRecorder = MCPToolWorkCountDiagnostics.gitCommandRecorder()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+        process.executableURL = gitExecutableURL
         process.arguments = args
         process.currentDirectoryURL = repoURL
         process.environment = environment
@@ -2520,15 +2530,12 @@ actor GitService {
             }
         }, onCancel: {
             timeoutController.cancel()
-            // Stop callbacks and terminate before waiting on a drain lock. A callback may be
-            // blocked in FileHandle.availableData until the child closes its pipe.
-            outPipe.fileHandleForReading.readabilityHandler = nil
-            errPipe.fileHandleForReading.readabilityHandler = nil
+            // Keep stdout/stderr drains active until termination. A child may flush more than
+            // pipe capacity while handling SIGTERM; closing the drains here can block that
+            // flush forever and prevent the termination handler from reaping the process.
             if process.isRunning {
                 process.terminate()
             }
-            outDrain.cancel()
-            errDrain.cancel()
         })
     }
 

--- a/Sources/RepoPrompt/Infrastructure/VCS/GitService.swift
+++ b/Sources/RepoPrompt/Infrastructure/VCS/GitService.swift
@@ -51,14 +51,17 @@ actor GitService {
     private let inheritedProcessEnvironment = ProcessInfo.processInfo.environment
     private let gitExecutableURL: URL
     private let processAdmissionController: GitProcessAdmissionController
+    private let processTerminationGrace: Duration
     private var preparedBaseProcessEnvironment: [String: String]?
 
     init(
         gitExecutableURL: URL = URL(fileURLWithPath: "/usr/bin/git"),
-        processAdmissionController: GitProcessAdmissionController = .shared
+        processAdmissionController: GitProcessAdmissionController = .shared,
+        processTerminationGrace: Duration = GitService.gitProcessTerminationGrace
     ) {
         self.gitExecutableURL = gitExecutableURL
         self.processAdmissionController = processAdmissionController
+        self.processTerminationGrace = processTerminationGrace
     }
 
     struct UncommittedFile: Equatable {
@@ -2383,6 +2386,7 @@ actor GitService {
     ) async throws -> (String, String, Int32) {
         let process = Process()
         let timeoutController = GitProcessTimeoutController()
+        let lifecycleController = GitProcessLifecycleController()
         let commandRecorder = MCPToolWorkCountDiagnostics.gitCommandRecorder()
         process.executableURL = gitExecutableURL
         process.arguments = args
@@ -2430,7 +2434,7 @@ actor GitService {
             return buf
         }
 
-        return try await withTaskCancellationHandler(operation: {
+        let result = try await withTaskCancellationHandler(operation: {
             try await withCheckedThrowingContinuation { continuation in
                 // Drain stdout
                 outPipe.fileHandleForReading.readabilityHandler = { handle in
@@ -2446,6 +2450,7 @@ actor GitService {
                 }
 
                 process.terminationHandler = { proc in
+                    lifecycleController.didTerminate()
                     timeoutController.cancel()
 
                     // Stop handlers to break strong reference cycles
@@ -2476,15 +2481,26 @@ actor GitService {
                 }
 
                 do {
+                    try lifecycleController.checkCancellationBeforeSpawn()
                     let spawnStart = DispatchTime.now().uptimeNanoseconds
                     try process.run()
                     let processIdentifier = process.processIdentifier
-                    timeoutController.schedule(
+                    let spawnState = lifecycleController.didSpawn(
                         process: process,
                         processIdentifier: processIdentifier,
-                        timeout: Self.gitProcessTimeout,
-                        terminationGrace: Self.gitProcessTerminationGrace
+                        terminationGrace: processTerminationGrace
                     )
+                    if spawnState == .running {
+                        timeoutController.schedule(
+                            process: process,
+                            processIdentifier: processIdentifier,
+                            timeout: Self.gitProcessTimeout,
+                            terminationGrace: processTerminationGrace
+                        )
+                        if !lifecycleController.shouldKeepNormalTimeout() {
+                            timeoutController.cancel()
+                        }
+                    }
                     let spawnEnd = DispatchTime.now().uptimeNanoseconds
                     processMetrics.spawnMicroseconds = Int(
                         clamping: spawnEnd >= spawnStart ? (spawnEnd - spawnStart) / 1000 : 0
@@ -2525,7 +2541,7 @@ actor GitService {
                     errPipe.fileHandleForReading.readabilityHandler = nil
                     outDrain.cancel()
                     errDrain.cancel()
-                    continuation.resume(throwing: error)
+                    continuation.resume(throwing: lifecycleController.cancellationErrorIfRequested() ?? error)
                 }
             }
         }, onCancel: {
@@ -2533,10 +2549,13 @@ actor GitService {
             // Keep stdout/stderr drains active until termination. A child may flush more than
             // pipe capacity while handling SIGTERM; closing the drains here can block that
             // flush forever and prevent the termination handler from reaping the process.
-            if process.isRunning {
-                process.terminate()
-            }
+            lifecycleController.requestCancellation(
+                process: process,
+                terminationGrace: processTerminationGrace
+            )
         })
+        try Task.checkCancellation()
+        return result
     }
 
     static func shouldFallbackFromWorktreeListZError(_ stderr: String) -> Bool {
@@ -3168,6 +3187,136 @@ private final class GitProcessTimeoutController: @unchecked Sendable {
         defer { lock.unlock() }
         task?.cancel()
         task = nil
+    }
+}
+
+private final class GitProcessLifecycleController: @unchecked Sendable {
+    enum SpawnState: Equatable {
+        case running
+        case cancellationRequested
+        case terminated
+    }
+
+    private let lock = NSLock()
+    private var cancellationRequested = false
+    private var processIdentifier: pid_t?
+    private var terminated = false
+    private var cancellationEscalationTask: Task<Void, Never>?
+
+    func checkCancellationBeforeSpawn() throws {
+        lock.lock()
+        let shouldCancel = cancellationRequested
+        lock.unlock()
+        if shouldCancel {
+            throw CancellationError()
+        }
+    }
+
+    func didSpawn(
+        process: Process,
+        processIdentifier: pid_t,
+        terminationGrace: Duration
+    ) -> SpawnState {
+        lock.lock()
+        if terminated {
+            let wasCancelled = cancellationRequested
+            lock.unlock()
+            return wasCancelled ? .cancellationRequested : .terminated
+        }
+
+        self.processIdentifier = processIdentifier
+        let shouldTerminate = cancellationRequested
+        if shouldTerminate {
+            armCancellationEscalationLocked(
+                process: process,
+                processIdentifier: processIdentifier,
+                terminationGrace: terminationGrace
+            )
+        }
+        lock.unlock()
+
+        if shouldTerminate, process.isRunning {
+            process.terminate()
+        }
+        return shouldTerminate ? .cancellationRequested : .running
+    }
+
+    func requestCancellation(
+        process: Process,
+        terminationGrace: Duration
+    ) {
+        lock.lock()
+        cancellationRequested = true
+        let processIdentifier = terminated ? nil : processIdentifier
+        if let processIdentifier {
+            armCancellationEscalationLocked(
+                process: process,
+                processIdentifier: processIdentifier,
+                terminationGrace: terminationGrace
+            )
+        }
+        lock.unlock()
+
+        if processIdentifier != nil, process.isRunning {
+            process.terminate()
+        }
+    }
+
+    func shouldKeepNormalTimeout() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return !cancellationRequested && !terminated
+    }
+
+    func cancellationErrorIfRequested() -> CancellationError? {
+        lock.lock()
+        defer { lock.unlock() }
+        return cancellationRequested ? CancellationError() : nil
+    }
+
+    func didTerminate() {
+        lock.lock()
+        terminated = true
+        processIdentifier = nil
+        let escalationTask = cancellationEscalationTask
+        cancellationEscalationTask = nil
+        lock.unlock()
+        escalationTask?.cancel()
+    }
+
+    private func armCancellationEscalationLocked(
+        process: Process,
+        processIdentifier: pid_t,
+        terminationGrace: Duration
+    ) {
+        guard cancellationEscalationTask == nil else { return }
+        cancellationEscalationTask = Task.detached { [self] in
+            do {
+                try await Task.sleep(for: terminationGrace)
+            } catch {
+                return
+            }
+            sendCancellationKillIfNeeded(
+                process: process,
+                processIdentifier: processIdentifier
+            )
+        }
+    }
+
+    private func sendCancellationKillIfNeeded(
+        process: Process,
+        processIdentifier: pid_t
+    ) {
+        lock.lock()
+        defer { lock.unlock() }
+        guard cancellationRequested,
+              !terminated,
+              self.processIdentifier == processIdentifier,
+              process.isRunning
+        else {
+            return
+        }
+        _ = kill(processIdentifier, SIGKILL)
     }
 }
 

--- a/Tests/RepoPromptTests/MCP/AgentRunWorktreeStartTests.swift
+++ b/Tests/RepoPromptTests/MCP/AgentRunWorktreeStartTests.swift
@@ -186,6 +186,7 @@ final class AgentRunWorktreeStartTests: XCTestCase {
     func testManualFirstSendCanCreateAndBindNewWorktree() async throws {
         let fixture = try makeGitFixture()
         let window = try await makeWindow(root: fixture.repo)
+        defer { WindowStatesManager.shared.unregisterWindowState(window) }
         let viewModel = window.agentModeViewModel
         window.apiSettingsViewModel.isCodexConnected = true
         let sourceTabID = try XCTUnwrap(window.workspaceManager.activeWorkspace?.activeComposeTabID)
@@ -253,6 +254,7 @@ final class AgentRunWorktreeStartTests: XCTestCase {
     func testFreshLinkedManualFirstSendCanCreateAndBindNewWorktreeInPlace() async throws {
         let fixture = try makeGitFixture()
         let window = try await makeWindow(root: fixture.repo)
+        defer { WindowStatesManager.shared.unregisterWindowState(window) }
         let viewModel = window.agentModeViewModel
         window.apiSettingsViewModel.isCodexConnected = true
         let createdTabID = await viewModel.createAndActivateSessionTab()
@@ -331,6 +333,7 @@ final class AgentRunWorktreeStartTests: XCTestCase {
         let sibling = fixture.sandbox.appendingPathComponent("existing-ui-worktree", isDirectory: true)
         try runGit(["worktree", "add", "-b", "feature/existing-ui-\(fixture.suffix)", sibling.path, "HEAD"], cwd: fixture.repo)
         let window = try await makeWindow(root: fixture.repo)
+        defer { WindowStatesManager.shared.unregisterWindowState(window) }
         let viewModel = window.agentModeViewModel
         window.apiSettingsViewModel.isCodexConnected = true
         let sourceTabID = try XCTUnwrap(window.workspaceManager.activeWorkspace?.activeComposeTabID)

--- a/Tests/RepoPromptTests/Services/VCS/GitServiceCancellationTests.swift
+++ b/Tests/RepoPromptTests/Services/VCS/GitServiceCancellationTests.swift
@@ -1,0 +1,269 @@
+import Darwin
+import Foundation
+@testable import RepoPrompt
+import XCTest
+
+#if DEBUG
+    final class GitServiceCancellationTests: XCTestCase {
+        func testCancellationDrainsTerminatedChildBeforeReleasingAdmission() async throws {
+            let fixture = try GitCancellationFixture()
+            defer { fixture.cleanup() }
+            let admission = GitProcessAdmissionController(globalLimit: 1, perRepositoryLimit: 1)
+            let baseline = await admission.snapshot()
+            let git = GitService(
+                gitExecutableURL: fixture.executableURL,
+                processAdmissionController: admission
+            )
+
+            MCPToolWorkCountDiagnostics.resetForTesting()
+            let command = Task {
+                try await MCPToolWorkCountDiagnostics.withGitInvocation(operation: "cancel_drain") {
+                    try await git.findGitRoot(from: fixture.repo)
+                }
+            }
+            defer { command.cancel() }
+
+            let childPID = try await fixture.awaitReadyPID()
+            defer {
+                if kill(childPID, 0) == 0 {
+                    _ = kill(childPID, SIGKILL)
+                }
+            }
+
+            let completion = TestCompletionSignal()
+            Task {
+                _ = await command.result
+                completion.signal()
+            }
+
+            command.cancel()
+            let completed = await completion.wait(timeout: .seconds(15))
+            if !completed {
+                _ = kill(childPID, SIGKILL)
+                _ = await completion.wait(timeout: .seconds(5))
+                XCTFail("Cancelled Git command did not finish while the child flushed output after SIGTERM.")
+                return
+            }
+
+            switch await command.result {
+            case let .success(root):
+                XCTAssertEqual(root, fixture.expectedRoot)
+            case let .failure(error):
+                XCTAssertTrue(error is CancellationError, "Unexpected cancellation result: \(error)")
+            }
+
+            let snapshot = try XCTUnwrap(MCPToolWorkCountDiagnostics.debugSnapshots().git.last)
+            XCTAssertEqual(snapshot.commandCount, 1)
+            XCTAssertEqual(snapshot.outputBytes, fixture.expectedOutputByteCount)
+            let finalAdmission = await admission.snapshot()
+            XCTAssertEqual(finalAdmission, baseline)
+
+            errno = 0
+            XCTAssertEqual(kill(childPID, 0), -1)
+            XCTAssertEqual(errno, ESRCH, "Git subprocess was not reaped after cancellation.")
+        }
+    }
+
+    private final class GitCancellationFixture {
+        static let payloadByteCount = 4 * 1024 * 1024
+
+        let sandbox: URL
+        let repo: URL
+        let expectedRoot: URL
+        let executableURL: URL
+        let expectedOutputByteCount: Int
+
+        private let readyDescriptor: Int32
+
+        init() throws {
+            let sandbox = FileManager.default.temporaryDirectory
+                .appendingPathComponent("GitServiceCancellationTests-\(UUID().uuidString)", isDirectory: true)
+            let repo = sandbox.appendingPathComponent("repo", isDirectory: true).standardizedFileURL
+            let executableURL = sandbox.appendingPathComponent("git-stub")
+            let readyURL = sandbox.appendingPathComponent("ready.fifo")
+
+            try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
+            let pwd = try TestProcessRunner.run(
+                executableURL: URL(fileURLWithPath: "/bin/pwd"),
+                currentDirectoryURL: repo
+            )
+            guard pwd.terminationStatus == 0 else {
+                throw NSError(
+                    domain: "GitServiceCancellationTests.pwd",
+                    code: Int(pwd.terminationStatus),
+                    userInfo: [NSLocalizedDescriptionKey: pwd.outputText]
+                )
+            }
+            let expectedRoot = URL(
+                fileURLWithPath: pwd.outputText.trimmingCharacters(in: .whitespacesAndNewlines)
+            )
+            let expectedOutputByteCount = Self.payloadByteCount + expectedRoot.path.utf8.count + 1
+            guard mkfifo(readyURL.path, S_IRUSR | S_IWUSR) == 0 else {
+                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+            }
+
+            let readyDescriptor = Darwin.open(readyURL.path, O_RDWR | O_CLOEXEC)
+            guard readyDescriptor >= 0 else {
+                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+            }
+            var shouldCloseReadyDescriptor = true
+            defer {
+                if shouldCloseReadyDescriptor {
+                    _ = Darwin.close(readyDescriptor)
+                }
+            }
+
+            let sourceURL = sandbox.appendingPathComponent("git-stub.c")
+            let readyPathLiteral = try Self.cStringLiteral(readyURL.path)
+            let source = """
+            #include <errno.h>
+            #include <fcntl.h>
+            #include <signal.h>
+            #include <stdio.h>
+            #include <string.h>
+            #include <unistd.h>
+
+            static int write_all(int fd, const void *buffer, size_t count) {
+                const unsigned char *cursor = buffer;
+                while (count > 0) {
+                    ssize_t written = write(fd, cursor, count);
+                    if (written > 0) {
+                        cursor += written;
+                        count -= (size_t)written;
+                        continue;
+                    }
+                    if (written < 0 && errno == EINTR) {
+                        continue;
+                    }
+                    return -1;
+                }
+                return 0;
+            }
+
+            int main(void) {
+                sigset_t termination_set;
+                sigemptyset(&termination_set);
+                sigaddset(&termination_set, SIGTERM);
+                if (sigprocmask(SIG_BLOCK, &termination_set, NULL) != 0) {
+                    return 2;
+                }
+
+                int ready_fd = open(\(readyPathLiteral), O_WRONLY);
+                if (ready_fd < 0) {
+                    return 3;
+                }
+                char ready[64];
+                int ready_count = snprintf(ready, sizeof(ready), "%d\\n", getpid());
+                if (ready_count <= 0 || write_all(ready_fd, ready, (size_t)ready_count) != 0) {
+                    return 4;
+                }
+                close(ready_fd);
+
+                int received_signal = 0;
+                if (sigwait(&termination_set, &received_signal) != 0 || received_signal != SIGTERM) {
+                    return 5;
+                }
+
+                char chunk[64 * 1024];
+                memset(chunk, 'x', sizeof(chunk));
+                for (int index = 0; index < \(Self.payloadByteCount / (64 * 1024)); ++index) {
+                    if (write_all(STDERR_FILENO, chunk, sizeof(chunk)) != 0) {
+                        return 6;
+                    }
+                }
+
+                char cwd[4096];
+                if (getcwd(cwd, sizeof(cwd)) == NULL) {
+                    return 7;
+                }
+                if (write_all(STDOUT_FILENO, cwd, strlen(cwd)) != 0 ||
+                    write_all(STDOUT_FILENO, "\\n", 1) != 0) {
+                    return 8;
+                }
+                return 0;
+            }
+            """
+            try source.write(to: sourceURL, atomically: true, encoding: .utf8)
+            let compile = try TestProcessRunner.run(
+                executableURL: URL(fileURLWithPath: "/usr/bin/clang"),
+                arguments: [sourceURL.path, "-o", executableURL.path]
+            )
+            guard compile.terminationStatus == 0 else {
+                throw NSError(
+                    domain: "GitServiceCancellationTests.compile",
+                    code: Int(compile.terminationStatus),
+                    userInfo: [NSLocalizedDescriptionKey: compile.outputText]
+                )
+            }
+
+            self.sandbox = sandbox
+            self.repo = repo
+            self.expectedRoot = expectedRoot
+            self.executableURL = executableURL
+            self.expectedOutputByteCount = expectedOutputByteCount
+            self.readyDescriptor = readyDescriptor
+            shouldCloseReadyDescriptor = false
+        }
+
+        func cleanup() {
+            _ = Darwin.close(readyDescriptor)
+            try? FileManager.default.removeItem(at: sandbox)
+        }
+
+        func awaitReadyPID() async throws -> pid_t {
+            let descriptor = readyDescriptor
+            return try await withCheckedThrowingContinuation { continuation in
+                DispatchQueue.global(qos: .userInitiated).async {
+                    var pollDescriptor = pollfd(fd: descriptor, events: Int16(POLLIN), revents: 0)
+                    let pollResult = Darwin.poll(&pollDescriptor, 1, 5000)
+                    guard pollResult > 0, pollDescriptor.revents & Int16(POLLIN) != 0 else {
+                        let code = pollResult == 0 ? ETIMEDOUT : errno
+                        continuation.resume(throwing: POSIXError(POSIXErrorCode(rawValue: code) ?? .EIO))
+                        return
+                    }
+
+                    var buffer = [UInt8](repeating: 0, count: 64)
+                    let count = Darwin.read(descriptor, &buffer, buffer.count)
+                    guard count > 0,
+                          let text = String(bytes: buffer.prefix(Int(count)), encoding: .ascii),
+                          let pid = pid_t(text.trimmingCharacters(in: .whitespacesAndNewlines))
+                    else {
+                        continuation.resume(throwing: POSIXError(.EIO))
+                        return
+                    }
+                    continuation.resume(returning: pid)
+                }
+            }
+        }
+
+        private static func cStringLiteral(_ value: String) throws -> String {
+            let data = try JSONEncoder().encode(value)
+            return String(decoding: data, as: UTF8.self)
+        }
+    }
+
+    private final class TestCompletionSignal: @unchecked Sendable {
+        private let semaphore = DispatchSemaphore(value: 0)
+
+        func signal() {
+            semaphore.signal()
+        }
+
+        func wait(timeout: Duration) async -> Bool {
+            await withCheckedContinuation { continuation in
+                DispatchQueue.global(qos: .userInitiated).async {
+                    let result = self.semaphore.wait(timeout: .now() + timeout.timeInterval)
+                    continuation.resume(returning: result == .success)
+                }
+            }
+        }
+    }
+
+    private extension Duration {
+        var timeInterval: TimeInterval {
+            let components = components
+            return TimeInterval(components.seconds)
+                + TimeInterval(components.attoseconds) / 1_000_000_000_000_000_000
+        }
+    }
+#endif

--- a/Tests/RepoPromptTests/Services/VCS/GitServiceCancellationTests.swift
+++ b/Tests/RepoPromptTests/Services/VCS/GitServiceCancellationTests.swift
@@ -37,6 +37,16 @@ import XCTest
             }
 
             command.cancel()
+            try await fixture.awaitOutputGate()
+            let heldAdmission = await admission.snapshot()
+            XCTAssertEqual(heldAdmission.activeGlobal, baseline.activeGlobal + 1)
+            XCTAssertEqual(heldAdmission.activeLeaseCount, baseline.activeLeaseCount + 1)
+            XCTAssertEqual(heldAdmission.waiterCount, baseline.waiterCount)
+            XCTAssertEqual(heldAdmission.activeByRepository.values.sorted(), [1])
+            let completedWhileGated = await completion.wait(timeout: .zero)
+            XCTAssertFalse(completedWhileGated, "Cancelled Git command completed before the gated child exited.")
+
+            try fixture.releaseChild()
             let completed = await completion.wait(timeout: .seconds(15))
             if !completed {
                 _ = kill(childPID, SIGKILL)
@@ -46,8 +56,8 @@ import XCTest
             }
 
             switch await command.result {
-            case let .success(root):
-                XCTAssertEqual(root, fixture.expectedRoot)
+            case .success:
+                XCTFail("Cancelled Git command returned success instead of CancellationError.")
             case let .failure(error):
                 XCTAssertTrue(error is CancellationError, "Unexpected cancellation result: \(error)")
             }
@@ -62,6 +72,59 @@ import XCTest
             XCTAssertEqual(kill(childPID, 0), -1)
             XCTAssertEqual(errno, ESRCH, "Git subprocess was not reaped after cancellation.")
         }
+
+        func testCancellationEscalatesWhenTerminatedChildDoesNotExit() async throws {
+            let fixture = try GitCancellationFixture()
+            defer { fixture.cleanup() }
+            let admission = GitProcessAdmissionController(globalLimit: 1, perRepositoryLimit: 1)
+            let baseline = await admission.snapshot()
+            let git = GitService(
+                gitExecutableURL: fixture.executableURL,
+                processAdmissionController: admission,
+                processTerminationGrace: .seconds(2)
+            )
+
+            let command = Task {
+                try await git.findGitRoot(from: fixture.repo)
+            }
+            defer { command.cancel() }
+
+            let childPID = try await fixture.awaitReadyPID()
+            defer {
+                if kill(childPID, 0) == 0 {
+                    _ = kill(childPID, SIGKILL)
+                }
+            }
+
+            let completion = TestCompletionSignal()
+            Task {
+                _ = await command.result
+                completion.signal()
+            }
+
+            command.cancel()
+            try await fixture.awaitOutputGate()
+            let completed = await completion.wait(timeout: .seconds(5))
+            if !completed {
+                _ = kill(childPID, SIGKILL)
+                _ = await completion.wait(timeout: .seconds(5))
+                XCTFail("Cancelled Git command did not complete after the SIGKILL grace period.")
+                return
+            }
+
+            switch await command.result {
+            case .success:
+                XCTFail("Cancelled Git command returned success instead of escalating to SIGKILL.")
+            case let .failure(error):
+                XCTAssertTrue(error is CancellationError, "Unexpected escalation result: \(error)")
+            }
+
+            let finalAdmission = await admission.snapshot()
+            XCTAssertEqual(finalAdmission, baseline)
+            errno = 0
+            XCTAssertEqual(kill(childPID, 0), -1)
+            XCTAssertEqual(errno, ESRCH, "Escalated Git subprocess was not reaped.")
+        }
     }
 
     private final class GitCancellationFixture {
@@ -69,11 +132,12 @@ import XCTest
 
         let sandbox: URL
         let repo: URL
-        let expectedRoot: URL
         let executableURL: URL
         let expectedOutputByteCount: Int
 
         private let readyDescriptor: Int32
+        private let outputGateDescriptor: Int32
+        private let releaseDescriptor: Int32
 
         init() throws {
             let sandbox = FileManager.default.temporaryDirectory
@@ -81,6 +145,14 @@ import XCTest
             let repo = sandbox.appendingPathComponent("repo", isDirectory: true).standardizedFileURL
             let executableURL = sandbox.appendingPathComponent("git-stub")
             let readyURL = sandbox.appendingPathComponent("ready.fifo")
+            let outputGateURL = sandbox.appendingPathComponent("output-gate.fifo")
+            let releaseURL = sandbox.appendingPathComponent("release.fifo")
+            var shouldRemoveSandbox = true
+            defer {
+                if shouldRemoveSandbox {
+                    try? FileManager.default.removeItem(at: sandbox)
+                }
+            }
 
             try FileManager.default.createDirectory(at: repo, withIntermediateDirectories: true)
             let pwd = try TestProcessRunner.run(
@@ -101,20 +173,40 @@ import XCTest
             guard mkfifo(readyURL.path, S_IRUSR | S_IWUSR) == 0 else {
                 throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
             }
-
-            let readyDescriptor = Darwin.open(readyURL.path, O_RDWR | O_CLOEXEC)
-            guard readyDescriptor >= 0 else {
+            guard mkfifo(outputGateURL.path, S_IRUSR | S_IWUSR) == 0,
+                  mkfifo(releaseURL.path, S_IRUSR | S_IWUSR) == 0
+            else {
                 throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
             }
-            var shouldCloseReadyDescriptor = true
+
+            let readyDescriptor = Darwin.open(readyURL.path, O_RDWR | O_CLOEXEC)
+            let outputGateDescriptor = Darwin.open(outputGateURL.path, O_RDWR | O_CLOEXEC)
+            let releaseDescriptor = Darwin.open(releaseURL.path, O_RDWR | O_CLOEXEC)
+            var shouldCloseDescriptors = true
             defer {
-                if shouldCloseReadyDescriptor {
-                    _ = Darwin.close(readyDescriptor)
+                if shouldCloseDescriptors {
+                    if readyDescriptor >= 0 {
+                        _ = Darwin.close(readyDescriptor)
+                    }
+                    if outputGateDescriptor >= 0 {
+                        _ = Darwin.close(outputGateDescriptor)
+                    }
+                    if releaseDescriptor >= 0 {
+                        _ = Darwin.close(releaseDescriptor)
+                    }
                 }
+            }
+            guard readyDescriptor >= 0,
+                  outputGateDescriptor >= 0,
+                  releaseDescriptor >= 0
+            else {
+                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
             }
 
             let sourceURL = sandbox.appendingPathComponent("git-stub.c")
             let readyPathLiteral = try Self.cStringLiteral(readyURL.path)
+            let outputGatePathLiteral = try Self.cStringLiteral(outputGateURL.path)
+            let releasePathLiteral = try Self.cStringLiteral(releaseURL.path)
             let source = """
             #include <errno.h>
             #include <fcntl.h>
@@ -180,6 +272,22 @@ import XCTest
                     write_all(STDOUT_FILENO, "\\n", 1) != 0) {
                     return 8;
                 }
+
+                int output_gate_fd = open(\(outputGatePathLiteral), O_WRONLY);
+                if (output_gate_fd < 0 ||
+                    write_all(output_gate_fd, "gated\\n", 6) != 0) {
+                    return 9;
+                }
+                close(output_gate_fd);
+
+                int release_fd = open(\(releasePathLiteral), O_RDONLY);
+                if (release_fd < 0) {
+                    return 10;
+                }
+                char release = 0;
+                while (read(release_fd, &release, 1) < 0 && errno == EINTR) {
+                }
+                close(release_fd);
                 return 0;
             }
             """
@@ -198,21 +306,48 @@ import XCTest
 
             self.sandbox = sandbox
             self.repo = repo
-            self.expectedRoot = expectedRoot
             self.executableURL = executableURL
             self.expectedOutputByteCount = expectedOutputByteCount
             self.readyDescriptor = readyDescriptor
-            shouldCloseReadyDescriptor = false
+            self.outputGateDescriptor = outputGateDescriptor
+            self.releaseDescriptor = releaseDescriptor
+            shouldCloseDescriptors = false
+            shouldRemoveSandbox = false
         }
 
         func cleanup() {
             _ = Darwin.close(readyDescriptor)
+            _ = Darwin.close(outputGateDescriptor)
+            _ = Darwin.close(releaseDescriptor)
             try? FileManager.default.removeItem(at: sandbox)
         }
 
         func awaitReadyPID() async throws -> pid_t {
-            let descriptor = readyDescriptor
-            return try await withCheckedThrowingContinuation { continuation in
+            let data = try await readSignal(from: readyDescriptor)
+            guard let text = String(data: data, encoding: .ascii),
+                  let pid = pid_t(text.trimmingCharacters(in: .whitespacesAndNewlines))
+            else {
+                throw POSIXError(.EIO)
+            }
+            return pid
+        }
+
+        func awaitOutputGate() async throws {
+            let data = try await readSignal(from: outputGateDescriptor)
+            guard data == Data("gated\n".utf8) else {
+                throw POSIXError(.EIO)
+            }
+        }
+
+        func releaseChild() throws {
+            var release: UInt8 = 1
+            guard Darwin.write(releaseDescriptor, &release, 1) == 1 else {
+                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+            }
+        }
+
+        private func readSignal(from descriptor: Int32) async throws -> Data {
+            try await withCheckedThrowingContinuation { continuation in
                 DispatchQueue.global(qos: .userInitiated).async {
                     var pollDescriptor = pollfd(fd: descriptor, events: Int16(POLLIN), revents: 0)
                     let pollResult = Darwin.poll(&pollDescriptor, 1, 5000)
@@ -224,14 +359,11 @@ import XCTest
 
                     var buffer = [UInt8](repeating: 0, count: 64)
                     let count = Darwin.read(descriptor, &buffer, buffer.count)
-                    guard count > 0,
-                          let text = String(bytes: buffer.prefix(Int(count)), encoding: .ascii),
-                          let pid = pid_t(text.trimmingCharacters(in: .whitespacesAndNewlines))
-                    else {
+                    guard count > 0 else {
                         continuation.resume(throwing: POSIXError(.EIO))
                         return
                     }
-                    continuation.resume(returning: pid)
+                    continuation.resume(returning: Data(buffer.prefix(Int(count))))
                 }
             }
         }


### PR DESCRIPTION
## Problem

A sampled residual full-suite stall left this subprocess alive after its test/window had ended:

`GitStatusActor.refreshGitWorktreeContexts → VCSService.listGitWorktrees → GitService.runAdmittedGit`

The child was `git worktree list --porcelain -z`, blocked in:

`std::ostream::flush → fflush → write`

The moving ownership boundary was cancellation cleanup in `GitService`: `onCancel` cleared the stdout/stderr readability handlers and cancelled/closed the duplicate nonblocking drains *before* sending SIGTERM. A child that flushed more than pipe capacity while handling termination could then block forever. The existing termination handler owns the other side of that boundary: final handler removal, tail drainage, collector completion, process reaping, continuation resumption, and the subsequent admission-lease release. Premature cancellation cleanup could therefore strand the child, continuation, and admission lease together.

## Change

- Preserve active stdout/stderr drains on cancellation and leave final drain/collector/reap cleanup with the termination handler.
- Add a locked cancellation/process lifecycle state around spawn:
  - check cancellation immediately before `process.run()`;
  - publish the captured PID immediately after spawn;
  - route cancellation that lands between those checks through the same termination path.
- Keep the normal 120-second timeout controller separate from cancellation. Cancellation now arms a fresh grace-period escalation tied to the captured PID: SIGTERM first, then SIGKILL if that exact process is still running. The cancellation escalation is cancelled only when the termination handler observes process termination.
- After termination, output collection, and continuation resumption, call `Task.checkCancellation()` so a cancelled Git operation cannot return success after drain/reap completes.
- Add narrow Git executable/admission/grace injection plus an admission snapshot so the real admitted process path can be tested deterministically.
- Add missing `WindowStatesManager` unregister defers to the three confirmed `AgentRunWorktreeStartTests` registrations that lacked teardown.

## Regression coverage

`GitServiceCancellationTests` builds a controllable C Git stub that:

1. blocks SIGTERM and reports its PID through a FIFO;
2. synchronously receives cancellation/SIGTERM via `sigwait`;
3. writes exactly 4 MiB to stderr (beyond pipe capacity) and a valid root to stdout;
4. signals a second FIFO only after those writes have drained;
5. remains gated on a release FIFO before exit.

The primary regression uses FIFO/semaphore synchronization rather than staging sleeps and asserts:

- the child reaches the post-capacity output gate after cancellation;
- while the child is deliberately gated, the Git admission lease remains active and the operation has not completed;
- after release, the operation completes specifically with `CancellationError`;
- the exact stdout+stderr byte count was drained;
- the subprocess has been reaped (`ESRCH`);
- admission returns exactly to its baseline only after release/reap.

A second regression leaves the child gated and verifies the fresh cancellation grace path escalates to SIGKILL, still returns `CancellationError`, reaps the subprocess, and restores admission.

### Known-bad discrimination

- Removing the post-reap `Task.checkCancellation()` made both regressions fail because the cancelled commands returned success (`9bf9a83f-2fba-46bb-92e7-1424f9c43161`).
- Restoring the old cancel-time handler/drain teardown prevented the helper from reaching its post-capacity gate and made both regressions fail within their bounded guards (`bf6c9d3a-e9ed-43c9-9dac-0cc21333baf6`).
- Restoring the fix passed the focused suite and 10/10 follow-up stress iterations. The original drain fix also passed 20/20 stress iterations before this review follow-up.

## Scope

- Git cancellation/process ownership only.
- Directly related `AgentRunWorktreeStartTests` registration teardown only.
- No Workspace store/watcher lifecycle changes.
- No MCP transport changes; no file overlap with the sibling Context Builder transport-closure work.

## Validation

Original implementation base: `origin/main` `057cf5d53619516bbbd260c73667aa9c2faacc94`  
Current merged base: `origin/main` `a59f67a49fe3de22bf95d5fb41965641b10aacba`  
Exact head: `5bc5c2df29db38594871b1f58261f444f0b7c038`

- `git diff --check` — passed
- `make dev-format` — passed (`614130f6-09ff-4176-9b83-0006f6c1eaec`)
- `make dev-test FILTER=GitServiceCancellationTests` — passed, 2 tests (`67e29941-d4de-4bdc-88b4-61e69797cd57`)
- cancellation regression stress — 10/10 coordinated follow-up iterations passed (plus the earlier 20/20 run)
- `make dev-test FILTER=GitProcess` — passed (`fe403214-95b9-42b8-98e8-f027ee5da765`)
- `make dev-lint` — passed (`3a9e8d88-e73c-465a-b168-f58c852b3df5`)
- `make dev-swift-build PRODUCT=RepoPrompt` — passed (`bed314ec-5e18-4ef6-9cc7-aac4d6d6e82f`)
- `make dev-test` — passed (`62e22cb8-4efd-4b9e-84df-9b0c2aa88d6d`)
- `make guardrails` — passed
- commit preflight — passed; staged-index secret scan clean
- push preflight — passed; outgoing-range secret scan clean; repeated lint/full tests/product build passed (`e004f902-ab76-43ff-8fa9-82352953aebe`, `f32913c2-082a-4e00-a258-9ca45a35a74c`, `c5256b20-26cf-450d-92c2-c1cda023bb86`)

### Post-`main` merge validation

- normal merge commit: `5bc5c2df29db38594871b1f58261f444f0b7c038`
- verified no merge delta in the four PR-owned files; reviewed cancellation/drain changes remained unchanged
- `make dev-test FILTER=GitServiceCancellationTests` — passed, 2 tests (`d199b90f-a28d-4412-b36b-97cf5ede5f9e`)
- `make dev-test FILTER=WindowStateDisplayedTitleTests` — passed, 2 tests (`c44c9f8b-73d1-4720-806d-2e59eef79675`)
- push preflight — passed on final clean retry; lint (`505d4e6d-147b-4fae-acfb-2df56ed98b9c`), full tests (`afe4299d-a85f-4db1-a77c-1ba4ed19e2cf`), and RepoPrompt build (`0d193bb2-f2a3-43e3-a10d-8a87d18c6d1b`) all passed
- two earlier full-suite attempts were canceled after nondeterministically stalling at the boundary between the two newly merged window-title tests; both candidate suites passed immediately in isolation, samples/logs were preserved, and no unrelated test changes were made

Live smoke was not run because the CE debug app was not running and this headless process-ownership change did not justify an unapproved visible app launch.

Do not merge until coordinated.

