### PR TITLE
fix(agent-mode): stop tool-result updates from remounting unrelated cards

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/Models/AgentTranscriptModels.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Models/AgentTranscriptModels.swift
@@ -1008,7 +1008,7 @@ struct AgentTranscriptPresentationSnapshot: Equatable {
     let hydratedBindingTransitionGeneration: UInt64?
     let performanceSnapshot: AgentTranscriptPerformanceSnapshot
     let metadata: AgentTranscriptPresentationMetadata
-    let rawToolResultPayloadRenderRevision: Int
+    let rawToolResultPayloadRenderRevisionByItemID: [UUID: Int]
 
     init(
         tabID: UUID? = nil,
@@ -1028,7 +1028,7 @@ struct AgentTranscriptPresentationSnapshot: Equatable {
         hydratedBindingTransitionGeneration: UInt64? = nil,
         performanceSnapshot: AgentTranscriptPerformanceSnapshot = .empty,
         metadata: AgentTranscriptPresentationMetadata = .empty,
-        rawToolResultPayloadRenderRevision: Int = 0
+        rawToolResultPayloadRenderRevisionByItemID: [UUID: Int] = [:]
     ) {
         self.tabID = tabID
         self.revision = revision
@@ -1047,7 +1047,7 @@ struct AgentTranscriptPresentationSnapshot: Equatable {
         self.hydratedBindingTransitionGeneration = hydratedBindingTransitionGeneration
         self.performanceSnapshot = performanceSnapshot
         self.metadata = metadata
-        self.rawToolResultPayloadRenderRevision = rawToolResultPayloadRenderRevision
+        self.rawToolResultPayloadRenderRevisionByItemID = rawToolResultPayloadRenderRevisionByItemID
     }
 
     func contentEqualsExcludingPerformance(_ other: Self) -> Bool {
@@ -1066,7 +1066,7 @@ struct AgentTranscriptPresentationSnapshot: Equatable {
             && hydratedPersistentBinding == other.hydratedPersistentBinding
             && hydratedBindingTransitionGeneration == other.hydratedBindingTransitionGeneration
             && metadata == other.metadata
-            && rawToolResultPayloadRenderRevision == other.rawToolResultPayloadRenderRevision
+            && rawToolResultPayloadRenderRevisionByItemID == other.rawToolResultPayloadRenderRevisionByItemID
     }
 
     func hasVisiblePresentationDelta(comparedTo other: Self) -> Bool {
@@ -1076,7 +1076,7 @@ struct AgentTranscriptPresentationSnapshot: Equatable {
             || isCompressedHistoryRevealed != other.isCompressedHistoryRevealed
             || isTranscriptWindowExpanded != other.isTranscriptWindowExpanded
             || isWindowCappedWhileActive != other.isWindowCappedWhileActive
-            || rawToolResultPayloadRenderRevision != other.rawToolResultPayloadRenderRevision
+            || rawToolResultPayloadRenderRevisionByItemID != other.rawToolResultPayloadRenderRevisionByItemID
     }
 
     static let empty = AgentTranscriptPresentationSnapshot()

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+TabSession.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+TabSession.swift
@@ -41,7 +41,7 @@ extension AgentModeViewModel {
         private(set) var liveItemIDs: Set<UUID> = []
         private var toolCorrelationIndexes = ToolCorrelationIndexes()
         private var nextEphemeralToolResultPayloadRevision: Int = 1
-        var rawToolResultPayloadRenderRevision: Int = 0
+        var rawToolResultPayloadRenderRevisionByItemID: [UUID: Int] = [:]
         var onSourceItemsChanged: ((TabSession, SourceItemsMutation) -> Void)?
         var onRunStateChanged: ((TabSession) -> Void)?
         #if DEBUG
@@ -1525,7 +1525,7 @@ extension AgentModeViewModel {
             transcriptProjectionCounts = .zero
             transcriptAnalyticsSnapshot = .init()
             transcriptPerformanceSnapshot = .empty
-            rawToolResultPayloadRenderRevision = 0
+            rawToolResultPayloadRenderRevisionByItemID = [:]
             derivedTranscriptSyncState = nil
         }
 

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+Types.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+Types.swift
@@ -751,7 +751,7 @@ extension AgentModeViewModel {
         let analyticsSnapshot: AgentTranscriptAnalyticsSnapshot
         let sanitizedActivityCount: Int
         let performanceSnapshot: AgentTranscriptPerformanceSnapshot
-        let rawToolResultPayloadRenderRevision: Int
+        let rawToolResultPayloadRenderRevisionByItemID: [UUID: Int]
     }
 
     enum DerivedTranscriptRefreshReason: String {

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -7249,7 +7249,7 @@ final class AgentModeViewModel: ObservableObject {
                 transcript: session.transcript,
                 runState: session.runState
             ),
-            rawToolResultPayloadRenderRevision: session.rawToolResultPayloadRenderRevision
+            rawToolResultPayloadRenderRevisionByItemID: session.rawToolResultPayloadRenderRevisionByItemID
         )
     }
 
@@ -7485,7 +7485,7 @@ final class AgentModeViewModel: ObservableObject {
             hydratedBindingTransitionGeneration: hydratedTransitionGeneration,
             performanceSnapshot: snapshot.performanceSnapshot,
             metadata: snapshot.metadata,
-            rawToolResultPayloadRenderRevision: snapshot.rawToolResultPayloadRenderRevision
+            rawToolResultPayloadRenderRevisionByItemID: snapshot.rawToolResultPayloadRenderRevisionByItemID
         )
     }
 
@@ -9126,7 +9126,7 @@ final class AgentModeViewModel: ObservableObject {
             analyticsSnapshot: session.transcriptAnalyticsSnapshot,
             sanitizedActivityCount: 0,
             performanceSnapshot: session.transcriptPerformanceSnapshot,
-            rawToolResultPayloadRenderRevision: session.rawToolResultPayloadRenderRevision
+            rawToolResultPayloadRenderRevisionByItemID: session.rawToolResultPayloadRenderRevisionByItemID
         )
     }
 
@@ -9307,9 +9307,11 @@ final class AgentModeViewModel: ObservableObject {
             #endif
         }
         let visibleRetainedIDs = visibleToolResultIDs(in: baseProjection)
-        let rawToolResultPayloadRenderRevision = visibleRetainedIDs.reduce(0) { current, itemID in
-            max(current, capturedPayloadRevisionByItemID[itemID] ?? 0)
-        }
+        let rawToolResultPayloadRenderRevisionByItemID = Dictionary(
+            uniqueKeysWithValues: visibleRetainedIDs.compactMap { itemID in
+                capturedPayloadRevisionByItemID[itemID].map { (itemID, $0) }
+            }
+        )
         let fullProjection = degradeCollapsedTranscriptBlocksIfNeeded(
             baseProjection,
             isColdLoad: isColdLoad
@@ -9427,7 +9429,7 @@ final class AgentModeViewModel: ObservableObject {
             ),
             sanitizedActivityCount: sanitizeMetrics.sanitizedActivityCount,
             performanceSnapshot: performanceSnapshot,
-            rawToolResultPayloadRenderRevision: rawToolResultPayloadRenderRevision
+            rawToolResultPayloadRenderRevisionByItemID: rawToolResultPayloadRenderRevisionByItemID
         )
     }
 
@@ -9564,7 +9566,7 @@ final class AgentModeViewModel: ObservableObject {
         session.transcriptCanonicalVisibleRowCount = presentation.canonicalVisibleRowCount
         session.transcriptProjectionCounts = presentation.projectionCounts
         session.transcriptAnalyticsSnapshot = presentation.analyticsSnapshot
-        session.rawToolResultPayloadRenderRevision = presentation.rawToolResultPayloadRenderRevision
+        session.rawToolResultPayloadRenderRevisionByItemID = presentation.rawToolResultPayloadRenderRevisionByItemID
         #if DEBUG || EDIT_FLOW_PERF
             session.transcriptPerformanceSnapshot = presentation.performanceSnapshot
         #else

--- a/Sources/RepoPrompt/Features/AgentMode/Views/AgentModeView.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/AgentModeView.swift
@@ -2734,7 +2734,8 @@ struct AgentModeChatDetailView: View {
             promptManager: promptManager,
             handoffConfig: runInteractionSnapshot.canForkCurrentSession ? handoffConfig(for: item.id) : nil,
             rawToolResultPayload: agentModeVM.rawToolResultPayloadForRendering(tabID: ownerTabID, itemID: item.id),
-            rawToolResultPayloadRenderRevision: transcriptSnapshot.presentation.rawToolResultPayloadRenderRevision,
+            rawToolResultPayloadRenderRevision: transcriptSnapshot.presentation
+                .rawToolResultPayloadRenderRevisionByItemID[item.id] ?? 0,
             showRunScopedToolCancel: showCancel,
             cancelActiveToolsAction: cancelAction,
             codexManagedLoginAction: codexManagedLoginAction

--- a/Tests/RepoPromptTests/AgentMode/AgentModeViewModelInactiveRefreshTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeViewModelInactiveRefreshTests.swift
@@ -49,7 +49,93 @@ final class AgentModeViewModelInactiveRefreshTests: XCTestCase {
         let retainedRawPayload = try XCTUnwrap(viewModel.rawToolResultPayloadForRendering(tabID: tabID, itemID: toolResult.id))
         XCTAssertTrue(retainedRawPayload.contains(marker))
         XCTAssertGreaterThan(session.ephemeralToolResultPayloadRevisionByItemID[toolResult.id] ?? 0, 0)
-        XCTAssertGreaterThan(viewModel.activeTranscriptPresentation.rawToolResultPayloadRenderRevision, 0)
+        XCTAssertGreaterThan(
+            viewModel.activeTranscriptPresentation.rawToolResultPayloadRenderRevisionByItemID[toolResult.id] ?? 0,
+            0
+        )
+    }
+
+    func testRetainedPayloadRefreshChangesOnlyMatchingResultRenderIdentity() async throws {
+        let viewModel = makeViewModel()
+        let tabID = UUID()
+        viewModel.test_setCurrentTabIDOverride(tabID)
+        defer { viewModel.test_setCurrentTabIDOverride(nil) }
+
+        let session = await viewModel.ensureSessionReady(tabID: tabID)
+        session.runState = .running
+        let invocationA = UUID()
+        let invocationB = UUID()
+        let markerA1 = "RESULT_A_INITIAL_\(UUID().uuidString)"
+        let markerA2 = "RESULT_A_UPDATED_\(UUID().uuidString)"
+        let markerB = "RESULT_B_\(UUID().uuidString)"
+        let rawA1 = retainedApplyEditsPayload(marker: markerA1)
+        let rawA2 = retainedApplyEditsPayload(marker: markerA2)
+        let rawB = retainedApplyEditsPayload(marker: markerB)
+        let callA = AgentChatItem.toolCall(
+            name: "apply_edits",
+            invocationID: invocationA,
+            argsJSON: #"{"path":"A.swift"}"#,
+            sequenceIndex: 1
+        )
+        let callB = AgentChatItem.toolCall(
+            name: "apply_edits",
+            invocationID: invocationB,
+            argsJSON: #"{"path":"B.swift"}"#,
+            sequenceIndex: 3
+        )
+        let resultA = AgentChatItem.toolResult(
+            name: "apply_edits",
+            invocationID: invocationA,
+            resultJSON: rawA1,
+            sequenceIndex: 2
+        )
+        let resultB = AgentChatItem.toolResult(
+            name: "apply_edits",
+            invocationID: invocationB,
+            resultJSON: rawB,
+            sequenceIndex: 4
+        )
+
+        session.replaceItems([
+            .user("Start", sequenceIndex: 0),
+            callA,
+            resultA,
+            callB,
+            resultB,
+            .assistant("Done", sequenceIndex: 5)
+        ])
+        viewModel.refreshDerivedTranscriptState(for: session)
+        viewModel.applySessionToBindings(session)
+
+        let initialRevisions = viewModel.activeTranscriptPresentation.rawToolResultPayloadRenderRevisionByItemID
+        let initialRevisionA = try XCTUnwrap(initialRevisions[resultA.id])
+        let initialRevisionB = try XCTUnwrap(initialRevisions[resultB.id])
+        XCTAssertTrue(viewModel.rawToolResultPayloadForRendering(tabID: tabID, itemID: resultA.id)?.contains(markerA1) == true)
+        XCTAssertTrue(viewModel.rawToolResultPayloadForRendering(tabID: tabID, itemID: resultB.id)?.contains(markerB) == true)
+
+        var updatedResultA = resultA
+        updatedResultA.text = rawA2
+        updatedResultA.toolResultJSON = rawA2
+        session.replaceItems([
+            .user("Start", sequenceIndex: 0),
+            callA,
+            updatedResultA,
+            callB,
+            resultB,
+            .assistant("Done", sequenceIndex: 5)
+        ])
+        viewModel.refreshDerivedTranscriptState(for: session)
+        viewModel.applySessionToBindings(session)
+
+        let updatedRevisions = viewModel.activeTranscriptPresentation.rawToolResultPayloadRenderRevisionByItemID
+        XCTAssertGreaterThan(try XCTUnwrap(updatedRevisions[resultA.id]), initialRevisionA)
+        XCTAssertEqual(updatedRevisions[resultB.id], initialRevisionB)
+        let updatedPayloadA = try XCTUnwrap(viewModel.rawToolResultPayloadForRendering(tabID: tabID, itemID: resultA.id))
+        let unchangedPayloadB = try XCTUnwrap(viewModel.rawToolResultPayloadForRendering(tabID: tabID, itemID: resultB.id))
+        XCTAssertTrue(updatedPayloadA.contains(markerA2))
+        XCTAssertFalse(updatedPayloadA.contains(markerB))
+        XCTAssertTrue(unchangedPayloadB.contains(markerB))
+        XCTAssertFalse(unchangedPayloadB.contains(markerA2))
     }
 
     func testLiveToolResultRefreshUsesIncrementalRetentionCompaction() async throws {
@@ -1491,6 +1577,17 @@ final class AgentModeViewModelInactiveRefreshTests: XCTestCase {
         XCTAssertTrue(JSONSerialization.isValidJSONObject(object), file: file, line: line)
         let data = try! JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
         return String(data: data, encoding: .utf8)!
+    }
+
+    private func retainedApplyEditsPayload(marker: String) -> String {
+        jsonString([
+            "status": "success",
+            "edits_requested": 1,
+            "edits_applied": 1,
+            "review_status": "approved",
+            "raw_output": String(repeating: marker, count: 4),
+            "diffs": [["path": "File.swift", "diff": String(repeating: marker, count: 4)]]
+        ])
     }
 
     private func makeTranscriptItems(prefix: String, turnCount: Int) -> [AgentChatItem] {


### PR DESCRIPTION
## Problem

Agent Mode keeps complete tool-result payloads separately from the compacted transcript so result cards can still show their detailed content.

Those retained payloads previously shared one presentation revision. That revision was also used as the SwiftUI identity for every visible result card. When one retained payload changed, every visible result card received a new identity.

Changing `.id` discards the existing result subtree and its local `@State`. Unrelated cards could therefore lose expansion state and recreate their AppKit text or diff views even though their content had not changed.

## Change

Retained payload revisions now remain keyed by tool-result item ID throughout the presentation path.

Each result card receives only its own revision:

- changing result A refreshes result A;
- result B keeps its existing identity and state.

Payload-only changes still publish a transcript update. Raw payload retention, transcript compaction, persistence, provider behavior, and tool output remain unchanged.

## Impact

Retained payload updates no longer fan out across every visible result card.

This preserves state and backing views for unrelated cards and reduces unnecessary reconstruction during tool-heavy Agent Mode runs.

## Tests

Adds regression coverage with two retained results to verify that:

- updating one result changes only its render identity;
- the other result keeps its previous identity;
- both cards continue receiving the correct retained payload.
