### PR TITLE
fix(doctor): detect missing Swift macro plugins on CLT-only hosts (#174)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,11 @@ another Mac or redistributed.
 ### Source-build requirements
 
 - macOS 26 or later
-- Xcode 26, or matching Command Line Tools with the macOS 26 SDK
+- Xcode 26 — full `Xcode.app`, not Command Line Tools alone. RepoPrompt CE and
+  its dependencies use the `@Entry` and `#Preview` Swift macros, whose plugins
+  (`SwiftUIMacros`, `PreviewsMacros`) ship only with `Xcode.app`. Its bundled
+  macOS 26 SDK satisfies the SDK requirement. Run `./Scripts/doctor.sh` to
+  verify your toolchain before building.
 
 ### Develop in Xcode
 

--- a/Scripts/doctor.sh
+++ b/Scripts/doctor.sh
@@ -104,6 +104,28 @@ SWIFT
 ARCH="$(uname -m)"
 run xcrun swiftc -typecheck -parse-as-library -target "${ARCH}-apple-macos14.0" "$TMP/GlassProbe.swift"
 log "OK: toolchain can compile SwiftUI Liquid Glass symbols."
+phase "Compiling Swift macro plugin probe"
+cat > "$TMP/MacroProbe.swift" <<'SWIFT'
+import SwiftUI
+
+// Mirrors real RepoPrompt CE usage: `@Entry` (SwiftUIMacros) in an
+// EnvironmentValues extension, plus `#Preview` (PreviewsMacros) carried by
+// dependencies such as KeyboardShortcuts. Both macro plugins ship only with
+// full Xcode.app; Command Line Tools alone cannot expand them, so a typecheck
+// (which runs macro expansion) is enough to detect their absence.
+extension EnvironmentValues {
+    @Entry var repoPromptDoctorMacroProbe: Bool = false
+}
+
+#Preview("doctor macro probe") {
+    Text("OK")
+}
+SWIFT
+if ! xcrun swiftc -typecheck -parse-as-library -target "${ARCH}-apple-macos14.0" "$TMP/MacroProbe.swift" 2>"$TMP/MacroProbe.err"; then
+    (( quiet )) || cat "$TMP/MacroProbe.err" >&2
+    fail "Swift macro plugins unavailable (SwiftUIMacros / PreviewsMacros). RepoPrompt CE uses the @Entry and #Preview macros, whose plugins ship only with full Xcode.app — Command Line Tools alone cannot build it. Install Xcode 26 and select it: sudo xcode-select -s /Applications/Xcode.app"
+fi
+log "OK: toolchain provides Swift macro plugins (@Entry, #Preview)."
 if (( install_debug_cli )); then
     phase "Installing debug CLI"
     run "$ROOT_DIR/Scripts/install_debug_cli.sh" install --build


### PR DESCRIPTION
## Summary
`Scripts/doctor.sh --quiet` passes on Command Line Tools–only macOS hosts, but the build then fails at macro expansion. The check verified tool presence and a SwiftUI *symbol* typecheck (the Liquid Glass probe) but never exercised macro-plugin availability, so it reported success on a host that cannot build the app.

## Root cause
RepoPrompt CE requires two Swift macro plugins that ship only with full `Xcode.app`, never with Command Line Tools:
- `SwiftUIMacros` — CE's own source uses `@Entry` at 10 sites across 5 files.
- `PreviewsMacros` — the pinned `KeyboardShortcuts` 2.3.0 (`045cf174…`) uses `#Preview` in `Recorder.swift`.

CLT alone is structurally insufficient, and the old `doctor.sh` could not tell a contributor that.

## Fix
- **`Scripts/doctor.sh`**: adds a macro-plugin probe (mirrors the existing Liquid Glass probe) that typechecks a snippet using both `@Entry` and `#Preview`. Because macro expansion runs during type-checking, an absent plugin fails the probe, which then hard-fails with guidance to install Xcode 26. Catches both blockers — and any future macro dependency — in one place.
- **`README.md`**: corrects the source-build requirements, which incorrectly listed Command Line Tools as a supported alternative to Xcode.

## Validation
- **Xcode 26 host**: standalone probe typechecks clean (exit 0, no extra imports needed); full `doctor.sh` exits 0 with `OK: toolchain provides Swift macro plugins (@Entry, #Preview)`.
- **CLT-only host** (`DEVELOPER_DIR=/Library/Developer/CommandLineTools`): probe fails with `external macro implementation type 'SwiftUIMacros.EntryMacro' … plugin for module 'SwiftUIMacros' not found` and the equivalent for `PreviewsMacros`; `doctor.sh --quiet` exits non-zero with the install-Xcode guidance. Notably the Liquid Glass probe still passes under CLT — i.e. the old check would have reported success — confirming this reproduces and closes #174.
- `bash -n Scripts/doctor.sh` passes; `python3 Scripts/test_release_tooling.py` → 52 tests, all pass.

## Scope
- Blocker #1 from the issue (mid-cycle `PackageDescription` mismatch) is environment-specific and self-resolves via CLT reinstall; intentionally not probed to avoid false positives.
- This does not attempt to *restore* CLT-only builds. Blocker #3 is first-party `@Entry` usage; making CLT builds succeed would mean removing an idiomatic SwiftUI macro codebase-wide and guarding it in CI — a poor trade for a native macOS app. The honest fix is to detect the unsupported host and say so.

## Known limitation / follow-up
CI does not exercise the CLT-only path (GitHub `macos-26` runners ship Xcode), so this probe is validated by contributors, not CI. A job that selects CLT and asserts `doctor.sh` *fails* would close that gap but is awkward on hosted runners; proposed as a separate change.