### PR TITLE
Refresh approved contributors

### DIFF
--- a/.github/APPROVED_CONTRIBUTORS
+++ b/.github/APPROVED_CONTRIBUTORS
@@ -28,6 +28,7 @@ adamhelfgott pr
 adamkmccarthy pr
 adampearse pr
 adamteece pr
+adbutler007 pr
 adityadaniel pr
 AdrianAlonsoDev pr
 afadlallah pr
@@ -55,6 +56,7 @@ amit0365 pr
 amittell pr
 amlfi pr
 amogower pr
+anand180 pr
 anderjason pr
 AndreElijah pr
 andrewmunsell pr
@@ -71,9 +73,12 @@ appboypov pr
 arbitraryvolume pr
 aringy pr
 arnemue pr
+arnoud-dv pr
+arthuraraujo pr
 artnaz pr
 artuskg pr
 ashesfall pr
+asselinpaul pr
 ataricoder pr
 atdrendel pr
 Aur0r pr
@@ -105,6 +110,7 @@ bonkey pr
 bornio pr
 BoweyLou pr
 boyleryan pr
+BppAur pr
 BradferdT pr
 bradhallett pr
 brandonskane pr
@@ -192,6 +198,7 @@ davidandrewsmith90 pr
 davidarce pr
 davidgovea pr
 davidmansaray pr
+davidrd123 pr
 DavidSchargel pr
 DavidWells pr
 dayvough pr
@@ -202,6 +209,7 @@ desaikarna pr
 designerbjk pr
 devdotbo pr
 dhamaniasad pr
+diegolanda pr
 dillycone pr
 dimifontaine pr
 dineshmatta pr
@@ -230,6 +238,7 @@ eclipsology pr
 eddiekollar pr
 eichert12 pr
 emigal pr
+emil pr
 EmilMN pr
 Empedoclez pr
 ENY66 pr
@@ -239,6 +248,7 @@ erauner12 pr
 erikdrouhard pr
 erodriguezh pr
 ethan-wickstrom pr
+eugene1g pr
 eugenepyvovarov pr
 everjose pr
 FalconEdi pr
@@ -323,6 +333,7 @@ iguit0 pr
 iieedndb pr
 IkechukwuAbuah pr
 ilyannn pr
+imnoahd pr
 internetoftim pr
 ipapandinas pr
 ipruning pr
@@ -368,6 +379,7 @@ jmaartenson pr
 jmdfm pr
 Jmeg8r pr
 jmslagle pr
+jnennis pr
 joedevon pr
 JoelHarlander pr
 JohanM-er pr
@@ -452,6 +464,7 @@ mcdargh pr
 mdulghier pr
 mefengl pr
 mejiasd3v pr
+mendelgold220 pr
 mertdumenci pr
 mewkung99 pr
 michaelbiven pr
@@ -472,6 +485,7 @@ moonray pr
 moradology pr
 morluto pr
 mplibunao pr
+mr-oakley pr
 mrbagels pr
 mrruby pr
 MSadauskas pr
@@ -518,6 +532,7 @@ OmarAlShishani pr
 Omoeba pr
 optixailusion pr
 owa1da pr
+p-c-mo pr
 patriciomassaro pr
 pauloelias pr
 pavelklymenko pr
@@ -606,6 +621,7 @@ SiTaggart pr
 sivash-922 pr
 skovtunenko pr
 slashjul pr
+slavakurilyak pr
 slkiser pr
 smat-dev pr
 sodiumsun pr
@@ -723,6 +739,7 @@ yerffejytnac pr
 yihuikhuu pr
 Yip-Yip pr
 yjsoon pr
+yoshua0x pr
 youqad pr
 yourDomainAdmin pr
 yug105 pr


### PR DESCRIPTION
## Summary
- Refresh `.github/APPROVED_CONTRIBUTORS` from live customer claims.
- Previous contributor count: 738
- New contributor count: 755
- Live valid GitHub users resolved this run: 752
- Preserved existing-only entries to avoid deletions: 3

## Unresolved claim-form GitHub IDs
- `TeamLandiLTD` (`Organization`, not a user)
- `Tyschultz7` (`not_found`)
- `ahafonof` (`not_found`)
- `hsinskip` (`not_found`)

## Validation
- `make guardrails`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh commit`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh push`
