### PR TITLE
Bound conductor XCTest stalls

### DIFF
--- a/Scripts/conductor.py
+++ b/Scripts/conductor.py
@@ -68,8 +68,10 @@ APP_STOP_CONFIRM_TIMEOUT_SECONDS = 8.0
 APP_STOP_DELAYED_LAUNCH_CONFIRM_TIMEOUT_SECONDS = 25.0
 
 SHORT_TIMEOUT_SECONDS = 5 * 60
+TEST_TIMEOUT_SECONDS = 15 * 60
 MEDIUM_TIMEOUT_SECONDS = 60 * 60
 RELEASE_TIMEOUT_SECONDS = 2 * 60 * 60
+DEFAULT_XCTEST_STALL_SECONDS = 120.0
 SMOKE_AGENT_WAIT_SECONDS = 120.0
 
 IMPLEMENTED_OPERATIONS = {
@@ -176,6 +178,7 @@ class ConductorError(Exception):
 XCTEST_PROGRESS_RE = re.compile(
     r"^Test Case '(.+)' (started|passed|failed|skipped)(?: \([^)]*\))?\.\s*$"
 )
+XCTEST_BUILD_COMPLETE_RE = re.compile(r"^Build complete! \([^)]+\)\s*$")
 
 
 @dataclasses.dataclass(frozen=True)
@@ -944,9 +947,16 @@ class OperationRegistry:
             snapshot[key] = value
         return snapshot
 
+    @staticmethod
+    def normalize_operation_args(operation: Any, args: Dict[str, Any]) -> Dict[str, Any]:
+        normalized = dict(args)
+        if operation in {"test", "provider-test"} and "xctestStallSeconds" not in normalized:
+            normalized["xctestStallSeconds"] = DEFAULT_XCTEST_STALL_SECONDS
+        return normalized
+
     def prepare(self, request: Dict[str, Any]) -> Tuple[List[str], List[str], Path, Dict[str, str], Optional[float]]:
         operation = request.get("operation")
-        args = request.get("args") or {}
+        args = self.normalize_operation_args(operation, request.get("args") or {})
         timeout = request.get("timeout")
         verbose = bool(request.get("verbose"))
         if timeout is not None and float(timeout) < 0:
@@ -1107,6 +1117,8 @@ class OperationRegistry:
         return [sys.executable, "-u", str(self.script_path), "__operation_runner", json_dumps(payload)]
 
     def _default_timeout(self, operation: Any, args: Dict[str, Any]) -> float:
+        if operation in {"test", "provider-test"}:
+            return TEST_TIMEOUT_SECONDS
         if operation in {"doctor", "guardrails", "debug-cli-status", "format-tools-status", "check-format-tools"}:
             return SHORT_TIMEOUT_SECONDS
         if operation == "app" and args.get("subcommand") in {"status", "stop"}:
@@ -1225,6 +1237,7 @@ class DaemonState:
         if operation == "app" and args.get("subcommand") in {"stop", "relaunch"}:
             # Derived exclusively by supersession below, never accepted from a client.
             args.pop("guardDelayedLaunch", None)
+        args = self.registry.normalize_operation_args(operation, args)
         normalized_request = dict(request)
         normalized_request["args"] = args
         fingerprint = self.registry.fingerprint(normalized_request)
@@ -1692,6 +1705,7 @@ class DaemonState:
                 job = self.jobs.get(ticket)
                 if job:
                     self._append_tail_locked(job, text)
+                    self._record_xctest_startup_locked(job, text)
                     self._record_xctest_progress_locked(job, text)
                     self.condition.notify_all()
 
@@ -1752,6 +1766,20 @@ class DaemonState:
                 if job.xctest_current_test == test_name:
                     job.xctest_current_test = None
         return matched
+
+    def _record_xctest_startup_locked(
+        self,
+        job: Job,
+        text: str,
+        observed_at: Optional[float] = None,
+    ) -> bool:
+        if not self._xctest_watchdog_enabled(job) or job.xctest_progress_deadline is not None:
+            return False
+        if not any(XCTEST_BUILD_COMPLETE_RE.match(raw_line.strip()) for raw_line in text.splitlines()):
+            return False
+        timestamp = time.monotonic() if observed_at is None else observed_at
+        job.xctest_progress_deadline = timestamp + float(job.args["xctestStallSeconds"])
+        return True
 
     def _claim_xctest_stall_locked(
         self,

--- a/Scripts/test_conductor_lifecycle.py
+++ b/Scripts/test_conductor_lifecycle.py
@@ -200,6 +200,34 @@ class LifecycleQueueTests(LifecycleTestCase):
         self.assertEqual(guarded_env["REPOPROMPT_GUARD_DELAYED_LAUNCH"], "1")
         self.assertEqual(conductor.operation_display_name("app", {"subcommand": "relaunch"}), "app relaunch")
 
+    def test_test_operations_default_to_bounded_timeout_and_xctest_stall_watchdog(self) -> None:
+        tmp, state = self.make_state()
+        self.addCleanup(tmp.cleanup)
+
+        with mock.patch.object(state, "_schedule_locked"):
+            root_payload = state.enqueue({"operation": "test", "args": {}})
+            provider_payload = state.enqueue({"operation": "provider-test", "args": {}})
+
+        root_job = state.jobs[root_payload["ticket"]]
+        provider_job = state.jobs[provider_payload["ticket"]]
+        self.assertEqual(root_job.timeout, conductor.TEST_TIMEOUT_SECONDS)
+        self.assertEqual(provider_job.timeout, conductor.TEST_TIMEOUT_SECONDS)
+        self.assertEqual(root_job.args["xctestStallSeconds"], conductor.DEFAULT_XCTEST_STALL_SECONDS)
+        self.assertEqual(provider_job.args["xctestStallSeconds"], conductor.DEFAULT_XCTEST_STALL_SECONDS)
+        self.assertTrue(state._xctest_watchdog_enabled(root_job))
+        self.assertTrue(state._xctest_watchdog_enabled(provider_job))
+
+    def test_explicit_xctest_stall_timeout_overrides_default(self) -> None:
+        tmp, state = self.make_state()
+        self.addCleanup(tmp.cleanup)
+
+        with mock.patch.object(state, "_schedule_locked"):
+            payload = state.enqueue({"operation": "test", "args": {"xctestStallSeconds": 45.0}})
+
+        job = state.jobs[payload["ticket"]]
+        self.assertEqual(job.args["xctestStallSeconds"], 45.0)
+        self.assertEqual(job.timeout, conductor.TEST_TIMEOUT_SECONDS)
+
     def test_release_artifact_delegates_release_script_with_release_lanes_and_timeout(self) -> None:
         tmp, state = self.make_state()
         self.addCleanup(tmp.cleanup)
@@ -637,6 +665,30 @@ class XCTestStallWatchdogTests(LifecycleTestCase):
         self.assertIsNone(claim)
         self.assertFalse(job.measurement_invalid)
         kill.assert_not_called()
+
+    def test_watchdog_arms_after_build_complete_before_first_progress_marker(self) -> None:
+        tmp, state = self.make_state()
+        self.addCleanup(tmp.cleanup)
+        job = self.make_watchdog_job(state)
+
+        armed = state._record_xctest_startup_locked(job, "Build complete! (2.35s)\n", observed_at=40.0)
+
+        self.assertTrue(armed)
+        self.assertEqual(job.xctest_progress_deadline, 45.0)
+        claim = state._claim_xctest_stall_locked(job, observed_at=45.0)
+        self.assertIsNotNone(claim)
+        self.assertIsNone(claim.current_test)
+        self.assertTrue(job.measurement_invalid)
+
+    def test_watchdog_waits_for_build_complete_before_startup_deadline(self) -> None:
+        tmp, state = self.make_state()
+        self.addCleanup(tmp.cleanup)
+        job = self.make_watchdog_job(state)
+
+        armed = state._record_xctest_startup_locked(job, "[12/34] Compiling Thing.swift\n", observed_at=40.0)
+
+        self.assertFalse(armed)
+        self.assertIsNone(job.xctest_progress_deadline)
 
     def test_only_xctest_progress_markers_reset_after_first_started_marker(self) -> None:
         tmp, state = self.make_state()


### PR DESCRIPTION
## Summary
- cap conductor `test` / `provider-test` jobs at 15 minutes by default
- enable the XCTest progress-stall watchdog by default for test operations
- arm the watchdog after SwiftPM reports `Build complete!` so pre-first-test XCTest stalls are diagnosed and killed instead of running until the generic timeout

## Validation
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh commit`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh push`
- `make conductor-selftest`
- `./conductor test --filter WorkspaceFileContextStoreTests` now fails fast after the watchdog threshold and captures stall diagnostics instead of hanging indefinitely; observed diagnostic: `currentTest: null`, xctest sampled inside `XCTWaiter` before first progress marker.

## Notes
This keeps the conductor/test-runner fix separate from PR #167.
