### PR TITLE
Harden Sentry privacy and release metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -216,6 +216,7 @@ jobs:
           REPOPROMPT_RELEASE_SOURCE_ROOT: ${{ github.workspace }}/release-source
           REPOPROMPT_APPROVED_SOURCE_ROOT: ${{ github.workspace }}/approved-source
           REPOPROMPT_REQUIRE_HEAD_MATCH: 0
+          REPOPROMPT_ENABLE_SENTRY: "1"
           SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
           NOTARYTOOL_KEY_ID: ${{ secrets.NOTARYTOOL_KEY_ID }}
           NOTARYTOOL_ISSUER_ID: ${{ secrets.NOTARYTOOL_ISSUER_ID }}
@@ -225,6 +226,7 @@ jobs:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           REPOPROMPT_SENTRY_ORG: ${{ vars.SENTRY_ORG }}
           REPOPROMPT_SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
+          REPOPROMPT_SENTRY_DEPLOY_ENVIRONMENT: production
         run: ./trusted-control-plane/Scripts/release.sh publish-staged
 
       - name: Remove ephemeral keychain

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -213,7 +213,8 @@ prepare_sentry_release() {
     if lookup_error="$(sentry-cli --org "$REPOPROMPT_SENTRY_ORG" releases info "$SENTRY_RELEASE_NAME" 2>&1 >/dev/null)"; then
         :
     else
-        local normalized_lookup_error="${lookup_error,,}"
+        local normalized_lookup_error
+        normalized_lookup_error="$(printf '%s' "$lookup_error" | tr '[:upper:]' '[:lower:]')"
         if [[ "$normalized_lookup_error" == *"release not found"* ||
             "$normalized_lookup_error" == *"release does not exist"* ||
             "$normalized_lookup_error" =~ (^|[^0-9])404([^0-9]|$) ]]; then

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -209,10 +209,20 @@ prepare_sentry_release() {
     local source_repository="${SOURCE_GITHUB_REPOSITORY:-$GITHUB_REPOSITORY}"
     [[ -n "$source_repository" ]] || fail "Missing SOURCE_GITHUB_REPOSITORY for Sentry commit association"
     printf 'Preparing Sentry release %s for %s/%s.\n' "$SENTRY_RELEASE_NAME" "$REPOPROMPT_SENTRY_ORG" "$REPOPROMPT_SENTRY_PROJECT"
-    if ! sentry-cli --org "$REPOPROMPT_SENTRY_ORG" releases info "$SENTRY_RELEASE_NAME" >/dev/null 2>&1; then
-        sentry-cli --org "$REPOPROMPT_SENTRY_ORG" releases new \
-            --project "$REPOPROMPT_SENTRY_PROJECT" \
-            "$SENTRY_RELEASE_NAME"
+    local lookup_error=""
+    if lookup_error="$(sentry-cli --org "$REPOPROMPT_SENTRY_ORG" releases info "$SENTRY_RELEASE_NAME" 2>&1 >/dev/null)"; then
+        :
+    else
+        local normalized_lookup_error="${lookup_error,,}"
+        if [[ "$normalized_lookup_error" == *"release not found"* ||
+            "$normalized_lookup_error" == *"release does not exist"* ||
+            "$normalized_lookup_error" =~ (^|[^0-9])404([^0-9]|$) ]]; then
+            sentry-cli --org "$REPOPROMPT_SENTRY_ORG" releases new \
+                --project "$REPOPROMPT_SENTRY_PROJECT" \
+                "$SENTRY_RELEASE_NAME"
+        else
+            fail "Unable to look up Sentry release $SENTRY_RELEASE_NAME; refusing to create it after an authentication, authorization, or network failure."
+        fi
     fi
     sentry-cli --org "$REPOPROMPT_SENTRY_ORG" releases set-commits \
         "$SENTRY_RELEASE_NAME" \
@@ -396,8 +406,6 @@ publish_staged_release() {
             > "$(basename "$CHECKSUMS")"
     )
 
-    finalize_sentry_release
-    record_sentry_production_deploy
     "$CONTROL_PLANE_SCRIPTS_DIR/verify_remote_release_commit.sh" "$RELEASE_TAG" "$RELEASE_COMMIT"
     local release_args=(
         "$RELEASE_TAG"
@@ -414,15 +422,24 @@ publish_staged_release() {
         --draft
         --target "$RELEASE_COMMIT"
     )
+    local existing_release_state=""
+    if existing_release_state="$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json isDraft --jq .isDraft 2>/dev/null)"; then
+        fail "GitHub release $RELEASE_TAG already exists (isDraft=$existing_release_state). Refusing to repeat Sentry finalization or deploy publication; inspect the existing draft and Sentry release before manual recovery."
+    fi
     gh release create "${release_args[@]}"
     printf 'Created draft GitHub release assets for %s.\n' "$RELEASE_TAG"
+
+    finalize_sentry_release
+    record_sentry_production_deploy
 }
 
-case "$MODE" in
-    sync-cli-version) sync_mcp_cli_version ;;
-    preflight) run_preflight ;;
-    artifact) package_release_candidate ;;
-    stage-publish) stage_publish_release ;;
-    publish-staged) publish_staged_release ;;
-    *) fail "Usage: $0 sync-cli-version|preflight|artifact|stage-publish|publish-staged" ;;
-esac
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    case "$MODE" in
+        sync-cli-version) sync_mcp_cli_version ;;
+        preflight) run_preflight ;;
+        artifact) package_release_candidate ;;
+        stage-publish) stage_publish_release ;;
+        publish-staged) publish_staged_release ;;
+        *) fail "Usage: $0 sync-cli-version|preflight|artifact|stage-publish|publish-staged" ;;
+    esac
+fi

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -21,6 +21,8 @@ APPCAST="$DIST_DIR/appcast.xml"
 CHECKSUMS="$DIST_DIR/SHA256SUMS"
 BUILD_ARTIFACT_MANIFEST="$ROOT_DIR/.build/release/$APP_NAME-artifact-manifest.json"
 SENTRY_SYMBOLS_DIR="$ROOT_DIR/.build/sentry-symbols/release"
+SENTRY_RELEASE_NAME="$BUNDLE_ID@$MARKETING_VERSION+$BUILD_NUMBER"
+SENTRY_DEPLOY_ENVIRONMENT="${REPOPROMPT_SENTRY_DEPLOY_ENVIRONMENT:-production}"
 FINAL_ARTIFACT_MANIFEST="$DIST_DIR/$ARCHIVE_BASENAME-artifact-manifest.json"
 STAGE_ARCHIVE="$DIST_DIR/$ARCHIVE_BASENAME-stage.zip"
 STAGE_ARCHIVE_CHECKSUM="$STAGE_ARCHIVE.sha256"
@@ -181,15 +183,58 @@ require_staged_sentry_symbols_when_enabled() {
     fi
 }
 
-require_sentry_publish_symbol_upload_configuration() {
+require_sentry_publish_configuration() {
     sentry_linking_enabled || return 0
-    [[ -n "${SENTRY_AUTH_TOKEN:-}" || -n "${REPOPROMPT_SENTRY_AUTH_TOKEN_FILE:-${SENTRY_AUTH_TOKEN_FILE:-}}" ]] || fail "Official Sentry-enabled release publishing requires SENTRY_AUTH_TOKEN or REPOPROMPT_SENTRY_AUTH_TOKEN_FILE for debug symbol upload."
+    [[ -n "${SENTRY_AUTH_TOKEN:-}" || -n "${REPOPROMPT_SENTRY_AUTH_TOKEN_FILE:-${SENTRY_AUTH_TOKEN_FILE:-}}" ]] || fail "Official Sentry-enabled release publishing requires SENTRY_AUTH_TOKEN or REPOPROMPT_SENTRY_AUTH_TOKEN_FILE for Sentry release metadata and debug symbol upload."
     require_env REPOPROMPT_SENTRY_ORG
     require_env REPOPROMPT_SENTRY_PROJECT
+    require_command sentry-cli
+}
+
+load_sentry_auth_token_for_publish() {
+    sentry_linking_enabled || return 0
+    if [[ -z "${SENTRY_AUTH_TOKEN:-}" ]]; then
+        local token_file="${REPOPROMPT_SENTRY_AUTH_TOKEN_FILE:-${SENTRY_AUTH_TOKEN_FILE:-}}"
+        [[ -n "$token_file" ]] || fail "Missing Sentry auth token file"
+        [[ -f "$token_file" ]] || fail "Sentry auth token file does not exist: $token_file"
+        SENTRY_AUTH_TOKEN="$(tr -d '\r\n' < "$token_file")"
+        export SENTRY_AUTH_TOKEN
+    fi
+    [[ -n "$SENTRY_AUTH_TOKEN" ]] || fail "Sentry auth token file was empty"
+}
+
+prepare_sentry_release() {
+    sentry_linking_enabled || return 0
+    load_sentry_auth_token_for_publish
+    local source_repository="${SOURCE_GITHUB_REPOSITORY:-$GITHUB_REPOSITORY}"
+    [[ -n "$source_repository" ]] || fail "Missing SOURCE_GITHUB_REPOSITORY for Sentry commit association"
+    printf 'Preparing Sentry release %s for %s/%s.\n' "$SENTRY_RELEASE_NAME" "$REPOPROMPT_SENTRY_ORG" "$REPOPROMPT_SENTRY_PROJECT"
+    if ! sentry-cli --org "$REPOPROMPT_SENTRY_ORG" releases info "$SENTRY_RELEASE_NAME" >/dev/null 2>&1; then
+        sentry-cli --org "$REPOPROMPT_SENTRY_ORG" releases new \
+            --project "$REPOPROMPT_SENTRY_PROJECT" \
+            "$SENTRY_RELEASE_NAME"
+    fi
+    sentry-cli --org "$REPOPROMPT_SENTRY_ORG" releases set-commits \
+        "$SENTRY_RELEASE_NAME" \
+        --commit "$source_repository@$RELEASE_COMMIT"
+}
+
+finalize_sentry_release() {
+    sentry_linking_enabled || return 0
+    load_sentry_auth_token_for_publish
+    sentry-cli --org "$REPOPROMPT_SENTRY_ORG" releases finalize "$SENTRY_RELEASE_NAME"
+}
+
+record_sentry_production_deploy() {
+    sentry_linking_enabled || return 0
+    load_sentry_auth_token_for_publish
+    sentry-cli --org "$REPOPROMPT_SENTRY_ORG" releases deploys "$SENTRY_RELEASE_NAME" new \
+        --env "$SENTRY_DEPLOY_ENVIRONMENT" \
+        --name "$RELEASE_TAG"
 }
 
 upload_required_sentry_symbols() {
-    require_sentry_publish_symbol_upload_configuration
+    require_sentry_publish_configuration
     "$CONTROL_PLANE_SCRIPTS_DIR/upload_sentry_debug_symbols.sh" "$SENTRY_SYMBOLS_DIR"
 }
 
@@ -238,7 +283,7 @@ verify_publish_inputs() {
     require_release_tag_matches_metadata
     require_file "$REPOPROMPT_PROVISIONING_PROFILE"
     require_file "$NOTARYTOOL_PRIVATE_KEY"
-    require_sentry_publish_symbol_upload_configuration
+    require_sentry_publish_configuration
 
     "$CONTROL_PLANE_SCRIPTS_DIR/verify_remote_release_commit.sh" "$RELEASE_TAG" "$RELEASE_COMMIT"
 }
@@ -317,6 +362,7 @@ publish_staged_release() {
     xcrun stapler validate "$APP_BUNDLE"
     write_final_artifact_manifest
     validate_public_app "$APP_BUNDLE" "$FINAL_ARTIFACT_MANIFEST" "Final Developer ID app"
+    prepare_sentry_release
     upload_required_sentry_symbols
 
     local distribution_dir="$TMP_DIR/distribution"
@@ -350,6 +396,8 @@ publish_staged_release() {
             > "$(basename "$CHECKSUMS")"
     )
 
+    finalize_sentry_release
+    record_sentry_production_deploy
     "$CONTROL_PLANE_SCRIPTS_DIR/verify_remote_release_commit.sh" "$RELEASE_TAG" "$RELEASE_COMMIT"
     local release_args=(
         "$RELEASE_TAG"

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -1231,6 +1231,108 @@ printf '%s' "${SENTRY_AUTH_TOKEN:-}" > "$TOKEN_CAPTURE"
         self.assertNotIn(token, "\n".join(argv))
         self.assertEqual(token_capture.read_text(encoding="utf-8"), token)
 
+    def run_sentry_prepare_fixture(
+        self,
+        lookup_mode: str,
+        attempts: int = 1,
+    ) -> tuple[subprocess.CompletedProcess[str], list[str]]:
+        temp_dir = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, temp_dir, True)
+        call_log = temp_dir / "sentry-calls.log"
+        release_state = temp_dir / "release-created"
+        fake_cli = temp_dir / "sentry-cli"
+        fake_cli.write_text(
+            """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$SENTRY_CALL_LOG"
+if [[ "$*" == *"releases info"* ]]; then
+    case "$SENTRY_LOOKUP_MODE" in
+        not-found-once)
+            if [[ -f "$SENTRY_RELEASE_STATE" ]]; then
+                exit 0
+            fi
+            printf 'error: release not found (404)\n' >&2
+            exit 1
+            ;;
+        denied)
+            printf 'error: authentication failed\n' >&2
+            exit 2
+            ;;
+        existing)
+            exit 0
+            ;;
+    esac
+fi
+if [[ "$*" == *"releases new"* ]]; then
+    : > "$SENTRY_RELEASE_STATE"
+fi
+""",
+            encoding="utf-8",
+        )
+        fake_cli.chmod(0o755)
+        env = os.environ.copy()
+        env.update(
+            {
+                "PATH": f"{temp_dir}:{env.get('PATH', '')}",
+                "REPOPROMPT_ENABLE_SENTRY": "1",
+                "SENTRY_AUTH_TOKEN": "fixture-token",
+                "REPOPROMPT_SENTRY_ORG": "fixture-org",
+                "REPOPROMPT_SENTRY_PROJECT": "fixture-project",
+                "SOURCE_GITHUB_REPOSITORY": "fixture/repository",
+                "RELEASE_COMMIT": "0123456789abcdef",
+                "SENTRY_LOOKUP_MODE": lookup_mode,
+                "SENTRY_CALL_LOG": str(call_log),
+                "SENTRY_RELEASE_STATE": str(release_state),
+                "ATTEMPTS": str(attempts),
+            }
+        )
+        result = subprocess.run(
+            [
+                "bash",
+                "-c",
+                'source "$1"; for ((attempt = 0; attempt < ATTEMPTS; attempt++)); do prepare_sentry_release; done',
+                "sentry-release-test",
+                str(SCRIPT_DIR / "release.sh"),
+            ],
+            env=env,
+            text=True,
+            capture_output=True,
+        )
+        calls = call_log.read_text(encoding="utf-8").splitlines() if call_log.exists() else []
+        return result, calls
+
+    def test_sentry_release_prepare_creates_only_for_not_found_and_is_retry_safe(self) -> None:
+        result, calls = self.run_sentry_prepare_fixture("not-found-once", attempts=2)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(sum("releases info" in call for call in calls), 2)
+        self.assertEqual(sum("releases new" in call for call in calls), 1)
+        self.assertEqual(sum("releases set-commits" in call for call in calls), 2)
+        self.assertTrue(
+            any(
+                "--org fixture-org releases new --project fixture-project "
+                "com.pvncher.repoprompt.ce@" in call
+                for call in calls
+            )
+        )
+        self.assertTrue(
+            all(
+                "--commit fixture/repository@0123456789abcdef" in call
+                for call in calls
+                if "releases set-commits" in call
+            )
+        )
+
+    def test_sentry_release_prepare_does_not_create_after_lookup_failure(self) -> None:
+        result, calls = self.run_sentry_prepare_fixture("denied")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(sum("releases info" in call for call in calls), 1)
+        self.assertFalse(any("releases new" in call for call in calls))
+        self.assertFalse(any("releases set-commits" in call for call in calls))
+        self.assertIn("refusing to create it", result.stderr)
+        self.assertNotIn("fixture-token", result.stdout + result.stderr)
+
     def test_sentry_symbol_flow_is_explicit_secret_safe_and_release_only_by_default(self) -> None:
         package_script = (SCRIPT_DIR / "package_app.sh").read_text(encoding="utf-8")
         universal_builder = (SCRIPT_DIR / "build_swiftpm_release_products.sh").read_text(encoding="utf-8")
@@ -1268,8 +1370,10 @@ printf '%s' "${SENTRY_AUTH_TOKEN:-}" > "$TOKEN_CAPTURE"
 
         publish_staged = release_script.split("publish_staged_release() {", 1)[1].split("\n}\n\ncase", 1)[0]
         self.assertLess(publish_staged.index("prepare_sentry_release"), publish_staged.index("upload_required_sentry_symbols"))
-        self.assertLess(publish_staged.index("upload_required_sentry_symbols"), publish_staged.index("finalize_sentry_release"))
-        self.assertLess(publish_staged.index("record_sentry_production_deploy"), publish_staged.index("gh release create"))
+        self.assertLess(publish_staged.index("upload_required_sentry_symbols"), publish_staged.index("gh release view"))
+        self.assertLess(publish_staged.index("gh release view"), publish_staged.index("gh release create"))
+        self.assertLess(publish_staged.index("gh release create"), publish_staged.index("finalize_sentry_release"))
+        self.assertLess(publish_staged.index("finalize_sentry_release"), publish_staged.index("record_sentry_production_deploy"))
 
         stage_job = release_workflow.split("\n  stage:", 1)[1].split("\n  publish:", 1)[0]
         publish_job = release_workflow.split("\n  publish:", 1)[1].split("\n  smoke-signed-helper:", 1)[0]
@@ -1659,7 +1763,7 @@ printf '%s' "${SENTRY_AUTH_TOKEN:-}" > "$TOKEN_CAPTURE"
         self.assertIn('event.serverName = nil', bootstrap_source)
         self.assertIn('deviceIdentifierKeys', bootstrap_source)
         self.assertIn('geoPayloadKeys', bootstrap_source)
-        self.assertNotIn('options.dist =', bootstrap_source)
+        self.assertIn('options.dist = nil', bootstrap_source)
         self.assertIn('options.tracesSampleRate = performanceTracingEnabled ? 0.05 : 0', bootstrap_source)
         self.assertIn('#if DEBUG\n                if let value = ProcessInfo.processInfo.environment["REPOPROMPT_SENTRY_DSN"]', bootstrap_source)
         self.assertIn('Official Sentry-enabled release publishing requires SENTRY_AUTH_TOKEN', release_script)

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -1251,6 +1251,25 @@ printf '%s' "${SENTRY_AUTH_TOKEN:-}" > "$TOKEN_CAPTURE"
         self.assertIn('SENTRY_SYMBOLS_DIR="$ROOT_DIR/.build/sentry-symbols/release"', release_script)
         self.assertIn('ditto "$SENTRY_SYMBOLS_DIR" "$stage_root/.build/sentry-symbols/release"', release_script)
         self.assertIn('upload_required_sentry_symbols', release_script)
+        self.assertIn('SENTRY_RELEASE_NAME="$BUNDLE_ID@$MARKETING_VERSION+$BUILD_NUMBER"', release_script)
+        self.assertIn('require_sentry_publish_configuration() {', release_script)
+        self.assertIn('require_command sentry-cli', release_script)
+        self.assertIn('prepare_sentry_release', release_script)
+        self.assertIn('releases new', release_script)
+        self.assertIn('releases set-commits', release_script)
+        self.assertIn('--commit "$source_repository@$RELEASE_COMMIT"', release_script)
+        self.assertIn('finalize_sentry_release', release_script)
+        self.assertIn('releases finalize "$SENTRY_RELEASE_NAME"', release_script)
+        self.assertIn('record_sentry_production_deploy', release_script)
+        self.assertIn('releases deploys "$SENTRY_RELEASE_NAME" new', release_script)
+        self.assertIn('--env "$SENTRY_DEPLOY_ENVIRONMENT"', release_script)
+        self.assertIn('--name "$RELEASE_TAG"', release_script)
+        self.assertIn('SENTRY_AUTH_TOKEN="$(tr -d', release_script)
+
+        publish_staged = release_script.split("publish_staged_release() {", 1)[1].split("\n}\n\ncase", 1)[0]
+        self.assertLess(publish_staged.index("prepare_sentry_release"), publish_staged.index("upload_required_sentry_symbols"))
+        self.assertLess(publish_staged.index("upload_required_sentry_symbols"), publish_staged.index("finalize_sentry_release"))
+        self.assertLess(publish_staged.index("record_sentry_production_deploy"), publish_staged.index("gh release create"))
 
         stage_job = release_workflow.split("\n  stage:", 1)[1].split("\n  publish:", 1)[0]
         publish_job = release_workflow.split("\n  publish:", 1)[1].split("\n  smoke-signed-helper:", 1)[0]
@@ -1263,8 +1282,10 @@ printf '%s' "${SENTRY_AUTH_TOKEN:-}" > "$TOKEN_CAPTURE"
             publish_job.index("Install Sentry CLI when symbol upload is configured"),
             publish_job.index("Sign, notarize, and create draft release"),
         )
+        self.assertIn('REPOPROMPT_ENABLE_SENTRY: "1"', publish_job)
         self.assertIn("REPOPROMPT_SENTRY_ORG: ${{ vars.SENTRY_ORG }}", publish_job)
         self.assertIn("REPOPROMPT_SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}", publish_job)
+        self.assertIn("REPOPROMPT_SENTRY_DEPLOY_ENVIRONMENT: production", publish_job)
 
         self.assertIn('"REPOPROMPT_ENABLE_SENTRY"', conductor)
         self.assertIn('"REPOPROMPT_UPLOAD_SENTRY_SYMBOLS"', conductor)
@@ -1631,9 +1652,21 @@ printf '%s' "${SENTRY_AUTH_TOKEN:-}" > "$TOKEN_CAPTURE"
         self.assertIn('REPOPROMPT_TELEMETRY_DISABLED', bootstrap_source)
         self.assertIn('GlobalSettingsStore.shared.telemetryEnabled()', bootstrap_source)
         self.assertIn('options.beforeSend', bootstrap_source)
+        self.assertIn('options.enableCaptureFailedRequests = false', bootstrap_source)
+        self.assertIn('options.enableAutoSessionTracking = false', bootstrap_source)
+        self.assertIn('event.request = nil', bootstrap_source)
+        self.assertIn('event.user = nil', bootstrap_source)
+        self.assertIn('event.serverName = nil', bootstrap_source)
+        self.assertIn('deviceIdentifierKeys', bootstrap_source)
+        self.assertIn('geoPayloadKeys', bootstrap_source)
+        self.assertNotIn('options.dist =', bootstrap_source)
         self.assertIn('options.tracesSampleRate = performanceTracingEnabled ? 0.05 : 0', bootstrap_source)
         self.assertIn('#if DEBUG\n                if let value = ProcessInfo.processInfo.environment["REPOPROMPT_SENTRY_DSN"]', bootstrap_source)
         self.assertIn('Official Sentry-enabled release publishing requires SENTRY_AUTH_TOKEN', release_script)
+        self.assertIn('SENTRY_RELEASE_NAME="$BUNDLE_ID@$MARKETING_VERSION+$BUILD_NUMBER"', release_script)
+        self.assertIn('prepare_sentry_release', release_script)
+        self.assertIn('finalize_sentry_release', release_script)
+        self.assertIn('record_sentry_production_deploy', release_script)
 
         pins = {pin["identity"]: pin for pin in package_resolved["pins"]}
         self.assertEqual(pins["sentry-cocoa"]["state"]["version"], "9.17.1")

--- a/Sources/RepoPrompt/Features/Settings/Views/General/TelemetrySettingsView.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/General/TelemetrySettingsView.swift
@@ -37,7 +37,7 @@ struct TelemetrySettingsView: View {
 
                         SettingToggle(
                             title: "Share crash reports and diagnostics",
-                            description: "Allows Sentry crash reporting, app hang reports, and optional startup performance traces when this build is configured with telemetry.",
+                            description: "Allows Sentry crash reporting, app hang reports, and optional startup performance traces when this build is configured with telemetry. Automatic release-health sessions are disabled to avoid stable installation identifiers.",
                             isOn: telemetryEnabledBinding
                         )
                         .disabled(!SentryTelemetryBootstrap.currentStatus().sdkCompiledIn)
@@ -64,8 +64,9 @@ struct TelemetrySettingsView: View {
                 ) {
                     VStack(alignment: .leading, spacing: fontPreset.scaledClamped(8, max: 12)) {
                         bullet("Collected: crash diagnostics, app hangs when enabled, release/build metadata, OS/app version, and optional startup performance timing.")
-                        bullet("Never intentionally sent: prompt contents, chat transcripts, selected file contents, API keys, provider tokens, or full local paths.")
-                        bullet("A defense-in-depth scrubber removes obvious secrets, local home paths, user identifiers, server names, and IP-like values from events before upload.")
+                        bullet("Never intentionally sent: prompt contents, chat transcripts, selected file contents, tool payloads, API keys, provider tokens, or full local paths.")
+                        bullet("Automatic failed-request capture and automatic release-health session tracking are disabled.")
+                        bullet("A defense-in-depth scrubber removes request payloads, headers, cookies, query strings, obvious secrets, local home paths, user/geo/server identifiers, stable device identifiers, and IP-like values from events before upload.")
                         bullet("Set REPOPROMPT_TELEMETRY_DISABLED=1 before launch to disable telemetry for the process regardless of Settings.")
                     }
                 }

--- a/Sources/RepoPrompt/Infrastructure/Telemetry/SentryTelemetryBootstrap.swift
+++ b/Sources/RepoPrompt/Infrastructure/Telemetry/SentryTelemetryBootstrap.swift
@@ -38,6 +38,8 @@ enum SentryTelemetryBootstrap {
                     options.debug = false
                 #endif
                 options.tracesSampleRate = performanceTracingEnabled ? 0.05 : 0
+                // Do not let SDK defaults or future configuration attach distribution metadata.
+                options.dist = nil
                 options.add(inAppInclude: "RepoPrompt")
                 options.add(inAppInclude: "RepoPromptMCP")
                 options.add(inAppInclude: "RepoPromptShared")
@@ -325,9 +327,10 @@ enum SentryTelemetryBootstrap {
             }
             event.context = event.context?.reduce(into: [:]) { result, entry in
                 guard !shouldDropValue(at: [entry.key]) else { return }
-                let context = entry.value.reduce(into: [:]) { contextResult, contextEntry in
-                    if let value = scrubValue(contextEntry.value, keyPath: [entry.key, contextEntry.key]) {
-                        contextResult[contextEntry.key] = value
+                let context: [String: Any] = entry.value.reduce(into: [:]) { contextResult, contextEntry in
+                    guard let contextKey = contextEntry.key as? String else { return }
+                    if let value = scrubValue(contextEntry.value, keyPath: [entry.key, contextKey]) {
+                        contextResult[contextKey] = value
                     }
                 }
                 if !context.isEmpty {

--- a/Sources/RepoPrompt/Infrastructure/Telemetry/SentryTelemetryBootstrap.swift
+++ b/Sources/RepoPrompt/Infrastructure/Telemetry/SentryTelemetryBootstrap.swift
@@ -27,7 +27,6 @@ enum SentryTelemetryBootstrap {
 
             performanceTracingEnabled = GlobalSettingsStore.shared.telemetryPerformanceTracingEnabled()
             let appHangReportsEnabled = GlobalSettingsStore.shared.telemetryAppHangReportsEnabled()
-            let dist = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String
 
             SentrySDK.start { options in
                 options.dsn = dsn
@@ -39,7 +38,6 @@ enum SentryTelemetryBootstrap {
                     options.debug = false
                 #endif
                 options.tracesSampleRate = performanceTracingEnabled ? 0.05 : 0
-                options.dist = dist
                 options.add(inAppInclude: "RepoPrompt")
                 options.add(inAppInclude: "RepoPromptMCP")
                 options.add(inAppInclude: "RepoPromptShared")
@@ -57,6 +55,8 @@ enum SentryTelemetryBootstrap {
                 options.enableFileIOTracing = false
                 options.enableCoreDataTracing = false
                 options.enableAutoPerformanceTracing = false
+                options.enableCaptureFailedRequests = false
+                options.enableAutoSessionTracking = false
                 options.beforeSend = { event in
                     scrub(event: event)
                 }
@@ -305,6 +305,7 @@ enum SentryTelemetryBootstrap {
 
         private static func scrub(event: Event) -> Event? {
             event.user = nil
+            event.request = nil
             event.serverName = nil
             if let message = event.message {
                 event.message = SentryMessage(formatted: scrubString(message.formatted))
@@ -317,19 +318,35 @@ enum SentryTelemetryBootstrap {
                 exception.module = exception.module.map(scrubString)
                 return exception
             }
-            event.tags = event.tags?.mapValues(scrubString)
+            event.tags = event.tags?.reduce(into: [:]) { result, entry in
+                if let value = scrubValue(entry.value, keyPath: [entry.key]) as? String {
+                    result[entry.key] = value
+                }
+            }
             event.context = event.context?.reduce(into: [:]) { result, entry in
-                result[entry.key] = entry.value.reduce(into: [:]) { contextResult, contextEntry in
-                    contextResult[contextEntry.key] = scrubValue(contextEntry.value)
+                guard !shouldDropValue(at: [entry.key]) else { return }
+                let context = entry.value.reduce(into: [:]) { contextResult, contextEntry in
+                    if let value = scrubValue(contextEntry.value, keyPath: [entry.key, contextEntry.key]) {
+                        contextResult[contextEntry.key] = value
+                    }
+                }
+                if !context.isEmpty {
+                    result[entry.key] = context
                 }
             }
             event.extra = event.extra?.reduce(into: [:]) { result, entry in
-                result[entry.key] = scrubValue(entry.value)
+                if let value = scrubValue(entry.value, keyPath: [entry.key]) {
+                    result[entry.key] = value
+                }
             }
             event.breadcrumbs = event.breadcrumbs?.map { breadcrumb in
                 breadcrumb.message = breadcrumb.message.map(scrubString)
                 if let data = breadcrumb.data {
-                    breadcrumb.data = data.mapValues(scrubValue)
+                    breadcrumb.data = data.reduce(into: [:]) { result, entry in
+                        if let value = scrubValue(entry.value, keyPath: [entry.key]) {
+                            result[entry.key] = value
+                        }
+                    }
                 }
                 return breadcrumb
             }
@@ -337,18 +354,112 @@ enum SentryTelemetryBootstrap {
         }
     #endif
 
-    private static func scrubValue(_ value: Any) -> Any {
-        if let string = value as? String {
-            scrubString(string)
-        } else if let dictionary = value as? [String: Any] {
-            dictionary.reduce(into: [:]) { result, entry in
-                result[entry.key] = scrubValue(entry.value)
+    static func scrubPayloadForTesting(_ value: [String: Any]) -> [String: Any] {
+        value.reduce(into: [:]) { result, entry in
+            if let value = scrubValue(entry.value, keyPath: [entry.key]) {
+                result[entry.key] = value
             }
-        } else if let array = value as? [Any] {
-            array.map(scrubValue)
-        } else {
-            value
         }
+    }
+
+    private static func scrubValue(_ value: Any, keyPath: [String]) -> Any? {
+        guard !shouldDropValue(at: keyPath) else { return nil }
+        if let string = value as? String {
+            return scrubString(string)
+        } else if let dictionary = value as? [String: Any] {
+            let scrubbed = dictionary.reduce(into: [:]) { result, entry in
+                if let value = scrubValue(entry.value, keyPath: keyPath + [entry.key]) {
+                    result[entry.key] = value
+                }
+            }
+            return scrubbed.isEmpty ? nil : scrubbed
+        } else if let array = value as? [Any] {
+            return array.compactMap { scrubValue($0, keyPath: keyPath) }
+        } else {
+            return value
+        }
+    }
+
+    private static func shouldDropValue(at keyPath: [String]) -> Bool {
+        let components = keyPath.map(normalizedTelemetryKey)
+        guard let leaf = components.last else { return false }
+
+        if components.contains(where: requestPayloadKeys.contains) {
+            return true
+        }
+        if components.contains("geo") || geoPayloadKeys.contains(leaf) {
+            return true
+        }
+        if components.contains("user") || userIdentifierKeys.contains(leaf) {
+            return true
+        }
+        if components.contains("device"), deviceIdentifierKeys.contains(leaf) {
+            return true
+        }
+        if stableIdentifierKeys.contains(leaf) {
+            return true
+        }
+        return false
+    }
+
+    private static let requestPayloadKeys: Set<String> = [
+        "request",
+        "http",
+        "headers",
+        "cookies",
+        "cookie",
+        "query",
+        "query_string",
+        "body",
+        "url"
+    ]
+
+    private static let geoPayloadKeys: Set<String> = [
+        "city",
+        "region",
+        "country_code",
+        "latitude",
+        "longitude",
+        "location",
+        "user_geo"
+    ]
+
+    private static let userIdentifierKeys: Set<String> = [
+        "user_id",
+        "userid",
+        "username",
+        "email",
+        "ip_address",
+        "ipaddress"
+    ]
+
+    private static let deviceIdentifierKeys: Set<String> = [
+        "id",
+        "name",
+        "identifier",
+        "unique_id",
+        "uniqueid"
+    ]
+
+    private static let stableIdentifierKeys: Set<String> = [
+        "server_name",
+        "servername",
+        "vendor_id",
+        "vendorid",
+        "identifier_for_vendor",
+        "identifierforvendor",
+        "advertising_id",
+        "advertisingid",
+        "installation_id",
+        "installationid",
+        "device_app_hash",
+        "deviceapphash"
+    ]
+
+    private static func normalizedTelemetryKey(_ key: String) -> String {
+        key.trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .replacingOccurrences(of: "-", with: "_")
     }
 
     static func scrubStringForTesting(_ value: String) -> String {

--- a/Tests/RepoPromptTests/SettingsJSONOnlyPersistenceTests.swift
+++ b/Tests/RepoPromptTests/SettingsJSONOnlyPersistenceTests.swift
@@ -272,6 +272,79 @@ final class SettingsJSONOnlyPersistenceTests: XCTestCase {
         XCTAssertTrue(scrubbed.contains("the basic idea is simple"))
     }
 
+    func testSentryScrubPayloadDropsRequestGeoUserAndStableDeviceIdentifiers() throws {
+        let scrubbed = SentryTelemetryBootstrap.scrubPayloadForTesting([
+            "request": [
+                "url": "https://example.invalid/private?token=secret",
+                "headers": ["Authorization": "Bearer abcdef"]
+            ],
+            "contexts": [
+                "device": [
+                    "id": "stable-device-id",
+                    "identifier_for_vendor": "stable-vendor-id",
+                    "name": "Alice’s MacBook",
+                    "model": "Mac14,7"
+                ],
+                "os": ["name": "macOS", "version": "15.0"],
+                "app": [
+                    "device_app_hash": "stable-app-device-hash",
+                    "app_identifier": "com.pvncher.repoprompt.ce"
+                ]
+            ],
+            "user": [
+                "id": "stable-user-id",
+                "geo": ["city": "Tokyo", "country_code": "JP"]
+            ],
+            "extra": [
+                "installation_id": "stable-installation-id",
+                "safe_note": "token=abcdef 10.0.0.1"
+            ]
+        ])
+
+        XCTAssertNil(scrubbed["request"])
+        XCTAssertNil(scrubbed["user"])
+        let contexts = try XCTUnwrap(scrubbed["contexts"] as? [String: Any])
+        let device = try XCTUnwrap(contexts["device"] as? [String: Any])
+        XCTAssertNil(device["id"])
+        XCTAssertNil(device["identifier_for_vendor"])
+        XCTAssertNil(device["name"])
+        XCTAssertEqual(device["model"] as? String, "Mac14,7")
+        XCTAssertNotNil(contexts["os"])
+        let app = try XCTUnwrap(contexts["app"] as? [String: Any])
+        XCTAssertNil(app["device_app_hash"])
+        XCTAssertEqual(app["app_identifier"] as? String, "com.pvncher.repoprompt.ce")
+        let extra = try XCTUnwrap(scrubbed["extra"] as? [String: Any])
+        XCTAssertNil(extra["installation_id"])
+        XCTAssertEqual(extra["safe_note"] as? String, "token=[redacted] [ip]")
+    }
+
+    func testSentryScrubPayloadDropsNestedRequestAndGeoFieldsWithoutDroppingSafeSiblings() throws {
+        let scrubbed = SentryTelemetryBootstrap.scrubPayloadForTesting([
+            "breadcrumb": [
+                "category": "app.lifecycle",
+                "url": "https://example.invalid/private",
+                "data": [
+                    "query_string": "api_key=secret",
+                    "result": "ok"
+                ]
+            ],
+            "profile": [
+                "user_geo": ["region": "CA"],
+                "display": "safe value"
+            ]
+        ])
+
+        let breadcrumb = try XCTUnwrap(scrubbed["breadcrumb"] as? [String: Any])
+        XCTAssertEqual(breadcrumb["category"] as? String, "app.lifecycle")
+        XCTAssertNil(breadcrumb["url"])
+        let data = try XCTUnwrap(breadcrumb["data"] as? [String: Any])
+        XCTAssertNil(data["query_string"])
+        XCTAssertEqual(data["result"] as? String, "ok")
+        let profile = try XCTUnwrap(scrubbed["profile"] as? [String: Any])
+        XCTAssertNil(profile["user_geo"])
+        XCTAssertEqual(profile["display"] as? String, "safe value")
+    }
+
     func testObsoleteGitignoreJSONKeyIsIgnoredAndNeverEmitted() throws {
         let temp = try makeTempDirectory()
         defer { try? FileManager.default.removeItem(at: temp) }

--- a/docs/privacy/telemetry.md
+++ b/docs/privacy/telemetry.md
@@ -75,7 +75,7 @@ RepoPrompt CE does not intentionally send:
 Native crash reports may include SDK-provided crash context such as stack traces, exception messages,
 app/OS versions, device model, locale, and memory values. RepoPrompt disables default PII, disables
 Sentry's automatic failed-request and release-health session capture, and applies its own scrubber
-before events are sent. RepoPrompt does not set Sentry `dist` for new events; older cached crashes from
+before events are sent. RepoPrompt explicitly clears Sentry `dist` at SDK startup for new events; older cached crashes from
 previous builds may retain the distribution value originally attached by those builds.
 
 ## Processor

--- a/docs/privacy/telemetry.md
+++ b/docs/privacy/telemetry.md
@@ -39,21 +39,26 @@ When active, RepoPrompt can send:
 
 - crash reports and unhandled exception diagnostics with stack traces,
 - app-hang reports when **App hang reports** is enabled; this sub-option defaults off for release safety,
-- app version/build, OS version, release distribution, and SDK metadata,
+- app version/build, OS version, environment, and SDK metadata,
 - a conservative sample of app startup performance traces when **Performance timing and tracing** is enabled.
 
-Production performance tracing defaults to off. Manual tool-stack breadcrumbs, metrics, per-message
-transcript hooks, MCP tool execution spans, and agent-run state metrics are disabled/deferred in this
-telemetry pass.
+Production performance tracing defaults to off. Sentry Cocoa automatic release-health session tracking
+is explicitly disabled because the pinned SDK stores and sends a persistent installation identifier as
+the session `did`; RepoPrompt prefers not to collect that stable identifier. Manual tool-stack
+breadcrumbs, metrics, per-message transcript hooks, MCP tool execution spans, and agent-run state
+metrics are disabled/deferred in this telemetry pass.
 
 The runtime configuration is deliberately conservative:
 
 - `sendDefaultPii` is false,
-- no session replay, MetricKit, structured logs, automatic network breadcrumbs, automatic network
-  tracking, automatic file I/O tracing, or Core Data tracing,
+- no session replay, release-health auto sessions, MetricKit, structured logs, automatic failed-request
+  capture, automatic network breadcrumbs, automatic network tracking, automatic file I/O tracing, or
+  Core Data tracing,
 - a small bounded Sentry cache and breadcrumb limit,
-- a `beforeSend` scrubber that removes user identifiers/server name and redacts obvious secrets,
-  local home paths, and IP-like values from event fields exposed by Sentry Cocoa.
+- a `beforeSend` scrubber that removes the Sentry request object, request payload fields, user and
+  geo fields, server names, stable device identifiers, installation/vendor/advertising identifiers,
+  and redacts obvious secrets, local home paths, and IP-like values from event fields exposed by
+  Sentry Cocoa.
 
 ## What is not sent
 
@@ -65,15 +70,17 @@ RepoPrompt CE does not intentionally send:
 - AI provider request/response bodies,
 - API keys, tokens, bearer credentials, passwords, or environment variables,
 - workspace names, run IDs, tool invocation IDs, or raw model names,
-- screenshots, view hierarchy, or session replay.
+- screenshots, view hierarchy, session replay, or automatic release-health session identifiers.
 
 Native crash reports may include SDK-provided crash context such as stack traces, exception messages,
-app/OS versions, device model, locale, and memory values. RepoPrompt disables default PII and applies
-its own scrubber before events are sent.
+app/OS versions, device model, locale, and memory values. RepoPrompt disables default PII, disables
+Sentry's automatic failed-request and release-health session capture, and applies its own scrubber
+before events are sent. RepoPrompt does not set Sentry `dist` for new events; older cached crashes from
+previous builds may retain the distribution value originally attached by those builds.
 
 ## Processor
 
 Telemetry data is processed by Sentry (a third-party SaaS provider) acting as a data processor on
-behalf of the RepoPrompt CE project. Sentry project-side data scrubbing is also configured as
-defense-in-depth; RepoPrompt's primary privacy boundary is avoiding sensitive data collection in the
-app before upload.
+behalf of the RepoPrompt CE project. Sentry project-side data scrubbing is maintained as additional
+defense-in-depth where available; RepoPrompt's primary privacy boundary is avoiding sensitive data
+collection in the app before upload.


### PR DESCRIPTION
## Summary

- disable Sentry failed-request capture and automatic release-health sessions
- remove the explicit distribution override so cached crashes retain their historical build metadata
- scrub request, user, geo, server, and stable device/install identifiers, including macOS `device_app_hash`
- document the effective privacy behavior in Settings and the telemetry policy
- create/finalize Sentry releases, associate commits, record production deploys, and preserve symbol uploads during publication
- add focused privacy and release-tooling regression coverage

## Privacy decisions

Automatic Sentry session tracking is disabled because Sentry Cocoa 9.17.1 persists an installation identifier as the session `did`. This intentionally means crash-free-session metrics will not be populated unless a future privacy-safe session strategy is introduced.

The app-side scrubber is defense in depth alongside the live Sentry project settings. It removes the Sentry request object and recursively drops request payload, geo, user, and stable identifier fields while retaining safe diagnostic siblings.

## Release behavior

The publication path now:

1. derives the Sentry release as `bundleID@marketingVersion+buildNumber`
2. creates the release and associates the exact source commit
3. uploads the existing required dSYMs
4. finalizes the Sentry release
5. records a production deploy

The publish workflow explicitly enables Sentry linking and supplies the production deploy environment.

## Validation

Passed:

- commit preflight: staged-index secret scan + repository guardrails
- push preflight: outgoing-range secret scan + clean-branch checks
- `make dev-format`
- `make dev-lint` / PR-ready lint ticket `62a6fd43-1d6f-40b1-ba4d-517bde126411`
- `make dev-test FILTER=SettingsJSONOnlyPersistenceTests`: 36 tests, 0 failures (ticket `409f32aa-5f65-45e3-8d8e-5c9f305e4c41`)
- `python3 Scripts/test_release_tooling.py`: 55 tests, OK
- Claude Fable 5 High review; final verdict: merge-ready, no remaining must-fix findings

Pending due machine-wide coordination:

- path-selected PR-ready full root test/build lane: ticket `005543a0-fad5-4f2f-bd44-380e52784192`
- the ticket is waiting on `/tmp/conductor-501/global-heavy.lock`, held by another checkout's long-running Swift test; no duplicate or uncoordinated build was started
- explicit release preflight should run after the shared heavy slot is available

## Live Sentry operational changes

Already applied to `repoprompt/repoprompt`:

- enabled IP-address scrubbing
- added sensitive-field scrubbing for geo and stable device/install identifiers
- created production issue-frequency alert `RepoPrompt CE production error volume spike` (ID `17279372`)

Metric-alert creation returned 403 Forbidden. No crash-free-session alert was created because this change deliberately disables automatic sessions.

## Follow-up

Before the first Sentry-enabled publication, confirm the release token retains `project:releases` access. The Sentry GitHub integration for `repoprompt/repoprompt-ce` is present and release reads currently succeed.
