### PR TITLE
Stabilize CI app tests with sharding and lifecycle cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,12 +33,25 @@ jobs:
         run: make release-selftest
 
   build-and-test:
-    name: Build and Test
+    name: Build and Test (app shard ${{ matrix.shard }})
     runs-on: macos-26
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
 
+      - name: Restore SwiftPM build cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            .build
+            Packages/RepoPromptAgentProviders/.build
+          key: ${{ runner.os }}-${{ runner.arch }}-swiftpm-${{ hashFiles('Package.swift', 'Package.resolved', 'Packages/RepoPromptAgentProviders/Package.swift', 'Packages/RepoPromptAgentProviders/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-swiftpm-
 
       - name: Build app product
         run: swift build --product RepoPrompt
@@ -52,12 +65,39 @@ jobs:
           set -euo pipefail
           # A single long-lived XCTest process accumulates suspended app-lifecycle tasks
           # and can wedge Swift's cooperative executor late in the suite on hosted runners.
-          # Preserve serial test semantics while bounding each process to one test class.
+          # Preserve serial test semantics while bounding each process to one small group.
           # The runner auto-discovers the built .xctest bundle and invokes xcrun xctest
-          # directly per suite, bypassing swift test's per-invocation package resolution
-          # overhead that can wedge silently on loaded hosted runners.
+          # directly, using ledger-backed runtime-balanced shards, slow-first ordering,
+          # and conservative batching only for fast stateless suites.
           # Retry only silent startup timeouts; assertion failures fail fast in the runner.
-          python3 Scripts/ci_app_test_runner.py --suite-timeout-seconds 180 --silent-timeout-retries 1 --silent-startup-seconds 60
+          python3 Scripts/ci_app_test_runner.py \
+            --suite-timeout-seconds 180 \
+            --silent-timeout-retries 1 \
+            --silent-startup-seconds 60 \
+            --ledger Scripts/Fixtures/test-suite-contract-ledger.tsv \
+            --strict-ledger \
+            --shard-count 4 \
+            --shard-index "${{ matrix.shard }}" \
+            --slow-first \
+            --batch-fast-suites \
+            --require-runtime-for-batching
+
+  provider-tests:
+    name: Provider Tests
+    runs-on: macos-26
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Restore SwiftPM build cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            .build
+            Packages/RepoPromptAgentProviders/.build
+          key: ${{ runner.os }}-${{ runner.arch }}-swiftpm-provider-${{ hashFiles('Package.swift', 'Package.resolved', 'Packages/RepoPromptAgentProviders/Package.swift', 'Packages/RepoPromptAgentProviders/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-swiftpm-
 
       - name: Run provider package tests
         working-directory: Packages/RepoPromptAgentProviders

--- a/Scripts/ci_app_test_runner.py
+++ b/Scripts/ci_app_test_runner.py
@@ -200,6 +200,31 @@ def discover_test_bundles(swift_binary: str, cwd: Path | None) -> dict[str, Path
     }
 
 
+def package_test_bundle(discovered: dict[str, Path]) -> Path | None:
+    """Return SwiftPM's combined package XCTest bundle when it is unambiguous."""
+    package_bundles = [
+        path
+        for name, path in discovered.items()
+        if name.endswith("PackageTests")
+    ]
+    if len(package_bundles) == 1:
+        return package_bundles[0]
+    return None
+
+
+def target_bundles_for_suites(discovered: dict[str, Path], suites: Sequence[str]) -> dict[str, Path] | None:
+    """Return exact target bundles when every selected suite target is covered.
+
+    Stale bundles from restored SwiftPM caches are ignored; only bundle names
+    matching the currently selected suite targets are routed per-target.
+    """
+    targets = {test_target_for_suite(suite) for suite in suites}
+    matching = {target: discovered[target] for target in sorted(targets) if target in discovered}
+    if targets and set(matching) == targets:
+        return matching
+    return None
+
+
 def test_target_for_suite(suite: str) -> str:
     return suite.split(".", 1)[0]
 
@@ -647,6 +672,22 @@ def plan_selected_suites(
     missing = list(plan.get("missing_suites") or [])
     if strict_ledger and missing:
         raise ValueError(f"ledger is missing discovered suites: {missing[:10]}")
+    if missing:
+        for suite in missing:
+            entry = {
+                "suite": suite,
+                "estimated_seconds": 1.0,
+                "method_count": 0,
+                "missing_runtime_count": 1,
+                "execution_tiers": [],
+                "resource_cost_tags": [],
+                "shared_state_tags": [],
+                "batch_eligible": False,
+            }
+            shard = min(plan["shards"], key=lambda item: (item["estimated_seconds"], item["index"]))
+            shard["estimated_seconds"] += entry["estimated_seconds"]
+            shard["suites"].append(entry)
+            shard["suite_count"] = len(shard["suites"])
     entries_by_suite: dict[str, SuitePlanEntry] = {}
     for shard in plan["shards"]:
         for entry in shard["suites"]:
@@ -910,7 +951,11 @@ def main(argv: list[str]) -> int:
                 # bundles are discovered.
                 test_bundle = next(iter(discovered.values()))
             elif discovered:
-                test_bundles = discovered
+                test_bundle = package_test_bundle(discovered)
+                if test_bundle is None:
+                    test_bundles = target_bundles_for_suites(discovered, suites)
+                if test_bundle is None and test_bundles is None:
+                    test_bundles = discovered
     xctest_binary = xctest_binary_path() if test_bundle is not None or test_bundles else None
 
     return run_all_suites(

--- a/Scripts/ci_app_test_runner.py
+++ b/Scripts/ci_app_test_runner.py
@@ -17,7 +17,13 @@ import threading
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable, Iterable, TextIO
+from typing import Any, Callable, Iterable, Sequence, TextIO
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from test_suite_optimizer import OptimizerError, ci_suite_plan
 
 DEFAULT_SUITE_TIMEOUT_SECONDS = 180.0
 DEFAULT_SILENT_TIMEOUT_RETRIES = 1
@@ -64,6 +70,23 @@ class OutputState:
                 first_failure_line=self.first_failure_line,
                 last_started_test=self.last_started_test,
             )
+
+
+@dataclass(frozen=True)
+class SuitePlanEntry:
+    suite: str
+    estimated_seconds: float
+    batch_eligible: bool
+
+
+@dataclass(frozen=True)
+class SuiteGroup:
+    suites: tuple[str, ...]
+    estimated_seconds: float
+
+    @property
+    def label(self) -> str:
+        return self.suites[0] if len(self.suites) == 1 else "+".join(self.suites)
 
 
 @dataclass(frozen=True)
@@ -338,6 +361,58 @@ def create_suite_process(
     )
 
 
+def suite_filter_regex(suites: Sequence[str]) -> str:
+    if not suites:
+        raise ValueError("cannot build a suite filter without suites")
+    if len(suites) == 1:
+        return suites[0]
+    return "^(?:" + "|".join(re.escape(suite) for suite in suites) + ")$"
+
+
+def create_suite_group_process(
+    suites: Sequence[str],
+    *,
+    swift_binary: str,
+    cwd: Path | None,
+    test_bundle: Path | None = None,
+    xctest_binary: list[str] | None = None,
+) -> subprocess.Popen[str]:
+    if not suites:
+        raise ValueError("cannot run an empty suite group")
+    if len(suites) == 1:
+        return create_suite_process(
+            suites[0],
+            swift_binary=swift_binary,
+            cwd=cwd,
+            test_bundle=test_bundle,
+            xctest_binary=xctest_binary,
+        )
+    if test_bundle is not None:
+        xctest_prefix = xctest_binary if xctest_binary is not None else ["xcrun", "xctest"]
+        filters: list[str] = []
+        for suite in suites:
+            filters.extend(["-XCTest", suite])
+        return subprocess.Popen(
+            [*xctest_prefix, *filters, str(test_bundle)],
+            cwd=cwd,
+            start_new_session=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        )
+    return subprocess.Popen(
+        [swift_binary, "test", "--skip-build", "--filter", suite_filter_regex(suites)],
+        cwd=cwd,
+        start_new_session=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    )
+
+
+
 def relay_output(process: subprocess.Popen[str], state: OutputState, output: TextIO) -> None:
     stream = process.stdout
     if stream is None:
@@ -537,6 +612,108 @@ def report_suite_result(result: SuiteRunResult, output: TextIO) -> None:
     )
 
 
+def validate_shard_args(shard_count: int, shard_index: int) -> None:
+    if shard_count <= 0:
+        raise ValueError("--shard-count must be greater than zero")
+    if shard_index < 1 or shard_index > shard_count:
+        raise ValueError("--shard-index must be between 1 and --shard-count")
+
+
+def plan_selected_suites(
+    suites: Sequence[str],
+    *,
+    ledger: Path | None,
+    shard_count: int,
+    shard_index: int,
+    strict_ledger: bool,
+    slow_first: bool,
+    batch_max_seconds: float,
+    require_runtime_for_batching: bool,
+) -> tuple[list[SuitePlanEntry], dict[str, Any] | None]:
+    validate_shard_args(shard_count, shard_index)
+    if ledger is None:
+        ordered = sorted(suites)
+        return [
+            SuitePlanEntry(suite=suite, estimated_seconds=1.0, batch_eligible=False)
+            for suite in ordered
+        ], None
+    plan = ci_suite_plan(
+        ledger,
+        shard_count,
+        suites=suites,
+        batch_max_seconds=batch_max_seconds,
+        require_runtime_for_batching=require_runtime_for_batching,
+    )
+    missing = list(plan.get("missing_suites") or [])
+    if strict_ledger and missing:
+        raise ValueError(f"ledger is missing discovered suites: {missing[:10]}")
+    entries_by_suite: dict[str, SuitePlanEntry] = {}
+    for shard in plan["shards"]:
+        for entry in shard["suites"]:
+            entries_by_suite[str(entry["suite"])] = SuitePlanEntry(
+                suite=str(entry["suite"]),
+                estimated_seconds=float(entry["estimated_seconds"]),
+                batch_eligible=bool(entry["batch_eligible"]),
+            )
+    selected_shard = plan["shards"][shard_index - 1]
+    selected = [entries_by_suite[str(entry["suite"])] for entry in selected_shard["suites"]]
+    if slow_first:
+        selected.sort(key=lambda entry: (-entry.estimated_seconds, entry.suite))
+    else:
+        selected.sort(key=lambda entry: entry.suite)
+    return selected, plan
+
+
+def batch_suite_entries(
+    entries: Sequence[SuitePlanEntry],
+    *,
+    batch_fast_suites: bool,
+    batch_max_suites: int,
+    batch_max_seconds: float,
+    bundle_selector: Callable[[str], Path | None],
+) -> list[SuiteGroup]:
+    if batch_max_suites <= 0:
+        raise ValueError("--batch-max-suites must be greater than zero")
+    if batch_max_seconds <= 0:
+        raise ValueError("--batch-max-seconds must be greater than zero")
+    groups: list[SuiteGroup] = []
+    pending: list[SuitePlanEntry] = []
+    pending_bundle: Path | None = None
+
+    def flush() -> None:
+        nonlocal pending, pending_bundle
+        if pending:
+            groups.append(
+                SuiteGroup(
+                    tuple(entry.suite for entry in pending),
+                    sum(entry.estimated_seconds for entry in pending),
+                )
+            )
+            pending = []
+            pending_bundle = None
+
+    for entry in entries:
+        selected_bundle = bundle_selector(entry.suite)
+        if not batch_fast_suites or not entry.batch_eligible:
+            flush()
+            groups.append(SuiteGroup((entry.suite,), entry.estimated_seconds))
+            continue
+        if (
+            pending
+            and (
+                len(pending) >= batch_max_suites
+                or sum(item.estimated_seconds for item in pending) + entry.estimated_seconds > batch_max_seconds
+                or selected_bundle != pending_bundle
+            )
+        ):
+            flush()
+        pending.append(entry)
+        pending_bundle = selected_bundle
+    flush()
+    return groups
+
+
+
 def run_all_suites(
     suites: Iterable[str],
     *,
@@ -549,7 +726,17 @@ def run_all_suites(
     test_bundle: Path | None = None,
     test_bundles: dict[str, Path] | None = None,
     xctest_binary: list[str] | None = None,
+    ledger: Path | None = None,
+    shard_count: int = 1,
+    shard_index: int = 1,
+    strict_ledger: bool = False,
+    slow_first: bool = False,
+    batch_fast_suites: bool = False,
+    batch_max_suites: int = 4,
+    batch_max_seconds: float = 5.0,
+    require_runtime_for_batching: bool = True,
 ) -> int:
+    suite_list = list(suites)
     passed_results: list[SuiteRunResult] = []
     if test_bundle is not None:
         print(
@@ -564,19 +751,51 @@ def run_all_suites(
             flush=True,
             file=output,
         )
-    for suite in suites:
-        selected_bundle = test_bundle if test_bundle is not None else bundle_for_suite(suite, test_bundles)
+    try:
+        selected_entries, plan = plan_selected_suites(
+            suite_list,
+            ledger=ledger,
+            shard_count=shard_count,
+            shard_index=shard_index,
+            strict_ledger=strict_ledger,
+            slow_first=slow_first,
+            batch_max_seconds=batch_max_seconds,
+            require_runtime_for_batching=require_runtime_for_batching,
+        )
+        groups = batch_suite_entries(
+            selected_entries,
+            batch_fast_suites=batch_fast_suites,
+            batch_max_suites=batch_max_suites,
+            batch_max_seconds=batch_max_seconds,
+            bundle_selector=lambda suite: (
+                test_bundle if test_bundle is not None else bundle_for_suite(suite, test_bundles)
+            ),
+        )
+    except (OptimizerError, ValueError) as error:
+        print(f"::error::{error}", flush=True, file=output)
+        return 1
+    if ledger is not None:
+        total = plan["shards"][shard_index - 1]["estimated_seconds"] if plan is not None else 0.0
+        print(
+            f"Selected app test shard {shard_index}/{shard_count}: "
+            f"{len(selected_entries)} suites, estimated {total:.1f}s, {len(groups)} process groups",
+            flush=True,
+            file=output,
+        )
+    for group in groups:
+        suite = group.label
+        selected_bundle = test_bundle if test_bundle is not None else bundle_for_suite(group.suites[0], test_bundles)
         if test_bundles is not None and selected_bundle is None:
             print(
-                f"::error::No XCTest bundle found for suite target {test_target_for_suite(suite)} "
+                f"::error::No XCTest bundle found for suite target {test_target_for_suite(group.suites[0])} "
                 f"while routing {suite}; available bundles: {sorted(test_bundles)}",
                 flush=True,
                 file=output,
             )
             return 1
         print(f"::group::{suite}", flush=True, file=output)
-        process_factory = lambda selected_suite: create_suite_process(  # noqa: E731
-            selected_suite,
+        process_factory = lambda _selected_suite: create_suite_group_process(  # noqa: E731
+            group.suites,
             swift_binary=swift_binary,
             cwd=cwd,
             test_bundle=selected_bundle,
@@ -630,6 +849,15 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         help="Exact built .xctest bundle name to auto-select when multiple bundles exist, "
         "for example RepoPromptTests.xctest.",
     )
+    parser.add_argument("--ledger", type=Path, default=None)
+    parser.add_argument("--shard-count", type=int, default=1)
+    parser.add_argument("--shard-index", type=int, default=1)
+    parser.add_argument("--strict-ledger", action="store_true", default=False)
+    parser.add_argument("--slow-first", action="store_true", default=False)
+    parser.add_argument("--batch-fast-suites", action="store_true", default=False)
+    parser.add_argument("--batch-max-suites", type=int, default=4)
+    parser.add_argument("--batch-max-seconds", type=float, default=5.0)
+    parser.add_argument("--require-runtime-for-batching", action="store_true", default=False)
     parser.add_argument(
         "--no-xctest-bundle",
         action="store_true",
@@ -696,6 +924,15 @@ def main(argv: list[str]) -> int:
         test_bundle=test_bundle,
         test_bundles=test_bundles,
         xctest_binary=xctest_binary,
+        ledger=args.ledger,
+        shard_count=args.shard_count,
+        shard_index=args.shard_index,
+        strict_ledger=args.strict_ledger,
+        slow_first=args.slow_first,
+        batch_fast_suites=args.batch_fast_suites,
+        batch_max_suites=args.batch_max_suites,
+        batch_max_seconds=args.batch_max_seconds,
+        require_runtime_for_batching=args.require_runtime_for_batching or args.batch_fast_suites,
     )
 
 

--- a/Scripts/ci_app_test_runner.py
+++ b/Scripts/ci_app_test_runner.py
@@ -391,7 +391,7 @@ def suite_filter_regex(suites: Sequence[str]) -> str:
         raise ValueError("cannot build a suite filter without suites")
     if len(suites) == 1:
         return suites[0]
-    return "^(?:" + "|".join(re.escape(suite) for suite in suites) + ")$"
+    return "^(?:" + "|".join(re.escape(suite) for suite in suites) + r")(/|$)"
 
 
 def create_suite_group_process(
@@ -414,11 +414,9 @@ def create_suite_group_process(
         )
     if test_bundle is not None:
         xctest_prefix = xctest_binary if xctest_binary is not None else ["xcrun", "xctest"]
-        filters: list[str] = []
-        for suite in suites:
-            filters.extend(["-XCTest", suite])
+        filter_list = ",".join(suites)
         return subprocess.Popen(
-            [*xctest_prefix, *filters, str(test_bundle)],
+            [*xctest_prefix, "-XCTest", filter_list, str(test_bundle)],
             cwd=cwd,
             start_new_session=True,
             stdout=subprocess.PIPE,

--- a/Scripts/test_ci_app_test_runner.py
+++ b/Scripts/test_ci_app_test_runner.py
@@ -318,6 +318,35 @@ class CIAppTestRunnerTests(unittest.TestCase):
         )
         self.assertIsNone(ci_app_test_runner.bundle_for_suite("MissingTarget.Tests", bundles))
 
+    def test_target_bundles_for_suites_ignores_stale_bundles_when_targets_covered(self) -> None:
+        bundles = {
+            "RepoPromptTests": Path("/fake/RepoPromptTests.xctest"),
+            "RepoPromptCEPackageTests": Path("/fake/RepoPromptCEPackageTests.xctest"),
+            "StaleTests": Path("/fake/StaleTests.xctest"),
+        }
+
+        self.assertEqual(
+            ci_app_test_runner.target_bundles_for_suites(
+                bundles,
+                ["RepoPromptTests.A", "RepoPromptTests.B"],
+            ),
+            {"RepoPromptTests": Path("/fake/RepoPromptTests.xctest")},
+        )
+
+    def test_package_test_bundle_selects_unambiguous_combined_swiftpm_bundle(self) -> None:
+        bundle = Path("/fake/RepoPromptCEPackageTests.xctest")
+        self.assertEqual(
+            ci_app_test_runner.package_test_bundle({
+                "RepoPromptCEPackageTests": bundle,
+                "StaleTests": Path("/fake/StaleTests.xctest"),
+            }),
+            bundle,
+        )
+        self.assertIsNone(ci_app_test_runner.package_test_bundle({
+            "OnePackageTests": Path("/fake/OnePackageTests.xctest"),
+            "TwoPackageTests": Path("/fake/TwoPackageTests.xctest"),
+        }))
+
     def test_create_suite_process_uses_xctest_when_bundle_provided(self) -> None:
         captured_args: list[list[str]] = []
 
@@ -585,6 +614,45 @@ class CIAppTestRunnerTests(unittest.TestCase):
         self.assertEqual(captured["test_bundles"], bundles)
         self.assertEqual(captured["xctest_binary"], ["/usr/bin/xctest"])
 
+    def test_main_prefers_combined_package_bundle_when_cache_contains_stale_bundle(self) -> None:
+        captured: dict[str, object] = {}
+
+        def fake_run_all_suites(suites, **kwargs):
+            captured["suites"] = list(suites)
+            captured["test_bundle"] = kwargs["test_bundle"]
+            captured["test_bundles"] = kwargs["test_bundles"]
+            captured["xctest_binary"] = kwargs["xctest_binary"]
+            return 0
+
+        with (
+            mock.patch.object(
+                ci_app_test_runner,
+                "list_suites",
+                return_value=["RepoPromptTests.A", "RepoPromptWorkspaceTests.B"],
+            ),
+            mock.patch.object(
+                ci_app_test_runner,
+                "discover_test_bundles",
+                return_value={
+                    "RepoPromptCEPackageTests": Path("/fake/RepoPromptCEPackageTests.xctest"),
+                    "RepoPromptTests": Path("/fake/stale/RepoPromptTests.xctest"),
+                    "RepoPromptWorkspaceTests": Path("/fake/stale/RepoPromptWorkspaceTests.xctest"),
+                    "StaleTests": Path("/fake/StaleTests.xctest"),
+                },
+            ),
+            mock.patch.object(ci_app_test_runner, "xctest_binary_path", return_value=["/usr/bin/xctest"]),
+            mock.patch.object(ci_app_test_runner, "run_all_suites", side_effect=fake_run_all_suites),
+        ):
+            exit_code = ci_app_test_runner.main([])
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(captured["suites"], ["RepoPromptTests.A", "RepoPromptWorkspaceTests.B"])
+        self.assertEqual(
+            captured["test_bundle"], Path("/fake/RepoPromptCEPackageTests.xctest")
+        )
+        self.assertIsNone(captured["test_bundles"])
+        self.assertEqual(captured["xctest_binary"], ["/usr/bin/xctest"])
+
     def test_main_uses_single_discovered_bundle_for_all_suite_targets(self) -> None:
         # SwiftPM emits one combined ``<PackageName>PackageTests.xctest`` bundle
         # whose name does not match any individual test target, so a single
@@ -751,6 +819,31 @@ class CIAppTestRunnerTests(unittest.TestCase):
                     require_runtime_for_batching=True,
                 )
 
+    def test_non_strict_ledger_includes_missing_discovered_suite_with_defaults(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            ledger = self.write_ledger(Path(tmp), [
+                {"suite": "RepoPromptTests.Known", "method": "testOne", "runtime_seconds": "1.0"},
+            ])
+            selected, plan = ci_app_test_runner.plan_selected_suites(
+                ["RepoPromptTests.Known", "RepoPromptTests.Unknown"],
+                ledger=ledger,
+                shard_count=1,
+                shard_index=1,
+                strict_ledger=False,
+                slow_first=False,
+                batch_max_seconds=5.0,
+                require_runtime_for_batching=True,
+            )
+
+        self.assertIsNotNone(plan)
+        self.assertEqual(
+            [entry.suite for entry in selected],
+            ["RepoPromptTests.Known", "RepoPromptTests.Unknown"],
+        )
+        missing = next(entry for entry in selected if entry.suite == "RepoPromptTests.Unknown")
+        self.assertEqual(missing.estimated_seconds, 1.0)
+        self.assertFalse(missing.batch_eligible)
+
     def test_batch_suite_entries_groups_only_adjacent_eligible_same_bundle(self) -> None:
         entries = [
             ci_app_test_runner.SuitePlanEntry("RepoPromptTests.A", 1.0, True),
@@ -810,6 +903,55 @@ class CIAppTestRunnerTests(unittest.TestCase):
                 str(bundle),
             ],
         )
+
+    def test_run_all_suites_batches_multiple_xctest_filters_through_one_process(self) -> None:
+        launched: list[tuple[tuple[str, ...], Path | None]] = []
+
+        def fake_create_suite_group_process(suites, **kwargs):
+            launched.append((tuple(suites), kwargs["test_bundle"]))
+            return FakeProcess([
+                "Test Case '-[RepoPromptTests.A testOne]' started.\n",
+                "Test Case '-[RepoPromptTests.B testOne]' started.\n",
+            ], returncode=0)
+
+        entries = [
+            ci_app_test_runner.SuitePlanEntry("RepoPromptTests.A", 1.0, True),
+            ci_app_test_runner.SuitePlanEntry("RepoPromptTests.B", 1.0, True),
+        ]
+        output = io.StringIO()
+        with (
+            mock.patch.object(
+                ci_app_test_runner,
+                "plan_selected_suites",
+                return_value=(entries, None),
+            ),
+            mock.patch.object(
+                ci_app_test_runner,
+                "create_suite_group_process",
+                side_effect=fake_create_suite_group_process,
+            ),
+        ):
+            exit_code = ci_app_test_runner.run_all_suites(
+                ["RepoPromptTests.A", "RepoPromptTests.B"],
+                timeout_seconds=1.0,
+                silent_timeout_retries=0,
+                swift_binary="swift",
+                cwd=None,
+                output=output,
+                test_bundle=Path("/fake/RepoPromptCEPackageTests.xctest"),
+                xctest_binary=["/usr/bin/xctest"],
+                batch_fast_suites=True,
+                batch_max_suites=4,
+                batch_max_seconds=5.0,
+            )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(
+            launched,
+            [(("RepoPromptTests.A", "RepoPromptTests.B"), Path("/fake/RepoPromptCEPackageTests.xctest"))],
+        )
+        self.assertIn("::group::RepoPromptTests.A+RepoPromptTests.B", output.getvalue())
+        self.assertIn("RepoPromptTests.B testOne", output.getvalue())
 
     def test_create_suite_group_process_uses_anchored_swift_filter_without_bundle(self) -> None:
         captured_args: list[list[str]] = []

--- a/Scripts/test_ci_app_test_runner.py
+++ b/Scripts/test_ci_app_test_runner.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import io
+import tempfile
 import time
 import unittest
 from pathlib import Path
@@ -655,6 +656,188 @@ class CIAppTestRunnerTests(unittest.TestCase):
         self.assertEqual(exit_code, 1)
         self.assertIn("did not match any built XCTest bundle", output.getvalue())
         run_all_suites.assert_not_called()
+
+    def write_ledger(self, directory: Path, rows: list[dict[str, str]]) -> Path:
+        header = [
+            "method_id",
+            "target",
+            "file",
+            "suite",
+            "method",
+            "domain",
+            "primary_contract_id",
+            "secondary_contract_tags",
+            "validation_class",
+            "layer",
+            "execution_tier",
+            "scenario_count",
+            "fixture_ids",
+            "observable_oracle",
+            "failure_risk",
+            "runtime_seconds",
+            "resource_cost_tags",
+            "shared_state_tags",
+            "lifecycle_owner",
+            "current_disposition",
+            "replacement_method_id",
+            "preserved_scenario_delta",
+            "notes",
+        ]
+        path = directory / "ledger.tsv"
+        lines = ["\t".join(header)]
+        for row in rows:
+            complete = {key: "" for key in header}
+            complete.update(
+                {
+                    "method_id": f"root/{row['suite']}/{row['method']}",
+                    "target": "root",
+                    "file": "Tests/Fake.swift",
+                    "domain": "Root",
+                    "primary_contract_id": "contract",
+                    "validation_class": "unit",
+                    "layer": "root_swiftpm",
+                    "execution_tier": "fast",
+                    "scenario_count": "1",
+                    "observable_oracle": "oracle",
+                    "failure_risk": "low",
+                    "lifecycle_owner": "owner",
+                    "current_disposition": "retain",
+                    "preserved_scenario_delta": "0",
+                }
+            )
+            complete.update(row)
+            lines.append("\t".join(complete[key] for key in header))
+        path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        return path
+
+    def test_plan_selected_suites_uses_runtime_balanced_shard_and_slow_first(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            ledger = self.write_ledger(Path(tmp), [
+                {"suite": "RepoPromptTests.Slow", "method": "testOne", "runtime_seconds": "10.0"},
+                {"suite": "RepoPromptTests.Medium", "method": "testOne", "runtime_seconds": "6.0"},
+                {"suite": "RepoPromptTests.Fast", "method": "testOne", "runtime_seconds": "1.0"},
+            ])
+            selected, plan = ci_app_test_runner.plan_selected_suites(
+                ["RepoPromptTests.Fast", "RepoPromptTests.Medium", "RepoPromptTests.Slow"],
+                ledger=ledger,
+                shard_count=2,
+                shard_index=2,
+                strict_ledger=True,
+                slow_first=True,
+                batch_max_seconds=5.0,
+                require_runtime_for_batching=True,
+            )
+
+        self.assertIsNotNone(plan)
+        self.assertEqual(
+            [entry.suite for entry in selected],
+            ["RepoPromptTests.Medium", "RepoPromptTests.Fast"],
+        )
+
+    def test_strict_ledger_rejects_missing_discovered_suite(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            ledger = self.write_ledger(Path(tmp), [
+                {"suite": "RepoPromptTests.Known", "method": "testOne", "runtime_seconds": "1.0"},
+            ])
+            with self.assertRaisesRegex(ValueError, "missing discovered suites"):
+                ci_app_test_runner.plan_selected_suites(
+                    ["RepoPromptTests.Known", "RepoPromptTests.Unknown"],
+                    ledger=ledger,
+                    shard_count=1,
+                    shard_index=1,
+                    strict_ledger=True,
+                    slow_first=False,
+                    batch_max_seconds=5.0,
+                    require_runtime_for_batching=True,
+                )
+
+    def test_batch_suite_entries_groups_only_adjacent_eligible_same_bundle(self) -> None:
+        entries = [
+            ci_app_test_runner.SuitePlanEntry("RepoPromptTests.A", 1.0, True),
+            ci_app_test_runner.SuitePlanEntry("RepoPromptTests.B", 1.5, True),
+            ci_app_test_runner.SuitePlanEntry("RepoPromptTests.C", 1.0, False),
+            ci_app_test_runner.SuitePlanEntry("OtherTests.D", 1.0, True),
+        ]
+        groups = ci_app_test_runner.batch_suite_entries(
+            entries,
+            batch_fast_suites=True,
+            batch_max_suites=4,
+            batch_max_seconds=5.0,
+            bundle_selector=lambda suite: (
+                Path("/fake/RepoPromptTests.xctest")
+                if suite.startswith("RepoPrompt")
+                else Path("/fake/OtherTests.xctest")
+            ),
+        )
+
+        self.assertEqual(
+            [group.suites for group in groups],
+            [
+                ("RepoPromptTests.A", "RepoPromptTests.B"),
+                ("RepoPromptTests.C",),
+                ("OtherTests.D",),
+            ],
+        )
+
+    def test_create_suite_group_process_repeats_xctest_filters_for_batch(self) -> None:
+        captured_args: list[list[str]] = []
+
+        class FakePopen:
+            def __init__(self, args, **kwargs) -> None:
+                captured_args.append(args)
+                self.pid = -1
+                self.stdout = None
+                self.returncode = 0
+
+        bundle = Path("/fake/Tests.xctest")
+        with mock.patch.object(ci_app_test_runner.subprocess, "Popen", side_effect=FakePopen):
+            ci_app_test_runner.create_suite_group_process(
+                ["RepoPromptTests.A", "RepoPromptTests.B"],
+                swift_binary="swift",
+                cwd=None,
+                test_bundle=bundle,
+                xctest_binary=["/usr/bin/xctest"],
+            )
+
+        self.assertEqual(
+            captured_args[0],
+            [
+                "/usr/bin/xctest",
+                "-XCTest",
+                "RepoPromptTests.A",
+                "-XCTest",
+                "RepoPromptTests.B",
+                str(bundle),
+            ],
+        )
+
+    def test_create_suite_group_process_uses_anchored_swift_filter_without_bundle(self) -> None:
+        captured_args: list[list[str]] = []
+
+        class FakePopen:
+            def __init__(self, args, **kwargs) -> None:
+                captured_args.append(args)
+                self.pid = -1
+                self.stdout = None
+                self.returncode = 0
+
+        with mock.patch.object(ci_app_test_runner.subprocess, "Popen", side_effect=FakePopen):
+            ci_app_test_runner.create_suite_group_process(
+                ["RepoPromptTests.A", "RepoPromptTests.B"],
+                swift_binary="swift",
+                cwd=None,
+            )
+
+        self.assertEqual(
+            captured_args[0],
+            [
+                "swift",
+                "test",
+                "--skip-build",
+                "--filter",
+                "^(?:RepoPromptTests\\.A|RepoPromptTests\\.B)$",
+            ],
+        )
 
 
 if __name__ == "__main__":

--- a/Scripts/test_ci_app_test_runner.py
+++ b/Scripts/test_ci_app_test_runner.py
@@ -872,7 +872,7 @@ class CIAppTestRunnerTests(unittest.TestCase):
             ],
         )
 
-    def test_create_suite_group_process_repeats_xctest_filters_for_batch(self) -> None:
+    def test_create_suite_group_process_uses_single_comma_separated_xctest_filter_for_batch(self) -> None:
         captured_args: list[list[str]] = []
 
         class FakePopen:
@@ -897,9 +897,7 @@ class CIAppTestRunnerTests(unittest.TestCase):
             [
                 "/usr/bin/xctest",
                 "-XCTest",
-                "RepoPromptTests.A",
-                "-XCTest",
-                "RepoPromptTests.B",
+                "RepoPromptTests.A,RepoPromptTests.B",
                 str(bundle),
             ],
         )
@@ -953,7 +951,16 @@ class CIAppTestRunnerTests(unittest.TestCase):
         self.assertIn("::group::RepoPromptTests.A+RepoPromptTests.B", output.getvalue())
         self.assertIn("RepoPromptTests.B testOne", output.getvalue())
 
-    def test_create_suite_group_process_uses_anchored_swift_filter_without_bundle(self) -> None:
+    def test_suite_filter_regex_matches_swiftpm_suite_method_identifiers(self) -> None:
+        pattern = ci_app_test_runner.suite_filter_regex(["RepoPromptTests.A", "RepoPromptTests.B"])
+
+        self.assertRegex("RepoPromptTests.A/testOne", pattern)
+        self.assertRegex("RepoPromptTests.B/testTwo", pattern)
+        self.assertRegex("RepoPromptTests.A", pattern)
+        self.assertNotRegex("RepoPromptTests.Ab/testOne", pattern)
+        self.assertNotRegex("OtherTests.A/testOne", pattern)
+
+    def test_create_suite_group_process_uses_suite_prefix_swift_filter_without_bundle(self) -> None:
         captured_args: list[list[str]] = []
 
         class FakePopen:
@@ -977,7 +984,7 @@ class CIAppTestRunnerTests(unittest.TestCase):
                 "test",
                 "--skip-build",
                 "--filter",
-                "^(?:RepoPromptTests\\.A|RepoPromptTests\\.B)$",
+                "^(?:RepoPromptTests\\.A|RepoPromptTests\\.B)(/|$)",
             ],
         )
 

--- a/Scripts/test_suite_optimizer.py
+++ b/Scripts/test_suite_optimizer.py
@@ -570,6 +570,150 @@ def read_ledger_rows(path: Path) -> list[LedgerTest]:
     return rows
 
 
+
+
+def read_ledger_dict_rows(path: Path) -> list[dict[str, str]]:
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle, delimiter="\t")
+        if reader.fieldnames != LEDGER_COLUMNS:
+            raise OptimizerError("ledger columns do not match the required schema")
+        rows = [dict(row) for row in reader]
+    ids = [str(row.get("method_id") or "") for row in rows]
+    if len(ids) != len(set(ids)):
+        raise OptimizerError("ledger contains duplicate method_id rows")
+    # Reuse typed validation for runtime_seconds and execution_tier checks.
+    read_ledger_rows(path)
+    return rows
+
+
+def baseline_runtime_timings(path: Path) -> dict[tuple[str, str, str], float]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    target = str(payload.get("target") or "root")
+    rows = payload.get("slowest_tests")
+    if not isinstance(rows, list):
+        raise OptimizerError("baseline artifact is missing slowest_tests")
+    timings: dict[tuple[str, str, str], float] = {}
+    for index, row in enumerate(rows):
+        if not isinstance(row, dict):
+            raise OptimizerError(f"slowest_tests[{index}] is not an object")
+        suite = str(row.get("suite") or "")
+        method = str(row.get("method") or "")
+        if not suite or not method:
+            raise OptimizerError(f"slowest_tests[{index}] is missing suite or method")
+        seconds_value = row.get("median_seconds")
+        if seconds_value is None:
+            seconds_value = row.get("observed_p95_seconds")
+        if seconds_value is None:
+            raise OptimizerError(f"slowest_tests[{index}] is missing median_seconds")
+        try:
+            seconds = float(seconds_value)
+        except (TypeError, ValueError) as exc:
+            raise OptimizerError(f"invalid baseline runtime for {target}/{suite}/{method}") from exc
+        if not math.isfinite(seconds) or seconds < 0:
+            raise OptimizerError(f"invalid baseline runtime for {target}/{suite}/{method}")
+        timings[(target, suite, method)] = seconds
+    return timings
+
+
+def runtime_import(ledger: Path, baseline_path: Path, output: Path) -> dict[str, Any]:
+    if output.exists():
+        raise OptimizerError(f"refusing to overwrite existing ledger: {output}")
+    rows = read_ledger_dict_rows(ledger)
+    timings = baseline_runtime_timings(baseline_path)
+    timing_keys = set(timings)
+    ledger_keys = {(row["target"], row["suite"], row["method"]) for row in rows}
+    updated = 0
+    unchanged = 0
+    for row in rows:
+        key = (row["target"], row["suite"], row["method"])
+        seconds = timings.get(key)
+        if seconds is None:
+            unchanged += 1
+            continue
+        formatted = f"{seconds:.6f}"
+        if row.get("runtime_seconds") == formatted:
+            unchanged += 1
+            continue
+        row["runtime_seconds"] = formatted
+        updated += 1
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with output.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=LEDGER_COLUMNS, delimiter="\t", lineterminator="\n")
+        writer.writeheader()
+        writer.writerows(rows)
+    return {
+        "rows_updated": updated,
+        "rows_unchanged": unchanged,
+        "artifact_methods_missing_from_ledger": [
+            f"{target}/{suite}/{method}" for target, suite, method in sorted(timing_keys - ledger_keys)
+        ],
+        "ledger_methods_missing_from_artifact": [
+            f"{target}/{suite}/{method}" for target, suite, method in sorted(ledger_keys - timing_keys)
+        ],
+        "output": str(output),
+    }
+
+
+def ci_suite_plan(
+    ledger: Path,
+    shard_count: int,
+    suites: Sequence[str] | None = None,
+    default_runtime_seconds: float = 1.0,
+    batch_max_seconds: float = 5.0,
+    require_runtime_for_batching: bool = True,
+) -> dict[str, Any]:
+    if shard_count <= 0:
+        raise OptimizerError("--shards must be greater than zero")
+    if default_runtime_seconds <= 0:
+        raise OptimizerError("default runtime seconds must be greater than zero")
+    rows = [row for row in read_ledger_rows(ledger) if row.target == "root"]
+    suite_filter = set(suites or [])
+    if suite_filter:
+        rows = [row for row in rows if row.suite in suite_filter]
+    grouped: dict[str, list[LedgerTest]] = defaultdict(list)
+    for row in rows:
+        grouped[row.suite].append(row)
+    missing_suites = sorted(suite_filter - set(grouped))
+    suite_entries: list[dict[str, Any]] = []
+    for suite, suite_rows in sorted(grouped.items()):
+        runtime_values = [row.runtime_seconds for row in suite_rows]
+        missing_runtime_count = sum(value is None for value in runtime_values)
+        estimated = sum(value if value is not None else default_runtime_seconds for value in runtime_values)
+        execution_tiers = sorted({row.execution_tier for row in suite_rows})
+        resource_tags = sorted({tag for row in suite_rows for tag in row.resource_cost_tags})
+        shared_tags = sorted({tag for row in suite_rows for tag in row.shared_state_tags})
+        batch_eligible = (
+            (not require_runtime_for_batching or missing_runtime_count == 0)
+            and not shared_tags
+            and not resource_tags
+            and not (set(execution_tiers) & HEAVY_TEST_EXECUTION_TIERS)
+            and estimated <= batch_max_seconds
+        )
+        suite_entries.append({
+            "suite": suite,
+            "estimated_seconds": estimated,
+            "method_count": len(suite_rows),
+            "missing_runtime_count": missing_runtime_count,
+            "execution_tiers": execution_tiers,
+            "resource_cost_tags": resource_tags,
+            "shared_state_tags": shared_tags,
+            "batch_eligible": batch_eligible,
+        })
+    shards = [{"index": index + 1, "estimated_seconds": 0.0, "suites": []} for index in range(shard_count)]
+    for entry in sorted(suite_entries, key=lambda item: (-float(item["estimated_seconds"]), str(item["suite"]))):
+        shard = min(shards, key=lambda item: (item["estimated_seconds"], item["index"]))
+        shard["estimated_seconds"] += float(entry["estimated_seconds"])
+        shard["suites"].append(entry)
+    for shard in shards:
+        shard["suite_count"] = len(shard["suites"])
+    return {
+        "target": "root",
+        "shard_count": shard_count,
+        "default_runtime_seconds": default_runtime_seconds,
+        "missing_suites": missing_suites,
+        "shards": shards,
+    }
+
 def source_domains_for_changed_path(path: str) -> set[str]:
     parts = Path(path).parts
     if len(parts) >= 4 and parts[0] == "Sources" and parts[1] == "RepoPrompt":
@@ -2150,6 +2294,19 @@ def build_parser() -> argparse.ArgumentParser:
     shard_parser.add_argument("--shards", type=int, required=True)
     shard_parser.add_argument("--include-heavy", action="store_true")
 
+    runtime_import_parser = subparsers.add_parser("runtime-import", help="write a candidate ledger with runtime_seconds from a baseline artifact")
+    runtime_import_parser.add_argument("--ledger", type=Path, required=True)
+    runtime_import_parser.add_argument("--baseline", type=Path, required=True)
+    runtime_import_parser.add_argument("--output", type=Path, required=True)
+
+    ci_suite_plan_parser = subparsers.add_parser("ci-suite-plan", help="partition root XCTest suites for hosted CI planning")
+    ci_suite_plan_parser.add_argument("--ledger", type=Path, required=True)
+    ci_suite_plan_parser.add_argument("--shards", type=int, required=True)
+    ci_suite_plan_parser.add_argument("--suite", action="append", default=[])
+    ci_suite_plan_parser.add_argument("--default-runtime-seconds", type=float, default=1.0)
+    ci_suite_plan_parser.add_argument("--batch-max-seconds", type=float, default=5.0)
+    ci_suite_plan_parser.add_argument("--allow-missing-runtime-for-batching", action="store_true")
+
     verify_parser = subparsers.add_parser("verify-ledger", help="re-list tests and reconcile ledger rows")
     verify_parser.add_argument("--ledger", type=Path, required=True)
     verify_parser.add_argument(
@@ -2213,6 +2370,17 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
         elif args.command == "shard-plan":
             payload = shard_root_tests(args.ledger, args.shards, include_heavy=args.include_heavy)
+        elif args.command == "runtime-import":
+            payload = runtime_import(args.ledger, args.baseline, args.output)
+        elif args.command == "ci-suite-plan":
+            payload = ci_suite_plan(
+                args.ledger,
+                args.shards,
+                suites=args.suite,
+                default_runtime_seconds=args.default_runtime_seconds,
+                batch_max_seconds=args.batch_max_seconds,
+                require_runtime_for_batching=not args.allow_missing_runtime_for_batching,
+            )
         elif args.command == "verify-ledger":
             payload = verify_ledger(repo_root, args.ledger, args.list_timeout_seconds)
         else:

--- a/Scripts/test_test_suite_optimizer.py
+++ b/Scripts/test_test_suite_optimizer.py
@@ -753,6 +753,152 @@ class SourceAndLedgerTests(unittest.TestCase):
         self.assertIn("shared_state_tag_counts", payload["shards"][0])
         self.assertIn("parallelization_warning", payload)
 
+    def test_runtime_import_updates_matching_rows_and_preserves_order(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            ledger = root / "ledger.tsv"
+            output = root / "candidate.tsv"
+            baseline = root / "baseline.json"
+            self.write_ledger(
+                ledger,
+                [
+                    {
+                        "method_id": "root/RepoPromptTests.A/testOne",
+                        "target": "root",
+                        "suite": "RepoPromptTests.A",
+                        "method": "testOne",
+                        "execution_tier": "routine",
+                    },
+                    {
+                        "method_id": "root/RepoPromptTests.B/testTwo",
+                        "target": "root",
+                        "suite": "RepoPromptTests.B",
+                        "method": "testTwo",
+                        "execution_tier": "routine",
+                        "runtime_seconds": "1.000000",
+                    },
+                ],
+            )
+            baseline.write_text(
+                json.dumps({
+                    "target": "root",
+                    "slowest_tests": [
+                        {"suite": "RepoPromptTests.A", "method": "testOne", "median_seconds": 2.5},
+                        {"suite": "RepoPromptTests.C", "method": "testMissing", "median_seconds": 9.0},
+                    ],
+                }),
+                encoding="utf-8",
+            )
+
+            summary = optimizer.runtime_import(ledger, baseline, output)
+
+            self.assertEqual(summary["rows_updated"], 1)
+            self.assertEqual(summary["rows_unchanged"], 1)
+            self.assertEqual(summary["artifact_methods_missing_from_ledger"], ["root/RepoPromptTests.C/testMissing"])
+            self.assertEqual(summary["ledger_methods_missing_from_artifact"], ["root/RepoPromptTests.B/testTwo"])
+            with output.open("r", encoding="utf-8", newline="") as handle:
+                rows = list(csv.DictReader(handle, delimiter="\t"))
+            self.assertEqual([row["method_id"] for row in rows], [
+                "root/RepoPromptTests.A/testOne",
+                "root/RepoPromptTests.B/testTwo",
+            ])
+            self.assertEqual(rows[0]["runtime_seconds"], "2.500000")
+            self.assertEqual(rows[1]["runtime_seconds"], "1.000000")
+
+    def test_runtime_import_refuses_to_overwrite_output(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            ledger = root / "ledger.tsv"
+            output = root / "candidate.tsv"
+            baseline = root / "baseline.json"
+            self.write_ledger(
+                ledger,
+                [{
+                    "method_id": "root/RepoPromptTests.A/testOne",
+                    "target": "root",
+                    "suite": "RepoPromptTests.A",
+                    "method": "testOne",
+                    "execution_tier": "routine",
+                }],
+            )
+            baseline.write_text(json.dumps({"target": "root", "slowest_tests": []}), encoding="utf-8")
+            output.write_text("existing", encoding="utf-8")
+
+            with self.assertRaisesRegex(optimizer.OptimizerError, "refusing to overwrite"):
+                optimizer.runtime_import(ledger, baseline, output)
+
+    def test_ci_suite_plan_balances_suites_and_marks_batch_eligibility(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            ledger = Path(tmp) / "ledger.tsv"
+            self.write_ledger(
+                ledger,
+                [
+                    {
+                        "method_id": "root/RepoPromptTests.Slow/testOne",
+                        "target": "root",
+                        "suite": "RepoPromptTests.Slow",
+                        "method": "testOne",
+                        "execution_tier": "routine",
+                        "runtime_seconds": "8",
+                    },
+                    {
+                        "method_id": "root/RepoPromptTests.Fast/testOne",
+                        "target": "root",
+                        "suite": "RepoPromptTests.Fast",
+                        "method": "testOne",
+                        "execution_tier": "fast",
+                        "runtime_seconds": "1.5",
+                    },
+                    {
+                        "method_id": "root/RepoPromptTests.MissingRuntime/testOne",
+                        "target": "root",
+                        "suite": "RepoPromptTests.MissingRuntime",
+                        "method": "testOne",
+                        "execution_tier": "fast",
+                    },
+                    {
+                        "method_id": "root/RepoPromptTests.Shared/testOne",
+                        "target": "root",
+                        "suite": "RepoPromptTests.Shared",
+                        "method": "testOne",
+                        "execution_tier": "fast",
+                        "runtime_seconds": "1",
+                        "shared_state_tags": "UserDefaults",
+                    },
+                    {
+                        "method_id": "provider/ProviderTests.Ignored/testOne",
+                        "target": "provider",
+                        "suite": "ProviderTests.Ignored",
+                        "method": "testOne",
+                        "execution_tier": "fast",
+                        "runtime_seconds": "100",
+                    },
+                ],
+            )
+
+            plan = optimizer.ci_suite_plan(ledger, 2, suites=[
+                "RepoPromptTests.Slow",
+                "RepoPromptTests.Fast",
+                "RepoPromptTests.MissingRuntime",
+                "RepoPromptTests.Shared",
+                "RepoPromptTests.NotLive",
+            ])
+
+        self.assertEqual(plan["shard_count"], 2)
+        self.assertEqual(plan["missing_suites"], ["RepoPromptTests.NotLive"])
+        all_suites = {entry["suite"]: entry for shard in plan["shards"] for entry in shard["suites"]}
+        self.assertEqual(set(all_suites), {
+            "RepoPromptTests.Slow",
+            "RepoPromptTests.Fast",
+            "RepoPromptTests.MissingRuntime",
+            "RepoPromptTests.Shared",
+        })
+        self.assertEqual(all_suites["RepoPromptTests.MissingRuntime"]["missing_runtime_count"], 1)
+        self.assertTrue(all_suites["RepoPromptTests.Fast"]["batch_eligible"])
+        self.assertFalse(all_suites["RepoPromptTests.MissingRuntime"]["batch_eligible"])
+        self.assertFalse(all_suites["RepoPromptTests.Shared"]["batch_eligible"])
+        self.assertGreaterEqual(plan["shards"][0]["estimated_seconds"], plan["shards"][1]["estimated_seconds"])
+
     def test_source_mapping_supports_multiple_root_test_directories(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/Sources/RepoPrompt/Features/Settings/ViewModels/APISettingsViewModel.swift
+++ b/Sources/RepoPrompt/Features/Settings/ViewModels/APISettingsViewModel.swift
@@ -349,6 +349,7 @@ public class APISettingsViewModel: ObservableObject {
     private var openCodeModelsTask: Task<Void, Never>?
     private var cursorModelsTask: Task<Void, Never>?
     private var openRouterModelsTask: Task<Void, Never>?
+    private var customModelsTask: Task<Void, Never>?
     private var initialLoadTask: Task<Void, Never>?
     private var cliConnectionCancellables = Set<AnyCancellable>()
     private var hasLoadedStoredData = false
@@ -1008,6 +1009,8 @@ public class APISettingsViewModel: ObservableObject {
         cursorModelsTask = nil
         openRouterModelsTask?.cancel()
         openRouterModelsTask = nil
+        customModelsTask?.cancel()
+        customModelsTask = nil
         contextBuilderProviderValidationTask?.cancel()
         contextBuilderProviderValidationTask = nil
         cliConnectionCancellables.removeAll()
@@ -1026,6 +1029,7 @@ public class APISettingsViewModel: ObservableObject {
         openCodeModelsTask?.cancel()
         cursorModelsTask?.cancel()
         openRouterModelsTask?.cancel()
+        customModelsTask?.cancel()
         contextBuilderProviderValidationTask?.cancel()
     }
 
@@ -1324,6 +1328,8 @@ public class APISettingsViewModel: ObservableObject {
         cursorModelsTask = nil
         openRouterModelsTask?.cancel()
         openRouterModelsTask = nil
+        customModelsTask?.cancel()
+        customModelsTask = nil
 
         keychainAccessDiagnostics.removeAll()
         loadNonSecretStoredData()
@@ -1477,7 +1483,7 @@ public class APISettingsViewModel: ObservableObject {
         if isOpenCodeConnected { startOpenCodeModelsSubscriptionIfNeeded(workspacePath: nil) } else { stopOpenCodeModelsSubscription(clearModels: true) }
         if isCursorConnected { startCursorModelsSubscriptionIfNeeded(workspacePath: nil) } else { stopCursorModelsSubscription(clearModels: true) }
         if isOpenRouterKeyValid { openRouterModelsTask = Task { await self.fetchOpenRouterModels() } }
-        if isCustomProviderValid { Task { await self.fetchCustomModels() } }
+        if isCustomProviderValid { customModelsTask = Task { await self.fetchCustomModels() } }
 
         // ----------------------------------------------------------------
         // 5. Build initial UI list from whatever caches we already have

--- a/Sources/RepoPrompt/Features/Settings/ViewModels/APISettingsViewModel.swift
+++ b/Sources/RepoPrompt/Features/Settings/ViewModels/APISettingsViewModel.swift
@@ -2765,8 +2765,10 @@ public class APISettingsViewModel: ObservableObject {
             )
 
             let models = try await provider.getAvailableModels()
+            guard !Task.isCancelled else { return }
             availableCustomModels = models
         } catch {
+            guard !Task.isCancelled else { return }
             availableCustomModels = []
             apiSettingsViewModelDebugLog("Error fetching custom models: \(error)")
         }

--- a/Sources/RepoPrompt/Features/WorkspaceFiles/ViewModels/WorkspaceFilesViewModel.swift
+++ b/Sources/RepoPrompt/Features/WorkspaceFiles/ViewModels/WorkspaceFilesViewModel.swift
@@ -1789,8 +1789,22 @@ class WorkspaceFilesViewModel: ObservableObject {
                 let targets = stillCurrentTargets.map { (identity: $0.identity, fullPath: $0.logicalFullPath) }
                 await workspaceManager?.rebaseSlicesForFilesAcrossTabs(
                     targets: targets,
-                    asyncTransform: { _, logicalFullPath, currentRanges in
-                        await Task.detached(priority: .utility) {
+                    asyncTransform: { identity, logicalFullPath, currentRanges in
+                        if let commit = partitionCommits.first(where: { commit in
+                            guard let target = commit.hiddenSessionTarget else { return false }
+                            return target.identity == identity && target.logicalFullPath == logicalFullPath
+                        }), let expectedLogicalRanges = commit.expectedLogicalRanges {
+                            let normalizedCurrent = SliceRangeMath.normalize(currentRanges)
+                            let normalizedCommitted = SliceRangeMath.normalize(commit.ranges)
+                            if normalizedCurrent == normalizedCommitted {
+                                return normalizedCurrent
+                            }
+                            if normalizedCurrent == SliceRangeMath.normalize(expectedLogicalRanges) {
+                                return normalizedCommitted
+                            }
+                        }
+
+                        return await Task.detached(priority: .utility) {
                             let engineStartedMS = ProcessInfo.processInfo.systemUptime * 1000
                             let result = SliceRebaseEngine.rebase(
                                 oldText: sourceSnapshot.text,

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexAppServerClient.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexAppServerClient.swift
@@ -326,6 +326,10 @@ actor CodexAppServerClient {
     private let livenessProbe: @Sendable (SpawnedProcess) -> Bool
     private let expectedAgentPIDRegistrar: ExpectedAgentPIDRegistrar
 
+    deinit {
+        emergencyTerminateTransportForDeinit()
+    }
+
     init(
         writeFrameHandler: @escaping @Sendable (Int32, Data) throws -> Void = { descriptor, frame in
             try FDWriteSupport.writeAll(frame, to: descriptor)
@@ -618,6 +622,58 @@ actor CodexAppServerClient {
         guard let terminatingTransport else { return }
         Task {
             await self.finishTransportTermination(terminatingTransport)
+        }
+    }
+
+    private func emergencyTerminateTransportForDeinit() {
+        startupTask?.task.cancel()
+        startupTask = nil
+        stdoutChunkChannel?.finish()
+        stderrChunkChannel?.finish()
+        stdoutConsumerTask?.cancel()
+        stderrConsumerTask?.cancel()
+        stdoutChunkChannel = nil
+        stderrChunkChannel = nil
+        stdoutConsumerTask = nil
+        stderrConsumerTask = nil
+        for task in timeoutTasks.values {
+            task.cancel()
+        }
+        timeoutTasks.removeAll()
+        let requests = pendingRequests
+        pendingRequests.removeAll()
+        pendingRequestMetadata.removeAll()
+        for continuation in requests.values {
+            continuation.resume(throwing: ClientError.processNotRunning)
+        }
+        for continuation in notificationContinuations.values {
+            continuation.finish()
+        }
+        notificationContinuations.removeAll()
+        for continuation in serverRequestContinuations.values {
+            continuation.finish()
+        }
+        serverRequestContinuations.removeAll()
+        let expectedAgentPIDToClear = registeredExpectedAgentPID
+        registeredExpectedAgentPID = nil
+        if let expectedAgentPIDToClear {
+            let registrar = expectedAgentPIDRegistrar
+            Task.detached {
+                await registrar.clear(
+                    expectedAgentPIDToClear.pid,
+                    expectedAgentPIDToClear.clientName,
+                    expectedAgentPIDToClear.runID
+                )
+            }
+        }
+        guard let process else { return }
+        self.process = nil
+        process.stdout.readabilityHandler = nil
+        process.stderr.readabilityHandler = nil
+        process.stdin?.closeFile()
+        let pid = process.pid
+        Task.detached {
+            _ = await ProcessTermination.terminateAndReap(pid: pid)
         }
     }
 

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexNativeSessionController.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexNativeSessionController.swift
@@ -783,19 +783,9 @@ final class CodexNativeSessionController {
         notificationTask?.cancel()
         serverRequestTask?.cancel()
         finishEventsStreamIfNeeded()
-        if clientShutdownBehavior == .stopOnShutdown || expectedMCPClientName != nil {
-            let ownedClient = client
-            let shouldStopClient = clientShutdownBehavior == .stopOnShutdown
-            let shouldClearExpectedPID = expectedMCPClientName != nil
-            Task {
-                if shouldClearExpectedPID {
-                    await ownedClient.clearExpectedAgentPIDRegistration()
-                }
-                if shouldStopClient {
-                    await ownedClient.stop()
-                }
-            }
-        }
+        // Deterministic cleanup is performed by shutdown(). If a controller is
+        // dropped without shutdown, CodexAppServerClient owns the last-resort
+        // transport cleanup in its deinit without retaining this controller.
     }
 
     private func withEventsStateLock<T>(_ body: () -> T) -> T {

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexNativeSessionController.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexNativeSessionController.swift
@@ -783,9 +783,20 @@ final class CodexNativeSessionController {
         notificationTask?.cancel()
         serverRequestTask?.cancel()
         finishEventsStreamIfNeeded()
-        // Deterministic cleanup is performed by shutdown(). If a controller is
-        // dropped without shutdown, CodexAppServerClient owns the last-resort
-        // transport cleanup in its deinit without retaining this controller.
+
+        let client = client
+        let shouldClearExpectedPID = expectedMCPClientName != nil
+        let shouldStopClient = clientShutdownBehavior == .stopOnShutdown
+        if shouldClearExpectedPID || shouldStopClient {
+            Task.detached {
+                if shouldClearExpectedPID {
+                    await client.clearExpectedAgentPIDRegistration()
+                }
+                if shouldStopClient {
+                    await client.stop()
+                }
+            }
+        }
     }
 
     private func withEventsStateLock<T>(_ body: () -> T) -> T {

--- a/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService+FSEvents.swift
+++ b/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService+FSEvents.swift
@@ -337,11 +337,13 @@ extension FileSystemService {
         guard fseventStreamRef == nil else { return }
 
         watcherIngressMailbox.startAccepting()
-        selfPointer = Unmanaged.passRetained(self).toOpaque()
+        fseventCallbackContextPointer = Unmanaged.passRetained(
+            FileSystemServiceFSEventCallbackContext(service: self)
+        ).toOpaque()
 
         var streamContext = FSEventStreamContext(
             version: 0,
-            info: selfPointer,
+            info: fseventCallbackContextPointer,
             retain: nil,
             release: nil,
             copyDescription: nil
@@ -380,11 +382,7 @@ extension FileSystemService {
         #endif
 
         guard let stream = fseventStreamRef else {
-            // Release the retained self if creation failed to avoid leaks
-            if let ptr = selfPointer {
-                Unmanaged<FileSystemService>.fromOpaque(ptr).release()
-                selfPointer = nil
-            }
+            releaseFSEventCallbackContext()
             resetWatcherIngressState()
             throw FileSystemWatcherActivationError.streamCreationFailed(path: path)
         }
@@ -400,10 +398,7 @@ extension FileSystemService {
             FSEventStreamInvalidate(stream)
             FSEventStreamRelease(stream)
             fseventStreamRef = nil
-            if let ptr = selfPointer {
-                Unmanaged<FileSystemService>.fromOpaque(ptr).release()
-                selfPointer = nil
-            }
+            releaseFSEventCallbackContext()
             resetWatcherIngressState()
             throw FileSystemWatcherActivationError.streamStartFailed(path: path)
         }
@@ -422,10 +417,7 @@ extension FileSystemService {
             FSEventStreamRelease(stream)
             fseventStreamRef = nil
 
-            if let ptr = selfPointer {
-                Unmanaged<FileSystemService>.fromOpaque(ptr).release()
-                selfPointer = nil
-            }
+            releaseFSEventCallbackContext()
 
             fileSystemDebugLog("FSEventStream stopped for path: \(path)")
         } else {
@@ -433,6 +425,12 @@ extension FileSystemService {
         }
 
         resetWatcherIngressState()
+    }
+
+    private func releaseFSEventCallbackContext() {
+        guard let ptr = fseventCallbackContextPointer else { return }
+        fseventCallbackContextPointer = nil
+        Unmanaged<FileSystemServiceFSEventCallbackContext>.fromOpaque(ptr).release()
     }
 
     nonisolated static func deepCopySwiftString(_ source: String) -> String {
@@ -515,7 +513,10 @@ extension FileSystemService {
         _, context, numEvents, eventPaths, eventFlags, eventIds in
         // Context must be valid
         guard let context else { return }
-        let service = Unmanaged<FileSystemService>.fromOpaque(context).takeUnretainedValue()
+        let callbackContext = Unmanaged<FileSystemServiceFSEventCallbackContext>
+            .fromOpaque(context)
+            .takeUnretainedValue()
+        guard let service = callbackContext.service else { return }
 
         let count = Int(numEvents)
         guard count > 0 else { return }

--- a/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService.swift
+++ b/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService.swift
@@ -26,6 +26,14 @@ struct FileSystemMutationWaiter {
     let continuation: CheckedContinuation<Void, any Error>
 }
 
+final class FileSystemServiceFSEventCallbackContext {
+    weak var service: FileSystemService?
+
+    init(service: FileSystemService) {
+        self.service = service
+    }
+}
+
 actor FileSystemService {
     // Internal for FileSystemService same-target extensions only.
     // These are not public API; preserve actor isolation when accessing them.
@@ -219,8 +227,9 @@ actor FileSystemService {
         var freshnessMaxWatcherBatchSize = 0
     #endif
 
-    /// Retained pointer to self (to avoid deallocation while FSEvent stream is active)
-    var selfPointer: UnsafeMutableRawPointer?
+    /// Retained FSEvent callback context. The context holds the service weakly so an
+    /// un-stopped stream cannot keep the actor alive forever.
+    var fseventCallbackContextPointer: UnsafeMutableRawPointer?
 
     /// The in-memory IgnoreRules instance for our path
     var ignoreRules: IgnoreRules
@@ -242,6 +251,10 @@ actor FileSystemService {
 
     var standardizedRootPath: String {
         rootURL.path
+    }
+
+    deinit {
+        stopFSEventStream()
     }
 
     var respectRepoIgnore: Bool

--- a/Sources/RepoPrompt/Infrastructure/MCP/ServerController.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ServerController.swift
@@ -201,7 +201,9 @@ final actor ServerController: ObservableObject {
     }
 
     deinit {
-        // No cleanup needed - callbacks are weak self
+        if let wakeObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(wakeObserver)
+        }
     }
 
     // MARK: – Allow-list helpers –

--- a/Tests/RepoPromptTests/ContextBuilder/ContextBuilderNestedMCPFailureTests.swift
+++ b/Tests/RepoPromptTests/ContextBuilder/ContextBuilderNestedMCPFailureTests.swift
@@ -27,6 +27,7 @@ import XCTest
                 )
                 let recorder = NestedContextBuilderExecutionTraceRecorder()
                 MCPToolExecutionTracer.setTestSink { recorder.append($0) }
+                defer { MCPToolExecutionTracer.setTestSink(nil) }
 
                 do {
                     let outerEndpoint = try fixture.endpointA()
@@ -94,6 +95,7 @@ import XCTest
                 let manager = fixture.networkManager
                 let recorder = NestedContextBuilderExecutionTraceRecorder()
                 MCPToolExecutionTracer.setTestSink { recorder.append($0) }
+                defer { MCPToolExecutionTracer.setTestSink(nil) }
                 await manager.debugSetToolExecutionWatchdogEnvironment(clock.environment)
                 await manager.debugSetResolvedToolOperationOverride(toolName: MCPWindowToolName.readFile) {
                     await gate.enterAndWait()
@@ -317,28 +319,79 @@ import XCTest
         private static let synchronizationTimeout: Duration = .seconds(10)
 
         private var nestedConnectionID: UUID?
+        private var nestedConnectionWaiters: [UUID: CheckedContinuation<UUID, Error>] = [:]
+        private var failedNestedConnectionWaiters: [UUID: Error] = [:]
+        private var grantedNestedConnectionWaiterIDs: Set<UUID> = []
         private var failureCount = 0
 
         func recordNestedConnectionID(_ id: UUID) {
             nestedConnectionID = id
+            failedNestedConnectionWaiters.removeAll()
+            let waiters = nestedConnectionWaiters
+            nestedConnectionWaiters.removeAll()
+            grantedNestedConnectionWaiterIDs.formUnion(waiters.keys)
+            waiters.values.forEach { $0.resume(returning: id) }
         }
 
         func requireNestedConnectionID(
             timeout: Duration = synchronizationTimeout
         ) async throws -> UUID {
-            let clock = ContinuousClock()
-            let deadline = clock.now.advanced(by: timeout)
-            while nestedConnectionID == nil {
-                try Task.checkCancellation()
-                guard clock.now < deadline else {
-                    throw NestedContextBuilderFailureError.nestedConnectionDidNotRegister
+            if let nestedConnectionID { return nestedConnectionID }
+
+            let waiterID = UUID()
+            let timeoutTask = Task {
+                do {
+                    try await Task.sleep(for: timeout)
+                    await self.failNestedConnectionWaiter(
+                        id: waiterID,
+                        error: NestedContextBuilderFailureError.nestedConnectionDidNotRegister
+                    )
+                } catch is CancellationError {
+                    return
+                } catch {
+                    return
                 }
-                try await Task.sleep(for: .milliseconds(10))
             }
-            guard let nestedConnectionID else {
-                throw NestedContextBuilderFailureError.nestedConnectionDidNotRegister
+
+            do {
+                let id = try await withTaskCancellationHandler {
+                    try await withCheckedThrowingContinuation { continuation in
+                        registerNestedConnectionWaiter(id: waiterID, continuation: continuation)
+                    }
+                } onCancel: {
+                    Task {
+                        await self.failNestedConnectionWaiter(id: waiterID, error: CancellationError())
+                    }
+                }
+                grantedNestedConnectionWaiterIDs.remove(waiterID)
+                try Task.checkCancellation()
+                timeoutTask.cancel()
+                return id
+            } catch {
+                timeoutTask.cancel()
+                throw error
             }
-            return nestedConnectionID
+        }
+
+        private func registerNestedConnectionWaiter(
+            id: UUID,
+            continuation: CheckedContinuation<UUID, Error>
+        ) {
+            if let nestedConnectionID {
+                continuation.resume(returning: nestedConnectionID)
+            } else if let error = failedNestedConnectionWaiters.removeValue(forKey: id) {
+                continuation.resume(throwing: error)
+            } else {
+                nestedConnectionWaiters[id] = continuation
+            }
+        }
+
+        private func failNestedConnectionWaiter(id: UUID, error: Error) async {
+            if let continuation = nestedConnectionWaiters.removeValue(forKey: id) {
+                continuation.resume(throwing: error)
+            } else if nestedConnectionID == nil && !grantedNestedConnectionWaiterIDs.contains(id) {
+                failedNestedConnectionWaiters[id] = error
+            }
         }
 
         func recordProviderFailure() {

--- a/Tests/RepoPromptTests/ContextBuilder/ContextBuilderNestedMCPFailureTests.swift
+++ b/Tests/RepoPromptTests/ContextBuilder/ContextBuilderNestedMCPFailureTests.swift
@@ -389,7 +389,7 @@ import XCTest
         private func failNestedConnectionWaiter(id: UUID, error: Error) async {
             if let continuation = nestedConnectionWaiters.removeValue(forKey: id) {
                 continuation.resume(throwing: error)
-            } else if nestedConnectionID == nil && !grantedNestedConnectionWaiterIDs.contains(id) {
+            } else if nestedConnectionID == nil, !grantedNestedConnectionWaiterIDs.contains(id) {
                 failedNestedConnectionWaiters[id] = error
             }
         }

--- a/Tests/RepoPromptTests/ContextBuilder/ContextBuilderWorktreeInheritanceTests.swift
+++ b/Tests/RepoPromptTests/ContextBuilder/ContextBuilderWorktreeInheritanceTests.swift
@@ -25,6 +25,7 @@ import XCTest
                     let logicalRoot = fixture.contextA.rootURL
                     let logicalFile = fixture.contextA.fileURL
                     let gitFixture = try ReviewGitRepositoryFixture(name: "ContextBuilderPublishedWorktree")
+                    defer { gitFixture.cleanup() }
                     try initializeGitRepository(at: logicalRoot, using: gitFixture)
                     await markGitDirectoryObserved(fixture.contextA)
                     let worktreeRoot = try gitFixture.makeLinkedWorktree(

--- a/Tests/RepoPromptTests/MCP/AgentRunWorktreeStartTests.swift
+++ b/Tests/RepoPromptTests/MCP/AgentRunWorktreeStartTests.swift
@@ -867,19 +867,34 @@ final class AgentRunWorktreeStartTests: AgentRunWorktreeStartGitSeedTestCase {
             ],
             codemapAutoEnabled: false
         )
+        let workspaceID = try XCTUnwrap(window.workspaceManager.activeWorkspace?.id)
+        let sourceIdentity = WorkspaceSelectionIdentity(workspaceID: workspaceID, tabID: sourceTabID)
         var composeTab = try XCTUnwrap(window.workspaceManager.composeTab(with: sourceTabID))
-        composeTab.selection = storedSelection
         composeTab.activeAgentSessionID = parentSessionID
         window.workspaceManager.updateComposeTab(composeTab, markDirty: false)
+        _ = await window.selectionCoordinator.persistSelection(
+            storedSelection,
+            for: sourceIdentity,
+            source: .runtimeMutation,
+            mirrorToUIIfActive: false
+        )
         // Wait for post-switch git-data root load to complete so any selection revision
         // published by the async git-data load settles before we diverge the UI selection.
         await window.workspaceManager.waitUntilPostSwitchGitDataLoadComplete()
-        await window.workspaceFilesViewModel.applyStoredSelection(StoredSelection())
+        await window.selectionCoordinator.withApplyingSelectionMirror {
+            await window.workspaceFilesViewModel.applyStoredSelection(StoredSelection())
+        }
         let divergentUISelection = window.workspaceFilesViewModel.snapshotSelection()
         XCTAssertTrue(divergentUISelection.selectedPaths.isEmpty)
         XCTAssertNotEqual(divergentUISelection, storedSelection)
+        _ = await window.selectionCoordinator.persistSelection(
+            storedSelection,
+            for: sourceIdentity,
+            source: .runtimeMutation,
+            mirrorToUIIfActive: false
+        )
+        XCTAssertEqual(window.workspaceManager.composeTab(for: sourceIdentity)?.selection, storedSelection)
 
-        let workspaceID = try XCTUnwrap(window.workspaceManager.activeWorkspace?.id)
         let launchSnapshot = AgentRunOracleReviewLaunchSnapshot(
             route: .explicitTabContext,
             windowID: window.windowID,

--- a/Tests/RepoPromptTests/MCP/Control/MCPSharedServerTestLease.swift
+++ b/Tests/RepoPromptTests/MCP/Control/MCPSharedServerTestLease.swift
@@ -1,27 +1,91 @@
 #if DEBUG
+    import Foundation
+
     actor MCPSharedServerTestLease {
         struct Ownership {
             fileprivate init() {}
         }
 
+        private struct Waiter {
+            let id: UUID
+            let continuation: CheckedContinuation<Void, Error>
+        }
+
         static let shared = MCPSharedServerTestLease()
 
         private var occupied = false
-        private var waiters: [CheckedContinuation<Void, Never>] = []
+        private var waiters: [Waiter] = []
+        private var cancelledWaiterIDs: Set<UUID> = []
+        private var grantedWaiterIDs: Set<UUID> = []
 
-        func withLease<T>(_ operation: (Ownership) async throws -> T) async rethrows -> T {
-            if occupied {
-                await withCheckedContinuation { waiters.append($0) }
-            }
-            occupied = true
+        func withLease<T>(_ operation: (Ownership) async throws -> T) async throws -> T {
+            var ownsLease = false
+            try await acquireLease()
+            ownsLease = true
             defer {
-                if waiters.isEmpty {
-                    occupied = false
-                } else {
-                    waiters.removeFirst().resume()
+                if ownsLease {
+                    ownsLease = false
+                    releaseLease()
                 }
             }
             return try await operation(Ownership())
+        }
+
+        private func acquireLease() async throws {
+            guard occupied else {
+                occupied = true
+                do {
+                    try Task.checkCancellation()
+                } catch {
+                    releaseLease()
+                    throw error
+                }
+                return
+            }
+
+            let waiterID = UUID()
+            try await withTaskCancellationHandler {
+                try await withCheckedThrowingContinuation { continuation in
+                    registerWaiter(id: waiterID, continuation: continuation)
+                }
+            } onCancel: {
+                Task { await Self.shared.cancelWaiter(id: waiterID) }
+            }
+
+            grantedWaiterIDs.remove(waiterID)
+            do {
+                try Task.checkCancellation()
+            } catch {
+                releaseLease()
+                throw error
+            }
+        }
+
+        private func registerWaiter(id: UUID, continuation: CheckedContinuation<Void, Error>) {
+            if cancelledWaiterIDs.remove(id) != nil {
+                continuation.resume(throwing: CancellationError())
+            } else {
+                waiters.append(Waiter(id: id, continuation: continuation))
+            }
+        }
+
+        private func releaseLease() {
+            if waiters.isEmpty {
+                occupied = false
+            } else {
+                let waiter = waiters.removeFirst()
+                grantedWaiterIDs.insert(waiter.id)
+                waiter.continuation.resume()
+            }
+        }
+
+        private func cancelWaiter(id: UUID) {
+            if let index = waiters.firstIndex(where: { $0.id == id }) {
+                let waiter = waiters.remove(at: index)
+                waiter.continuation.resume(throwing: CancellationError())
+            } else if !grantedWaiterIDs.contains(id) {
+                cancelledWaiterIDs.insert(id)
+            }
         }
     }
 #endif

--- a/Tests/RepoPromptTests/MCP/Control/PersistentAgentModeMCPReadFileConnectionTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/PersistentAgentModeMCPReadFileConnectionTests.swift
@@ -4004,6 +4004,49 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
         }
     }
 
+    private final class SocketPairResponseWaiter: @unchecked Sendable {
+        private let lock = NSLock()
+        private var continuation: CheckedContinuation<String, Error>?
+
+        init(_ continuation: CheckedContinuation<String, Error>) {
+            self.continuation = continuation
+        }
+
+        func resume(returning value: String) {
+            take()?.resume(returning: value)
+        }
+
+        func resume(throwing error: Error) {
+            take()?.resume(throwing: error)
+        }
+
+        private func take() -> CheckedContinuation<String, Error>? {
+            lock.lock()
+            defer { lock.unlock() }
+            defer { continuation = nil }
+            return continuation
+        }
+    }
+
+    private final class SocketPairResponseWaiterHolder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var waiter: SocketPairResponseWaiter?
+
+        func install(_ waiter: SocketPairResponseWaiter) {
+            lock.lock()
+            self.waiter = waiter
+            lock.unlock()
+        }
+
+        func resume(throwing error: Error) {
+            lock.lock()
+            let waiter = waiter
+            self.waiter = nil
+            lock.unlock()
+            waiter?.resume(throwing: error)
+        }
+    }
+
     private final class SocketPairJSONRPCClient: @unchecked Sendable {
         enum ClientError: Error {
             case closed
@@ -4060,37 +4103,45 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
         }
 
         private func response(matching expectedID: Int) async throws -> String {
-            try await withCheckedThrowingContinuation { continuation in
-                queue.async {
-                    do {
-                        while true {
-                            let line = try self.readLine()
-                            let object = try JSONSerialization.jsonObject(with: line) as? [String: Any]
-                            guard let object else { throw ClientError.invalidResponse }
-                            if let rawID = object["id"] {
-                                guard let responseID = (rawID as? NSNumber)?.intValue else {
+            let waiterHolder = SocketPairResponseWaiterHolder()
+            return try await withTaskCancellationHandler {
+                try await withCheckedThrowingContinuation { continuation in
+                    let responseWaiter = SocketPairResponseWaiter(continuation)
+                    waiterHolder.install(responseWaiter)
+                    queue.async {
+                        do {
+                            while true {
+                                let line = try self.readLine()
+                                let object = try JSONSerialization.jsonObject(with: line) as? [String: Any]
+                                guard let object else { throw ClientError.invalidResponse }
+                                if let rawID = object["id"] {
+                                    guard let responseID = (rawID as? NSNumber)?.intValue else {
+                                        throw ClientError.invalidResponse
+                                    }
+                                    guard responseID == expectedID else {
+                                        throw ClientError.invalidResponse
+                                    }
+                                    guard let rawJSON = String(data: line, encoding: .utf8) else {
+                                        throw ClientError.invalidResponse
+                                    }
+                                    responseWaiter.resume(returning: rawJSON)
+                                    return
+                                }
+                                guard object["method"] as? String != nil,
+                                      let rawJSON = String(data: line, encoding: .utf8)
+                                else {
                                     throw ClientError.invalidResponse
                                 }
-                                guard responseID == expectedID else {
-                                    throw ClientError.invalidResponse
-                                }
-                                guard let rawJSON = String(data: line, encoding: .utf8) else {
-                                    throw ClientError.invalidResponse
-                                }
-                                continuation.resume(returning: rawJSON)
-                                return
+                                self.nonMatchingFrames.append(rawJSON)
                             }
-                            guard object["method"] as? String != nil,
-                                  let rawJSON = String(data: line, encoding: .utf8)
-                            else {
-                                throw ClientError.invalidResponse
-                            }
-                            self.nonMatchingFrames.append(rawJSON)
+                        } catch {
+                            responseWaiter.resume(throwing: error)
                         }
-                    } catch {
-                        continuation.resume(throwing: error)
                     }
                 }
+            } onCancel: {
+                waiterHolder.resume(throwing: CancellationError())
+                close()
             }
         }
 

--- a/Tests/RepoPromptTests/MCP/Control/PersistentMCPDistinctConnectionConcurrencyTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/PersistentMCPDistinctConnectionConcurrencyTests.swift
@@ -1859,8 +1859,15 @@ final class PersistentMCPDistinctConnectionConcurrencyTests: XCTestCase {
         private let stateLock = NSLock()
         private var fd: Int32
         private var nextRequestID = 1
+        private struct InterceptingResponse {
+            let continuation: CheckedContinuation<String, Error>
+            var task: Task<Void, Never>?
+        }
+
         private var pending: [Int: CheckedContinuation<String, Error>] = [:]
+        private var timeoutTasks: [Int: Task<Void, Never>] = [:]
         private var responseInterceptors: [Int: @Sendable (String) async throws -> String] = [:]
+        private var interceptingResponses: [Int: InterceptingResponse] = [:]
         private var notifications: [String] = []
         private var isClosed = false
 
@@ -1906,17 +1913,30 @@ final class PersistentMCPDistinctConnectionConcurrencyTests: XCTestCase {
                 try await withCheckedThrowingContinuation { continuation in
                     var registered = false
                     do {
-                        try register(continuation, for: id)
-                        registered = true
-                        try sendJSON([
-                            "jsonrpc": "2.0",
-                            "id": id,
-                            "method": method,
-                            "params": params
-                        ])
-                        Task { [weak self] in
-                            try? await Task.sleep(for: .seconds(timeoutSeconds))
-                            self?.failPending(id: id, error: ClientError.timedOut(id))
+                        let timeoutTask = Task { [weak self] in
+                            do {
+                                try await Task.sleep(for: .seconds(timeoutSeconds))
+                                guard !Task.isCancelled else { return }
+                                self?.failRequest(id: id, error: ClientError.timedOut(id))
+                            } catch is CancellationError {
+                                return
+                            } catch {
+                                return
+                            }
+                        }
+                        do {
+                            try register(continuation, timeoutTask: timeoutTask, for: id)
+                            registered = true
+                            try Task.checkCancellation()
+                            try sendJSON([
+                                "jsonrpc": "2.0",
+                                "id": id,
+                                "method": method,
+                                "params": params
+                            ])
+                        } catch {
+                            timeoutTask.cancel()
+                            throw error
                         }
                     } catch {
                         if registered {
@@ -1929,7 +1949,7 @@ final class PersistentMCPDistinctConnectionConcurrencyTests: XCTestCase {
                     }
                 }
             } onCancel: {
-                self.failPending(id: id, error: CancellationError())
+                self.failRequest(id: id, error: CancellationError())
             }
             return PersistentMCPTestRPCResponse(id: id, rawJSON: rawJSON)
         }
@@ -1941,11 +1961,16 @@ final class PersistentMCPDistinctConnectionConcurrencyTests: XCTestCase {
             }
         }
 
-        private func register(_ continuation: CheckedContinuation<String, Error>, for id: Int) throws {
+        private func register(
+            _ continuation: CheckedContinuation<String, Error>,
+            timeoutTask: Task<Void, Never>,
+            for id: Int
+        ) throws {
             try withStateLock {
                 guard !isClosed, fd >= 0 else { throw ClientError.closed }
                 guard pending[id] == nil else { throw ClientError.duplicateRequestID(id) }
                 pending[id] = continuation
+                timeoutTasks[id] = timeoutTask
             }
         }
 
@@ -2029,14 +2054,21 @@ final class PersistentMCPDistinctConnectionConcurrencyTests: XCTestCase {
                         continuation.resume(returning: rawJSON)
                         return true
                     }
-                    Task { [weak self] in
+                    guard pendingResponse.isIntercepting else {
+                        continuation.resume(throwing: ClientError.closed)
+                        return false
+                    }
+                    let task = Task { [weak self] in
                         do {
-                            try await continuation.resume(returning: interceptor(rawJSON))
+                            let intercepted = try await interceptor(rawJSON)
+                            _ = self?.completeIntercepting(id: id, returning: intercepted)
                         } catch {
-                            continuation.resume(throwing: error)
-                            self?.close(with: error)
+                            if self?.failIntercepting(id: id, error: error) == true {
+                                self?.close(with: error)
+                            }
                         }
                     }
+                    installInterceptingTask(id: id, task: task)
                     return true
                 }
                 guard object["method"] as? String != nil,
@@ -2053,21 +2085,60 @@ final class PersistentMCPDistinctConnectionConcurrencyTests: XCTestCase {
         }
 
         private func takePending(id: Int) -> CheckedContinuation<String, Error>? {
-            withStateLock {
+            let snapshot = withStateLock {
+                let continuation = pending.removeValue(forKey: id)
                 responseInterceptors.removeValue(forKey: id)
-                return pending.removeValue(forKey: id)
+                let timeoutTask = continuation == nil ? nil : timeoutTasks.removeValue(forKey: id)
+                return (continuation, timeoutTask)
             }
+            snapshot.1?.cancel()
+            return snapshot.0
+        }
+
+        private func installInterceptingTask(id: Int, task: Task<Void, Never>) {
+            let shouldCancelTask = withStateLock {
+                guard var response = interceptingResponses[id] else { return true }
+                response.task = task
+                interceptingResponses[id] = response
+                return false
+            }
+            if shouldCancelTask { task.cancel() }
+        }
+
+        private func takeIntercepting(
+            id: Int,
+            cancelInterceptorTask: Bool
+        ) -> InterceptingResponse? {
+            let snapshot = withStateLock {
+                let response = interceptingResponses.removeValue(forKey: id)
+                let timeoutTask = response == nil ? nil : timeoutTasks.removeValue(forKey: id)
+                let interceptorTask = cancelInterceptorTask ? response?.task : nil
+                return (response, timeoutTask, interceptorTask)
+            }
+            snapshot.1?.cancel()
+            snapshot.2?.cancel()
+            return snapshot.0
         }
 
         private func takePendingResponse(
             id: Int
         ) -> (
             continuation: CheckedContinuation<String, Error>?,
-            interceptor: (@Sendable (String) async throws -> String)?
+            interceptor: (@Sendable (String) async throws -> String)?,
+            isIntercepting: Bool
         ) {
-            withStateLock {
-                (pending.removeValue(forKey: id), responseInterceptors.removeValue(forKey: id))
+            let snapshot = withStateLock {
+                let continuation = pending.removeValue(forKey: id)
+                let interceptor = responseInterceptors.removeValue(forKey: id)
+                let isIntercepting = continuation != nil && interceptor != nil && !isClosed
+                if isIntercepting, let continuation {
+                    interceptingResponses[id] = InterceptingResponse(continuation: continuation)
+                }
+                let timeoutTask = isIntercepting ? nil : timeoutTasks.removeValue(forKey: id)
+                return (continuation, interceptor, isIntercepting, timeoutTask)
             }
+            snapshot.3?.cancel()
+            return (snapshot.0, snapshot.1, snapshot.2)
         }
 
         @discardableResult
@@ -2077,19 +2148,55 @@ final class PersistentMCPDistinctConnectionConcurrencyTests: XCTestCase {
             return true
         }
 
+        @discardableResult
+        private func completeIntercepting(id: Int, returning rawJSON: String) -> Bool {
+            guard let response = takeIntercepting(id: id, cancelInterceptorTask: false) else { return false }
+            response.continuation.resume(returning: rawJSON)
+            return true
+        }
+
+        @discardableResult
+        private func failIntercepting(id: Int, error: Error) -> Bool {
+            guard let response = takeIntercepting(id: id, cancelInterceptorTask: true) else { return false }
+            response.continuation.resume(throwing: error)
+            return true
+        }
+
+        @discardableResult
+        private func failRequest(id: Int, error: Error) -> Bool {
+            if failPending(id: id, error: error) { return true }
+            return failIntercepting(id: id, error: error)
+        }
+
         private func close(with error: Error) {
-            let snapshot: (Int32, [CheckedContinuation<String, Error>]) = withStateLock {
-                guard !isClosed else { return (-1, []) }
+            let snapshot: (
+                activeFD: Int32,
+                pendingContinuations: [CheckedContinuation<String, Error>],
+                interceptingContinuations: [CheckedContinuation<String, Error>],
+                tasks: [Task<Void, Never>]
+            ) = withStateLock {
+                guard !isClosed else { return (-1, [], [], []) }
                 isClosed = true
                 let activeFD = fd
                 fd = -1
-                let continuations = Array(pending.values)
+                let pendingContinuations = Array(pending.values)
+                let intercepting = Array(interceptingResponses.values)
+                let interceptorTasks = intercepting.compactMap { response -> Task<Void, Never>? in
+                    response.task
+                }
+                let tasks = Array(timeoutTasks.values) + interceptorTasks
                 pending.removeAll()
+                timeoutTasks.removeAll()
                 responseInterceptors.removeAll()
-                return (activeFD, continuations)
+                interceptingResponses.removeAll()
+                let interceptingContinuations = intercepting.map { response -> CheckedContinuation<String, Error> in
+                    response.continuation
+                }
+                return (activeFD, pendingContinuations, interceptingContinuations, tasks)
             }
-            if snapshot.0 >= 0 { Darwin.close(snapshot.0) }
-            for continuation in snapshot.1 {
+            if snapshot.activeFD >= 0 { Darwin.close(snapshot.activeFD) }
+            snapshot.tasks.forEach { $0.cancel() }
+            for continuation in snapshot.pendingContinuations + snapshot.interceptingContinuations {
                 continuation.resume(throwing: error)
             }
         }

--- a/Tests/RepoPromptTests/MCP/MCPReadSearchLatencyDiagnosticsGuardTests.swift
+++ b/Tests/RepoPromptTests/MCP/MCPReadSearchLatencyDiagnosticsGuardTests.swift
@@ -455,9 +455,11 @@
         }
 
         private var temporaryRoots = FileSystemTemporaryRoots()
+        private var cancellables = Set<AnyCancellable>()
 
         override func tearDown() {
             EditFlowPerf.resetDebugCaptureForTesting()
+            cancellables.removeAll()
             temporaryRoots.removeAll()
             super.tearDown()
         }
@@ -1836,7 +1838,7 @@
             XCTAssertTrue(snapshot.lifecycleEvents.contains {
                 $0.eventName == "FileSystem.ServicePublish" && $0.correlationID == sinkID.uuidString
             })
-            withExtendedLifetime(cancellable) {}
+            cancellables.insert(cancellable)
             await service.stopWatchingForChanges()
         }
 

--- a/Tests/RepoPromptTests/Services/FileSystem/FileSystemAcceptedIngressBarrierTests.swift
+++ b/Tests/RepoPromptTests/Services/FileSystem/FileSystemAcceptedIngressBarrierTests.swift
@@ -5,8 +5,10 @@ import XCTest
 
 final class FileSystemAcceptedIngressBarrierTests: XCTestCase {
     private var temporaryRoots = FileSystemTemporaryRoots()
+    private var cancellables = Set<AnyCancellable>()
 
     override func tearDownWithError() throws {
+        cancellables.removeAll()
         temporaryRoots.removeAll()
         try super.tearDownWithError()
     }
@@ -48,7 +50,7 @@ final class FileSystemAcceptedIngressBarrierTests: XCTestCase {
         XCTAssertTrue(snapshot[1].deltas.isEmpty)
         let queuedAfterSecondCut = await service.watcherIngressMailboxSnapshotForTesting()
         XCTAssertEqual(queuedAfterSecondCut.queuedRawEntryCount, 0)
-        withExtendedLifetime(cancellable) {}
+        cancellables.insert(cancellable)
     }
 
     func testNoDeltaAcceptedPayloadAdvancesPublishedWatcherWatermark() async throws {
@@ -71,7 +73,7 @@ final class FileSystemAcceptedIngressBarrierTests: XCTestCase {
         XCTAssertEqual(publication.watcherAcceptedWatermark, accepted)
         XCTAssertTrue(publication.deltas.isEmpty)
         XCTAssertEqual(serviceState.lastPublishedWatcherAcceptedWatermark, accepted)
-        withExtendedLifetime(cancellable) {}
+        cancellables.insert(cancellable)
     }
 
     func testIgnoredEventsBeyondMailboxCapAreFilteredBeforeOverflow() async throws {
@@ -203,7 +205,7 @@ final class FileSystemAcceptedIngressBarrierTests: XCTestCase {
         XCTAssertEqual(publication.watcherAcceptedWatermark, highest)
         let serviceState = await service.publicationStateForTesting()
         XCTAssertEqual(serviceState.lastPublishedWatcherAcceptedWatermark, highest)
-        withExtendedLifetime(cancellable) {}
+        cancellables.insert(cancellable)
     }
 
     func testFlushWaitsForInFlightWatcherBatchBeforePublishingAcceptedCut() async throws {
@@ -240,7 +242,7 @@ final class FileSystemAcceptedIngressBarrierTests: XCTestCase {
         XCTAssertGreaterThan(sequence, 0)
         XCTAssertEqual(publication.watcherAcceptedWatermark, accepted)
         await service.setWatcherBatchWillProcessHandlerForTesting(nil)
-        withExtendedLifetime(cancellable) {}
+        cancellables.insert(cancellable)
     }
 
     func testMailboxOverflowPreservesIgnoreChangeAlreadyBufferedOnActor() async throws {
@@ -321,7 +323,7 @@ final class FileSystemAcceptedIngressBarrierTests: XCTestCase {
         XCTAssertEqual(publication.source, .syntheticMutation)
         XCTAssertNil(publication.watcherAcceptedWatermark)
         XCTAssertEqual(publication.servicePublicationSequence, sequence)
-        withExtendedLifetime(cancellable) {}
+        cancellables.insert(cancellable)
     }
 
     func testPausedMailboxAcceptsMonotonicRangeWithoutSchedulingUntilResume() async throws {
@@ -438,7 +440,7 @@ final class FileSystemAcceptedIngressBarrierTests: XCTestCase {
         let serviceState = await service.publicationStateForTesting()
         XCTAssertGreaterThanOrEqual(serviceState.lastPublishedWatcherAcceptedWatermark, postCutDrainTarget)
         await service.stopWatchingForChanges()
-        withExtendedLifetime(cancellable) {}
+        cancellables.insert(cancellable)
     }
 
     func testSeedReplayRejectsCollapsedMailboxRangeBeforePublication() async throws {
@@ -477,7 +479,7 @@ final class FileSystemAcceptedIngressBarrierTests: XCTestCase {
         let cleaned = await service.watcherIngressMailboxSnapshotForTesting()
         XCTAssertFalse(cleaned.isAutomaticDrainPaused)
         XCTAssertEqual(cleaned.queuedPayloadCount, 0)
-        withExtendedLifetime(cancellable) {}
+        cancellables.insert(cancellable)
     }
 
     func testSeedReplayTeardownCannotSynthesizeSuccessfulBarrier() async throws {
@@ -510,7 +512,7 @@ final class FileSystemAcceptedIngressBarrierTests: XCTestCase {
             XCTAssertEqual(error, .initializationNotCurrent)
         }
         XCTAssertTrue(publications.snapshot().isEmpty)
-        withExtendedLifetime(cancellable) {}
+        cancellables.insert(cancellable)
     }
 
     func testSyntheticPathReplayUsesBoundedSpillWorkingSet() throws {

--- a/Tests/RepoPromptTests/Services/FileSystem/FileSystemServiceRecoveryTests.swift
+++ b/Tests/RepoPromptTests/Services/FileSystem/FileSystemServiceRecoveryTests.swift
@@ -5,8 +5,10 @@ import XCTest
 
 final class FileSystemServiceRecoveryTests: XCTestCase {
     private var temporaryRoots = FileSystemTemporaryRoots()
+    private var cancellables = Set<AnyCancellable>()
 
     override func tearDownWithError() throws {
+        cancellables.removeAll()
         temporaryRoots.removeAll()
         try super.tearDownWithError()
     }
@@ -83,7 +85,7 @@ final class FileSystemServiceRecoveryTests: XCTestCase {
             XCTAssertNil(state.lastScannedEventIdByFolder["Sources/Nested"])
             XCTAssertNil(state.lastVerifiedAtByFolder["Sources/Nested"])
             XCTAssertNil(state.fileEventCountSinceLastScan["Sources/Nested"])
-            withExtendedLifetime(cancellable) {}
+            cancellables.insert(cancellable)
         }
 
         func testFolderScanCapSchedulesQuietFollowUpBatchesThroughAcceptedWatermark() async throws {
@@ -211,7 +213,7 @@ final class FileSystemServiceRecoveryTests: XCTestCase {
             XCTAssertEqual(fullResyncPublication.source, .recoveryFullResync)
             XCTAssertEqual(fullResyncPublication.watcherAcceptedWatermark, accepted)
             XCTAssertTrue(fullResyncPublication.deltas.contains(.fileAdded("A/recovered.txt")))
-            withExtendedLifetime(cancellable) {}
+            cancellables.insert(cancellable)
         }
 
         func testParallelScanFailureRestoresStateBeforeSerialFallback() async throws {
@@ -501,7 +503,7 @@ final class FileSystemServiceRecoveryTests: XCTestCase {
                 }
                 XCTAssertTrue(publications.snapshot().isEmpty)
                 await service.abortSeededPreparation(initializationID: initializationID)
-                withExtendedLifetime(cancellable) {}
+                cancellables.insert(cancellable)
             }
         }
 
@@ -553,7 +555,7 @@ final class FileSystemServiceRecoveryTests: XCTestCase {
             XCTAssertEqual(publication.lastServicePublicationSequence, 0)
             XCTAssertEqual(publication.lastPublishedWatcherAcceptedWatermark, .zero)
             await service.abortSeededPreparation(initializationID: initializationID)
-            withExtendedLifetime(cancellable) {}
+            cancellables.insert(cancellable)
         }
 
         private final class LockedPublications: @unchecked Sendable {

--- a/Tests/RepoPromptTests/Services/VCS/GitWorktreeMergeGitServiceTests.swift
+++ b/Tests/RepoPromptTests/Services/VCS/GitWorktreeMergeGitServiceTests.swift
@@ -214,29 +214,32 @@ final class GitWorktreeMergeGitServiceTests: XCTestCase {
         let fixture = try GitMergeFixture()
         defer { fixture.cleanup() }
         let git = GitService()
-        let gate = AsyncGate()
-        let order = LockOrder()
+        let firstEntered = AsyncGate()
+        let releaseFirst = AsyncGate()
+        let order = AsyncTestCondition<[String]>([])
 
         let first = Task {
             try await git.withWorktreeMergeAdvisoryLock(at: fixture.source) {
-                await order.append("first-enter")
-                await gate.open()
-                try await Task.sleep(nanoseconds: 250_000_000)
-                await order.append("first-exit")
+                order.update { $0.append("first-enter") }
+                await firstEntered.open()
+                await releaseFirst.wait()
+                order.update { $0.append("first-exit") }
             }
         }
-        await gate.wait()
+        await firstEntered.wait()
         let second = Task {
             try await git.withWorktreeMergeAdvisoryLock(at: fixture.repo) {
-                await order.append("second-enter")
+                order.update { $0.append("second-enter") }
             }
         }
-        try await Task.sleep(nanoseconds: 50_000_000)
-        let beforeRelease = await order.snapshot()
+        await Task.yield()
+        let beforeRelease = order.snapshot()
         XCTAssertEqual(beforeRelease, ["first-enter"])
+        await releaseFirst.open()
         try await first.value
+        try await order.waitUntil("second lock entry after first release") { $0.contains("second-enter") }
         try await second.value
-        let afterRelease = await order.snapshot()
+        let afterRelease = order.snapshot()
         XCTAssertEqual(afterRelease, ["first-enter", "first-exit", "second-enter"])
         XCTAssertTrue(FileManager.default.fileExists(atPath: fixture.repo.appendingPathComponent(".git/repoprompt-mutex/worktree.lock").path))
     }
@@ -315,14 +318,14 @@ final class GitWorktreeMergeGitServiceTests: XCTestCase {
         }
 
         let git = GitService()
-        let order = LockOrder()
+        let order = AsyncTestCondition<[String]>([])
         let waiter = Task {
             try await git.withWorktreeMergeAdvisoryLock(at: fixture.source) {
-                await order.append("swift-enter")
+                order.update { $0.append("swift-enter") }
             }
         }
-        try await Task.sleep(for: .milliseconds(200))
-        let beforeRelease = await order.snapshot()
+        await Task.yield()
+        let beforeRelease = order.snapshot()
         XCTAssertEqual(beforeRelease, [], "Swift lock entered while another process held the common Git dir lock")
 
         try "release\n".write(to: URL(fileURLWithPath: releasePath), atomically: true, encoding: .utf8)
@@ -349,45 +352,24 @@ final class GitWorktreeMergeGitServiceTests: XCTestCase {
         let holderOutput = String(decoding: output.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
         XCTAssertEqual(holder.terminationStatus, 0, holderOutput)
 
-        let waiterCompleted = try await withThrowingTaskGroup(of: Bool.self) { group in
-            group.addTask {
-                try await waiter.value
-                return true
-            }
-            group.addTask {
-                try await Task.sleep(for: .seconds(10))
-                return false
-            }
-            let completed = try await group.next() ?? false
-            group.cancelAll()
-            return completed
-        }
-        guard waiterCompleted else {
+        do {
+            try await order.waitUntil("Swift lock waiter entry after holder release", timeout: 3) { $0 == ["swift-enter"] }
+            try await waiter.value
+        } catch {
             waiter.cancel()
-            await XCTFail("""
+            XCTFail("""
             Swift lock waiter did not enter after holder released the cross-process flock.
             lock_path: \(lockPath)
             holder_output:
             \(holderOutput)
             observed_order_before_release: \(beforeRelease)
             observed_order_after_timeout: \(order.snapshot())
+            error: \(error)
             """)
             return
         }
-        let afterRelease = await order.snapshot()
+        let afterRelease = order.snapshot()
         XCTAssertEqual(afterRelease, ["swift-enter"], holderOutput)
-    }
-}
-
-private actor LockOrder {
-    private var values: [String] = []
-
-    func append(_ value: String) {
-        values.append(value)
-    }
-
-    func snapshot() -> [String] {
-        values
     }
 }
 

--- a/Tests/RepoPromptTests/WorkspaceContext/CodemapAutomaticSelectionBasicTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/CodemapAutomaticSelectionBasicTests.swift
@@ -1010,8 +1010,7 @@ final class CodemapAutomaticSelectionBasicTests: WorkspaceFileContextStoreCodema
         let target = try XCTUnwrap(files.first { $0.standardizedRelativePath == "Sources/Target.swift" })
         var readyByFileID: [UUID: WorkspaceCodemapArtifactDemandReady] = [:]
         for file in [source, target] {
-            let ticket = try await pendingTicket(store.requestCodemapArtifact(forFileID: file.id))
-            readyByFileID[file.id] = try await readyResult(settledResult(store: store, ticket: ticket))
+            readyByFileID[file.id] = try await readyArtifactDemand(store: store, forFileID: file.id).ready
         }
         let sourceReady = try XCTUnwrap(readyByFileID[source.id])
         let targetReady = try XCTUnwrap(readyByFileID[target.id])
@@ -1096,9 +1095,8 @@ final class CodemapAutomaticSelectionBasicTests: WorkspaceFileContextStoreCodema
         let source = try XCTUnwrap(files.first { $0.standardizedRelativePath == "Sources/Source.swift" })
         var sourceTicket: WorkspaceCodemapArtifactDemandTicket?
         for file in files {
-            let ticket = try await pendingTicket(store.requestCodemapArtifact(forFileID: file.id))
-            _ = try await readyResult(settledResult(store: store, ticket: ticket))
-            if file.id == source.id { sourceTicket = ticket }
+            let demand = try await readyArtifactDemand(store: store, forFileID: file.id)
+            if file.id == source.id { sourceTicket = demand.ticket }
         }
         let identities = await store.codemapAutomaticSelectionSourceIdentities(
             forFileIDs: [source.id],

--- a/Tests/RepoPromptTests/WorkspaceContext/Search/SearchPathFilteringTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/Search/SearchPathFilteringTests.swift
@@ -100,14 +100,35 @@ final class SearchPathFilteringTests: XCTestCase {
             clauses: [.legacyPrefix(candidateLower: "sources")]
         )
 
+        let gate = SearchCancellationGate()
         let task = Task.detached(priority: .background) {
-            try? await Task.sleep(nanoseconds: 10_000_000_000)
+            await gate.wait()
             return filterPathIndicesResult(snapshots: snapshots, spec: spec)
         }
         task.cancel()
+        await gate.open()
         let result = await task.value
 
         XCTAssertTrue(result.cancelled)
-        XCTAssertLessThan(result.visitedSnapshotCount, snapshots.count)
+        XCTAssertEqual(result.visitedSnapshotCount, 0)
+    }
+}
+
+private actor SearchCancellationGate {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func open() {
+        isOpen = true
+        let current = waiters
+        waiters.removeAll()
+        current.forEach { $0.resume() }
+    }
+
+    func wait() async {
+        if isOpen { return }
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
     }
 }

--- a/Tests/RepoPromptTests/WorkspaceContext/WorkspaceFileContextStoreTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/WorkspaceFileContextStoreTests.swift
@@ -23,6 +23,8 @@ private actor UUIDRecorder {
 }
 
 final class WorkspaceFileContextStoreTests: XCTestCase {
+    private var cancellables = Set<AnyCancellable>()
+
     func testRootLoadIndexesFilesFoldersReadsContentAndLooksUpPaths() async throws {
         let rootA = try makeTemporaryRoot(name: "RootA")
         let rootB = try makeTemporaryRoot(name: "RootB")
@@ -720,7 +722,7 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
 
             await service.setMutationIOWillBeginHandlerForTesting(nil)
             await store.stopWatchingRoot(id: record.id)
-            withExtendedLifetime(publicationCancellable) {}
+            cancellables.insert(publicationCancellable)
 
             let postTokenRoot = try makeTemporaryRoot(name: "CancelledOverwriteAfterDeferredToken")
             let postTokenFileURL = postTokenRoot.appendingPathComponent("PostToken.swift")
@@ -776,7 +778,7 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
 
             await postTokenStore.setStoreEditDeferredPublicationDidRegisterHandlerForTesting(nil)
             await postTokenStore.stopWatchingRoot(id: postTokenRecord.id)
-            withExtendedLifetime(postTokenCancellable) {}
+            cancellables.insert(postTokenCancellable)
         }
 
         func testCancelledMoveDeleteAndTrashSettleBeforeIOAndReconcileAfterCompletion() async throws {
@@ -5218,7 +5220,8 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
             XCTAssertEqual(directPublications.flatMap(\.deltas).count, 1, caseLabel)
             let pendingAfterDirectEdit = await serviceB.pendingDeferredEditPublicationCountForTesting()
             XCTAssertEqual(pendingAfterDirectEdit, 0, caseLabel)
-            withExtendedLifetime((cancellableA, cancellableB)) {}
+            cancellables.insert(cancellableA)
+            cancellables.insert(cancellableB)
         }
 
         do {
@@ -5244,7 +5247,7 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
             XCTAssertTrue(publications.snapshot().isEmpty, caseLabel)
             let pendingAfterMissingEdit = await service.pendingDeferredEditPublicationCountForTesting()
             XCTAssertEqual(pendingAfterMissingEdit, 0, caseLabel)
-            withExtendedLifetime(cancellable) {}
+            cancellables.insert(cancellable)
         }
 
         do {
@@ -5275,7 +5278,7 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
             XCTAssertEqual(managedOnlyPublications.flatMap(\.deltas).count, 1, caseLabel)
             let pendingAfterManagedOnlyEdit = await service.pendingDeferredEditPublicationCountForTesting()
             XCTAssertEqual(pendingAfterManagedOnlyEdit, 0, caseLabel)
-            withExtendedLifetime(cancellable) {}
+            cancellables.insert(cancellable)
         }
 
         do {
@@ -5322,7 +5325,7 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
             let pendingAfterStaleLifetime = await service.pendingDeferredEditPublicationCountForTesting()
             XCTAssertEqual(pendingAfterStaleLifetime, 0, caseLabel)
             await service.setMutationIOWillBeginHandlerForTesting(nil)
-            withExtendedLifetime(cancellable) {}
+            cancellables.insert(cancellable)
         }
     }
 


### PR DESCRIPTION
## Summary

- Split hosted app XCTest execution into 4 runtime-balanced shards.
- Batch fast stateless app test suites into bounded direct-XCTest process groups.
- Harden XCTest bundle discovery against stale restored `.xctest` bundles by preferring SwiftPM’s combined `*PackageTests.xctest` bundle when available.
- Move provider package tests into their own CI job.
- Add runtime-ledger import/planning support and regression coverage for CI runner behavior.
- Clean up Codex app-server, FSEvents, wake-observer, and custom-model fetch lifecycle edges.
- Replace fragile sleeps / short-lived cancellables in tests with explicit waiters, retained cancellables, and cancellation-safe cleanup.

## Why

The previous hosted CI app-test path had several bottlenecks and reliability risks:

- app XCTest execution ran through one serial hosted macOS job;
- each suite used its own XCTest process, increasing process startup overhead;
- hosted runners could wedge before XCTest emitted output;
- restored SwiftPM caches could leave stale `.xctest` bundles next to the current combined package test bundle;
- provider tests ran in the same build/test job;
- several async tests relied on sleeps or fragile cancellable lifetimes.

This branch keeps the full validation path intact while making the hosted app-test lane more parallel, more bounded, and easier to diagnose.

## Quantitative impact

Using the checked-in test contract ledger:

- App test planning covers **307 app XCTest suites**.
- The 4 shards are balanced at approximately **187.2s estimated suite runtime each**.
- Total ledger-estimated app-suite runtime is **748.9s**.
- That changes the estimated app-test critical path from ~**748.9s serial** to ~**187.2s parallel**, a roughly **75% reduction in app-test phase wall time** before build/cache/runner overhead.
- Conservative batching reduces planned XCTest launches from **307 suite processes** to **224 process groups**:
  - **83 fewer process launches**
  - about **27% fewer XCTest invocations**
- Batching remains bounded to **4 suites max** and **5 estimated seconds max** per group.
- Silent startup handling remains bounded: **60s silent-startup timeout**, **1 retry**, **180s suite/group timeout**.

These are ledger/planner estimates, not hosted-runner timing results. Hosted CI still needs to confirm real macOS runner behavior.

## Reviewer guide

Suggested review order:

1. **CI/test runner behavior**
   - `.github/workflows/ci.yml`
   - `Scripts/ci_app_test_runner.py`
   - `Scripts/test_ci_app_test_runner.py`

2. **Runtime-ledger planning**
   - `Scripts/test_suite_optimizer.py`
   - `Scripts/test_test_suite_optimizer.py`

3. **Production lifecycle cleanup**
   - `CodexAppServerClient.swift`
   - `CodexNativeSessionController.swift`
   - `FileSystemService*.swift`
   - `ServerController.swift`
   - `APISettingsViewModel.swift`

4. **Test reliability hardening**
   - MCP shared lease / persistent connection tests
   - ContextBuilder nested MCP failure tests
   - FileSystem / VCS / WorkspaceContext wait and cancellable-retention tests

## Validation

- `python3 Scripts/test_ci_app_test_runner.py` — passed, 38 tests
- `make dev-format` — passed
- `make dev-swift-build PRODUCT=RepoPrompt` — passed
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh commit` — passed before each follow-up commit
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh push` — passed

## Notes

- No release metadata, signing, Sparkle, bundle ID, or release-channel changes.
- No visible app launch/relaunch was performed.
- Default push preflight does not run full path-selected PR-ready validation; run `.agents/skills/rpce-contribution-check/scripts/preflight.sh pr-ready` if maintainers want full local PR-ready evidence before merge.
