### PR TITLE
Fix symlinked global skill root readability

### DIFF
--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/PathResolution/AgentSupportDirectoryCatalog.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/PathResolution/AgentSupportDirectoryCatalog.swift
@@ -88,9 +88,13 @@ enum AgentSupportDirectoryCatalog {
     ) -> Bool {
         let normalizedDirectory = normalizedPath(for: directoryPath)
         guard normalizedDirectory.hasPrefix("/") else { return false }
-        for candidate in containmentCandidates(for: absolutePath, fileManager: fileManager) {
-            if candidate == normalizedDirectory || candidate.hasPrefix(normalizedDirectory + "/") {
-                return true
+        let directoryCandidates = containmentCandidates(for: normalizedDirectory, fileManager: fileManager)
+        let pathCandidates = containmentCandidates(for: absolutePath, fileManager: fileManager)
+        for directoryCandidate in directoryCandidates {
+            for pathCandidate in pathCandidates {
+                if pathCandidate == directoryCandidate || pathCandidate.hasPrefix(directoryCandidate + "/") {
+                    return true
+                }
             }
         }
         return false

--- a/Tests/RepoPromptTests/MCP/MCPReadFileExactAbsoluteCatalogFastPathTests.swift
+++ b/Tests/RepoPromptTests/MCP/MCPReadFileExactAbsoluteCatalogFastPathTests.swift
@@ -198,6 +198,44 @@ final class MCPReadFileExactAbsoluteCatalogFastPathTests: XCTestCase {
             }
             XCTAssertEqual(file.displayPath, "~/.agents/skills/example/SKILL.md", caseLabel)
         }
+
+        do {
+            let caseLabel = "testSymlinkedExternalSupportPathRemainsFallbackOnly"
+            let root = try makeTemporaryRoot(name: "SymlinkFallbackWorkspace")
+            try write("visible", to: root.appendingPathComponent("Visible.swift"))
+            let home = try makeTemporaryRoot(name: "SymlinkFallbackHome")
+            let realSkillsRoot = try makeTemporaryRoot(name: "SymlinkFallbackSkills")
+            let nominalSkillsRoot = home.appendingPathComponent(".agents/skills", isDirectory: true)
+            try FileManager.default.createDirectory(
+                at: nominalSkillsRoot.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try createDirectorySymlinkOrSkip(at: nominalSkillsRoot, destination: realSkillsRoot)
+            let realSkillFile = realSkillsRoot.appendingPathComponent("example/SKILL.md")
+            try write("symlinked skill body", to: realSkillFile)
+            let nominalSkillFile = nominalSkillsRoot.appendingPathComponent("example/SKILL.md")
+
+            let store = WorkspaceFileContextStore()
+            _ = try await store.loadRoot(path: root.path)
+            let service = WorkspaceReadableFileService(store: store, homeDirectoryURL: home)
+
+            let externalShortcutHit = await service.resolveExactWorkspaceCatalogHit(
+                nominalSkillFile.path,
+                rootScope: .visibleWorkspace
+            )
+            XCTAssertNil(externalShortcutHit, caseLabel)
+            let readable = await service.resolveReadableFile(
+                nominalSkillFile.path,
+                profile: .mcpRead,
+                rootScope: .visibleWorkspace
+            )
+            guard case let .external(file) = readable else {
+                return XCTFail(caseLabel + ": Expected symlinked support file to resolve through external fallback")
+            }
+            XCTAssertEqual(file.absolutePath, realSkillFile.path, caseLabel)
+            let content = try await service.readAlwaysReadableExternalFile(file)
+            XCTAssertEqual(content, "symlinked skill body", caseLabel)
+        }
     }
 
     func testNonMatchedLookupOutcomesCannotShortCircuit() async throws {
@@ -329,6 +367,14 @@ final class MCPReadFileExactAbsoluteCatalogFastPathTests: XCTestCase {
     private func write(_ content: String, to url: URL) throws {
         try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
         try content.write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    private func createDirectorySymlinkOrSkip(at link: URL, destination: URL) throws {
+        do {
+            try FileManager.default.createSymbolicLink(at: link, withDestinationURL: destination)
+        } catch {
+            throw XCTSkip("Directory symlink creation unavailable in this environment: \(error)")
+        }
     }
 
     private func source(_ relativePath: String) throws -> String {

--- a/Tests/RepoPromptTests/WorkspaceContext/WorkspaceFileContextStoreTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/WorkspaceFileContextStoreTests.swift
@@ -5741,6 +5741,56 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
         }
     }
 
+    func testWorkspaceReadableFileServiceResolvesSymlinkedAlwaysReadableExternalFilesAndRejectsEscapes() async throws {
+        let home = try makeTemporaryRoot(name: "ReadableSymlinkHome")
+        let realSkillsRoot = try makeTemporaryRoot(name: "ReadableSymlinkSkills")
+        let nominalSkillsRoot = home.appendingPathComponent(".agents/skills", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: nominalSkillsRoot.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try createDirectorySymlinkOrSkip(at: nominalSkillsRoot, destination: realSkillsRoot)
+
+        let realSkillFile = realSkillsRoot.appendingPathComponent("example/SKILL.md")
+        try write("symlinked skill body", to: realSkillFile)
+        let nominalSkillFile = nominalSkillsRoot.appendingPathComponent("example/SKILL.md")
+
+        let store = WorkspaceFileContextStore()
+        let service = WorkspaceReadableFileService(store: store, homeDirectoryURL: home)
+
+        let nominalResolved = try XCTUnwrap(
+            service.resolveAlwaysReadableExternalFile(atAbsolutePath: nominalSkillFile.path),
+            "nominal symlink-root support path should resolve as external"
+        )
+        XCTAssertEqual(nominalResolved.absolutePath, realSkillFile.path)
+        let nominalContent = try await service.readAlwaysReadableExternalFile(nominalResolved)
+        XCTAssertEqual(nominalContent, "symlinked skill body")
+
+        let canonicalResolved = try XCTUnwrap(
+            service.resolveAlwaysReadableExternalFile(atAbsolutePath: realSkillFile.path),
+            "canonical support-root symlink target path should resolve as external"
+        )
+        XCTAssertEqual(canonicalResolved.absolutePath, realSkillFile.path)
+        let canonicalContent = try await service.readAlwaysReadableExternalFile(canonicalResolved)
+        XCTAssertEqual(canonicalContent, "symlinked skill body")
+
+        let outsideRoot = try makeTemporaryRoot(name: "ReadableSymlinkOutside")
+        let outsideFile = outsideRoot.appendingPathComponent("secret.md")
+        try write("outside", to: outsideFile)
+        let nestedEscape = realSkillsRoot.appendingPathComponent("example/escape", isDirectory: true)
+        try createDirectorySymlinkOrSkip(at: nestedEscape, destination: outsideRoot)
+        let nominalEscapedFile = nominalSkillsRoot.appendingPathComponent("example/escape/secret.md")
+
+        XCTAssertNil(
+            service.resolveAlwaysReadableExternalFile(atAbsolutePath: nominalEscapedFile.path),
+            "nested symlink escape from an allowed support root should remain blocked"
+        )
+        XCTAssertNil(
+            service.resolveAlwaysReadableExternalFile(atAbsolutePath: outsideFile.path),
+            "canonical outside target should not become always-readable"
+        )
+    }
+
     @MainActor
     func testStoreBackedRootShellProjectionsPreserveIdentityWithoutMaterializingDescendants() async throws {
         do {
@@ -8078,6 +8128,14 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
     private func write(_ content: String, to url: URL) throws {
         try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
         try content.write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    private func createDirectorySymlinkOrSkip(at link: URL, destination: URL) throws {
+        do {
+            try FileManager.default.createSymbolicLink(at: link, withDestinationURL: destination)
+        } catch {
+            throw XCTSkip("Directory symlink creation unavailable in this environment: \(error)")
+        }
     }
 
     private func setDiskModificationDate(_ date: Date, for url: URL) throws {


### PR DESCRIPTION
**Summary**

This fixes native RepoPrompt reads for files under symlinked global skill/support roots, such as:

`~/.agents/skills -> /path/to/external-skills-checkout`

Previously, a skill reference file could pass the initial allowlist check using the lexical ~/.agents/skills/... path, then be canonicalized to the symlink target and rejected by the second allowlist check. That could force agents or spawned workers to fall back to shell reads for files that should be RepoPrompt-readable.

**Changes**

	•	Makes always-readable support-root containment symmetric across symlink resolution.
	•	Allows both the nominal lexical path and canonical realpath under a symlinked support root to resolve correctly.
	•	Preserves nested symlink escape protection so paths escaping outside the allowed support root remain blocked.
	•	Adds focused regression coverage for:
	•	WorkspaceReadableFileService
	•	MCP read_file external fallback behavior

**Validation**

	•	make dev-test FILTER=WorkspaceFileContextStoreTests
	•	make dev-test FILTER=MCPReadFileExactAbsoluteCatalogFastPathTests
	•	make dev-lint
	•	rpce-contribution-check commit preflight

Closes https://github.com/repoprompt/repoprompt-ce/issues/288