### PR TITLE
Make git fixtures hermetic and hang-proof codemap engine test

### DIFF
--- a/Tests/RepoPromptTests/Helpers/ReviewGitRepositoryFixture.swift
+++ b/Tests/RepoPromptTests/Helpers/ReviewGitRepositoryFixture.swift
@@ -35,6 +35,11 @@ final class ReviewGitRepositoryFixture {
         _ = try runGit(["config", "user.name", "RepoPrompt Test"], at: root)
         _ = try runGit(["config", "user.email", "repoprompt@example.test"], at: root)
         _ = try runGit(["config", "commit.gpgSign", "false"], at: root)
+        // The product reads checkout config at engine runtime with the host environment, so
+        // fixture repos pin transform-relevant keys locally to stay hermetic against host gitconfig.
+        _ = try runGit(["config", "core.autocrlf", "false"], at: root)
+        _ = try runGit(["config", "core.eol", "native"], at: root)
+        _ = try runGit(["config", "core.attributesfile", "/dev/null"], at: root)
         _ = try runGit(["checkout", "-b", "main"], at: root)
 
         for (path, contents) in files {

--- a/Tests/RepoPromptTests/WorkspaceContext/WorkspaceCodemapBindingEngineTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/WorkspaceCodemapBindingEngineTests.swift
@@ -2283,6 +2283,33 @@ final class WorkspaceCodemapBindingEngineTests: XCTestCase {
         XCTAssertEqual(source, .cleanManifest)
     }
 
+    /// Characterization test codifying the current silent-skip behavior described in
+    /// docs/investigations/codemap-binding-engine-test-hang-2026-07-02.md. The codemaps owner
+    /// may deliberately change this behavior; update this test in the same commit if so.
+    func testAutoCRLFInputClassifiesWorktreeAndSkipsManifestPersistence() async throws {
+        let repository = try makeRepositoryFixture(name: #function)
+        let root = try repository.makeRepository(
+            named: "repository",
+            files: ["Sources/Warm.swift": "struct Warm {}\n"]
+        )
+        _ = try repository.runGit(["config", "core.autocrlf", "input"], at: root)
+        let artifactRoot = try makeSecureDirectory(in: repository.sandbox, named: "artifacts")
+        let runtime = try CodeMapArtifactRuntime(rootURL: artifactRoot)
+        let fixture = try await makeEngineFixture(root: root, runtime: runtime)
+        _ = await fixture.engine.registerRoot(fixture.registration)
+
+        guard case .ready = await fixture.engine.demand(fixture.demand(path: "Sources/Warm.swift")) else {
+            return XCTFail("Expected worktree-classified demand to resolve ready.")
+        }
+
+        let accounting = await fixture.engine.accounting()
+        XCTAssertEqual(accounting.counters.worktreeClassifications, 1)
+        XCTAssertEqual(accounting.counters.cleanClassifications, 0)
+        XCTAssertEqual(accounting.counters.manifestWrites, 0)
+        XCTAssertEqual(accounting.counters.manifestFailures, 0)
+        XCTAssertEqual(accounting.counters.validatedWorktreeReads, 1)
+    }
+
     func testManifestAdoptionSkipsRecordWhenCandidateGenerationIsNewerThanBindingGeneration() async throws {
         let repository = try makeRepositoryFixture(name: #function)
         let root = try repository.makeRepository(
@@ -2810,15 +2837,23 @@ final class WorkspaceCodemapBindingEngineTests: XCTestCase {
             ))
         }
         let sharedLoadEntered = await loadGate.waitUntilEntered()
-        XCTAssertTrue(sharedLoadEntered)
+        guard sharedLoadEntered else {
+            await loadGate.release()
+            return XCTFail("Expected the warm manifest load to reach afterReadAdmission.")
+        }
         let second = Task {
             await fixture.engine.demand(fixture.demand(
                 path: "Sources/Warm.swift",
                 priority: .background
             ))
         }
-        while await fixture.engine.accounting().queuedRequestCount != 1 {
-            await Task.yield()
+        let secondQueued = await waitForEngineCondition {
+            await fixture.engine.accounting().queuedRequestCount == 1
+        }
+        guard secondQueued else {
+            first.cancel()
+            await loadGate.release()
+            return XCTFail("Expected the second demand to occupy the queue slot.")
         }
 
         first.cancel()
@@ -2837,7 +2872,7 @@ final class WorkspaceCodemapBindingEngineTests: XCTestCase {
         XCTAssertEqual(recovered.counters.cancellations, 1)
 
         await loadGate.release()
-        guard await isReady(second.value) else {
+        guard let secondResult = await demandResult(second, before: .seconds(10)), isReady(secondResult) else {
             return XCTFail("Expected the remaining waiter to complete from the shared adoption.")
         }
         XCTAssertFalse(sharedLoadCancellation.value)


### PR DESCRIPTION
Fixes https://github.com/repoprompt/repoprompt-ce/issues/348

## Problem

On machines with `core.autocrlf=input` in the global gitconfig (a common, valid
setting), the full root suite cannot complete:
`WorkspaceCodemapBindingEngineTests.testCancelledManifestAdoptionWaiterReleasesAdmissionWithoutCancellingSharedLoad`
spins at 100% CPU forever, and the rest of the warm-manifest-seed test family
fails. Reproduced at HEAD and at the commit that introduced the test — not a
regression, a latent host-config leak.

## Root cause

Fixture repos never pinned checkout-transform config. The product reads
`git config --get core.autocrlf` at engine runtime with the host environment
(`GitService.gitBlobCheckoutConfiguration`), so the host's global value leaked
into fixture repos. The classifier treats any value ≠ `false` as a checkout
transformation (`GitBlobIdentityService`), which silently skips warm-manifest
persistence — the warm fixture then misses before the test's gate hook, and the
test's unbounded `while … { await Task.yield() }` poll spun forever on an
unsatisfiable condition.

## Changes (test-only, 2 files)

- `ReviewGitRepositoryFixture.makeRepository`: pin repo-local
  `core.autocrlf=false`, `core.eol=native`, `core.attributesfile=/dev/null`.
  Tests that want transform behavior can still override after creation.
- Hang-proof the affected test: bounded wait + fatal guards (which release the
  test gate and cancel the in-flight demand), bounded final await.
- New characterization test codifying the current silent persistence-skip under
  `core.autocrlf=input`, so any future change to that behavior is deliberate.

Deliberately untouched: the file's four other `Task.yield()` polls sample
transient states; bounding them at 10 ms granularity was measured to cause
failures and was reverted.

## Validation (on a machine with host `core.autocrlf=input`)

- Previously-hanging test: passes focused (~2.6 s).
- Previously-failing warm-seed siblings
  (`testPathInvalidationDuringBlockedWarmAdoptionRemainsRetryable`,
  `testDemandWarmLocatorAndCASBypassUnstartedManifestAdoption`): pass.
- Characterization test: passes.
- Fixture blast radius: 9 consumer suites run focused; 7 fully green, and the
  pins *reduce* failures in the other two (`GitBlobIdentityServiceTests`
  18 → 2 vs clean main; `WorkspaceFileContextStoreCodemapSeamTests` 21 → 1;
  residuals reproduce on clean main).
- `make guardrails`, `make dev-format`, `make dev-lint`: clean.