### PR TITLE
Harden workspace restore persistence safety

### DIFF
--- a/Sources/RepoPrompt/App/WindowStateManager.swift
+++ b/Sources/RepoPrompt/App/WindowStateManager.swift
@@ -13,6 +13,59 @@ import SwiftUI
 struct WindowSessionSnapshot: Codable {
     var version: Int
     var windows: [WindowSessionEntry]
+
+    /// Transient decode-time signal. Excluded from encoding.
+    var lossyDecodeRecovered: Bool
+
+    /// Number of window elements present in the decoded payload before lossy filtering.
+    /// Nil when the windows payload itself is malformed. Excluded from encoding.
+    var decodedWindowElementCount: Int?
+
+    /// Number of malformed/future-incompatible window elements dropped during lossy decode.
+    /// Excluded from encoding.
+    var droppedWindowElementCount: Int
+
+    init(version: Int, windows: [WindowSessionEntry]) {
+        self.version = version
+        self.windows = windows
+        lossyDecodeRecovered = false
+        decodedWindowElementCount = windows.count
+        droppedWindowElementCount = 0
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        version = try c.decodeIfPresent(Int.self, forKey: .version) ?? 1
+        do {
+            if let lossyWindows = try c.decodeIfPresent(LossyDecodableArray<WindowSessionEntry>.self, forKey: .windows) {
+                windows = lossyWindows.elements
+                decodedWindowElementCount = lossyWindows.elements.count + lossyWindows.droppedCount
+                droppedWindowElementCount = lossyWindows.droppedCount
+                lossyDecodeRecovered = lossyWindows.droppedCount > 0
+            } else {
+                windows = []
+                decodedWindowElementCount = 0
+                droppedWindowElementCount = 0
+                lossyDecodeRecovered = false
+            }
+        } catch {
+            windows = []
+            decodedWindowElementCount = nil
+            droppedWindowElementCount = 0
+            lossyDecodeRecovered = true
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(version, forKey: .version)
+        try c.encode(windows, forKey: .windows)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case version
+        case windows
+    }
 }
 
 struct WindowSessionEntry: Codable {
@@ -35,6 +88,100 @@ struct WindowSessionCaptureCandidate {
 struct WindowInitialRefreshDeferral: Equatable {
     let id: UUID
     let waiterID: UUID
+}
+
+struct WindowSessionPersistenceSignature: Hashable {
+    let windowKind: String
+    let workspaceID: UUID?
+    let workspaceName: String?
+    let isSystemWorkspace: Bool
+    let isEphemeral: Bool
+    let primaryRepoPath: String?
+    let workspaceInstanceNumber: Int?
+
+    init(entry: WindowSessionEntry) {
+        windowKind = entry.windowKind.rawValue
+        workspaceID = entry.workspaceID
+        workspaceName = entry.workspaceName
+        isSystemWorkspace = entry.isSystemWorkspace
+        isEphemeral = entry.isEphemeral
+        primaryRepoPath = entry.primaryRepoPath
+        workspaceInstanceNumber = entry.workspaceInstanceNumber
+    }
+}
+
+enum WindowSessionPersistenceDecision: Equatable {
+    case persist
+    case deferUntilRestoreCompletes
+    case blockDestructiveReduction
+    case blockDestructiveReplacement
+    case blockAfterLossyRestore
+}
+
+enum WindowSessionPersistenceGuard {
+    static func decision(
+        capturedSignatures: [WindowSessionPersistenceSignature],
+        restoredBaselineCount: Int?,
+        restoredBaselineSignatures: [WindowSessionPersistenceSignature]?,
+        allowedReductionBudget: Int,
+        restoreIncomplete: Bool,
+        restoredSessionWasLossy: Bool
+    ) -> WindowSessionPersistenceDecision {
+        if restoreIncomplete {
+            return .deferUntilRestoreCompletes
+        }
+        if restoredSessionWasLossy, allowedReductionBudget == 0 {
+            return .blockAfterLossyRestore
+        }
+        guard let restoredBaselineCount else { return .persist }
+        if capturedSignatures.count + allowedReductionBudget < restoredBaselineCount {
+            return .blockDestructiveReduction
+        }
+        if allowedReductionBudget == 0,
+           let restoredBaselineSignatures,
+           capturedSignatures.count == restoredBaselineSignatures.count,
+           signatureCounts(capturedSignatures) != signatureCounts(restoredBaselineSignatures)
+        {
+            return .blockDestructiveReplacement
+        }
+        return .persist
+    }
+
+    static func baselineCountForLoadedRestoreSession(
+        restorableEntryCount: Int,
+        droppedWindowElementCount: Int
+    ) -> Int? {
+        let baselineCount = restorableEntryCount + droppedWindowElementCount
+        return baselineCount > 0 ? baselineCount : nil
+    }
+
+    static func baselineCountAfterPersist(
+        currentBaselineCount: Int?,
+        capturedWindowCount: Int
+    ) -> Int? {
+        guard currentBaselineCount != nil else { return nil }
+        return capturedWindowCount
+    }
+
+    static func baselineSignaturesAfterPersist(
+        currentBaselineSignatures _: [WindowSessionPersistenceSignature]?,
+        capturedSignatures _: [WindowSessionPersistenceSignature]
+    ) -> [WindowSessionPersistenceSignature]? {
+        // Signature replacement protection is a one-shot restore safety net.
+        // Once the first safe post-restore snapshot is allowed through, normal same-count
+        // workspace switches should not be blocked by the original restore signature set.
+        nil
+    }
+
+    private static func signatureCounts(
+        _ signatures: [WindowSessionPersistenceSignature]
+    ) -> [WindowSessionPersistenceSignature: Int] {
+        var counts: [WindowSessionPersistenceSignature: Int] = [:]
+        for signature in signatures {
+            counts[signature, default: 0] += 1
+        }
+        return counts
+    }
 }
 
 enum WindowSessionSnapshotBuilder {
@@ -230,9 +377,13 @@ class WindowStatesManager: ObservableObject {
         fileURL: WindowSessionStore.sessionFileURL()
     )
     private var explicitlyClosingWindowIDs: Set<Int> = []
+    private var allowedWindowSessionReductionBudget = 0
     private var restoreQueue: [WindowSessionEntry] = []
     private var hasLoadedRestoreSession = false
     private var isRestoreSessionLoadPending = false
+    private var restoredWindowPersistenceBaselineCount: Int?
+    private var restoredWindowPersistenceBaselineSignatures: [WindowSessionPersistenceSignature]?
+    private var restoredWindowSessionWasLossy = false
 
     func claimInitialRefreshDeferralForNewWindow() -> WindowInitialRefreshDeferral? {
         guard !pendingInitialRefreshDeferrals.isEmpty else { return nil }
@@ -306,6 +457,12 @@ class WindowStatesManager: ObservableObject {
                 self.preseedInstanceNumberState(from: snapshot)
 
                 self.restoreQueue = entries
+                self.restoredWindowPersistenceBaselineCount = WindowSessionPersistenceGuard.baselineCountForLoadedRestoreSession(
+                    restorableEntryCount: entries.count,
+                    droppedWindowElementCount: snapshot?.droppedWindowElementCount ?? 0
+                )
+                self.restoredWindowPersistenceBaselineSignatures = !entries.isEmpty ? entries.map(WindowSessionPersistenceSignature.init(entry:)) : nil
+                self.restoredWindowSessionWasLossy = snapshot?.lossyDecodeRecovered ?? false
                 self.isRestoreSessionLoadPending = false
                 if !entries.isEmpty {
                     self.applyRestoreEntriesIfPossible()
@@ -639,6 +796,7 @@ class WindowStatesManager: ObservableObject {
         guard !isTerminating else { return }
         guard allWindows.contains(where: { $0.windowID == windowID }) else { return }
         guard explicitlyClosingWindowIDs.insert(windowID).inserted else { return }
+        allowedWindowSessionReductionBudget += 1
 
         Task { @MainActor in
             await self.persistWindowSessionImmediately(reason: "explicitClose:\(windowID)")
@@ -648,13 +806,53 @@ class WindowStatesManager: ObservableObject {
     func persistWindowSession(reason: String = "unspecified") {
         guard !AppLaunchConfiguration.current.suppressesWindowPersistence else { return }
         let snapshot = captureCurrentSession()
+        guard shouldPersistWindowSessionSnapshot(snapshot, reason: reason) else { return }
         Task { await windowSessionWriter.scheduleWrite(snapshot) }
     }
 
     func persistWindowSessionImmediately(reason: String = "unspecified") async {
         guard !AppLaunchConfiguration.current.suppressesWindowPersistence else { return }
         let snapshot = captureCurrentSession()
+        guard shouldPersistWindowSessionSnapshot(snapshot, reason: reason) else { return }
         await windowSessionWriter.writeImmediately(snapshot)
+    }
+
+    private func shouldPersistWindowSessionSnapshot(_ snapshot: WindowSessionSnapshot, reason: String) -> Bool {
+        let capturedSignatures = snapshot.windows.map(WindowSessionPersistenceSignature.init(entry:))
+        let shouldWaitForRestoreLoad = !AppLaunchConfiguration.current.suppressesWindowRestore && autoRestoreWorkspacesEnabled
+        let decision = WindowSessionPersistenceGuard.decision(
+            capturedSignatures: capturedSignatures,
+            restoredBaselineCount: restoredWindowPersistenceBaselineCount,
+            restoredBaselineSignatures: restoredWindowPersistenceBaselineSignatures,
+            allowedReductionBudget: allowedWindowSessionReductionBudget,
+            restoreIncomplete: (shouldWaitForRestoreLoad && !hasLoadedRestoreSession) || isRestoreSessionLoadPending || !restoreQueue.isEmpty,
+            restoredSessionWasLossy: restoredWindowSessionWasLossy
+        )
+        switch decision {
+        case .persist:
+            let previousBaselineCount = restoredWindowPersistenceBaselineCount
+            if let previousBaselineCount {
+                let persistedReduction = max(0, previousBaselineCount - snapshot.windows.count)
+                allowedWindowSessionReductionBudget = max(0, allowedWindowSessionReductionBudget - persistedReduction)
+            }
+            restoredWindowPersistenceBaselineCount = WindowSessionPersistenceGuard.baselineCountAfterPersist(
+                currentBaselineCount: restoredWindowPersistenceBaselineCount,
+                capturedWindowCount: snapshot.windows.count
+            )
+            restoredWindowPersistenceBaselineSignatures = WindowSessionPersistenceGuard.baselineSignaturesAfterPersist(
+                currentBaselineSignatures: restoredWindowPersistenceBaselineSignatures,
+                capturedSignatures: capturedSignatures
+            )
+            restoredWindowSessionWasLossy = false
+            return true
+        case .deferUntilRestoreCompletes, .blockDestructiveReduction, .blockDestructiveReplacement, .blockAfterLossyRestore:
+            // Preserve the last complete session rather than overwrite it with a partial restore snapshot.
+            // TODO: Revisit with an explicit restore-complete/abandon signal if restore can be known terminal.
+            #if DEBUG
+                WorkspaceRestorePerfLog.log("restore.sessionPersistence skipped reason=\(reason) decision=\(decision) capturedWindows=\(snapshot.windows.count) baseline=\(restoredWindowPersistenceBaselineCount ?? -1) pendingRestore=\(isRestoreSessionLoadPending) queuedRestore=\(restoreQueue.count)")
+            #endif
+            return false
+        }
     }
 
     private func captureCurrentSession() -> WindowSessionSnapshot {

--- a/Sources/RepoPrompt/Features/Workspaces/ViewModels/WorkspaceManagerViewModel.swift
+++ b/Sources/RepoPrompt/Features/Workspaces/ViewModels/WorkspaceManagerViewModel.swift
@@ -71,9 +71,10 @@ struct WorkspaceFileLoadResult {
     let workspace: WorkspaceModel
     let cacheHit: Bool
     let composeTabsNormalized: Bool
+    let lossyDecodeRecovered: Bool
 
     var normalizationRequiresSave: Bool {
-        composeTabsNormalized
+        composeTabsNormalized && !lossyDecodeRecovered
     }
 
     let normalizationSaveTask: Task<Void, Never>?
@@ -89,9 +90,10 @@ private struct WorkspaceFileCachedLoadResult {
     let workspace: WorkspaceModel
     let cacheHit: Bool
     let composeTabsNormalized: Bool
+    let lossyDecodeRecovered: Bool
 
     var normalizationRequiresSave: Bool {
-        composeTabsNormalized
+        composeTabsNormalized && !lossyDecodeRecovered
     }
 
     let cacheKey: WorkspaceFileDecodeCacheKey
@@ -115,6 +117,7 @@ final class WorkspaceFileDecodeCache: @unchecked Sendable {
                 workspace: cached,
                 cacheHit: true,
                 composeTabsNormalized: cached.normalizationRequiresSave,
+                lossyDecodeRecovered: cached.lossyDecodeRecovered,
                 cacheKey: keyBeforeRead
             )
         }
@@ -123,10 +126,11 @@ final class WorkspaceFileDecodeCache: @unchecked Sendable {
         let standardizedURL = URL(fileURLWithPath: keyBeforeRead.standardizedPath)
         let data = try Data(contentsOf: standardizedURL)
         var workspace = try JSONDecoder().decode(WorkspaceModel.self, from: data)
+        let lossyDecodeRecovered = workspace.lossyDecodeRecovered
         let decodedRequiresSave = workspace.normalizationRequiresSave
         let normalized = workspace.normalizeComposeTabInvariants()
         let normalizationRequiresSave = decodedRequiresSave || normalized || workspace.normalizationRequiresSave
-        workspace.normalizationRequiresSave = normalizationRequiresSave
+        workspace.normalizationRequiresSave = lossyDecodeRecovered ? false : normalizationRequiresSave
 
         if let keyAfterRead = try? metadataKey(for: fileURL),
            keyAfterRead == keyBeforeRead
@@ -140,6 +144,7 @@ final class WorkspaceFileDecodeCache: @unchecked Sendable {
             workspace: workspace,
             cacheHit: false,
             composeTabsNormalized: normalizationRequiresSave,
+            lossyDecodeRecovered: lossyDecodeRecovered,
             cacheKey: keyBeforeRead
         )
     }
@@ -274,6 +279,7 @@ class WorkspaceManagerViewModel: ObservableObject {
 
     private var stateVersionByWorkspaceID: [UUID: Int] = [:]
     private var lastSavedVersionByWorkspaceID: [UUID: Int] = [:]
+    private var lossyLoadedWorkspaceIDs = Set<UUID>()
 
     @MainActor
     private static var nextWorkspaceSelectionRevision: UInt64 = 1
@@ -309,6 +315,13 @@ class WorkspaceManagerViewModel: ObservableObject {
     private func bumpStateVersion(for id: UUID?) {
         guard let id else { return }
         stateVersionByWorkspaceID[id, default: 0] &+= 1 // wraparound-safe
+    }
+
+    private func markLossyLoadedWorkspacesClean(_ workspaces: [WorkspaceModel]) {
+        for workspace in workspaces where workspace.lossyDecodeRecovered {
+            lossyLoadedWorkspaceIDs.insert(workspace.id)
+            lastSavedVersionByWorkspaceID[workspace.id] = stateVersionByWorkspaceID[workspace.id, default: 0]
+        }
     }
 
     private static func allocateWorkspaceSelectionRevision() -> UInt64 {
@@ -1466,6 +1479,7 @@ class WorkspaceManagerViewModel: ObservableObject {
             }
         #endif
         workspaces = loaded
+        markLossyLoadedWorkspacesClean(loaded)
         recordRepoPathBaselines(for: loaded)
 
         startPollTimer()
@@ -1613,15 +1627,51 @@ class WorkspaceManagerViewModel: ObservableObject {
         Self.loadWorkspaceIndex(from: workspaceIndexFileURL)
     }
 
-    private nonisolated static func loadWorkspaceIndex(from indexURL: URL) -> [WorkspaceIndexEntry] {
-        guard FileManager.default.fileExists(atPath: indexURL.path) else { return [] }
+    nonisolated static func loadWorkspaceIndex(from indexURL: URL) -> [WorkspaceIndexEntry] {
+        guard FileManager.default.fileExists(atPath: indexURL.path) else {
+            return recoverWorkspaceIndexEntries(fromBaseRoot: indexURL.deletingLastPathComponent())
+        }
 
         do {
             let data = try Data(contentsOf: indexURL)
             return try JSONDecoder().decode([WorkspaceIndexEntry].self, from: data)
         } catch {
             print("Failed to load workspaceIndex.json: \(error)")
-            return []
+            return recoverWorkspaceIndexEntries(fromBaseRoot: indexURL.deletingLastPathComponent())
+        }
+    }
+
+    nonisolated static func recoverWorkspaceIndexEntries(fromBaseRoot baseRoot: URL) -> [WorkspaceIndexEntry] {
+        guard let contents = try? FileManager.default.contentsOfDirectory(
+            at: baseRoot,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ) else { return [] }
+
+        var entries: [WorkspaceIndexEntry] = []
+        var seenIDs = Set<UUID>()
+        for directory in contents.sorted(by: { $0.path < $1.path }) {
+            let values = try? directory.resourceValues(forKeys: [.isDirectoryKey])
+            guard values?.isDirectory == true else { continue }
+            let workspaceURL = directory.appendingPathComponent("workspace.json")
+            guard FileManager.default.fileExists(atPath: workspaceURL.path),
+                  let workspace = try? loadWorkspaceFromFile(at: workspaceURL),
+                  seenIDs.insert(workspace.id).inserted
+            else { continue }
+            entries.append(WorkspaceIndexEntry(
+                id: workspace.id,
+                name: workspace.name,
+                customStoragePath: workspace.customStoragePath,
+                isSystemWorkspace: workspace.isSystemWorkspace,
+                isHiddenInMenus: workspace.isHiddenInMenus
+            ))
+        }
+        return entries.sorted { lhs, rhs in
+            let nameOrder = lhs.name.localizedCaseInsensitiveCompare(rhs.name)
+            if nameOrder != .orderedSame {
+                return nameOrder == .orderedAscending
+            }
+            return lhs.id.uuidString < rhs.id.uuidString
         }
     }
 
@@ -1684,6 +1734,7 @@ class WorkspaceManagerViewModel: ObservableObject {
                 guard reloadWorkspacesToken == token else { return }
 
                 workspaces = loaded
+                markLossyLoadedWorkspacesClean(loaded)
                 recordRepoPathBaselines(for: loaded)
                 if let currentActiveID,
                    loaded.contains(where: { $0.id == currentActiveID })
@@ -6896,6 +6947,26 @@ class WorkspaceManagerViewModel: ObservableObject {
 
     // MARK: - Save/Load Single Workspace
 
+    @discardableResult
+    nonisolated static func backupExistingWorkspaceJSONBeforeLossySave(at url: URL, now: Date = Date()) throws -> URL? {
+        let fm = FileManager.default
+        guard fm.fileExists(atPath: url.path) else { return nil }
+
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let timestamp = formatter.string(from: now).replacingOccurrences(of: ":", with: "-")
+        let directory = url.deletingLastPathComponent()
+        let baseName = url.lastPathComponent + ".pre-lossy-restore-" + timestamp
+        var candidate = directory.appendingPathComponent(baseName)
+        var suffix = 1
+        while fm.fileExists(atPath: candidate.path) {
+            candidate = directory.appendingPathComponent(baseName + "-" + String(suffix))
+            suffix += 1
+        }
+        try fm.copyItem(at: url, to: candidate)
+        return candidate
+    }
+
     private func saveWorkspaceAsync(source: WorkspaceSaveSource = .saveWorkspaceAsync) async {
         guard let active = activeWorkspace,
               let idx = workspaces.firstIndex(where: { $0.id == active.id })
@@ -6910,6 +6981,7 @@ class WorkspaceManagerViewModel: ObservableObject {
         let customStoragePath = current.customStoragePath
         let workspaceDirName = directoryName(for: current)
         let lastSyncedRepoPaths = lastSyncedRepoPathsByWorkspaceID[current.id]
+        let shouldBackupBeforeLossySave = lossyLoadedWorkspaceIDs.contains(current.id)
         await WorkspaceDiskWriter.shared.flush(url: workspaceFileURL(for: current))
 
         do {
@@ -6993,9 +7065,15 @@ class WorkspaceManagerViewModel: ObservableObject {
             }
             recordRepoPathBaseline(for: merged)
 
+            if shouldBackupBeforeLossySave {
+                _ = try Self.backupExistingWorkspaceJSONBeforeLossySave(at: url)
+            }
             let metadata = workspaceSaveMetadata(for: merged, source: source)
             WorkspaceFileDecodeCache.shared.invalidate(url: url)
             await WorkspaceDiskWriter.shared.enqueueWorkspace(data: data, url: url, metadata: metadata)
+            if shouldBackupBeforeLossySave {
+                lossyLoadedWorkspaceIDs.remove(current.id)
+            }
 
             if indexFieldsChanged {
                 await rebuildAndSaveIndexAsync()
@@ -7066,19 +7144,37 @@ class WorkspaceManagerViewModel: ObservableObject {
         }
 
         let metadata = workspaceSaveMetadata(for: workspaceToSave, source: source)
+        let shouldBackupBeforeLossySave = lossyLoadedWorkspaceIDs.contains(workspace.id)
         WorkspaceSaveTracer.event("workspaceSave.direct.enqueue", metadata: metadata, url: targetURL)
-        let finalURL = try await saveWorkspaceToFileAsync(workspaceToSave, baseRoot: currentBaseRoot, metadata: metadata)
+        let finalURL = try await saveWorkspaceToFileAsync(
+            workspaceToSave,
+            baseRoot: currentBaseRoot,
+            metadata: metadata,
+            backupBeforeLossySave: shouldBackupBeforeLossySave
+        )
         recordRepoPathBaseline(for: workspaceToSave)
+        if shouldBackupBeforeLossySave {
+            lossyLoadedWorkspaceIDs.remove(workspace.id)
+        }
         return finalURL
     }
 
-    nonisolated func saveWorkspaceToFileAsync(_ workspace: WorkspaceModel, baseRoot: URL, metadata: WorkspaceSavePayloadMetadata? = nil) async throws -> URL {
+    nonisolated func saveWorkspaceToFileAsync(
+        _ workspace: WorkspaceModel,
+        baseRoot: URL,
+        metadata: WorkspaceSavePayloadMetadata? = nil,
+        backupBeforeLossySave: Bool = false
+    ) async throws -> URL {
         // Encode JSON
         let encoded = try JSONEncoder().encode(workspace)
 
         // Prepare file path
         let folder = try ensureWorkspaceDirectoryExists(for: workspace, baseRoot: baseRoot)
         let finalURL = folder.appendingPathComponent("workspace.json")
+
+        if backupBeforeLossySave {
+            _ = try Self.backupExistingWorkspaceJSONBeforeLossySave(at: finalURL)
+        }
 
         // Enqueue write to shared disk writer for serialization
         WorkspaceFileDecodeCache.shared.invalidate(url: finalURL)
@@ -7098,12 +7194,19 @@ class WorkspaceManagerViewModel: ObservableObject {
         let folder = try ensureWorkspaceDirectoryExists(for: workspace)
         let finalURL = folder.appendingPathComponent("workspace.json")
         let metadata = workspaceSaveMetadata(for: workspace, source: source)
+        let shouldBackupBeforeLossySave = lossyLoadedWorkspaceIDs.contains(workspace.id)
+        if shouldBackupBeforeLossySave {
+            _ = try Self.backupExistingWorkspaceJSONBeforeLossySave(at: finalURL)
+        }
 
         // Write synchronously for direct save paths.
         WorkspaceFileDecodeCache.shared.invalidate(url: finalURL)
         WorkspaceSaveTracer.event("workspaceSave.syncWrite.begin", metadata: metadata, url: finalURL)
         do {
             try encoded.write(to: finalURL, options: .atomic)
+            if shouldBackupBeforeLossySave {
+                lossyLoadedWorkspaceIDs.remove(workspace.id)
+            }
             WorkspaceSaveTracer.event("workspaceSave.syncWrite.success", metadata: metadata, url: finalURL)
         } catch {
             WorkspaceSaveTracer.event("workspaceSave.syncWrite.failure", metadata: metadata, url: finalURL, extra: ["error": error.localizedDescription])
@@ -7153,6 +7256,7 @@ class WorkspaceManagerViewModel: ObservableObject {
             workspace: cachedResult.workspace,
             cacheHit: cachedResult.cacheHit,
             composeTabsNormalized: cachedResult.composeTabsNormalized,
+            lossyDecodeRecovered: cachedResult.lossyDecodeRecovered,
             normalizationSaveTask: normalizationSaveTask
         )
     }
@@ -8308,6 +8412,7 @@ class WorkspaceManagerViewModel: ObservableObject {
         // 5) Replace your in-memory array with newly loaded (or appended) ones
         //    or you can union them if you want to keep older existing ones.
         workspaces = newlyLoadedWorkspaces
+        markLossyLoadedWorkspacesClean(workspaces)
 
         // Rebuild and save the index to reflect the newly loaded sets
         await rebuildAndSaveIndexAsync()

--- a/Sources/RepoPrompt/Features/Workspaces/WorkspaceModel.swift
+++ b/Sources/RepoPrompt/Features/Workspaces/WorkspaceModel.swift
@@ -145,6 +145,37 @@ struct WorkspacePreset: Codable, Identifiable, Equatable {
     }
 }
 
+struct LossyDecodableArray<Element: Decodable>: Decodable {
+    private struct ElementWrapper: Decodable {
+        let value: Element?
+
+        init(from decoder: Decoder) throws {
+            value = try? Element(from: decoder)
+        }
+    }
+
+    let elements: [Element]
+    let droppedCount: Int
+
+    init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        var decoded: [Element] = []
+        var dropped = 0
+
+        while !container.isAtEnd {
+            let wrapper = try container.decode(ElementWrapper.self)
+            if let value = wrapper.value {
+                decoded.append(value)
+            } else {
+                dropped += 1
+            }
+        }
+
+        elements = decoded
+        droppedCount = dropped
+    }
+}
+
 struct StoredSelection: Codable, Equatable, Hashable {
     let selectedPaths: [String]
     let manualCodemapPaths: [String]
@@ -165,11 +196,21 @@ struct StoredSelection: Codable, Equatable, Hashable {
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        try self.init(
-            selectedPaths: container.decodeIfPresent([String].self, forKey: .selectedPaths) ?? [],
-            manualCodemapPaths: container.decodeIfPresent([String].self, forKey: .manualCodemapPaths) ?? [],
-            slices: container.decodeIfPresent([String: [LineRange]].self, forKey: .slices) ?? [:],
-            codemapAutoEnabled: container.decodeIfPresent(Bool.self, forKey: .codemapAutoEnabled) ?? true
+        let manualKeyWasPresent = container.contains(.manualCodemapPaths)
+        let selectedPaths = try container.decodeIfPresent([String].self, forKey: .selectedPaths) ?? []
+        let manualPaths = try container.decodeIfPresent([String].self, forKey: .manualCodemapPaths) ?? []
+        let legacyAutoPaths = (try? container.decodeIfPresent([String].self, forKey: .autoCodemapPaths)) ?? []
+        let slices = try container.decodeIfPresent([String: [LineRange]].self, forKey: .slices) ?? [:]
+        let codemapAutoEnabled = try container.decodeIfPresent(Bool.self, forKey: .codemapAutoEnabled) ?? true
+        self.init(
+            selectedPaths: selectedPaths,
+            manualCodemapPaths: Self.compatibilityCodemapPaths(
+                manualPaths: manualPaths,
+                legacyAutoPaths: legacyAutoPaths,
+                manualKeyWasPresent: manualKeyWasPresent
+            ),
+            slices: slices,
+            codemapAutoEnabled: codemapAutoEnabled
         )
     }
 
@@ -177,7 +218,7 @@ struct StoredSelection: Codable, Equatable, Hashable {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(selectedPaths, forKey: .selectedPaths)
         try container.encode(manualCodemapPaths, forKey: .manualCodemapPaths)
-        try container.encode([String](), forKey: .autoCodemapPaths)
+        try container.encode(manualCodemapPaths, forKey: .autoCodemapPaths)
         try container.encode(slices, forKey: .slices)
         try container.encode(codemapAutoEnabled, forKey: .codemapAutoEnabled)
     }
@@ -188,6 +229,24 @@ struct StoredSelection: Codable, Equatable, Hashable {
         case autoCodemapPaths
         case slices
         case codemapAutoEnabled
+    }
+
+    private static func compatibilityCodemapPaths(
+        manualPaths: [String],
+        legacyAutoPaths: [String],
+        manualKeyWasPresent: Bool
+    ) -> [String] {
+        dedupedCodemapPaths(manualKeyWasPresent ? manualPaths : legacyAutoPaths)
+    }
+
+    private static func dedupedCodemapPaths(_ paths: [String]) -> [String] {
+        var seen = Set<String>()
+        var deduped: [String] = []
+        for path in paths {
+            guard seen.insert(path).inserted else { continue }
+            deduped.append(path)
+        }
+        return deduped
     }
 }
 
@@ -302,7 +361,11 @@ struct ComposeTabState: Codable, Identifiable, Equatable {
         isPinned = try c.decodeIfPresent(Bool.self, forKey: .isPinned) ?? false
         activeChatSessionID = try c.decodeIfPresent(UUID.self, forKey: .activeChatSessionID)
         activeAgentSessionID = try c.decodeIfPresent(UUID.self, forKey: .activeAgentSessionID)
-        selection = (try? c.decodeIfPresent(StoredSelection.self, forKey: .selection)) ?? .init()
+        if c.contains(.selection) {
+            selection = try c.decodeIfPresent(StoredSelection.self, forKey: .selection) ?? .init()
+        } else {
+            selection = .init()
+        }
         expandedFolders = try c.decodeIfPresent([String].self, forKey: .expandedFolders) ?? []
         promptText = try c.decodeIfPresent(String.self, forKey: .promptText) ?? ""
         selectedMetaPromptIDs = try c.decodeIfPresent([UUID].self, forKey: .selectedMetaPromptIDs) ?? []
@@ -389,6 +452,10 @@ struct WorkspaceModel: Codable, Identifiable, Equatable {
     /// compose-tab invariant normalization once. Excluded from CodingKeys/Equatable.
     var normalizationRequiresSave: Bool
 
+    /// Transient decode-time signal indicating one or more compose/stash entries
+    /// were skipped to preserve the rest of the workspace. Excluded from CodingKeys/Equatable.
+    var lossyDecodeRecovered: Bool
+
     private static let decodeLogger = Logger(subsystem: "com.repoprompt.workspace", category: "decode")
     private static var composeTabsDecodeWarningEmitted = false
 
@@ -447,6 +514,7 @@ struct WorkspaceModel: Codable, Identifiable, Equatable {
         self.activeComposeTabID = activeComposeTabID
         self.stashedTabs = stashedTabs
         normalizationRequiresSave = false
+        lossyDecodeRecovered = false
         normalizeComposeTabInvariants()
         normalizationRequiresSave = false
     }
@@ -474,16 +542,37 @@ struct WorkspaceModel: Codable, Identifiable, Equatable {
         copyPresetId = (try? c.decode(UUID.self, forKey: .copyPresetId))
         copyCustomizations = (try? c.decode(CopyCustomizations.self, forKey: .copyCustomizations))
         chatPresetId = (try? c.decode(UUID.self, forKey: .chatPresetId))
+        let lossyComposeTabs: LossyDecodableArray<ComposeTabState>?
+        var composeTabsRecoveredFromMalformedValue = false
         do {
-            composeTabs = try c.decodeIfPresent([ComposeTabState].self, forKey: .composeTabs) ?? []
+            lossyComposeTabs = try c.decodeIfPresent(LossyDecodableArray<ComposeTabState>.self, forKey: .composeTabs)
+            composeTabs = lossyComposeTabs?.elements ?? []
         } catch {
             Self.logComposeTabsDecodeFailure(error: error, workspaceID: id)
+            lossyComposeTabs = nil
             composeTabs = []
+            composeTabsRecoveredFromMalformedValue = true
         }
         activeComposeTabID = (try? c.decode(UUID.self, forKey: .activeComposeTabID))
-        stashedTabs = (try? c.decode([StashedTab].self, forKey: .stashedTabs)) ?? []
+        let lossyStashedTabs: LossyDecodableArray<StashedTab>?
+        var stashedTabsRecoveredFromMalformedValue = false
+        do {
+            lossyStashedTabs = try c.decodeIfPresent(LossyDecodableArray<StashedTab>.self, forKey: .stashedTabs)
+            stashedTabs = lossyStashedTabs?.elements ?? []
+        } catch {
+            lossyStashedTabs = nil
+            stashedTabs = []
+            stashedTabsRecoveredFromMalformedValue = true
+        }
         normalizationRequiresSave = false
-        normalizeComposeTabInvariants()
+        lossyDecodeRecovered = composeTabsRecoveredFromMalformedValue
+            || stashedTabsRecoveredFromMalformedValue
+            || (lossyComposeTabs?.droppedCount ?? 0) > 0
+            || (lossyStashedTabs?.droppedCount ?? 0) > 0
+        let normalized = normalizeComposeTabInvariants()
+        if lossyDecodeRecovered, normalized {
+            normalizationRequiresSave = false
+        }
     }
 
     func encode(to encoder: Encoder) throws {

--- a/Tests/RepoPromptTests/WorkspaceContext/WorkspaceFilesAutoCodemapModeTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/WorkspaceFilesAutoCodemapModeTests.swift
@@ -44,7 +44,7 @@ final class WorkspaceFilesAutoCodemapModeTests: XCTestCase {
         }
     }
 
-    func testSnapshotAndEncodingContainNoInferredPathState() throws {
+    func testSnapshotAndEncodingContainNoInferredPathStateBeyondLegacyCompatibilityKey() throws {
         let fixture = makeFixture(fileName: "Dependency.swift")
         fixture.viewModel.selectFileForTesting(fixture.file)
 
@@ -56,7 +56,7 @@ final class WorkspaceFilesAutoCodemapModeTests: XCTestCase {
         let encodedObject = try XCTUnwrap(
             JSONSerialization.jsonObject(with: encoded) as? [String: Any]
         )
-        XCTAssertEqual(encodedObject["autoCodemapPaths"] as? [String], [])
+        XCTAssertEqual(encodedObject["autoCodemapPaths"] as? [String], snapshot.manualCodemapPaths)
 
         fixture.viewModel.setAutoCodemapFilesForTesting([fixture.file])
         XCTAssertEqual(fixture.viewModel.autoCodemapFiles.map(\.id), [fixture.file.id])

--- a/Tests/RepoPromptTests/WorkspaceContext/WorkspaceSelectionAutoCodemapInvariantTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/WorkspaceSelectionAutoCodemapInvariantTests.swift
@@ -109,7 +109,7 @@ final class WorkspaceSelectionAutoCodemapInvariantTests: XCTestCase {
         XCTAssertTrue(removed.mutated)
     }
 
-    func testStoredSelectionIgnoresLegacyInferredPathsAndWritesCompatibilityAlias() throws {
+    func testStoredSelectionUsesManualCodemapPathsAndReencodesLegacyCompatibilityAlias() throws {
         let legacyJSON = try XCTUnwrap(
             """
             {
@@ -135,10 +135,13 @@ final class WorkspaceSelectionAutoCodemapInvariantTests: XCTestCase {
             encodedObject["manualCodemapPaths"] as? [String],
             ["/workspace/Manual.swift"]
         )
-        XCTAssertEqual(encodedObject["autoCodemapPaths"] as? [String], [])
+        XCTAssertEqual(
+            encodedObject["autoCodemapPaths"] as? [String],
+            ["/workspace/Manual.swift"]
+        )
     }
 
-    func testStoredSelectionEncodingRemainsReadableByLegacyDecoder() throws {
+    func testStoredSelectionEncodingProvidesManualPathsToLegacyDecoder() throws {
         let currentManual = StoredSelection(
             selectedPaths: ["/workspace/Source.swift"],
             manualCodemapPaths: ["/workspace/Manual.swift"],
@@ -147,7 +150,7 @@ final class WorkspaceSelectionAutoCodemapInvariantTests: XCTestCase {
 
         let manualEncoded = try JSONEncoder().encode(currentManual)
         let legacyManual = try JSONDecoder().decode(LegacyStoredSelection.self, from: manualEncoded)
-        XCTAssertTrue(legacyManual.autoCodemapPaths.isEmpty)
+        XCTAssertEqual(legacyManual.autoCodemapPaths, ["/workspace/Manual.swift"])
     }
 
     func testSelectionProductionPathContainsNoLegacyRelationshipCalls() throws {

--- a/Tests/RepoPromptTests/Workspaces/WorkspaceRestoreSafetyTests.swift
+++ b/Tests/RepoPromptTests/Workspaces/WorkspaceRestoreSafetyTests.swift
@@ -1,0 +1,535 @@
+import Foundation
+@testable import RepoPrompt
+import XCTest
+
+final class WorkspaceRestoreSafetyTests: XCTestCase {
+    func testStoredSelectionEncodesLegacyAutoCodemapPathsForOlderDecoder() throws {
+        struct OldSelectionDecoder: Decodable {
+            let autoCodemapPaths: [String]
+        }
+
+        let selection = StoredSelection(manualCodemapPaths: ["/tmp/A.swift"])
+        let data = try JSONEncoder().encode(selection)
+        let decoded = try JSONDecoder().decode(OldSelectionDecoder.self, from: data)
+        XCTAssertEqual(decoded.autoCodemapPaths, ["/tmp/A.swift"])
+    }
+
+    func testStoredSelectionUsesManualCodemapPathsWhenLegacyAutoCodemapPathsAlsoExists() throws {
+        let json = #"""
+        {
+          "selectedPaths": [],
+          "manualCodemapPaths": ["/tmp/A.swift", "/tmp/Case.swift", " /tmp/Space.swift"],
+          "autoCodemapPaths": ["/tmp/A.swift", "/tmp/B.swift", "/tmp/case.swift", "/tmp/Space.swift"],
+          "slices": {},
+          "codemapAutoEnabled": false
+        }
+        """#.data(using: .utf8)!
+
+        let selection = try JSONDecoder().decode(StoredSelection.self, from: json)
+        XCTAssertEqual(
+            selection.manualCodemapPaths,
+            ["/tmp/A.swift", "/tmp/Case.swift", " /tmp/Space.swift"]
+        )
+    }
+
+    func testStoredSelectionFallsBackToLegacyAutoCodemapPathsWhenManualKeyIsAbsent() throws {
+        let json = #"""
+        {
+          "selectedPaths": [],
+          "autoCodemapPaths": ["/tmp/Legacy.swift", "/tmp/Legacy.swift", "/tmp/Other.swift"],
+          "slices": {},
+          "codemapAutoEnabled": false
+        }
+        """#.data(using: .utf8)!
+
+        let selection = try JSONDecoder().decode(StoredSelection.self, from: json)
+        XCTAssertEqual(selection.manualCodemapPaths, ["/tmp/Legacy.swift", "/tmp/Other.swift"])
+    }
+
+    func testWorkspaceDecodePreservesTabWhenLegacyAutoCodemapPathsIsMalformed() throws {
+        let tabID = UUID()
+        let workspaceID = UUID()
+        let tabObject = try XCTUnwrap(encodedJSONObject(ComposeTabState(id: tabID, name: "Keep Me")) as? [String: Any])
+        var selectionObject = try XCTUnwrap(tabObject["selection"] as? [String: Any])
+        selectionObject["manualCodemapPaths"] = ["/tmp/Manual.swift"]
+        selectionObject["autoCodemapPaths"] = ["unexpected": "object"]
+        var malformedTabObject = tabObject
+        malformedTabObject["selection"] = selectionObject
+        let jsonObject: [String: Any] = baseWorkspaceJSON(
+            id: workspaceID,
+            name: "Malformed Legacy Selection",
+            composeTabs: [malformedTabObject],
+            activeComposeTabID: tabID.uuidString
+        )
+        let json = try JSONSerialization.data(withJSONObject: jsonObject)
+
+        let workspace = try JSONDecoder().decode(WorkspaceModel.self, from: json)
+        XCTAssertFalse(workspace.lossyDecodeRecovered)
+        XCTAssertEqual(workspace.composeTabs.map(\.id), [tabID])
+        XCTAssertEqual(workspace.composeTabs.first?.selection.manualCodemapPaths, ["/tmp/Manual.swift"])
+    }
+
+    func testMalformedCoreSelectionFieldMarksWorkspaceLossy() throws {
+        let tabID = UUID()
+        let workspaceID = UUID()
+        let tabObject = try XCTUnwrap(encodedJSONObject(ComposeTabState(id: tabID, name: "Drop Me")) as? [String: Any])
+        var selectionObject = try XCTUnwrap(tabObject["selection"] as? [String: Any])
+        selectionObject["selectedPaths"] = ["unexpected": "object"]
+        var malformedTabObject = tabObject
+        malformedTabObject["selection"] = selectionObject
+        let jsonObject = baseWorkspaceJSON(
+            id: workspaceID,
+            name: "Malformed Core Selection",
+            composeTabs: [malformedTabObject],
+            activeComposeTabID: tabID.uuidString
+        )
+        let json = try JSONSerialization.data(withJSONObject: jsonObject)
+
+        let workspace = try JSONDecoder().decode(WorkspaceModel.self, from: json)
+        XCTAssertTrue(workspace.lossyDecodeRecovered)
+        XCTAssertNotEqual(workspace.composeTabs.map(\.id), [tabID])
+        XCTAssertFalse(workspace.normalizationRequiresSave)
+    }
+
+    func testWorkspaceDecodePreservesValidComposeTabsWhenOneEntryIsCorrupt() throws {
+        let goodTabID = UUID()
+        let badTabID = UUID()
+        let workspaceID = UUID()
+        let goodTabJSON = try encodedJSONObject(ComposeTabState(id: goodTabID, name: "Keep Me", promptText: "important prompt"))
+        let jsonObject = baseWorkspaceJSON(
+            id: workspaceID,
+            name: "Lossy Tabs",
+            composeTabs: [goodTabJSON, ["id": 5, "name": "Corrupt"]],
+            activeComposeTabID: badTabID.uuidString
+        )
+        let json = try JSONSerialization.data(withJSONObject: jsonObject)
+
+        let workspace = try JSONDecoder().decode(WorkspaceModel.self, from: json)
+        XCTAssertTrue(workspace.lossyDecodeRecovered)
+        XCTAssertEqual(workspace.composeTabs.map(\.id), [goodTabID])
+        XCTAssertEqual(workspace.activeComposeTabID, goodTabID)
+        XCTAssertFalse(workspace.normalizationRequiresSave)
+    }
+
+    func testMalformedTopLevelComposeTabsDoesNotScheduleNormalizationWriteback() throws {
+        #if DEBUG
+            WorkspaceFileDecodeCache.shared.removeAllForTesting()
+        #endif
+        let root = try makeTemporaryDirectory(named: "MalformedComposeTabsLoad")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let fileURL = root.appendingPathComponent("workspace.json")
+        let jsonObject: [String: Any] = [
+            "id": UUID().uuidString,
+            "schemaVersion": 1,
+            "name": "Malformed Compose Tabs",
+            "repoPaths": [],
+            "presets": [],
+            "selectedMetaPromptIDs": [],
+            "isSystemWorkspace": false,
+            "isHiddenInMenus": false,
+            "composeTabs": ["unexpected": "object"],
+            "stashedTabs": []
+        ]
+        let json = try JSONSerialization.data(withJSONObject: jsonObject)
+        try json.write(to: fileURL, options: .atomic)
+
+        let originalBytes = try Data(contentsOf: fileURL)
+        let result = try WorkspaceManagerViewModel.loadWorkspaceFromFileResult(at: fileURL)
+        let loadedBytes = try Data(contentsOf: fileURL)
+        XCTAssertEqual(loadedBytes, originalBytes)
+        XCTAssertTrue(result.lossyDecodeRecovered)
+        XCTAssertEqual(result.workspace.composeTabs.count, 1)
+        XCTAssertFalse(result.normalizationRequiresSave)
+        XCTAssertNil(result.normalizationSaveTask)
+    }
+
+    func testLoadWorkspaceFromFileDoesNotScheduleNormalizationWritebackAfterLossyRecovery() throws {
+        #if DEBUG
+            WorkspaceFileDecodeCache.shared.removeAllForTesting()
+        #endif
+        let root = try makeTemporaryDirectory(named: "LossyWorkspaceLoad")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let fileURL = root.appendingPathComponent("workspace.json")
+        let goodTabID = UUID()
+        let badTabID = UUID()
+        let goodTabJSON = try encodedJSONObject(ComposeTabState(id: goodTabID, name: "Keep Me", promptText: "important prompt"))
+        let jsonObject = baseWorkspaceJSON(
+            id: UUID(),
+            name: "Lossy Load",
+            composeTabs: [goodTabJSON, ["id": 5]],
+            activeComposeTabID: badTabID.uuidString
+        )
+        let json = try JSONSerialization.data(withJSONObject: jsonObject)
+        try json.write(to: fileURL, options: .atomic)
+
+        let result = try WorkspaceManagerViewModel.loadWorkspaceFromFileResult(at: fileURL)
+        XCTAssertTrue(result.lossyDecodeRecovered)
+        XCTAssertFalse(result.normalizationRequiresSave)
+        XCTAssertNil(result.normalizationSaveTask)
+    }
+
+    func testLossyStashedTabsPreservesValidEntries() throws {
+        let activeTabID = UUID()
+        let stashedTabID = UUID()
+        let activeTabJSON = try encodedJSONObject(ComposeTabState(id: activeTabID, name: "Active"))
+        let stashedJSON = try encodedJSONObject(StashedTab(tab: ComposeTabState(id: stashedTabID, name: "Stashed")))
+        let jsonObject = baseWorkspaceJSON(
+            id: UUID(),
+            name: "Lossy Stash",
+            composeTabs: [activeTabJSON],
+            activeComposeTabID: activeTabID.uuidString,
+            stashedTabs: [stashedJSON, ["id": 5]]
+        )
+        let json = try JSONSerialization.data(withJSONObject: jsonObject)
+
+        let workspace = try JSONDecoder().decode(WorkspaceModel.self, from: json)
+        XCTAssertTrue(workspace.lossyDecodeRecovered)
+        XCTAssertEqual(workspace.stashedTabs.map(\.tab.id), [stashedTabID])
+        XCTAssertFalse(workspace.normalizationRequiresSave)
+    }
+
+    func testWindowSessionSnapshotTracksLossyDecode() throws {
+        let validEntry = try encodedJSONObject(makeWindowEntry(workspaceID: UUID(), workspaceName: "A"))
+        let jsonObject: [String: Any] = [
+            "version": 4,
+            "windows": [validEntry, ["windowKind": "standard", "workspaceName": "Missing required booleans"]]
+        ]
+        let json = try JSONSerialization.data(withJSONObject: jsonObject)
+
+        let snapshot = try JSONDecoder().decode(WindowSessionSnapshot.self, from: json)
+        XCTAssertTrue(snapshot.lossyDecodeRecovered)
+        XCTAssertEqual(snapshot.decodedWindowElementCount, 2)
+        XCTAssertEqual(snapshot.droppedWindowElementCount, 1)
+        XCTAssertEqual(snapshot.windows.count, 1)
+
+        let encoded = try JSONEncoder().encode(snapshot)
+        let encodedObject = try XCTUnwrap(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        XCTAssertNil(encodedObject["lossyDecodeRecovered"])
+        XCTAssertNil(encodedObject["decodedWindowElementCount"])
+        XCTAssertNil(encodedObject["droppedWindowElementCount"])
+    }
+
+    func testWindowSessionSnapshotTracksMalformedWindowsPayloadAsLossy() throws {
+        let json = #"{"version":4,"windows":{"unexpected":"object"}}"#.data(using: .utf8)!
+
+        let snapshot = try JSONDecoder().decode(WindowSessionSnapshot.self, from: json)
+        XCTAssertTrue(snapshot.lossyDecodeRecovered)
+        XCTAssertNil(snapshot.decodedWindowElementCount)
+        XCTAssertEqual(snapshot.droppedWindowElementCount, 0)
+        XCTAssertTrue(snapshot.windows.isEmpty)
+    }
+
+    func testWindowSessionBaselineIgnoresEphemeralEntriesButCountsDroppedEntries() throws {
+        let standardA = makeWindowEntry(workspaceID: UUID(), workspaceName: "A", repoPath: "/repo/a", instance: 1)
+        let standardB = makeWindowEntry(workspaceID: UUID(), workspaceName: "B", repoPath: "/repo/b", instance: 2)
+        let ephemeral = makeWindowEntry(
+            workspaceID: UUID(),
+            workspaceName: "Ephemeral",
+            repoPath: "/tmp/ephemeral",
+            instance: 3,
+            isEphemeral: true
+        )
+        let snapshotWithEphemeralOnly = WindowSessionSnapshot(
+            version: 4,
+            windows: [standardA, ephemeral, standardB]
+        )
+        let restorableEntries = snapshotWithEphemeralOnly.windows.filter { !$0.isEphemeral }
+        let baselineCount = WindowSessionPersistenceGuard.baselineCountForLoadedRestoreSession(
+            restorableEntryCount: restorableEntries.count,
+            droppedWindowElementCount: snapshotWithEphemeralOnly.droppedWindowElementCount
+        )
+        XCTAssertEqual(baselineCount, 2)
+        XCTAssertEqual(
+            WindowSessionPersistenceGuard.decision(
+                capturedSignatures: restorableEntries.map(WindowSessionPersistenceSignature.init(entry:)),
+                restoredBaselineCount: baselineCount,
+                restoredBaselineSignatures: restorableEntries.map(WindowSessionPersistenceSignature.init(entry:)),
+                allowedReductionBudget: 0,
+                restoreIncomplete: false,
+                restoredSessionWasLossy: false
+            ),
+            .persist
+        )
+
+        let standardJSON = try encodedJSONObject(standardA)
+        let ephemeralJSON = try encodedJSONObject(ephemeral)
+        let jsonObject: [String: Any] = [
+            "version": 4,
+            "windows": [
+                standardJSON,
+                ephemeralJSON,
+                ["windowKind": "standard", "workspaceName": "Missing required booleans"]
+            ]
+        ]
+        let lossySnapshot = try JSONDecoder().decode(
+            WindowSessionSnapshot.self,
+            from: JSONSerialization.data(withJSONObject: jsonObject)
+        )
+        let lossyRestorableEntries = lossySnapshot.windows.filter { !$0.isEphemeral }
+        let lossyBaselineCount = WindowSessionPersistenceGuard.baselineCountForLoadedRestoreSession(
+            restorableEntryCount: lossyRestorableEntries.count,
+            droppedWindowElementCount: lossySnapshot.droppedWindowElementCount
+        )
+        XCTAssertEqual(lossySnapshot.decodedWindowElementCount, 3)
+        XCTAssertEqual(lossySnapshot.droppedWindowElementCount, 1)
+        XCTAssertEqual(lossyBaselineCount, 2)
+        XCTAssertEqual(
+            WindowSessionPersistenceGuard.decision(
+                capturedSignatures: lossyRestorableEntries.map(WindowSessionPersistenceSignature.init(entry:)),
+                restoredBaselineCount: lossyBaselineCount,
+                restoredBaselineSignatures: lossyRestorableEntries.map(WindowSessionPersistenceSignature.init(entry:)),
+                allowedReductionBudget: 0,
+                restoreIncomplete: false,
+                restoredSessionWasLossy: false
+            ),
+            .blockDestructiveReduction
+        )
+    }
+
+    func testWindowSessionPersistenceGuardBlocksIncompleteLossyReductionAndReplacement() {
+        let baselineA = WindowSessionPersistenceSignature(entry: makeWindowEntry(workspaceID: UUID(), workspaceName: "A", repoPath: "/repo/a", instance: 1))
+        let baselineB = WindowSessionPersistenceSignature(entry: makeWindowEntry(workspaceID: UUID(), workspaceName: "B", repoPath: "/repo/b", instance: 2))
+        let degradedA = WindowSessionPersistenceSignature(entry: makeWindowEntry(workspaceID: UUID(), workspaceName: "T1", repoPath: nil, instance: 1))
+        let degradedB = WindowSessionPersistenceSignature(entry: makeWindowEntry(workspaceID: UUID(), workspaceName: "T1", repoPath: nil, instance: 2))
+
+        XCTAssertEqual(
+            WindowSessionPersistenceGuard.decision(
+                capturedSignatures: [baselineA],
+                restoredBaselineCount: 2,
+                restoredBaselineSignatures: [baselineA, baselineB],
+                allowedReductionBudget: 0,
+                restoreIncomplete: true,
+                restoredSessionWasLossy: false
+            ),
+            .deferUntilRestoreCompletes
+        )
+        XCTAssertEqual(
+            WindowSessionPersistenceGuard.decision(
+                capturedSignatures: [baselineA],
+                restoredBaselineCount: 2,
+                restoredBaselineSignatures: [baselineA, baselineB],
+                allowedReductionBudget: 0,
+                restoreIncomplete: false,
+                restoredSessionWasLossy: false
+            ),
+            .blockDestructiveReduction
+        )
+        XCTAssertEqual(
+            WindowSessionPersistenceGuard.decision(
+                capturedSignatures: [baselineA, baselineB],
+                restoredBaselineCount: 2,
+                restoredBaselineSignatures: [baselineA, baselineB],
+                allowedReductionBudget: 0,
+                restoreIncomplete: false,
+                restoredSessionWasLossy: true
+            ),
+            .blockAfterLossyRestore
+        )
+        XCTAssertEqual(
+            WindowSessionPersistenceGuard.decision(
+                capturedSignatures: [degradedA, degradedB],
+                restoredBaselineCount: 2,
+                restoredBaselineSignatures: [baselineA, baselineB],
+                allowedReductionBudget: 0,
+                restoreIncomplete: false,
+                restoredSessionWasLossy: false
+            ),
+            .blockDestructiveReplacement
+        )
+        XCTAssertEqual(
+            WindowSessionPersistenceGuard.decision(
+                capturedSignatures: [baselineA],
+                restoredBaselineCount: 2,
+                restoredBaselineSignatures: [baselineA, baselineB],
+                allowedReductionBudget: 1,
+                restoreIncomplete: false,
+                restoredSessionWasLossy: false
+            ),
+            .persist
+        )
+        XCTAssertEqual(
+            WindowSessionPersistenceGuard.baselineCountAfterPersist(
+                currentBaselineCount: 2,
+                capturedWindowCount: 1
+            ),
+            1
+        )
+        XCTAssertNil(
+            WindowSessionPersistenceGuard.baselineCountForLoadedRestoreSession(
+                restorableEntryCount: 0,
+                droppedWindowElementCount: 0
+            )
+        )
+        XCTAssertEqual(
+            WindowSessionPersistenceGuard.baselineCountForLoadedRestoreSession(
+                restorableEntryCount: 1,
+                droppedWindowElementCount: 1
+            ),
+            2
+        )
+        XCTAssertNil(
+            WindowSessionPersistenceGuard.baselineCountAfterPersist(
+                currentBaselineCount: nil,
+                capturedWindowCount: 1
+            )
+        )
+        XCTAssertNil(
+            WindowSessionPersistenceGuard.baselineSignaturesAfterPersist(
+                currentBaselineSignatures: [baselineA, baselineB],
+                capturedSignatures: [baselineA, baselineB]
+            )
+        )
+        XCTAssertEqual(
+            WindowSessionPersistenceGuard.decision(
+                capturedSignatures: [degradedA, degradedB],
+                restoredBaselineCount: 2,
+                restoredBaselineSignatures: nil,
+                allowedReductionBudget: 0,
+                restoreIncomplete: false,
+                restoredSessionWasLossy: false
+            ),
+            .persist
+        )
+    }
+
+    func testLossyWorkspaceBackupHelperCopiesExistingWorkspaceJSON() throws {
+        let root = try makeTemporaryDirectory(named: "LossyBackup")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let fileURL = root.appendingPathComponent("workspace.json")
+        let original = Data("original workspace".utf8)
+        try original.write(to: fileURL, options: .atomic)
+
+        let backupURL = try XCTUnwrap(
+            WorkspaceManagerViewModel.backupExistingWorkspaceJSONBeforeLossySave(
+                at: fileURL,
+                now: Date(timeIntervalSince1970: 0)
+            )
+        )
+        XCTAssertEqual(try Data(contentsOf: backupURL), original)
+        XCTAssertTrue(backupURL.lastPathComponent.contains("pre-lossy-restore"))
+        XCTAssertEqual(try Data(contentsOf: fileURL), original)
+    }
+
+    func testMissingWorkspaceIndexFallsBackToWorkspaceDirectories() throws {
+        let root = try makeTemporaryDirectory(named: "MissingWorkspaceIndexRecovery")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let workspace = WorkspaceModel(name: "Recovered Missing", repoPaths: [root.path])
+        let workspaceDirectory = root.appendingPathComponent("Workspace-RecoveredMissing-\(workspace.id.uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: workspaceDirectory, withIntermediateDirectories: true)
+        try JSONEncoder().encode(workspace).write(to: workspaceDirectory.appendingPathComponent("workspace.json"), options: .atomic)
+        let indexURL = root.appendingPathComponent("workspaceIndex.json")
+
+        let entries = WorkspaceManagerViewModel.loadWorkspaceIndex(from: indexURL)
+        XCTAssertEqual(entries.count, 1)
+        XCTAssertEqual(entries.first?.id, workspace.id)
+        XCTAssertEqual(entries.first?.name, "Recovered Missing")
+    }
+
+    func testCorruptWorkspaceIndexFallsBackToWorkspaceDirectories() throws {
+        let root = try makeTemporaryDirectory(named: "WorkspaceIndexRecovery")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let workspace = WorkspaceModel(name: "Recovered", repoPaths: [root.path])
+        let workspaceDirectory = root.appendingPathComponent("Workspace-Recovered-\(workspace.id.uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: workspaceDirectory, withIntermediateDirectories: true)
+        try JSONEncoder().encode(workspace).write(to: workspaceDirectory.appendingPathComponent("workspace.json"), options: .atomic)
+        let indexURL = root.appendingPathComponent("workspaceIndex.json")
+        try "not json".write(to: indexURL, atomically: true, encoding: .utf8)
+
+        let entries = WorkspaceManagerViewModel.loadWorkspaceIndex(from: indexURL)
+        XCTAssertEqual(entries.count, 1)
+        XCTAssertEqual(entries.first?.id, workspace.id)
+        XCTAssertEqual(entries.first?.name, "Recovered")
+    }
+
+    func testRecoveredWorkspaceIndexUsesDeterministicDirectoryOrderForDuplicateIDs() throws {
+        let root = try makeTemporaryDirectory(named: "WorkspaceIndexDuplicateIDRecovery")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let workspaceID = try XCTUnwrap(UUID(uuidString: "11111111-1111-1111-1111-111111111111"))
+        let zWorkspace = WorkspaceModel(id: workspaceID, name: "Zed", repoPaths: [root.path])
+        let aWorkspace = WorkspaceModel(id: workspaceID, name: "Alpha", repoPaths: [root.path])
+        try writeWorkspace(zWorkspace, under: root, suffix: "z")
+        try writeWorkspace(aWorkspace, under: root, suffix: "a")
+
+        let entries = WorkspaceManagerViewModel.recoverWorkspaceIndexEntries(fromBaseRoot: root)
+        XCTAssertEqual(entries.count, 1)
+        XCTAssertEqual(entries.first?.id, workspaceID)
+        XCTAssertEqual(entries.first?.name, "Alpha")
+    }
+
+    func testRecoveredWorkspaceIndexSortsDuplicateNamesDeterministicallyByID() throws {
+        let root = try makeTemporaryDirectory(named: "WorkspaceIndexDuplicateNameRecovery")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let highID = try XCTUnwrap(UUID(uuidString: "FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF"))
+        let lowID = try XCTUnwrap(UUID(uuidString: "00000000-0000-0000-0000-000000000001"))
+        let highWorkspace = WorkspaceModel(id: highID, name: "Same", repoPaths: [root.path])
+        let lowWorkspace = WorkspaceModel(id: lowID, name: "Same", repoPaths: [root.path])
+        try writeWorkspace(highWorkspace, under: root, suffix: "high")
+        try writeWorkspace(lowWorkspace, under: root, suffix: "low")
+
+        let entries = WorkspaceManagerViewModel.recoverWorkspaceIndexEntries(fromBaseRoot: root)
+        XCTAssertEqual(entries.map(\.id), [lowID, highID])
+    }
+
+    private func baseWorkspaceJSON(
+        id: UUID,
+        name: String,
+        composeTabs: [Any],
+        activeComposeTabID: String?,
+        stashedTabs: [Any] = []
+    ) -> [String: Any] {
+        var json: [String: Any] = [
+            "id": id.uuidString,
+            "schemaVersion": 1,
+            "name": name,
+            "repoPaths": [],
+            "presets": [],
+            "selectedMetaPromptIDs": [],
+            "isSystemWorkspace": false,
+            "isHiddenInMenus": false,
+            "composeTabs": composeTabs,
+            "stashedTabs": stashedTabs
+        ]
+        if let activeComposeTabID {
+            json["activeComposeTabID"] = activeComposeTabID
+        }
+        return json
+    }
+
+    private func makeWindowEntry(
+        workspaceID: UUID?,
+        workspaceName: String,
+        repoPath: String? = "/repo",
+        instance: Int? = 1,
+        isEphemeral: Bool = false
+    ) -> WindowSessionEntry {
+        WindowSessionEntry(
+            windowKind: .standard,
+            workspaceID: workspaceID,
+            workspaceName: workspaceName,
+            isSystemWorkspace: false,
+            isEphemeral: isEphemeral,
+            primaryRepoPath: repoPath,
+            lastFocused: false,
+            workspaceInstanceNumber: instance
+        )
+    }
+
+    private func writeWorkspace(_ workspace: WorkspaceModel, under root: URL, suffix: String) throws {
+        let workspaceDirectory = root.appendingPathComponent("Workspace-\(suffix)-\(workspace.id.uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: workspaceDirectory, withIntermediateDirectories: true)
+        try JSONEncoder().encode(workspace).write(to: workspaceDirectory.appendingPathComponent("workspace.json"), options: .atomic)
+    }
+
+    private func encodedJSONObject(_ value: some Encodable) throws -> Any {
+        let data = try JSONEncoder().encode(value)
+        return try JSONSerialization.jsonObject(with: data)
+    }
+
+    private func makeTemporaryDirectory(named name: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("RepoPromptTests", isDirectory: true)
+            .appendingPathComponent(name + "-" + UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+}


### PR DESCRIPTION
## Summary

- Harden workspace/session restore against lossy decode and degraded/default writeback paths.
- Add legacy `autoCodemapPaths` compatibility encoding while keeping `manualCodemapPaths` authoritative on decode.
- Make malformed core selection data drop only the affected tab/stash element and mark workspace recovery lossy, instead of silently defaulting state.
- Guard `windowSessions.json` persistence during restore, after lossy session recovery, on destructive reductions, and on same-count degraded replacements.
- Track malformed dropped window entries separately from ephemeral entries so legacy ephemeral windows do not freeze persistence, while dropped/future-incompatible entries still protect against lossy overwrite.
- Back up `workspace.json` before first save of lossy-loaded workspaces and make workspace index recovery deterministic.
- Add focused restore-safety regression coverage.

Refs #335 and #337.

## Validation

- `make dev-test FILTER=WorkspaceRestoreSafetyTests`
- `make dev-test FILTER=WorkspaceFilesAutoCodemapModeTests`
- `make dev-test FILTER=WorkspaceSelectionAutoCodemapInvariantTests`
- `make dev-format`
- `make dev-lint`
- `git diff --check origin/main -- .`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh commit`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh push`

## Review notes

- Claude Code Fable 5 review workflow initially found an ephemeral-window baseline issue.
- Follow-up fix was implemented and the focused Fable re-review verdict was `ship` with no must-fix issues remaining.
