### PR TITLE
feat(agent-mode): Grok Build CLI ACP provider

### DIFF
--- a/Sources/RepoPrompt/App/Notifications/WorkspaceNotifications.swift
+++ b/Sources/RepoPrompt/App/Notifications/WorkspaceNotifications.swift
@@ -38,4 +38,7 @@ extension Notification.Name {
     /// Posted when Cursor CLI connection status changes
     /// userInfo mirrors `claudeCodeConnectionChanged`
     static let cursorConnectionChanged = Notification.Name("cursorConnectionChanged")
+    /// Posted when Grok CLI connection status changes
+    /// userInfo mirrors `claudeCodeConnectionChanged`
+    static let grokConnectionChanged = Notification.Name("grokConnectionChanged")
 }

--- a/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentModel.swift
@@ -82,6 +82,10 @@ enum AgentModel: String, CaseIterable, Codable {
     case cursorAuto = "auto"
     case cursorComposer2 = "composer-2"
 
+    // Grok Build models
+    case grokComposer25Fast = "grok-composer-2.5-fast"
+    case grokBuild = "grok-build"
+
     /// Default (no model specified)
     case defaultModel = "default"
 
@@ -125,6 +129,8 @@ enum AgentModel: String, CaseIterable, Codable {
         case .customClaudeCompatible: "CC Custom"
         case .cursorAuto: "Auto"
         case .cursorComposer2: "Composer 2"
+        case .grokComposer25Fast: "Composer 2.5 Fast"
+        case .grokBuild: "Grok Build"
         case .defaultModel: "Default"
         }
     }
@@ -169,6 +175,8 @@ enum AgentModel: String, CaseIterable, Codable {
         case .customClaudeCompatible: "Custom Claude-compatible backend. RepoPrompt does not pass a model flag when configured for no-model behavior."
         case .cursorAuto: "Let Cursor choose the best model automatically. Built-in fallback for Cursor ACP runs when dynamic model metadata is unavailable."
         case .cursorComposer2: "Cursor's Composer 2 model. Available when Cursor exposes it through ACP model metadata."
+        case .grokComposer25Fast: "Grok Composer 2.5 Fast. Recommended fast agent for explore, engineering, and RepoPrompt orchestration."
+        case .grokBuild: "Grok Build model for deep agentic coding and pair-agent work."
         case .defaultModel: "Use the agent's default model. Good starting point when unsure."
         }
     }
@@ -216,6 +224,8 @@ enum AgentModel: String, CaseIterable, Codable {
             [.defaultModel]
         case .cursor:
             [.cursorAuto, .cursorComposer2]
+        case .grok:
+            [.grokComposer25Fast, .grokBuild, .defaultModel]
         case .claudeCodeGLM:
             [.claudeHaiku, .claudeSonnet, .claudeOpus]
         case .kimiCode:

--- a/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentModelCatalog.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentModelCatalog.swift
@@ -6,6 +6,7 @@ enum AgentModelCatalog {
         let codexAvailable: Bool
         let openCodeAvailable: Bool
         let cursorAvailable: Bool
+        let grokAvailable: Bool
         let zaiConfigured: Bool
         let kimiConfigured: Bool
         let customClaudeCompatibleConfigured: Bool
@@ -15,6 +16,7 @@ enum AgentModelCatalog {
             codexAvailable: false,
             openCodeAvailable: false,
             cursorAvailable: false,
+            grokAvailable: false,
             zaiConfigured: false,
             kimiConfigured: false,
             customClaudeCompatibleConfigured: false
@@ -26,6 +28,7 @@ enum AgentModelCatalog {
                 codexAvailable: codexAvailable && providers.contains(.codex),
                 openCodeAvailable: false,
                 cursorAvailable: cursorAvailable && providers.contains(.cursor),
+                grokAvailable: grokAvailable && providers.contains(.grok),
                 zaiConfigured: zaiConfigured && providers.contains(.claudeCode),
                 kimiConfigured: kimiConfigured && providers.contains(.claudeCode),
                 customClaudeCompatibleConfigured: customClaudeCompatibleConfigured && providers.contains(.claudeCode)
@@ -39,6 +42,7 @@ enum AgentModelCatalog {
                 codexAvailable: true,
                 openCodeAvailable: true,
                 cursorAvailable: false,
+                grokAvailable: false,
                 zaiConfigured: backendIsAvailable(.glmZAI, store: store),
                 kimiConfigured: backendIsAvailable(.kimi, store: store),
                 customClaudeCompatibleConfigured: backendIsAvailable(.custom, store: store)
@@ -50,6 +54,7 @@ enum AgentModelCatalog {
             codexAvailable: Bool = true,
             openCodeAvailable: Bool = true,
             cursorAvailable: Bool = false,
+            grokAvailable: Bool = false,
             zaiConfigured: Bool = false,
             kimiConfigured: Bool = false,
             customClaudeCompatibleConfigured: Bool = false
@@ -58,6 +63,7 @@ enum AgentModelCatalog {
             self.codexAvailable = codexAvailable
             self.openCodeAvailable = openCodeAvailable
             self.cursorAvailable = cursorAvailable
+            self.grokAvailable = grokAvailable
             self.zaiConfigured = zaiConfigured
             self.kimiConfigured = kimiConfigured
             self.customClaudeCompatibleConfigured = customClaudeCompatibleConfigured
@@ -80,6 +86,7 @@ enum AgentModelCatalog {
                 codexAvailable: codexAvailable || agentKind == .codexExec,
                 openCodeAvailable: openCodeAvailable || agentKind == .openCode,
                 cursorAvailable: cursorAvailable || agentKind == .cursor,
+                grokAvailable: grokAvailable || agentKind == .grok,
                 zaiConfigured: zaiConfigured || agentKind == .claudeCodeGLM,
                 kimiConfigured: kimiConfigured || agentKind == .kimiCode,
                 customClaudeCompatibleConfigured: customClaudeCompatibleConfigured || agentKind == .customClaudeCompatible
@@ -179,14 +186,15 @@ enum AgentModelCatalog {
         .codexExec,
         .claudeCode,
         .openCode,
-        .cursor
+        .cursor,
+        .grok
     ]
 
     static func selectableAgents(
         availability: AvailabilityContext = .current,
         surface: AgentSelectionSurface = .general
     ) -> [AgentProviderKind] {
-        [.codexExec, .claudeCode, .openCode, .cursor, .claudeCodeGLM, .kimiCode, .customClaudeCompatible]
+        [.codexExec, .claudeCode, .openCode, .cursor, .grok, .claudeCodeGLM, .kimiCode, .customClaudeCompatible]
             .filter { surface.allows($0) && isAgentAvailable($0, availability: availability) }
     }
 
@@ -216,6 +224,8 @@ enum AgentModelCatalog {
             availability.openCodeAvailable
         case .cursor:
             availability.cursorAvailable
+        case .grok:
+            availability.grokAvailable
         }
     }
 
@@ -228,6 +238,9 @@ enum AgentModelCatalog {
         if agentKind == .cursor {
             return AgentModel.cursorAuto.rawValue
         }
+        if agentKind == .grok {
+            return AgentModel.grokComposer25Fast.rawValue
+        }
         if isAgentAvailable(agentKind, availability: availability),
            let preferredModelRaw = resolvedACPDiscoveredModels(for: agentKind)?.preferredModelRaw
         {
@@ -236,6 +249,8 @@ enum AgentModelCatalog {
         switch agentKind {
         case .cursor:
             return AgentModel.cursorAuto.rawValue
+        case .grok:
+            return AgentModel.grokComposer25Fast.rawValue
         case .claudeCode, .claudeCodeGLM, .kimiCode, .customClaudeCompatible:
             return ClaudeCompatibleModelCatalogAdapter.defaultModelRaw(for: agentKind, availability: availability)
                 ?? AgentModel.defaultModel.rawValue
@@ -329,6 +344,11 @@ enum AgentModelCatalog {
             }
             return fallbacks
         }
+        if agentKind == .grok {
+            return AgentModel.modelsForAgent(.grok)
+                .filter { isAvailable($0, for: .grok, availability: availability) }
+                .map { staticOption($0, for: .grok) }
+        }
         if let discoveredOptions = resolvedACPDiscoveredModels(for: agentKind)?.options,
            !discoveredOptions.isEmpty
         {
@@ -347,7 +367,7 @@ enum AgentModelCatalog {
                 availability: availability,
                 includeClaudeEffortVariants: includeClaudeEffortVariants
             ) ?? []
-        case .openCode, .cursor:
+        case .openCode, .cursor, .grok:
             return AgentModel.modelsForAgent(agentKind)
                 .filter { isAvailable($0, for: agentKind, availability: availability) }
                 .map { staticOption($0, for: agentKind) }
@@ -1357,7 +1377,7 @@ enum AgentModelCatalog {
             .kimi
         case .customClaudeCompatible:
             .custom
-        case .claudeCode, .codexExec, .openCode, .cursor:
+        case .claudeCode, .codexExec, .openCode, .cursor, .grok:
             nil
         }
     }
@@ -1560,12 +1580,18 @@ enum AgentModelCatalog {
             availability.kimiConfigured
         case .customClaudeCompatible:
             availability.customClaudeCompatibleConfigured
-        case .claudeCode, .codexExec, .openCode, .cursor:
+        case .claudeCode, .codexExec, .openCode, .cursor, .grok:
             true
         }
     }
 
     private static func canonicalModelRaw(_ rawModel: String, for agentKind: AgentProviderKind) -> String {
+        if agentKind == .grok {
+            if rawModel.trimmingCharacters(in: .whitespacesAndNewlines).caseInsensitiveCompare(AgentModel.grokComposer25Fast.rawValue) == .orderedSame {
+                return AgentModel.grokComposer25Fast.rawValue
+            }
+            return rawModel
+        }
         guard agentKind == .cursor else { return rawModel }
         if rawModel.trimmingCharacters(in: .whitespacesAndNewlines).caseInsensitiveCompare(AgentModel.cursorAuto.rawValue) == .orderedSame {
             return AgentModel.cursorAuto.rawValue
@@ -1802,6 +1828,7 @@ enum AgentModelCatalog {
         switch kind {
         case .explore:
             [
+                SelectionCandidate(agent: .grok, modelRaw: AgentModel.grokComposer25Fast.rawValue),
                 SelectionCandidate(agent: .codexExec, modelRaw: AgentModel.gpt55CodexLow.rawValue),
                 SelectionCandidate(agent: .claudeCode, modelRaw: ClaudeModelSpecifier.encodedRaw(baseModelRaw: AgentModel.claudeSonnet.rawValue, effort: .high)),
                 SelectionCandidate(agent: .claudeCode, modelRaw: AgentModel.claudeHaiku.rawValue),
@@ -1814,6 +1841,7 @@ enum AgentModelCatalog {
             ]
         case .engineer:
             [
+                SelectionCandidate(agent: .grok, modelRaw: AgentModel.grokComposer25Fast.rawValue),
                 SelectionCandidate(agent: .codexExec, modelRaw: AgentModel.gpt55CodexLow.rawValue),
                 SelectionCandidate(agent: .claudeCode, modelRaw: AgentModel.claudeSonnet.rawValue),
                 SelectionCandidate(agent: .claudeCodeGLM, modelRaw: AgentModel.claudeSonnet.rawValue),
@@ -1823,6 +1851,7 @@ enum AgentModelCatalog {
             ]
         case .pair:
             [
+                SelectionCandidate(agent: .grok, modelRaw: AgentModel.grokComposer25Fast.rawValue),
                 SelectionCandidate(agent: .codexExec, modelRaw: AgentModel.gpt55CodexHigh.rawValue),
                 SelectionCandidate(agent: .claudeCode, modelRaw: AgentModel.claudeOpus.rawValue),
                 SelectionCandidate(agent: .claudeCodeGLM, modelRaw: AgentModel.claudeOpus.rawValue),
@@ -1832,6 +1861,7 @@ enum AgentModelCatalog {
             ]
         case .design:
             [
+                SelectionCandidate(agent: .grok, modelRaw: AgentModel.grokComposer25Fast.rawValue),
                 SelectionCandidate(agent: .claudeCode, modelRaw: AgentModel.claudeOpus.rawValue),
                 SelectionCandidate(agent: .claudeCodeGLM, modelRaw: AgentModel.claudeOpus.rawValue),
                 SelectionCandidate(agent: .kimiCode, modelRaw: AgentModel.kimiCode.rawValue),

--- a/Sources/RepoPrompt/Features/AgentMode/Providers/ACP/ACPAgentProvider.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Providers/ACP/ACPAgentProvider.swift
@@ -3,6 +3,7 @@ import Foundation
 enum ACPProviderID: String, Hashable {
     case openCode
     case cursor
+    case grok
 }
 
 enum ACPSupportResult: Equatable {

--- a/Sources/RepoPrompt/Features/AgentMode/Recommendations/AutoRecommendationEngine.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Recommendations/AutoRecommendationEngine.swift
@@ -11,6 +11,7 @@ struct ProviderFlags {
     let claudeCodeConnected: Bool
     let codexConnected: Bool
     let cursorConnected: Bool
+    let grokConnected: Bool
 }
 
 // MARK: - Auto Recommendation Engine
@@ -51,6 +52,7 @@ final class AutoRecommendationEngine {
                 claudeCodeCLI: .notConfigured,
                 codexCLI: .notConfigured,
                 cursorCLI: .notConfigured,
+                grokCLI: .notConfigured,
                 openAI: .notConfigured
             )
         }
@@ -66,7 +68,8 @@ final class AutoRecommendationEngine {
             openAIValid: vm.isOpenAIKeyValid,
             claudeCodeConnected: vm.isClaudeCodeConnected,
             codexConnected: vm.isCodexConnected,
-            cursorConnected: vm.isCursorConnected
+            cursorConnected: vm.isCursorConnected,
+            grokConnected: vm.isGrokConnected
         )
     }
 
@@ -316,6 +319,13 @@ final class AutoRecommendationEngine {
                 rationale: "Claude Code with Sonnet provides strong context building with good balance of speed and quality.",
                 upgradeHint: "For best context building, connect Codex CLI with GPT-5.5 Low. Requires OpenAI Plus/Pro subscription."
             )
+        } else if status.grokCLI == .ready {
+            return ContextBuilderRecommendation(
+                recommendedAgent: .grok,
+                recommendedModel: .grokComposer25Fast,
+                rationale: "Grok CLI with Composer 2.5 Fast can handle context building when Codex or Claude Code are not configured.",
+                upgradeHint: "For best context building, connect Codex CLI with GPT-5.5 Low or Claude Code with Sonnet."
+            )
         } else if status.cursorCLI == .ready {
             return ContextBuilderRecommendation(
                 recommendedAgent: .cursor,
@@ -354,6 +364,7 @@ final class AutoRecommendationEngine {
             claudeCodeCLI: availability.claudeCodeAvailable ? .ready : .notConfigured,
             codexCLI: availability.codexAvailable ? .ready : .notConfigured,
             cursorCLI: availability.cursorAvailable ? .ready : .notConfigured,
+            grokCLI: availability.grokAvailable ? .ready : .notConfigured,
             openAI: .notConfigured
         ).filtered(to: enabledRecommendationProviders)
         if let recommendation = contextBuilderRecommendation(status: status) {
@@ -372,6 +383,8 @@ final class AutoRecommendationEngine {
                 enabledRecommendationProviders.contains(.codex)
             case .cursor:
                 enabledRecommendationProviders.contains(.cursor)
+            case .grok:
+                enabledRecommendationProviders.contains(.grok)
             case .openCode, .claudeCodeGLM, .kimiCode, .customClaudeCompatible:
                 true
             }
@@ -436,6 +449,7 @@ final class AutoRecommendationEngine {
             codexAvailable: status.codexCLI == .ready,
             openCodeAvailable: false,
             cursorAvailable: status.cursorCLI == .ready,
+            grokAvailable: status.grokCLI == .ready,
             zaiConfigured: backendStore.isConfigured(.glmZAI) && backendStore.config(for: .glmZAI).isEnabled && backendStore.config(for: .glmZAI).isValid,
             kimiConfigured: backendStore.isConfigured(.kimi) && backendStore.config(for: .kimi).isEnabled && backendStore.config(for: .kimi).isValid,
             customClaudeCompatibleConfigured: backendStore.isConfigured(.custom) && backendStore.config(for: .custom).isEnabled && backendStore.config(for: .custom).isValid

--- a/Sources/RepoPrompt/Features/AgentMode/Recommendations/RecommendationTypes.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Recommendations/RecommendationTypes.swift
@@ -17,6 +17,7 @@ enum RecommendationProviderKind: String, CaseIterable, Identifiable {
     case claudeCode
     case codex
     case cursor
+    case grok
     case openAI
 
     var id: String {
@@ -28,6 +29,7 @@ enum RecommendationProviderKind: String, CaseIterable, Identifiable {
         case .claudeCode: "Claude Code"
         case .codex: "Codex CLI"
         case .cursor: "Cursor CLI"
+        case .grok: "Grok CLI"
         case .openAI: "OpenAI API"
         }
     }
@@ -37,6 +39,7 @@ enum RecommendationProviderKind: String, CaseIterable, Identifiable {
         case .claudeCode: "Claude"
         case .codex: "Codex"
         case .cursor: "Cursor"
+        case .grok: "Grok"
         case .openAI: "OpenAI"
         }
     }
@@ -55,17 +58,18 @@ struct ProviderStatusSnapshot {
     let claudeCodeCLI: Availability
     let codexCLI: Availability
     let cursorCLI: Availability
+    let grokCLI: Availability
 
     let openAI: Availability
 
     /// Returns true if at least one provider is ready for chat.
     var hasAnyReadyProvider: Bool {
-        [claudeCodeCLI, codexCLI, cursorCLI, openAI].contains(.ready)
+        [claudeCodeCLI, codexCLI, cursorCLI, grokCLI, openAI].contains(.ready)
     }
 
     /// Returns true if any CLI agent is ready.
     var hasAnyCLIAgentReady: Bool {
-        [claudeCodeCLI, codexCLI, cursorCLI].contains(.ready)
+        [claudeCodeCLI, codexCLI, cursorCLI, grokCLI].contains(.ready)
     }
 
     /// Returns a copy with providers outside the enabled set treated as unavailable.
@@ -74,6 +78,7 @@ struct ProviderStatusSnapshot {
             claudeCodeCLI: enabledProviders.contains(.claudeCode) ? claudeCodeCLI : .notConfigured,
             codexCLI: enabledProviders.contains(.codex) ? codexCLI : .notConfigured,
             cursorCLI: enabledProviders.contains(.cursor) ? cursorCLI : .notConfigured,
+            grokCLI: enabledProviders.contains(.grok) ? grokCLI : .notConfigured,
             openAI: enabledProviders.contains(.openAI) ? openAI : .notConfigured
         )
     }

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentModeProviderBindingService.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentModeProviderBindingService.swift
@@ -216,7 +216,7 @@ final class AgentModeProviderBindingService {
                         updateActiveBindings(session)
                     }
                 }
-            case .cursor:
+            case .cursor, .grok:
                 let runtime = runtimePermission(for: session.selectedAgent, profile: session.permissionProfile)
                 guard session.runState.isActive, let controller = session.acpController else { continue }
                 Task { @MainActor in

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentProviderBindingID.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentProviderBindingID.swift
@@ -5,6 +5,7 @@ enum AgentProviderBindingID: String, CaseIterable, Hashable {
     case claude
     case openCode
     case cursor
+    case grok
 
     var displayName: String {
         switch self {
@@ -16,6 +17,8 @@ enum AgentProviderBindingID: String, CaseIterable, Hashable {
             "OpenCode"
         case .cursor:
             "Cursor CLI"
+        case .grok:
+            "Grok CLI"
         }
     }
 }
@@ -31,6 +34,8 @@ extension AgentProviderKind {
             .openCode
         case .cursor:
             .cursor
+        case .grok:
+            .grok
         }
     }
 }

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentProviderBindingModels.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentProviderBindingModels.swift
@@ -18,6 +18,7 @@ enum AgentProviderPermissionLevelID: Hashable {
     case claude(ClaudeAgentToolPreferences.PermissionLevel)
     case openCode(OpenCodeAgentToolPreferences.PermissionLevel)
     case cursor(CursorAgentToolPreferences.PermissionLevel)
+    case grok(GrokAgentToolPreferences.PermissionLevel)
 
     var providerID: AgentProviderBindingID {
         switch self {
@@ -29,6 +30,8 @@ enum AgentProviderPermissionLevelID: Hashable {
             .openCode
         case .cursor:
             .cursor
+        case .grok:
+            .grok
         }
     }
 
@@ -42,6 +45,8 @@ enum AgentProviderPermissionLevelID: Hashable {
             .openCode(.managedDefault)
         case .cursor:
             .cursor(.managedDefault)
+        case .grok:
+            .grok(.alwaysApprove)
         }
     }
 
@@ -55,6 +60,8 @@ enum AgentProviderPermissionLevelID: Hashable {
             OpenCodeAgentToolPreferences.PermissionLevel.allCases.map(AgentProviderPermissionLevelID.openCode)
         case .cursor:
             CursorAgentToolPreferences.PermissionLevel.allCases.map(AgentProviderPermissionLevelID.cursor)
+        case .grok:
+            GrokAgentToolPreferences.PermissionLevel.allCases.map(AgentProviderPermissionLevelID.grok)
         }
     }
 
@@ -73,6 +80,9 @@ enum AgentProviderPermissionLevelID: Hashable {
         case .cursor:
             guard let level = CursorAgentToolPreferences.PermissionLevel(rawValue: raw) else { return nil }
             self = .cursor(level)
+        case .grok:
+            guard let level = GrokAgentToolPreferences.PermissionLevel(rawValue: raw) else { return nil }
+            self = .grok(level)
         }
     }
 
@@ -85,6 +95,8 @@ enum AgentProviderPermissionLevelID: Hashable {
         case let .openCode(level):
             level.rawValue
         case let .cursor(level):
+            level.rawValue
+        case let .grok(level):
             level.rawValue
         }
     }
@@ -99,6 +111,8 @@ enum AgentProviderPermissionLevelID: Hashable {
             level.displayName
         case let .cursor(level):
             level.displayName
+        case let .grok(level):
+            level.displayName
         }
     }
 
@@ -111,6 +125,8 @@ enum AgentProviderPermissionLevelID: Hashable {
         case let .openCode(level):
             level.iconName
         case let .cursor(level):
+            level.iconName
+        case let .grok(level):
             level.iconName
         }
     }
@@ -125,6 +141,8 @@ enum AgentProviderPermissionLevelID: Hashable {
             level.detailText
         case let .cursor(level):
             level.detailText
+        case let .grok(level):
+            level.detailText
         }
     }
 
@@ -137,6 +155,8 @@ enum AgentProviderPermissionLevelID: Hashable {
         case let .openCode(level):
             level.isWarning
         case let .cursor(level):
+            level.isWarning
+        case let .grok(level):
             level.isWarning
         }
     }

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentProviderPermissionProfile.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentProviderPermissionProfile.swift
@@ -144,11 +144,22 @@ extension AgentProviderPermissionProfile {
         }
     }
 
+    func grokPermissionLevel(
+        userConfigured: GrokAgentToolPreferences.PermissionLevel = GrokAgentToolPreferences.permissionLevel()
+    ) -> GrokAgentToolPreferences.PermissionLevel {
+        switch self {
+        case .userConfigured: userConfigured
+        case .mcpSafeDefaults: .alwaysApprove
+        case let .providerOverride(.grok(level)): level
+        case .providerOverride: .alwaysApprove
+        }
+    }
+
     func acpSessionModeID(for agent: AgentProviderKind) -> String? {
         switch agent {
         case .openCode:
             openCodeSessionModeID
-        case .cursor:
+        case .cursor, .grok:
             nil
         case .claudeCode, .claudeCodeGLM, .kimiCode, .customClaudeCompatible, .codexExec:
             nil

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentProviderPreferenceSnapshotStore.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/ProviderBindings/AgentProviderPreferenceSnapshotStore.swift
@@ -135,6 +135,12 @@ final class AgentProviderPreferenceSnapshotStore {
                 autoApproveAllACPToolPermissions: level.autoApprovesACPToolPermissions,
                 acceptsPendingACPApprovalWhenActivated: level.autoApprovesACPToolPermissions
             )
+        case .grok:
+            let level = effectiveGrokPermissionLevel(profile: profile)
+            return AgentProviderRuntimePermissionBinding(
+                autoApproveAllACPToolPermissions: level.autoApprovesACPToolPermissions,
+                acceptsPendingACPApprovalWhenActivated: level.autoApprovesACPToolPermissions
+            )
         }
     }
 
@@ -149,6 +155,8 @@ final class AgentProviderPreferenceSnapshotStore {
             OpenCodeAgentToolPreferences.setPermissionLevel(level, defaults: defaults, secureStore: securePermissions)
         case let .cursor(level):
             CursorAgentToolPreferences.setPermissionLevel(level, defaults: defaults, secureStore: securePermissions)
+        case let .grok(level):
+            GrokAgentToolPreferences.setPermissionLevel(level, defaults: defaults)
         }
         bumpRevision(for: id.providerID)
         return id.providerID
@@ -307,6 +315,26 @@ final class AgentProviderPreferenceSnapshotStore {
                 options: CursorAgentToolPreferences.PermissionLevel.allCases.map { level in
                     AgentPermissionOptionBinding(
                         id: .cursor(level),
+                        title: level.displayName,
+                        iconName: level.iconName,
+                        detailText: level.detailText,
+                        isWarning: level.isWarning,
+                        isSelected: level == effective,
+                        isEnabled: externallyManagedReason == nil
+                    )
+                }
+            )
+        case .grok:
+            let effective = effectiveGrokPermissionLevel(profile: profile)
+            return AgentPermissionChromeBinding(
+                providerID: providerID,
+                displayName: effective.displayName,
+                iconName: effective.iconName,
+                isWarning: effective.isWarning,
+                externallyManagedReason: externallyManagedReason,
+                options: GrokAgentToolPreferences.PermissionLevel.allCases.map { level in
+                    AgentPermissionOptionBinding(
+                        id: .grok(level),
                         title: level.displayName,
                         iconName: level.iconName,
                         detailText: level.detailText,
@@ -476,12 +504,28 @@ final class AgentProviderPreferenceSnapshotStore {
         }
     }
 
+    private func effectiveGrokPermissionLevel(
+        profile: AgentProviderPermissionProfile
+    ) -> GrokAgentToolPreferences.PermissionLevel {
+        switch profile {
+        case .userConfigured:
+            GrokAgentToolPreferences.permissionLevel(defaults: defaults)
+        case .mcpSafeDefaults:
+            .alwaysApprove
+        case let .providerOverride(.grok(level)):
+            level
+        case .providerOverride:
+            .alwaysApprove
+        }
+    }
+
     private static func representativeAgent(for providerID: AgentProviderBindingID) -> AgentProviderKind {
         switch providerID {
         case .codex: .codexExec
         case .claude: .claudeCode
         case .openCode: .openCode
         case .cursor: .cursor
+        case .grok: .grok
         }
     }
 

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Providers/AgentRuntimeProviderService.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Providers/AgentRuntimeProviderService.swift
@@ -40,6 +40,7 @@ enum AgentProviderKind: String, CaseIterable, Hashable {
     case codexExec
     case openCode
     case cursor
+    case grok
     case claudeCodeGLM
     case kimiCode
     case customClaudeCompatible
@@ -48,6 +49,7 @@ enum AgentProviderKind: String, CaseIterable, Hashable {
     static let codexMCPClientID = "codex-mcp-client"
     static let openCodeMCPClientID = "opencode"
     static let cursorMCPClientID = "cursor"
+    static let grokMCPClientID = "grok"
 
     var commandName: String {
         switch self {
@@ -59,6 +61,8 @@ enum AgentProviderKind: String, CaseIterable, Hashable {
             "opencode"
         case .cursor:
             "cursor-agent"
+        case .grok:
+            "grok"
         }
     }
 
@@ -72,6 +76,8 @@ enum AgentProviderKind: String, CaseIterable, Hashable {
             "OpenCode"
         case .cursor:
             "Cursor CLI"
+        case .grok:
+            "Grok CLI"
         case .claudeCodeGLM:
             ClaudeCodeCompatibleBackendStore.shared.config(for: .glmZAI).normalizedDisplayName
         case .kimiCode:
@@ -91,6 +97,8 @@ enum AgentProviderKind: String, CaseIterable, Hashable {
             Self.openCodeMCPClientID
         case .cursor:
             Self.cursorMCPClientID
+        case .grok:
+            Self.grokMCPClientID
         }
     }
 
@@ -100,6 +108,8 @@ enum AgentProviderKind: String, CaseIterable, Hashable {
             .openCode
         case .cursor:
             .cursor
+        case .grok:
+            .grok
         case .claudeCode, .codexExec, .claudeCodeGLM, .kimiCode, .customClaudeCompatible:
             nil
         }
@@ -109,7 +119,7 @@ enum AgentProviderKind: String, CaseIterable, Hashable {
         switch self {
         case .claudeCode, .claudeCodeGLM, .kimiCode, .customClaudeCompatible:
             true
-        case .codexExec, .openCode, .cursor:
+        case .codexExec, .openCode, .cursor, .grok:
             false
         }
     }
@@ -120,14 +130,14 @@ enum AgentProviderKind: String, CaseIterable, Hashable {
 
     var requiresExpectedPIDOwnedAgentModeMCPRouting: Bool {
         switch self {
-        case .claudeCode, .codexExec, .openCode, .cursor, .claudeCodeGLM, .kimiCode, .customClaudeCompatible:
+        case .claudeCode, .codexExec, .openCode, .cursor, .grok, .claudeCodeGLM, .kimiCode, .customClaudeCompatible:
             true
         }
     }
 
     var requiresPrePromptAgentModeMCPRouting: Bool {
         switch self {
-        case .cursor:
+        case .cursor, .grok:
             false
         case .claudeCode, .codexExec, .openCode, .claudeCodeGLM, .kimiCode, .customClaudeCompatible:
             true
@@ -145,6 +155,8 @@ enum AgentProviderKind: String, CaseIterable, Hashable {
             return "OpenCode ACP agent. Interactive Agent Mode uses RepoPrompt MCP tools; headless discovery/delegate runs use RepoPrompt's managed no-native-tools mode."
         case .cursor:
             return "Cursor CLI ACP agent. Uses Cursor's ACP runtime and injects RepoPrompt MCP tools through ACP session configuration."
+        case .grok:
+            return "Grok Build CLI ACP agent. Uses `grok agent stdio` with always-approve tool permissions and injects RepoPrompt MCP tools through ACP session configuration."
         case .claudeCodeGLM:
             let config = ClaudeCodeCompatibleBackendStore.shared.config(for: .glmZAI)
             if case let .claudeSlotMapping(mapping) = config.modelBehavior {
@@ -177,6 +189,8 @@ enum AgentProviderKind: String, CaseIterable, Hashable {
             "opencode_acp"
         case .cursor:
             "cursor_acp"
+        case .grok:
+            "grok_acp"
         }
     }
 
@@ -190,7 +204,7 @@ enum AgentProviderKind: String, CaseIterable, Hashable {
             .kimi
         case .customClaudeCompatible:
             .customCompatible
-        case .codexExec, .openCode, .cursor:
+        case .codexExec, .openCode, .cursor, .grok:
             nil
         }
     }
@@ -290,6 +304,15 @@ final class AgentRuntimeProviderService {
                 Self.logger.debug("Created CursorACPHeadlessAgentProvider")
             }
             return CursorACPHeadlessAgentProvider(config: config, workspacePath: workspacePath)
+        case .grok:
+            let config = GrokAgentConfig(
+                modelString: modelString,
+                enableDebugLogging: Self.enableDebugLogging
+            )
+            if Self.enableDebugLogging {
+                Self.logger.debug("Created GrokACPHeadlessAgentProvider")
+            }
+            return GrokACPHeadlessAgentProvider(config: config, workspacePath: workspacePath)
         }
     }
 }

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentPermissionCapabilitySummaryBuilder.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentPermissionCapabilitySummaryBuilder.swift
@@ -172,6 +172,22 @@ struct AgentPermissionCapabilitySummaryBuilder {
                 approvalModeDescription: level.autoApprovesACPToolPermissions ? "Auto-approve: on" : "Auto-approve: off",
                 warnings: warnings
             )
+        case .grok:
+            let level = grokPermissionLevel(profile: profile)
+            let warnings = level == .alwaysApprove
+                ? ["Grok launches with `--always-approve` and auto-approves ACP tool permissions."]
+                : []
+            return AgentPermissionCapabilitySummary(
+                providerID: providerID,
+                providerName: providerID.displayName,
+                isAvailable: isAvailable,
+                fileMutation: "Auto-approve ACP tools: \(level.autoApprovesACPToolPermissions ? "on" : "off")",
+                shell: "Handled by Grok Build CLI",
+                externalMCP: "Third-party MCP: not supported",
+                search: "Managed by Grok Build CLI",
+                approvalModeDescription: level.autoApprovesACPToolPermissions ? "Always approve: on" : "Always approve: off",
+                warnings: warnings
+            )
         }
     }
 
@@ -193,6 +209,7 @@ struct AgentPermissionCapabilitySummaryBuilder {
         case .claude: availability.claudeCodeAvailable
         case .openCode: availability.openCodeAvailable
         case .cursor: availability.cursorAvailable
+        case .grok: availability.grokAvailable
         }
     }
 
@@ -253,5 +270,9 @@ struct AgentPermissionCapabilitySummaryBuilder {
         case .providerOverride:
             .managedDefault
         }
+    }
+
+    private func grokPermissionLevel(profile: AgentProviderPermissionProfile) -> GrokAgentToolPreferences.PermissionLevel {
+        profile.grokPermissionLevel()
     }
 }

--- a/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionRows.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionRows.swift
@@ -858,6 +858,7 @@ extension AgentProviderKind {
         case .claudeCode, .claudeCodeGLM, .kimiCode, .customClaudeCompatible: "cpu"
         case .openCode: "curlybraces.square"
         case .cursor: "cursorarrow"
+        case .grok: "sparkles"
         }
     }
 }

--- a/Sources/RepoPrompt/Features/AgentMode/Views/RecommendationWizardPopoverView.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/RecommendationWizardPopoverView.swift
@@ -187,6 +187,7 @@ struct RecommendationWizardPopoverView: View {
                 providerRow("Claude Code", status: status.claudeCodeCLI)
                 providerRow("Codex CLI", status: status.codexCLI)
                 providerRow("Cursor CLI", status: status.cursorCLI)
+                providerRow("Grok CLI", status: status.grokCLI)
                 providerRow("OpenAI API", status: status.openAI)
             }
         }
@@ -556,6 +557,7 @@ private struct IntroStepView: View {
                 providerStatusRow("Claude Code", status: status.claudeCodeCLI)
                 providerStatusRow("Codex CLI", status: status.codexCLI)
                 providerStatusRow("Cursor CLI", status: status.cursorCLI)
+                providerStatusRow("Grok CLI", status: status.grokCLI)
                 providerStatusRow("OpenAI API", status: status.openAI)
             }
         }

--- a/Sources/RepoPrompt/Features/Settings/ViewModels/APISettingsViewModel.swift
+++ b/Sources/RepoPrompt/Features/Settings/ViewModels/APISettingsViewModel.swift
@@ -296,6 +296,8 @@ public class APISettingsViewModel: ObservableObject {
     private var openCodeLogCollector: CLIProcessLogCollector?
     // Cursor Agent CLI / ACP
     @Published var isCursorConnected: Bool = UserDefaults.standard.bool(forKey: "CursorCLIConnected")
+    @Published var isGrokConnected: Bool = UserDefaults.standard.bool(forKey: "GrokCLIConnected")
+    @Published var grokError: String?
     @Published var cursorError: String? = nil
     @Published private(set) var availableCursorModelOptions: [AgentModelOption] = []
     private var cursorLogCollector: CLIProcessLogCollector?
@@ -378,6 +380,7 @@ public class APISettingsViewModel: ObservableObject {
             codexAvailable: isCodexConnected,
             openCodeAvailable: isOpenCodeConnected,
             cursorAvailable: isCursorConnected,
+            grokAvailable: isGrokConnected,
             zaiConfigured: compatibleBackendIsActive(.glmZAI),
             kimiConfigured: compatibleBackendIsActive(.kimi),
             customClaudeCompatibleConfigured: compatibleBackendIsActive(.custom)
@@ -408,6 +411,7 @@ public class APISettingsViewModel: ObservableObject {
             $isCodexConnected.map { _ in () }.eraseToAnyPublisher(),
             $isOpenCodeConnected.map { _ in () }.eraseToAnyPublisher(),
             $isCursorConnected.map { _ in () }.eraseToAnyPublisher(),
+            $isGrokConnected.map { _ in () }.eraseToAnyPublisher(),
             $claudeCodeCLIStatus.map { _ in () }.eraseToAnyPublisher(),
             $compatibleBackendConfigs.map { _ in () }.eraseToAnyPublisher(),
             $compatibleBackendSecretPresence.map { _ in () }.eraseToAnyPublisher()
@@ -428,6 +432,7 @@ public class APISettingsViewModel: ObservableObject {
             codexAvailable: isVerifiedContextBuilderProvider(.codexExec) && isCodexConnected,
             openCodeAvailable: isVerifiedContextBuilderProvider(.openCode) && isOpenCodeConnected,
             cursorAvailable: isVerifiedContextBuilderProvider(.cursor) && isCursorConnected,
+            grokAvailable: isVerifiedContextBuilderProvider(.grok) && isGrokConnected,
             zaiConfigured: compatibleBackendIsActive(.glmZAI),
             kimiConfigured: compatibleBackendIsActive(.kimi),
             customClaudeCompatibleConfigured: compatibleBackendIsActive(.custom)
@@ -439,6 +444,7 @@ public class APISettingsViewModel: ObservableObject {
             claudeCodeCLI: recommendationAvailability(isConnected: isClaudeCodeConnected, provider: .claudeCode),
             codexCLI: recommendationAvailability(isConnected: isCodexConnected, provider: .codexExec),
             cursorCLI: recommendationAvailability(isConnected: isCursorConnected, provider: .cursor),
+            grokCLI: recommendationAvailability(isConnected: isGrokConnected, provider: .grok),
             openAI: isOpenAIKeyValid ? .ready : (!openAIApiKey.isEmpty ? .configured : .notConfigured)
         )
     }
@@ -480,6 +486,8 @@ public class APISettingsViewModel: ObservableObject {
             isOpenCodeConnected
         case .cursor:
             isCursorConnected
+        case .grok:
+            isGrokConnected
         case .claudeCodeGLM, .kimiCode, .customClaudeCompatible:
             false
         }
@@ -526,7 +534,8 @@ public class APISettingsViewModel: ObservableObject {
             NotificationCenter.default.publisher(for: .claudeCodeConnectionChanged).map { _ in AgentProviderKind.claudeCode },
             NotificationCenter.default.publisher(for: .codexConnectionChanged).map { _ in AgentProviderKind.codexExec },
             NotificationCenter.default.publisher(for: .openCodeConnectionChanged).map { _ in AgentProviderKind.openCode },
-            NotificationCenter.default.publisher(for: .cursorConnectionChanged).map { _ in AgentProviderKind.cursor }
+            NotificationCenter.default.publisher(for: .cursorConnectionChanged).map { _ in AgentProviderKind.cursor },
+            NotificationCenter.default.publisher(for: .grokConnectionChanged).map { _ in AgentProviderKind.grok }
         ])
         .receive(on: DispatchQueue.main)
         .sink { [weak self] provider in
@@ -549,6 +558,7 @@ public class APISettingsViewModel: ObservableObject {
         isCodexConnected = UserDefaults.standard.bool(forKey: "CodexCLIConnected")
         isOpenCodeConnected = UserDefaults.standard.bool(forKey: "OpenCodeCLIConnected")
         isCursorConnected = UserDefaults.standard.bool(forKey: "CursorCLIConnected")
+        isGrokConnected = UserDefaults.standard.bool(forKey: "GrokCLIConnected")
         guard wasCursorConnected != isCursorConnected else { return }
         if isCursorConnected {
             startCursorModelsSubscriptionIfNeeded(workspacePath: nil)
@@ -1146,6 +1156,7 @@ public class APISettingsViewModel: ObservableObject {
         let shouldValidateCodex = isCodexConnected
         let shouldValidateOpenCode = isOpenCodeConnected
         let shouldValidateCursor = isCursorConnected
+        let shouldValidateGrok = isGrokConnected
 
         let task = Task { @MainActor [weak self] in
             guard let self, !Task.isCancelled, !hasPreparedForWindowClose else { return }
@@ -1157,13 +1168,15 @@ public class APISettingsViewModel: ObservableObject {
             async let codexReady = probeCachedCodexConnection(ifNeeded: shouldValidateCodex)
             async let openCodeReady = probeCachedOpenCodeConnection(ifNeeded: shouldValidateOpenCode)
             async let cursorReady = probeCachedCursorConnection(ifNeeded: shouldValidateCursor)
-            let readiness = await (claudeReady, codexReady, openCodeReady, cursorReady)
+            async let grokReady = probeCachedGrokConnection(ifNeeded: shouldValidateGrok)
+            let readiness = await (claudeReady, codexReady, openCodeReady, cursorReady, grokReady)
             guard !Task.isCancelled, !hasPreparedForWindowClose else { return }
 
             applyContextBuilderProviderValidationResult(readiness.0, provider: .claudeCode)
             applyContextBuilderProviderValidationResult(readiness.1, provider: .codexExec)
             applyContextBuilderProviderValidationResult(readiness.2, provider: .openCode)
             applyContextBuilderProviderValidationResult(readiness.3, provider: .cursor)
+            applyContextBuilderProviderValidationResult(readiness.4, provider: .grok)
             if isCodexConnected, isVerifiedContextBuilderProvider(.codexExec) {
                 startCodexModelsSubscriptionIfNeeded()
             }
@@ -1250,6 +1263,13 @@ public class APISettingsViewModel: ObservableObject {
             return true
         }
         return await CursorACPModelPollingService.shared.refreshNow(workspacePath: nil)
+    }
+
+    private func probeCachedGrokConnection(ifNeeded: Bool) async -> Bool {
+        guard ifNeeded else { return false }
+        let config = GrokAgentConfig(enableDebugLogging: false)
+        let result = try? await GrokACPLaunchResolver().probeSupport(for: config)
+        return result == .supported
     }
 
     private func diagnosticReason(for error: Error) -> APIKeychainAccessDiagnostic.Reason {
@@ -3362,6 +3382,83 @@ public class APISettingsViewModel: ObservableObject {
         )
     }
 
+    // MARK: - Grok CLI / ACP
+
+    func testGrokConnection() async throws -> Bool {
+        let collector = CLIProcessLogCollector()
+        collector.append("Grok Build CLI connection test started")
+        collector.append("Preferred Grok model fallback: \(AgentModel.grokComposer25Fast.rawValue)")
+
+        collector.append("Refreshing login-shell environment cache")
+        await CLIEnvironmentCache.shared.invalidate()
+        collector.append("Starting Grok ACP support preflight")
+
+        do {
+            let config = GrokAgentConfig(enableDebugLogging: false)
+            let support = try await GrokACPLaunchResolver().probeSupport(for: config)
+            guard support == .supported else {
+                let reason = support.reason ?? "Grok ACP preflight failed."
+                throw AIProviderError.invalidConfiguration(detail: reason)
+            }
+
+            isGrokConnected = true
+            setContextBuilderProviderVerified(.grok, verified: true)
+            grokError = nil
+            UserDefaults.standard.set(true, forKey: "GrokCLIConnected")
+            await updateAvailableModels()
+            collector.append("Grok Build CLI marked as connected")
+            NotificationCenter.default.post(
+                name: .grokConnectionChanged,
+                object: nil,
+                userInfo: ["windowID": 0]
+            )
+            return true
+        } catch {
+            collector.append("Connection test threw error: \(error.localizedDescription)")
+            isGrokConnected = false
+            setContextBuilderProviderVerified(.grok, verified: false)
+            grokError = friendlyGrokMessage(for: error)
+            UserDefaults.standard.set(false, forKey: "GrokCLIConnected")
+            await updateAvailableModels()
+            NotificationCenter.default.post(
+                name: .grokConnectionChanged,
+                object: nil,
+                userInfo: ["windowID": 0]
+            )
+            throw error
+        }
+    }
+
+    func disconnectGrok() {
+        isGrokConnected = false
+        setContextBuilderProviderVerified(.grok, verified: false)
+        grokError = nil
+        UserDefaults.standard.set(false, forKey: "GrokCLIConnected")
+        Task {
+            await updateAvailableModels()
+            resetPreferredModelIfNeeded(for: .grok)
+        }
+        NotificationCenter.default.post(
+            name: .grokConnectionChanged,
+            object: nil,
+            userInfo: ["windowID": 0]
+        )
+    }
+
+    private func friendlyGrokMessage(for error: Error) -> String {
+        if let providerError = error as? AIProviderError {
+            switch providerError {
+            case let .invalidConfiguration(detail):
+                return detail
+            case let .apiError(source):
+                return source?.localizedDescription ?? "Unknown Grok Build CLI error"
+            default:
+                return providerError.localizedDescription
+            }
+        }
+        return error.localizedDescription
+    }
+
     private func friendlyCursorMessage(for error: Error) -> String {
         if let providerError = error as? AIProviderError {
             switch providerError {
@@ -3700,6 +3797,7 @@ extension APISettingsViewModel {
         let claudeCodeConnected: Bool
         let codexConnected: Bool
         let cursorConnected: Bool
+        let grokConnected: Bool
     }
 
     /// Get a snapshot of all provider flags for use by other services.
@@ -3709,7 +3807,8 @@ extension APISettingsViewModel {
             openAIValid: isOpenAIKeyValid,
             claudeCodeConnected: isClaudeCodeConnected,
             codexConnected: isCodexConnected,
-            cursorConnected: isCursorConnected
+            cursorConnected: isCursorConnected,
+            grokConnected: isGrokConnected
         )
     }
 }

--- a/Sources/RepoPrompt/Features/Settings/Views/AgentModeGeneralSettingsView.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/AgentModeGeneralSettingsView.swift
@@ -235,6 +235,7 @@ struct AgentModeGeneralSettingsView: View {
         case .codex: apiSettingsVM.isCodexConnected
         case .openCode: apiSettingsVM.isOpenCodeConnected
         case .cursor: apiSettingsVM.isCursorConnected
+        case .grok: apiSettingsVM.isGrokConnected
         }
     }
 

--- a/Sources/RepoPrompt/Features/Settings/Views/AgentProviderPermissionControlsComponents.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/AgentProviderPermissionControlsComponents.swift
@@ -88,7 +88,7 @@ struct AgentProviderPermissionLevelSection: View {
         switch providerID {
         case .codex, .claude: "Permission Level"
         case .openCode: "ACP Session Mode"
-        case .cursor: "ACP Auto-Approve"
+        case .cursor, .grok: "ACP Auto-Approve"
         }
     }
 }

--- a/Sources/RepoPrompt/Features/Settings/Views/CLIProvidersSettingsView.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/CLIProvidersSettingsView.swift
@@ -40,6 +40,7 @@ struct CLIProvidersSettingsView: View {
     @State private var isLoggingIntoCodex = false
     @State private var isLoadingOpenCode = false
     @State private var isLoadingCursor = false
+    @State private var isLoadingGrok = false
     @State private var isLoadingZAI = false
     @State private var showClaudeCodeTraceDump = false
     @State private var showCodexTraceDump = false
@@ -57,6 +58,7 @@ struct CLIProvidersSettingsView: View {
     @State private var isCodexExpanded: Bool = false
     @State private var isOpenCodeExpanded: Bool = false
     @State private var isCursorExpanded: Bool = false
+    @State private var isGrokExpanded: Bool = false
 
     // Per-backend secret text entry buffers (GLM uses viewModel.zaiApiKey directly).
     // SEARCH-HELPER: Claude-Compatible Backends settings, Kimi API key entry, Custom backend key entry
@@ -75,6 +77,7 @@ struct CLIProvidersSettingsView: View {
             || viewModel.isCodexConnected
             || viewModel.isOpenCodeConnected
             || viewModel.isCursorConnected
+            || viewModel.isGrokConnected
     }
 
     private var codexStatusText: String? {
@@ -105,7 +108,7 @@ struct CLIProvidersSettingsView: View {
                         .font(.title2)
                         .fontWeight(.semibold)
 
-                    Text("Primary way to add Agent Mode model support. Connect Claude Code, Codex, OpenCode, or Cursor to leverage your existing subscriptions — OpenCode can also proxy any API key.")
+                    Text("Primary way to add Agent Mode model support. Connect Claude Code, Codex, OpenCode, Cursor, or Grok to leverage your existing subscriptions — OpenCode can also proxy any API key.")
                         .font(.subheadline)
                         .foregroundColor(.secondary)
                         .fixedSize(horizontal: false, vertical: true)
@@ -132,6 +135,7 @@ struct CLIProvidersSettingsView: View {
                 claudeCompatibleBackendsSection
                 openCodeCard
                 cursorCard
+                grokCard
             }
             .padding(16)
         }
@@ -368,6 +372,11 @@ struct CLIProvidersSettingsView: View {
             return level.autoApprovesACPToolPermissions
                 ? "ACP auto-approve: on"
                 : "ACP auto-approve: off"
+        case .grok:
+            let level = GrokAgentToolPreferences.permissionLevel(defaults: defaults)
+            return level.autoApprovesACPToolPermissions
+                ? "ACP always-approve: on"
+                : "ACP always-approve: off"
         }
     }
 
@@ -434,7 +443,7 @@ struct CLIProvidersSettingsView: View {
             } else {
                 permissionControlsUnavailableRow()
             }
-        case .openCode, .cursor:
+        case .openCode, .cursor, .grok:
             EmptyView()
         }
     }
@@ -1866,6 +1875,80 @@ struct CLIProvidersSettingsView: View {
         return hasComposer2 ? "\(base) Composer 2 is available when selected." : "\(base) Auto is the built-in fallback."
     }
 
+    // MARK: - Grok Card
+
+    private var grokCard: some View {
+        providerCard(
+            title: "Grok CLI",
+            subtitle: "Uses Grok Build's ACP runtime (`grok agent stdio`) for Agent Mode and headless tasks. Launches with always-approve and injects RepoPrompt MCP tools.",
+            infoURL: "https://x.ai/cli",
+            isConnected: viewModel.isGrokConnected,
+            isExpanded: $isGrokExpanded
+        ) {
+            VStack(alignment: .leading, spacing: 12) {
+                if viewModel.isGrokConnected {
+                    HStack(spacing: 8) {
+                        Button(action: { testGrokConnection() }) {
+                            if isLoadingGrok {
+                                ProgressView()
+                                    .scaleEffect(0.6)
+                                    .frame(height: 16)
+                            } else {
+                                Label("Test Connection", systemImage: "antenna.radiowaves.left.and.right")
+                            }
+                        }
+                        .disabled(isLoadingGrok)
+                        .buttonStyle(CustomButtonStyle())
+
+                        Spacer()
+
+                        Button(action: { signOutFromGrok() }) {
+                            Text("Sign Out")
+                                .foregroundColor(.secondary)
+                        }
+                        .buttonStyle(CustomButtonStyle())
+                    }
+
+                    Text(grokModelSummary)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    permissionSummaryLinkRow(for: .grok)
+                } else {
+                    HStack(spacing: 10) {
+                        Button(action: { testGrokConnection() }) {
+                            if isLoadingGrok {
+                                ProgressView()
+                                    .scaleEffect(0.6)
+                                    .frame(height: 16)
+                            } else {
+                                Label("Connect", systemImage: "link")
+                            }
+                        }
+                        .disabled(isLoadingGrok)
+                        .buttonStyle(CustomButtonStyle())
+
+                        if let error = viewModel.grokError, !error.isEmpty {
+                            Text(error)
+                                .font(.caption)
+                                .foregroundColor(.red)
+                                .fixedSize(horizontal: false, vertical: true)
+                        } else {
+                            Text("Install with `curl -fsSL https://x.ai/cli/install.sh | bash`. Defaults to Composer 2.5 Fast with always-approve.")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private var grokModelSummary: String {
+        "Composer 2.5 Fast is the default Agent Mode model. Grok Build also exposes grok-build for deeper agentic work."
+    }
+
     // MARK: - Actions
 
     private func validateAndSaveZAIKey() {
@@ -2248,6 +2331,36 @@ struct CLIProvidersSettingsView: View {
         viewModel.disconnectCursor()
         alertMessage = "Signed out from Cursor CLI"
         showCursorTraceDump = false
+        showAlert = true
+        onAPIKeyUpdated?()
+    }
+
+    private func testGrokConnection() {
+        isLoadingGrok = true
+        Task {
+            do {
+                let ok = try await viewModel.testGrokConnection()
+                await MainActor.run {
+                    isLoadingGrok = false
+                    if ok {
+                        alertMessage = "Grok CLI connected successfully."
+                        onAPIKeyUpdated?()
+                    }
+                    showAlert = true
+                }
+            } catch {
+                await MainActor.run {
+                    isLoadingGrok = false
+                    alertMessage = viewModel.grokError ?? error.localizedDescription
+                    showAlert = true
+                }
+            }
+        }
+    }
+
+    private func signOutFromGrok() {
+        viewModel.disconnectGrok()
+        alertMessage = "Signed out from Grok CLI"
         showAlert = true
         onAPIKeyUpdated?()
     }

--- a/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPAgentProviderFactory.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPAgentProviderFactory.swift
@@ -21,6 +21,13 @@ enum ACPAgentProviderFactory {
                     modelString: modelString
                 )
             )
+        case .grok:
+            GrokACPAgentProvider(
+                config: GrokAgentConfig(
+                    modelString: modelString,
+                    enableDebugLogging: AgentRuntimeProviderService.enableDebugLogging
+                )
+            )
         case .claudeCode, .claudeCodeGLM, .kimiCode, .customClaudeCompatible, .codexExec:
             nil
         }

--- a/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPAgentSessionController.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPAgentSessionController.swift
@@ -649,7 +649,7 @@ actor ACPAgentSessionController {
         }
 
         switch provider.providerID {
-        case .openCode, .cursor:
+        case .openCode, .cursor, .grok:
             if let sessionModelFailureReason {
                 throw ControllerError.protocolViolation("malformed modern model config option: \(sessionModelFailureReason)")
             }
@@ -2677,7 +2677,7 @@ actor ACPAgentSessionController {
 
     private func preferredAllowOptionID(for options: [PermissionOption], sessionScoped: Bool) -> String {
         let preferences: [PermissionOptionPreference] = switch provider.providerID {
-        case .openCode, .cursor:
+        case .openCode, .cursor, .grok:
             genericAllowOptionPreferences(sessionScoped: sessionScoped)
         }
         return optionID(for: options, preferences: preferences) ?? options.first?.optionID ?? ""
@@ -2703,7 +2703,7 @@ actor ACPAgentSessionController {
     private func fullAccessAutoApprovalOptionID(for options: [PermissionOption]) -> String? {
         guard autoApproveAllToolPermissions else { return nil }
         switch provider.providerID {
-        case .cursor:
+        case .cursor, .grok:
             return optionID(for: options, preferences: genericAllowOptionPreferences(sessionScoped: true))
         case .openCode:
             return nil
@@ -2748,7 +2748,7 @@ actor ACPAgentSessionController {
         }
 
         let preferences: [PermissionOptionPreference] = switch provider.providerID {
-        case .openCode, .cursor:
+        case .openCode, .cursor, .grok:
             [
                 .optionID("always"),
                 .optionID("allow_always"),
@@ -2940,6 +2940,8 @@ actor ACPAgentSessionController {
                 "RP_CURSOR_RAW_CAPTURE_PATH"
             case .openCode:
                 "RP_OPENCODE_ACP_RAW_CAPTURE_PATH"
+            case .grok:
+                "RP_GROK_ACP_RAW_CAPTURE_PATH"
             }
             let customPath = providerSpecificKey.flatMap { key in
                 env[key]?.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/CLIPathHints.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/CLIPathHints.swift
@@ -7,6 +7,7 @@ enum CLIPathHints {
     static let codex: [String] = CLILaunchProfiles.codex.supplementalSearchPaths
     static let openCode: [String] = CLILaunchProfiles.openCodeProviderSpecificPaths
     static let cursor: [String] = CLILaunchProfiles.cursorProviderSpecificPaths
+    static let grok: [String] = CLILaunchProfiles.grokProviderSpecificPaths
 
     static func nativeDefaultsSupplemented(with providerSpecificPaths: [String]) -> [String] {
         CLILaunchProfiles.nativeDefaultsSupplemented(with: providerSpecificPaths)

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Grok/GrokACPAgentProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Grok/GrokACPAgentProvider.swift
@@ -1,0 +1,133 @@
+import Foundation
+
+struct GrokACPAgentProvider: ACPAgentProvider {
+    private let config: GrokAgentConfig
+    private let repoPromptMCPConfiguration: RepoPromptMCPServerConfiguration
+    private let launchResolver: GrokACPLaunchResolver
+
+    #if DEBUG
+        var test_config: GrokAgentConfig {
+            config
+        }
+    #endif
+
+    init(
+        config: GrokAgentConfig,
+        repoPromptMCPConfiguration: RepoPromptMCPServerConfiguration = .repoPrompt,
+        launchResolver: GrokACPLaunchResolver = GrokACPLaunchResolver()
+    ) {
+        self.config = config
+        self.repoPromptMCPConfiguration = repoPromptMCPConfiguration
+        self.launchResolver = launchResolver
+    }
+
+    var providerID: ACPProviderID {
+        .grok
+    }
+
+    func support(for _: ACPRunRequest) async throws -> ACPSupportResult {
+        try await launchResolver.probeSupport(for: config)
+    }
+
+    func makeLaunchConfiguration(for request: ACPRunRequest) throws -> ACPLaunchConfiguration {
+        let workingDirectory = standardizedWorkingDirectory(from: request.workspacePath)
+        let resolvedLaunch = try launchResolver.resolvedLaunch(for: config)
+        return ACPLaunchConfiguration(
+            providerID: providerID,
+            command: resolvedLaunch.command,
+            arguments: resolvedLaunch.arguments,
+            environment: [:],
+            workingDirectory: workingDirectory,
+            additionalPathHints: resolvedLaunch.additionalPathHints,
+            enableDebugLogging: config.enableDebugLogging,
+            expectedExecutableIdentity: resolvedLaunch.executableIdentity
+        )
+    }
+
+    func makeSessionConfiguration(
+        for request: ACPRunRequest,
+        mcpServer _: RepoPromptMCPServerConfiguration
+    ) throws -> ACPSessionConfiguration {
+        let mode: ACPSessionConfiguration.Mode = if let resume = request.resumeSessionID?.trimmingCharacters(in: .whitespacesAndNewlines),
+                                                    !resume.isEmpty
+        {
+            .load(existingSessionID: resume)
+        } else {
+            .new
+        }
+
+        return try ACPSessionConfiguration(
+            mode: mode,
+            workingDirectory: standardizedWorkingDirectory(from: request.workspacePath),
+            mcpServers: config.includeRepoPromptMCPServer ? [repoPromptMCPConfiguration] : []
+        )
+    }
+
+    func buildPromptBlocks(
+        for message: AgentMessage,
+        request: ACPRunRequest
+    ) throws -> [[String: Any]] {
+        let isFollowUp = request.resumeSessionID?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .isEmpty == false
+        let systemPrompt = message.systemPrompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        let userMessage = message.userMessage.trimmingCharacters(in: .whitespacesAndNewlines)
+        let text: String = if isFollowUp || systemPrompt.isEmpty {
+            userMessage.isEmpty ? message.userMessage : userMessage
+        } else if userMessage.isEmpty {
+            systemPrompt
+        } else {
+            "\(systemPrompt)\n\n\(userMessage)"
+        }
+
+        return try ACPPromptContentBuilder.blocks(
+            text: text,
+            attachments: request.attachments
+        )
+    }
+
+    func normalizeSessionUpdate(
+        _ payload: [String: Any],
+        sessionID _: String
+    ) -> [NormalizedAgentRuntimeEvent] {
+        GrokACPEventNormalizer.normalize(payload)
+    }
+
+    func preferredAuthMethodID(context: ACPAuthenticationContext) -> String? {
+        let envTokenKeys = ["XAI_API_KEY", "GROK_API_KEY"]
+        let hasEnvironmentToken = envTokenKeys.contains { key in
+            context.environment[key]?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .isEmpty == false
+        }
+        guard !hasEnvironmentToken else { return nil }
+        return context.authMethodIDs.first {
+            $0.caseInsensitiveCompare("grok_login") == .orderedSame
+        }
+    }
+
+    func normalizeError(_ error: Error) -> Error {
+        if error is AIProviderError {
+            return error
+        }
+        if let runnerError = error as? CLIProcessRunnerError,
+           case .commandNotFound = runnerError
+        {
+            return AIProviderError.invalidConfiguration(detail: "Grok Build CLI not found. Install from https://x.ai/cli and ensure `grok agent stdio` is available.")
+        }
+        if error is GrokACPLaunchResolutionError || error is ExecutableFileIdentityError {
+            return AIProviderError.invalidConfiguration(detail: error.localizedDescription)
+        }
+        return AIProviderError.apiError(source: error)
+    }
+
+    private func standardizedWorkingDirectory(from workspacePath: String?) throws -> String {
+        if let cwd = workspacePath?.trimmingCharacters(in: .whitespacesAndNewlines), !cwd.isEmpty {
+            return URL(fileURLWithPath: cwd, isDirectory: true).standardizedFileURL.path
+        }
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("RepoPromptGrokACPPreflight", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true, attributes: nil)
+        return url.standardizedFileURL.path
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Grok/GrokACPEventNormalizer.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Grok/GrokACPEventNormalizer.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+enum GrokACPEventNormalizer {
+    static func normalize(_ payload: [String: Any]) -> [NormalizedAgentRuntimeEvent] {
+        ACPDefaultSessionUpdateNormalizer.normalize(payload, providerID: .grok)
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Grok/GrokACPHeadlessAgentProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Grok/GrokACPHeadlessAgentProvider.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+/// Headless/discovery adapter for Grok Build's ACP runtime.
+final class GrokACPHeadlessAgentProvider: HeadlessAgentProvider {
+    typealias ProviderFactory = @Sendable (_ config: GrokAgentConfig) -> any ACPAgentProvider
+    typealias ControllerFactory = ACPHeadlessAgentProviderBridge.ControllerFactory
+
+    private let config: GrokAgentConfig
+    private let bridge: ACPHeadlessAgentProviderBridge
+
+    #if DEBUG
+        var test_config: GrokAgentConfig {
+            config
+        }
+    #endif
+
+    init(
+        config: GrokAgentConfig,
+        workspacePath: String? = nil,
+        providerFactory: ProviderFactory? = nil,
+        controllerFactory: @escaping ControllerFactory = { provider, request, diagnosticSink in
+            try ACPAgentSessionController(
+                provider: provider,
+                runRequest: request,
+                diagnosticSink: diagnosticSink
+            )
+        }
+    ) {
+        self.config = config
+        let resolvedProviderFactory = providerFactory ?? { config in
+            GrokACPAgentProvider(config: config)
+        }
+        bridge = ACPHeadlessAgentProviderBridge(
+            providerName: "Grok",
+            makeProvider: {
+                resolvedProviderFactory(config)
+            },
+            makeRequest: { message, _ in
+                ACPRunRequest(
+                    agentKind: .grok,
+                    modelString: config.modelString,
+                    workspacePath: workspacePath,
+                    resumeSessionID: message.resumeSessionID,
+                    attachments: [],
+                    taskLabelKind: nil,
+                    sessionModeID: nil,
+                    autoApproveAllToolPermissions: config.alwaysApproveToolPermissions
+                )
+            },
+            makeController: controllerFactory,
+            beforePrompt: { controller, _ in
+                if let model = Self.selectedModelToApply(config: config) {
+                    try await controller.setSessionModel(model)
+                }
+            }
+        )
+    }
+
+    func run(message: AgentMessage) async throws -> AIStreamResult {
+        try await bridge.run(message: message)
+    }
+
+    private static func selectedModelToApply(config: GrokAgentConfig) -> String? {
+        let trimmed = config.modelString?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let trimmed, !trimmed.isEmpty else { return nil }
+        if trimmed.caseInsensitiveCompare(AgentModel.defaultModel.rawValue) == .orderedSame {
+            return nil
+        }
+        return trimmed
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Grok/GrokACPLaunchResolver.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Grok/GrokACPLaunchResolver.swift
@@ -1,0 +1,222 @@
+import Foundation
+
+struct GrokACPResolvedLaunch: Equatable {
+    let command: String
+    let arguments: [String]
+    let additionalPathHints: [String]
+    let executableIdentity: ExecutableFileIdentity
+}
+
+enum GrokACPLaunchResolutionError: Error, Equatable, LocalizedError {
+    case missingConfiguredCommand
+    case exactPathNotFound(String)
+    case environmentDiscoveryRequired(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingConfiguredCommand:
+            "Grok ACP launch requires a `grok` command or executable path."
+        case let .exactPathNotFound(command):
+            "Grok CLI was not found as a valid executable regular file for `\(command)`. Install Grok Build CLI and ensure `grok` is available on PATH."
+        case let .environmentDiscoveryRequired(command):
+            "Grok CLI path discovery has not completed for `\(command)`. Run the Grok ACP support preflight or configure an absolute executable path."
+        }
+    }
+}
+
+final class GrokACPLaunchResolver: @unchecked Sendable {
+    typealias EnvironmentProvider = @Sendable (_ enableDebugLogging: Bool) async -> [String: String]
+
+    private static let launchArguments = ["agent", "--always-approve", "stdio"]
+    private static let helpArguments = ["agent", "--help"]
+
+    private let environmentProvider: EnvironmentProvider
+    private let probeMutex = AsyncMutex()
+    private let lock = NSLock()
+    private var cachedLaunchByKey: [String: GrokACPResolvedLaunch] = [:]
+
+    init(
+        environmentProvider: @escaping EnvironmentProvider = { enableDebugLogging in
+            let result = await ProcessEnvironmentBuilder.build(
+                ProcessEnvironmentRequest(
+                    purpose: .acpAgent(providerID: ACPProviderID.grok.rawValue),
+                    enableDebugLogging: enableDebugLogging
+                )
+            )
+            return result.environment
+        }
+    ) {
+        self.environmentProvider = environmentProvider
+    }
+
+    func resolvedLaunch(for config: GrokAgentConfig) throws -> GrokACPResolvedLaunch {
+        let key = cacheKey(for: config)
+        if let cached = cachedLaunch(forKey: key) {
+            do {
+                try cached.executableIdentity.validateForTrustedPathLaunch(atPath: cached.command)
+                return cached
+            } catch {
+                invalidate(key: key)
+                throw error
+            }
+        }
+
+        let launch = try resolveExplicitLaunch(for: config)
+        cache(launch, key: key)
+        return launch
+    }
+
+    func probeSupport(for config: GrokAgentConfig) async throws -> ACPSupportResult {
+        try await probeMutex.withLock { [self] in
+            try await probeSupportSerially(for: config)
+        }
+    }
+
+    private func probeSupportSerially(for config: GrokAgentConfig) async throws -> ACPSupportResult {
+        let key = cacheKey(for: config)
+        invalidate(key: key)
+        do {
+            let launch = try await resolveLaunchForProbe(for: config)
+            let processConfig = CLIProcessConfiguration(
+                command: launch.command,
+                additionalPaths: [],
+                enableDebugLogging: config.enableDebugLogging
+            )
+            let result = try await CLIProcessRunner(config: processConfig).run(
+                args: Self.helpArguments,
+                stdin: nil,
+                outputMode: .none,
+                timeout: 10,
+                cancelChildOnTaskCancellation: true
+            )
+            guard result.status == 0 else {
+                return .unsupported(
+                    reason: "Grok ACP preflight failed: `grok agent --help` exited with status \(result.status)."
+                )
+            }
+
+            let stdout = String(data: result.stdout, encoding: .utf8) ?? ""
+            let stderr = String(data: result.stderr, encoding: .utf8) ?? ""
+            let combined = "\(stdout)\n\(stderr)"
+            guard combined.localizedCaseInsensitiveContains("stdio")
+                || combined.localizedCaseInsensitiveContains("agent client protocol")
+                || combined.localizedCaseInsensitiveContains("acp")
+            else {
+                return .unsupported(reason: "Installed Grok CLI does not advertise ACP stdio support.")
+            }
+
+            try launch.executableIdentity.validateForTrustedPathLaunch(atPath: launch.command)
+            cache(launch, key: key)
+            return .supported
+        } catch is CancellationError {
+            invalidate(key: key)
+            throw CancellationError()
+        } catch {
+            invalidate(key: key)
+            return .unsupported(reason: error.localizedDescription)
+        }
+    }
+
+    private func resolveLaunchForProbe(for config: GrokAgentConfig) async throws -> GrokACPResolvedLaunch {
+        let configuredCommand = try validatedConfiguredCommand(config)
+        let environment = await environmentProvider(config.enableDebugLogging)
+        try Task.checkCancellation()
+        if configuredCommand.contains("/") {
+            return try resolveExplicitLaunch(for: config, environment: environment)
+        }
+
+        let effectiveHints = CLIPathHints.nativeDefaultsSupplemented(with: config.additionalPathHints)
+        let resolved = CommandPathResolver.resolve(
+            CLILaunchProfiles.grok.commandName,
+            environment: environment,
+            additionalPaths: effectiveHints,
+            preferredBasenames: CLILaunchProfiles.grok.preferredBasenames
+        )
+        return try validatedLaunch(
+            entryPath: resolved,
+            configuredCommand: configuredCommand,
+            additionalPathHints: effectiveHints
+        )
+    }
+
+    private func resolveExplicitLaunch(
+        for config: GrokAgentConfig,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) throws -> GrokACPResolvedLaunch {
+        let configuredCommand = try validatedConfiguredCommand(config)
+        guard configuredCommand.contains("/") else {
+            throw GrokACPLaunchResolutionError.environmentDiscoveryRequired(configuredCommand)
+        }
+        let effectiveHints = CLIPathHints.nativeDefaultsSupplemented(with: config.additionalPathHints)
+        let expanded = CommandPathResolver.expandPath(configuredCommand, environment: environment)
+        return try validatedLaunch(
+            entryPath: expanded,
+            configuredCommand: configuredCommand,
+            additionalPathHints: effectiveHints
+        )
+    }
+
+    private func validatedConfiguredCommand(_ config: GrokAgentConfig) throws -> String {
+        let configuredCommand = config.commandName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !configuredCommand.isEmpty else {
+            throw GrokACPLaunchResolutionError.missingConfiguredCommand
+        }
+        let expectedCommand = CLILaunchProfiles.grok.commandName
+        if configuredCommand.contains("/") {
+            guard URL(fileURLWithPath: configuredCommand).lastPathComponent.caseInsensitiveCompare(expectedCommand) == .orderedSame else {
+                throw GrokACPLaunchResolutionError.exactPathNotFound(configuredCommand)
+            }
+        } else if configuredCommand.caseInsensitiveCompare(expectedCommand) != .orderedSame {
+            throw GrokACPLaunchResolutionError.exactPathNotFound(configuredCommand)
+        }
+        return configuredCommand
+    }
+
+    private func validatedLaunch(
+        entryPath: String,
+        configuredCommand: String,
+        additionalPathHints: [String]
+    ) throws -> GrokACPResolvedLaunch {
+        guard entryPath.hasPrefix("/"),
+              URL(fileURLWithPath: entryPath).lastPathComponent.caseInsensitiveCompare(CLILaunchProfiles.grok.commandName) == .orderedSame
+        else {
+            throw GrokACPLaunchResolutionError.exactPathNotFound(configuredCommand)
+        }
+
+        let identity: ExecutableFileIdentity
+        do {
+            identity = try ExecutableFileIdentity.captureForTrustedPathLaunch(atPath: entryPath)
+        } catch {
+            throw GrokACPLaunchResolutionError.exactPathNotFound(configuredCommand)
+        }
+
+        return GrokACPResolvedLaunch(
+            command: identity.canonicalPath,
+            arguments: Self.launchArguments,
+            additionalPathHints: additionalPathHints,
+            executableIdentity: identity
+        )
+    }
+
+    private func cachedLaunch(forKey key: String) -> GrokACPResolvedLaunch? {
+        lock.lock()
+        defer { lock.unlock() }
+        return cachedLaunchByKey[key]
+    }
+
+    private func cache(_ launch: GrokACPResolvedLaunch, key: String) {
+        lock.lock()
+        cachedLaunchByKey[key] = launch
+        lock.unlock()
+    }
+
+    private func invalidate(key: String) {
+        lock.lock()
+        cachedLaunchByKey.removeValue(forKey: key)
+        lock.unlock()
+    }
+
+    private func cacheKey(for config: GrokAgentConfig) -> String {
+        ([config.commandName] + config.additionalPathHints).joined(separator: "\u{1F}")
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Grok/GrokAgentConfig.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Grok/GrokAgentConfig.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+struct GrokAgentConfig {
+    let commandName: String
+    let additionalPathHints: [String]
+    let enableDebugLogging: Bool
+    let modelString: String?
+    let includeRepoPromptMCPServer: Bool
+    let alwaysApproveToolPermissions: Bool
+
+    init(
+        commandName: String = "grok",
+        additionalPathHints: [String] = CLIPathHints.grok,
+        enableDebugLogging: Bool = false,
+        modelString: String? = nil,
+        includeRepoPromptMCPServer: Bool = true,
+        alwaysApproveToolPermissions: Bool = true
+    ) {
+        self.commandName = commandName
+        self.additionalPathHints = additionalPathHints
+        self.enableDebugLogging = enableDebugLogging
+        self.modelString = modelString
+        self.includeRepoPromptMCPServer = includeRepoPromptMCPServer
+        self.alwaysApproveToolPermissions = alwaysApproveToolPermissions
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Grok/GrokAgentToolPreferences.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Grok/GrokAgentToolPreferences.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+enum GrokAgentToolPreferences {
+    enum PermissionLevel: String, CaseIterable {
+        case alwaysApprove
+        case managedDefault
+
+        var displayName: String {
+            switch self {
+            case .alwaysApprove:
+                "Always Approve"
+            case .managedDefault:
+                "Default"
+            }
+        }
+
+        var detailText: String {
+            switch self {
+            case .alwaysApprove:
+                "Grok Build launches with `--always-approve` and RepoPrompt auto-approves ACP tool permissions."
+            case .managedDefault:
+                "Grok may prompt before running tools that need approval. RepoPrompt MCP is injected through the ACP session."
+            }
+        }
+
+        var iconName: String {
+            switch self {
+            case .alwaysApprove:
+                "checkmark.shield.fill"
+            case .managedDefault:
+                "shield"
+            }
+        }
+
+        var isWarning: Bool {
+            self == .alwaysApprove
+        }
+
+        var autoApprovesACPToolPermissions: Bool {
+            self == .alwaysApprove
+        }
+
+        var launchesWithAlwaysApproveCLIArg: Bool {
+            self == .alwaysApprove
+        }
+
+        static func from(rawValue: String?) -> PermissionLevel {
+            guard let raw = rawValue?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !raw.isEmpty
+            else {
+                return .alwaysApprove
+            }
+            switch raw.lowercased() {
+            case PermissionLevel.alwaysApprove.rawValue.lowercased():
+                return .alwaysApprove
+            case PermissionLevel.managedDefault.rawValue.lowercased():
+                return .managedDefault
+            default:
+                return .alwaysApprove
+            }
+        }
+    }
+
+    private static let permissionLevelKey = "grokACPToolPermissionLevel"
+
+    static func permissionLevel(defaults: UserDefaults = .standard) -> PermissionLevel {
+        PermissionLevel.from(rawValue: defaults.string(forKey: permissionLevelKey))
+    }
+
+    static func setPermissionLevel(
+        _ level: PermissionLevel,
+        defaults: UserDefaults = .standard
+    ) {
+        defaults.set(level.rawValue, forKey: permissionLevelKey)
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/MCP/Policies/AgentModeMCPToolPolicy.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/Policies/AgentModeMCPToolPolicy.swift
@@ -79,6 +79,8 @@ enum AgentModeMCPToolPolicy {
             openCodeGrantedTools
         case .cursor:
             cursorGrantedTools
+        case .grok:
+            cursorGrantedTools
         }
     }
 }

--- a/Sources/RepoPrompt/Infrastructure/Process/CLILaunchProfile.swift
+++ b/Sources/RepoPrompt/Infrastructure/Process/CLILaunchProfile.swift
@@ -15,6 +15,9 @@ enum CLILaunchProfiles {
         "~/.opencode/bin"
     ]
     static let cursorProviderSpecificPaths: [String] = []
+    static let grokProviderSpecificPaths: [String] = [
+        "~/.grok/bin"
+    ]
 
     /// Preserve the committed Codex hint order exactly: shell/package-manager
     /// fallbacks first, then Codex.app resources. System bins are intentionally not
@@ -58,6 +61,12 @@ enum CLILaunchProfiles {
         commandName: "cursor-agent",
         preferredBasenames: ["cursor-agent"],
         supplementalSearchPaths: nativeDefaultsSupplemented(with: cursorProviderSpecificPaths)
+    )
+
+    static let grok = CLILaunchProfile(
+        commandName: "grok",
+        preferredBasenames: ["grok"],
+        supplementalSearchPaths: providerSpecificPathsSupplementedWithNativeDefaults(grokProviderSpecificPaths)
     )
 
     static func nativeDefaultsSupplemented(with providerSpecificPaths: [String]) -> [String] {

--- a/Tests/RepoPromptTests/AgentMode/GrokACPLaunchResolverTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/GrokACPLaunchResolverTests.swift
@@ -1,0 +1,96 @@
+import Foundation
+@testable import RepoPrompt
+import XCTest
+
+final class GrokACPLaunchResolverTests: XCTestCase {
+    func testMakeLaunchConfigurationResolvesExactPathWithoutPriorProbe() throws {
+        let directory = try makeTemporaryDirectory()
+        let executable = try makeExecutable(named: "grok", in: directory)
+        let resolver = GrokACPLaunchResolver()
+        let provider = GrokACPAgentProvider(
+            config: GrokAgentConfig(
+                commandName: executable.path,
+                additionalPathHints: [],
+                includeRepoPromptMCPServer: false
+            ),
+            launchResolver: resolver
+        )
+
+        let launch = try provider.makeLaunchConfiguration(for: makeRunRequest(workspacePath: directory.path))
+
+        XCTAssertEqual(launch.command, executable.resolvingSymlinksInPath().standardizedFileURL.path)
+        XCTAssertEqual(launch.arguments, ["agent", "--always-approve", "stdio"])
+        XCTAssertEqual(launch.expectedExecutableIdentity?.canonicalPath, launch.command)
+    }
+
+    func testBareGrokUsesCapturedEnvironmentAndCachesCanonicalPathForSpawn() async throws {
+        let directory = try makeTemporaryDirectory()
+        let probePathRecord = directory.appendingPathComponent("probe-path")
+        let executable = try makeExecutable(named: "grok", in: directory, marker: probePathRecord)
+        var environment = ProcessInfo.processInfo.environment
+        environment["PATH"] = directory.path
+        environment["SHELL"] = "/bin/false"
+        let testEnvironment = environment
+        let resolver = GrokACPLaunchResolver(environmentProvider: { _ in testEnvironment })
+        let config = GrokAgentConfig(
+            commandName: "grok",
+            additionalPathHints: [],
+            includeRepoPromptMCPServer: false
+        )
+
+        let support = try await resolver.probeSupport(for: config)
+        let provider = GrokACPAgentProvider(config: config, launchResolver: resolver)
+        let launch = try provider.makeLaunchConfiguration(for: makeRunRequest(workspacePath: directory.path))
+        let probedPath = try String(contentsOf: probePathRecord, encoding: .utf8)
+
+        XCTAssertEqual(support, .supported)
+        XCTAssertEqual(launch.command, executable.resolvingSymlinksInPath().standardizedFileURL.path)
+        XCTAssertEqual(probedPath, launch.command)
+        XCTAssertEqual(launch.arguments, ["agent", "--always-approve", "stdio"])
+    }
+}
+
+private extension GrokACPLaunchResolverTests {
+    func makeRunRequest(workspacePath: String) -> ACPRunRequest {
+        ACPRunRequest(
+            agentKind: .grok,
+            modelString: AgentModel.grokComposer25Fast.rawValue,
+            workspacePath: workspacePath,
+            resumeSessionID: nil,
+            attachments: [],
+            taskLabelKind: nil,
+            sessionModeID: nil,
+            autoApproveAllToolPermissions: true
+        )
+    }
+
+    func makeTemporaryDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("GrokACPLaunchResolverTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: directory)
+        }
+        return directory
+    }
+
+    @discardableResult
+    func makeExecutable(
+        named name: String,
+        in directory: URL,
+        marker: URL? = nil,
+        output: String = "grok agent stdio ACP support",
+        exitStatus: Int32 = 0
+    ) throws -> URL {
+        let executable = directory.appendingPathComponent(name)
+        var lines = ["#!/bin/sh"]
+        if let marker {
+            lines.append("printf '%s' \"$0\" > '\(marker.path)'")
+        }
+        lines.append("printf '%s\\n' '\(output)'")
+        lines.append("exit \(exitStatus)")
+        try lines.joined(separator: "\n").write(to: executable, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+        return executable
+    }
+}


### PR DESCRIPTION
## Summary

Adds **Grok Build CLI** as a first-class ACP agent provider in RepoPrompt CE, alongside OpenCode and Cursor.

- Launches via `grok agent --always-approve stdio` with RepoPrompt MCP injection
- Default Agent Mode model: `grok-composer-2.5-fast` (also exposes `grok-build`)
- **CLI Providers** settings card with Connect / Test / Sign Out
- **Setup wizard** provider filter includes **Grok CLI** with status grid row
- **Agent permissions** binding with default **Always Approve**
- Role-default candidate chains prefer Grok Composer 2.5 Fast when Grok is connected
- Unit tests: `GrokACPLaunchResolverTests`

## Install note

Users need the Grok Build CLI:

```bash
curl -fsSL https://x.ai/cli/install.sh | bash
```

Ensure `~/.grok/bin/grok` is on PATH (or configure an absolute path).

## Testing

- `GrokACPLaunchResolverTests` added (mirrors Cursor ACP resolver tests)
- Commit preflight passed (guardrails + gitleaks)

Local `swift test` may require Xcode toolchain for KeyboardShortcuts preview macros in this environment.

## Screenshots / UX

After merge + local production install (`Install RepoPrompt CE Local Production.command`):

1. Settings → CLI Providers → **Grok CLI** card
2. Agent dropdown → **Grok CLI** with **Composer 2.5 Fast**
3. Setup wizard → Provider filter → **Grok**