### PR TITLE
Stabilize AgentRunWorktreeStartTests production-capture selection race (#420)

### DIFF
--- a/Tests/RepoPromptTests/MCP/AgentRunWorktreeStartTests.swift
+++ b/Tests/RepoPromptTests/MCP/AgentRunWorktreeStartTests.swift
@@ -909,10 +909,20 @@ final class AgentRunWorktreeStartTests: AgentRunWorktreeStartGitSeedTestCase {
             sourceAgentSessionID: parentSessionID,
             routedRunID: nil
         )
-        let source = await window.mcpServer.testCaptureAgentRunOracleReviewSource(
-            snapshot: launchSnapshot,
-            targetWindow: window
-        )
+        // The capture's drift guard re-validates the canonical selection after its async work. This
+        // test deliberately keeps the active UI selection diverged from canonical so it can prove
+        // capture serves the *stored* selection rather than the UI. A debounced token recount can
+        // otherwise flush that divergent UI selection back into canonical during the capture's await
+        // window and falsely trip the guard ("launching selection changed ..."). Hold the selection
+        // mirror's flush suppression across the capture — the same suppression production applies
+        // during sensitive selection operations — so canonical stays stable while the frozen review
+        // capability is built.
+        let source = await window.selectionCoordinator.withApplyingSelectionMirror {
+            await window.mcpServer.testCaptureAgentRunOracleReviewSource(
+                snapshot: launchSnapshot,
+                targetWindow: window
+            )
+        }
         guard case let .captured(captured) = source else {
             if case let .unavailable(unavailable) = source {
                 return XCTFail(


### PR DESCRIPTION
## Summary

Fixes the intermittent CI flake in `AgentRunWorktreeStartTests/testProductionCapturePreservesBoundStoredSelectionInsteadOfCanonicalUI` (app shard 4). Closes #420.

## Root cause

`captureAgentRunOracleReviewSource` re-validates the canonical tab selection after its async work (`requiredLookupContext` + `freezePromptGitReviewContext`) via the `agentRunOracleReviewLaunchSelectionStillMatches` guard. This test deliberately keeps the active **UI** selection diverged (empty) from the **canonical** tab selection (`storedSelection`) to prove capture serves the stored selection rather than the UI.

The divergence is created with `mirrorToUIIfActive: false`, so no `DeferredUISelectionFence` protects canonical. A debounced `TokenCountingViewModel` recount — armed by the test's `applyStoredSelection(StoredSelection())` — fires during the capture's await window and reads `activeSelectionSnapshot(flushPendingUI: true)`, flushing the divergent empty UI into canonical. That bumps `selectionRevisionForMCP` and flips the canonical identity, falsely tripping the guard:

> The launching selection changed while its frozen review capability was being created.

In normal production use the selection mirror suppresses these flushes during sensitive operations; the test bypassed the mirror and ran the capture outside that protection. This matches the precedent in `6f32dcf7` (Stabilize full-suite MCP worktree tests), which introduced the identity-based comparison for exactly this class of mirror/re-commit churn.

## Fix

Test-only (+14/−4). Wrap the capture call in `window.selectionCoordinator.withApplyingSelectionMirror { … }` to hold the production flush suppression across the capture window, keeping canonical stable while the frozen review capability is built. No production code changed; assertions unchanged.

## Validation

- **Repro on base (`27064af8`, an ancestor of current `main`):** focused test failed **6/25 (24%)** with the exact issue signature.
- **After fix:** focused test **50/50 pass**, 0 fail.
- **Full `AgentRunWorktreeStartTests` class: 38/38 pass**, 0 fail.
- SwiftFormat: 0 files need formatting. SwiftLint `--strict`: 0 violations.
- Contribution preflight: `commit` and `push` modes both passed.
- The 36 commits between this branch's base and current `main` do not touch the test, the capture guard, the selection coordinator, or token counting (only unrelated Sentry telemetry + formatting in `MCPServerViewModel`), so the fix applies unchanged.

## Notes

- Deliberately **test-side**: the production guard is correct for real usage; the race is an artifact of the test's artificial unsupervised UI↔canonical divergence. Happy to revisit as a production-side stabilization if maintainers prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)