### PR TITLE
Fix tab slice rebase retries with planned ranges

### DIFF
--- a/Sources/RepoPrompt/Features/WorkspaceFiles/ViewModels/WorkspaceFilesViewModel.swift
+++ b/Sources/RepoPrompt/Features/WorkspaceFiles/ViewModels/WorkspaceFilesViewModel.swift
@@ -1204,6 +1204,7 @@ class WorkspaceFilesViewModel: ObservableObject {
         private var appliedIndexProjectionWillHandleHandler: (@Sendable (UUID, UInt64) async -> Void)?
         private var hiddenSessionSliceRebaseWillCommitHandler: (@Sendable (String) async -> Void)?
         private var hiddenSessionSliceRebaseWillApplyTabPlansHandler: (@Sendable (String) async -> Void)?
+        private var hiddenSessionSliceRangesDidPassOwnershipHandler: (@Sendable (String) async -> Void)?
         private var appliedIndexProjectionStateObserver: ((AppliedIndexProjectionDiagnosticsSnapshot) -> Void)?
 
         func setAppliedIndexProjectionWillHandleHandlerForTesting(
@@ -1222,6 +1223,12 @@ class WorkspaceFilesViewModel: ObservableObject {
             _ handler: (@Sendable (String) async -> Void)?
         ) {
             hiddenSessionSliceRebaseWillApplyTabPlansHandler = handler
+        }
+
+        func setHiddenSessionSliceRangesDidPassOwnershipHandlerForTesting(
+            _ handler: (@Sendable (String) async -> Void)?
+        ) {
+            hiddenSessionSliceRangesDidPassOwnershipHandler = handler
         }
 
         func setAppliedIndexProjectionStateObserverForTesting(
@@ -2057,7 +2064,23 @@ class WorkspaceFilesViewModel: ObservableObject {
                   physicalRootPaths: target.physicalRootPaths
               )
         else { return nil }
-        return SliceRangeMath.normalize(ranges)
+
+        #if DEBUG
+            if let hiddenSessionSliceRangesDidPassOwnershipHandler {
+                await hiddenSessionSliceRangesDidPassOwnershipHandler(target.logicalFullPath)
+            }
+        #endif
+
+        // Re-read after the ownership await (actor hop). A mid-suspension session
+        // clear/switch must not return ranges for a tab that no longer owns the target.
+        guard let refreshedTab = manager.composeTab(for: target.identity),
+              refreshedTab.activeAgentSessionID == target.agentSessionID,
+              let refreshedRanges = StoredSelectionPathNormalization.standardizedSlices(
+                  refreshedTab.selection.slices
+              )[target.logicalFullPath],
+              !refreshedRanges.isEmpty
+        else { return nil }
+        return SliceRangeMath.normalize(refreshedRanges)
     }
 
     @MainActor

--- a/Sources/RepoPrompt/Features/WorkspaceFiles/ViewModels/WorkspaceFilesViewModel.swift
+++ b/Sources/RepoPrompt/Features/WorkspaceFiles/ViewModels/WorkspaceFilesViewModel.swift
@@ -428,6 +428,18 @@ private struct SlicePartitionRebaseCommit {
     }
 }
 
+private struct TabSliceRebasePlanInput {
+    let identity: WorkspaceSelectionIdentity
+    let fullPath: String
+    let expectedRanges: [LineRange]
+}
+
+private struct HiddenSessionTabSliceRebasePlan {
+    let target: HiddenSessionSliceRebaseTarget
+    let expectedLogicalRanges: [LineRange]
+    let plan: WorkspaceManagerViewModel.WorkspaceTabSliceRebasePlan
+}
+
 private struct ReplayRootPassAccumulator {
     let rootKey: String
     var processedDigests: [WorkspaceFilesViewModel.FileSystemDeltaDigest] = []
@@ -1191,6 +1203,7 @@ class WorkspaceFilesViewModel: ObservableObject {
         private var appliedIndexProjectionIndexRebuildVisitedFileCount = 0
         private var appliedIndexProjectionWillHandleHandler: (@Sendable (UUID, UInt64) async -> Void)?
         private var hiddenSessionSliceRebaseWillCommitHandler: (@Sendable (String) async -> Void)?
+        private var hiddenSessionSliceRebaseWillApplyTabPlansHandler: (@Sendable (String) async -> Void)?
         private var appliedIndexProjectionStateObserver: ((AppliedIndexProjectionDiagnosticsSnapshot) -> Void)?
 
         func setAppliedIndexProjectionWillHandleHandlerForTesting(
@@ -1203,6 +1216,12 @@ class WorkspaceFilesViewModel: ObservableObject {
             _ handler: (@Sendable (String) async -> Void)?
         ) {
             hiddenSessionSliceRebaseWillCommitHandler = handler
+        }
+
+        func setHiddenSessionSliceRebaseWillApplyTabPlansHandlerForTesting(
+            _ handler: (@Sendable (String) async -> Void)?
+        ) {
+            hiddenSessionSliceRebaseWillApplyTabPlansHandler = handler
         }
 
         func setAppliedIndexProjectionStateObserverForTesting(
@@ -1693,6 +1712,22 @@ class WorkspaceFilesViewModel: ObservableObject {
         return true
     }
 
+    private nonisolated static func tabSliceRebaseDedupeKey(
+        identity: WorkspaceSelectionIdentity,
+        fullPath: String
+    ) -> String? {
+        guard let standardizedFullPath = StoredSelectionPathNormalization.standardizedPath(fullPath) else {
+            return nil
+        }
+        return "\(identity.workspaceID.uuidString):\(identity.tabID.uuidString):\(standardizedFullPath)"
+    }
+
+    private nonisolated static func tabSliceRebaseDedupeKey(
+        for plan: WorkspaceManagerViewModel.WorkspaceTabSliceRebasePlan
+    ) -> String {
+        "\(plan.identity.workspaceID.uuidString):\(plan.identity.tabID.uuidString):\(plan.fullPath)"
+    }
+
     @MainActor
     private func hiddenSessionSliceRebaseTargets(
         physicalRootPath: String,
@@ -1865,6 +1900,8 @@ class WorkspaceFilesViewModel: ObservableObject {
                     taskID: taskID,
                     registrationGeneration: registrationGeneration
                 ) else { return }
+                var tabPlans: [HiddenSessionTabSliceRebasePlan] = []
+                var plannedTargetKeys = Set<String>()
                 for commit in partitionCommits {
                     guard await isHiddenSessionSliceRebaseCurrent(
                         request,
@@ -1894,52 +1931,69 @@ class WorkspaceFilesViewModel: ObservableObject {
                         ) != nil else {
                             return
                         }
+                        if let target = commit.hiddenSessionTarget,
+                           let expectedLogicalRanges = commit.expectedLogicalRanges,
+                           let plan = WorkspaceManagerViewModel.WorkspaceTabSliceRebasePlan(
+                               identity: target.identity,
+                               fullPath: target.logicalFullPath,
+                               expectedRanges: expectedLogicalRanges,
+                               rebasedRanges: commit.ranges
+                           )
+                        {
+                            tabPlans.append(HiddenSessionTabSliceRebasePlan(
+                                target: target,
+                                expectedLogicalRanges: expectedLogicalRanges,
+                                plan: plan
+                            ))
+                            plannedTargetKeys.insert(Self.tabSliceRebaseDedupeKey(for: plan))
+                        }
                     } catch {
                         return
                     }
                 }
-                var stillCurrentTargets: [HiddenSessionSliceRebaseTarget] = []
-                for target in currentTargets where await isHiddenSessionSliceRebaseTargetCurrent(target) {
-                    stillCurrentTargets.append(target)
-                }
-                guard !stillCurrentTargets.isEmpty else { return }
-                let targets = stillCurrentTargets.map { (identity: $0.identity, fullPath: $0.logicalFullPath) }
-                await workspaceManager?.rebaseSlicesForFilesAcrossTabs(
-                    targets: targets,
-                    asyncTransform: { identity, logicalFullPath, currentRanges in
-                        if let commit = partitionCommits.first(where: { commit in
-                            guard let target = commit.hiddenSessionTarget else { return false }
-                            return target.identity == identity && target.logicalFullPath == logicalFullPath
-                        }), let expectedLogicalRanges = commit.expectedLogicalRanges {
-                            let normalizedCurrent = SliceRangeMath.normalize(currentRanges)
-                            let normalizedCommitted = SliceRangeMath.normalize(commit.ranges)
-                            if normalizedCurrent == normalizedCommitted {
-                                return normalizedCurrent
-                            }
-                            if normalizedCurrent == SliceRangeMath.normalize(expectedLogicalRanges) {
-                                return normalizedCommitted
-                            }
-                        }
-
-                        return await Task.detached(priority: .utility) {
-                            let engineStartedMS = ProcessInfo.processInfo.systemUptime * 1000
-                            let result = SliceRebaseEngine.rebase(
-                                oldText: sourceSnapshot.text,
-                                newText: loadedSnapshot.text,
-                                oldRanges: currentRanges,
-                                anchors: nil
-                            )
-                            #if DEBUG
-                                MCPApplyEditsRebaseProbeRecorder.recordEngineCall(
-                                    fullPath: logicalFullPath,
-                                    durationMS: ProcessInfo.processInfo.systemUptime * 1000 - engineStartedMS,
-                                    scope: "hidden-tab"
-                                )
-                            #endif
-                            return result.isStale ? currentRanges : result.rebased
-                        }.value
+                for target in currentTargets {
+                    guard let targetKey = Self.tabSliceRebaseDedupeKey(
+                        identity: target.identity,
+                        fullPath: target.logicalFullPath
+                    ), !plannedTargetKeys.contains(targetKey),
+                    await isHiddenSessionSliceRebaseTargetCurrent(target),
+                    let expectedLogicalRanges = await hiddenSessionSliceRangesIfTargetCurrent(target)
+                    else { continue }
+                    let input = TabSliceRebasePlanInput(
+                        identity: target.identity,
+                        fullPath: target.logicalFullPath,
+                        expectedRanges: expectedLogicalRanges
+                    )
+                    if let plan = await Self.computeTabSliceRebasePlan(
+                        input: input,
+                        oldText: sourceSnapshot.text,
+                        newText: loadedSnapshot.text,
+                        debugFullPath: target.logicalFullPath,
+                        debugScope: "hidden-tab"
+                    ) {
+                        tabPlans.append(HiddenSessionTabSliceRebasePlan(
+                            target: target,
+                            expectedLogicalRanges: expectedLogicalRanges,
+                            plan: plan
+                        ))
+                        plannedTargetKeys.insert(Self.tabSliceRebaseDedupeKey(for: plan))
                     }
-                )
+                }
+                #if DEBUG
+                    if let hiddenSessionSliceRebaseWillApplyTabPlansHandler {
+                        await hiddenSessionSliceRebaseWillApplyTabPlansHandler(fullPath)
+                    }
+                #endif
+                var applicablePlans: [WorkspaceManagerViewModel.WorkspaceTabSliceRebasePlan] = []
+                for tabPlan in tabPlans {
+                    guard await isHiddenSessionSliceRebaseTargetCurrent(tabPlan.target),
+                          await hiddenSessionSliceRangesIfTargetCurrent(tabPlan.target) == tabPlan.expectedLogicalRanges
+                    else { continue }
+                    applicablePlans.append(tabPlan.plan)
+                }
+                if !applicablePlans.isEmpty {
+                    await workspaceManager?.applyPlannedSliceRebasesAcrossTabs(applicablePlans)
+                }
                 guard await isHiddenSessionSliceRebaseCurrent(
                     request,
                     taskID: taskID,
@@ -12808,6 +12862,111 @@ extension WorkspaceFilesViewModel {
     }
 
     @MainActor
+    private func captureTabSliceRebasePlanInputs(
+        workspaceID: UUID,
+        fullPath: String
+    ) -> [TabSliceRebasePlanInput] {
+        guard let standardizedFullPath = StoredSelectionPathNormalization.standardizedPath(fullPath),
+              let tabs = workspaceManager?.activeWorkspace?.composeTabs
+        else { return [] }
+
+        var inputs: [TabSliceRebasePlanInput] = []
+        var seen = Set<UUID>()
+        for tab in tabs where seen.insert(tab.id).inserted {
+            let slices = StoredSelectionPathNormalization.standardizedSlices(tab.selection.slices)
+            guard let ranges = slices[standardizedFullPath] else { continue }
+            let normalizedRanges = SliceRangeMath.normalize(ranges)
+            guard !normalizedRanges.isEmpty else { continue }
+            inputs.append(TabSliceRebasePlanInput(
+                identity: WorkspaceSelectionIdentity(workspaceID: workspaceID, tabID: tab.id),
+                fullPath: standardizedFullPath,
+                expectedRanges: normalizedRanges
+            ))
+        }
+        return inputs
+    }
+
+    private nonisolated static func matchingTabPartitionCommit(
+        for input: TabSliceRebasePlanInput,
+        in commits: [SlicePartitionRebaseCommit]
+    ) -> SlicePartitionRebaseCommit? {
+        commits.first { commit in
+            guard commit.scope.workspaceID == input.identity.workspaceID,
+                  commit.scope.tabID == input.identity.tabID
+            else { return false }
+            return SliceRangeMath.normalize(commit.expectedStoredSlices.ranges) == input.expectedRanges
+        }
+    }
+
+    private nonisolated static func computeTabSliceRebasePlan(
+        input: TabSliceRebasePlanInput,
+        oldText: String,
+        newText: String,
+        debugFullPath: String,
+        debugScope: String
+    ) async -> WorkspaceManagerViewModel.WorkspaceTabSliceRebasePlan? {
+        guard oldText != newText else { return nil }
+        let computed = await Task.detached(priority: .utility) {
+            let engineStartedMS = ProcessInfo.processInfo.systemUptime * 1000
+            let result = SliceRebaseEngine.rebase(
+                oldText: oldText,
+                newText: newText,
+                oldRanges: input.expectedRanges,
+                anchors: nil
+            )
+            #if DEBUG
+                MCPApplyEditsRebaseProbeRecorder.recordEngineCall(
+                    fullPath: debugFullPath,
+                    durationMS: ProcessInfo.processInfo.systemUptime * 1000 - engineStartedMS,
+                    scope: debugScope
+                )
+            #endif
+            return result.isStale ? nil : result.rebased
+        }.value
+        guard let computed else { return nil }
+        return WorkspaceManagerViewModel.WorkspaceTabSliceRebasePlan(
+            identity: input.identity,
+            fullPath: input.fullPath,
+            expectedRanges: input.expectedRanges,
+            rebasedRanges: computed
+        )
+    }
+
+    private nonisolated static func computeTabSliceRebasePlans(
+        inputs: [TabSliceRebasePlanInput],
+        partitionCommits: [SlicePartitionRebaseCommit],
+        oldText: String,
+        newText: String,
+        fullPath: String
+    ) async -> [WorkspaceManagerViewModel.WorkspaceTabSliceRebasePlan] {
+        var plans: [WorkspaceManagerViewModel.WorkspaceTabSliceRebasePlan] = []
+        for input in inputs {
+            if let commit = matchingTabPartitionCommit(for: input, in: partitionCommits),
+               let plan = WorkspaceManagerViewModel.WorkspaceTabSliceRebasePlan(
+                   identity: input.identity,
+                   fullPath: input.fullPath,
+                   expectedRanges: input.expectedRanges,
+                   rebasedRanges: commit.ranges
+               )
+            {
+                plans.append(plan)
+                continue
+            }
+
+            if let plan = await computeTabSliceRebasePlan(
+                input: input,
+                oldText: oldText,
+                newText: newText,
+                debugFullPath: fullPath,
+                debugScope: "tab"
+            ) {
+                plans.append(plan)
+            }
+        }
+        return plans
+    }
+
+    @MainActor
     private func rebaseSlicesForModifiedFile(
         _ file: FileViewModel,
         relativePath: String,
@@ -12856,6 +13015,7 @@ extension WorkspaceFilesViewModel {
               )
         else { return }
 
+        let tabPlanInputs = captureTabSliceRebasePlanInputs(workspaceID: workspaceID, fullPath: fullPath)
         var partitionCommits: [SlicePartitionRebaseCommit] = []
         var encounteredStalePartition = false
 
@@ -12909,6 +13069,14 @@ extension WorkspaceFilesViewModel {
             ))
         }
 
+        let tabPlans = await Self.computeTabSliceRebasePlans(
+            inputs: tabPlanInputs,
+            partitionCommits: partitionCommits,
+            oldText: sourceSnapshot?.text ?? loadedSnapshot.text,
+            newText: loadedSnapshot.text,
+            fullPath: fullPath
+        )
+
         await beginSliceRebaseCommit(
             workspaceID: workspaceID,
             rootID: workspaceRoot.id,
@@ -12920,6 +13088,7 @@ extension WorkspaceFilesViewModel {
             relativePath: relKey,
             activeScope: activeScope,
             partitionCommits: partitionCommits,
+            tabPlans: tabPlans,
             sourceSnapshot: sourceSnapshot,
             loadedSnapshot: loadedSnapshot,
             encounteredStalePartition: encounteredStalePartition
@@ -13013,6 +13182,7 @@ extension WorkspaceFilesViewModel {
         relativePath: String,
         activeScope: PartitionScope?,
         partitionCommits: [SlicePartitionRebaseCommit],
+        tabPlans: [WorkspaceManagerViewModel.WorkspaceTabSliceRebasePlan],
         sourceSnapshot: SliceRebaseSourceSnapshot?,
         loadedSnapshot: SliceRebaseSourceSnapshot,
         encounteredStalePartition: Bool
@@ -13038,6 +13208,7 @@ extension WorkspaceFilesViewModel {
                 relativePath: relativePath,
                 activeScope: activeScope,
                 partitionCommits: partitionCommits,
+                tabPlans: tabPlans,
                 sourceSnapshot: sourceSnapshot,
                 loadedSnapshot: loadedSnapshot,
                 encounteredStalePartition: encounteredStalePartition
@@ -13059,6 +13230,7 @@ extension WorkspaceFilesViewModel {
         relativePath: String,
         activeScope: PartitionScope?,
         partitionCommits: [SlicePartitionRebaseCommit],
+        tabPlans: [WorkspaceManagerViewModel.WorkspaceTabSliceRebasePlan],
         sourceSnapshot: SliceRebaseSourceSnapshot?,
         loadedSnapshot: SliceRebaseSourceSnapshot,
         encounteredStalePartition: Bool
@@ -13138,29 +13310,7 @@ extension WorkspaceFilesViewModel {
               )
         else { return }
 
-        let tabOldText = sourceSnapshot?.text ?? loadedSnapshot.text
-        await workspaceManager?.rebaseSlicesForFileAcrossTabs(
-            fullPath: fullPath,
-            asyncTransform: { _, current in
-                await Task.detached(priority: .utility) {
-                    let engineStartedMS = ProcessInfo.processInfo.systemUptime * 1000
-                    let result = SliceRebaseEngine.rebase(
-                        oldText: tabOldText,
-                        newText: loadedSnapshot.text,
-                        oldRanges: current,
-                        anchors: nil
-                    )
-                    #if DEBUG
-                        MCPApplyEditsRebaseProbeRecorder.recordEngineCall(
-                            fullPath: fullPath,
-                            durationMS: ProcessInfo.processInfo.systemUptime * 1000 - engineStartedMS,
-                            scope: "tab"
-                        )
-                    #endif
-                    return result.isStale ? current : result.rebased
-                }.value
-            }
-        )
+        await workspaceManager?.applyPlannedSliceRebasesAcrossTabs(tabPlans)
 
         guard persistenceSucceeded,
               !encounteredStalePartition,

--- a/Sources/RepoPrompt/Features/Workspaces/ViewModels/WorkspaceManagerViewModel.swift
+++ b/Sources/RepoPrompt/Features/Workspaces/ViewModels/WorkspaceManagerViewModel.swift
@@ -5391,6 +5391,28 @@ class WorkspaceManagerViewModel: ObservableObject {
         return true
     }
 
+    struct WorkspaceTabSliceRebasePlan: Equatable {
+        let identity: WorkspaceSelectionIdentity
+        let fullPath: String
+        let expectedRanges: [LineRange]
+        let rebasedRanges: [LineRange]
+
+        init?(
+            identity: WorkspaceSelectionIdentity,
+            fullPath: String,
+            expectedRanges: [LineRange],
+            rebasedRanges: [LineRange]
+        ) {
+            guard let standardizedFullPath = StoredSelectionPathNormalization.standardizedPath(fullPath) else {
+                return nil
+            }
+            self.identity = identity
+            self.fullPath = standardizedFullPath
+            self.expectedRanges = SliceRangeMath.normalize(expectedRanges)
+            self.rebasedRanges = SliceRangeMath.normalize(rebasedRanges)
+        }
+    }
+
     nonisolated static func rebasedStoredSelectionSlices(
         _ selection: StoredSelection,
         for fullPath: String,
@@ -5406,6 +5428,43 @@ class WorkspaceManagerViewModel: ObservableObject {
         }
 
         let nextRanges = SliceRangeMath.normalize(transform(existingRanges))
+        return storedSelection(
+            selection,
+            replacingSlices: normalizedSlices,
+            for: standardizedFullPath,
+            with: nextRanges
+        )
+    }
+
+    nonisolated static func rebasedStoredSelectionSlices(
+        _ selection: StoredSelection,
+        applying plan: WorkspaceTabSliceRebasePlan
+    ) -> StoredSelection? {
+        let normalizedSlices = StoredSelectionPathNormalization.standardizedSlices(selection.slices)
+        guard let currentRanges = normalizedSlices[plan.fullPath] else {
+            return nil
+        }
+        let normalizedCurrent = SliceRangeMath.normalize(currentRanges)
+        if normalizedCurrent == plan.rebasedRanges {
+            return nil
+        }
+        guard normalizedCurrent == plan.expectedRanges else {
+            return nil
+        }
+        return storedSelection(
+            selection,
+            replacingSlices: normalizedSlices,
+            for: plan.fullPath,
+            with: plan.rebasedRanges
+        )
+    }
+
+    private nonisolated static func storedSelection(
+        _ selection: StoredSelection,
+        replacingSlices normalizedSlices: [String: [LineRange]],
+        for standardizedFullPath: String,
+        with nextRanges: [LineRange]
+    ) -> StoredSelection? {
         var nextSlices = normalizedSlices
         if nextRanges.isEmpty {
             nextSlices.removeValue(forKey: standardizedFullPath)
@@ -5509,50 +5568,51 @@ class WorkspaceManagerViewModel: ObservableObject {
         asyncTransform: @Sendable (WorkspaceSelectionIdentity, String, [LineRange]) async -> [LineRange]
     ) async {
         var seen = Set<String>()
+        var plans: [WorkspaceTabSliceRebasePlan] = []
         for target in targets {
             guard let standardizedFullPath = StoredSelectionPathNormalization.standardizedPath(target.fullPath) else {
                 continue
             }
             let dedupeKey = "\(target.identity.workspaceID.uuidString):\(target.identity.tabID.uuidString):\(standardizedFullPath)"
             guard seen.insert(dedupeKey).inserted else { continue }
+            guard let currentTab = composeTab(for: target.identity),
+                  !currentTab.selection.slices.isEmpty
+            else { continue }
+            let currentSlices = StoredSelectionPathNormalization.standardizedSlices(currentTab.selection.slices)
+            guard let currentRanges = currentSlices[standardizedFullPath] else { continue }
+            let nextRanges = await asyncTransform(target.identity, standardizedFullPath, currentRanges)
+            if let plan = WorkspaceTabSliceRebasePlan(
+                identity: target.identity,
+                fullPath: standardizedFullPath,
+                expectedRanges: currentRanges,
+                rebasedRanges: nextRanges
+            ) {
+                plans.append(plan)
+            }
+        }
+        await applyPlannedSliceRebasesAcrossTabs(plans)
+    }
+
+    @MainActor
+    func applyPlannedSliceRebasesAcrossTabs(_ plans: [WorkspaceTabSliceRebasePlan]) async {
+        var seen = Set<String>()
+        for plan in plans {
+            let dedupeKey = "\(plan.identity.workspaceID.uuidString):\(plan.identity.tabID.uuidString):\(plan.fullPath)"
+            guard seen.insert(dedupeKey).inserted else { continue }
             #if DEBUG
-                MCPApplyEditsRebaseProbeRecorder.recordTabInspection(fullPath: standardizedFullPath)
+                MCPApplyEditsRebaseProbeRecorder.recordTabInspection(fullPath: plan.fullPath)
             #endif
             for _ in 0 ..< 3 {
-                guard let currentTab = composeTab(for: target.identity),
-                      !currentTab.selection.slices.isEmpty
+                guard var latestTab = composeTab(for: plan.identity),
+                      let nextSelection = Self.rebasedStoredSelectionSlices(latestTab.selection, applying: plan)
                 else { break }
-                let currentSlices = StoredSelectionPathNormalization.standardizedSlices(currentTab.selection.slices)
-                guard let currentRanges = currentSlices[standardizedFullPath] else { break }
-
-                let nextRanges = await SliceRangeMath.normalize(
-                    asyncTransform(target.identity, standardizedFullPath, currentRanges)
-                )
-                guard var latestTab = composeTab(for: target.identity) else { break }
-                let latestSlices = StoredSelectionPathNormalization.standardizedSlices(latestTab.selection.slices)
-                guard let latestRanges = latestSlices[standardizedFullPath] else { break }
-                guard latestRanges == currentRanges else { continue }
-
-                var nextSlices = latestSlices
-                if nextRanges.isEmpty {
-                    nextSlices.removeValue(forKey: standardizedFullPath)
-                } else {
-                    nextSlices[standardizedFullPath] = nextRanges
-                }
-                guard nextSlices != latestTab.selection.slices else { break }
 
                 let expectedSelection = latestTab.selection
-                let nextSelection = StoredSelection(
-                    selectedPaths: expectedSelection.selectedPaths,
-                    manualCodemapPaths: expectedSelection.manualCodemapPaths,
-                    slices: nextSlices,
-                    codemapAutoEnabled: expectedSelection.codemapAutoEnabled
-                )
                 let persistedSelection: StoredSelection
                 if let selectionCoordinator {
                     persistedSelection = await selectionCoordinator.persistSelection(
                         nextSelection,
-                        for: target.identity,
+                        for: plan.identity,
                         source: .mcpTabContext,
                         mirrorToUIIfActive: true,
                         expectedCurrentSelection: expectedSelection
@@ -5562,12 +5622,12 @@ class WorkspaceManagerViewModel: ObservableObject {
                     latestTab.lastModified = Date()
                     persistedSelection = updateComposeTabStoredOnly(
                         latestTab,
-                        inWorkspaceID: target.identity.workspaceID
+                        inWorkspaceID: plan.identity.workspaceID
                     ) ? nextSelection : expectedSelection
                 }
                 guard persistedSelection == nextSelection else { continue }
                 #if DEBUG
-                    MCPApplyEditsRebaseProbeRecorder.recordTabWrite(fullPath: standardizedFullPath)
+                    MCPApplyEditsRebaseProbeRecorder.recordTabWrite(fullPath: plan.fullPath)
                 #endif
                 break
             }

--- a/Tests/RepoPromptTests/MCP/Control/PersistentAgentModeMCPReadFileConnectionTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/PersistentAgentModeMCPReadFileConnectionTests.swift
@@ -645,6 +645,59 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
             XCTAssertEqual(selection.slices[targetLogicalPath], expectedRanges)
             fixture.window.workspaceManager.workspaces[workspaceIndex].composeTabs[tabIndex].activeAgentSessionID = Fixture.agentSessionID
 
+            // Pause after ownership await inside hiddenSessionSliceRangesIfTargetCurrent, then
+            // clear the tab's active session while selection ranges stay unchanged. Post-await
+            // re-read must fail closed so ranges from the pre-await snapshot are not returned.
+            let ownershipPassGate = PersistentAsyncGate()
+            fixture.window.workspaceFilesViewModel.setHiddenSessionSliceRangesDidPassOwnershipHandlerForTesting { path in
+                guard path == targetLogicalPath || path == physicalURL.path else { return }
+                await ownershipPassGate.markStartedAndWaitForRelease()
+            }
+            defer {
+                fixture.window.workspaceFilesViewModel.setHiddenSessionSliceRangesDidPassOwnershipHandlerForTesting(nil)
+                Task { await ownershipPassGate.release() }
+            }
+            var ownershipRaceLines = editedLines
+            ownershipRaceLines.insert(contentsOf: (1 ... 10).map { "ownership-race-insert-\($0)" }, at: 0)
+            let ownershipReplacementURL = physicalURL.deletingLastPathComponent()
+                .appendingPathComponent(".SessionWorktree6500.swift.ownership-\(UUID().uuidString)")
+            try (ownershipRaceLines.joined(separator: "\n") + "\n").write(
+                to: ownershipReplacementURL,
+                atomically: false,
+                encoding: .utf8
+            )
+            _ = try FileManager.default.replaceItemAt(physicalURL, withItemAt: ownershipReplacementURL)
+            let ownershipAccepted = try await fixture.window.workspaceFileContextStore.acceptWatcherPayloadForTesting(
+                rootID: fixture.installedWorktreeRootID,
+                events: [(
+                    absolutePath: physicalURL.path,
+                    flags: FSEventStreamEventFlags(
+                        kFSEventStreamEventFlagItemRenamed
+                            | kFSEventStreamEventFlagItemCreated
+                            | kFSEventStreamEventFlagItemIsFile
+                    ),
+                    eventId: 8_900_000_000_000_000_004
+                )]
+            )
+            XCTAssertNotNil(ownershipAccepted)
+            _ = await fixture.window.workspaceFileContextStore.awaitAppliedIngressForExplicitRequest(
+                userPath: physicalURL.path,
+                fallbackScope: .allLoaded
+            )
+            try await requireGateStarted(ownershipPassGate)
+            fixture.window.workspaceManager.workspaces[workspaceIndex].composeTabs[tabIndex].activeAgentSessionID = nil
+            await ownershipPassGate.release()
+            fixture.window.workspaceFilesViewModel.setHiddenSessionSliceRangesDidPassOwnershipHandlerForTesting(nil)
+            let ownershipFence = await fixture.window.workspaceFilesViewModel.waitForPendingSliceRebasesAndCaptureFence(
+                affectingCandidatePaths: [physicalURL.path]
+            )
+            XCTAssertTrue(fixture.window.workspaceFilesViewModel.isSliceRebaseFenceCurrent(ownershipFence))
+            selection = try XCTUnwrap(
+                fixture.window.workspaceManager.composeTab(with: Fixture.tabID)?.selection
+            )
+            XCTAssertEqual(selection.slices[targetLogicalPath], expectedRanges)
+            fixture.window.workspaceManager.workspaces[workspaceIndex].composeTabs[tabIndex].activeAgentSessionID = Fixture.agentSessionID
+
             // `manage_selection get` flushes pending active-UI state before replying. Hidden
             // worktree-only paths cannot materialize in the visible file tree, so the MCP-owned
             // canonical selection fence must advance with the watcher-driven rebase rather than

--- a/Tests/RepoPromptTests/MCP/Control/PersistentAgentModeMCPReadFileConnectionTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/PersistentAgentModeMCPReadFileConnectionTests.swift
@@ -586,6 +586,65 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
             XCTAssertNil(selection.slices[unrelatedLogicalPath])
             XCTAssertEqual(selection.slices[targetLogicalPath], expectedRanges)
 
+            // Pause a successor after partition CAS but before planned tab application, then
+            // stale the hidden target without changing ranges. The post-CAS target recheck must
+            // prevent the already-built plan from applying to a no-longer-owned hidden session.
+            let staleTabPlanGate = PersistentAsyncGate()
+            fixture.window.workspaceFilesViewModel.setHiddenSessionSliceRebaseWillApplyTabPlansHandlerForTesting { path in
+                guard path == physicalURL.path else { return }
+                await staleTabPlanGate.markStartedAndWaitForRelease()
+            }
+            defer {
+                fixture.window.workspaceFilesViewModel.setHiddenSessionSliceRebaseWillApplyTabPlansHandlerForTesting(nil)
+                Task { await staleTabPlanGate.release() }
+            }
+            var postCASTabStaleLines = editedLines
+            postCASTabStaleLines.insert(contentsOf: (1 ... 10).map { "post-cas-insert-\($0)" }, at: 0)
+            let postCASReplacementURL = physicalURL.deletingLastPathComponent()
+                .appendingPathComponent(".SessionWorktree6500.swift.post-cas-\(UUID().uuidString)")
+            try (postCASTabStaleLines.joined(separator: "\n") + "\n").write(
+                to: postCASReplacementURL,
+                atomically: false,
+                encoding: .utf8
+            )
+            _ = try FileManager.default.replaceItemAt(physicalURL, withItemAt: postCASReplacementURL)
+            let postCASAccepted = try await fixture.window.workspaceFileContextStore.acceptWatcherPayloadForTesting(
+                rootID: fixture.installedWorktreeRootID,
+                events: [(
+                    absolutePath: physicalURL.path,
+                    flags: FSEventStreamEventFlags(
+                        kFSEventStreamEventFlagItemRenamed
+                            | kFSEventStreamEventFlagItemCreated
+                            | kFSEventStreamEventFlagItemIsFile
+                    ),
+                    eventId: 8_900_000_000_000_000_002
+                )]
+            )
+            XCTAssertNotNil(postCASAccepted)
+            _ = await fixture.window.workspaceFileContextStore.awaitAppliedIngressForExplicitRequest(
+                userPath: physicalURL.path,
+                fallbackScope: .allLoaded
+            )
+            try await requireGateStarted(staleTabPlanGate)
+            let workspaceIndex = try XCTUnwrap(
+                fixture.window.workspaceManager.workspaces.firstIndex { $0.id == fixture.workspaceID }
+            )
+            let tabIndex = try XCTUnwrap(
+                fixture.window.workspaceManager.workspaces[workspaceIndex].composeTabs.firstIndex { $0.id == Fixture.tabID }
+            )
+            fixture.window.workspaceManager.workspaces[workspaceIndex].composeTabs[tabIndex].activeAgentSessionID = nil
+            await staleTabPlanGate.release()
+            fixture.window.workspaceFilesViewModel.setHiddenSessionSliceRebaseWillApplyTabPlansHandlerForTesting(nil)
+            let postCASFence = await fixture.window.workspaceFilesViewModel.waitForPendingSliceRebasesAndCaptureFence(
+                affectingCandidatePaths: [physicalURL.path]
+            )
+            XCTAssertTrue(fixture.window.workspaceFilesViewModel.isSliceRebaseFenceCurrent(postCASFence))
+            selection = try XCTUnwrap(
+                fixture.window.workspaceManager.composeTab(with: Fixture.tabID)?.selection
+            )
+            XCTAssertEqual(selection.slices[targetLogicalPath], expectedRanges)
+            fixture.window.workspaceManager.workspaces[workspaceIndex].composeTabs[tabIndex].activeAgentSessionID = Fixture.agentSessionID
+
             // `manage_selection get` flushes pending active-UI state before replying. Hidden
             // worktree-only paths cannot materialize in the visible file tree, so the MCP-owned
             // canonical selection fence must advance with the watcher-driven rebase rather than
@@ -630,7 +689,7 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
                             | kFSEventStreamEventFlagItemCreated
                             | kFSEventStreamEventFlagItemIsFile
                     ),
-                    eventId: 8_900_000_000_000_000_002
+                    eventId: 8_900_000_000_000_000_003
                 )]
             )
             XCTAssertNotNil(staleAccepted)

--- a/Tests/RepoPromptTests/WorkspaceContext/Slices/SelectionSlicePersistenceAndRebaseTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/Slices/SelectionSlicePersistenceAndRebaseTests.swift
@@ -342,6 +342,41 @@ final class SelectionSlicePersistenceAndRebaseTests: XCTestCase {
         XCTAssertNil(WorkspaceManagerViewModel.rebasedStoredSelectionSlices(independentlyChanged, applying: plan))
     }
 
+    func testApplyPlannedSliceRebasesPlanRebuildsAgainstLatestExpectedRangesAfterCASDrift() throws {
+        // Models the applyPlannedSliceRebasesAcrossTabs retry loop: a failed CAS leaves the
+        // tab on its current selection; the next iteration rebuilds from latest expected
+        // ranges. Once applied, the same plan fails closed (idempotent).
+        let workspaceID = UUID()
+        let tabID = UUID()
+        let editedPath = "/tmp/CAS-retry.swift"
+        let expectedRanges = [LineRange(start: 2, end: 3, description: "edited")]
+        let rebasedRanges = [LineRange(start: 5, end: 6, description: "edited")]
+        let initialSelection = StoredSelection(
+            selectedPaths: [editedPath],
+            slices: [editedPath: expectedRanges],
+            codemapAutoEnabled: false
+        )
+        let plan = try XCTUnwrap(WorkspaceManagerViewModel.WorkspaceTabSliceRebasePlan(
+            identity: WorkspaceSelectionIdentity(workspaceID: workspaceID, tabID: tabID),
+            fullPath: editedPath,
+            expectedRanges: expectedRanges,
+            rebasedRanges: rebasedRanges
+        ))
+
+        // Simulated first attempt: CAS fails, tab stays on initialSelection.
+        XCTAssertEqual(
+            WorkspaceManagerViewModel.rebasedStoredSelectionSlices(initialSelection, applying: plan)?.slices[editedPath],
+            rebasedRanges
+        )
+        // Simulated successful attempt: apply against still-matching expected ranges.
+        let afterApply = try XCTUnwrap(
+            WorkspaceManagerViewModel.rebasedStoredSelectionSlices(initialSelection, applying: plan)
+        )
+        XCTAssertEqual(afterApply.slices[editedPath], rebasedRanges)
+        // Next retry against already-rebased selection fails closed (no double apply).
+        XCTAssertNil(WorkspaceManagerViewModel.rebasedStoredSelectionSlices(afterApply, applying: plan))
+    }
+
     func testSliceRebaseTransformsOverlapMatrixWithStableAffinity() {
         struct Case {
             let name: String

--- a/Tests/RepoPromptTests/WorkspaceContext/Slices/SelectionSlicePersistenceAndRebaseTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/Slices/SelectionSlicePersistenceAndRebaseTests.swift
@@ -304,6 +304,44 @@ final class SelectionSlicePersistenceAndRebaseTests: XCTestCase {
         XCTAssertFalse(result.isStale)
     }
 
+    func testPlannedTabSliceRebaseIsIdempotentAndFailsClosed() throws {
+        let workspaceID = UUID()
+        let tabID = UUID()
+        let editedPath = "/tmp/Selected.swift"
+        let unrelatedPath = "/tmp/Unrelated.swift"
+        let expectedRanges = [LineRange(start: 10, end: 12, description: "edited")]
+        let rebasedRanges = [LineRange(start: 15, end: 17, description: "edited")]
+        let selection = StoredSelection(
+            selectedPaths: [editedPath, unrelatedPath],
+            slices: [
+                editedPath: expectedRanges,
+                unrelatedPath: [LineRange(start: 30, end: 35, description: "unrelated")]
+            ],
+            codemapAutoEnabled: false
+        )
+        let plan = try XCTUnwrap(WorkspaceManagerViewModel.WorkspaceTabSliceRebasePlan(
+            identity: WorkspaceSelectionIdentity(workspaceID: workspaceID, tabID: tabID),
+            fullPath: editedPath,
+            expectedRanges: expectedRanges,
+            rebasedRanges: rebasedRanges
+        ))
+
+        let applied = try XCTUnwrap(WorkspaceManagerViewModel.rebasedStoredSelectionSlices(selection, applying: plan))
+        XCTAssertEqual(applied.slices[editedPath], rebasedRanges)
+        XCTAssertEqual(applied.slices[unrelatedPath], selection.slices[unrelatedPath])
+        XCTAssertNil(WorkspaceManagerViewModel.rebasedStoredSelectionSlices(applied, applying: plan))
+
+        let independentlyChanged = StoredSelection(
+            selectedPaths: selection.selectedPaths,
+            slices: [
+                editedPath: [LineRange(start: 40, end: 42, description: "manual")],
+                unrelatedPath: [LineRange(start: 30, end: 35, description: "unrelated")]
+            ],
+            codemapAutoEnabled: false
+        )
+        XCTAssertNil(WorkspaceManagerViewModel.rebasedStoredSelectionSlices(independentlyChanged, applying: plan))
+    }
+
     func testSliceRebaseTransformsOverlapMatrixWithStableAffinity() {
         struct Case {
             let name: String


### PR DESCRIPTION
## Summary

Follow-up to #379.

- Replace live tab-slice rebasing with planned expected→rebased range application, so retry paths are idempotent and unknown states fail closed instead of being rebased again.
- Update visible-root and hidden-session rebase paths to build tab plans from captured pre-await ranges.
- Carry and revalidate hidden-session targets immediately before applying planned tab rebases.
- Add regression coverage for planned rebase idempotency/fail-closed behavior and the hidden-session post-CAS stale-target race.
- Update the XCTest contract ledger for the new and expanded coverage.

## Why

This is a focused correctness follow-up to #379, not another CI/test-suite optimization change. That PR included an initial hidden-session slice rebase fix, and review feedback correctly pointed out that the deeper issue was not hidden-session ownership itself, but that tab slice rebasing could become coordinate-epoch ambiguous across async retry boundaries.

The previous tab rebase flow could resume after async partition writes and compute against whatever ranges were live in the tab at retry time. That made already-rebased ranges or stale hidden-session mappings vulnerable to being transformed again.

This change makes tab rebase application explicit: apply only when the tab still matches the captured expected ranges, no-op when it is already at the planned rebased ranges, and skip otherwise.

## Reviewer guide

Suggested review order:

1. `WorkspaceManagerViewModel.swift`
   - planned tab rebase model
   - idempotent/fail-closed application helper
   - CAS retry behavior

2. `WorkspaceFilesViewModel.swift`
   - visible-root plan construction
   - hidden-session target revalidation before tab apply

3. Regression tests
   - planned helper idempotency/fail-closed coverage
   - hidden-session post-CAS stale-target race coverage

## Validation

- `make guardrails`
- `make dev-format`
- `make dev-swift-build PRODUCT=RepoPrompt`
- `make dev-test FILTER=PersistentAgentModeMCPReadFileConnectionTests/testAgentOwnedHiddenWorktreeWatcherRebases6500LineReadSlicesBeforePostEditReads`
- `make dev-test FILTER=SelectionSlicePersistenceAndRebaseTests`
- `python3 Scripts/test_suite_optimizer.py verify-ledger --ledger Scripts/Fixtures/test-suite-contract-ledger.tsv`
- `make dev-lint`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh commit`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh push`

## Notes

- The fail-closed path only skips tab slice updates when the current tab ranges no longer match a known safe state: either the captured expected ranges or the planned rebased ranges.
- In that ambiguous state, preserving the current tab selection is safer than applying a second best-effort text rebase against ranges that may already be in the new coordinate epoch.
- Normal successful partition and tab rebase behavior is unchanged when the expected ranges still match.
- Full root `make dev-test` passed earlier during this refactor; after the final stale-target regression hook/test, I reran focused coverage, build, lint, guardrails, and ledger verification.
