### PR TITLE
Refresh approved contributors

### DIFF
--- a/.github/APPROVED_CONTRIBUTORS
+++ b/.github/APPROVED_CONTRIBUTORS
@@ -28,6 +28,7 @@ adamhelfgott pr
 adamkmccarthy pr
 adampearse pr
 adamteece pr
+adbutler007 pr
 adityadaniel pr
 AdrianAlonsoDev pr
 afadlallah pr
@@ -71,9 +72,12 @@ appboypov pr
 arbitraryvolume pr
 aringy pr
 arnemue pr
+arnoud-dv pr
+arthuraraujo pr
 artnaz pr
 artuskg pr
 ashesfall pr
+asselinpaul pr
 ataricoder pr
 atdrendel pr
 Aur0r pr
@@ -105,6 +109,7 @@ bonkey pr
 bornio pr
 BoweyLou pr
 boyleryan pr
+BppAur pr
 BradferdT pr
 bradhallett pr
 brandonskane pr
@@ -192,6 +197,7 @@ davidandrewsmith90 pr
 davidarce pr
 davidgovea pr
 davidmansaray pr
+davidrd123 pr
 DavidSchargel pr
 DavidWells pr
 dayvough pr
@@ -202,6 +208,7 @@ desaikarna pr
 designerbjk pr
 devdotbo pr
 dhamaniasad pr
+diegolanda pr
 dillycone pr
 dimifontaine pr
 dineshmatta pr
@@ -230,6 +237,7 @@ eclipsology pr
 eddiekollar pr
 eichert12 pr
 emigal pr
+emil pr
 EmilMN pr
 Empedoclez pr
 ENY66 pr
@@ -323,6 +331,7 @@ iguit0 pr
 iieedndb pr
 IkechukwuAbuah pr
 ilyannn pr
+imnoahd pr
 internetoftim pr
 ipapandinas pr
 ipruning pr
@@ -368,6 +377,7 @@ jmaartenson pr
 jmdfm pr
 Jmeg8r pr
 jmslagle pr
+jnennis pr
 joedevon pr
 JoelHarlander pr
 JohanM-er pr
@@ -452,6 +462,7 @@ mcdargh pr
 mdulghier pr
 mefengl pr
 mejiasd3v pr
+mendelgold220 pr
 mertdumenci pr
 mewkung99 pr
 michaelbiven pr
@@ -472,6 +483,7 @@ moonray pr
 moradology pr
 morluto pr
 mplibunao pr
+mr-oakley pr
 mrbagels pr
 mrruby pr
 MSadauskas pr
@@ -518,6 +530,7 @@ OmarAlShishani pr
 Omoeba pr
 optixailusion pr
 owa1da pr
+p-c-mo pr
 patriciomassaro pr
 pauloelias pr
 pavelklymenko pr
@@ -723,6 +736,7 @@ yerffejytnac pr
 yihuikhuu pr
 Yip-Yip pr
 yjsoon pr
+yoshua0x pr
 youqad pr
 yourDomainAdmin pr
 yug105 pr


### PR DESCRIPTION
## Summary
- Refresh `.github/APPROVED_CONTRIBUTORS` from live customer claims without removing pre-existing allowlist entries
- Contributor count: 738 -> 752
- Live claim usernames resolved to 749 GitHub users; unresolved claim-form IDs: 4

## Unresolved claim-form IDs
- TeamLandiLTD (`Organization`, not a user account)
- Tyschultz7 (`not_found`)
- ahafonof (`not_found`)
- hsinskip (`not_found`)

## Validation
- `make guardrails`

