### PR TITLE
Preserve Agent chat order when opening sessions

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeSidebarSessionBuilder.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeSidebarSessionBuilder.swift
@@ -13,7 +13,6 @@ struct AgentModeSidebarSessionBuilder {
     let sessionListSortDates: [UUID: Date]
     let sessionListCacheReady: Bool
     let sidebarRestoreFrozenOrderByTabID: [UUID: Int]
-    let activeTabID: UUID?
     let mcpControlledTabIDs: Set<UUID>
 
     private struct BuildContext {
@@ -603,11 +602,6 @@ struct AgentModeSidebarSessionBuilder {
                     let rhsContainsPinned = subtreeContainsPinned(rhs)
                     if lhsContainsPinned != rhsContainsPinned {
                         return lhsContainsPinned && !rhsContainsPinned
-                    }
-                    let lhsIsActive = flat[lhs].tabID == activeTabID
-                    let rhsIsActive = flat[rhs].tabID == activeTabID
-                    if lhsIsActive != rhsIsActive {
-                        return lhsIsActive && !rhsIsActive
                     }
                     return sidebarRowPrecedes(flat[lhs], flat[rhs], tabOrder: tabOrder)
                 }

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+SidebarSessions.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+SidebarSessions.swift
@@ -309,13 +309,6 @@ extension AgentModeViewModel {
     /// Session-linked sidebar data source.
     /// Blank compose tabs stay hidden until they are explicitly linked to an agent session.
     func sidebarSessions(for tabs: [ComposeTabState]) -> [SidebarSession] {
-        sidebarSessions(for: tabs, activeTabID: currentTabID)
-    }
-
-    func sidebarSessions(
-        for tabs: [ComposeTabState],
-        activeTabID: UUID?
-    ) -> [SidebarSession] {
         let currentIndex = ownerValidatedSessionIndex
         let indexEntriesByTabID = Dictionary(grouping: currentIndex.values, by: \.tabID)
         let authoritativeSessionIDByTabID = Dictionary(
@@ -350,7 +343,6 @@ extension AgentModeViewModel {
             sessionListSortDates: ownerValidatedSessionListSortDates,
             sessionListCacheReady: ownerValidatedSessionListCacheReady,
             sidebarRestoreFrozenOrderByTabID: ownerValidatedSidebarRestoreFrozenOrderByTabID,
-            activeTabID: activeTabID,
             mcpControlledTabIDs: mcpControlledTabIDs
         ).build()
     }
@@ -383,7 +375,7 @@ extension AgentModeViewModel {
             let startMS = AgentModePerfDiagnostics.timestampMSIfEnabled()
         #endif
         let source = diagnosticSource ?? "unknown"
-        let sortedSessions = sidebarSessions(for: tabs, activeTabID: currentTabID)
+        let sortedSessions = sidebarSessions(for: tabs)
         let effectiveSearchText = searchText ?? sessionSidebarSearchText
         let searchTrimmed = effectiveSearchText.trimmingCharacters(in: .whitespacesAndNewlines)
         let result: [SidebarSession]
@@ -439,13 +431,8 @@ extension AgentModeViewModel {
             }
 
             let filtered = sortedSessions.filter { matchedIDs.contains($0.id) }
-            let reordered = sidebarSearchRowsPromotingActiveThread(
-                filtered,
-                currentTabID: currentTabID,
-                sessionByID: sessionByID
-            )
             result = sidebarRowsApplyingThreadCollapse(
-                reordered,
+                filtered,
                 currentTabID: currentTabID,
                 searchText: effectiveSearchText,
                 diagnosticSource: source
@@ -466,46 +453,6 @@ extension AgentModeViewModel {
             )
         #endif
         return result
-    }
-
-    private func sidebarSearchRowsPromotingActiveThread(
-        _ rows: [SidebarSession],
-        currentTabID: UUID?,
-        sessionByID: [UUID: SidebarSession]
-    ) -> [SidebarSession] {
-        guard let activeTabID = currentTabID,
-              let activeIndex = rows.firstIndex(where: { $0.tabID == activeTabID })
-        else {
-            return rows
-        }
-        var rootID = rows[activeIndex].id
-        var cursor = rows[activeIndex].parentSessionID
-        var visitedSessionIDs: Set<UUID> = []
-        while let parentSessionID = cursor,
-              visitedSessionIDs.insert(parentSessionID).inserted,
-              let parent = sessionByID[parentSessionID]
-        {
-            rootID = parent.id
-            cursor = parent.parentSessionID
-        }
-        guard let groupStartIndex = rows.firstIndex(where: { $0.id == rootID }) else {
-            var reordered = rows
-            let active = reordered.remove(at: activeIndex)
-            reordered.insert(active, at: 0)
-            return reordered
-        }
-        let rootDepth = rows[groupStartIndex].depth
-        let groupEndIndex = rows[(groupStartIndex + 1)...]
-            .firstIndex(where: { $0.depth <= rootDepth }) ?? rows.endIndex
-        let groupRange = groupStartIndex ..< groupEndIndex
-        guard groupRange.contains(activeIndex), groupStartIndex != rows.startIndex else {
-            return rows
-        }
-        var reordered = rows
-        let group = Array(reordered[groupRange])
-        reordered.removeSubrange(groupRange)
-        reordered.insert(contentsOf: group, at: rows.startIndex)
-        return reordered
     }
 
     private func sidebarRowsApplyingThreadCollapse(

--- a/Tests/RepoPromptTests/AgentMode/AgentModeSidebarSessionBuilderTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeSidebarSessionBuilderTests.swift
@@ -197,7 +197,7 @@ final class AgentModeSidebarSessionBuilderTests: XCTestCase {
         XCTAssertEqual(try row(for: staleTabID, in: rows).activityDate, date(100))
     }
 
-    func testActiveChildPromotesAmongSiblingsWithoutChangingActivityDates() throws {
+    func testSiblingOrderFollowsActivityDates() throws {
         let parentTabID = id(30)
         let newerChildTabID = id(31)
         let activeOlderChildTabID = id(32)
@@ -225,13 +225,9 @@ final class AgentModeSidebarSessionBuilderTests: XCTestCase {
             )
         ])
 
-        let rows = build(
-            tabs: tabs,
-            sessionIndex: index,
-            activeTabID: activeOlderChildTabID
-        )
+        let rows = build(tabs: tabs, sessionIndex: index)
 
-        XCTAssertEqual(rows.map(\.tabID), [parentTabID, activeOlderChildTabID, newerChildTabID])
+        XCTAssertEqual(rows.map(\.tabID), [parentTabID, newerChildTabID, activeOlderChildTabID])
         XCTAssertEqual(
             try XCTUnwrap(rows.first(where: { $0.tabID == activeOlderChildTabID })).activityDate,
             date(100)
@@ -458,8 +454,7 @@ final class AgentModeSidebarSessionBuilderTests: XCTestCase {
     private func build(
         tabs: [ComposeTabState],
         sessions: [UUID: AgentModeViewModel.TabSession] = [:],
-        sessionIndex: [UUID: AgentSessionIndexEntry],
-        activeTabID: UUID? = nil
+        sessionIndex: [UUID: AgentSessionIndexEntry]
     ) -> [AgentModeViewModel.SidebarSession] {
         AgentModeSidebarSessionBuilder(
             allTabs: tabs,
@@ -474,7 +469,6 @@ final class AgentModeSidebarSessionBuilderTests: XCTestCase {
             sessionListSortDates: [:],
             sessionListCacheReady: true,
             sidebarRestoreFrozenOrderByTabID: [:],
-            activeTabID: activeTabID,
             mcpControlledTabIDs: []
         ).build()
     }

--- a/Tests/RepoPromptTests/AgentMode/AgentModeViewModelInactiveRefreshTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeViewModelInactiveRefreshTests.swift
@@ -1277,8 +1277,8 @@ final class AgentModeViewModelInactiveRefreshTests: XCTestCase {
         let newerChildRowIndex = try XCTUnwrap(
             transitionRows.firstIndex(where: { $0.tabID == newerChildTabID })
         )
-        XCTAssertLessThan(rootRowIndex, activeChildRowIndex)
-        XCTAssertLessThan(activeChildRowIndex, newerChildRowIndex)
+        XCTAssertLessThan(rootRowIndex, newerChildRowIndex)
+        XCTAssertLessThan(newerChildRowIndex, activeChildRowIndex)
         let activeOlderChildRow = try XCTUnwrap(
             transitionRows.first(where: { $0.tabID == activeOlderChildTabID })
         )
@@ -1286,6 +1286,28 @@ final class AgentModeViewModelInactiveRefreshTests: XCTestCase {
         XCTAssertEqual(activeOlderChildRow.parentSessionID, rootSessionID)
         XCTAssertEqual(activeOlderChildRow.activityDate, Date(timeIntervalSince1970: 100))
         XCTAssertEqual(activeOlderChildRow.worktreeMergeAttention?.operationID, mergeSummary.id)
+
+        let newerActiveRows = viewModel.filteredSidebarSessions(
+            for: transitionWorkspace.composeTabs,
+            currentTabID: newerChildTabID,
+            searchText: ""
+        )
+        XCTAssertEqual(transitionRows.map(\.tabID), newerActiveRows.map(\.tabID))
+
+        let searchRowsWithoutActivePromotion = viewModel.filteredSidebarSessions(
+            for: transitionWorkspace.composeTabs,
+            currentTabID: nil,
+            searchText: "root"
+        )
+        let searchRowsWithStaleRootActive = viewModel.filteredSidebarSessions(
+            for: transitionWorkspace.composeTabs,
+            currentTabID: staleRootTabID,
+            searchText: "root"
+        )
+        XCTAssertEqual(
+            searchRowsWithStaleRootActive.map(\.tabID),
+            searchRowsWithoutActivePromotion.map(\.tabID)
+        )
 
         let currentCascade = viewModel.test_sessionTreeCascadePlan(
             forComposeTabIDs: [rootTabID],


### PR DESCRIPTION
## Summary
- keep sub-agent siblings ordered by their canonical activity/message dates when selection changes
- remove search-mode promotion of the active root thread while retaining active-row and ancestor visibility
- replace regression-encoding expectations with ordinary and search selection-invariance coverage

## Root cause
The sidebar hierarchy comparator placed the exact active child ahead of sibling activity ordering. Opening an older sub-agent therefore moved it above newer siblings even though no message timestamp changed.

## Validation
- `make dev-test FILTER=AgentModeSidebarSessionBuilderTests` — 9 tests passed
- `make dev-test FILTER=AgentModeViewModelInactiveRefreshTests` — 31 tests passed
- `make dev-lint` — passed
- `make dev-test` — passed on the initial full run
- `make dev-swift-build PRODUCT=RepoPrompt` — passed
- `make guardrails` — passed
- staged and outgoing secret scans — passed
- Oracle diff review — no findings

## Validation exceptions
- Non-disruptive `make dev-smoke` could not connect because the CE app was not running; no visible app launch was performed.
- The later full-suite rerun inside push preflight hit unrelated `WorkspaceFileContextStoreTests.testSessionWorktreeOwnershipReleaseDuringRootLoadUnloadsLateRoot` at line 1468. The first full suite passed, all changed-area tests pass, and this branch has no changes in the workspace-context subsystem.
