### PR TITLE
Restore Oracle popover for running chat tool cards

### DIFF
--- a/Packages/RepoPromptAgentProviders/Sources/RepoPromptClaudeCompatibleProvider/ClaudeCompatibleRuntimeSupport.swift
+++ b/Packages/RepoPromptAgentProviders/Sources/RepoPromptClaudeCompatibleProvider/ClaudeCompatibleRuntimeSupport.swift
@@ -328,8 +328,20 @@ public enum ClaudeCompatibleBackendEnvironmentBuilder {
     private static let glmAutoCompactWindow = "1000000"
 
     public static func removedEnvironmentKeys(config: ClaudeCompatibleBackendConfig) -> Set<String> {
-        let configuredAuthKey = config.normalized.auth.environmentVariableName
-        return Set(["ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"].filter { $0 != configuredAuthKey })
+        let normalizedConfig = config.normalized
+        let configuredAuthKey = normalizedConfig.auth.environmentVariableName
+        var removed = Set(["ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"].filter { $0 != configuredAuthKey })
+        if case .noModel = normalizedConfig.modelBehavior {
+            removed.formUnion([
+                "ANTHROPIC_MODEL",
+                "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+                "ANTHROPIC_DEFAULT_SONNET_MODEL",
+                "ANTHROPIC_DEFAULT_OPUS_MODEL",
+                "ANTHROPIC_SMALL_FAST_MODEL",
+                "CLAUDE_CODE_SUBAGENT_MODEL"
+            ])
+        }
+        return removed
     }
 
     public static func environment(
@@ -342,19 +354,34 @@ public enum ClaudeCompatibleBackendEnvironmentBuilder {
             "ANTHROPIC_BASE_URL": normalizedConfig.normalizedBaseURL ?? normalizedConfig.baseURL,
             normalizedConfig.auth.environmentVariableName: apiKey
         ]
+        let normalizedSelectedBackendModelID = selectedBackendModelID?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let effectiveSlotBackendModelID: String? = if case let .claudeSlotMapping(mapping) = normalizedConfig.modelBehavior {
+            if let normalizedSelectedBackendModelID, !normalizedSelectedBackendModelID.isEmpty {
+                normalizedSelectedBackendModelID
+            } else {
+                mapping.normalized.sonnet
+            }
+        } else {
+            nil
+        }
 
         if normalizedConfig.id == .glmZAI {
             environment["API_TIMEOUT_MS"] = glmTimeoutMilliseconds
-            if ClaudeCompatibleModelNormalizer.contextWindowTokens(forBackendModelID: selectedBackendModelID) == 1_000_000 {
+            if ClaudeCompatibleModelNormalizer.contextWindowTokens(forBackendModelID: effectiveSlotBackendModelID) == 1_000_000 {
                 environment["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] = glmAutoCompactWindow
             }
         }
 
         if case let .claudeSlotMapping(mapping) = normalizedConfig.modelBehavior {
             let normalizedMapping = mapping.normalized
+            let defaultBackendModelID = effectiveSlotBackendModelID ?? normalizedMapping.sonnet
+            environment["ANTHROPIC_MODEL"] = defaultBackendModelID
             environment["ANTHROPIC_DEFAULT_HAIKU_MODEL"] = normalizedMapping.haiku
             environment["ANTHROPIC_DEFAULT_SONNET_MODEL"] = normalizedMapping.sonnet
             environment["ANTHROPIC_DEFAULT_OPUS_MODEL"] = normalizedMapping.opus
+            environment["ANTHROPIC_SMALL_FAST_MODEL"] = normalizedMapping.haiku
+            environment["CLAUDE_CODE_SUBAGENT_MODEL"] = normalizedMapping.haiku
         }
 
         return environment
@@ -738,6 +765,10 @@ public enum ClaudeCompatibleHeadlessRuntime {
 
         if let sessionID = request.resumeSessionID {
             args.append(contentsOf: ["--resume", sessionID])
+        }
+        if request.runtimeConfig.pluginID != .claudeCode {
+            args.append("--bare")
+            args.append(contentsOf: ["--setting-sources", "project,local"])
         }
         if let model = runtimeModelParam(request.launchEnvironment?.effectiveModel) {
             args.append(contentsOf: ["--model", model])

--- a/Packages/RepoPromptAgentProviders/Sources/RepoPromptClaudeCompatibleProvider/ClaudeCompatibleRuntimeSupport.swift
+++ b/Packages/RepoPromptAgentProviders/Sources/RepoPromptClaudeCompatibleProvider/ClaudeCompatibleRuntimeSupport.swift
@@ -507,6 +507,7 @@ public enum ClaudeCompatibleModelNormalizer {
             return configuredSlot
         }
 
+        guard config.id == .glmZAI else { return nil }
         switch normalized {
         case haikuEquivalentModelRawValue, "glm-4.7":
             return haikuRequestedModelRawValue
@@ -595,7 +596,8 @@ public struct ClaudeCompatibleLaunchEnvironmentResolver: Sendable {
 
     public func resolve(
         variant: ClaudeCompatibleRuntimeVariant,
-        requestedModel: String?
+        requestedModel: String?,
+        requestedEffort: String? = nil
     ) async throws -> ClaudeCompatibleLaunchEnvironment {
         switch variant {
         case .standard:
@@ -616,14 +618,20 @@ public struct ClaudeCompatibleLaunchEnvironmentResolver: Sendable {
             guard let backendID = variant.compatibleBackendID else {
                 throw ClaudeCompatibleProviderError.invalidConfiguration(detail: "Unsupported Claude Code runtime variant.")
             }
-            return try await resolveCompatibleBackend(backendID, variant: variant, requestedModel: requestedModel)
+            return try await resolveCompatibleBackend(
+                backendID,
+                variant: variant,
+                requestedModel: requestedModel,
+                requestedEffort: requestedEffort
+            )
         }
     }
 
     private func resolveCompatibleBackend(
         _ backendID: ClaudeCompatibleBackendID,
         variant: ClaudeCompatibleRuntimeVariant,
-        requestedModel: String?
+        requestedModel: String?,
+        requestedEffort: String?
     ) async throws -> ClaudeCompatibleLaunchEnvironment {
         let config = backendConfigProvider(backendID).normalized
         guard config.isEnabled, config.isValid else {
@@ -631,12 +639,14 @@ public struct ClaudeCompatibleLaunchEnvironmentResolver: Sendable {
         }
 
         let requestedSpecifier = ClaudeCompatibleEffortEncodedModel(raw: requestedModel)
+        let normalizedRequestedEffort = Self.normalizedEffortRaw(requestedEffort)
+        let effectiveEffortRaw = requestedSpecifier.effortRaw ?? normalizedRequestedEffort
         let effectiveModel: String?
         let selectedBackendModelID: String?
         let environmentConfig: ClaudeCompatibleBackendConfig
         switch config.modelBehavior {
         case .noModel:
-            guard !requestedSpecifier.hasEffort,
+            guard effectiveEffortRaw == nil,
                   isAllowedNoModelSelection(requestedModel, backendID: backendID)
             else {
                 throw ClaudeCompatibleProviderError.invalidConfiguration(detail: "Unsupported \(config.normalizedDisplayName) model selection.")
@@ -649,7 +659,7 @@ public struct ClaudeCompatibleLaunchEnvironmentResolver: Sendable {
                let directBackendModelID = requestedSpecifier.baseModel?.lowercased(),
                let directSlot = ClaudeCompatibleModelNormalizer.directSelectableGLMSlotRawValue(for: directBackendModelID)
             {
-                if requestedSpecifier.effortRaw == "xhigh",
+                if effectiveEffortRaw == "xhigh",
                    !ClaudeCompatibleModelNormalizer.supportsXHighEffort(directBackendModelID)
                 {
                     throw ClaudeCompatibleProviderError.invalidConfiguration(detail: "Unsupported \(config.normalizedDisplayName) model selection.")
@@ -667,7 +677,7 @@ public struct ClaudeCompatibleLaunchEnvironmentResolver: Sendable {
             else {
                 throw ClaudeCompatibleProviderError.invalidConfiguration(detail: "Unsupported \(config.normalizedDisplayName) model selection.")
             }
-            if requestedSpecifier.effortRaw == "xhigh",
+            if effectiveEffortRaw == "xhigh",
                !ClaudeCompatibleModelNormalizer.supportsXHighEffort(backendModelID)
             {
                 throw ClaudeCompatibleProviderError.invalidConfiguration(detail: "Unsupported \(config.normalizedDisplayName) model selection.")
@@ -697,6 +707,12 @@ public struct ClaudeCompatibleLaunchEnvironmentResolver: Sendable {
             backendID: backendID,
             suppressesEffortSettings: config.modelBehavior == .noModel
         )
+    }
+
+    private static func normalizedEffortRaw(_ raw: String?) -> String? {
+        let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() ?? ""
+        guard !trimmed.isEmpty else { return nil }
+        return trimmed == "x-high" ? "xhigh" : trimmed
     }
 
     private func backendModelID(forSlot slot: String, config: ClaudeCompatibleBackendConfig) -> String? {

--- a/Packages/RepoPromptAgentProviders/Tests/RepoPromptClaudeCompatibleProviderTests/Runtime/ClaudeCompatibleRuntimeSupportTests.swift
+++ b/Packages/RepoPromptAgentProviders/Tests/RepoPromptClaudeCompatibleProviderTests/Runtime/ClaudeCompatibleRuntimeSupportTests.swift
@@ -33,22 +33,32 @@ final class ClaudeCompatibleRuntimeSupportTests: XCTestCase {
             modelBehavior: .claudeSlotMapping(.init(haiku: " h ", sonnet: " s ", opus: " o "))
         )
         let environment = ClaudeCompatibleBackendEnvironmentBuilder.environment(config: config, apiKey: "secret")
+        let defaultGLMEnvironment = ClaudeCompatibleBackendEnvironmentBuilder.environment(
+            config: ClaudeCompatibleBackendID.glmZAI.defaultPreset,
+            apiKey: "secret"
+        )
         XCTAssertEqual(config.normalizedDisplayName, "Claude Code GLM")
         XCTAssertEqual(environment["ANTHROPIC_BASE_URL"], "https://api.z.ai/api/anthropic")
         XCTAssertEqual(environment["ANTHROPIC_AUTH_TOKEN"], "secret")
         XCTAssertEqual(environment["API_TIMEOUT_MS"], "3000000")
         XCTAssertNil(environment["CLAUDE_CODE_AUTO_COMPACT_WINDOW"])
+        XCTAssertEqual(environment["ANTHROPIC_MODEL"], "s")
         XCTAssertEqual(environment["ANTHROPIC_DEFAULT_HAIKU_MODEL"], "h")
         XCTAssertEqual(environment["ANTHROPIC_DEFAULT_SONNET_MODEL"], "s")
         XCTAssertEqual(environment["ANTHROPIC_DEFAULT_OPUS_MODEL"], "o")
+        XCTAssertEqual(environment["ANTHROPIC_SMALL_FAST_MODEL"], "h")
+        XCTAssertEqual(environment["CLAUDE_CODE_SUBAGENT_MODEL"], "h")
         XCTAssertEqual(ClaudeCompatibleBackendEnvironmentBuilder.removedEnvironmentKeys(config: config), ["ANTHROPIC_API_KEY"])
+        XCTAssertEqual(defaultGLMEnvironment["ANTHROPIC_MODEL"], "glm-5.2[1m]")
+        XCTAssertEqual(defaultGLMEnvironment["CLAUDE_CODE_AUTO_COMPACT_WINDOW"], "1000000")
 
         let oneMillionEnvironment = ClaudeCompatibleBackendEnvironmentBuilder.environment(
             config: ClaudeCompatibleBackendID.glmZAI.defaultPreset,
             apiKey: "secret",
-            selectedBackendModelID: "glm-5.2[1m]"
+            selectedBackendModelID: " glm-5.2[1m] "
         )
         XCTAssertEqual(oneMillionEnvironment["API_TIMEOUT_MS"], "3000000")
+        XCTAssertEqual(oneMillionEnvironment["ANTHROPIC_MODEL"], "glm-5.2[1m]")
         XCTAssertEqual(oneMillionEnvironment["CLAUDE_CODE_AUTO_COMPACT_WINDOW"], "1000000")
         let haikuEnvironment = ClaudeCompatibleBackendEnvironmentBuilder.environment(
             config: ClaudeCompatibleBackendID.glmZAI.defaultPreset,
@@ -56,6 +66,7 @@ final class ClaudeCompatibleRuntimeSupportTests: XCTestCase {
             selectedBackendModelID: "glm-4.5-air"
         )
         XCTAssertEqual(haikuEnvironment["API_TIMEOUT_MS"], "3000000")
+        XCTAssertEqual(haikuEnvironment["ANTHROPIC_MODEL"], "glm-4.5-air")
         XCTAssertNil(haikuEnvironment["CLAUDE_CODE_AUTO_COMPACT_WINDOW"])
 
         let resolver = ClaudeCompatibleLaunchEnvironmentResolver(
@@ -94,13 +105,60 @@ final class ClaudeCompatibleRuntimeSupportTests: XCTestCase {
         XCTAssertEqual(glm.backendID, .glmZAI)
         XCTAssertEqual(glm.effectiveModel, "opus")
         XCTAssertEqual(glm.environmentOverrides["ANTHROPIC_AUTH_TOKEN"], "zai-secret")
+        XCTAssertEqual(glm.environmentOverrides["ANTHROPIC_MODEL"], "glm-opus")
         XCTAssertFalse(glm.suppressesEffortSettings)
 
         let kimi = try await resolver.resolve(variant: .kimi, requestedModel: "kimi-code")
         XCTAssertEqual(kimi.backendID, .kimi)
         XCTAssertNil(kimi.effectiveModel)
         XCTAssertEqual(kimi.environmentOverrides["ANTHROPIC_API_KEY"], "kimi-secret")
+        XCTAssertNil(kimi.environmentOverrides["ANTHROPIC_MODEL"])
+        XCTAssertNil(kimi.environmentOverrides["ANTHROPIC_DEFAULT_HAIKU_MODEL"])
+        XCTAssertNil(kimi.environmentOverrides["ANTHROPIC_SMALL_FAST_MODEL"])
+        XCTAssertNil(kimi.environmentOverrides["CLAUDE_CODE_SUBAGENT_MODEL"])
+        XCTAssertTrue(kimi.removedEnvironmentKeys.isSuperset(of: [
+            "ANTHROPIC_AUTH_TOKEN",
+            "ANTHROPIC_MODEL",
+            "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+            "ANTHROPIC_DEFAULT_SONNET_MODEL",
+            "ANTHROPIC_DEFAULT_OPUS_MODEL",
+            "ANTHROPIC_SMALL_FAST_MODEL",
+            "CLAUDE_CODE_SUBAGENT_MODEL"
+        ]))
         XCTAssertTrue(kimi.suppressesEffortSettings)
+
+        let deepSeekConfig = ClaudeCompatibleBackendConfig(
+            id: .custom,
+            isEnabled: true,
+            displayName: "CC DS",
+            baseURL: "https://api.deepseek.com/anthropic",
+            auth: .anthropicAuthToken,
+            modelBehavior: .claudeSlotMapping(.init(
+                haiku: "deepseek-v4-flash",
+                sonnet: "deepseek-v4-pro[1m]",
+                opus: "deepseek-v4-pro[1m]"
+            ))
+        )
+        let deepSeekResolver = ClaudeCompatibleLaunchEnvironmentResolver(
+            backendConfigProvider: { id in id == .custom ? deepSeekConfig : id.defaultPreset },
+            zaiSecretProvider: { nil },
+            backendSecretProvider: { id in
+                XCTAssertEqual(id, .custom)
+                return " deepseek-secret "
+            }
+        )
+        let deepSeekHaiku = try await deepSeekResolver.resolve(variant: .customCompatible, requestedModel: "haiku:low")
+        XCTAssertEqual(deepSeekHaiku.backendID, .custom)
+        XCTAssertEqual(deepSeekHaiku.effectiveModel, "haiku")
+        XCTAssertEqual(deepSeekHaiku.environmentOverrides["ANTHROPIC_BASE_URL"], "https://api.deepseek.com/anthropic")
+        XCTAssertEqual(deepSeekHaiku.environmentOverrides["ANTHROPIC_AUTH_TOKEN"], "deepseek-secret")
+        XCTAssertNil(deepSeekHaiku.environmentOverrides["ANTHROPIC_API_KEY"])
+        XCTAssertEqual(deepSeekHaiku.environmentOverrides["ANTHROPIC_MODEL"], "deepseek-v4-flash")
+        XCTAssertEqual(deepSeekHaiku.environmentOverrides["ANTHROPIC_DEFAULT_HAIKU_MODEL"], "deepseek-v4-flash")
+        XCTAssertEqual(deepSeekHaiku.environmentOverrides["ANTHROPIC_DEFAULT_SONNET_MODEL"], "deepseek-v4-pro[1m]")
+        XCTAssertEqual(deepSeekHaiku.environmentOverrides["ANTHROPIC_DEFAULT_OPUS_MODEL"], "deepseek-v4-pro[1m]")
+        XCTAssertEqual(deepSeekHaiku.environmentOverrides["ANTHROPIC_SMALL_FAST_MODEL"], "deepseek-v4-flash")
+        XCTAssertEqual(deepSeekHaiku.environmentOverrides["CLAUDE_CODE_SUBAGENT_MODEL"], "deepseek-v4-flash")
 
         let runtimeConfig = ClaudeCompatibleRuntimeConfig(
             pluginID: .claudeCode,
@@ -146,6 +204,39 @@ final class ClaudeCompatibleRuntimeSupportTests: XCTestCase {
             "--strict-mcp-config",
             "--disallowedTools", "Bash,Edit"
         ])
+
+        let compatibleRuntimeConfig = ClaudeCompatibleRuntimeConfig(
+            pluginID: .customClaudeCompatible,
+            mode: .discovery,
+            commandName: "claude",
+            additionalPathHints: [],
+            modelString: "sonnet",
+            enableDebugLogging: false,
+            sdkConnectTimeoutSeconds: 10,
+            sdkRelaunchMaxAttempts: 1,
+            permissionMode: "bypassPermissions",
+            allowNativeBashTool: false,
+            toolContext: .discoverRun,
+            disallowedBuiltInTools: [],
+            mcpStrictMode: false,
+            toolSearchEnabled: false,
+            effortLevel: nil,
+            processEnvironmentOverrides: [:],
+            effortEnvironmentOverrides: [:],
+            backendConfig: nil
+        )
+        let compatibleArgs = ClaudeCompatibleHeadlessRuntime.buildArguments(.init(
+            runtimeConfig: compatibleRuntimeConfig,
+            mcpConfigPath: nil,
+            launchEnvironment: .init(
+                effectiveModel: "sonnet",
+                environmentOverrides: [:],
+                backendID: .custom
+            )
+        ))
+        XCTAssertTrue(compatibleArgs.contains("--bare"), "compatible backends must not inherit user settings env: \(compatibleArgs)")
+        let settingSourcesIndex = try XCTUnwrap(compatibleArgs.firstIndex(of: "--setting-sources"), "compatible backends must restrict user settings sources: \(compatibleArgs)")
+        XCTAssertEqual(compatibleArgs[compatibleArgs.index(after: settingSourcesIndex)], "project,local")
     }
 
     func testProviderCatalogDefaultsExposeStableRawValues() throws {

--- a/Packages/RepoPromptAgentProviders/Tests/RepoPromptClaudeCompatibleProviderTests/Runtime/ClaudeCompatibleRuntimeSupportTests.swift
+++ b/Packages/RepoPromptAgentProviders/Tests/RepoPromptClaudeCompatibleProviderTests/Runtime/ClaudeCompatibleRuntimeSupportTests.swift
@@ -49,6 +49,19 @@ final class ClaudeCompatibleRuntimeSupportTests: XCTestCase {
         XCTAssertEqual(environment["ANTHROPIC_SMALL_FAST_MODEL"], "h")
         XCTAssertEqual(environment["CLAUDE_CODE_SUBAGENT_MODEL"], "h")
         XCTAssertEqual(ClaudeCompatibleBackendEnvironmentBuilder.removedEnvironmentKeys(config: config), ["ANTHROPIC_API_KEY"])
+        let customNoModelRemovedKeys = ClaudeCompatibleBackendEnvironmentBuilder.removedEnvironmentKeys(
+            config: ClaudeCompatibleBackendID.custom.defaultPreset
+        )
+        XCTAssertTrue(customNoModelRemovedKeys.isSuperset(of: [
+            "ANTHROPIC_AUTH_TOKEN",
+            "ANTHROPIC_MODEL",
+            "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+            "ANTHROPIC_DEFAULT_SONNET_MODEL",
+            "ANTHROPIC_DEFAULT_OPUS_MODEL",
+            "ANTHROPIC_SMALL_FAST_MODEL",
+            "CLAUDE_CODE_SUBAGENT_MODEL"
+        ]))
+        XCTAssertFalse(customNoModelRemovedKeys.contains("ANTHROPIC_API_KEY"))
         XCTAssertEqual(defaultGLMEnvironment["ANTHROPIC_MODEL"], "glm-5.2[1m]")
         XCTAssertEqual(defaultGLMEnvironment["CLAUDE_CODE_AUTO_COMPACT_WINDOW"], "1000000")
 
@@ -159,6 +172,13 @@ final class ClaudeCompatibleRuntimeSupportTests: XCTestCase {
         XCTAssertEqual(deepSeekHaiku.environmentOverrides["ANTHROPIC_DEFAULT_OPUS_MODEL"], "deepseek-v4-pro[1m]")
         XCTAssertEqual(deepSeekHaiku.environmentOverrides["ANTHROPIC_SMALL_FAST_MODEL"], "deepseek-v4-flash")
         XCTAssertEqual(deepSeekHaiku.environmentOverrides["CLAUDE_CODE_SUBAGENT_MODEL"], "deepseek-v4-flash")
+
+        do {
+            _ = try await deepSeekResolver.resolve(variant: .customCompatible, requestedModel: "glm-5-turbo")
+            XCTFail("Expected custom slot-mapped backends to reject GLM-only aliases")
+        } catch ClaudeCompatibleProviderError.invalidConfiguration {
+            // Expected.
+        }
 
         let runtimeConfig = ClaudeCompatibleRuntimeConfig(
             pluginID: .claudeCode,
@@ -386,6 +406,20 @@ final class ClaudeCompatibleRuntimeSupportTests: XCTestCase {
         }
 
         do {
+            _ = try await resolver.resolve(variant: .glm, requestedModel: "glm-5-turbo", requestedEffort: "xhigh")
+            XCTFail("Expected glm-5-turbo with separate xhigh effort to be rejected")
+        } catch ClaudeCompatibleProviderError.invalidConfiguration {
+            // Expected.
+        }
+
+        do {
+            _ = try await resolver.resolve(variant: .glm, requestedModel: "haiku", requestedEffort: "x-high")
+            XCTFail("Expected haiku with separate x-high effort to be rejected")
+        } catch ClaudeCompatibleProviderError.invalidConfiguration {
+            // Expected.
+        }
+
+        do {
             _ = try await resolver.resolve(variant: .glm, requestedModel: "glm-5.1:xhigh")
             XCTFail("Expected glm-5.1:xhigh to be rejected")
         } catch ClaudeCompatibleProviderError.invalidConfiguration {
@@ -421,6 +455,13 @@ final class ClaudeCompatibleRuntimeSupportTests: XCTestCase {
         do {
             _ = try await resolver.resolve(variant: .kimi, requestedModel: "kimi-code:xhigh")
             XCTFail("Expected no-model backend to reject effort-encoded selections")
+        } catch ClaudeCompatibleProviderError.invalidConfiguration {
+            // Expected.
+        }
+
+        do {
+            _ = try await resolver.resolve(variant: .kimi, requestedModel: "kimi-code", requestedEffort: "max")
+            XCTFail("Expected no-model backend to reject separate effort selections")
         } catch ClaudeCompatibleProviderError.invalidConfiguration {
             // Expected.
         }

--- a/Scripts/conductor.py
+++ b/Scripts/conductor.py
@@ -137,8 +137,8 @@ Operation commands:
   ./conductor app status
   ./conductor app stop                                 # latest interactive stop intent
   ./conductor app relaunch [-- <app args...>]          # latest interactive relaunch intent
-  ./conductor smoke [--launch | --packaged-app <path>] [--artifact-manifest <path>] [--workspace <name>] [--window-id <id>] [--agent-run]
-    (without --launch/--packaged-app, requires the CE debug app to already be running and CLI installed)
+  ./conductor smoke [--launch | --packaged-app <path>] [--artifact-manifest <path>] [--workspace <name>] [--window-id <id>] [--agent-run] [--execution-location-ui]
+      (without --launch/--packaged-app, requires the CE debug app to already be running and CLI installed)
   ./conductor diagnostics agent-mode-on [--log-file <path>]
   ./conductor release preflight|artifact|package|local-install
 
@@ -3548,6 +3548,16 @@ def operation_smoke(repo_root: Path, args: Dict[str, Any]) -> int:
                 print(f"FAILED stage '{name}' with status {code}", flush=True)
             return code
 
+    if args.get("executionLocationUI"):
+        code, _stdout, _stderr = run_operation_command(
+            "execution location UI smoke",
+            [str(repo_root / "Scripts" / "smoke_agent_execution_location_popover.sh"), "RepoPrompt"],
+            repo_root,
+            env=env,
+        )
+        if code != 0:
+            return code
+
     if args.get("agentRun"):
         agent_timeout = float(args.get("agentTimeout") or SMOKE_AGENT_WAIT_SECONDS)
         start_payload = {
@@ -3762,6 +3772,7 @@ def handle_real_operation(paths: Paths, operation: str, argv: List[str]) -> int:
         parser.add_argument("--window-id", type=int, default=1)
         parser.add_argument("--agent-run", action="store_true")
         parser.add_argument("--agent-timeout", type=float, default=SMOKE_AGENT_WAIT_SECONDS)
+        parser.add_argument("--execution-location-ui", action="store_true")
         ns = parser.parse_args(rest)
         if ns.agent_timeout < 0:
             raise ConductorError("--agent-timeout must be non-negative")
@@ -3769,6 +3780,8 @@ def handle_real_operation(paths: Paths, operation: str, argv: List[str]) -> int:
             raise ConductorError("--artifact-manifest requires --packaged-app")
         if ns.packaged_app and ns.agent_run:
             raise ConductorError("--agent-run is not supported with --packaged-app")
+        if ns.packaged_app and ns.execution_location_ui:
+            raise ConductorError("--execution-location-ui is not supported with --packaged-app")
         args.update(
             {
                 "launch": ns.launch,
@@ -3778,6 +3791,7 @@ def handle_real_operation(paths: Paths, operation: str, argv: List[str]) -> int:
                 "windowId": ns.window_id,
                 "agentRun": ns.agent_run,
                 "agentTimeout": ns.agent_timeout,
+                "executionLocationUI": ns.execution_location_ui,
             }
         )
     elif operation == "diagnostics":

--- a/Scripts/smoke_agent_execution_location_popover.sh
+++ b/Scripts/smoke_agent_execution_location_popover.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_PROCESS_NAME="${1:-RepoPrompt}"
+WAIT_SECONDS="${REPOPROMPT_EXECUTION_LOCATION_UI_SMOKE_WAIT:-3}"
+
+fail() {
+  printf 'ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+osascript <<APPLESCRIPT
+on labelText(elementRef)
+    tell application "System Events"
+        set parts to {}
+        try
+            set elementName to name of elementRef
+            if elementName is not missing value and elementName is not "" then set end of parts to elementName as text
+        end try
+        try
+            set elementDescription to description of elementRef
+            if elementDescription is not missing value and elementDescription is not "" then set end of parts to elementDescription as text
+        end try
+        try
+            set elementValue to value of elementRef
+            if elementValue is not missing value and elementValue is not "" then set end of parts to elementValue as text
+        end try
+        return parts as text
+    end tell
+end labelText
+
+on containsAnyNeedle(haystack, needles)
+    set lowerHaystack to do shell script "printf %s " & quoted form of haystack & " | tr '[:upper:]' '[:lower:]'"
+    repeat with needle in needles
+        set lowerNeedle to do shell script "printf %s " & quoted form of (needle as text) & " | tr '[:upper:]' '[:lower:]'"
+        if lowerHaystack contains lowerNeedle then return true
+    end repeat
+    return false
+end containsAnyNeedle
+
+on firstButtonContaining(containerRef, needles)
+    tell application "System Events"
+        try
+            repeat with candidate in buttons of containerRef
+                if my containsAnyNeedle(my labelText(candidate), needles) then return candidate
+            end repeat
+        end try
+        try
+            repeat with child in UI elements of containerRef
+                set found to my firstButtonContaining(child, needles)
+                if found is not missing value then return found
+            end repeat
+        end try
+    end tell
+    return missing value
+end firstButtonContaining
+
+on clickButtonContaining(processRef, needles, requiredLabel)
+    tell application "System Events"
+        set targetButton to my firstButtonContaining(processRef, needles)
+        if targetButton is missing value then error "Could not find " & requiredLabel
+        click targetButton
+    end tell
+end clickButtonContaining
+
+tell application "${APP_PROCESS_NAME}" to activate
+delay 0.5
+
+tell application "System Events"
+    if not (exists process "${APP_PROCESS_NAME}") then error "${APP_PROCESS_NAME} process is not running"
+    tell process "${APP_PROCESS_NAME}"
+        set frontmost to true
+        repeat 30 times
+            if exists window 1 then exit repeat
+            delay 0.2
+        end repeat
+        if not (exists window 1) then error "${APP_PROCESS_NAME} has no front window"
+    end tell
+end tell
+
+-- Open the execution-location popover from the pill. The visible pill label is usually
+-- "Work locally" before an Agent session is bound to a worktree.
+tell application "System Events"
+    tell process "${APP_PROCESS_NAME}"
+        my clickButtonContaining(it, {"Work locally", "Workspace checkout", "New worktree"}, "execution-location pill")
+    end tell
+end tell
+
+delay ${WAIT_SECONDS}
+
+-- Exercise at least one option if it is present, then switch back to local when available.
+tell application "System Events"
+    tell process "${APP_PROCESS_NAME}"
+        set newWorktreeButton to my firstButtonContaining(it, {"New worktree"})
+        if newWorktreeButton is not missing value then
+            click newWorktreeButton
+            delay 0.5
+        end if
+        set localButton to my firstButtonContaining(it, {"Workspace checkout", "Work locally"})
+        if localButton is not missing value then
+            click localButton
+            delay 0.5
+        end if
+    end tell
+end tell
+
+-- If the app survived the popover open, async load, and option click path, the smoke passes.
+tell application "System Events"
+    if not (exists process "${APP_PROCESS_NAME}") then error "${APP_PROCESS_NAME} process exited during execution-location UI smoke"
+end tell
+APPLESCRIPT
+
+printf 'OK: Agent execution-location UI smoke passed for process %s.\n' "$APP_PROCESS_NAME"

--- a/Scripts/smoke_agent_execution_location_popover.sh
+++ b/Scripts/smoke_agent_execution_location_popover.sh
@@ -9,7 +9,7 @@ fail() {
   exit 1
 }
 
-osascript <<APPLESCRIPT
+osascript - "$APP_PROCESS_NAME" "$WAIT_SECONDS" <<'APPLESCRIPT'
 on labelText(elementRef)
     tell application "System Events"
         set parts to {}
@@ -63,51 +63,52 @@ on clickButtonContaining(processRef, needles, requiredLabel)
     end tell
 end clickButtonContaining
 
-tell application "${APP_PROCESS_NAME}" to activate
-delay 0.5
+on run argv
+    set appProcessName to item 1 of argv
+    set waitSeconds to item 2 of argv as number
 
-tell application "System Events"
-    if not (exists process "${APP_PROCESS_NAME}") then error "${APP_PROCESS_NAME} process is not running"
-    tell process "${APP_PROCESS_NAME}"
-        set frontmost to true
-        repeat 30 times
-            if exists window 1 then exit repeat
-            delay 0.2
-        end repeat
-        if not (exists window 1) then error "${APP_PROCESS_NAME} has no front window"
+    tell application "System Events"
+        if not (exists process appProcessName) then error appProcessName & " process is not running"
+        tell process appProcessName
+            set frontmost to true
+            delay 0.5
+            repeat 30 times
+                if exists window 1 then exit repeat
+                delay 0.2
+            end repeat
+            if not (exists window 1) then error appProcessName & " has no front window"
+        end tell
     end tell
-end tell
 
--- Open the execution-location popover from the pill. The visible pill label is usually
--- "Work locally" before an Agent session is bound to a worktree.
-tell application "System Events"
-    tell process "${APP_PROCESS_NAME}"
-        my clickButtonContaining(it, {"Work locally", "Workspace checkout", "New worktree"}, "execution-location pill")
+    -- Open the execution-location popover from the pill. The visible pill label is usually
+    -- "Work locally" before an Agent session is bound to a worktree.
+    tell application "System Events"
+        set processRef to process appProcessName
+        my clickButtonContaining(processRef, {"Work locally", "Workspace checkout", "New worktree"}, "execution-location pill")
     end tell
-end tell
 
-delay ${WAIT_SECONDS}
+    delay waitSeconds
 
--- Exercise at least one option if it is present, then switch back to local when available.
-tell application "System Events"
-    tell process "${APP_PROCESS_NAME}"
-        set newWorktreeButton to my firstButtonContaining(it, {"New worktree"})
+    -- Exercise at least one option if it is present, then switch back to local when available.
+    tell application "System Events"
+        set processRef to process appProcessName
+        set newWorktreeButton to my firstButtonContaining(processRef, {"New worktree"})
         if newWorktreeButton is not missing value then
             click newWorktreeButton
             delay 0.5
         end if
-        set localButton to my firstButtonContaining(it, {"Workspace checkout", "Work locally"})
+        set localButton to my firstButtonContaining(processRef, {"Workspace checkout", "Work locally"})
         if localButton is not missing value then
             click localButton
             delay 0.5
         end if
     end tell
-end tell
 
--- If the app survived the popover open, async load, and option click path, the smoke passes.
-tell application "System Events"
-    if not (exists process "${APP_PROCESS_NAME}") then error "${APP_PROCESS_NAME} process exited during execution-location UI smoke"
-end tell
+    -- If the app survived the popover open, async load, and option click path, the smoke passes.
+    tell application "System Events"
+        if not (exists process appProcessName) then error appProcessName & " process exited during execution-location UI smoke"
+    end tell
+end run
 APPLESCRIPT
 
 printf 'OK: Agent execution-location UI smoke passed for process %s.\n' "$APP_PROCESS_NAME"

--- a/Scripts/test_conductor_lifecycle.py
+++ b/Scripts/test_conductor_lifecycle.py
@@ -1427,6 +1427,35 @@ class SmokeOperationTests(unittest.TestCase):
             ],
         )
 
+    def test_execution_location_ui_smoke_runs_after_worktree_readiness_stages(self) -> None:
+        calls: list[tuple[str, list[str]]] = []
+
+        def record_command(name: str, argv: list[str], *_args: object, **_kwargs: object) -> tuple[int, str, str]:
+            calls.append((name, argv))
+            return 0, "", ""
+
+        with mock.patch.object(conductor, "require_debug_cli", return_value="/tmp/rpce-cli-debug"), mock.patch.object(
+            conductor, "run_operation_command", side_effect=record_command
+        ):
+            code = conductor.operation_smoke(
+                Path("/tmp/repo"),
+                {"windowId": "7", "workspace": "test-workspace", "executionLocationUI": True},
+            )
+
+        self.assertEqual(code, 0)
+        self.assertEqual([name for name, _argv in calls], [
+            "windows",
+            "workspace switch",
+            "tree roots",
+            "manage_worktree list",
+            "agent_manage roles",
+            "execution location UI smoke",
+        ])
+        self.assertEqual(
+            calls[-1][1],
+            ["/tmp/repo/Scripts/smoke_agent_execution_location_popover.sh", "RepoPrompt"],
+        )
+
     def test_structured_smoke_calls_route_to_requested_window_with_fake_cli(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/Sources/RepoPrompt/App/Notifications/AppNotifications.swift
+++ b/Sources/RepoPrompt/App/Notifications/AppNotifications.swift
@@ -65,6 +65,8 @@ extension Notification.Name {
     static let showMCPServerPopover = Notification.Name("showMCPServerPopover")
     /// Posted when Agent Mode should open the Oracle pill popover.
     /// userInfo: ["windowID": Int, "workspaceID": UUID, "tabID": UUID, "chatID": String]
+    /// Running Oracle tool calls may instead use ["route": "latest"] without chatID to open
+    /// the latest eligible tab/run-scoped Oracle chat.
     static let showAgentOraclePopover = Notification.Name("showAgentOraclePopover")
     /// Posted when Agent Mode should open the Workflow pill popover.
     /// userInfo: ["windowID": Int]

--- a/Sources/RepoPrompt/Features/AgentMode/Providers/ClaudeCompatible/ClaudeCompatiblePluginBridge.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Providers/ClaudeCompatible/ClaudeCompatiblePluginBridge.swift
@@ -125,6 +125,7 @@ enum ClaudeCompatiblePluginBridge {
     static func resolveLaunchEnvironment(
         variant: ClaudeCodeRuntimeVariant,
         requestedModel: String?,
+        requestedEffort: String? = nil,
         backendConfigProvider: @escaping @Sendable (ClaudeCodeCompatibleBackendID) -> ClaudeCodeCompatibleBackendConfig,
         zaiKeyProvider: @escaping @Sendable () async throws -> String?,
         backendSecretProvider: @escaping @Sendable (ClaudeCodeCompatibleBackendID) async throws -> String?
@@ -132,6 +133,7 @@ enum ClaudeCompatiblePluginBridge {
         try await ClaudeCompatibleProviderRuntimeBridge.resolveLaunchEnvironment(
             variant: variant,
             requestedModel: requestedModel,
+            requestedEffort: requestedEffort,
             backendConfigProvider: backendConfigProvider,
             zaiKeyProvider: zaiKeyProvider,
             backendSecretProvider: backendSecretProvider

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentOracleRoutingPolicy.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentOracleRoutingPolicy.swift
@@ -14,6 +14,62 @@ struct AgentOracleOpenContext {
     }
 }
 
+struct AgentOracleLatestPopoverRoute: Equatable {
+    let windowID: Int
+    let workspaceID: UUID
+    let tabID: UUID
+
+    init?(
+        openContext: AgentOracleOpenContext?,
+        tabID: UUID? = nil
+    ) {
+        guard let openContext,
+              let workspaceID = openContext.workspaceID,
+              let tabID = tabID ?? openContext.tabID
+        else { return nil }
+        windowID = openContext.windowID
+        self.workspaceID = workspaceID
+        self.tabID = tabID
+    }
+
+    init?(notificationUserInfo userInfo: [AnyHashable: Any]?) {
+        guard let userInfo,
+              userInfo[Key.chatID] == nil,
+              userInfo[Key.route] as? String == Key.latestRoute,
+              let windowID = userInfo[Key.windowID] as? Int,
+              let workspaceID = Self.uuid(from: userInfo[Key.workspaceID]),
+              let tabID = Self.uuid(from: userInfo[Key.tabID])
+        else { return nil }
+        self.windowID = windowID
+        self.workspaceID = workspaceID
+        self.tabID = tabID
+    }
+
+    var notificationUserInfo: [AnyHashable: Any] {
+        [
+            Key.windowID: windowID,
+            Key.workspaceID: workspaceID,
+            Key.tabID: tabID,
+            Key.route: Key.latestRoute
+        ]
+    }
+
+    private enum Key {
+        static let windowID = "windowID"
+        static let workspaceID = "workspaceID"
+        static let tabID = "tabID"
+        static let chatID = "chatID"
+        static let route = "route"
+        static let latestRoute = "latest"
+    }
+
+    private static func uuid(from value: Any?) -> UUID? {
+        if let value = value as? UUID { return value }
+        if let value = value as? String { return UUID(uuidString: value) }
+        return nil
+    }
+}
+
 struct AgentOraclePopoverRoute: Equatable {
     let windowID: Int
     let workspaceID: UUID

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Claude/ClaudeAgentModeCoordinator.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Claude/ClaudeAgentModeCoordinator.swift
@@ -43,6 +43,16 @@ final class ClaudeAgentModeCoordinator {
         let permissionMode: String?
         let allowNativeBashTool: Bool?
         let mcpStrictMode: Bool?
+        let modelString: String?
+        let effortLevel: ClaudeCodeEffortLevel?
+
+        static func == (lhs: ControllerLaunchSettings, rhs: ControllerLaunchSettings) -> Bool {
+            lhs.runtimeVariant == rhs.runtimeVariant
+                && lhs.workspacePath == rhs.workspacePath
+                && lhs.permissionMode == rhs.permissionMode
+                && lhs.allowNativeBashTool == rhs.allowNativeBashTool
+                && lhs.mcpStrictMode == rhs.mcpStrictMode
+        }
     }
 
     private static let logger = Logger(subsystem: "com.repoprompt.agents", category: "ClaudeSteering")
@@ -101,10 +111,12 @@ final class ClaudeAgentModeCoordinator {
         launchSettings: ControllerLaunchSettings
     ) -> any NativeAgentRuntimeControlling {
         let coreConfig = ClaudeCodeAgentConfig.agentMode(
+            modelString: launchSettings.modelString,
             runtimeVariant: launchSettings.runtimeVariant,
             permissionMode: launchSettings.permissionMode,
             allowNativeBashTool: launchSettings.allowNativeBashTool,
-            mcpStrictMode: launchSettings.mcpStrictMode
+            mcpStrictMode: launchSettings.mcpStrictMode,
+            effortLevel: launchSettings.effortLevel
         )
         let runtimeConfig = ClaudeCompatiblePluginBridge.runtimeConfig(from: coreConfig, mode: .agentMode)
         return ClaudeCompatibleNativeSessionAdapter(runtimeConfig: runtimeConfig) {
@@ -267,6 +279,8 @@ final class ClaudeAgentModeCoordinator {
         ).effectiveMode
         let effectiveAllowNativeBashTool = runtimePermission.allowNativeBashTool
         let effectiveMCPStrictMode = runtimePermission.mcpStrictMode
+        let effectiveLaunchModel = effectiveClaudeModel(selectedModelRaw: launchModelRaw)
+        let effectiveLaunchEffort = currentClaudeEffortLevel(for: session)
 
         // If the session's Claude runtime variant or effective permission mode no
         // longer matches the controller, recycle it so the next process launches
@@ -325,7 +339,9 @@ final class ClaudeAgentModeCoordinator {
                 workspacePath: runtimeWorkspacePath,
                 permissionMode: effectivePermissionMode,
                 allowNativeBashTool: effectiveAllowNativeBashTool,
-                mcpStrictMode: effectiveMCPStrictMode
+                mcpStrictMode: effectiveMCPStrictMode,
+                modelString: effectiveLaunchModel,
+                effortLevel: effectiveLaunchEffort
             )
             let createdController = claudeControllerFactory(
                 runID,
@@ -381,9 +397,10 @@ final class ClaudeAgentModeCoordinator {
             return true
         }
         let runtimePermission = effectiveClaudeRuntimePermission(for: session)
+        let selectedModelRaw = session.selectedModelRaw
         let effectivePermissionMode = effectiveClaudePermissionResolution(
             for: session,
-            selectedModelRaw: session.selectedModelRaw,
+            selectedModelRaw: selectedModelRaw,
             runtimePermission: runtimePermission
         ).effectiveMode
         let expected = ControllerLaunchSettings(
@@ -391,7 +408,9 @@ final class ClaudeAgentModeCoordinator {
             workspacePath: runtimeWorkspacePath,
             permissionMode: effectivePermissionMode,
             allowNativeBashTool: runtimePermission.allowNativeBashTool,
-            mcpStrictMode: runtimePermission.mcpStrictMode
+            mcpStrictMode: runtimePermission.mcpStrictMode,
+            modelString: effectiveClaudeModel(selectedModelRaw: selectedModelRaw),
+            effortLevel: currentClaudeEffortLevel(for: session)
         )
         return controllerLaunchSettingsByTabID[session.tabID] != expected
     }
@@ -598,7 +617,9 @@ final class ClaudeAgentModeCoordinator {
                 workspacePath: retryWorkspacePath,
                 permissionMode: effectivePermissionMode,
                 allowNativeBashTool: effectiveAllowNativeBashTool,
-                mcpStrictMode: effectiveMCPStrictMode
+                mcpStrictMode: effectiveMCPStrictMode,
+                modelString: model,
+                effortLevel: effortLevel
             )
             let freshController = claudeControllerFactory(
                 freshRunID,

--- a/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentExecutionLocationPill.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentExecutionLocationPill.swift
@@ -27,10 +27,6 @@ struct AgentExecutionLocationPill: View {
         fontPreset.scaledClamped(170, max: 220)
     }
 
-    private var existingWorktreeRowEstimatedHeight: CGFloat {
-        fontPreset.scaledClamped(48, min: 42, max: 62)
-    }
-
     private var existingWorktreeRowsMaxHeight: CGFloat {
         fontPreset.scaledClamped(288, min: 220, max: 360)
     }
@@ -41,13 +37,6 @@ struct AgentExecutionLocationPill: View {
 
     private var optionRowContentWidth: CGFloat {
         optionRowWidth - 16
-    }
-
-    private func existingWorktreeRowsViewportHeight(rowCount: Int) -> CGFloat {
-        let visibleRowCount = min(CGFloat(rowCount), 6)
-        let interRowSpacing = max(0, visibleRowCount - 1) * 2
-        let estimatedHeight = visibleRowCount * existingWorktreeRowEstimatedHeight + interRowSpacing
-        return min(existingWorktreeRowsMaxHeight, estimatedHeight)
     }
 
     private var accentColor: Color {
@@ -145,32 +134,7 @@ struct AgentExecutionLocationPill: View {
                     .foregroundStyle(.secondary)
                     .padding(.horizontal, 8)
 
-                if isLoadingExistingWorktrees {
-                    ProgressView().controlSize(.small).padding(.horizontal, 8).padding(.vertical, 6)
-                } else if let optionError {
-                    Text(optionError)
-                        .font(fontPreset.swiftUIFont(sizeAtNormal: 11))
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .padding(.horizontal, 8)
-                } else if existingWorktrees.isEmpty {
-                    Text("No other worktrees available")
-                        .font(fontPreset.swiftUIFont(sizeAtNormal: 11))
-                        .foregroundStyle(.secondary)
-                        .padding(.horizontal, 8)
-                        .padding(.vertical, 4)
-                } else {
-                    ScrollView(.vertical) {
-                        LazyVStack(alignment: .leading, spacing: 2) {
-                            ForEach(existingWorktrees) { selection in
-                                existingWorktreeOption(ExistingWorktreePickerRow(selection: selection))
-                            }
-                        }
-                        .frame(width: optionRowWidth, alignment: .leading)
-                    }
-                    .frame(width: optionRowWidth, height: existingWorktreeRowsViewportHeight(rowCount: existingWorktrees.count))
-                    .scrollIndicators(.automatic)
-                }
+                existingWorktreePicker
 
                 if props.isInitialSelection {
                     Text("Worktrees are applied when you first send.")
@@ -221,6 +185,40 @@ struct AgentExecutionLocationPill: View {
         } message: {
             Text(confirmationMessage)
         }
+    }
+
+    private var existingWorktreePicker: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if isLoadingExistingWorktrees {
+                ProgressView().controlSize(.small).padding(.horizontal, 8).padding(.vertical, 6)
+            } else if let optionError {
+                Text(optionError)
+                    .font(fontPreset.swiftUIFont(sizeAtNormal: 11))
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.horizontal, 8)
+            } else if existingWorktrees.isEmpty {
+                Text("No other worktrees available")
+                    .font(fontPreset.swiftUIFont(sizeAtNormal: 11))
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+            } else {
+                ScrollView(.vertical) {
+                    LazyVStack(alignment: .leading, spacing: 2) {
+                        ForEach(existingWorktrees) { selection in
+                            existingWorktreeOption(ExistingWorktreePickerRow(selection: selection))
+                        }
+                    }
+                    .frame(width: optionRowWidth, alignment: .leading)
+                }
+                .frame(width: optionRowWidth, height: existingWorktreeRowsMaxHeight)
+                .scrollIndicators(.automatic)
+            }
+            Spacer(minLength: 0)
+        }
+        .frame(width: optionRowWidth, height: existingWorktreeRowsMaxHeight, alignment: .topLeading)
+        .clipped()
     }
 
     private struct ExistingWorktreePickerRow: Identifiable {

--- a/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentOraclePill.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentOraclePill.swift
@@ -96,11 +96,17 @@ enum AgentOraclePillLogic {
         in sessions: [ChatSession],
         streamingSessionIDs: Set<UUID>
     ) -> ChatSession? {
-        let streaming = sessions.filter { streamingSessionIDs.contains($0.id) }
-        if let latestStreaming = streaming.max(by: { $0.savedAt < $1.savedAt }) {
-            return latestStreaming
-        }
-        return sessions.max(by: { $0.savedAt < $1.savedAt })
+        latestStreamingSession(in: sessions, streamingSessionIDs: streamingSessionIDs)
+            ?? sessions.max(by: { $0.savedAt < $1.savedAt })
+    }
+
+    static func latestStreamingSession(
+        in sessions: [ChatSession],
+        streamingSessionIDs: Set<UUID>
+    ) -> ChatSession? {
+        sessions
+            .filter { streamingSessionIDs.contains($0.id) }
+            .max(by: { $0.savedAt < $1.savedAt })
     }
 
     static func selectedSessionID(
@@ -270,12 +276,20 @@ struct AgentOraclePill: View {
             }
         }
         .onReceive(NotificationCenter.default.publisher(for: .showAgentOraclePopover)) { note in
-            guard let route = AgentOraclePopoverRoute(notificationUserInfo: note.userInfo),
+            if let route = AgentOraclePopoverRoute(notificationUserInfo: note.userInfo) {
+                guard route.windowID == windowID,
+                      route.tabID == currentTabID,
+                      route.workspaceID == oracleViewModel.workspaceManager.activeWorkspaceID
+                else { return }
+                openPopover(chatID: route.chatID, workspaceID: route.workspaceID)
+                return
+            }
+            guard let route = AgentOracleLatestPopoverRoute(notificationUserInfo: note.userInfo),
                   route.windowID == windowID,
                   route.tabID == currentTabID,
                   route.workspaceID == oracleViewModel.workspaceManager.activeWorkspaceID
             else { return }
-            openPopover(chatID: route.chatID, workspaceID: route.workspaceID)
+            openLatestStreamingPopover()
         }
         .popover(isPresented: $showPopover, arrowEdge: .bottom) {
             oraclePopoverContent
@@ -359,6 +373,17 @@ struct AgentOraclePill: View {
             return
         }
         presentedSessionID = resolvedID
+    }
+
+    private func openLatestStreamingPopover() {
+        guard let target = AgentOraclePillLogic.latestStreamingSession(
+            in: eligibleTabSessions,
+            streamingSessionIDs: oracleViewModel.streamingSessions
+        ) else { return }
+        openRequestGeneration &+= 1
+        presentedSessionID = target.id
+        presentedSessionSource = .latest
+        showPopover = true
     }
 
     private func openPopover(chatID: String?, workspaceID: UUID? = nil) {

--- a/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/ToolCardContainer.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/ToolCardContainer.swift
@@ -356,8 +356,7 @@ struct StaticToolCardContainer<Content: View>: View {
                 }
                 .buttonStyle(.plain)
             } else if let onTap {
-                cardBody
-                    .onTapGesture(perform: onTap)
+                cardBodyWithLeadingTap(onTap)
             } else {
                 cardBody
             }
@@ -366,20 +365,64 @@ struct StaticToolCardContainer<Content: View>: View {
 
     private var cardBody: some View {
         HStack {
-            VStack(alignment: .leading, spacing: 6) {
+            cardContent {
                 standardHeaderRow
-                content()
             }
-            .padding(10)
-            .background(backgroundColor)
-            .cornerRadius(12)
-            .contentShape(Rectangle())
 
             Spacer(minLength: 40)
         }
     }
 
+    private func cardBodyWithLeadingTap(_ onTap: @escaping () -> Void) -> some View {
+        HStack {
+            cardContent {
+                standardHeaderRow(tappableLeadingAction: onTap)
+            }
+
+            Spacer(minLength: 40)
+        }
+    }
+
+    private func cardContent(@ViewBuilder header: () -> some View) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            header()
+            content()
+        }
+        .padding(10)
+        .background(backgroundColor)
+        .cornerRadius(12)
+        .contentShape(Rectangle())
+    }
+
     private var standardHeaderRow: some View {
+        standardHeaderRow(tappableLeadingAction: nil)
+    }
+
+    private func standardHeaderRow(tappableLeadingAction: (() -> Void)?) -> some View {
+        HStack(spacing: 6) {
+            if let tappableLeadingAction {
+                HStack(spacing: 6) {
+                    headerLeadingContent
+                    Spacer()
+                }
+                .contentShape(Rectangle())
+                .onTapGesture(perform: tappableLeadingAction)
+            } else {
+                headerLeadingContent
+                Spacer()
+            }
+
+            if let headerTrailingView {
+                headerTrailingView
+            } else if showsTimestamp, let timestamp {
+                MessageTimestampText(date: timestamp)
+                    .font(.system(size: 10))
+                    .foregroundColor(.secondary.opacity(0.7))
+            }
+        }
+    }
+
+    private var headerLeadingContent: some View {
         HStack(spacing: 6) {
             Image(systemName: iconName)
                 .font(.system(size: 11))
@@ -398,16 +441,6 @@ struct StaticToolCardContainer<Content: View>: View {
                     .foregroundColor(.secondary)
                     .lineLimit(1)
                     .truncationMode(.middle)
-            }
-
-            Spacer()
-
-            if let headerTrailingView {
-                headerTrailingView
-            } else if showsTimestamp, let timestamp {
-                MessageTimestampText(date: timestamp)
-                    .font(.system(size: 10))
-                    .foregroundColor(.secondary.opacity(0.7))
             }
         }
     }

--- a/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/ToolCardRouter.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/ToolCardRouter.swift
@@ -49,6 +49,16 @@ enum AgentOracleToolRouting {
             tabID: tabID
         )?.notificationUserInfo
     }
+
+    static func latestPopoverUserInfo(
+        openContext: AgentOracleOpenContext?,
+        tabID: UUID? = nil
+    ) -> [AnyHashable: Any]? {
+        AgentOracleLatestPopoverRoute(
+            openContext: openContext,
+            tabID: tabID
+        )?.notificationUserInfo
+    }
 }
 
 struct ContextBuilderCardContext {
@@ -733,11 +743,25 @@ func oracleToolCallPopoverUserInfo(
     guard let toolName = normalizedToolCardName(item.toolName)?.lowercased(),
           toolName == "chat_send" || toolName == "ask_oracle" || toolName == "oracle_send"
     else { return nil }
-    let chatID = AgentOracleAuthoritativeChatIDPolicy.extract(fromSerializedJSON: item.toolArgsJSON)
-    return AgentOracleToolRouting.operationPopoverUserInfo(
+
+    if let exact = AgentOracleToolRouting.operationPopoverUserInfo(
         openContext: openContext,
-        chatID: chatID
-    )
+        chatID: AgentOracleAuthoritativeChatIDPolicy.extract(fromSerializedJSON: item.toolResultJSON)
+    ) {
+        return exact
+    }
+    guard item.toolResultJSON == nil, item.toolIsError == nil else { return nil }
+
+    if let exact = AgentOracleToolRouting.operationPopoverUserInfo(
+        openContext: openContext,
+        chatID: AgentOracleAuthoritativeChatIDPolicy.extract(fromSerializedJSON: item.toolArgsJSON)
+    ) {
+        return exact
+    }
+    guard AgentOracleAuthoritativeChatIDPolicy.allowsLatestFallback(fromSerializedJSON: item.toolArgsJSON) else {
+        return nil
+    }
+    return AgentOracleToolRouting.latestPopoverUserInfo(openContext: openContext)
 }
 
 enum ToolCallCardStateResolver {

--- a/Sources/RepoPrompt/Infrastructure/AI/AgentOracleAuthoritativeChatIDPolicy.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/AgentOracleAuthoritativeChatIDPolicy.swift
@@ -20,6 +20,16 @@ enum AgentOracleAuthoritativeChatIDPolicy {
         return trimmed.isEmpty ? nil : trimmed
     }
 
+    static func allowsLatestFallback(fromSerializedJSON json: String?) -> Bool {
+        guard let json else { return false }
+        let trimmed = json.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              let data = trimmed.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
+        else { return false }
+        return !containsChatID(in: object)
+    }
+
     private static func containsChatID(in value: Any, excludingAuthoritativeRoot: Bool = false) -> Bool {
         if let dictionary = value as? [String: Any] {
             for (key, nested) in dictionary {

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/ClaudeCode/ClaudeCodeLaunchEnvironmentResolver.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/ClaudeCode/ClaudeCodeLaunchEnvironmentResolver.swift
@@ -118,7 +118,8 @@ struct ClaudeCodeLaunchEnvironment {
 protocol ClaudeCodeLaunchEnvironmentResolving: Sendable {
     func resolve(
         variant: ClaudeCodeRuntimeVariant,
-        requestedModel: String?
+        requestedModel: String?,
+        requestedEffort: String?
     ) async throws -> ClaudeCodeLaunchEnvironment
 }
 
@@ -159,11 +160,13 @@ struct ClaudeCodeLaunchEnvironmentResolver: ClaudeCodeLaunchEnvironmentResolving
 
     func resolve(
         variant: ClaudeCodeRuntimeVariant,
-        requestedModel: String?
+        requestedModel: String?,
+        requestedEffort: String?
     ) async throws -> ClaudeCodeLaunchEnvironment {
         try await ClaudeCompatibleProviderRuntimeBridge.resolveLaunchEnvironment(
             variant: variant,
             requestedModel: requestedModel,
+            requestedEffort: requestedEffort,
             backendConfigProvider: { backendStore.config(for: $0) },
             zaiKeyProvider: zaiKeyProvider,
             backendSecretProvider: backendSecretProvider

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/ClaudeCode/ClaudeCompatibleProviderRuntimeBridge.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/ClaudeCode/ClaudeCompatibleProviderRuntimeBridge.swift
@@ -147,6 +147,7 @@ enum ClaudeCompatibleProviderRuntimeBridge {
     static func resolveLaunchEnvironment(
         variant: ClaudeCodeRuntimeVariant,
         requestedModel: String?,
+        requestedEffort: String? = nil,
         backendConfigProvider: @escaping @Sendable (ClaudeCodeCompatibleBackendID) -> ClaudeCodeCompatibleBackendConfig,
         zaiKeyProvider: @escaping @Sendable () async throws -> String?,
         backendSecretProvider: @escaping @Sendable (ClaudeCodeCompatibleBackendID) async throws -> String?
@@ -163,7 +164,8 @@ enum ClaudeCompatibleProviderRuntimeBridge {
         do {
             let resolved = try await resolver.resolve(
                 variant: pluginRuntimeVariant(for: variant),
-                requestedModel: requestedModel
+                requestedModel: requestedModel,
+                requestedEffort: requestedEffort
             )
             return coreLaunchEnvironment(from: resolved)
         } catch let ClaudeCompatiblePluginProviderError.invalidConfiguration(detail) {

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/ClaudeCode/SDK/ClaudeNativeProcessSessionController.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/ClaudeCode/SDK/ClaudeNativeProcessSessionController.swift
@@ -126,12 +126,16 @@ final actor ClaudeNativeProcessSessionController {
     }
 
     private struct LaunchEnvironmentSignature: Equatable {
+        private static let liveMutableEnvironmentKeys: Set<String> = ["ANTHROPIC_MODEL"]
+
         let environmentOverrides: [String: String]
         let removedEnvironmentKeys: Set<String>
         let backend: ClaudeCodeLaunchEnvironment.Backend
 
         init(_ launchEnvironment: ClaudeCodeLaunchEnvironment) {
-            environmentOverrides = launchEnvironment.environmentOverrides
+            environmentOverrides = launchEnvironment.environmentOverrides.filter {
+                !Self.liveMutableEnvironmentKeys.contains($0.key)
+            }
             removedEnvironmentKeys = launchEnvironment.removedEnvironmentKeys
             backend = launchEnvironment.backend
         }
@@ -572,7 +576,8 @@ final actor ClaudeNativeProcessSessionController {
         let launchEnvironment = resolvedFlags.launchEnvironment
         let environment = await resolvedLaunchEnvironment(
             resolverOverrides: launchEnvironment.environmentOverrides,
-            resolverRemovedKeys: launchEnvironment.removedEnvironmentKeys
+            resolverRemovedKeys: launchEnvironment.removedEnvironmentKeys,
+            suppressesEffortSettings: launchEnvironment.suppressesEffortSettings
         )
         let resolvedCommand = CommandPathResolver.resolve(
             config.commandName,
@@ -585,7 +590,7 @@ final actor ClaudeNativeProcessSessionController {
         activeLaunchEnvironmentSignature = LaunchEnvironmentSignature(launchEnvironment)
         let arguments = buildArguments(
             existingSessionID: existingSessionID,
-            model: nil
+            model: launchEnvironment.effectiveModel
         )
 
         let workingDirectory = resolvedWorkingDirectory()
@@ -637,7 +642,10 @@ final actor ClaudeNativeProcessSessionController {
 
         let request = Self.buildInitializeRequest(systemPromptOverride: systemPromptOverride)
 
-        let initializeResult = try await sendControlRequest(request: request)
+        let initializeResult = try await sendControlRequest(
+            request: request,
+            timeoutSeconds: config.sdkConnectTimeoutSeconds
+        )
         if let returnedSessionID = (initializeResult["session_id"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines),
            !returnedSessionID.isEmpty
         {
@@ -1283,6 +1291,12 @@ final actor ClaudeNativeProcessSessionController {
             publishRuntimeInitIfChanged()
         }
 
+        if let retryProgress = Self.parseAPIRetryProgressResult(from: payload) {
+            let logPayload = streamResultLogPayload(retryProgress)
+            writeRawEventLogRecord(kind: "translator.streamResult", payload: logPayload)
+            emit(.stream(retryProgress))
+        }
+
         guard let data = try? JSONSerialization.data(withJSONObject: payload, options: []) else {
             return
         }
@@ -1479,6 +1493,66 @@ final actor ClaudeNativeProcessSessionController {
         return ClaudeAbortArtifactFilter.shouldSuppressUserFacingError(text)
     }
 
+    /// Converts Claude Code `system/api_retry` events into status text so provider throttling
+    /// does not leave Agent Mode stuck on an opaque generic "Thinking…" state.
+    private static func parseAPIRetryProgressResult(from payload: [String: Any]) -> AIStreamResult? {
+        guard (payload["type"] as? String) == "system",
+              ((payload["subtype"] as? String)?.lowercased() == "api_retry")
+        else {
+            return nil
+        }
+
+        func trimmedString(_ key: String) -> String? {
+            guard let value = payload[key] else { return nil }
+            let text: String = if let stringValue = value as? String {
+                stringValue
+            } else {
+                String(describing: value)
+            }
+            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        }
+
+        func intValue(_ key: String) -> Int? {
+            if let value = payload[key] as? Int { return value }
+            if let value = payload[key] as? Double { return Int(value) }
+            if let value = payload[key] as? String { return Int(value.trimmingCharacters(in: .whitespacesAndNewlines)) }
+            return nil
+        }
+
+        let attemptText: String? = if let attempt = intValue("attempt") {
+            if let maxRetries = intValue("max_retries"), maxRetries > 0 {
+                "\(attempt)/\(maxRetries)"
+            } else {
+                "\(attempt)"
+            }
+        } else {
+            nil
+        }
+
+        var detailParts: [String] = []
+        if let status = trimmedString("error_status") {
+            detailParts.append(status)
+        }
+        if let error = trimmedString("error") {
+            detailParts.append(error)
+        }
+
+        var message = "Provider API retry"
+        if let attemptText {
+            message += " \(attemptText)"
+        }
+        if !detailParts.isEmpty {
+            message += ": " + detailParts.joined(separator: " ")
+        }
+        if let retryDelayMS = intValue("retry_delay_ms"), retryDelayMS > 0 {
+            let retryDelaySeconds = max(1, Int((Double(retryDelayMS) / 1000.0).rounded(.up)))
+            message += ". Retrying in \(retryDelaySeconds)s."
+        }
+
+        return AIStreamResult(type: "task_progress", text: message)
+    }
+
     /// Extracts tools and MCP server statuses from a `system/init` stream payload.
     /// Returns `nil` if the payload is not a `system/init` event.
     private static func parseSystemInitFields(from payload: [String: Any]) -> (tools: [String], mcpStatuses: [String: String])? {
@@ -1656,12 +1730,14 @@ final actor ClaudeNativeProcessSessionController {
         func test_effectiveLaunchEnvironment(
             base: [String: String],
             resolverOverrides: [String: String] = [:],
-            resolverRemovedKeys: Set<String> = []
+            resolverRemovedKeys: Set<String> = [],
+            suppressesEffortSettings: Bool = false
         ) -> [String: String] {
             effectiveLaunchEnvironment(
                 base: base,
                 resolverOverrides: resolverOverrides,
-                resolverRemovedKeys: resolverRemovedKeys
+                resolverRemovedKeys: resolverRemovedKeys,
+                suppressesEffortSettings: suppressesEffortSettings
             )
         }
 
@@ -1973,6 +2049,15 @@ final actor ClaudeNativeProcessSessionController {
 
         args.append(contentsOf: ["--permission-prompt-tool", "stdio"])
 
+        // Claude-compatible backends must not inherit ~/.claude/settings.json env such as
+        // ANTHROPIC_BASE_URL or ANTHROPIC_MODEL from another provider. `--bare` alone still
+        // permits user settings env; restrict settings sources while keeping explicit project/local
+        // configuration and RepoPrompt's --mcp-config available.
+        if config.runtimeVariant != .standard {
+            args.append("--bare")
+            args.append(contentsOf: ["--setting-sources", "project,local"])
+        }
+
         // GLM/z.ai sheds requests carrying the Agent SDK identity preamble under load (see #295).
         // Any non-empty --append-system-prompt flips the CLI onto the never-shed "Claude Code" preamble.
         if config.runtimeVariant == .glm {
@@ -1983,6 +2068,10 @@ final actor ClaudeNativeProcessSessionController {
             args.append(contentsOf: ["--resume", existingSessionID])
             // RepoPrompt instructions are delivered in provider-bound user messages,
             // so CLI prompt flags remain unused on both fresh starts and resumes.
+        }
+
+        if let model = Self.normalizedFlagSettingsModel(model) {
+            args.append(contentsOf: ["--model", model])
         }
 
         if config.permissionMode.caseInsensitiveCompare("bypassPermissions") == .orderedSame {
@@ -2203,7 +2292,8 @@ final actor ClaudeNativeProcessSessionController {
 
     private func resolvedLaunchEnvironment(
         resolverOverrides: [String: String],
-        resolverRemovedKeys: Set<String>
+        resolverRemovedKeys: Set<String>,
+        suppressesEffortSettings: Bool
     ) async -> [String: String] {
         let result = await ProcessEnvironmentBuilder.build(
             ProcessEnvironmentRequest(
@@ -2215,14 +2305,16 @@ final actor ClaudeNativeProcessSessionController {
         return effectiveLaunchEnvironment(
             base: result.environment,
             resolverOverrides: resolverOverrides,
-            resolverRemovedKeys: resolverRemovedKeys
+            resolverRemovedKeys: resolverRemovedKeys,
+            suppressesEffortSettings: suppressesEffortSettings
         )
     }
 
     private func effectiveLaunchEnvironment(
         base: [String: String],
         resolverOverrides: [String: String],
-        resolverRemovedKeys: Set<String> = []
+        resolverRemovedKeys: Set<String> = [],
+        suppressesEffortSettings: Bool = false
     ) -> [String: String] {
         var env = base
         if env["CLAUDE_CODE_ENTRYPOINT"].map({ !$0.isEmpty }) != true {
@@ -2239,6 +2331,13 @@ final actor ClaudeNativeProcessSessionController {
         }
         for (key, value) in resolverOverrides {
             env[key] = value
+        }
+        if suppressesEffortSettings {
+            env.removeValue(forKey: "CLAUDE_CODE_EFFORT_LEVEL")
+        } else {
+            for (key, value) in config.effortEnvironmentOverrides {
+                env[key] = value
+            }
         }
         return ProcessEnvironmentSanitizer.sanitizedForChildLaunch(
             env,

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/ClaudeCode/SDK/ClaudeNativeProcessSessionController.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/ClaudeCode/SDK/ClaudeNativeProcessSessionController.swift
@@ -577,6 +577,7 @@ final actor ClaudeNativeProcessSessionController {
         let environment = await resolvedLaunchEnvironment(
             resolverOverrides: launchEnvironment.environmentOverrides,
             resolverRemovedKeys: launchEnvironment.removedEnvironmentKeys,
+            effortLevel: resolvedFlags.environmentEffortLevel,
             suppressesEffortSettings: launchEnvironment.suppressesEffortSettings
         )
         let resolvedCommand = CommandPathResolver.resolve(
@@ -672,7 +673,7 @@ final actor ClaudeNativeProcessSessionController {
     private func resolveLaunchFlagSettings(
         model: String?,
         effortLevel suppliedEffortLevel: ClaudeCodeEffortLevel?
-    ) async throws -> (launchEnvironment: ClaudeCodeLaunchEnvironment, request: [String: Any]?) {
+    ) async throws -> (launchEnvironment: ClaudeCodeLaunchEnvironment, request: [String: Any]?, environmentEffortLevel: ClaudeCodeEffortLevel?) {
         let modelSpecifier = model.map { ClaudeModelSpecifier(raw: $0) }
         let requestedModel = modelSpecifier != nil
             ? model
@@ -682,7 +683,8 @@ final actor ClaudeNativeProcessSessionController {
             ?? config.effortLevel
         let launchEnvironment = try await environmentResolver.resolve(
             variant: config.runtimeVariant,
-            requestedModel: requestedModel
+            requestedModel: requestedModel,
+            requestedEffort: effectiveEffortLevel?.rawValue
         )
         let requestEffortLevel = Self.shouldSuppressEffortSettings(for: launchEnvironment)
             ? nil
@@ -691,7 +693,7 @@ final actor ClaudeNativeProcessSessionController {
             model: launchEnvironment.effectiveModel,
             effortLevel: requestEffortLevel
         )
-        return (launchEnvironment, request)
+        return (launchEnvironment, request, requestEffortLevel)
     }
 
     private func liveFlagSettingsRequiresProcessRestart(for launchEnvironment: ClaudeCodeLaunchEnvironment) -> Bool {
@@ -1731,12 +1733,14 @@ final actor ClaudeNativeProcessSessionController {
             base: [String: String],
             resolverOverrides: [String: String] = [:],
             resolverRemovedKeys: Set<String> = [],
+            effortLevel: ClaudeCodeEffortLevel? = nil,
             suppressesEffortSettings: Bool = false
         ) -> [String: String] {
             effectiveLaunchEnvironment(
                 base: base,
                 resolverOverrides: resolverOverrides,
                 resolverRemovedKeys: resolverRemovedKeys,
+                effortLevel: effortLevel,
                 suppressesEffortSettings: suppressesEffortSettings
             )
         }
@@ -2293,6 +2297,7 @@ final actor ClaudeNativeProcessSessionController {
     private func resolvedLaunchEnvironment(
         resolverOverrides: [String: String],
         resolverRemovedKeys: Set<String>,
+        effortLevel: ClaudeCodeEffortLevel?,
         suppressesEffortSettings: Bool
     ) async -> [String: String] {
         let result = await ProcessEnvironmentBuilder.build(
@@ -2306,6 +2311,7 @@ final actor ClaudeNativeProcessSessionController {
             base: result.environment,
             resolverOverrides: resolverOverrides,
             resolverRemovedKeys: resolverRemovedKeys,
+            effortLevel: effortLevel,
             suppressesEffortSettings: suppressesEffortSettings
         )
     }
@@ -2314,6 +2320,7 @@ final actor ClaudeNativeProcessSessionController {
         base: [String: String],
         resolverOverrides: [String: String],
         resolverRemovedKeys: Set<String> = [],
+        effortLevel: ClaudeCodeEffortLevel? = nil,
         suppressesEffortSettings: Bool = false
     ) -> [String: String] {
         var env = base
@@ -2334,10 +2341,10 @@ final actor ClaudeNativeProcessSessionController {
         }
         if suppressesEffortSettings {
             env.removeValue(forKey: "CLAUDE_CODE_EFFORT_LEVEL")
+        } else if let effortLevel {
+            env["CLAUDE_CODE_EFFORT_LEVEL"] = effortLevel.envValue
         } else {
-            for (key, value) in config.effortEnvironmentOverrides {
-                env[key] = value
-            }
+            env.removeValue(forKey: "CLAUDE_CODE_EFFORT_LEVEL")
         }
         return ProcessEnvironmentSanitizer.sanitizedForChildLaunch(
             env,

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/ClaudeCodeAgentProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/ClaudeCodeAgentProvider.swift
@@ -78,7 +78,8 @@ final class ClaudeCodeAgentProvider: HeadlessAgentProvider {
             }
             let launchEnvironment = try await environmentResolver.resolve(
                 variant: config.runtimeVariant,
-                requestedModel: config.modelString
+                requestedModel: config.modelString,
+                requestedEffort: config.effortLevel?.rawValue
             )
             return HeadlessAgentContext(
                 runID: actualRunID,

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/ClaudeCodeProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/ClaudeCodeProvider.swift
@@ -246,7 +246,8 @@ final class ClaudeCodeProvider: AIProvider {
             let resolver = ClaudeCodeLaunchEnvironmentResolver()
             let launchEnvironment = try await resolver.resolve(
                 variant: Self.runtimeVariant(for: descriptor.backendID),
-                requestedModel: descriptor.requestedModelRaw
+                requestedModel: descriptor.requestedModelRaw,
+                requestedEffort: nil
             )
             options.model = launchEnvironment.effectiveModel
             options.environmentOverrides = launchEnvironment.environmentOverrides
@@ -424,7 +425,8 @@ final class ClaudeCodeProvider: AIProvider {
         let resolver = ClaudeCodeLaunchEnvironmentResolver()
         let launchEnvironment = try await resolver.resolve(
             variant: Self.runtimeVariant(for: backendID),
-            requestedModel: Self.compatibleBackendTestRequestedModel(for: backendID)
+            requestedModel: Self.compatibleBackendTestRequestedModel(for: backendID),
+            requestedEffort: nil
         )
         let emptyConfigLease = try await configService.prepareEmptyLaunchConfig()
         defer { emptyConfigLease.release() }

--- a/Tests/RepoPromptTests/AgentMode/AgentOraclePillRoutingTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentOraclePillRoutingTests.swift
@@ -129,6 +129,56 @@ final class AgentOraclePillRoutingTests: XCTestCase {
         XCTAssertEqual(fixture.oracleViewModel.messagesSnapshot(for: exact.id).count, 1)
     }
 
+    func testLatestStreamingSessionDoesNotFallbackToStaleCompletedSession() {
+        let workspaceID = UUID()
+        let tabID = UUID()
+        let olderStreaming = ChatSession(
+            workspaceID: workspaceID,
+            composeTabID: tabID,
+            name: "Older Streaming",
+            savedAt: Date(timeIntervalSince1970: 100)
+        )
+        let staleCompleted = ChatSession(
+            workspaceID: workspaceID,
+            composeTabID: tabID,
+            name: "Stale Completed",
+            savedAt: Date(timeIntervalSince1970: 300)
+        )
+        let newerStreaming = ChatSession(
+            workspaceID: workspaceID,
+            composeTabID: tabID,
+            name: "Newer Streaming",
+            savedAt: Date(timeIntervalSince1970: 200)
+        )
+        let sessions = [olderStreaming, staleCompleted, newerStreaming]
+
+        XCTAssertEqual(
+            AgentOraclePillLogic.latestSession(
+                in: sessions,
+                streamingSessionIDs: [olderStreaming.id, newerStreaming.id]
+            )?.id,
+            newerStreaming.id
+        )
+        XCTAssertEqual(
+            AgentOraclePillLogic.latestStreamingSession(
+                in: sessions,
+                streamingSessionIDs: [olderStreaming.id, newerStreaming.id]
+            )?.id,
+            newerStreaming.id
+        )
+        XCTAssertNil(AgentOraclePillLogic.latestStreamingSession(
+            in: sessions,
+            streamingSessionIDs: []
+        ))
+        XCTAssertEqual(
+            AgentOraclePillLogic.latestSession(
+                in: sessions,
+                streamingSessionIDs: []
+            )?.id,
+            staleCompleted.id
+        )
+    }
+
     func testExactPersistedResolutionHydratesAndRegistersUUIDAndShortID() async throws {
         let fixture = try await makeFixture()
         defer { fixture.cleanup() }

--- a/Tests/RepoPromptTests/AgentMode/ClaudeCompatible/ClaudeAgentModeCoordinatorLifecycleTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/ClaudeCompatible/ClaudeAgentModeCoordinatorLifecycleTests.swift
@@ -414,6 +414,39 @@ extension AgentModeRunServiceLifecycleTests {
         XCTAssertTrue(recorder.contains("claude:shutdown"))
     }
 
+    func testClaudeControllerLaunchSettingsIdentityIgnoresLiveModelAndEffort() {
+        let base = ClaudeAgentModeCoordinator.ControllerLaunchSettings(
+            runtimeVariant: .customCompatible,
+            workspacePath: "/workspace",
+            permissionMode: "default",
+            allowNativeBashTool: false,
+            mcpStrictMode: true,
+            modelString: "sonnet",
+            effortLevel: .low
+        )
+        let liveFlagChange = ClaudeAgentModeCoordinator.ControllerLaunchSettings(
+            runtimeVariant: .customCompatible,
+            workspacePath: "/workspace",
+            permissionMode: "default",
+            allowNativeBashTool: false,
+            mcpStrictMode: true,
+            modelString: "opus",
+            effortLevel: .max
+        )
+        let permissionChange = ClaudeAgentModeCoordinator.ControllerLaunchSettings(
+            runtimeVariant: .customCompatible,
+            workspacePath: "/workspace",
+            permissionMode: "acceptEdits",
+            allowNativeBashTool: false,
+            mcpStrictMode: true,
+            modelString: "opus",
+            effortLevel: .max
+        )
+
+        XCTAssertEqual(base, liveFlagChange)
+        XCTAssertNotEqual(base, permissionChange)
+    }
+
     private func resolvedClaudeLaunchPolicy(
         profile: AgentProviderPermissionProfile,
         harness: LifecycleHarness
@@ -448,7 +481,9 @@ extension AgentModeRunServiceLifecycleTests {
                 workspacePath: workspacePath,
                 permissionMode: permissionMode,
                 allowNativeBashTool: allowNativeBashTool,
-                mcpStrictMode: mcpStrictMode
+                mcpStrictMode: mcpStrictMode,
+                modelString: nil,
+                effortLevel: nil
             ),
             for: session
         )

--- a/Tests/RepoPromptTests/AgentMode/ClaudeCompatible/ClaudeNativeApprovalAndResumeTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/ClaudeCompatible/ClaudeNativeApprovalAndResumeTests.swift
@@ -51,6 +51,56 @@ final class ClaudeNativeApprovalAndResumeTests: XCTestCase {
         XCTAssertEqual(requestedModels, ["glm-5-turbo:xhigh"])
     }
 
+    func testNativeLaunchEnvironmentIncludesEffortEnvironment() async {
+        let controller = ClaudeNativeProcessSessionController(
+            runID: UUID(),
+            tabID: UUID(),
+            windowID: 1,
+            workspacePath: nil,
+            config: .agentMode(
+                commandName: "/usr/bin/false",
+                runtimeVariant: .standard,
+                effortLevel: .max
+            )
+        )
+
+        let environment = await controller.test_effectiveLaunchEnvironment(
+            base: [:],
+            resolverOverrides: [
+                "ANTHROPIC_BASE_URL": "https://api.deepseek.com/anthropic",
+                "ANTHROPIC_MODEL": "deepseek-v4-pro[1m]"
+            ]
+        )
+
+        XCTAssertEqual(environment["ANTHROPIC_MODEL"], "deepseek-v4-pro[1m]")
+        XCTAssertEqual(environment["CLAUDE_CODE_EFFORT_LEVEL"], "max")
+    }
+
+    func testNativeLaunchEnvironmentOmitsEffortEnvironmentWhenSuppressed() async {
+        let controller = ClaudeNativeProcessSessionController(
+            runID: UUID(),
+            tabID: UUID(),
+            windowID: 1,
+            workspacePath: nil,
+            config: .agentMode(
+                commandName: "/usr/bin/false",
+                runtimeVariant: .glm,
+                effortLevel: .max
+            )
+        )
+
+        let environment = await controller.test_effectiveLaunchEnvironment(
+            base: ["CLAUDE_CODE_EFFORT_LEVEL": "low"],
+            resolverOverrides: [
+                "ANTHROPIC_MODEL": "glm-4.7"
+            ],
+            suppressesEffortSettings: true
+        )
+
+        XCTAssertEqual(environment["ANTHROPIC_MODEL"], "glm-4.7")
+        XCTAssertNil(environment["CLAUDE_CODE_EFFORT_LEVEL"])
+    }
+
     func testNativeLiveModelSwitchRequiresRestartWhenLaunchEnvironmentChanges() async {
         let controller = ClaudeNativeProcessSessionController(
             runID: UUID(),
@@ -66,7 +116,8 @@ final class ClaudeNativeApprovalAndResumeTests: XCTestCase {
             effectiveModel: "sonnet",
             environmentOverrides: [
                 "ANTHROPIC_DEFAULT_OPUS_MODEL": "glm-5-turbo",
-                "ANTHROPIC_DEFAULT_SONNET_MODEL": "glm-5-turbo"
+                "ANTHROPIC_DEFAULT_SONNET_MODEL": "glm-5-turbo",
+                "ANTHROPIC_MODEL": "glm-5-turbo"
             ],
             backend: .compatible(.glmZAI),
             suppressesEffortSettings: true
@@ -75,14 +126,17 @@ final class ClaudeNativeApprovalAndResumeTests: XCTestCase {
             effectiveModel: "sonnet",
             environmentOverrides: [
                 "ANTHROPIC_DEFAULT_OPUS_MODEL": "glm-4.7",
-                "ANTHROPIC_DEFAULT_SONNET_MODEL": "glm-4.7"
+                "ANTHROPIC_DEFAULT_SONNET_MODEL": "glm-4.7",
+                "ANTHROPIC_MODEL": "glm-4.7"
             ],
             backend: .compatible(.glmZAI),
             suppressesEffortSettings: true
         )
+        var selectedModelOnlyEnvironment = directGLM.environmentOverrides
+        selectedModelOnlyEnvironment["ANTHROPIC_MODEL"] = "glm-4.7"
         let sameEnvironmentDifferentFlagModel = ClaudeCodeLaunchEnvironment(
             effectiveModel: "opus",
-            environmentOverrides: directGLM.environmentOverrides,
+            environmentOverrides: selectedModelOnlyEnvironment,
             backend: .compatible(.glmZAI),
             suppressesEffortSettings: true
         )

--- a/Tests/RepoPromptTests/AgentMode/ClaudeCompatible/ClaudeNativeApprovalAndResumeTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/ClaudeCompatible/ClaudeNativeApprovalAndResumeTests.swift
@@ -9,12 +9,15 @@ final class ClaudeNativeApprovalAndResumeTests: XCTestCase {
 
     actor RecordingLaunchEnvironmentResolver: ClaudeCodeLaunchEnvironmentResolving {
         private(set) var requestedModels: [String?] = []
+        private(set) var requestedEfforts: [String?] = []
 
         func resolve(
             variant _: ClaudeCodeRuntimeVariant,
-            requestedModel: String?
+            requestedModel: String?,
+            requestedEffort: String?
         ) async throws -> ClaudeCodeLaunchEnvironment {
             requestedModels.append(requestedModel)
+            requestedEfforts.append(requestedEffort)
             guard requestedModel != "glm-5-turbo:xhigh" else {
                 throw ResolverError.unsupportedModel
             }
@@ -48,7 +51,31 @@ final class ClaudeNativeApprovalAndResumeTests: XCTestCase {
         }
 
         let requestedModels = await resolver.requestedModels
+        let requestedEfforts = await resolver.requestedEfforts
         XCTAssertEqual(requestedModels, ["glm-5-turbo:xhigh"])
+        XCTAssertEqual(requestedEfforts, ["xhigh"])
+    }
+
+    func testNativeFlagResolutionPassesSeparateEffortToResolver() async throws {
+        let resolver = RecordingLaunchEnvironmentResolver()
+        let controller = ClaudeNativeProcessSessionController(
+            runID: UUID(),
+            tabID: UUID(),
+            windowID: 1,
+            workspacePath: nil,
+            config: .discovery(
+                commandName: "/usr/bin/false",
+                runtimeVariant: .glm
+            ),
+            environmentResolver: resolver
+        )
+
+        _ = try await controller.test_resolveApplyFlagSettingsRequest(model: "sonnet", effortLevel: .max)
+
+        let requestedModels = await resolver.requestedModels
+        let requestedEfforts = await resolver.requestedEfforts
+        XCTAssertEqual(requestedModels, ["sonnet"])
+        XCTAssertEqual(requestedEfforts, ["max"])
     }
 
     func testNativeLaunchEnvironmentIncludesEffortEnvironment() async {
@@ -69,11 +96,33 @@ final class ClaudeNativeApprovalAndResumeTests: XCTestCase {
             resolverOverrides: [
                 "ANTHROPIC_BASE_URL": "https://api.deepseek.com/anthropic",
                 "ANTHROPIC_MODEL": "deepseek-v4-pro[1m]"
-            ]
+            ],
+            effortLevel: .max
         )
 
         XCTAssertEqual(environment["ANTHROPIC_MODEL"], "deepseek-v4-pro[1m]")
         XCTAssertEqual(environment["CLAUDE_CODE_EFFORT_LEVEL"], "max")
+    }
+
+    func testNativeLaunchEnvironmentUsesPerLaunchEffortEnvironment() async {
+        let controller = ClaudeNativeProcessSessionController(
+            runID: UUID(),
+            tabID: UUID(),
+            windowID: 1,
+            workspacePath: nil,
+            config: .agentMode(
+                commandName: "/usr/bin/false",
+                runtimeVariant: .standard,
+                effortLevel: .max
+            )
+        )
+
+        let environment = await controller.test_effectiveLaunchEnvironment(
+            base: ["CLAUDE_CODE_EFFORT_LEVEL": "max"],
+            effortLevel: .low
+        )
+
+        XCTAssertEqual(environment["CLAUDE_CODE_EFFORT_LEVEL"], "low")
     }
 
     func testNativeLaunchEnvironmentOmitsEffortEnvironmentWhenSuppressed() async {

--- a/Tests/RepoPromptTests/AgentMode/ClaudeCompatible/ClaudeNativeIdentityPreambleTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/ClaudeCompatible/ClaudeNativeIdentityPreambleTests.swift
@@ -65,4 +65,34 @@ final class ClaudeNativeIdentityPreambleTests: XCTestCase {
             )
         }
     }
+
+    func testBuildArgumentsIncludesResolvedModelFlag() async throws {
+        let controller = makeController(variant: .customCompatible)
+        let args = await controller.test_buildArguments(existingSessionID: nil, model: " sonnet ")
+        let modelFlagIndex = try XCTUnwrap(args.firstIndex(of: "--model"), "expected --model, got: \(args)")
+        XCTAssertEqual(args[args.index(after: modelFlagIndex)], "sonnet")
+    }
+
+    func testCompatibleBackendsUseBareModeToAvoidUserSettingsEnvLeakage() async throws {
+        for variant in [ClaudeCodeRuntimeVariant.glm, .kimi, .customCompatible] {
+            let controller = makeController(variant: variant)
+            let args = await controller.test_buildArguments(existingSessionID: nil, model: "sonnet")
+            XCTAssertTrue(args.contains("--bare"), "\(variant) must isolate ~/.claude/settings.json env, got: \(args)")
+            let settingSourcesIndex = try XCTUnwrap(args.firstIndex(of: "--setting-sources"), "\(variant) must restrict user settings sources, got: \(args)")
+            XCTAssertEqual(args[args.index(after: settingSourcesIndex)], "project,local")
+        }
+    }
+
+    func testStandardClaudeDoesNotUseBareMode() async {
+        let controller = makeController(variant: .standard)
+        let args = await controller.test_buildArguments(existingSessionID: nil, model: "sonnet")
+        XCTAssertFalse(args.contains("--bare"), "standard Claude Code should preserve normal user configuration, got: \(args)")
+        XCTAssertFalse(args.contains("--setting-sources"), "standard Claude Code should preserve normal user settings sources, got: \(args)")
+    }
+
+    func testBuildArgumentsOmitsModelFlagForNoModelBackends() async {
+        let controller = makeController(variant: .kimi)
+        let args = await controller.test_buildArguments(existingSessionID: nil, model: nil)
+        XCTAssertFalse(args.contains("--model"), "no-model backends must not pass --model, got: \(args)")
+    }
 }

--- a/Tests/RepoPromptTests/AgentMode/ToolCards/OracleOperationToolCardRoutingTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/ToolCards/OracleOperationToolCardRoutingTests.swift
@@ -56,6 +56,61 @@ final class OracleOperationToolCardRoutingTests: XCTestCase {
         ))
     }
 
+    func testOracleLatestPopoverRouteOmitsChatIDAndPreservesScope() throws {
+        let workspaceID = UUID()
+        let contextTabID = UUID()
+        let overrideTabID = UUID()
+        let openContext = AgentOracleOpenContext(
+            windowID: 42,
+            workspaceID: workspaceID,
+            tabID: contextTabID,
+            chatID: "ambient-chat"
+        )
+        let route = try XCTUnwrap(AgentOracleLatestPopoverRoute(
+            openContext: openContext,
+            tabID: overrideTabID
+        ))
+
+        XCTAssertEqual(route.windowID, 42)
+        XCTAssertEqual(route.workspaceID, workspaceID)
+        XCTAssertEqual(route.tabID, overrideTabID)
+
+        let userInfo = route.notificationUserInfo
+        XCTAssertEqual(userInfo["windowID"] as? Int, 42)
+        XCTAssertEqual(userInfo["workspaceID"] as? UUID, workspaceID)
+        XCTAssertEqual(userInfo["tabID"] as? UUID, overrideTabID)
+        XCTAssertEqual(userInfo["route"] as? String, "latest")
+        XCTAssertNil(userInfo["chatID"])
+        XCTAssertEqual(AgentOracleLatestPopoverRoute(notificationUserInfo: userInfo), route)
+        XCTAssertNil(AgentOraclePopoverRoute(notificationUserInfo: userInfo))
+
+        XCTAssertNil(AgentOracleLatestPopoverRoute(openContext: nil))
+        XCTAssertNil(AgentOracleLatestPopoverRoute(
+            openContext: AgentOracleOpenContext(windowID: 42, workspaceID: nil, tabID: contextTabID)
+        ))
+        XCTAssertNil(AgentOracleLatestPopoverRoute(
+            openContext: AgentOracleOpenContext(windowID: 42, workspaceID: workspaceID, tabID: nil)
+        ))
+        XCTAssertNil(AgentOracleLatestPopoverRoute(notificationUserInfo: [
+            "windowID": 42,
+            "workspaceID": workspaceID,
+            "tabID": contextTabID
+        ]))
+        XCTAssertNil(AgentOracleLatestPopoverRoute(notificationUserInfo: [
+            "windowID": 42,
+            "workspaceID": workspaceID,
+            "tabID": contextTabID,
+            "route": "other"
+        ]))
+        XCTAssertNil(AgentOracleLatestPopoverRoute(notificationUserInfo: [
+            "windowID": 42,
+            "workspaceID": workspaceID,
+            "tabID": contextTabID,
+            "route": "latest",
+            "chatID": "exact-chat"
+        ]))
+    }
+
     func testOraclePopoverRoutePreservesNotificationTypesAndCompatibilityDecoding() throws {
         let workspaceID = UUID()
         let contextTabID = UUID()
@@ -233,7 +288,33 @@ final class OracleOperationToolCardRoutingTests: XCTestCase {
 
         XCTAssertEqual(exactUserInfo["chatID"] as? String, "exact-call-chat")
 
+        let completedExactUserInfo = try XCTUnwrap(oracleToolCallPopoverUserInfo(
+            item: AgentChatItem(
+                kind: .toolCall,
+                text: "",
+                toolName: "ask_oracle",
+                toolArgsJSON: jsonString(["message": "start a new chat"]),
+                toolResultJSON: jsonString(["chat_id": "  exact-result-chat  ", "mode": "review"]),
+                toolIsError: false
+            ),
+            openContext: openContext
+        ))
+        XCTAssertEqual(completedExactUserInfo["chatID"] as? String, "exact-result-chat")
+        XCTAssertNil(completedExactUserInfo["route"])
+
         XCTAssertNil(oracleToolCallPopoverUserInfo(
+            item: AgentChatItem(
+                kind: .toolCall,
+                text: "",
+                toolName: "ask_oracle",
+                toolArgsJSON: jsonString(["message": "start a new chat"]),
+                toolResultJSON: jsonString(["status": "failed"]),
+                toolIsError: true
+            ),
+            openContext: openContext
+        ))
+
+        let latestUserInfo = try XCTUnwrap(oracleToolCallPopoverUserInfo(
             item: AgentChatItem(
                 kind: .toolCall,
                 text: "",
@@ -242,12 +323,64 @@ final class OracleOperationToolCardRoutingTests: XCTestCase {
             ),
             openContext: openContext
         ))
+        XCTAssertEqual(latestUserInfo["windowID"] as? Int, openContext.windowID)
+        XCTAssertEqual(latestUserInfo["workspaceID"] as? UUID, openContext.workspaceID)
+        XCTAssertEqual(latestUserInfo["tabID"] as? UUID, openContext.tabID)
+        XCTAssertEqual(latestUserInfo["route"] as? String, "latest")
+        XCTAssertNil(latestUserInfo["chatID"])
+        XCTAssertNotNil(AgentOracleLatestPopoverRoute(notificationUserInfo: latestUserInfo))
+        XCTAssertNil(AgentOraclePopoverRoute(notificationUserInfo: latestUserInfo))
         XCTAssertNil(oracleToolCallPopoverUserInfo(
             item: AgentChatItem(
                 kind: .toolCall,
                 text: "",
                 toolName: "oracle_send",
                 toolArgsJSON: jsonString(["chat_id": "\t "])
+            ),
+            openContext: openContext
+        ))
+        XCTAssertNil(oracleToolCallPopoverUserInfo(
+            item: AgentChatItem(
+                kind: .toolCall,
+                text: "",
+                toolName: "ask_oracle",
+                toolArgsJSON: jsonString(["chatID": "camel-alias"])
+            ),
+            openContext: openContext
+        ))
+        XCTAssertNil(oracleToolCallPopoverUserInfo(
+            item: AgentChatItem(
+                kind: .toolCall,
+                text: "",
+                toolName: "ask_oracle",
+                toolArgsJSON: jsonString(["message": "continue", "payload": ["chat_id": "nested"]])
+            ),
+            openContext: openContext
+        ))
+        XCTAssertNil(oracleToolCallPopoverUserInfo(
+            item: AgentChatItem(
+                kind: .toolCall,
+                text: "",
+                toolName: "ask_oracle",
+                toolArgsJSON: "{bad json"
+            ),
+            openContext: openContext
+        ))
+        XCTAssertNil(oracleToolCallPopoverUserInfo(
+            item: AgentChatItem(
+                kind: .toolCall,
+                text: "",
+                toolName: "ask_oracle",
+                toolArgsJSON: "  \n"
+            ),
+            openContext: openContext
+        ))
+        XCTAssertNil(oracleToolCallPopoverUserInfo(
+            item: AgentChatItem(
+                kind: .toolCall,
+                text: "",
+                toolName: "ask_oracle",
+                toolArgsJSON: "[]"
             ),
             openContext: openContext
         ))


### PR DESCRIPTION
## Summary

Fixes a regression where clicking an in-flight Oracle tool card in Agent Mode no longer opened the Oracle popover. This happened for new/running `ask_oracle` calls before the result returned a `chat_id`.

## What changed

- Added an explicit `route: "latest"` Oracle popover route for running tool calls that do not yet have a `chat_id`.
- Kept exact `chat_id` routing preferred whenever available.
- Made the fallback live-only: it opens the latest eligible streaming Oracle session, not an older completed chat.
- Preserved fail-closed behavior for malformed, blank, nested, or ambiguous `chat_id` payloads.
- Prevented the tool-card Cancel button from also triggering the Oracle popover tap.
- Added focused routing tests for exact vs latest behavior and stale-chat prevention.

## Validation

- `make dev-format`
- `make dev-test FILTER=OracleOperationToolCardRoutingTests`
- `make dev-test FILTER=AgentOraclePillRoutingTests`
- `make dev-lint`

## Review notes

Key behavior to verify:

1. Running Oracle card with no `chat_id` opens the current live Oracle popover.
2. Completed/result card with `chat_id` opens the exact Oracle chat.
3. Malformed/ambiguous `chat_id` payload has no popover route.
4. Cancel button cancels only and does not open the popover.