### PR TITLE
Refresh approved contributors

### DIFF
--- a/.github/APPROVED_CONTRIBUTORS
+++ b/.github/APPROVED_CONTRIBUTORS
@@ -28,6 +28,7 @@ adamhelfgott pr
 adamkmccarthy pr
 adampearse pr
 adamteece pr
+adbutler007 pr
 adityadaniel pr
 AdrianAlonsoDev pr
 afadlallah pr
@@ -71,9 +72,12 @@ appboypov pr
 arbitraryvolume pr
 aringy pr
 arnemue pr
+arnoud-dv pr
+arthuraraujo pr
 artnaz pr
 artuskg pr
 ashesfall pr
+asselinpaul pr
 ataricoder pr
 atdrendel pr
 Aur0r pr
@@ -192,6 +196,7 @@ davidandrewsmith90 pr
 davidarce pr
 davidgovea pr
 davidmansaray pr
+davidrd123 pr
 DavidSchargel pr
 DavidWells pr
 dayvough pr
@@ -202,6 +207,7 @@ desaikarna pr
 designerbjk pr
 devdotbo pr
 dhamaniasad pr
+diegolanda pr
 dillycone pr
 dimifontaine pr
 dineshmatta pr
@@ -452,6 +458,7 @@ mcdargh pr
 mdulghier pr
 mefengl pr
 mejiasd3v pr
+mendelgold220 pr
 mertdumenci pr
 mewkung99 pr
 michaelbiven pr
@@ -472,6 +479,7 @@ moonray pr
 moradology pr
 morluto pr
 mplibunao pr
+mr-oakley pr
 mrbagels pr
 mrruby pr
 MSadauskas pr
@@ -518,6 +526,7 @@ OmarAlShishani pr
 Omoeba pr
 optixailusion pr
 owa1da pr
+p-c-mo pr
 patriciomassaro pr
 pauloelias pr
 pavelklymenko pr
@@ -723,6 +732,7 @@ yerffejytnac pr
 yihuikhuu pr
 Yip-Yip pr
 yjsoon pr
+yoshua0x pr
 youqad pr
 yourDomainAdmin pr
 yug105 pr


### PR DESCRIPTION
## Summary
- Refresh `.github/APPROVED_CONTRIBUTORS` from live customer claims.
- Previous contributor count: 738
- New contributor count: 748
- Preserved previously added entries instead of deleting them during the refresh.

## Unresolved claim-form IDs
- `TeamLandiLTD` (`not_user`: resolves to an organization)
- `Tyschultz7` (`not_found`)
- `hsinskip` (`not_found`)
- `ahafonof` (`not_found`, preserved in allowlist per instruction not to delete prior additions)

## Validation
- `make guardrails`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh commit`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh push`
