### PR TITLE
Enforce strict ledger validation for suite plans

### DIFF
--- a/Scripts/ci_app_test_runner.py
+++ b/Scripts/ci_app_test_runner.py
@@ -1145,6 +1145,10 @@ def batch_suite_entries(
     return groups
 
 
+def effective_strict_ledger(strict_ledger: bool, workers: int) -> bool:
+    return strict_ledger or workers > 1
+
+
 def run_all_suites(
     suites: Iterable[str],
     *,
@@ -1184,7 +1188,7 @@ def run_all_suites(
             flush=True,
             file=output,
         )
-        strict_ledger = True
+    strict_ledger = effective_strict_ledger(strict_ledger, workers)
     serial_plan = suite_plan or build_suite_plan(suite_list, ledger_suites={}, serial_policy={})
     if test_bundle is not None:
         print(
@@ -1447,11 +1451,25 @@ def main(argv: list[str]) -> int:
         if error.stderr:
             print(error.stderr, end="", file=sys.stderr)
         return error.returncode
+    strict_ledger = effective_strict_ledger(args.strict_ledger, args.workers)
     try:
         ledger_suites = read_ledger_suites(args.ledger)
         serial_policy = load_serial_group_policy(args.serial_group_policy)
         suite_plan = build_suite_plan(suites, ledger_suites=ledger_suites, serial_policy=serial_policy)
-    except ValueError as error:
+        if args.print_suite_plan_json and strict_ledger:
+            plan_selected_suites(
+                suites,
+                ledger=args.ledger,
+                shard_count=args.shard_count,
+                shard_index=args.shard_index,
+                strict_ledger=strict_ledger,
+                slow_first=args.slow_first,
+                batch_max_seconds=args.batch_max_seconds,
+                require_runtime_for_batching=(
+                    args.require_runtime_for_batching or args.batch_fast_suites
+                ),
+            )
+    except (OptimizerError, ValueError) as error:
         print(f"::error::{error}", flush=True)
         return 1
 

--- a/Scripts/test_ci_app_test_runner.py
+++ b/Scripts/test_ci_app_test_runner.py
@@ -265,6 +265,7 @@ class CIAppTestRunnerTests(unittest.TestCase):
                         str(ledger),
                         "--serial-group-policy",
                         str(policy),
+                        "--strict-ledger",
                         "--print-suite-plan-json",
                     ]
                 )
@@ -279,6 +280,133 @@ class CIAppTestRunnerTests(unittest.TestCase):
             [suite["suite"] for suite in payload["parallel_eligible"]],
             ["RepoPromptTests.Free"],
         )
+
+    def test_main_print_suite_plan_json_rejects_missing_suite_when_strict(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            ledger = self.write_ledger(
+                root,
+                [
+                    {
+                        "suite": "RepoPromptTests.Known",
+                        "method": "testOne",
+                        "runtime_seconds": "1.0",
+                    },
+                ],
+            )
+            policy = self.write_policy(root)
+            output = io.StringIO()
+
+            with (
+                mock.patch.object(
+                    ci_app_test_runner,
+                    "list_suites",
+                    return_value=["RepoPromptTests.Known", "RepoPromptTests.Unknown"],
+                ),
+                mock.patch("sys.stdout", output),
+            ):
+                exit_code = ci_app_test_runner.main(
+                    [
+                        "--ledger",
+                        str(ledger),
+                        "--serial-group-policy",
+                        str(policy),
+                        "--strict-ledger",
+                        "--print-suite-plan-json",
+                    ]
+                )
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(
+            output.getvalue().strip(),
+            "::error::ledger is missing discovered suites: ['RepoPromptTests.Unknown']",
+        )
+
+    def test_main_print_suite_plan_json_rejects_missing_suite_with_parallel_workers(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            ledger = self.write_ledger(
+                root,
+                [
+                    {
+                        "suite": "RepoPromptTests.Known",
+                        "method": "testOne",
+                        "runtime_seconds": "1.0",
+                    },
+                ],
+            )
+            policy = self.write_policy(root)
+            output = io.StringIO()
+
+            with (
+                mock.patch.object(
+                    ci_app_test_runner,
+                    "list_suites",
+                    return_value=["RepoPromptTests.Known", "RepoPromptTests.Unknown"],
+                ),
+                mock.patch("sys.stdout", output),
+            ):
+                exit_code = ci_app_test_runner.main(
+                    [
+                        "--ledger",
+                        str(ledger),
+                        "--serial-group-policy",
+                        str(policy),
+                        "--workers",
+                        "2",
+                        "--print-suite-plan-json",
+                    ]
+                )
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(
+            output.getvalue().strip(),
+            "::error::ledger is missing discovered suites: ['RepoPromptTests.Unknown']",
+        )
+
+    def test_main_print_suite_plan_json_preserves_non_strict_missing_suite_fallback(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            ledger = self.write_ledger(
+                root,
+                [
+                    {
+                        "suite": "RepoPromptTests.Known",
+                        "method": "testOne",
+                        "runtime_seconds": "1.0",
+                    },
+                ],
+            )
+            policy = self.write_policy(root)
+            output = io.StringIO()
+
+            with (
+                mock.patch.object(
+                    ci_app_test_runner,
+                    "list_suites",
+                    return_value=["RepoPromptTests.Known", "RepoPromptTests.Unknown"],
+                ),
+                mock.patch("sys.stdout", output),
+            ):
+                exit_code = ci_app_test_runner.main(
+                    [
+                        "--ledger",
+                        str(ledger),
+                        "--serial-group-policy",
+                        str(policy),
+                        "--print-suite-plan-json",
+                    ]
+                )
+
+        self.assertEqual(exit_code, 0)
+        payload = json.loads(output.getvalue())
+        unknown = next(
+            suite
+            for suite in payload["parallel_eligible"]
+            if suite["suite"] == "RepoPromptTests.Unknown"
+        )
+        self.assertEqual(unknown["method_count"], 0)
+        self.assertEqual(unknown["classification"], "parallel_eligible")
 
     def test_main_reports_missing_ledger_file(self) -> None:
         output = io.StringIO()


### PR DESCRIPTION
## Summary
- enforce strict discovery-versus-ledger validation before emitting JSON suite plans
- share worker-implied strictness and validation authority with the execution path
- preserve non-strict planning fallback behavior

## Tests
- focused Python CI app test runner contracts (4 tests, passing)
- mandatory commit and push contribution preflights