### PR TITLE
fix(xcode): Support generated workspace in Xcode 26 and 27

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,8 @@
 // swift-tools-version: 6.2
+import Foundation
 import PackageDescription
+
+let packageRoot = URL(fileURLWithPath: #filePath).deletingLastPathComponent().path
 
 let package = Package(
     name: "RepoPromptCE",
@@ -80,7 +83,7 @@ let package = Package(
                 .define("DEBUG", .when(configuration: .debug)),
                 .enableUpcomingFeature("BareSlashRegexLiterals"),
                 .unsafeFlags([
-                    "-import-objc-header", "Sources/RepoPrompt/Support/RepoPrompt-Bridging-Header.h",
+                    "-import-objc-header", "\(packageRoot)/Sources/RepoPrompt/Support/RepoPrompt-Bridging-Header.h",
                     "-disable-bridging-pch"
                 ])
             ]

--- a/Scripts/generate_xcode_workspace.py
+++ b/Scripts/generate_xcode_workspace.py
@@ -36,6 +36,9 @@ TEST_SCHEME = "RepoPrompt CE Tests"
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_DESTINATION = REPO_ROOT / ".build/xcode"
 CUSTOM_DESTINATION_ROOT = REPO_ROOT / ".build/xcode-custom"
+DEFAULT_DEBUG_APP_BUNDLE = (
+    Path.home() / "Library/Application Support/RepoPrompt CE/DebugApps/RepoPrompt.app"
+)
 
 
 class GeneratorError(RuntimeError):
@@ -108,12 +111,14 @@ def validate_manifest(manifest: dict, repo_root: Path) -> None:
         value = setting.get("kind", {}).get("unsafeFlags", {}).get("_0")
         if isinstance(value, list):
             unsafe_flags.append(value)
-    required_flags = [
-        "-import-objc-header",
-        "Sources/RepoPrompt/Support/RepoPrompt-Bridging-Header.h",
-        "-disable-bridging-pch",
-    ]
-    if required_flags not in unsafe_flags:
+    expected_header = repo_root / "Sources/RepoPrompt/Support/RepoPrompt-Bridging-Header.h"
+    if not any(
+        len(flags) == 3
+        and flags[0] == "-import-objc-header"
+        and Path(flags[1]) == expected_header
+        and flags[2] == "-disable-bridging-pch"
+        for flags in unsafe_flags
+    ):
         raise GeneratorError(
             "RepoPrompt must retain the Objective-C bridging-header unsafe flags"
         )
@@ -266,7 +271,7 @@ def render_project(repository_relative_path: str) -> str:
 \t\t\tdependencies = (
 \t\t\t);
 \t\t\tname = \"{APP_SCHEME}\";
-\t\t\tpassBuildSettingsInEnvironment = 1;
+\t\t\tpassBuildSettingsInEnvironment = 0;
 \t\t\tproductName = \"{APP_SCHEME}\";
 \t\t}};
 \t\t{mcp_target_id} /* {MCP_SCHEME} */ = {{
@@ -280,7 +285,7 @@ def render_project(repository_relative_path: str) -> str:
 \t\t\tdependencies = (
 \t\t\t);
 \t\t\tname = \"{MCP_SCHEME}\";
-\t\t\tpassBuildSettingsInEnvironment = 1;
+\t\t\tpassBuildSettingsInEnvironment = 0;
 \t\t\tproductName = \"{MCP_SCHEME}\";
 \t\t}};
 \t\t{test_target_id} /* {TEST_SCHEME} */ = {{
@@ -294,7 +299,7 @@ def render_project(repository_relative_path: str) -> str:
 \t\t\tdependencies = (
 \t\t\t);
 \t\t\tname = \"{TEST_SCHEME}\";
-\t\t\tpassBuildSettingsInEnvironment = 1;
+\t\t\tpassBuildSettingsInEnvironment = 0;
 \t\t\tproductName = \"{TEST_SCHEME}\";
 \t\t}};
 /* End PBXLegacyTarget section */
@@ -374,14 +379,14 @@ def render_project(repository_relative_path: str) -> str:
 def render_scheme(
     name: str,
     target_label: str,
-    runnable_relative_path: str,
+    runnable_path: str,
     app: bool,
     repository_relative_path: str,
     working_directory: Path,
 ) -> str:
     target_id = stable_id(target_label)
     repository_path = f"$(PROJECT_DIR)/{repository_relative_path}"
-    runnable_path = f"{repository_path}/{runnable_relative_path}"
+    escaped_runnable_path = xml_escape(runnable_path)
     escaped_working_directory = xml_escape(str(working_directory))
     environment = ""
     preactions = ""
@@ -416,10 +421,10 @@ def render_scheme(
       <Testables/>
    </TestAction>
    <LaunchAction buildConfiguration = "Debug" selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB" selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB" launchStyle = "0" useCustomWorkingDirectory = "YES" customWorkingDirectory = "{escaped_working_directory}" ignoresPersistentStateOnLaunch = "NO" debugDocumentVersioning = "YES" debugServiceExtension = "internal" allowLocationSimulation = "YES">{preactions}
-      <PathRunnable runnableDebuggingMode = "0" FilePath = "{runnable_path}"/>{environment}
+      <PathRunnable runnableDebuggingMode = "0" FilePath = "{escaped_runnable_path}"/>{environment}
    </LaunchAction>
    <ProfileAction buildConfiguration = "Debug" shouldUseLaunchSchemeArgsEnv = "YES" savedToolIdentifier = "" useCustomWorkingDirectory = "YES" customWorkingDirectory = "{escaped_working_directory}" debugDocumentVersioning = "YES">
-      <PathRunnable runnableDebuggingMode = "0" FilePath = "{runnable_path}"/>
+      <PathRunnable runnableDebuggingMode = "0" FilePath = "{escaped_runnable_path}"/>
    </ProfileAction>
    <AnalyzeAction buildConfiguration = "Debug"/>
    <ArchiveAction buildConfiguration = "Release" revealArchiveInOrganizer = "NO"/>
@@ -473,9 +478,11 @@ test action is not the supported test workflow because Xcode does not expose the
 XCFramework also declares an omitted dSYMs directory; this generator deliberately does
 not mutate `Vendor/` to compensate. Use the convenience schemes above.
 
-Xcode does not expand project macros in an external runnable's custom working-directory
-field, so generated schemes record the current worktree root there. Regenerate after
-moving the checkout; all other repository references remain relative.
+Xcode does not expand project macros reliably for every external runnable field. The
+generated app scheme records the current worktree root as the working directory and the
+local debug app bundle path as the Run/Profile runnable. Regenerate after moving the
+checkout or changing the local debug app bundle location; build-time repository
+references remain relative.
 """
 
 
@@ -526,7 +533,7 @@ def render_outputs(
         Path(PROJECT_NAME) / f"xcshareddata/xcschemes/{APP_SCHEME}.xcscheme": render_scheme(
             APP_SCHEME,
             "target:app",
-            ".build/debug/RepoPrompt.app",
+            str(DEFAULT_DEBUG_APP_BUNDLE),
             app=True,
             repository_relative_path=relative_repo,
             working_directory=repo_root,
@@ -534,7 +541,7 @@ def render_outputs(
         Path(PROJECT_NAME) / f"xcshareddata/xcschemes/{MCP_SCHEME}.xcscheme": render_scheme(
             MCP_SCHEME,
             "target:mcp",
-            ".build/debug/repoprompt-mcp",
+            f"$(PROJECT_DIR)/{relative_repo}/.build/debug/repoprompt-mcp",
             app=False,
             repository_relative_path=relative_repo,
             working_directory=repo_root,

--- a/Scripts/normalize_swiftpm_resource_bundles.sh
+++ b/Scripts/normalize_swiftpm_resource_bundles.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_BUNDLE="${1:-}"
+
+fail() {
+    printf 'ERROR: %s\n' "$*" >&2
+    exit 1
+}
+
+[[ -n "$APP_BUNDLE" ]] || fail "Usage: $0 <app-bundle>"
+
+python3 - "$APP_BUNDLE" <<'PYTHON'
+import shutil
+import sys
+from pathlib import Path
+
+app = Path(sys.argv[1])
+required_bundles = ["KeyboardShortcuts_KeyboardShortcuts.bundle"]
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"ERROR: {message}")
+
+
+def require_file(path: Path) -> None:
+    if not path.is_file():
+        fail(f"missing SwiftPM resource bundle file: {path}")
+
+
+def normalize_bundle(bundle: Path) -> None:
+    if not bundle.is_dir():
+        fail(f"missing SwiftPM resource bundle directory: {bundle}")
+
+    canonical_info = bundle / "Contents" / "Info.plist"
+    canonical_strings = bundle / "Contents" / "Resources" / "en.lproj" / "Localizable.strings"
+    if canonical_info.exists() or (bundle / "Contents").exists():
+        require_file(canonical_info)
+        require_file(canonical_strings)
+        return
+
+    flat_info = bundle / "Info.plist"
+    flat_strings = bundle / "en.lproj" / "Localizable.strings"
+    require_file(flat_info)
+    require_file(flat_strings)
+
+    temporary = bundle / ".repoprompt-normalize-tmp"
+    if temporary.exists():
+        fail(f"stale SwiftPM resource bundle normalization directory: {temporary}")
+
+    resources = temporary / "Contents" / "Resources"
+    resources.mkdir(parents=True)
+    shutil.move(str(flat_info), str(temporary / "Contents" / "Info.plist"))
+    for entry in list(bundle.iterdir()):
+        if entry.name == ".repoprompt-normalize-tmp":
+            continue
+        shutil.move(str(entry), str(resources / entry.name))
+
+    for entry in list((temporary / "Contents").iterdir()):
+        shutil.move(str(entry), str(bundle / "Contents" / entry.name))
+    (temporary / "Contents").rmdir()
+    temporary.rmdir()
+
+
+for bundle_name in required_bundles:
+    normalize_bundle(app / "Contents" / "Resources" / bundle_name)
+
+print("OK: normalized SwiftPM resource bundle layout.")
+PYTHON

--- a/Scripts/package_app.sh
+++ b/Scripts/package_app.sh
@@ -250,6 +250,7 @@ run cp -R "$ROOT_DIR/ThirdPartyLicenses" "$APP_BUNDLE/Contents/Resources/Legal/"
 shopt -s nullglob
 for bundle in "$BUILD_DIR"/*.bundle; do run cp -R "$bundle" "$APP_BUNDLE/Contents/Resources/"; done
 shopt -u nullglob
+run "$CONTROL_PLANE_SCRIPTS_DIR/normalize_swiftpm_resource_bundles.sh" "$APP_BUNDLE"
 run "$CONTROL_PLANE_SCRIPTS_DIR/validate_required_swiftpm_resource_bundles.sh" "$APP_BUNDLE" "Packaged app SwiftPM resource bundle layout"
 
 phase "Writing Info.plist"

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -1166,6 +1166,27 @@ SIGNING_TEAM_ID=648A27MST5
         self.assertIn("missing required SwiftPM resource bundle directory", result.stderr)
         self.assertIn("KeyboardShortcuts_KeyboardShortcuts.bundle", result.stderr)
 
+    def test_resource_bundle_normalizer_rewrites_flat_keyboard_shortcuts_bundle(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            app = root / "RepoPrompt.app"
+            bundle = app / "Contents" / "Resources" / "KeyboardShortcuts_KeyboardShortcuts.bundle"
+            (bundle / "en.lproj").mkdir(parents=True)
+            (bundle / "Info.plist").write_text("<plist/>\n", encoding="utf-8")
+            (bundle / "en.lproj" / "Localizable.strings").write_text('"record_shortcut" = "Record Shortcut";\n', encoding="utf-8")
+
+            result = subprocess.run(
+                [str(SCRIPT_DIR / "normalize_swiftpm_resource_bundles.sh"), str(app)],
+                text=True,
+                capture_output=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertTrue((bundle / "Contents" / "Info.plist").is_file())
+            self.assertTrue((bundle / "Contents" / "Resources" / "en.lproj" / "Localizable.strings").is_file())
+            self.assertFalse((bundle / "Info.plist").exists())
+            self.assertFalse((bundle / "en.lproj").exists())
+
     def test_staged_release_validator_rejects_missing_keyboard_shortcuts_patch_marker(self) -> None:
         approved, staged, scripts = self.make_staged_release_fixture()
         app = staged / ".build" / "release" / "RepoPrompt.app"
@@ -1972,9 +1993,10 @@ esac
 
     @staticmethod
     def write_keyboard_shortcuts_bundle(bundle: Path) -> None:
-        (bundle / "en.lproj").mkdir(parents=True, exist_ok=True)
-        (bundle / "Info.plist").write_text("<plist/>\n", encoding="utf-8")
-        (bundle / "en.lproj" / "Localizable.strings").write_text('"record_shortcut" = "Record Shortcut";\n', encoding="utf-8")
+        resources = bundle / "Contents" / "Resources"
+        (resources / "en.lproj").mkdir(parents=True, exist_ok=True)
+        (bundle / "Contents" / "Info.plist").write_text("<plist/>\n", encoding="utf-8")
+        (resources / "en.lproj" / "Localizable.strings").write_text('"record_shortcut" = "Record Shortcut";\n', encoding="utf-8")
 
     @staticmethod
     def run_staged_validation(approved: Path, staged: Path, scripts: Path) -> subprocess.CompletedProcess[str]:

--- a/Scripts/test_xcode_workspace_generator.py
+++ b/Scripts/test_xcode_workspace_generator.py
@@ -103,10 +103,15 @@ class XcodeWorkspaceGeneratorTests(unittest.TestCase):
         self.assertIn(generator.MCP_SCHEME, project)
         self.assertIn(generator.TEST_SCHEME, project)
 
+    def test_convenience_targets_do_not_pass_xcode_build_settings(self) -> None:
+        project = self.outputs[Path(generator.PROJECT_NAME) / "project.pbxproj"].decode()
+        self.assertEqual(project.count("passBuildSettingsInEnvironment = 0;"), 3)
+        self.assertNotIn("passBuildSettingsInEnvironment = 1;", project)
+
     def test_app_scheme_has_runnable_markers_and_prepare_action(self) -> None:
         path = Path(generator.PROJECT_NAME) / f"xcshareddata/xcschemes/{generator.APP_SCHEME}.xcscheme"
         scheme = self.outputs[path].decode()
-        self.assertIn(".build/debug/RepoPrompt.app", scheme)
+        self.assertIn(str(generator.DEFAULT_DEBUG_APP_BUNDLE), scheme)
         self.assertIn("REPOPROMPT_LAUNCH_SOURCE", scheme)
         self.assertIn("__XCODE_BUILT_PRODUCTS_DIR_PATHS", scheme)
         self.assertIn("prepare-app-run", scheme)
@@ -127,6 +132,15 @@ class XcodeWorkspaceGeneratorTests(unittest.TestCase):
             expected_working_directory,
         )
         self.assertTrue(Path(expected_working_directory).is_dir())
+        expected_runnable = str(generator.DEFAULT_DEBUG_APP_BUNDLE)
+        self.assertEqual(
+            launch_action.find("PathRunnable").attrib["FilePath"],
+            expected_runnable,
+        )
+        self.assertEqual(
+            profile_action.find("PathRunnable").attrib["FilePath"],
+            expected_runnable,
+        )
 
         environment = {
             item.attrib["key"]: item.attrib["value"]

--- a/Scripts/validate_required_swiftpm_resource_bundles.sh
+++ b/Scripts/validate_required_swiftpm_resource_bundles.sh
@@ -54,8 +54,8 @@ if app_root_entries != {"Contents"}:
 for bundle_name in required_bundles:
     bundle = app / "Contents" / "Resources" / bundle_name
     require_real_directory(bundle)
-    require_regular_file(bundle / "Info.plist")
-    require_regular_file(bundle / "en.lproj" / "Localizable.strings")
+    require_regular_file(bundle / "Contents" / "Info.plist")
+    require_regular_file(bundle / "Contents" / "Resources" / "en.lproj" / "Localizable.strings")
 
 executable = app / "Contents" / "MacOS" / "RepoPrompt"
 require_regular_file(executable)

--- a/Scripts/xcode_developer_workflow.sh
+++ b/Scripts/xcode_developer_workflow.sh
@@ -21,11 +21,45 @@ interrupted(){
 }
 trap interrupted INT TERM
 
+sanitize_xcode_build_environment(){
+    local variable_name
+    unset \
+        ARCHS \
+        BUILD_DIR \
+        BUILD_ROOT \
+        BUILT_PRODUCTS_DIR \
+        CONFIGURATION \
+        CONFIGURATION_BUILD_DIR \
+        DERIVED_FILE_DIR \
+        DSTROOT \
+        OBJROOT \
+        PROJECT_DIR \
+        PROJECT_FILE_PATH \
+        PROJECT_NAME \
+        PROJECT_TEMP_DIR \
+        SDKROOT \
+        SRCROOT \
+        SYMROOT \
+        TARGET_BUILD_DIR \
+        TARGET_NAME \
+        TARGET_TEMP_DIR \
+        TOOLCHAINS
+
+    while IFS= read -r variable_name; do
+        case "$variable_name" in
+            CLANG_*|GCC_*|LD_*|SWIFT_*|PRODUCT_*|HEADER_SEARCH_PATHS|FRAMEWORK_SEARCH_PATHS|LIBRARY_SEARCH_PATHS)
+                unset "$variable_name"
+                ;;
+        esac
+    done < <(compgen -e)
+}
+
 [[ -n "$ACTION" ]] || usage
 case "$ACTION" in app|mcp|test|prepare-app-run) ;; *) usage ;; esac
 [[ "$CONFIGURATION" == "Debug" ]] || fail "The generated Xcode workflow is Debug-only; use the repository release workflow for '$CONFIGURATION'."
 
 cd "$ROOT_DIR"
+sanitize_xcode_build_environment
 
 case "$ACTION" in
     app)

--- a/docs/architecture/xcode-workspace.md
+++ b/docs/architecture/xcode-workspace.md
@@ -20,7 +20,7 @@ The generator writes `.build/xcode/RepoPromptCE.xcworkspace`. Everything under `
 
 Xcode exposes SwiftPM product schemes, including `RepoPrompt` and `repoprompt-mcp`, alongside three repository convenience schemes:
 
-- `RepoPrompt CE App` delegates to conductor to assemble the real debug app through the existing packaging flow, then runs `.build/debug/RepoPrompt.app`.
+- `RepoPrompt CE App` delegates to conductor to assemble the real debug app through the existing packaging flow, verifies the `.build/debug/RepoPrompt.app` compatibility path, then runs the local debug bundle under `~/Library/Application Support/RepoPrompt CE/DebugApps/RepoPrompt.app`.
 - `RepoPrompt CE MCP` delegates to conductor to build and run `.build/debug/repoprompt-mcp`.
 - `RepoPrompt CE Tests` delegates to the conductor test runner. It is a legacy build target rather than a native Xcode test bundle because `RepoPromptMCP` is an executable-only SwiftPM target.
 


### PR DESCRIPTION
The generated Xcode workspace now builds and runs through both Xcode 26.5 and Xcode 27. The convenience targets no longer pass IDE build settings into nested SwiftPM/conductor work, the packaged app normalizes Xcode 26's flat SwiftPM resource bundle layout into the canonical macOS bundle layout, and the app scheme points LLDB at the real debug bundle instead of the `.build/debug` compatibility symlink.

This keeps `Package.swift`, conductor, and `Scripts/package_app.sh` authoritative while making regenerated `.build/xcode` workspaces portable per checkout. The generated app scheme still validates `.build/debug/RepoPrompt.app`, but Run/Profile use the local debug bundle under `~/Library/Application Support/RepoPrompt CE/DebugApps/RepoPrompt.app` so Xcode 26 does not resolve the executable path to null.

Validation run locally:
- `DEVELOPER_DIR=/Applications/Xcode-26.5.0.app/Contents/Developer SDKROOT=/Applications/Xcode-26.5.0.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.5.sdk python3 Scripts/test_xcode_workspace_generator.py`
- `python3 -m unittest Scripts.test_release_tooling.ReleaseToolingTests.test_resource_bundle_normalizer_rewrites_flat_keyboard_shortcuts_bundle Scripts.test_release_tooling.ReleaseToolingTests.test_staged_release_validator_accepts_keyboard_shortcuts_resources_layout Scripts.test_release_tooling.ReleaseToolingTests.test_staged_release_validator_rejects_missing_keyboard_shortcuts_resources_bundle`
- `DEVELOPER_DIR=/Applications/Xcode-26.5.0.app/Contents/Developer SDKROOT=/Applications/Xcode-26.5.0.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.5.sdk ./conductor build --request-key xcode26-debug-package`
- Xcode 26.5 and Xcode 27 IDE build/run were manually verified during investigation.

Push preflight ran, including whitespace checks, staged/outgoing gitleaks scans, and guardrails. It failed in the coordinated Swift lint lane because the current repository baseline has unrelated SwiftFormat violations across existing Swift files; none of those files are changed by this PR.
