### PR TITLE
Fail closed on unsigned Tip appcasts

### DIFF
--- a/.github/workflows/main-tip.yml
+++ b/.github/workflows/main-tip.yml
@@ -89,45 +89,20 @@ jobs:
           archive_basename="RepoPrompt-tip-$short_sha-$build_number"
           tag="tip-$short_sha"
 
-          release_json="$RUNNER_TEMP/existing-tip-release.json"
-          status="$(curl --location --silent --show-error \
-            --header 'Accept: application/vnd.github+json' \
-            --output "$release_json" \
-            --write-out '%{http_code}' \
-            "https://api.github.com/repos/$TIP_UPDATE_REPOSITORY/releases/tags/$tag")"
-          case "$status" in
-            200)
-              python3 - "$release_json" "$archive_basename" <<'PYTHON'
-          import json
-          import sys
-
-          release = json.load(open(sys.argv[1], encoding="utf-8"))
-          archive_basename = sys.argv[2]
-          expected = {
-              f"{archive_basename}.zip",
-              f"{archive_basename}.dmg",
-              "appcast.xml",
-              "SHA256SUMS",
-              f"{archive_basename}-artifact-manifest.json",
-              f"{archive_basename}-metadata.json",
-          }
-          actual = {asset["name"] for asset in release.get("assets", [])}
-          if release.get("draft") or release.get("prerelease") or actual != expected:
-              missing = sorted(expected - actual)
-              extra = sorted(actual - expected)
-              raise SystemExit(
-                  "Existing tip release is incomplete or malformed; "
-                  f"missing={missing}, extra={extra}"
-              )
-          PYTHON
+          lookup_classification="$(./Scripts/lookup_public_tip_release.sh \
+            "$TIP_UPDATE_REPOSITORY" \
+            "$tag" \
+            "$archive_basename")"
+          case "$lookup_classification" in
+            found)
               should_publish=false
-              echo "Tip release $tag already exists with the complete asset set; skipping rebuild."
+              echo "Existing tip release response classification=complete; skipping rebuild."
               ;;
-            404)
+            not-found)
               should_publish=true
               ;;
             *)
-              echo "Failed to inspect existing tip release: GitHub returned HTTP $status" >&2
+              echo "GitHub public tip lookup classification=unexpected-helper-output" >&2
               exit 1
               ;;
           esac

--- a/Scripts/lookup_public_tip_release.sh
+++ b/Scripts/lookup_public_tip_release.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$#" != 3 ]]; then
+    printf '%s\n' \
+        'GitHub public tip lookup classification=invalid-input status=000 request_id=unavailable rate_limit_remaining=unavailable rate_limit_reset=unavailable retry_after=unavailable' \
+        >&2
+    exit 1
+fi
+
+REPOSITORY="$1"
+TAG="$2"
+ARCHIVE_BASENAME="$3"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/repoprompt-tip-lookup.XXXXXX")"
+RESPONSE_BODY="$TMP_DIR/response.json"
+RESPONSE_HEADERS="$TMP_DIR/response.headers"
+
+cleanup() { rm -rf "$TMP_DIR"; }
+trap cleanup EXIT
+
+header_value() {
+    local wanted="$1"
+    awk -v wanted="$wanted" '
+        {
+            line = $0
+            sub(/\r$/, "", line)
+            if (line ~ /^HTTP\/[0-9.]+[[:space:]]+[0-9][0-9][0-9]([[:space:]]|$)/) {
+                result = ""
+                next
+            }
+            separator = index(line, ":")
+            if (separator > 0 && tolower(substr(line, 1, separator - 1)) == tolower(wanted)) {
+                value = substr(line, separator + 1)
+                sub(/^[[:space:]]+/, "", value)
+                sub(/[[:space:]]+$/, "", value)
+                result = value
+            }
+        }
+        END { print result }
+    ' "$RESPONSE_HEADERS"
+}
+
+classify_403_body() {
+    python3 - "$RESPONSE_BODY" <<'PYTHON'
+import json
+import sys
+
+try:
+    with open(sys.argv[1], encoding="utf-8") as handle:
+        response = json.load(handle)
+    message = response.get("message", "") if isinstance(response, dict) else ""
+except Exception:
+    message = ""
+
+normalized = message.casefold()
+if "rate limit" in normalized or "abuse detection" in normalized:
+    print("rate-limited")
+else:
+    print("unexpected-failure")
+PYTHON
+}
+
+classify_found_body() {
+    python3 - "$RESPONSE_BODY" "$ARCHIVE_BASENAME" <<'PYTHON'
+import json
+import sys
+
+try:
+    with open(sys.argv[1], encoding="utf-8") as handle:
+        release = json.load(handle)
+    if not isinstance(release, dict):
+        raise ValueError
+    archive_basename = sys.argv[2]
+    expected = {
+        f"{archive_basename}.zip",
+        f"{archive_basename}.dmg",
+        "appcast.xml",
+        "SHA256SUMS",
+        f"{archive_basename}-artifact-manifest.json",
+        f"{archive_basename}-metadata.json",
+    }
+    assets = release.get("assets", [])
+    if not isinstance(assets, list) or not all(isinstance(asset, dict) for asset in assets):
+        raise ValueError
+    actual = {asset.get("name") for asset in assets}
+    if release.get("draft") is not False or release.get("prerelease") is not False or actual != expected:
+        raise ValueError
+except Exception:
+    print("malformed")
+else:
+    print("found")
+PYTHON
+}
+
+classification=transport-failure
+status=000
+for attempt in 1 2 3; do
+    : > "$RESPONSE_BODY"
+    : > "$RESPONSE_HEADERS"
+    request_id=unavailable
+    rate_limit_remaining=unavailable
+    rate_limit_reset=unavailable
+    retry_after=unavailable
+
+    if status="$(curl --location --silent \
+        --connect-timeout 10 \
+        --max-time 30 \
+        --header 'Accept: application/vnd.github+json' \
+        --header 'X-GitHub-Api-Version: 2022-11-28' \
+        --dump-header "$RESPONSE_HEADERS" \
+        --output "$RESPONSE_BODY" \
+        --write-out '%{http_code}' \
+        "https://api.github.com/repos/$REPOSITORY/releases/tags/$TAG" \
+        2>/dev/null)"; then
+        [[ "$status" =~ ^[0-9]{3}$ ]] || status=000
+        request_id="$(header_value x-github-request-id)"
+        rate_limit_remaining="$(header_value x-ratelimit-remaining)"
+        rate_limit_reset="$(header_value x-ratelimit-reset)"
+        retry_after="$(header_value retry-after)"
+        request_id="${request_id:-unavailable}"
+        rate_limit_remaining="${rate_limit_remaining:-unavailable}"
+        rate_limit_reset="${rate_limit_reset:-unavailable}"
+        retry_after="${retry_after:-unavailable}"
+
+        case "$status" in
+            200) classification="$(classify_found_body)" ;;
+            404) classification=not-found ;;
+            403)
+                if [[ "$rate_limit_remaining" == "0" || "$retry_after" != "unavailable" ]]; then
+                    classification=rate-limited
+                else
+                    classification="$(classify_403_body)"
+                fi
+                ;;
+            429) classification=rate-limited ;;
+            5??) classification=server-failure ;;
+            *) classification=unexpected-failure ;;
+        esac
+    else
+        status=000
+        classification=transport-failure
+    fi
+
+    printf '%s\n' \
+        "GitHub public tip lookup classification=$classification status=$status request_id=$request_id rate_limit_remaining=$rate_limit_remaining rate_limit_reset=$rate_limit_reset retry_after=$retry_after" \
+        >&2
+
+    case "$classification" in
+        found|not-found|malformed|unexpected-failure)
+            break
+            ;;
+        rate-limited|server-failure|transport-failure)
+            if (( attempt == 3 )); then
+                break
+            fi
+            retry_delay="$attempt"
+            if [[ "$retry_after" =~ ^[0-9]+$ ]]; then
+                retry_delay="$retry_after"
+                (( retry_delay <= 10 )) || retry_delay=10
+            fi
+            sleep "$retry_delay"
+            ;;
+    esac
+done
+
+case "$classification" in
+    found|not-found)
+        printf '%s\n' "$classification"
+        ;;
+    *)
+        exit 1
+        ;;
+esac

--- a/Scripts/main_tip_release.sh
+++ b/Scripts/main_tip_release.sh
@@ -189,11 +189,11 @@ values = [
     item.findtext(f"{{{sparkle}}}version", default=""),
     item.findtext(f"{{{sparkle}}}shortVersionString", default=""),
 ]
-print("\t".join(values))
+print("\x1f".join(values))
 PYTHON
 
     local enclosure_url enclosure_signature enclosure_length appcast_build appcast_marketing
-    IFS=$'\t' read -r enclosure_url enclosure_signature enclosure_length appcast_build appcast_marketing < "$appcast_values"
+    IFS=$'\x1f' read -r enclosure_url enclosure_signature enclosure_length appcast_build appcast_marketing < "$appcast_values"
     [[ "$enclosure_url" == "$TIP_DOWNLOAD_URL_PREFIX$(basename "$UPDATE_ZIP")" ]] ||
         fail "Tip appcast enclosure URL mismatch: $enclosure_url"
     [[ -n "$enclosure_signature" ]] || fail "Tip appcast enclosure is missing an EdDSA signature"
@@ -322,9 +322,11 @@ publish_tip() {
     printf 'OK: published tip update release %s to %s.\n' "$TIP_TAG" "$TIP_UPDATE_REPOSITORY"
 }
 
-case "$MODE" in
-    stage) stage_tip ;;
-    sign) sign_tip ;;
-    publish-tip) publish_tip ;;
-    *) fail "Usage: $0 stage|sign|publish-tip" ;;
-esac
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    case "$MODE" in
+        stage) stage_tip ;;
+        sign) sign_tip ;;
+        publish-tip) publish_tip ;;
+        *) fail "Usage: $0 stage|sign|publish-tip" ;;
+    esac
+fi

--- a/Scripts/main_tip_release.sh
+++ b/Scripts/main_tip_release.sh
@@ -42,10 +42,12 @@ FINAL_METADATA="$DIST_DIR/$ARCHIVE_BASENAME-metadata.json"
 STAGE_ARCHIVE="$DIST_DIR/$ARCHIVE_BASENAME-stage.zip"
 STAGE_ARCHIVE_CHECKSUM="$STAGE_ARCHIVE.sha256"
 RUN_WITHOUT_GITHUB_TOKENS="$CONTROL_PLANE_SCRIPTS_DIR/run_without_github_tokens.sh"
+SIGN_UPDATE="$TRUSTED_ROOT/Vendor/Sparkle/bin/sign_update"
 TMP_DIR=""
 
 require_command() { command -v "$1" >/dev/null 2>&1 || fail "Missing required command: $1"; }
 require_env() { [[ -n "${!1:-}" ]] || fail "Missing required environment variable: $1"; }
+require_file() { [[ -f "$1" ]] || fail "Missing required file: $1"; }
 cleanup() { [[ -z "$TMP_DIR" ]] || rm -rf "$TMP_DIR"; }
 trap cleanup EXIT
 
@@ -160,11 +162,80 @@ submit_notarization() {
         --timeout "${NOTARYTOOL_TIMEOUT:-30m}"
 }
 
+derive_sparkle_public_key() {
+    xcrun swift "$CONTROL_PLANE_SCRIPTS_DIR/derive_sparkle_public_key.swift" "$1"
+}
+
+validate_generated_tip_appcast() {
+    local appcast_values="$TMP_DIR/tip-appcast-values.tsv"
+    python3 - "$APPCAST" > "$appcast_values" <<'PYTHON'
+import sys
+import xml.etree.ElementTree as ET
+
+sparkle = "http://www.andymatuschak.org/xml-namespaces/sparkle"
+root = ET.parse(sys.argv[1]).getroot()
+items = root.findall("./channel/item")
+if len(items) != 1:
+    raise SystemExit(f"tip appcast must contain exactly one item, got {len(items)}")
+enclosures = items[0].findall("enclosure")
+if len(enclosures) != 1:
+    raise SystemExit(f"tip appcast item must contain exactly one enclosure, got {len(enclosures)}")
+item = items[0]
+enclosure = enclosures[0]
+values = [
+    enclosure.attrib.get("url", ""),
+    enclosure.attrib.get(f"{{{sparkle}}}edSignature", ""),
+    enclosure.attrib.get("length", ""),
+    item.findtext(f"{{{sparkle}}}version", default=""),
+    item.findtext(f"{{{sparkle}}}shortVersionString", default=""),
+]
+print("\t".join(values))
+PYTHON
+
+    local enclosure_url enclosure_signature enclosure_length appcast_build appcast_marketing
+    IFS=$'\t' read -r enclosure_url enclosure_signature enclosure_length appcast_build appcast_marketing < "$appcast_values"
+    [[ "$enclosure_url" == "$TIP_DOWNLOAD_URL_PREFIX$(basename "$UPDATE_ZIP")" ]] ||
+        fail "Tip appcast enclosure URL mismatch: $enclosure_url"
+    [[ -n "$enclosure_signature" ]] || fail "Tip appcast enclosure is missing an EdDSA signature"
+    [[ "$enclosure_length" == "$(stat -f %z "$UPDATE_ZIP")" ]] ||
+        fail "Tip appcast enclosure length does not match $(basename "$UPDATE_ZIP")"
+    [[ "$appcast_build" == "$TIP_BUILD_NUMBER" ]] ||
+        fail "Tip appcast build mismatch: expected $TIP_BUILD_NUMBER, got $appcast_build"
+    [[ "$appcast_marketing" == "$MARKETING_VERSION" ]] ||
+        fail "Tip appcast marketing version mismatch: expected $MARKETING_VERSION, got $appcast_marketing"
+
+    local private_key_file="$TMP_DIR/tip-sparkle-private-key"
+    local public_key_file="$TMP_DIR/tip-sparkle-public-key"
+    umask 077
+    printf '%s' "$SPARKLE_PRIVATE_KEY" > "$private_key_file"
+
+    local derived_public_key committed_public_key reproduced_signature
+    derived_public_key="$(derive_sparkle_public_key "$private_key_file")"
+    committed_public_key="$(plutil -extract SUPublicEDKey raw "$APP_BUNDLE/Contents/Info.plist")"
+    [[ "$derived_public_key" == "$committed_public_key" ]] ||
+        fail "Tip Sparkle private key does not match the app bundle SUPublicEDKey"
+    reproduced_signature="$(printf '%s' "$SPARKLE_PRIVATE_KEY" |
+        "$SIGN_UPDATE" --ed-key-file - -p "$UPDATE_ZIP" |
+        tr -d '\r\n')"
+    [[ "$reproduced_signature" == "$enclosure_signature" ]] ||
+        fail "Tip Sparkle private key does not reproduce the generated appcast signature"
+
+    printf '%s' "$committed_public_key" > "$public_key_file"
+    xcrun swift "$CONTROL_PLANE_SCRIPTS_DIR/verify_sparkle_signature.swift" \
+        "$public_key_file" "$enclosure_signature" "$UPDATE_ZIP"
+}
+
 sign_tip() {
     require_command ditto
     require_command hdiutil
+    require_command plutil
+    require_command python3
     require_command shasum
+    require_command stat
     require_command xcrun
+    require_file "$SIGN_UPDATE"
+    require_file "$CONTROL_PLANE_SCRIPTS_DIR/derive_sparkle_public_key.swift"
+    require_file "$CONTROL_PLANE_SCRIPTS_DIR/verify_sparkle_signature.swift"
     require_env SIGN_IDENTITY
     require_env REPOPROMPT_PROVISIONING_PROFILE
     require_env SPARKLE_PRIVATE_KEY
@@ -214,6 +285,7 @@ sign_tip() {
             --download-url-prefix "$TIP_DOWNLOAD_URL_PREFIX" \
             -o "$APPCAST" \
             "$appcast_dir"
+    validate_generated_tip_appcast
     (cd "$DIST_DIR" && shasum -a 256 \
         "$(basename "$UPDATE_ZIP")" \
         "$(basename "$DMG")" \

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -1765,6 +1765,91 @@ fi
             package_script,
         )
 
+    def test_generated_tip_appcast_validation_executes_crypto_and_rejects_missing_signature(self) -> None:
+        root = SCRIPT_DIR.parent
+        temp_dir = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, temp_dir, True)
+        app_bundle = temp_dir / "RepoPrompt.app"
+        info_plist = app_bundle / "Contents" / "Info.plist"
+        archive = temp_dir / "RepoPrompt-tip-fixture.zip"
+        appcast = temp_dir / "appcast.xml"
+        private_key_file = temp_dir / "private-key"
+        validator_tmp_dir = temp_dir / "validator-tmp"
+        info_plist.parent.mkdir(parents=True)
+        archive.write_text("signed tip archive\n", encoding="utf-8")
+        private_key = base64.b64encode(bytes(range(32))).decode("ascii")
+        private_key_file.write_text(private_key, encoding="utf-8")
+        public_key = self.run_checked(
+            ["xcrun", "swift", str(SCRIPT_DIR / "derive_sparkle_public_key.swift"), str(private_key_file)]
+        ).stdout.strip()
+        info_plist.write_bytes(plistlib.dumps({"SUPublicEDKey": public_key}))
+        signature = self.run_checked(
+            [
+                str(root / "Vendor" / "Sparkle" / "bin" / "sign_update"),
+                "--ed-key-file",
+                str(private_key_file),
+                "-p",
+                str(archive),
+            ]
+        ).stdout.strip()
+
+        def write_appcast(enclosure_signature: str) -> None:
+            appcast.write_text(
+                f"""<?xml version="1.0" encoding="utf-8"?>
+<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <item>
+      <sparkle:version>1.2.3</sparkle:version>
+      <sparkle:shortVersionString>9.8.7</sparkle:shortVersionString>
+      <enclosure url="https://example.invalid/tip/{archive.name}"
+                 length="{archive.stat().st_size}"
+                 sparkle:edSignature="{enclosure_signature}" />
+    </item>
+  </channel>
+</rss>
+""",
+                encoding="utf-8",
+            )
+
+        env = os.environ.copy()
+        env.update(
+            {
+                "REPOPROMPT_RELEASE_SOURCE_ROOT": str(root),
+                "REPOPROMPT_CONTROL_PLANE_SCRIPTS_DIR": str(SCRIPT_DIR),
+                "TIP_COMMIT": "0" * 40,
+                "TIP_BUILD_NUMBER": "1.2.3",
+                "TIP_DOWNLOAD_URL_PREFIX": "https://example.invalid/tip/",
+                "SPARKLE_PRIVATE_KEY": private_key,
+                "VALIDATOR_APP_BUNDLE": str(app_bundle),
+                "VALIDATOR_UPDATE_ZIP": str(archive),
+                "VALIDATOR_APPCAST": str(appcast),
+                "VALIDATOR_TMP_DIR": str(validator_tmp_dir),
+            }
+        )
+        command = [
+            "bash",
+            "-c",
+            """source "$1"
+APP_BUNDLE="$VALIDATOR_APP_BUNDLE"
+UPDATE_ZIP="$VALIDATOR_UPDATE_ZIP"
+APPCAST="$VALIDATOR_APPCAST"
+TMP_DIR="$VALIDATOR_TMP_DIR"
+mkdir -p "$TMP_DIR"
+MARKETING_VERSION="9.8.7"
+validate_generated_tip_appcast""",
+            "tip-appcast-validation",
+            str(SCRIPT_DIR / "main_tip_release.sh"),
+        ]
+
+        write_appcast(signature)
+        accepted = subprocess.run(command, env=env, text=True, capture_output=True)
+        self.assertEqual(accepted.returncode, 0, accepted.stderr)
+
+        write_appcast("")
+        rejected = subprocess.run(command, env=env, text=True, capture_output=True)
+        self.assertNotEqual(rejected.returncode, 0)
+        self.assertIn("Tip appcast enclosure is missing an EdDSA signature", rejected.stderr)
+
     def test_release_sentry_runtime_wiring_uses_protected_dsn_and_stable_resolution(self) -> None:
         root = SCRIPT_DIR.parent
         package_manifest = (root / "Package.swift").read_text(encoding="utf-8")

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -1765,6 +1765,179 @@ fi
             package_script,
         )
 
+    def test_main_tip_setup_uses_anonymous_release_lookup_helper(self) -> None:
+        tip_workflow = (SCRIPT_DIR.parent / ".github" / "workflows" / "main-tip.yml").read_text(encoding="utf-8")
+        setup_job = tip_workflow.split("\n  setup:", 1)[1].split("\n  stage:", 1)[0]
+        before_publish, publish_job = tip_workflow.split("\n  publish:", 1)
+
+        self.assertIn("permissions:\n  contents: read", tip_workflow)
+        self.assertIn("./Scripts/lookup_public_tip_release.sh", setup_job)
+        self.assertNotIn("GITHUB_TOKEN", setup_job)
+        self.assertNotIn("Authorization:", setup_job)
+        self.assertNotIn("api.github.com", setup_job)
+        self.assertNotIn("TIP_UPDATE_REPOSITORY_TOKEN", before_publish)
+        self.assertIn("TIP_GH_TOKEN: ${{ secrets.TIP_UPDATE_REPOSITORY_TOKEN }}", publish_job)
+        self.assertEqual(tip_workflow.count("TIP_UPDATE_REPOSITORY_TOKEN"), 1)
+
+    def test_public_tip_release_lookup_helper_handles_github_outcomes_safely(self) -> None:
+        root = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, root, True)
+        tools = root / "tools"
+        tools.mkdir()
+        calls = root / "curl-calls"
+        archive_basename = "RepoPrompt-tip-fixture-1.2.3"
+        fake_curl = tools / "curl"
+        fake_curl.write_text(
+            """#!/usr/bin/env python3
+import json
+import os
+import sys
+from pathlib import Path
+
+args = sys.argv[1:]
+
+def option(name):
+    return args[args.index(name) + 1]
+
+request_headers = [args[index + 1] for index, value in enumerate(args) if value == "--header"]
+if any(header.lower().startswith("authorization:") for header in request_headers):
+    raise SystemExit(90)
+if any(option_name in args for option_name in ("--user", "--netrc", "--netrc-file", "-u")):
+    raise SystemExit(91)
+if "Accept: application/vnd.github+json" not in request_headers:
+    raise SystemExit(92)
+if "X-GitHub-Api-Version: 2022-11-28" not in request_headers:
+    raise SystemExit(93)
+if option("--connect-timeout") != "10" or option("--max-time") != "30":
+    raise SystemExit(94)
+
+calls = Path(os.environ["FAKE_CURL_CALLS"])
+with calls.open("a", encoding="utf-8") as handle:
+    handle.write("call\\n")
+
+scenario = os.environ["FAKE_GITHUB_SCENARIO"]
+if scenario == "transport":
+    raise SystemExit(7)
+
+status = {
+    "found": 200,
+    "absent": 404,
+    "rate-403-primary": 403,
+    "rate-403-secondary": 403,
+    "rate-429": 429,
+    "server": 503,
+    "unexpected-403": 403,
+    "redirect-final-unexpected-403": 403,
+    "malformed": 200,
+    "malformed-flags": 200,
+}[scenario]
+remaining = "0" if scenario in {"rate-403-primary", "rate-429"} else "42"
+headers = [
+    f"HTTP/1.1 {status} Fixture",
+    "X-GitHub-Request-Id: fixture-request",
+    f"X-RateLimit-Remaining: {remaining}",
+    "X-RateLimit-Reset: 1234567890",
+]
+if scenario in {"rate-403-primary", "rate-429"}:
+    headers.append("Retry-After: 0")
+if scenario == "redirect-final-unexpected-403":
+    headers = [
+        "HTTP/1.1 302 Fixture",
+        "X-GitHub-Request-Id: intermediate-request",
+        "X-RateLimit-Remaining: 0",
+        "X-RateLimit-Reset: 1111111111",
+        "Retry-After: 30",
+        "",
+        "HTTP/2 403 Fixture",
+        "X-GitHub-Request-Id: final-request",
+    ]
+Path(option("--dump-header")).write_text("\\r\\n".join(headers) + "\\r\\n\\r\\n", encoding="utf-8")
+
+archive = os.environ["FAKE_ARCHIVE_BASENAME"]
+expected = [
+    f"{archive}.zip",
+    f"{archive}.dmg",
+    "appcast.xml",
+    "SHA256SUMS",
+    f"{archive}-artifact-manifest.json",
+    f"{archive}-metadata.json",
+]
+if scenario == "found":
+    body = {"draft": False, "prerelease": False, "assets": [{"name": name} for name in expected]}
+elif scenario == "rate-403-secondary":
+    body = {"message": "You have exceeded a secondary rate limit. SECRET_BODY_MARKER"}
+elif scenario in {"unexpected-403", "redirect-final-unexpected-403"}:
+    body = {"message": "Resource not accessible by integration. SECRET_BODY_MARKER"}
+elif scenario == "malformed":
+    body = []
+elif scenario == "malformed-flags":
+    body = {"assets": [{"name": name} for name in expected]}
+else:
+    body = {"message": "SECRET_BODY_MARKER"}
+Path(option("--output")).write_text(json.dumps(body), encoding="utf-8")
+sys.stdout.write(str(status))
+""",
+            encoding="utf-8",
+        )
+        fake_curl.chmod(0o755)
+        fake_sleep = tools / "sleep"
+        fake_sleep.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        fake_sleep.chmod(0o755)
+
+        scenarios = (
+            ("found", 0, "found", 1, "found"),
+            ("absent", 0, "not-found", 1, "not-found"),
+            ("rate-403-primary", 1, "", 3, "rate-limited"),
+            ("rate-403-secondary", 1, "", 3, "rate-limited"),
+            ("rate-429", 1, "", 3, "rate-limited"),
+            ("server", 1, "", 3, "server-failure"),
+            ("transport", 1, "", 3, "transport-failure"),
+            ("unexpected-403", 1, "", 1, "unexpected-failure"),
+            ("redirect-final-unexpected-403", 1, "", 1, "unexpected-failure"),
+            ("malformed", 1, "", 1, "malformed"),
+            ("malformed-flags", 1, "", 1, "malformed"),
+        )
+        helper = SCRIPT_DIR / "lookup_public_tip_release.sh"
+        for scenario, returncode, stdout, attempt_count, classification in scenarios:
+            with self.subTest(scenario=scenario):
+                calls.unlink(missing_ok=True)
+                env = os.environ.copy()
+                env.update(
+                    {
+                        "PATH": f"{tools}:{env['PATH']}",
+                        "TMPDIR": str(root),
+                        "FAKE_CURL_CALLS": str(calls),
+                        "FAKE_GITHUB_SCENARIO": scenario,
+                        "FAKE_ARCHIVE_BASENAME": archive_basename,
+                    }
+                )
+                result = subprocess.run(
+                    [str(helper), "example/public-tip", "tip-fixture", archive_basename],
+                    env=env,
+                    text=True,
+                    capture_output=True,
+                )
+
+                self.assertEqual(result.returncode, returncode, result.stderr)
+                self.assertEqual(result.stdout.strip(), stdout)
+                self.assertEqual(len(calls.read_text(encoding="utf-8").splitlines()), attempt_count)
+                self.assertIn(f"classification={classification}", result.stderr)
+                self.assertNotIn("SECRET_BODY_MARKER", result.stdout + result.stderr)
+                if scenario == "redirect-final-unexpected-403":
+                    self.assertNotIn("classification=rate-limited", result.stderr)
+                    self.assertIn(
+                        "request_id=final-request rate_limit_remaining=unavailable "
+                        "rate_limit_reset=unavailable retry_after=unavailable",
+                        result.stderr,
+                    )
+                for diagnostic in result.stderr.splitlines():
+                    self.assertRegex(
+                        diagnostic,
+                        r"^GitHub public tip lookup classification=[a-z-]+ status=[0-9]{3} "
+                        r"request_id=[^ ]+ rate_limit_remaining=[^ ]+ rate_limit_reset=[^ ]+ "
+                        r"retry_after=[^ ]+$",
+                    )
+
     def test_generated_tip_appcast_validation_executes_crypto_and_rejects_missing_signature(self) -> None:
         root = SCRIPT_DIR.parent
         temp_dir = Path(tempfile.mkdtemp())

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -1742,6 +1742,17 @@ fi
         self.assertNotIn('BUILD_NUMBER="$TIP_BUILD_NUMBER"', tip_script)
         self.assertIn("stage|sign|publish-tip", tip_script)
 
+        sign_tip = tip_script.split("sign_tip() {", 1)[1].split("\n}", 1)[0]
+        generate_appcast = sign_tip.index('"$TRUSTED_ROOT/Vendor/Sparkle/bin/generate_appcast"')
+        validate_appcast = sign_tip.index("validate_generated_tip_appcast")
+        write_checksums = sign_tip.index('shasum -a 256', validate_appcast)
+        self.assertLess(generate_appcast, validate_appcast)
+        self.assertLess(validate_appcast, write_checksums)
+        self.assertIn('fail "Tip appcast enclosure is missing an EdDSA signature"', tip_script)
+        self.assertIn('fail "Tip Sparkle private key does not match the app bundle SUPublicEDKey"', tip_script)
+        self.assertIn('fail "Tip Sparkle private key does not reproduce the generated appcast signature"', tip_script)
+        self.assertIn('"$CONTROL_PLANE_SCRIPTS_DIR/verify_sparkle_signature.swift"', tip_script)
+
         capture_override = package_script.index(
             'RELEASE_BUILD_NUMBER_OVERRIDE="${REPOPROMPT_RELEASE_BUILD_NUMBER_OVERRIDE:-}"'
         )


### PR DESCRIPTION
## Summary

- validate every generated Tip appcast before checksums or publication
- require the protected Sparkle private key to match the app bundle public key
- reproduce and independently verify the ZIP EdDSA signature
- reject missing signatures, URL/length drift, and version/build mismatches

## Production evidence

Both published Tip appcasts are missing `sparkle:edSignature`, so Sparkle rejects them even though the apps are correctly Developer ID signed and notarized:

- `tip-3f11c3ac0125`
- `tip-3c4bf58f39d2`

The latest artifact manifest confirms `Developer ID Application: Eric Provencher (648A27MST5)` and Team ID `648A27MST5`. Update discovery is blocked by the unsigned Sparkle feed, not Apple code signing.

## Required environment repair

Before the post-merge Tip run, replace `tip-release/SPARKLE_PRIVATE_KEY` with the same modern 32-byte private-key seed used by the Stable `release` environment. GitHub secrets are write-only, so this value cannot be copied back out through the API.

## Validation

- `bash -n Scripts/main_tip_release.sh`
- `python3 Scripts/test_release_tooling.py` (57 passed)
- `make dev-release-preflight`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh pr-ready`
