### PR TITLE
Fix git diff artifact export after alias authorization rejection

### DIFF
--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPGitToolProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPGitToolProvider.swift
@@ -437,12 +437,14 @@ final class MCPGitToolProvider: MCPWindowToolProviding {
                             MCPWindowToolName.git,
                             advertised
                         )
+                    } catch let error as CancellationError {
+                        throw error
                     } catch {
                         await dependencies.invalidateAdvertisedGitArtifactsForCurrentTab(
                             MCPWindowToolName.git
                         )
-                        throw MCPError.internalError(
-                            "Git artifacts were published, but their advertised aliases could not be authorized: \(error.localizedDescription)"
+                        dependencies.logDebug(
+                            "Git artifacts were published, but advertised aliases were not authorized: \(error.localizedDescription)"
                         )
                     }
                 }

--- a/Tests/RepoPromptTests/MCP/MCPAskOracleWorktreeTests.swift
+++ b/Tests/RepoPromptTests/MCP/MCPAskOracleWorktreeTests.swift
@@ -455,6 +455,95 @@ import XCTest
             }
         }
 
+        func testGitDiffArtifactsReturnWhenExplicitLinkedWorktreeAdvertisementIsUnauthorized() async throws {
+            try await MCPSharedServerTestLease.shared.withLease { lease in
+                let fixture = try await PersistentMCPTestFixture.make(lease: lease)
+                let gitFixture = try ReviewGitRepositoryFixture(name: "ExplicitLinkedArtifactNoBinding")
+                defer { gitFixture.cleanup() }
+                do {
+                    try await activateWorkspace(fixture.contextA)
+                    let logicalRoot = try gitFixture.makeRepository(
+                        named: "logical",
+                        files: ["Sources/Feature.swift": "let value = \"initial\"\n"]
+                    )
+                    let worktreeRoot = try gitFixture.makeLinkedWorktree(
+                        from: logicalRoot,
+                        named: "worktree",
+                        branch: "feature/explicit-artifact"
+                    )
+                    let logicalFile = logicalRoot.appendingPathComponent("Sources/Feature.swift")
+                    let worktreeFile = worktreeRoot.appendingPathComponent("Sources/Feature.swift")
+                    try write("let value = \"canonical_artifact_leak\"\n", to: logicalFile)
+                    try write("let value = \"explicit_worktree_artifact_source\"\n", to: worktreeFile)
+                    _ = try await fixture.contextA.window.workspaceFileContextStore.loadRoot(
+                        path: logicalRoot.path,
+                        kind: .primaryWorkspace
+                    )
+
+                    let context = makeFrozenContext(
+                        fixture: fixture,
+                        selection: StoredSelection(),
+                        bindings: []
+                    )
+                    let endpoint = try fixture.endpointA()
+                    try await configureAgentModeEndpoint(endpoint, context: context, fixture: fixture)
+
+                    let gitResponse = try await endpoint.callTool(
+                        name: MCPWindowToolName.git,
+                        arguments: [
+                            "op": "diff",
+                            "repo_root": worktreeRoot.path,
+                            "scope": "all",
+                            "artifacts": true,
+                            "mode": "standard",
+                            "inline": ["map": false]
+                        ],
+                        timeoutSeconds: 30
+                    )
+
+                    XCTAssertFalse(gitResponse.rawJSON.contains("\"isError\":true"), gitResponse.rawJSON)
+                    let gitText = try toolResultText(gitResponse)
+                    XCTAssertTrue(gitText.contains("MAP.txt"), gitText)
+                    XCTAssertTrue(gitText.contains("all.patch"), gitText)
+                    let patchAlias = try XCTUnwrap(
+                        gitText.split(separator: "`").map(String.init).first { candidate in
+                            candidate.hasPrefix("_git_data/") && candidate.hasSuffix("/diff/all.patch")
+                        },
+                        gitText
+                    )
+                    let workspaceDirectory = try fixture.contextA.window.workspaceManager.workspaceDirectory(
+                        for: XCTUnwrap(fixture.contextA.window.workspaceManager.activeWorkspace)
+                    )
+                    let patchPath = workspaceDirectory
+                        .appendingPathComponent("_git_data", isDirectory: true)
+                        .appendingPathComponent(String(patchAlias.dropFirst("_git_data/".count)))
+                        .path
+                    let patchText = try String(contentsOfFile: patchPath, encoding: .utf8)
+                    XCTAssertTrue(patchText.contains("explicit_worktree_artifact_source"), patchText)
+                    XCTAssertFalse(patchText.contains("canonical_artifact_leak"), patchText)
+
+                    let rejectedAliasSelection = try await endpoint.callTool(
+                        name: MCPWindowToolName.manageSelection,
+                        arguments: [
+                            "op": "add",
+                            "paths": [patchAlias],
+                            "strict": true
+                        ],
+                        timeoutSeconds: 20
+                    )
+                    XCTAssertTrue(
+                        rejectedAliasSelection.rawJSON.contains("\"isError\":true"),
+                        rejectedAliasSelection.rawJSON
+                    )
+
+                    await fixture.cleanup()
+                } catch {
+                    await fixture.cleanup()
+                    throw error
+                }
+            }
+        }
+
         func testGitDiffSelectedArtifactsAutoSelectPatchForBoundLinkedWorktreeWithoutSessionRootCatalog() async throws {
             try await MCPSharedServerTestLease.shared.withLease { lease in
                 let fixture = try await PersistentMCPTestFixture.make(lease: lease)


### PR DESCRIPTION
## Summary
- allow git diff artifact export to return successfully when advertised `_git_data` alias authorization is rejected
- invalidate advertised git artifact aliases after authorization failure so rejected aliases remain unselectable
- add a regression covering explicit linked-worktree diff artifacts without a tab binding, including the security postcondition that the returned alias cannot be selected

## Root cause
The git tool published diff artifacts successfully, but then treated failure to authorize advertised `_git_data` aliases as a fatal tool error. That could surface as a worktree/provenance pathing failure even when the caller only needed the already-published artifact output.

## Review
- Consulted Claude Fable 5 High; no must-fix findings.
- Addressed the suggested regression hardening by asserting the rejected alias cannot be added through `manage_selection`.

## Validation
- `make dev-format` ✅
- `make dev-test FILTER=MCPAskOracleWorktreeTests/testGitDiffArtifactsReturnWhenExplicitLinkedWorktreeAdvertisementIsUnauthorized` ✅
- `make dev-lint` ✅
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh commit` ✅
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh push` ✅

## PR-ready caveat
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh pr-ready` was attempted.
- The safety/lint portions passed, then the full root `make dev-test` lane produced broad unrelated CodeMap/Codemap projection failures outside this diff. I canceled the already-failing root test job to avoid holding the build lane further.
- Focused regression and lint are green for this change.
