### PR TITLE
Back off token recount selection retries

### DIFF
--- a/Sources/RepoPrompt/Features/Prompt/ViewModels/TokenCountingViewModel.swift
+++ b/Sources/RepoPrompt/Features/Prompt/ViewModels/TokenCountingViewModel.swift
@@ -73,6 +73,8 @@ class TokenCountingViewModel: ObservableObject {
     // MARK: - Private Properties
 
     private static let tokenUpdateDebounceNanoseconds: UInt64 = 500_000_000
+    private static let maxSelectionConsistencyRetryCount = 5
+    private static let maxSelectionConsistencyRetryDelayNanoseconds: UInt64 = 5_000_000_000
 
     private let tokenCalculationService = TokenCalculationService()
     private let promptContextAccountingService = PromptContextAccountingService()
@@ -86,6 +88,8 @@ class TokenCountingViewModel: ObservableObject {
     private var lastObservedSelectionObservationRevision: UInt64 = 0
     private var lastPredominantLanguage: String = "Swift"
     private var automaticRecountSuspendDepth: Int = 0
+    private var selectionConsistencyRetryCount = 0
+    private var shouldUseSelectionConsistencyRetryBackoffForNextSelectionRecount = false
     private var lastPublishedSelection: StoredSelection?
     #if DEBUG
         private var debugBeforeTokenCalculationForTesting: (@MainActor @Sendable () async -> Void)?
@@ -277,10 +281,16 @@ class TokenCountingViewModel: ObservableObject {
         }
 
         let generation = tokenCountSchedulerGeneration
+        let usesSelectionConsistencyRetryBackoff = shouldUseSelectionConsistencyRetryBackoffForNextSelectionRecount
+            && pendingDirty.contains(.selection)
+        shouldUseSelectionConsistencyRetryBackoffForNextSelectionRecount = false
+        let debounceNanoseconds = tokenCountUpdateDebounceNanoseconds(
+            useSelectionConsistencyRetryBackoff: usesSelectionConsistencyRetryBackoff
+        )
         tokenUpdateDebounceTask?.cancel()
         tokenUpdateDebounceTask = Task { @MainActor [weak self] in
             do {
-                try await Task.sleep(nanoseconds: Self.tokenUpdateDebounceNanoseconds)
+                try await Task.sleep(nanoseconds: debounceNanoseconds)
             } catch {
                 return
             }
@@ -293,6 +303,29 @@ class TokenCountingViewModel: ObservableObject {
             tokenUpdateDebounceTask = nil
             startPendingTokenCountUpdate(generation: generation)
         }
+    }
+
+    private func tokenCountUpdateDebounceNanoseconds(useSelectionConsistencyRetryBackoff: Bool) -> UInt64 {
+        guard useSelectionConsistencyRetryBackoff,
+              selectionConsistencyRetryCount > 0
+        else {
+            return Self.tokenUpdateDebounceNanoseconds
+        }
+        let retryDelay = UInt64(selectionConsistencyRetryCount) * Self.tokenUpdateDebounceNanoseconds * 2
+        return min(retryDelay, Self.maxSelectionConsistencyRetryDelayNanoseconds)
+    }
+
+    private func recordSelectionConsistencyRetry() {
+        selectionConsistencyRetryCount = min(
+            selectionConsistencyRetryCount + 1,
+            Self.maxSelectionConsistencyRetryCount
+        )
+        shouldUseSelectionConsistencyRetryBackoffForNextSelectionRecount = true
+    }
+
+    private func resetSelectionConsistencyRetry() {
+        selectionConsistencyRetryCount = 0
+        shouldUseSelectionConsistencyRetryBackoffForNextSelectionRecount = false
     }
 
     private func startPendingTokenCountUpdate(generation: UInt64) {
@@ -348,6 +381,7 @@ class TokenCountingViewModel: ObservableObject {
 
     private func recordSelectionProjectionChanged() {
         selectionObservationRevision &+= 1
+        resetSelectionConsistencyRetry()
         markDirty(.selection)
     }
 
@@ -422,6 +456,30 @@ class TokenCountingViewModel: ObservableObject {
 
         func tokenCalculationStartCountForTesting() -> Int {
             debugTokenCalculationStartCount
+        }
+
+        func selectionConsistencyRetryCountForTesting() -> Int {
+            selectionConsistencyRetryCount
+        }
+
+        func selectionConsistencyRetryBackoffPendingForTesting() -> Bool {
+            shouldUseSelectionConsistencyRetryBackoffForNextSelectionRecount
+        }
+
+        func recordSelectionConsistencyRetryForTesting() {
+            recordSelectionConsistencyRetry()
+        }
+
+        func recordSelectionProjectionChangedForTesting() {
+            recordSelectionProjectionChanged()
+        }
+
+        func tokenCountUpdateDebounceNanosecondsForTesting(
+            useSelectionConsistencyRetryBackoff: Bool = true
+        ) -> UInt64 {
+            tokenCountUpdateDebounceNanoseconds(
+                useSelectionConsistencyRetryBackoff: useSelectionConsistencyRetryBackoff
+            )
         }
 
         func debugTokenRecountStateFields() -> [String: String] {
@@ -772,9 +830,11 @@ class TokenCountingViewModel: ObservableObject {
                     fields: ["duration": consistencyStartMS.map { PromptTokenRecountDiagnostics.formatElapsedMS(since: $0) } ?? "notMeasured"]
                 )
             #endif
+            recordSelectionConsistencyRetry()
             markDirty(.selection)
             return
         }
+        resetSelectionConsistencyRetry()
         #if DEBUG
             PromptTokenRecountDiagnostics.event(
                 "tokenRecount.calculate.selectionConsistent",

--- a/Tests/RepoPromptTests/MCP/MCPSelectionReplyFreshnessTests.swift
+++ b/Tests/RepoPromptTests/MCP/MCPSelectionReplyFreshnessTests.swift
@@ -845,6 +845,34 @@ final class MCPSelectionReplyFreshnessTests: XCTestCase {
     }
 
     #if DEBUG
+        func testSelectionConsistencyRetryDebounceBacksOffOnlyForRetrySelectionRecounts() {
+            let tokenCounter = TokenCountingViewModel()
+
+            XCTAssertEqual(tokenCounter.tokenCountUpdateDebounceNanosecondsForTesting(), 500_000_000)
+
+            tokenCounter.recordSelectionConsistencyRetryForTesting()
+            XCTAssertEqual(tokenCounter.selectionConsistencyRetryCountForTesting(), 1)
+            XCTAssertTrue(tokenCounter.selectionConsistencyRetryBackoffPendingForTesting())
+            XCTAssertEqual(
+                tokenCounter.tokenCountUpdateDebounceNanosecondsForTesting(
+                    useSelectionConsistencyRetryBackoff: false
+                ),
+                500_000_000
+            )
+            XCTAssertEqual(tokenCounter.tokenCountUpdateDebounceNanosecondsForTesting(), 1_000_000_000)
+
+            for _ in 0 ..< 6 {
+                tokenCounter.recordSelectionConsistencyRetryForTesting()
+            }
+            XCTAssertEqual(tokenCounter.selectionConsistencyRetryCountForTesting(), 5)
+            XCTAssertEqual(tokenCounter.tokenCountUpdateDebounceNanosecondsForTesting(), 5_000_000_000)
+
+            tokenCounter.recordSelectionProjectionChangedForTesting()
+            XCTAssertEqual(tokenCounter.selectionConsistencyRetryCountForTesting(), 0)
+            XCTAssertFalse(tokenCounter.selectionConsistencyRetryBackoffPendingForTesting())
+            XCTAssertEqual(tokenCounter.tokenCountUpdateDebounceNanosecondsForTesting(), 500_000_000)
+        }
+
         func testActiveMCPTokenRepliesCompleteWhileBackgroundRecountIsBlockedAndCoalesce() async throws {
             let root = try makeTemporaryRoot(name: "ActiveTokenCache")
             defer { try? FileManager.default.removeItem(at: root.deletingLastPathComponent()) }


### PR DESCRIPTION
## Summary
- Add a one-shot, capped retry backoff for token recounts when selection changes during a heavy token calculation
- Reset retry backoff on fresh selection projection changes and after a consistent recount
- Add DEBUG-only coverage for retry delay gating, cap, and reset behavior

## Validation
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh commit` ✅
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh push` ✅
- `swiftformat --config .swiftformat --lint Sources/RepoPrompt/Features/Prompt/ViewModels/TokenCountingViewModel.swift Tests/RepoPromptTests/MCP/MCPSelectionReplyFreshnessTests.swift` ✅
- `swiftlint lint --strict --config .swiftlint.yml Sources/RepoPrompt/Features/Prompt/ViewModels/TokenCountingViewModel.swift Tests/RepoPromptTests/MCP/MCPSelectionReplyFreshnessTests.swift` ✅

Notes:
- `make dev-lint` was attempted but failed in the full-repo SwiftFormat lint phase with an unrelated `environmentEntry rule timed out` error in `Sources/RepoPrompt/Infrastructure/WorkspaceContext/Models/WorkspaceCodemapLiveOverlayModels.swift`.
- Focused XCTest compile was previously attempted but did not reach test execution before being canceled due a very long fresh worktree compile.
