### PR TITLE
feat(telemetry): instrument Codex runtime events and session persistence

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentSessionDataService.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentSessionDataService.swift
@@ -926,18 +926,36 @@ actor AgentSessionDataService {
         let filename = "AgentSession-\(session.id.uuidString).json"
         let fileURL = agentSessionsFolder.appendingPathComponent(filename)
 
-        let sessionToSave = sessionPreparedForStorage(
-            session,
-            fileURL: fileURL,
-            savedAt: Date(),
-            preparation: preparation,
-            trustedCanonicalItemCount: trustedCanonicalItemCount
-        )
-        let freshEncoder = JSONEncoder()
-        let data = try freshEncoder.encode(sessionToSave)
-        try await diskWriter.enqueueAndWait(data: data, url: fileURL)
-        await upsertMetadataRecord(metadataRecord(from: sessionToSave, fileURL: fileURL), folder: agentSessionsFolder)
-        return fileURL
+        AgentSessionPersistenceSentryTelemetry.recordScheduled(session: session)
+        do {
+            return try await SentryTelemetryBootstrap.spanAsync(
+                .agentSessionPersist,
+                attributes: AgentSessionPersistenceSentryTelemetry.attributes(session: session, outcome: .started)
+            ) { parentSpan in
+                let sessionToSave = try await SentryTelemetryBootstrap.childSpanAsync(
+                    parent: parentSpan,
+                    operation: .agentSessionPrepare,
+                    attributes: AgentSessionPersistenceSentryTelemetry.attributes(session: session, outcome: .started)
+                ) {
+                    sessionPreparedForStorage(
+                        session,
+                        fileURL: fileURL,
+                        savedAt: Date(),
+                        preparation: preparation,
+                        trustedCanonicalItemCount: trustedCanonicalItemCount
+                    )
+                }
+                let freshEncoder = JSONEncoder()
+                let data = try freshEncoder.encode(sessionToSave)
+                try await diskWriter.enqueueAndWait(data: data, url: fileURL)
+                await upsertMetadataRecord(metadataRecord(from: sessionToSave, fileURL: fileURL), folder: agentSessionsFolder)
+                AgentSessionPersistenceSentryTelemetry.recordCompleted(session: sessionToSave)
+                return fileURL
+            }
+        } catch {
+            AgentSessionPersistenceSentryTelemetry.recordFailed(session: session)
+            throw error
+        }
     }
 
     func renameAgentSession(

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentSessionPersistenceSentryTelemetry.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentSessionPersistenceSentryTelemetry.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+enum AgentSessionPersistenceSentryTelemetry {
+    static func recordScheduled(session: AgentSession) {
+        SentryTelemetryBootstrap.addBreadcrumb(
+            .persistenceAction,
+            action: .persistenceScheduled,
+            attributes: attributes(session: session, outcome: .started)
+        )
+    }
+
+    static func recordCompleted(session: AgentSession) {
+        SentryTelemetryBootstrap.addBreadcrumb(
+            .persistenceAction,
+            action: .persistenceCompleted,
+            attributes: attributes(session: session, outcome: .completed)
+        )
+    }
+
+    static func recordFailed(session: AgentSession) {
+        SentryTelemetryBootstrap.addBreadcrumb(
+            .persistenceAction,
+            action: .persistenceFailed,
+            attributes: attributes(session: session, outcome: .failed, isError: true)
+        )
+    }
+
+    static func attributes(
+        session: AgentSession,
+        outcome: SentryTelemetryBootstrap.Outcome,
+        isError: Bool = false
+    ) -> [SentryTelemetryBootstrap.Attribute] {
+        var attributes: [SentryTelemetryBootstrap.Attribute] = [
+            .entrypoint(.agent),
+            .clientClass(session.isMCPOriginated ? .externalAgent : .inApp),
+            .outcome(outcome),
+            .isError(isError),
+            .messageCount(session.items.count),
+            .isChildSession(session.parentSessionID != nil),
+            .hasProviderResumeSession(session.providerSessionID != nil)
+        ]
+        if let agentKind = session.agentKind,
+           let providerKind = SentryTelemetryBootstrap.ProviderKind(agentKindRaw: agentKind)
+        {
+            attributes.append(.providerKind(providerKind))
+        }
+        return attributes
+    }
+}

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Codex/CodexAgentModeCoordinator.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Codex/CodexAgentModeCoordinator.swift
@@ -3144,6 +3144,12 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
             session: session,
             urgent: true
         )
+        AgentRunSentryTelemetry.recordRuntimeEvent(
+            session: session,
+            event: .codexStallWarningShown,
+            action: .agentRuntimeStallWarningShown,
+            outcome: .started
+        )
         logCodex("[AgentModeVM][CodexWatchdog] recorded non-rendering stall warning for tab \(session.tabID) reason=\(reason)")
         viewModel?.requestUIRefresh(tabID: session.tabID, urgent: true, scope: .runtimeMetrics)
     }
@@ -3160,6 +3166,12 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
             guard !hasPendingCodexInteraction(for: session) else {
                 return .skipped
             }
+            AgentRunSentryTelemetry.recordRuntimeEvent(
+                session: session,
+                event: .codexStallProbeTriggered,
+                action: .agentRuntimeStallProbeTriggered,
+                outcome: .started
+            )
         }
         guard let runID = session.runID else {
             if trigger == .stallWatchdog {
@@ -3252,10 +3264,25 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
             }
         }
 
+        if trigger == .unexpectedStreamEnd {
+            AgentRunSentryTelemetry.recordProviderError(session: session, kind: .streamEndedUnexpectedly)
+        }
         guard codexRecoveryAttemptedRunIDs.insert(runID).inserted else {
+            AgentRunSentryTelemetry.recordRuntimeEvent(
+                session: session,
+                event: .codexRecoveryFailed,
+                action: .agentRuntimeRecoveryFailed,
+                outcome: .failed
+            )
             return .unrecoverable(recoveryFailureMessage(for: trigger, recoveryAlreadyAttempted: true))
         }
 
+        AgentRunSentryTelemetry.recordRuntimeEvent(
+            session: session,
+            event: .codexRecoveryStarted,
+            action: .agentRuntimeRecoveryStarted,
+            outcome: .started
+        )
         let recoveryStartedAt = Date()
         setRunningStatus("Reconnecting…", source: .reconnect, session: session, urgent: true)
         session.codexLastEventAt = recoveryStartedAt
@@ -3302,6 +3329,12 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
             let alreadyReportedStartFailure = session.items.last.map {
                 $0.kind == .error && Self.isCodexNativeSessionFailureText($0.text)
             } ?? false
+            AgentRunSentryTelemetry.recordRuntimeEvent(
+                session: session,
+                event: .codexRecoveryFailed,
+                action: .agentRuntimeRecoveryFailed,
+                outcome: .failed
+            )
             return .unrecoverable(alreadyReportedStartFailure ? nil : recoveryFailureMessage(for: trigger))
         }
 
@@ -3309,6 +3342,12 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
         session.codexLastEventAt = recoveredAt
         recordCodexWatchdogProgress(for: session, at: recoveredAt)
         updateCodexStallWatchdogState(for: session)
+        AgentRunSentryTelemetry.recordRuntimeEvent(
+            session: session,
+            event: .codexRecoveryRecovered,
+            action: .agentRuntimeRecoveryRecovered,
+            outcome: .completed
+        )
         viewModel?.requestUIRefresh(tabID: session.tabID, urgent: true)
         return .recovered
     }
@@ -3363,6 +3402,7 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
 
         switch await authRecovery.refreshManagedAccount() {
         case let .requiresUserLogin(guidance):
+            AgentRunSentryTelemetry.recordProviderError(session: session, kind: .authRequired)
             _ = markCodexReconnectNeeded(for: session, source: "managed-auth-recovery-required")
             await finalizeCodexRun(
                 session,
@@ -3374,6 +3414,7 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
             )
             return true
         case let .executableUnavailable(message):
+            AgentRunSentryTelemetry.recordProviderError(session: session, kind: .executableUnavailable)
             await finalizeCodexRun(
                 session,
                 turnStatus: .failed,
@@ -3547,7 +3588,15 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
                     trigger: .unexpectedStreamEnd,
                     sourceController: sourceController
                 ) {
-                case .recovered, .skipped:
+                case .recovered:
+                    return
+                case .skipped:
+                    AgentRunSentryTelemetry.recordRuntimeEvent(
+                        session: session,
+                        event: .codexRecoverySkipped,
+                        action: .agentRuntimeRecoverySkipped,
+                        outcome: .cancelled
+                    )
                     return
                 case let .unrecoverable(errorMessage):
                     guard shouldFinalizeAfterRecovery(session: session, expectedRunID: runID, source: "transport-closed-fallback") else { return }
@@ -3806,7 +3855,15 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
                         trigger: .unexpectedStreamEnd,
                         sourceController: controller
                     ) {
-                    case .recovered, .skipped:
+                    case .recovered:
+                        return
+                    case .skipped:
+                        AgentRunSentryTelemetry.recordRuntimeEvent(
+                            session: session,
+                            event: .codexRecoverySkipped,
+                            action: .agentRuntimeRecoverySkipped,
+                            outcome: .cancelled
+                        )
                         return
                     case let .unrecoverable(errorMessage):
                         guard shouldFinalizeAfterRecovery(session: session, expectedRunID: taskRunID, source: "unexpected-stream-end") else { return }
@@ -3961,6 +4018,7 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
             await ensureCodexToolTrackingForReadySessionIfNeeded(for: session, runID: runID)
         } catch {
             var effectiveError: Error = error
+            var providerErrorRecorded = false
             if session.runState.isActive,
                let runID = session.runID,
                CodexManagedAuthRecoveryClassifier.isRecoverable(message: error.localizedDescription),
@@ -3970,9 +4028,13 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
                 viewModel?.requestUIRefresh(tabID: session.tabID, urgent: true)
                 switch await authRecovery.refreshManagedAccount() {
                 case let .requiresUserLogin(guidance):
+                    AgentRunSentryTelemetry.recordProviderError(session: session, kind: .authRequired)
+                    providerErrorRecorded = true
                     _ = markCodexReconnectNeeded(for: session, source: "managed-auth-recovery-required-during-start")
                     effectiveError = AIProviderError.invalidConfiguration(detail: guidance)
                 case let .executableUnavailable(message):
+                    AgentRunSentryTelemetry.recordProviderError(session: session, kind: .executableUnavailable)
+                    providerErrorRecorded = true
                     effectiveError = AIProviderError.invalidConfiguration(detail: message)
                 case .recovered:
                     let expectedController = session.codexController
@@ -4060,6 +4122,7 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
                     await ensureCodexToolTrackingForReadySessionIfNeeded(for: session, runID: runID)
                     return
                 } catch {
+                    AgentRunSentryTelemetry.recordProviderError(session: session, error: error)
                     let invalidatedTimedOutController = CodexAppServerClient.isTimeoutError(error)
                         ? invalidateCodexControllerForReconnect(
                             session: session,
@@ -4093,6 +4156,9 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
                 : false
             if !invalidatedTimedOutController {
                 markCodexReconnectNeeded(for: session, source: "ensure-error")
+            }
+            if !providerErrorRecorded {
+                AgentRunSentryTelemetry.recordProviderError(session: session, error: effectiveError)
             }
             let errorItem = AgentChatItem.error(
                 "\(Self.codexNativeSessionFailurePrefix(attemptedResume: attemptedResume)) \(effectiveError.localizedDescription)",
@@ -6029,6 +6095,13 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
     ) async {
         let isTransportClosed = message.localizedCaseInsensitiveContains("transport closed")
         if isTransportClosed {
+            AgentRunSentryTelemetry.recordRuntimeEvent(
+                session: session,
+                event: .codexTransportClosed,
+                action: .agentRuntimeTransportClosed,
+                outcome: .started
+            )
+            AgentRunSentryTelemetry.recordProviderError(session: session, kind: .transportClosed)
             if !session.runState.isActive {
                 _ = invalidateCodexControllerForReconnect(
                     session: session,
@@ -6056,6 +6129,7 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
             }
             return
         }
+        AgentRunSentryTelemetry.recordProviderError(session: session, kind: .unknown)
         await finalizeCodexRun(
             session,
             turnStatus: .failed,
@@ -7661,7 +7735,7 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
             var updated = session.items[index]
             let isAgentControlTool = AgentTranscriptIO.isAgentControlToolName(updated.toolName)
             let isRepoPromptTool = MCPIntegrationHelper.isRepoPromptToolNameAfterNormalization(updated.toolName)
-            if isRepoPromptTool && !isAgentControlTool {
+            if isRepoPromptTool, !isAgentControlTool {
                 continue
             }
             let agentControlFallback = isAgentControlTool
@@ -7835,6 +7909,12 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
         else {
             return
         }
+        AgentRunSentryTelemetry.recordApprovalDecision(
+            session: session,
+            kind: .toolPermission,
+            outcome: Self.telemetryApprovalOutcome(for: decision),
+            cancellationReason: Self.telemetryCancellationReason(for: decision)
+        )
         let result = Self.buildPermissionsResult(decision: decision, request: request)
         session.pendingPermissionsRequest = nil
         viewModel?.reconcileInteractiveRunState(session)
@@ -7913,6 +7993,24 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
             answers[question.id] = [label]
         }
         return AgentRequestUserInputResponse(answersByQuestionID: answers)
+    }
+
+    private static func telemetryApprovalOutcome(for decision: AgentApprovalDecision) -> SentryTelemetryBootstrap.ApprovalOutcome {
+        switch decision {
+        case .accept, .acceptForSession, .acceptWithExecpolicyAmendment:
+            .approved
+        case .decline, .cancel:
+            .denied
+        }
+    }
+
+    private static func telemetryCancellationReason(for decision: AgentApprovalDecision) -> SentryTelemetryBootstrap.CancellationReason? {
+        switch decision {
+        case .cancel:
+            .user
+        case .accept, .acceptForSession, .acceptWithExecpolicyAmendment, .decline:
+            nil
+        }
     }
 
     private static func buildPermissionsResult(decision: AgentApprovalDecision, request: AgentPermissionsRequest) -> [String: Any] {


### PR DESCRIPTION
## Summary
Instruments **Codex runtime events** and **agent session persistence** — the two small tails of Agent Mode telemetry.

**Stack:** 9/10 · depends on PR 8 (uses `AgentRunSentryTelemetry.recordRuntimeEvent`) · Refs GH-183

## What this changes
- `CodexAgentModeCoordinator.swift` — classifies Codex recovery/stall/transport events into the `RuntimeEvent` enum and provider failures into `ProviderErrorKind`; emits `agent.runtime.*` breadcrumbs + `agent.runtime.events` metric.
- `AgentSessionPersistenceSentryTelemetry.swift` (new) + `AgentSessionDataService.swift` — `agent.session.persist` spans + `persistence.scheduled/completed/failed` breadcrumbs.

## Business rules
- Only typed event kinds and outcomes are recorded — **no transcript, session content, or paths.**

## Key decisions
- Codex events reuse PR 8's `recordRuntimeEvent`, which is why this PR stacks on top of it. Session persistence uses its own helper and is otherwise independent.

## Test plan
- Builds in both modes. ✅ verified.
