### PR TITLE
Fix debug provenance JSON validation

### DIFF
--- a/Scripts/package_app.sh
+++ b/Scripts/package_app.sh
@@ -383,7 +383,8 @@ path = bundle / "Contents" / "Resources" / "RepoPromptDebugProvenance.json"
 path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 print(f"Debug bundle provenance: {path}")
 PY
-    run plutil -lint "$APP_BUNDLE/Contents/Resources/RepoPromptDebugProvenance.json"
+    run python3 "$CONTROL_PLANE_SCRIPTS_DIR/validate_json.py" \
+        "$APP_BUNDLE/Contents/Resources/RepoPromptDebugProvenance.json"
 fi
 
 phase "Signing app bundle"

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -23,6 +23,40 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 
 
 class ReleaseToolingTests(unittest.TestCase):
+    def test_debug_provenance_uses_json_validation_and_rejects_truncated_output(self) -> None:
+        package_script = (SCRIPT_DIR / "package_app.sh").read_text(encoding="utf-8")
+        validator = SCRIPT_DIR / "validate_json.py"
+        temp_dir = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, temp_dir, True)
+        provenance = temp_dir / "RepoPromptDebugProvenance.json"
+
+        self.assertIn(
+            'run python3 "$CONTROL_PLANE_SCRIPTS_DIR/validate_json.py" \\\n        "$APP_BUNDLE/Contents/Resources/RepoPromptDebugProvenance.json"',
+            package_script,
+        )
+        self.assertNotIn(
+            'plutil -lint "$APP_BUNDLE/Contents/Resources/RepoPromptDebugProvenance.json"',
+            package_script,
+        )
+
+        provenance.write_text('{"version": 1}\n', encoding="utf-8")
+        valid = subprocess.run(
+            [sys.executable, str(validator), str(provenance)],
+            text=True,
+            capture_output=True,
+        )
+        self.assertEqual(valid.returncode, 0, valid.stderr)
+        self.assertEqual(valid.stdout.strip(), f"Valid JSON: {provenance}")
+
+        provenance.write_text('{"version":', encoding="utf-8")
+        truncated = subprocess.run(
+            [sys.executable, str(validator), str(provenance)],
+            text=True,
+            capture_output=True,
+        )
+        self.assertEqual(truncated.returncode, 1)
+        self.assertIn(f"error: invalid JSON file {provenance}:", truncated.stderr)
+
     def test_runtime_signing_policy_matches_release_metadata_and_entitlement_templates(self) -> None:
         root = SCRIPT_DIR.parent
         metadata = {}

--- a/Scripts/validate_json.py
+++ b/Scripts/validate_json.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Validate that a file contains one complete JSON value."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(f"usage: {Path(sys.argv[0]).name} <json-file>", file=sys.stderr)
+        return 2
+
+    path = Path(sys.argv[1])
+    try:
+        with path.open(encoding="utf-8") as stream:
+            json.load(stream)
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        print(f"error: invalid JSON file {path}: {error}", file=sys.stderr)
+        return 1
+
+    print(f"Valid JSON: {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- validate debug bundle provenance with Python's JSON parser instead of `plutil`
- add a reusable validator that reports clear errors for malformed or truncated JSON
- add focused regression coverage for valid and truncated provenance payloads

## Root cause

`Scripts/package_app.sh` emits `RepoPromptDebugProvenance.json` with `json.dumps`, then passed it to `plutil -lint`. On affected macOS environments, `plutil` rejects the valid JSON as though it were an invalid property list, aborting packaging after the build completes.

## Impact

Valid debug provenance now passes the format boundary, while malformed or truncated output still fails packaging before lifecycle activation with a clear validation error.

Fixes #511

## Validation

- `python3 -m unittest Scripts.test_release_tooling` (60 tests)
- focused provenance regression test
- `bash -n Scripts/package_app.sh`
- `make guardrails`
- `make dev-smoke` (non-disruptive; ticket `0fe25974-7263-4c85-aa88-2ab7d41d3c71`)
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh pr-ready`