### PR TITLE
Fix Git MCP admission blocking

### DIFF
--- a/Sources/RepoPrompt/Infrastructure/MCP/Policies/MCPToolAdmissionPolicy.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/Policies/MCPToolAdmissionPolicy.swift
@@ -26,15 +26,14 @@ enum MCPToolAdmissionClass: String, CaseIterable {
 }
 
 enum MCPToolAdmissionPolicy {
-    /// Gate B selected the conservative lower bounds from the WI-3 baseline:
-    /// two small reads per connection and per window/store, two Git requests per connection
-    /// with a separate one-per-repository request gate, and the unchanged PR #155 four-search burst.
+    /// Modernized multi-agent defaults: keep mutation/artifact gates conservative while
+    /// giving read/control lanes enough capacity for several active agents in one window.
     static let exclusiveConnectionLimit = 1
-    static let controlConnectionLimit = 8
-    static let smallReadConnectionLimit = 2
-    static let smallReadPerWindowLimit = 2
-    static let gitReadConnectionLimit = 2
-    static let fileSearchConnectionLimit = 4
+    static let controlConnectionLimit = 16
+    static let smallReadConnectionLimit = 6
+    static let smallReadPerWindowLimit = 8
+    static let gitReadConnectionLimit = 4
+    static let fileSearchConnectionLimit = 6
     static let gitReadPerRepositoryLimit = 1
 
     /// Exhaustive canonical-tool table. Do not add a default: every advertised tool must be

--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPGitToolAdmissionController.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPGitToolAdmissionController.swift
@@ -1,7 +1,24 @@
 import Foundation
+import OSLog
 
-/// Tool-level Git admission keyed by canonical repository identity. The lower-level WI-9
-/// GitProcessAdmissionController remains the global/per-repository subprocess budget.
+enum MCPGitToolAdmissionError: LocalizedError, Equatable {
+    case waitTimedOut
+
+    var errorDescription: String? {
+        switch self {
+        case .waitTimedOut:
+            "Timed out waiting for another Git artifact export to finish for this repository. The earlier export may still be running or stuck; retry shortly. Read-only Git status/diff calls do not wait on this artifact-export gate."
+        }
+    }
+}
+
+/// Tool-level Git artifact-publication admission keyed by canonical repository identity.
+///
+/// This controller intentionally does not guard plain read-only Git operations such as
+/// status, log, show, blame, or non-artifact diff. Those calls use the lower-level
+/// GitProcessAdmissionController subprocess budget instead. Keeping this gate scoped to
+/// artifact publication prevents one stuck snapshot/export path from freezing ordinary
+/// Git reads across chats.
 @MainActor
 final class MCPGitToolAdmissionController {
     struct Lease: Equatable {
@@ -19,14 +36,34 @@ final class MCPGitToolAdmissionController {
         perRepositoryLimit: MCPToolAdmissionPolicy.gitReadPerRepositoryLimit
     )
 
+    /// Bounded UX wait for queued artifact publication. Plain read-only Git operations
+    /// do not use this controller, so they do not inherit this queue.
+    nonisolated static let defaultWaitTimeout: Duration = .seconds(30)
+    /// Last-resort watchdog for leaked artifact-publication leases. Expiry is short
+    /// enough to heal a wedged export promptly; actual Git subprocess fanout is still
+    /// governed by GitProcessAdmissionController.
+    nonisolated static let defaultLeaseTimeout: Duration = .seconds(120)
+
+    private static let log = Logger(subsystem: "com.repoprompt.mcp", category: "GitArtifactAdmission")
+
     let perRepositoryLimit: Int
+    private let waitTimeout: Duration?
+    private let leaseTimeout: Duration?
     private var activeByRepository: [String: Int] = [:]
     private var activeLeaseIDs: Set<UUID> = []
     private var waiters: [Waiter] = []
+    private var waiterTimeoutTasks: [UUID: Task<Void, Never>] = [:]
+    private var leaseTimeoutTasks: [UUID: Task<Void, Never>] = [:]
 
-    init(perRepositoryLimit: Int) {
+    init(
+        perRepositoryLimit: Int,
+        waitTimeout: Duration? = MCPGitToolAdmissionController.defaultWaitTimeout,
+        leaseTimeout: Duration? = MCPGitToolAdmissionController.defaultLeaseTimeout
+    ) {
         precondition(perRepositoryLimit > 0)
         self.perRepositoryLimit = perRepositoryLimit
+        self.waitTimeout = waitTimeout
+        self.leaseTimeout = leaseTimeout
     }
 
     func acquire(repositoryRoots: [URL]) async throws -> Lease {
@@ -58,6 +95,7 @@ final class MCPGitToolAdmissionController {
                     repositoryKeys: repositoryKeys,
                     continuation: continuation
                 ))
+                scheduleWaitTimeout(waiterID)
             }
         } onCancel: {
             Task { @MainActor [weak self] in
@@ -75,6 +113,7 @@ final class MCPGitToolAdmissionController {
 
     func release(_ lease: Lease) {
         guard activeLeaseIDs.remove(lease.id) != nil else { return }
+        leaseTimeoutTasks.removeValue(forKey: lease.id)?.cancel()
         for key in lease.repositoryKeys {
             let next = max(0, (activeByRepository[key] ?? 0) - 1)
             if next == 0 {
@@ -96,6 +135,14 @@ final class MCPGitToolAdmissionController {
 
     func waiterCount() -> Int {
         waiters.count
+    }
+
+    func waiterTimeoutTaskCount() -> Int {
+        waiterTimeoutTasks.count
+    }
+
+    func leaseTimeoutTaskCount() -> Int {
+        leaseTimeoutTasks.count
     }
 
     nonisolated static func repositoryKey(for checkoutRoot: URL) -> String {
@@ -121,19 +168,72 @@ final class MCPGitToolAdmissionController {
             activeByRepository[key, default: 0] += 1
         }
         activeLeaseIDs.insert(id)
+        scheduleLeaseTimeout(id, repositoryKeys: repositoryKeys)
         return Lease(id: id, repositoryKeys: repositoryKeys)
     }
 
     private func cancelWaiter(_ waiterID: UUID) {
         guard let index = waiters.firstIndex(where: { $0.id == waiterID }) else { return }
         let waiter = waiters.remove(at: index)
+        waiterTimeoutTasks.removeValue(forKey: waiterID)?.cancel()
         waiter.continuation.resume(throwing: CancellationError())
         admitWaitersInFIFOOrder()
+    }
+
+    private func timeoutWaiter(_ waiterID: UUID) {
+        guard let index = waiters.firstIndex(where: { $0.id == waiterID }) else { return }
+        let waiter = waiters.remove(at: index)
+        waiterTimeoutTasks.removeValue(forKey: waiterID)?.cancel()
+        Self.log.warning("Git artifact admission wait timed out for repositories: \(waiter.repositoryKeys.joined(separator: ", "))")
+        waiter.continuation.resume(throwing: MCPGitToolAdmissionError.waitTimedOut)
+        admitWaitersInFIFOOrder()
+    }
+
+    private func expireLease(_ leaseID: UUID, repositoryKeys: [String]) {
+        guard activeLeaseIDs.remove(leaseID) != nil else { return }
+        leaseTimeoutTasks.removeValue(forKey: leaseID)?.cancel()
+        Self.log.warning("Expired stale Git artifact admission lease for repositories: \(repositoryKeys.joined(separator: ", "))")
+        for key in repositoryKeys {
+            let next = max(0, (activeByRepository[key] ?? 0) - 1)
+            if next == 0 {
+                activeByRepository.removeValue(forKey: key)
+            } else {
+                activeByRepository[key] = next
+            }
+        }
+        admitWaitersInFIFOOrder()
+    }
+
+    private func scheduleWaitTimeout(_ waiterID: UUID) {
+        guard let waitTimeout else { return }
+        waiterTimeoutTasks[waiterID]?.cancel()
+        waiterTimeoutTasks[waiterID] = Task { @MainActor [weak self] in
+            do {
+                try await Task.sleep(for: waitTimeout)
+            } catch {
+                return
+            }
+            self?.timeoutWaiter(waiterID)
+        }
+    }
+
+    private func scheduleLeaseTimeout(_ leaseID: UUID, repositoryKeys: [String]) {
+        guard let leaseTimeout else { return }
+        leaseTimeoutTasks[leaseID]?.cancel()
+        leaseTimeoutTasks[leaseID] = Task { @MainActor [weak self] in
+            do {
+                try await Task.sleep(for: leaseTimeout)
+            } catch {
+                return
+            }
+            self?.expireLease(leaseID, repositoryKeys: repositoryKeys)
+        }
     }
 
     private func admitWaitersInFIFOOrder() {
         while let index = waiters.firstIndex(where: { canAcquire($0.repositoryKeys) }) {
             let waiter = waiters.remove(at: index)
+            waiterTimeoutTasks.removeValue(forKey: waiter.id)?.cancel()
             waiter.continuation.resume(returning: activate(waiter.repositoryKeys))
         }
     }

--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPGitToolProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPGitToolProvider.swift
@@ -597,13 +597,6 @@ final class MCPGitToolProvider: MCPWindowToolProviding {
             try await dependencies.validateContextBuilderGitArtifactSelection(metadata, publicationFence.target)
         }
 
-        // Tool-level admission is keyed by every repository touched by this request. WI-9's
-        // lower-level global/per-repository subprocess controller remains independently active.
-        let gitAdmissionLease = try await MCPGitToolAdmissionController.shared.acquire(
-            repositoryRoots: repos.map(\.rootURL)
-        )
-        defer { MCPGitToolAdmissionController.shared.release(gitAdmissionLease) }
-
         // For now, use primary repo for single-repo operations
         // Multi-root execution will be implemented for operations that benefit from it (status, diff)
         MCPToolWorkCountDiagnostics.setGitRepositories(repos.map(\.repoKey))
@@ -1097,6 +1090,16 @@ final class MCPGitToolProvider: MCPWindowToolProviding {
 
             // If artifacts requested, use the publisher
             if artifacts {
+                // Tool-level admission is only needed for artifact publication paths,
+                // which write Git snapshot files and can commit primary artifacts to the
+                // current tab selection. Plain read-only Git operations are protected by
+                // the lower-level GitProcessAdmissionController and must not queue behind
+                // a stuck artifact export.
+                let gitAdmissionLease = try await MCPGitToolAdmissionController.shared.acquire(
+                    repositoryRoots: repos.map(\.rootURL)
+                )
+                defer { MCPGitToolAdmissionController.shared.release(gitAdmissionLease) }
+
                 let modeRaw = args["mode"]?.stringValue?.lowercased() ?? "standard"
                 guard let mode = GitDiffPublishMode(rawValue: modeRaw) else {
                     throw MCPError.invalidParams("Invalid mode: \(modeRaw)")

--- a/Tests/RepoPromptTests/MCP/Control/MCPToolAdmissionPolicyTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/MCPToolAdmissionPolicyTests.swift
@@ -55,18 +55,18 @@ final class MCPToolAdmissionPolicyTests: XCTestCase {
         XCTAssertEqual(ServerNetworkManager.admissionClass(forCanonicalToolName: alias), .exclusive)
     }
 
-    func testGateBCapacitiesRecordConservativeWI3BaselineChoices() {
+    func testCapacitiesRecordModernMultiAgentDefaults() {
         XCTAssertEqual(MCPToolAdmissionPolicy.exclusiveConnectionLimit, 1)
-        XCTAssertEqual(MCPToolAdmissionPolicy.controlConnectionLimit, 8)
-        XCTAssertEqual(MCPToolAdmissionPolicy.smallReadConnectionLimit, 2)
-        XCTAssertEqual(MCPToolAdmissionPolicy.smallReadPerWindowLimit, 2)
-        XCTAssertEqual(MCPToolAdmissionPolicy.gitReadConnectionLimit, 2)
+        XCTAssertEqual(MCPToolAdmissionPolicy.controlConnectionLimit, 16)
+        XCTAssertEqual(MCPToolAdmissionPolicy.smallReadConnectionLimit, 6)
+        XCTAssertEqual(MCPToolAdmissionPolicy.smallReadPerWindowLimit, 8)
+        XCTAssertEqual(MCPToolAdmissionPolicy.gitReadConnectionLimit, 4)
         XCTAssertEqual(MCPToolAdmissionPolicy.gitReadPerRepositoryLimit, 1)
-        XCTAssertEqual(MCPToolAdmissionPolicy.fileSearchConnectionLimit, 4)
-        XCTAssertEqual(ServerNetworkManager.smallReadCallLaneLimit, 2)
-        XCTAssertEqual(ServerNetworkManager.controlCallLaneLimit, 8)
-        XCTAssertEqual(ServerNetworkManager.gitReadCallLaneLimit, 2)
-        XCTAssertEqual(ServerNetworkManager.fileSearchCallLaneLimit, 4)
+        XCTAssertEqual(MCPToolAdmissionPolicy.fileSearchConnectionLimit, 6)
+        XCTAssertEqual(ServerNetworkManager.smallReadCallLaneLimit, 6)
+        XCTAssertEqual(ServerNetworkManager.controlCallLaneLimit, 16)
+        XCTAssertEqual(ServerNetworkManager.gitReadCallLaneLimit, 4)
+        XCTAssertEqual(ServerNetworkManager.fileSearchCallLaneLimit, 6)
     }
 
     func testSameConnectionSmallReadsOverlapAtBoundedCapacity() async throws {
@@ -226,31 +226,32 @@ final class MCPToolAdmissionPolicyTests: XCTestCase {
     }
 
     func testSmallReadResourceAdmissionBoundsOneWindowAndOverlapsDistinctWindows() async throws {
-        let controller = MCPToolResourceAdmissionController(
-            limit: MCPToolAdmissionPolicy.smallReadPerWindowLimit
-        )
+        let limit = MCPToolAdmissionPolicy.smallReadPerWindowLimit
+        let controller = MCPToolResourceAdmissionController(limit: limit)
         let gate = AdmissionTestGate()
 
-        let first = mutationTask(controller: controller, resource: .window(30), gate: gate)
-        let second = mutationTask(controller: controller, resource: .window(30), gate: gate)
-        let didFillWindowCapacity = await waitUntil { await gate.startedCount() == 2 }
+        let sameWindowTasks = (0 ..< limit).map { _ in
+            mutationTask(controller: controller, resource: .window(30), gate: gate)
+        }
+        let didFillWindowCapacity = await waitUntil { await gate.startedCount() == limit }
         XCTAssertTrue(didFillWindowCapacity)
 
         let queuedSameWindow = mutationTask(controller: controller, resource: .window(30), gate: gate)
         let distinctWindow = mutationTask(controller: controller, resource: .window(40), gate: gate)
-        let didOverlapDistinctWindow = await waitUntil { await gate.startedCount() == 3 }
+        let didOverlapDistinctWindow = await waitUntil { await gate.startedCount() == limit + 1 }
         XCTAssertTrue(didOverlapDistinctWindow)
-        XCTAssertEqual(controller.activeCount(for: .window(30)), 2)
+        XCTAssertEqual(controller.activeCount(for: .window(30)), limit)
         XCTAssertEqual(controller.activeCount(for: .window(40)), 1)
         XCTAssertEqual(controller.waiterCount(for: .window(30)), 1)
 
         await gate.release()
-        try await first.value
-        try await second.value
+        for task in sameWindowTasks {
+            try await task.value
+        }
         try await queuedSameWindow.value
         try await distinctWindow.value
         let finalReadCount = await gate.startedCount()
-        XCTAssertEqual(finalReadCount, 4)
+        XCTAssertEqual(finalReadCount, limit + 2)
         XCTAssertEqual(controller.activeCount(for: .window(30)), 0)
         XCTAssertEqual(controller.activeCount(for: .window(40)), 0)
     }
@@ -351,6 +352,113 @@ final class MCPToolAdmissionPolicyTests: XCTestCase {
         XCTAssertEqual(finalGitCount, 3)
         XCTAssertEqual(controller.activeCount(repositoryKey: repoA), 0)
         XCTAssertEqual(controller.activeCount(repositoryKey: repoB), 0)
+    }
+
+    func testGitAdmissionWaiterTimesOutInsteadOfBlockingForever() async throws {
+        let controller = MCPGitToolAdmissionController(
+            perRepositoryLimit: 1,
+            waitTimeout: .milliseconds(50),
+            leaseTimeout: nil
+        )
+        let repo = "/tmp/WI10-Repo-Timeout"
+        let lease = try await controller.acquire(repositoryKeys: [repo])
+
+        let blocked = Task {
+            try await controller.acquire(repositoryKeys: [repo])
+        }
+
+        do {
+            _ = try await blocked.value
+            XCTFail("Expected queued Git admission to time out")
+        } catch let error as MCPGitToolAdmissionError {
+            XCTAssertEqual(error, .waitTimedOut)
+        }
+
+        XCTAssertEqual(controller.waiterCount(), 0)
+        XCTAssertEqual(controller.activeCount(repositoryKey: repo), 1)
+        controller.release(lease)
+        XCTAssertEqual(controller.activeCount(repositoryKey: repo), 0)
+    }
+
+    func testGitAdmissionExpiresStaleLeaseAndAdmitsQueuedWork() async throws {
+        let controller = MCPGitToolAdmissionController(
+            perRepositoryLimit: 1,
+            waitTimeout: nil,
+            leaseTimeout: .milliseconds(50)
+        )
+        let repo = "/tmp/WI10-Repo-StaleLease"
+        let staleLease = try await controller.acquire(repositoryKeys: [repo])
+
+        let successor = Task {
+            try await controller.acquire(repositoryKeys: [repo])
+        }
+
+        let successorLease = try await successor.value
+        XCTAssertEqual(controller.waiterCount(), 0)
+        XCTAssertEqual(controller.activeCount(repositoryKey: repo), 1)
+
+        // Releasing the expired lease should be a no-op; the successor remains active.
+        controller.release(staleLease)
+        XCTAssertEqual(controller.activeCount(repositoryKey: repo), 1)
+        controller.release(successorLease)
+        XCTAssertEqual(controller.activeCount(repositoryKey: repo), 0)
+    }
+
+    func testGitAdmissionReleaseCancelsLeaseWatchdog() async throws {
+        let controller = MCPGitToolAdmissionController(
+            perRepositoryLimit: 1,
+            waitTimeout: .seconds(1),
+            leaseTimeout: .milliseconds(50)
+        )
+        let repo = "/tmp/WI10-Repo-ReleaseCancelsWatchdog"
+        let firstLease = try await controller.acquire(repositoryKeys: [repo])
+        XCTAssertEqual(controller.leaseTimeoutTaskCount(), 1)
+
+        controller.release(firstLease)
+        XCTAssertEqual(controller.leaseTimeoutTaskCount(), 0)
+        try await Task.sleep(for: .milliseconds(100))
+        XCTAssertEqual(controller.activeCount(repositoryKey: repo), 0)
+
+        let secondLease = try await controller.acquire(repositoryKeys: [repo])
+        XCTAssertEqual(controller.leaseTimeoutTaskCount(), 1)
+        XCTAssertEqual(controller.waiterCount(), 0)
+        XCTAssertEqual(controller.activeCount(repositoryKey: repo), 1)
+        controller.release(secondLease)
+        XCTAssertEqual(controller.leaseTimeoutTaskCount(), 0)
+        XCTAssertEqual(controller.activeCount(repositoryKey: repo), 0)
+    }
+
+    func testGitAdmissionCancellingBlockedWaiterDoesNotLaterTimeout() async throws {
+        let controller = MCPGitToolAdmissionController(
+            perRepositoryLimit: 1,
+            waitTimeout: .milliseconds(50),
+            leaseTimeout: nil
+        )
+        let repo = "/tmp/WI10-Repo-CancelWaiter"
+        let lease = try await controller.acquire(repositoryKeys: [repo])
+
+        let blocked = Task {
+            try await controller.acquire(repositoryKeys: [repo])
+        }
+        let didQueueWaiter = await waitUntil { controller.waiterCount() == 1 }
+        XCTAssertTrue(didQueueWaiter)
+        XCTAssertEqual(controller.waiterTimeoutTaskCount(), 1)
+
+        blocked.cancel()
+        do {
+            _ = try await blocked.value
+            XCTFail("Expected blocked Git admission waiter to cancel")
+        } catch is CancellationError {
+            // Expected.
+        }
+
+        XCTAssertEqual(controller.waiterTimeoutTaskCount(), 0)
+        try await Task.sleep(for: .milliseconds(100))
+        XCTAssertEqual(controller.waiterCount(), 0)
+        XCTAssertEqual(controller.waiterTimeoutTaskCount(), 0)
+        XCTAssertEqual(controller.activeCount(repositoryKey: repo), 1)
+        controller.release(lease)
+        XCTAssertEqual(controller.activeCount(repositoryKey: repo), 0)
     }
 
     private func assertClass(_ expected: MCPToolAdmissionClass, tools: [String]) {


### PR DESCRIPTION
## Summary
- scope the per-repository Git tool admission gate to `git diff` artifact publication only, so ordinary `git status` and read-only `git diff` do not queue behind a stuck artifact export
- add bounded artifact admission waiter/lease watchdog handling with warnings
- raise read/control lane capacities for concurrent agent use while keeping mutation/artifact gates conservative
- add focused admission-policy tests for timeout, stale lease expiry, cancellation cleanup, watchdog cleanup, and updated capacity behavior

## Validation
- `make dev-format`
- `make dev-test FILTER=MCPToolAdmissionPolicyTests`
- duplicate focused rerun: `make dev-test FILTER=MCPToolAdmissionPolicyTests`
- `make dev-lint`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh commit`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh push`

## Review / runtime checks
- Claude Fable 5 High reviewed the Git admission fix and follow-up policy capacity change; no commit blockers.
- Relaunched CE debug app and stress-tested window 5 toy repo:
  - read-only burst: 40/40 Git MCP calls succeeded, 0 timeouts
  - mixed artifact/read burst: 42/42 Git MCP calls succeeded, 0 timeouts
  - monitor sub-agent observed no app crash/restart, no listening TCP port churn, and no memory/thread growth trend

## Notes
- Fable recommended an additional `make dev-test FILTER=MCPConnectionManager` run for the capacity tuning; it was started but canceled before acquiring the global heavy slot because another worktree held `/tmp/conductor-501/global-heavy.lock` for several minutes. The targeted admission tests and lint passed.
