### PR TITLE
fix(claude-code): emit CLI identity preamble for GLM/z.ai backend

### DIFF
--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/ClaudeCode/SDK/ClaudeNativeProcessSessionController.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/ClaudeCode/SDK/ClaudeNativeProcessSessionController.swift
@@ -1640,7 +1640,7 @@ final actor ClaudeNativeProcessSessionController {
             Self.buildSetPermissionModeRequest(permissionMode: permissionMode ?? config.permissionMode)
         }
 
-        /// Build CLI arguments for testing (verifies prompt flags are absent).
+        /// Build CLI arguments for testing.
         func test_buildArguments(
             existingSessionID: String?,
             model: String?
@@ -1893,6 +1893,15 @@ final actor ClaudeNativeProcessSessionController {
         return (stream, continuation)
     }
 
+    /// Non-empty system-prompt suffix that makes the CLI emit its interactive `You are Claude Code…`
+    /// identity preamble instead of the Agent SDK `You are a Claude agent…` form. z.ai (GLM)
+    /// selectively rejects the Agent SDK self-identification under peak load with a misleading 529
+    /// `overloaded` that exhausts the CLI's retry budget and fails the run; the interactive form is
+    /// never shed. Empty/whitespace-only values are ignored by the CLI, so this must be a real token,
+    /// and it deliberately avoids the trigger words ("Claude"/"Anthropic"/"agent"/"SDK") so it cannot
+    /// reintroduce the shedding. See https://github.com/repoprompt/repoprompt-ce/issues/295.
+    private static let glmZAIAppendSystemPrompt = "Running within RepoPrompt CE."
+
     private func buildArguments(
         existingSessionID: String?,
         model: String?
@@ -1905,6 +1914,12 @@ final actor ClaudeNativeProcessSessionController {
         ]
 
         args.append(contentsOf: ["--permission-prompt-tool", "stdio"])
+
+        // GLM/z.ai sheds requests carrying the Agent SDK identity preamble under load (see #295).
+        // Any non-empty --append-system-prompt flips the CLI onto the never-shed "Claude Code" preamble.
+        if config.runtimeVariant == .glm {
+            args.append(contentsOf: ["--append-system-prompt", Self.glmZAIAppendSystemPrompt])
+        }
 
         if let existingSessionID, !existingSessionID.isEmpty {
             args.append(contentsOf: ["--resume", existingSessionID])

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/ClaudeCode/SDK/ClaudeNativeProcessSessionController.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/ClaudeCode/SDK/ClaudeNativeProcessSessionController.swift
@@ -1640,7 +1640,7 @@ final actor ClaudeNativeProcessSessionController {
             Self.buildSetPermissionModeRequest(permissionMode: permissionMode ?? config.permissionMode)
         }
 
-        /// Build CLI arguments for testing.
+        /// Build CLI arguments for testing (verifies prompt flags are absent).
         func test_buildArguments(
             existingSessionID: String?,
             model: String?

--- a/Tests/RepoPromptTests/AgentMode/ClaudeCompatible/ClaudeNativeIdentityPreambleTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/ClaudeCompatible/ClaudeNativeIdentityPreambleTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+@testable import RepoPrompt
+import XCTest
+
+/// Regression coverage for the GLM/z.ai identity-preamble fix (issue #295).
+///
+/// z.ai selectively rejects requests whose system prompt carries the Claude Agent SDK identity
+/// preamble ("You are a Claude agent, built on Anthropic's Claude Agent SDK.") under peak load,
+/// returning a misleading 529. Passing a non-empty `--append-system-prompt` makes the CLI emit the
+/// never-shed "You are Claude Code…" preamble instead. These tests lock that behavior and its scope.
+///
+/// Layer note: a unit test over the process-exec trust boundary (the CLI args RPCE spawns `claude`
+/// with). The deeper guarantee — that the value actually flips block 1 to the CLI preamble — depends
+/// on the real `claude` binary and is verified as a local capture-proxy diagnostic, not a committed
+/// test, since it requires the binary and live credentials.
+final class ClaudeNativeIdentityPreambleTests: XCTestCase {
+    private func makeController(variant: ClaudeCodeRuntimeVariant) -> ClaudeNativeProcessSessionController {
+        // buildArguments' append logic keys only on `runtimeVariant`; the other fields .agentMode
+        // derives from UserDefaults do not affect the assertions below.
+        ClaudeNativeProcessSessionController(
+            runID: UUID(),
+            tabID: UUID(),
+            windowID: 1,
+            workspacePath: nil,
+            config: .agentMode(modelString: nil, runtimeVariant: variant)
+        )
+    }
+
+    func testGLMVariantAppendsIdentityPreambleFlagWithValidValue() async throws {
+        // Defect guarded: dropping the gate, mis-scoping it, or using an empty/trigger-word value
+        // re-exposes GLM runs to z.ai's 529 shedding under peak load (issue #295).
+        let controller = makeController(variant: .glm)
+        let args = await controller.test_buildArguments(existingSessionID: nil, model: nil)
+
+        let flagIndex = try XCTUnwrap(
+            args.firstIndex(of: "--append-system-prompt"),
+            "expected --append-system-prompt for GLM variant, got: \(args)"
+        )
+        let value = args[args.index(after: flagIndex)]
+
+        // Empty/whitespace is ignored by the CLI and would NOT flip the preamble.
+        XCTAssertFalse(
+            value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+            "--append-system-prompt value must be non-empty, got: \(value)"
+        )
+        // Heuristic proxy for "won't reintroduce shedding": the value must avoid the SDK identity
+        // trigger words. (The exact, binary-dependent proof is the local capture diagnostic.)
+        let lowered = value.lowercased()
+        XCTAssertNil(
+            ["claude", "anthropic", "agent", "sdk"].first { lowered.contains($0) },
+            "--append-system-prompt value must not contain an SDK identity trigger word, got: \(value)"
+        )
+    }
+
+    func testNonGLMVariantsDoNotAppendIdentityPreambleFlag() async {
+        // .standard is a hard contract: real-Anthropic usage is never shed and must stay untouched.
+        // .kimi/.customCompatible lock the current GLM-only scope; if they later show the same
+        // symptom, broaden the gate from `.glm` to `!= .standard` and drop those rows here.
+        for variant in [ClaudeCodeRuntimeVariant.standard, .kimi, .customCompatible] {
+            let controller = makeController(variant: variant)
+            let args = await controller.test_buildArguments(existingSessionID: nil, model: nil)
+            XCTAssertFalse(
+                args.contains("--append-system-prompt"),
+                "\(variant) must not append a system prompt, got: \(args)"
+            )
+        }
+    }
+}


### PR DESCRIPTION
Fixes #295.

## Problem

GLM (z.ai) Agent Mode runs frequently fail with `API Error: 529 [1305][The service may be temporarily overloaded…]`, mostly during evening peak hours, while the same models work in an interactive terminal.

## Root cause

This is **not** a timeout or retry-budget issue (both disproven in #295). z.ai's gateway selectively rejects requests whose system prompt carries the Claude Agent SDK identity preamble — `"You are a Claude agent, built on Anthropic's Claude Agent SDK."` — returning a misleading `529 overloaded_error`. RepoPrompt CE launches Claude Code with `--verbose` (required for `--output-format stream-json`), which makes the CLI emit that SDK preamble. Interactive terminal usage emits the never-shed `"You are Claude Code…"` preamble instead.

Proven by A/B capture over a live overload window: byte-identical ~127 KB requests differing only in block 1 were shed with the SDK preamble (16×529, median 1.4 s) and served with the CLI preamble (0×529). Full evidence in #295.

## Fix

Pass `--append-system-prompt` for the `.glm` runtime variant in `ClaudeNativeProcessSessionController.buildArguments`, so the CLI emits the interactive `"You are Claude Code…"` identity preamble (the form z.ai never sheds). Scoped to `.glm` only — real-Anthropic (`.standard`) and the other compatible variants are unchanged.

The value (`"Running within RepoPrompt CE."`) is:
- **non-empty** — an empty/whitespace value is ignored by the CLI and does **not** flip the preamble (verified);
- **free of the trigger words** ("Claude"/"Anthropic"/"agent"/"SDK") so it cannot reintroduce the shedding.

## Testing

- **Unit test** (`ClaudeNativeIdentityPreambleTests`): `.glm` emits the flag with a non-empty, trigger-word-free value; `.standard`/`.kimi`/`.customCompatible` do not. Regression-proven — the `.glm` test fails on the unpatched code (`XCTUnwrap` for the flag) while the negative test passes.
- **Integration check** (capture proxy, the real `claude` CLI + RPCE's exact `buildArguments` output): with the fix, block 1 of the generated system prompt is `"You are Claude Code, Anthropic's official CLI…"`; without it, block 1 is the shed `"You are a Claude agent…"` form. (Run locally; not a committed test since it needs the binary + live credentials.)
