### PR TITLE
Refresh approved contributors

### DIFF
--- a/.github/APPROVED_CONTRIBUTORS
+++ b/.github/APPROVED_CONTRIBUTORS
@@ -56,6 +56,7 @@ amit0365 pr
 amittell pr
 amlfi pr
 amogower pr
+anand180 pr
 anderjason pr
 AndreElijah pr
 andrewmunsell pr
@@ -109,6 +110,7 @@ bonkey pr
 bornio pr
 BoweyLou pr
 boyleryan pr
+BppAur pr
 BradferdT pr
 bradhallett pr
 brandonskane pr
@@ -154,6 +156,7 @@ chufucious pr
 ci pr
 cipradu pr
 civvic pr
+cjbyte pr
 clairernovotny pr
 clang194 pr
 clark874 pr
@@ -245,6 +248,7 @@ erauner12 pr
 erikdrouhard pr
 erodriguezh pr
 ethan-wickstrom pr
+eugene1g pr
 eugenepyvovarov pr
 everjose pr
 FalconEdi pr
@@ -308,6 +312,7 @@ helpimfalling pr
 HendrikReh pr
 henrycarrero pr
 heomin86 pr
+HeroRushGo pr
 heyalchang pr
 hierosir1984 pr
 highlandhodl pr
@@ -329,6 +334,7 @@ iguit0 pr
 iieedndb pr
 IkechukwuAbuah pr
 ilyannn pr
+imnoahd pr
 internetoftim pr
 ipapandinas pr
 ipruning pr
@@ -374,6 +380,7 @@ jmaartenson pr
 jmdfm pr
 Jmeg8r pr
 jmslagle pr
+jnennis pr
 joedevon pr
 JoelHarlander pr
 JohanM-er pr
@@ -428,6 +435,7 @@ lev0a pr
 LevSky22 pr
 lewis4x4 pr
 lionrooter pr
+lisaross pr
 LLMpsycho pr
 loukianos pr
 lucket pr
@@ -442,6 +450,7 @@ malayyka pr
 manansh11 pr
 mancevd pr
 manifoldfrs pr
+manugomez95 pr
 marcisme pr
 marcmagn1 pr
 marcromeyn pr
@@ -556,6 +565,7 @@ Qwantime pr
 radosek pr
 RadRebelSam pr
 rahulxsomething pr
+RameezShuhaib pr
 raphaelluethy pr
 ratulsarna pr
 raydocs pr
@@ -577,6 +587,7 @@ RoeeJ pr
 rohanp2051 pr
 RomainCrz pr
 rondered pr
+Rossnkama pr
 rpalermodrums pr
 rshagiev pr
 rwblackburn pr
@@ -595,6 +606,7 @@ sandman187154 pr
 sankara0717 pr
 sanky369 pr
 saqbach pr
+sashabaranov pr
 scathers pr
 scullionw pr
 seamasmc pr
@@ -614,6 +626,7 @@ SiTaggart pr
 sivash-922 pr
 skovtunenko pr
 slashjul pr
+slavakurilyak pr
 slkiser pr
 smat-dev pr
 sodiumsun pr


### PR DESCRIPTION
## Summary
- Refresh `.github/APPROVED_CONTRIBUTORS` from live customer claims.
- Preserve existing approvals that were no longer claim-resolvable so the refresh stays additive.

## Counts
- Previous contributor count: 747
- New contributor count: 760
- Live claim-backed valid GitHub users: 758

## Unresolved claim-form GitHub IDs
- `TeamLandiLTD` (`Organization`, not a user)
- `Tyschultz7` (`not_found`)
- `ahafonof` (`not_found`, preserved in allowlist)
- `hsinskip` (`not_found`)
- `vchepeli` (`not_found`, preserved in allowlist)
- `woody-chin` (`not_found`)
