### PR TITLE
Avoid duplicate manage_selection freshness work

### DIFF
--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+SelectionReply.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+SelectionReply.swift
@@ -1,6 +1,11 @@
 import Foundation
 
 extension MCPServerViewModel {
+    enum SelectionReplyIngressPolicy: Equatable {
+        case awaitPending
+        case alreadyAwaited
+    }
+
     @MainActor
     func stabilizedVirtualSelection(for context: TabScopedContext) async -> StoredSelection {
         // For any tab-bound virtual context (including runs), prefer latest stored tab selection.
@@ -272,7 +277,8 @@ extension MCPServerViewModel {
         viewMode: String? = nil,
         codeMapUsageOverride: CodeMapUsage? = nil,
         virtualContext: TabScopedContext? = nil,
-        lookupContextOverride: WorkspaceLookupContext? = nil
+        lookupContextOverride: WorkspaceLookupContext? = nil,
+        ingressPolicy: SelectionReplyIngressPolicy = .awaitPending
     ) async -> ToolResultDTOs.SelectionReply {
         // Always use .auto mode for manage_selection (normalized view)
         let effectiveOverride = effectiveMCPCodeMapUsage(codeMapUsageOverride ?? .auto)
@@ -283,7 +289,9 @@ extension MCPServerViewModel {
         } else {
             WorkspaceLookupContext.visibleWorkspace
         }
-        _ = await promptVM.workspaceFileContextStore.awaitAppliedIngress(rootScope: lookupContext.rootScope)
+        if ingressPolicy == .awaitPending {
+            _ = await promptVM.workspaceFileContextStore.awaitAppliedIngress(rootScope: lookupContext.rootScope)
+        }
         let effectiveSelection = lookupContext.physicalizeSelection(selection)
         let source = StoredSelectionSource(stored: effectiveSelection, codeMapUsage: effectiveOverride)
         let collections = await SelectionReplyAssembler.collect(from: source, owner: self, rootScope: lookupContext.rootScope)
@@ -380,10 +388,7 @@ extension MCPServerViewModel {
         viewMode: String? = nil,
         resolvedContext: ResolvedTabContextSnapshot
     ) async -> ToolResultDTOs.SelectionReply {
-        var context = resolvedContext.snapshot
-        if !resolvedContext.usesActiveTabCompatibility {
-            context.selection = await stabilizedVirtualSelection(for: context)
-        }
+        let context = resolvedContext.snapshot
         return await buildTabSelectionReply(
             from: context.selection,
             includeBlocks: includeBlocks,
@@ -391,7 +396,8 @@ extension MCPServerViewModel {
             extraInvalid: extraInvalid,
             viewMode: viewMode,
             codeMapUsageOverride: .auto,
-            virtualContext: resolvedContext.usesActiveTabCompatibility ? nil : context
+            virtualContext: resolvedContext.usesActiveTabCompatibility ? nil : context,
+            ingressPolicy: .alreadyAwaited
         )
     }
 

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+SelectionReply.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+SelectionReply.swift
@@ -10,13 +10,12 @@ extension MCPServerViewModel {
     func stabilizedVirtualSelection(for context: TabScopedContext) async -> StoredSelection {
         // For any tab-bound virtual context (including runs), prefer latest stored tab selection.
         // This prevents resurrecting stale slices from the run snapshot after the user clears them.
-        if let manager = workspaceManager,
-           let liveTab = manager.composeTab(with: context.tabID)
-        {
-            return liveTab.selection
+        guard let manager = workspaceManager else { return context.selection }
+        if let workspaceID = context.workspaceID {
+            let identity = WorkspaceSelectionIdentity(workspaceID: workspaceID, tabID: context.tabID)
+            return manager.composeTab(for: identity)?.selection ?? context.selection
         }
-
-        return context.selection
+        return manager.composeTab(with: context.tabID)?.selection ?? context.selection
     }
 
     struct TabSelectionData {
@@ -282,10 +281,10 @@ extension MCPServerViewModel {
     ) async -> ToolResultDTOs.SelectionReply {
         // Always use .auto mode for manage_selection (normalized view)
         let effectiveOverride = effectiveMCPCodeMapUsage(codeMapUsageOverride ?? .auto)
-        let lookupContext = if let virtualContext {
-            await lookupContext(for: virtualContext)
-        } else if let lookupContextOverride {
+        let lookupContext = if let lookupContextOverride {
             lookupContextOverride
+        } else if let virtualContext {
+            await lookupContext(for: virtualContext)
         } else {
             WorkspaceLookupContext.visibleWorkspace
         }
@@ -386,9 +385,13 @@ extension MCPServerViewModel {
         display: FilePathDisplay,
         extraInvalid: [String] = [],
         viewMode: String? = nil,
-        resolvedContext: ResolvedTabContextSnapshot
+        resolvedContext: ResolvedTabContextSnapshot,
+        lookupContext: WorkspaceLookupContext
     ) async -> ToolResultDTOs.SelectionReply {
-        let context = resolvedContext.snapshot
+        var context = resolvedContext.snapshot
+        if !resolvedContext.usesActiveTabCompatibility {
+            context.selection = await stabilizedVirtualSelection(for: context)
+        }
         return await buildTabSelectionReply(
             from: context.selection,
             includeBlocks: includeBlocks,
@@ -397,6 +400,38 @@ extension MCPServerViewModel {
             viewMode: viewMode,
             codeMapUsageOverride: .auto,
             virtualContext: resolvedContext.usesActiveTabCompatibility ? nil : context,
+            lookupContextOverride: lookupContext,
+            ingressPolicy: .alreadyAwaited
+        )
+    }
+
+    @MainActor
+    func buildSelectionMutationReply(
+        from selection: StoredSelection,
+        includeBlocks: Bool,
+        display: FilePathDisplay,
+        extraInvalid: [String] = [],
+        viewMode: String? = nil,
+        codeMapUsageOverride: CodeMapUsage? = nil,
+        virtualContext: TabScopedContext?,
+        lookupContext: WorkspaceLookupContext
+    ) async -> ToolResultDTOs.SelectionReply {
+        var effectiveSelection = selection
+        var effectiveVirtualContext = virtualContext
+        if var context = virtualContext {
+            effectiveSelection = await stabilizedVirtualSelection(for: context)
+            context.selection = effectiveSelection
+            effectiveVirtualContext = context
+        }
+        return await buildTabSelectionReply(
+            from: effectiveSelection,
+            includeBlocks: includeBlocks,
+            display: display,
+            extraInvalid: extraInvalid,
+            viewMode: viewMode,
+            codeMapUsageOverride: codeMapUsageOverride,
+            virtualContext: effectiveVirtualContext,
+            lookupContextOverride: lookupContext,
             ingressPolicy: .alreadyAwaited
         )
     }

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+TabContext.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+TabContext.swift
@@ -1704,6 +1704,11 @@ extension MCPServerViewModel {
         guard let resolved else {
             return WorkspaceLookupContext(rootScope: baseScope, bindingProjection: nil)
         }
+        if resolved.usesActiveTabCompatibility,
+           resolved.snapshot.activeAgentSessionID == nil
+        {
+            return WorkspaceLookupContext(rootScope: baseScope, bindingProjection: nil)
+        }
         if let frozenLookupContext = resolved.snapshot.frozenLookupContext {
             return frozenLookupContext
         }

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel.swift
@@ -781,14 +781,15 @@ final class MCPServerViewModel: ObservableObject {
             guard let self else { return context.selection }
             return await stabilizedVirtualSelection(for: context)
         },
-        buildCurrentSelectionReply: { [weak self] includeBlocks, display, extraInvalid, viewMode, resolvedContext in
+        buildCurrentSelectionReply: { [weak self] includeBlocks, display, extraInvalid, viewMode, resolvedContext, lookupContext in
             guard let self else { throw MCPError.internalError("Window deallocated while building selection reply") }
             return await buildCurrentSelectionReply(
                 includeBlocks: includeBlocks,
                 display: display,
                 extraInvalid: extraInvalid,
                 viewMode: viewMode,
-                resolvedContext: resolvedContext
+                resolvedContext: resolvedContext,
+                lookupContext: lookupContext
             )
         },
         buildSelectionPreviewReply: { [weak self] selection, includeBlocks, display, extraInvalid, viewMode, codeMapUsageOverride, lookupContext in
@@ -803,9 +804,9 @@ final class MCPServerViewModel: ObservableObject {
                 lookupContext: lookupContext
             )
         },
-        buildSelectionMutationReply: { [weak self] selection, includeBlocks, display, extraInvalid, viewMode, codeMapUsageOverride, virtualContext in
+        buildSelectionMutationReply: { [weak self] selection, includeBlocks, display, extraInvalid, viewMode, codeMapUsageOverride, virtualContext, lookupContext in
             guard let self else { throw MCPError.internalError("Window deallocated while building selection mutation reply") }
-            return await buildTabSelectionReply(
+            return await buildSelectionMutationReply(
                 from: selection,
                 includeBlocks: includeBlocks,
                 display: display,
@@ -813,7 +814,7 @@ final class MCPServerViewModel: ObservableObject {
                 viewMode: viewMode,
                 codeMapUsageOverride: codeMapUsageOverride,
                 virtualContext: virtualContext,
-                ingressPolicy: .alreadyAwaited
+                lookupContext: lookupContext
             )
         },
         buildManageSelectionSetSelection: { [weak self] inputs, mode, existing, lookupRootScope in

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel.swift
@@ -812,7 +812,8 @@ final class MCPServerViewModel: ObservableObject {
                 extraInvalid: extraInvalid,
                 viewMode: viewMode,
                 codeMapUsageOverride: codeMapUsageOverride,
-                virtualContext: virtualContext
+                virtualContext: virtualContext,
+                ingressPolicy: .alreadyAwaited
             )
         },
         buildManageSelectionSetSelection: { [weak self] inputs, mode, existing, lookupRootScope in

--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPSelectionToolProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPSelectionToolProvider.swift
@@ -157,7 +157,7 @@ final class MCPSelectionToolProvider: MCPWindowToolProviding {
             await MCPToolExecutionHandlerPhaseContext.report(.manageSelectionConstruction, transition: .completed)
             try Task.checkCancellation()
             await MCPToolExecutionHandlerPhaseContext.report(.manageSelectionReplyConstruction)
-            let reply = try await dependencies.buildCurrentSelectionReply(includeBlocks, display, extraInvalid, view, resolvedContext)
+            let reply = try await dependencies.buildCurrentSelectionReply(includeBlocks, display, extraInvalid, view, resolvedContext, lookupContext)
             await MCPToolExecutionHandlerPhaseContext.report(.manageSelectionReplyConstruction, transition: .completed)
             try Task.checkCancellation()
             return reply
@@ -226,6 +226,7 @@ final class MCPSelectionToolProvider: MCPWindowToolProviding {
             return try await persistAndReply(
                 resolvedContext: &resolvedContext,
                 metadata: metadata,
+                lookupContext: lookupContext,
                 baseContext: context,
                 selection: currentSelection,
                 includeBlocks: includeBlocks,
@@ -296,7 +297,7 @@ final class MCPSelectionToolProvider: MCPWindowToolProviding {
             for msg in codemapUnavailableMsgs where !combinedInvalid.contains(msg) {
                 combinedInvalid.append(msg)
             }
-            return try await persistAndReply(resolvedContext: &resolvedContext, metadata: metadata, baseContext: context, selection: currentSelection, includeBlocks: includeBlocks, display: display, extraInvalid: combinedInvalid, view: view)
+            return try await persistAndReply(resolvedContext: &resolvedContext, metadata: metadata, lookupContext: lookupContext, baseContext: context, selection: currentSelection, includeBlocks: includeBlocks, display: display, extraInvalid: combinedInvalid, view: view)
         case "remove":
             if physicalSelectionPaths.isEmpty, physicalSliceInputs.isEmpty { throw MCPError.invalidParams("paths or slices required for remove") }
             if mode == "codemap_only", !physicalSliceInputs.isEmpty { throw MCPError.invalidParams("mode 'codemap_only' cannot be used with slices") }
@@ -345,7 +346,7 @@ final class MCPSelectionToolProvider: MCPWindowToolProviding {
             for error in sliceParseErrors where !combinedInvalid.contains(error) {
                 combinedInvalid.append(error)
             }
-            return try await persistAndReply(resolvedContext: &resolvedContext, metadata: metadata, baseContext: context, selection: currentSelection, includeBlocks: includeBlocks, display: display, extraInvalid: combinedInvalid, view: view)
+            return try await persistAndReply(resolvedContext: &resolvedContext, metadata: metadata, lookupContext: lookupContext, baseContext: context, selection: currentSelection, includeBlocks: includeBlocks, display: display, extraInvalid: combinedInvalid, view: view)
         case "promote":
             let context = resolvedContext.snapshot
             selectionLog("[Virtual] manage_selection op=promote paths=\(selectionPaths.count) tab=\(context.tabID)")
@@ -361,7 +362,7 @@ final class MCPSelectionToolProvider: MCPWindowToolProviding {
                 let hint = await dependencies.makeSelectionHintError(rawPaths, "promote", lookupContext)
                 throw MCPError.invalidParams(hint)
             }
-            return try await persistAndReply(resolvedContext: &resolvedContext, metadata: metadata, baseContext: context, selection: newSelection, includeBlocks: includeBlocks, display: display, extraInvalid: combinedInvalid, view: view)
+            return try await persistAndReply(resolvedContext: &resolvedContext, metadata: metadata, lookupContext: lookupContext, baseContext: context, selection: newSelection, includeBlocks: includeBlocks, display: display, extraInvalid: combinedInvalid, view: view)
         case "demote":
             let context = resolvedContext.snapshot
             selectionLog("[Virtual] manage_selection op=demote paths=\(selectionPaths.count) tab=\(context.tabID)")
@@ -380,7 +381,7 @@ final class MCPSelectionToolProvider: MCPWindowToolProviding {
                 let hint = await dependencies.makeSelectionHintError(rawPaths, "demote", lookupContext)
                 throw MCPError.invalidParams(hint)
             }
-            return try await persistAndReply(resolvedContext: &resolvedContext, metadata: metadata, baseContext: context, selection: demoteResult.selection, includeBlocks: includeBlocks, display: display, extraInvalid: combinedInvalid, view: view)
+            return try await persistAndReply(resolvedContext: &resolvedContext, metadata: metadata, lookupContext: lookupContext, baseContext: context, selection: demoteResult.selection, includeBlocks: includeBlocks, display: display, extraInvalid: combinedInvalid, view: view)
         case "clear":
             let baseContext = resolvedContext.snapshot
             selectionLog("[Virtual] manage_selection op=clear mode=\(mode) tab=\(baseContext.tabID)")
@@ -389,7 +390,7 @@ final class MCPSelectionToolProvider: MCPWindowToolProviding {
             } else {
                 StoredSelection()
             }
-            return try await persistAndReply(resolvedContext: &resolvedContext, metadata: metadata, baseContext: baseContext, selection: clearedSelection, includeBlocks: includeBlocks, display: display, extraInvalid: extraInvalid, view: view)
+            return try await persistAndReply(resolvedContext: &resolvedContext, metadata: metadata, lookupContext: lookupContext, baseContext: baseContext, selection: clearedSelection, includeBlocks: includeBlocks, display: display, extraInvalid: extraInvalid, view: view)
         default:
             throw MCPError.invalidParams("Unsupported op '\(op)' for manage_selection when tab context is active")
         }
@@ -398,6 +399,7 @@ final class MCPSelectionToolProvider: MCPWindowToolProviding {
     private func persistAndReply(
         resolvedContext: inout MCPServerViewModel.ResolvedTabContextSnapshot,
         metadata: MCPServerViewModel.RequestMetadata,
+        lookupContext: WorkspaceLookupContext,
         baseContext: MCPServerViewModel.TabScopedContext,
         selection: StoredSelection,
         includeBlocks: Bool,
@@ -430,7 +432,8 @@ final class MCPSelectionToolProvider: MCPWindowToolProviding {
             extraInvalid,
             view,
             codeMapOverride,
-            resolvedContext.usesActiveTabCompatibility ? nil : replyContext
+            resolvedContext.usesActiveTabCompatibility ? nil : replyContext,
+            lookupContext
         )
         await MCPToolExecutionHandlerPhaseContext.report(.manageSelectionReplyConstruction, transition: .completed)
         try Task.checkCancellation()

--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPWindowToolDependencies.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPWindowToolDependencies.swift
@@ -113,7 +113,8 @@ struct MCPWindowToolDependencies {
         _ display: FilePathDisplay,
         _ extraInvalid: [String],
         _ viewMode: String?,
-        _ resolvedContext: MCPServerViewModel.ResolvedTabContextSnapshot
+        _ resolvedContext: MCPServerViewModel.ResolvedTabContextSnapshot,
+        _ lookupContext: WorkspaceLookupContext
     ) async throws -> ToolResultDTOs.SelectionReply
     typealias BuildSelectionPreviewReply = @MainActor @Sendable (
         _ selection: StoredSelection,
@@ -131,7 +132,8 @@ struct MCPWindowToolDependencies {
         _ extraInvalid: [String],
         _ viewMode: String?,
         _ codeMapUsageOverride: CodeMapUsage?,
-        _ virtualContext: MCPServerViewModel.TabScopedContext?
+        _ virtualContext: MCPServerViewModel.TabScopedContext?,
+        _ lookupContext: WorkspaceLookupContext
     ) async throws -> ToolResultDTOs.SelectionReply
     typealias BuildManageSelectionSetSelection = @MainActor @Sendable (
         _ inputs: MCPServerViewModel.ManageSelectionInputs,

--- a/Tests/RepoPromptTests/MCP/Control/PersistentAgentModeMCPReadFileConnectionTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/PersistentAgentModeMCPReadFileConnectionTests.swift
@@ -1855,6 +1855,10 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
         }
 
         func installPeerWindowLookupSnapshot() async throws {
+            routingGuardWindow.mcpServer.registerAgentWorktreeBindingsProvider { sessionID, tabID in
+                guard sessionID == Self.agentSessionID, tabID == Self.tabID else { return .unavailable }
+                return .hydrated([])
+            }
             var peerWorkspace = try XCTUnwrap(window.workspaceManager.activeWorkspace)
             peerWorkspace.activeComposeTabID = Self.tabID
             let unrelatedSelection = StoredSelection(selectedPaths: ["/tmp/unrelated-workspace.swift"])

--- a/Tests/RepoPromptTests/MCP/MCPSelectionReplyFreshnessTests.swift
+++ b/Tests/RepoPromptTests/MCP/MCPSelectionReplyFreshnessTests.swift
@@ -1,0 +1,367 @@
+import Foundation
+@testable import RepoPrompt
+import XCTest
+
+@MainActor
+final class MCPSelectionReplyFreshnessTests: XCTestCase {
+    func testMutationReplyRereadsLiveTabSelectionAfterProviderStabilization() async throws {
+        let root = try makeTemporaryRoot(name: "MutationReply")
+        defer { try? FileManager.default.removeItem(at: root.deletingLastPathComponent()) }
+        let staleFile = root.appendingPathComponent("Stale.swift")
+        let freshFile = root.appendingPathComponent("Fresh.swift")
+        try write("struct Stale {}\n", to: staleFile)
+        try write("struct Fresh {}\n", to: freshFile)
+
+        let tabID = UUID()
+        let staleSelection = StoredSelection(selectedPaths: [staleFile.path])
+        let freshSelection = StoredSelection(selectedPaths: [freshFile.path])
+        let (window, workspaceID) = await makeWindow(root: root, tabID: tabID, selection: staleSelection)
+        defer { WindowStatesManager.shared.unregisterWindowState(window) }
+        let loadedRoot = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(
+            in: window,
+            path: root.path
+        )
+
+        let providerStabilizedContext = makeContext(
+            window: window,
+            workspaceID: workspaceID,
+            tabID: tabID,
+            selection: staleSelection
+        )
+        let ingressBeforeReply = await window.workspaceFileContextStore.scopedIngressBarrierStatsForTesting(
+            rootID: loadedRoot.id
+        )
+        var liveTab = try XCTUnwrap(window.workspaceManager.composeTab(with: tabID))
+        liveTab.selection = freshSelection
+        XCTAssertTrue(window.workspaceManager.updateComposeTabStoredOnly(liveTab, inWorkspaceID: workspaceID))
+        let reply = await window.mcpServer.buildSelectionMutationReply(
+            from: staleSelection,
+            includeBlocks: false,
+            display: .full,
+            virtualContext: providerStabilizedContext,
+            lookupContext: .visibleWorkspace
+        )
+
+        let ingressAfterReply = await window.workspaceFileContextStore.scopedIngressBarrierStatsForTesting(
+            rootID: loadedRoot.id
+        )
+        XCTAssertEqual(reply.files?.map(\.path), [freshFile.path])
+        XCTAssertEqual(ingressAfterReply.launchCount, ingressBeforeReply.launchCount)
+    }
+
+    func testCurrentReplyRereadsLiveTabSelectionAfterProviderStabilization() async throws {
+        let root = try makeTemporaryRoot(name: "CurrentReply")
+        defer { try? FileManager.default.removeItem(at: root.deletingLastPathComponent()) }
+        let staleFile = root.appendingPathComponent("Stale.swift")
+        let freshFile = root.appendingPathComponent("Fresh.swift")
+        try write("struct Stale {}\n", to: staleFile)
+        try write("struct Fresh {}\n", to: freshFile)
+
+        let tabID = UUID()
+        let staleSelection = StoredSelection(selectedPaths: [staleFile.path])
+        let freshSelection = StoredSelection(selectedPaths: [freshFile.path])
+        let (window, workspaceID) = await makeWindow(root: root, tabID: tabID, selection: staleSelection)
+        defer { WindowStatesManager.shared.unregisterWindowState(window) }
+        let loadedRoot = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(
+            in: window,
+            path: root.path
+        )
+
+        let providerStabilizedContext = makeContext(
+            window: window,
+            workspaceID: workspaceID,
+            tabID: tabID,
+            selection: staleSelection
+        )
+        let resolvedContext = MCPServerViewModel.ResolvedTabContextSnapshot(
+            snapshot: providerStabilizedContext,
+            usesActiveTabCompatibility: false
+        )
+        let ingressBeforeReply = await window.workspaceFileContextStore.scopedIngressBarrierStatsForTesting(
+            rootID: loadedRoot.id
+        )
+        var liveTab = try XCTUnwrap(window.workspaceManager.composeTab(with: tabID))
+        liveTab.selection = freshSelection
+        XCTAssertTrue(window.workspaceManager.updateComposeTabStoredOnly(liveTab, inWorkspaceID: workspaceID))
+        let reply = await window.mcpServer.buildCurrentSelectionReply(
+            includeBlocks: false,
+            display: .full,
+            resolvedContext: resolvedContext,
+            lookupContext: .visibleWorkspace
+        )
+
+        let ingressAfterReply = await window.workspaceFileContextStore.scopedIngressBarrierStatsForTesting(
+            rootID: loadedRoot.id
+        )
+        XCTAssertEqual(reply.files?.map(\.path), [freshFile.path])
+        XCTAssertEqual(ingressAfterReply.launchCount, ingressBeforeReply.launchCount)
+    }
+
+    func testAlreadyAwaitedRepliesKeepProviderResolvedLookupContext() async throws {
+        let workspaceRoot = try makeTemporaryRoot(name: "Workspace")
+        let worktreeRoot = try makeTemporaryRoot(name: "Worktree")
+        defer {
+            try? FileManager.default.removeItem(at: workspaceRoot.deletingLastPathComponent())
+            try? FileManager.default.removeItem(at: worktreeRoot.deletingLastPathComponent())
+        }
+        try write("struct WorkspacePlaceholder {}\n", to: workspaceRoot.appendingPathComponent("Placeholder.swift"))
+        let worktreeFile = worktreeRoot.appendingPathComponent("WorktreeOnly.swift")
+        try write("struct WorktreeOnly {}\n", to: worktreeFile)
+
+        let tabID = UUID()
+        let logicalFile = workspaceRoot.appendingPathComponent(worktreeFile.lastPathComponent)
+        let logicalSelection = StoredSelection(selectedPaths: [logicalFile.path])
+        let (window, workspaceID) = await makeWindow(
+            root: workspaceRoot,
+            tabID: tabID,
+            selection: logicalSelection
+        )
+        defer { WindowStatesManager.shared.unregisterWindowState(window) }
+        let loadedWorkspaceRoot = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(
+            in: window,
+            path: workspaceRoot.path
+        )
+        let loadedWorktreeRoot = try await window.workspaceFileContextStore.loadRoot(
+            path: worktreeRoot.path,
+            kind: .sessionWorktree
+        )
+        let logicalRoot = WorkspaceRootRef(
+            id: loadedWorkspaceRoot.id,
+            name: loadedWorkspaceRoot.name,
+            fullPath: loadedWorkspaceRoot.standardizedFullPath
+        )
+        let physicalRoot = WorkspaceRootRef(
+            id: loadedWorktreeRoot.id,
+            name: loadedWorkspaceRoot.name,
+            fullPath: loadedWorktreeRoot.standardizedFullPath
+        )
+        let projection = WorkspaceRootBindingProjection(
+            sessionID: UUID(),
+            boundRoots: [
+                .init(
+                    logicalRoot: logicalRoot,
+                    physicalRoot: physicalRoot,
+                    binding: makeBinding(logicalRoot: logicalRoot, physicalRoot: physicalRoot)
+                )
+            ],
+            visibleLogicalRoots: [logicalRoot]
+        )
+        let providerResolvedLookupContext = WorkspaceLookupContext(
+            rootScope: projection.lookupRootScope,
+            bindingProjection: projection
+        )
+        let targetIdentity = WorkspaceSelectionIdentity(workspaceID: workspaceID, tabID: tabID)
+        let targetWorkspace = try XCTUnwrap(
+            window.workspaceManager.workspaces.first(where: { $0.id == workspaceID })
+        )
+        let unrelatedSelection = StoredSelection(selectedPaths: ["/tmp/unrelated-duplicate-tab.swift"])
+        let unrelatedWorkspace = WorkspaceModel(
+            name: "Unrelated Duplicate Tab",
+            repoPaths: [],
+            ephemeralFlag: true,
+            composeTabs: [ComposeTabState(id: tabID, name: "Unrelated", selection: unrelatedSelection)],
+            activeComposeTabID: tabID
+        )
+        window.workspaceManager.workspaces = [unrelatedWorkspace, targetWorkspace]
+        var targetTab = try XCTUnwrap(window.workspaceManager.composeTab(for: targetIdentity))
+        targetTab.selection = logicalSelection
+        XCTAssertTrue(window.workspaceManager.updateComposeTabStoredOnly(targetTab, inWorkspaceID: workspaceID))
+        XCTAssertEqual(window.workspaceManager.composeTab(with: tabID)?.selection, unrelatedSelection)
+        XCTAssertEqual(window.workspaceManager.composeTab(for: targetIdentity)?.selection, logicalSelection)
+
+        let context = makeContext(
+            window: window,
+            workspaceID: workspaceID,
+            tabID: tabID,
+            selection: logicalSelection
+        )
+        let resolvedContext = MCPServerViewModel.ResolvedTabContextSnapshot(
+            snapshot: context,
+            usesActiveTabCompatibility: false
+        )
+
+        var liveTab = try XCTUnwrap(window.workspaceManager.composeTab(for: targetIdentity))
+        liveTab.selection = logicalSelection
+        XCTAssertTrue(window.workspaceManager.updateComposeTabStoredOnly(liveTab, inWorkspaceID: workspaceID))
+        let currentReply = await window.mcpServer.buildCurrentSelectionReply(
+            includeBlocks: false,
+            display: .full,
+            resolvedContext: resolvedContext,
+            lookupContext: providerResolvedLookupContext
+        )
+        liveTab = try XCTUnwrap(window.workspaceManager.composeTab(for: targetIdentity))
+        liveTab.selection = logicalSelection
+        XCTAssertTrue(window.workspaceManager.updateComposeTabStoredOnly(liveTab, inWorkspaceID: workspaceID))
+        let mutationReply = await window.mcpServer.buildSelectionMutationReply(
+            from: logicalSelection,
+            includeBlocks: false,
+            display: .full,
+            virtualContext: context,
+            lookupContext: providerResolvedLookupContext
+        )
+
+        XCTAssertEqual(currentReply.files?.map(\.path), [logicalFile.path])
+        XCTAssertEqual(mutationReply.files?.map(\.path), [logicalFile.path])
+    }
+
+    func testActiveCompatibilityLookupContextPreservesActiveSessionAuthority() async throws {
+        let workspaceRoot = try makeTemporaryRoot(name: "CompatibilityWorkspace")
+        let worktreeRoot = try makeTemporaryRoot(name: "CompatibilityWorktree")
+        defer {
+            try? FileManager.default.removeItem(at: workspaceRoot.deletingLastPathComponent())
+            try? FileManager.default.removeItem(at: worktreeRoot.deletingLastPathComponent())
+        }
+        try write("struct WorkspaceFile {}\n", to: workspaceRoot.appendingPathComponent("WorkspaceFile.swift"))
+        try write("struct WorktreeFile {}\n", to: worktreeRoot.appendingPathComponent("WorktreeFile.swift"))
+
+        let tabID = UUID()
+        let sessionID = UUID()
+        let (window, workspaceID) = await makeWindow(
+            root: workspaceRoot,
+            tabID: tabID,
+            selection: StoredSelection()
+        )
+        defer { WindowStatesManager.shared.unregisterWindowState(window) }
+        let loadedWorkspaceRoot = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(
+            in: window,
+            path: workspaceRoot.path
+        )
+        _ = try await window.workspaceFileContextStore.loadRoot(
+            path: worktreeRoot.path,
+            kind: .sessionWorktree
+        )
+        let metadata = MCPServerViewModel.RequestMetadata(
+            connectionID: nil,
+            clientName: "selection-reply-compatibility-test",
+            windowID: window.windowID
+        )
+
+        var bindingState = AgentSessionWorktreeBindingState.unavailable
+        window.mcpServer.registerAgentWorktreeBindingsProvider { requestedSessionID, requestedTabID in
+            guard requestedSessionID == sessionID, requestedTabID == tabID else { return .unavailable }
+            return bindingState
+        }
+
+        let noSessionContext = await window.mcpServer.resolveFileToolLookupContext(from: metadata)
+        XCTAssertEqual(noSessionContext, .visibleWorkspace)
+
+        let identity = WorkspaceSelectionIdentity(workspaceID: workspaceID, tabID: tabID)
+        var liveTab = try XCTUnwrap(window.workspaceManager.composeTab(for: identity))
+        liveTab.activeAgentSessionID = sessionID
+        XCTAssertTrue(window.workspaceManager.updateComposeTabStoredOnly(liveTab, inWorkspaceID: workspaceID))
+
+        bindingState = .hydrated([])
+        let emptyBindingContext = await window.mcpServer.resolveFileToolLookupContext(from: metadata)
+        XCTAssertEqual(emptyBindingContext, .visibleWorkspace)
+
+        let logicalRoot = WorkspaceRootRef(
+            id: loadedWorkspaceRoot.id,
+            name: loadedWorkspaceRoot.name,
+            fullPath: loadedWorkspaceRoot.standardizedFullPath
+        )
+        let physicalRoot = WorkspaceRootRef(
+            id: UUID(),
+            name: loadedWorkspaceRoot.name,
+            fullPath: worktreeRoot.path
+        )
+        bindingState = .hydrated([makeBinding(logicalRoot: logicalRoot, physicalRoot: physicalRoot)])
+        let boundContext = await window.mcpServer.resolveFileToolLookupContext(from: metadata)
+        XCTAssertNotNil(boundContext.bindingProjection)
+        XCTAssertEqual(boundContext.rootScope, boundContext.bindingProjection?.lookupRootScope)
+        XCTAssertEqual(
+            boundContext.translateInputPath(workspaceRoot.appendingPathComponent("WorktreeFile.swift").path),
+            worktreeRoot.appendingPathComponent("WorktreeFile.swift").path
+        )
+
+        bindingState = .unhydrated
+        let unresolvedContext = await window.mcpServer.resolveFileToolLookupContext(from: metadata)
+        XCTAssertEqual(
+            unresolvedContext,
+            WorkspaceLookupContext(
+                rootScope: .sessionBoundWorkspace(canonicalRootPaths: [], physicalRootPaths: []),
+                bindingProjection: nil
+            )
+        )
+    }
+
+    private func makeWindow(
+        root: URL,
+        tabID: UUID,
+        selection: StoredSelection
+    ) async -> (window: WindowState, workspaceID: UUID) {
+        let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
+        GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
+        let window = WindowState()
+        WindowStatesManager.shared.registerWindowState(window)
+        GlobalSettingsStore.shared.setMCPAutoStart(previousAutoStart, commit: false)
+
+        let workspace = WorkspaceModel(
+            name: "Selection Reply \(UUID().uuidString.prefix(8))",
+            repoPaths: [root.path],
+            ephemeralFlag: true,
+            composeTabs: [ComposeTabState(id: tabID, name: "Agent", selection: selection)],
+            activeComposeTabID: tabID
+        )
+        window.workspaceManager.workspaces = [workspace]
+        await window.workspaceManager.switchWorkspace(
+            to: workspace,
+            saveState: false,
+            reason: "mcpSelectionReplyFreshnessTests"
+        )
+        window.promptManager.loadComposeTabsFromWorkspace(workspace, syncPromptText: true)
+        return (window, workspace.id)
+    }
+
+    private func makeContext(
+        window: WindowState,
+        workspaceID: UUID,
+        tabID: UUID,
+        selection: StoredSelection
+    ) -> MCPServerViewModel.TabScopedContext {
+        MCPServerViewModel.TabContextSnapshot(
+            tabID: tabID,
+            windowID: window.windowID,
+            workspaceID: workspaceID,
+            promptText: "",
+            selection: selection,
+            selectedMetaPromptIDs: [],
+            tabName: "Agent",
+            runID: UUID(),
+            explicitlyBound: true
+        )
+    }
+
+    private func makeBinding(
+        logicalRoot: WorkspaceRootRef,
+        physicalRoot: WorkspaceRootRef
+    ) -> AgentSessionWorktreeBinding {
+        AgentSessionWorktreeBinding(
+            id: "selection-reply-binding",
+            repositoryID: "selection-reply-repository",
+            repoKey: "selection-reply-repo-key",
+            logicalRootPath: logicalRoot.standardizedFullPath,
+            logicalRootName: logicalRoot.name,
+            worktreeID: "selection-reply-worktree",
+            worktreeRootPath: physicalRoot.standardizedFullPath,
+            worktreeName: URL(fileURLWithPath: physicalRoot.standardizedFullPath).lastPathComponent,
+            branch: "feature/selection-reply",
+            source: "test"
+        )
+    }
+
+    private func makeTemporaryRoot(name: String) throws -> URL {
+        let parent = FileManager.default.temporaryDirectory
+            .appendingPathComponent("MCPSelectionReplyFreshnessTests-\(UUID().uuidString)", isDirectory: true)
+        let root = parent.appendingPathComponent(name, isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return root.standardizedFileURL
+    }
+
+    private func write(_ content: String, to url: URL) throws {
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try content.write(to: url, atomically: true, encoding: .utf8)
+    }
+}


### PR DESCRIPTION
## Summary
- reuse the request-level workspace ingress barrier when `manage_selection` builds current and mutation replies
- avoid stabilizing virtual selection a second time during `get` replies
- keep standalone selection reply consumers on the safe default ingress policy
- add regression guards for manage_selection, Context Builder, and AgentMode fork reply call sites

## Why
`manage_selection` already drained read-file auto-selection, awaited workspace ingress, and stabilized virtual selection before dispatching the operation. Reply construction repeated the ingress wait, and virtual `get` repeated stabilization, adding unnecessary work and latency.

## Validation
- `make dev-test FILTER=MCPReadSearchLatencyDiagnosticsGuardTests` (66 tests)
- `make dev-lint`
- `make dev-swift-build PRODUCT=RepoPrompt`
- `make dev-test`
- contribution preflight: commit + push modes
