### PR TITLE
fix(codex): correct managed auth checks and browser login completion

### DIFF
--- a/Sources/RepoPrompt/Features/Settings/ViewModels/APISettingsViewModel.swift
+++ b/Sources/RepoPrompt/Features/Settings/ViewModels/APISettingsViewModel.swift
@@ -1283,7 +1283,7 @@ public class APISettingsViewModel: ObservableObject {
     private func probeCachedCodexConnection(ifNeeded: Bool) async -> Bool {
         guard ifNeeded else { return false }
         let publicationToken = codexSessionFence.capturePublicationToken()
-        let refreshResult = await codexManagedAuthRecovery.refreshManagedAccount()
+        let refreshResult = await codexManagedAuthRecovery.checkManagedAccount()
         guard codexSessionFence.allowsAuthenticationPublication(publicationToken) else { return false }
         switch refreshResult {
         case let .recovered(account):

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/Shared/CodexManagedAuthRecoveryService.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/Shared/CodexManagedAuthRecoveryService.swift
@@ -14,6 +14,7 @@ protocol CodexManagedAuthRPCClient: Sendable {
 
 protocol CodexManagedAuthRecovering: Sendable {
     func refreshManagedAccount() async -> CodexManagedAuthRefreshResult
+    func checkManagedAccount() async -> CodexManagedAuthRefreshResult
     func managedAccountSnapshot() async -> CodexManagedAccount?
     func startManagedChatgptLogin(
         openURL: @MainActor @escaping @Sendable (URL) -> Void
@@ -249,6 +250,7 @@ actor CodexManagedAuthRecoveryService: CodexManagedAuthRecovering {
     private let sleep: @Sendable (TimeInterval) async throws -> Void
     private let retirementSleep: @Sendable (TimeInterval) async throws -> Void
     private var inFlightRefresh: InFlightRefresh?
+    private var inFlightCheck: InFlightRefresh?
     private var inFlightLogin: InFlightLogin?
     private var inFlightLogout: InFlightLogout?
     private var latestManagedAccount: CodexManagedAccount?
@@ -321,7 +323,78 @@ actor CodexManagedAuthRecoveryService: CodexManagedAuthRecovering {
             return result
         }
 
-        let task = Task<CodexManagedAuthRefreshResult, Never> { [clientFactory, refreshRequestTimeout] in
+        let task = makeAccountReadTask(refreshToken: true)
+        let refreshID = UUID()
+        inFlightRefresh = InFlightRefresh(id: refreshID, task: task)
+        let result = await task.value
+        if inFlightRefresh?.id == refreshID {
+            inFlightRefresh = nil
+        }
+        guard operationGeneration == authMutationGeneration else {
+            return .requiresUserLogin(message: CodexManagedAuthRecoveryClassifier.manualLoginGuidanceMessage)
+        }
+        applyRefreshResult(result)
+        return result
+    }
+
+    /// Checks the currently projected account without attempting token refresh. This is
+    /// appropriate for passive Settings/status probes; recovery paths keep using the
+    /// force-refreshing `refreshManagedAccount` entry point above.
+    func checkManagedAccount() async -> CodexManagedAuthRefreshResult {
+        if let inFlightLogout {
+            switch await inFlightLogout.task.value {
+            case .signedOut:
+                latestManagedAccount = nil
+                return .requiresUserLogin(message: CodexManagedAuthRecoveryClassifier.manualLoginGuidanceMessage)
+            case .failed, .executableUnavailable:
+                break
+            }
+        }
+        let operationGeneration = authMutationGeneration
+        if let inFlightLogin {
+            let result = await inFlightLogin.task.value
+            guard operationGeneration == authMutationGeneration else {
+                return .requiresUserLogin(message: CodexManagedAuthRecoveryClassifier.manualLoginGuidanceMessage)
+            }
+            switch result {
+            case let .authenticated(account):
+                latestManagedAccount = account
+                return .recovered(account: account)
+            case .authenticatedWithoutManagedAccount:
+                latestManagedAccount = nil
+                return .recovered(account: nil)
+            case let .executableUnavailable(message):
+                latestManagedAccount = nil
+                return .executableUnavailable(message: message)
+            case .failed:
+                return .requiresUserLogin(message: CodexManagedAuthRecoveryClassifier.manualLoginGuidanceMessage)
+            }
+        }
+        if let inFlightCheck {
+            let result = await inFlightCheck.task.value
+            guard operationGeneration == authMutationGeneration else {
+                return .requiresUserLogin(message: CodexManagedAuthRecoveryClassifier.manualLoginGuidanceMessage)
+            }
+            applyRefreshResult(result)
+            return result
+        }
+
+        let checkID = UUID()
+        let task = makeAccountReadTask(refreshToken: false)
+        inFlightCheck = InFlightRefresh(id: checkID, task: task)
+        let result = await task.value
+        if inFlightCheck?.id == checkID {
+            inFlightCheck = nil
+        }
+        guard operationGeneration == authMutationGeneration else {
+            return .requiresUserLogin(message: CodexManagedAuthRecoveryClassifier.manualLoginGuidanceMessage)
+        }
+        applyRefreshResult(result)
+        return result
+    }
+
+    private func makeAccountReadTask(refreshToken: Bool) -> Task<CodexManagedAuthRefreshResult, Never> {
+        Task { [clientFactory, refreshRequestTimeout] in
             let client = clientFactory()
             let result: CodexManagedAuthRefreshResult
             do {
@@ -329,7 +402,7 @@ actor CodexManagedAuthRecoveryService: CodexManagedAuthRecovering {
                 try await client.startIfNeeded()
                 let response = try await client.request(
                     method: "account/read",
-                    params: ["refreshToken": true],
+                    params: ["refreshToken": refreshToken],
                     timeout: refreshRequestTimeout
                 )
                 if Self.isValidAccountReadResult(response) {
@@ -347,17 +420,6 @@ actor CodexManagedAuthRecoveryService: CodexManagedAuthRecovering {
             await client.stop()
             return result
         }
-        let refreshID = UUID()
-        inFlightRefresh = InFlightRefresh(id: refreshID, task: task)
-        let result = await task.value
-        if inFlightRefresh?.id == refreshID {
-            inFlightRefresh = nil
-        }
-        guard operationGeneration == authMutationGeneration else {
-            return .requiresUserLogin(message: CodexManagedAuthRecoveryClassifier.manualLoginGuidanceMessage)
-        }
-        applyRefreshResult(result)
-        return result
     }
 
     func managedAccountSnapshot() -> CodexManagedAccount? {
@@ -526,6 +588,9 @@ actor CodexManagedAuthRecoveryService: CodexManagedAuthRecovering {
         let refreshTask = inFlightRefresh?.task
         refreshTask?.cancel()
         inFlightRefresh = nil
+        let checkTask = inFlightCheck?.task
+        checkTask?.cancel()
+        inFlightCheck = nil
         currentDeviceCode = nil
 
         var retirementTasks: [Task<Void, Never>] = []
@@ -534,6 +599,9 @@ actor CodexManagedAuthRecoveryService: CodexManagedAuthRecovering {
         }
         if let refreshTask {
             retirementTasks.append(Task { _ = await refreshTask.value })
+        }
+        if let checkTask {
+            retirementTasks.append(Task { _ = await checkTask.value })
         }
 
         let id = UUID()
@@ -842,15 +910,7 @@ actor CodexManagedAuthRecoveryService: CodexManagedAuthRecovering {
         timeout: TimeInterval
     ) async throws -> ManagedChatgptLoginStartResponse {
         let type = flow == .browser ? "chatgpt" : "chatgptDeviceCode"
-        do {
-            return try await requestLoginStart(client: client, type: type, timeout: timeout)
-        } catch {
-            if error.localizedDescription.localizedCaseInsensitiveContains("external auth is active") {
-                _ = try? await client.request(method: "account/logout", params: nil, timeout: timeout)
-                return try await requestLoginStart(client: client, type: type, timeout: timeout)
-            }
-            throw error
-        }
+        return try await requestLoginStart(client: client, type: type, timeout: timeout)
     }
 
     private static func requestLoginStart(

--- a/Tests/RepoPromptTests/AI/CodexManagedAuthRecoveryServiceTests.swift
+++ b/Tests/RepoPromptTests/AI/CodexManagedAuthRecoveryServiceTests.swift
@@ -648,6 +648,32 @@ final class CodexManagedAuthRecoveryServiceTests: XCTestCase {
         XCTAssertNil(clearedSnapshot)
     }
 
+    func testPassiveAccountCheckDoesNotRefreshToken() async {
+        let accountPayload: [String: Any] = [
+            "account": ["type": "chatgpt", "email": "passive@example.com", "planType": "plus"],
+            "requiresOpenaiAuth": true
+        ]
+        let client = MockCodexManagedAuthClient(
+            loginStartResponse: Self.browserStartResponse,
+            accountReadResponses: [Self.signedOutAccount],
+            unrefreshedAccountReadResponse: accountPayload
+        )
+        let service = makeService(client: client, clock: TestClock(), validationTimeout: 1)
+
+        let result = await service.checkManagedAccount()
+
+        XCTAssertEqual(
+            result,
+            .recovered(account: CodexManagedAccount(
+                email: "passive@example.com",
+                planType: "plus",
+                accountType: "chatgpt"
+            ))
+        )
+        XCTAssertEqual(client.accountReadRefreshFlags(), [false])
+        XCTAssertEqual(await service.managedAccountSnapshot()?.email, "passive@example.com")
+    }
+
     func testLoginReturnsFreshManagedAccountSnapshot() async {
         let accountPayload: [String: Any] = [
             "account": ["type": "chatgpt", "email": "fresh@example.com", "planType": "plus"],

--- a/Tests/RepoPromptTests/Settings/APISettingsCodexAuthPublicationTests.swift
+++ b/Tests/RepoPromptTests/Settings/APISettingsCodexAuthPublicationTests.swift
@@ -195,6 +195,12 @@ private actor ControlledCodexAuthRecovery: CodexManagedAuthRecovering {
         return .recovered(account: account)
     }
 
+    func checkManagedAccount() async -> CodexManagedAuthRefreshResult {
+        refreshCallCount += 1
+        await refreshGate?.wait()
+        return .recovered(account: account)
+    }
+
     func managedAccountSnapshot() async -> CodexManagedAccount? {
         snapshotCallCount += 1
         await snapshotGate?.wait()


### PR DESCRIPTION
## Summary

Fixes #479.

Corrects RepoPrompt's Codex managed-auth state handling so connection checks no longer invalidate otherwise usable sessions, and browser login cannot report success before OAuth actually completes.

## Changes

- Use passive `account/read(refreshToken: false)` for Test Connection and cached connection-status checks.
- Preserve forced token refresh for genuine authentication recovery.
- Keep passive checks and forced refreshes in separate single-flight tasks.
- Require browser login to receive a successful `account/login/completed` notification matching the returned `loginId`.
- Verify the account passively after the matching completion notification.
- Ignore missing, stale, or mismatched login-completion notifications.
- Remove the implicit `account/logout` fallback when external authentication is active.
- Add focused regression coverage for the managed-auth state machine.
- Stabilize two existing prompt preassembly synchronization tests discovered during PR-ready validation.
- Reconcile the affected test contract ledger entries.

## User impact

Previously, a user could see this sequence:

1. Codex CLI remained usable with its current access token.
2. RepoPrompt's Test Connection forced refresh.
3. A stale or reused refresh token failed with `401 refresh_token_reused`.
4. RepoPrompt incorrectly appeared disconnected.
5. Login with ChatGPT opened a browser flow.
6. RepoPrompt saw the pre-existing account and reported success before the new OAuth flow completed.

After this change:

- status checks do not force token rotation;
- refresh failures are not confused with passive account presence;
- browser login only succeeds after the correlated OAuth completion;
- RepoPrompt does not silently logout shared terminal Codex authentication.

## Validation

- `CodexManagedAuthRecoveryServiceTests`: 7 passed
- `PromptContextPreAssemblyServiceTests`: 16 passed
- Full coordinated root test suite: passed
- SwiftFormat and SwiftLint strict: passed
- RepoPrompt product build: passed
- Test contract ledger verification: 3,155 tests reconciled
- Repository guardrails and secret scans: passed
