### PR TITLE
Refresh approved contributors

### DIFF
--- a/.github/APPROVED_CONTRIBUTORS
+++ b/.github/APPROVED_CONTRIBUTORS
@@ -192,6 +192,7 @@ davidandrewsmith90 pr
 davidarce pr
 davidgovea pr
 davidmansaray pr
+davidrd123 pr
 DavidSchargel pr
 DavidWells pr
 dayvough pr
@@ -202,6 +203,7 @@ desaikarna pr
 designerbjk pr
 devdotbo pr
 dhamaniasad pr
+diegolanda pr
 dillycone pr
 dimifontaine pr
 dineshmatta pr
@@ -230,7 +232,7 @@ eclipsology pr
 eddiekollar pr
 eichert12 pr
 emigal pr
-EmilMN pr
+emil pr
 Empedoclez pr
 ENY66 pr
 enzodesena pr
@@ -556,7 +558,6 @@ redrumkev pr
 redwhitblack pr
 regismesquita pr
 Reksa97 pr
-remarkz007 pr
 resolutionathens pr
 richardreeze pr
 riddhish143 pr
@@ -723,6 +724,7 @@ yerffejytnac pr
 yihuikhuu pr
 Yip-Yip pr
 yjsoon pr
+yoshua0x pr
 youqad pr
 yourDomainAdmin pr
 yug105 pr


### PR DESCRIPTION
Refresh approved contributors from live customer claims.

- contributor count: 738 -> 740
- added: davidrd123, diegolanda, yoshua0x
- corrected: EmilMN -> emil
- removed: remarkz007
- unresolved claim-form GitHub IDs: TeamLandiLTD (organization), Tyschultz7 (not found), hsinskip (not found)
