### PR TITLE
Explore RepoPrompt CE performance and memory reductions

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -7942,6 +7942,7 @@ final class AgentModeViewModel: ObservableObject {
             precomputedEphemeralPayloadRevisionByItemID: session.ephemeralToolResultPayloadRevisionByItemID,
             selectedAgent: session.selectedAgent,
             previousPerformanceSnapshot: previousPerformanceSnapshotForBuild,
+            previousAnalyticsSnapshot: session.transcriptAnalyticsSnapshot,
             previousSanitizedTranscript: existingTranscript,
             previousBaseProjection: session.baseTranscriptProjection,
             previousTurnProjectionCaches: session.turnProjectionCaches,
@@ -8332,6 +8333,7 @@ final class AgentModeViewModel: ObservableObject {
         precomputedEphemeralPayloadRevisionByItemID: [UUID: Int]? = nil,
         selectedAgent: AgentProviderKind,
         previousPerformanceSnapshot: AgentTranscriptPerformanceSnapshot,
+        previousAnalyticsSnapshot: AgentTranscriptAnalyticsSnapshot? = nil,
         previousSanitizedTranscript: AgentTranscript? = nil,
         previousBaseProjection: AgentTranscriptProjection? = nil,
         previousTurnProjectionCaches: [UUID: AgentTranscriptTurnProjectionCache] = [:],
@@ -8605,6 +8607,27 @@ final class AgentModeViewModel: ObservableObject {
                 performanceSnapshot.lastColdLoadProjectionBuildDurationMS = buildDurationMS
             }
         #endif
+        let canReuseAnalyticsSnapshot: Bool = if let previousSanitizedTranscript {
+            previousSanitizedTranscript.version == sanitizedTranscript.version
+                && previousSanitizedTranscript.nextSequenceIndex == sanitizedTranscript.nextSequenceIndex
+                && previousSanitizedTranscript.compactionFrontier == sanitizedTranscript.compactionFrontier
+                && previousSanitizedTranscript.turns.count == sanitizedTranscript.turns.count
+                && sanitizeMetrics.reusedTurnCount == sanitizedTranscript.turns.count
+        } else {
+            sanitizedTranscript.turns.isEmpty
+        }
+        let analyticsSnapshot: AgentTranscriptAnalyticsSnapshot = if let previousAnalyticsSnapshot,
+                                                                     previousAnalyticsSnapshot.selectedAgent == selectedAgent,
+                                                                     canReuseAnalyticsSnapshot
+        {
+            previousAnalyticsSnapshot
+        } else {
+            AgentTranscriptAnalyticsBuilder.build(
+                from: sanitizedTranscript,
+                selectedAgent: selectedAgent
+            )
+        }
+
         return BuiltTranscriptPresentation(
             transcript: sanitizedTranscript,
             baseProjection: baseProjection,
@@ -8616,10 +8639,7 @@ final class AgentModeViewModel: ObservableObject {
             projectionProtection: projectionProtection,
             canonicalVisibleRowCount: canonicalVisibleRowCount,
             projectionCounts: projectionCounts,
-            analyticsSnapshot: AgentTranscriptAnalyticsBuilder.build(
-                from: sanitizedTranscript,
-                selectedAgent: selectedAgent
-            ),
+            analyticsSnapshot: analyticsSnapshot,
             sanitizedActivityCount: sanitizeMetrics.sanitizedActivityCount,
             performanceSnapshot: performanceSnapshot,
             rawToolResultPayloadRenderRevision: rawToolResultPayloadRenderRevision
@@ -8793,6 +8813,7 @@ final class AgentModeViewModel: ObservableObject {
             precomputedEphemeralPayloadRevisionByItemID: canonicalSourceItems == session.items ? session.ephemeralToolResultPayloadRevisionByItemID : nil,
             selectedAgent: session.selectedAgent,
             previousPerformanceSnapshot: session.transcriptPerformanceSnapshot,
+            previousAnalyticsSnapshot: session.transcriptAnalyticsSnapshot,
             previousSanitizedTranscript: session.transcript,
             previousBaseProjection: session.baseTranscriptProjection,
             previousTurnProjectionCaches: session.turnProjectionCaches,

--- a/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentContextPill.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentContextPill.swift
@@ -26,19 +26,16 @@ struct AgentContextPill: View {
         runtimeVM.snapshot.effectiveContextWindowTokens
     }
 
-    private var fileCount: Int {
-        AgentContextExportResolver.displayFileCount(
-            resolvedModel: nil,
-            sourceSelection: currentExportSourceSelection
-        )
+    private struct ContextSummary: Equatable {
+        let fileCount: Int
     }
 
-    private var currentExportSourceSelection: StoredSelection {
+    private func makeContextSummary() -> ContextSummary {
         let requestedTabID = currentTabID ?? promptManager.activeComposeTabID
         let selectionSnapshot = requestedTabID.flatMap {
             selectionCoordinator.selectionSnapshot(for: $0, flushPendingUIIfActive: false)
         }
-        return AgentContextExportSourceBuilder.makeSource(
+        let selection = AgentContextExportSourceBuilder.makeSource(
             AgentContextExportSourceBuildRequest(
                 requestedTabID: requestedTabID,
                 activeComposeTabID: promptManager.activeComposeTabID,
@@ -49,17 +46,23 @@ struct AgentContextPill: View {
                 worktreeBindingsProvider: worktreeBindingsProvider
             )
         ).selection
+        return ContextSummary(
+            fileCount: AgentContextExportResolver.displayFileCount(
+                resolvedModel: nil,
+                sourceSelection: selection
+            )
+        )
     }
 
     private var selectionTokens: Int? {
         runtimeVM.snapshot.selectionTokens
     }
 
-    private var fileSummaryText: String {
-        "\(fileCount) file\(fileCount == 1 ? "" : "s")"
+    private func fileSummaryText(_ summary: ContextSummary) -> String {
+        "\(summary.fileCount) file\(summary.fileCount == 1 ? "" : "s")"
     }
 
-    private var contextUsageTooltip: String {
+    private func contextUsageTooltip(_ summary: ContextSummary) -> String {
         var lines: [String] = []
 
         if let usedTokens = estimatedUsedTokens,
@@ -74,7 +77,7 @@ struct AgentContextPill: View {
             lines.append("Context usage unavailable")
         }
 
-        lines.append("Selected: \(fileSummaryText)")
+        lines.append("Selected: \(fileSummaryText(summary))")
         if let selectionTokens {
             lines.append("Selection: \(AgentContextIndicator.formatTokens(selectionTokens)) tokens")
         }
@@ -87,11 +90,12 @@ struct AgentContextPill: View {
             let _ = AgentModePerfDiagnostics.increment("ui.body.statusPills.context")
         #endif
         let cornerRadius = AgentPillMetrics.cornerRadius()
+        let contextSummary = makeContextSummary()
         Button {
             showPopover.toggle()
         } label: {
             HStack(spacing: 6) {
-                Text(fileSummaryText)
+                Text(fileSummaryText(contextSummary))
                     .font(fontPreset.swiftUIFont(sizeAtNormal: 12, weight: .medium))
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
@@ -112,14 +116,14 @@ struct AgentContextPill: View {
             )
         }
         .buttonStyle(.plain)
-        .hoverTooltip(contextUsageTooltip, .top)
+        .hoverTooltip(contextUsageTooltip(contextSummary), .top)
         .popover(isPresented: $showPopover, arrowEdge: .bottom) {
-            contextPopoverContent
+            contextPopoverContent(contextSummary)
         }
     }
 
     @ViewBuilder
-    private var contextPopoverContent: some View {
+    private func contextPopoverContent(_ summary: ContextSummary) -> some View {
         // Width grows with the font scale so the export card never feels
         // pinched at Large/Extra Large.
         let popoverWidth = fontPreset.scaledClamped(360, max: 480)
@@ -138,7 +142,7 @@ struct AgentContextPill: View {
                     Text("Selected")
                         .font(fontPreset.swiftUIFont(sizeAtNormal: 10))
                         .foregroundStyle(.tertiary)
-                    Text("\(fileCount) files")
+                    Text("\(summary.fileCount) files")
                         .font(fontPreset.swiftUIFont(sizeAtNormal: 12, weight: .semibold))
                 }
             }
@@ -149,7 +153,7 @@ struct AgentContextPill: View {
                 promptManager: promptManager,
                 tokenCounter: promptManager.tokenCountingViewModel,
                 selectionCoordinator: selectionCoordinator,
-                fileCount: fileCount,
+                fileCount: summary.fileCount,
                 selectionTokens: selectionTokens,
                 currentTabID: currentTabID,
                 activeAgentSessionID: activeAgentSessionID,

--- a/Sources/RepoPrompt/Features/Search/SearchMatch.swift
+++ b/Sources/RepoPrompt/Features/Search/SearchMatch.swift
@@ -208,23 +208,19 @@ private struct SearchContentResult {
 
 private struct SearchLineIndex {
     let lineRanges: [NSRange]
-    let lineStartsUTF16: [Int]
     let lineStartsUTF8: [Int]
 
     init(content: String) {
         let nsContent = content as NSString
         guard !content.isEmpty else {
             lineRanges = []
-            lineStartsUTF16 = []
             lineStartsUTF8 = []
             return
         }
 
         var ranges: [NSRange] = []
-        var startsUTF16: [Int] = []
         var startsUTF8: [Int] = []
         ranges.reserveCapacity(32)
-        startsUTF16.reserveCapacity(32)
         startsUTF8.reserveCapacity(32)
 
         var lineStartUTF16 = 0
@@ -235,7 +231,6 @@ private struct SearchLineIndex {
         var index = scalars.startIndex
 
         func appendLine(endingAtUTF16 endUTF16: Int) {
-            startsUTF16.append(lineStartUTF16)
             startsUTF8.append(lineStartUTF8)
             ranges.append(NSRange(location: lineStartUTF16, length: endUTF16 - lineStartUTF16))
         }
@@ -266,18 +261,28 @@ private struct SearchLineIndex {
         }
 
         if lineStartUTF16 < nsContent.length {
-            startsUTF16.append(lineStartUTF16)
             startsUTF8.append(lineStartUTF8)
             ranges.append(NSRange(location: lineStartUTF16, length: nsContent.length - lineStartUTF16))
         }
 
         lineRanges = ranges
-        lineStartsUTF16 = startsUTF16
         lineStartsUTF8 = startsUTF8
     }
 
     func lineNumber(forUTF16Offset offset: Int) -> Int {
-        lineNumber(forOffset: offset, starts: lineStartsUTF16)
+        guard !lineRanges.isEmpty else { return -1 }
+
+        var lo = 0
+        var hi = lineRanges.count - 1
+        while lo <= hi {
+            let mid = (lo + hi) / 2
+            if lineRanges[mid].location <= offset {
+                lo = mid + 1
+            } else {
+                hi = mid - 1
+            }
+        }
+        return max(0, min(lo - 1, lineRanges.count - 1))
     }
 
     func lineNumber(forUTF8Offset offset: Int) -> Int {

--- a/Sources/RepoPrompt/Features/Workspaces/ViewModels/WorkspaceManagerViewModel.swift
+++ b/Sources/RepoPrompt/Features/Workspaces/ViewModels/WorkspaceManagerViewModel.swift
@@ -83,21 +83,42 @@ private struct WorkspaceFileCachedLoadResult {
 final class WorkspaceFileDecodeCache: @unchecked Sendable {
     static let shared = WorkspaceFileDecodeCache()
 
-    private let lock = NSLock()
-    private var cachedWorkspacesByKey: [WorkspaceFileDecodeCacheKey: WorkspaceModel] = [:]
-    private var scheduledNormalizationSaveKeys: Set<WorkspaceFileDecodeCacheKey> = []
+    private struct CacheEntry {
+        var workspace: WorkspaceModel
+        var estimatedCost: Int
+        var lastAccessOrdinal: UInt64
+    }
 
-    private init() {}
+    private static let defaultMaxEntryCount = 128
+    private static let defaultMaxEstimatedCost = 64 * 1024 * 1024
+
+    private let lock = NSLock()
+    private var cachedWorkspacesByKey: [WorkspaceFileDecodeCacheKey: CacheEntry] = [:]
+    private var scheduledNormalizationSaveKeys: Set<WorkspaceFileDecodeCacheKey> = []
+    private var totalEstimatedCost = 0
+    private var accessOrdinal: UInt64 = 0
+    private var maxEntryCount: Int
+    private var maxEstimatedCost: Int
+
+    private init(
+        maxEntryCount: Int = WorkspaceFileDecodeCache.defaultMaxEntryCount,
+        maxEstimatedCost: Int = WorkspaceFileDecodeCache.defaultMaxEstimatedCost
+    ) {
+        self.maxEntryCount = max(1, maxEntryCount)
+        self.maxEstimatedCost = max(1, maxEstimatedCost)
+    }
 
     fileprivate func loadWorkspace(at fileURL: URL) throws -> WorkspaceFileCachedLoadResult {
         let keyBeforeRead = try metadataKey(for: fileURL)
         lock.lock()
         if let cached = cachedWorkspacesByKey[keyBeforeRead] {
+            let nextOrdinal = nextAccessOrdinalLocked()
+            cachedWorkspacesByKey[keyBeforeRead]?.lastAccessOrdinal = nextOrdinal
             lock.unlock()
             return WorkspaceFileCachedLoadResult(
-                workspace: cached,
+                workspace: cached.workspace,
                 cacheHit: true,
-                composeTabsNormalized: cached.normalizationRequiresSave,
+                composeTabsNormalized: cached.workspace.normalizationRequiresSave,
                 cacheKey: keyBeforeRead
             )
         }
@@ -105,6 +126,7 @@ final class WorkspaceFileDecodeCache: @unchecked Sendable {
 
         let standardizedURL = URL(fileURLWithPath: keyBeforeRead.standardizedPath)
         let data = try Data(contentsOf: standardizedURL)
+        let estimatedCost = data.count
         var workspace = try JSONDecoder().decode(WorkspaceModel.self, from: data)
         let decodedRequiresSave = workspace.normalizationRequiresSave
         let normalized = workspace.normalizeComposeTabInvariants()
@@ -115,7 +137,7 @@ final class WorkspaceFileDecodeCache: @unchecked Sendable {
            keyAfterRead == keyBeforeRead
         {
             lock.lock()
-            cachedWorkspacesByKey[keyBeforeRead] = workspace
+            insertLocked(workspace, for: keyBeforeRead, estimatedCost: estimatedCost)
             lock.unlock()
         }
 
@@ -125,6 +147,48 @@ final class WorkspaceFileDecodeCache: @unchecked Sendable {
             composeTabsNormalized: normalizationRequiresSave,
             cacheKey: keyBeforeRead
         )
+    }
+
+    private func nextAccessOrdinalLocked() -> UInt64 {
+        accessOrdinal &+= 1
+        return accessOrdinal
+    }
+
+    private func insertLocked(_ workspace: WorkspaceModel, for key: WorkspaceFileDecodeCacheKey, estimatedCost: Int) {
+        if let existing = cachedWorkspacesByKey[key] {
+            totalEstimatedCost -= existing.estimatedCost
+        }
+        let boundedEstimatedCost = max(1, estimatedCost)
+        cachedWorkspacesByKey[key] = CacheEntry(
+            workspace: workspace,
+            estimatedCost: boundedEstimatedCost,
+            lastAccessOrdinal: nextAccessOrdinalLocked()
+        )
+        totalEstimatedCost += boundedEstimatedCost
+        trimToBudgetLocked()
+    }
+
+    private func removeCachedWorkspaceLocked(for key: WorkspaceFileDecodeCacheKey) {
+        if let removed = cachedWorkspacesByKey.removeValue(forKey: key) {
+            totalEstimatedCost -= removed.estimatedCost
+        }
+    }
+
+    private func removeCachedWorkspacesLocked(where shouldRemove: (WorkspaceFileDecodeCacheKey) -> Bool) {
+        for key in Array(cachedWorkspacesByKey.keys) where shouldRemove(key) {
+            removeCachedWorkspaceLocked(for: key)
+        }
+    }
+
+    private func trimToBudgetLocked() {
+        while cachedWorkspacesByKey.count > maxEntryCount ||
+            (totalEstimatedCost > maxEstimatedCost && cachedWorkspacesByKey.count > 1)
+        {
+            guard let keyToEvict = cachedWorkspacesByKey.min(by: { lhs, rhs in
+                lhs.value.lastAccessOrdinal < rhs.value.lastAccessOrdinal
+            })?.key else { break }
+            removeCachedWorkspaceLocked(for: keyToEvict)
+        }
     }
 
     fileprivate func metadataKey(for fileURL: URL) throws -> WorkspaceFileDecodeCacheKey {
@@ -160,23 +224,53 @@ final class WorkspaceFileDecodeCache: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         scheduledNormalizationSaveKeys.remove(key)
-        cachedWorkspacesByKey = cachedWorkspacesByKey.filter { $0.key.standardizedPath != key.standardizedPath }
+        removeCachedWorkspacesLocked { $0.standardizedPath == key.standardizedPath }
     }
 
     func invalidate(url: URL) {
         let standardizedPath = url.standardizedFileURL.path
         lock.lock()
         defer { lock.unlock() }
-        cachedWorkspacesByKey = cachedWorkspacesByKey.filter { $0.key.standardizedPath != standardizedPath }
+        removeCachedWorkspacesLocked { $0.standardizedPath == standardizedPath }
         scheduledNormalizationSaveKeys = scheduledNormalizationSaveKeys.filter { $0.standardizedPath != standardizedPath }
     }
 
     #if DEBUG
+        var cachedEntryCountForTesting: Int {
+            lock.lock()
+            defer { lock.unlock() }
+            return cachedWorkspacesByKey.count
+        }
+
+        var estimatedCostForTesting: Int {
+            lock.lock()
+            defer { lock.unlock() }
+            return totalEstimatedCost
+        }
+
+        func setBudgetForTesting(maxEntryCount: Int, maxEstimatedCost: Int) {
+            lock.lock()
+            defer { lock.unlock() }
+            self.maxEntryCount = max(1, maxEntryCount)
+            self.maxEstimatedCost = max(1, maxEstimatedCost)
+            trimToBudgetLocked()
+        }
+
+        func resetBudgetForTesting() {
+            lock.lock()
+            defer { lock.unlock() }
+            maxEntryCount = Self.defaultMaxEntryCount
+            maxEstimatedCost = Self.defaultMaxEstimatedCost
+            trimToBudgetLocked()
+        }
+
         func removeAllForTesting() {
             lock.lock()
             defer { lock.unlock() }
             cachedWorkspacesByKey.removeAll()
             scheduledNormalizationSaveKeys.removeAll()
+            totalEstimatedCost = 0
+            accessOrdinal = 0
         }
     #endif
 }

--- a/Sources/RepoPrompt/Features/Workspaces/ViewModels/WorkspaceManagerViewModel.swift
+++ b/Sources/RepoPrompt/Features/Workspaces/ViewModels/WorkspaceManagerViewModel.swift
@@ -6381,12 +6381,33 @@ class WorkspaceManagerViewModel: ObservableObject {
             let shouldWrite: Bool
         }
 
+        private struct WorkspacePayloadHeader: Decodable {
+            let id: UUID
+            let dateModified: Date
+            let name: String
+
+            enum CodingKeys: String, CodingKey {
+                case id
+                case dateModified
+                case name
+            }
+
+            init(from decoder: Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                id = try container.decode(UUID.self, forKey: .id)
+                dateModified = try container.decode(Date.self, forKey: .dateModified)
+                name = (try? container.decode(String.self, forKey: .name)) ?? "Untitled Workspace"
+            }
+        }
+
         private var pendingByURL: [URL: Pending] = [:]
         private var waitersByURL: [URL: [CheckedContinuation<Void, Never>]] = [:]
         private var latestSelectionByWorkspaceTab: [WorkspaceTabSelectionKey: LatestSelectionRecord] = [:]
         private var lastWrittenSelectionRevisionByWorkspaceTab: [WorkspaceTabSelectionKey: UInt64] = [:]
         #if DEBUG
             private var atomicWriteGateForTesting: (@Sendable () async -> Void)?
+            private static let fullDecodeCountLock = NSLock()
+            private static var fullDecodeCountForTesting = 0
         #endif
 
         // MARK: public API
@@ -6509,6 +6530,7 @@ class WorkspaceManagerViewModel: ObservableObject {
                 latestSelectionByWorkspaceTab.removeAll()
                 lastWrittenSelectionRevisionByWorkspaceTab.removeAll()
                 atomicWriteGateForTesting = nil
+                Self.resetFullDecodeCountForTesting()
                 let allWaiters = waitersByURL.values.flatMap(\.self)
                 waitersByURL.removeAll()
                 for waiter in allWaiters {
@@ -6521,8 +6543,32 @@ class WorkspaceManagerViewModel: ObservableObject {
 
         private static func decodedWorkspacePayload(_ data: Data) -> WorkspaceModel? {
             guard !data.isEmpty else { return nil }
+            #if DEBUG
+                fullDecodeCountLock.lock()
+                fullDecodeCountForTesting += 1
+                fullDecodeCountLock.unlock()
+            #endif
             return try? JSONDecoder().decode(WorkspaceModel.self, from: data)
         }
+
+        private static func decodedWorkspacePayloadHeader(_ data: Data) -> WorkspacePayloadHeader? {
+            guard !data.isEmpty else { return nil }
+            return try? JSONDecoder().decode(WorkspacePayloadHeader.self, from: data)
+        }
+
+        #if DEBUG
+            static func resetFullDecodeCountForTesting() {
+                fullDecodeCountLock.lock()
+                fullDecodeCountForTesting = 0
+                fullDecodeCountLock.unlock()
+            }
+
+            static var fullDecodeCountSnapshotForTesting: Int {
+                fullDecodeCountLock.lock()
+                defer { fullDecodeCountLock.unlock() }
+                return fullDecodeCountForTesting
+            }
+        #endif
 
         private func recordLatestSelectionIfNeeded(_ metadata: WorkspaceSavePayloadMetadata?) {
             guard let metadata,
@@ -6541,10 +6587,10 @@ class WorkspaceManagerViewModel: ObservableObject {
         }
 
         private static func shouldKeepExistingWorkspacePayload(existing: Data, incoming: Data, url: URL) -> Bool {
-            guard let existingWorkspace = decodedWorkspacePayload(existing),
-                  let incomingWorkspace = decodedWorkspacePayload(incoming),
-                  existingWorkspace.id == incomingWorkspace.id,
-                  existingWorkspace.dateModified > incomingWorkspace.dateModified
+            guard let existingHeader = decodedWorkspacePayloadHeader(existing),
+                  let incomingHeader = decodedWorkspacePayloadHeader(incoming),
+                  existingHeader.id == incomingHeader.id,
+                  existingHeader.dateModified > incomingHeader.dateModified
             else {
                 return false
             }
@@ -6552,8 +6598,8 @@ class WorkspaceManagerViewModel: ObservableObject {
                 WorkspaceRestorePerfLog.event(
                     "workspaceDiskWriter.skipStaleCoalescedPayload",
                     fields: [
-                        "workspaceID": WorkspaceRestorePerfLog.shortID(incomingWorkspace.id),
-                        "workspaceName": incomingWorkspace.name,
+                        "workspaceID": WorkspaceRestorePerfLog.shortID(incomingHeader.id),
+                        "workspaceName": incomingHeader.name,
                         "url": url.lastPathComponent
                     ]
                 )
@@ -6569,8 +6615,8 @@ class WorkspaceManagerViewModel: ObservableObject {
             lastWrittenRevision: UInt64
         ) -> EffectiveWritePayload {
             guard let metadata,
-                  let incomingWorkspace = decodedWorkspacePayload(payload),
-                  incomingWorkspace.id == metadata.workspaceID
+                  let incomingHeader = decodedWorkspacePayloadHeader(payload),
+                  incomingHeader.id == metadata.workspaceID
             else {
                 let shouldWrite = !shouldSkipStaleWorkspaceDiskWrite(payload: payload, url: url, metadata: metadata)
                 return EffectiveWritePayload(data: payload, metadata: metadata, selectionKey: metadata?.selectionKey, effectiveSelectionRevision: metadata?.activeSelectionRevision ?? 0, shouldWrite: shouldWrite)
@@ -6581,17 +6627,19 @@ class WorkspaceManagerViewModel: ObservableObject {
             let latestRevision = latestRecord?.revision ?? incomingRevision
             let latestSelection = latestRecord?.selection ?? metadata.activeSelection
             let latestMetadata = latestRecord?.metadata ?? metadata
-            let diskWorkspace: WorkspaceModel? = if FileManager.default.fileExists(atPath: url.path),
-                                                    let diskData = try? Data(contentsOf: url),
-                                                    let decoded = decodedWorkspacePayload(diskData),
-                                                    decoded.id == incomingWorkspace.id
-            {
-                decoded
-            } else {
-                nil
-            }
+            let diskData = FileManager.default.fileExists(atPath: url.path) ? try? Data(contentsOf: url) : nil
+            let diskHeader = diskData.flatMap(decodedWorkspacePayloadHeader)
+            let diskHasNewerPayload = diskHeader?.id == incomingHeader.id &&
+                (diskHeader?.dateModified ?? .distantPast) > incomingHeader.dateModified
 
-            if let diskWorkspace, diskWorkspace.dateModified > incomingWorkspace.dateModified {
+            if diskHasNewerPayload {
+                guard let diskData,
+                      let diskWorkspace = decodedWorkspacePayload(diskData),
+                      diskWorkspace.id == incomingHeader.id,
+                      diskWorkspace.dateModified > incomingHeader.dateModified
+                else {
+                    return EffectiveWritePayload(data: payload, metadata: metadata, selectionKey: key, effectiveSelectionRevision: incomingRevision, shouldWrite: true)
+                }
                 if latestRevision > lastWrittenRevision,
                    let latestSelection,
                    let activeTabID = metadata.activeTabID
@@ -6621,7 +6669,8 @@ class WorkspaceManagerViewModel: ObservableObject {
 
             if latestRevision > incomingRevision,
                let latestSelection,
-               let activeTabID = metadata.activeTabID
+               let activeTabID = metadata.activeTabID,
+               let incomingWorkspace = decodedWorkspacePayload(payload)
             {
                 let applied = WorkspaceManagerViewModel.workspaceByApplyingSelection(latestSelection, toActiveTab: activeTabID, in: incomingWorkspace)
                 if applied.applied,
@@ -6646,11 +6695,14 @@ class WorkspaceManagerViewModel: ObservableObject {
 
         private static func shouldSkipStaleWorkspaceDiskWrite(payload: Data, url: URL, metadata: WorkspaceSavePayloadMetadata?) -> Bool {
             guard FileManager.default.fileExists(atPath: url.path),
-                  let incomingWorkspace = decodedWorkspacePayload(payload),
+                  let incomingHeader = decodedWorkspacePayloadHeader(payload),
                   let diskData = try? Data(contentsOf: url),
+                  let diskHeader = decodedWorkspacePayloadHeader(diskData),
+                  diskHeader.id == incomingHeader.id,
+                  diskHeader.dateModified > incomingHeader.dateModified,
                   let diskWorkspace = decodedWorkspacePayload(diskData),
-                  diskWorkspace.id == incomingWorkspace.id,
-                  diskWorkspace.dateModified > incomingWorkspace.dateModified
+                  diskWorkspace.id == incomingHeader.id,
+                  diskWorkspace.dateModified > incomingHeader.dateModified
             else {
                 return false
             }

--- a/Sources/RepoPrompt/Features/Workspaces/ViewModels/WorkspaceManagerViewModel.swift
+++ b/Sources/RepoPrompt/Features/Workspaces/ViewModels/WorkspaceManagerViewModel.swift
@@ -155,9 +155,7 @@ final class WorkspaceFileDecodeCache: @unchecked Sendable {
     }
 
     private func insertLocked(_ workspace: WorkspaceModel, for key: WorkspaceFileDecodeCacheKey, estimatedCost: Int) {
-        if let existing = cachedWorkspacesByKey[key] {
-            totalEstimatedCost -= existing.estimatedCost
-        }
+        removeCachedWorkspacesLocked { $0.standardizedPath == key.standardizedPath }
         let boundedEstimatedCost = max(1, estimatedCost)
         cachedWorkspacesByKey[key] = CacheEntry(
             workspace: workspace,

--- a/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService+ContentLoading.swift
+++ b/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService+ContentLoading.swift
@@ -1179,7 +1179,10 @@ extension FileSystemService {
         defer { try? handle.close() }
 
         let skipProbe = shouldSkipBinaryProbe(url: validated.url)
-        if !skipProbe {
+        let probedTextPrefix: Data
+        if skipProbe {
+            probedTextPrefix = Data()
+        } else {
             try await runContentReadChunkHook(request)
             let probe = try handle.read(upToCount: 8192) ?? Data()
             try Task.checkCancellation()
@@ -1191,12 +1194,12 @@ extension FileSystemService {
                     required: requireStableIdentity
                 )
             }
-            try handle.seek(toOffset: 0)
+            probedTextPrefix = probe
         }
 
         if validated.fileSize < 2_000_000 {
             let data: Data
-            switch try await readBoundedData(request, handle: handle) {
+            switch try await readBoundedData(request, handle: handle, initialData: probedTextPrefix) {
             case let .data(readData):
                 data = readData
             case let .tooLarge(observedByteCount):
@@ -1386,9 +1389,13 @@ extension FileSystemService {
 
     private nonisolated static func readBoundedData(
         _ request: ContentReadRequest,
-        handle: FileHandle
+        handle: FileHandle,
+        initialData: Data = Data()
     ) async throws -> BoundedDataReadResult {
-        var data = Data()
+        var data = initialData
+        if Int64(data.count) > request.fileSizeLimit {
+            return .tooLarge(observedByteCount: Int64(data.count))
+        }
         while true {
             try await runContentReadChunkHook(request)
             let next = try handle.read(upToCount: request.chunkSize) ?? Data()

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/PathLookup/PathMatchTypes.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/PathLookup/PathMatchTypes.swift
@@ -18,6 +18,7 @@ struct PathMatchCacheIdentity: Hashable {
 
 struct PathMatchRootPathCache {
     struct Entry {
+        let rootPath: String
         let standardizedPath: String
         let resolvedPath: String
     }
@@ -28,6 +29,7 @@ struct PathMatchRootPathCache {
         entries = rootFolders.map { root in
             let standardizedPath = StandardizedPath.absolute(root.fullPath)
             return Entry(
+                rootPath: root.fullPath,
                 standardizedPath: standardizedPath,
                 resolvedPath: (standardizedPath as NSString).resolvingSymlinksInPath
             )

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/PathLookup/PathMatchTypes.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/PathLookup/PathMatchTypes.swift
@@ -16,6 +16,25 @@ struct PathMatchCacheIdentity: Hashable {
     let snapshotID: UInt64
 }
 
+struct PathMatchRootPathCache {
+    struct Entry {
+        let standardizedPath: String
+        let resolvedPath: String
+    }
+
+    let entries: [Entry]
+
+    init(rootFolders: [FolderRecord]) {
+        entries = rootFolders.map { root in
+            let standardizedPath = StandardizedPath.absolute(root.fullPath)
+            return Entry(
+                standardizedPath: standardizedPath,
+                resolvedPath: (standardizedPath as NSString).resolvingSymlinksInPath
+            )
+        }
+    }
+}
+
 /// Static part of the snapshot (expensive to build, cached).
 /// Immutable, cross-actor-safe snapshot used by PathMatcher and PathMatchWorker.
 /// All references to UI/ViewModel types are stripped; uses frozen records only.
@@ -23,6 +42,7 @@ struct StaticPathMatchData {
     let filesByFullPath: [String: FileRecord]
     let foldersByFullPath: [String: FolderRecord]
     let rootFolders: [FolderRecord]
+    let rootPathCache: PathMatchRootPathCache
 
     // Case-insensitive dictionaries (no duplicates in original maps)
     let filesByLowerFullPath: [String: FileRecord]
@@ -48,6 +68,7 @@ struct StaticPathMatchData {
         self.filesByFullPath = filesByFullPath
         self.foldersByFullPath = foldersByFullPath
         self.rootFolders = rootFolders
+        rootPathCache = PathMatchRootPathCache(rootFolders: rootFolders)
         cacheIdentity = PathMatchCacheIdentity(scopeID: cacheScopeID, snapshotID: id)
         self.id = id
 
@@ -80,6 +101,7 @@ struct PathMatchSnapshot {
     let filesByFullPath: [String: FileRecord]
     let foldersByFullPath: [String: FolderRecord]
     let rootFolders: [FolderRecord]
+    let rootPathCache: PathMatchRootPathCache
 
     // Case-insensitive dictionaries copied from StaticPathMatchData or computed on the fly
     let filesByLowerFullPath: [String: FileRecord]
@@ -106,6 +128,7 @@ struct PathMatchSnapshot {
         filesByFullPath = staticData.filesByFullPath
         foldersByFullPath = staticData.foldersByFullPath
         rootFolders = staticData.rootFolders
+        rootPathCache = staticData.rootPathCache
         filesByLowerFullPath = staticData.filesByLowerFullPath
         foldersByLowerFullPath = staticData.foldersByLowerFullPath
         self.selectedFileFullPaths = selectedFileFullPaths
@@ -180,6 +203,7 @@ struct PathMatchSnapshot {
         self.filesByFullPath = normalizedFilesByFullPath
         self.foldersByFullPath = normalizedFoldersByFullPath
         self.rootFolders = normalizedRootFolders
+        rootPathCache = PathMatchRootPathCache(rootFolders: normalizedRootFolders)
 
         // Duplicate-safe "first wins" build to avoid traps on case-sensitive filesystems
         var filesLower: [String: FileRecord] = [:]

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/PathLookup/PathMatcher.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/PathLookup/PathMatcher.swift
@@ -1573,7 +1573,7 @@ enum PathMatcher {
             if isUnder(fullStd, root: rStd) || isUnder(fullRes, root: rStd) ||
                 isUnder(fullStd, root: rRes) || isUnder(fullRes, root: rRes)
             {
-                out.insert(rStd)
+                out.insert(root.rootPath)
             }
         }
         return Array(out)

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/PathLookup/PathMatcher.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/PathLookup/PathMatcher.swift
@@ -377,20 +377,11 @@ enum PathMatcher {
             }
 
             // 2) Gather candidate roots (string-only, avoid URL bridging)
-            var candidateRoots = getCandidateRoots(forFullPath: standardizedPath, snapshot: snapshot)
+            let candidateRoots = getCandidateRoots(forFullPath: standardizedPath, snapshot: snapshot)
 
             if Self.isLoggingEnabled {
                 print("Full path: \(standardizedPath)")
-                print("Candidate roots (std): \(candidateRoots)")
-            }
-
-            // If none matched by simple prefix, try symlink-resolved comparisons
-            if candidateRoots.isEmpty {
-                let resolvedFull = (standardizedPath as NSString).resolvingSymlinksInPath
-                candidateRoots = getCandidateRoots(forFullPath: resolvedFull, snapshot: snapshot)
-                if Self.isLoggingEnabled {
-                    print("Candidate roots (resolved): \(candidateRoots)")
-                }
+                print("Candidate roots (std/resolved): \(candidateRoots)")
             }
 
             // If no candidate root matches, allow a conservative, parent-qualified suffix fallback.
@@ -1575,10 +1566,10 @@ enum PathMatcher {
         let fullStd = StandardizedPath.absolute(fullPath)
         let fullRes = (fullStd as NSString).resolvingSymlinksInPath
         var out = Set<String>()
-        out.reserveCapacity(snapshot.rootFolders.count)
-        for root in snapshot.rootFolders {
-            let rStd = root.fullPath
-            let rRes = (rStd as NSString).resolvingSymlinksInPath
+        out.reserveCapacity(snapshot.rootPathCache.entries.count)
+        for root in snapshot.rootPathCache.entries {
+            let rStd = root.standardizedPath
+            let rRes = root.resolvedPath
             if isUnder(fullStd, root: rStd) || isUnder(fullRes, root: rStd) ||
                 isUnder(fullStd, root: rRes) || isUnder(fullRes, root: rRes)
             {

--- a/Tests/RepoPromptTests/AgentMode/Transcript/AgentTranscriptAnalyticsCacheTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Transcript/AgentTranscriptAnalyticsCacheTests.swift
@@ -1,0 +1,24 @@
+import Foundation
+@testable import RepoPrompt
+import XCTest
+
+final class AgentTranscriptAnalyticsCacheTests: XCTestCase {
+    func testBuildTranscriptPresentationReusesAnalyticsForUnchangedTranscriptAndAgent() {
+        let previousAnalytics = AgentTranscriptAnalyticsSnapshot(
+            observedReadFiles: ["Sources/RepoPrompt/App/AppDelegate.swift"],
+            estimatedTranscriptTokens: 42,
+            selectedAgent: .codexExec
+        )
+
+        let presentation = AgentModeViewModel.buildTranscriptPresentation(
+            from: .empty,
+            sourceItems: [],
+            selectedAgent: .codexExec,
+            previousPerformanceSnapshot: .empty,
+            previousAnalyticsSnapshot: previousAnalytics,
+            previousSanitizedTranscript: .empty
+        )
+
+        XCTAssertEqual(presentation.analyticsSnapshot, previousAnalytics)
+    }
+}

--- a/Tests/RepoPromptTests/MCP/Control/PersistentAgentModeMCPReadFileConnectionTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/PersistentAgentModeMCPReadFileConnectionTests.swift
@@ -1674,8 +1674,15 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
                 throw error
             }
 
+            let isolatedWorkspaceStorageURL = rootURL.appendingPathComponent("WorkspaceStorage", isDirectory: true)
+            try FileManager.default.createDirectory(
+                at: isolatedWorkspaceStorageURL,
+                withIntermediateDirectories: true
+            )
             let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
+            let previousGlobalStoragePath = UserDefaults.standard.string(forKey: "GlobalCustomStorageURL")
             GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
+            UserDefaults.standard.set(isolatedWorkspaceStorageURL.path, forKey: "GlobalCustomStorageURL")
             let window = WindowState()
             let routingGuardWindow = WindowState()
             if agentOwned {
@@ -1688,7 +1695,16 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
             // Keep dispatch in ordinary multi-window routing mode so catalog services retained by
             // earlier tests are filtered by window ID instead of relying on singleton cleanliness.
             WindowStatesManager.shared.registerWindowState(routingGuardWindow)
+
+            await window.workspaceManager.awaitInitialized()
+            await routingGuardWindow.workspaceManager.awaitInitialized()
+
             GlobalSettingsStore.shared.setMCPAutoStart(previousAutoStart, commit: false)
+            if let previousGlobalStoragePath {
+                UserDefaults.standard.set(previousGlobalStoragePath, forKey: "GlobalCustomStorageURL")
+            } else {
+                UserDefaults.standard.removeObject(forKey: "GlobalCustomStorageURL")
+            }
 
             var rootID: UUID?
             var catalogService: MCPWindowToolCatalogService?

--- a/Tests/RepoPromptTests/Services/FileSystem/FileSystemContentLoadingConcurrencyTests.swift
+++ b/Tests/RepoPromptTests/Services/FileSystem/FileSystemContentLoadingConcurrencyTests.swift
@@ -61,6 +61,27 @@ final class FileSystemContentLoadingConcurrencyTests: XCTestCase {
         XCTAssertNil(standardizedNestedEncoding)
     }
 
+    func testSmallTextReadReusesBinaryProbePrefix() async throws {
+        let root = try temporaryRoots.makeRoot(suiteName: "FileSystemContentLoadingProbePrefix")
+        let service = try await makeService(root: root)
+        try FileSystemTestSupport.write("hello", to: root.appendingPathComponent("Small.txt"))
+        try Data([0x00, 0x01, 0x02, 0x03]).write(to: root.appendingPathComponent("Opaque.dat"))
+        let readCount = AsyncCounter()
+        await service.setContentReadChunkHandlerForTesting { _ in
+            _ = await readCount.incrementAndValue()
+        }
+
+        let text = try await service.loadContent(ofRelativePath: "Small.txt")
+        let countAfterText = await readCount.value()
+        let binary = try await service.loadContent(ofRelativePath: "Opaque.dat")
+        let countAfterBinary = await readCount.value()
+
+        XCTAssertEqual(text, "hello")
+        XCTAssertEqual(countAfterText, 2)
+        XCTAssertNil(binary)
+        XCTAssertEqual(countAfterBinary, 3)
+    }
+
     func testContentLoadingRejectsTraversalAndSymlinkTargets() async throws {
         let root = try temporaryRoots.makeRoot(suiteName: "FileSystemContentLoadingContainment")
         let outside = try temporaryRoots.makeRoot(suiteName: "FileSystemContentLoadingOutside")

--- a/Tests/RepoPromptTests/WorkspaceContext/PathMatching/PathMatchingRecoveryTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/PathMatching/PathMatchingRecoveryTests.swift
@@ -2,6 +2,32 @@
 import XCTest
 
 final class PathMatchingRecoveryTests: XCTestCase {
+    func testRootSymlinkResolutionCacheIsSnapshotScoped() throws {
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PathMatchingRecoveryTests-\(UUID().uuidString)", isDirectory: true)
+        let targetA = tempRoot.appendingPathComponent("target-a", isDirectory: true)
+        let targetB = tempRoot.appendingPathComponent("target-b", isDirectory: true)
+        let link = tempRoot.appendingPathComponent("linked-root")
+        try FileManager.default.createDirectory(at: targetA, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: targetB, withIntermediateDirectories: true)
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: targetA)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        let resolvedTargetA = (StandardizedPath.absolute(targetA.path) as NSString).resolvingSymlinksInPath
+        let snapshotA = makeSnapshot(files: [("Sources/App.swift", link.path)])
+        XCTAssertEqual(snapshotA.rootPathCache.entries.first?.standardizedPath, StandardizedPath.absolute(link.path))
+        XCTAssertEqual(snapshotA.rootPathCache.entries.first?.resolvedPath, resolvedTargetA)
+
+        try FileManager.default.removeItem(at: link)
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: targetB)
+
+        let resolvedTargetB = (StandardizedPath.absolute(targetB.path) as NSString).resolvingSymlinksInPath
+        let snapshotB = makeSnapshot(files: [("Sources/App.swift", link.path)])
+        XCTAssertEqual(snapshotB.rootPathCache.entries.first?.standardizedPath, StandardizedPath.absolute(link.path))
+        XCTAssertEqual(snapshotB.rootPathCache.entries.first?.resolvedPath, resolvedTargetB)
+        XCTAssertEqual(snapshotA.rootPathCache.entries.first?.resolvedPath, resolvedTargetA)
+    }
+
     func testAliasAndAbsoluteResolutionStayScopedToTheMatchingRoot() {
         let snapshot = makeSnapshot(files: [
             ("src/App.swift", "/Users/test/web"),

--- a/Tests/RepoPromptTests/WorkspaceContext/Search/StoreBackedWorkspaceSearchTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/Search/StoreBackedWorkspaceSearchTests.swift
@@ -908,6 +908,35 @@ final class StoreBackedWorkspaceSearchTests: XCTestCase {
             XCTAssertTrue((countOnly.matches ?? []).isEmpty)
         }
 
+        func testRegexContentSearchMapsUTF8OffsetsToUnicodeLineNumbersAndMaterializesLines() async throws {
+            let root = try makeTemporaryRoot(name: "UnicodeRegexLineLookup")
+            let fileURL = root.appendingPathComponent("Unicode.swift")
+            try write("🙂 first\né second needle\r\nthird needle\n", to: fileURL)
+            let store = WorkspaceFileContextStore()
+            _ = try await store.loadRoot(path: root.path)
+
+            let result = try await StoreBackedWorkspaceSearch.search(
+                pattern: "needle",
+                mode: .content,
+                isRegex: true,
+                caseInsensitive: false,
+                maxPaths: 10,
+                maxMatches: 10,
+                contextLines: 1,
+                rootScope: .visibleWorkspace,
+                store: store,
+                workspaceManager: nil
+            )
+            let matches = try XCTUnwrap(result.matches)
+
+            XCTAssertEqual(matches.map(\.lineNumber), [1, 2])
+            XCTAssertEqual(matches.map(\.lineText), ["é second needle", "third needle"])
+            XCTAssertEqual(matches[0].contextBefore, ["🙂 first"])
+            XCTAssertEqual(matches[0].contextAfter, ["third needle"])
+            XCTAssertEqual(matches[1].contextBefore, ["é second needle"])
+            XCTAssertNil(matches[1].contextAfter)
+        }
+
         func testCancelledScopedContentSearchDrainsCacheFlight() async throws {
             let root = try makeTemporaryRoot(name: "CancelledContentSearch")
             let fileURL = root.appendingPathComponent("A.swift")

--- a/Tests/RepoPromptTests/WorkspaceContext/WorkspaceSelectionPersistenceTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/WorkspaceSelectionPersistenceTests.swift
@@ -103,6 +103,95 @@ final class WorkspaceSelectionPersistenceTests: XCTestCase {
         XCTAssertEqual(decoded.composeTabs[0].promptText, "disk-field")
     }
 
+    func testDiskWriterVerifiesNewerDiskPayloadWithSingleFullWorkspaceDecode() async throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("WorkspaceSelectionPersistenceTests-")
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let url = tempDir.appendingPathComponent("workspace.json")
+        let writer = WorkspaceManagerViewModel.WorkspaceDiskWriter.shared
+        await writer.removeAllForTesting()
+
+        let workspaceID = UUID()
+        let tabID = UUID()
+        let disk = Self.workspace(
+            id: workspaceID,
+            tabID: tabID,
+            selection: Self.selection(count: 2),
+            dateModified: Date(timeIntervalSince1970: 300),
+            promptText: "disk-field"
+        )
+        try JSONEncoder().encode(disk).write(to: url, options: .atomic)
+        let incoming = Self.workspace(
+            id: workspaceID,
+            tabID: tabID,
+            selection: Self.selection(count: 3),
+            dateModified: Date(timeIntervalSince1970: 200),
+            promptText: "incoming-field"
+        )
+
+        WorkspaceManagerViewModel.WorkspaceDiskWriter.resetFullDecodeCountForTesting()
+        try await writer.enqueue(data: JSONEncoder().encode(incoming), url: url)
+        await writer.flush(url: url)
+
+        XCTAssertEqual(WorkspaceManagerViewModel.WorkspaceDiskWriter.fullDecodeCountSnapshotForTesting, 1)
+        let decoded = try JSONDecoder().decode(WorkspaceModel.self, from: Data(contentsOf: url))
+        XCTAssertEqual(decoded.composeTabs[0].promptText, "disk-field")
+    }
+
+    func testDiskWriterCoalescesOlderPendingPayloadWithoutFullWorkspaceDecode() async throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("WorkspaceSelectionPersistenceTests-")
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let url = tempDir.appendingPathComponent("workspace.json")
+        let writer = WorkspaceManagerViewModel.WorkspaceDiskWriter.shared
+        await writer.removeAllForTesting()
+        let gate = WorkspacePersistenceAsyncGate()
+        await writer.setAtomicWriteGateForTesting {
+            await gate.markStartedAndWaitForRelease()
+        }
+
+        let workspaceID = UUID()
+        let tabID = UUID()
+        let first = Self.workspace(
+            id: workspaceID,
+            tabID: tabID,
+            selection: Self.selection(count: 2),
+            dateModified: Date(timeIntervalSince1970: 300),
+            promptText: "first-field"
+        )
+        let newerPending = Self.workspace(
+            id: workspaceID,
+            tabID: tabID,
+            selection: Self.selection(count: 4),
+            dateModified: Date(timeIntervalSince1970: 400),
+            promptText: "newer-pending-field"
+        )
+        let older = Self.workspace(
+            id: workspaceID,
+            tabID: tabID,
+            selection: Self.selection(count: 3),
+            dateModified: Date(timeIntervalSince1970: 200),
+            promptText: "older-field"
+        )
+
+        try await writer.enqueue(data: JSONEncoder().encode(first), url: url)
+        await gate.waitUntilStarted()
+        try await writer.enqueue(data: JSONEncoder().encode(newerPending), url: url)
+        WorkspaceManagerViewModel.WorkspaceDiskWriter.resetFullDecodeCountForTesting()
+        try await writer.enqueue(data: JSONEncoder().encode(older), url: url)
+        await gate.release()
+        await writer.flush(url: url)
+        await writer.setAtomicWriteGateForTesting(nil)
+
+        XCTAssertEqual(WorkspaceManagerViewModel.WorkspaceDiskWriter.fullDecodeCountSnapshotForTesting, 0)
+        let decoded = try JSONDecoder().decode(WorkspaceModel.self, from: Data(contentsOf: url))
+        XCTAssertEqual(decoded.composeTabs[0].promptText, "newer-pending-field")
+    }
+
     func testDiskWriterFlushAndAtomicWriteTelemetryCarryDurabilityAttributionWithoutPaths() async throws {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("WorkspaceSelectionPersistenceTests-")

--- a/Tests/RepoPromptTests/Workspaces/WorkspaceFileDecodeCacheTests.swift
+++ b/Tests/RepoPromptTests/Workspaces/WorkspaceFileDecodeCacheTests.swift
@@ -1,0 +1,83 @@
+import Foundation
+@testable import RepoPrompt
+import XCTest
+
+final class WorkspaceFileDecodeCacheTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        WorkspaceFileDecodeCache.shared.removeAllForTesting()
+        WorkspaceFileDecodeCache.shared.resetBudgetForTesting()
+    }
+
+    override func tearDown() {
+        WorkspaceFileDecodeCache.shared.removeAllForTesting()
+        WorkspaceFileDecodeCache.shared.resetBudgetForTesting()
+        super.tearDown()
+    }
+
+    func testCacheEvictsLeastRecentlyUsedEntryWhenCountBudgetExceeded() throws {
+        WorkspaceFileDecodeCache.shared.setBudgetForTesting(maxEntryCount: 2, maxEstimatedCost: .max)
+        let directory = try makeTemporaryDirectory()
+        let firstURL = try writeWorkspace(named: "First", in: directory)
+        let secondURL = try writeWorkspace(named: "Second", in: directory)
+        let thirdURL = try writeWorkspace(named: "Third", in: directory)
+
+        XCTAssertFalse(try WorkspaceManagerViewModel.loadWorkspaceFromFileResult(at: firstURL).cacheHit)
+        XCTAssertFalse(try WorkspaceManagerViewModel.loadWorkspaceFromFileResult(at: secondURL).cacheHit)
+        XCTAssertTrue(try WorkspaceManagerViewModel.loadWorkspaceFromFileResult(at: firstURL).cacheHit)
+
+        XCTAssertFalse(try WorkspaceManagerViewModel.loadWorkspaceFromFileResult(at: thirdURL).cacheHit)
+        XCTAssertEqual(WorkspaceFileDecodeCache.shared.cachedEntryCountForTesting, 2)
+        XCTAssertTrue(try WorkspaceManagerViewModel.loadWorkspaceFromFileResult(at: firstURL).cacheHit)
+        XCTAssertFalse(try WorkspaceManagerViewModel.loadWorkspaceFromFileResult(at: secondURL).cacheHit)
+    }
+
+    func testCacheEvictsLeastRecentlyUsedEntryWhenCostBudgetExceededButKeepsSingleOversizedEntry() throws {
+        WorkspaceFileDecodeCache.shared.setBudgetForTesting(maxEntryCount: 8, maxEstimatedCost: 1)
+        let directory = try makeTemporaryDirectory()
+        let firstURL = try writeWorkspace(named: "First", in: directory)
+        let secondURL = try writeWorkspace(named: "Second", in: directory)
+
+        XCTAssertFalse(try WorkspaceManagerViewModel.loadWorkspaceFromFileResult(at: firstURL).cacheHit)
+        XCTAssertEqual(WorkspaceFileDecodeCache.shared.cachedEntryCountForTesting, 1)
+        XCTAssertTrue(try WorkspaceManagerViewModel.loadWorkspaceFromFileResult(at: firstURL).cacheHit)
+
+        XCTAssertFalse(try WorkspaceManagerViewModel.loadWorkspaceFromFileResult(at: secondURL).cacheHit)
+        XCTAssertEqual(WorkspaceFileDecodeCache.shared.cachedEntryCountForTesting, 1)
+        XCTAssertFalse(try WorkspaceManagerViewModel.loadWorkspaceFromFileResult(at: firstURL).cacheHit)
+        XCTAssertEqual(WorkspaceFileDecodeCache.shared.cachedEntryCountForTesting, 1)
+    }
+
+    func testInvalidationRemovesAllEntriesForStandardizedPath() throws {
+        WorkspaceFileDecodeCache.shared.setBudgetForTesting(maxEntryCount: 8, maxEstimatedCost: .max)
+        let directory = try makeTemporaryDirectory()
+        let fileURL = try writeWorkspace(named: "Standardized", in: directory)
+        let nonStandardURL = fileURL.deletingLastPathComponent()
+            .appendingPathComponent("unused")
+            .appendingPathComponent("..")
+            .appendingPathComponent(fileURL.lastPathComponent)
+
+        XCTAssertFalse(try WorkspaceManagerViewModel.loadWorkspaceFromFileResult(at: nonStandardURL).cacheHit)
+        XCTAssertTrue(try WorkspaceManagerViewModel.loadWorkspaceFromFileResult(at: fileURL).cacheHit)
+
+        WorkspaceFileDecodeCache.shared.invalidate(url: fileURL)
+
+        XCTAssertFalse(try WorkspaceManagerViewModel.loadWorkspaceFromFileResult(at: nonStandardURL).cacheHit)
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("WorkspaceFileDecodeCacheTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+
+    private func writeWorkspace(named name: String, in directory: URL) throws -> URL {
+        let workspaceDirectory = directory.appendingPathComponent(name, isDirectory: true)
+        try FileManager.default.createDirectory(at: workspaceDirectory, withIntermediateDirectories: true)
+        let fileURL = workspaceDirectory.appendingPathComponent("workspace.json")
+        let workspace = WorkspaceModel(name: name, repoPaths: [])
+        try JSONEncoder().encode(workspace).write(to: fileURL, options: .atomic)
+        return fileURL
+    }
+}

--- a/Tests/RepoPromptTests/Workspaces/WorkspaceFileDecodeCacheTests.swift
+++ b/Tests/RepoPromptTests/Workspaces/WorkspaceFileDecodeCacheTests.swift
@@ -65,6 +65,29 @@ final class WorkspaceFileDecodeCacheTests: XCTestCase {
         XCTAssertFalse(try WorkspaceManagerViewModel.loadWorkspaceFromFileResult(at: nonStandardURL).cacheHit)
     }
 
+    func testCacheReplacesOlderMetadataEntriesForSameStandardizedPath() throws {
+        WorkspaceFileDecodeCache.shared.setBudgetForTesting(maxEntryCount: 8, maxEstimatedCost: .max)
+        let directory = try makeTemporaryDirectory()
+        let workspaceDirectory = directory.appendingPathComponent("SamePath", isDirectory: true)
+        let fileURL = workspaceDirectory.appendingPathComponent("workspace.json")
+
+        try writeWorkspace(
+            named: "Same Path First",
+            to: fileURL,
+            modificationDate: Date(timeIntervalSince1970: 1000)
+        )
+        XCTAssertFalse(try WorkspaceManagerViewModel.loadWorkspaceFromFileResult(at: fileURL).cacheHit)
+        XCTAssertEqual(WorkspaceFileDecodeCache.shared.cachedEntryCountForTesting, 1)
+
+        try writeWorkspace(
+            named: "Same Path Second With Different Metadata",
+            to: fileURL,
+            modificationDate: Date(timeIntervalSince1970: 2000)
+        )
+        XCTAssertFalse(try WorkspaceManagerViewModel.loadWorkspaceFromFileResult(at: fileURL).cacheHit)
+        XCTAssertEqual(WorkspaceFileDecodeCache.shared.cachedEntryCountForTesting, 1)
+    }
+
     private func makeTemporaryDirectory() throws -> URL {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("WorkspaceFileDecodeCacheTests-\(UUID().uuidString)", isDirectory: true)
@@ -74,10 +97,22 @@ final class WorkspaceFileDecodeCacheTests: XCTestCase {
 
     private func writeWorkspace(named name: String, in directory: URL) throws -> URL {
         let workspaceDirectory = directory.appendingPathComponent(name, isDirectory: true)
-        try FileManager.default.createDirectory(at: workspaceDirectory, withIntermediateDirectories: true)
         let fileURL = workspaceDirectory.appendingPathComponent("workspace.json")
+        try writeWorkspace(named: name, to: fileURL)
+        return fileURL
+    }
+
+    private func writeWorkspace(
+        named name: String,
+        to fileURL: URL,
+        modificationDate: Date = Date()
+    ) throws {
+        try FileManager.default.createDirectory(
+            at: fileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
         let workspace = WorkspaceModel(name: name, repoPaths: [])
         try JSONEncoder().encode(workspace).write(to: fileURL, options: .atomic)
-        return fileURL
+        try FileManager.default.setAttributes([.modificationDate: modificationDate], ofItemAtPath: fileURL.path)
     }
 }


### PR DESCRIPTION
## Purpose

This PR is for **further analysis and discussion** of RepoPrompt CE performance and memory behavior. It collects an initial set of low-level performance hygiene changes discovered while monitoring a live app process and stress/smoke-testing the debug build.

This issue and PR are intentionally framed as investigation/discussion artifacts. The changes are structurally motivated and validated for correctness, but they should **not** be read as a claim of controlled, quantified performance gains yet.

Related issue: https://github.com/repoprompt/repoprompt-ce/issues/241

## Summary

This branch includes 10 focused commits over the base checkout:

1. Bound workspace decode cache
2. Use workspace payload headers for disk writer checks
3. Reduce search line index memory
4. Cache path matcher root resolutions
5. Memoize agent context pill summary
6. Reuse binary probe bytes for text reads
7. Reuse transcript analytics snapshot
8. Preserve path matcher root identity
9. Isolate persistent MCP workspace fixture
10. Replace stale workspace decode cache entries

Changed surface:

- Workspace decode/cache and selection persistence
- Workspace disk writer stale checks
- Store-backed search line indexing
- Workspace path lookup/matching
- Agent transcript analytics and context pill rendering
- File text loading / binary probing
- Persistent MCP fixture isolation

Diff stat for the perf range:

```text
14 files changed, 602 insertions(+), 81 deletions(-)
```

## Evidence and validation

Validation completed on the branch:

- `make dev-format` passed.
- `make dev-lint` passed.
- `git diff --check` passed.
- Focused tests passed for the affected areas, including:
  - `WorkspaceFileDecodeCacheTests`
  - `WorkspaceSelectionPersistenceTests`
  - `StoreBackedWorkspaceSearchTests`
  - `PathMatchingRecoveryTests`
  - `FileSystemContentLoadingConcurrencyTests`
  - `AgentTranscriptAnalyticsCacheTests`
  - persistent MCP read-file connection coverage
- A full coordinated `make dev-test` passed before the final stale-entry cache follow-up.
- After the final stale-entry follow-up, push preflight passed:
  - secret scanning / repository guardrails
  - coordinated Swift lint
  - coordinated root `swift test`
  - coordinated provider tests
  - `swift build --product RepoPrompt`
  - `swift build --product repoprompt-mcp`
- Debug build smoke passed against the perf build:
  - app launched successfully from the perf worktree
  - live MCP operations worked (`tree`, `file_search`, `read_file`, `code_structure`, `workspace_context`, settings)
  - Agent Mode smoke returned the expected response
- Oracle review found no remaining blocker after the stale same-path decode cache concern was patched.

## Runtime observations from live monitoring

The original investigation started from monitoring a live RepoPrompt CE process, then expanded beyond memory into CPU/runtime behavior and debug-build smoke workloads.

During perf-branch debug smoke, the app survived a heavy live workload including a large `workspace_context` render (~154k selected context), CLI MCP calls, and an Agent Mode smoke run.

Observed RSS movement for the debug process was roughly:

- baseline: ~326 MB
- after heavy context generation: ~627 MB
- after CLI + Agent smoke: ~656 MB

These observations are useful evidence that the branch holds up under the exercised workload, but they are **not** attribution-quality before/after measurements.

## Brutal caveat

I do think this branch contains real performance hygiene improvements: fewer repeated decodes, bounded cache behavior, less retained search indexing data, less repeated path-resolution work, fewer repeated UI/transcript derivations, and less duplicate file-read work.

But the gains are not yet quantified. We still need a controlled benchmark plan comparing `main` vs this branch on the same workspace/workload before claiming specific wins.

Known follow-ups:

- Add repeatable perf scenarios for large workspace load/save, repeated selection persistence, large `workspace_context`, search generation, path matching, and large transcript refresh.
- Capture wall-clock, CPU samples, allocations, RSS/dirty memory, and p50/p95 latency.
- Revisit whether disk-writer stale checks truly avoid full payload decode or need a dedicated compact header path.

## Notes for reviewers

Please treat this PR as a concrete discussion branch attached to issue #241 rather than a final benchmark-backed performance claim. I would especially like review on:

- cache invalidation and stale-entry correctness
- memory bounds/cost accounting
- whether the path matcher root-resolution cache has any identity/ordering edge cases
- whether the search line-index representation preserves all expected behavior
- whether the UI/transcript memoization changes risk stale display state
