### PR TITLE
Refresh approved contributors

### DIFF
--- a/.github/APPROVED_CONTRIBUTORS
+++ b/.github/APPROVED_CONTRIBUTORS
@@ -5,7 +5,6 @@
 # capability:
 #   issue  issues stay open
 #   pr     issues and PRs stay open
-
 0guban0v pr
 0NotApplicable0 pr
 0xNino pr
@@ -24,6 +23,7 @@ abhshkt pr
 abyssbugg pr
 achiu3q pr
 aconcepcion pr
+adamarul pr
 adamhelfgott pr
 adamkmccarthy pr
 adampearse pr
@@ -34,6 +34,7 @@ AdrianAlonsoDev pr
 afadlallah pr
 agamrp pr
 agentdouble0zero pr
+agustif pr
 ahafonof pr
 AI-MickyJ pr
 ajitaravind pr
@@ -119,6 +120,7 @@ brettmadill pr
 brianhays pr
 brichase pr
 brytoncooper pr
+BTCElectrician pr
 BullThistle pr
 bz8768 pr
 c-p-b pr
@@ -246,6 +248,7 @@ enzodesena pr
 eolach pr
 erauner12 pr
 erikdrouhard pr
+erikois pr
 erodriguezh pr
 ethan-wickstrom pr
 eugene1g pr
@@ -312,7 +315,9 @@ helpimfalling pr
 HendrikReh pr
 henrycarrero pr
 heomin86 pr
+HeroRushGo pr
 heyalchang pr
+hghallTAZ pr
 hierosir1984 pr
 highlandhodl pr
 hmottestad pr
@@ -518,6 +523,7 @@ Nitron pr
 nkeat12 pr
 NKHN-AU pr
 nkraus pr
+NomDeBits pr
 NoRKin pr
 notmyalias pr
 nstranquist pr
@@ -529,6 +535,7 @@ OCPdev25 pr
 OCWC22 pr
 oegedijk pr
 olety pr
+olivier-auber pr
 OlivierPineau pr
 OmarAlShishani pr
 Omoeba pr
@@ -555,6 +562,7 @@ phpfour pr
 phren0logy pr
 pnascimento9596 pr
 pottedmeat pr
+pranavsuri4303 pr
 pryley pr
 pszanser pr
 pyronaur pr
@@ -563,8 +571,10 @@ qtm pr
 Qwantime pr
 radosek pr
 RadRebelSam pr
+rahulvrane pr
 rahulxsomething pr
-rameezshuhaib pr
+RameezShuhaib pr
+ranvier2d2 pr
 raphaelluethy pr
 ratulsarna pr
 raydocs pr
@@ -586,6 +596,7 @@ RoeeJ pr
 rohanp2051 pr
 RomainCrz pr
 rondered pr
+Rossnkama pr
 rpalermodrums pr
 rshagiev pr
 rwblackburn pr
@@ -630,6 +641,7 @@ smat-dev pr
 sodiumsun pr
 Sophanos pr
 sounart pr
+spazbg pr
 sportsandfragrance pr
 Srini-B pr
 staceymoore pr


### PR DESCRIPTION
## Summary
- Refresh `.github/APPROVED_CONTRIBUTORS` from live customer claims.
- Preserve pre-existing allowlist entries instead of deleting non-claim additions.
- Contributor count changed from 758 to 771.

## Claim refresh details
- Live customer-claim GitHub users resolved: 767
- Unresolved claim-form IDs (8): `TeamLandiLTD`, `Tyschultz7`, `ahafonof`, `hsinskip`, `mrbagels`, `vchepeli`, `woody-chin`, `xuanvinhvu`

## Validation
- `make guardrails`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh commit`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh push`
