### PR TITLE
Increase MCP admission limits for multi-agent workflows

### DIFF
--- a/Sources/RepoPrompt/Infrastructure/MCP/Policies/MCPToolAdmissionPolicy.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/Policies/MCPToolAdmissionPolicy.swift
@@ -26,15 +26,14 @@ enum MCPToolAdmissionClass: String, CaseIterable {
 }
 
 enum MCPToolAdmissionPolicy {
-    /// Gate B selected the conservative lower bounds from the WI-3 baseline:
-    /// two small reads per connection and per window/store, two Git requests per connection
-    /// with a separate one-per-repository request gate, and the unchanged PR #155 four-search burst.
+    /// Modernized multi-agent defaults: keep mutation/artifact gates conservative while
+    /// giving read/control lanes enough capacity for several active agents in one window.
     static let exclusiveConnectionLimit = 1
-    static let controlConnectionLimit = 8
-    static let smallReadConnectionLimit = 2
-    static let smallReadPerWindowLimit = 2
-    static let gitReadConnectionLimit = 2
-    static let fileSearchConnectionLimit = 4
+    static let controlConnectionLimit = 16
+    static let smallReadConnectionLimit = 6
+    static let smallReadPerWindowLimit = 8
+    static let gitReadConnectionLimit = 4
+    static let fileSearchConnectionLimit = 6
     static let gitReadPerRepositoryLimit = 1
 
     /// Exhaustive canonical-tool table. Do not add a default: every advertised tool must be

--- a/Tests/RepoPromptTests/MCP/Control/MCPToolAdmissionPolicyTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/MCPToolAdmissionPolicyTests.swift
@@ -55,18 +55,18 @@ final class MCPToolAdmissionPolicyTests: XCTestCase {
         XCTAssertEqual(ServerNetworkManager.admissionClass(forCanonicalToolName: alias), .exclusive)
     }
 
-    func testGateBCapacitiesRecordConservativeWI3BaselineChoices() {
+    func testCapacitiesRecordModernMultiAgentDefaults() {
         XCTAssertEqual(MCPToolAdmissionPolicy.exclusiveConnectionLimit, 1)
-        XCTAssertEqual(MCPToolAdmissionPolicy.controlConnectionLimit, 8)
-        XCTAssertEqual(MCPToolAdmissionPolicy.smallReadConnectionLimit, 2)
-        XCTAssertEqual(MCPToolAdmissionPolicy.smallReadPerWindowLimit, 2)
-        XCTAssertEqual(MCPToolAdmissionPolicy.gitReadConnectionLimit, 2)
+        XCTAssertEqual(MCPToolAdmissionPolicy.controlConnectionLimit, 16)
+        XCTAssertEqual(MCPToolAdmissionPolicy.smallReadConnectionLimit, 6)
+        XCTAssertEqual(MCPToolAdmissionPolicy.smallReadPerWindowLimit, 8)
+        XCTAssertEqual(MCPToolAdmissionPolicy.gitReadConnectionLimit, 4)
         XCTAssertEqual(MCPToolAdmissionPolicy.gitReadPerRepositoryLimit, 1)
-        XCTAssertEqual(MCPToolAdmissionPolicy.fileSearchConnectionLimit, 4)
-        XCTAssertEqual(ServerNetworkManager.smallReadCallLaneLimit, 2)
-        XCTAssertEqual(ServerNetworkManager.controlCallLaneLimit, 8)
-        XCTAssertEqual(ServerNetworkManager.gitReadCallLaneLimit, 2)
-        XCTAssertEqual(ServerNetworkManager.fileSearchCallLaneLimit, 4)
+        XCTAssertEqual(MCPToolAdmissionPolicy.fileSearchConnectionLimit, 6)
+        XCTAssertEqual(ServerNetworkManager.smallReadCallLaneLimit, 6)
+        XCTAssertEqual(ServerNetworkManager.controlCallLaneLimit, 16)
+        XCTAssertEqual(ServerNetworkManager.gitReadCallLaneLimit, 4)
+        XCTAssertEqual(ServerNetworkManager.fileSearchCallLaneLimit, 6)
     }
 
     func testSameConnectionSmallReadsOverlapAtBoundedCapacity() async throws {
@@ -226,31 +226,32 @@ final class MCPToolAdmissionPolicyTests: XCTestCase {
     }
 
     func testSmallReadResourceAdmissionBoundsOneWindowAndOverlapsDistinctWindows() async throws {
-        let controller = MCPToolResourceAdmissionController(
-            limit: MCPToolAdmissionPolicy.smallReadPerWindowLimit
-        )
+        let limit = MCPToolAdmissionPolicy.smallReadPerWindowLimit
+        let controller = MCPToolResourceAdmissionController(limit: limit)
         let gate = AdmissionTestGate()
 
-        let first = mutationTask(controller: controller, resource: .window(30), gate: gate)
-        let second = mutationTask(controller: controller, resource: .window(30), gate: gate)
-        let didFillWindowCapacity = await waitUntil { await gate.startedCount() == 2 }
+        let sameWindowTasks = (0 ..< limit).map { _ in
+            mutationTask(controller: controller, resource: .window(30), gate: gate)
+        }
+        let didFillWindowCapacity = await waitUntil { await gate.startedCount() == limit }
         XCTAssertTrue(didFillWindowCapacity)
 
         let queuedSameWindow = mutationTask(controller: controller, resource: .window(30), gate: gate)
         let distinctWindow = mutationTask(controller: controller, resource: .window(40), gate: gate)
-        let didOverlapDistinctWindow = await waitUntil { await gate.startedCount() == 3 }
+        let didOverlapDistinctWindow = await waitUntil { await gate.startedCount() == limit + 1 }
         XCTAssertTrue(didOverlapDistinctWindow)
-        XCTAssertEqual(controller.activeCount(for: .window(30)), 2)
+        XCTAssertEqual(controller.activeCount(for: .window(30)), limit)
         XCTAssertEqual(controller.activeCount(for: .window(40)), 1)
         XCTAssertEqual(controller.waiterCount(for: .window(30)), 1)
 
         await gate.release()
-        try await first.value
-        try await second.value
+        for task in sameWindowTasks {
+            try await task.value
+        }
         try await queuedSameWindow.value
         try await distinctWindow.value
         let finalReadCount = await gate.startedCount()
-        XCTAssertEqual(finalReadCount, 4)
+        XCTAssertEqual(finalReadCount, limit + 2)
         XCTAssertEqual(controller.activeCount(for: .window(30)), 0)
         XCTAssertEqual(controller.activeCount(for: .window(40)), 0)
     }

--- a/Tests/RepoPromptTests/MCP/Control/MCPToolExecutionWatchdogIntegrationTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/MCPToolExecutionWatchdogIntegrationTests.swift
@@ -1681,29 +1681,20 @@ import XCTest
                 }
                 do {
                     let endpoint = try fixture.endpointA()
-                    let first = Task {
-                        try await endpoint.callTool(
-                            name: MCPWindowToolName.readFile,
-                            arguments: [
-                                "path": fixture.contextA.fileURL.path,
-                                "context_id": fixture.contextA.tabID.uuidString
-                            ]
-                        )
+                    let capacity = MCPToolAdmissionPolicy.smallReadConnectionLimit
+                    let admittedTasks = (0 ..< capacity).map { _ in
+                        Task {
+                            try await endpoint.callTool(
+                                name: MCPWindowToolName.readFile,
+                                arguments: [
+                                    "path": fixture.contextA.fileURL.path,
+                                    "context_id": fixture.contextA.tabID.uuidString
+                                ]
+                            )
+                        }
                     }
-                    try await clock.waitForSleeperCount(1)
-                    try await operationGate.waitUntilEntered(count: 1)
-
-                    let second = Task {
-                        try await endpoint.callTool(
-                            name: MCPWindowToolName.readFile,
-                            arguments: [
-                                "path": fixture.contextA.fileURL.path,
-                                "context_id": fixture.contextA.tabID.uuidString
-                            ]
-                        )
-                    }
-                    try await clock.waitForSleeperCount(2)
-                    try await operationGate.waitUntilEntered(count: 2)
+                    try await clock.waitForSleeperCount(capacity)
+                    try await operationGate.waitUntilEntered(count: capacity)
 
                     let queuedBeyondCapacity = Task {
                         try await endpoint.callTool(
@@ -1714,18 +1705,19 @@ import XCTest
                             ]
                         )
                     }
-                    try await clock.advanceNext(expected: MCPTimeoutPolicy.boundedToolExecutionDeadline)
-                    try await clock.waitForSleeperCount(2)
-                    try await clock.advanceNext(expected: MCPTimeoutPolicy.boundedToolExecutionDeadline)
-                    try await clock.waitForSleeperCount(2)
+                    for _ in 0 ..< capacity {
+                        try await clock.advanceNext(expected: MCPTimeoutPolicy.boundedToolExecutionDeadline)
+                        try await clock.waitForSleeperCount(capacity)
+                    }
                     try await clock.advanceNext(expected: MCPTimeoutPolicy.boundedToolCancellationCleanupGrace)
 
-                    await Self.assertSocketClosed(first)
-                    await Self.assertSocketClosed(second)
+                    for task in admittedTasks {
+                        await Self.assertSocketClosed(task)
+                    }
                     await Self.assertSocketClosed(queuedBeyondCapacity)
                     let enteredCount = await operationGate.enteredCount()
                     let isTerminal = await manager.debugIsExecutionWatchdogTerminal(connectionID: endpoint.connectionID)
-                    XCTAssertEqual(enteredCount, MCPToolAdmissionPolicy.smallReadPerWindowLimit)
+                    XCTAssertEqual(enteredCount, capacity)
                     XCTAssertTrue(isTerminal)
 
                     let events = recorder.snapshot().filter {


### PR DESCRIPTION
## Summary

- raise control connection capacity from 8 to 16
- raise small-read capacity from 2 to 6 per connection and from 2 to 8 per window
- raise Git-read connection capacity from 2 to 4 and file-search capacity from 4 to 6
- keep exclusive and per-repository Git admission limits at 1
- update admission-policy tests to assert and exercise the new limits

## Validation

- `make dev-format`
- `make dev-lint`
- `make dev-test FILTER=MCPToolAdmissionPolicyTests` (11 tests, 0 failures)
- contribution preflight: commit and push modes