### PR TITLE
Refresh approved contributors

### DIFF
--- a/.github/APPROVED_CONTRIBUTORS
+++ b/.github/APPROVED_CONTRIBUTORS
@@ -570,6 +570,7 @@ RadRebelSam pr
 rahulvrane pr
 rahulxsomething pr
 RameezShuhaib pr
+ranvier2d2 pr
 raphaelluethy pr
 ratulsarna pr
 raydocs pr

--- a/.github/APPROVED_CONTRIBUTORS
+++ b/.github/APPROVED_CONTRIBUTORS
@@ -24,6 +24,7 @@ abhshkt pr
 abyssbugg pr
 achiu3q pr
 aconcepcion pr
+adamarul pr
 adamhelfgott pr
 adamkmccarthy pr
 adampearse pr
@@ -312,7 +313,9 @@ helpimfalling pr
 HendrikReh pr
 henrycarrero pr
 heomin86 pr
+HeroRushGo pr
 heyalchang pr
+hghallTAZ pr
 hierosir1984 pr
 highlandhodl pr
 hmottestad pr
@@ -518,6 +521,7 @@ Nitron pr
 nkeat12 pr
 NKHN-AU pr
 nkraus pr
+NomDeBits pr
 NoRKin pr
 notmyalias pr
 nstranquist pr
@@ -563,8 +567,9 @@ qtm pr
 Qwantime pr
 radosek pr
 RadRebelSam pr
+rahulvrane pr
 rahulxsomething pr
-rameezshuhaib pr
+RameezShuhaib pr
 raphaelluethy pr
 ratulsarna pr
 raydocs pr
@@ -586,6 +591,7 @@ RoeeJ pr
 rohanp2051 pr
 RomainCrz pr
 rondered pr
+Rossnkama pr
 rpalermodrums pr
 rshagiev pr
 rwblackburn pr
@@ -630,6 +636,7 @@ smat-dev pr
 sodiumsun pr
 Sophanos pr
 sounart pr
+spazbg pr
 sportsandfragrance pr
 Srini-B pr
 staceymoore pr


### PR DESCRIPTION
## Summary
Refresh the approved contributor allowlist from live customer claims while preserving existing previously added entries.

## Counts
- Previous contributor count: 758
- New contributor count: 766
- Claims-resolved GitHub users this run: 763
- Preserved existing non-claims entries: 3

## Unresolved claim-form IDs
- TeamLandiLTD (`Organization`, not a user account)
- Tyschultz7 (`not_found`)
- ahafonof (`not_found`)
- hsinskip (`not_found`)
- mrbagels (`not_found`)
- vchepeli (`not_found`)
- woody-chin (`not_found`)

## Validation
- `make guardrails`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh commit`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh push`
