### PR TITLE
build(telemetry): generate and upload dSYMs in the release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,10 @@ jobs:
           SOURCE_GITHUB_REPOSITORY: ${{ github.repository }}
           REPOPROMPT_CONTROL_PLANE_SCRIPTS_DIR: ${{ github.workspace }}/trusted-control-plane/Scripts
           REPOPROMPT_RELEASE_SOURCE_ROOT: ${{ github.workspace }}/release-source
+          # Link the Sentry SDK into the official release binary. Release-candidate and local
+          # builds never set this, so they neither download nor compile the SDK. Telemetry stays
+          # inert here regardless — the DSN is only injected later, in the signing step.
+          REPOPROMPT_ENABLE_SENTRY: "1"
         run: ./trusted-control-plane/Scripts/release.sh stage-publish
 
       - name: Upload staged release source
@@ -181,6 +185,15 @@ jobs:
           echo "REPOPROMPT_PROVISIONING_PROFILE=$SECRETS_DIR/repoprompt-ce.provisionprofile" >> "$GITHUB_ENV"
           echo "NOTARYTOOL_PRIVATE_KEY=$SECRETS_DIR/notarytool-private-key.p8" >> "$GITHUB_ENV"
 
+      - name: Install Sentry CLI when symbol upload is configured
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [[ -n "${SENTRY_AUTH_TOKEN:-}" ]] && ! command -v sentry-cli >/dev/null 2>&1; then
+            brew install getsentry/tools/sentry-cli
+          fi
+
       - name: Sign, notarize, and create draft release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -195,6 +208,14 @@ jobs:
           SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
           NOTARYTOOL_KEY_ID: ${{ secrets.NOTARYTOOL_KEY_ID }}
           NOTARYTOOL_ISSUER_ID: ${{ secrets.NOTARYTOOL_ISSUER_ID }}
+          # Protected `release` environment secret, baked into the signed bundle's Info.plist by
+          # sign_staged_release.sh. Optional: if unset, telemetry simply stays off (fail-safe).
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          # Optional protected release secret for native symbolication. The upload helper reads the
+          # token from the environment but never prints it.
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          REPOPROMPT_SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+          REPOPROMPT_SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
         run: ./trusted-control-plane/Scripts/release.sh publish-staged
 
       - name: Remove ephemeral keychain

--- a/Scripts/build_swiftpm_release_products.sh
+++ b/Scripts/build_swiftpm_release_products.sh
@@ -18,6 +18,10 @@ fail() {
     exit 1
 }
 
+sentry_linking_enabled() {
+    [[ "${REPOPROMPT_ENABLE_SENTRY:-}" == "1" ]]
+}
+
 run() {
     printf '+ '
     printf '%q ' "$@"
@@ -74,6 +78,11 @@ esac
 run mkdir -p "$SCRATCH_ROOT"
 printf 'RepoPrompt CE universal public SwiftPM scratch\n' > "$SCRATCH_ROOT/$SCRATCH_SENTINEL_NAME"
 
+SWIFT_BUILD_ARGS=(-c release)
+if sentry_linking_enabled; then
+    SWIFT_BUILD_ARGS+=(-debug-info-format dwarf)
+fi
+
 ARM64_BIN_DIR=""
 X86_64_BIN_DIR=""
 for arch in arm64 x86_64; do
@@ -83,18 +92,18 @@ for arch in arm64 x86_64; do
         REPOPROMPT_SWIFTPM_SCRATCH_PATH="$scratch" \
         "$KEYBOARD_SHORTCUTS_PATCH_HELPER" "$ROOT_DIR"
     run "$RUN_WITHOUT_GITHUB_TOKENS" swift build \
-        -c release \
+        "${SWIFT_BUILD_ARGS[@]}" \
         --arch "$arch" \
         --scratch-path "$scratch" \
         --product RepoPrompt
     run "$RUN_WITHOUT_GITHUB_TOKENS" swift build \
-        -c release \
+        "${SWIFT_BUILD_ARGS[@]}" \
         --arch "$arch" \
         --scratch-path "$scratch" \
         --product repoprompt-mcp
-    printf '+ %q ' "$RUN_WITHOUT_GITHUB_TOKENS" swift build -c release --arch "$arch" --scratch-path "$scratch" --show-bin-path
+    printf '+ %q ' "$RUN_WITHOUT_GITHUB_TOKENS" swift build "${SWIFT_BUILD_ARGS[@]}" --arch "$arch" --scratch-path "$scratch" --show-bin-path
     printf '\n'
-    bin_dir="$("$RUN_WITHOUT_GITHUB_TOKENS" swift build -c release --arch "$arch" --scratch-path "$scratch" --show-bin-path)"
+    bin_dir="$("$RUN_WITHOUT_GITHUB_TOKENS" swift build "${SWIFT_BUILD_ARGS[@]}" --arch "$arch" --scratch-path "$scratch" --show-bin-path)"
     if [[ "$arch" == "arm64" ]]; then
         ARM64_BIN_DIR="$bin_dir"
     else

--- a/Scripts/conductor.py
+++ b/Scripts/conductor.py
@@ -1030,8 +1030,25 @@ class OperationRegistry:
         "RPCE_RUN_CODEMAP_E2E",
         "RPCE_RUN_SCALE_TESTS",
     ]
+    TELEMETRY_ENV_KEYS = [
+        "REPOPROMPT_ENABLE_SENTRY",
+        "REPOPROMPT_SENTRY_DSN",
+        "REPOPROMPT_UPLOAD_SENTRY_SYMBOLS",
+        "REPOPROMPT_SENTRY_AUTH_TOKEN_FILE",
+        "REPOPROMPT_SENTRY_ORG",
+        "REPOPROMPT_SENTRY_PROJECT",
+        "REPOPROMPT_SENTRY_UPLOAD_WAIT",
+        "SENTRY_URL",
+    ]
     PASSTHROUGH_ENV_KEYS = sorted(
-        set(SIGNING_ENV_KEYS + DEBUG_ENV_KEYS + BUILD_ENV_KEYS + STYLE_ENV_KEYS + TEST_ENV_KEYS)
+        set(
+            SIGNING_ENV_KEYS
+            + DEBUG_ENV_KEYS
+            + BUILD_ENV_KEYS
+            + STYLE_ENV_KEYS
+            + TEST_ENV_KEYS
+            + TELEMETRY_ENV_KEYS
+        )
     )
 
     def __init__(self, repo_root: Path) -> None:

--- a/Scripts/package_app.sh
+++ b/Scripts/package_app.sh
@@ -29,6 +29,20 @@ run(){
     "$@"
 }
 fail(){ echo "ERROR: $*" >&2; exit 1; }
+truthy(){
+    case "${1:-}" in
+        1|true|TRUE|yes|YES) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+sentry_linking_enabled(){
+    [[ "${REPOPROMPT_ENABLE_SENTRY:-}" == "1" ]]
+}
+require_sentry_upload_credentials(){
+    if [[ -z "${SENTRY_AUTH_TOKEN:-}" && -z "${REPOPROMPT_SENTRY_AUTH_TOKEN_FILE:-}" && -z "${SENTRY_AUTH_TOKEN_FILE:-}" ]]; then
+        fail "REPOPROMPT_UPLOAD_SENTRY_SYMBOLS requires SENTRY_AUTH_TOKEN or REPOPROMPT_SENTRY_AUTH_TOKEN_FILE."
+    fi
+}
 remove_stale_artifact_manifests(){
     local manifests=()
     shopt -s nullglob
@@ -75,6 +89,7 @@ source "$CONTROL_PLANE_SCRIPTS_DIR/load_release_metadata.sh"
 load_release_metadata "$ROOT_DIR"
 APP_NAME="${APP_NAME:-RepoPrompt}"; DISPLAY_NAME="${DISPLAY_NAME:-RepoPrompt CE}"; BASE_BUNDLE_ID="${BUNDLE_ID:-com.pvncher.repoprompt.ce}"; MARKETING_VERSION="${MARKETING_VERSION:-0.1.0}"; BUILD_NUMBER="${BUILD_NUMBER:-1}"; SIGNING_TEAM_ID="${SIGNING_TEAM_ID:-648A27MST5}"
 ARTIFACT_MANIFEST="$ROOT_DIR/.build/release/$APP_NAME-artifact-manifest.json"
+SENTRY_SYMBOLS_DIR="$ROOT_DIR/.build/sentry-symbols/$CONF"
 
 IS_RELEASE=0
 [[ "$CONF" == "release" ]] && IS_RELEASE=1
@@ -188,6 +203,9 @@ printf 'Debug secure storage backend marker: %s\n' "$DEBUG_STORAGE_BACKEND_MARKE
 printf 'Signing mode marker: %s\n' "$SIGNING_MODE_MARKER"
 
 SWIFT_BUILD_ARGS=(-c "$CONF")
+if sentry_linking_enabled; then
+    SWIFT_BUILD_ARGS+=(-debug-info-format dwarf)
+fi
 PUBLIC_UNIVERSAL_RELEASE=0
 ARCHITECTURE_POLICY="matching"
 if (( IS_RELEASE )) && (( ! USE_LOCAL_SELF_SIGNED_RELEASE )); then
@@ -229,6 +247,20 @@ fi
 COMPAT_APP_BUNDLE="$ROOT_DIR/.build/$CONF/$APP_NAME.app"
 CLI_PATH="$BUILD_DIR/repoprompt-mcp"
 printf 'BUILD_DIR=%s\nAPP_BUNDLE=%s\nCOMPAT_APP_BUNDLE=%s\nCLI_PATH=%s\nAD_HOC_SIGNING=%s\nARCHITECTURE_POLICY=%s\n' "$BUILD_DIR" "$APP_BUNDLE" "$COMPAT_APP_BUNDLE" "$CLI_PATH" "$USE_ADHOC_SIGNING" "$ARCHITECTURE_POLICY"
+
+generate_sentry_debug_symbols(){
+    sentry_linking_enabled || return 0
+    phase "Generating Sentry debug symbols"
+    command -v xcrun >/dev/null 2>&1 || fail "xcrun is required to generate dSYMs."
+    run rm -rf "$SENTRY_SYMBOLS_DIR"
+    run mkdir -p "$SENTRY_SYMBOLS_DIR"
+    for exe in "$APP_NAME" repoprompt-mcp; do
+        [[ -f "$BUILD_DIR/$exe" ]] || fail "Missing built executable for dSYM generation: $BUILD_DIR/$exe"
+        run xcrun dsymutil "$BUILD_DIR/$exe" -o "$SENTRY_SYMBOLS_DIR/$exe.dSYM"
+    done
+    printf 'Sentry debug symbols: %s\n' "$SENTRY_SYMBOLS_DIR"
+}
+generate_sentry_debug_symbols
 
 phase "Creating app bundle layout"
 run rm -rf "$APP_BUNDLE"
@@ -397,6 +429,11 @@ if (( PUBLIC_UNIVERSAL_RELEASE )); then
 fi
 run "$CONTROL_PLANE_SCRIPTS_DIR/validate_embedded_mcp_helper_layout.sh" "$APP_BUNDLE" "Packaged app MCP helper layout"
 run "$RUN_WITHOUT_GITHUB_TOKENS" "$CONTROL_PLANE_SCRIPTS_DIR/smoke_embedded_mcp_helper.sh" "$APP_BUNDLE" "Packaged app MCP helper"
+if truthy "${REPOPROMPT_UPLOAD_SENTRY_SYMBOLS:-}"; then
+    sentry_linking_enabled || fail "REPOPROMPT_UPLOAD_SENTRY_SYMBOLS requires REPOPROMPT_ENABLE_SENTRY=1."
+    require_sentry_upload_credentials
+    run "$CONTROL_PLANE_SCRIPTS_DIR/upload_sentry_debug_symbols.sh" "$SENTRY_SYMBOLS_DIR"
+fi
 if [[ "$APP_BUNDLE_MATCHES_COMPAT" != "1" ]]; then
     phase "Updating compatibility app bundle link"
     run mkdir -p "$(dirname "$COMPAT_APP_BUNDLE")"

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -20,6 +20,7 @@ DMG="$DIST_DIR/$ARCHIVE_BASENAME.dmg"
 APPCAST="$DIST_DIR/appcast.xml"
 CHECKSUMS="$DIST_DIR/SHA256SUMS"
 BUILD_ARTIFACT_MANIFEST="$ROOT_DIR/.build/release/$APP_NAME-artifact-manifest.json"
+SENTRY_SYMBOLS_DIR="$ROOT_DIR/.build/sentry-symbols/release"
 FINAL_ARTIFACT_MANIFEST="$DIST_DIR/$ARCHIVE_BASENAME-artifact-manifest.json"
 STAGE_ARCHIVE="$DIST_DIR/$ARCHIVE_BASENAME-stage.zip"
 STAGE_ARCHIVE_CHECKSUM="$STAGE_ARCHIVE.sha256"
@@ -47,6 +48,10 @@ require_file() {
 
 require_env() {
     [[ -n "${!1:-}" ]] || fail "Missing required environment variable: $1"
+}
+
+sentry_linking_enabled() {
+    [[ "${REPOPROMPT_ENABLE_SENTRY:-}" == "1" ]]
 }
 
 require_release_tag_matches_metadata() {
@@ -77,6 +82,7 @@ run_preflight() {
     require_file "$ROOT_DIR/Vendor/Sparkle/PROVENANCE.md"
     require_file "$ROOT_DIR/Vendor/Sparkle/SHA256SUMS"
     require_file "$CONTROL_PLANE_SCRIPTS_DIR/sign_staged_release.sh"
+    require_file "$CONTROL_PLANE_SCRIPTS_DIR/upload_sentry_debug_symbols.sh"
     require_file "$CONTROL_PLANE_SCRIPTS_DIR/build_swiftpm_release_products.sh"
     require_file "$CONTROL_PLANE_SCRIPTS_DIR/compare_swiftpm_release_resources.py"
     require_file "$CONTROL_PLANE_SCRIPTS_DIR/smoke_embedded_mcp_helper.sh"
@@ -169,6 +175,16 @@ write_final_artifact_manifest() {
         --expected-architectures "arm64,x86_64"
 }
 
+require_staged_sentry_symbols_when_enabled() {
+    if sentry_linking_enabled && [[ ! -d "$SENTRY_SYMBOLS_DIR" ]]; then
+        fail "Sentry-enabled release staging did not produce debug symbols at $SENTRY_SYMBOLS_DIR"
+    fi
+}
+
+upload_sentry_symbols_if_configured() {
+    "$CONTROL_PLANE_SCRIPTS_DIR/upload_sentry_debug_symbols.sh" "$SENTRY_SYMBOLS_DIR"
+}
+
 package_release_candidate() {
     resolve_without_lockfile_drift
     run_preflight
@@ -213,6 +229,10 @@ verify_publish_inputs() {
     require_release_tag_matches_metadata
     require_file "$REPOPROMPT_PROVISIONING_PROFILE"
     require_file "$NOTARYTOOL_PRIVATE_KEY"
+    if [[ -n "${SENTRY_AUTH_TOKEN:-}" ]]; then
+        require_env REPOPROMPT_SENTRY_ORG
+        require_env REPOPROMPT_SENTRY_PROJECT
+    fi
 
     "$CONTROL_PLANE_SCRIPTS_DIR/verify_remote_release_commit.sh" "$RELEASE_TAG" "$RELEASE_COMMIT"
 }
@@ -244,11 +264,16 @@ stage_publish_release() {
     run_preflight
     validate_packaged_legal "$APP_BUNDLE"
     validate_public_app "$APP_BUNDLE" "$BUILD_ARTIFACT_MANIFEST" "Release staging"
+    require_staged_sentry_symbols_when_enabled
     TMP_DIR="$(mktemp -d)"
     local stage_root="$TMP_DIR/release-stage"
     mkdir -p "$stage_root/.build/release"
     ditto "$APP_BUNDLE" "$stage_root/.build/release/$APP_NAME.app"
     cp "$BUILD_ARTIFACT_MANIFEST" "$stage_root/.build/release/$APP_NAME-artifact-manifest.json"
+    if [[ -d "$SENTRY_SYMBOLS_DIR" ]]; then
+        mkdir -p "$stage_root/.build/sentry-symbols"
+        ditto "$SENTRY_SYMBOLS_DIR" "$stage_root/.build/sentry-symbols/release"
+    fi
     cp "$ROOT_DIR/version.env" "$ROOT_DIR/LICENSE" "$ROOT_DIR/THIRD_PARTY_NOTICES.md" "$stage_root/"
     cp -R "$ROOT_DIR/ThirdPartyLicenses" "$stage_root/"
     printf '%s\n' "$RELEASE_COMMIT" > "$stage_root/RELEASE_COMMIT"
@@ -285,6 +310,7 @@ publish_staged_release() {
     xcrun stapler validate "$APP_BUNDLE"
     write_final_artifact_manifest
     validate_public_app "$APP_BUNDLE" "$FINAL_ARTIFACT_MANIFEST" "Final Developer ID app"
+    upload_sentry_symbols_if_configured
 
     local distribution_dir="$TMP_DIR/distribution"
     mkdir -p "$distribution_dir"

--- a/Scripts/sign_staged_release.sh
+++ b/Scripts/sign_staged_release.sh
@@ -67,6 +67,13 @@ plutil -lint "$app_entitlements"
 plutil -replace RepoPromptDebugSecureStorageBackend -string keychain "$APP_BUNDLE/Contents/Info.plist"
 plutil -replace RepoPromptSigningMode -string developer-id "$APP_BUNDLE/Contents/Info.plist"
 
+# Telemetry is gated on DSN presence: only the official Developer ID publish job receives the
+# protected SENTRY_DSN secret, and only here is it baked into the signed bundle. The value is never
+# echoed or written to the artifact manifest.
+if [[ -n "${SENTRY_DSN:-}" ]]; then
+    plutil -replace RepoPromptSentryDSN -string "$SENTRY_DSN" "$APP_BUNDLE/Contents/Info.plist"
+fi
+
 sign_path() {
     local path="$1"
     shift

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -31,11 +31,16 @@ class ReleaseToolingTests(unittest.TestCase):
                 key, value = line.split("=", 1)
                 metadata[key] = value.strip('"')
 
+        package_manifest = (root / "Package.swift").read_text(encoding="utf-8")
         policy = (
             root / "Sources" / "RepoPrompt" / "Infrastructure" / "Security" / "RuntimeCodeSigningPolicy.swift"
         ).read_text(encoding="utf-8")
         entitlements = (root / "AppBundle" / "RepoPrompt.entitlements.template").read_text(encoding="utf-8")
         info_plist = plistlib.loads((root / "AppBundle" / "Info.plist.template").read_bytes())
+
+        self.assertIn('environment["REPOPROMPT_ENABLE_SENTRY"] == "1"', package_manifest)
+        self.assertIn('repoPromptSwiftSettings.append(.define("REPOPROMPT_SENTRY_ENABLED"))', package_manifest)
+        self.assertNotIn("let sentryEnabled = true", package_manifest)
 
         self.assertIn(
             f'static let developerIDBundleIdentifier = "{metadata["BUNDLE_ID"]}"',
@@ -58,6 +63,8 @@ class ReleaseToolingTests(unittest.TestCase):
         self.assertIn("RepoPromptDebugSecureStorageBackend", info_plist)
         self.assertIn("RepoPromptLocalSigningCertificateSHA256", info_plist)
         self.assertIn("RepoPromptLocalSecureStorageGeneration", info_plist)
+        self.assertIn("RepoPromptSentryDSN", info_plist)
+        self.assertEqual(info_plist["RepoPromptSentryDSN"], "")
         self.assertIn(
             'static let localSelfSignedCertificateName = "RepoPrompt CE Local Self-Signed Code Signing"',
             policy,
@@ -501,6 +508,38 @@ esac
         self.assertIsNone(manifest_content["bundle_signing"]["leaf_certificate_sha256"])
         for executable in manifest_content["executables"]:
             self.assertIsNone(executable["signing"]["leaf_certificate_sha256"])
+        # The RC fixture has no DSN, so telemetry is disabled.
+        self.assertFalse(manifest_content["bundle"]["telemetry_enabled"])
+
+        # With a DSN present, the manifest records telemetry_enabled=True but never the DSN value.
+        dsn_value = "https://examplepublickey@o9999.ingest.sentry.io/424242"
+        info_with_dsn = dict(info)
+        info_with_dsn["RepoPromptSentryDSN"] = dsn_value
+        (app / "Contents" / "Info.plist").write_bytes(plistlib.dumps(info_with_dsn))
+        dsn_manifest = app.parent / "telemetry-manifest.json"
+        dsn_written = subprocess.run(
+            [
+                str(writer),
+                "write",
+                "--app",
+                str(app),
+                "--output",
+                str(dsn_manifest),
+                "--expected-architectures",
+                "arm64,x86_64",
+            ],
+            env=env,
+            text=True,
+            capture_output=True,
+        )
+        self.assertEqual(dsn_written.returncode, 0, dsn_written.stderr)
+        dsn_manifest_text = dsn_manifest.read_text(encoding="utf-8")
+        self.assertNotIn(dsn_value, dsn_manifest_text)
+        self.assertNotIn("examplepublickey", dsn_manifest_text)
+        self.assertTrue(json.loads(dsn_manifest_text)["bundle"]["telemetry_enabled"])
+        # Restore the no-DSN RC Info.plist so the remainder of the test is unaffected.
+        (app / "Contents" / "Info.plist").write_bytes(plistlib.dumps(info))
+
         accepted = subprocess.run(
             [
                 str(writer),
@@ -1105,6 +1144,110 @@ SIGNING_TEAM_ID=648A27MST5
         self.assertIn('CERTIFICATE_PATH="$RUNNER_TEMP/repoprompt-release.p12"', final_cleanup)
         self.assertIn('rm -f "$CERTIFICATE_PATH"', final_cleanup)
         self.assertIn('rm -rf "$RUNNER_TEMP/repoprompt-release-secrets"', final_cleanup)
+
+    def test_sentry_symbol_upload_helper_uses_token_file_without_logging_secret(self) -> None:
+        temp_dir = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, temp_dir, True)
+        symbols = temp_dir / "symbols"
+        symbols.mkdir()
+        (symbols / "RepoPrompt.dSYM").mkdir()
+        ambient_token = "sntrys_wrong_ambient_secret_token"
+        token = "sntrys_fixture_secret_token"
+        token_file = temp_dir / "sentry-token"
+        token_file.write_text(token + "\n", encoding="utf-8")
+        argv_capture = temp_dir / "argv.txt"
+        token_capture = temp_dir / "token.txt"
+        fake_cli = temp_dir / "sentry-cli"
+        fake_cli.write_text(
+            """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$@" > "$ARGV_CAPTURE"
+printf '%s' "${SENTRY_AUTH_TOKEN:-}" > "$TOKEN_CAPTURE"
+""",
+            encoding="utf-8",
+        )
+        fake_cli.chmod(0o755)
+        env = os.environ.copy()
+        env["SENTRY_AUTH_TOKEN"] = ambient_token
+        env.update(
+            {
+                "PATH": f"{temp_dir}:{env.get('PATH', '')}",
+                "REPOPROMPT_SENTRY_AUTH_TOKEN_FILE": str(token_file),
+                "REPOPROMPT_SENTRY_ORG": "fixture-org",
+                "REPOPROMPT_SENTRY_PROJECT": "fixture-project",
+                "ARGV_CAPTURE": str(argv_capture),
+                "TOKEN_CAPTURE": str(token_capture),
+            }
+        )
+
+        result = subprocess.run(
+            [str(SCRIPT_DIR / "upload_sentry_debug_symbols.sh"), str(symbols)],
+            env=env,
+            text=True,
+            capture_output=True,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertNotIn(token, result.stdout)
+        self.assertNotIn(token, result.stderr)
+        argv = argv_capture.read_text(encoding="utf-8").splitlines()
+        self.assertEqual(
+            argv,
+            [
+                "debug-files",
+                "upload",
+                "--include-sources",
+                "--org",
+                "fixture-org",
+                "--project",
+                "fixture-project",
+                str(symbols),
+            ],
+        )
+        self.assertNotIn(token, "\n".join(argv))
+        self.assertEqual(token_capture.read_text(encoding="utf-8"), token)
+
+    def test_sentry_symbol_flow_is_explicit_secret_safe_and_release_only_by_default(self) -> None:
+        package_script = (SCRIPT_DIR / "package_app.sh").read_text(encoding="utf-8")
+        universal_builder = (SCRIPT_DIR / "build_swiftpm_release_products.sh").read_text(encoding="utf-8")
+        release_script = (SCRIPT_DIR / "release.sh").read_text(encoding="utf-8")
+        release_workflow = (SCRIPT_DIR.parent / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+        conductor = (SCRIPT_DIR / "conductor.py").read_text(encoding="utf-8")
+
+        self.assertIn('SENTRY_SYMBOLS_DIR="$ROOT_DIR/.build/sentry-symbols/$CONF"', package_script)
+        self.assertNotIn("REPOPROMPT_SENTRY_SYMBOLS_DIR", package_script)
+        self.assertIn("SWIFT_BUILD_ARGS+=(-debug-info-format dwarf)", package_script)
+        self.assertIn('run xcrun dsymutil "$BUILD_DIR/$exe" -o "$SENTRY_SYMBOLS_DIR/$exe.dSYM"', package_script)
+        self.assertIn('if truthy "${REPOPROMPT_UPLOAD_SENTRY_SYMBOLS:-}"; then', package_script)
+        self.assertIn("REPOPROMPT_UPLOAD_SENTRY_SYMBOLS requires REPOPROMPT_ENABLE_SENTRY=1", package_script)
+        self.assertIn("REPOPROMPT_UPLOAD_SENTRY_SYMBOLS requires SENTRY_AUTH_TOKEN or REPOPROMPT_SENTRY_AUTH_TOKEN_FILE", package_script)
+        self.assertIn("SWIFT_BUILD_ARGS+=(-debug-info-format dwarf)", universal_builder)
+
+        self.assertIn('require_file "$CONTROL_PLANE_SCRIPTS_DIR/upload_sentry_debug_symbols.sh"', release_script)
+        self.assertIn('SENTRY_SYMBOLS_DIR="$ROOT_DIR/.build/sentry-symbols/release"', release_script)
+        self.assertIn('ditto "$SENTRY_SYMBOLS_DIR" "$stage_root/.build/sentry-symbols/release"', release_script)
+        self.assertIn('upload_sentry_symbols_if_configured', release_script)
+
+        stage_job = release_workflow.split("\n  stage:", 1)[1].split("\n  publish:", 1)[0]
+        publish_job = release_workflow.split("\n  publish:", 1)[1].split("\n  smoke-signed-helper:", 1)[0]
+        self.assertIn('REPOPROMPT_ENABLE_SENTRY: "1"', stage_job)
+        self.assertNotIn("SENTRY_AUTH_TOKEN", stage_job)
+        self.assertIn("Install Sentry CLI when symbol upload is configured", publish_job)
+        self.assertIn("brew install getsentry/tools/sentry-cli", publish_job)
+        self.assertIn("SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}", publish_job)
+        self.assertLess(
+            publish_job.index("Install Sentry CLI when symbol upload is configured"),
+            publish_job.index("Sign, notarize, and create draft release"),
+        )
+        self.assertIn("REPOPROMPT_SENTRY_ORG: ${{ vars.SENTRY_ORG }}", publish_job)
+        self.assertIn("REPOPROMPT_SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}", publish_job)
+
+        self.assertIn('"REPOPROMPT_ENABLE_SENTRY"', conductor)
+        self.assertIn('"REPOPROMPT_UPLOAD_SENTRY_SYMBOLS"', conductor)
+        self.assertIn('"REPOPROMPT_SENTRY_AUTH_TOKEN_FILE"', conductor)
+        self.assertIn('"REPOPROMPT_SENTRY_ORG"', conductor)
+        self.assertIn('"REPOPROMPT_SENTRY_PROJECT"', conductor)
+        self.assertNotIn('"SENTRY_AUTH_TOKEN"', conductor)
 
     def test_staged_release_extractor_rejects_alternate_in_app_cli_target(self) -> None:
         for relative, alternate_target in (

--- a/Scripts/upload_sentry_debug_symbols.sh
+++ b/Scripts/upload_sentry_debug_symbols.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+    printf 'ERROR: %s\n' "$*" >&2
+    exit 1
+}
+
+truthy() {
+    case "${1:-}" in
+        1|true|TRUE|yes|YES) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+if [[ $# -lt 1 ]]; then
+    fail "usage: upload_sentry_debug_symbols.sh <debug-symbol-path>..."
+fi
+
+token_file="${REPOPROMPT_SENTRY_AUTH_TOKEN_FILE:-}"
+if [[ -n "$token_file" ]]; then
+    [[ -f "$token_file" ]] || fail "Sentry auth token file does not exist: $token_file"
+    SENTRY_AUTH_TOKEN="$(tr -d '\r\n' < "$token_file")"
+fi
+
+if [[ -z "${SENTRY_AUTH_TOKEN:-}" ]]; then
+    printf 'Skipping Sentry debug symbol upload: SENTRY_AUTH_TOKEN is not set.\n'
+    exit 0
+fi
+
+sentry_org="${REPOPROMPT_SENTRY_ORG:-}"
+sentry_project="${REPOPROMPT_SENTRY_PROJECT:-}"
+[[ -n "$sentry_org" ]] || fail "REPOPROMPT_SENTRY_ORG is required when uploading Sentry debug symbols."
+[[ -n "$sentry_project" ]] || fail "REPOPROMPT_SENTRY_PROJECT is required when uploading Sentry debug symbols."
+command -v sentry-cli >/dev/null 2>&1 || fail "sentry-cli is required to upload Sentry debug symbols."
+
+paths=()
+for candidate in "$@"; do
+    if [[ -e "$candidate" ]]; then
+        paths+=("$candidate")
+    fi
+done
+(( ${#paths[@]} > 0 )) || fail "No existing Sentry debug symbol paths were provided."
+
+args=(debug-files upload --include-sources --org "$sentry_org" --project "$sentry_project")
+if truthy "${REPOPROMPT_SENTRY_UPLOAD_WAIT:-0}"; then
+    args+=(--wait)
+fi
+args+=("${paths[@]}")
+
+export SENTRY_AUTH_TOKEN
+printf 'Uploading Sentry debug symbols for org=%s project=%s from %s path(s).\n' \
+    "$sentry_org" "$sentry_project" "${#paths[@]}"
+sentry-cli "${args[@]}"

--- a/Scripts/write_app_artifact_manifest.py
+++ b/Scripts/write_app_artifact_manifest.py
@@ -151,6 +151,9 @@ def collect_manifest(app: Path, expected_architectures: list[str] | None) -> dic
     signing_mode = info.get("RepoPromptSigningMode")
     allow_adhoc_without_requirement = signing_mode == "release-candidate-adhoc"
     require_leaf_certificate = signing_mode in {"developer-id", "local-self-signed"}
+    # Record only whether telemetry is enabled, never the DSN value itself (it is secret).
+    sentry_dsn = info.get("RepoPromptSentryDSN")
+    telemetry_enabled = isinstance(sentry_dsn, str) and bool(sentry_dsn.strip())
     entries = [
         executable_entry(
             app,
@@ -189,6 +192,7 @@ def collect_manifest(app: Path, expected_architectures: list[str] | None) -> dic
             "marketing_version": info.get("CFBundleShortVersionString"),
             "build_number": info.get("CFBundleVersion"),
             "signing_mode": signing_mode,
+            "telemetry_enabled": telemetry_enabled,
             "architecture_policy": "universal-public"
             if actual_architectures == ["arm64", "x86_64"]
             else "host-native",

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -222,6 +222,64 @@ Add these environment secrets:
 | `NOTARYTOOL_ISSUER_ID` | App Store Connect API issuer ID. |
 | `SPARKLE_PRIVATE_KEY` | Modern Sparkle EdDSA private-key seed for the CE update channel. It must decode from base64 to exactly 32 bytes. |
 | `PUBLIC_UPDATE_REPOSITORY_TOKEN` | Fine-grained GitHub token scoped only to `repoprompt/repoprompt-ce-updates` with repository contents read/write permission. |
+| `SENTRY_DSN` | Protected Sentry DSN injected into official signed builds. |
+| `SENTRY_AUTH_TOKEN` | Sentry auth token used only for uploading release debug symbols during publication. |
+
+Add these non-secret release environment variables when Sentry symbol upload is enabled:
+
+| Variable | Contents |
+| --- | --- |
+| `REPOPROMPT_ENABLE_SENTRY` | `1` for official telemetry-enabled release staging. |
+| `REPOPROMPT_SENTRY_ORG` | Sentry organization slug. |
+| `REPOPROMPT_SENTRY_PROJECT` | Sentry project slug. |
+
+## Sentry telemetry and debug symbols
+
+Official telemetry-enabled release staging links the Sentry SDK when
+`REPOPROMPT_ENABLE_SENTRY=1`. The protected `SENTRY_DSN` secret is injected into
+`Info.plist` as `RepoPromptSentryDSN` only by `Scripts/sign_staged_release.sh`.
+Do not commit, log, or record the DSN in artifact manifests; manifests record
+only the non-secret `telemetry_enabled` boolean.
+
+When Sentry is enabled, release staging generates dSYMs under
+`.build/sentry-symbols/release` and carries them inside the staged release ZIP.
+`release.sh publish-staged` uploads those debug symbols when `SENTRY_AUTH_TOKEN`
+is available, using `REPOPROMPT_SENTRY_ORG` and `REPOPROMPT_SENTRY_PROJECT`.
+The upload helper runs:
+
+```bash
+sentry-cli debug-files upload --include-sources
+```
+
+That uploads dSYMs/debug files and local source context together so Sentry can
+symbolicate RepoPrompt frames and show source context for app-owned code.
+
+Local/debug symbol upload is opt-in and is mainly for testing the integration:
+
+```bash
+REPOPROMPT_ENABLE_SENTRY=1 \
+REPOPROMPT_SENTRY_DSN="https://examplePublicKey@o0.ingest.sentry.io/0" \
+REPOPROMPT_UPLOAD_SENTRY_SYMBOLS=1 \
+REPOPROMPT_SENTRY_ORG="repoprompt" \
+REPOPROMPT_SENTRY_PROJECT="repoprompt" \
+REPOPROMPT_SENTRY_AUTH_TOKEN_FILE="$HOME/.config/repoprompt/sentry-token" \
+./Scripts/package_app.sh debug
+```
+
+Prefer `REPOPROMPT_SENTRY_AUTH_TOKEN_FILE` for coordinated `make dev-build` /
+conductor runs. The daemon intentionally does not pass through `SENTRY_AUTH_TOKEN`
+because it stores job environment snapshots for status and retry identity.
+
+DEBUG telemetry-enabled builds support a shell-only crash probe for validating
+Sentry event detail:
+
+```bash
+"$HOME/Library/Application Support/RepoPrompt CE/DebugApps/RepoPrompt.app/Contents/MacOS/RepoPrompt" \
+  --repoprompt-sentry-test-crash
+```
+
+Relaunch the app once without the argument so the SDK can flush the cached native
+crash report.
 
 The optional `SIGN_IDENTITY` environment variable defaults to:
 


### PR DESCRIPTION
## Summary
Makes crash reports symbolicate: **generates and uploads dSYMs** in the release pipeline, plus CI/docs wiring. Caps the stack.

Refs GH-183

## What this changes
- `package_app.sh` / `build_swiftpm_release_products.sh` — build with `-debug-info-format dwarf` and run `dsymutil` per executable when `REPOPROMPT_ENABLE_SENTRY=1`.
- `upload_sentry_debug_symbols.sh` (new) — uploads via `sentry-cli`.
- `release.sh`, `sign_staged_release.sh`, `conductor.py`, `write_app_artifact_manifest.py`, `.github/workflows/release.yml` — thread the Sentry env + symbol dir through the release flow.
- `source_layout_guardrails.sh` + `test_release_tooling.py` (new) — cover the new tooling.
- `docs/releasing.md` — documents the Sentry-enabled release steps.

## Business rules
- **dSYM upload is skipped silently when no `SENTRY_AUTH_TOKEN`** is set — contributor/local release builds never fail or leak credentials.
- Upload requires **both** `REPOPROMPT_ENABLE_SENTRY=1` **and** credentials, plus `REPOPROMPT_SENTRY_ORG`/`REPOPROMPT_SENTRY_PROJECT`.
- Auth token is preferred from a file (`REPOPROMPT_SENTRY_AUTH_TOKEN_FILE`) over an env var.

## Key decisions
- Fail-open on missing credentials (skip), fail-closed on misconfiguration (require org/project when a token *is* present) — so the default contributor path is frictionless while the official pipeline is strict.

## Test plan
- Builds in both modes; `repoprompt-mcp` also builds. ✅ verified.
- `test_release_tooling.py` exercises the new gating logic.
