### PR TITLE
Speed up dev-lint SwiftLint discovery

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,7 +1,6 @@
 # RepoPrompt CE SwiftLint policy.
-# Scripts/swift_style.sh owns the canonical first-party Swift file list used by
-# local and CI checks. The include/exclude lists here mirror that scope for
-# direct SwiftLint invocations and editor integrations.
+# Full-repo lint uses this config for file discovery. Keep these include/exclude
+# lists aligned with Scripts/swift_style.sh's SwiftFormat first-party scope.
 
 included:
   - Package.swift
@@ -16,13 +15,26 @@ included:
 excluded:
   - .build
   - .swiftpm
-  - DerivedData
   - build
+  - Carthage
+  - DerivedData
+  - Generated
+  - Pods
   - Vendor
   - Packages/RepoPromptAgentProviders/.build
   - Sources/CSwiftPCRE2
   - Sources/RepoPromptC
   - Sources/RepoPrompt/ThirdParty/SwiftPCRE2
+  - Sources/RepoPrompt/Infrastructure/AI/Prompts/Workflows/WorkflowPromptSharedFragments.swift
+  - Sources/RepoPrompt/Infrastructure/AI/Prompts/Workflows/WorkflowPrompt+Build.swift
+  - Sources/RepoPrompt/Infrastructure/AI/Prompts/Workflows/WorkflowPrompt+DeepPlan.swift
+  - Sources/RepoPrompt/Infrastructure/AI/Prompts/Workflows/WorkflowPrompt+Investigate.swift
+  - Sources/RepoPrompt/Infrastructure/AI/Prompts/Workflows/WorkflowPrompt+Optimize.swift
+  - Sources/RepoPrompt/Infrastructure/AI/Prompts/Workflows/WorkflowPrompt+OracleExport.swift
+  - Sources/RepoPrompt/Infrastructure/AI/Prompts/Workflows/WorkflowPrompt+Orchestrate.swift
+  - Sources/RepoPrompt/Infrastructure/AI/Prompts/Workflows/WorkflowPrompt+Refactor.swift
+  - Sources/RepoPrompt/Infrastructure/AI/Prompts/Workflows/WorkflowPrompt+Reminder.swift
+  - Sources/RepoPrompt/Infrastructure/AI/Prompts/Workflows/WorkflowPrompt+Review.swift
 
 # Keep the initial integration intentionally humane. Broader cleanup-oriented
 # rules are deferred until the one-time baseline and future focused cleanup work.

--- a/Scripts/swift_style.sh
+++ b/Scripts/swift_style.sh
@@ -133,19 +133,10 @@ run_swiftformat(){
 
 run_swiftlint(){
     ensure_tool swiftlint
-    ensure_swift_files_collected
 
-    if (( ${#SWIFT_FILES[@]} == 0 )); then
-        fail "No Swift files found in configured style scope."
-    fi
-
-    local index
-    export SCRIPT_INPUT_FILE_COUNT="${#SWIFT_FILES[@]}"
-    for index in "${!SWIFT_FILES[@]}"; do
-        export "SCRIPT_INPUT_FILE_$index=${SWIFT_FILES[$index]}"
-    done
-
-    local args=(lint --strict --config "$ROOT_DIR/.swiftlint.yml" --use-script-input-files)
+    # Full-repo lint lets SwiftLint discover files from .swiftlint.yml instead of
+    # paying the large environment/script-input overhead for every Swift file.
+    local args=(lint --strict --config "$ROOT_DIR/.swiftlint.yml" --quiet --force-exclude)
     if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
         args+=(--reporter github-actions-logging)
     fi

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -1454,6 +1454,51 @@ printf '%s' "${SENTRY_AUTH_TOKEN:-}" > "$TOKEN_CAPTURE"
         self.assertIn('gitleaks git --redact --log-opts="$range" .', workflow)
         self.assertIn("gitleaks dir --redact .", workflow)
 
+    def test_swift_style_lint_uses_config_discovery_without_script_input_overhead(self) -> None:
+        root = SCRIPT_DIR.parent
+        style_script = (SCRIPT_DIR / "swift_style.sh").read_text(encoding="utf-8")
+        swiftlint_config = (root / ".swiftlint.yml").read_text(encoding="utf-8")
+        lint_body = style_script.split("run_swiftlint(){", 1)[1].split("\n}\n\ncase", 1)[0]
+
+        self.assertIn('local args=(lint --strict --config "$ROOT_DIR/.swiftlint.yml" --quiet --force-exclude)', lint_body)
+        self.assertNotIn("SCRIPT_INPUT_FILE", lint_body)
+        self.assertNotIn("--use-script-input-files", lint_body)
+
+        style_paths_body = style_script.split("STYLE_PATHS=(", 1)[1].split("\n)", 1)[0]
+        style_paths = [
+            line.strip().strip('"')
+            for line in style_paths_body.splitlines()
+            if line.strip().startswith('"')
+        ]
+        for style_path in style_paths:
+            self.assertIn(f"  - {style_path}", swiftlint_config)
+
+        for excluded_path in (
+            ".build",
+            ".swiftpm",
+            "build",
+            "Carthage",
+            "DerivedData",
+            "Generated",
+            "Pods",
+            "Vendor",
+            "Packages/RepoPromptAgentProviders/.build",
+            "Sources/CSwiftPCRE2",
+            "Sources/RepoPromptC",
+            "Sources/RepoPrompt/ThirdParty/SwiftPCRE2",
+            "Sources/RepoPrompt/Infrastructure/AI/Prompts/Workflows/WorkflowPromptSharedFragments.swift",
+            "Sources/RepoPrompt/Infrastructure/AI/Prompts/Workflows/WorkflowPrompt+Build.swift",
+            "Sources/RepoPrompt/Infrastructure/AI/Prompts/Workflows/WorkflowPrompt+DeepPlan.swift",
+            "Sources/RepoPrompt/Infrastructure/AI/Prompts/Workflows/WorkflowPrompt+Investigate.swift",
+            "Sources/RepoPrompt/Infrastructure/AI/Prompts/Workflows/WorkflowPrompt+Optimize.swift",
+            "Sources/RepoPrompt/Infrastructure/AI/Prompts/Workflows/WorkflowPrompt+OracleExport.swift",
+            "Sources/RepoPrompt/Infrastructure/AI/Prompts/Workflows/WorkflowPrompt+Orchestrate.swift",
+            "Sources/RepoPrompt/Infrastructure/AI/Prompts/Workflows/WorkflowPrompt+Refactor.swift",
+            "Sources/RepoPrompt/Infrastructure/AI/Prompts/Workflows/WorkflowPrompt+Reminder.swift",
+            "Sources/RepoPrompt/Infrastructure/AI/Prompts/Workflows/WorkflowPrompt+Review.swift",
+        ):
+            self.assertIn(f"  - {excluded_path}", swiftlint_config)
+
     def test_publish_staged_validates_before_creating_dist(self) -> None:
         release_script = (SCRIPT_DIR / "release.sh").read_text(encoding="utf-8")
         publish_staged = release_script.split("publish_staged_release() {", 1)[1].split("\n}", 1)[0]

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -1458,7 +1458,7 @@ printf '%s' "${SENTRY_AUTH_TOKEN:-}" > "$TOKEN_CAPTURE"
         root = SCRIPT_DIR.parent
         style_script = (SCRIPT_DIR / "swift_style.sh").read_text(encoding="utf-8")
         swiftlint_config = (root / ".swiftlint.yml").read_text(encoding="utf-8")
-        lint_body = style_script.split("run_swiftlint(){", 1)[1].split("\n}\n\ncase", 1)[0]
+        lint_body = style_script.split("run_swiftlint(){", 1)[1].split("\n}", 1)[0]
 
         self.assertIn('local args=(lint --strict --config "$ROOT_DIR/.swiftlint.yml" --quiet --force-exclude)', lint_body)
         self.assertNotIn("SCRIPT_INPUT_FILE", lint_body)


### PR DESCRIPTION
## Summary

- Switch full-repo `Scripts/swift_style.sh lint` to config-discovered SwiftLint with `--quiet --force-exclude`, avoiding `SCRIPT_INPUT_FILE_*` overhead.
- Align `.swiftlint.yml` include/exclude scope with the wrapper's first-party Swift style scope, including generated/vendor/build/transient paths and large workflow prompt files.
- Add a regression test to guard against reintroducing script-input mode and to keep SwiftLint config includes aligned with `STYLE_PATHS`.

Closes #426.

## Validation

- `python3 -m unittest Scripts.test_release_tooling.ReleaseToolingTests.test_swift_style_lint_uses_config_discovery_without_script_input_overhead`
- `bash -n Scripts/swift_style.sh`
- `/usr/bin/time -p make dev-lint`
  - Post-rebase conductor ticket: `a695917e-ff5f-43a8-b9b6-57b68d284c14`
  - Passed; SwiftLint command shown as `swiftlint lint --strict --config .../.swiftlint.yml --quiet --force-exclude`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh commit`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh push`

## Review

- Claude Fable 5 read-only review found no must-fix issues and concluded lint/formatting integrity is preserved.
- Folded in its suggested test hardening for `.swiftlint.yml` `included:` parity with `STYLE_PATHS`.
