### PR TITLE
Refresh approved contributors

### DIFF
--- a/.github/APPROVED_CONTRIBUTORS
+++ b/.github/APPROVED_CONTRIBUTORS
@@ -192,6 +192,7 @@ davidandrewsmith90 pr
 davidarce pr
 davidgovea pr
 davidmansaray pr
+davidrd123 pr
 DavidSchargel pr
 DavidWells pr
 dayvough pr
@@ -230,7 +231,7 @@ eclipsology pr
 eddiekollar pr
 eichert12 pr
 emigal pr
-EmilMN pr
+emil pr
 Empedoclez pr
 ENY66 pr
 enzodesena pr
@@ -556,7 +557,6 @@ redrumkev pr
 redwhitblack pr
 regismesquita pr
 Reksa97 pr
-remarkz007 pr
 resolutionathens pr
 richardreeze pr
 riddhish143 pr
@@ -723,6 +723,7 @@ yerffejytnac pr
 yihuikhuu pr
 Yip-Yip pr
 yjsoon pr
+yoshua0x pr
 youqad pr
 yourDomainAdmin pr
 yug105 pr


### PR DESCRIPTION
## Summary
- Refresh `.github/APPROVED_CONTRIBUTORS` from live customer claims.
- Contributor count changed from 738 to 739.
- Unresolved claim-form IDs: `TeamLandiLTD` (organization account), `Tyschultz7` (not found), `hsinskip` (not found).

## Validation
- `make guardrails`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh commit`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh push`
