### PR TITLE
Fix duplicate validated root scope crash

### DIFF
--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
@@ -2798,25 +2798,59 @@ actor WorkspaceFileContextStore {
             guard !canonicalRoots.isEmpty || !physicalRoots.isEmpty else {
                 return .sessionWorktreeUnavailable(missingPhysicalRootPaths: [])
             }
-            missing = (
-                canonicalRoots.map { ($0, WorkspaceRootKind.primaryWorkspace) }
-                    + physicalRoots.map { ($0, WorkspaceRootKind.sessionWorktree) }
+            missing = validatedSessionRootScopeMissingPaths(
+                canonicalPathsByRootID: validatedRootPathsByID(canonicalRoots),
+                physicalPathsByRootID: validatedRootPathsByID(physicalRoots)
             )
-            .compactMap { expectedRoot, expectedKind in
-                guard let currentRoot = rootStatesByID[expectedRoot.id]?.root,
-                      currentRoot.kind == expectedKind,
-                      currentRoot.standardizedFullPath == expectedRoot.standardizedFullPath
-                else { return expectedRoot.standardizedFullPath }
-                var isDirectory: ObjCBool = false
-                return FileManager.default.fileExists(
-                    atPath: currentRoot.standardizedFullPath,
-                    isDirectory: &isDirectory
-                ) && isDirectory.boolValue ? nil : currentRoot.standardizedFullPath
-            }.sorted()
         }
         return missing.isEmpty
             ? .available
             : .sessionWorktreeUnavailable(missingPhysicalRootPaths: missing)
+    }
+
+    private func validatedRootPathsByID(_ roots: Set<WorkspaceRootRef>) -> [UUID: Set<String>] {
+        roots.reduce(into: [UUID: Set<String>]()) { result, root in
+            result[root.id, default: []].insert(root.standardizedFullPath)
+        }
+    }
+
+    private func validatedSessionRootScopeMissingPaths(
+        canonicalPathsByRootID: [UUID: Set<String>],
+        physicalPathsByRootID: [UUID: Set<String>]
+    ) -> [String] {
+        (
+            canonicalPathsByRootID.map { ($0.key, $0.value, WorkspaceRootKind.primaryWorkspace) }
+                + physicalPathsByRootID.map { ($0.key, $0.value, WorkspaceRootKind.sessionWorktree) }
+        )
+        .flatMap { expectedRootID, expectedPaths, expectedKind -> [String] in
+            let sortedExpectedPaths = expectedPaths.sorted()
+            guard let currentRoot = rootStatesByID[expectedRootID]?.root,
+                  currentRoot.kind == expectedKind,
+                  expectedPaths.contains(currentRoot.standardizedFullPath)
+            else { return sortedExpectedPaths }
+
+            var isDirectory: ObjCBool = false
+            return FileManager.default.fileExists(
+                atPath: currentRoot.standardizedFullPath,
+                isDirectory: &isDirectory
+            ) && isDirectory.boolValue ? [] : [currentRoot.standardizedFullPath]
+        }
+        .sorted()
+    }
+
+    private func validatedRootScopeContains(
+        _ root: WorkspaceRootRecord,
+        canonicalPathsByRootID: [UUID: Set<String>],
+        physicalPathsByRootID: [UUID: Set<String>]
+    ) -> Bool {
+        switch root.kind {
+        case .primaryWorkspace:
+            canonicalPathsByRootID[root.id]?.contains(root.standardizedFullPath) == true
+        case .sessionWorktree:
+            physicalPathsByRootID[root.id]?.contains(root.standardizedFullPath) == true
+        case .workspaceGitData, .supplementalSystem:
+            false
+        }
     }
 
     #if DEBUG
@@ -9172,17 +9206,14 @@ actor WorkspaceFileContextStore {
                 }
             }
         case let .validatedSessionBoundWorkspace(canonicalRoots, physicalRoots):
-            let canonicalByID = Dictionary(uniqueKeysWithValues: canonicalRoots.map { ($0.id, $0) })
-            let physicalByID = Dictionary(uniqueKeysWithValues: physicalRoots.map { ($0.id, $0) })
+            let canonicalPathsByRootID = validatedRootPathsByID(canonicalRoots)
+            let physicalPathsByRootID = validatedRootPathsByID(physicalRoots)
             return allRoots.filter { root in
-                switch root.kind {
-                case .primaryWorkspace:
-                    canonicalByID[root.id]?.standardizedFullPath == root.standardizedFullPath
-                case .sessionWorktree:
-                    physicalByID[root.id]?.standardizedFullPath == root.standardizedFullPath
-                case .workspaceGitData, .supplementalSystem:
-                    false
-                }
+                validatedRootScopeContains(
+                    root,
+                    canonicalPathsByRootID: canonicalPathsByRootID,
+                    physicalPathsByRootID: physicalPathsByRootID
+                )
             }
         }
     }

--- a/Tests/RepoPromptTests/WorkspaceContext/WorkspaceFileContextStoreTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/WorkspaceFileContextStoreTests.swift
@@ -4203,6 +4203,58 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
             XCTAssertEqual(try String(contentsOf: replacementTarget, encoding: .utf8), "replacement")
         }
 
+        func testValidatedSessionScopeToleratesDuplicateRootIDs() async throws {
+            let logicalRoot = try makeTemporaryRoot(name: "DuplicateValidatedLogical")
+            let worktree = try makeTemporaryRoot(name: "DuplicateValidatedWorktree")
+            let staleWorktree = try makeTemporaryRoot(name: "DuplicateValidatedStaleWorktree")
+            try write("logical", to: logicalRoot.appendingPathComponent("Logical.swift"))
+            try write("worktree", to: worktree.appendingPathComponent("Target.swift"))
+            try write("stale", to: staleWorktree.appendingPathComponent("Stale.swift"))
+
+            let store = WorkspaceFileContextStore()
+            let logicalRecord = try await store.loadRoot(path: logicalRoot.path)
+            let worktreeRecord = try await store.loadRoot(path: worktree.path, kind: .sessionWorktree)
+            let scope = WorkspaceLookupRootScope.validatedSessionBoundWorkspace(
+                canonicalRoots: [
+                    WorkspaceRootRef(
+                        id: logicalRecord.id,
+                        name: logicalRecord.name,
+                        fullPath: logicalRecord.standardizedFullPath
+                    )
+                ],
+                physicalRoots: [
+                    WorkspaceRootRef(
+                        id: worktreeRecord.id,
+                        name: worktreeRecord.name,
+                        fullPath: worktreeRecord.standardizedFullPath
+                    ),
+                    WorkspaceRootRef(
+                        id: worktreeRecord.id,
+                        name: worktreeRecord.name,
+                        fullPath: staleWorktree.standardizedFileURL.path
+                    )
+                ]
+            )
+
+            let availability = await store.rootScopeAvailability(scope)
+            let scopedRootIDs = await store.rootRefs(scope: scope).map(\.id)
+            let catalogAccess = await store.searchCatalogAccess(rootScope: scope)
+            let lookup = await store.lookupPath(
+                worktree.appendingPathComponent("Target.swift").path,
+                profile: .mcpRead,
+                rootScope: scope
+            )
+
+            XCTAssertEqual(availability, .available)
+            XCTAssertEqual(scopedRootIDs, [logicalRecord.id, worktreeRecord.id])
+            if case let .available(snapshot) = catalogAccess {
+                XCTAssertEqual(snapshot.roots.map(\.id), [logicalRecord.id, worktreeRecord.id])
+            } else {
+                XCTFail("Expected duplicate refs for the same loaded root to remain available")
+            }
+            XCTAssertEqual(lookup?.file?.rootID, worktreeRecord.id)
+        }
+
         func testSearchCatalogSnapshotCacheEvictsOnlyLeastRecentlyUsedEntryAtCapacity() async {
             let store = WorkspaceFileContextStore()
             let scopes = (0 ... 16).map { index in


### PR DESCRIPTION
Summary:
- Avoid `Dictionary(uniqueKeysWithValues:)` traps for validated session root refs with duplicate UUIDs.
- Keep validated scope matching strict by root ID + current standardized path.
- Add regression coverage for duplicate physical root refs during lookup/catalog access.

Validation:
- `make dev-test FILTER=WorkspaceFileContextStoreTests` PASS.
- `make dev-lint` PASS.
- `make dev-swift-build PRODUCT=RepoPrompt` PASS.
- `git diff --check` PASS.
- `make guardrails` PASS.
- Push preflight full `make dev-test` FAILS outside this change: `AgentOraclePillRoutingTests.testExactInMemoryResolutionUsesUUIDOrShortIDInsteadOfLatestSession` returned nil at lines 119 and 126.