### PR TITLE
Refresh approved contributors

### DIFF
--- a/.github/APPROVED_CONTRIBUTORS
+++ b/.github/APPROVED_CONTRIBUTORS
@@ -24,6 +24,7 @@ abhshkt pr
 abyssbugg pr
 achiu3q pr
 aconcepcion pr
+adamarul pr
 adamhelfgott pr
 adamkmccarthy pr
 adampearse pr
@@ -246,6 +247,7 @@ enzodesena pr
 eolach pr
 erauner12 pr
 erikdrouhard pr
+erikois pr
 erodriguezh pr
 ethan-wickstrom pr
 eugene1g pr
@@ -312,7 +314,9 @@ helpimfalling pr
 HendrikReh pr
 henrycarrero pr
 heomin86 pr
+HeroRushGo pr
 heyalchang pr
+hghallTAZ pr
 hierosir1984 pr
 highlandhodl pr
 hmottestad pr
@@ -518,6 +522,7 @@ Nitron pr
 nkeat12 pr
 NKHN-AU pr
 nkraus pr
+NomDeBits pr
 NoRKin pr
 notmyalias pr
 nstranquist pr
@@ -529,6 +534,7 @@ OCPdev25 pr
 OCWC22 pr
 oegedijk pr
 olety pr
+olivier-auber pr
 OlivierPineau pr
 OmarAlShishani pr
 Omoeba pr
@@ -563,8 +569,10 @@ qtm pr
 Qwantime pr
 radosek pr
 RadRebelSam pr
+rahulvrane pr
 rahulxsomething pr
 rameezshuhaib pr
+ranvier2d2 pr
 raphaelluethy pr
 ratulsarna pr
 raydocs pr
@@ -586,6 +594,7 @@ RoeeJ pr
 rohanp2051 pr
 RomainCrz pr
 rondered pr
+Rossnkama pr
 rpalermodrums pr
 rshagiev pr
 rwblackburn pr
@@ -630,6 +639,7 @@ smat-dev pr
 sodiumsun pr
 Sophanos pr
 sounart pr
+spazbg pr
 sportsandfragrance pr
 Srini-B pr
 staceymoore pr


### PR DESCRIPTION
## Summary
- Refreshed `.github/APPROVED_CONTRIBUTORS` from live customer claims.
- Previous contributor count: 758.
- New contributor count: 768.
- Preserved existing approved entries that were not present in the live claims refresh.

## Unresolved claim-form IDs
- `TeamLandiLTD` (`not_user`, resolved to an organization)
- `Tyschultz7` (`not_found`)
- `ahafonof` (`not_found`)
- `hsinskip` (`not_found`)
- `mrbagels` (`not_found`)
- `vchepeli` (`not_found`)
- `woody-chin` (`not_found`)
