### PR TITLE
Fix Context Builder MCP response teardown race

### DIFF
--- a/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderAgentViewModel.swift
+++ b/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderAgentViewModel.swift
@@ -2585,6 +2585,11 @@ final class ContextBuilderAgentViewModel: ObservableObject {
 
         let finalizedConnections = await ContextBuilderChildConnectionFinalizer.finalize(
             connectionIDs: agentConnections,
+            awaitResponseDeliveryDrain: { cid in
+                await ServerNetworkManager.shared.waitUntilResponseDeliveryDrained(
+                    for: cid
+                )
+            },
             commitContext: { [weak self, weak record] cid in
                 guard let self, let record,
                       activeAgentRuns.contains(runID),

--- a/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderRunLifecycle.swift
+++ b/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderRunLifecycle.swift
@@ -37,6 +37,7 @@ enum ContextBuilderRunWaiterResolution {
 /// Termination completion is joined before connection/run mappings are removed.
 @MainActor
 enum ContextBuilderChildConnectionFinalizer {
+    typealias AwaitResponseDeliveryDrain = @MainActor (_ connectionID: UUID) async -> Bool
     typealias RequestTermination = @MainActor (_ connectionID: UUID) -> Task<Void, Never>
     typealias CommitContext = @MainActor (_ connectionID: UUID) async -> Bool
     typealias BeforeTerminationRequest = @MainActor () async -> Void
@@ -45,6 +46,7 @@ enum ContextBuilderChildConnectionFinalizer {
 
     static func finalize(
         connectionIDs: [UUID],
+        awaitResponseDeliveryDrain: AwaitResponseDeliveryDrain,
         commitContext: CommitContext,
         beforeTerminationRequest: BeforeTerminationRequest,
         requestTermination: RequestTermination,
@@ -52,6 +54,7 @@ enum ContextBuilderChildConnectionFinalizer {
         cleanupMapping: CleanupMapping
     ) async -> Bool {
         for connectionID in connectionIDs {
+            guard await awaitResponseDeliveryDrain(connectionID) else { return false }
             guard await commitContext(connectionID) else { return false }
         }
 

--- a/Sources/RepoPrompt/Infrastructure/MCP/BootstrapSocketConnectionManager.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/BootstrapSocketConnectionManager.swift
@@ -286,6 +286,10 @@ actor BootstrapSocketConnectionManager: MCPServerConnection {
         await transport.ingressSnapshot()
     }
 
+    func waitUntilResponseDeliveryDrained() async -> Bool {
+        await transport.waitUntilResponseDeliveryDrained()
+    }
+
     private func updateState(_ newState: ConnectionStateSnapshot) {
         state = newState
     }

--- a/Sources/RepoPrompt/Infrastructure/MCP/MCPConnectionManager.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/MCPConnectionManager.swift
@@ -149,6 +149,7 @@ protocol MCPServerConnection: Actor {
     func isViableForRetention() -> Bool
     func secondsSinceLastActivity() async -> TimeInterval
     func transportIngressSnapshot() async -> MCPTransportIngressSnapshot?
+    func waitUntilResponseDeliveryDrained() async -> Bool
     /// Whether this is a legacy filesystem-backed connection (deprecated)
     nonisolated var isFilesystemBacked: Bool { get }
     /// Legacy: connection folder URL for filesystem connections
@@ -169,6 +170,12 @@ protocol MCPServerConnection: Actor {
     ///   - stage: Current stage name
     ///   - message: Human-readable message
     func sendProgress(tool: String, kind: RepoPromptProgressKind, stage: String, message: String) async
+}
+
+extension MCPServerConnection {
+    func waitUntilResponseDeliveryDrained() async -> Bool {
+        true
+    }
 }
 
 // MARK: - Dashboard Models
@@ -12411,6 +12418,11 @@ actor ServerNetworkManager {
     func hasInFlightCalls(for connectionID: UUID) async -> Bool {
         guard let limiters = callLimiters[connectionID] else { return false }
         return await limiters.hasInFlightCalls()
+    }
+
+    func waitUntilResponseDeliveryDrained(for connectionID: UUID) async -> Bool {
+        guard let connection = connections[connectionID] else { return false }
+        return await connection.waitUntilResponseDeliveryDrained()
     }
 
     #if DEBUG

--- a/Sources/RepoPrompt/Infrastructure/MCP/UnixSocketMCPTransport.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/UnixSocketMCPTransport.swift
@@ -152,6 +152,126 @@ private final class MCPTransportIngressGate: @unchecked Sendable {
     }
 }
 
+/// Tracks request/response publication at the socket boundary so lifecycle cleanup can
+/// wait for completed writes rather than closing after a handler merely returns.
+final class MCPTransportResponseDeliveryGate: @unchecked Sendable {
+    struct Snapshot {
+        let pendingRequestCount: Int
+        let waiterCount: Int
+        let isTerminal: Bool
+    }
+
+    private let lock = NSLock()
+    private var pendingRequestIDs: Set<JSONRPCBridgeID> = []
+    private var waiters: [CheckedContinuation<Bool, Never>] = []
+    private var isTerminal = false
+
+    func recordAcceptedClientFrame(_ frame: Data) {
+        let requestIDs = JSONRPCBridgeFrameInspector.inspectPermissively(
+            frame,
+            direction: .clientToServer
+        ).compactMap { message -> JSONRPCBridgeID? in
+            guard message.kind == .request,
+                  let id = message.id,
+                  id != .null
+            else {
+                return nil
+            }
+            return id
+        }
+        guard !requestIDs.isEmpty else { return }
+
+        lock.lock()
+        if !isTerminal {
+            pendingRequestIDs.formUnion(requestIDs)
+        }
+        lock.unlock()
+    }
+
+    func recordDeliveredServerFrame(_ frame: Data) {
+        let responseIDs = JSONRPCBridgeFrameInspector.inspectPermissively(
+            frame,
+            direction: .serverToClient
+        ).compactMap { message -> JSONRPCBridgeID? in
+            guard message.kind == .response,
+                  let id = message.id,
+                  id != .null
+            else {
+                return nil
+            }
+            return id
+        }
+        guard !responseIDs.isEmpty else { return }
+
+        let continuations: [CheckedContinuation<Bool, Never>]
+        lock.lock()
+        pendingRequestIDs.subtract(responseIDs)
+        if !isTerminal, pendingRequestIDs.isEmpty {
+            continuations = waiters
+            waiters.removeAll()
+        } else {
+            continuations = []
+        }
+        lock.unlock()
+        continuations.forEach { $0.resume(returning: true) }
+    }
+
+    func waitUntilDrained() async -> Bool {
+        await withCheckedContinuation { continuation in
+            let immediateResult: Bool?
+            lock.lock()
+            if isTerminal {
+                immediateResult = false
+            } else if pendingRequestIDs.isEmpty {
+                immediateResult = true
+            } else {
+                waiters.append(continuation)
+                immediateResult = nil
+            }
+            lock.unlock()
+
+            if let immediateResult {
+                continuation.resume(returning: immediateResult)
+            }
+        }
+    }
+
+    func reset() {
+        let continuations: [CheckedContinuation<Bool, Never>]
+        lock.lock()
+        continuations = waiters
+        waiters.removeAll()
+        pendingRequestIDs.removeAll()
+        isTerminal = false
+        lock.unlock()
+        continuations.forEach { $0.resume(returning: false) }
+    }
+
+    func close() {
+        let continuations: [CheckedContinuation<Bool, Never>]
+        lock.lock()
+        guard !isTerminal else {
+            lock.unlock()
+            return
+        }
+        isTerminal = true
+        continuations = waiters
+        waiters.removeAll()
+        lock.unlock()
+        continuations.forEach { $0.resume(returning: false) }
+    }
+
+    func snapshot() -> Snapshot {
+        lock.lock()
+        defer { lock.unlock() }
+        return Snapshot(
+            pendingRequestCount: pendingRequestIDs.count,
+            waiterCount: waiters.count,
+            isTerminal: isTerminal
+        )
+    }
+}
+
 /// A Transport implementation using UNIX domain sockets for local MCP communication.
 ///
 /// This transport connects to a UNIX socket created by the CLI within a connection folder.
@@ -258,6 +378,7 @@ public actor UnixSocketMCPTransport: Transport {
     private var fdGeneration: UInt64 = 0
 
     private var lastActivityTime: Date?
+    private let responseDeliveryGate = MCPTransportResponseDeliveryGate()
 
     /// Connection timeout when waiting for socket to appear and accept connections
     private let connectionTimeout: TimeInterval = 30.0
@@ -495,6 +616,7 @@ public actor UnixSocketMCPTransport: Transport {
             )
             throw error
         }
+        responseDeliveryGate.recordDeliveredServerFrame(framed)
         lastActivityTime = Date()
         #if DEBUG
             if recordedResponses.isEmpty {
@@ -581,9 +703,14 @@ public actor UnixSocketMCPTransport: Transport {
         return Date().timeIntervalSince(lastActivityTime)
     }
 
+    func waitUntilResponseDeliveryDrained() async -> Bool {
+        await responseDeliveryGate.waitUntilDrained()
+    }
+
     // MARK: - Private Implementation
 
     private func prepareForConnectionAttempt() {
+        responseDeliveryGate.reset()
         isStopping = false
         if streamFinished || closeSignaled {
             inboundChannel = InboundChannel(capacity: receiveBufferCapacity)
@@ -678,6 +805,7 @@ public actor UnixSocketMCPTransport: Transport {
     /// avoid a stale callback closing a reused descriptor number.
     private func tearDownSocket(error proposedError: Swift.Error?) {
         guard !streamFinished else { return }
+        responseDeliveryGate.close()
         #if DEBUG
             if let timelineConnectionID {
                 MCPRequestTimelineRegistry.shared.removeConnection(
@@ -999,6 +1127,7 @@ public actor UnixSocketMCPTransport: Transport {
             logger: log,
             onFrame: { [weak self] frame in
                 guard let self else { return }
+                responseDeliveryGate.recordAcceptedClientFrame(frame)
                 switch inboundChannel.gate.offer(frame, to: inboundChannel.continuation) {
                 case .accepted:
                     #if DEBUG

--- a/Tests/RepoPromptTests/ContextBuilder/ContextBuilderRunLifecycleTests.swift
+++ b/Tests/RepoPromptTests/ContextBuilder/ContextBuilderRunLifecycleTests.swift
@@ -60,6 +60,11 @@ final class ContextBuilderRunLifecycleTests: XCTestCase {
         let finalization = Task { @MainActor in
             await ContextBuilderChildConnectionFinalizer.finalize(
                 connectionIDs: [connectionID],
+                awaitResponseDeliveryDrain: { drainedID in
+                    XCTAssertEqual(drainedID, connectionID)
+                    events.append("response_delivery_drained")
+                    return true
+                },
                 commitContext: { committedID in
                     XCTAssertEqual(committedID, connectionID)
                     events.append("context_committed")
@@ -88,6 +93,7 @@ final class ContextBuilderRunLifecycleTests: XCTestCase {
 
         await terminationGate.waitUntilArrived()
         XCTAssertEqual(events, [
+            "response_delivery_drained",
             "context_committed",
             "before_termination_request",
             "termination_requested",
@@ -100,6 +106,62 @@ final class ContextBuilderRunLifecycleTests: XCTestCase {
         XCTAssertTrue(didFinalize)
         XCTAssertEqual(cleanupCount, 1)
         XCTAssertEqual(events, [
+            "response_delivery_drained",
+            "context_committed",
+            "before_termination_request",
+            "termination_requested",
+            "termination_join",
+            "mapping_cleaned"
+        ])
+    }
+
+    func testSuccessfulFinalizationWaitsForResponseDeliveryBeforeCommit() async {
+        let connectionID = UUID()
+        let responseDeliveryGate = LifecycleTestGate()
+        var events: [String] = []
+
+        let finalization = Task { @MainActor in
+            await ContextBuilderChildConnectionFinalizer.finalize(
+                connectionIDs: [connectionID],
+                awaitResponseDeliveryDrain: { drainedID in
+                    XCTAssertEqual(drainedID, connectionID)
+                    events.append("drain_started")
+                    await responseDeliveryGate.arriveAndWait()
+                    events.append("drain_finished")
+                    return true
+                },
+                commitContext: { committedID in
+                    XCTAssertEqual(committedID, connectionID)
+                    events.append("context_committed")
+                    return true
+                },
+                beforeTerminationRequest: {
+                    events.append("before_termination_request")
+                },
+                requestTermination: { requestedID in
+                    XCTAssertEqual(requestedID, connectionID)
+                    events.append("termination_requested")
+                    return Task {}
+                },
+                beforeTerminationJoin: {
+                    events.append("termination_join")
+                },
+                cleanupMapping: { cleanedID in
+                    XCTAssertEqual(cleanedID, connectionID)
+                    events.append("mapping_cleaned")
+                }
+            )
+        }
+
+        await responseDeliveryGate.waitUntilArrived()
+        XCTAssertEqual(events, ["drain_started"])
+
+        await responseDeliveryGate.release()
+        let didFinalize = await finalization.value
+        XCTAssertTrue(didFinalize)
+        XCTAssertEqual(events, [
+            "drain_started",
+            "drain_finished",
             "context_committed",
             "before_termination_request",
             "termination_requested",
@@ -115,6 +177,7 @@ final class ContextBuilderRunLifecycleTests: XCTestCase {
 
         let didFinalize = await ContextBuilderChildConnectionFinalizer.finalize(
             connectionIDs: [connectionID],
+            awaitResponseDeliveryDrain: { _ in true },
             commitContext: { _ in false },
             beforeTerminationRequest: {
                 XCTFail("Termination phase must not start without committed context ownership")
@@ -198,6 +261,7 @@ final class ContextBuilderRunLifecycleTests: XCTestCase {
 
             let didFinalize = await ContextBuilderChildConnectionFinalizer.finalize(
                 connectionIDs: [connectionID],
+                awaitResponseDeliveryDrain: { _ in true },
                 commitContext: { committedID in
                     await window.mcpServer.commitAndClearTabContext(
                         connectionID: committedID,

--- a/Tests/RepoPromptTests/MCP/Control/PersistentMCPResponseDeliveryTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/PersistentMCPResponseDeliveryTests.swift
@@ -6,6 +6,48 @@ import RepoPromptShared
 import XCTest
 
 final class PersistentMCPResponseDeliveryTests: XCTestCase {
+    func testResponseDeliveryDrainWaitsForMatchingResponseWrite() async {
+        let gate = MCPTransportResponseDeliveryGate()
+        gate.recordAcceptedClientFrame(request(id: 808))
+        XCTAssertEqual(gate.snapshot().pendingRequestCount, 1)
+
+        let waitTask = Task {
+            await gate.waitUntilDrained()
+        }
+        for _ in 0 ..< 100 where gate.snapshot().waiterCount == 0 {
+            await Task.yield()
+        }
+        XCTAssertEqual(gate.snapshot().waiterCount, 1)
+
+        gate.recordDeliveredServerFrame(response(id: 909))
+        XCTAssertEqual(gate.snapshot().pendingRequestCount, 1)
+        XCTAssertEqual(gate.snapshot().waiterCount, 1)
+
+        gate.recordDeliveredServerFrame(response(id: 808))
+        let didDrain = await waitTask.value
+        XCTAssertTrue(didDrain)
+        XCTAssertEqual(gate.snapshot().pendingRequestCount, 0)
+        XCTAssertEqual(gate.snapshot().waiterCount, 0)
+    }
+
+    func testResponseDeliveryDrainFailsWhenTransportClosesWithOutstandingRequest() async {
+        let gate = MCPTransportResponseDeliveryGate()
+        gate.recordAcceptedClientFrame(request(id: 818))
+
+        let waitTask = Task {
+            await gate.waitUntilDrained()
+        }
+        for _ in 0 ..< 100 where gate.snapshot().waiterCount == 0 {
+            await Task.yield()
+        }
+        XCTAssertEqual(gate.snapshot().waiterCount, 1)
+
+        gate.close()
+        let didDrain = await waitTask.value
+        XCTAssertFalse(didDrain)
+        XCTAssertTrue(gate.snapshot().isTerminal)
+    }
+
     func testProxyHalfCloseDrainsResponseAfterFormerGraceCheckpoint() async throws {
         var sockets = [Int32](repeating: -1, count: 2)
         var stdinPipe = [Int32](repeating: -1, count: 2)


### PR DESCRIPTION
## Summary

Prevent Context Builder child MCP teardown from closing its Unix socket before the final JSON-RPC response has actually been written.

## Intermittent failure evidence

The parent-session reproduction selected roughly 87k tokens during `context_builder response_type=plan`, then the RepoPrompt MCP transport closed while larger selection slices were being added. Follow-up `workspace_context` / `manage_selection` calls failed with `Transport closed`, so no export was returned.

The persisted helper event for the original incident recorded:

- `socket_eof_with_outstanding_work`
- app process still alive at the failure timestamp
- no app crash report
- successful multi-megabyte `transport_write_completed` events in surrounding stress runs

Repeated baseline stress did not deterministically trigger the intermittent race, even with parallel Agent-thread Context Builder runs and selections exceeding 1M tokens. That ruled out a simple payload-size ceiling, stdout backpressure, process crash, or fixed client timeout and pointed to socket lifecycle ordering.

## Root cause

Context Builder considered the child run complete when the provider/tool handler returned. `ContextBuilderChildConnectionFinalizer` could then commit and terminate the child MCP connection immediately. The MCP request limiter covered handler execution, but not the MCP SDK's subsequent serialization and socket write of the final response. Termination could therefore close the UDS while the external helper ledger still had an outstanding request, producing EOF with outstanding work.

## Fix

- Track accepted client JSON-RPC request IDs at the Unix-socket boundary.
- Clear an ID only after the matching server response completes `writeAll` successfully.
- Add an event-driven response-delivery drain barrier to the connection manager.
- Make Context Builder finalization await that barrier before commit/termination.
- Fail drain waiters if the transport becomes terminal; no retries or arbitrary deadline increases.

No Workspace store lifecycle files are changed.

## Regression coverage

- Response-delivery gate waits for the matching response and ignores unrelated response IDs.
- Socket closure with an outstanding request fails the drain.
- Context Builder cannot commit or terminate its child connection before final response delivery drains.

## Validation

- `make dev-test FILTER=ContextBuilderRunLifecycleTests`
- `make dev-test FILTER=PersistentMCPResponseDeliveryTests`
- final push preflight `make dev-test` full suite: passed
- `make dev-swift-build PRODUCT=RepoPrompt`
- `make dev-swift-build PRODUCT=repoprompt-mcp`
- `make dev-lint`
- `make dev-build`
- `make dev-smoke`
- contribution commit and push preflights, guardrails, and secret scans

### Live patched-app stress

After a coordinated relaunch from this branch, two parallel external Agent Mode threads each invoked nested `context_builder response_type=plan` with export enabled, then performed same-turn/same-connection follow-up MCP calls and read the export:

- 109,878 selected tokens: export + `workspace_context` + `manage_selection` + `read_file` succeeded
- 115,405 selected tokens: export + `manage_selection` + `workspace_context` + `read_file` succeeded

The final diagnostics captured 108 request timelines and contained no `socket_eof_with_outstanding_work`, `transport_write_failed`, `connection_failed`, `Transport closed`, or terminal bridge-session event. All external Agent sessions were deleted afterward.
