### PR TITLE
fix(mcp): bound agent_run provisioning stalls (#419)

### DIFF
--- a/Sources/RepoPrompt/App/WindowStateComposition.swift
+++ b/Sources/RepoPrompt/App/WindowStateComposition.swift
@@ -32,6 +32,7 @@ enum WindowStateCompositionFactory {
         contextBuilderProviderFactory: ContextBuilderAgentViewModel.ProviderFactory? = nil,
         aiQueriesServiceFactory: ((_ keyManager: KeyManager) -> AIQueriesService)? = nil,
         workspaceFileContextStore injectedWorkspaceFileContextStore: WorkspaceFileContextStore? = nil,
+        workspaceSearchService injectedWorkspaceSearchService: WorkspaceSearchService? = nil,
         workspaceSwitchTimingPolicy: WorkspaceSwitchTimingPolicy = .production,
         loadStoredAPISettingsDataOnInit: Bool = true,
         codexModelPollingService: CodexModelPollingService = .shared
@@ -45,7 +46,7 @@ enum WindowStateCompositionFactory {
             let defaultWorkspaceFileContextStore = WorkspaceFileContextStore()
         #endif
         let workspaceFileContextStore = injectedWorkspaceFileContextStore ?? defaultWorkspaceFileContextStore
-        let workspaceSearchService = WorkspaceSearchService()
+        let workspaceSearchService = injectedWorkspaceSearchService ?? WorkspaceSearchService()
         let workspaceFilesViewModel = WorkspaceFilesViewModel(workspaceFileContextStore: workspaceFileContextStore)
 
         // 2) AI queries

--- a/Sources/RepoPrompt/Features/Workspaces/ViewModels/WorkspaceManagerViewModel.swift
+++ b/Sources/RepoPrompt/Features/Workspaces/ViewModels/WorkspaceManagerViewModel.swift
@@ -5936,6 +5936,13 @@ class WorkspaceManagerViewModel: ObservableObject {
         3
     }
 
+    /// Maximum extra `rebuildIndex` passes the search-readiness convergence loop in
+    /// `loadWorkspaceFolders` will spend chasing a live catalog generation before
+    /// breaking out and letting the keep-fresh listener finish catch-up. Bounds the
+    /// otherwise unbounded rebuild chase under multi-window catalog churn.
+    /// See repoprompt-ce #419.
+    nonisolated static let maxSearchIndexConvergenceRebuilds = 3
+
     nonisolated static func boundedWorkspaceRootLoadLimit(forRootCount rootCount: Int) -> Int {
         guard rootCount > 0 else { return 0 }
         return min(rootCount, maxConcurrentWorkspaceRootLoads)
@@ -6328,10 +6335,20 @@ class WorkspaceManagerViewModel: ObservableObject {
             _ = await warmedGeneration
         #endif
         guard isHydrationGenerationCurrent(hydrationGeneration, workspaceID: workspace.id) else { return }
+        var convergenceRebuilds = 0
         while true {
             let currentCatalogGeneration = await fileManager.workspaceFileContextStore.catalogGeneration(rootScope: .visibleWorkspace)
-            guard isHydrationGenerationCurrent(hydrationGeneration, workspaceID: workspace.id) else { return }
+            guard !Task.isCancelled,
+                  isHydrationGenerationCurrent(hydrationGeneration, workspaceID: workspace.id) else { return }
             guard currentCatalogGeneration != indexGeneration else { break }
+            guard convergenceRebuilds < Self.maxSearchIndexConvergenceRebuilds else {
+                // The keep-fresh listener (subscribed above) continues catch-up in the
+                // background and queries report `isStale` until it lands. Bounding this
+                // readiness barrier avoids an unbounded rebuild chase under multi-window
+                // catalog churn (repoprompt-ce #419).
+                break
+            }
+            convergenceRebuilds += 1
             #if DEBUG
                 let loopSearchCatalogSnapshotStartMS = WorkspaceRestorePerfLog.timestampMSIfEnabled()
             #endif
@@ -6392,6 +6409,7 @@ class WorkspaceManagerViewModel: ObservableObject {
                 "catalogFolders": "\(snapshot.diagnostics.folderCount)",
                 "catalogFiles": "\(snapshot.diagnostics.fileCount)",
                 "rebuildCount": "\(searchIndexRebuildCount)",
+                "convergenceCapReached": "\(convergenceRebuilds >= Self.maxSearchIndexConvergenceRebuilds)",
                 "failureCount": "\(failures.count)",
                 "catalogSnapshotDuration": WorkspaceRestorePerfLog.formatMS(totalSearchCatalogSnapshotDurationMS),
                 "searchRebuildDuration": WorkspaceRestorePerfLog.formatMS(totalSearchIndexRebuildDurationMS),

--- a/Sources/RepoPrompt/Infrastructure/AI/Agents/AgentRunCoordinator.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Agents/AgentRunCoordinator.swift
@@ -88,7 +88,15 @@ final class AgentRunCoordinator {
 
         let lease = MCPBootstrapLease(spec: leaseSpec)
         let acquired = await lease.acquire()
-        guard acquired else { throw CancellationError() }
+        guard acquired else {
+            // A gate-deadline timeout is a retryable provisioning failure, not an
+            // intentional cancel; surface it as a distinct error so `catch is
+            // CancellationError` callers do not misclassify it. See #419.
+            if await lease.lastAcquireWasTimeout {
+                throw HeadlessAgentConnectionAcquireTimeoutError()
+            }
+            throw CancellationError()
+        }
         return lease
     }
 

--- a/Sources/RepoPrompt/Infrastructure/AI/Agents/HeadlessAgentConnectionGate.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Agents/HeadlessAgentConnectionGate.swift
@@ -1,5 +1,12 @@
 import Foundation
 import OSLog
+import RepoPromptShared
+
+/// Outcome of a bounded wait on the headless agent connection gate.
+enum HeadlessAgentConnectionWaitOutcome {
+    case resumed
+    case timedOut
+}
 
 /// Global gate to serialize headless agent connections and prevent racing.
 /// This ensures that only one headless agent (discovery, delegate-edit, or future types)
@@ -30,38 +37,73 @@ actor HeadlessAgentConnectionGate {
     private var activeConnectionID: UUID?
     private struct WaitingContinuation {
         let id: UUID
-        let continuation: CheckedContinuation<Void, Never>
+        let continuation: CheckedContinuation<HeadlessAgentConnectionWaitOutcome, Never>
     }
 
     private var waitingContinuations: [WaitingContinuation] = []
+    private var deadlineTasks: [UUID: Task<Void, Never>] = [:]
 
     private let log = Logger(subsystem: "com.repoprompt.agents", category: "ConnectionGate")
 
-    /// Wait for any currently connecting agent to finish before proceeding
-    func waitForClearConnection() async {
-        if let currentConnectionID = activeConnectionID {
-            log.info("Gate busy; waiting (current=\(currentConnectionID.uuidString))")
-            let waiterID = UUID()
-            await withTaskCancellationHandler(
-                operation: {
-                    await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-                        waitingContinuations.append(WaitingContinuation(id: waiterID, continuation: continuation))
+    /// Wait for any currently connecting agent to finish before proceeding.
+    ///
+    /// A bounded `deadline` keeps a stalled peer connection from blocking this
+    /// wait indefinitely; on expiry the wait simply returns so the caller can
+    /// proceed to acquire (which queues with its own deadline). See #419.
+    func waitForClearConnection(
+        deadline: Duration? = MCPTimeoutPolicy.headlessAgentConnectionAcquireDeadline
+    ) async {
+        guard let currentConnectionID = activeConnectionID else { return }
+        log.info("Gate busy; waiting (current=\(currentConnectionID.uuidString))")
+        let waiterID = UUID()
+        await withTaskCancellationHandler(
+            operation: {
+                await withCheckedContinuation { (continuation: CheckedContinuation<HeadlessAgentConnectionWaitOutcome, Never>) in
+                    if Task.isCancelled {
+                        continuation.resume(returning: .resumed)
+                        return
                     }
-                },
-                onCancel: {
-                    Task { await self.cancelWaitingContinuation(with: waiterID) }
+                    waitingContinuations.append(WaitingContinuation(id: waiterID, continuation: continuation))
+                    if let deadline {
+                        scheduleDeadline(for: waiterID, deadline: deadline)
+                    }
                 }
-            )
-        }
+            },
+            onCancel: {
+                Task { await self.cancelWaitingContinuation(with: waiterID) }
+            }
+        )
     }
 
     /// Note: Intentionally no logging here to avoid actor hop complexity during cancellation
     /// which can cause resource starvation/deadlock.
     private func cancelWaitingContinuation(with id: UUID) {
+        cancelDeadlineTask(for: id)
         if let index = waitingContinuations.firstIndex(where: { $0.id == id }) {
             let waiter = waitingContinuations.remove(at: index)
-            waiter.continuation.resume()
+            waiter.continuation.resume(returning: .resumed)
         }
+    }
+
+    /// Schedule a deadline after which `waiterID` is resumed with `.timedOut`.
+    private func scheduleDeadline(for waiterID: UUID, deadline: Duration) {
+        deadlineTasks[waiterID] = Task { [weak self] in
+            try? await Task.sleep(for: deadline)
+            guard !Task.isCancelled else { return }
+            await self?.timeoutWaiter(waiterID)
+        }
+    }
+
+    private func timeoutWaiter(_ waiterID: UUID) {
+        cancelDeadlineTask(for: waiterID)
+        guard let index = waitingContinuations.firstIndex(where: { $0.id == waiterID }) else { return }
+        let waiter = waitingContinuations.remove(at: index)
+        log.info("Gate waiter timed out (id=\(waiterID.uuidString))")
+        waiter.continuation.resume(returning: .timedOut)
+    }
+
+    private func cancelDeadlineTask(for waiterID: UUID) {
+        deadlineTasks.removeValue(forKey: waiterID)?.cancel()
     }
 
     /// Atomically waits until the gate is free, then marks it owned by `gateID`.
@@ -69,7 +111,10 @@ actor HeadlessAgentConnectionGate {
     /// IMPORTANT: This method re-checks ownership after every suspension so that a resumed waiter
     /// cannot overwrite a gate acquisition by a task that arrived between resume and re-entry.
     /// Returns diagnostics used by the MCP bootstrap history/perf surfaces.
-    func acquireWithDiagnostics(_ gateID: UUID) async -> AcquisitionResult {
+    func acquireWithDiagnostics(
+        _ gateID: UUID,
+        deadline: Duration? = MCPTimeoutPolicy.headlessAgentConnectionAcquireDeadline
+    ) async -> AcquisitionResult {
         let startUptime = ProcessInfo.processInfo.systemUptime
         let activeConnectionIDAtStart = activeConnectionID
         let queueDepthAtStart = waitingContinuations.count
@@ -77,17 +122,35 @@ actor HeadlessAgentConnectionGate {
         while let currentConnectionID = activeConnectionID {
             log.info("Gate busy; waiting to acquire (gateID=\(gateID.uuidString), current=\(currentConnectionID.uuidString))")
             let waiterID = UUID()
-            await withTaskCancellationHandler(
+            let outcome = await withTaskCancellationHandler(
                 operation: {
-                    await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                    await withCheckedContinuation { (continuation: CheckedContinuation<HeadlessAgentConnectionWaitOutcome, Never>) in
+                        if Task.isCancelled {
+                            continuation.resume(returning: .resumed)
+                            return
+                        }
                         waitingContinuations.append(WaitingContinuation(id: waiterID, continuation: continuation))
+                        if let deadline {
+                            scheduleDeadline(for: waiterID, deadline: deadline)
+                        }
                     }
                 },
                 onCancel: {
                     Task { await self.cancelWaitingContinuation(with: waiterID) }
                 }
             )
+            cancelDeadlineTask(for: waiterID)
             if Task.isCancelled {
+                return AcquisitionResult(
+                    acquired: false,
+                    activeConnectionIDAtStart: activeConnectionIDAtStart,
+                    queueDepthAtStart: queueDepthAtStart,
+                    queueDepthAtAcquire: waitingContinuations.count,
+                    waitDurationMS: (ProcessInfo.processInfo.systemUptime - startUptime) * 1000
+                )
+            }
+            if outcome == .timedOut {
+                log.info("Gate acquire timed out before acquisition (gateID=\(gateID.uuidString))")
                 return AcquisitionResult(
                     acquired: false,
                     activeConnectionIDAtStart: activeConnectionIDAtStart,
@@ -117,8 +180,11 @@ actor HeadlessAgentConnectionGate {
         )
     }
 
-    func acquire(_ gateID: UUID) async -> Bool {
-        await acquireWithDiagnostics(gateID).acquired
+    func acquire(
+        _ gateID: UUID,
+        deadline: Duration? = MCPTimeoutPolicy.headlessAgentConnectionAcquireDeadline
+    ) async -> Bool {
+        await acquireWithDiagnostics(gateID, deadline: deadline).acquired
     }
 
     /// Mark an agent as beginning connection
@@ -145,10 +211,11 @@ actor HeadlessAgentConnectionGate {
 
         // Resume ONE waiting agent (FIFO)
         let resumedWaiter: Bool
-        if !waitingContinuations.isEmpty {
-            let next = waitingContinuations.removeFirst()
+        if let next = waitingContinuations.first {
+            cancelDeadlineTask(for: next.id)
+            waitingContinuations.removeFirst()
             log.info("Resuming waiting gate permit (id=\(next.id.uuidString))")
-            next.continuation.resume()
+            next.continuation.resume(returning: .resumed)
             resumedWaiter = true
         } else {
             resumedWaiter = false
@@ -228,8 +295,9 @@ actor HeadlessAgentConnectionGate {
     /// Cancel all waiting agents (e.g., on app shutdown)
     func cancelAll() {
         activeConnectionID = nil
-        for continuation in waitingContinuations {
-            continuation.continuation.resume()
+        for waiter in waitingContinuations {
+            cancelDeadlineTask(for: waiter.id)
+            waiter.continuation.resume(returning: .resumed)
         }
         waitingContinuations.removeAll()
     }

--- a/Sources/RepoPrompt/Infrastructure/AI/Agents/HeadlessAgentConnectionGate.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Agents/HeadlessAgentConnectionGate.swift
@@ -8,6 +8,24 @@ enum HeadlessAgentConnectionWaitOutcome {
     case timedOut
 }
 
+/// Acquiring the gate exceeded its deadline (see #419).
+///
+/// Deliberately distinct from `CancellationError` so a provisioning timeout is not
+/// misclassified as an intentional cancel by `catch is CancellationError` branches
+/// (e.g. the `agent_run` start path). Callers that fail fast on cancellation should
+/// keep treating `CancellationError` as a cancel and surface this as a retryable error.
+struct HeadlessAgentConnectionAcquireTimeoutError: Error, CustomStringConvertible, LocalizedError {
+    private static let message = "Timed out waiting to acquire the headless agent connection gate. Another agent start may still be in progress; please retry."
+    var description: String {
+        Self.message
+    }
+
+    /// Surfaced via `error.localizedDescription` by callers that finalize the run as failed.
+    var errorDescription: String? {
+        Self.message
+    }
+}
+
 /// Global gate to serialize headless agent connections and prevent racing.
 /// This ensures that only one headless agent (discovery, delegate-edit, or future types)
 /// installs its connection policy and spawns at a time, preventing MCP connection conflicts.
@@ -25,6 +43,26 @@ actor HeadlessAgentConnectionGate {
         let queueDepthAtStart: Int
         let queueDepthAtAcquire: Int
         let waitDurationMS: Double
+        /// True when acquisition failed specifically because the deadline elapsed
+        /// (vs. task cancellation), so callers can tell a provisioning timeout from
+        /// an intentional cancel. See #419.
+        let timedOut: Bool
+
+        init(
+            acquired: Bool,
+            activeConnectionIDAtStart: UUID?,
+            queueDepthAtStart: Int,
+            queueDepthAtAcquire: Int,
+            waitDurationMS: Double,
+            timedOut: Bool = false
+        ) {
+            self.acquired = acquired
+            self.activeConnectionIDAtStart = activeConnectionIDAtStart
+            self.queueDepthAtStart = queueDepthAtStart
+            self.queueDepthAtAcquire = queueDepthAtAcquire
+            self.waitDurationMS = waitDurationMS
+            self.timedOut = timedOut
+        }
     }
 
     struct ReleaseResult {
@@ -46,6 +84,12 @@ actor HeadlessAgentConnectionGate {
     private let log = Logger(subsystem: "com.repoprompt.agents", category: "ConnectionGate")
 
     /// Wait for any currently connecting agent to finish before proceeding.
+    ///
+    /// - Note: This method and its static wrapper currently have no production
+    ///   callers — production bootstraps route through `acquireWithDiagnostics`,
+    ///   which atomically waits and acquires. This is most likely dead code,
+    ///   retained for symmetry/future use. If you call it, wire it through the
+    ///   same fail-fast contract as `acquireWithDiagnostics`. See #419.
     ///
     /// A bounded `deadline` keeps a stalled peer connection from blocking this
     /// wait indefinitely; on expiry the wait simply returns so the caller can
@@ -156,7 +200,8 @@ actor HeadlessAgentConnectionGate {
                     activeConnectionIDAtStart: activeConnectionIDAtStart,
                     queueDepthAtStart: queueDepthAtStart,
                     queueDepthAtAcquire: waitingContinuations.count,
-                    waitDurationMS: (ProcessInfo.processInfo.systemUptime - startUptime) * 1000
+                    waitDurationMS: (ProcessInfo.processInfo.systemUptime - startUptime) * 1000,
+                    timedOut: true
                 )
             }
         }
@@ -180,11 +225,8 @@ actor HeadlessAgentConnectionGate {
         )
     }
 
-    func acquire(
-        _ gateID: UUID,
-        deadline: Duration? = MCPTimeoutPolicy.headlessAgentConnectionAcquireDeadline
-    ) async -> Bool {
-        await acquireWithDiagnostics(gateID, deadline: deadline).acquired
+    func acquire(_ gateID: UUID) async -> Bool {
+        await acquireWithDiagnostics(gateID).acquired
     }
 
     /// Mark an agent as beginning connection
@@ -306,7 +348,8 @@ actor HeadlessAgentConnectionGate {
 // MARK: - Static Convenience Methods
 
 extension HeadlessAgentConnectionGate {
-    /// Wait for any in-progress agent connection to complete before proceeding
+    /// Wait for any in-progress agent connection to complete before proceeding.
+    /// - Note: Most likely dead code — no production callers (see instance method).
     static func waitForClearConnection() async {
         await HeadlessAgentConnectionGate.shared.waitForClearConnection()
     }

--- a/Sources/RepoPrompt/Infrastructure/MCP/MCPBootstrapLease.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/MCPBootstrapLease.swift
@@ -66,6 +66,15 @@ actor MCPBootstrapLease {
     private var didReleaseGate = false
     private var didCleanupRouting = false
     private var didClearPolicy = false
+    /// True iff the most recent `acquire()` failed specifically because the gate
+    /// deadline elapsed (vs. cancellation/abort), so callers can tell a provisioning
+    /// timeout from an intentional cancel. See #419.
+    private var lastAcquireTimedOut = false
+
+    /// Whether the most recent failed `acquire()` was a gate-deadline timeout.
+    var lastAcquireWasTimeout: Bool {
+        lastAcquireTimedOut
+    }
 
     /// Creates a unified bootstrap lease.
     ///
@@ -98,6 +107,7 @@ actor MCPBootstrapLease {
     /// PID-owned policies release the gate after their unique pending policy is confirmed armed.
     /// Returns `false` if cancelled, the gate could not be acquired, or PID ownership could not be armed.
     func acquire() async -> Bool {
+        lastAcquireTimedOut = false
         if hasReleased {
             acpLeaseLog("[ACP-Runner] lease run=\(spec.runID) gate=\(spec.gateID) acquire() ignored because lease already released")
             return false
@@ -159,13 +169,18 @@ actor MCPBootstrapLease {
             if gateAcquisition.acquired {
                 ownsGate = true
             }
+            // A gate deadline expiry is the one acquire failure that is not a
+            // cancel/abort; record it so callers can surface a timeout-specific
+            // error instead of a misleading cancellation. See #419.
+            lastAcquireTimedOut = (!gateAcquisition.acquired) && gateAcquisition.timedOut
             await recordDiagnosticEvent(
                 gateAcquisition.acquired ? "lease_gate_acquired" : "lease_gate_acquire_failed",
                 fields: [
                     "active_gate_id_at_start": gateAcquisition.activeConnectionIDAtStart?.uuidString ?? "nil",
                     "queue_depth_at_start": String(gateAcquisition.queueDepthAtStart),
                     "queue_depth_at_acquire": String(gateAcquisition.queueDepthAtAcquire),
-                    "wait_duration_ms": String(format: "%.3f", gateAcquisition.waitDurationMS)
+                    "wait_duration_ms": String(format: "%.3f", gateAcquisition.waitDurationMS),
+                    "timed_out": String(gateAcquisition.timedOut)
                 ]
             )
             acpLeaseLog("[ACP-Runner] lease run=\(spec.runID) gate=\(spec.gateID) global MCP gate acquired=\(gateAcquisition.acquired)")

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/Search/WorkspaceSearchService.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/Search/WorkspaceSearchService.swift
@@ -121,6 +121,18 @@ actor WorkspaceSearchService {
             searchDidCaptureGenerationHandler = handler
         }
 
+        /// DEBUG-only: transform the generation reported by `rebuildIndex` so the
+        /// search-readiness convergence loop can be driven into a deterministic
+        /// non-converging state in tests (repoprompt-ce #419). Internal freshness
+        /// bookkeeping (`commit`) is unaffected — only the value reported to callers.
+        private var rebuildIndexReportedGenerationTransformForTesting: (@Sendable (UInt64) -> UInt64)?
+
+        func setRebuildIndexReportedGenerationTransformForTesting(
+            _ transform: (@Sendable (UInt64) -> UInt64)?
+        ) {
+            rebuildIndexReportedGenerationTransformForTesting = transform
+        }
+
         static func authoritativeGlobalResultsForTesting(
             from snapshot: WorkspaceSearchCatalogSnapshot,
             query: String,
@@ -203,7 +215,11 @@ actor WorkspaceSearchService {
         }
         commit(prepared)
         activeRebuildGeneration = nil
-        return snapshot.generation
+        #if DEBUG
+            return rebuildIndexReportedGenerationTransformForTesting?(snapshot.generation) ?? snapshot.generation
+        #else
+            return snapshot.generation
+        #endif
     }
 
     @discardableResult

--- a/Sources/RepoPromptShared/MCP/MCPTimeoutPolicy.swift
+++ b/Sources/RepoPromptShared/MCP/MCPTimeoutPolicy.swift
@@ -46,6 +46,15 @@ public enum MCPTimeoutPolicy {
     public static let cliSemanticWaitResponseMarginSeconds: TimeInterval = .init(responseSendDeadlineSeconds)
 
     public static let agentLifecycleDefaultWaitSeconds: TimeInterval = 120
+
+    /// Server-side deadline for a headless agent connection gate acquisition
+    /// (`agent_run` / `agent_explore` bootstrap). Bounds the multi-window amplifier
+    /// where one stalled bootstrap would otherwise queue every subsequent start
+    /// indefinitely up to the MCP client idle timeout. See repoprompt-ce #419.
+    public static let headlessAgentConnectionAcquireDeadlineSeconds: TimeInterval = 120
+    public static let headlessAgentConnectionAcquireDeadline: Duration = .seconds(
+        headlessAgentConnectionAcquireDeadlineSeconds
+    )
     public static let askUserDefaultTimeoutSeconds: TimeInterval = 300
     public static let nextUserInstructionDefaultWaitSeconds: TimeInterval = 600
     public static let applyEditsApprovalTimeoutSeconds: TimeInterval = 300

--- a/Tests/RepoPromptTests/AgentMode/HeadlessAgentConnectionGateDeadlineTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/HeadlessAgentConnectionGateDeadlineTests.swift
@@ -13,19 +13,26 @@ import XCTest
             let holderID = UUID()
             let waiterID = UUID()
 
-            let holderAcquired = await HeadlessAgentConnectionGate.shared.acquire(holderID, deadline: .seconds(60))
+            let holderAcquired = await HeadlessAgentConnectionGate.shared.acquire(holderID)
             XCTAssertTrue(holderAcquired, "holder should acquire the idle gate immediately")
 
             // The holder holds for 60s, so the waiter (200ms deadline) must time out, return
-            // false, and do so promptly — not park on the gate continuation up to the ~30-minute
-            // MCP client idle timeout.
+            // acquired=false with timedOut=true, and do so promptly — not park on the gate
+            // continuation up to the ~30-minute MCP client idle timeout.
             let clock = ContinuousClock()
             let waitStart = clock.now
-            let waiterAcquired = await HeadlessAgentConnectionGate.shared.acquire(waiterID, deadline: .milliseconds(200))
+            let waiterAcquisition = await HeadlessAgentConnectionGate.shared.acquireWithDiagnostics(
+                waiterID,
+                deadline: .milliseconds(200)
+            )
             let waitElapsed = waitStart.duration(to: clock.now)
             XCTAssertFalse(
-                waiterAcquired,
-                "a queued gate acquire must respect its deadline and return false on timeout (repoprompt-ce #419)"
+                waiterAcquisition.acquired,
+                "a queued gate acquire must respect its deadline and return acquired=false on timeout (repoprompt-ce #419)"
+            )
+            XCTAssertTrue(
+                waiterAcquisition.timedOut,
+                "a deadline expiry must be reported as timedOut=true so callers can distinguish it from cancellation (repoprompt-ce #419)"
             )
             XCTAssertLessThan(
                 waitElapsed,

--- a/Tests/RepoPromptTests/AgentMode/HeadlessAgentConnectionGateDeadlineTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/HeadlessAgentConnectionGateDeadlineTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+@testable import RepoPromptApp
+import RepoPromptShared
+import XCTest
+
+#if DEBUG
+    final class HeadlessAgentConnectionGateDeadlineTests: XCTestCase {
+        /// repoprompt-ce #419: a queued agent_run bootstrap must not wait indefinitely
+        /// behind a held gate. It must respect a deadline and fail fast, so one stalled
+        /// start cannot block every subsequent start across windows.
+        func testQueuedAcquireTimesOutInsteadOfWaitingIndefinitely() async {
+            await HeadlessAgentConnectionGate.cancelAll()
+            let holderID = UUID()
+            let waiterID = UUID()
+
+            let holderAcquired = await HeadlessAgentConnectionGate.shared.acquire(holderID, deadline: .seconds(60))
+            XCTAssertTrue(holderAcquired, "holder should acquire the idle gate immediately")
+
+            // The holder holds for 60s, so the waiter (200ms deadline) must time out, return
+            // false, and do so promptly — not park on the gate continuation up to the ~30-minute
+            // MCP client idle timeout.
+            let clock = ContinuousClock()
+            let waitStart = clock.now
+            let waiterAcquired = await HeadlessAgentConnectionGate.shared.acquire(waiterID, deadline: .milliseconds(200))
+            let waitElapsed = waitStart.duration(to: clock.now)
+            XCTAssertFalse(
+                waiterAcquired,
+                "a queued gate acquire must respect its deadline and return false on timeout (repoprompt-ce #419)"
+            )
+            XCTAssertLessThan(
+                waitElapsed,
+                .seconds(5),
+                "a timed-out acquire must fail fast, well under the MCP client idle timeout (repoprompt-ce #419)"
+            )
+
+            let queued = await HeadlessAgentConnectionGate.shared.debugWaitingCount()
+            XCTAssertEqual(queued, 0, "a timed-out waiter must be removed from the queue (repoprompt-ce #419)")
+
+            await HeadlessAgentConnectionGate.shared.completeConnection(holderID)
+            await HeadlessAgentConnectionGate.cancelAll()
+        }
+    }
+#endif

--- a/Tests/RepoPromptTests/MCP/Control/MCPToolExecutionContractTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/MCPToolExecutionContractTests.swift
@@ -9,6 +9,7 @@ final class MCPToolExecutionContractTests: XCTestCase {
         XCTAssertEqual(MCPTimeoutPolicy.boundedToolExecutionDeadlineSeconds, 30)
         XCTAssertEqual(MCPTimeoutPolicy.workspaceFreshnessWaitTimeoutSeconds, 30)
         XCTAssertEqual(MCPTimeoutPolicy.workspaceSwitchToolExecutionDeadlineSeconds, 120)
+        XCTAssertEqual(MCPTimeoutPolicy.headlessAgentConnectionAcquireDeadlineSeconds, 120)
         XCTAssertEqual(MCPTimeoutPolicy.boundedToolCancellationCleanupGraceSeconds, 5)
         XCTAssertEqual(MCPTimeoutPolicy.responseSendDeadlineSeconds, 30)
         XCTAssertEqual(MCPTimeoutPolicy.codexServerActiveTimeoutSeconds, 10000)

--- a/Tests/RepoPromptTests/Workspaces/WorkspaceSearchIndexConvergenceCapTests.swift
+++ b/Tests/RepoPromptTests/Workspaces/WorkspaceSearchIndexConvergenceCapTests.swift
@@ -1,0 +1,129 @@
+#if DEBUG
+    import Foundation
+    @testable import RepoPromptApp
+    import RepoPromptShared
+    import XCTest
+
+    /// Behavioral guard for repoprompt-ce #419.
+    ///
+    /// The search-readiness convergence loop in `loadWorkspaceFolders` is uncancellable
+    /// by construction (its guards check hydration but never `Task.isCancelled`) and had
+    /// no iteration cap, so under multi-window catalog churn it could spin indefinitely on
+    /// the MainActor — wedging `switchWorkspace` and `agent_run` provisioning until the MCP
+    /// client idle timeout. This test drives the loop into a deterministic non-converging
+    /// state and asserts the cap bounds it.
+    ///
+    /// On a regression (cap removed), `switchWorkspace` never returns and the test fails via
+    /// the XCTest watchdog rather than an assertion — the accepted trade for an unbounded-loop
+    /// defect, matching `HeadlessAgentConnectionGateDeadlineTests`.
+    @MainActor
+    final class WorkspaceSearchIndexConvergenceCapTests: XCTestCase {
+        func testConvergenceLoopIsBoundedWhenIndexNeverConverges() async throws {
+            let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
+            let defaults = UserDefaults.standard
+            let previousStoragePath = defaults.string(forKey: "GlobalCustomStorageURL")
+            GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
+            let storageRoot = FileManager.default.temporaryDirectory
+                .appendingPathComponent("convergence-cap-storage-\(UUID().uuidString)")
+            try FileManager.default.createDirectory(at: storageRoot, withIntermediateDirectories: true)
+            defaults.set(storageRoot.path, forKey: "GlobalCustomStorageURL")
+            defer {
+                GlobalSettingsStore.shared.setMCPAutoStart(previousAutoStart, commit: false)
+                if let previousStoragePath {
+                    defaults.set(previousStoragePath, forKey: "GlobalCustomStorageURL")
+                } else {
+                    defaults.removeObject(forKey: "GlobalCustomStorageURL")
+                }
+                try? FileManager.default.removeItem(at: storageRoot)
+            }
+
+            let searchService = WorkspaceSearchService()
+            let rebuildCounter = RebuildCounter()
+            // Always report a generation one behind the live catalog, so the loop's
+            // `currentCatalogGeneration != indexGeneration` guard can never be false.
+            await searchService.setRebuildIndexReportedGenerationTransformForTesting { generation in
+                rebuildCounter.increment()
+                return generation &- 1
+            }
+
+            let composition = WindowStateCompositionFactory.make(
+                windowID: -600 - Int.random(in: 1 ... 99),
+                deferredInitialAgentSystemWorkspaceRefresh: true,
+                sharedMCPService: MCPService(),
+                workspaceSearchService: searchService
+            )
+            let manager = composition.workspaceManager
+            await manager.awaitInitialized()
+            // The composition's initial workspace activation also hydrates through the
+            // convergence loop; reset so the count reflects only this switch.
+            rebuildCounter.reset()
+
+            let workspaceRoot = FileManager.default.temporaryDirectory
+                .appendingPathComponent("convergence-cap-ws-\(UUID().uuidString)")
+            try FileManager.default.createDirectory(
+                at: workspaceRoot.appendingPathComponent("Sources"),
+                withIntermediateDirectories: true
+            )
+            try "one\ntwo\nthree\n".write(
+                to: workspaceRoot.appendingPathComponent("Sources/Selected.swift"),
+                atomically: true,
+                encoding: .utf8
+            )
+            defer { try? FileManager.default.removeItem(at: workspaceRoot) }
+
+            let workspace = manager.createWorkspace(
+                name: "Convergence Cap Test \(UUID().uuidString.prefix(8))",
+                repoPaths: [workspaceRoot.path],
+                ephemeral: true
+            )
+
+            let clock = ContinuousClock()
+            let start = clock.now
+            let result = await manager.switchWorkspace(
+                to: workspace,
+                saveState: false,
+                reason: "convergenceCapTest"
+            )
+            let elapsed = start.duration(to: clock.now)
+
+            XCTAssertEqual(
+                result,
+                .switched,
+                "switch must commit even when the index never converges (repoprompt-ce #419)"
+            )
+            XCTAssertLessThan(
+                elapsed,
+                .seconds(10),
+                "the convergence loop must be bounded by the cap, not spin on the MainActor (repoprompt-ce #419)"
+            )
+            XCTAssertEqual(
+                rebuildCounter.value,
+                1 + WorkspaceManagerViewModel.maxSearchIndexConvergenceRebuilds,
+                "rebuildIndex must run once for the pre-loop build plus exactly maxSearchIndexConvergenceRebuilds capped loop passes (repoprompt-ce #419)"
+            )
+        }
+    }
+
+    private final class RebuildCounter: @unchecked Sendable {
+        private let lock = NSLock()
+        private var count = 0
+
+        func increment() {
+            lock.lock()
+            count += 1
+            lock.unlock()
+        }
+
+        func reset() {
+            lock.lock()
+            count = 0
+            lock.unlock()
+        }
+
+        var value: Int {
+            lock.lock()
+            defer { lock.unlock() }
+            return count
+        }
+    }
+#endif


### PR DESCRIPTION
## Summary

Bounds two unbounded awaits in `agent_run` / `agent_explore` provisioning that turned dispatch stalls into ~30-minute MCP client idle timeouts under multi-window load (#419).

### `HeadlessAgentConnectionGate` — the bootstrap amplifier
The gate is a process-wide singleton that serializes every agent bootstrap, and its `acquire` wait had **no deadline**. When one start's bootstrap stalled, every subsequent start across all windows queued indefinitely behind it — the "concurrent multi-window load" trigger. (Operationally corroborated: restarting only the MCP server didn't clear it; a full app restart was required — pinning the stuck state to the app process, exactly where this singleton lives.)

- `acquire` / `acquireWithDiagnostics` / `waitForClearConnection` now take a bounded `deadline` (default 120s, `MCPTimeoutPolicy.headlessAgentConnectionAcquireDeadline`). On expiry the queued waiter resumes with `.timedOut` → returns `acquired: false` → the runner tears the start down cleanly instead of parking forever.
- `WindowStateComposition.make` gains a `workspaceSearchService` injection seam (mirrors the existing `workspaceFileContextStore` seam) for deterministic tests.

### `WorkspaceManagerViewModel.loadWorkspaceFolders` — the convergence loop
The search-readiness convergence loop had **no iteration cap** and was **uncancellable by construction** (its guards checked hydration but never `Task.isCancelled` — which is why the MCP execution watchdog's cancellation couldn't rescue the stall). Under multi-window catalog churn the live `catalogGeneration` keeps advancing, so `rebuildIndex` chased a moving target indefinitely.

- Added `maxSearchIndexConvergenceRebuilds = 3` cap + a `!Task.isCancelled` guard. On cap, `break` to the existing `.ready` / `.degraded` decision — safe because `startKeepingFresh` (subscribed before the loop) self-heals in the background and `isStale` reporting stays honest.
- `WorkspaceSearchService` gains a DEBUG-only `setRebuildIndexReportedGenerationTransformForTesting` hook (idiomatic; mirrors `setSearchDidCaptureGenerationHandler`) for deterministic non-convergence tests.

`loadRoot`'s directory walk is intentionally **not** bounded here — it is a finite computation already covered externally by the watchdog; only a dead mount would hang it, which a Swift cap does not fix.

## Design note
`agent_run` stays `.lifecycleManagedCancellable` (no dispatch watchdog) by deliberate contract (`testAgentRunAndExploreUseLifecycleManagedExemption`). This PR bounds the two specific unbounded awaits rather than reversing that contract; an inline watchdog wrap of the `@MainActor` provisioning path was rejected as fighting the isolation.

## Tests
- `HeadlessAgentConnectionGateDeadlineTests` — a queued acquire with a short deadline returns `false` and the waiter is removed from the queue; uncapped it parks forever.
- `WorkspaceSearchIndexConvergenceCapTests` — a deterministic non-converging rebuild drives the loop; asserts `.switched`, elapsed < 10s, and exact `rebuildIndex` count `== 1 + maxSearchIndexConvergenceRebuilds`.

Both green on `main` (post #437 target split — tests import `RepoPromptApp`). Red state re-confirmed on `main`: the gate has no `deadline` and the convergence loop has no cap / no `Task.isCancelled` guard, so the fix is still needed. Regression suites green (`ContextBuilderRunLifecycleTests` 10/10, `WorkspaceSwitchRecoveryTests` 22/22).

## Follow-ups
- Contract ledger: `verify-ledger` reports `missing=2` for these new methods (main itself is currently `missing=22`, so it's a curation tool, not a CI gate). Happy to add the two rows if you want them curated now.
- The convergence loop is a candidate for future extraction into a bounded helper; an Oracle review judged that over-engineering for a single call site, so this ships the minimal inline cap.

Refs repoprompt/repoprompt-ce#419.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
