### PR TITLE
Add Claude Sonnet 5 model support

### DIFF
--- a/Packages/RepoPromptAgentProviders/Sources/RepoPromptClaudeCompatibleProvider/ClaudeCompatibleProviderPlugin.swift
+++ b/Packages/RepoPromptAgentProviders/Sources/RepoPromptClaudeCompatibleProvider/ClaudeCompatibleProviderPlugin.swift
@@ -239,6 +239,7 @@ public enum ClaudeCompatibleModelCatalog {
     private static let opus47Raw = "claude-opus-4-7"
     private static let opus46Raw = "claude-opus-4-6"
     private static let opus45Raw = "claude-opus-4-5"
+    private static let sonnet5Raw = "claude-sonnet-5"
     private static let sonnet46Raw = "claude-sonnet-4-6"
     private static let sonnet45Raw = "claude-sonnet-4-5"
     private static let haiku45Raw = "claude-haiku-4-5"
@@ -285,6 +286,12 @@ public enum ClaudeCompatibleModelCatalog {
             displayName: "Sonnet Latest",
             description: "Balanced speed and capability. Good for general coding, analysis, and everyday work.",
             supportsXHigh: false
+        ),
+        StaticModel(
+            rawValue: sonnet5Raw,
+            displayName: "Sonnet 5",
+            description: "Pinned Claude Sonnet 5. Balanced speed and capability with 1M context for everyday engineering.",
+            supportsXHigh: true
         ),
         StaticModel(
             rawValue: sonnet46Raw,

--- a/Packages/RepoPromptAgentProviders/Tests/RepoPromptClaudeCompatibleProviderTests/Runtime/ClaudeCompatibleRuntimeSupportTests.swift
+++ b/Packages/RepoPromptAgentProviders/Tests/RepoPromptClaudeCompatibleProviderTests/Runtime/ClaudeCompatibleRuntimeSupportTests.swift
@@ -148,7 +148,7 @@ final class ClaudeCompatibleRuntimeSupportTests: XCTestCase {
         ])
     }
 
-    func testProviderCatalogDefaultsExposeStableRawValues() {
+    func testProviderCatalogDefaultsExposeStableRawValues() throws {
         XCTAssertEqual(ClaudeCompatibleProviderPluginID.allCases.map(\.rawValue), [
             "claude-code",
             "zai-claude-code",
@@ -167,6 +167,13 @@ final class ClaudeCompatibleRuntimeSupportTests: XCTestCase {
         XCTAssertEqual(claude.options.first?.isPlaceholderDefault, true)
         XCTAssertTrue(claude.options.contains { $0.rawValue == "claude-fable-5" && $0.supportedEffortLevels.contains("xhigh") })
         XCTAssertTrue(claude.options.contains { $0.rawValue == "opus[1m]" && $0.supportedEffortLevels.contains("xhigh") })
+        let sonnet5 = try XCTUnwrap(claude.options.first { $0.rawValue == "claude-sonnet-5" })
+        XCTAssertEqual(sonnet5.displayName, "Sonnet 5")
+        XCTAssertEqual(sonnet5.supportedEffortLevels, ["low", "medium", "high", "max", "xhigh"])
+
+        let expandedClaude = ClaudeCompatibleModelCatalog.snapshot(pluginID: .claudeCode)
+        XCTAssertTrue(expandedClaude.options.contains { $0.rawValue == "claude-sonnet-5:max" })
+        XCTAssertTrue(expandedClaude.options.contains { $0.rawValue == "claude-sonnet-5:xhigh" })
 
         let zai = ClaudeCompatibleModelCatalog.snapshot(pluginID: .zaiClaudeCode, includeEffortVariants: false)
         XCTAssertEqual(zai.defaultModelRaw, "sonnet")
@@ -202,6 +209,7 @@ final class ClaudeCompatibleRuntimeSupportTests: XCTestCase {
         XCTAssertEqual(ClaudeCompatibleModelNormalizer.normalizedSlotModel("sonnet:xhigh", config: ClaudeCompatibleBackendID.glmZAI.defaultPreset), "sonnet")
         XCTAssertEqual(ClaudeCompatibleModelNormalizer.normalizedSlotModel("glm-5.2[1m]:xhigh", config: ClaudeCompatibleBackendID.glmZAI.defaultPreset), "sonnet")
         XCTAssertEqual(ClaudeCompatibleHeadlessRuntime.runtimeModelParam("opus:xhigh"), "opus")
+        XCTAssertEqual(ClaudeCompatibleHeadlessRuntime.runtimeModelParam("claude-sonnet-5:xhigh"), "claude-sonnet-5")
         XCTAssertEqual(ClaudeCompatibleModelNormalizer.normalizedGLMModel("glm-4.5-air", config: ClaudeCompatibleBackendID.glmZAI.defaultPreset), "haiku")
         XCTAssertEqual(ClaudeCompatibleModelNormalizer.normalizedGLMModel("glm-4.7", config: ClaudeCompatibleBackendID.glmZAI.defaultPreset), "haiku")
         XCTAssertEqual(ClaudeCompatibleModelNormalizer.normalizedGLMModel("glm-5.2", config: ClaudeCompatibleBackendID.glmZAI.defaultPreset), "sonnet")

--- a/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentModel.swift
@@ -62,6 +62,7 @@ enum AgentModel: String, CaseIterable, Codable {
 
     // Claude Code full model IDs (static known versions; no dynamic probing)
     case claudeFable5 = "claude-fable-5"
+    case claudeSonnet5 = "claude-sonnet-5"
     case claudeSonnet46 = "claude-sonnet-4-6"
     case claudeSonnet45 = "claude-sonnet-4-5"
     case claudeOpus47 = "claude-opus-4-7"
@@ -115,6 +116,7 @@ enum AgentModel: String, CaseIterable, Codable {
         case .claudeHaiku: "Haiku Latest"
         case .claudeOpus1m: "Opus Latest (1M)"
         case .claudeFable5: "Fable 5"
+        case .claudeSonnet5: "Sonnet 5"
         case .claudeSonnet46: "Sonnet 4.6"
         case .claudeSonnet45: "Sonnet 4.5"
         case .claudeOpus47: "Opus 4.7"
@@ -162,6 +164,7 @@ enum AgentModel: String, CaseIterable, Codable {
         case .claudeHaiku: "Fast and lightweight. Good for exploration, quick edits, and mapping codebases."
         case .claudeOpus1m: "Claude Opus with 1M token context. Best for large codebases and tasks requiring extensive context."
         case .claudeFable5: "Claude Fable 5. Anthropic's most capable widely released model for demanding reasoning and long-horizon agentic work."
+        case .claudeSonnet5: "Pinned Claude Sonnet 5. Balanced speed and capability with 1M context for everyday engineering."
         case .claudeSonnet46: "Pinned Claude Sonnet 4.6. Balanced speed and capability for everyday engineering."
         case .claudeSonnet45: "Pinned Claude Sonnet 4.5. Balanced speed and capability for everyday engineering."
         case .claudeOpus47: "Pinned Claude Opus 4.7. Opus-tier capability for complex reasoning and architecture."
@@ -218,7 +221,7 @@ enum AgentModel: String, CaseIterable, Codable {
                 .claudeFable5,
                 .claudeOpus1m,
                 .claudeOpus, .claudeOpus47, .claudeOpus46, .claudeOpus45,
-                .claudeSonnet, .claudeSonnet46, .claudeSonnet45,
+                .claudeSonnet, .claudeSonnet5, .claudeSonnet46, .claudeSonnet45,
                 .claudeHaiku, .claudeHaiku45
             ]
         case .openCode:
@@ -437,6 +440,8 @@ enum AgentModel: String, CaseIterable, Codable {
             [.complex, .engineering, .pair]
         case .claudeFable5:
             [.complex, .engineering, .pair, .extendedContext]
+        case .claudeSonnet5:
+            [.balanced, .engineering, .extendedContext]
         case .claudeOpus:
             [.complex, .engineering, .pair]
         default:
@@ -448,7 +453,7 @@ enum AgentModel: String, CaseIterable, Codable {
     /// Returns `nil` for models where the context window is unknown or unverified.
     var contextWindowTokens: Int? {
         switch self {
-        case .claudeFable5, .claudeOpus1m, .glm52_1m:
+        case .claudeFable5, .claudeSonnet5, .claudeOpus1m, .glm52_1m:
             1_000_000
         case .claudeSonnet, .claudeOpus, .claudeHaiku,
              .claudeSonnet46, .claudeSonnet45,

--- a/Sources/RepoPrompt/Features/AgentMode/Providers/ClaudeCompatible/ClaudeCompatibleModelCatalogAdapter.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Providers/ClaudeCompatible/ClaudeCompatibleModelCatalogAdapter.swift
@@ -385,6 +385,7 @@ enum ClaudeCompatibleModelCatalogAdapter {
     /// Base model raw values (lowercased) that support the XHigh effort tier.
     private static let claudeXHighEligibleBaseRaws: Set<String> = [
         AgentModel.claudeFable5.rawValue.lowercased(),
+        AgentModel.claudeSonnet5.rawValue.lowercased(),
         AgentModel.claudeOpus.rawValue.lowercased(),
         AgentModel.claudeOpus1m.rawValue.lowercased(),
         AgentModel.claudeOpus47.rawValue.lowercased(),

--- a/Sources/RepoPrompt/Infrastructure/AI/ModelCatalog/Providers/ClaudeCodeAIModelCatalog.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/ModelCatalog/Providers/ClaudeCodeAIModelCatalog.swift
@@ -31,6 +31,7 @@ enum ClaudeCodeAIModelCatalog {
         ModelDefinition(runtimeModelRaw: "claude-opus-4-5-20251101", displayName: "Opus 4.5", supportedEfforts: []),
         ModelDefinition(runtimeModelRaw: "sonnet[1m]", displayName: "Sonnet Latest (1M)", supportedEfforts: [.low, .medium, .high]),
         ModelDefinition(runtimeModelRaw: "sonnet", displayName: "Sonnet Latest", supportedEfforts: [.low, .medium, .high]),
+        ModelDefinition(runtimeModelRaw: "claude-sonnet-5", displayName: "Sonnet 5", supportedEfforts: [.low, .medium, .high, .max, .xhigh]),
         ModelDefinition(runtimeModelRaw: "claude-sonnet-4-6", displayName: "Sonnet 4.6", supportedEfforts: [.low, .medium, .high]),
         ModelDefinition(runtimeModelRaw: "claude-sonnet-4-5-20250929", displayName: "Sonnet 4.5", supportedEfforts: []),
         ModelDefinition(runtimeModelRaw: "haiku", displayName: "Haiku Latest", supportedEfforts: []),

--- a/Tests/RepoPromptTests/AI/ModelPickerStringOrderingTests.swift
+++ b/Tests/RepoPromptTests/AI/ModelPickerStringOrderingTests.swift
@@ -70,6 +70,39 @@ final class ModelPickerStringOrderingTests: XCTestCase {
         XCTAssertTrue(fableGroup.options.contains { $0.displayName == "XHigh" })
     }
 
+    func testClaudeCodePickerExposesSonnet5WithAllOfficialEffortVariants() throws {
+        let models = AIModel.modelsForProvider(.claudeCode)
+        XCTAssertTrue(models.contains(.claudeCodeModel(specifier: "claude-sonnet-5")))
+        XCTAssertTrue(models.contains(.claudeCodeModel(specifier: "claude-sonnet-5:max")))
+        XCTAssertTrue(models.contains(.claudeCodeModel(specifier: "claude-sonnet-5:xhigh")))
+        XCTAssertEqual(
+            AIModel.fromModelName("\(ClaudeCodeAIModelCatalog.rawPrefix)claude-sonnet-5:xhigh"),
+            .claudeCodeModel(specifier: "claude-sonnet-5:xhigh")
+        )
+
+        let menu = AIModel.claudeCodeMenu(for: models)
+        let sonnet5Group = try XCTUnwrap(menu.groups.first { $0.baseModelRaw == "claude-sonnet-5" })
+        XCTAssertEqual(sonnet5Group.displayName, "Sonnet 5")
+        XCTAssertEqual(sonnet5Group.options.compactMap(\.model.claudeCodeRuntimeSpecifierRaw), [
+            "claude-sonnet-5:low",
+            "claude-sonnet-5:medium",
+            "claude-sonnet-5:high",
+            "claude-sonnet-5:max",
+            "claude-sonnet-5:xhigh"
+        ])
+        XCTAssertEqual(sonnet5Group.options.map(\.displayName), ["Low", "Medium", "High", "Max", "XHigh"])
+    }
+
+    func testClaudeCodeProviderResolvesSonnet5EffortSpecifierForCLI() throws {
+        let maxSelection = try ClaudeCodeProvider.resolveCLIModelSelection(for: .claudeCodeModel(specifier: "claude-sonnet-5:max"))
+        XCTAssertEqual(maxSelection.modelArgument, "claude-sonnet-5")
+        XCTAssertEqual(maxSelection.effortLevel, .max)
+
+        let xhighSelection = try ClaudeCodeProvider.resolveCLIModelSelection(for: .claudeCodeModel(specifier: "claude-sonnet-5:xhigh"))
+        XCTAssertEqual(xhighSelection.modelArgument, "claude-sonnet-5")
+        XCTAssertEqual(xhighSelection.effortLevel, .xhigh)
+    }
+
     func testAIModelCodexMenuGroupsUseStableSemanticOrdering() {
         let groups = AIModel.codexMenuGroups(for: [
             .codexCustom(name: "gpt-5.2-high"),

--- a/Tests/RepoPromptTests/AgentMode/AgentRuntimeSidebarViewModelTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentRuntimeSidebarViewModelTests.swift
@@ -152,6 +152,15 @@ final class AgentRuntimeSidebarViewModelTests: XCTestCase {
 
         XCTAssertNil(store.runtimeVM.snapshot.contextWindowTokens)
         XCTAssertEqual(store.runtimeVM.snapshot.effectiveContextWindowTokens, 1_000_000)
+
+        store.update(
+            transcriptSnapshot: AgentTranscriptAnalyticsSnapshot(),
+            codexUsage: nil,
+            liveSelectedFileCount: nil,
+            selectedAgent: .claudeCode,
+            selectedModelRaw: "claude-sonnet-5"
+        )
+        XCTAssertEqual(store.runtimeVM.snapshot.effectiveContextWindowTokens, 1_000_000)
     }
 
     func testEncodedClaudeEffortSelectionResolvesContextWindowFallback() {
@@ -171,6 +180,24 @@ final class AgentRuntimeSidebarViewModelTests: XCTestCase {
             liveSelectedFileCount: nil,
             selectedAgent: .claudeCode,
             selectedModelRaw: "opus[1m]:xhigh"
+        )
+        XCTAssertEqual(store.runtimeVM.snapshot.effectiveContextWindowTokens, 1_000_000)
+
+        store.update(
+            transcriptSnapshot: AgentTranscriptAnalyticsSnapshot(),
+            codexUsage: nil,
+            liveSelectedFileCount: nil,
+            selectedAgent: .claudeCode,
+            selectedModelRaw: "claude-sonnet-5:max"
+        )
+        XCTAssertEqual(store.runtimeVM.snapshot.effectiveContextWindowTokens, 1_000_000)
+
+        store.update(
+            transcriptSnapshot: AgentTranscriptAnalyticsSnapshot(),
+            codexUsage: nil,
+            liveSelectedFileCount: nil,
+            selectedAgent: .claudeCode,
+            selectedModelRaw: "claude-sonnet-5:xhigh"
         )
         XCTAssertEqual(store.runtimeVM.snapshot.effectiveContextWindowTokens, 1_000_000)
 
@@ -281,9 +308,15 @@ final class AgentRuntimeSidebarViewModelTests: XCTestCase {
         viewModel.update(items: [], codexUsage: nil, selectedModelRaw: "claude-fable-5")
         XCTAssertEqual(viewModel.snapshot.effectiveContextWindowTokens, 1_000_000)
 
+        viewModel.update(items: [], codexUsage: nil, selectedModelRaw: "claude-sonnet-5")
+        XCTAssertEqual(viewModel.snapshot.effectiveContextWindowTokens, 1_000_000)
+
         // Encoded selections need the agent to disambiguate the specifier
         // grammar; without one they pin to the conservative default.
         viewModel.update(items: [], codexUsage: nil, selectedModelRaw: "claude-fable-5:xhigh")
+        XCTAssertEqual(viewModel.snapshot.effectiveContextWindowTokens, 200_000)
+
+        viewModel.update(items: [], codexUsage: nil, selectedModelRaw: "claude-sonnet-5:xhigh")
         XCTAssertEqual(viewModel.snapshot.effectiveContextWindowTokens, 200_000)
 
         // Supplying the agent unlocks encoded-raw resolution on the items path.
@@ -292,6 +325,14 @@ final class AgentRuntimeSidebarViewModelTests: XCTestCase {
             codexUsage: nil,
             selectedAgent: .claudeCode,
             selectedModelRaw: "claude-fable-5:xhigh"
+        )
+        XCTAssertEqual(viewModel.snapshot.effectiveContextWindowTokens, 1_000_000)
+
+        viewModel.update(
+            items: [],
+            codexUsage: nil,
+            selectedAgent: .claudeCode,
+            selectedModelRaw: "claude-sonnet-5:xhigh"
         )
         XCTAssertEqual(viewModel.snapshot.effectiveContextWindowTokens, 1_000_000)
     }

--- a/Tests/RepoPromptTests/AgentMode/ClaudeCompatible/ClaudeCompatiblePluginBridgeTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/ClaudeCompatible/ClaudeCompatiblePluginBridgeTests.swift
@@ -85,6 +85,9 @@ final class ClaudeCompatiblePluginBridgeTests: XCTestCase {
         XCTAssertEqual(snapshot.options.first?.isPlaceholderDefault, true)
         XCTAssertTrue(snapshot.options.contains { $0.rawValue == "claude-fable-5" && $0.supportedEffortLevels.contains("xhigh") })
         XCTAssertTrue(snapshot.options.contains { $0.rawValue == "opus" && $0.supportedEffortLevels.contains("xhigh") })
+        let sonnet5BaseOption = try XCTUnwrap(snapshot.options.first { $0.rawValue == "claude-sonnet-5" })
+        XCTAssertEqual(sonnet5BaseOption.displayName, "Sonnet 5")
+        XCTAssertEqual(sonnet5BaseOption.supportedEffortLevels, ["low", "medium", "high", "max", "xhigh"])
 
         let options = AgentModelCatalog.options(for: .claudeCode, availability: availability)
         let menu = AgentModelCatalog.claudeMenu(for: options, agentKind: .claudeCode)
@@ -95,6 +98,19 @@ final class ClaudeCompatiblePluginBridgeTests: XCTestCase {
         XCTAssertTrue(groupRaws.contains("opus[1m]"))
         XCTAssertTrue(groupRaws.contains("opus"))
         XCTAssertTrue(groupRaws.contains("sonnet"))
+        XCTAssertTrue(groupRaws.contains("claude-sonnet-5"))
+        let sonnet5Group = try XCTUnwrap(menu.groups.first { $0.baseModelRaw == "claude-sonnet-5" })
+        XCTAssertEqual(sonnet5Group.displayName, "Sonnet 5")
+        XCTAssertEqual(sonnet5Group.options.map(\.rawValue), [
+            "claude-sonnet-5:low",
+            "claude-sonnet-5:medium",
+            "claude-sonnet-5:high",
+            "claude-sonnet-5:max",
+            "claude-sonnet-5:xhigh"
+        ])
+        XCTAssertTrue(AgentModelCatalog.isValid(rawModel: "claude-sonnet-5", for: .claudeCode, availability: availability))
+        XCTAssertTrue(AgentModelCatalog.isValid(rawModel: "claude-sonnet-5:max", for: .claudeCode, availability: availability))
+        XCTAssertTrue(AgentModelCatalog.isValid(rawModel: "claude-sonnet-5:xhigh", for: .claudeCode, availability: availability))
 
         let discovery = try XCTUnwrap(AgentModelCatalog.discoveryAgents(availability: availability).first { $0.agent == .claudeCode })
         XCTAssertEqual(discovery.defaults.modelRaw, "opus")
@@ -103,6 +119,18 @@ final class ClaudeCompatiblePluginBridgeTests: XCTestCase {
         XCTAssertTrue(discovery.models.contains { $0.id == "default" })
         XCTAssertTrue(discovery.models.contains { $0.id == "claude-fable-5" && $0.contextWindowTokens == 1_000_000 })
         XCTAssertTrue(discovery.models.contains { $0.id == "opus" })
+        let sonnet5Discovery = try XCTUnwrap(discovery.models.first { $0.id == "claude-sonnet-5" })
+        XCTAssertEqual(sonnet5Discovery.contextWindowTokens, 1_000_000)
+        XCTAssertTrue(sonnet5Discovery.tags.contains(.balanced))
+        XCTAssertTrue(sonnet5Discovery.tags.contains(.extendedContext))
+        XCTAssertEqual(
+            sonnet5Discovery.startTargets.first { $0.modelRaw == "claude-sonnet-5:xhigh" }?.contextWindowTokens,
+            1_000_000
+        )
+        XCTAssertEqual(
+            sonnet5Discovery.startTargets.first { $0.modelRaw == "claude-sonnet-5:max" }?.contextWindowTokens,
+            1_000_000
+        )
 
         let glmBaseSnapshot = try XCTUnwrap(ClaudeCompatibleModelCatalogAdapter.catalogSnapshot(
             for: .claudeCodeGLM,


### PR DESCRIPTION
## Summary
- Adds explicit Claude Sonnet 5 (`claude-sonnet-5`) support across app and provider model catalogs
- Enables all official Claude Code effort levels: low, medium, high, max, and xhigh
- Marks Sonnet 5 as a 1M-context model for discovery/sidebar context reporting
- Adds focused tests for provider catalog, bridge/discovery, picker variants, CLI model selection, and sidebar context-window behavior

## Testing
- `make dev-format`
- `make dev-provider-test FILTER=ClaudeCompatibleRuntimeSupportTests`
- `make dev-test FILTER=ClaudeCompatiblePluginBridgeTests`
- `make dev-test FILTER=ModelPickerStringOrderingTests`
- `make dev-test FILTER=AgentRuntimeSidebarViewModelTests`
- `make dev-lint`