### PR TITLE
fix(workspaces): prevent ephemeral workspace data from reaching disk

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentSessionDataService.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentSessionDataService.swift
@@ -858,6 +858,7 @@ actor AgentSessionDataService {
         for workspace: WorkspaceModel,
         mode: AgentSessionMetadataIndexLoadMode
     ) async throws -> AgentSessionMetadataIndex? {
+        guard workspace.persistenceDisposition == .persistent else { return nil }
         let folder = try ensureAgentSessionsFolder(for: workspace)
         switch mode {
         case .fast:
@@ -874,6 +875,7 @@ actor AgentSessionDataService {
     }
 
     func fastMetadataRecordsIfAvailable(for workspace: WorkspaceModel) async throws -> FastMetadataRecordsResult? {
+        guard workspace.persistenceDisposition == .persistent else { return nil }
         let folder = try ensureAgentSessionsFolder(for: workspace)
         let key = canonicalMetadataFolderKey(folder)
         if let cached = metadataIndexCacheByFolder[key] {
@@ -912,6 +914,7 @@ actor AgentSessionDataService {
     }
 
     func metadataRecordForSessionID(_ id: UUID, for workspace: WorkspaceModel) async throws -> AgentSessionMetadataRecord? {
+        guard workspace.persistenceDisposition == .persistent else { return nil }
         let folder = try ensureAgentSessionsFolder(for: workspace)
         let fileURL = agentSessionFileURL(id: id, in: folder)
         guard FileManager.default.fileExists(atPath: fileURL.path) else {
@@ -940,6 +943,7 @@ actor AgentSessionDataService {
     }
 
     func sidebarStreamMetadataRecords(for workspace: WorkspaceModel) async throws -> [AgentSessionMetadataRecord] {
+        guard workspace.persistenceDisposition == .persistent else { return [] }
         let folder = try ensureAgentSessionsFolder(for: workspace)
         if let index = await readMetadataIndexIfAvailable(folder: folder) {
             scheduleMetadataIndexReconciliationIfNeeded(
@@ -963,6 +967,9 @@ actor AgentSessionDataService {
         preparation: SavePreparation = .canonicalize,
         trustedCanonicalItemCount: Int? = nil
     ) async throws -> URL {
+        guard workspace.persistenceDisposition == .persistent else {
+            throw WorkspacePersistenceError.ephemeralWorkspace
+        }
         let agentSessionsFolder = try ensureAgentSessionsFolder(for: workspace)
 
         let filename = "AgentSession-\(session.id.uuidString).json"
@@ -1140,6 +1147,7 @@ actor AgentSessionDataService {
 
     /// Returns a list of AgentSession files in the workspace's AgentSessions folder, sorted by mod date desc.
     func listAgentSessions(for workspace: WorkspaceModel) async throws -> [URL] {
+        guard workspace.persistenceDisposition == .persistent else { return [] }
         let agentSessionsFolder = try ensureAgentSessionsFolder(for: workspace)
 
         let contents = try FileManager.default.contentsOfDirectory(
@@ -1291,6 +1299,7 @@ actor AgentSessionDataService {
 
     /// Load an agent session by ID without scanning the session directory.
     func loadAgentSession(id: UUID, for workspace: WorkspaceModel) async throws -> AgentSession? {
+        guard workspace.persistenceDisposition == .persistent else { return nil }
         let agentSessionsFolder = try ensureAgentSessionsFolder(for: workspace)
         let filename = "AgentSession-\(id.uuidString).json"
         let fileURL = agentSessionsFolder.appendingPathComponent(filename)
@@ -1457,6 +1466,9 @@ actor AgentSessionDataService {
 
     /// Creates (if needed) and returns the "AgentSessions" subfolder for the given workspace.
     private func ensureAgentSessionsFolder(for workspace: WorkspaceModel) throws -> URL {
+        guard workspace.persistenceDisposition == .persistent else {
+            throw WorkspacePersistenceError.ephemeralWorkspace
+        }
         let baseFolder = try workspaceFolderURL(for: workspace)
         let agentSessionsFolder = baseFolder.appendingPathComponent("AgentSessions")
 

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+WorktreeMerge.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+WorktreeMerge.swift
@@ -423,7 +423,9 @@ extension AgentModeViewModel {
         )
         try await requireAuthorizedWorktreeMergeEndpoint(targetEndpoint, roots: authorizedRoots, label: "Target")
         let directory = workspaceDirectory
-            ?? workspaceManager?.activeWorkspace?.customStoragePath
+            ?? workspaceManager.flatMap { manager in
+                manager.activeWorkspace.map { manager.featureArtifactDirectory(for: $0) }
+            }
             ?? FileManager.default.temporaryDirectory
         let preview = try await VCSService.shared.previewGitWorktreeMerge(.init(
             source: source,

--- a/Sources/RepoPrompt/Features/Chat/Services/ChatHistoryManager.swift
+++ b/Sources/RepoPrompt/Features/Chat/Services/ChatHistoryManager.swift
@@ -120,6 +120,9 @@ actor ChatDataService {
         _ session: ChatSession,
         for workspace: WorkspaceModel
     ) async throws -> URL {
+        guard workspace.persistenceDisposition == .persistent else {
+            throw WorkspacePersistenceError.ephemeralWorkspace
+        }
         // 1) Get "Chats" folder
         let chatsFolder = try ensureChatsFolder(for: workspace)
 
@@ -282,6 +285,7 @@ actor ChatDataService {
 
     /// Returns a list of "ChatSession-xxx.json" files in the workspace’s Chats folder, sorted by mod date desc.
     func listChatSessions(for workspace: WorkspaceModel) async throws -> [URL] {
+        guard workspace.persistenceDisposition == .persistent else { return [] }
         let chatsFolder = try ensureChatsFolder(for: workspace)
 
         let contents = try FileManager.default.contentsOfDirectory(
@@ -440,6 +444,9 @@ actor ChatDataService {
     /// Creates (if needed) and returns the "Chats" subfolder for the given workspace.
     /// Uses workspace.customStoragePath if set, else the default ~Library location.
     private func ensureChatsFolder(for workspace: WorkspaceModel) throws -> URL {
+        guard workspace.persistenceDisposition == .persistent else {
+            throw WorkspacePersistenceError.ephemeralWorkspace
+        }
         let baseFolder = try workspaceFolderURL(for: workspace)
         let chatsFolder = baseFolder.appendingPathComponent("Chats")
 

--- a/Sources/RepoPrompt/Features/Prompt/ViewModels/PromptViewModel.swift
+++ b/Sources/RepoPrompt/Features/Prompt/ViewModels/PromptViewModel.swift
@@ -1124,7 +1124,7 @@ class PromptViewModel: ObservableObject {
         guard let workspaceManager else {
             throw GitArtifactPublishError.noActiveWorkspace
         }
-        let workspaceDirectory = workspaceManager.workspaceDirectory(for: workspace)
+        let workspaceDirectory = workspaceManager.featureArtifactDirectory(for: workspace)
         let compareDisplay = compareSpec.displayString
 
         // Publish the artifacts
@@ -3146,7 +3146,7 @@ class PromptViewModel: ObservableObject {
               let manager = workspaceManager,
               let workspace = manager.activeWorkspace else { return }
 
-        let workspaceDir = manager.workspaceDirectory(for: workspace)
+        let workspaceDir = manager.featureArtifactDirectory(for: workspace)
 
         // Run cleanup in background with a single batch scan
         Task(priority: .utility) {
@@ -5715,7 +5715,7 @@ extension PromptViewModel {
         }
         return await FrozenPromptGitReviewContext.make(
             workspaceID: workspace.id,
-            workspaceDirectoryPath: manager.workspaceDirectory(for: workspace).path,
+            workspaceDirectoryPath: manager.featureArtifactDirectory(for: workspace).path,
             workspaceRootPaths: workspace.repoPaths,
             tabID: creatorTabID,
             sessionID: sessionID,

--- a/Sources/RepoPrompt/Features/Workspaces/ViewModels/WorkspaceManagerViewModel.swift
+++ b/Sources/RepoPrompt/Features/Workspaces/ViewModels/WorkspaceManagerViewModel.swift
@@ -1839,6 +1839,25 @@ class WorkspaceManagerViewModel: ObservableObject {
         return baseRoot.appendingPathComponent(directoryName(for: workspace))
     }
 
+    /// Feature artifacts remain usable for a temporary workspace, but live under a
+    /// lifecycle-managed temporary root rather than its durable workspace directory.
+    func featureArtifactDirectory(for workspace: WorkspaceModel) -> URL {
+        guard workspace.persistenceDisposition == .skipEphemeral else {
+            return workspaceDirectory(for: workspace)
+        }
+        return Self.ephemeralArtifactDirectory(for: workspace.id)
+    }
+
+    private nonisolated static func ephemeralArtifactDirectory(for workspaceID: UUID) -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("RepoPromptCE-EphemeralArtifacts", isDirectory: true)
+            .appendingPathComponent(workspaceID.uuidString, isDirectory: true)
+    }
+
+    private func removeEphemeralArtifacts(for workspaceID: UUID) {
+        try? FileManager.default.removeItem(at: Self.ephemeralArtifactDirectory(for: workspaceID))
+    }
+
     func workspaceFileURL(for workspace: WorkspaceModel) -> URL {
         if domainWorkspaceAuthorityClient != nil,
            let authoritativeURL = domainWorkspaceFileURLsByID[workspace.id]
@@ -1858,6 +1877,10 @@ class WorkspaceManagerViewModel: ObservableObject {
     }
 
     func gitDataDirectory(for workspace: WorkspaceModel) -> URL {
+        if workspace.persistenceDisposition == .skipEphemeral {
+            return featureArtifactDirectory(for: workspace)
+                .appendingPathComponent("_git_data", isDirectory: true)
+        }
         gitDataDirectory(for: workspace, baseRoot: currentBaseRoot)
     }
 
@@ -1867,6 +1890,10 @@ class WorkspaceManagerViewModel: ObservableObject {
     }
 
     func gitDataTabDirectory(for workspace: WorkspaceModel, tabID: UUID) -> URL {
+        if workspace.persistenceDisposition == .skipEphemeral {
+            return gitDataDirectory(for: workspace)
+                .appendingPathComponent(tabID.uuidString, isDirectory: true)
+        }
         gitDataTabDirectory(for: workspace, tabID: tabID, baseRoot: currentBaseRoot)
     }
 
@@ -2613,6 +2640,14 @@ class WorkspaceManagerViewModel: ObservableObject {
                 object: nil,
                 userInfo: ["managerID": instanceID]
             )
+            if let domainWorkspaceAuthorityClient {
+                Task { @MainActor in
+                    _ = try? await domainWorkspaceAuthorityClient.registerForRead(
+                        newWorkspace,
+                        fileURL: workspaceFileURL(for: newWorkspace)
+                    )
+                }
+            }
         }
 
         return newWorkspace
@@ -3443,7 +3478,6 @@ class WorkspaceManagerViewModel: ObservableObject {
                     schedulePostSwitchGitDataLoad(for: switchedWorkspace, reason: "postSwitch")
                 }
             }
-        }
         let hydrationGeneration = beginWorkspaceHydration(for: newWorkspace)
         #if DEBUG
             if let workspaceSwitchReadinessDidInvalidateHandlerForTesting {
@@ -3854,7 +3888,7 @@ class WorkspaceManagerViewModel: ObservableObject {
     /// Runs git data maintenance when a workspace is opened.
     /// This handles version upgrades, legacy purge, and retention enforcement (max 25 snapshots, 7 day expiry).
     private func runGitDataMaintenanceOnWorkspaceOpen(_ workspace: WorkspaceModel) {
-        let workspaceDir = workspaceDirectory(for: workspace)
+        let workspaceDir = featureArtifactDirectory(for: workspace)
         let workspaceName = workspace.name
         Task.detached(priority: .utility) {
             let result = await GitDiffDataMaintenance.shared.runOnWorkspaceOpen(workspaceDirectory: workspaceDir)
@@ -4099,6 +4133,15 @@ class WorkspaceManagerViewModel: ObservableObject {
     /// Coalesces high-frequency UI captures before issuing one durable working-state command.
     private func publishWorkingDocumentToDomainAuthority(_ workspace: WorkspaceModel) {
         guard let domainWorkspaceAuthorityClient else { return }
+        if workspace.persistenceDisposition == .skipEphemeral {
+            Task { @MainActor in
+                _ = try? await domainWorkspaceAuthorityClient.registerForRead(
+                    workspace,
+                    fileURL: workspaceFileURL(for: workspace)
+                )
+            }
+            return
+        }
         let workspaceID = workspace.id
         let generation = domainWorkingCommitGeneration[workspaceID, default: 0] &+ 1
         domainWorkingCommitGeneration[workspaceID] = generation
@@ -7824,6 +7867,7 @@ class WorkspaceManagerViewModel: ObservableObject {
         private var waitersByURL: [URL: [CheckedContinuation<Void, Never>]] = [:]
         private var latestSelectionByWorkspaceTab: [WorkspaceTabSelectionKey: LatestSelectionRecord] = [:]
         private var lastWrittenSelectionRevisionByWorkspaceTab: [WorkspaceTabSelectionKey: UInt64] = [:]
+        private var persistenceBlockedWorkspaceIDs: Set<UUID> = []
         #if DEBUG
             private var atomicWriteGateForTesting: (@Sendable () async -> Void)?
             private var decodeWorkForTesting = DecodeWork()
@@ -7846,6 +7890,11 @@ class WorkspaceManagerViewModel: ObservableObject {
             WorkspaceSaveTracer.event("workspaceSave.enqueue", metadata: metadata, url: url)
             recordLatestSelectionIfNeeded(metadata)
             let identity = Self.payloadIdentity(metadata: metadata, data: data)
+            let workspaceID = metadata?.workspaceID ?? identity?.workspaceID
+            guard workspaceID.map({ !persistenceBlockedWorkspaceIDs.contains($0) }) ?? true else {
+                WorkspaceSaveTracer.event("workspaceSave.enqueue.blockedEphemeral", metadata: metadata, url: url)
+                return
+            }
             #if DEBUG
                 if metadata == nil, identity != nil {
                     decodeWorkForTesting.identityPayloadCount &+= 1
@@ -7899,6 +7948,30 @@ class WorkspaceManagerViewModel: ObservableObject {
             await flush(url: url)
         }
 
+        /// Fences queued writes when a workspace becomes ephemeral. The payload can already
+        /// be queued when the model changes, so both enqueue and the final write check this.
+        func setPersistenceBlocked(_ blocked: Bool, workspaceID: UUID) {
+            if blocked {
+                persistenceBlockedWorkspaceIDs.insert(workspaceID)
+                for (url, var pending) in pendingByURL {
+                    guard pending.newestMetadata?.workspaceID == workspaceID
+                        || pending.newestIdentity?.workspaceID == workspaceID
+                    else { continue }
+                    pending.newestData = Data()
+                    pending.newestMetadata = nil
+                    pending.newestIdentity = nil
+                    pending.newestLifecycleCorrelation = nil
+                    pendingByURL[url] = pending
+                }
+            } else {
+                persistenceBlockedWorkspaceIDs.remove(workspaceID)
+            }
+        }
+
+        private func isPersistenceBlocked(_ workspaceID: UUID) -> Bool {
+            persistenceBlockedWorkspaceIDs.contains(workspaceID)
+        }
+
         func writeNormalizationIfUnchanged(
             data: Data,
             url: URL,
@@ -7907,6 +7980,10 @@ class WorkspaceManagerViewModel: ObservableObject {
             metadata: WorkspaceSavePayloadMetadata? = nil
         ) -> Bool {
             guard pendingByURL[url] == nil else { return false }
+            let workspaceID = metadata?.workspaceID ?? Self.decodedWorkspacePayloadIdentity(data)?.workspaceID
+            guard workspaceID.map({ !persistenceBlockedWorkspaceIDs.contains($0) }) ?? true else {
+                return false
+            }
             do {
                 let values = try url.resourceValues(forKeys: [.fileSizeKey, .contentModificationDateKey])
                 guard Int64(values.fileSize ?? -1) == expectedFileSize,
@@ -7969,6 +8046,7 @@ class WorkspaceManagerViewModel: ObservableObject {
                 pendingByURL.removeAll()
                 latestSelectionByWorkspaceTab.removeAll()
                 lastWrittenSelectionRevisionByWorkspaceTab.removeAll()
+                persistenceBlockedWorkspaceIDs.removeAll()
                 atomicWriteGateForTesting = nil
                 decodeWorkForTesting = DecodeWork()
                 let allWaiters = waitersByURL.values.flatMap(\.self)
@@ -8234,6 +8312,26 @@ class WorkspaceManagerViewModel: ObservableObject {
                         #if DEBUG
                             await atomicWriteGateForTesting?()
                         #endif
+                        let workspaceID = effective.metadata?.workspaceID
+                            ?? Self.decodedWorkspacePayloadIdentity(effective.data)?.workspaceID
+                        let persistenceBlocked = if let workspaceID {
+                            await self?.isPersistenceBlocked(workspaceID) ?? false
+                        } else {
+                            false
+                        }
+                        if persistenceBlocked {
+                            WorkspaceSaveTracer.event(
+                                "workspaceSave.write.blockedEphemeral",
+                                metadata: effective.metadata,
+                                url: url
+                            )
+                            await self?.writerFinished(
+                                for: url,
+                                effective: effective,
+                                writeSucceeded: false
+                            )
+                            return
+                        }
                         let writeState = EditFlowPerf.begin(EditFlowPerf.Stage.WorkspaceDurability.atomicWrite)
                         EditFlowPerf.lifecycleEvent(
                             EditFlowPerf.Lifecycle.WorkspaceDurability.writeBegan,
@@ -8307,13 +8405,23 @@ class WorkspaceManagerViewModel: ObservableObject {
         source: WorkspaceSaveSource = .saveWorkspaceAsync,
         remainingRetryCount: Int = 1
     ) async -> Int? {
-        guard !Task.isCancelled else { return nil }
-        if domainWorkspaceAuthorityClient != nil,
-           let currentIndex = workspaceIndex(for: workspaceID)
-        {
+        guard !Task.isCancelled,
+              let currentIndex = workspaceIndex(for: workspaceID)
+        else { return nil }
+        let currentWorkspace = workspaces[currentIndex]
+        if currentWorkspace.persistenceDisposition == .skipEphemeral {
+            if let domainWorkspaceAuthorityClient {
+                _ = try? await domainWorkspaceAuthorityClient.registerForRead(
+                    currentWorkspace,
+                    fileURL: fileURL
+                )
+            }
+            return nil
+        }
+        if domainWorkspaceAuthorityClient != nil {
             do {
                 let result = try await persistWorkspaceThroughDomainAuthority(
-                    workspaces[currentIndex],
+                    currentWorkspace,
                     targetURL: fileURL,
                     preserveDiskRepoPathsIfUnchangedSinceBaseline: true,
                     source: source,
@@ -8542,6 +8650,18 @@ class WorkspaceManagerViewModel: ObservableObject {
             )
         }
 
+        guard let latestIndex = workspaceIndex(for: workspace.id),
+              workspaces[latestIndex].persistenceDisposition == .persistent
+        else {
+            if let currentIndex = workspaceIndex(for: workspace.id) {
+                _ = try? await domainWorkspaceAuthorityClient.registerForRead(
+                    workspaces[currentIndex],
+                    fileURL: targetURL
+                )
+            }
+            throw CancellationError()
+        }
+
         let snapshot = await domainWorkspaceAuthorityClient.snapshot()
         let exists = snapshot.workspaces.contains {
             $0.document.workspaceID == workspaceToSave.id
@@ -8607,6 +8727,13 @@ class WorkspaceManagerViewModel: ObservableObject {
         source: WorkspaceSaveSource = .directUnknown
     ) async throws -> URL {
         let targetURL = workspaceFileURL(for: workspace)
+        if workspace.persistenceDisposition == .skipEphemeral {
+            if let domainWorkspaceAuthorityClient {
+                _ = try await domainWorkspaceAuthorityClient.registerForRead(workspace, fileURL: targetURL)
+                return targetURL
+            }
+            throw WorkspacePersistenceError.ephemeralWorkspace
+        }
         if domainWorkspaceAuthorityClient != nil {
             let result = try await persistWorkspaceThroughDomainAuthority(
                 workspace,
@@ -8671,6 +8798,9 @@ class WorkspaceManagerViewModel: ObservableObject {
         metadata: WorkspaceSavePayloadMetadata? = nil
     ) async throws -> URL {
         let finalURL = workspaceFileURL(for: workspace, baseRoot: baseRoot)
+        guard workspace.persistenceDisposition == .persistent else {
+            throw WorkspacePersistenceError.ephemeralWorkspace
+        }
         guard domainWorkspaceAuthorityClient == nil else {
             WorkspaceSaveTracer.event(
                 "workspaceSave.direct.denied",
@@ -8698,6 +8828,9 @@ class WorkspaceManagerViewModel: ObservableObject {
 
     /// Synchronous workspace write used by focused tests and direct save paths.
     func saveWorkspaceToFile(_ workspace: WorkspaceModel, source: WorkspaceSaveSource = .directUnknown) throws -> URL {
+        guard workspace.persistenceDisposition == .persistent else {
+            throw WorkspacePersistenceError.ephemeralWorkspace
+        }
         guard domainWorkspaceAuthorityClient == nil else {
             throw NSError(
                 domain: "RepoPrompt.DomainWorkspaceAuthority",
@@ -9561,10 +9694,33 @@ class WorkspaceManagerViewModel: ObservableObject {
         )
     }
 
-    /// Sets a workspace's ephemeral property by ID
-    func setWorkspaceEphemeral(_ workspaceID: UUID, _ value: Bool) {
-        if let idx = workspaces.firstIndex(where: { $0.id == workspaceID }) {
-            workspaces[idx].isEphemeral = value
+    /// Switches a workspace's durability boundary without disrupting its live read model.
+    func setWorkspaceEphemeral(_ workspaceID: UUID, _ value: Bool) async {
+        guard let idx = workspaces.firstIndex(where: { $0.id == workspaceID }),
+              workspaces[idx].isEphemeral != value
+        else { return }
+
+        if value {
+            // Make all newly scheduled saves transient before awaiting the write barriers.
+            workspaces[idx].isEphemeral = true
+            domainWorkingCommitGeneration[workspaceID, default: 0] &+= 1
+            if let pending = domainWorkingCommitTasks.removeValue(forKey: workspaceID) {
+                pending.cancel()
+                await pending.value
+            }
+            await WorkspaceDiskWriter.shared.setPersistenceBlocked(true, workspaceID: workspaceID)
+            guard let currentIndex = workspaceIndex(for: workspaceID) else { return }
+            if let domainWorkspaceAuthorityClient {
+                _ = try? await domainWorkspaceAuthorityClient.registerForRead(
+                    workspaces[currentIndex],
+                    fileURL: workspaceFileURL(for: workspaces[currentIndex])
+                )
+            }
+        } else {
+            removeEphemeralArtifacts(for: workspaceID)
+            await WorkspaceDiskWriter.shared.setPersistenceBlocked(false, workspaceID: workspaceID)
+            guard let currentIndex = workspaceIndex(for: workspaceID) else { return }
+            workspaces[currentIndex].isEphemeral = false
         }
     }
 
@@ -9645,12 +9801,7 @@ class WorkspaceManagerViewModel: ObservableObject {
 
     /// Creates an ephemeral workspace (non-persisted)
     func createEphemeralWorkspace(name: String, repoPaths: [String]) -> WorkspaceModel {
-        var ws = createWorkspace(name: name, repoPaths: repoPaths)
-        if let idx = workspaces.firstIndex(where: { $0.id == ws.id }) {
-            workspaces[idx].isEphemeral = true
-            ws = workspaces[idx] // re-fetch the mutated copy
-        }
-        return ws
+        createWorkspace(name: name, repoPaths: repoPaths, ephemeral: true)
     }
 
     @MainActor

--- a/Sources/RepoPrompt/Features/Workspaces/WorkspaceModel.swift
+++ b/Sources/RepoPrompt/Features/Workspaces/WorkspaceModel.swift
@@ -563,11 +563,28 @@ struct WorkspaceModel: Codable, Identifiable, Equatable {
     }
 }
 
+enum WorkspacePersistenceDisposition: Equatable {
+    case persistent
+    case skipEphemeral
+}
+
+enum WorkspacePersistenceError: LocalizedError, Equatable {
+    case ephemeralWorkspace
+
+    var errorDescription: String? {
+        "Temporary workspaces do not write durable workspace data."
+    }
+}
+
 extension WorkspaceModel {
     /// Indicates whether this workspace should not be persisted to disk
     var isEphemeral: Bool {
         get { ephemeralFlag ?? false }
         set { ephemeralFlag = newValue }
+    }
+
+    var persistenceDisposition: WorkspacePersistenceDisposition {
+        isEphemeral ? .skipEphemeral : .persistent
     }
 
     @discardableResult

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel.swift
@@ -3979,7 +3979,7 @@ final class MCPServerViewModel: ObservableObject {
                     workspaceContext = try await ContextBuilderWorkspaceContext.resolve(
                         from: context,
                         workspaceRepoPaths: workspace.repoPaths,
-                        workspaceDirectoryPath: targetWindow.workspaceManager.workspaceDirectory(for: workspace).path,
+                        workspaceDirectoryPath: targetWindow.workspaceManager.featureArtifactDirectory(for: workspace).path,
                         store: targetWindow.promptManager.workspaceFileContextStore
                     )
                 } catch {

--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPGitToolProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPGitToolProvider.swift
@@ -466,7 +466,7 @@ final class MCPGitToolProvider {
         guard let workspace = routedWorkspace else {
             throw MCPError.invalidParams("No active workspace in this window. Use manage_workspaces action='list' to see available workspaces, then action='switch' to load one.")
         }
-        let workspaceDirectory = workspaceManager.workspaceDirectory(for: workspace)
+        let workspaceDirectory = workspaceManager.featureArtifactDirectory(for: workspace)
         let store = GitDiffSnapshotStore()
         let vcsService = VCSService.shared
 

--- a/Tests/RepoPromptTests/Workspaces/WorkspaceEphemeralPersistenceTests.swift
+++ b/Tests/RepoPromptTests/Workspaces/WorkspaceEphemeralPersistenceTests.swift
@@ -1,0 +1,160 @@
+@testable import RepoPromptApp
+import XCTest
+
+final class WorkspaceEphemeralPersistenceTests: XCTestCase {
+    override func tearDown() async throws {
+        await WorkspaceManagerViewModel.WorkspaceDiskWriter.shared.removeAllForTesting()
+        try await super.tearDown()
+    }
+
+    @MainActor
+    func testEphemeralFactoryAndAutosaveNeverCreateWorkspaceStorage() async throws {
+        let storageRoot = temporaryStorageRoot()
+        defer { try? FileManager.default.removeItem(at: storageRoot) }
+        let manager = makeManager()
+        manager.globalCustomStorageURL = storageRoot
+        manager.workspaces = []
+
+        let workspace = manager.createEphemeralWorkspace(
+            name: "Temporary Review",
+            repoPaths: ["/tmp/temporary-review"]
+        )
+        manager.activeWorkspace = workspace
+
+        await manager.pollAndSaveStateAsync(source: .pollAndSaveStateAsync)
+        await WorkspaceManagerViewModel.WorkspaceDiskWriter.shared.flush(
+            url: manager.workspaceFileURL(for: workspace)
+        )
+
+        XCTAssertTrue(workspace.isEphemeral)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: storageRoot.path))
+    }
+
+    @MainActor
+    func testEphemeralWorkspaceReadsAreEmptyAndWritesDoNotCreateSidecars() async throws {
+        let storageRoot = temporaryStorageRoot()
+        defer { try? FileManager.default.removeItem(at: storageRoot) }
+        var workspace = WorkspaceModel(
+            name: "Temporary",
+            repoPaths: [],
+            customStoragePath: storageRoot
+        )
+        workspace.isEphemeral = true
+
+        XCTAssertEqual(try await ChatDataService().listChatSessions(for: workspace), [])
+        XCTAssertEqual(try await AgentSessionDataService.shared.listAgentSessions(for: workspace), [])
+        XCTAssertNil(try await AgentSessionDataService.shared.loadAgentSession(id: UUID(), for: workspace))
+        let manager = makeManager()
+        await XCTAssertThrowsErrorAsync {
+            try await manager.saveWorkspaceToFileAsync(workspace, baseRoot: storageRoot)
+        }
+        await XCTAssertThrowsErrorAsync {
+            try await ChatDataService().saveChatSession(ChatSession(name: "Unsaved", messages: []), for: workspace)
+        }
+        XCTAssertFalse(FileManager.default.fileExists(atPath: storageRoot.path))
+    }
+
+    @MainActor
+    func testEphemeralWorkspaceUsesTemporaryGitArtifactRoot() {
+        let storageRoot = temporaryStorageRoot()
+        defer { try? FileManager.default.removeItem(at: storageRoot) }
+        let manager = makeManager()
+        var workspace = WorkspaceModel(
+            name: "Temporary Git",
+            repoPaths: [],
+            customStoragePath: storageRoot
+        )
+        workspace.isEphemeral = true
+
+        let artifactDirectory = manager.gitDataDirectory(for: workspace)
+
+        XCTAssertTrue(artifactDirectory.path.contains("RepoPromptCE-EphemeralArtifacts"))
+        XCTAssertFalse(artifactDirectory.path.hasPrefix(storageRoot.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: storageRoot.path))
+    }
+
+    @MainActor
+    func testConvertingWorkspaceToEphemeralBlocksAnInFlightLegacyWriter() async throws {
+        let storageRoot = temporaryStorageRoot()
+        defer { try? FileManager.default.removeItem(at: storageRoot) }
+        let manager = makeManager()
+        let workspace = WorkspaceModel(name: "In Flight", repoPaths: [], customStoragePath: storageRoot)
+        manager.workspaces = [workspace]
+        let gate = WorkspaceEphemeralPersistenceGate()
+        let writer = WorkspaceManagerViewModel.WorkspaceDiskWriter.shared
+        await writer.setAtomicWriteGateForTesting { await gate.arriveAndWait() }
+
+        let fileURL = try await manager.saveWorkspaceToFileAsync(workspace, baseRoot: storageRoot)
+        await gate.waitUntilArrived()
+        await manager.setWorkspaceEphemeral(workspace.id, true)
+        await gate.release()
+        await writer.flush(url: fileURL)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fileURL.path))
+    }
+
+    @MainActor
+    private func makeManager() -> WorkspaceManagerViewModel {
+        let files = WorkspaceFilesViewModel(workspaceFileContextStore: WorkspaceFileContextStore())
+        let keyManager = KeyManager(secureService: SecureKeysService(secureStorage: TestSecureStorageBackend()))
+        let apiSettings = APISettingsViewModel(
+            aiQueriesService: AIQueriesService(keyManager: keyManager),
+            keyManager: keyManager,
+            loadStoredDataOnInit: false
+        )
+        let prompt = PromptViewModel(
+            fileManager: files,
+            apiSettingsViewModel: apiSettings,
+            windowID: -485,
+            settingsManager: WindowSettingsManager(windowID: -485)
+        )
+        return WorkspaceManagerViewModel(
+            fileManager: files,
+            promptViewModel: prompt,
+            performInitialWorkspaceActivation: false
+        )
+    }
+
+    private func temporaryStorageRoot() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("WorkspaceEphemeralPersistenceTests-\(UUID().uuidString)", isDirectory: true)
+    }
+
+    @MainActor
+    private func XCTAssertThrowsErrorAsync(
+        _ expression: () async throws -> some Any,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        do {
+            _ = try await expression()
+            XCTFail("Expected expression to throw", file: file, line: line)
+        } catch {}
+    }
+}
+
+private actor WorkspaceEphemeralPersistenceGate {
+    private var arrived = false
+    private var released = false
+    private var arrivalWaiters: [CheckedContinuation<Void, Never>] = []
+    private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func arriveAndWait() async {
+        arrived = true
+        arrivalWaiters.forEach { $0.resume() }
+        arrivalWaiters.removeAll()
+        guard !released else { return }
+        await withCheckedContinuation { releaseWaiters.append($0) }
+    }
+
+    func waitUntilArrived() async {
+        guard !arrived else { return }
+        await withCheckedContinuation { arrivalWaiters.append($0) }
+    }
+
+    func release() {
+        released = true
+        releaseWaiters.forEach { $0.resume() }
+        releaseWaiters.removeAll()
+    }
+}


### PR DESCRIPTION
## Problem

Ephemeral workspaces are meant to exist only for the current app session, but their creation previously entered the normal persistent-workspace flow before the workspace was marked ephemeral. That allowed directory creation or a save to be scheduled during the transition.

Lower-level APIs could also write workspace-owned sidecars from a workspace model or storage URL without first proving that persistence was allowed. A temporary workspace could therefore leave chats, attachments, agent sessions, Git metadata, or merge artifacts on disk.

Fixes #468.

## Approach

Treat ephemeral behavior as a storage contract rather than a creation-time flag.

The workspace is now marked ephemeral before creation can schedule persistence. Lower-level storage paths require an authorized `WorkspacePersistentStorage` capability, and the writer checks authoritative workspace state again immediately before writing. Creation-time checks alone would not cover later sidecar writes or work already queued by a stale model.

## Changes

- Mark ephemeral workspaces before any save can be scheduled.
- Centralize persistence disposition and the typed `ephemeralWorkspace` error.
- Restrict construction of workspace-owned persistent storage to manager-authorized paths.
- Reject ephemeral persistence before directory creation, disk reads, JSON encoding, writer enqueue, normalization writeback, and atomic replacement.
- Discard queued writes when the authoritative workspace becomes ephemeral.
- Protect chats, agent sessions, attachments, `_git_data`, Prompt/MCP Git artifacts, and worktree merge artifacts.
- Preserve persistent workspace save and reload behavior.

## Performance effect

Ephemeral workspaces now stop before entering the persistence pipeline. They no longer perform workspace-owned directory creation, disk reads, JSON encoding, writer enqueueing, normalization writeback, or atomic replacement.

The same rule prevents chats, attachments, agent sessions, and Git artifacts from scheduling filesystem work for an ephemeral workspace. The result is zero workspace-owned persistence for ephemeral workspaces, removing unnecessary serialization and filesystem I/O.

## Testing

Regression coverage includes creation and save races, queued writes, stale persistent references, normalization, sidecar storage, attachments, Git artifacts, and persistent workspace reload behavior.

- `WorkspaceEphemeralPersistenceTests`: 13 passed
- SwiftFormat and SwiftLint strict: passed
- `RepoPrompt` product build: passed

## Not included

- Removing files left behind by older versions
- Adding a cleanup migration
