### PR TITLE
Surface OpenCode empty ACP completions

### DIFF
--- a/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPAgentSessionController.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/ACP/ACPAgentSessionController.swift
@@ -254,6 +254,7 @@ actor ACPAgentSessionController {
     private var pendingRequests: [String: PendingRequest] = [:]
     private var pendingPermissionRequests: [String: PendingPermissionRequest] = [:]
     private var activePromptTurnID: UUID?
+    private var activePromptOpenCodeStderrError: String?
     #if DEBUG
         private var activePromptSessionUpdateCounts: [String: Int] = [:]
         private var activePromptNormalizedStreamCount = 0
@@ -618,7 +619,7 @@ actor ACPAgentSessionController {
                     )
                 }
             #endif
-            emit(.stream(AIStreamResult(type: "error", text: diagnosticMessage)))
+            emit(.stream(AIStreamResult(type: "final_content", text: diagnosticMessage)))
         }
         emit(.stream(messageStopResult(from: response, sessionID: sessionID, stopReason: stopReason)))
         emitTerminal(
@@ -1082,6 +1083,7 @@ actor ACPAgentSessionController {
             else { return }
             stderrLineCount += 1
             lastStderrPreview = Self.truncatedDiagnosticPreview(text)
+            recordActivePromptStderrLine(text)
             diagnose(.stderrLine(text))
             emit(.stream(AIStreamResult(type: "system", text: text)))
         }
@@ -2954,6 +2956,7 @@ actor ACPAgentSessionController {
             activePromptSessionUpdateCounts = [:]
             activePromptNormalizedStreamCount = 0
         #endif
+        activePromptOpenCodeStderrError = nil
         activePromptNormalizedContentCount = 0
         activePromptNormalizedReasoningCount = 0
     }
@@ -3041,15 +3044,18 @@ actor ACPAgentSessionController {
         let outputTokens = intValue(usage?["outputTokens"]) ?? 0
         let totalTokens = intValue(usage?["totalTokens"]) ?? 0
         let stopDescription = stopReason?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false ? stopReason! : "unknown"
+        let stderrDescription = activePromptOpenCodeStderrError.map {
+            " OpenCode stderr reported: \($0)."
+        } ?? ""
         #if DEBUG
             let updateCounts = activePromptSessionUpdateCounts
                 .sorted { $0.key < $1.key }
                 .map { "\($0.key)=\($0.value)" }
                 .joined(separator: ", ")
             let updateDescription = updateCounts.isEmpty ? "none" : updateCounts
-            return "OpenCode ACP completed with stopReason=\(stopDescription) but emitted no assistant content or reasoning chunks. Prompt usage was input=\(inputTokens), output=\(outputTokens), total=\(totalTokens); raw session updates during the prompt: \(updateDescription). RepoPrompt did not receive model text to render."
+            return "OpenCode ACP completed with stopReason=\(stopDescription) but emitted no assistant content or reasoning chunks. Prompt usage was input=\(inputTokens), output=\(outputTokens), total=\(totalTokens); raw session updates during the prompt: \(updateDescription).\(stderrDescription) RepoPrompt did not receive model text to render."
         #else
-            return "OpenCode ACP completed with stopReason=\(stopDescription) but emitted no assistant content or reasoning chunks. Prompt usage was input=\(inputTokens), output=\(outputTokens), total=\(totalTokens). RepoPrompt did not receive model text to render."
+            return "OpenCode ACP completed with stopReason=\(stopDescription) but emitted no assistant content or reasoning chunks. Prompt usage was input=\(inputTokens), output=\(outputTokens), total=\(totalTokens).\(stderrDescription) RepoPrompt did not receive model text to render."
         #endif
     }
 
@@ -3100,6 +3106,79 @@ actor ACPAgentSessionController {
                 break
             }
         }
+    }
+
+    private func recordActivePromptStderrLine(_ line: String) {
+        guard activePromptTurnID != nil,
+              provider.providerID == .openCode
+        else {
+            return
+        }
+
+        let lowercased = line.lowercased()
+        guard lowercased.contains("level=error")
+            || lowercased.contains("stream error")
+            || lowercased.contains("ai_apicallerror")
+        else {
+            return
+        }
+
+        activePromptOpenCodeStderrError = Self.truncatedDiagnosticPreview(
+            Self.openCodeProviderErrorSummary(from: line),
+            limit: 360
+        )
+    }
+
+    private static func openCodeProviderErrorSummary(from stderrLine: String) -> String {
+        for key in ["error.error", "error"] {
+            if let value = shellStyleKeyValue(key, in: stderrLine) {
+                return cleanOpenCodeProviderError(value)
+            }
+        }
+        return truncatedDiagnosticPreview(stderrLine, limit: 360)
+    }
+
+    private static func cleanOpenCodeProviderError(_ value: String) -> String {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        let prefixes = [
+            "AI_APICallError:",
+            "APICallError:"
+        ]
+        for prefix in prefixes where trimmed.hasPrefix(prefix) {
+            return trimmed.dropFirst(prefix.count)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        return trimmed
+    }
+
+    private static func shellStyleKeyValue(_ key: String, in line: String) -> String? {
+        guard let keyRange = line.range(of: "\(key)=") else { return nil }
+        var index = keyRange.upperBound
+        guard index < line.endIndex else { return nil }
+        if line[index] == "\"" {
+            line.formIndex(after: &index)
+            var value = ""
+            var escaped = false
+            while index < line.endIndex {
+                let character = line[index]
+                line.formIndex(after: &index)
+                if escaped {
+                    value.append(character)
+                    escaped = false
+                } else if character == "\\" {
+                    escaped = true
+                } else if character == "\"" {
+                    return value
+                } else {
+                    value.append(character)
+                }
+            }
+            return value.isEmpty ? nil : value
+        }
+
+        let end = line[index...].firstIndex(where: { $0 == " " || $0 == "\t" }) ?? line.endIndex
+        let value = line[index ..< end].trimmingCharacters(in: .whitespacesAndNewlines)
+        return value.isEmpty ? nil : value
     }
 
     #if DEBUG

--- a/Tests/RepoPromptTests/AgentMode/ACPAgentSessionControllerModeConfigTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/ACPAgentSessionControllerModeConfigTests.swift
@@ -640,6 +640,87 @@ final class ACPAgentSessionControllerModeConfigTests: XCTestCase {
         }
     }
 
+    func testOpenCodeEmptySuccessfulPromptEmitsAssistantVisibleDiagnostic() async throws {
+        let fixture = try makeFixture(
+            shape: "modern",
+            extraEnvironment: ["ACP_EMPTY_PROMPT": "1"]
+        )
+        let collectedEvents = LockedACPStreamResults()
+        let events = await fixture.controller.currentEventsStream()
+        let eventTask = Task {
+            for await event in events {
+                switch event {
+                case let .stream(result):
+                    collectedEvents.append(result)
+                case .terminal:
+                    collectedEvents.markTerminal()
+                    return
+                case .approvalRequested, .approvalCancelled:
+                    continue
+                }
+            }
+        }
+        defer { eventTask.cancel() }
+
+        _ = try await fixture.controller.bootstrap()
+        try await fixture.controller.prompt(AgentMessage(userMessage: "Say hello"))
+        try await waitUntil("OpenCode empty prompt terminal event") {
+            collectedEvents.didSeeTerminal
+        }
+        let results = collectedEvents.values
+        await fixture.controller.shutdown()
+
+        let diagnostic = try XCTUnwrap(results.first { $0.type == "final_content" }?.text)
+        XCTAssertTrue(diagnostic.contains("OpenCode ACP completed with stopReason=end_turn"))
+        XCTAssertTrue(diagnostic.contains("emitted no assistant content or reasoning chunks"))
+        XCTAssertTrue(diagnostic.contains("input=0, output=0, total=0"))
+        XCTAssertNil(results.first { $0.type == "error" && $0.text?.contains("OpenCode ACP completed") == true })
+
+        let stop = try XCTUnwrap(results.first { $0.type == "message_stop" })
+        XCTAssertEqual(stop.promptTokens, 0)
+        XCTAssertEqual(stop.completionTokens, 0)
+        XCTAssertEqual(stop.stopReason, "end_turn")
+    }
+
+    func testOpenCodeEmptySuccessfulPromptIncludesPromptTimeStderrError() async throws {
+        let fixture = try makeFixture(
+            shape: "modern",
+            extraEnvironment: [
+                "ACP_EMPTY_PROMPT": "1",
+                "ACP_EMPTY_PROMPT_STDERR": #"timestamp=2026-06-27T15:45:21.351Z level=ERROR run=82912cb3 message="stream error" providerID=zai-coding-plan modelID=glm-5.2 error.error="AI_APICallError: Authentication Failed""#
+            ]
+        )
+        let collectedEvents = LockedACPStreamResults()
+        let events = await fixture.controller.currentEventsStream()
+        let eventTask = Task {
+            for await event in events {
+                switch event {
+                case let .stream(result):
+                    collectedEvents.append(result)
+                case .terminal:
+                    collectedEvents.markTerminal()
+                    return
+                case .approvalRequested, .approvalCancelled:
+                    continue
+                }
+            }
+        }
+        defer { eventTask.cancel() }
+
+        _ = try await fixture.controller.bootstrap()
+        try await fixture.controller.prompt(AgentMessage(userMessage: "Say hello"))
+        try await waitUntil("OpenCode empty prompt terminal event") {
+            collectedEvents.didSeeTerminal
+        }
+        let results = collectedEvents.values
+        await fixture.controller.shutdown()
+
+        let diagnostic = try XCTUnwrap(results.first { $0.type == "final_content" }?.text)
+        XCTAssertTrue(diagnostic.contains("OpenCode ACP completed with stopReason=end_turn"))
+        XCTAssertTrue(diagnostic.contains("OpenCode stderr reported: Authentication Failed."))
+        XCTAssertTrue(diagnostic.contains("RepoPrompt did not receive model text to render."))
+    }
+
     func testTransportTerminationDrainsPromptSettlementWaiters() async throws {
         #if DEBUG
             for termination in TransportTerminationKind.allCases {
@@ -1331,6 +1412,12 @@ final class ACPAgentSessionControllerModeConfigTests: XCTestCase {
             elif method == "session/prompt":
                 if os.environ.get("ACP_HANG_PROMPT") == "1":
                     continue
+                if os.environ.get("ACP_EMPTY_PROMPT") == "1":
+                    stderr_line = os.environ.get("ACP_EMPTY_PROMPT_STDERR")
+                    if stderr_line:
+                        print(stderr_line, file=sys.stderr, flush=True)
+                    respond(request.get("id"), {"stopReason": "end_turn", "usage": {"inputTokens": 0, "outputTokens": 0, "totalTokens": 0}})
+                    continue
                 respond(request.get("id"), {"stopReason": "end_turn", "usage": {"inputTokens": 1, "outputTokens": 1}})
             else:
                 respond(request.get("id"), {})
@@ -1338,6 +1425,36 @@ final class ACPAgentSessionControllerModeConfigTests: XCTestCase {
         try script.write(to: scriptURL, atomically: true, encoding: .utf8)
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: scriptURL.path)
         return scriptURL
+    }
+}
+
+private final class LockedACPStreamResults: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [AIStreamResult] = []
+    private var terminal = false
+
+    var values: [AIStreamResult] {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage
+    }
+
+    var didSeeTerminal: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return terminal
+    }
+
+    func append(_ value: AIStreamResult) {
+        lock.lock()
+        storage.append(value)
+        lock.unlock()
+    }
+
+    func markTerminal() {
+        lock.lock()
+        terminal = true
+        lock.unlock()
     }
 }
 

--- a/Tests/RepoPromptTests/AgentMode/AgentModeMCPWaitEpochTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeMCPWaitEpochTests.swift
@@ -536,6 +536,49 @@ final class AgentModeMCPWaitEpochTests: XCTestCase {
         await viewModel.mcpDeactivateControlContext(sessionID: sessionID, cleanupSessionStore: true)
     }
 
+    func testFinalContentDiagnosticPublishesAsTerminalAssistantTextForMCPWait() async throws {
+        #if DEBUG
+            let viewModel = makeViewModel()
+            let sessionID = UUID()
+            let session = await viewModel.ensureSessionReady(tabID: UUID())
+            _ = viewModel.test_installPersistentSessionBinding(sessionID: sessionID, on: session)
+            try await viewModel.mcpActivateControlContext(
+                forTabID: session.tabID,
+                sessionID: sessionID,
+                originatingConnectionID: nil,
+                startPending: true
+            )
+            await viewModel.prepareMCPWaitTrackingForRunStart(session: session)
+            let runID = UUID()
+            session.selectedAgent = .openCode
+            session.runID = runID
+            session.runState = .running
+            let ownership = session.beginRunAttempt(source: "test.finalContentDiagnostic")
+            let runAttemptID = try XCTUnwrap(session.activeRunAttemptID)
+            let diagnostic = "OpenCode ACP completed with stopReason=end_turn but emitted no assistant content or reasoning chunks."
+
+            await viewModel.test_handleStreamResult(
+                AIStreamResult(type: "final_content", text: diagnostic),
+                session: session,
+                runID: runID,
+                runAttemptID: runAttemptID
+            )
+            viewModel.refreshDerivedTranscriptState(for: session)
+            session.runState = .completed
+
+            let envelope = try XCTUnwrap(viewModel.test_makeTerminalPublicationEnvelope(
+                for: session,
+                ownership: ownership,
+                terminalState: .completed
+            ))
+            XCTAssertEqual(envelope.snapshot.latestAssistantPreview, diagnostic)
+            XCTAssertEqual(envelope.snapshot.asObject()["assistant_text"]?.stringValue, diagnostic)
+            await viewModel.mcpDeactivateControlContext(sessionID: sessionID, cleanupSessionStore: true)
+        #else
+            throw XCTSkip("Stream-result test hook is DEBUG-only.")
+        #endif
+    }
+
     func testStaleTranscriptDoesNotOverrideAuthoritativeSourceWithoutAssistantTail() async throws {
         let viewModel = makeViewModel()
         let sessionID = UUID()


### PR DESCRIPTION
## Summary
- surface OpenCode zero-token empty-success ACP completions as assistant-visible final content instead of silent output
- include prompt-time OpenCode stderr provider errors in the diagnostic when available
- cover MCP wait publication so agent_run wait returns the diagnostic text

Fixes #309.

## Validation
- make dev-test FILTER=ACPAgentSessionControllerModeConfigTests/testOpenCodeEmptySuccessfulPromptIncludesPromptTimeStderrError
- make dev-test FILTER=ACPAgentSessionControllerModeConfigTests
- make dev-test FILTER=AgentModeMCPWaitEpochTests/testFinalContentDiagnosticPublishesAsTerminalAssistantTextForMCPWait
- make dev-lint
- make dev-build
- live debug OpenCode smoke: opencode/big-pickle returned RPCE_309_OPENCODE_DEFAULT_OK
- live debug OpenCode smoke: zai-coding-plan/glm-5.2 returned RPCE_309_OPENCODE_ZAI_OK

## Local root-suite note
- Local make dev-test / push preflight currently fails in unrelated MCPAskOracleWorktreeTests variants around selected path/package source assertions. The touched ACP/OpenCode suites pass in the same runs; focused rerun of one failing MCPAskOracleWorktreeTests case passed. Hosted CI should be treated as authoritative for the clean environment.