### PR TITLE
Fix MCP selection token freshness

### DIFF
--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+SelectionCore.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+SelectionCore.swift
@@ -260,6 +260,11 @@ extension MCPServerViewModel {
     }
 
     enum SelectionReplyAssembler {
+        private static let codemapPresentationPolicy = WorkspaceCodemapPresentationRequestPolicy(
+            maximumReadinessRounds: 1,
+            maximumTotalWait: .zero
+        )
+
         struct SelectedEntry {
             let entry: ResolvedPromptFileEntry
             var ranges: [LineRange]? {
@@ -789,7 +794,10 @@ extension MCPServerViewModel {
                 rootScope: rootScope,
                 profile: .uiAssisted
             )
-            return try await WorkspaceCodemapPresentationCoordinator(store: store).withPresentation(
+            return try await WorkspaceCodemapPresentationCoordinator(
+                store: store,
+                policy: codemapPresentationPolicy
+            ).withPresentation(
                 for: plan.intent,
                 rootScope: rootScope,
                 logicalRootDisplayNamesByRootID: rootDisplayNames
@@ -1561,18 +1569,36 @@ extension MCPServerViewModel {
         let lookupContext: WorkspaceLookupContext
 
         func build(
+            for collections: SelectionReplyAssembler.SelectionCollections
+        ) async -> ToolResultDTOs.SelectedCodeStructureDTO? {
+            await build(
+                rendering: collections.selected.map(\.file) + collections.codemap.map(\.file),
+                diagnostics: SelectionReplyAssembler.codemapDiagnosticFiles(for: collections),
+                presentation: collections.codemapPresentation
+            )
+        }
+
+        func build(
             for files: [WorkspaceFileRecord],
             presentation: WorkspaceCodemapOperationPresentation
         ) async -> ToolResultDTOs.SelectedCodeStructureDTO? {
-            guard !files.isEmpty else { return nil }
+            await build(rendering: files, diagnostics: files, presentation: presentation)
+        }
+
+        private func build(
+            rendering renderingFiles: [WorkspaceFileRecord],
+            diagnostics diagnosticFiles: [WorkspaceFileRecord],
+            presentation: WorkspaceCodemapOperationPresentation
+        ) async -> ToolResultDTOs.SelectedCodeStructureDTO? {
+            guard !renderingFiles.isEmpty || !diagnosticFiles.isEmpty else { return nil }
             let disabled = await MainActor.run { owner.promptVM.codeMapsGloballyDisabled }
             guard !disabled else { return nil }
 
-            let fileIDs = Set(files.map(\.id))
+            let fileIDs = Set(renderingFiles.map(\.id))
             let rendered = presentation.orderedEntries.filter { fileIDs.contains($0.fileID) }
             let included = Array(rendered.prefix(25))
             let diagnostics = await SelectionReplyAssembler.missingCodemapDiagnostics(
-                for: files,
+                for: diagnosticFiles,
                 presentation: presentation
             ) { file in
                 if let projected = lookupContext.bindingProjection?.projectedLogicalDisplayPath(

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+SelectionCore.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+SelectionCore.swift
@@ -1578,13 +1578,6 @@ extension MCPServerViewModel {
             )
         }
 
-        func build(
-            for files: [WorkspaceFileRecord],
-            presentation: WorkspaceCodemapOperationPresentation
-        ) async -> ToolResultDTOs.SelectedCodeStructureDTO? {
-            await build(rendering: files, diagnostics: files, presentation: presentation)
-        }
-
         private func build(
             rendering renderingFiles: [WorkspaceFileRecord],
             diagnostics diagnosticFiles: [WorkspaceFileRecord],

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+SelectionReply.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+SelectionReply.swift
@@ -434,21 +434,33 @@ extension MCPServerViewModel {
             _ = await promptVM.workspaceFileContextStore.awaitAppliedIngress(rootScope: lookupContext.rootScope)
         }
         let effectiveSelection = lookupContext.physicalizeSelection(selection)
-        let reviewGitContext = if let reviewGitContextOverride {
-            reviewGitContextOverride
+        let selectionHasGitArtifactCandidates = !SelectedGitArtifactSelectionClassifier
+            .artifactCandidatePaths(from: effectiveSelection, capability: nil)
+            .isEmpty
+        let artifactAuthorization: SelectedGitArtifactAuthorizationResult
+        if selectionHasGitArtifactCandidates {
+            let reviewGitContext = if let reviewGitContextOverride {
+                reviewGitContextOverride
+            } else {
+                await promptVM.freezePromptGitReviewContext(
+                    workspaceID: virtualContext?.workspaceID,
+                    tabID: virtualContext?.tabID,
+                    sessionID: virtualContext?.activeAgentSessionID,
+                    bindings: virtualContext?.worktreeBindings ?? [],
+                    base: "HEAD"
+                )
+            }
+            artifactAuthorization = await authorizeSelectedGitArtifacts(
+                selection: effectiveSelection,
+                reviewGitContext: reviewGitContext
+            )
         } else {
-            await promptVM.freezePromptGitReviewContext(
-                workspaceID: virtualContext?.workspaceID,
-                tabID: virtualContext?.tabID,
-                sessionID: virtualContext?.activeAgentSessionID,
-                bindings: virtualContext?.worktreeBindings ?? [],
-                base: "HEAD"
+            artifactAuthorization = SelectedGitArtifactAuthorizationResult(
+                entries: [],
+                consumedSelectionPaths: [],
+                dispositions: []
             )
         }
-        let artifactAuthorization = await authorizeSelectedGitArtifacts(
-            selection: effectiveSelection,
-            reviewGitContext: reviewGitContext
-        )
         let ordinarySelection = selectionExcludingArtifacts(
             effectiveSelection,
             excluding: artifactAuthorization.consumedSelectionPaths

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+TokenStats.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+TokenStats.swift
@@ -124,18 +124,12 @@ extension MCPServerViewModel {
                 scheduleRefreshIfNeeded: allowActivePublishedSnapshotRefresh
             )
 
-            var incompleteComponents = Set<String>()
-            if !published.isComplete {
-                incompleteComponents.insert("published_snapshot")
-            }
-            if Self.hasMissingFileTokenInputs(
+            var incompleteComponents = Self.virtualSnapshotIncompleteComponents(
                 collections: collections,
                 reliableFileIDs: publishedOverlay.reliableFileIDs
-            ) {
-                incompleteComponents.insert("files")
-            }
-            if Self.hasPendingCodemapPresentationGaps(collections: collections) {
-                incompleteComponents.insert("codemap_presentation")
+            )
+            if !published.isComplete {
+                incompleteComponents.insert("published_snapshot")
             }
 
             let orderedIncomplete = Self.orderedIncompleteComponents(incompleteComponents)
@@ -195,16 +189,10 @@ extension MCPServerViewModel {
         if allowVirtualTokenRefresh,
            let cachedSnapshot = mcpVirtualTokenSnapshotsByTabID[context.tabID]?[signature]
         {
-            var incompleteComponents = Set<String>()
-            if Self.hasMissingFileTokenInputs(
+            var incompleteComponents = Self.virtualSnapshotIncompleteComponents(
                 collections: collections,
                 reliableFileIDs: Set(cachedSnapshot.entryResultsByFileID.keys)
-            ) {
-                incompleteComponents.insert("files")
-            }
-            if Self.hasPendingCodemapPresentationGaps(collections: collections) {
-                incompleteComponents.insert("codemap_presentation")
-            }
+            )
             incompleteComponents.formUnion(cachedSnapshot.incompleteComponents ?? [])
             let orderedIncomplete = Self.orderedIncompleteComponents(incompleteComponents)
             if !incompleteComponents.isEmpty {
@@ -230,16 +218,10 @@ extension MCPServerViewModel {
             )
         }
 
-        var incompleteComponents = Set<String>()
-        if Self.hasMissingFileTokenInputs(
+        var incompleteComponents = Self.virtualSnapshotIncompleteComponents(
             collections: collections,
             reliableFileIDs: publishedOverlay.reliableFileIDs
-        ) {
-            incompleteComponents.insert("files")
-        }
-        if Self.hasPendingCodemapPresentationGaps(collections: collections) {
-            incompleteComponents.insert("codemap_presentation")
-        }
+        )
         if resolvedContext.rendersFileTree {
             incompleteComponents.insert("file_tree")
         }

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+TokenStats.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+TokenStats.swift
@@ -114,42 +114,15 @@ extension MCPServerViewModel {
         allowActivePublishedSnapshotRefresh: Bool = true,
         allowVirtualTokenRefresh: Bool = true
     ) async -> MCPPreparedTokenAccounting {
-        let cachedEvaluation = await cachedPromptEntriesEvaluation(collections: collections)
         if activeTabCompatibility {
+            let publishedOverlay = publishedEntryResultsOverlay(
+                collections: collections,
+                base: [:]
+            )
             let published = promptVM.tokenCountingViewModel.latestPublishedTokenSnapshot(
                 for: effectiveSelection,
                 scheduleRefreshIfNeeded: allowActivePublishedSnapshotRefresh
             )
-            var entryResults = cachedEvaluation.entryResultsByFileID
-            var reliablePublishedFileIDs = Set<UUID>()
-            for entry in collections.selected {
-                guard let info = promptVM.tokenCountingViewModel.latestPublishedTokenInfo(
-                    forFullPath: entry.file.standardizedFullPath
-                ) else { continue }
-                let renderMode: PromptEntriesEvaluation.RenderMode = entry.ranges?.isEmpty == false ? .slice : .full
-                let displayTokens = renderMode == .slice ? info.count : info.fullCount
-                entryResults[entry.file.id] = .init(
-                    fileID: entry.file.id,
-                    renderMode: renderMode,
-                    displayTokens: displayTokens,
-                    fullTokens: info.fullCount,
-                    codemapTokens: info.codemapCount
-                )
-                reliablePublishedFileIDs.insert(entry.file.id)
-            }
-            for entry in collections.codemap {
-                guard let info = promptVM.tokenCountingViewModel.latestPublishedTokenInfo(
-                    forFullPath: entry.file.standardizedFullPath
-                ) else { continue }
-                entryResults[entry.file.id] = .init(
-                    fileID: entry.file.id,
-                    renderMode: .codemap,
-                    displayTokens: info.codemapCount,
-                    fullTokens: info.fullCount,
-                    codemapTokens: info.codemapCount
-                )
-                reliablePublishedFileIDs.insert(entry.file.id)
-            }
 
             var incompleteComponents = Set<String>()
             if !published.isComplete {
@@ -157,7 +130,7 @@ extension MCPServerViewModel {
             }
             if Self.hasMissingFileTokenInputs(
                 collections: collections,
-                reliableFileIDs: reliablePublishedFileIDs
+                reliableFileIDs: publishedOverlay.reliableFileIDs
             ) {
                 incompleteComponents.insert("files")
             }
@@ -188,7 +161,7 @@ extension MCPServerViewModel {
             }
 
             return MCPPreparedTokenAccounting(
-                entryResultsByFileID: entryResults,
+                entryResultsByFileID: publishedOverlay.entryResultsByFileID,
                 breakdown: .init(
                     prompt: published.breakdown.prompt,
                     duplicatePrompt: 0,
@@ -207,6 +180,11 @@ extension MCPServerViewModel {
             )
         }
 
+        let cachedEvaluation = await cachedPromptEntriesEvaluation(collections: collections)
+        let publishedOverlay = publishedEntryResultsOverlay(
+            collections: collections,
+            base: cachedEvaluation.entryResultsByFileID
+        )
         let signature = virtualTokenSignature(
             context: context,
             selection: effectiveSelection,
@@ -217,14 +195,6 @@ extension MCPServerViewModel {
         if allowVirtualTokenRefresh,
            let cachedSnapshot = mcpVirtualTokenSnapshotsByTabID[context.tabID]?[signature]
         {
-            enqueueVirtualTokenRefresh(
-                signature: signature,
-                context: context,
-                effectiveSelection: effectiveSelection,
-                resolvedContext: resolvedContext,
-                collections: collections,
-                lookupContext: lookupContext
-            )
             var incompleteComponents = Set<String>()
             if Self.hasMissingFileTokenInputs(
                 collections: collections,
@@ -235,21 +205,36 @@ extension MCPServerViewModel {
             if Self.hasPendingCodemapPresentationGaps(collections: collections) {
                 incompleteComponents.insert("codemap_presentation")
             }
+            incompleteComponents.formUnion(cachedSnapshot.incompleteComponents ?? [])
+            let orderedIncomplete = Self.orderedIncompleteComponents(incompleteComponents)
+            if !incompleteComponents.isEmpty {
+                enqueueVirtualTokenRefresh(
+                    signature: signature,
+                    context: context,
+                    effectiveSelection: effectiveSelection,
+                    resolvedContext: resolvedContext,
+                    collections: collections,
+                    lookupContext: lookupContext
+                )
+            }
             return MCPPreparedTokenAccounting(
                 entryResultsByFileID: cachedSnapshot.entryResultsByFileID,
                 breakdown: cachedSnapshot.breakdown,
                 tokenAccounting: .init(
-                    status: "stale",
+                    status: incompleteComponents.isEmpty ? "fresh" : "stale",
                     source: "bound_tab_cache",
-                    refreshPending: true,
-                    incompleteComponents: Self.orderedIncompleteComponents(incompleteComponents)
+                    refreshPending: !incompleteComponents.isEmpty,
+                    incompleteComponents: orderedIncomplete
                 ),
                 activePublishedSnapshot: nil
             )
         }
 
         var incompleteComponents = Set<String>()
-        if Self.hasMissingFileTokenInputs(collections: collections, reliableFileIDs: []) {
+        if Self.hasMissingFileTokenInputs(
+            collections: collections,
+            reliableFileIDs: publishedOverlay.reliableFileIDs
+        ) {
             incompleteComponents.insert("files")
         }
         if Self.hasPendingCodemapPresentationGaps(collections: collections) {
@@ -283,7 +268,7 @@ extension MCPServerViewModel {
             ? promptVM.duplicateUserInstructionsAtTop
             : false
         return MCPPreparedTokenAccounting(
-            entryResultsByFileID: cachedEvaluation.entryResultsByFileID,
+            entryResultsByFileID: publishedOverlay.entryResultsByFileID,
             breakdown: TokenCalculationService.calculateComponentBreakdown(
                 promptText: promptText,
                 selectedInstructionsText: selectedInstructionsText,
@@ -300,6 +285,47 @@ extension MCPServerViewModel {
             ),
             activePublishedSnapshot: nil
         )
+    }
+
+    @MainActor
+    private func publishedEntryResultsOverlay(
+        collections: SelectionReplyAssembler.SelectionCollections,
+        base: [UUID: PromptEntriesEvaluation.EntryResult]
+    ) -> (
+        entryResultsByFileID: [UUID: PromptEntriesEvaluation.EntryResult],
+        reliableFileIDs: Set<UUID>
+    ) {
+        var entryResults = base
+        var reliableFileIDs = Set<UUID>()
+        for entry in collections.selected {
+            guard let info = promptVM.tokenCountingViewModel.latestPublishedTokenInfo(
+                forFullPath: entry.file.standardizedFullPath
+            ) else { continue }
+            let renderMode: PromptEntriesEvaluation.RenderMode = entry.ranges?.isEmpty == false ? .slice : .full
+            let displayTokens = renderMode == .slice ? info.count : info.fullCount
+            entryResults[entry.file.id] = .init(
+                fileID: entry.file.id,
+                renderMode: renderMode,
+                displayTokens: displayTokens,
+                fullTokens: info.fullCount,
+                codemapTokens: info.codemapCount
+            )
+            reliableFileIDs.insert(entry.file.id)
+        }
+        for entry in collections.codemap {
+            guard let info = promptVM.tokenCountingViewModel.latestPublishedTokenInfo(
+                forFullPath: entry.file.standardizedFullPath
+            ) else { continue }
+            entryResults[entry.file.id] = .init(
+                fileID: entry.file.id,
+                renderMode: .codemap,
+                displayTokens: info.codemapCount,
+                fullTokens: info.fullCount,
+                codemapTokens: info.codemapCount
+            )
+            reliableFileIDs.insert(entry.file.id)
+        }
+        return (entryResults, reliableFileIDs)
     }
 
     private static func orderedIncompleteComponents(
@@ -407,7 +433,13 @@ extension MCPServerViewModel {
             mcpVirtualTokenSnapshotsByTabID[context.tabID, default: [:]][signature] = MCPVirtualTokenSnapshot(
                 signature: signature,
                 entryResultsByFileID: evaluation.entryResultsByFileID,
-                breakdown: breakdown
+                breakdown: breakdown,
+                incompleteComponents: Self.orderedIncompleteComponents(
+                    Self.virtualSnapshotIncompleteComponents(
+                        collections: collections,
+                        reliableFileIDs: Set(evaluation.entryResultsByFileID.keys)
+                    )
+                )
             )
             mcpVirtualTokenRefreshTasksByTabID[context.tabID]?[signature] = nil
             mcpVirtualTokenRefreshGenerationByTabID[context.tabID]?[signature] = nil
@@ -418,6 +450,23 @@ extension MCPServerViewModel {
                 mcpVirtualTokenRefreshGenerationByTabID[context.tabID] = nil
             }
         }
+    }
+
+    private static func virtualSnapshotIncompleteComponents(
+        collections: SelectionReplyAssembler.SelectionCollections,
+        reliableFileIDs: Set<UUID>
+    ) -> Set<String> {
+        var incompleteComponents = Set<String>()
+        if hasMissingFileTokenInputs(
+            collections: collections,
+            reliableFileIDs: reliableFileIDs
+        ) {
+            incompleteComponents.insert("files")
+        }
+        if hasPendingCodemapPresentationGaps(collections: collections) {
+            incompleteComponents.insert("codemap_presentation")
+        }
+        return incompleteComponents
     }
 
     nonisolated static func publishedTokenStats(

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+WorkspaceContext.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+WorkspaceContext.swift
@@ -104,11 +104,7 @@ extension MCPServerViewModel {
         var codeStructDTO: ToolResultDTOs.SelectedCodeStructureDTO? = nil
         if include.contains("code"), !promptVM.codeMapsGloballyDisabled, let coll = collections {
             let builder = CodeStructureBuilder(owner: self, lookupContext: lookupContext)
-            let combined = coll.selected.map(\.file) + coll.codemap.map(\.file)
-            codeStructDTO = await builder.build(
-                for: combined,
-                presentation: coll.codemapPresentation
-            )
+            codeStructDTO = await builder.build(for: coll)
         }
 
         var fileTreeDTO: ToolResultDTOs.FileTreeDTO? = nil

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel.swift
@@ -373,6 +373,7 @@ final class MCPServerViewModel: ObservableObject {
         let signature: MCPVirtualTokenSignature
         let entryResultsByFileID: [UUID: PromptEntriesEvaluation.EntryResult]
         let breakdown: TokenComponentBreakdown
+        let incompleteComponents: [String]?
     }
 
     var mcpVirtualTokenSnapshotsByTabID: [UUID: [MCPVirtualTokenSignature: MCPVirtualTokenSnapshot]] = [:]

--- a/Tests/RepoPromptTests/MCP/MCPSelectionReplyFreshnessTests.swift
+++ b/Tests/RepoPromptTests/MCP/MCPSelectionReplyFreshnessTests.swift
@@ -85,44 +85,6 @@ final class MCPSelectionReplyFreshnessTests: XCTestCase {
         XCTAssertEqual(diagnostics.unmappedPaths, ["README.txt"])
     }
 
-    func testAutoModeOnlyDiagnosesRequestedCodemapFiles() async {
-        let selectedFile = makeFileRecord(relativePath: "Sources/Selected.swift")
-        let requestedCodemapFile = makeFileRecord(relativePath: "Sources/Requested.swift")
-        let selectedEntry = MCPServerViewModel.SelectionReplyAssembler.SelectedEntry(
-            entry: ResolvedPromptFileEntry(file: selectedFile)
-        )
-        let issue = WorkspaceCodemapOperationIssue.coordinationUnavailable
-        let presentation = WorkspaceCodemapOperationPresentation(
-            orderedEntries: [],
-            coverage: .pending([issue]),
-            issues: [issue],
-            publicationReceipt: nil
-        )
-        let collections = MCPServerViewModel.SelectionReplyAssembler.SelectionCollections(
-            selected: [selectedEntry],
-            codemap: [],
-            requestedCodemapFiles: [requestedCodemapFile],
-            codemapAutoEnabled: false,
-            codeMapUsage: .auto,
-            invalid: [],
-            codemapPresentation: presentation
-        )
-
-        let diagnosticFiles = MCPServerViewModel.SelectionReplyAssembler.codemapDiagnosticFiles(
-            for: collections
-        )
-        XCTAssertEqual(diagnosticFiles.map(\.id), [requestedCodemapFile.id])
-
-        let diagnostics = await MCPServerViewModel.SelectionReplyAssembler.missingCodemapDiagnostics(
-            for: diagnosticFiles,
-            presentation: presentation
-        ) { file in
-            file.standardizedRelativePath
-        }
-        XCTAssertEqual(diagnostics.pendingPaths, ["Sources/Requested.swift"])
-        XCTAssertEqual(diagnostics.unmappedPaths, [])
-    }
-
     func testWorkspaceContextCodeStructureUsesUsageAwareAutoDiagnostics() async throws {
         let root = try makeTemporaryRoot(name: "WorkspaceCodeDiagnostics")
         defer { try? FileManager.default.removeItem(at: root.deletingLastPathComponent()) }
@@ -151,6 +113,9 @@ final class MCPSelectionReplyFreshnessTests: XCTestCase {
             invalid: [],
             codemapPresentation: presentation
         )
+
+        let diagnosticFiles = MCPServerViewModel.SelectionReplyAssembler.codemapDiagnosticFiles(for: collections)
+        XCTAssertEqual(diagnosticFiles.map(\.id), [requestedCodemapFile.id])
 
         let builder = MCPServerViewModel.CodeStructureBuilder(
             owner: window.mcpServer,

--- a/Tests/RepoPromptTests/MCP/MCPSelectionReplyFreshnessTests.swift
+++ b/Tests/RepoPromptTests/MCP/MCPSelectionReplyFreshnessTests.swift
@@ -123,6 +123,47 @@ final class MCPSelectionReplyFreshnessTests: XCTestCase {
         XCTAssertEqual(diagnostics.unmappedPaths, [])
     }
 
+    func testWorkspaceContextCodeStructureUsesUsageAwareAutoDiagnostics() async throws {
+        let root = try makeTemporaryRoot(name: "WorkspaceCodeDiagnostics")
+        defer { try? FileManager.default.removeItem(at: root.deletingLastPathComponent()) }
+        let tabID = UUID()
+        let (window, _) = await makeWindow(root: root, tabID: tabID, selection: StoredSelection())
+        defer { WindowStatesManager.shared.unregisterWindowState(window) }
+
+        let selectedFile = makeFileRecord(relativePath: "Sources/Selected.swift")
+        let requestedCodemapFile = makeFileRecord(relativePath: "Sources/Requested.swift")
+        let selectedEntry = MCPServerViewModel.SelectionReplyAssembler.SelectedEntry(
+            entry: ResolvedPromptFileEntry(file: selectedFile)
+        )
+        let issue = WorkspaceCodemapOperationIssue.coordinationUnavailable
+        let presentation = WorkspaceCodemapOperationPresentation(
+            orderedEntries: [],
+            coverage: .pending([issue]),
+            issues: [issue],
+            publicationReceipt: nil
+        )
+        let collections = MCPServerViewModel.SelectionReplyAssembler.SelectionCollections(
+            selected: [selectedEntry],
+            codemap: [],
+            requestedCodemapFiles: [requestedCodemapFile],
+            codemapAutoEnabled: true,
+            codeMapUsage: .auto,
+            invalid: [],
+            codemapPresentation: presentation
+        )
+
+        let builder = MCPServerViewModel.CodeStructureBuilder(
+            owner: window.mcpServer,
+            lookupContext: .visibleWorkspace
+        )
+        let maybeDTO = await builder.build(for: collections)
+        let dto = try XCTUnwrap(maybeDTO)
+
+        XCTAssertEqual(dto.pendingPaths, ["Sources/Requested.swift"])
+        XCTAssertFalse(dto.pendingPaths?.contains("Sources/Selected.swift") == true)
+        XCTAssertNil(dto.unmappedPaths)
+    }
+
     func testTerminalCodemapDispositionOverridesPendingRegardlessOfIssueOrder() async {
         let file = makeFileRecord(relativePath: "Sources/Terminal.swift")
         let ticket = makeCodemapTicket(fileID: file.id, rootID: file.rootID)
@@ -745,7 +786,7 @@ final class MCPSelectionReplyFreshnessTests: XCTestCase {
             firstLogicalRoot.appendingPathComponent(firstRelativePath).path,
             secondLogicalRoot.appendingPathComponent(secondRelativePath).path
         ])
-        let (window, workspaceID) = await makeWindow(
+        let (window, _) = await makeWindow(
             roots: [firstLogicalRoot, secondLogicalRoot],
             tabID: tabID,
             selection: logicalSelection
@@ -932,7 +973,7 @@ final class MCPSelectionReplyFreshnessTests: XCTestCase {
             let selection = StoredSelection(selectedPaths: [fileURL.path])
             let (window, workspaceID) = await makeWindow(root: root, tabID: tabID, selection: selection)
             defer { WindowStatesManager.shared.unregisterWindowState(window) }
-            let loadedRoot = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(
+            _ = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(
                 in: window,
                 path: root.path
             )
@@ -1005,15 +1046,15 @@ final class MCPSelectionReplyFreshnessTests: XCTestCase {
             XCTAssertEqual(resolvedFirstReply.tokenAccounting?.source, "bound_tab_cached_state")
             XCTAssertEqual(resolvedFirstReply.tokenAccounting?.status, "incomplete")
             XCTAssertTrue(resolvedFirstReply.tokenAccounting?.refreshPending == true)
-            XCTAssertTrue(resolvedFirstReply.tokenAccounting?.incompleteComponents?.contains("files") == true)
+            XCTAssertFalse(resolvedFirstReply.tokenAccounting?.incompleteComponents?.contains("files") == true)
             XCTAssertEqual(resolvedSecondReply.tokenAccounting?.source, "bound_tab_cached_state")
             XCTAssertEqual(resolvedSecondReply.tokenAccounting?.status, "incomplete")
             XCTAssertTrue(resolvedSecondReply.tokenAccounting?.refreshPending == true)
-            XCTAssertTrue(resolvedSecondReply.tokenAccounting?.incompleteComponents?.contains("files") == true)
+            XCTAssertFalse(resolvedSecondReply.tokenAccounting?.incompleteComponents?.contains("files") == true)
             XCTAssertEqual(resolvedWorkspaceReply.tokenAccounting?.source, "bound_tab_cached_state")
             XCTAssertEqual(resolvedWorkspaceReply.tokenAccounting?.status, "incomplete")
             XCTAssertTrue(resolvedWorkspaceReply.tokenAccounting?.refreshPending == true)
-            XCTAssertTrue(resolvedWorkspaceReply.tokenAccounting?.incompleteComponents?.contains("files") == true)
+            XCTAssertFalse(resolvedWorkspaceReply.tokenAccounting?.incompleteComponents?.contains("files") == true)
             XCTAssertEqual(window.mcpServer.virtualTokenRefreshStartCountForTesting(), baselineStarts + 1)
             let refreshStartCount = await refreshGate.startCount()
             // Identical bound selection and workspace token requests share one signature,
@@ -1022,6 +1063,67 @@ final class MCPSelectionReplyFreshnessTests: XCTestCase {
 
             await refreshGate.release()
             window.mcpServer.setBeforeVirtualTokenRefreshForTesting(nil)
+        }
+
+        func testBoundReplyUsesPublishedFileTokensWhileCodemapPresentationIsPending() async throws {
+            let root = try makeTemporaryRoot(name: "BoundPublishedPendingCodemap")
+            defer { try? FileManager.default.removeItem(at: root.deletingLastPathComponent()) }
+            let source = root.appendingPathComponent("Source.swift")
+            let target = root.appendingPathComponent("Target.swift")
+            try write("struct SourceForPublishedTokens { func selected() {} }\n", to: source)
+            try write("struct TargetForPendingCodemap { func related() {} }\n", to: target)
+
+            let tabID = UUID()
+            let selection = StoredSelection(
+                selectedPaths: [source.path],
+                codemapAutoEnabled: true
+            )
+            let (window, _) = await makeWindow(root: root, tabID: tabID, selection: selection)
+            defer { WindowStatesManager.shared.unregisterWindowState(window) }
+            let loadedRoot = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(
+                in: window,
+                path: root.path
+            )
+            await window.promptManager.tokenCountingViewModel.forceImmediateRecount()
+            let targetRecordCandidate = await window.promptManager.workspaceFileContextStore.file(
+                rootID: loadedRoot.id,
+                relativePath: "Target.swift"
+            )
+            let targetRecord = try XCTUnwrap(targetRecordCandidate)
+            let rootEpoch = makeRootEpoch(rootID: targetRecord.rootID)
+            let issue = WorkspaceCodemapOperationIssue.automatic(.pending([
+                .candidateDemand(
+                    rootEpoch: rootEpoch,
+                    fileID: targetRecord.id,
+                    ticket: makeCodemapTicket(fileID: targetRecord.id, rootID: targetRecord.rootID)
+                )
+            ]))
+            let presentation = WorkspaceCodemapOperationPresentation(
+                orderedEntries: [],
+                coverage: .pending([issue]),
+                issues: [issue],
+                publicationReceipt: nil
+            )
+            let baselineStarts = window.mcpServer.virtualTokenRefreshStartCountForTesting()
+
+            let reply = await window.mcpServer.buildBorrowedTabSelectionReply(
+                codemapPresentation: presentation,
+                from: selection,
+                includeBlocks: false,
+                display: .full,
+                lookupContext: .visibleWorkspace
+            )
+
+            XCTAssertEqual(reply.files?.map(\.path), [source.path])
+            XCTAssertGreaterThan(reply.totalTokens ?? 0, 0)
+            XCTAssertEqual(reply.summary?.fullCount, 1)
+            XCTAssertGreaterThan(reply.summary?.fullTokens ?? 0, 0)
+            XCTAssertEqual(reply.tokenAccounting?.source, "bound_tab_cached_state")
+            XCTAssertEqual(reply.tokenAccounting?.status, "incomplete")
+            XCTAssertTrue(reply.tokenAccounting?.refreshPending == false)
+            XCTAssertFalse(reply.tokenAccounting?.incompleteComponents?.contains("files") == true)
+            XCTAssertTrue(reply.tokenAccounting?.incompleteComponents?.contains("codemap_presentation") == true)
+            XCTAssertEqual(window.mcpServer.virtualTokenRefreshStartCountForTesting(), baselineStarts)
         }
 
         func testBoundMCPTokenRefreshesForDistinctSignaturesDoNotCancelEachOther() async throws {
@@ -1638,10 +1740,13 @@ final class MCPSelectionReplyFreshnessTests: XCTestCase {
             in: window,
             path: workspaceRoot.path
         )
-        _ = try await window.workspaceFileContextStore.loadRoot(
+        let loadedSessionWorktreeRoot = try await window.workspaceFileContextStore.loadRoot(
             path: worktreeRoot.path,
             kind: .sessionWorktree
         )
+        addTeardownBlock {
+            await window.workspaceFileContextStore.unloadRoot(id: loadedSessionWorktreeRoot.id)
+        }
         let metadata = MCPServerViewModel.RequestMetadata(
             connectionID: nil,
             clientName: "selection-reply-compatibility-test",

--- a/Tests/RepoPromptTests/MCP/MCPSelectionReplyFreshnessTests.swift
+++ b/Tests/RepoPromptTests/MCP/MCPSelectionReplyFreshnessTests.swift
@@ -114,9 +114,6 @@ final class MCPSelectionReplyFreshnessTests: XCTestCase {
             codemapPresentation: presentation
         )
 
-        let diagnosticFiles = MCPServerViewModel.SelectionReplyAssembler.codemapDiagnosticFiles(for: collections)
-        XCTAssertEqual(diagnosticFiles.map(\.id), [requestedCodemapFile.id])
-
         let builder = MCPServerViewModel.CodeStructureBuilder(
             owner: window.mcpServer,
             lookupContext: .visibleWorkspace
@@ -125,7 +122,6 @@ final class MCPSelectionReplyFreshnessTests: XCTestCase {
         let dto = try XCTUnwrap(maybeDTO)
 
         XCTAssertEqual(dto.pendingPaths, ["Sources/Requested.swift"])
-        XCTAssertFalse(dto.pendingPaths?.contains("Sources/Selected.swift") == true)
         XCTAssertNil(dto.unmappedPaths)
     }
 


### PR DESCRIPTION
## Summary

- keep MCP selection replies non-blocking for codemap presentation by reporting pending codemaps instead of waiting
- overlay latest published per-file token data for active and bound/non-active token accounting so file tokens can appear while codemap presentation is pending
- stop treating cached bound-tab token snapshots as perpetually stale/pending once incomplete components clear
- align `workspace_context` code-structure diagnostics with selection reply usage-aware codemap diagnostics
- avoid freezing git review context for ordinary selections with no git-artifact candidate paths
- fix order-dependent test leakage by unloading the session-worktree root in teardown

## Diagnosis notes

- Current-main `file_search` display paths round-trip through `manage_selection`; no path-lookup change is included.
- The reproduced issues were token freshness, bound cache status, codemap diagnostic mismatch, and slow ordinary selection/token reply paths.
- Codemap generation remains async/non-blocking.

## Validation

- `make dev-test FILTER=MCPSelectionReplyFreshnessTests` — passed, 24 tests, 0 failures; ticket `b169fea1-9d36-4cf8-8a5d-dd8abef7220a`
- `make dev-test FILTER=PathMatchingRecoveryTests` — passed, 3 tests, 0 failures; ticket `e2541737-ef75-4819-9c41-a4ae54853b0b`
- `make dev-lint` — passed, SwiftFormat clean and SwiftLint 0 violations; ticket `2cc3a8fa-96aa-43fc-ab3b-2ff1327e9485`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh commit` — passed
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh push` — passed
