### PR TITLE
Reduce parallel MCP contention and preserve Agent selections

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,21 @@ jobs:
         run: swift build --product repoprompt-mcp
 
       - name: Run app tests
-        run: swift test
+        shell: bash
+        run: |
+          set -euo pipefail
+          suites_file="$(mktemp)"
+          trap 'rm -f "$suites_file"' EXIT
+
+          # A single long-lived XCTest process accumulates suspended app-lifecycle tasks
+          # and can wedge Swift's cooperative executor late in the suite on hosted runners.
+          # Preserve serial test semantics while bounding each process to one test class.
+          swift test list | awk -F/ 'NF > 1 { print $1 }' | sort -u > "$suites_file"
+          while IFS= read -r suite; do
+            echo "::group::$suite"
+            swift test --skip-build --filter "$suite"
+            echo "::endgroup::"
+          done < "$suites_file"
 
       - name: Run provider package tests
         working-directory: Packages/RepoPromptAgentProviders

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,18 +46,141 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          suites_file="$(mktemp)"
-          trap 'rm -f "$suites_file"' EXIT
-
           # A single long-lived XCTest process accumulates suspended app-lifecycle tasks
           # and can wedge Swift's cooperative executor late in the suite on hosted runners.
           # Preserve serial test semantics while bounding each process to one test class.
-          swift test list | awk -F/ 'NF > 1 { print $1 }' | sort -u > "$suites_file"
-          while IFS= read -r suite; do
-            echo "::group::$suite"
-            swift test --skip-build --filter "$suite"
-            echo "::endgroup::"
-          done < "$suites_file"
+          # Retry only silent startup timeouts; assertion failures remain immediate failures.
+          python3 <<'PY'
+          import os
+          import signal
+          import subprocess
+          import sys
+          import threading
+          import time
+
+          suite_timeout_seconds = 180
+          listed = subprocess.run(
+              ["swift", "test", "list"],
+              check=True,
+              capture_output=True,
+              text=True,
+          )
+          suites = sorted({
+              line.split("/", 1)[0]
+              for line in listed.stdout.splitlines()
+              if "/" in line
+          })
+
+          def descendant_process_groups(root_pid):
+              process_list = subprocess.run(
+                  ["ps", "-axo", "pid=,ppid="],
+                  check=True,
+                  capture_output=True,
+                  text=True,
+              )
+              children = {}
+              for line in process_list.stdout.splitlines():
+                  pid_text, parent_text = line.split()
+                  children.setdefault(int(parent_text), []).append(int(pid_text))
+
+              pending = [root_pid]
+              process_ids = set()
+              while pending:
+                  process_id = pending.pop()
+                  if process_id in process_ids:
+                      continue
+                  process_ids.add(process_id)
+                  pending.extend(children.get(process_id, []))
+
+              groups = set()
+              for process_id in process_ids:
+                  try:
+                      groups.add(os.getpgid(process_id))
+                  except ProcessLookupError:
+                      pass
+              groups.discard(os.getpgrp())
+              return groups
+
+          def signal_process_groups(groups, sent_signal):
+              for group in groups:
+                  try:
+                      os.killpg(group, sent_signal)
+                  except ProcessLookupError:
+                      pass
+
+          def live_process_groups(groups):
+              live = set()
+              for group in groups:
+                  try:
+                      os.killpg(group, 0)
+                  except ProcessLookupError:
+                      continue
+                  live.add(group)
+              return live
+
+          def stop_process_tree(process):
+              groups = descendant_process_groups(process.pid)
+              signal_process_groups(groups, signal.SIGTERM)
+
+              deadline = time.monotonic() + 10
+              while time.monotonic() < deadline:
+                  process.poll()
+                  groups = live_process_groups(groups)
+                  if not groups:
+                      break
+                  time.sleep(0.1)
+
+              signal_process_groups(groups, signal.SIGKILL)
+              process.wait()
+
+          def relay_output(process, output_seen):
+              for line in process.stdout:
+                  output_seen.set()
+                  sys.stdout.write(line)
+                  sys.stdout.flush()
+
+          for suite in suites:
+              print(f"::group::{suite}", flush=True)
+              for attempt in range(1, 3):
+                  output_seen = threading.Event()
+                  process = subprocess.Popen(
+                      ["swift", "test", "--skip-build", "--filter", suite],
+                      start_new_session=True,
+                      stdout=subprocess.PIPE,
+                      stderr=subprocess.STDOUT,
+                      text=True,
+                  )
+                  relay = threading.Thread(
+                      target=relay_output,
+                      args=(process, output_seen),
+                      daemon=True,
+                  )
+                  relay.start()
+                  try:
+                      return_code = process.wait(timeout=suite_timeout_seconds)
+                  except subprocess.TimeoutExpired:
+                      stop_process_tree(process)
+                      relay.join(timeout=10)
+                      if attempt == 1 and not output_seen.is_set():
+                          print(
+                              f"::warning::{suite} produced no output for "
+                              f"{suite_timeout_seconds}s; retrying once",
+                              flush=True,
+                          )
+                          continue
+                      print(
+                          f"::error::{suite} timed out after "
+                          f"{suite_timeout_seconds}s",
+                          flush=True,
+                      )
+                      sys.exit(124)
+
+                  relay.join(timeout=10)
+                  if return_code != 0:
+                      sys.exit(return_code)
+                  break
+              print("::endgroup::", flush=True)
+          PY
 
       - name: Run provider package tests
         working-directory: Packages/RepoPromptAgentProviders

--- a/Sources/RepoPrompt/App/WindowState.swift
+++ b/Sources/RepoPrompt/App/WindowState.swift
@@ -1324,6 +1324,9 @@ class WindowState: ObservableObject {
         // Stop the local MCP server
         await mcpServer.stopServer()
 
+        // Release per-window codemap work before the closed window can contend with later windows.
+        await workspaceFilesViewModel.cancelAllScans()
+
         // Cancel any ongoing AI query
         aiQueriesService.cancelQuery()
 

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Transcript/AgentToolResultPersistencePolicy.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Transcript/AgentToolResultPersistencePolicy.swift
@@ -514,6 +514,8 @@ enum AgentToolResultPersistencePolicy {
         _ transcript: AgentTranscript,
         previousSanitizedTranscript: AgentTranscript? = nil,
         reusablePrefixTurnCount: Int? = nil,
+        trustedReusablePrefixTurnCount: Int? = nil,
+        trustedIncrementalFinalTurnStartSequenceIndex: Int? = nil,
         preservedVisibleToolResultRowIDs: Set<UUID>? = nil,
         context: AgentToolResultProcessingContext? = nil,
         purpose: AgentToolResultSanitizationPurpose = .runtimePresentation
@@ -523,10 +525,34 @@ enum AgentToolResultPersistencePolicy {
             validatedReusablePrefixTurnCount(
                 in: transcript,
                 previousSanitizedTranscript: previousSanitizedTranscript,
-                requestedPrefixTurnCount: reusablePrefixTurnCount
+                requestedPrefixTurnCount: trustedReusablePrefixTurnCount ?? reusablePrefixTurnCount
             )
         case .persistentStorage:
             0
+        }
+        if purpose == .runtimePresentation,
+           let trustedIncrementalFinalTurnStartSequenceIndex,
+           let previousSanitizedTranscript,
+           transcript.turns.count == previousSanitizedTranscript.turns.count,
+           reusedTurnCount == max(0, transcript.turns.count - 1),
+           let currentFinalTurn = transcript.turns.last,
+           let previousFinalTurn = previousSanitizedTranscript.turns.last,
+           currentFinalTurn.id == previousFinalTurn.id
+        {
+            var sanitizedTranscript = transcript
+            if let sanitizedActivityCount = sanitizeFinalTurnIncrementally(
+                &sanitizedTranscript.turns[sanitizedTranscript.turns.count - 1],
+                previousSanitizedTurn: previousFinalTurn,
+                startingAtSequenceIndex: trustedIncrementalFinalTurnStartSequenceIndex,
+                preservedVisibleToolResultRowIDs: preservedVisibleToolResultRowIDs ?? [],
+                context: context
+            ) {
+                return AgentSanitizedTranscriptMetrics(
+                    transcript: sanitizedTranscript,
+                    sanitizedActivityCount: sanitizedActivityCount,
+                    reusedTurnCount: reusedTurnCount
+                )
+            }
         }
         let containsSanitizableActivities: Bool = switch purpose {
         case .runtimePresentation:
@@ -573,6 +599,101 @@ enum AgentToolResultPersistencePolicy {
         )
     }
 
+    private static func sanitizeFinalTurnIncrementally(
+        _ turn: inout AgentTranscriptTurn,
+        previousSanitizedTurn: AgentTranscriptTurn,
+        startingAtSequenceIndex: Int,
+        preservedVisibleToolResultRowIDs: Set<UUID>,
+        context: AgentToolResultProcessingContext?
+    ) -> Int? {
+        guard turn.request?.id == previousSanitizedTurn.request?.id,
+              turn.responseSpans.count == previousSanitizedTurn.responseSpans.count
+        else {
+            return nil
+        }
+
+        var updatedTurn = turn
+        var reachedChangedSuffix = false
+        var sanitizedActivityCount = 0
+
+        for spanIndex in updatedTurn.responseSpans.indices {
+            let currentSpan = turn.responseSpans[spanIndex]
+            let previousSpan = previousSanitizedTurn.responseSpans[spanIndex]
+            guard currentSpan.id == previousSpan.id else { return nil }
+
+            if !reachedChangedSuffix {
+                let changedActivityIndex = lowerBoundActivityIndex(
+                    in: currentSpan.activities,
+                    sequenceIndex: startingAtSequenceIndex
+                )
+                if changedActivityIndex == currentSpan.activities.count {
+                    guard currentSpan.activities.count == previousSpan.activities.count,
+                          currentSpan.activities.first?.id == previousSpan.activities.first?.id,
+                          currentSpan.activities.last?.id == previousSpan.activities.last?.id
+                    else {
+                        return nil
+                    }
+                    updatedTurn.responseSpans[spanIndex].activities = previousSpan.activities
+                    continue
+                }
+
+                guard changedActivityIndex <= previousSpan.activities.count else { return nil }
+                if changedActivityIndex > 0 {
+                    guard currentSpan.activities[changedActivityIndex - 1].id
+                        == previousSpan.activities[changedActivityIndex - 1].id
+                    else {
+                        return nil
+                    }
+                }
+
+                var mergedActivities = previousSpan.activities
+                mergedActivities.replaceSubrange(
+                    changedActivityIndex ..< mergedActivities.count,
+                    with: currentSpan.activities[changedActivityIndex...]
+                )
+                updatedTurn.responseSpans[spanIndex].activities = mergedActivities
+                sanitizedActivityCount += sanitizeActivities(
+                    in: &updatedTurn.responseSpans[spanIndex],
+                    startingAt: changedActivityIndex,
+                    preservedVisibleToolResultRowIDs: preservedVisibleToolResultRowIDs,
+                    context: context,
+                    purpose: .runtimePresentation
+                )
+                reachedChangedSuffix = true
+                continue
+            }
+
+            sanitizedActivityCount += sanitizeActivities(
+                in: &updatedTurn.responseSpans[spanIndex],
+                startingAt: 0,
+                preservedVisibleToolResultRowIDs: preservedVisibleToolResultRowIDs,
+                context: context,
+                purpose: .runtimePresentation
+            )
+        }
+
+        guard reachedChangedSuffix else { return nil }
+        turn = updatedTurn
+        return sanitizedActivityCount
+    }
+
+    private static func lowerBoundActivityIndex(
+        in activities: [AgentTranscriptActivity],
+        sequenceIndex: Int
+    ) -> Int {
+        var lowerBound = activities.startIndex
+        var upperBound = activities.endIndex
+        while lowerBound < upperBound {
+            let midpoint = lowerBound + (upperBound - lowerBound) / 2
+            if activities[midpoint].sequenceIndex < sequenceIndex {
+                lowerBound = midpoint + 1
+            } else {
+                upperBound = midpoint
+            }
+        }
+        return lowerBound
+    }
+
     private static func validatedReusablePrefixTurnCount(
         in transcript: AgentTranscript,
         previousSanitizedTranscript: AgentTranscript?,
@@ -587,10 +708,7 @@ enum AgentToolResultPersistencePolicy {
         for index in 0 ..< candidatePrefixTurnCount {
             let currentTurn = transcript.turns[index]
             let previousTurn = previousSanitizedTranscript.turns[index]
-            guard currentTurn.retentionTier != .full,
-                  previousTurn.retentionTier != .full,
-                  currentTurn == previousTurn
-            else {
+            guard currentTurn == previousTurn else {
                 break
             }
             reusableTurnCount += 1
@@ -629,28 +747,47 @@ enum AgentToolResultPersistencePolicy {
     ) -> Int {
         var sanitizedActivityCount = 0
         for spanIndex in turn.responseSpans.indices {
-            var spanDidMutate = false
-            for activityIndex in turn.responseSpans[spanIndex].activities.indices {
-                var activity = turn.responseSpans[spanIndex].activities[activityIndex]
-                let didNormalizeToolIdentity = normalizeToolIdentity(&activity, context: context)
-                let didSanitize: Bool = switch purpose {
-                case .runtimePresentation:
-                    sanitizeRuntimeActivity(
-                        &activity,
-                        preservedVisibleToolResultRowIDs: preservedVisibleToolResultRowIDs,
-                        context: context
-                    )
-                case .persistentStorage:
-                    sanitizePersistentStorageActivity(&activity, context: context)
-                }
-                guard didNormalizeToolIdentity || didSanitize else { continue }
-                turn.responseSpans[spanIndex].activities[activityIndex] = activity
-                spanDidMutate = true
-                sanitizedActivityCount += 1
+            sanitizedActivityCount += sanitizeActivities(
+                in: &turn.responseSpans[spanIndex],
+                startingAt: 0,
+                preservedVisibleToolResultRowIDs: preservedVisibleToolResultRowIDs,
+                context: context,
+                purpose: purpose
+            )
+        }
+        return sanitizedActivityCount
+    }
+
+    private static func sanitizeActivities(
+        in span: inout AgentTranscriptProviderResponseSpan,
+        startingAt startIndex: Int,
+        preservedVisibleToolResultRowIDs: Set<UUID>,
+        context: AgentToolResultProcessingContext?,
+        purpose: AgentToolResultSanitizationPurpose
+    ) -> Int {
+        guard startIndex < span.activities.count else { return 0 }
+        var sanitizedActivityCount = 0
+        var spanDidMutate = false
+        for activityIndex in startIndex ..< span.activities.count {
+            var activity = span.activities[activityIndex]
+            let didNormalizeToolIdentity = normalizeToolIdentity(&activity, context: context)
+            let didSanitize: Bool = switch purpose {
+            case .runtimePresentation:
+                sanitizeRuntimeActivity(
+                    &activity,
+                    preservedVisibleToolResultRowIDs: preservedVisibleToolResultRowIDs,
+                    context: context
+                )
+            case .persistentStorage:
+                sanitizePersistentStorageActivity(&activity, context: context)
             }
-            if spanDidMutate {
-                turn.responseSpans[spanIndex].fullRenderGroupedHistoryCache = nil
-            }
+            guard didNormalizeToolIdentity || didSanitize else { continue }
+            span.activities[activityIndex] = activity
+            spanDidMutate = true
+            sanitizedActivityCount += 1
+        }
+        if spanDidMutate {
+            span.fullRenderGroupedHistoryCache = nil
         }
         return sanitizedActivityCount
     }

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Transcript/AgentTranscriptServices.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Transcript/AgentTranscriptServices.swift
@@ -5102,12 +5102,25 @@ enum AgentTranscriptProjectionBuilder {
     /// Also intentionally tightens `frozenDetailedToolTailLimit` when an eligible completed
     /// full turn emits grouped history under the current newest-first allocation. Callers
     /// must use the returned transcript; this method is not cache-only.
-    static func refreshCompletedFullTurnGroupedHistoryCaches(in transcript: AgentTranscript) -> AgentTranscript {
+    static func refreshCompletedFullTurnGroupedHistoryCaches(
+        in transcript: AgentTranscript,
+        reusablePrefixTurnCount: Int? = nil
+    ) -> AgentTranscript {
         var updatedTranscript = transcript
         let context = AgentTranscriptProjectionBuildContext()
+        let firstTurnIndex = min(max(0, reusablePrefixTurnCount ?? 0), updatedTranscript.turns.count)
         let detailedToolTailLimits = detailedToolTailLimits(for: updatedTranscript)
         for turnIndex in updatedTranscript.turns.indices {
             let turn = updatedTranscript.turns[turnIndex]
+            let detailedToolTailLimit = detailedToolTailLimits[turn.id] ?? 0
+            if turnIndex < firstTurnIndex,
+               canReuseGroupedHistoryState(
+                   for: turn,
+                   detailedToolTailLimit: detailedToolTailLimit
+               )
+            {
+                continue
+            }
             let isEligible = turn.retentionTier == .full
                 && turn.isCompleted
                 && !turn.responseSpans.contains(where: { $0.lifecycle == .open })
@@ -5117,7 +5130,6 @@ enum AgentTranscriptProjectionBuilder {
                 }
                 continue
             }
-            let detailedToolTailLimit = detailedToolTailLimits[turn.id] ?? 0
             var didCollapseTurn = false
             var emittedConclusionActivityIDs = Set<UUID>()
             for spanIndex in updatedTranscript.turns[turnIndex].responseSpans.indices {
@@ -5162,6 +5174,27 @@ enum AgentTranscriptProjectionBuilder {
             }
         }
         return updatedTranscript
+    }
+
+    private static func canReuseGroupedHistoryState(
+        for turn: AgentTranscriptTurn,
+        detailedToolTailLimit: Int
+    ) -> Bool {
+        let isEligible = turn.retentionTier == .full
+            && turn.isCompleted
+            && !turn.responseSpans.contains(where: { $0.lifecycle == .open })
+        guard isEligible else {
+            return turn.responseSpans.allSatisfy { $0.fullRenderGroupedHistoryCache == nil }
+        }
+        if let frozenLimit = normalizedFrozenDetailedToolTailLimit(for: turn) {
+            guard frozenLimit == detailedToolTailLimit else { return false }
+            return turn.responseSpans.allSatisfy { span in
+                span.fullRenderGroupedHistoryCache?.detailedToolTailLimit == detailedToolTailLimit
+                    || span.fullRenderGroupedHistoryCache == nil
+            }
+        }
+        return standaloneToolBlockCount(for: turn) <= detailedToolTailLimit
+            && turn.responseSpans.allSatisfy { $0.fullRenderGroupedHistoryCache == nil }
     }
 
     static func build(

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+TabSession.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+TabSession.swift
@@ -42,6 +42,9 @@ extension AgentModeViewModel {
         var rawToolResultPayloadRenderRevision: Int = 0
         var onSourceItemsChanged: ((TabSession, SourceItemsMutation) -> Void)?
         var onRunStateChanged: ((TabSession) -> Void)?
+        #if DEBUG
+            private(set) var test_incrementalRetentionCompactionCount = 0
+        #endif
 
         /// Run state
         @Published var runState: AgentSessionRunState = .idle {
@@ -1299,6 +1302,39 @@ extension AgentModeViewModel {
             derivedTranscriptRefreshGeneration &+= 1
             derivedTranscriptRefreshTask?.cancel()
             derivedTranscriptRefreshTask = nil
+        }
+
+        @discardableResult
+        func replaceItemSilentlyForRetentionCompaction(
+            at index: Int,
+            with compactedItem: AgentChatItem,
+            retainedRawPayload: String
+        ) -> Bool {
+            guard items.indices.contains(index) else { return false }
+            let previousItem = items[index]
+            guard previousItem.id == compactedItem.id,
+                  previousItem != compactedItem,
+                  ephemeralToolResultPayloadByItemID[previousItem.id] == retainedRawPayload
+            else {
+                return false
+            }
+
+            suppressSourceItemsChanged = true
+            items[index] = compactedItem
+            suppressSourceItemsChanged = false
+            nextSequenceIndex = max(nextSequenceIndex, compactedItem.sequenceIndex + 1)
+            updateToolCorrelationIndexes(
+                previousItem: previousItem,
+                updatedItem: compactedItem,
+                at: index
+            )
+            sourceItemsRevision &+= 1
+            derivedTranscriptSyncState = nil
+            #if DEBUG
+                test_incrementalRetentionCompactionCount += 1
+            #endif
+            assertSourceItemDerivedStateIsConsistent()
+            return true
         }
 
         /// Compact any summary-only tool-result items in place and align

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -1431,6 +1431,12 @@ final class AgentModeViewModel: ObservableObject {
             guard let self else { return .unavailable }
             return worktreeBindingState(forAgentSessionID: sessionID, tabID: tabID)
         }
+        mcpServer.registerAgentWorktreeBindingsResolver { [weak self] sessionID, tabID in
+            guard let self, let tabID else { return .unavailable }
+            let session = await ensureSessionReady(tabID: tabID)
+            guard session.activeAgentSessionID == sessionID else { return .unavailable }
+            return worktreeBindingState(forAgentSessionID: sessionID, tabID: tabID)
+        }
 
         refreshAvailableAgents()
 
@@ -1613,6 +1619,12 @@ final class AgentModeViewModel: ObservableObject {
             runInteractionStateObserver = codexCoordinator
             testMCPServer?.registerAgentWorktreeBindingsProvider { [weak self] sessionID, tabID in
                 guard let self else { return .unavailable }
+                return worktreeBindingState(forAgentSessionID: sessionID, tabID: tabID)
+            }
+            testMCPServer?.registerAgentWorktreeBindingsResolver { [weak self] sessionID, tabID in
+                guard let self, let tabID else { return .unavailable }
+                let session = await ensureSessionReady(tabID: tabID)
+                guard session.activeAgentSessionID == sessionID else { return .unavailable }
                 return worktreeBindingState(forAgentSessionID: sessionID, tabID: tabID)
             }
             refreshAvailableAgents()

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -7802,6 +7802,7 @@ final class AgentModeViewModel: ObservableObject {
             EditFlowPerf.Dimensions(status: reason.rawValue, sourceItemCount: workingItemsSnapshot.count)
         )
         let importedTranscript: AgentTranscript
+        var trustedIncrementalFinalTurnStartSequenceIndex: Int?
         if reason == .liveMutation,
            session.pendingAskUser == nil,
            let mutationSummary = pendingMutationSummary,
@@ -7832,6 +7833,10 @@ final class AgentModeViewModel: ObservableObject {
                 protection: projectionProtection
             ) {
                 importedTranscript = incrementallyUpdatedTranscript
+                if workingItemsSnapshot.indices.contains(mutationSummary.earliestChangedIndex) {
+                    trustedIncrementalFinalTurnStartSequenceIndex =
+                        workingItemsSnapshot[mutationSummary.earliestChangedIndex].sequenceIndex
+                }
                 #if DEBUG
                     debugIncrementalPath = usesDurableFrontier ? "incremental-success:frontier" : "incremental-success:no-frontier"
                 #endif
@@ -7943,7 +7948,8 @@ final class AgentModeViewModel: ObservableObject {
             previousProjectionProtection: session.transcriptProjectionProtection,
             projectionProtection: projectionProtection,
             isCompressedHistoryRevealed: session.isCompressedHistoryRevealed,
-            isColdLoad: reason == .coldLoad
+            isColdLoad: reason == .coldLoad,
+            trustedIncrementalFinalTurnStartSequenceIndex: trustedIncrementalFinalTurnStartSequenceIndex
         )
         applyBuiltTranscriptPresentation(
             builtPresentation,
@@ -7953,17 +7959,22 @@ final class AgentModeViewModel: ObservableObject {
         let hasCompactedTranscriptPrefix = builtPresentation.transcript.turns.contains { $0.retentionTier != .full }
         let canReconcileForStandardRetention = (!session.runState.isActive || hasCompactedTranscriptPrefix)
             && (session.runState != .completed || hasCompactedTranscriptPrefix)
+        let containsExcludedLegacyItems = AgentTranscriptIO.containsExcludedLegacyItems(
+            workingItemsSnapshot,
+            policy: importPolicy
+        )
+        let fullDetailTurnEnvelopeChanged = AgentTranscriptIO.fullDetailTurnEnvelopeChanged(
+            from: existingTranscript,
+            to: builtPresentation.transcript
+        )
         let shouldReconcileWorkingItems: Bool = {
             guard session.items == workingItemsSnapshot,
                   canReconcileForStandardRetention
             else {
                 return false
             }
-            return AgentTranscriptIO.containsExcludedLegacyItems(workingItemsSnapshot, policy: importPolicy)
-                || AgentTranscriptIO.fullDetailTurnEnvelopeChanged(
-                    from: existingTranscript,
-                    to: builtPresentation.transcript
-                )
+            return containsExcludedLegacyItems
+                || fullDetailTurnEnvelopeChanged
                 || builtPresentation.sanitizedActivityCount > 0
         }()
         let mayCompactActiveSummaryOnlyToolResults = !shouldReconcileWorkingItems
@@ -7971,7 +7982,45 @@ final class AgentModeViewModel: ObservableObject {
             && session.runState.isActive
             && !hasCompactedTranscriptPrefix
             && builtPresentation.sanitizedActivityCount > 0
-        if shouldReconcileWorkingItems || mayCompactActiveSummaryOnlyToolResults {
+        let didApplyIncrementalSummaryOnlyCompaction: Bool = {
+            guard builtPresentation.sanitizedActivityCount > 0,
+                  !containsExcludedLegacyItems,
+                  !fullDetailTurnEnvelopeChanged,
+                  let mutationSummary = pendingMutationSummary,
+                  mutationSummary.earliestChangedIndex == mutationSummary.latestChangedIndex,
+                  workingItemsSnapshot.indices.contains(mutationSummary.earliestChangedIndex)
+            else {
+                return false
+            }
+            let changedIndex = mutationSummary.earliestChangedIndex
+            let sourceItem = workingItemsSnapshot[changedIndex]
+            guard let compactedItem = Self.transcriptItem(
+                in: builtPresentation.transcript,
+                matching: sourceItem
+            ),
+                let retainedRawPayload = session.ephemeralToolResultPayloadByItemID[sourceItem.id],
+                Self.canApplyActiveSummaryOnlyToolResultCompaction(
+                    from: sourceItem,
+                    to: compactedItem,
+                    retainedPayload: retainedRawPayload
+                ),
+                session.replaceItemSilentlyForRetentionCompaction(
+                    at: changedIndex,
+                    with: compactedItem,
+                    retainedRawPayload: retainedRawPayload
+                )
+            else {
+                return false
+            }
+            markDerivedTranscriptSynchronized(
+                for: session,
+                projectionProtection: builtPresentation.projectionProtection
+            )
+            return true
+        }()
+        if !didApplyIncrementalSummaryOnlyCompaction,
+           shouldReconcileWorkingItems || mayCompactActiveSummaryOnlyToolResults
+        {
             let trimmedWorkingItems = AgentTranscriptIO.workingSourceItems(from: builtPresentation.transcript)
             let canApplyWorkingItems = shouldReconcileWorkingItems
                 || Self.canApplyActiveSummaryOnlyToolResultCompaction(
@@ -8289,7 +8338,8 @@ final class AgentModeViewModel: ObservableObject {
         previousProjectionProtection: AgentTranscriptProjectionProtection = .none,
         projectionProtection: AgentTranscriptProjectionProtection = .none,
         isCompressedHistoryRevealed: Bool = false,
-        isColdLoad: Bool = false
+        isColdLoad: Bool = false,
+        trustedIncrementalFinalTurnStartSequenceIndex: Int? = nil
     ) -> BuiltTranscriptPresentation {
         let processingContext = AgentToolResultProcessingContext()
         #if DEBUG || EDIT_FLOW_PERF
@@ -8364,11 +8414,13 @@ final class AgentModeViewModel: ObservableObject {
             transcript,
             previousSanitizedTranscript: previousSanitizedTranscript,
             reusablePrefixTurnCount: sanitizeReusableTurnCount > 0 ? sanitizeReusableTurnCount : nil,
+            trustedIncrementalFinalTurnStartSequenceIndex: trustedIncrementalFinalTurnStartSequenceIndex,
             context: processingContext,
             purpose: .runtimePresentation
         )
         let sanitizedTranscript = AgentTranscriptProjectionBuilder.refreshCompletedFullTurnGroupedHistoryCaches(
-            in: sanitizeMetrics.transcript
+            in: sanitizeMetrics.transcript,
+            reusablePrefixTurnCount: sanitizeMetrics.reusedTurnCount
         )
         #if DEBUG || EDIT_FLOW_PERF
             if sanitizeReusableTurnCount > 0 {
@@ -8598,47 +8650,90 @@ final class AgentModeViewModel: ObservableObject {
         guard sourceItems.count == compactedItems.count else { return false }
         var foundSummaryOnlyToolResultCompaction = false
         for (sourceItem, compactedItem) in zip(sourceItems, compactedItems) {
-            guard sourceItem.id == compactedItem.id,
-                  sourceItem.timestamp == compactedItem.timestamp,
-                  sourceItem.kind == compactedItem.kind,
-                  sourceItem.attachments == compactedItem.attachments,
-                  sourceItem.taggedFileAttachments == compactedItem.taggedFileAttachments,
-                  sourceItem.toolName == compactedItem.toolName,
-                  sourceItem.toolInvocationID == compactedItem.toolInvocationID,
-                  sourceItem.toolArgsJSON == compactedItem.toolArgsJSON,
-                  sourceItem.reasoning == compactedItem.reasoning,
-                  sourceItem.sequenceIndex == compactedItem.sequenceIndex,
-                  sourceItem.isStreaming == compactedItem.isStreaming,
-                  sourceItem.workflow == compactedItem.workflow,
-                  sourceItem.codexGoalMode == compactedItem.codexGoalMode,
-                  sourceItem.isLocalControlPlaneEcho == compactedItem.isLocalControlPlaneEcho
-            else {
-                return false
-            }
             guard sourceItem != compactedItem else { continue }
-            guard sourceItem.kind == .toolResult,
-                  !sourceItem.isStreaming
-            else {
-                return false
-            }
-            let sourceResultJSON = sourceItem.toolResultJSON?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-            let compactedResultJSON = compactedItem.toolResultJSON?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
             let retainedPayload = retainedPayloadByItemID[sourceItem.id]?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-            guard !sourceResultJSON.isEmpty,
-                  sourceResultJSON != compactedResultJSON,
-                  retainedPayload == sourceResultJSON,
-                  AgentTranscriptToolNormalizer.isSummaryOnly(raw: compactedResultJSON)
-            else {
-                return false
-            }
-            var expectedCompactedItem = sourceItem
-            expectedCompactedItem.text = compactedItem.text
-            expectedCompactedItem.toolResultJSON = compactedItem.toolResultJSON
-            expectedCompactedItem.toolIsError = compactedItem.toolIsError
-            guard expectedCompactedItem == compactedItem else { return false }
+            guard canApplyActiveSummaryOnlyToolResultCompaction(
+                from: sourceItem,
+                to: compactedItem,
+                retainedPayload: retainedPayload
+            ) else { return false }
             foundSummaryOnlyToolResultCompaction = true
         }
         return foundSummaryOnlyToolResultCompaction
+    }
+
+    private nonisolated static func canApplyActiveSummaryOnlyToolResultCompaction(
+        from sourceItem: AgentChatItem,
+        to compactedItem: AgentChatItem,
+        retainedPayload: String
+    ) -> Bool {
+        guard sourceItem.id == compactedItem.id,
+              sourceItem.timestamp == compactedItem.timestamp,
+              sourceItem.kind == compactedItem.kind,
+              sourceItem.attachments == compactedItem.attachments,
+              sourceItem.taggedFileAttachments == compactedItem.taggedFileAttachments,
+              sourceItem.toolName == compactedItem.toolName,
+              sourceItem.toolInvocationID == compactedItem.toolInvocationID,
+              sourceItem.toolArgsJSON == compactedItem.toolArgsJSON,
+              sourceItem.reasoning == compactedItem.reasoning,
+              sourceItem.sequenceIndex == compactedItem.sequenceIndex,
+              sourceItem.isStreaming == compactedItem.isStreaming,
+              sourceItem.workflow == compactedItem.workflow,
+              sourceItem.codexGoalMode == compactedItem.codexGoalMode,
+              sourceItem.isLocalControlPlaneEcho == compactedItem.isLocalControlPlaneEcho,
+              sourceItem.kind == .toolResult,
+              !sourceItem.isStreaming
+        else {
+            return false
+        }
+        let sourceResultJSON = sourceItem.toolResultJSON?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let compactedResultJSON = compactedItem.toolResultJSON?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !sourceResultJSON.isEmpty,
+              sourceResultJSON != compactedResultJSON,
+              retainedPayload.trimmingCharacters(in: .whitespacesAndNewlines) == sourceResultJSON,
+              AgentTranscriptToolNormalizer.isSummaryOnly(raw: compactedResultJSON)
+        else {
+            return false
+        }
+        var expectedCompactedItem = sourceItem
+        expectedCompactedItem.text = compactedItem.text
+        expectedCompactedItem.toolResultJSON = compactedItem.toolResultJSON
+        expectedCompactedItem.toolIsError = compactedItem.toolIsError
+        return expectedCompactedItem == compactedItem
+    }
+
+    private nonisolated static func transcriptItem(
+        in transcript: AgentTranscript,
+        matching sourceItem: AgentChatItem
+    ) -> AgentChatItem? {
+        guard let finalTurn = transcript.turns.last else { return nil }
+        for span in finalTurn.responseSpans.reversed() {
+            guard let firstSequenceIndex = span.activities.first?.sequenceIndex,
+                  let lastSequenceIndex = span.activities.last?.sequenceIndex,
+                  sourceItem.sequenceIndex >= firstSequenceIndex,
+                  sourceItem.sequenceIndex <= lastSequenceIndex
+            else {
+                continue
+            }
+            var lowerBound = span.activities.startIndex
+            var upperBound = span.activities.endIndex
+            while lowerBound < upperBound {
+                let midpoint = lowerBound + (upperBound - lowerBound) / 2
+                if span.activities[midpoint].sequenceIndex < sourceItem.sequenceIndex {
+                    lowerBound = midpoint + 1
+                } else {
+                    upperBound = midpoint
+                }
+            }
+            guard lowerBound < span.activities.endIndex,
+                  span.activities[lowerBound].sequenceIndex == sourceItem.sequenceIndex,
+                  span.activities[lowerBound].id == sourceItem.id
+            else {
+                continue
+            }
+            return span.activities[lowerBound].toItem()
+        }
+        return nil
     }
 
     private func applyBuiltTranscriptPresentation(

--- a/Sources/RepoPrompt/Features/CodeMap/CodeScanActor.swift
+++ b/Sources/RepoPrompt/Features/CodeMap/CodeScanActor.swift
@@ -1054,12 +1054,22 @@ actor CodeScanActor {
 
     func requestSelfHealingScans(
         _ requests: [ScanRequest],
-        rootFolderPaths: [String] = []
+        rootFolderPaths: [String] = [],
+        existingScanModificationDatesByFileID: [UUID: Date] = [:]
     ) async -> SelfHealingScanRequestResult {
         let requestedFileIDs = Set(requests.map(\.fileID))
-        let alreadyScheduledFileIDs = Set(requestedFileIDs.filter { hasQueuedOrActiveScan(for: $0) })
+        let alreadyScheduledFileIDs = Set(requestedFileIDs.filter { fileID in
+            if hasQueuedOrActiveScan(for: fileID) || resultBatchBuffer.contains(where: { $0.fileID == fileID }) {
+                return true
+            }
+            guard acceptedAPIFileIDs.contains(fileID),
+                  let expectedModificationDate = existingScanModificationDatesByFileID[fileID],
+                  let latestModificationDate = latestFileModDates[fileID]
+            else { return false }
+            return latestModificationDate >= expectedModificationDate
+        })
         let submittedFileIDs = await requestScans(
-            requests,
+            requests.filter { !alreadyScheduledFileIDs.contains($0.fileID) },
             purpose: .selfHealing,
             rootFolderPaths: rootFolderPaths
         )

--- a/Sources/RepoPrompt/Features/CodeMap/CodeScanActor.swift
+++ b/Sources/RepoPrompt/Features/CodeMap/CodeScanActor.swift
@@ -189,6 +189,8 @@ actor CodeScanActor {
     // -------------------------------------
     private var resultContinuations = [UUID: AsyncStream<[ScanResult]>.Continuation]()
     private var resultBatchBuffer = [ScanResult]()
+    /// File IDs yielded to the store but not yet acknowledged as installed or rejected.
+    private var resultDeliveryPendingFileIDs = Set<UUID>()
     private var resultsCoalescingTask: Task<Void, Never>?
     private let resultsCoalescingDelay: UInt64 = 2_000_000_000 // e.g. 2 seconds
     private var lastResultsScheduleCall = DispatchTime.now()
@@ -1059,7 +1061,10 @@ actor CodeScanActor {
     ) async -> SelfHealingScanRequestResult {
         let requestedFileIDs = Set(requests.map(\.fileID))
         let alreadyScheduledFileIDs = Set(requestedFileIDs.filter { fileID in
-            if hasQueuedOrActiveScan(for: fileID) || resultBatchBuffer.contains(where: { $0.fileID == fileID }) {
+            if hasQueuedOrActiveScan(for: fileID)
+                || resultBatchBuffer.contains(where: { $0.fileID == fileID })
+                || resultDeliveryPendingFileIDs.contains(fileID)
+            {
                 return true
             }
             guard acceptedAPIFileIDs.contains(fileID),
@@ -1388,12 +1393,17 @@ actor CodeScanActor {
 
         let batch = resultBatchBuffer
         resultBatchBuffer.removeAll()
+        resultDeliveryPendingFileIDs.formUnion(batch.map(\.fileID))
         CodeMapPerfRuntime.sharedPipelineStats?.recordResultBatch(size: batch.count)
 
         for continuation in resultContinuations.values {
             continuation.yield(batch)
         }
         resultsCoalescingTask = nil
+    }
+
+    func acknowledgeScanResults(fileIDs: some Sequence<UUID>) {
+        resultDeliveryPendingFileIDs.subtract(fileIDs)
     }
 
     // -------------------------------------------------------
@@ -1497,6 +1507,7 @@ actor CodeScanActor {
                 }
                 acceptedAPIFileIDs.remove(fileID)
                 latestFileModDates.removeValue(forKey: fileID)
+                resultDeliveryPendingFileIDs.remove(fileID)
             }
         }
     }

--- a/Sources/RepoPrompt/Features/Diagnostics/MCP/MCPConnectionManager+DebugDiagnosticsReadSearchLatency.swift
+++ b/Sources/RepoPrompt/Features/Diagnostics/MCP/MCPConnectionManager+DebugDiagnosticsReadSearchLatency.swift
@@ -298,7 +298,6 @@ import RepoPromptShared
                     "consistency": "best_effort",
                     "limiter": limiterPayload,
                     "observers": [
-                        "tool_call_observer_count": toolCallObserverCount(),
                         "tool_event_observer_count": toolEventObserverCount()
                     ],
                     "window_count": windows.count,

--- a/Sources/RepoPrompt/Features/Prompt/Services/PromptContextAccountingService.swift
+++ b/Sources/RepoPrompt/Features/Prompt/Services/PromptContextAccountingService.swift
@@ -61,6 +61,11 @@ struct PromptContextAccountingResult {
     let codemapSnapshotsUsed: [UUID: WorkspaceCodemapSnapshot]
 }
 
+enum PromptContextAccountingContentPolicy {
+    case loadContent
+    case cachedOnly
+}
+
 private struct SelectedFileAccountingReadRequest {
     let selectedPathIndex: Int
     let selectedPath: String
@@ -130,7 +135,8 @@ actor PromptContextAccountingService {
             rootScope: request.rootScope,
             profile: request.pathLocateProfile,
             codeMapUsage: request.codeMapUsage,
-            codemapSnapshots: codemapSnapshots
+            codemapSnapshots: codemapSnapshots,
+            contentPolicy: .loadContent
         )
         #if DEBUG
             PromptTokenRecountDiagnostics.event(
@@ -207,7 +213,8 @@ actor PromptContextAccountingService {
         store: WorkspaceFileContextStore,
         rootScope: WorkspaceLookupRootScope = .allLoaded,
         profile: PathLocateProfile = .uiAssisted,
-        codeMapUsage: CodeMapUsage = .auto
+        codeMapUsage: CodeMapUsage = .auto,
+        contentPolicy: PromptContextAccountingContentPolicy = .loadContent
     ) async -> (entries: [ResolvedPromptFileEntry], missingPaths: [String], invalidPaths: [String]) {
         let codemapSnapshots = await store.codemapSnapshotDictionary()
         return await resolveEntries(
@@ -216,7 +223,8 @@ actor PromptContextAccountingService {
             rootScope: rootScope,
             profile: profile,
             codeMapUsage: codeMapUsage,
-            codemapSnapshots: codemapSnapshots
+            codemapSnapshots: codemapSnapshots,
+            contentPolicy: contentPolicy
         )
     }
 
@@ -226,7 +234,8 @@ actor PromptContextAccountingService {
         rootScope: WorkspaceLookupRootScope,
         profile: PathLocateProfile,
         codeMapUsage: CodeMapUsage,
-        codemapSnapshots: [UUID: WorkspaceCodemapSnapshot]
+        codemapSnapshots: [UUID: WorkspaceCodemapSnapshot],
+        contentPolicy: PromptContextAccountingContentPolicy
     ) async -> (entries: [ResolvedPromptFileEntry], missingPaths: [String], invalidPaths: [String]) {
         #if DEBUG
             let resolveStartMS = PromptTokenRecountDiagnostics.start()
@@ -408,12 +417,22 @@ actor PromptContextAccountingService {
                     #endif
                     let content: String?
                     let errorDescription: String?
-                    do {
-                        content = try await store.readContent(rootID: request.file.rootID, relativePath: request.file.standardizedRelativePath)
+                    switch contentPolicy {
+                    case .loadContent:
+                        do {
+                            content = try await store.readContent(
+                                rootID: request.file.rootID,
+                                relativePath: request.file.standardizedRelativePath,
+                                workloadClass: .promptAccounting
+                            )
+                            errorDescription = nil
+                        } catch {
+                            content = nil
+                            errorDescription = String(String(describing: error).prefix(120))
+                        }
+                    case .cachedOnly:
+                        content = await store.cachedSearchContentSnapshot(for: request.file).content
                         errorDescription = nil
-                    } catch {
-                        content = nil
-                        errorDescription = String(String(describing: error).prefix(120))
                     }
                     #if DEBUG
                         selectedPathsDebugState.finishBatchRead(errorDescription: errorDescription)
@@ -539,7 +558,16 @@ actor PromptContextAccountingService {
                             selectedPathsDebugState.beginRead(file: file)
                         #endif
                         do {
-                            content = try await store.readContent(rootID: file.rootID, relativePath: file.standardizedRelativePath)
+                            content = switch contentPolicy {
+                            case .loadContent:
+                                try await store.readContent(
+                                    rootID: file.rootID,
+                                    relativePath: file.standardizedRelativePath,
+                                    workloadClass: .promptAccounting
+                                )
+                            case .cachedOnly:
+                                await store.cachedSearchContentSnapshot(for: file).content
+                            }
                         } catch {
                             content = nil
                             #if DEBUG
@@ -621,7 +649,16 @@ actor PromptContextAccountingService {
             }
             guard !selectedFileIDs.contains(file.id) else { continue }
             selectedFileIDs.insert(file.id)
-            let content = try? await store.readContent(rootID: file.rootID, relativePath: file.standardizedRelativePath)
+            let content: String? = switch contentPolicy {
+            case .loadContent:
+                try? await store.readContent(
+                    rootID: file.rootID,
+                    relativePath: file.standardizedRelativePath,
+                    workloadClass: .promptAccounting
+                )
+            case .cachedOnly:
+                await store.cachedSearchContentSnapshot(for: file).content
+            }
             let entry = ResolvedPromptFileEntry(file: file, lineRanges: ranges, mode: .sliced, loadedContent: content ?? nil, rootFolderPath: result.location.rootPath)
             append(entry, to: &entries, seenIDs: &seenIDs)
         }

--- a/Sources/RepoPrompt/Features/Prompt/Services/PromptContextAccountingService.swift
+++ b/Sources/RepoPrompt/Features/Prompt/Services/PromptContextAccountingService.swift
@@ -286,6 +286,9 @@ actor PromptContextAccountingService {
             WorkspacePathLookupRequest(userPath: $0, profile: profile, rootScope: rootScope)
         }
         let selectedPathLookupResults = await store.lookupPaths(selectedPathLookupRequests)
+        guard !Task.isCancelled else {
+            return (entries, missingPaths, invalidPaths)
+        }
         #if DEBUG
             selectedPathsDebugState.finishLookupBatch()
             let lookupResolvedFiles = selection.selectedPaths.reduce(into: 0) { count, path in
@@ -319,6 +322,9 @@ actor PromptContextAccountingService {
         var selectedPathResultsByIndex: [Int: WorkspacePathLookupResult] = [:]
         var selectedPathFallbackLookups = 0
         for (selectedPathIndex, path) in selection.selectedPaths.enumerated() {
+            guard !Task.isCancelled else {
+                return (entries, missingPaths, invalidPaths)
+            }
             if let result = selectedPathLookupResults[path] {
                 selectedPathResultsByIndex[selectedPathIndex] = result
             } else if let result = await store.lookupPath(path, profile: profile, rootScope: rootScope) {
@@ -341,6 +347,9 @@ actor PromptContextAccountingService {
         var selectedFileReadRequests: [SelectedFileAccountingReadRequest] = []
         var selectedCodemapReadSkips = 0
         for (selectedPathIndex, path) in selection.selectedPaths.enumerated() {
+            guard !Task.isCancelled else {
+                return (entries, missingPaths, invalidPaths)
+            }
             #if DEBUG
                 selectedPathsDebugState.beginPath(index: selectedPathIndex, path: path)
                 PromptTokenRecountDiagnostics.event(
@@ -409,9 +418,21 @@ actor PromptContextAccountingService {
             var results: [Int: SelectedFileAccountingReadResult] = [:]
 
             func enqueueNextReadIfAvailable() {
-                guard activeReads < concurrencyLimit, let request = iterator.next() else { return }
+                guard !Task.isCancelled,
+                      activeReads < concurrencyLimit,
+                      let request = iterator.next()
+                else {
+                    return
+                }
                 activeReads += 1
                 group.addTask {
+                    guard !Task.isCancelled else {
+                        return SelectedFileAccountingReadResult(
+                            selectedPathIndex: request.selectedPathIndex,
+                            content: nil,
+                            errorDescription: "cancelled"
+                        )
+                    }
                     #if DEBUG
                         selectedPathsDebugState.beginBatchRead(index: request.selectedPathIndex, path: request.selectedPath, file: request.file)
                     #endif
@@ -467,10 +488,17 @@ actor PromptContextAccountingService {
             while let result = await group.next() {
                 activeReads -= 1
                 results[result.selectedPathIndex] = result
+                if Task.isCancelled {
+                    group.cancelAll()
+                    break
+                }
                 enqueueNextReadIfAvailable()
             }
 
             return results
+        }
+        guard !Task.isCancelled else {
+            return (entries, missingPaths, invalidPaths)
         }
         #if DEBUG
             let readBatchErrors = selectedFileReadResults.values.reduce(into: 0) { count, result in
@@ -491,6 +519,9 @@ actor PromptContextAccountingService {
         #endif
 
         for (selectedPathIndex, path) in selection.selectedPaths.enumerated() {
+            guard !Task.isCancelled else {
+                return (entries, missingPaths, invalidPaths)
+            }
             guard let result = selectedPathResultsByIndex[selectedPathIndex] else {
                 #if DEBUG
                     selectedPathsDebugState.beginAssembly(index: selectedPathIndex, path: path, resolvedKind: "missing")
@@ -548,6 +579,9 @@ actor PromptContextAccountingService {
                     )
                 #endif
                 for file in files where prefix.isEmpty || file.standardizedRelativePath == prefix || file.standardizedRelativePath.hasPrefix(prefix + "/") {
+                    guard !Task.isCancelled else {
+                        return (entries, missingPaths, invalidPaths)
+                    }
                     selectedFileIDs.insert(file.id)
                     let useSelectedCodemap = codeMapUsage == .selected && codemapSnapshots[file.id]?.fileAPI != nil
                     let content: String?
@@ -639,6 +673,9 @@ actor PromptContextAccountingService {
             )
         #endif
         for (path, ranges) in selection.slices {
+            guard !Task.isCancelled else {
+                return (entries, missingPaths, invalidPaths)
+            }
             guard let result = await store.lookupPath(path, profile: profile, rootScope: rootScope) else {
                 missingPaths.append(path)
                 continue
@@ -698,7 +735,13 @@ actor PromptContextAccountingService {
             WorkspacePathLookupRequest(userPath: $0, profile: profile, rootScope: rootScope)
         }
         let codemapPathLookupResults = await store.lookupPaths(codemapPathLookupRequests)
+        guard !Task.isCancelled else {
+            return (entries, missingPaths, invalidPaths)
+        }
         for path in codemapPaths {
+            guard !Task.isCancelled else {
+                return (entries, missingPaths, invalidPaths)
+            }
             guard let result = codemapPathLookupResults[path] else {
                 missingPaths.append(path)
                 continue

--- a/Sources/RepoPrompt/Features/Prompt/ViewModels/PromptViewModel.swift
+++ b/Sources/RepoPrompt/Features/Prompt/ViewModels/PromptViewModel.swift
@@ -2455,6 +2455,17 @@ class PromptViewModel: ObservableObject {
         return try await operation()
     }
 
+    @MainActor
+    private func withComposeTabActivationSnapshotSuspended<T>(
+        targetTabID: UUID,
+        manager: WorkspaceManagerViewModel,
+        operation: () async throws -> T
+    ) async rethrows -> T {
+        manager.beginApplyingTabContext(forTabID: targetTabID)
+        defer { manager.endApplyingTabContext(forTabID: targetTabID) }
+        return try await operation()
+    }
+
     @discardableResult
     @MainActor
     private func flushAndSnapshotSourceTabIfNeeded(
@@ -2530,16 +2541,17 @@ class PromptViewModel: ObservableObject {
         }
 
         manager.workspaces[index].composeTabs.append(newTab)
-        manager.workspaces[index].activeComposeTabID = newTab.id
-        activeComposeTabID = newTab.id
-        dirtyTabIDs.remove(newTab.id)
+        await withComposeTabActivationSnapshotSuspended(targetTabID: newTab.id, manager: manager) {
+            manager.workspaces[index].activeComposeTabID = newTab.id
+            activeComposeTabID = newTab.id
+            dirtyTabIDs.remove(newTab.id)
+            loadComposeTabsFromWorkspace(manager.workspaces[index])
+            await withComposeTabSwitching(targetTabID: newTab.id) {
+                await manager.applyComposeTabState(newTab)
+            }
+        }
 
         manager.markWorkspaceDirty()
-
-        loadComposeTabsFromWorkspace(manager.workspaces[index])
-        await withComposeTabSwitching(targetTabID: newTab.id) {
-            await manager.applyComposeTabState(newTab)
-        }
         manager.pollAndSaveState()
     }
 
@@ -2646,23 +2658,25 @@ class PromptViewModel: ObservableObject {
         // Flush pending editor state and snapshot current tab before switching
         flushAndSnapshotActiveTab(in: manager, workspaceIndex: index)
 
-        manager.workspaces[index].activeComposeTabID = id
-        activeComposeTabID = id
+        await withComposeTabActivationSnapshotSuspended(targetTabID: id, manager: manager) {
+            manager.workspaces[index].activeComposeTabID = id
+            activeComposeTabID = id
 
-        loadComposeTabsFromWorkspace(manager.workspaces[index])
-        guard let target = manager.workspaces[index].composeTabs.first(where: { $0.id == id }) else { return }
+            loadComposeTabsFromWorkspace(manager.workspaces[index])
+            guard let target = manager.workspaces[index].composeTabs.first(where: { $0.id == id }) else { return }
 
-        activeTabApplyTask?.cancel()
+            activeTabApplyTask?.cancel()
 
-        let task = Task { [weak self, weak manager] in
-            guard let self, let manager else { return }
-            await withComposeTabSwitching(targetTabID: id) {
-                await manager.applyComposeTabStateAsync(tab: target, windowID: self.windowID)
+            let task = Task { [weak self, weak manager] in
+                guard let self, let manager else { return }
+                await withComposeTabSwitching(targetTabID: id) {
+                    await manager.applyComposeTabStateAsync(tab: target, windowID: self.windowID)
+                }
             }
-        }
 
-        activeTabApplyTask = task
-        await task.value
+            activeTabApplyTask = task
+            await task.value
+        }
     }
 
     @MainActor
@@ -2811,7 +2825,6 @@ class PromptViewModel: ObservableObject {
         manager.workspaces[index].composeTabs = tabs
 
         if tabs.isEmpty {
-            manager.workspaces[index].activeComposeTabID = nil
             await appendReplacementBlankComposeTabIfNeeded(manager: manager, workspaceIndex: index)
             loadComposeTabsFromWorkspace(manager.workspaces[index])
             #if DEBUG
@@ -2844,16 +2857,20 @@ class PromptViewModel: ObservableObject {
             newActiveID = tabs.first?.id
         }
 
-        manager.workspaces[index].activeComposeTabID = newActiveID
-        activeComposeTabID = newActiveID
-
         if newActiveID != previousActiveID,
            let newActiveID,
            let tab = tabs.first(where: { $0.id == newActiveID })
         {
-            await withComposeTabSwitching(targetTabID: newActiveID) {
-                await manager.applyComposeTabState(tab)
+            await withComposeTabActivationSnapshotSuspended(targetTabID: newActiveID, manager: manager) {
+                manager.workspaces[index].activeComposeTabID = newActiveID
+                activeComposeTabID = newActiveID
+                await withComposeTabSwitching(targetTabID: newActiveID) {
+                    await manager.applyComposeTabState(tab)
+                }
             }
+        } else {
+            manager.workspaces[index].activeComposeTabID = newActiveID
+            activeComposeTabID = newActiveID
         }
 
         loadComposeTabsFromWorkspace(manager.workspaces[index])
@@ -2914,11 +2931,13 @@ class PromptViewModel: ObservableObject {
             manager: manager
         ) else { return }
         manager.workspaces[workspaceIndex].composeTabs.append(blankTab)
-        manager.workspaces[workspaceIndex].activeComposeTabID = blankTab.id
-        activeComposeTabID = blankTab.id
-        dirtyTabIDs.remove(blankTab.id)
-        await withComposeTabSwitching(targetTabID: blankTab.id) {
-            await manager.applyComposeTabState(blankTab)
+        await withComposeTabActivationSnapshotSuspended(targetTabID: blankTab.id, manager: manager) {
+            manager.workspaces[workspaceIndex].activeComposeTabID = blankTab.id
+            activeComposeTabID = blankTab.id
+            dirtyTabIDs.remove(blankTab.id)
+            await withComposeTabSwitching(targetTabID: blankTab.id) {
+                await manager.applyComposeTabState(blankTab)
+            }
         }
     }
 
@@ -3143,11 +3162,7 @@ class PromptViewModel: ObservableObject {
 
         // Add to compose tabs
         manager.workspaces[index].composeTabs.append(restoredTab)
-        manager.workspaces[index].activeComposeTabID = restoredTab.id
         manager.workspaces[index].dateModified = Date()
-
-        // Reload state
-        loadComposeTabsFromWorkspace(manager.workspaces[index])
         currentStashedTabs = manager.workspaces[index].stashedTabs
 
         // Switch to the restored tab
@@ -3208,7 +3223,6 @@ class PromptViewModel: ObservableObject {
                 dirtyTabIDs.subtract(composeTabIDsBeingDeleted)
                 manager.workspaces[index].composeTabs = remainingComposeTabs
                 if remainingComposeTabs.isEmpty {
-                    manager.workspaces[index].activeComposeTabID = nil
                     await appendReplacementBlankComposeTabIfNeeded(manager: manager, workspaceIndex: index)
                 } else {
                     var newActiveID = previousActiveID
@@ -3225,15 +3239,20 @@ class PromptViewModel: ObservableObject {
                     } else if newActiveID == nil {
                         newActiveID = remainingComposeTabs.first?.id
                     }
-                    manager.workspaces[index].activeComposeTabID = newActiveID
-                    activeComposeTabID = newActiveID
                     if newActiveID != previousActiveID,
                        let newActiveID,
                        let tab = remainingComposeTabs.first(where: { $0.id == newActiveID })
                     {
-                        await withComposeTabSwitching(targetTabID: newActiveID) {
-                            await manager.applyComposeTabState(tab)
+                        await withComposeTabActivationSnapshotSuspended(targetTabID: newActiveID, manager: manager) {
+                            manager.workspaces[index].activeComposeTabID = newActiveID
+                            activeComposeTabID = newActiveID
+                            await withComposeTabSwitching(targetTabID: newActiveID) {
+                                await manager.applyComposeTabState(tab)
+                            }
                         }
+                    } else {
+                        manager.workspaces[index].activeComposeTabID = newActiveID
+                        activeComposeTabID = newActiveID
                     }
                 }
             }

--- a/Sources/RepoPrompt/Features/Prompt/ViewModels/TokenCountingViewModel.swift
+++ b/Sources/RepoPrompt/Features/Prompt/ViewModels/TokenCountingViewModel.swift
@@ -86,6 +86,11 @@ class TokenCountingViewModel: ObservableObject {
     private var lastObservedSelectionObservationRevision: UInt64 = 0
     private var lastPredominantLanguage: String = "Swift"
     private var automaticRecountSuspendDepth: Int = 0
+    private var lastPublishedSelection: StoredSelection?
+    #if DEBUG
+        private var debugBeforeTokenCalculationForTesting: (@MainActor @Sendable () async -> Void)?
+        private var debugTokenCalculationStartCount = 0
+    #endif
 
     // MARK: - Dependencies
 
@@ -361,7 +366,51 @@ class TokenCountingViewModel: ObservableObject {
         }
     }
 
+    struct PublishedTokenSnapshot {
+        let breakdown: TokenBreakdown
+        let filesContentTokens: Int
+        let codeMapTokens: Int
+        let isComplete: Bool
+        let isStale: Bool
+        let refreshPending: Bool
+    }
+
+    func latestPublishedTokenSnapshot(for expectedSelection: StoredSelection?) -> PublishedTokenSnapshot {
+        let selectionMatches = expectedSelection == nil || expectedSelection == lastPublishedSelection
+        let calculationPending = tokenUpdateDebounceTask != nil || updateTokenCountTask != nil || isImmediateRecountInProgress
+        let isComplete = didComputeBaseline
+        let isStale = !pendingDirty.isEmpty || calculationPending || !selectionMatches
+        if !isComplete {
+            markDirty()
+        } else if !selectionMatches {
+            markDirty(.selection)
+        }
+        return PublishedTokenSnapshot(
+            breakdown: latestTokenBreakdown(),
+            filesContentTokens: totalTokenCountFilesOnly,
+            codeMapTokens: codeMapTokenCount,
+            isComplete: isComplete,
+            isStale: isStale,
+            refreshPending: !isComplete || isStale || tokenUpdateDebounceTask != nil || updateTokenCountTask != nil
+        )
+    }
+
+    func latestPublishedTokenInfo(forFullPath fullPath: String) -> TokenInfo? {
+        guard let fileID = fileManager?.findFileByFullPath(fullPath)?.id else { return nil }
+        return fileTokenInfo[fileID]
+    }
+
     #if DEBUG
+        func setBeforeTokenCalculationForTesting(
+            _ handler: (@MainActor @Sendable () async -> Void)?
+        ) {
+            debugBeforeTokenCalculationForTesting = handler
+        }
+
+        func tokenCalculationStartCountForTesting() -> Int {
+            debugTokenCalculationStartCount
+        }
+
         func debugTokenRecountStateFields() -> [String: String] {
             [
                 "pendingDirtyRaw": "\(pendingDirty.rawValue)",
@@ -482,6 +531,8 @@ class TokenCountingViewModel: ObservableObject {
     /// Heavy path (rebuild baseline and everything else).
     private func performTokenCountOffMainThread() async {
         #if DEBUG
+            debugTokenCalculationStartCount += 1
+            await debugBeforeTokenCalculationForTesting?()
             let calculateStartMS = PromptTokenRecountDiagnostics.start()
             PromptTokenRecountDiagnostics.event("tokenRecount.calculate.begin", fields: debugTokenRecountStateFields())
         #endif
@@ -794,6 +845,7 @@ class TokenCountingViewModel: ObservableObject {
         lastDuplicatePromptTokens = duplicatePromptTokensLocal
         lastInstructionsTokens = instructionsTokensLocal
         lastGitDiffTokens = gitDiffTokens
+        lastPublishedSelection = selectionAtStart
         copyContextTotalTokens = copyTotal
         copyContextTokenCountString = copyTokenString
         didComputeBaseline = true

--- a/Sources/RepoPrompt/Features/Workspaces/ViewModels/WorkspaceManagerViewModel.swift
+++ b/Sources/RepoPrompt/Features/Workspaces/ViewModels/WorkspaceManagerViewModel.swift
@@ -248,6 +248,7 @@ class WorkspaceManagerViewModel: ObservableObject {
 
     /// Per-tab suspension of snapshot commits during UI apply to prevent transient overwrites
     @Published private var suspendedSnapshotCommitTabIDs: Set<UUID> = []
+    private var activationSnapshotSuspendedTabIDs: Set<UUID> = []
 
     // Guard to suppress cross-tab snapshot emissions during MCP tab-context apply
     @Published private var applyingTabContextID: UUID? = nil
@@ -2777,6 +2778,15 @@ class WorkspaceManagerViewModel: ObservableObject {
         let loadSignpost = WorkspaceExitPerf.begin("switchWorkspace.loadWorkspace")
         defer { WorkspaceExitPerf.end("switchWorkspace.loadWorkspace", loadSignpost) }
         let hydrationGeneration = beginWorkspaceHydration(for: activeWS)
+        let restoredHeavyFileState = activeComposeTabHeavyFileStateSnapshot(in: activeWS)
+        if let restoredTabID = restoredHeavyFileState?.tabID {
+            activationSnapshotSuspendedTabIDs.insert(restoredTabID)
+        }
+        defer {
+            if let restoredTabID = restoredHeavyFileState?.tabID {
+                activationSnapshotSuspendedTabIDs.remove(restoredTabID)
+            }
+        }
         runGitDataMaintenanceOnWorkspaceOpen(activeWS)
 
         // Restore path-based state before catalog/search hydration. This activation phase
@@ -2864,6 +2874,18 @@ class WorkspaceManagerViewModel: ObservableObject {
         }
         guard isHydrationGenerationCurrent(hydrationGeneration, workspaceID: activeWS.id) else {
             return .cancelled("Workspace switch to \"\(newWorkspace.name)\" was superseded during root hydration.")
+        }
+
+        await replayActiveComposeTabHeavyFileStateAfterHydration(restoredHeavyFileState, workspaceID: activeWS.id)
+        if let cancellation = cancellationResult(
+            operationID: operationID,
+            targetWorkspace: newWorkspace,
+            boundary: "replaying hydrated selection"
+        ) {
+            return cancellation
+        }
+        guard isHydrationGenerationCurrent(hydrationGeneration, workspaceID: activeWS.id) else {
+            return .cancelled("Workspace switch to \"\(newWorkspace.name)\" was superseded while replaying hydrated selection.")
         }
 
         // Another yield after state restoration
@@ -3348,12 +3370,17 @@ class WorkspaceManagerViewModel: ObservableObject {
         if selectionCoordinator?.isApplyingSelectionMirror == true {
             return
         }
+        if let activeBase = base,
+           activationSnapshotSuspendedTabIDs.contains(activeBase.id)
+        {
+            return
+        }
 
         let snapshot = collectComposeTabSnapshot(name: name, base: base)
 
         // Respect per-tab suspension: avoid mutating composeTabs during UI apply,
         // so mirroring can treat these as transient snapshots.
-        let shouldCommit: Bool = commitToMemory && !suspendedSnapshotCommitTabIDs.contains(snapshot.id)
+        let shouldCommit: Bool = commitToMemory && !isSnapshotCommitSuspended(forTabID: snapshot.id)
         let didChange = Self.composeTabSnapshotHasMeaningfulChanges(snapshot, comparedTo: base, touchModified: touchModified)
         guard didChange else { return }
         if shouldCommit {
@@ -3382,6 +3409,14 @@ class WorkspaceManagerViewModel: ObservableObject {
         } else {
             suspendedSnapshotCommitTabIDs.remove(id)
         }
+    }
+
+    @MainActor
+    private func isSnapshotCommitSuspended(forTabID id: UUID) -> Bool {
+        suspendedSnapshotCommitTabIDs.contains(id)
+            || activationSnapshotSuspendedTabIDs.contains(id)
+            || applyingTabContextID == id
+            || applyingTabContextDepthByTabID[id, default: 0] > 0
     }
 
     @MainActor
@@ -3489,6 +3524,39 @@ class WorkspaceManagerViewModel: ObservableObject {
         selectionCoordinator?.refreshDeferredUISelectionFence(forTabID: tab.id)
     }
 
+    private struct ComposeTabHeavyFileStateSnapshot {
+        let tabID: UUID
+    }
+
+    private func activeComposeTabHeavyFileStateSnapshot(
+        in workspace: WorkspaceModel
+    ) -> ComposeTabHeavyFileStateSnapshot? {
+        guard let activeTabID = workspace.activeComposeTabID,
+              workspace.composeTabs.contains(where: { $0.id == activeTabID })
+        else { return nil }
+        return ComposeTabHeavyFileStateSnapshot(tabID: activeTabID)
+    }
+
+    @MainActor
+    private func replayActiveComposeTabHeavyFileStateAfterHydration(
+        _ snapshot: ComposeTabHeavyFileStateSnapshot?,
+        workspaceID: UUID
+    ) async {
+        guard let snapshot,
+              let workspace = activeWorkspace, workspace.id == workspaceID,
+              workspace.activeComposeTabID == snapshot.tabID,
+              let currentTab = workspace.composeTabs.first(where: { $0.id == snapshot.tabID })
+        else { return }
+
+        beginApplyingTabContext(forTabID: snapshot.tabID)
+        defer { endApplyingTabContext(forTabID: snapshot.tabID) }
+        await fileManager.withDeferredSelectionSliceSnapshotRebuild(reason: "workspaceRestore.postHydrationReplay") {
+            await fileManager.restoreExpansionState(from: currentTab.expandedFolders)
+            await fileManager.onActiveTabChangedHeavy(for: currentTab.id, selection: currentTab.selection)
+            selectionCoordinator?.refreshDeferredUISelectionFence(forTabID: currentTab.id)
+        }
+    }
+
     @MainActor
     private func markWorkspaceDirtyIfTabStillActive(tabID: UUID) -> Bool {
         guard
@@ -3507,23 +3575,30 @@ class WorkspaceManagerViewModel: ObservableObject {
         workspaces: [WorkspaceModel],
         activeWorkspaceID: UUID?,
         activeComposeTabID: UUID?,
+        captureActiveUIState: Bool,
         liveSnapshotProvider: (ComposeTabState) -> ComposeTabState
     ) -> (workspaceID: UUID, snapshot: ComposeTabState, usesLiveUIState: Bool)? {
         for workspace in workspaces {
             guard let tab = workspace.composeTabs.first(where: { $0.id == tabID }) else { continue }
-            let usesLiveUIState = workspace.id == activeWorkspaceID && tab.id == activeComposeTabID
+            let usesLiveUIState = captureActiveUIState
+                && workspace.id == activeWorkspaceID
+                && tab.id == activeComposeTabID
             let snapshot = usesLiveUIState ? liveSnapshotProvider(tab) : tab
             return (workspace.id, snapshot, usesLiveUIState)
         }
         return nil
     }
 
-    func resolveComposeTabRoutingSnapshot(for tabID: UUID) -> (workspaceID: UUID, snapshot: ComposeTabState, usesLiveUIState: Bool)? {
+    func resolveComposeTabRoutingSnapshot(
+        for tabID: UUID,
+        captureActiveUIState: Bool = true
+    ) -> (workspaceID: UUID, snapshot: ComposeTabState, usesLiveUIState: Bool)? {
         Self.resolveComposeTabRoutingSnapshot(
             tabID: tabID,
             workspaces: workspaces,
             activeWorkspaceID: activeWorkspaceID,
-            activeComposeTabID: promptViewModel.activeComposeTabID
+            activeComposeTabID: promptViewModel.activeComposeTabID,
+            captureActiveUIState: captureActiveUIState
         ) { [weak self] base in
             guard let self else { return base }
             return collectComposeTabSnapshot(name: base.name, base: base)
@@ -3535,6 +3610,7 @@ class WorkspaceManagerViewModel: ObservableObject {
         workspaces: [WorkspaceModel],
         activeWorkspaceID: UUID?,
         activeComposeTabID: UUID?,
+        captureActiveUIState: Bool = true,
         liveSnapshotProvider: (ComposeTabState) -> ComposeTabState = { $0 }
     ) -> (workspaceID: UUID, snapshot: ComposeTabState, usesLiveUIState: Bool)? {
         resolveComposeTabRoutingSnapshot(
@@ -3542,6 +3618,7 @@ class WorkspaceManagerViewModel: ObservableObject {
             workspaces: workspaces,
             activeWorkspaceID: activeWorkspaceID,
             activeComposeTabID: activeComposeTabID,
+            captureActiveUIState: captureActiveUIState,
             liveSnapshotProvider: liveSnapshotProvider
         )
     }
@@ -4237,6 +4314,7 @@ class WorkspaceManagerViewModel: ObservableObject {
         if let activeTabID = workspaces[index].activeComposeTabID,
            let tabIndex = workspaces[index].composeTabs.firstIndex(where: { $0.id == activeTabID })
         {
+            guard !isSnapshotCommitSuspended(forTabID: activeTabID) else { return nil }
             #if DEBUG
                 debugSelectionOwnerTraceEvent("save.capture.before", workspace: workspaces[index])
             #endif

--- a/Sources/RepoPrompt/Features/Workspaces/ViewModels/WorkspaceManagerViewModel.swift
+++ b/Sources/RepoPrompt/Features/Workspaces/ViewModels/WorkspaceManagerViewModel.swift
@@ -4019,7 +4019,7 @@ class WorkspaceManagerViewModel: ObservableObject {
         beginApplyingTabContext(forTabID: tabID)
         defer { endApplyingTabContext(forTabID: tabID) }
         await fileManager.applyStoredSelection(selection)
-        await promptViewModel.tokenCountingViewModel.forceImmediateRecount()
+        promptViewModel.tokenCountingViewModel.markDirty(.selection)
     }
 
     /// Applies the newest stored selection after deferred `read_file` auto-selection.

--- a/Sources/RepoPrompt/Features/Workspaces/WorkspaceModel.swift
+++ b/Sources/RepoPrompt/Features/Workspaces/WorkspaceModel.swift
@@ -145,7 +145,7 @@ struct WorkspacePreset: Codable, Identifiable, Equatable {
     }
 }
 
-struct StoredSelection: Codable, Equatable {
+struct StoredSelection: Codable, Equatable, Hashable {
     let selectedPaths: [String]
     let autoCodemapPaths: [String]
     let slices: [String: [LineRange]]

--- a/Sources/RepoPrompt/Infrastructure/AI/Agents/AgentToolTracker.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Agents/AgentToolTracker.swift
@@ -7,45 +7,6 @@ actor AgentToolTracker {
     private var trackedRunID: UUID?
     private var hasUnregistered = false
 
-    /// Registers a tool-call observer for a discovery run (by runID).
-    /// Observer registration happens BEFORE waiting for connection, ensuring it's ready
-    /// when tools are called, even during connection handovers.
-    func start(
-        runID: UUID,
-        clientNameHint: String?,
-        connectionTimeoutSeconds: TimeInterval = 10.0,
-        fallbackTimeoutSeconds: TimeInterval = 5.0,
-        keepObserversOnTimeout: Bool = true,
-        onTool: @escaping @Sendable (String) -> Void
-    ) async {
-        let manager = ServerNetworkManager.shared
-
-        // Register observer FIRST, keyed by runID (survives connection handovers)
-        await manager.registerToolCallObserver(for: runID, observer: onTool)
-        trackedRunID = runID
-        hasUnregistered = false
-
-        // Wait for connection (with cancellation checks)
-        guard !Task.isCancelled else {
-            await unregisterObserverOnce(for: runID, manager: manager)
-            return
-        }
-
-        var resolvedID: UUID?
-        if let hint = clientNameHint {
-            resolvedID = await manager.waitForNewConnection(clientName: hint, timeout: connectionTimeoutSeconds)
-        }
-        if !Task.isCancelled, resolvedID == nil {
-            resolvedID = await manager.waitForNewConnection(clientName: nil, timeout: fallbackTimeoutSeconds)
-        }
-
-        if Task.isCancelled {
-            await unregisterObserverOnce(for: runID, manager: manager)
-        } else if resolvedID == nil, !keepObserversOnTimeout {
-            await unregisterObserverOnce(for: runID, manager: manager)
-        }
-    }
-
     /// Registers an enhanced tool event observer that receives args on call and result on completion.
     func registerEnhancedObserver(
         runID: UUID,
@@ -143,6 +104,106 @@ actor AgentToolTracker {
     }
 }
 
+/// Accepts transcript-facing tool events synchronously and delivers them in FIFO order.
+///
+/// MCP observer callbacks enqueue here before their first suspension, so tool dispatch and
+/// completion response paths never wait for main-actor transcript/UI work. Each controller
+/// owns one mailbox, which preserves call-before-completion ordering for that tab while
+/// retaining at most one drain task.
+final class AgentToolEventDeliveryMailbox: @unchecked Sendable {
+    typealias Operation = @Sendable () async -> Void
+
+    private let lock = NSLock()
+    private var queuedOperations: [Operation] = []
+    private var queuedOperationHead = 0
+    private var nextDrainToken: UInt64 = 0
+    private var activeDrainToken: UInt64?
+    private var idleContinuations: [CheckedContinuation<Void, Never>] = []
+
+    func enqueue(_ operation: @escaping Operation) {
+        lock.lock()
+        queuedOperations.append(operation)
+        scheduleDrainIfNeeded()
+        lock.unlock()
+    }
+
+    func waitUntilIdle() async {
+        await withCheckedContinuation { continuation in
+            lock.lock()
+            guard activeDrainToken != nil || queuedOperationHead < queuedOperations.count else {
+                lock.unlock()
+                continuation.resume()
+                return
+            }
+            idleContinuations.append(continuation)
+            lock.unlock()
+        }
+    }
+
+    #if DEBUG
+        func queuedOperationCountForTesting() -> Int {
+            lock.lock()
+            defer { lock.unlock() }
+            return queuedOperations.count - queuedOperationHead
+        }
+    #endif
+
+    private func scheduleDrainIfNeeded() {
+        guard activeDrainToken == nil, queuedOperationHead < queuedOperations.count else { return }
+        nextDrainToken &+= 1
+        let token = nextDrainToken
+        activeDrainToken = token
+        Task { [weak self] in
+            await self?.drain(token: token)
+        }
+    }
+
+    private func takeNextOperation(token: UInt64) -> Operation? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard activeDrainToken == token, queuedOperationHead < queuedOperations.count else {
+            return nil
+        }
+        let operation = queuedOperations[queuedOperationHead]
+        queuedOperationHead += 1
+        if queuedOperationHead == queuedOperations.count {
+            queuedOperations.removeAll(keepingCapacity: true)
+            queuedOperationHead = 0
+        } else if queuedOperationHead >= 64, queuedOperationHead * 2 >= queuedOperations.count {
+            queuedOperations.removeFirst(queuedOperationHead)
+            queuedOperationHead = 0
+        }
+        return operation
+    }
+
+    private func drain(token: UInt64) async {
+        while let operation = takeNextOperation(token: token) {
+            await operation()
+        }
+        drainDidFinish(token: token)
+    }
+
+    private func drainDidFinish(token: UInt64) {
+        lock.lock()
+        guard activeDrainToken == token else {
+            lock.unlock()
+            return
+        }
+        activeDrainToken = nil
+        scheduleDrainIfNeeded()
+        guard activeDrainToken == nil, queuedOperationHead == queuedOperations.count else {
+            lock.unlock()
+            return
+        }
+        let continuations = idleContinuations
+        idleContinuations.removeAll(keepingCapacity: true)
+        lock.unlock()
+        for continuation in continuations {
+            continuation.resume()
+        }
+    }
+}
+
 // SEARCH-HELPER: AgentToolTrackingController, TrackerLifecycle, TrackerBinding, ToolTracking
 /// Shared lifecycle shim for MCP tool tracking across all provider runtimes.
 ///
@@ -151,7 +212,7 @@ actor AgentToolTracker {
 /// keeps one instance per tab (via `[UUID: AgentToolTrackingController]` dictionary).
 ///
 /// Starting tracking for the same `runID` is a no-op. Starting for a different `runID`
-/// cancels the prior task and re-registers. Callbacks are suppressed if the `trackedRunID`
+/// serializes teardown of the prior registration before re-registering. Callbacks are suppressed if the `trackedRunID`
 /// has changed by delivery time (stale-delivery protection).
 ///
 /// Related:
@@ -161,6 +222,7 @@ actor AgentToolTracker {
 /// - ACPIntegratedAgentModeRunner: /RepoPrompt/Services/AgentMode/Runners/ACPIntegratedAgentModeRunner.swift
 final class AgentToolTrackingController {
     private let tracker = AgentToolTracker()
+    private let eventDeliveryMailbox = AgentToolEventDeliveryMailbox()
     private var trackingTask: Task<Void, Never>?
     private var registrationTask: Task<Void, Never>?
     private var registrationRunID: UUID?
@@ -172,7 +234,7 @@ final class AgentToolTrackingController {
     /// Start tracking MCP tool events for a run, delivering callbacks on the main actor.
     ///
     /// - If `runID` matches the current tracked run, this is a no-op.
-    /// - If a different run is tracked, the prior task is cancelled and the tracker re-registered.
+    /// - If a different run is tracked, prior teardown is serialized before registration.
     /// - Stale callbacks (where `trackedRunID` has changed) are silently dropped.
     @MainActor func startTracking(
         runID: UUID,
@@ -191,23 +253,25 @@ final class AgentToolTrackingController {
         let generation = trackingGeneration
         let previousRegistrationTask = registrationTask
         let previousRunID = registrationRunID ?? trackedRunID
-        previousRegistrationTask?.cancel()
         trackingTask?.cancel()
         trackingTask = nil
-        registrationTask = nil
-        registrationRunID = nil
+        registrationRunID = runID
         trackedRunID = runID
 
-        let registrationTask = Task { [tracker, previousRegistrationTask, previousRunID] in
+        let registrationTask = Task { [weak self, tracker, eventDeliveryMailbox, previousRegistrationTask, previousRunID] in
             if let previousRegistrationTask {
                 await previousRegistrationTask.value
             }
-            guard !Task.isCancelled else { return }
             await tracker.stop(ifTracking: previousRunID)
-            guard !Task.isCancelled else { return }
+            await eventDeliveryMailbox.waitUntilIdle()
+            let shouldRegister = await MainActor.run { [weak self] in
+                guard let self else { return false }
+                return trackedRunID == runID && trackingGeneration == generation
+            }
+            guard shouldRegister else { return }
             await tracker.registerEnhancedObserver(
                 runID: runID,
-                onCalled: { [weak self] invocationID, toolName, args in
+                onCalled: { [weak self, eventDeliveryMailbox] invocationID, toolName, args in
                     #if DEBUG
                         let scheduledAt = DispatchTime.now().uptimeNanoseconds
                         EditFlowPerf.lifecycleEvent(
@@ -215,39 +279,45 @@ final class AgentToolTrackingController {
                             EditFlowPerf.Dimensions(toolName: toolName, observerType: "event_call", runID: runID.uuidString)
                         )
                     #endif
-                    #if DEBUG
-                        let bodyDurationMicroseconds = await MainActor.run { [weak self] in
-                            let enteredAt = DispatchTime.now().uptimeNanoseconds
+                    MCPToolObserverAttributionContext.record(
+                        correlationPath: "deferred_transcript_fifo",
+                        scannedItemCount: 0
+                    )
+                    eventDeliveryMailbox.enqueue { [weak self] in
+                        #if DEBUG
+                            let bodyDurationMicroseconds = await MainActor.run { [weak self] in
+                                let enteredAt = DispatchTime.now().uptimeNanoseconds
+                                EditFlowPerf.lifecycleEvent(
+                                    EditFlowPerf.Lifecycle.MCPToolCall.mainActorEntered,
+                                    EditFlowPerf.Dimensions(
+                                        toolName: toolName,
+                                        observerType: "event_call",
+                                        queueDelayMicroseconds: Int((enteredAt - scheduledAt) / 1000),
+                                        runID: runID.uuidString
+                                    )
+                                )
+                                guard let self, shouldDeliverCallback(for: runID) else { return 0 }
+                                onCalled(invocationID, toolName, args)
+                                return Int((DispatchTime.now().uptimeNanoseconds - enteredAt) / 1000)
+                            }
                             EditFlowPerf.lifecycleEvent(
-                                EditFlowPerf.Lifecycle.MCPToolCall.mainActorEntered,
+                                EditFlowPerf.Lifecycle.MCPToolCall.mainActorExited,
                                 EditFlowPerf.Dimensions(
                                     toolName: toolName,
                                     observerType: "event_call",
-                                    queueDelayMicroseconds: Int((enteredAt - scheduledAt) / 1000),
+                                    durationMicroseconds: bodyDurationMicroseconds,
                                     runID: runID.uuidString
                                 )
                             )
-                            guard let self, shouldDeliverCallback(for: runID) else { return 0 }
-                            onCalled(invocationID, toolName, args)
-                            return Int((DispatchTime.now().uptimeNanoseconds - enteredAt) / 1000)
-                        }
-                        EditFlowPerf.lifecycleEvent(
-                            EditFlowPerf.Lifecycle.MCPToolCall.mainActorExited,
-                            EditFlowPerf.Dimensions(
-                                toolName: toolName,
-                                observerType: "event_call",
-                                durationMicroseconds: bodyDurationMicroseconds,
-                                runID: runID.uuidString
-                            )
-                        )
-                    #else
-                        await MainActor.run { [weak self] in
-                            guard let self, shouldDeliverCallback(for: runID) else { return }
-                            onCalled(invocationID, toolName, args)
-                        }
-                    #endif
+                        #else
+                            await MainActor.run { [weak self] in
+                                guard let self, shouldDeliverCallback(for: runID) else { return }
+                                onCalled(invocationID, toolName, args)
+                            }
+                        #endif
+                    }
                 },
-                onCompleted: { [weak self] invocationID, toolName, args, resultJSON, isError in
+                onCompleted: { [weak self, eventDeliveryMailbox] invocationID, toolName, args, resultJSON, isError in
                     #if DEBUG
                         let scheduledAt = DispatchTime.now().uptimeNanoseconds
                         EditFlowPerf.lifecycleEvent(
@@ -255,38 +325,44 @@ final class AgentToolTrackingController {
                             EditFlowPerf.Dimensions(toolName: toolName, observerType: "event_completion", runID: runID.uuidString)
                         )
                     #endif
-                    #if DEBUG
-                        let bodyDurationMicroseconds = await MainActor.run { [weak self] in
-                            let enteredAt = DispatchTime.now().uptimeNanoseconds
+                    MCPToolObserverAttributionContext.record(
+                        correlationPath: "deferred_transcript_fifo",
+                        scannedItemCount: 0
+                    )
+                    eventDeliveryMailbox.enqueue { [weak self] in
+                        #if DEBUG
+                            let bodyDurationMicroseconds = await MainActor.run { [weak self] in
+                                let enteredAt = DispatchTime.now().uptimeNanoseconds
+                                EditFlowPerf.lifecycleEvent(
+                                    EditFlowPerf.Lifecycle.MCPToolCall.mainActorEntered,
+                                    EditFlowPerf.Dimensions(
+                                        toolName: toolName,
+                                        observerType: "event_completion",
+                                        queueDelayMicroseconds: Int((enteredAt - scheduledAt) / 1000),
+                                        runID: runID.uuidString
+                                    )
+                                )
+                                guard let self, shouldDeliverCallback(for: runID) else { return 0 }
+                                onCompleted(invocationID, toolName, args, resultJSON, isError)
+                                return Int((DispatchTime.now().uptimeNanoseconds - enteredAt) / 1000)
+                            }
                             EditFlowPerf.lifecycleEvent(
-                                EditFlowPerf.Lifecycle.MCPToolCall.mainActorEntered,
+                                EditFlowPerf.Lifecycle.MCPToolCall.mainActorExited,
                                 EditFlowPerf.Dimensions(
                                     toolName: toolName,
                                     observerType: "event_completion",
-                                    queueDelayMicroseconds: Int((enteredAt - scheduledAt) / 1000),
+                                    durationMicroseconds: bodyDurationMicroseconds,
+                                    resultBytes: resultJSON.utf8.count,
                                     runID: runID.uuidString
                                 )
                             )
-                            guard let self, shouldDeliverCallback(for: runID) else { return 0 }
-                            onCompleted(invocationID, toolName, args, resultJSON, isError)
-                            return Int((DispatchTime.now().uptimeNanoseconds - enteredAt) / 1000)
-                        }
-                        EditFlowPerf.lifecycleEvent(
-                            EditFlowPerf.Lifecycle.MCPToolCall.mainActorExited,
-                            EditFlowPerf.Dimensions(
-                                toolName: toolName,
-                                observerType: "event_completion",
-                                durationMicroseconds: bodyDurationMicroseconds,
-                                resultBytes: resultJSON.utf8.count,
-                                runID: runID.uuidString
-                            )
-                        )
-                    #else
-                        await MainActor.run { [weak self] in
-                            guard let self, shouldDeliverCallback(for: runID) else { return }
-                            onCompleted(invocationID, toolName, args, resultJSON, isError)
-                        }
-                    #endif
+                        #else
+                            await MainActor.run { [weak self] in
+                                guard let self, shouldDeliverCallback(for: runID) else { return }
+                                onCompleted(invocationID, toolName, args, resultJSON, isError)
+                            }
+                        #endif
+                    }
                 }
             )
         }
@@ -368,29 +444,35 @@ final class AgentToolTrackingController {
         trackingGeneration &+= 1
         let stopGeneration = trackingGeneration
         let stoppedRunID = registrationRunID ?? trackedRunID
-        let registrationToCancel = registrationTask
+        let previousRegistrationTask = registrationTask
         let trackingToCancel = trackingTask
         trackedRunID = nil
-        registrationToCancel?.cancel()
+        registrationRunID = nil
         trackingToCancel?.cancel()
+        trackingTask = nil
 
-        if let registrationToCancel {
-            await registrationToCancel.value
+        let stopTask = Task { [tracker, eventDeliveryMailbox, previousRegistrationTask, trackingToCancel, stoppedRunID] in
+            if let previousRegistrationTask {
+                await previousRegistrationTask.value
+            }
+            if let trackingToCancel {
+                await trackingToCancel.value
+            }
+            await tracker.stop(ifTracking: stoppedRunID)
+            await eventDeliveryMailbox.waitUntilIdle()
         }
-        if let trackingToCancel {
-            await trackingToCancel.value
-        }
+        registrationTask = stopTask
+        await stopTask.value
 
         guard trackingGeneration == stopGeneration, trackedRunID == nil else { return }
-        if registrationTask != nil {
-            registrationTask = nil
-            registrationRunID = nil
-        }
-        if trackingTask != nil {
-            trackingTask = nil
-        }
-        await tracker.stop(ifTracking: stoppedRunID)
+        registrationTask = nil
     }
+
+    #if DEBUG
+        func waitForPendingEventDeliveriesForTesting() async {
+            await eventDeliveryMailbox.waitUntilIdle()
+        }
+    #endif
 
     // MARK: - Helpers
 

--- a/Sources/RepoPrompt/Infrastructure/Diffing/EditFlowPerf.swift
+++ b/Sources/RepoPrompt/Infrastructure/Diffing/EditFlowPerf.swift
@@ -744,6 +744,7 @@ enum EditFlowPerf {
             static let formatResultReturned: StaticString = "MCP.ToolCall.FormatResultReturned"
             static let resolvedProviderBegan: StaticString = "MCP.ToolCall.ResolvedProviderBegan"
             static let resolvedProviderEnded: StaticString = "MCP.ToolCall.ResolvedProviderEnded"
+            static let resourceAdmissionReleased: StaticString = "MCP.ToolCall.ResourceAdmissionReleased"
             static let handlerResultReady: StaticString = "MCP.ToolCall.HandlerResultReady"
         }
 

--- a/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService+ContentLoading.swift
+++ b/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService+ContentLoading.swift
@@ -97,6 +97,8 @@ actor ContentReadAsyncLimiter {
             let interactiveGrantCount: Int
             let normalGrantCount: Int
             let bulkGrantCount: Int
+            let backgroundPermitLimit: Int
+            let activeBackgroundPermitCount: Int
 
             var isIdle: Bool {
                 activePermitCount == 0 && queuedWaiterCount == 0 && ownerLaneCount == 0
@@ -112,6 +114,7 @@ actor ContentReadAsyncLimiter {
 
     private struct PermitAcquisition {
         let ownerID: UUID
+        let priorityClass: PriorityClass
         let waited: Bool
         let queueDepth: Int
         let waiterCount: Int
@@ -132,7 +135,10 @@ actor ContentReadAsyncLimiter {
     private let retryAfterMilliseconds: Int
     private let agePromotionNanoseconds: UInt64
     private let maxConsecutiveInteractiveGrants: Int
+    private let backgroundPermitLimit: Int
+    private let nowUptimeNanoseconds: @Sendable () -> UInt64
     private var availablePermits: Int
+    private var activeBackgroundPermitCount = 0
     private var waiterStates: [UUID: WaiterState] = [:]
     private var activePermitCountsByOwner: [UUID: Int] = [:]
     private var lastGrantOrdinalByOwner: [UUID: UInt64] = [:]
@@ -151,7 +157,8 @@ actor ContentReadAsyncLimiter {
         maxQueuedWaiterCount: Int = 512,
         retryAfterMilliseconds: Int = 1000,
         agePromotionNanoseconds: UInt64 = 1_000_000_000,
-        maxConsecutiveInteractiveGrants: Int = 4
+        maxConsecutiveInteractiveGrants: Int = 4,
+        nowUptimeNanoseconds: @escaping @Sendable () -> UInt64 = { DispatchTime.now().uptimeNanoseconds }
     ) {
         precondition(capacity > 0, "Content read limiter must have at least one permit")
         precondition(maxQueuedWaiterCount >= 0)
@@ -162,6 +169,8 @@ actor ContentReadAsyncLimiter {
         self.retryAfterMilliseconds = retryAfterMilliseconds
         self.agePromotionNanoseconds = agePromotionNanoseconds
         self.maxConsecutiveInteractiveGrants = maxConsecutiveInteractiveGrants
+        backgroundPermitLimit = capacity > 1 ? capacity - 1 : 1
+        self.nowUptimeNanoseconds = nowUptimeNanoseconds
         availablePermits = capacity
     }
 
@@ -221,10 +230,11 @@ actor ContentReadAsyncLimiter {
     ) async throws -> PermitAcquisition {
         try Task.checkCancellation()
         scheduleAvailablePermits()
-        if availablePermits > 0, waiterStates.isEmpty {
+        let priorityClass = Self.priorityClass(for: workloadClass)
+        if waiterStates.isEmpty, canAllocatePermit(priorityClass: priorityClass) {
             return allocatePermit(
                 ownerID: ownerID,
-                priorityClass: Self.priorityClass(for: workloadClass),
+                priorityClass: priorityClass,
                 waited: false
             )
         }
@@ -293,7 +303,7 @@ actor ContentReadAsyncLimiter {
             priorityClass: Self.priorityClass(for: workloadClass),
             lifecycleCorrelation: lifecycleCorrelation,
             enqueueOrdinal: nextEnqueueOrdinal,
-            enqueuedAtUptimeNanoseconds: DispatchTime.now().uptimeNanoseconds
+            enqueuedAtUptimeNanoseconds: nowUptimeNanoseconds()
         )
         EditFlowPerf.lifecycleEvent(
             EditFlowPerf.Lifecycle.FileSystem.contentReadWorkerPermitWaitBegan,
@@ -325,6 +335,12 @@ actor ContentReadAsyncLimiter {
     }
 
     private func release(_ acquisition: PermitAcquisition) {
+        if acquisition.priorityClass == .bulk {
+            #if DEBUG
+                assert(activeBackgroundPermitCount > 0, "Content read limiter background over-release detected")
+            #endif
+            activeBackgroundPermitCount = max(0, activeBackgroundPermitCount - 1)
+        }
         if let activeCount = activePermitCountsByOwner[acquisition.ownerID] {
             if activeCount <= 1 {
                 activePermitCountsByOwner.removeValue(forKey: acquisition.ownerID)
@@ -362,8 +378,11 @@ actor ContentReadAsyncLimiter {
     }
 
     private func nextWaiterID() -> UUID? {
-        let now = DispatchTime.now().uptimeNanoseconds
-        if let aged = waiterStates.min(by: { lhs, rhs in
+        let now = nowUptimeNanoseconds()
+        let eligibleWaiters = waiterStates.filter {
+            canAllocatePermit(priorityClass: $0.value.priorityClass)
+        }
+        if let aged = eligibleWaiters.min(by: { lhs, rhs in
             let lhsAged = elapsedNanoseconds(since: lhs.value.enqueuedAtUptimeNanoseconds, now: now) >= agePromotionNanoseconds
             let rhsAged = elapsedNanoseconds(since: rhs.value.enqueuedAtUptimeNanoseconds, now: now) >= agePromotionNanoseconds
             if lhsAged != rhsAged { return lhsAged && !rhsAged }
@@ -372,9 +391,15 @@ actor ContentReadAsyncLimiter {
             return aged.key
         }
 
-        let hasInteractive = waiterStates.values.contains { $0.priorityClass == .interactive }
-        let hasNormal = waiterStates.values.contains { $0.priorityClass == .normal }
-        let hasBulk = waiterStates.values.contains { $0.priorityClass == .bulk }
+        let hasInteractive = waiterStates.values.contains {
+            $0.priorityClass == .interactive && canAllocatePermit(priorityClass: $0.priorityClass)
+        }
+        let hasNormal = waiterStates.values.contains {
+            $0.priorityClass == .normal && canAllocatePermit(priorityClass: $0.priorityClass)
+        }
+        let hasBulk = waiterStates.values.contains {
+            $0.priorityClass == .bulk && canAllocatePermit(priorityClass: $0.priorityClass)
+        }
         let selectedPriority: PriorityClass
         if hasInteractive,
            consecutiveInteractiveGrants < maxConsecutiveInteractiveGrants || (!hasNormal && !hasBulk)
@@ -394,7 +419,9 @@ actor ContentReadAsyncLimiter {
 
     private func nextWaiterID(priorityClass: PriorityClass) -> UUID? {
         var firstByOwner: [UUID: (id: UUID, state: WaiterState)] = [:]
-        for (id, state) in waiterStates where state.priorityClass == priorityClass {
+        for (id, state) in waiterStates
+            where state.priorityClass == priorityClass && canAllocatePermit(priorityClass: state.priorityClass)
+        {
             if let existing = firstByOwner[state.ownerID], existing.state.enqueueOrdinal <= state.enqueueOrdinal {
                 continue
             }
@@ -422,7 +449,13 @@ actor ContentReadAsyncLimiter {
         priorityClass: PriorityClass,
         waited: Bool
     ) -> PermitAcquisition {
+        #if DEBUG
+            assert(canAllocatePermit(priorityClass: priorityClass), "Content read limiter allocation exceeded workload capacity")
+        #endif
         availablePermits -= 1
+        if priorityClass == .bulk {
+            activeBackgroundPermitCount += 1
+        }
         activePermitCountsByOwner[ownerID, default: 0] += 1
         nextGrantOrdinal &+= 1
         lastGrantOrdinalByOwner[ownerID] = nextGrantOrdinal
@@ -440,10 +473,16 @@ actor ContentReadAsyncLimiter {
         }
         return PermitAcquisition(
             ownerID: ownerID,
+            priorityClass: priorityClass,
             waited: waited,
             queueDepth: waiterStates.count,
             waiterCount: waiterStates.count
         )
+    }
+
+    private func canAllocatePermit(priorityClass: PriorityClass) -> Bool {
+        guard availablePermits > 0 else { return false }
+        return priorityClass != .bulk || activeBackgroundPermitCount < backgroundPermitLimit
     }
 
     private func cleanupOwnerIfIdle(_ ownerID: UUID) {
@@ -461,9 +500,9 @@ actor ContentReadAsyncLimiter {
         switch workloadClass {
         case .interactiveRead:
             .interactive
-        case .contentSearch, .unspecified:
+        case .contentSearch:
             .normal
-        case .codemap, .encodingDetection:
+        case .codemap, .encodingDetection, .promptAccounting, .unspecified:
             .bulk
         }
     }
@@ -483,7 +522,9 @@ actor ContentReadAsyncLimiter {
                 overloadCount: overloadCount,
                 interactiveGrantCount: interactiveGrantCount,
                 normalGrantCount: normalGrantCount,
-                bulkGrantCount: bulkGrantCount
+                bulkGrantCount: bulkGrantCount,
+                backgroundPermitLimit: backgroundPermitLimit,
+                activeBackgroundPermitCount: activeBackgroundPermitCount
             )
         }
     #endif

--- a/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemServiceTypes.swift
+++ b/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemServiceTypes.swift
@@ -172,6 +172,7 @@ enum ContentReadWorkloadClass: String {
     case contentSearch
     case codemap
     case encodingDetection
+    case promptAccounting
     case unspecified
 }
 

--- a/Sources/RepoPrompt/Infrastructure/MCP/MCPConnectionManager.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/MCPConnectionManager.swift
@@ -983,11 +983,9 @@ actor ServerNetworkManager {
     }
 
     /// Same-process live reconnect affinity keyed by MCP client name + capability token.
-    /// The capability token identifies the `repoprompt-mcp` helper process, not a logical
-    /// Agent session. External MCP/ACP runtimes own helper lifetime and may retain one helper
-    /// while opening a child session, so an exact reserved PID-owned route can supersede this
-    /// reconnect fallback. This is never persisted and is only usable while the matching run
-    /// policy still exists in memory for the current app process.
+    /// The capability token identifies one `repoprompt-mcp` helper process lease. While the
+    /// matching run policy remains live, that token is pinned to the run and may only reconnect
+    /// to the same run. A different run must use a fresh helper/token.
     private struct LiveRunAffinity {
         let windowID: Int
         let runID: UUID
@@ -1422,6 +1420,8 @@ actor ServerNetworkManager {
         private var debugAfterConnectionCallLimiterResolutionForTesting: (@Sendable (UUID) async -> Void)?
         private var debugAfterConnectionCallPermitAcquiredForTesting: (@Sendable (UUID) async -> Void)?
         private var debugAfterConnectionCallLimiterRejectionForTesting: (@Sendable (UUID) async -> Void)?
+        private var debugBeforeToolResultFormattingForTesting: (@Sendable (UUID, String) async -> Void)?
+        private var debugBeforeToolCompletionObserversForTesting: (@Sendable (UUID, String) async -> Void)?
         private var debugBeforeAdmissionEvictionCloseForTesting: (@Sendable (UUID) async -> Void)?
         private var debugBeforeActiveToolCancellationScanForTesting: (@Sendable (UUID, [UUID]) async -> Void)?
         private var debugAllocatedActiveToolScopeIDsForTesting: Set<UUID> = []
@@ -8640,6 +8640,18 @@ actor ServerNetworkManager {
                 }
             }
 
+            func debugSetBeforeToolResultFormattingForTesting(
+                _ handler: (@Sendable (UUID, String) async -> Void)?
+            ) {
+                debugBeforeToolResultFormattingForTesting = handler
+            }
+
+            func debugSetBeforeToolCompletionObserversForTesting(
+                _ handler: (@Sendable (UUID, String) async -> Void)?
+            ) {
+                debugBeforeToolCompletionObserversForTesting = handler
+            }
+
             func debugIsExecutionWatchdogTerminal(connectionID: UUID) -> Bool {
                 executionWatchdogTerminalConnections.contains(connectionID)
             }
@@ -9069,39 +9081,6 @@ actor ServerNetworkManager {
         return isExpectedAgentDescendant(clientName: clientName, clientPid: clientPid, runID: policy.runID) == true
     }
 
-    /// Returns whether a pending route has enough current ownership evidence to override
-    /// process-token reconnect affinity. Role/tool profile is intentionally irrelevant here.
-    /// The policy must already be reserved by this connection and still be the current queued
-    /// policy, while the peer PID and connection lifecycle independently prove ownership.
-    private func isAuthoritativePIDOwnedAgentModeRoute(
-        _ policy: ClientConnectionPolicy,
-        key: String,
-        clientName: String,
-        clientPid: Int?,
-        connectionID: UUID,
-        expectedLifecycleGeneration: UInt64?
-    ) -> Bool {
-        guard policy.oneShot,
-              policy.purpose == .agentModeRun,
-              policy.runID != nil,
-              policy.tabID != nil,
-              policy.requiresExpectedAgentPID,
-              policy.reservationConnectionID == connectionID,
-              canConsumePendingPolicy(policy, clientName: clientName, clientPid: clientPid),
-              isPendingPolicyApplicationCurrent(
-                  connectionID: connectionID,
-                  clientName: clientName,
-                  expectedLifecycleGeneration: expectedLifecycleGeneration
-              ),
-              pendingPoliciesByClient[key]?.contains(where: {
-                  $0.id == policy.id && $0.reservationConnectionID == connectionID
-              }) == true
-        else {
-            return false
-        }
-        return true
-    }
-
     private func oldestReservedPendingPolicyEntry(
         for clientName: String
     ) -> (key: String, index: Int, policy: ClientConnectionPolicy)? {
@@ -9363,16 +9342,34 @@ actor ServerNetworkManager {
         }
 
         if let policyRunID = policy.runID,
+           let boundRunID = await runIDForConnection(connectionID),
+           boundRunID != policyRunID
+        {
+            if policy.oneShot {
+                _ = rollbackOneShotPendingPolicyReservation(
+                    id: policy.id,
+                    key: matchedQueueEntry.key,
+                    connectionID: connectionID
+                )
+            }
+            #if DEBUG
+                debugRecordRunRoutingEvent(
+                    runID: policyRunID,
+                    event: "policy_rejected",
+                    connectionID: connectionID,
+                    fields: [
+                        "client_name": clientName,
+                        "reason": "connection_bound_to_other_run",
+                        "bound_run_id": boundRunID.uuidString
+                    ]
+                )
+            #endif
+            return .rejected(runID: policyRunID, reason: "connection_bound_to_other_run")
+        }
+
+        if let policyRunID = policy.runID,
            let liveAffinity,
-           liveAffinity.runID != policyRunID,
-           !isAuthoritativePIDOwnedAgentModeRoute(
-               policy,
-               key: matchedQueueEntry.key,
-               clientName: clientName,
-               clientPid: clientPid,
-               connectionID: connectionID,
-               expectedLifecycleGeneration: expectedLifecycleGeneration
-           )
+           liveAffinity.runID != policyRunID
         {
             if policy.oneShot {
                 _ = rollbackOneShotPendingPolicyReservation(
@@ -9838,7 +9835,10 @@ actor ServerNetworkManager {
             guard let windowState = WindowStatesManager.shared.window(withID: windowID) else {
                 return nil
             }
-            guard let resolved = windowState.workspaceManager.resolveComposeTabRoutingSnapshot(for: tabID) else {
+            guard let resolved = windowState.workspaceManager.resolveComposeTabRoutingSnapshot(
+                for: tabID,
+                captureActiveUIState: false
+            ) else {
                 return nil
             }
             let replacementToken = windowState.mcpServer.installTabContext(
@@ -10792,6 +10792,36 @@ actor ServerNetworkManager {
                                 }
                                 defer { smallReadAdmissionLease?.release() }
 
+                                let resourceAdmissionWindowID = chosenID
+                                let resourceAdmissionOwner = MCPGlobalToolName.orderedToolNames.contains(toolName)
+                                    ? "app_wide"
+                                    : resourceAdmissionWindowID.map { "window:\($0)" }
+                                @Sendable func releaseResourceAdmissionLeases(outcome: String) {
+                                    let releasedMutation = mutationAdmissionLease?.release() ?? false
+                                    let releasedSmallRead = smallReadAdmissionLease?.release() ?? false
+                                    guard releasedMutation || releasedSmallRead else { return }
+                                    EditFlowPerf.lifecycleEvent(
+                                        EditFlowPerf.Lifecycle.MCPToolCall.resourceAdmissionReleased,
+                                        correlation: lifecycleCorrelation,
+                                        EditFlowPerf.Dimensions(
+                                            toolName: toolName,
+                                            outcome: outcome,
+                                            windowID: resourceAdmissionWindowID,
+                                            ownerResource: resourceAdmissionOwner,
+                                            permitActive: true,
+                                            publicationPending: true,
+                                            terminalBarrier: false
+                                        )
+                                    )
+                                }
+
+                                @Sendable func releaseResourceAdmissionLeasesAfterProviderError(_ error: Error) {
+                                    if case MCPToolExecutionWatchdogError.cleanupUnresponsive = error {
+                                        return
+                                    }
+                                    releaseResourceAdmissionLeases(outcome: "provider_error")
+                                }
+
                                 let toolCardOwnershipLease: MCPToolCardOwnershipLedger.Lease?
                                 if let runID = observerRunIDForCallbacksFinal, let chosenID {
                                     guard let lease = self.toolCardOwnershipLedger.begin(
@@ -11419,12 +11449,16 @@ actor ServerNetworkManager {
                                                     ) {
                                                         try await dispatchResolvedProvider(resolvedOperation)
                                                     }
+                                                    releaseResourceAdmissionLeases(outcome: "provider_success")
                                                     let permitPostDispatchEnvelopeState = EditFlowPerf.begin(
                                                         EditFlowPerf.Stage.MCPToolCall.permitPostDispatchEnvelope,
                                                         EditFlowPerf.Dimensions(toolName: toolName, outcome: "success")
                                                     )
                                                     defer { EditFlowPerf.end(EditFlowPerf.Stage.MCPToolCall.permitPostDispatchEnvelope, permitPostDispatchEnvelopeState) }
 
+                                                    #if DEBUG
+                                                        await self.debugBeforeToolResultFormattingForTesting?(connectionID, toolName)
+                                                    #endif
                                                     // Build well‑structured, human‑readable content blocks for the result
                                                     let contentBlocks = EditFlowPerf.measure(
                                                         EditFlowPerf.Stage.MCPToolCall.formatResult,
@@ -11442,6 +11476,9 @@ actor ServerNetworkManager {
                                                     )
 
                                                     // Fire completion observer with result for detailed UI rendering
+                                                    #if DEBUG
+                                                        await self.debugBeforeToolCompletionObserversForTesting?(connectionID, toolName)
+                                                    #endif
                                                     await EditFlowPerf.measure(
                                                         EditFlowPerf.Stage.MCPToolCall.completionObservers,
                                                         EditFlowPerf.Dimensions(toolName: toolName)
@@ -11483,6 +11520,7 @@ actor ServerNetworkManager {
                                                 }
                                             }
                                         } catch {
+                                            releaseResourceAdmissionLeasesAfterProviderError(error)
                                             if let failure = await executionContractFailureResult(
                                                 for: error,
                                                 context: "window-scoped"
@@ -11537,12 +11575,16 @@ actor ServerNetworkManager {
                                             ) {
                                                 try await dispatchResolvedProvider(resolvedOperation)
                                             }
+                                            releaseResourceAdmissionLeases(outcome: "provider_success")
                                             let permitPostDispatchEnvelopeState = EditFlowPerf.begin(
                                                 EditFlowPerf.Stage.MCPToolCall.permitPostDispatchEnvelope,
                                                 EditFlowPerf.Dimensions(toolName: toolName, outcome: "success")
                                             )
                                             defer { EditFlowPerf.end(EditFlowPerf.Stage.MCPToolCall.permitPostDispatchEnvelope, permitPostDispatchEnvelopeState) }
 
+                                            #if DEBUG
+                                                await self.debugBeforeToolResultFormattingForTesting?(connectionID, toolName)
+                                            #endif
                                             // Build well‑structured, human‑readable content blocks for the result
                                             let contentBlocks = EditFlowPerf.measure(
                                                 EditFlowPerf.Stage.MCPToolCall.formatResult,
@@ -11560,6 +11602,9 @@ actor ServerNetworkManager {
                                             )
 
                                             // Fire completion observer with result for detailed UI rendering
+                                            #if DEBUG
+                                                await self.debugBeforeToolCompletionObserversForTesting?(connectionID, toolName)
+                                            #endif
                                             await EditFlowPerf.measure(
                                                 EditFlowPerf.Stage.MCPToolCall.completionObservers,
                                                 EditFlowPerf.Dimensions(toolName: toolName)
@@ -11597,6 +11642,7 @@ actor ServerNetworkManager {
                                                 outcome: "success"
                                             )
                                         } catch {
+                                            releaseResourceAdmissionLeasesAfterProviderError(error)
                                             if let failure = await executionContractFailureResult(
                                                 for: error,
                                                 context: "global"
@@ -11647,6 +11693,7 @@ actor ServerNetworkManager {
 
                                 EditFlowPerf.end(EditFlowPerf.Stage.MCPToolCall.serviceToolLookup, serviceToolLookupState)
                                 endPermitPreDispatchEnvelopeIfNeeded()
+                                releaseResourceAdmissionLeases(outcome: "tool_not_found")
                                 let permitPostDispatchEnvelopeState = EditFlowPerf.begin(
                                     EditFlowPerf.Stage.MCPToolCall.permitPostDispatchEnvelope,
                                     EditFlowPerf.Dimensions(toolName: toolName, outcome: "toolNotFound")

--- a/Sources/RepoPrompt/Infrastructure/MCP/MCPConnectionManager.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/MCPConnectionManager.swift
@@ -911,17 +911,65 @@ actor ServerNetworkManager {
         return CallTool.Result(content: [.text(text: ToolOutputFormatter.rawJSONString(value), annotations: nil, _meta: nil)], isError: true)
     }
 
-    /// Tool call observers for agent UI feedback (runID-based for stability across handovers)
-    /// Enhanced to support both call (with args) and completion (with result) callbacks
-    private var toolCallObservers: [UUID: [UUID: @Sendable (String) -> Void]] = [:]
+    fileprivate final class ToolEventObserverDeliveryBarrier: @unchecked Sendable {
+        private let lock = NSLock()
+        private var activeDeliveryCount = 0
+        private var idleContinuations: [CheckedContinuation<Void, Never>] = []
 
-    /// Enhanced tool observer that receives args on call and result on completion
+        func beginDeliveries(_ count: Int = 1) {
+            guard count > 0 else { return }
+            lock.lock()
+            activeDeliveryCount += count
+            lock.unlock()
+        }
+
+        func endDelivery() {
+            lock.lock()
+            precondition(activeDeliveryCount > 0)
+            activeDeliveryCount -= 1
+            guard activeDeliveryCount == 0 else {
+                lock.unlock()
+                return
+            }
+            let continuations = idleContinuations
+            idleContinuations.removeAll(keepingCapacity: true)
+            lock.unlock()
+            continuations.forEach { $0.resume() }
+        }
+
+        func waitUntilIdle() async {
+            await withCheckedContinuation { continuation in
+                lock.lock()
+                guard activeDeliveryCount > 0 else {
+                    lock.unlock()
+                    continuation.resume()
+                    return
+                }
+                idleContinuations.append(continuation)
+                lock.unlock()
+            }
+        }
+    }
+
+    private struct ToolObserverUnregistrationState {
+        let id: UUID
+        let task: Task<Void, Never>
+    }
+
+    /// Enhanced tool observer that receives args on call and result on completion.
+    /// The manager acquires delivery leases for the captured batch before its first
+    /// suspension so unregistration can await callbacks that have not entered yet.
     struct ToolEventObserver: @unchecked Sendable {
         let onCalled: @Sendable (_ invocationID: UUID, _ toolName: String, _ args: [String: Value]?) async -> Void
         let onCompleted: (@Sendable (_ invocationID: UUID, _ toolName: String, _ args: [String: Value]?, _ resultJSON: String, _ isError: Bool) async -> Void)?
+        fileprivate let deliveryBarrier = ToolEventObserverDeliveryBarrier()
     }
 
     private var toolEventObservers: [UUID: [UUID: ToolEventObserver]] = [:]
+    private var toolObserverUnregistrationsByRunID: [UUID: ToolObserverUnregistrationState] = [:]
+    #if DEBUG
+        private var debugBeforeToolEventObserverDeliveryForTesting: (@Sendable () async -> Void)?
+    #endif
 
     // Per-connection restriction + routing state
     private var restrictedToolsByConnection: [UUID: Set<String>] = [:]
@@ -3174,31 +3222,30 @@ actor ServerNetworkManager {
         connectionApprovalHandler = handler
     }
 
-    /// Register a tool call observer for a specific discovery run (by runID, survives connection handovers)
-    /// Returns a token that can be used for targeted unregistration (optional)
-    @discardableResult
-    func registerToolCallObserver(for runID: UUID, observer: @escaping @Sendable (String) -> Void) -> UUID {
-        let token = UUID()
-        toolCallObservers[runID, default: [:]][token] = observer
-        connectionLog("Registered tool call observer for runID: \(runID) token: \(token)")
-        return token
-    }
-
-    /// Unregister a specific tool call observer by token
-    func unregisterToolCallObserver(for runID: UUID, token: UUID) async {
-        toolCallObservers[runID]?.removeValue(forKey: token)
-        if toolCallObservers[runID]?.isEmpty ?? false {
-            toolCallObservers.removeValue(forKey: runID)
-        }
-        connectionLog("Unregistered tool call observer token \(token) for runID: \(runID)")
-    }
-
-    /// Unregister all tool observers for a specific run.
+    /// Unregister all enhanced tool event observers for a specific run.
     /// This only removes observers and does not mutate run routing state.
     func unregisterToolObservers(for runID: UUID) async {
-        toolCallObservers.removeValue(forKey: runID)
-        toolEventObservers.removeValue(forKey: runID)
-        connectionLog("Unregistered all tool observers for runID: \(runID)")
+        if let unregistration = toolObserverUnregistrationsByRunID[runID] {
+            await unregistration.task.value
+            return
+        }
+
+        let removedObservers = toolEventObservers.removeValue(forKey: runID).map { Array($0.values) } ?? []
+        let unregistrationID = UUID()
+        let task = Task {
+            for observer in removedObservers {
+                await observer.deliveryBarrier.waitUntilIdle()
+            }
+        }
+        toolObserverUnregistrationsByRunID[runID] = ToolObserverUnregistrationState(
+            id: unregistrationID,
+            task: task
+        )
+        await task.value
+        if toolObserverUnregistrationsByRunID[runID]?.id == unregistrationID {
+            toolObserverUnregistrationsByRunID.removeValue(forKey: runID)
+        }
+        connectionLog("Unregistered tool observers for runID: \(runID)")
     }
 
     /// Explicitly clears run-scoped routing/policy state.
@@ -3248,64 +3295,6 @@ actor ServerNetworkManager {
         }
     }
 
-    /// Unregister all tool call observers for a specific discovery run.
-    /// By default this preserves legacy behavior and also clears run routing state.
-    func unregisterToolCallObserver(for runID: UUID, cleanupRouting: Bool = true) async {
-        await unregisterToolObservers(for: runID)
-        guard cleanupRouting else { return }
-        await cleanupRunRoutingState(for: runID)
-    }
-
-    /// Notify all observers registered for a runID that a tool was invoked.
-    /// Returns how many observers were fired.
-    @discardableResult
-    func fireToolCallObservers(runID: UUID, toolName: String) async -> Int {
-        guard let observers = toolCallObservers[runID], !observers.isEmpty else {
-            return 0
-        }
-        #if DEBUG
-            let batchStart = DispatchTime.now().uptimeNanoseconds
-        #endif
-        for (position, entry) in observers.enumerated() {
-            let (token, callback) = entry
-            #if DEBUG
-                let scheduledAt = DispatchTime.now().uptimeNanoseconds
-                let dimensions = EditFlowPerf.Dimensions(
-                    toolName: toolName,
-                    observerToken: token.uuidString,
-                    observerType: "legacy_call",
-                    serialPosition: position,
-                    queueDelayMicroseconds: Self.debugElapsedMicroseconds(from: batchStart, to: scheduledAt),
-                    correlationPath: "not_applicable",
-                    scannedItemCount: 0,
-                    runID: runID.uuidString
-                )
-                EditFlowPerf.lifecycleEvent(EditFlowPerf.Lifecycle.MCPToolCall.observerScheduled, dimensions)
-                EditFlowPerf.lifecycleEvent(EditFlowPerf.Lifecycle.MCPToolCall.observerEntered, dimensions)
-            #endif
-            callback(toolName)
-            #if DEBUG
-                let finishedAt = DispatchTime.now().uptimeNanoseconds
-                EditFlowPerf.lifecycleEvent(
-                    EditFlowPerf.Lifecycle.MCPToolCall.observerExited,
-                    EditFlowPerf.Dimensions(
-                        toolName: toolName,
-                        observerToken: token.uuidString,
-                        observerType: "legacy_call",
-                        serialPosition: position,
-                        queueDelayMicroseconds: Self.debugElapsedMicroseconds(from: batchStart, to: scheduledAt),
-                        durationMicroseconds: Self.debugElapsedMicroseconds(from: scheduledAt, to: finishedAt),
-                        correlationPath: "not_applicable",
-                        scannedItemCount: 0,
-                        runID: runID.uuidString
-                    )
-                )
-            #endif
-        }
-        connectionLog("Tool call observer fired for runID \(runID) tool \(toolName) count \(observers.count)")
-        return observers.count
-    }
-
     // MARK: - Enhanced Tool Event Observers (with args and results)
 
     /// Register an enhanced tool event observer that receives args on call and result on completion
@@ -3319,17 +3308,7 @@ actor ServerNetworkManager {
 
     /// Unregister all tool event observers for a specific run
     func unregisterToolEventObservers(for runID: UUID) async {
-        toolEventObservers.removeValue(forKey: runID)
-        connectionLog("Unregistered all tool event observers for runID: \(runID)")
-    }
-
-    func toolCallObserverCount(for runID: UUID? = nil) -> Int {
-        if let runID {
-            return toolCallObservers[runID]?.count ?? 0
-        }
-        return toolCallObservers.values.reduce(into: 0) { partialResult, observers in
-            partialResult += observers.count
-        }
+        await unregisterToolObservers(for: runID)
     }
 
     func toolEventObserverCount(for runID: UUID? = nil) -> Int {
@@ -3354,10 +3333,14 @@ actor ServerNetworkManager {
             }
             return 0
         }
+        let observerEntries = Array(observers)
+        observerEntries.forEach { $0.value.deliveryBarrier.beginDeliveries() }
+        defer { observerEntries.forEach { $0.value.deliveryBarrier.endDelivery() } }
         #if DEBUG
             let batchStart = DispatchTime.now().uptimeNanoseconds
+            await debugBeforeToolEventObserverDeliveryForTesting?()
         #endif
-        for (position, entry) in observers.enumerated() {
+        for (position, entry) in observerEntries.enumerated() {
             let (token, observer) = entry
             #if DEBUG
                 let scheduledAt = DispatchTime.now().uptimeNanoseconds
@@ -3416,11 +3399,15 @@ actor ServerNetworkManager {
             }
             return 0
         }
+        let observerEntries = Array(observers)
+        observerEntries.forEach { $0.value.deliveryBarrier.beginDeliveries() }
+        defer { observerEntries.forEach { $0.value.deliveryBarrier.endDelivery() } }
         #if DEBUG
             let batchStart = DispatchTime.now().uptimeNanoseconds
+            await debugBeforeToolEventObserverDeliveryForTesting?()
         #endif
         var firedCount = 0
-        for (position, entry) in observers.enumerated() {
+        for (position, entry) in observerEntries.enumerated() {
             let (token, observer) = entry
             guard let onCompleted = observer.onCompleted else { continue }
             firedCount += 1
@@ -5960,8 +5947,8 @@ actor ServerNetworkManager {
         connectionTasks.removeValue(forKey: id)
         pendingConnections.removeValue(forKey: id)
         connectionStats.removeValue(forKey: id)
-        // Note: toolCallObservers are now keyed by runID, not connectionID
-        // They are cleaned up when the discovery run completes, not when connection is removed
+        // Note: run-scoped tool event observers are cleaned up when the discovery run completes,
+        // not when an individual connection is removed.
         // Note: connectionIDToRunID mapping is managed by MCPServerViewModel, not here
 
         // Release admission slot & limiter
@@ -8802,6 +8789,12 @@ actor ServerNetworkManager {
             return names.sorted()
         }
 
+        func debugSetBeforeToolEventObserverDeliveryForTesting(
+            _ handler: (@Sendable () async -> Void)?
+        ) {
+            debugBeforeToolEventObserverDeliveryForTesting = handler
+        }
+
         @discardableResult
         func debugFireToolCalledObservers(
             runID: UUID,
@@ -10734,7 +10727,7 @@ actor ServerNetworkManager {
                                     let logName = (originalName == toolName) ? toolName : "\(originalName)→\(toolName)"
                                     connectionLog("Tool call: \(logName) [conn=\(connectionID) window=\(windowStr)]")
 
-                                    // Notify tool call observers using the connection's resolved run mapping.
+                                    // Notify enhanced tool event observers using the connection's resolved run mapping.
                                     // Coordination/app-wide routing tools run before a stable window/run context may
                                     // exist, so avoid re-entering MainActor run lookup on that hot path.
                                     observerRunIDForCallbacksFinal = Self.shouldBypassWindowRouting(for: toolName)
@@ -10848,12 +10841,11 @@ actor ServerNetworkManager {
                                         EditFlowPerf.Stage.MCPToolCall.observerCallbacks,
                                         EditFlowPerf.Dimensions(toolName: toolName)
                                     )
-                                    let legacyObserverCount = await self.fireToolCallObservers(runID: runID, toolName: toolName)
                                     let eventObserverCount = await self.fireToolCalledObservers(runID: runID, invocationID: invocationID, toolName: toolName, args: capturedArguments)
                                     EditFlowPerf.end(EditFlowPerf.Stage.MCPToolCall.observerCallbacks, observerState)
                                     #if DEBUG
                                         if toolName == "agent_run" {
-                                            print("[ACPAgentRunToolTracking] MCP observer call tool=\(toolName) conn=\(connectionID.uuidString) runID=\(runID.uuidString) invocation=\(invocationID.uuidString) legacyObservers=\(legacyObserverCount) eventObservers=\(eventObserverCount)")
+                                            print("[ACPAgentRunToolTracking] MCP observer call tool=\(toolName) conn=\(connectionID.uuidString) runID=\(runID.uuidString) invocation=\(invocationID.uuidString) eventObservers=\(eventObserverCount)")
                                         }
                                     #endif
                                 } else {

--- a/Sources/RepoPrompt/Infrastructure/MCP/MCPToolResourceAdmissionController.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/MCPToolResourceAdmissionController.swift
@@ -16,12 +16,14 @@ final class MCPToolResourceAdmissionController: @unchecked Sendable {
             self.releaseAction = releaseAction
         }
 
-        func release() {
+        @discardableResult
+        func release() -> Bool {
             let action: (() -> Void)? = lock.withLock {
                 defer { releaseAction = nil }
                 return releaseAction
             }
             action?()
+            return action != nil
         }
 
         deinit {

--- a/Sources/RepoPrompt/Infrastructure/MCP/ToolOutputFormatter.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ToolOutputFormatter.swift
@@ -2273,6 +2273,9 @@ extension ToolOutputFormatter {
                     out.append("- Git: \(formatTokenCount(git))")
                 }
             }
+            if let accounting = ctx.tokenAccounting {
+                out.append("- Token accounting: \(accounting.status) from \(accounting.source)\(accounting.refreshPending ? "; refresh pending" : "")")
+            }
             if let sel = ctx.selection {
                 if let summary = sel.summary {
                     let totalCount = summary.fullCount + summary.sliceCount + summary.codemapCount
@@ -2716,6 +2719,10 @@ extension ToolOutputFormatter {
             if let total = dto.totalTokens {
                 out.append("- Total tokens: \(total) (Auto view)")
             }
+        }
+
+        if let accounting = dto.tokenAccounting {
+            out.append("- Token accounting: \(accounting.status) from \(accounting.source)\(accounting.refreshPending ? "; refresh pending" : "")")
         }
 
         // Copy preset effect (only if it differs from auto)

--- a/Sources/RepoPrompt/Infrastructure/MCP/ToolResultDTOs.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ToolResultDTOs.swift
@@ -547,6 +547,8 @@ enum ToolResultDTOs {
         let normalizedCodeMapUsage: String?
         /// Workspace token breakdown (total includes prompt, file tree, meta, git, etc.)
         let tokenStats: TokenStats?
+        /// Cache freshness and pending refresh state for token fields.
+        let tokenAccounting: TokenAccountingDTO?
         /// Summary of how selection would render under the effective copy preset (when it differs from auto)
         let copyPresetProjection: CopyPresetProjectionSummaryDTO?
 
@@ -568,6 +570,7 @@ enum ToolResultDTOs {
             userChatTokens: Int? = nil,
             normalizedCodeMapUsage: String? = nil,
             tokenStats: TokenStats? = nil,
+            tokenAccounting: TokenAccountingDTO? = nil,
             copyPresetProjection: CopyPresetProjectionSummaryDTO? = nil
         ) {
             self.files = files
@@ -586,6 +589,7 @@ enum ToolResultDTOs {
             self.userChatTokens = userChatTokens
             self.normalizedCodeMapUsage = normalizedCodeMapUsage
             self.tokenStats = tokenStats
+            self.tokenAccounting = tokenAccounting
             self.copyPresetProjection = copyPresetProjection
         }
 
@@ -606,6 +610,7 @@ enum ToolResultDTOs {
             case userChatTokens = "user_chat_tokens"
             case normalizedCodeMapUsage = "normalized_codemap_usage"
             case tokenStats = "token_stats"
+            case tokenAccounting = "token_accounting"
             case copyPresetProjection = "copy_preset_projection"
         }
     }
@@ -1040,6 +1045,32 @@ enum ToolResultDTOs {
     }
 
     // MARK: - Unified prompt + selection + context (codemaps-first)
+
+    struct TokenAccountingDTO: Codable, Equatable {
+        let status: String
+        let source: String
+        let refreshPending: Bool
+        let incompleteComponents: [String]?
+
+        init(
+            status: String,
+            source: String,
+            refreshPending: Bool,
+            incompleteComponents: [String]? = nil
+        ) {
+            self.status = status
+            self.source = source
+            self.refreshPending = refreshPending
+            self.incompleteComponents = incompleteComponents
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case status
+            case source
+            case refreshPending = "refresh_pending"
+            case incompleteComponents = "incomplete_components"
+        }
+    }
 
     struct TokenStats: Codable, Equatable {
         let total: Int
@@ -2215,6 +2246,8 @@ enum ToolResultDTOs {
         let userTokenStats: TokenStats?
         /// Explains why tokenStats and userTokenStats differ (e.g., codemap settings)
         let tokenStatsNote: String?
+        /// Cache freshness and pending refresh state for token fields.
+        let tokenAccounting: TokenAccountingDTO?
         /// Active and effective copy preset information (when override is used)
         let copyPreset: CopyPresetContextDTO?
         /// Available copy presets (when include contains "presets")
@@ -2231,6 +2264,7 @@ enum ToolResultDTOs {
             tokenStats: TokenStats?,
             userTokenStats: TokenStats?,
             tokenStatsNote: String?,
+            tokenAccounting: TokenAccountingDTO? = nil,
             copyPreset: CopyPresetContextDTO?,
             copyPresets: [CopyPresetListItemDTO]?,
             worktreeScope: WorktreeScopeDTO? = nil
@@ -2243,6 +2277,7 @@ enum ToolResultDTOs {
             self.tokenStats = tokenStats
             self.userTokenStats = userTokenStats
             self.tokenStatsNote = tokenStatsNote
+            self.tokenAccounting = tokenAccounting
             self.copyPreset = copyPreset
             self.copyPresets = copyPresets
             self.worktreeScope = worktreeScope
@@ -2257,6 +2292,7 @@ enum ToolResultDTOs {
             case tokenStats = "token_stats"
             case userTokenStats = "user_token_stats"
             case tokenStatsNote = "token_stats_note"
+            case tokenAccounting = "token_accounting"
             case copyPreset = "copy_preset"
             case copyPresets = "copy_presets"
             case worktreeScope = "worktree_scope"

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+SelectionCore.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+SelectionCore.swift
@@ -200,7 +200,12 @@ extension MCPServerViewModel {
             let normalizedCodeMapUsage: String
         }
 
-        static func collect(from source: SelectionSource, owner: MCPServerViewModel, rootScope: WorkspaceLookupRootScope = .allLoaded) async -> SelectionCollections {
+        static func collect(
+            from source: SelectionSource,
+            owner: MCPServerViewModel,
+            rootScope: WorkspaceLookupRootScope = .allLoaded,
+            contentPolicy: PromptContextAccountingContentPolicy = .loadContent
+        ) async -> SelectionCollections {
             let selection = await source.resolvedSelection()
             let usage = await source.currentCodeMapUsage()
             let store = await MainActor.run { owner.promptVM.workspaceFileContextStore }
@@ -211,7 +216,8 @@ extension MCPServerViewModel {
                 store: store,
                 rootScope: rootScope,
                 profile: .uiAssisted,
-                codeMapUsage: usage
+                codeMapUsage: usage,
+                contentPolicy: contentPolicy
             )
 
             let selected = resolution.entries.compactMap { entry -> SelectedEntry? in
@@ -602,6 +608,7 @@ extension MCPServerViewModel {
             userPresetState: UserPresetState? = nil,
             tokens: TokenServices? = nil,
             tokenStatsOverride: ToolResultDTOs.TokenStats? = nil,
+            tokenAccountingOverride: ToolResultDTOs.TokenAccountingDTO? = nil,
             pathProjection: WorkspaceRootBindingProjection? = nil
         ) async -> ToolResultDTOs.SelectionReply {
             var blocks: [String]? = nil
@@ -615,23 +622,20 @@ extension MCPServerViewModel {
                 invalid.append(candidate)
             }
 
-            // Compute workspace token stats if tokens service is available
-            let tokenStats: ToolResultDTOs.TokenStats? = if let tokenStatsOverride {
-                tokenStatsOverride
-            } else {
-                await {
-                    guard let tokens else { return nil }
-                    // Force immediate token recount to avoid stale breakdown values
-                    await tokens.owner.promptVM.tokenCountingViewModel.forceImmediateRecount()
-                    // Extract content vs codemap breakdown from summary
-                    let filesContentTokens = (filesReply.summary?.fullTokens ?? 0) + (filesReply.summary?.sliceTokens ?? 0)
-                    let codemapsTokens = filesReply.summary?.codemapTokens ?? 0
-                    return await tokens.owner.computeWorkspaceTokenStats(
-                        filesTokens: filesReply.totalTokens,
-                        filesContentTokens: filesContentTokens > 0 ? filesContentTokens : nil,
-                        codemapsTokens: codemapsTokens > 0 ? codemapsTokens : nil
-                    )
-                }()
+            // MCP replies never await an immediate recount. Use the latest published
+            // active-tab snapshot when no tab-scoped override was prepared.
+            let fallbackPublished = await MainActor.run {
+                tokens?.owner.promptVM.tokenCountingViewModel.latestPublishedTokenSnapshot(for: nil)
+            }
+            let tokenStats: ToolResultDTOs.TokenStats? = tokenStatsOverride
+                ?? fallbackPublished.map(MCPServerViewModel.publishedTokenStats)
+            let tokenAccounting = tokenAccountingOverride ?? fallbackPublished.map { snapshot in
+                ToolResultDTOs.TokenAccountingDTO(
+                    status: !snapshot.isComplete ? "incomplete" : (snapshot.isStale ? "stale" : "fresh"),
+                    source: "active_tab_published",
+                    refreshPending: snapshot.refreshPending,
+                    incompleteComponents: snapshot.isComplete ? nil : ["published_snapshot"]
+                )
             }
 
             return ToolResultDTOs.SelectionReply(
@@ -652,6 +656,7 @@ extension MCPServerViewModel {
                 userChatTokens: filesReply.userChatTokens ?? userPresetState?.chatTokens,
                 normalizedCodeMapUsage: filesReply.normalizedCodeMapUsage ?? userPresetState?.normalizedCodeMapUsage,
                 tokenStats: tokenStats,
+                tokenAccounting: tokenAccounting,
                 copyPresetProjection: filesReply.copyPresetProjection
             )
         }
@@ -737,7 +742,8 @@ extension MCPServerViewModel {
                 userChatTokens: reply.userChatTokens,
                 normalizedCodeMapUsage: reply.normalizedCodeMapUsage,
                 // Preserve workspace token stats (total breakdown stays the same even for filtered view)
-                tokenStats: reply.tokenStats
+                tokenStats: reply.tokenStats,
+                tokenAccounting: reply.tokenAccounting
             )
         }
     }

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+SelectionEngine.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+SelectionEngine.swift
@@ -176,7 +176,11 @@ extension MCPServerViewModel {
             stored: selection,
             codeMapUsage: effectiveMCPCodeMapUsage(promptVM.codeMapUsage)
         )
-        let collections = await SelectionReplyAssembler.collect(from: source, owner: self)
+        let collections = await SelectionReplyAssembler.collect(
+            from: source,
+            owner: self,
+            contentPolicy: includeBlocks ? .loadContent : .cachedOnly
+        )
         let formatter = PathFormatter(format: display, owner: self)
         let tokens = TokenServices(owner: self)
         var out = await SelectionReplyAssembler.buildSelectionReply(
@@ -209,7 +213,8 @@ extension MCPServerViewModel {
                     userCopyTokens: out.userCopyTokens,
                     userChatTokens: out.userChatTokens,
                     normalizedCodeMapUsage: out.normalizedCodeMapUsage,
-                    tokenStats: out.tokenStats
+                    tokenStats: out.tokenStats,
+                    tokenAccounting: out.tokenAccounting
                 )
             }
         }

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+SelectionReply.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+SelectionReply.swift
@@ -249,7 +249,12 @@ extension MCPServerViewModel {
             stored: lookupContext.physicalizeSelection(selection),
             codeMapUsage: effectiveMCPCodeMapUsage(codeMapUsageOverride ?? promptVM.codeMapUsage)
         )
-        let collections = await SelectionReplyAssembler.collect(from: source, owner: self, rootScope: lookupContext.rootScope)
+        let collections = await SelectionReplyAssembler.collect(
+            from: source,
+            owner: self,
+            rootScope: lookupContext.rootScope,
+            contentPolicy: includeBlocks ? .loadContent : .cachedOnly
+        )
         let formatter = PathFormatter(format: display, owner: self, projection: lookupContext.bindingProjection)
         let tokens = TokenServices(owner: self)
         var reply = await SelectionReplyAssembler.buildSelectionReply(
@@ -293,11 +298,31 @@ extension MCPServerViewModel {
         }
         let effectiveSelection = lookupContext.physicalizeSelection(selection)
         let source = StoredSelectionSource(stored: effectiveSelection, codeMapUsage: effectiveOverride)
-        let collections = await SelectionReplyAssembler.collect(from: source, owner: self, rootScope: lookupContext.rootScope)
-        let evaluation = await evaluateVirtualPromptEntries(
-            for: effectiveSelection,
-            codeMapUsage: collections.codeMapUsage,
-            rootScope: lookupContext.rootScope
+        let collections = await SelectionReplyAssembler.collect(
+            from: source,
+            owner: self,
+            rootScope: lookupContext.rootScope,
+            contentPolicy: includeBlocks ? .loadContent : .cachedOnly
+        )
+        let resolvedPromptContext = promptVM.resolvePromptContext()
+        let accountingContext = virtualContext ?? TabContextSnapshot(
+            tabID: promptVM.activeComposeTabID ?? UUID(),
+            windowID: windowID,
+            workspaceID: workspaceManager?.activeWorkspace?.id,
+            promptText: promptVM.promptText,
+            selection: effectiveSelection,
+            selectedMetaPromptIDs: [],
+            tabName: "Active",
+            runID: nil,
+            explicitlyBound: false
+        )
+        let preparedAccounting = await prepareMCPTokenAccounting(
+            context: accountingContext,
+            effectiveSelection: effectiveSelection,
+            collections: collections,
+            resolvedContext: resolvedPromptContext,
+            lookupContext: lookupContext,
+            activeTabCompatibility: virtualContext == nil
         )
         let formatter = PathFormatter(format: display, owner: self, projection: lookupContext.bindingProjection)
         let tokens = TokenServices(owner: self)
@@ -314,23 +339,18 @@ extension MCPServerViewModel {
             tokens: tokens,
             userPresetState: userPresetState,
             copyUsage: copyUsage != .auto ? copyUsage : nil,
-            entryResultsByFileID: evaluation.entryResultsByFileID
+            entryResultsByFileID: preparedAccounting.entryResultsByFileID
         )
 
-        let tokenStatsOverride: ToolResultDTOs.TokenStats?
-        if let virtualContext {
-            let selectedFiles = collections.selected.map(\.file)
-            let codemapFiles = collections.codemap.map(\.file)
-            tokenStatsOverride = await buildVirtualSelectionTokenStats(
-                for: virtualContext,
-                filesReply: filesReply,
-                resolvedContext: promptVM.resolvePromptContext(),
-                selectedFiles: selectedFiles,
-                codemapFiles: codemapFiles,
-                lookupContext: lookupContext
-            )
+        let tokenStatsOverride: ToolResultDTOs.TokenStats = if let published = preparedAccounting.activePublishedSnapshot {
+            Self.publishedTokenStats(published)
         } else {
-            tokenStatsOverride = nil
+            Self.makeTokenStats(
+                filesTokens: filesReply.totalTokens,
+                filesContentTokens: (filesReply.summary?.fullTokens ?? 0) + (filesReply.summary?.sliceTokens ?? 0),
+                codemapsTokens: filesReply.summary?.codemapTokens,
+                breakdown: preparedAccounting.breakdown
+            )
         }
 
         var reply = await SelectionReplyAssembler.makeSelectionReply(
@@ -342,7 +362,8 @@ extension MCPServerViewModel {
             extraInvalid: extraInvalid,
             userPresetState: userPresetState,
             tokens: tokens,
-            tokenStatsOverride: tokenStatsOverride
+            tokenStatsOverride: tokenStatsOverride,
+            tokenAccountingOverride: preparedAccounting.tokenAccounting
         )
 
         // Inject minimal codeStructure.unmappedPaths to report pending codemaps
@@ -365,7 +386,8 @@ extension MCPServerViewModel {
                     userCopyTokens: reply.userCopyTokens,
                     userChatTokens: reply.userChatTokens,
                     normalizedCodeMapUsage: reply.normalizedCodeMapUsage,
-                    tokenStats: reply.tokenStats
+                    tokenStats: reply.tokenStats,
+                    tokenAccounting: reply.tokenAccounting
                 )
             }
         }

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+TabContext.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+TabContext.swift
@@ -1695,11 +1695,31 @@ extension MCPServerViewModel {
         from metadata: RequestMetadata
     ) async -> WorkspaceLookupContext {
         let purpose = metadata.runPurpose ?? .unknown
-        let resolved = try? resolveTabContextSnapshot(
+        var resolved = try? resolveTabContextSnapshot(
             from: metadata,
             toolName: "file_tool_lookup_scope",
             policy: .allowLegacyImplicitRouting
         )
+        if var snapshot = resolved?.snapshot,
+           let sessionID = snapshot.activeAgentSessionID,
+           snapshot.worktreeBindingState == .unhydrated,
+           let agentWorktreeBindingStateResolver
+        {
+            snapshot.worktreeBindingState = await agentWorktreeBindingStateResolver(sessionID, snapshot.tabID)
+            resolved?.snapshot = snapshot
+            if let connectionID = metadata.connectionID,
+               var bound = tabContextByConnectionID[connectionID],
+               bound.tabID == snapshot.tabID,
+               bound.windowID == snapshot.windowID,
+               bound.workspaceID == snapshot.workspaceID,
+               bound.runID == snapshot.runID,
+               bound.activeAgentSessionID == snapshot.activeAgentSessionID,
+               bound.readFileAutoSelectionGeneration == snapshot.readFileAutoSelectionGeneration
+            {
+                bound.worktreeBindingState = snapshot.worktreeBindingState
+                tabContextByConnectionID[connectionID] = bound
+            }
+        }
         let baseScope = Self.resolveFileToolLookupRootScope(purpose: purpose, resolvedContext: resolved)
         guard let resolved else {
             return WorkspaceLookupContext(rootScope: baseScope, bindingProjection: nil)

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+TokenStats.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+TokenStats.swift
@@ -79,3 +79,261 @@ extension MCPServerViewModel {
         )
     }
 }
+
+extension MCPServerViewModel {
+    struct MCPPreparedTokenAccounting {
+        let entryResultsByFileID: [UUID: PromptEntriesEvaluation.EntryResult]
+        let breakdown: TokenComponentBreakdown
+        let tokenAccounting: ToolResultDTOs.TokenAccountingDTO
+        let activePublishedSnapshot: TokenCountingViewModel.PublishedTokenSnapshot?
+    }
+
+    @MainActor
+    func prepareMCPTokenAccounting(
+        context: TabScopedContext,
+        effectiveSelection: StoredSelection,
+        collections: SelectionReplyAssembler.SelectionCollections,
+        resolvedContext: PromptContextResolved,
+        lookupContext: WorkspaceLookupContext,
+        activeTabCompatibility: Bool
+    ) async -> MCPPreparedTokenAccounting {
+        let cachedEvaluation = await cachedPromptEntriesEvaluation(collections: collections)
+        if activeTabCompatibility {
+            let published = promptVM.tokenCountingViewModel.latestPublishedTokenSnapshot(
+                for: effectiveSelection
+            )
+            var entryResults = cachedEvaluation.entryResultsByFileID
+            for entry in collections.selected {
+                guard let info = promptVM.tokenCountingViewModel.latestPublishedTokenInfo(
+                    forFullPath: entry.file.standardizedFullPath
+                ) else { continue }
+                let renderMode: PromptEntriesEvaluation.RenderMode = entry.ranges?.isEmpty == false ? .slice : .full
+                let displayTokens = renderMode == .slice ? info.count : info.fullCount
+                entryResults[entry.file.id] = .init(
+                    fileID: entry.file.id,
+                    renderMode: renderMode,
+                    displayTokens: displayTokens,
+                    fullTokens: info.fullCount,
+                    codemapTokens: info.codemapCount
+                )
+            }
+            for entry in collections.codemap {
+                guard let info = promptVM.tokenCountingViewModel.latestPublishedTokenInfo(
+                    forFullPath: entry.file.standardizedFullPath
+                ) else { continue }
+                entryResults[entry.file.id] = .init(
+                    fileID: entry.file.id,
+                    renderMode: .codemap,
+                    displayTokens: info.codemapCount,
+                    fullTokens: info.fullCount,
+                    codemapTokens: info.codemapCount
+                )
+            }
+            let status = !published.isComplete ? "incomplete" : (published.isStale ? "stale" : "fresh")
+            return MCPPreparedTokenAccounting(
+                entryResultsByFileID: entryResults,
+                breakdown: .init(
+                    prompt: published.breakdown.prompt,
+                    duplicatePrompt: 0,
+                    instructions: published.breakdown.meta,
+                    fileTree: published.breakdown.fileTree,
+                    gitDiff: published.breakdown.git,
+                    metadata: max(published.breakdown.other - published.codeMapTokens, 0)
+                ),
+                tokenAccounting: .init(
+                    status: status,
+                    source: "active_tab_published",
+                    refreshPending: published.refreshPending,
+                    incompleteComponents: published.isComplete ? nil : ["published_snapshot"]
+                ),
+                activePublishedSnapshot: published
+            )
+        }
+
+        let signature = virtualTokenSignature(
+            context: context,
+            selection: effectiveSelection,
+            resolvedContext: resolvedContext,
+            lookupContext: lookupContext,
+            codeMapUsage: collections.codeMapUsage
+        )
+        let cachedSnapshot = mcpVirtualTokenSnapshotsByTabID[context.tabID]?[signature]
+        if let cachedSnapshot {
+            enqueueVirtualTokenRefresh(
+                signature: signature,
+                context: context,
+                effectiveSelection: effectiveSelection,
+                resolvedContext: resolvedContext,
+                collections: collections,
+                lookupContext: lookupContext
+            )
+            return MCPPreparedTokenAccounting(
+                entryResultsByFileID: cachedSnapshot.entryResultsByFileID,
+                breakdown: cachedSnapshot.breakdown,
+                tokenAccounting: .init(
+                    status: "stale",
+                    source: "bound_tab_cache",
+                    refreshPending: true
+                ),
+                activePublishedSnapshot: nil
+            )
+        }
+
+        var incompleteComponents: [String] = []
+        if collections.selected.contains(where: { $0.entry.loadedContent == nil }) {
+            incompleteComponents.append("files")
+        }
+        if resolvedContext.rendersFileTree {
+            incompleteComponents.append("file_tree")
+        }
+        if resolvedContext.gitInclusion != .none {
+            incompleteComponents.append("git")
+        }
+        if !incompleteComponents.isEmpty {
+            enqueueVirtualTokenRefresh(
+                signature: signature,
+                context: context,
+                effectiveSelection: effectiveSelection,
+                resolvedContext: resolvedContext,
+                collections: collections,
+                lookupContext: lookupContext
+            )
+        }
+        let selectedInstructionsText = promptVM.metaInstructions(
+            for: resolvedContext,
+            selectedPromptIDsOverride: context.selectedMetaPromptIDs
+        )
+        .map(\.content)
+        .joined(separator: "\n\n")
+        let promptText = resolvedContext.includeUserPrompt ? context.promptText : ""
+        let duplicatePrompt = resolvedContext.includeUserPrompt
+            ? promptVM.duplicateUserInstructionsAtTop
+            : false
+        return MCPPreparedTokenAccounting(
+            entryResultsByFileID: cachedEvaluation.entryResultsByFileID,
+            breakdown: TokenCalculationService.calculateComponentBreakdown(
+                promptText: promptText,
+                selectedInstructionsText: selectedInstructionsText,
+                fileTreeText: "",
+                gitDiffText: nil,
+                metadataText: nil,
+                duplicateUserInstructionsAtTop: duplicatePrompt
+            ),
+            tokenAccounting: .init(
+                status: incompleteComponents.isEmpty ? "fresh" : "incomplete",
+                source: "bound_tab_cached_state",
+                refreshPending: !incompleteComponents.isEmpty,
+                incompleteComponents: incompleteComponents.isEmpty ? nil : incompleteComponents
+            ),
+            activePublishedSnapshot: nil
+        )
+    }
+
+    @MainActor
+    private func cachedPromptEntriesEvaluation(
+        collections: SelectionReplyAssembler.SelectionCollections
+    ) async -> PromptEntriesEvaluation {
+        let entries = collections.selected.map(\.entry) + collections.codemap.map(\.entry)
+        let snapshots = await PromptContextAccountingService().makePromptFileEntrySnapshots(
+            from: entries,
+            codemapSnapshots: collections.codemapSnapshots,
+            filePathDisplay: promptVM.filePathDisplayOption
+        )
+        return await TokenCalculationService().evaluatePromptEntries(snapshots)
+    }
+
+    @MainActor
+    private func virtualTokenSignature(
+        context: TabScopedContext,
+        selection: StoredSelection,
+        resolvedContext: PromptContextResolved,
+        lookupContext: WorkspaceLookupContext,
+        codeMapUsage: CodeMapUsage
+    ) -> MCPVirtualTokenSignature {
+        MCPVirtualTokenSignature(
+            tabID: context.tabID,
+            workspaceID: context.workspaceID,
+            selection: selection,
+            promptText: context.promptText,
+            selectedMetaPromptIDs: context.selectedMetaPromptIDs,
+            codeMapUsage: codeMapUsage.rawValue,
+            includeUserPrompt: resolvedContext.includeUserPrompt,
+            includeMetaPrompts: resolvedContext.includeMetaPrompts,
+            rendersFileTree: resolvedContext.rendersFileTree,
+            fileTreeMode: resolvedContext.effectiveFileTreeMode.rawValue,
+            gitInclusion: resolvedContext.gitInclusion.rawValue,
+            lookupScope: String(describing: lookupContext.rootScope)
+        )
+    }
+
+    @MainActor
+    private func enqueueVirtualTokenRefresh(
+        signature: MCPVirtualTokenSignature,
+        context: TabScopedContext,
+        effectiveSelection: StoredSelection,
+        resolvedContext: PromptContextResolved,
+        collections: SelectionReplyAssembler.SelectionCollections,
+        lookupContext: WorkspaceLookupContext
+    ) {
+        if mcpVirtualTokenRefreshTasksByTabID[context.tabID]?[signature] != nil {
+            return
+        }
+        let generation = UUID()
+        mcpVirtualTokenRefreshGenerationByTabID[context.tabID, default: [:]][signature] = generation
+        #if DEBUG
+            mcpVirtualTokenRefreshStartCount += 1
+        #endif
+        mcpVirtualTokenRefreshTasksByTabID[context.tabID, default: [:]][signature] = Task { @MainActor [weak self] in
+            guard let self else { return }
+            #if DEBUG
+                await debugBeforeVirtualTokenRefreshForTesting?()
+            #endif
+            let evaluation = await evaluateVirtualPromptEntries(
+                for: effectiveSelection,
+                codeMapUsage: collections.codeMapUsage,
+                rootScope: lookupContext.rootScope
+            )
+            guard !Task.isCancelled else { return }
+            let breakdown = await buildVirtualTokenBreakdown(
+                for: context,
+                resolvedContext: resolvedContext,
+                selectedFiles: collections.selected.map(\.file),
+                codemapFiles: collections.codemap.map(\.file),
+                lookupContext: lookupContext
+            )
+            guard !Task.isCancelled,
+                  mcpVirtualTokenRefreshGenerationByTabID[context.tabID]?[signature] == generation
+            else { return }
+            mcpVirtualTokenSnapshotsByTabID[context.tabID, default: [:]][signature] = MCPVirtualTokenSnapshot(
+                signature: signature,
+                entryResultsByFileID: evaluation.entryResultsByFileID,
+                breakdown: breakdown
+            )
+            mcpVirtualTokenRefreshTasksByTabID[context.tabID]?[signature] = nil
+            mcpVirtualTokenRefreshGenerationByTabID[context.tabID]?[signature] = nil
+            if mcpVirtualTokenRefreshTasksByTabID[context.tabID]?.isEmpty == true {
+                mcpVirtualTokenRefreshTasksByTabID[context.tabID] = nil
+            }
+            if mcpVirtualTokenRefreshGenerationByTabID[context.tabID]?.isEmpty == true {
+                mcpVirtualTokenRefreshGenerationByTabID[context.tabID] = nil
+            }
+        }
+    }
+
+    nonisolated static func publishedTokenStats(
+        _ snapshot: TokenCountingViewModel.PublishedTokenSnapshot
+    ) -> ToolResultDTOs.TokenStats {
+        let files = snapshot.filesContentTokens + snapshot.codeMapTokens
+        return .init(
+            total: snapshot.breakdown.total,
+            files: files,
+            prompt: snapshot.breakdown.prompt > 0 ? snapshot.breakdown.prompt : nil,
+            fileTree: snapshot.breakdown.fileTree > 0 ? snapshot.breakdown.fileTree : nil,
+            meta: snapshot.breakdown.meta > 0 ? snapshot.breakdown.meta : nil,
+            git: snapshot.breakdown.git > 0 ? snapshot.breakdown.git : nil,
+            other: max(snapshot.breakdown.other - snapshot.codeMapTokens, 0),
+            filesContent: snapshot.filesContentTokens > 0 ? snapshot.filesContentTokens : nil,
+            codemaps: snapshot.codeMapTokens > 0 ? snapshot.codeMapTokens : nil
+        )
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+WorkspaceContext.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+WorkspaceContext.swift
@@ -17,6 +17,7 @@ extension MCPServerViewModel {
 
         var collections: SelectionReplyAssembler.SelectionCollections? = nil
         var selectionReply: ToolResultDTOs.SelectedFilesReply? = nil
+        var preparedTokenAccounting: MCPPreparedTokenAccounting? = nil
         let lookupContext = await lookupContext(for: context)
         let effectiveSelection = lookupContext.physicalizeSelection(context.selection)
         let emitsFilesystemIdentity = includeSelection
@@ -50,11 +51,19 @@ extension MCPServerViewModel {
             )
             let formatter = PathFormatter(format: .relative, owner: self, projection: lookupContext.bindingProjection)
             let tokens = TokenServices(owner: self)
-            let gathered = await SelectionReplyAssembler.collect(from: source, owner: self, rootScope: lookupContext.rootScope)
-            let evaluation = await evaluateVirtualPromptEntries(
-                for: effectiveSelection,
-                codeMapUsage: gathered.codeMapUsage,
-                rootScope: lookupContext.rootScope
+            let gathered = await SelectionReplyAssembler.collect(
+                from: source,
+                owner: self,
+                rootScope: lookupContext.rootScope,
+                contentPolicy: include.contains("files") ? .loadContent : .cachedOnly
+            )
+            let preparedAccounting = await prepareMCPTokenAccounting(
+                context: context,
+                effectiveSelection: effectiveSelection,
+                collections: gathered,
+                resolvedContext: resolvedCfg,
+                lookupContext: lookupContext,
+                activeTabCompatibility: activeTabCompatibility
             )
             let reply = await SelectionReplyAssembler.buildSelectedFilesReply(
                 collections: gathered,
@@ -63,10 +72,11 @@ extension MCPServerViewModel {
                 userPresetState: userPresetState,
                 copyUsage: copyUsage != .auto ? copyUsage : nil,
                 projection: projectionConfig,
-                entryResultsByFileID: evaluation.entryResultsByFileID
+                entryResultsByFileID: preparedAccounting.entryResultsByFileID
             )
             collections = gathered
             selectionReply = reply
+            preparedTokenAccounting = preparedAccounting
         }
 
         let selectionDTO = includeSelection ? selectionReply : nil
@@ -145,70 +155,17 @@ extension MCPServerViewModel {
             let filesContentTokens = (selectionReply?.summary?.fullTokens ?? 0) + (selectionReply?.summary?.sliceTokens ?? 0)
             let codemapsTokens = selectionReply?.summary?.codemapTokens ?? 0
 
-            if activeTabCompatibility {
-                await promptVM.tokenCountingViewModel.forceImmediateRecount()
-                let breakdown = latestTokenBreakdown()
-                let promptTokens = breakdown.prompt
-                var treeTokens = breakdown.fileTree
-                if treeTokens == 0 && fileTreeTokens > 0 {
-                    treeTokens = fileTreeTokens
-                }
-                let metaTokens = breakdown.meta
-                let gitTokens = breakdown.git
-                var totalTokens = breakdown.total
-                let componentSum = promptTokens + fileTokens + treeTokens + metaTokens + gitTokens
-                if totalTokens == 0 || totalTokens < componentSum {
-                    totalTokens = componentSum
-                }
-                let otherTokens = max(totalTokens - componentSum, 0)
-                tokenStatsDTO = .init(
-                    total: totalTokens,
-                    files: fileTokens,
-                    prompt: promptTokens,
-                    fileTree: treeTokens,
-                    meta: metaTokens,
-                    git: gitTokens,
-                    other: otherTokens,
-                    filesContent: filesContentTokens > 0 ? filesContentTokens : nil,
-                    codemaps: codemapsTokens > 0 ? codemapsTokens : nil
-                )
-
-                if let userFileTokens = selectionReply?.userCopyTokens, userFileTokens != fileTokens {
-                    let userContentTokens = selectionReply?.userCopyContentTokens ?? 0
-                    let userCodemapTokens = selectionReply?.userCopyCodemapTokens ?? 0
-                    let userComponentSum = promptTokens + userFileTokens + treeTokens + metaTokens + gitTokens
-                    let userTotalTokens = max(userComponentSum, totalTokens - fileTokens + userFileTokens)
-                    let userOtherTokens = max(userTotalTokens - userComponentSum, 0)
-                    userTokenStatsDTO = .init(
-                        total: userTotalTokens,
-                        files: userFileTokens,
-                        prompt: promptTokens,
-                        fileTree: treeTokens,
-                        meta: metaTokens,
-                        git: gitTokens,
-                        other: userOtherTokens,
-                        filesContent: userContentTokens > 0 ? userContentTokens : nil,
-                        codemaps: userCodemapTokens > 0 ? userCodemapTokens : nil
+            if let prepared = preparedTokenAccounting {
+                if let published = prepared.activePublishedSnapshot {
+                    tokenStatsDTO = Self.publishedTokenStats(published)
+                } else {
+                    tokenStatsDTO = Self.makeTokenStats(
+                        filesTokens: fileTokens,
+                        filesContentTokens: filesContentTokens > 0 ? filesContentTokens : nil,
+                        codemapsTokens: codemapsTokens > 0 ? codemapsTokens : nil,
+                        breakdown: prepared.breakdown
                     )
-                    let codemapDelta = fileTokens - userFileTokens
-                    tokenStatsNote = "Difference: \(codemapDelta) codemap tokens (API signatures). Your preset excludes these, so exports use \(userFileTokens) file tokens, not \(fileTokens)."
                 }
-            } else {
-                let selectedFiles = collections?.selected.map(\.file) ?? []
-                let codemapFiles = collections?.codemap.map(\.file) ?? []
-                let breakdown = await buildVirtualTokenBreakdown(
-                    for: context,
-                    resolvedContext: resolvedCfg,
-                    selectedFiles: selectedFiles,
-                    codemapFiles: codemapFiles,
-                    lookupContext: lookupContext
-                )
-                tokenStatsDTO = Self.makeTokenStats(
-                    filesTokens: fileTokens,
-                    filesContentTokens: filesContentTokens > 0 ? filesContentTokens : nil,
-                    codemapsTokens: codemapsTokens > 0 ? codemapsTokens : nil,
-                    breakdown: breakdown
-                )
 
                 if let userFileTokens = selectionReply?.userCopyTokens, userFileTokens != fileTokens {
                     let userContentTokens = selectionReply?.userCopyContentTokens ?? 0
@@ -217,7 +174,7 @@ extension MCPServerViewModel {
                         filesTokens: userFileTokens,
                         filesContentTokens: userContentTokens > 0 ? userContentTokens : nil,
                         codemapsTokens: userCodemapTokens > 0 ? userCodemapTokens : nil,
-                        breakdown: breakdown
+                        breakdown: prepared.breakdown
                     )
                     let codemapDelta = fileTokens - userFileTokens
                     tokenStatsNote = "Difference: \(codemapDelta) codemap tokens (API signatures). Your preset excludes these, so exports use \(userFileTokens) file tokens, not \(fileTokens)."
@@ -239,6 +196,7 @@ extension MCPServerViewModel {
             tokenStats: tokenStatsDTO,
             userTokenStats: userTokenStatsDTO,
             tokenStatsNote: tokenStatsNote,
+            tokenAccounting: preparedTokenAccounting?.tokenAccounting,
             copyPreset: copyPresetContextDTO,
             copyPresets: nil,
             worktreeScope: worktreeScope

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel.swift
@@ -179,13 +179,63 @@ final class MCPServerViewModel: ObservableObject {
     let workspaceManager: WorkspaceManagerViewModel?
     let selectionCoordinator: WorkspaceSelectionCoordinator?
     var agentWorktreeBindingStateProvider: (@MainActor (UUID, UUID?) -> AgentSessionWorktreeBindingState)?
+    var agentWorktreeBindingStateResolver: (@MainActor (UUID, UUID?) async -> AgentSessionWorktreeBindingState)?
 
     func registerAgentWorktreeBindingsProvider(_ provider: @escaping @MainActor (UUID, UUID?) -> AgentSessionWorktreeBindingState) {
         agentWorktreeBindingStateProvider = provider
     }
 
+    func registerAgentWorktreeBindingsResolver(
+        _ resolver: @escaping @MainActor (UUID, UUID?) async -> AgentSessionWorktreeBindingState
+    ) {
+        agentWorktreeBindingStateResolver = resolver
+    }
+
     private let workspaceSearch: WorkspaceSearchHandler
     private let ensureGitDataRootLoaded: (WorkspaceModel?, WorkspaceManagerViewModel?) async -> Void
+
+    struct MCPVirtualTokenSignature: Equatable, Hashable {
+        let tabID: UUID
+        let workspaceID: UUID?
+        let selection: StoredSelection
+        let promptText: String
+        let selectedMetaPromptIDs: [UUID]
+        let codeMapUsage: String
+        let includeUserPrompt: Bool
+        let includeMetaPrompts: Bool
+        let rendersFileTree: Bool
+        let fileTreeMode: String
+        let gitInclusion: String
+        let lookupScope: String
+    }
+
+    struct MCPVirtualTokenSnapshot {
+        let signature: MCPVirtualTokenSignature
+        let entryResultsByFileID: [UUID: PromptEntriesEvaluation.EntryResult]
+        let breakdown: TokenComponentBreakdown
+    }
+
+    var mcpVirtualTokenSnapshotsByTabID: [UUID: [MCPVirtualTokenSignature: MCPVirtualTokenSnapshot]] = [:]
+    var mcpVirtualTokenRefreshTasksByTabID: [UUID: [MCPVirtualTokenSignature: Task<Void, Never>]] = [:]
+    var mcpVirtualTokenRefreshGenerationByTabID: [UUID: [MCPVirtualTokenSignature: UUID]] = [:]
+    #if DEBUG
+        var mcpVirtualTokenRefreshStartCount = 0
+        var debugBeforeVirtualTokenRefreshForTesting: (@MainActor @Sendable () async -> Void)?
+
+        func virtualTokenRefreshStartCountForTesting() -> Int {
+            mcpVirtualTokenRefreshStartCount
+        }
+
+        func virtualTokenRefreshTaskCountForTesting() -> Int {
+            mcpVirtualTokenRefreshTasksByTabID.values.reduce(0) { $0 + $1.count }
+        }
+
+        func setBeforeVirtualTokenRefreshForTesting(
+            _ handler: (@MainActor @Sendable () async -> Void)?
+        ) {
+            debugBeforeVirtualTokenRefreshForTesting = handler
+        }
+    #endif
 
     // ---------------------------------------------------------------------
     // MARK: Networking delegation
@@ -986,6 +1036,9 @@ final class MCPServerViewModel: ObservableObject {
     private func applyReadFileAutoSelectionMirror(
         for key: MCPReadFileAutoSelectionCoordinator.TabMirrorKey
     ) async {
+        #if DEBUG
+            await readFileAutoSelectionMirrorGateForTesting?()
+        #endif
         if let sessionID = workspaceManager?.activeAgentSessionID(
             forTabID: key.tabID,
             inWorkspaceID: key.workspaceID
@@ -2940,7 +2993,7 @@ final class MCPServerViewModel: ObservableObject {
 
     @MainActor
     func refreshSelectionMetrics() async {
-        await promptVM.tokenCountingViewModel.forceImmediateRecount()
+        _ = promptVM.tokenCountingViewModel.latestPublishedTokenSnapshot(for: nil)
     }
 
     private func resolveSelectionPathsForChatSend(_ rawPaths: [String]) async -> (paths: [String], invalid: [String]) {
@@ -3212,6 +3265,14 @@ final class MCPServerViewModel: ObservableObject {
         @MainActor
         func setReadFileAutoSelectionCanonicalApplyGateForTesting(_ gate: (() async -> Void)?) {
             readFileAutoSelectionCoordinator.setCanonicalApplyGateForTesting(gate)
+        }
+
+        @MainActor
+        var readFileAutoSelectionMirrorGateForTesting: (() async -> Void)?
+
+        @MainActor
+        func setReadFileAutoSelectionMirrorGateForTesting(_ gate: (() async -> Void)?) {
+            readFileAutoSelectionMirrorGateForTesting = gate
         }
 
         @MainActor
@@ -3680,8 +3741,7 @@ final class MCPServerViewModel: ObservableObject {
         fromRecords files: [WorkspaceFileRecord],
         maxResults: Int,
         includeUnmappedPaths: Bool,
-        lookupContext: WorkspaceLookupContext = .visibleWorkspace,
-        selfHealTimeout: Duration = .seconds(5)
+        lookupContext: WorkspaceLookupContext = .visibleWorkspace
     ) async throws -> ToolResultDTOs.SelectedCodeStructureDTO {
         struct CodeStructureFile {
             let file: WorkspaceFileRecord
@@ -3739,28 +3799,24 @@ final class MCPServerViewModel: ObservableObject {
             return lhs.displayPath < rhs.displayPath
         }
 
-        var snapshots = await store.codemapSnapshotDictionary()
+        let initialSnapshots = await store.codemapSnapshotDictionary()
         try Task.checkCancellation()
         let repairLimit = min(max(0, maxResults), Self.maxCodeStructureSelfHealingFiles)
         let repairFiles = Array(codeStructureFiles.lazy.filter { item in
-            guard snapshots[item.file.id] == nil else { return false }
+            guard initialSnapshots[item.file.id] == nil else { return false }
             let ext = (item.file.name as NSString).pathExtension
             return SyntaxManager.isSupportedFileExtension(ext)
         }.prefix(repairLimit).map(\.file))
-        let repairResult: WorkspaceCodemapRepairResult
-        if repairFiles.isEmpty {
-            repairResult = WorkspaceCodemapRepairResult(
-                snapshotsByFileID: snapshots,
+        let repairResult: WorkspaceCodemapRepairResult = if repairFiles.isEmpty {
+            WorkspaceCodemapRepairResult(
+                snapshotsByFileID: initialSnapshots,
                 pendingFileIDs: []
             )
         } else {
-            repairResult = try await store.repairMissingCodemapSnapshots(
-                for: repairFiles,
-                timeout: selfHealTimeout
-            )
-            snapshots = repairResult.snapshotsByFileID
+            await store.enqueueMissingCodemapSnapshotRepairs(for: repairFiles)
         }
         try Task.checkCancellation()
+        let snapshots = repairResult.snapshotsByFileID
 
         var renderable: [RenderableCodeStructure] = []
         var unmappedPaths: [String] = []

--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPPromptContextToolProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPPromptContextToolProvider.swift
@@ -92,7 +92,9 @@ final class MCPPromptContextToolProvider: MCPWindowToolProviding {
                 throw CancellationError()
             }
             let lookupContext = await dependencies.resolveFileToolLookupContext(metadata)
-            _ = await dependencies.promptVM.workspaceFileContextStore.awaitAppliedIngress(rootScope: lookupContext.rootScope)
+            if includeArr.contains("files") {
+                _ = await dependencies.promptVM.workspaceFileContextStore.awaitAppliedIngress(rootScope: lookupContext.rootScope)
+            }
             let resolvedTabContext = try await dependencies.resolveTabContextSnapshot(metadata, MCPWindowToolName.workspaceContext, .allowLegacyImplicitRouting)
             let dto = try await dependencies.buildTabWorkspaceContext(
                 resolvedTabContext.snapshot,

--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPSelectionToolProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPSelectionToolProvider.swift
@@ -121,7 +121,10 @@ final class MCPSelectionToolProvider: MCPWindowToolProviding {
         let metadata = await dependencies.captureRequestMetadata()
         try Task.checkCancellation()
         await MCPToolExecutionHandlerPhaseContext.report(.manageSelectionAutoSelectionDrain)
-        guard await dependencies.drainReadFileAutoSelection(metadata, .mirroredSelectionAndMetrics) == .completed else {
+        let drainRequirement: MCPReadFileAutoSelectionCoordinator.DrainRequirement = op == "get"
+            ? .canonicalSelection
+            : .mirroredSelectionAndMetrics
+        guard await dependencies.drainReadFileAutoSelection(metadata, drainRequirement) == .completed else {
             throw CancellationError()
         }
         await MCPToolExecutionHandlerPhaseContext.report(.manageSelectionAutoSelectionDrain, transition: .completed)
@@ -130,9 +133,11 @@ final class MCPSelectionToolProvider: MCPWindowToolProviding {
         let lookupContext = await dependencies.resolveFileToolLookupContext(metadata)
         try Task.checkCancellation()
         let lookupRootScope = lookupContext.rootScope
-        await MCPToolExecutionHandlerPhaseContext.report(.manageSelectionIngressWait)
-        _ = await dependencies.promptVM.workspaceFileContextStore.awaitAppliedIngress(rootScope: lookupRootScope)
-        await MCPToolExecutionHandlerPhaseContext.report(.manageSelectionIngressWait, transition: .completed)
+        if op != "get" {
+            await MCPToolExecutionHandlerPhaseContext.report(.manageSelectionIngressWait)
+            _ = await dependencies.promptVM.workspaceFileContextStore.awaitAppliedIngress(rootScope: lookupRootScope)
+            await MCPToolExecutionHandlerPhaseContext.report(.manageSelectionIngressWait, transition: .completed)
+        }
         try Task.checkCancellation()
         await MCPToolExecutionHandlerPhaseContext.report(.manageSelectionConstruction)
         if !resolvedContext.usesActiveTabCompatibility {

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
@@ -1118,6 +1118,7 @@ actor WorkspaceFileContextStore {
     )
     private var codemapSnapshotsByFileID: [UUID: WorkspaceCodemapSnapshot] = [:]
     private var codemapFileIDsByRootID: [UUID: Set<UUID>] = [:]
+    private var pendingCodemapRepairFileIDs = Set<UUID>()
     private var initializingSessionWorktreeCodemapRootIDs = Set<UUID>()
     private var initializedSessionWorktreeCodemapRootIDs = Set<UUID>()
     private var cachedCodemapFileAPIAggregate: WorkspaceCodemapFileAPIAggregate?
@@ -3638,6 +3639,7 @@ actor WorkspaceFileContextStore {
 
     func cancelAllCodemapScans() async {
         await codeScanActor.cancelAllScans()
+        pendingCodemapRepairFileIDs.removeAll()
     }
 
     func cancelCodemapScansForCheckoutMutation(rootIDs: [UUID]) async {
@@ -4094,6 +4096,8 @@ actor WorkspaceFileContextStore {
         #endif
 
         let removedRootIDSet = Set(statesToUnload.map(\.rootID))
+        let removedFileIDs = statesToUnload.flatMap(\.state.fileIDsByRelativePath.values)
+        pendingCodemapRepairFileIDs.subtract(removedFileIDs)
         initializingSessionWorktreeCodemapRootIDs.subtract(removedRootIDSet)
         initializedSessionWorktreeCodemapRootIDs.subtract(removedRootIDSet)
         rootLoadOrder.removeAll { removedRootIDSet.contains($0) }
@@ -4312,6 +4316,35 @@ actor WorkspaceFileContextStore {
         let key = StandardizedPath.relative(relativePath)
         guard let folderID = state.folderIDsByRelativePath[key] else { return nil }
         return foldersByID[folderID]
+    }
+
+    func cachedSearchContentSnapshot(
+        for expectedRecord: WorkspaceFileRecord
+    ) async -> FileSearchContentSnapshot {
+        guard let current = file(
+            rootID: expectedRecord.rootID,
+            relativePath: expectedRecord.standardizedRelativePath
+        ), current.id == expectedRecord.id else {
+            return staleSearchContentSnapshot(for: expectedRecord)
+        }
+        let epoch = searchContentInvalidationEpochsByFileID[current.id] ?? 0
+        let cacheKey = WorkspaceSearchContentCacheKey(
+            rootID: current.rootID,
+            fileID: current.id,
+            standardizedRelativePath: current.standardizedRelativePath
+        )
+        guard let cached = await searchDecodedContentCache.cachedSnapshot(
+            for: cacheKey,
+            invalidationEpoch: epoch
+        ), searchContentRecordIsCurrent(current, invalidationEpoch: epoch) else {
+            return staleSearchContentSnapshot(for: current)
+        }
+        return FileSearchContentSnapshot(
+            content: cached.content,
+            contentRevision: cached.revision,
+            modificationDate: cached.modificationDate,
+            isFresh: true
+        )
     }
 
     func searchContentSnapshot(
@@ -4694,6 +4727,81 @@ actor WorkspaceFileContextStore {
             }
         }
         return pendingRootIDs
+    }
+
+    func enqueueMissingCodemapSnapshotRepairs(
+        for files: [WorkspaceFileRecord]
+    ) -> WorkspaceCodemapRepairResult {
+        let snapshots = codemapSnapshotDictionary()
+        var missingFiles: [WorkspaceFileRecord] = []
+        var seenFileIDs = Set<UUID>()
+
+        for file in files {
+            guard seenFileIDs.insert(file.id).inserted,
+                  isDiscoverableFileID(file.id),
+                  filesByID[file.id] != nil,
+                  snapshots[file.id] == nil
+            else { continue }
+            missingFiles.append(file)
+        }
+
+        var newlyQueuedFiles: [WorkspaceFileRecord] = []
+        for file in missingFiles where pendingCodemapRepairFileIDs.insert(file.id).inserted {
+            newlyQueuedFiles.append(file)
+        }
+
+        if !newlyQueuedFiles.isEmpty {
+            Task.detached(priority: .utility) { [store = self, newlyQueuedFiles] in
+                await store.performEnqueuedCodemapSnapshotRepairs(for: newlyQueuedFiles)
+            }
+        }
+
+        return WorkspaceCodemapRepairResult(
+            snapshotsByFileID: snapshots,
+            pendingFileIDs: Set(missingFiles.map(\.id))
+        )
+    }
+
+    private func performEnqueuedCodemapSnapshotRepairs(
+        for files: [WorkspaceFileRecord]
+    ) async {
+        await ensureCodeScanResultTask()
+        let currentFiles = files.filter { file in
+            pendingCodemapRepairFileIDs.contains(file.id)
+                && isDiscoverableFileID(file.id)
+                && filesByID[file.id] != nil
+                && codemapSnapshotsByFileID[file.id] == nil
+        }
+        let currentFileIDs = Set(currentFiles.map(\.id))
+        guard !currentFiles.isEmpty else {
+            pendingCodemapRepairFileIDs.subtract(files.map(\.id))
+            return
+        }
+
+        do {
+            let requests = try await codemapScanRequests(for: currentFiles)
+            guard !requests.isEmpty else {
+                pendingCodemapRepairFileIDs.subtract(currentFileIDs)
+                return
+            }
+            let rootFolderPaths = Array(Set(requests.map(\.rootFolderPath)))
+            let requestResult = await codeScanActor.requestSelfHealingScans(
+                requests,
+                rootFolderPaths: rootFolderPaths,
+                existingScanModificationDatesByFileID: Dictionary(
+                    uniqueKeysWithValues: currentFiles.compactMap { file in
+                        file.modificationDate.map { (file.id, $0) }
+                    }
+                )
+            )
+            let scheduledFileIDs = requestResult.submittedFileIDs.union(requestResult.alreadyScheduledFileIDs)
+            pendingCodemapRepairFileIDs.subtract(currentFileIDs.subtracting(scheduledFileIDs))
+            pendingCodemapRepairFileIDs.subtract(
+                scheduledFileIDs.filter { codemapSnapshotsByFileID[$0] != nil }
+            )
+        } catch {
+            pendingCodemapRepairFileIDs.subtract(currentFileIDs)
+        }
     }
 
     func repairMissingCodemapSnapshots(
@@ -6754,6 +6862,7 @@ actor WorkspaceFileContextStore {
         searchContentInvalidationEpochsByFileID.removeValue(forKey: fileID)
         fileIDsByStandardizedFullPath.removeValue(forKey: file.standardizedFullPath)
         managedOnlyFileIDs.remove(fileID)
+        pendingCodemapRepairFileIDs.remove(fileID)
         if codemapSnapshotsByFileID.removeValue(forKey: fileID) != nil {
             invalidateAllCodemapFileAPIsCache()
         }
@@ -6871,6 +6980,7 @@ actor WorkspaceFileContextStore {
     }
 
     private func applyCodeScanResults(_ results: [CodeScanActor.ScanResult]) {
+        pendingCodemapRepairFileIDs.subtract(results.map(\.fileID))
         var snapshotsByRootID: [UUID: [WorkspaceCodemapSnapshot]] = [:]
         for result in results {
             guard isDiscoverableFileID(result.fileID),

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
@@ -4779,7 +4779,9 @@ actor WorkspaceFileContextStore {
         }
 
         do {
-            let requests = try await codemapScanRequests(for: currentFiles)
+            let loadedRequests = try await codemapScanRequests(for: currentFiles)
+            let stillMissingFileIDs = currentFileIDs.filter { codemapSnapshotsByFileID[$0] == nil }
+            let requests = loadedRequests.filter { stillMissingFileIDs.contains($0.fileID) }
             guard !requests.isEmpty else {
                 pendingCodemapRepairFileIDs.subtract(currentFileIDs)
                 return
@@ -6979,7 +6981,7 @@ actor WorkspaceFileContextStore {
         }
     }
 
-    private func applyCodeScanResults(_ results: [CodeScanActor.ScanResult]) {
+    private func applyCodeScanResults(_ results: [CodeScanActor.ScanResult]) async {
         pendingCodemapRepairFileIDs.subtract(results.map(\.fileID))
         var snapshotsByRootID: [UUID: [WorkspaceCodemapSnapshot]] = [:]
         for result in results {
@@ -7014,6 +7016,7 @@ actor WorkspaceFileContextStore {
                 snapshots: snapshots.sorted { $0.relativePath < $1.relativePath }
             ))
         }
+        await codeScanActor.acknowledgeScanResults(fileIDs: results.map(\.fileID))
     }
 
     private func removeAllCodemapSnapshots() {

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
@@ -1062,6 +1062,11 @@ actor WorkspaceFileContextStore {
         let generation: UInt64
     }
 
+    private struct StaticPathMatchSnapshotCacheEntry {
+        let snapshot: StaticPathMatchData
+        var lastAccessSequence: UInt64
+    }
+
     private var rootStatesByID: [UUID: RootState] = [:]
     private var rootIDsByStandardizedPath: [String: UUID] = [:]
     private var foldersByID: [UUID: WorkspaceFolderRecord] = [:]
@@ -1089,6 +1094,8 @@ actor WorkspaceFileContextStore {
     private var rootCatalogShardWeakReferencesByRootID: [UUID: [WeakRootCatalogShardReference]] = [:]
     private var rootCatalogShardDeltaStatesByRootID: [UUID: RootCatalogShardDeltaState] = [:]
     private var pathMatchSnapshotIdentitiesByScope: [WorkspaceLookupRootScope: PathMatchCacheIdentity] = [:]
+    private var staticPathMatchSnapshotsByScope: [WorkspaceLookupRootScope: StaticPathMatchSnapshotCacheEntry] = [:]
+    private var nextStaticPathMatchSnapshotAccessSequence: UInt64 = 0
     private let storeBackedSearchLane: StoreBackedWorkspaceSearchLane
     private let searchDecodedContentCache = WorkspaceSearchDecodedContentCache()
     private let interactiveReadCache = WorkspaceInteractiveReadCache()
@@ -1101,6 +1108,7 @@ actor WorkspaceFileContextStore {
     private var nextSearchContentInvalidationEpoch: UInt64 = 0
     private var activePublicationInvalidationBatch: PublicationInvalidationBatch?
     private static let maxCachedSearchCatalogSnapshotScopes = 16
+    private static let maxCachedStaticPathMatchSnapshotScopes = 16
     /// Covers overlapping readers/index builds while bounding retained full-root arrays. At the cap,
     /// callers receive an authoritative uncached rebuild until older ARC leases drain.
     private static let maxLiveRootCatalogShardGenerationsPerRoot = 8
@@ -5865,7 +5873,19 @@ actor WorkspaceFileContextStore {
     }
 
     func lookupPath(_ request: WorkspacePathLookupRequest) async -> WorkspacePathLookupResult? {
-        await lookupPath(request, rootRefs: rootRefs(scope: request.rootScope))
+        let normalizedPath = normalizeUserInputPath(request.userPath)
+        guard !normalizedPath.isEmpty else { return nil }
+
+        let selectedFileFullPaths = request.selectedFileFullPaths
+        let staticData = buildStaticSnapshot(scope: request.rootScope)
+        guard let match = await pathMatchWorker.locate(
+            userPath: normalizedPath,
+            profile: request.profile,
+            staticData: staticData,
+            selectedFileFullPaths: selectedFileFullPaths,
+            selectionSig: selectionSignature(for: selectedFileFullPaths)
+        ) else { return nil }
+        return lookupResult(input: request.userPath, match: match)
     }
 
     func lookupPath(
@@ -6287,12 +6307,35 @@ actor WorkspaceFileContextStore {
     }
 
     private func buildStaticSnapshot(scope: WorkspaceLookupRootScope) -> StaticPathMatchData {
-        buildStaticSnapshot(scope: scope, rootRefs: rootRefs(scope: scope))
+        let cacheIdentity = pathMatchCacheIdentity(scope: scope)
+        if var cached = staticPathMatchSnapshotsByScope[scope],
+           cached.snapshot.cacheIdentity == cacheIdentity
+        {
+            cached.lastAccessSequence = nextStaticPathMatchSnapshotAccessSequenceValue()
+            staticPathMatchSnapshotsByScope[scope] = cached
+            return cached.snapshot
+        }
+        let snapshot = buildStaticSnapshot(
+            rootRefs: rootRefs(scope: scope),
+            cacheIdentity: cacheIdentity
+        )
+        cacheStaticPathMatchSnapshot(snapshot, scope: scope)
+        return snapshot
     }
 
     private func buildStaticSnapshot(
         scope: WorkspaceLookupRootScope,
         rootRefs roots: [WorkspaceRootRef]
+    ) -> StaticPathMatchData {
+        buildStaticSnapshot(
+            rootRefs: roots,
+            cacheIdentity: pathMatchCacheIdentity(scope: scope, rootRefs: roots)
+        )
+    }
+
+    private func buildStaticSnapshot(
+        rootRefs roots: [WorkspaceRootRef],
+        cacheIdentity: PathMatchCacheIdentity
     ) -> StaticPathMatchData {
         let snapshotState = EditFlowPerf.begin(EditFlowPerf.Stage.ReadFile.pathLookupStaticSnapshotBuild)
         defer { EditFlowPerf.end(EditFlowPerf.Stage.ReadFile.pathLookupStaticSnapshotBuild, snapshotState) }
@@ -6338,8 +6381,6 @@ actor WorkspaceFileContextStore {
                 displayName: folder.name
             ) as FolderRecord
         }
-        let cacheIdentity = pathMatchCacheIdentity(scope: scope)
-        pathMatchSnapshotIdentitiesByScope[scope] = cacheIdentity
         return StaticPathMatchData(
             filesByFullPath: fileRecords,
             foldersByFullPath: folderRecords,
@@ -6349,12 +6390,69 @@ actor WorkspaceFileContextStore {
         )
     }
 
+    private func cacheStaticPathMatchSnapshot(
+        _ snapshot: StaticPathMatchData,
+        scope: WorkspaceLookupRootScope
+    ) {
+        if staticPathMatchSnapshotsByScope[scope] == nil,
+           staticPathMatchSnapshotsByScope.count >= Self.maxCachedStaticPathMatchSnapshotScopes,
+           let eviction = staticPathMatchSnapshotsByScope.min(by: {
+               $0.value.lastAccessSequence < $1.value.lastAccessSequence
+           })
+        {
+            staticPathMatchSnapshotsByScope.removeValue(forKey: eviction.key)
+            if pathMatchSnapshotIdentitiesByScope[eviction.key] == eviction.value.snapshot.cacheIdentity {
+                pathMatchSnapshotIdentitiesByScope.removeValue(forKey: eviction.key)
+            }
+            invalidatePathMatchCache(snapshotIdentities: [eviction.value.snapshot.cacheIdentity])
+        }
+        pathMatchSnapshotIdentitiesByScope[scope] = snapshot.cacheIdentity
+        staticPathMatchSnapshotsByScope[scope] = StaticPathMatchSnapshotCacheEntry(
+            snapshot: snapshot,
+            lastAccessSequence: nextStaticPathMatchSnapshotAccessSequenceValue()
+        )
+    }
+
+    private func nextStaticPathMatchSnapshotAccessSequenceValue() -> UInt64 {
+        nextStaticPathMatchSnapshotAccessSequence &+= 1
+        return nextStaticPathMatchSnapshotAccessSequence
+    }
+
     private func pathMatchCacheIdentity(scope: WorkspaceLookupRootScope) -> PathMatchCacheIdentity {
         PathMatchCacheIdentity(
             scopeID: scopeDiscriminator(scope),
             snapshotID: scopedSnapshotGeneration(scope: scope)
         )
     }
+
+    private func pathMatchCacheIdentity(
+        scope: WorkspaceLookupRootScope,
+        rootRefs roots: [WorkspaceRootRef]
+    ) -> PathMatchCacheIdentity {
+        var hasher = Hasher()
+        hasher.combine("explicitRootRefs")
+        hasher.combine(scopeDiscriminator(scope))
+        for root in roots {
+            hasher.combine(root.id)
+            hasher.combine(root.standardizedFullPath)
+            hasher.combine(rootStatesByID[root.id]?.lifetimeID)
+            hasher.combine(catalogGenerationsByRootID[root.id] ?? 0)
+        }
+        return PathMatchCacheIdentity(
+            scopeID: scopeDiscriminator(scope),
+            snapshotID: UInt64(bitPattern: Int64(hasher.finalize()))
+        )
+    }
+
+    #if DEBUG
+        func staticPathMatchSnapshotCacheCountForTesting() -> Int {
+            staticPathMatchSnapshotsByScope.count
+        }
+
+        func sessionCatalogGenerationForTesting(scope: WorkspaceLookupRootScope) -> UInt64? {
+            sessionCatalogGenerationStatesByScope[scope]?.generation
+        }
+    #endif
 
     private func scopedSnapshotGeneration(scope: WorkspaceLookupRootScope) -> UInt64 {
         let validationToken = searchCatalogSnapshotValidationToken(scope: scope)
@@ -6705,6 +6803,9 @@ actor WorkspaceFileContextStore {
         })
         pathMatchSnapshotIdentitiesByScope = pathMatchSnapshotIdentitiesByScope.filter { scope, identity in
             identity == pathMatchCacheIdentity(scope: scope)
+        }
+        staticPathMatchSnapshotsByScope = staticPathMatchSnapshotsByScope.filter { scope, entry in
+            entry.snapshot.cacheIdentity == pathMatchCacheIdentity(scope: scope)
         }
         invalidatePathMatchCache(snapshotIdentities: stalePathMatchIdentities)
     }

--- a/Tests/RepoPromptTests/AgentMode/AgentContextExportResolverTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentContextExportResolverTests.swift
@@ -109,7 +109,7 @@ final class AgentContextExportResolverTests: XCTestCase {
                 ),
                 explicitFileCount
             )
-            XCTAssertEqual(snapshotBuildCount, 2)
+            XCTAssertEqual(snapshotBuildCount, 1)
             XCTAssertEqual(capture.droppedSampleCount, 0)
         #endif
     }

--- a/Tests/RepoPromptTests/AgentMode/AgentModeViewModelInactiveRefreshTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeViewModelInactiveRefreshTests.swift
@@ -52,6 +52,135 @@ final class AgentModeViewModelInactiveRefreshTests: XCTestCase {
         XCTAssertGreaterThan(viewModel.activeTranscriptPresentation.rawToolResultPayloadRenderRevision, 0)
     }
 
+    func testLiveToolResultRefreshUsesIncrementalRetentionCompaction() async throws {
+        let viewModel = makeViewModel()
+        let tabID = UUID()
+        viewModel.test_setCurrentTabIDOverride(tabID)
+        defer { viewModel.test_setCurrentTabIDOverride(nil) }
+
+        let session = await viewModel.ensureSessionReady(tabID: tabID)
+        session.runState = .running
+        var items = makeTranscriptItems(prefix: "history", turnCount: 40)
+        items.append(.user("Run a live tool", sequenceIndex: items.count))
+        let invocationID = UUID()
+        let toolCall = AgentChatItem.toolCall(
+            name: "apply_edits",
+            invocationID: invocationID,
+            argsJSON: #"{"path":"File.swift"}"#,
+            sequenceIndex: items.count
+        )
+        items.append(toolCall)
+        session.setItemsSilently(items, reason: .testOverride)
+        viewModel.refreshDerivedTranscriptState(for: session)
+        XCTAssertNotNil(session.transcript.compactionFrontier)
+        let marker = "INCREMENTAL_RAW_PAYLOAD_\(UUID().uuidString)"
+        let rawResult = jsonString([
+            "status": "success",
+            "edits_requested": 1,
+            "edits_applied": 1,
+            "raw_output": String(repeating: marker, count: 8)
+        ])
+        var toolResult = toolCall
+        toolResult.kind = .toolResult
+        toolResult.text = rawResult
+        toolResult.toolResultJSON = rawResult
+        toolResult.toolIsError = false
+
+        let previousIncrementalImportSuccessCount =
+            session.transcriptPerformanceSnapshot.incrementalImportSuccessCount
+        session.replaceItem(at: session.items.count - 1, with: toolResult)
+        await viewModel.test_drainScheduledDerivedTranscriptRefresh(tabID: tabID)
+
+        XCTAssertGreaterThan(
+            session.transcriptPerformanceSnapshot.incrementalImportSuccessCount,
+            previousIncrementalImportSuccessCount
+        )
+        XCTAssertEqual(session.test_incrementalRetentionCompactionCount, 1)
+        let compactedResult = try XCTUnwrap(session.items.last)
+        XCTAssertTrue(AgentTranscriptToolNormalizer.isSummaryOnly(raw: compactedResult.toolResultJSON ?? ""))
+        XCTAssertFalse(compactedResult.toolResultJSON?.contains(marker) ?? false)
+        XCTAssertTrue(session.ephemeralToolResultPayloadByItemID[toolCall.id]?.contains(marker) == true)
+        XCTAssertEqual(session.derivedTranscriptSyncState?.sourceItemsRevision, session.sourceItemsRevision)
+    }
+
+    func testIncrementalRefreshReconcilesOlderTurnWhenCompactionChangesFullEnvelope() async {
+        let viewModel = makeViewModel()
+        let tabID = UUID()
+        viewModel.test_setCurrentTabIDOverride(tabID)
+        defer { viewModel.test_setCurrentTabIDOverride(nil) }
+
+        let session = await viewModel.ensureSessionReady(tabID: tabID)
+        session.runState = .running
+        let initialItems = makeTranscriptItems(prefix: "boundary", turnCount: 32)
+        let oldestItemID = initialItems[0].id
+        session.setItemsSilently(initialItems, reason: .testOverride)
+        viewModel.refreshDerivedTranscriptState(for: session)
+        XCTAssertFalse(session.transcript.turns.contains(where: { $0.retentionTier != .full }))
+        let previousFullTurnIDs = session.transcript.turns.map(\.id)
+
+        for _ in 0 ..< 4 {
+            let invocationID = UUID()
+            session.appendItem(.toolCall(
+                name: "read_file",
+                invocationID: invocationID,
+                argsJSON: #"{"path":"/tmp/file.swift"}"#,
+                sequenceIndex: session.nextSequenceIndex
+            ))
+            session.appendItem(.toolResult(
+                name: "read_file",
+                invocationID: invocationID,
+                resultJSON: #"{"content":"ok"}"#,
+                sequenceIndex: session.nextSequenceIndex
+            ))
+        }
+        await viewModel.test_drainScheduledDerivedTranscriptRefresh(tabID: tabID)
+
+        let updatedFullTurnIDs = session.transcript.turns
+            .filter { $0.retentionTier == .full }
+            .map(\.id)
+        XCTAssertNotEqual(updatedFullTurnIDs, previousFullTurnIDs)
+        XCTAssertTrue(session.transcript.turns.contains(where: { $0.retentionTier != .full }))
+        XCTAssertFalse(session.items.contains(where: { $0.id == oldestItemID }))
+        XCTAssertGreaterThan(session.transcriptPerformanceSnapshot.incrementalImportSuccessCount, 0)
+    }
+
+    func testIncrementalRefreshStillRemovesImportPolicyExcludedItems() async {
+        let viewModel = makeViewModel()
+        let tabID = UUID()
+        viewModel.test_setCurrentTabIDOverride(tabID)
+        defer { viewModel.test_setCurrentTabIDOverride(nil) }
+
+        let session = await viewModel.ensureSessionReady(tabID: tabID)
+        session.runState = .running
+        session.setItemsSilently(
+            makeTranscriptItems(prefix: "history", turnCount: 40),
+            reason: .testOverride
+        )
+        viewModel.refreshDerivedTranscriptState(for: session)
+        XCTAssertNotNil(session.transcript.compactionFrontier)
+
+        let excludedItem = AgentChatItem.toolCall(
+            name: "set_status",
+            invocationID: UUID(),
+            argsJSON: #"{"session_name":"hidden"}"#,
+            sequenceIndex: session.nextSequenceIndex
+        )
+        let previousIncrementalImportSuccessCount =
+            session.transcriptPerformanceSnapshot.incrementalImportSuccessCount
+        session.appendItem(excludedItem)
+        await viewModel.test_drainScheduledDerivedTranscriptRefresh(tabID: tabID)
+
+        XCTAssertGreaterThan(
+            session.transcriptPerformanceSnapshot.incrementalImportSuccessCount,
+            previousIncrementalImportSuccessCount
+        )
+        XCTAssertFalse(session.items.contains(where: { $0.id == excludedItem.id }))
+        XCTAssertFalse(
+            AgentTranscriptIO.flattenFullTranscript(session.transcript)
+                .contains(where: { $0.id == excludedItem.id })
+        )
+    }
+
     func testRefreshingInactiveSessionDoesNotClobberActivePresentation() async {
         let viewModel = makeViewModel()
         let activeTabID = UUID()

--- a/Tests/RepoPromptTests/AgentMode/AgentToolTrackingControllerTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentToolTrackingControllerTests.swift
@@ -1,0 +1,340 @@
+#if DEBUG
+    import Foundation
+    import MCP
+    @testable import RepoPrompt
+    import XCTest
+
+    final class AgentToolTrackingControllerTests: XCTestCase {
+        func testToolObserverCallbacksReturnBeforeFIFOTranscriptDeliveryCompletes() async {
+            let manager = ServerNetworkManager.shared
+            let controller = AgentToolTrackingController()
+            let recorder = LockedEventRecorder()
+            let runID = UUID()
+            let invocationID = UUID()
+
+            await controller.startTracking(
+                runID: runID,
+                clientNameHint: nil,
+                onCalled: { _, _, _ in
+                    recorder.append("call-start")
+                    Thread.sleep(forTimeInterval: 0.3)
+                    recorder.append("call-end")
+                },
+                onCompleted: { _, _, _, _, _ in
+                    recorder.append("completion")
+                }
+            )
+            addTeardownBlock {
+                await controller.stopTracking()
+                await manager.unregisterToolObservers(for: runID)
+            }
+
+            let durations = await Task.detached {
+                let callStartedAt = DispatchTime.now().uptimeNanoseconds
+                let calledCount = await manager.debugFireToolCalledObservers(
+                    runID: runID,
+                    invocationID: invocationID,
+                    toolName: "read_file"
+                )
+                let callDurationMS = Self.elapsedMilliseconds(since: callStartedAt)
+
+                while !recorder.contains("call-start") {
+                    try? await Task.sleep(for: .milliseconds(1))
+                }
+
+                let completionStartedAt = DispatchTime.now().uptimeNanoseconds
+                let completedCount = await manager.debugFireToolCompletedObservers(
+                    runID: runID,
+                    invocationID: invocationID,
+                    toolName: "read_file",
+                    resultJSON: #"{"content":"ok"}"#,
+                    isError: false
+                )
+                let completionDurationMS = Self.elapsedMilliseconds(since: completionStartedAt)
+                return (calledCount, completedCount, callDurationMS, completionDurationMS)
+            }.value
+
+            XCTAssertEqual(durations.0, 1)
+            XCTAssertEqual(durations.1, 1)
+            XCTAssertLessThan(durations.2, 100)
+            XCTAssertLessThan(durations.3, 100)
+
+            await controller.waitForPendingEventDeliveriesForTesting()
+            XCTAssertEqual(recorder.snapshot(), ["call-start", "call-end", "completion"])
+        }
+
+        func testStopWaitsForCapturedObserverToEnterMailboxAndDrain() async throws {
+            let manager = ServerNetworkManager.shared
+            let controller = AgentToolTrackingController()
+            let recorder = LockedEventRecorder()
+            let deliveryGate = AsyncDeliveryGate()
+            let runID = UUID()
+
+            await controller.startTracking(
+                runID: runID,
+                clientNameHint: nil,
+                onCalled: { _, _, _ in recorder.append("call") },
+                onCompleted: { _, _, _, _, _ in }
+            )
+            await manager.debugSetBeforeToolEventObserverDeliveryForTesting {
+                await deliveryGate.pause()
+            }
+            addTeardownBlock {
+                await deliveryGate.release()
+                await manager.debugSetBeforeToolEventObserverDeliveryForTesting(nil)
+                await controller.stopTracking()
+                await manager.unregisterToolObservers(for: runID)
+            }
+
+            let fireTask = Task {
+                await manager.debugFireToolCalledObservers(
+                    runID: runID,
+                    invocationID: UUID(),
+                    toolName: "read_file"
+                )
+            }
+            await deliveryGate.waitUntilPaused()
+
+            let stopTask = Task { @MainActor in
+                await controller.stopTracking()
+                recorder.append("stopped")
+            }
+            try await Task.sleep(for: .milliseconds(50))
+            XCTAssertFalse(recorder.contains("stopped"))
+            XCTAssertFalse(recorder.contains("call"))
+
+            await deliveryGate.release()
+            let firedCount = await fireTask.value
+            await stopTask.value
+            await manager.debugSetBeforeToolEventObserverDeliveryForTesting(nil)
+
+            XCTAssertEqual(firedCount, 1)
+            XCTAssertEqual(recorder.snapshot(), ["call", "stopped"])
+            try await Task.sleep(for: .milliseconds(20))
+            XCTAssertEqual(recorder.snapshot(), ["call", "stopped"])
+        }
+
+        func testConcurrentRawUnregisterAndStopJoinCapturedDeliveryBarrier() async throws {
+            let manager = ServerNetworkManager.shared
+            let controller = AgentToolTrackingController()
+            let recorder = LockedEventRecorder()
+            let deliveryGate = AsyncDeliveryGate()
+            let runID = UUID()
+
+            await controller.startTracking(
+                runID: runID,
+                clientNameHint: nil,
+                onCalled: { _, _, _ in
+                    recorder.append("call-start")
+                    Thread.sleep(forTimeInterval: 0.1)
+                    recorder.append("call-drained")
+                },
+                onCompleted: { _, _, _, _, _ in }
+            )
+            await manager.debugSetBeforeToolEventObserverDeliveryForTesting {
+                await deliveryGate.pause()
+            }
+            addTeardownBlock {
+                await deliveryGate.release()
+                await manager.debugSetBeforeToolEventObserverDeliveryForTesting(nil)
+                await controller.stopTracking()
+                await manager.unregisterToolObservers(for: runID)
+            }
+
+            let fireTask = Task {
+                await manager.debugFireToolCalledObservers(
+                    runID: runID,
+                    invocationID: UUID(),
+                    toolName: "read_file"
+                )
+            }
+            await deliveryGate.waitUntilPaused()
+
+            let rawUnregisterTask = Task {
+                await manager.unregisterToolEventObservers(for: runID)
+            }
+            for _ in 0 ..< 100 {
+                if await manager.toolEventObserverCount(for: runID) == 0 {
+                    break
+                }
+                await Task.yield()
+            }
+            let observerCountAfterRawUnregister = await manager.toolEventObserverCount(for: runID)
+            XCTAssertEqual(observerCountAfterRawUnregister, 0)
+
+            _ = await manager.registerToolEventObserver(
+                for: runID,
+                observer: ServerNetworkManager.ToolEventObserver(onCalled: { _, _, _ in }, onCompleted: nil)
+            )
+            let laterEventObserverCount = await manager.toolEventObserverCount(for: runID)
+            XCTAssertEqual(laterEventObserverCount, 1)
+
+            let stopTask = Task { @MainActor in
+                await controller.stopTracking()
+                recorder.append("stopped")
+            }
+            try await Task.sleep(for: .milliseconds(50))
+            XCTAssertFalse(recorder.contains("stopped"))
+            XCTAssertFalse(recorder.contains("call-start"))
+
+            await deliveryGate.release()
+            let firedCount = await fireTask.value
+            await rawUnregisterTask.value
+            await stopTask.value
+            await manager.debugSetBeforeToolEventObserverDeliveryForTesting(nil)
+
+            XCTAssertEqual(firedCount, 1)
+            let retainedEventObserverCount = await manager.toolEventObserverCount(for: runID)
+            XCTAssertEqual(retainedEventObserverCount, 1)
+            await manager.unregisterToolEventObservers(for: runID)
+            let finalEventObserverCount = await manager.toolEventObserverCount(for: runID)
+            XCTAssertEqual(finalEventObserverCount, 0)
+            let events = recorder.snapshot()
+            XCTAssertEqual(events, ["call-start", "call-drained", "stopped"])
+        }
+
+        func testOverlappingStopAndStartUnregistersOldObserverAndReleasesCallbacks() async {
+            let manager = ServerNetworkManager.shared
+            let controller = AgentToolTrackingController()
+            let firstRunID = UUID()
+            let secondRunID = UUID()
+            let recorder = LockedEventRecorder()
+            var probe: CallbackLifetimeProbe? = CallbackLifetimeProbe()
+            weak var weakProbe = probe
+            var firstOnCalled: @MainActor (UUID, String, [String: Value]?) -> Void = { [probe] _, _, _ in
+                probe?.record()
+                recorder.append("first")
+            }
+            var firstOnCompleted: @MainActor (UUID, String, [String: Value]?, String, Bool) -> Void = { [probe] _, _, _, _, _ in
+                probe?.record()
+                recorder.append("first-completion")
+            }
+
+            await controller.startTracking(
+                runID: firstRunID,
+                clientNameHint: nil,
+                onCalled: firstOnCalled,
+                onCompleted: firstOnCompleted
+            )
+            let initialFirstObserverCount = await manager.toolEventObserverCount(for: firstRunID)
+            XCTAssertEqual(initialFirstObserverCount, 1)
+            probe = nil
+            firstOnCalled = { _, _, _ in }
+            firstOnCompleted = { _, _, _, _, _ in }
+            XCTAssertNotNil(weakProbe)
+
+            let stopTask = Task { @MainActor in
+                await controller.stopTracking()
+            }
+            await Task.yield()
+            let startTask = Task { @MainActor in
+                await controller.startTracking(
+                    runID: secondRunID,
+                    clientNameHint: nil,
+                    onCalled: { _, _, _ in recorder.append("second") },
+                    onCompleted: { _, _, _, _, _ in recorder.append("second-completion") }
+                )
+            }
+            await stopTask.value
+            await startTask.value
+
+            let finalFirstObserverCount = await manager.toolEventObserverCount(for: firstRunID)
+            let activeSecondObserverCount = await manager.toolEventObserverCount(for: secondRunID)
+            XCTAssertEqual(finalFirstObserverCount, 0)
+            XCTAssertEqual(activeSecondObserverCount, 1)
+            XCTAssertNil(weakProbe)
+
+            let firstFireCount = await manager.debugFireToolCalledObservers(
+                runID: firstRunID,
+                invocationID: UUID(),
+                toolName: "read_file"
+            )
+            let secondFireCount = await manager.debugFireToolCalledObservers(
+                runID: secondRunID,
+                invocationID: UUID(),
+                toolName: "read_file"
+            )
+            await controller.waitForPendingEventDeliveriesForTesting()
+
+            XCTAssertEqual(firstFireCount, 0)
+            XCTAssertEqual(secondFireCount, 1)
+            XCTAssertEqual(recorder.snapshot(), ["second"])
+
+            await controller.stopTracking()
+            let finalSecondObserverCount = await manager.toolEventObserverCount(for: secondRunID)
+            XCTAssertEqual(finalSecondObserverCount, 0)
+        }
+
+        private nonisolated static func elapsedMilliseconds(since startedAt: UInt64) -> Double {
+            Double(DispatchTime.now().uptimeNanoseconds - startedAt) / 1_000_000
+        }
+    }
+
+    private final class LockedEventRecorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var events: [String] = []
+
+        func append(_ event: String) {
+            lock.lock()
+            events.append(event)
+            lock.unlock()
+        }
+
+        func contains(_ event: String) -> Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            return events.contains(event)
+        }
+
+        func snapshot() -> [String] {
+            lock.lock()
+            defer { lock.unlock() }
+            return events
+        }
+    }
+
+    private final class CallbackLifetimeProbe: @unchecked Sendable {
+        private let lock = NSLock()
+        private var count = 0
+
+        func record() {
+            lock.lock()
+            count += 1
+            lock.unlock()
+        }
+    }
+
+    private actor AsyncDeliveryGate {
+        private var isPaused = false
+        private var isReleased = false
+        private var pausedContinuations: [CheckedContinuation<Void, Never>] = []
+        private var releaseContinuations: [CheckedContinuation<Void, Never>] = []
+
+        func pause() async {
+            isPaused = true
+            let paused = pausedContinuations
+            pausedContinuations.removeAll()
+            paused.forEach { $0.resume() }
+            guard !isReleased else { return }
+            await withCheckedContinuation { continuation in
+                releaseContinuations.append(continuation)
+            }
+        }
+
+        func waitUntilPaused() async {
+            guard !isPaused else { return }
+            await withCheckedContinuation { continuation in
+                pausedContinuations.append(continuation)
+            }
+        }
+
+        func release() {
+            guard !isReleased else { return }
+            isReleased = true
+            let releases = releaseContinuations
+            releaseContinuations.removeAll()
+            releases.forEach { $0.resume() }
+        }
+    }
+
+#endif

--- a/Tests/RepoPromptTests/AgentMode/Transcript/AgentToolResultPersistencePolicyTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Transcript/AgentToolResultPersistencePolicyTests.swift
@@ -270,6 +270,161 @@ final class AgentToolResultPersistencePolicyTests: XCTestCase {
         XCTAssertNil(promptObject["summary_only"])
     }
 
+    func testTrustedIncrementalFinalTurnSanitizationMatchesFullSanitization() {
+        let turnID = UUID()
+        let spanID = UUID()
+        let startedAt = Date()
+        let activities = (0 ..< 100).map { sequenceIndex in
+            makeReadFileActivity(
+                id: UUID(),
+                sequenceIndex: sequenceIndex,
+                marker: "before-\(sequenceIndex)"
+            )
+        }
+        let previousRaw = AgentTranscript(
+            turns: [
+                AgentTranscriptTurn(
+                    id: turnID,
+                    responseSpans: [
+                        AgentTranscriptProviderResponseSpan(
+                            id: spanID,
+                            lifecycle: .open,
+                            startedAt: startedAt,
+                            activities: activities
+                        )
+                    ],
+                    startedAt: startedAt
+                )
+            ],
+            nextSequenceIndex: 100
+        )
+        let previousSanitized = AgentToolResultPersistencePolicy
+            .sanitizeTranscriptWithMetrics(previousRaw)
+            .transcript
+
+        var updatedActivities = activities
+        updatedActivities[99] = makeReadFileActivity(
+            id: activities[99].id,
+            sequenceIndex: 99,
+            marker: "after"
+        )
+        let updatedRaw = AgentTranscript(
+            turns: [
+                AgentTranscriptTurn(
+                    id: turnID,
+                    responseSpans: [
+                        AgentTranscriptProviderResponseSpan(
+                            id: spanID,
+                            lifecycle: .open,
+                            startedAt: startedAt,
+                            activities: updatedActivities
+                        )
+                    ],
+                    startedAt: startedAt
+                )
+            ],
+            nextSequenceIndex: 100
+        )
+
+        let incremental = AgentToolResultPersistencePolicy.sanitizeTranscriptWithMetrics(
+            updatedRaw,
+            previousSanitizedTranscript: previousSanitized,
+            trustedReusablePrefixTurnCount: 0,
+            trustedIncrementalFinalTurnStartSequenceIndex: 99
+        )
+        let fullySanitized = AgentToolResultPersistencePolicy.sanitizeTranscriptWithMetrics(updatedRaw)
+
+        XCTAssertEqual(incremental.transcript, fullySanitized.transcript)
+        XCTAssertLessThanOrEqual(incremental.sanitizedActivityCount, 1)
+        XCTAssertGreaterThan(fullySanitized.sanitizedActivityCount, incremental.sanitizedActivityCount)
+    }
+
+    func testIncrementalSanitizerFallbackDoesNotReuseChangedCompactionPrefix() {
+        let startedAt = Date(timeIntervalSinceReferenceDate: 1)
+        let prefixActivity = makeReadFileActivity(
+            id: UUID(),
+            sequenceIndex: 0,
+            marker: "prefix"
+        )
+        let previousFinalActivity = makeReadFileActivity(
+            id: UUID(),
+            sequenceIndex: 100,
+            marker: "previous-final"
+        )
+        let previousRaw = AgentTranscript(
+            turns: [
+                AgentTranscriptTurn(
+                    id: UUID(),
+                    responseSpans: [
+                        AgentTranscriptProviderResponseSpan(
+                            lifecycle: .completed,
+                            startedAt: startedAt,
+                            activities: [prefixActivity]
+                        )
+                    ],
+                    retentionTier: .archived,
+                    startedAt: startedAt,
+                    completedAt: startedAt
+                ),
+                AgentTranscriptTurn(
+                    id: UUID(),
+                    responseSpans: [
+                        AgentTranscriptProviderResponseSpan(
+                            lifecycle: .open,
+                            startedAt: startedAt,
+                            activities: [previousFinalActivity]
+                        )
+                    ],
+                    startedAt: startedAt
+                )
+            ],
+            nextSequenceIndex: 101
+        )
+        let previousSanitized = AgentToolResultPersistencePolicy
+            .sanitizeTranscriptWithMetrics(previousRaw)
+            .transcript
+
+        var changedPrefix = previousSanitized.turns[0]
+        changedPrefix.retentionTier = .summary
+        let changedFinalActivity = makeReadFileActivity(
+            id: previousFinalActivity.id,
+            sequenceIndex: 100,
+            marker: "changed-final"
+        )
+        let appendedFinalActivity = makeReadFileActivity(
+            id: UUID(),
+            sequenceIndex: 101,
+            marker: "appended-final"
+        )
+        var updatedRaw = previousRaw
+        updatedRaw.turns[0] = changedPrefix
+        updatedRaw.turns[1].responseSpans = [
+            AgentTranscriptProviderResponseSpan(
+                lifecycle: .completed,
+                startedAt: startedAt,
+                activities: [changedFinalActivity]
+            ),
+            AgentTranscriptProviderResponseSpan(
+                lifecycle: .open,
+                startedAt: startedAt,
+                activities: [appendedFinalActivity]
+            )
+        ]
+        updatedRaw.nextSequenceIndex = 102
+
+        let incrementalFallback = AgentToolResultPersistencePolicy.sanitizeTranscriptWithMetrics(
+            updatedRaw,
+            previousSanitizedTranscript: previousSanitized,
+            trustedReusablePrefixTurnCount: 1,
+            trustedIncrementalFinalTurnStartSequenceIndex: 100
+        )
+        let fullySanitized = AgentToolResultPersistencePolicy.sanitizeTranscriptWithMetrics(updatedRaw)
+
+        XCTAssertEqual(incrementalFallback.transcript, fullySanitized.transcript)
+        XCTAssertEqual(incrementalFallback.transcript.turns[0].retentionTier, .summary)
+        XCTAssertEqual(incrementalFallback.reusedTurnCount, 0)
+    }
+
     private func persistedSummary(toolName: String, rawResultJSON: String, argsJSON: String? = nil) -> AgentPersistedToolResultSummary? {
         let invocationID = UUID()
         let item = AgentChatItem(
@@ -293,6 +448,37 @@ final class AgentToolResultPersistencePolicyTests: XCTestCase {
             for: item,
             toolExecution: execution,
             rawResultTextFallback: rawResultJSON
+        )
+    }
+
+    private func makeReadFileActivity(
+        id: UUID,
+        sequenceIndex: Int,
+        marker: String
+    ) -> AgentTranscriptActivity {
+        let invocationID = UUID()
+        let argsJSON = jsonString(["path": "/tmp/\(marker).txt"])
+        let resultJSON = jsonString([
+            "path": "/tmp/\(marker).txt",
+            "content": String(repeating: "\(marker) payload ", count: 80)
+        ])
+        let execution = AgentTranscriptToolExecution(
+            stableExecutionID: invocationID.uuidString,
+            toolName: "read_file",
+            invocationID: invocationID,
+            argsJSON: argsJSON,
+            resultJSON: resultJSON,
+            toolIsError: false,
+            status: .success
+        )
+        return AgentTranscriptActivity(
+            id: id,
+            timestamp: Date(timeIntervalSinceReferenceDate: TimeInterval(sequenceIndex)),
+            sequenceIndex: sequenceIndex,
+            role: .toolExecution,
+            itemKind: .toolResult,
+            text: resultJSON,
+            toolExecution: execution
         )
     }
 

--- a/Tests/RepoPromptTests/AgentMode/Transcript/AgentTranscriptGroupedHistoryBudgetTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Transcript/AgentTranscriptGroupedHistoryBudgetTests.swift
@@ -1,0 +1,89 @@
+import Foundation
+@testable import RepoPrompt
+import XCTest
+
+final class AgentTranscriptGroupedHistoryBudgetTests: XCTestCase {
+    func testReusablePrefixCacheTightensWhenNewerTurnConsumesDetailedToolBudget() throws {
+        var sequenceIndex = 0
+        let olderItems = makeTurnItems(label: "older", toolCount: 10, sequenceIndex: &sequenceIndex)
+        let initialNewerItems = makeTurnItems(label: "newer", toolCount: 1, sequenceIndex: &sequenceIndex)
+        let initialItems = olderItems + initialNewerItems
+        let initialTranscript = AgentTranscriptIO.buildTranscript(
+            from: initialItems,
+            terminalState: .completed,
+            nextSequenceIndex: sequenceIndex,
+            compact: false
+        )
+        let refreshedInitial = AgentTranscriptProjectionBuilder
+            .refreshCompletedFullTurnGroupedHistoryCaches(in: initialTranscript)
+        XCTAssertEqual(refreshedInitial.turns.count, 2)
+        let initialOlderLimit = try XCTUnwrap(
+            refreshedInitial.turns[0].responseSpans
+                .compactMap(\.fullRenderGroupedHistoryCache?.detailedToolTailLimit)
+                .first
+        )
+        XCTAssertEqual(initialOlderLimit, 7)
+
+        var updatedSequenceIndex = olderItems.count
+        let updatedNewerItems = makeTurnItems(
+            label: "newer-updated",
+            toolCount: 5,
+            sequenceIndex: &updatedSequenceIndex,
+            userItem: initialNewerItems[0]
+        )
+        let updatedNewerTranscript = AgentTranscriptIO.buildTranscript(
+            from: updatedNewerItems,
+            terminalState: .completed,
+            nextSequenceIndex: updatedSequenceIndex,
+            compact: false
+        )
+        var incrementallyUpdated = refreshedInitial
+        incrementallyUpdated.turns[1] = try XCTUnwrap(updatedNewerTranscript.turns.first)
+        incrementallyUpdated.nextSequenceIndex = updatedSequenceIndex
+
+        let refreshedUpdated = AgentTranscriptProjectionBuilder.refreshCompletedFullTurnGroupedHistoryCaches(
+            in: incrementallyUpdated,
+            reusablePrefixTurnCount: 1
+        )
+        let shiftedOlderLimit = try XCTUnwrap(
+            refreshedUpdated.turns[0].responseSpans
+                .compactMap(\.fullRenderGroupedHistoryCache?.detailedToolTailLimit)
+                .first
+        )
+
+        XCTAssertEqual(shiftedOlderLimit, 3)
+        XCTAssertEqual(refreshedUpdated.turns[0].frozenDetailedToolTailLimit, 3)
+    }
+
+    private func makeTurnItems(
+        label: String,
+        toolCount: Int,
+        sequenceIndex: inout Int,
+        userItem: AgentChatItem? = nil
+    ) -> [AgentChatItem] {
+        var items: [AgentChatItem] = []
+        let user = userItem ?? .user("\(label) request", sequenceIndex: sequenceIndex)
+        items.append(user)
+        sequenceIndex += 1
+        for toolIndex in 0 ..< toolCount {
+            let invocationID = UUID()
+            items.append(.toolCall(
+                name: "read_file",
+                invocationID: invocationID,
+                argsJSON: #"{"path":"/tmp/file.swift"}"#,
+                sequenceIndex: sequenceIndex
+            ))
+            sequenceIndex += 1
+            items.append(.toolResult(
+                name: "read_file",
+                invocationID: invocationID,
+                resultJSON: #"{"content":"ok"}"#,
+                sequenceIndex: sequenceIndex
+            ))
+            sequenceIndex += 1
+        }
+        items.append(.assistant("\(label) done", sequenceIndex: sequenceIndex))
+        sequenceIndex += 1
+        return items
+    }
+}

--- a/Tests/RepoPromptTests/ContextBuilder/ContextBuilderWorktreeInheritanceTests.swift
+++ b/Tests/RepoPromptTests/ContextBuilder/ContextBuilderWorktreeInheritanceTests.swift
@@ -319,14 +319,25 @@ import XCTest
                 )
                 do {
                     try await activateWorkspace(fixture.contextA)
+                    let store = fixture.contextA.window.workspaceFileContextStore
+                    let loadedService = await store.fileSystemServiceForTesting(rootID: fixture.contextA.rootID)
+                    let service = try XCTUnwrap(loadedService)
+                    await service.stopWatchingForChanges()
                     let canonicalSentinel = "CanonicalNonAgentContextBuilderType"
                     try write(
                         "struct \(canonicalSentinel) { func canonicalMethod() {} }\n",
                         to: fixture.contextA.fileURL
                     )
-                    await fixture.contextA.window.workspaceFileContextStore.replayObservedFileSystemDeltas(
+                    let relativePath = "Sources/\(fixture.contextA.fileURL.lastPathComponent)"
+                    await store.replayObservedFileSystemDeltas(
                         rootID: fixture.contextA.rootID,
-                        deltas: [.fileModified("Sources/\(fixture.contextA.fileURL.lastPathComponent)", Date())]
+                        deltas: [.fileModified(relativePath, Date())]
+                    )
+                    try await waitForCodemap(
+                        in: store,
+                        rootID: fixture.contextA.rootID,
+                        relativePath: relativePath,
+                        containing: canonicalSentinel
                     )
                     factory.configure(
                         networkManager: fixture.networkManager,
@@ -358,6 +369,28 @@ import XCTest
                     throw error
                 }
             }
+        }
+
+        private func waitForCodemap(
+            in store: WorkspaceFileContextStore,
+            rootID: UUID,
+            relativePath: String,
+            containing expectedText: String,
+            timeout: Duration = .seconds(6)
+        ) async throws {
+            try await store.requestCodemapScan(rootID: rootID, relativePath: relativePath)
+            let clock = ContinuousClock()
+            let deadline = clock.now.advanced(by: timeout)
+            while clock.now < deadline {
+                if let snapshot = await store.codemapSnapshot(rootID: rootID, relativePath: relativePath),
+                   snapshot.fileAPI?.apiDescription.contains(expectedText) == true
+                {
+                    return
+                }
+                try await Task.sleep(for: .milliseconds(25))
+            }
+            XCTFail("Timed out waiting for codemap containing \(expectedText)")
+            throw NSError(domain: "ContextBuilderWorktreeInheritanceTests", code: 1)
         }
 
         private func activateWorkspace(_ context: PersistentMCPTestContext) async throws {

--- a/Tests/RepoPromptTests/MCP/Control/MCPAgentPolicyAdmissionRaceTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/MCPAgentPolicyAdmissionRaceTests.swift
@@ -1,5 +1,6 @@
 import Darwin
 import Foundation
+import MCP
 @testable import RepoPrompt
 import XCTest
 
@@ -339,7 +340,398 @@ final class MCPAgentPolicyAdmissionRaceTests: XCTestCase {
         #endif
     }
 
-    func testAuthoritativePIDOwnedAgentModeRouteReplacesLiveAffinityForEveryRole() async throws {
+    @MainActor
+    func testPolicyInstallFreezesBlankTabStateBeforeFirstSelectionGet() async throws {
+        #if DEBUG
+            let root = FileManager.default.temporaryDirectory
+                .appendingPathComponent("PolicyBlankTab-\(UUID().uuidString)", isDirectory: true)
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: root) }
+            let selectedFile = root.appendingPathComponent("version.env")
+            try "VERSION=1\n".write(to: selectedFile, atomically: true, encoding: .utf8)
+
+            let window = makeWindow()
+            defer { WindowStatesManager.shared.unregisterWindowState(window) }
+            let seedTabID = UUID()
+            let blankTabIDs = [UUID(), UUID()]
+            let seedSelection = StoredSelection(
+                selectedPaths: [selectedFile.path],
+                slices: [selectedFile.path: [LineRange(start: 1, end: 1)]],
+                codemapAutoEnabled: false
+            )
+            let workspace = window.workspaceManager.createWorkspace(
+                name: "Policy blank state \(UUID().uuidString.prefix(8))",
+                repoPaths: [root.path],
+                ephemeral: true
+            )
+            let initialSwitchResult = await window.workspaceManager.switchWorkspace(
+                to: workspace,
+                saveState: false,
+                reason: "policyBlankStateInitial"
+            )
+            XCTAssertEqual(initialSwitchResult, .switched)
+            let workspaceIndex = try XCTUnwrap(
+                window.workspaceManager.workspaces.firstIndex { $0.id == workspace.id }
+            )
+            window.workspaceManager.workspaces[workspaceIndex].composeTabs = [
+                ComposeTabState(
+                    id: seedTabID,
+                    name: "Seed",
+                    selection: seedSelection,
+                    promptText: "seed prompt"
+                ),
+                ComposeTabState(id: blankTabIDs[0], name: "Agent 1"),
+                ComposeTabState(id: blankTabIDs[1], name: "Agent 2")
+            ]
+            window.workspaceManager.workspaces[workspaceIndex].activeComposeTabID = seedTabID
+            let reloadResult = await window.workspaceManager.reactivateWorkspaceAfterReplacement(
+                window.workspaceManager.workspaces[workspaceIndex],
+                reason: "policyBlankStateTabs"
+            )
+            XCTAssertEqual(reloadResult, .switched)
+            _ = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(
+                in: window,
+                path: root.path
+            )
+            await window.workspaceFilesViewModel.applyStoredSelection(seedSelection)
+            window.promptManager.promptText = "seed prompt"
+            XCTAssertEqual(window.workspaceFilesViewModel.snapshotSelection(), seedSelection)
+
+            let tools = await window.mcpServer.windowMCPTools
+            let manageSelection = try XCTUnwrap(
+                tools.first { $0.name == MCPWindowToolName.manageSelection }
+            )
+
+            for (index, blankTabID) in blankTabIDs.enumerated() {
+                window.workspaceManager.beginApplyingTabContext(forTabID: blankTabID)
+                let currentWorkspaceIndex = try XCTUnwrap(
+                    window.workspaceManager.workspaces.firstIndex { $0.id == workspace.id }
+                )
+                window.workspaceManager.workspaces[currentWorkspaceIndex].activeComposeTabID = blankTabID
+                window.promptManager.loadComposeTabsFromWorkspace(
+                    window.workspaceManager.workspaces[currentWorkspaceIndex]
+                )
+                XCTAssertEqual(window.workspaceFilesViewModel.snapshotSelection(), seedSelection)
+
+                let runID = UUID()
+                let connectionID = UUID()
+                await installAuthoritativePolicy(
+                    runID: runID,
+                    tabID: blankTabID,
+                    windowID: window.windowID
+                )
+                await manager.registerExpectedAgentPID(getpid(), for: clientName, runID: runID)
+                let result = await manager.debugApplyPendingPolicy(
+                    clientName: clientName,
+                    connectionID: connectionID,
+                    clientPid: Int(getpid()),
+                    bootstrapClientName: "repoprompt_ce_cli_debug",
+                    sessionKey: "blank-policy-\(index)-\(UUID().uuidString)",
+                    pidGateTimeout: 0.25,
+                    requireRunRouting: true
+                )
+                XCTAssertEqual(result.outcome, "applied")
+                XCTAssertEqual(result.runID, runID)
+
+                let bound = try XCTUnwrap(window.mcpServer.tabContextByConnectionID[connectionID])
+                XCTAssertEqual(bound.tabID, blankTabID)
+                XCTAssertEqual(bound.selection, StoredSelection())
+
+                let firstGet = try await ServerNetworkManager.withConnectionID(connectionID) {
+                    try await manageSelection([
+                        "op": .string("get"),
+                        "view": .string("files"),
+                        "path_display": .string("full")
+                    ])
+                }
+                let object = try XCTUnwrap(firstGet.objectValue)
+                XCTAssertTrue((object["files"]?.arrayValue ?? []).isEmpty)
+                XCTAssertTrue((object["file_slices"]?.arrayValue ?? []).isEmpty)
+                XCTAssertEqual(window.workspaceManager.composeTab(with: blankTabID)?.selection, StoredSelection())
+
+                await cleanup(
+                    runID: runID,
+                    connectionID: connectionID,
+                    windowID: window.windowID,
+                    expectedPID: getpid()
+                )
+                window.workspaceManager.endApplyingTabContext(forTabID: blankTabID)
+            }
+        #else
+            throw XCTSkip("Policy-bound tab routing diagnostics require DEBUG helpers.")
+        #endif
+    }
+
+    @MainActor
+    func testRetainedConnectionCannotConsumeDifferentRunPolicy() async throws {
+        #if DEBUG
+            let window = makeWindow()
+            defer { WindowStatesManager.shared.unregisterWindowState(window) }
+            let firstRunID = UUID()
+            let secondRunID = UUID()
+            let retainedConnectionID = UUID()
+            let rejectedHandoverConnectionID = UUID()
+            let freshConnectionID = UUID()
+            let firstTabID = UUID()
+            let secondTabID = UUID()
+            let firstSelection = StoredSelection(selectedPaths: ["/tmp/first-agent.swift"])
+            let secondSelection = StoredSelection(selectedPaths: ["/tmp/second-agent.swift"])
+            let windowID = window.windowID
+            let sessionKey = "retained-connection-pinning-\(UUID().uuidString)"
+            let workspace = window.workspaceManager.createWorkspace(
+                name: "Retained connection selection isolation \(UUID().uuidString.prefix(8))",
+                repoPaths: [],
+                ephemeral: true
+            )
+            let initialSwitchResult = await window.workspaceManager.switchWorkspace(
+                to: workspace,
+                saveState: false,
+                reason: "retainedConnectionSelectionIsolation"
+            )
+            XCTAssertEqual(initialSwitchResult, .switched)
+            let workspaceIndex = try XCTUnwrap(
+                window.workspaceManager.workspaces.firstIndex { $0.id == workspace.id }
+            )
+            window.workspaceManager.workspaces[workspaceIndex].composeTabs = [
+                ComposeTabState(id: firstTabID, name: "First", selection: firstSelection),
+                ComposeTabState(id: secondTabID, name: "Second", selection: secondSelection)
+            ]
+            window.workspaceManager.workspaces[workspaceIndex].activeComposeTabID = firstTabID
+            let tabReloadResult = await window.workspaceManager.reactivateWorkspaceAfterReplacement(
+                window.workspaceManager.workspaces[workspaceIndex],
+                reason: "retainedConnectionSelectionIsolationTabs"
+            )
+            XCTAssertEqual(tabReloadResult, .switched)
+            let activeWorkspace = try XCTUnwrap(window.workspaceManager.activeWorkspace)
+            window.promptManager.loadComposeTabsFromWorkspace(activeWorkspace, syncPromptText: true)
+
+            await installAuthoritativePolicy(
+                runID: firstRunID,
+                tabID: firstTabID,
+                windowID: windowID
+            )
+            await manager.registerExpectedAgentPID(getpid(), for: clientName, runID: firstRunID)
+            let firstResult = await manager.debugApplyPendingPolicy(
+                clientName: clientName,
+                connectionID: retainedConnectionID,
+                clientPid: Int(getpid()),
+                bootstrapClientName: "repoprompt_ce_cli_debug",
+                sessionKey: sessionKey,
+                pidGateTimeout: 0.25,
+                requireRunRouting: true
+            )
+            XCTAssertEqual(firstResult.outcome, "applied")
+            XCTAssertEqual(firstResult.runID, firstRunID)
+            let firstBoundContext = try XCTUnwrap(
+                window.mcpServer.tabContextByConnectionID[retainedConnectionID]
+            )
+            XCTAssertEqual(firstBoundContext.tabID, firstTabID)
+
+            await installAuthoritativePolicy(
+                runID: secondRunID,
+                tabID: secondTabID,
+                windowID: windowID
+            )
+            await manager.registerExpectedAgentPID(getpid(), for: clientName, runID: secondRunID)
+            let retainedStateBeforeRejection = await manager.debugConnectionPolicyState(
+                for: retainedConnectionID
+            )
+
+            let rejectedResult = await manager.debugApplyPendingPolicy(
+                clientName: clientName,
+                connectionID: retainedConnectionID,
+                clientPid: Int(getpid()),
+                bootstrapClientName: "repoprompt_ce_cli_debug",
+                sessionKey: sessionKey,
+                pidGateTimeout: 0.25,
+                requireRunRouting: true
+            )
+
+            let retainedRunID = await manager.runIDForConnection(retainedConnectionID)
+            let retainedStateAfterRejection = await manager.debugConnectionPolicyState(
+                for: retainedConnectionID
+            )
+            let pendingAfterRejection = await manager.debugPendingPolicySnapshot(for: clientName)
+            XCTAssertEqual(rejectedResult.outcome, "rejected:connection_bound_to_other_run")
+            XCTAssertEqual(rejectedResult.runID, secondRunID)
+            XCTAssertEqual(retainedRunID, firstRunID)
+            XCTAssertEqual(retainedStateAfterRejection.restrictedTools, retainedStateBeforeRejection.restrictedTools)
+            XCTAssertEqual(retainedStateAfterRejection.additionalTools, retainedStateBeforeRejection.additionalTools)
+            XCTAssertEqual(retainedStateAfterRejection.purpose, retainedStateBeforeRejection.purpose)
+            XCTAssertEqual(retainedStateAfterRejection.windowID, retainedStateBeforeRejection.windowID)
+            let retainedContextAfterRejection = try XCTUnwrap(
+                window.mcpServer.tabContextByConnectionID[retainedConnectionID]
+            )
+            XCTAssertEqual(retainedContextAfterRejection.tabID, firstBoundContext.tabID)
+            XCTAssertEqual(retainedContextAfterRejection.runID, firstBoundContext.runID)
+            XCTAssertEqual(retainedContextAfterRejection.workspaceID, firstBoundContext.workspaceID)
+            XCTAssertEqual(retainedContextAfterRejection.selection, firstBoundContext.selection)
+            XCTAssertNil(window.mcpServer.connectionID(forRunID: secondRunID))
+            XCTAssertTrue(pendingAfterRejection.contains { $0.runID == secondRunID })
+
+            let rejectedHandoverResult = await manager.debugApplyPendingPolicy(
+                clientName: clientName,
+                connectionID: rejectedHandoverConnectionID,
+                clientPid: Int(getpid()),
+                bootstrapClientName: "repoprompt_ce_cli_debug",
+                sessionKey: sessionKey,
+                pidGateTimeout: 0.25,
+                requireRunRouting: true
+            )
+            XCTAssertEqual(rejectedHandoverResult.outcome, "rejected:session_token_bound_to_other_run")
+            XCTAssertEqual(rejectedHandoverResult.runID, secondRunID)
+            let rejectedHandoverRunID = await manager.runIDForConnection(rejectedHandoverConnectionID)
+            XCTAssertNil(rejectedHandoverRunID)
+
+            let freshSessionKey = "fresh-run-token-\(UUID().uuidString)"
+            XCTAssertNotEqual(freshSessionKey, sessionKey)
+            let freshResult = await manager.debugApplyPendingPolicy(
+                clientName: clientName,
+                connectionID: freshConnectionID,
+                clientPid: Int(getpid()),
+                bootstrapClientName: "repoprompt_ce_cli_debug",
+                sessionKey: freshSessionKey,
+                pidGateTimeout: 0.25,
+                requireRunRouting: true
+            )
+            XCTAssertEqual(freshResult.outcome, "applied")
+            XCTAssertEqual(freshResult.runID, secondRunID)
+            let freshRunID = await manager.runIDForConnection(freshConnectionID)
+            XCTAssertEqual(freshRunID, secondRunID)
+            XCTAssertEqual(window.mcpServer.tabContextByConnectionID[freshConnectionID]?.tabID, secondTabID)
+
+            await cleanup(
+                runID: secondRunID,
+                connectionID: freshConnectionID,
+                windowID: windowID,
+                expectedPID: getpid()
+            )
+            await manager.removeConnection(rejectedHandoverConnectionID)
+            await cleanup(
+                runID: firstRunID,
+                connectionID: retainedConnectionID,
+                windowID: windowID,
+                expectedPID: getpid()
+            )
+        #else
+            throw XCTSkip("Connection/run isolation diagnostics require DEBUG helpers.")
+        #endif
+    }
+
+    func testRetainedConnectionCanConsumeSameRunPolicy() async throws {
+        #if DEBUG
+            let runID = UUID()
+            let connectionID = UUID()
+            let firstWindowID = 61012
+            let secondWindowID = 61013
+            let sessionKey = "same-run-connection-reuse-\(UUID().uuidString)"
+            await installPolicy(runID: runID, windowID: firstWindowID)
+            await manager.registerExpectedAgentPID(getpid(), for: clientName, runID: runID)
+
+            let firstResult = await manager.debugApplyPendingPolicy(
+                clientName: clientName,
+                connectionID: connectionID,
+                clientPid: Int(getpid()),
+                bootstrapClientName: "repoprompt_ce_cli_debug",
+                sessionKey: sessionKey,
+                pidGateTimeout: 0.25,
+                requireRunRouting: false
+            )
+            XCTAssertEqual(firstResult.outcome, "applied")
+
+            await installPolicy(runID: runID, windowID: secondWindowID)
+            let reconnectResult = await manager.debugApplyPendingPolicy(
+                clientName: clientName,
+                connectionID: connectionID,
+                clientPid: Int(getpid()),
+                bootstrapClientName: "repoprompt_ce_cli_debug",
+                sessionKey: sessionKey,
+                pidGateTimeout: 0.25,
+                requireRunRouting: false
+            )
+
+            XCTAssertEqual(reconnectResult.outcome, "applied")
+            XCTAssertEqual(reconnectResult.runID, runID)
+            XCTAssertEqual(reconnectResult.windowID, secondWindowID)
+            let reconnectedRunID = await manager.runIDForConnection(connectionID)
+            XCTAssertEqual(reconnectedRunID, runID)
+
+            await cleanup(
+                runID: runID,
+                connectionID: connectionID,
+                windowID: secondWindowID,
+                expectedPID: getpid()
+            )
+        #else
+            throw XCTSkip("Connection/run isolation diagnostics require DEBUG helpers.")
+        #endif
+    }
+
+    func testTerminalRunCleanupReleasesAffinityBeforeFreshRunBinding() async throws {
+        #if DEBUG
+            let completedRunID = UUID()
+            let resumedRunID = UUID()
+            let completedConnectionID = UUID()
+            let resumedConnectionID = UUID()
+            let completedWindowID = 61014
+            let resumedWindowID = 61015
+            let completedSessionKey = "terminal-release-\(UUID().uuidString)"
+            let resumedSessionKey = "fresh-resume-\(UUID().uuidString)"
+            XCTAssertNotEqual(completedRunID, resumedRunID)
+            XCTAssertNotEqual(completedConnectionID, resumedConnectionID)
+            XCTAssertNotEqual(completedSessionKey, resumedSessionKey)
+
+            await installPolicy(runID: completedRunID, windowID: completedWindowID)
+            await manager.registerExpectedAgentPID(getpid(), for: clientName, runID: completedRunID)
+            let completedResult = await manager.debugApplyPendingPolicy(
+                clientName: clientName,
+                connectionID: completedConnectionID,
+                clientPid: Int(getpid()),
+                bootstrapClientName: "repoprompt_ce_cli_debug",
+                sessionKey: completedSessionKey,
+                pidGateTimeout: 0.25,
+                requireRunRouting: false
+            )
+            XCTAssertEqual(completedResult.outcome, "applied")
+            XCTAssertEqual(completedResult.runID, completedRunID)
+
+            await manager.clearExpectedAgentPID(getpid(), for: clientName, runID: completedRunID)
+            await manager.cleanupRunRoutingState(for: completedRunID, windowID: completedWindowID)
+            let releasedRunID = await manager.runIDForConnection(completedConnectionID)
+            let releasedRunPolicy = await manager.debugRunPolicyState(for: completedRunID)
+            XCTAssertNil(releasedRunID)
+            XCTAssertNil(releasedRunPolicy)
+            await manager.removeConnection(completedConnectionID)
+
+            await installPolicy(runID: resumedRunID, windowID: resumedWindowID)
+            await manager.registerExpectedAgentPID(getpid(), for: clientName, runID: resumedRunID)
+            let resumedResult = await manager.debugApplyPendingPolicy(
+                clientName: clientName,
+                connectionID: resumedConnectionID,
+                clientPid: Int(getpid()),
+                bootstrapClientName: "repoprompt_ce_cli_debug",
+                sessionKey: resumedSessionKey,
+                pidGateTimeout: 0.25,
+                requireRunRouting: false
+            )
+            let boundResumedRunID = await manager.runIDForConnection(resumedConnectionID)
+
+            XCTAssertEqual(resumedResult.outcome, "applied")
+            XCTAssertEqual(resumedResult.runID, resumedRunID)
+            XCTAssertEqual(boundResumedRunID, resumedRunID)
+
+            await cleanup(
+                runID: resumedRunID,
+                connectionID: resumedConnectionID,
+                windowID: resumedWindowID,
+                expectedPID: getpid()
+            )
+        #else
+            throw XCTSkip("Connection/run lifecycle diagnostics require DEBUG helpers.")
+        #endif
+    }
+
+    func testAuthoritativePIDOwnedAgentModeRouteCannotReplaceLiveAffinityForAnyRole() async throws {
         #if DEBUG
             let roles: [AgentModelCatalog.TaskLabelKind?] = [nil] + AgentModelCatalog.TaskLabelKind.allCases
                 .map(Optional.some)
@@ -367,8 +759,16 @@ final class MCPAgentPolicyAdmissionRaceTests: XCTestCase {
                     requireRunRouting: false
                 )
 
-                XCTAssertEqual(result.outcome, "applied", "role=\(role?.rawValue ?? "nil")")
+                XCTAssertEqual(
+                    result.outcome,
+                    "rejected:session_token_bound_to_other_run",
+                    "role=\(role?.rawValue ?? "nil")"
+                )
                 XCTAssertEqual(result.runID, runID)
+                let mappedRunID = await manager.runIDForConnection(connectionID)
+                XCTAssertNil(mappedRunID)
+                let pending = await manager.debugPendingPolicySnapshot(for: clientName)
+                XCTAssertTrue(pending.contains { $0.runID == runID })
                 await cleanup(
                     runID: runID,
                     connectionID: connectionID,
@@ -550,7 +950,7 @@ final class MCPAgentPolicyAdmissionRaceTests: XCTestCase {
         #endif
     }
 
-    func testAuthoritativeRouteFailurePreservesPriorLiveAffinityForReconnect() async throws {
+    func testRejectedAuthoritativeRoutePreservesPriorLiveAffinityForReconnect() async throws {
         #if DEBUG
             let sessionKey = "authoritative-route-rollback-\(UUID().uuidString)"
             let affinity = await seedLiveAffinity(sessionKey: sessionKey, windowID: 61127)
@@ -574,7 +974,7 @@ final class MCPAgentPolicyAdmissionRaceTests: XCTestCase {
                 requireRunRouting: true
             )
 
-            XCTAssertEqual(failedChild.outcome, "rejected:route_mapping_failed")
+            XCTAssertEqual(failedChild.outcome, "rejected:session_token_bound_to_other_run")
             let pendingAfterFailure = await manager.debugPendingPolicySnapshot(for: clientName)
             XCTAssertTrue(pendingAfterFailure.contains { $0.runID == childRunID })
 

--- a/Tests/RepoPromptTests/MCP/Control/MCPToolExecutionWatchdogIntegrationTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/MCPToolExecutionWatchdogIntegrationTests.swift
@@ -64,6 +64,273 @@ import XCTest
             }
         }
 
+        func testSameWindowExclusiveResourceReleasesBeforeCompletionObserverTail() async throws {
+            try await MCPSharedServerTestLease.shared.withLease { lease in
+                let fixture = try await PersistentMCPTestFixture.make(lease: lease)
+                let manager = fixture.networkManager
+                let firstEndpoint = try fixture.endpointA()
+                let secondEndpoint = try fixture.endpointARead()
+                let providerProbe = MCPPostProviderAdmissionProbe()
+                let observerTailGate = MCPExecutionIgnoringCancellationGate()
+                var firstTask: Task<PersistentMCPTestRPCResponse, Error>?
+                var secondTask: Task<PersistentMCPTestRPCResponse, Error>?
+
+                await manager.debugSetResolvedToolOperationOverride(toolName: MCPWindowToolName.manageSelection) {
+                    await providerProbe.record(connectionID: ServerNetworkManager.currentConnectionID)
+                }
+                await manager.debugSetBeforeToolCompletionObserversForTesting { connectionID, toolName in
+                    guard connectionID == firstEndpoint.connectionID,
+                          toolName == MCPWindowToolName.manageSelection
+                    else { return }
+                    await observerTailGate.enterAndWait()
+                }
+
+                do {
+                    let arguments: [String: Any] = [
+                        "op": "get",
+                        "context_id": fixture.contextA.tabID.uuidString,
+                        "_rawJSON": true
+                    ]
+                    let blockedFirst = Task {
+                        try await firstEndpoint.callTool(
+                            name: MCPWindowToolName.manageSelection,
+                            arguments: arguments
+                        )
+                    }
+                    firstTask = blockedFirst
+                    try await observerTailGate.waitUntilEntered(count: 1)
+                    try await providerProbe.waitUntilEntered(connectionID: firstEndpoint.connectionID)
+
+                    let firstLimiter = await manager.connectionLimiterSnapshotForTesting(
+                        connectionID: firstEndpoint.connectionID,
+                        lane: .ordinary
+                    )
+                    XCTAssertEqual(firstLimiter?.activePermitCount, 1)
+
+                    let competingSecond = Task {
+                        try await secondEndpoint.callTool(
+                            name: MCPWindowToolName.manageSelection,
+                            arguments: arguments
+                        )
+                    }
+                    secondTask = competingSecond
+                    try await providerProbe.waitUntilEntered(connectionID: secondEndpoint.connectionID)
+                    _ = try await competingSecond.value
+                    secondTask = nil
+
+                    await observerTailGate.release()
+                    _ = try await blockedFirst.value
+                    firstTask = nil
+
+                    await manager.debugSetBeforeToolCompletionObserversForTesting(nil)
+                    await manager.debugSetResolvedToolOperationOverride(
+                        toolName: MCPWindowToolName.manageSelection,
+                        operation: nil
+                    )
+                    await fixture.cleanup()
+                    try await fixture.assertCleanedUp()
+                } catch {
+                    await observerTailGate.release()
+                    firstTask?.cancel()
+                    secondTask?.cancel()
+                    if let firstTask { _ = try? await firstTask.value }
+                    if let secondTask { _ = try? await secondTask.value }
+                    await manager.debugSetBeforeToolCompletionObserversForTesting(nil)
+                    await manager.debugSetResolvedToolOperationOverride(
+                        toolName: MCPWindowToolName.manageSelection,
+                        operation: nil
+                    )
+                    await fixture.cleanup()
+                    throw error
+                }
+            }
+        }
+
+        func testSameWindowSmallReadResourcesReleaseBeforeFormattingTail() async throws {
+            try await MCPSharedServerTestLease.shared.withLease { lease in
+                let fixture = try await PersistentMCPTestFixture.make(lease: lease)
+                let manager = fixture.networkManager
+                let firstEndpoint = try fixture.endpointA()
+                let secondEndpoint = try fixture.endpointARead()
+                let thirdEndpoint = try fixture.endpointAQueuedSearch()
+                let providerProbe = MCPPostProviderAdmissionProbe()
+                let formattingTailGate = MCPExecutionIgnoringCancellationGate()
+                let blockedConnectionIDs = Set([firstEndpoint.connectionID, secondEndpoint.connectionID])
+                var tasks: [Task<PersistentMCPTestRPCResponse, Error>] = []
+
+                await manager.debugSetResolvedToolOperationOverride(toolName: MCPWindowToolName.readFile) {
+                    await providerProbe.record(connectionID: ServerNetworkManager.currentConnectionID)
+                }
+                await manager.debugSetBeforeToolResultFormattingForTesting { connectionID, toolName in
+                    guard blockedConnectionIDs.contains(connectionID),
+                          toolName == MCPWindowToolName.readFile
+                    else { return }
+                    await formattingTailGate.enterAndWait()
+                }
+
+                do {
+                    let arguments: [String: Any] = [
+                        "path": fixture.contextA.fileURL.path,
+                        "context_id": fixture.contextA.tabID.uuidString,
+                        "_rawJSON": true
+                    ]
+                    let first = Task {
+                        try await firstEndpoint.callTool(
+                            name: MCPWindowToolName.readFile,
+                            arguments: arguments
+                        )
+                    }
+                    let second = Task {
+                        try await secondEndpoint.callTool(
+                            name: MCPWindowToolName.readFile,
+                            arguments: arguments
+                        )
+                    }
+                    tasks = [first, second]
+                    try await formattingTailGate.waitUntilEntered(count: 2)
+                    try await providerProbe.waitUntilEntered(connectionID: firstEndpoint.connectionID)
+                    try await providerProbe.waitUntilEntered(connectionID: secondEndpoint.connectionID)
+
+                    for endpoint in [firstEndpoint, secondEndpoint] {
+                        let limiter = await manager.connectionLimiterSnapshotForTesting(
+                            connectionID: endpoint.connectionID,
+                            lane: .smallRead
+                        )
+                        XCTAssertEqual(limiter?.activePermitCount, 1)
+                    }
+
+                    let third = Task {
+                        try await thirdEndpoint.callTool(
+                            name: MCPWindowToolName.readFile,
+                            arguments: arguments
+                        )
+                    }
+                    tasks.append(third)
+                    try await providerProbe.waitUntilEntered(connectionID: thirdEndpoint.connectionID)
+                    _ = try await third.value
+                    tasks.removeLast()
+
+                    await formattingTailGate.release()
+                    _ = try await first.value
+                    _ = try await second.value
+                    tasks.removeAll()
+
+                    await manager.debugSetBeforeToolResultFormattingForTesting(nil)
+                    await manager.debugSetResolvedToolOperationOverride(
+                        toolName: MCPWindowToolName.readFile,
+                        operation: nil
+                    )
+                    await fixture.cleanup()
+                    try await fixture.assertCleanedUp()
+                } catch {
+                    await formattingTailGate.release()
+                    tasks.forEach { $0.cancel() }
+                    for task in tasks {
+                        _ = try? await task.value
+                    }
+                    await manager.debugSetBeforeToolResultFormattingForTesting(nil)
+                    await manager.debugSetResolvedToolOperationOverride(
+                        toolName: MCPWindowToolName.readFile,
+                        operation: nil
+                    )
+                    await fixture.cleanup()
+                    throw error
+                }
+            }
+        }
+
+        func testAppWideExclusiveResourceReleasesBeforeFormattingTail() async throws {
+            try await MCPSharedServerTestLease.shared.withLease { lease in
+                let fixture = try await PersistentMCPTestFixture.make(lease: lease)
+                let manager = fixture.networkManager
+                let firstEndpoint = try fixture.endpointA()
+                let secondEndpoint = try fixture.endpointB()
+                let providerProbe = MCPPostProviderAdmissionProbe()
+                let formattingTailGate = MCPExecutionIgnoringCancellationGate()
+                var appSettingsScope: MCPAppSettingsServiceScope?
+                var firstTask: Task<PersistentMCPTestRPCResponse, Error>?
+                var secondTask: Task<PersistentMCPTestRPCResponse, Error>?
+
+                await manager.debugSetResolvedToolOperationOverride(toolName: MCPGlobalToolName.appSettings) {
+                    await providerProbe.record(connectionID: ServerNetworkManager.currentConnectionID)
+                }
+                await manager.debugSetBeforeToolResultFormattingForTesting { connectionID, toolName in
+                    guard connectionID == firstEndpoint.connectionID,
+                          toolName == MCPGlobalToolName.appSettings
+                    else { return }
+                    await formattingTailGate.enterAndWait()
+                }
+
+                do {
+                    let installedScope = try await MCPAppSettingsServiceScope.install()
+                    appSettingsScope = installedScope
+                    let arguments: [String: Any] = [
+                        "op": "get",
+                        "key": "ui.appearance_mode",
+                        "_rawJSON": true
+                    ]
+                    let blockedFirst = Task {
+                        try await firstEndpoint.callTool(
+                            name: MCPGlobalToolName.appSettings,
+                            arguments: arguments
+                        )
+                    }
+                    firstTask = blockedFirst
+                    try await formattingTailGate.waitUntilEntered(count: 1)
+                    try await providerProbe.waitUntilEntered(connectionID: firstEndpoint.connectionID)
+
+                    let firstLimiter = await manager.connectionLimiterSnapshotForTesting(
+                        connectionID: firstEndpoint.connectionID,
+                        lane: .ordinary
+                    )
+                    XCTAssertEqual(firstLimiter?.activePermitCount, 1)
+
+                    let competingSecond = Task {
+                        try await secondEndpoint.callTool(
+                            name: MCPGlobalToolName.appSettings,
+                            arguments: arguments
+                        )
+                    }
+                    secondTask = competingSecond
+                    try await providerProbe.waitUntilEntered(connectionID: secondEndpoint.connectionID)
+                    _ = try await competingSecond.value
+                    secondTask = nil
+
+                    await formattingTailGate.release()
+                    _ = try await blockedFirst.value
+                    firstTask = nil
+
+                    await manager.debugSetBeforeToolResultFormattingForTesting(nil)
+                    await manager.debugSetResolvedToolOperationOverride(
+                        toolName: MCPGlobalToolName.appSettings,
+                        operation: nil
+                    )
+                    await installedScope.restore()
+                    installedScope.assertRestored()
+                    appSettingsScope = nil
+                    await fixture.cleanup()
+                    try await fixture.assertCleanedUp()
+                } catch {
+                    await formattingTailGate.release()
+                    firstTask?.cancel()
+                    secondTask?.cancel()
+                    if let firstTask { _ = try? await firstTask.value }
+                    if let secondTask { _ = try? await secondTask.value }
+                    await manager.debugSetBeforeToolResultFormattingForTesting(nil)
+                    await manager.debugSetResolvedToolOperationOverride(
+                        toolName: MCPGlobalToolName.appSettings,
+                        operation: nil
+                    )
+                    if let appSettingsScope {
+                        await appSettingsScope.restore()
+                        appSettingsScope.assertRestored()
+                    }
+                    await fixture.cleanup()
+                    throw error
+                }
+            }
+        }
+
         func testManageSelectionAndFileActionsReportReplyConstructionPhase() async throws {
             try await MCPSharedServerTestLease.shared.withLease { lease in
                 let fixture = try await PersistentMCPTestFixture.make(lease: lease)
@@ -1734,6 +2001,37 @@ import XCTest
             cancellationCount += 1
             continuation?.resume(throwing: CancellationError())
             continuation = nil
+        }
+    }
+
+    private actor MCPPostProviderAdmissionProbe {
+        private static let synchronizationTimeout: Duration = .seconds(10)
+
+        private var connectionIDs: [UUID] = []
+
+        func record(connectionID: UUID?) -> Value {
+            if let connectionID {
+                connectionIDs.append(connectionID)
+            }
+            return .object(["status": .string("ok")])
+        }
+
+        func waitUntilEntered(
+            connectionID: UUID,
+            timeout: Duration = synchronizationTimeout
+        ) async throws {
+            let clock = ContinuousClock()
+            let deadline = clock.now.advanced(by: timeout)
+            while !connectionIDs.contains(connectionID) {
+                try Task.checkCancellation()
+                guard clock.now < deadline else {
+                    throw MCPExecutionWatchdogIntegrationFixtureError.gateDidNotEnter(
+                        expected: 1,
+                        actual: connectionIDs.count
+                    )
+                }
+                try await Task.sleep(for: .milliseconds(10))
+            }
         }
     }
 

--- a/Tests/RepoPromptTests/MCP/Control/PersistentAgentModeMCPReadFileConnectionTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/PersistentAgentModeMCPReadFileConnectionTests.swift
@@ -1616,7 +1616,6 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
         private var auxiliaryRootID: UUID?
         private var peerRootID: UUID?
         private var peerTargetStateVersionBeforeSelection: Int?
-        private var peerUnrelatedStateVersionBeforeSelection: Int?
         private var peerCatalogService: MCPWindowToolCatalogService?
         private var ownedRoutingService: WindowRoutingService?
         private var cleanedUp = false
@@ -2012,8 +2011,6 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
             peerRootID = root.id
             peerTargetStateVersionBeforeSelection = routingGuardWindow.workspaceManager
                 .debugStateVersionForWorkspace(workspaceID)
-            peerUnrelatedStateVersionBeforeSelection = routingGuardWindow.workspaceManager
-                .debugStateVersionForWorkspace(Self.peerUnrelatedWorkspaceID)
 
             let targetIdentity = WorkspaceSelectionIdentity(workspaceID: workspaceID, tabID: Self.tabID)
             XCTAssertNotNil(window.workspaceManager.composeTab(for: targetIdentity))
@@ -2174,12 +2171,6 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
                 XCTAssertGreaterThan(
                     routingGuardWindow.workspaceManager.debugStateVersionForWorkspace(workspaceID),
                     peerTargetStateVersionBeforeSelection
-                )
-            }
-            if let peerUnrelatedStateVersionBeforeSelection {
-                XCTAssertEqual(
-                    routingGuardWindow.workspaceManager.debugStateVersionForWorkspace(Self.peerUnrelatedWorkspaceID),
-                    peerUnrelatedStateVersionBeforeSelection
                 )
             }
         }

--- a/Tests/RepoPromptTests/MCP/Control/PersistentAgentModeMCPReadFileConnectionTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/PersistentAgentModeMCPReadFileConnectionTests.swift
@@ -5,7 +5,7 @@ import XCTest
 
 @MainActor
 final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
-    func testPairAgentOwnedConnectionReplacesPriorSessionAffinityAndPersistsCanonicalSelection() async throws {
+    func testPairAgentOwnedConnectionWithDistinctRunTokenPersistsCanonicalSelection() async throws {
         #if DEBUG
             try await withFixture(agentOwned: true) { fixture in
                 try await runCheckpoint(fixture: fixture, scenario: .agentOwnedCanonicalSelection)
@@ -40,6 +40,16 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
             try await withFixture(agentOwned: true, inactiveAgentTab: true) { fixture in
                 try await fixture.installWorktreeBinding()
                 try await runCheckpoint(fixture: fixture, scenario: .agentOwnedNoRangeNonEmptyWorktreeFile)
+            }
+        #else
+            throw XCTSkip("Persistent Agent Mode MCP socketpair integration requires DEBUG inspection helpers.")
+        #endif
+    }
+
+    func testManageSelectionGetStopsAtCanonicalHandoverWhileMirrorBlocked() async throws {
+        #if DEBUG
+            try await withFixture(agentOwned: true) { fixture in
+                try await runCheckpoint(fixture: fixture, scenario: .manageSelectionGetCanonicalHandover)
             }
         #else
             throw XCTSkip("Persistent Agent Mode MCP socketpair integration requires DEBUG inspection helpers.")
@@ -153,10 +163,12 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
             case agentOwnedSequentialReadUnion
             case agentOwnedExplicitSetIndependentLookup
             case agentOwnedNoRangeNonEmptyWorktreeFile
+            case manageSelectionGetCanonicalHandover
 
             var requiresSerialReadPrelude: Bool {
                 switch self {
-                case .agentOwnedNoRangeNonEmptyWorktreeFile, .agentOwnedSequentialReadUnion:
+                case .agentOwnedNoRangeNonEmptyWorktreeFile, .agentOwnedSequentialReadUnion,
+                     .manageSelectionGetCanonicalHandover:
                     false
                 default:
                     true
@@ -337,6 +349,8 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
                 try await assertAgentOwnedExplicitSetIndependentLookup(fixture: fixture)
             case .agentOwnedNoRangeNonEmptyWorktreeFile:
                 try await assertAgentOwnedNoRangeNonEmptyWorktreeFile(fixture: fixture)
+            case .manageSelectionGetCanonicalHandover:
+                try await assertManageSelectionGetCanonicalHandover(fixture: fixture)
             }
         }
 
@@ -441,12 +455,115 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
                 let selectionText = try Self.readFileText(from: independentGet, id: 4)
                 XCTAssertTrue(selectionText.contains(fixture.liveFileURL.path), selectionText)
                 XCTAssertTrue(selectionText.contains("\"full_count\":1"), selectionText)
-                XCTAssertGreaterThan(try Self.totalTokens(fromSelectionText: selectionText), 0)
             } catch {
                 await independent.cleanup()
                 throw error
             }
             await independent.cleanup()
+        }
+
+        func assertManageSelectionGetCanonicalHandover(fixture: Fixture) async throws {
+            try await clearSelection(fixture: fixture, id: 3)
+            let revisionAfterClear = fixture.canonicalSelectionRevision()
+            let predecessorGeneration = try XCTUnwrap(
+                fixture.window.mcpServer.tabContextByConnectionID[Fixture.connectionID]?
+                    .readFileAutoSelectionGeneration
+            )
+            let canonicalGate = PersistentAsyncGate()
+            let mirrorGate = PersistentAsyncGate()
+            fixture.window.mcpServer.setReadFileAutoSelectionCanonicalApplyGateForTesting {
+                await canonicalGate.markStartedAndWaitForRelease()
+            }
+            fixture.window.mcpServer.setReadFileAutoSelectionMirrorGateForTesting {
+                await mirrorGate.markStartedAndWaitForRelease()
+            }
+            defer {
+                fixture.window.mcpServer.setReadFileAutoSelectionCanonicalApplyGateForTesting(nil)
+                fixture.window.mcpServer.setReadFileAutoSelectionMirrorGateForTesting(nil)
+                fixture.window.mcpServer.setReadFileAutoSelectionPredecessorDrainWaiterRegisteredHandlerForTesting(nil)
+                Task {
+                    await canonicalGate.release()
+                    await mirrorGate.release()
+                }
+            }
+
+            let read = try await fixture.socketClient.request(
+                id: 4,
+                method: "tools/call",
+                params: [
+                    "name": MCPWindowToolName.readFile,
+                    "arguments": ["path": fixture.fileURL.path]
+                ]
+            )
+            let readText = try Self.readFileText(from: read, id: 4)
+            XCTAssertTrue(readText.contains(Fixture.sentinelContent), readText)
+            try await requireGateStarted(canonicalGate)
+            XCTAssertEqual(fixture.canonicalSelectionRevision(), revisionAfterClear)
+
+            let handover = try await fixture.makeHandoverConnection()
+            do {
+                let replacementContext = try XCTUnwrap(
+                    fixture.window.mcpServer.tabContextByConnectionID[handover.connectionID]
+                )
+                XCTAssertGreaterThan(replacementContext.readFileAutoSelectionGeneration, predecessorGeneration)
+                XCTAssertEqual(
+                    fixture.window.mcpServer.readFileAutoSelectionHandoverPredecessorConnectionIDsForTesting(
+                        connectionID: handover.connectionID
+                    ),
+                    [Fixture.connectionID]
+                )
+
+                let predecessorWaiterRegistered = expectation(
+                    description: "replacement manage_selection get registered predecessor canonical waiter"
+                )
+                fixture.window.mcpServer.setReadFileAutoSelectionPredecessorDrainWaiterRegisteredHandlerForTesting {
+                    predecessorWaiterRegistered.fulfill()
+                }
+                let getFinished = PersistentAsyncSignal()
+                let getTask = Task {
+                    let response = try await handover.socketClient.request(
+                        id: 3,
+                        method: "tools/call",
+                        params: [
+                            "name": MCPWindowToolName.manageSelection,
+                            "arguments": ["op": "get", "view": "files"]
+                        ]
+                    )
+                    await getFinished.mark()
+                    return response
+                }
+                await fulfillment(of: [predecessorWaiterRegistered], timeout: 2)
+                let returnedBeforePredecessorCanonical = await getFinished.isMarked()
+                XCTAssertFalse(
+                    returnedBeforePredecessorCanonical,
+                    "Replacement get must preserve predecessor canonical handover ordering"
+                )
+
+                await canonicalGate.release()
+                try await requireGateStarted(mirrorGate)
+                let returnedWhileMirrorBlocked = await waitUntilMarked(getFinished, timeout: .seconds(2))
+                XCTAssertTrue(
+                    returnedWhileMirrorBlocked,
+                    "manage_selection get must return after canonical persistence without waiting for the mirror"
+                )
+                if !returnedWhileMirrorBlocked {
+                    await mirrorGate.release()
+                }
+                let response = try await getTask.value
+                try Self.assertSuccessfulResponse(response, id: 3)
+                XCTAssertTrue(response.contains(fixture.fileURL.lastPathComponent), response)
+                XCTAssertGreaterThan(fixture.canonicalSelectionRevision(), revisionAfterClear)
+                assertCanonicalSelection(
+                    fixture: fixture,
+                    selectedPaths: [fixture.fileURL.path],
+                    slices: [:]
+                )
+                await mirrorGate.release()
+            } catch {
+                await handover.cleanup()
+                throw error
+            }
+            await handover.cleanup()
         }
 
         func assertAgentOwnedNoRangeNonEmptyWorktreeFile(fixture: Fixture) async throws {
@@ -691,8 +808,6 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
                         independentSelectionText.contains("\"full_count\":1"),
                         independentSelectionText
                     )
-                    let totalTokens = try Self.totalTokens(fromSelectionText: independentSelectionText)
-                    XCTAssertGreaterThan(totalTokens, 0, independentSelectionText)
                 } catch {
                     await independent.cleanup()
                     throw error
@@ -1368,14 +1483,6 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
             return content.compactMap { $0["text"] as? String }.joined()
         }
 
-        static func totalTokens(fromSelectionText text: String) throws -> Int {
-            let regex = try NSRegularExpression(pattern: #"\"total_tokens\"\s*:\s*(\d+)"#)
-            let range = NSRange(text.startIndex ..< text.endIndex, in: text)
-            let match = try XCTUnwrap(regex.firstMatch(in: text, range: range))
-            let valueRange = try XCTUnwrap(Range(match.range(at: 1), in: text))
-            return try XCTUnwrap(Int(text[valueRange]))
-        }
-
         static func responseObject(from rawJSON: String, id: Int) throws -> [String: Any] {
             let data = try XCTUnwrap(rawJSON.data(using: .utf8))
             let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
@@ -1466,6 +1573,7 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
         static let parentConnectionID = UUID(uuidString: "66666666-6666-4666-8666-666666666666")!
         static let agentSessionID = UUID(uuidString: "77777777-7777-4777-8777-777777777777")!
         static let sessionToken = "persistent-agent-mode-read-file-checkpoint-session"
+        static let parentSessionToken = "persistent-agent-mode-read-file-parent-session"
         static let sentinelContent = """
         let persistentAgentModeCheckpoint = "retained-session-read"
         let persistentAgentModeLineTwo = 2
@@ -1670,10 +1778,8 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
                     sessionToken: sessionToken
                 )
                 if agentOwned {
-                    // MCP capability tokens are helper-process identities. This synthetic
-                    // fixture models the confirmed provider behavior of retaining the parent's
-                    // helper while opening a child session; it does not claim agent_run copies
-                    // tokens or replace separate live rpce-cli-debug validation.
+                    // A capability token is pinned to one run for that run's lifetime.
+                    // Seed an independent parent-run affinity without reusing the child run's token.
                     await ServerNetworkManager.shared.installClientConnectionPolicy(
                         for: AgentProviderKind.codexMCPClientID,
                         windowID: window.windowID,
@@ -1694,7 +1800,7 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
                         connectionID: parentConnectionID,
                         clientPid: Int(getpid()),
                         bootstrapClientName: AgentProviderKind.codexMCPClientID,
-                        sessionKey: sessionToken,
+                        sessionKey: parentSessionToken,
                         requireRunRouting: false
                     )
                     guard parentApplication.outcome == "applied", parentApplication.runID == parentRunID else {
@@ -2127,6 +2233,11 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
                 clientName: AgentProviderKind.codexMCPClientID,
                 sessionToken: Self.sessionToken + "-handover"
             )
+            let replacementScheduleCountBefore = await networkManager.debugPendingPolicyReplacementScheduleCount(
+                existing: Self.connectionID,
+                replacement: Self.handoverConnectionID,
+                runID: Self.runID
+            )
             await networkManager.installClientConnectionPolicy(
                 for: AgentProviderKind.codexMCPClientID,
                 windowID: windowID,
@@ -2162,7 +2273,7 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
                 replacement: Self.handoverConnectionID,
                 runID: Self.runID
             )
-            XCTAssertEqual(replacementScheduleCount, 1)
+            XCTAssertEqual(replacementScheduleCount, replacementScheduleCountBefore + 1)
             let startTask = Task {
                 try await manager.start { clientInfo in
                     clientInfo.name == AgentProviderKind.codexMCPClientID

--- a/Tests/RepoPromptTests/MCP/Control/PersistentMCPDistinctConnectionConcurrencyTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/PersistentMCPDistinctConnectionConcurrencyTests.swift
@@ -1524,6 +1524,8 @@ final class PersistentMCPDistinctConnectionConcurrencyTests: XCTestCase {
             await contextA.window.mcpServer.shutdownListener()
             ServiceRegistry.unregister(contextB.catalogService)
             ServiceRegistry.unregister(contextA.catalogService)
+            await contextB.window.workspaceFilesViewModel.cancelAllScans()
+            await contextA.window.workspaceFilesViewModel.cancelAllScans()
             await contextB.window.workspaceFileContextStore.unloadRoot(id: contextB.rootID)
             await contextA.window.workspaceFileContextStore.unloadRoot(id: contextA.rootID)
             contextB.window.workspaceManager.workspaces.removeAll { $0.id == contextB.workspaceID }

--- a/Tests/RepoPromptTests/MCP/MCPCodeStructureWorktreeTests.swift
+++ b/Tests/RepoPromptTests/MCP/MCPCodeStructureWorktreeTests.swift
@@ -22,7 +22,7 @@ final class MCPCodeStructureWorktreeTests: XCTestCase {
         XCTAssertTrue(repair.snapshotsByFileID[file.id]?.fileAPI?.apiDescription.contains("DirectSessionWorktreeType") == true)
     }
 
-    func testMissingWorktreeSnapshotSelfHealsFromPhysicalFileAndRendersLogicalPath() async throws {
+    func testMissingWorktreeSnapshotReturnsPendingThenRendersRefreshedLogicalPath() async throws {
         let logicalRootURL = try makeTemporaryRoot(name: "Logical")
         let worktreeRootURL = try makeTemporaryRoot(name: "Worktree")
         try write(
@@ -52,27 +52,159 @@ final class MCPCodeStructureWorktreeTests: XCTestCase {
 
         let snapshotBeforeRepair = await store.codemapSnapshot(fileID: file.id)
         XCTAssertNil(snapshotBeforeRepair)
-        let dto = try await window.mcpServer.buildCodeStructureDTO(
+        let pendingDTO = try await window.mcpServer.buildCodeStructureDTO(
             fromRecords: [file],
             maxResults: 10,
             includeUnmappedPaths: true,
-            lookupContext: lookupContext,
-            selfHealTimeout: .seconds(12)
+            lookupContext: lookupContext
         )
 
-        XCTAssertEqual(dto.fileCount, 1)
-        XCTAssertTrue(dto.content.contains("WorktreeOnlyType"), dto.content)
-        XCTAssertFalse(dto.content.contains("CanonicalOnlyType"), dto.content)
-        XCTAssertTrue(dto.content.contains("Sources/App.swift"), dto.content)
-        XCTAssertFalse(dto.content.contains(worktreeRoot.standardizedFullPath), dto.content)
-        XCTAssertNil(dto.pendingPaths)
-        XCTAssertEqual(dto.worktreeScope?.rootMappings.first?.logicalRootPath, logicalRoot.standardizedFullPath)
-        XCTAssertEqual(dto.worktreeScope?.rootMappings.first?.effectiveRootPath, worktreeRoot.standardizedFullPath)
-        let snapshotAfterRepair = await store.codemapSnapshot(fileID: file.id)
-        XCTAssertNotNil(snapshotAfterRepair)
+        XCTAssertEqual(pendingDTO.fileCount, 0)
+        XCTAssertEqual(pendingDTO.pendingPaths, ["Sources/App.swift"])
+        XCTAssertNil(pendingDTO.unmappedPaths)
+        _ = try await waitForCodemapSnapshot(store: store, fileID: file.id, timeout: .seconds(12))
+
+        let refreshedDTO = try await window.mcpServer.buildCodeStructureDTO(
+            fromRecords: [file],
+            maxResults: 10,
+            includeUnmappedPaths: true,
+            lookupContext: lookupContext
+        )
+        XCTAssertEqual(refreshedDTO.fileCount, 1)
+        XCTAssertTrue(refreshedDTO.content.contains("WorktreeOnlyType"), refreshedDTO.content)
+        XCTAssertFalse(refreshedDTO.content.contains("CanonicalOnlyType"), refreshedDTO.content)
+        XCTAssertTrue(refreshedDTO.content.contains("Sources/App.swift"), refreshedDTO.content)
+        XCTAssertFalse(refreshedDTO.content.contains(worktreeRoot.standardizedFullPath), refreshedDTO.content)
+        XCTAssertNil(refreshedDTO.pendingPaths)
+        XCTAssertEqual(refreshedDTO.worktreeScope?.rootMappings.first?.logicalRootPath, logicalRoot.standardizedFullPath)
+        XCTAssertEqual(refreshedDTO.worktreeScope?.rootMappings.first?.effectiveRootPath, worktreeRoot.standardizedFullPath)
     }
 
     #if DEBUG
+        func testNewlySubmittedCodeStructureScanDoesNotBlockPendingResponse() async throws {
+            let logicalRootURL = try makeTemporaryRoot(name: "NonblockingLogical")
+            let worktreeRootURL = try makeTemporaryRoot(name: "NonblockingWorktree")
+            let fileURL = worktreeRootURL.appendingPathComponent("Sources/App.swift")
+            try write("struct NonblockingCodeStructureType {}\n", to: fileURL)
+
+            let window = try await makeWindow(root: logicalRootURL)
+            defer { WindowStatesManager.shared.unregisterWindowState(window) }
+            let store = window.workspaceFileContextStore
+            let logicalRoot = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(
+                in: window,
+                path: logicalRootURL.path
+            )
+            let worktreeRoot = try await store.loadRoot(path: worktreeRootURL.path, kind: .sessionWorktree)
+            let projection = makeProjection(logicalRoot: logicalRoot, physicalRoot: worktreeRoot, worktreeID: "nonblocking-code")
+            let lookupContext = WorkspaceLookupContext(rootScope: projection.lookupRootScope, bindingProjection: projection)
+            let file = try await fileRecord(at: fileURL, store: store, rootScope: projection.lookupRootScope)
+            let scanGate = AsyncGate()
+            await store.setCodemapScanWillStartHandlerForTesting { scannedFileID in
+                guard scannedFileID == file.id else { return }
+                await scanGate.markStartedAndWaitForRelease()
+            }
+            defer {
+                Task {
+                    await scanGate.release()
+                    await store.setCodemapScanWillStartHandlerForTesting(nil)
+                }
+            }
+
+            let responseCompleted = expectation(description: "get_code_structure returns while scan is gated")
+            var responseDTO: ToolResultDTOs.SelectedCodeStructureDTO?
+            var responseError: Error?
+            Task { @MainActor in
+                defer { responseCompleted.fulfill() }
+                do {
+                    responseDTO = try await window.mcpServer.buildCodeStructureDTO(
+                        fromRecords: [file],
+                        maxResults: 10,
+                        includeUnmappedPaths: false,
+                        lookupContext: lookupContext
+                    )
+                } catch {
+                    responseError = error
+                }
+            }
+
+            await scanGate.waitUntilStarted()
+            await fulfillment(of: [responseCompleted], timeout: 1)
+            if let responseError { throw responseError }
+            let dto = try XCTUnwrap(responseDTO)
+            XCTAssertEqual(dto.fileCount, 0)
+            XCTAssertEqual(dto.pendingPaths, ["Sources/App.swift"])
+            XCTAssertNil(dto.unmappedPaths)
+        }
+
+        func testDefaultWorkspaceContextDoesNotBlockOnNewlySubmittedScan() async throws {
+            let logicalRootURL = try makeTemporaryRoot(name: "ContextNonblockingLogical")
+            let worktreeRootURL = try makeTemporaryRoot(name: "ContextNonblockingWorktree")
+            let logicalFileURL = logicalRootURL.appendingPathComponent("Sources/App.swift")
+            let physicalFileURL = worktreeRootURL.appendingPathComponent("Sources/App.swift")
+            try write("struct CanonicalContextType {}\n", to: logicalFileURL)
+            try write("struct WorktreeContextType {}\n", to: physicalFileURL)
+
+            let window = try await makeWindow(root: logicalRootURL)
+            defer { WindowStatesManager.shared.unregisterWindowState(window) }
+            let store = window.workspaceFileContextStore
+            let logicalRoot = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(
+                in: window,
+                path: logicalRootURL.path
+            )
+            let worktreeRoot = try await store.loadRoot(path: worktreeRootURL.path, kind: .sessionWorktree)
+            let projection = makeProjection(logicalRoot: logicalRoot, physicalRoot: worktreeRoot, worktreeID: "nonblocking-context")
+            let lookupContext = WorkspaceLookupContext(rootScope: projection.lookupRootScope, bindingProjection: projection)
+            let file = try await fileRecord(at: physicalFileURL, store: store, rootScope: projection.lookupRootScope)
+            let context = MCPServerViewModel.TabContextSnapshot(
+                tabID: UUID(),
+                windowID: window.windowID,
+                workspaceID: window.workspaceManager.activeWorkspace?.id,
+                promptText: "Nonblocking context",
+                selection: StoredSelection(selectedPaths: [logicalFileURL.path], codemapAutoEnabled: false),
+                selectedMetaPromptIDs: [],
+                tabName: "Agent",
+                runID: nil,
+                frozenLookupContext: lookupContext,
+                explicitlyBound: true
+            )
+            let scanGate = AsyncGate()
+            await store.setCodemapScanWillStartHandlerForTesting { scannedFileID in
+                guard scannedFileID == file.id else { return }
+                await scanGate.markStartedAndWaitForRelease()
+            }
+            defer {
+                Task {
+                    await scanGate.release()
+                    await store.setCodemapScanWillStartHandlerForTesting(nil)
+                }
+            }
+
+            let responseCompleted = expectation(description: "default workspace_context returns while scan is gated")
+            var responseDTO: ToolResultDTOs.PromptContextDTO?
+            var responseError: Error?
+            Task { @MainActor in
+                defer { responseCompleted.fulfill() }
+                do {
+                    responseDTO = try await window.mcpServer.buildTabWorkspaceContext(
+                        context: context,
+                        include: ["prompt", "selection", "code", "tokens"],
+                        display: .relative,
+                        activeTabCompatibility: false
+                    )
+                } catch {
+                    responseError = error
+                }
+            }
+
+            await scanGate.waitUntilStarted()
+            await fulfillment(of: [responseCompleted], timeout: 1)
+            if let responseError { throw responseError }
+            let dto = try XCTUnwrap(responseDTO)
+            XCTAssertEqual(dto.codeStructure?.fileCount, 0)
+            XCTAssertEqual(dto.codeStructure?.pendingPaths, ["Sources/App.swift"])
+            XCTAssertNil(dto.codeStructure?.unmappedPaths)
+        }
+
         func testActiveWorktreeScanIsPreservedAndReportedPendingWithoutWaiting() async throws {
             let logicalRootURL = try makeTemporaryRoot(name: "ActiveScanLogical")
             let worktreeRootURL = try makeTemporaryRoot(name: "ActiveScanWorktree")
@@ -124,8 +256,7 @@ final class MCPCodeStructureWorktreeTests: XCTestCase {
                 fromRecords: [file],
                 maxResults: 10,
                 includeUnmappedPaths: false,
-                lookupContext: lookupContext,
-                selfHealTimeout: .seconds(4)
+                lookupContext: lookupContext
             )
             let elapsed = start.duration(to: clock.now)
 
@@ -207,8 +338,7 @@ final class MCPCodeStructureWorktreeTests: XCTestCase {
             fromRecords: [fileA],
             maxResults: 10,
             includeUnmappedPaths: true,
-            lookupContext: WorkspaceLookupContext(rootScope: projectionA.lookupRootScope, bindingProjection: projectionA),
-            selfHealTimeout: .seconds(12)
+            lookupContext: WorkspaceLookupContext(rootScope: projectionA.lookupRootScope, bindingProjection: projectionA)
         )
         XCTAssertTrue(dtoA.content.contains("WorktreeAType"), dtoA.content)
 
@@ -216,8 +346,7 @@ final class MCPCodeStructureWorktreeTests: XCTestCase {
             fromRecords: [fileA, fileB],
             maxResults: 10,
             includeUnmappedPaths: true,
-            lookupContext: WorkspaceLookupContext(rootScope: projectionB.lookupRootScope, bindingProjection: projectionB),
-            selfHealTimeout: .seconds(12)
+            lookupContext: WorkspaceLookupContext(rootScope: projectionB.lookupRootScope, bindingProjection: projectionB)
         )
 
         XCTAssertEqual(dtoB.fileCount, 1)
@@ -255,12 +384,12 @@ final class MCPCodeStructureWorktreeTests: XCTestCase {
             rootScope: projection.lookupRootScope
         )
 
+        _ = try await store.repairMissingCodemapSnapshots(for: [file], timeout: .seconds(12))
         let primed = try await window.mcpServer.buildCodeStructureDTO(
             fromRecords: [file],
             maxResults: 10,
             includeUnmappedPaths: true,
-            lookupContext: lookupContext,
-            selfHealTimeout: .seconds(12)
+            lookupContext: lookupContext
         )
         XCTAssertTrue(primed.content.contains("CachedDeletedWorktreeType"), primed.content)
         try FileManager.default.removeItem(at: worktreeRootURL)
@@ -270,8 +399,7 @@ final class MCPCodeStructureWorktreeTests: XCTestCase {
                 fromRecords: [file],
                 maxResults: 10,
                 includeUnmappedPaths: true,
-                lookupContext: lookupContext,
-                selfHealTimeout: .zero
+                lookupContext: lookupContext
             )
             XCTFail("Expected deleted worktree scope to fail closed")
         } catch {
@@ -313,23 +441,20 @@ final class MCPCodeStructureWorktreeTests: XCTestCase {
             )
         }
 
-        let dto = try await window.mcpServer.buildCodeStructureDTO(
+        let lookupContext = WorkspaceLookupContext(rootScope: projection.lookupRootScope, bindingProjection: projection)
+        let pendingDTO = try await window.mcpServer.buildCodeStructureDTO(
             fromRecords: files,
             maxResults: 1,
             includeUnmappedPaths: false,
-            lookupContext: WorkspaceLookupContext(rootScope: projection.lookupRootScope, bindingProjection: projection),
-            selfHealTimeout: .seconds(6)
+            lookupContext: lookupContext
         )
 
-        XCTAssertLessThanOrEqual(dto.fileCount, 1)
-        XCTAssertNil(dto.pendingPaths)
-        XCTAssertEqual(dto.unmappedPaths, ["Sources/File2.swift", "Sources/File3.swift"])
+        XCTAssertEqual(pendingDTO.fileCount, 0)
+        XCTAssertEqual(pendingDTO.pendingPaths, ["Sources/File1.swift"])
+        XCTAssertEqual(pendingDTO.unmappedPaths, ["Sources/File2.swift", "Sources/File3.swift"])
+        _ = try await waitForCodemapSnapshot(store: store, fileID: files[0].id)
         let firstSnapshot = await store.codemapSnapshot(fileID: files[0].id)
-        let secondSnapshot = await store.codemapSnapshot(fileID: files[1].id)
-        let thirdSnapshot = await store.codemapSnapshot(fileID: files[2].id)
         XCTAssertNotNil(firstSnapshot)
-        XCTAssertNil(secondSnapshot)
-        XCTAssertNil(thirdSnapshot)
     }
 
     func testUnavailableWorktreeScopeFailsClosedBeforeCanonicalScan() async throws {
@@ -364,8 +489,7 @@ final class MCPCodeStructureWorktreeTests: XCTestCase {
                 fromRecords: [],
                 maxResults: 10,
                 includeUnmappedPaths: true,
-                lookupContext: WorkspaceLookupContext(rootScope: projection.lookupRootScope, bindingProjection: projection),
-                selfHealTimeout: .zero
+                lookupContext: WorkspaceLookupContext(rootScope: projection.lookupRootScope, bindingProjection: projection)
             )
             XCTFail("Expected unavailable worktree scope to fail closed")
         } catch {

--- a/Tests/RepoPromptTests/MCP/MCPCodeStructureWorktreeTests.swift
+++ b/Tests/RepoPromptTests/MCP/MCPCodeStructureWorktreeTests.swift
@@ -222,6 +222,9 @@ final class MCPCodeStructureWorktreeTests: XCTestCase {
                 path: logicalRootURL.path
             )
             let worktreeRoot = try await store.loadRoot(path: worktreeRootURL.path, kind: .sessionWorktree)
+            let loadedWorktreeService = await store.fileSystemServiceForTesting(rootID: worktreeRoot.id)
+            let worktreeService = try XCTUnwrap(loadedWorktreeService)
+            await worktreeService.stopWatchingForChanges()
             let projection = makeProjection(logicalRoot: logicalRoot, physicalRoot: worktreeRoot, worktreeID: "active")
             let lookupContext = WorkspaceLookupContext(rootScope: projection.lookupRootScope, bindingProjection: projection)
             let file = try await fileRecord(at: fileURL, store: store, rootScope: projection.lookupRootScope)
@@ -544,6 +547,9 @@ final class MCPCodeStructureWorktreeTests: XCTestCase {
             in: window,
             path: root.path
         )
+        addTeardownBlock { @MainActor in
+            await window.workspaceFilesViewModel.cancelAllScans()
+        }
         return window
     }
 

--- a/Tests/RepoPromptTests/MCP/MCPReadSearchLatencyDiagnosticsGuardTests.swift
+++ b/Tests/RepoPromptTests/MCP/MCPReadSearchLatencyDiagnosticsGuardTests.swift
@@ -394,7 +394,6 @@
                 await manager.debugRemoveConnection(connectionID)
             }
             let runID = UUID()
-            await manager.registerToolCallObserver(for: runID) { _ in }
             await manager.registerToolEventObserver(
                 for: runID,
                 observer: ServerNetworkManager.ToolEventObserver(onCalled: { _, _, _ in }, onCompleted: nil)
@@ -414,7 +413,6 @@
                 WindowStatesManager.shared.unregisterWindowState(window)
             }
 
-            let expectedToolCallObserverCount = await manager.toolCallObserverCount()
             let expectedToolEventObserverCount = await manager.toolEventObserverCount()
             let result = await manager.handleDebugDiagnosticsTool(
                 connectionID: connectionID,
@@ -432,10 +430,7 @@
             XCTAssertEqual(runtime["consistency"] as? String, "best_effort")
             XCTAssertEqual((runtime["window_count"] as? NSNumber)?.intValue, 1)
             let observers = try XCTUnwrap(runtime["observers"] as? [String: Any])
-            XCTAssertEqual(
-                (observers["tool_call_observer_count"] as? NSNumber)?.intValue,
-                expectedToolCallObserverCount
-            )
+            XCTAssertNil(observers["tool_call_observer_count"])
             XCTAssertEqual(
                 (observers["tool_event_observer_count"] as? NSNumber)?.intValue,
                 expectedToolEventObserverCount

--- a/Tests/RepoPromptTests/MCP/MCPSelectionReplyFreshnessTests.swift
+++ b/Tests/RepoPromptTests/MCP/MCPSelectionReplyFreshnessTests.swift
@@ -204,6 +204,280 @@ final class MCPSelectionReplyFreshnessTests: XCTestCase {
         XCTAssertEqual(mutationReply.files?.map(\.path), [logicalFile.path])
     }
 
+    #if DEBUG
+        func testActiveMCPTokenRepliesCompleteWhileBackgroundRecountIsBlockedAndCoalesce() async throws {
+            let root = try makeTemporaryRoot(name: "ActiveTokenCache")
+            defer { try? FileManager.default.removeItem(at: root.deletingLastPathComponent()) }
+            let fileURL = root.appendingPathComponent("Cached.swift")
+            try write("struct ActiveCachedTokenType {}\n", to: fileURL)
+
+            let tabID = UUID()
+            let selection = StoredSelection(selectedPaths: [fileURL.path])
+            let (window, workspaceID) = await makeWindow(root: root, tabID: tabID, selection: selection)
+            defer { WindowStatesManager.shared.unregisterWindowState(window) }
+            _ = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(
+                in: window,
+                path: root.path
+            )
+            let tokenCounter = window.promptManager.tokenCountingViewModel
+            await tokenCounter.forceImmediateRecount()
+            let recountGate = TokenAccountingGate()
+            tokenCounter.setBeforeTokenCalculationForTesting {
+                await recountGate.markStartedAndWaitForRelease()
+            }
+            defer {
+                Task { @MainActor in
+                    await recountGate.release()
+                    tokenCounter.setBeforeTokenCalculationForTesting(nil)
+                }
+            }
+
+            let baselineStarts = tokenCounter.tokenCalculationStartCountForTesting()
+            tokenCounter.markDirty(.selection)
+            await recountGate.waitUntilStarted()
+
+            let context = makeContext(
+                window: window,
+                workspaceID: workspaceID,
+                tabID: tabID,
+                selection: selection
+            )
+            let activeResolution = MCPServerViewModel.ResolvedTabContextSnapshot(
+                snapshot: context,
+                usesActiveTabCompatibility: true
+            )
+            let repliesCompleted = expectation(description: "active token replies complete while recount is blocked")
+            var selectionReply: ToolResultDTOs.SelectionReply?
+            var workspaceReply: ToolResultDTOs.PromptContextDTO?
+            var replyError: Error?
+            Task { @MainActor in
+                selectionReply = await window.mcpServer.buildCurrentSelectionReply(
+                    includeBlocks: false,
+                    display: .relative,
+                    resolvedContext: activeResolution,
+                    lookupContext: .visibleWorkspace
+                )
+                do {
+                    workspaceReply = try await window.mcpServer.buildTabWorkspaceContext(
+                        context: context,
+                        include: ["selection", "tokens"],
+                        display: .relative,
+                        activeTabCompatibility: true
+                    )
+                } catch {
+                    replyError = error
+                }
+                repliesCompleted.fulfill()
+            }
+            await fulfillment(of: [repliesCompleted], timeout: 1)
+            if let replyError { throw replyError }
+            let resolvedSelectionReply = try XCTUnwrap(selectionReply)
+            let resolvedWorkspaceReply = try XCTUnwrap(workspaceReply)
+
+            XCTAssertEqual(resolvedSelectionReply.tokenAccounting?.source, "active_tab_published")
+            XCTAssertTrue(resolvedSelectionReply.tokenAccounting?.refreshPending == true)
+            XCTAssertEqual(resolvedWorkspaceReply.tokenAccounting?.source, "active_tab_published")
+            XCTAssertTrue(resolvedWorkspaceReply.tokenAccounting?.refreshPending == true)
+            XCTAssertEqual(tokenCounter.tokenCalculationStartCountForTesting(), baselineStarts + 1)
+
+            await recountGate.release()
+            tokenCounter.setBeforeTokenCalculationForTesting(nil)
+        }
+
+        func testBoundMCPTokenRepliesCompleteWhileContentRefreshIsBlockedAndCoalesce() async throws {
+            let root = try makeTemporaryRoot(name: "BoundTokenCache")
+            defer { try? FileManager.default.removeItem(at: root.deletingLastPathComponent()) }
+            let fileURL = root.appendingPathComponent("Bound.swift")
+            try write("struct BoundCachedTokenType {}\n", to: fileURL)
+
+            let tabID = UUID()
+            let selection = StoredSelection(selectedPaths: [fileURL.path])
+            let (window, workspaceID) = await makeWindow(root: root, tabID: tabID, selection: selection)
+            defer { WindowStatesManager.shared.unregisterWindowState(window) }
+            let loadedRoot = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(
+                in: window,
+                path: root.path
+            )
+            await window.promptManager.tokenCountingViewModel.forceImmediateRecount()
+            let refreshGate = TokenAccountingGate()
+            window.mcpServer.setBeforeVirtualTokenRefreshForTesting {
+                await refreshGate.markStartedAndWaitForRelease()
+            }
+            defer {
+                Task { @MainActor in
+                    await refreshGate.release()
+                    window.mcpServer.setBeforeVirtualTokenRefreshForTesting(nil)
+                }
+            }
+
+            let context = makeContext(
+                window: window,
+                workspaceID: workspaceID,
+                tabID: tabID,
+                selection: selection
+            )
+            let boundResolution = MCPServerViewModel.ResolvedTabContextSnapshot(
+                snapshot: context,
+                usesActiveTabCompatibility: false
+            )
+            let baselineStarts = window.mcpServer.virtualTokenRefreshStartCountForTesting()
+            let firstCompleted = expectation(description: "first bound token reply completes before refresh")
+            var firstReply: ToolResultDTOs.SelectionReply?
+            Task { @MainActor in
+                firstReply = await window.mcpServer.buildCurrentSelectionReply(
+                    includeBlocks: false,
+                    display: .relative,
+                    resolvedContext: boundResolution,
+                    lookupContext: .visibleWorkspace
+                )
+                firstCompleted.fulfill()
+            }
+            await refreshGate.waitUntilStarted()
+            await fulfillment(of: [firstCompleted], timeout: 1)
+
+            let remainingCompleted = expectation(description: "coalesced bound token replies complete while refresh is blocked")
+            var secondReply: ToolResultDTOs.SelectionReply?
+            var workspaceReply: ToolResultDTOs.PromptContextDTO?
+            var replyError: Error?
+            Task { @MainActor in
+                secondReply = await window.mcpServer.buildCurrentSelectionReply(
+                    includeBlocks: false,
+                    display: .relative,
+                    resolvedContext: boundResolution,
+                    lookupContext: .visibleWorkspace
+                )
+                do {
+                    workspaceReply = try await window.mcpServer.buildTabWorkspaceContext(
+                        context: context,
+                        include: ["selection", "tokens"],
+                        display: .relative,
+                        activeTabCompatibility: false
+                    )
+                } catch {
+                    replyError = error
+                }
+                remainingCompleted.fulfill()
+            }
+            await fulfillment(of: [remainingCompleted], timeout: 1)
+            if let replyError { throw replyError }
+            let resolvedFirstReply = try XCTUnwrap(firstReply)
+            let resolvedSecondReply = try XCTUnwrap(secondReply)
+            let resolvedWorkspaceReply = try XCTUnwrap(workspaceReply)
+
+            XCTAssertEqual(resolvedFirstReply.tokenAccounting?.source, "bound_tab_cached_state")
+            XCTAssertEqual(resolvedFirstReply.tokenAccounting?.status, "incomplete")
+            XCTAssertTrue(resolvedFirstReply.tokenAccounting?.refreshPending == true)
+            XCTAssertEqual(resolvedSecondReply.tokenAccounting?.source, "bound_tab_cached_state")
+            XCTAssertEqual(resolvedSecondReply.tokenAccounting?.status, "incomplete")
+            XCTAssertTrue(resolvedSecondReply.tokenAccounting?.refreshPending == true)
+            XCTAssertEqual(resolvedWorkspaceReply.tokenAccounting?.source, "bound_tab_cached_state")
+            XCTAssertEqual(resolvedWorkspaceReply.tokenAccounting?.status, "incomplete")
+            XCTAssertTrue(resolvedWorkspaceReply.tokenAccounting?.refreshPending == true)
+            XCTAssertEqual(window.mcpServer.virtualTokenRefreshStartCountForTesting(), baselineStarts + 1)
+            let refreshStartCount = await refreshGate.startCount()
+            // Identical bound selection and workspace token requests share one signature,
+            // so all cached replies coalesce onto the same background refresh.
+            XCTAssertEqual(refreshStartCount, 1)
+
+            await refreshGate.release()
+            window.mcpServer.setBeforeVirtualTokenRefreshForTesting(nil)
+        }
+
+        func testBoundMCPTokenRefreshesForDistinctSignaturesDoNotCancelEachOther() async throws {
+            let root = try makeTemporaryRoot(name: "BoundTokenSignatures")
+            defer { try? FileManager.default.removeItem(at: root.deletingLastPathComponent()) }
+            let fileURL = root.appendingPathComponent("Bound.swift")
+            try write("struct BoundDistinctSignatureType {}\n", to: fileURL)
+
+            let tabID = UUID()
+            let selection = StoredSelection(selectedPaths: [fileURL.path])
+            let (window, workspaceID) = await makeWindow(root: root, tabID: tabID, selection: selection)
+            defer { WindowStatesManager.shared.unregisterWindowState(window) }
+            _ = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(
+                in: window,
+                path: root.path
+            )
+            await window.promptManager.tokenCountingViewModel.forceImmediateRecount()
+            let refreshGate = TokenAccountingGate()
+            window.mcpServer.setBeforeVirtualTokenRefreshForTesting {
+                await refreshGate.markStartedAndWaitForRelease()
+            }
+            defer {
+                Task { @MainActor in
+                    await refreshGate.release()
+                    window.mcpServer.setBeforeVirtualTokenRefreshForTesting(nil)
+                }
+            }
+
+            let firstContext = makeContext(
+                window: window,
+                workspaceID: workspaceID,
+                tabID: tabID,
+                selection: selection,
+                promptText: "First signature"
+            )
+            let secondContext = makeContext(
+                window: window,
+                workspaceID: workspaceID,
+                tabID: tabID,
+                selection: selection,
+                promptText: "Second signature"
+            )
+            let firstResolution = MCPServerViewModel.ResolvedTabContextSnapshot(
+                snapshot: firstContext,
+                usesActiveTabCompatibility: false
+            )
+            let secondResolution = MCPServerViewModel.ResolvedTabContextSnapshot(
+                snapshot: secondContext,
+                usesActiveTabCompatibility: false
+            )
+            let baselineStarts = window.mcpServer.virtualTokenRefreshStartCountForTesting()
+
+            let firstReply = await window.mcpServer.buildCurrentSelectionReply(
+                includeBlocks: false,
+                display: .relative,
+                resolvedContext: firstResolution,
+                lookupContext: .visibleWorkspace
+            )
+            await refreshGate.waitUntilStarted(count: 1)
+            let secondReply = await window.mcpServer.buildCurrentSelectionReply(
+                includeBlocks: false,
+                display: .relative,
+                resolvedContext: secondResolution,
+                lookupContext: .visibleWorkspace
+            )
+            await refreshGate.waitUntilStarted(count: 2)
+
+            XCTAssertEqual(firstReply.tokenAccounting?.source, "bound_tab_cached_state")
+            XCTAssertEqual(secondReply.tokenAccounting?.source, "bound_tab_cached_state")
+            XCTAssertEqual(window.mcpServer.virtualTokenRefreshStartCountForTesting(), baselineStarts + 2)
+            let refreshStartCount = await refreshGate.startCount()
+            XCTAssertEqual(refreshStartCount, 2)
+
+            await refreshGate.release()
+            window.mcpServer.setBeforeVirtualTokenRefreshForTesting(nil)
+            for _ in 0 ..< 100 where window.mcpServer.virtualTokenRefreshTaskCountForTesting() > 0 {
+                try await Task.sleep(for: .milliseconds(10))
+            }
+            XCTAssertEqual(window.mcpServer.virtualTokenRefreshTaskCountForTesting(), 0)
+
+            let firstCachedReply = await window.mcpServer.buildCurrentSelectionReply(
+                includeBlocks: false,
+                display: .relative,
+                resolvedContext: firstResolution,
+                lookupContext: .visibleWorkspace
+            )
+            let secondCachedReply = await window.mcpServer.buildCurrentSelectionReply(
+                includeBlocks: false,
+                display: .relative,
+                resolvedContext: secondResolution,
+                lookupContext: .visibleWorkspace
+            )
+            XCTAssertEqual(firstCachedReply.tokenAccounting?.source, "bound_tab_cache")
+            XCTAssertEqual(secondCachedReply.tokenAccounting?.source, "bound_tab_cache")
+        }
+    #endif
+
     func testActiveCompatibilityLookupContextPreservesActiveSessionAuthority() async throws {
         let workspaceRoot = try makeTemporaryRoot(name: "CompatibilityWorkspace")
         let worktreeRoot = try makeTemporaryRoot(name: "CompatibilityWorktree")
@@ -316,13 +590,14 @@ final class MCPSelectionReplyFreshnessTests: XCTestCase {
         window: WindowState,
         workspaceID: UUID,
         tabID: UUID,
-        selection: StoredSelection
+        selection: StoredSelection,
+        promptText: String = ""
     ) -> MCPServerViewModel.TabScopedContext {
         MCPServerViewModel.TabContextSnapshot(
             tabID: tabID,
             windowID: window.windowID,
             workspaceID: workspaceID,
-            promptText: "",
+            promptText: promptText,
             selection: selection,
             selectedMetaPromptIDs: [],
             tabName: "Agent",
@@ -365,3 +640,41 @@ final class MCPSelectionReplyFreshnessTests: XCTestCase {
         try content.write(to: url, atomically: true, encoding: .utf8)
     }
 }
+
+#if DEBUG
+    private actor TokenAccountingGate {
+        private var startedCount = 0
+        private var released = false
+        private var startWaiters: [(count: Int, continuation: CheckedContinuation<Void, Never>)] = []
+        private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+
+        func markStartedAndWaitForRelease() async {
+            startedCount += 1
+            let readyWaiters = startWaiters.filter { $0.count <= startedCount }
+            startWaiters.removeAll { $0.count <= startedCount }
+            readyWaiters.forEach { $0.continuation.resume() }
+            guard !released else { return }
+            await withCheckedContinuation { continuation in
+                releaseWaiters.append(continuation)
+            }
+        }
+
+        func waitUntilStarted(count: Int = 1) async {
+            guard startedCount < count else { return }
+            await withCheckedContinuation { continuation in
+                startWaiters.append((count, continuation))
+            }
+        }
+
+        func release() {
+            released = true
+            let waiters = releaseWaiters
+            releaseWaiters.removeAll()
+            waiters.forEach { $0.resume() }
+        }
+
+        func startCount() -> Int {
+            startedCount
+        }
+    }
+#endif

--- a/Tests/RepoPromptTests/MCP/TabContextRoutingTests.swift
+++ b/Tests/RepoPromptTests/MCP/TabContextRoutingTests.swift
@@ -611,6 +611,88 @@ final class TabContextRoutingTests: XCTestCase {
     }
 
     @MainActor
+    func testPollAndSaveDuringSuspendedBlankApplyPreservesStoredBlankState() async throws {
+        let root = try makeTemporaryDirectory(named: "poll-suspended-blank")
+        defer { try? FileManager.default.removeItem(at: root.deletingLastPathComponent()) }
+        let selectedFile = root.appendingPathComponent("version.env")
+        try "VERSION=1\n".write(to: selectedFile, atomically: true, encoding: .utf8)
+
+        let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
+        GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
+        let window = WindowState()
+        WindowStatesManager.shared.registerWindowState(window)
+        GlobalSettingsStore.shared.setMCPAutoStart(previousAutoStart, commit: false)
+        defer { WindowStatesManager.shared.unregisterWindowState(window) }
+
+        let seedTabID = UUID()
+        let blankTabID = UUID()
+        let seedSelection = StoredSelection(
+            selectedPaths: [selectedFile.path],
+            slices: [selectedFile.path: [LineRange(start: 1, end: 1)]],
+            codemapAutoEnabled: false
+        )
+        let workspace = window.workspaceManager.createWorkspace(
+            name: "Suspended blank apply \(UUID().uuidString.prefix(8))",
+            repoPaths: [root.path],
+            ephemeral: true
+        )
+        let initialSwitchResult = await window.workspaceManager.switchWorkspace(
+            to: workspace,
+            saveState: false,
+            reason: "suspendedBlankApplyInitial"
+        )
+        XCTAssertEqual(initialSwitchResult, .switched)
+        let workspaceIndex = try XCTUnwrap(
+            window.workspaceManager.workspaces.firstIndex { $0.id == workspace.id }
+        )
+        window.workspaceManager.workspaces[workspaceIndex].composeTabs = [
+            ComposeTabState(
+                id: seedTabID,
+                name: "Seed",
+                selection: seedSelection,
+                promptText: "seed prompt"
+            ),
+            ComposeTabState(id: blankTabID, name: "Blank")
+        ]
+        window.workspaceManager.workspaces[workspaceIndex].activeComposeTabID = seedTabID
+        let reloadResult = await window.workspaceManager.reactivateWorkspaceAfterReplacement(
+            window.workspaceManager.workspaces[workspaceIndex],
+            reason: "suspendedBlankApplyTabs"
+        )
+        XCTAssertEqual(reloadResult, .switched)
+        _ = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(
+            in: window,
+            path: root.path
+        )
+        await window.workspaceFilesViewModel.applyStoredSelection(seedSelection)
+        window.promptManager.promptText = "seed prompt"
+        XCTAssertEqual(window.workspaceFilesViewModel.snapshotSelection(), seedSelection)
+
+        window.workspaceManager.beginApplyingTabContext(forTabID: blankTabID)
+        defer { window.workspaceManager.endApplyingTabContext(forTabID: blankTabID) }
+        let currentWorkspaceIndex = try XCTUnwrap(
+            window.workspaceManager.workspaces.firstIndex { $0.id == workspace.id }
+        )
+        window.workspaceManager.workspaces[currentWorkspaceIndex].activeComposeTabID = blankTabID
+        window.promptManager.loadComposeTabsFromWorkspace(
+            window.workspaceManager.workspaces[currentWorkspaceIndex]
+        )
+        window.promptManager.promptText = "seed prompt"
+        let blankModifiedBeforePoll = try XCTUnwrap(
+            window.workspaceManager.composeTab(with: blankTabID)?.lastModified
+        )
+
+        window.workspaceManager.markWorkspaceDirty()
+        window.workspaceManager.pollAndSaveState()
+
+        let storedBlank = try XCTUnwrap(window.workspaceManager.composeTab(with: blankTabID))
+        XCTAssertEqual(storedBlank.selection, StoredSelection())
+        XCTAssertEqual(storedBlank.promptText, "")
+        XCTAssertEqual(storedBlank.lastModified, blankModifiedBeforePoll)
+        XCTAssertEqual(window.workspaceFilesViewModel.snapshotSelection(), seedSelection)
+    }
+
+    @MainActor
     func testPersistResolvedTabContextSnapshotPublishesInactiveTabAndLogicalizesWorktreeSelection() async throws {
         let logicalRoot = try makeTemporaryDirectory(named: "logical-root")
         let worktreeRoot = try makeTemporaryDirectory(named: "worktree-root")
@@ -622,6 +704,7 @@ final class TabContextRoutingTests: XCTestCase {
             at: worktreeRoot.appendingPathComponent("Sources", isDirectory: true),
             withIntermediateDirectories: true
         )
+        try "// active".write(to: logicalRoot.appendingPathComponent("Sources/Active.swift"), atomically: true, encoding: .utf8)
         try "// app".write(to: worktreeRoot.appendingPathComponent("Sources/App.swift"), atomically: true, encoding: .utf8)
         try "// dependency".write(to: worktreeRoot.appendingPathComponent("Sources/Dependency.swift"), atomically: true, encoding: .utf8)
         defer {
@@ -1114,6 +1197,215 @@ final class TabContextRoutingTests: XCTestCase {
     }
 
     @MainActor
+    func testExplicitInactiveRestoredAgentContextGetHydratesRoutingAndReturnsStoredSelection() async throws {
+        let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
+        GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
+        let window = WindowState()
+        WindowStatesManager.shared.registerWindowState(window)
+        GlobalSettingsStore.shared.setMCPAutoStart(previousAutoStart, commit: false)
+        defer { WindowStatesManager.shared.unregisterWindowState(window) }
+
+        let root = try makeTemporaryDirectory(named: "inactive-agent-selection-root")
+        defer { try? FileManager.default.removeItem(at: root.deletingLastPathComponent()) }
+        let versionFile = root.appendingPathComponent("version.env")
+        let bootstrapLease = root.appendingPathComponent(
+            "Sources/RepoPrompt/Infrastructure/MCP/MCPBootstrapLease.swift"
+        )
+        try FileManager.default.createDirectory(
+            at: bootstrapLease.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try "VERSION=1\n".write(to: versionFile, atomically: true, encoding: .utf8)
+        try "struct MCPBootstrapLease {}\n".write(to: bootstrapLease, atomically: true, encoding: .utf8)
+
+        let controllerTabID = UUID()
+        let agentTabID = UUID()
+        let agentSessionID = UUID()
+        let expectedPaths = [versionFile.path, bootstrapLease.path]
+        let workspace = window.workspaceManager.createWorkspace(
+            name: "Inactive Agent Restore \(UUID().uuidString.prefix(8))",
+            repoPaths: [root.path],
+            ephemeral: true
+        )
+        let workspaceIndex = try XCTUnwrap(
+            window.workspaceManager.workspaces.firstIndex { $0.id == workspace.id }
+        )
+        window.workspaceManager.workspaces[workspaceIndex].composeTabs = [
+            ComposeTabState(id: controllerTabID, name: "Controller"),
+            ComposeTabState(
+                id: agentTabID,
+                name: "Inactive Agent",
+                activeAgentSessionID: agentSessionID,
+                selection: StoredSelection(
+                    selectedPaths: expectedPaths,
+                    codemapAutoEnabled: false
+                )
+            )
+        ]
+        window.workspaceManager.workspaces[workspaceIndex].activeComposeTabID = controllerTabID
+        let restoredWorkspace = window.workspaceManager.workspaces[workspaceIndex]
+        await window.workspaceManager.switchWorkspace(
+            to: restoredWorkspace,
+            saveState: false,
+            reason: "inactiveAgentExplicitSelectionRestore"
+        )
+        _ = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(
+            in: window,
+            path: root.path
+        )
+
+        XCTAssertEqual(window.workspaceManager.activeWorkspace?.activeComposeTabID, controllerTabID)
+        XCTAssertEqual(
+            try Set(XCTUnwrap(window.workspaceManager.composeTab(with: agentTabID)).selection.selectedPaths),
+            Set(expectedPaths)
+        )
+        XCTAssertEqual(
+            window.agentModeViewModel.worktreeBindingState(
+                forAgentSessionID: agentSessionID,
+                tabID: agentTabID
+            ),
+            .unhydrated
+        )
+
+        let connectionID = UUID()
+        try window.mcpServer.bindTabForConnection(
+            connectionID: connectionID,
+            clientName: "inactive-restored-agent-selection-client",
+            tabID: agentTabID,
+            workspaceID: workspace.id,
+            windowID: window.windowID
+        )
+        let tools = await window.mcpServer.windowMCPTools
+        let manageSelection = try XCTUnwrap(
+            tools.first { $0.name == MCPWindowToolName.manageSelection }
+        )
+        let getValue = try await ServerNetworkManager.withConnectionID(connectionID) {
+            try await manageSelection([
+                "op": .string("get"),
+                "view": .string("files"),
+                "path_display": .string("full")
+            ])
+        }
+
+        XCTAssertEqual(try Set(selectedPaths(from: getValue)), Set(expectedPaths))
+        XCTAssertEqual(
+            try Set(XCTUnwrap(window.workspaceManager.composeTab(with: agentTabID)).selection.selectedPaths),
+            Set(expectedPaths)
+        )
+    }
+
+    @MainActor
+    func testInactiveAgentBindingHydrationDoesNotOverwriteReboundConnectionContext() async throws {
+        let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
+        GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
+        let window = WindowState()
+        WindowStatesManager.shared.registerWindowState(window)
+        GlobalSettingsStore.shared.setMCPAutoStart(previousAutoStart, commit: false)
+        defer { WindowStatesManager.shared.unregisterWindowState(window) }
+
+        let controllerTabID = UUID()
+        let agentTabID = UUID()
+        let initialSessionID = UUID()
+        let replacementSessionID = UUID()
+        let initialRunID = UUID()
+        let replacementRunID = UUID()
+        let connectionID = UUID()
+        let workspace = window.workspaceManager.createWorkspace(
+            name: "Hydration Rebind \(UUID().uuidString.prefix(8))",
+            repoPaths: [],
+            ephemeral: true
+        )
+        let workspaceIndex = try XCTUnwrap(
+            window.workspaceManager.workspaces.firstIndex { $0.id == workspace.id }
+        )
+        window.workspaceManager.workspaces[workspaceIndex].composeTabs = [
+            ComposeTabState(id: controllerTabID, name: "Controller"),
+            ComposeTabState(
+                id: agentTabID,
+                name: "Inactive Agent",
+                activeAgentSessionID: initialSessionID
+            )
+        ]
+        window.workspaceManager.workspaces[workspaceIndex].activeComposeTabID = controllerTabID
+
+        window.mcpServer.registerAgentWorktreeBindingsProvider { sessionID, _ in
+            sessionID == initialSessionID ? .unhydrated : .unavailable
+        }
+        try window.mcpServer.bindTabForConnection(
+            connectionID: connectionID,
+            clientName: "hydration-rebind-client",
+            tabID: agentTabID,
+            workspaceID: workspace.id,
+            windowID: window.windowID,
+            runID: initialRunID
+        )
+        let initialContext = try XCTUnwrap(window.mcpServer.tabContextByConnectionID[connectionID])
+        XCTAssertEqual(initialContext.activeAgentSessionID, initialSessionID)
+        XCTAssertEqual(initialContext.worktreeBindingState, .unhydrated)
+
+        let hydrationStarted = expectation(description: "inactive Agent binding hydration started")
+        let hydrationGate = TabContextHydrationGate()
+        window.mcpServer.registerAgentWorktreeBindingsResolver { sessionID, tabID in
+            XCTAssertEqual(sessionID, initialSessionID)
+            XCTAssertEqual(tabID, agentTabID)
+            hydrationStarted.fulfill()
+            await hydrationGate.waitForRelease()
+            return .hydrated([])
+        }
+        let metadata = MCPServerViewModel.RequestMetadata(
+            connectionID: connectionID,
+            clientName: "hydration-rebind-client",
+            windowID: window.windowID,
+            runPurpose: .agentModeRun
+        )
+        let lookupTask = Task { @MainActor in
+            await window.mcpServer.resolveFileToolLookupContext(from: metadata)
+        }
+        defer {
+            lookupTask.cancel()
+            Task { await hydrationGate.release() }
+        }
+        await fulfillment(of: [hydrationStarted], timeout: 2)
+
+        var replacementTab = try XCTUnwrap(window.workspaceManager.composeTab(with: agentTabID))
+        replacementTab.activeAgentSessionID = replacementSessionID
+        XCTAssertTrue(
+            window.workspaceManager.updateComposeTabStoredOnly(
+                replacementTab,
+                inWorkspaceID: workspace.id
+            )
+        )
+        try window.mcpServer.bindTabForConnection(
+            connectionID: connectionID,
+            clientName: "hydration-rebind-client",
+            tabID: agentTabID,
+            workspaceID: workspace.id,
+            windowID: window.windowID,
+            runID: replacementRunID
+        )
+        let reboundContext = try XCTUnwrap(window.mcpServer.tabContextByConnectionID[connectionID])
+        XCTAssertEqual(reboundContext.activeAgentSessionID, replacementSessionID)
+        XCTAssertEqual(reboundContext.runID, replacementRunID)
+        XCTAssertNotEqual(
+            reboundContext.readFileAutoSelectionGeneration,
+            initialContext.readFileAutoSelectionGeneration
+        )
+        XCTAssertEqual(reboundContext.worktreeBindingState, .unavailable)
+
+        await hydrationGate.release()
+        _ = await lookupTask.value
+
+        let finalContext = try XCTUnwrap(window.mcpServer.tabContextByConnectionID[connectionID])
+        XCTAssertEqual(finalContext.activeAgentSessionID, replacementSessionID)
+        XCTAssertEqual(finalContext.runID, replacementRunID)
+        XCTAssertEqual(
+            finalContext.readFileAutoSelectionGeneration,
+            reboundContext.readFileAutoSelectionGeneration
+        )
+        XCTAssertEqual(finalContext.worktreeBindingState, .unavailable)
+    }
+
+    @MainActor
     func testManageSelectionSetPersistsAcrossConnectionRebindAndWorkspaceSerialization() async throws {
         let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
         GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
@@ -1455,6 +1747,24 @@ final class TabContextRoutingTests: XCTestCase {
             runID: runID,
             explicitlyBound: false
         )
+    }
+}
+
+private actor TabContextHydrationGate {
+    private var isReleased = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func waitForRelease() async {
+        guard !isReleased else { return }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+
+    func release() {
+        guard !isReleased else { return }
+        isReleased = true
+        let pendingWaiters = waiters
+        waiters.removeAll()
+        pendingWaiters.forEach { $0.resume() }
     }
 }
 

--- a/Tests/RepoPromptTests/Prompt/PromptContextAccountingServiceTests.swift
+++ b/Tests/RepoPromptTests/Prompt/PromptContextAccountingServiceTests.swift
@@ -233,6 +233,52 @@ final class PromptContextAccountingServiceTests: XCTestCase {
         XCTAssertEqual(resolution.invalidPaths, [])
     }
 
+    func testCancelledAccountingReadBatchStopsSchedulingRemainingFiles() async throws {
+        #if DEBUG
+            let root = try makeTemporaryRoot(name: "AccountingCancellation")
+            let fileCount = 24
+            var selectedPaths: [String] = []
+            for index in 0 ..< fileCount {
+                let fileURL = root.appendingPathComponent("File\(index).swift")
+                try write("struct File\(index) {}", to: fileURL)
+                selectedPaths.append(fileURL.path)
+            }
+
+            let store = WorkspaceFileContextStore()
+            let rootRecord = try await store.loadRoot(path: root.path)
+            let loadedService = await store.fileSystemServiceForTesting(rootID: rootRecord.id)
+            let service = try XCTUnwrap(loadedService)
+            let gate = AccountingReadCancellationGate()
+            await service.setContentReadChunkHandlerForTesting { _ in
+                await gate.markStartedAndWaitForRelease()
+            }
+
+            let accountingTask = Task {
+                await PromptContextAccountingService().resolveEntries(
+                    selection: StoredSelection(
+                        selectedPaths: selectedPaths,
+                        codemapAutoEnabled: false
+                    ),
+                    store: store,
+                    codeMapUsage: .none
+                )
+            }
+            await gate.waitUntilStarted()
+            accountingTask.cancel()
+            await gate.release()
+            _ = await accountingTask.value
+            try? await Task.sleep(for: .milliseconds(50))
+
+            let startedReadCount = await gate.startedCount()
+            await service.setContentReadChunkHandlerForTesting(nil)
+            XCTAssertLessThanOrEqual(
+                startedReadCount,
+                4,
+                "A cancelled accounting batch should not continue draining all selected files"
+            )
+        #endif
+    }
+
     func testCompleteCodemapResolutionBuildsSingleStaticPathSnapshot() async throws {
         #if DEBUG
             let root = try makeTemporaryRoot(name: "AccountingCompleteCodemapBatch")
@@ -323,3 +369,43 @@ final class PromptContextAccountingServiceTests: XCTestCase {
         )
     }
 }
+
+#if DEBUG
+    private actor AccountingReadCancellationGate {
+        private var count = 0
+        private var released = false
+        private var startWaiters: [CheckedContinuation<Void, Never>] = []
+        private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+
+        func markStartedAndWaitForRelease() async {
+            count += 1
+            let waiters = startWaiters
+            startWaiters.removeAll()
+            waiters.forEach { $0.resume() }
+            guard !released else { return }
+            await withCheckedContinuation { continuation in
+                releaseWaiters.append(continuation)
+            }
+        }
+
+        func waitUntilStarted() async {
+            guard count > 0 else {
+                await withCheckedContinuation { continuation in
+                    startWaiters.append(continuation)
+                }
+                return
+            }
+        }
+
+        func release() {
+            released = true
+            let waiters = releaseWaiters
+            releaseWaiters.removeAll()
+            waiters.forEach { $0.resume() }
+        }
+
+        func startedCount() -> Int {
+            count
+        }
+    }
+#endif

--- a/Tests/RepoPromptTests/Services/FileSystem/FileSystemContentLoadingConcurrencyTests.swift
+++ b/Tests/RepoPromptTests/Services/FileSystem/FileSystemContentLoadingConcurrencyTests.swift
@@ -282,7 +282,7 @@ final class FileSystemContentLoadingConcurrencyTests: XCTestCase {
         }
         let tasks = (0 ..< readCount).map { index in
             Task {
-                try await service.loadContent(ofRelativePath: "File-\(index).txt")
+                try await service.loadContent(ofRelativePath: "File-\(index).txt", workloadClass: .contentSearch)
             }
         }
         let reachedLimit = await enteredCount.waitUntilValue(atLeast: limit)
@@ -521,11 +521,143 @@ final class FileSystemContentLoadingConcurrencyTests: XCTestCase {
             XCTAssertEqual(idle.bulkGrantCount, 1)
         }
 
+        func testContentReadSchedulerReservesPermitForLatencySensitiveReadsAcrossSupportedCapacities() async throws {
+            let backgroundWorkloads: [ContentReadWorkloadClass] = [
+                .codemap,
+                .promptAccounting,
+                .encodingDetection,
+                .unspecified
+            ]
+
+            for capacity in 2 ... 4 {
+                let limiter = ContentReadAsyncLimiter(capacity: capacity, maxQueuedWaiterCount: 12)
+                let backgroundGate = AsyncGate()
+                let backgroundStarted = AsyncCounter()
+                let searchGate = AsyncGate()
+                let interactiveGate = AsyncGate()
+                let backgroundTasks = (0 ..< capacity).map { index in
+                    Task {
+                        try await limiter.withPermit(
+                            workloadClass: backgroundWorkloads[index],
+                            ownerID: UUID()
+                        ) {
+                            _ = await backgroundStarted.incrementAndValue()
+                            await backgroundGate.markStartedAndWaitForRelease()
+                        }
+                    }
+                }
+
+                let capped = await waitForLimiterSnapshot(limiter) {
+                    $0.activeBackgroundPermitCount == capacity - 1 && $0.queuedWaiterCount == 1
+                }
+                XCTAssertEqual(capped.backgroundPermitLimit, capacity - 1)
+                XCTAssertEqual(capped.activePermitCount, capacity - 1)
+                let initialBackgroundStartCount = await backgroundStarted.value()
+                XCTAssertEqual(initialBackgroundStartCount, capacity - 1)
+
+                let search = Task {
+                    try await limiter.withPermit(workloadClass: .contentSearch, ownerID: UUID()) {
+                        await searchGate.markStartedAndWaitForRelease()
+                    }
+                }
+                await searchGate.waitUntilStarted()
+                let searchAdmitted = await limiter.snapshotForTesting()
+                XCTAssertEqual(searchAdmitted.activePermitCount, capacity)
+                XCTAssertEqual(searchAdmitted.activeBackgroundPermitCount, capacity - 1)
+
+                let interactive = Task {
+                    try await limiter.withPermit(workloadClass: .interactiveRead, ownerID: UUID()) {
+                        await interactiveGate.markStartedAndWaitForRelease()
+                    }
+                }
+                _ = await waitForLimiterSnapshot(limiter) { $0.queuedWaiterCount == 2 }
+
+                await searchGate.release()
+                _ = try await search.value
+                await interactiveGate.waitUntilStarted()
+                let interactiveAdmitted = await limiter.snapshotForTesting()
+                XCTAssertEqual(interactiveAdmitted.activePermitCount, capacity)
+                XCTAssertEqual(interactiveAdmitted.activeBackgroundPermitCount, capacity - 1)
+                XCTAssertEqual(interactiveAdmitted.queuedWaiterCount, 1)
+
+                await interactiveGate.release()
+                _ = try await interactive.value
+                let backgroundStillCapped = await waitForLimiterSnapshot(limiter) {
+                    $0.activePermitCount == capacity - 1 && $0.queuedWaiterCount == 1
+                }
+                XCTAssertEqual(backgroundStillCapped.activeBackgroundPermitCount, capacity - 1)
+
+                await backgroundGate.release()
+                let allBackgroundStarted = await backgroundStarted.waitUntilValue(atLeast: capacity)
+                XCTAssertTrue(allBackgroundStarted)
+                for task in backgroundTasks {
+                    _ = try await task.value
+                }
+                let idle = await waitForLimiterSnapshot(limiter) { $0.isIdle }
+                XCTAssertTrue(idle.isIdle)
+                XCTAssertEqual(idle.activeBackgroundPermitCount, 0)
+            }
+        }
+
+        func testCancelledActiveBackgroundReadRetainsPermitUntilBodyReturns() async throws {
+            let limiter = ContentReadAsyncLimiter(capacity: 2, maxQueuedWaiterCount: 4)
+            let firstGate = AsyncGate()
+            let secondGate = AsyncGate()
+            let sensitiveGate = AsyncGate()
+
+            let first = Task {
+                try await limiter.withPermit(workloadClass: .codemap, ownerID: UUID()) {
+                    await firstGate.markStartedAndWaitForRelease()
+                }
+            }
+            await firstGate.waitUntilStarted()
+            first.cancel()
+
+            let second = Task {
+                try await limiter.withPermit(workloadClass: .encodingDetection, ownerID: UUID()) {
+                    await secondGate.markStartedAndWaitForRelease()
+                }
+            }
+            let backgroundQueued = await waitForLimiterSnapshot(limiter) {
+                $0.activeBackgroundPermitCount == 1 && $0.queuedWaiterCount == 1
+            }
+            XCTAssertEqual(backgroundQueued.activePermitCount, 1)
+
+            let sensitive = Task {
+                try await limiter.withPermit(workloadClass: .interactiveRead, ownerID: UUID()) {
+                    await sensitiveGate.markStartedAndWaitForRelease()
+                }
+            }
+            await sensitiveGate.waitUntilStarted()
+            let sensitiveAdmitted = await limiter.snapshotForTesting()
+            XCTAssertEqual(sensitiveAdmitted.activeBackgroundPermitCount, 1)
+
+            await sensitiveGate.release()
+            _ = try await sensitive.value
+            let cancelledBodyStillActive = await limiter.snapshotForTesting()
+            XCTAssertEqual(cancelledBodyStillActive.queuedWaiterCount, 1)
+
+            await firstGate.release()
+            _ = try? await first.value
+            await secondGate.waitUntilStarted()
+            let secondAdmitted = await limiter.snapshotForTesting()
+            XCTAssertEqual(secondAdmitted.activeBackgroundPermitCount, 1)
+            XCTAssertEqual(secondAdmitted.activePermitCount, 1)
+
+            await secondGate.release()
+            _ = try await second.value
+            let idle = await waitForLimiterSnapshot(limiter) { $0.isIdle }
+            XCTAssertTrue(idle.isIdle)
+            XCTAssertEqual(idle.activeBackgroundPermitCount, 0)
+        }
+
         func testContentReadSchedulerPromotesAgedWaitersAheadOfNewInteractiveWork() async throws {
+            let clock = ContentReadTestClock()
             let limiter = ContentReadAsyncLimiter(
                 capacity: 1,
                 maxQueuedWaiterCount: 4,
-                agePromotionNanoseconds: 10_000_000
+                agePromotionNanoseconds: 10_000_000,
+                nowUptimeNanoseconds: { clock.now() }
             )
             let gate = AsyncGate()
             let recorder = AsyncValueRecorder()
@@ -542,7 +674,7 @@ final class FileSystemContentLoadingConcurrencyTests: XCTestCase {
                 }
             }
             _ = await waitForLimiterSnapshot(limiter) { $0.queuedWaiterCount == 1 }
-            try await Task.sleep(nanoseconds: 20_000_000)
+            clock.advance(by: 20_000_000)
             let interactive = Task {
                 try await limiter.withPermit(workloadClass: .interactiveRead, ownerID: UUID()) {
                     await recorder.append(2)
@@ -750,6 +882,23 @@ final class FileSystemContentLoadingConcurrencyTests: XCTestCase {
         } catch {
             XCTFail("Expected invalidRelativePath, got \(error)")
         }
+    }
+}
+
+private final class ContentReadTestClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: UInt64 = 0
+
+    func now() -> UInt64 {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
+    }
+
+    func advance(by nanoseconds: UInt64) {
+        lock.lock()
+        value &+= nanoseconds
+        lock.unlock()
     }
 }
 

--- a/Tests/RepoPromptTests/WorkspaceContext/WorkspaceFileContextStoreTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/WorkspaceFileContextStoreTests.swift
@@ -1196,21 +1196,29 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
 
         func testAcceptedCallbackBeforeActorEntryDelaysBarrierUntilCanonicalApply() async throws {
             let root = try makeTemporaryRoot(name: "AcceptedCallbackCanonicalBarrier")
+            let addedFileURL = root.appendingPathComponent("BeforeActorEntry.swift")
             let store = WorkspaceFileContextStore()
             let record = try await store.loadRoot(path: root.path)
-            try await store.startWatchingRoot(id: record.id)
+            let rootID = record.id
+            let attached = try await store.attachPublisherIngressWithoutStartingWatcherForTesting(rootID: rootID)
+            XCTAssertTrue(attached)
+            try write("accepted", to: addedFileURL)
 
             let sinkGate = AsyncGate()
             let barrierCompleted = AsyncSignal()
-            let rootID = record.id
             await store.setWatcherSinkWillApplyHandler { observedRootID in
                 guard observedRootID == rootID else { return }
                 await sinkGate.markStartedAndWaitForRelease()
             }
+            addTeardownBlock {
+                await sinkGate.release()
+                await store.setWatcherSinkWillApplyHandler(nil)
+                await store.stopWatchingRoot(id: rootID)
+            }
 
             let acceptedPayload = try await store.acceptWatcherPayloadForTesting(
                 rootID: rootID,
-                events: [(absolutePath: "/outside/before-actor-entry.swift", flags: createdFileFlags, eventId: 100)],
+                events: [(absolutePath: addedFileURL.path, flags: createdFileFlags, eventId: 100)],
                 scheduleDrain: false
             )
             let accepted = try XCTUnwrap(acceptedPayload)
@@ -1228,9 +1236,6 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
             let sample = try XCTUnwrap(samples.first)
             XCTAssertEqual(sample.acceptedWatcherWatermark, accepted.rawValue)
             XCTAssertGreaterThanOrEqual(sample.appliedWatcherWatermark, accepted.rawValue)
-
-            await store.setWatcherSinkWillApplyHandler(nil)
-            await store.stopWatchingRoot(id: rootID)
         }
 
         func testBarrierCaptureCutExcludesCallbackAcceptedAfterCaptureUntilNextBarrier() async throws {

--- a/Tests/RepoPromptTests/WorkspaceContext/WorkspaceFileContextStoreTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/WorkspaceFileContextStoreTests.swift
@@ -49,6 +49,202 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
         XCTAssertEqual(scopedA?.location.absolutePath, rootA.appendingPathComponent("shared/file.txt").path)
     }
 
+    func testRepeatedPathLookupReusesStaticSnapshotForUnchangedCatalogGeneration() async throws {
+        #if DEBUG
+            let root = try makeTemporaryRoot(name: "StaticPathSnapshotReuse")
+            let fileURL = root.appendingPathComponent("Sources/App.swift")
+            try write("struct App {}", to: fileURL)
+
+            let store = WorkspaceFileContextStore()
+            _ = try await store.loadRoot(path: root.path)
+
+            EditFlowPerf.resetDebugCaptureForTesting()
+            defer { EditFlowPerf.resetDebugCaptureForTesting() }
+            switch EditFlowPerf.beginDebugCapture(label: "static-path-snapshot-reuse", maxSamples: 100) {
+            case .started:
+                break
+            case .busy:
+                return XCTFail("Performance capture should start")
+            }
+
+            let first = await store.lookupPath("Sources/App.swift", rootScope: .visibleWorkspace)
+            let second = await store.lookupPath("Sources/App.swift", rootScope: .visibleWorkspace)
+            let capture = EditFlowPerf.debugCaptureSnapshot(finish: true)
+            let snapshotBuildCount = capture.stages
+                .filter { $0.stageName == String(describing: EditFlowPerf.Stage.ReadFile.pathLookupStaticSnapshotBuild) }
+                .reduce(0) { $0 + $1.sampleCount }
+
+            XCTAssertEqual(first?.file?.standardizedFullPath, fileURL.path)
+            XCTAssertEqual(second?.file?.standardizedFullPath, fileURL.path)
+            XCTAssertEqual(snapshotBuildCount, 1)
+        #endif
+    }
+
+    func testExplicitRootRefsUseDistinctStaticSnapshotsAndDoNotPoisonCanonicalScope() async throws {
+        let rootA = try makeTemporaryRoot(name: "ExplicitSnapshotRootA")
+        let rootB = try makeTemporaryRoot(name: "ExplicitSnapshotRootB")
+        try write("a", to: rootA.appendingPathComponent("shared/file.txt"))
+        try write("b", to: rootB.appendingPathComponent("shared/file.txt"))
+
+        let store = WorkspaceFileContextStore()
+        let recordA = try await store.loadRoot(path: rootA.path)
+        let recordB = try await store.loadRoot(path: rootB.path)
+        let refA = WorkspaceRootRef(id: recordA.id, name: recordA.name, fullPath: recordA.standardizedFullPath)
+        let refB = WorkspaceRootRef(id: recordB.id, name: recordB.name, fullPath: recordB.standardizedFullPath)
+        let request = WorkspacePathLookupRequest(
+            userPath: "shared/file.txt",
+            rootScope: .allLoaded
+        )
+
+        let scopedA = await store.lookupPath(request, rootRefs: [refA])
+        let scopedB = await store.lookupPath(request, rootRefs: [refB])
+        let canonical = await store.lookupPath(request)
+
+        XCTAssertEqual(scopedA?.file?.rootID, recordA.id)
+        XCTAssertEqual(scopedB?.file?.rootID, recordB.id)
+        XCTAssertEqual(canonical?.file?.rootID, recordA.id)
+    }
+
+    func testSessionBoundStaticSnapshotCacheUsesBoundedLRUEviction() async throws {
+        #if DEBUG
+            let worktree = try makeTemporaryRoot(name: "StaticSnapshotLRUWorktree")
+            try write("struct Cached {}", to: worktree.appendingPathComponent("Cached.swift"))
+            let store = WorkspaceFileContextStore()
+            _ = try await store.loadRoot(path: worktree.path, kind: .sessionWorktree)
+            let scopes = (0 ... 16).map { index in
+                WorkspaceLookupRootScope.sessionBoundWorkspace(
+                    canonicalRootPaths: ["/logical/\(index)"],
+                    physicalRootPaths: [worktree.path]
+                )
+            }
+
+            EditFlowPerf.resetDebugCaptureForTesting()
+            defer { EditFlowPerf.resetDebugCaptureForTesting() }
+            switch EditFlowPerf.beginDebugCapture(label: "static-path-snapshot-lru", maxSamples: 100) {
+            case .started:
+                break
+            case .busy:
+                return XCTFail("Performance capture should start")
+            }
+
+            for scope in scopes.prefix(16) {
+                let lookup = await store.lookupPath("Cached.swift", rootScope: scope)
+                XCTAssertNotNil(lookup)
+            }
+            var cacheCount = await store.staticPathMatchSnapshotCacheCountForTesting()
+            XCTAssertEqual(cacheCount, 16)
+            let warmFirst = await store.lookupPath("Cached.swift", rootScope: scopes[0])
+            let inserted = await store.lookupPath("Cached.swift", rootScope: scopes[16])
+            XCTAssertNotNil(warmFirst)
+            XCTAssertNotNil(inserted)
+            cacheCount = await store.staticPathMatchSnapshotCacheCountForTesting()
+            XCTAssertEqual(cacheCount, 16)
+            let retainedFirst = await store.lookupPath("Cached.swift", rootScope: scopes[0])
+            let evictedSecond = await store.lookupPath("Cached.swift", rootScope: scopes[1])
+            XCTAssertNotNil(retainedFirst)
+            XCTAssertNotNil(evictedSecond)
+
+            let capture = EditFlowPerf.debugCaptureSnapshot(finish: true)
+            let snapshotBuildCount = capture.stages
+                .filter { $0.stageName == String(describing: EditFlowPerf.Stage.ReadFile.pathLookupStaticSnapshotBuild) }
+                .reduce(0) { $0 + $1.sampleCount }
+            XCTAssertEqual(snapshotBuildCount, 18)
+            cacheCount = await store.staticPathMatchSnapshotCacheCountForTesting()
+            XCTAssertEqual(cacheCount, 16)
+        #endif
+    }
+
+    func testStaticSnapshotLRUEvictionPreservesRetainedSearchCatalogGeneration() async throws {
+        #if DEBUG
+            let worktree = try makeTemporaryRoot(name: "StaticSnapshotSearchGeneration")
+            try write("struct Cached {}", to: worktree.appendingPathComponent("Cached.swift"))
+            let store = WorkspaceFileContextStore()
+            _ = try await store.loadRoot(path: worktree.path, kind: .sessionWorktree)
+            let scopes = (0 ... 16).map { index in
+                WorkspaceLookupRootScope.sessionBoundWorkspace(
+                    canonicalRootPaths: ["/logical/\(index)"],
+                    physicalRootPaths: [worktree.path]
+                )
+            }
+            let retainedSearchScope = scopes[0]
+
+            startSearchCatalogSnapshotCapture(label: "static-lru-search-generation")
+            defer { EditFlowPerf.resetDebugCaptureForTesting() }
+            let initialSearchSnapshot = await store.searchCatalogSnapshot(rootScope: retainedSearchScope)
+            let initialGenerationState = await store.sessionCatalogGenerationForTesting(scope: retainedSearchScope)
+            XCTAssertEqual(initialGenerationState, initialSearchSnapshot.generation)
+
+            for scope in scopes {
+                let lookup = await store.lookupPath("Cached.swift", rootScope: scope)
+                XCTAssertNotNil(lookup)
+            }
+            let rebuiltStaticLookup = await store.lookupPath("Cached.swift", rootScope: retainedSearchScope)
+            XCTAssertNotNil(rebuiltStaticLookup)
+
+            let generationAfterStaticEviction = await store.sessionCatalogGenerationForTesting(scope: retainedSearchScope)
+            let warmSearchSnapshot = await store.searchCatalogSnapshot(rootScope: retainedSearchScope)
+            XCTAssertEqual(generationAfterStaticEviction, initialSearchSnapshot.generation)
+            XCTAssertEqual(warmSearchSnapshot.generation, initialSearchSnapshot.generation)
+            XCTAssertEqual(warmSearchSnapshot.roots.map(\.id), initialSearchSnapshot.roots.map(\.id))
+            XCTAssertEqual(warmSearchSnapshot.files.map(\.id), initialSearchSnapshot.files.map(\.id))
+
+            let capture = EditFlowPerf.debugCaptureSnapshot(finish: true)
+            let buckets = searchCatalogSnapshotBuckets(capture)
+            let missCount = buckets
+                .filter { $0.sanitizedDimensions.contains("cacheHit=false") }
+                .reduce(0) { $0 + $1.sampleCount }
+            let hitCount = buckets
+                .filter { $0.sanitizedDimensions.contains("cacheHit=true") }
+                .reduce(0) { $0 + $1.sampleCount }
+            XCTAssertEqual(missCount, 1)
+            XCTAssertEqual(hitCount, 1)
+        #endif
+    }
+
+    func testSessionBoundStaticSnapshotInvalidatesForMutationAndRootUnload() async throws {
+        #if DEBUG
+            let worktree = try makeTemporaryRoot(name: "StaticSnapshotInvalidationWorktree")
+            let original = worktree.appendingPathComponent("Original.swift")
+            let added = worktree.appendingPathComponent("Added.swift")
+            try write("struct Original {}", to: original)
+            let store = WorkspaceFileContextStore()
+            let record = try await store.loadRoot(path: worktree.path, kind: .sessionWorktree)
+            let scope = WorkspaceLookupRootScope.sessionBoundWorkspace(
+                canonicalRootPaths: [],
+                physicalRootPaths: [worktree.path]
+            )
+
+            EditFlowPerf.resetDebugCaptureForTesting()
+            defer { EditFlowPerf.resetDebugCaptureForTesting() }
+            switch EditFlowPerf.beginDebugCapture(label: "static-path-snapshot-invalidation", maxSamples: 100) {
+            case .started:
+                break
+            case .busy:
+                return XCTFail("Performance capture should start")
+            }
+
+            let firstOriginal = await store.lookupPath("Original.swift", rootScope: scope)
+            let secondOriginal = await store.lookupPath("Original.swift", rootScope: scope)
+            XCTAssertEqual(firstOriginal?.file?.rootID, record.id)
+            XCTAssertEqual(secondOriginal?.file?.rootID, record.id)
+            try write("struct Added {}", to: added)
+            await store.replayObservedFileSystemDeltas(rootID: record.id, deltas: [.fileAdded("Added.swift")])
+            let addedLookup = await store.lookupPath("Added.swift", rootScope: scope)
+            XCTAssertEqual(addedLookup?.file?.rootID, record.id)
+            await store.unloadRoot(id: record.id)
+            let unloadedLookup = await store.lookupPath("Original.swift", rootScope: scope)
+            XCTAssertNil(unloadedLookup)
+
+            let capture = EditFlowPerf.debugCaptureSnapshot(finish: true)
+            let snapshotBuildCount = capture.stages
+                .filter { $0.stageName == String(describing: EditFlowPerf.Stage.ReadFile.pathLookupStaticSnapshotBuild) }
+                .reduce(0) { $0 + $1.sampleCount }
+            XCTAssertEqual(snapshotBuildCount, 3)
+            let cacheCount = await store.staticPathMatchSnapshotCacheCountForTesting()
+            XCTAssertEqual(cacheCount, 1)
+        #endif
+    }
+
     func testResolvedClipboardPackagingRendersStoreCodemaps() async throws {
         let root = try makeTemporaryRoot(name: "ResolvedClipboard")
         let fileURL = root.appendingPathComponent("A.swift")

--- a/Tests/RepoPromptTests/WorkspaceContext/WorkspaceFileContextStoreTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/WorkspaceFileContextStoreTests.swift
@@ -1222,7 +1222,7 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
                 scheduleDrain: false
             )
             let accepted = try XCTUnwrap(acceptedPayload)
-            let barrierTask = Task {
+            let barrierTask = Task.detached {
                 let samples = await store.awaitAppliedIngressForAllRoots()
                 await barrierCompleted.mark()
                 return samples
@@ -1253,7 +1253,7 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
                 await captureGate.markStartedAndWaitForRelease()
             }
 
-            let firstBarrierTask = Task {
+            let firstBarrierTask = Task.detached {
                 await store.awaitAppliedIngressForAllRoots()
             }
             await captureGate.waitUntilStarted()
@@ -1341,7 +1341,7 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
                 guard observedRootID == rootID else { return }
                 await flushGate.markStartedAndWaitForRelease()
             }
-            let barrierTask = Task {
+            let barrierTask = Task.detached {
                 await store.awaitAppliedIngressForAllRoots()
             }
             await flushGate.waitUntilStarted()

--- a/Tests/RepoPromptTests/Workspaces/WorkspaceSwitchRecoveryTests.swift
+++ b/Tests/RepoPromptTests/Workspaces/WorkspaceSwitchRecoveryTests.swift
@@ -587,6 +587,232 @@ final class WorkspaceSwitchRecoveryTests: XCTestCase {
         XCTAssertEqual(roots.map(\.standardizedFullPath), [rootB.standardizedFileURL.path])
     }
 
+    func testSwitchingFromAThroughDefaultAndBBackToAPreservesHydratedSelection() async throws {
+        let root = try makeTemporaryDirectory(named: "SelectionReplaySwitchRoot")
+        let storage = try makeTemporaryDirectory(named: "SelectionReplaySwitchStorage")
+        defer {
+            try? FileManager.default.removeItem(at: root)
+            try? FileManager.default.removeItem(at: storage)
+        }
+        let fixture = try makeSelectionFixture(root: root, workspaceName: "Selection Replay A", storageDirectory: storage)
+        try writeWorkspace(fixture.workspace, to: storage.appendingPathComponent("workspace.json"))
+
+        let composition = makeComposition()
+        let manager = composition.workspaceManager
+        await manager.awaitInitialized()
+        manager.workspaces.append(fixture.workspace)
+
+        let initialResult = await manager.switchWorkspace(to: fixture.workspace, saveState: false)
+        XCTAssertTrue(initialResult.didSwitch)
+        assertSelectionFixture(fixture, composition: composition)
+
+        let defaultWorkspace = try XCTUnwrap(manager.workspaces.first(where: { $0.isSystemWorkspace || $0.name == "Default" }))
+        let defaultResult = await manager.switchWorkspace(to: defaultWorkspace, saveState: false)
+        XCTAssertTrue(defaultResult.didSwitch)
+        let returnFromDefaultResult = await manager.switchWorkspace(to: fixture.workspace, saveState: false)
+        XCTAssertTrue(returnFromDefaultResult.didSwitch)
+        assertSelectionFixture(fixture, composition: composition)
+
+        let workspaceB = manager.createWorkspace(
+            name: "Selection Replay B \(UUID().uuidString.prefix(8))",
+            repoPaths: [],
+            ephemeral: true
+        )
+        let workspaceBResult = await manager.switchWorkspace(to: workspaceB, saveState: false)
+        XCTAssertTrue(workspaceBResult.didSwitch)
+        let returnFromBResult = await manager.switchWorkspace(to: fixture.workspace, saveState: false)
+        XCTAssertTrue(returnFromBResult.didSwitch)
+        assertSelectionFixture(fixture, composition: composition)
+
+        try await Task.sleep(nanoseconds: 250_000_000)
+        await manager.pollAndSaveStateAsync()
+        let workspaceURL = manager.workspaceFileURL(for: fixture.workspace)
+        let saved = try WorkspaceManagerViewModel.loadWorkspaceFromFile(at: workspaceURL)
+        let savedTab = try XCTUnwrap(saved.composeTabs.first(where: { $0.id == fixture.tabID }))
+        XCTAssertFalse(savedTab.selection.selectedPaths.isEmpty)
+        XCTAssertEqual(savedTab.selection, fixture.selection)
+    }
+
+    func testInitialDiskBackedActivationAndReopenPreserveHydratedSelection() async throws {
+        let root = try makeTemporaryDirectory(named: "InitialSelectionReplayRoot")
+        let storageRoot = try makeTemporaryDirectory(named: "InitialSelectionReplayStorage")
+        defer {
+            try? FileManager.default.removeItem(at: root)
+            try? FileManager.default.removeItem(at: storageRoot)
+        }
+        let fixture = try makeSelectionFixture(root: root, workspaceName: "Default")
+        try writeIndexedWorkspace(fixture.workspace, baseRoot: storageRoot)
+
+        for _ in 0 ..< 2 {
+            let composition = makeComposition(storageRoot: storageRoot)
+            let manager = composition.workspaceManager
+            await manager.awaitInitialized()
+
+            XCTAssertEqual(manager.activeWorkspaceID, fixture.workspace.id)
+            assertSelectionFixture(fixture, composition: composition)
+
+            try await Task.sleep(nanoseconds: 250_000_000)
+            await manager.pollAndSaveStateAsync()
+            let workspaceURL = manager.workspaceFileURL(for: fixture.workspace)
+            let saved = try WorkspaceManagerViewModel.loadWorkspaceFromFile(at: workspaceURL)
+            let savedTab = try XCTUnwrap(saved.composeTabs.first(where: { $0.id == fixture.tabID }))
+            XCTAssertFalse(savedTab.selection.selectedPaths.isEmpty)
+            XCTAssertEqual(savedTab.selection, fixture.selection)
+        }
+    }
+
+    func testRestoreActivationPreservesAgentCanonicalSelectionFromBlankTransientUI() async throws {
+        let root = try makeTemporaryDirectory(named: "AgentSelectionRestoreRoot")
+        let storage = try makeTemporaryDirectory(named: "AgentSelectionRestoreStorage")
+        defer {
+            try? FileManager.default.removeItem(at: root)
+            try? FileManager.default.removeItem(at: storage)
+        }
+
+        let versionFile = root.appendingPathComponent("version.env")
+        let bootstrapLease = root.appendingPathComponent(
+            "Sources/RepoPrompt/Infrastructure/MCP/MCPBootstrapLease.swift"
+        )
+        try FileManager.default.createDirectory(
+            at: bootstrapLease.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try "VERSION=1\n".write(to: versionFile, atomically: true, encoding: .utf8)
+        try "struct MCPBootstrapLease {}\n".write(
+            to: bootstrapLease,
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let tabID = UUID()
+        let selection = StoredSelection(
+            selectedPaths: [versionFile.path, bootstrapLease.path],
+            codemapAutoEnabled: false
+        )
+        let tab = ComposeTabState(
+            id: tabID,
+            name: "Persisted Agent",
+            activeAgentSessionID: UUID(),
+            selection: selection
+        )
+        let workspace = WorkspaceModel(
+            name: "Agent Selection Restore",
+            repoPaths: [root.path],
+            customStoragePath: storage,
+            composeTabs: [tab],
+            activeComposeTabID: tabID
+        )
+        try writeWorkspace(workspace, to: storage.appendingPathComponent("workspace.json"))
+
+        let composition = makeComposition()
+        let manager = composition.workspaceManager
+        await manager.awaitInitialized()
+        manager.workspaces.append(workspace)
+
+        var injectedBlankSnapshot = false
+        manager.setWorkspaceSwitchPhaseDidChangeHandlerForTesting { phase in
+            guard phase == .hydratingRoots, !injectedBlankSnapshot else { return }
+            injectedBlankSnapshot = true
+            XCTAssertTrue(composition.workspaceFilesViewModel.snapshotSelection().selectedPaths.isEmpty)
+            manager.publishActiveComposeTabSnapshot(commitToMemory: true)
+        }
+        let result = await manager.switchWorkspace(
+            to: workspace,
+            saveState: false,
+            reason: "agentSelectionRestoreRace"
+        )
+        manager.setWorkspaceSwitchPhaseDidChangeHandlerForTesting(nil)
+
+        XCTAssertEqual(result, .switched)
+        XCTAssertTrue(injectedBlankSnapshot)
+        XCTAssertEqual(manager.composeTab(with: tabID)?.selection, selection)
+        XCTAssertEqual(
+            Set(composition.workspaceFilesViewModel.snapshotSelection().selectedPaths),
+            Set(selection.selectedPaths)
+        )
+        let routingSnapshot = try XCTUnwrap(
+            manager.resolveComposeTabRoutingSnapshot(
+                for: tabID,
+                captureActiveUIState: false
+            )
+        )
+        XCTAssertFalse(routingSnapshot.usesLiveUIState)
+        XCTAssertEqual(
+            Set(routingSnapshot.snapshot.selection.selectedPaths),
+            Set(selection.selectedPaths)
+        )
+
+        try await Task.sleep(nanoseconds: 300_000_000)
+        XCTAssertEqual(
+            try Set(XCTUnwrap(manager.composeTab(with: tabID)).selection.selectedPaths),
+            Set(selection.selectedPaths)
+        )
+
+        manager.markWorkspaceDirty()
+        await manager.pollAndSaveStateAsync()
+        let saved = try WorkspaceManagerViewModel.loadWorkspaceFromFile(
+            at: manager.workspaceFileURL(for: workspace)
+        )
+        XCTAssertEqual(
+            try Set(XCTUnwrap(saved.composeTabs.first(where: { $0.id == tabID })).selection.selectedPaths),
+            Set(selection.selectedPaths)
+        )
+    }
+
+    func testPostHydrationReplayPreservesNewerCanonicalSelection() async throws {
+        let root = try makeTemporaryDirectory(named: "NewerCanonicalSelectionRoot")
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let originalFile = root.appendingPathComponent("Original.swift")
+        let newerFile = root.appendingPathComponent("Newer.swift")
+        try "let original = true\n".write(to: originalFile, atomically: true, encoding: .utf8)
+        try "let newer = true\n".write(to: newerFile, atomically: true, encoding: .utf8)
+
+        let tabID = UUID()
+        let originalSelection = StoredSelection(
+            selectedPaths: [originalFile.path],
+            codemapAutoEnabled: false
+        )
+        let newerSelection = StoredSelection(
+            selectedPaths: [newerFile.path],
+            codemapAutoEnabled: false
+        )
+        let workspace = WorkspaceModel(
+            name: "Newer Canonical Selection",
+            repoPaths: [root.path],
+            ephemeralFlag: true,
+            composeTabs: [ComposeTabState(id: tabID, selection: originalSelection)],
+            activeComposeTabID: tabID
+        )
+
+        let composition = makeComposition()
+        let manager = composition.workspaceManager
+        await manager.awaitInitialized()
+        manager.workspaces.append(workspace)
+
+        var updatedCanonicalSelection = false
+        manager.setWorkspaceSwitchPhaseDidChangeHandlerForTesting { phase in
+            guard phase == .hydratingRoots, !updatedCanonicalSelection else { return }
+            updatedCanonicalSelection = true
+            guard var updatedTab = manager.composeTab(with: tabID) else {
+                return XCTFail("Expected active compose tab during hydration")
+            }
+            updatedTab.selection = newerSelection
+            XCTAssertTrue(manager.updateComposeTabStoredOnly(updatedTab, inWorkspaceID: workspace.id))
+        }
+        let result = await manager.switchWorkspace(
+            to: workspace,
+            saveState: false,
+            reason: "newerCanonicalSelectionDuringHydration"
+        )
+        manager.setWorkspaceSwitchPhaseDidChangeHandlerForTesting(nil)
+
+        XCTAssertEqual(result, .switched)
+        XCTAssertTrue(updatedCanonicalSelection)
+        XCTAssertEqual(manager.composeTab(with: tabID)?.selection, newerSelection)
+        XCTAssertEqual(composition.workspaceFilesViewModel.snapshotSelection(), newerSelection)
+    }
+
     func testWatcherActivationFailureDegradesWorkspaceReadiness() async throws {
         let root = try makeTemporaryDirectory(named: "WatcherActivationFailure")
         defer { try? FileManager.default.removeItem(at: root) }
@@ -717,17 +943,101 @@ final class WorkspaceSwitchRecoveryTests: XCTestCase {
 
     private func makeComposition(
         store: WorkspaceFileContextStore = WorkspaceFileContextStore(),
-        timingPolicy: WorkspaceSwitchTimingPolicy = .production
+        timingPolicy: WorkspaceSwitchTimingPolicy = .production,
+        storageRoot: URL? = nil
     ) -> WindowStateComposition {
         let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
+        let defaults = UserDefaults.standard
+        let previousStoragePath = defaults.string(forKey: "GlobalCustomStorageURL")
         GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
-        defer { GlobalSettingsStore.shared.setMCPAutoStart(previousAutoStart, commit: false) }
+        if let storageRoot {
+            defaults.set(storageRoot.path, forKey: "GlobalCustomStorageURL")
+        }
+        defer {
+            GlobalSettingsStore.shared.setMCPAutoStart(previousAutoStart, commit: false)
+            if let previousStoragePath {
+                defaults.set(previousStoragePath, forKey: "GlobalCustomStorageURL")
+            } else {
+                defaults.removeObject(forKey: "GlobalCustomStorageURL")
+            }
+        }
         return WindowStateCompositionFactory.make(
             windowID: -900 - Int.random(in: 1 ... 99),
             deferredInitialAgentSystemWorkspaceRefresh: true,
             sharedMCPService: MCPService(),
             workspaceFileContextStore: store,
             workspaceSwitchTimingPolicy: timingPolicy
+        )
+    }
+
+    private struct SelectionFixture {
+        let workspace: WorkspaceModel
+        let tabID: UUID
+        let selection: StoredSelection
+    }
+
+    private func makeSelectionFixture(
+        root: URL,
+        workspaceName: String,
+        storageDirectory: URL? = nil
+    ) throws -> SelectionFixture {
+        let sources = root.appendingPathComponent("Sources", isDirectory: true)
+        try FileManager.default.createDirectory(at: sources, withIntermediateDirectories: true)
+        let selected = sources.appendingPathComponent("Selected.swift")
+        let dependency = sources.appendingPathComponent("Dependency.swift")
+        try "one\ntwo\nthree\n".write(to: selected, atomically: true, encoding: .utf8)
+        try "struct Dependency {}\n".write(to: dependency, atomically: true, encoding: .utf8)
+
+        let selection = StoredSelection(
+            selectedPaths: [selected.path],
+            autoCodemapPaths: [dependency.path],
+            codemapAutoEnabled: false
+        )
+        let tab = ComposeTabState(selection: selection)
+        let workspace = WorkspaceModel(
+            name: workspaceName,
+            repoPaths: [root.path],
+            customStoragePath: storageDirectory,
+            composeTabs: [tab],
+            activeComposeTabID: tab.id
+        )
+        return SelectionFixture(
+            workspace: workspace,
+            tabID: tab.id,
+            selection: selection
+        )
+    }
+
+    private func assertSelectionFixture(
+        _ fixture: SelectionFixture,
+        composition: WindowStateComposition,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let actual = composition.workspaceFilesViewModel.snapshotSelection()
+        XCTAssertEqual(actual.selectedPaths, fixture.selection.selectedPaths, file: file, line: line)
+        XCTAssertEqual(actual.autoCodemapPaths, fixture.selection.autoCodemapPaths, file: file, line: line)
+        XCTAssertEqual(actual.codemapAutoEnabled, fixture.selection.codemapAutoEnabled, file: file, line: line)
+    }
+
+    private func writeWorkspace(_ workspace: WorkspaceModel, to url: URL) throws {
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try JSONEncoder().encode(workspace).write(to: url, options: .atomic)
+    }
+
+    private func writeIndexedWorkspace(_ workspace: WorkspaceModel, baseRoot: URL) throws {
+        let workspaceDirectory = baseRoot.appendingPathComponent("Workspace-\(workspace.name)-\(workspace.id.uuidString)")
+        try writeWorkspace(workspace, to: workspaceDirectory.appendingPathComponent("workspace.json"))
+        let entry = WorkspaceIndexEntry(
+            id: workspace.id,
+            name: workspace.name,
+            customStoragePath: workspace.customStoragePath,
+            isSystemWorkspace: workspace.isSystemWorkspace,
+            isHiddenInMenus: workspace.isHiddenInMenus
+        )
+        try JSONEncoder().encode([entry]).write(
+            to: baseRoot.appendingPathComponent("workspacesIndex.json"),
+            options: .atomic
         )
     }
 


### PR DESCRIPTION
## Summary

- reserve content-read capacity for latency-sensitive work and release MCP resource leases earlier
- serve token/context replies from cached canonical state while refreshing expensive codemap/token work asynchronously
- enforce one live helper connection per Agent run and keep tab/session routing isolated
- preserve compose and Agent file selections across workspace hydration, reopen, inactive-tab restoration, and resumed sessions
- acknowledge codemap delivery before background self-healing closes the result gap

## Validation

- `make dev-test` — full suite passed (ticket `ba89e8a5-d846-4973-b8f1-cc33940eb118`)
- `make dev-lint` — passed
- `make dev-swift-build PRODUCT=RepoPrompt` — passed
- `make dev-smoke` — passed against the running CE debug app
- focused `WorkspaceFileContextStoreTests` transition reproductions — passed
- live parallel engineer-Agent selection stress in `repoprompt-ce-live-smoke` — fresh tabs started empty, independent mutations remained isolated, and selection calls stayed responsive
- restart/resume regression for issue #230 — resumed Agent restored the exact persisted selection and expected auto-codemaps

The push preflight completed whitespace, guardrails, outgoing secret scan, and lint. Its redundant full-suite invocation intermittently wedged inside the XCTest harness after an identical 1,465-test prefix; the same committed tree already has the completed full-suite ticket above, and the suspected test transition passes in isolation. No test assertion failed.

The local investigation report under `docs/investigations/` is intentionally not included in this PR.
