### PR TITLE
Refresh approved contributors

### DIFF
--- a/.github/APPROVED_CONTRIBUTORS
+++ b/.github/APPROVED_CONTRIBUTORS
@@ -24,6 +24,7 @@ abhshkt pr
 abyssbugg pr
 achiu3q pr
 aconcepcion pr
+adamarul pr
 adamhelfgott pr
 adamkmccarthy pr
 adampearse pr
@@ -34,6 +35,7 @@ AdrianAlonsoDev pr
 afadlallah pr
 agamrp pr
 agentdouble0zero pr
+agustif pr
 ahafonof pr
 AI-MickyJ pr
 ajitaravind pr
@@ -50,6 +52,7 @@ alexdav pr
 alexg021 pr
 alexss200010 pr
 alimbaydoun pr
+alvaroybanez pr
 amadad pr
 amit-feldman pr
 amit0365 pr
@@ -119,6 +122,7 @@ brettmadill pr
 brianhays pr
 brichase pr
 brytoncooper pr
+BTCElectrician pr
 BullThistle pr
 bz8768 pr
 c-p-b pr
@@ -246,6 +250,7 @@ enzodesena pr
 eolach pr
 erauner12 pr
 erikdrouhard pr
+erikois pr
 erodriguezh pr
 ethan-wickstrom pr
 eugene1g pr
@@ -312,7 +317,9 @@ helpimfalling pr
 HendrikReh pr
 henrycarrero pr
 heomin86 pr
+HeroRushGo pr
 heyalchang pr
+hghallTAZ pr
 hierosir1984 pr
 highlandhodl pr
 hmottestad pr
@@ -514,10 +521,12 @@ nick3t pr
 nickdavis pr
 nickperry12 pr
 nicolasburgosg pr
+NiestrojMateusz pr
 Nitron pr
 nkeat12 pr
 NKHN-AU pr
 nkraus pr
+NomDeBits pr
 NoRKin pr
 notmyalias pr
 nstranquist pr
@@ -529,6 +538,7 @@ OCPdev25 pr
 OCWC22 pr
 oegedijk pr
 olety pr
+olivier-auber pr
 OlivierPineau pr
 OmarAlShishani pr
 Omoeba pr
@@ -555,6 +565,7 @@ phpfour pr
 phren0logy pr
 pnascimento9596 pr
 pottedmeat pr
+pranavsuri4303 pr
 pryley pr
 pszanser pr
 pyronaur pr
@@ -563,8 +574,10 @@ qtm pr
 Qwantime pr
 radosek pr
 RadRebelSam pr
+rahulvrane pr
 rahulxsomething pr
 rameezshuhaib pr
+ranvier2d2 pr
 raphaelluethy pr
 ratulsarna pr
 raydocs pr
@@ -586,6 +599,7 @@ RoeeJ pr
 rohanp2051 pr
 RomainCrz pr
 rondered pr
+Rossnkama pr
 rpalermodrums pr
 rshagiev pr
 rwblackburn pr
@@ -630,6 +644,7 @@ smat-dev pr
 sodiumsun pr
 Sophanos pr
 sounart pr
+spazbg pr
 sportsandfragrance pr
 Srini-B pr
 staceymoore pr


### PR DESCRIPTION
## Summary
- refresh `.github/APPROVED_CONTRIBUTORS` from live customer claims
- contributor count: 758 -> 773
- unresolved claim-form GitHub IDs: TeamLandiLTD (organization), Tyschultz7, ahafonof, hsinskip, mrbagels, vchepeli, woody-chin, xuanvinhvu
- preserved existing allowlist entries and added 15 newly resolved contributors

## Validation
- `make guardrails`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh commit`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh push`
