### PR TITLE
Add focused-build cost reporting and high-output conductor diagnostics

### DIFF
--- a/.agents/skills/rpce-contribution-check/scripts/preflight.sh
+++ b/.agents/skills/rpce-contribution-check/scripts/preflight.sh
@@ -198,7 +198,7 @@ run_pr_ready_path_validations() {
   files="$tmp_root/range-files.z"
   write_range_files "$files"
 
-  local control_plane_paths_pattern='^(Scripts/conductor\.py|Scripts/guardrails\.sh|Scripts/test_conductor_(lifecycle|output)\.py|Scripts/test_contribution_preflight\.py|\.agents/skills/rpce-contribution-check/scripts/preflight(_timing\.py|\.sh)|Makefile)$'
+  local control_plane_paths_pattern='^(Scripts/conductor\.py|Scripts/conductor_diagnostics\.py|Scripts/guardrails\.sh|Scripts/test_conductor_(lifecycle|output|diagnostics|high_output)\.py|Scripts/test_contribution_preflight\.py|\.agents/skills/rpce-contribution-check/scripts/preflight(_timing\.py|\.sh)|Makefile)$'
   local ci_app_test_runner_paths_pattern='^(Scripts/ci_app_test_runner\.py|Scripts/test_ci_app_test_runner\.py|\.github/workflows/ci\.yml)$'
   local swift_paths_pattern='\.swift$'
   local root_test_paths_pattern='^(Sources/RepoPrompt/|Tests/RepoPrompt[^/]*Tests/)'

--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,8 @@ conductor-selftest:
 	python3 Scripts/test_ci_app_test_runner.py
 	python3 Scripts/test_conductor_cache.py
 	python3 Scripts/test_conductor_output.py
+	python3 Scripts/test_conductor_diagnostics.py
+	python3 Scripts/test_conductor_high_output.py
 	python3 Scripts/test_agent_mode_file_tools_benchmark.py
 	python3 Scripts/test_conductor_lifecycle.py
 	python3 Scripts/test_local_production_installer.py

--- a/Scripts/conductor.py
+++ b/Scripts/conductor.py
@@ -80,7 +80,7 @@ BUILD_CACHE_ENV_KEYS = (
     "SWIFT_EXEC",
     "SWIFTFLAGS",
 )
-SUMMARY_VERSION = 1
+SUMMARY_VERSION = 2
 SUMMARY_SUCCESS_MAX_LINES = 25
 SUMMARY_FAILURE_MAX_LINES = 100
 SUMMARY_MAX_CHARS = 16000
@@ -2530,7 +2530,7 @@ class OutputSummarizer:
         re.IGNORECASE,
     )
     SWIFT_ERROR_RE = re.compile(r"(: error:|error: emit-module command failed|Command SwiftCompile failed|Command CompileSwift failed|fatal error:)")
-    WARNING_RE = re.compile(r"(: warning:|^WARNING:)")
+    WARNING_RE = re.compile(r"(: warning:|^WARNING:)", re.IGNORECASE)
     TEST_FAILURE_RE = re.compile(
         r"(Test Case '.*' failed|XCTAssert|: error: .*Test|Executed .* tests?, with .* failures?|Failing tests:|error: Exited with unexpected signal|error: terminated)"
     )
@@ -2591,6 +2591,7 @@ class OutputSummarizer:
         lines_iterable: Any,
     ) -> Dict[str, Any]:
         del args
+        summary_start = now()
         failure = state in {"failed", "canceled"} or bool(timed_out) or (exit_code not in (None, 0))
         launch_lifecycle = {
             "transitionStarted": False,
@@ -2647,7 +2648,7 @@ class OutputSummarizer:
 
             if cls.WARNING_RE.search(line):
                 warning_count += 1
-                if failure or line.startswith("WARNING:"):
+                if failure or cls.WARNING_RE.match(line):
                     sections["Warnings"].add(line)
             if cls.SWIFT_ERROR_RE.search(line) or cls.FAILURE_RE.search(line):
                 error_count += 1
@@ -2772,6 +2773,7 @@ class OutputSummarizer:
             "omittedLineCount": omitted_line_count,
             "errorCount": error_count,
             "warningCount": warning_count,
+            "summaryDurationSeconds": round(now() - summary_start, 6),
             "launchLifecycle": launch_lifecycle,
             "sections": payload_sections,
             "truncated": truncated or input_truncated,
@@ -2801,6 +2803,7 @@ class OutputSummarizer:
             "omittedLineCount": 0,
             "errorCount": 0,
             "warningCount": 0,
+            "summaryDurationSeconds": 0.0,
             "sections": [
                 {
                     "title": "Summary notes",

--- a/Scripts/conductor.py
+++ b/Scripts/conductor.py
@@ -229,6 +229,8 @@ Operation commands:
   ./conductor diagnostics build-cache [--limit <n>]
   ./conductor cache status [--limit <n>] [--json]  # read-only; performs no repair or cleanup
   ./conductor cache drop <compatibility-key> [--json]
+  ./conductor diagnostics focused-build [--product <name>] [--test] [--filter <filter>]
+  ./conductor diagnostics high-output [--lines <n>] [--warnings <n>] [--exit-code <n>] [--linger <s>]
   ./conductor release preflight|artifact|package|local-install
 
 Foundation validation operation:
@@ -2842,6 +2844,8 @@ def operation_requires_global_heavy_slot(operation: str, args: Dict[str, Any]) -
         return True
     if operation == "release" and args.get("subcommand") in {"artifact", "package", "local-install"}:
         return True
+    if operation == "diagnostics" and args.get("subcommand") == "focused-build":
+        return True
     return False
 
 
@@ -3280,6 +3284,10 @@ class OperationRegistry:
                 return self._internal_argv("diagnostics_agent_mode_on", dict(args)), ["debugArtifact", "liveApp"], cwd, env, effective_timeout
             if subcommand == "build-cache":
                 return self._internal_argv("diagnostics_build_cache", dict(args)), lanes, cwd, env, effective_timeout
+            if subcommand == "focused-build":
+                return self._internal_argv("diagnostics_focused_build", dict(args)), ["build"], cwd, env, effective_timeout
+            if subcommand == "high-output":
+                return self._internal_argv("diagnostics_high_output", dict(args)), lanes, cwd, env, effective_timeout
         if operation == "release":
             subcommand = args.get("subcommand")
             if subcommand == "package":
@@ -8106,6 +8114,10 @@ def run_operation_runner(payload_json: str) -> int:
         return operation_diagnostics_agent_mode_on(repo_root, args)
     if kind == "diagnostics_build_cache":
         return operation_diagnostics_build_cache(repo_root, args)
+    if kind == "diagnostics_focused_build" or kind == "diagnostics_high_output":
+        import conductor_diagnostics
+
+        return conductor_diagnostics.run_diagnostic(kind, repo_root, args)
     if kind == "release_preflight_missing":
         return operation_release_preflight_missing(repo_root)
     print(f"unknown internal operation runner kind: {kind}", file=sys.stderr)
@@ -8273,6 +8285,17 @@ def handle_real_operation(paths: Paths, operation: str, argv: List[str]) -> int:
         build_cache = subparsers.add_parser("build-cache")
         build_cache.add_argument("--limit", type=int, default=BUILD_CACHE_DIAGNOSTIC_MAX_ROWS)
 
+        focused_build = subparsers.add_parser("focused-build")
+        focused_build.add_argument("--product", default="RepoPrompt")
+        focused_build.add_argument("--test", action="store_true")
+        focused_build.add_argument("--filter")
+
+        high_output = subparsers.add_parser("high-output")
+        high_output.add_argument("--lines", type=int, default=1000)
+        high_output.add_argument("--warnings", type=int, default=0)
+        high_output.add_argument("--exit-code", type=int, default=0)
+        high_output.add_argument("--linger", type=float, default=0.0)
+
         ns = parser.parse_args(rest)
         args["subcommand"] = ns.subcommand
         if ns.subcommand == "agent-mode-on":
@@ -8281,6 +8304,27 @@ def handle_real_operation(paths: Paths, operation: str, argv: List[str]) -> int:
             if ns.limit <= 0:
                 raise ConductorError("diagnostics build-cache --limit must be greater than zero")
             args["limit"] = ns.limit
+        elif ns.subcommand == "focused-build":
+            args.update({
+                "product": ns.product,
+                "runTests": ns.test or bool(ns.filter),
+                "testFilter": ns.filter,
+            })
+        elif ns.subcommand == "high-output":
+            if ns.lines < 0:
+                raise ConductorError("diagnostics high-output --lines must be non-negative")
+            if ns.warnings < 0:
+                raise ConductorError("diagnostics high-output --warnings must be non-negative")
+            if ns.exit_code < 0 or ns.exit_code > 255:
+                raise ConductorError("diagnostics high-output --exit-code must be 0-255")
+            if ns.linger < 0:
+                raise ConductorError("diagnostics high-output --linger must be non-negative")
+            args.update({
+                "lines": ns.lines,
+                "warnings": ns.warnings,
+                "exitCode": ns.exit_code,
+                "linger": ns.linger,
+            })
     elif operation == "release":
         parser = argparse.ArgumentParser(prog="conductor release")
         parser.add_argument("subcommand", choices=["preflight", "artifact", "package", "local-install"])

--- a/Scripts/conductor_diagnostics.py
+++ b/Scripts/conductor_diagnostics.py
@@ -70,6 +70,13 @@ def format_bytes(byte_count: Optional[int]) -> str:
 
 
 def directory_size_bytes(path: Path) -> Optional[int]:
+    """Return an approximate size in bytes for ``path``.
+
+    Top-level symlinks are resolved before measuring. ``du -sk`` is preferred;
+    if it is unavailable, a manual walk is used. The manual walk does not follow
+    directory symlinks inside the tree, so nested symlinked directories may be
+    undercounted. This is acceptable for the read-only scratch-size estimate.
+    """
     try:
         if not path.exists():
             return None
@@ -449,7 +456,7 @@ def run_focused_build(repo_root: Path, args: Dict[str, Any]) -> int:
     Args:
         repo_root: path to the Swift package root.
         args: operation args from the daemon; may include ``product``,
-            ``testFilter`` (or ``test``), ``runTests``.
+            ``testFilter``, and ``runTests``.
 
     Returns:
         0 if the diagnostic ran (regardless of build/test exit code), or

--- a/Scripts/conductor_diagnostics.py
+++ b/Scripts/conductor_diagnostics.py
@@ -1,0 +1,583 @@
+#!/usr/bin/env python3
+"""Read-only/conductor diagnostics used by run_operation_runner.
+
+These diagnostics are intentionally self-contained so they can be imported by
+conductor self-tests without pulling the full daemon module into a circular
+import.  They run as the child process of a conductor __operation_runner job.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import dataclasses
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+import threading
+import time
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+
+# Reuse the same regex vocabulary as conductor's OutputSummarizer so focused-build
+# warning/error counts are comparable with terminal summary counts.
+WARNING_RE = re.compile(r"(: warning:|^warning:|^WARNING:)", re.IGNORECASE)
+ERROR_RE = re.compile(r"(: error:|^error:|error: emit-module command failed|Command SwiftCompile failed|Command CompileSwift failed|fatal error:)")
+
+# Progress/task line emitted by swift build / swift test.
+SWIFT_PROGRESS_RE = re.compile(r"^\[(\d+)/(\d+)\]\s+(\S.*)$")
+# Compiling / Emitting module / Wrapping AST / Write / Linking / etc.
+#   [3/7] Compiling swift_probe swift_probe.swift
+#   [4/7] Emitting module swift_probe
+#   [5/8] Wrapping AST for swift_probe for debugging
+#   [7/8] Linking swift_probe
+SWIFT_TASK_RE = re.compile(r"^(Compiling|Emitting module|Wrapping AST|Write|Linking)\s+(.*)")
+
+BUILD_COMPLETE_RE = re.compile(r"Build complete!\s*\(([\d.]+)s\)")
+TEST_EXECUTED_RE = re.compile(r"Executed\s+(\d+)\s+test.*?in\s+([\d.]+)\s+\(([\d.]+)\)\s+seconds")
+
+
+def now() -> float:
+    return time.time()
+
+
+def format_duration(seconds: Optional[float]) -> str:
+    if seconds is None:
+        return "n/a"
+    seconds = max(0.0, float(seconds))
+    if seconds < 60:
+        return f"{seconds:.1f}s"
+    minutes, seconds = divmod(seconds, 60)
+    if minutes < 60:
+        return f"{int(minutes)}m {seconds:.0f}s"
+    hours, minutes = divmod(minutes, 60)
+    return f"{int(hours)}h {int(minutes)}m {seconds:.0f}s"
+
+
+def format_bytes(byte_count: Optional[int]) -> str:
+    if byte_count is None:
+        return "n/a"
+    value = float(max(0, int(byte_count)))
+    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
+        if value < 1024:
+            return f"{value:.1f} {unit}"
+        value /= 1024
+    return f"{value:.1f} PiB"
+
+
+def directory_size_bytes(path: Path) -> Optional[int]:
+    try:
+        if not path.exists():
+            return None
+        if path.is_symlink():
+            path = path.resolve(strict=True)
+    except OSError:
+        return None
+
+    try:
+        result = subprocess.run(
+            ["du", "-sk", str(path)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=120,
+            check=False,
+        )
+        if result.returncode == 0:
+            first = result.stdout.strip().split()[0]
+            return int(first) * 1024
+    except (OSError, subprocess.SubprocessError, ValueError, IndexError):
+        pass
+
+    total = 0
+    stack = [path]
+    while stack:
+        current = stack.pop()
+        try:
+            with os.scandir(current) as entries:
+                for entry in entries:
+                    try:
+                        stat_result = entry.stat(follow_symlinks=False)
+                    except OSError:
+                        continue
+                    if entry.is_dir(follow_symlinks=False):
+                        stack.append(Path(entry.path))
+                    else:
+                        total += stat_result.st_size
+        except NotADirectoryError:
+            try:
+                total += current.stat(follow_symlinks=False).st_size
+            except OSError:
+                pass
+        except OSError:
+            continue
+    return total
+
+
+def process_resource_snapshot() -> Dict[int, Tuple[int, int, str]]:
+    """Return a snapshot of all processes: pid -> (ppid, rss_kb, command).
+
+    RSS is in kilobytes (the units used by `ps -o rss` on both Linux and macOS).
+    """
+    try:
+        result = subprocess.run(
+            ["ps", "-axo", "pid=,ppid=,rss=,command="],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=2.0,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return {}
+    if result.returncode != 0:
+        return {}
+
+    snapshot: Dict[int, Tuple[int, int, str]] = {}
+    for line in result.stdout.splitlines():
+        parts = line.strip().split(None, 3)
+        if len(parts) != 4:
+            continue
+        try:
+            pid = int(parts[0])
+            ppid = int(parts[1])
+            rss = int(parts[2])
+        except ValueError:
+            continue
+        if pid > 0:
+            snapshot[pid] = (ppid, rss, parts[3])
+    return snapshot
+
+
+def process_tree_resources(root_pid: int, snapshot: Optional[Dict[int, Tuple[int, int, str]]] = None) -> Tuple[int, int, int, List[int]]:
+    """Sum RSS for all descendants of root_pid (including root_pid itself).
+
+    Returns (sum_rss_kb, max_single_rss_kb, pid_count, pids).
+    """
+    if snapshot is None:
+        snapshot = process_resource_snapshot()
+    if root_pid not in snapshot:
+        return (0, 0, 0, [])
+
+    children: Dict[int, List[int]] = defaultdict(list)
+    for pid, (ppid, _rss, _cmd) in snapshot.items():
+        if pid != ppid:
+            children[ppid].append(pid)
+
+    visited: set[int] = set()
+    pids: List[int] = []
+    stack = [root_pid]
+    while stack:
+        pid = stack.pop()
+        if pid in visited:
+            continue
+        visited.add(pid)
+        pids.append(pid)
+        stack.extend(children.get(pid, []))
+
+    sum_rss = 0
+    max_rss = 0
+    for pid in pids:
+        rss = snapshot[pid][1]
+        sum_rss += rss
+        if rss > max_rss:
+            max_rss = rss
+    return (sum_rss, max_rss, len(pids), pids)
+
+
+def pid_alive(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+
+
+@dataclasses.dataclass
+class _ResourceSampler:
+    """Sample peak process-tree RSS while a child process is running."""
+
+    root_pid: int
+    interval: float = 0.1
+    _running: bool = False
+    _thread: Optional[threading.Thread] = None
+    peak_sum_kb: int = 0
+    peak_max_kb: int = 0
+    peak_pids: int = 0
+    sample_count: int = 0
+
+    def start(self) -> None:
+        self._running = True
+        self._thread = threading.Thread(target=self._sample, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._running = False
+        if self._thread is not None:
+            self._thread.join(timeout=self.interval + 0.2)
+
+    def _sample(self) -> None:
+        while self._running:
+            with contextlib.suppress(OSError, subprocess.SubprocessError):
+                total, max_single, pids, _ = process_tree_resources(self.root_pid)
+                self.sample_count += 1
+                if total > self.peak_sum_kb:
+                    self.peak_sum_kb = total
+                    self.peak_pids = pids
+                if max_single > self.peak_max_kb:
+                    self.peak_max_kb = max_single
+            time.sleep(self.interval)
+
+
+@dataclasses.dataclass
+class _WarningRecord:
+    line: str
+    module: Optional[str]
+    source: Optional[str]
+    message: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "line": self.line.strip(),
+            "module": self.module,
+            "source": self.source,
+            "message": self.message,
+        }
+
+
+class _FocusedBuildParser:
+    """Parse `swift build` / `swift test` output into the focused-build report."""
+
+    def __init__(self, repo_root: Path) -> None:
+        self.repo_root = repo_root
+        self.lines: List[str] = []
+        self.current_module: Optional[str] = None
+        self.build_complete_seconds: Optional[float] = None
+        self.build_complete_line: Optional[str] = None
+        self.link_count = 0
+        self.compile_count = 0
+        self.emit_module_count = 0
+        self.wrap_ast_count = 0
+        self.write_count = 0
+        self.progress_max: Optional[int] = None
+        self.test_executed: Optional[int] = None
+        self.test_seconds: Optional[float] = None
+        self.test_wall_seconds: Optional[float] = None
+        self.warnings: List[_WarningRecord] = []
+        self.errors: List[_WarningRecord] = []
+
+    def _module_from_file(self, file_path: str) -> Optional[str]:
+        if not file_path:
+            return None
+        try:
+            rel = (self.repo_root / file_path).relative_to(self.repo_root)
+        except ValueError:
+            return None
+        parts = rel.parts
+        if not parts:
+            return None
+        if parts[0] == "Sources" and len(parts) >= 2:
+            directory = parts[1]
+            mapping = {
+                "RepoPrompt": "RepoPromptApp",
+                "RepoPromptExecutable": "RepoPrompt",
+                "RepoPromptShared": "RepoPromptShared",
+                "RepoPromptMCP": "RepoPromptMCP",
+                "RepoPromptC": "RepoPromptC",
+                "CSwiftPCRE2": "CSwiftPCRE2",
+                "TreeSitterScannerSupport": "TreeSitterScannerSupport",
+            }
+            return mapping.get(directory, directory)
+        return None
+
+    def _extract_file_path(self, line: str) -> Optional[str]:
+        # Matches "Sources/Foo.swift:10:5: warning|error: ..." or
+        # absolute path variants.
+        match = re.match(r"([^:\s]+\.swift):\d+:\d+:\s*(?:warning|error):", line)
+        if match:
+            return match.group(1)
+        return None
+
+    def _extract_message(self, line: str) -> str:
+        # Drop the leading file:line:col: prefix if present.
+        match = re.match(r"([^:\s]+\.swift:\d+:\d+:\s*(?:warning|error):\s*)?(.+)", line)
+        if match:
+            return match.group(2).strip()
+        return line.strip()
+
+    def _categorize(self, line: str) -> _WarningRecord:
+        source = self._extract_file_path(line)
+        module = self.current_module or self._module_from_file(source) if source else self.current_module
+        message = self._extract_message(line)
+        return _WarningRecord(line=line, module=module, source=source, message=message)
+
+    def feed(self, line: str) -> None:
+        self.lines.append(line)
+
+        progress = SWIFT_PROGRESS_RE.match(line)
+        if progress:
+            self.progress_max = max(self.progress_max or 0, int(progress.group(2)))
+            task_text = progress.group(3)
+            task = SWIFT_TASK_RE.match(task_text)
+            if task:
+                kind = task.group(1)
+                rest = task.group(2).strip()
+                if kind == "Compiling":
+                    self.compile_count += 1
+                    # [3/7] Compiling swift_probe swift_probe.swift
+                    # The first token after "Compiling" is the target/module.
+                    parts = rest.split(None, 1)
+                    self.current_module = parts[0] if parts else None
+                elif kind == "Emitting module":
+                    self.emit_module_count += 1
+                    self.current_module = rest
+                elif kind == "Wrapping AST":
+                    self.wrap_ast_count += 1
+                    # "for swift_probe for debugging" -> extract target
+                    m = re.search(r"for\s+(\S+)", rest)
+                    self.current_module = m.group(1) if m else None
+                elif kind == "Write":
+                    self.write_count += 1
+                elif kind == "Linking":
+                    self.link_count += 1
+                    self.current_module = None
+
+        build = BUILD_COMPLETE_RE.search(line)
+        if build:
+            self.build_complete_seconds = float(build.group(1))
+            self.build_complete_line = line.strip()
+            self.current_module = None
+
+        test = TEST_EXECUTED_RE.search(line)
+        if test:
+            self.test_executed = int(test.group(1))
+            self.test_seconds = float(test.group(2))
+            self.test_wall_seconds = float(test.group(3))
+
+        if WARNING_RE.search(line):
+            self.warnings.append(self._categorize(line))
+        elif ERROR_RE.search(line):
+            self.errors.append(self._categorize(line))
+
+    def _summary_for(self, records: List[_WarningRecord]) -> Dict[str, Any]:
+        by_module: Dict[str, int] = Counter()
+        by_source: Dict[str, int] = Counter()
+        by_message: Dict[str, int] = Counter()
+        for record in records:
+            if record.module:
+                by_module[record.module] += 1
+            if record.source:
+                by_source[record.source] += 1
+            by_message[record.message] += 1
+        return {
+            "rawCount": len(records),
+            "uniqueCount": len(by_message),
+            "byModule": dict(by_module),
+            "bySource": dict(by_source),
+            "uniqueByMessage": dict(by_message),
+            "items": [record.to_dict() for record in records[:250]],
+        }
+
+    def report(self, swift_invocation: List[str], swift_exit_code: int, scratch_info: Dict[str, Any], peak_rss_bytes: Optional[int]) -> Dict[str, Any]:
+        output_bytes = sum(len(line.encode("utf-8", errors="replace")) for line in self.lines)
+        return {
+            "diagnostic": "focused-build",
+            "repoRoot": str(self.repo_root),
+            "swift": {
+                "command": " ".join(shlex.quote(str(arg)) for arg in swift_invocation),
+                "exitCode": swift_exit_code,
+            },
+            "scratch": scratch_info,
+            "output": {
+                "lines": len(self.lines),
+                "bytes": output_bytes,
+            },
+            "timing": {
+                "build": {
+                    "seconds": self.build_complete_seconds,
+                    "line": self.build_complete_line,
+                },
+                "link": {
+                    "commandCount": self.link_count,
+                },
+                "xctest": {
+                    "tests": self.test_executed,
+                    "seconds": self.test_seconds,
+                    "wallSeconds": self.test_wall_seconds,
+                } if self.test_executed is not None else None,
+            },
+            "jobs": {
+                "compile": self.compile_count,
+                "emitModule": self.emit_module_count,
+                "wrapAst": self.wrap_ast_count,
+                "link": self.link_count,
+                "write": self.write_count,
+                "progressMax": self.progress_max,
+                "frontend": self.compile_count + self.emit_module_count + self.wrap_ast_count,
+            },
+            "warnings": self._summary_for(self.warnings),
+            "errors": self._summary_for(self.errors),
+            "peakChildProcessTreeRSS": {
+                "bytes": peak_rss_bytes,
+                "human": format_bytes(peak_rss_bytes),
+            } if peak_rss_bytes is not None else None,
+        }
+
+
+def _scratch_info(repo_root: Path, build_dir: Path) -> Dict[str, Any]:
+    observed_state = "cold" if not build_dir.exists() else "warm"
+    size = directory_size_bytes(build_dir) if build_dir.exists() else None
+    return {
+        "directory": str(build_dir),
+        "observedBefore": observed_state,
+        "sizeBytes": size,
+        "sizeHuman": format_bytes(size),
+    }
+
+
+def run_focused_build(repo_root: Path, args: Dict[str, Any]) -> int:
+    """Run a focused, read-only build diagnostic and print a JSON report.
+
+    Args:
+        repo_root: path to the Swift package root.
+        args: operation args from the daemon; may include ``product``,
+            ``testFilter`` (or ``test``), ``runTests``.
+
+    Returns:
+        0 if the diagnostic ran (regardless of build/test exit code), or
+        1 if the diagnostic itself could not run.
+    """
+    product = str(args.get("product") or "RepoPrompt")
+    test_filter = str(args.get("testFilter") or "")
+    run_tests = bool(args.get("runTests") or test_filter)
+    build_dir = repo_root / ".build"
+
+    if run_tests:
+        invocation = ["swift", "test", "--no-color-diagnostics"]
+        if test_filter:
+            invocation.extend(["--filter", test_filter])
+    else:
+        invocation = ["swift", "build", "--product", product, "--no-color-diagnostics"]
+
+    scratch_info = _scratch_info(repo_root, build_dir)
+
+    parser = _FocusedBuildParser(repo_root)
+    process: Optional[subprocess.Popen[str]] = None
+    sampler: Optional[_ResourceSampler] = None
+
+    start_time = now()
+    try:
+        process = subprocess.Popen(
+            invocation,
+            cwd=str(repo_root),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            stdin=subprocess.DEVNULL,
+            text=True,
+            errors="replace",
+        )
+    except FileNotFoundError:
+        print(f"ERROR: {invocation[0]} not found in PATH", flush=True)
+        return 1
+    except OSError as exc:
+        print(f"ERROR: could not launch {invocation[0]}: {exc}", flush=True)
+        return 1
+
+    if process.pid:
+        sampler = _ResourceSampler(process.pid)
+        sampler.start()
+
+    try:
+        with process as p:
+            assert p.stdout is not None
+            for line in p.stdout:
+                parser.feed(line)
+        exit_code = process.returncode
+    except Exception as exc:
+        print(f"ERROR: reading swift output: {exc}", flush=True)
+        if process.poll() is None:
+            process.terminate()
+            try:
+                process.wait(timeout=2.0)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait()
+        return 1
+    finally:
+        if sampler is not None:
+            sampler.stop()
+
+    elapsed = now() - start_time
+    peak_rss_bytes = None
+    if sampler is not None:
+        peak_rss_bytes = sampler.peak_sum_kb * 1024
+
+    # Update scratch info after the build (size is a read-only observation).
+    scratch_info_after = _scratch_info(repo_root, build_dir)
+    scratch_info_after["observedBefore"] = scratch_info["observedBefore"]
+
+    report = parser.report(
+        swift_invocation=invocation,
+        swift_exit_code=exit_code,
+        scratch_info=scratch_info_after,
+        peak_rss_bytes=peak_rss_bytes,
+    )
+    report["diagnosticDurationSeconds"] = round(elapsed, 3)
+    report["resourceSamples"] = sampler.sample_count if sampler else 0
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return exit_code
+
+
+def run_high_output(_repo_root: Path, args: Dict[str, Any]) -> int:
+    """Synthetic high-output child used for conductor output-pipeline tests.
+
+    Args:
+        args: operation args; may include ``lines``, ``warnings``,
+            ``exitCode``, ``linger``.
+
+    Returns:
+        The requested exit code.
+    """
+    lines_arg = args.get("lines")
+    lines = max(0, int(lines_arg if lines_arg is not None else 1000))
+    warnings_arg = args.get("warnings")
+    warnings = max(0, int(warnings_arg if warnings_arg is not None else 0))
+    exit_code = int(args.get("exitCode") or 0)
+    linger = max(0.0, float(args.get("linger") or 0.0))
+
+    print("==> high-output diagnostic start", flush=True)
+    for index in range(lines):
+        print(f"high-output line {index}", flush=True)
+    for index in range(warnings):
+        print(f"Sources/Fake.swift:{index + 1}:1: warning: synthetic warning {index}", flush=True)
+    print("==> high-output diagnostic done", flush=True)
+
+    if linger:
+        time.sleep(linger)
+    return exit_code
+
+
+def run_diagnostic(kind: str, repo_root: Path, args: Dict[str, Any]) -> int:
+    """Entrypoint for the operation_runner dispatch.
+
+    Keeping the switch here means conductor.py only needs to know the name
+    and the diagnostic module is free to add more runners.
+    """
+    if kind == "diagnostics_focused_build":
+        return run_focused_build(repo_root, args)
+    if kind == "diagnostics_high_output":
+        return run_high_output(repo_root, args)
+    print(f"unknown diagnostic kind: {kind}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit("run via conductor __operation_runner")

--- a/Scripts/conductor_diagnostics.py
+++ b/Scripts/conductor_diagnostics.py
@@ -540,7 +540,10 @@ def run_focused_build(repo_root: Path, args: Dict[str, Any]) -> int:
     report["diagnosticDurationSeconds"] = round(elapsed, 3)
     report["resourceSamples"] = sampler.sample_count if sampler else 0
     print(json.dumps(report, indent=2, sort_keys=True))
-    return exit_code
+    # A non-zero Swift exit is an observed build result recorded in the report,
+    # not a failure of this diagnostic. This lets callers collect diagnostics
+    # for failing builds without the runner discarding the job as unsuccessful.
+    return 0
 
 
 def run_high_output(_repo_root: Path, args: Dict[str, Any]) -> int:

--- a/Scripts/test_conductor_diagnostics.py
+++ b/Scripts/test_conductor_diagnostics.py
@@ -14,6 +14,7 @@ import tempfile
 import unittest
 from pathlib import Path
 from typing import Tuple
+from unittest import mock
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 if str(SCRIPT_DIR) not in sys.path:
@@ -159,9 +160,12 @@ class FocusedBuildDiagnosticTests(unittest.TestCase):
         self.assertEqual(report["timing"]["xctest"]["wallSeconds"], 0.457)
 
     def test_focused_build_missing_swift_returns_one(self) -> None:
-        empty_path = Path(tempfile.mkdtemp())
-        self.addCleanup(lambda p=empty_path: shutil.rmtree(p, ignore_errors=True))
-        code, _ = self._run_with_path(empty_path, {"product": "RepoPrompt"})
+        with tempfile.TemporaryDirectory() as tmp, mock.patch.object(
+            conductor_diagnostics.subprocess,
+            "Popen",
+            side_effect=FileNotFoundError,
+        ):
+            code, _ = self._run_with_path(Path(tmp), {"product": "RepoPrompt"})
         self.assertEqual(code, 1)
 
     def test_focused_build_reports_scratch_state(self) -> None:

--- a/Scripts/test_conductor_diagnostics.py
+++ b/Scripts/test_conductor_diagnostics.py
@@ -39,8 +39,10 @@ class FocusedBuildDiagnosticTests(unittest.TestCase):
     def _run_with_path(self, path: Path, args: dict) -> Tuple[int, str]:
         old_path = os.environ.get("PATH")
         try:
-            # Keep only the fake swift directory and /usr/bin for ps/du/bash/cat.
-            os.environ["PATH"] = f"{path}{os.pathsep}/usr/bin"
+            # Keep only the fake swift directory plus the system tools the
+            # fixture needs. macOS keeps bash in /bin, while /usr/bin/env
+            # resolves the fixture's shebang through PATH.
+            os.environ["PATH"] = f"{path}{os.pathsep}/usr/bin{os.pathsep}/bin"
             buf = io.StringIO()
             with contextlib.redirect_stdout(buf):
                 code = conductor_diagnostics.run_focused_build(self.repo_root, args)

--- a/Scripts/test_conductor_diagnostics.py
+++ b/Scripts/test_conductor_diagnostics.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Unit tests for the focused-build and high-output diagnostic helpers."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import os
+import shutil
+import stat
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Tuple
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import conductor_diagnostics  # noqa: E402
+
+
+class FocusedBuildDiagnosticTests(unittest.TestCase):
+    def _make_fake_swift(self, output: str, exit_code: int = 0) -> Path:
+        tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda p=tmp: shutil.rmtree(p, ignore_errors=True))
+        swift = tmp / "swift"
+        swift.write_text(
+            "#!/usr/bin/env bash\n"
+            f"cat <<'EOF'\n{output}EOF\n"
+            f"exit {exit_code}\n",
+            encoding="utf-8",
+        )
+        swift.chmod(swift.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        return tmp
+
+    def _run_with_path(self, path: Path, args: dict) -> Tuple[int, str]:
+        old_path = os.environ.get("PATH")
+        try:
+            # Keep only the fake swift directory and /usr/bin for ps/du/bash/cat.
+            os.environ["PATH"] = f"{path}{os.pathsep}/usr/bin"
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                code = conductor_diagnostics.run_focused_build(self.repo_root, args)
+            return code, buf.getvalue()
+        finally:
+            if old_path is None:
+                os.environ.pop("PATH", None)
+            else:
+                os.environ["PATH"] = old_path
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.repo_root = Path(self.tmp.name)
+
+    def test_focused_build_parses_swift_build_output(self) -> None:
+        output = (
+            "Building for debugging...\n"
+            "[0/5] Write swift-version--42C19770CB19FCAE.txt\n"
+            "[3/7] Compiling swift_probe swift_probe.swift\n"
+            "[4/7] Emitting module swift_probe\n"
+            "[5/8] Wrapping AST for swift_probe for debugging\n"
+            "[6/8] Write Objects.LinkFileList\n"
+            "[7/8] Linking swift_probe\n"
+            "Build complete! (1.23s)\n"
+        )
+        fake_path = self._make_fake_swift(output, exit_code=0)
+        code, captured = self._run_with_path(fake_path, {"product": "RepoPrompt"})
+        self.assertEqual(code, 0)
+        report = json.loads(captured)
+        self.assertEqual(report["diagnostic"], "focused-build")
+        self.assertEqual(report["swift"]["exitCode"], 0)
+        self.assertEqual(report["timing"]["build"]["seconds"], 1.23)
+        self.assertEqual(report["jobs"]["compile"], 1)
+        self.assertEqual(report["jobs"]["emitModule"], 1)
+        self.assertEqual(report["jobs"]["wrapAst"], 1)
+        self.assertEqual(report["jobs"]["link"], 1)
+        self.assertEqual(report["jobs"]["write"], 2)
+        self.assertEqual(report["jobs"]["frontend"], 3)
+        self.assertEqual(report["output"]["lines"], 8)
+
+    def test_focused_build_counts_warnings_and_errors_by_module(self) -> None:
+        output = (
+            "Building for debugging...\n"
+            "[2/101] Emitting module RepoPromptShared\n"
+            "[3/103] Compiling RepoPromptShared POSIXDescriptorSupport.swift\n"
+            "Sources/RepoPromptShared/Warning.swift:10:5: warning: unused variable\n"
+            "Sources/RepoPromptShared/Warning.swift:11:5: warning: unused variable\n"
+            "Sources/RepoPromptShared/Error.swift:20:5: error: cannot find 'x' in scope\n"
+            "Build complete! (2.50s)\n"
+        )
+        fake_path = self._make_fake_swift(output, exit_code=1)
+        code, captured = self._run_with_path(fake_path, {"product": "RepoPrompt"})
+        self.assertEqual(code, 1)
+        report = json.loads(captured)
+        self.assertEqual(report["swift"]["exitCode"], 1)
+        self.assertEqual(report["warnings"]["rawCount"], 2)
+        self.assertEqual(report["warnings"]["uniqueCount"], 1)
+        self.assertEqual(report["warnings"]["byModule"]["RepoPromptShared"], 2)
+        self.assertEqual(report["errors"]["rawCount"], 1)
+        self.assertEqual(report["errors"]["byModule"]["RepoPromptShared"], 1)
+        self.assertEqual(report["errors"]["bySource"]["Sources/RepoPromptShared/Error.swift"], 1)
+
+    def test_focused_build_resolves_relative_warning_and_error_paths(self) -> None:
+        # No compile-task context is emitted before the diagnostics, so the
+        # parser must derive the module from the repo-relative source path.
+        output = (
+            "Building for debugging...\n"
+            "Sources/RepoPromptShared/Warning.swift:10:5: warning: unused variable\n"
+            "Sources/RepoPromptShared/Error.swift:20:5: error: cannot find 'x' in scope\n"
+            "Build complete! (1.00s)\n"
+        )
+        fake_path = self._make_fake_swift(output, exit_code=0)
+        code, captured = self._run_with_path(fake_path, {"product": "RepoPrompt"})
+        self.assertEqual(code, 0)
+        report = json.loads(captured)
+        self.assertEqual(report["warnings"]["byModule"]["RepoPromptShared"], 1)
+        self.assertEqual(report["warnings"]["bySource"]["Sources/RepoPromptShared/Warning.swift"], 1)
+        self.assertEqual(report["errors"]["byModule"]["RepoPromptShared"], 1)
+        self.assertEqual(report["errors"]["bySource"]["Sources/RepoPromptShared/Error.swift"], 1)
+
+    def test_focused_build_resolves_absolute_warning_paths(self) -> None:
+        abs_warning = str(self.repo_root / "Sources/RepoPromptShared/Warning.swift")
+        abs_error = str(self.repo_root / "Sources/RepoPromptShared/Error.swift")
+        output = (
+            "Building for debugging...\n"
+            f"{abs_warning}:10:5: warning: unused variable\n"
+            f"{abs_error}:20:5: error: cannot find 'x' in scope\n"
+            "Build complete! (1.00s)\n"
+        )
+        fake_path = self._make_fake_swift(output, exit_code=0)
+        code, captured = self._run_with_path(fake_path, {"product": "RepoPrompt"})
+        self.assertEqual(code, 0)
+        report = json.loads(captured)
+        self.assertEqual(report["warnings"]["byModule"]["RepoPromptShared"], 1)
+        self.assertEqual(report["errors"]["byModule"]["RepoPromptShared"], 1)
+
+    def test_focused_build_parses_swift_test_output(self) -> None:
+        output = (
+            "Building for debugging...\n"
+            "[7/8] Linking swift_probe\n"
+            "Build complete! (2.00s)\n"
+            "Test Suite 'All tests' started at 2025-10-09 13:12:08.094\n"
+            "Test Suite 'All tests' passed at 2025-10-09 13:12:08.095\n"
+            "     Executed 3 tests, with 0 failures (0 unexpected) in 0.456 (0.457) seconds\n"
+        )
+        fake_path = self._make_fake_swift(output, exit_code=0)
+        code, captured = self._run_with_path(fake_path, {"testFilter": "Example"})
+        self.assertEqual(code, 0)
+        report = json.loads(captured)
+        self.assertEqual(report["swift"]["exitCode"], 0)
+        self.assertEqual(report["timing"]["xctest"]["tests"], 3)
+        self.assertEqual(report["timing"]["xctest"]["seconds"], 0.456)
+        self.assertEqual(report["timing"]["xctest"]["wallSeconds"], 0.457)
+
+    def test_focused_build_missing_swift_returns_one(self) -> None:
+        empty_path = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda p=empty_path: shutil.rmtree(p, ignore_errors=True))
+        code, _ = self._run_with_path(empty_path, {"product": "RepoPrompt"})
+        self.assertEqual(code, 1)
+
+    def test_focused_build_reports_scratch_state(self) -> None:
+        output = "Build complete! (0.50s)\n"
+        fake_path = self._make_fake_swift(output, exit_code=0)
+        build_dir = self.repo_root / ".build"
+        build_dir.mkdir()
+        (build_dir / "some").write_text("x", encoding="utf-8")
+        code, captured = self._run_with_path(fake_path, {"product": "RepoPrompt"})
+        self.assertEqual(code, 0)
+        report = json.loads(captured)
+        self.assertEqual(report["scratch"]["observedBefore"], "warm")
+        self.assertIsNotNone(report["scratch"]["sizeBytes"])
+        self.assertGreaterEqual(report["scratch"]["sizeBytes"], 1)
+
+
+class HighOutputDiagnosticTests(unittest.TestCase):
+    def test_high_output_generates_expected_counts(self) -> None:
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            code = conductor_diagnostics.run_high_output(Path("/tmp"), {"lines": 10, "warnings": 2, "exitCode": 42})
+        self.assertEqual(code, 42)
+        text = buf.getvalue()
+        lines = text.strip().splitlines()
+        # start marker + 10 lines + 2 warnings + done marker
+        self.assertEqual(len(lines), 14)
+        self.assertEqual(sum(1 for line in lines if "synthetic warning 0" in line), 1)
+        self.assertEqual(sum(1 for line in lines if "synthetic warning 1" in line), 1)
+
+    def test_high_output_honors_zero_lines_and_warnings(self) -> None:
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            code = conductor_diagnostics.run_high_output(Path("/tmp"), {"lines": 0, "warnings": 0, "exitCode": 7})
+        self.assertEqual(code, 7)
+        lines = buf.getvalue().strip().splitlines()
+        self.assertEqual(lines, ["==> high-output diagnostic start", "==> high-output diagnostic done"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Scripts/test_conductor_diagnostics.py
+++ b/Scripts/test_conductor_diagnostics.py
@@ -96,7 +96,7 @@ class FocusedBuildDiagnosticTests(unittest.TestCase):
         )
         fake_path = self._make_fake_swift(output, exit_code=1)
         code, captured = self._run_with_path(fake_path, {"product": "RepoPrompt"})
-        self.assertEqual(code, 1)
+        self.assertEqual(code, 0)
         report = json.loads(captured)
         self.assertEqual(report["swift"]["exitCode"], 1)
         self.assertEqual(report["warnings"]["rawCount"], 2)

--- a/Scripts/test_conductor_high_output.py
+++ b/Scripts/test_conductor_high_output.py
@@ -243,6 +243,7 @@ class HighOutputDiagnosticTest(unittest.TestCase):
         peak_child = 0
         peak_daemon = 0
         samples = 0
+        deadline = time.monotonic() + 30.0
         while True:
             snapshot = conductor_diagnostics.process_resource_snapshot()
             if daemon_pid in snapshot:
@@ -254,6 +255,8 @@ class HighOutputDiagnosticTest(unittest.TestCase):
             status = self._request({"type": "job-status", "ticket": ticket}, socket_timeout=2.0)
             if status.get("state") in {"completed", "failed", "canceled"}:
                 break
+            if time.monotonic() > deadline:
+                self.fail("resource polling exceeded deadline")
             time.sleep(0.1)
 
         self._wait_for_terminal(ticket)

--- a/Scripts/test_conductor_high_output.py
+++ b/Scripts/test_conductor_high_output.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Synthetic high-output conductor integration diagnostic.
+
+Starts a real conductor daemon in a disposable temporary directory, enqueues a
+`diagnostics high-output` job, and verifies:
+
+* status / job-wait / cancel RPC phase latency
+* daemon versus child process resources
+* raw-log completeness vs terminal summary counts
+* summary duration instrumentation
+* verified process-tree exit after completion and after cancellation
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import unittest
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import conductor  # noqa: E402
+import conductor_diagnostics  # noqa: E402
+
+
+class HighOutputDiagnosticTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+        self.state_dir = self.root / "state"
+        self.state_dir.mkdir()
+        self.socket_path = self.root / "conductor.sock"
+        self.env = os.environ.copy()
+        self.env["REPOPROMPT_DEV_DAEMON_STATE_DIR"] = str(self.state_dir)
+        self.env["REPOPROMPT_DEV_DAEMON_SOCKET"] = str(self.socket_path)
+
+        self.paths = conductor.Paths(
+            repo_root=self.root,
+            repo_hash="test",
+            state_dir=self.state_dir,
+            socket_path=self.socket_path,
+            pid_path=self.state_dir / "conductor.pid",
+            lock_path=self.state_dir / "conductor.lock",
+            jobs_dir=self.state_dir / "jobs",
+            daemon_log_path=self.state_dir / "daemon.log",
+            daemon_meta_path=self.state_dir / "daemon.json",
+            running_processes_path=self.state_dir / "running-processes.json",
+        )
+        self.daemon: Optional[subprocess.Popen[str]] = None
+        self._start_daemon()
+
+    def _start_daemon(self) -> None:
+        self.daemon = subprocess.Popen(
+            [sys.executable, str(SCRIPT_DIR / "conductor.py"), "__daemon", "--repo-root", str(self.root)],
+            env=self.env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            stdin=subprocess.DEVNULL,
+        )
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            with contextlib.suppress(OSError, conductor.ConductorError):
+                payload = conductor.request_daemon(self.paths, {"type": "status"}, timeout=0.5)
+                if payload.get("pid"):
+                    return
+            time.sleep(0.05)
+        self.fail("daemon did not become ready")
+
+    def tearDown(self) -> None:
+        if self.daemon is not None and self.daemon.poll() is None:
+            with contextlib.suppress(OSError, conductor.ConductorError):
+                conductor.request_daemon(self.paths, {"type": "stop", "force": True}, timeout=5.0)
+            try:
+                self.daemon.wait(timeout=5.0)
+            except subprocess.TimeoutExpired:
+                self.daemon.terminate()
+                try:
+                    self.daemon.wait(timeout=2.0)
+                except subprocess.TimeoutExpired:
+                    self.daemon.kill()
+                    self.daemon.wait()
+
+    def _request(self, payload: Dict[str, Any], socket_timeout: float = 5.0) -> Dict[str, Any]:
+        return conductor.request_daemon(self.paths, payload, timeout=socket_timeout)
+
+    def _enqueue(self, args: Dict[str, Any]) -> str:
+        payload = self._request(
+            {
+                "type": "enqueue",
+                "operation": "diagnostics",
+                "args": args,
+                "timeout": 30.0,
+            },
+            socket_timeout=10.0,
+        )
+        self.assertIn("ticket", payload)
+        return str(payload["ticket"])
+
+    def _wait_for_running(self, ticket: str, timeout: float = 5.0) -> Dict[str, Any]:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            payload = self._request({"type": "job-status", "ticket": ticket}, socket_timeout=2.0)
+            if payload.get("state") == "running" and payload.get("processPID"):
+                return payload
+            time.sleep(0.05)
+        self.fail("job did not reach running state with a process PID")
+
+    def _wait_for_terminal(self, ticket: str, timeout: float = 30.0) -> Dict[str, Any]:
+        return self._request(
+            {"type": "job-wait", "ticket": ticket, "timeout": timeout},
+            socket_timeout=timeout + 5.0,
+        )
+
+    def _pid(self, payload: Dict[str, Any]) -> int:
+        return int(payload.get("processPID") or 0)
+
+    def _sample_resources(self, daemon_pid: int, child_pid: int) -> Dict[str, int]:
+        daemon_rss = 0
+        child_rss = 0
+        snapshot = conductor_diagnostics.process_resource_snapshot()
+        if daemon_pid in snapshot:
+            daemon_rss = snapshot[daemon_pid][1]
+        if child_pid in snapshot:
+            child_rss, _, _, _ = conductor_diagnostics.process_tree_resources(child_pid, snapshot)
+        return {"daemon_rss_kb": daemon_rss, "child_tree_rss_kb": child_rss}
+
+    def test_high_output_completes_and_summary_matches_raw_log(self) -> None:
+        lines = 1000
+        warnings = 10
+        start = time.monotonic()
+        ticket = self._enqueue({"subcommand": "high-output", "lines": lines, "warnings": warnings, "exitCode": 0})
+        enqueue_latency = time.monotonic() - start
+
+        start = time.monotonic()
+        payload = self._wait_for_terminal(ticket)
+        wait_latency = time.monotonic() - start
+
+        self.assertIn(payload.get("state"), {"completed", "failed"})
+        self.assertEqual(payload.get("exitCode"), 0)
+
+        log_path = Path(str(payload.get("logPath") or ""))
+        self.assertTrue(log_path.exists(), f"raw log missing: {log_path}")
+        log_text = log_path.read_text(encoding="utf-8", errors="replace")
+        log_lines = log_text.splitlines()
+        # Expected: $ python3 ... start line + start marker + lines + warnings + done marker
+        expected_lines = 1 + 2 + lines + warnings
+        self.assertEqual(len(log_lines), expected_lines)
+        self.assertIn("high-output diagnostic start", log_text)
+        self.assertIn("high-output diagnostic done", log_text)
+        self.assertIn("synthetic warning 0", log_text)
+        self.assertIn("synthetic warning 9", log_text)
+
+        summary = payload.get("outputSummary") or {}
+        self.assertEqual(summary.get("logLineCount"), expected_lines)
+        self.assertEqual(summary.get("warningCount"), warnings)
+        self.assertEqual(summary.get("errorCount"), 0)
+        self.assertIn("summaryDurationSeconds", summary)
+        self.assertIsInstance(summary.get("summaryDurationSeconds"), float)
+        self.assertGreaterEqual(summary.get("summaryDurationSeconds", 0), 0)
+
+        status_payload = self._request({"type": "job-status", "ticket": ticket}, socket_timeout=2.0)
+        self.assertIn("outputSummary", status_payload)
+
+        # Status RPC latency.
+        start = time.monotonic()
+        self._request({"type": "job-status", "ticket": ticket}, socket_timeout=2.0)
+        status_latency = time.monotonic() - start
+
+        # Verified process-tree exit.
+        process_pid = self._pid(payload)
+        self.assertGreater(process_pid, 0)
+        self.assertFalse(conductor_diagnostics.pid_alive(process_pid), "child process still alive after completion")
+        daemon_status = self._request({"type": "status"}, socket_timeout=2.0)
+        resources = self._sample_resources(int(daemon_status.get("pid") or 0), process_pid)
+
+        report: Dict[str, Any] = {
+            "enqueue_latency_seconds": round(enqueue_latency, 4),
+            "wait_latency_seconds": round(wait_latency, 4),
+            "status_latency_seconds": round(status_latency, 4),
+            "log_lines": len(log_lines),
+            "summary_warning_count": summary.get("warningCount"),
+            "summary_log_line_count": summary.get("logLineCount"),
+            "summary_duration_seconds": summary.get("summaryDurationSeconds"),
+            "daemon_rss_kb": resources["daemon_rss_kb"],
+            "child_tree_rss_kb": resources["child_tree_rss_kb"],
+        }
+        # Surface the evidence for the human runner.
+        print(f"HIGH_OUTPUT_EVIDENCE: {report}")
+
+    def test_cancel_terminates_process_tree(self) -> None:
+        ticket = self._enqueue({"subcommand": "high-output", "lines": 0, "linger": 30, "exitCode": 0})
+        running_payload = self._wait_for_running(ticket)
+        process_pid = self._pid(running_payload)
+        self.assertGreater(process_pid, 0)
+
+        start = time.monotonic()
+        cancel_payload = self._request({"type": "job-cancel", "ticket": ticket}, socket_timeout=2.0)
+        cancel_latency = time.monotonic() - start
+
+        self.assertTrue(cancel_payload.get("cancelRequested") or cancel_payload.get("state") in {"canceled", "running"})
+
+        start = time.monotonic()
+        terminal = self._wait_for_terminal(ticket)
+        wait_after_cancel_latency = time.monotonic() - start
+
+        self.assertEqual(terminal.get("state"), "canceled")
+        self.assertFalse(
+            conductor_diagnostics.pid_alive(process_pid),
+            "child process still alive after cancellation",
+        )
+        self.assertEqual(
+            conductor_diagnostics.process_tree_resources(process_pid)[0],
+            0,
+            "process tree still resident after cancellation",
+        )
+
+        report = {
+            "cancel_latency_seconds": round(cancel_latency, 4),
+            "wait_after_cancel_latency_seconds": round(wait_after_cancel_latency, 4),
+            "process_pid": process_pid,
+        }
+        print(f"CANCEL_EVIDENCE: {report}")
+
+    def test_daemon_versus_child_resources(self) -> None:
+        ticket = self._enqueue({"subcommand": "high-output", "lines": 500, "linger": 2, "exitCode": 0})
+        running_payload = self._wait_for_running(ticket)
+        process_pid = self._pid(running_payload)
+        daemon_status = self._request({"type": "status"}, socket_timeout=2.0)
+        daemon_pid = int(daemon_status.get("pid") or 0)
+        self.assertGreater(process_pid, 0)
+        self.assertGreater(daemon_pid, 0)
+
+        peak_child = 0
+        peak_daemon = 0
+        samples = 0
+        while True:
+            snapshot = conductor_diagnostics.process_resource_snapshot()
+            if daemon_pid in snapshot:
+                peak_daemon = max(peak_daemon, snapshot[daemon_pid][1])
+            if process_pid in snapshot:
+                child_total, _, _, _ = conductor_diagnostics.process_tree_resources(process_pid, snapshot)
+                peak_child = max(peak_child, child_total)
+            samples += 1
+            status = self._request({"type": "job-status", "ticket": ticket}, socket_timeout=2.0)
+            if status.get("state") in {"completed", "failed", "canceled"}:
+                break
+            time.sleep(0.1)
+
+        self._wait_for_terminal(ticket)
+
+        report = {
+            "samples": samples,
+            "peak_daemon_rss_kb": peak_daemon,
+            "peak_child_tree_rss_kb": peak_child,
+        }
+        print(f"RESOURCE_EVIDENCE: {report}")
+
+        # The child is a tiny Python process; the daemon should be larger but not
+        # by orders of magnitude.  Sanity check that the child is observable.
+        self.assertGreater(peak_child, 0)
+        self.assertGreater(peak_daemon, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Scripts/test_conductor_lifecycle.py
+++ b/Scripts/test_conductor_lifecycle.py
@@ -2898,7 +2898,10 @@ time.sleep(60)
         while time.monotonic() < deadline:
             with state.condition:
                 job = state.jobs[ticket]
-                if job.state in conductor.TERMINAL_STATES:
+                # A job becomes terminal before the runner's final persistence
+                # and lane-release work is complete. Wait for that finalizer so
+                # TemporaryDirectory cleanup cannot race its record write.
+                if job.state in conductor.TERMINAL_STATES and ticket not in state.active_lanes.values():
                     return job
             time.sleep(0.01)
         with state.condition:

--- a/Scripts/test_conductor_output.py
+++ b/Scripts/test_conductor_output.py
@@ -280,6 +280,37 @@ class OutputSummarizerTests(unittest.TestCase):
         self.assertLessEqual(rendered_chars, conductor.SUMMARY_MAX_CHARS)
         self.assertTrue(summary["truncated"] or summary["omittedLineCount"] > 0)
 
+    def test_lowercase_warning_at_start_is_counted_and_shown(self) -> None:
+        summary = summarize(
+            "swift-build",
+            "completed",
+            0,
+            [
+                "warning: cannot find user version number for module 'Dependency'\n",
+                "Sources/Foo.swift:10:5: warning: unused variable\n",
+            ],
+        )
+
+        self.assertEqual(summary["warningCount"], 2)
+        warnings = section(summary, "Warnings")
+        self.assertEqual(len(warnings), 1)
+        self.assertIn("cannot find user version number", warnings[0])
+
+    def test_summary_version_and_duration_are_included(self) -> None:
+        summary = summarize("build", "completed", 0, ["==> Build\n"])
+
+        self.assertEqual(summary["version"], conductor.SUMMARY_VERSION)
+        self.assertIn("summaryDurationSeconds", summary)
+        self.assertIsInstance(summary["summaryDurationSeconds"], float)
+        self.assertGreaterEqual(summary["summaryDurationSeconds"], 0.0)
+
+    def test_minimal_summary_version_and_duration_are_included(self) -> None:
+        summary = conductor.OutputSummarizer._minimal_summary("build", "failed", 1, "note")
+
+        self.assertEqual(summary["version"], conductor.SUMMARY_VERSION)
+        self.assertIn("summaryDurationSeconds", summary)
+        self.assertEqual(summary["summaryDurationSeconds"], 0.0)
+
     def test_ansi_and_long_lines_are_cleaned(self) -> None:
         long_error = "\x1b[31mERROR: " + ("x" * 1000) + "\x1b[0m\n"
         summary = summarize("build", "failed", 1, [long_error])


### PR DESCRIPTION
## Why

A cold focused test spent 315.49 seconds building and 2.515 seconds running tests. The same run emitted roughly 11,000 warning lines from about 451 source locations and produced a 97,209-line log.

During that run, one `conductor job wait` request timed out while the child continued and the daemon remained alive. Existing evidence did not identify output handling, daemon scheduling, summary generation, or machine pressure as the cause. Changing the output pipeline before reproducing the failure would risk hiding it.

This PR adds the measurements needed to distinguish those explanations.

Supports #519. Investigates #518.

## What changes

- Adds `conductor diagnostics focused-build` for warning ownership, output size, build/link/XCTest timing, compiler job counts, peak child RSS, and scratch state.
- Adds `conductor diagnostics high-output` for status, wait, cancellation, raw-log completeness, resources, and terminal-summary behavior.
- Records summary-generation duration.
- Correctly recognizes lowercase Swift `warning:` output.
- Adds the diagnostic scripts to conductor self-tests and contribution-preflight selection.

## Result

A synthetic run exceeding 100,000 lines did not reproduce the `job wait` timeout. This PR therefore does not guess at an output-pipeline fix. It leaves a reproducible probe for representative Swift load.

## Review order

1. `Scripts/conductor_diagnostics.py`
2. diagnostic tests
3. `Scripts/conductor.py`
4. summary parsing tests
5. Makefile and preflight wiring

## Verification

- `make conductor-selftest`
- `make guardrails`
- focused parser tests
- high-output completion and cancellation tests
- contribution commit/push preflights
