### PR TITLE
Dismiss hover tooltips when MCP toolbar buttons open a surface

### DIFF
--- a/Sources/RepoPrompt/Infrastructure/UI/Components/MCPConnectionsCounter.swift
+++ b/Sources/RepoPrompt/Infrastructure/UI/Components/MCPConnectionsCounter.swift
@@ -29,6 +29,7 @@ struct MCPConnectionsCounter: View {
 
     var body: some View {
         Button {
+            HoverTooltipCoordinator.dismissAll()
             NotificationCenter.default.post(
                 name: .showMCPStatusWindow,
                 object: nil,

--- a/Sources/RepoPrompt/Infrastructure/UI/Components/MCPServerToggleView.swift
+++ b/Sources/RepoPrompt/Infrastructure/UI/Components/MCPServerToggleView.swift
@@ -95,7 +95,10 @@ struct MCPServerToggleView: View {
     }
 
     var body: some View {
-        Button(action: { showPopover.toggle() }) {
+        Button(action: {
+            HoverTooltipCoordinator.dismissAll()
+            showPopover.toggle()
+        }) {
             HStack(spacing: 6) {
                 Image(systemName: "server.rack")
                     .imageScale(.medium)

--- a/Sources/RepoPrompt/Infrastructure/UI/Components/TooltipBubble.swift
+++ b/Sources/RepoPrompt/Infrastructure/UI/Components/TooltipBubble.swift
@@ -46,6 +46,16 @@ struct TooltipBubble: View {
 /// ──────────────────────────────────
 enum TooltipPlacement { case top, bottom, left, right, topLeft, topRight, bottomLeft, bottomRight }
 
+enum HoverTooltipCoordinator {
+    static func dismissAll() {
+        NotificationCenter.default.post(name: .hoverTooltipsShouldDismiss, object: nil)
+    }
+}
+
+extension Notification.Name {
+    static let hoverTooltipsShouldDismiss = Notification.Name("RepoPromptHoverTooltipsShouldDismiss")
+}
+
 // ──────────────────────────────────
 // MARK: - Modifier
 
@@ -152,6 +162,9 @@ private struct HoverTooltipModifier: ViewModifier {
                 if !enabled {
                     cleanup(resetContext: false)
                 }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .hoverTooltipsShouldDismiss)) { _ in
+                cleanup(resetContext: false)
             }
     }
 

--- a/Sources/RepoPrompt/Infrastructure/UI/Tooltip/TooltipOverlayController.swift
+++ b/Sources/RepoPrompt/Infrastructure/UI/Tooltip/TooltipOverlayController.swift
@@ -19,6 +19,11 @@ final class TooltipOverlayController {
         placement: TooltipPlacement,
         preset: FontScalePreset
     ) {
+        guard Self.isValidAnchorRect(anchorRect) else {
+            hide()
+            return
+        }
+
         prepareWindowIfNeeded(owner: owner, preset: preset)
         let bubbleSize = bubbleSize(for: text, preset: preset)
         guard let win else { return }
@@ -43,6 +48,11 @@ final class TooltipOverlayController {
     }
 
     func reposition(to anchorRect: NSRect) {
+        guard Self.isValidAnchorRect(anchorRect) else {
+            hide()
+            return
+        }
+
         guard
             let win,
             let owner,
@@ -137,11 +147,7 @@ final class TooltipOverlayController {
             owner.removeChildWindow(w)
         }
 
-        // Remove notification observer
-        if let token = ownerWillCloseObserver {
-            NotificationCenter.default.removeObserver(token)
-            ownerWillCloseObserver = nil
-        }
+        removeObservers()
 
         win = nil
         owner = nil
@@ -159,6 +165,7 @@ final class TooltipOverlayController {
     private var cachedPreset: FontScalePreset?
 
     private var ownerWillCloseObserver: NSObjectProtocol?
+    private var hoverDismissObserver: NSObjectProtocol?
 
     /// Distance (in points) between the tooltip bubble and its anchor view.
     /// Kept small to avoid a large visual gap; still multiplied by
@@ -178,16 +185,57 @@ final class TooltipOverlayController {
         // This avoids hierarchy issues with menus
         win = tooltipWindow
 
-        ownerWillCloseObserver = NotificationCenter.default.addObserver(
+        installObservers(for: owner)
+    }
+
+    private func installObservers(for owner: NSWindow) {
+        removeObservers()
+
+        let center = NotificationCenter.default
+        ownerWillCloseObserver = center.addObserver(
             forName: NSWindow.willCloseNotification,
             object: owner,
             queue: .main
-        ) // ensure main thread
-            { [weak self] _ in
-                Task { @MainActor [weak self] in
-                    self?.hide()
-                }
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.hide()
+            }
         }
+
+        hoverDismissObserver = center.addObserver(
+            forName: .hoverTooltipsShouldDismiss,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.hide()
+            }
+        }
+    }
+
+    private func removeObservers() {
+        if let ownerWillCloseObserver {
+            NotificationCenter.default.removeObserver(ownerWillCloseObserver)
+            self.ownerWillCloseObserver = nil
+        }
+        if let hoverDismissObserver {
+            NotificationCenter.default.removeObserver(hoverDismissObserver)
+            self.hoverDismissObserver = nil
+        }
+    }
+
+    #if DEBUG
+        var isVisibleForTesting: Bool {
+            win?.isVisible == true
+        }
+    #endif
+
+    private static func isValidAnchorRect(_ rect: NSRect) -> Bool {
+        !rect.isEmpty
+            && rect.origin.x.isFinite
+            && rect.origin.y.isFinite
+            && rect.size.width.isFinite
+            && rect.size.height.isFinite
     }
 
     private func bubbleSize(for text: String, preset: FontScalePreset) -> CGSize {

--- a/Tests/RepoPromptTests/Infrastructure/UI/TooltipOverlayControllerTests.swift
+++ b/Tests/RepoPromptTests/Infrastructure/UI/TooltipOverlayControllerTests.swift
@@ -1,0 +1,79 @@
+import AppKit
+@testable import RepoPrompt
+import XCTest
+
+@MainActor
+final class TooltipOverlayControllerTests: XCTestCase {
+    func testTooltipHidesWhenDismissAllIsRequested() async {
+        let owner = makeVisibleOwnerWindow()
+        let controller = showTooltip(owner: owner)
+        defer {
+            controller.hide()
+            owner.orderOut(nil)
+        }
+
+        XCTAssertTrue(controller.isVisibleForTesting)
+
+        HoverTooltipCoordinator.dismissAll()
+        await Task.yield()
+
+        XCTAssertFalse(controller.isVisibleForTesting)
+    }
+
+    func testTooltipHidesInsteadOfMovingToWindowOriginWhenRepositionedToInvalidAnchor() {
+        let owner = makeVisibleOwnerWindow()
+        let controller = showTooltip(owner: owner)
+        defer {
+            controller.hide()
+            owner.orderOut(nil)
+        }
+
+        XCTAssertTrue(controller.isVisibleForTesting)
+
+        controller.reposition(to: .zero)
+
+        XCTAssertFalse(controller.isVisibleForTesting)
+    }
+
+    func testTooltipDoesNotShowWithInvalidInitialAnchor() {
+        let owner = makeVisibleOwnerWindow()
+        let controller = TooltipOverlayController()
+        defer {
+            controller.hide()
+            owner.orderOut(nil)
+        }
+
+        controller.show(
+            text: "1 connection - View status",
+            anchorRect: .zero,
+            owner: owner,
+            placement: .top,
+            preset: .current
+        )
+
+        XCTAssertFalse(controller.isVisibleForTesting)
+    }
+
+    private func makeVisibleOwnerWindow() -> NSWindow {
+        let owner = NSWindow(
+            contentRect: NSRect(x: 80, y: 120, width: 320, height: 240),
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: false
+        )
+        owner.orderFront(nil)
+        return owner
+    }
+
+    private func showTooltip(owner: NSWindow) -> TooltipOverlayController {
+        let controller = TooltipOverlayController()
+        controller.show(
+            text: "1 connection - View status",
+            anchorRect: NSRect(x: 8, y: 8, width: 80, height: 20),
+            owner: owner,
+            placement: .top,
+            preset: .current
+        )
+        return controller
+    }
+}


### PR DESCRIPTION
## Problem

Clicking the MCP **connections counter** (the green link/count pill) or the **MCP Server** toggle in the toolbar could leave a hover tooltip floating over the freshly opened status window / popover.

Why it sticks:
- A hover tooltip's only auto-dismiss paths are hover-exit (`onHover(false)`) and the click/scroll/key event monitors — but those monitors are installed *only after* the tooltip becomes visible (after the 300 ms hover delay). A click that lands during that delay can't dismiss it.
- When the button opens a new window/popover, that surface appears under the cursor and steals focus, so the button's `onHover(false)` never fires.
- The tooltip overlay renders at `.floating` window level, so it sits *on top of* the newly opened surface — very visibly stuck until the next unrelated click/scroll/keypress.

A second, related failure: a stale/empty anchor geometry report (e.g. `.zero` during a layout/window transition) fed `owner.convertToScreen(.zero)`, snapping the bubble to the owner window's bottom-left corner.

## Fix

- Add `HoverTooltipCoordinator.dismissAll()`, which posts a notification observed by both `HoverTooltipModifier` and `TooltipOverlayController`. The modifier-side cleanup cancels a *pending-but-unshown* tooltip as well as hiding a visible one. The two MCP toolbar buttons call it before opening their surface.
- Guard `show()` / `reposition()` against empty or non-finite anchor rects — hide instead of mispositioning to the window origin.
- Refactor observer install/teardown so the new dismiss observer is cleaned up alongside the owner-will-close observer.

## Tests

Adds `TooltipOverlayControllerTests` covering dismiss-all and the invalid-anchor `show`/`reposition` paths.

## Validation

- `make dev-lint` — 0 violations (format-check + SwiftLint strict)
- `make dev-test` — full suite green (run via push preflight); new suite passes, stable across repeated runs
- `make dev-swift-build PRODUCT=RepoPrompt` — clean
- Contribution preflight passed in `commit` and `push` modes (staged-index + outgoing-range secret scans)

UI-only change; does not touch MCP CLI/server, Agent Mode, or packaging.

## Screenshot

This shows the issue: the MCP status surface opens while the hover tooltip remains floating over any app.

<img width="2560" height="1412" alt="Screenshot 2026-06-15 at 15 09 53" src="https://github.com/user-attachments/assets/ec6190b9-7d2a-43f2-a3c1-810928e6e389" />

<img width="2560" height="1407" alt="Screenshot 2026-06-15 at 15 09 09" src="https://github.com/user-attachments/assets/386f73e2-ea53-40f3-a1ab-127259507119" />