### PR TITLE
Fix agent preview retention architecture

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/Services/AgentContextExportResolver.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Services/AgentContextExportResolver.swift
@@ -128,6 +128,22 @@ extension AgentContextExportRow {
     }
 }
 
+enum AgentContextPreviewContentPolicy {
+    static let maximumBytes = 256_000
+    static let maximumCharacters = 200_000
+
+    static func boundedPreviewText(_ text: String, wasTruncated: Bool = false) -> String {
+        let exceedsCharacterLimit = text.count > maximumCharacters
+        guard wasTruncated || exceedsCharacterLimit else { return text }
+        let preview = exceedsCharacterLimit ? String(text.prefix(maximumCharacters)) : text
+        return """
+        \(preview)
+
+        … Preview truncated to avoid retaining large file content. Copy the file content for the full text.
+        """
+    }
+}
+
 struct AgentContextClipboardRequest {
     let cfg: PromptContextResolved
     let source: AgentContextExportSource
@@ -272,17 +288,33 @@ enum AgentContextExportResolver {
         case .codemap:
             let snapshots = await store.codemapSnapshotDictionary()
             let text = snapshots[row.id.fileID]?.fileAPI?.getFullAPIDescription(displayPath: row.displayPath)
-            return text?.isEmpty == false ? text : nil
+            guard let text, !text.isEmpty else { return nil }
+            return purpose == .preview ? AgentContextPreviewContentPolicy.boundedPreviewText(text) : text
         case .full:
+            if purpose == .preview {
+                guard let prefix = try? await store.readContentPrefix(
+                    rootID: row.rootID,
+                    relativePath: row.relativePath,
+                    maximumBytes: AgentContextPreviewContentPolicy.maximumBytes
+                ) else {
+                    return nil
+                }
+                return AgentContextPreviewContentPolicy.boundedPreviewText(
+                    prefix.content,
+                    wasTruncated: prefix.truncated
+                )
+            }
             return try? await store.readContent(rootID: row.rootID, relativePath: row.relativePath)
         case .slices:
             guard let content = try? await store.readContent(rootID: row.rootID, relativePath: row.relativePath) else {
                 return nil
             }
-            guard purpose == .copy, let ranges = row.lineRanges, !ranges.isEmpty else {
-                return content
+            let renderedContent: String = if let ranges = row.lineRanges, !ranges.isEmpty {
+                SliceAssemblyBuilder.build(from: content, ranges: ranges).combinedText
+            } else {
+                content
             }
-            return SliceAssemblyBuilder.build(from: content, ranges: ranges).combinedText
+            return purpose == .preview ? AgentContextPreviewContentPolicy.boundedPreviewText(renderedContent) : renderedContent
         }
     }
 

--- a/Sources/RepoPrompt/Features/AgentMode/Views/RuntimeSidebar/AgentRuntimeExportCard.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/RuntimeSidebar/AgentRuntimeExportCard.swift
@@ -365,6 +365,7 @@ private struct AgentSelectedFilesPopover: View {
     let onClear: (AgentContextExportModel) -> Void
 
     @ObservedObject private var fontScale = FontScaleManager.shared
+    @StateObject private var previewCoordinator = AgentSelectedFilePreviewLoadCoordinator()
     @State private var activeTab: Tab = .files
 
     private enum Tab {
@@ -435,6 +436,7 @@ private struct AgentSelectedFilesPopover: View {
                                     row: row,
                                     rowIndex: index,
                                     canRemove: canMutate && row.canRemove,
+                                    previewCoordinator: previewCoordinator,
                                     onLoadContent: onLoadContent,
                                     onRemove: { row in
                                         guard let model else { return }
@@ -459,6 +461,12 @@ private struct AgentSelectedFilesPopover: View {
         }
         .onChange(of: split.codemapRows.count) { _, _ in
             adjustActiveTab(fileCount: split.fileRows.count, codemapCount: split.codemapRows.count)
+        }
+        .onChange(of: activeTab) { _, _ in
+            previewCoordinator.reconcileVisibleRows(split.rows(for: activeTab))
+        }
+        .onChange(of: split.rows.map(\.id)) { _, _ in
+            previewCoordinator.reconcileVisibleRows(split.rows(for: activeTab))
         }
     }
 
@@ -561,7 +569,7 @@ private struct AgentSelectedFilesPopover: View {
 
 @MainActor
 final class AgentSelectedFilePreviewLoadCoordinator: ObservableObject {
-    @Published private(set) var showPreview = false
+    @Published private(set) var activePreviewRowID: ResolvedPromptFileEntryID?
     @Published private(set) var contentRevision = 0
     @Published private(set) var previewText: String? {
         didSet { contentRevision &+= 1 }
@@ -571,24 +579,39 @@ final class AgentSelectedFilePreviewLoadCoordinator: ObservableObject {
         didSet { contentRevision &+= 1 }
     }
 
+    private var activePreviewRow: AgentContextExportRow?
     private var previewLoadTask: Task<Void, Never>?
+
+    deinit {
+        previewLoadTask?.cancel()
+    }
 
     var hasPreviewLoadTask: Bool {
         previewLoadTask != nil
+    }
+
+    func isPreviewPresented(for row: AgentContextExportRow) -> Bool {
+        activePreviewRowID == row.id
+    }
+
+    func isLoadingPreview(for row: AgentContextExportRow) -> Bool {
+        activePreviewRowID == row.id && isLoadingPreview
     }
 
     func openPreview(
         row: AgentContextExportRow,
         loadContent: @escaping (AgentContextExportRow, AgentContextExportRow.ContentPurpose) async -> String?
     ) {
-        cancelPreviewLoad()
-        showPreview = true
-        previewText = nil
+        closeActivePreview()
+        activePreviewRow = row
+        activePreviewRowID = row.id
         isLoadingPreview = true
         previewLoadTask = Task { [weak self] in
+            let rowID = row.id
             let text = await loadContent(row, .preview)
             guard !Task.isCancelled else { return }
             await MainActor.run { [weak self] in
+                guard self?.activePreviewRow?.id == rowID else { return }
                 self?.previewText = text
                 self?.isLoadingPreview = false
                 self?.previewLoadTask = nil
@@ -596,21 +619,38 @@ final class AgentSelectedFilePreviewLoadCoordinator: ObservableObject {
         }
     }
 
-    func handlePreviewPresentationChanged(isPresented: Bool) {
-        showPreview = isPresented
-        if !isPresented {
-            cancelPreviewLoad()
+    func displayText(for row: AgentContextExportRow) -> String {
+        guard activePreviewRowID == row.id else { return "No preview content available" }
+        if isLoadingPreview { return "Loading preview…" }
+        return previewText ?? "No preview content available"
+    }
+
+    func handlePreviewPresentationChanged(row: AgentContextExportRow, isPresented: Bool) {
+        if !isPresented, activePreviewRow == row {
+            closeActivePreview()
         }
     }
 
-    func handleRowDisappear() {
-        cancelPreviewLoad()
+    func handleRowDisappear(row: AgentContextExportRow) {
+        if activePreviewRow == row {
+            closeActivePreview()
+        }
     }
 
-    private func cancelPreviewLoad() {
+    func reconcileVisibleRows(_ rows: [AgentContextExportRow]) {
+        guard let activePreviewRow else { return }
+        if !rows.contains(activePreviewRow) {
+            closeActivePreview()
+        }
+    }
+
+    private func closeActivePreview() {
         previewLoadTask?.cancel()
         previewLoadTask = nil
+        activePreviewRow = nil
+        activePreviewRowID = nil
         isLoadingPreview = false
+        previewText = nil
     }
 }
 
@@ -618,10 +658,10 @@ private struct AgentSelectedFileRow: View {
     let row: AgentContextExportRow
     let rowIndex: Int
     let canRemove: Bool
+    @ObservedObject var previewCoordinator: AgentSelectedFilePreviewLoadCoordinator
     let onLoadContent: (AgentContextExportRow, AgentContextExportRow.ContentPurpose) async -> String?
     let onRemove: (AgentContextExportRow) -> Void
 
-    @StateObject private var previewCoordinator = AgentSelectedFilePreviewLoadCoordinator()
     @State private var copyTask: Task<Void, Never>?
     @State private var isCopying = false
     @ObservedObject private var fontScale = FontScaleManager.shared
@@ -688,7 +728,7 @@ private struct AgentSelectedFileRow: View {
 
             HStack(spacing: 6) {
                 Button(action: openPreview) {
-                    Image(systemName: previewCoordinator.isLoadingPreview ? "hourglass" : "magnifyingglass")
+                    Image(systemName: previewCoordinator.isLoadingPreview(for: row) ? "hourglass" : "magnifyingglass")
                         .font(.system(size: 13, weight: .medium))
                         .padding(6)
                 }
@@ -739,8 +779,8 @@ private struct AgentSelectedFileRow: View {
         .contentShape(Rectangle())
         .popover(
             isPresented: Binding(
-                get: { previewCoordinator.showPreview },
-                set: { previewCoordinator.handlePreviewPresentationChanged(isPresented: $0) }
+                get: { previewCoordinator.isPreviewPresented(for: row) },
+                set: { previewCoordinator.handlePreviewPresentationChanged(row: row, isPresented: $0) }
             ),
             arrowEdge: .bottom
         ) {
@@ -750,7 +790,7 @@ private struct AgentSelectedFileRow: View {
             )
         }
         .onDisappear {
-            previewCoordinator.handleRowDisappear()
+            previewCoordinator.handleRowDisappear(row: row)
             copyTask?.cancel()
         }
     }
@@ -780,8 +820,7 @@ private struct AgentResolvedFilePreviewPopover: View {
     @ObservedObject var previewCoordinator: AgentSelectedFilePreviewLoadCoordinator
 
     private var displayText: String {
-        if previewCoordinator.isLoadingPreview { return "Loading preview…" }
-        return previewCoordinator.previewText ?? "No preview content available"
+        previewCoordinator.displayText(for: row)
     }
 
     var body: some View {

--- a/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService+ContentLoading.swift
+++ b/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService+ContentLoading.swift
@@ -71,6 +71,11 @@ private struct ContentReadResult {
     }
 }
 
+struct FileContentPrefix {
+    let content: String
+    let truncated: Bool
+}
+
 private struct ValidatedContentFile {
     let url: URL
     let fileSize: Int64
@@ -557,6 +562,25 @@ extension FileSystemService {
         )
     }
 
+    func loadContentPrefix(
+        ofRelativePath relativePath: String,
+        maximumBytes: Int,
+        workloadClass: ContentReadWorkloadClass = .unspecified
+    ) async throws -> FileContentPrefix? {
+        guard maximumBytes > 0 else { return FileContentPrefix(content: "", truncated: true) }
+        if Self.hasAlwaysBinaryExtension(relativePath) { return nil }
+        let request = try makeContentReadRequest(
+            cacheKey: relativePath,
+            chunkSize: min(maximumBytes + 1, 1_048_576),
+            fileSizeLimit: 10_000_000,
+            mode: .automatic,
+            workloadClass: workloadClass
+        )
+        let prefix = try await Self.performContentPrefixReadOffActor(request, maximumBytes: maximumBytes)
+        try Task.checkCancellation()
+        return prefix
+    }
+
     func loadContent(
         ofRelativePath relativePath: String,
         workloadClass: ContentReadWorkloadClass = .unspecified
@@ -920,6 +944,28 @@ extension FileSystemService {
         encodingMap[cacheKey] = detectedEncoding
     }
 
+    private nonisolated static func performContentPrefixReadOffActor(
+        _ request: ContentReadRequest,
+        maximumBytes: Int
+    ) async throws -> FileContentPrefix? {
+        let workerPriority = Task.currentPriority
+        return try await contentReadWorkerLimiter.withPermit(
+            workloadClass: request.workloadClass,
+            ownerID: request.schedulerOwnerID
+        ) {
+            try await withThrowingTaskGroup(of: FileContentPrefix?.self) { group in
+                group.addTask(priority: workerPriority) {
+                    try await readContentPrefixFromDisk(request, maximumBytes: maximumBytes)
+                }
+                guard let result = try await group.next() else {
+                    throw CancellationError()
+                }
+                group.cancelAll()
+                return result
+            }
+        }
+    }
+
     private nonisolated static func performContentReadOffActor(
         _ request: ContentReadRequest,
         expectedFingerprint: FileContentFingerprint? = nil,
@@ -945,6 +991,47 @@ extension FileSystemService {
                 return result
             }
         }
+    }
+
+    private nonisolated static func readContentPrefixFromDisk(
+        _ request: ContentReadRequest,
+        maximumBytes: Int
+    ) async throws -> FileContentPrefix? {
+        if hasAlwaysBinaryExtension(request.relativePath) {
+            return nil
+        }
+        try Task.checkCancellation()
+        let validated = try validateContentFileForReading(request)
+        let handle = try openValidatedContentHandle(
+            request,
+            validated: validated,
+            requireStableIdentity: false
+        )
+        defer { try? handle.close() }
+
+        try await runContentReadChunkHook(request)
+        let requestedByteCount = max(0, maximumBytes)
+        let data = try handle.read(upToCount: requestedByteCount + 1) ?? Data()
+        try Task.checkCancellation()
+        guard !data.isEmpty else {
+            return FileContentPrefix(content: "", truncated: false)
+        }
+
+        let probe = data.prefix(min(data.count, 8192))
+        if isProbablyBinary(probe) {
+            return nil
+        }
+
+        let wasTruncated = data.count > requestedByteCount || validated.fileSize > Int64(requestedByteCount)
+        var prefixData = Data(data.prefix(requestedByteCount))
+        let encoding: String.Encoding = detectBOMEncoding(in: prefixData) ?? detectEncodingFull(prefixData)
+        while !prefixData.isEmpty {
+            if let decoded = String(data: prefixData, encoding: encoding) {
+                return FileContentPrefix(content: decoded, truncated: wasTruncated)
+            }
+            prefixData.removeLast()
+        }
+        return FileContentPrefix(content: "", truncated: wasTruncated)
     }
 
     private nonisolated static func readContentFromDisk(

--- a/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService+ContentLoading.swift
+++ b/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService+ContentLoading.swift
@@ -1001,7 +1001,17 @@ extension FileSystemService {
             return nil
         }
         try Task.checkCancellation()
+        let requestedByteCount = max(0, maximumBytes)
         let validated = try validateContentFileForReading(request)
+        if validated.fileSize <= Int64(requestedByteCount) {
+            let result = try await readAutomaticContent(
+                request,
+                validated: validated,
+                requireStableIdentity: false
+            )
+            return result.content.map { FileContentPrefix(content: $0, truncated: false) }
+        }
+
         let handle = try openValidatedContentHandle(
             request,
             validated: validated,
@@ -1010,7 +1020,6 @@ extension FileSystemService {
         defer { try? handle.close() }
 
         try await runContentReadChunkHook(request)
-        let requestedByteCount = max(0, maximumBytes)
         let data = try handle.read(upToCount: requestedByteCount + 1) ?? Data()
         try Task.checkCancellation()
         guard !data.isEmpty else {

--- a/Sources/RepoPrompt/Infrastructure/UI/TextField/TextKitView.swift
+++ b/Sources/RepoPrompt/Infrastructure/UI/TextField/TextKitView.swift
@@ -346,6 +346,9 @@ struct TextKitView: NSViewRepresentable {
         textView.isContinuousSpellCheckingEnabled = false
         textView.isAutomaticSpellingCorrectionEnabled = false
         coordinator.textViewUndoManager.removeAllActions()
+        textView.string = ""
+        coordinator.internalText = ""
+        coordinator.wasEmpty = true
         coordinator.pendingLayoutTask?.cancel()
         coordinator.pendingLayoutTask = nil
         // NEW: mark inactive

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
@@ -4494,6 +4494,20 @@ actor WorkspaceFileContextStore {
         await interactiveReadCache.clear()
     }
 
+    func readContentPrefix(
+        rootID: UUID,
+        relativePath: String,
+        maximumBytes: Int,
+        workloadClass: ContentReadWorkloadClass = .unspecified
+    ) async throws -> FileContentPrefix? {
+        let state = try state(for: rootID)
+        return try await state.service.loadContentPrefix(
+            ofRelativePath: StandardizedPath.relative(relativePath),
+            maximumBytes: maximumBytes,
+            workloadClass: workloadClass
+        )
+    }
+
     func readContent(
         rootID: UUID,
         relativePath: String,

--- a/Tests/RepoPromptTests/AgentMode/AgentContextExportResolverTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentContextExportResolverTests.swift
@@ -560,6 +560,48 @@ final class AgentContextExportResolverTests: XCTestCase {
         XCTAssertFalse(clipboard.contains("base checkout complete diff must not appear"), clipboard)
     }
 
+    func testPreviewContentIsPrefixBoundedWhileCopyRemainsFullContent() async throws {
+        let root = try makeTemporaryRoot(name: "AgentExportPreviewBound")
+        let content = String(repeating: "x", count: AgentContextPreviewContentPolicy.maximumBytes + 2000)
+        try write(content, to: root.appendingPathComponent("Sources/Large.swift"))
+
+        let store = WorkspaceFileContextStore()
+        _ = try await store.loadRoot(path: root.path)
+        let source = AgentContextExportSource(
+            tabID: UUID(),
+            promptText: "Review",
+            selection: StoredSelection(selectedPaths: ["Sources/Large.swift"], codemapAutoEnabled: false),
+            selectedMetaPromptIDs: [],
+            tabName: "Agent Tab",
+            activeAgentSessionID: nil,
+            worktreeBindings: []
+        )
+        let model = await AgentContextExportResolver.resolveModel(
+            source: source,
+            store: store,
+            filePathDisplay: .relative,
+            codeMapUsage: .none
+        )
+        let row = try XCTUnwrap(model.rows.first)
+
+        let previewResult = await AgentContextExportResolver.loadRowContent(
+            for: row,
+            store: store,
+            purpose: .preview
+        )
+        let copyResult = await AgentContextExportResolver.loadRowContent(
+            for: row,
+            store: store,
+            purpose: .copy
+        )
+        let preview = try XCTUnwrap(previewResult)
+        let copy = try XCTUnwrap(copyResult)
+
+        XCTAssertLessThan(preview.count, copy.count)
+        XCTAssertTrue(preview.contains("Preview truncated"))
+        XCTAssertEqual(copy, content)
+    }
+
     private func makeBoundFixture() async throws -> (logicalRoot: URL, worktreeRoot: URL, store: WorkspaceFileContextStore) {
         let logicalRoot = try makeTemporaryRoot(name: "AgentExportLogical")
         let worktreeRoot = try makeTemporaryRoot(name: "AgentExportWorktree")

--- a/Tests/RepoPromptTests/AgentMode/AgentContextExportResolverTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentContextExportResolverTests.swift
@@ -602,6 +602,46 @@ final class AgentContextExportResolverTests: XCTestCase {
         XCTAssertEqual(copy, content)
     }
 
+    func testPreviewContentBelowPrefixLimitUsesCompleteContentWithoutTruncationMarker() async throws {
+        let root = try makeTemporaryRoot(name: "AgentExportPreviewSmall")
+        let content = String(repeating: "small\n", count: 1000)
+        try write(content, to: root.appendingPathComponent("Sources/Small.swift"))
+
+        let store = WorkspaceFileContextStore()
+        _ = try await store.loadRoot(path: root.path)
+        let source = AgentContextExportSource(
+            tabID: UUID(),
+            promptText: "Review",
+            selection: StoredSelection(selectedPaths: ["Sources/Small.swift"], codemapAutoEnabled: false),
+            selectedMetaPromptIDs: [],
+            tabName: "Agent Tab",
+            activeAgentSessionID: nil,
+            worktreeBindings: []
+        )
+        let model = await AgentContextExportResolver.resolveModel(
+            source: source,
+            store: store,
+            filePathDisplay: .relative,
+            codeMapUsage: .none
+        )
+        let row = try XCTUnwrap(model.rows.first)
+
+        let previewResult = await AgentContextExportResolver.loadRowContent(
+            for: row,
+            store: store,
+            purpose: .preview
+        )
+        let copyResult = await AgentContextExportResolver.loadRowContent(
+            for: row,
+            store: store,
+            purpose: .copy
+        )
+
+        XCTAssertEqual(previewResult, content)
+        XCTAssertEqual(copyResult, content)
+        XCTAssertFalse(previewResult?.contains("Preview truncated") ?? true)
+    }
+
     private func makeBoundFixture() async throws -> (logicalRoot: URL, worktreeRoot: URL, store: WorkspaceFileContextStore) {
         let logicalRoot = try makeTemporaryRoot(name: "AgentExportLogical")
         let worktreeRoot = try makeTemporaryRoot(name: "AgentExportWorktree")

--- a/Tests/RepoPromptTests/AgentMode/AgentSelectedFilePreviewLifecycleTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentSelectedFilePreviewLifecycleTests.swift
@@ -5,7 +5,7 @@ final class AgentSelectedFilePreviewLifecycleTests: XCTestCase {
     @MainActor
     func testPreviewLoadCompletionPublishesTextAndClearsLoadingState() async {
         let coordinator = AgentSelectedFilePreviewLoadCoordinator()
-        let row = makeRow()
+        let row = makeRow(displayName: "A.swift")
         let gate = PreviewLoadGate()
         let initialRevision = coordinator.contentRevision
 
@@ -13,8 +13,9 @@ final class AgentSelectedFilePreviewLifecycleTests: XCTestCase {
             await gate.load(row: row, purpose: purpose)
         }
 
-        XCTAssertTrue(coordinator.showPreview)
-        XCTAssertTrue(coordinator.isLoadingPreview)
+        XCTAssertTrue(coordinator.isPreviewPresented(for: row))
+        XCTAssertTrue(coordinator.isLoadingPreview(for: row))
+        XCTAssertEqual(coordinator.activePreviewRowID, row.id)
         XCTAssertNil(coordinator.previewText)
         XCTAssertTrue(coordinator.hasPreviewLoadTask)
         let loadingRevision = coordinator.contentRevision
@@ -29,29 +30,33 @@ final class AgentSelectedFilePreviewLifecycleTests: XCTestCase {
         XCTAssertTrue(didComplete, "Preview load should complete")
         await drainCancelledTask()
 
-        XCTAssertTrue(coordinator.showPreview)
-        XCTAssertFalse(coordinator.isLoadingPreview)
+        XCTAssertTrue(coordinator.isPreviewPresented(for: row))
+        XCTAssertFalse(coordinator.isLoadingPreview(for: row))
         XCTAssertEqual(coordinator.previewText, "loaded preview text")
+        XCTAssertEqual(coordinator.displayText(for: row), "loaded preview text")
         XCTAssertFalse(coordinator.hasPreviewLoadTask)
         let loadedRevision = coordinator.contentRevision
         XCTAssertGreaterThan(loadedRevision, loadingRevision)
 
-        coordinator.handlePreviewPresentationChanged(isPresented: false)
+        coordinator.handlePreviewPresentationChanged(row: row, isPresented: false)
+        XCTAssertFalse(coordinator.isPreviewPresented(for: row))
+        XCTAssertNil(coordinator.activePreviewRowID)
+        XCTAssertNil(coordinator.previewText)
         XCTAssertGreaterThan(coordinator.contentRevision, loadedRevision)
     }
 
     @MainActor
-    func testRowDisappearCancellationClearsPreviewLoadingState() async {
+    func testRowDisappearCancellationClearsActivePreviewAndLoadedText() async {
         let coordinator = AgentSelectedFilePreviewLoadCoordinator()
-        let row = makeRow()
+        let row = makeRow(displayName: "A.swift")
         let gate = PreviewLoadGate()
 
         coordinator.openPreview(row: row) { row, purpose in
             await gate.load(row: row, purpose: purpose)
         }
 
-        XCTAssertTrue(coordinator.showPreview)
-        XCTAssertTrue(coordinator.isLoadingPreview)
+        XCTAssertTrue(coordinator.isPreviewPresented(for: row))
+        XCTAssertTrue(coordinator.isLoadingPreview(for: row))
         XCTAssertNil(coordinator.previewText)
         XCTAssertTrue(coordinator.hasPreviewLoadTask)
         guard await gate.waitUntilStarted() else {
@@ -59,9 +64,11 @@ final class AgentSelectedFilePreviewLifecycleTests: XCTestCase {
             return
         }
 
-        coordinator.handleRowDisappear()
+        coordinator.handleRowDisappear(row: row)
 
-        XCTAssertFalse(coordinator.isLoadingPreview)
+        XCTAssertFalse(coordinator.isPreviewPresented(for: row))
+        XCTAssertNil(coordinator.activePreviewRowID)
+        XCTAssertFalse(coordinator.isLoadingPreview(for: row))
         XCTAssertNil(coordinator.previewText)
         XCTAssertFalse(coordinator.hasPreviewLoadTask)
 
@@ -70,33 +77,36 @@ final class AgentSelectedFilePreviewLifecycleTests: XCTestCase {
         XCTAssertTrue(didCompleteAfterDisappear, "Preview load should resume after release")
         await drainCancelledTask()
 
-        XCTAssertFalse(coordinator.isLoadingPreview)
+        XCTAssertFalse(coordinator.isPreviewPresented(for: row))
+        XCTAssertNil(coordinator.activePreviewRowID)
+        XCTAssertFalse(coordinator.isLoadingPreview(for: row))
         XCTAssertNil(coordinator.previewText)
         XCTAssertFalse(coordinator.hasPreviewLoadTask)
     }
 
     @MainActor
-    func testPreviewDismissalCancellationClearsLoadingState() async {
+    func testPreviewDismissalCancellationClearsActivePreviewAndLoadedText() async {
         let coordinator = AgentSelectedFilePreviewLoadCoordinator()
-        let row = makeRow()
+        let row = makeRow(displayName: "A.swift")
         let gate = PreviewLoadGate()
 
         coordinator.openPreview(row: row) { row, purpose in
             await gate.load(row: row, purpose: purpose)
         }
 
-        XCTAssertTrue(coordinator.showPreview)
-        XCTAssertTrue(coordinator.isLoadingPreview)
+        XCTAssertTrue(coordinator.isPreviewPresented(for: row))
+        XCTAssertTrue(coordinator.isLoadingPreview(for: row))
         XCTAssertTrue(coordinator.hasPreviewLoadTask)
         guard await gate.waitUntilStarted() else {
             XCTFail("Preview load did not start")
             return
         }
 
-        coordinator.handlePreviewPresentationChanged(isPresented: false)
+        coordinator.handlePreviewPresentationChanged(row: row, isPresented: false)
 
-        XCTAssertFalse(coordinator.showPreview)
-        XCTAssertFalse(coordinator.isLoadingPreview)
+        XCTAssertFalse(coordinator.isPreviewPresented(for: row))
+        XCTAssertNil(coordinator.activePreviewRowID)
+        XCTAssertFalse(coordinator.isLoadingPreview(for: row))
         XCTAssertNil(coordinator.previewText)
         XCTAssertFalse(coordinator.hasPreviewLoadTask)
 
@@ -105,29 +115,138 @@ final class AgentSelectedFilePreviewLifecycleTests: XCTestCase {
         XCTAssertTrue(didCompleteAfterDismissal, "Preview load should resume after release")
         await drainCancelledTask()
 
-        XCTAssertFalse(coordinator.showPreview)
-        XCTAssertFalse(coordinator.isLoadingPreview)
+        XCTAssertFalse(coordinator.isPreviewPresented(for: row))
+        XCTAssertNil(coordinator.activePreviewRowID)
+        XCTAssertFalse(coordinator.isLoadingPreview(for: row))
         XCTAssertNil(coordinator.previewText)
         XCTAssertFalse(coordinator.hasPreviewLoadTask)
     }
 
+    @MainActor
+    func testOpeningSecondPreviewCancelsFirstAndOnlyPublishesActiveRowText() async {
+        let coordinator = AgentSelectedFilePreviewLoadCoordinator()
+        let rowA = makeRow(displayName: "A.swift")
+        let rowB = makeRow(displayName: "B.swift")
+        let gate = MultiPreviewLoadGate()
+
+        coordinator.openPreview(row: rowA) { row, purpose in
+            await gate.load(row: row, purpose: purpose)
+        }
+        guard await gate.waitUntilStarted(rowA.displayName) else {
+            XCTFail("First preview load did not start")
+            return
+        }
+
+        coordinator.openPreview(row: rowB) { row, purpose in
+            await gate.load(row: row, purpose: purpose)
+        }
+        guard await gate.waitUntilStarted(rowB.displayName) else {
+            XCTFail("Second preview load did not start")
+            return
+        }
+
+        XCTAssertFalse(coordinator.isPreviewPresented(for: rowA))
+        XCTAssertTrue(coordinator.isPreviewPresented(for: rowB))
+        XCTAssertEqual(coordinator.activePreviewRowID, rowB.id)
+
+        coordinator.handlePreviewPresentationChanged(row: rowA, isPresented: false)
+        XCTAssertTrue(coordinator.isPreviewPresented(for: rowB))
+        XCTAssertEqual(coordinator.activePreviewRowID, rowB.id)
+
+        await gate.release("A.swift", value: "late first text")
+        let didCompleteRowA = await gate.waitUntilCompleted(rowA.displayName)
+        XCTAssertTrue(didCompleteRowA)
+        await drainCancelledTask()
+        XCTAssertNil(coordinator.previewText)
+        XCTAssertTrue(coordinator.isLoadingPreview(for: rowB))
+
+        await gate.release("B.swift", value: "second text")
+        let didCompleteRowB = await gate.waitUntilCompleted(rowB.displayName)
+        XCTAssertTrue(didCompleteRowB)
+        let didPublishSecondText = await waitForPreviewText("second text", in: coordinator)
+
+        XCTAssertTrue(didPublishSecondText)
+        XCTAssertEqual(coordinator.previewText, "second text")
+        XCTAssertEqual(coordinator.displayText(for: rowB), "second text")
+        XCTAssertFalse(coordinator.isPreviewPresented(for: rowA))
+    }
+
+    @MainActor
+    func testReconcileVisibleRowsClearsPreviewWhenActiveRowIdentityChanges() async {
+        let coordinator = AgentSelectedFilePreviewLoadCoordinator()
+        let row = makeRow(displayName: "A.swift")
+        let changedRow = makeRow(
+            id: row.id,
+            displayName: "A.swift",
+            relativePath: "Sources/Renamed.swift"
+        )
+        let gate = PreviewLoadGate()
+
+        coordinator.openPreview(row: row) { row, purpose in
+            await gate.load(row: row, purpose: purpose)
+        }
+        guard await gate.waitUntilStarted() else {
+            XCTFail("Preview load did not start")
+            return
+        }
+        await gate.release("loaded preview text")
+        let didComplete = await gate.waitUntilCompleted()
+        XCTAssertTrue(didComplete)
+        let didPublishText = await waitForPreviewText("loaded preview text", in: coordinator)
+        XCTAssertTrue(didPublishText)
+
+        coordinator.reconcileVisibleRows([changedRow])
+
+        XCTAssertNil(coordinator.activePreviewRowID)
+        XCTAssertNil(coordinator.previewText)
+        XCTAssertFalse(coordinator.isPreviewPresented(for: row))
+        XCTAssertFalse(coordinator.isPreviewPresented(for: changedRow))
+    }
+
+    func testPreviewPolicyBoundsLargeText() {
+        let limit = AgentContextPreviewContentPolicy.maximumCharacters
+        let text = String(repeating: "x", count: limit + 1)
+
+        let bounded = AgentContextPreviewContentPolicy.boundedPreviewText(text)
+
+        XCTAssertTrue(bounded.hasPrefix(String(repeating: "x", count: limit)))
+        XCTAssertFalse(bounded.hasPrefix(text))
+        XCTAssertTrue(bounded.contains("Preview truncated"))
+    }
+
     private func makeRow(
+        id: ResolvedPromptFileEntryID? = nil,
+        displayName: String = "App.swift",
         kind: AgentContextExportRow.Kind = .full,
         mode: PromptFileEntryMode = .fullFile,
-        lineRanges: [LineRange]? = nil
+        lineRanges: [LineRange]? = nil,
+        rootID: UUID = UUID(),
+        relativePath: String? = nil
     ) -> AgentContextExportRow {
-        AgentContextExportRow(
-            id: ResolvedPromptFileEntryID(fileID: UUID(), mode: mode, lineRanges: lineRanges),
+        let resolvedID = id ?? ResolvedPromptFileEntryID(fileID: UUID(), mode: mode, lineRanges: lineRanges)
+        let resolvedRelativePath = relativePath ?? "Sources/\(displayName)"
+        return AgentContextExportRow(
+            id: resolvedID,
             kind: kind,
-            physicalPath: "/tmp/RepoPromptTests/Sources/App.swift",
-            rootID: UUID(),
-            relativePath: "Sources/App.swift",
-            displayPath: "Sources/App.swift",
-            displayName: "App.swift",
+            physicalPath: "/tmp/RepoPromptTests/\(resolvedRelativePath)",
+            rootID: rootID,
+            relativePath: resolvedRelativePath,
+            displayPath: resolvedRelativePath,
+            displayName: displayName,
             directoryDisplay: "Sources",
             lineRanges: lineRanges,
             canRemove: true
         )
+    }
+
+    @MainActor
+    private func waitForPreviewText(_ expected: String, in coordinator: AgentSelectedFilePreviewLoadCoordinator) async -> Bool {
+        for _ in 0 ..< 500 {
+            if coordinator.previewText == expected { return true }
+            await Task.yield()
+            try? await Task.sleep(nanoseconds: 1_000_000)
+        }
+        return coordinator.previewText == expected
     }
 
     private func drainCancelledTask() async {
@@ -170,5 +289,39 @@ private actor PreviewLoadGate {
             try? await Task.sleep(nanoseconds: 1_000_000)
         }
         return completed
+    }
+}
+
+private actor MultiPreviewLoadGate {
+    private var started = Set<String>()
+    private var completed = Set<String>()
+    private var releaseContinuations: [String: CheckedContinuation<String?, Never>] = [:]
+
+    func load(row: AgentContextExportRow, purpose _: AgentContextExportRow.ContentPurpose) async -> String? {
+        await withCheckedContinuation { continuation in
+            releaseContinuations[row.displayName] = continuation
+            started.insert(row.displayName)
+        }
+    }
+
+    func waitUntilStarted(_ displayName: String) async -> Bool {
+        for _ in 0 ..< 500 {
+            if started.contains(displayName) { return true }
+            try? await Task.sleep(nanoseconds: 1_000_000)
+        }
+        return started.contains(displayName)
+    }
+
+    func release(_ displayName: String, value: String?) {
+        releaseContinuations.removeValue(forKey: displayName)?.resume(returning: value)
+        completed.insert(displayName)
+    }
+
+    func waitUntilCompleted(_ displayName: String) async -> Bool {
+        for _ in 0 ..< 500 {
+            if completed.contains(displayName) { return true }
+            try? await Task.sleep(nanoseconds: 1_000_000)
+        }
+        return completed.contains(displayName)
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #221 after lead review flagged that per-row preview coordinators could retain preview state for many selected files.

This PR reworks the Agent selected-files preview path so it no longer scales retained preview state with row count:

- moves preview loading state from per-row `@StateObject`s to a single popover/card-level coordinator
- clears active preview text/task/row identity on dismissal and reconciles active state when rows change
- bounds preview reads to a prefix while keeping copy/export reads full-fidelity
- adds prefix loading through the file-system/content store path instead of materializing whole large files for preview
- clears TextKit preview backing strings during teardown
- adds lifecycle/regression tests for stale completions, row identity changes, dismissal, and truncation behavior

## Context

#221 fixed stale preview loading state, but after merge we identified a broader architecture concern: each row could own a coordinator that retained preview content, and preview loading could materialize full large files even though the UI only needs bounded preview text. This PR is intended as the proper follow-up architecture fix.

## Validation

- `make dev-test FILTER=AgentSelectedFilePreviewLifecycleTests` — passed, 6 tests
- `make dev-test FILTER=AgentContextExportResolverTests/testPreviewContentIsPrefixBoundedWhileCopyRemainsFullContent` — passed
- `make dev-lint` — passed, 0 violations
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh commit` — passed before commit
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh push` — passed
  - outgoing range: `upstream/main..HEAD`
  - full coordinated `swift test` — passed
  - `swift build --product RepoPrompt` — passed

## Informal performance notes

I will add a separate PR comment with the informal local measurements from the synthetic preview probe and live RSS monitoring so the numbers are easy to find/discuss.
