### PR TITLE
Refresh approved contributors

### DIFF
--- a/.github/APPROVED_CONTRIBUTORS
+++ b/.github/APPROVED_CONTRIBUTORS
@@ -449,6 +449,7 @@ malayyka pr
 manansh11 pr
 mancevd pr
 manifoldfrs pr
+manugomez95 pr
 marcisme pr
 marcmagn1 pr
 marcromeyn pr
@@ -563,6 +564,7 @@ Qwantime pr
 radosek pr
 RadRebelSam pr
 rahulxsomething pr
+rameezshuhaib pr
 raphaelluethy pr
 ratulsarna pr
 raydocs pr

--- a/.github/APPROVED_CONTRIBUTORS
+++ b/.github/APPROVED_CONTRIBUTORS
@@ -56,6 +56,7 @@ amit0365 pr
 amittell pr
 amlfi pr
 amogower pr
+anand180 pr
 anderjason pr
 AndreElijah pr
 andrewmunsell pr
@@ -109,6 +110,7 @@ bonkey pr
 bornio pr
 BoweyLou pr
 boyleryan pr
+BppAur pr
 BradferdT pr
 bradhallett pr
 brandonskane pr
@@ -154,6 +156,7 @@ chufucious pr
 ci pr
 cipradu pr
 civvic pr
+cjbyte pr
 clairernovotny pr
 clang194 pr
 clark874 pr
@@ -245,6 +248,7 @@ erauner12 pr
 erikdrouhard pr
 erodriguezh pr
 ethan-wickstrom pr
+eugene1g pr
 eugenepyvovarov pr
 everjose pr
 FalconEdi pr
@@ -329,6 +333,7 @@ iguit0 pr
 iieedndb pr
 IkechukwuAbuah pr
 ilyannn pr
+imnoahd pr
 internetoftim pr
 ipapandinas pr
 ipruning pr
@@ -374,6 +379,7 @@ jmaartenson pr
 jmdfm pr
 Jmeg8r pr
 jmslagle pr
+jnennis pr
 joedevon pr
 JoelHarlander pr
 JohanM-er pr
@@ -428,6 +434,7 @@ lev0a pr
 LevSky22 pr
 lewis4x4 pr
 lionrooter pr
+lisaross pr
 LLMpsycho pr
 loukianos pr
 lucket pr
@@ -595,6 +602,7 @@ sandman187154 pr
 sankara0717 pr
 sanky369 pr
 saqbach pr
+sashabaranov pr
 scathers pr
 scullionw pr
 seamasmc pr
@@ -614,6 +622,7 @@ SiTaggart pr
 sivash-922 pr
 skovtunenko pr
 slashjul pr
+slavakurilyak pr
 slkiser pr
 smat-dev pr
 sodiumsun pr


### PR DESCRIPTION
## Summary
- refresh `.github/APPROVED_CONTRIBUTORS` from live customer claims
- contributor count: 756 -> 758
- preserved existing approved entries that no longer resolve so the refresh does not delete prior additions

## Unresolved claim-form GitHub IDs
- `TeamLandiLTD` (organization account)
- `Tyschultz7` (not found)
- `ahafonof` (not found, existing approved contributor preserved)
- `hsinskip` (not found)
- `woody-chin` (not found)

## Validation
- `make guardrails`
