### PR TITLE
Improve conductor worktree parallelism

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,10 +144,11 @@ These settings are intentionally DEBUG-only. If a key is unavailable, confirm `r
 
 ## Developer daemon / coordinated validation
 
-Prefer the developer daemon as the default way to build, run, and validate. Two properties are the whole reason it exists — and the reason to reach for it instead of a bare `swift build` / `swift test`:
+Prefer the developer daemon as the default way to build, run, and validate. Four properties are the whole reason it exists — and the reason to reach for it instead of a bare `swift build` / `swift test`:
 
 - **Lane-serialized job queue** — every job claims named lanes (`build`, `debugArtifact`, `liveApp`, `release`, `style`); the daemon runs jobs that share a lane one at a time while letting unrelated lanes proceed concurrently. That serial queue is what stops multiple agents from building, launching, or running style tooling over each other and corrupting `.build` or the live app.
-- **Machine-wide heavy-job slot** — Swift/Xcode-heavy daemon jobs also acquire a per-user global heavy slot before spawning their subprocess. This coordinates expensive work across worktree-local conductor daemons. If `job status` or `job wait` shows `global-wait` or "waiting for global heavy slot", another checkout/worktree is already running heavy work; wait on the ticket instead of bypassing conductor with direct `swift`/`xcodebuild` commands or starting duplicate jobs.
+- **Machine-wide heavy-job slots** — Swift/Xcode-heavy daemon jobs acquire per-user global heavy admission under `/tmp/repoprompt-ce-dev-locks-<uid>/`, independent of daemon socket overrides. The default capacity is 1; set `REPOPROMPT_DEV_HEAVY_SLOTS=N` explicitly to allow more concurrent heavy jobs. If `job status` or `job wait` shows `global-wait` or "waiting for global heavy slot", another checkout/worktree is already running heavy work; wait on the ticket instead of bypassing conductor with direct `swift`/`xcodebuild` commands or starting duplicate jobs. Holder metadata is display-only and identifies the operation/ticket/repo/worktree when available.
+- **Machine-wide live-app lock** — debug app stop/launch/relaunch/smoke-launch lifecycle work acquires a separate per-user `live-app.lock`, so worktree-local daemons cannot mutate the singleton debug app at the same time.
 - **Tickets + async jobs** — every job gets a ticket and can run detached (`--async`). Fire a build, keep working, and query or wait on it later (`job status` / `job wait`) instead of blocking on a long compile. Jobs survive reconnects and are reusable by `--request-key`.
 
 `conductor` is repo-internal developer tooling for this checkout; the daemon auto-starts on first use.
@@ -159,6 +160,7 @@ make dev-status
 make dev-build
 make dev-swift-build PRODUCT=repoprompt-mcp         # focused product build (PRODUCT=RepoPrompt|repoprompt-mcp|all, default all)
 make dev-run
+make dev-launch-existing                         # launch current DebugApps bundle without building
 make dev-test                                       # full coordinated test suite
 make dev-test FILTER=WorkspaceFileContextStoreTests # focused coordinated test run
 make dev-test-list                                  # coordinated authoritative root XCTest method list
@@ -191,7 +193,8 @@ Daemon output defaults are intentionally concise for agent use: synchronous `dev
 
 Behavior notes:
 
-- `make dev-run` (daemon `run`) still delegates to the debug launch flow and stops only the running process whose resolved executable matches the target CE debug app, same as `make run`; it remains FIFO and does not supersede older lifecycle work.
+- `make dev-run` (daemon `run`) builds/packages a unique staged app under heavy admission, releases that heavy slot, then takes the live-app lock for stop/staged-bundle activation/open/confirm against the shared `DebugApps/RepoPrompt.app` bundle. A build/package failure performs no lifecycle action and does not mutate the live bundle.
+- `./conductor app launch-existing` / `make dev-launch-existing` requires the shared debug app bundle to already exist, reports bundle provenance, never waits for heavy admission, and never falls back to building.
 - `./conductor app relaunch` is the overriding interactive relaunch used by the Finder launcher; like `app stop`, it can cancel older active or queued `liveApp` work. It builds/packages before replacing the visible app, so a failure before lifecycle work begins does not itself stop or reopen an already-running app.
 - Do not assume an in-flight `run`, `smoke`, or diagnostics job will complete if another operator issues `app stop` or interactive `app relaunch`.
 - `make dev-smoke` is the non-disruptive live-only check: it assumes the CE debug app is already running and the debug CLI is installed/resolvable.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help doctor setup install-format-tools format-tools-status format format-check lint install-debug-cli uninstall-debug-cli debug-cli-status resolve build run test guardrails conductor-selftest ci-app-test-runner-selftest release-selftest release-sync-cli-version release-preflight release-artifact install-local-production xcode xcode-open xcode-generate xcode-check xcode-validate xcode-generator-test xcode-clean dev-status dev-build dev-swift-build dev-run dev-test dev-test-impacted dev-test-shard-plan dev-test-list dev-provider-test dev-provider-test-list dev-smoke dev-smoke-launch dev-format dev-format-check dev-lint dev-format-tools-status dev-check-format-tools dev-install-format-tools dev-release-preflight dev-release-artifact dev-install-local-production dev-stop-app dev-daemon-stop clean
+.PHONY: help doctor setup install-format-tools format-tools-status format format-check lint install-debug-cli uninstall-debug-cli debug-cli-status resolve build run test guardrails conductor-selftest ci-app-test-runner-selftest release-selftest release-sync-cli-version release-preflight release-artifact install-local-production xcode xcode-open xcode-generate xcode-check xcode-validate xcode-generator-test xcode-clean dev-status dev-build dev-swift-build dev-run dev-launch-existing dev-test dev-test-impacted dev-test-shard-plan dev-test-list dev-provider-test dev-provider-test-list dev-smoke dev-smoke-launch dev-format dev-format-check dev-lint dev-format-tools-status dev-check-format-tools dev-install-format-tools dev-release-preflight dev-release-artifact dev-install-local-production dev-stop-app dev-daemon-stop clean
 
 PRODUCT ?= all
 
@@ -17,6 +17,7 @@ help:
 	@printf '  %-30s %s\n' 'dev-build' 'Coordinated debug app package build'
 	@printf '  %-30s %s\n' 'dev-swift-build' 'Coordinated Swift build; override with PRODUCT=name'
 	@printf '  %-30s %s\n' 'dev-run' 'Coordinated debug app build and launch'
+	@printf '  %-30s %s\n' 'dev-launch-existing' 'Launch existing coordinated debug app without building'
 	@printf '  %-30s %s\n' 'dev-test' 'Coordinated test run; override with FILTER=name'
 	@printf '  %-30s %s\n' 'dev-test-impacted' 'Run impacted root tests; default includes branch, staged, and unstaged changes; override with RANGE=...'
 	@printf '  %-30s %s\n' 'dev-test-shard-plan' 'Print weighted full-root shard filters; override with SHARDS=N'
@@ -172,6 +173,9 @@ dev-swift-build:
 
 dev-run:
 	./conductor run
+
+dev-launch-existing:
+	./conductor app launch-existing
 
 dev-test:
 	./conductor test$(if $(TEST_PRODUCT), --test-product $(TEST_PRODUCT))$(if $(FILTER), --filter $(FILTER))

--- a/Scripts/conductor.py
+++ b/Scripts/conductor.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 import contextlib
+import ctypes
 import dataclasses
 import errno
 import fcntl
@@ -35,7 +36,7 @@ from typing import Any, Deque, Dict, List, Optional, Sequence, Tuple
 
 from debug_app_process import ProcessIdentityError, matching_processes, terminate_matching_processes
 
-PROTOCOL_VERSION = 9
+PROTOCOL_VERSION = 10
 TERMINAL_STATES = {"completed", "failed", "canceled"}
 LANE_NAMES = {"build", "debugArtifact", "liveApp", "release", "style"}
 LOG_TAIL_LINES = 30
@@ -69,6 +70,9 @@ APP_STOP_DELAYED_LAUNCH_GUARD_SECONDS = 12.0
 APP_STOP_CONFIRM_TIMEOUT_SECONDS = 8.0
 APP_STOP_DELAYED_LAUNCH_CONFIRM_TIMEOUT_SECONDS = 25.0
 GLOBAL_HEAVY_SLOT_POLL_SECONDS = 0.2
+MACHINE_LOCK_POLL_SECONDS = 0.2
+MAX_GLOBAL_HEAVY_SLOTS = 64
+DEBUG_APP_PROVENANCE_RELATIVE_PATH = "Contents/Resources/RepoPromptDebugProvenance.json"
 
 SHORT_TIMEOUT_SECONDS = 5 * 60
 MEDIUM_TIMEOUT_SECONDS = 60 * 60
@@ -135,9 +139,10 @@ Operation commands:
   ./conductor provider-test [--list | --filter <filter>] [--test-product <product>] [--xctest-stall-seconds <seconds>] [--xctest-stall-wake-probe]
   ./conductor install-debug-cli
   ./conductor debug-cli-status
-  ./conductor run [-- <app args...>]                  # FIFO coordinated run
+  ./conductor run [-- <app args...>]                  # build/package, then FIFO coordinated launch
   ./conductor app status
   ./conductor app stop                                 # latest interactive stop intent
+  ./conductor app launch-existing [-- <app args...>]   # launch existing DebugApps bundle without building
   ./conductor app relaunch [-- <app args...>]          # latest interactive relaunch intent
   ./conductor smoke [--launch | --packaged-app <path>] [--artifact-manifest <path>] [--workspace <name>] [--window-id <id>] [--agent-run]
     (without --launch/--packaged-app, requires the CE debug app to already be running and CLI installed)
@@ -167,6 +172,8 @@ Output:
 State paths:
   state dir default: ~/Library/Application Support/RepoPrompt CE/Conductor/<repo-root-hash>/
   socket default:    /tmp/conductor-<uid>/<repo-root-hash16>.sock (directory mode 0700)
+  machine locks:     /tmp/repoprompt-ce-dev-locks-<uid>/ (directory mode 0700; independent of socket overrides)
+  heavy slots:       REPOPROMPT_DEV_HEAVY_SLOTS=N (default 1)
   overrides: REPOPROMPT_DEV_DAEMON_STATE_DIR, REPOPROMPT_DEV_DAEMON_SOCKET (socket parent must be owned 0700)
 
 Protocol version: {PROTOCOL_VERSION}
@@ -378,6 +385,173 @@ def ensure_state_dirs(paths: Paths) -> None:
     ensure_private_dir(paths.state_dir)
     ensure_private_dir(paths.jobs_dir)
     ensure_private_dir(paths.socket_path.parent)
+    ensure_private_dir(machine_lock_dir())
+
+
+def machine_lock_dir() -> Path:
+    uid = os.getuid() if hasattr(os, "getuid") else 0
+    return Path("/tmp") / f"repoprompt-ce-dev-locks-{uid}"
+
+
+def configured_global_heavy_slots(env: Optional[Dict[str, str]] = None) -> int:
+    raw = (env or os.environ).get("REPOPROMPT_DEV_HEAVY_SLOTS")
+    if raw is None or raw == "":
+        return 1
+    try:
+        slots = int(raw)
+    except ValueError as exc:
+        raise ConductorError("REPOPROMPT_DEV_HEAVY_SLOTS must be a positive integer") from exc
+    if slots < 1 or slots > MAX_GLOBAL_HEAVY_SLOTS:
+        raise ConductorError(f"REPOPROMPT_DEV_HEAVY_SLOTS must be between 1 and {MAX_GLOBAL_HEAVY_SLOTS}")
+    return slots
+
+
+def global_heavy_slot_paths(env: Optional[Dict[str, str]] = None) -> List[Path]:
+    root = machine_lock_dir()
+    return [root / f"global-heavy-{index}.lock" for index in range(configured_global_heavy_slots(env))]
+
+
+def live_app_lock_path() -> Path:
+    return machine_lock_dir() / "live-app.lock"
+
+
+def repo_worktree_name(repo_root: Path) -> str:
+    return repo_root.name or str(repo_root)
+
+
+def display_lock_metadata(
+    *,
+    lock_kind: str,
+    ticket: Optional[str],
+    operation: str,
+    operation_label: str,
+    repo_root: Path,
+    repo_hash: Optional[str] = None,
+) -> Dict[str, Any]:
+    acquired_at = now()
+    return {
+        "version": 1,
+        "displayOnly": True,
+        "kind": lock_kind,
+        "ticket": ticket,
+        "operation": operation,
+        "operationLabel": operation_label,
+        "repoRoot": str(repo_root),
+        "repoHash": repo_hash,
+        "worktree": repo_worktree_name(repo_root),
+        "pid": os.getpid(),
+        "acquiredAt": acquired_at,
+        "acquiredAtISO": iso_timestamp(acquired_at),
+    }
+
+
+def write_display_lock_metadata(lock_file: Any, metadata: Dict[str, Any]) -> None:
+    try:
+        lock_file.seek(0)
+        lock_file.truncate()
+        lock_file.write(json.dumps(metadata, indent=2, sort_keys=True))
+        lock_file.write("\n")
+        lock_file.flush()
+    except OSError:
+        pass
+
+
+def read_display_lock_metadata(path: Path) -> Optional[Dict[str, Any]]:
+    try:
+        raw = path.read_text(encoding="utf-8", errors="replace")
+        payload = json.loads(raw) if raw.strip() else None
+    except (OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def format_display_lock_holder(metadata: Optional[Dict[str, Any]]) -> str:
+    if not metadata:
+        return "holder unknown"
+    label = metadata.get("operationLabel") or metadata.get("operation") or "unknown operation"
+    ticket = metadata.get("ticket") or "no-ticket"
+    repo = metadata.get("repoRoot") or "unknown repo"
+    worktree = metadata.get("worktree") or Path(str(repo)).name
+    acquired_at = metadata.get("acquiredAt")
+    held_for = "unknown duration"
+    if isinstance(acquired_at, (int, float)):
+        held_for = format_duration(now() - float(acquired_at))
+    return f"holder {label} ticket={ticket} repo={repo} worktree={worktree} held={held_for}"
+
+
+@contextlib.contextmanager
+def machine_exclusive_lock(lock_path: Path, metadata: Dict[str, Any], wait_label: str):
+    ensure_private_dir(lock_path.parent)
+    lock_file = lock_path.open("a+", encoding="utf-8")
+    did_log_wait = False
+    while True:
+        try:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            break
+        except BlockingIOError:
+            if not did_log_wait:
+                holder = format_display_lock_holder(read_display_lock_metadata(lock_path))
+                print(f"waiting for {wait_label}: {lock_path} ({holder})", flush=True)
+                did_log_wait = True
+            time.sleep(MACHINE_LOCK_POLL_SECONDS)
+        except OSError as exc:
+            if exc.errno == errno.EINTR:
+                continue
+            lock_file.close()
+            raise
+    write_display_lock_metadata(lock_file, metadata)
+    try:
+        yield lock_file
+    finally:
+        with contextlib.suppress(OSError):
+            lock_file.seek(0)
+            lock_file.truncate()
+            lock_file.flush()
+        with contextlib.suppress(OSError):
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+        with contextlib.suppress(OSError):
+            lock_file.close()
+
+
+@contextlib.contextmanager
+def machine_heavy_slot(metadata: Dict[str, Any], env: Optional[Dict[str, str]], wait_label: str):
+    ensure_private_dir(machine_lock_dir())
+    lock_files = [(path, path.open("a+", encoding="utf-8")) for path in global_heavy_slot_paths(env)]
+    did_log_wait = False
+    selected_file: Optional[Any] = None
+    try:
+        while True:
+            for lock_path, lock_file in lock_files:
+                try:
+                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    selected_file = lock_file
+                    write_display_lock_metadata(lock_file, metadata)
+                    print(f"acquired {wait_label}: {lock_path}", flush=True)
+                    yield lock_file
+                    return
+                except BlockingIOError:
+                    continue
+                except OSError as exc:
+                    if exc.errno == errno.EINTR:
+                        continue
+                    raise
+            if not did_log_wait:
+                holders = "; ".join(format_display_lock_holder(read_display_lock_metadata(path)) for path, _ in lock_files)
+                paths = ",".join(str(path) for path, _ in lock_files)
+                print(f"waiting for {wait_label} ({len(lock_files)} configured): {paths}; {holders}", flush=True)
+                did_log_wait = True
+            time.sleep(GLOBAL_HEAVY_SLOT_POLL_SECONDS)
+    finally:
+        for _path, lock_file in lock_files:
+            if lock_file is selected_file:
+                with contextlib.suppress(OSError):
+                    lock_file.seek(0)
+                    lock_file.truncate()
+                    lock_file.flush()
+                with contextlib.suppress(OSError):
+                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+            with contextlib.suppress(OSError):
+                lock_file.close()
 
 
 def read_pid(path: Path) -> Optional[int]:
@@ -861,13 +1035,13 @@ class OutputSummarizer:
 
 
 def operation_display_name(operation: str, args: Dict[str, Any]) -> str:
-    if operation == "app" and args.get("subcommand") in {"status", "stop", "relaunch"}:
+    if operation == "app" and args.get("subcommand") in {"status", "stop", "launch-existing", "relaunch"}:
         return f"app {args['subcommand']}"
     return operation
 
 
 def latest_lifecycle_intent(operation: str, args: Dict[str, Any]) -> Optional[str]:
-    if operation == "app" and args.get("subcommand") in {"stop", "relaunch"}:
+    if operation == "app" and args.get("subcommand") in {"stop", "launch-existing", "relaunch"}:
         return operation_display_name(operation, args)
     return None
 
@@ -875,19 +1049,15 @@ def latest_lifecycle_intent(operation: str, args: Dict[str, Any]) -> Optional[st
 def is_launch_capable_job(operation: str, args: Dict[str, Any]) -> bool:
     return (
         operation == "run"
-        or (operation == "app" and args.get("subcommand") == "relaunch")
+        or (operation == "app" and args.get("subcommand") in {"launch-existing", "relaunch"})
         or (operation == "smoke" and bool(args.get("launch") or args.get("packagedApp")))
     )
 
 
 def operation_requires_global_heavy_slot(operation: str, args: Dict[str, Any]) -> bool:
-    if operation in {"swift-build", "build", "package", "test", "provider-test", "install-debug-cli", "run"}:
+    if operation in {"swift-build", "build", "package", "test", "provider-test", "install-debug-cli"}:
         return True
     if operation in {"sleep", "fake-sleep"} and "build" in set(args.get("lanes") or []):
-        return True
-    if operation == "app" and args.get("subcommand") == "relaunch":
-        return True
-    if operation == "smoke" and bool(args.get("launch")):
         return True
     if operation == "release" and args.get("subcommand") in {"artifact", "package", "local-install"}:
         return True
@@ -949,6 +1119,7 @@ class Job:
     process_group_identity_confirmed: bool = False
     global_heavy_slot_wait_seconds: Optional[float] = None
     global_heavy_slot_path: Optional[str] = None
+    global_heavy_slot_holder: Optional[str] = None
     exit_code: Optional[int] = None
     error: Optional[str] = None
     result_summary: Optional[str] = None
@@ -1006,6 +1177,7 @@ class Job:
             "processPGID": self.process_pgid,
             "globalHeavySlotWaitSeconds": self.global_heavy_slot_wait_seconds,
             "globalHeavySlotPath": self.global_heavy_slot_path,
+            "globalHeavySlotHolder": self.global_heavy_slot_holder,
             "exitCode": self.exit_code,
             "error": self.error,
             "resultSummary": self.result_summary,
@@ -1082,6 +1254,9 @@ class OperationRegistry:
         "RPCE_RUN_CODEMAP_E2E",
         "RPCE_RUN_SCALE_TESTS",
     ]
+    CONDUCTOR_ENV_KEYS = [
+        "REPOPROMPT_DEV_HEAVY_SLOTS",
+    ]
     TELEMETRY_ENV_KEYS = [
         "REPOPROMPT_ENABLE_SENTRY",
         "REPOPROMPT_SENTRY_DSN",
@@ -1099,6 +1274,7 @@ class OperationRegistry:
             + BUILD_ENV_KEYS
             + STYLE_ENV_KEYS
             + TEST_ENV_KEYS
+            + CONDUCTOR_ENV_KEYS
             + TELEMETRY_ENV_KEYS
         )
     )
@@ -1207,7 +1383,7 @@ class OperationRegistry:
         if operation == "debug-cli-status":
             return [script("install_debug_cli.sh"), "status"], lanes, cwd, env, effective_timeout
         if operation == "run":
-            return [script("run.sh"), *[str(arg) for arg in args.get("appArgs") or []]], ["build", "debugArtifact", "liveApp"], cwd, env, effective_timeout
+            return self._internal_argv("debug_app_build_then_launch", dict(args)), ["liveApp"], cwd, env, effective_timeout
         if operation == "app":
             subcommand = args.get("subcommand")
             if subcommand == "stop":
@@ -1215,14 +1391,14 @@ class OperationRegistry:
                 return self._internal_argv("app_stop", internal_args), ["liveApp"], cwd, env, effective_timeout
             if subcommand == "status":
                 return self._internal_argv("app_status", {}), lanes, cwd, env, effective_timeout
+            if subcommand == "launch-existing":
+                return self._internal_argv("app_launch_existing", dict(args)), ["liveApp"], cwd, env, effective_timeout
             if subcommand == "relaunch":
-                if args.get("guardDelayedLaunch"):
-                    env["REPOPROMPT_GUARD_DELAYED_LAUNCH"] = "1"
-                return [script("run.sh"), *[str(arg) for arg in args.get("appArgs") or []]], ["build", "debugArtifact", "liveApp"], cwd, env, effective_timeout
+                return self._internal_argv("debug_app_build_then_launch", dict(args)), ["liveApp"], cwd, env, effective_timeout
         if operation == "smoke":
             lanes = ["debugArtifact", "liveApp"]
             if args.get("launch"):
-                lanes = ["build", "debugArtifact", "liveApp"]
+                lanes = ["liveApp"]
             elif args.get("packagedApp"):
                 lanes = ["liveApp"]
             smoke_args = dict(args)
@@ -1351,8 +1527,8 @@ class DaemonState:
         self.shutdown_requested = False
         self.server: Optional[socketserver.BaseServer] = None
 
-    def _global_heavy_slot_path(self) -> Path:
-        return self.paths.socket_path.parent / "global-heavy.lock"
+    def _global_heavy_slot_paths(self, env: Optional[Dict[str, str]] = None) -> List[Path]:
+        return global_heavy_slot_paths(env)
 
     def status_payload(self) -> Dict[str, Any]:
         with self.lock:
@@ -1371,7 +1547,9 @@ class DaemonState:
                 "repoHash": self.paths.repo_hash,
                 "socketPath": str(self.paths.socket_path),
                 "stateDir": str(self.paths.state_dir),
-                "globalHeavySlotPath": str(self._global_heavy_slot_path()),
+                "globalHeavySlotPaths": [str(path) for path in self._global_heavy_slot_paths()],
+                "globalHeavySlotCount": configured_global_heavy_slots(),
+                "liveAppLockPath": str(live_app_lock_path()),
                 "activeJobsByLane": active_by_lane,
                 "runningJobs": running_jobs,
                 "queuedJobs": queued_jobs,
@@ -1432,7 +1610,7 @@ class DaemonState:
             raise ConductorError("request args must be an object")
         args = dict(raw_args)
         operation = str(request.get("operation") or "")
-        if operation == "app" and args.get("subcommand") in {"stop", "relaunch"}:
+        if operation == "app" and args.get("subcommand") in {"stop", "launch-existing", "relaunch"}:
             # Derived exclusively by supersession below, never accepted from a client.
             args.pop("guardDelayedLaunch", None)
         normalized_request = dict(request)
@@ -1724,56 +1902,94 @@ class DaemonState:
 
     def _acquire_global_heavy_slot(self, ticket: str) -> Optional[Any]:
         wait_start = now()
-        lock_path = self._global_heavy_slot_path()
-        lock_path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
-        lock_file = lock_path.open("a+", encoding="utf-8")
-        did_log_wait = False
-        while True:
-            with self.condition:
-                job = self.jobs.get(ticket)
-                if not job or job.state != "running":
-                    lock_file.close()
-                    return None
-                if job.cancel_requested:
-                    job.state = "canceled"
-                    job.exit_code = 130
-                    job.result_summary = "canceled before global heavy slot"
-                    job.finished_at = now()
-                    self._append_system_line_locked(job, "job canceled before global heavy slot\n")
-                    self.condition.notify_all()
-                    lock_file.close()
-                    return None
-            try:
-                fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-                break
-            except BlockingIOError:
-                with self.condition:
-                    job = self.jobs.get(ticket)
-                    if job and job.state == "running" and not did_log_wait:
-                        job.global_heavy_slot_path = str(lock_path)
-                        self._append_system_line_locked(job, f"waiting for global heavy slot: {lock_path}\n")
-                        self.condition.notify_all()
-                        did_log_wait = True
-                time.sleep(GLOBAL_HEAVY_SLOT_POLL_SECONDS)
-            except OSError as exc:
-                if exc.errno == errno.EINTR:
-                    continue
-                lock_file.close()
-                raise
-        waited = now() - wait_start
         with self.condition:
             job = self.jobs.get(ticket)
-            if job and job.state == "running":
-                job.global_heavy_slot_wait_seconds = waited
-                job.global_heavy_slot_path = str(lock_path)
-                self._append_system_line_locked(job, f"acquired global heavy slot after {format_duration(waited)}\n")
-                self.condition.notify_all()
-        return lock_file
+            env = dict(job.env) if job else {}
+        lock_paths = self._global_heavy_slot_paths(env)
+        ensure_private_dir(machine_lock_dir())
+        lock_files = [(path, path.open("a+", encoding="utf-8")) for path in lock_paths]
+        did_log_wait = False
+        selected_path: Optional[Path] = None
+        selected_file: Optional[Any] = None
+        try:
+            while True:
+                with self.condition:
+                    job = self.jobs.get(ticket)
+                    if not job or job.state != "running":
+                        return None
+                    if job.cancel_requested:
+                        job.state = "canceled"
+                        job.exit_code = 130
+                        job.result_summary = "canceled before global heavy slot"
+                        job.finished_at = now()
+                        self._append_system_line_locked(job, "job canceled before global heavy slot\n")
+                        self.condition.notify_all()
+                        return None
+                for lock_path, lock_file in lock_files:
+                    try:
+                        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                        selected_path = lock_path
+                        selected_file = lock_file
+                        break
+                    except BlockingIOError:
+                        continue
+                    except OSError as exc:
+                        if exc.errno == errno.EINTR:
+                            continue
+                        raise
+                if selected_file is not None and selected_path is not None:
+                    break
+                holders = [format_display_lock_holder(read_display_lock_metadata(path)) for path, _file in lock_files]
+                with self.condition:
+                    job = self.jobs.get(ticket)
+                    if job and job.state == "running":
+                        job.global_heavy_slot_path = ",".join(str(path) for path, _file in lock_files)
+                        job.global_heavy_slot_holder = "; ".join(holders)
+                        if not did_log_wait:
+                            self._append_system_line_locked(
+                                job,
+                                f"waiting for global heavy slot ({len(lock_files)} configured): {job.global_heavy_slot_path}; {job.global_heavy_slot_holder}\n",
+                            )
+                            self.condition.notify_all()
+                            did_log_wait = True
+                time.sleep(GLOBAL_HEAVY_SLOT_POLL_SECONDS)
+            waited = now() - wait_start
+            with self.condition:
+                job = self.jobs.get(ticket)
+                if job and job.state == "running":
+                    metadata = display_lock_metadata(
+                        lock_kind="global-heavy",
+                        ticket=job.ticket,
+                        operation=job.operation,
+                        operation_label=operation_display_name(job.operation, job.args),
+                        repo_root=self.paths.repo_root,
+                        repo_hash=self.paths.repo_hash,
+                    )
+                    write_display_lock_metadata(selected_file, metadata)
+                    job.global_heavy_slot_wait_seconds = waited
+                    job.global_heavy_slot_path = str(selected_path)
+                    job.global_heavy_slot_holder = None
+                    self._append_system_line_locked(
+                        job,
+                        f"acquired global heavy slot {selected_path} after {format_duration(waited)}\n",
+                    )
+                    self.condition.notify_all()
+            return selected_file
+        finally:
+            for _path, lock_file in lock_files:
+                if lock_file is selected_file:
+                    continue
+                with contextlib.suppress(OSError):
+                    lock_file.close()
 
     @staticmethod
     def _release_global_heavy_slot(lock_file: Optional[Any]) -> None:
         if lock_file is None:
             return
+        with contextlib.suppress(OSError):
+            lock_file.seek(0)
+            lock_file.truncate()
+            lock_file.flush()
         with contextlib.suppress(OSError):
             fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
         with contextlib.suppress(OSError):
@@ -1803,6 +2019,7 @@ class DaemonState:
                     self._append_system_line_locked(job, "job canceled before process start\n")
                     return
             argv, _lanes, cwd, env, effective_timeout = self.registry.prepare(request)
+            env["REPOPROMPT_CONDUCTOR_JOB_TICKET"] = job.ticket
             if operation_requires_global_heavy_slot(job.operation, job.args):
                 global_heavy_slot = self._acquire_global_heavy_slot(job.ticket)
                 if global_heavy_slot is None:
@@ -3166,6 +3383,10 @@ def render_job(job: Dict[str, Any], output_mode: str = "summary", include_tail: 
         timing_parts.append(f"global-wait={format_duration(float(job.get('globalHeavySlotWaitSeconds')))}")
     if timing_parts:
         print(f"timing:    {', '.join(timing_parts)}")
+    if job.get("globalHeavySlotPath") and job.get("state") == "running":
+        print(f"heavy:     {job.get('globalHeavySlotPath')}")
+    if job.get("globalHeavySlotHolder") and job.get("state") == "running":
+        print(f"holder:    {job.get('globalHeavySlotHolder')}")
     print(f"log:       {job.get('logPath')}")
     if job.get("startedAtISO"):
         print(f"started:   {job.get('startedAtISO')}")
@@ -3626,45 +3847,131 @@ def terminate_debug_app_processes() -> List[str]:
     return [str(pid) for pid in terminate_matching_processes(debug_app_executable_path())]
 
 
-def operation_app_status(repo_root: Path) -> int:
-    bundle = debug_app_bundle_path()
-    print("RepoPrompt CE debug app status")
-    print(f"  Debug app bundle: {bundle}")
-    print("  Running matching debug app PIDs: ", end="")
+def debug_app_provenance_path(bundle: Path) -> Path:
+    return bundle / DEBUG_APP_PROVENANCE_RELATIVE_PATH
+
+
+def read_debug_app_provenance(bundle: Path) -> Optional[Dict[str, Any]]:
+    path = debug_app_provenance_path(bundle)
     try:
-        pids = find_debug_app_pids()
-    except ProcessIdentityError as exc:
-        print("unknown")
-        print(f"ERROR: could not safely identify the debug app process: {exc}")
-        return 1
-    print(", ".join(pids) if pids else "none")
-    print(f"  Bundle exists: {'yes' if bundle.exists() else 'no'}")
-    if bundle.exists():
-        # Keep the signing/storage probes aligned with Scripts/run.sh launch diagnostics.
-        codesign = subprocess.run(["codesign", "-dv", str(bundle)], text=True, capture_output=True)
-        details = (codesign.stdout or "") + (codesign.stderr or "")
-        team = "<missing>"
-        authorities: List[str] = []
-        for line in details.splitlines():
-            if line.startswith("TeamIdentifier="):
-                team = line.split("=", 1)[1] or "<missing>"
-            elif line.startswith("Authority="):
-                authorities.append(line.split("=", 1)[1])
-        print(f"  Signing team: {team}")
-        print(f"  Signing authorities: {', '.join(authorities) if authorities else '<none/ad-hoc>'}")
-        plist = bundle / "Contents" / "Info.plist"
-        marker = subprocess.run(
-            ["plutil", "-extract", "RepoPromptDebugSecureStorageBackend", "raw", "-o", "-", str(plist)],
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def git_metadata_value(repo_root: Path, args: Sequence[str]) -> Optional[str]:
+    try:
+        completed = subprocess.run(
+            ["git", "-C", str(repo_root), *args],
             text=True,
             capture_output=True,
+            timeout=2.0,
         )
-        print(f"  Debug secure storage marker: {marker.stdout.strip() if marker.returncode == 0 and marker.stdout.strip() else '<missing>'}")
-    status_script = repo_root / "Scripts" / "install_debug_cli.sh"
-    code, _stdout, _stderr = run_operation_command("debug CLI status", [str(status_script), "status"], repo_root, allow_exit_codes={0, 1})
-    return 0 if code in {0, 1} else code
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if completed.returncode != 0:
+        return None
+    value = completed.stdout.strip()
+    return value or None
 
 
-def operation_app_stop(repo_root: Path, args: Dict[str, Any]) -> int:
+def current_repo_commit(repo_root: Path) -> Optional[str]:
+    return git_metadata_value(repo_root, ["rev-parse", "HEAD"])
+
+
+def provenance_report_lines(repo_root: Path, bundle: Path) -> List[str]:
+    provenance = read_debug_app_provenance(bundle)
+    if not provenance:
+        return ["  Bundle provenance: <missing>"]
+    lines = ["  Bundle provenance:"]
+    repo = str(provenance.get("repoRoot") or "<unknown>")
+    worktree = str(provenance.get("worktreePath") or repo)
+    branch = str(provenance.get("branch") or "<unknown>")
+    commit = str(provenance.get("commit") or "<unknown>")
+    dirty = provenance.get("dirty")
+    built_at = str(provenance.get("buildTimeISO") or "<unknown>")
+    lines.append(f"    repo: {repo}")
+    lines.append(f"    worktree: {worktree}")
+    lines.append(f"    branch: {branch}")
+    lines.append(f"    commit: {commit[:12] if commit != '<unknown>' else commit}")
+    lines.append(f"    dirty at build: {dirty if isinstance(dirty, bool) else '<unknown>'}")
+    lines.append(f"    built: {built_at}")
+    flags: List[str] = []
+    try:
+        current_root = str(repo_root.resolve())
+        built_root = str(Path(repo).resolve(strict=False))
+        if built_root != current_root:
+            flags.append("foreign worktree")
+    except OSError:
+        flags.append("foreign worktree unknown")
+    current_commit = current_repo_commit(repo_root)
+    if current_commit and commit not in {"<unknown>", current_commit}:
+        flags.append("stale commit")
+    if flags:
+        lines.append(f"    WARNING: {'; '.join(flags)}")
+    return lines
+
+
+def print_debug_app_provenance(repo_root: Path, bundle: Path) -> None:
+    for line in provenance_report_lines(repo_root, bundle):
+        print(line, flush=True)
+
+
+def report_launch_bundle_details(repo_root: Path, bundle: Path) -> int:
+    print(f"Launch app path: {bundle}", flush=True)
+    print_debug_app_provenance(repo_root, bundle)
+    codesign = subprocess.run(["codesign", "-dv", str(bundle)], text=True, capture_output=True)
+    details = (codesign.stdout or "") + (codesign.stderr or "")
+    team = "<missing>"
+    authorities: List[str] = []
+    for line in details.splitlines():
+        if line.startswith("TeamIdentifier="):
+            team = line.split("=", 1)[1] or "<missing>"
+        elif line.startswith("Authority="):
+            authorities.append(line.split("=", 1)[1])
+    marker = subprocess.run(
+        ["plutil", "-extract", "RepoPromptDebugSecureStorageBackend", "raw", "-o", "-", str(bundle / "Contents" / "Info.plist")],
+        text=True,
+        capture_output=True,
+    )
+    storage = marker.stdout.strip() if marker.returncode == 0 and marker.stdout.strip() else "<missing>"
+    print(f"Launch app team: {team}", flush=True)
+    print(f"Launch app signing authorities: {', '.join(authorities) if authorities else '<none/ad-hoc>'}", flush=True)
+    print(f"Launch app debug secure storage marker: {storage}", flush=True)
+    if storage != "keychain":
+        print("WARNING: Debug secure storage is in-memory this run; secrets and permission changes won't persist.", flush=True)
+    elif not team or team in {"<missing>", "not set"}:
+        print("WARNING: Launching a keychain-marked debug app without a team identifier; runtime will fall back to in-memory secure storage.", flush=True)
+    return 0
+
+
+def wait_for_no_debug_app_process(timeout: float = 5.0) -> bool:
+    deadline = now() + timeout
+    while now() <= deadline:
+        pids = find_debug_app_pids()
+        if not pids:
+            return True
+        time.sleep(APP_STOP_POLL_SECONDS)
+    return False
+
+
+def wait_for_debug_app_process(timeout: float = STARTUP_TIMEOUT_SECONDS) -> List[str]:
+    deadline = now() + timeout
+    while now() <= deadline:
+        pids = find_debug_app_pids()
+        if pids:
+            return pids
+        time.sleep(APP_STOP_POLL_SECONDS)
+    return []
+
+
+def guard_delayed_debug_app_launch() -> int:
+    print("Guarding against a delayed RepoPrompt CE debug app launch from superseded app work.", flush=True)
+    return _operation_app_stop_unlocked(Path.cwd(), {"guardDelayedLaunch": True})
+
+
+def _operation_app_stop_unlocked(_repo_root: Path, args: Dict[str, Any]) -> int:
     guard_delayed_launch = bool(args.get("guardDelayedLaunch"))
     required_quiet = APP_STOP_DELAYED_LAUNCH_GUARD_SECONDS if guard_delayed_launch else APP_STOP_QUIET_SECONDS
     confirmation_timeout = APP_STOP_DELAYED_LAUNCH_CONFIRM_TIMEOUT_SECONDS if guard_delayed_launch else APP_STOP_CONFIRM_TIMEOUT_SECONDS
@@ -3701,6 +4008,223 @@ def operation_app_stop(repo_root: Path, args: Dict[str, Any]) -> int:
             print("ERROR: timed out confirming that RepoPrompt remained stopped.", flush=True)
             return 1
         time.sleep(APP_STOP_POLL_SECONDS)
+
+
+def staged_debug_app_parent(live_bundle: Optional[Path] = None) -> Path:
+    bundle = live_bundle or debug_app_bundle_path()
+    token = f"{int(now() * 1000)}-{os.getpid()}-{uuid.uuid4().hex[:8]}"
+    return bundle.parent / ".staging" / token
+
+
+def cleanup_staged_debug_bundle(staged_bundle: Optional[Path]) -> None:
+    if staged_bundle is None:
+        return
+    parent = staged_bundle.parent
+    with contextlib.suppress(FileNotFoundError):
+        shutil.rmtree(parent)
+
+
+def package_debug_app_under_heavy(repo_root: Path, operation_label: str) -> Tuple[int, Optional[Path]]:
+    live_bundle = debug_app_bundle_path()
+    staging_parent = staged_debug_app_parent(live_bundle)
+    staged_bundle = staging_parent / live_bundle.name
+    metadata = display_lock_metadata(
+        lock_kind="global-heavy",
+        ticket=os.environ.get("REPOPROMPT_CONDUCTOR_JOB_TICKET"),
+        operation=operation_label,
+        operation_label=operation_label,
+        repo_root=repo_root,
+        repo_hash=None,
+    )
+    env = os.environ.copy()
+    env["REPOPROMPT_DEBUG_APP_BUNDLE"] = str(staged_bundle)
+    try:
+        with machine_heavy_slot(metadata, env, "global heavy slot for debug package"):
+            code, _stdout, _stderr = run_operation_command(
+                "package staged debug app",
+                [str(repo_root / "Scripts" / "package_app.sh"), "debug"],
+                repo_root,
+                env=env,
+            )
+        if code != 0:
+            cleanup_staged_debug_bundle(staged_bundle)
+            return code, None
+        executable = staged_bundle / "Contents" / "MacOS" / "RepoPrompt"
+        if not executable.is_file() or not os.access(executable, os.X_OK):
+            print(f"ERROR: staged debug app is not launchable: {staged_bundle}", flush=True)
+            cleanup_staged_debug_bundle(staged_bundle)
+            return 1, None
+        print(f"Staged debug app bundle: {staged_bundle}", flush=True)
+        return 0, staged_bundle
+    except BaseException:
+        cleanup_staged_debug_bundle(staged_bundle)
+        raise
+
+
+def swap_staged_debug_bundle_into_place(staged_bundle: Path, live_bundle: Path) -> bool:
+    if not live_bundle.exists():
+        staged_bundle.rename(live_bundle)
+        return True
+    if sys.platform != "darwin":
+        return False
+    try:
+        renamex_np = ctypes.CDLL(None, use_errno=True).renamex_np
+    except AttributeError:
+        return False
+    renamex_np.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_uint]
+    renamex_np.restype = ctypes.c_int
+    rename_swap = 0x00000002
+    result = renamex_np(os.fsencode(staged_bundle), os.fsencode(live_bundle), rename_swap)
+    if result == 0:
+        return True
+    return False
+
+
+def activate_staged_debug_bundle(staged_bundle: Path, live_bundle: Optional[Path] = None) -> None:
+    live = live_bundle or debug_app_bundle_path()
+    if not staged_bundle.exists():
+        raise ConductorError(f"staged debug app bundle is missing: {staged_bundle}")
+    executable = staged_bundle / "Contents" / "MacOS" / "RepoPrompt"
+    if not executable.is_file() or not os.access(executable, os.X_OK):
+        raise ConductorError(f"staged debug app bundle is not launchable: {staged_bundle}")
+    live.parent.mkdir(parents=True, exist_ok=True)
+    backup = live.parent / f".{live.name}.previous.{os.getpid()}.{uuid.uuid4().hex[:8]}"
+    moved_existing = False
+    try:
+        if not swap_staged_debug_bundle_into_place(staged_bundle, live):
+            if live.exists():
+                live.rename(backup)
+                moved_existing = True
+            staged_bundle.rename(live)
+    except BaseException:
+        if moved_existing and not live.exists() and backup.exists():
+            with contextlib.suppress(OSError):
+                backup.rename(live)
+        raise
+    finally:
+        if backup.exists():
+            shutil.rmtree(backup, ignore_errors=True)
+        staging_parent = staged_bundle.parent
+        if staging_parent.exists():
+            shutil.rmtree(staging_parent, ignore_errors=True)
+    print(f"Activated staged debug app bundle: {live}", flush=True)
+
+
+def operation_app_launch_existing(repo_root: Path, args: Dict[str, Any]) -> int:
+    bundle = debug_app_bundle_path()
+    staged_value = args.get("stagedBundle")
+    staged_bundle = Path(str(staged_value)) if staged_value else None
+    activated = False
+    executable = bundle / "Contents" / "MacOS" / "RepoPrompt"
+    if staged_bundle is None and (not bundle.exists() or not executable.is_file() or not os.access(executable, os.X_OK)):
+        print(f"ERROR: existing debug app bundle is not launchable: {bundle}", flush=True)
+        print("Build it first with './conductor build' or './conductor run'.", flush=True)
+        return 1
+    metadata = display_lock_metadata(
+        lock_kind="live-app",
+        ticket=os.environ.get("REPOPROMPT_CONDUCTOR_JOB_TICKET"),
+        operation="app launch-existing" if staged_bundle is None else "app activate-staged-and-launch",
+        operation_label="app launch-existing" if staged_bundle is None else "app activate staged and launch",
+        repo_root=repo_root,
+        repo_hash=None,
+    )
+    try:
+        with machine_exclusive_lock(live_app_lock_path(), metadata, "live-app lock"):
+            if staged_bundle is None:
+                report_launch_bundle_details(repo_root, bundle)
+            print("Stopping existing RepoPrompt CE debug app instance", flush=True)
+            stop_code = _operation_app_stop_unlocked(repo_root, {"guardDelayedLaunch": bool(args.get("guardDelayedLaunch"))})
+            if stop_code != 0:
+                return stop_code
+            if staged_bundle is not None:
+                activate_staged_debug_bundle(staged_bundle, bundle)
+                activated = True
+                report_launch_bundle_details(repo_root, bundle)
+            app_args = [str(arg) for arg in args.get("appArgs") or []]
+            argv = ["open", "-n", str(bundle)]
+            if app_args:
+                argv.extend(["--args", *app_args])
+            code, _stdout, _stderr = run_operation_command("launch existing debug app", argv, repo_root)
+            if code != 0:
+                return code
+            try:
+                launched_pids = wait_for_debug_app_process()
+            except ProcessIdentityError as exc:
+                print(f"ERROR: could not safely identify the launched RepoPrompt CE debug app process: {exc}", flush=True)
+                return 1
+            if not launched_pids:
+                print("ERROR: launch request returned, but no matching RepoPrompt CE debug app process appeared within 10 seconds.", flush=True)
+                _operation_app_stop_unlocked(repo_root, {"guardDelayedLaunch": True})
+                return 1
+            print(f"Observed launched RepoPrompt CE debug PID(s): {', '.join(launched_pids)}", flush=True)
+        return 0
+    finally:
+        if staged_bundle is not None and not activated:
+            cleanup_staged_debug_bundle(staged_bundle)
+
+
+def operation_debug_app_build_then_launch(repo_root: Path, args: Dict[str, Any]) -> int:
+    package_code, staged_bundle = package_debug_app_under_heavy(repo_root, "debug app build/package")
+    if package_code != 0 or staged_bundle is None:
+        print("Package failed; no live bundle or stop/launch lifecycle action was performed.", flush=True)
+        return package_code or 1
+    launch_args = dict(args)
+    launch_args.setdefault("appArgs", [])
+    launch_args["stagedBundle"] = str(staged_bundle)
+    return operation_app_launch_existing(repo_root, launch_args)
+
+
+def operation_app_status(repo_root: Path) -> int:
+    bundle = debug_app_bundle_path()
+    print("RepoPrompt CE debug app status")
+    print(f"  Debug app bundle: {bundle}")
+    print("  Running matching debug app PIDs: ", end="")
+    try:
+        pids = find_debug_app_pids()
+    except ProcessIdentityError as exc:
+        print("unknown")
+        print(f"ERROR: could not safely identify the debug app process: {exc}")
+        return 1
+    print(", ".join(pids) if pids else "none")
+    print(f"  Bundle exists: {'yes' if bundle.exists() else 'no'}")
+    if bundle.exists():
+        # Keep the signing/storage probes aligned with Scripts/run.sh launch diagnostics.
+        codesign = subprocess.run(["codesign", "-dv", str(bundle)], text=True, capture_output=True)
+        details = (codesign.stdout or "") + (codesign.stderr or "")
+        team = "<missing>"
+        authorities: List[str] = []
+        for line in details.splitlines():
+            if line.startswith("TeamIdentifier="):
+                team = line.split("=", 1)[1] or "<missing>"
+            elif line.startswith("Authority="):
+                authorities.append(line.split("=", 1)[1])
+        print(f"  Signing team: {team}")
+        print(f"  Signing authorities: {', '.join(authorities) if authorities else '<none/ad-hoc>'}")
+        plist = bundle / "Contents" / "Info.plist"
+        marker = subprocess.run(
+            ["plutil", "-extract", "RepoPromptDebugSecureStorageBackend", "raw", "-o", "-", str(plist)],
+            text=True,
+            capture_output=True,
+        )
+        print(f"  Debug secure storage marker: {marker.stdout.strip() if marker.returncode == 0 and marker.stdout.strip() else '<missing>'}")
+        for line in provenance_report_lines(repo_root, bundle):
+            print(line)
+    status_script = repo_root / "Scripts" / "install_debug_cli.sh"
+    code, _stdout, _stderr = run_operation_command("debug CLI status", [str(status_script), "status"], repo_root, allow_exit_codes={0, 1})
+    return 0 if code in {0, 1} else code
+
+
+def operation_app_stop(repo_root: Path, args: Dict[str, Any]) -> int:
+    metadata = display_lock_metadata(
+        lock_kind="live-app",
+        ticket=os.environ.get("REPOPROMPT_CONDUCTOR_JOB_TICKET"),
+        operation="app stop",
+        operation_label="app stop",
+        repo_root=repo_root,
+        repo_hash=None,
+    )
+    with machine_exclusive_lock(live_app_lock_path(), metadata, "live-app lock"):
+        return _operation_app_stop_unlocked(repo_root, args)
 
 
 def operation_swift_build_all(repo_root: Path) -> int:
@@ -3743,7 +4267,7 @@ def operation_smoke(repo_root: Path, args: Dict[str, Any]) -> int:
 
     launched = bool(args.get("launch"))
     if launched:
-        code, _stdout, _stderr = run_operation_command("launch debug app", [str(repo_root / "Scripts" / "run.sh")], repo_root, env=env)
+        code = operation_debug_app_build_then_launch(repo_root, {"appArgs": []})
         if code != 0:
             return code
 
@@ -3978,6 +4502,10 @@ def run_operation_runner(payload_json: str) -> int:
         return operation_app_stop(repo_root, args)
     if kind == "app_status":
         return operation_app_status(repo_root)
+    if kind == "app_launch_existing":
+        return operation_app_launch_existing(repo_root, args)
+    if kind == "debug_app_build_then_launch":
+        return operation_debug_app_build_then_launch(repo_root, args)
     if kind == "smoke":
         return operation_smoke(repo_root, args)
     if kind == "diagnostics_agent_mode_on":
@@ -4105,15 +4633,15 @@ def handle_real_operation(paths: Paths, operation: str, argv: List[str]) -> int:
         app_args = rest[1:] if rest and rest[0] == "--" else rest
         args["appArgs"] = app_args
     elif operation == "app":
-        if not rest or rest[0] not in {"status", "stop", "relaunch"}:
-            raise ConductorError("usage: ./conductor app status|stop|relaunch [-- <app args...>]")
+        if not rest or rest[0] not in {"status", "stop", "launch-existing", "relaunch"}:
+            raise ConductorError("usage: ./conductor app status|stop|launch-existing|relaunch [-- <app args...>]")
         args["subcommand"] = rest[0]
         trailing = rest[1:]
         if args["subcommand"] in {"status", "stop"} and trailing:
             raise ConductorError(f"app {args['subcommand']} does not accept application arguments")
-        if args["subcommand"] == "relaunch":
+        if args["subcommand"] in {"launch-existing", "relaunch"}:
             if trailing and trailing[0] != "--":
-                raise ConductorError("app relaunch application arguments must follow '--'")
+                raise ConductorError(f"app {args['subcommand']} application arguments must follow '--'")
             args["appArgs"] = trailing[1:] if trailing else []
     elif operation == "smoke":
         parser = argparse.ArgumentParser(prog="conductor smoke")
@@ -4175,19 +4703,21 @@ def handle_real_operation(paths: Paths, operation: str, argv: List[str]) -> int:
 
 def main(argv: List[str]) -> int:
     repo_root = resolve_repo_root()
-    paths = compute_paths(repo_root)
-    ensure_state_dirs(paths)
 
+    if argv and argv[0] == "__operation_runner":
+        if len(argv) != 2:
+            raise ConductorError("__operation_runner requires one JSON payload argument")
+        return run_operation_runner(argv[1])
     if argv and argv[0] == "__daemon":
         parser = argparse.ArgumentParser(prog="conductor.py __daemon")
         parser.add_argument("--repo-root", required=True)
         ns = parser.parse_args(argv[1:])
         daemon_paths = compute_paths(Path(ns.repo_root))
+        ensure_state_dirs(daemon_paths)
         return run_daemon(daemon_paths)
-    if argv and argv[0] == "__operation_runner":
-        if len(argv) != 2:
-            raise ConductorError("__operation_runner requires one JSON payload argument")
-        return run_operation_runner(argv[1])
+
+    paths = compute_paths(repo_root)
+    ensure_state_dirs(paths)
 
     if not argv or argv[0] in {"-h", "--help"}:
         print(HELP)

--- a/Scripts/package_app.sh
+++ b/Scripts/package_app.sh
@@ -335,6 +335,51 @@ run cp -R "$SPARKLE_FRAMEWORK" "$APP_BUNDLE/Contents/Frameworks/"
 run install_name_tool -add_rpath @executable_path/../Frameworks "$APP_BUNDLE/Contents/MacOS/$APP_NAME" 2>/dev/null || true
 run "$CONTROL_PLANE_SCRIPTS_DIR/validate_app_architectures.sh" "$APP_BUNDLE" "$ARCHITECTURE_POLICY" "Pre-sign packaged app"
 
+if (( ! IS_RELEASE )); then
+    phase "Writing debug bundle provenance"
+    ROOT_DIR_FOR_PROVENANCE="$ROOT_DIR" APP_BUNDLE_FOR_PROVENANCE="$APP_BUNDLE" python3 - <<'PY'
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+import json
+import os
+import subprocess
+import time
+
+root = Path(os.environ["ROOT_DIR_FOR_PROVENANCE"]).resolve()
+bundle = Path(os.environ["APP_BUNDLE_FOR_PROVENANCE"])
+
+def git(args: list[str]) -> str | None:
+    try:
+        completed = subprocess.run(["git", "-C", str(root), *args], text=True, capture_output=True, timeout=5)
+    except Exception:
+        return None
+    if completed.returncode != 0:
+        return None
+    value = completed.stdout.strip()
+    return value or None
+
+status = git(["status", "--porcelain"])
+now = time.time()
+payload = {
+    "version": 1,
+    "repoRoot": str(root),
+    "worktreePath": str(root),
+    "worktreeName": root.name,
+    "branch": git(["rev-parse", "--abbrev-ref", "HEAD"]),
+    "commit": git(["rev-parse", "HEAD"]),
+    "dirty": bool(status),
+    "buildTimeEpoch": now,
+    "buildTimeISO": datetime.fromtimestamp(now, timezone.utc).astimezone().isoformat(timespec="seconds"),
+}
+path = bundle / "Contents" / "Resources" / "RepoPromptDebugProvenance.json"
+path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+print(f"Debug bundle provenance: {path}")
+PY
+    run plutil -lint "$APP_BUNDLE/Contents/Resources/RepoPromptDebugProvenance.json"
+fi
+
 phase "Signing app bundle"
 sign_path(){
     local path="$1"

--- a/Scripts/run.sh
+++ b/Scripts/run.sh
@@ -1,116 +1,21 @@
 #!/usr/bin/env bash
 set -euo pipefail
 [[ "${VERBOSE:-0}" == "1" || "${VERBOSE:-0}" == "true" ]] && set -x
-START_TIME="$(date +%s)"
-PHASE_START="$START_TIME"
-phase(){
-    local now elapsed total
-    now="$(date +%s)"
-    elapsed=$((now - PHASE_START))
-    total=$((now - START_TIME))
-    printf '\n==> [%s] %s (previous: %ss, total: %ss)\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*" "$elapsed" "$total"
-    PHASE_START="$now"
-}
-run(){ printf '+ '; printf '%q ' "$@"; printf '\n'; "$@"; }
-DELAYED_LAUNCH_GUARD_SECONDS=12
-find_debug_app_pids(){ python3 "$PROCESS_HELPER" list --executable "$APP_EXECUTABLE"; }
-terminate_debug_app_processes(){ python3 "$PROCESS_HELPER" terminate --executable "$APP_EXECUTABLE"; }
-wait_for_no_debug_app_process(){
-    local deadline pids
-    deadline=$(( $(date +%s) + 5 ))
-    while (( $(date +%s) <= deadline )); do
-        if ! pids="$(find_debug_app_pids)"; then
-            echo "ERROR: could not safely identify the RepoPrompt CE debug app process."
-            return 1
-        fi
-        [[ -z "$pids" ]] && return 0
-        sleep 0.2
-    done
-    return 1
-}
-wait_for_debug_app_process(){
-    local deadline pids
-    deadline=$(( $(date +%s) + 10 ))
-    while (( $(date +%s) <= deadline )); do
-        if ! pids="$(find_debug_app_pids)"; then
-            echo "ERROR: could not safely identify the launched RepoPrompt CE debug app process." >&2
-            return 1
-        fi
-        if [[ -n "$pids" ]]; then
-            printf '%s\n' "$pids"
-            return 0
-        fi
-        sleep 0.2
-    done
-    return 1
-}
-guard_delayed_debug_app_launch(){
-    local deadline pids terminated_pids
-    deadline=$(( $(date +%s) + DELAYED_LAUNCH_GUARD_SECONDS ))
-    while (( $(date +%s) <= deadline )); do
-        if ! pids="$(find_debug_app_pids)"; then
-            echo "ERROR: could not safely identify a delayed RepoPrompt CE debug app process."
-            return 1
-        fi
-        if [[ -n "$pids" ]]; then
-            printf 'Observed delayed RepoPrompt CE debug PID(s): %s\n' "$(printf '%s' "$pids" | paste -sd ', ' -)"
-            if ! terminated_pids="$(terminate_debug_app_processes)"; then
-                echo "ERROR: refused to signal a delayed process without validated debug app identity."
-                return 1
-            fi
-        fi
-        sleep 0.2
-    done
-    if ! wait_for_no_debug_app_process; then
-        echo "ERROR: RepoPrompt CE debug app remained running after delayed-launch guard."
-        return 1
-    fi
-    echo "Delayed launch guard confirmed RepoPrompt CE debug app stopped."
-}
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-PROCESS_HELPER="$ROOT_DIR/Scripts/debug_app_process.py"
-DEBUG_APP_ROOT="${REPOPROMPT_DEBUG_APP_ROOT:-$HOME/Library/Application Support/RepoPrompt CE/DebugApps}"
-APP_BUNDLE="${REPOPROMPT_DEBUG_APP_BUNDLE:-$DEBUG_APP_ROOT/RepoPrompt.app}"
-APP_EXECUTABLE="$APP_BUNDLE/Contents/MacOS/RepoPrompt"
-export REPOPROMPT_DEBUG_APP_BUNDLE="$APP_BUNDLE"
-phase "Packaging debug app"
-run "$ROOT_DIR/Scripts/package_app.sh" debug
-phase "Checking packaged app signing"
-SIGNING_DETAILS="$(codesign -dv "$APP_BUNDLE" 2>&1 || true)"
-TEAM_ID="$(printf '%s\n' "$SIGNING_DETAILS" | awk -F= '/^TeamIdentifier=/{print $2; exit}')"
-AUTHORITIES="$(printf '%s\n' "$SIGNING_DETAILS" | awk -F= '/^Authority=/{print $2}' | paste -sd ', ' -)"
-DEBUG_STORAGE_BACKEND_MARKER="$(plutil -extract RepoPromptDebugSecureStorageBackend raw -o - "$APP_BUNDLE/Contents/Info.plist" 2>/dev/null || true)"
-printf 'Launch app path: %s\n' "$APP_BUNDLE"
-printf 'Launch app team: %s\n' "${TEAM_ID:-<missing>}"
-printf 'Launch app signing authorities: %s\n' "${AUTHORITIES:-<none/ad-hoc>}"
-printf 'Launch app debug secure storage marker: %s\n' "${DEBUG_STORAGE_BACKEND_MARKER:-<missing>}"
-if [[ "$DEBUG_STORAGE_BACKEND_MARKER" != "keychain" ]]; then
-    echo "WARNING: Debug secure storage is in-memory this run; secrets and permission changes won't persist (set SIGN_IDENTITY=\"Apple Development: ...\" for Keychain)."
-elif [[ -z "$TEAM_ID" || "$TEAM_ID" == "not set" ]]; then
-    echo "WARNING: Launching a keychain-marked debug app without a team identifier; runtime will fall back to in-memory secure storage."
-fi
-phase "Stopping existing RepoPrompt CE debug app instance"
-if ! TERMINATED_PIDS="$(terminate_debug_app_processes)"; then
-    echo "ERROR: refused to stop a process without validated RepoPrompt CE debug app identity."
-    exit 1
-fi
-phase "Waiting for existing RepoPrompt CE debug app process to exit"
-if ! wait_for_no_debug_app_process; then
-    echo "ERROR: existing RepoPrompt CE debug app process did not exit within 5 seconds; refusing to open another instance."
-    exit 1
-fi
-echo "RepoPrompt CE debug app stop confirmed."
-if [[ "${REPOPROMPT_GUARD_DELAYED_LAUNCH:-0}" == "1" ]]; then
-    phase "Guarding against a delayed RepoPrompt CE debug app launch from superseded app work"
-    guard_delayed_debug_app_launch
-fi
-phase "Launching $APP_BUNDLE"
-if (( $# > 0 )); then run open -n "$APP_BUNDLE" --args "$@"; else run open -n "$APP_BUNDLE"; fi
-phase "Confirming launched RepoPrompt CE debug app process"
-if ! LAUNCHED_PIDS="$(wait_for_debug_app_process)"; then
-    echo "ERROR: launch request returned, but no matching RepoPrompt CE debug app process appeared within 10 seconds."
-    phase "Guarding against a delayed RepoPrompt CE debug app launch after launch confirmation failure"
-    guard_delayed_debug_app_launch || true
-    exit 1
-fi
-printf 'Observed launched RepoPrompt CE debug PID(s): %s\n' "$(printf '%s' "$LAUNCHED_PIDS" | paste -sd ', ' -)"
+PAYLOAD="$(ROOT_DIR="$ROOT_DIR" python3 - "$@" <<'PY'
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+print(json.dumps({
+    "kind": "debug_app_build_then_launch",
+    "repoRoot": os.environ["ROOT_DIR"],
+    "args": {"appArgs": sys.argv[1:]},
+}))
+PY
+)"
+
+exec python3 -u "$ROOT_DIR/Scripts/conductor.py" __operation_runner "$PAYLOAD"

--- a/Scripts/test_conductor_lifecycle.py
+++ b/Scripts/test_conductor_lifecycle.py
@@ -77,7 +77,7 @@ class LifecycleTestCase(unittest.TestCase):
 
 class LifecycleQueueTests(LifecycleTestCase):
     def test_protocol_version_bump_replaces_older_daemons(self) -> None:
-        self.assertEqual(conductor.PROTOCOL_VERSION, 9)
+        self.assertEqual(conductor.PROTOCOL_VERSION, 10)
 
     def test_ensure_daemon_stops_and_replaces_idle_protocol_3_daemon(self) -> None:
         tmp, state = self.make_state()
@@ -184,23 +184,27 @@ class LifecycleQueueTests(LifecycleTestCase):
         self.assertEqual(enqueue.call_args.args[2], {"subcommand": "relaunch", "appArgs": ["--demo"]})
         with self.assertRaises(conductor.ConductorError):
             conductor.handle_real_operation(state.paths, "app", ["relaunch", "--demo"])
+        with mock.patch.object(conductor, "enqueue_and_maybe_wait", return_value=0) as enqueue_launch:
+            code = conductor.handle_real_operation(state.paths, "app", ["launch-existing", "--", "--demo"])
+        self.assertEqual(code, 0)
+        self.assertEqual(enqueue_launch.call_args.args[2], {"subcommand": "launch-existing", "appArgs": ["--demo"]})
 
-    def test_app_relaunch_delegates_run_script_with_run_lanes_and_timeout(self) -> None:
+    def test_app_relaunch_delegates_split_internal_runner_with_live_lane_and_timeout(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             registry = conductor.OperationRegistry(Path(tmp))
             argv, lanes, _cwd, _env, timeout = registry.prepare(
                 {"operation": "app", "args": {"subcommand": "relaunch", "appArgs": ["--demo"]}}
             )
-            _guarded_argv, _guarded_lanes, _guarded_cwd, guarded_env, _guarded_timeout = registry.prepare(
-                {"operation": "app", "args": {"subcommand": "relaunch", "appArgs": [], "guardDelayedLaunch": True}}
+            launch_existing_argv, launch_existing_lanes, _cwd, _env, _timeout = registry.prepare(
+                {"operation": "app", "args": {"subcommand": "launch-existing", "appArgs": ["--demo"]}}
             )
 
-        self.assertEqual(Path(argv[-2]).name, "run.sh")
-        self.assertEqual(Path(argv[-2]).parent.name, "Scripts")
-        self.assertEqual(argv[-1], "--demo")
-        self.assertEqual(lanes, ["build", "debugArtifact", "liveApp"])
+        self.assertIn("__operation_runner", argv)
+        self.assertIn("debug_app_build_then_launch", argv[-1])
+        self.assertEqual(lanes, ["liveApp"])
         self.assertEqual(timeout, conductor.MEDIUM_TIMEOUT_SECONDS)
-        self.assertEqual(guarded_env["REPOPROMPT_GUARD_DELAYED_LAUNCH"], "1")
+        self.assertIn("app_launch_existing", launch_existing_argv[-1])
+        self.assertEqual(launch_existing_lanes, ["liveApp"])
         self.assertEqual(conductor.operation_display_name("app", {"subcommand": "relaunch"}), "app relaunch")
 
     def test_guardrails_delegates_aggregator_without_lanes(self) -> None:
@@ -336,7 +340,9 @@ class LifecycleQueueTests(LifecycleTestCase):
         fake_process.stdout = fake_stdout
         fake_process.wait.return_value = 0
 
-        with mock.patch.object(conductor.subprocess, "Popen", return_value=fake_process) as popen, mock.patch.object(
+        with mock.patch.object(conductor, "operation_requires_global_heavy_slot", return_value=False), mock.patch.object(
+            conductor.subprocess, "Popen", return_value=fake_process
+        ) as popen, mock.patch.object(
             conductor, "process_table_snapshot", return_value={os.getpid(): (os.getppid(), "fixture-start")}
         ), mock.patch.object(state, "_schedule_locked"), mock.patch.object(state, "_refresh_output_summary"):
             state._run_job(job.ticket)
@@ -362,7 +368,9 @@ class LifecycleQueueTests(LifecycleTestCase):
             subprocess.TimeoutExpired(["fixture"], conductor.KILL_GRACE_SECONDS),
         ]
 
-        with mock.patch.object(conductor.subprocess, "Popen", return_value=fake_process), mock.patch.object(
+        with mock.patch.object(conductor, "operation_requires_global_heavy_slot", return_value=False), mock.patch.object(
+            conductor.subprocess, "Popen", return_value=fake_process
+        ), mock.patch.object(
             conductor, "process_table_snapshot", return_value={os.getpid(): (os.getppid(), "fixture-start")}
         ), mock.patch.object(state, "_terminate_process_group_locked"), mock.patch.object(
             state, "_kill_process_group_locked"
@@ -483,28 +491,29 @@ class LifecycleQueueTests(LifecycleTestCase):
                     os.kill(grandchild_pid, signal.SIGKILL)
 
         self.addCleanup(cleanup_grandchild)
-        worker = threading.Thread(target=state._run_job, args=(job.ticket,), daemon=True)
-        worker.start()
-        deadline = time.time() + 5.0
-        while time.time() < deadline:
+        with mock.patch.object(conductor, "operation_requires_global_heavy_slot", return_value=False):
+            worker = threading.Thread(target=state._run_job, args=(job.ticket,), daemon=True)
+            worker.start()
+            deadline = time.time() + 5.0
+            while time.time() < deadline:
+                with state.condition:
+                    process_pgid = job.process_pgid
+                if grandchild_ready_path.exists() and process_pgid:
+                    break
+                time.sleep(0.05)
+            self.assertTrue(grandchild_ready_path.exists())
+            grandchild_pid = int(grandchild_pid_path.read_text(encoding="utf-8"))
             with state.condition:
-                process_pgid = job.process_pgid
-            if grandchild_ready_path.exists() and process_pgid:
-                break
-            time.sleep(0.05)
-        self.assertTrue(grandchild_ready_path.exists())
-        grandchild_pid = int(grandchild_pid_path.read_text(encoding="utf-8"))
-        with state.condition:
-            self.assertEqual(os.getpgid(grandchild_pid), job.process_pgid)
+                self.assertEqual(os.getpgid(grandchild_pid), job.process_pgid)
 
-        with mock.patch.multiple(
-            conductor,
-            TERMINATE_GRACE_SECONDS=0.2,
-            KILL_GRACE_SECONDS=1.0,
-            PROCESS_TREE_POLL_SECONDS=0.02,
-        ):
-            state.job_cancel(job.ticket, None)
-        worker.join(timeout=5.0)
+            with mock.patch.multiple(
+                conductor,
+                TERMINATE_GRACE_SECONDS=0.2,
+                KILL_GRACE_SECONDS=1.0,
+                PROCESS_TREE_POLL_SECONDS=0.02,
+            ):
+                state.job_cancel(job.ticket, None)
+            worker.join(timeout=5.0)
 
         self.assertFalse(worker.is_alive())
         self.assertEqual(job.state, "canceled")
@@ -536,6 +545,7 @@ class LifecycleQueueTests(LifecycleTestCase):
 
             tmp = tempfile.TemporaryDirectory()
             root = Path(tmp.name)
+            conductor.machine_lock_dir = lambda: root / "machine-locks"
             jobs_dir = root / "jobs"
             scripts_dir = root / "Scripts"
             jobs_dir.mkdir()
@@ -823,7 +833,10 @@ class LifecycleQueueTests(LifecycleTestCase):
         state_a = self.make_state_for_global_slot(root, "daemon-a", shared_socket_parent)
         state_b = self.make_state_for_global_slot(root, "daemon-b", shared_socket_parent)
 
-        with mock.patch.object(conductor, "GLOBAL_HEAVY_SLOT_POLL_SECONDS", 0.01):
+        lock_root = root / "machine-locks"
+        with mock.patch.object(conductor, "GLOBAL_HEAVY_SLOT_POLL_SECONDS", 0.01), mock.patch.object(
+            conductor, "machine_lock_dir", return_value=lock_root
+        ):
             payload_a = state_a.enqueue(
                 {
                     "operation": "fake-sleep",
@@ -841,8 +854,8 @@ class LifecycleQueueTests(LifecycleTestCase):
 
         self.assertEqual(job_a.state, "completed", job_a.result_summary)
         self.assertEqual(job_b.state, "completed", job_b.result_summary)
-        self.assertEqual(job_a.global_heavy_slot_path, str(shared_socket_parent / "global-heavy.lock"))
-        self.assertEqual(job_b.global_heavy_slot_path, str(shared_socket_parent / "global-heavy.lock"))
+        self.assertEqual(job_a.global_heavy_slot_path, str(lock_root / "global-heavy-0.lock"))
+        self.assertEqual(job_b.global_heavy_slot_path, str(lock_root / "global-heavy-0.lock"))
         self.assertIsNotNone(job_a.process_started_at)
         self.assertIsNotNone(job_a.process_finished_at)
         self.assertIsNotNone(job_b.process_started_at)
@@ -859,13 +872,16 @@ class LifecycleQueueTests(LifecycleTestCase):
         shared_socket_parent = root / "shared"
         shared_socket_parent.mkdir()
         state = self.make_state_for_global_slot(root, "daemon", shared_socket_parent)
-        lock_path = shared_socket_parent / "global-heavy.lock"
-        lock_file = lock_path.open("a+", encoding="utf-8")
-        self.addCleanup(lock_file.close)
-        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
-        self.addCleanup(lambda: fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN))
-
-        with mock.patch.object(conductor, "GLOBAL_HEAVY_SLOT_POLL_SECONDS", 0.01):
+        lock_root = root / "machine-locks"
+        with mock.patch.object(conductor, "GLOBAL_HEAVY_SLOT_POLL_SECONDS", 0.01), mock.patch.object(
+            conductor, "machine_lock_dir", return_value=lock_root
+        ):
+            lock_path = lock_root / "global-heavy-0.lock"
+            lock_root.mkdir(mode=0o700, parents=True, exist_ok=True)
+            lock_file = lock_path.open("a+", encoding="utf-8")
+            self.addCleanup(lock_file.close)
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+            self.addCleanup(lambda: fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN))
             payload = state.enqueue(
                 {
                     "operation": "fake-sleep",
@@ -892,6 +908,112 @@ class LifecycleQueueTests(LifecycleTestCase):
         self.assertIsNone(job.process_pid)
         self.assertIsNone(job.process_started_at)
         self.assertIn("job canceled before global heavy slot", "".join(job.tail))
+
+    def test_socket_parent_does_not_shard_global_heavy_slots(self) -> None:
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        root = Path(tmp.name)
+        state_a = self.make_state_for_global_slot(root, "daemon-a", root / "socket-a")
+        state_b = self.make_state_for_global_slot(root, "daemon-b", root / "socket-b")
+        lock_root = root / "machine-locks"
+
+        with mock.patch.object(conductor, "machine_lock_dir", return_value=lock_root):
+            self.assertEqual(state_a._global_heavy_slot_paths(), [lock_root / "global-heavy-0.lock"])
+            self.assertEqual(state_b._global_heavy_slot_paths(), [lock_root / "global-heavy-0.lock"])
+
+    def test_configured_global_heavy_slots_allow_two_cross_daemon_builds(self) -> None:
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        root = Path(tmp.name)
+        state_a = self.make_state_for_global_slot(root, "daemon-a", root / "socket-a")
+        state_b = self.make_state_for_global_slot(root, "daemon-b", root / "socket-b")
+        lock_root = root / "machine-locks"
+
+        with mock.patch.object(conductor, "machine_lock_dir", return_value=lock_root), mock.patch.dict(
+            os.environ,
+            {"REPOPROMPT_DEV_HEAVY_SLOTS": "2"},
+        ):
+            payload_a = state_a.enqueue(
+                {
+                    "operation": "fake-sleep",
+                    "args": {"seconds": 0.25, "lanes": ["build"], "message": "daemon-a"},
+                    "env": {"REPOPROMPT_DEV_HEAVY_SLOTS": "2"},
+                }
+            )
+            payload_b = state_b.enqueue(
+                {
+                    "operation": "fake-sleep",
+                    "args": {"seconds": 0.25, "lanes": ["build"], "message": "daemon-b"},
+                    "env": {"REPOPROMPT_DEV_HEAVY_SLOTS": "2"},
+                }
+            )
+            job_a = self.wait_for_terminal_job(state_a, payload_a["ticket"])
+            job_b = self.wait_for_terminal_job(state_b, payload_b["ticket"])
+
+        self.assertEqual(job_a.state, "completed", job_a.result_summary)
+        self.assertEqual(job_b.state, "completed", job_b.result_summary)
+        self.assertNotEqual(job_a.global_heavy_slot_path, job_b.global_heavy_slot_path)
+        latest_start = max(job_a.process_started_at or 0, job_b.process_started_at or 0)
+        earliest_finish = min(job_a.process_finished_at or 0, job_b.process_finished_at or 0)
+        self.assertLess(latest_start, earliest_finish)
+
+    def test_live_app_lock_serializes_across_processes_without_gui_launch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            lock_root = root / "machine-locks"
+            events = root / "events.log"
+            ready = root / "ready-a"
+            child = textwrap.dedent(
+                """\
+                import sys, time
+                from pathlib import Path
+                sys.path.insert(0, sys.argv[1])
+                import conductor
+                conductor.MACHINE_LOCK_POLL_SECONDS = 0.01
+                conductor.machine_lock_dir = lambda: Path(sys.argv[2])
+                label = sys.argv[3]
+                events = Path(sys.argv[4])
+                ready = Path(sys.argv[5]) if sys.argv[5] != '-' else None
+                metadata = conductor.display_lock_metadata(
+                    lock_kind='live-app',
+                    ticket=label,
+                    operation='test-live-app',
+                    operation_label='test live app',
+                    repo_root=Path(sys.argv[2]),
+                )
+                with conductor.machine_exclusive_lock(conductor.live_app_lock_path(), metadata, 'live-app lock'):
+                    with events.open('a', encoding='utf-8') as handle:
+                        handle.write(f'start {label} {time.time()}\\n')
+                    if ready is not None:
+                        ready.write_text('ready', encoding='utf-8')
+                    time.sleep(0.25)
+                    with events.open('a', encoding='utf-8') as handle:
+                        handle.write(f'end {label} {time.time()}\\n')
+                """
+            )
+            proc_a = subprocess.Popen(
+                [sys.executable, "-c", child, str(SCRIPT_DIR), str(lock_root), "a", str(events), str(ready)],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            deadline = time.monotonic() + 2.0
+            while time.monotonic() < deadline and not ready.exists():
+                time.sleep(0.01)
+            self.assertTrue(ready.exists())
+            proc_b = subprocess.Popen(
+                [sys.executable, "-c", child, str(SCRIPT_DIR), str(lock_root), "b", str(events), "-"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            stdout_a, stderr_a = proc_a.communicate(timeout=5)
+            stdout_b, stderr_b = proc_b.communicate(timeout=5)
+            self.assertEqual(proc_a.returncode, 0, stdout_a + stderr_a)
+            self.assertEqual(proc_b.returncode, 0, stdout_b + stderr_b)
+            rows = events.read_text(encoding="utf-8").splitlines()
+
+        self.assertEqual([row.split()[0:2] for row in rows], [["start", "a"], ["end", "a"], ["start", "b"], ["end", "b"]])
 
 
 class XCTestStallWatchdogTests(LifecycleTestCase):
@@ -1068,7 +1190,9 @@ class XCTestStallWatchdogTests(LifecycleTestCase):
         def prepare(_request: dict) -> tuple[list[str], list[str], Path, dict[str, str], float]:
             return argv, ["build"], root, os.environ.copy(), 5.0
 
-        with mock.patch.object(state.registry, "prepare", side_effect=prepare), mock.patch.object(
+        with mock.patch.object(conductor, "operation_requires_global_heavy_slot", return_value=False), mock.patch.object(
+            state.registry, "prepare", side_effect=prepare
+        ), mock.patch.object(
             conductor.os, "openpty", side_effect=tracking_openpty
         ), mock.patch.object(
             state,
@@ -1107,7 +1231,9 @@ class XCTestStallWatchdogTests(LifecycleTestCase):
             opened_fds.extend(pair)
             return pair
 
-        with mock.patch.object(conductor.os, "openpty", side_effect=tracking_openpty), mock.patch.object(
+        with mock.patch.object(conductor, "operation_requires_global_heavy_slot", return_value=False), mock.patch.object(
+            conductor.os, "openpty", side_effect=tracking_openpty
+        ), mock.patch.object(
             conductor.subprocess,
             "Popen",
             side_effect=OSError("fixture launch failure"),
@@ -1149,7 +1275,9 @@ class XCTestStallWatchdogTests(LifecycleTestCase):
 
                     fake_process.wait.side_effect = cancel_then_exit
 
-                with mock.patch.object(state, "_create_process_output_transport", return_value=transport), mock.patch.object(
+                with mock.patch.object(conductor, "operation_requires_global_heavy_slot", return_value=False), mock.patch.object(
+                    state, "_create_process_output_transport", return_value=transport
+                ), mock.patch.object(
                     conductor.subprocess,
                     "Popen",
                     return_value=fake_process,
@@ -1406,10 +1534,27 @@ class XCTestStallWatchdogTests(LifecycleTestCase):
                 for pid in candidates
             }
 
-        with mock.patch.object(state.registry, "prepare", side_effect=prepare), mock.patch.object(
+        fake_tree = [
+            {
+                "pid": os.getpid(),
+                "ppid": os.getppid(),
+                "depth": 0,
+                "startToken": "fixture-start",
+                "command": str(fake_xctest),
+            }
+        ]
+        with mock.patch.object(conductor, "operation_requires_global_heavy_slot", return_value=False), mock.patch.object(
+            state.registry, "prepare", side_effect=prepare
+        ), mock.patch.object(
             state,
             "_capture_xctest_stall_diagnostics",
             side_effect=lambda _job, diagnostic, _identity: diagnostic,
+        ), mock.patch.object(
+            state,
+            "_xctest_process_snapshot_locked",
+            return_value=((os.getpid(), "fixture-start"), fake_tree),
+        ), mock.patch.object(state, "_signal_process_identity", return_value=True), mock.patch.object(
+            state, "_wait_for_xctest_progress_after_probe", return_value=True
         ), mock.patch.object(conductor, "process_command_snapshot", side_effect=controlled_commands):
             state._run_job(job.ticket)
 
@@ -1720,7 +1865,9 @@ class ProcessTreeCancellationTests(LifecycleTestCase):
         def prepare(_request: dict) -> tuple[list[str], list[str], Path, dict[str, str], float]:
             return argv, ["build"], root, os.environ.copy(), float(job.timeout or 30.0)
 
-        with mock.patch.object(state.registry, "prepare", side_effect=prepare), mock.patch.multiple(
+        with mock.patch.object(conductor, "operation_requires_global_heavy_slot", return_value=False), mock.patch.object(
+            state.registry, "prepare", side_effect=prepare
+        ), mock.patch.multiple(
             conductor,
             TERMINATE_GRACE_SECONDS=0.2,
             KILL_GRACE_SECONDS=1.0,
@@ -1880,13 +2027,15 @@ class SmokeOperationTests(unittest.TestCase):
 
             with mock.patch.object(conductor, "debug_app_bundle_path", return_value=app), mock.patch.object(
                 conductor, "require_debug_cli"
-            ) as fallback, mock.patch.object(conductor, "run_operation_command", side_effect=record_command):
+            ) as fallback, mock.patch.object(
+                conductor, "operation_debug_app_build_then_launch", return_value=0
+            ) as launch, mock.patch.object(conductor, "run_operation_command", side_effect=record_command):
                 code = conductor.operation_smoke(Path(tmp), {"launch": True, "windowId": 1, "workspace": "fixture"})
 
         self.assertEqual(code, 0)
         fallback.assert_not_called()
-        self.assertEqual(calls[0][0], "launch debug app")
-        for name, argv in calls[1:]:
+        launch.assert_called_once_with(Path(tmp), {"appArgs": []})
+        for name, argv in calls:
             self.assertEqual(argv[0], str(helper.resolve()), name)
 
     def test_embedded_helper_resolution_rejects_symlink_escape(self) -> None:
@@ -1927,6 +2076,7 @@ class RunScriptTransitionTests(unittest.TestCase):
             scripts.mkdir()
             run_script = scripts / "run.sh"
             shutil.copy2(SCRIPT_DIR / "run.sh", run_script)
+            shutil.copy2(SCRIPT_DIR / "conductor.py", scripts / "conductor.py")
             run_script.chmod(0o755)
             package_script = scripts / "package_app.sh"
             package_script.write_text("#!/usr/bin/env bash\necho package failed\nexit 23\n", encoding="utf-8")
@@ -1934,7 +2084,23 @@ class RunScriptTransitionTests(unittest.TestCase):
             marker = root / "process-helper-invoked"
             helper = scripts / "debug_app_process.py"
             helper.write_text(
-                "from pathlib import Path\nimport os\nPath(os.environ['PROCESS_HELPER_MARKER']).write_text('invoked')\n",
+                textwrap.dedent(
+                    """\
+                    from pathlib import Path
+                    import os
+
+                    class ProcessIdentityError(Exception):
+                        pass
+
+                    def matching_processes(_executable):
+                        Path(os.environ['PROCESS_HELPER_MARKER']).write_text('invoked')
+                        return []
+
+                    def terminate_matching_processes(_executable):
+                        Path(os.environ['PROCESS_HELPER_MARKER']).write_text('invoked')
+                        return []
+                    """
+                ),
                 encoding="utf-8",
             )
             env = os.environ.copy()
@@ -1942,36 +2108,37 @@ class RunScriptTransitionTests(unittest.TestCase):
                 {
                     "PROCESS_HELPER_MARKER": str(marker),
                     "REPOPROMPT_GUARD_DELAYED_LAUNCH": "1",
+                    "REPOPROMPT_DEV_HEAVY_SLOTS": "8",
                 }
             )
 
-            result = subprocess.run(["bash", str(run_script)], env=env, text=True, capture_output=True, timeout=2)
+            result = subprocess.run(["bash", str(run_script)], env=env, text=True, capture_output=True, timeout=10)
             helper_invoked = marker.exists()
 
-        self.assertEqual(result.returncode, 23)
-        self.assertIn("Packaging debug app", result.stdout)
+        self.assertEqual(result.returncode, 23, result.stdout + result.stderr)
+        self.assertIn("package staged debug app", result.stdout)
         self.assertNotIn("Stopping existing RepoPrompt CE debug app instance", result.stdout)
         self.assertFalse(helper_invoked)
 
-    def test_successful_relaunch_uses_debug_executable_for_stop_and_readiness(self) -> None:
+    def test_direct_run_packages_before_waiting_for_live_lock_then_activates(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             scripts = root / "Scripts"
             scripts.mkdir()
             run_script = scripts / "run.sh"
             shutil.copy2(SCRIPT_DIR / "run.sh", run_script)
+            shutil.copy2(SCRIPT_DIR / "conductor.py", scripts / "conductor.py")
             run_script.chmod(0o755)
             event_log = root / "events.log"
             launched_marker = root / "launched"
             app_bundle = root / "DebugApps" / "RepoPrompt.app"
-            app_executable = app_bundle / "Contents" / "MacOS" / "RepoPrompt"
             package_script = scripts / "package_app.sh"
             package_script.write_text(
                 textwrap.dedent(
                     """\
                     #!/usr/bin/env bash
                     set -e
-                    echo package >> "$EVENT_LOG"
+                    echo package:$REPOPROMPT_DEBUG_APP_BUNDLE >> "$EVENT_LOG"
                     mkdir -p "$REPOPROMPT_DEBUG_APP_BUNDLE/Contents/MacOS"
                     printf binary > "$REPOPROMPT_DEBUG_APP_BUNDLE/Contents/MacOS/RepoPrompt"
                     chmod +x "$REPOPROMPT_DEBUG_APP_BUNDLE/Contents/MacOS/RepoPrompt"
@@ -1985,16 +2152,25 @@ class RunScriptTransitionTests(unittest.TestCase):
                 textwrap.dedent(
                     """\
                     import os
-                    import sys
                     from pathlib import Path
 
-                    operation = sys.argv[1]
-                    executable = sys.argv[sys.argv.index("--executable") + 1]
-                    state = "launched" if Path(os.environ["LAUNCHED_MARKER"]).exists() else "stopped"
-                    with Path(os.environ["EVENT_LOG"]).open("a", encoding="utf-8") as handle:
-                        handle.write(f"{operation}:{state}:{executable}\\n")
-                    if operation == "list" and state == "launched":
-                        print("4242")
+                    class ProcessIdentityError(Exception):
+                        pass
+
+                    def _state():
+                        return "launched" if Path(os.environ["LAUNCHED_MARKER"]).exists() else "stopped"
+
+                    def _log(operation, executable):
+                        with Path(os.environ["EVENT_LOG"]).open("a", encoding="utf-8") as handle:
+                            handle.write(f"{operation}:{_state()}:{executable}\\n")
+
+                    def matching_processes(executable):
+                        _log("list", executable)
+                        return [4242] if _state() == "launched" else []
+
+                    def terminate_matching_processes(executable):
+                        _log("terminate", executable)
+                        return []
                     """
                 ),
                 encoding="utf-8",
@@ -2016,27 +2192,213 @@ class RunScriptTransitionTests(unittest.TestCase):
                     "EVENT_LOG": str(event_log),
                     "LAUNCHED_MARKER": str(launched_marker),
                     "REPOPROMPT_DEBUG_APP_BUNDLE": str(app_bundle),
+                    "REPOPROMPT_DEV_HEAVY_SLOTS": "8",
+                }
+            )
+            lock_ready = threading.Event()
+            release_lock = threading.Event()
+
+            def hold_live_lock() -> None:
+                metadata = conductor.display_lock_metadata(
+                    lock_kind="live-app",
+                    ticket="direct-run-test",
+                    operation="test-live-lock",
+                    operation_label="test live lock",
+                    repo_root=root,
+                )
+                with conductor.machine_exclusive_lock(conductor.live_app_lock_path(), metadata, "live-app lock"):
+                    with event_log.open("a", encoding="utf-8") as handle:
+                        handle.write("lock-start\n")
+                    lock_ready.set()
+                    release_lock.wait(timeout=5.0)
+                    with event_log.open("a", encoding="utf-8") as handle:
+                        handle.write("lock-release\n")
+
+            holder = threading.Thread(target=hold_live_lock, daemon=True)
+            holder.start()
+            self.assertTrue(lock_ready.wait(timeout=2.0))
+            proc = subprocess.Popen(["bash", str(run_script)], env=env, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            deadline = time.monotonic() + 5.0
+            while time.monotonic() < deadline:
+                rows = event_log.read_text(encoding="utf-8").splitlines() if event_log.exists() else []
+                if any(row.startswith("package:") for row in rows):
+                    break
+                time.sleep(0.02)
+            rows_before_release = event_log.read_text(encoding="utf-8").splitlines()
+            self.assertTrue(any(row.startswith("package:") for row in rows_before_release), rows_before_release)
+            self.assertFalse(any(row.startswith(("list:", "terminate:")) for row in rows_before_release), rows_before_release)
+            release_lock.set()
+            stdout, stderr = proc.communicate(timeout=10)
+            holder.join(timeout=2.0)
+            rows = event_log.read_text(encoding="utf-8").splitlines()
+
+        self.assertEqual(proc.returncode, 0, stdout + stderr)
+        self.assertLess(
+            rows.index("lock-release"),
+            next(index for index, row in enumerate(rows) if row.startswith(("list:", "terminate:"))),
+        )
+        self.assertIn("Activated staged debug app bundle", stdout)
+
+    def test_successful_relaunch_uses_debug_executable_for_stop_and_readiness(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            scripts = root / "Scripts"
+            scripts.mkdir()
+            run_script = scripts / "run.sh"
+            shutil.copy2(SCRIPT_DIR / "run.sh", run_script)
+            shutil.copy2(SCRIPT_DIR / "conductor.py", scripts / "conductor.py")
+            run_script.chmod(0o755)
+            event_log = root / "events.log"
+            launched_marker = root / "launched"
+            app_bundle = root / "DebugApps" / "RepoPrompt.app"
+            app_executable = app_bundle / "Contents" / "MacOS" / "RepoPrompt"
+            package_script = scripts / "package_app.sh"
+            package_script.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/usr/bin/env bash
+                    set -e
+                    echo package:$REPOPROMPT_DEBUG_APP_BUNDLE >> "$EVENT_LOG"
+                    mkdir -p "$REPOPROMPT_DEBUG_APP_BUNDLE/Contents/MacOS"
+                    printf binary > "$REPOPROMPT_DEBUG_APP_BUNDLE/Contents/MacOS/RepoPrompt"
+                    chmod +x "$REPOPROMPT_DEBUG_APP_BUNDLE/Contents/MacOS/RepoPrompt"
+                    """
+                ),
+                encoding="utf-8",
+            )
+            package_script.chmod(0o755)
+            helper = scripts / "debug_app_process.py"
+            helper.write_text(
+                textwrap.dedent(
+                    """\
+                    import os
+                    from pathlib import Path
+
+                    class ProcessIdentityError(Exception):
+                        pass
+
+                    def _state():
+                        return "launched" if Path(os.environ["LAUNCHED_MARKER"]).exists() else "stopped"
+
+                    def _log(operation, executable):
+                        with Path(os.environ["EVENT_LOG"]).open("a", encoding="utf-8") as handle:
+                            handle.write(f"{operation}:{_state()}:{executable}\\n")
+
+                    def matching_processes(executable):
+                        _log("list", executable)
+                        return [4242] if _state() == "launched" else []
+
+                    def terminate_matching_processes(executable):
+                        _log("terminate", executable)
+                        return []
+                    """
+                ),
+                encoding="utf-8",
+            )
+            bin_dir = root / "bin"
+            bin_dir.mkdir()
+            (bin_dir / "codesign").write_text("#!/usr/bin/env bash\necho TeamIdentifier=TEST >&2\n", encoding="utf-8")
+            (bin_dir / "plutil").write_text("#!/usr/bin/env bash\necho memory\n", encoding="utf-8")
+            (bin_dir / "open").write_text(
+                "#!/usr/bin/env bash\necho open >> \"$EVENT_LOG\"\ntouch \"$LAUNCHED_MARKER\"\n",
+                encoding="utf-8",
+            )
+            for command in ["codesign", "plutil", "open"]:
+                (bin_dir / command).chmod(0o755)
+            env = os.environ.copy()
+            env.update(
+                {
+                    "PATH": f"{bin_dir}:{env.get('PATH', '')}",
+                    "EVENT_LOG": str(event_log),
+                    "LAUNCHED_MARKER": str(launched_marker),
+                    "REPOPROMPT_DEBUG_APP_BUNDLE": str(app_bundle),
+                    "REPOPROMPT_DEV_HEAVY_SLOTS": "8",
                 }
             )
 
-            result = subprocess.run(["bash", str(run_script), "--demo"], env=env, text=True, capture_output=True, timeout=5)
+            result = subprocess.run(["bash", str(run_script), "--demo"], env=env, text=True, capture_output=True, timeout=20)
             events = event_log.read_text(encoding="utf-8").splitlines()
+            activated_executable_exists = app_executable.exists()
 
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         expected_suffix = f":{app_executable}"
-        self.assertEqual(events[0], "package")
-        self.assertEqual(events[1], f"terminate:stopped:{app_executable}")
-        self.assertEqual(events[2], f"list:stopped:{app_executable}")
-        self.assertEqual(events[3], "open")
-        self.assertEqual(events[4], f"list:launched:{app_executable}")
+        self.assertTrue(events[0].startswith("package:"), events)
+        self.assertIn("/.staging/", events[0])
+        self.assertNotIn(str(app_bundle), events[0])
+        open_index = events.index("open")
+        self.assertGreater(open_index, 1, events)
+        self.assertTrue(all(event == f"list:stopped:{app_executable}" for event in events[1:open_index]), events)
+        self.assertEqual(events[open_index + 1], f"list:launched:{app_executable}")
         self.assertTrue(all(event.endswith(expected_suffix) for event in events if event.startswith(("list:", "terminate:"))))
         source = (SCRIPT_DIR / "run.sh").read_text(encoding="utf-8")
+        self.assertTrue(activated_executable_exists)
+        self.assertIn("Activated staged debug app bundle", result.stdout)
         self.assertIn("Observed launched RepoPrompt CE debug PID(s): 4242", result.stdout)
         self.assertNotIn("pgrep", source)
         self.assertNotIn("pkill", source)
 
 
 class AppStatusIdentityTests(unittest.TestCase):
+    def make_bundle(self, bundle: Path, marker: str = "binary") -> None:
+        executable = bundle / "Contents" / "MacOS" / "RepoPrompt"
+        executable.parent.mkdir(parents=True, exist_ok=True)
+        executable.write_text(marker, encoding="utf-8")
+        executable.chmod(0o755)
+
+    def test_activate_staged_debug_bundle_replaces_live_and_cleans_staging(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            live = root / "DebugApps" / "RepoPrompt.app"
+            staged = root / "DebugApps" / ".staging" / "token" / "RepoPrompt.app"
+            self.make_bundle(live, "old")
+            self.make_bundle(staged, "new")
+
+            conductor.activate_staged_debug_bundle(staged, live)
+
+            self.assertEqual((live / "Contents" / "MacOS" / "RepoPrompt").read_text(encoding="utf-8"), "new")
+            self.assertFalse(staged.parent.exists())
+            self.assertFalse(any(live.parent.glob(".RepoPrompt.app.previous.*")))
+
+    def test_staged_launch_stop_failure_preserves_live_and_cleans_staging(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            live = root / "DebugApps" / "RepoPrompt.app"
+            staged = root / "DebugApps" / ".staging" / "token" / "RepoPrompt.app"
+            self.make_bundle(live, "old")
+            self.make_bundle(staged, "new")
+            with mock.patch.dict(os.environ, {"REPOPROMPT_DEBUG_APP_BUNDLE": str(live)}), mock.patch.object(
+                conductor, "_operation_app_stop_unlocked", return_value=7
+            ), mock.patch.object(conductor, "run_operation_command") as run, contextlib.redirect_stdout(io.StringIO()):
+                code = conductor.operation_app_launch_existing(root, {"stagedBundle": str(staged), "appArgs": []})
+
+            self.assertEqual(code, 7)
+            self.assertEqual((live / "Contents" / "MacOS" / "RepoPrompt").read_text(encoding="utf-8"), "old")
+            self.assertFalse(staged.parent.exists())
+            run.assert_not_called()
+
+    def test_launch_existing_requires_bundle_and_does_not_build(self) -> None:
+        output = io.StringIO()
+        with tempfile.TemporaryDirectory() as tmp, mock.patch.dict(
+            os.environ,
+            {"REPOPROMPT_DEBUG_APP_BUNDLE": str(Path(tmp) / "missing" / "RepoPrompt.app")},
+        ), mock.patch.object(conductor, "package_debug_app_under_heavy") as package, contextlib.redirect_stdout(output):
+            code = conductor.operation_app_launch_existing(Path(tmp), {"appArgs": []})
+
+        self.assertEqual(code, 1)
+        package.assert_not_called()
+        self.assertIn("existing debug app bundle is not launchable", output.getvalue())
+
+    def test_split_build_failure_performs_no_lifecycle_action(self) -> None:
+        with mock.patch.object(conductor, "package_debug_app_under_heavy", return_value=(23, None)) as package, mock.patch.object(
+            conductor, "operation_app_launch_existing"
+        ) as launch, contextlib.redirect_stdout(io.StringIO()) as output:
+            code = conductor.operation_debug_app_build_then_launch(Path("/tmp/repo"), {"appArgs": []})
+
+        self.assertEqual(code, 23)
+        package.assert_called_once()
+        launch.assert_not_called()
+        self.assertIn("no live bundle or stop/launch lifecycle action", output.getvalue())
+
     def test_status_treats_missing_debug_executable_as_not_installed(self) -> None:
         output = io.StringIO()
         with tempfile.TemporaryDirectory() as tmp, mock.patch.dict(

--- a/Scripts/test_debug_app_process.py
+++ b/Scripts/test_debug_app_process.py
@@ -133,7 +133,8 @@ class LifecycleSurfaceTests(unittest.TestCase):
         for source in [run_script, conductor_script, finder_launcher]:
             self.assertNotIn("pgrep -x RepoPrompt", source)
             self.assertNotIn("pkill -x RepoPrompt", source)
-        self.assertIn('python3 "$PROCESS_HELPER" list --executable "$APP_EXECUTABLE"', run_script)
+        self.assertIn('exec python3 -u "$ROOT_DIR/Scripts/conductor.py" __operation_runner "$PAYLOAD"', run_script)
+        self.assertIn('"kind": "debug_app_build_then_launch"', run_script)
         self.assertIn("terminate_matching_processes(debug_app_executable_path())", conductor_script)
         self.assertIn("safe coordinated launcher requires Python 3", finder_launcher)
         self.assertIn("No uncoordinated fallback is provided", finder_launcher)


### PR DESCRIPTION
## Summary
- make global heavy-job admission observable and configurable while keeping the safe default at one slot
- separate build/package admission from singleton debug-app lifecycle locking
- stage debug bundles and activate them atomically under a cross-daemon live-app lock
- add an explicit launch-existing path and packaged artifact provenance
- route direct `make run` through the same safe lifecycle helper

## Why
Developers working in multiple worktrees could wait indefinitely for an opaque machine-wide heavy slot, and `dev-run` held that slot through non-heavy app lifecycle work. The shared debug bundle also needed stronger protection against concurrent packaging and launch operations.

## Validation
- commit and push contribution preflights passed
- focused 13-test concurrency/staging/lifecycle suite passed
- full conductor lifecycle suite: 80 tests passed
- conductor process-helper, preflight, CI-runner, output, and benchmark suites passed
- one unchanged local-production installer fixture timed out under an external saturated PR-463 build, then passed immediately in isolation
- no visible app launch, relaunch, or stop performed

## Scope
This keeps the debug GUI/runtime singleton. It does not implement independent simultaneous debug-app instances and does not resolve watcher/codemap churn tracked in #465.
