### PR TITLE
[codex] Contain codemap selection decode failures

### DIFF
--- a/Sources/RepoPrompt/Features/Workspaces/WorkspaceModel.swift
+++ b/Sources/RepoPrompt/Features/Workspaces/WorkspaceModel.swift
@@ -165,11 +165,14 @@ struct StoredSelection: Codable, Equatable, Hashable {
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
+        let codemapAutoEnabled = try container.decodeIfPresent(Bool.self, forKey: .codemapAutoEnabled) ?? true
+        let decodedManualCodemapPaths = try container.decodeIfPresent([String].self, forKey: .manualCodemapPaths)
+        let legacyAutoCodemapPaths = try container.decodeIfPresent([String].self, forKey: .autoCodemapPaths) ?? []
         try self.init(
             selectedPaths: container.decodeIfPresent([String].self, forKey: .selectedPaths) ?? [],
-            manualCodemapPaths: container.decodeIfPresent([String].self, forKey: .manualCodemapPaths) ?? [],
+            manualCodemapPaths: decodedManualCodemapPaths ?? (codemapAutoEnabled ? [] : legacyAutoCodemapPaths),
             slices: container.decodeIfPresent([String: [LineRange]].self, forKey: .slices) ?? [:],
-            codemapAutoEnabled: container.decodeIfPresent(Bool.self, forKey: .codemapAutoEnabled) ?? true
+            codemapAutoEnabled: codemapAutoEnabled
         )
     }
 
@@ -177,6 +180,7 @@ struct StoredSelection: Codable, Equatable, Hashable {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(selectedPaths, forKey: .selectedPaths)
         try container.encode(manualCodemapPaths, forKey: .manualCodemapPaths)
+        try container.encode(codemapAutoEnabled ? [] : manualCodemapPaths, forKey: .autoCodemapPaths)
         try container.encode(slices, forKey: .slices)
         try container.encode(codemapAutoEnabled, forKey: .codemapAutoEnabled)
     }
@@ -184,6 +188,7 @@ struct StoredSelection: Codable, Equatable, Hashable {
     private enum CodingKeys: String, CodingKey {
         case selectedPaths
         case manualCodemapPaths
+        case autoCodemapPaths
         case slices
         case codemapAutoEnabled
     }

--- a/Sources/RepoPrompt/Features/Workspaces/WorkspaceModel.swift
+++ b/Sources/RepoPrompt/Features/Workspaces/WorkspaceModel.swift
@@ -165,14 +165,11 @@ struct StoredSelection: Codable, Equatable, Hashable {
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        let codemapAutoEnabled = try container.decodeIfPresent(Bool.self, forKey: .codemapAutoEnabled) ?? true
-        let decodedManualCodemapPaths = try container.decodeIfPresent([String].self, forKey: .manualCodemapPaths)
-        let legacyAutoCodemapPaths = try container.decodeIfPresent([String].self, forKey: .autoCodemapPaths) ?? []
         try self.init(
             selectedPaths: container.decodeIfPresent([String].self, forKey: .selectedPaths) ?? [],
-            manualCodemapPaths: decodedManualCodemapPaths ?? (codemapAutoEnabled ? [] : legacyAutoCodemapPaths),
+            manualCodemapPaths: container.decodeIfPresent([String].self, forKey: .manualCodemapPaths) ?? [],
             slices: container.decodeIfPresent([String: [LineRange]].self, forKey: .slices) ?? [:],
-            codemapAutoEnabled: codemapAutoEnabled
+            codemapAutoEnabled: container.decodeIfPresent(Bool.self, forKey: .codemapAutoEnabled) ?? true
         )
     }
 
@@ -180,7 +177,7 @@ struct StoredSelection: Codable, Equatable, Hashable {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(selectedPaths, forKey: .selectedPaths)
         try container.encode(manualCodemapPaths, forKey: .manualCodemapPaths)
-        try container.encode(codemapAutoEnabled ? [] : manualCodemapPaths, forKey: .autoCodemapPaths)
+        try container.encode([String](), forKey: .autoCodemapPaths)
         try container.encode(slices, forKey: .slices)
         try container.encode(codemapAutoEnabled, forKey: .codemapAutoEnabled)
     }
@@ -305,7 +302,7 @@ struct ComposeTabState: Codable, Identifiable, Equatable {
         isPinned = try c.decodeIfPresent(Bool.self, forKey: .isPinned) ?? false
         activeChatSessionID = try c.decodeIfPresent(UUID.self, forKey: .activeChatSessionID)
         activeAgentSessionID = try c.decodeIfPresent(UUID.self, forKey: .activeAgentSessionID)
-        selection = try c.decodeIfPresent(StoredSelection.self, forKey: .selection) ?? .init()
+        selection = (try? c.decodeIfPresent(StoredSelection.self, forKey: .selection)) ?? .init()
         expandedFolders = try c.decodeIfPresent([String].self, forKey: .expandedFolders) ?? []
         promptText = try c.decodeIfPresent(String.self, forKey: .promptText) ?? ""
         selectedMetaPromptIDs = try c.decodeIfPresent([UUID].self, forKey: .selectedMetaPromptIDs) ?? []

--- a/Tests/RepoPromptTests/WorkspaceContext/WorkspaceFilesAutoCodemapModeTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/WorkspaceFilesAutoCodemapModeTests.swift
@@ -53,8 +53,10 @@ final class WorkspaceFilesAutoCodemapModeTests: XCTestCase {
         XCTAssertTrue(snapshot.codemapAutoEnabled)
 
         let encoded = try JSONEncoder().encode(snapshot)
-        let encodedText = try XCTUnwrap(String(data: encoded, encoding: .utf8))
-        XCTAssertFalse(encodedText.contains("autoCodemapPaths"))
+        let encodedObject = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        )
+        XCTAssertEqual(encodedObject["autoCodemapPaths"] as? [String], [])
 
         fixture.viewModel.setAutoCodemapFilesForTesting([fixture.file])
         XCTAssertEqual(fixture.viewModel.autoCodemapFiles.map(\.id), [fixture.file.id])

--- a/Tests/RepoPromptTests/WorkspaceContext/WorkspaceSelectionAutoCodemapInvariantTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/WorkspaceSelectionAutoCodemapInvariantTests.swift
@@ -109,7 +109,7 @@ final class WorkspaceSelectionAutoCodemapInvariantTests: XCTestCase {
         XCTAssertTrue(removed.mutated)
     }
 
-    func testStoredSelectionPrefersManualPathsAndDualWritesLegacyCompatibilityAlias() throws {
+    func testStoredSelectionIgnoresLegacyInferredPathsAndWritesCompatibilityAlias() throws {
         let legacyJSON = try XCTUnwrap(
             """
             {
@@ -128,51 +128,14 @@ final class WorkspaceSelectionAutoCodemapInvariantTests: XCTestCase {
         XCTAssertFalse(decoded.codemapAutoEnabled)
 
         let encoded = try JSONEncoder().encode(decoded)
-        let encodedText = try XCTUnwrap(String(data: encoded, encoding: .utf8))
         let encodedObject = try XCTUnwrap(
             JSONSerialization.jsonObject(with: encoded) as? [String: Any]
         )
-        XCTAssertFalse(encodedText.contains("/workspace/Legacy.swift"))
         XCTAssertEqual(
             encodedObject["manualCodemapPaths"] as? [String],
             ["/workspace/Manual.swift"]
         )
-        XCTAssertEqual(
-            encodedObject["autoCodemapPaths"] as? [String],
-            ["/workspace/Manual.swift"]
-        )
-    }
-
-    func testStoredSelectionMigratesLegacyManualModePathsOnly() throws {
-        let manualLegacyJSON = try XCTUnwrap(
-            """
-            {
-              "selectedPaths": ["/workspace/Source.swift"],
-              "autoCodemapPaths": ["/workspace/LegacyManual.swift"],
-              "slices": {},
-              "codemapAutoEnabled": false
-            }
-            """.data(using: .utf8)
-        )
-
-        let manualDecoded = try JSONDecoder().decode(StoredSelection.self, from: manualLegacyJSON)
-        XCTAssertEqual(manualDecoded.manualCodemapPaths, ["/workspace/LegacyManual.swift"])
-        XCTAssertFalse(manualDecoded.codemapAutoEnabled)
-
-        let autoLegacyJSON = try XCTUnwrap(
-            """
-            {
-              "selectedPaths": ["/workspace/Source.swift"],
-              "autoCodemapPaths": ["/workspace/Inferred.swift"],
-              "slices": {},
-              "codemapAutoEnabled": true
-            }
-            """.data(using: .utf8)
-        )
-
-        let autoDecoded = try JSONDecoder().decode(StoredSelection.self, from: autoLegacyJSON)
-        XCTAssertTrue(autoDecoded.manualCodemapPaths.isEmpty)
-        XCTAssertTrue(autoDecoded.codemapAutoEnabled)
+        XCTAssertEqual(encodedObject["autoCodemapPaths"] as? [String], [])
     }
 
     func testStoredSelectionEncodingRemainsReadableByLegacyDecoder() throws {
@@ -184,16 +147,7 @@ final class WorkspaceSelectionAutoCodemapInvariantTests: XCTestCase {
 
         let manualEncoded = try JSONEncoder().encode(currentManual)
         let legacyManual = try JSONDecoder().decode(LegacyStoredSelection.self, from: manualEncoded)
-        XCTAssertEqual(legacyManual.autoCodemapPaths, ["/workspace/Manual.swift"])
-
-        let currentAuto = StoredSelection(
-            selectedPaths: ["/workspace/Source.swift"],
-            codemapAutoEnabled: true
-        )
-
-        let autoEncoded = try JSONEncoder().encode(currentAuto)
-        let legacyAuto = try JSONDecoder().decode(LegacyStoredSelection.self, from: autoEncoded)
-        XCTAssertTrue(legacyAuto.autoCodemapPaths.isEmpty)
+        XCTAssertTrue(legacyManual.autoCodemapPaths.isEmpty)
     }
 
     func testSelectionProductionPathContainsNoLegacyRelationshipCalls() throws {

--- a/Tests/RepoPromptTests/WorkspaceContext/WorkspaceSelectionAutoCodemapInvariantTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/WorkspaceSelectionAutoCodemapInvariantTests.swift
@@ -109,7 +109,7 @@ final class WorkspaceSelectionAutoCodemapInvariantTests: XCTestCase {
         XCTAssertTrue(removed.mutated)
     }
 
-    func testStoredSelectionPersistsManualPathsButDiscardsLegacyInferredPathKey() throws {
+    func testStoredSelectionPrefersManualPathsAndDualWritesLegacyCompatibilityAlias() throws {
         let legacyJSON = try XCTUnwrap(
             """
             {
@@ -132,12 +132,68 @@ final class WorkspaceSelectionAutoCodemapInvariantTests: XCTestCase {
         let encodedObject = try XCTUnwrap(
             JSONSerialization.jsonObject(with: encoded) as? [String: Any]
         )
-        XCTAssertFalse(encodedText.contains("autoCodemapPaths"))
         XCTAssertFalse(encodedText.contains("/workspace/Legacy.swift"))
         XCTAssertEqual(
             encodedObject["manualCodemapPaths"] as? [String],
             ["/workspace/Manual.swift"]
         )
+        XCTAssertEqual(
+            encodedObject["autoCodemapPaths"] as? [String],
+            ["/workspace/Manual.swift"]
+        )
+    }
+
+    func testStoredSelectionMigratesLegacyManualModePathsOnly() throws {
+        let manualLegacyJSON = try XCTUnwrap(
+            """
+            {
+              "selectedPaths": ["/workspace/Source.swift"],
+              "autoCodemapPaths": ["/workspace/LegacyManual.swift"],
+              "slices": {},
+              "codemapAutoEnabled": false
+            }
+            """.data(using: .utf8)
+        )
+
+        let manualDecoded = try JSONDecoder().decode(StoredSelection.self, from: manualLegacyJSON)
+        XCTAssertEqual(manualDecoded.manualCodemapPaths, ["/workspace/LegacyManual.swift"])
+        XCTAssertFalse(manualDecoded.codemapAutoEnabled)
+
+        let autoLegacyJSON = try XCTUnwrap(
+            """
+            {
+              "selectedPaths": ["/workspace/Source.swift"],
+              "autoCodemapPaths": ["/workspace/Inferred.swift"],
+              "slices": {},
+              "codemapAutoEnabled": true
+            }
+            """.data(using: .utf8)
+        )
+
+        let autoDecoded = try JSONDecoder().decode(StoredSelection.self, from: autoLegacyJSON)
+        XCTAssertTrue(autoDecoded.manualCodemapPaths.isEmpty)
+        XCTAssertTrue(autoDecoded.codemapAutoEnabled)
+    }
+
+    func testStoredSelectionEncodingRemainsReadableByLegacyDecoder() throws {
+        let currentManual = StoredSelection(
+            selectedPaths: ["/workspace/Source.swift"],
+            manualCodemapPaths: ["/workspace/Manual.swift"],
+            codemapAutoEnabled: false
+        )
+
+        let manualEncoded = try JSONEncoder().encode(currentManual)
+        let legacyManual = try JSONDecoder().decode(LegacyStoredSelection.self, from: manualEncoded)
+        XCTAssertEqual(legacyManual.autoCodemapPaths, ["/workspace/Manual.swift"])
+
+        let currentAuto = StoredSelection(
+            selectedPaths: ["/workspace/Source.swift"],
+            codemapAutoEnabled: true
+        )
+
+        let autoEncoded = try JSONEncoder().encode(currentAuto)
+        let legacyAuto = try JSONDecoder().decode(LegacyStoredSelection.self, from: autoEncoded)
+        XCTAssertTrue(legacyAuto.autoCodemapPaths.isEmpty)
     }
 
     func testSelectionProductionPathContainsNoLegacyRelationshipCalls() throws {
@@ -192,4 +248,11 @@ final class WorkspaceSelectionAutoCodemapInvariantTests: XCTestCase {
         )
         try content.write(to: url, atomically: true, encoding: .utf8)
     }
+}
+
+private struct LegacyStoredSelection: Codable {
+    let selectedPaths: [String]
+    let autoCodemapPaths: [String]
+    let slices: [String: [LineRange]]
+    let codemapAutoEnabled: Bool
 }

--- a/Tests/RepoPromptTests/WorkspaceContext/WorkspaceSelectionPersistenceTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/WorkspaceSelectionPersistenceTests.swift
@@ -186,6 +186,56 @@ final class WorkspaceSelectionPersistenceTests: XCTestCase {
         XCTAssertEqual(result.workspace.repoPaths, workspace.repoPaths)
     }
 
+    func testMalformedComposeTabSelectionDoesNotDropTabState() throws {
+        let workspaceID = UUID()
+        let tabID = UUID()
+        let activeChatSessionID = UUID()
+        let activeAgentSessionID = UUID()
+        let workspaceJSON = """
+        {
+          "id": "\(workspaceID.uuidString)",
+          "schemaVersion": 1,
+          "name": "Selection Decode Recovery",
+          "repoPaths": ["/tmp/root"],
+          "composeTabs": [
+            {
+              "id": "\(tabID.uuidString)",
+              "name": "Investigation",
+              "isPinned": true,
+              "activeChatSessionID": "\(activeChatSessionID.uuidString)",
+              "activeAgentSessionID": "\(activeAgentSessionID.uuidString)",
+              "selection": {
+                "selectedPaths": 42,
+                "manualCodemapPaths": ["/tmp/root/Manual.swift"],
+                "slices": {},
+                "codemapAutoEnabled": false
+              },
+              "expandedFolders": ["/tmp/root/Sources"],
+              "promptText": "preserve this prompt",
+              "selectedMetaPromptIDs": []
+            }
+          ],
+          "activeComposeTabID": "\(tabID.uuidString)",
+          "stashedTabs": []
+        }
+        """
+
+        let data = try XCTUnwrap(workspaceJSON.data(using: .utf8))
+        let decoded = try JSONDecoder().decode(WorkspaceModel.self, from: data)
+
+        XCTAssertEqual(decoded.composeTabs.count, 1)
+        let tab = try XCTUnwrap(decoded.composeTabs.first)
+        XCTAssertEqual(tab.id, tabID)
+        XCTAssertEqual(tab.name, "Investigation")
+        XCTAssertTrue(tab.isPinned)
+        XCTAssertEqual(tab.activeChatSessionID, activeChatSessionID)
+        XCTAssertEqual(tab.activeAgentSessionID, activeAgentSessionID)
+        XCTAssertEqual(tab.expandedFolders, ["/tmp/root/Sources"])
+        XCTAssertEqual(tab.promptText, "preserve this prompt")
+        XCTAssertEqual(tab.selection, StoredSelection())
+        XCTAssertEqual(decoded.activeComposeTabID, tabID)
+    }
+
     private static func workspace(
         id: UUID,
         tabID: UUID,


### PR DESCRIPTION
## Summary
- contain malformed compose-tab `selection` decode failures to the selection field instead of failing the whole tab array
- keep tab metadata, prompt text, expanded folders, and active chat/agent IDs when selection JSON is stale or malformed
- write an empty legacy `autoCodemapPaths` key so older v1.0.22-shaped decoders do not fail on the missing non-optional field

## Why
The dangerous failure mode is not losing file selection. It is a nested `StoredSelection` decode failure propagating into `composeTabs`, falling back to an empty array, normalizing to `T1`, and then potentially writing that broader tab loss back to disk.

This keeps the fix intentionally small: current builds may drop only the bad selection, while older readers get the required legacy key without reintroducing persisted inferred codemap paths.

## Validation
- Context Builder review for minimality: keep lossy nested selection decode as the core data-loss containment fix; keep the legacy key only as old-reader structural compatibility
- `make dev-format`
- `make dev-test FILTER=WorkspaceSelectionAutoCodemapInvariantTests`
- `make dev-test FILTER=WorkspaceSelectionPersistenceTests`
- `make dev-test FILTER=WorkspaceFilesAutoCodemapModeTests`
- `make dev-lint`
- `make dev-swift-build PRODUCT=RepoPrompt`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh commit`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh push`