### PR TITLE
[codex] Refresh approved contributors

### DIFF
--- a/.github/APPROVED_CONTRIBUTORS
+++ b/.github/APPROVED_CONTRIBUTORS
@@ -28,12 +28,12 @@ adamhelfgott pr
 adamkmccarthy pr
 adampearse pr
 adamteece pr
+adbutler007 pr
 adityadaniel pr
 AdrianAlonsoDev pr
 afadlallah pr
 agamrp pr
 agentdouble0zero pr
-ahafonof pr
 AI-MickyJ pr
 ajitaravind pr
 ajmcclary pr
@@ -71,9 +71,12 @@ appboypov pr
 arbitraryvolume pr
 aringy pr
 arnemue pr
+arnoud-dv pr
+arthuraraujo pr
 artnaz pr
 artuskg pr
 ashesfall pr
+asselinpaul pr
 ataricoder pr
 atdrendel pr
 Aur0r pr
@@ -192,6 +195,7 @@ davidandrewsmith90 pr
 davidarce pr
 davidgovea pr
 davidmansaray pr
+davidrd123 pr
 DavidSchargel pr
 DavidWells pr
 dayvough pr
@@ -202,6 +206,7 @@ desaikarna pr
 designerbjk pr
 devdotbo pr
 dhamaniasad pr
+diegolanda pr
 dillycone pr
 dimifontaine pr
 dineshmatta pr
@@ -452,6 +457,7 @@ mcdargh pr
 mdulghier pr
 mefengl pr
 mejiasd3v pr
+mendelgold220 pr
 mertdumenci pr
 mewkung99 pr
 michaelbiven pr
@@ -472,6 +478,7 @@ moonray pr
 moradology pr
 morluto pr
 mplibunao pr
+mr-oakley pr
 mrbagels pr
 mrruby pr
 MSadauskas pr
@@ -518,6 +525,7 @@ OmarAlShishani pr
 Omoeba pr
 optixailusion pr
 owa1da pr
+p-c-mo pr
 patriciomassaro pr
 pauloelias pr
 pavelklymenko pr
@@ -556,7 +564,6 @@ redrumkev pr
 redwhitblack pr
 regismesquita pr
 Reksa97 pr
-remarkz007 pr
 resolutionathens pr
 richardreeze pr
 riddhish143 pr
@@ -723,6 +730,7 @@ yerffejytnac pr
 yihuikhuu pr
 Yip-Yip pr
 yjsoon pr
+yoshua0x pr
 youqad pr
 yourDomainAdmin pr
 yug105 pr


### PR DESCRIPTION
## Summary
- Refresh `.github/APPROVED_CONTRIBUTORS` from live customer claims.
- Contributor count changed from 738 to 746.
- Preserved the known Emil correction: `emigal pr` stays, `EmilMN pr` stays, and `emil pr` does not return.

## Unresolved claim-form IDs
- `TeamLandiLTD` (organization, not a user)
- `Tyschultz7` (not found)
- `ahafonof` (not found)
- `hsinskip` (not found)

## Validation
- `make guardrails`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh commit`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh push`
