### PR TITLE
Collapse nested Agent Mode sidebar threads by default

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+SidebarSessions.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+SidebarSessions.swift
@@ -349,20 +349,56 @@ extension AgentModeViewModel {
 
     func collapsibleSidebarThreadKeys(
         for tabs: [ComposeTabState],
-        currentTabID: UUID?,
+        currentTabID _: UUID?,
         searchText: String,
-        diagnosticSource: String? = nil
+        diagnosticSource _: String? = nil
     ) -> [AgentSidebarThreadKey] {
-        filteredSidebarSessions(
+        guard searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return [] }
+        let rows = sidebarSessions(for: tabs)
+        guard !rows.isEmpty else { return [] }
+        return rows.indices.compactMap { index in
+            let nextIndex = rows.index(after: index)
+            guard nextIndex < rows.endIndex,
+                  rows[nextIndex].depth > rows[index].depth
+            else { return nil }
+            return AgentSidebarThreadKey.key(sessionID: rows[index].sessionID, tabID: rows[index].tabID)
+        }
+    }
+
+    func displaySidebarSessions(
+        for tabs: [ComposeTabState],
+        currentTabID: UUID?,
+        searchText: String? = nil,
+        diagnosticSource: String? = nil
+    ) -> [SidebarSession] {
+        let effectiveSearchText = searchText ?? sessionSidebarSearchText
+        if effectiveSearchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            seedDefaultCollapsedSidebarThreads(
+                for: tabs,
+                currentTabID: currentTabID,
+                diagnosticSource: diagnosticSource.map { "\($0).seedDefaults" } ?? "display.seedDefaults"
+            )
+        }
+        return filteredSidebarSessions(
             for: tabs,
             currentTabID: currentTabID,
-            searchText: searchText,
+            searchText: effectiveSearchText,
             diagnosticSource: diagnosticSource
         )
-        .compactMap { row in
-            guard row.depth == 0, row.hasThreadChildren, let key = row.threadKey else { return nil }
-            return key
-        }
+    }
+
+    private func seedDefaultCollapsedSidebarThreads(
+        for tabs: [ComposeTabState],
+        currentTabID: UUID?,
+        diagnosticSource: String
+    ) {
+        let eligibleKeys = collapsibleSidebarThreadKeys(
+            for: tabs,
+            currentTabID: currentTabID,
+            searchText: "",
+            diagnosticSource: diagnosticSource
+        )
+        ui.sessionSidebar.seedDefaultCollapsedThreads(eligibleKeys: eligibleKeys)
     }
 
     func filteredSidebarSessions(

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+SidebarSessions.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+SidebarSessions.swift
@@ -389,15 +389,18 @@ extension AgentModeViewModel {
 
     private func seedDefaultCollapsedSidebarThreads(
         for tabs: [ComposeTabState],
-        currentTabID: UUID?,
-        diagnosticSource: String
+        currentTabID _: UUID?,
+        diagnosticSource _: String
     ) {
-        let eligibleKeys = collapsibleSidebarThreadKeys(
-            for: tabs,
-            currentTabID: currentTabID,
-            searchText: "",
-            diagnosticSource: diagnosticSource
-        )
+        let rows = sidebarSessions(for: tabs)
+        let eligibleKeys = rows.indices.compactMap { index -> AgentSidebarThreadKey? in
+            let nextIndex = rows.index(after: index)
+            guard rows[index].depth > 0,
+                  nextIndex < rows.endIndex,
+                  rows[nextIndex].depth > rows[index].depth
+            else { return nil }
+            return AgentSidebarThreadKey.key(sessionID: rows[index].sessionID, tabID: rows[index].tabID)
+        }
         ui.sessionSidebar.seedDefaultCollapsedThreads(eligibleKeys: eligibleKeys)
     }
 

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+SidebarUI.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+SidebarUI.swift
@@ -189,7 +189,13 @@ extension AgentModeViewModel {
     }
 
     func expandAllSidebarThreads(for tabs: [ComposeTabState], currentTabID: UUID?) {
-        ui.sessionSidebar.clearCollapsedThreads()
+        let keys = collapsibleSidebarThreadKeys(
+            for: tabs,
+            currentTabID: currentTabID,
+            searchText: "",
+            diagnosticSource: "collapseAllButton.applyExpand"
+        )
+        ui.sessionSidebar.expandAllSidebarThreads(eligibleKeys: keys)
     }
 
     func isSidebarThreadCollapsed(_ key: AgentSidebarThreadKey) -> Bool {

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentSessionSidebarUIStore.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentSessionSidebarUIStore.swift
@@ -4,6 +4,11 @@ struct AgentSessionSidebarSnapshot: Equatable {
     var searchText: String
     var visibleSessionCount: Int
     var collapsedThreadKeys: Set<AgentSidebarThreadKey> = []
+    /// Thread keys that have already received one-shot default collapse handling
+    /// during this view-model lifetime. Explicit user expand/collapse actions
+    /// and Expand All mark keys handled so later renders do not immediately
+    /// re-collapse them by default.
+    var defaultCollapsedThreadKeysHandled: Set<AgentSidebarThreadKey> = []
     /// Per-tab "unseen" run-state attention. Populated when a session's run
     /// transitions to a user-relevant state (completed / failed / waiting) in
     /// the background — i.e. while the user is looking at a different tab —
@@ -39,6 +44,7 @@ final class AgentSessionSidebarUIStore: ObservableObject {
         } else {
             next.collapsedThreadKeys.remove(key)
         }
+        next.defaultCollapsedThreadKeysHandled.insert(key)
         _ = publish(next, eventName: "sessionSidebar.threadCollapse", force: false)
     }
 
@@ -50,6 +56,22 @@ final class AgentSessionSidebarUIStore: ObservableObject {
         var next = snapshot
         next.collapsedThreadKeys.removeAll()
         _ = publish(next, eventName: "sessionSidebar.threadCollapse.clear", force: false)
+    }
+
+    func expandAllSidebarThreads(eligibleKeys: [AgentSidebarThreadKey]) {
+        var next = snapshot
+        next.collapsedThreadKeys.removeAll()
+        next.defaultCollapsedThreadKeysHandled.formUnion(eligibleKeys)
+        _ = publish(next, eventName: "sessionSidebar.threadCollapse.expandAll", force: false)
+    }
+
+    func seedDefaultCollapsedThreads(eligibleKeys: [AgentSidebarThreadKey]) {
+        let newKeys = eligibleKeys.filter { !snapshot.defaultCollapsedThreadKeysHandled.contains($0) }
+        guard !newKeys.isEmpty else { return }
+        var next = snapshot
+        next.collapsedThreadKeys.formUnion(newKeys)
+        next.defaultCollapsedThreadKeysHandled.formUnion(newKeys)
+        _ = publish(next, eventName: "sessionSidebar.threadCollapse.seedDefaults", force: false)
     }
 
     // MARK: - Run-state attention

--- a/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionRows.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionRows.swift
@@ -99,7 +99,7 @@ struct AgentSessionRow: View {
     }
 
     private var showsDisclosureChevron: Bool {
-        threadDepth == 0 && hasThreadChildren && onToggleThreadCollapse != nil
+        hasThreadChildren && onToggleThreadCollapse != nil
     }
 
     private var hiddenCountTooltip: String {
@@ -561,14 +561,10 @@ struct AgentSessionRow: View {
                 .font(.system(size: 10, weight: .bold))
                 .foregroundStyle(Color.red)
                 .accessibilityLabel("Failed in background")
-        } else if threadDepth > 0 {
-            // Sub-agent identity glyph.
-            Image(systemName: "arrow.turn.down.right")
-                .font(.system(size: 11, weight: .semibold))
-                .foregroundStyle(Color.secondary.opacity(0.55))
-                .accessibilityHidden(true)
         } else if showsDisclosureChevron, let onToggleThreadCollapse {
-            // Expandable root identity glyph — tappable disclosure affordance.
+            // Expandable thread identity glyph — tappable disclosure affordance.
+            // Nested expandable rows reuse this status slot instead of drawing
+            // a second leading sub-agent arrow; leaf children keep the arrow.
             // MCP-controlled roots tint the chevron orange when idle so the
             // row still signals "opened by an MCP client" without needing a
             // dedicated leading rail.
@@ -591,6 +587,12 @@ struct AgentSessionRow: View {
             .onHover { isDisclosureHovered = $0 }
             .hoverTooltip(disclosureAccessibilityLabel)
             .accessibilityLabel(disclosureAccessibilityLabel)
+        } else if threadDepth > 0 {
+            // Leaf sub-agent identity glyph.
+            Image(systemName: "arrow.turn.down.right")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(Color.secondary.opacity(0.55))
+                .accessibilityHidden(true)
         } else if isMCPControlledRoot {
             // MCP-controlled leaf root — keeps the existing anchor-dot
             // design but recolors it orange and bumps the size a hair so

--- a/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionsSidebarView.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionsSidebarView.swift
@@ -317,7 +317,7 @@ struct AgentModeSessionsListView: View {
             let snapshotStartMS = AgentModePerfDiagnostics.timestampMSIfEnabled()
         #endif
         let sidebarSnapshot = sidebarUI.snapshot
-        let filteredSessions = agentModeVM.filteredSidebarSessions(
+        let filteredSessions = agentModeVM.displaySidebarSessions(
             for: promptManager.currentComposeTabs,
             currentTabID: currentTabID,
             searchText: sidebarSnapshot.searchText,

--- a/Tests/RepoPromptTests/AgentMode/AgentModeViewModelInactiveRefreshTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeViewModelInactiveRefreshTests.swift
@@ -927,6 +927,89 @@ final class AgentModeViewModelInactiveRefreshTests: XCTestCase {
         XCTAssertEqual(rows.map(\.depth), [0, 1, 2])
     }
 
+    func testNestedSidebarThreadsDefaultCollapseAndPreserveSearchActiveAndExpandAll() async throws {
+        let viewModel = makeViewModel()
+        let rootTabID = UUID()
+        let childTabID = UUID()
+        let grandchildTabID = UUID()
+        let rootSessionID = UUID()
+        let childSessionID = UUID()
+        let grandchildSessionID = UUID()
+        let tabs = [
+            ComposeTabState(id: rootTabID, name: "Root", activeAgentSessionID: rootSessionID),
+            ComposeTabState(id: childTabID, name: "Child", activeAgentSessionID: childSessionID),
+            ComposeTabState(id: grandchildTabID, name: "Grandchild", activeAgentSessionID: grandchildSessionID)
+        ]
+        let entries = [
+            makeIndexEntry(id: rootSessionID, tabID: rootTabID),
+            makeIndexEntry(id: childSessionID, tabID: childTabID, parentSessionID: rootSessionID),
+            makeIndexEntry(id: grandchildSessionID, tabID: grandchildTabID, parentSessionID: childSessionID)
+        ]
+        let gate = SidebarIndexStreamGate()
+        let harness = SidebarIndexStreamHarness(plans: [
+            .init(batches: [makeBatch(entries)], gate: gate)
+        ])
+        installSidebarIndexHarness(harness, on: viewModel)
+        let workspace = makeWorkspace(name: "Nested sidebar", tabs: tabs, activeTabID: rootTabID)
+        let owner = viewModel.test_receiveWorkspaceSwitchNotification(workspace)
+        await viewModel.test_handleWorkspaceSwitch(workspace, owner: owner)
+        await harness.waitForRequestCount(1)
+        await gate.release()
+        await viewModel.test_waitForSessionListCacheRefresh()
+        try await waitUntil {
+            Set(viewModel.test_ownerValidatedSessionIndex.keys) == [rootSessionID, childSessionID, grandchildSessionID]
+        }
+
+        let rootKey = AgentSidebarThreadKey.session(rootSessionID)
+        let childKey = AgentSidebarThreadKey.session(childSessionID)
+        XCTAssertEqual(
+            Set(viewModel.collapsibleSidebarThreadKeys(
+                for: tabs,
+                currentTabID: rootTabID,
+                searchText: ""
+            )),
+            [rootKey, childKey]
+        )
+
+        let initialRows = viewModel.displaySidebarSessions(
+            for: tabs,
+            currentTabID: rootTabID,
+            searchText: ""
+        )
+        XCTAssertEqual(initialRows.map(\.tabID), [rootTabID])
+        XCTAssertEqual(initialRows.first?.isThreadCollapsed, true)
+        XCTAssertEqual(initialRows.first?.hiddenThreadDescendantCount, 2)
+        XCTAssertEqual(viewModel.ui.sessionSidebar.snapshot.collapsedThreadKeys, [rootKey, childKey])
+
+        let activeGrandchildRows = viewModel.displaySidebarSessions(
+            for: tabs,
+            currentTabID: grandchildTabID,
+            searchText: ""
+        )
+        XCTAssertEqual(activeGrandchildRows.map(\.tabID), [rootTabID, childTabID, grandchildTabID])
+        XCTAssertEqual(activeGrandchildRows.map(\.isThreadCollapsed), [false, false, false])
+
+        let searchRows = viewModel.displaySidebarSessions(
+            for: tabs,
+            currentTabID: rootTabID,
+            searchText: "Grandchild"
+        )
+        XCTAssertEqual(searchRows.map(\.tabID), [rootTabID, childTabID, grandchildTabID])
+        XCTAssertEqual(searchRows.map(\.isThreadCollapsed), [false, false, false])
+
+        viewModel.expandAllSidebarThreads(for: tabs, currentTabID: rootTabID)
+        XCTAssertTrue(viewModel.ui.sessionSidebar.snapshot.collapsedThreadKeys.isEmpty)
+        let expandedRows = viewModel.displaySidebarSessions(
+            for: tabs,
+            currentTabID: rootTabID,
+            searchText: ""
+        )
+        XCTAssertEqual(expandedRows.map(\.tabID), [rootTabID, childTabID, grandchildTabID])
+
+        viewModel.collapseAllSidebarThreads(for: tabs, currentTabID: rootTabID)
+        XCTAssertEqual(viewModel.ui.sessionSidebar.snapshot.collapsedThreadKeys, [rootKey, childKey])
+    }
+
     func testConflictingBindingStartsSuccessorRefresh() async throws {
         let viewModel = makeViewModel()
         let tabID = UUID()

--- a/Tests/RepoPromptTests/AgentMode/AgentModeViewModelInactiveRefreshTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeViewModelInactiveRefreshTests.swift
@@ -976,10 +976,10 @@ final class AgentModeViewModelInactiveRefreshTests: XCTestCase {
             currentTabID: rootTabID,
             searchText: ""
         )
-        XCTAssertEqual(initialRows.map(\.tabID), [rootTabID])
-        XCTAssertEqual(initialRows.first?.isThreadCollapsed, true)
-        XCTAssertEqual(initialRows.first?.hiddenThreadDescendantCount, 2)
-        XCTAssertEqual(viewModel.ui.sessionSidebar.snapshot.collapsedThreadKeys, [rootKey, childKey])
+        XCTAssertEqual(initialRows.map(\.tabID), [rootTabID, childTabID])
+        XCTAssertEqual(initialRows.map(\.isThreadCollapsed), [false, true])
+        XCTAssertEqual(initialRows.map(\.hiddenThreadDescendantCount), [0, 1])
+        XCTAssertEqual(viewModel.ui.sessionSidebar.snapshot.collapsedThreadKeys, [childKey])
 
         let activeGrandchildRows = viewModel.displaySidebarSessions(
             for: tabs,
@@ -999,6 +999,10 @@ final class AgentModeViewModelInactiveRefreshTests: XCTestCase {
 
         viewModel.expandAllSidebarThreads(for: tabs, currentTabID: rootTabID)
         XCTAssertTrue(viewModel.ui.sessionSidebar.snapshot.collapsedThreadKeys.isEmpty)
+        XCTAssertEqual(
+            viewModel.ui.sessionSidebar.snapshot.defaultCollapsedThreadKeysHandled,
+            [rootKey, childKey]
+        )
         let expandedRows = viewModel.displaySidebarSessions(
             for: tabs,
             currentTabID: rootTabID,

--- a/Tests/RepoPromptTests/AgentMode/AgentSessionSidebarUIStoreTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentSessionSidebarUIStoreTests.swift
@@ -1,0 +1,39 @@
+@testable import RepoPrompt
+import XCTest
+
+@MainActor
+final class AgentSessionSidebarUIStoreTests: XCTestCase {
+    func testDefaultCollapseSeedingIsOneShotAndPreservesUserIntent() {
+        let store = AgentSessionSidebarUIStore()
+        let root = AgentSidebarThreadKey.session(id(1))
+        let nested = AgentSidebarThreadKey.session(id(2))
+        let later = AgentSidebarThreadKey.session(id(3))
+
+        store.seedDefaultCollapsedThreads(eligibleKeys: [root, nested])
+        XCTAssertEqual(store.snapshot.collapsedThreadKeys, [root, nested])
+        XCTAssertEqual(store.snapshot.defaultCollapsedThreadKeysHandled, [root, nested])
+
+        store.setThreadCollapsed(false, for: nested)
+        XCTAssertEqual(store.snapshot.collapsedThreadKeys, [root])
+        XCTAssertTrue(store.snapshot.defaultCollapsedThreadKeysHandled.contains(nested))
+
+        store.seedDefaultCollapsedThreads(eligibleKeys: [root, nested])
+        XCTAssertEqual(store.snapshot.collapsedThreadKeys, [root])
+
+        store.expandAllSidebarThreads(eligibleKeys: [root, nested])
+        XCTAssertTrue(store.snapshot.collapsedThreadKeys.isEmpty)
+        XCTAssertEqual(store.snapshot.defaultCollapsedThreadKeysHandled, [root, nested])
+
+        store.seedDefaultCollapsedThreads(eligibleKeys: [root, nested])
+        XCTAssertTrue(store.snapshot.collapsedThreadKeys.isEmpty)
+
+        store.seedDefaultCollapsedThreads(eligibleKeys: [root, nested, later])
+        XCTAssertEqual(store.snapshot.collapsedThreadKeys, [later])
+        XCTAssertEqual(store.snapshot.defaultCollapsedThreadKeysHandled, [root, nested, later])
+    }
+
+    private func id(_ value: Int) -> UUID {
+        let suffix = String(format: "%012d", value)
+        return UUID(uuidString: "00000000-0000-0000-0000-\(suffix)")!
+    }
+}


### PR DESCRIPTION
- default-collapse only nested Agent Mode sidebar thread parents on the normal display path
- keep top-level/root parent threads expanded by default while still generally collapsible
- preserve user intent for explicit expand/collapse and Expand All
- allow nested parent rows to use the existing glyph slot for disclosure without duplicate arrows
- add focused store and view-model regression coverage

Fixes #279

## Validation

Passed:

- `.agents/skills/rpce-contribution-check/scripts/preflight.sh commit`
- `make dev-format`
- `make dev-test FILTER=AgentSessionSidebarUIStoreTests`
- `make dev-test FILTER=AgentModeViewModelInactiveRefreshTests/testNestedSidebarThreadsDefaultCollapseAndPreserveSearchActiveAndExpandAll`
- `make dev-lint`
- `make dev-smoke`
- `make dev-swift-build PRODUCT=RepoPrompt` via earlier push preflight

Notes:

- Push preflight guardrails, secret scans, and lint passed.
- A full `make dev-test` passed earlier before branch repair.
- Repeated full-suite push-preflight retries later failed in unrelated long-running Agent/MCP/worktree integration tests, most recently `AgentModeWorkspaceSwitchCleanupTests/testDetachedMCPTeardownDoesNotDeactivateNewLiveControlContextWithSameSessionID`. Focused tests for this PR's changed behavior passed.


```
Root parent                 expanded by default
  Leaf child                visible
  Nested parent             collapsed by default
    Grandchild              hidden until nested parent expands
```