### PR TITLE
Fix duplicate Check for Updates menu item

### DIFF
--- a/Sources/RepoPrompt/App/HelpMenu.swift
+++ b/Sources/RepoPrompt/App/HelpMenu.swift
@@ -1,19 +1,8 @@
-import Sparkle
 import SwiftUI
 
 struct HelpMenu: View {
-    private var sparkleManager: SparkleUpdaterManager {
-        SparkleUpdaterManager.shared
-    }
-
     var body: some View {
         Group {
-            Button("Check for Updates…") {
-                sparkleManager.checkForUpdates()
-            }
-
-            Divider()
-
             Link(
                 "What's New",
                 destination: URL(string: "https://repoprompt.com/docs#s=changelog")!

--- a/Sources/RepoPrompt/App/RepoPromptApp.swift
+++ b/Sources/RepoPrompt/App/RepoPromptApp.swift
@@ -129,7 +129,7 @@ struct RepoPromptApp: App {
         .windowStyle(.automatic)
         .windowToolbarStyle(.unified)
         .commands {
-            UpdateMenu()
+            UpdateMenu(sparkleManager: appDelegate.sparkleManager)
 
             // macOS standard "Settings…" (⌘,) menu item
             CommandGroup(replacing: .appSettings) {

--- a/Sources/RepoPrompt/App/Sparkle/UpdateMenu.swift
+++ b/Sources/RepoPrompt/App/Sparkle/UpdateMenu.swift
@@ -13,9 +13,7 @@ import SwiftUI
 
 /// Main Commands implementation – now identical in behaviour to the Settings UI
 struct UpdateMenu: Commands {
-    private var sparkleManager: SparkleUpdaterManager {
-        SparkleUpdaterManager.shared
-    }
+    @ObservedObject var sparkleManager: SparkleUpdaterManager
 
     var body: some Commands {
         CommandGroup(after: .appInfo) {


### PR DESCRIPTION
## Summary

Fixes the duplicated “Check for Updates…” menu command and aligns RepoPrompt CE with standard macOS menu conventions.

On macOS, application update commands conventionally live in the app menu near “About <App>”, not in Help. RepoPrompt CE already had an app-menu update command after “About RepoPrompt CE”, but it also added a second “Check for Updates…” item under Help.

This PR keeps the native app-menu location as the single update entry point and removes the Help-menu duplicate.

It also fixes stale update-menu state by passing the app-owned `SparkleUpdaterManager` into `UpdateMenu` as an observed object instead of reading the singleton through an unobserved computed property. This lets the app-menu command refresh when Sparkle publishes readiness or update-availability changes.

## Changes

- Keep the update command in the native macOS app menu after “About RepoPrompt CE”
- Remove the duplicate “Check for Updates…” command from Help
- Inject `appDelegate.sparkleManager` into `UpdateMenu`
- Observe `SparkleUpdaterManager` from `UpdateMenu` so published Sparkle state updates the command UI

## Validation

- `make dev-format`
- `git diff --check`
- `make guardrails`
- `make dev-lint`
- `make dev-swift-build PRODUCT=RepoPrompt`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh commit`