### PR TITLE
feat(telemetry): instrument file, prompt, selection and apply-edits tools

### DIFF
--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPApplyEditsToolProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPApplyEditsToolProvider.swift
@@ -76,6 +76,15 @@ final class MCPApplyEditsToolProvider: MCPWindowToolProviding {
     }
 
     private func executeApplyEdits(args: [String: Value]) async throws -> EditSummary {
+        try await WorkspaceToolSentryTelemetry.span(
+            operation: .fileEditApply,
+            toolName: .applyEdits
+        ) {
+            try await executeApplyEditsBody(args: args)
+        }
+    }
+
+    private func executeApplyEditsBody(args: [String: Value]) async throws -> EditSummary {
         var requestPath: String? = nil
         do {
             let request = try EditFlowPerf.measure(EditFlowPerf.Stage.ApplyEdits.requestBuild) {

--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPFileToolProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPFileToolProvider.swift
@@ -123,65 +123,74 @@ final class MCPFileToolProvider: MCPWindowToolProviding {
                 required: []
             )
         ) { [self] _, args in
-            try Task.checkCancellation()
-            if await dependencies.promptVM.codeMapsGloballyDisabled {
-                throw MCPError.invalidParams(MCPServerViewModel.codeMapsGloballyDisabledMCPMessage)
+            try await WorkspaceToolSentryTelemetry.span(
+                operation: .codeMapStructure,
+                toolName: .getCodeStructure
+            ) {
+                try await executeGetCodeStructure(args: args)
             }
-            let scope = (args["scope"]?.stringValue ?? "paths").lowercased()
-            let maxResults = max(0, args["max_results"]?.intValue ?? MCPWindowWorkspaceToolHelpers.defaultCodeStructureMaxResults)
-            let metadata = await dependencies.captureRequestMetadata()
-            try Task.checkCancellation()
-            let lookupContext = await dependencies.resolveFileToolLookupContext(metadata)
-            try Task.checkCancellation()
-            _ = await dependencies.promptVM.workspaceFileContextStore.awaitAppliedIngress(rootScope: lookupContext.rootScope)
-            try Task.checkCancellation()
+        }
+    }
 
-            switch scope {
-            case "selected":
-                guard await dependencies.drainReadFileAutoSelection(metadata, .canonicalSelection) == .completed else {
-                    throw CancellationError()
-                }
-                try Task.checkCancellation()
-                let collections = try await dependencies.selectionCollectionsForCurrentTabContext()
-                try Task.checkCancellation()
-                var combined: [WorkspaceFileRecord] = []
-                var seenPaths = Set<String>()
-                for entry in collections.selected {
-                    try Task.checkCancellation()
-                    let abs = entry.file.standardizedFullPath
-                    if seenPaths.insert(abs).inserted { combined.append(entry.file) }
-                }
-                for entry in collections.codemap {
-                    try Task.checkCancellation()
-                    let abs = entry.file.standardizedFullPath
-                    if seenPaths.insert(abs).inserted { combined.append(entry.file) }
-                }
-                let reply = try await dependencies.buildCodeStructureDTO(combined, maxResults, true, lookupContext)
-                try Task.checkCancellation()
-                return try Value(reply)
-            default:
-                guard let rawPaths = args["paths"]?.arrayValue else {
-                    throw MCPError.invalidParams("missing paths (required when scope='paths')")
-                }
-                let paths = rawPaths.compactMap(\.stringValue)
-                guard !paths.isEmpty else {
-                    throw MCPError.invalidParams("paths array cannot be empty")
-                }
-                let lookupRootScope = lookupContext.rootScope
-                let resolvedPaths = lookupContext.translateInputPaths(paths)
-                for path in resolvedPaths {
-                    try Task.checkCancellation()
-                    if let issue = await dependencies.promptVM.workspaceFileContextStore.exactPathResolutionIssue(for: path, kind: .either, rootScope: lookupRootScope) {
-                        throw MCPError.invalidParams(PathResolutionIssueRenderer.message(for: issue))
-                    }
-                }
-                try Task.checkCancellation()
-                let resolvedFiles = try await dependencies.resolveFilesForCodeStructure(resolvedPaths, lookupRootScope)
-                try Task.checkCancellation()
-                let reply = try await dependencies.buildCodeStructureDTO(resolvedFiles, maxResults, false, lookupContext)
-                try Task.checkCancellation()
-                return try Value(reply)
+    private func executeGetCodeStructure(args: [String: Value]) async throws -> Value {
+        try Task.checkCancellation()
+        if await dependencies.promptVM.codeMapsGloballyDisabled {
+            throw MCPError.invalidParams(MCPServerViewModel.codeMapsGloballyDisabledMCPMessage)
+        }
+        let scope = (args["scope"]?.stringValue ?? "paths").lowercased()
+        let maxResults = max(0, args["max_results"]?.intValue ?? MCPWindowWorkspaceToolHelpers.defaultCodeStructureMaxResults)
+        let metadata = await dependencies.captureRequestMetadata()
+        try Task.checkCancellation()
+        let lookupContext = await dependencies.resolveFileToolLookupContext(metadata)
+        try Task.checkCancellation()
+        _ = await dependencies.promptVM.workspaceFileContextStore.awaitAppliedIngress(rootScope: lookupContext.rootScope)
+        try Task.checkCancellation()
+
+        switch scope {
+        case "selected":
+            guard await dependencies.drainReadFileAutoSelection(metadata, .canonicalSelection) == .completed else {
+                throw CancellationError()
             }
+            try Task.checkCancellation()
+            let collections = try await dependencies.selectionCollectionsForCurrentTabContext()
+            try Task.checkCancellation()
+            var combined: [WorkspaceFileRecord] = []
+            var seenPaths = Set<String>()
+            for entry in collections.selected {
+                try Task.checkCancellation()
+                let abs = entry.file.standardizedFullPath
+                if seenPaths.insert(abs).inserted { combined.append(entry.file) }
+            }
+            for entry in collections.codemap {
+                try Task.checkCancellation()
+                let abs = entry.file.standardizedFullPath
+                if seenPaths.insert(abs).inserted { combined.append(entry.file) }
+            }
+            let reply = try await dependencies.buildCodeStructureDTO(combined, maxResults, true, lookupContext)
+            try Task.checkCancellation()
+            return try Value(reply)
+        default:
+            guard let rawPaths = args["paths"]?.arrayValue else {
+                throw MCPError.invalidParams("missing paths (required when scope='paths')")
+            }
+            let paths = rawPaths.compactMap(\.stringValue)
+            guard !paths.isEmpty else {
+                throw MCPError.invalidParams("paths array cannot be empty")
+            }
+            let lookupRootScope = lookupContext.rootScope
+            let resolvedPaths = lookupContext.translateInputPaths(paths)
+            for path in resolvedPaths {
+                try Task.checkCancellation()
+                if let issue = await dependencies.promptVM.workspaceFileContextStore.exactPathResolutionIssue(for: path, kind: .either, rootScope: lookupRootScope) {
+                    throw MCPError.invalidParams(PathResolutionIssueRenderer.message(for: issue))
+                }
+            }
+            try Task.checkCancellation()
+            let resolvedFiles = try await dependencies.resolveFilesForCodeStructure(resolvedPaths, lookupRootScope)
+            try Task.checkCancellation()
+            let reply = try await dependencies.buildCodeStructureDTO(resolvedFiles, maxResults, false, lookupContext)
+            try Task.checkCancellation()
+            return try Value(reply)
         }
     }
 
@@ -321,6 +330,15 @@ final class MCPFileToolProvider: MCPWindowToolProviding {
     }
 
     private func executeReadFile(args: [String: Value]) async throws -> Value {
+        try await WorkspaceToolSentryTelemetry.span(
+            operation: .fileRead,
+            toolName: .readFile
+        ) {
+            try await executeReadFileBody(args: args)
+        }
+    }
+
+    private func executeReadFileBody(args: [String: Value]) async throws -> Value {
         try Task.checkCancellation()
         EditFlowPerf.lifecycleEvent(EditFlowPerf.Lifecycle.ReadFile.providerEntered)
         let providerTotalState = EditFlowPerf.begin(EditFlowPerf.Stage.ReadFile.providerTotal)
@@ -462,17 +480,32 @@ final class MCPFileToolProvider: MCPWindowToolProviding {
                 required: ["pattern"]
             )
         ) { [self] _, args in
-            EditFlowPerf.lifecycleEvent(EditFlowPerf.Lifecycle.Search.providerEntered)
-            let providerTotal = EditFlowPerf.begin(EditFlowPerf.Stage.Search.providerTotal)
-            defer { EditFlowPerf.end(EditFlowPerf.Stage.Search.providerTotal, providerTotal) }
-            let reply = try await executeFileSearch(args: args)
-            try Task.checkCancellation()
-            let value = try EditFlowPerf.measure(EditFlowPerf.Stage.Search.providerValueEncoding) {
-                try Value(reply)
-            }
-            EditFlowPerf.lifecycleEvent(EditFlowPerf.Lifecycle.Search.providerResultReady)
-            return value
+            try await executeFileSearchToolValue(args: args)
         }
+    }
+
+    private func executeFileSearchToolValue(args: [String: Value]) async throws -> Value {
+        EditFlowPerf.lifecycleEvent(EditFlowPerf.Lifecycle.Search.providerEntered)
+        let providerTotal = EditFlowPerf.begin(EditFlowPerf.Stage.Search.providerTotal)
+        defer { EditFlowPerf.end(EditFlowPerf.Stage.Search.providerTotal, providerTotal) }
+        let reply = try await WorkspaceToolSentryTelemetry.span(
+            operation: .workspaceSearch,
+            toolName: .fileSearch,
+            completionAttributes: { reply in
+                [
+                    .resultCount(reply.totalMatches),
+                    .limitHit(reply.limitHit)
+                ]
+            }
+        ) {
+            try await executeFileSearch(args: args)
+        }
+        try Task.checkCancellation()
+        let value = try EditFlowPerf.measure(EditFlowPerf.Stage.Search.providerValueEncoding) {
+            try Value(reply)
+        }
+        EditFlowPerf.lifecycleEvent(EditFlowPerf.Lifecycle.Search.providerResultReady)
+        return value
     }
 
     private func executeFileSearch(args: [String: Value]) async throws -> ToolResultDTOs.SearchResultDTO {

--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPPromptContextToolProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPPromptContextToolProvider.swift
@@ -73,38 +73,47 @@ final class MCPPromptContextToolProvider: MCPWindowToolProviding {
                 required: []
             )
         ) { [self] _, args in
-            let op = (args["op"]?.stringValue ?? "snapshot").trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-            if op != "snapshot" {
-                var forwarded = args
-                forwarded["op"] = .string(op)
-                switch op {
-                case "export", "list_presets", "select_preset":
-                    return try await executePrompt(args: forwarded)
-                default:
-                    throw MCPError.invalidParams("Unsupported workspace_context op '\(op)'. Use snapshot, export, list_presets, or select_preset.")
-                }
+            try await WorkspaceToolSentryTelemetry.span(
+                operation: .promptRender,
+                toolName: .workspaceContext
+            ) {
+                try await executeWorkspaceContext(args: args)
             }
-            let includeArr = args["include"]?.arrayValue?.compactMap { $0.stringValue?.lowercased() } ?? ["prompt", "selection", "code", "tokens"]
-            let display: FilePathDisplay = ((args["path_display"]?.stringValue ?? "relative").lowercased() == "full") ? .full : .relative
-            let overridePreset = try await resolveCopyPresetOverride(args["copy_preset"])
-            let metadata = await dependencies.captureRequestMetadata()
-            guard await dependencies.drainReadFileAutoSelection(metadata, .mirroredSelectionAndMetrics) == .completed else {
-                throw CancellationError()
-            }
-            let lookupContext = await dependencies.resolveFileToolLookupContext(metadata)
-            if includeArr.contains("files") {
-                _ = await dependencies.promptVM.workspaceFileContextStore.awaitAppliedIngress(rootScope: lookupContext.rootScope)
-            }
-            let resolvedTabContext = try await dependencies.resolveTabContextSnapshot(metadata, MCPWindowToolName.workspaceContext, .allowLegacyImplicitRouting)
-            let dto = try await dependencies.buildTabWorkspaceContext(
-                resolvedTabContext.snapshot,
-                Set(includeArr),
-                display,
-                overridePreset,
-                resolvedTabContext.usesActiveTabCompatibility
-            )
-            return try Value(dto)
         }
+    }
+
+    private func executeWorkspaceContext(args: [String: Value]) async throws -> Value {
+        let op = (args["op"]?.stringValue ?? "snapshot").trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if op != "snapshot" {
+            var forwarded = args
+            forwarded["op"] = .string(op)
+            switch op {
+            case "export", "list_presets", "select_preset":
+                return try await executePrompt(args: forwarded)
+            default:
+                throw MCPError.invalidParams("Unsupported workspace_context op '\(op)'. Use snapshot, export, list_presets, or select_preset.")
+            }
+        }
+        let includeArr = args["include"]?.arrayValue?.compactMap { $0.stringValue?.lowercased() } ?? ["prompt", "selection", "code", "tokens"]
+        let display: FilePathDisplay = ((args["path_display"]?.stringValue ?? "relative").lowercased() == "full") ? .full : .relative
+        let overridePreset = try await resolveCopyPresetOverride(args["copy_preset"])
+        let metadata = await dependencies.captureRequestMetadata()
+        guard await dependencies.drainReadFileAutoSelection(metadata, .mirroredSelectionAndMetrics) == .completed else {
+            throw CancellationError()
+        }
+        let lookupContext = await dependencies.resolveFileToolLookupContext(metadata)
+        if includeArr.contains("files") {
+            _ = await dependencies.promptVM.workspaceFileContextStore.awaitAppliedIngress(rootScope: lookupContext.rootScope)
+        }
+        let resolvedTabContext = try await dependencies.resolveTabContextSnapshot(metadata, MCPWindowToolName.workspaceContext, .allowLegacyImplicitRouting)
+        let dto = try await dependencies.buildTabWorkspaceContext(
+            resolvedTabContext.snapshot,
+            Set(includeArr),
+            display,
+            overridePreset,
+            resolvedTabContext.usesActiveTabCompatibility
+        )
+        return try Value(dto)
     }
 
     private func promptTool() -> Tool {
@@ -152,6 +161,15 @@ final class MCPPromptContextToolProvider: MCPWindowToolProviding {
     }
 
     private func executePrompt(args: [String: Value]) async throws -> Value {
+        try await WorkspaceToolSentryTelemetry.span(
+            operation: .promptRender,
+            toolName: .prompt
+        ) {
+            try await executePromptBody(args: args)
+        }
+    }
+
+    private func executePromptBody(args: [String: Value]) async throws -> Value {
         let op = (args["op"]?.stringValue ?? "get").lowercased()
         if op == "list_presets" {
             return try Value(ToolResultDTOs.PromptToolEnvelope.forPresetsList(dependencies.buildCopyPresetsListDTO()))

--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPSelectionToolProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPSelectionToolProvider.swift
@@ -108,15 +108,20 @@ final class MCPSelectionToolProvider: MCPWindowToolProviding {
     }
 
     private func executeManageSelection(args: [String: Value]) async throws -> ToolResultDTOs.SelectionReply {
-        do {
-            return try await executeManageSelectionAttempt(args: args)
-        } catch is ArtifactCommitConflict {
+        try await WorkspaceToolSentryTelemetry.span(
+            operation: .selectionUpdate,
+            toolName: .manageSelection
+        ) {
             do {
                 return try await executeManageSelectionAttempt(args: args)
-            } catch let retryConflict as ArtifactCommitConflict {
-                throw MCPError.internalError(
-                    "Canonical selection changed concurrently (\(retryConflict.reason)). Retry manage_selection."
-                )
+            } catch is ArtifactCommitConflict {
+                do {
+                    return try await executeManageSelectionAttempt(args: args)
+                } catch let retryConflict as ArtifactCommitConflict {
+                    throw MCPError.internalError(
+                        "Canonical selection changed concurrently (\(retryConflict.reason)). Retry manage_selection."
+                    )
+                }
             }
         }
     }

--- a/Sources/RepoPrompt/Infrastructure/MCP/WorkspaceToolSentryTelemetry.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WorkspaceToolSentryTelemetry.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+enum WorkspaceToolSentryTelemetry {
+    static func span<T>(
+        operation: SentryTelemetryBootstrap.SpanOperation,
+        toolName: SentryTelemetryBootstrap.ToolName,
+        completionAttributes: (T) -> [SentryTelemetryBootstrap.Attribute] = { _ in [] },
+        _ work: () async throws -> T
+    ) async rethrows -> T {
+        let attributes = attributes(toolName: toolName, outcome: .started)
+        SentryTelemetryBootstrap.addBreadcrumb(
+            .workspaceTool,
+            action: .mcpToolStarted,
+            attributes: attributes
+        )
+        return try await SentryTelemetryBootstrap.spanAsync(operation, attributes: attributes) { _ in
+            do {
+                let result = try await work()
+                SentryTelemetryBootstrap.addBreadcrumb(
+                    .workspaceTool,
+                    action: .mcpToolCompleted,
+                    attributes: self.attributes(toolName: toolName, outcome: .completed)
+                        + completionAttributes(result)
+                )
+                return result
+            } catch {
+                SentryTelemetryBootstrap.addBreadcrumb(
+                    .workspaceTool,
+                    action: .mcpToolFailed,
+                    attributes: self.attributes(toolName: toolName, outcome: .failed, isError: true)
+                )
+                throw error
+            }
+        }
+    }
+
+    private static func attributes(
+        toolName: SentryTelemetryBootstrap.ToolName,
+        outcome: SentryTelemetryBootstrap.Outcome,
+        isError: Bool = false
+    ) -> [SentryTelemetryBootstrap.Attribute] {
+        [
+            .entrypoint(.mcp),
+            .clientClass(.externalAgent),
+            .toolName(toolName),
+            .toolDomain(toolName.domain),
+            .outcome(outcome),
+            .isError(isError)
+        ]
+    }
+}


### PR DESCRIPTION
## Summary
Instruments the **file / prompt / selection / apply-edits** window tools.

**Stack:** 6/10 · depends on PR 2 · Refs GH-183

## What this changes
- `WorkspaceToolSentryTelemetry.swift` (new) — shared helper for these providers.
- `MCPFileToolProvider.swift` (`file.read`, `file.edit.apply`), `MCPApplyEditsToolProvider.swift`, `MCPPromptContextToolProvider.swift` (`prompt.render`), `MCPSelectionToolProvider.swift` (`selection.update`) — span wrappers around existing work.

## Business rules
- Records counts only (`selection_file_count`, `result_count`) and `cache_hit`.
- **No path, name, file content, prompt text, or edit content** is ever an attribute.

## Key decisions
- A single shared helper keeps the four providers consistent and prevents any provider from inventing a non-allow-listed attribute.

## Test plan
- Builds in both modes. ✅ verified.
