### PR TITLE
Fix bound-tab token cache freshness

### DIFF
--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+TokenStats.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+TokenStats.swift
@@ -195,23 +195,25 @@ extension MCPServerViewModel {
             )
             incompleteComponents.formUnion(cachedSnapshot.incompleteComponents ?? [])
             let orderedIncomplete = Self.orderedIncompleteComponents(incompleteComponents)
-            if !incompleteComponents.isEmpty {
-                enqueueVirtualTokenRefresh(
-                    signature: signature,
-                    context: context,
-                    effectiveSelection: effectiveSelection,
-                    resolvedContext: resolvedContext,
-                    collections: collections,
-                    lookupContext: lookupContext
-                )
-            }
+            // The virtual-token signature intentionally captures logical selection and prompt
+            // shape, but not file-content, search-catalog, or codemap-authority generations.
+            // Treat every cache hit as a stale lower-bound and refresh in the background so
+            // bound agent tabs cannot permanently report obsolete token totals as fresh.
+            enqueueVirtualTokenRefresh(
+                signature: signature,
+                context: context,
+                effectiveSelection: effectiveSelection,
+                resolvedContext: resolvedContext,
+                collections: collections,
+                lookupContext: lookupContext
+            )
             return MCPPreparedTokenAccounting(
                 entryResultsByFileID: cachedSnapshot.entryResultsByFileID,
                 breakdown: cachedSnapshot.breakdown,
                 tokenAccounting: .init(
-                    status: incompleteComponents.isEmpty ? "fresh" : "stale",
+                    status: "stale",
                     source: "bound_tab_cache",
-                    refreshPending: !incompleteComponents.isEmpty,
+                    refreshPending: true,
                     incompleteComponents: orderedIncomplete
                 ),
                 activePublishedSnapshot: nil

--- a/Tests/RepoPromptTests/MCP/MCPSelectionReplyFreshnessTests.swift
+++ b/Tests/RepoPromptTests/MCP/MCPSelectionReplyFreshnessTests.swift
@@ -1165,6 +1165,7 @@ final class MCPSelectionReplyFreshnessTests: XCTestCase {
             }
             XCTAssertEqual(window.mcpServer.virtualTokenRefreshTaskCountForTesting(), 0)
 
+            let startsBeforeCacheHits = window.mcpServer.virtualTokenRefreshStartCountForTesting()
             let firstCachedReply = await window.mcpServer.buildCurrentSelectionReply(
                 includeBlocks: false,
                 display: .relative,
@@ -1178,7 +1179,12 @@ final class MCPSelectionReplyFreshnessTests: XCTestCase {
                 lookupContext: .visibleWorkspace
             )
             XCTAssertEqual(firstCachedReply.tokenAccounting?.source, "bound_tab_cache")
+            XCTAssertEqual(firstCachedReply.tokenAccounting?.status, "stale")
+            XCTAssertTrue(firstCachedReply.tokenAccounting?.refreshPending == true)
             XCTAssertEqual(secondCachedReply.tokenAccounting?.source, "bound_tab_cache")
+            XCTAssertEqual(secondCachedReply.tokenAccounting?.status, "stale")
+            XCTAssertTrue(secondCachedReply.tokenAccounting?.refreshPending == true)
+            XCTAssertEqual(window.mcpServer.virtualTokenRefreshStartCountForTesting(), startsBeforeCacheHits + 2)
         }
     #endif
 


### PR DESCRIPTION
## Summary
- Treat every bound-tab virtual-token cache hit as stale and refresh-pending.
- Always enqueue the background virtual-token refresh on bound-tab cache hits.
- Add regression coverage that distinct cached signatures schedule refreshes and report stale cache metadata.

## Why
The virtual-token cache signature does not include file-content, search-index, or codemap-authority generations. Reporting cache hits as fresh can leave bound agent tabs with permanently obsolete token totals. This restores the conservative 1.0.22 behavior for the 1.0.23 RC hotfix path.

## Validation
- `make dev-format`
- `make dev-test FILTER=MCPSelectionReplyFreshnessTests/testBoundMCPTokenRefreshesForDistinctSignaturesDoNotCancelEachOther`
- `make dev-lint`
- `make dev-swift-build PRODUCT=RepoPrompt`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh commit`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh push`
- Claude Fable 5 read-only review: no release blockers; ship it.
