### PR TITLE
feat(telemetry): start telemetry and trace app launch

### DIFF
--- a/Sources/RepoPrompt/App/RepoPromptApp.swift
+++ b/Sources/RepoPrompt/App/RepoPromptApp.swift
@@ -69,6 +69,13 @@ struct RepoPromptApp: App {
         // Avoid process-killing SIGPIPE when the child closes stdin while we're still writing.
         signal(SIGPIPE, SIG_IGN)
 
+        #if REPOPROMPT_SENTRY_ENABLED
+            SentryTelemetryBootstrap.start()
+            SentryTelemetryBootstrap.trace(.appLaunch) {
+                SentryTelemetryBootstrap.addBreadcrumb(.appLifecycle, action: .appInitialized)
+            }
+        #endif
+
         ProcessDebugLogging.log(
             prefix: "MCPStartup",
             "RepoPromptApp.init scheduling ServerNetworkManager.start",
@@ -80,7 +87,14 @@ struct RepoPromptApp: App {
                 "RepoPromptApp.init start task running",
                 flushStdout: true
             )
-            await ServerController.shared.startServer()
+            #if REPOPROMPT_SENTRY_ENABLED
+                await SentryTelemetryBootstrap.traceAsync(.mcpServerStart) {
+                    await ServerController.shared.startServer()
+                    SentryTelemetryBootstrap.addBreadcrumb(.mcpBootstrap, action: .mcpServerStarted)
+                }
+            #else
+                await ServerController.shared.startServer()
+            #endif
         }
 
         if !AppLaunchConfiguration.current.suppressesWindowRestore {


### PR DESCRIPTION
## Summary
The **runtime trigger**: starts telemetry at app launch and traces startup. Behind this PR, the foundation from PR 2 actually runs.

**Stack:** 3/10 · depends on PR 2 · Refs GH-183

## What this changes
- `RepoPromptApp.init`: calls `SentryTelemetryBootstrap.start()`, records the `app.launch` transaction + `app.initialized` breadcrumb, and wraps MCP server startup in an `app.mcp_server.start` transaction with an `mcp.server.started` breadcrumb.

## Business rules
- **Second runtime gate:** `start()` returns early unless a DSN is present (env `REPOPROMPT_SENTRY_DSN` or Info.plist `RepoPromptSentryDSN`). A telemetry-enabled binary with no DSN stays inert.
- `app.launch` is the root transaction and the breadcrumbs become the trail preceding any later crash.

## Key decisions
- All wiring is under `#if REPOPROMPT_SENTRY_ENABLED` with an `#else` that still starts the server unchanged — **launch behavior is byte-identical when telemetry is compiled out.**

## Test plan
- Builds in both modes. ✅ verified.
