### PR TITLE
Fix MCP transport close provenance for Codex clients

### DIFF
--- a/Sources/RepoPrompt/Infrastructure/MCP/BootstrapSocketConnectionManager.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/BootstrapSocketConnectionManager.swift
@@ -121,7 +121,7 @@ actor BootstrapSocketConnectionManager: MCPServerConnection {
         // Start close-watch task to clean up when socket closes
         closeWatchTask = Task { [weak self] in
             guard let self else { return }
-            for await _ in await transport.closed() {
+            for await closeSnapshot in await transport.closed() {
                 let id = connectionID
                 let ingressSnapshot = await transport.ingressSnapshot()
                 mcpConnectionLog("BootstrapSocketConnectionManager: transport closed for \(id)")
@@ -129,9 +129,13 @@ actor BootstrapSocketConnectionManager: MCPServerConnection {
                     connectionID: id,
                     clientName: _clientName,
                     sessionToken: sessionToken,
-                    snapshot: ingressSnapshot
+                    snapshot: ingressSnapshot,
+                    closeSnapshot: closeSnapshot
                 )
-                await parentManager.removeConnection(id)
+                await parentManager.removeConnection(
+                    id,
+                    context: MCPConnectionCloseContext(transport: closeSnapshot)
+                )
                 break
             }
         }
@@ -161,6 +165,8 @@ actor BootstrapSocketConnectionManager: MCPServerConnection {
         } catch {
             bootstrapLog.error("BootstrapSocketConnectionManager: start failed: \(error)")
             updateState(.failed(error))
+            closeWatchTask?.cancel()
+            closeWatchTask = nil
             await transport.disconnect()
             throw error
         }
@@ -220,7 +226,14 @@ actor BootstrapSocketConnectionManager: MCPServerConnection {
         } catch {
             if isClosing { return }
             bootstrapLog.error("Failed to notify bootstrap client of tool list change: \(error)")
-            await parentManager.removeConnection(connectionID)
+            await parentManager.removeConnection(
+                connectionID,
+                context: MCPConnectionCloseContext(
+                    reason: "tool_list_notification_failure",
+                    initiator: .app,
+                    errorDescription: String(describing: error)
+                )
+            )
         }
     }
 

--- a/Sources/RepoPrompt/Infrastructure/MCP/MCPConnectionManager.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/MCPConnectionManager.swift
@@ -12,10 +12,6 @@ import RepoPromptShared
 import SwiftUI
 
 #if DEBUG
-    import CryptoKit
-#endif
-
-#if DEBUG
     private var mcpConnectionManagerDebugLoggingEnabled = ProcessInfo.processInfo.environment["REPOPROMPT_MCP_DEBUG"] == "1"
     private var mcpRoutingDebugLoggingEnabled = false
     private var mcpPolicyDebugLoggingEnabled = false
@@ -877,6 +873,8 @@ actor ServerNetworkManager {
     private var executionWatchdogTerminalConnections: Set<UUID> = []
     private var toolExecutionWatchdogEnvironment = MCPToolExecutionWatchdogEnvironment.continuous()
     private var connectionLifecycleGenerationByID: [UUID: UInt64] = [:]
+    private var bootstrapPeerPIDByConnectionID: [UUID: Int] = [:]
+    private var terminalRecordClaimsByConnectionID: [UUID: MCPFirstTerminalRecordClaim] = [:]
     private var connectionTasks: [UUID: Task<Void, Never>] = [:]
     private var pendingConnections: [UUID: String] = [:]
 
@@ -3766,7 +3764,7 @@ actor ServerNetworkManager {
         guard !connections.isEmpty else { return }
         let now = Date()
         let connectingTimeout = TimeInterval(connectingTimeoutSeconds)
-        var toRemove: [UUID] = []
+        var toRemove: [(UUID, MCPConnectionCloseContext)] = []
 
         for (id, mgr) in connections {
             if let expectedLifecycleGeneration {
@@ -3777,11 +3775,17 @@ actor ServerNetworkManager {
                 guard isCurrentLifecycle(expectedLifecycleGeneration) else { return }
             }
             if case .failed = state {
-                toRemove.append(id)
+                toRemove.append((
+                    id,
+                    MCPConnectionCloseContext(reason: "maintenance_prune_failed", initiator: .app)
+                ))
                 continue
             }
             if case .cancelled = state {
-                toRemove.append(id)
+                toRemove.append((
+                    id,
+                    MCPConnectionCloseContext(reason: "maintenance_prune_cancelled", initiator: .app)
+                ))
                 continue
             }
             let viable = await mgr.isViableForRetention()
@@ -3789,7 +3793,10 @@ actor ServerNetworkManager {
                 guard isCurrentLifecycle(expectedLifecycleGeneration) else { return }
             }
             if !viable {
-                toRemove.append(id)
+                toRemove.append((
+                    id,
+                    MCPConnectionCloseContext(reason: "maintenance_prune_nonviable", initiator: .app)
+                ))
                 continue
             }
             if connectingTimeout > 0, state == .connecting {
@@ -3797,16 +3804,19 @@ actor ServerNetworkManager {
                    now.timeIntervalSince(createdAt) > connectingTimeout
                 {
                     log.warning("Pruning connection \(id) stuck in connecting for \(Int(now.timeIntervalSince(createdAt)))s")
-                    toRemove.append(id)
+                    toRemove.append((
+                        id,
+                        MCPConnectionCloseContext(reason: "maintenance_prune_connect_timeout", initiator: .app)
+                    ))
                 }
             }
         }
 
-        for id in toRemove {
+        for (id, context) in toRemove {
             if let expectedLifecycleGeneration {
                 guard isCurrentLifecycle(expectedLifecycleGeneration) else { return }
             }
-            await removeConnection(id)
+            await removeConnection(id, context: context)
         }
     }
 
@@ -3865,7 +3875,11 @@ actor ServerNetworkManager {
         _ = await removeConnection(
             victim.id,
             committedRemoval: committedRemoval,
-            connectionAlreadyStopped: false
+            connectionAlreadyStopped: false,
+            context: MCPConnectionCloseContext(
+                reason: "pressure_eviction",
+                initiator: .app
+            )
         )
     }
 
@@ -4561,6 +4575,14 @@ actor ServerNetworkManager {
         #endif
         Task { [weak self] in
             guard let self else { return }
+            let closeContext = MCPConnectionCloseContext(
+                reason: TerminationReason.connectionReplaced.rawValue,
+                initiator: .app
+            )
+            await persistAcceptedSocketTerminalRecord(
+                connectionID: committedRemoval.connectionID,
+                context: closeContext
+            )
             let race = MCPConnectionStopRace()
             Task {
                 await committedRemoval.connection.stop()
@@ -4584,7 +4606,8 @@ actor ServerNetworkManager {
             _ = await removeConnection(
                 committedRemoval.connectionID,
                 committedRemoval: committedRemoval,
-                connectionAlreadyStopped: true
+                connectionAlreadyStopped: true,
+                context: closeContext
             )
         }
     }
@@ -4711,6 +4734,7 @@ actor ServerNetworkManager {
         mcpACPLog("[MCP-ACP] registered bootstrap connection connection=\(connectionID) pendingClientName=\(clientName ?? "unknown")")
 
         connections[connectionID] = manager
+        bootstrapPeerPIDByConnectionID[connectionID] = clientPid
         callLimiters[connectionID] = MCPConnectionCallLimiters(
             limit: limiterLimit(for: connectionID),
             controlLimit: controlLimiterLimit(for: connectionID),
@@ -4858,7 +4882,13 @@ actor ServerNetworkManager {
             do {
                 guard let approvalHandler = self.connectionApprovalHandler else {
                     log.error("No connection approval handler set, rejecting bootstrap connection")
-                    await removeConnection(connectionID)
+                    await removeConnection(
+                        connectionID,
+                        context: MCPConnectionCloseContext(
+                            reason: "connection_approval_handler_unavailable",
+                            initiator: .app
+                        )
+                    )
                     return
                 }
 
@@ -5006,7 +5036,16 @@ actor ServerNetworkManager {
                 startupOutcome = error is CancellationError ? "cancelled" : "error"
                 log.error("Bootstrap connection \(connectionID) start failed: \(error)")
                 guard self.isCurrentConnection(connectionID, lifecycleGeneration: expectedLifecycleGeneration) else { return }
-                await removeConnection(connectionID)
+                await removeConnection(
+                    connectionID,
+                    context: MCPConnectionCloseContext(
+                        reason: error is CancellationError
+                            ? "connection_start_cancelled"
+                            : "connection_start_failure",
+                        initiator: .app,
+                        errorDescription: String(describing: error)
+                    )
+                )
             }
         }
     }
@@ -5057,6 +5096,16 @@ actor ServerNetworkManager {
         let connectionsToStop = connections.compactMap { connectionID, connectionManager -> (UUID, any MCPServerConnection)? in
             guard connectionLifecycleGenerationByID[connectionID] == stoppedLifecycleGeneration else { return nil }
             return (connectionID, connectionManager)
+        }
+        let shutdownContext = MCPConnectionCloseContext(
+            reason: "server_shutdown",
+            initiator: .app
+        )
+        for (connectionID, _) in connectionsToStop {
+            persistAcceptedSocketTerminalRecord(
+                connectionID: connectionID,
+                context: shutdownContext
+            )
         }
         let limitersToStop = Array(callLimiters)
         let committingBootstrapConnectionsToStop = bootstrapReservations.values.compactMap { reservation in
@@ -5109,6 +5158,7 @@ actor ServerNetworkManager {
             connectionTasks[id]?.cancel()
             connections.removeValue(forKey: id)
             connectionLifecycleGenerationByID.removeValue(forKey: id)
+            bootstrapPeerPIDByConnectionID.removeValue(forKey: id)
             connectionTasks.removeValue(forKey: id)
             pendingConnections.removeValue(forKey: id)
             identityContextByConnection.removeValue(forKey: id)
@@ -5126,6 +5176,9 @@ actor ServerNetworkManager {
         connectionIDBySessionToken.removeAll()
         sessionTokenBindingGeneration.removeAll()
         resetInMemoryRoutingCachesForRestart()
+        for (connectionID, _) in connectionsToStop {
+            terminalRecordClaimsByConnectionID.removeValue(forKey: connectionID)
+        }
 
         for (_, limiters) in limitersToStop {
             await limiters.cancelAll()
@@ -5133,7 +5186,7 @@ actor ServerNetworkManager {
         for (connectionID, _) in limitersToStop {
             let cancelledToolCount = await cancelActiveToolsOwnedByConnection(
                 connectionID,
-                reason: "serverShutdown"
+                reason: shutdownContext.reason
             )
             if cancelledToolCount > 0 {
                 connectionLog(
@@ -5152,7 +5205,7 @@ actor ServerNetworkManager {
         for (id, connectionManager) in connectionsToStop {
             connectionLog("Stopping connection: \(id)")
             #if DEBUG
-                debugRecordConnectionEvent("removed", connectionID: id, reason: "serverShutdown")
+                debugRecordConnectionEvent("removed", connectionID: id, reason: shutdownContext.reason)
             #endif
             await connectionManager.stop()
         }
@@ -5371,6 +5424,12 @@ actor ServerNetworkManager {
         #if DEBUG
             debugRecordConnectionEvent("terminated", connectionID: id, reason: reason.rawValue, sessionToken: sessionToken)
         #endif
+        let closeContext = MCPConnectionCloseContext(
+            reason: reason.rawValue,
+            initiator: .app,
+            errorDescription: message
+        )
+        persistAcceptedSocketTerminalRecord(connectionID: id, context: closeContext)
 
         // 1. Write kill signal file (works for both transport types)
         if sem.writeKillSignal, let token = sessionToken {
@@ -5401,7 +5460,7 @@ actor ServerNetworkManager {
         await connection.terminate(reason: reason, message: message)
 
         // 4. Clean up connection state
-        await removeConnection(id)
+        await removeConnection(id, context: closeContext)
 
         connectionLog("Successfully terminated and removed connection \(id)")
 
@@ -5422,8 +5481,14 @@ actor ServerNetworkManager {
         #if DEBUG
             debugRecordConnectionEvent("soft_disconnected", connectionID: id, reason: reason.rawValue)
         #endif
+        let closeContext = MCPConnectionCloseContext(
+            reason: reason.rawValue,
+            initiator: .app,
+            errorDescription: message
+        )
+        persistAcceptedSocketTerminalRecord(connectionID: id, context: closeContext)
         await connection.stop()
-        await removeConnection(id)
+        await removeConnection(id, context: closeContext)
     }
 
     private func currentBootstrapReplacementConnectionID(forSessionToken token: String) -> UUID? {
@@ -5504,6 +5569,37 @@ actor ServerNetworkManager {
         capabilityTokenByConnection[connectionID] ?? connections[connectionID]?.capabilityToken
     }
 
+    private func persistAcceptedSocketTerminalRecord(
+        connectionID: UUID,
+        context: MCPConnectionCloseContext
+    ) {
+        guard let peerPID = bootstrapPeerPIDByConnectionID[connectionID] else { return }
+
+        let candidate = MCPTerminalRecord(
+            layer: .appAcceptedSocket,
+            initiator: context.initiator,
+            reason: context.reason,
+            sessionToken: sessionToken(for: connectionID),
+            localPID: Int(getpid()),
+            peerPID: peerPID,
+            appConnectionID: connectionID,
+            connectionGeneration: connectionLifecycleGenerationByID[connectionID],
+            errno: context.errno,
+            errorDescription: context.errorDescription
+        )
+        var claim = terminalRecordClaimsByConnectionID[connectionID] ?? MCPFirstTerminalRecordClaim()
+        guard let record = claim.claim(candidate) else { return }
+        terminalRecordClaimsByConnectionID[connectionID] = claim
+
+        if MCPTerminalRecordStore.writeBestEffort(
+            record,
+            to: MCPFilesystemConstants.eventsDirectoryURL()
+        ) != nil {
+            claim.markPersisted()
+            terminalRecordClaimsByConnectionID[connectionID] = claim
+        }
+    }
+
     /// Handles connection replacement when a new connection registers with the same runID.
     /// Uses soft-disconnect for same-session replacements to avoid blocking legitimate reconnects.
     func handleConnectionReplaced(
@@ -5579,12 +5675,22 @@ actor ServerNetworkManager {
         connectionID: UUID,
         clientName: String?,
         sessionToken: String?,
-        snapshot: MCPTransportIngressSnapshot
+        snapshot: MCPTransportIngressSnapshot,
+        closeSnapshot: MCPTransportCloseSnapshot
     ) {
-        guard snapshot.terminalCause == .receiveBufferOverflow else { return }
-        log.error(
-            "MCP connection \(connectionID) ingress terminated: cause=\(MCPTransportTerminalCause.receiveBufferOverflow.rawValue) capacity=\(snapshot.receiveBufferCapacity) highWaterMark=\(snapshot.receiveBufferHighWaterMark)"
+        persistAcceptedSocketTerminalRecord(
+            connectionID: connectionID,
+            context: MCPConnectionCloseContext(transport: closeSnapshot)
         )
+        if snapshot.terminalCause == .receiveBufferOverflow {
+            log.error(
+                "MCP connection \(connectionID) ingress terminated: cause=\(closeSnapshot.cause.rawValue) capacity=\(snapshot.receiveBufferCapacity) highWaterMark=\(snapshot.receiveBufferHighWaterMark)"
+            )
+        } else {
+            connectionLog(
+                "MCP connection \(connectionID) transport terminated: cause=\(closeSnapshot.cause.rawValue)"
+            )
+        }
         #if DEBUG
             let retained = DebugRetainedTransportIngress(
                 snapshot: snapshot,
@@ -5603,7 +5709,7 @@ actor ServerNetworkManager {
                 debugRecordConnectionEvent(
                     "transport_terminal",
                     connectionID: connectionID,
-                    reason: MCPTransportTerminalCause.receiveBufferOverflow.rawValue,
+                    reason: closeSnapshot.cause.rawValue,
                     clientName: clientName,
                     sessionToken: sessionToken,
                     transportIngress: snapshot
@@ -5637,6 +5743,12 @@ actor ServerNetworkManager {
                 reason: "tool_execution_watchdog"
             )
         #endif
+        let closeContext = MCPConnectionCloseContext(
+            reason: "tool_execution_watchdog",
+            initiator: .app,
+            errorDescription: "Unresponsive tool execution exceeded the watchdog deadline"
+        )
+        persistAcceptedSocketTerminalRecord(connectionID: id, context: closeContext)
 
         let connection: (any MCPServerConnection)? = if let registeredConnection = connections[id] {
             registeredConnection
@@ -5650,7 +5762,7 @@ actor ServerNetworkManager {
         guard let connection else { return }
         await connection.abortForExecutionWatchdog()
         Task { [weak self] in
-            await self?.removeConnection(id)
+            await self?.removeConnection(id, context: closeContext)
         }
     }
 
@@ -5715,15 +5827,24 @@ actor ServerNetworkManager {
         }
     }
 
-    func removeConnection(_ id: UUID) async {
-        _ = await removeConnection(id, committedRemoval: nil, connectionAlreadyStopped: false)
+    func removeConnection(
+        _ id: UUID,
+        context: MCPConnectionCloseContext = .cleanupUnspecified
+    ) async {
+        _ = await removeConnection(
+            id,
+            committedRemoval: nil,
+            connectionAlreadyStopped: false,
+            context: context
+        )
     }
 
     @discardableResult
     private func removeConnection(
         _ id: UUID,
         committedRemoval: CommittedConnectionRemoval?,
-        connectionAlreadyStopped: Bool
+        connectionAlreadyStopped: Bool,
+        context: MCPConnectionCloseContext
     ) async -> Bool {
         if let committedRemoval {
             guard committedRemoval.connectionID == id,
@@ -5739,21 +5860,6 @@ actor ServerNetworkManager {
                 connectionLog("removeConnection: \(id) cleanup already in progress; ignoring duplicate call")
                 return false
             }
-        }
-
-        // Always drop any lingering bootstrap reservation (commit/rollback should handle it,
-        // but this is a leak safety-net for edge cases)
-        if let reservation = bootstrapReservations.removeValue(forKey: id) {
-            releaseBootstrapAdmissionClaim(
-                sessionToken: reservation.sessionToken,
-                connectionID: id,
-                lifecycleGeneration: reservation.lifecycleGeneration
-            )
-            closeTransferredBootstrapSocket(
-                connectionID: id,
-                lifecycleGeneration: reservation.lifecycleGeneration
-            )
-            await reservation.committingConnection?.stop()
         }
 
         // Idempotent guard – if already gone, do nothing (and do not log)
@@ -5773,6 +5879,26 @@ actor ServerNetworkManager {
         }
         defer { connectionsBeingRemoved.remove(id) }
 
+        // Claim and persist the first terminal cause before any suspension.
+        // Later termination/watchdog cleanup must not overwrite the event that
+        // actually initiated removal.
+        persistAcceptedSocketTerminalRecord(connectionID: id, context: context)
+
+        // Always drop any lingering bootstrap reservation (commit/rollback should handle it,
+        // but this is a leak safety-net for edge cases)
+        if let reservation = bootstrapReservations.removeValue(forKey: id) {
+            releaseBootstrapAdmissionClaim(
+                sessionToken: reservation.sessionToken,
+                connectionID: id,
+                lifecycleGeneration: reservation.lifecycleGeneration
+            )
+            closeTransferredBootstrapSocket(
+                connectionID: id,
+                lifecycleGeneration: reservation.lifecycleGeneration
+            )
+            await reservation.committingConnection?.stop()
+        }
+
         connectionLog("Removing connection: \(id)")
 
         let limiters = callLimiters.removeValue(forKey: id)
@@ -5786,7 +5912,7 @@ actor ServerNetworkManager {
             debugRecordConnectionEvent(
                 "removed",
                 connectionID: id,
-                reason: "connectionRemoved",
+                reason: context.reason,
                 clientName: cleanupClientName,
                 sessionToken: sessionToken,
                 windowID: assignedWindowID
@@ -5805,7 +5931,7 @@ actor ServerNetworkManager {
 
         let cancelledToolCount = await cancelActiveToolsOwnedByConnection(
             id,
-            reason: "connectionRemoved"
+            reason: context.reason
         )
         if cancelledToolCount > 0 {
             connectionLog("Cancelled \(cancelledToolCount) active tool execution(s) owned by disconnected connection \(id)")
@@ -5832,6 +5958,7 @@ actor ServerNetworkManager {
         // Remove from all collections
         connections.removeValue(forKey: id)
         connectionLifecycleGenerationByID.removeValue(forKey: id)
+        bootstrapPeerPIDByConnectionID.removeValue(forKey: id)
         connectionTasks.removeValue(forKey: id)
         pendingConnections.removeValue(forKey: id)
         connectionStats.removeValue(forKey: id)
@@ -5850,6 +5977,7 @@ actor ServerNetworkManager {
         // Clean up routing metadata before any bounded drain wait so the disconnected
         // connection cannot remain discoverable while an active owner ignores cancellation.
         unbindSessionToken(sessionToken, forConnectionID: id)
+        terminalRecordClaimsByConnectionID.removeValue(forKey: id)
 
         if let limiters {
             let results = await limiters.waitUntilIdle(
@@ -6904,11 +7032,7 @@ actor ServerNetworkManager {
             }
 
             func debugSessionFingerprint(forToken token: String?) -> String? {
-                guard let token, !token.isEmpty else { return nil }
-                let salted = "RepoPrompt.DEBUG.MCP.session:\(token)"
-                let digest = SHA256.hash(data: Data(salted.utf8))
-                let hex = digest.prefix(8).map { String(format: "%02x", $0) }.joined()
-                return "sha256:\(hex)"
+                MCPTerminalFingerprint.session(token)?.description
             }
 
             func debugSessionFingerprint(forConnection connectionID: UUID) -> String? {
@@ -8114,7 +8238,13 @@ actor ServerNetworkManager {
             #if DEBUG
                 debugExecutionWatchdogAbortTargets.removeValue(forKey: id)
             #endif
-            await removeConnection(id)
+            await removeConnection(
+                id,
+                context: MCPConnectionCloseContext(
+                    reason: "debug_remove_connection",
+                    initiator: .app
+                )
+            )
         }
 
         #if DEBUG
@@ -12877,7 +13007,11 @@ actor ServerNetworkManager {
             _ = await removeConnection(
                 victim.id,
                 committedRemoval: committedRemoval,
-                connectionAlreadyStopped: false
+                connectionAlreadyStopped: false,
+                context: MCPConnectionCloseContext(
+                    reason: "per_client_admission_eviction",
+                    initiator: .app
+                )
             )
             return .evicted
         }
@@ -13032,7 +13166,11 @@ actor ServerNetworkManager {
                 _ = await removeConnection(
                     victim.id,
                     committedRemoval: committedRemoval,
-                    connectionAlreadyStopped: false
+                    connectionAlreadyStopped: false,
+                    context: MCPConnectionCloseContext(
+                        reason: "global_admission_eviction_lifecycle_invalidated",
+                        initiator: .app
+                    )
                 )
                 return .admissionContextInvalidated
             }
@@ -13093,7 +13231,11 @@ actor ServerNetworkManager {
                 _ = await removeConnection(
                     victim.id,
                     committedRemoval: committedRemoval,
-                    connectionAlreadyStopped: false
+                    connectionAlreadyStopped: false,
+                    context: MCPConnectionCloseContext(
+                        reason: "global_admission_eviction_restore_failed",
+                        initiator: .app
+                    )
                 )
                 guard isCurrentBootstrapAdmissionContext(
                     sourceListener: sourceListener,
@@ -13119,7 +13261,11 @@ actor ServerNetworkManager {
             _ = await removeConnection(
                 victim.id,
                 committedRemoval: committedRemoval,
-                connectionAlreadyStopped: false
+                connectionAlreadyStopped: false,
+                context: MCPConnectionCloseContext(
+                    reason: "global_admission_eviction",
+                    initiator: .app
+                )
             )
             guard isCurrentBootstrapAdmissionContext(
                 sourceListener: sourceListener,

--- a/Sources/RepoPrompt/Infrastructure/MCP/MCPDiagnostics.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/MCPDiagnostics.swift
@@ -1,7 +1,74 @@
 import Foundation
+import RepoPromptShared
 
-enum MCPTransportTerminalCause: String, Equatable {
+public enum MCPTransportTerminalCause: String, Codable, Equatable, Sendable {
+    case peerEOF = "peer_eof"
+    case incompleteEOF = "incomplete_eof"
+    case readError = "read_error"
+    case writeFailure = "write_failure"
+    case writeStall = "write_stall"
+    case writeHangup = "write_hangup"
     case receiveBufferOverflow = "receive_buffer_overflow"
+    case localDisconnect = "local_disconnect"
+    case connectFailure = "connect_failure"
+}
+
+public struct MCPTransportCloseSnapshot: Equatable, Sendable {
+    public let cause: MCPTransportTerminalCause
+    public let initiator: MCPTerminalInitiator
+    public let errno: Int32?
+    public let errorDescription: String?
+}
+
+struct MCPFirstTerminalRecordClaim: Equatable {
+    private(set) var record: MCPTerminalRecord?
+    private(set) var didPersist = false
+
+    mutating func claim(_ candidate: MCPTerminalRecord) -> MCPTerminalRecord? {
+        guard !didPersist else { return nil }
+        if record == nil {
+            record = candidate
+        }
+        return record
+    }
+
+    mutating func markPersisted() {
+        guard record != nil else { return }
+        didPersist = true
+    }
+}
+
+struct MCPConnectionCloseContext: Equatable {
+    let reason: String
+    let initiator: MCPTerminalInitiator
+    let errno: Int32?
+    let errorDescription: String?
+
+    init(
+        reason: String,
+        initiator: MCPTerminalInitiator,
+        errno: Int32? = nil,
+        errorDescription: String? = nil
+    ) {
+        self.reason = reason
+        self.initiator = initiator
+        self.errno = errno
+        self.errorDescription = errorDescription
+    }
+
+    init(transport snapshot: MCPTransportCloseSnapshot) {
+        self.init(
+            reason: snapshot.cause.rawValue,
+            initiator: snapshot.initiator,
+            errno: snapshot.errno,
+            errorDescription: snapshot.errorDescription
+        )
+    }
+
+    static let cleanupUnspecified = MCPConnectionCloseContext(
+        reason: "connection_cleanup_unspecified",
+        initiator: .unknown
+    )
 }
 
 struct MCPTransportIngressSnapshot: Equatable {

--- a/Sources/RepoPrompt/Infrastructure/MCP/UnixSocketMCPTransport.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/UnixSocketMCPTransport.swift
@@ -309,12 +309,12 @@ public actor UnixSocketMCPTransport: Transport {
     }
 
     private struct CloseChannel {
-        let stream: AsyncStream<Void>
-        let continuation: AsyncStream<Void>.Continuation
+        let stream: AsyncStream<MCPTransportCloseSnapshot>
+        let continuation: AsyncStream<MCPTransportCloseSnapshot>.Continuation
 
         init() {
-            var continuation: AsyncStream<Void>.Continuation!
-            stream = AsyncStream(Void.self) { continuation = $0 }
+            var continuation: AsyncStream<MCPTransportCloseSnapshot>.Continuation!
+            stream = AsyncStream(MCPTransportCloseSnapshot.self) { continuation = $0 }
             self.continuation = continuation
         }
     }
@@ -325,6 +325,7 @@ public actor UnixSocketMCPTransport: Transport {
     private var inboundChannel: InboundChannel
     private var closeChannel: CloseChannel
     private var closeSignaled = false
+    private var firstCloseSnapshot: MCPTransportCloseSnapshot?
 
     /// Event-driven read source (replaces poll loop)
     private let readQueue = DispatchQueue(label: "com.repoprompt.mcp.unix.read", qos: .userInitiated)
@@ -497,6 +498,11 @@ public actor UnixSocketMCPTransport: Transport {
 
         while Date().timeIntervalSince(startTime) < connectionTimeout {
             if Task.isCancelled {
+                tearDownSocket(
+                    error: CancellationError(),
+                    cause: .connectFailure,
+                    initiator: .app
+                )
                 throw MCPError.connectionClosed
             }
 
@@ -517,7 +523,12 @@ public actor UnixSocketMCPTransport: Transport {
                     lastError = error
                 } catch {
                     // Other error - fail this connection attempt cleanly.
-                    tearDownSocket(error: error)
+                    tearDownSocket(
+                        error: error,
+                        cause: .connectFailure,
+                        initiator: .transport,
+                        errno: Self.errnoValue(from: error)
+                    )
                     throw error
                 }
             }
@@ -528,7 +539,14 @@ public actor UnixSocketMCPTransport: Transport {
 
         // Timeout reached
         logger.error("UnixSocketMCPTransport connection timeout after \(connectionTimeout)s")
-        throw lastError ?? MCPError.internalError("Timeout connecting to UNIX socket at \(socketURL.path)")
+        let error = lastError ?? MCPError.internalError("Timeout connecting to UNIX socket at \(socketURL.path)")
+        tearDownSocket(
+            error: error,
+            cause: .connectFailure,
+            initiator: .transport,
+            errno: Self.errnoValue(from: error)
+        )
+        throw error
     }
 
     /// Disconnects from the UNIX socket.
@@ -537,7 +555,11 @@ public actor UnixSocketMCPTransport: Transport {
         guard isConnected || !isStopping else { return }
 
         mcpConnectionLog("UnixSocketMCPTransport disconnecting")
-        tearDownSocket(error: MCPError.connectionClosed)
+        tearDownSocket(
+            error: MCPError.connectionClosed,
+            cause: .localDisconnect,
+            initiator: .app
+        )
         mcpConnectionLog("UnixSocketMCPTransport disconnect requested")
     }
 
@@ -689,8 +711,12 @@ public actor UnixSocketMCPTransport: Transport {
 
     /// Returns the close notification stream.
     /// Use this to detect when the socket closes so connections can be cleaned up promptly.
-    public func closed() -> AsyncStream<Void> {
+    public func closed() -> AsyncStream<MCPTransportCloseSnapshot> {
         closeChannel.stream
+    }
+
+    public func closeSnapshot() -> MCPTransportCloseSnapshot? {
+        firstCloseSnapshot
     }
 
     func ingressSnapshot() -> MCPTransportIngressSnapshot {
@@ -718,6 +744,7 @@ public actor UnixSocketMCPTransport: Transport {
         }
         streamFinished = false
         closeSignaled = false
+        firstCloseSnapshot = nil
     }
 
     /// Connects to the UNIX socket at socketURL.
@@ -803,7 +830,12 @@ public actor UnixSocketMCPTransport: Transport {
     /// Wakes blocked I/O and deterministically transfers final-close responsibility.
     /// If a reader exists, its cancel handler remains the sole final-close owner to
     /// avoid a stale callback closing a reused descriptor number.
-    private func tearDownSocket(error proposedError: Swift.Error?) {
+    private func tearDownSocket(
+        error proposedError: Swift.Error?,
+        cause proposedCause: MCPTransportTerminalCause,
+        initiator proposedInitiator: MCPTerminalInitiator,
+        errno proposedErrno: Int32? = nil
+    ) {
         guard !streamFinished else { return }
         responseDeliveryGate.close()
         #if DEBUG
@@ -815,13 +847,28 @@ public actor UnixSocketMCPTransport: Transport {
             }
         #endif
         let ingressSnapshot = inboundChannel.gate.closeAndSnapshot()
+        let overflowError = MCPReceiveBufferOverflowError(
+            capacity: ingressSnapshot.receiveBufferCapacity,
+            highWaterMark: ingressSnapshot.receiveBufferHighWaterMark
+        )
         let resolvedError: Swift.Error? = if ingressSnapshot.terminalCause == .receiveBufferOverflow {
-            MCPReceiveBufferOverflowError(
-                capacity: ingressSnapshot.receiveBufferCapacity,
-                highWaterMark: ingressSnapshot.receiveBufferHighWaterMark
-            )
+            overflowError
         } else {
             proposedError
+        }
+        if firstCloseSnapshot == nil {
+            firstCloseSnapshot = MCPTransportCloseSnapshot(
+                cause: ingressSnapshot.terminalCause == .receiveBufferOverflow
+                    ? .receiveBufferOverflow
+                    : proposedCause,
+                initiator: ingressSnapshot.terminalCause == .receiveBufferOverflow
+                    ? .transport
+                    : proposedInitiator,
+                errno: ingressSnapshot.terminalCause == .receiveBufferOverflow
+                    ? nil
+                    : proposedErrno,
+                errorDescription: resolvedError.map { String(describing: $0) }
+            )
         }
         if ingressSnapshot.terminalCause == .receiveBufferOverflow {
             logger.error("UnixSocketMCPTransport ingress terminated: \(String(describing: resolvedError))")
@@ -843,7 +890,11 @@ public actor UnixSocketMCPTransport: Transport {
         if isConnected {
             guard activeReaderOwnership != nil else {
                 let error = MCPError.connectionClosed
-                tearDownSocket(error: error)
+                tearDownSocket(
+                    error: error,
+                    cause: .connectFailure,
+                    initiator: .transport
+                )
                 throw error
             }
             return
@@ -851,7 +902,11 @@ public actor UnixSocketMCPTransport: Transport {
 
         guard !streamFinished, !closeSignaled, socketFD >= 0 else {
             let error = MCPError.connectionClosed
-            tearDownSocket(error: error)
+            tearDownSocket(
+                error: error,
+                cause: .connectFailure,
+                initiator: .transport
+            )
             throw error
         }
 
@@ -876,9 +931,21 @@ public actor UnixSocketMCPTransport: Transport {
             lastActivityTime = Date()
             unixSocketMCPTransportDebugLog("started with existing FD \(socketFD)")
         } catch {
-            tearDownSocket(error: error)
+            tearDownSocket(
+                error: error,
+                cause: .connectFailure,
+                initiator: .transport,
+                errno: Self.errnoValue(from: error)
+            )
             throw error
         }
+    }
+
+    private nonisolated static func errnoValue(from error: Swift.Error) -> Int32? {
+        if let posixError = error as? POSIXError {
+            return posixError.code.rawValue
+        }
+        return nil
     }
 
     #if DEBUG
@@ -982,7 +1049,7 @@ public actor UnixSocketMCPTransport: Transport {
         do {
             try Self.ensureNonBlocking(fd: fd)
         } catch {
-            closeAfterSendFailure(error)
+            closeAfterSendFailure(error, cause: .writeFailure, errno: Self.errnoValue(from: error))
             throw error
         }
         var remaining = data
@@ -999,7 +1066,7 @@ public actor UnixSocketMCPTransport: Transport {
                     bytesRemaining: remaining.count,
                     totalBytes: data.count
                 ))
-                closeAfterSendFailure(error)
+                closeAfterSendFailure(error, cause: .writeStall)
                 throw error
             }
 
@@ -1021,16 +1088,16 @@ public actor UnixSocketMCPTransport: Transport {
                     )
                     continue
                 } else if err == EPIPE || err == ECONNRESET {
-                    closeAfterSendFailure(MCPError.connectionClosed)
+                    closeAfterSendFailure(MCPError.connectionClosed, cause: .writeHangup, initiator: .peer, errno: err)
                     throw MCPError.connectionClosed
                 } else {
                     let error = MCPError.transportError(POSIXError(POSIXErrorCode(rawValue: err) ?? .EIO))
-                    closeAfterSendFailure(error)
+                    closeAfterSendFailure(error, cause: .writeFailure, errno: err)
                     throw error
                 }
             } else if written == 0 {
                 // On sockets, a 0-length write generally means closed / unusable
-                closeAfterSendFailure(MCPError.connectionClosed)
+                closeAfterSendFailure(MCPError.connectionClosed, cause: .writeHangup, initiator: .peer)
                 throw MCPError.connectionClosed
             }
 
@@ -1058,7 +1125,7 @@ public actor UnixSocketMCPTransport: Transport {
                     bytesRemaining: bytesRemaining,
                     totalBytes: totalBytes
                 ))
-                closeAfterSendFailure(error)
+                closeAfterSendFailure(error, cause: .writeStall)
                 throw error
             }
 
@@ -1069,8 +1136,9 @@ public actor UnixSocketMCPTransport: Transport {
 
             if result < 0 {
                 if errno == EINTR { continue }
-                let error = MCPError.transportError(POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO))
-                closeAfterSendFailure(error)
+                let err = errno
+                let error = MCPError.transportError(POSIXError(POSIXErrorCode(rawValue: err) ?? .EIO))
+                closeAfterSendFailure(error, cause: .writeFailure, errno: err)
                 throw error
             }
 
@@ -1079,7 +1147,7 @@ public actor UnixSocketMCPTransport: Transport {
             }
 
             if pfd.revents & Int16(POLLHUP | POLLERR | POLLNVAL) != 0 {
-                closeAfterSendFailure(MCPError.connectionClosed)
+                closeAfterSendFailure(MCPError.connectionClosed, cause: .writeHangup, initiator: .peer)
                 throw MCPError.connectionClosed
             }
 
@@ -1089,9 +1157,19 @@ public actor UnixSocketMCPTransport: Transport {
         }
     }
 
-    private func closeAfterSendFailure(_ error: Swift.Error) {
+    private func closeAfterSendFailure(
+        _ error: Swift.Error,
+        cause: MCPTransportTerminalCause,
+        initiator: MCPTerminalInitiator = .transport,
+        errno: Int32? = nil
+    ) {
         logger.error("UnixSocketMCPTransport send failed; closing transport: \(String(describing: error))")
-        tearDownSocket(error: error)
+        tearDownSocket(
+            error: error,
+            cause: cause,
+            initiator: initiator,
+            errno: errno
+        )
     }
 
     private struct UnixSocketWriteStalledError: Swift.Error, CustomStringConvertible {
@@ -1292,7 +1370,11 @@ public actor UnixSocketMCPTransport: Transport {
                 return
             }
         #endif
-        tearDownSocket(error: error)
+        tearDownSocket(
+            error: error,
+            cause: .receiveBufferOverflow,
+            initiator: .transport
+        )
     }
 
     private func handleReaderTerminal(
@@ -1312,16 +1394,29 @@ public actor UnixSocketMCPTransport: Transport {
 
         switch terminal {
         case let .error(error):
-            tearDownSocket(error: error)
+            tearDownSocket(
+                error: error,
+                cause: .readError,
+                initiator: .transport,
+                errno: Self.errnoValue(from: error)
+            )
         case let .eof(hasResidualData):
             mcpConnectionLog("UnixSocketMCPTransport received EOF")
             guard hasResidualData else {
-                tearDownSocket(error: nil)
+                tearDownSocket(
+                    error: nil,
+                    cause: .peerEOF,
+                    initiator: .peer
+                )
                 return
             }
             // Treat residual incomplete frame as a protocol error
             let truncationError = MCPError.internalError("Connection closed with incomplete frame data")
-            tearDownSocket(error: truncationError)
+            tearDownSocket(
+                error: truncationError,
+                cause: .incompleteEOF,
+                initiator: .peer
+            )
         }
     }
 
@@ -1360,7 +1455,9 @@ public actor UnixSocketMCPTransport: Transport {
     private func signalClosedOnce() {
         guard !closeSignaled else { return }
         closeSignaled = true
-        closeChannel.continuation.yield()
+        if let firstCloseSnapshot {
+            closeChannel.continuation.yield(firstCloseSnapshot)
+        }
         closeChannel.continuation.finish()
     }
 }

--- a/Sources/RepoPromptMCP/main.swift
+++ b/Sources/RepoPromptMCP/main.swift
@@ -66,11 +66,81 @@ enum MCPCLIExitCode: Int32 {
     case unknownError = 1
 }
 
+struct CLIHostDisconnectProvenance: Equatable, CustomStringConvertible {
+    enum Reason: String {
+        case stdinClosed = "stdin_closed"
+        case parentProcessChanged = "parent_process_changed"
+        case stdoutBrokenPipe = "stdout_broken_pipe"
+        case taskCancelled = "host_task_cancelled"
+    }
+
+    let reason: Reason
+    let bytesWritten: Int?
+    let totalBytes: Int?
+    let initialParentPID: Int?
+    let currentParentPID: Int?
+
+    static let stdinClosed = CLIHostDisconnectProvenance(reason: .stdinClosed)
+    static let taskCancelled = CLIHostDisconnectProvenance(reason: .taskCancelled)
+
+    static func stdoutBrokenPipe(bytesWritten: Int, totalBytes: Int) -> CLIHostDisconnectProvenance {
+        CLIHostDisconnectProvenance(
+            reason: .stdoutBrokenPipe,
+            bytesWritten: bytesWritten,
+            totalBytes: totalBytes
+        )
+    }
+
+    static func parentProcessChanged(initialPPID: pid_t, currentPPID: pid_t) -> CLIHostDisconnectProvenance {
+        CLIHostDisconnectProvenance(
+            reason: .parentProcessChanged,
+            initialParentPID: Int(initialPPID),
+            currentParentPID: Int(currentPPID)
+        )
+    }
+
+    init(
+        reason: Reason,
+        bytesWritten: Int? = nil,
+        totalBytes: Int? = nil,
+        initialParentPID: Int? = nil,
+        currentParentPID: Int? = nil
+    ) {
+        self.reason = reason
+        self.bytesWritten = bytesWritten
+        self.totalBytes = totalBytes
+        self.initialParentPID = initialParentPID
+        self.currentParentPID = currentParentPID
+    }
+
+    var description: String {
+        var fields = ["reason=\(reason.rawValue)"]
+        if let bytesWritten { fields.append("bytes_written=\(bytesWritten)") }
+        if let totalBytes { fields.append("total_bytes=\(totalBytes)") }
+        if let initialParentPID { fields.append("initial_parent_pid=\(initialParentPID)") }
+        if let currentParentPID { fields.append("current_parent_pid=\(currentParentPID)") }
+        return fields.joined(separator: " ")
+    }
+}
+
+struct CLIServerTerminationProvenance: Equatable {
+    let reason: TerminationReason?
+    let message: String?
+
+    var stableReason: String {
+        reason?.rawValue ?? "terminated_by_server"
+    }
+
+    var humanMessage: String {
+        message ?? "Connection terminated by server"
+    }
+}
+
 enum CLIRuntimeError: Swift.Error {
     case connectionFailed(underlying: Swift.Error)
     case approvalDenied
-    case terminatedByServer(reason: String?)
-    case hostDisconnected // Stdin closed or stdout broken pipe
+    case terminatedByServer(CLIServerTerminationProvenance)
+    case hostDisconnected(CLIHostDisconnectProvenance)
 }
 
 // ────────────────────────────────────────────────────────────
@@ -184,11 +254,11 @@ enum CLIEventLogger {
             return (.connectionFailed, "Connection failed", details)
         case .approvalDenied:
             return (.approvalDenied, "Connection approval denied", nil)
-        case let .terminatedByServer(reason):
+        case let .terminatedByServer(provenance):
             // Server explicitly terminated - this is expected behavior, not an error to surface
-            return (.approvalDenied, reason ?? "Connection terminated by server", nil)
-        case .hostDisconnected:
-            return (.connectionFailed, "Host disconnected (stdin closed or stdout broken)", nil)
+            return (.approvalDenied, provenance.humanMessage, nil)
+        case let .hostDisconnected(provenance):
+            return (.connectionFailed, "Host disconnected (\(provenance.description))", nil)
         }
     }
 
@@ -1407,36 +1477,192 @@ actor MCPService: Service {
         // Capture initial parent PID for orphan detection
         let initialPPID = getppid()
 
-        // Race between transport loop, kill signal, and PPID watchdog
-        try await withThrowingTaskGroup(of: Void.self) { group in
-            // Kill signal monitor task
-            group.addTask {
-                guard let signal = await self.waitForKillSignal() else {
-                    // Task was cancelled - just return without throwing
-                    return
+        do {
+            // Race between transport loop, kill signal, and PPID watchdog
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                // Kill signal monitor task
+                group.addTask {
+                    guard let signal = await self.waitForKillSignal() else {
+                        // Task was cancelled - just return without throwing
+                        return
+                    }
+                    throw CLIRuntimeError.terminatedByServer(CLIServerTerminationProvenance(
+                        reason: signal.reason,
+                        message: signal.message ?? CLIKillSignal.messageForReason(signal.reason)
+                    ))
                 }
-                throw CLIRuntimeError.terminatedByServer(
-                    reason: CLIKillSignal.messageForReason(signal.reason)
-                )
-            }
 
-            // PPID watchdog - detect orphaned CLI when parent dies
-            group.addTask {
-                try await self.runPPIDWatchdog(initialPPID: initialPPID)
-            }
+                // PPID watchdog - detect orphaned CLI when parent dies
+                group.addTask {
+                    try await self.runPPIDWatchdog(initialPPID: initialPPID)
+                }
 
-            // Main transport task
-            group.addTask {
-                try await self.runTransport()
-            }
+                // Main transport task
+                group.addTask {
+                    try await self.runTransport()
+                }
 
-            // Wait for first to complete (either kill signal, orphan detection, or transport exit)
-            do {
-                while let _ = try await group.next() {}
-            } catch {
-                group.cancelAll()
-                throw error
+                // Wait for first to complete (either kill signal, orphan detection, or transport exit)
+                do {
+                    while let _ = try await group.next() {}
+                } catch {
+                    group.cancelAll()
+                    throw error
+                }
             }
+            await persistProxyTerminalRecord(
+                runtimeError: nil,
+                fallbackReason: "proxy_task_group_completed",
+                initialPPID: initialPPID
+            )
+        } catch {
+            await persistProxyTerminalRecord(
+                runtimeError: error as? CLIRuntimeError,
+                fallbackReason: "proxy_unexpected_error",
+                initialPPID: initialPPID,
+                unexpectedError: error
+            )
+            throw error
+        }
+    }
+
+    private func persistProxyTerminalRecord(
+        runtimeError: CLIRuntimeError?,
+        fallbackReason: String,
+        initialPPID: pid_t,
+        unexpectedError: Swift.Error? = nil
+    ) async {
+        let snapshot = await bridgeLedger.snapshot()
+        let reason = proxyTerminalReason(
+            runtimeError: runtimeError,
+            ledgerTerminalReason: snapshot.terminalReason,
+            fallbackReason: fallbackReason
+        )
+        let details = proxyTerminalDetails(
+            runtimeError: runtimeError,
+            unexpectedError: unexpectedError
+        )
+        let record = MCPTerminalRecord(
+            layer: .proxy,
+            initiator: details.initiator,
+            reason: reason,
+            sessionToken: sessionToken,
+            localPID: Int(getpid()),
+            peerPID: Int(initialPPID),
+            appConnectionID: nil,
+            connectionGeneration: snapshot.connectionGeneration,
+            errno: details.errno,
+            errorDescription: details.errorDescription,
+            bridgeActiveRequestCount: snapshot.activeRequestCount,
+            bridgeResponseInDeliveryCount: snapshot.responseInDeliveryCount,
+            bridgeCancellationTombstoneCount: snapshot.cancellationTombstoneCount,
+            bridgeRecentCompletionCount: snapshot.recentCompletionCount,
+            bridgePendingTransactionCount: snapshot.pendingTransactionCount,
+            bridgeHasForwardedProtocolFrame: snapshot.hasForwardedProtocolFrame
+        )
+        _ = MCPTerminalRecordStore.writeBestEffort(
+            record,
+            to: MCPFilesystemConstants.eventsDirectoryURL()
+        )
+    }
+
+    private func proxyTerminalReason(
+        runtimeError: CLIRuntimeError?,
+        ledgerTerminalReason: String?,
+        fallbackReason: String
+    ) -> String {
+        guard let runtimeError else {
+            return ledgerTerminalReason ?? fallbackReason
+        }
+        switch runtimeError {
+        case .approvalDenied:
+            return "approval_denied"
+        case let .terminatedByServer(provenance):
+            return provenance.stableReason
+        case let .hostDisconnected(provenance):
+            return provenance.reason.rawValue
+        case .connectionFailed:
+            return ledgerTerminalReason ?? transportFailureReason(for: runtimeError)
+        }
+    }
+
+    private func proxyTerminalDetails(
+        runtimeError: CLIRuntimeError?,
+        unexpectedError: Swift.Error?
+    ) -> (initiator: MCPTerminalInitiator, errno: Int32?, errorDescription: String?) {
+        guard let runtimeError else {
+            return (
+                .proxy,
+                nil,
+                unexpectedError.map { String(describing: $0) }
+            )
+        }
+        switch runtimeError {
+        case .approvalDenied:
+            return (.app, nil, "Connection approval denied")
+        case let .terminatedByServer(provenance):
+            return (.app, nil, provenance.humanMessage)
+        case let .hostDisconnected(provenance):
+            return (.host, nil, provenance.description)
+        case let .connectionFailed(underlying):
+            let socketError = underlying as? SocketProxyError
+            return (
+                proxyTerminalInitiator(
+                    for: socketError,
+                    underlying: underlying
+                ),
+                proxyTerminalErrno(for: socketError),
+                (underlying as? LocalizedError)?.errorDescription
+                    ?? String(describing: underlying)
+            )
+        }
+    }
+
+    private func proxyTerminalInitiator(
+        for error: SocketProxyError?,
+        underlying: Swift.Error
+    ) -> MCPTerminalInitiator {
+        if let ledgerError = underlying as? JSONRPCBridgeLedgerError,
+           case let .terminal(reason) = ledgerError
+        {
+            if reason.hasPrefix("socket_") {
+                return .peer
+            }
+            if reason.hasPrefix("stdin_") {
+                return .host
+            }
+            return .proxy
+        }
+        guard let error else { return .proxy }
+        switch error {
+        case .stdoutBrokenPipe, .stdoutWriteTimeout, .hostDisconnected:
+            return .host
+        case .approvalDenied, .terminatedByServer:
+            return .app
+        case .serverClosed, .connectionReset, .readFailed:
+            return .peer
+        default:
+            return .transport
+        }
+    }
+
+    private func proxyTerminalErrno(for error: SocketProxyError?) -> Int32? {
+        guard let error else { return nil }
+        switch error {
+        case let .socketCreationFailed(errno),
+             let .descriptorConfigurationFailed(errno),
+             let .bindFailed(errno),
+             let .listenFailed(errno),
+             let .acceptFailed(errno),
+             let .connectFailed(errno),
+             let .writeFailed(errno),
+             let .readFailed(errno),
+             let .pollFailed(errno):
+            return errno
+        case .connectionRefused:
+            return ECONNREFUSED
+        default:
+            return nil
         }
     }
 
@@ -1451,7 +1677,7 @@ actor MCPService: Service {
             if currentPPID != initialPPID {
                 // Parent changed - we've been orphaned (typically reparented to PID 1)
                 log.notice("CLI: Parent process died (PPID changed from \(initialPPID) to \(currentPPID)), exiting")
-                throw CLIRuntimeError.hostDisconnected
+                throw CLIRuntimeError.hostDisconnected(.parentProcessChanged(initialPPID: initialPPID, currentPPID: currentPPID))
             }
         }
     }
@@ -1514,22 +1740,42 @@ actor MCPService: Service {
         switch error {
         case .approvalDenied:
             return "approval_denied"
-        case .hostDisconnected:
-            return "host_disconnected"
-        case .terminatedByServer:
-            return "terminated_by_server"
+        case let .hostDisconnected(provenance):
+            return provenance.reason.rawValue
+        case let .terminatedByServer(provenance):
+            return provenance.stableReason
         case let .connectionFailed(underlying):
             if underlying is JSONRPCBridgeLedgerError {
                 return "jsonrpc_bridge_terminal"
             }
             if let socketError = underlying as? SocketProxyError {
                 switch socketError {
+                case .socketCreationFailed: return "socket_creation_failed"
+                case .descriptorConfigurationFailed: return "descriptor_configuration_failed"
+                case .pathTooLong: return "socket_path_too_long"
+                case .bindFailed: return "socket_bind_failed"
+                case .listenFailed: return "socket_listen_failed"
+                case .acceptFailed: return "socket_accept_failed"
+                case .connectFailed: return "app_socket_connect_failed"
+                case .notListening: return "socket_not_listening"
+                case .notConnected: return "socket_not_connected"
+                case .connectionTimeout: return "app_socket_write_timeout"
+                case .bootstrapResponseTimeout: return "bootstrap_response_timeout"
+                case .connectionReset: return "app_socket_reset"
+                case .connectionRefused: return "app_socket_connection_refused"
+                case .writeFailed: return "socket_write_failed"
+                case .readFailed: return "socket_read_failed"
+                case .pollFailed: return "socket_poll_failed"
                 case .stdoutWriteTimeout: return "stdout_write_timeout"
                 case .stdoutBrokenPipe: return "stdout_broken_pipe"
+                case .cancelled: return "transport_cancelled"
                 case .serverClosed: return "app_socket_closed"
-                case .connectionReset: return "app_socket_reset"
-                case .connectionTimeout: return "app_socket_write_timeout"
-                default: return "bootstrap_transport_failure"
+                case .approvalDenied: return "approval_denied"
+                case .terminatedByServer: return "terminated_by_server"
+                case .handshakeFailed: return "handshake_failed"
+                case .handshakeRejected: return "handshake_rejected"
+                case .protocolVersionMismatch: return "protocol_version_mismatch"
+                case .hostDisconnected: return "host_disconnected"
                 }
             }
             return "transport_failure"
@@ -1645,7 +1891,7 @@ actor MCPService: Service {
                     try await Task.sleep(for: .seconds(delay))
                 } catch is CancellationError {
                     // Cancelled by kill signal or PPID watchdog
-                    throw CLIRuntimeError.hostDisconnected
+                    throw CLIRuntimeError.hostDisconnected(.taskCancelled)
                 }
             } catch {
                 // Unknown error type - treat as fatal connection failure
@@ -1654,7 +1900,7 @@ actor MCPService: Service {
         }
 
         // If loop exits due to Task cancellation
-        throw CLIRuntimeError.hostDisconnected
+        throw CLIRuntimeError.hostDisconnected(.taskCancelled)
     }
 
     /// Single connection attempt to the bootstrap socket.
@@ -1682,7 +1928,7 @@ actor MCPService: Service {
         do {
             try await proxy.start()
             log.debug("Bootstrap socket proxy stopped cleanly")
-            throw CLIRuntimeError.hostDisconnected
+            throw CLIRuntimeError.hostDisconnected(.stdinClosed)
         } catch let err as SocketProxyError {
             await proxy.stop()
             switch err {
@@ -1690,10 +1936,13 @@ actor MCPService: Service {
                 throw CLIRuntimeError.approvalDenied
             case .hostDisconnected:
                 // Host process closed stdin - clean exit
-                throw CLIRuntimeError.hostDisconnected
+                throw CLIRuntimeError.hostDisconnected(.stdinClosed)
             case let .stdoutBrokenPipe(bytesWritten, totalBytes):
                 debugLog("BootstrapSocketProxy: stdout bridge broken_pipe bytes_written=\(bytesWritten) total_bytes=\(totalBytes)")
-                throw CLIRuntimeError.hostDisconnected
+                throw CLIRuntimeError.hostDisconnected(.stdoutBrokenPipe(
+                    bytesWritten: bytesWritten,
+                    totalBytes: totalBytes
+                ))
             case .stdoutWriteTimeout:
                 throw CLIRuntimeError.connectionFailed(underlying: err)
             case .serverClosed, .connectionReset, .connectionTimeout:
@@ -1703,7 +1952,10 @@ actor MCPService: Service {
                 throw CLIRuntimeError.connectionFailed(underlying: err)
             case let .terminatedByServer(reason):
                 // Server explicitly killed this connection - exit without retry
-                throw CLIRuntimeError.terminatedByServer(reason: reason)
+                throw CLIRuntimeError.terminatedByServer(CLIServerTerminationProvenance(
+                    reason: nil,
+                    message: reason
+                ))
             case let .handshakeFailed(reason):
                 log.error("Bootstrap handshake failed: \(reason)")
                 throw CLIRuntimeError.connectionFailed(underlying: err)
@@ -1752,15 +2004,14 @@ func handleRuntimeError(_ err: CLIRuntimeError) -> Never {
     case .approvalDenied:
         fputs("RepoPrompt MCP: connection closed immediately. Approval was likely denied or the server is disabled. Check the RepoPrompt approval dialog or MCP settings.\n", stderr)
         exit(exitCode.rawValue)
-    case let .terminatedByServer(reason):
+    case let .terminatedByServer(provenance):
         // Clean exit - server explicitly terminated this connection
-        let message = reason ?? "Connection terminated by server"
-        log.notice("CLI exiting: \(message)")
-        fputs("RepoPrompt MCP: \(message)\n", stderr)
+        log.notice("CLI exiting: \(provenance.humanMessage)")
+        fputs("RepoPrompt MCP: \(provenance.humanMessage)\n", stderr)
         exit(exitCode.rawValue)
-    case .hostDisconnected:
+    case let .hostDisconnected(provenance):
         // Host process died - exit cleanly without retry
-        log.notice("CLI exiting: host disconnected")
+        log.notice("CLI exiting: host disconnected \(provenance.description)")
         exit(exitCode.rawValue)
     }
 }

--- a/Sources/RepoPromptShared/MCP/MCPTerminalRecord.swift
+++ b/Sources/RepoPromptShared/MCP/MCPTerminalRecord.swift
@@ -1,0 +1,264 @@
+import CryptoKit
+import Foundation
+
+public enum MCPTerminalLayer: String, Codable, Sendable {
+    case appAcceptedSocket = "app_accepted_socket"
+    case proxy
+}
+
+public enum MCPTerminalInitiator: String, Codable, Sendable {
+    case app
+    case host
+    case peer
+    case proxy
+    case transport
+    case unknown
+}
+
+public struct MCPTerminalRecord: Codable, Equatable, Sendable {
+    public let id: UUID
+    public let timestamp: Date
+    public let monotonicUptime: TimeInterval
+    public let layer: MCPTerminalLayer
+    public let initiator: MCPTerminalInitiator
+    public let reason: String
+    public let sessionFingerprint: MCPTerminalFingerprint?
+    public let localPID: Int
+    public let peerPID: Int?
+    public let appConnectionID: UUID?
+    public let connectionGeneration: UInt64?
+    public let errno: Int32?
+    public let errorDescription: String?
+    public let bridgeActiveRequestCount: Int?
+    public let bridgeResponseInDeliveryCount: Int?
+    public let bridgeCancellationTombstoneCount: Int?
+    public let bridgeRecentCompletionCount: Int?
+    public let bridgePendingTransactionCount: Int?
+    public let bridgeHasForwardedProtocolFrame: Bool?
+
+    public init(
+        id: UUID = UUID(),
+        timestamp: Date = Date(),
+        monotonicUptime: TimeInterval = ProcessInfo.processInfo.systemUptime,
+        layer: MCPTerminalLayer,
+        initiator: MCPTerminalInitiator,
+        reason: String,
+        sessionToken: String?,
+        localPID: Int,
+        peerPID: Int?,
+        appConnectionID: UUID?,
+        connectionGeneration: UInt64?,
+        errno: Int32?,
+        errorDescription: String?,
+        bridgeActiveRequestCount: Int? = nil,
+        bridgeResponseInDeliveryCount: Int? = nil,
+        bridgeCancellationTombstoneCount: Int? = nil,
+        bridgeRecentCompletionCount: Int? = nil,
+        bridgePendingTransactionCount: Int? = nil,
+        bridgeHasForwardedProtocolFrame: Bool? = nil
+    ) {
+        self.id = id
+        self.timestamp = timestamp
+        self.monotonicUptime = monotonicUptime
+        self.layer = layer
+        self.initiator = initiator
+        self.reason = Self.privacySafeText(
+            reason,
+            maximumLength: 512,
+            sensitiveValues: [sessionToken]
+        ) ?? "unknown"
+        sessionFingerprint = MCPTerminalFingerprint.session(sessionToken)
+        self.localPID = localPID
+        self.peerPID = peerPID
+        self.appConnectionID = appConnectionID
+        self.connectionGeneration = connectionGeneration
+        self.errno = errno
+        self.errorDescription = Self.privacySafeText(
+            errorDescription,
+            maximumLength: 2048,
+            sensitiveValues: [sessionToken]
+        )
+        self.bridgeActiveRequestCount = bridgeActiveRequestCount
+        self.bridgeResponseInDeliveryCount = bridgeResponseInDeliveryCount
+        self.bridgeCancellationTombstoneCount = bridgeCancellationTombstoneCount
+        self.bridgeRecentCompletionCount = bridgeRecentCompletionCount
+        self.bridgePendingTransactionCount = bridgePendingTransactionCount
+        self.bridgeHasForwardedProtocolFrame = bridgeHasForwardedProtocolFrame
+    }
+
+    private static func privacySafeText(
+        _ value: String?,
+        maximumLength: Int,
+        sensitiveValues: [String?]
+    ) -> String? {
+        guard let value else { return nil }
+        var sanitized = value
+            .replacingOccurrences(of: "\r", with: " ")
+            .replacingOccurrences(of: "\n", with: " ")
+        for sensitiveValue in sensitiveValues.compactMap(\.self) where !sensitiveValue.isEmpty {
+            sanitized = sanitized.replacingOccurrences(
+                of: sensitiveValue,
+                with: "<redacted>"
+            )
+        }
+
+        let credentialURLPattern = #"(?i)\b([a-z][a-z0-9+.-]*://)[^/\s:@]+:[^/\s@]+@"#
+        if let regex = try? NSRegularExpression(pattern: credentialURLPattern) {
+            let range = NSRange(sanitized.startIndex..., in: sanitized)
+            sanitized = regex.stringByReplacingMatches(
+                in: sanitized,
+                range: range,
+                withTemplate: "$1<redacted>@"
+            )
+        }
+
+        let sensitiveKeyPattern = #"(?i)([\"']?[a-z0-9_.-]*(?:authorization|proxy-authorization|api[_-]?key|access[_-]?token|refresh[_-]?token|session[_-]?token|token|secret|password|credential|private[_-]?key|cookie|set-cookie|environment|request[_-]?payload|payload|prompt)[a-z0-9_.-]*[\"']?\s*[:=]\s*)(?:bearer\s+[^\s,;&]+|basic\s+[^\s,;&]+|\"[^\"]*\"|'[^']*'|[^\s,;&]+)"#
+        if let regex = try? NSRegularExpression(pattern: sensitiveKeyPattern) {
+            let range = NSRange(sanitized.startIndex..., in: sanitized)
+            sanitized = regex.stringByReplacingMatches(
+                in: sanitized,
+                range: range,
+                withTemplate: "$1<redacted>"
+            )
+        }
+
+        let standaloneSecretPatterns = [
+            #"(?i)\b(bearer|basic)\s+[a-z0-9._~+/=-]+"#,
+            #"\beyJ[a-zA-Z0-9_-]{8,}\.[a-zA-Z0-9_-]{8,}\.[a-zA-Z0-9_-]{8,}\b"#,
+            #"\bsk-[a-zA-Z0-9_-]{16,}\b"#
+        ]
+        for pattern in standaloneSecretPatterns {
+            guard let regex = try? NSRegularExpression(pattern: pattern) else { continue }
+            let range = NSRange(sanitized.startIndex..., in: sanitized)
+            sanitized = regex.stringByReplacingMatches(
+                in: sanitized,
+                range: range,
+                withTemplate: "<redacted>"
+            )
+        }
+
+        let trimmed = sanitized.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        return String(trimmed.prefix(maximumLength))
+    }
+}
+
+public struct MCPTerminalFingerprint: Codable, CustomStringConvertible, Equatable, Sendable {
+    private static let salt = "RepoPrompt.CE.MCP.terminal.v1:"
+    private let value: String
+
+    public var description: String {
+        value
+    }
+
+    private init(value: String) {
+        self.value = value
+    }
+
+    public static func session(_ sessionToken: String?) -> MCPTerminalFingerprint? {
+        guard let sessionToken, !sessionToken.isEmpty else { return nil }
+        let digest = SHA256.hash(data: Data((salt + sessionToken).utf8))
+        return MCPTerminalFingerprint(
+            value: "sha256:" + digest.prefix(8).map { String(format: "%02x", $0) }.joined()
+        )
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let value = try container.decode(String.self)
+        guard value.range(
+            of: #"^sha256:[0-9a-f]{16}$"#,
+            options: .regularExpression
+        ) != nil else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Invalid MCP terminal fingerprint"
+            )
+        }
+        self.value = value
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(value)
+    }
+}
+
+public enum MCPTerminalRecordStore {
+    private static let retainedRecordLimit = 256
+
+    @discardableResult
+    public static func write(
+        _ record: MCPTerminalRecord,
+        to directory: URL,
+        fileManager: FileManager = .default
+    ) throws -> URL {
+        try fileManager.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        try? fileManager.setAttributes(
+            [.posixPermissions: 0o700],
+            ofItemAtPath: directory.path
+        )
+
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let timestamp = formatter.string(from: record.timestamp)
+            .replacingOccurrences(of: ":", with: "-")
+        let fileURL = directory.appendingPathComponent(
+            "terminal-\(timestamp)-\(record.id.uuidString).json",
+            isDirectory: false
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        try encoder.encode(record).write(to: fileURL, options: .atomic)
+        try? fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: fileURL.path)
+        // Retention is best-effort: never discard the terminal event we just
+        // captured merely because an older diagnostic could not be removed.
+        try? pruneTerminalRecords(
+            in: directory,
+            keeping: retainedRecordLimit,
+            fileManager: fileManager
+        )
+        return fileURL
+    }
+
+    private static func pruneTerminalRecords(
+        in directory: URL,
+        keeping limit: Int,
+        fileManager: FileManager
+    ) throws {
+        let terminalRecords = try fileManager.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles, .skipsSubdirectoryDescendants]
+        ).filter { fileURL in
+            fileURL.pathExtension == "json"
+                && fileURL.lastPathComponent.hasPrefix("terminal-")
+        }.sorted { lhs, rhs in
+            lhs.lastPathComponent > rhs.lastPathComponent
+        }
+
+        guard terminalRecords.count > limit else { return }
+        for staleRecord in terminalRecords.dropFirst(limit) {
+            do {
+                try fileManager.removeItem(at: staleRecord)
+            } catch let error as CocoaError where error.code == .fileNoSuchFile {
+                continue
+            }
+        }
+    }
+
+    @discardableResult
+    public static func writeBestEffort(
+        _ record: MCPTerminalRecord,
+        to directory: URL,
+        fileManager: FileManager = .default
+    ) -> URL? {
+        try? write(record, to: directory, fileManager: fileManager)
+    }
+}

--- a/Tests/RepoPromptTests/MCP/Control/UnixSocketMCPReceiveOverflowTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/UnixSocketMCPReceiveOverflowTests.swift
@@ -45,18 +45,23 @@ final class UnixSocketMCPReceiveOverflowTests: XCTestCase {
             }
 
             let snapshot = await transport.ingressSnapshot()
+            let closeValue = await transport.closeSnapshot()
+            let closeSnapshot = try XCTUnwrap(closeValue)
             XCTAssertEqual(snapshot.receiveBufferCapacity, 2)
             XCTAssertEqual(snapshot.acceptedFrameCount, 2)
             XCTAssertEqual(snapshot.droppedFrameCount, 1)
             XCTAssertEqual(snapshot.receiveBufferHighWaterMark, 2)
             XCTAssertTrue(snapshot.isTerminal)
             XCTAssertEqual(snapshot.terminalCause, .receiveBufferOverflow)
+            XCTAssertEqual(closeSnapshot.cause, .receiveBufferOverflow)
+            XCTAssertEqual(closeSnapshot.initiator, .transport)
 
             await manager.recordTransportIngressTerminal(
                 connectionID: connectionID,
                 clientName: "overflow-test-client",
                 sessionToken: "overflow-test-session",
-                snapshot: snapshot
+                snapshot: snapshot,
+                closeSnapshot: closeSnapshot
             )
             let payload = await manager.debugTransportIngressSnapshotPayload(
                 currentConnectionID: connectionID,
@@ -141,6 +146,10 @@ final class UnixSocketMCPReceiveOverflowTests: XCTestCase {
             } catch {
                 XCTFail("Unexpected terminal error: \(error)")
             }
+            let closeValue = await transport.closeSnapshot()
+            let closeSnapshot = try XCTUnwrap(closeValue)
+            XCTAssertEqual(closeSnapshot.cause, .receiveBufferOverflow)
+            XCTAssertEqual(closeSnapshot.initiator, .transport)
 
             let peerSawEOF = await Self.waitUntil { Self.peerObservedEOF(on: descriptors[1]) }
             XCTAssertTrue(peerSawEOF)

--- a/Tests/RepoPromptTests/MCP/Control/UnixSocketMCPTerminalCleanupTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/UnixSocketMCPTerminalCleanupTests.swift
@@ -4,6 +4,84 @@ import Foundation
 import XCTest
 
 final class UnixSocketMCPTerminalCleanupTests: XCTestCase {
+    func testCleanPeerEOFPreservesFirstCloseCause() async throws {
+        let descriptors = try Self.makeSocketPair()
+        defer { Self.closeIfOpen(descriptors[1]) }
+
+        let transport = try UnixSocketMCPTransport(connectedFD: descriptors[0])
+        try await transport.connect()
+        let closeStream = await transport.closed()
+
+        XCTAssertEqual(Darwin.shutdown(descriptors[1], SHUT_WR), 0)
+
+        var iterator = closeStream.makeAsyncIterator()
+        let closeValue = await iterator.next()
+        let close = try XCTUnwrap(closeValue)
+        XCTAssertEqual(close.cause, .peerEOF)
+        XCTAssertEqual(close.initiator, .peer)
+        XCTAssertNil(close.errno)
+        XCTAssertNil(close.errorDescription)
+        let storedClose = await transport.closeSnapshot()
+        XCTAssertEqual(storedClose, close)
+    }
+
+    func testIncompletePeerEOFPreservesProtocolCause() async throws {
+        let descriptors = try Self.makeSocketPair()
+        defer { Self.closeIfOpen(descriptors[1]) }
+
+        let transport = try UnixSocketMCPTransport(connectedFD: descriptors[0])
+        try await transport.connect()
+        let closeStream = await transport.closed()
+
+        try Self.writeAll(Data(#"{"jsonrpc":"2.0""#.utf8), to: descriptors[1])
+        XCTAssertEqual(Darwin.shutdown(descriptors[1], SHUT_WR), 0)
+
+        var iterator = closeStream.makeAsyncIterator()
+        let closeValue = await iterator.next()
+        let close = try XCTUnwrap(closeValue)
+        XCTAssertEqual(close.cause, .incompleteEOF)
+        XCTAssertEqual(close.initiator, .peer)
+        XCTAssertTrue(close.errorDescription?.contains("incomplete frame data") == true)
+        let storedClose = await transport.closeSnapshot()
+        XCTAssertEqual(storedClose, close)
+    }
+
+    func testPeerCloseDuringWritePublishesPeerWriteHangup() async throws {
+        #if DEBUG
+            let descriptors = try Self.makeSocketPair()
+            var peerFD = descriptors[1]
+            defer { Self.closeIfOpen(peerFD) }
+
+            let transport = try UnixSocketMCPTransport(connectedFD: descriptors[0])
+            await transport.debugHoldReaderTerminalCallback()
+            try await transport.connect()
+            let closeStream = await transport.closed()
+
+            Self.closeIfOpen(peerFD)
+            peerFD = -1
+
+            do {
+                try await transport.send(Data("peer-close-write".utf8))
+                XCTFail("Expected write to fail after the peer closed")
+            } catch {
+                // Expected: the close snapshot is the behavior under test.
+            }
+
+            var iterator = closeStream.makeAsyncIterator()
+            let closeValue = await iterator.next()
+            let close = try XCTUnwrap(closeValue)
+            XCTAssertEqual(close.cause, .writeHangup)
+            XCTAssertEqual(close.initiator, .peer)
+            XCTAssertTrue(close.errno == EPIPE || close.errno == ECONNRESET)
+            let storedClose = await transport.closeSnapshot()
+            XCTAssertEqual(storedClose, close)
+
+            await transport.debugReleaseReaderTerminalCallbacks()
+        #else
+            throw XCTSkip("Deterministic transport callback gates require a DEBUG build")
+        #endif
+    }
+
     func testCancellationCallbackBeforeTerminalTaskFinalizesExactlyOnce() async throws {
         #if DEBUG
             let descriptors = try Self.makeSocketPair()

--- a/Tests/RepoPromptTests/MCP/MCPProxyTerminalRecordSourceTests.swift
+++ b/Tests/RepoPromptTests/MCP/MCPProxyTerminalRecordSourceTests.swift
@@ -1,0 +1,36 @@
+import Foundation
+import XCTest
+
+final class MCPProxyTerminalRecordSourceTests: XCTestCase {
+    func testProxyExitPersistsBridgeLedgerTerminalSnapshot() throws {
+        let root = try RepoRoot.url()
+        let source = try String(
+            contentsOf: root.appendingPathComponent("Sources/RepoPromptMCP/main.swift"),
+            encoding: .utf8
+        )
+
+        XCTAssertTrue(source.contains("await bridgeLedger.snapshot()"))
+        XCTAssertTrue(source.contains("MCPTerminalRecordStore.writeBestEffort"))
+        XCTAssertTrue(source.contains("layer: .proxy"))
+        XCTAssertTrue(source.contains("localPID: Int(getpid())"))
+        XCTAssertTrue(source.contains("peerPID: Int(initialPPID)"))
+        XCTAssertTrue(source.contains("bridgeActiveRequestCount: snapshot.activeRequestCount"))
+        XCTAssertTrue(source.contains("bridgeResponseInDeliveryCount: snapshot.responseInDeliveryCount"))
+        XCTAssertTrue(source.contains("bridgePendingTransactionCount: snapshot.pendingTransactionCount"))
+        XCTAssertTrue(source.contains("bridgeHasForwardedProtocolFrame: snapshot.hasForwardedProtocolFrame"))
+        XCTAssertFalse(source.contains("bridgeCommitted:"))
+        XCTAssertTrue(source.contains("reason: reason"))
+        XCTAssertTrue(source.contains("case stdinClosed = \"stdin_closed\""))
+        XCTAssertTrue(source.contains("case parentProcessChanged = \"parent_process_changed\""))
+        XCTAssertTrue(source.contains("case stdoutBrokenPipe = \"stdout_broken_pipe\""))
+        XCTAssertTrue(source.contains("bytesWritten: bytesWritten"))
+        XCTAssertTrue(source.contains("totalBytes: totalBytes"))
+        XCTAssertTrue(source.contains("reason: signal.reason"))
+        XCTAssertTrue(source.contains("message: signal.message ?? CLIKillSignal.messageForReason(signal.reason)"))
+        XCTAssertTrue(source.contains("return provenance.reason.rawValue"))
+        XCTAssertTrue(source.contains("return provenance.stableReason"))
+        XCTAssertTrue(source.contains("case .hostDisconnected, .terminatedByServer:"))
+        XCTAssertTrue(source.contains("case .hostDisconnected:\n        .ok"))
+        XCTAssertTrue(source.contains("case .terminatedByServer:\n        .terminatedByServer"))
+    }
+}

--- a/Tests/RepoPromptTests/MCP/MCPTerminalRecordTests.swift
+++ b/Tests/RepoPromptTests/MCP/MCPTerminalRecordTests.swift
@@ -1,0 +1,172 @@
+import Foundation
+@testable import RepoPrompt
+import RepoPromptShared
+import XCTest
+
+final class MCPTerminalRecordTests: XCTestCase {
+    func testRecordRoundTripUsesTerminalPrefixAndExcludesRawSecrets() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("MCPTerminalRecordTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let rawSessionToken = "raw-session-token-never-persist"
+        let record = try MCPTerminalRecord(
+            id: XCTUnwrap(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE")),
+            timestamp: Date(timeIntervalSince1970: 1_750_000_000),
+            monotonicUptime: 1234.5,
+            layer: .proxy,
+            initiator: .peer,
+            reason: "read_error token=reason-secret",
+            sessionToken: rawSessionToken,
+            localPID: 101,
+            peerPID: 202,
+            appConnectionID: UUID(uuidString: "11111111-2222-3333-4444-555555555555"),
+            connectionGeneration: 7,
+            errno: 54,
+            errorDescription: "Authorization: Bearer bearer-secret url=https://user:pass@example.test/path request_payload={\"token\":\"json-secret\"} environment=env-secret cookie=session-cookie session=\(rawSessionToken)",
+            bridgeActiveRequestCount: 3,
+            bridgeResponseInDeliveryCount: 2,
+            bridgeCancellationTombstoneCount: 1,
+            bridgeRecentCompletionCount: 4,
+            bridgePendingTransactionCount: 5,
+            bridgeHasForwardedProtocolFrame: true
+        )
+
+        let fileURL = try MCPTerminalRecordStore.write(record, to: directory)
+        XCTAssertTrue(fileURL.lastPathComponent.hasPrefix("terminal-"))
+
+        let data = try Data(contentsOf: fileURL)
+        let persistedText = try XCTUnwrap(String(data: data, encoding: .utf8))
+        XCTAssertFalse(persistedText.contains(rawSessionToken))
+        XCTAssertFalse(persistedText.contains("reason-secret"))
+        XCTAssertFalse(persistedText.contains("bearer-secret"))
+        XCTAssertFalse(persistedText.contains("user:pass"))
+        XCTAssertFalse(persistedText.contains("json-secret"))
+        XCTAssertFalse(persistedText.contains("env-secret"))
+        XCTAssertFalse(persistedText.contains("session-cookie"))
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(MCPTerminalRecord.self, from: data)
+        XCTAssertEqual(decoded, record)
+        XCTAssertEqual(decoded.reason, "read_error token=<redacted>")
+        XCTAssertNotNil(decoded.errorDescription)
+        XCTAssertFalse(decoded.errorDescription?.contains("bearer-secret") == true)
+        XCTAssertFalse(decoded.errorDescription?.contains("user:pass") == true)
+        XCTAssertFalse(decoded.errorDescription?.contains("json-secret") == true)
+        XCTAssertFalse(decoded.errorDescription?.contains("env-secret") == true)
+        XCTAssertFalse(decoded.errorDescription?.contains("session-cookie") == true)
+        XCTAssertFalse(decoded.errorDescription?.contains(rawSessionToken) == true)
+    }
+
+    func testStoreRetainsNewestTerminalRecordsWithoutTouchingCLIEvents() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("MCPTerminalRecordRetentionTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        let cliEventURL = directory.appendingPathComponent("cli-preserve-me.json")
+        try Data("cli-event".utf8).write(to: cliEventURL)
+
+        var writtenURLs: [URL] = []
+        for index in 0 ..< 260 {
+            let id = try XCTUnwrap(UUID(uuidString: String(format: "00000000-0000-0000-0000-%012X", index)))
+            let record = MCPTerminalRecord(
+                id: id,
+                timestamp: Date(timeIntervalSince1970: 1_750_000_000 + TimeInterval(index)),
+                monotonicUptime: TimeInterval(index),
+                layer: .proxy,
+                initiator: .transport,
+                reason: "retention_test",
+                sessionToken: nil,
+                localPID: 1,
+                peerPID: nil,
+                appConnectionID: nil,
+                connectionGeneration: UInt64(index),
+                errno: nil,
+                errorDescription: nil
+            )
+            try writtenURLs.append(MCPTerminalRecordStore.write(record, to: directory))
+        }
+
+        let files = try FileManager.default.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: nil
+        )
+        let terminalFiles = files.filter {
+            $0.pathExtension == "json" && $0.lastPathComponent.hasPrefix("terminal-")
+        }
+        XCTAssertEqual(terminalFiles.count, 256)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: cliEventURL.path))
+        for staleURL in writtenURLs.prefix(4) {
+            XCTAssertFalse(FileManager.default.fileExists(atPath: staleURL.path))
+        }
+        for retainedURL in writtenURLs.dropFirst(4) {
+            XCTAssertTrue(FileManager.default.fileExists(atPath: retainedURL.path))
+        }
+    }
+
+    func testFirstTerminalRecordClaimRetriesOriginalRecordWithoutSubstitutingNewCause() {
+        let firstRecord = MCPTerminalRecord(
+            layer: .appAcceptedSocket,
+            initiator: .peer,
+            reason: "peer_eof",
+            sessionToken: "first-cause-session",
+            localPID: 1,
+            peerPID: 2,
+            appConnectionID: UUID(),
+            connectionGeneration: 3,
+            errno: nil,
+            errorDescription: nil
+        )
+        let laterRecord = MCPTerminalRecord(
+            layer: .appAcceptedSocket,
+            initiator: .app,
+            reason: "local_disconnect",
+            sessionToken: "first-cause-session",
+            localPID: 1,
+            peerPID: 2,
+            appConnectionID: firstRecord.appConnectionID,
+            connectionGeneration: 3,
+            errno: nil,
+            errorDescription: "later cleanup"
+        )
+
+        var claim = MCPFirstTerminalRecordClaim()
+        XCTAssertEqual(claim.claim(firstRecord), firstRecord)
+        XCTAssertEqual(claim.claim(laterRecord), firstRecord)
+        XCTAssertEqual(claim.record, firstRecord)
+        XCTAssertFalse(claim.didPersist)
+
+        claim.markPersisted()
+        XCTAssertTrue(claim.didPersist)
+        XCTAssertNil(claim.claim(laterRecord))
+        XCTAssertEqual(claim.record, firstRecord)
+    }
+
+    func testDebugFingerprintMatchesDurableTerminalFingerprint() async {
+        #if DEBUG
+            let token = "shared-fingerprint-session"
+            let manager = ServerNetworkManager()
+            let debugFingerprint = await manager.debugSessionFingerprint(forToken: token)
+            XCTAssertEqual(
+                debugFingerprint,
+                MCPTerminalFingerprint.session(token)?.description
+            )
+        #else
+            throw XCTSkip("DEBUG connection history is unavailable in release builds")
+        #endif
+    }
+
+    func testSaltedFingerprintIsStableAndDoesNotExposeToken() {
+        let token = "sensitive-session-token"
+        let first = MCPTerminalFingerprint.session(token)
+        let second = MCPTerminalFingerprint.session(token)
+
+        XCTAssertEqual(first, second)
+        XCTAssertTrue(first?.description.hasPrefix("sha256:") == true)
+        XCTAssertFalse(first?.description.contains(token) == true)
+        XCTAssertNotEqual(first, MCPTerminalFingerprint.session("different-token"))
+        XCTAssertNil(MCPTerminalFingerprint.session(nil))
+    }
+}


### PR DESCRIPTION
## Summary
- persist correlated, privacy-safe MCP terminal records for app-side accepted sockets and the stdio proxy
- preserve the first transport close cause through cleanup, including EOF, incomplete frames, write hangups, overflow, replacement, shutdown, and watchdog paths
- retain structured Codex host/server disconnect provenance without changing retry, replay, exit-code, or user-facing event behavior
- add transport and persistence regressions for first-cause wins, peer hangups, redaction, retention, and debug fingerprint compatibility

## Design boundary
This intentionally does **not** reconnect or replay a session after a protocol frame may have been committed. A fresh helper/client process remains the safe recovery boundary; replacing an already-terminal Codex RMCP service is upstream client behavior. The new records make that boundary diagnosable from both sides without persisting raw session tokens or request payloads.

## Validation
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh commit`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh push`
- `make dev-test` (full suite)
- `make dev-lint`
- `make guardrails`
- `make dev-swift-build PRODUCT=RepoPrompt`
- `make dev-swift-build PRODUCT=repoprompt-mcp`
- `make dev-smoke` (non-disruptive, existing CE debug app)
- focused terminal record, socket cleanup/overflow, proxy provenance, and persistent-connection tests
