### PR TITLE
Fix MCP token accounting freshness reporting

### DIFF
--- a/Sources/RepoPrompt/Infrastructure/MCP/ToolOutputFormatter.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ToolOutputFormatter.swift
@@ -2255,12 +2255,28 @@ extension ToolOutputFormatter {
 
             // Token breakdown - organized by category
             if let ts = ctx.tokenStats {
-                out.append("**\(formatTokenCount(ts.total)) total tokens**")
+                let totalPending = selectionTokenTotalIsPending(
+                    totalTokens: ts.total,
+                    fileCount: selectionCount,
+                    accounting: ctx.tokenAccounting
+                )
+                let selectionPending = selectionTokenTotalIsPending(
+                    totalTokens: ts.files,
+                    fileCount: selectionCount,
+                    accounting: ctx.tokenAccounting
+                )
+                if totalPending {
+                    out.append("**Token accounting pending**")
+                } else {
+                    out.append("**\(formatTokenCount(ts.total)) total tokens**")
+                }
                 out.append("")
 
                 // Selection section (files + codemaps)
                 let hasFilesBreakdown = (ts.filesContent != nil && ts.filesContent! > 0) || (ts.codemaps != nil && ts.codemaps! > 0)
-                if hasFilesBreakdown {
+                if selectionPending {
+                    out.append("- **Selection**: pending")
+                } else if hasFilesBreakdown {
                     out.append("- **Selection**: \(formatTokenCount(ts.files))")
                     if let filesContent = ts.filesContent, filesContent > 0 {
                         out.append("  - Files: \(formatTokenCount(filesContent))")
@@ -2287,7 +2303,7 @@ extension ToolOutputFormatter {
                 }
             }
             if let accounting = ctx.tokenAccounting {
-                out.append("- Token accounting: \(accounting.status) from \(accounting.source)\(accounting.refreshPending ? "; refresh pending" : "")")
+                out.append("- Token accounting: \(tokenAccountingSummaryText(accounting))")
             }
             if let sel = ctx.selection {
                 if let summary = sel.summary {
@@ -2688,6 +2704,35 @@ extension ToolOutputFormatter {
         return formatGeneric(value: value)
     }
 
+    private static func tokenAccountingSummaryText(_ accounting: ToolResultDTOs.TokenAccountingDTO) -> String {
+        var text = "\(accounting.status) from \(accounting.source)"
+        if accounting.refreshPending {
+            text += "; refresh pending"
+        }
+        if let incomplete = accounting.incompleteComponents, !incomplete.isEmpty {
+            text += "; incomplete: \(incomplete.joined(separator: ", "))"
+        }
+        return text
+    }
+
+    private static func selectionTokenTotalIsPending(
+        totalTokens: Int?,
+        fileCount: Int,
+        accounting: ToolResultDTOs.TokenAccountingDTO?
+    ) -> Bool {
+        guard fileCount > 0 else { return false }
+        guard totalTokens.map({ $0 == 0 }) ?? true else { return false }
+        guard let accounting else { return false }
+        if accounting.status == "incomplete" { return true }
+        if accounting.incompleteComponents?.isEmpty == false { return true }
+        let pendingSources: Set = [
+            "active_tab_published",
+            "bound_tab_cached_state",
+            "bound_tab_cache"
+        ]
+        return accounting.refreshPending && pendingSources.contains(accounting.source)
+    }
+
     /// Formats a SelectionReply to a string for embedding in other responses
     static func formatSelectionReplyToString(_ dto: ToolResultDTOs.SelectionReply) -> String {
         var out: [String] = []
@@ -2706,7 +2751,15 @@ extension ToolOutputFormatter {
                 }
             }
             let totalTokens = dto.totalTokens ?? (summary.fullTokens + summary.sliceTokens + summary.codemapTokens)
-            out.append("- Total tokens: \(totalTokens) (Auto view)")
+            if selectionTokenTotalIsPending(
+                totalTokens: totalTokens,
+                fileCount: fileCount,
+                accounting: dto.tokenAccounting
+            ) {
+                out.append("- Total tokens: pending (Auto view)")
+            } else {
+                out.append("- Total tokens: \(totalTokens) (Auto view)")
+            }
             let tokenBreakdown = selectionTokenBreakdownText(summary)
             if !tokenBreakdown.isEmpty {
                 out.append("- Token breakdown: \(tokenBreakdown)")
@@ -2716,12 +2769,20 @@ extension ToolOutputFormatter {
                 out.append("- Files: \(files.count)")
             }
             if let total = dto.totalTokens {
-                out.append("- Total tokens: \(total) (Auto view)")
+                if selectionTokenTotalIsPending(
+                    totalTokens: total,
+                    fileCount: fileCount,
+                    accounting: dto.tokenAccounting
+                ) {
+                    out.append("- Total tokens: pending (Auto view)")
+                } else {
+                    out.append("- Total tokens: \(total) (Auto view)")
+                }
             }
         }
 
         if let accounting = dto.tokenAccounting {
-            out.append("- Token accounting: \(accounting.status) from \(accounting.source)\(accounting.refreshPending ? "; refresh pending" : "")")
+            out.append("- Token accounting: \(tokenAccountingSummaryText(accounting))")
         }
 
         // Copy preset effect (only if it differs from auto)
@@ -2775,9 +2836,27 @@ extension ToolOutputFormatter {
             let copyMode = dto.userCopyCodeMapUsage ?? "auto"
             let isNonAutoMode = copyMode != "auto"
 
+            let totalPending = selectionTokenTotalIsPending(
+                totalTokens: actualTotal,
+                fileCount: fileCount,
+                accounting: dto.tokenAccounting
+            )
+            let autoFileTokensPending = selectionTokenTotalIsPending(
+                totalTokens: fileTokens,
+                fileCount: fileCount,
+                accounting: dto.tokenAccounting
+            )
+
             // Header
             out.append("## Selection \(statusIcon(success: true))")
-            out.append("**\(formatTokenCount(actualTotal)) total tokens**")
+            if totalPending {
+                out.append("**Token accounting pending**")
+            } else {
+                out.append("**\(formatTokenCount(actualTotal)) total tokens**")
+            }
+            if let accounting = dto.tokenAccounting {
+                out.append("Token accounting: \(tokenAccountingSummaryText(accounting))")
+            }
 
             if let ts = dto.tokenStats {
                 out.append("")
@@ -2796,7 +2875,15 @@ extension ToolOutputFormatter {
                     if hiddenFiles > 0 {
                         fileDesc += ", \(hiddenFiles) hidden"
                     }
-                    out.append("Files: \(formatTokenCount(copyPresetTokens)) (\(fileDesc))")
+                    if selectionTokenTotalIsPending(
+                        totalTokens: copyPresetTokens,
+                        fileCount: visibleFiles,
+                        accounting: dto.tokenAccounting
+                    ) {
+                        out.append("Files: pending (\(fileDesc))")
+                    } else {
+                        out.append("Files: \(formatTokenCount(copyPresetTokens)) (\(fileDesc))")
+                    }
 
                     // Show auto view as reference for MCP tools
                     let hasFilesBreakdown = (ts.filesContent != nil && ts.filesContent! > 0) || (ts.codemaps != nil && ts.codemaps! > 0)
@@ -2809,7 +2896,9 @@ extension ToolOutputFormatter {
                 } else {
                     // Auto mode - show breakdown directly
                     let hasFilesBreakdown = (ts.filesContent != nil && ts.filesContent! > 0) || (ts.codemaps != nil && ts.codemaps! > 0)
-                    if hasFilesBreakdown {
+                    if autoFileTokensPending {
+                        out.append("Files: pending (\(fileCount) file\(fileCount == 1 ? "" : "s"))")
+                    } else if hasFilesBreakdown {
                         var parts: [String] = []
                         if let fc = ts.filesContent, fc > 0 { parts.append("\(formatTokenCount(fc)) full") }
                         if let cm = ts.codemaps, cm > 0 { parts.append("\(formatTokenCount(cm)) codemaps") }

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+SelectionCore.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+SelectionCore.swift
@@ -274,6 +274,7 @@ extension MCPServerViewModel {
         struct SelectionCollections {
             let selected: [SelectedEntry]
             let codemap: [CodemapEntry]
+            let requestedCodemapFiles: [WorkspaceFileRecord]
             let codemapAutoEnabled: Bool
             let codeMapUsage: CodeMapUsage
             let invalid: [String]
@@ -283,11 +284,400 @@ extension MCPServerViewModel {
                 SelectionCollections(
                     selected: [],
                     codemap: [],
+                    requestedCodemapFiles: [],
                     codemapAutoEnabled: false,
                     codeMapUsage: codeMapUsage,
                     invalid: [],
                     codemapPresentation: .empty
                 )
+            }
+        }
+
+        struct CodemapPathDiagnostics: Equatable {
+            let pendingPaths: [String]
+            let unmappedPaths: [String]
+
+            var isEmpty: Bool {
+                pendingPaths.isEmpty && unmappedPaths.isEmpty
+            }
+        }
+
+        private enum MissingCodemapDisposition {
+            case pending
+            case unmapped
+        }
+
+        private enum CodemapIssueDisposition {
+            case pending
+            case unmapped(terminal: Bool)
+        }
+
+        static func codemapDiagnosticFiles(
+            for collections: SelectionCollections
+        ) -> [WorkspaceFileRecord] {
+            switch collections.codeMapUsage {
+            case .none:
+                []
+            case .auto:
+                collections.requestedCodemapFiles + collections.codemap.map(\.file)
+            case .selected, .complete:
+                collections.selected.map(\.file)
+                    + collections.codemap.map(\.file)
+                    + collections.requestedCodemapFiles
+            }
+        }
+
+        static func missingCodemapDiagnostics(
+            for files: [WorkspaceFileRecord],
+            presentation: WorkspaceCodemapOperationPresentation,
+            displayPath: (WorkspaceFileRecord) async -> String
+        ) async -> CodemapPathDiagnostics {
+            let missingFiles = codemapDiagnosticFiles(files, presentation: presentation)
+            var pendingPaths: [String] = []
+            var unmappedPaths: [String] = []
+            var seenPending = Set<String>()
+            var seenUnmapped = Set<String>()
+
+            for file in missingFiles {
+                let path = await displayPath(file)
+                switch missingCodemapDisposition(for: file, presentation: presentation) {
+                case .pending:
+                    if seenPending.insert(path).inserted {
+                        pendingPaths.append(path)
+                    }
+                case .unmapped:
+                    if seenUnmapped.insert(path).inserted {
+                        unmappedPaths.append(path)
+                    }
+                }
+            }
+
+            return CodemapPathDiagnostics(
+                pendingPaths: pendingPaths,
+                unmappedPaths: unmappedPaths
+            )
+        }
+
+        static func hasPendingCodemapPresentationGaps(
+            for files: [WorkspaceFileRecord],
+            presentation: WorkspaceCodemapOperationPresentation,
+            codeMapUsage: CodeMapUsage
+        ) -> Bool {
+            guard codeMapUsage != .none else { return false }
+            return codemapDiagnosticFiles(files, presentation: presentation).contains { file in
+                missingCodemapDisposition(for: file, presentation: presentation) == .pending
+            }
+        }
+
+        private static func codemapDiagnosticFiles(
+            _ files: [WorkspaceFileRecord],
+            presentation: WorkspaceCodemapOperationPresentation
+        ) -> [WorkspaceFileRecord] {
+            var seen = Set<UUID>()
+            var missing: [WorkspaceFileRecord] = []
+            for file in files {
+                guard seen.insert(file.id).inserted else { continue }
+                guard presentation.renderedEntriesByFileID[file.id] == nil else { continue }
+                missing.append(file)
+            }
+            return missing
+        }
+
+        private static func missingCodemapDisposition(
+            for file: WorkspaceFileRecord,
+            presentation: WorkspaceCodemapOperationPresentation
+        ) -> MissingCodemapDisposition {
+            guard supportsCodemap(file) else { return .unmapped }
+
+            let issues = presentation.issues + coverageIssues(presentation.coverage)
+            var sawPending = false
+            var sawUnmapped = false
+            var sawTerminalUnmapped = false
+            for issue in issues {
+                guard let disposition = codemapDisposition(
+                    for: issue,
+                    fileID: file.id
+                ) else { continue }
+                switch disposition {
+                case .pending:
+                    sawPending = true
+                case let .unmapped(terminal):
+                    sawUnmapped = true
+                    sawTerminalUnmapped = sawTerminalUnmapped || terminal
+                }
+            }
+            if sawTerminalUnmapped { return .unmapped }
+            if sawPending { return .pending }
+            if sawUnmapped { return .unmapped }
+
+            if presentationCoverageIsIncomplete(presentation.coverage) || !issues.isEmpty {
+                return .pending
+            }
+
+            // A supported file absent from an otherwise empty/complete presentation is
+            // ambiguous in MCP's non-blocking path: CAS may not have produced a rendered
+            // bundle yet, or the codemap may not have been requested by the stale snapshot.
+            // Prefer a retryable/pending diagnostic over a final-looking unmapped result.
+            return .pending
+        }
+
+        private static func supportsCodemap(_ file: WorkspaceFileRecord) -> Bool {
+            let fileExtension = (file.name as NSString).pathExtension.lowercased()
+            guard !fileExtension.isEmpty else { return false }
+            return SyntaxManager.supportsCodeMap(fileExtension: fileExtension)
+        }
+
+        private static func coverageIssues(
+            _ coverage: WorkspaceCodemapOperationPresentationCoverage
+        ) -> [WorkspaceCodemapOperationIssue] {
+            switch coverage {
+            case .complete:
+                []
+            case let .partial(issues), let .pending(issues), let .unavailable(issues):
+                issues
+            }
+        }
+
+        private static func presentationCoverageIsIncomplete(
+            _ coverage: WorkspaceCodemapOperationPresentationCoverage
+        ) -> Bool {
+            switch coverage {
+            case .complete:
+                false
+            case .partial, .pending, .unavailable:
+                true
+            }
+        }
+
+        private static func codemapDisposition(
+            for issue: WorkspaceCodemapOperationIssue,
+            fileID: UUID
+        ) -> CodemapIssueDisposition? {
+            switch issue {
+            case .coordinationUnavailable, .cancelled, .publicationStale:
+                return .pending
+            case let .candidate(candidateIssue):
+                return candidateDisposition(candidateIssue, fileID: fileID)
+            case let .pending(pendingFileID, _):
+                return pendingFileID == fileID ? .pending : nil
+            case let .unavailable(unavailableFileID, reason):
+                guard unavailableFileID == fileID else { return nil }
+                return unavailableDisposition(reason)
+            case let .automatic(coverage):
+                return automaticCoverageDisposition(coverage, fileID: fileID)
+            case let .freezeUnavailable(_, reason):
+                return freezeUnavailableDisposition(reason)
+            case let .renderUnavailable(_, reason):
+                return renderUnavailableDisposition(reason, fileID: fileID)
+            }
+        }
+
+        private static func candidateDisposition(
+            _ issue: WorkspaceCodemapOperationCandidateIssue,
+            fileID: UUID
+        ) -> CodemapIssueDisposition? {
+            switch issue {
+            case let .fileNotCataloged(candidateFileID):
+                candidateFileID == fileID ? .pending : nil
+            case let .fileOutsideRootScope(candidateFileID),
+                 let .logicalPathUnavailable(candidateFileID):
+                candidateFileID == fileID ? .unmapped(terminal: true) : nil
+            case let .incompleteRootSet(missingFileIDs):
+                missingFileIDs.contains(fileID) ? .pending : nil
+            }
+        }
+
+        private static func unavailableDisposition(
+            _ reason: WorkspaceCodemapArtifactDemandUnavailableReason
+        ) -> CodemapIssueDisposition {
+            switch reason {
+            case .unsupportedFileType:
+                .unmapped(terminal: true)
+            case .gitTerminal:
+                .unmapped(terminal: true)
+            case let .demandUnavailable(reason):
+                demandUnavailableDisposition(reason)
+            case .rootNotLoaded, .fileNotCataloged, .gitTransient, .busy,
+                 .rejected, .routeConflict, .registrationFailed, .runtimeFailure,
+                 .staleCurrentness, .cancelled:
+                .pending
+            }
+        }
+
+        private static func demandUnavailableDisposition(
+            _ reason: WorkspaceCodemapBindingDemandUnavailableReason
+        ) -> CodemapIssueDisposition {
+            switch reason {
+            case .unsupportedFileType, .missing, .securityExcluded, .nonRegular,
+                 .oversized, .terminalArtifact:
+                .unmapped(terminal: true)
+            case .transient:
+                .pending
+            }
+        }
+
+        private static func automaticCoverageDisposition(
+            _ coverage: WorkspaceCodemapAutomaticSelectionAggregateCoverage,
+            fileID: UUID
+        ) -> CodemapIssueDisposition? {
+            automaticCoverageDispositionByFileID(coverage)[fileID]
+        }
+
+        private static func automaticCoverageDispositionByFileID(
+            _ coverage: WorkspaceCodemapAutomaticSelectionAggregateCoverage
+        ) -> [UUID: CodemapIssueDisposition] {
+            var dispositions: [UUID: CodemapIssueDisposition] = [:]
+
+            func merged(
+                _ existing: CodemapIssueDisposition?,
+                _ next: CodemapIssueDisposition
+            ) -> CodemapIssueDisposition {
+                guard let existing else { return next }
+                switch (existing, next) {
+                case (.unmapped(terminal: true), _), (_, .unmapped(terminal: true)):
+                    return .unmapped(terminal: true)
+                case (.pending, _), (_, .pending):
+                    return .pending
+                case (.unmapped, .unmapped):
+                    return .unmapped(terminal: false)
+                }
+            }
+
+            func record(_ fileID: UUID, _ disposition: CodemapIssueDisposition) {
+                dispositions[fileID] = merged(dispositions[fileID], disposition)
+            }
+
+            func recordPending(_ fileID: UUID) {
+                record(fileID, .pending)
+            }
+
+            func recordUnavailable(
+                _ fileID: UUID,
+                _ reason: WorkspaceCodemapArtifactDemandUnavailableReason
+            ) {
+                record(fileID, unavailableDisposition(reason))
+            }
+
+            func recordSourceIssue(_ issue: WorkspaceCodemapAutomaticSelectionSourceIssue) {
+                switch issue {
+                case let .outsideRootScope(source):
+                    record(source.fileID, .unmapped(terminal: true))
+                case let .notCataloged(source), let .notDemanded(source),
+                     let .staleCatalogGeneration(source, _):
+                    recordPending(source.fileID)
+                case let .pending(source, _):
+                    recordPending(source.fileID)
+                case let .unavailable(source, reason):
+                    recordUnavailable(source.fileID, reason)
+                }
+            }
+
+            func recordTargetIssue(_ issue: WorkspaceCodemapAutomaticSelectionTargetIssue) {
+                switch issue {
+                case let .notCataloged(_, fileID), let .staleGeneration(_, fileID, _):
+                    recordPending(fileID)
+                case let .logicalPathUnavailable(_, fileID):
+                    record(fileID, .unmapped(terminal: true))
+                }
+            }
+
+            func recordPartialReason(_ reason: WorkspaceCodemapAutomaticSelectionPartialReason) {
+                switch reason {
+                case .graph:
+                    break
+                case let .source(issue):
+                    recordSourceIssue(issue)
+                case let .sourceDemandTimedOut(source):
+                    recordPending(source.fileID)
+                case let .candidateUnavailable(_, fileID, reason):
+                    recordUnavailable(fileID, reason)
+                }
+            }
+
+            func recordPendingReason(_ reason: WorkspaceCodemapAutomaticSelectionPendingReason) {
+                switch reason {
+                case let .sourceDemand(source, _), let .sourceBusy(source, _):
+                    recordPending(source.fileID)
+                case let .candidateDemand(_, fileID, _), let .candidateBusy(_, fileID, _):
+                    recordPending(fileID)
+                case .manifestAdmission, .graphRebuild:
+                    break
+                }
+            }
+
+            func recordUnavailableReason(_ reason: WorkspaceCodemapAutomaticSelectionUnavailableReason) {
+                switch reason {
+                case .noReadySources, .graph:
+                    break
+                case let .candidate(_, fileID, reason):
+                    recordUnavailable(fileID, reason)
+                }
+            }
+
+            func recordStaleReason(_ reason: WorkspaceCodemapAutomaticSelectionStaleReason) {
+                switch reason {
+                case let .sourceStateChanged(source), let .sourceCatalogGeneration(source, _):
+                    recordPending(source.fileID)
+                case let .targetStateChanged(issue):
+                    recordTargetIssue(issue)
+                case .rootEpochNotCurrent, .rootScopeChanged, .coverageProof, .graph,
+                     .publicationReceipt:
+                    break
+                }
+            }
+
+            switch coverage {
+            case .complete:
+                break
+            case let .partial(_, reasons):
+                reasons.forEach(recordPartialReason)
+            case let .provisional(_, pending, partial):
+                pending.forEach(recordPendingReason)
+                partial.forEach(recordPartialReason)
+            case .incomplete:
+                break
+            case let .pending(reasons):
+                reasons.forEach(recordPendingReason)
+            case let .unavailable(reason):
+                recordUnavailableReason(reason)
+            case let .stale(reason):
+                recordStaleReason(reason)
+            case .busy, .budget:
+                break
+            }
+
+            return dispositions
+        }
+
+        private static func automaticCoverageFileIDs(
+            _ coverage: WorkspaceCodemapAutomaticSelectionAggregateCoverage
+        ) -> [UUID] {
+            automaticCoverageDispositionByFileID(coverage).keys.sorted { lhs, rhs in
+                lhs.uuidString < rhs.uuidString
+            }
+        }
+
+        private static func freezeUnavailableDisposition(
+            _ reason: WorkspaceCodemapPresentationFreezeUnavailableReason
+        ) -> CodemapIssueDisposition {
+            switch reason {
+            case .emptyRequest, .entryLimitExceeded, .retainedBundleLimitExceeded,
+                 .duplicateFileID, .mixedRootEpoch, .pending, .demandUnavailable,
+                 .logicalPathMismatch, .staleCurrentness, .handleRevoked:
+                .pending
+            }
+        }
+
+        private static func renderUnavailableDisposition(
+            _ reason: WorkspaceCodemapPresentationRenderUnavailableReason,
+            fileID: UUID
+        ) -> CodemapIssueDisposition? {
+            switch reason {
+            case .bundleNotRetained, .bundleMetadataMismatch, .staleCurrentness,
+                 .handleRevoked:
+                .pending
+            case let .noRenderableCodemap(unavailableFileID):
+                unavailableFileID == fileID ? .unmapped(terminal: true) : nil
             }
         }
 
@@ -371,11 +761,20 @@ extension MCPServerViewModel {
                         display: issuePathDisplay
                     )
                 }.sorted(by: utf8Precedes)
+                let requestedCodemapFiles = await requestedCodemapFiles(
+                    selection: selection,
+                    usage: usage,
+                    resolution: resolution,
+                    store: store,
+                    rootScope: rootScope,
+                    profile: .uiAssisted
+                )
                 let collections = makeCollections(
                     resolution: resolution,
                     selection: selection,
                     usage: usage,
-                    invalid: invalid
+                    invalid: invalid,
+                    requestedCodemapFiles: requestedCodemapFiles
                 )
                 try Task.checkCancellation()
                 return try await operation(collections)
@@ -408,7 +807,8 @@ extension MCPServerViewModel {
             resolution: PromptContextEntryResolution,
             selection: StoredSelection,
             usage: CodeMapUsage,
-            invalid: [String]
+            invalid: [String],
+            requestedCodemapFiles: [WorkspaceFileRecord]
         ) -> SelectionCollections {
             let selected = resolution.entries.compactMap { entry -> SelectedEntry? in
                 entry.isCodemap ? nil : SelectedEntry(entry: entry)
@@ -430,11 +830,135 @@ extension MCPServerViewModel {
             return SelectionCollections(
                 selected: selected,
                 codemap: codemap,
+                requestedCodemapFiles: requestedCodemapFiles,
                 codemapAutoEnabled: selection.codemapAutoEnabled,
                 codeMapUsage: usage,
                 invalid: invalid,
                 codemapPresentation: resolution.codemapPresentation
             )
+        }
+
+        private static func requestedCodemapFiles(
+            selection: StoredSelection,
+            usage: CodeMapUsage,
+            resolution: PromptContextEntryResolution,
+            store: WorkspaceFileContextStore,
+            rootScope: WorkspaceLookupRootScope,
+            profile: PathLocateProfile
+        ) async -> [WorkspaceFileRecord] {
+            var files: [WorkspaceFileRecord] = []
+            var seen = Set<UUID>()
+            func append(_ file: WorkspaceFileRecord?) {
+                guard let file, seen.insert(file.id).inserted else { return }
+                files.append(file)
+            }
+
+            switch usage {
+            case .none:
+                break
+            case .auto:
+                if selection.codemapAutoEnabled {
+                    for fileID in codemapIssueFileIDs(resolution.codemapPresentation) {
+                        await append(store.file(id: fileID))
+                    }
+                } else {
+                    await appendManualCodemapFiles(
+                        selection: selection,
+                        store: store,
+                        rootScope: rootScope,
+                        profile: profile,
+                        append: append
+                    )
+                }
+            case .selected:
+                for entry in resolution.entries {
+                    append(entry.file)
+                }
+                await appendManualCodemapFiles(
+                    selection: selection,
+                    store: store,
+                    rootScope: rootScope,
+                    profile: profile,
+                    append: append
+                )
+                for fileID in codemapIssueFileIDs(resolution.codemapPresentation) {
+                    await append(store.file(id: fileID))
+                }
+            case .complete:
+                for fileID in codemapIssueFileIDs(resolution.codemapPresentation) {
+                    await append(store.file(id: fileID))
+                }
+            }
+            return files
+        }
+
+        private static func appendManualCodemapFiles(
+            selection: StoredSelection,
+            store: WorkspaceFileContextStore,
+            rootScope: WorkspaceLookupRootScope,
+            profile: PathLocateProfile,
+            append: (WorkspaceFileRecord?) -> Void
+        ) async {
+            guard !selection.manualCodemapPaths.isEmpty else { return }
+            let requests = selection.manualCodemapPaths.map {
+                WorkspacePathLookupRequest(userPath: $0, profile: profile, rootScope: rootScope)
+            }
+            let results = await store.lookupPaths(requests)
+            for path in selection.manualCodemapPaths {
+                append(results[path]?.file)
+            }
+        }
+
+        private static func codemapIssueFileIDs(
+            _ presentation: WorkspaceCodemapOperationPresentation
+        ) -> [UUID] {
+            var ids: [UUID] = []
+            var seen = Set<UUID>()
+            func append(_ id: UUID) {
+                if seen.insert(id).inserted {
+                    ids.append(id)
+                }
+            }
+            for issue in presentation.issues + coverageIssues(presentation.coverage) {
+                for id in codemapIssueFileIDs(issue) {
+                    append(id)
+                }
+            }
+            return ids
+        }
+
+        private static func codemapIssueFileIDs(
+            _ issue: WorkspaceCodemapOperationIssue
+        ) -> [UUID] {
+            switch issue {
+            case .coordinationUnavailable, .cancelled, .freezeUnavailable,
+                 .publicationStale:
+                return []
+            case let .automatic(coverage):
+                return automaticCoverageFileIDs(coverage)
+            case let .candidate(candidateIssue):
+                return candidateIssueFileIDs(candidateIssue)
+            case let .pending(fileID, _), let .unavailable(fileID, _):
+                return [fileID]
+            case let .renderUnavailable(_, reason):
+                if case let .noRenderableCodemap(fileID) = reason {
+                    return [fileID]
+                }
+                return []
+            }
+        }
+
+        private static func candidateIssueFileIDs(
+            _ issue: WorkspaceCodemapOperationCandidateIssue
+        ) -> [UUID] {
+            switch issue {
+            case let .fileNotCataloged(fileID),
+                 let .fileOutsideRootScope(fileID),
+                 let .logicalPathUnavailable(fileID):
+                [fileID]
+            case let .incompleteRootSet(missingFileIDs):
+                missingFileIDs
+            }
         }
 
         static func logicalIssuePath(
@@ -1026,7 +1550,8 @@ extension MCPServerViewModel {
                 normalizedCodeMapUsage: reply.normalizedCodeMapUsage,
                 // Preserve workspace token stats (total breakdown stays the same even for filtered view)
                 tokenStats: reply.tokenStats,
-                tokenAccounting: reply.tokenAccounting
+                tokenAccounting: reply.tokenAccounting,
+                copyPresetProjection: reply.copyPresetProjection
             )
         }
     }
@@ -1046,22 +1571,24 @@ extension MCPServerViewModel {
             let fileIDs = Set(files.map(\.id))
             let rendered = presentation.orderedEntries.filter { fileIDs.contains($0.fileID) }
             let included = Array(rendered.prefix(25))
-            let renderedIDs = Set(rendered.map(\.fileID))
-            var unmapped: [String] = []
-            for file in files where !renderedIDs.contains(file.id) {
+            let diagnostics = await SelectionReplyAssembler.missingCodemapDiagnostics(
+                for: files,
+                presentation: presentation
+            ) { file in
                 if let projected = lookupContext.bindingProjection?.projectedLogicalDisplayPath(
                     forPhysicalPath: file.standardizedFullPath,
                     display: .relative
                 ) {
-                    unmapped.append(projected)
-                } else {
-                    unmapped.append(file.standardizedRelativePath)
+                    return projected
                 }
+                return file.standardizedRelativePath
             }
+            guard !included.isEmpty || !diagnostics.isEmpty else { return nil }
             return ToolResultDTOs.SelectedCodeStructureDTO(
                 fileCount: included.count,
                 content: included.map(\.text).joined(separator: "\n\n"),
-                unmappedPaths: unmapped.isEmpty ? nil : unmapped.sorted(),
+                unmappedPaths: diagnostics.unmappedPaths.isEmpty ? nil : diagnostics.unmappedPaths,
+                pendingPaths: diagnostics.pendingPaths.isEmpty ? nil : diagnostics.pendingPaths,
                 omittedCount: rendered.count > included.count ? rendered.count - included.count : nil,
                 worktreeScope: ToolResultDTOs.WorktreeScopeDTO.sessionBound(
                     from: lookupContext.bindingProjection

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+SelectionEngine.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+SelectionEngine.swift
@@ -195,12 +195,19 @@ extension MCPServerViewModel {
             stored: selection,
             codeMapUsage: effectiveMCPCodeMapUsage(promptVM.codeMapUsage)
         )
+        let lookupContext = WorkspaceLookupContext(rootScope: lookupRootScope, bindingProjection: nil)
         let collections = await SelectionReplyAssembler.collect(
             from: source,
             owner: self,
-            contentPolicy: includeBlocks ? .loadContent : .cachedOnly
+            rootScope: lookupRootScope,
+            contentPolicy: includeBlocks ? .loadContent : .cachedOnly,
+            lookupContext: lookupContext
         )
-        let formatter = PathFormatter(format: display, owner: self)
+        let formatter = PathFormatter(
+            format: display,
+            owner: self,
+            rootScope: lookupRootScope
+        )
         let tokens = TokenServices(owner: self)
         var out = await SelectionReplyAssembler.buildSelectionReply(
             collections: collections,
@@ -214,7 +221,11 @@ extension MCPServerViewModel {
 
         // Inject minimal codeStructure.unmappedPaths to report pending codemaps
         if out.codeStructure == nil {
-            if let minimal = await buildUnmappedOnlyCodeStructure(collections: collections, display: display) {
+            if let minimal = await buildUnmappedOnlyCodeStructure(
+                collections: collections,
+                display: display,
+                rootScope: lookupRootScope
+            ) {
                 out = ToolResultDTOs.SelectionReply(
                     files: out.files,
                     totalTokens: out.totalTokens,
@@ -233,7 +244,8 @@ extension MCPServerViewModel {
                     userChatTokens: out.userChatTokens,
                     normalizedCodeMapUsage: out.normalizedCodeMapUsage,
                     tokenStats: out.tokenStats,
-                    tokenAccounting: out.tokenAccounting
+                    tokenAccounting: out.tokenAccounting,
+                    copyPresetProjection: out.copyPresetProjection
                 )
             }
         }

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+SelectionReply.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+SelectionReply.swift
@@ -535,16 +535,14 @@ extension MCPServerViewModel {
             entryResultsByFileID: preparedAccounting.entryResultsByFileID
         )
 
-        let tokenStatsOverride: ToolResultDTOs.TokenStats = if let published = preparedAccounting.activePublishedSnapshot {
-            Self.publishedTokenStats(published)
-        } else {
-            Self.makeTokenStats(
-                filesTokens: filesReply.totalTokens,
-                filesContentTokens: (filesReply.summary?.fullTokens ?? 0) + (filesReply.summary?.sliceTokens ?? 0),
-                codemapsTokens: filesReply.summary?.codemapTokens,
-                breakdown: preparedAccounting.breakdown
-            )
-        }
+        let filesContentTokens = (filesReply.summary?.fullTokens ?? 0) + (filesReply.summary?.sliceTokens ?? 0)
+        let codemapsTokens = filesReply.summary?.codemapTokens ?? 0
+        let tokenStatsOverride = Self.makeTokenStats(
+            filesTokens: filesReply.totalTokens,
+            filesContentTokens: filesContentTokens > 0 ? filesContentTokens : nil,
+            codemapsTokens: codemapsTokens > 0 ? codemapsTokens : nil,
+            breakdown: preparedAccounting.breakdown
+        )
 
         var reply = await SelectionReplyAssembler.makeSelectionReply(
             filesReply: filesReply,
@@ -563,7 +561,12 @@ extension MCPServerViewModel {
 
         // Inject minimal codeStructure.unmappedPaths to report pending codemaps
         if reply.codeStructure == nil {
-            if let minimal = await buildUnmappedOnlyCodeStructure(collections: collections, display: display, projection: lookupContext.bindingProjection) {
+            if let minimal = await buildUnmappedOnlyCodeStructure(
+                collections: collections,
+                display: display,
+                projection: lookupContext.bindingProjection,
+                rootScope: lookupContext.rootScope
+            ) {
                 reply = ToolResultDTOs.SelectionReply(
                     files: reply.files,
                     totalTokens: reply.totalTokens,
@@ -582,7 +585,8 @@ extension MCPServerViewModel {
                     userChatTokens: reply.userChatTokens,
                     normalizedCodeMapUsage: reply.normalizedCodeMapUsage,
                     tokenStats: reply.tokenStats,
-                    tokenAccounting: reply.tokenAccounting
+                    tokenAccounting: reply.tokenAccounting,
+                    copyPresetProjection: reply.copyPresetProjection
                 )
             }
         }
@@ -645,6 +649,7 @@ extension MCPServerViewModel {
         return SelectionReplyAssembler.SelectionCollections(
             selected: artifactEntries + collections.selected,
             codemap: collections.codemap,
+            requestedCodemapFiles: collections.requestedCodemapFiles,
             codemapAutoEnabled: collections.codemapAutoEnabled,
             codeMapUsage: collections.codeMapUsage,
             invalid: collections.invalid,
@@ -739,40 +744,43 @@ extension MCPServerViewModel {
 
     // MARK: - Unmapped Paths Helper
 
-    /// Builds a minimal code structure DTO containing only unmappedPaths
-    /// (files without codemaps). Used to report pending codemaps in selection replies
-    /// without generating full codemap content.
+    /// Builds a minimal code structure DTO containing only codemap diagnostics
+    /// (files whose codemap presentation is pending or permanently unavailable).
+    /// Used to report codemap readiness in selection replies without generating full
+    /// codemap content.
     @MainActor
     func buildUnmappedOnlyCodeStructure(
         collections: SelectionReplyAssembler.SelectionCollections,
         display: FilePathDisplay,
-        projection: WorkspaceRootBindingProjection? = nil
+        projection: WorkspaceRootBindingProjection? = nil,
+        rootScope: WorkspaceLookupRootScope = .visibleWorkspace
     ) async -> ToolResultDTOs.SelectedCodeStructureDTO? {
         guard !promptVM.codeMapsGloballyDisabled else { return nil }
-        // Combine selected + codemap files
-        let files = collections.selected.map(\.file) + collections.codemap.map(\.file)
+        guard collections.codeMapUsage != .none else { return nil }
+
+        let files = SelectionReplyAssembler.codemapDiagnosticFiles(for: collections)
         guard !files.isEmpty else { return nil }
 
-        var unmapped: [String] = []
-        var seen = Set<String>()
-        for file in files where collections.codemapPresentation.renderedEntriesByFileID[file.id] == nil {
-            let p = await PathFormatter(
-                format: display,
-                owner: self,
-                projection: projection
-            ).displayPath(for: file)
-            if seen.insert(p).inserted {
-                unmapped.append(p)
-            }
+        let formatter = PathFormatter(
+            format: display,
+            owner: self,
+            projection: projection,
+            rootScope: rootScope
+        )
+        let diagnostics = await SelectionReplyAssembler.missingCodemapDiagnostics(
+            for: files,
+            presentation: collections.codemapPresentation
+        ) { file in
+            await formatter.displayPath(for: file)
         }
 
-        guard !unmapped.isEmpty else { return nil }
+        guard !diagnostics.isEmpty else { return nil }
 
-        // Minimal DTO: report unmappedPaths only; keep content empty and counts neutral
         return ToolResultDTOs.SelectedCodeStructureDTO(
             fileCount: 0,
             content: "",
-            unmappedPaths: unmapped,
+            unmappedPaths: diagnostics.unmappedPaths.isEmpty ? nil : diagnostics.unmappedPaths,
+            pendingPaths: diagnostics.pendingPaths.isEmpty ? nil : diagnostics.pendingPaths,
             omittedCount: nil,
             worktreeScope: ToolResultDTOs.WorktreeScopeDTO.sessionBound(from: projection)
         )

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+TokenStats.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+TokenStats.swift
@@ -88,6 +88,21 @@ extension MCPServerViewModel {
         let activePublishedSnapshot: TokenCountingViewModel.PublishedTokenSnapshot?
     }
 
+    /// Canonical `TokenAccountingDTO.incompleteComponents` values, in stable display order.
+    ///
+    /// - `published_snapshot`: the active tab's published token snapshot is stale/incomplete.
+    /// - `files`: selected file content or per-file token inputs are missing.
+    /// - `codemap_presentation`: requested codemap presentation is pending or retryable.
+    /// - `file_tree`: file-tree tokens require asynchronous virtual-context rendering.
+    /// - `git`: git-review tokens require asynchronous virtual-context rendering.
+    private static let tokenAccountingComponentOrder = [
+        "published_snapshot",
+        "files",
+        "codemap_presentation",
+        "file_tree",
+        "git"
+    ]
+
     @MainActor
     func prepareMCPTokenAccounting(
         context: TabScopedContext,
@@ -106,6 +121,7 @@ extension MCPServerViewModel {
                 scheduleRefreshIfNeeded: allowActivePublishedSnapshotRefresh
             )
             var entryResults = cachedEvaluation.entryResultsByFileID
+            var reliablePublishedFileIDs = Set<UUID>()
             for entry in collections.selected {
                 guard let info = promptVM.tokenCountingViewModel.latestPublishedTokenInfo(
                     forFullPath: entry.file.standardizedFullPath
@@ -119,6 +135,7 @@ extension MCPServerViewModel {
                     fullTokens: info.fullCount,
                     codemapTokens: info.codemapCount
                 )
+                reliablePublishedFileIDs.insert(entry.file.id)
             }
             for entry in collections.codemap {
                 guard let info = promptVM.tokenCountingViewModel.latestPublishedTokenInfo(
@@ -131,8 +148,45 @@ extension MCPServerViewModel {
                     fullTokens: info.fullCount,
                     codemapTokens: info.codemapCount
                 )
+                reliablePublishedFileIDs.insert(entry.file.id)
             }
-            let status = !published.isComplete ? "incomplete" : (published.isStale ? "stale" : "fresh")
+
+            var incompleteComponents = Set<String>()
+            if !published.isComplete {
+                incompleteComponents.insert("published_snapshot")
+            }
+            if Self.hasMissingFileTokenInputs(
+                collections: collections,
+                reliableFileIDs: reliablePublishedFileIDs
+            ) {
+                incompleteComponents.insert("files")
+            }
+            if Self.hasPendingCodemapPresentationGaps(collections: collections) {
+                incompleteComponents.insert("codemap_presentation")
+            }
+
+            let orderedIncomplete = Self.orderedIncompleteComponents(incompleteComponents)
+            if allowActivePublishedSnapshotRefresh, !incompleteComponents.isEmpty {
+                if incompleteComponents.contains("files") {
+                    promptVM.tokenCountingViewModel.markDirty(.selection)
+                }
+                if incompleteComponents.contains("codemap_presentation") {
+                    promptVM.tokenCountingViewModel.markDirty(.codeMap)
+                }
+                if incompleteComponents.contains("published_snapshot") {
+                    promptVM.tokenCountingViewModel.markDirty()
+                }
+            }
+            let refreshPending = published.refreshPending
+                || (allowActivePublishedSnapshotRefresh && !incompleteComponents.isEmpty)
+            let status = if !incompleteComponents.isEmpty {
+                "incomplete"
+            } else if published.isStale {
+                "stale"
+            } else {
+                "fresh"
+            }
+
             return MCPPreparedTokenAccounting(
                 entryResultsByFileID: entryResults,
                 breakdown: .init(
@@ -146,8 +200,8 @@ extension MCPServerViewModel {
                 tokenAccounting: .init(
                     status: status,
                     source: "active_tab_published",
-                    refreshPending: published.refreshPending,
-                    incompleteComponents: published.isComplete ? nil : ["published_snapshot"]
+                    refreshPending: refreshPending,
+                    incompleteComponents: orderedIncomplete
                 ),
                 activePublishedSnapshot: published
             )
@@ -171,28 +225,43 @@ extension MCPServerViewModel {
                 collections: collections,
                 lookupContext: lookupContext
             )
+            var incompleteComponents = Set<String>()
+            if Self.hasMissingFileTokenInputs(
+                collections: collections,
+                reliableFileIDs: Set(cachedSnapshot.entryResultsByFileID.keys)
+            ) {
+                incompleteComponents.insert("files")
+            }
+            if Self.hasPendingCodemapPresentationGaps(collections: collections) {
+                incompleteComponents.insert("codemap_presentation")
+            }
             return MCPPreparedTokenAccounting(
                 entryResultsByFileID: cachedSnapshot.entryResultsByFileID,
                 breakdown: cachedSnapshot.breakdown,
                 tokenAccounting: .init(
                     status: "stale",
                     source: "bound_tab_cache",
-                    refreshPending: true
+                    refreshPending: true,
+                    incompleteComponents: Self.orderedIncompleteComponents(incompleteComponents)
                 ),
                 activePublishedSnapshot: nil
             )
         }
 
-        var incompleteComponents: [String] = []
-        if collections.selected.contains(where: { $0.entry.loadedContent == nil }) {
-            incompleteComponents.append("files")
+        var incompleteComponents = Set<String>()
+        if Self.hasMissingFileTokenInputs(collections: collections, reliableFileIDs: []) {
+            incompleteComponents.insert("files")
+        }
+        if Self.hasPendingCodemapPresentationGaps(collections: collections) {
+            incompleteComponents.insert("codemap_presentation")
         }
         if resolvedContext.rendersFileTree {
-            incompleteComponents.append("file_tree")
+            incompleteComponents.insert("file_tree")
         }
         if resolvedContext.gitInclusion != .none {
-            incompleteComponents.append("git")
+            incompleteComponents.insert("git")
         }
+        let orderedIncomplete = Self.orderedIncompleteComponents(incompleteComponents)
         if allowVirtualTokenRefresh, !incompleteComponents.isEmpty {
             enqueueVirtualTokenRefresh(
                 signature: signature,
@@ -227,9 +296,35 @@ extension MCPServerViewModel {
                 status: incompleteComponents.isEmpty ? "fresh" : "incomplete",
                 source: "bound_tab_cached_state",
                 refreshPending: allowVirtualTokenRefresh && !incompleteComponents.isEmpty,
-                incompleteComponents: incompleteComponents.isEmpty ? nil : incompleteComponents
+                incompleteComponents: orderedIncomplete
             ),
             activePublishedSnapshot: nil
+        )
+    }
+
+    private static func orderedIncompleteComponents(
+        _ components: Set<String>
+    ) -> [String]? {
+        let ordered = tokenAccountingComponentOrder.filter(components.contains)
+        return ordered.isEmpty ? nil : ordered
+    }
+
+    private static func hasMissingFileTokenInputs(
+        collections: SelectionReplyAssembler.SelectionCollections,
+        reliableFileIDs: Set<UUID>
+    ) -> Bool {
+        collections.selected.contains { entry in
+            entry.entry.loadedContent == nil && !reliableFileIDs.contains(entry.file.id)
+        }
+    }
+
+    private static func hasPendingCodemapPresentationGaps(
+        collections: SelectionReplyAssembler.SelectionCollections
+    ) -> Bool {
+        SelectionReplyAssembler.hasPendingCodemapPresentationGaps(
+            for: SelectionReplyAssembler.codemapDiagnosticFiles(for: collections),
+            presentation: collections.codemapPresentation,
+            codeMapUsage: collections.codeMapUsage
         )
     }
 

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+WorkspaceContext.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+WorkspaceContext.swift
@@ -158,16 +158,12 @@ extension MCPServerViewModel {
             let codemapsTokens = selectionReply?.summary?.codemapTokens ?? 0
 
             if let prepared = preparedTokenAccounting {
-                if let published = prepared.activePublishedSnapshot {
-                    tokenStatsDTO = Self.publishedTokenStats(published)
-                } else {
-                    tokenStatsDTO = Self.makeTokenStats(
-                        filesTokens: fileTokens,
-                        filesContentTokens: filesContentTokens > 0 ? filesContentTokens : nil,
-                        codemapsTokens: codemapsTokens > 0 ? codemapsTokens : nil,
-                        breakdown: prepared.breakdown
-                    )
-                }
+                tokenStatsDTO = Self.makeTokenStats(
+                    filesTokens: fileTokens,
+                    filesContentTokens: filesContentTokens > 0 ? filesContentTokens : nil,
+                    codemapsTokens: codemapsTokens > 0 ? codemapsTokens : nil,
+                    breakdown: prepared.breakdown
+                )
 
                 if let userFileTokens = selectionReply?.userCopyTokens, userFileTokens != fileTokens {
                     let userContentTokens = selectionReply?.userCopyContentTokens ?? 0

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
@@ -8794,13 +8794,34 @@ actor WorkspaceFileContextStore {
                 startFolder: nil
             )
         }
-        let startFolder = await (lookupSelectionPath(trimmedStartPath, profile: profile, rootScope: request.rootScope))?.folder
+        let startFolder = await resolveFileTreeStartFolder(
+            trimmedStartPath,
+            request: request,
+            profile: profile
+        )
         return makeFileTreeSelectionSnapshot(
             request,
             selectedStoreFileIDs: selectedStoreFileIDs,
             renderableCodemapFileIDs: renderableCodemapFileIDs,
             startFolder: startFolder
         )
+    }
+
+    private func resolveFileTreeStartFolder(
+        _ trimmedStartPath: String,
+        request: WorkspaceFileTreeSnapshotRequest,
+        profile: PathLocateProfile
+    ) async -> WorkspaceFolderRecord? {
+        let roots = rootRefs(scope: request.rootScope)
+        let resolution = await resolveFolderInput(
+            trimmedStartPath,
+            rootScope: request.rootScope,
+            profile: profile,
+            rootRefs: roots,
+            validateIssue: true,
+            allowGeneralLookupFallback: false
+        )
+        return resolution.folder
     }
 
     private func makeFileTreeSelectionSnapshot(

--- a/Tests/RepoPromptTests/MCP/MCPReadFileExactAbsoluteCatalogFastPathTests.swift
+++ b/Tests/RepoPromptTests/MCP/MCPReadFileExactAbsoluteCatalogFastPathTests.swift
@@ -64,6 +64,28 @@ final class MCPReadFileExactAbsoluteCatalogFastPathTests: XCTestCase {
         }
     }
 
+    func testFileTreeStartPathSourceOrderingUsesFolderResolverNotSelectionLookup() throws {
+        let caseLabel = "testFileTreeStartPathSourceOrderingUsesFolderResolverNotSelectionLookup"
+        let storeSource = try source("Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift")
+        let startPathSnapshot = try XCTUnwrap(storeSource.slice(
+            from: "    private func makeFileTreeSelectionSnapshot(\n        _ request: WorkspaceFileTreeSnapshotRequest,\n        selectedStoreFileIDs: Set<UUID>,\n        renderableCodemapFileIDs: Set<UUID>,\n        profile: PathLocateProfile\n    ) async -> FileTreeSelectionSnapshot {\n",
+            to: "    private func resolveFileTreeStartFolder("
+        ), caseLabel)
+        XCTAssertTrue(startPathSnapshot.contains("resolveFileTreeStartFolder("), caseLabel)
+        XCTAssertFalse(startPathSnapshot.contains("lookupSelectionPath(trimmedStartPath"), caseLabel)
+
+        let startFolderResolver = try XCTUnwrap(storeSource.slice(
+            from: "    private func resolveFileTreeStartFolder(",
+            to: "    private func makeFileTreeSelectionSnapshot(\n        _ request: WorkspaceFileTreeSnapshotRequest,\n        selectedStoreFileIDs: Set<UUID>,\n        renderableCodemapFileIDs: Set<UUID>,\n        startFolder: WorkspaceFolderRecord?"
+        ), caseLabel)
+        try assertOrdered([
+            "let roots = rootRefs(scope: request.rootScope)",
+            "resolveFolderInput(",
+            "rootRefs: roots",
+            "allowGeneralLookupFallback: false"
+        ], in: startFolderResolver, label: caseLabel)
+    }
+
     func testExactAbsoluteInputValidationCoversQualificationEmptyAndEmbeddedNUL() async throws {
         do {
             let caseLabel = "testExactAbsoluteQualificationAcceptsTrimmedAndTildeExpandedAbsoluteInputsOnly"

--- a/Tests/RepoPromptTests/MCP/MCPSelectionReplyFreshnessTests.swift
+++ b/Tests/RepoPromptTests/MCP/MCPSelectionReplyFreshnessTests.swift
@@ -50,6 +50,254 @@ final class MCPSelectionReplyFreshnessTests: XCTestCase {
         }
     }
 
+    func testSupportedMissingCodemapDiagnosticsArePending() async {
+        let file = makeFileRecord(relativePath: "Sources/Pending.swift")
+        let issue = WorkspaceCodemapOperationIssue.coordinationUnavailable
+        let presentation = WorkspaceCodemapOperationPresentation(
+            orderedEntries: [],
+            coverage: .pending([issue]),
+            issues: [issue],
+            publicationReceipt: nil
+        )
+
+        let diagnostics = await MCPServerViewModel.SelectionReplyAssembler.missingCodemapDiagnostics(
+            for: [file],
+            presentation: presentation
+        ) { file in
+            file.standardizedRelativePath
+        }
+
+        XCTAssertEqual(diagnostics.pendingPaths, ["Sources/Pending.swift"])
+        XCTAssertEqual(diagnostics.unmappedPaths, [])
+    }
+
+    func testUnsupportedMissingCodemapDiagnosticsRemainUnmapped() async {
+        let file = makeFileRecord(relativePath: "README.txt")
+
+        let diagnostics = await MCPServerViewModel.SelectionReplyAssembler.missingCodemapDiagnostics(
+            for: [file],
+            presentation: .empty
+        ) { file in
+            file.standardizedRelativePath
+        }
+
+        XCTAssertEqual(diagnostics.pendingPaths, [])
+        XCTAssertEqual(diagnostics.unmappedPaths, ["README.txt"])
+    }
+
+    func testAutoModeOnlyDiagnosesRequestedCodemapFiles() async {
+        let selectedFile = makeFileRecord(relativePath: "Sources/Selected.swift")
+        let requestedCodemapFile = makeFileRecord(relativePath: "Sources/Requested.swift")
+        let selectedEntry = MCPServerViewModel.SelectionReplyAssembler.SelectedEntry(
+            entry: ResolvedPromptFileEntry(file: selectedFile)
+        )
+        let issue = WorkspaceCodemapOperationIssue.coordinationUnavailable
+        let presentation = WorkspaceCodemapOperationPresentation(
+            orderedEntries: [],
+            coverage: .pending([issue]),
+            issues: [issue],
+            publicationReceipt: nil
+        )
+        let collections = MCPServerViewModel.SelectionReplyAssembler.SelectionCollections(
+            selected: [selectedEntry],
+            codemap: [],
+            requestedCodemapFiles: [requestedCodemapFile],
+            codemapAutoEnabled: false,
+            codeMapUsage: .auto,
+            invalid: [],
+            codemapPresentation: presentation
+        )
+
+        let diagnosticFiles = MCPServerViewModel.SelectionReplyAssembler.codemapDiagnosticFiles(
+            for: collections
+        )
+        XCTAssertEqual(diagnosticFiles.map(\.id), [requestedCodemapFile.id])
+
+        let diagnostics = await MCPServerViewModel.SelectionReplyAssembler.missingCodemapDiagnostics(
+            for: diagnosticFiles,
+            presentation: presentation
+        ) { file in
+            file.standardizedRelativePath
+        }
+        XCTAssertEqual(diagnostics.pendingPaths, ["Sources/Requested.swift"])
+        XCTAssertEqual(diagnostics.unmappedPaths, [])
+    }
+
+    func testTerminalCodemapDispositionOverridesPendingRegardlessOfIssueOrder() async {
+        let file = makeFileRecord(relativePath: "Sources/Terminal.swift")
+        let ticket = makeCodemapTicket(fileID: file.id, rootID: file.rootID)
+        let pending = WorkspaceCodemapOperationIssue.pending(fileID: file.id, ticket: ticket)
+        let terminal = WorkspaceCodemapOperationIssue.unavailable(
+            fileID: file.id,
+            reason: .unsupportedFileType
+        )
+
+        for issues in [[terminal, pending], [pending, terminal]] {
+            let presentation = WorkspaceCodemapOperationPresentation(
+                orderedEntries: [],
+                coverage: .pending(issues),
+                issues: issues,
+                publicationReceipt: nil
+            )
+            let diagnostics = await MCPServerViewModel.SelectionReplyAssembler.missingCodemapDiagnostics(
+                for: [file],
+                presentation: presentation
+            ) { file in
+                file.standardizedRelativePath
+            }
+
+            XCTAssertEqual(diagnostics.pendingPaths, [], "Issue order: \(issues)")
+            XCTAssertEqual(diagnostics.unmappedPaths, ["Sources/Terminal.swift"], "Issue order: \(issues)")
+        }
+    }
+
+    func testAutoUnsupportedNoTargetPresentationDoesNotMarkCodemapIncomplete() async throws {
+        let root = try makeTemporaryRoot(name: "AutoUnsupportedNoTarget")
+        defer { try? FileManager.default.removeItem(at: root.deletingLastPathComponent()) }
+        let readme = root.appendingPathComponent("README.txt")
+        try write("plain text\n", to: readme)
+
+        let tabID = UUID()
+        let selection = StoredSelection(
+            selectedPaths: [readme.path],
+            codemapAutoEnabled: true
+        )
+        let (window, _) = await makeWindow(root: root, tabID: tabID, selection: selection)
+        defer { WindowStatesManager.shared.unregisterWindowState(window) }
+        _ = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(
+            in: window,
+            path: root.path
+        )
+
+        let issue = WorkspaceCodemapOperationIssue.automatic(.unavailable(.noReadySources))
+        let presentation = WorkspaceCodemapOperationPresentation(
+            orderedEntries: [],
+            coverage: .pending([issue]),
+            issues: [issue],
+            publicationReceipt: nil
+        )
+        let reply = await window.mcpServer.buildBorrowedTabSelectionReply(
+            codemapPresentation: presentation,
+            from: selection,
+            includeBlocks: true,
+            display: .relative,
+            lookupContext: .visibleWorkspace
+        )
+
+        XCTAssertFalse(
+            reply.tokenAccounting?.incompleteComponents?.contains("codemap_presentation") == true,
+            String(describing: reply.tokenAccounting?.incompleteComponents)
+        )
+        XCTAssertTrue(reply.codeStructure?.pendingPaths?.isEmpty ?? true)
+        XCTAssertTrue(reply.codeStructure?.unmappedPaths?.isEmpty ?? true)
+    }
+
+    func testBorrowedAutoReplyReportsPendingAutomaticTargetCodemap() async throws {
+        let root = try makeTemporaryRoot(name: "AutoPendingTarget")
+        defer { try? FileManager.default.removeItem(at: root.deletingLastPathComponent()) }
+        let source = root.appendingPathComponent("Source.swift")
+        let target = root.appendingPathComponent("Target.swift")
+        try write("struct Source {}\n", to: source)
+        try write("struct Target {}\n", to: target)
+
+        let tabID = UUID()
+        let selection = StoredSelection(
+            selectedPaths: [source.path],
+            codemapAutoEnabled: true
+        )
+        let (window, _) = await makeWindow(root: root, tabID: tabID, selection: selection)
+        defer { WindowStatesManager.shared.unregisterWindowState(window) }
+        let loadedRoot = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(
+            in: window,
+            path: root.path
+        )
+        let maybeTargetRecord = await window.promptManager.workspaceFileContextStore.file(
+            rootID: loadedRoot.id,
+            relativePath: "Target.swift"
+        )
+        let targetRecord = try XCTUnwrap(maybeTargetRecord)
+        let rootEpoch = makeRootEpoch(rootID: targetRecord.rootID)
+        let issue = WorkspaceCodemapOperationIssue.automatic(.pending([
+            .candidateDemand(
+                rootEpoch: rootEpoch,
+                fileID: targetRecord.id,
+                ticket: makeCodemapTicket(fileID: targetRecord.id, rootID: targetRecord.rootID)
+            )
+        ]))
+        let presentation = WorkspaceCodemapOperationPresentation(
+            orderedEntries: [],
+            coverage: .pending([issue]),
+            issues: [issue],
+            publicationReceipt: nil
+        )
+
+        let reply = await window.mcpServer.buildBorrowedTabSelectionReply(
+            codemapPresentation: presentation,
+            from: selection,
+            includeBlocks: true,
+            display: .full,
+            lookupContext: .visibleWorkspace
+        )
+
+        XCTAssertTrue(
+            reply.tokenAccounting?.incompleteComponents?.contains("codemap_presentation") == true,
+            String(describing: reply.tokenAccounting?.incompleteComponents)
+        )
+        XCTAssertEqual(reply.codeStructure?.pendingPaths, [target.standardizedFileURL.path])
+        XCTAssertTrue(reply.codeStructure?.unmappedPaths?.isEmpty ?? true)
+    }
+
+    func testActiveVisibleSelectionMarksMissingCachedFileTokensIncomplete() async throws {
+        let root = try makeTemporaryRoot(name: "ActiveVisibleIncomplete")
+        defer { try? FileManager.default.removeItem(at: root.deletingLastPathComponent()) }
+        let oldFile = root.appendingPathComponent("Old.swift")
+        let newFile = root.appendingPathComponent("New.swift")
+        try write("struct OldTokenBaseline {}\n", to: oldFile)
+        try write("struct NewVisibleSelection {}\n", to: newFile)
+
+        let tabID = UUID()
+        let oldSelection = StoredSelection(selectedPaths: [oldFile.path])
+        let newSelection = StoredSelection(selectedPaths: [newFile.path])
+        let (window, workspaceID) = await makeWindow(root: root, tabID: tabID, selection: oldSelection)
+        defer { WindowStatesManager.shared.unregisterWindowState(window) }
+        _ = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(
+            in: window,
+            path: root.path
+        )
+        await window.promptManager.tokenCountingViewModel.forceImmediateRecount()
+
+        var liveTab = try XCTUnwrap(window.workspaceManager.composeTab(with: tabID))
+        liveTab.selection = newSelection
+        XCTAssertTrue(window.workspaceManager.updateComposeTabStoredOnly(liveTab, inWorkspaceID: workspaceID))
+        let context = makeContext(
+            window: window,
+            workspaceID: workspaceID,
+            tabID: tabID,
+            selection: newSelection
+        )
+        let activeResolution = MCPServerViewModel.ResolvedTabContextSnapshot(
+            snapshot: context,
+            usesActiveTabCompatibility: true
+        )
+
+        let reply = await window.mcpServer.buildCurrentSelectionReply(
+            includeBlocks: false,
+            display: .full,
+            resolvedContext: activeResolution,
+            lookupContext: .visibleWorkspace
+        )
+
+        XCTAssertEqual(reply.files?.map(\.path), [newFile.path])
+        XCTAssertEqual(reply.tokenAccounting?.source, "active_tab_published")
+        XCTAssertEqual(reply.tokenAccounting?.status, "incomplete")
+        XCTAssertTrue(reply.tokenAccounting?.refreshPending == true)
+        XCTAssertTrue(reply.tokenAccounting?.incompleteComponents?.contains("files") == true)
+        XCTAssertEqual(reply.totalTokens, 0)
+        let formatted = ToolOutputFormatter.formatSelectionReplyToString(reply)
+        XCTAssertTrue(formatted.contains("- Total tokens: pending (Auto view)"), formatted)
+        XCTAssertFalse(formatted.contains("- Total tokens: 0 (Auto view)"), formatted)
+    }
+
     func testMutationReplyRereadsLiveTabSelectionAfterProviderStabilization() async throws {
         let root = try makeTemporaryRoot(name: "MutationReply")
         defer { try? FileManager.default.removeItem(at: root.deletingLastPathComponent()) }
@@ -757,12 +1005,15 @@ final class MCPSelectionReplyFreshnessTests: XCTestCase {
             XCTAssertEqual(resolvedFirstReply.tokenAccounting?.source, "bound_tab_cached_state")
             XCTAssertEqual(resolvedFirstReply.tokenAccounting?.status, "incomplete")
             XCTAssertTrue(resolvedFirstReply.tokenAccounting?.refreshPending == true)
+            XCTAssertTrue(resolvedFirstReply.tokenAccounting?.incompleteComponents?.contains("files") == true)
             XCTAssertEqual(resolvedSecondReply.tokenAccounting?.source, "bound_tab_cached_state")
             XCTAssertEqual(resolvedSecondReply.tokenAccounting?.status, "incomplete")
             XCTAssertTrue(resolvedSecondReply.tokenAccounting?.refreshPending == true)
+            XCTAssertTrue(resolvedSecondReply.tokenAccounting?.incompleteComponents?.contains("files") == true)
             XCTAssertEqual(resolvedWorkspaceReply.tokenAccounting?.source, "bound_tab_cached_state")
             XCTAssertEqual(resolvedWorkspaceReply.tokenAccounting?.status, "incomplete")
             XCTAssertTrue(resolvedWorkspaceReply.tokenAccounting?.refreshPending == true)
+            XCTAssertTrue(resolvedWorkspaceReply.tokenAccounting?.incompleteComponents?.contains("files") == true)
             XCTAssertEqual(window.mcpServer.virtualTokenRefreshStartCountForTesting(), baselineStarts + 1)
             let refreshStartCount = await refreshGate.startCount()
             // Identical bound selection and workspace token requests share one signature,
@@ -1526,6 +1777,39 @@ final class MCPSelectionReplyFreshnessTests: XCTestCase {
         let root = parent.appendingPathComponent(name, isDirectory: true)
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         return root.standardizedFileURL
+    }
+
+    private func makeFileRecord(
+        relativePath: String,
+        rootID: UUID = UUID()
+    ) -> WorkspaceFileRecord {
+        WorkspaceFileRecord(
+            rootID: rootID,
+            name: URL(fileURLWithPath: relativePath).lastPathComponent,
+            relativePath: relativePath,
+            fullPath: "/workspace/project/\(relativePath)",
+            parentFolderID: nil
+        )
+    }
+
+    private func makeRootEpoch(rootID: UUID = UUID()) -> WorkspaceCodemapRootEpoch {
+        WorkspaceCodemapRootEpoch(rootID: rootID, rootLifetimeID: UUID())
+    }
+
+    private func makeCodemapTicket(
+        fileID: UUID,
+        rootID: UUID = UUID()
+    ) -> WorkspaceCodemapArtifactDemandTicket {
+        WorkspaceCodemapArtifactDemandTicket(
+            retainID: UUID(),
+            requestID: UUID(),
+            rootEpoch: makeRootEpoch(rootID: rootID),
+            fileID: fileID,
+            requestGeneration: 1,
+            catalogGeneration: 1,
+            pathGeneration: 1,
+            ingressGeneration: 1
+        )
     }
 
     private func write(_ content: String, to url: URL) throws {

--- a/Tests/RepoPromptTests/MCP/ToolOutputFormatterWorktreeTests.swift
+++ b/Tests/RepoPromptTests/MCP/ToolOutputFormatterWorktreeTests.swift
@@ -377,6 +377,118 @@ final class ToolOutputFormatterWorktreeTests: XCTestCase {
         XCTAssertTrue(text.contains("  - `Project/README.md`"), text)
     }
 
+    func testManageSelectionIncompleteZeroTokensShowsPendingAccounting() throws {
+        let dto = ToolResultDTOs.SelectionReply(
+            files: [
+                .init(
+                    path: "Project/Sources/Pending.swift",
+                    tokens: 0,
+                    renderMode: "full",
+                    ranges: nil,
+                    isAuto: false,
+                    codemapOrigin: nil,
+                    copyPreset: nil,
+                    rootPath: "Project",
+                    pathWithinRoot: "Sources/Pending.swift"
+                )
+            ],
+            totalTokens: 0,
+            status: "ok",
+            codeStructure: .init(
+                fileCount: 0,
+                content: "",
+                pendingPaths: ["Project/Sources/Pending.swift"]
+            ),
+            summary: .init(
+                fullCount: 1,
+                sliceCount: 0,
+                codemapCount: 0,
+                fullTokens: 0,
+                sliceTokens: 0,
+                codemapTokens: 0
+            ),
+            tokenStats: .init(total: 0, files: 0),
+            tokenAccounting: .init(
+                status: "incomplete",
+                source: "active_tab_published",
+                refreshPending: true,
+                incompleteComponents: ["files", "codemap_presentation"]
+            )
+        )
+
+        let text = try Self.onlyText(ToolOutputFormatter.formatManageSelection(args: [:], value: Self.value(dto)))
+
+        XCTAssertTrue(text.contains("**Token accounting pending**"), text)
+        XCTAssertFalse(text.contains("**0 total tokens**"), text)
+        XCTAssertTrue(
+            text.contains("Token accounting: incomplete from active_tab_published; refresh pending; incomplete: files, codemap_presentation"),
+            text
+        )
+        XCTAssertTrue(text.contains("Files: pending (1 file)"), text)
+        XCTAssertTrue(text.contains("Pending codemaps: 1"), text)
+        XCTAssertFalse(text.contains("Unmapped codemap paths: 1"), text)
+
+        let embedded = ToolOutputFormatter.formatSelectionReplyToString(dto)
+        XCTAssertTrue(embedded.contains("- Total tokens: pending (Auto view)"), embedded)
+        XCTAssertFalse(embedded.contains("- Total tokens: 0 (Auto view)"), embedded)
+        XCTAssertTrue(
+            embedded.contains("- Token accounting: incomplete from active_tab_published; refresh pending; incomplete: files, codemap_presentation"),
+            embedded
+        )
+    }
+
+    func testManageSelectionNonzeroPartialTokensStillShowsAccountingLine() throws {
+        let dto = ToolResultDTOs.SelectionReply(
+            files: [
+                .init(
+                    path: "Project/Sources/Partial.swift",
+                    tokens: 12,
+                    renderMode: "full",
+                    ranges: nil,
+                    isAuto: false,
+                    codemapOrigin: nil,
+                    copyPreset: nil,
+                    rootPath: "Project",
+                    pathWithinRoot: "Sources/Partial.swift"
+                )
+            ],
+            totalTokens: 12,
+            status: "ok",
+            summary: .init(
+                fullCount: 1,
+                sliceCount: 0,
+                codemapCount: 0,
+                fullTokens: 12,
+                sliceTokens: 0,
+                codemapTokens: 0
+            ),
+            tokenStats: .init(total: 42, files: 12, prompt: 30),
+            tokenAccounting: .init(
+                status: "incomplete",
+                source: "active_tab_published",
+                refreshPending: true,
+                incompleteComponents: ["files"]
+            )
+        )
+
+        let text = try Self.onlyText(ToolOutputFormatter.formatManageSelection(args: [:], value: Self.value(dto)))
+
+        XCTAssertTrue(text.contains("**42 total tokens**"), text)
+        XCTAssertFalse(text.contains("**Token accounting pending**"), text)
+        XCTAssertTrue(
+            text.contains("Token accounting: incomplete from active_tab_published; refresh pending; incomplete: files"),
+            text
+        )
+        XCTAssertTrue(text.contains("Files: 12"), text)
+
+        let embedded = ToolOutputFormatter.formatSelectionReplyToString(dto)
+        XCTAssertTrue(embedded.contains("- Total tokens: 12 (Auto view)"), embedded)
+        XCTAssertTrue(
+            embedded.contains("- Token accounting: incomplete from active_tab_published; refresh pending; incomplete: files"),
+            embedded
+        )
+    }
+
     func testAgentRunOutputShowsWorktreeSummaryAndUnavailableState() throws {
         let cases = [
             (

--- a/Tests/RepoPromptTests/WorkspaceContext/WorkspaceFileContextStoreTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/WorkspaceFileContextStoreTests.swift
@@ -4588,6 +4588,148 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
             XCTAssertTrue(tree.contains("B.swift"), caseLabel)
             XCTAssertFalse(tree.contains("Other.swift"), caseLabel)
         }
+
+        do {
+            let caseLabel = "testFileTreeSnapshotStartPathResolvesRootAliasesAndAbsoluteSubfolders"
+            let rootA = try makeTemporaryRoot(name: "AliasTreeA")
+            let rootB = try makeTemporaryRoot(name: "AliasTreeB")
+            try write("app", to: rootA.appendingPathComponent("Sources/App.swift"))
+            try write("mcp", to: rootA.appendingPathComponent("Sources/RepoPromptMCP/Main.swift"))
+            try write("other", to: rootA.appendingPathComponent("Other.swift"))
+            try write("sdk", to: rootB.appendingPathComponent("Sources/SDK.swift"))
+
+            let store = WorkspaceFileContextStore()
+            let recordA = try await store.loadRoot(path: rootA.path)
+            _ = try await store.loadRoot(path: rootB.path)
+
+            let rootAliasSnapshot = await store.makeFileTreeSelectionSnapshot(
+                selection: StoredSelection(),
+                request: WorkspaceFileTreeSnapshotRequest(
+                    mode: .full,
+                    filePathDisplay: .relative,
+                    onlyIncludeRootsWithSelectedFiles: false,
+                    includeLegend: false,
+                    showCodeMapMarkers: false,
+                    rootScope: .visibleWorkspace,
+                    startPath: recordA.name
+                ),
+                profile: .mcpRead
+            )
+            let rootAliasTree = CodeMapExtractor.generateFileTree(using: rootAliasSnapshot)
+            XCTAssertEqual(rootAliasSnapshot.roots.count, 1, caseLabel)
+            XCTAssertTrue(rootAliasTree.contains("App.swift"), caseLabel)
+            XCTAssertTrue(rootAliasTree.contains("Other.swift"), caseLabel)
+            XCTAssertFalse(rootAliasTree.contains("SDK.swift"), caseLabel)
+
+            let prefixedSnapshot = await store.makeFileTreeSelectionSnapshot(
+                selection: StoredSelection(),
+                request: WorkspaceFileTreeSnapshotRequest(
+                    mode: .full,
+                    filePathDisplay: .relative,
+                    onlyIncludeRootsWithSelectedFiles: false,
+                    includeLegend: false,
+                    showCodeMapMarkers: false,
+                    rootScope: .visibleWorkspace,
+                    startPath: "\(recordA.name)/Sources"
+                ),
+                profile: .mcpRead
+            )
+            let prefixedTree = CodeMapExtractor.generateFileTree(using: prefixedSnapshot)
+            XCTAssertEqual(prefixedSnapshot.roots.count, 1, caseLabel)
+            XCTAssertTrue(prefixedTree.contains("Sources"), caseLabel)
+            XCTAssertTrue(prefixedTree.contains("App.swift"), caseLabel)
+            XCTAssertTrue(prefixedTree.contains("RepoPromptMCP"), caseLabel)
+            XCTAssertFalse(prefixedTree.contains("Other.swift"), caseLabel)
+            XCTAssertFalse(prefixedTree.contains("SDK.swift"), caseLabel)
+
+            let absoluteSubfolderSnapshot = await store.makeFileTreeSelectionSnapshot(
+                selection: StoredSelection(),
+                request: WorkspaceFileTreeSnapshotRequest(
+                    mode: .full,
+                    filePathDisplay: .relative,
+                    onlyIncludeRootsWithSelectedFiles: false,
+                    includeLegend: false,
+                    showCodeMapMarkers: false,
+                    rootScope: .visibleWorkspace,
+                    startPath: rootA.appendingPathComponent("Sources/RepoPromptMCP").path
+                ),
+                profile: .mcpRead
+            )
+            let absoluteSubfolderTree = CodeMapExtractor.generateFileTree(using: absoluteSubfolderSnapshot)
+            XCTAssertEqual(absoluteSubfolderSnapshot.roots.count, 1, caseLabel)
+            XCTAssertTrue(absoluteSubfolderTree.contains("RepoPromptMCP"), caseLabel)
+            XCTAssertTrue(absoluteSubfolderTree.contains("Main.swift"), caseLabel)
+            XCTAssertFalse(absoluteSubfolderTree.contains("App.swift"), caseLabel)
+            XCTAssertFalse(absoluteSubfolderTree.contains("Other.swift"), caseLabel)
+
+            let missingRelativeSnapshot = await store.makeFileTreeSelectionSnapshot(
+                selection: StoredSelection(),
+                request: WorkspaceFileTreeSnapshotRequest(
+                    mode: .full,
+                    filePathDisplay: .relative,
+                    onlyIncludeRootsWithSelectedFiles: false,
+                    includeLegend: false,
+                    showCodeMapMarkers: false,
+                    rootScope: .visibleWorkspace,
+                    startPath: "Missing/Subtree"
+                ),
+                profile: .mcpRead
+            )
+            XCTAssertTrue(missingRelativeSnapshot.roots.isEmpty, caseLabel)
+
+            let missingAbsoluteSnapshot = await store.makeFileTreeSelectionSnapshot(
+                selection: StoredSelection(),
+                request: WorkspaceFileTreeSnapshotRequest(
+                    mode: .full,
+                    filePathDisplay: .relative,
+                    onlyIncludeRootsWithSelectedFiles: false,
+                    includeLegend: false,
+                    showCodeMapMarkers: false,
+                    rootScope: .visibleWorkspace,
+                    startPath: rootA.appendingPathComponent("Missing/Subtree").path
+                ),
+                profile: .mcpRead
+            )
+            XCTAssertTrue(missingAbsoluteSnapshot.roots.isEmpty, caseLabel)
+        }
+
+        do {
+            let caseLabel = "testFileTreeSnapshotStartPathAcceptsGeneratedDisplayAlias"
+            let parentA = try makeTemporaryRoot(name: "GeneratedAliasParentA")
+            let parentB = try makeTemporaryRoot(name: "GeneratedAliasParentB")
+            let rootA = parentA.appendingPathComponent("App", isDirectory: true)
+            let rootB = parentB.appendingPathComponent("App", isDirectory: true)
+            try write("a", to: rootA.appendingPathComponent("Sources/A.swift"))
+            try write("b", to: rootB.appendingPathComponent("Sources/B.swift"))
+            try write("other", to: rootA.appendingPathComponent("Other.swift"))
+
+            let store = WorkspaceFileContextStore()
+            let recordA = try await store.loadRoot(path: rootA.path)
+            _ = try await store.loadRoot(path: rootB.path)
+            let visibleRoots = await store.rootRefs(scope: .visibleWorkspace)
+            let rootRefA = try XCTUnwrap(visibleRoots.first { $0.id == recordA.id }, caseLabel)
+            let generatedAlias = ClientPathFormatter.nonAbsoluteRootAlias(root: rootRefA, visibleRoots: visibleRoots)
+
+            let snapshot = await store.makeFileTreeSelectionSnapshot(
+                selection: StoredSelection(),
+                request: WorkspaceFileTreeSnapshotRequest(
+                    mode: .full,
+                    filePathDisplay: .relative,
+                    onlyIncludeRootsWithSelectedFiles: false,
+                    includeLegend: false,
+                    showCodeMapMarkers: false,
+                    rootScope: .visibleWorkspace,
+                    startPath: "\(generatedAlias)/Sources"
+                ),
+                profile: .mcpRead
+            )
+            let tree = CodeMapExtractor.generateFileTree(using: snapshot)
+
+            XCTAssertEqual(snapshot.roots.count, 1, caseLabel)
+            XCTAssertTrue(tree.contains("A.swift"), caseLabel)
+            XCTAssertFalse(tree.contains("B.swift"), caseLabel)
+            XCTAssertFalse(tree.contains("Other.swift"), caseLabel)
+        }
     }
 
     func testAmbiguousLookupConsumersFailWithoutMaterializingCandidates() async throws {
@@ -4680,6 +4822,36 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
                 profile: .mcpRead
             )
             XCTAssertTrue(snapshot.selectedFileIDs.isEmpty, caseLabel)
+
+            let rootAliasTreeSnapshot = await store.makeFileTreeSelectionSnapshot(
+                selection: StoredSelection(),
+                request: WorkspaceFileTreeSnapshotRequest(
+                    mode: .full,
+                    filePathDisplay: .relative,
+                    onlyIncludeRootsWithSelectedFiles: false,
+                    includeLegend: false,
+                    showCodeMapMarkers: false,
+                    rootScope: .visibleWorkspace,
+                    startPath: "App"
+                ),
+                profile: .mcpRead
+            )
+            XCTAssertTrue(rootAliasTreeSnapshot.roots.isEmpty, caseLabel)
+
+            let prefixedAliasTreeSnapshot = await store.makeFileTreeSelectionSnapshot(
+                selection: StoredSelection(),
+                request: WorkspaceFileTreeSnapshotRequest(
+                    mode: .full,
+                    filePathDisplay: .relative,
+                    onlyIncludeRootsWithSelectedFiles: false,
+                    includeLegend: false,
+                    showCodeMapMarkers: false,
+                    rootScope: .visibleWorkspace,
+                    startPath: "App/Sources"
+                ),
+                profile: .mcpRead
+            )
+            XCTAssertTrue(prefixedAliasTreeSnapshot.roots.isEmpty, caseLabel)
         }
     }
 


### PR DESCRIPTION
## Summary
- make MCP selection/workspace replies report stale or incomplete token accounting explicitly instead of presenting authoritative-looking zero totals
- classify missing codemap renders as pending vs truly unmapped where possible using existing DTO fields
- update selection/workspace token stat composition and formatter output for incomplete accounting states
- add focused regression coverage for MCP selection freshness, codemap diagnostics, and formatter behavior

## Validation
- `make dev-format`
- `make dev-test FILTER=MCPSelectionReplyFreshnessTests`
- `make dev-test FILTER=ToolOutputFormatterWorktreeTests`
- `make dev-lint`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh commit`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh push`
- `./conductor app relaunch` — completed successfully, ticket `c5b3fc72-a3d0-4391-8156-6ea1205f7ab1`
- `make dev-smoke` — completed successfully, ticket `252a2b34-3202-4a67-aebd-482fdb855e34`
- live `rpce-cli-debug` validation:
  - `manage_selection set` for the five-file repro now shows `Token accounting pending` / incomplete components instead of authoritative `0 total tokens`
  - subsequent `manage_selection get` populated selected-file token counts while keeping codemap presentation pending explicit
  - `workspace_context` reported selected paths/tokens plus pending codemaps coherently
  - live debug-app `agent_run` engineer validation passed; noted one expected extra pending auto-codemap from auto mode
