### PR TITLE
Fix worktree readiness and parallel agent startup

### DIFF
--- a/Sources/RepoPrompt/App/AppLaunchConfiguration.swift
+++ b/Sources/RepoPrompt/App/AppLaunchConfiguration.swift
@@ -5,7 +5,10 @@ struct AppLaunchConfiguration {
         case main
     }
 
-    static let current = AppLaunchConfiguration(processInfo: .processInfo)
+    static let current = AppLaunchConfiguration(
+        processInfo: .processInfo,
+        bundleURL: Bundle.main.bundleURL
+    )
 
     let isUITestSession: Bool
     let suppressesWindowRestore: Bool
@@ -15,9 +18,25 @@ struct AppLaunchConfiguration {
     let forcedRootRoute: ForcedRootRoute?
     #if DEBUG
         let agentChatStress: AgentChatStressLaunchConfiguration?
+        let forcesMCPAutoStart: Bool
     #endif
 
-    private init(processInfo: ProcessInfo) {
+    #if DEBUG
+        static func debugBuildForcesMCPAutoStart(
+            bundleURL: URL,
+            arguments: Set<String> = [],
+            environment: [String: String] = [:]
+        ) -> Bool {
+            let isPackagedApp = bundleURL.pathExtension.caseInsensitiveCompare("app") == .orderedSame
+            let isUITestSession = arguments.contains("-RP_UITEST")
+            let isHostedXCTestSession = environment["XCTestConfigurationFilePath"] != nil
+                || environment["XCInjectBundleInto"] != nil
+                || arguments.contains(where: { $0.hasPrefix("-XCTest") })
+            return isPackagedApp && !isUITestSession && !isHostedXCTestSession
+        }
+    #endif
+
+    private init(processInfo: ProcessInfo, bundleURL: URL) {
         let arguments = Set(processInfo.arguments)
         let environment = processInfo.environment
         let isUITestSession = arguments.contains("-RP_UITEST")
@@ -44,6 +63,11 @@ struct AppLaunchConfiguration {
         forcedRootRoute = isDeterministicUITestLaunch ? .main : nil
         #if DEBUG
             self.agentChatStress = agentChatStress
+            forcesMCPAutoStart = Self.debugBuildForcesMCPAutoStart(
+                bundleURL: bundleURL,
+                arguments: arguments,
+                environment: environment
+            )
         #endif
     }
 }

--- a/Sources/RepoPrompt/App/WindowState.swift
+++ b/Sources/RepoPrompt/App/WindowState.swift
@@ -384,6 +384,11 @@ class WindowState: ObservableObject {
 
         // Set up additional actions
         setupSendPromptAction()
+        #if DEBUG
+            if AppLaunchConfiguration.current.forcesMCPAutoStart {
+                setupMCPAutoStart()
+            }
+        #endif
 
         // Set up workspace switch listener to sync settings and validate prompts
         workspaceManager.addWorkspaceDidSwitchListener(label: "windowState") { [weak self] workspace in

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentModeProcessRunIdentity.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentModeProcessRunIdentity.swift
@@ -6,6 +6,32 @@ enum AgentModeProcessRunIdentity {
         session.runID
     }
 
+    static func mostRecentTranscriptProcessRunID(for session: AgentModeViewModel.TabSession) -> UUID? {
+        session.transcript.turns.last?.responseSpans.reversed().compactMap(\.runID).first
+    }
+
+    @discardableResult
+    static func retainProcessRunID(
+        _ runID: UUID,
+        inTranscriptTurnID turnID: UUID,
+        for session: AgentModeViewModel.TabSession
+    ) -> Bool {
+        guard let turnIndex = session.transcript.turns.firstIndex(where: { $0.id == turnID }),
+              let spanIndex = session.transcript.turns[turnIndex].responseSpans.indices.last
+        else {
+            return false
+        }
+        let existingRunID = session.transcript.turns[turnIndex].responseSpans[spanIndex].runID
+        guard existingRunID == nil || existingRunID == runID else {
+            return false
+        }
+        if existingRunID == nil {
+            session.transcript.turns[turnIndex].responseSpans[spanIndex].runID = runID
+            session.isDirty = true
+        }
+        return true
+    }
+
     static func startFreshProcessRun(for session: AgentModeViewModel.TabSession) -> UUID {
         let runID = UUID()
         session.runID = runID

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentModeRunLease.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentModeRunLease.swift
@@ -63,7 +63,7 @@ extension MCPBootstrapLease {
 
         return { leaseSpec in
             guard let clientName = leaseSpec.clientName else { return }
-            await ServerNetworkManager.shared.clearClientConnectionPolicy(
+            await ServerNetworkManager.shared.revokeClientConnectionPolicy(
                 for: clientName,
                 windowID: leaseSpec.windowID,
                 runID: leaseSpec.runID

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentModeRunService.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentModeRunService.swift
@@ -8,6 +8,7 @@ final class AgentModeRunService {
         let acpProviderFactory: AgentModeViewModel.ACPProviderFactory
         let acpControllerFactory: AgentModeViewModel.ACPControllerFactory
         let connectionPolicyInstaller: AgentModeViewModel.ConnectionPolicyInstaller
+        let expectedPIDPolicyArmer: (MCPBootstrapLeaseSpec) async -> Bool
         let mcpServerEnabler: AgentModeViewModel.MCPServerEnabler
         let workspacePathProvider: (AgentModeViewModel.TabSession) throws -> String?
         let codexCoordinator: CodexAgentModeCoordinator
@@ -74,7 +75,8 @@ final class AgentModeRunService {
         let makeTerminalPublicationEnvelope: (
             AgentModeViewModel.TabSession,
             AgentRunOwnership,
-            AgentSessionRunState
+            AgentSessionRunState,
+            UUID?
         ) -> AgentRunTerminalPublicationEnvelope?
         let publishTerminalCommit: (
             AgentModeViewModel.TabSession,
@@ -204,6 +206,7 @@ final class AgentModeRunService {
         let windowID = dependencies.windowID
         let mcpServerEnabler = dependencies.mcpServerEnabler
         let connectionPolicyInstaller = dependencies.connectionPolicyInstaller
+        let expectedPIDPolicyArmer = dependencies.expectedPIDPolicyArmer
         let taskLabelKind = session.mcpControlContext?.taskLabelKind
         let allowsAgentExternalControlTools = session.mcpControlContext != nil && session.parentSessionID == nil
         let makeLease: (_ runID: UUID) -> MCPBootstrapLease = { runID in
@@ -219,7 +222,8 @@ final class AgentModeRunService {
             return MCPBootstrapLease(
                 spec: leaseSpec,
                 mcpServerEnabler: mcpServerEnabler,
-                policyInstaller: MCPBootstrapLease.agentModePolicyInstaller(connectionPolicyInstaller)
+                policyInstaller: MCPBootstrapLease.agentModePolicyInstaller(connectionPolicyInstaller),
+                expectedPIDPolicyArmer: expectedPIDPolicyArmer
             )
         }
         if selectedAgent.usesClaudeNativeRuntime {

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentRunTerminalCommitBarrier.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentRunTerminalCommitBarrier.swift
@@ -172,6 +172,7 @@ final class AgentRunTerminalCommitBarrier {
             recordRejection("provider_buffers_pending", request: request)
             return nil
         }
+        let terminalTurnID = session.items.last(where: { $0.kind == .user })?.id
 
         session.terminalCommitInProgress = true
         recordTerminalBarrierState(true, request: request)
@@ -260,6 +261,13 @@ final class AgentRunTerminalCommitBarrier {
         _ = session.endRunAttempt(ifCurrent: request.ownership, source: request.source)
         hooks.setAgentRunActive(session.tabID, false)
         hooks.prepareTerminalPublication(session)
+        if let runID = request.expectedRunID, let terminalTurnID {
+            AgentModeProcessRunIdentity.retainProcessRunID(
+                runID,
+                inTranscriptTurnID: terminalTurnID,
+                for: session
+            )
+        }
 
         let successorKind: AgentRunEpochTransitionKind? = if queuedInstruction != nil {
             .relatedFollowUp
@@ -276,7 +284,8 @@ final class AgentRunTerminalCommitBarrier {
             mcpPublicationEnvelope: hooks.makeTerminalPublicationEnvelope(
                 session,
                 request.ownership,
-                request.terminalState
+                request.terminalState,
+                request.expectedRunID
             ),
             successorKind: successorKind,
             providerSuccessorID: providerSuccessor?.id

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Codex/CodexAgentModeCoordinator.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Codex/CodexAgentModeCoordinator.swift
@@ -3843,6 +3843,7 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
             let acquired = await lease.acquire()
             guard acquired else { return }
 
+            await lease.providerInitializationStarted(provider: AgentProviderKind.codexExec.rawValue)
             await ensureCodexNativeSession(
                 session: session,
                 policyAlreadyInstalled: true,
@@ -3852,6 +3853,12 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
                 semanticRunState: semanticRunState
             )
 
+            let providerReady = effectiveRunState.isActive
+                && session.codexController?.hasActiveThread == true
+            await lease.providerInitializationCompleted(
+                provider: AgentProviderKind.codexExec.rawValue,
+                outcome: providerReady ? "ready" : (Task.isCancelled ? "cancelled" : "failed")
+            )
             guard effectiveRunState.isActive,
                   session.codexController?.hasActiveThread == true
             else {

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/ACPIntegratedAgentModeRunner.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/ACPIntegratedAgentModeRunner.swift
@@ -479,9 +479,14 @@ final class ACPIntegratedAgentModeRunner {
             return
         }
 
+        var providerInitializationCompleted = false
         do {
+            let providerName = runRequest.agentKind.rawValue
+            await lease.providerInitializationStarted(provider: providerName)
             log("bootstrap begin", runID: runID)
             let bootstrap = try await controller.bootstrap()
+            providerInitializationCompleted = true
+            await lease.providerInitializationCompleted(provider: providerName, outcome: "ready")
             log("bootstrap completed sessionID=\(bootstrap.sessionID)", runID: runID)
             guard session.runID == runID,
                   session.activeRunAttemptID == runAttemptID
@@ -543,6 +548,9 @@ final class ACPIntegratedAgentModeRunner {
                 prepareControllerForNextTurn: false
             )
         } catch is CancellationError {
+            if !providerInitializationCompleted {
+                await lease.providerInitializationCompleted(provider: runRequest.agentKind.rawValue, outcome: "cancelled")
+            }
             log("fresh start cancelled", runID: runID)
             await finalize(
                 session: session,
@@ -556,6 +564,9 @@ final class ACPIntegratedAgentModeRunner {
                 shouldShutdownController: true
             )
         } catch {
+            if !providerInitializationCompleted {
+                await lease.providerInitializationCompleted(provider: runRequest.agentKind.rawValue, outcome: "failed")
+            }
             let normalized = await controller.normalizeError(error)
             let normalizedText = displayText(for: normalized)
             log("fresh start failed raw=\(String(describing: error)) normalized=\(normalizedText)", runID: runID)

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/ClaudeIntegratedAgentModeRunner.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/ClaudeIntegratedAgentModeRunner.swift
@@ -110,10 +110,16 @@ final class ClaudeIntegratedAgentModeRunner {
                     runID: runID
                 )
 
+                let providerName = session.selectedAgent.rawValue
+                await lease.providerInitializationStarted(provider: providerName)
                 let sent = await self.claudeCoordinator.sendClaudeNativeMessage(
                     session: session,
                     text: initialMessageForRun,
                     attachments: attachments
+                )
+                await lease.providerInitializationCompleted(
+                    provider: providerName,
+                    outcome: sent ? "ready" : (Task.isCancelled ? "cancelled" : "failed")
                 )
                 self.hooks.recordPendingHandoffSendOutcome(session, sent)
                 guard sent else {

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/HeadlessAgentModeRunner.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/HeadlessAgentModeRunner.swift
@@ -168,8 +168,12 @@ final class HeadlessAgentModeRunner {
         attachmentReservationID: UUID?,
         lease: MCPBootstrapLease
     ) async {
+        var providerInitializationCompleted = false
         do {
+            await lease.providerInitializationStarted(provider: session.selectedAgent.rawValue)
             let stream = try await provider.streamAgentMessage(initialMessage, runID: runID)
+            providerInitializationCompleted = true
+            await lease.providerInitializationCompleted(provider: session.selectedAgent.rawValue, outcome: "ready")
             hooks.recordPendingHandoffSendOutcome(session, true)
             hooks.stageConsumedAttachmentFilesForDeferredCleanup(attachments, session)
             hooks.markAttachmentsConsumed(session, attachmentReservationID)
@@ -209,6 +213,9 @@ final class HeadlessAgentModeRunner {
                 }
             ))
         } catch is CancellationError {
+            if !providerInitializationCompleted {
+                await lease.providerInitializationCompleted(provider: session.selectedAgent.rawValue, outcome: "cancelled")
+            }
             hooks.recordPendingHandoffSendOutcome(session, false)
             await terminalCommitBarrier.commit(.init(
                 session: session,
@@ -228,6 +235,9 @@ final class HeadlessAgentModeRunner {
                 }
             ))
         } catch {
+            if !providerInitializationCompleted {
+                await lease.providerInitializationCompleted(provider: session.selectedAgent.rawValue, outcome: "failed")
+            }
             hooks.recordPendingHandoffSendOutcome(session, false)
             await terminalCommitBarrier.commit(.init(
                 session: session,

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -670,12 +670,14 @@ final class AgentModeViewModel: ObservableObject {
         func test_makeTerminalPublicationEnvelope(
             for session: TabSession,
             ownership: AgentRunOwnership,
-            terminalState: AgentSessionRunState
+            terminalState: AgentSessionRunState,
+            providerRunID: UUID? = nil
         ) -> AgentRunTerminalPublicationEnvelope? {
             makeTerminalPublicationEnvelope(
                 for: session,
                 ownership: ownership,
-                terminalState: terminalState
+                terminalState: terminalState,
+                providerRunID: providerRunID
             )
         }
 
@@ -1874,6 +1876,16 @@ final class AgentModeViewModel: ObservableObject {
             acpProviderFactory: acpProviderFactory,
             acpControllerFactory: acpControllerFactory,
             connectionPolicyInstaller: connectionPolicyInstaller,
+            expectedPIDPolicyArmer: { spec in
+                guard spec.requiresExpectedAgentPID, let clientName = spec.clientName else {
+                    return !spec.requiresExpectedAgentPID
+                }
+                return await ServerNetworkManager.shared.requireExpectedAgentPIDForPendingPolicy(
+                    for: clientName,
+                    runID: spec.runID,
+                    windowID: spec.windowID
+                )
+            },
             mcpServerEnabler: mcpServerEnabler,
             workspacePathProvider: { [weak self] session in
                 guard let self else { return nil }
@@ -2002,11 +2014,12 @@ final class AgentModeViewModel: ObservableObject {
             prepareTerminalPublication: { [weak self] session in
                 self?.prepareTerminalPublication(for: session)
             },
-            makeTerminalPublicationEnvelope: { [weak self] session, ownership, terminalState in
+            makeTerminalPublicationEnvelope: { [weak self] session, ownership, terminalState, providerRunID in
                 self?.makeTerminalPublicationEnvelope(
                     for: session,
                     ownership: ownership,
-                    terminalState: terminalState
+                    terminalState: terminalState,
+                    providerRunID: providerRunID
                 )
             },
             publishTerminalCommit: { [weak self] session, revision, successorKind in
@@ -4143,14 +4156,19 @@ final class AgentModeViewModel: ObservableObject {
     private func makeTerminalPublicationEnvelope(
         for session: TabSession,
         ownership: AgentRunOwnership,
-        terminalState: AgentSessionRunState
+        terminalState: AgentSessionRunState,
+        providerRunID: UUID?
     ) -> AgentRunTerminalPublicationEnvelope? {
         guard let epoch = ownership.turnEpoch,
               let context = session.mcpControlContext,
               context.sessionID == epoch.sessionID,
               context.activationID == epoch.activationID,
               context.registration.generation == epoch.registrationGeneration,
-              let snapshot = mcpSnapshot(for: session, canonicalTerminalState: terminalState)
+              let snapshot = mcpSnapshot(
+                  for: session,
+                  canonicalTerminalState: terminalState,
+                  canonicalProviderRunID: providerRunID
+              )
         else {
             return nil
         }
@@ -4556,7 +4574,8 @@ final class AgentModeViewModel: ObservableObject {
 
     func mcpSnapshot(
         for session: TabSession,
-        canonicalTerminalState: AgentSessionRunState? = nil
+        canonicalTerminalState: AgentSessionRunState? = nil,
+        canonicalProviderRunID: UUID? = nil
     ) -> AgentRunMCPSnapshot? {
         guard let context = session.mcpControlContext else { return nil }
         let interaction = canonicalTerminalState == nil ? mcpPendingInteraction(for: session) : nil
@@ -4668,8 +4687,16 @@ final class AgentModeViewModel: ObservableObject {
             return "Agent Session"
         }()
         let failureReason = AgentRunMCPSnapshot.FailureReason.classify(status: status, statusText: resolvedStatusText)
+        let providerRunID: UUID? = if canonicalTerminalState != nil {
+            canonicalProviderRunID ?? AgentModeProcessRunIdentity.mostRecentTranscriptProcessRunID(for: session)
+        } else if status.isTerminal {
+            session.runID ?? AgentModeProcessRunIdentity.mostRecentTranscriptProcessRunID(for: session)
+        } else {
+            session.runID
+        }
         return AgentRunMCPSnapshot(
             sessionID: resolvedSessionID,
+            runID: providerRunID,
             tabID: session.tabID,
             sessionName: resolvedSessionName,
             agentRaw: session.selectedAgent.rawValue,

--- a/Sources/RepoPrompt/Features/Search/StoreBackedWorkspaceSearch.swift
+++ b/Sources/RepoPrompt/Features/Search/StoreBackedWorkspaceSearch.swift
@@ -4,6 +4,9 @@ import RepoPromptShared
 enum StoreBackedWorkspaceSearchError: LocalizedError, Equatable {
     case worktreeScopeUnavailable(missingPhysicalRootPaths: [String])
     case workspaceFreshnessTimedOut
+    case workspaceReadinessUnavailable
+    case workspaceReadinessTimedOut
+    case workspaceReadinessSuperseded
 
     var retryAfterMilliseconds: Int {
         1000
@@ -15,6 +18,12 @@ enum StoreBackedWorkspaceSearchError: LocalizedError, Equatable {
             "Retry after the suggested delay. If the worktree remains unavailable, restore it or rebind the Agent session to an available worktree."
         case .workspaceFreshnessTimedOut:
             "Retry after workspace file updates finish applying."
+        case .workspaceReadinessUnavailable:
+            "Wait for a workspace activation to establish search readiness, then retry."
+        case .workspaceReadinessTimedOut:
+            "Retry after workspace catalog and index hydration completes."
+        case .workspaceReadinessSuperseded:
+            "Retry the search against the newly active workspace."
         }
     }
 
@@ -26,6 +35,12 @@ enum StoreBackedWorkspaceSearchError: LocalizedError, Equatable {
             return "The bound physical \(noun) unavailable. The visible base workspace was intentionally not searched."
         case .workspaceFreshnessTimedOut:
             return "Workspace freshness timed out before file_search could begin. Retry the search after workspace updates finish applying."
+        case .workspaceReadinessUnavailable:
+            return "Workspace search readiness is unavailable because no workspace activation is currently established."
+        case .workspaceReadinessTimedOut:
+            return "Workspace search readiness timed out before file_search could begin."
+        case .workspaceReadinessSuperseded:
+            return "Workspace search was superseded by a workspace activation or hydration generation change."
         }
     }
 }
@@ -36,6 +51,7 @@ enum StoreBackedWorkspaceSearchError: LocalizedError, Equatable {
 /// `WorkspaceFilesViewModel` tree projections.
 enum StoreBackedWorkspaceSearch {
     #if DEBUG
+        @TaskLocal static var readinessWaitTimeoutOverrideForTesting: Duration?
         @TaskLocal static var freshnessWaitTimeoutOverrideForTesting: Duration?
         @TaskLocal static var freshnessWaitOperationOverrideForTesting: (@Sendable ([WorkspaceRootRef], WorkspaceFileContextStore) async -> [WorkspaceIngressBarrierSample])?
     #endif
@@ -61,7 +77,17 @@ enum StoreBackedWorkspaceSearch {
     ) async throws -> SearchResults {
         try Task.checkCancellation()
         try await ensureRootScopeAvailable(rootScope, store: store)
-        try await ensureSearchReady(store: store, workspaceManager: workspaceManager)
+        let readinessTicket = try await acquireSearchReadiness(
+            store: store,
+            workspaceManager: workspaceManager
+        )
+        try await ensureRootScopeAvailable(
+            rootScope,
+            store: store,
+            readinessTicket: readinessTicket,
+            workspaceManager: workspaceManager
+        )
+        try await validateSearchReadiness(readinessTicket, workspaceManager: workspaceManager)
 
         let effectiveMode = mode == .auto ? FileSearchActor.inferredAutoMode(pattern) : mode
         let admissionClass = broadSearchAdmissionClass(pattern: pattern, mode: mode, paths: paths)
@@ -70,9 +96,14 @@ enum StoreBackedWorkspaceSearch {
             admissionClass: admissionClass
         ) { fileSearchActor in
             if admissionClass != nil {
-                try await ensureRootScopeAvailable(rootScope, store: store)
-                try await ensureSearchReady(store: store, workspaceManager: workspaceManager)
+                try await ensureRootScopeAvailable(
+                    rootScope,
+                    store: store,
+                    readinessTicket: readinessTicket,
+                    workspaceManager: workspaceManager
+                )
             }
+            try await validateSearchReadiness(readinessTicket, workspaceManager: workspaceManager)
 
             var parsedSearchScope: SearchScopeParseResult? = if let rawPaths = paths, !rawPaths.isEmpty {
                 await parseSearchScopePaths(
@@ -84,11 +115,13 @@ enum StoreBackedWorkspaceSearch {
             } else {
                 nil
             }
+            try await validateSearchReadiness(readinessTicket, workspaceManager: workspaceManager)
             let freshnessRootRefs: [WorkspaceRootRef] = if let parsedSearchScope {
                 parsedSearchScope.freshnessRootRefs
             } else {
                 await store.rootRefs(scope: rootScope)
             }
+            try await validateSearchReadiness(readinessTicket, workspaceManager: workspaceManager)
             #if DEBUG
                 let freshnessWaitTimeout = freshnessWaitTimeoutOverrideForTesting
                     ?? MCPTimeoutPolicy.workspaceFreshnessWaitTimeout
@@ -103,6 +136,7 @@ enum StoreBackedWorkspaceSearch {
                     store: store,
                     timeout: freshnessWaitTimeout
                 )
+                try await validateSearchReadiness(readinessTicket, workspaceManager: workspaceManager)
             } catch {
                 EditFlowPerf.end(EditFlowPerf.Stage.Search.ingressFreshnessWait, ingressFreshnessState)
                 throw error
@@ -113,6 +147,7 @@ enum StoreBackedWorkspaceSearch {
                 rootRefs: freshnessRootRefs,
                 appliedIngressSamples: appliedIngressSamples
             )
+            try await validateSearchReadiness(readinessTicket, workspaceManager: workspaceManager)
             try Task.checkCancellation()
             if let parsed = parsedSearchScope {
                 // Exact paths can change kind or disappear while the freshness barrier applies
@@ -122,6 +157,7 @@ enum StoreBackedWorkspaceSearch {
                     parsed,
                     store: store
                 )
+                try await validateSearchReadiness(readinessTicket, workspaceManager: workspaceManager)
             }
             try Task.checkCancellation()
 
@@ -146,7 +182,9 @@ enum StoreBackedWorkspaceSearch {
                 parsedSearchScope: parsedSearchScope,
                 rootScope: rootScope,
                 store: store,
-                fileSearchActor: fileSearchActor
+                fileSearchActor: fileSearchActor,
+                workspaceManager: workspaceManager,
+                readinessTicket: readinessTicket
             )
         }
     }
@@ -200,7 +238,9 @@ enum StoreBackedWorkspaceSearch {
         parsedSearchScope: SearchScopeParseResult?,
         rootScope: WorkspaceLookupRootScope,
         store: WorkspaceFileContextStore,
-        fileSearchActor: FileSearchActor
+        fileSearchActor: FileSearchActor,
+        workspaceManager: WorkspaceManagerViewModel?,
+        readinessTicket: WorkspaceSearchReadinessTicket?
     ) async throws -> SearchResults {
         let entryPerfState = EditFlowPerf.begin(
             EditFlowPerf.Stage.Search.entrypoint,
@@ -232,8 +272,11 @@ enum StoreBackedWorkspaceSearch {
             )
         }
 
+        try await validateSearchReadiness(readinessTicket, workspaceManager: workspaceManager)
+        let catalogAccess = await store.searchCatalogAccess(rootScope: rootScope)
+        try await validateSearchReadiness(readinessTicket, workspaceManager: workspaceManager)
         let snapshot: WorkspaceSearchCatalogSnapshot
-        switch await store.searchCatalogAccess(rootScope: rootScope) {
+        switch catalogAccess {
         case let .available(availableSnapshot):
             snapshot = availableSnapshot
         case let .unavailable(availability):
@@ -243,6 +286,7 @@ enum StoreBackedWorkspaceSearch {
 
         let rootsByID = Dictionary(uniqueKeysWithValues: snapshot.roots.map { ($0.id, $0) })
         let visibleRootRefs = await store.rootRefs(scope: .visibleWorkspace)
+        try await validateSearchReadiness(readinessTicket, workspaceManager: workspaceManager)
         let visibleRootIDs = Set(visibleRootRefs.map(\.id))
         let visibleRootRecords = snapshot.roots.filter { visibleRootIDs.contains($0.id) }
         let allFiles = snapshot.files
@@ -292,6 +336,7 @@ enum StoreBackedWorkspaceSearch {
             if filterResult.cancelled || Task.isCancelled {
                 throw CancellationError()
             }
+            try await validateSearchReadiness(readinessTicket, workspaceManager: workspaceManager)
             filesToSearch = filterResult.matchedSnapshotIndices.map { allFiles[$0] }
         } else {
             filesToSearch = allFiles
@@ -323,6 +368,7 @@ enum StoreBackedWorkspaceSearch {
         var wasAutoCorrected: Bool? = nil
         var results: SearchResults
         do {
+            try await validateSearchReadiness(readinessTicket, workspaceManager: workspaceManager)
             results = try await EditFlowPerf.measure(
                 EditFlowPerf.Stage.Search.actorSearchCall,
                 EditFlowPerf.Dimensions(
@@ -359,6 +405,7 @@ enum StoreBackedWorkspaceSearch {
                     aliasByRootPath: aliasByRootPath
                 )
             }
+            try await validateSearchReadiness(readinessTicket, workspaceManager: workspaceManager)
         } catch {
             entryPerfStatus = "error"
             throw error
@@ -372,9 +419,12 @@ enum StoreBackedWorkspaceSearch {
 
     private static func ensureRootScopeAvailable(
         _ rootScope: WorkspaceLookupRootScope,
-        store: WorkspaceFileContextStore
+        store: WorkspaceFileContextStore,
+        readinessTicket: WorkspaceSearchReadinessTicket? = nil,
+        workspaceManager: WorkspaceManagerViewModel? = nil
     ) async throws {
         let availability = await store.rootScopeAvailability(rootScope)
+        try await validateSearchReadiness(readinessTicket, workspaceManager: workspaceManager)
         guard availability == .available else {
             throw searchError(for: availability)
         }
@@ -391,28 +441,82 @@ enum StoreBackedWorkspaceSearch {
         }
     }
 
-    private static func ensureSearchReady(
+    private static func acquireSearchReadiness(
         store: WorkspaceFileContextStore,
+        workspaceManager: WorkspaceManagerViewModel?
+    ) async throws -> WorkspaceSearchReadinessTicket? {
+        guard let workspaceManager else {
+            try await ensureVisibleWorkspaceLoaded(
+                store: store,
+                readinessTicket: nil,
+                workspaceManager: nil
+            )
+            return nil
+        }
+        #if DEBUG
+            let timeout = readinessWaitTimeoutOverrideForTesting
+                ?? MCPTimeoutPolicy.workspaceReadinessWaitTimeout
+        #else
+            let timeout = MCPTimeoutPolicy.workspaceReadinessWaitTimeout
+        #endif
+        let ticket: WorkspaceSearchReadinessTicket
+        do {
+            ticket = try await workspaceManager.awaitWorkspaceSearchReadiness(timeout: timeout)
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch let error as WorkspaceSearchReadinessWaitError {
+            throw searchError(for: error)
+        }
+        try await validateSearchReadiness(ticket, workspaceManager: workspaceManager)
+        try await ensureVisibleWorkspaceLoaded(
+            store: store,
+            readinessTicket: ticket,
+            workspaceManager: workspaceManager
+        )
+        try await validateSearchReadiness(ticket, workspaceManager: workspaceManager)
+        return ticket
+    }
+
+    private static func ensureVisibleWorkspaceLoaded(
+        store: WorkspaceFileContextStore,
+        readinessTicket: WorkspaceSearchReadinessTicket?,
         workspaceManager: WorkspaceManagerViewModel?
     ) async throws {
         let roots = await store.rootRefs(scope: .visibleWorkspace)
+        try await validateSearchReadiness(readinessTicket, workspaceManager: workspaceManager)
         guard !roots.isEmpty else {
             let msg = "No workspace is currently loaded in this window. Use the 'manage_workspaces' tool with action: 'list' to see available workspaces, then action: 'switch' to load one."
             throw FileManagerError.fileSystemServiceNotFoundWithContext(msg)
         }
-        guard let workspaceManager else { return }
-        // This state covers the activated workspace catalog. Session-bound worktrees can be
-        // loaded afterward, so their applied-ingress barrier below remains authoritative.
-        let state = await MainActor.run { workspaceManager.workspaceSearchReadinessState }
-        switch state {
-        case .ready, .degraded:
-            return
-        case .idle:
-            return
-        case .activating, .loadingCatalog, .buildingIndexes:
-            throw FileManagerError.fileSystemServiceNotFoundWithContext(
-                "Workspace search is still loading. Wait for workspace search readiness before using file_search to avoid partial or false-empty results."
-            )
+    }
+
+    private static func validateSearchReadiness(
+        _ ticket: WorkspaceSearchReadinessTicket?,
+        workspaceManager: WorkspaceManagerViewModel?
+    ) async throws {
+        guard let ticket else { return }
+        guard let workspaceManager else {
+            preconditionFailure("A workspace readiness ticket requires its issuing manager")
+        }
+        do {
+            try await workspaceManager.validateWorkspaceSearchReadiness(ticket)
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch let error as WorkspaceSearchReadinessWaitError {
+            throw searchError(for: error)
+        }
+    }
+
+    private static func searchError(
+        for error: WorkspaceSearchReadinessWaitError
+    ) -> StoreBackedWorkspaceSearchError {
+        switch error {
+        case .unavailable:
+            .workspaceReadinessUnavailable
+        case .timedOut:
+            .workspaceReadinessTimedOut
+        case .superseded:
+            .workspaceReadinessSuperseded
         }
     }
 

--- a/Sources/RepoPrompt/Features/Workspaces/ViewModels/WorkspaceManagerViewModel.swift
+++ b/Sources/RepoPrompt/Features/Workspaces/ViewModels/WorkspaceManagerViewModel.swift
@@ -569,12 +569,19 @@ class WorkspaceManagerViewModel: ObservableObject {
         let continuation: CheckedContinuation<Bool, Never>
     }
 
+    private struct WorkspaceSearchReadinessWaiter {
+        let ticket: WorkspaceSearchReadinessTicket
+        let continuation: CheckedContinuation<WorkspaceSearchReadinessTicket, any Error>
+        let timeoutTask: Task<Void, Never>
+    }
+
     private var pendingSwitchConfirmationRequest: PendingSwitchConfirmationRequest?
     private let switchSessionRegistry = WorkspaceSwitchSessionRegistry()
     private let switchTimingPolicy: WorkspaceSwitchTimingPolicy
     #if DEBUG
         private var workspaceSwitchPhaseDidChangeHandlerForTesting: ((WorkspaceSwitchPhase) -> Void)?
         private var workspaceSwitchRecoveryWillBeginHandlerForTesting: (@MainActor () async -> Void)?
+        private var workspaceSwitchReadinessDidInvalidateHandlerForTesting: (@MainActor () async -> Void)?
     #endif
 
     private struct WorkspaceDidSwitchListener {
@@ -804,8 +811,14 @@ class WorkspaceManagerViewModel: ObservableObject {
     }
 
     private(set) var isSwitchingWorkspace = false
-    @Published private(set) var workspaceSearchReadinessState: WorkspaceSearchReadinessState = .idle
+    @Published private(set) var workspaceSearchReadinessState: WorkspaceSearchReadinessState = .idle {
+        didSet {
+            reconcileWorkspaceSearchReadinessWaiters()
+        }
+    }
+
     private var workspaceHydrationGeneration: UInt64 = 0
+    private var workspaceSearchReadinessWaiters: [UUID: WorkspaceSearchReadinessWaiter] = [:]
     private var postCatalogRootWorkTasks: [UInt64: [Task<WorkspaceRootLoadFailure?, Never>]] = [:]
     private var returnToSystemAfterSwitchCancellationOperationID: UUID?
     private var committedWorkspaceSwitchOperationID: UUID?
@@ -2133,6 +2146,13 @@ class WorkspaceManagerViewModel: ObservableObject {
             && committedWorkspaceSwitchOperationID != operationID
             && (explicitlyRequestedRecovery || crossedDestructiveBoundary)
 
+        if !originalResult.didSwitch,
+           !needsRecovery,
+           committedWorkspaceSwitchOperationID != operationID
+        {
+            invalidateWorkspaceSearchReadiness()
+        }
+
         if needsRecovery, let originalActivity {
             returnToSystemAfterSwitchCancellationOperationID = nil
             let recoveryResult = await recoverWorkspaceSwitch(
@@ -2501,6 +2521,10 @@ class WorkspaceManagerViewModel: ObservableObject {
     }
 
     #if DEBUG
+        var workspaceSearchReadinessWaiterCountForTesting: Int {
+            workspaceSearchReadinessWaiters.count
+        }
+
         func setWorkspaceSwitchPhaseDidChangeHandlerForTesting(
             _ handler: ((WorkspaceSwitchPhase) -> Void)?
         ) {
@@ -2512,7 +2536,125 @@ class WorkspaceManagerViewModel: ObservableObject {
         ) {
             workspaceSwitchRecoveryWillBeginHandlerForTesting = handler
         }
+
+        func setWorkspaceSwitchReadinessDidInvalidateHandlerForTesting(
+            _ handler: (@MainActor () async -> Void)?
+        ) {
+            workspaceSwitchReadinessDidInvalidateHandlerForTesting = handler
+        }
     #endif
+
+    func awaitWorkspaceSearchReadiness(
+        timeout: Duration
+    ) async throws -> WorkspaceSearchReadinessTicket {
+        try Task.checkCancellation()
+        guard let ticket = workspaceSearchReadinessState.ticket else {
+            throw WorkspaceSearchReadinessWaitError.unavailable
+        }
+        if workspaceSearchReadinessState.isSearchAdmissible {
+            try validateWorkspaceSearchReadiness(ticket)
+            return ticket
+        }
+
+        let waiterID = UUID()
+        return try await withTaskCancellationHandler {
+            try Task.checkCancellation()
+            return try await withCheckedThrowingContinuation { continuation in
+                guard !Task.isCancelled else {
+                    continuation.resume(throwing: CancellationError())
+                    return
+                }
+                guard workspaceSearchReadinessState.ticket == ticket else {
+                    continuation.resume(throwing: WorkspaceSearchReadinessWaitError.superseded)
+                    return
+                }
+                if workspaceSearchReadinessState.isSearchAdmissible {
+                    do {
+                        try validateWorkspaceSearchReadiness(ticket)
+                        continuation.resume(returning: ticket)
+                    } catch {
+                        continuation.resume(throwing: error)
+                    }
+                    return
+                }
+
+                let timeoutTask = Task { @MainActor [weak self] in
+                    do {
+                        try await Task.sleep(for: timeout)
+                    } catch {
+                        return
+                    }
+                    guard !Task.isCancelled else { return }
+                    self?.failWorkspaceSearchReadinessWaiter(
+                        waiterID,
+                        throwing: WorkspaceSearchReadinessWaitError.timedOut
+                    )
+                }
+                workspaceSearchReadinessWaiters[waiterID] = WorkspaceSearchReadinessWaiter(
+                    ticket: ticket,
+                    continuation: continuation,
+                    timeoutTask: timeoutTask
+                )
+                if Task.isCancelled {
+                    failWorkspaceSearchReadinessWaiter(waiterID, throwing: CancellationError())
+                }
+            }
+        } onCancel: {
+            Task { @MainActor [weak self] in
+                self?.failWorkspaceSearchReadinessWaiter(waiterID, throwing: CancellationError())
+            }
+        }
+    }
+
+    func validateWorkspaceSearchReadiness(
+        _ ticket: WorkspaceSearchReadinessTicket
+    ) throws {
+        guard workspaceSearchReadinessState.isSearchAdmissible,
+              workspaceSearchReadinessState.ticket == ticket,
+              workspaceHydrationGeneration == ticket.generation,
+              activeWorkspaceID == ticket.workspaceID
+        else {
+            throw WorkspaceSearchReadinessWaitError.superseded
+        }
+    }
+
+    private func reconcileWorkspaceSearchReadinessWaiters() {
+        for waiterID in Array(workspaceSearchReadinessWaiters.keys) {
+            guard let waiter = workspaceSearchReadinessWaiters[waiterID] else { continue }
+            guard workspaceSearchReadinessState.ticket == waiter.ticket else {
+                failWorkspaceSearchReadinessWaiter(
+                    waiterID,
+                    throwing: WorkspaceSearchReadinessWaitError.superseded
+                )
+                continue
+            }
+            guard workspaceSearchReadinessState.isSearchAdmissible else { continue }
+            do {
+                try validateWorkspaceSearchReadiness(waiter.ticket)
+                succeedWorkspaceSearchReadinessWaiter(waiterID, ticket: waiter.ticket)
+            } catch {
+                failWorkspaceSearchReadinessWaiter(waiterID, throwing: error)
+            }
+        }
+    }
+
+    private func succeedWorkspaceSearchReadinessWaiter(
+        _ waiterID: UUID,
+        ticket: WorkspaceSearchReadinessTicket
+    ) {
+        guard let waiter = workspaceSearchReadinessWaiters.removeValue(forKey: waiterID) else { return }
+        waiter.timeoutTask.cancel()
+        waiter.continuation.resume(returning: ticket)
+    }
+
+    private func failWorkspaceSearchReadinessWaiter(
+        _ waiterID: UUID,
+        throwing error: any Error
+    ) {
+        guard let waiter = workspaceSearchReadinessWaiters.removeValue(forKey: waiterID) else { return }
+        waiter.timeoutTask.cancel()
+        waiter.continuation.resume(throwing: error)
+    }
 
     @discardableResult
     func reactivateWorkspaceAfterReplacement(
@@ -2675,10 +2817,13 @@ class WorkspaceManagerViewModel: ObservableObject {
                 }
             }
         }
+        let hydrationGeneration = beginWorkspaceHydration(for: newWorkspace)
+        #if DEBUG
+            if let workspaceSwitchReadinessDidInvalidateHandlerForTesting {
+                await workspaceSwitchReadinessDidInvalidateHandlerForTesting()
+            }
+        #endif
         await promptViewModel.stopTokenCountUpdateTimer()
-        workspaceHydrationGeneration &+= 1
-        workspaceSearchReadinessState = .idle
-        cancelPostCatalogRootWorkTasks()
         await workspaceSearchService.reset()
         await fileManager.cancelAllScans()
         if let cancellation = cancellationResult(
@@ -2804,7 +2949,6 @@ class WorkspaceManagerViewModel: ObservableObject {
         }
         let loadSignpost = WorkspaceExitPerf.begin("switchWorkspace.loadWorkspace")
         defer { WorkspaceExitPerf.end("switchWorkspace.loadWorkspace", loadSignpost) }
-        let hydrationGeneration = beginWorkspaceHydration(for: activeWS)
         let restoredHeavyFileState = activeComposeTabHeavyFileStateSnapshot(in: activeWS)
         if let restoredTabID = restoredHeavyFileState?.tabID {
             activationSnapshotSuspendedTabIDs.insert(restoredTabID)
@@ -3002,9 +3146,7 @@ class WorkspaceManagerViewModel: ObservableObject {
                     confirmationID: pending.confirmationID
                 )
             }
-            workspaceHydrationGeneration &+= 1
-            workspaceSearchReadinessState = .idle
-            cancelPostCatalogRootWorkTasks()
+            invalidateWorkspaceSearchReadiness()
             await workspaceSearchService.reset()
             await fileManager.cancelAllScans()
             fileManager.cancelAllLoadingTasks()
@@ -5674,6 +5816,12 @@ class WorkspaceManagerViewModel: ObservableObject {
         return generation
     }
 
+    private func invalidateWorkspaceSearchReadiness() {
+        workspaceHydrationGeneration &+= 1
+        workspaceSearchReadinessState = .idle
+        cancelPostCatalogRootWorkTasks()
+    }
+
     private func isHydrationGenerationCurrent(_ generation: UInt64, workspaceID: UUID?) -> Bool {
         workspaceHydrationGeneration == generation && activeWorkspaceID == workspaceID && returnToSystemAfterSwitchCancellationOperationID == nil
     }
@@ -5794,6 +5942,7 @@ class WorkspaceManagerViewModel: ObservableObject {
             #endif
         }
 
+        guard isHydrationGenerationCurrent(hydrationGeneration, workspaceID: workspace.id) else { return }
         let pathsToLoad = Self.loadableRepoPaths(for: workspace)
         let rootLoadRequests = uniqueWorkspaceRootLoadRequests(for: pathsToLoad)
         let maxConcurrentLoads = Self.boundedWorkspaceRootLoadLimit(forRootCount: rootLoadRequests.count)
@@ -5845,7 +5994,12 @@ class WorkspaceManagerViewModel: ObservableObject {
                 )
             }
         #endif
-        guard !Task.isCancelled else {
+        guard !Task.isCancelled,
+              isHydrationGenerationCurrent(hydrationGeneration, workspaceID: workspace.id)
+        else {
+            for rootRecord in hydrationResults.compactMap(\.rootRecord) {
+                await fileManager.workspaceFileContextStore.unloadRoot(id: rootRecord.id)
+            }
             return
         }
         #if DEBUG
@@ -5853,6 +6007,12 @@ class WorkspaceManagerViewModel: ObservableObject {
         #endif
         for result in hydrationResults.sorted(by: { $0.request.rootIndex < $1.request.rootIndex }) {
             if result.wasCancelled {
+                continue
+            }
+            guard isHydrationGenerationCurrent(hydrationGeneration, workspaceID: workspace.id) else {
+                if let rootRecord = result.rootRecord {
+                    await fileManager.workspaceFileContextStore.unloadRoot(id: rootRecord.id)
+                }
                 continue
             }
             if let failure = result.failure {
@@ -5866,10 +6026,6 @@ class WorkspaceManagerViewModel: ObservableObject {
                     expectedRootCount: rootLoadRequests.count,
                     failures: failures
                 )
-                continue
-            }
-            guard isHydrationGenerationCurrent(hydrationGeneration, workspaceID: workspace.id) else {
-                await fileManager.workspaceFileContextStore.unloadRoot(id: rootRecord.id)
                 continue
             }
             do {
@@ -5918,6 +6074,7 @@ class WorkspaceManagerViewModel: ObservableObject {
                 #endif
             }
         }
+        guard isHydrationGenerationCurrent(hydrationGeneration, workspaceID: workspace.id) else { return }
         let reorderChanged = fileManager.reorderRootFolders(to: pathsToLoad)
         let allPrimaryRootsVisibleSuccessfully = loadedRootCount == rootLoadRequests.count && failures.isEmpty
         #if DEBUG
@@ -5939,10 +6096,12 @@ class WorkspaceManagerViewModel: ObservableObject {
         await failures.append(contentsOf: awaitPostCatalogRootWorkFailures(generation: hydrationGeneration))
         guard isHydrationGenerationCurrent(hydrationGeneration, workspaceID: workspace.id) else { return }
         await workspaceSearchService.startKeepingFresh(with: fileManager.workspaceFileContextStore)
+        guard isHydrationGenerationCurrent(hydrationGeneration, workspaceID: workspace.id) else { return }
         #if DEBUG
             let searchCatalogSnapshotStartMS = WorkspaceRestorePerfLog.timestampMSIfEnabled()
         #endif
         var snapshot = await fileManager.workspaceFileContextStore.searchCatalogSnapshot(rootScope: .visibleWorkspace)
+        guard isHydrationGenerationCurrent(hydrationGeneration, workspaceID: workspace.id) else { return }
         #if DEBUG
             let initialSearchCatalogSnapshotDurationMS = searchCatalogSnapshotStartMS.map { WorkspaceRestorePerfLog.elapsedMS(since: $0) }
             if let initialSearchCatalogSnapshotDurationMS {
@@ -5999,11 +6158,13 @@ class WorkspaceManagerViewModel: ObservableObject {
         guard isHydrationGenerationCurrent(hydrationGeneration, workspaceID: workspace.id) else { return }
         while true {
             let currentCatalogGeneration = await fileManager.workspaceFileContextStore.catalogGeneration(rootScope: .visibleWorkspace)
+            guard isHydrationGenerationCurrent(hydrationGeneration, workspaceID: workspace.id) else { return }
             guard currentCatalogGeneration != indexGeneration else { break }
             #if DEBUG
                 let loopSearchCatalogSnapshotStartMS = WorkspaceRestorePerfLog.timestampMSIfEnabled()
             #endif
             snapshot = await fileManager.workspaceFileContextStore.searchCatalogSnapshot(rootScope: .visibleWorkspace)
+            guard isHydrationGenerationCurrent(hydrationGeneration, workspaceID: workspace.id) else { return }
             #if DEBUG
                 if let loopSearchCatalogSnapshotStartMS {
                     let duration = WorkspaceRestorePerfLog.elapsedMS(since: loopSearchCatalogSnapshotStartMS)
@@ -6065,6 +6226,7 @@ class WorkspaceManagerViewModel: ObservableObject {
                 ].merging(debugWorkspaceOpenTraceFields(), uniquingKeysWith: { current, _ in current })
             )
         #endif
+        guard isHydrationGenerationCurrent(hydrationGeneration, workspaceID: workspace.id) else { return }
         if failures.isEmpty {
             workspaceSearchReadinessState = .ready(
                 workspaceID: workspace.id,

--- a/Sources/RepoPrompt/Infrastructure/AI/Agents/AgentRunCoordinator.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Agents/AgentRunCoordinator.swift
@@ -24,6 +24,11 @@ struct AgentRunSpec {
 /// Shared coordinator for preparing, launching, and cleaning up headless agent runs.
 /// This centralises policy installation and provider orchestration for headless runs.
 final class AgentRunCoordinator {
+    struct GateRoutingReleaseResult {
+        let routed: Bool
+        let gateRelease: HeadlessAgentConnectionGate.ReleaseResult
+    }
+
     static let shared = AgentRunCoordinator()
 
     private let log = Logger(subsystem: "com.repoprompt.agents", category: "AgentRunCoordinator")
@@ -139,9 +144,13 @@ final class AgentRunCoordinator {
     ///   - runID: The run identifier associated with routing state and waiter notifications.
     ///   - gateID: The gate ownership identifier to release when routing completes. Defaults to `runID`.
     ///   - timeoutMs: Maximum time to wait for routing before forcing release (default: 10,000 ms).
-    /// - Returns: `true` if routing succeeded, `false` on timeout, failure, or cancellation.
+    /// - Returns: Routing and gate-release diagnostics for the run.
     @discardableResult
-    func releaseGateWhenRouted(runID: UUID, gateID: UUID? = nil, timeoutMs: Int = defaultRoutingTimeoutMs) async -> Bool {
+    func releaseGateWhenRouted(
+        runID: UUID,
+        gateID: UUID? = nil,
+        timeoutMs: Int = defaultRoutingTimeoutMs
+    ) async -> GateRoutingReleaseResult {
         let timeoutSeconds = TimeInterval(timeoutMs) / 1000.0
 
         // Event-driven wait with cancellation support:
@@ -154,17 +163,15 @@ final class AgentRunCoordinator {
         }
 
         let gateKey = gateID ?? runID
-        let released = await HeadlessAgentConnectionGate.completeIfActive(gateKey)
+        let gateRelease = await HeadlessAgentConnectionGate.completeIfActiveWithDiagnostics(gateKey)
 
         if routed {
-            log.info("Gate release after routing event: runID=\(runID.uuidString) gateID=\(gateKey.uuidString) released=\(released)")
+            log.info("Gate release after routing event: runID=\(runID.uuidString) gateID=\(gateKey.uuidString) released=\(gateRelease.released)")
         } else {
-            log.info("Gate release after timeout/failure/cancel: runID=\(runID.uuidString) gateID=\(gateKey.uuidString) released=\(released)")
+            log.info("Gate release after timeout/failure/cancel: runID=\(runID.uuidString) gateID=\(gateKey.uuidString) released=\(gateRelease.released)")
         }
 
-        // Clean up waiter state to prevent memory leaks
-        await MCPRoutingWaiter.cleanup(runID: runID)
-        return routed
+        return GateRoutingReleaseResult(routed: routed, gateRelease: gateRelease)
     }
 }
 

--- a/Sources/RepoPrompt/Infrastructure/AI/Agents/HeadlessAgentConnectionGate.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Agents/HeadlessAgentConnectionGate.swift
@@ -7,6 +7,26 @@ import OSLog
 actor HeadlessAgentConnectionGate {
     static let shared = HeadlessAgentConnectionGate()
 
+    struct Snapshot {
+        let activeConnectionID: UUID?
+        let queueDepth: Int
+    }
+
+    struct AcquisitionResult {
+        let acquired: Bool
+        let activeConnectionIDAtStart: UUID?
+        let queueDepthAtStart: Int
+        let queueDepthAtAcquire: Int
+        let waitDurationMS: Double
+    }
+
+    struct ReleaseResult {
+        let released: Bool
+        let activeConnectionIDBeforeRelease: UUID?
+        let queueDepthBeforeRelease: Int
+        let resumedWaiter: Bool
+    }
+
     private var activeConnectionID: UUID?
     private struct WaitingContinuation {
         let id: UUID
@@ -48,8 +68,12 @@ actor HeadlessAgentConnectionGate {
     ///
     /// IMPORTANT: This method re-checks ownership after every suspension so that a resumed waiter
     /// cannot overwrite a gate acquisition by a task that arrived between resume and re-entry.
-    /// Returns false if the task was cancelled before acquisition completed.
-    func acquire(_ gateID: UUID) async -> Bool {
+    /// Returns diagnostics used by the MCP bootstrap history/perf surfaces.
+    func acquireWithDiagnostics(_ gateID: UUID) async -> AcquisitionResult {
+        let startUptime = ProcessInfo.processInfo.systemUptime
+        let activeConnectionIDAtStart = activeConnectionID
+        let queueDepthAtStart = waitingContinuations.count
+
         while let currentConnectionID = activeConnectionID {
             log.info("Gate busy; waiting to acquire (gateID=\(gateID.uuidString), current=\(currentConnectionID.uuidString))")
             let waiterID = UUID()
@@ -63,12 +87,38 @@ actor HeadlessAgentConnectionGate {
                     Task { await self.cancelWaitingContinuation(with: waiterID) }
                 }
             )
-            if Task.isCancelled { return false }
+            if Task.isCancelled {
+                return AcquisitionResult(
+                    acquired: false,
+                    activeConnectionIDAtStart: activeConnectionIDAtStart,
+                    queueDepthAtStart: queueDepthAtStart,
+                    queueDepthAtAcquire: waitingContinuations.count,
+                    waitDurationMS: (ProcessInfo.processInfo.systemUptime - startUptime) * 1000
+                )
+            }
         }
-        if Task.isCancelled { return false }
+        if Task.isCancelled {
+            return AcquisitionResult(
+                acquired: false,
+                activeConnectionIDAtStart: activeConnectionIDAtStart,
+                queueDepthAtStart: queueDepthAtStart,
+                queueDepthAtAcquire: waitingContinuations.count,
+                waitDurationMS: (ProcessInfo.processInfo.systemUptime - startUptime) * 1000
+            )
+        }
         activeConnectionID = gateID
         log.info("Gate acquired atomically (gateID=\(gateID.uuidString))")
-        return true
+        return AcquisitionResult(
+            acquired: true,
+            activeConnectionIDAtStart: activeConnectionIDAtStart,
+            queueDepthAtStart: queueDepthAtStart,
+            queueDepthAtAcquire: waitingContinuations.count,
+            waitDurationMS: (ProcessInfo.processInfo.systemUptime - startUptime) * 1000
+        )
+    }
+
+    func acquire(_ gateID: UUID) async -> Bool {
+        await acquireWithDiagnostics(gateID).acquired
     }
 
     /// Mark an agent as beginning connection
@@ -77,22 +127,42 @@ actor HeadlessAgentConnectionGate {
         log.info("Gate begin (gateID=\(gateID.uuidString))")
     }
 
-    func completeConnectionReturningStatus(_ gateID: UUID) -> Bool {
+    func completeConnectionReturningDiagnostics(_ gateID: UUID) -> ReleaseResult {
+        let activeConnectionIDBeforeRelease = activeConnectionID
+        let queueDepthBeforeRelease = waitingContinuations.count
         guard activeConnectionID == gateID else {
             let currentConnectionID = activeConnectionID?.uuidString ?? "nil"
             log.info("Gate release no-op (gateID=\(gateID.uuidString), current=\(currentConnectionID))")
-            return false
+            return ReleaseResult(
+                released: false,
+                activeConnectionIDBeforeRelease: activeConnectionIDBeforeRelease,
+                queueDepthBeforeRelease: queueDepthBeforeRelease,
+                resumedWaiter: false
+            )
         }
         activeConnectionID = nil
         log.info("Gate released (gateID=\(gateID.uuidString))")
 
         // Resume ONE waiting agent (FIFO)
+        let resumedWaiter: Bool
         if !waitingContinuations.isEmpty {
             let next = waitingContinuations.removeFirst()
             log.info("Resuming waiting gate permit (id=\(next.id.uuidString))")
             next.continuation.resume()
+            resumedWaiter = true
+        } else {
+            resumedWaiter = false
         }
-        return true
+        return ReleaseResult(
+            released: true,
+            activeConnectionIDBeforeRelease: activeConnectionIDBeforeRelease,
+            queueDepthBeforeRelease: queueDepthBeforeRelease,
+            resumedWaiter: resumedWaiter
+        )
+    }
+
+    func completeConnectionReturningStatus(_ gateID: UUID) -> Bool {
+        completeConnectionReturningDiagnostics(gateID).released
     }
 
     /// Signal that an agent connection completed, unblocking next agent.
@@ -104,6 +174,14 @@ actor HeadlessAgentConnectionGate {
 
     func completeIfActive(_ gateID: UUID) -> Bool {
         completeConnectionReturningStatus(gateID)
+    }
+
+    func completeIfActiveWithDiagnostics(_ gateID: UUID) -> ReleaseResult {
+        completeConnectionReturningDiagnostics(gateID)
+    }
+
+    func snapshot() -> Snapshot {
+        Snapshot(activeConnectionID: activeConnectionID, queueDepth: waitingContinuations.count)
     }
 
     @discardableResult
@@ -176,6 +254,14 @@ extension HeadlessAgentConnectionGate {
         await HeadlessAgentConnectionGate.shared.acquire(gateID)
     }
 
+    static func acquireWithDiagnostics(_ gateID: UUID) async -> AcquisitionResult {
+        await HeadlessAgentConnectionGate.shared.acquireWithDiagnostics(gateID)
+    }
+
+    static func snapshot() async -> Snapshot {
+        await HeadlessAgentConnectionGate.shared.snapshot()
+    }
+
     /// Signal that an agent connection completed
     static func completeConnection(_ gateID: UUID) async {
         await HeadlessAgentConnectionGate.shared.completeConnection(gateID)
@@ -188,6 +274,10 @@ extension HeadlessAgentConnectionGate {
 
     static func completeIfActive(_ gateID: UUID) async -> Bool {
         await HeadlessAgentConnectionGate.shared.completeIfActive(gateID)
+    }
+
+    static func completeIfActiveWithDiagnostics(_ gateID: UUID) async -> ReleaseResult {
+        await HeadlessAgentConnectionGate.shared.completeIfActiveWithDiagnostics(gateID)
     }
 
     static func withPermit<T>(

--- a/Sources/RepoPrompt/Infrastructure/MCP/Agent/AgentRunMCPSnapshot.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/Agent/AgentRunMCPSnapshot.swift
@@ -299,6 +299,7 @@ struct AgentRunMCPSnapshot: Equatable {
     // MARK: - Snapshot properties
 
     let sessionID: UUID
+    let runID: UUID?
     let tabID: UUID?
     let sessionName: String?
 
@@ -319,6 +320,46 @@ struct AgentRunMCPSnapshot: Equatable {
     let worktreeBindings: [WorktreeBinding]
     let activeWorktreeMerges: [AgentSessionWorktreeMergeSummary]
 
+    init(
+        sessionID: UUID,
+        runID: UUID? = nil,
+        tabID: UUID?,
+        sessionName: String?,
+        agentRaw: String?,
+        agentDisplayName: String?,
+        modelRaw: String?,
+        reasoningEffortRaw: String?,
+        status: Status,
+        statusText: String?,
+        latestAssistantPreview: String?,
+        interaction: Interaction?,
+        transcriptItemCount: Int,
+        updatedAt: Date,
+        parentSessionID: UUID?,
+        failureReason: FailureReason?,
+        worktreeBindings: [WorktreeBinding],
+        activeWorktreeMerges: [AgentSessionWorktreeMergeSummary]
+    ) {
+        self.sessionID = sessionID
+        self.runID = runID
+        self.tabID = tabID
+        self.sessionName = sessionName
+        self.agentRaw = agentRaw
+        self.agentDisplayName = agentDisplayName
+        self.modelRaw = modelRaw
+        self.reasoningEffortRaw = reasoningEffortRaw
+        self.status = status
+        self.statusText = statusText
+        self.latestAssistantPreview = latestAssistantPreview
+        self.interaction = interaction
+        self.transcriptItemCount = transcriptItemCount
+        self.updatedAt = updatedAt
+        self.parentSessionID = parentSessionID
+        self.failureReason = failureReason
+        self.worktreeBindings = worktreeBindings
+        self.activeWorktreeMerges = activeWorktreeMerges
+    }
+
     var isActionableForMCPWait: Bool {
         interaction != nil || status == .waitingForInput || status.isTerminal
     }
@@ -330,6 +371,9 @@ struct AgentRunMCPSnapshot: Equatable {
             "transcript_item_count": .int(transcriptItemCount),
             "updated_at": .string(Self.timestampFormatter.string(from: updatedAt))
         ]
+        if let runID {
+            obj["run_id"] = .string(runID.uuidString)
+        }
         if let statusText, !statusText.isEmpty {
             obj["status_text"] = .string(statusText)
         }

--- a/Sources/RepoPrompt/Infrastructure/MCP/Agent/AgentRunMCPToolService.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/Agent/AgentRunMCPToolService.swift
@@ -1552,6 +1552,7 @@ struct AgentRunMCPToolService {
         }
         let session = object["session"]?.objectValue
         let agent = object["agent"]?.objectValue
+        let runID = object["run_id"]?.stringValue.flatMap(UUID.init(uuidString:))
         let interaction = object["interaction"]?.objectValue.flatMap(interaction(from:))
         let updatedAt = object["updated_at"]?.stringValue.flatMap(Self.timestampFormatter.date(from:)) ?? Date()
         let tabID = (session?["context_id"] ?? session?["tab_id"])?.stringValue.flatMap(UUID.init(uuidString:))
@@ -1561,6 +1562,7 @@ struct AgentRunMCPToolService {
         let activeWorktreeMerges = activeWorktreeMerges(from: object)
         return AgentRunMCPSnapshot(
             sessionID: sessionID,
+            runID: runID,
             tabID: tabID,
             sessionName: session?["name"]?.stringValue,
             agentRaw: agent?["id"]?.stringValue,

--- a/Sources/RepoPrompt/Infrastructure/MCP/MCPBootstrapLease.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/MCPBootstrapLease.swift
@@ -31,16 +31,18 @@ struct MCPBootstrapLeaseSpec {
     let requiresExpectedAgentPID: Bool
 }
 
-/// Unified lease actor that owns the entire MCP "bootstrap window" that must be serialized
-/// across all shared MCP client types — agent mode, headless agent runs, and any future flows.
+/// Unified lease actor for the MCP bootstrap policy and routing lifecycle.
 ///
-/// This consolidates the gate acquisition, routing waiter registration, policy installation,
-/// and release-on-routed semantics for all MCP bootstrap flows.
+/// Policy installation remains serialized across shared MCP client types. PID-owned policies
+/// release the process-global gate as soon as the unique run policy is confirmed armed, allowing
+/// independent provider processes to initialize concurrently while their routing waits remain isolated.
+/// Legacy policies without expected-PID ownership retain release-on-routed serialization.
 ///
 /// ## Lifecycle
-/// 1. `acquire()` — registers routing, acquires gate atomically, installs policy
-/// 2. `releaseWhenRouted()` — releases gate when connection routing is established (or on timeout)
-/// 3. `cancelAndCleanup()` — emergency cleanup on cancellation
+/// 1. `acquire()` — registers routing, acquires the gate, installs and arms the policy
+/// 2. PID-owned policies release the gate immediately; routing state stays retained by the lease
+/// 3. `releaseWhenRouted()` — waits for routing (or timeout) and cleans retained state
+/// 4. `cancelAndCleanup()` — emergency cleanup on cancellation
 ///
 /// ## Additional operations (agent-mode specific)
 /// - `releaseWithoutRoutingWait()` — releases gate immediately (when no fresh connection is expected)
@@ -51,6 +53,7 @@ actor MCPBootstrapLease {
     private var spec: MCPBootstrapLeaseSpec
     private let mcpServerEnabler: (() async -> Void)?
     private let policyInstaller: (MCPBootstrapLeaseSpec) async -> Void
+    private let expectedPIDPolicyArmer: (MCPBootstrapLeaseSpec) async -> Bool
     private let policyClearer: (MCPBootstrapLeaseSpec) async -> Void
 
     private var hasAcquired = false
@@ -60,6 +63,7 @@ actor MCPBootstrapLease {
     private var routingRegistered = false
     private var policyInstalled = false
     private var didSignalRoutingFailure = false
+    private var didReleaseGate = false
     private var didCleanupRouting = false
     private var didClearPolicy = false
 
@@ -71,24 +75,28 @@ actor MCPBootstrapLease {
     ///     Agent-mode provides this; headless flows typically don't need it.
     ///   - policyInstaller: Installs the per-run connection policy. Defaults to calling
     ///     `ServerNetworkManager.shared.installClientConnectionPolicy(...)`.
+    ///   - expectedPIDPolicyArmer: Confirms the intended pending policy is uniquely PID-owned.
     ///   - policyClearer: Clears the per-run connection policy on failure/timeout. Defaults to calling
     ///     `ServerNetworkManager.shared.clearClientConnectionPolicy(...)`.
     init(
         spec: MCPBootstrapLeaseSpec,
         mcpServerEnabler: (() async -> Void)? = nil,
         policyInstaller: ((MCPBootstrapLeaseSpec) async -> Void)? = nil,
+        expectedPIDPolicyArmer: ((MCPBootstrapLeaseSpec) async -> Bool)? = nil,
         policyClearer: ((MCPBootstrapLeaseSpec) async -> Void)? = nil
     ) {
         self.spec = spec
         self.mcpServerEnabler = mcpServerEnabler
         self.policyInstaller = policyInstaller ?? Self.defaultPolicyInstaller
+        self.expectedPIDPolicyArmer = expectedPIDPolicyArmer ?? Self.defaultExpectedPIDPolicyArmer
         self.policyClearer = policyClearer ?? Self.defaultPolicyClearer
     }
 
     // MARK: - Core Lifecycle
 
     /// Atomically acquires the global gate, registers routing, and installs connection policy.
-    /// Returns `false` if cancelled or the gate could not be acquired.
+    /// PID-owned policies release the gate after their unique pending policy is confirmed armed.
+    /// Returns `false` if cancelled, the gate could not be acquired, or PID ownership could not be armed.
     func acquire() async -> Bool {
         if hasReleased {
             acpLeaseLog("[ACP-Runner] lease run=\(spec.runID) gate=\(spec.gateID) acquire() ignored because lease already released")
@@ -137,14 +145,31 @@ actor MCPBootstrapLease {
         acpLeaseLog("[ACP-Runner] lease run=\(spec.runID) gate=\(spec.gateID) routing waiter registered")
 
         return await withTaskCancellationHandler {
-            // Atomically wait + acquire the global gate
+            // Atomically wait + acquire the global gate.
+            let gateSnapshot = await HeadlessAgentConnectionGate.snapshot()
+            await recordDiagnosticEvent(
+                "lease_gate_wait_started",
+                fields: [
+                    "active_gate_id": gateSnapshot.activeConnectionID?.uuidString ?? "nil",
+                    "queue_depth": String(gateSnapshot.queueDepth)
+                ]
+            )
             acpLeaseLog("[ACP-Runner] lease run=\(spec.runID) gate=\(spec.gateID) waiting to acquire global MCP gate")
-            let gateAcquired = await HeadlessAgentConnectionGate.acquire(spec.gateID)
-            if gateAcquired {
+            let gateAcquisition = await HeadlessAgentConnectionGate.acquireWithDiagnostics(spec.gateID)
+            if gateAcquisition.acquired {
                 ownsGate = true
             }
-            acpLeaseLog("[ACP-Runner] lease run=\(spec.runID) gate=\(spec.gateID) global MCP gate acquired=\(gateAcquired)")
-            if !gateAcquired || shouldAbortAcquire {
+            await recordDiagnosticEvent(
+                gateAcquisition.acquired ? "lease_gate_acquired" : "lease_gate_acquire_failed",
+                fields: [
+                    "active_gate_id_at_start": gateAcquisition.activeConnectionIDAtStart?.uuidString ?? "nil",
+                    "queue_depth_at_start": String(gateAcquisition.queueDepthAtStart),
+                    "queue_depth_at_acquire": String(gateAcquisition.queueDepthAtAcquire),
+                    "wait_duration_ms": String(format: "%.3f", gateAcquisition.waitDurationMS)
+                ]
+            )
+            acpLeaseLog("[ACP-Runner] lease run=\(spec.runID) gate=\(spec.gateID) global MCP gate acquired=\(gateAcquisition.acquired)")
+            if !gateAcquisition.acquired || shouldAbortAcquire {
                 acpLeaseLog("[ACP-Runner] lease run=\(spec.runID) gate=\(spec.gateID) acquire() failed, was released, or task cancelled")
                 await cancelAndCleanup()
                 return false
@@ -158,12 +183,17 @@ actor MCPBootstrapLease {
                 await cancelAndCleanup()
                 return false
             }
-            if spec.requiresExpectedAgentPID, let clientName = spec.clientName {
-                await ServerNetworkManager.shared.requireExpectedAgentPIDForPendingPolicy(
-                    for: clientName,
-                    runID: spec.runID,
-                    windowID: spec.windowID
+            if spec.requiresExpectedAgentPID {
+                let policyArmed = await expectedPIDPolicyArmer(spec)
+                await recordDiagnosticEvent(
+                    "lease_expected_pid_policy_armed",
+                    fields: ["armed": String(policyArmed)]
                 )
+                guard policyArmed else {
+                    acpLeaseLog("[ACP-Runner] lease run=\(spec.runID) gate=\(spec.gateID) expected-PID policy could not be armed")
+                    await cancelAndCleanup()
+                    return false
+                }
                 if shouldAbortAcquire {
                     await cancelAndCleanup()
                     return false
@@ -189,6 +219,12 @@ actor MCPBootstrapLease {
             }
 
             hasAcquired = true
+            if spec.requiresExpectedAgentPID {
+                // The pending policy is now uniquely run-scoped and PID-owned. Release the
+                // process-global gate before spawning so independent sessions may initialize
+                // concurrently; the routing waiter and policy remain owned by this lease.
+                await releaseOwnedGate(reason: "expected_pid_policy_armed")
+            }
             acpLeaseLog("[ACP-Runner] lease run=\(spec.runID) gate=\(spec.gateID) acquire() completed")
             return true
         } onCancel: {
@@ -199,7 +235,8 @@ actor MCPBootstrapLease {
 
     // MARK: - Release Strategies
 
-    /// Releases the global gate once routing is established, or on timeout.
+    /// Waits for routing and releases legacy gate ownership once established or timed out.
+    /// PID-owned policies have already released the gate but retain this routing/policy cleanup.
     /// If routing fails/times out, clears the pending policy entry.
     @discardableResult
     func releaseWhenRouted(timeoutMs: Int = 10000) async -> Bool {
@@ -221,13 +258,20 @@ actor MCPBootstrapLease {
                 ]
             )
         #endif
-        let routed = await AgentRunCoordinator.shared.releaseGateWhenRouted(
+        let ownedGateBeforeWait = ownsGate
+        let releaseResult = await AgentRunCoordinator.shared.releaseGateWhenRouted(
             runID: spec.runID,
             gateID: spec.gateID,
             timeoutMs: timeoutMs
         )
         ownsGate = false
-        didCleanupRouting = true
+        let routed = releaseResult.routed
+        if ownedGateBeforeWait || releaseResult.gateRelease.released {
+            await recordGateRelease(
+                releaseResult.gateRelease,
+                reason: routed ? "routing_completed" : (Task.isCancelled ? "routing_cancelled" : "routing_timeout_or_failure")
+            )
+        }
         acpLeaseLog("[ACP-Runner] lease run=\(spec.runID) gate=\(spec.gateID) releaseWhenRouted() completed routed=\(routed)")
         #if DEBUG
             await ServerNetworkManager.shared.debugRecordRunRoutingEvent(
@@ -244,7 +288,10 @@ actor MCPBootstrapLease {
         if !routed {
             acpLeaseLog("[ACP-Runner] lease run=\(spec.runID) gate=\(spec.gateID) routing wait failed or timed out; clearing connection policy")
             await policyClearer(spec)
+            didClearPolicy = true
         }
+        await AgentRunCoordinator.shared.cleanupRouting(runID: spec.runID)
+        didCleanupRouting = true
 
         return routed
     }
@@ -258,8 +305,7 @@ actor MCPBootstrapLease {
         }
         hasReleased = true
         acpLeaseLog("[ACP-Runner] lease run=\(spec.runID) gate=\(spec.gateID) releasing gate without waiting for routing")
-        _ = await HeadlessAgentConnectionGate.completeIfActive(spec.gateID)
-        ownsGate = false
+        await releaseOwnedGate(reason: "without_routing_wait")
         await AgentRunCoordinator.shared.cleanupRouting(runID: spec.runID)
         didCleanupRouting = true
     }
@@ -282,10 +328,7 @@ actor MCPBootstrapLease {
                 ]
             )
         #endif
-        if ownsGate {
-            _ = await HeadlessAgentConnectionGate.completeIfActive(spec.gateID)
-            ownsGate = false
-        }
+        await releaseOwnedGate(reason: "deferred_routing")
     }
 
     /// Cleans up deferred routing state after a prompt-deferred provider reaches a terminal state
@@ -336,6 +379,76 @@ actor MCPBootstrapLease {
         cleanupRequested || hasReleased || Task.isCancelled
     }
 
+    func providerInitializationStarted(provider: String) async {
+        await recordDiagnosticEvent(
+            "provider_initialization_started",
+            fields: ["provider": provider]
+        )
+    }
+
+    func providerInitializationCompleted(provider: String, outcome: String) async {
+        await recordDiagnosticEvent(
+            "provider_initialization_completed",
+            fields: [
+                "provider": provider,
+                "outcome": outcome
+            ]
+        )
+    }
+
+    private func releaseOwnedGate(reason: String) async {
+        guard ownsGate else { return }
+        let result = await HeadlessAgentConnectionGate.completeIfActiveWithDiagnostics(spec.gateID)
+        ownsGate = false
+        didReleaseGate = didReleaseGate || result.released
+        await recordGateRelease(result, reason: reason)
+    }
+
+    private func recordGateRelease(
+        _ result: HeadlessAgentConnectionGate.ReleaseResult,
+        reason: String
+    ) async {
+        await recordDiagnosticEvent(
+            "lease_gate_release",
+            fields: [
+                "reason": reason,
+                "released": String(result.released),
+                "active_gate_id_before_release": result.activeConnectionIDBeforeRelease?.uuidString ?? "nil",
+                "queue_depth_before_release": String(result.queueDepthBeforeRelease),
+                "resumed_waiter": String(result.resumedWaiter)
+            ]
+        )
+    }
+
+    private func recordDiagnosticEvent(
+        _ event: String,
+        fields: [String: String] = [:]
+    ) async {
+        #if DEBUG
+            var diagnosticFields: [String: String] = [
+                "client_name": spec.clientName ?? "nil",
+                "connection_id": "nil",
+                "gate_id": spec.gateID.uuidString,
+                "window_id": String(spec.windowID),
+                "tab_id": spec.tabID?.uuidString ?? "nil",
+                "requires_expected_pid": String(spec.requiresExpectedAgentPID)
+            ]
+            for (key, value) in fields {
+                diagnosticFields[key] = value
+            }
+            await ServerNetworkManager.shared.debugRecordRunRoutingEvent(
+                runID: spec.runID,
+                event: event,
+                fields: diagnosticFields
+            )
+            AgentModePerfDiagnostics.event(
+                "mcp.routing.\(event)",
+                tabID: spec.tabID,
+                fields: diagnosticFields
+            )
+        #endif
+    }
+
     private func performCancellationCleanup(reason: String) async {
         #if DEBUG
             await ServerNetworkManager.shared.debugRecordRunRoutingEvent(
@@ -352,17 +465,14 @@ actor MCPBootstrapLease {
             didSignalRoutingFailure = true
             await MCPRoutingWaiter.notifyFailed(runID: spec.runID)
         }
-        if ownsGate {
-            _ = await HeadlessAgentConnectionGate.completeIfActive(spec.gateID)
-            ownsGate = false
+        await releaseOwnedGate(reason: reason)
+        if policyInstalled, !didClearPolicy {
+            didClearPolicy = true
+            await policyClearer(spec)
         }
         if routingRegistered, !didCleanupRouting {
             didCleanupRouting = true
             await AgentRunCoordinator.shared.cleanupRouting(runID: spec.runID)
-        }
-        if policyInstalled, !didClearPolicy {
-            didClearPolicy = true
-            await policyClearer(spec)
         }
         #if DEBUG
             await ServerNetworkManager.shared.debugRecordRunRoutingEvent(
@@ -372,7 +482,10 @@ actor MCPBootstrapLease {
                     "client_name": spec.clientName ?? "nil",
                     "reason": reason,
                     "owns_gate": String(ownsGate),
-                    "policy_installed": String(policyInstalled)
+                    "gate_released": String(didReleaseGate),
+                    "routing_cleaned": String(didCleanupRouting),
+                    "policy_installed": String(policyInstalled),
+                    "policy_cleared": String(didClearPolicy)
                 ]
             )
         #endif
@@ -390,17 +503,14 @@ actor MCPBootstrapLease {
                 ]
             )
         #endif
-        if ownsGate {
-            _ = await HeadlessAgentConnectionGate.completeIfActive(spec.gateID)
-            ownsGate = false
+        await releaseOwnedGate(reason: reason)
+        if policyInstalled, !didClearPolicy {
+            didClearPolicy = true
+            await policyClearer(spec)
         }
         if routingRegistered, !didCleanupRouting {
             didCleanupRouting = true
             await AgentRunCoordinator.shared.cleanupRouting(runID: spec.runID)
-        }
-        if policyInstalled, !didClearPolicy {
-            didClearPolicy = true
-            await policyClearer(spec)
         }
         #if DEBUG
             await ServerNetworkManager.shared.debugRecordRunRoutingEvent(
@@ -410,13 +520,27 @@ actor MCPBootstrapLease {
                     "client_name": spec.clientName ?? "nil",
                     "reason": reason,
                     "owns_gate": String(ownsGate),
-                    "policy_installed": String(policyInstalled)
+                    "gate_released": String(didReleaseGate),
+                    "routing_cleaned": String(didCleanupRouting),
+                    "policy_installed": String(policyInstalled),
+                    "policy_cleared": String(didClearPolicy)
                 ]
             )
         #endif
     }
 
     // MARK: - Default Policy Hooks
+
+    private static let defaultExpectedPIDPolicyArmer: (MCPBootstrapLeaseSpec) async -> Bool = { spec in
+        guard spec.requiresExpectedAgentPID, let clientName = spec.clientName else {
+            return !spec.requiresExpectedAgentPID
+        }
+        return await ServerNetworkManager.shared.requireExpectedAgentPIDForPendingPolicy(
+            for: clientName,
+            runID: spec.runID,
+            windowID: spec.windowID
+        )
+    }
 
     private static let defaultPolicyInstaller: (MCPBootstrapLeaseSpec) async -> Void = { spec in
         guard let clientName = spec.clientName else { return }
@@ -439,7 +563,7 @@ actor MCPBootstrapLease {
 
     private static let defaultPolicyClearer: (MCPBootstrapLeaseSpec) async -> Void = { spec in
         guard let clientName = spec.clientName else { return }
-        await ServerNetworkManager.shared.clearClientConnectionPolicy(
+        await ServerNetworkManager.shared.revokeClientConnectionPolicy(
             for: clientName,
             windowID: spec.windowID,
             runID: spec.runID

--- a/Sources/RepoPrompt/Infrastructure/MCP/MCPConnectionManager.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/MCPConnectionManager.swift
@@ -6652,19 +6652,22 @@ actor ServerNetworkManager {
         #endif
     }
 
+    @discardableResult
     func requireExpectedAgentPIDForPendingPolicy(
         for clientName: String,
         runID: UUID,
         windowID: Int? = nil
-    ) {
+    ) -> Bool {
         pruneExpiredPolicies(for: clientName)
         let keys = matchingClientKeys(for: clientName, in: Array(pendingPoliciesByClient.keys))
+        var matchedCount = 0
         var updatedCount = 0
         for key in keys {
             guard var queue = pendingPoliciesByClient[key] else { continue }
             for index in queue.indices {
                 guard queue[index].runID == runID else { continue }
                 if let windowID, queue[index].windowID != windowID { continue }
+                matchedCount += 1
                 if !queue[index].requiresExpectedAgentPID {
                     queue[index].requiresExpectedAgentPID = true
                     updatedCount += 1
@@ -6672,9 +6675,24 @@ actor ServerNetworkManager {
             }
             pendingPoliciesByClient[key] = queue
         }
+        let armed = matchedCount == 1
         mcpPolicyLog(
-            "marked policy requires expected pid client=\(clientName) runID=\(runID.uuidString) window=\(windowID.map(String.init) ?? "any") updated=\(updatedCount)"
+            "marked policy requires expected pid client=\(clientName) runID=\(runID.uuidString) window=\(windowID.map(String.init) ?? "any") matched=\(matchedCount) updated=\(updatedCount) armed=\(armed)"
         )
+        #if DEBUG
+            debugRecordRunRoutingEvent(
+                runID: runID,
+                event: "expected_pid_policy_armed",
+                fields: [
+                    "client_name": clientName,
+                    "window_id": windowID.map(String.init) ?? "any",
+                    "matched_count": String(matchedCount),
+                    "updated_count": String(updatedCount),
+                    "armed": String(armed)
+                ]
+            )
+        #endif
+        return armed
     }
 
     #if DEBUG
@@ -8896,6 +8914,34 @@ actor ServerNetworkManager {
                     ]
                 )
             }
+        #endif
+    }
+
+    /// Revokes a run-scoped pending policy and invalidates any reserved/in-flight application
+    /// before removing live routing state. This is the terminal cleanup counterpart to
+    /// PID-owned early gate release.
+    func revokeClientConnectionPolicy(
+        for clientName: String,
+        windowID: Int,
+        runID: UUID
+    ) async {
+        // Any application already past reservation must fail its next ownership check.
+        pendingPolicyApplicationIDByRunID.removeValue(forKey: runID)
+        await clearClientConnectionPolicy(
+            for: clientName,
+            windowID: windowID,
+            runID: runID
+        )
+        await cleanupRunRoutingState(for: runID, windowID: windowID)
+        #if DEBUG
+            debugRecordRunRoutingEvent(
+                runID: runID,
+                event: "policy_revoked",
+                fields: [
+                    "client_name": clientName,
+                    "window_id": String(windowID)
+                ]
+            )
         #endif
     }
 

--- a/Sources/RepoPrompt/Infrastructure/MCP/ToolOutputFormatter.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ToolOutputFormatter.swift
@@ -176,13 +176,26 @@ enum ToolOutputFormatter {
         let isBackpressure = dto.errorCode == "search_backpressure" && dto.retryable == true
         let isWorktreeUnavailable = dto.errorCode == "worktree_scope_unavailable" && dto.retryable == true
         let isFreshnessTimeout = dto.errorCode == "workspace_freshness_timeout" && dto.retryable == true
-        lines.append((isBackpressure || isWorktreeUnavailable || isFreshnessTimeout) ? "## Search Results ⚠️" : "## Search Results ❌")
+        let readinessStatus: String? = switch dto.errorCode {
+        case "workspace_readiness_unavailable":
+            "Workspace readiness unavailable"
+        case "workspace_readiness_timeout":
+            "Workspace readiness timed out"
+        case "workspace_readiness_superseded":
+            "Workspace changed during search"
+        default:
+            nil
+        }
+        let isReadinessFailure = readinessStatus != nil && dto.retryable == true
+        lines.append((isBackpressure || isWorktreeUnavailable || isFreshnessTimeout || isReadinessFailure) ? "## Search Results ⚠️" : "## Search Results ❌")
         if isBackpressure {
             lines.append("- **Status**: Temporarily busy")
         } else if isWorktreeUnavailable {
             lines.append("- **Status**: Worktree unavailable")
         } else if isFreshnessTimeout {
             lines.append("- **Status**: Workspace freshness timed out")
+        } else if isReadinessFailure, let readinessStatus {
+            lines.append("- **Status**: \(readinessStatus)")
         }
         lines.append("- **Error**: \(error)")
         if let errorCode = dto.errorCode, !errorCode.isEmpty {
@@ -4851,6 +4864,7 @@ extension ToolOutputFormatter {
         let interaction = object["interaction"]?.objectValue
         let meta = object["_meta"]?.objectValue
         let sessionID = object["session_id"]?.stringValue ?? session?["id"]?.stringValue
+        let runID = object["run_id"]?.stringValue
         let status = prettifiedAgentStatus(object["status"]?.stringValue)
         let statusText = object["status_text"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines)
         let sessionName = session?["name"]?.stringValue
@@ -4894,6 +4908,9 @@ extension ToolOutputFormatter {
         }
         if let sessionID, !sessionID.isEmpty {
             lines.append("- Session ID: `\(sessionID)`")
+        }
+        if let runID, !runID.isEmpty {
+            lines.append("- Run ID: `\(runID)`")
         }
         lines.append(contentsOf: formattedAgentRunWorktreeLines(worktrees))
         // Multi-wait metadata

--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPFileToolProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPFileToolProvider.swift
@@ -522,6 +522,12 @@ final class MCPFileToolProvider: MCPWindowToolProviding {
                 "worktreeScopeUnavailable"
             case .workspaceFreshnessTimedOut:
                 "workspaceFreshnessTimedOut"
+            case .workspaceReadinessUnavailable:
+                "workspaceReadinessUnavailable"
+            case .workspaceReadinessTimedOut:
+                "workspaceReadinessTimedOut"
+            case .workspaceReadinessSuperseded:
+                "workspaceReadinessSuperseded"
             }
             EditFlowPerf.lifecycleEvent(
                 EditFlowPerf.Lifecycle.Search.providerWorkspaceSearchReturned,
@@ -803,6 +809,12 @@ final class MCPFileToolProvider: MCPWindowToolProviding {
             "worktree_scope_unavailable"
         case .workspaceFreshnessTimedOut:
             "workspace_freshness_timeout"
+        case .workspaceReadinessUnavailable:
+            "workspace_readiness_unavailable"
+        case .workspaceReadinessTimedOut:
+            "workspace_readiness_timeout"
+        case .workspaceReadinessSuperseded:
+            "workspace_readiness_superseded"
         }
         return ToolResultDTOs.SearchResultDTO(
             totalMatches: 0,

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/Models/WorkspaceFileContextModels.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/Models/WorkspaceFileContextModels.swift
@@ -62,6 +62,17 @@ struct WorkspaceRootLoadFailure: Equatable, Identifiable {
     }
 }
 
+struct WorkspaceSearchReadinessTicket: Equatable, Hashable {
+    let workspaceID: UUID?
+    let generation: UInt64
+}
+
+enum WorkspaceSearchReadinessWaitError: Error, Equatable {
+    case unavailable
+    case timedOut
+    case superseded
+}
+
 enum WorkspaceSearchReadinessState: Equatable {
     case idle
     case activating(workspaceID: UUID?, generation: UInt64)
@@ -69,6 +80,28 @@ enum WorkspaceSearchReadinessState: Equatable {
     case buildingIndexes(workspaceID: UUID?, generation: UInt64, catalogGeneration: UInt64, failures: [WorkspaceRootLoadFailure])
     case ready(workspaceID: UUID?, generation: UInt64, catalogGeneration: UInt64, indexedGeneration: UInt64, diagnostics: WorkspaceCatalogDiagnostics)
     case degraded(workspaceID: UUID?, generation: UInt64, catalogGeneration: UInt64?, indexedGeneration: UInt64?, failures: [WorkspaceRootLoadFailure], diagnostics: WorkspaceCatalogDiagnostics?)
+
+    var ticket: WorkspaceSearchReadinessTicket? {
+        switch self {
+        case .idle:
+            nil
+        case let .activating(workspaceID, generation),
+             let .loadingCatalog(workspaceID, generation, _, _, _),
+             let .buildingIndexes(workspaceID, generation, _, _),
+             let .ready(workspaceID, generation, _, _, _),
+             let .degraded(workspaceID, generation, _, _, _, _):
+            WorkspaceSearchReadinessTicket(workspaceID: workspaceID, generation: generation)
+        }
+    }
+
+    var isSearchAdmissible: Bool {
+        switch self {
+        case .ready, .degraded:
+            true
+        case .idle, .activating, .loadingCatalog, .buildingIndexes:
+            false
+        }
+    }
 }
 
 struct WorkspaceCatalogDiagnostics: Equatable {

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
@@ -136,14 +136,152 @@ actor WorkspaceFileContextStore {
         let enableHierarchicalIgnores: Bool
     }
 
+    private struct RootLoadCompletionIdentity {
+        let rootID: UUID
+        let lifetimeID: UUID
+    }
+
+    private final class RootLoadFlightCompletion: @unchecked Sendable {
+        private let lock = NSLock()
+        private var completionIdentity: RootLoadCompletionIdentity?
+
+        func record(rootID: UUID, lifetimeID: UUID) {
+            lock.lock()
+            completionIdentity = RootLoadCompletionIdentity(
+                rootID: rootID,
+                lifetimeID: lifetimeID
+            )
+            lock.unlock()
+        }
+
+        func identity() -> RootLoadCompletionIdentity? {
+            lock.lock()
+            let identity = completionIdentity
+            lock.unlock()
+            return identity
+        }
+    }
+
+    private struct RootLoadFlight {
+        let id: UUID
+        let task: Task<WorkspaceRootRecord, Error>
+        let completion: RootLoadFlightCompletion
+    }
+
     private struct SessionWorktreeRootLifetimeKey: Hashable {
         let rootID: UUID
         let lifetimeID: UUID
     }
 
+    private struct WatcherInfrastructureKey: Hashable {
+        let rootID: UUID
+        let lifetimeID: UUID
+    }
+
+    private struct WatcherPublisherAttachment {
+        let subscription: WorkspaceFileSystemIngressCoordinator.Subscription
+        let cancellable: AnyCancellable
+    }
+
+    private struct WatcherInfrastructureFlight {
+        let id: UUID
+        let task: Task<Void, Error>
+    }
+
     private struct SessionWorktreeOwnershipRecord {
         let bindingFingerprint: String
         let roots: [WorkspaceSessionWorktreeOwnedRoot]
+    }
+
+    private struct SessionWorktreeReservedLoadFlight {
+        let standardizedPath: String
+        let flight: RootLoadFlight
+    }
+
+    private struct SessionWorktreeOwnershipRemoval {
+        var ownedRoots: [WorkspaceSessionWorktreeOwnedRoot] = []
+        var reservedLoadFlights: [SessionWorktreeReservedLoadFlight] = []
+
+        mutating func append(_ other: SessionWorktreeOwnershipRemoval) {
+            ownedRoots.append(contentsOf: other.ownedRoots)
+            reservedLoadFlights.append(contentsOf: other.reservedLoadFlights)
+        }
+    }
+
+    private final class RootLoadTaskWaitRace: @unchecked Sendable {
+        private let lock = NSLock()
+        private var resolution: Result<WorkspaceRootRecord, Error>?
+        private var continuation: CheckedContinuation<WorkspaceRootRecord, Error>?
+
+        func value() async throws -> WorkspaceRootRecord {
+            try await withCheckedThrowingContinuation { continuation in
+                lock.lock()
+                if let resolution {
+                    lock.unlock()
+                    continuation.resume(with: resolution)
+                } else {
+                    precondition(self.continuation == nil)
+                    self.continuation = continuation
+                    lock.unlock()
+                }
+            }
+        }
+
+        func resolve(_ resolution: Result<WorkspaceRootRecord, Error>) {
+            let continuation: CheckedContinuation<WorkspaceRootRecord, Error>?
+            lock.lock()
+            guard self.resolution == nil else {
+                lock.unlock()
+                return
+            }
+            self.resolution = resolution
+            continuation = self.continuation
+            self.continuation = nil
+            lock.unlock()
+            continuation?.resume(with: resolution)
+        }
+
+        func cancel() {
+            resolve(.failure(CancellationError()))
+        }
+    }
+
+    private final class WatcherInfrastructureTaskWaitRace: @unchecked Sendable {
+        private let lock = NSLock()
+        private var resolution: Result<Void, Error>?
+        private var continuation: CheckedContinuation<Void, Error>?
+
+        func value() async throws {
+            try await withCheckedThrowingContinuation { continuation in
+                lock.lock()
+                if let resolution {
+                    lock.unlock()
+                    continuation.resume(with: resolution)
+                } else {
+                    precondition(self.continuation == nil)
+                    self.continuation = continuation
+                    lock.unlock()
+                }
+            }
+        }
+
+        func resolve(_ resolution: Result<Void, Error>) {
+            let continuation: CheckedContinuation<Void, Error>?
+            lock.lock()
+            guard self.resolution == nil else {
+                lock.unlock()
+                return
+            }
+            self.resolution = resolution
+            continuation = self.continuation
+            self.continuation = nil
+            lock.unlock()
+            continuation?.resume(with: resolution)
+        }
+
+        func cancel() {
+            resolve(.failure(CancellationError()))
+        }
     }
 
     private struct SliceRebaseSourceCacheKey: Hashable {
@@ -501,6 +639,8 @@ actor WorkspaceFileContextStore {
         private var watcherSinkWillApplyHandler: (@Sendable (UUID) async -> Void)?
         private var storeEditDeferredPublicationDidRegisterHandler: (@Sendable (UUID, String) async -> Void)?
         private var publisherIngressWillWaitHandler: (@Sendable (Set<UUID>) async -> Void)?
+        private var watcherPublisherIngressDidOpenHandler: (@Sendable (UUID, UUID) async -> Void)?
+        private var watcherInfrastructureDidJoinFlightHandler: (@Sendable (UUID, UUID) async -> Void)?
         private var watcherServiceStateWillReconcileHandler: (@Sendable (UUID, Bool) async -> Void)?
         private var watcherStopWillBeginHandler: (@Sendable (UUID) async -> Void)?
         private var rootUnloadTerminationDidCompleteHandler: (@Sendable (WorkspaceRootUnloadTerminationDiagnostics) async -> Void)?
@@ -559,6 +699,18 @@ actor WorkspaceFileContextStore {
 
         func setPublisherIngressWillWaitHandler(_ handler: (@Sendable (Set<UUID>) async -> Void)?) {
             publisherIngressWillWaitHandler = handler
+        }
+
+        func setWatcherPublisherIngressDidOpenHandler(_ handler: (@Sendable (UUID, UUID) async -> Void)?) {
+            watcherPublisherIngressDidOpenHandler = handler
+        }
+
+        func setWatcherInfrastructureDidJoinFlightHandler(_ handler: (@Sendable (UUID, UUID) async -> Void)?) {
+            watcherInfrastructureDidJoinFlightHandler = handler
+        }
+
+        func watcherInfrastructureFlightCountForTesting(rootID: UUID) -> Int {
+            watcherInfrastructureFlightsByKey.keys.count(where: { $0.rootID == rootID })
         }
 
         func setWatcherServiceStateWillReconcileHandler(_ handler: (@Sendable (UUID, Bool) async -> Void)?) {
@@ -1152,7 +1304,7 @@ actor WorkspaceFileContextStore {
     private var rootLoadOrder: [UUID] = []
     private var unloadingRootPaths: Set<String> = []
     private var unloadWaitersByRootPath: [String: [UUID: CheckedContinuation<Void, Error>]] = [:]
-    private var rootLoadTasksByPath: [String: Task<WorkspaceRootRecord, Error>] = [:]
+    private var rootLoadFlightsByPath: [String: RootLoadFlight] = [:]
     private var rootLoadConfigurationsByPath: [String: RootLoadConfiguration] = [:]
     private var catalogGenerationsByScope: [WorkspaceLookupRootScope: UInt64] = [
         .visibleWorkspace: 0,
@@ -1214,12 +1366,17 @@ actor WorkspaceFileContextStore {
     private static let maxSliceRebaseSourceEntryCount = 64
     private static let maxSliceRebaseSourceTotalBytes = 32 * 1024 * 1024
     private static let maxSliceRebaseSourceEntryBytes = 8 * 1024 * 1024
-    private var watcherCancellablesByRootID: [UUID: AnyCancellable] = [:]
+    private var watcherPublisherAttachmentsByKey: [WatcherInfrastructureKey: WatcherPublisherAttachment] = [:]
+    private var watcherInfrastructureFlightsByKey: [WatcherInfrastructureKey: WatcherInfrastructureFlight] = [:]
     private var explicitWatcherDemandRootIDs = Set<UUID>()
+    private var explicitWatcherDemandGenerationByKey: [WatcherInfrastructureKey: UInt64] = [:]
     private var latestSessionWorktreeOwnershipGenerationByOwnerID: [UUID: UInt64] = [:]
     private var installedSessionWorktreeOwnershipTokenByOwnerID: [UUID: WorkspaceSessionWorktreeOwnershipToken] = [:]
     private var sessionWorktreeOwnershipRecordsByToken: [WorkspaceSessionWorktreeOwnershipToken: SessionWorktreeOwnershipRecord] = [:]
     private var sessionWorktreeOwnershipTokensByRootLifetime: [SessionWorktreeRootLifetimeKey: Set<WorkspaceSessionWorktreeOwnershipToken>] = [:]
+    private var sessionWorktreeReservationTokensByStandardizedPath: [String: Set<WorkspaceSessionWorktreeOwnershipToken>] = [:]
+    private var sessionWorktreeReservedPathsByToken: [WorkspaceSessionWorktreeOwnershipToken: Set<String>] = [:]
+    private var sessionWorktreeReservationLoadFlightsByToken: [WorkspaceSessionWorktreeOwnershipToken: [String: RootLoadFlight]] = [:]
     private let publisherIngressCoordinator: WorkspaceFileSystemIngressCoordinator
     private let unloadTerminationPolicy: WorkspaceRootUnloadTerminationPolicy
     private var scopedIngressBarrierFlightStatesByRootID: [UUID: ScopedIngressBarrierRootFlightState] = [:]
@@ -1281,8 +1438,11 @@ actor WorkspaceFileContextStore {
             searchContentMemoryPressureSource.cancel()
         #endif
         codeScanResultTask?.cancel()
-        for cancellable in watcherCancellablesByRootID.values {
-            cancellable.cancel()
+        for attachment in watcherPublisherAttachmentsByKey.values {
+            attachment.cancellable.cancel()
+        }
+        for flight in watcherInfrastructureFlightsByKey.values {
+            flight.task.cancel()
         }
         for continuation in codemapUpdateContinuations.values {
             continuation.finish()
@@ -1342,44 +1502,147 @@ actor WorkspaceFileContextStore {
     }
 
     func startWatchingRoot(id rootID: UUID) async throws {
-        _ = try state(for: rootID)
+        let state = try state(for: rootID)
+        let key = WatcherInfrastructureKey(rootID: rootID, lifetimeID: state.lifetimeID)
+        let demandGeneration = (explicitWatcherDemandGenerationByKey[key] ?? 0) &+ 1
+        explicitWatcherDemandGenerationByKey[key] = demandGeneration
         explicitWatcherDemandRootIDs.insert(rootID)
         do {
             try await reconcileAggregateWatcherDemand(rootID: rootID)
         } catch {
-            explicitWatcherDemandRootIDs.remove(rootID)
-            try? await reconcileAggregateWatcherDemand(rootID: rootID)
+            if explicitWatcherDemandGenerationByKey[key] == demandGeneration,
+               isRootLifetimeCurrent(rootID: rootID, expectedLifetimeID: key.lifetimeID)
+            {
+                explicitWatcherDemandRootIDs.remove(rootID)
+                try? await reconcileAggregateWatcherDemand(rootID: rootID)
+            }
             throw error
         }
     }
 
     private func ensureWatcherInfrastructure(state: RootState, rootID: UUID) async throws {
-        if watcherCancellablesByRootID[rootID] != nil {
-            try await reconcileWatcherServiceState(state.service, rootID: rootID)
-            await waitForCurrentPublisherIngress(rootIDs: [rootID])
-            return
-        }
-        guard try await attachPublisherIngress(state: state, rootID: rootID) else {
+        let key = WatcherInfrastructureKey(rootID: rootID, lifetimeID: state.lifetimeID)
+        guard isRootLifetimeCurrent(rootID: rootID, expectedLifetimeID: key.lifetimeID) else {
             throw WorkspaceSessionWorktreeOwnershipError.unavailableRoot(state.root.standardizedFullPath)
         }
-        do {
-            try await reconcileWatcherServiceState(state.service, rootID: rootID)
-            await waitForCurrentPublisherIngress(rootIDs: [rootID])
-        } catch {
-            watcherCancellablesByRootID.removeValue(forKey: rootID)?.cancel()
-            publisherIngressCoordinator.closePublisherIngress(rootID: rootID)
-            try? await reconcileWatcherServiceState(state.service, rootID: rootID)
-            await waitForCurrentPublisherIngress(rootIDs: [rootID])
-            throw error
+        if let flight = watcherInfrastructureFlightsByKey[key] {
+            #if DEBUG
+                if let watcherInfrastructureDidJoinFlightHandler {
+                    await watcherInfrastructureDidJoinFlightHandler(rootID, key.lifetimeID)
+                }
+            #endif
+            try await awaitWatcherInfrastructureFlight(flight)
+            return
+        }
+
+        let flightID = UUID()
+        let rootPath = state.root.standardizedFullPath
+        let task = Task { [weak self] in
+            guard let self else { throw CancellationError() }
+            do {
+                try await performWatcherInfrastructureSetup(key: key, rootPath: rootPath)
+                await clearWatcherInfrastructureFlight(key: key, expectedID: flightID)
+            } catch {
+                await clearWatcherInfrastructureFlight(key: key, expectedID: flightID)
+                throw error
+            }
+        }
+        let flight = WatcherInfrastructureFlight(id: flightID, task: task)
+        watcherInfrastructureFlightsByKey[key] = flight
+        try await awaitWatcherInfrastructureFlight(flight)
+    }
+
+    private func awaitWatcherInfrastructureFlight(_ flight: WatcherInfrastructureFlight) async throws {
+        let race = WatcherInfrastructureTaskWaitRace()
+        Task {
+            let result = await flight.task.result
+            race.resolve(result)
+        }
+        try await withTaskCancellationHandler {
+            try await race.value()
+        } onCancel: {
+            race.cancel()
         }
     }
 
-    private func attachPublisherIngress(state: RootState, rootID: UUID) async throws -> Bool {
+    private func clearWatcherInfrastructureFlight(key: WatcherInfrastructureKey, expectedID: UUID) {
+        guard watcherInfrastructureFlightsByKey[key]?.id == expectedID else { return }
+        watcherInfrastructureFlightsByKey.removeValue(forKey: key)
+    }
+
+    private func performWatcherInfrastructureSetup(
+        key: WatcherInfrastructureKey,
+        rootPath: String
+    ) async throws {
+        while true {
+            guard let state = rootStatesByID[key.rootID],
+                  state.lifetimeID == key.lifetimeID,
+                  hasAggregateWatcherDemand(rootID: key.rootID, lifetimeID: key.lifetimeID)
+            else {
+                throw WorkspaceSessionWorktreeOwnershipError.unavailableRoot(rootPath)
+            }
+
+            let subscription: WorkspaceFileSystemIngressCoordinator.Subscription
+            if let attachment = watcherPublisherAttachmentsByKey[key],
+               publisherIngressCoordinator.isPublisherIngressOpen(attachment.subscription)
+            {
+                subscription = attachment.subscription
+            } else {
+                watcherPublisherAttachmentsByKey.removeValue(forKey: key)?.cancellable.cancel()
+                guard let attachedSubscription = try await attachPublisherIngress(
+                    state: state,
+                    key: key
+                ) else {
+                    guard isRootLifetimeCurrent(rootID: key.rootID, expectedLifetimeID: key.lifetimeID),
+                          hasAggregateWatcherDemand(rootID: key.rootID, lifetimeID: key.lifetimeID)
+                    else {
+                        throw WorkspaceSessionWorktreeOwnershipError.unavailableRoot(rootPath)
+                    }
+                    continue
+                }
+                subscription = attachedSubscription
+            }
+
+            do {
+                try await reconcileWatcherServiceState(state.service, rootID: key.rootID)
+                await waitForCurrentPublisherIngress(rootIDs: [key.rootID])
+            } catch {
+                removeWatcherPublisherAttachment(key: key, subscription: subscription)
+                if isRootLifetimeCurrent(rootID: key.rootID, expectedLifetimeID: key.lifetimeID) {
+                    try? await reconcileWatcherServiceState(state.service, rootID: key.rootID)
+                    await waitForCurrentPublisherIngress(rootIDs: [key.rootID])
+                }
+                throw error
+            }
+
+            guard isRootLifetimeCurrent(rootID: key.rootID, expectedLifetimeID: key.lifetimeID),
+                  hasAggregateWatcherDemand(rootID: key.rootID, lifetimeID: key.lifetimeID)
+            else {
+                removeWatcherPublisherAttachment(key: key, subscription: subscription)
+                if isRootLifetimeCurrent(rootID: key.rootID, expectedLifetimeID: key.lifetimeID) {
+                    try? await reconcileWatcherServiceState(state.service, rootID: key.rootID)
+                    await waitForCurrentPublisherIngress(rootIDs: [key.rootID])
+                }
+                throw WorkspaceSessionWorktreeOwnershipError.unavailableRoot(rootPath)
+            }
+            guard watcherPublisherAttachmentsByKey[key]?.subscription == subscription,
+                  publisherIngressCoordinator.isPublisherIngressOpen(subscription)
+            else {
+                continue
+            }
+            return
+        }
+    }
+
+    private func attachPublisherIngress(
+        state: RootState,
+        key: WatcherInfrastructureKey
+    ) async throws -> WorkspaceFileSystemIngressCoordinator.Subscription? {
+        guard isRootLifetimeCurrent(rootID: key.rootID, expectedLifetimeID: key.lifetimeID) else { return nil }
         let root = state.root
-        let lifetimeID = state.lifetimeID
         let diagnosticRootToken = state.service.diagnosticRootToken
         let publisherIngressCoordinator = publisherIngressCoordinator
-        let subscription = publisherIngressCoordinator.openPublisherIngress(rootID: rootID) { [weak self] publication, publicationCorrelation in
+        let subscription = publisherIngressCoordinator.openPublisherIngress(rootID: key.rootID) { [weak self] publication, publicationCorrelation in
             EditFlowPerf.lifecycleEvent(
                 EditFlowPerf.Lifecycle.WorkspaceIngress.storeSinkBegan,
                 correlation: publicationCorrelation,
@@ -1393,17 +1656,22 @@ actor WorkspaceFileContextStore {
             await self?.handleObservedPublisherFileSystemPublication(
                 publication,
                 root: root,
-                expectedLifetimeID: lifetimeID,
+                expectedLifetimeID: key.lifetimeID,
                 publicationCorrelation: publicationCorrelation,
                 diagnosticRootToken: diagnosticRootToken
             )
         }
+        #if DEBUG
+            if let watcherPublisherIngressDidOpenHandler {
+                await watcherPublisherIngressDidOpenHandler(key.rootID, key.lifetimeID)
+            }
+        #endif
         let publisher = await state.service.publisherForChanges()
-        guard isRootLifetimeCurrent(rootID: rootID, expectedLifetimeID: lifetimeID),
+        guard isRootLifetimeCurrent(rootID: key.rootID, expectedLifetimeID: key.lifetimeID),
               publisherIngressCoordinator.isPublisherIngressOpen(subscription)
         else {
-            try await reconcileWatcherServiceState(state.service, rootID: rootID)
-            return false
+            publisherIngressCoordinator.closePublisherIngress(subscription)
+            return nil
         }
         let cancellable = publisher.sink { publication in
             #if DEBUG || EDIT_FLOW_PERF
@@ -1427,26 +1695,48 @@ actor WorkspaceFileContextStore {
                 lifecycleCorrelation: publicationCorrelation
             )
         }
-        guard isRootLifetimeCurrent(rootID: rootID, expectedLifetimeID: lifetimeID),
+        guard isRootLifetimeCurrent(rootID: key.rootID, expectedLifetimeID: key.lifetimeID),
               publisherIngressCoordinator.isPublisherIngressOpen(subscription)
         else {
             cancellable.cancel()
-            try await reconcileWatcherServiceState(state.service, rootID: rootID)
-            return false
+            publisherIngressCoordinator.closePublisherIngress(subscription)
+            return nil
         }
-        watcherCancellablesByRootID[rootID] = cancellable
-        return true
+        watcherPublisherAttachmentsByKey[key] = WatcherPublisherAttachment(
+            subscription: subscription,
+            cancellable: cancellable
+        )
+        return subscription
+    }
+
+    private func removeWatcherPublisherAttachment(
+        key: WatcherInfrastructureKey,
+        subscription: WorkspaceFileSystemIngressCoordinator.Subscription
+    ) {
+        if watcherPublisherAttachmentsByKey[key]?.subscription == subscription {
+            watcherPublisherAttachmentsByKey.removeValue(forKey: key)?.cancellable.cancel()
+        }
+        publisherIngressCoordinator.closePublisherIngress(subscription)
     }
 
     #if DEBUG
         func attachPublisherIngressWithoutStartingWatcherForTesting(rootID: UUID) async throws -> Bool {
-            if watcherCancellablesByRootID[rootID] != nil { return true }
             let state = try state(for: rootID)
-            return try await attachPublisherIngress(state: state, rootID: rootID)
+            let key = WatcherInfrastructureKey(rootID: rootID, lifetimeID: state.lifetimeID)
+            if let attachment = watcherPublisherAttachmentsByKey[key],
+               publisherIngressCoordinator.isPublisherIngressOpen(attachment.subscription)
+            {
+                return true
+            }
+            return try await attachPublisherIngress(state: state, key: key) != nil
         }
     #endif
 
     func stopWatchingRoot(id rootID: UUID) async {
+        if let state = rootStatesByID[rootID] {
+            let key = WatcherInfrastructureKey(rootID: rootID, lifetimeID: state.lifetimeID)
+            explicitWatcherDemandGenerationByKey[key, default: 0] &+= 1
+        }
         explicitWatcherDemandRootIDs.remove(rootID)
         try? await reconcileAggregateWatcherDemand(rootID: rootID)
     }
@@ -1480,11 +1770,11 @@ actor WorkspaceFileContextStore {
         let supersededTokens = sessionWorktreeOwnershipRecordsByToken.keys.filter {
             $0.ownerID == ownerID && $0 != installedToken
         }
-        var supersededRoots: [WorkspaceSessionWorktreeOwnedRoot] = []
+        var supersededResources = SessionWorktreeOwnershipRemoval()
         for supersededToken in supersededTokens {
-            supersededRoots.append(contentsOf: removeSessionWorktreeOwnershipToken(supersededToken))
+            supersededResources.append(removeSessionWorktreeOwnershipToken(supersededToken))
         }
-        await cleanupOrphanedSessionWorktreeRoots(supersededRoots)
+        await cleanupOrphanedSessionWorktreeResources(supersededResources)
         guard latestSessionWorktreeOwnershipGenerationByOwnerID[ownerID] == generation else {
             throw WorkspaceSessionWorktreeOwnershipError.staleUpdate
         }
@@ -1493,20 +1783,31 @@ actor WorkspaceFileContextStore {
             bindingFingerprint: bindingFingerprint,
             roots: []
         )
+        reserveSessionWorktreePaths(standardizedPaths, for: token)
         do {
             var preparedRoots: [WorkspaceSessionWorktreeOwnedRoot] = []
             for path in standardizedPaths {
+                try Task.checkCancellation()
+                guard latestSessionWorktreeOwnershipGenerationByOwnerID[ownerID] == generation else {
+                    throw WorkspaceSessionWorktreeOwnershipError.staleUpdate
+                }
                 let root = try await loadRoot(
                     path: path,
                     kind: .sessionWorktree,
                     respectGitignore: true,
                     respectRepoIgnore: true,
-                    respectCursorignore: true
+                    respectCursorignore: true,
+                    sessionWorktreeReservationToken: token
                 )
-                guard let state = rootStatesByID[root.id],
+                try Task.checkCancellation()
+                guard latestSessionWorktreeOwnershipGenerationByOwnerID[ownerID] == generation,
+                      let state = rootStatesByID[root.id],
                       state.root.kind == .sessionWorktree,
                       state.root.standardizedFullPath == path
                 else {
+                    if latestSessionWorktreeOwnershipGenerationByOwnerID[ownerID] != generation {
+                        throw WorkspaceSessionWorktreeOwnershipError.staleUpdate
+                    }
                     throw WorkspaceSessionWorktreeOwnershipError.invalidRootKind(path)
                 }
                 let ownedRoot = WorkspaceSessionWorktreeOwnedRoot(
@@ -1514,18 +1815,15 @@ actor WorkspaceFileContextStore {
                     lifetimeID: state.lifetimeID,
                     standardizedPhysicalPath: path
                 )
-                guard latestSessionWorktreeOwnershipGenerationByOwnerID[ownerID] == generation else {
-                    await cleanupOrphanedSessionWorktreeRoots([ownedRoot])
-                    throw WorkspaceSessionWorktreeOwnershipError.staleUpdate
-                }
                 preparedRoots.append(ownedRoot)
-                sessionWorktreeOwnershipRecordsByToken[token] = SessionWorktreeOwnershipRecord(
+                try convertSessionWorktreeReservationToClaim(
+                    token: token,
                     bindingFingerprint: bindingFingerprint,
-                    roots: preparedRoots
+                    preparedRoots: preparedRoots,
+                    ownedRoot: ownedRoot
                 )
-                let rootKey = SessionWorktreeRootLifetimeKey(rootID: root.id, lifetimeID: state.lifetimeID)
-                sessionWorktreeOwnershipTokensByRootLifetime[rootKey, default: []].insert(token)
                 try await reconcileAggregateWatcherDemand(rootID: root.id)
+                try Task.checkCancellation()
                 guard latestSessionWorktreeOwnershipGenerationByOwnerID[ownerID] == generation,
                       isRootLifetimeCurrent(rootID: root.id, expectedLifetimeID: state.lifetimeID)
                 else {
@@ -1539,8 +1837,8 @@ actor WorkspaceFileContextStore {
                 reusesInstalledOwnership: false
             )
         } catch {
-            let roots = removeSessionWorktreeOwnershipToken(token)
-            await cleanupOrphanedSessionWorktreeRoots(roots)
+            let resources = removeSessionWorktreeOwnershipToken(token)
+            await cleanupOrphanedSessionWorktreeResources(resources)
             throw error
         }
     }
@@ -1569,14 +1867,14 @@ actor WorkspaceFileContextStore {
 
         if record.roots.isEmpty {
             installedSessionWorktreeOwnershipTokenByOwnerID.removeValue(forKey: preparation.token.ownerID)
-            var releasedRoots = removeSessionWorktreeOwnershipToken(preparation.token)
+            var releasedResources = removeSessionWorktreeOwnershipToken(preparation.token)
             let previousTokens = sessionWorktreeOwnershipRecordsByToken.keys.filter {
                 $0.ownerID == preparation.token.ownerID
             }
             for previousToken in previousTokens {
-                releasedRoots.append(contentsOf: removeSessionWorktreeOwnershipToken(previousToken))
+                releasedResources.append(removeSessionWorktreeOwnershipToken(previousToken))
             }
-            scheduleOrphanedSessionWorktreeRootCleanup(releasedRoots)
+            scheduleOrphanedSessionWorktreeResourceCleanup(releasedResources)
             return []
         }
 
@@ -1584,11 +1882,11 @@ actor WorkspaceFileContextStore {
             preparation.token,
             forKey: preparation.token.ownerID
         )
-        var previousRoots: [WorkspaceSessionWorktreeOwnedRoot] = []
+        var previousResources = SessionWorktreeOwnershipRemoval()
         if let previousToken, previousToken != preparation.token {
-            previousRoots = removeSessionWorktreeOwnershipToken(previousToken)
+            previousResources = removeSessionWorktreeOwnershipToken(previousToken)
         }
-        scheduleOrphanedSessionWorktreeRootCleanup(previousRoots)
+        scheduleOrphanedSessionWorktreeResourceCleanup(previousResources)
         return record.roots
     }
 
@@ -1598,19 +1896,19 @@ actor WorkspaceFileContextStore {
         guard !preparation.reusesInstalledOwnership,
               installedSessionWorktreeOwnershipTokenByOwnerID[preparation.token.ownerID] != preparation.token
         else { return }
-        let roots = removeSessionWorktreeOwnershipToken(preparation.token)
-        await cleanupOrphanedSessionWorktreeRoots(roots)
+        let resources = removeSessionWorktreeOwnershipToken(preparation.token)
+        await cleanupOrphanedSessionWorktreeResources(resources)
     }
 
     func releaseSessionWorktreeOwnership(ownerID: UUID) async {
         latestSessionWorktreeOwnershipGenerationByOwnerID[ownerID, default: 0] &+= 1
         installedSessionWorktreeOwnershipTokenByOwnerID.removeValue(forKey: ownerID)
         let tokens = sessionWorktreeOwnershipRecordsByToken.keys.filter { $0.ownerID == ownerID }
-        var roots: [WorkspaceSessionWorktreeOwnedRoot] = []
+        var resources = SessionWorktreeOwnershipRemoval()
         for token in tokens {
-            roots.append(contentsOf: removeSessionWorktreeOwnershipToken(token))
+            resources.append(removeSessionWorktreeOwnershipToken(token))
         }
-        await cleanupOrphanedSessionWorktreeRoots(roots)
+        await cleanupOrphanedSessionWorktreeResources(resources)
     }
 
     func sessionWorktreeOwnershipCovers(
@@ -1650,6 +1948,7 @@ actor WorkspaceFileContextStore {
             let installedOwnerCount: Int
             let provisionalOwnerCount: Int
             let rootClaimCount: Int
+            let pathReservationCount: Int
             let explicitWatcherDemandCount: Int
         }
 
@@ -1659,6 +1958,7 @@ actor WorkspaceFileContextStore {
                 installedOwnerCount: installedTokens.count,
                 provisionalOwnerCount: sessionWorktreeOwnershipRecordsByToken.keys.count(where: { !installedTokens.contains($0) }),
                 rootClaimCount: sessionWorktreeOwnershipTokensByRootLifetime.values.reduce(0) { $0 + $1.count },
+                pathReservationCount: sessionWorktreeReservationTokensByStandardizedPath.values.reduce(0) { $0 + $1.count },
                 explicitWatcherDemandCount: explicitWatcherDemandRootIDs.count
             )
         }
@@ -1666,37 +1966,135 @@ actor WorkspaceFileContextStore {
 
     private func sessionWorktreeOwnershipRecordIsCurrent(_ record: SessionWorktreeOwnershipRecord) -> Bool {
         record.roots.allSatisfy { root in
+            let watcherKey = WatcherInfrastructureKey(rootID: root.rootID, lifetimeID: root.lifetimeID)
             guard let state = rootStatesByID[root.rootID],
                   state.lifetimeID == root.lifetimeID,
                   state.root.kind == .sessionWorktree,
                   state.root.standardizedFullPath == root.standardizedPhysicalPath,
-                  watcherCancellablesByRootID[root.rootID] != nil,
-                  publisherIngressCoordinator.hasOpenPublisherIngress(rootID: root.rootID)
+                  let attachment = watcherPublisherAttachmentsByKey[watcherKey],
+                  publisherIngressCoordinator.isPublisherIngressOpen(attachment.subscription)
             else { return false }
             let key = SessionWorktreeRootLifetimeKey(rootID: root.rootID, lifetimeID: root.lifetimeID)
             return sessionWorktreeOwnershipTokensByRootLifetime[key]?.isEmpty == false
         }
     }
 
+    private func reserveSessionWorktreePaths(
+        _ standardizedPaths: [String],
+        for token: WorkspaceSessionWorktreeOwnershipToken
+    ) {
+        guard !standardizedPaths.isEmpty else { return }
+        let paths = Set(standardizedPaths)
+        sessionWorktreeReservedPathsByToken[token] = paths
+        for path in paths {
+            sessionWorktreeReservationTokensByStandardizedPath[path, default: []].insert(token)
+        }
+    }
+
+    private func registerSessionWorktreeReservationLoadFlight(
+        _ flight: RootLoadFlight,
+        standardizedPath: String,
+        token: WorkspaceSessionWorktreeOwnershipToken
+    ) {
+        guard sessionWorktreeReservedPathsByToken[token]?.contains(standardizedPath) == true else { return }
+        sessionWorktreeReservationLoadFlightsByToken[token, default: [:]][standardizedPath] = flight
+    }
+
+    private func convertSessionWorktreeReservationToClaim(
+        token: WorkspaceSessionWorktreeOwnershipToken,
+        bindingFingerprint: String,
+        preparedRoots: [WorkspaceSessionWorktreeOwnedRoot],
+        ownedRoot: WorkspaceSessionWorktreeOwnedRoot
+    ) throws {
+        guard let record = sessionWorktreeOwnershipRecordsByToken[token],
+              record.bindingFingerprint == bindingFingerprint,
+              record.roots == Array(preparedRoots.dropLast()),
+              preparedRoots.last == ownedRoot,
+              sessionWorktreeReservedPathsByToken[token]?.contains(ownedRoot.standardizedPhysicalPath) == true,
+              sessionWorktreeReservationTokensByStandardizedPath[
+                  ownedRoot.standardizedPhysicalPath
+              ]?.contains(token) == true
+        else {
+            throw WorkspaceSessionWorktreeOwnershipError.staleUpdate
+        }
+
+        sessionWorktreeOwnershipRecordsByToken[token] = SessionWorktreeOwnershipRecord(
+            bindingFingerprint: bindingFingerprint,
+            roots: preparedRoots
+        )
+        let rootKey = SessionWorktreeRootLifetimeKey(
+            rootID: ownedRoot.rootID,
+            lifetimeID: ownedRoot.lifetimeID
+        )
+        sessionWorktreeOwnershipTokensByRootLifetime[rootKey, default: []].insert(token)
+        removeSessionWorktreeReservation(
+            standardizedPath: ownedRoot.standardizedPhysicalPath,
+            token: token
+        )
+    }
+
+    private func removeSessionWorktreeReservation(
+        standardizedPath: String,
+        token: WorkspaceSessionWorktreeOwnershipToken
+    ) {
+        sessionWorktreeReservationTokensByStandardizedPath[standardizedPath]?.remove(token)
+        if sessionWorktreeReservationTokensByStandardizedPath[standardizedPath]?.isEmpty == true {
+            sessionWorktreeReservationTokensByStandardizedPath.removeValue(forKey: standardizedPath)
+        }
+        sessionWorktreeReservedPathsByToken[token]?.remove(standardizedPath)
+        sessionWorktreeReservationLoadFlightsByToken[token]?.removeValue(forKey: standardizedPath)
+        if sessionWorktreeReservedPathsByToken[token]?.isEmpty == true {
+            sessionWorktreeReservedPathsByToken.removeValue(forKey: token)
+        }
+        if sessionWorktreeReservationLoadFlightsByToken[token]?.isEmpty == true {
+            sessionWorktreeReservationLoadFlightsByToken.removeValue(forKey: token)
+        }
+    }
+
     private func removeSessionWorktreeOwnershipToken(
         _ token: WorkspaceSessionWorktreeOwnershipToken
-    ) -> [WorkspaceSessionWorktreeOwnedRoot] {
-        guard let record = sessionWorktreeOwnershipRecordsByToken.removeValue(forKey: token) else { return [] }
-        for root in record.roots {
+    ) -> SessionWorktreeOwnershipRemoval {
+        let record = sessionWorktreeOwnershipRecordsByToken.removeValue(forKey: token)
+        let reservedPaths = sessionWorktreeReservedPathsByToken.removeValue(forKey: token) ?? []
+        let reservedLoadFlightsByPath =
+            sessionWorktreeReservationLoadFlightsByToken.removeValue(forKey: token) ?? [:]
+        for path in reservedPaths {
+            sessionWorktreeReservationTokensByStandardizedPath[path]?.remove(token)
+            if sessionWorktreeReservationTokensByStandardizedPath[path]?.isEmpty == true {
+                sessionWorktreeReservationTokensByStandardizedPath.removeValue(forKey: path)
+            }
+        }
+        for root in record?.roots ?? [] {
             let key = SessionWorktreeRootLifetimeKey(rootID: root.rootID, lifetimeID: root.lifetimeID)
             sessionWorktreeOwnershipTokensByRootLifetime[key]?.remove(token)
             if sessionWorktreeOwnershipTokensByRootLifetime[key]?.isEmpty == true {
                 sessionWorktreeOwnershipTokensByRootLifetime.removeValue(forKey: key)
             }
         }
-        return record.roots
+        return SessionWorktreeOwnershipRemoval(
+            ownedRoots: record?.roots ?? [],
+            reservedLoadFlights: reservedLoadFlightsByPath.compactMap { path, flight in
+                guard reservedPaths.contains(path) else { return nil }
+                return SessionWorktreeReservedLoadFlight(
+                    standardizedPath: path,
+                    flight: flight
+                )
+            }
+        )
     }
 
-    private func scheduleOrphanedSessionWorktreeRootCleanup(
-        _ roots: [WorkspaceSessionWorktreeOwnedRoot]
+    private func scheduleOrphanedSessionWorktreeResourceCleanup(
+        _ resources: SessionWorktreeOwnershipRemoval
     ) {
-        guard !roots.isEmpty else { return }
-        Task { await cleanupOrphanedSessionWorktreeRoots(roots) }
+        guard !resources.ownedRoots.isEmpty || !resources.reservedLoadFlights.isEmpty else { return }
+        Task { await cleanupOrphanedSessionWorktreeResources(resources) }
+    }
+
+    private func cleanupOrphanedSessionWorktreeResources(
+        _ resources: SessionWorktreeOwnershipRemoval
+    ) async {
+        await cleanupOrphanedSessionWorktreeRoots(resources.ownedRoots)
+        scheduleOrphanedSessionWorktreeLoadFlightCleanup(resources.reservedLoadFlights)
     }
 
     private func cleanupOrphanedSessionWorktreeRoots(
@@ -1707,14 +2105,38 @@ actor WorkspaceFileContextStore {
             let key = SessionWorktreeRootLifetimeKey(rootID: root.rootID, lifetimeID: root.lifetimeID)
             guard seen.insert(key).inserted,
                   isRootLifetimeCurrent(rootID: root.rootID, expectedLifetimeID: root.lifetimeID),
+                  rootStatesByID[root.rootID]?.root.standardizedFullPath == root.standardizedPhysicalPath,
                   !hasAggregateWatcherDemand(rootID: root.rootID, lifetimeID: root.lifetimeID)
             else { continue }
             try? await reconcileAggregateWatcherDemand(rootID: root.rootID)
             guard isRootLifetimeCurrent(rootID: root.rootID, expectedLifetimeID: root.lifetimeID),
                   !hasAggregateWatcherDemand(rootID: root.rootID, lifetimeID: root.lifetimeID),
-                  rootStatesByID[root.rootID]?.root.kind == .sessionWorktree
+                  rootStatesByID[root.rootID]?.root.kind == .sessionWorktree,
+                  rootStatesByID[root.rootID]?.root.standardizedFullPath == root.standardizedPhysicalPath
             else { continue }
             await unloadRoot(id: root.rootID)
+        }
+    }
+
+    private func scheduleOrphanedSessionWorktreeLoadFlightCleanup(
+        _ reservations: [SessionWorktreeReservedLoadFlight]
+    ) {
+        var scheduledFlightIDs = Set<UUID>()
+        for reservation in reservations where scheduledFlightIDs.insert(reservation.flight.id).inserted {
+            let flight = reservation.flight
+            Task { [weak self] in
+                guard let root = try? await flight.task.value,
+                      let identity = flight.completion.identity(),
+                      root.id == identity.rootID
+                else { return }
+                await self?.cleanupOrphanedSessionWorktreeRoots([
+                    WorkspaceSessionWorktreeOwnedRoot(
+                        rootID: identity.rootID,
+                        lifetimeID: identity.lifetimeID,
+                        standardizedPhysicalPath: reservation.standardizedPath
+                    )
+                ])
+            }
         }
     }
 
@@ -1725,8 +2147,16 @@ actor WorkspaceFileContextStore {
     }
 
     private func hasAggregateWatcherDemand(rootID: UUID, lifetimeID: UUID) -> Bool {
-        explicitWatcherDemandRootIDs.contains(rootID)
+        let hasPathReservation: Bool = if let state = rootStatesByID[rootID], state.lifetimeID == lifetimeID {
+            sessionWorktreeReservationTokensByStandardizedPath[
+                state.root.standardizedFullPath
+            ]?.isEmpty == false
+        } else {
+            false
+        }
+        return explicitWatcherDemandRootIDs.contains(rootID)
             || sessionWorktreeOwnerCount(rootID: rootID, lifetimeID: lifetimeID) > 0
+            || hasPathReservation
     }
 
     private func reconcileAggregateWatcherDemand(rootID: UUID) async throws {
@@ -1738,7 +2168,8 @@ actor WorkspaceFileContextStore {
             try await ensureWatcherInfrastructure(state: state, rootID: rootID)
             return
         }
-        watcherCancellablesByRootID.removeValue(forKey: rootID)?.cancel()
+        let key = WatcherInfrastructureKey(rootID: rootID, lifetimeID: state.lifetimeID)
+        watcherPublisherAttachmentsByKey.removeValue(forKey: key)?.cancellable.cancel()
         publisherIngressCoordinator.closePublisherIngress(rootID: rootID)
         try await reconcileWatcherServiceState(state.service, rootID: rootID)
         await waitForCurrentPublisherIngress(rootIDs: [rootID])
@@ -4119,7 +4550,8 @@ actor WorkspaceFileContextStore {
         respectCursorignore: Bool = true,
         skipSymlinks: Bool = true,
         enableHierarchicalIgnores: Bool = true,
-        cancelUnderlyingLoadOnCallerCancellation: Bool = false
+        cancelUnderlyingLoadOnCallerCancellation: Bool = false,
+        sessionWorktreeReservationToken: WorkspaceSessionWorktreeOwnershipToken? = nil
     ) async throws -> WorkspaceRootRecord {
         let standardizedPath = (path as NSString).standardizingPath
         #if DEBUG
@@ -4129,6 +4561,13 @@ actor WorkspaceFileContextStore {
         try Task.checkCancellation()
         try await waitForRootUnloadIfNeeded(standardizedPath: standardizedPath)
         try Task.checkCancellation()
+        if let sessionWorktreeReservationToken {
+            guard sessionWorktreeReservedPathsByToken[
+                sessionWorktreeReservationToken
+            ]?.contains(standardizedPath) == true else {
+                throw WorkspaceSessionWorktreeOwnershipError.staleUpdate
+            }
+        }
         let loadConfiguration = RootLoadConfiguration(
             kind: kind ?? (isSystemRoot ? .supplementalSystem : .primaryWorkspace),
             respectGitignore: respectGitignore,
@@ -4156,9 +4595,16 @@ actor WorkspaceFileContextStore {
             #endif
             return existing
         }
-        if let inFlight = rootLoadTasksByPath[standardizedPath] {
+        if let inFlight = rootLoadFlightsByPath[standardizedPath] {
             guard rootLoadConfigurationsByPath[standardizedPath] == loadConfiguration else {
                 throw WorkspaceFileContextStoreError.rootLoadInFlightWithDifferentConfiguration(standardizedPath)
+            }
+            if let sessionWorktreeReservationToken {
+                registerSessionWorktreeReservationLoadFlight(
+                    inFlight,
+                    standardizedPath: standardizedPath,
+                    token: sessionWorktreeReservationToken
+                )
             }
             #if DEBUG
                 WorkspaceRestorePerfLog.event(
@@ -4173,7 +4619,8 @@ actor WorkspaceFileContextStore {
                 }
             #endif
             return try await awaitRootLoadTask(
-                inFlight,
+                inFlight.task,
+                flightID: inFlight.id,
                 standardizedPath: standardizedPath,
                 cancelUnderlyingLoadOnCallerCancellation: cancelUnderlyingLoadOnCallerCancellation
             )
@@ -4188,6 +4635,7 @@ actor WorkspaceFileContextStore {
                 ]
             )
         #endif
+        let completion = RootLoadFlightCompletion()
         let task = Task { [weak self] in
             guard let self else { throw WorkspaceFileContextStoreError.storeDeallocated }
             return try await performLoadRoot(
@@ -4198,17 +4646,35 @@ actor WorkspaceFileContextStore {
                 respectRepoIgnore: respectRepoIgnore,
                 respectCursorignore: respectCursorignore,
                 skipSymlinks: skipSymlinks,
-                enableHierarchicalIgnores: enableHierarchicalIgnores
+                enableHierarchicalIgnores: enableHierarchicalIgnores,
+                completion: completion
             )
         }
-        rootLoadTasksByPath[standardizedPath] = task
+        let flightID = UUID()
+        let flight = RootLoadFlight(
+            id: flightID,
+            task: task,
+            completion: completion
+        )
+        rootLoadFlightsByPath[standardizedPath] = flight
         rootLoadConfigurationsByPath[standardizedPath] = loadConfiguration
+        if let sessionWorktreeReservationToken {
+            registerSessionWorktreeReservationLoadFlight(
+                flight,
+                standardizedPath: standardizedPath,
+                token: sessionWorktreeReservationToken
+            )
+        }
         Task { [weak self] in
             _ = try? await task.value
-            await self?.clearCompletedRootLoadTask(standardizedPath: standardizedPath)
+            await self?.clearCompletedRootLoadTask(
+                standardizedPath: standardizedPath,
+                expectedFlightID: flightID
+            )
         }
         return try await awaitRootLoadTask(
             task,
+            flightID: flightID,
             standardizedPath: standardizedPath,
             cancelUnderlyingLoadOnCallerCancellation: cancelUnderlyingLoadOnCallerCancellation
         )
@@ -4216,29 +4682,71 @@ actor WorkspaceFileContextStore {
 
     private func awaitRootLoadTask(
         _ task: Task<WorkspaceRootRecord, Error>,
+        flightID: UUID,
         standardizedPath: String,
         cancelUnderlyingLoadOnCallerCancellation: Bool
     ) async throws -> WorkspaceRootRecord {
-        try await withTaskCancellationHandler {
-            try await task.value
+        let race = RootLoadTaskWaitRace()
+        Task {
+            await race.resolve(task.result)
+        }
+        let root = try await withTaskCancellationHandler {
+            try await race.value()
         } onCancel: {
+            race.cancel()
             guard cancelUnderlyingLoadOnCallerCancellation else { return }
             task.cancel()
-            Task { await self.cancelRootLoad(path: standardizedPath) }
+            Task {
+                await self.cancelRootLoad(
+                    standardizedPath: standardizedPath,
+                    expectedFlightID: flightID
+                )
+            }
         }
+        try Task.checkCancellation()
+        return root
     }
 
     func cancelRootLoad(path: String) {
         let standardizedPath = (path as NSString).standardizingPath
-        rootLoadTasksByPath[standardizedPath]?.cancel()
-        rootLoadTasksByPath.removeValue(forKey: standardizedPath)
-        if rootIDsByStandardizedPath[standardizedPath] == nil {
-            rootLoadConfigurationsByPath.removeValue(forKey: standardizedPath)
-        }
+        guard let flight = rootLoadFlightsByPath[standardizedPath] else { return }
+        flight.task.cancel()
+        removeRootLoadFlight(
+            standardizedPath: standardizedPath,
+            expectedFlightID: flight.id
+        )
     }
 
-    private func clearCompletedRootLoadTask(standardizedPath: String) {
-        rootLoadTasksByPath.removeValue(forKey: standardizedPath)
+    private func cancelRootLoad(
+        standardizedPath: String,
+        expectedFlightID: UUID
+    ) {
+        guard let flight = rootLoadFlightsByPath[standardizedPath],
+              flight.id == expectedFlightID
+        else { return }
+        flight.task.cancel()
+        removeRootLoadFlight(
+            standardizedPath: standardizedPath,
+            expectedFlightID: expectedFlightID
+        )
+    }
+
+    private func clearCompletedRootLoadTask(
+        standardizedPath: String,
+        expectedFlightID: UUID
+    ) {
+        removeRootLoadFlight(
+            standardizedPath: standardizedPath,
+            expectedFlightID: expectedFlightID
+        )
+    }
+
+    private func removeRootLoadFlight(
+        standardizedPath: String,
+        expectedFlightID: UUID
+    ) {
+        guard rootLoadFlightsByPath[standardizedPath]?.id == expectedFlightID else { return }
+        rootLoadFlightsByPath.removeValue(forKey: standardizedPath)
         if rootIDsByStandardizedPath[standardizedPath] == nil {
             rootLoadConfigurationsByPath.removeValue(forKey: standardizedPath)
         }
@@ -4252,12 +4760,17 @@ actor WorkspaceFileContextStore {
         respectRepoIgnore: Bool,
         respectCursorignore: Bool,
         skipSymlinks: Bool,
-        enableHierarchicalIgnores: Bool
+        enableHierarchicalIgnores: Bool,
+        completion: RootLoadFlightCompletion
     ) async throws -> WorkspaceRootRecord {
         if let existingID = rootIDsByStandardizedPath[standardizedPath],
-           let existing = rootStatesByID[existingID]?.root
+           let existingState = rootStatesByID[existingID]
         {
-            return existing
+            completion.record(
+                rootID: existingState.root.id,
+                lifetimeID: existingState.lifetimeID
+            )
+            return existingState.root
         }
 
         #if DEBUG
@@ -4392,6 +4905,7 @@ actor WorkspaceFileContextStore {
         #endif
         rootIDsByStandardizedPath[root.standardizedFullPath] = root.id
         rootStatesByID[root.id] = state
+        completion.record(rootID: root.id, lifetimeID: state.lifetimeID)
         rootLoadOrder.append(root.id)
         appliedIndexGenerationsByRootID[root.id] = 0
         catalogGenerationsByRootID[root.id] = 0
@@ -4461,18 +4975,24 @@ actor WorkspaceFileContextStore {
         guard !orderedRootIDs.isEmpty else { return }
 
         var statesToUnload: [(rootID: UUID, state: RootState)] = []
-        var ownershipRootsReleasedByUnload: [WorkspaceSessionWorktreeOwnedRoot] = []
+        var ownershipResourcesReleasedByUnload = SessionWorktreeOwnershipRemoval()
+        var invalidatedOwnershipTokens = Set<WorkspaceSessionWorktreeOwnershipToken>()
         for rootID in orderedRootIDs {
             explicitWatcherDemandRootIDs.remove(rootID)
             if let state = rootStatesByID[rootID] {
+                let watcherKey = WatcherInfrastructureKey(rootID: rootID, lifetimeID: state.lifetimeID)
+                explicitWatcherDemandGenerationByKey.removeValue(forKey: watcherKey)
+            }
+            if let state = rootStatesByID[rootID], state.root.kind == .sessionWorktree {
                 let lifetimeKey = SessionWorktreeRootLifetimeKey(rootID: rootID, lifetimeID: state.lifetimeID)
-                let ownershipTokens = sessionWorktreeOwnershipTokensByRootLifetime[lifetimeKey] ?? []
-                for token in ownershipTokens {
+                let ownershipTokens = (sessionWorktreeOwnershipTokensByRootLifetime[lifetimeKey] ?? [])
+                    .union(sessionWorktreeReservationTokensByStandardizedPath[state.root.standardizedFullPath] ?? [])
+                for token in ownershipTokens where invalidatedOwnershipTokens.insert(token).inserted {
                     latestSessionWorktreeOwnershipGenerationByOwnerID[token.ownerID, default: 0] &+= 1
                     if installedSessionWorktreeOwnershipTokenByOwnerID[token.ownerID] == token {
                         installedSessionWorktreeOwnershipTokenByOwnerID.removeValue(forKey: token.ownerID)
                     }
-                    ownershipRootsReleasedByUnload.append(contentsOf: removeSessionWorktreeOwnershipToken(token))
+                    ownershipResourcesReleasedByUnload.append(removeSessionWorktreeOwnershipToken(token))
                 }
             }
             if let flightState = scopedIngressBarrierFlightStatesByRootID.removeValue(forKey: rootID) {
@@ -4481,7 +5001,11 @@ actor WorkspaceFileContextStore {
                 flightState.pending?.join.complete(with: nil)
             }
             completedScopedIngressBarrierCutsByRootID.removeValue(forKey: rootID)
-            watcherCancellablesByRootID.removeValue(forKey: rootID)?.cancel()
+            if let state = rootStatesByID[rootID] {
+                let watcherKey = WatcherInfrastructureKey(rootID: rootID, lifetimeID: state.lifetimeID)
+                watcherPublisherAttachmentsByKey.removeValue(forKey: watcherKey)?.cancellable.cancel()
+                watcherInfrastructureFlightsByKey.removeValue(forKey: watcherKey)?.task.cancel()
+            }
             publisherIngressCoordinator.closePublisherIngress(rootID: rootID)
             guard let state = rootStatesByID.removeValue(forKey: rootID) else { continue }
             statesToUnload.append((rootID, state))
@@ -4666,9 +5190,17 @@ actor WorkspaceFileContextStore {
         let removedLifetimeKeys = Set(statesToUnload.map {
             SessionWorktreeRootLifetimeKey(rootID: $0.rootID, lifetimeID: $0.state.lifetimeID)
         })
-        await cleanupOrphanedSessionWorktreeRoots(ownershipRootsReleasedByUnload.filter {
-            !removedLifetimeKeys.contains(SessionWorktreeRootLifetimeKey(rootID: $0.rootID, lifetimeID: $0.lifetimeID))
-        })
+        let removedStandardizedPaths = Set(statesToUnload.map(\.state.root.standardizedFullPath))
+        await cleanupOrphanedSessionWorktreeResources(SessionWorktreeOwnershipRemoval(
+            ownedRoots: ownershipResourcesReleasedByUnload.ownedRoots.filter {
+                !removedLifetimeKeys.contains(
+                    SessionWorktreeRootLifetimeKey(rootID: $0.rootID, lifetimeID: $0.lifetimeID)
+                )
+            },
+            reservedLoadFlights: ownershipResourcesReleasedByUnload.reservedLoadFlights.filter {
+                !removedStandardizedPaths.contains($0.standardizedPath)
+            }
+        ))
         #if DEBUG
             WorkspaceRestorePerfLog.event(
                 "store.rootUnload.end",

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileSystemIngressCoordinator.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileSystemIngressCoordinator.swift
@@ -172,6 +172,21 @@ final class WorkspaceFileSystemIngressCoordinator: @unchecked Sendable {
         state.isOpen = false
     }
 
+    @discardableResult
+    func closePublisherIngress(_ subscription: Subscription) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard let state = rootStatesByID[subscription.rootID],
+              state.isOpen,
+              state.generation == subscription.generation
+        else { return false }
+        nextSubscriptionGeneration &+= 1
+        state.generation = nextSubscriptionGeneration
+        state.isOpen = false
+        return true
+    }
+
     func isPublisherIngressOpen(_ subscription: Subscription) -> Bool {
         lock.lock()
         defer { lock.unlock() }

--- a/Sources/RepoPromptShared/MCP/MCPTimeoutPolicy.swift
+++ b/Sources/RepoPromptShared/MCP/MCPTimeoutPolicy.swift
@@ -9,6 +9,9 @@ public enum MCPTimeoutPolicy {
     public static let workspaceFreshnessWaitTimeoutSeconds = 30
     public static let workspaceFreshnessWaitTimeout: Duration = .seconds(workspaceFreshnessWaitTimeoutSeconds)
 
+    public static let workspaceReadinessWaitTimeoutSeconds = 30
+    public static let workspaceReadinessWaitTimeout: Duration = .seconds(workspaceReadinessWaitTimeoutSeconds)
+
     public static let workspaceSwitchToolExecutionDeadlineSeconds = 120
     public static let workspaceSwitchToolExecutionDeadline: Duration = .seconds(
         workspaceSwitchToolExecutionDeadlineSeconds

--- a/Tests/RepoPromptTests/AgentMode/AgentModeMCPWaitEpochTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeMCPWaitEpochTests.swift
@@ -150,19 +150,58 @@ final class AgentModeMCPWaitEpochTests: XCTestCase {
             startPending: true
         )
         await viewModel.prepareMCPWaitTrackingForRunStart(session: session)
+        let previousRunID = UUID()
+        let runID = UUID()
+        let currentTurnID = UUID()
+        session.transcript = AgentTranscript(turns: [
+            AgentTranscriptTurn(
+                responseSpans: [AgentTranscriptProviderResponseSpan(runID: previousRunID, startedAt: Date())],
+                startedAt: Date()
+            ),
+            AgentTranscriptTurn(
+                id: currentTurnID,
+                responseSpans: [AgentTranscriptProviderResponseSpan(startedAt: Date())],
+                startedAt: Date()
+            )
+        ])
+        session.runID = runID
         let ownership = session.beginRunAttempt(source: "test.canonical")
         session.runState = .completed
         session.mcpFollowUpRunPending = true
 
         let projected = try XCTUnwrap(viewModel.mcpSnapshot(for: session))
+        XCTAssertEqual(projected.status, .running)
+        XCTAssertEqual(projected.runID, runID)
+
+        session.runID = nil
+        let queuedProjection = try XCTUnwrap(viewModel.mcpSnapshot(for: session))
+        XCTAssertEqual(queuedProjection.status, .running)
+        XCTAssertNil(queuedProjection.runID)
+
         let envelope = try XCTUnwrap(viewModel.test_makeTerminalPublicationEnvelope(
             for: session,
             ownership: ownership,
-            terminalState: .completed
+            terminalState: .completed,
+            providerRunID: runID
         ))
-        XCTAssertEqual(projected.status, .running)
         XCTAssertEqual(envelope.snapshot.status, .completed)
+        XCTAssertEqual(envelope.snapshot.runID, runID)
         XCTAssertEqual(envelope.epoch, ownership.turnEpoch)
+
+        XCTAssertTrue(AgentModeProcessRunIdentity.retainProcessRunID(
+            runID,
+            inTranscriptTurnID: currentTurnID,
+            for: session
+        ))
+        XCTAssertFalse(AgentModeProcessRunIdentity.retainProcessRunID(
+            previousRunID,
+            inTranscriptTurnID: currentTurnID,
+            for: session
+        ))
+        session.mcpFollowUpRunPending = false
+        let completed = try XCTUnwrap(viewModel.mcpSnapshot(for: session))
+        XCTAssertEqual(completed.status, .completed)
+        XCTAssertEqual(completed.runID, runID)
         await viewModel.mcpDeactivateControlContext(sessionID: sessionID, cleanupSessionStore: true)
     }
 

--- a/Tests/RepoPromptTests/AgentMode/AgentModeRunServiceLifecycleTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeRunServiceLifecycleTests.swift
@@ -833,7 +833,7 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
                     ? .rejected(reason: "test_transient_rejection")
                     : .accepted(successorEpoch: successor)
             },
-            makeTerminalPublicationEnvelope: { _, _, _ in
+            makeTerminalPublicationEnvelope: { _, _, _, _ in
                 .init(epoch: epoch, snapshot: .expired(sessionID: sessionID))
             },
             startFollowUpRun: { _, text in recorder.record("follow-up:\(text)") }
@@ -1441,6 +1441,7 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
             acpProviderFactory: acpProviderFactory,
             acpControllerFactory: trackedACPControllerFactory,
             connectionPolicyInstaller: policyInstaller,
+            expectedPIDPolicyArmer: { _ in true },
             mcpServerEnabler: serverEnabler,
             workspacePathProvider: workspacePathProvider,
             codexCoordinator: host.test_codexCoordinator,
@@ -1480,7 +1481,8 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
         makeTerminalPublicationEnvelope: ((
             AgentModeViewModel.TabSession,
             AgentRunOwnership,
-            AgentSessionRunState
+            AgentSessionRunState,
+            UUID?
         ) -> AgentRunTerminalPublicationEnvelope?)? = nil,
         startFollowUpRun: ((UUID, String) -> Void)? = nil
     ) -> AgentModeRunService.Hooks {
@@ -1517,7 +1519,7 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
             flushPendingAssistantDelta: flushPendingAssistantDelta,
             clearPendingAssistantDelta: { _ in },
             prepareTerminalPublication: { _ in recorder.record("prepare-publication") },
-            makeTerminalPublicationEnvelope: makeTerminalPublicationEnvelope ?? { _, _, _ in nil },
+            makeTerminalPublicationEnvelope: makeTerminalPublicationEnvelope ?? { _, _, _, _ in nil },
             publishTerminalCommit: { session, revision, successorKind in
                 if let publishTerminalCommitResult {
                     return await publishTerminalCommitResult(session, revision, successorKind)

--- a/Tests/RepoPromptTests/MCP/AgentRunMCPToolServiceWaitTests.swift
+++ b/Tests/RepoPromptTests/MCP/AgentRunMCPToolServiceWaitTests.swift
@@ -66,7 +66,8 @@ final class AgentRunMCPToolServiceWaitTests: XCTestCase {
             ])
         }
         try await waitForWaiter(registration: fixture.registration)
-        let terminal = makeSnapshot(sessionID: fixture.sessionID, status: .completed)
+        let terminalRunID = UUID()
+        let terminal = makeSnapshot(sessionID: fixture.sessionID, runID: terminalRunID, status: .completed)
         await liveSnapshots.set(terminal)
         _ = await AgentRunSessionStore.publishTerminal(
             .init(epoch: fixture.epoch, snapshot: terminal),
@@ -77,6 +78,7 @@ final class AgentRunMCPToolServiceWaitTests: XCTestCase {
 
         let resumedValue = try await secondWait.value
         XCTAssertEqual(resumedValue.objectValue?["status"]?.stringValue, AgentRunMCPSnapshot.Status.completed.rawValue)
+        XCTAssertEqual(resumedValue.objectValue?["run_id"]?.stringValue, terminalRunID.uuidString)
         XCTAssertNil(resumedValue.objectValue?["_meta"]?.objectValue?["wake_reason"])
         let allCompletions = await recorder.completions()
         XCTAssertEqual(allCompletions.count, 2)
@@ -424,11 +426,13 @@ final class AgentRunMCPToolServiceWaitTests: XCTestCase {
 
     private func makeSnapshot(
         sessionID: UUID,
+        runID: UUID? = nil,
         status: AgentRunMCPSnapshot.Status,
         latestAssistantPreview: String? = nil
     ) -> AgentRunMCPSnapshot {
         AgentRunMCPSnapshot(
             sessionID: sessionID,
+            runID: runID,
             tabID: nil,
             sessionName: "Child Agent",
             agentRaw: AgentProviderKind.codexExec.rawValue,

--- a/Tests/RepoPromptTests/MCP/AgentRunWorktreeStartTests.swift
+++ b/Tests/RepoPromptTests/MCP/AgentRunWorktreeStartTests.swift
@@ -483,8 +483,10 @@ final class AgentRunWorktreeStartTests: AgentRunWorktreeStartGitSeedTestCase {
         let root = try makeTemporaryDirectory(named: "root")
         let worktree = try makeTemporaryDirectory(named: "worktree")
         let binding = makeBinding(logicalRoot: root.path, worktreeRoot: worktree.path, label: "Feature WT")
+        let runID = UUID()
         let snapshot = AgentRunMCPSnapshot(
             sessionID: UUID(),
+            runID: runID,
             tabID: UUID(),
             sessionName: "Worktree Agent",
             agentRaw: AgentProviderKind.codexExec.rawValue,
@@ -504,6 +506,8 @@ final class AgentRunWorktreeStartTests: AgentRunWorktreeStartGitSeedTestCase {
         )
 
         let object = snapshot.asObject()
+        XCTAssertEqual(object["run_id"]?.stringValue, runID.uuidString)
+        XCTAssertNil(AgentRunMCPSnapshot.expired(sessionID: UUID()).asObject()["run_id"])
         let worktreeObject = try XCTUnwrap(object["worktree"]?.objectValue)
         XCTAssertEqual(worktreeObject["worktree_id"]?.stringValue, "wt_test")
         XCTAssertEqual(worktreeObject["worktree_root_path"]?.stringValue, worktree.path)

--- a/Tests/RepoPromptTests/MCP/Control/MCPAgentPolicyAdmissionRaceTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/MCPAgentPolicyAdmissionRaceTests.swift
@@ -149,8 +149,23 @@ final class MCPAgentPolicyAdmissionRaceTests: XCTestCase {
             let secondWindowID = 61005
             await installPolicy(runID: firstRunID, windowID: firstWindowID)
             await installPolicy(runID: secondRunID, windowID: secondWindowID)
-            await manager.registerExpectedAgentPID(firstProcess.parentPID, for: clientName, runID: firstRunID)
+            let firstArmed = await manager.requireExpectedAgentPIDForPendingPolicy(
+                for: clientName,
+                runID: firstRunID,
+                windowID: firstWindowID
+            )
+            let secondArmed = await manager.requireExpectedAgentPIDForPendingPolicy(
+                for: clientName,
+                runID: secondRunID,
+                windowID: secondWindowID
+            )
+            XCTAssertTrue(firstArmed)
+            XCTAssertTrue(secondArmed)
+
+            // Register in reverse policy order to prove PID ownership, not FIFO position,
+            // determines which same-client run each connection consumes.
             await manager.registerExpectedAgentPID(secondProcess.parentPID, for: clientName, runID: secondRunID)
+            await manager.registerExpectedAgentPID(firstProcess.parentPID, for: clientName, runID: firstRunID)
 
             async let first = manager.debugApplyPendingPolicy(
                 clientName: clientName,
@@ -1693,6 +1708,65 @@ final class MCPAgentPolicyAdmissionRaceTests: XCTestCase {
             XCTAssertTrue(didRoute)
         #else
             throw XCTSkip("Tab-context routing diagnostics require DEBUG helpers.")
+        #endif
+    }
+
+    func testRunPolicyRevocationInvalidatesSuspendedApplicationBeforeAdmission() async throws {
+        #if DEBUG
+            let runID = UUID()
+            let connectionID = UUID()
+            let windowID = 61026
+            await installPolicy(runID: runID, windowID: windowID)
+            let armed = await manager.requireExpectedAgentPIDForPendingPolicy(
+                for: clientName,
+                runID: runID,
+                windowID: windowID
+            )
+            XCTAssertTrue(armed)
+            await manager.registerExpectedAgentPID(getpid(), for: clientName, runID: runID)
+            await manager.debugSuspendNextPendingPolicyRouteInstallation()
+
+            let application = Task {
+                await manager.debugApplyPendingPolicy(
+                    clientName: clientName,
+                    connectionID: connectionID,
+                    clientPid: Int(getpid()),
+                    bootstrapClientName: "repoprompt_ce_cli_debug",
+                    pidGateTimeout: 0.25,
+                    requireRunRouting: false
+                )
+            }
+            let suspended = await waitUntil {
+                await self.manager.debugIsPendingPolicyRouteInstallationSuspended()
+            }
+            XCTAssertTrue(suspended)
+
+            await manager.revokeClientConnectionPolicy(
+                for: clientName,
+                windowID: windowID,
+                runID: runID
+            )
+            await manager.debugResumePendingPolicyRouteInstallation()
+            let result = await application.value
+
+            XCTAssertTrue(
+                result.outcome == "rejected:stale_connection" || result.outcome == "rejected:policy_removed",
+                result.outcome
+            )
+            let mappedRunID = await manager.runIDForConnection(connectionID)
+            let pending = await manager.debugPendingPolicySnapshot(for: clientName)
+            let runPolicy = await manager.debugRunPolicyState(for: runID)
+            XCTAssertNil(mappedRunID)
+            XCTAssertFalse(pending.contains { $0.runID == runID })
+            XCTAssertNil(runPolicy)
+            await cleanup(
+                runID: runID,
+                connectionID: connectionID,
+                windowID: windowID,
+                expectedPID: getpid()
+            )
+        #else
+            throw XCTSkip("PID-gated routing diagnostics require DEBUG helpers.")
         #endif
     }
 

--- a/Tests/RepoPromptTests/MCP/Control/MCPBootstrapLeaseTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/MCPBootstrapLeaseTests.swift
@@ -4,6 +4,212 @@ import Foundation
 import XCTest
 
 final class MCPBootstrapLeaseTests: XCTestCase {
+    func testPIDOwnedSameClientLeasesReleaseBootstrapGateBeforeEitherRoutes() async throws {
+        #if DEBUG
+            let firstRunID = UUID()
+            let secondRunID = UUID()
+            let firstGateID = UUID()
+            let secondGateID = UUID()
+            let clientName = "bootstrap-lease-parallel-same-client"
+            let recorder = PolicyRecorder()
+
+            await HeadlessAgentConnectionGate.cancelAll()
+            await MCPRoutingWaiter.cleanup(runID: firstRunID)
+            await MCPRoutingWaiter.cleanup(runID: secondRunID)
+            await ServerNetworkManager.shared.debugClearRunRoutingHistoryForTesting()
+
+            func makeLease(runID: UUID, gateID: UUID, tabID: UUID) -> MCPBootstrapLease {
+                MCPBootstrapLease(
+                    spec: MCPBootstrapLeaseSpec(
+                        runID: runID,
+                        gateID: gateID,
+                        windowID: 1,
+                        tabID: tabID,
+                        clientName: clientName,
+                        restrictedTools: [],
+                        additionalTools: nil,
+                        oneShot: true,
+                        reason: "parallel PID-owned bootstrap regression",
+                        ttl: 10,
+                        purpose: .agentModeRun,
+                        taskLabelKind: nil,
+                        allowsAgentExternalControlTools: false,
+                        requiresExpectedAgentPID: true
+                    ),
+                    policyInstaller: { _ in await recorder.recordInstall() },
+                    expectedPIDPolicyArmer: { _ in await recorder.recordArm() },
+                    policyClearer: { _ in await recorder.recordClear() }
+                )
+            }
+
+            let firstLease = makeLease(runID: firstRunID, gateID: firstGateID, tabID: UUID())
+            let secondLease = makeLease(runID: secondRunID, gateID: secondGateID, tabID: UUID())
+            let firstAcquired = await firstLease.acquire()
+            let activeGateAfterFirstAcquire = await HeadlessAgentConnectionGate.shared.debugActiveConnectionID()
+            XCTAssertTrue(firstAcquired)
+            XCTAssertNil(activeGateAfterFirstAcquire)
+
+            let secondCompleted = expectation(description: "second same-client PID-owned lease acquires before first routes")
+            let secondAcquisition = Task {
+                let acquired = await secondLease.acquire()
+                secondCompleted.fulfill()
+                return acquired
+            }
+            await fulfillment(of: [secondCompleted], timeout: 1)
+            let secondAcquired = await secondAcquisition.value
+
+            let installCount = await recorder.installCount
+            let armCount = await recorder.armCount
+            let activeGateAfterSecondAcquire = await HeadlessAgentConnectionGate.shared.debugActiveConnectionID()
+            XCTAssertTrue(secondAcquired)
+            XCTAssertEqual(installCount, 2)
+            XCTAssertEqual(armCount, 2)
+            XCTAssertNil(activeGateAfterSecondAcquire)
+
+            await firstLease.providerInitializationStarted(provider: "test-provider")
+            await firstLease.providerInitializationCompleted(provider: "test-provider", outcome: "ready")
+            let firstHistory = await ServerNetworkManager.shared.debugRunRoutingHistoryPayload(
+                runID: firstRunID,
+                limit: 50
+            )
+            let firstEvents = try XCTUnwrap(firstHistory["events"] as? [[String: Any]])
+            XCTAssertTrue(firstEvents.contains { $0["event"] as? String == "lease_gate_wait_started" })
+            XCTAssertTrue(firstEvents.contains { $0["event"] as? String == "lease_gate_acquired" })
+            XCTAssertTrue(firstEvents.contains { $0["event"] as? String == "provider_initialization_started" })
+            let providerCompleted = try XCTUnwrap(firstEvents.first { $0["event"] as? String == "provider_initialization_completed" })
+            let providerFields = try XCTUnwrap(providerCompleted["fields"] as? [String: String])
+            XCTAssertEqual(providerFields["provider"], "test-provider")
+            XCTAssertEqual(providerFields["outcome"], "ready")
+            let earlyRelease = try XCTUnwrap(firstEvents.first { $0["event"] as? String == "lease_gate_release" })
+            let releaseFields = try XCTUnwrap(earlyRelease["fields"] as? [String: String])
+            XCTAssertEqual(releaseFields["reason"], "expected_pid_policy_armed")
+            XCTAssertEqual(releaseFields["released"], "true")
+            XCTAssertNotNil(releaseFields["queue_depth_before_release"])
+
+            await firstLease.cancelAndCleanup()
+            await secondLease.cancelAndCleanup()
+            let clearCount = await recorder.clearCount
+            let firstWaiterCount = await MCPRoutingWaiter.debugContinuationCount(runID: firstRunID)
+            let secondWaiterCount = await MCPRoutingWaiter.debugContinuationCount(runID: secondRunID)
+            let activeGateAfterCleanup = await HeadlessAgentConnectionGate.shared.debugActiveConnectionID()
+            XCTAssertEqual(clearCount, 2)
+            XCTAssertEqual(firstWaiterCount, 0)
+            XCTAssertEqual(secondWaiterCount, 0)
+            XCTAssertNil(activeGateAfterCleanup)
+        #else
+            throw XCTSkip("Bootstrap gate diagnostics require DEBUG helpers.")
+        #endif
+    }
+
+    func testPIDOwnedEarlyReleaseCleanupRemovesRetainedPolicyForEveryExit() async throws {
+        #if DEBUG
+            enum ExitMode: String, CaseIterable {
+                case timeout
+                case cancellation
+                case failure
+            }
+
+            let manager = ServerNetworkManager.shared
+            await HeadlessAgentConnectionGate.cancelAll()
+
+            for mode in ExitMode.allCases {
+                let runID = UUID()
+                let gateID = UUID()
+                let clientName = "bootstrap-lease-early-release-\(mode.rawValue)-\(runID.uuidString)"
+                let lease = MCPBootstrapLease(
+                    spec: MCPBootstrapLeaseSpec(
+                        runID: runID,
+                        gateID: gateID,
+                        windowID: 1,
+                        tabID: UUID(),
+                        clientName: clientName,
+                        restrictedTools: [],
+                        additionalTools: nil,
+                        oneShot: true,
+                        reason: "early release \(mode.rawValue) cleanup regression",
+                        ttl: 10,
+                        purpose: .agentModeRun,
+                        taskLabelKind: nil,
+                        allowsAgentExternalControlTools: false,
+                        requiresExpectedAgentPID: true
+                    )
+                )
+
+                await MCPRoutingWaiter.cleanup(runID: runID)
+                let acquired = await lease.acquire()
+                let activeGateAfterAcquire = await HeadlessAgentConnectionGate.shared.debugActiveConnectionID()
+                let pendingBeforeExit = await manager.debugPendingPolicySnapshot(for: clientName)
+                XCTAssertTrue(acquired, mode.rawValue)
+                XCTAssertNil(activeGateAfterAcquire, mode.rawValue)
+                XCTAssertTrue(pendingBeforeExit.contains { $0.runID == runID }, mode.rawValue)
+
+                switch mode {
+                case .timeout:
+                    let routed = await lease.releaseWhenRouted(timeoutMs: 10)
+                    XCTAssertFalse(routed)
+                case .cancellation:
+                    await lease.cancelAndCleanup()
+                case .failure:
+                    await lease.failAndRelease()
+                }
+
+                let pendingAfterExit = await manager.debugPendingPolicySnapshot(for: clientName)
+                let waiterCount = await MCPRoutingWaiter.debugContinuationCount(runID: runID)
+                let activeGateAfterExit = await HeadlessAgentConnectionGate.shared.debugActiveConnectionID()
+                XCTAssertFalse(pendingAfterExit.contains { $0.runID == runID }, mode.rawValue)
+                XCTAssertEqual(waiterCount, 0, mode.rawValue)
+                XCTAssertNil(activeGateAfterExit, mode.rawValue)
+                await manager.cleanupRunRoutingState(for: runID, windowID: 1)
+                await MCPRoutingWaiter.cleanup(runID: runID)
+            }
+        #else
+            throw XCTSkip("PID-owned policy diagnostics require DEBUG helpers.")
+        #endif
+    }
+
+    func testPIDOwnedAcquireFailsClosedWhenPolicyCannotBeArmed() async throws {
+        #if DEBUG
+            let runID = UUID()
+            let gateID = UUID()
+            let recorder = PolicyRecorder()
+            await HeadlessAgentConnectionGate.cancelAll()
+            await MCPRoutingWaiter.cleanup(runID: runID)
+
+            let lease = MCPBootstrapLease(
+                spec: MCPBootstrapLeaseSpec(
+                    runID: runID,
+                    gateID: gateID,
+                    windowID: 1,
+                    tabID: UUID(),
+                    clientName: "bootstrap-lease-unarmed-policy",
+                    restrictedTools: [],
+                    additionalTools: nil,
+                    oneShot: true,
+                    reason: "unarmed PID policy regression",
+                    ttl: 10,
+                    purpose: .agentModeRun,
+                    taskLabelKind: nil,
+                    allowsAgentExternalControlTools: false,
+                    requiresExpectedAgentPID: true
+                ),
+                policyInstaller: { _ in await recorder.recordInstall() },
+                expectedPIDPolicyArmer: { _ in false },
+                policyClearer: { _ in await recorder.recordClear() }
+            )
+
+            let acquired = await lease.acquire()
+            let clearCount = await recorder.clearCount
+            let waiterCount = await MCPRoutingWaiter.debugContinuationCount(runID: runID)
+            let activeGate = await HeadlessAgentConnectionGate.shared.debugActiveConnectionID()
+            XCTAssertFalse(acquired)
+            XCTAssertEqual(clearCount, 1)
+            XCTAssertEqual(waiterCount, 0)
+            XCTAssertNil(activeGate)
+        #else
+            throw XCTSkip("Bootstrap gate diagnostics require DEBUG helpers.")
+        #endif
+    }
+
     func testCleanupWhileQueuedReleasesGateOwnershipThatArrivesLater() async throws {
         #if DEBUG
             let blockerGateID = UUID()
@@ -313,10 +519,16 @@ private extension MCPBootstrapLeaseTests {
 
 private actor PolicyRecorder {
     private(set) var installCount = 0
+    private(set) var armCount = 0
     private(set) var clearCount = 0
 
     func recordInstall() {
         installCount += 1
+    }
+
+    func recordArm() -> Bool {
+        armCount += 1
+        return true
     }
 
     func recordClear() {

--- a/Tests/RepoPromptTests/MCP/ToolCatalogSnapshotTests.swift
+++ b/Tests/RepoPromptTests/MCP/ToolCatalogSnapshotTests.swift
@@ -198,12 +198,29 @@ final class ToolCatalogSnapshotTests: XCTestCase {
 
     func testProductionRegistrationUsesCatalogServiceNotViewModel() async throws {
         #if DEBUG
+            XCTAssertTrue(AppLaunchConfiguration.debugBuildForcesMCPAutoStart(
+                bundleURL: URL(fileURLWithPath: "/tmp/RepoPrompt.app", isDirectory: true)
+            ))
+            XCTAssertFalse(AppLaunchConfiguration.debugBuildForcesMCPAutoStart(
+                bundleURL: URL(fileURLWithPath: "/tmp/RepoPromptTests.xctest", isDirectory: true)
+            ))
+            XCTAssertFalse(AppLaunchConfiguration.debugBuildForcesMCPAutoStart(
+                bundleURL: URL(fileURLWithPath: "/tmp/RepoPrompt.app", isDirectory: true),
+                arguments: ["-RP_UITEST"]
+            ))
+            XCTAssertFalse(AppLaunchConfiguration.debugBuildForcesMCPAutoStart(
+                bundleURL: URL(fileURLWithPath: "/tmp/RepoPrompt.app", isDirectory: true),
+                environment: ["XCTestConfigurationFilePath": "/tmp/session.xctestconfiguration"]
+            ))
+
             try await MCPSharedServerTestLease.shared.withLease { _ in
                 let window = Self.makeWindowWithoutAutoStart()
                 let catalogService = window.mcpServer.windowMCPToolCatalogService
 
                 try await Self.withIsolatedBootstrapSocketNamespace(window: window, catalogService: catalogService) { socketURL in
+                    let storedAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
                     await window.mcpServer.ensureServerReadyForAgentBootstrap()
+                    XCTAssertEqual(GlobalSettingsStore.shared.mcpAutoStart(), storedAutoStart)
                     XCTAssertTrue(ServiceRegistry.services.contains { service in
                         (service as AnyObject) === (catalogService as AnyObject)
                     })

--- a/Tests/RepoPromptTests/MCP/ToolOutputFormatterWorktreeTests.swift
+++ b/Tests/RepoPromptTests/MCP/ToolOutputFormatterWorktreeTests.swift
@@ -307,6 +307,7 @@ final class ToolOutputFormatterWorktreeTests: XCTestCase {
                     op: "start",
                     status: "running",
                     sessionID: "session-available",
+                    runID: "11111111-1111-1111-1111-111111111111",
                     session: Session(name: "Available feature agent"),
                     worktreeBindings: [
                         WorktreeBinding(
@@ -322,7 +323,7 @@ final class ToolOutputFormatterWorktreeTests: XCTestCase {
                         )
                     ]
                 ),
-                ["- Worktree: **Feature WT**", "branch `feature/available`", "`wt_test`", "path `/tmp/repo-feature`", "#3366FF"]
+                ["- Run ID: `11111111-1111-1111-1111-111111111111`", "- Worktree: **Feature WT**", "branch `feature/available`", "`wt_test`", "path `/tmp/repo-feature`", "#3366FF"]
             ),
             (
                 "unavailable",
@@ -330,6 +331,7 @@ final class ToolOutputFormatterWorktreeTests: XCTestCase {
                     op: "start",
                     status: "failed",
                     sessionID: "session-unavailable",
+                    runID: "22222222-2222-2222-2222-222222222222",
                     session: Session(name: "Feature agent"),
                     worktreeBindings: [
                         WorktreeBinding(
@@ -345,7 +347,7 @@ final class ToolOutputFormatterWorktreeTests: XCTestCase {
                         )
                     ]
                 ),
-                ["- Worktree: **demo**", "branch `feature/demo`", "`wt_missing`", "path `/tmp/repo-missing`", "⚠️ unavailable"]
+                ["- Run ID: `22222222-2222-2222-2222-222222222222`", "- Worktree: **demo**", "branch `feature/demo`", "`wt_missing`", "path `/tmp/repo-missing`", "⚠️ unavailable"]
             )
         ]
 
@@ -532,12 +534,14 @@ final class ToolOutputFormatterWorktreeTests: XCTestCase {
         let op: String
         let status: String
         let sessionID: String
+        let runID: String
         let session: Session
         let worktreeBindings: [WorktreeBinding]
 
         private enum CodingKeys: String, CodingKey {
             case op, status, session
             case sessionID = "session_id"
+            case runID = "run_id"
             case worktreeBindings = "worktree_bindings"
         }
     }

--- a/Tests/RepoPromptTests/WorkspaceContext/Search/StoreBackedWorkspaceSearchTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/Search/StoreBackedWorkspaceSearchTests.swift
@@ -1780,6 +1780,284 @@ final class StoreBackedWorkspaceSearchTests: XCTestCase {
             await store.stopWatchingRoot(id: record.id)
         }
 
+        @MainActor
+        func testReadinessWaitMapsTimeoutCancellationAndIdleUnavailable() async throws {
+            let root = try makeTemporaryRoot(name: "SearchReadinessWait")
+            let fileURL = root.appendingPathComponent("OldWorkspace.swift")
+            try write("let oldWorkspaceNeedle = true\n", to: fileURL)
+            let store = WorkspaceFileContextStore()
+            let composition = makeComposition(store: store)
+            let manager = composition.workspaceManager
+            await manager.awaitInitialized()
+            let source = manager.createWorkspace(
+                name: "Search Readiness Source \(UUID().uuidString.prefix(8))",
+                repoPaths: [root.path],
+                ephemeral: true
+            )
+            let sourceSwitchResult = await manager.switchWorkspace(to: source, saveState: false)
+            XCTAssertTrue(sourceSwitchResult.didSwitch)
+
+            let readinessGate = AsyncGate()
+            manager.setWorkspaceSwitchReadinessDidInvalidateHandlerForTesting {
+                await readinessGate.markStartedAndWaitForRelease()
+            }
+            let target = manager.createWorkspace(
+                name: "Search Readiness Target \(UUID().uuidString.prefix(8))",
+                repoPaths: [],
+                ephemeral: true
+            )
+            let switchTask = Task { @MainActor in
+                await manager.switchWorkspace(to: target, saveState: false, reason: "searchReadinessErrors")
+            }
+            addTeardownBlock {
+                switchTask.cancel()
+                await MainActor.run {
+                    manager.setWorkspaceSwitchReadinessDidInvalidateHandlerForTesting(nil)
+                }
+                await readinessGate.release()
+                _ = await switchTask.value
+            }
+            let switchReachedReadinessGate = await readinessGate.waitUntilStartedWithinTimeout()
+            XCTAssertTrue(switchReachedReadinessGate)
+
+            do {
+                _ = try await StoreBackedWorkspaceSearch.$readinessWaitTimeoutOverrideForTesting.withValue(.milliseconds(20)) {
+                    try await StoreBackedWorkspaceSearch.search(
+                        pattern: "oldWorkspaceNeedle",
+                        mode: .content,
+                        paths: [fileURL.path],
+                        rootScope: .visibleWorkspace,
+                        store: store,
+                        workspaceManager: manager
+                    )
+                }
+                XCTFail("Expected workspace readiness timeout")
+            } catch let error as StoreBackedWorkspaceSearchError {
+                XCTAssertEqual(error, .workspaceReadinessTimedOut)
+                XCTAssertTrue(error.localizedDescription.contains("readiness timed out"))
+            }
+            XCTAssertEqual(manager.workspaceSearchReadinessWaiterCountForTesting, 0)
+
+            let cancelledSearch = Task { @MainActor in
+                try await StoreBackedWorkspaceSearch.$readinessWaitTimeoutOverrideForTesting.withValue(.seconds(2)) {
+                    try await StoreBackedWorkspaceSearch.search(
+                        pattern: "oldWorkspaceNeedle",
+                        mode: .content,
+                        paths: [fileURL.path],
+                        rootScope: .visibleWorkspace,
+                        store: store,
+                        workspaceManager: manager
+                    )
+                }
+            }
+            try await waitForReadinessWaiterCount(1, manager: manager)
+            cancelledSearch.cancel()
+            do {
+                _ = try await cancelledSearch.value
+                XCTFail("Expected readiness cancellation")
+            } catch is CancellationError {
+                // Expected: search must preserve manager cancellation rather than remapping it.
+            }
+            try await waitForReadinessWaiterCount(0, manager: manager)
+
+            await manager.cancelCurrentWorkspaceSwitchAndReturnToSystem()
+            XCTAssertEqual(manager.workspaceSearchReadinessState, .idle)
+            do {
+                _ = try await StoreBackedWorkspaceSearch.search(
+                    pattern: "oldWorkspaceNeedle",
+                    mode: .content,
+                    paths: [fileURL.path],
+                    rootScope: .visibleWorkspace,
+                    store: store,
+                    workspaceManager: manager
+                )
+                XCTFail("Expected idle readiness to be unavailable")
+            } catch let error as StoreBackedWorkspaceSearchError {
+                XCTAssertEqual(error, .workspaceReadinessUnavailable)
+            }
+
+            manager.setWorkspaceSwitchReadinessDidInvalidateHandlerForTesting(nil)
+            await readinessGate.release()
+            _ = await switchTask.value
+        }
+
+        @MainActor
+        func testQueuedBroadSearchRejectsSupersededReadinessTicketAfterAdmission() async throws {
+            let root = try makeTemporaryRoot(name: "QueuedReadinessSupersession")
+            try write("let queuedReadinessNeedle = true\n", to: root.appendingPathComponent("Old.swift"))
+            let store = WorkspaceFileContextStore()
+            let composition = makeComposition(store: store)
+            let manager = composition.workspaceManager
+            await manager.awaitInitialized()
+            let source = manager.createWorkspace(
+                name: "Queued Search Source \(UUID().uuidString.prefix(8))",
+                repoPaths: [root.path],
+                ephemeral: true
+            )
+            let sourceSwitchResult = await manager.switchWorkspace(to: source, saveState: false)
+            XCTAssertTrue(sourceSwitchResult.didSwitch)
+
+            await configureSingleLeaseSearchLane(store)
+            let admissionGate = AsyncGate()
+            await store.setSearchLanePermitAcquiredHandlerForTesting {
+                await admissionGate.markStartedAndWaitForRelease()
+            }
+            let held = Task { @MainActor in
+                try await StoreBackedWorkspaceSearch.search(
+                    pattern: "queuedReadinessNeedle",
+                    mode: .content,
+                    rootScope: .visibleWorkspace,
+                    store: store,
+                    workspaceManager: manager
+                )
+            }
+            addTeardownBlock {
+                held.cancel()
+                await admissionGate.release()
+                await store.setSearchLanePermitAcquiredHandlerForTesting(nil)
+                _ = try? await held.value
+            }
+            let heldSearchReachedAdmission = await admissionGate.waitUntilStartedWithinTimeout()
+            XCTAssertTrue(heldSearchReachedAdmission)
+            let queued = Task { @MainActor in
+                try await StoreBackedWorkspaceSearch.search(
+                    pattern: "queuedReadinessNeedle",
+                    mode: .content,
+                    rootScope: .visibleWorkspace,
+                    store: store,
+                    workspaceManager: manager
+                )
+            }
+            addTeardownBlock {
+                queued.cancel()
+                await admissionGate.release()
+                _ = try? await queued.value
+            }
+            await assertAsyncTrue(waitForAdmissionWaiterCount(1, store: store))
+
+            let readinessGate = AsyncGate()
+            manager.setWorkspaceSwitchReadinessDidInvalidateHandlerForTesting {
+                await readinessGate.markStartedAndWaitForRelease()
+            }
+            let target = manager.createWorkspace(
+                name: "Queued Search Target \(UUID().uuidString.prefix(8))",
+                repoPaths: [],
+                ephemeral: true
+            )
+            let switchTask = Task { @MainActor in
+                await manager.switchWorkspace(to: target, saveState: false, reason: "queuedSearchSupersession")
+            }
+            addTeardownBlock {
+                switchTask.cancel()
+                await MainActor.run {
+                    manager.setWorkspaceSwitchReadinessDidInvalidateHandlerForTesting(nil)
+                }
+                await admissionGate.release()
+                await readinessGate.release()
+                await store.setSearchLanePermitAcquiredHandlerForTesting(nil)
+                _ = await switchTask.value
+            }
+            let switchReachedReadinessGate = await readinessGate.waitUntilStartedWithinTimeout()
+            XCTAssertTrue(switchReachedReadinessGate)
+            await admissionGate.release()
+
+            for searchTask in [held, queued] {
+                do {
+                    _ = try await searchTask.value
+                    XCTFail("Expected the old readiness ticket to be rejected")
+                } catch let error as StoreBackedWorkspaceSearchError {
+                    XCTAssertEqual(error, .workspaceReadinessSuperseded)
+                }
+            }
+            let searchLaneBecameIdle = await waitForSearchLaneIdle(store: store)
+            XCTAssertTrue(searchLaneBecameIdle)
+
+            manager.setWorkspaceSwitchReadinessDidInvalidateHandlerForTesting(nil)
+            await readinessGate.release()
+            _ = await switchTask.value
+            await store.setSearchLanePermitAcquiredHandlerForTesting(nil)
+        }
+
+        @MainActor
+        func testSearchRejectsSupersededReadinessAfterAppliedIngressWait() async throws {
+            let root = try makeTemporaryRoot(name: "IngressReadinessSupersession")
+            let fileURL = root.appendingPathComponent("Old.swift")
+            try write("let ingressReadinessNeedle = true\n", to: fileURL)
+            let store = WorkspaceFileContextStore()
+            let composition = makeComposition(store: store)
+            let manager = composition.workspaceManager
+            await manager.awaitInitialized()
+            let source = manager.createWorkspace(
+                name: "Ingress Search Source \(UUID().uuidString.prefix(8))",
+                repoPaths: [root.path],
+                ephemeral: true
+            )
+            let sourceSwitchResult = await manager.switchWorkspace(to: source, saveState: false)
+            XCTAssertTrue(sourceSwitchResult.didSwitch)
+
+            let ingressGate = AsyncGate()
+            let searchTask = Task { @MainActor in
+                try await StoreBackedWorkspaceSearch.$freshnessWaitOperationOverrideForTesting.withValue({ _, _ in
+                    await ingressGate.markStartedAndWaitForRelease()
+                    return []
+                }) {
+                    try await StoreBackedWorkspaceSearch.search(
+                        pattern: "ingressReadinessNeedle",
+                        mode: .content,
+                        paths: [fileURL.path],
+                        rootScope: .visibleWorkspace,
+                        store: store,
+                        workspaceManager: manager
+                    )
+                }
+            }
+            addTeardownBlock {
+                searchTask.cancel()
+                await ingressGate.release()
+                _ = try? await searchTask.value
+            }
+            let searchReachedIngressGate = await ingressGate.waitUntilStartedWithinTimeout()
+            XCTAssertTrue(searchReachedIngressGate)
+
+            let readinessGate = AsyncGate()
+            manager.setWorkspaceSwitchReadinessDidInvalidateHandlerForTesting {
+                await readinessGate.markStartedAndWaitForRelease()
+            }
+            let target = manager.createWorkspace(
+                name: "Ingress Search Target \(UUID().uuidString.prefix(8))",
+                repoPaths: [],
+                ephemeral: true
+            )
+            let switchTask = Task { @MainActor in
+                await manager.switchWorkspace(to: target, saveState: false, reason: "ingressSearchSupersession")
+            }
+            addTeardownBlock {
+                switchTask.cancel()
+                await MainActor.run {
+                    manager.setWorkspaceSwitchReadinessDidInvalidateHandlerForTesting(nil)
+                }
+                await ingressGate.release()
+                await readinessGate.release()
+                _ = await switchTask.value
+            }
+            let switchReachedReadinessGate = await readinessGate.waitUntilStartedWithinTimeout()
+            XCTAssertTrue(switchReachedReadinessGate)
+            let rootsBeforeUnload = await store.roots()
+            XCTAssertTrue(rootsBeforeUnload.contains { $0.standardizedFullPath == root.path })
+            await ingressGate.release()
+
+            do {
+                _ = try await searchTask.value
+                XCTFail("Expected post-ingress readiness validation to reject old-root results")
+            } catch let error as StoreBackedWorkspaceSearchError {
+                XCTAssertEqual(error, .workspaceReadinessSuperseded)
+            }
+
+            manager.setWorkspaceSwitchReadinessDidInvalidateHandlerForTesting(nil)
+            await readinessGate.release()
+            _ = await switchTask.value
+        }
+
         func testMissingSessionWorktreeScopeThrowsTypedUnavailableErrorBeforeAdmission() async throws {
             let logicalRoot = try makeTemporaryRoot(name: "UnavailableWorktreeLogical")
             try write("let baseNeedle = true\n", to: logicalRoot.appendingPathComponent("A.swift"))
@@ -1876,16 +2154,41 @@ final class StoreBackedWorkspaceSearchTests: XCTestCase {
         )
         try assertOrdered([
             "try await ensureRootScopeAvailable(rootScope, store: store)",
-            "try await ensureSearchReady(store: store, workspaceManager: workspaceManager)",
+            "let readinessTicket = try await acquireSearchReadiness(",
+            "readinessTicket: readinessTicket,",
+            "try await validateSearchReadiness(readinessTicket, workspaceManager: workspaceManager)",
             "let effectiveMode = mode == .auto ? FileSearchActor.inferredAutoMode(pattern) : mode",
             "return try await store.withStoreBackedSearchAccess(",
-            "try await ensureRootScopeAvailable(rootScope, store: store)",
-            "try await ensureSearchReady(store: store, workspaceManager: workspaceManager)",
-            "try Task.checkCancellation()",
+            "if admissionClass != nil {",
+            "try await ensureRootScopeAvailable(",
+            "readinessTicket: readinessTicket,",
+            "try await validateSearchReadiness(readinessTicket, workspaceManager: workspaceManager)",
+            "var parsedSearchScope:",
+            "try await validateSearchReadiness(readinessTicket, workspaceManager: workspaceManager)",
+            "let freshnessRootRefs:",
+            "try await validateSearchReadiness(readinessTicket, workspaceManager: workspaceManager)",
+            "appliedIngressSamples = try await awaitAppliedIngress(",
+            "try await validateSearchReadiness(readinessTicket, workspaceManager: workspaceManager)",
             "let contentFreshnessPolicy = await store.contentSearchFreshnessPolicy(",
-            "try Task.checkCancellation()",
-            "try await performSearch("
+            "try await validateSearchReadiness(readinessTicket, workspaceManager: workspaceManager)",
+            "parsedSearchScope = await refreshExactSearchScopeClauses(",
+            "try await validateSearchReadiness(readinessTicket, workspaceManager: workspaceManager)",
+            "return try await performSearch("
         ], in: source)
+        let performSearchStart = try XCTUnwrap(source.range(of: "private static func performSearch("))
+        try assertOrdered([
+            "try await validateSearchReadiness(readinessTicket, workspaceManager: workspaceManager)",
+            "let catalogAccess = await store.searchCatalogAccess(rootScope: rootScope)",
+            "try await validateSearchReadiness(readinessTicket, workspaceManager: workspaceManager)",
+            "let visibleRootRefs = await store.rootRefs(scope: .visibleWorkspace)",
+            "try await validateSearchReadiness(readinessTicket, workspaceManager: workspaceManager)",
+            "let filterResult = await withTaskCancellationHandler",
+            "try await validateSearchReadiness(readinessTicket, workspaceManager: workspaceManager)",
+            "results = try await EditFlowPerf.measure(",
+            "try await fileSearchActor.searchUnified(",
+            "try await validateSearchReadiness(readinessTicket, workspaceManager: workspaceManager)",
+            "results.scopedFileCount = filesToSearch.count"
+        ], in: String(source[performSearchStart.lowerBound...]))
     }
 
     func testSearchScopeParserKeepsRequiredResolutionOrder() throws {
@@ -1962,6 +2265,47 @@ final class StoreBackedWorkspaceSearchTests: XCTestCase {
     }
 
     #if DEBUG
+        @MainActor
+        private func makeComposition(
+            store: WorkspaceFileContextStore
+        ) -> WindowStateComposition {
+            let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
+            GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
+            defer {
+                GlobalSettingsStore.shared.setMCPAutoStart(previousAutoStart, commit: false)
+            }
+            return WindowStateCompositionFactory.make(
+                windowID: -700 - Int.random(in: 1 ... 99),
+                deferredInitialAgentSystemWorkspaceRefresh: true,
+                sharedMCPService: MCPService(),
+                workspaceFileContextStore: store
+            )
+        }
+
+        @MainActor
+        private func waitForReadinessWaiterCount(
+            _ expectedCount: Int,
+            manager: WorkspaceManagerViewModel,
+            timeoutNanoseconds: UInt64 = 1_000_000_000,
+            file: StaticString = #filePath,
+            line: UInt = #line
+        ) async throws {
+            let interval: UInt64 = 10_000_000
+            var waited: UInt64 = 0
+            while manager.workspaceSearchReadinessWaiterCountForTesting != expectedCount,
+                  waited < timeoutNanoseconds
+            {
+                try await Task.sleep(nanoseconds: interval)
+                waited += interval
+            }
+            XCTAssertEqual(
+                manager.workspaceSearchReadinessWaiterCountForTesting,
+                expectedCount,
+                file: file,
+                line: line
+            )
+        }
+
         private func assertAsyncTrue(
             _ value: Bool,
             _ message: @autoclosure () -> String = "",

--- a/Tests/RepoPromptTests/WorkspaceContext/WorkspaceFileContextStoreTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/WorkspaceFileContextStoreTests.swift
@@ -1242,12 +1242,46 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
             let ownerA = UUID()
             let ownerB = UUID()
             let fingerprint = "shared-binding"
+            let startGate = AsyncGate()
+            let joinGate = AsyncGate()
+            await store.setRootLoadWillStartHandler { _ in
+                await startGate.markStartedAndWaitForRelease()
+            }
+            await store.setRootLoadDidJoinInFlightHandler { _ in
+                await joinGate.markStartedAndWaitForRelease()
+            }
+            addTeardownBlock {
+                await startGate.release()
+                await joinGate.release()
+                await store.setRootLoadWillStartHandler(nil)
+                await store.setRootLoadDidJoinInFlightHandler(nil)
+            }
 
-            let first = try await store.prepareSessionWorktreeOwnership(
-                ownerID: ownerA,
-                bindingFingerprint: fingerprint,
-                physicalRootPaths: [root.path]
-            )
+            let firstPreparationTask = Task {
+                try await store.prepareSessionWorktreeOwnership(
+                    ownerID: ownerA,
+                    bindingFingerprint: fingerprint,
+                    physicalRootPaths: [root.path]
+                )
+            }
+            await startGate.waitUntilStarted()
+            let secondPreparationTask = Task {
+                try await store.prepareSessionWorktreeOwnership(
+                    ownerID: ownerB,
+                    bindingFingerprint: fingerprint,
+                    physicalRootPaths: [root.path]
+                )
+            }
+            await joinGate.waitUntilStarted()
+
+            let joinedOwnership = await store.sessionWorktreeOwnershipDebugSnapshotForTesting()
+            XCTAssertEqual(joinedOwnership.installedOwnerCount, 0)
+            XCTAssertEqual(joinedOwnership.provisionalOwnerCount, 2)
+            XCTAssertEqual(joinedOwnership.rootClaimCount, 0)
+            XCTAssertEqual(joinedOwnership.pathReservationCount, 2)
+
+            await startGate.release()
+            let first = try await firstPreparationTask.value
             let firstRoots = try await store.commitSessionWorktreeOwnership(first)
             let rootID = try XCTUnwrap(firstRoots.first?.rootID)
             let firstWatcherActive = try await store.rootWatcherIsActiveForTesting(rootID: rootID)
@@ -1262,28 +1296,37 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
             let repeatedRoots = try await store.commitSessionWorktreeOwnership(repeated)
             XCTAssertEqual(repeatedRoots, firstRoots)
 
-            let second = try await store.prepareSessionWorktreeOwnership(
-                ownerID: ownerB,
-                bindingFingerprint: fingerprint,
-                physicalRootPaths: [root.path]
-            )
-            let secondRoots = try await store.commitSessionWorktreeOwnership(second)
-            XCTAssertEqual(secondRoots.map(\.rootID), [rootID])
-
-            let sharedDiagnostics = await store.readSearchRootDiagnosticsSnapshot()
-            let sharedRoot = try XCTUnwrap(sharedDiagnostics.first { $0.rootID == rootID })
-            XCTAssertEqual(sharedRoot.crawlCount, 1)
-            XCTAssertTrue(sharedRoot.watcherActive)
-            XCTAssertFalse(sharedRoot.explicitWatcherDemand)
-            XCTAssertEqual(sharedRoot.sessionWorktreeOwnerCount, 2)
-
             await store.releaseSessionWorktreeOwnership(ownerID: ownerA)
             let rootsAfterFirstRelease = await store.roots()
             XCTAssertTrue(rootsAfterFirstRelease.contains { $0.id == rootID })
             let watcherAfterFirstRelease = try await store.rootWatcherIsActiveForTesting(rootID: rootID)
             XCTAssertTrue(watcherAfterFirstRelease)
-            let oneOwnerDiagnostics = await store.readSearchRootDiagnosticsSnapshot()
-            XCTAssertEqual(oneOwnerDiagnostics.first { $0.rootID == rootID }?.sessionWorktreeOwnerCount, 1)
+            let reservedRootDiagnostics = await store.readSearchRootDiagnosticsSnapshot()
+            let reservedRoot = try XCTUnwrap(reservedRootDiagnostics.first { $0.rootID == rootID })
+            XCTAssertEqual(reservedRoot.crawlCount, 1)
+            XCTAssertTrue(reservedRoot.watcherActive)
+            XCTAssertFalse(reservedRoot.explicitWatcherDemand)
+            XCTAssertEqual(reservedRoot.sessionWorktreeOwnerCount, 0)
+            let ownershipWhileSecondJoinerIsHeld = await store.sessionWorktreeOwnershipDebugSnapshotForTesting()
+            XCTAssertEqual(ownershipWhileSecondJoinerIsHeld.installedOwnerCount, 0)
+            XCTAssertEqual(ownershipWhileSecondJoinerIsHeld.provisionalOwnerCount, 1)
+            XCTAssertEqual(ownershipWhileSecondJoinerIsHeld.rootClaimCount, 0)
+            XCTAssertEqual(ownershipWhileSecondJoinerIsHeld.pathReservationCount, 1)
+
+            await joinGate.release()
+            let second = try await secondPreparationTask.value
+            let secondRoots = try await store.commitSessionWorktreeOwnership(second)
+            XCTAssertEqual(secondRoots.map(\.rootID), [rootID])
+
+            let sharedOwnership = await store.sessionWorktreeOwnershipDebugSnapshotForTesting()
+            XCTAssertEqual(sharedOwnership.installedOwnerCount, 1)
+            XCTAssertEqual(sharedOwnership.provisionalOwnerCount, 0)
+            XCTAssertEqual(sharedOwnership.rootClaimCount, 1)
+            XCTAssertEqual(sharedOwnership.pathReservationCount, 0)
+            let startCount = await startGate.startCount()
+            let joinCount = await joinGate.startCount()
+            XCTAssertEqual(startCount, 1)
+            XCTAssertEqual(joinCount, 1)
 
             await store.releaseSessionWorktreeOwnership(ownerID: ownerB)
             let rootsAfterLastRelease = await store.roots()
@@ -1292,6 +1335,92 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
             XCTAssertEqual(finalOwnership.installedOwnerCount, 0)
             XCTAssertEqual(finalOwnership.provisionalOwnerCount, 0)
             XCTAssertEqual(finalOwnership.rootClaimCount, 0)
+            XCTAssertEqual(finalOwnership.pathReservationCount, 0)
+
+            let explicitUnloadRoot = try makeTemporaryRoot(name: "SessionWorktreeOwnershipExplicitUnload")
+            try write("seed", to: explicitUnloadRoot.appendingPathComponent("Seed.swift"))
+            let explicitUnloadStore = WorkspaceFileContextStore()
+            let loadedOwnerID = UUID()
+            let suspendedOwnerID = UUID()
+            let unloadStartGate = AsyncGate()
+            let unloadJoinGate = AsyncGate()
+            let unloadStartObserved = expectation(description: "explicit-unload creator starts root load")
+            let unloadJoinObserved = expectation(description: "explicit-unload owner joins root load")
+            await explicitUnloadStore.setRootLoadWillStartHandler { _ in
+                unloadStartObserved.fulfill()
+                await unloadStartGate.markStartedAndWaitForRelease()
+            }
+            await explicitUnloadStore.setRootLoadDidJoinInFlightHandler { _ in
+                unloadJoinObserved.fulfill()
+                await unloadJoinGate.markStartedAndWaitForRelease()
+            }
+            addTeardownBlock {
+                await unloadStartGate.release()
+                await unloadJoinGate.release()
+                await explicitUnloadStore.setRootLoadWillStartHandler(nil)
+                await explicitUnloadStore.setRootLoadDidJoinInFlightHandler(nil)
+            }
+
+            let loadedOwnerPreparationTask = Task {
+                try await explicitUnloadStore.prepareSessionWorktreeOwnership(
+                    ownerID: loadedOwnerID,
+                    bindingFingerprint: "loaded-owner",
+                    physicalRootPaths: [explicitUnloadRoot.path]
+                )
+            }
+            await fulfillment(of: [unloadStartObserved], timeout: 1)
+            let unloadStartCount = await unloadStartGate.startCount()
+            XCTAssertEqual(unloadStartCount, 1)
+
+            let suspendedOwnerPreparationTask = Task {
+                try await explicitUnloadStore.prepareSessionWorktreeOwnership(
+                    ownerID: suspendedOwnerID,
+                    bindingFingerprint: "suspended-owner",
+                    physicalRootPaths: [explicitUnloadRoot.path]
+                )
+            }
+            await fulfillment(of: [unloadJoinObserved], timeout: 1)
+            let unloadJoinCount = await unloadJoinGate.startCount()
+            XCTAssertEqual(unloadJoinCount, 1)
+
+            await unloadStartGate.release()
+            let loadedOwnerPreparation = try await loadedOwnerPreparationTask.value
+            let loadedOwnerRoots = try await explicitUnloadStore.commitSessionWorktreeOwnership(
+                loadedOwnerPreparation
+            )
+            let explicitlyUnloadedRootID = try XCTUnwrap(loadedOwnerRoots.first?.rootID)
+            if unloadJoinCount == 1 {
+                let ownershipBeforeExplicitUnload =
+                    await explicitUnloadStore.sessionWorktreeOwnershipDebugSnapshotForTesting()
+                XCTAssertEqual(ownershipBeforeExplicitUnload.installedOwnerCount, 1)
+                XCTAssertEqual(ownershipBeforeExplicitUnload.provisionalOwnerCount, 1)
+                XCTAssertEqual(ownershipBeforeExplicitUnload.rootClaimCount, 1)
+                XCTAssertEqual(ownershipBeforeExplicitUnload.pathReservationCount, 1)
+            }
+
+            await explicitUnloadStore.unloadRoot(id: explicitlyUnloadedRootID)
+            let ownershipAfterExplicitUnload =
+                await explicitUnloadStore.sessionWorktreeOwnershipDebugSnapshotForTesting()
+            XCTAssertEqual(ownershipAfterExplicitUnload.installedOwnerCount, 0)
+            XCTAssertEqual(ownershipAfterExplicitUnload.provisionalOwnerCount, 0)
+            XCTAssertEqual(ownershipAfterExplicitUnload.rootClaimCount, 0)
+            XCTAssertEqual(ownershipAfterExplicitUnload.pathReservationCount, 0)
+            let rootsAfterExplicitUnload = await explicitUnloadStore.roots()
+            XCTAssertTrue(rootsAfterExplicitUnload.isEmpty)
+
+            await unloadJoinGate.release()
+            do {
+                _ = try await suspendedOwnerPreparationTask.value
+                XCTFail("Expected explicit unload to invalidate the suspended owner generation")
+            } catch let error as WorkspaceSessionWorktreeOwnershipError {
+                XCTAssertEqual(error, .staleUpdate)
+            }
+            let ownershipAfterSuspendedOwnerResumes =
+                await explicitUnloadStore.sessionWorktreeOwnershipDebugSnapshotForTesting()
+            XCTAssertEqual(ownershipAfterSuspendedOwnerResumes.installedOwnerCount, 0)
+            XCTAssertEqual(ownershipAfterSuspendedOwnerResumes.provisionalOwnerCount, 0)
+            XCTAssertEqual(ownershipAfterSuspendedOwnerResumes.rootClaimCount, 0)
+            XCTAssertEqual(ownershipAfterSuspendedOwnerResumes.pathReservationCount, 0)
         }
 
         func testSessionWorktreeOwnershipReleaseDuringRootLoadUnloadsLateRoot() async throws {
@@ -1315,6 +1444,10 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
                 )
             }
             await loadGate.waitUntilStarted()
+            let ownershipDuringLoad = await store.sessionWorktreeOwnershipDebugSnapshotForTesting()
+            XCTAssertEqual(ownershipDuringLoad.provisionalOwnerCount, 1)
+            XCTAssertEqual(ownershipDuringLoad.rootClaimCount, 0)
+            XCTAssertEqual(ownershipDuringLoad.pathReservationCount, 1)
             await store.releaseSessionWorktreeOwnership(ownerID: ownerID)
             await loadGate.release()
 
@@ -1332,6 +1465,129 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
             XCTAssertEqual(ownership.installedOwnerCount, 0)
             XCTAssertEqual(ownership.provisionalOwnerCount, 0)
             XCTAssertEqual(ownership.rootClaimCount, 0)
+            XCTAssertEqual(ownership.pathReservationCount, 0)
+
+            let cancellationRoot = try makeTemporaryRoot(name: "SessionWorktreeOwnershipCancelledCreator")
+            try write("seed", to: cancellationRoot.appendingPathComponent("Seed.swift"))
+            let cancellationStore = WorkspaceFileContextStore()
+            let cancelledCreatorOwnerID = UUID()
+            let joiningOwnerID = UUID()
+            let startGate = AsyncGate()
+            let joinGate = AsyncGate()
+            let startObserved = expectation(description: "creator starts canonical ownership root load")
+            let joinObserved = expectation(description: "later owner joins creator's canonical root load")
+            await cancellationStore.setRootLoadWillStartHandler { _ in
+                startObserved.fulfill()
+                await startGate.markStartedAndWaitForRelease()
+            }
+            await cancellationStore.setRootLoadDidJoinInFlightHandler { _ in
+                joinObserved.fulfill()
+                await joinGate.markStartedAndWaitForRelease()
+            }
+            addTeardownBlock {
+                await startGate.release()
+                await joinGate.release()
+                await cancellationStore.setRootLoadWillStartHandler(nil)
+                await cancellationStore.setRootLoadDidJoinInFlightHandler(nil)
+            }
+
+            let cancelledCreatorPreparationTask = Task {
+                try await cancellationStore.prepareSessionWorktreeOwnership(
+                    ownerID: cancelledCreatorOwnerID,
+                    bindingFingerprint: "cancelled-creator",
+                    physicalRootPaths: [cancellationRoot.path]
+                )
+            }
+            await fulfillment(of: [startObserved], timeout: 1)
+            let ownershipBeforeCancellation =
+                await cancellationStore.sessionWorktreeOwnershipDebugSnapshotForTesting()
+            XCTAssertEqual(ownershipBeforeCancellation.provisionalOwnerCount, 1)
+            XCTAssertEqual(ownershipBeforeCancellation.rootClaimCount, 0)
+            XCTAssertEqual(ownershipBeforeCancellation.pathReservationCount, 1)
+
+            let cancellationCompleted = expectation(
+                description: "creator ownership cancellation completes while its shared load remains blocked"
+            )
+            let cancellationCompletion = AsyncSignal()
+            let cancellationResultTask = Task {
+                let observedCancellation: Bool
+                do {
+                    _ = try await cancelledCreatorPreparationTask.value
+                    observedCancellation = false
+                } catch is CancellationError {
+                    observedCancellation = true
+                } catch {
+                    observedCancellation = false
+                }
+                await cancellationCompletion.mark()
+                cancellationCompleted.fulfill()
+                return observedCancellation
+            }
+            cancelledCreatorPreparationTask.cancel()
+            await fulfillment(of: [cancellationCompleted], timeout: 1)
+            let cancellationCompletedPromptly = await cancellationCompletion.isMarked()
+            if cancellationCompletedPromptly {
+                let ownershipAfterCancellation =
+                    await cancellationStore.sessionWorktreeOwnershipDebugSnapshotForTesting()
+                XCTAssertEqual(ownershipAfterCancellation.provisionalOwnerCount, 0)
+                XCTAssertEqual(ownershipAfterCancellation.rootClaimCount, 0)
+                XCTAssertEqual(ownershipAfterCancellation.pathReservationCount, 0)
+            }
+
+            let joiningPreparationTask = Task {
+                try await cancellationStore.prepareSessionWorktreeOwnership(
+                    ownerID: joiningOwnerID,
+                    bindingFingerprint: "joining-owner",
+                    physicalRootPaths: [cancellationRoot.path]
+                )
+            }
+            await fulfillment(of: [joinObserved], timeout: 1)
+            let joinCount = await joinGate.startCount()
+            XCTAssertEqual(joinCount, 1, "The cancelled creator's shared flight must remain joinable")
+            if joinCount == 1 {
+                let joinedOwnership =
+                    await cancellationStore.sessionWorktreeOwnershipDebugSnapshotForTesting()
+                XCTAssertEqual(joinedOwnership.provisionalOwnerCount, 1)
+                XCTAssertEqual(joinedOwnership.rootClaimCount, 0)
+                XCTAssertEqual(joinedOwnership.pathReservationCount, 1)
+            }
+
+            await startGate.release()
+            let observedCancellation = await cancellationResultTask.value
+            XCTAssertTrue(observedCancellation, "Expected the creator ownership preparation to throw CancellationError")
+            let rootLoadedForJoiner = await waitForAsyncCondition {
+                let roots = await cancellationStore.roots()
+                return !roots.isEmpty
+            }
+            XCTAssertTrue(rootLoadedForJoiner)
+            if joinCount == 1 {
+                let heldJoinOwnership =
+                    await cancellationStore.sessionWorktreeOwnershipDebugSnapshotForTesting()
+                XCTAssertEqual(heldJoinOwnership.provisionalOwnerCount, 1)
+                XCTAssertEqual(heldJoinOwnership.rootClaimCount, 0)
+                XCTAssertEqual(heldJoinOwnership.pathReservationCount, 1)
+            }
+
+            await joinGate.release()
+            let joiningPreparation = try await joiningPreparationTask.value
+            let joiningRoots = try await cancellationStore.commitSessionWorktreeOwnership(joiningPreparation)
+            let joiningRootID = try XCTUnwrap(joiningRoots.first?.rootID)
+            let diagnostics = await cancellationStore.readSearchRootDiagnosticsSnapshot()
+            XCTAssertEqual(diagnostics.first { $0.rootID == joiningRootID }?.crawlCount, 1)
+            let installedOwnership = await cancellationStore.sessionWorktreeOwnershipDebugSnapshotForTesting()
+            XCTAssertEqual(installedOwnership.installedOwnerCount, 1)
+            XCTAssertEqual(installedOwnership.provisionalOwnerCount, 0)
+            XCTAssertEqual(installedOwnership.rootClaimCount, 1)
+            XCTAssertEqual(installedOwnership.pathReservationCount, 0)
+
+            await cancellationStore.releaseSessionWorktreeOwnership(ownerID: joiningOwnerID)
+            let rootsAfterJoinerRelease = await cancellationStore.roots()
+            XCTAssertTrue(rootsAfterJoinerRelease.isEmpty)
+            let finalCancellationOwnership = await cancellationStore.sessionWorktreeOwnershipDebugSnapshotForTesting()
+            XCTAssertEqual(finalCancellationOwnership.installedOwnerCount, 0)
+            XCTAssertEqual(finalCancellationOwnership.provisionalOwnerCount, 0)
+            XCTAssertEqual(finalCancellationOwnership.rootClaimCount, 0)
+            XCTAssertEqual(finalCancellationOwnership.pathReservationCount, 0)
         }
 
         func testStartWatchingMissingRootThrowsWithoutRetainingDemand() async throws {
@@ -1352,29 +1608,141 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
         }
 
         func testSessionWorktreeOwnershipActivationFailureRollsBackClaimsAndRoot() async throws {
-            let root = try makeTemporaryRoot(name: "SessionWorktreeOwnershipActivationFailure")
-            try write("seed", to: root.appendingPathComponent("Seed.swift"))
+            let parent = try makeTemporaryRoot(name: "SessionWorktreeOwnershipActivationFailure")
+            let claimedRoot = parent.appendingPathComponent("A-Claimed", isDirectory: true)
+            let failingRoot = parent.appendingPathComponent("B-Fails", isDirectory: true)
+            let unreachedRoot = parent.appendingPathComponent("C-Unreached", isDirectory: true)
+            try write("claimed", to: claimedRoot.appendingPathComponent("Claimed.swift"))
+            try write("failing", to: failingRoot.appendingPathComponent("Failing.swift"))
+            try write("unreached", to: unreachedRoot.appendingPathComponent("Unreached.swift"))
             let store = WorkspaceFileContextStore()
+            let preloadedRoot = try await store.loadRoot(path: claimedRoot.path, kind: .sessionWorktree)
             await store.setWatcherActivationFailureForNewServicesForTesting(.streamStart)
+            addTeardownBlock {
+                await store.setWatcherActivationFailureForNewServicesForTesting(nil)
+            }
 
             do {
                 _ = try await store.prepareSessionWorktreeOwnership(
                     ownerID: UUID(),
                     bindingFingerprint: "activation-failure",
-                    physicalRootPaths: [root.path]
+                    physicalRootPaths: [unreachedRoot.path, failingRoot.path, claimedRoot.path]
                 )
                 XCTFail("Expected session-worktree watcher activation to fail")
             } catch let error as FileSystemWatcherActivationError {
-                XCTAssertEqual(error, .streamStartFailed(path: root.path))
+                XCTAssertEqual(error, .streamStartFailed(path: failingRoot.path))
             }
 
             let rootsAfterFailure = await store.roots()
             XCTAssertTrue(rootsAfterFailure.isEmpty)
+            XCTAssertFalse(rootsAfterFailure.contains { $0.id == preloadedRoot.id })
             let ownership = await store.sessionWorktreeOwnershipDebugSnapshotForTesting()
             XCTAssertEqual(ownership.installedOwnerCount, 0)
             XCTAssertEqual(ownership.provisionalOwnerCount, 0)
             XCTAssertEqual(ownership.rootClaimCount, 0)
+            XCTAssertEqual(ownership.pathReservationCount, 0)
             await store.setWatcherActivationFailureForNewServicesForTesting(nil)
+
+            let untouchedParent = try makeTemporaryRoot(name: "SessionWorktreeUntouchedReservation")
+            let blockedFirstRoot = untouchedParent.appendingPathComponent("A-Blocked", isDirectory: true)
+            let alreadyLoadedSecondRoot = untouchedParent.appendingPathComponent("B-AlreadyLoaded", isDirectory: true)
+            try write("blocked", to: blockedFirstRoot.appendingPathComponent("Blocked.swift"))
+            try write("existing", to: alreadyLoadedSecondRoot.appendingPathComponent("Existing.swift"))
+            let untouchedStore = WorkspaceFileContextStore()
+            let alreadyLoadedRecord = try await untouchedStore.loadRoot(
+                path: alreadyLoadedSecondRoot.path,
+                kind: .sessionWorktree
+            )
+            let blockedLoadGate = AsyncGate()
+            let blockedCleanupGate = AsyncGate()
+            let blockedLoadObserved = expectation(description: "multi-path preparation reaches blocked first path")
+            let blockedCleanupObserved = expectation(description: "cancelled first-path flight unloads exact produced root")
+            await untouchedStore.setRootLoadWillStartHandler { path in
+                guard path == blockedFirstRoot.path else { return }
+                blockedLoadObserved.fulfill()
+                await blockedLoadGate.markStartedAndWaitForRelease()
+            }
+            await untouchedStore.setRootUnloadDidDetachHandler { paths in
+                guard paths.contains(blockedFirstRoot.path) else { return }
+                blockedCleanupObserved.fulfill()
+                await blockedCleanupGate.markStartedAndWaitForRelease()
+            }
+            addTeardownBlock {
+                await blockedLoadGate.release()
+                await blockedCleanupGate.release()
+                await untouchedStore.setRootLoadWillStartHandler(nil)
+                await untouchedStore.setRootUnloadDidDetachHandler(nil)
+            }
+
+            let untouchedOwnerID = UUID()
+            let untouchedPreparationTask = Task {
+                try await untouchedStore.prepareSessionWorktreeOwnership(
+                    ownerID: untouchedOwnerID,
+                    bindingFingerprint: "untouched-second-root",
+                    physicalRootPaths: [alreadyLoadedSecondRoot.path, blockedFirstRoot.path]
+                )
+            }
+            await fulfillment(of: [blockedLoadObserved], timeout: 1)
+            let ownershipBeforeUntouchedCancellation =
+                await untouchedStore.sessionWorktreeOwnershipDebugSnapshotForTesting()
+            XCTAssertEqual(ownershipBeforeUntouchedCancellation.provisionalOwnerCount, 1)
+            XCTAssertEqual(ownershipBeforeUntouchedCancellation.rootClaimCount, 0)
+            XCTAssertEqual(ownershipBeforeUntouchedCancellation.pathReservationCount, 2)
+
+            let untouchedCancellationCompleted = expectation(
+                description: "multi-path preparation cancellation completes while first flight is blocked"
+            )
+            let untouchedCancellationSignal = AsyncSignal()
+            let untouchedCancellationResultTask = Task {
+                let observedCancellation: Bool
+                do {
+                    _ = try await untouchedPreparationTask.value
+                    observedCancellation = false
+                } catch is CancellationError {
+                    observedCancellation = true
+                } catch {
+                    observedCancellation = false
+                }
+                await untouchedCancellationSignal.mark()
+                untouchedCancellationCompleted.fulfill()
+                return observedCancellation
+            }
+            untouchedPreparationTask.cancel()
+            await fulfillment(of: [untouchedCancellationCompleted], timeout: 1)
+            let untouchedCancellationCompletedPromptly = await untouchedCancellationSignal.isMarked()
+            if untouchedCancellationCompletedPromptly {
+                let rootsWhileFirstFlightIsBlocked = await untouchedStore.roots()
+                XCTAssertEqual(rootsWhileFirstFlightIsBlocked.map(\.id), [alreadyLoadedRecord.id])
+                let ownershipAfterUntouchedCancellation =
+                    await untouchedStore.sessionWorktreeOwnershipDebugSnapshotForTesting()
+                XCTAssertEqual(ownershipAfterUntouchedCancellation.installedOwnerCount, 0)
+                XCTAssertEqual(ownershipAfterUntouchedCancellation.provisionalOwnerCount, 0)
+                XCTAssertEqual(ownershipAfterUntouchedCancellation.rootClaimCount, 0)
+                XCTAssertEqual(ownershipAfterUntouchedCancellation.pathReservationCount, 0)
+            }
+
+            await blockedLoadGate.release()
+            let observedUntouchedCancellation = await untouchedCancellationResultTask.value
+            XCTAssertTrue(
+                observedUntouchedCancellation,
+                "Expected cancellation before the untouched second path reached loadRoot"
+            )
+            await fulfillment(of: [blockedCleanupObserved], timeout: 1)
+            let blockedCleanupCount = await blockedCleanupGate.startCount()
+            XCTAssertEqual(blockedCleanupCount, 1)
+            let rootsDuringExactFlightCleanup = await untouchedStore.roots()
+            XCTAssertEqual(rootsDuringExactFlightCleanup.map(\.id), [alreadyLoadedRecord.id])
+            await blockedCleanupGate.release()
+
+            let finalUntouchedRoots = await untouchedStore.roots()
+            XCTAssertEqual(finalUntouchedRoots.map(\.id), [alreadyLoadedRecord.id])
+            let finalUntouchedOwnership =
+                await untouchedStore.sessionWorktreeOwnershipDebugSnapshotForTesting()
+            XCTAssertEqual(finalUntouchedOwnership.installedOwnerCount, 0)
+            XCTAssertEqual(finalUntouchedOwnership.provisionalOwnerCount, 0)
+            XCTAssertEqual(finalUntouchedOwnership.rootClaimCount, 0)
+            XCTAssertEqual(finalUntouchedOwnership.pathReservationCount, 0)
+            await untouchedStore.unloadRoot(id: alreadyLoadedRecord.id)
         }
 
         func testWatcherActivationFailureThrowsAndRollsBackStoreLifecycle() async throws {
@@ -1404,6 +1772,135 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
             let watcherIsActiveAfterRetry = try await store.rootWatcherIsActiveForTesting(rootID: record.id)
             XCTAssertTrue(watcherIsActiveAfterRetry)
             await store.stopWatchingRoot(id: record.id)
+        }
+
+        func testConcurrentWatcherColdStartsJoinExactRootLifetimeFlight() async throws {
+            let root = try makeTemporaryRoot(name: "ConcurrentWatcherColdStart")
+            let lateFileURL = root.appendingPathComponent("Late.swift")
+            let store = WorkspaceFileContextStore()
+            let record = try await store.loadRoot(path: root.path)
+            let rootID = record.id
+            let lifetimeID = try await store.rootLifetimeIDForTesting(rootID: rootID)
+            let publisherOpenGate = AsyncGate()
+            let joinObserved = expectation(description: "second watcher start joins the exact-lifetime flight")
+
+            await store.setWatcherPublisherIngressDidOpenHandler { observedRootID, observedLifetimeID in
+                guard observedRootID == rootID else { return }
+                XCTAssertEqual(observedLifetimeID, lifetimeID)
+                await publisherOpenGate.markStartedAndWaitForRelease()
+            }
+            await store.setWatcherInfrastructureDidJoinFlightHandler { observedRootID, observedLifetimeID in
+                guard observedRootID == rootID else { return }
+                XCTAssertEqual(observedLifetimeID, lifetimeID)
+                joinObserved.fulfill()
+            }
+            addTeardownBlock {
+                await publisherOpenGate.release()
+                await store.setWatcherPublisherIngressDidOpenHandler(nil)
+                await store.setWatcherInfrastructureDidJoinFlightHandler(nil)
+                await store.stopWatchingRoot(id: rootID)
+            }
+
+            let firstStart = Task {
+                try await store.startWatchingRoot(id: rootID)
+            }
+            await publisherOpenGate.waitUntilStarted()
+            let secondStart = Task {
+                try await store.startWatchingRoot(id: rootID)
+            }
+            await fulfillment(of: [joinObserved], timeout: 1)
+
+            let publisherOpenCount = await publisherOpenGate.startCount()
+            XCTAssertEqual(publisherOpenCount, 1)
+            let flightCountWhileBlocked = await store.watcherInfrastructureFlightCountForTesting(rootID: rootID)
+            XCTAssertEqual(flightCountWhileBlocked, 1)
+            let ownershipWhileBlocked = await store.sessionWorktreeOwnershipDebugSnapshotForTesting()
+            XCTAssertEqual(ownershipWhileBlocked.explicitWatcherDemandCount, 1)
+
+            await publisherOpenGate.release()
+            try await firstStart.value
+            try await secondStart.value
+
+            let watcherIsActive = try await store.rootWatcherIsActiveForTesting(rootID: rootID)
+            let ingress = await store.publisherIngressDebugSnapshotForTesting(rootID: rootID)
+            let flightCountAfterStart = await store.watcherInfrastructureFlightCountForTesting(rootID: rootID)
+            XCTAssertTrue(watcherIsActive)
+            XCTAssertTrue(ingress.isOpen)
+            XCTAssertEqual(flightCountAfterStart, 0)
+
+            try write("late", to: lateFileURL)
+            try await store.publishSyntheticFileSystemDeltasForTesting(
+                rootID: rootID,
+                deltas: [.fileAdded("Late.swift")]
+            )
+            _ = await store.flushPendingServiceEventsForAllRoots()
+            let lateFile = await store.file(rootID: rootID, relativePath: "Late.swift")
+            XCTAssertNotNil(lateFile)
+
+            await store.stopWatchingRoot(id: rootID)
+            let watcherIsActiveAfterStop = try await store.rootWatcherIsActiveForTesting(rootID: rootID)
+            let ingressAfterStop = await store.publisherIngressDebugSnapshotForTesting(rootID: rootID)
+            XCTAssertFalse(watcherIsActiveAfterStop)
+            XCTAssertFalse(ingressAfterStop.isOpen)
+        }
+
+        func testCancelledColdStartCannotRemoveRestartedExplicitDemand() async throws {
+            let root = try makeTemporaryRoot(name: "CancelledWatcherColdStartRestart")
+            let store = WorkspaceFileContextStore()
+            let record = try await store.loadRoot(path: root.path)
+            let rootID = record.id
+            let publisherOpenGate = AsyncGate()
+            let restartJoinObserved = expectation(description: "restart joins the blocked watcher flight")
+
+            await store.setWatcherPublisherIngressDidOpenHandler { observedRootID, _ in
+                guard observedRootID == rootID else { return }
+                await publisherOpenGate.markStartedAndWaitForRelease()
+            }
+            await store.setWatcherInfrastructureDidJoinFlightHandler { observedRootID, _ in
+                guard observedRootID == rootID else { return }
+                restartJoinObserved.fulfill()
+            }
+            addTeardownBlock {
+                await publisherOpenGate.release()
+                await store.setWatcherPublisherIngressDidOpenHandler(nil)
+                await store.setWatcherInfrastructureDidJoinFlightHandler(nil)
+                await store.stopWatchingRoot(id: rootID)
+            }
+
+            let staleStart = Task {
+                try await store.startWatchingRoot(id: rootID)
+            }
+            await publisherOpenGate.waitUntilStarted()
+            await store.stopWatchingRoot(id: rootID)
+
+            let restartedStart = Task {
+                try await store.startWatchingRoot(id: rootID)
+            }
+            await fulfillment(of: [restartJoinObserved], timeout: 1)
+
+            staleStart.cancel()
+            do {
+                try await staleStart.value
+                XCTFail("Expected the stale pre-stop start to observe cancellation")
+            } catch is CancellationError {
+                // Expected. Its generation-scoped rollback must not remove the restart's demand.
+            } catch {
+                XCTFail("Expected cancellation, got \(error)")
+            }
+
+            let ownershipAfterStaleCancellation =
+                await store.sessionWorktreeOwnershipDebugSnapshotForTesting()
+            XCTAssertEqual(ownershipAfterStaleCancellation.explicitWatcherDemandCount, 1)
+
+            await publisherOpenGate.release()
+            try await restartedStart.value
+
+            let publisherOpenCount = await publisherOpenGate.startCount()
+            let watcherIsActive = try await store.rootWatcherIsActiveForTesting(rootID: rootID)
+            let ingress = await store.publisherIngressDebugSnapshotForTesting(rootID: rootID)
+            XCTAssertEqual(publisherOpenCount, 2)
+            XCTAssertTrue(watcherIsActive)
+            XCTAssertTrue(ingress.isOpen)
         }
 
         @MainActor
@@ -6445,6 +6942,62 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
             XCTAssertEqual(manager.rootFolders.first?.standardizedFullPath, (root.path as NSString).standardizingPath)
 
             await manager.unloadAllRootFolders()
+
+            let lifetimeRoot = try makeTemporaryRoot(name: "SessionWorktreeSuccessorLifetime")
+            try write("first", to: lifetimeRoot.appendingPathComponent("First.swift"))
+            let lifetimeStore = WorkspaceFileContextStore()
+            let lifetimeOwnerID = UUID()
+            let lifetimePreparation = try await lifetimeStore.prepareSessionWorktreeOwnership(
+                ownerID: lifetimeOwnerID,
+                bindingFingerprint: "first-lifetime",
+                physicalRootPaths: [lifetimeRoot.path]
+            )
+            let firstLifetimeRoots = try await lifetimeStore.commitSessionWorktreeOwnership(lifetimePreparation)
+            let firstLifetimeRootID = try XCTUnwrap(firstLifetimeRoots.first?.rootID)
+            let firstLifetimeID = try await lifetimeStore.rootLifetimeIDForTesting(rootID: firstLifetimeRootID)
+            let staleCleanupGate = AsyncGate()
+            let staleCleanupObserved = expectation(description: "first-lifetime orphan cleanup reaches watcher reconciliation")
+            await lifetimeStore.setWatcherServiceStateWillReconcileHandler { rootID, shouldWatch in
+                guard rootID == firstLifetimeRootID, !shouldWatch else { return }
+                staleCleanupObserved.fulfill()
+                await staleCleanupGate.markStartedAndWaitForRelease()
+            }
+            addTeardownBlock {
+                await staleCleanupGate.release()
+                await lifetimeStore.setWatcherServiceStateWillReconcileHandler(nil)
+            }
+
+            let firstLifetimeReleaseTask = Task {
+                await lifetimeStore.releaseSessionWorktreeOwnership(ownerID: lifetimeOwnerID)
+            }
+            await fulfillment(of: [staleCleanupObserved], timeout: 1)
+            let staleCleanupCount = await staleCleanupGate.startCount()
+            XCTAssertEqual(staleCleanupCount, 1)
+            if staleCleanupCount == 1 {
+                await lifetimeStore.unloadRoot(id: firstLifetimeRootID)
+                try write("second", to: lifetimeRoot.appendingPathComponent("Second.swift"))
+                let successorRoot = try await lifetimeStore.loadRoot(
+                    path: lifetimeRoot.path,
+                    kind: .sessionWorktree
+                )
+                let successorLifetimeID = try await lifetimeStore.rootLifetimeIDForTesting(rootID: successorRoot.id)
+                XCTAssertNotEqual(successorRoot.id, firstLifetimeRootID)
+                XCTAssertNotEqual(successorLifetimeID, firstLifetimeID)
+
+                await staleCleanupGate.release()
+                await firstLifetimeReleaseTask.value
+
+                let rootsAfterStaleCleanup = await lifetimeStore.roots()
+                XCTAssertEqual(rootsAfterStaleCleanup.map(\.id), [successorRoot.id])
+                let retainedSuccessorLifetimeID = try await lifetimeStore.rootLifetimeIDForTesting(
+                    rootID: successorRoot.id
+                )
+                XCTAssertEqual(retainedSuccessorLifetimeID, successorLifetimeID)
+                await lifetimeStore.unloadRoot(id: successorRoot.id)
+            } else {
+                await staleCleanupGate.release()
+                await firstLifetimeReleaseTask.value
+            }
         }
 
         @MainActor

--- a/Tests/RepoPromptTests/Workspaces/WorkspaceSwitchRecoveryTests.swift
+++ b/Tests/RepoPromptTests/Workspaces/WorkspaceSwitchRecoveryTests.swift
@@ -813,6 +813,236 @@ final class WorkspaceSwitchRecoveryTests: XCTestCase {
         XCTAssertEqual(composition.workspaceFilesViewModel.snapshotSelection(), newerSelection)
     }
 
+    func testWorkspaceSearchReadinessWaitsForExactSwitchGenerationAndRejectsStaleTicket() async throws {
+        let composition = makeComposition()
+        let manager = composition.workspaceManager
+        await manager.awaitInitialized()
+
+        let readinessGate = WorkspaceSwitchRecoveryGate()
+        manager.setWorkspaceSwitchReadinessDidInvalidateHandlerForTesting {
+            await readinessGate.arriveAndWait()
+        }
+        let target = manager.createWorkspace(
+            name: "Readiness Target \(UUID().uuidString.prefix(8))",
+            repoPaths: [],
+            ephemeral: true
+        )
+        let switchTask = Task { @MainActor in
+            await manager.switchWorkspace(to: target, saveState: false, reason: "readinessExactGeneration")
+        }
+        addTeardownBlock {
+            await MainActor.run {
+                manager.setWorkspaceSwitchReadinessDidInvalidateHandlerForTesting(nil)
+            }
+            await readinessGate.release()
+            _ = await switchTask.value
+        }
+        await readinessGate.waitUntilArrived()
+
+        guard case let .activating(workspaceID, generation) = manager.workspaceSearchReadinessState else {
+            await readinessGate.release()
+            _ = await switchTask.value
+            return XCTFail("Expected target-bound activating readiness")
+        }
+        XCTAssertEqual(workspaceID, target.id)
+        let expectedTicket = WorkspaceSearchReadinessTicket(workspaceID: target.id, generation: generation)
+        let readinessTask = Task { @MainActor in
+            try await manager.awaitWorkspaceSearchReadiness(timeout: .seconds(2))
+        }
+        try await waitUntil {
+            manager.workspaceSearchReadinessWaiterCountForTesting == 1
+        }
+
+        await readinessGate.release()
+        let switchResult = await switchTask.value
+        XCTAssertEqual(switchResult, .switched)
+        let ticket = try await readinessTask.value
+        XCTAssertEqual(ticket, expectedTicket)
+        XCTAssertEqual(manager.workspaceSearchReadinessWaiterCountForTesting, 0)
+        XCTAssertNoThrow(try manager.validateWorkspaceSearchReadiness(ticket))
+        manager.setWorkspaceSwitchReadinessDidInvalidateHandlerForTesting(nil)
+
+        let nextTarget = manager.createWorkspace(
+            name: "Next Readiness Target \(UUID().uuidString.prefix(8))",
+            repoPaths: [],
+            ephemeral: true
+        )
+        let nextSwitchResult = await manager.switchWorkspace(
+            to: nextTarget,
+            saveState: false,
+            reason: "supersedeReadinessTicket"
+        )
+        XCTAssertEqual(nextSwitchResult, .switched)
+        do {
+            try manager.validateWorkspaceSearchReadiness(ticket)
+            XCTFail("Expected the previous readiness ticket to be superseded")
+        } catch let error as WorkspaceSearchReadinessWaitError {
+            XCTAssertEqual(error, .superseded)
+        }
+    }
+
+    func testWorkspaceSearchReadinessCancellationAndTimeoutRemoveWaiters() async throws {
+        let composition = makeComposition()
+        let manager = composition.workspaceManager
+        await manager.awaitInitialized()
+
+        let readinessGate = WorkspaceSwitchRecoveryGate()
+        manager.setWorkspaceSwitchReadinessDidInvalidateHandlerForTesting {
+            await readinessGate.arriveAndWait()
+        }
+        let target = manager.createWorkspace(
+            name: "Bounded Readiness Target \(UUID().uuidString.prefix(8))",
+            repoPaths: [],
+            ephemeral: true
+        )
+        let switchTask = Task { @MainActor in
+            await manager.switchWorkspace(to: target, saveState: false, reason: "boundedReadiness")
+        }
+        addTeardownBlock {
+            await MainActor.run {
+                manager.setWorkspaceSwitchReadinessDidInvalidateHandlerForTesting(nil)
+            }
+            await readinessGate.release()
+            _ = await switchTask.value
+        }
+        await readinessGate.waitUntilArrived()
+
+        let cancelledWaiter = Task { @MainActor in
+            do {
+                _ = try await manager.awaitWorkspaceSearchReadiness(timeout: .seconds(2))
+                XCTFail("Expected readiness wait cancellation")
+                return false
+            } catch is CancellationError {
+                return true
+            } catch {
+                XCTFail("Expected CancellationError, got \(error)")
+                return false
+            }
+        }
+        try await waitUntil {
+            manager.workspaceSearchReadinessWaiterCountForTesting == 1
+        }
+        cancelledWaiter.cancel()
+        let wasCancelled = await cancelledWaiter.value
+        XCTAssertTrue(wasCancelled)
+        try await waitUntil {
+            manager.workspaceSearchReadinessWaiterCountForTesting == 0
+        }
+
+        do {
+            _ = try await manager.awaitWorkspaceSearchReadiness(timeout: .milliseconds(20))
+            XCTFail("Expected readiness wait timeout")
+        } catch let error as WorkspaceSearchReadinessWaitError {
+            XCTAssertEqual(error, .timedOut)
+        }
+        XCTAssertEqual(manager.workspaceSearchReadinessWaiterCountForTesting, 0)
+
+        switchTask.cancel()
+        manager.setWorkspaceSwitchReadinessDidInvalidateHandlerForTesting(nil)
+        await readinessGate.release()
+        let switchResult = await switchTask.value
+        guard case .cancelled = switchResult else {
+            return XCTFail("Expected pre-hydration switch cancellation")
+        }
+        XCTAssertEqual(manager.workspaceSearchReadinessState, .idle)
+        XCTAssertEqual(manager.workspaceSearchReadinessWaiterCountForTesting, 0)
+    }
+
+    func testSwitchPublishesTargetTicketBeforeOldRootUnloadAndCancellationRejectsIdle() async throws {
+        let root = try makeTemporaryDirectory(named: "ReadinessInvalidation")
+        defer { try? FileManager.default.removeItem(at: root) }
+        try "let oldWorkspaceValue = true\n".write(
+            to: root.appendingPathComponent("OldWorkspace.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let store = WorkspaceFileContextStore()
+        let composition = makeComposition(store: store)
+        let manager = composition.workspaceManager
+        await manager.awaitInitialized()
+        let source = manager.createWorkspace(
+            name: "Readiness Source \(UUID().uuidString.prefix(8))",
+            repoPaths: [root.path],
+            ephemeral: true
+        )
+        let sourceSwitchResult = await manager.switchWorkspace(to: source, saveState: false)
+        XCTAssertEqual(sourceSwitchResult, .switched)
+        let sourceTicket = try await manager.awaitWorkspaceSearchReadiness(timeout: .seconds(1))
+
+        let readinessGate = WorkspaceSwitchRecoveryGate()
+        manager.setWorkspaceSwitchReadinessDidInvalidateHandlerForTesting {
+            await readinessGate.arriveAndWait()
+        }
+        let target = manager.createWorkspace(
+            name: "Readiness Cancellation Target \(UUID().uuidString.prefix(8))",
+            repoPaths: [],
+            ephemeral: true
+        )
+        let switchTask = Task { @MainActor in
+            await manager.switchWorkspace(to: target, saveState: true, reason: "readinessCancellation")
+        }
+        addTeardownBlock {
+            await MainActor.run {
+                manager.setWorkspaceSwitchReadinessDidInvalidateHandlerForTesting(nil)
+            }
+            await readinessGate.release()
+            _ = await switchTask.value
+        }
+        await readinessGate.waitUntilArrived()
+
+        XCTAssertEqual(manager.activeWorkspaceID, source.id)
+        guard case let .activating(workspaceID, generation) = manager.workspaceSearchReadinessState else {
+            await readinessGate.release()
+            _ = await switchTask.value
+            return XCTFail("Expected target-bound readiness before old-root unload")
+        }
+        XCTAssertEqual(workspaceID, target.id)
+        let targetTicket = WorkspaceSearchReadinessTicket(workspaceID: target.id, generation: generation)
+        let pendingTargetWaiter = Task { @MainActor in
+            try await manager.awaitWorkspaceSearchReadiness(timeout: .seconds(2))
+        }
+        try await waitUntil {
+            manager.workspaceSearchReadinessWaiterCountForTesting == 1
+        }
+        let rootsBeforeUnload = await store.roots()
+        XCTAssertTrue(rootsBeforeUnload.contains { $0.standardizedFullPath == root.path })
+        do {
+            try manager.validateWorkspaceSearchReadiness(sourceTicket)
+            XCTFail("Expected the source readiness ticket to be superseded")
+        } catch let error as WorkspaceSearchReadinessWaitError {
+            XCTAssertEqual(error, .superseded)
+        }
+
+        await manager.cancelCurrentWorkspaceSwitchAndReturnToSystem()
+        XCTAssertEqual(manager.workspaceSearchReadinessState, .idle)
+        do {
+            _ = try await pendingTargetWaiter.value
+            XCTFail("Expected the pending target readiness wait to be superseded")
+        } catch let error as WorkspaceSearchReadinessWaitError {
+            XCTAssertEqual(error, .superseded)
+        }
+        XCTAssertEqual(manager.workspaceSearchReadinessWaiterCountForTesting, 0)
+        let rootsAfterCancellation = await store.roots()
+        XCTAssertTrue(rootsAfterCancellation.contains { $0.standardizedFullPath == root.path })
+        do {
+            _ = try await manager.awaitWorkspaceSearchReadiness(timeout: .seconds(1))
+            XCTFail("Expected idle readiness to be unavailable")
+        } catch let error as WorkspaceSearchReadinessWaitError {
+            XCTAssertEqual(error, .unavailable)
+        }
+
+        manager.setWorkspaceSwitchReadinessDidInvalidateHandlerForTesting(nil)
+        await readinessGate.release()
+        _ = await switchTask.value
+        XCTAssertEqual(manager.workspaceSearchReadinessWaiterCountForTesting, 0)
+        guard let finalTicket = manager.workspaceSearchReadinessState.ticket else {
+            return XCTFail("Expected recovery to publish a new readiness ticket")
+        }
+        XCTAssertNotEqual(finalTicket, targetTicket)
+        XCTAssertEqual(finalTicket.workspaceID, manager.activeWorkspaceID)
+    }
+
     func testWatcherActivationFailureDegradesWorkspaceReadiness() async throws {
         let root = try makeTemporaryDirectory(named: "WatcherActivationFailure")
         defer { try? FileManager.default.removeItem(at: root) }
@@ -842,6 +1072,9 @@ final class WorkspaceSwitchRecoveryTests: XCTestCase {
         XCTAssertEqual(failures.count, 1)
         XCTAssertEqual(failures.first?.standardizedRootPath, root.path)
         XCTAssertTrue(failures.first?.errorDescription.contains("Failed to start FSEvent stream") == true)
+        let ticket = try await manager.awaitWorkspaceSearchReadiness(timeout: .seconds(1))
+        XCTAssertEqual(ticket.workspaceID, target.id)
+        XCTAssertNoThrow(try manager.validateWorkspaceSearchReadiness(ticket))
 
         let roots = await store.roots()
         let loadedRoot = try XCTUnwrap(roots.first)


### PR DESCRIPTION
## Summary
- add generation-bound workspace search readiness waits and reject stale `.idle` searches during workspace switches
- protect shared worktree root loads with provisional reservations and lifetime-safe cleanup
- single-flight watcher ingress setup so concurrent sessions can cold-start on the same worktree
- release the process-wide MCP bootstrap gate after PID-owned policy arming, allowing parallel provider initialization while preserving per-run routing
- add gate/provider diagnostics plus durable `run_id` linkage in `agent_run` output
- force MCP/Agent tool auto-start for packaged DEBUG app launches without changing release preferences

## Validation
- `make dev-test` — passed full root suite
- `make dev-lint` — 0 violations
- RepoPrompt and repoprompt-mcp builds — passed
- repository guardrails and contribution secret scans — passed
- focused readiness, worktree ownership, MCP policy/lease, lifecycle, catalog, and formatter suites — passed

## Live CE smoke
- relaunched the packaged CE debug app and switched to `MixedRealityToolkit-Unity`
- cold-started two sessions on one detached worktree concurrently; both completed tree/search/read tools
- launched six sessions simultaneously: two on worktree A, two on worktree B, and two on the canonical root; tool execution overlapped after the bootstrap fix
- measured direct MCP latency across all six contexts:
  - `get_file_tree`: 36.6–40.6 ms
  - `file_search`: 117.6–139.5 ms
  - `read_file`: 97.8–111.5 ms
- routing diagnostics showed independent gate waits of 0.007 ms and 0.004 ms and overlapping provider initialization for approximately 6.4 seconds
- verified DEBUG MCP Agent tools are registered immediately after relaunch without a manual toggle
