### PR TITLE
Fix CLI install recovery from stale App Translocation symlinks

### DIFF
--- a/Sources/RepoPrompt/Infrastructure/Process/CLI/CLIPathInstaller.swift
+++ b/Sources/RepoPrompt/Infrastructure/Process/CLI/CLIPathInstaller.swift
@@ -201,7 +201,8 @@ enum CLIPathInstaller {
         case noBundledCLI
         case directoryMissing
         case permissionDenied
-        case pathExistsNotOurs
+        case pathExistsNotOurs(path: String)
+        case userSymlinkSetupFailed(path: String)
         case scriptFailed(String)
         case unknown(Error)
 
@@ -213,14 +214,31 @@ enum CLIPathInstaller {
                 "\(installDirectory) does not exist. Create it first with: sudo mkdir -p \(installDirectory)"
             case .permissionDenied:
                 "Permission denied. Administrator access is required."
-            case .pathExistsNotOurs:
-                "A file already exists at \(installPath) that wasn't created by RepoPrompt"
+            case let .pathExistsNotOurs(path):
+                "A file already exists at \(path) that wasn't created by RepoPrompt"
+            case let .userSymlinkSetupFailed(path):
+                "Could not set up the CLI link at \(path). Check permissions for its parent directory and try again."
             case let .scriptFailed(message):
                 "Installation failed: \(message)"
             case let .unknown(error):
                 "Installation failed: \(error.localizedDescription)"
             }
         }
+    }
+
+    /// Distinguishes an unmanaged occupant (a real conflict) from other
+    /// user-space symlink setup failures (e.g. directory creation or atomic
+    /// swap), so `install()` reports an accurate message instead of always
+    /// claiming a conflicting file exists.
+    static func userSymlinkInstallError(userLink: String, bundledPath: String) -> InstallError {
+        if case .unmanaged = ManagedCLIPathPolicy.classifySymlink(
+            at: userLink,
+            desiredDestination: bundledPath,
+            managedDestinations: ManagedCLIPathPolicy.managedDestinations(currentBundledCLIPath: bundledPath)
+        ) {
+            return .pathExistsNotOurs(path: userLink)
+        }
+        return .userSymlinkSetupFailed(path: userLink)
     }
 
     /// Install the CLI to PATH using AppleScript for admin privileges
@@ -236,7 +254,7 @@ enum CLIPathInstaller {
         case .directoryMissing:
             throw InstallError.directoryMissing
         case .installedByOther:
-            throw InstallError.pathExistsNotOurs
+            throw InstallError.pathExistsNotOurs(path: installPath)
         case .installed:
             logger.info("CLI already installed at \(installPath)")
             return
@@ -249,7 +267,7 @@ enum CLIPathInstaller {
             userSymlinkURL: URL(fileURLWithPath: userLink),
             bundledCLIURL: URL(fileURLWithPath: bundledPath)
         ) else {
-            throw InstallError.pathExistsNotOurs
+            throw Self.userSymlinkInstallError(userLink: userLink, bundledPath: bundledPath)
         }
 
         let managedDestinations = ManagedCLIPathPolicy.managedDestinations(
@@ -291,7 +309,7 @@ enum CLIPathInstaller {
             logger.info("CLI not installed, nothing to uninstall")
             return
         case .installedByOther:
-            throw InstallError.pathExistsNotOurs
+            throw InstallError.pathExistsNotOurs(path: installPath)
         case .installed, .installedButStale:
             break
         }
@@ -389,7 +407,7 @@ enum CLIPathInstaller {
         case .directoryMissing:
             throw InstallError.directoryMissing
         case .installedByOther:
-            throw InstallError.pathExistsNotOurs
+            throw InstallError.pathExistsNotOurs(path: claudeRPInstallPath)
         case .installed:
             // Wrapper is already installed, but still refresh the MCP config file
             logger.info("claude-rp already installed at \(claudeRPInstallPath)")
@@ -455,7 +473,7 @@ enum CLIPathInstaller {
             logger.info("claude-rp not installed, nothing to uninstall")
             return
         case .installedByOther:
-            throw InstallError.pathExistsNotOurs
+            throw InstallError.pathExistsNotOurs(path: claudeRPInstallPath)
         case .installed, .installedButOutdated:
             break
         }

--- a/Sources/RepoPrompt/Infrastructure/Process/CLI/ManagedCLIPathPolicy.swift
+++ b/Sources/RepoPrompt/Infrastructure/Process/CLI/ManagedCLIPathPolicy.swift
@@ -40,7 +40,10 @@ enum ManagedCLIPathPolicy {
         let destination = resolvedDestination(rawDestination, linkPath: path)
         let desired = standardized(desiredDestination)
         let allowlist = Set(managedDestinations.map(standardized))
-        guard destination == desired || allowlist.contains(destination) else {
+        guard destination == desired
+            || allowlist.contains(destination)
+            || isTranslocatedManagedDestination(destination, allowlist: allowlist)
+        else {
             return .unmanaged
         }
         if destination == desired, fileManager.isExecutableFile(atPath: destination) {
@@ -126,5 +129,36 @@ enum ManagedCLIPathPolicy {
 
     private static func standardized(_ path: String) -> String {
         URL(fileURLWithPath: (path as NSString).expandingTildeInPath).standardizedFileURL.path
+    }
+
+    /// App Translocation relocates a quarantined app bundle to a randomized,
+    /// read-only mount such as
+    /// `/private/var/folders/.../AppTranslocation/<uuid>/d/<App>.app/...`.
+    /// A user-space CLI link created during a translocated launch therefore
+    /// points at a path that is neither the desired destination nor on the
+    /// static allowlist, and that path usually vanishes once the app is moved
+    /// to a stable location. Treat such a link as a managed (stale) entry when
+    /// its app-bundle-relative suffix matches a known managed destination, so it
+    /// can be repaired instead of being rejected as unmanaged.
+    private static func isTranslocatedManagedDestination(
+        _ destination: String,
+        allowlist: Set<String>
+    ) -> Bool {
+        let components = (destination as NSString).pathComponents
+        guard components.contains("AppTranslocation"),
+              let suffix = appBundleRelativeSuffix(destination)
+        else { return false }
+        return allowlist.contains { appBundleRelativeSuffix($0) == suffix }
+    }
+
+    /// Returns the portion of a path from its last `*.app` component to the end
+    /// (e.g. `RepoPrompt CE.app/Contents/MacOS/repoprompt-mcp`), or nil when the
+    /// path has no app-bundle component.
+    private static func appBundleRelativeSuffix(_ path: String) -> String? {
+        let components = (path as NSString).pathComponents
+        guard let appIndex = components.lastIndex(where: { $0.hasSuffix(".app") }) else {
+            return nil
+        }
+        return components[appIndex...].joined(separator: "/")
     }
 }

--- a/Tests/RepoPromptTests/MCP/CLIPathInstallerTests.swift
+++ b/Tests/RepoPromptTests/MCP/CLIPathInstallerTests.swift
@@ -124,6 +124,62 @@ final class CLIPathInstallerTests: XCTestCase {
         XCTAssertEqual(try FileManager.default.destinationOfSymbolicLink(atPath: linkURL.path), bundledCLI.path)
     }
 
+    func testClassifierReclaimsStaleTranslocatedManagedTarget() throws {
+        // Managed destination lives inside an app bundle.
+        let allowlist: Set = [bundledCLI.path]
+
+        // Simulate a user-space link created while the app ran translocated:
+        // it targets the same app bundle CLI, but under a now-removed App
+        // Translocation mount (dangling; the path does not exist).
+        let staleTranslocated = "/private/var/folders/xx/T/AppTranslocation/"
+            + UUID().uuidString
+            + "/d/RepoPrompt.app/Contents/MacOS/repoprompt-mcp"
+        try FileManager.default.createSymbolicLink(atPath: linkURL.path, withDestinationPath: staleTranslocated)
+        XCTAssertEqual(
+            ManagedCLIPathPolicy.classifySymlink(
+                at: linkURL.path,
+                desiredDestination: bundledCLI.path,
+                managedDestinations: allowlist
+            ),
+            .managedStale(destination: staleTranslocated)
+        )
+
+        // A translocated path whose app-bundle suffix does NOT match any
+        // managed destination must stay unmanaged.
+        try FileManager.default.removeItem(at: linkURL)
+        let foreignTranslocated = "/private/var/folders/xx/T/AppTranslocation/"
+            + UUID().uuidString
+            + "/d/Evil.app/Contents/MacOS/repoprompt-mcp"
+        try FileManager.default.createSymbolicLink(atPath: linkURL.path, withDestinationPath: foreignTranslocated)
+        XCTAssertEqual(
+            ManagedCLIPathPolicy.classifySymlink(
+                at: linkURL.path,
+                desiredDestination: bundledCLI.path,
+                managedDestinations: allowlist
+            ),
+            .unmanaged
+        )
+    }
+
+    func testUserSpaceManagerRepairsStaleTranslocatedSymlink() throws {
+        // Reproduces the reported bug: the user-space link points at a CLI
+        // inside a now-removed App Translocation mount (dangling). Because the
+        // app has since moved to a stable location, the link must be reclaimed
+        // and repaired rather than rejected as unmanaged.
+        let staleTranslocated = "/private/var/folders/xx/T/AppTranslocation/"
+            + UUID().uuidString
+            + "/d/RepoPrompt.app/Contents/MacOS/repoprompt-mcp"
+        try FileManager.default.createSymbolicLink(atPath: linkURL.path, withDestinationPath: staleTranslocated)
+
+        XCTAssertTrue(
+            CLISymlinkManagerUserSpace.ensureLocalSymlink(
+                userSymlinkURL: linkURL,
+                bundledCLIURL: bundledCLI
+            )
+        )
+        XCTAssertEqual(try FileManager.default.destinationOfSymbolicLink(atPath: linkURL.path), bundledCLI.path)
+    }
+
     func testUserSpaceManagerRollsBackRacedUnmanagedReplacement() throws {
         let recognizedOldPath = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent("Library/Application Support/RepoPrompt CE/DebugApps/RepoPrompt.app/Contents/MacOS/repoprompt-mcp")
@@ -234,5 +290,59 @@ final class CLIPathInstallerTests: XCTestCase {
         XCTAssertTrue(ManagedCLIPathPolicy.isManagedWrapper("#!/bin/bash\n\(ManagedCLIPathPolicy.legacyClaudeWrapperMarkers[0])\n"))
         XCTAssertFalse(ManagedCLIPathPolicy.isManagedWrapper("#!/bin/bash\necho '\(ManagedCLIPathPolicy.currentClaudeWrapperMarker)'\n"))
         XCTAssertFalse(ManagedCLIPathPolicy.isManagedWrapper("#!/bin/bash\necho unrelated\n"))
+    }
+
+    func testPathExistsNotOursErrorReportsProvidedPath() {
+        // The message must name the actual offending path, not a hardcoded one.
+        let path = "/Users/example/Library/Application Support/RepoPrompt CE/repoprompt_ce_cli"
+        let description = CLIPathInstaller.InstallError.pathExistsNotOurs(path: path).errorDescription
+        XCTAssertEqual(description, "A file already exists at \(path) that wasn't created by RepoPrompt")
+    }
+
+    func testUserSymlinkInstallErrorDistinguishesConflictFromSetupFailure() throws {
+        // A genuinely foreign occupant is reported as a real conflict.
+        try Data("foreign".utf8).write(to: linkURL)
+        let conflict = CLIPathInstaller.userSymlinkInstallError(userLink: linkURL.path, bundledPath: bundledCLI.path)
+        guard case let .pathExistsNotOurs(path) = conflict else {
+            return XCTFail("expected pathExistsNotOurs, got \(conflict)")
+        }
+        XCTAssertEqual(path, linkURL.path)
+
+        // No occupant (e.g. a directory-creation or atomic-swap failure) is
+        // reported as a setup failure, not a spurious conflict.
+        try FileManager.default.removeItem(at: linkURL)
+        let setupFailure = CLIPathInstaller.userSymlinkInstallError(userLink: linkURL.path, bundledPath: bundledCLI.path)
+        guard case let .userSymlinkSetupFailed(path) = setupFailure else {
+            return XCTFail("expected userSymlinkSetupFailed, got \(setupFailure)")
+        }
+        XCTAssertEqual(path, linkURL.path)
+    }
+
+    func testUserSymlinkSetupFailedErrorReportsProvidedPath() {
+        // The setup-failure message must name the path and avoid claiming a conflict.
+        let path = "/Users/example/Library/Application Support/RepoPrompt CE/repoprompt_ce_cli"
+        let description = CLIPathInstaller.InstallError.userSymlinkSetupFailed(path: path).errorDescription
+        XCTAssertEqual(
+            description,
+            "Could not set up the CLI link at \(path). Check permissions for its parent directory and try again."
+        )
+    }
+
+    func testClassifierRejectsTranslocatedPathWithoutAppBundleComponent() throws {
+        // A path under /AppTranslocation/ but with no *.app component has no
+        // app-bundle suffix to match, so it must remain unmanaged.
+        let allowlist: Set = [bundledCLI.path]
+        let noAppBundle = "/private/var/folders/xx/T/AppTranslocation/"
+            + UUID().uuidString
+            + "/d/repoprompt-mcp"
+        try FileManager.default.createSymbolicLink(atPath: linkURL.path, withDestinationPath: noAppBundle)
+        XCTAssertEqual(
+            ManagedCLIPathPolicy.classifySymlink(
+                at: linkURL.path,
+                desiredDestination: bundledCLI.path,
+                managedDestinations: allowlist
+            ),
+            .unmanaged
+        )
     }
 }


### PR DESCRIPTION
## Summary
- Repair CE user-space CLI symlinks that were created while the app ran under macOS App Translocation and later became dangling once the app moved to a stable location.
- Preserve the existing "refuse to touch unmanaged files" safety boundary by only reclaiming translocated targets whose app-bundle-relative suffix matches a known managed destination.
- Make `InstallError.pathExistsNotOurs` carry the actual offending path instead of always reporting `/usr/local/bin/rpce-cli`.

## Symptom
Installing the `rpce-cli` CLI (Settings → MCP → CLI Tools → Install) fails with:

`Install failed: A file already exists at /usr/local/bin/rpce-cli that wasn't created by RepoPrompt`

even though `/usr/local/bin/rpce-cli` does not exist. This reproduces for anyone who first launched the app from a quarantined location (Downloads/DMG, i.e. App Translocation) and later moved it to `/Applications`.

## Root cause
The install failure originates at the user-space symlink step, not the `/usr/local/bin` shim:
1. `CLIPathInstaller.install()` finds the PATH shim `notInstalled`, then calls `CLISymlinkManagerUserSpace.ensureLocalSymlink(...)`.
2. `ensureLocalSymlink` classifies the existing user-space symlink via `ManagedCLIPathPolicy.classifySymlink(...)`.
3. That symlink was created during a translocated launch, so it points at a randomized path such as `/private/var/folders/.../AppTranslocation/<uuid>/d/RepoPrompt CE.app/Contents/MacOS/repoprompt-mcp`.
4. After the app moves to `/Applications`, that target disappears and is not on the managed-destination allowlist, so `classifySymlink` returns `.unmanaged`.
5. `ensureLocalSymlink` refuses to replace `.unmanaged` entries and returns `false`; `install()` throws `.pathExistsNotOurs`.

Second, independent bug: `InstallError.pathExistsNotOurs` had no associated value and always formatted its message with `installPath`, so a user-space symlink (or `claude-rpce` wrapper) conflict was reported as `/usr/local/bin/rpce-cli`, a path that may not exist.

## Fix
`ManagedCLIPathPolicy.classifySymlink(...)` now also treats a destination as managed-stale (repairable) when:
- the destination path contains `/AppTranslocation/`, and
- its suffix from the last `*.app` component to the end matches the same suffix of a known managed destination (e.g. `RepoPrompt CE.app/Contents/MacOS/repoprompt-mcp`).

This keeps unrelated paths unmanaged (an unrelated translocated `*.app`, or plain foreign symlinks stay `.unmanaged`), and leaves current/stale/normal classifications unchanged.

`InstallError.pathExistsNotOurs` now carries `path: String`; each throw site passes the path that actually conflicted (the PATH shim, the user-space symlink, or the `claude-rpce` wrapper).

## Proof
Standalone harness that mirrors `classifySymlink` and toggles only the new translocation branch, run against real on-disk symlinks:

```
=== BEFORE FIX ===
  valid current link -> bundled CLI                 -> managedCurrent
  stale translocation link (OUR app, vanished)      -> unmanaged     (REFUSED -> install fails)
  foreign translocation link (other .app)           -> unmanaged
  plain foreign link                                -> unmanaged

=== AFTER FIX ===
  valid current link -> bundled CLI                 -> managedCurrent
  stale translocation link (OUR app, vanished)      -> managedStale  (reclaimable -> repaired)
  foreign translocation link (other .app)           -> unmanaged
  plain foreign link                                -> unmanaged
```

Local reproduction confirmed the user-space symlink pointed at a deleted `AppTranslocation` target while `/usr/local/bin/rpce-cli` did not exist, matching both the misleading message and the refusal to repair.

## Tests
Added to `CLIPathInstallerTests`:
- `testClassifierReclaimsStaleTranslocatedManagedTarget` — stale translocated managed target is `.managedStale`; a non-matching translocated `*.app` suffix stays `.unmanaged`.
- `testUserSpaceManagerRepairsStaleTranslocatedSymlink` — `ensureLocalSymlink` repairs the stale translocated link (direct regression for the reported bug).
- `testPathExistsNotOursErrorReportsProvidedPath` — the error message names the provided path.

## Validation notes
- `xcrun swiftc -parse` on both edited source files: no syntax errors.
- Standalone classifier harness: expected before/after behavior (above).
- `make dev-test FILTER=CLIPathInstallerTests`, `make dev-lint`, and `make dev-swift-build` could not run in the contributor environment because it is Command Line Tools–only and hits the existing `PreviewsMacros` plugin limitation (issue #174); the XCTest target cannot compile there. These lanes should run in CI / on a full-Xcode machine, and the added tests are written to run there.

## Relationship to #278
Complementary and non-conflicting. #278 relocates the user-space symlink path in `MCPFilesystemIdentity.swift` (a hard cutover) and would incidentally sidestep the symptom by targeting a fresh path; it does not fix the classifier logic or the misleading error text. This PR touches only `ManagedCLIPathPolicy.swift` and `CLIPathInstaller.swift`.

Conversation: https://app.warp.dev/conversation/550683e7-eeb5-469a-894f-eb6f7360e3fc

Co-Authored-By: Oz <oz-agent@warp.dev>
