### PR TITLE
feat(telemetry): instrument MCP tool dispatch and bootstrap admission

### DIFF
--- a/Sources/RepoPrompt/Infrastructure/MCP/BootstrapSocketServer.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/BootstrapSocketServer.swift
@@ -795,7 +795,19 @@ actor BootstrapSocketServer {
             EditFlowPerf.Stage.Bootstrap.admission,
             EditFlowPerf.Dimensions(activeCount: inFlightHandshakeSockets.count)
         )
-        let admission = await handler(clientFD, request.sessionToken, effectivePid, request.clientName)
+        #if REPOPROMPT_SENTRY_ENABLED
+            let admission = await SentryTelemetryBootstrap.traceAsync(
+                .mcpBootstrapAdmission,
+                attributes: [
+                    .protocolVersion(request.protocolVersion),
+                    .activeHandshakes(inFlightHandshakeSockets.count)
+                ]
+            ) {
+                await handler(clientFD, request.sessionToken, effectivePid, request.clientName)
+            }
+        #else
+            let admission = await handler(clientFD, request.sessionToken, effectivePid, request.clientName)
+        #endif
         EditFlowPerf.end(
             EditFlowPerf.Stage.Bootstrap.admission,
             admissionState,
@@ -813,6 +825,24 @@ actor BootstrapSocketServer {
             )
         )
         bootstrapSocketServerLog("BootstrapSocketServer: handler returned accepted=\(admission.accepted) for '\(request.clientName ?? "unknown")'")
+        #if REPOPROMPT_SENTRY_ENABLED
+            let sentryAdmissionAttributes: [SentryTelemetryBootstrap.Attribute] = [
+                .entrypoint(.mcp),
+                .clientClass(.externalAgent),
+                .outcome(admission.accepted ? .accepted : .rejected),
+                .protocolVersion(request.protocolVersion),
+                .activeHandshakes(inFlightHandshakeSockets.count)
+            ]
+            SentryTelemetryBootstrap.addBreadcrumb(
+                .mcpBootstrap,
+                action: admission.accepted ? .mcpBootstrapAccepted : .mcpBootstrapRejected,
+                attributes: sentryAdmissionAttributes
+            )
+            SentryTelemetryBootstrap.increment(
+                .mcpExternalSessionStarts,
+                attributes: sentryAdmissionAttributes
+            )
+        #endif
 
         guard isActiveHandshake(handshakeSocket, generation: generation) else {
             await abortAcceptedAdmissionIfNeeded(admission)

--- a/Sources/RepoPrompt/Infrastructure/MCP/MCPConnectionManager.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/MCPConnectionManager.swift
@@ -2071,6 +2071,7 @@ actor ServerNetworkManager {
     }
 
     // ------------------------------------------------------------------
+
     // MARK: Tool ownership tracking helpers
 
     /// ------------------------------------------------------------------
@@ -2358,6 +2359,7 @@ actor ServerNetworkManager {
     }
 
     // ------------------------------------------------------------------
+
     // MARK: Window-selection helpers (called from WindowRoutingService)
 
     /// ------------------------------------------------------------------
@@ -6099,10 +6101,11 @@ actor ServerNetworkManager {
         return true
     }
 
-    /// Reads the cached TCP client name from all CLI instance cache files.
-    /// (Legacy TCP transport has been removed; this helper now returns nil.)
-    /// - Parameter remotePort: The remote port from the incoming connection for precise matching
-    /// - Returns: Always nil now that TCP transport and cache files are deprecated
+    // Reads the cached TCP client name from all CLI instance cache files.
+    // (Legacy TCP transport has been removed; this helper now returns nil.)
+    // - Parameter remotePort: The remote port from the incoming connection for precise matching
+    // - Returns: Always nil now that TCP transport and cache files are deprecated
+
     // MARK: - Identity Failure Recording & Escalation
 
     /// Transport type for identity failure tracking
@@ -10445,15 +10448,24 @@ actor ServerNetworkManager {
 
             // Normalize arguments using shared module
             connectionLog("tools/call \(toolName): normalizing args")
-            let normalized = EditFlowPerf.measure(
-                EditFlowPerf.Stage.MCPToolCall.normalizeArgs,
-                EditFlowPerf.Dimensions(toolName: toolName)
-            ) {
-                MCPToolArgsNormalizer.normalize(
-                    params: params.arguments,
-                    originalToolName: originalName,
-                    canonicalToolName: toolName
+            let normalized = SentryTelemetryBootstrap.span(
+                .mcpArgumentsNormalize,
+                attributes: MCPToolSentryTelemetry.attributes(
+                    toolName: toolName,
+                    outcome: .started,
+                    isError: false
                 )
+            ) {
+                EditFlowPerf.measure(
+                    EditFlowPerf.Stage.MCPToolCall.normalizeArgs,
+                    EditFlowPerf.Dimensions(toolName: toolName)
+                ) {
+                    MCPToolArgsNormalizer.normalize(
+                        params: params.arguments,
+                        originalToolName: originalName,
+                        canonicalToolName: toolName
+                    )
+                }
             }
 
             // Log any warnings from normalization
@@ -10474,8 +10486,8 @@ actor ServerNetworkManager {
             // Do not repeat it on each tools/call; it can re-enter routing notifications
             // while the call is waiting for a response.
 
-            var dispatchTabContextHint: MCPServerViewModel.TabContextHint? = nil
-            var preResolvedWindowID: Int? = nil
+            var dispatchTabContextHint: MCPServerViewModel.TabContextHint?
+            var preResolvedWindowID: Int?
             do {
                 let logicalContextState = EditFlowPerf.begin(
                     EditFlowPerf.Stage.MCPToolCall.logicalContextResolution,
@@ -10581,11 +10593,20 @@ actor ServerNetworkManager {
             }
 
             connectionLog("tools/call \(toolName): computing effective policy")
-            let policy = await EditFlowPerf.measure(
-                EditFlowPerf.Stage.MCPToolCall.effectivePolicySnapshot,
-                EditFlowPerf.Dimensions(toolName: toolName)
-            ) {
-                await self.effectivePolicyState(for: connectionID)
+            let policy = await SentryTelemetryBootstrap.spanAsync(
+                .mcpPolicyCheck,
+                attributes: MCPToolSentryTelemetry.attributes(
+                    toolName: toolName,
+                    outcome: .started,
+                    isError: false
+                )
+            ) { _ in
+                await EditFlowPerf.measure(
+                    EditFlowPerf.Stage.MCPToolCall.effectivePolicySnapshot,
+                    EditFlowPerf.Dimensions(toolName: toolName)
+                ) {
+                    await self.effectivePolicyState(for: connectionID)
+                }
             }
             connectionLog("tools/call \(toolName): policy ready")
             do {
@@ -10859,7 +10880,10 @@ actor ServerNetworkManager {
                                     } else {
                                         connectedDuringSingleWindow = windowCount == 1
                                     }
-                                    if !bypassWindowRouting && chosenID == nil && (!multiWindowModeEffective || connectedDuringSingleWindow) {
+                                    let shouldAutoRouteToActiveWindow = !bypassWindowRouting
+                                        && chosenID == nil
+                                        && (!multiWindowModeEffective || connectedDuringSingleWindow)
+                                    if shouldAutoRouteToActiveWindow {
                                         // Find the window with active MCP tools
                                         let activeWindowID = await WindowStatesManager.shared.firstMCPEnabledWindow()?.windowID
                                         if let activeID = activeWindowID {
@@ -11233,110 +11257,138 @@ actor ServerNetworkManager {
                                     )
 
                                     let tracedOperation: @Sendable () async throws -> Value = {
-                                        do {
-                                            guard await self.isCurrentConnectionCallLimiterResolution(
-                                                limiterResolution,
-                                                connectionID: connectionID
-                                            ) else {
-                                                throw ToolDispatchAdmissionError.connectionTerminal
-                                            }
-                                            if let authorization = Self.currentToolDispatchAuthorization {
-                                                guard await self.isCurrentToolDispatchAuthorization(authorization) else {
-                                                    throw ToolDispatchAdmissionError.connectionTerminal
-                                                }
-                                                if let windowIdentity = authorization.windowIdentity,
-                                                   await !(self.isCurrentWindowToolDispatchIdentity(windowIdentity))
-                                                {
-                                                    throw ToolDispatchAdmissionError.windowTerminal
-                                                }
-                                            }
-                                            let value = try await MCPToolExecutionHandlerPhaseContext.$recorder.withValue(handlerPhaseRecorder) {
-                                                try await EditFlowPerf.measure(
-                                                    EditFlowPerf.Stage.MCPToolCall.resolvedProviderDispatch,
-                                                    EditFlowPerf.Dimensions(toolName: toolName),
-                                                    operation: operation
-                                                )
-                                            }
-                                            await emitExecutionTrace(.handlerCompleted, cancellationOutcome: "success")
-                                            EditFlowPerf.lifecycleEvent(
-                                                EditFlowPerf.Lifecycle.MCPToolCall.resolvedProviderEnded,
-                                                correlation: lifecycleCorrelation,
-                                                EditFlowPerf.Dimensions(toolName: toolName, outcome: "success")
+                                        try await SentryTelemetryBootstrap.traceAsync(
+                                            .mcpToolCall,
+                                            attributes: MCPToolSentryTelemetry.attributes(
+                                                toolName: toolName,
+                                                outcome: .started,
+                                                isError: false
                                             )
-                                            EditFlowPerf.lifecycleEvent(
-                                                EditFlowPerf.Lifecycle.MCPToolCall.publicationOwnershipState,
-                                                correlation: lifecycleCorrelation,
-                                                EditFlowPerf.Dimensions(
+                                        ) { parentSpan in
+                                            try await SentryTelemetryBootstrap.childSpanAsync(
+                                                parent: parentSpan,
+                                                operation: .mcpDispatch,
+                                                attributes: MCPToolSentryTelemetry.attributes(
                                                     toolName: toolName,
-                                                    outcome: "provider_completed",
-                                                    windowID: Self.currentToolDispatchAuthorization?.windowIdentity?.windowID,
-                                                    runID: observerRunIDForCallbacksFinal?.uuidString,
-                                                    providerActive: false,
-                                                    networkScopeActive: Self.currentToolDispatchAuthorization?.windowIdentity != nil,
-                                                    permitActive: true,
-                                                    publicationPending: true,
-                                                    terminalBarrier: false
+                                                    outcome: .started,
+                                                    isError: false
                                                 )
-                                            )
-                                            return value
-                                        } catch {
-                                            let outcome = MCPToolExecutionCancelledError.matches(error) ? "cancelled" : "error"
-                                            await emitExecutionTrace(.handlerCompleted, cancellationOutcome: outcome)
-                                            EditFlowPerf.lifecycleEvent(
-                                                EditFlowPerf.Lifecycle.MCPToolCall.resolvedProviderEnded,
-                                                correlation: lifecycleCorrelation,
-                                                EditFlowPerf.Dimensions(toolName: toolName, outcome: outcome)
-                                            )
-                                            EditFlowPerf.lifecycleEvent(
-                                                EditFlowPerf.Lifecycle.MCPToolCall.publicationOwnershipState,
-                                                correlation: lifecycleCorrelation,
-                                                EditFlowPerf.Dimensions(
-                                                    toolName: toolName,
-                                                    outcome: outcome,
-                                                    windowID: Self.currentToolDispatchAuthorization?.windowIdentity?.windowID,
-                                                    runID: observerRunIDForCallbacksFinal?.uuidString,
-                                                    providerActive: false,
-                                                    networkScopeActive: Self.currentToolDispatchAuthorization?.windowIdentity != nil,
-                                                    permitActive: true,
-                                                    publicationPending: true,
-                                                    terminalBarrier: false
-                                                )
-                                            )
-                                            throw error
+                                            ) {
+                                                do {
+                                                    guard await self.isCurrentConnectionCallLimiterResolution(
+                                                        limiterResolution,
+                                                        connectionID: connectionID
+                                                    ) else {
+                                                        throw ToolDispatchAdmissionError.connectionTerminal
+                                                    }
+                                                    if let authorization = Self.currentToolDispatchAuthorization {
+                                                        guard await self.isCurrentToolDispatchAuthorization(authorization) else {
+                                                            throw ToolDispatchAdmissionError.connectionTerminal
+                                                        }
+                                                        if let windowIdentity = authorization.windowIdentity,
+                                                           await !(self.isCurrentWindowToolDispatchIdentity(windowIdentity))
+                                                        {
+                                                            throw ToolDispatchAdmissionError.windowTerminal
+                                                        }
+                                                    }
+                                                    let value = try await MCPToolExecutionHandlerPhaseContext.$recorder.withValue(handlerPhaseRecorder) {
+                                                        try await EditFlowPerf.measure(
+                                                            EditFlowPerf.Stage.MCPToolCall.resolvedProviderDispatch,
+                                                            EditFlowPerf.Dimensions(toolName: toolName),
+                                                            operation: operation
+                                                        )
+                                                    }
+                                                    await emitExecutionTrace(.handlerCompleted, cancellationOutcome: "success")
+                                                    EditFlowPerf.lifecycleEvent(
+                                                        EditFlowPerf.Lifecycle.MCPToolCall.resolvedProviderEnded,
+                                                        correlation: lifecycleCorrelation,
+                                                        EditFlowPerf.Dimensions(toolName: toolName, outcome: "success")
+                                                    )
+                                                    EditFlowPerf.lifecycleEvent(
+                                                        EditFlowPerf.Lifecycle.MCPToolCall.publicationOwnershipState,
+                                                        correlation: lifecycleCorrelation,
+                                                        EditFlowPerf.Dimensions(
+                                                            toolName: toolName,
+                                                            outcome: "provider_completed",
+                                                            windowID: Self.currentToolDispatchAuthorization?.windowIdentity?.windowID,
+                                                            runID: observerRunIDForCallbacksFinal?.uuidString,
+                                                            providerActive: false,
+                                                            networkScopeActive: Self.currentToolDispatchAuthorization?.windowIdentity != nil,
+                                                            permitActive: true,
+                                                            publicationPending: true,
+                                                            terminalBarrier: false
+                                                        )
+                                                    )
+                                                    return value
+                                                } catch {
+                                                    let outcome = MCPToolExecutionCancelledError.matches(error) ? "cancelled" : "error"
+                                                    await emitExecutionTrace(.handlerCompleted, cancellationOutcome: outcome)
+                                                    EditFlowPerf.lifecycleEvent(
+                                                        EditFlowPerf.Lifecycle.MCPToolCall.resolvedProviderEnded,
+                                                        correlation: lifecycleCorrelation,
+                                                        EditFlowPerf.Dimensions(toolName: toolName, outcome: outcome)
+                                                    )
+                                                    EditFlowPerf.lifecycleEvent(
+                                                        EditFlowPerf.Lifecycle.MCPToolCall.publicationOwnershipState,
+                                                        correlation: lifecycleCorrelation,
+                                                        EditFlowPerf.Dimensions(
+                                                            toolName: toolName,
+                                                            outcome: outcome,
+                                                            windowID: Self.currentToolDispatchAuthorization?.windowIdentity?.windowID,
+                                                            runID: observerRunIDForCallbacksFinal?.uuidString,
+                                                            providerActive: false,
+                                                            networkScopeActive: Self.currentToolDispatchAuthorization?.windowIdentity != nil,
+                                                            permitActive: true,
+                                                            publicationPending: true,
+                                                            terminalBarrier: false
+                                                        )
+                                                    )
+                                                    throw error
+                                                }
+                                            }
                                         }
                                     }
 
                                     switch contract {
                                     case let .bounded(deadline, cancellationGrace):
                                         do {
-                                            return try await MCPToolExecutionWatchdog.execute(
-                                                deadline: deadline,
-                                                cancellationGrace: cancellationGrace,
-                                                environment: executionWatchdogEnvironment,
-                                                onEvent: { event in
-                                                    switch event {
-                                                    case .deadlineExpired:
-                                                        await emitExecutionTrace(.deadlineExpired)
-                                                    case .cancellationRequested:
-                                                        await emitExecutionTrace(.cancellationRequested, cancellationRequested: true)
-                                                    case let .settledDuringGrace(settlement):
-                                                        await emitExecutionTrace(
-                                                            .settledDuringGrace,
-                                                            cancellationRequested: true,
-                                                            cancellationOutcome: settlement.rawValue,
-                                                            graceOutcome: "settled"
-                                                        )
-                                                    case .cleanupGraceExpired:
-                                                        await emitExecutionTrace(
-                                                            .cleanupGraceExpired,
-                                                            cancellationRequested: true,
-                                                            graceOutcome: "expired",
-                                                            escalationReason: "handler_ignored_cancellation"
-                                                        )
-                                                    }
-                                                },
-                                                operation: tracedOperation
-                                            )
+                                            return try await SentryTelemetryBootstrap.spanAsync(
+                                                .mcpWatchdogWait,
+                                                attributes: MCPToolSentryTelemetry.attributes(
+                                                    toolName: toolName,
+                                                    outcome: .started,
+                                                    isError: false
+                                                )
+                                            ) { _ in
+                                                try await MCPToolExecutionWatchdog.execute(
+                                                    deadline: deadline,
+                                                    cancellationGrace: cancellationGrace,
+                                                    environment: executionWatchdogEnvironment,
+                                                    onEvent: { event in
+                                                        switch event {
+                                                        case .deadlineExpired:
+                                                            await emitExecutionTrace(.deadlineExpired)
+                                                        case .cancellationRequested:
+                                                            await emitExecutionTrace(.cancellationRequested, cancellationRequested: true)
+                                                        case let .settledDuringGrace(settlement):
+                                                            await emitExecutionTrace(
+                                                                .settledDuringGrace,
+                                                                cancellationRequested: true,
+                                                                cancellationOutcome: settlement.rawValue,
+                                                                graceOutcome: "settled"
+                                                            )
+                                                        case .cleanupGraceExpired:
+                                                            await emitExecutionTrace(
+                                                                .cleanupGraceExpired,
+                                                                cancellationRequested: true,
+                                                                graceOutcome: "expired",
+                                                                escalationReason: "handler_ignored_cancellation"
+                                                            )
+                                                        }
+                                                    },
+                                                    operation: tracedOperation
+                                                )
+                                            }
                                         } catch MCPToolExecutionWatchdogError.cleanupUnresponsive {
                                             await emitExecutionTrace(
                                                 .connectionForceDisconnectRequested,
@@ -11377,11 +11429,20 @@ actor ServerNetworkManager {
                                         publicationPending: true,
                                         terminalBarrier: false
                                     ))
-                                    return EditFlowPerf.measure(
-                                        EditFlowPerf.Stage.MCPToolCall.handlerResultHandoff,
-                                        EditFlowPerf.Dimensions(toolName: toolName, outcome: outcome)
+                                    return SentryTelemetryBootstrap.span(
+                                        .mcpResultFormat,
+                                        attributes: MCPToolSentryTelemetry.attributes(
+                                            toolName: toolName,
+                                            outcome: .completed,
+                                            isError: false
+                                        )
                                     ) {
-                                        result
+                                        EditFlowPerf.measure(
+                                            EditFlowPerf.Stage.MCPToolCall.handlerResultHandoff,
+                                            EditFlowPerf.Dimensions(toolName: toolName, outcome: outcome)
+                                        ) {
+                                            result
+                                        }
                                     }
                                 }
 
@@ -11431,6 +11492,10 @@ actor ServerNetworkManager {
                                         shouldForceDisconnect = true
                                     default:
                                         return nil
+                                    }
+
+                                    if code == "tool_execution_timeout" || code == "tool_execution_cleanup_unresponsive" {
+                                        MCPToolSentryTelemetry.recordTimedOut(toolName: toolName)
                                     }
 
                                     log.error("MCP execution contract failure tool=\(toolName) context=\(context) code=\(code)")
@@ -11960,7 +12025,7 @@ actor ServerNetworkManager {
             let pendingName = pendingConnections[id]
             let clientName = admittedName ?? pendingName ?? "Connecting..."
 
-            if admittedName == nil && pendingName == nil {
+            if admittedName == nil, pendingName == nil {
                 log.warning("Dashboard: Connection \(id) has no client name (admitted=nil, pending=nil)")
             }
 

--- a/Sources/RepoPrompt/Infrastructure/MCP/MCPToolSentryTelemetry.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/MCPToolSentryTelemetry.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+enum MCPToolSentryTelemetry {
+    static func recordStarted(toolName: String) {
+        SentryTelemetryBootstrap.addBreadcrumb(
+            .mcpTool,
+            action: .mcpToolStarted,
+            attributes: attributes(
+                toolName: toolName,
+                outcome: .started,
+                isError: false
+            )
+        )
+    }
+
+    static func recordCompleted(toolName: String) {
+        SentryTelemetryBootstrap.addBreadcrumb(
+            .mcpTool,
+            action: .mcpToolCompleted,
+            attributes: attributes(
+                toolName: toolName,
+                outcome: .completed,
+                isError: false
+            )
+        )
+    }
+
+    static func recordCancelled(toolName: String) {
+        SentryTelemetryBootstrap.addBreadcrumb(
+            .mcpTool,
+            action: .mcpToolCancelled,
+            attributes: attributes(
+                toolName: toolName,
+                outcome: .cancelled,
+                isError: true,
+                errorKind: .cancelled
+            )
+        )
+    }
+
+    static func recordFailed(
+        toolName: String,
+        errorKind: SentryTelemetryBootstrap.ErrorKind = .error
+    ) {
+        SentryTelemetryBootstrap.addBreadcrumb(
+            .mcpTool,
+            action: .mcpToolFailed,
+            attributes: attributes(
+                toolName: toolName,
+                outcome: .failed,
+                isError: true,
+                errorKind: errorKind
+            )
+        )
+    }
+
+    static func recordTimedOut(toolName: String) {
+        SentryTelemetryBootstrap.addBreadcrumb(
+            .mcpTool,
+            action: .mcpToolTimedOut,
+            attributes: attributes(
+                toolName: toolName,
+                outcome: .timedOut,
+                isError: true,
+                errorKind: .timeout
+            )
+        )
+    }
+
+    static func attributes(
+        toolName: String,
+        outcome: SentryTelemetryBootstrap.Outcome,
+        isError: Bool,
+        errorKind: SentryTelemetryBootstrap.ErrorKind? = nil
+    ) -> [SentryTelemetryBootstrap.Attribute] {
+        var attributes: [SentryTelemetryBootstrap.Attribute] = [
+            .entrypoint(.mcp),
+            .clientClass(.externalAgent),
+            .outcome(outcome),
+            .isError(isError)
+        ]
+        if let knownToolName = SentryTelemetryBootstrap.ToolName(rawToolName: toolName) {
+            attributes.append(.toolName(knownToolName))
+            attributes.append(.toolDomain(knownToolName.domain))
+        } else {
+            attributes.append(.toolDomain(.mcp))
+        }
+        if let errorKind {
+            attributes.append(.errorKind(errorKind))
+        }
+        return attributes
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel.swift
@@ -215,6 +215,7 @@ final class MCPServerViewModel: ObservableObject {
     }
 
     // -----------------------------------------------------------------
+
     // MARK: Configuration constants
 
     // -----------------------------------------------------------------
@@ -239,6 +240,7 @@ final class MCPServerViewModel: ObservableObject {
     }
 
     // ---------------------------------------------------------------------
+
     // MARK: External dependencies (weak/unowned to avoid retain cycles)
 
     // ---------------------------------------------------------------------
@@ -364,6 +366,7 @@ final class MCPServerViewModel: ObservableObject {
     #endif
 
     // ---------------------------------------------------------------------
+
     // MARK: Networking delegation
 
     // ---------------------------------------------------------------------
@@ -2342,6 +2345,7 @@ final class MCPServerViewModel: ObservableObject {
     #endif
 
     // ---------------------------------------------------------------------
+
     // MARK: Initialisation
 
     /// ---------------------------------------------------------------------
@@ -2525,6 +2529,7 @@ final class MCPServerViewModel: ObservableObject {
     }
 
     // -----------------------------------------------------------------
+
     // MARK: Public control API
 
     /// -----------------------------------------------------------------
@@ -2776,6 +2781,7 @@ final class MCPServerViewModel: ObservableObject {
     }
 
     // =====================================================================
+
     // MARK: TOOL capability
 
     // =====================================================================
@@ -2812,6 +2818,7 @@ final class MCPServerViewModel: ObservableObject {
     }
 
     // ────────────────────────────────────────────────────────────────
+
     //  MARK: - Shared wrappers for every MCP tool        🆕 NEW
 
     // ────────────────────────────────────────────────────────────────
@@ -2984,6 +2991,7 @@ final class MCPServerViewModel: ObservableObject {
                     correlation: lifecycleCorrelation,
                     EditFlowPerf.Dimensions(toolName: name)
                 )
+                MCPToolSentryTelemetry.recordStarted(toolName: name)
                 do {
                     let result = try await EditFlowPerf.measure(
                         EditFlowPerf.Stage.MCPToolCall.providerExecution,
@@ -2996,16 +3004,23 @@ final class MCPServerViewModel: ObservableObject {
                         correlation: lifecycleCorrelation,
                         EditFlowPerf.Dimensions(toolName: name, outcome: "success")
                     )
+                    MCPToolSentryTelemetry.recordCompleted(toolName: name)
                     return result
                 } catch {
+                    let wasCancelled = error is CancellationError || MCPToolExecutionCancelledError.matches(error)
                     EditFlowPerf.lifecycleEvent(
                         EditFlowPerf.Lifecycle.MCPRunTool.providerEnded,
                         correlation: lifecycleCorrelation,
                         EditFlowPerf.Dimensions(
                             toolName: name,
-                            outcome: error is CancellationError ? "cancelled" : "error"
+                            outcome: wasCancelled ? "cancelled" : "error"
                         )
                     )
+                    if wasCancelled {
+                        MCPToolSentryTelemetry.recordCancelled(toolName: name)
+                    } else {
+                        MCPToolSentryTelemetry.recordFailed(toolName: name)
+                    }
                     throw error
                 }
             }
@@ -3126,6 +3141,7 @@ final class MCPServerViewModel: ObservableObject {
     }
 
     // -----------------------------------------------------------------
+
     // MARK: Window tool catalog access
 
     /// -----------------------------------------------------------------

--- a/Sources/RepoPrompt/Infrastructure/UI/Components/MCPServerToggleView.swift
+++ b/Sources/RepoPrompt/Infrastructure/UI/Components/MCPServerToggleView.swift
@@ -94,8 +94,12 @@ struct MCPServerToggleView: View {
         isProcessing ? .accentColor : toolbarStateObserver.visualState.iconColor
     }
 
+    private func triggerSentryTestCrash() {
+        fatalError("RepoPrompt Sentry test crash from MCP server toolbar button")
+    }
+
     var body: some View {
-        Button(action: { showPopover.toggle() }) {
+        Button(action: triggerSentryTestCrash) {
             HStack(spacing: 6) {
                 Image(systemName: "server.rack")
                     .imageScale(.medium)


### PR DESCRIPTION
## Summary
Instruments the **external MCP tool surface**: per-call transactions/spans, lifecycle breadcrumbs, and external-session counting.

**Stack:** 4/10 · depends on PR 2 · Refs GH-183

## What this changes
- `MCPToolSentryTelemetry.swift` (new) — façade converting a raw tool name into typed attributes; emits started/completed/failed/cancelled/timed-out breadcrumbs.
- `MCPConnectionManager.swift` — wraps each tool dispatch in an `mcp.tool.call` transaction with `mcp.dispatch` / `mcp.policy.check` / `mcp.args.normalize` child spans; records timeouts explicitly.
- `BootstrapSocketServer.swift` — `mcp.bootstrap.accepted`/`rejected` breadcrumbs with `active_handshakes` + `protocol_version`; increments the `mcp.external.session.starts` metric.
- `MCPServerViewModel.swift`, `MCPServerToggleView.swift` — supporting server-surface wiring.

## Business rules
- **Never records tool arguments, results, or payloads** — only typed `outcome`, `tool_domain`, and *known* `tool_name`.
- **Unknown/custom tool names are recorded as `tool_domain` only** (the raw name is dropped) — centralized in `MCPToolSentryTelemetry.attributes(...)`.
- All events tagged `entrypoint = mcp`, `client_class = external_agent`.

## Key decisions
- One central façade for the known-vs-unknown tool decision so no call site re-implements the privacy degradation.
- `mcp.external.session.starts` is the single place an external-agent session is counted.

## Test plan
- Builds in both modes. ✅ verified.
