### PR TITLE
Fix role-default rows under filtered availability

### DIFF
--- a/Sources/RepoPrompt/Infrastructure/MCP/Agent/MCPAgentRoleDefaultsService.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/Agent/MCPAgentRoleDefaultsService.swift
@@ -109,7 +109,11 @@ enum MCPAgentRoleDefaultsService {
     ) -> Bool {
         let settingsStore = settingsStore ?? GlobalSettingsStore.shared
         let recommendationAvailability = defaultRecommendedAvailability(from: availability, settingsStore: settingsStore)
-        let recommended = AgentModelCatalog.resolveTaskLabelKind(role, availability: recommendationAvailability)
+        let recommended = resolvedRecommendedSelection(
+            for: role,
+            recommendedAvailability: recommendationAvailability,
+            fallbackAvailability: availability
+        )
         let selectionID = AgentModelSelectionID(agentRaw: selection.agent.rawValue, modelRaw: selection.modelRaw)
         var overrides = settingsStore.globalMCPAgentRoleOverrides() ?? [:]
 
@@ -163,7 +167,11 @@ enum MCPAgentRoleDefaultsService {
         codexDynamicModels: [CodexAppServerClient.RemoteModel]?
     ) -> RoleDefaultResolution? {
         guard let taskLabel = AgentModelCatalog.taskLabel(for: kind) else { return nil }
-        guard let recommended = AgentModelCatalog.resolveTaskLabelKind(kind, availability: recommendedAvailability) else {
+        guard let recommended = resolvedRecommendedSelection(
+            for: kind,
+            recommendedAvailability: recommendedAvailability,
+            fallbackAvailability: availability
+        ) else {
             return nil
         }
 
@@ -209,5 +217,16 @@ enum MCPAgentRoleDefaultsService {
             hasCustomOverride: hasCustomOverride,
             overrideUnavailable: overrideUnavailable
         )
+    }
+
+    private static func resolvedRecommendedSelection(
+        for role: AgentModelCatalog.TaskLabelKind,
+        recommendedAvailability: AgentModelCatalog.AvailabilityContext,
+        fallbackAvailability: AgentModelCatalog.AvailabilityContext
+    ) -> AgentModelCatalog.NormalizedAgentSelection? {
+        // Recommendation filters pick the preferred default when possible, but they should not hide
+        // role rows when the app still has selectable agents outside the filtered recommendation set.
+        AgentModelCatalog.resolveTaskLabelKind(role, availability: recommendedAvailability)
+            ?? AgentModelCatalog.resolveTaskLabelKind(role, availability: fallbackAvailability)
     }
 }

--- a/Tests/RepoPromptTests/AgentMode/MCPAgentRoleDefaultsServiceTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/MCPAgentRoleDefaultsServiceTests.swift
@@ -1,0 +1,117 @@
+@testable import RepoPrompt
+import XCTest
+
+@MainActor
+final class MCPAgentRoleDefaultsServiceTests: XCTestCase {
+    func testResolutionsFallbackToActualAvailabilityWhenRecommendationAvailabilityIsEmpty() {
+        let actualAvailability = AgentModelCatalog.AvailabilityContext(
+            claudeCodeAvailable: false,
+            codexAvailable: true,
+            openCodeAvailable: false,
+            cursorAvailable: false,
+            zaiConfigured: false,
+            kimiConfigured: false,
+            customClaudeCompatibleConfigured: false
+        )
+
+        let resolutions = MCPAgentRoleDefaultsService.resolutions(
+            availability: actualAvailability,
+            recommendedAvailability: AgentModelCatalog.AvailabilityContext.none,
+            settingsStore: RoleDefaultsStoreStub()
+        )
+
+        XCTAssertEqual(
+            resolutions.map(\.role),
+            AgentModelCatalog.TaskLabelKind.allCases
+        )
+
+        XCTAssertEqual(resolutions[0].recommended.agent, .codexExec)
+        XCTAssertEqual(resolutions[0].recommended.modelRaw, AgentModel.gpt55CodexLow.rawValue)
+        XCTAssertEqual(resolutions[1].recommended.agent, .codexExec)
+        XCTAssertEqual(resolutions[1].recommended.modelRaw, AgentModel.gpt55CodexLow.rawValue)
+        XCTAssertEqual(resolutions[2].recommended.agent, .codexExec)
+        XCTAssertEqual(resolutions[2].recommended.modelRaw, AgentModel.gpt55CodexHigh.rawValue)
+        XCTAssertEqual(resolutions[3].recommended.agent, .codexExec)
+        XCTAssertEqual(resolutions[3].recommended.modelRaw, AgentModel.gpt55CodexMedium.rawValue)
+    }
+
+    func testResolutionsPreferRecommendationAvailabilityWhenItCanResolveRole() throws {
+        let actualAvailability = AgentModelCatalog.AvailabilityContext(
+            claudeCodeAvailable: false,
+            codexAvailable: true,
+            openCodeAvailable: false,
+            cursorAvailable: false,
+            zaiConfigured: true,
+            kimiConfigured: false,
+            customClaudeCompatibleConfigured: false
+        )
+        let recommendedAvailability = AgentModelCatalog.AvailabilityContext(
+            claudeCodeAvailable: false,
+            codexAvailable: false,
+            openCodeAvailable: false,
+            cursorAvailable: false,
+            zaiConfigured: true,
+            kimiConfigured: false,
+            customClaudeCompatibleConfigured: false
+        )
+
+        let engineer = try XCTUnwrap(MCPAgentRoleDefaultsService.effectiveSelection(
+            for: .engineer,
+            availability: actualAvailability,
+            recommendedAvailability: recommendedAvailability,
+            settingsStore: RoleDefaultsStoreStub()
+        ))
+
+        XCTAssertEqual(engineer.recommended.agent, .claudeCodeGLM)
+        XCTAssertEqual(engineer.recommended.modelRaw, AgentModel.claudeSonnet.rawValue)
+        XCTAssertEqual(engineer.effective, engineer.recommended)
+    }
+
+    func testSetSelectionClearsOverrideWhenSelectionMatchesFallbackRecommendation() {
+        let actualAvailability = AgentModelCatalog.AvailabilityContext(
+            claudeCodeAvailable: false,
+            codexAvailable: true,
+            openCodeAvailable: false,
+            cursorAvailable: false,
+            zaiConfigured: false,
+            kimiConfigured: false,
+            customClaudeCompatibleConfigured: false
+        )
+        let store = RoleDefaultsStoreStub(overrides: [
+            AgentModelCatalog.TaskLabelKind.explore.rawValue: AgentModelSelectionID(
+                agentRaw: AgentProviderKind.claudeCode.rawValue,
+                modelRaw: AgentModel.claudeOpus.rawValue
+            ).rawValue
+        ])
+        let selection = AgentModelCatalog.NormalizedAgentSelection(
+            agent: .codexExec,
+            modelRaw: AgentModel.gpt55CodexLow.rawValue
+        )
+
+        MCPAgentRoleDefaultsService.setSelection(
+            selection,
+            for: .explore,
+            availability: actualAvailability,
+            settingsStore: store
+        )
+
+        XCTAssertNil(store.overrides)
+    }
+}
+
+@MainActor
+private final class RoleDefaultsStoreStub: MCPAgentRoleDefaultsStoring {
+    private(set) var overrides: [String: String]?
+
+    init(overrides: [String: String]? = nil) {
+        self.overrides = overrides
+    }
+
+    func globalMCPAgentRoleOverrides() -> [String: String]? {
+        overrides
+    }
+
+    func updateGlobalMCPAgentRoleOverrides(_ overrides: [String: String]?, commit: Bool) {
+        self.overrides = overrides
+    }
+}


### PR DESCRIPTION
## Summary
- keep sub-agent role-default rows visible when recommendation-filtered availability cannot resolve a role
- preserve recommendation-filtered defaults when they are available, falling back to actual selectable availability only when needed
- add focused coverage for fallback rendering, filtered recommendation precedence, and override clearing

Fixes #222

## Validation
- `git diff --check`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh commit`
- `./conductor test --filter MCPAgentRoleDefaultsServiceTests --request-key issue-222-role-defaults-review-followup`
- `make dev-format`
- `make dev-lint`
- `make dev-swift-build PRODUCT=RepoPrompt`
- `make dev-smoke`
- `make dev-test`
- `/usr/local/bin/rpce-cli -w 4 review ...` returned no findings
- Live debug app check: Settings -> Agent Models and the main Models popover both render explore/engineer/pair/design rows with Z.ai available

Note: push preflight was run after commit; guardrails, outgoing secret scan, and lint passed, but its repeated full-suite reruns parked late in `WorkspaceFileContextStoreTests` after a separate full `make dev-test` had already passed. Both parked reruns were canceled cleanly to avoid leaving dangling test processes.