### PR TITLE
Fix Context Builder teardown finalization

### DIFF
--- a/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderAgentViewModel.swift
+++ b/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderAgentViewModel.swift
@@ -464,6 +464,19 @@ final class ContextBuilderAgentViewModel: ObservableObject {
         func isRunTeardownPendingForTesting(runID: UUID) -> Bool {
             runRegistry.record(runID: runID)?.isTeardownPending == true
         }
+
+        func retireStaleRunRecordForTesting(
+            _ record: ContextBuilderRunRecord,
+            waiterResolution: ContextBuilderRunWaiterResolution = .snapshot,
+            cancelExecution: Bool = true
+        ) {
+            retireContextBuilderRunRecordWithoutPublishing(
+                record,
+                waiterResolution: waiterResolution,
+                cancelExecution: cancelExecution,
+                source: "contextBuilder.testing.staleRetirement"
+            )
+        }
     #endif
 
     // MARK: - Published session-scoped proxies
@@ -1939,9 +1952,20 @@ final class ContextBuilderAgentViewModel: ObservableObject {
         saveHistory: Bool,
         source: String
     ) -> Bool {
-        guard acceptsEvents(from: record) else { return false }
+        guard acceptsEvents(from: record) else {
+            retireContextBuilderRunRecordWithoutPublishing(
+                record,
+                waiterResolution: waiterResolution,
+                cancelExecution: cancelExecution,
+                source: source
+            )
+            return false
+        }
         flushAssistantPreview(for: record)
-        guard record.claimTerminal(outcome) else { return false }
+        guard record.claimTerminal(outcome) else {
+            scheduleRunTeardown(record, cancelExecution: cancelExecution)
+            return false
+        }
 
         let session = record.session
         session.lastAgentOutput = record.output.fullOutput()
@@ -2018,6 +2042,47 @@ final class ContextBuilderAgentViewModel: ObservableObject {
             continuation?.resume(throwing: CancellationError())
         }
         return true
+    }
+
+    /// Retires records that have lost active ownership before their terminal path runs.
+    ///
+    /// Superseded/stale records must not publish previews, mutate current tab state, or
+    /// restore run-start configuration over a newer run. They still own provider/process
+    /// resources, continuations, and possibly a registry record, so retirement must always
+    /// schedule teardown and resolve any waiter exactly once.
+    private func retireContextBuilderRunRecordWithoutPublishing(
+        _ record: ContextBuilderRunRecord,
+        waiterResolution: ContextBuilderRunWaiterResolution,
+        cancelExecution: Bool,
+        source: String
+    ) {
+        record.previewPublicationTask?.cancel()
+        record.previewPublicationTask = nil
+
+        let didClaimTerminal = record.claimTerminal(.cancelled)
+        record.session.endRunAttempt(ifCurrent: record.ownership, source: "\(source).staleRetirement")
+        if runRegistry.releaseActiveSlot(for: record) {
+            tabsWithActiveContextBuilderRun.remove(record.tabID)
+        }
+
+        let continuation = didClaimTerminal ? record.takeContinuation() : nil
+        let completion = MCPContextBuilderRunCompletion(
+            runID: record.runID,
+            tabID: record.tabID,
+            terminalDisposition: .cancelled,
+            agentOutput: record.output.fullOutput(),
+            usedAgentOutputAsPrompt: false,
+            committedTab: nil
+        )
+
+        scheduleRunTeardown(record, cancelExecution: cancelExecution)
+
+        switch waiterResolution {
+        case .snapshot:
+            continuation?.resume(returning: completion)
+        case .cancellationError:
+            continuation?.resume(throwing: CancellationError())
+        }
     }
 
     private func scheduleRunTeardown(

--- a/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderAgentViewModel.swift
+++ b/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderAgentViewModel.swift
@@ -465,6 +465,10 @@ final class ContextBuilderAgentViewModel: ObservableObject {
             runRegistry.record(runID: runID)?.isTeardownPending == true
         }
 
+        func replaceSessionForTesting(tabID: UUID) {
+            sessions[tabID] = TabSession(tabID: tabID)
+        }
+
         func retireStaleRunRecordForTesting(
             _ record: ContextBuilderRunRecord,
             waiterResolution: ContextBuilderRunWaiterResolution = .snapshot,
@@ -1473,8 +1477,10 @@ final class ContextBuilderAgentViewModel: ObservableObject {
                 session.followUpOracleSessionID = nil
             }
 
-            // 3. Logically cancel the active run without waiting for teardown.
-            if let record = runRegistry.activeRecord(tabID: tabID) {
+            // 3. Logically cancel every registered run for the tab without waiting for teardown.
+            // A superseded record may no longer own the active slot but still owns a provider,
+            // execution task, waiter, and launch-config lease that tab close must retire.
+            for record in runRegistry.records(tabID: tabID) where !record.isTerminal {
                 debugLog("handleComposeTabsWillClose: cancelling run \(record.runID) for tab \(tabID)")
                 cancelRun(
                     record,
@@ -2384,6 +2390,10 @@ final class ContextBuilderAgentViewModel: ObservableObject {
                 )
                 guard !Task.isCancelled, acceptsEvents(from: record) else { return .cancelled }
                 debugLog("Routing result for run \(runID): routed=\(routed)")
+                if routed {
+                    record.finalContextConnectionIDForDiagnostics =
+                        mcpServer.contextBuilderFinalContextConnectionID(runID: runID)
+                }
 
                 if !routed, record.origin.isMCP {
                     let timeoutSeconds = TimeInterval(ContextBuilderDefaults.mcpRoutingTimeoutMilliseconds) / 1000
@@ -2609,7 +2619,15 @@ final class ContextBuilderAgentViewModel: ObservableObject {
         waiterResolution: ContextBuilderRunWaiterResolution,
         saveHistory: Bool
     ) {
-        guard acceptsEvents(from: record) else { return }
+        guard acceptsEvents(from: record) else {
+            retireContextBuilderRunRecordWithoutPublishing(
+                record,
+                waiterResolution: waiterResolution,
+                cancelExecution: true,
+                source: "contextBuilder.cancel.staleRetirement"
+            )
+            return
+        }
         guard record.canAcceptCancellation else {
             debugLog("Cancel ignored after final context commit claim for run \(record.runID)")
             return
@@ -2794,7 +2812,10 @@ final class ContextBuilderAgentViewModel: ObservableObject {
                 }
             #endif
             return MCPServerViewModel.ContextBuilderTabContextCommitResult(
-                outcome: .missingFinalContext(runID: runID, connectionID: nil),
+                outcome: .missingFinalContext(
+                    runID: runID,
+                    connectionID: record.finalContextConnectionIDForDiagnostics
+                ),
                 committedTab: nil
             )
         }
@@ -2848,7 +2869,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
                         #endif
                         return result
                     },
-                    isAuthoritativePeerEOFDetached: {
+                    isAuthoritativeDetached: {
                         mcpServer.isDetachedContextBuilderConnection(
                             connectionID: cid,
                             runID: runID

--- a/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderRunLifecycle.swift
+++ b/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderRunLifecycle.swift
@@ -35,6 +35,7 @@ enum ContextBuilderRunWaiterResolution {
 enum ContextBuilderResponseDeliveryDrainOutcome: Equatable {
     case drained
     case peerEOFDetached
+    case detachedAfterResponseDeliveryDrained
     case failed
 
     var succeeded: Bool {
@@ -42,7 +43,7 @@ enum ContextBuilderResponseDeliveryDrainOutcome: Equatable {
     }
 
     var transportAlreadyClosed: Bool {
-        self == .peerEOFDetached
+        self == .peerEOFDetached || self == .detachedAfterResponseDeliveryDrained
     }
 }
 
@@ -51,16 +52,18 @@ enum ContextBuilderResponseDeliveryDrainResolver {
     static func resolve(
         initiallyDetached: Bool,
         awaitDrain: @MainActor () async -> Bool,
-        isAuthoritativePeerEOFDetached: @MainActor () -> Bool,
+        isAuthoritativeDetached: @MainActor () -> Bool,
         awaitTeardownPublication: @MainActor () async -> MCPServerViewModel.ContextBuilderTeardownPublicationOutcome
     ) async -> ContextBuilderResponseDeliveryDrainOutcome {
         if !initiallyDetached, await awaitDrain() { return .drained }
 
         let publication = await awaitTeardownPublication()
-        guard publication == .peerEOFDetached,
-              isAuthoritativePeerEOFDetached()
+        guard publication.completedDiscoveryCanCommit,
+              isAuthoritativeDetached()
         else { return .failed }
-        return .peerEOFDetached
+        return publication == .peerEOFDetached
+            ? .peerEOFDetached
+            : .detachedAfterResponseDeliveryDrained
     }
 }
 
@@ -272,6 +275,10 @@ final class ContextBuilderRunRegistry {
     func activeRecord(tabID: UUID) -> ContextBuilderRunRecord? {
         guard let runID = activeRunIDByTabID[tabID] else { return nil }
         return recordsByRunID[runID]
+    }
+
+    func records(tabID: UUID) -> [ContextBuilderRunRecord] {
+        recordsByRunID.values.filter { $0.tabID == tabID }
     }
 
     func acceptsEvents(from record: ContextBuilderRunRecord, currentSession: ContextBuilderAgentViewModel.TabSession?) -> Bool {

--- a/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderRunLifecycle.swift
+++ b/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderRunLifecycle.swift
@@ -54,9 +54,7 @@ enum ContextBuilderResponseDeliveryDrainResolver {
         isAuthoritativePeerEOFDetached: @MainActor () -> Bool,
         awaitTeardownPublication: @MainActor () async -> MCPServerViewModel.ContextBuilderTeardownPublicationOutcome
     ) async -> ContextBuilderResponseDeliveryDrainOutcome {
-        if initiallyDetached { return .peerEOFDetached }
-        if await awaitDrain() { return .drained }
-        if isAuthoritativePeerEOFDetached() { return .peerEOFDetached }
+        if !initiallyDetached, await awaitDrain() { return .drained }
 
         let publication = await awaitTeardownPublication()
         guard publication == .peerEOFDetached,

--- a/Sources/RepoPrompt/Infrastructure/MCP/BootstrapSocketConnectionManager.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/BootstrapSocketConnectionManager.swift
@@ -318,6 +318,10 @@ actor BootstrapSocketConnectionManager: MCPServerConnection {
         await transport.ingressSnapshot()
     }
 
+    func responseDeliverySnapshot() async -> MCPResponseDeliverySnapshot? {
+        await transport.responseDeliverySnapshot()
+    }
+
     func waitUntilResponseDeliveryDrained() async -> Bool {
         await transport.waitUntilResponseDeliveryDrained()
     }

--- a/Sources/RepoPrompt/Infrastructure/MCP/MCPConnectionManager.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/MCPConnectionManager.swift
@@ -5895,7 +5895,7 @@ actor ServerNetworkManager {
         var didDetachContextBuilderContext = false
         if let detachContextBuilderRunID {
             for state in targets {
-                didDetachContextBuilderContext = state.mcpServer.detachContextBuilderTabContextForPeerEOF(
+                didDetachContextBuilderContext = state.mcpServer.detachContextBuilderTabContextForDiscoveryTeardown(
                     connectionID: connectionID,
                     runID: detachContextBuilderRunID
                 ) || didDetachContextBuilderContext
@@ -5985,17 +5985,14 @@ actor ServerNetworkManager {
         persistAcceptedSocketTerminalRecord(connectionID: id, context: context)
 
         // Capture run ownership before any suspension or connection-dictionary cleanup.
-        // Only orderly peer EOF from a discover-run child may transfer final context ownership.
+        // A discovery child can finish successfully and then disappear through several
+        // transport shapes (server terminate, write hangup/stall, read error, TTL, etc.).
+        // Preserve its final tab context for commit whenever the connection still has
+        // authoritative discover-run ownership; cancellation/staleness is enforced later
+        // by the commit path's isStillCurrent checks.
         let cleanupRunPurpose = runPurposeByConnection[id] ?? .unknown
         let cleanupRunID = runIDByConnectionID[id]
-        let detachContextBuilderRunID: UUID? = if context.reason == MCPTransportTerminalCause.peerEOF.rawValue,
-                                                  context.initiator == .peer,
-                                                  cleanupRunPurpose == .discoverRun
-        {
-            cleanupRunID
-        } else {
-            nil
-        }
+        let detachContextBuilderRunID: UUID? = cleanupRunPurpose == .discoverRun ? cleanupRunID : nil
 
         // Always drop any lingering bootstrap reservation (commit/rollback should handle it,
         // but this is a leak safety-net for edge cases)

--- a/Sources/RepoPrompt/Infrastructure/MCP/MCPConnectionManager.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/MCPConnectionManager.swift
@@ -150,6 +150,16 @@ private actor MCPConnectionStopRace {
     }
 }
 
+struct MCPResponseDeliverySnapshot: Equatable {
+    let pendingRequestCount: Int
+    let waiterCount: Int
+    let isTerminal: Bool
+
+    var acceptedRequestsFullyResponded: Bool {
+        pendingRequestCount == 0
+    }
+}
+
 protocol MCPServerConnection: Actor {
     func start(approvalHandler: @escaping (MCP.Client.Info) async -> Bool) async throws
     func stop() async
@@ -161,6 +171,7 @@ protocol MCPServerConnection: Actor {
     func isViableForRetention() -> Bool
     func secondsSinceLastActivity() async -> TimeInterval
     func transportIngressSnapshot() async -> MCPTransportIngressSnapshot?
+    func responseDeliverySnapshot() async -> MCPResponseDeliverySnapshot?
     func waitUntilResponseDeliveryDrained() async -> Bool
     /// Whether this is a legacy filesystem-backed connection (deprecated)
     nonisolated var isFilesystemBacked: Bool { get }
@@ -185,6 +196,10 @@ protocol MCPServerConnection: Actor {
 }
 
 extension MCPServerConnection {
+    func responseDeliverySnapshot() async -> MCPResponseDeliverySnapshot? {
+        nil
+    }
+
     func waitUntilResponseDeliveryDrained() async -> Bool {
         true
     }
@@ -5872,7 +5887,8 @@ actor ServerNetworkManager {
         assignedWindowID: Int?,
         contextBuilderRunID: UUID?,
         detachContextBuilderRunID: UUID?,
-        closeContext: MCPConnectionCloseContext
+        closeContext: MCPConnectionCloseContext,
+        responseDeliverySnapshot: MCPResponseDeliverySnapshot?
     ) async -> Bool {
         let windows = WindowStatesManager.shared.allWindows
         let targets: [WindowState]
@@ -5918,9 +5934,13 @@ actor ServerNetworkManager {
                     runID: contextBuilderRunID
                 )
                 let outcome: MCPServerViewModel.ContextBuilderTeardownPublicationOutcome = if wasDetached {
-                    isOrderlyPeerEOF
-                        ? .peerEOFDetached
-                        : .detachedWithoutOrderlyPeerEOF(reason: closeContext.reason)
+                    if isOrderlyPeerEOF {
+                        .peerEOFDetached
+                    } else if responseDeliverySnapshot?.acceptedRequestsFullyResponded == true {
+                        .detachedAfterResponseDeliveryDrained(reason: closeContext.reason)
+                    } else {
+                        .detachedWithoutOrderlyPeerEOF(reason: closeContext.reason)
+                    }
                 } else {
                     .resolvedWithoutPeerEOFDetachment(reason: closeContext.reason)
                 }
@@ -6000,6 +6020,7 @@ actor ServerNetworkManager {
         let cleanupRunPurpose = runPurposeByConnection[id] ?? .unknown
         let cleanupRunID = runIDByConnectionID[id]
         let detachContextBuilderRunID: UUID? = cleanupRunPurpose == .discoverRun ? cleanupRunID : nil
+        let responseDeliverySnapshot = await connections[id]?.responseDeliverySnapshot()
 
         // Always drop any lingering bootstrap reservation (commit/rollback should handle it,
         // but this is a leak safety-net for edge cases)
@@ -6060,7 +6081,8 @@ actor ServerNetworkManager {
             assignedWindowID: assignedWindowID,
             contextBuilderRunID: cleanupRunPurpose == .discoverRun ? cleanupRunID : nil,
             detachContextBuilderRunID: detachContextBuilderRunID,
-            closeContext: context
+            closeContext: context,
+            responseDeliverySnapshot: responseDeliverySnapshot
         )
         #if DEBUG
             if cleanupRunPurpose == .discoverRun, let cleanupRunID {

--- a/Sources/RepoPrompt/Infrastructure/MCP/MCPConnectionManager.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/MCPConnectionManager.swift
@@ -5910,15 +5910,22 @@ actor ServerNetworkManager {
             )
         }
         if let contextBuilderRunID {
+            let isOrderlyPeerEOF = closeContext.reason == MCPTransportTerminalCause.peerEOF.rawValue
+                && closeContext.initiator == .peer
             for state in targets {
                 let wasDetached = state.mcpServer.isDetachedContextBuilderConnection(
                     connectionID: connectionID,
                     runID: contextBuilderRunID
                 )
-                state.mcpServer.contextBuilderTeardownPublicationCoordinator.publish(
-                    wasDetached
+                let outcome: MCPServerViewModel.ContextBuilderTeardownPublicationOutcome = if wasDetached {
+                    isOrderlyPeerEOF
                         ? .peerEOFDetached
-                        : .resolvedWithoutPeerEOFDetachment(reason: closeContext.reason),
+                        : .detachedWithoutOrderlyPeerEOF(reason: closeContext.reason)
+                } else {
+                    .resolvedWithoutPeerEOFDetachment(reason: closeContext.reason)
+                }
+                state.mcpServer.contextBuilderTeardownPublicationCoordinator.publish(
+                    outcome,
                     runID: contextBuilderRunID,
                     connectionID: connectionID
                 )

--- a/Sources/RepoPrompt/Infrastructure/MCP/UnixSocketMCPTransport.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/UnixSocketMCPTransport.swift
@@ -162,12 +162,6 @@ private final class MCPTransportIngressGate: @unchecked Sendable {
 /// Tracks request/response publication at the socket boundary so lifecycle cleanup can
 /// wait for completed writes rather than closing after a handler merely returns.
 final class MCPTransportResponseDeliveryGate: @unchecked Sendable {
-    struct Snapshot {
-        let pendingRequestCount: Int
-        let waiterCount: Int
-        let isTerminal: Bool
-    }
-
     private let lock = NSLock()
     private var pendingRequestIDs: Set<JSONRPCBridgeID> = []
     private var waiters: [CheckedContinuation<Bool, Never>] = []
@@ -268,10 +262,10 @@ final class MCPTransportResponseDeliveryGate: @unchecked Sendable {
         continuations.forEach { $0.resume(returning: false) }
     }
 
-    func snapshot() -> Snapshot {
+    func snapshot() -> MCPResponseDeliverySnapshot {
         lock.lock()
         defer { lock.unlock() }
-        return Snapshot(
+        return MCPResponseDeliverySnapshot(
             pendingRequestCount: pendingRequestIDs.count,
             waiterCount: waiters.count,
             isTerminal: isTerminal
@@ -735,6 +729,10 @@ public actor UnixSocketMCPTransport: Transport {
     public func secondsSinceLastActivity() -> TimeInterval? {
         guard let lastActivityTime else { return nil }
         return Date().timeIntervalSince(lastActivityTime)
+    }
+
+    func responseDeliverySnapshot() async -> MCPResponseDeliverySnapshot {
+        responseDeliveryGate.snapshot()
     }
 
     func waitUntilResponseDeliveryDrained() async -> Bool {

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+TabContext.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+TabContext.swift
@@ -4011,7 +4011,7 @@ extension MCPServerViewModel {
 
     @MainActor
     @discardableResult
-    func detachContextBuilderTabContextForPeerEOF(
+    func detachContextBuilderTabContextForDiscoveryTeardown(
         connectionID: UUID,
         runID: UUID
     ) -> Bool {
@@ -4036,7 +4036,7 @@ extension MCPServerViewModel {
         connectionIDByRunID.removeValue(forKey: runID)
         pendingPolicyRunIDMappingTokenIDByRunID.removeValue(forKey: runID)
         connectionIDToRunID.removeValue(forKey: connectionID)
-        tabContextLog("Detached Context Builder context after peer EOF connectionID=\(connectionID) runID=\(runID)")
+        tabContextLog("Detached Context Builder context for discovery teardown connectionID=\(connectionID) runID=\(runID)")
         return true
     }
 

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+TabContext.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+TabContext.swift
@@ -45,15 +45,27 @@ extension MCPServerViewModel {
 
     enum ContextBuilderTeardownPublicationOutcome: Equatable {
         case peerEOFDetached
+        case detachedAfterResponseDeliveryDrained(reason: String)
         case detachedWithoutOrderlyPeerEOF(reason: String)
         case resolvedWithoutPeerEOFDetachment(reason: String)
         case timedOut
         case cancelled
 
+        var completedDiscoveryCanCommit: Bool {
+            switch self {
+            case .peerEOFDetached, .detachedAfterResponseDeliveryDrained:
+                true
+            case .detachedWithoutOrderlyPeerEOF, .resolvedWithoutPeerEOFDetachment, .timedOut, .cancelled:
+                false
+            }
+        }
+
         var diagnosticSource: String {
             switch self {
             case .peerEOFDetached:
                 "peer_eof_detached"
+            case let .detachedAfterResponseDeliveryDrained(reason):
+                "detached_after_response_delivery_drained:\(reason)"
             case let .detachedWithoutOrderlyPeerEOF(reason):
                 "detached_without_orderly_peer_eof:\(reason)"
             case let .resolvedWithoutPeerEOFDetachment(reason):

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+TabContext.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+TabContext.swift
@@ -45,6 +45,7 @@ extension MCPServerViewModel {
 
     enum ContextBuilderTeardownPublicationOutcome: Equatable {
         case peerEOFDetached
+        case detachedWithoutOrderlyPeerEOF(reason: String)
         case resolvedWithoutPeerEOFDetachment(reason: String)
         case timedOut
         case cancelled
@@ -53,6 +54,8 @@ extension MCPServerViewModel {
             switch self {
             case .peerEOFDetached:
                 "peer_eof_detached"
+            case let .detachedWithoutOrderlyPeerEOF(reason):
+                "detached_without_orderly_peer_eof:\(reason)"
             case let .resolvedWithoutPeerEOFDetachment(reason):
                 "resolved_without_detachment:\(reason)"
             case .timedOut:

--- a/Tests/RepoPromptTests/ContextBuilder/ContextBuilderRunLifecycleTests.swift
+++ b/Tests/RepoPromptTests/ContextBuilder/ContextBuilderRunLifecycleTests.swift
@@ -608,6 +608,88 @@ final class ContextBuilderRunLifecycleTests: XCTestCase {
                 )
             )
 
+            func seedDiscoveryConnection(
+                connectionID: UUID,
+                runID: UUID,
+                purpose: MCPRunPurpose,
+                prompt: String? = nil,
+                authoritative: Bool = true
+            ) async throws {
+                try window.mcpServer.bindTabForConnection(
+                    connectionID: connectionID,
+                    clientName: clientName,
+                    tabID: tabID,
+                    workspaceID: activeWorkspace.id,
+                    windowID: window.windowID,
+                    runID: runID
+                )
+                if let prompt {
+                    var context = try XCTUnwrap(window.mcpServer.tabContextByConnectionID[connectionID])
+                    context.promptText = prompt
+                    window.mcpServer.tabContextByConnectionID[connectionID] = context
+                }
+                await ServerNetworkManager.shared.debugRegisterConnectionForSocketFixture(
+                    connectionID: connectionID,
+                    connection: ContextBuilderCleanupTestConnection(),
+                    clientName: clientName,
+                    sessionToken: UUID().uuidString
+                )
+                await ServerNetworkManager.shared.debugSeedConnectionRunRouting(
+                    connectionID: connectionID,
+                    runID: runID,
+                    purpose: purpose,
+                    windowID: window.windowID
+                )
+                if !authoritative {
+                    window.mcpServer.connectionIDByRunID[runID] = UUID()
+                }
+            }
+
+            func assertDiscoveryCloseDetachesAndCommits(
+                closeContext: MCPConnectionCloseContext,
+                prompt: String
+            ) async throws {
+                let detachedConnectionID = UUID()
+                let detachedRunID = UUID()
+                try await seedDiscoveryConnection(
+                    connectionID: detachedConnectionID,
+                    runID: detachedRunID,
+                    purpose: .discoverRun,
+                    prompt: prompt
+                )
+
+                await ServerNetworkManager.shared.removeConnection(
+                    detachedConnectionID,
+                    context: closeContext
+                )
+
+                XCTAssertNil(window.mcpServer.tabContextByConnectionID[detachedConnectionID])
+                XCTAssertTrue(
+                    window.mcpServer.isDetachedContextBuilderConnection(
+                        connectionID: detachedConnectionID,
+                        runID: detachedRunID
+                    )
+                )
+                XCTAssertEqual(
+                    window.mcpServer.contextBuilderFinalContextConnectionID(runID: detachedRunID),
+                    detachedConnectionID
+                )
+                let commitOutcome = await window.mcpServer.commitContextBuilderTabContext(
+                    connectionID: detachedConnectionID,
+                    expectedRunID: detachedRunID,
+                    isStillCurrent: { true }
+                )
+                XCTAssertEqual(commitOutcome.outcome, .committed)
+                XCTAssertEqual(commitOutcome.committedTab?.nestedRunID, detachedRunID)
+                XCTAssertEqual(commitOutcome.committedTab?.tab.promptText, prompt)
+                XCTAssertFalse(
+                    window.mcpServer.isDetachedContextBuilderConnection(
+                        connectionID: detachedConnectionID,
+                        runID: detachedRunID
+                    )
+                )
+            }
+
             func assertDoesNotDetach(
                 closeContext: MCPConnectionCloseContext,
                 purpose: MCPRunPurpose,
@@ -615,29 +697,12 @@ final class ContextBuilderRunLifecycleTests: XCTestCase {
             ) async throws {
                 let excludedConnectionID = UUID()
                 let excludedRunID = UUID()
-                try window.mcpServer.bindTabForConnection(
-                    connectionID: excludedConnectionID,
-                    clientName: clientName,
-                    tabID: tabID,
-                    workspaceID: activeWorkspace.id,
-                    windowID: window.windowID,
-                    runID: excludedRunID
-                )
-                await ServerNetworkManager.shared.debugRegisterConnectionForSocketFixture(
-                    connectionID: excludedConnectionID,
-                    connection: ContextBuilderCleanupTestConnection(),
-                    clientName: clientName,
-                    sessionToken: UUID().uuidString
-                )
-                await ServerNetworkManager.shared.debugSeedConnectionRunRouting(
+                try await seedDiscoveryConnection(
                     connectionID: excludedConnectionID,
                     runID: excludedRunID,
                     purpose: purpose,
-                    windowID: window.windowID
+                    authoritative: authoritative
                 )
-                if !authoritative {
-                    window.mcpServer.connectionIDByRunID[excludedRunID] = UUID()
-                }
 
                 await ServerNetworkManager.shared.removeConnection(
                     excludedConnectionID,
@@ -672,26 +737,40 @@ final class ContextBuilderRunLifecycleTests: XCTestCase {
                 )
             }
 
-            try await assertDoesNotDetach(
+            try await assertDiscoveryCloseDetachesAndCommits(
                 closeContext: MCPConnectionCloseContext(
                     reason: "server_shutdown",
                     initiator: .app
                 ),
-                purpose: .discoverRun
+                prompt: "context retained after app/server shutdown"
             )
-            try await assertDoesNotDetach(
+            try await assertDiscoveryCloseDetachesAndCommits(
                 closeContext: MCPConnectionCloseContext(
                     reason: TerminationReason.runCancelled.rawValue,
                     initiator: .app
                 ),
-                purpose: .discoverRun
+                prompt: "context retained after app cancellation close"
             )
-            try await assertDoesNotDetach(
+            try await assertDiscoveryCloseDetachesAndCommits(
                 closeContext: MCPConnectionCloseContext(
                     reason: MCPTransportTerminalCause.readError.rawValue,
                     initiator: .peer
                 ),
-                purpose: .discoverRun
+                prompt: "context retained after read error"
+            )
+            try await assertDiscoveryCloseDetachesAndCommits(
+                closeContext: MCPConnectionCloseContext(
+                    reason: MCPTransportTerminalCause.writeHangup.rawValue,
+                    initiator: .app
+                ),
+                prompt: "context retained after write hangup"
+            )
+            try await assertDiscoveryCloseDetachesAndCommits(
+                closeContext: MCPConnectionCloseContext(
+                    reason: MCPTransportTerminalCause.writeStall.rawValue,
+                    initiator: .app
+                ),
+                prompt: "context retained after write stall"
             )
             try await assertDoesNotDetach(
                 closeContext: MCPConnectionCloseContext(
@@ -794,6 +873,80 @@ final class ContextBuilderRunLifecycleTests: XCTestCase {
         XCTAssertFalse(first.isTeardownPending)
         XCTAssertTrue(registry.removeAfterTeardown(first))
         XCTAssertTrue(registry.acceptsEvents(from: second, currentSession: session))
+    }
+
+    func testStaleRunRetirementStillDisposesProviderAndCancelsExecution() async throws {
+        #if DEBUG
+            let previousMCPAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
+            GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
+            let composition = WindowStateCompositionFactory.make(
+                windowID: -176,
+                deferredInitialAgentSystemWorkspaceRefresh: true,
+                sharedMCPService: MCPService()
+            )
+            GlobalSettingsStore.shared.setMCPAutoStart(previousMCPAutoStart, commit: false)
+            await composition.workspaceManager.awaitInitialized()
+            defer {
+                Task {
+                    await composition.mcpServer.stopServer()
+                    await composition.mcpServer.shutdownListener()
+                }
+            }
+
+            let tabID = UUID()
+            let session = ContextBuilderAgentViewModel.TabSession(tabID: tabID)
+            let ownership = session.beginRunAttempt(source: "stale-retirement-test")
+            let record = ContextBuilderRunRecord(
+                runID: UUID(),
+                tabID: tabID,
+                session: session,
+                ownership: ownership,
+                origin: .mcp(controlToken: UUID()),
+                agentKind: .claudeCode,
+                modelRaw: AgentModel.defaultModel.rawValue
+            )
+            let providerDisposeFinished = expectation(description: "stale provider disposed")
+            let provider = ControllableLifecycleTestProvider(
+                eventTexts: [],
+                blocksDisposal: false,
+                disposeFinishedExpectation: providerDisposeFinished
+            )
+            XCTAssertTrue(record.installProvider(provider))
+
+            let executionCancelled = LifecycleTestGate()
+            let executionTask = Task<Void, Never> {
+                await withTaskCancellationHandler {
+                    while !Task.isCancelled {
+                        try? await Task.sleep(for: .milliseconds(10))
+                    }
+                } onCancel: {
+                    Task { await executionCancelled.arrive() }
+                }
+            }
+            record.executionTask = executionTask
+
+            composition.contextBuilderAgentViewModel.retireStaleRunRecordForTesting(
+                record,
+                waiterResolution: .snapshot,
+                cancelExecution: true
+            )
+
+            await executionCancelled.waitUntilArrived()
+            await executionTask.value
+            await fulfillment(of: [providerDisposeFinished], timeout: 1)
+            for _ in 0 ..< 100 where record.teardownFinishedAt == nil {
+                await Task.yield()
+            }
+
+            let disposeCallCount = await provider.disposeCallCount()
+            XCTAssertEqual(disposeCallCount, 1)
+            XCTAssertTrue(record.providerDisposalFinished)
+            XCTAssertTrue(record.executionTaskFinished)
+            XCTAssertNotNil(record.teardownFinishedAt)
+            XCTAssertTrue(record.isTerminal)
+        #else
+            throw XCTSkip("Stale run retirement test uses DEBUG-only test hook.")
+        #endif
     }
 
     func testProductionMCPCancellationResumesBeforeTeardownAndRejectsLateProviderEvent() async throws {

--- a/Tests/RepoPromptTests/ContextBuilder/ContextBuilderRunLifecycleTests.swift
+++ b/Tests/RepoPromptTests/ContextBuilder/ContextBuilderRunLifecycleTests.swift
@@ -288,6 +288,41 @@ final class ContextBuilderRunLifecycleTests: XCTestCase {
         XCTAssertTrue(didAwaitNegativeTeardownResolution)
         XCTAssertEqual(liveDrainFailure, .failed)
         XCTAssertFalse(liveDrainFailure.succeeded)
+
+        var didAttemptInitialDrain = false
+        let initiallyDetachedPeerEOF = await ContextBuilderResponseDeliveryDrainResolver.resolve(
+            initiallyDetached: true,
+            awaitDrain: {
+                didAttemptInitialDrain = true
+                return false
+            },
+            isAuthoritativePeerEOFDetached: { true },
+            awaitTeardownPublication: { .peerEOFDetached }
+        )
+        XCTAssertFalse(didAttemptInitialDrain)
+        XCTAssertEqual(initiallyDetachedPeerEOF, .peerEOFDetached)
+        XCTAssertTrue(initiallyDetachedPeerEOF.succeeded)
+
+        let initiallyDetachedFailure = await ContextBuilderResponseDeliveryDrainResolver.resolve(
+            initiallyDetached: true,
+            awaitDrain: {
+                XCTFail("Already-detached contexts must resolve from the teardown publication")
+                return true
+            },
+            isAuthoritativePeerEOFDetached: { true },
+            awaitTeardownPublication: { .detachedWithoutOrderlyPeerEOF(reason: "read_error") }
+        )
+        XCTAssertEqual(initiallyDetachedFailure, .failed)
+        XCTAssertFalse(initiallyDetachedFailure.succeeded)
+
+        let failureDetachedDuringDrain = await ContextBuilderResponseDeliveryDrainResolver.resolve(
+            initiallyDetached: false,
+            awaitDrain: { false },
+            isAuthoritativePeerEOFDetached: { true },
+            awaitTeardownPublication: { .detachedWithoutOrderlyPeerEOF(reason: "write_hangup") }
+        )
+        XCTAssertEqual(failureDetachedDuringDrain, .failed)
+        XCTAssertFalse(failureDetachedDuringDrain.succeeded)
     }
 
     func testRealConnectionCleanupCannotEraseContextBeforeCommit() async throws {
@@ -553,6 +588,107 @@ final class ContextBuilderRunLifecycleTests: XCTestCase {
             )
             let transitioningConnectionTerminationCount = await transitioningConnection.terminationCount()
             XCTAssertEqual(transitioningConnectionTerminationCount, 0)
+
+            // Non-orderly transport failures still detach the final context so a later
+            // safe path can inspect/discard it, but they must not satisfy response drain
+            // or commit partial context through the successful finalization path.
+            let failureConnectionID = UUID()
+            let failureRunID = UUID()
+            let failurePrompt = "must not auto-commit after read error"
+            try window.mcpServer.bindTabForConnection(
+                connectionID: failureConnectionID,
+                clientName: clientName,
+                tabID: tabID,
+                workspaceID: activeWorkspace.id,
+                windowID: window.windowID,
+                runID: failureRunID
+            )
+            var failureContext = try XCTUnwrap(window.mcpServer.tabContextByConnectionID[failureConnectionID])
+            failureContext.promptText = failurePrompt
+            window.mcpServer.tabContextByConnectionID[failureConnectionID] = failureContext
+            await ServerNetworkManager.shared.debugRegisterConnectionForSocketFixture(
+                connectionID: failureConnectionID,
+                connection: ContextBuilderCleanupTestConnection(),
+                clientName: clientName,
+                sessionToken: UUID().uuidString
+            )
+            await ServerNetworkManager.shared.debugSeedConnectionRunRouting(
+                connectionID: failureConnectionID,
+                runID: failureRunID,
+                purpose: .discoverRun,
+                windowID: window.windowID
+            )
+
+            let failureWaitStarted = LifecycleTestGate()
+            var failureDrainOutcome: ContextBuilderResponseDeliveryDrainOutcome = .drained
+            var failureCommitCount = 0
+            var failureTerminationCount = 0
+            let failureFinalization = Task { @MainActor in
+                await ContextBuilderChildConnectionFinalizer.finalize(
+                    connectionIDs: [failureConnectionID],
+                    awaitResponseDeliveryDrain: { drainedID in
+                        failureDrainOutcome = await ContextBuilderResponseDeliveryDrainResolver.resolve(
+                            initiallyDetached: false,
+                            awaitDrain: {
+                                XCTAssertEqual(drainedID, failureConnectionID)
+                                return false
+                            },
+                            isAuthoritativePeerEOFDetached: {
+                                window.mcpServer.isDetachedContextBuilderConnection(
+                                    connectionID: drainedID,
+                                    runID: failureRunID
+                                )
+                            },
+                            awaitTeardownPublication: {
+                                await failureWaitStarted.arrive()
+                                return await window.mcpServer.contextBuilderTeardownPublicationCoordinator.wait(
+                                    runID: failureRunID,
+                                    connectionID: drainedID,
+                                    timeoutSeconds: 1
+                                )
+                            }
+                        )
+                        return failureDrainOutcome.succeeded
+                    },
+                    commitContext: { _ in
+                        failureCommitCount += 1
+                        return true
+                    },
+                    beforeTerminationRequest: {},
+                    requestTermination: { _ in
+                        failureTerminationCount += 1
+                        return Task {}
+                    },
+                    beforeTerminationJoin: {},
+                    cleanupMapping: { _ in }
+                )
+            }
+
+            await failureWaitStarted.waitUntilArrived()
+            await ServerNetworkManager.shared.removeConnection(
+                failureConnectionID,
+                context: MCPConnectionCloseContext(
+                    reason: MCPTransportTerminalCause.readError.rawValue,
+                    initiator: .peer
+                )
+            )
+            let didFinalizeFailure = await failureFinalization.value
+            XCTAssertFalse(didFinalizeFailure)
+            XCTAssertEqual(failureDrainOutcome, .failed)
+            XCTAssertEqual(failureCommitCount, 0)
+            XCTAssertEqual(failureTerminationCount, 0)
+            XCTAssertTrue(
+                window.mcpServer.isDetachedContextBuilderConnection(
+                    connectionID: failureConnectionID,
+                    runID: failureRunID
+                )
+            )
+            XCTAssertEqual(
+                window.mcpServer.contextBuilderFinalContextConnectionID(runID: failureRunID),
+                failureConnectionID
+            )
+            XCTAssertEqual(window.workspaceManager.composeTab(with: tabID)?.promptText, transitioningPrompt)
+            window.mcpServer.discardDetachedContextBuilderTabContext(runID: failureRunID)
 
             // The negative twin uses the same production peer-EOF teardown, then models
             // explicit cancellation before commit. Detached ownership is discarded and

--- a/Tests/RepoPromptTests/ContextBuilder/ContextBuilderRunLifecycleTests.swift
+++ b/Tests/RepoPromptTests/ContextBuilder/ContextBuilderRunLifecycleTests.swift
@@ -279,7 +279,7 @@ final class ContextBuilderRunLifecycleTests: XCTestCase {
         let liveDrainFailure = await ContextBuilderResponseDeliveryDrainResolver.resolve(
             initiallyDetached: false,
             awaitDrain: { false },
-            isAuthoritativePeerEOFDetached: { false },
+            isAuthoritativeDetached: { false },
             awaitTeardownPublication: {
                 didAwaitNegativeTeardownResolution = true
                 return .resolvedWithoutPeerEOFDetachment(reason: "read_error")
@@ -296,12 +296,27 @@ final class ContextBuilderRunLifecycleTests: XCTestCase {
                 didAttemptInitialDrain = true
                 return false
             },
-            isAuthoritativePeerEOFDetached: { true },
+            isAuthoritativeDetached: { true },
             awaitTeardownPublication: { .peerEOFDetached }
         )
         XCTAssertFalse(didAttemptInitialDrain)
         XCTAssertEqual(initiallyDetachedPeerEOF, .peerEOFDetached)
         XCTAssertTrue(initiallyDetachedPeerEOF.succeeded)
+
+        let initiallyDetachedAfterDrainedClose = await ContextBuilderResponseDeliveryDrainResolver.resolve(
+            initiallyDetached: true,
+            awaitDrain: {
+                XCTFail("Already-detached contexts must resolve from the teardown publication")
+                return false
+            },
+            isAuthoritativeDetached: { true },
+            awaitTeardownPublication: {
+                .detachedAfterResponseDeliveryDrained(reason: "read_error")
+            }
+        )
+        XCTAssertEqual(initiallyDetachedAfterDrainedClose, .detachedAfterResponseDeliveryDrained)
+        XCTAssertTrue(initiallyDetachedAfterDrainedClose.succeeded)
+        XCTAssertTrue(initiallyDetachedAfterDrainedClose.transportAlreadyClosed)
 
         let initiallyDetachedFailure = await ContextBuilderResponseDeliveryDrainResolver.resolve(
             initiallyDetached: true,
@@ -309,7 +324,7 @@ final class ContextBuilderRunLifecycleTests: XCTestCase {
                 XCTFail("Already-detached contexts must resolve from the teardown publication")
                 return true
             },
-            isAuthoritativePeerEOFDetached: { true },
+            isAuthoritativeDetached: { true },
             awaitTeardownPublication: { .detachedWithoutOrderlyPeerEOF(reason: "read_error") }
         )
         XCTAssertEqual(initiallyDetachedFailure, .failed)
@@ -318,7 +333,7 @@ final class ContextBuilderRunLifecycleTests: XCTestCase {
         let failureDetachedDuringDrain = await ContextBuilderResponseDeliveryDrainResolver.resolve(
             initiallyDetached: false,
             awaitDrain: { false },
-            isAuthoritativePeerEOFDetached: { true },
+            isAuthoritativeDetached: { true },
             awaitTeardownPublication: { .detachedWithoutOrderlyPeerEOF(reason: "write_hangup") }
         )
         XCTAssertEqual(failureDetachedDuringDrain, .failed)
@@ -436,9 +451,9 @@ final class ContextBuilderRunLifecycleTests: XCTestCase {
                 .missingFinalContext(runID: runID, connectionID: connectionID)
             )
 
-            // Begin finalization while the connection is live, then complete peer-EOF
-            // teardown while response delivery is draining. The failed drain is accepted
-            // only after the same authoritative context has been detached.
+            // Begin finalization while the connection is live, then complete a non-orderly
+            // teardown after every accepted request has a delivered response. The failed live
+            // drain is accepted only from the retained close-time delivery snapshot.
             let transitioningConnectionID = UUID()
             let transitioningRunID = UUID()
             let transitioningPrompt = "context detached during response drain"
@@ -456,7 +471,7 @@ final class ContextBuilderRunLifecycleTests: XCTestCase {
             transitioningContext.promptText = transitioningPrompt
             window.mcpServer.tabContextByConnectionID[transitioningConnectionID] = transitioningContext
 
-            let transitioningConnection = ContextBuilderCleanupTestConnection()
+            let transitioningConnection = ContextBuilderCleanupTestConnection(pendingRequestCount: 0)
             await ServerNetworkManager.shared.debugRegisterConnectionForSocketFixture(
                 connectionID: transitioningConnectionID,
                 connection: transitioningConnection,
@@ -485,7 +500,7 @@ final class ContextBuilderRunLifecycleTests: XCTestCase {
                                 XCTAssertEqual(drainedID, transitioningConnectionID)
                                 return false
                             },
-                            isAuthoritativePeerEOFDetached: {
+                            isAuthoritativeDetached: {
                                 window.mcpServer.isDetachedContextBuilderConnection(
                                     connectionID: drainedID,
                                     runID: transitioningRunID
@@ -549,7 +564,7 @@ final class ContextBuilderRunLifecycleTests: XCTestCase {
             await ServerNetworkManager.shared.removeConnection(
                 transitioningConnectionID,
                 context: MCPConnectionCloseContext(
-                    reason: MCPTransportTerminalCause.peerEOF.rawValue,
+                    reason: MCPTransportTerminalCause.readError.rawValue,
                     initiator: .peer
                 )
             )
@@ -564,7 +579,7 @@ final class ContextBuilderRunLifecycleTests: XCTestCase {
 
             let didFinalizeTransition = await transitioningFinalization.value
             XCTAssertTrue(didFinalizeTransition)
-            XCTAssertEqual(transitioningDrainOutcome, .peerEOFDetached)
+            XCTAssertEqual(transitioningDrainOutcome, .detachedAfterResponseDeliveryDrained)
             XCTAssertEqual(transitioningCommitCount, 1)
             XCTAssertEqual(transitioningTerminationCount, 0)
             XCTAssertEqual(window.workspaceManager.composeTab(with: tabID)?.promptText, transitioningPrompt)
@@ -589,9 +604,9 @@ final class ContextBuilderRunLifecycleTests: XCTestCase {
             let transitioningConnectionTerminationCount = await transitioningConnection.terminationCount()
             XCTAssertEqual(transitioningConnectionTerminationCount, 0)
 
-            // Non-orderly transport failures still detach the final context so a later
-            // safe path can inspect/discard it, but they must not satisfy response drain
-            // or commit partial context through the successful finalization path.
+            // Non-orderly transport failures with an accepted response still pending detach
+            // the final context so a later safe path can inspect/discard it, but they must not
+            // satisfy response drain or commit partial context through successful finalization.
             let failureConnectionID = UUID()
             let failureRunID = UUID()
             let failurePrompt = "must not auto-commit after read error"
@@ -608,7 +623,7 @@ final class ContextBuilderRunLifecycleTests: XCTestCase {
             window.mcpServer.tabContextByConnectionID[failureConnectionID] = failureContext
             await ServerNetworkManager.shared.debugRegisterConnectionForSocketFixture(
                 connectionID: failureConnectionID,
-                connection: ContextBuilderCleanupTestConnection(),
+                connection: ContextBuilderCleanupTestConnection(pendingRequestCount: 1),
                 clientName: clientName,
                 sessionToken: UUID().uuidString
             )
@@ -633,7 +648,7 @@ final class ContextBuilderRunLifecycleTests: XCTestCase {
                                 XCTAssertEqual(drainedID, failureConnectionID)
                                 return false
                             },
-                            isAuthoritativePeerEOFDetached: {
+                            isAuthoritativeDetached: {
                                 window.mcpServer.isDetachedContextBuilderConnection(
                                     connectionID: drainedID,
                                     runID: failureRunID
@@ -1086,6 +1101,18 @@ final class ContextBuilderRunLifecycleTests: XCTestCase {
     }
 
     func testProductionMCPCancellationResumesBeforeTeardownAndRejectsLateProviderEvent() async throws {
+        let configRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ContextBuilderStaleRunLeaseTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: configRoot, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: configRoot) }
+        let configService = MCPConfigExportService(
+            configDirectoryURL: configRoot,
+            renderServerConfig: { "{\"mcpServers\":{}}" }
+        )
+        let firstConfigLease = try await configService.prepareLaunchConfig()
+        let firstConfigURL = firstConfigLease.url
+        XCTAssertTrue(FileManager.default.fileExists(atPath: firstConfigURL.path))
+
         let firstStreamStarted = expectation(description: "first provider stream started")
         let firstEventAccepted = expectation(description: "first provider event accepted")
         let firstDisposeStarted = expectation(description: "first provider disposal started")
@@ -1100,7 +1127,8 @@ final class ContextBuilderRunLifecycleTests: XCTestCase {
             blocksDisposal: true,
             streamStartedExpectation: firstStreamStarted,
             disposeStartedExpectation: firstDisposeStarted,
-            disposeFinishedExpectation: firstDisposeFinished
+            disposeFinishedExpectation: firstDisposeFinished,
+            configLease: firstConfigLease
         )
         let successorProvider = ControllableLifecycleTestProvider(
             eventTexts: ["successor-event"],
@@ -1219,8 +1247,13 @@ final class ContextBuilderRunLifecycleTests: XCTestCase {
             )
             firstRunID = try XCTUnwrap(viewModel.activeRunIDForTesting(tabID: tabID))
 
+            // Replace the tab session to model a superseding owner while the original
+            // provider stream remains parked. Cancellation by run ID must eagerly retire
+            // the registered stale record instead of waiting for another provider event.
+            viewModel.replaceSessionForTesting(tabID: tabID)
             try await viewModel.cancelMCPContextBuilderRun(runID: XCTUnwrap(firstRunID))
             await fulfillment(of: [firstWaiterFinished, firstDisposeStarted], timeout: 1)
+            XCTAssertFalse(FileManager.default.fileExists(atPath: firstConfigURL.path))
 
             let firstWaiterWasCancelled = await firstWaiter.value
             let firstCompletionCount = await firstWaiterCompletion.value()
@@ -1646,6 +1679,7 @@ private final class ControllableLifecycleTestProvider: HeadlessAgentProvider {
     private let streamStartedExpectation: XCTestExpectation?
     private let disposeStartedExpectation: XCTestExpectation?
     private let disposeFinishedExpectation: XCTestExpectation?
+    private let configLease: MCPConfigLease?
     private let disposeGate = LifecycleTestGate()
     private let state = LifecycleTestProviderState()
     private var streamContinuation: AsyncThrowingStream<AIStreamResult, Error>.Continuation?
@@ -1655,13 +1689,15 @@ private final class ControllableLifecycleTestProvider: HeadlessAgentProvider {
         blocksDisposal: Bool,
         streamStartedExpectation: XCTestExpectation? = nil,
         disposeStartedExpectation: XCTestExpectation? = nil,
-        disposeFinishedExpectation: XCTestExpectation? = nil
+        disposeFinishedExpectation: XCTestExpectation? = nil,
+        configLease: MCPConfigLease? = nil
     ) {
         self.eventTexts = eventTexts
         self.blocksDisposal = blocksDisposal
         self.streamStartedExpectation = streamStartedExpectation
         self.disposeStartedExpectation = disposeStartedExpectation
         self.disposeFinishedExpectation = disposeFinishedExpectation
+        self.configLease = configLease
     }
 
     func streamAgentMessage(
@@ -1685,6 +1721,7 @@ private final class ControllableLifecycleTestProvider: HeadlessAgentProvider {
 
     func dispose() async {
         await state.recordDisposeCall()
+        configLease?.release()
         disposeStartedExpectation?.fulfill()
         if blocksDisposal {
             await disposeGate.arriveAndWait()
@@ -1991,6 +2028,17 @@ private actor CodexShapedBlockedRoutingTestState {
 private actor ContextBuilderCleanupTestConnection: MCPServerConnection {
     private var terminations = 0
     private var stops = 0
+    private let deliverySnapshot: MCPResponseDeliverySnapshot?
+
+    init(pendingRequestCount: Int? = nil) {
+        deliverySnapshot = pendingRequestCount.map {
+            MCPResponseDeliverySnapshot(
+                pendingRequestCount: $0,
+                waiterCount: 0,
+                isTerminal: true
+            )
+        }
+    }
 
     nonisolated var isFilesystemBacked: Bool {
         false
@@ -2034,6 +2082,10 @@ private actor ContextBuilderCleanupTestConnection: MCPServerConnection {
 
     func transportIngressSnapshot() async -> MCPTransportIngressSnapshot? {
         nil
+    }
+
+    func responseDeliverySnapshot() async -> MCPResponseDeliverySnapshot? {
+        deliverySnapshot
     }
 
     func terminate(reason _: TerminationReason, message _: String?) async {


### PR DESCRIPTION
## Summary

Fixes #444.

- Preserve Context Builder final context for every discovery-run teardown path, not just orderly peer EOF.
- Ensure stale/superseded Context Builder run records still retire safely, cancel pending publication, resolve continuations, release active ownership when appropriate, and dispose the provider/lease via teardown.
- Add regression coverage for non-orderly discovery-child close causes and stale run retirement/provider disposal.

## Validation

- `make dev-test FILTER=ContextBuilderRunLifecycleTests` — passed 11 tests, 0 failures (conductor client later timed out, direct job log showed the suite passed)
- `make format-check` — passed
- `swiftlint lint --strict` — passed
- `git diff --check` — passed
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh commit` — passed before commit
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh push` — passed before push

## Notes

I did not run the full `pr-ready` lane; focused lifecycle tests and Swift style checks covered the changed boundary for this fix.
