### PR TITLE
Add title-adjacent Agent chat options menu

### DIFF
--- a/Sources/RepoPrompt/App/Notifications/AppNotifications.swift
+++ b/Sources/RepoPrompt/App/Notifications/AppNotifications.swift
@@ -78,6 +78,9 @@ extension Notification.Name {
     /// Posted when a compose tab's persisted display name changes.
     /// userInfo: ["tabID": UUID, "windowID": Int, "name": String]
     static let composeTabNameChanged = Notification.Name("composeTabNameChanged")
+    /// Posted when a compose tab is linked to or unlinked from a persistent Agent session.
+    /// userInfo: ["tabID": UUID, "windowID": Int, "previousSessionID": UUID?, "sessionID": UUID?]
+    static let agentSessionBindingDidChange = Notification.Name("agentSessionBindingDidChange")
 
     /// Toggle the Agent session sidebar for the focused window.
     /// `userInfo["windowID"]` should be the target window ID.

--- a/Sources/RepoPrompt/App/Views/ContentViewToolbarContent.swift
+++ b/Sources/RepoPrompt/App/Views/ContentViewToolbarContent.swift
@@ -9,6 +9,13 @@ struct ContentViewToolbarContent: ToolbarContent {
     @Binding var showMCPServerPopover: Bool
 
     var body: some ToolbarContent {
+        if #available(macOS 26.0, *) {
+            agentChatTitleItem
+                .sharedBackgroundVisibility(.hidden)
+        } else {
+            agentChatTitleItem
+        }
+
         // Recommendation wizard button
         ToolbarItem(placement: .automatic) {
             if let wizardVM = recommendationWizardViewModel {
@@ -27,6 +34,19 @@ struct ContentViewToolbarContent: ToolbarContent {
         // Update pill (user-initiated Sparkle UI)
         ToolbarItem(placement: .automatic) {
             UpdateAvailableToolbarPill(sparkleManager: SparkleUpdaterManager.shared)
+        }
+    }
+
+    @ToolbarContentBuilder
+    private var agentChatTitleItem: some ToolbarContent {
+        ToolbarItem(placement: .principal) {
+            AgentChatTitleClusterView(
+                model: windowState.agentChatTitleCluster,
+                menuSnapshot: { [weak windowState] in
+                    windowState?.agentChatTitleClusterMenuSnapshot()
+                },
+                menuActions: windowState.agentChatTitleClusterMenuActions()
+            )
         }
     }
 }

--- a/Sources/RepoPrompt/App/WindowContentView.swift
+++ b/Sources/RepoPrompt/App/WindowContentView.swift
@@ -28,6 +28,7 @@ struct WindowContentView: View {
             // default app-name title over the workspace name whenever it refreshes the
             // window chrome (visible in both window titles and native tab names).
             .navigationTitle(windowState.displayedWindowTitle)
+            .removingSystemToolbarTitle()
             .background(
                 WindowAccessor { newWindow in
                     // IMPORTANT: do not mutate SwiftUI @State here.
@@ -72,5 +73,16 @@ struct WindowContentView: View {
             .sheet(isPresented: $versionManager.shouldShowVersionPopup) {
                 VersionPopupView(isPresented: $versionManager.shouldShowVersionPopup)
             }
+    }
+}
+
+private extension View {
+    @ViewBuilder
+    func removingSystemToolbarTitle() -> some View {
+        if #available(macOS 15.0, *) {
+            toolbar(removing: .title)
+        } else {
+            self
+        }
     }
 }

--- a/Sources/RepoPrompt/App/WindowState.swift
+++ b/Sources/RepoPrompt/App/WindowState.swift
@@ -939,7 +939,8 @@ class WindowState: ObservableObject {
 
     private func collapseRedundantSingleWindowTabBarIfNeeded(for window: NSWindow) {
         guard let tabbedWindows = window.tabbedWindows,
-              tabbedWindows.count == 1
+              tabbedWindows.count == 1,
+              window.tabGroup?.isTabBarVisible == true
         else {
             return
         }

--- a/Sources/RepoPrompt/App/WindowState.swift
+++ b/Sources/RepoPrompt/App/WindowState.swift
@@ -167,12 +167,14 @@ class WindowState: ObservableObject {
 
     // MARK: - Agent Mode Titlebar Accessory
 
-    /// Titlebar accessory controller for Agent mode ("New Session" button near traffic lights)
+    /// Native titlebar edge accessory controller for the Agent mode New Session button
     private weak var agentTitlebarAccessory: AgentModeTitlebarAccessoryViewController?
     /// Whether Agent mode has requested the titlebar accessory be visible
     private var wantsAgentTitlebarAccessory: Bool = false
     /// Action to call when the "New Session" button is tapped
     private var agentNewSessionAction: (() -> Void)?
+    /// Narrow titlebar state observed only by the principal toolbar title cluster.
+    let agentChatTitleCluster = AgentChatTitleClusterModel(title: WindowTitleFormatter.defaultTitle)
 
     /// The sticky instance number assigned for this window's current workspace (monotonically increasing per workspace).
     /// Nil when no workspace is active yet.
@@ -433,7 +435,6 @@ class WindowState: ObservableObject {
                       notifiedWindowID == windowID
                 else { return }
                 requestWindowTitleUpdate(reason: .activeComposeTabChanged)
-                refreshAgentTitlebarChatOptionsVisibility()
             }
             .store(in: &cancellables)
 
@@ -447,7 +448,6 @@ class WindowState: ObservableObject {
                       tabID == promptManager.activeComposeTabID
                 else { return }
                 requestWindowTitleUpdate(reason: .agentSessionNameChanged)
-                refreshAgentTitlebarChatOptionsVisibility()
             }
             .store(in: &cancellables)
 
@@ -460,7 +460,7 @@ class WindowState: ObservableObject {
                       let tabID = notification.userInfo?["tabID"] as? UUID,
                       tabID == promptManager.activeComposeTabID
                 else { return }
-                refreshAgentTitlebarChatOptionsVisibility()
+                refreshAgentChatTitleCluster()
             }
             .store(in: &cancellables)
     }
@@ -528,9 +528,15 @@ class WindowState: ObservableObject {
     private func configureWindowChrome(for window: NSWindow) {
         // Keep titlebar visually continuous with content (no horizontal separator).
         window.toolbar?.showsBaselineSeparator = false
+        if #unavailable(macOS 15.0) {
+            window.titleVisibility = .hidden
+        }
         // SwiftUI can recreate toolbar chrome during toolbar updates; re-apply on next runloop.
         DispatchQueue.main.async { [weak window] in
             window?.toolbar?.showsBaselineSeparator = false
+            if #unavailable(macOS 15.0) {
+                window?.titleVisibility = .hidden
+            }
         }
     }
 
@@ -643,6 +649,7 @@ class WindowState: ObservableObject {
         if displayedWindowTitle != title {
             displayedWindowTitle = title
         }
+        refreshAgentChatTitleCluster()
         guard let window = nsWindow else { return }
         if window.title == title, lastAppliedWindowTitle == title {
             return
@@ -751,7 +758,8 @@ class WindowState: ObservableObject {
     }
 
     private func currentAgentTitlebarChatOptionsTabID() -> UUID? {
-        guard let tabID = agentModeViewModel.currentTabID,
+        guard wantsAgentTitlebarAccessory,
+              let tabID = agentModeViewModel.currentTabID,
               agentModeViewModel.hasLinkedAgentSession(for: tabID)
         else {
             return nil
@@ -759,31 +767,24 @@ class WindowState: ObservableObject {
         return tabID
     }
 
-    private func hasAgentTitlebarChatOptions() -> Bool {
-        currentAgentTitlebarChatOptionsTabID() != nil
-    }
-
     private func agentTitlebarChatOptionsTabExists(_ tabID: UUID) -> Bool {
         promptManager.currentComposeTabs.contains(where: { $0.id == tabID })
             && agentModeViewModel.hasLinkedAgentSession(for: tabID)
     }
 
-    private func agentTitlebarChatTitle(for tabID: UUID) -> String {
-        promptManager.currentComposeTabs.first(where: { $0.id == tabID })?.name
-            ?? workspaceManager.composeTabName(with: tabID)
-            ?? "Chat"
-    }
-
-    private func agentTitlebarChatMenuSnapshot() -> AgentModeTitlebarChatMenuSnapshot? {
-        guard let tabID = currentAgentTitlebarChatOptionsTabID() else { return nil }
+    func agentChatTitleClusterMenuSnapshot() -> AgentChatOptionsMenuSnapshot? {
+        guard let tabID = currentAgentTitlebarChatOptionsTabID() else {
+            refreshAgentChatTitleCluster()
+            return nil
+        }
         let tab = promptManager.currentComposeTabs.first(where: { $0.id == tabID })
-        return AgentModeTitlebarChatMenuSnapshot(
+        return AgentChatOptionsMenuSnapshot(
             isPinned: tab?.isPinned ?? false
         )
     }
 
-    private func makeAgentTitlebarChatMenuActions() -> AgentModeTitlebarChatMenuActions {
-        AgentModeTitlebarChatMenuActions(
+    func agentChatTitleClusterMenuActions() -> AgentChatOptionsMenuActions {
+        AgentChatOptionsMenuActions(
             togglePin: { [weak self] in
                 self?.toggleCurrentAgentChatPinFromTitlebar()
             },
@@ -799,14 +800,16 @@ class WindowState: ObservableObject {
         )
     }
 
-    private func refreshAgentTitlebarChatOptionsVisibility() {
-        agentTitlebarAccessory?.refreshChatOptionsVisibility()
+    private func refreshAgentChatTitleCluster() {
+        agentChatTitleCluster.update(
+            title: displayedWindowTitle,
+            showsChatOptions: currentAgentTitlebarChatOptionsTabID() != nil
+        )
     }
 
     private func toggleCurrentAgentChatPinFromTitlebar() {
         guard let tabID = currentAgentTitlebarChatOptionsTabID() else { return }
         promptManager.toggleComposeTabPinned(tabID)
-        refreshAgentTitlebarChatOptionsVisibility()
     }
 
     private func stashCurrentAgentChatFromTitlebar() {
@@ -816,13 +819,14 @@ class WindowState: ObservableObject {
                   agentTitlebarChatOptionsTabExists(tabID)
             else { return }
             await promptManager.stashTab(tabID)
-            refreshAgentTitlebarChatOptionsVisibility()
         }
     }
 
     private func renameCurrentAgentChatFromTitlebar() {
         guard let tabID = currentAgentTitlebarChatOptionsTabID() else { return }
-        let currentName = agentTitlebarChatTitle(for: tabID)
+        let currentName = promptManager.currentComposeTabs.first(where: { $0.id == tabID })?.name
+            ?? workspaceManager.composeTabName(with: tabID)
+            ?? "Chat"
         let alert = NSAlert()
         alert.messageText = "Rename chat"
         alert.informativeText = "Choose a new name for this chat."
@@ -844,7 +848,6 @@ class WindowState: ObservableObject {
             let newName = input.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !newName.isEmpty, newName != currentName else { return }
             agentModeViewModel.renameSession(tabID: tabID, to: newName)
-            refreshAgentTitlebarChatOptionsVisibility()
         }
 
         if let window = nsWindow {
@@ -877,7 +880,6 @@ class WindowState: ObservableObject {
                       agentTitlebarChatOptionsTabExists(tabID)
                 else { return }
                 await promptManager.closeComposeTab(tabID)
-                refreshAgentTitlebarChatOptionsVisibility()
             }
         }
 
@@ -888,7 +890,7 @@ class WindowState: ObservableObject {
         }
     }
 
-    /// Shows or hides the Agent mode titlebar accessory ("New Session" button near traffic lights).
+    /// Shows or hides the Agent mode New Session titlebar edge accessory.
     /// - Parameters:
     ///   - visible: Whether to show the accessory
     ///   - onNewSession: Action to call when button is tapped (required when visible is true)
@@ -897,11 +899,13 @@ class WindowState: ObservableObject {
             guard !shouldSuppressObservationSideEffects else { return }
             wantsAgentTitlebarAccessory = true
             agentNewSessionAction = onNewSession
+            refreshAgentChatTitleCluster()
             applyAgentTitlebarAccessoryIfPossible()
         } else {
             wantsAgentTitlebarAccessory = false
             agentNewSessionAction = nil
             removeAgentTitlebarAccessory()
+            refreshAgentChatTitleCluster()
         }
     }
 
@@ -915,28 +919,31 @@ class WindowState: ObservableObject {
             return
         }
 
-        let menuActions = makeAgentTitlebarChatMenuActions()
         if let existing = agentTitlebarAccessory {
-            existing.update(
-                onNewSession: action,
-                hasChatOptions: { [weak self] in self?.hasAgentTitlebarChatOptions() ?? false },
-                chatMenuSnapshot: { [weak self] in self?.agentTitlebarChatMenuSnapshot() },
-                chatMenuActions: menuActions
-            )
+            existing.update(onNewSession: action)
             if !window.titlebarAccessoryViewControllers.contains(where: { $0 === existing }) {
                 window.addTitlebarAccessoryViewController(existing)
             }
         } else {
-            let accessory = AgentModeTitlebarAccessoryViewController(
-                onNewSession: action,
-                hasChatOptions: { [weak self] in self?.hasAgentTitlebarChatOptions() ?? false },
-                chatMenuSnapshot: { [weak self] in self?.agentTitlebarChatMenuSnapshot() },
-                chatMenuActions: menuActions
-            )
+            let accessory = AgentModeTitlebarAccessoryViewController(onNewSession: action)
             window.addTitlebarAccessoryViewController(accessory)
             agentTitlebarAccessory = accessory
         }
         configureWindowChrome(for: window)
+        collapseRedundantSingleWindowTabBarIfNeeded(for: window)
+        DispatchQueue.main.async { [weak self, weak window] in
+            guard let self, let window else { return }
+            collapseRedundantSingleWindowTabBarIfNeeded(for: window)
+        }
+    }
+
+    private func collapseRedundantSingleWindowTabBarIfNeeded(for window: NSWindow) {
+        guard let tabbedWindows = window.tabbedWindows,
+              tabbedWindows.count == 1
+        else {
+            return
+        }
+        window.toggleTabBar(nil)
     }
 
     /// Removes the titlebar accessory from the window

--- a/Sources/RepoPrompt/App/WindowState.swift
+++ b/Sources/RepoPrompt/App/WindowState.swift
@@ -433,6 +433,7 @@ class WindowState: ObservableObject {
                       notifiedWindowID == windowID
                 else { return }
                 requestWindowTitleUpdate(reason: .activeComposeTabChanged)
+                refreshAgentTitlebarChatOptionsVisibility()
             }
             .store(in: &cancellables)
 
@@ -446,6 +447,20 @@ class WindowState: ObservableObject {
                       tabID == promptManager.activeComposeTabID
                 else { return }
                 requestWindowTitleUpdate(reason: .agentSessionNameChanged)
+                refreshAgentTitlebarChatOptionsVisibility()
+            }
+            .store(in: &cancellables)
+
+        NotificationCenter.default.publisher(for: .agentSessionBindingDidChange)
+            .receive(on: RunLoop.main)
+            .sink { [weak self] notification in
+                guard let self,
+                      let notifiedWindowID = notification.userInfo?["windowID"] as? Int,
+                      notifiedWindowID == windowID,
+                      let tabID = notification.userInfo?["tabID"] as? UUID,
+                      tabID == promptManager.activeComposeTabID
+                else { return }
+                refreshAgentTitlebarChatOptionsVisibility()
             }
             .store(in: &cancellables)
     }
@@ -735,6 +750,144 @@ class WindowState: ObservableObject {
         agentNewSessionAction = nil
     }
 
+    private func currentAgentTitlebarChatOptionsTabID() -> UUID? {
+        guard let tabID = agentModeViewModel.currentTabID,
+              agentModeViewModel.hasLinkedAgentSession(for: tabID)
+        else {
+            return nil
+        }
+        return tabID
+    }
+
+    private func hasAgentTitlebarChatOptions() -> Bool {
+        currentAgentTitlebarChatOptionsTabID() != nil
+    }
+
+    private func agentTitlebarChatOptionsTabExists(_ tabID: UUID) -> Bool {
+        promptManager.currentComposeTabs.contains(where: { $0.id == tabID })
+            && agentModeViewModel.hasLinkedAgentSession(for: tabID)
+    }
+
+    private func agentTitlebarChatTitle(for tabID: UUID) -> String {
+        promptManager.currentComposeTabs.first(where: { $0.id == tabID })?.name
+            ?? workspaceManager.composeTabName(with: tabID)
+            ?? "Chat"
+    }
+
+    private func agentTitlebarChatMenuSnapshot() -> AgentModeTitlebarChatMenuSnapshot? {
+        guard let tabID = currentAgentTitlebarChatOptionsTabID() else { return nil }
+        let tab = promptManager.currentComposeTabs.first(where: { $0.id == tabID })
+        return AgentModeTitlebarChatMenuSnapshot(
+            isPinned: tab?.isPinned ?? false
+        )
+    }
+
+    private func makeAgentTitlebarChatMenuActions() -> AgentModeTitlebarChatMenuActions {
+        AgentModeTitlebarChatMenuActions(
+            togglePin: { [weak self] in
+                self?.toggleCurrentAgentChatPinFromTitlebar()
+            },
+            rename: { [weak self] in
+                self?.renameCurrentAgentChatFromTitlebar()
+            },
+            stash: { [weak self] in
+                self?.stashCurrentAgentChatFromTitlebar()
+            },
+            delete: { [weak self] in
+                self?.confirmDeleteCurrentAgentChatFromTitlebar()
+            }
+        )
+    }
+
+    private func refreshAgentTitlebarChatOptionsVisibility() {
+        agentTitlebarAccessory?.refreshChatOptionsVisibility()
+    }
+
+    private func toggleCurrentAgentChatPinFromTitlebar() {
+        guard let tabID = currentAgentTitlebarChatOptionsTabID() else { return }
+        promptManager.toggleComposeTabPinned(tabID)
+        refreshAgentTitlebarChatOptionsVisibility()
+    }
+
+    private func stashCurrentAgentChatFromTitlebar() {
+        guard let tabID = currentAgentTitlebarChatOptionsTabID() else { return }
+        Task { @MainActor [weak self] in
+            guard let self,
+                  agentTitlebarChatOptionsTabExists(tabID)
+            else { return }
+            await promptManager.stashTab(tabID)
+            refreshAgentTitlebarChatOptionsVisibility()
+        }
+    }
+
+    private func renameCurrentAgentChatFromTitlebar() {
+        guard let tabID = currentAgentTitlebarChatOptionsTabID() else { return }
+        let currentName = agentTitlebarChatTitle(for: tabID)
+        let alert = NSAlert()
+        alert.messageText = "Rename chat"
+        alert.informativeText = "Choose a new name for this chat."
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: "Rename")
+        alert.addButton(withTitle: "Cancel")
+
+        let input = NSTextField(string: currentName)
+        input.frame = NSRect(x: 0, y: 0, width: 280, height: 24)
+        input.selectText(nil)
+        alert.accessoryView = input
+
+        let applyRename: (NSApplication.ModalResponse) -> Void = { [weak self, weak input] response in
+            guard response == .alertFirstButtonReturn,
+                  let self,
+                  let input,
+                  agentTitlebarChatOptionsTabExists(tabID)
+            else { return }
+            let newName = input.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !newName.isEmpty, newName != currentName else { return }
+            agentModeViewModel.renameSession(tabID: tabID, to: newName)
+            refreshAgentTitlebarChatOptionsVisibility()
+        }
+
+        if let window = nsWindow {
+            alert.beginSheetModal(for: window, completionHandler: applyRename)
+        } else {
+            applyRename(alert.runModal())
+        }
+    }
+
+    private func confirmDeleteCurrentAgentChatFromTitlebar() {
+        guard let tabID = currentAgentTitlebarChatOptionsTabID() else { return }
+        let alert = NSAlert()
+        alert.messageText = "Delete chat?"
+        alert.informativeText = "This permanently deletes this chat."
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "Delete")
+        alert.addButton(withTitle: "Cancel")
+
+        let applyDelete: (NSApplication.ModalResponse) -> Void = { [weak self] response in
+            guard response == .alertFirstButtonReturn, let self else { return }
+            #if DEBUG
+                agentModeViewModel.debugBeginSidebarDeleteRequest(
+                    tabID: tabID,
+                    source: "WindowState.titlebarDelete",
+                    reason: "titlebar_delete_confirmation"
+                )
+            #endif
+            Task { @MainActor [weak self] in
+                guard let self,
+                      agentTitlebarChatOptionsTabExists(tabID)
+                else { return }
+                await promptManager.closeComposeTab(tabID)
+                refreshAgentTitlebarChatOptionsVisibility()
+            }
+        }
+
+        if let window = nsWindow {
+            alert.beginSheetModal(for: window, completionHandler: applyDelete)
+        } else {
+            applyDelete(alert.runModal())
+        }
+    }
+
     /// Shows or hides the Agent mode titlebar accessory ("New Session" button near traffic lights).
     /// - Parameters:
     ///   - visible: Whether to show the accessory
@@ -762,13 +915,24 @@ class WindowState: ObservableObject {
             return
         }
 
+        let menuActions = makeAgentTitlebarChatMenuActions()
         if let existing = agentTitlebarAccessory {
-            existing.update(onNewSession: action)
+            existing.update(
+                onNewSession: action,
+                hasChatOptions: { [weak self] in self?.hasAgentTitlebarChatOptions() ?? false },
+                chatMenuSnapshot: { [weak self] in self?.agentTitlebarChatMenuSnapshot() },
+                chatMenuActions: menuActions
+            )
             if !window.titlebarAccessoryViewControllers.contains(where: { $0 === existing }) {
                 window.addTitlebarAccessoryViewController(existing)
             }
         } else {
-            let accessory = AgentModeTitlebarAccessoryViewController(onNewSession: action)
+            let accessory = AgentModeTitlebarAccessoryViewController(
+                onNewSession: action,
+                hasChatOptions: { [weak self] in self?.hasAgentTitlebarChatOptions() ?? false },
+                chatMenuSnapshot: { [weak self] in self?.agentTitlebarChatMenuSnapshot() },
+                chatMenuActions: menuActions
+            )
             window.addTitlebarAccessoryViewController(accessory)
             agentTitlebarAccessory = accessory
         }

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -3373,15 +3373,10 @@ final class AgentModeViewModel: ObservableObject {
             tabID: session.tabID,
             sessionID: sessionID
         )
-        NotificationCenter.default.post(
-            name: .agentSessionBindingDidChange,
-            object: self,
-            userInfo: [
-                "tabID": session.tabID,
-                "windowID": windowID,
-                "previousSessionID": previousSessionID as Any,
-                "sessionID": sessionID as Any
-            ]
+        postAgentSessionBindingDidChange(
+            tabID: session.tabID,
+            previousSessionID: previousSessionID,
+            sessionID: sessionID
         )
 
         if session.tabID == currentTabID {
@@ -3400,6 +3395,23 @@ final class AgentModeViewModel: ObservableObject {
             )
         #endif
         return binding
+    }
+
+    private func postAgentSessionBindingDidChange(
+        tabID: UUID,
+        previousSessionID: UUID?,
+        sessionID: UUID?
+    ) {
+        NotificationCenter.default.post(
+            name: .agentSessionBindingDidChange,
+            object: self,
+            userInfo: [
+                "tabID": tabID,
+                "windowID": windowID,
+                "previousSessionID": previousSessionID as Any,
+                "sessionID": sessionID as Any
+            ]
+        )
     }
 
     /// Single creation point for attaching an Agent session identity to a compose tab.
@@ -15634,6 +15646,14 @@ final class AgentModeViewModel: ObservableObject {
         removeSessionIndex(sessionID: sessionID)
         if let cleanupRegistration {
             await AgentRunSessionStore.cleanup(registration: cleanupRegistration)
+        }
+
+        for tabID in clearedComposeTabIDs.union(clearedStashedTabIDs) {
+            postAgentSessionBindingDidChange(
+                tabID: tabID,
+                previousSessionID: sessionID,
+                sessionID: nil
+            )
         }
 
         let activeTabID = currentTabID

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -3373,6 +3373,16 @@ final class AgentModeViewModel: ObservableObject {
             tabID: session.tabID,
             sessionID: sessionID
         )
+        NotificationCenter.default.post(
+            name: .agentSessionBindingDidChange,
+            object: self,
+            userInfo: [
+                "tabID": session.tabID,
+                "windowID": windowID,
+                "previousSessionID": previousSessionID as Any,
+                "sessionID": sessionID as Any
+            ]
+        )
 
         if session.tabID == currentTabID {
             publishLoadingTranscriptPresentation(tabID: session.tabID)

--- a/Sources/RepoPrompt/Features/AgentMode/Views/Titlebar/AgentChatOptionsMenuPresenter.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Titlebar/AgentChatOptionsMenuPresenter.swift
@@ -1,0 +1,75 @@
+import AppKit
+
+struct AgentChatOptionsMenuSnapshot: Equatable {
+    let isPinned: Bool
+}
+
+struct AgentChatOptionsMenuActions {
+    let togglePin: () -> Void
+    let rename: () -> Void
+    let stash: () -> Void
+    let delete: () -> Void
+}
+
+private final class AgentChatOptionsMenuItem: NSMenuItem {
+    private let handler: () -> Void
+
+    init(title: String, symbolName: String, handler: @escaping () -> Void) {
+        self.handler = handler
+        super.init(title: title, action: #selector(performHandler(_:)), keyEquivalent: "")
+        target = self
+        image = NSImage(systemSymbolName: symbolName, accessibilityDescription: title)
+    }
+
+    @available(*, unavailable)
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    @objc private func performHandler(_ sender: NSMenuItem) {
+        _ = sender
+        handler()
+    }
+}
+
+@MainActor
+enum AgentChatOptionsMenuPresenter {
+    static func popUp(
+        below anchorView: NSView,
+        snapshot: AgentChatOptionsMenuSnapshot,
+        actions: AgentChatOptionsMenuActions
+    ) {
+        let menu = NSMenu(title: "Chat Options")
+        menu.autoenablesItems = false
+        menu.addItem(AgentChatOptionsMenuItem(
+            title: snapshot.isPinned ? "Unpin Chat" : "Pin Chat",
+            symbolName: snapshot.isPinned ? "pin.slash" : "pin",
+            handler: actions.togglePin
+        ))
+        menu.addItem(AgentChatOptionsMenuItem(
+            title: "Rename Chat…",
+            symbolName: "pencil",
+            handler: actions.rename
+        ))
+        menu.addItem(AgentChatOptionsMenuItem(
+            title: "Stash Chat",
+            symbolName: "tray.and.arrow.down",
+            handler: actions.stash
+        ))
+        menu.addItem(.separator())
+        menu.addItem(AgentChatOptionsMenuItem(
+            title: "Delete Chat…",
+            symbolName: "trash",
+            handler: actions.delete
+        ))
+
+        let menuOriginY = anchorView.isFlipped
+            ? anchorView.bounds.maxY + 2
+            : anchorView.bounds.minY - 2
+        menu.popUp(
+            positioning: nil,
+            at: NSPoint(x: anchorView.bounds.minX, y: menuOriginY),
+            in: anchorView
+        )
+    }
+}

--- a/Sources/RepoPrompt/Features/AgentMode/Views/Titlebar/AgentChatTitleClusterView.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Titlebar/AgentChatTitleClusterView.swift
@@ -1,0 +1,172 @@
+import AppKit
+import SwiftUI
+
+@MainActor
+final class AgentChatTitleClusterModel: ObservableObject {
+    struct State: Equatable {
+        var title: String
+        var showsChatOptions: Bool
+    }
+
+    @Published private(set) var state: State
+
+    init(title: String) {
+        state = State(title: title, showsChatOptions: false)
+    }
+
+    func update(title: String, showsChatOptions: Bool) {
+        let nextState = State(title: title, showsChatOptions: showsChatOptions)
+        guard state != nextState else { return }
+        state = nextState
+    }
+}
+
+struct AgentChatTitleClusterView: View {
+    @ObservedObject var model: AgentChatTitleClusterModel
+    let menuSnapshot: () -> AgentChatOptionsMenuSnapshot?
+    let menuActions: AgentChatOptionsMenuActions
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Text(model.state.title)
+                .font(.system(size: 13, weight: .semibold))
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .frame(maxWidth: 520)
+                .accessibilityIdentifier("AgentChatTitle")
+
+            if model.state.showsChatOptions {
+                AgentChatOptionsMenuButton(
+                    menuSnapshot: menuSnapshot,
+                    menuActions: menuActions
+                )
+            }
+        }
+        .fixedSize(horizontal: false, vertical: true)
+        .accessibilityElement(children: .contain)
+    }
+}
+
+private final class AgentChatOptionsButton: NSButton {
+    private var actionHandler: ((NSButton) -> Void)?
+    private var trackingArea: NSTrackingArea?
+    private var isHovering = false {
+        didSet { updateAppearance() }
+    }
+
+    init() {
+        super.init(frame: .zero)
+
+        image = NSImage(systemSymbolName: "ellipsis", accessibilityDescription: "Chat Options")
+        imagePosition = .imageOnly
+        isBordered = false
+        focusRingType = .none
+        translatesAutoresizingMaskIntoConstraints = false
+        toolTip = "Chat Options"
+        setAccessibilityLabel("Chat Options")
+        setAccessibilityRole(.menuButton)
+        setAccessibilityIdentifier("AgentChatOptionsButton")
+
+        wantsLayer = true
+        layer?.cornerRadius = 6
+        layer?.cornerCurve = .continuous
+
+        NSLayoutConstraint.activate([
+            widthAnchor.constraint(equalToConstant: 26),
+            heightAnchor.constraint(equalToConstant: 24)
+        ])
+        updateAppearance()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func setActionHandler(_ handler: @escaping (NSButton) -> Void) {
+        actionHandler = handler
+    }
+
+    override func mouseDown(with _: NSEvent) {
+        actionHandler?(self)
+    }
+
+    override func accessibilityPerformPress() -> Bool {
+        actionHandler?(self)
+        return true
+    }
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let trackingArea {
+            removeTrackingArea(trackingArea)
+        }
+        let options: NSTrackingArea.Options = [.activeAlways, .inVisibleRect, .mouseEnteredAndExited]
+        let area = NSTrackingArea(rect: bounds, options: options, owner: self, userInfo: nil)
+        addTrackingArea(area)
+        trackingArea = area
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        super.mouseEntered(with: event)
+        isHovering = true
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        super.mouseExited(with: event)
+        isHovering = false
+    }
+
+    private func updateAppearance() {
+        layer?.backgroundColor = isHovering
+            ? NSColor.labelColor.withAlphaComponent(0.08).cgColor
+            : NSColor.clear.cgColor
+        contentTintColor = NSColor.labelColor.withAlphaComponent(isHovering ? 1 : 0.8)
+    }
+}
+
+private struct AgentChatOptionsMenuButton: NSViewRepresentable {
+    let menuSnapshot: () -> AgentChatOptionsMenuSnapshot?
+    let menuActions: AgentChatOptionsMenuActions
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(menuSnapshot: menuSnapshot, menuActions: menuActions)
+    }
+
+    func makeNSView(context: Context) -> AgentChatOptionsButton {
+        let button = AgentChatOptionsButton()
+        button.setActionHandler { [coordinator = context.coordinator] sender in
+            coordinator.showMenu(sender)
+        }
+        return button
+    }
+
+    func updateNSView(_ nsView: AgentChatOptionsButton, context: Context) {
+        _ = nsView
+        context.coordinator.menuSnapshot = menuSnapshot
+        context.coordinator.menuActions = menuActions
+    }
+
+    @MainActor
+    final class Coordinator {
+        var menuSnapshot: () -> AgentChatOptionsMenuSnapshot?
+        var menuActions: AgentChatOptionsMenuActions
+
+        init(
+            menuSnapshot: @escaping () -> AgentChatOptionsMenuSnapshot?,
+            menuActions: AgentChatOptionsMenuActions
+        ) {
+            self.menuSnapshot = menuSnapshot
+            self.menuActions = menuActions
+        }
+
+        func showMenu(_ sender: NSButton) {
+            guard let snapshot = menuSnapshot() else { return }
+            AgentChatOptionsMenuPresenter.popUp(
+                below: sender,
+                snapshot: snapshot,
+                actions: menuActions
+            )
+        }
+    }
+}

--- a/Sources/RepoPrompt/Features/AgentMode/Views/Titlebar/AgentModeTitlebarAccessoryViewController.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Titlebar/AgentModeTitlebarAccessoryViewController.swift
@@ -2,123 +2,73 @@
 //  AgentModeTitlebarAccessoryViewController.swift
 //  RepoPrompt
 //
-//  Xcode-style titlebar accessory that places Agent Mode controls
+//  Xcode-style titlebar accessory that places a "New Session" button
 //  near the traffic lights using NSTitlebarAccessoryViewController.
 //
 
 import Cocoa
+import SwiftUI
 
-struct AgentModeTitlebarChatMenuSnapshot: Equatable {
-    let isPinned: Bool
-}
+// MARK: - SwiftUI View for Titlebar Button
 
-struct AgentModeTitlebarChatMenuActions {
-    let togglePin: () -> Void
-    let rename: () -> Void
-    let stash: () -> Void
-    let delete: () -> Void
-}
+/// Compact "New Session" button designed for the titlebar area
+private struct AgentModeTitlebarNewSessionView: View {
+    let onNewSession: () -> Void
+    @State private var isHovering = false
 
-// MARK: - Titlebar Button
-
-private final class TitlebarAccessoryIconButton: NSButton {
-    private let symbolName: String
-    private let accessibilityLabelText: String
-    private let normalAlpha: CGFloat
-    private var trackingArea: NSTrackingArea?
-    private var isHovering = false {
-        didSet { updateAppearance() }
-    }
-
-    init(symbolName: String, accessibilityLabel: String, toolTip: String, normalAlpha: CGFloat = 0.7) {
-        self.symbolName = symbolName
-        accessibilityLabelText = accessibilityLabel
-        self.normalAlpha = normalAlpha
-        super.init(frame: .zero)
-
-        image = NSImage(systemSymbolName: symbolName, accessibilityDescription: accessibilityLabel)
-        imagePosition = .imageOnly
-        isBordered = false
-        bezelStyle = .regularSquare
-        setButtonType(.momentaryChange)
-        focusRingType = .none
-        translatesAutoresizingMaskIntoConstraints = false
-        self.toolTip = toolTip
-        setAccessibilityLabel(accessibilityLabel)
-        setAccessibilityRole(.button)
-
-        wantsLayer = true
-        layer?.cornerRadius = 6
-        layer?.cornerCurve = .continuous
-
-        NSLayoutConstraint.activate([
-            widthAnchor.constraint(equalToConstant: 36),
-            heightAnchor.constraint(equalToConstant: 28)
-        ])
-        updateAppearance()
-    }
-
-    @available(*, unavailable)
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    override var isHighlighted: Bool {
-        didSet { updateAppearance() }
-    }
-
-    override func updateTrackingAreas() {
-        super.updateTrackingAreas()
-        if let trackingArea {
-            removeTrackingArea(trackingArea)
+    var body: some View {
+        Button(action: onNewSession) {
+            Image(systemName: "square.and.pencil")
+                .font(.system(size: 15, weight: .medium))
+                .foregroundColor(.primary.opacity(isHovering ? 1.0 : 0.7))
+                // SEARCH-HELPER: Titlebar, Alignment, Compose icon offset
+                // The `square.and.pencil` glyph's pencil shaft extends up-and-right
+                // beyond the square, so the geometric center of its bounding box sits
+                // higher than the visible mass (the square). Centering the bounding
+                // box therefore renders the square visibly *low* relative to the
+                // traffic lights — nudge the icon up slightly to correct the optical
+                // center.
+                .offset(y: -1.5)
         }
-        let options: NSTrackingArea.Options = [.activeAlways, .inVisibleRect, .mouseEnteredAndExited]
-        let area = NSTrackingArea(rect: bounds, options: options, owner: self, userInfo: nil)
-        addTrackingArea(area)
-        trackingArea = area
+        .buttonStyle(TitlebarAccessoryButtonStyle(isHovering: isHovering))
+        .onHover { hovering in
+            withAnimation(.easeInOut(duration: 0.15)) {
+                isHovering = hovering
+            }
+        }
+        .hoverTooltip("New Session", .bottom)
+        .accessibilityLabel("New Session")
+    }
+}
+
+/// Button style optimized for titlebar accessory placement
+struct TitlebarAccessoryButtonStyle: ButtonStyle {
+    let isHovering: Bool
+
+    init(isHovering: Bool = false) {
+        self.isHovering = isHovering
     }
 
-    override func mouseEntered(with event: NSEvent) {
-        super.mouseEntered(with: event)
-        isHovering = true
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .frame(width: 36, height: 28)
+            .background(
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(backgroundColor(isPressed: configuration.isPressed))
+            )
+            .contentShape(Rectangle())
+            .scaleEffect(configuration.isPressed ? 0.95 : 1.0)
+            .animation(.easeInOut(duration: 0.1), value: configuration.isPressed)
     }
 
-    override func mouseExited(with event: NSEvent) {
-        super.mouseExited(with: event)
-        isHovering = false
-    }
-
-    private func updateAppearance() {
-        if isHighlighted {
-            layer?.backgroundColor = NSColor.labelColor.withAlphaComponent(0.15).cgColor
+    private func backgroundColor(isPressed: Bool) -> Color {
+        if isPressed {
+            Color.primary.opacity(0.15)
         } else if isHovering {
-            layer?.backgroundColor = NSColor.labelColor.withAlphaComponent(0.08).cgColor
+            Color.primary.opacity(0.08)
         } else {
-            layer?.backgroundColor = NSColor.clear.cgColor
+            Color.clear
         }
-        contentTintColor = NSColor.labelColor.withAlphaComponent(isHovering ? 1.0 : normalAlpha)
-        image = NSImage(systemSymbolName: symbolName, accessibilityDescription: accessibilityLabelText)
-    }
-}
-
-private final class AgentModeTitlebarMenuItem: NSMenuItem {
-    private let handler: () -> Void
-
-    init(title: String, symbolName: String, handler: @escaping () -> Void) {
-        self.handler = handler
-        super.init(title: title, action: #selector(performHandler(_:)), keyEquivalent: "")
-        target = self
-        image = NSImage(systemSymbolName: symbolName, accessibilityDescription: title)
-    }
-
-    @available(*, unavailable)
-    required init(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    @objc private func performHandler(_ sender: NSMenuItem) {
-        _ = sender
-        handler()
     }
 }
 
@@ -126,24 +76,11 @@ private final class AgentModeTitlebarMenuItem: NSMenuItem {
 
 @MainActor
 final class AgentModeTitlebarAccessoryViewController: NSTitlebarAccessoryViewController {
+    private var hostingView: NSHostingView<AgentModeTitlebarNewSessionView>?
     private var onNewSession: () -> Void
-    private var hasChatOptions: () -> Bool
-    private var chatMenuSnapshot: () -> AgentModeTitlebarChatMenuSnapshot?
-    private var chatMenuActions: AgentModeTitlebarChatMenuActions
 
-    private weak var newSessionButton: TitlebarAccessoryIconButton?
-    private weak var chatOptionsButton: TitlebarAccessoryIconButton?
-
-    init(
-        onNewSession: @escaping () -> Void,
-        hasChatOptions: @escaping () -> Bool,
-        chatMenuSnapshot: @escaping () -> AgentModeTitlebarChatMenuSnapshot?,
-        chatMenuActions: AgentModeTitlebarChatMenuActions
-    ) {
+    init(onNewSession: @escaping () -> Void) {
         self.onNewSession = onNewSession
-        self.hasChatOptions = hasChatOptions
-        self.chatMenuSnapshot = chatMenuSnapshot
-        self.chatMenuActions = chatMenuActions
         super.init(nibName: nil, bundle: nil)
         layoutAttribute = .leading
     }
@@ -154,98 +91,16 @@ final class AgentModeTitlebarAccessoryViewController: NSTitlebarAccessoryViewCon
     }
 
     override func loadView() {
-        let stack = NSStackView()
-        stack.orientation = .horizontal
-        stack.alignment = .centerY
-        stack.spacing = 2
-        stack.edgeInsets = NSEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
-
-        let newButton = TitlebarAccessoryIconButton(
-            symbolName: "square.and.pencil",
-            accessibilityLabel: "New Session",
-            toolTip: "New Session"
-        )
-        newButton.target = self
-        newButton.action = #selector(performNewSession(_:))
-        stack.addArrangedSubview(newButton)
-        newSessionButton = newButton
-
-        let optionsButton = TitlebarAccessoryIconButton(
-            symbolName: "ellipsis",
-            accessibilityLabel: "Chat Options",
-            toolTip: "Chat Options"
-        )
-        optionsButton.target = self
-        optionsButton.action = #selector(showChatOptionsMenu(_:))
-        stack.addArrangedSubview(optionsButton)
-        chatOptionsButton = optionsButton
-
-        view = stack
-        refreshChatOptionsVisibility()
+        let swiftUIView = AgentModeTitlebarNewSessionView(onNewSession: onNewSession)
+        let hosting = NSHostingView(rootView: swiftUIView)
+        hosting.frame.size = hosting.fittingSize
+        hostingView = hosting
+        view = hosting
     }
 
-    /// Updates action closures without recreating the controller.
-    func update(
-        onNewSession: @escaping () -> Void,
-        hasChatOptions: @escaping () -> Bool,
-        chatMenuSnapshot: @escaping () -> AgentModeTitlebarChatMenuSnapshot?,
-        chatMenuActions: AgentModeTitlebarChatMenuActions
-    ) {
+    /// Updates the action closure without recreating the controller
+    func update(onNewSession: @escaping () -> Void) {
         self.onNewSession = onNewSession
-        self.hasChatOptions = hasChatOptions
-        self.chatMenuSnapshot = chatMenuSnapshot
-        self.chatMenuActions = chatMenuActions
-        refreshChatOptionsVisibility()
-    }
-
-    func refreshChatOptionsVisibility() {
-        guard let chatOptionsButton else { return }
-        let shouldHide = !hasChatOptions()
-        guard chatOptionsButton.isHidden != shouldHide else { return }
-
-        chatOptionsButton.isHidden = shouldHide
-        view.invalidateIntrinsicContentSize()
-        view.needsLayout = true
-        view.superview?.needsLayout = true
-    }
-
-    @objc private func performNewSession(_ sender: NSButton) {
-        _ = sender
-        onNewSession()
-        refreshChatOptionsVisibility()
-    }
-
-    @objc private func showChatOptionsMenu(_ sender: NSButton) {
-        guard let snapshot = chatMenuSnapshot() else {
-            refreshChatOptionsVisibility()
-            return
-        }
-
-        let menu = NSMenu(title: "Chat Options")
-        menu.autoenablesItems = false
-        menu.addItem(AgentModeTitlebarMenuItem(
-            title: snapshot.isPinned ? "Unpin Chat" : "Pin Chat",
-            symbolName: snapshot.isPinned ? "pin.slash" : "pin",
-            handler: { [weak self] in self?.chatMenuActions.togglePin() }
-        ))
-        menu.addItem(AgentModeTitlebarMenuItem(
-            title: "Rename Chat…",
-            symbolName: "pencil",
-            handler: { [weak self] in self?.chatMenuActions.rename() }
-        ))
-        menu.addItem(AgentModeTitlebarMenuItem(
-            title: "Stash Chat",
-            symbolName: "tray.and.arrow.down",
-            handler: { [weak self] in self?.chatMenuActions.stash() }
-        ))
-        menu.addItem(.separator())
-        menu.addItem(AgentModeTitlebarMenuItem(
-            title: "Delete Chat…",
-            symbolName: "trash",
-            handler: { [weak self] in self?.chatMenuActions.delete() }
-        ))
-
-        menu.popUp(positioning: nil, at: NSPoint(x: 0, y: sender.bounds.minY - 4), in: sender)
-        refreshChatOptionsVisibility()
+        hostingView?.rootView = AgentModeTitlebarNewSessionView(onNewSession: onNewSession)
     }
 }

--- a/Sources/RepoPrompt/Features/AgentMode/Views/Titlebar/AgentModeTitlebarAccessoryViewController.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Titlebar/AgentModeTitlebarAccessoryViewController.swift
@@ -2,73 +2,123 @@
 //  AgentModeTitlebarAccessoryViewController.swift
 //  RepoPrompt
 //
-//  Xcode-style titlebar accessory that places a "New Session" button
+//  Xcode-style titlebar accessory that places Agent Mode controls
 //  near the traffic lights using NSTitlebarAccessoryViewController.
 //
 
 import Cocoa
-import SwiftUI
 
-// MARK: - SwiftUI View for Titlebar Button
+struct AgentModeTitlebarChatMenuSnapshot: Equatable {
+    let isPinned: Bool
+}
 
-/// Compact "New Session" button designed for the titlebar area
-private struct AgentModeTitlebarNewSessionView: View {
-    let onNewSession: () -> Void
-    @State private var isHovering = false
+struct AgentModeTitlebarChatMenuActions {
+    let togglePin: () -> Void
+    let rename: () -> Void
+    let stash: () -> Void
+    let delete: () -> Void
+}
 
-    var body: some View {
-        Button(action: onNewSession) {
-            Image(systemName: "square.and.pencil")
-                .font(.system(size: 15, weight: .medium))
-                .foregroundColor(.primary.opacity(isHovering ? 1.0 : 0.7))
-                // SEARCH-HELPER: Titlebar, Alignment, Compose icon offset
-                // The `square.and.pencil` glyph's pencil shaft extends up-and-right
-                // beyond the square, so the geometric center of its bounding box sits
-                // higher than the visible mass (the square). Centering the bounding
-                // box therefore renders the square visibly *low* relative to the
-                // traffic lights — nudge the icon up slightly to correct the optical
-                // center.
-                .offset(y: -1.5)
+// MARK: - Titlebar Button
+
+private final class TitlebarAccessoryIconButton: NSButton {
+    private let symbolName: String
+    private let accessibilityLabelText: String
+    private let normalAlpha: CGFloat
+    private var trackingArea: NSTrackingArea?
+    private var isHovering = false {
+        didSet { updateAppearance() }
+    }
+
+    init(symbolName: String, accessibilityLabel: String, toolTip: String, normalAlpha: CGFloat = 0.7) {
+        self.symbolName = symbolName
+        accessibilityLabelText = accessibilityLabel
+        self.normalAlpha = normalAlpha
+        super.init(frame: .zero)
+
+        image = NSImage(systemSymbolName: symbolName, accessibilityDescription: accessibilityLabel)
+        imagePosition = .imageOnly
+        isBordered = false
+        bezelStyle = .regularSquare
+        setButtonType(.momentaryChange)
+        focusRingType = .none
+        translatesAutoresizingMaskIntoConstraints = false
+        self.toolTip = toolTip
+        setAccessibilityLabel(accessibilityLabel)
+        setAccessibilityRole(.button)
+
+        wantsLayer = true
+        layer?.cornerRadius = 6
+        layer?.cornerCurve = .continuous
+
+        NSLayoutConstraint.activate([
+            widthAnchor.constraint(equalToConstant: 36),
+            heightAnchor.constraint(equalToConstant: 28)
+        ])
+        updateAppearance()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override var isHighlighted: Bool {
+        didSet { updateAppearance() }
+    }
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let trackingArea {
+            removeTrackingArea(trackingArea)
         }
-        .buttonStyle(TitlebarAccessoryButtonStyle(isHovering: isHovering))
-        .onHover { hovering in
-            withAnimation(.easeInOut(duration: 0.15)) {
-                isHovering = hovering
-            }
+        let options: NSTrackingArea.Options = [.activeAlways, .inVisibleRect, .mouseEnteredAndExited]
+        let area = NSTrackingArea(rect: bounds, options: options, owner: self, userInfo: nil)
+        addTrackingArea(area)
+        trackingArea = area
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        super.mouseEntered(with: event)
+        isHovering = true
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        super.mouseExited(with: event)
+        isHovering = false
+    }
+
+    private func updateAppearance() {
+        if isHighlighted {
+            layer?.backgroundColor = NSColor.labelColor.withAlphaComponent(0.15).cgColor
+        } else if isHovering {
+            layer?.backgroundColor = NSColor.labelColor.withAlphaComponent(0.08).cgColor
+        } else {
+            layer?.backgroundColor = NSColor.clear.cgColor
         }
-        .hoverTooltip("New Session", .bottom)
-        .accessibilityLabel("New Session")
+        contentTintColor = NSColor.labelColor.withAlphaComponent(isHovering ? 1.0 : normalAlpha)
+        image = NSImage(systemSymbolName: symbolName, accessibilityDescription: accessibilityLabelText)
     }
 }
 
-/// Button style optimized for titlebar accessory placement
-struct TitlebarAccessoryButtonStyle: ButtonStyle {
-    let isHovering: Bool
+private final class AgentModeTitlebarMenuItem: NSMenuItem {
+    private let handler: () -> Void
 
-    init(isHovering: Bool = false) {
-        self.isHovering = isHovering
+    init(title: String, symbolName: String, handler: @escaping () -> Void) {
+        self.handler = handler
+        super.init(title: title, action: #selector(performHandler(_:)), keyEquivalent: "")
+        target = self
+        image = NSImage(systemSymbolName: symbolName, accessibilityDescription: title)
     }
 
-    func makeBody(configuration: Configuration) -> some View {
-        configuration.label
-            .frame(width: 36, height: 28)
-            .background(
-                RoundedRectangle(cornerRadius: 6)
-                    .fill(backgroundColor(isPressed: configuration.isPressed))
-            )
-            .contentShape(Rectangle())
-            .scaleEffect(configuration.isPressed ? 0.95 : 1.0)
-            .animation(.easeInOut(duration: 0.1), value: configuration.isPressed)
+    @available(*, unavailable)
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
 
-    private func backgroundColor(isPressed: Bool) -> Color {
-        if isPressed {
-            Color.primary.opacity(0.15)
-        } else if isHovering {
-            Color.primary.opacity(0.08)
-        } else {
-            Color.clear
-        }
+    @objc private func performHandler(_ sender: NSMenuItem) {
+        _ = sender
+        handler()
     }
 }
 
@@ -76,11 +126,24 @@ struct TitlebarAccessoryButtonStyle: ButtonStyle {
 
 @MainActor
 final class AgentModeTitlebarAccessoryViewController: NSTitlebarAccessoryViewController {
-    private var hostingView: NSHostingView<AgentModeTitlebarNewSessionView>?
     private var onNewSession: () -> Void
+    private var hasChatOptions: () -> Bool
+    private var chatMenuSnapshot: () -> AgentModeTitlebarChatMenuSnapshot?
+    private var chatMenuActions: AgentModeTitlebarChatMenuActions
 
-    init(onNewSession: @escaping () -> Void) {
+    private weak var newSessionButton: TitlebarAccessoryIconButton?
+    private weak var chatOptionsButton: TitlebarAccessoryIconButton?
+
+    init(
+        onNewSession: @escaping () -> Void,
+        hasChatOptions: @escaping () -> Bool,
+        chatMenuSnapshot: @escaping () -> AgentModeTitlebarChatMenuSnapshot?,
+        chatMenuActions: AgentModeTitlebarChatMenuActions
+    ) {
         self.onNewSession = onNewSession
+        self.hasChatOptions = hasChatOptions
+        self.chatMenuSnapshot = chatMenuSnapshot
+        self.chatMenuActions = chatMenuActions
         super.init(nibName: nil, bundle: nil)
         layoutAttribute = .leading
     }
@@ -91,16 +154,98 @@ final class AgentModeTitlebarAccessoryViewController: NSTitlebarAccessoryViewCon
     }
 
     override func loadView() {
-        let swiftUIView = AgentModeTitlebarNewSessionView(onNewSession: onNewSession)
-        let hosting = NSHostingView(rootView: swiftUIView)
-        hosting.frame.size = hosting.fittingSize
-        hostingView = hosting
-        view = hosting
+        let stack = NSStackView()
+        stack.orientation = .horizontal
+        stack.alignment = .centerY
+        stack.spacing = 2
+        stack.edgeInsets = NSEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
+
+        let newButton = TitlebarAccessoryIconButton(
+            symbolName: "square.and.pencil",
+            accessibilityLabel: "New Session",
+            toolTip: "New Session"
+        )
+        newButton.target = self
+        newButton.action = #selector(performNewSession(_:))
+        stack.addArrangedSubview(newButton)
+        newSessionButton = newButton
+
+        let optionsButton = TitlebarAccessoryIconButton(
+            symbolName: "ellipsis",
+            accessibilityLabel: "Chat Options",
+            toolTip: "Chat Options"
+        )
+        optionsButton.target = self
+        optionsButton.action = #selector(showChatOptionsMenu(_:))
+        stack.addArrangedSubview(optionsButton)
+        chatOptionsButton = optionsButton
+
+        view = stack
+        refreshChatOptionsVisibility()
     }
 
-    /// Updates the action closure without recreating the controller
-    func update(onNewSession: @escaping () -> Void) {
+    /// Updates action closures without recreating the controller.
+    func update(
+        onNewSession: @escaping () -> Void,
+        hasChatOptions: @escaping () -> Bool,
+        chatMenuSnapshot: @escaping () -> AgentModeTitlebarChatMenuSnapshot?,
+        chatMenuActions: AgentModeTitlebarChatMenuActions
+    ) {
         self.onNewSession = onNewSession
-        hostingView?.rootView = AgentModeTitlebarNewSessionView(onNewSession: onNewSession)
+        self.hasChatOptions = hasChatOptions
+        self.chatMenuSnapshot = chatMenuSnapshot
+        self.chatMenuActions = chatMenuActions
+        refreshChatOptionsVisibility()
+    }
+
+    func refreshChatOptionsVisibility() {
+        guard let chatOptionsButton else { return }
+        let shouldHide = !hasChatOptions()
+        guard chatOptionsButton.isHidden != shouldHide else { return }
+
+        chatOptionsButton.isHidden = shouldHide
+        view.invalidateIntrinsicContentSize()
+        view.needsLayout = true
+        view.superview?.needsLayout = true
+    }
+
+    @objc private func performNewSession(_ sender: NSButton) {
+        _ = sender
+        onNewSession()
+        refreshChatOptionsVisibility()
+    }
+
+    @objc private func showChatOptionsMenu(_ sender: NSButton) {
+        guard let snapshot = chatMenuSnapshot() else {
+            refreshChatOptionsVisibility()
+            return
+        }
+
+        let menu = NSMenu(title: "Chat Options")
+        menu.autoenablesItems = false
+        menu.addItem(AgentModeTitlebarMenuItem(
+            title: snapshot.isPinned ? "Unpin Chat" : "Pin Chat",
+            symbolName: snapshot.isPinned ? "pin.slash" : "pin",
+            handler: { [weak self] in self?.chatMenuActions.togglePin() }
+        ))
+        menu.addItem(AgentModeTitlebarMenuItem(
+            title: "Rename Chat…",
+            symbolName: "pencil",
+            handler: { [weak self] in self?.chatMenuActions.rename() }
+        ))
+        menu.addItem(AgentModeTitlebarMenuItem(
+            title: "Stash Chat",
+            symbolName: "tray.and.arrow.down",
+            handler: { [weak self] in self?.chatMenuActions.stash() }
+        ))
+        menu.addItem(.separator())
+        menu.addItem(AgentModeTitlebarMenuItem(
+            title: "Delete Chat…",
+            symbolName: "trash",
+            handler: { [weak self] in self?.chatMenuActions.delete() }
+        ))
+
+        menu.popUp(positioning: nil, at: NSPoint(x: 0, y: sender.bounds.minY - 4), in: sender)
+        refreshChatOptionsVisibility()
     }
 }


### PR DESCRIPTION
## Summary
- place a native Chat Options ellipsis beside the centered Agent chat title
- build the NSMenu lazily from a menu-open snapshot with pin, rename, stash, and delete actions
- preserve the existing New Session titlebar accessory and avoid observing streaming session state
- hide the menu when no focused Agent session is available and collapse only redundant single-window tab chrome

## Validation
- strict SwiftFormat/SwiftLint: passed
- focused `RepoPrompt` product build: passed
- contribution whitespace, guardrail, staged/outgoing secret scans: passed
- live title-adjacent placement and menu contents were verified during implementation

Hosted exact-head checks will provide the final full test/build gate.