### PR TITLE
Stabilize workspace switch cleanup tests

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -614,6 +614,8 @@ final class AgentModeViewModel: ObservableObject {
     private var workspaceSwitchBackgroundCleanupTasks: [UUID: Task<Void, Never>] = [:]
     #if DEBUG
         private var test_workspaceSwitchBackgroundCleanupDrainTasks: [UUID: Task<Void, Never>] = [:]
+        private var test_workspaceSwitchBackgroundCleanupDrainWaiters: [UUID: CheckedContinuation<Void, Error>] = [:]
+        private var test_workspaceSwitchBackgroundCleanupDrainTimeoutTasks: [UUID: Task<Void, Never>] = [:]
     #endif
     var sidebarAutoArchiveTask: Task<Void, Never>?
     var isApplyingSidebarAutoArchive = false
@@ -829,16 +831,53 @@ final class AgentModeViewModel: ObservableObject {
             }
         }
 
-        func test_drainWorkspaceSwitchBackgroundCleanup() async {
-            while true {
-                let tasks = Array(test_workspaceSwitchBackgroundCleanupDrainTasks.values)
-                guard !tasks.isEmpty else { return }
+        func test_drainWorkspaceSwitchBackgroundCleanup(
+            timeoutNanoseconds: UInt64 = 5_000_000_000
+        ) async throws {
+            guard !test_workspaceSwitchBackgroundCleanupDrainTasks.isEmpty else { return }
 
-                for task in tasks {
-                    await task.value
+            let waiterID = UUID()
+            try await withCheckedThrowingContinuation { continuation in
+                test_workspaceSwitchBackgroundCleanupDrainWaiters[waiterID] = continuation
+                test_workspaceSwitchBackgroundCleanupDrainTimeoutTasks[waiterID] = Task { @MainActor in
+                    do {
+                        try await Task.sleep(nanoseconds: timeoutNanoseconds)
+                    } catch {
+                        return
+                    }
+                    self.test_timeoutWorkspaceSwitchBackgroundCleanupDrain(
+                        waiterID: waiterID,
+                        timeoutNanoseconds: timeoutNanoseconds
+                    )
                 }
-                await Task.yield()
             }
+        }
+
+        private func test_completeWorkspaceSwitchBackgroundCleanup(_ cleanupID: UUID) {
+            test_workspaceSwitchBackgroundCleanupDrainTasks.removeValue(forKey: cleanupID)
+            guard test_workspaceSwitchBackgroundCleanupDrainTasks.isEmpty else { return }
+
+            let waiters = Array(test_workspaceSwitchBackgroundCleanupDrainWaiters.values)
+            test_workspaceSwitchBackgroundCleanupDrainWaiters.removeAll()
+            let timeoutTasks = Array(test_workspaceSwitchBackgroundCleanupDrainTimeoutTasks.values)
+            test_workspaceSwitchBackgroundCleanupDrainTimeoutTasks.removeAll()
+            timeoutTasks.forEach { $0.cancel() }
+            waiters.forEach { $0.resume() }
+        }
+
+        private func test_timeoutWorkspaceSwitchBackgroundCleanupDrain(
+            waiterID: UUID,
+            timeoutNanoseconds: UInt64
+        ) {
+            guard let waiter = test_workspaceSwitchBackgroundCleanupDrainWaiters.removeValue(forKey: waiterID) else {
+                return
+            }
+            test_workspaceSwitchBackgroundCleanupDrainTimeoutTasks.removeValue(forKey: waiterID)
+            waiter.resume(
+                throwing: AgentModeWorkspaceSwitchCleanupDrainTimeoutError(
+                    timeoutNanoseconds: timeoutNanoseconds
+                )
+            )
         }
 
         func test_setActiveWorkspaceIDForSessionIndex(_ workspaceID: UUID?) {
@@ -9505,7 +9544,7 @@ final class AgentModeViewModel: ObservableObject {
         let task = Task(priority: .utility) { @MainActor [weak self] in
             #if DEBUG
                 defer {
-                    self?.test_workspaceSwitchBackgroundCleanupDrainTasks.removeValue(forKey: cleanupID)
+                    self?.test_completeWorkspaceSwitchBackgroundCleanup(cleanupID)
                 }
             #endif
             await Task.yield()
@@ -15798,3 +15837,15 @@ final class AgentModeViewModel: ObservableObject {
         )
     }
 }
+
+#if DEBUG
+    private struct AgentModeWorkspaceSwitchCleanupDrainTimeoutError: LocalizedError {
+        let timeoutNanoseconds: UInt64
+
+        var errorDescription: String? {
+            let timeoutSeconds = Double(timeoutNanoseconds) / 1_000_000_000
+            return "Timed out waiting for workspace-switch background cleanup after \(timeoutSeconds)s."
+        }
+    }
+
+#endif

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -612,6 +612,9 @@ final class AgentModeViewModel: ObservableObject {
     private var saveInFlightSessionIDs: Set<UUID> = []
     private var saveRequestedWhileInFlightSessionIDs: Set<UUID> = []
     private var workspaceSwitchBackgroundCleanupTasks: [UUID: Task<Void, Never>] = [:]
+    #if DEBUG
+        private var test_workspaceSwitchBackgroundCleanupDrainTasks: [UUID: Task<Void, Never>] = [:]
+    #endif
     var sidebarAutoArchiveTask: Task<Void, Never>?
     var isApplyingSidebarAutoArchive = false
     let sidebarAutoArchivePolicy = AgentModeSidebarAutoArchivePolicy()
@@ -822,6 +825,18 @@ final class AgentModeViewModel: ObservableObject {
         func test_waitForSessionListCacheRefresh() async {
             while let task = sessionListCacheTask {
                 await task.value
+                await Task.yield()
+            }
+        }
+
+        func test_drainWorkspaceSwitchBackgroundCleanup() async {
+            while true {
+                let tasks = Array(test_workspaceSwitchBackgroundCleanupDrainTasks.values)
+                guard !tasks.isEmpty else { return }
+
+                for task in tasks {
+                    await task.value
+                }
                 await Task.yield()
             }
         }
@@ -1730,6 +1745,9 @@ final class AgentModeViewModel: ObservableObject {
             task.cancel()
         }
         workspaceSwitchBackgroundCleanupTasks.removeAll()
+        #if DEBUG
+            test_workspaceSwitchBackgroundCleanupDrainTasks.removeAll()
+        #endif
         sessionListCacheTask?.cancel()
         sidebarAutoArchiveTask?.cancel()
         sessionListCacheGeneration &+= 1
@@ -9487,6 +9505,11 @@ final class AgentModeViewModel: ObservableObject {
         let task = Task(priority: .utility) { @MainActor [weak self] in
             await Task.yield()
             guard let self else { return }
+            #if DEBUG
+                defer {
+                    test_workspaceSwitchBackgroundCleanupDrainTasks.removeValue(forKey: cleanupID)
+                }
+            #endif
             for target in targets {
                 await teardownMCPControl(
                     for: target.session,
@@ -9515,6 +9538,9 @@ final class AgentModeViewModel: ObservableObject {
             }
         }
         workspaceSwitchBackgroundCleanupTasks[cleanupID] = task
+        #if DEBUG
+            test_workspaceSwitchBackgroundCleanupDrainTasks[cleanupID] = task
+        #endif
     }
 
     private static func disposeDetachedWorkspaceSwitchTarget(

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -9503,13 +9503,13 @@ final class AgentModeViewModel: ObservableObject {
         guard !targets.isEmpty else { return }
         let cleanupID = UUID()
         let task = Task(priority: .utility) { @MainActor [weak self] in
-            await Task.yield()
-            guard let self else { return }
             #if DEBUG
                 defer {
-                    test_workspaceSwitchBackgroundCleanupDrainTasks.removeValue(forKey: cleanupID)
+                    self?.test_workspaceSwitchBackgroundCleanupDrainTasks.removeValue(forKey: cleanupID)
                 }
             #endif
+            await Task.yield()
+            guard let self else { return }
             for target in targets {
                 await teardownMCPControl(
                     for: target.session,

--- a/Tests/RepoPromptTests/AgentMode/WorkspaceSwitchCleanupTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/WorkspaceSwitchCleanupTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 @MainActor
 final class AgentModeWorkspaceSwitchCleanupTests: XCTestCase {
-    func testWorkspaceSwitchClearsForegroundBeforeSlowProviderDisposeCompletes() async {
+    func testWorkspaceSwitchClearsForegroundBeforeSlowProviderDisposeCompletes() async throws {
         let provider = BlockingHeadlessProvider()
         let viewModel = makeViewModel()
         let tabID = UUID()
@@ -17,14 +17,15 @@ final class AgentModeWorkspaceSwitchCleanupTests: XCTestCase {
         await viewModel.handleWorkspaceSwitch(nil)
 
         XCTAssertTrue(viewModel.sessions.isEmpty)
+        try await provider.waitUntilDisposeIsSuspended()
+        let startedBeforeRelease = await provider.isDisposeStarted()
         let finishedBeforeRelease = await provider.isDisposeFinished()
+        XCTAssertTrue(startedBeforeRelease)
         XCTAssertFalse(finishedBeforeRelease)
 
         await provider.releaseDispose()
-        await viewModel.test_drainWorkspaceSwitchBackgroundCleanup()
-        let startedAfterDrain = await provider.isDisposeStarted()
+        try await viewModel.test_drainWorkspaceSwitchBackgroundCleanup()
         let finishedAfterDrain = await provider.isDisposeFinished()
-        XCTAssertTrue(startedAfterDrain)
         XCTAssertTrue(finishedAfterDrain)
     }
 
@@ -58,10 +59,10 @@ final class AgentModeWorkspaceSwitchCleanupTests: XCTestCase {
         XCTAssertEqual(ownership.installedOwnerCount, 0)
         XCTAssertEqual(ownership.provisionalOwnerCount, 0)
         XCTAssertEqual(ownership.rootClaimCount, 0)
-        await viewModel.test_drainWorkspaceSwitchBackgroundCleanup()
+        try await viewModel.test_drainWorkspaceSwitchBackgroundCleanup()
     }
 
-    func testWorkspaceSwitchBackgroundCleanupUsesCapturedRunIDAfterForegroundSessionsAreCleared() async {
+    func testWorkspaceSwitchBackgroundCleanupUsesCapturedRunIDAfterForegroundSessionsAreCleared() async throws {
         let routing = RoutingRecorder()
         let cancelled = RoutingRecorder()
         let oldRunID = UUID()
@@ -82,13 +83,13 @@ final class AgentModeWorkspaceSwitchCleanupTests: XCTestCase {
         await viewModel.handleWorkspaceSwitch(nil)
 
         XCTAssertTrue(viewModel.sessions.isEmpty)
-        await viewModel.test_drainWorkspaceSwitchBackgroundCleanup()
+        try await viewModel.test_drainWorkspaceSwitchBackgroundCleanup()
         let routingCleaned = await routing.contains(runID: oldRunID, reason: "workspace_switch")
         XCTAssertTrue(routingCleaned)
         XCTAssertTrue(cancelled.containsSync(runID: oldRunID, reason: "workspace_switch"))
     }
 
-    func testDetachedMCPTeardownDoesNotDeactivateNewLiveControlContextWithSameSessionID() async {
+    func testDetachedMCPTeardownDoesNotDeactivateNewLiveControlContextWithSameSessionID() async throws {
         let routing = RoutingRecorder()
         let mcpSessionID = UUID()
         let oldRunID = UUID()
@@ -109,13 +110,13 @@ final class AgentModeWorkspaceSwitchCleanupTests: XCTestCase {
         newSession.mcpControlContext = makeMCPControlContext(sessionID: mcpSessionID)
         viewModel.test_setMCPControlledTabIDs([tabID])
 
-        await viewModel.test_drainWorkspaceSwitchBackgroundCleanup()
+        try await viewModel.test_drainWorkspaceSwitchBackgroundCleanup()
         let routingCleaned = await routing.contains(runID: oldRunID, reason: "workspace_switch")
         XCTAssertTrue(routingCleaned)
         XCTAssertEqual(newSession.mcpControlContext?.sessionID, mcpSessionID)
     }
 
-    func testDetachedWorkspaceSwitchCleanupDoesNotClearNewSessionOnSameTab() async {
+    func testDetachedWorkspaceSwitchCleanupDoesNotClearNewSessionOnSameTab() async throws {
         let provider = BlockingHeadlessProvider()
         let tabID = UUID()
         let oldRunID = UUID()
@@ -135,11 +136,15 @@ final class AgentModeWorkspaceSwitchCleanupTests: XCTestCase {
         newSession.runID = newRunID
         newSession.runState = .running
 
+        try await provider.waitUntilDisposeIsSuspended()
+        let startedBeforeRelease = await provider.isDisposeStarted()
+        let finishedBeforeRelease = await provider.isDisposeFinished()
+        XCTAssertTrue(startedBeforeRelease)
+        XCTAssertFalse(finishedBeforeRelease)
+
         await provider.releaseDispose()
-        await viewModel.test_drainWorkspaceSwitchBackgroundCleanup()
-        let startedAfterDrain = await provider.isDisposeStarted()
+        try await viewModel.test_drainWorkspaceSwitchBackgroundCleanup()
         let finishedAfterDrain = await provider.isDisposeFinished()
-        XCTAssertTrue(startedAfterDrain)
         XCTAssertTrue(finishedAfterDrain)
 
         XCTAssertTrue(viewModel.sessions[tabID] === newSession)
@@ -181,6 +186,8 @@ final class AgentModeWorkspaceSwitchCleanupTests: XCTestCase {
 
 private actor BlockingHeadlessProvider: HeadlessAgentProvider {
     private var disposeContinuation: CheckedContinuation<Void, Never>?
+    private var disposeSuspendedWaiter: CheckedContinuation<Void, Error>?
+    private var disposeSuspendedWaiterTimeoutTask: Task<Void, Never>?
     private var disposeReleaseRequested = false
     private(set) var disposeStarted = false
     private(set) var disposeFinished = false
@@ -196,9 +203,28 @@ private actor BlockingHeadlessProvider: HeadlessAgentProvider {
         if !disposeReleaseRequested {
             await withCheckedContinuation { continuation in
                 disposeContinuation = continuation
+                resumeDisposeSuspendedWaiter()
             }
         }
         disposeFinished = true
+    }
+
+    func waitUntilDisposeIsSuspended(
+        timeoutNanoseconds: UInt64 = 5_000_000_000
+    ) async throws {
+        guard disposeContinuation == nil else { return }
+        try await withCheckedThrowingContinuation { continuation in
+            precondition(disposeSuspendedWaiter == nil)
+            disposeSuspendedWaiter = continuation
+            disposeSuspendedWaiterTimeoutTask = Task { [weak self] in
+                do {
+                    try await Task.sleep(nanoseconds: timeoutNanoseconds)
+                } catch {
+                    return
+                }
+                await self?.timeoutDisposeSuspendedWaiter(timeoutNanoseconds: timeoutNanoseconds)
+            }
+        }
     }
 
     func releaseDispose() {
@@ -208,12 +234,37 @@ private actor BlockingHeadlessProvider: HeadlessAgentProvider {
         disposeContinuation = nil
     }
 
+    private func resumeDisposeSuspendedWaiter() {
+        disposeSuspendedWaiterTimeoutTask?.cancel()
+        disposeSuspendedWaiterTimeoutTask = nil
+        disposeSuspendedWaiter?.resume()
+        disposeSuspendedWaiter = nil
+    }
+
+    private func timeoutDisposeSuspendedWaiter(timeoutNanoseconds: UInt64) {
+        guard let disposeSuspendedWaiter else { return }
+        self.disposeSuspendedWaiter = nil
+        disposeSuspendedWaiterTimeoutTask = nil
+        disposeSuspendedWaiter.resume(
+            throwing: BlockingHeadlessProviderTimeoutError(timeoutNanoseconds: timeoutNanoseconds)
+        )
+    }
+
     func isDisposeStarted() -> Bool {
         disposeStarted
     }
 
     func isDisposeFinished() -> Bool {
         disposeFinished
+    }
+}
+
+private struct BlockingHeadlessProviderTimeoutError: LocalizedError {
+    let timeoutNanoseconds: UInt64
+
+    var errorDescription: String? {
+        let timeoutSeconds = Double(timeoutNanoseconds) / 1_000_000_000
+        return "Timed out waiting for dispose() to reach its suspension point after \(timeoutSeconds)s."
     }
 }
 

--- a/Tests/RepoPromptTests/AgentMode/WorkspaceSwitchCleanupTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/WorkspaceSwitchCleanupTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 @MainActor
 final class AgentModeWorkspaceSwitchCleanupTests: XCTestCase {
-    func testWorkspaceSwitchClearsForegroundBeforeSlowProviderDisposeCompletes() async throws {
+    func testWorkspaceSwitchClearsForegroundBeforeSlowProviderDisposeCompletes() async {
         let provider = BlockingHeadlessProvider()
         let viewModel = makeViewModel()
         let tabID = UUID()
@@ -20,9 +20,12 @@ final class AgentModeWorkspaceSwitchCleanupTests: XCTestCase {
         let finishedBeforeRelease = await provider.isDisposeFinished()
         XCTAssertFalse(finishedBeforeRelease)
 
-        try await waitUntil { await provider.isDisposeStarted() }
         await provider.releaseDispose()
-        try await waitUntil { await provider.isDisposeFinished() }
+        await viewModel.test_drainWorkspaceSwitchBackgroundCleanup()
+        let startedAfterDrain = await provider.isDisposeStarted()
+        let finishedAfterDrain = await provider.isDisposeFinished()
+        XCTAssertTrue(startedAfterDrain)
+        XCTAssertTrue(finishedAfterDrain)
     }
 
     func testWorkspaceSwitchReleasesSessionWorktreeOwnershipBeforeDiscardingSessions() async throws {
@@ -55,9 +58,10 @@ final class AgentModeWorkspaceSwitchCleanupTests: XCTestCase {
         XCTAssertEqual(ownership.installedOwnerCount, 0)
         XCTAssertEqual(ownership.provisionalOwnerCount, 0)
         XCTAssertEqual(ownership.rootClaimCount, 0)
+        await viewModel.test_drainWorkspaceSwitchBackgroundCleanup()
     }
 
-    func testWorkspaceSwitchBackgroundCleanupUsesCapturedRunIDAfterForegroundSessionsAreCleared() async throws {
+    func testWorkspaceSwitchBackgroundCleanupUsesCapturedRunIDAfterForegroundSessionsAreCleared() async {
         let routing = RoutingRecorder()
         let cancelled = RoutingRecorder()
         let oldRunID = UUID()
@@ -78,11 +82,13 @@ final class AgentModeWorkspaceSwitchCleanupTests: XCTestCase {
         await viewModel.handleWorkspaceSwitch(nil)
 
         XCTAssertTrue(viewModel.sessions.isEmpty)
-        try await waitUntil { await routing.contains(runID: oldRunID, reason: "workspace_switch") }
+        await viewModel.test_drainWorkspaceSwitchBackgroundCleanup()
+        let routingCleaned = await routing.contains(runID: oldRunID, reason: "workspace_switch")
+        XCTAssertTrue(routingCleaned)
         XCTAssertTrue(cancelled.containsSync(runID: oldRunID, reason: "workspace_switch"))
     }
 
-    func testDetachedMCPTeardownDoesNotDeactivateNewLiveControlContextWithSameSessionID() async throws {
+    func testDetachedMCPTeardownDoesNotDeactivateNewLiveControlContextWithSameSessionID() async {
         let routing = RoutingRecorder()
         let mcpSessionID = UUID()
         let oldRunID = UUID()
@@ -103,11 +109,13 @@ final class AgentModeWorkspaceSwitchCleanupTests: XCTestCase {
         newSession.mcpControlContext = makeMCPControlContext(sessionID: mcpSessionID)
         viewModel.test_setMCPControlledTabIDs([tabID])
 
-        try await waitUntil { await routing.contains(runID: oldRunID, reason: "workspace_switch") }
+        await viewModel.test_drainWorkspaceSwitchBackgroundCleanup()
+        let routingCleaned = await routing.contains(runID: oldRunID, reason: "workspace_switch")
+        XCTAssertTrue(routingCleaned)
         XCTAssertEqual(newSession.mcpControlContext?.sessionID, mcpSessionID)
     }
 
-    func testDetachedWorkspaceSwitchCleanupDoesNotClearNewSessionOnSameTab() async throws {
+    func testDetachedWorkspaceSwitchCleanupDoesNotClearNewSessionOnSameTab() async {
         let provider = BlockingHeadlessProvider()
         let tabID = UUID()
         let oldRunID = UUID()
@@ -127,9 +135,12 @@ final class AgentModeWorkspaceSwitchCleanupTests: XCTestCase {
         newSession.runID = newRunID
         newSession.runState = .running
 
-        try await waitUntil { await provider.isDisposeStarted() }
         await provider.releaseDispose()
-        try await waitUntil { await provider.isDisposeFinished() }
+        await viewModel.test_drainWorkspaceSwitchBackgroundCleanup()
+        let startedAfterDrain = await provider.isDisposeStarted()
+        let finishedAfterDrain = await provider.isDisposeFinished()
+        XCTAssertTrue(startedAfterDrain)
+        XCTAssertTrue(finishedAfterDrain)
 
         XCTAssertTrue(viewModel.sessions[tabID] === newSession)
         XCTAssertEqual(newSession.providerSessionID, "new-provider-session")
@@ -166,24 +177,11 @@ final class AgentModeWorkspaceSwitchCleanupTests: XCTestCase {
             testWorkspaceFileContextStore: workspaceFileContextStore
         )
     }
-
-    private func waitUntil(
-        timeout: TimeInterval = 2.0,
-        file: StaticString = #filePath,
-        line: UInt = #line,
-        _ condition: @escaping () async -> Bool
-    ) async throws {
-        let deadline = Date().addingTimeInterval(timeout)
-        while Date() < deadline {
-            if await condition() { return }
-            try await Task.sleep(nanoseconds: 10_000_000)
-        }
-        XCTFail("Timed out waiting for condition", file: file, line: line)
-    }
 }
 
 private actor BlockingHeadlessProvider: HeadlessAgentProvider {
     private var disposeContinuation: CheckedContinuation<Void, Never>?
+    private var disposeReleaseRequested = false
     private(set) var disposeStarted = false
     private(set) var disposeFinished = false
 
@@ -195,13 +193,17 @@ private actor BlockingHeadlessProvider: HeadlessAgentProvider {
 
     func dispose() async {
         disposeStarted = true
-        await withCheckedContinuation { continuation in
-            disposeContinuation = continuation
+        if !disposeReleaseRequested {
+            await withCheckedContinuation { continuation in
+                disposeContinuation = continuation
+            }
         }
         disposeFinished = true
     }
 
     func releaseDispose() {
+        guard !disposeFinished else { return }
+        disposeReleaseRequested = true
         disposeContinuation?.resume()
         disposeContinuation = nil
     }


### PR DESCRIPTION
Closes #261

## Problem
Full `make dev-test` runs could intermittently time out in `AgentModeWorkspaceSwitchCleanupTests` while focused retries passed. The failing assertions waited for workspace-switch background cleanup side effects after foreground session state had already been cleared:

- old run routing cleanup (`WorkspaceSwitchCleanupTests.swift:106`)
- old provider disposal (`WorkspaceSwitchCleanupTests.swift:130/132`)

The cleanup itself is scheduled asynchronously, so the tests were relying on short polling windows that can miss progress under full-suite executor/MainActor load.

## Why this fixes it
This adds a DEBUG-only workspace-switch cleanup drain seam on `AgentModeViewModel` and updates the cleanup tests to await that deterministic seam instead of polling. The drain tracks cleanup through full task completion, including detached provider/coordinator disposal, so the tests assert the intended race contract without depending on wall-clock timing.

No MCP certificate behavior is changed.

## Validation
- `make dev-format`
- `make dev-test FILTER=AgentModeWorkspaceSwitchCleanupTests`
- repeated `make dev-test FILTER=AgentModeWorkspaceSwitchCleanupTests`
- `make dev-lint`
- `make dev-test`
- `make dev-swift-build PRODUCT=RepoPrompt`
- push preflight: `.agents/skills/rpce-contribution-check/scripts/preflight.sh push`

Note: one push-preflight full-suite attempt hit an unrelated `MCPCodeStructureWorktreeTests` assertion; focused `make dev-test FILTER=MCPCodeStructureWorktreeTests` passed, and the rerun of push preflight passed.
