### PR TITLE
fix: omit nil Codex service tier

### DIFF
--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexNativeSessionController.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexNativeSessionController.swift
@@ -1102,7 +1102,7 @@ final class CodexNativeSessionController {
                 if let reasoningEffort {
                     params["effort"] = reasoningEffort
                 }
-                params["serviceTier"] = serviceTier ?? NSNull()
+                Self.addServiceTier(serviceTier, to: &params)
                 if let workspacePath {
                     params["cwd"] = workspacePath
                 }
@@ -1131,7 +1131,7 @@ final class CodexNativeSessionController {
                 if let reasoningEffort {
                     params["effort"] = reasoningEffort
                 }
-                params["serviceTier"] = serviceTier ?? NSNull()
+                Self.addServiceTier(serviceTier, to: &params)
                 if let workspacePath {
                     params["cwd"] = workspacePath
                 }
@@ -1333,7 +1333,7 @@ final class CodexNativeSessionController {
         if let reasoningEffort {
             params["effort"] = reasoningEffort
         }
-        params["serviceTier"] = serviceTier ?? NSNull()
+        Self.addServiceTier(serviceTier, to: &params)
         if let workspacePath {
             params["cwd"] = workspacePath
         }
@@ -7897,6 +7897,12 @@ final class CodexNativeSessionController {
             }
         }
         return nil
+    }
+
+    private static func addServiceTier(_ serviceTier: String?, to params: inout [String: Any]) {
+        guard let serviceTier = serviceTier?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !serviceTier.isEmpty else { return }
+        params["serviceTier"] = serviceTier
     }
 
     static func appServerTurnSandboxPolicyPayload(


### PR DESCRIPTION
## Summary
- omit `serviceTier` from Codex app-server `thread/start`, `thread/resume`, and `turn/start` payloads when no explicit tier is selected
- keep explicit non-empty service tiers, trimming whitespace before sending
- add CE regression coverage for nil omission and explicit `fast` propagation

## Validation
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh commit`
- focused `swift test --filter 'CodexNativeSessionControllerGoalConfigTests/testStartAndResumeOmitNilServiceTier|CodexNativeSessionControllerGoalConfigTests/testStartAndResumeSendExplicitServiceTier|CodexNativeSessionControllerTurnDispatchTests/testTurnStartOmitsNilServiceTier|CodexNativeSessionControllerTurnDispatchTests/testTurnStartReturnsProvisionalReceiptWithoutInstallingActiveIdentity'`\n- `.agents/skills/rpce-contribution-check/scripts/preflight.sh push` (includes coordinated lint, full root tests, and `swift build --product RepoPrompt`)\n- `make dev-smoke` attempted; blocked because the CE debug app was not running/MCP unavailable. Did not launch/relaunch visible app without approval.\n\n## Notes\nLatest Codex behavior can treat explicit `serviceTier: null` as standard/default routing intent, which can materialize as unsupported persisted `service_tier = "default"`. This change sends no field for unset service tier instead.