### PR TITLE
Bump engineer role default to GPT-5.5 Medium

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentModel.swift
@@ -140,8 +140,8 @@ enum AgentModel: String, CaseIterable, Codable {
     var description: String {
         switch self {
         case .codexMini: "Ultra-fast. Good for quick lookups, simple edits, and surface-level exploration."
-        case .gpt55CodexLow: "Fast GPT-5.5 reasoning through Codex. Recommended for explore, discovery, and default implementation."
-        case .gpt55CodexMedium: "Balanced GPT-5.5 reasoning through Codex. Good when you want more reasoning than Low without jumping to High."
+        case .gpt55CodexLow: "Fast GPT-5.5 reasoning through Codex. Recommended for explore, discovery, and lightweight implementation."
+        case .gpt55CodexMedium: "Balanced GPT-5.5 reasoning through Codex. Good for Engineer defaults when you want more reasoning than Low without jumping to High."
         case .gpt55CodexHigh: "Deep GPT-5.5 reasoning through Codex. Recommended for planning, review, and pair-agent work."
         case .gpt55CodexXHigh: "Maximum GPT-5.5 reasoning through Codex. Use selectively for the hardest agentic tasks."
         case .codexLow: "Fast agentic coding. Good for well-scoped, straightforward tasks."

--- a/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentModelCatalog.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentModelCatalog.swift
@@ -1825,7 +1825,7 @@ enum AgentModelCatalog {
             ]
         case .engineer:
             [
-                SelectionCandidate(agent: .codexExec, modelRaw: AgentModel.gpt55CodexLow.rawValue),
+                SelectionCandidate(agent: .codexExec, modelRaw: AgentModel.gpt55CodexMedium.rawValue),
                 SelectionCandidate(agent: .claudeCode, modelRaw: AgentModel.claudeSonnet.rawValue),
                 SelectionCandidate(agent: .claudeCodeGLM, modelRaw: AgentModel.claudeSonnet.rawValue),
                 SelectionCandidate(agent: .kimiCode, modelRaw: AgentModel.kimiCode.rawValue),

--- a/Sources/RepoPrompt/Features/AgentMode/Recommendations/AutoRecommendationEngine.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Recommendations/AutoRecommendationEngine.swift
@@ -492,7 +492,7 @@ final class AutoRecommendationEngine {
         // Suggest upgrade if only some CLIs are available
         let upgradeHint: String? = {
             if recommendedStatus.codexCLI != .ready {
-                return "Connect Codex CLI for GPT-5.5 Low (explore/discovery/engineer/default implementation), GPT-5.5 High (pair/Oracle), and GPT-5.5 Medium (design fallback)."
+                return "Connect Codex CLI for GPT-5.5 Low (explore/discovery), GPT-5.5 Medium (engineer and design fallback), and GPT-5.5 High (pair/Oracle)."
             }
             if recommendedStatus.claudeCodeCLI != .ready {
                 return "Connect Claude Code for Claude Opus (design/pair). Best for architecture and creative work."

--- a/Sources/RepoPrompt/Features/AgentMode/Recommendations/RecommendationTypes.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Recommendations/RecommendationTypes.swift
@@ -261,14 +261,14 @@ struct RecommendationSet {
     }
 }
 
-// MARK: - Best Practice Profiles (May 2026)
+// MARK: - Best Practice Profiles (July 2026)
 
 /// Canonical best practice recommendations, versioned by date.
 /// Update `versionCode` when recommendations change significantly.
 enum BestPracticeProfiles {
     /// Bump when the table changes (used for gating mutes/badge).
     /// Format: YYYYMM
-    static let versionCode: Int = 202_606
+    static let versionCode: Int = 202_607
     static let tableTitle = "Best Models by Use Case (GPT-5.5)"
 
     struct UseCase {
@@ -297,7 +297,7 @@ enum BestPracticeProfiles {
         agentKind: .codexExec,
         agentModel: .gpt55CodexLow,
         strengths: [
-            "Fast default for explore, discovery, and implementation",
+            "Fast default for explore, discovery, and lightweight implementation",
             "Strong reasoning during agentic tool use",
             "Lower usage burn than higher GPT-5.5 efforts",
             "Codex-only GPT-5.5 via Codex CLI"
@@ -363,12 +363,12 @@ enum BestPracticeProfiles {
 
     static let claudeStrengths = """
     Claude Opus 4.6 remains great for editing-heavy work and careful file modifications. \
-    GPT-5.5 Low via Codex CLI is now our default recommendation for explore, discovery, and general agentic work.
+    GPT-5.5 Low via Codex CLI is now our default recommendation for explore, discovery, and lightweight agentic work.
     """
 
     static let gpt5HighStrengths = """
     GPT-5.5 Low/High via Codex CLI provides strong reasoning without extended wait times. \
-    Low is recommended for explore, discovery, and default implementation; High is recommended for Oracle, review, and pair agents. \
+    Low is recommended for explore and discovery; Medium is recommended for Engineer/default implementation; High is recommended for Oracle, review, and pair agents. \
     XHigh offers maximum reasoning but can exhaust usage limits quickly.
     """
 
@@ -382,8 +382,8 @@ enum BestPracticeProfiles {
     static let codexVsOpenAIExplanation = """
     GPT-5.5 is available to RepoPrompt through Codex CLI; do not configure it as an OpenAI API/OpenRouter model.
 
-    Use GPT‑5.5 Low via Codex CLI for Context Builder discovery, explore, and default agentic implementation, \
-    and GPT‑5.5 High via Codex CLI for Oracle, review, and pair-agent work. Use GPT‑5.5 Pro for ChatGPT Pro export/planning.
+    Use GPT‑5.5 Low via Codex CLI for Context Builder discovery and explore, \
+    GPT‑5.5 Medium for Engineer/default implementation, and GPT‑5.5 High for Oracle, review, and pair-agent work. Use GPT‑5.5 Pro for ChatGPT Pro export/planning.
     """
 
     static let contextBuilderRationale = "Codex with GPT-5.5 Low provides the best Context Builder/discovery default – strong codebase exploration with practical usage burn."

--- a/Tests/RepoPromptTests/AgentMode/MCPAgentRoleDefaultsServiceTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/MCPAgentRoleDefaultsServiceTests.swift
@@ -28,7 +28,7 @@ final class MCPAgentRoleDefaultsServiceTests: XCTestCase {
         XCTAssertEqual(resolutions[0].recommended.agent, .codexExec)
         XCTAssertEqual(resolutions[0].recommended.modelRaw, AgentModel.gpt55CodexLow.rawValue)
         XCTAssertEqual(resolutions[1].recommended.agent, .codexExec)
-        XCTAssertEqual(resolutions[1].recommended.modelRaw, AgentModel.gpt55CodexLow.rawValue)
+        XCTAssertEqual(resolutions[1].recommended.modelRaw, AgentModel.gpt55CodexMedium.rawValue)
         XCTAssertEqual(resolutions[2].recommended.agent, .codexExec)
         XCTAssertEqual(resolutions[2].recommended.modelRaw, AgentModel.gpt55CodexHigh.rawValue)
         XCTAssertEqual(resolutions[3].recommended.agent, .codexExec)


### PR DESCRIPTION
## Summary
- bump the MCP `engineer` role default from GPT-5.5 Low to GPT-5.5 Medium
- keep Explore, Context Builder, Pair, Design, Oracle/planning, and fallbacks unchanged
- update recommendation copy and schema version so guidance aligns with the new Engineer default
- update the existing focused role-default assertion only; no new tests or debug lines added

## Validation
- `make dev-test FILTER=MCPAgentRoleDefaultsServiceTests`
- `make dev-format` (0 files formatted)
- `make dev-lint`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh commit`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh push`

## Review notes
- Consulted Claude Fable 5 after the patch; applied its must-fix feedback to avoid changing historical changelog notes.
