### PR TITLE
Add Compose: context inspector inspired by RP Classic

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ is unchanged and does not use the generated workspace.
   files, and curate context within a token budget. Long-running MCP calls expose
   [request-scoped progress](docs/mcp-progress.md) when the client supplies a
   progress token.
+- **Compose inspector**: Review selected files and codemaps, configure prompt packaging and Git context, and copy a fresh model-ready prompt without leaving Agent Mode.
 - **Agent orchestration**: Run and coordinate CLI-backed coding agents from the
   native macOS app. See [`docs/worktrees.md`](docs/worktrees.md) for app-managed
   worktrees and `.worktreeinclude` local file copying.
@@ -156,6 +157,7 @@ third-party notices in
   checks, source placement, and contribution preflight
 - [`CONTRIBUTING.md`](CONTRIBUTING.md): contribution policy and pull request
   steps
+- [`docs/architecture/compose.md`](docs/architecture/compose.md): Compose inspector architecture, invariants, and state ownership
 - [`docs/architecture/source-layout.md`](docs/architecture/source-layout.md):
   source ownership and placement rules
 - [`docs/architecture/provider-plugins.md`](docs/architecture/provider-plugins.md):

--- a/Scripts/source_layout_guardrails.sh
+++ b/Scripts/source_layout_guardrails.sh
@@ -705,6 +705,7 @@ print_matches \
 # promoted into the contributor-facing documentation set.
 allowed_tracked_docs=(
   "docs/architecture/codex-app-server-schema-gate.md"
+  "docs/architecture/compose.md"
   "docs/architecture/provider-plugins.md"
   "docs/architecture/settings-persistence.md"
   "docs/architecture/source-layout.md"

--- a/Sources/RepoPrompt/App/GlobalKeyboardShortcutsCoordinator.swift
+++ b/Sources/RepoPrompt/App/GlobalKeyboardShortcutsCoordinator.swift
@@ -213,6 +213,7 @@ final class GlobalKeyboardShortcutsCoordinator {
     private func registerAgentShortcuts() {
         register(.agentNewChat) { [weak self] in self?.startNewAgentSessionFromShortcut() }
         register(.toggleNavigationSidebar) { [weak self] in self?.toggleNavigationSidebarFromShortcut() }
+        register(.toggleComposeInspector) { [weak self] in self?.toggleComposeInspectorFromShortcut() }
         register(.previousParentAgentSession) { [weak self] in self?.focusAdjacentParentAgentSession(forward: false) }
         register(.nextParentAgentSession) { [weak self] in self?.focusAdjacentParentAgentSession(forward: true) }
         register(.showCurrentWindowAgentNavigationHUD) { [weak self] in self?.showAgentNavigationHUD(mode: .currentWindow) }
@@ -232,6 +233,21 @@ final class GlobalKeyboardShortcutsCoordinator {
             userInfo: ["windowID": win.windowID]
         )
     }
+
+    private func toggleComposeInspectorFromShortcut() {
+        guard let win = guardedFocusedWindowState() else { return }
+        toggleComposeInspector(in: win)
+    }
+
+    private func toggleComposeInspector(in win: WindowState) {
+        win.agentModeViewModel.toggleComposeInspectorIfActive()
+    }
+
+    #if DEBUG
+        func test_toggleComposeInspector(in win: WindowState) {
+            toggleComposeInspector(in: win)
+        }
+    #endif
 
     private func focusAdjacentParentAgentSession(forward: Bool) {
         guard let win = guardedFocusedWindowState() else { return }

--- a/Sources/RepoPrompt/App/Views/ContentView.swift
+++ b/Sources/RepoPrompt/App/Views/ContentView.swift
@@ -36,6 +36,7 @@ struct ContentView: View {
             ContentViewToolbarContent(
                 windowState: viewModel.state,
                 recommendationWizardViewModel: recommendationWizardViewModel,
+                isAgentModeActive: viewModel.rootRoute == .main,
                 showRecommendationsPopover: $showRecommendationsPopover,
                 showMCPServerPopover: $showMCPServerPopover
             )

--- a/Sources/RepoPrompt/App/Views/ContentViewToolbarContent.swift
+++ b/Sources/RepoPrompt/App/Views/ContentViewToolbarContent.swift
@@ -5,10 +5,24 @@ import SwiftUI
 struct ContentViewToolbarContent: ToolbarContent {
     let windowState: WindowState
     let recommendationWizardViewModel: RecommendationWizardViewModel?
+    let isAgentModeActive: Bool
     @Binding var showRecommendationsPopover: Bool
     @Binding var showMCPServerPopover: Bool
 
     var body: some ToolbarContent {
+        // Agent Mode context drawer button
+        ToolbarItem(placement: .automatic) {
+            if isAgentModeActive {
+                Button {
+                    windowState.agentModeViewModel.ui.contextDrawer.toggle()
+                } label: {
+                    Label("Compose", systemImage: "pencil")
+                        .labelStyle(.titleAndIcon)
+                }
+                .hoverTooltip("Generate prompts from selected files")
+            }
+        }
+
         if #available(macOS 26.0, *) {
             agentChatTitleItem
                 .sharedBackgroundVisibility(.hidden)

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentOracleRoutingPolicy.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentOracleRoutingPolicy.swift
@@ -70,16 +70,23 @@ struct AgentOracleLatestPopoverRoute: Equatable {
     }
 }
 
+enum AgentOraclePopoverPresentation: String, Equatable {
+    case standard
+    case generatedAnswerReadOnly = "generated_answer_read_only"
+}
+
 struct AgentOraclePopoverRoute: Equatable {
     let windowID: Int
     let workspaceID: UUID
     let tabID: UUID
     let chatID: String
+    let presentation: AgentOraclePopoverPresentation
 
     init?(
         openContext: AgentOracleOpenContext?,
         chatID: String?,
-        tabID: UUID? = nil
+        tabID: UUID? = nil,
+        presentation: AgentOraclePopoverPresentation = .standard
     ) {
         guard let openContext,
               let workspaceID = openContext.workspaceID,
@@ -90,6 +97,7 @@ struct AgentOraclePopoverRoute: Equatable {
         self.workspaceID = workspaceID
         self.tabID = tabID
         self.chatID = chatID
+        self.presentation = presentation
     }
 
     init?(notificationUserInfo userInfo: [AnyHashable: Any]?) {
@@ -97,21 +105,27 @@ struct AgentOraclePopoverRoute: Equatable {
               let windowID = userInfo[Key.windowID] as? Int,
               let workspaceID = Self.uuid(from: userInfo[Key.workspaceID]),
               let tabID = Self.uuid(from: userInfo[Key.tabID]),
-              let chatID = Self.chatID(from: userInfo[Key.chatID])
+              let chatID = Self.chatID(from: userInfo[Key.chatID]),
+              let presentation = Self.presentation(from: userInfo)
         else { return nil }
         self.windowID = windowID
         self.workspaceID = workspaceID
         self.tabID = tabID
         self.chatID = chatID
+        self.presentation = presentation
     }
 
     var notificationUserInfo: [AnyHashable: Any] {
-        [
+        var userInfo: [AnyHashable: Any] = [
             Key.windowID: windowID,
             Key.workspaceID: workspaceID,
             Key.tabID: tabID,
             Key.chatID: chatID
         ]
+        if presentation != .standard {
+            userInfo[Key.presentation] = presentation.rawValue
+        }
+        return userInfo
     }
 
     private enum Key {
@@ -119,6 +133,13 @@ struct AgentOraclePopoverRoute: Equatable {
         static let workspaceID = "workspaceID"
         static let tabID = "tabID"
         static let chatID = "chatID"
+        static let presentation = "presentation"
+    }
+
+    private static func presentation(from userInfo: [AnyHashable: Any]) -> AgentOraclePopoverPresentation? {
+        guard let value = userInfo[Key.presentation] else { return .standard }
+        guard let rawValue = value as? String else { return nil }
+        return AgentOraclePopoverPresentation(rawValue: rawValue)
     }
 
     private static func uuid(from value: Any?) -> UUID? {

--- a/Sources/RepoPrompt/Features/AgentMode/Services/AgentContextExportResolver.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Services/AgentContextExportResolver.swift
@@ -39,6 +39,7 @@ struct AgentContextSelectionSummary: Equatable {
     let totalExplicitFileCount: Int
     let fullFileCount: Int
     let slicedFileCount: Int
+    let codemapFileCount: Int
     let sliceRangeCount: Int
 
     static func filesOnly(_ count: Int) -> AgentContextSelectionSummary {
@@ -46,6 +47,7 @@ struct AgentContextSelectionSummary: Equatable {
             totalExplicitFileCount: count,
             fullFileCount: count,
             slicedFileCount: 0,
+            codemapFileCount: 0,
             sliceRangeCount: 0
         )
     }
@@ -113,6 +115,7 @@ struct AgentContextExportModel: Equatable {
     let source: AgentContextExportSource
     let lookupContext: WorkspaceLookupContext
     let rows: [AgentContextExportRow]
+    let totalSelectedDisplayTokens: Int
     let missingPaths: [String]
     let invalidPaths: [String]
     let codemapPresentation: WorkspaceCodemapOperationPresentation
@@ -131,6 +134,30 @@ struct AgentContextExportModel: Equatable {
 }
 
 struct AgentContextExportRow: Identifiable, Equatable {
+    enum Metrics: Equatable {
+        struct Known: Equatable {
+            let tokenCount: Int
+            let tokenPercentage: Double
+            let lineCount: Int?
+        }
+
+        case unknown
+        case known(Known)
+
+        static func known(tokenCount: Int, tokenPercentage: Double, lineCount: Int?) -> Metrics {
+            .known(Known(tokenCount: tokenCount, tokenPercentage: tokenPercentage, lineCount: lineCount))
+        }
+
+        var knownValues: Known? {
+            guard case let .known(values) = self else { return nil }
+            return values
+        }
+
+        var tokenSortKey: Int {
+            knownValues?.tokenCount ?? 0
+        }
+    }
+
     enum Kind: Int, Equatable {
         case codemap = 0
         case slices = 1
@@ -159,10 +186,15 @@ struct AgentContextExportRow: Identifiable, Equatable {
     let relativePath: String
     let displayPath: String
     let displayName: String
+    let physicalPath: String?
     let directoryDisplay: String?
     let lineRanges: [LineRange]?
+    let metrics: Metrics
+    let rootDisplayName: String
+    let rootColorKey: String
+    let showRootPill: Bool
     let canRemove: Bool
-    let directContentPath: String?
+    let resolvedContentLocation: ResolvedFileContentLocation?
     let removesAutomaticSourceIntent: Bool
 
     init(
@@ -172,10 +204,15 @@ struct AgentContextExportRow: Identifiable, Equatable {
         relativePath: String,
         displayPath: String,
         displayName: String,
+        physicalPath: String? = nil,
         directoryDisplay: String?,
         lineRanges: [LineRange]?,
+        metrics: Metrics = .unknown,
+        rootDisplayName: String = "",
+        rootColorKey: String = "",
+        showRootPill: Bool = false,
         canRemove: Bool,
-        directContentPath: String? = nil,
+        resolvedContentLocation: ResolvedFileContentLocation? = nil,
         removesAutomaticSourceIntent: Bool = false
     ) {
         self.id = id
@@ -184,10 +221,15 @@ struct AgentContextExportRow: Identifiable, Equatable {
         self.relativePath = relativePath
         self.displayPath = displayPath
         self.displayName = displayName
+        self.physicalPath = physicalPath
         self.directoryDisplay = directoryDisplay
         self.lineRanges = lineRanges
+        self.metrics = metrics
+        self.rootDisplayName = rootDisplayName
+        self.rootColorKey = rootColorKey
+        self.showRootPill = showRootPill
         self.canRemove = canRemove
-        self.directContentPath = directContentPath
+        self.resolvedContentLocation = resolvedContentLocation
         self.removesAutomaticSourceIntent = removesAutomaticSourceIntent
     }
 }
@@ -196,6 +238,46 @@ extension AgentContextExportRow {
     enum ContentPurpose {
         case preview
         case copy
+    }
+
+    func withMetricsAndRootMetadata(
+        metrics: Metrics,
+        rootMetadata: AgentContextExportResolver.RowRootMetadata?
+    ) -> AgentContextExportRow {
+        AgentContextExportRow(
+            id: id,
+            kind: kind,
+            rootID: rootID,
+            relativePath: relativePath,
+            displayPath: displayPath,
+            displayName: displayName,
+            physicalPath: physicalPath,
+            directoryDisplay: directoryDisplay,
+            lineRanges: lineRanges,
+            metrics: metrics,
+            rootDisplayName: rootMetadata?.displayName ?? rootDisplayName,
+            rootColorKey: rootMetadata?.colorKey ?? rootColorKey,
+            showRootPill: rootMetadata?.showPill ?? showRootPill,
+            canRemove: canRemove,
+            resolvedContentLocation: resolvedContentLocation,
+            removesAutomaticSourceIntent: removesAutomaticSourceIntent
+        )
+    }
+
+    func withMetrics(_ metrics: Metrics) -> AgentContextExportRow {
+        withMetricsAndRootMetadata(metrics: metrics, rootMetadata: nil)
+    }
+
+    var canPromoteToFullFile: Bool {
+        kind == .codemap
+    }
+
+    var canDemoteToCodemap: Bool {
+        kind != .codemap
+    }
+
+    var canClearSlices: Bool {
+        kind == .slices
     }
 }
 
@@ -235,6 +317,18 @@ struct AgentContextClipboardRequest {
 typealias AgentCodemapPresentationPlan = WorkspaceCodemapOperationPresentationPlan
 
 enum AgentContextExportResolver {
+    enum ResolutionPhase {
+        case codemapFileRecords
+        case metricsAssembly
+        case finalModelAssembly
+    }
+
+    typealias ResolutionPhaseDidBegin = @Sendable (ResolutionPhase) -> Void
+
+    private static func checkCancellation() throws(CancellationError) {
+        guard !Task.isCancelled else { throw CancellationError() }
+    }
+
     private struct RowResolutionEntry {
         let entry: ResolvedPromptFileEntry
         let canRemove: Bool
@@ -262,8 +356,16 @@ enum AgentContextExportResolver {
         let resolution: RowResolution
     }
 
+    struct RowRootMetadata {
+        let displayName: String
+        let colorKey: String
+        let showPill: Bool
+    }
+
     static func selectionSummary(for selection: StoredSelection) -> AgentContextSelectionSummary {
-        var explicitFileKeys = Set(selection.selectedPaths.map(normalizedSelectionKey))
+        let selectedFileKeys = Set(selection.selectedPaths.map(normalizedSelectionKey))
+        let manualCodemapKeys = Set(selection.manualCodemapPaths.map(normalizedSelectionKey))
+        var explicitFileKeys = selectedFileKeys.union(manualCodemapKeys)
         var slicedFileKeys = Set<String>()
         var sliceRangeCount = 0
 
@@ -274,10 +376,16 @@ enum AgentContextExportResolver {
             sliceRangeCount += ranges.count
         }
 
+        let fullFileKeys = selectedFileKeys.subtracting(slicedFileKeys)
+        let codemapFileKeys = manualCodemapKeys
+            .subtracting(selectedFileKeys)
+            .subtracting(slicedFileKeys)
+
         return AgentContextSelectionSummary(
             totalExplicitFileCount: explicitFileKeys.count,
-            fullFileCount: explicitFileKeys.count - slicedFileKeys.count,
+            fullFileCount: fullFileKeys.count,
             slicedFileCount: slicedFileKeys.count,
+            codemapFileCount: codemapFileKeys.count,
             sliceRangeCount: sliceRangeCount
         )
     }
@@ -306,6 +414,23 @@ enum AgentContextExportResolver {
         }
     }
 
+    private static func shouldEmitInterimFileRows(for selection: StoredSelection, codeMapUsage: CodeMapUsage) -> Bool {
+        guard hasExplicitFileRows(selection) else { return false }
+        switch codeMapUsage {
+        case .auto:
+            return selection.codemapAutoEnabled || !selection.manualCodemapPaths.isEmpty
+        case .complete:
+            return true
+        case .none, .selected:
+            return false
+        }
+    }
+
+    private static func hasExplicitFileRows(_ selection: StoredSelection) -> Bool {
+        if !selection.selectedPaths.isEmpty { return true }
+        return selection.slices.contains { !$0.value.isEmpty }
+    }
+
     static func lookupContext(
         source: AgentContextExportSource,
         store: WorkspaceFileContextStore
@@ -331,8 +456,14 @@ enum AgentContextExportResolver {
         store: WorkspaceFileContextStore,
         filePathDisplay: FilePathDisplay,
         codeMapUsage: CodeMapUsage,
-        presentationCoordinator: WorkspaceCodemapPresentationCoordinator? = nil
-    ) async -> AgentContextExportModel {
+        entryMetricsSnapshot: PromptContextEntryMetricsSnapshot? = nil,
+        accountingService: PromptContextAccountingService = PromptContextAccountingService(),
+        presentationCoordinator: WorkspaceCodemapPresentationCoordinator? = nil,
+        interimFileRowsHandler: ((AgentContextExportModel) async -> Void)? = nil,
+        presentationWillBeginForTesting: (@Sendable () async throws(CancellationError) -> Void)? = nil,
+        phaseDidBeginForTesting: ResolutionPhaseDidBegin? = nil
+    ) async throws -> AgentContextExportModel {
+        try checkCancellation()
         let totalStartMS = AgentSelectedFilesDiagnostics.timestampMSIfEnabled()
         var startFields = AgentSelectedFilesDiagnostics.sourceFields(source)
         startFields["filePathDisplay"] = String(describing: filePathDisplay)
@@ -348,24 +479,93 @@ enum AgentContextExportResolver {
                 source: source,
                 lookupContext: .visibleWorkspace,
                 rows: [],
+                totalSelectedDisplayTokens: 0,
                 missingPaths: [],
                 invalidPaths: [],
                 codemapPresentation: .empty
             )
         }
 
-        if let displayModel = resolveMetadataOnlyWorktreeModel(
+        if let displayModel = try await resolveMetadataOnlyWorktreeModel(
             source: source,
             filePathDisplay: filePathDisplay,
             codeMapUsage: codeMapUsage,
+            entryMetricsSnapshot: entryMetricsSnapshot,
+            accountingService: accountingService,
+            phaseDidBeginForTesting: phaseDidBeginForTesting,
             totalStartMS: totalStartMS,
             fields: startFields
         ) {
             return displayModel
         }
 
+        let lookupContext = await authoritativeLookupContext(
+            source: source,
+            store: store,
+            fallback: .visibleWorkspace
+        )
+        let physicalizeStartMS = AgentSelectedFilesDiagnostics.timestampMSIfEnabled()
+        let physicalSelection = lookupContext.physicalizeSelection(source.selection)
+        var physicalizeFields = AgentSelectedFilesDiagnostics.selectionFields(physicalSelection)
+        physicalizeFields["hasProjection"] = String(lookupContext.bindingProjection != nil)
+        AgentSelectedFilesDiagnostics.durationEvent("resolver.physicalizeSelection", startMS: physicalizeStartMS, fields: physicalizeFields)
+
+        let resolveRowsStartMS = AgentSelectedFilesDiagnostics.timestampMSIfEnabled()
+        let resolution = await resolveRows(
+            selection: physicalSelection,
+            store: store,
+            rootScope: lookupContext.rootScope,
+            profile: .uiAssisted
+        )
+        AgentSelectedFilesDiagnostics.durationEvent(
+            "resolver.resolveRows",
+            startMS: resolveRowsStartMS,
+            fields: [
+                "rowEntries": String(resolution.rows.count),
+                "missingPaths": String(resolution.missingPaths.count),
+                "invalidPaths": String(resolution.invalidPaths.count)
+            ]
+        )
+
+        let roots = await store.rootRefs(scope: lookupContext.rootScope)
+        let logicalRootDisplayNames = await lookupContext.logicalRootDisplayNamesByRootID(store: store)
+        if shouldEmitInterimFileRows(for: physicalSelection, codeMapUsage: codeMapUsage), let interimFileRowsHandler {
+            let interimModel = try await makeModel(
+                source: source,
+                lookupContext: lookupContext,
+                resolution: resolution,
+                roots: roots,
+                codemapFilesByID: [:],
+                store: store,
+                filePathDisplay: filePathDisplay,
+                codeMapUsage: .none,
+                codemapPresentation: .empty,
+                logicalRootDisplayNamesByRootID: logicalRootDisplayNames,
+                entryMetricsSnapshot: entryMetricsSnapshot ?? .empty,
+                phaseDidBeginForTesting: phaseDidBeginForTesting
+            )
+            await interimFileRowsHandler(interimModel)
+            try checkCancellation()
+        }
+        if codeMapUsage == .none {
+            return try await makeModel(
+                source: source,
+                lookupContext: lookupContext,
+                resolution: resolution,
+                roots: roots,
+                codemapFilesByID: [:],
+                store: store,
+                filePathDisplay: filePathDisplay,
+                codeMapUsage: codeMapUsage,
+                codemapPresentation: .empty,
+                logicalRootDisplayNamesByRootID: logicalRootDisplayNames,
+                entryMetricsSnapshot: entryMetricsSnapshot,
+                phaseDidBeginForTesting: phaseDidBeginForTesting
+            )
+        }
         let coordinator = presentationCoordinator ?? WorkspaceCodemapPresentationCoordinator(store: store)
         do {
+            try await presentationWillBeginForTesting?()
             return try await coordinator.withPresentation(
                 prepareAttempt: {
                     let attempt = await modelPresentationAttempt(
@@ -395,6 +595,8 @@ enum AgentContextExportResolver {
                     store: store,
                     codeMapUsage: codeMapUsage
                 )
+                try checkCancellation()
+                phaseDidBeginForTesting?(.codemapFileRecords)
                 let codemapFilesByID = await codemapFileRecordsByID(
                     for: presentation,
                     resolution: resolution,
@@ -402,18 +604,23 @@ enum AgentContextExportResolver {
                     store: store,
                     codeMapUsage: codeMapUsage
                 )
-                return makeModel(
+                return try await makeModel(
                     source: source,
                     lookupContext: attempt.authority.lookupContext,
                     resolution: resolution,
                     roots: attempt.authority.roots,
                     codemapFilesByID: codemapFilesByID,
+                    store: store,
                     filePathDisplay: filePathDisplay,
                     codeMapUsage: codeMapUsage,
                     codemapPresentation: presentation,
-                    logicalRootDisplayNamesByRootID: attempt.authority.logicalRootDisplayNamesByRootID
+                    logicalRootDisplayNamesByRootID: attempt.authority.logicalRootDisplayNamesByRootID,
+                    entryMetricsSnapshot: entryMetricsSnapshot,
+                    phaseDidBeginForTesting: phaseDidBeginForTesting
                 )
             }
+        } catch is CancellationError {
+            throw CancellationError()
         } catch {
             let issue: WorkspaceCodemapOperationIssue = if Task.isCancelled || error is CancellationError {
                 .cancelled
@@ -435,6 +642,8 @@ enum AgentContextExportResolver {
                 store: store,
                 codeMapUsage: codeMapUsage
             )
+            try checkCancellation()
+            phaseDidBeginForTesting?(.codemapFileRecords)
             let codemapFilesByID = await codemapFileRecordsByID(
                 for: presentation,
                 resolution: resolution,
@@ -442,16 +651,19 @@ enum AgentContextExportResolver {
                 store: store,
                 codeMapUsage: codeMapUsage
             )
-            return makeModel(
+            return try await makeModel(
                 source: source,
                 lookupContext: attempt.authority.lookupContext,
                 resolution: resolution,
                 roots: attempt.authority.roots,
                 codemapFilesByID: codemapFilesByID,
+                store: store,
                 filePathDisplay: filePathDisplay,
                 codeMapUsage: codeMapUsage,
                 codemapPresentation: presentation,
-                logicalRootDisplayNamesByRootID: attempt.authority.logicalRootDisplayNamesByRootID
+                logicalRootDisplayNamesByRootID: attempt.authority.logicalRootDisplayNamesByRootID,
+                entryMetricsSnapshot: entryMetricsSnapshot,
+                phaseDidBeginForTesting: phaseDidBeginForTesting
             )
         }
     }
@@ -529,9 +741,9 @@ enum AgentContextExportResolver {
             let text = entry.text
             return purpose == .preview ? AgentContextPreviewContentPolicy.boundedPreviewText(text) : text
         case .full:
-            if let directContentPath = row.directContentPath {
+            if let resolvedContentLocation = row.resolvedContentLocation {
                 return await loadDirectFileContent(
-                    path: directContentPath,
+                    location: resolvedContentLocation,
                     lineRanges: nil,
                     purpose: purpose
                 )
@@ -551,9 +763,9 @@ enum AgentContextExportResolver {
             }
             return try? await store.readContent(rootID: row.rootID, relativePath: row.relativePath)
         case .slices:
-            if let directContentPath = row.directContentPath {
+            if let resolvedContentLocation = row.resolvedContentLocation {
                 return await loadDirectFileContent(
-                    path: directContentPath,
+                    location: resolvedContentLocation,
                     lineRanges: row.lineRanges,
                     purpose: purpose
                 )
@@ -590,7 +802,7 @@ enum AgentContextExportResolver {
             )
         }
         let results = await store.lookupPaths(requests)
-        let targetDirectPath = row.directContentPath.map(StandardizedPath.absolute)
+        let targetDirectPath = row.physicalPath.map(StandardizedPath.absolute)
         let removedKeys = Set(originalKeys.filter { original in
             guard let physical = physicalKeysByOriginal[original] else { return false }
             if let targetDirectPath, StandardizedPath.absolute(physical) == targetDirectPath {
@@ -775,41 +987,37 @@ enum AgentContextExportResolver {
     }
 
     private static func loadDirectFileContent(
-        path rawPath: String,
+        location: ResolvedFileContentLocation,
         lineRanges: [LineRange]?,
         purpose: AgentContextExportRow.ContentPurpose
     ) async -> String? {
-        let path = StandardizedPath.absolute((rawPath as NSString).expandingTildeInPath)
-        return await Task.detached(priority: .userInitiated) {
-            switch purpose {
-            case .preview where lineRanges?.isEmpty != false:
-                guard let file = FileHandle(forReadingAtPath: path) else { return nil }
+        if purpose == .preview, lineRanges?.isEmpty != false {
+            return await Task.detached(priority: .userInitiated) {
+                guard let file = try? FileHandle(forReadingFrom: location.resolvedFileURL) else { return nil }
                 defer { try? file.close() }
-                let data: Data
-                do {
-                    data = try file.read(upToCount: AgentContextPreviewContentPolicy.maximumBytes + 1) ?? Data()
-                } catch {
+                guard let data = try? file.read(upToCount: AgentContextPreviewContentPolicy.maximumBytes + 1) else {
                     return nil
                 }
                 let truncated = data.count > AgentContextPreviewContentPolicy.maximumBytes
                 let boundedData = truncated ? data.prefix(AgentContextPreviewContentPolicy.maximumBytes) : data[...]
                 let text = Self.decodeText(Data(boundedData))
                 return AgentContextPreviewContentPolicy.boundedPreviewText(text, wasTruncated: truncated)
-            case .preview, .copy:
-                guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)) else {
-                    return nil
-                }
-                let content = Self.decodeText(data)
-                let renderedContent: String = if let lineRanges, !lineRanges.isEmpty {
-                    SliceAssemblyBuilder.build(from: content, ranges: lineRanges).combinedText
-                } else {
-                    content
-                }
-                return purpose == .preview
-                    ? AgentContextPreviewContentPolicy.boundedPreviewText(renderedContent)
-                    : renderedContent
-            }
-        }.value
+            }.value
+        }
+        guard let content = try? await FileSystemService.loadEntireFileContentOptimized(
+            at: location,
+            workloadClass: .interactiveRead
+        ) else {
+            return nil
+        }
+        let renderedContent: String = if let lineRanges, !lineRanges.isEmpty {
+            SliceAssemblyBuilder.build(from: content, ranges: lineRanges).combinedText
+        } else {
+            content
+        }
+        return purpose == .preview
+            ? AgentContextPreviewContentPolicy.boundedPreviewText(renderedContent)
+            : renderedContent
     }
 
     static func removeSelectionSnapshot(_ snapshot: StoredSelection, from selection: StoredSelection) -> StoredSelection {
@@ -835,9 +1043,12 @@ enum AgentContextExportResolver {
         source: AgentContextExportSource,
         filePathDisplay: FilePathDisplay,
         codeMapUsage: CodeMapUsage,
+        entryMetricsSnapshot: PromptContextEntryMetricsSnapshot?,
+        accountingService: PromptContextAccountingService,
+        phaseDidBeginForTesting: ResolutionPhaseDidBegin?,
         totalStartMS: Double?,
         fields startFields: [String: String]
-    ) -> AgentContextExportModel? {
+    ) async throws -> AgentContextExportModel? {
         let startMS = AgentSelectedFilesDiagnostics.timestampMSIfEnabled()
         guard source.hasWorktreeBindings,
               source.worktreeBindings.count >= 1,
@@ -859,9 +1070,11 @@ enum AgentContextExportResolver {
         var missingPaths: [String] = []
         var invalidPaths: [String] = []
         var seenPhysicalPaths = Set<String>()
+        try checkCancellation()
 
         let selectedPaths = source.selection.selectedPaths
         for path in selectedPaths {
+            try checkCancellation()
             let translatedPath = lookupContext.translateInputPath(path)
             var requiresStoreFallback = false
             guard let row = metadataOnlyRow(
@@ -879,13 +1092,15 @@ enum AgentContextExportResolver {
                 }
                 continue
             }
-            guard let physicalPath = row.directContentPath,
-                  seenPhysicalPaths.insert(physicalPath).inserted
+            guard let location = row.resolvedContentLocation,
+                  seenPhysicalPaths.insert(location.resolvedFileURL.path).inserted
             else { continue }
             rows.append(row)
+            try checkCancellation()
         }
 
         for (path, ranges) in source.selection.slices where !ranges.isEmpty && !selectedPaths.contains(where: { normalizedSelectionKey($0) == normalizedSelectionKey(path) }) {
+            try checkCancellation()
             let translatedPath = lookupContext.translateInputPath(path)
             var requiresStoreFallback = false
             guard let row = metadataOnlyRow(
@@ -903,13 +1118,44 @@ enum AgentContextExportResolver {
                 }
                 continue
             }
-            guard let physicalPath = row.directContentPath,
-                  seenPhysicalPaths.insert(physicalPath).inserted
+            guard let location = row.resolvedContentLocation,
+                  seenPhysicalPaths.insert(location.resolvedFileURL.path).inserted
             else { continue }
             rows.append(row)
+            try checkCancellation()
         }
 
+        let directMetricsSnapshot: PromptContextEntryMetricsSnapshot
+        if let entryMetricsSnapshot {
+            directMetricsSnapshot = entryMetricsSnapshot
+        } else {
+            let metricEntries = rows.map { row in
+                PromptContextResolvedContentMetricsEntry(
+                    fileID: row.id.fileID,
+                    rootID: row.rootID,
+                    location: row.resolvedContentLocation!,
+                    renderedDisplayPath: row.displayPath,
+                    lineRanges: row.lineRanges
+                )
+            }
+            directMetricsSnapshot = try await accountingService.calculateEntryMetricsSnapshot(
+                resolvedContentEntries: metricEntries
+            )
+        }
+        try checkCancellation()
+        let selectedPhysicalRootIDs = Set(rows.map(\.rootID))
+        let rootMetadata = rootMetadataByPhysicalRootID(
+            for: projection,
+            selectedPhysicalRootIDs: selectedPhysicalRootIDs
+        )
+        rows = rows.map { row in
+            row.withMetricsAndRootMetadata(
+                metrics: metrics(from: directMetricsSnapshot.metric(forFileID: row.id.fileID)),
+                rootMetadata: rootMetadata[row.rootID]
+            )
+        }
         rows.sort(by: rowSort)
+        try checkCancellation()
         AgentSelectedFilesDiagnostics.durationEvent(
             "resolver.metadataOnlyWorktreeModel",
             startMS: startMS,
@@ -931,10 +1177,14 @@ enum AgentContextExportResolver {
             startMS: totalStartMS,
             fields: completeFields
         )
+        try checkCancellation()
+        phaseDidBeginForTesting?(.finalModelAssembly)
+        try checkCancellation()
         return AgentContextExportModel(
             source: source,
             lookupContext: lookupContext,
             rows: rows,
+            totalSelectedDisplayTokens: directMetricsSnapshot.totalSelectedDisplayTokens,
             missingPaths: Array(Set(missingPaths)).sorted(),
             invalidPaths: Array(Set(invalidPaths)).sorted(),
             codemapPresentation: .empty
@@ -973,11 +1223,14 @@ enum AgentContextExportResolver {
         resolution: RowResolution,
         roots: [WorkspaceRootRef],
         codemapFilesByID: [UUID: WorkspaceFileRecord],
+        store: WorkspaceFileContextStore,
         filePathDisplay: FilePathDisplay,
         codeMapUsage: CodeMapUsage,
         codemapPresentation: WorkspaceCodemapOperationPresentation,
-        logicalRootDisplayNamesByRootID: [UUID: String]
-    ) -> AgentContextExportModel {
+        logicalRootDisplayNamesByRootID: [UUID: String],
+        entryMetricsSnapshot: PromptContextEntryMetricsSnapshot?,
+        phaseDidBeginForTesting: ResolutionPhaseDidBegin?
+    ) async throws(CancellationError) -> AgentContextExportModel {
         var rowEntries = resolution.rows
         if codeMapUsage == .selected {
             rowEntries = rowEntries.map { rowEntry in
@@ -1020,6 +1273,34 @@ enum AgentContextExportResolver {
                 )
             }
         }
+        try checkCancellation()
+        phaseDidBeginForTesting?(.metricsAssembly)
+        let metricsSnapshot: PromptContextEntryMetricsSnapshot = if let entryMetricsSnapshot {
+            entryMetricsSnapshot
+        } else {
+            await PromptContextAccountingService().calculateEntryMetricsSnapshot(
+                entries: rowEntries.map(\.entry),
+                store: store,
+                codemapPresentation: codemapPresentation,
+                filePathDisplay: filePathDisplay,
+                displayPathResolver: { entry in
+                    displayPath(
+                        for: entry,
+                        roots: roots,
+                        lookupContext: lookupContext,
+                        logicalRootDisplayNamesByRootID: logicalRootDisplayNamesByRootID,
+                        filePathDisplay: filePathDisplay
+                    )
+                }
+            )
+        }
+        let selectedPhysicalRootIDs = Set(rowEntries.map(\.entry.file.rootID))
+        let rootMetadata = rootMetadataByPhysicalRootID(
+            roots: roots,
+            lookupContext: lookupContext,
+            logicalRootDisplayNamesByRootID: logicalRootDisplayNamesByRootID,
+            selectedPhysicalRootIDs: selectedPhysicalRootIDs
+        )
         let rows = rowEntries.map { rowEntry in
             row(
                 from: rowEntry.entry,
@@ -1028,14 +1309,18 @@ enum AgentContextExportResolver {
                 logicalRootDisplayNamesByRootID: logicalRootDisplayNamesByRootID,
                 filePathDisplay: filePathDisplay,
                 canRemove: rowEntry.canRemove,
-                removesAutomaticSourceIntent: rowEntry.removesAutomaticSourceIntent
+                removesAutomaticSourceIntent: rowEntry.removesAutomaticSourceIntent,
+                metricsSnapshot: metricsSnapshot,
+                rootMetadata: rootMetadata[rowEntry.entry.file.rootID]
             )
-        }
-        .sorted(by: rowSort)
+        }.sorted(by: rowSort)
+        try checkCancellation()
+        phaseDidBeginForTesting?(.finalModelAssembly)
         return AgentContextExportModel(
             source: source,
             lookupContext: lookupContext,
             rows: rows,
+            totalSelectedDisplayTokens: metricsSnapshot.totalSelectedDisplayTokens,
             missingPaths: logicalizedIssuePaths(
                 resolution.missingPaths,
                 roots: roots,
@@ -1092,6 +1377,65 @@ enum AgentContextExportResolver {
         return filesByID
     }
 
+    private static func rootMetadataByPhysicalRootID(
+        for projection: WorkspaceRootBindingProjection,
+        selectedPhysicalRootIDs: Set<UUID>
+    ) -> [UUID: RowRootMetadata] {
+        let boundRoots = projection.boundRootsForMetadata
+        let logicalRootPathsByPhysicalRootID = Dictionary(uniqueKeysWithValues: boundRoots.map { boundRoot in
+            (boundRoot.physicalRoot.id, boundRoot.logicalRoot.standardizedFullPath)
+        })
+        let selectedLogicalRootPaths = Set(selectedPhysicalRootIDs.compactMap { logicalRootPathsByPhysicalRootID[$0] })
+        let showRootPill = selectedLogicalRootPaths.count > 1
+        return Dictionary(uniqueKeysWithValues: boundRoots.map { boundRoot in
+            (
+                boundRoot.physicalRoot.id,
+                RowRootMetadata(
+                    displayName: boundRoot.logicalRoot.name,
+                    colorKey: boundRoot.logicalRoot.standardizedFullPath,
+                    showPill: showRootPill
+                )
+            )
+        })
+    }
+
+    private static func rootMetadataByPhysicalRootID(
+        roots: [WorkspaceRootRef],
+        lookupContext: WorkspaceLookupContext,
+        logicalRootDisplayNamesByRootID: [UUID: String],
+        selectedPhysicalRootIDs: Set<UUID>
+    ) -> [UUID: RowRootMetadata] {
+        let boundRootsByPhysicalRootID = Dictionary(
+            (lookupContext.bindingProjection?.boundRootsForMetadata ?? []).map { ($0.physicalRoot.id, $0) },
+            uniquingKeysWith: { current, _ in current }
+        )
+        let logicalRootPathsByPhysicalRootID = Dictionary(uniqueKeysWithValues: roots.map { root in
+            (root.id, boundRootsByPhysicalRootID[root.id]?.logicalRoot.standardizedFullPath ?? root.standardizedFullPath)
+        })
+        let selectedLogicalRootPaths = Set(selectedPhysicalRootIDs.compactMap { logicalRootPathsByPhysicalRootID[$0] })
+        let showRootPill = selectedLogicalRootPaths.count > 1
+        return Dictionary(uniqueKeysWithValues: roots.map { root in
+            let boundRoot = boundRootsByPhysicalRootID[root.id]
+            return (
+                root.id,
+                RowRootMetadata(
+                    displayName: logicalRootDisplayNamesByRootID[root.id] ?? boundRoot?.logicalRoot.name ?? root.name,
+                    colorKey: logicalRootPathsByPhysicalRootID[root.id] ?? root.standardizedFullPath,
+                    showPill: showRootPill
+                )
+            )
+        })
+    }
+
+    private static func metrics(from metric: PromptContextEntryMetric?) -> AgentContextExportRow.Metrics {
+        guard let metric else { return .unknown }
+        return .known(
+            tokenCount: metric.displayTokenCount,
+            tokenPercentage: metric.displayPercentage,
+            lineCount: metric.includedLineCount
+        )
+    }
+
     static func unavailablePresentation(
         _ issue: WorkspaceCodemapOperationIssue
     ) -> WorkspaceCodemapOperationPresentation {
@@ -1131,7 +1475,6 @@ enum AgentContextExportResolver {
             ),
             codemapPresentation: codemapPresentation
         )
-
         return await PromptPackagingService.generateClipboardContent(
             metaInstructions: request.metaInstructions,
             userInstructions: cfg.includeUserPrompt ? request.source.promptText : "",
@@ -1227,7 +1570,10 @@ enum AgentContextExportResolver {
             return nil
         }
         guard !isDirectory.boolValue else { return nil }
-        guard safeDirectContentPath(physicalPath, boundRoot: boundRoot) != nil else {
+        guard let resolvedContentLocation = safeDirectContentLocation(
+            physicalPath,
+            boundRoot: boundRoot
+        ) else {
             requiresStoreFallback = true
             return nil
         }
@@ -1253,24 +1599,38 @@ enum AgentContextExportResolver {
             relativePath: relativePath,
             displayPath: displayPath,
             displayName: displayName.isEmpty ? URL(fileURLWithPath: physicalPath).lastPathComponent : displayName,
+            physicalPath: physicalPath,
             directoryDisplay: directoryDisplay(for: displayPath, fallbackRootName: boundRoot.logicalRoot.name),
             lineRanges: lineRanges,
             canRemove: true,
-            directContentPath: physicalPath
+            resolvedContentLocation: resolvedContentLocation
         )
     }
 
-    private static func safeDirectContentPath(
+    private static func safeDirectContentLocation(
         _ physicalPath: String,
         boundRoot: WorkspaceRootBindingProjection.BoundRoot
-    ) -> String? {
-        let rootPath = boundRoot.physicalRoot.standardizedFullPath
-        let resolvedRoot = StandardizedPath.absolute((rootPath as NSString).resolvingSymlinksInPath)
-        let resolvedPath = StandardizedPath.absolute((physicalPath as NSString).resolvingSymlinksInPath)
-        guard resolvedPath == resolvedRoot || resolvedPath.hasPrefix("\(resolvedRoot)/") else {
+    ) -> ResolvedFileContentLocation? {
+        let resolvedRootURL = URL(
+            fileURLWithPath: boundRoot.physicalRoot.standardizedFullPath,
+            isDirectory: true
+        ).resolvingSymlinksInPath().standardizedFileURL
+        let resolvedFileURL = URL(fileURLWithPath: physicalPath)
+            .resolvingSymlinksInPath()
+            .standardizedFileURL
+        let resolvedRootPath = StandardizedPath.absolute(resolvedRootURL.path)
+        let resolvedFilePath = StandardizedPath.absolute(resolvedFileURL.path)
+        guard StandardizedPath.isDescendant(resolvedFilePath, of: resolvedRootPath) else {
             return nil
         }
-        return physicalPath
+        let relativePath = StandardizedPath.relative(
+            String(resolvedFilePath.dropFirst(resolvedRootPath.count + 1))
+        )
+        return ResolvedFileContentLocation(
+            resolvedRootURL: resolvedRootURL,
+            resolvedFileURL: resolvedFileURL,
+            relativePath: relativePath
+        )
     }
 
     private static func metadataOnlyPathRequiresStoreFallback(
@@ -1485,7 +1845,9 @@ enum AgentContextExportResolver {
         logicalRootDisplayNamesByRootID: [UUID: String],
         filePathDisplay: FilePathDisplay,
         canRemove: Bool,
-        removesAutomaticSourceIntent: Bool
+        removesAutomaticSourceIntent: Bool,
+        metricsSnapshot: PromptContextEntryMetricsSnapshot,
+        rootMetadata: RowRootMetadata?
     ) -> AgentContextExportRow {
         let displayPath = displayPath(
             for: entry,
@@ -1511,8 +1873,16 @@ enum AgentContextExportResolver {
             relativePath: entry.file.standardizedRelativePath,
             displayPath: displayPath,
             displayName: displayName.isEmpty ? entry.file.name : displayName,
+            physicalPath: entry.file.standardizedFullPath,
             directoryDisplay: directory,
             lineRanges: entry.lineRanges,
+            metrics: metrics(
+                from: metricsSnapshot.metric(forFileID: entry.file.id)
+                    ?? metricsSnapshot.metric(forStandardizedFullPath: entry.file.standardizedFullPath)
+            ),
+            rootDisplayName: rootMetadata?.displayName ?? fallbackRootName ?? "",
+            rootColorKey: rootMetadata?.colorKey ?? entry.rootFolderPath ?? entry.file.standardizedFullPath,
+            showRootPill: rootMetadata?.showPill ?? false,
             canRemove: canRemove,
             removesAutomaticSourceIntent: removesAutomaticSourceIntent
         )
@@ -1567,7 +1937,10 @@ enum AgentContextExportResolver {
         })).sorted()
     }
 
-    private static func rowSort(_ lhs: AgentContextExportRow, _ rhs: AgentContextExportRow) -> Bool {
+    static func rowSort(_ lhs: AgentContextExportRow, _ rhs: AgentContextExportRow) -> Bool {
+        if lhs.metrics.tokenSortKey != rhs.metrics.tokenSortKey {
+            return lhs.metrics.tokenSortKey > rhs.metrics.tokenSortKey
+        }
         if lhs.kind != rhs.kind { return lhs.kind.rawValue < rhs.kind.rawValue }
         if lhs.displayName != rhs.displayName {
             return lhs.displayName.utf8.lexicographicallyPrecedes(rhs.displayName.utf8)

--- a/Sources/RepoPrompt/Features/AgentMode/Services/AgentWorkspaceLookupContextResolver.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Services/AgentWorkspaceLookupContextResolver.swift
@@ -150,8 +150,17 @@ enum AgentWorkspaceLookupContextResolver {
         let logicalRootPaths = Set(bindings.compactMap {
             AgentWorktreeRuntimeWorkspaceResolver.standardizedWorkspacePath($0.logicalRootPath)
         })
+        let bindingsMapDistinctLogicalRootsToWorktrees = bindings.allSatisfy { binding in
+            guard let logicalRootPath = AgentWorktreeRuntimeWorkspaceResolver.standardizedWorkspacePath(
+                binding.logicalRootPath
+            ), let worktreeRootPath = AgentWorktreeRuntimeWorkspaceResolver.standardizedWorkspacePath(
+                binding.worktreeRootPath
+            ) else { return false }
+            return logicalRootPath != worktreeRootPath
+        }
         guard logicalRootPaths.count == bindings.count,
-              logicalRootPaths.isSubset(of: visibleRootPaths)
+              logicalRootPaths.isSubset(of: visibleRootPaths),
+              bindingsMapDistinctLogicalRootsToWorktrees
         else {
             throw AgentWorkspaceLookupContextResolutionError.unavailableProjection
         }

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -2743,6 +2743,11 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         refreshSessionListCache(for: workspace, owner: owner)
     }
 
+    func toggleComposeInspectorIfActive() {
+        guard isAgentModeActive else { return }
+        ui.contextDrawer.toggle()
+    }
+
     /// Toggle whether agent mode UI is active (used to defer heavy session loads).
     func setAgentModeActive(_ isActive: Bool) {
         #if DEBUG

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentContextDrawerUIStore.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentContextDrawerUIStore.swift
@@ -1,0 +1,164 @@
+import Combine
+
+@MainActor
+final class AgentContextDrawerPresentationStore: ObservableObject {
+    @Published private(set) var isPresented = false
+
+    func present() {
+        isPresented = true
+    }
+
+    func close() {
+        isPresented = false
+    }
+}
+
+@MainActor
+final class AgentContextDrawerDetailStore: ObservableObject {
+    @Published var activeTab: AgentContextDrawerUIStore.Tab = .files
+    @Published var filesSubtab: AgentContextDrawerUIStore.FilesSubtab = .files
+    @Published var fileFilterText = ""
+    @Published var selectionSort: AgentContextDrawerUIStore.SelectionSort = .tokensDescending
+}
+
+@MainActor
+final class AgentContextDrawerUIStore {
+    enum Tab: String, CaseIterable, Equatable {
+        case files
+        case builder
+        case prompt
+    }
+
+    enum FilesSubtab: String, CaseIterable, Equatable {
+        case files
+        case codemaps
+    }
+
+    enum SelectionSort: String, CaseIterable, Identifiable, Equatable {
+        case nameAscending
+        case nameDescending
+        case tokensDescending
+        case tokensAscending
+
+        var id: Self {
+            self
+        }
+
+        var label: String {
+            switch self {
+            case .nameAscending: "Name A→Z"
+            case .nameDescending: "Name Z→A"
+            case .tokensDescending: "Tokens ↓"
+            case .tokensAscending: "Tokens ↑"
+            }
+        }
+
+        func sortedRows(_ rows: [AgentContextExportRow]) -> [AgentContextExportRow] {
+            rows.sorted(by: areInIncreasingOrder)
+        }
+
+        func areInIncreasingOrder(_ lhs: AgentContextExportRow, _ rhs: AgentContextExportRow) -> Bool {
+            switch self {
+            case .nameAscending:
+                if let ordering = Self.stringOrdering(lhs.displayName, rhs.displayName, ascending: true) {
+                    return ordering
+                }
+                if let ordering = Self.stringOrdering(lhs.displayPath, rhs.displayPath, ascending: true) {
+                    return ordering
+                }
+                return Self.tieBreakAfterNameAndPath(lhs, rhs)
+            case .nameDescending:
+                if let ordering = Self.stringOrdering(lhs.displayName, rhs.displayName, ascending: false) {
+                    return ordering
+                }
+                if let ordering = Self.stringOrdering(lhs.displayPath, rhs.displayPath, ascending: false) {
+                    return ordering
+                }
+                return Self.tieBreakAfterNameAndPath(lhs, rhs)
+            case .tokensDescending:
+                if lhs.metrics.tokenSortKey != rhs.metrics.tokenSortKey {
+                    return lhs.metrics.tokenSortKey > rhs.metrics.tokenSortKey
+                }
+                return Self.tieBreakAfterTokens(lhs, rhs)
+            case .tokensAscending:
+                if lhs.metrics.tokenSortKey != rhs.metrics.tokenSortKey {
+                    return lhs.metrics.tokenSortKey < rhs.metrics.tokenSortKey
+                }
+                return Self.tieBreakAfterTokens(lhs, rhs)
+            }
+        }
+
+        private static func stringOrdering(_ lhs: String, _ rhs: String, ascending: Bool) -> Bool? {
+            guard lhs != rhs else { return nil }
+            return ascending
+                ? lhs.utf8.lexicographicallyPrecedes(rhs.utf8)
+                : rhs.utf8.lexicographicallyPrecedes(lhs.utf8)
+        }
+
+        private static func tieBreakAfterTokens(_ lhs: AgentContextExportRow, _ rhs: AgentContextExportRow) -> Bool {
+            if lhs.kind != rhs.kind { return lhs.kind.rawValue < rhs.kind.rawValue }
+            if let ordering = stringOrdering(lhs.displayName, rhs.displayName, ascending: true) { return ordering }
+            if let ordering = stringOrdering(lhs.displayPath, rhs.displayPath, ascending: true) { return ordering }
+            return tieBreakAfterNameAndPath(lhs, rhs)
+        }
+
+        private static func tieBreakAfterNameAndPath(_ lhs: AgentContextExportRow, _ rhs: AgentContextExportRow) -> Bool {
+            if lhs.metrics.tokenSortKey != rhs.metrics.tokenSortKey {
+                return lhs.metrics.tokenSortKey > rhs.metrics.tokenSortKey
+            }
+            if lhs.kind != rhs.kind { return lhs.kind.rawValue < rhs.kind.rawValue }
+            if lhs.rootID != rhs.rootID { return lhs.rootID.uuidString < rhs.rootID.uuidString }
+            return lhs.id.fileID.uuidString < rhs.id.fileID.uuidString
+        }
+    }
+
+    let presentation = AgentContextDrawerPresentationStore()
+    let detail = AgentContextDrawerDetailStore()
+
+    var isPresented: Bool {
+        presentation.isPresented
+    }
+
+    var activeTab: Tab {
+        get { detail.activeTab }
+        set { detail.activeTab = newValue }
+    }
+
+    var filesSubtab: FilesSubtab {
+        get { detail.filesSubtab }
+        set { detail.filesSubtab = newValue }
+    }
+
+    var fileFilterText: String {
+        get { detail.fileFilterText }
+        set { detail.fileFilterText = newValue }
+    }
+
+    var selectionSort: SelectionSort {
+        get { detail.selectionSort }
+        set { detail.selectionSort = newValue }
+    }
+
+    func open(tab: Tab? = nil) {
+        if let tab, detail.activeTab != tab {
+            detail.activeTab = tab
+        }
+        presentation.present()
+    }
+
+    func close() {
+        presentation.close()
+    }
+
+    func toggle(tab: Tab? = nil) {
+        if presentation.isPresented {
+            if let tab, detail.activeTab != tab {
+                detail.activeTab = tab
+            } else {
+                close()
+            }
+        } else {
+            open(tab: tab)
+        }
+    }
+}

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentModeUIFacades.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentModeUIFacades.swift
@@ -5,6 +5,7 @@ final class AgentModeUIFacades {
     let composer = AgentComposerUIStore()
     let statusPills = AgentStatusPillsUIStore()
     let runtimeMetrics = AgentRuntimeMetricsUIStore()
+    let contextDrawer = AgentContextDrawerUIStore()
     let sessionSidebar = AgentSessionSidebarUIStore()
     let transcript = AgentTranscriptUIStore()
     let runInteraction = AgentRunInteractionUIStore()

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentSelectedFilesModelCoordinator.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentSelectedFilesModelCoordinator.swift
@@ -12,12 +12,110 @@ struct AgentSelectedFilesModelRequest {
     let store: WorkspaceFileContextStore
     let filePathDisplay: FilePathDisplay
     let codeMapUsage: CodeMapUsage
+    let entryMetricsSnapshot: PromptContextEntryMetricsSnapshot?
+}
+
+enum AgentSelectedFilesRequestMetricsSnapshotResolver {
+    @MainActor
+    static func activeTokenMetricsSnapshot(
+        source: AgentContextExportSource,
+        promptManager: PromptViewModel,
+        codeMapUsage: CodeMapUsage,
+        filePathDisplay: FilePathDisplay
+    ) -> PromptContextEntryMetricsSnapshot? {
+        let published = promptManager.tokenCountingViewModel.latestPublishedTokenSnapshot(
+            for: source.selection,
+            scheduleRefreshIfNeeded: false
+        )
+        return activeTokenMetricsSnapshot(
+            source: source,
+            activeComposeTabID: promptManager.activeComposeTabID,
+            codeMapUsage: codeMapUsage,
+            filePathDisplay: filePathDisplay,
+            published: published
+        )
+    }
+
+    @MainActor
+    static func activeTokenMetricsSnapshot(
+        source: AgentContextExportSource,
+        activeComposeTabID: UUID?,
+        codeMapUsage: CodeMapUsage,
+        filePathDisplay: FilePathDisplay,
+        published: TokenCountingViewModel.PublishedTokenSnapshot
+    ) -> PromptContextEntryMetricsSnapshot? {
+        guard !source.hasWorktreeBindings,
+              source.activeAgentSessionID == nil,
+              source.tabID == activeComposeTabID,
+              published.isComplete,
+              !published.isStale,
+              !published.refreshPending,
+              published.codeMapUsage == codeMapUsage,
+              published.filePathDisplay == filePathDisplay
+        else { return nil }
+        return published.entryMetricsSnapshot
+    }
+}
+
+struct AgentContextSelectionDisplayText: Equatable {
+    let compact: String
+    let detailed: String
+}
+
+enum AgentContextCountReadiness: Equatable {
+    case known(Int)
+    case unknown
+}
+
+struct AgentContextFileCodemapCountReadiness: Equatable {
+    let file: AgentContextCountReadiness
+    let codemap: AgentContextCountReadiness
+}
+
+struct AgentContextFileCodemapCountSummary: Equatable {
+    let fileCount: Int
+    let codemapCount: Int
+    let sliceRangeCount: Int
+
+    static func intent(from summary: AgentContextSelectionSummary) -> AgentContextFileCodemapCountSummary {
+        AgentContextFileCodemapCountSummary(
+            fileCount: summary.fullFileCount + summary.slicedFileCount,
+            codemapCount: summary.codemapFileCount,
+            sliceRangeCount: summary.sliceRangeCount
+        )
+    }
+
+    static func selectionDisplayText(from summary: AgentContextSelectionSummary) -> AgentContextSelectionDisplayText {
+        guard summary.codemapFileCount > 0 else {
+            return AgentContextSelectionDisplayText(compact: summary.compactText, detailed: summary.headlineText)
+        }
+        let fileCodemapSummary = intent(from: summary)
+        return AgentContextSelectionDisplayText(
+            compact: fileCodemapSummary.headlineText,
+            detailed: fileCodemapSummary.headlineText
+        )
+    }
+
+    var headlineText: String {
+        var parts: [String] = []
+        if fileCount > 0 || codemapCount == 0 {
+            parts.append("\(fileCount) file\(fileCount == 1 ? "" : "s")")
+        }
+        if codemapCount > 0 {
+            parts.append("\(codemapCount) codemap\(codemapCount == 1 ? "" : "s")")
+        }
+        if sliceRangeCount > 0 {
+            parts.append("\(sliceRangeCount) slice\(sliceRangeCount == 1 ? "" : "s")")
+        }
+        return parts.joined(separator: " · ")
+    }
 }
 
 struct AgentSelectedFilesRowSplit: Equatable {
     let rows: [AgentContextExportRow]
     let fileRows: [AgentContextExportRow]
     let codemapRows: [AgentContextExportRow]
+    let fileCodemapCountSummary: AgentContextFileCodemapCountSummary
 
     static let empty = AgentSelectedFilesRowSplit(rows: [])
 
@@ -25,6 +123,7 @@ struct AgentSelectedFilesRowSplit: Equatable {
         self.rows = rows
         var fileRows: [AgentContextExportRow] = []
         var codemapRows: [AgentContextExportRow] = []
+        var sliceRangeCount = 0
         fileRows.reserveCapacity(rows.count)
         codemapRows.reserveCapacity(rows.count)
         for row in rows {
@@ -32,10 +131,16 @@ struct AgentSelectedFilesRowSplit: Equatable {
                 codemapRows.append(row)
             } else {
                 fileRows.append(row)
+                sliceRangeCount += row.lineRanges?.count ?? 0
             }
         }
         self.fileRows = fileRows
         self.codemapRows = codemapRows
+        fileCodemapCountSummary = AgentContextFileCodemapCountSummary(
+            fileCount: fileRows.count,
+            codemapCount: codemapRows.count,
+            sliceRangeCount: sliceRangeCount
+        )
     }
 }
 
@@ -71,7 +176,11 @@ struct AgentSelectedFilesModelState: Equatable {
 
 @MainActor
 final class AgentSelectedFilesModelCoordinator: ObservableObject {
-    typealias ResolveModel = (AgentSelectedFilesModelRequest) async -> AgentContextExportModel
+    typealias ResolveInterimFileRows = (AgentContextExportModel) async -> Void
+    typealias ResolveModel = (
+        AgentSelectedFilesModelRequest,
+        ResolveInterimFileRows?
+    ) async throws -> AgentContextExportModel
 
     @Published private var state: AgentSelectedFilesModelState = .empty
     private(set) var debugStats = AgentSelectedFilesModelDebugStats()
@@ -92,17 +201,118 @@ final class AgentSelectedFilesModelCoordinator: ObservableObject {
         state.canMutateDisplayedModel
     }
 
+    func displayedModelMatches(_ identity: AgentSelectedFilesModelIdentity) -> Bool {
+        displayedIdentity == identity && model != nil
+    }
+
+    func completedModelMatches(_ identity: AgentSelectedFilesModelIdentity) -> Bool {
+        completedDisplayedModelMatches(identity)
+    }
+
+    func loadedFileCodemapCountSummary(
+        for identity: AgentSelectedFilesModelIdentity
+    ) -> AgentContextFileCodemapCountSummary? {
+        guard completedModelMatches(identity) else { return nil }
+        return rowSplit.fileCodemapCountSummary
+    }
+
+    func displayedFileCodemapCountReadiness(
+        for identity: AgentSelectedFilesModelIdentity
+    ) -> AgentContextFileCodemapCountReadiness? {
+        guard displayedModelMatches(identity) else { return nil }
+        let codemapReadiness: AgentContextCountReadiness = if loadedIdentity == identity,
+                                                              let completedSnapshot = completedCountSnapshots[identity]
+        {
+            .known(completedSnapshot.codemapCount)
+        } else if Self.codemapCountIsStableBeforeCompletion(identity) {
+            .known(rowSplit.codemapRows.count)
+        } else {
+            .unknown
+        }
+        return AgentContextFileCodemapCountReadiness(
+            file: .known(rowSplit.fileRows.count),
+            codemap: codemapReadiness
+        )
+    }
+
+    static func unresolvedFileCodemapCountReadiness(
+        for identity: AgentSelectedFilesModelIdentity,
+        summary: AgentContextFileCodemapCountSummary
+    ) -> AgentContextFileCodemapCountReadiness {
+        let fileReadiness: AgentContextCountReadiness = switch identity.codeMapUsage {
+        case .selected:
+            .unknown
+        case .auto, .complete, .none:
+            .known(summary.fileCount)
+        }
+        let codemapReadiness: AgentContextCountReadiness = if codemapCountIsStableBeforeCompletion(identity) {
+            .known(0)
+        } else {
+            .unknown
+        }
+        return AgentContextFileCodemapCountReadiness(file: fileReadiness, codemap: codemapReadiness)
+    }
+
     private let resolver: ResolveModel
     private var loadedIdentity: AgentSelectedFilesModelIdentity?
     private var loadingIdentity: AgentSelectedFilesModelIdentity?
+    private var displayedIdentity: AgentSelectedFilesModelIdentity?
     private var refreshID: UUID?
+
+    private func completedDisplayedModelMatches(_ identity: AgentSelectedFilesModelIdentity) -> Bool {
+        loadedIdentity == identity &&
+            displayedIdentity == identity &&
+            model != nil &&
+            loadingIdentity == nil
+    }
+
+    private var displayedModelIsMutable: Bool {
+        guard let displayedIdentity else { return false }
+        return completedDisplayedModelMatches(displayedIdentity)
+    }
+
     private var refreshTask: Task<Void, Never>?
     private let cachedModelLimit = 5
     private var cachedModels: [AgentSelectedFilesModelIdentity: AgentContextExportModel] = [:]
     private var cachedModelOrder: [AgentSelectedFilesModelIdentity] = []
+    private var completedCountSnapshots: [AgentSelectedFilesModelIdentity: AgentContextFileCodemapCountSummary] = [:]
+
+    private struct VisibleFileMetricsScope: Equatable {
+        let filePathDisplay: FilePathDisplay
+        let codeMapUsage: CodeMapUsage
+        let selectedPaths: [String]
+        let manualCodemapPaths: [String]
+        let slices: [String: [LineRange]]
+        let codemapAutoEnabled: Bool
+        let worktreeBindingFingerprint: String
+    }
+
+    private struct VisibleFileMetricsKey: Hashable {
+        let rootID: UUID
+        let rowID: ResolvedPromptFileEntryID
+        let kind: AgentContextExportRow.Kind
+    }
+
+    private struct VisibleFileMetricsSnapshot {
+        let scope: VisibleFileMetricsScope
+        let keys: Set<VisibleFileMetricsKey>
+        let metricsByKey: [VisibleFileMetricsKey: AgentContextExportRow.Metrics]
+        let totalSelectedDisplayTokens: Int
+    }
+
+    private var visibleFileMetricsSnapshot: VisibleFileMetricsSnapshot?
 
     init(resolver: @escaping ResolveModel = AgentSelectedFilesModelCoordinator.resolveModel) {
         self.resolver = resolver
+    }
+
+    init(
+        resolver: @escaping (AgentSelectedFilesModelRequest) async throws -> AgentContextExportModel
+    ) {
+        self.resolver = {
+            (request: AgentSelectedFilesModelRequest, _: ResolveInterimFileRows?) async throws in
+            try await resolver(request)
+        }
     }
 
     deinit {
@@ -115,23 +325,58 @@ final class AgentSelectedFilesModelCoordinator: ObservableObject {
         force: Bool = false,
         preserveDisplayedModel: Bool = false
     ) -> AgentSelectedFilesRefreshOutcome {
+        refresh(
+            request,
+            force: force,
+            preserveDisplayedModel: preserveDisplayedModel,
+            publishesInterimFileRows: true
+        )
+    }
+
+    @discardableResult
+    func refreshAfterTokenMetricsCompletion(
+        _ request: AgentSelectedFilesModelRequest
+    ) -> AgentSelectedFilesRefreshOutcome? {
+        guard request.entryMetricsSnapshot != nil else { return nil }
+        guard displayedModelMatches(request.identity) || loadingIdentity == request.identity else { return nil }
+        return refresh(
+            request,
+            force: true,
+            preserveDisplayedModel: true,
+            publishesInterimFileRows: false
+        )
+    }
+
+    private func refresh(
+        _ request: AgentSelectedFilesModelRequest,
+        force: Bool,
+        preserveDisplayedModel: Bool,
+        publishesInterimFileRows: Bool
+    ) -> AgentSelectedFilesRefreshOutcome {
         debugStats.refreshRequests += 1
         var refreshFields = AgentSelectedFilesDiagnostics.requestFields(request)
         refreshFields["force"] = String(force)
         refreshFields["preserveDisplayedModel"] = String(preserveDisplayedModel)
+        refreshFields["publishesInterimFileRows"] = String(publishesInterimFileRows)
         refreshFields["hasModel"] = String(model != nil)
         refreshFields["loadedMatch"] = String(loadedIdentity == request.identity)
         refreshFields["loadingMatch"] = String(loadingIdentity == request.identity)
         refreshFields["hasRefreshTask"] = String(refreshTask != nil)
         AgentSelectedFilesDiagnostics.event("coordinator.refresh.request", fields: refreshFields, includeStack: true)
 
-        if !force, loadedIdentity == request.identity, model != nil {
+        if !force, loadingIdentity == request.identity {
+            debugStats.skippedLoading += 1
+            AgentSelectedFilesDiagnostics.event("coordinator.refresh.skipLoading", fields: refreshFields)
+            return .skippedLoading
+        }
+
+        if !force, completedDisplayedModelMatches(request.identity) {
             cancelActiveRefresh(reason: "skipLoaded", fields: refreshFields)
             state = AgentSelectedFilesModelState(
                 model: state.model,
                 rowSplit: state.rowSplit,
                 isLoading: false,
-                canMutateDisplayedModel: true
+                canMutateDisplayedModel: displayedModelIsMutable
             )
             debugStats.skippedLoaded += 1
             AgentSelectedFilesDiagnostics.event("coordinator.refresh.skipLoaded", fields: refreshFields)
@@ -142,29 +387,33 @@ final class AgentSelectedFilesModelCoordinator: ObservableObject {
             cancelActiveRefresh(reason: "skipCached", fields: refreshFields)
             debugStats.skippedLoaded += 1
             touchCachedModel(request.identity)
+            let cachedRowSplit = AgentSelectedFilesRowSplit(rows: cachedModel.rows)
             state = AgentSelectedFilesModelState(
                 model: cachedModel,
-                rowSplit: AgentSelectedFilesRowSplit(rows: cachedModel.rows),
+                rowSplit: cachedRowSplit,
                 isLoading: false,
                 canMutateDisplayedModel: true
             )
+            completedCountSnapshots[request.identity] = cachedRowSplit.fileCodemapCountSummary
             loadedIdentity = request.identity
+            displayedIdentity = request.identity
+            recordVisibleFileMetricsSnapshot(
+                identity: request.identity,
+                rowSplit: cachedRowSplit,
+                totalSelectedDisplayTokens: cachedModel.totalSelectedDisplayTokens
+            )
             AgentSelectedFilesDiagnostics.event("coordinator.refresh.skipCached", fields: refreshFields)
             return .skippedLoaded
-        }
-
-        if !force, loadingIdentity == request.identity {
-            debugStats.skippedLoading += 1
-            AgentSelectedFilesDiagnostics.event("coordinator.refresh.skipLoading", fields: refreshFields)
-            return .skippedLoading
         }
 
         cancelActiveRefresh(reason: "startReplacement", fields: refreshFields)
 
         let shouldClearLoadedModel = loadedIdentity != request.identity
-        let shouldClearDisplayedModel = shouldClearLoadedModel && !preserveDisplayedModel
+        let shouldPreserveDisplayedModel = preserveDisplayedModel || displayedModelMatches(request.identity)
+        let shouldClearDisplayedModel = shouldClearLoadedModel && !shouldPreserveDisplayedModel
         if shouldClearDisplayedModel {
             loadedIdentity = nil
+            displayedIdentity = nil
         }
 
         let refreshID = UUID()
@@ -184,10 +433,9 @@ final class AgentSelectedFilesModelCoordinator: ObservableObject {
 
         refreshTask = Task { [weak self, resolver] in
             let resolveStartMS = AgentSelectedFilesDiagnostics.timestampMSIfEnabled()
-            if Self.shouldResolveFileRowsFirst(request) {
-                let fileRowsRequest = Self.fileRowsOnlyRequest(from: request)
+            let resolvesFileRowsFirst = publishesInterimFileRows && Self.shouldResolveFileRowsFirst(request)
+            let interimFileRowsHandler: ResolveInterimFileRows? = resolvesFileRowsFirst ? { fileRowsModel in
                 let fileRowsStartMS = AgentSelectedFilesDiagnostics.timestampMSIfEnabled()
-                let fileRowsModel = await resolver(fileRowsRequest)
                 guard !Task.isCancelled else {
                     AgentSelectedFilesDiagnostics.event(
                         "coordinator.resolve.cancelledAfterFileRows",
@@ -195,8 +443,8 @@ final class AgentSelectedFilesModelCoordinator: ObservableObject {
                     )
                     return
                 }
-                let shouldContinue = await MainActor.run { [weak self] in
-                    guard let self else { return false }
+                await MainActor.run { [weak self] in
+                    guard let self else { return }
                     guard self.refreshID == refreshID, loadingIdentity == request.identity else {
                         debugStats.staleResultsIgnored += 1
                         AgentSelectedFilesDiagnostics.event(
@@ -204,24 +452,64 @@ final class AgentSelectedFilesModelCoordinator: ObservableObject {
                             fields: refreshFields.merging(AgentSelectedFilesDiagnostics.elapsedFields(since: fileRowsStartMS)) { _, new in new },
                             includeStack: true
                         )
-                        return false
+                        return
                     }
                     var fileRowsFields = refreshFields.merging(AgentSelectedFilesDiagnostics.elapsedFields(since: fileRowsStartMS)) { _, new in new }
                     fileRowsFields["rowCount"] = String(fileRowsModel.rows.count)
                     fileRowsFields["missingPaths"] = String(fileRowsModel.missingPaths.count)
                     fileRowsFields["invalidPaths"] = String(fileRowsModel.invalidPaths.count)
                     AgentSelectedFilesDiagnostics.event("coordinator.resolve.fileRowsReady", fields: fileRowsFields)
+                    let codemapReadinessIsPending = codemapReadinessPending(for: request.identity)
+                    let publishedFileRowsModel = modelByPreservingKnownFileMetrics(
+                        in: fileRowsModel,
+                        identity: request.identity,
+                        codemapReadinessPending: codemapReadinessIsPending
+                    )
+                    let fileRowsSplit = AgentSelectedFilesRowSplit(rows: publishedFileRowsModel.rows)
                     state = AgentSelectedFilesModelState(
-                        model: fileRowsModel,
-                        rowSplit: AgentSelectedFilesRowSplit(rows: fileRowsModel.rows),
+                        model: publishedFileRowsModel,
+                        rowSplit: fileRowsSplit,
                         isLoading: true,
                         canMutateDisplayedModel: false
                     )
-                    return true
+                    displayedIdentity = request.identity
+                    recordVisibleFileMetricsSnapshot(
+                        identity: request.identity,
+                        rowSplit: fileRowsSplit,
+                        totalSelectedDisplayTokens: publishedFileRowsModel.totalSelectedDisplayTokens
+                    )
                 }
-                guard shouldContinue else { return }
+            } : nil
+            let resolvedModel: AgentContextExportModel
+            do {
+                resolvedModel = try await resolver(request, interimFileRowsHandler)
+            } catch is CancellationError {
+                AgentSelectedFilesDiagnostics.event(
+                    "coordinator.resolve.cancelled",
+                    fields: refreshFields.merging(AgentSelectedFilesDiagnostics.elapsedFields(since: resolveStartMS)) { _, new in new }
+                )
+                return
+            } catch {
+                var failureFields = refreshFields.merging(AgentSelectedFilesDiagnostics.elapsedFields(since: resolveStartMS)) { _, new in new }
+                failureFields["errorType"] = String(reflecting: type(of: error))
+                AgentSelectedFilesDiagnostics.event("coordinator.resolve.failed", fields: failureFields)
+                await MainActor.run { [weak self] in
+                    guard let self,
+                          self.refreshID == refreshID,
+                          loadingIdentity == request.identity
+                    else { return }
+                    loadingIdentity = nil
+                    self.refreshID = nil
+                    refreshTask = nil
+                    state = AgentSelectedFilesModelState(
+                        model: state.model,
+                        rowSplit: state.rowSplit,
+                        isLoading: false,
+                        canMutateDisplayedModel: displayedModelIsMutable
+                    )
+                }
+                return
             }
-            let resolvedModel = await resolver(request)
             guard !Task.isCancelled else {
                 AgentSelectedFilesDiagnostics.event(
                     "coordinator.resolve.cancelledAfterReturn",
@@ -246,14 +534,22 @@ final class AgentSelectedFilesModelCoordinator: ObservableObject {
                 completionFields["invalidPaths"] = String(resolvedModel.invalidPaths.count)
                 completionFields["hasProjection"] = String(resolvedModel.lookupContext.bindingProjection != nil)
                 AgentSelectedFilesDiagnostics.event("coordinator.resolve.complete", fields: completionFields)
+                let resolvedRowSplit = AgentSelectedFilesRowSplit(rows: resolvedModel.rows)
                 state = AgentSelectedFilesModelState(
                     model: resolvedModel,
-                    rowSplit: AgentSelectedFilesRowSplit(rows: resolvedModel.rows),
+                    rowSplit: resolvedRowSplit,
                     isLoading: false,
                     canMutateDisplayedModel: true
                 )
+                completedCountSnapshots[request.identity] = resolvedRowSplit.fileCodemapCountSummary
                 cacheModel(resolvedModel, for: request.identity)
                 loadedIdentity = request.identity
+                displayedIdentity = request.identity
+                recordVisibleFileMetricsSnapshot(
+                    identity: request.identity,
+                    rowSplit: resolvedRowSplit,
+                    totalSelectedDisplayTokens: resolvedModel.totalSelectedDisplayTokens
+                )
                 loadingIdentity = nil
                 self.refreshID = nil
                 refreshTask = nil
@@ -286,11 +582,12 @@ final class AgentSelectedFilesModelCoordinator: ObservableObject {
                 model: state.model,
                 rowSplit: state.rowSplit,
                 isLoading: false,
-                canMutateDisplayedModel: loadedIdentity != nil && state.model != nil
+                canMutateDisplayedModel: displayedModelIsMutable
             )
             : .empty
         if !keepLoadedModel {
             loadedIdentity = nil
+            displayedIdentity = nil
         }
     }
 
@@ -308,11 +605,106 @@ final class AgentSelectedFilesModelCoordinator: ObservableObject {
         if !keepLoadedModel {
             state = .empty
             loadedIdentity = nil
+            displayedIdentity = nil
         }
     }
 
     func resetDebugStats() {
         debugStats = AgentSelectedFilesModelDebugStats()
+    }
+
+    private func modelByPreservingKnownFileMetrics(
+        in model: AgentContextExportModel,
+        identity: AgentSelectedFilesModelIdentity,
+        codemapReadinessPending: Bool
+    ) -> AgentContextExportModel {
+        guard codemapReadinessPending else { return model }
+        let fileRows = model.rows.filter { $0.kind != .codemap }
+        guard !fileRows.isEmpty else { return model }
+        let keys = Set(fileRows.map(visibleFileMetricsKey(for:)))
+        guard let metricsSnapshot = visibleFileMetricsSnapshot,
+              metricsSnapshot.scope == visibleFileMetricsScope(for: identity),
+              metricsSnapshot.keys == keys
+        else { return model }
+
+        var didPreserveMetrics = false
+        let rows = model.rows.map { row in
+            guard row.kind != .codemap,
+                  row.metrics == .unknown,
+                  let metrics = metricsSnapshot.metricsByKey[visibleFileMetricsKey(for: row)]
+            else { return row }
+            didPreserveMetrics = true
+            return row.withMetrics(metrics)
+        }.sorted(by: AgentContextExportResolver.rowSort)
+        guard didPreserveMetrics else { return model }
+
+        return AgentContextExportModel(
+            source: model.source,
+            lookupContext: model.lookupContext,
+            rows: rows,
+            totalSelectedDisplayTokens: metricsSnapshot.totalSelectedDisplayTokens,
+            missingPaths: model.missingPaths,
+            invalidPaths: model.invalidPaths,
+            codemapPresentation: model.codemapPresentation
+        )
+    }
+
+    private func recordVisibleFileMetricsSnapshot(
+        identity: AgentSelectedFilesModelIdentity,
+        rowSplit: AgentSelectedFilesRowSplit,
+        totalSelectedDisplayTokens: Int
+    ) {
+        guard !rowSplit.fileRows.isEmpty else {
+            visibleFileMetricsSnapshot = nil
+            return
+        }
+        var metricsByKey: [VisibleFileMetricsKey: AgentContextExportRow.Metrics] = [:]
+        for row in rowSplit.fileRows {
+            guard row.metrics.knownValues != nil else {
+                visibleFileMetricsSnapshot = nil
+                return
+            }
+            metricsByKey[visibleFileMetricsKey(for: row)] = row.metrics
+        }
+        guard metricsByKey.count == rowSplit.fileRows.count else {
+            visibleFileMetricsSnapshot = nil
+            return
+        }
+
+        visibleFileMetricsSnapshot = VisibleFileMetricsSnapshot(
+            scope: visibleFileMetricsScope(for: identity),
+            keys: Set(metricsByKey.keys),
+            metricsByKey: metricsByKey,
+            totalSelectedDisplayTokens: totalSelectedDisplayTokens
+        )
+    }
+
+    private func visibleFileMetricsScope(for identity: AgentSelectedFilesModelIdentity) -> VisibleFileMetricsScope {
+        let selection = identity.exportContextIdentity.selection
+        return VisibleFileMetricsScope(
+            filePathDisplay: identity.filePathDisplay,
+            codeMapUsage: identity.codeMapUsage,
+            selectedPaths: selection.selectedPaths.sorted(),
+            manualCodemapPaths: selection.manualCodemapPaths.sorted(),
+            slices: selection.slices.mapValues { lineRanges in
+                lineRanges.sorted { lhs, rhs in
+                    if lhs.start != rhs.start { return lhs.start < rhs.start }
+                    return lhs.end < rhs.end
+                }
+            },
+            codemapAutoEnabled: selection.codemapAutoEnabled,
+            worktreeBindingFingerprint: identity.exportContextIdentity.worktreeBindingFingerprint
+        )
+    }
+
+    private func codemapReadinessPending(for identity: AgentSelectedFilesModelIdentity) -> Bool {
+        guard !Self.codemapCountIsStableBeforeCompletion(identity) else { return false }
+        guard loadedIdentity == identity else { return true }
+        return completedCountSnapshots[identity] == nil
+    }
+
+    private func visibleFileMetricsKey(for row: AgentContextExportRow) -> VisibleFileMetricsKey {
+        VisibleFileMetricsKey(rootID: row.rootID, rowID: row.id, kind: row.kind)
     }
 
     private func cancelActiveRefresh(reason: String, fields: [String: String]) {
@@ -338,6 +730,7 @@ final class AgentSelectedFilesModelCoordinator: ObservableObject {
         while cachedModelOrder.count > cachedModelLimit {
             let evicted = cachedModelOrder.removeFirst()
             cachedModels[evicted] = nil
+            completedCountSnapshots[evicted] = nil
         }
     }
 
@@ -358,31 +751,34 @@ final class AgentSelectedFilesModelCoordinator: ObservableObject {
         }
     }
 
+    private static func codemapCountIsStableBeforeCompletion(_ identity: AgentSelectedFilesModelIdentity) -> Bool {
+        switch identity.codeMapUsage {
+        case .none:
+            return true
+        case .auto:
+            let selection = identity.exportContextIdentity.selection
+            return !selection.codemapAutoEnabled && selection.manualCodemapPaths.isEmpty
+        case .complete, .selected:
+            return false
+        }
+    }
+
     private static func hasExplicitFileRows(_ selection: StoredSelection) -> Bool {
         if !selection.selectedPaths.isEmpty { return true }
         return selection.slices.contains { !$0.value.isEmpty }
     }
 
-    private static func fileRowsOnlyRequest(from request: AgentSelectedFilesModelRequest) -> AgentSelectedFilesModelRequest {
-        AgentSelectedFilesModelRequest(
-            identity: AgentSelectedFilesModelIdentity(
-                exportContextIdentity: request.identity.exportContextIdentity,
-                filePathDisplay: request.identity.filePathDisplay,
-                codeMapUsage: .none
-            ),
+    private static func resolveModel(
+        _ request: AgentSelectedFilesModelRequest,
+        interimFileRowsHandler: ResolveInterimFileRows?
+    ) async throws -> AgentContextExportModel {
+        try await AgentContextExportResolver.resolveModel(
             source: request.source,
             store: request.store,
             filePathDisplay: request.filePathDisplay,
-            codeMapUsage: .none
-        )
-    }
-
-    private static func resolveModel(_ request: AgentSelectedFilesModelRequest) async -> AgentContextExportModel {
-        await AgentContextExportResolver.resolveModel(
-            source: request.source,
-            store: request.store,
-            filePathDisplay: request.filePathDisplay,
-            codeMapUsage: request.codeMapUsage
+            codeMapUsage: request.codeMapUsage,
+            entryMetricsSnapshot: request.entryMetricsSnapshot,
+            interimFileRowsHandler: interimFileRowsHandler
         )
     }
 }

--- a/Sources/RepoPrompt/Features/AgentMode/Views/AgentInputBar.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/AgentInputBar.swift
@@ -39,6 +39,7 @@ struct AgentInputBar: View {
     let agentModeVM: AgentModeViewModel
     @ObservedObject var composerUI: AgentComposerUIStore
     @ObservedObject var statusPillsUI: AgentStatusPillsUIStore
+    let openContextDrawerFiles: () -> Void
     let oracleViewModel: OracleViewModel
     let promptManager: PromptViewModel
     let workspaceSearchService: WorkspaceSearchService
@@ -164,6 +165,7 @@ struct AgentInputBar: View {
         AgentStatusPillsRow(
             agentModeVM: agentModeVM,
             statusPillsUI: statusPillsUI,
+            openContextDrawerFiles: openContextDrawerFiles,
             oracleViewModel: oracleViewModel,
             promptManager: promptManager,
             selectionCoordinator: selectionCoordinator,
@@ -656,7 +658,7 @@ struct AgentComposerView: View, Equatable {
                 transaction.animation = nil
             }
 
-            // Right side: Attach + Context indicator + Send/Cancel button
+            // Right side: Attach + Send/Cancel button
             HStack(spacing: 8) {
                 Button(action: pickImages) {
                     Image(systemName: "photo.badge.plus")

--- a/Sources/RepoPrompt/Features/AgentMode/Views/AgentModeDetailWithSidebarView.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/AgentModeDetailWithSidebarView.swift
@@ -134,29 +134,43 @@ struct AgentModeDetailWithSidebarView: View {
 
     var body: some View {
         #if DEBUG
-            AgentModeChatDetailView(
-                agentModeVM: agentModeVM,
-                transcriptUI: agentModeVM.ui.transcript,
-                runInteractionUI: agentModeVM.ui.runInteraction,
-                statusPillsUI: statusPillsUI,
-                contextBuilderAgentVM: contextBuilderAgentVM,
-                isContextBuilderQuestionPresented: isContextBuilderQuestionPresented,
-                oracleViewModel: oracleViewModel,
+            AgentContextInspectorPresenter(
+                drawerStore: agentModeVM.ui.contextDrawer,
                 promptManager: promptManager,
-                workspaceSearchService: workspaceSearchService,
-                selectionCoordinator: selectionCoordinator,
-                stressHarness: stressHarness,
                 runtimeVM: runtimeVM,
+                contextBuilderAgentVM: contextBuilderAgentVM,
+                oracleViewModel: oracleViewModel,
+                selectionCoordinator: selectionCoordinator,
+                activeAgentSessionID: statusPillsUI.snapshot.activeAgentSessionID,
+                agentModeVM: agentModeVM,
                 windowID: windowID,
-                currentTabID: currentTabID,
-                codexManagedLoginAction: codexManagedLoginAction
-            )
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .overlay(alignment: .topTrailing) {
-                if let stressHarness, stressHarness.configuration.showOverlay {
-                    AgentChatStressHarnessPanel(harness: stressHarness, currentTabID: currentTabID)
-                        .padding(.top, 14)
-                        .padding(.trailing, 14)
+                currentTabID: currentTabID
+            ) {
+                AgentModeChatDetailView(
+                    agentModeVM: agentModeVM,
+                    transcriptUI: agentModeVM.ui.transcript,
+                    runInteractionUI: agentModeVM.ui.runInteraction,
+                    statusPillsUI: statusPillsUI,
+                    openContextDrawerFiles: { agentModeVM.ui.contextDrawer.toggle(tab: .files) },
+                    contextBuilderAgentVM: contextBuilderAgentVM,
+                    isContextBuilderQuestionPresented: isContextBuilderQuestionPresented,
+                    oracleViewModel: oracleViewModel,
+                    promptManager: promptManager,
+                    workspaceSearchService: workspaceSearchService,
+                    selectionCoordinator: selectionCoordinator,
+                    stressHarness: stressHarness,
+                    runtimeVM: runtimeVM,
+                    windowID: windowID,
+                    currentTabID: currentTabID,
+                    codexManagedLoginAction: codexManagedLoginAction
+                )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .overlay(alignment: .topTrailing) {
+                    if let stressHarness, stressHarness.configuration.showOverlay {
+                        AgentChatStressHarnessPanel(harness: stressHarness, currentTabID: currentTabID)
+                            .padding(.top, 14)
+                            .padding(.trailing, 14)
+                    }
                 }
             }
             .onAppear {
@@ -188,23 +202,37 @@ struct AgentModeDetailWithSidebarView: View {
             }
             .onDisappear { stressHarness?.pause() }
         #else
-            AgentModeChatDetailView(
-                agentModeVM: agentModeVM,
-                transcriptUI: agentModeVM.ui.transcript,
-                runInteractionUI: agentModeVM.ui.runInteraction,
-                statusPillsUI: statusPillsUI,
-                contextBuilderAgentVM: contextBuilderAgentVM,
-                isContextBuilderQuestionPresented: isContextBuilderQuestionPresented,
-                oracleViewModel: oracleViewModel,
+            AgentContextInspectorPresenter(
+                drawerStore: agentModeVM.ui.contextDrawer,
                 promptManager: promptManager,
-                workspaceSearchService: workspaceSearchService,
-                selectionCoordinator: selectionCoordinator,
                 runtimeVM: runtimeVM,
+                contextBuilderAgentVM: contextBuilderAgentVM,
+                oracleViewModel: oracleViewModel,
+                selectionCoordinator: selectionCoordinator,
+                activeAgentSessionID: statusPillsUI.snapshot.activeAgentSessionID,
+                agentModeVM: agentModeVM,
                 windowID: windowID,
-                currentTabID: currentTabID,
-                codexManagedLoginAction: codexManagedLoginAction
-            )
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                currentTabID: currentTabID
+            ) {
+                AgentModeChatDetailView(
+                    agentModeVM: agentModeVM,
+                    transcriptUI: agentModeVM.ui.transcript,
+                    runInteractionUI: agentModeVM.ui.runInteraction,
+                    statusPillsUI: statusPillsUI,
+                    openContextDrawerFiles: { agentModeVM.ui.contextDrawer.toggle(tab: .files) },
+                    contextBuilderAgentVM: contextBuilderAgentVM,
+                    isContextBuilderQuestionPresented: isContextBuilderQuestionPresented,
+                    oracleViewModel: oracleViewModel,
+                    promptManager: promptManager,
+                    workspaceSearchService: workspaceSearchService,
+                    selectionCoordinator: selectionCoordinator,
+                    runtimeVM: runtimeVM,
+                    windowID: windowID,
+                    currentTabID: currentTabID,
+                    codexManagedLoginAction: codexManagedLoginAction
+                )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
             .onAppear {
                 syncContextBuilderQuestionPresentation()
                 agentModeVM.syncComposerUIState(tabID: currentTabID)
@@ -266,6 +294,131 @@ struct AgentModeDetailWithSidebarView: View {
         agentModeVM.syncRuntimeMetricsUIState(
             liveSelectedFileCount: summary.totalExplicitFileCount,
             liveSelectionSummary: summary
+        )
+    }
+}
+
+struct AgentContextInspectorColumnMetrics: Equatable {
+    let minimumWidth: CGFloat
+    let idealWidth: CGFloat
+    let maximumWidth: CGFloat
+}
+
+enum AgentContextInspectorColumnSizing {
+    private static let shellMinimumWidth: CGFloat = 320
+    private static let preferredWidthRatio: CGFloat = 2.0 / 3.0
+    private static let minimumChatColumnWidth: CGFloat = 360
+    private static let absoluteMaximumWidth: CGFloat = 800
+
+    static func metrics(forDetailWidth detailWidth: CGFloat) -> AgentContextInspectorColumnMetrics {
+        guard detailWidth.isFinite, detailWidth > 0 else {
+            return AgentContextInspectorColumnMetrics(
+                minimumWidth: shellMinimumWidth,
+                idealWidth: shellMinimumWidth,
+                maximumWidth: shellMinimumWidth
+            )
+        }
+
+        let availableWidth = detailWidth.rounded(.down)
+        let maximumPreservingChat = availableWidth - minimumChatColumnWidth
+        let maximumWidth = max(shellMinimumWidth, min(absoluteMaximumWidth, maximumPreservingChat))
+        let preferredWidth = availableWidth * preferredWidthRatio
+        let idealWidth = min(max(preferredWidth, shellMinimumWidth), maximumWidth)
+
+        return AgentContextInspectorColumnMetrics(
+            minimumWidth: shellMinimumWidth,
+            idealWidth: idealWidth,
+            maximumWidth: maximumWidth
+        )
+    }
+}
+
+private struct AgentContextInspectorPresenter<PrimaryContent: View>: View {
+    let drawerStore: AgentContextDrawerUIStore
+    @ObservedObject var presentationStore: AgentContextDrawerPresentationStore
+    let promptManager: PromptViewModel
+    @ObservedObject var runtimeVM: AgentRuntimeSidebarViewModel
+    let contextBuilderAgentVM: ContextBuilderAgentViewModel
+    let oracleViewModel: OracleViewModel
+    let selectionCoordinator: WorkspaceSelectionCoordinator
+    let activeAgentSessionID: UUID?
+    let agentModeVM: AgentModeViewModel
+    let windowID: Int
+    let currentTabID: UUID?
+    let primaryContent: PrimaryContent
+
+    init(
+        drawerStore: AgentContextDrawerUIStore,
+        promptManager: PromptViewModel,
+        runtimeVM: AgentRuntimeSidebarViewModel,
+        contextBuilderAgentVM: ContextBuilderAgentViewModel,
+        oracleViewModel: OracleViewModel,
+        selectionCoordinator: WorkspaceSelectionCoordinator,
+        activeAgentSessionID: UUID?,
+        agentModeVM: AgentModeViewModel,
+        windowID: Int,
+        currentTabID: UUID?,
+        @ViewBuilder primaryContent: () -> PrimaryContent
+    ) {
+        self.drawerStore = drawerStore
+        _presentationStore = ObservedObject(wrappedValue: drawerStore.presentation)
+        self.promptManager = promptManager
+        _runtimeVM = ObservedObject(wrappedValue: runtimeVM)
+        self.contextBuilderAgentVM = contextBuilderAgentVM
+        self.oracleViewModel = oracleViewModel
+        self.selectionCoordinator = selectionCoordinator
+        self.activeAgentSessionID = activeAgentSessionID
+        self.agentModeVM = agentModeVM
+        self.windowID = windowID
+        self.currentTabID = currentTabID
+        self.primaryContent = primaryContent()
+    }
+
+    var body: some View {
+        GeometryReader { geometry in
+            let metrics = AgentContextInspectorColumnSizing.metrics(forDetailWidth: geometry.size.width)
+
+            primaryContent
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .inspector(isPresented: presentationBinding) {
+                    AgentContextControlDrawerView(
+                        drawerStore: drawerStore,
+                        detailStore: drawerStore.detail,
+                        isPresented: presentationStore.isPresented,
+                        promptManager: promptManager,
+                        runtimeVM: runtimeVM,
+                        contextBuilderAgentVM: contextBuilderAgentVM,
+                        oracleViewModel: oracleViewModel,
+                        selectionCoordinator: selectionCoordinator,
+                        windowID: windowID,
+                        currentTabID: currentTabID,
+                        activeAgentSessionID: activeAgentSessionID,
+                        worktreeBindingsProvider: { sessionID, tabID in
+                            agentModeVM.worktreeBindings(forAgentSessionID: sessionID, tabID: tabID)
+                        }
+                    )
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .background(Color(NSColor.windowBackgroundColor))
+                    .clipped()
+                    .inspectorColumnWidth(
+                        min: metrics.minimumWidth,
+                        ideal: metrics.idealWidth,
+                        max: metrics.maximumWidth
+                    )
+                }
+        }
+    }
+
+    private var presentationBinding: Binding<Bool> {
+        Binding(
+            get: { presentationStore.isPresented },
+            set: { isPresented in
+                if isPresented {
+                    drawerStore.open()
+                } else {
+                    drawerStore.close()
+                }
+            }
         )
     }
 }

--- a/Sources/RepoPrompt/Features/AgentMode/Views/AgentModeView.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/AgentModeView.swift
@@ -185,6 +185,7 @@ struct AgentModeChatDetailView: View {
     @ObservedObject var transcriptUI: AgentTranscriptUIStore
     @ObservedObject var runInteractionUI: AgentRunInteractionUIStore
     @ObservedObject var statusPillsUI: AgentStatusPillsUIStore
+    let openContextDrawerFiles: () -> Void
     let contextBuilderAgentVM: ContextBuilderAgentViewModel
     let isContextBuilderQuestionPresented: Bool
     let oracleViewModel: OracleViewModel
@@ -1879,6 +1880,7 @@ struct AgentModeChatDetailView: View {
                     agentModeVM: agentModeVM,
                     composerUI: agentModeVM.ui.composer,
                     statusPillsUI: agentModeVM.ui.statusPills,
+                    openContextDrawerFiles: openContextDrawerFiles,
                     oracleViewModel: oracleViewModel,
                     promptManager: promptManager,
                     workspaceSearchService: workspaceSearchService,

--- a/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentContextPill.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentContextPill.swift
@@ -3,16 +3,15 @@ import SwiftUI
 // MARK: - Context Pill
 
 /// Always-visible pill showing context usage wheel + file/token info.
-/// Expands upward into a popover with export controls.
 struct AgentContextPill: View {
     @ObservedObject var promptManager: PromptViewModel
+    let openContextDrawerFiles: () -> Void
     let selectionCoordinator: WorkspaceSelectionCoordinator
     @ObservedObject var runtimeVM: AgentRuntimeSidebarViewModel
     let currentTabID: UUID?
     let activeAgentSessionID: UUID?
     let worktreeBindingsProvider: @MainActor (UUID, UUID?) -> [AgentSessionWorktreeBinding]
 
-    @State private var showPopover = false
     @ObservedObject private var fontScale = FontScaleManager.shared
     private var fontPreset: FontScalePreset {
         fontScale.preset
@@ -34,6 +33,10 @@ struct AgentContextPill: View {
             return .filesOnly(count)
         }
         return AgentContextExportResolver.selectionSummary(for: currentExportSourceSelection)
+    }
+
+    private var selectionDisplayText: AgentContextSelectionDisplayText {
+        AgentContextFileCodemapCountSummary.selectionDisplayText(from: selectionSummary)
     }
 
     private var currentExportSourceSelection: StoredSelection {
@@ -73,7 +76,7 @@ struct AgentContextPill: View {
             lines.append("Context usage unavailable")
         }
 
-        lines.append("Selected: \(detailedFileSummaryText)")
+        lines.append("Selected context: \(detailedFileSummaryText)")
         if let selectionTokens {
             lines.append("Selection: \(AgentContextIndicator.formatTokens(selectionTokens)) tokens")
         }
@@ -86,12 +89,12 @@ struct AgentContextPill: View {
             let _ = AgentModePerfDiagnostics.increment("ui.body.statusPills.context")
         #endif
         let cornerRadius = AgentPillMetrics.cornerRadius()
-        let summary = selectionSummary
-        let compactFileSummaryText = summary.compactText
-        let detailedFileSummaryText = summary.headlineText
+        let displayText = selectionDisplayText
+        let compactFileSummaryText = displayText.compact
+        let detailedFileSummaryText = displayText.detailed
 
         Button {
-            showPopover.toggle()
+            openContextDrawerFiles()
         } label: {
             HStack(spacing: 6) {
                 Text(compactFileSummaryText)
@@ -118,64 +121,6 @@ struct AgentContextPill: View {
         .buttonStyle(.plain)
         .hoverTooltip(contextUsageTooltip(detailedFileSummaryText: detailedFileSummaryText), .top)
         .accessibilityLabel("Agent context: \(detailedFileSummaryText)")
-        .accessibilityHint("Opens context export controls and usage details")
-        .popover(isPresented: $showPopover, arrowEdge: .bottom) {
-            contextPopoverContent
-        }
-    }
-
-    @ViewBuilder
-    private var contextPopoverContent: some View {
-        // Width grows with the font scale so the export card never feels
-        // pinched at Large/Extra Large.
-        let popoverWidth = fontPreset.scaledClamped(420, max: 520)
-        let summary = selectionSummary
-        let fileCount = summary.totalExplicitFileCount
-        let visibleManagerRows = min(max(fileCount, 3), 7)
-        let managerIdealHeight = min(360, Double(visibleManagerRows) * 40 + 54)
-
-        VStack(alignment: .leading, spacing: 6) {
-            HStack(spacing: 10) {
-                AgentContextIndicator(
-                    contextWindowTokens: contextWindowTokens,
-                    usedTokens: estimatedUsedTokens,
-                    sourceLabel: runtimeVM.snapshot.usedTokens != nil
-                        ? runtimeVM.snapshot.usageSource.label
-                        : "Estimated",
-                    style: .labeled
-                )
-                Spacer()
-            }
-
-            AgentSelectedFilesInlineManager(
-                promptManager: promptManager,
-                selectionCoordinator: selectionCoordinator,
-                currentTabID: currentTabID,
-                activeAgentSessionID: activeAgentSessionID,
-                worktreeBindingsProvider: worktreeBindingsProvider,
-                summary: summary
-            )
-            .frame(
-                minHeight: 124,
-                idealHeight: managerIdealHeight,
-                maxHeight: 360
-            )
-
-            Divider()
-
-            AgentExportCard(
-                promptManager: promptManager,
-                tokenCounter: promptManager.tokenCountingViewModel,
-                selectionCoordinator: selectionCoordinator,
-                fileCount: fileCount,
-                selectionTokens: selectionTokens,
-                showsFilesButton: false,
-                currentTabID: currentTabID,
-                activeAgentSessionID: activeAgentSessionID,
-                worktreeBindingsProvider: worktreeBindingsProvider
-            )
-        }
-        .padding(12)
-        .frame(width: popoverWidth)
+        .accessibilityHint("Opens Compose selections")
     }
 }

--- a/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentOraclePill.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentOraclePill.swift
@@ -8,13 +8,15 @@ enum AgentOraclePillLogic {
         let workspaceID: UUID
         let tabID: UUID
         let chatID: String
+        let presentation: AgentOraclePopoverPresentation
     }
 
     static func explicitOpenRequest(
         chatID rawChatID: String,
         workspaceID: UUID,
         tabID: UUID,
-        generation: UInt64
+        generation: UInt64,
+        presentation: AgentOraclePopoverPresentation = .standard
     ) -> ExplicitOpenRequest? {
         let chatID = rawChatID.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !chatID.isEmpty else { return nil }
@@ -22,8 +24,20 @@ enum AgentOraclePillLogic {
             generation: generation,
             workspaceID: workspaceID,
             tabID: tabID,
-            chatID: chatID
+            chatID: chatID,
+            presentation: presentation
         )
+    }
+
+    static func transcriptActionPolicy(
+        for presentation: AgentOraclePopoverPresentation
+    ) -> ChatTranscriptActionPolicy {
+        switch presentation {
+        case .standard:
+            .standard
+        case .generatedAnswerReadOnly:
+            .nonMutating
+        }
     }
 
     static func shouldPresent(
@@ -173,15 +187,16 @@ struct AgentOraclePill: View {
     let activeAgentSessionID: UUID?
     let activeRunID: UUID?
 
-    private enum PresentedSessionSource {
-        case latest
-        case explicit
+    private struct PopoverPresentation: Identifiable {
+        /// Identifies the open request; bump the generation whenever the session or policy changes
+        let id: UInt64
+        let sessionID: UUID
+        let isExplicit: Bool
+        let actionPolicy: ChatTranscriptActionPolicy
     }
 
-    @State private var showPopover = false
+    @State private var presentedPopover: PopoverPresentation?
     @State private var autoScrollEnabled = false
-    @State private var presentedSessionID: UUID?
-    @State private var presentedSessionSource: PresentedSessionSource = .latest
     @State private var openRequestGeneration: UInt64 = 0
     @ObservedObject private var fontScale = FontScaleManager.shared
     private var fontPreset: FontScalePreset {
@@ -211,23 +226,21 @@ struct AgentOraclePill: View {
         return oracleViewModel.streamingSessions.contains(latestTabSession.id)
     }
 
-    private var presentedSession: ChatSession? {
-        guard let presentedSessionID,
-              let tabID = currentTabID else { return nil }
-        return oracleViewModel.sessions(forTabID: tabID).first { $0.id == presentedSessionID }
+    private func presentedSession(for presentation: PopoverPresentation) -> ChatSession? {
+        guard let tabID = currentTabID else { return nil }
+        return oracleViewModel.sessions(forTabID: tabID).first { $0.id == presentation.sessionID }
     }
 
-    private var isPresentedSessionStreaming: Bool {
-        guard let presentedSessionID else { return isStreaming }
-        return oracleViewModel.streamingSessions.contains(presentedSessionID)
+    private func isPresentedSessionStreaming(_ presentation: PopoverPresentation) -> Bool {
+        oracleViewModel.streamingSessions.contains(presentation.sessionID)
     }
 
-    private var popoverSubtitle: String {
-        guard let presentedSession else { return "Latest tab chat" }
-        if presentedSession.id == latestTabSession?.id {
+    private func popoverSubtitle(_ presentation: PopoverPresentation) -> String {
+        guard let session = presentedSession(for: presentation) else { return "Latest tab chat" }
+        if session.id == latestTabSession?.id {
             return "Latest tab chat"
         }
-        return presentedSession.name
+        return session.name
     }
 
     private var hasAnySessions: Bool {
@@ -281,7 +294,11 @@ struct AgentOraclePill: View {
                       route.tabID == currentTabID,
                       route.workspaceID == oracleViewModel.workspaceManager.activeWorkspaceID
                 else { return }
-                openPopover(chatID: route.chatID, workspaceID: route.workspaceID)
+                openPopover(
+                    chatID: route.chatID,
+                    workspaceID: route.workspaceID,
+                    presentation: route.presentation
+                )
                 return
             }
             guard let route = AgentOracleLatestPopoverRoute(notificationUserInfo: note.userInfo),
@@ -291,8 +308,8 @@ struct AgentOraclePill: View {
             else { return }
             openLatestStreamingPopover()
         }
-        .popover(isPresented: $showPopover, arrowEdge: .bottom) {
-            oraclePopoverContent
+        .popover(item: $presentedPopover, arrowEdge: .bottom) { presentation in
+            oraclePopoverContent(presentation)
         }
         .onChange(of: currentTabID) { _, _ in
             openRequestGeneration &+= 1
@@ -300,9 +317,8 @@ struct AgentOraclePill: View {
         }
         .onReceive(oracleViewModel.workspaceManager.$activeWorkspaceID) { _ in
             openRequestGeneration &+= 1
-            if presentedSessionSource == .explicit {
-                presentedSessionID = nil
-                showPopover = false
+            if presentedPopover?.isExplicit == true {
+                presentedPopover = nil
             } else {
                 reconcilePresentedSession()
             }
@@ -316,7 +332,7 @@ struct AgentOraclePill: View {
     }
 
     @ViewBuilder
-    private var oraclePopoverContent: some View {
+    private func oraclePopoverContent(_ presentation: PopoverPresentation) -> some View {
         // Popover dimensions scale so chat messages don't feel cramped at
         // Larger/Extra Large. Width gets a tighter cap than height because the
         // popover is anchored to the composer and we don't want it to spill
@@ -329,13 +345,13 @@ struct AgentOraclePill: View {
             HStack(spacing: 6) {
                 Text("Oracle")
                     .font(fontPreset.swiftUIFont(sizeAtNormal: 13, weight: .semibold))
-                if isPresentedSessionStreaming {
+                if isPresentedSessionStreaming(presentation) {
                     ProgressView()
                         .controlSize(.mini)
                         .scaleEffect(0.7)
                 }
                 Spacer()
-                Text(popoverSubtitle)
+                Text(popoverSubtitle(presentation))
                     .font(fontPreset.swiftUIFont(sizeAtNormal: 11))
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
@@ -347,7 +363,8 @@ struct AgentOraclePill: View {
                 bottomOcclusion: 0,
                 showsScrollControls: true,
                 autoScrollOnAppear: true,
-                sessionIDOverride: presentedSessionID
+                sessionIDOverride: presentation.sessionID,
+                actionPolicy: presentation.actionPolicy
             )
             .frame(minHeight: transcriptMinHeight, idealHeight: transcriptIdealHeight, maxHeight: transcriptMaxHeight)
             .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
@@ -357,22 +374,42 @@ struct AgentOraclePill: View {
     }
 
     private func reconcilePresentedSession() {
-        guard showPopover else { return }
+        guard let presentation = presentedPopover else { return }
         let sameTabSessions = currentTabID.map { oracleViewModel.sessions(forTabID: $0) } ?? []
         let resolvedID = AgentOraclePillLogic.reconciledPresentedSessionID(
-            currentSessionID: presentedSessionID,
-            isExplicit: presentedSessionSource == .explicit,
+            currentSessionID: presentation.sessionID,
+            isExplicit: presentation.isExplicit,
             currentWorkspaceID: oracleViewModel.workspaceManager.activeWorkspaceID,
             sameTabSessions: sameTabSessions,
             eligibleSessions: eligibleTabSessions,
             streamingSessionIDs: oracleViewModel.streamingSessions
         )
         guard let resolvedID else {
-            presentedSessionID = nil
-            showPopover = false
+            presentedPopover = nil
             return
         }
-        presentedSessionID = resolvedID
+        guard resolvedID != presentation.sessionID else { return }
+        openRequestGeneration &+= 1
+        present(
+            sessionID: resolvedID,
+            isExplicit: presentation.isExplicit,
+            actionPolicy: presentation.actionPolicy,
+            generation: openRequestGeneration
+        )
+    }
+
+    private func present(
+        sessionID: UUID,
+        isExplicit: Bool,
+        actionPolicy: ChatTranscriptActionPolicy,
+        generation: UInt64
+    ) {
+        presentedPopover = PopoverPresentation(
+            id: generation,
+            sessionID: sessionID,
+            isExplicit: isExplicit,
+            actionPolicy: actionPolicy
+        )
     }
 
     private func openLatestStreamingPopover() {
@@ -381,33 +418,42 @@ struct AgentOraclePill: View {
             streamingSessionIDs: oracleViewModel.streamingSessions
         ) else { return }
         openRequestGeneration &+= 1
-        presentedSessionID = target.id
-        presentedSessionSource = .latest
-        showPopover = true
+        present(
+            sessionID: target.id,
+            isExplicit: false,
+            actionPolicy: .standard,
+            generation: openRequestGeneration
+        )
     }
 
-    private func openPopover(chatID: String?, workspaceID: UUID? = nil) {
+    private func openPopover(
+        chatID: String?,
+        workspaceID: UUID? = nil,
+        presentation: AgentOraclePopoverPresentation = .standard
+    ) {
         guard let tabID = currentTabID else { return }
         openRequestGeneration &+= 1
         let generation = openRequestGeneration
 
         guard let chatID else {
             guard let target = latestTabSession else { return }
-            presentedSessionID = target.id
-            presentedSessionSource = .latest
-            showPopover = true
+            present(
+                sessionID: target.id,
+                isExplicit: false,
+                actionPolicy: .standard,
+                generation: generation
+            )
             return
         }
 
-        presentedSessionID = nil
-        presentedSessionSource = .explicit
-        showPopover = false
+        presentedPopover = nil
         guard let workspaceID,
               let request = AgentOraclePillLogic.explicitOpenRequest(
                   chatID: chatID,
                   workspaceID: workspaceID,
                   tabID: tabID,
-                  generation: generation
+                  generation: generation,
+                  presentation: presentation
               ) else { return }
 
         Task { @MainActor in
@@ -425,9 +471,12 @@ struct AgentOraclePill: View {
                 )
             else { return }
 
-            presentedSessionID = target.id
-            presentedSessionSource = .explicit
-            showPopover = true
+            present(
+                sessionID: target.id,
+                isExplicit: true,
+                actionPolicy: AgentOraclePillLogic.transcriptActionPolicy(for: request.presentation),
+                generation: request.generation
+            )
         }
     }
 }

--- a/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentStatusPillsRow.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentStatusPillsRow.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct AgentStatusPillsRow: View {
     let agentModeVM: AgentModeViewModel
     @ObservedObject var statusPillsUI: AgentStatusPillsUIStore
+    let openContextDrawerFiles: () -> Void
     @ObservedObject var oracleViewModel: OracleViewModel
     @ObservedObject var promptManager: PromptViewModel
     let selectionCoordinator: WorkspaceSelectionCoordinator
@@ -74,6 +75,7 @@ struct AgentStatusPillsRow: View {
 
                 AgentContextPill(
                     promptManager: promptManager,
+                    openContextDrawerFiles: openContextDrawerFiles,
                     selectionCoordinator: selectionCoordinator,
                     runtimeVM: runtimeVM,
                     currentTabID: snapshot.currentTabID,

--- a/Sources/RepoPrompt/Features/AgentMode/Views/ContextDrawer/AgentContextControlDrawerView.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/ContextDrawer/AgentContextControlDrawerView.swift
@@ -1,0 +1,408 @@
+import SwiftUI
+
+private struct AgentContextDrawerSwitchKey: Equatable {
+    let tabID: UUID?
+    let activeAgentSessionID: UUID?
+}
+
+@MainActor
+@discardableResult
+func refreshSelectedFilesModelAfterTokenMetricsCompletion(
+    request: AgentSelectedFilesModelRequest,
+    coordinator: AgentSelectedFilesModelCoordinator
+) -> AgentSelectedFilesRefreshOutcome? {
+    coordinator.refreshAfterTokenMetricsCompletion(request)
+}
+
+struct AgentContextControlDrawerView: View {
+    let drawerStore: AgentContextDrawerUIStore
+    @ObservedObject var detailStore: AgentContextDrawerDetailStore
+    let isPresented: Bool
+    @ObservedObject var promptManager: PromptViewModel
+    @ObservedObject var runtimeVM: AgentRuntimeSidebarViewModel
+    let contextBuilderAgentVM: ContextBuilderAgentViewModel
+    let oracleViewModel: OracleViewModel
+    let selectionCoordinator: WorkspaceSelectionCoordinator
+    let windowID: Int
+    let currentTabID: UUID?
+    let activeAgentSessionID: UUID?
+    let worktreeBindingsProvider: @MainActor (UUID, UUID?) -> [AgentSessionWorktreeBinding]
+
+    @StateObject private var modelCoordinator = AgentSelectedFilesModelCoordinator()
+    @State private var hoveredTab: AgentContextDrawerUIStore.Tab?
+    @State private var observedSwitchKey: AgentContextDrawerSwitchKey?
+    @State private var selectedFilesBlankingIdentity: AgentSelectedFilesModelIdentity?
+    @State private var tokenBlankingSelection: StoredSelection?
+    @ObservedObject private var fontScale = FontScaleManager.shared
+
+    private var fontPreset: FontScalePreset {
+        fontScale.preset
+    }
+
+    private var exportContext: AgentContextExportViewContext {
+        AgentContextExportViewContext(
+            promptManager: promptManager,
+            selectionCoordinator: selectionCoordinator,
+            currentTabID: currentTabID,
+            activeAgentSessionID: activeAgentSessionID,
+            worktreeBindingsProvider: worktreeBindingsProvider
+        )
+    }
+
+    private var selectionSummary: AgentContextSelectionSummary {
+        exportContext.selectionSummary
+    }
+
+    private var currentSwitchKey: AgentContextDrawerSwitchKey {
+        AgentContextDrawerSwitchKey(
+            tabID: currentTabID ?? promptManager.activeComposeTabID,
+            activeAgentSessionID: activeAgentSessionID
+        )
+    }
+
+    private var hasPendingSwitchKeyChange: Bool {
+        guard let observedSwitchKey else { return false }
+        return observedSwitchKey != currentSwitchKey
+    }
+
+    private var isSwitchBlankingSelectedFiles: Bool {
+        hasPendingSwitchKeyChange || selectedFilesBlankingIdentity != nil
+    }
+
+    private var isSwitchBlankingTokenEstimate: Bool {
+        tokenBlankingSelection != nil
+    }
+
+    private var resolvedFileCodemapCountSummary: AgentContextFileCodemapCountSummary? {
+        modelCoordinator.loadedFileCodemapCountSummary(for: exportContext.modelRequestIdentity)
+    }
+
+    private var fileCodemapCountSummary: AgentContextFileCodemapCountSummary {
+        resolvedFileCodemapCountSummary ?? AgentContextFileCodemapCountSummary.intent(from: selectionSummary)
+    }
+
+    private var fileCodemapCountReadiness: AgentContextFileCodemapCountReadiness {
+        let identity = exportContext.modelRequestIdentity
+        if hasPendingSwitchKeyChange { return unknownFileCodemapCountReadiness }
+        if selectedFilesBlankingIdentity == identity {
+            return modelCoordinator.displayedFileCodemapCountReadiness(for: identity) ?? unknownFileCodemapCountReadiness
+        }
+        if let displayedReadiness = modelCoordinator.displayedFileCodemapCountReadiness(for: identity) {
+            return displayedReadiness
+        }
+        return AgentSelectedFilesModelCoordinator.unresolvedFileCodemapCountReadiness(
+            for: identity,
+            summary: fileCodemapCountSummary
+        )
+    }
+
+    private var unknownFileCodemapCountReadiness: AgentContextFileCodemapCountReadiness {
+        AgentContextFileCodemapCountReadiness(file: .unknown, codemap: .unknown)
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            topTabs
+            Divider()
+            tabContent
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(NSColor.windowBackgroundColor))
+        .clipped()
+        .onAppear {
+            if observedSwitchKey == nil {
+                observedSwitchKey = currentSwitchKey
+            }
+            if isPresented {
+                handleDrawerPresented()
+            }
+        }
+        .onChange(of: isPresented) { _, isPresented in
+            if isPresented {
+                handleDrawerPresented()
+                return
+            }
+            cleanupModelCoordinator()
+        }
+        .onChange(of: currentSwitchKey) { _, newKey in
+            handleSwitchKeyChange(newKey)
+        }
+        .onReceive(exportContext.selectionChangesPublisher) { change in
+            guard exportContext.tabMatchesSelectionChange(change) else { return }
+            updateBlankingTargetsIfNeeded()
+        }
+        .onChange(of: exportContext.modelRequestIdentity) { _, _ in
+            updateBlankingTargetsIfNeeded()
+        }
+        .onChange(of: modelCoordinator.isLoading) { _, _ in
+            clearCompletedSelectedFilesBlankingIfNeeded()
+        }
+        .onReceive(promptManager.tokenCountingViewModel.tokenCalculationCompletedPublisher) { _ in
+            handleTokenMetricsCompletion()
+        }
+        .onDisappear {
+            cleanupModelCoordinator()
+        }
+    }
+
+    private var topTabs: some View {
+        HStack(spacing: 0) {
+            topTabButton(tab: .files, title: "Selections") {
+                selectionCountPill
+            }
+            topTabButton(tab: .prompt, title: "Prompt") {
+                Image(systemName: "wand.and.stars")
+                    .font(fontPreset.swiftUIFont(sizeAtNormal: 12, weight: .medium))
+            }
+            topTabButton(tab: .builder, title: "Context Builder") {
+                Image(systemName: "sparkles")
+                    .font(fontPreset.swiftUIFont(sizeAtNormal: 12, weight: .medium))
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, 20)
+        .background(Color(NSColor.controlBackgroundColor).opacity(0.12))
+    }
+
+    /// Compact `files | codemaps` count pill shown before the Selections tab label.
+    /// Resolved models use materialized row counts so this matches the Files/Codemaps subtabs.
+    private var selectionCountPill: some View {
+        let readiness = fileCodemapCountReadiness
+        return HStack(spacing: 4) {
+            countText(readiness.file)
+                .foregroundColor(countForegroundColor(readiness.file))
+            Rectangle()
+                .fill(Color.secondary.opacity(0.35))
+                .frame(width: 1, height: fontPreset.scaledMetric(9))
+            countText(readiness.codemap)
+                .foregroundColor(codemapCountForegroundColor(readiness.codemap))
+        }
+        .font(fontPreset.captionFont.weight(.semibold).monospacedDigit())
+        .padding(.horizontal, 5)
+        .padding(.vertical, 1)
+        .background(Capsule().fill(Color.secondary.opacity(0.12)))
+    }
+
+    private func countText(_ readiness: AgentContextCountReadiness) -> Text {
+        switch readiness {
+        case let .known(count):
+            Text("\(count)")
+        case .unknown:
+            Text("—")
+        }
+    }
+
+    private func countForegroundColor(_ readiness: AgentContextCountReadiness) -> Color? {
+        switch readiness {
+        case .known:
+            nil
+        case .unknown:
+            Color.secondary
+        }
+    }
+
+    private func codemapCountForegroundColor(_ readiness: AgentContextCountReadiness) -> Color? {
+        switch readiness {
+        case .known:
+            Color.accentColor
+        case .unknown:
+            Color.secondary
+        }
+    }
+
+    private func topTabButton(
+        tab: AgentContextDrawerUIStore.Tab,
+        title: String,
+        @ViewBuilder leading: () -> some View
+    ) -> some View {
+        let isActive = detailStore.activeTab == tab
+        let isHovered = hoveredTab == tab
+        return Button {
+            drawerStore.open(tab: tab)
+        } label: {
+            HStack(spacing: 5) {
+                leading()
+                Text(title)
+                    .font(fontPreset.captionFont.weight(.semibold))
+                    .lineLimit(2)
+                    .multilineTextAlignment(.center)
+                    .minimumScaleFactor(0.7)
+            }
+            .frame(maxWidth: .infinity, minHeight: 42)
+            .padding(.horizontal, 6)
+            .background(isHovered ? Color.primary.opacity(0.1) : Color.clear)
+            .foregroundColor(isActive ? Color.accentColor : Color.secondary)
+            .overlay(alignment: .bottom) {
+                Rectangle()
+                    .fill(isActive ? Color.accentColor : Color.secondary.opacity(0.2))
+                    .frame(height: isActive ? 2 : 1)
+            }
+            .contentShape(Rectangle())
+            .onHover { hovering in
+                hoveredTab = hovering ? tab : (hoveredTab == tab ? nil : hoveredTab)
+            }
+        }
+        .buttonStyle(.plain)
+        .disabled(isActive)
+    }
+
+    private func cleanupModelCoordinator() {
+        if isSwitchBlankingSelectedFiles {
+            modelCoordinator.cancelLoading(keepLoadedModel: false)
+            return
+        }
+        modelCoordinator.cancelLoading(keepLoadedModel: true)
+        guard !isSwitchBlankingTokenEstimate else { return }
+        selectedFilesBlankingIdentity = nil
+        tokenBlankingSelection = nil
+        observedSwitchKey = currentSwitchKey
+    }
+
+    private func handleDrawerPresented() {
+        if isSwitchBlankingSelectedFiles {
+            beginSwitchBlanking(for: currentSwitchKey)
+        } else {
+            clearCompletedSelectedFilesBlankingIfNeeded()
+            updateTokenBlankingSelectionIfNeeded()
+        }
+    }
+
+    private func handleSwitchKeyChange(_ newKey: AgentContextDrawerSwitchKey) {
+        guard isPresented else {
+            modelCoordinator.cancelLoading(keepLoadedModel: false)
+            return
+        }
+        beginSwitchBlanking(for: newKey)
+    }
+
+    private func beginSwitchBlanking(for newKey: AgentContextDrawerSwitchKey) {
+        let request = exportContext.makeModelRequest(flushPendingUI: false)
+        modelCoordinator.cancelLoading(keepLoadedModel: false)
+        selectedFilesBlankingIdentity = request.identity
+        captureTokenBlankingSelection()
+        modelCoordinator.refreshIfNeeded(request, force: true, preserveDisplayedModel: false)
+        observedSwitchKey = newKey
+        clearCompletedSelectedFilesBlankingIfNeeded(currentIdentity: request.identity)
+        clearCompletedTokenBlankingIfNeeded()
+    }
+
+    private func updateBlankingTargetsIfNeeded() {
+        if isSwitchBlankingSelectedFiles {
+            updateSwitchBlankingTargetIfNeeded()
+        } else {
+            updateTokenBlankingSelectionIfNeeded()
+        }
+    }
+
+    private func updateSwitchBlankingTargetIfNeeded() {
+        guard isPresented else { return }
+        guard isSwitchBlankingSelectedFiles else { return }
+        guard !hasPendingSwitchKeyChange else { return }
+        let request = exportContext.makeModelRequest(flushPendingUI: false)
+        let shouldRefreshTarget = selectedFilesBlankingIdentity != request.identity
+        selectedFilesBlankingIdentity = request.identity
+        captureTokenBlankingSelection()
+        if shouldRefreshTarget {
+            modelCoordinator.refreshIfNeeded(request, force: true, preserveDisplayedModel: false)
+        }
+        clearCompletedSelectedFilesBlankingIfNeeded(currentIdentity: request.identity)
+        clearCompletedTokenBlankingIfNeeded()
+    }
+
+    private func updateTokenBlankingSelectionIfNeeded() {
+        guard isPresented else { return }
+        guard tokenBlankingSelection != nil else { return }
+        captureTokenBlankingSelection()
+        clearCompletedTokenBlankingIfNeeded()
+    }
+
+    private func captureTokenBlankingSelection() {
+        tokenBlankingSelection = promptManager.tokenCountingViewModel.currentExpectedSelectionForPublishedSnapshot()
+    }
+
+    private func clearCompletedSelectedFilesBlankingIfNeeded(
+        currentIdentity: AgentSelectedFilesModelIdentity? = nil
+    ) {
+        let identity = currentIdentity ?? exportContext.modelRequestIdentity
+        guard selectedFilesBlankingIdentity == identity else { return }
+        guard modelCoordinator.completedModelMatches(identity) else { return }
+        selectedFilesBlankingIdentity = nil
+    }
+
+    private func handleTokenMetricsCompletion() {
+        clearCompletedTokenBlankingIfNeeded()
+        guard isPresented else { return }
+        let request = exportContext.makeModelRequest(flushPendingUI: false)
+        refreshSelectedFilesModelAfterTokenMetricsCompletion(
+            request: request,
+            coordinator: modelCoordinator
+        )
+    }
+
+    private func clearCompletedTokenBlankingIfNeeded() {
+        guard let tokenBlankingSelection else { return }
+        let snapshot = promptManager.tokenCountingViewModel.latestPublishedTokenSnapshot(
+            for: tokenBlankingSelection,
+            scheduleRefreshIfNeeded: false
+        )
+        guard snapshot.isComplete, !snapshot.isStale, !snapshot.refreshPending else { return }
+        self.tokenBlankingSelection = nil
+    }
+
+    private var header: some View {
+        HStack(spacing: 14) {
+            Text("Compose")
+                .font(fontPreset.swiftUIFont(sizeAtNormal: 15, weight: .semibold))
+
+            AgentContextDrawerTokenEstimatePill(
+                tokenCounter: promptManager.tokenCountingViewModel,
+                runtimeVM: runtimeVM,
+                fontPreset: fontPreset,
+                tokenBlankingSelection: tokenBlankingSelection
+            )
+
+            Spacer()
+
+            Button {
+                drawerStore.close()
+            } label: {
+                Image(systemName: "xmark")
+                    .font(fontPreset.swiftUIFont(sizeAtNormal: 13, weight: .semibold))
+                    .frame(width: 28, height: 28)
+            }
+            .buttonStyle(.plain)
+            .hoverTooltip("Close Compose")
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 14)
+    }
+
+    @ViewBuilder
+    private var tabContent: some View {
+        switch detailStore.activeTab {
+        case .files:
+            AgentContextDrawerFilesTab(
+                detailStore: detailStore,
+                modelCoordinator: modelCoordinator,
+                exportContext: exportContext,
+                isSwitchBlankingRows: isSwitchBlankingSelectedFiles
+            )
+        case .builder:
+            AgentContextDrawerBuilderTab(
+                contextBuilderAgentVM: contextBuilderAgentVM,
+                oracleViewModel: oracleViewModel,
+                windowID: windowID
+            )
+        case .prompt:
+            AgentContextDrawerPromptTab(
+                promptManager: promptManager,
+                modelCoordinator: modelCoordinator,
+                exportContext: exportContext,
+                isSwitchBlankingSelectedFiles: isSwitchBlankingSelectedFiles
+            )
+        }
+    }
+}

--- a/Sources/RepoPrompt/Features/AgentMode/Views/ContextDrawer/AgentContextDrawerBuilderTab.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/ContextDrawer/AgentContextDrawerBuilderTab.swift
@@ -1,0 +1,48 @@
+import Foundation
+import SwiftUI
+
+func agentContextDrawerGeneratedAnswerPopoverUserInfo(
+    windowID: Int,
+    route: ContextBuilderGeneratedAnswerRoute
+) -> [AnyHashable: Any]? {
+    contextBuilderOraclePopoverUserInfo(
+        openContext: AgentOracleOpenContext(
+            windowID: windowID,
+            workspaceID: route.workspaceID,
+            tabID: route.tabID,
+            chatID: route.chatID
+        ),
+        chatID: route.chatID
+    )
+}
+
+struct AgentContextDrawerBuilderTab: View {
+    @ObservedObject var contextBuilderAgentVM: ContextBuilderAgentViewModel
+    @ObservedObject var oracleViewModel: OracleViewModel
+    let windowID: Int
+
+    var body: some View {
+        GeometryReader { geometry in
+            ScrollView(.vertical, showsIndicators: true) {
+                ContextBuilderAgentView(
+                    viewModel: contextBuilderAgentVM,
+                    oracleViewModel: oracleViewModel,
+                    windowID: windowID,
+                    availableWidth: max(280, geometry.size.width - 40),
+                    openGeneratedAnswerChat: openGeneratedAnswerChat(route:)
+                )
+                .padding(.horizontal, 20)
+                .padding(.vertical, 16)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+
+    private func openGeneratedAnswerChat(route: ContextBuilderGeneratedAnswerRoute) {
+        guard let userInfo = agentContextDrawerGeneratedAnswerPopoverUserInfo(
+            windowID: windowID,
+            route: route
+        ) else { return }
+        NotificationCenter.default.post(name: .showAgentOraclePopover, object: nil, userInfo: userInfo)
+    }
+}

--- a/Sources/RepoPrompt/Features/AgentMode/Views/ContextDrawer/AgentContextDrawerFilesTab.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/ContextDrawer/AgentContextDrawerFilesTab.swift
@@ -1,0 +1,567 @@
+import SwiftUI
+
+func presentedSelectedContextCount(
+    authoritativeRowCount: Int?,
+    isSwitchBlankingRows: Bool
+) -> Int? {
+    guard !isSwitchBlankingRows else { return nil }
+    return authoritativeRowCount
+}
+
+struct AgentContextDrawerFilesTab: View {
+    @ObservedObject var detailStore: AgentContextDrawerDetailStore
+    @ObservedObject var modelCoordinator: AgentSelectedFilesModelCoordinator
+    let exportContext: AgentContextExportViewContext
+    let isSwitchBlankingRows: Bool
+
+    @ObservedObject private var fontScale = FontScaleManager.shared
+    @StateObject private var previewCoordinator = AgentSelectedFilePreviewLoadCoordinator()
+
+    private var fontPreset: FontScalePreset {
+        fontScale.preset
+    }
+
+    private var currentModel: AgentContextExportModel? {
+        modelCoordinator.model
+    }
+
+    private var isSwitchHidingRows: Bool {
+        isSwitchBlankingRows && !modelCoordinator.displayedModelMatches(exportContext.modelRequestIdentity)
+    }
+
+    private var rows: [AgentContextExportRow] {
+        isSwitchHidingRows ? [] : modelCoordinator.rowSplit.rows
+    }
+
+    private var selectedContextCount: Int? {
+        let authoritativeRowCount = modelCoordinator.displayedModelMatches(exportContext.modelRequestIdentity)
+            ? modelCoordinator.rowSplit.rows.count
+            : nil
+        return presentedSelectedContextCount(
+            authoritativeRowCount: authoritativeRowCount,
+            isSwitchBlankingRows: isSwitchBlankingRows
+        )
+    }
+
+    private var isResolvingWithoutModel: Bool {
+        modelCoordinator.isLoading && currentModel == nil
+    }
+
+    private var trimmedFilterText: String {
+        detailStore.fileFilterText.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var hasActiveFilter: Bool {
+        !trimmedFilterText.isEmpty
+    }
+
+    private var filteredRows: [AgentContextExportRow] {
+        let query = trimmedFilterText
+        guard !query.isEmpty else { return rows }
+        return rows.filter { row in
+            row.displayName.localizedCaseInsensitiveContains(query)
+                || row.displayPath.localizedCaseInsensitiveContains(query)
+                || row.rootDisplayName.localizedCaseInsensitiveContains(query)
+                || (row.physicalPath?.localizedCaseInsensitiveContains(query) ?? false)
+                || (row.directoryDisplay?.localizedCaseInsensitiveContains(query) ?? false)
+        }
+    }
+
+    private var sortedRows: [AgentContextExportRow] {
+        detailStore.selectionSort.sortedRows(filteredRows)
+    }
+
+    private var fileRows: [AgentContextExportRow] {
+        sortedRows.filter { $0.kind != .codemap }
+    }
+
+    private var codemapRows: [AgentContextExportRow] {
+        sortedRows.filter { $0.kind == .codemap }
+    }
+
+    private var displayedCountReadiness: AgentContextFileCodemapCountReadiness? {
+        guard !isSwitchHidingRows else { return nil }
+        return modelCoordinator.displayedFileCodemapCountReadiness(for: exportContext.modelRequestIdentity)
+    }
+
+    private var fileSubtabCountReadiness: AgentContextCountReadiness {
+        guard let displayedCountReadiness else { return .unknown }
+        return switch displayedCountReadiness.file {
+        case .known:
+            .known(fileRows.count)
+        case .unknown:
+            .unknown
+        }
+    }
+
+    private var codemapSubtabCountReadiness: AgentContextCountReadiness {
+        guard let displayedCountReadiness else { return .unknown }
+        return switch displayedCountReadiness.codemap {
+        case let .known(count) where count == modelCoordinator.rowSplit.codemapRows.count:
+            .known(codemapRows.count)
+        case let .known(count):
+            hasActiveFilter ? .unknown : .known(count)
+        case .unknown:
+            .unknown
+        }
+    }
+
+    private var isAwaitingCodemapRows: Bool {
+        guard detailStore.filesSubtab == .codemaps, codemapRows.isEmpty else { return false }
+        return switch codemapSubtabCountReadiness {
+        case .known:
+            false
+        case .unknown:
+            true
+        }
+    }
+
+    private var activeRows: [AgentContextExportRow] {
+        switch detailStore.filesSubtab {
+        case .files: fileRows
+        case .codemaps: codemapRows
+        }
+    }
+
+    private var previewVisibleRows: [AgentContextExportRow] {
+        isSwitchHidingRows ? [] : activeRows
+    }
+
+    private var canMutateCurrentModel: Bool {
+        guard !isSwitchBlankingRows else { return false }
+        guard !exportContext.promptManager.isSwitchingComposeTab else { return false }
+        guard modelCoordinator.canMutateDisplayedModel else { return false }
+        guard let model = currentModel,
+              let sourceTabID = model.source.tabID,
+              let selectionCoordinator = exportContext.selectionCoordinator
+        else { return false }
+        return selectionCoordinator.activeTabID() == sourceTabID
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            controls
+            subtabSwitcher
+            content
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 16)
+        .onAppear {
+            refreshIfNeeded()
+            adjustActiveSubtab()
+        }
+        .onDisappear {
+            previewCoordinator.reconcileVisibleRows([])
+            if !isSwitchBlankingRows {
+                modelCoordinator.cancelLoading(keepLoadedModel: true)
+            }
+        }
+        .onReceive(exportContext.selectionChangesPublisher) { change in
+            guard !isSwitchBlankingRows else { return }
+            guard !exportContext.promptManager.isSwitchingComposeTab else { return }
+            handleSelectionChange(change, isVisible: true)
+        }
+        .onChange(of: exportContext.modelRequestIdentity) { _, _ in
+            guard !isSwitchBlankingRows else { return }
+            guard !exportContext.promptManager.isSwitchingComposeTab else { return }
+            resetOrRefresh(isVisible: true)
+        }
+        .onChange(of: fileRows.count) { _, _ in adjustActiveSubtab() }
+        .onChange(of: codemapRows.count) { _, _ in adjustActiveSubtab() }
+        .onChange(of: isAwaitingCodemapRows) { _, _ in adjustActiveSubtab() }
+        .onChange(of: detailStore.filesSubtab) { _, _ in
+            previewCoordinator.reconcileVisibleRows(previewVisibleRows)
+        }
+        .onChange(of: sortedRows.map(\.id)) { _, _ in
+            previewCoordinator.reconcileVisibleRows(previewVisibleRows)
+        }
+        .onChange(of: isSwitchHidingRows) { _, _ in
+            previewCoordinator.reconcileVisibleRows(previewVisibleRows)
+        }
+    }
+
+    private var controls: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 8) {
+                filterField
+                sortControl
+            }
+
+            HStack(spacing: 8) {
+                if let selectedContextCount {
+                    Text("Selected context: \(selectedContextCount)")
+                        .font(fontPreset.captionFont.weight(.medium))
+                        .foregroundStyle(.secondary)
+                }
+                if hasActiveFilter {
+                    Text("\(filteredRows.count) matching")
+                        .font(fontPreset.captionFont)
+                        .foregroundStyle(.tertiary)
+                }
+                Spacer()
+                Button {
+                    guard let model = currentModel else { return }
+                    clearSelection(for: model)
+                } label: {
+                    Label("Clear", systemImage: "xmark.circle")
+                        .font(fontPreset.captionFont)
+                }
+                .buttonStyle(CustomButtonStyle(verticalPadding: 4, horizontalPadding: 9))
+                .disabled(rows.isEmpty || !canMutateCurrentModel || currentModel == nil)
+                .hoverTooltip(canMutateCurrentModel ? "Clear selected context" : "Selection mutation is unavailable for this Agent context")
+            }
+        }
+    }
+
+    private var filterField: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(.secondary)
+            TextField("Filter selected files", text: $detailStore.fileFilterText)
+                .textFieldStyle(.plain)
+            if !detailStore.fileFilterText.isEmpty {
+                Button {
+                    detailStore.fileFilterText = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.tertiary)
+                }
+                .buttonStyle(.plain)
+                .hoverTooltip("Clear filter")
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .frame(maxWidth: .infinity)
+        .background(Color(NSColor.textBackgroundColor).opacity(0.65))
+        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .stroke(Color.secondary.opacity(0.18), lineWidth: 0.5)
+        )
+    }
+
+    private var sortControl: some View {
+        Menu {
+            ForEach(AgentContextDrawerUIStore.SelectionSort.allCases) { sort in
+                Button {
+                    detailStore.selectionSort = sort
+                } label: {
+                    HStack {
+                        Text(sort.label)
+                        if sort == detailStore.selectionSort {
+                            Spacer()
+                            Image(systemName: "checkmark")
+                        }
+                    }
+                }
+            }
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: "line.3.horizontal.decrease")
+                    .font(fontPreset.swiftUIFont(sizeAtNormal: 11, weight: .medium))
+                Text("Sort")
+                Text(detailStore.selectionSort.label)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(.primary)
+            }
+            .font(fontPreset.captionFont)
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
+            .background(Color(NSColor.textBackgroundColor).opacity(0.65))
+            .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .stroke(Color.secondary.opacity(0.18), lineWidth: 0.5)
+            )
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
+        .hoverTooltip("Sort selected context")
+    }
+
+    private var subtabSwitcher: some View {
+        HStack(spacing: 0) {
+            subtabButton(icon: "doc.text", title: "Files", count: fileSubtabCountReadiness, subtab: .files)
+            subtabButton(
+                icon: "square.grid.2x2",
+                title: "Codemaps",
+                count: codemapSubtabCountReadiness,
+                subtab: .codemaps
+            )
+        }
+        .background(Color(NSColor.controlBackgroundColor).opacity(0.28))
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(Color.secondary.opacity(0.16), lineWidth: 0.5)
+        )
+    }
+
+    private func subtabButton(
+        icon: String,
+        title: String,
+        count: AgentContextCountReadiness,
+        subtab: AgentContextDrawerUIStore.FilesSubtab
+    ) -> some View {
+        let isActive = detailStore.filesSubtab == subtab
+        return Button {
+            detailStore.filesSubtab = subtab
+        } label: {
+            HStack(spacing: 7) {
+                Image(systemName: icon)
+                    .font(fontPreset.swiftUIFont(sizeAtNormal: 12, weight: .medium))
+                Text(title)
+                    .font(fontPreset.captionFont.weight(.semibold))
+                countText(count)
+                    .font(fontPreset.captionFont.weight(.medium))
+                    .foregroundStyle(countForegroundStyle(count, isActive: isActive))
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 9)
+            .frame(maxWidth: .infinity)
+            .foregroundStyle(isActive ? Color.primary : Color.secondary)
+            .background(isActive ? Color.accentColor.opacity(0.16) : Color.clear)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(isActive)
+    }
+
+    private func countText(_ readiness: AgentContextCountReadiness) -> Text {
+        switch readiness {
+        case let .known(count):
+            Text("\(count)")
+        case .unknown:
+            Text("—")
+        }
+    }
+
+    private func countForegroundStyle(
+        _ readiness: AgentContextCountReadiness,
+        isActive: Bool
+    ) -> HierarchicalShapeStyle {
+        switch readiness {
+        case .known:
+            isActive ? .primary : .secondary
+        case .unknown:
+            .secondary
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if isSwitchHidingRows || (modelCoordinator.isLoading && currentModel == nil) {
+            ProgressView()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if rows.isEmpty {
+            emptyState(
+                icon: "doc.text.magnifyingglass",
+                title: "No selected context",
+                subtitle: "Selections appear here when the agent or workspace selection adds files."
+            )
+        } else if isAwaitingCodemapRows {
+            ProgressView()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if filteredRows.isEmpty {
+            emptyState(
+                icon: "line.3.horizontal.decrease.circle",
+                title: "No matches",
+                subtitle: "No selected files match this filter."
+            )
+        } else if activeRows.isEmpty {
+            emptyState(
+                icon: detailStore.filesSubtab == .files ? "doc.text" : "square.grid.2x2",
+                title: detailStore.filesSubtab == .files ? "No files" : "No codemaps",
+                subtitle: detailStore.filesSubtab == .files
+                    ? "Full files and sliced files appear in this subtab."
+                    : "Codemap-only files appear in this subtab."
+            )
+        } else {
+            ScrollView(.vertical, showsIndicators: true) {
+                LazyVStack(alignment: .leading, spacing: 8) {
+                    ForEach(activeRows) { row in
+                        selectedFileCard(row)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.trailing, 4)
+                .padding(.bottom, 20)
+            }
+        }
+    }
+
+    private func selectedFileCard(_ row: AgentContextExportRow) -> some View {
+        AgentContextSelectedFileCard(
+            row: row,
+            canRemove: canMutateCurrentModel && row.canRemove,
+            previewCoordinator: previewCoordinator,
+            onLoadContent: { row, purpose in
+                guard let model = currentModel else { return nil }
+                return await AgentContextExportResolver.loadRowContent(
+                    for: row,
+                    model: model,
+                    store: exportContext.promptManager.workspaceFileContextStore,
+                    purpose: purpose
+                )
+            },
+            onPromoteToFullFile: canMutateCurrentModel ? { row in
+                guard let model = currentModel else { return }
+                promoteToFullFile(row, from: model)
+            } : nil,
+            onDemoteToCodemap: canMutateCurrentModel ? { row in
+                guard let model = currentModel else { return }
+                demoteToCodemap(row, from: model)
+            } : nil,
+            onClearSlices: canMutateCurrentModel ? { row in
+                guard let model = currentModel else { return }
+                clearSlices(row, from: model)
+            } : nil,
+            onRemove: { row in
+                guard let model = currentModel else { return }
+                remove(row, from: model)
+            }
+        )
+    }
+
+    private func refreshIfNeeded(force: Bool = false, preserveDisplayedModel: Bool = false) {
+        guard !isSwitchBlankingRows else { return }
+        guard !exportContext.promptManager.isSwitchingComposeTab else { return }
+        modelCoordinator.refreshIfNeeded(
+            exportContext.makeModelRequest(flushPendingUI: true),
+            force: force,
+            preserveDisplayedModel: preserveDisplayedModel
+        )
+    }
+
+    private func resetOrRefresh(isVisible: Bool) {
+        guard !isSwitchBlankingRows else { return }
+        guard !exportContext.promptManager.isSwitchingComposeTab else { return }
+        modelCoordinator.invalidate()
+        if isVisible {
+            refreshIfNeeded()
+        }
+    }
+
+    private func handleSelectionChange(_ change: WorkspaceSelectionCoordinator.Change, isVisible: Bool) {
+        guard exportContext.tabMatchesSelectionChange(change) else { return }
+        if isVisible {
+            refreshIfNeeded(force: true, preserveDisplayedModel: true)
+        } else {
+            modelCoordinator.invalidate()
+        }
+    }
+
+    private func clearSelection(for model: AgentContextExportModel) {
+        guard let target = exportContext.activeSelectionMutationTarget(for: model.source) else { return }
+        let updated = AgentContextExportResolver.removeSelectionSnapshot(
+            model.source.selection,
+            from: target.expectedSelection
+        )
+        Task {
+            await exportContext.persistSelection(updated, target: target)
+            await MainActor.run { refreshIfNeeded(force: true) }
+        }
+    }
+
+    private func remove(_ row: AgentContextExportRow, from model: AgentContextExportModel) {
+        guard row.canRemove,
+              let target = exportContext.activeSelectionMutationTarget(for: model.source)
+        else { return }
+        Task {
+            let updated = await AgentContextExportResolver.removeRow(
+                row,
+                from: target.expectedSelection,
+                lookupContext: model.lookupContext,
+                store: exportContext.promptManager.workspaceFileContextStore
+            )
+            await exportContext.persistSelection(updated, target: target)
+            await MainActor.run { refreshIfNeeded(force: true) }
+        }
+    }
+
+    private func promoteToFullFile(_ row: AgentContextExportRow, from model: AgentContextExportModel) {
+        guard row.canPromoteToFullFile else { return }
+        mutateSelectionPath(row, model: model) { selectionCoordinator, path, lookupContext, target in
+            await selectionCoordinator.promotePathsInSelection(
+                paths: [path],
+                for: target.identity,
+                expectedCurrentSelection: target.expectedSelection,
+                lookupContext: lookupContext
+            )
+        }
+    }
+
+    private func demoteToCodemap(_ row: AgentContextExportRow, from model: AgentContextExportModel) {
+        guard row.canDemoteToCodemap else { return }
+        mutateSelectionPath(row, model: model) { selectionCoordinator, path, lookupContext, target in
+            await selectionCoordinator.demotePathsInSelection(
+                paths: [path],
+                for: target.identity,
+                expectedCurrentSelection: target.expectedSelection,
+                lookupContext: lookupContext
+            )
+        }
+    }
+
+    private func clearSlices(_ row: AgentContextExportRow, from model: AgentContextExportModel) {
+        guard row.canClearSlices else { return }
+        mutateSelectionPath(row, model: model) { selectionCoordinator, path, lookupContext, target in
+            await selectionCoordinator.clearSlicesInSelection(
+                paths: [path],
+                for: target.identity,
+                expectedCurrentSelection: target.expectedSelection,
+                lookupContext: lookupContext
+            )
+        }
+    }
+
+    private func mutateSelectionPath(
+        _ row: AgentContextExportRow,
+        model: AgentContextExportModel,
+        operation: @escaping (
+            WorkspaceSelectionCoordinator,
+            String,
+            WorkspaceLookupContext,
+            AgentContextSelectionMutationTarget
+        ) async -> Void
+    ) {
+        guard let selectionCoordinator = exportContext.selectionCoordinator,
+              let target = exportContext.activeSelectionMutationTarget(for: model.source)
+        else { return }
+        let path = row.physicalPath ?? row.displayPath
+        Task {
+            await operation(selectionCoordinator, path, model.lookupContext, target)
+            await MainActor.run { refreshIfNeeded(force: true) }
+        }
+    }
+
+    private func emptyState(icon: String, title: String, subtitle: String) -> some View {
+        VStack(spacing: 10) {
+            Image(systemName: icon)
+                .font(.system(size: 34))
+                .foregroundStyle(.secondary.opacity(0.45))
+            Text(title)
+                .font(fontPreset.standardFont.weight(.semibold))
+                .foregroundStyle(.secondary)
+            Text(subtitle)
+                .font(fontPreset.captionFont)
+                .foregroundStyle(.tertiary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 320)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func adjustActiveSubtab() {
+        guard !isSwitchBlankingRows else { return }
+        guard !exportContext.promptManager.isSwitchingComposeTab else { return }
+        guard !isResolvingWithoutModel else { return }
+        if detailStore.filesSubtab == .files, fileRows.isEmpty, !codemapRows.isEmpty {
+            detailStore.filesSubtab = .codemaps
+        } else if detailStore.filesSubtab == .codemaps, codemapRows.isEmpty, !fileRows.isEmpty, !isAwaitingCodemapRows {
+            detailStore.filesSubtab = .files
+        }
+    }
+}

--- a/Sources/RepoPrompt/Features/AgentMode/Views/ContextDrawer/AgentContextDrawerPromptTab.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/ContextDrawer/AgentContextDrawerPromptTab.swift
@@ -1,0 +1,1270 @@
+import SwiftUI
+
+struct AgentContextDrawerPromptTab: View {
+    @ObservedObject var promptManager: PromptViewModel
+    @ObservedObject var modelCoordinator: AgentSelectedFilesModelCoordinator
+    let exportContext: AgentContextExportViewContext
+    let isSwitchBlankingSelectedFiles: Bool
+
+    @ObservedObject private var fontScale = FontScaleManager.shared
+    @State private var copyStatus: CopyStatus = .idle
+    @State private var showCopyPresetPopover = false
+    @State private var showFileTreePopover = false
+    @State private var showCodeMapPopover = false
+    @State private var showGitPopover = false
+    @State private var showPromptsPopover = false
+
+    private enum CopyStatus: Equatable {
+        case idle
+        case copying
+        case copied
+    }
+
+    struct PresetOption: Identifiable {
+        let id: UUID
+        let label: String
+        let icon: String
+        let description: String
+    }
+
+    struct RenderState {
+        let presetOptions: [PresetOption]
+        let selectedOption: PresetOption
+        let resolvedConfig: PromptContextResolved
+        let isManualPreset: Bool
+        let selectedPromptIDs: Set<UUID>
+        let selectedPrompts: [PromptViewModel.StoredPrompt]
+
+        var selectedPresetID: UUID {
+            selectedOption.id
+        }
+    }
+
+    private struct PresetPresentation {
+        let id: UUID
+        let label: String
+        let icon: String
+    }
+
+    private static let basePresetPresentations = [
+        PresetPresentation(id: BuiltInCopyPresets.standard.id, label: "Standard", icon: "doc.text"),
+        PresetPresentation(id: BuiltInCopyPresets.plan.id, label: "Plan · Architect", icon: "building.columns"),
+        PresetPresentation(id: BuiltInCopyPresets.codeReview.id, label: "Review", icon: "checklist"),
+        PresetPresentation(id: BuiltInCopyPresets.manual.id, label: "Manual", icon: "slider.horizontal.3")
+    ]
+
+    private var fontPreset: FontScalePreset {
+        fontScale.preset
+    }
+
+    var body: some View {
+        let state = makeRenderState()
+
+        ScrollView(.vertical, showsIndicators: true) {
+            VStack(alignment: .leading, spacing: 16) {
+                AgentContextPromptInstructionsEditor(
+                    text: $promptManager.promptText,
+                    fontPreset: fontPreset
+                )
+
+                composeControlsSection(state)
+            }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 16)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .onAppear {
+            refreshIfNeeded()
+        }
+        .onDisappear {
+            if !isSwitchBlankingSelectedFiles {
+                modelCoordinator.cancelLoading(keepLoadedModel: true)
+            }
+        }
+        .onReceive(exportContext.selectionChangesPublisher) { change in
+            guard !isSwitchBlankingSelectedFiles else { return }
+            guard !exportContext.promptManager.isSwitchingComposeTab else { return }
+            handleSelectionChange(change, isVisible: true)
+        }
+        .onChange(of: exportContext.modelRequestIdentity) { _, _ in
+            guard !isSwitchBlankingSelectedFiles else { return }
+            guard !exportContext.promptManager.isSwitchingComposeTab else { return }
+            resetOrRefresh(isVisible: true)
+        }
+        .onChange(of: state.selectedPresetID) { _, _ in
+            guard !isSwitchBlankingSelectedFiles else { return }
+            guard !exportContext.promptManager.isSwitchingComposeTab else { return }
+            copyStatus = .idle
+            refreshIfNeeded()
+        }
+    }
+
+    private func refreshIfNeeded(force: Bool = false, preserveDisplayedModel: Bool = false) {
+        guard !isSwitchBlankingSelectedFiles else { return }
+        guard !exportContext.promptManager.isSwitchingComposeTab else { return }
+        modelCoordinator.refreshIfNeeded(
+            exportContext.makeModelRequest(flushPendingUI: true),
+            force: force,
+            preserveDisplayedModel: preserveDisplayedModel
+        )
+    }
+
+    private func resetOrRefresh(isVisible: Bool) {
+        guard !isSwitchBlankingSelectedFiles else { return }
+        guard !exportContext.promptManager.isSwitchingComposeTab else { return }
+        modelCoordinator.invalidate()
+        if isVisible {
+            refreshIfNeeded()
+        }
+    }
+
+    private func handleSelectionChange(_ change: WorkspaceSelectionCoordinator.Change, isVisible: Bool) {
+        guard exportContext.tabMatchesSelectionChange(change) else { return }
+        if isVisible {
+            refreshIfNeeded(force: true, preserveDisplayedModel: true)
+        } else {
+            modelCoordinator.invalidate()
+        }
+    }
+
+    func makeRenderState() -> RenderState {
+        let currentPreset = promptManager.currentCopyPreset()
+        let presetOptions = makePresetOptions(currentPreset: currentPreset)
+        let selectedOption = presetOptions.first { $0.id == currentPreset.id }!
+        let isManualPreset = currentPreset.builtInKind == .manual
+        let resolvedConfig = promptManager.resolvePromptContext()
+        let selectedPromptIDs = if isManualPreset {
+            promptManager.promptSelection(for: .copy)
+        } else {
+            Set(resolvedConfig.storedPromptIds ?? currentPreset.storedPromptIds ?? [])
+        }
+        let selectedPrompts = promptManager.storedPrompts.filter { selectedPromptIDs.contains($0.id) }
+
+        return RenderState(
+            presetOptions: presetOptions,
+            selectedOption: selectedOption,
+            resolvedConfig: resolvedConfig,
+            isManualPreset: isManualPreset,
+            selectedPromptIDs: selectedPromptIDs,
+            selectedPrompts: selectedPrompts
+        )
+    }
+
+    private func makePresetOptions(currentPreset: CopyPreset) -> [PresetOption] {
+        let presetManager = CopyPresetManager.shared
+        var options = Self.basePresetPresentations.map { presentation in
+            let preset = presetManager.preset(with: presentation.id)!
+            return PresetOption(
+                id: preset.id,
+                label: presentation.label,
+                icon: presentation.icon,
+                description: preset.description ?? copyPresetFallbackDescription(preset)
+            )
+        }
+        if !options.contains(where: { $0.id == currentPreset.id }) {
+            options.append(
+                PresetOption(
+                    id: currentPreset.id,
+                    label: currentPreset.name,
+                    icon: "doc.text",
+                    description: currentPreset.description ?? copyPresetFallbackDescription(currentPreset)
+                )
+            )
+        }
+        return options
+    }
+
+    private func composeControlsSection(_ state: RenderState) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            LazyVGrid(
+                columns: [GridItem(.adaptive(minimum: 145), spacing: 8, alignment: .topLeading)],
+                alignment: .leading,
+                spacing: 8
+            ) {
+                copyPresetButton(state)
+                promptsButton(state)
+                fileTreeButton(state)
+                codeMapButton(state)
+                gitButton(state)
+                copyButtonGridCell(state)
+            }
+        }
+        .padding(12)
+        .background(Color(NSColor.controlBackgroundColor).opacity(0.24))
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(Color.secondary.opacity(0.14), lineWidth: 0.5)
+        )
+    }
+
+    private func copyPresetButton(_ state: RenderState) -> some View {
+        Button {
+            showCopyPresetPopover.toggle()
+        } label: {
+            AgentContextDrawerControlLabel(
+                title: "Copy Preset",
+                value: state.selectedOption.label,
+                icon: state.selectedOption.icon,
+                tint: .accentColor,
+                fontPreset: fontPreset
+            )
+        }
+        .buttonStyle(.plain)
+        .popover(isPresented: $showCopyPresetPopover, arrowEdge: .bottom) {
+            copyPresetPopover(state)
+        }
+        .hoverTooltip("Choose clipboard packaging preset")
+    }
+
+    private func promptsButton(_ state: RenderState) -> some View {
+        Button {
+            showPromptsPopover.toggle()
+        } label: {
+            AgentContextDrawerControlLabel(
+                title: "Prompts",
+                value: promptSummaryText(state),
+                icon: "text.quote",
+                tint: .teal,
+                fontPreset: fontPreset
+            )
+        }
+        .buttonStyle(.plain)
+        .popover(isPresented: $showPromptsPopover, arrowEdge: .bottom) {
+            promptsPopover(state)
+        }
+        .hoverTooltip(state.isManualPreset ? "Choose stored prompts" : "View preset-supplied prompts")
+    }
+
+    private func fileTreeButton(_ state: RenderState) -> some View {
+        Button {
+            showFileTreePopover.toggle()
+        } label: {
+            AgentContextDrawerControlLabel(
+                title: "File Tree",
+                value: fileTreeLabel(state.resolvedConfig.effectiveFileTreeMode),
+                icon: fileTreeIcon(state.resolvedConfig.effectiveFileTreeMode),
+                tint: .purple,
+                fontPreset: fontPreset
+            )
+        }
+        .buttonStyle(.plain)
+        .popover(isPresented: $showFileTreePopover, arrowEdge: .bottom) {
+            fileTreePopover(state)
+        }
+        .hoverTooltip(state.resolvedConfig.effectiveFileTreeMode.caption)
+    }
+
+    private func codeMapButton(_ state: RenderState) -> some View {
+        Button {
+            showCodeMapPopover.toggle()
+        } label: {
+            AgentContextDrawerControlLabel(
+                title: "Code Map",
+                value: codeMapLabel(state.resolvedConfig.codeMapUsage),
+                icon: codeMapIcon(state.resolvedConfig.codeMapUsage),
+                tint: .indigo,
+                fontPreset: fontPreset
+            )
+        }
+        .buttonStyle(.plain)
+        .popover(isPresented: $showCodeMapPopover, arrowEdge: .bottom) {
+            codeMapPopover(state)
+        }
+        .hoverTooltip(state.resolvedConfig.codeMapUsage.caption)
+    }
+
+    private func gitButton(_ state: RenderState) -> some View {
+        Button {
+            showGitPopover.toggle()
+        } label: {
+            AgentContextDrawerControlLabel(
+                title: "Git",
+                value: gitLabel(state.resolvedConfig.gitInclusion),
+                icon: gitIcon(state.resolvedConfig.gitInclusion),
+                tint: .orange,
+                fontPreset: fontPreset
+            )
+        }
+        .buttonStyle(.plain)
+        .popover(isPresented: $showGitPopover, arrowEdge: .bottom) {
+            gitPopover(state)
+        }
+        .hoverTooltip("Choose git diff inclusion for copied context")
+    }
+
+    private func copyButtonGridCell(_ state: RenderState) -> some View {
+        copyButton(state)
+            .frame(maxWidth: .infinity, minHeight: fontPreset.scaledMetric(50), alignment: .center)
+    }
+
+    private func copyButton(_ state: RenderState) -> some View {
+        Button {
+            copyPromptContext()
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: copyButtonIcon)
+                Text(copyButtonTitle)
+            }
+            .font(fontPreset.captionFont.weight(.semibold))
+        }
+        .buttonStyle(CustomButtonStyle(verticalPadding: 6, horizontalPadding: 12, height: 30))
+        .disabled(copyStatus == .copying)
+    }
+
+    private func copyPresetPopover(_ state: RenderState) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            popoverHeader(
+                title: "Copy Preset",
+                subtitle: "Choose how the current prompt and selected context are packaged."
+            )
+
+            VStack(alignment: .leading, spacing: 4) {
+                ForEach(state.presetOptions) { option in
+                    popoverOptionRow(
+                        title: option.label,
+                        subtitle: option.description,
+                        icon: option.icon,
+                        isSelected: option.id == state.selectedPresetID
+                    ) {
+                        promptManager.selectCopyPreset(option.id)
+                        copyStatus = .idle
+                        showCopyPresetPopover = false
+                    }
+                }
+            }
+        }
+        .padding(12)
+        .frame(width: 360)
+    }
+
+    private func fileTreePopover(_ state: RenderState) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            popoverHeader(
+                title: "File Tree",
+                subtitle: "Choose the project structure map included in copied context."
+            )
+
+            VStack(alignment: .leading, spacing: 4) {
+                ForEach(FileTreeOption.allCases) { option in
+                    popoverOptionRow(
+                        title: fileTreeLabel(option),
+                        subtitle: option.caption,
+                        icon: fileTreeIcon(option),
+                        isSelected: option == state.resolvedConfig.effectiveFileTreeMode
+                    ) {
+                        promptManager.updateFileTreeOption(option)
+                        copyStatus = .idle
+                        showFileTreePopover = false
+                    }
+                }
+            }
+        }
+        .padding(12)
+        .frame(width: 360)
+    }
+
+    private func codeMapPopover(_ state: RenderState) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            popoverHeader(
+                title: "Code Map",
+                subtitle: "Choose how source structure is represented in copied context."
+            )
+
+            VStack(alignment: .leading, spacing: 4) {
+                ForEach(CodeMapUsage.allCases, id: \.rawValue) { usage in
+                    popoverOptionRow(
+                        title: codeMapLabel(usage),
+                        subtitle: usage.caption,
+                        icon: codeMapIcon(usage),
+                        isSelected: usage == state.resolvedConfig.codeMapUsage
+                    ) {
+                        promptManager.updateCodeMapUsage(usage)
+                        copyStatus = .idle
+                        showCodeMapPopover = false
+                    }
+                }
+            }
+        }
+        .padding(12)
+        .frame(width: 360)
+    }
+
+    private func gitPopover(_ state: RenderState) -> some View {
+        AgentContextDrawerGitPopover(
+            gitViewModel: promptManager.gitViewModel,
+            currentInclusion: state.resolvedConfig.gitInclusion,
+            fontPreset: fontPreset,
+            onInclusionChange: { inclusion in
+                updateGitInclusion(inclusion, closesPopover: false)
+            }
+        )
+        .onAppear {
+            promptManager.gitViewModel.isPopoverVisible = true
+            Task {
+                await promptManager.gitViewModel.fetchUnstagedFiles(trigger: .popoverOpen)
+            }
+        }
+        .onDisappear {
+            promptManager.gitViewModel.isPopoverVisible = false
+        }
+    }
+
+    private func promptsPopover(_ state: RenderState) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            popoverHeader(
+                title: "Prompts",
+                subtitle: state.isManualPreset
+                    ? "Choose stored prompts for Manual copy mode."
+                    : "This preset supplies its stored prompt selection."
+            )
+
+            if promptManager.storedPrompts.isEmpty {
+                emptyPopoverText("No stored prompts available")
+            } else if state.isManualPreset {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 4) {
+                        ForEach(promptManager.storedPrompts) { prompt in
+                            promptSelectionRow(
+                                prompt,
+                                isSelected: state.selectedPromptIDs.contains(prompt.id),
+                                isEditable: true
+                            ) {
+                                toggleManualPrompt(prompt)
+                            }
+                        }
+                    }
+                }
+                .frame(maxHeight: 320)
+            } else if state.selectedPrompts.isEmpty {
+                emptyPopoverText("No stored prompts selected")
+            } else {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 4) {
+                        ForEach(state.selectedPrompts) { prompt in
+                            promptSelectionRow(prompt, isSelected: true, isEditable: false) {}
+                        }
+                    }
+                }
+                .frame(maxHeight: 260)
+            }
+        }
+        .padding(12)
+        .frame(width: 380)
+    }
+
+    private func popoverHeader(title: String, subtitle: String) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title)
+                .font(fontPreset.standardFont.weight(.semibold))
+            Text(subtitle)
+                .font(fontPreset.captionFont)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private func popoverOptionRow(
+        title: String,
+        subtitle: String,
+        icon: String,
+        isSelected: Bool,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(spacing: 9) {
+                Image(systemName: icon)
+                    .font(fontPreset.swiftUIFont(sizeAtNormal: 12, weight: .medium))
+                    .foregroundStyle(isSelected ? Color.accentColor : Color.secondary)
+                    .frame(width: 18)
+
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(title)
+                        .font(fontPreset.captionFont.weight(.semibold))
+                        .foregroundStyle(.primary)
+                    Text(subtitle)
+                        .font(fontPreset.captionFont)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+
+                Spacer(minLength: 8)
+
+                if isSelected {
+                    Image(systemName: "checkmark")
+                        .font(fontPreset.swiftUIFont(sizeAtNormal: 11, weight: .semibold))
+                        .foregroundStyle(Color.accentColor)
+                }
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 7)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(isSelected ? Color.accentColor.opacity(0.10) : Color.clear)
+            .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+            .contentShape(Rectangle())
+            .textSelection(.disabled)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func promptSelectionRow(
+        _ prompt: PromptViewModel.StoredPrompt,
+        isSelected: Bool,
+        isEditable: Bool,
+        action: @escaping () -> Void
+    ) -> some View {
+        HStack(spacing: 8) {
+            Button(action: action) {
+                HStack(spacing: 7) {
+                    Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                        .font(fontPreset.swiftUIFont(sizeAtNormal: 12, weight: .medium))
+                        .foregroundStyle(isSelected ? Color.accentColor : Color.secondary)
+                    Text(prompt.title)
+                        .font(fontPreset.captionFont.weight(.medium))
+                        .lineLimit(1)
+                    Spacer(minLength: 4)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .disabled(!isEditable)
+
+            AgentContextStoredPromptPreviewButton(prompt: prompt)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 7)
+        .background(isSelected ? Color.teal.opacity(0.10) : Color(NSColor.controlBackgroundColor).opacity(0.18))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .textSelection(.disabled)
+    }
+
+    private func emptyPopoverText(_ text: String) -> some View {
+        Text(text)
+            .font(fontPreset.captionFont)
+            .foregroundStyle(.tertiary)
+            .italic()
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.vertical, 6)
+    }
+
+    private func promptSummaryText(_ state: RenderState) -> String {
+        guard state.resolvedConfig.includeMetaPrompts else { return "None" }
+        let count = state.selectedPrompts.count
+        return count == 0 ? "None" : "\(count) stored"
+    }
+
+    private func copyPresetFallbackDescription(_ preset: CopyPreset) -> String {
+        switch preset.builtInKind {
+        case .some(.standard):
+            "Balanced copy context for everyday work."
+        case .some(.plan):
+            "Planning handoff with the Architect stored prompt."
+        case .some(.codeReview):
+            "Review handoff with selected git diff context."
+        case .some(.manual):
+            "Use the current manual File Tree, Code Map, Git, and Prompt controls."
+        case .some(.diffFollowUp):
+            "Git-focused follow-up context."
+        case nil:
+            "Custom copy preset."
+        }
+    }
+
+    private func fileTreeLabel(_ option: FileTreeOption) -> String {
+        switch option {
+        case .none:
+            "None"
+        case .auto:
+            "Auto"
+        case .files:
+            "Full"
+        case .selected:
+            "Selected"
+        }
+    }
+
+    private func fileTreeIcon(_ option: FileTreeOption) -> String {
+        switch option {
+        case .none:
+            "xmark.circle"
+        case .auto:
+            "arrow.triangle.2.circlepath.circle"
+        case .files:
+            "list.bullet.rectangle"
+        case .selected:
+            "target"
+        }
+    }
+
+    private func codeMapLabel(_ usage: CodeMapUsage) -> String {
+        switch usage {
+        case .none:
+            "None"
+        case .selected:
+            "Selected"
+        case .auto:
+            "Auto"
+        case .complete:
+            "Complete"
+        }
+    }
+
+    private func codeMapIcon(_ usage: CodeMapUsage) -> String {
+        switch usage {
+        case .none:
+            "xmark.circle"
+        case .selected:
+            "target"
+        case .auto:
+            "arrow.triangle.2.circlepath.circle"
+        case .complete:
+            "checkmark.circle.fill"
+        }
+    }
+
+    private func gitLabel(_ inclusion: GitInclusion) -> String {
+        switch inclusion {
+        case .none:
+            "None"
+        case .selected:
+            "Selected"
+        case .complete:
+            "All"
+        }
+    }
+
+    private func gitCaption(_ inclusion: GitInclusion) -> String {
+        switch inclusion {
+        case .none:
+            "Do not include git diff context"
+        case .selected:
+            "Include selected git diff context"
+        case .complete:
+            "Include the complete git diff"
+        }
+    }
+
+    private func gitIcon(_ inclusion: GitInclusion) -> String {
+        switch inclusion {
+        case .none:
+            "circle"
+        case .selected:
+            "smallcircle.filled.circle"
+        case .complete:
+            "circle.fill"
+        }
+    }
+
+    private func updateGitInclusion(_ inclusion: GitInclusion, closesPopover: Bool = true) {
+        promptManager.updateGitInclusion(gitDiffMode(for: inclusion))
+        var customizations = promptManager.workingCopyCustomizations
+        customizations.gitInclusion = inclusion
+        promptManager.workingCopyCustomizations = customizations
+        copyStatus = .idle
+        if closesPopover {
+            showGitPopover = false
+        }
+    }
+
+    private func gitDiffMode(for inclusion: GitInclusion) -> GitDiffInclusionMode {
+        switch inclusion {
+        case .none:
+            .none
+        case .selected:
+            .selectedFiles
+        case .complete:
+            .all
+        }
+    }
+
+    private var copyButtonIcon: String {
+        switch copyStatus {
+        case .idle:
+            "doc.on.clipboard"
+        case .copying:
+            "hourglass"
+        case .copied:
+            "checkmark"
+        }
+    }
+
+    private var copyButtonTitle: String {
+        switch copyStatus {
+        case .idle:
+            "Copy Prompt"
+        case .copying:
+            "Copying"
+        case .copied:
+            "Copy Prompt"
+        }
+    }
+
+    private func copyPromptContext() {
+        let currentPreset = promptManager.currentCopyPreset()
+        let cfg = promptManager.resolvePromptContext()
+        copyStatus = .copying
+        let selectedPromptIDsOverride = currentPreset.builtInKind == .manual
+            ? promptManager.promptSelection(for: .copy).sorted { $0.uuidString < $1.uuidString }
+            : nil
+        Task {
+            let clipboard = await exportContext.buildClipboardContent(
+                for: cfg,
+                model: modelCoordinator.model,
+                selectedPromptIDsOverride: selectedPromptIDsOverride
+            )
+            await MainActor.run {
+                NSPasteboard.general.clearContents()
+                NSPasteboard.general.setString(clipboard, forType: .string)
+                copyStatus = .copied
+            }
+            try? await Task.sleep(nanoseconds: 500_000_000)
+            await MainActor.run {
+                if copyStatus == .copied {
+                    copyStatus = .idle
+                }
+            }
+        }
+    }
+
+    private func toggleManualPrompt(_ prompt: PromptViewModel.StoredPrompt) {
+        guard promptManager.currentCopyPreset().builtInKind == .manual else { return }
+        var next = promptManager.promptSelection(for: .copy)
+        if next.contains(prompt.id) {
+            next.remove(prompt.id)
+        } else {
+            next.insert(prompt.id)
+        }
+        promptManager.updatePromptSelection(next, for: .copy)
+        copyStatus = .idle
+    }
+}
+
+private struct AgentContextDrawerGitPopover: View {
+    @ObservedObject var gitViewModel: GitViewModel
+    let currentInclusion: GitInclusion
+    let fontPreset: FontScalePreset
+    let onInclusionChange: (GitInclusion) -> Void
+
+    @State private var isCopyingSelected = false
+    @State private var isCopyingAll = false
+    @State private var showCopiedSelectedFeedback = false
+    @State private var showCopiedAllFeedback = false
+
+    private var includeModeBinding: Binding<GitInclusion> {
+        Binding(
+            get: { currentInclusion },
+            set: { onInclusionChange($0) }
+        )
+    }
+
+    private var selectedVisibleFileCount: Int {
+        gitViewModel.filteredUnstagedFiles.count { gitViewModel.isFileSelected($0.path) }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            header
+            rootSection
+            includeModeSection
+            compareSection
+            changedFilesSection
+        }
+        .padding(12)
+        .frame(width: 460)
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text("Git")
+                .font(fontPreset.standardFont.weight(.semibold))
+            Text("Selected includes the checked pending changes below. Working changes are compared to the chosen target.")
+                .font(fontPreset.captionFont)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    @ViewBuilder
+    private var rootSection: some View {
+        if gitViewModel.gitEnabledRootFolders.isEmpty {
+            compactInfoRow(icon: "minus.circle", text: "No git repositories available in this workspace")
+        } else {
+            VStack(alignment: .leading, spacing: 5) {
+                HStack {
+                    Text("Root")
+                        .font(fontPreset.captionFont.weight(.semibold))
+                    Spacer()
+                    if let branch = gitViewModel.currentBranch {
+                        Text(branch)
+                            .font(fontPreset.captionFont)
+                            .foregroundStyle(.secondary)
+                            .padding(.horizontal, 7)
+                            .padding(.vertical, 3)
+                            .background(Color.secondary.opacity(0.10))
+                            .clipShape(Capsule())
+                    }
+                }
+
+                if gitViewModel.gitEnabledRootFolders.count > 1 {
+                    Picker("Root", selection: $gitViewModel.selectedRootFolder) {
+                        ForEach(gitViewModel.gitEnabledRootFolders, id: \.id) { folder in
+                            Text(folder.name).tag(folder as FolderViewModel?)
+                        }
+                    }
+                    .labelsHidden()
+                    .pickerStyle(.menu)
+                } else if let root = gitViewModel.selectedRootFolder ?? gitViewModel.gitEnabledRootFolders.first {
+                    Text(root.name)
+                        .font(fontPreset.captionFont)
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 6)
+                        .background(Color(NSColor.controlBackgroundColor).opacity(0.38))
+                        .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+                }
+            }
+        }
+    }
+
+    private var includeModeSection: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            Text("Include")
+                .font(fontPreset.captionFont.weight(.semibold))
+            Picker("Include", selection: includeModeBinding) {
+                Text("None").tag(GitInclusion.none)
+                Text("Selected").tag(GitInclusion.selected)
+                Text("All").tag(GitInclusion.complete)
+            }
+            .labelsHidden()
+            .pickerStyle(.segmented)
+        }
+    }
+
+    private var compareSection: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            Text("Compare working changes with")
+                .font(fontPreset.captionFont.weight(.semibold))
+            Picker("Compare", selection: $gitViewModel.selectedDiffBranch) {
+                Text(headCompareLabel).tag("HEAD")
+                if !gitViewModel.availableBranches.isEmpty {
+                    Divider()
+                    ForEach(gitViewModel.availableBranches, id: \.name) { branch in
+                        Text(branch.isCurrent ? "\(branch.name) (current)" : branch.name)
+                            .tag(branch.name)
+                    }
+                }
+                if !gitViewModel.availableRemoteBranches.isEmpty {
+                    Divider()
+                    ForEach(gitViewModel.availableRemoteBranches, id: \.name) { branch in
+                        Text(branch.name).tag(branch.name)
+                    }
+                }
+                if !gitViewModel.availableTags.isEmpty {
+                    Divider()
+                    ForEach(gitViewModel.availableTags, id: \.name) { tag in
+                        Text(tag.name).tag(tag.name)
+                    }
+                }
+            }
+            .labelsHidden()
+            .pickerStyle(.menu)
+            .disabled(!gitViewModel.hasValidRepository)
+        }
+    }
+
+    private var changedFilesSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 8) {
+                Text("Pending changes")
+                    .font(fontPreset.captionFont.weight(.semibold))
+                if !gitViewModel.unstagedFiles.isEmpty {
+                    Text("\(gitViewModel.unstagedFiles.count)")
+                        .font(fontPreset.captionFont)
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 1)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 4)
+                                .stroke(Color.secondary.opacity(0.28), lineWidth: 0.5)
+                        )
+                }
+                if gitViewModel.isLoadingStatus {
+                    ProgressView()
+                        .scaleEffect(0.5)
+                        .frame(width: 12, height: 12)
+                }
+                Spacer()
+            }
+
+            actionButtons
+
+            GitSearchField(gitViewModel: gitViewModel, fontPreset: fontPreset)
+
+            if let error = gitViewModel.errorMessage {
+                compactInfoRow(icon: "exclamationmark.triangle", text: error)
+                    .frame(height: 172)
+            } else if gitViewModel.filteredUnstagedFiles.isEmpty {
+                compactInfoRow(icon: "checkmark.circle", text: emptyChangedFilesText)
+                    .frame(height: 172)
+            } else {
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 2) {
+                        ForEach(gitViewModel.filteredUnstagedFiles, id: \.path) { file in
+                            AgentContextDrawerGitFileRow(
+                                gitViewModel: gitViewModel,
+                                file: file,
+                                fontPreset: fontPreset
+                            )
+                        }
+                    }
+                    .padding(6)
+                }
+                .frame(height: 172)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .stroke(Color.secondary.opacity(0.16), lineWidth: 0.5)
+                )
+            }
+
+            Text(selectedVisibleFileCount == 1 ? "1 visible file checked" : "\(selectedVisibleFileCount) visible files checked")
+                .font(fontPreset.captionFont)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var headCompareLabel: String {
+        if let currentBranch = gitViewModel.currentBranch {
+            return "HEAD (\(currentBranch))"
+        }
+        return "HEAD"
+    }
+
+    private var emptyChangedFilesText: String {
+        gitViewModel.fileSearchText.isEmpty ? "No pending changes" : "No changed files match the filter"
+    }
+
+    private var actionButtons: some View {
+        HStack(spacing: 6) {
+            Button("Select All") {
+                selectVisibleFiles()
+            }
+            .font(fontPreset.captionFont)
+            .buttonStyle(CustomButtonStyle(verticalPadding: 3, horizontalPadding: 7, height: 24))
+            .disabled(gitViewModel.filteredUnstagedFiles.isEmpty || gitViewModel.isBulkSelectionRunning)
+            .hoverTooltip("Add visible changed files to selection")
+
+            Button("Clear") {
+                clearSelectedChangedFiles()
+            }
+            .font(fontPreset.captionFont)
+            .buttonStyle(CustomButtonStyle(verticalPadding: 3, horizontalPadding: 7, height: 24))
+            .disabled(!gitViewModel.hasTrackedSelectedChangedFiles || gitViewModel.isBulkSelectionRunning)
+            .hoverTooltip("Remove selected changed files from selection")
+
+            Button(showCopiedSelectedFeedback ? "Copied!" : "Copy Selected") {
+                copySelectedDiff()
+            }
+            .font(fontPreset.captionFont)
+            .buttonStyle(CustomButtonStyle(verticalPadding: 3, horizontalPadding: 7, height: 24))
+            .disabled(!gitViewModel.hasCurrentSelectedChangedFiles || isCopyingSelected || showCopiedSelectedFeedback)
+            .opacity(showCopiedSelectedFeedback ? 0.7 : 1.0)
+            .hoverTooltip("Copy diff of selected files")
+
+            Button(showCopiedAllFeedback ? "Copied!" : "Copy All") {
+                copyAllDiff()
+            }
+            .font(fontPreset.captionFont)
+            .buttonStyle(CustomButtonStyle(verticalPadding: 3, horizontalPadding: 7, height: 24))
+            .disabled(gitViewModel.unstagedFiles.isEmpty || isCopyingAll || showCopiedAllFeedback)
+            .opacity(showCopiedAllFeedback ? 0.7 : 1.0)
+            .hoverTooltip("Copy diff of all working tree files")
+        }
+    }
+
+    private func selectVisibleFiles() {
+        Task {
+            await gitViewModel.addFilteredUnstagedToFileManager()
+        }
+    }
+
+    private func clearSelectedChangedFiles() {
+        Task {
+            await gitViewModel.clearSelectedChangedFilesFromFileManager()
+        }
+    }
+
+    private func copySelectedDiff() {
+        isCopyingSelected = true
+        Task { @MainActor in
+            let success = await gitViewModel.copySelectedDiff()
+            isCopyingSelected = false
+            guard success else { return }
+            showCopiedSelectedFeedback = true
+            try? await Task.sleep(nanoseconds: 1_500_000_000)
+            showCopiedSelectedFeedback = false
+        }
+    }
+
+    private func copyAllDiff() {
+        isCopyingAll = true
+        Task { @MainActor in
+            let success = await gitViewModel.copyAllDiff()
+            isCopyingAll = false
+            guard success else { return }
+            showCopiedAllFeedback = true
+            try? await Task.sleep(nanoseconds: 1_500_000_000)
+            showCopiedAllFeedback = false
+        }
+    }
+
+    private func compactInfoRow(icon: String, text: String) -> some View {
+        HStack(spacing: 7) {
+            Image(systemName: icon)
+                .foregroundStyle(.secondary)
+            Text(text)
+                .font(fontPreset.captionFont)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(8)
+        .background(Color(NSColor.controlBackgroundColor).opacity(0.24))
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+}
+
+private struct GitSearchField: View {
+    @ObservedObject var gitViewModel: GitViewModel
+    let fontPreset: FontScalePreset
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "magnifyingglass")
+                .font(fontPreset.captionFont)
+                .foregroundStyle(.secondary)
+            TextField("Filter changed files", text: $gitViewModel.fileSearchText)
+                .textFieldStyle(.plain)
+                .font(fontPreset.captionFont)
+            if !gitViewModel.fileSearchText.isEmpty {
+                Button {
+                    gitViewModel.clearFileSearch()
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(fontPreset.captionFont)
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 6)
+        .background(Color(NSColor.controlBackgroundColor).opacity(0.30))
+        .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+    }
+}
+
+private struct AgentContextDrawerGitFileRow: View {
+    @ObservedObject var gitViewModel: GitViewModel
+    let file: VCSUncommittedFile
+    let fontPreset: FontScalePreset
+
+    private var isSelected: Bool {
+        gitViewModel.isFileSelected(file.path)
+    }
+
+    var body: some View {
+        Button {
+            toggleSelection()
+        } label: {
+            HStack(spacing: 7) {
+                Image(systemName: isSelected ? "checkmark.square.fill" : "square")
+                    .font(fontPreset.swiftUIFont(sizeAtNormal: 13, weight: .medium))
+                    .foregroundStyle(isSelected ? Color.accentColor : Color.secondary)
+                    .frame(width: 16)
+
+                Text(file.status)
+                    .font(.system(size: fontPreset.scaledClamped(10, min: 10, max: 12), weight: .medium, design: .monospaced))
+                    .foregroundStyle(statusColor)
+                    .frame(width: 22, alignment: .leading)
+
+                HStack(spacing: 3) {
+                    if let additions = file.additions, additions > 0 {
+                        Text("+\(additions)")
+                            .foregroundStyle(.green)
+                    }
+                    if let deletions = file.deletions, deletions > 0 {
+                        Text("-\(deletions)")
+                            .foregroundStyle(.red)
+                    }
+                }
+                .font(.system(size: fontPreset.scaledClamped(10, min: 10, max: 12), design: .monospaced))
+                .frame(width: 54, alignment: .leading)
+
+                Text(file.path)
+                    .font(.system(size: fontPreset.scaledClamped(10, min: 10, max: 12), design: .monospaced))
+                    .lineLimit(1)
+                    .truncationMode(.head)
+                    .foregroundStyle(.primary)
+
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 7)
+            .padding(.vertical, 5)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .background(isSelected ? Color.accentColor.opacity(0.08) : Color.clear)
+        .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+        .textSelection(.disabled)
+    }
+
+    private var statusColor: Color {
+        if file.status.contains("D") { return .red }
+        if file.status.contains("A") || file.status == "??" { return .green }
+        if file.status.contains("R") { return .purple }
+        return .orange
+    }
+
+    private func toggleSelection() {
+        Task {
+            if isSelected {
+                await gitViewModel.removeFileFromSelection(file.path)
+            } else {
+                await gitViewModel.addFileToSelection(file.path)
+            }
+        }
+    }
+}
+
+private struct AgentContextPromptInstructionsEditor: View {
+    @Binding var text: String
+    let fontPreset: FontScalePreset
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Receiving-model instructions")
+                    .font(fontPreset.standardFont.weight(.semibold))
+                Text("Tell the model what to do with this selected context.")
+                    .font(fontPreset.captionFont)
+                    .foregroundStyle(.secondary)
+            }
+
+            ZStack(alignment: .topLeading) {
+                TextEditor(text: $text)
+                    .font(fontPreset.standardFont)
+                    .scrollContentBackground(.hidden)
+                    .frame(minHeight: 154)
+
+                if text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    Text("Plan a fix, review the selected changes, or ask a specific question about this context.")
+                        .font(fontPreset.captionFont)
+                        .foregroundStyle(.tertiary)
+                        .padding(.top, 8)
+                        .padding(.leading, 6)
+                        .allowsHitTesting(false)
+                }
+            }
+            .padding(8)
+            .background(Color(NSColor.textBackgroundColor).opacity(0.65))
+            .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .stroke(Color.secondary.opacity(0.18), lineWidth: 0.5)
+            )
+        }
+    }
+}
+
+private struct AgentContextDrawerControlLabel: View {
+    let title: String
+    let value: String
+    let icon: String
+    let tint: Color
+    let fontPreset: FontScalePreset
+
+    @Environment(\.isEnabled) private var isEnabled
+    @State private var isHovering = false
+
+    var body: some View {
+        HStack(spacing: 7) {
+            Image(systemName: icon)
+                .font(fontPreset.swiftUIFont(sizeAtNormal: 12, weight: .medium))
+                .foregroundStyle(isEnabled ? tint : Color.secondary)
+                .frame(width: 16)
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(title)
+                    .font(fontPreset.swiftUIFont(sizeAtNormal: 9, weight: .medium))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                Text(value)
+                    .font(fontPreset.captionFont.weight(.semibold))
+                    .foregroundStyle(isEnabled ? Color.primary : Color.secondary)
+                    .lineLimit(1)
+            }
+
+            Image(systemName: "chevron.down")
+                .font(fontPreset.swiftUIFont(sizeAtNormal: 9, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .opacity(isEnabled ? 1 : 0)
+        }
+        .padding(.horizontal, 9)
+        .padding(.vertical, 7)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            Color(NSColor.controlBackgroundColor)
+                .opacity(isHovering ? 0.55 : 0.30)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 9, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 9, style: .continuous)
+                .stroke(tint.opacity(isHovering ? 0.35 : 0.20), lineWidth: 0.5)
+        )
+        .contentShape(Rectangle())
+        .textSelection(.disabled)
+        .onHover { isHovering = $0 }
+    }
+}
+
+private struct AgentContextStoredPromptPreviewButton: View {
+    let prompt: PromptViewModel.StoredPrompt
+
+    @ObservedObject private var fontScale = FontScaleManager.shared
+    @State private var showPreview = false
+
+    private var fontPreset: FontScalePreset {
+        fontScale.preset
+    }
+
+    var body: some View {
+        Button {
+            showPreview = true
+        } label: {
+            Image(systemName: "eye")
+                .font(fontPreset.swiftUIFont(sizeAtNormal: 11, weight: .medium))
+                .foregroundStyle(.secondary)
+        }
+        .buttonStyle(.plain)
+        .hoverTooltip("Preview prompt")
+        .popover(isPresented: $showPreview) {
+            VStack(alignment: .leading, spacing: 8) {
+                Text(prompt.title)
+                    .font(fontPreset.standardFont.weight(.semibold))
+                ScrollView {
+                    Text(prompt.content)
+                        .font(fontPreset.standardFont)
+                        .textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .frame(width: 360, height: 260)
+            }
+            .padding(12)
+        }
+    }
+}

--- a/Sources/RepoPrompt/Features/AgentMode/Views/ContextDrawer/AgentContextDrawerTokenEstimatePill.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/ContextDrawer/AgentContextDrawerTokenEstimatePill.swift
@@ -1,0 +1,132 @@
+import SwiftUI
+
+struct AgentContextDrawerTokenEstimatePill: View {
+    @ObservedObject var tokenCounter: TokenCountingViewModel
+    @ObservedObject var runtimeVM: AgentRuntimeSidebarViewModel
+    let fontPreset: FontScalePreset
+    let tokenBlankingSelection: StoredSelection?
+
+    private func isWaitingForExpectedSelection(_ snapshot: TokenCountingViewModel.PublishedTokenSnapshot) -> Bool {
+        guard tokenBlankingSelection != nil else { return false }
+        return !snapshot.isComplete || snapshot.isStale || snapshot.refreshPending
+    }
+
+    private var contextWindowTokens: Int {
+        runtimeVM.snapshot.effectiveContextWindowTokens
+    }
+
+    var body: some View {
+        let snapshot = tokenCounter.latestPublishedTokenSnapshot(for: tokenBlankingSelection)
+        let contextWindowTokenBudget = contextWindowTokens
+        let isWaiting = isWaitingForExpectedSelection(snapshot)
+
+        Group {
+            if isWaiting {
+                loadingCapsule
+            } else {
+                let usedTokens = snapshot.breakdown.total
+                let usedPercent = contextUsedPercent(usedTokens: usedTokens, contextWindowTokens: contextWindowTokenBudget)
+
+                HStack(spacing: 8) {
+                    AgentContextIndicator(
+                        contextWindowTokens: contextWindowTokenBudget,
+                        usedTokens: usedTokens,
+                        style: .compact
+                    )
+
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text(
+                            "\(AgentContextIndicator.formatTokens(usedTokens)) / "
+                                + "\(AgentContextIndicator.formatTokens(contextWindowTokenBudget))"
+                        )
+                        .font(fontPreset.swiftUIFont(sizeAtNormal: 11, weight: .semibold))
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+                        .fixedSize(horizontal: true, vertical: false)
+
+                        HStack(spacing: 4) {
+                            Text("\(formattedPercent(usedPercent))% of budget")
+                            if snapshot.refreshPending {
+                                Text("· Updating token estimate…")
+                            }
+                        }
+                        .font(fontPreset.swiftUIFont(sizeAtNormal: 10, weight: .medium))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .fixedSize(horizontal: true, vertical: false)
+                    }
+                }
+            }
+        }
+        .padding(.horizontal, 9)
+        .padding(.vertical, 6)
+        .background(Color.secondary.opacity(0.10))
+        .clipShape(Capsule())
+        .overlay(
+            Capsule()
+                .stroke(Color.secondary.opacity(0.18), lineWidth: 0.5)
+        )
+        .hoverTooltip(
+            isWaiting
+                ? "Updating token estimate for the current selection."
+                : tokenWarningHelp(
+                    snapshot,
+                    contextWindowTokens: contextWindowTokenBudget,
+                    usedPercent: contextUsedPercent(
+                        usedTokens: snapshot.breakdown.total,
+                        contextWindowTokens: contextWindowTokenBudget
+                    )
+                )
+        )
+    }
+
+    private var loadingCapsule: some View {
+        VStack(alignment: .leading, spacing: 1) {
+            Text("Token estimate")
+                .font(fontPreset.swiftUIFont(sizeAtNormal: 11, weight: .semibold))
+                .foregroundStyle(.primary)
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)
+
+            Text("Updating for current selection…")
+                .font(fontPreset.swiftUIFont(sizeAtNormal: 10, weight: .medium))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)
+        }
+    }
+
+    private func contextUsedPercent(usedTokens: Int, contextWindowTokens: Int) -> Double {
+        guard contextWindowTokens > 0 else { return 0 }
+        return min(max((Double(usedTokens) / Double(contextWindowTokens)) * 100, 0), 100)
+    }
+
+    private func formattedPercent(_ usedPercent: Double) -> String {
+        "\(Int(usedPercent.rounded()))"
+    }
+
+    private func tokenWarningHelp(
+        _ snapshot: TokenCountingViewModel.PublishedTokenSnapshot,
+        contextWindowTokens: Int,
+        usedPercent: Double
+    ) -> String {
+        var lines: [String] = []
+        lines.append("Prompt context used: \(formattedPercent(usedPercent))%")
+        lines.append(
+            "\(AgentContextIndicator.formatTokens(snapshot.breakdown.total)) / "
+                + "\(AgentContextIndicator.formatTokens(contextWindowTokens)) tokens"
+        )
+
+        if !snapshot.isComplete {
+            lines.append("Token estimate is not complete yet.")
+        } else if snapshot.refreshPending {
+            lines.append("Token estimate is refreshing; the displayed count may be stale.")
+        }
+
+        let breakdown = tokenCounter.tokenBreakdownDescription
+        if !breakdown.isEmpty {
+            lines.append(breakdown)
+        }
+        return lines.joined(separator: "\n")
+    }
+}

--- a/Sources/RepoPrompt/Features/AgentMode/Views/ContextDrawer/AgentContextExportRequestContext.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/ContextDrawer/AgentContextExportRequestContext.swift
@@ -1,0 +1,242 @@
+import Combine
+import Foundation
+
+struct AgentContextSelectionMutationTarget {
+    let identity: WorkspaceSelectionIdentity
+    let expectedSelection: StoredSelection
+}
+
+@MainActor
+struct AgentContextExportViewContext {
+    typealias LookupContextProvider = @MainActor (
+        AgentContextExportSource,
+        WorkspaceFileContextStore
+    ) async -> WorkspaceLookupContext
+    typealias CompleteGitDiffResolver = (
+        _ rootPath: String,
+        _ compareIntent: ReviewGitCompareIntent
+    ) async -> String?
+
+    let promptManager: PromptViewModel
+    let selectionCoordinator: WorkspaceSelectionCoordinator?
+    let currentTabID: UUID?
+    let activeAgentSessionID: UUID?
+    let worktreeBindingsProvider: (@MainActor (UUID, UUID?) -> [AgentSessionWorktreeBinding])?
+    private let lookupContextProvider: LookupContextProvider
+    private let completeGitDiffResolver: CompleteGitDiffResolver
+
+    init(
+        promptManager: PromptViewModel,
+        selectionCoordinator: WorkspaceSelectionCoordinator?,
+        currentTabID: UUID?,
+        activeAgentSessionID: UUID?,
+        worktreeBindingsProvider: (@MainActor (UUID, UUID?) -> [AgentSessionWorktreeBinding])?,
+        lookupContextProvider: @escaping LookupContextProvider = { source, store in
+            await AgentContextExportResolver.lookupContext(source: source, store: store)
+        },
+        completeGitDiffResolver: @escaping CompleteGitDiffResolver = { rootPath, compareIntent in
+            await AgentContextExportViewContext.resolveCompleteGitDiff(
+                rootPath: rootPath,
+                compareIntent: compareIntent
+            )
+        }
+    ) {
+        self.promptManager = promptManager
+        self.selectionCoordinator = selectionCoordinator
+        self.currentTabID = currentTabID
+        self.activeAgentSessionID = activeAgentSessionID
+        self.worktreeBindingsProvider = worktreeBindingsProvider
+        self.lookupContextProvider = lookupContextProvider
+        self.completeGitDiffResolver = completeGitDiffResolver
+    }
+
+    var selectionSummary: AgentContextSelectionSummary {
+        AgentContextExportResolver.selectionSummary(
+            for: makeExportSource(flushPendingUI: false).selection
+        )
+    }
+
+    var selectionChangesPublisher: AnyPublisher<WorkspaceSelectionCoordinator.Change, Never> {
+        selectionCoordinator?.changes
+            ?? Empty<WorkspaceSelectionCoordinator.Change, Never>(completeImmediately: false).eraseToAnyPublisher()
+    }
+
+    var modelRequestIdentity: AgentSelectedFilesModelIdentity {
+        makeModelRequest(flushPendingUI: false).identity
+    }
+
+    func makeModelRequest(flushPendingUI: Bool = true) -> AgentSelectedFilesModelRequest {
+        let source = makeExportSource(flushPendingUI: flushPendingUI)
+        let cfg = promptManager.resolvePromptContext()
+        let filePathDisplay = promptManager.filePathDisplayOption
+        return AgentSelectedFilesModelRequest(
+            identity: AgentSelectedFilesModelIdentity(
+                exportContextIdentity: source.exportContextIdentity,
+                filePathDisplay: filePathDisplay,
+                codeMapUsage: cfg.codeMapUsage
+            ),
+            source: source,
+            store: promptManager.workspaceFileContextStore,
+            filePathDisplay: filePathDisplay,
+            codeMapUsage: cfg.codeMapUsage,
+            entryMetricsSnapshot: AgentSelectedFilesRequestMetricsSnapshotResolver.activeTokenMetricsSnapshot(
+                source: source,
+                promptManager: promptManager,
+                codeMapUsage: cfg.codeMapUsage,
+                filePathDisplay: filePathDisplay
+            )
+        )
+    }
+
+    func makeExportSource(flushPendingUI: Bool = true) -> AgentContextExportSource {
+        let activeComposeTabID = promptManager.activeComposeTabID
+        let requestedTabID = currentTabID ?? activeComposeTabID
+        let selectionSnapshot = requestedTabID.flatMap {
+            selectionCoordinator?.selectionSnapshot(for: $0, flushPendingUIIfActive: flushPendingUI)
+        }
+        return AgentContextExportSourceBuilder.makeSource(
+            AgentContextExportSourceBuildRequest(
+                requestedTabID: requestedTabID,
+                activeComposeTabID: activeComposeTabID,
+                activePromptText: promptManager.promptText,
+                selectionSnapshot: selectionSnapshot,
+                composeTabs: promptManager.currentComposeTabs,
+                explicitActiveAgentSessionID: activeAgentSessionID,
+                worktreeBindingsProvider: { sessionID, tabID in
+                    worktreeBindingsProvider?(sessionID, tabID) ?? []
+                }
+            )
+        )
+    }
+
+    func tabMatchesSelectionChange(_ change: WorkspaceSelectionCoordinator.Change) -> Bool {
+        let tabID = currentTabID
+            ?? selectionCoordinator?.activeTabID()
+            ?? promptManager.activeComposeTabID
+        return change.tabID == tabID
+    }
+
+    func activeSelectionMutationTarget(
+        for source: AgentContextExportSource
+    ) -> AgentContextSelectionMutationTarget? {
+        guard let selectionCoordinator,
+              let sourceTabID = source.tabID,
+              let identity = selectionCoordinator.activeSelectionIdentity(),
+              identity.tabID == sourceTabID
+        else { return nil }
+        return AgentContextSelectionMutationTarget(
+            identity: identity,
+            expectedSelection: selectionCoordinator.activeSelectionSnapshot(flushPendingUI: true).selection
+        )
+    }
+
+    func persistSelection(
+        _ selection: StoredSelection,
+        target: AgentContextSelectionMutationTarget
+    ) async {
+        guard let selectionCoordinator else { return }
+        _ = await selectionCoordinator.persistSelection(
+            selection,
+            for: target.identity,
+            source: .runtimeMutation,
+            expectedCurrentSelection: target.expectedSelection
+        )
+    }
+
+    func buildClipboardContent(
+        for cfg: PromptContextResolved,
+        model: AgentContextExportModel?,
+        selectedPromptIDsOverride: [UUID]? = nil
+    ) async -> String {
+        let source = makeExportSource(flushPendingUI: true)
+        let store = promptManager.workspaceFileContextStore
+        let filePathDisplay = promptManager.filePathDisplayOption
+        let onlyIncludeRootsWithSelectedFiles = promptManager.onlyIncludeRootsWithSelectedFiles
+        let showCodeMapMarkers = !promptManager.codeMapsGloballyDisabled
+        let includeDatetimeInUserInstructions = promptManager.includeDatetimeInUserInstructions
+        let promptSectionsOrder = promptManager.promptSectionsOrder
+        let disabledPromptSections = promptManager.disabledPromptSections
+        let duplicateUserInstructionsAtTop = promptManager.duplicateUserInstructionsAtTop
+        let gitRootPath = promptManager.gitViewModel.selectedRootFolder?.fullPath
+        let gitComparisonBase = promptManager.gitViewModel.selectedDiffBranch
+        let completeGitDiffProvider = Self.makeCompleteGitDiffProvider(
+            inclusion: cfg.gitInclusion,
+            rootPath: gitRootPath,
+            compareIntent: ReviewGitCompareIntent(base: gitComparisonBase),
+            resolver: completeGitDiffResolver
+        )
+        let meta = promptManager.metaInstructions(
+            for: cfg,
+            selectedPromptIDsOverride: selectedPromptIDsOverride
+        )
+        let reviewGitContext = await promptManager.freezePromptGitReviewContext(
+            tabID: source.tabID,
+            sessionID: source.activeAgentSessionID,
+            bindings: source.worktreeBindings,
+            base: gitComparisonBase
+        )
+        let lookupContext: WorkspaceLookupContext = if let model, model.source.exportContextIdentity == source.exportContextIdentity {
+            model.lookupContext
+        } else {
+            await lookupContextProvider(source, store)
+        }
+        let request = AgentContextClipboardRequest(
+            cfg: cfg,
+            source: source,
+            store: store,
+            lookupContext: lookupContext,
+            filePathDisplay: filePathDisplay,
+            onlyIncludeRootsWithSelectedFiles: onlyIncludeRootsWithSelectedFiles,
+            showCodeMapMarkers: showCodeMapMarkers,
+            metaInstructions: meta,
+            includeDatetimeInUserInstructions: includeDatetimeInUserInstructions,
+            promptSectionsOrder: promptSectionsOrder,
+            disabledPromptSections: disabledPromptSections,
+            duplicateUserInstructionsAtTop: duplicateUserInstructionsAtTop,
+            reviewGitContext: reviewGitContext,
+            completeGitDiffProvider: completeGitDiffProvider
+        )
+        return await AgentContextExportResolver.buildClipboardContent(request)
+    }
+
+    private static func makeCompleteGitDiffProvider(
+        inclusion: GitInclusion,
+        rootPath: String?,
+        compareIntent: ReviewGitCompareIntent,
+        resolver: @escaping CompleteGitDiffResolver
+    ) -> () async -> String {
+        guard inclusion == .complete else { return { "" } }
+        guard let rootPath else {
+            return { PromptContextGitDiffPolicy.unavailableCompleteGitDiffMessage }
+        }
+        return {
+            await resolver(rootPath, compareIntent) ?? ""
+        }
+    }
+
+    private static func resolveCompleteGitDiff(
+        rootPath: String,
+        compareIntent: ReviewGitCompareIntent
+    ) async -> String? {
+        guard let resolvedRepo = await VCSService.shared.resolveRepo(
+            from: URL(fileURLWithPath: rootPath, isDirectory: true)
+        ) else { return nil }
+        let target: GitDiffTarget = switch compareIntent {
+        case .uncommittedHEAD:
+            .uncommitted(base: "HEAD")
+        case let .uncommittedMergeBase(symbolicBase):
+            .uncommittedMergeBase(base: symbolicBase)
+        }
+        do {
+            let result = try await GitDiffEngine.shared.diffText(
+                target: target,
+                scope: .all,
+                selectedAbsolutePaths: [],
+                repoURL: resolvedRepo.rootURL
+            )
+            return result.text.isEmpty ? nil : result.text
+        } catch {
+            return nil
+        }
+    }
+}

--- a/Sources/RepoPrompt/Features/AgentMode/Views/ContextDrawer/AgentContextSelectedFileCard.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/ContextDrawer/AgentContextSelectedFileCard.swift
@@ -1,0 +1,565 @@
+import SwiftUI
+
+struct AgentContextSelectedFileCardMetricRowPresentation: Equatable {
+    enum Content: Equatable {
+        case known(AgentContextExportRow.Metrics.Known)
+        case pathOnly(String)
+        case hidden
+    }
+
+    let content: Content
+    let accessibilityLabel: String?
+
+    static func make(
+        rowKind: AgentContextExportRow.Kind,
+        metrics: AgentContextExportRow.Metrics,
+        parentPathDisplay: String?,
+        displayPath: String,
+        sliceCountText: String?
+    ) -> AgentContextSelectedFileCardMetricRowPresentation {
+        switch metrics {
+        case let .known(values):
+            AgentContextSelectedFileCardMetricRowPresentation(
+                content: .known(values),
+                accessibilityLabel: knownAccessibilityLabel(
+                    rowKind: rowKind,
+                    metrics: values,
+                    sliceCountText: sliceCountText
+                )
+            )
+        case .unknown where rowKind == .codemap:
+            AgentContextSelectedFileCardMetricRowPresentation(content: .hidden, accessibilityLabel: nil)
+        case .unknown:
+            AgentContextSelectedFileCardMetricRowPresentation(
+                content: .pathOnly(parentPathDisplay ?? displayPath),
+                accessibilityLabel: pathAccessibilityLabel(displayPath: displayPath, sliceCountText: sliceCountText)
+            )
+        }
+    }
+
+    static func percentText(for metrics: AgentContextExportRow.Metrics.Known) -> String {
+        let percentage = metrics.tokenPercentage
+        if percentage <= 0 { return "0%" }
+        if percentage < 0.01 { return "<1%" }
+        return "\(Int((percentage * 100).rounded()))%"
+    }
+
+    static func tokenTooltip(for metrics: AgentContextExportRow.Metrics.Known) -> String {
+        "≈\(metrics.tokenCount.formatted(.number.grouping(.automatic))) tokens"
+    }
+
+    private static func knownAccessibilityLabel(
+        rowKind: AgentContextExportRow.Kind,
+        metrics: AgentContextExportRow.Metrics.Known,
+        sliceCountText: String?
+    ) -> String {
+        var components = [
+            "Approximate tokens: \(AgentContextIndicator.formatTokens(metrics.tokenCount))",
+            "Share of selected context: \(percentText(for: metrics))"
+        ]
+        if rowKind != .codemap, let lineCount = metrics.lineCount {
+            components.append("Included lines: \(lineCount)")
+        }
+        if let sliceCountText {
+            components.append("Selected slice ranges: \(sliceCountText)")
+        }
+        return components.joined(separator: ", ")
+    }
+
+    private static func pathAccessibilityLabel(displayPath: String, sliceCountText: String?) -> String {
+        var components = ["Path: \(displayPath)"]
+        if let sliceCountText {
+            components.append("Selected slice ranges: \(sliceCountText)")
+        }
+        return components.joined(separator: ", ")
+    }
+}
+
+struct AgentContextSelectedFileCard: View {
+    let row: AgentContextExportRow
+    let canRemove: Bool
+    @ObservedObject var previewCoordinator: AgentSelectedFilePreviewLoadCoordinator
+    let onLoadContent: (AgentContextExportRow, AgentContextExportRow.ContentPurpose) async -> String?
+    let onPromoteToFullFile: ((AgentContextExportRow) -> Void)?
+    let onDemoteToCodemap: ((AgentContextExportRow) -> Void)?
+    let onClearSlices: ((AgentContextExportRow) -> Void)?
+    let onRemove: (AgentContextExportRow) -> Void
+
+    @State private var copyTask: Task<Void, Never>?
+    @State private var isCopying = false
+    @State private var isHovered = false
+    @ObservedObject private var fontScale = FontScaleManager.shared
+
+    private var fontPreset: FontScalePreset {
+        fontScale.preset
+    }
+
+    private var accentColor: Color {
+        switch row.kind {
+        case .codemap: .purple
+        case .slices: .orange
+        case .full: .accentColor
+        }
+    }
+
+    private var leadingIconName: String {
+        switch row.kind {
+        case .codemap: "square.grid.2x2"
+        case .slices: "curlybraces"
+        case .full: "doc.text"
+        }
+    }
+
+    private var disabledRemoveExplanation: String? {
+        if !row.canRemove {
+            return "Expanded from a selected folder; remove the folder selection to remove this file"
+        }
+        if !canRemove {
+            return "Selection mutation is unavailable for this Agent context"
+        }
+        return nil
+    }
+
+    private var canPromoteToFullFile: Bool {
+        canRemove && row.canPromoteToFullFile && onPromoteToFullFile != nil
+    }
+
+    private var canDemoteToCodemap: Bool {
+        canRemove && row.canDemoteToCodemap && onDemoteToCodemap != nil
+    }
+
+    private var canClearSlices: Bool {
+        canRemove && row.canClearSlices && onClearSlices != nil
+    }
+
+    private var sliceCountText: String? {
+        guard row.kind == .slices, let count = row.lineRanges?.count, count > 0 else { return nil }
+        return "\(count)"
+    }
+
+    private var parentPathDisplay: String? {
+        let parent = (row.relativePath as NSString).deletingLastPathComponent
+        guard parent != ".", !parent.isEmpty else { return nil }
+        let components = parent.split(separator: "/").map(String.init)
+        guard components.count > 2 else { return parent }
+        return "…/" + components.suffix(2).joined(separator: "/")
+    }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 9) {
+            Image(systemName: leadingIconName)
+                .symbolRenderingMode(.monochrome)
+                .foregroundColor(accentColor)
+                .font(fontPreset.swiftUIFont(sizeAtNormal: 13, weight: .medium))
+                .imageScale(.medium)
+                .frame(width: 18, height: 18)
+                .padding(.top, 2)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 4) {
+                titleRow
+                detailRow
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(.horizontal, 9)
+        .padding(.vertical, 8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(
+                    isHovered
+                        ? Color(NSColor.controlBackgroundColor).opacity(0.34)
+                        : Color(NSColor.controlBackgroundColor).opacity(0.16)
+                )
+        )
+        .contentShape(Rectangle())
+        .onHover { hovering in
+            isHovered = hovering
+        }
+        .popover(
+            isPresented: Binding(
+                get: { previewCoordinator.isPreviewPresented(for: row) },
+                set: { previewCoordinator.handlePreviewPresentationChanged(row: row, isPresented: $0) }
+            ),
+            arrowEdge: .bottom
+        ) {
+            AgentResolvedFilePreviewPopover(
+                row: row,
+                previewCoordinator: previewCoordinator
+            )
+        }
+        .onDisappear {
+            previewCoordinator.handleRowDisappear(row: row)
+            copyTask?.cancel()
+        }
+    }
+
+    private var titleRow: some View {
+        HStack(spacing: 7) {
+            Text(row.displayName)
+                .font(fontPreset.standardFont.weight(.medium))
+                .foregroundColor(.primary)
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .layoutPriority(1)
+                .accessibilityLabel(row.displayPath)
+                .accessibilityHint(pathTooltip)
+
+            if row.showRootPill, !row.rootDisplayName.isEmpty {
+                rootPill
+            }
+
+            Spacer(minLength: 0)
+
+            if let sliceCountText {
+                Text(sliceCountText)
+                    .font(fontPreset.captionFont.weight(.semibold).monospacedDigit())
+                    .foregroundColor(.orange)
+                    .lineLimit(1)
+                    .fixedSize()
+                    .hoverTooltip("\(sliceCountText) selected slice ranges")
+                    .accessibilityLabel("\(sliceCountText) selected slice ranges")
+            }
+        }
+    }
+
+    private var rootPill: some View {
+        Text(row.rootDisplayName)
+            .font(fontPreset.swiftUIFont(sizeAtNormal: 10, weight: .semibold))
+            .foregroundColor(Color(red: 0.72, green: 0.82, blue: 0.74))
+            .lineLimit(1)
+            .truncationMode(.tail)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 1.5)
+            .background(
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .fill(Color(red: 0.37, green: 0.56, blue: 0.42).opacity(0.28))
+            )
+            .fixedSize(horizontal: true, vertical: false)
+            .hoverTooltip(pathTooltip)
+            .accessibilityLabel("Root: \(row.rootDisplayName)")
+    }
+
+    private var detailRow: some View {
+        HStack(spacing: 8) {
+            metricsPathRow
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .layoutPriority(1)
+
+            actionControls
+        }
+    }
+
+    @ViewBuilder
+    private var metricsPathRow: some View {
+        switch metricRowPresentation.content {
+        case let .known(metrics):
+            knownMetricsPathRow(metrics)
+        case let .pathOnly(pathText):
+            Text(pathText)
+                .font(fontPreset.captionFont.monospacedDigit())
+                .foregroundColor(.secondary.opacity(0.72))
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .hoverTooltip(pathTooltip)
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(metricRowPresentation.accessibilityLabel ?? row.displayPath)
+                .accessibilityHint(pathTooltip)
+        case .hidden:
+            EmptyView()
+                .accessibilityHidden(true)
+        }
+    }
+
+    private func knownMetricsPathRow(_ metrics: AgentContextExportRow.Metrics.Known) -> some View {
+        let percentText = AgentContextSelectedFileCardMetricRowPresentation.percentText(for: metrics)
+        return HStack(spacing: 6) {
+            Text("~\(AgentContextIndicator.formatTokens(metrics.tokenCount))")
+                .fontWeight(.medium)
+                .foregroundColor(.primary)
+                .hoverTooltip(AgentContextSelectedFileCardMetricRowPresentation.tokenTooltip(for: metrics))
+
+            metricsSeparator
+
+            Text(percentText)
+                .hoverTooltip("\(percentText) of selected context")
+
+            if row.kind != .codemap {
+                if let lineCount = metrics.lineCount {
+                    metricsSeparator
+
+                    Text("\(lineCount)")
+                        .hoverTooltip("\(lineCount) \(lineCount == 1 ? "line" : "lines")")
+                }
+
+                if let parentPathDisplay {
+                    metricsSeparator
+
+                    Text(parentPathDisplay)
+                        .foregroundColor(.secondary.opacity(0.72))
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .hoverTooltip(pathTooltip)
+                }
+            }
+        }
+        .font(fontPreset.captionFont.monospacedDigit())
+        .foregroundColor(.secondary)
+        .lineLimit(1)
+        .truncationMode(.tail)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(metricRowPresentation.accessibilityLabel ?? row.displayPath)
+        .accessibilityHint(pathTooltip)
+    }
+
+    private var metricRowPresentation: AgentContextSelectedFileCardMetricRowPresentation {
+        AgentContextSelectedFileCardMetricRowPresentation.make(
+            rowKind: row.kind,
+            metrics: row.metrics,
+            parentPathDisplay: parentPathDisplay,
+            displayPath: row.displayPath,
+            sliceCountText: sliceCountText
+        )
+    }
+
+    private var metricsSeparator: some View {
+        Text("·")
+            .foregroundColor(.secondary.opacity(0.5))
+    }
+
+    private var pathTooltip: String {
+        var lines = [row.displayPath]
+        if !row.rootDisplayName.isEmpty {
+            lines.append("Root: \(row.rootDisplayName)")
+        }
+        if let physicalPath = row.physicalPath, physicalPath != row.displayPath {
+            lines.append(physicalPath)
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    private var actionControls: some View {
+        HStack(spacing: 3) {
+            AgentContextFileActionButton(
+                systemName: "eye",
+                tooltip: "Preview",
+                rowIsHovered: isHovered,
+                isLoading: previewCoordinator.isLoadingPreview(for: row),
+                action: openPreview
+            )
+
+            AgentContextFileActionButton(
+                systemName: "doc.on.doc",
+                tooltip: row.kind == .codemap ? "Copy codemap" : "Copy file content",
+                rowIsHovered: isHovered,
+                isLoading: isCopying,
+                isDisabled: isCopying,
+                action: copyToClipboard
+            )
+
+            AgentContextFileActionMenu(
+                rowIsHovered: isHovered,
+                canPromoteToFullFile: canPromoteToFullFile,
+                canDemoteToCodemap: canDemoteToCodemap,
+                canClearSlices: canClearSlices,
+                hasPhysicalPath: row.physicalPath != nil,
+                onPromoteToFullFile: { onPromoteToFullFile?(row) },
+                onDemoteToCodemap: { onDemoteToCodemap?(row) },
+                onClearSlices: { onClearSlices?(row) },
+                onCopyAbsolutePath: copyAbsolutePath,
+                onCopyRelativePath: copyRelativePath,
+                onOpenFile: openFile,
+                onRevealInFinder: revealInFinder
+            )
+
+            removeControl
+        }
+        .fixedSize()
+    }
+
+    @ViewBuilder
+    private var removeControl: some View {
+        if let disabledRemoveExplanation {
+            Image(systemName: "info.circle")
+                .font(.system(size: 12, weight: .regular))
+                .imageScale(.medium)
+                .foregroundColor(.secondary.opacity(isHovered ? 1 : 0.55))
+                .frame(width: 26, height: 26)
+                .hoverTooltip(disabledRemoveExplanation)
+                .accessibilityLabel(disabledRemoveExplanation)
+        } else {
+            AgentContextFileActionButton(
+                systemName: "minus.circle",
+                tooltip: "Remove from Agent selection",
+                rowIsHovered: isHovered,
+                hoverColor: .red,
+                action: { onRemove(row) }
+            )
+        }
+    }
+
+    private func openPreview() {
+        previewCoordinator.openPreview(row: row, loadContent: onLoadContent)
+    }
+
+    private func copyAbsolutePath() {
+        guard let physicalPath = row.physicalPath else { return }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(physicalPath, forType: .string)
+    }
+
+    private func copyRelativePath() {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(row.relativePath, forType: .string)
+    }
+
+    private func openFile() {
+        guard let physicalPath = row.physicalPath else { return }
+        NSWorkspace.shared.open(URL(fileURLWithPath: physicalPath))
+    }
+
+    private func revealInFinder() {
+        guard let physicalPath = row.physicalPath else { return }
+        NSWorkspace.shared.activateFileViewerSelecting([URL(fileURLWithPath: physicalPath)])
+    }
+
+    private func copyToClipboard() {
+        isCopying = true
+        copyTask?.cancel()
+        copyTask = Task {
+            let text = await onLoadContent(row, .copy) ?? ""
+            guard !Task.isCancelled else { return }
+            await MainActor.run {
+                NSPasteboard.general.clearContents()
+                NSPasteboard.general.setString(text, forType: .string)
+                isCopying = false
+                copyTask = nil
+            }
+        }
+    }
+}
+
+private struct AgentContextFileActionButton: View {
+    let systemName: String
+    let tooltip: String
+    let rowIsHovered: Bool
+    var hoverColor: Color = .primary
+    var isLoading = false
+    var isDisabled = false
+    let action: () -> Void
+
+    @State private var isButtonHovered = false
+
+    private var foregroundColor: Color {
+        guard !isDisabled else { return .secondary.opacity(0.35) }
+        if isButtonHovered { return hoverColor }
+        return .secondary.opacity(rowIsHovered ? 1 : 0.55)
+    }
+
+    var body: some View {
+        Button(action: action) {
+            ZStack {
+                Image(systemName: systemName)
+                    .font(.system(size: 12, weight: .regular))
+                    .imageScale(.medium)
+                    .opacity(isLoading ? 0 : 1)
+                if isLoading {
+                    ProgressView()
+                        .controlSize(.small)
+                        .scaleEffect(0.60)
+                }
+            }
+            .foregroundColor(foregroundColor)
+            .frame(width: 26, height: 26)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(isDisabled)
+        .hoverTooltip(tooltip)
+        .accessibilityLabel(tooltip)
+        .onHover { hovering in
+            isButtonHovered = hovering
+        }
+    }
+}
+
+private struct AgentContextFileActionMenu: View {
+    let rowIsHovered: Bool
+    let canPromoteToFullFile: Bool
+    let canDemoteToCodemap: Bool
+    let canClearSlices: Bool
+    let hasPhysicalPath: Bool
+    let onPromoteToFullFile: () -> Void
+    let onDemoteToCodemap: () -> Void
+    let onClearSlices: () -> Void
+    let onCopyAbsolutePath: () -> Void
+    let onCopyRelativePath: () -> Void
+    let onOpenFile: () -> Void
+    let onRevealInFinder: () -> Void
+
+    @State private var isButtonHovered = false
+
+    private var foregroundColor: Color {
+        if isButtonHovered { return .primary }
+        return .secondary.opacity(rowIsHovered ? 1 : 0.55)
+    }
+
+    var body: some View {
+        Menu {
+            if canPromoteToFullFile {
+                Button(action: onPromoteToFullFile) {
+                    Label("Convert to Full File", systemImage: "doc.text")
+                }
+            }
+            if canDemoteToCodemap {
+                Button(action: onDemoteToCodemap) {
+                    Label("Convert to Codemap", systemImage: "square.grid.2x2")
+                }
+            }
+            if canClearSlices {
+                Button(action: onClearSlices) {
+                    Label("Clear Slices", systemImage: "scissors.badge.ellipsis")
+                }
+            }
+
+            if canPromoteToFullFile || canDemoteToCodemap || canClearSlices {
+                Divider()
+            }
+
+            Button(action: onCopyAbsolutePath) {
+                Label("Copy Absolute Path", systemImage: "link.circle")
+            }
+            .disabled(!hasPhysicalPath)
+
+            Button(action: onCopyRelativePath) {
+                Label("Copy Relative Path", systemImage: "link")
+            }
+
+            Button(action: onOpenFile) {
+                Label("Open File", systemImage: "arrow.up.right.square")
+            }
+            .disabled(!hasPhysicalPath)
+
+            Button(action: onRevealInFinder) {
+                Label("Reveal in Finder", systemImage: "folder")
+            }
+            .disabled(!hasPhysicalPath)
+        } label: {
+            Image(systemName: "ellipsis")
+                .font(.system(size: 12, weight: .regular))
+                .imageScale(.medium)
+                .foregroundColor(foregroundColor)
+                .frame(width: 26, height: 26)
+                .contentShape(Rectangle())
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .hoverTooltip("More actions")
+        .accessibilityLabel("More actions")
+        .onHover { hovering in
+            isButtonHovered = hovering
+        }
+    }
+}

--- a/Sources/RepoPrompt/Features/AgentMode/Views/ContextDrawer/AgentContextSelectedFilesContent.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/ContextDrawer/AgentContextSelectedFilesContent.swift
@@ -1,0 +1,243 @@
+import SwiftUI
+
+enum AgentContextSelectedFilesLayout: Equatable {
+    case list
+    case adaptiveGrid(minimumWidth: CGFloat)
+}
+
+struct AgentContextSelectedFilesContent: View {
+    let model: AgentContextExportModel?
+    let isLoading: Bool
+    let canMutate: Bool
+    let layout: AgentContextSelectedFilesLayout
+    let onRefresh: () -> Void
+    let onLoadContent: (AgentContextExportRow, AgentContextExportRow.ContentPurpose) async -> String?
+    let onRemove: (AgentContextExportRow, AgentContextExportModel) -> Void
+    let onClear: (AgentContextExportModel) -> Void
+
+    @ObservedObject private var fontScale = FontScaleManager.shared
+    @StateObject private var previewCoordinator = AgentSelectedFilePreviewLoadCoordinator()
+    @State private var activeTab: Tab = .files
+
+    private enum Tab {
+        case files
+        case codemaps
+    }
+
+    private var fontPreset: FontScalePreset {
+        fontScale.preset
+    }
+
+    private struct RowSplit {
+        let rows: [AgentContextExportRow]
+        let fileRows: [AgentContextExportRow]
+        let codemapRows: [AgentContextExportRow]
+
+        init(rows: [AgentContextExportRow]) {
+            self.rows = rows
+            var fileRows: [AgentContextExportRow] = []
+            var codemapRows: [AgentContextExportRow] = []
+            fileRows.reserveCapacity(rows.count)
+            codemapRows.reserveCapacity(rows.count)
+            for row in rows {
+                if row.kind == .codemap {
+                    codemapRows.append(row)
+                } else {
+                    fileRows.append(row)
+                }
+            }
+            self.fileRows = fileRows
+            self.codemapRows = codemapRows
+        }
+
+        func rows(for tab: Tab) -> [AgentContextExportRow] {
+            switch tab {
+            case .files: fileRows
+            case .codemaps: codemapRows
+            }
+        }
+    }
+
+    private var rows: [AgentContextExportRow] {
+        model?.rows ?? []
+    }
+
+    var body: some View {
+        let split = RowSplit(rows: rows)
+
+        VStack(alignment: .leading, spacing: 6) {
+            header(split: split)
+            Divider().padding(.vertical, 2)
+            tabSwitcher(split: split)
+
+            if isLoading, model == nil {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if split.rows.isEmpty {
+                emptyState(title: "No files selected")
+            } else {
+                let activeRows = split.rows(for: activeTab)
+                if activeRows.isEmpty {
+                    emptyState(title: activeTab == .files ? "No files in Agent context" : "No codemaps in Agent context")
+                } else {
+                    rowList(activeRows)
+                }
+            }
+        }
+        .padding(8)
+        .onAppear {
+            onRefresh()
+            adjustActiveTab(fileCount: split.fileRows.count, codemapCount: split.codemapRows.count)
+        }
+        .onChange(of: split.fileRows.count) { _, _ in
+            adjustActiveTab(fileCount: split.fileRows.count, codemapCount: split.codemapRows.count)
+        }
+        .onChange(of: split.codemapRows.count) { _, _ in
+            adjustActiveTab(fileCount: split.fileRows.count, codemapCount: split.codemapRows.count)
+        }
+        .onChange(of: activeTab) { _, _ in
+            previewCoordinator.reconcileVisibleRows(split.rows(for: activeTab))
+        }
+        .onChange(of: split.rows.map(\.id)) { _, _ in
+            previewCoordinator.reconcileVisibleRows(split.rows(for: activeTab))
+        }
+    }
+
+    private func header(split: RowSplit) -> some View {
+        HStack(alignment: .center) {
+            Text("Agent Files")
+                .font(fontPreset.standardFont.weight(.medium))
+                .foregroundColor(.primary)
+            Circle()
+                .fill(Color.secondary.opacity(0.3))
+                .frame(width: 4, height: 4)
+            Text("\(split.fileRows.count)")
+                .font(fontPreset.captionFont.weight(.medium))
+                .foregroundColor(.secondary)
+            Spacer()
+            Button {
+                guard let model else { return }
+                onClear(model)
+            } label: {
+                HStack(spacing: 4) {
+                    Image(systemName: "xmark.circle")
+                        .font(fontPreset.swiftUIFont(sizeAtNormal: 11))
+                    Text("Clear All")
+                        .font(fontPreset.captionFont)
+                }
+            }
+            .buttonStyle(CustomButtonStyle(verticalPadding: 3, horizontalPadding: 8))
+            .disabled(split.rows.isEmpty || !canMutate || model == nil)
+            .hoverTooltip(canMutate ? (split.rows.isEmpty ? "No Agent context files to clear" : "Clear the displayed Agent selection") : "Selection mutation is unavailable for this Agent context")
+            .accessibilityHint(canMutate ? (split.rows.isEmpty ? "No Agent context files to clear" : "Clear the displayed Agent selection") : "Selection mutation is unavailable for this Agent context")
+        }
+    }
+
+    private func tabSwitcher(split: RowSplit) -> some View {
+        HStack(spacing: 0) {
+            tabButton(icon: "doc.text", label: "Files", count: split.fileRows.count, tab: .files) {
+                activeTab = .files
+            }
+            tabButton(icon: "square.grid.2x2", label: "Codemaps", count: split.codemapRows.count, tab: .codemaps) {
+                activeTab = .codemaps
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, -12)
+        .padding(.vertical, -6)
+    }
+
+    private func tabButton(
+        icon: String,
+        label: String,
+        count: Int,
+        tab: Tab,
+        action: @escaping () -> Void
+    ) -> some View {
+        let isActive = activeTab == tab
+        return Button(action: action) {
+            HStack(spacing: 6) {
+                Image(systemName: icon)
+                    .font(fontPreset.swiftUIFont(sizeAtNormal: 11, weight: .medium))
+                Text(label)
+                    .font(fontPreset.captionFont.weight(.semibold))
+                Text("\(count)")
+                    .font(fontPreset.captionFont.weight(.medium))
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 8)
+            .frame(maxWidth: .infinity, minHeight: 34)
+            .foregroundColor(isActive ? Color.accentColor : Color.secondary)
+            .overlay(alignment: .bottom) {
+                Rectangle()
+                    .fill(isActive ? Color.accentColor : Color.secondary.opacity(0.2))
+                    .frame(height: isActive ? 2 : 1)
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(isActive)
+    }
+
+    private func rowList(_ activeRows: [AgentContextExportRow]) -> some View {
+        ScrollView(.vertical, showsIndicators: true) {
+            switch layout {
+            case .list:
+                LazyVStack(alignment: .leading, spacing: 8) {
+                    ForEach(activeRows) { row in
+                        selectedFileCard(row: row)
+                    }
+                }
+                .padding(.trailing, 4)
+            case let .adaptiveGrid(minimumWidth):
+                LazyVGrid(
+                    columns: [GridItem(.adaptive(minimum: minimumWidth), spacing: 8, alignment: .top)],
+                    alignment: .leading,
+                    spacing: 8
+                ) {
+                    ForEach(activeRows) { row in
+                        selectedFileCard(row: row)
+                    }
+                }
+                .padding(.trailing, 4)
+            }
+        }
+        .frame(maxHeight: .infinity)
+    }
+
+    private func selectedFileCard(row: AgentContextExportRow) -> some View {
+        AgentContextSelectedFileCard(
+            row: row,
+            canRemove: canMutate && row.canRemove,
+            previewCoordinator: previewCoordinator,
+            onLoadContent: onLoadContent,
+            onPromoteToFullFile: nil,
+            onDemoteToCodemap: nil,
+            onClearSlices: nil,
+            onRemove: { row in
+                guard let model else { return }
+                onRemove(row, model)
+            }
+        )
+    }
+
+    private func emptyState(title: String) -> some View {
+        VStack(spacing: 12) {
+            Image(systemName: "doc.text")
+                .font(.system(size: 34))
+                .foregroundColor(.secondary.opacity(0.4))
+            Text(title)
+                .font(fontPreset.standardFont)
+                .foregroundColor(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func adjustActiveTab(fileCount: Int, codemapCount: Int) {
+        if activeTab == .files, fileCount == 0, codemapCount > 0 {
+            activeTab = .codemaps
+        } else if activeTab == .codemaps, codemapCount == 0, fileCount > 0 {
+            activeTab = .files
+        }
+    }
+}

--- a/Sources/RepoPrompt/Features/AgentMode/Views/ContextDrawer/AgentResolvedFilePreviewPopover.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/ContextDrawer/AgentResolvedFilePreviewPopover.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+struct AgentResolvedFilePreviewPopover: View {
+    let row: AgentContextExportRow
+    @ObservedObject var previewCoordinator: AgentSelectedFilePreviewLoadCoordinator
+
+    private var displayText: String {
+        previewCoordinator.displayText(for: row)
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text(row.displayPath)
+                    .font(.headline)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Spacer()
+            }
+            .padding()
+            TextKitView(
+                text: .constant(displayText),
+                isEditable: false,
+                isSpellCheckEnabled: false,
+                useMonospacedFont: true,
+                // Keep this wired to the coordinator: TextKitView avoids overwriting
+                // first-responder AppKit text unless its external update tick changes.
+                externalUpdateTick: previewCoordinator.contentRevision
+            )
+        }
+        .frame(width: 900, height: 650)
+    }
+}

--- a/Sources/RepoPrompt/Features/AgentMode/Views/ContextDrawer/AgentSelectedFilePreviewLoadCoordinator.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/ContextDrawer/AgentSelectedFilePreviewLoadCoordinator.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+@MainActor
+final class AgentSelectedFilePreviewLoadCoordinator: ObservableObject {
+    @Published private(set) var activePreviewRowID: ResolvedPromptFileEntryID?
+    @Published private(set) var contentRevision = 0
+    @Published private(set) var previewText: String? {
+        didSet { contentRevision &+= 1 }
+    }
+
+    @Published private(set) var isLoadingPreview = false {
+        didSet { contentRevision &+= 1 }
+    }
+
+    private var activePreviewRow: AgentContextExportRow?
+    private var previewLoadTask: Task<Void, Never>?
+
+    deinit {
+        previewLoadTask?.cancel()
+    }
+
+    var hasPreviewLoadTask: Bool {
+        previewLoadTask != nil
+    }
+
+    func isPreviewPresented(for row: AgentContextExportRow) -> Bool {
+        activePreviewRowID == row.id
+    }
+
+    func isLoadingPreview(for row: AgentContextExportRow) -> Bool {
+        activePreviewRowID == row.id && isLoadingPreview
+    }
+
+    func openPreview(
+        row: AgentContextExportRow,
+        loadContent: @escaping (AgentContextExportRow, AgentContextExportRow.ContentPurpose) async -> String?
+    ) {
+        closeActivePreview()
+        activePreviewRow = row
+        activePreviewRowID = row.id
+        isLoadingPreview = true
+        previewLoadTask = Task { [weak self] in
+            let rowID = row.id
+            let text = await loadContent(row, .preview)
+            guard !Task.isCancelled else { return }
+            await MainActor.run { [weak self] in
+                guard self?.activePreviewRow?.id == rowID else { return }
+                self?.previewText = text
+                self?.isLoadingPreview = false
+                self?.previewLoadTask = nil
+            }
+        }
+    }
+
+    func displayText(for row: AgentContextExportRow) -> String {
+        guard activePreviewRowID == row.id else { return "No preview content available" }
+        if isLoadingPreview { return "Loading preview…" }
+        return previewText ?? "No preview content available"
+    }
+
+    func handlePreviewPresentationChanged(row: AgentContextExportRow, isPresented: Bool) {
+        if !isPresented, activePreviewRow == row {
+            closeActivePreview()
+        }
+    }
+
+    func handleRowDisappear(row: AgentContextExportRow) {
+        if activePreviewRow == row {
+            closeActivePreview()
+        }
+    }
+
+    func reconcileVisibleRows(_ rows: [AgentContextExportRow]) {
+        guard let activePreviewRow else { return }
+        if !rows.contains(activePreviewRow) {
+            closeActivePreview()
+        }
+    }
+
+    private func closeActivePreview() {
+        previewLoadTask?.cancel()
+        previewLoadTask = nil
+        activePreviewRow = nil
+        activePreviewRowID = nil
+        isLoadingPreview = false
+        previewText = nil
+    }
+}

--- a/Sources/RepoPrompt/Features/AgentMode/Views/RuntimeSidebar/AgentRuntimeExportCard.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/RuntimeSidebar/AgentRuntimeExportCard.swift
@@ -355,7 +355,13 @@ struct AgentSelectedFilesPopoverTrigger<Label: View>: View {
             source: source,
             store: promptManager.workspaceFileContextStore,
             filePathDisplay: promptManager.filePathDisplayOption,
-            codeMapUsage: codeMapUsage
+            codeMapUsage: codeMapUsage,
+            entryMetricsSnapshot: AgentSelectedFilesRequestMetricsSnapshotResolver.activeTokenMetricsSnapshot(
+                source: source,
+                promptManager: promptManager,
+                codeMapUsage: codeMapUsage,
+                filePathDisplay: promptManager.filePathDisplayOption
+            )
         )
     }
 
@@ -585,7 +591,13 @@ struct AgentSelectedFilesInlineManager: View {
             source: source,
             store: promptManager.workspaceFileContextStore,
             filePathDisplay: promptManager.filePathDisplayOption,
-            codeMapUsage: codeMapUsage
+            codeMapUsage: codeMapUsage,
+            entryMetricsSnapshot: AgentSelectedFilesRequestMetricsSnapshotResolver.activeTokenMetricsSnapshot(
+                source: source,
+                promptManager: promptManager,
+                codeMapUsage: codeMapUsage,
+                filePathDisplay: promptManager.filePathDisplayOption
+            )
         )
     }
 
@@ -900,93 +912,6 @@ private struct AgentSelectedFilesPopover: View {
     }
 }
 
-@MainActor
-final class AgentSelectedFilePreviewLoadCoordinator: ObservableObject {
-    @Published private(set) var activePreviewRowID: ResolvedPromptFileEntryID?
-    @Published private(set) var contentRevision = 0
-    @Published private(set) var previewText: String? {
-        didSet { contentRevision &+= 1 }
-    }
-
-    @Published private(set) var isLoadingPreview = false {
-        didSet { contentRevision &+= 1 }
-    }
-
-    private var activePreviewRow: AgentContextExportRow?
-    private var previewLoadTask: Task<Void, Never>?
-
-    deinit {
-        previewLoadTask?.cancel()
-    }
-
-    var hasPreviewLoadTask: Bool {
-        previewLoadTask != nil
-    }
-
-    func isPreviewPresented(for row: AgentContextExportRow) -> Bool {
-        activePreviewRowID == row.id
-    }
-
-    func isLoadingPreview(for row: AgentContextExportRow) -> Bool {
-        activePreviewRowID == row.id && isLoadingPreview
-    }
-
-    func openPreview(
-        row: AgentContextExportRow,
-        loadContent: @escaping (AgentContextExportRow, AgentContextExportRow.ContentPurpose) async -> String?
-    ) {
-        closeActivePreview()
-        activePreviewRow = row
-        activePreviewRowID = row.id
-        isLoadingPreview = true
-        previewLoadTask = Task { [weak self] in
-            let rowID = row.id
-            let text = await loadContent(row, .preview)
-            guard !Task.isCancelled else { return }
-            await MainActor.run { [weak self] in
-                guard self?.activePreviewRow?.id == rowID else { return }
-                self?.previewText = text
-                self?.isLoadingPreview = false
-                self?.previewLoadTask = nil
-            }
-        }
-    }
-
-    func displayText(for row: AgentContextExportRow) -> String {
-        guard activePreviewRowID == row.id else { return "No preview content available" }
-        if isLoadingPreview { return "Loading preview…" }
-        return previewText ?? "No preview content available"
-    }
-
-    func handlePreviewPresentationChanged(row: AgentContextExportRow, isPresented: Bool) {
-        if !isPresented, activePreviewRow == row {
-            closeActivePreview()
-        }
-    }
-
-    func handleRowDisappear(row: AgentContextExportRow) {
-        if activePreviewRow == row {
-            closeActivePreview()
-        }
-    }
-
-    func reconcileVisibleRows(_ rows: [AgentContextExportRow]) {
-        guard let activePreviewRow else { return }
-        if !rows.contains(activePreviewRow) {
-            closeActivePreview()
-        }
-    }
-
-    private func closeActivePreview() {
-        previewLoadTask?.cancel()
-        previewLoadTask = nil
-        activePreviewRow = nil
-        activePreviewRowID = nil
-        isLoadingPreview = false
-        previewText = nil
-    }
-}
-
 private struct AgentSelectedFileRow: View {
     let row: AgentContextExportRow
     let canRemove: Bool
@@ -1224,37 +1149,5 @@ private struct AgentFileRowActionButton: View {
         .onHover { hovering in
             isButtonHovered = hovering
         }
-    }
-}
-
-private struct AgentResolvedFilePreviewPopover: View {
-    let row: AgentContextExportRow
-    @ObservedObject var previewCoordinator: AgentSelectedFilePreviewLoadCoordinator
-
-    private var displayText: String {
-        previewCoordinator.displayText(for: row)
-    }
-
-    var body: some View {
-        VStack(spacing: 0) {
-            HStack {
-                Text(row.displayPath)
-                    .font(.headline)
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-                Spacer()
-            }
-            .padding()
-            TextKitView(
-                text: .constant(displayText),
-                isEditable: false,
-                isSpellCheckEnabled: false,
-                useMonospacedFont: true,
-                // Keep this wired to the coordinator: TextKitView avoids overwriting
-                // first-responder AppKit text unless its external update tick changes.
-                externalUpdateTick: previewCoordinator.contentRevision
-            )
-        }
-        .frame(width: 900, height: 650)
     }
 }

--- a/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/ContextBuilderToolCards.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/ContextBuilderToolCards.swift
@@ -552,7 +552,8 @@ func contextBuilderOraclePopoverUserInfo(
 ) -> [AnyHashable: Any]? {
     AgentOracleToolRouting.operationPopoverUserInfo(
         openContext: openContext,
-        chatID: chatID
+        chatID: chatID,
+        presentation: .generatedAnswerReadOnly
     )
 }
 

--- a/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/ToolCardRouter.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/ToolCards/ToolCardRouter.swift
@@ -41,12 +41,14 @@ enum AgentOracleToolRouting {
     static func operationPopoverUserInfo(
         openContext: AgentOracleOpenContext?,
         chatID: String?,
-        tabID: UUID? = nil
+        tabID: UUID? = nil,
+        presentation: AgentOraclePopoverPresentation = .standard
     ) -> [AnyHashable: Any]? {
         AgentOraclePopoverRoute(
             openContext: openContext,
             chatID: chatID,
-            tabID: tabID
+            tabID: tabID,
+            presentation: presentation
         )?.notificationUserInfo
     }
 

--- a/Sources/RepoPrompt/Features/Chat/Views/Bubbles.swift
+++ b/Sources/RepoPrompt/Features/Chat/Views/Bubbles.swift
@@ -282,6 +282,7 @@ struct MessageBubble: View {
     let message: AIChatMessage
     @ObservedObject var viewModel: OracleViewModel
     let isLatestMessage: Bool
+    let actionPolicy: ChatTranscriptActionPolicy
     @ObservedObject private var fontScale = FontScaleManager.shared
 
     // Flags for hover states
@@ -391,20 +392,21 @@ struct MessageBubble: View {
             // Buttons below the bubble
             HStack { // Outer container to align trailing without forcing inner to expand
                 HStack(spacing: 8) {
-                    // Token indicator for user messages - always render to prevent layout shifts
-                    Group {
-                        if let inTok = message.promptTokens,
-                           let outTok = message.completionTokens
-                        {
-                            TokenUsageIndicator(inputTokens: inTok, outputTokens: outTok, modelName: nil)
-                        } else {
-                            // Invisible placeholder with same height to maintain stable layout
-                            Color.clear
-                                .frame(width: 0, height: 20)
+                    if actionPolicy.showsTokenUsage {
+                        // Token indicator for user messages - always render to prevent layout shifts
+                        Group {
+                            if let inTok = message.promptTokens,
+                               let outTok = message.completionTokens
+                            {
+                                TokenUsageIndicator(inputTokens: inTok, outputTokens: outTok, modelName: nil)
+                            } else {
+                                // Invisible placeholder with same height to maintain stable layout
+                                Color.clear
+                                    .frame(width: 0, height: 20)
+                            }
                         }
                     }
 
-                    // Always show copy for user messages
                     CopyButtonOverlay(
                         message: message,
                         viewModel: viewModel,
@@ -413,21 +415,22 @@ struct MessageBubble: View {
                         showingDeleteConfirmation: $showingDeleteConfirmation
                     )
 
-                    // Edit button for user messages
-                    EditButtonOverlay(
-                        isHoveringEdit: $isHoveringEdit,
-                        isEditingMessage: $isEditingMessage,
-                        editedText: $editedText,
-                        messageContent: message.content,
-                        isDisabled: viewModel.isSessionStreaming(viewModel.currentSessionID)
-                    )
+                    if actionPolicy.allowsMutatingActions {
+                        EditButtonOverlay(
+                            isHoveringEdit: $isHoveringEdit,
+                            isEditingMessage: $isEditingMessage,
+                            editedText: $editedText,
+                            messageContent: message.content,
+                            isDisabled: viewModel.isSessionStreaming(viewModel.currentSessionID)
+                        )
 
-                    DeleteButtonOverlay(
-                        message: message,
-                        viewModel: viewModel,
-                        isHoveringDelete: $isHoveringDelete,
-                        showingConfirmation: $showingDeleteConfirmation
-                    )
+                        DeleteButtonOverlay(
+                            message: message,
+                            viewModel: viewModel,
+                            isHoveringDelete: $isHoveringDelete,
+                            showingConfirmation: $showingDeleteConfirmation
+                        )
+                    }
                 }
                 .padding(.vertical, 4)
                 .padding(.horizontal, 8)
@@ -479,24 +482,27 @@ struct MessageBubble: View {
                         showingDeleteConfirmation: $showingDeleteConfirmation
                     )
 
-                    ForkButtonOverlay(
-                        message: message,
-                        viewModel: viewModel,
-                        isHoveringFork: $isHoveringFork
-                    )
+                    if actionPolicy.allowsMutatingActions {
+                        ForkButtonOverlay(
+                            message: message,
+                            viewModel: viewModel,
+                            isHoveringFork: $isHoveringFork
+                        )
 
-                    DeleteButtonOverlay(
-                        message: message,
-                        viewModel: viewModel,
-                        isHoveringDelete: $isHoveringDelete,
-                        showingConfirmation: $showingDeleteConfirmation
-                    )
+                        DeleteButtonOverlay(
+                            message: message,
+                            viewModel: viewModel,
+                            isHoveringDelete: $isHoveringDelete,
+                            showingConfirmation: $showingDeleteConfirmation
+                        )
 
-                    if message.selectedFileCount > 0 {
-                        FileSelectionIndicator(message: message, viewModel: viewModel)
+                        if message.selectedFileCount > 0 {
+                            FileSelectionIndicator(message: message, viewModel: viewModel)
+                        }
                     }
 
-                    if let inTok = message.promptTokens,
+                    if actionPolicy.showsTokenUsage,
+                       let inTok = message.promptTokens,
                        let outTok = message.completionTokens
                     {
                         TokenUsageIndicator(

--- a/Sources/RepoPrompt/Features/Chat/Views/ChatMessagesView.swift
+++ b/Sources/RepoPrompt/Features/Chat/Views/ChatMessagesView.swift
@@ -1,5 +1,20 @@
 import SwiftUI
 
+enum ChatTranscriptActionPolicy: Equatable {
+    case standard
+    case nonMutating
+
+    /// Whether this transcript exposes controls that mutate chat or workspace state.
+    var allowsMutatingActions: Bool {
+        self == .standard
+    }
+
+    /// Whether this transcript displays provider token accounting.
+    var showsTokenUsage: Bool {
+        self == .standard
+    }
+}
+
 struct ChatMessagesView: View {
     @ObservedObject var viewModel: OracleViewModel
 
@@ -17,6 +32,9 @@ struct ChatMessagesView: View {
 
     /// Optional transcript session to render without changing global chat focus.
     let sessionIDOverride: UUID?
+
+    /// Controls which message actions this transcript presentation exposes.
+    let actionPolicy: ChatTranscriptActionPolicy
 
     private let contentAnimationDuration: Double = 0.2
 
@@ -48,7 +66,8 @@ struct ChatMessagesView: View {
         bottomOcclusion: CGFloat,
         showsScrollControls: Bool = true,
         autoScrollOnAppear: Bool = true,
-        sessionIDOverride: UUID? = nil
+        sessionIDOverride: UUID? = nil,
+        actionPolicy: ChatTranscriptActionPolicy = .standard
     ) {
         self.viewModel = viewModel
         _autoScrollEnabled = autoScrollEnabled
@@ -56,6 +75,7 @@ struct ChatMessagesView: View {
         self.showsScrollControls = showsScrollControls
         self.autoScrollOnAppear = autoScrollOnAppear
         self.sessionIDOverride = sessionIDOverride
+        self.actionPolicy = actionPolicy
     }
 
     private var renderedSessionID: UUID? {
@@ -209,7 +229,8 @@ struct ChatMessagesView: View {
                 MessageBubble(
                     message: message,
                     viewModel: viewModel,
-                    isLatestMessage: message.id == renderedMessages.last?.id
+                    isLatestMessage: message.id == renderedMessages.last?.id,
+                    actionPolicy: actionPolicy
                 )
                 .id(message.id)
                 .animation(.default, value: message.revisionCount)

--- a/Sources/RepoPrompt/Features/CodeMap/CodeMapExtractor+Snapshots.swift
+++ b/Sources/RepoPrompt/Features/CodeMap/CodeMapExtractor+Snapshots.swift
@@ -12,7 +12,10 @@ enum WorkspaceFileTreePresentationRenderer {
         guard !snapshot.roots.isEmpty else { return "" }
         if Task.isCancelled { return "" }
 
-        let effectiveRoots = snapshot.onlyIncludeRootsWithSelectedFiles
+        let normalizedMode = snapshot.mode.lowercased()
+        let shouldFilterRootsToSelection = snapshot.onlyIncludeRootsWithSelectedFiles
+            && (normalizedMode != "full" || !snapshot.selectedFileIDs.isEmpty)
+        let effectiveRoots = shouldFilterRootsToSelection
             ? snapshot.roots.filter { snapshotFolderContainsSelectedFile($0, selectedFileIDs: snapshot.selectedFileIDs) }
             : snapshot.roots
         guard !effectiveRoots.isEmpty else { return "" }
@@ -96,7 +99,6 @@ enum WorkspaceFileTreePresentationRenderer {
             return (parts.joined(separator: "\n"), usedSelectedMarker, hitBudget)
         }
 
-        let normalizedMode = snapshot.mode.lowercased()
         if normalizedMode != "auto" {
             let built = buildOnce(mode: snapshot.mode, depthLimit: snapshot.maxDepth, tokenBudget: nil, siblingCap: nil)
             return finalizeSnapshotTree(

--- a/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderAgentViewModel.swift
+++ b/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderAgentViewModel.swift
@@ -39,6 +39,13 @@ struct AgentRun: Identifiable {
 
 // DiscoveryQuestion and UserQuestionResponse are defined in Models/Agent/UserInteractionModels.swift
 
+/// Immutable origin of a generated Context Builder answer
+struct ContextBuilderGeneratedAnswerRoute: Equatable {
+    let workspaceID: UUID
+    let tabID: UUID
+    let chatID: String
+}
+
 /// Selected follow-up type for discovery auto-generate
 enum ContextBuilderFollowUpType: String, CaseIterable, Codable {
     case plan
@@ -222,8 +229,8 @@ final class ContextBuilderAgentViewModel: ObservableObject {
         @Published var contextBuilderInstructions: String
         /// Selected context builder prompt IDs for this tab
         @Published var selectedContextBuilderPromptIDs: Set<UUID> = []
-        /// Chat session ID from plan generation (wiped on new discovery run)
-        @Published var generatedPlanChatID: String?
+        /// Immutable origin of the generated answer (wiped on new discovery run)
+        @Published var generatedAnswerRoute: ContextBuilderGeneratedAnswerRoute?
 
         // Per-tab plan UI state
         @Published var isBackgroundPlanGenerating: Bool
@@ -378,7 +385,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
             didUserCancelActiveContextBuilderRun = false
             runHistory = []
             contextBuilderInstructions = ""
-            generatedPlanChatID = nil
+            generatedAnswerRoute = nil
             isBackgroundPlanGenerating = false
             backgroundPlanError = nil
             backgroundPlanResponseText = nil
@@ -710,8 +717,8 @@ final class ContextBuilderAgentViewModel: ObservableObject {
 
     /// Track last processed tab to detect changes
     private var lastProcessedTabID: UUID?
-    /// Chat session ID from plan generation (synced from active TabSession)
-    @Published private(set) var generatedPlanChatID: String?
+    /// Immutable generated-answer origin synced from the active tab session
+    @Published private(set) var generatedAnswerRoute: ContextBuilderGeneratedAnswerRoute?
 
     // MARK: - Background Plan Generation State
 
@@ -886,6 +893,12 @@ final class ContextBuilderAgentViewModel: ObservableObject {
 
     private var currentWorkspaceID: UUID? {
         workspaceManager?.activeWorkspaceID
+    }
+
+    private func workspaceID(containing tabID: UUID) -> UUID? {
+        workspaceManager?.workspaces.first { workspace in
+            workspace.composeTabs.contains { $0.id == tabID }
+        }?.id
     }
 
     private var currentWorkspacePath: String? {
@@ -1374,7 +1387,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
         runHistory = session.runHistory
         runAgentKind = session.lastRunAgentKind
         runModelRaw = session.lastRunModelRaw
-        generatedPlanChatID = session.generatedPlanChatID
+        generatedAnswerRoute = session.generatedAnswerRoute
         applyBackgroundPlanBindings(from: session)
         // Per-tab MCP control flag
         isMCPControlledRun = session.isMCPControlledRun
@@ -1403,7 +1416,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
         runHistory = []
         runAgentKind = nil
         runModelRaw = nil
-        generatedPlanChatID = nil
+        generatedAnswerRoute = nil
         // Per-tab plan UI state
         isBackgroundPlanGenerating = false
         backgroundPlanError = nil
@@ -1446,7 +1459,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
         runHistory = session.runHistory
         runAgentKind = session.lastRunAgentKind
         runModelRaw = session.lastRunModelRaw
-        generatedPlanChatID = session.generatedPlanChatID
+        generatedAnswerRoute = session.generatedAnswerRoute
         applyBackgroundPlanBindings(from: session)
         // Per-tab MCP control flag
         isMCPControlledRun = session.isMCPControlledRun
@@ -2438,7 +2451,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
         }
 
         session.resetLog()
-        session.generatedPlanChatID = nil
+        session.generatedAnswerRoute = nil
         session.backgroundPlanError = nil
         session.backgroundPlanResponseText = nil
         session.backgroundPlanReasoningText = nil
@@ -4276,11 +4289,16 @@ final class ContextBuilderAgentViewModel: ObservableObject {
     ) {
         // Session must exist - caller ensures tab is valid
         let session = session(for: tabID)
+        guard let originWorkspaceID = workspaceID(containing: tabID) else {
+            session.backgroundPlanError = ContextBuilderGenerationError.missingWorkspace.errorDescription
+            updateRuntimeBindings(from: session)
+            return
+        }
 
         // Cancel any existing background plan task for THIS tab only
         session.backgroundPlanTask?.cancel()
 
-        session.generatedPlanChatID = nil
+        session.generatedAnswerRoute = nil
         session.isBackgroundPlanGenerating = true
         session.backgroundPlanError = nil
         session.backgroundPlanResponseText = nil
@@ -4296,11 +4314,12 @@ final class ContextBuilderAgentViewModel: ObservableObject {
             do {
                 let reply = try await generatePlanFromDiscovery(
                     tabID: tabID,
+                    originWorkspaceID: originWorkspaceID,
                     oracleViewModel: oracleViewModel,
                     chatName: chatName,
                     mode: mode
                 )
-                // generatedPlanChatID is set inside generatePlanFromDiscovery
+                // generatedAnswerRoute is set inside generatePlanFromDiscovery
                 session.isBackgroundPlanGenerating = false
                 if let response = reply.response, !response.isEmpty {
                     session.backgroundPlanResponseText = response
@@ -4353,7 +4372,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
         session.backgroundPlanError = nil
         session.backgroundPlanResponseText = nil
         session.backgroundPlanReasoningText = nil
-        session.generatedPlanChatID = nil
+        session.generatedAnswerRoute = nil
         session.followUpOracleSessionID = nil
         clearPendingBackgroundPlanUIRefresh(for: targetTabID)
         applyPlanPreview(to: session)
@@ -4365,7 +4384,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
     @MainActor
     func clearBackgroundPlanState(forTabID tabID: UUID? = nil) {
         cancelBackgroundPlanGeneration(forTabID: tabID)
-        // generatedPlanChatID is cleared in cancelBackgroundPlanGeneration
+        // generatedAnswerRoute is cleared in cancelBackgroundPlanGeneration
     }
 
     /// Claims generation-safe MCP control ownership for discovery plus any follow-up generation.
@@ -4428,7 +4447,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
         // Set the prompt text
         promptManager.promptText = planText
 
-        // Clear plan state for this tab (keep generatedPlanChatID for "View in Chat" if desired)
+        // Clear plan state for this tab (keep generatedAnswerRoute for "View in Chat" if desired)
         session.backgroundPlanResponseText = nil
         session.backgroundPlanReasoningText = nil
         session.backgroundPlanError = nil
@@ -4447,9 +4466,9 @@ final class ContextBuilderAgentViewModel: ObservableObject {
         if let error = session.backgroundPlanError {
             return .error(error)
         }
-        if let chatID = session.generatedPlanChatID {
+        if let route = session.generatedAnswerRoute {
             let preview = session.backgroundPlanResponsePreviewText ?? session.backgroundPlanResponseText
-            return .ready(chatID: chatID, previewText: preview)
+            return .ready(route: route, previewText: preview)
         }
         return .idle
     }
@@ -4458,9 +4477,9 @@ final class ContextBuilderAgentViewModel: ObservableObject {
     @MainActor
     func currentFollowUpOracleChatID(for tabID: UUID?) -> String? {
         if let id = tabID {
-            return sessions[id]?.generatedPlanChatID
+            return sessions[id]?.generatedAnswerRoute?.chatID
         }
-        return generatedPlanChatID
+        return generatedAnswerRoute?.chatID
     }
 
     // MARK: - MCP Plan/Question Generation
@@ -4516,6 +4535,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
     @MainActor
     private func runFollowUpOracleStream(
         for tabID: UUID,
+        originWorkspaceID: UUID,
         oracleViewModel: OracleViewModel,
         mode: HeadlessMode,
         prompt: String,
@@ -4537,7 +4557,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
         let session = session(for: tabID)
 
         // Set initial UI state
-        session.generatedPlanChatID = nil
+        session.generatedAnswerRoute = nil
         session.isBackgroundPlanGenerating = true
         session.backgroundPlanError = nil
         session.backgroundPlanResponseText = nil
@@ -4593,7 +4613,11 @@ final class ContextBuilderAgentViewModel: ObservableObject {
             oracleViewModel.pinSession(createdSession.id)
             defer { oracleViewModel.unpinSession(createdSession.id) }
             session.followUpOracleSessionID = createdSession.id
-            session.generatedPlanChatID = createdSession.shortID
+            session.generatedAnswerRoute = ContextBuilderGeneratedAnswerRoute(
+                workspaceID: originWorkspaceID,
+                tabID: tabID,
+                chatID: createdSession.shortID
+            )
             updateRuntimeBindings(from: session)
 
             try Task.checkCancellation()
@@ -4666,7 +4690,11 @@ final class ContextBuilderAgentViewModel: ObservableObject {
 
             session.isBackgroundPlanGenerating = false
             session.followUpOracleSessionID = nil
-            session.generatedPlanChatID = reply.shortId
+            session.generatedAnswerRoute = ContextBuilderGeneratedAnswerRoute(
+                workspaceID: originWorkspaceID,
+                tabID: tabID,
+                chatID: reply.shortId
+            )
             if let response = reply.response, !response.isEmpty {
                 session.backgroundPlanResponseText = response
             }
@@ -4684,7 +4712,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
             if error is CancellationError {
                 session.backgroundPlanResponseText = nil
                 session.backgroundPlanReasoningText = nil
-                session.generatedPlanChatID = nil
+                session.generatedAnswerRoute = nil
                 session.backgroundPlanError = nil
             } else {
                 session.backgroundPlanError = error.asFriendlyString()
@@ -4731,6 +4759,10 @@ final class ContextBuilderAgentViewModel: ObservableObject {
                 return try await runner(mode, prompt, selection)
             }
         #endif
+
+        guard let originWorkspaceID = workspaceID(containing: tabID) else {
+            throw ContextBuilderGenerationError.missingWorkspace
+        }
 
         let modeName = mode.mcpModeName
         await progressReporter?(.modelResolution)
@@ -4797,7 +4829,11 @@ final class ContextBuilderAgentViewModel: ObservableObject {
                     }
                 )
                 session.isBackgroundPlanGenerating = false
-                session.generatedPlanChatID = reply.shortId
+                session.generatedAnswerRoute = ContextBuilderGeneratedAnswerRoute(
+                    workspaceID: identity.workspaceID,
+                    tabID: tabID,
+                    chatID: reply.shortId
+                )
                 session.backgroundPlanResponseText = reply.response
                 workspaceManager?.setActiveChatSessionID(reply.chatId, for: identity)
                 updateRuntimeBindings(from: session)
@@ -4814,6 +4850,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
 
         return try await runFollowUpOracleStream(
             for: tabID,
+            originWorkspaceID: originWorkspaceID,
             oracleViewModel: oracleViewModel,
             mode: mode,
             prompt: prompt,
@@ -4908,18 +4945,6 @@ final class ContextBuilderAgentViewModel: ObservableObject {
         updateRuntimeBindings(from: session)
     }
 
-    @MainActor
-    func setGeneratedPlanChatID(_ chatID: String, forTabID tabID: UUID? = nil) {
-        let targetTabID = tabID ?? currentTabID
-        guard let targetTabID, let session = sessions[targetTabID] else {
-            // Fallback: update published property directly
-            generatedPlanChatID = chatID
-            return
-        }
-        session.generatedPlanChatID = chatID
-        updateRuntimeBindings(from: session)
-    }
-
     /// Generate an implementation plan using the built context.
     /// Called from UI when user clicks "Generate Plan" after Context Builder completes.
     ///
@@ -4933,6 +4958,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
     @MainActor
     func generatePlanFromDiscovery(
         tabID: UUID,
+        originWorkspaceID: UUID,
         oracleViewModel: OracleViewModel,
         chatName: String? = nil,
         mode: HeadlessMode = .plan,
@@ -4967,6 +4993,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
 
         return try await runFollowUpOracleStream(
             for: tabID,
+            originWorkspaceID: originWorkspaceID,
             oracleViewModel: oracleViewModel,
             mode: mode,
             prompt: prompt,
@@ -5428,7 +5455,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
 enum ContextBuilderPlanStatus: Equatable {
     case idle
     case generating
-    case ready(chatID: String, previewText: String?)
+    case ready(route: ContextBuilderGeneratedAnswerRoute, previewText: String?)
     case error(String)
 
     static func == (lhs: ContextBuilderPlanStatus, rhs: ContextBuilderPlanStatus) -> Bool {
@@ -5450,12 +5477,14 @@ enum ContextBuilderPlanStatus: Equatable {
 enum ContextBuilderGenerationError: LocalizedError {
     case emptyPrompt
     case missingTab
+    case missingWorkspace
     case askUserAlreadyPending
 
     var errorDescription: String? {
         switch self {
         case .emptyPrompt: "Context Builder has no prompt to generate from."
         case .missingTab: "Unable to locate the Context Builder tab."
+        case .missingWorkspace: "Unable to locate the Context Builder workspace."
         case .askUserAlreadyPending: "ask_user is already waiting for a response in this Context Builder session."
         }
     }

--- a/Sources/RepoPrompt/Features/ContextBuilder/Views/ContextBuilderAgentView.swift
+++ b/Sources/RepoPrompt/Features/ContextBuilder/Views/ContextBuilderAgentView.swift
@@ -1,10 +1,32 @@
 import SwiftUI
 
+enum ContextBuilderGeneratedAnswerActionText {
+    static let useAsPromptTooltip = "Use the generated answer as your prompt"
+    static let copyTooltip = "Copy answer to clipboard"
+    static let previewTooltip = "Preview the generated answer"
+    static let viewInChatTooltip = "Open answer in chat view"
+}
+
 struct ContextBuilderAgentView: View {
     @ObservedObject var viewModel: ContextBuilderAgentViewModel
     @ObservedObject var oracleViewModel: OracleViewModel
     let windowID: Int
     var availableWidth: CGFloat
+    let openGeneratedAnswerChat: (ContextBuilderGeneratedAnswerRoute) -> Void
+
+    init(
+        viewModel: ContextBuilderAgentViewModel,
+        oracleViewModel: OracleViewModel,
+        windowID: Int,
+        availableWidth: CGFloat,
+        openGeneratedAnswerChat: @escaping (ContextBuilderGeneratedAnswerRoute) -> Void
+    ) {
+        _viewModel = ObservedObject(wrappedValue: viewModel)
+        _oracleViewModel = ObservedObject(wrappedValue: oracleViewModel)
+        self.windowID = windowID
+        self.availableWidth = availableWidth
+        self.openGeneratedAnswerChat = openGeneratedAnswerChat
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -203,8 +225,8 @@ struct ContextBuilderAgentView: View {
             }
 
             // Line 3: Plan actions (only when plan is ready)
-            if case let .ready(chatID, previewText) = status {
-                planReadyActions(chatID: chatID, previewText: previewText)
+            if case let .ready(route, previewText) = status {
+                planReadyActions(route: route, previewText: previewText)
             }
         }
         .padding(10)
@@ -507,7 +529,10 @@ struct ContextBuilderAgentView: View {
 
     /// Second line actions when plan is ready
     @ViewBuilder
-    private func planReadyActions(chatID: String, previewText: String?) -> some View {
+    private func planReadyActions(
+        route: ContextBuilderGeneratedAnswerRoute,
+        previewText: String?
+    ) -> some View {
         let fullResponseText = viewModel.generatedPlanResponseText(for: subjectTabID)
         HStack(spacing: 8) {
             // Use as Prompt - primary action
@@ -525,7 +550,7 @@ struct ContextBuilderAgentView: View {
                 height: 28
             ))
             .disabled(previewText == nil)
-            .hoverTooltip("Use the generated plan as your prompt")
+            .hoverTooltip(ContextBuilderGeneratedAnswerActionText.useAsPromptTooltip)
 
             if let text = previewText {
                 Button(action: copyGeneratedPlanToClipboard) {
@@ -542,7 +567,7 @@ struct ContextBuilderAgentView: View {
                     height: 28
                 ))
                 .disabled(fullResponseText == nil)
-                .hoverTooltip("Copy plan to clipboard")
+                .hoverTooltip(ContextBuilderGeneratedAnswerActionText.copyTooltip)
 
                 // Preview
                 Button(action: { showingPlanPreview.toggle() }) {
@@ -558,7 +583,7 @@ struct ContextBuilderAgentView: View {
                     horizontalPadding: 12,
                     height: 28
                 ))
-                .hoverTooltip("Preview the generated plan")
+                .hoverTooltip(ContextBuilderGeneratedAnswerActionText.previewTooltip)
                 .popover(isPresented: $showingPlanPreview) {
                     planPreviewPopover(overrideText: text)
                 }
@@ -567,7 +592,7 @@ struct ContextBuilderAgentView: View {
             Spacer()
 
             // View in Chat
-            Button(action: { viewGeneratedPlan(chatID: chatID) }) {
+            Button(action: { viewGeneratedPlan(route: route) }) {
                 HStack(spacing: 4) {
                     Image(systemName: "bubble.left.and.bubble.right")
                         .font(.callout)
@@ -580,7 +605,7 @@ struct ContextBuilderAgentView: View {
                 horizontalPadding: 12,
                 height: 28
             ))
-            .hoverTooltip("Open plan in chat view")
+            .hoverTooltip(ContextBuilderGeneratedAnswerActionText.viewInChatTooltip)
         }
     }
 
@@ -746,12 +771,12 @@ struct ContextBuilderAgentView: View {
         )
     }
 
-    /// Select the generated plan's Oracle chat session.
-    private func viewGeneratedPlan(chatID: String) {
-        oracleViewModel.selectSession(byShortID: chatID)
+    /// Open the generated answer's Oracle chat session.
+    private func viewGeneratedPlan(route: ContextBuilderGeneratedAnswerRoute) {
+        openGeneratedAnswerChat(route)
     }
 
-    /// Use the generated plan text as the prompt
+    /// Use the generated answer text as the prompt
     private func useAsPrompt() {
         viewModel.useGeneratedPlanAsPrompt()
     }

--- a/Sources/RepoPrompt/Features/ContextBuilder/Views/ContextBuilderView.swift
+++ b/Sources/RepoPrompt/Features/ContextBuilder/Views/ContextBuilderView.swift
@@ -10,7 +10,8 @@ struct ContextBuilderView: View {
             viewModel: contextBuilderAgentViewModel,
             oracleViewModel: windowState.oracleViewModel,
             windowID: windowState.windowID,
-            availableWidth: availableWidth
+            availableWidth: availableWidth,
+            openGeneratedAnswerChat: openGeneratedAnswerChat(route:)
         )
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .onAppear {
@@ -24,6 +25,30 @@ struct ContextBuilderView: View {
             if windowState.kind == .contextBuilder {
                 windowState.kind = .standard
             }
+        }
+    }
+
+    private func openGeneratedAnswerChat(route: ContextBuilderGeneratedAnswerRoute) {
+        Task { @MainActor in
+            let workspaceManager = windowState.workspaceManager
+            guard let workspace = workspaceManager.workspace(withID: route.workspaceID) else { return }
+
+            if workspaceManager.activeWorkspaceID != route.workspaceID {
+                let result = await workspaceManager.requestWorkspaceSwitch(to: workspace, saveState: true)
+                guard result.didSwitch else { return }
+            }
+
+            guard workspaceManager.activeWorkspace?.composeTabs.contains(where: { $0.id == route.tabID }) == true else {
+                return
+            }
+            if windowState.promptManager.activeComposeTabID != route.tabID {
+                await windowState.promptManager.switchComposeTab(route.tabID)
+            }
+            guard workspaceManager.activeWorkspaceID == route.workspaceID,
+                  windowState.promptManager.activeComposeTabID == route.tabID
+            else { return }
+
+            windowState.oracleViewModel.selectSession(byShortID: route.chatID)
         }
     }
 }

--- a/Sources/RepoPrompt/Features/Prompt/Services/PromptContextAccountingService.swift
+++ b/Sources/RepoPrompt/Features/Prompt/Services/PromptContextAccountingService.swift
@@ -56,6 +56,7 @@ struct PromptContextAccountingResult {
     let resolvedEntries: [ResolvedPromptFileEntry]
     let promptFileEntrySnapshots: [PromptFileEntrySnapshot]
     let tokenCalculationSnapshot: TokenCalculationSnapshot
+    let entryMetricsSnapshot: PromptContextEntryMetricsSnapshot
     let missingPaths: [String]
     let invalidPaths: [String]
     let codemapPresentation: WorkspaceCodemapOperationPresentation
@@ -74,6 +75,23 @@ enum PromptContextAccountingContentPolicy {
     case cachedOnly
 }
 
+enum PromptContextResolvedContentAccountingError: Error, Equatable {
+    case contentUnavailable(ResolvedFileContentLocation)
+}
+
+struct PromptContextResolvedContentMetricsEntry {
+    let fileID: UUID
+    let rootID: UUID
+    let location: ResolvedFileContentLocation
+    let renderedDisplayPath: String
+    let lineRanges: [LineRange]?
+}
+
+typealias PromptContextResolvedContentReader = @Sendable (
+    ResolvedFileContentLocation,
+    ContentReadWorkloadClass
+) async throws -> String?
+
 private struct SelectedFileAccountingReadRequest {
     let selectedPathIndex: Int
     let selectedPath: String
@@ -86,13 +104,37 @@ private struct SelectedFileAccountingReadResult {
     let errorDescription: String?
 }
 
+private struct ResolvedEntryAccountingReadRequest {
+    let entryIndex: Int
+    let entry: ResolvedPromptFileEntry
+}
+
+private struct ResolvedEntryAccountingReadResult {
+    let entryIndex: Int
+    let content: String?
+}
+
 actor PromptContextAccountingService {
     private static let selectedFileAccountingReadConcurrencyLimit = 4
 
     private let tokenCalculationService: TokenCalculationService
+    private let resolvedContentReader: PromptContextResolvedContentReader
 
-    init(tokenCalculationService: TokenCalculationService = TokenCalculationService()) {
+    init(
+        tokenCalculationService: TokenCalculationService = TokenCalculationService(),
+        resolvedContentReader: @escaping PromptContextResolvedContentReader = { location, workloadClass in
+            try await FileSystemService.loadEntireFileContentOptimized(
+                at: location,
+                workloadClass: workloadClass
+            )
+        }
+    ) {
         self.tokenCalculationService = tokenCalculationService
+        self.resolvedContentReader = resolvedContentReader
+    }
+
+    private nonisolated func checkResolvedContentCancellation() throws(CancellationError) {
+        guard !Task.isCancelled else { throw CancellationError() }
     }
 
     func calculatePromptStats(
@@ -165,6 +207,84 @@ actor PromptContextAccountingService {
         }
     }
 
+    func calculateEntryMetricsSnapshot(
+        entries: [ResolvedPromptFileEntry],
+        store: WorkspaceFileContextStore,
+        codemapPresentation: WorkspaceCodemapOperationPresentation,
+        filePathDisplay: FilePathDisplay,
+        displayPathResolver: ((ResolvedPromptFileEntry) -> String?)? = nil
+    ) async -> PromptContextEntryMetricsSnapshot {
+        guard !entries.isEmpty else { return .empty }
+
+        let loadedEntries = await entriesLoadingContentIfNeeded(entries, store: store)
+        let snapshots = makePromptFileEntrySnapshots(
+            from: loadedEntries,
+            codemapPresentation: codemapPresentation,
+            filePathDisplay: filePathDisplay,
+            displayPathResolver: displayPathResolver
+        )
+        let calculationSnapshot = TokenCalculationSnapshot(
+            promptText: "",
+            selectedInstructionsText: "",
+            duplicateUserInstructionsAtTop: false,
+            promptEntries: snapshots,
+            fileTree: .none
+        )
+        let tokenResult = await tokenCalculationService.calculatePromptStats(snapshot: calculationSnapshot)
+        return makeEntryMetricsSnapshot(from: loadedEntries, tokenResult: tokenResult)
+    }
+
+    func calculateEntryMetricsSnapshot(
+        resolvedContentEntries: [PromptContextResolvedContentMetricsEntry]
+    ) async throws -> PromptContextEntryMetricsSnapshot {
+        try checkResolvedContentCancellation()
+        guard !resolvedContentEntries.isEmpty else { return .empty }
+
+        var loadedEntries: [ResolvedPromptFileEntry] = []
+        loadedEntries.reserveCapacity(resolvedContentEntries.count)
+        for input in resolvedContentEntries {
+            try checkResolvedContentCancellation()
+            guard let content = try await resolvedContentReader(input.location, .promptAccounting) else {
+                throw PromptContextResolvedContentAccountingError.contentUnavailable(input.location)
+            }
+            try checkResolvedContentCancellation()
+            let file = WorkspaceFileRecord(
+                id: input.fileID,
+                rootID: input.rootID,
+                name: input.location.resolvedFileURL.lastPathComponent,
+                relativePath: input.location.relativePath,
+                fullPath: input.location.resolvedFileURL.path,
+                parentFolderID: nil
+            )
+            loadedEntries.append(ResolvedPromptFileEntry(
+                file: file,
+                lineRanges: input.lineRanges,
+                mode: input.lineRanges?.isEmpty == false ? .sliced : .fullFile,
+                loadedContent: content,
+                rootFolderPath: input.location.resolvedRootURL.path
+            ))
+        }
+        try checkResolvedContentCancellation()
+        let displayPathsByFileID = Dictionary(
+            uniqueKeysWithValues: resolvedContentEntries.map { ($0.fileID, $0.renderedDisplayPath) }
+        )
+        let snapshots = makePromptFileEntrySnapshots(
+            from: loadedEntries,
+            codemapPresentation: .empty,
+            displayPathResolver: { displayPathsByFileID[$0.file.id] }
+        )
+        let calculationSnapshot = TokenCalculationSnapshot(
+            promptText: "",
+            selectedInstructionsText: "",
+            duplicateUserInstructionsAtTop: false,
+            promptEntries: snapshots,
+            fileTree: .none
+        )
+        let tokenResult = await tokenCalculationService.calculatePromptStats(snapshot: calculationSnapshot)
+        try checkResolvedContentCancellation()
+        return makeEntryMetricsSnapshot(from: loadedEntries, tokenResult: tokenResult)
+    }
+
     private func calculatePromptStats(
         request: PromptContextAccountingRequest,
         store: WorkspaceFileContextStore,
@@ -215,6 +335,10 @@ actor PromptContextAccountingService {
             fileTree: effectiveFileTree
         )
         let tokenResult = await tokenCalculationService.calculatePromptStats(snapshot: calculationSnapshot)
+        let entryMetricsSnapshot = makeEntryMetricsSnapshot(
+            from: resolution.entries,
+            tokenResult: tokenResult
+        )
         let usedCodemapFileIDs = Set(snapshots.compactMap { snapshot in
             snapshot.isCodemapRequested && snapshot.codeMapContent != nil ? snapshot.fileID : nil
         })
@@ -223,6 +347,7 @@ actor PromptContextAccountingService {
             resolvedEntries: resolution.entries,
             promptFileEntrySnapshots: snapshots,
             tokenCalculationSnapshot: calculationSnapshot,
+            entryMetricsSnapshot: entryMetricsSnapshot,
             missingPaths: resolution.missingPaths,
             invalidPaths: resolution.invalidPaths,
             codemapPresentation: resolution.codemapPresentation,
@@ -898,13 +1023,109 @@ actor PromptContextAccountingService {
         return PromptContextEntryResolution(entries: entries, missingPaths: uniqueMissingPaths, invalidPaths: uniqueInvalidPaths, codemapPresentation: codemapPresentation)
     }
 
+    private func entriesLoadingContentIfNeeded(
+        _ entries: [ResolvedPromptFileEntry],
+        store: WorkspaceFileContextStore
+    ) async -> [ResolvedPromptFileEntry] {
+        let readRequests = entries.enumerated().compactMap { index, entry -> ResolvedEntryAccountingReadRequest? in
+            guard !entry.isCodemap, entry.loadedContent == nil else { return nil }
+            return ResolvedEntryAccountingReadRequest(entryIndex: index, entry: entry)
+        }
+        guard !readRequests.isEmpty else { return entries }
+
+        let readResults = await withTaskGroup(
+            of: ResolvedEntryAccountingReadResult.self,
+            returning: [Int: ResolvedEntryAccountingReadResult].self
+        ) { group in
+            let concurrencyLimit = Self.selectedFileAccountingReadConcurrencyLimit
+            var iterator = readRequests.makeIterator()
+            var activeReads = 0
+            var results: [Int: ResolvedEntryAccountingReadResult] = [:]
+
+            func enqueueNextReadIfAvailable() {
+                guard !Task.isCancelled,
+                      activeReads < concurrencyLimit,
+                      let request = iterator.next()
+                else {
+                    return
+                }
+                activeReads += 1
+                group.addTask {
+                    guard !Task.isCancelled else {
+                        return ResolvedEntryAccountingReadResult(entryIndex: request.entryIndex, content: nil)
+                    }
+                    let content = try? await store.readContent(
+                        rootID: request.entry.file.rootID,
+                        relativePath: request.entry.file.standardizedRelativePath,
+                        workloadClass: .promptAccounting
+                    )
+                    return ResolvedEntryAccountingReadResult(entryIndex: request.entryIndex, content: content)
+                }
+            }
+
+            for _ in 0 ..< concurrencyLimit {
+                enqueueNextReadIfAvailable()
+            }
+
+            while let result = await group.next() {
+                activeReads -= 1
+                results[result.entryIndex] = result
+                if Task.isCancelled {
+                    group.cancelAll()
+                    break
+                }
+                enqueueNextReadIfAvailable()
+            }
+
+            return results
+        }
+        guard !Task.isCancelled else { return entries }
+
+        return entries.enumerated().map { index, entry in
+            guard let content = readResults[index]?.content else { return entry }
+            return ResolvedPromptFileEntry(
+                file: entry.file,
+                isCodemap: entry.isCodemap,
+                lineRanges: entry.lineRanges,
+                mode: entry.mode,
+                loadedContent: content,
+                rootFolderPath: entry.rootFolderPath,
+                role: entry.role
+            )
+        }
+    }
+
+    private nonisolated func makeEntryMetricsSnapshot(
+        from entries: [ResolvedPromptFileEntry],
+        tokenResult: TokenCalculationResult
+    ) -> PromptContextEntryMetricsSnapshot {
+        let denominator = tokenResult.totalTokenCountFilesOnly + tokenResult.codeMapTokenCount
+        let metrics = entries.compactMap { entry -> PromptContextEntryMetric? in
+            guard let entryResult = tokenResult.entryResultsByFileID[entry.file.id] else { return nil }
+            let percentage = denominator > 0 ? Double(entryResult.displayTokens) / Double(denominator) : 0
+            return PromptContextEntryMetric(
+                fileID: entry.file.id,
+                standardizedFullPath: entry.file.standardizedFullPath,
+                renderedDisplayPath: entryResult.renderedDisplayPath,
+                renderMode: entryResult.renderMode,
+                displayTokenCount: entryResult.displayTokens,
+                displayPercentage: percentage,
+                includedLineCount: entryResult.displayLineCount
+            )
+        }
+        return PromptContextEntryMetricsSnapshot(totalSelectedDisplayTokens: denominator, metrics: metrics)
+    }
+
     func makePromptFileEntrySnapshots(
         from entries: [ResolvedPromptFileEntry],
         codemapPresentation: WorkspaceCodemapOperationPresentation,
-        filePathDisplay _: FilePathDisplay = .relative,
-        displayPathResolver _: ((ResolvedPromptFileEntry) -> String?)? = nil
+        filePathDisplay: FilePathDisplay = .relative,
+        displayPathResolver: ((ResolvedPromptFileEntry) -> String?)? = nil
     ) -> [PromptFileEntrySnapshot] {
-        entries.map { entry in
+        let hasMultipleRoots = Set(entries.map(\.file.rootID)).count > 1
+        return entries.map { entry in
+            let renderedDisplayPath = displayPathResolver?(entry)
+                ?? selectedDisplayPath(for: entry, filePathDisplay: filePathDisplay, hasMultipleRoots: hasMultipleRoots)
             let codeMapContent: String?
             let availableCodeMapTokenCount: Int
             if let rendered = codemapPresentation.renderedEntriesByFileID[entry.file.id] {
@@ -918,6 +1139,7 @@ actor PromptContextAccountingService {
             return PromptFileEntrySnapshot(
                 fileID: entry.file.id,
                 relativePath: entry.file.relativePath,
+                renderedDisplayPath: renderedDisplayPath,
                 isCodemapRequested: entry.isCodemap,
                 ranges: entry.lineRanges,
                 cachedFullTokenCount: cachedFullTokenCount,
@@ -926,6 +1148,24 @@ actor PromptContextAccountingService {
                 availableCodeMapTokenCount: availableCodeMapTokenCount
             )
         }
+    }
+
+    private nonisolated func selectedDisplayPath(
+        for entry: ResolvedPromptFileEntry,
+        filePathDisplay: FilePathDisplay,
+        hasMultipleRoots: Bool
+    ) -> String {
+        if filePathDisplay == .relative {
+            if hasMultipleRoots,
+               let rootFolderPath = entry.rootFolderPath,
+               !rootFolderPath.isEmpty
+            {
+                let rootFolderName = (StandardizedPath.absolute(rootFolderPath) as NSString).lastPathComponent
+                return rootFolderName.isEmpty ? entry.file.relativePath : "\(rootFolderName)/\(entry.file.relativePath)"
+            }
+            return entry.file.relativePath
+        }
+        return entry.file.fullPath
     }
 
     private nonisolated func sliceRanges(for path: String, file: WorkspaceFileRecord, location: WorkspacePathLocation, in slices: [String: [LineRange]]) -> [LineRange]? {

--- a/Sources/RepoPrompt/Features/Prompt/Services/PromptContextGitDiffPolicy.swift
+++ b/Sources/RepoPrompt/Features/Prompt/Services/PromptContextGitDiffPolicy.swift
@@ -2,4 +2,5 @@ import Foundation
 
 enum PromptContextGitDiffPolicy {
     static let deferredCompleteWorktreeGitDiffMessage = "Complete git diff export is not available for worktree-bound context yet; this export intentionally omits the base-checkout complete diff. Use selected-file diff for worktree-aware diff details."
+    static let unavailableCompleteGitDiffMessage = "Complete git diff export is not available because no git repository root is selected for this context."
 }

--- a/Sources/RepoPrompt/Features/Prompt/ViewModels/PromptViewModel.swift
+++ b/Sources/RepoPrompt/Features/Prompt/ViewModels/PromptViewModel.swift
@@ -760,8 +760,10 @@ class PromptViewModel: ObservableObject {
     @Published var gitDiffInclusionModeForCopy: GitDiffInclusionMode = .none {
         didSet {
             guard oldValue != gitDiffInclusionModeForCopy else { return }
-            // Git-only light path: update diff tokens immediately
-            tokenCountingViewModel.markGitDiffDirty()
+            let gitViewModelWillPublishChange = gitViewModel.gitDiffInclusionMode != gitDiffInclusionModeForCopy
+            if !gitViewModelWillPublishChange {
+                tokenCountingViewModel.markGitDiffDirty()
+            }
             if !isSyncingSettings {
                 guard let workspaceID = currentWorkspaceID else { return }
                 var settings = settingsManager.copySettings(for: workspaceID)
@@ -2758,24 +2760,24 @@ class PromptViewModel: ObservableObject {
         // Flush pending editor state and snapshot current tab before switching
         flushAndSnapshotActiveTab(in: manager, workspaceIndex: index)
 
-        await withComposeTabActivationSnapshotSuspended(targetTabID: id, manager: manager) {
-            manager.workspaces[index].activeComposeTabID = id
-            activeComposeTabID = id
+        await withComposeTabSwitching(targetTabID: id) {
+            await withComposeTabActivationSnapshotSuspended(targetTabID: id, manager: manager) {
+                manager.workspaces[index].activeComposeTabID = id
+                activeComposeTabID = id
 
-            loadComposeTabsFromWorkspace(manager.workspaces[index])
-            guard let target = manager.workspaces[index].composeTabs.first(where: { $0.id == id }) else { return }
+                loadComposeTabsFromWorkspace(manager.workspaces[index])
+                guard let target = manager.workspaces[index].composeTabs.first(where: { $0.id == id }) else { return }
 
-            activeTabApplyTask?.cancel()
+                activeTabApplyTask?.cancel()
 
-            let task = Task { [weak self, weak manager] in
-                guard let self, let manager else { return }
-                await withComposeTabSwitching(targetTabID: id) {
-                    await manager.applyComposeTabStateAsync(tab: target, windowID: self.windowID)
+                let task = Task { [weak self, weak manager] in
+                    guard let self, let manager else { return }
+                    await manager.applyComposeTabStateAsync(tab: target, windowID: windowID)
                 }
-            }
 
-            activeTabApplyTask = task
-            await task.value
+                activeTabApplyTask = task
+                await task.value
+            }
         }
     }
 

--- a/Sources/RepoPrompt/Features/Prompt/ViewModels/TokenCountingViewModel.swift
+++ b/Sources/RepoPrompt/Features/Prompt/ViewModels/TokenCountingViewModel.swift
@@ -88,6 +88,9 @@ class TokenCountingViewModel: ObservableObject {
     private var lastPredominantLanguage: String = "Swift"
     private var automaticRecountSuspendDepth: Int = 0
     private var lastPublishedSelection: StoredSelection?
+    private var lastPublishedCodeMapUsage: CodeMapUsage?
+    private var lastPublishedFilePathDisplay: FilePathDisplay?
+    private var lastPublishedEntryMetricsSnapshot: PromptContextEntryMetricsSnapshot = .empty
     #if DEBUG
         private var debugBeforeTokenCalculationForTesting: (@MainActor @Sendable () async -> Void)?
         private var debugTokenCalculationStartCount = 0
@@ -379,6 +382,9 @@ class TokenCountingViewModel: ObservableObject {
         let breakdown: TokenBreakdown
         let filesContentTokens: Int
         let codeMapTokens: Int
+        let entryMetricsSnapshot: PromptContextEntryMetricsSnapshot
+        let codeMapUsage: CodeMapUsage?
+        let filePathDisplay: FilePathDisplay?
         let isComplete: Bool
         let isStale: Bool
         let refreshPending: Bool
@@ -403,6 +409,9 @@ class TokenCountingViewModel: ObservableObject {
             breakdown: latestTokenBreakdown(),
             filesContentTokens: totalTokenCountFilesOnly,
             codeMapTokens: codeMapTokenCount,
+            entryMetricsSnapshot: lastPublishedEntryMetricsSnapshot,
+            codeMapUsage: lastPublishedCodeMapUsage,
+            filePathDisplay: lastPublishedFilePathDisplay,
             isComplete: isComplete,
             isStale: isStale,
             refreshPending: !isComplete || isStale || tokenUpdateDebounceTask != nil || updateTokenCountTask != nil
@@ -492,6 +501,14 @@ class TokenCountingViewModel: ObservableObject {
         getCopyContext?() ?? .default
     }
 
+    func currentExpectedSelectionForPublishedSnapshot() -> StoredSelection {
+        expectedSelectionForPublishedSnapshot(resolveCopyContextSnapshot())
+    }
+
+    private func expectedSelectionForPublishedSnapshot(_ copySnapshot: CopyContextSnapshot) -> StoredSelection {
+        currentStoredSelection(includeFiles: copySnapshot.includeFiles)
+    }
+
     private func currentStoredSelection(includeFiles: Bool) -> StoredSelection {
         guard includeFiles else { return StoredSelection() }
         if let selection = getStoredSelection?() {
@@ -572,7 +589,7 @@ class TokenCountingViewModel: ObservableObject {
         #if DEBUG
             let selectionSnapshotStartMS = PromptTokenRecountDiagnostics.start()
         #endif
-        let selectionAtStart = includeFiles ? currentStoredSelection(includeFiles: true) : StoredSelection()
+        let selectionAtStart = expectedSelectionForPublishedSnapshot(copySnapshot)
         #if DEBUG
             var selectionFields = debugSelectionFields(selectionAtStart)
             selectionFields["includeFiles"] = "\(includeFiles)"
@@ -836,6 +853,9 @@ class TokenCountingViewModel: ObservableObject {
         lastInstructionsTokens = instructionsTokensLocal
         lastGitDiffTokens = gitDiffTokens
         lastPublishedSelection = selectionAtStart
+        lastPublishedCodeMapUsage = accountingCodeMapUsage
+        lastPublishedFilePathDisplay = settings.filePathDisplayOption
+        lastPublishedEntryMetricsSnapshot = accountingResult.entryMetricsSnapshot
         copyContextTotalTokens = copyTotal
         copyContextTokenCountString = copyTokenString
         didComputeBaseline = true
@@ -899,51 +919,56 @@ class TokenCountingViewModel: ObservableObject {
 
         var gitDiffTokens = gitDiffTokenCount
         if kinds.contains(.gitDiff) {
-            if let fileManager {
-                // Check if artifact files are selected - if so, they're already counted as normal files.
-                let hasSelectedArtifacts: Bool
-                if copySnapshot.includeFiles {
-                    let store = fileManager.workspaceFileContextStore
-                    let selection = currentStoredSelection(includeFiles: true)
-                    let resolution = await promptContextAccountingService.resolveEntries(
-                        selection: selection,
-                        store: store,
-                        rootScope: .allLoaded,
-                        profile: .uiAssisted,
-                        codeMapUsage: copySnapshot.includeFiles ? copySnapshot.codeMapUsage : .none
-                    )
-                    let (diffEntries, _) = PromptPackagingService.partitionPromptEntriesForGitDiff(resolution.entries)
-                    hasSelectedArtifacts = !diffEntries.isEmpty
-                } else {
-                    hasSelectedArtifacts = false
-                }
+            switch copySnapshot.gitInclusion {
+            case .none:
+                gitDiffTokens = 0
+            case .selected, .complete:
+                if let fileManager {
+                    // Check if artifact files are selected - if so, they're already counted as normal files.
+                    let hasSelectedArtifacts: Bool
+                    if copySnapshot.includeFiles {
+                        let store = fileManager.workspaceFileContextStore
+                        let selection = currentStoredSelection(includeFiles: true)
+                        let resolution = await promptContextAccountingService.resolveEntries(
+                            selection: selection,
+                            store: store,
+                            rootScope: .allLoaded,
+                            profile: .uiAssisted,
+                            codeMapUsage: copySnapshot.codeMapUsage
+                        )
+                        let (diffEntries, _) = PromptPackagingService.partitionPromptEntriesForGitDiff(resolution.entries)
+                        hasSelectedArtifacts = !diffEntries.isEmpty
+                    } else {
+                        hasSelectedArtifacts = false
+                    }
 
-                if hasSelectedArtifacts {
-                    // Artifact files are selected - they're counted as normal files, not as gitDiffTokens
-                    gitDiffTokens = 0
-                } else if let gitViewModel {
-                    // No artifact files - use GitViewModel to generate diff if git inclusion is enabled
-                    switch copySnapshot.gitInclusion {
-                    case .none:
+                    if hasSelectedArtifacts {
+                        // Artifact files are selected - they're counted as normal files, not as gitDiffTokens
                         gitDiffTokens = 0
-                    case .selected:
-                        if let diff = await gitViewModel.getDiffUsing(inclusionMode: .selectedFiles) {
-                            gitDiffTokens = TokenCalculationService.estimateTokens(for: diff)
-                        } else {
+                    } else if let gitViewModel {
+                        // No artifact files - use GitViewModel to generate diff if git inclusion is enabled
+                        switch copySnapshot.gitInclusion {
+                        case .none:
                             gitDiffTokens = 0
+                        case .selected:
+                            if let diff = await gitViewModel.getDiffUsing(inclusionMode: .selectedFiles) {
+                                gitDiffTokens = TokenCalculationService.estimateTokens(for: diff)
+                            } else {
+                                gitDiffTokens = 0
+                            }
+                        case .complete:
+                            if let diff = await gitViewModel.getDiffUsing(inclusionMode: .all) {
+                                gitDiffTokens = TokenCalculationService.estimateTokens(for: diff)
+                            } else {
+                                gitDiffTokens = 0
+                            }
                         }
-                    case .complete:
-                        if let diff = await gitViewModel.getDiffUsing(inclusionMode: .all) {
-                            gitDiffTokens = TokenCalculationService.estimateTokens(for: diff)
-                        } else {
-                            gitDiffTokens = 0
-                        }
+                    } else {
+                        gitDiffTokens = 0
                     }
                 } else {
                     gitDiffTokens = 0
                 }
-            } else {
-                gitDiffTokens = 0
             }
             gitDiffTokenCount = gitDiffTokens
             gitDiffTokenCountString = String(format: "%.2fk", Double(gitDiffTokens) / 1000.0)
@@ -1063,6 +1088,9 @@ class TokenCountingViewModel: ObservableObject {
         scannedLanguages = []
         codeMapContent = ""
         codemapPresentation = .empty
+        lastPublishedEntryMetricsSnapshot = .empty
+        lastPublishedCodeMapUsage = nil
+        lastPublishedFilePathDisplay = nil
         fileTreeContent = ""
         codeMapFileCount = 0
         codeMapTokenCount = 0

--- a/Sources/RepoPrompt/Features/Settings/Views/KeyboardShortcutsSettingsView.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/KeyboardShortcutsSettingsView.swift
@@ -19,6 +19,12 @@ enum KeyboardShortcutCatalog {
             bindings: [
                 .init(id: "agent-new", title: "New Agent chat", detail: nil, name: .agentNewChat),
                 .init(id: "toggle-sidebar", title: "Toggle session sidebar", detail: "Show or hide the Agent sessions list.", name: .toggleNavigationSidebar),
+                .init(
+                    id: "toggle-compose",
+                    title: "Toggle Compose",
+                    detail: "Show or hide the Compose inspector.",
+                    name: .toggleComposeInspector
+                ),
                 .init(id: "agent-nav-current", title: "Show Agent Session Switcher", detail: "Jump between Agent sessions in the focused window.", name: .showCurrentWindowAgentNavigationHUD),
                 .init(id: "agent-nav-all", title: "Search all Agent sessions", detail: "Jump to active or recent Agent sessions across windows.", name: .showAllAgentsNavigationHUD)
             ]

--- a/Sources/RepoPrompt/Features/WorkspaceFiles/ViewModels/GitViewModel.swift
+++ b/Sources/RepoPrompt/Features/WorkspaceFiles/ViewModels/GitViewModel.swift
@@ -117,11 +117,13 @@ final class GitViewModel: ObservableObject {
     #endif
 
     private var resolvedStateTask: Task<Void, Never>?
+    private var resolvedStateGeneration: Int = 0
     private var latestStatusGeneration: Int = 0
     private var latestStatusRootPath: String?
     private var currentGitRootPath: String?
 
     private var unstagedFileSearchIndex: [(file: VCSUncommittedFile, pathKey: String)] = []
+    private var selectedChangedAbsolutePaths: Set<String> = []
 
     // Cache for git diffs to avoid regenerating for token counting
     private var cachedDiff: String?
@@ -192,13 +194,10 @@ final class GitViewModel: ObservableObject {
 
         reconcileSelectedDiffBranchIfInvalid()
 
-        // Update selection states when files change
         if filesChanged {
             invalidateDiffCache()
-            scheduleResolvedStateRebuild(for: snapshot)
-        } else if isPopoverVisible {
-            updateFileSelectionStates()
         }
+        scheduleResolvedStateRebuild(for: snapshot)
     }
 
     private struct ResolvedStateInput {
@@ -209,6 +208,8 @@ final class GitViewModel: ObservableObject {
 
     private struct ResolvedStateOutput {
         let fileSelectionStates: [String: Bool]
+        let changedAbsolutePaths: Set<String>
+        let selectedAbsolutePaths: Set<String>
     }
 
     private func scheduleResolvedStateRebuild(for snapshot: GitStatusActor.GitStatusSnapshot) {
@@ -222,6 +223,13 @@ final class GitViewModel: ObservableObject {
         )
     }
 
+    @discardableResult
+    private func supersedeResolvedStateRebuild() -> Int {
+        resolvedStateGeneration &+= 1
+        resolvedStateTask?.cancel()
+        return resolvedStateGeneration
+    }
+
     private func scheduleResolvedStateRebuild(
         baseRootPath: String?,
         unstagedRelativePaths: [String],
@@ -229,11 +237,11 @@ final class GitViewModel: ObservableObject {
         generation: Int,
         rootPath: String?
     ) {
-        resolvedStateTask?.cancel()
+        let rebuildGeneration = supersedeResolvedStateRebuild()
 
-        guard let fileManager else { return }
-        guard let baseRootPath, !unstagedRelativePaths.isEmpty else {
+        guard let fileManager, let baseRootPath else {
             fileSelectionStates = [:]
+            selectedChangedAbsolutePaths = []
             return
         }
 
@@ -244,38 +252,67 @@ final class GitViewModel: ObservableObject {
             selectedAbsolutePaths: selectedAbsPaths
         )
 
-        resolvedStateTask = Task.detached(priority: .userInitiated) { [input, generation, rootPath, selectedRootPath] in
+        resolvedStateTask = Task.detached(
+            priority: .userInitiated
+        ) { [input, generation, rebuildGeneration, rootPath, selectedRootPath] in
             if Task.isCancelled { return }
             let output = Self.buildResolvedState(input: input)
             if Task.isCancelled { return }
 
             await MainActor.run { [weak self] in
-                guard let self else { return }
                 guard !Task.isCancelled else { return }
-                guard generation == latestStatusGeneration else { return }
-                if let rootPath {
-                    guard rootPath == latestStatusRootPath else { return }
-                }
-                if let selectedRootPath {
-                    guard selectedRootPath == selectedRootFolder?.fullPath else { return }
-                }
-
-                fileSelectionStates = output.fileSelectionStates
+                self?.publishResolvedState(
+                    output,
+                    statusGeneration: generation,
+                    rebuildGeneration: rebuildGeneration,
+                    rootPath: rootPath,
+                    selectedRootPath: selectedRootPath
+                )
             }
         }
     }
 
-    private nonisolated static func buildResolvedState(input: ResolvedStateInput) -> ResolvedStateOutput {
-        let selectedAbs = Set(input.selectedAbsolutePaths.map { normalizeForComparison($0) })
-        var states: [String: Bool] = [:]
-        states.reserveCapacity(input.unstagedRelativePaths.count)
-
-        for relativePath in input.unstagedRelativePaths {
-            let abs = normalizedAbsolutePath(for: relativePath, baseRootPath: input.baseRootPath)
-            states[relativePath] = selectedAbs.contains(abs)
+    private func publishResolvedState(
+        _ output: ResolvedStateOutput,
+        statusGeneration: Int,
+        rebuildGeneration: Int,
+        rootPath: String?,
+        selectedRootPath: String?
+    ) {
+        guard rebuildGeneration == resolvedStateGeneration else { return }
+        guard statusGeneration == latestStatusGeneration else { return }
+        if let rootPath {
+            guard rootPath == latestStatusRootPath else { return }
+        }
+        if let selectedRootPath {
+            guard selectedRootPath == selectedRootFolder?.fullPath else { return }
         }
 
-        return ResolvedStateOutput(fileSelectionStates: states)
+        fileSelectionStates = output.fileSelectionStates
+        reconcileTrackedSelectedChangedPaths(
+            changedAbsolutePaths: output.changedAbsolutePaths,
+            selectedAbsolutePaths: output.selectedAbsolutePaths
+        )
+    }
+
+    private nonisolated static func buildResolvedState(input: ResolvedStateInput) -> ResolvedStateOutput {
+        let selectedAbsolutePaths = Set(input.selectedAbsolutePaths.map { normalizeForComparison($0) })
+        var states: [String: Bool] = [:]
+        var changedAbsolutePaths = Set<String>()
+        states.reserveCapacity(input.unstagedRelativePaths.count)
+        changedAbsolutePaths.reserveCapacity(input.unstagedRelativePaths.count)
+
+        for relativePath in input.unstagedRelativePaths {
+            let absolutePath = normalizedAbsolutePath(for: relativePath, baseRootPath: input.baseRootPath)
+            changedAbsolutePaths.insert(absolutePath)
+            states[relativePath] = selectedAbsolutePaths.contains(absolutePath)
+        }
+
+        return ResolvedStateOutput(
+            fileSelectionStates: states,
+            changedAbsolutePaths: changedAbsolutePaths,
+            selectedAbsolutePaths: selectedAbsolutePaths
+        )
     }
 
     private func setupModeObservers() {
@@ -324,6 +361,15 @@ final class GitViewModel: ObservableObject {
 
     private func setupFileManagerObservers(_ fileManager: WorkspaceFilesViewModel?) {
         guard let fileManager else { return }
+
+        fileManager.$selectedFiles
+            .dropFirst()
+            .sink { [weak self] selectedFiles in
+                guard let self else { return }
+                supersedeResolvedStateRebuild()
+                reconcileTrackedSelectedChangedPaths(selectedFiles: selectedFiles)
+            }
+            .store(in: &cancellables)
 
         // Observe file manager selection changes only when popover is visible
         fileManager.$selectedFiles
@@ -517,6 +563,42 @@ final class GitViewModel: ObservableObject {
             testWindowCloseTask = task
         }
 
+        var test_trackedSelectedChangedAbsolutePaths: Set<String> {
+            selectedChangedAbsolutePaths
+        }
+
+        var test_resolvedStateGeneration: Int {
+            resolvedStateGeneration
+        }
+
+        func test_publishSelectedChangedProjection(
+            changedAbsolutePaths: Set<String>,
+            selectedAbsolutePaths: Set<String>,
+            rebuildGeneration: Int
+        ) {
+            publishResolvedState(
+                ResolvedStateOutput(
+                    fileSelectionStates: [:],
+                    changedAbsolutePaths: changedAbsolutePaths,
+                    selectedAbsolutePaths: selectedAbsolutePaths
+                ),
+                statusGeneration: latestStatusGeneration,
+                rebuildGeneration: rebuildGeneration,
+                rootPath: latestStatusRootPath,
+                selectedRootPath: selectedRootFolder?.fullPath
+            )
+        }
+
+        func test_applyStatusSnapshot(_ snapshot: GitStatusActor.GitStatusSnapshot) async {
+            apply(snapshot)
+            await resolvedStateTask?.value
+        }
+
+        func test_rebuildSelectionProjection() async {
+            updateFileSelectionStates()
+            await resolvedStateTask?.value
+        }
+
     #endif
 
     private struct PeriodicGitContextRefreshRequest {
@@ -681,6 +763,7 @@ final class GitViewModel: ObservableObject {
         let resolvedPath = getResolvedPath(for: relativePath)
         fileManager.selectPath(resolvedPath, kind: nil)
 
+        selectedChangedAbsolutePaths.insert(resolvedPath)
         fileSelectionStates[relativePath] = true
 
         if gitDiffInclusionMode == .selectedFiles {
@@ -694,6 +777,7 @@ final class GitViewModel: ObservableObject {
         let resolvedPath = getResolvedPath(for: relativePath)
         fileManager.deselectPath(resolvedPath, kind: nil)
 
+        selectedChangedAbsolutePaths.remove(resolvedPath)
         fileSelectionStates[relativePath] = false
 
         if gitDiffInclusionMode == .selectedFiles {
@@ -703,6 +787,14 @@ final class GitViewModel: ObservableObject {
 
     func isFileSelected(_ relativePath: String) -> Bool {
         fileSelectionStates[relativePath] ?? false
+    }
+
+    var hasCurrentSelectedChangedFiles: Bool {
+        !selectedChangedPaths().absolute.isEmpty
+    }
+
+    var hasTrackedSelectedChangedFiles: Bool {
+        !selectedChangedAbsolutePaths.isEmpty || hasCurrentSelectedChangedFiles
     }
 
     private func updateFileSelectionStates() {
@@ -719,6 +811,26 @@ final class GitViewModel: ObservableObject {
     func refreshSelectionStatesIfNeeded() {
         guard isGitActive, isPopoverVisible else { return }
         updateFileSelectionStates()
+    }
+
+    private func reconcileTrackedSelectedChangedPaths(
+        changedAbsolutePaths: Set<String>,
+        selectedAbsolutePaths: Set<String>
+    ) {
+        selectedChangedAbsolutePaths = changedAbsolutePaths.intersection(selectedAbsolutePaths)
+    }
+
+    private func reconcileTrackedSelectedChangedPaths(selectedFiles: [FileViewModel]) {
+        let changedAbsolutePaths = Set(unstagedFiles.map { getResolvedPath(for: $0.path) })
+        let selectedAbsolutePaths = Set(selectedFiles.map { Self.normalizeForComparison($0.fullPath) })
+        reconcileTrackedSelectedChangedPaths(
+            changedAbsolutePaths: changedAbsolutePaths,
+            selectedAbsolutePaths: selectedAbsolutePaths
+        )
+    }
+
+    private func syncTrackedSelectedChangedPathsFromCurrentSnapshot() {
+        reconcileTrackedSelectedChangedPaths(selectedFiles: fileManager?.selectedFiles ?? [])
     }
 
     // MARK: - Public accessors for artifact publishing
@@ -839,7 +951,8 @@ final class GitViewModel: ObservableObject {
         rootUpdateTask?.cancel()
         unstagedFiles = []
         fileSelectionStates = [:]
-        resolvedStateTask?.cancel()
+        selectedChangedAbsolutePaths.removeAll()
+        supersedeResolvedStateRebuild()
         latestStatusGeneration = 0
         latestStatusRootPath = nil
         currentGitRootPath = nil
@@ -905,6 +1018,7 @@ final class GitViewModel: ObservableObject {
 
         await fileManager.selectFiles(withPaths: resolvedPaths, allowEmpty: false, clear: false)
 
+        selectedChangedAbsolutePaths.formUnion(Set(resolvedPaths))
         updateFileSelectionStates()
 
         if gitDiffInclusionMode == .selectedFiles {
@@ -922,6 +1036,7 @@ final class GitViewModel: ObservableObject {
 
         await fileManager.selectFiles(withPaths: resolvedPaths, allowEmpty: false, clear: false)
 
+        selectedChangedAbsolutePaths.formUnion(Set(resolvedPaths))
         updateFileSelectionStates()
         if gitDiffInclusionMode == .selectedFiles {
             invalidateDiffCache()
@@ -937,6 +1052,7 @@ final class GitViewModel: ObservableObject {
 
         await fileManager.selectFiles(withPaths: resolvedPaths, allowEmpty: false, clear: true)
 
+        selectedChangedAbsolutePaths = Set(resolvedPaths)
         updateFileSelectionStates()
 
         if gitDiffInclusionMode == .selectedFiles {
@@ -952,6 +1068,7 @@ final class GitViewModel: ObservableObject {
         let resolved = unstagedFiles.map { getResolvedPath(for: $0.path) }
         await fileManager.deselectFiles(withPaths: resolved)
 
+        selectedChangedAbsolutePaths.subtract(Set(resolved))
         updateFileSelectionStates()
         if gitDiffInclusionMode == .selectedFiles {
             invalidateDiffCache()
@@ -968,6 +1085,30 @@ final class GitViewModel: ObservableObject {
 
         await fileManager.deselectFiles(withPaths: resolved)
 
+        selectedChangedAbsolutePaths.subtract(Set(resolved))
+        updateFileSelectionStates()
+        if gitDiffInclusionMode == .selectedFiles {
+            invalidateDiffCache()
+        }
+    }
+
+    func clearSelectedChangedFilesFromFileManager() async {
+        syncTrackedSelectedChangedPathsFromCurrentSnapshot()
+        let resolved = selectedChangedAbsolutePaths.sorted()
+
+        selectedChangedAbsolutePaths.removeAll()
+        fileSelectionStates = fileSelectionStates.mapValues { _ in false }
+        guard let fileManager, !resolved.isEmpty else {
+            if gitDiffInclusionMode == .selectedFiles {
+                invalidateDiffCache()
+            }
+            return
+        }
+
+        isBulkSelectionRunning = true
+        defer { isBulkSelectionRunning = false }
+
+        await fileManager.deselectFiles(withPaths: resolved)
         updateFileSelectionStates()
         if gitDiffInclusionMode == .selectedFiles {
             invalidateDiffCache()

--- a/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService+ContentLoading.swift
+++ b/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService+ContentLoading.swift
@@ -99,6 +99,12 @@ struct FileContentPrefix {
     let truncated: Bool
 }
 
+struct ResolvedFileContentLocation: Equatable, Hashable {
+    let resolvedRootURL: URL
+    let resolvedFileURL: URL
+    let relativePath: String
+}
+
 private struct ValidatedContentFile {
     let url: URL
     let fileSize: Int64
@@ -771,6 +777,8 @@ actor ContentReadAsyncLimiter {
 }
 
 extension FileSystemService {
+    private static let defaultContentReadChunkSize = 1_048_576
+    private static let defaultContentReadFileSizeLimit: Int64 = 10_000_000
     private static let contentReadWorkerLimit = max(2, min(4, ProcessInfo.processInfo.activeProcessorCount))
     private static let contentReadWorkerLimiter = ContentReadAsyncLimiter(
         capacity: contentReadWorkerLimit,
@@ -800,6 +808,42 @@ extension FileSystemService {
             priority: priority,
             operation: operation
         )
+    }
+
+    nonisolated static func loadEntireFileContentOptimized(
+        at location: ResolvedFileContentLocation,
+        workloadClass: ContentReadWorkloadClass
+    ) async throws -> String? {
+        try Task.checkCancellation()
+        let rootPath = StandardizedPath.absolute(location.resolvedRootURL.path)
+        let filePath = StandardizedPath.absolute(location.resolvedFileURL.path)
+        let relativePath = StandardizedPath.relative(location.relativePath)
+        guard !relativePath.isEmpty,
+              relativePath != "..",
+              !relativePath.hasPrefix("../"),
+              StandardizedPath.join(
+                  standardizedRoot: rootPath,
+                  standardizedRelativePath: relativePath
+              ) == filePath
+        else {
+            throw FileSystemError.invalidRelativePath
+        }
+        let request = assembleContentReadRequest(
+            cacheKey: relativePath,
+            relativePath: relativePath,
+            absolutePath: filePath,
+            standardizedRootPath: rootPath,
+            canonicalRootPath: rootPath,
+            skipSymlinks: true,
+            chunkSize: defaultContentReadChunkSize,
+            fileSizeLimit: defaultContentReadFileSizeLimit,
+            mode: .automatic,
+            workloadClass: workloadClass,
+            schedulerOwnerID: UUID()
+        )
+        let result = try await performContentReadOffActor(request)
+        try Task.checkCancellation()
+        return result.content
     }
 
     #if DEBUG
@@ -960,8 +1004,8 @@ extension FileSystemService {
         do {
             request = try makeContentReadRequest(
                 cacheKey: relativePath,
-                chunkSize: 1_048_576,
-                fileSizeLimit: 10_000_000,
+                chunkSize: Self.defaultContentReadChunkSize,
+                fileSizeLimit: Self.defaultContentReadFileSizeLimit,
                 mode: .automatic,
                 workloadClass: workloadClass
             )
@@ -1177,7 +1221,7 @@ extension FileSystemService {
             throw FileSystemError.invalidRelativePath
         }
         #if DEBUG
-            return ContentReadRequest(
+            return Self.assembleContentReadRequest(
                 cacheKey: cacheKey,
                 relativePath: relativePath,
                 absolutePath: absolutePath,
@@ -1192,7 +1236,7 @@ extension FileSystemService {
                 chunkReadHandler: contentReadChunkHandler
             )
         #else
-            return ContentReadRequest(
+            return Self.assembleContentReadRequest(
                 cacheKey: cacheKey,
                 relativePath: relativePath,
                 absolutePath: absolutePath,
@@ -1207,6 +1251,66 @@ extension FileSystemService {
             )
         #endif
     }
+
+    #if DEBUG
+        private nonisolated static func assembleContentReadRequest(
+            cacheKey: String,
+            relativePath: String,
+            absolutePath: String,
+            standardizedRootPath: String,
+            canonicalRootPath: String,
+            skipSymlinks: Bool,
+            chunkSize: Int,
+            fileSizeLimit: Int64,
+            mode: ContentReadMode,
+            workloadClass: ContentReadWorkloadClass,
+            schedulerOwnerID: UUID,
+            chunkReadHandler: (@Sendable (String) async -> Void)? = nil
+        ) -> ContentReadRequest {
+            ContentReadRequest(
+                cacheKey: cacheKey,
+                relativePath: relativePath,
+                absolutePath: absolutePath,
+                standardizedRootPath: standardizedRootPath,
+                canonicalRootPath: canonicalRootPath,
+                skipSymlinks: skipSymlinks,
+                chunkSize: chunkSize,
+                fileSizeLimit: fileSizeLimit,
+                mode: mode,
+                workloadClass: workloadClass,
+                schedulerOwnerID: schedulerOwnerID,
+                chunkReadHandler: chunkReadHandler
+            )
+        }
+    #else
+        private nonisolated static func assembleContentReadRequest(
+            cacheKey: String,
+            relativePath: String,
+            absolutePath: String,
+            standardizedRootPath: String,
+            canonicalRootPath: String,
+            skipSymlinks: Bool,
+            chunkSize: Int,
+            fileSizeLimit: Int64,
+            mode: ContentReadMode,
+            workloadClass: ContentReadWorkloadClass,
+            schedulerOwnerID: UUID
+        ) -> ContentReadRequest {
+            ContentReadRequest(
+                cacheKey: cacheKey,
+                relativePath: relativePath,
+                absolutePath: absolutePath,
+                standardizedRootPath: standardizedRootPath,
+                canonicalRootPath: canonicalRootPath,
+                skipSymlinks: skipSymlinks,
+                chunkSize: chunkSize,
+                fileSizeLimit: fileSizeLimit,
+                mode: mode,
+                workloadClass: workloadClass,
+                schedulerOwnerID: schedulerOwnerID
+            )
+        }
+    #endif
 
     private func performMeasuredContentReadOffActor(
         _ request: ContentReadRequest,

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+TokenStats.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+TokenStats.swift
@@ -117,13 +117,13 @@ extension MCPServerViewModel {
         if activeTabCompatibility {
             let publishedOverlay = publishedEntryResultsOverlay(
                 collections: collections,
-                base: [:]
+                base: [:],
+                includeSliceDisplayTokens: true
             )
             let published = promptVM.tokenCountingViewModel.latestPublishedTokenSnapshot(
                 for: effectiveSelection,
                 scheduleRefreshIfNeeded: allowActivePublishedSnapshotRefresh
             )
-
             var incompleteComponents = Self.virtualSnapshotIncompleteComponents(
                 collections: collections,
                 reliableFileIDs: publishedOverlay.reliableFileIDs
@@ -177,7 +177,8 @@ extension MCPServerViewModel {
         let cachedEvaluation = await cachedPromptEntriesEvaluation(collections: collections)
         let publishedOverlay = publishedEntryResultsOverlay(
             collections: collections,
-            base: cachedEvaluation.entryResultsByFileID
+            base: cachedEvaluation.entryResultsByFileID,
+            includeSliceDisplayTokens: false
         )
         let signature = virtualTokenSignature(
             context: context,
@@ -189,11 +190,10 @@ extension MCPServerViewModel {
         if allowVirtualTokenRefresh,
            let cachedSnapshot = mcpVirtualTokenSnapshotsByTabID[context.tabID]?[signature]
         {
-            var incompleteComponents = Self.virtualSnapshotIncompleteComponents(
+            let incompleteComponents = Self.virtualSnapshotIncompleteComponents(
                 collections: collections,
                 reliableFileIDs: Set(cachedSnapshot.entryResultsByFileID.keys)
             )
-            incompleteComponents.formUnion(cachedSnapshot.incompleteComponents ?? [])
             let orderedIncomplete = Self.orderedIncompleteComponents(incompleteComponents)
             // The virtual-token signature intentionally captures logical selection and prompt
             // shape, but not file-content, search-catalog, or codemap-authority generations.
@@ -274,7 +274,8 @@ extension MCPServerViewModel {
     @MainActor
     private func publishedEntryResultsOverlay(
         collections: SelectionReplyAssembler.SelectionCollections,
-        base: [UUID: PromptEntriesEvaluation.EntryResult]
+        base: [UUID: PromptEntriesEvaluation.EntryResult],
+        includeSliceDisplayTokens: Bool
     ) -> (
         entryResultsByFileID: [UUID: PromptEntriesEvaluation.EntryResult],
         reliableFileIDs: Set<UUID>
@@ -282,17 +283,26 @@ extension MCPServerViewModel {
         var entryResults = base
         var reliableFileIDs = Set<UUID>()
         for entry in collections.selected {
+            let renderMode: PromptEntriesEvaluation.RenderMode = entry.ranges?.isEmpty == false ? .slice : .full
+            if renderMode == .slice, !includeSliceDisplayTokens {
+                if entryResults[entry.file.id]?.renderMode == .slice {
+                    reliableFileIDs.insert(entry.file.id)
+                }
+                continue
+            }
             guard let info = promptVM.tokenCountingViewModel.latestPublishedTokenInfo(
                 forFullPath: entry.file.standardizedFullPath
             ) else { continue }
-            let renderMode: PromptEntriesEvaluation.RenderMode = entry.ranges?.isEmpty == false ? .slice : .full
+            let existing = entryResults[entry.file.id]
             let displayTokens = renderMode == .slice ? info.count : info.fullCount
             entryResults[entry.file.id] = .init(
                 fileID: entry.file.id,
+                renderedDisplayPath: existing?.renderedDisplayPath ?? entry.file.standardizedRelativePath,
                 renderMode: renderMode,
                 displayTokens: displayTokens,
                 fullTokens: info.fullCount,
-                codemapTokens: info.codemapCount
+                codemapTokens: info.codemapCount,
+                displayLineCount: existing?.displayLineCount
             )
             reliableFileIDs.insert(entry.file.id)
         }
@@ -300,12 +310,15 @@ extension MCPServerViewModel {
             guard let info = promptVM.tokenCountingViewModel.latestPublishedTokenInfo(
                 forFullPath: entry.file.standardizedFullPath
             ) else { continue }
+            let existing = entryResults[entry.file.id]
             entryResults[entry.file.id] = .init(
                 fileID: entry.file.id,
+                renderedDisplayPath: existing?.renderedDisplayPath ?? entry.file.standardizedRelativePath,
                 renderMode: .codemap,
                 displayTokens: info.codemapCount,
                 fullTokens: info.fullCount,
-                codemapTokens: info.codemapCount
+                codemapTokens: info.codemapCount,
+                displayLineCount: existing?.displayLineCount
             )
             reliableFileIDs.insert(entry.file.id)
         }

--- a/Sources/RepoPrompt/Infrastructure/Utilities/Shortcuts.swift
+++ b/Sources/RepoPrompt/Infrastructure/Utilities/Shortcuts.swift
@@ -39,6 +39,8 @@ extension KeyboardShortcuts.Name {
     static let agentNewChat = Self("agentNewChat", default: .init(.n, modifiers: [.command, .option]))
     /// Toggle the Agent session sidebar.
     static let toggleNavigationSidebar = Self("toggleNavigationSidebar", default: .init(.b, modifiers: [.command, .option]))
+    /// Toggle the Compose inspector.
+    static let toggleComposeInspector = Self("toggleComposeInspector", default: .init(.p, modifiers: [.command]))
     /// Show the current-window Agent navigation HUD.
     static let showCurrentWindowAgentNavigationHUD = Self("showCurrentWindowAgentNavigationHUD", default: .init(.k, modifiers: [.command]))
     /// Show the all-active/recent Agents navigation HUD.

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/Selection/WorkspaceSelectionCoordinator.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/Selection/WorkspaceSelectionCoordinator.swift
@@ -1,5 +1,6 @@
 import Combine
 import Foundation
+import OSLog
 
 struct WorkspaceSelectionIdentity: Hashable {
     let workspaceID: UUID
@@ -116,6 +117,24 @@ extension WorkspaceManagerViewModel: WorkspaceSelectionHost {
 /// selection source while the WorkspaceFiles UI adapter still owns checkbox state.
 @MainActor
 final class WorkspaceSelectionCoordinator {
+    private enum SelectionPersistenceResult {
+        case committed(StoredSelection)
+        case conflict(current: StoredSelection)
+        case targetUnavailable
+    }
+
+    private enum SelectionMutationKind: String {
+        case remove
+        case promote
+        case demote
+        case slices
+    }
+
+    private static let logger = Logger(
+        subsystem: "com.repoprompt.workspace",
+        category: "SelectionPersistence"
+    )
+
     struct Snapshot: Equatable {
         let tabID: UUID?
         let selection: StoredSelection
@@ -270,7 +289,7 @@ final class WorkspaceSelectionCoordinator {
         guard let workspaceManager,
               workspaceManager.composeTab(for: identity)?.selection == selection
         else { return }
-        updateMCPSelectionPresentation(
+        updateSelectionPresentation(
             selection,
             for: identity,
             workspaceManager: workspaceManager
@@ -334,20 +353,47 @@ final class WorkspaceSelectionCoordinator {
         peerSourceRevision: UInt64? = nil,
         peerMutationFence: MCPSelectionPeerMutationFence? = nil
     ) async -> StoredSelection {
+        switch await persistSelectionResult(
+            selection,
+            for: identity,
+            source: source,
+            mirrorToUIIfActive: mirrorToUIIfActive,
+            expectedCurrentSelection: expectedCurrentSelection,
+            peerSourceRevision: peerSourceRevision,
+            peerMutationFence: peerMutationFence
+        ) {
+        case let .committed(committed):
+            committed
+        case let .conflict(current):
+            current
+        case .targetUnavailable:
+            selection
+        }
+    }
+
+    private func persistSelectionResult(
+        _ selection: StoredSelection,
+        for identity: WorkspaceSelectionIdentity,
+        source: Source = .runtimeMutation,
+        mirrorToUIIfActive: Bool = true,
+        expectedCurrentSelection: StoredSelection? = nil,
+        peerSourceRevision: UInt64? = nil,
+        peerMutationFence: MCPSelectionPeerMutationFence? = nil
+    ) async -> SelectionPersistenceResult {
         guard let workspaceManager,
               let currentSelection = workspaceManager.composeTab(for: identity)?.selection
-        else { return selection }
+        else { return .targetUnavailable }
         if let expectedCurrentSelection,
            currentSelection != expectedCurrentSelection
         {
-            return currentSelection
+            return .conflict(current: currentSelection)
         }
         if source == .mcpPeerContext {
             guard let peerSourceRevision,
                   let peerMutationFence,
                   workspaceManager.canCommitMCPSelectionPeerMutation(peerMutationFence),
                   workspaceManager.acceptMCPPeerSelectionRevision(peerSourceRevision, for: identity)
-            else { return currentSelection }
+            else { return .conflict(current: currentSelection) }
         }
 
         let propagationRegistration = source == .mcpTabContext
@@ -361,9 +407,9 @@ final class WorkspaceSelectionCoordinator {
                 peerMutationFence,
                 source: source,
                 workspaceManager: workspaceManager
-            ) else { return currentSelection }
-            if source.isMCPSelectionSource {
-                updateMCPSelectionPresentation(
+            ) else { return .conflict(current: currentSelection) }
+            if shouldUpdateSelectionPresentation(source: source, mirrorToUI: mirrorToUI) {
+                updateSelectionPresentation(
                     selection,
                     for: identity,
                     workspaceManager: workspaceManager
@@ -389,7 +435,7 @@ final class WorkspaceSelectionCoordinator {
                     )
                 )
             }
-            return selection
+            return .committed(selection)
         }
 
         let requiredPeerMutationFence = source == .mcpPeerContext ? peerMutationFence : nil
@@ -397,14 +443,14 @@ final class WorkspaceSelectionCoordinator {
             selection,
             for: identity,
             peerMutationFence: requiredPeerMutationFence
-        ) else { return currentSelection }
+        ) else { return .targetUnavailable }
         guard canCommitPeerMutation(
             peerMutationFence,
             source: source,
             workspaceManager: workspaceManager
-        ) else { return selection }
-        if source.isMCPSelectionSource {
-            updateMCPSelectionPresentation(
+        ) else { return .committed(selection) }
+        if shouldUpdateSelectionPresentation(source: source, mirrorToUI: mirrorToUI) {
+            updateSelectionPresentation(
                 selection,
                 for: identity,
                 workspaceManager: workspaceManager
@@ -437,7 +483,7 @@ final class WorkspaceSelectionCoordinator {
                 )
             )
         }
-        return selection
+        return .committed(selection)
     }
 
     /// Applies a synchronous transform to the latest canonical tab selection and stores the
@@ -472,8 +518,8 @@ final class WorkspaceSelectionCoordinator {
             mirrorRevision = persistedRevision
         }
 
-        if source.isMCPSelectionSource {
-            updateMCPSelectionPresentation(after, for: identity, workspaceManager: workspaceManager)
+        if shouldUpdateSelectionPresentation(source: source, mirrorToUI: mirrorToUI) {
+            updateSelectionPresentation(after, for: identity, workspaceManager: workspaceManager)
         }
         if after != before, !mirrorToUI || source.isMCPSelectionSource {
             changeSubject.send(Change(tabID: identity.tabID, selection: after, source: source))
@@ -569,6 +615,283 @@ final class WorkspaceSelectionCoordinator {
             _ = await persistActiveSelection(result.selection, source: .runtimeMutation)
         }
         return result
+    }
+
+    private func mutationPersistenceOutcome(
+        _ result: SelectionPersistenceResult,
+        sourceSelection: StoredSelection,
+        identity: WorkspaceSelectionIdentity,
+        kind: SelectionMutationKind
+    ) -> (selection: StoredSelection, mutated: Bool) {
+        switch result {
+        case let .committed(selection):
+            return (selection, true)
+        case let .conflict(current):
+            Self.logger.debug(
+                """
+                Selection mutation conflict kind=\(kind.rawValue, privacy: .public) \
+                workspaceID=\(identity.workspaceID.uuidString, privacy: .public) \
+                tabID=\(identity.tabID.uuidString, privacy: .public)
+                """
+            )
+            return (current, false)
+        case .targetUnavailable:
+            Self.logger.debug(
+                """
+                Selection mutation target unavailable kind=\(kind.rawValue, privacy: .public) \
+                workspaceID=\(identity.workspaceID.uuidString, privacy: .public) \
+                tabID=\(identity.tabID.uuidString, privacy: .public)
+                """
+            )
+            return (sourceSelection, false)
+        }
+    }
+
+    @discardableResult
+    func removePathsInActiveSelection(
+        paths: [String],
+        mode: String = "full",
+        rootScope: WorkspaceLookupRootScope = .visibleWorkspace,
+        lookupContext explicitLookupContext: WorkspaceLookupContext? = nil
+    ) async -> WorkspaceRemoveSelectionResult {
+        guard let identity = activeSelectionIdentity() else {
+            return WorkspaceRemoveSelectionResult(selection: StoredSelection(), invalidPaths: [], resolvedMap: [:], mutated: false)
+        }
+        let lookupContext = explicitLookupContext ?? WorkspaceLookupContext(rootScope: rootScope, bindingProjection: nil)
+        let currentSelection = activeSelectionSnapshot(flushPendingUI: true).selection
+        let current = lookupContext.physicalizeSelection(currentSelection)
+        let translatedPaths = lookupContext.translateInputPaths(paths)
+        let result = await mutationService.removePaths(
+            existing: current,
+            paths: translatedPaths,
+            rawPaths: paths,
+            mode: mode,
+            rootScope: lookupContext.rootScope
+        )
+        let logicalSelection = lookupContext.logicalizeSelection(result.selection)
+        guard result.mutated else {
+            return WorkspaceRemoveSelectionResult(
+                selection: logicalSelection,
+                invalidPaths: result.invalidPaths,
+                resolvedMap: result.resolvedMap,
+                mutated: false
+            )
+        }
+        let persistenceResult = await persistSelectionResult(
+            logicalSelection,
+            for: identity,
+            source: .runtimeMutation,
+            expectedCurrentSelection: currentSelection
+        )
+        let outcome = mutationPersistenceOutcome(
+            persistenceResult,
+            sourceSelection: currentSelection,
+            identity: identity,
+            kind: .remove
+        )
+        return WorkspaceRemoveSelectionResult(
+            selection: outcome.selection,
+            invalidPaths: result.invalidPaths,
+            resolvedMap: result.resolvedMap,
+            mutated: outcome.mutated
+        )
+    }
+
+    @discardableResult
+    func promotePathsInActiveSelection(
+        paths: [String],
+        rootScope: WorkspaceLookupRootScope = .visibleWorkspace,
+        lookupContext explicitLookupContext: WorkspaceLookupContext? = nil
+    ) async -> (selection: StoredSelection, invalidPaths: [String], mutated: Bool) {
+        guard let identity = activeSelectionIdentity() else {
+            return (StoredSelection(), [], false)
+        }
+        let currentSelection = activeSelectionSnapshot(flushPendingUI: true).selection
+        return await promotePathsInSelection(
+            paths: paths,
+            for: identity,
+            expectedCurrentSelection: currentSelection,
+            rootScope: rootScope,
+            lookupContext: explicitLookupContext
+        )
+    }
+
+    @discardableResult
+    func promotePathsInSelection(
+        paths: [String],
+        for identity: WorkspaceSelectionIdentity,
+        expectedCurrentSelection: StoredSelection,
+        rootScope: WorkspaceLookupRootScope = .visibleWorkspace,
+        lookupContext explicitLookupContext: WorkspaceLookupContext? = nil
+    ) async -> (selection: StoredSelection, invalidPaths: [String], mutated: Bool) {
+        let lookupContext = explicitLookupContext ?? WorkspaceLookupContext(rootScope: rootScope, bindingProjection: nil)
+        let current = lookupContext.physicalizeSelection(expectedCurrentSelection)
+        let translatedPaths = lookupContext.translateInputPaths(paths)
+        let result = await mutationService.promotePaths(
+            existing: current,
+            paths: translatedPaths,
+            rawPaths: paths,
+            rootScope: lookupContext.rootScope
+        )
+        let logicalSelection = lookupContext.logicalizeSelection(result.selection)
+        guard result.mutated else {
+            return (logicalSelection, result.invalidPaths, false)
+        }
+        let persistenceResult = await persistSelectionResult(
+            logicalSelection,
+            for: identity,
+            source: .runtimeMutation,
+            expectedCurrentSelection: expectedCurrentSelection
+        )
+        let outcome = mutationPersistenceOutcome(
+            persistenceResult,
+            sourceSelection: expectedCurrentSelection,
+            identity: identity,
+            kind: .promote
+        )
+        return (outcome.selection, result.invalidPaths, outcome.mutated)
+    }
+
+    @discardableResult
+    func demotePathsInActiveSelection(
+        paths: [String],
+        rootScope: WorkspaceLookupRootScope = .visibleWorkspace,
+        lookupContext explicitLookupContext: WorkspaceLookupContext? = nil
+    ) async -> WorkspaceDemoteSelectionResult {
+        guard let identity = activeSelectionIdentity() else {
+            return WorkspaceDemoteSelectionResult(
+                selection: StoredSelection(),
+                invalidPaths: [],
+                codemapUnavailable: [],
+                mutated: false
+            )
+        }
+        let currentSelection = activeSelectionSnapshot(flushPendingUI: true).selection
+        return await demotePathsInSelection(
+            paths: paths,
+            for: identity,
+            expectedCurrentSelection: currentSelection,
+            rootScope: rootScope,
+            lookupContext: explicitLookupContext
+        )
+    }
+
+    @discardableResult
+    func demotePathsInSelection(
+        paths: [String],
+        for identity: WorkspaceSelectionIdentity,
+        expectedCurrentSelection: StoredSelection,
+        rootScope: WorkspaceLookupRootScope = .visibleWorkspace,
+        lookupContext explicitLookupContext: WorkspaceLookupContext? = nil
+    ) async -> WorkspaceDemoteSelectionResult {
+        let lookupContext = explicitLookupContext ?? WorkspaceLookupContext(rootScope: rootScope, bindingProjection: nil)
+        let current = lookupContext.physicalizeSelection(expectedCurrentSelection)
+        let translatedPaths = lookupContext.translateInputPaths(paths)
+        let result = await mutationService.demotePaths(
+            existing: current,
+            paths: translatedPaths,
+            rawPaths: paths,
+            rootScope: lookupContext.rootScope
+        )
+        let logicalSelection = lookupContext.logicalizeSelection(result.selection)
+        guard result.mutated else {
+            return WorkspaceDemoteSelectionResult(
+                selection: logicalSelection,
+                invalidPaths: result.invalidPaths,
+                codemapUnavailable: result.codemapUnavailable,
+                mutated: false
+            )
+        }
+        let persistenceResult = await persistSelectionResult(
+            logicalSelection,
+            for: identity,
+            source: .runtimeMutation,
+            expectedCurrentSelection: expectedCurrentSelection
+        )
+        let outcome = mutationPersistenceOutcome(
+            persistenceResult,
+            sourceSelection: expectedCurrentSelection,
+            identity: identity,
+            kind: .demote
+        )
+        return WorkspaceDemoteSelectionResult(
+            selection: outcome.selection,
+            invalidPaths: result.invalidPaths,
+            codemapUnavailable: result.codemapUnavailable,
+            mutated: outcome.mutated
+        )
+    }
+
+    @discardableResult
+    func clearSlicesInActiveSelection(
+        paths: [String],
+        rootScope: WorkspaceLookupRootScope = .visibleWorkspace,
+        lookupContext explicitLookupContext: WorkspaceLookupContext? = nil
+    ) async -> WorkspaceSliceSelectionMutationResult {
+        guard let identity = activeSelectionIdentity() else {
+            return WorkspaceSliceSelectionMutationResult(
+                selection: StoredSelection(),
+                invalidPaths: [],
+                resolvedMap: [:],
+                mutated: false
+            )
+        }
+        let currentSelection = activeSelectionSnapshot(flushPendingUI: true).selection
+        return await clearSlicesInSelection(
+            paths: paths,
+            for: identity,
+            expectedCurrentSelection: currentSelection,
+            rootScope: rootScope,
+            lookupContext: explicitLookupContext
+        )
+    }
+
+    @discardableResult
+    func clearSlicesInSelection(
+        paths: [String],
+        for identity: WorkspaceSelectionIdentity,
+        expectedCurrentSelection: StoredSelection,
+        rootScope: WorkspaceLookupRootScope = .visibleWorkspace,
+        lookupContext explicitLookupContext: WorkspaceLookupContext? = nil
+    ) async -> WorkspaceSliceSelectionMutationResult {
+        let lookupContext = explicitLookupContext ?? WorkspaceLookupContext(rootScope: rootScope, bindingProjection: nil)
+        let current = lookupContext.physicalizeSelection(expectedCurrentSelection)
+        let entries = lookupContext.translateSliceInputs(
+            paths.map { WorkspaceSelectionSliceInput(path: $0, ranges: []) }
+        )
+        let result = await mutationService.mutateSlices(
+            base: current,
+            entries: entries,
+            mode: .remove,
+            rootScope: lookupContext.rootScope
+        )
+        let logicalSelection = lookupContext.logicalizeSelection(result.selection)
+        guard result.mutated else {
+            return WorkspaceSliceSelectionMutationResult(
+                selection: logicalSelection,
+                invalidPaths: result.invalidPaths,
+                resolvedMap: result.resolvedMap,
+                mutated: false
+            )
+        }
+        let persistenceResult = await persistSelectionResult(
+            logicalSelection,
+            for: identity,
+            source: .runtimeMutation,
+            expectedCurrentSelection: expectedCurrentSelection
+        )
+        let outcome = mutationPersistenceOutcome(
+            persistenceResult,
+            sourceSelection: expectedCurrentSelection,
+            identity: identity,
+            kind: .slices
+        )
+        return WorkspaceSliceSelectionMutationResult(
+            selection: outcome.selection,
+            invalidPaths: result.invalidPaths,
+            resolvedMap: result.resolvedMap,
+            mutated: outcome.mutated
+        )
     }
 
     func withApplyingSelectionMirror<T>(_ operation: () async throws -> T) async rethrows -> T {
@@ -750,7 +1073,11 @@ final class WorkspaceSelectionCoordinator {
         return workspaceManager.canCommitMCPSelectionPeerMutation(fence)
     }
 
-    private func updateMCPSelectionPresentation(
+    private func shouldUpdateSelectionPresentation(source: Source, mirrorToUI: Bool) -> Bool {
+        source.isMCPSelectionSource || (source == .runtimeMutation && mirrorToUI)
+    }
+
+    private func updateSelectionPresentation(
         _ selection: StoredSelection,
         for identity: WorkspaceSelectionIdentity,
         workspaceManager: any WorkspaceSelectionHost

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/Selection/WorkspaceSelectionMutationService.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/Selection/WorkspaceSelectionMutationService.swift
@@ -115,19 +115,22 @@ struct WorkspaceSelectionMutationService {
     let codemapsGloballyDisabledMessage: String
     let automaticSelectionPolicy: WorkspaceCodemapAutomaticSelectionRequestPolicy
     let automaticSelectionWaiter: WorkspaceCodemapAutomaticSelectionWaiter
+    let removePathsDidCaptureExistingHook: @Sendable (StoredSelection) async -> Void
 
     init(
         store: WorkspaceFileContextStore,
         codemapsGloballyDisabled: Bool = false,
         codemapsGloballyDisabledMessage: String = "Code maps are disabled for this tool.",
         automaticSelectionPolicy: WorkspaceCodemapAutomaticSelectionRequestPolicy = .default,
-        automaticSelectionWaiter: WorkspaceCodemapAutomaticSelectionWaiter = .production
+        automaticSelectionWaiter: WorkspaceCodemapAutomaticSelectionWaiter = .production,
+        removePathsDidCaptureExistingHook: @escaping @Sendable (StoredSelection) async -> Void = { _ in }
     ) {
         self.store = store
         self.codemapsGloballyDisabled = codemapsGloballyDisabled
         self.codemapsGloballyDisabledMessage = codemapsGloballyDisabledMessage
         self.automaticSelectionPolicy = automaticSelectionPolicy
         self.automaticSelectionWaiter = automaticSelectionWaiter
+        self.removePathsDidCaptureExistingHook = removePathsDidCaptureExistingHook
     }
 
     func buildSelection(
@@ -502,6 +505,7 @@ struct WorkspaceSelectionMutationService {
         mode: String = "full",
         rootScope: WorkspaceLookupRootScope = .visibleWorkspace
     ) async -> WorkspaceRemoveSelectionResult {
+        await removePathsDidCaptureExistingHook(existing)
         if mode == "codemap_only" {
             let resolution = await resolveSelectionCandidates(
                 paths: paths,

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/TokenAccounting/PromptContextEntryMetrics.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/TokenAccounting/PromptContextEntryMetrics.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+struct PromptContextEntryMetric: Equatable {
+    let fileID: UUID
+    let standardizedFullPath: String
+    let renderedDisplayPath: String
+    let renderMode: PromptEntriesEvaluation.RenderMode
+    let displayTokenCount: Int
+    let displayPercentage: Double
+    let includedLineCount: Int?
+}
+
+struct PromptContextEntryMetricsSnapshot: Equatable {
+    let totalSelectedDisplayTokens: Int
+    let metricsByFileID: [UUID: PromptContextEntryMetric]
+    let metricsByStandardizedFullPath: [String: PromptContextEntryMetric]
+
+    static let empty = PromptContextEntryMetricsSnapshot(
+        totalSelectedDisplayTokens: 0,
+        metricsByFileID: [:],
+        metricsByStandardizedFullPath: [:]
+    )
+
+    init(totalSelectedDisplayTokens: Int, metrics: [PromptContextEntryMetric]) {
+        self.totalSelectedDisplayTokens = totalSelectedDisplayTokens
+        metricsByFileID = Dictionary(
+            uniqueKeysWithValues: metrics.map { ($0.fileID, $0) }
+        )
+        metricsByStandardizedFullPath = Dictionary(
+            uniqueKeysWithValues: metrics.map { ($0.standardizedFullPath, $0) }
+        )
+    }
+
+    private init(
+        totalSelectedDisplayTokens: Int,
+        metricsByFileID: [UUID: PromptContextEntryMetric],
+        metricsByStandardizedFullPath: [String: PromptContextEntryMetric]
+    ) {
+        self.totalSelectedDisplayTokens = totalSelectedDisplayTokens
+        self.metricsByFileID = metricsByFileID
+        self.metricsByStandardizedFullPath = metricsByStandardizedFullPath
+    }
+
+    func metric(forFileID fileID: UUID) -> PromptContextEntryMetric? {
+        metricsByFileID[fileID]
+    }
+
+    func metric(forStandardizedFullPath standardizedFullPath: String) -> PromptContextEntryMetric? {
+        metricsByStandardizedFullPath[standardizedFullPath]
+    }
+
+    var renderedDisplayPathsByStandardizedFullPath: [String: String] {
+        metricsByStandardizedFullPath.mapValues(\.renderedDisplayPath)
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/TokenAccounting/TokenCalculationService.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/TokenAccounting/TokenCalculationService.swift
@@ -47,6 +47,7 @@ struct TokenCalculationResult {
     let codeMapContent: String // NEW – raw code-map block text
     let codeMapFileCount: Int
     let codeMapTokenCount: Int
+    let entryResultsByFileID: [UUID: PromptEntriesEvaluation.EntryResult]
 }
 
 struct TokenComponentBreakdown {
@@ -79,10 +80,12 @@ struct PromptEntriesEvaluation {
 
     struct EntryResult {
         let fileID: UUID
+        let renderedDisplayPath: String
         let renderMode: RenderMode
         let displayTokens: Int
         let fullTokens: Int
         let codemapTokens: Int
+        let displayLineCount: Int?
     }
 
     let entryResultsByFileID: [UUID: EntryResult]
@@ -343,7 +346,8 @@ actor TokenCalculationService {
                 fileTreeTokenCountRaw: fileTreeTokens,
                 codeMapContent: evaluation.codeMapContent,
                 codeMapFileCount: evaluation.codeMapFileCount,
-                codeMapTokenCount: evaluation.codeMapTokenCount
+                codeMapTokenCount: evaluation.codeMapTokenCount,
+                entryResultsByFileID: evaluation.entryResultsByFileID
             )
         }
 
@@ -418,6 +422,7 @@ actor TokenCalculationService {
             let displayTokens: Int
             let fullTokenCount: Int
             let charCountContribution: Int
+            let displayLineCount: Int?
             if let assembly {
                 renderMode = .slice
                 displayTokens = Self.estimateTokens(for: assembly.combinedText)
@@ -425,6 +430,7 @@ actor TokenCalculationService {
                     ?? entry.loadedContent.map(Self.estimateTokens(for:))
                     ?? displayTokens
                 charCountContribution = assembly.totalCharacters
+                displayLineCount = WorkspaceTextLineCounter.countLines(in: assembly.combinedText)
                 sliceCount += 1
                 sliceTokens += displayTokens
             } else {
@@ -435,16 +441,19 @@ actor TokenCalculationService {
                 fullTokenCount = resolvedTokens
                 charCountContribution = entry.loadedContent?.count
                     ?? (resolvedTokens > 0 ? Int(Double(resolvedTokens) * 4.0) : 0)
+                displayLineCount = entry.loadedContent.map(WorkspaceTextLineCounter.countLines(in:))
                 fullCount += 1
                 fullTokens += displayTokens
             }
 
             entryResultsByFileID[entry.fileID] = .init(
                 fileID: entry.fileID,
+                renderedDisplayPath: entry.renderedDisplayPath,
                 renderMode: renderMode,
                 displayTokens: displayTokens,
                 fullTokens: fullTokenCount,
-                codemapTokens: entry.availableCodeMapTokenCount
+                codemapTokens: entry.availableCodeMapTokenCount,
+                displayLineCount: displayLineCount
             )
             totalChars += charCountContribution
             let folderPath = extractFolderPath(from: entry.relativePath)
@@ -459,10 +468,12 @@ actor TokenCalculationService {
             codemapTokens += apiTokens
             entryResultsByFileID[entry.fileID] = .init(
                 fileID: entry.fileID,
+                renderedDisplayPath: entry.renderedDisplayPath,
                 renderMode: .codemap,
                 displayTokens: apiTokens,
                 fullTokens: entry.cachedFullTokenCount ?? entry.loadedContent.map(Self.estimateTokens(for:)) ?? 0,
-                codemapTokens: apiTokens
+                codemapTokens: apiTokens,
+                displayLineCount: entry.codeMapContent.map(WorkspaceTextLineCounter.countLines(in:))
             )
             let folderPath = extractFolderPath(from: entry.relativePath)
             folderTokenAccum[folderPath, default: 0] += apiTokens
@@ -473,10 +484,12 @@ actor TokenCalculationService {
             codemapCount += 1
             entryResultsByFileID[entry.fileID] = .init(
                 fileID: entry.fileID,
+                renderedDisplayPath: entry.renderedDisplayPath,
                 renderMode: .codemap,
                 displayTokens: 0,
                 fullTokens: entry.cachedFullTokenCount ?? entry.loadedContent.map(Self.estimateTokens(for:)) ?? 0,
-                codemapTokens: 0
+                codemapTokens: 0,
+                displayLineCount: nil
             )
         }
 
@@ -533,7 +546,8 @@ actor TokenCalculationService {
             fileTreeTokenCountRaw: 0,
             codeMapContent: "",
             codeMapFileCount: 0,
-            codeMapTokenCount: 0
+            codeMapTokenCount: 0,
+            entryResultsByFileID: [:]
         )
     }
 }

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/TokenAccounting/TokenCalculationSnapshot.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/TokenAccounting/TokenCalculationSnapshot.swift
@@ -3,6 +3,7 @@ import Foundation
 struct PromptFileEntrySnapshot {
     let fileID: UUID
     let relativePath: String
+    let renderedDisplayPath: String
     let isCodemapRequested: Bool
     let ranges: [LineRange]?
     let cachedFullTokenCount: Int?

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/TokenAccounting/WorkspaceTextLineCounter.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/TokenAccounting/WorkspaceTextLineCounter.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+enum WorkspaceTextLineCounter {
+    static func countLines(in text: String) -> Int {
+        guard !text.isEmpty else { return 0 }
+
+        var count = 0
+        var previousWasCarriageReturn = false
+        var lastWasLineEnding = false
+
+        for byte in text.utf8 {
+            switch byte {
+            case 10:
+                if previousWasCarriageReturn {
+                    previousWasCarriageReturn = false
+                } else {
+                    count += 1
+                }
+                lastWasLineEnding = true
+            case 13:
+                count += 1
+                previousWasCarriageReturn = true
+                lastWasLineEnding = true
+            default:
+                previousWasCarriageReturn = false
+                lastWasLineEnding = false
+            }
+        }
+
+        return lastWasLineEnding ? count : count + 1
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceCodemapGitCapabilityService.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceCodemapGitCapabilityService.swift
@@ -208,12 +208,35 @@ actor WorkspaceCodemapGitCapabilityService {
         let attributeGeneration: String
         let sparseGeneration: String
         let metadataGeneration: String
+
+        /// Per-file source-authority registration-to-demand windows prove the same repository/worktree
+        /// binding, not the absence of root-wide Git cache or metadata churn since registration.
+        /// Demand-window source and classification evidence is compared separately around issuance/revalidation.
+        /// Full `StableAuthority` equality remains the root-authority advancement contract used by resolution.
+        func matchesSourceAuthorityStability(of other: StableAuthority) -> Bool {
+            repositoryNamespace == other.repositoryNamespace &&
+                objectFormat == other.objectFormat &&
+                repositoryBindingEpoch == other.repositoryBindingEpoch &&
+                worktreeBindingEpoch == other.worktreeBindingEpoch
+        }
+    }
+
+    private struct SourceClassificationEvidence: Equatable {
+        let globalAttributeGeneration: String
+        let checkoutConfigurationValuesGeneration: String
     }
 
     private struct AuthorityCapture: Equatable {
         let layout: GitRepositoryLayout
         let objectFormat: GitObjectFormat
         let stableAuthority: StableAuthority
+        let sourceClassificationEvidence: SourceClassificationEvidence
+
+        func matchesSourceAuthorityStability(of other: AuthorityCapture) -> Bool {
+            layout == other.layout &&
+                objectFormat == other.objectFormat &&
+                stableAuthority.matchesSourceAuthorityStability(of: other.stableAuthority)
+        }
     }
 
     private struct RootBinding: Hashable {
@@ -739,7 +762,9 @@ actor WorkspaceCodemapGitCapabilityService {
                 expectedLayout: capability.repositoryLayout,
                 prefix: capability.repositoryRelativeLoadedRootPrefix
             )
-            guard preRepository.stableAuthority == stableAuthority else { return unavailable }
+            guard preRepository.stableAuthority.matchesSourceAuthorityStability(of: stableAuthority) else {
+                return unavailable
+            }
             await hooks.afterFirstAuthorityCapture()
             try Task.checkCancellation()
 
@@ -813,8 +838,10 @@ actor WorkspaceCodemapGitCapabilityService {
                 expectedLayout: capability.repositoryLayout,
                 prefix: capability.repositoryRelativeLoadedRootPrefix
             )
+            // Earlier root-wide churn does not invalidate the current request, but this request
+            // must observe one unchanged root authority across its two captures.
             guard preRepository == postRepository,
-                  postRepository.stableAuthority == stableAuthority,
+                  postRepository.stableAuthority.matchesSourceAuthorityStability(of: stableAuthority),
                   case let .eligible(currentCapability) = records[capability.rootEpoch]?.state,
                   currentCapability == capability
             else { return unavailable }
@@ -904,7 +931,9 @@ actor WorkspaceCodemapGitCapabilityService {
                 expectedLayout: capability.repositoryLayout,
                 prefix: capability.repositoryRelativeLoadedRootPrefix
             )
-            guard preRepository.stableAuthority == stableAuthority else { return false }
+            guard preRepository.stableAuthority.matchesSourceAuthorityStability(of: stableAuthority) else {
+                return false
+            }
 
             for token in tokens {
                 let path = token.standardizedRepositoryRelativePath
@@ -939,8 +968,11 @@ actor WorkspaceCodemapGitCapabilityService {
                 expectedLayout: capability.repositoryLayout,
                 prefix: capability.repositoryRelativeLoadedRootPrefix
             )
-            guard preRepository == postRepository,
-                  postRepository.stableAuthority == stableAuthority
+            // Demand-time classification owns current-state correctness. This pre/post window
+            // only fences classification-input races while revalidating per-file source authority.
+            guard preRepository.sourceClassificationEvidence == postRepository.sourceClassificationEvidence,
+                  preRepository.matchesSourceAuthorityStability(of: postRepository),
+                  postRepository.stableAuthority.matchesSourceAuthorityStability(of: stableAuthority)
             else { return false }
 
             for token in tokens {
@@ -1110,6 +1142,16 @@ actor WorkspaceCodemapGitCapabilityService {
             repositoryLayout: currentLayout,
             salt: namespaceSalt
         )
+        let sourceClassificationEvidence = try SourceClassificationEvidence(
+            globalAttributeGeneration: digestEvidence(
+                urls: Self.globalAttributeURLs(
+                    layout: currentLayout,
+                    configuredAttributesFile: configuration.attributesFilePath
+                ),
+                includeBoundedContents: true
+            ),
+            checkoutConfigurationValuesGeneration: Self.checkoutConfigurationValuesDigest(configuration)
+        )
 
         let layoutGeneration = try digestEvidence(
             urls: [
@@ -1190,7 +1232,8 @@ actor WorkspaceCodemapGitCapabilityService {
                 attributeGeneration: attributeGeneration,
                 sparseGeneration: sparseGeneration,
                 metadataGeneration: metadataGeneration
-            )
+            ),
+            sourceClassificationEvidence: sourceClassificationEvidence
         )
     }
 
@@ -1293,15 +1336,34 @@ actor WorkspaceCodemapGitCapabilityService {
         return urls
     }
 
-    private static func attributeURLs(
+    private static func globalAttributeURLs(
         layout: GitRepositoryLayout,
-        loadedRoot: URL,
         configuredAttributesFile: String?
     ) -> [URL] {
         var urls = [
             layout.gitDir.appendingPathComponent("info/attributes"),
             layout.commonDir.appendingPathComponent("info/attributes")
         ]
+        if let configuredAttributesFile {
+            // `git config --path --get core.attributesFile` expands `~` to an absolute path, while
+            // relative values remain relative and `git check-attr` resolves them from the worktree root.
+            let configuredURL = configuredAttributesFile.hasPrefix("/")
+                ? URL(fileURLWithPath: configuredAttributesFile)
+                : layout.workTreeRoot.appendingPathComponent(configuredAttributesFile)
+            urls.append(configuredURL.standardizedFileURL)
+        }
+        return urls
+    }
+
+    private static func attributeURLs(
+        layout: GitRepositoryLayout,
+        loadedRoot: URL,
+        configuredAttributesFile: String?
+    ) -> [URL] {
+        var urls = globalAttributeURLs(
+            layout: layout,
+            configuredAttributesFile: configuredAttributesFile
+        )
         var directory = layout.workTreeRoot.resolvingSymlinksInPath().standardizedFileURL
         let target = loadedRoot.resolvingSymlinksInPath().standardizedFileURL
         while true {
@@ -1311,11 +1373,6 @@ actor WorkspaceCodemapGitCapabilityService {
                 .split(separator: "/", omittingEmptySubsequences: true)
             guard let next = relative.first else { break }
             directory.appendPathComponent(String(next), isDirectory: true)
-        }
-        if let configuredAttributesFile {
-            let configuredURL = URL(fileURLWithPath: configuredAttributesFile, relativeTo: layout.commonDir)
-                .standardizedFileURL
-            urls.append(configuredURL)
         }
         return urls
     }
@@ -1573,6 +1630,21 @@ actor WorkspaceCodemapGitCapabilityService {
             if path.hasPrefix(alias + "/") { return target + path.dropFirst(alias.count) }
         }
         return path
+    }
+
+    private static func checkoutConfigurationValuesDigest(
+        _ configuration: GitCodemapAuthorityConfiguration
+    ) -> String {
+        var values = [
+            configuration.checkout.coreAutoCRLF ?? "<nil>",
+            configuration.checkout.coreEOL ?? "<nil>",
+            configuration.attributesFilePath ?? "<nil>"
+        ]
+        for key in configuration.checkout.filterDriverConfiguration.keys.sorted() {
+            values.append(key)
+            values.append(configuration.checkout.filterDriverConfiguration[key] ?? "")
+        }
+        return digestStrings(values)
     }
 
     private static func checkoutConfigurationDigest(

--- a/Tests/RepoPromptTests/AgentMode/AgentContextDrawerUIStoreTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentContextDrawerUIStoreTests.swift
@@ -1,0 +1,258 @@
+import Combine
+@testable import RepoPromptApp
+import XCTest
+
+@MainActor
+final class AgentContextDrawerUIStoreTests: XCTestCase {
+    func testPresentationStateDefaultsTogglesAndRetainsRuntimeValues() {
+        let store = AgentContextDrawerUIStore()
+
+        XCTAssertFalse(store.isPresented)
+        XCTAssertFalse(store.presentation.isPresented)
+        XCTAssertEqual(store.activeTab, .files)
+        XCTAssertEqual(store.detail.activeTab, .files)
+        XCTAssertEqual(store.filesSubtab, .files)
+        XCTAssertEqual(store.detail.filesSubtab, .files)
+        XCTAssertEqual(store.fileFilterText, "")
+        XCTAssertEqual(store.detail.fileFilterText, "")
+        XCTAssertEqual(store.selectionSort, .tokensDescending)
+        XCTAssertEqual(store.detail.selectionSort, .tokensDescending)
+        XCTAssertEqual(AgentContextDrawerUIStore.SelectionSort.allCases.map(\.label), [
+            "Name A→Z",
+            "Name Z→A",
+            "Tokens ↓",
+            "Tokens ↑"
+        ])
+
+        store.open()
+        XCTAssertTrue(store.isPresented)
+        XCTAssertTrue(store.presentation.isPresented)
+        XCTAssertEqual(store.activeTab, .files)
+
+        store.activeTab = .builder
+        store.filesSubtab = .codemaps
+        store.fileFilterText = "Sources"
+        store.selectionSort = .nameAscending
+        store.close()
+        store.open()
+        XCTAssertTrue(store.isPresented)
+        XCTAssertEqual(store.activeTab, .builder)
+        XCTAssertEqual(store.detail.activeTab, .builder)
+        XCTAssertEqual(store.filesSubtab, .codemaps)
+        XCTAssertEqual(store.detail.filesSubtab, .codemaps)
+        XCTAssertEqual(store.fileFilterText, "Sources")
+        XCTAssertEqual(store.detail.fileFilterText, "Sources")
+        XCTAssertEqual(store.selectionSort, .nameAscending)
+        XCTAssertEqual(store.detail.selectionSort, .nameAscending)
+
+        store.toggle(tab: .prompt)
+        XCTAssertTrue(store.isPresented)
+        XCTAssertEqual(store.activeTab, .prompt)
+
+        store.toggle(tab: .prompt)
+        XCTAssertFalse(store.isPresented)
+        XCTAssertEqual(store.activeTab, .prompt)
+
+        let publicationStore = AgentContextDrawerUIStore()
+        var cancellables = Set<AnyCancellable>()
+        var presentationPublicationCount = 0
+        var detailPublicationCount = 0
+        publicationStore.presentation.objectWillChange
+            .sink { presentationPublicationCount += 1 }
+            .store(in: &cancellables)
+        publicationStore.detail.objectWillChange
+            .sink { detailPublicationCount += 1 }
+            .store(in: &cancellables)
+
+        publicationStore.detail.fileFilterText = "Sources"
+        publicationStore.detail.filesSubtab = .codemaps
+        publicationStore.detail.selectionSort = .nameDescending
+        XCTAssertEqual(presentationPublicationCount, 0)
+        XCTAssertEqual(detailPublicationCount, 3)
+
+        publicationStore.open()
+        XCTAssertEqual(presentationPublicationCount, 1)
+        XCTAssertEqual(detailPublicationCount, 3)
+    }
+
+    func testSelectionSortOrdersRowsDeterministically() throws {
+        let rootA = try XCTUnwrap(UUID(uuidString: "00000000-0000-0000-0000-000000000001"))
+        let rootB = try XCTUnwrap(UUID(uuidString: "00000000-0000-0000-0000-000000000002"))
+        let alphaAID = try XCTUnwrap(UUID(uuidString: "00000000-0000-0000-0000-000000000101"))
+        let alphaZID = try XCTUnwrap(UUID(uuidString: "00000000-0000-0000-0000-000000000102"))
+        let betaID = try XCTUnwrap(UUID(uuidString: "00000000-0000-0000-0000-000000000103"))
+        let omegaRootBID = try XCTUnwrap(UUID(uuidString: "00000000-0000-0000-0000-000000000104"))
+        let omegaRootAID = try XCTUnwrap(UUID(uuidString: "00000000-0000-0000-0000-000000000105"))
+        let gammaID = try XCTUnwrap(UUID(uuidString: "00000000-0000-0000-0000-000000000106"))
+        let unknownID = try XCTUnwrap(UUID(uuidString: "00000000-0000-0000-0000-000000000107"))
+        let zeroID = try XCTUnwrap(UUID(uuidString: "00000000-0000-0000-0000-000000000108"))
+        let rows = [
+            makeRow(
+                fileID: omegaRootBID,
+                rootID: rootB,
+                name: "Omega.swift",
+                path: "Sources/Omega.swift",
+                tokens: 1
+            ),
+            makeRow(
+                fileID: alphaAID,
+                rootID: rootA,
+                name: "Alpha.swift",
+                path: "Sources/A/Alpha.swift",
+                tokens: 9
+            ),
+            makeRow(
+                fileID: betaID,
+                rootID: rootA,
+                name: "Beta.swift",
+                path: "Sources/Beta.swift",
+                kind: .codemap,
+                mode: .codemap,
+                tokens: 20
+            ),
+            makeRow(
+                fileID: alphaZID,
+                rootID: rootA,
+                name: "Alpha.swift",
+                path: "Sources/Z/Alpha.swift",
+                tokens: 4
+            ),
+            makeRow(
+                fileID: omegaRootAID,
+                rootID: rootA,
+                name: "Omega.swift",
+                path: "Sources/Omega.swift",
+                tokens: 1
+            ),
+            makeRow(
+                fileID: gammaID,
+                rootID: rootB,
+                name: "Gamma.swift",
+                path: "Sources/Gamma.swift",
+                tokens: 20
+            ),
+            makeRow(
+                fileID: unknownID,
+                rootID: rootA,
+                name: "Delta.swift",
+                path: "Sources/Delta.swift",
+                metrics: .unknown
+            ),
+            makeRow(
+                fileID: zeroID,
+                rootID: rootA,
+                name: "Zeta.swift",
+                path: "Sources/Zeta.swift",
+                tokens: 0
+            )
+        ]
+
+        XCTAssertEqual(
+            sortedPaths(rows, by: .tokensDescending),
+            [
+                "Sources/Beta.swift",
+                "Sources/Gamma.swift",
+                "Sources/A/Alpha.swift",
+                "Sources/Z/Alpha.swift",
+                "Sources/Omega.swift@00000000-0000-0000-0000-000000000001",
+                "Sources/Omega.swift@00000000-0000-0000-0000-000000000002",
+                "Sources/Delta.swift",
+                "Sources/Zeta.swift"
+            ]
+        )
+        XCTAssertEqual(
+            sortedPaths(rows, by: .tokensAscending),
+            [
+                "Sources/Delta.swift",
+                "Sources/Zeta.swift",
+                "Sources/Omega.swift@00000000-0000-0000-0000-000000000001",
+                "Sources/Omega.swift@00000000-0000-0000-0000-000000000002",
+                "Sources/Z/Alpha.swift",
+                "Sources/A/Alpha.swift",
+                "Sources/Beta.swift",
+                "Sources/Gamma.swift"
+            ]
+        )
+        XCTAssertEqual(
+            sortedPaths(rows, by: .nameAscending),
+            [
+                "Sources/A/Alpha.swift",
+                "Sources/Z/Alpha.swift",
+                "Sources/Beta.swift",
+                "Sources/Delta.swift",
+                "Sources/Gamma.swift",
+                "Sources/Omega.swift@00000000-0000-0000-0000-000000000001",
+                "Sources/Omega.swift@00000000-0000-0000-0000-000000000002",
+                "Sources/Zeta.swift"
+            ]
+        )
+        XCTAssertEqual(
+            sortedPaths(rows, by: .nameDescending),
+            [
+                "Sources/Zeta.swift",
+                "Sources/Omega.swift@00000000-0000-0000-0000-000000000001",
+                "Sources/Omega.swift@00000000-0000-0000-0000-000000000002",
+                "Sources/Gamma.swift",
+                "Sources/Delta.swift",
+                "Sources/Beta.swift",
+                "Sources/Z/Alpha.swift",
+                "Sources/A/Alpha.swift"
+            ]
+        )
+    }
+
+    private func sortedPaths(
+        _ rows: [AgentContextExportRow],
+        by sort: AgentContextDrawerUIStore.SelectionSort
+    ) -> [String] {
+        sort.sortedRows(rows).map { row in
+            if row.displayPath == "Sources/Omega.swift" {
+                return "\(row.displayPath)@\(row.rootID.uuidString)"
+            }
+            return row.displayPath
+        }
+    }
+
+    private func makeRow(
+        fileID: UUID,
+        rootID: UUID,
+        name: String,
+        path: String,
+        kind: AgentContextExportRow.Kind = .full,
+        mode: PromptFileEntryMode = .fullFile,
+        tokens: Int
+    ) -> AgentContextExportRow {
+        makeRow(
+            fileID: fileID,
+            rootID: rootID,
+            name: name,
+            path: path,
+            kind: kind,
+            mode: mode,
+            metrics: .known(tokenCount: tokens, tokenPercentage: 0, lineCount: nil)
+        )
+    }
+
+    private func makeRow(
+        fileID: UUID,
+        rootID: UUID,
+        name: String,
+        path: String,
+        kind: AgentContextExportRow.Kind = .full,
+        mode: PromptFileEntryMode = .fullFile,
+        metrics: AgentContextExportRow.Metrics
+    ) -> AgentContextExportRow {
+        AgentContextExportRow(
+            id: ResolvedPromptFileEntryID(fileID: fileID, mode: mode, lineRanges: nil),
+            kind: kind,
+            rootID: rootID,
+            relativePath: path,
+            displayPath: path,
+            displayName: name,
+            directoryDisplay: nil,
+            lineRanges: nil,
+            metrics: metrics,
+            canRemove: true
+        )
+    }
+}

--- a/Tests/RepoPromptTests/AgentMode/AgentContextExportResolverTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentContextExportResolverTests.swift
@@ -2,6 +2,110 @@ import Foundation
 @testable import RepoPromptApp
 import XCTest
 
+private actor CompleteGitDiffProviderSpy {
+    private let text: String?
+    private var invocationCount = 0
+
+    init(text: String?) {
+        self.text = text
+    }
+
+    func provide() -> String? {
+        invocationCount += 1
+        return text
+    }
+
+    func count() -> Int {
+        invocationCount
+    }
+}
+
+private actor AgentContextExportLookupGate {
+    private var isOpen = false
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    func wait() async {
+        guard !isOpen else { return }
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func open() {
+        isOpen = true
+        continuation?.resume()
+        continuation = nil
+    }
+}
+
+private actor ResolvedContentReaderProbe {
+    struct Input: Equatable {
+        let location: ResolvedFileContentLocation
+        let workloadClass: ContentReadWorkloadClass
+    }
+
+    private let content: String
+    private let blocksFirstRead: Bool
+    private var inputs: [Input] = []
+    private var firstReadContinuation: CheckedContinuation<Void, Never>?
+    private var startWaiters: [CheckedContinuation<Void, Never>] = []
+
+    init(content: String, blocksFirstRead: Bool = false) {
+        self.content = content
+        self.blocksFirstRead = blocksFirstRead
+    }
+
+    func read(
+        location: ResolvedFileContentLocation,
+        workloadClass: ContentReadWorkloadClass
+    ) async throws -> String? {
+        inputs.append(Input(location: location, workloadClass: workloadClass))
+        startWaiters.forEach { $0.resume() }
+        startWaiters.removeAll()
+        if blocksFirstRead, inputs.count == 1 {
+            await withCheckedContinuation { continuation in
+                firstReadContinuation = continuation
+            }
+        }
+        try Task.checkCancellation()
+        return content
+    }
+
+    func waitUntilReadStarts() async {
+        guard inputs.isEmpty else { return }
+        await withCheckedContinuation { continuation in
+            startWaiters.append(continuation)
+        }
+    }
+
+    func releaseFirstRead() {
+        firstReadContinuation?.resume()
+        firstReadContinuation = nil
+    }
+
+    func recordedInputs() -> [Input] {
+        inputs
+    }
+}
+
+private actor CompleteGitDiffInputRecorder {
+    struct Input: Equatable {
+        let rootPath: String
+        let compareIntent: ReviewGitCompareIntent
+    }
+
+    private var inputs: [Input] = []
+
+    func resolve(rootPath: String, compareIntent: ReviewGitCompareIntent) -> String? {
+        inputs.append(Input(rootPath: rootPath, compareIntent: compareIntent))
+        return "diff --git a/Sources/Original.swift b/Sources/Original.swift\n+completeGitSnapshot"
+    }
+
+    func recordedInputs() -> [Input] {
+        inputs
+    }
+}
+
 final class AgentContextExportResolverTests: WorkspaceFileContextStoreCodemapSeamTestSupport {
     func testDisplayFileCountUsesExplicitSelectionAndExcludesAutoCodemaps() {
         let selection = StoredSelection(
@@ -72,6 +176,29 @@ final class AgentContextExportResolverTests: WorkspaceFileContextStoreCodemapSea
         XCTAssertEqual(summary.fullFileCount, 0)
         XCTAssertEqual(summary.slicedFileCount, 1)
         XCTAssertEqual(summary.sliceRangeCount, 1)
+    }
+
+    func testSelectionSummaryIncludesManualCodemapSelections() {
+        let selection = StoredSelection(
+            selectedPaths: ["Sources/Full.swift", "Sources/Duplicate.swift"],
+            manualCodemapPaths: ["Sources/Codemap.swift", "Sources/Duplicate.swift"],
+            slices: ["Sources/Sliced.swift": [LineRange(start: 1, end: 2)]],
+            codemapAutoEnabled: false
+        )
+
+        let summary = AgentContextExportResolver.selectionSummary(for: selection)
+
+        XCTAssertEqual(summary.totalExplicitFileCount, 4)
+        XCTAssertEqual(summary.fullFileCount, 2)
+        XCTAssertEqual(summary.slicedFileCount, 1)
+        XCTAssertEqual(summary.codemapFileCount, 1)
+        XCTAssertEqual(summary.sliceRangeCount, 1)
+
+        let fileCodemapSummary = AgentContextFileCodemapCountSummary.intent(from: summary)
+        XCTAssertEqual(fileCodemapSummary.fileCount, 3)
+        XCTAssertEqual(fileCodemapSummary.codemapCount, 1)
+        XCTAssertEqual(fileCodemapSummary.sliceRangeCount, 1)
+        XCTAssertEqual(fileCodemapSummary.headlineText, "3 files · 1 codemap · 1 slice")
     }
 
     func testSelectionSummaryExcludesEmptySlicesAndDoesNotInferCodemaps() {
@@ -176,17 +303,28 @@ final class AgentContextExportResolverTests: WorkspaceFileContextStoreCodemapSea
                 XCTFail("Performance capture should start")
             }
 
-            let model = await AgentContextExportResolver.resolveModel(
+            let interimModels = AgentExportLockedModelRecorder()
+            let model = try await AgentContextExportResolver.resolveModel(
                 source: source,
                 store: store,
                 filePathDisplay: .relative,
-                codeMapUsage: .auto
+                codeMapUsage: .auto,
+                interimFileRowsHandler: { model in
+                    interimModels.append(model)
+                }
             )
             let capture = EditFlowPerf.debugCaptureSnapshot(finish: true)
             let snapshotBuildCount = capture.stages
                 .filter { $0.stageName == String(describing: EditFlowPerf.Stage.ReadFile.pathLookupStaticSnapshotBuild) }
                 .reduce(0) { $0 + $1.sampleCount }
 
+            let publishedInterimModels = interimModels.values
+            XCTAssertEqual(publishedInterimModels.count, 1)
+            let interimModel = try XCTUnwrap(publishedInterimModels.first)
+            XCTAssertEqual(interimModel.totalSelectedDisplayTokens, 0)
+            XCTAssertTrue(interimModel.rows.allSatisfy { $0.metrics == .unknown })
+            XCTAssertEqual(interimModel.rows.count(where: { $0.kind != .codemap }), explicitFileCount)
+            XCTAssertEqual(interimModel.rows.count(where: { $0.kind == .codemap }), 0)
             XCTAssertEqual(model.rows.count(where: { $0.kind != .codemap }), explicitFileCount)
             XCTAssertEqual(model.rows.count(where: { $0.kind == .slices }), 4)
             XCTAssertEqual(model.rows.count(where: { $0.kind == .codemap }), 0)
@@ -208,6 +346,69 @@ final class AgentContextExportResolverTests: WorkspaceFileContextStoreCodemapSea
         #endif
     }
 
+    func testAutoCodemapInterimRowsPreserveProvidedMetricsSnapshot() async throws {
+        let root = try makeTemporaryRoot(name: "AgentExportInterimMetrics")
+        let selectedURL = root.appendingPathComponent("Sources/Feature/Selected.swift")
+        try write("struct Selected {}", to: selectedURL)
+
+        let store = WorkspaceFileContextStore()
+        _ = try await store.loadRoot(path: root.path)
+        let selectedLookup = await store.lookupPath(selectedURL.path, profile: .uiAssisted)
+        let selectedFile = try XCTUnwrap(selectedLookup?.file)
+        let metricsSnapshot = PromptContextEntryMetricsSnapshot(
+            totalSelectedDisplayTokens: 42,
+            metrics: [
+                PromptContextEntryMetric(
+                    fileID: selectedFile.id,
+                    standardizedFullPath: selectedFile.standardizedFullPath,
+                    renderedDisplayPath: "Sources/Feature/Selected.swift",
+                    renderMode: .full,
+                    displayTokenCount: 42,
+                    displayPercentage: 1,
+                    includedLineCount: 7
+                )
+            ]
+        )
+        let source = AgentContextExportSource(
+            tabID: UUID(),
+            promptText: "Review",
+            selection: StoredSelection(selectedPaths: [selectedURL.path], codemapAutoEnabled: true),
+            selectedMetaPromptIDs: [],
+            tabName: "Agent Tab",
+            activeAgentSessionID: nil,
+            worktreeBindings: []
+        )
+        let interimModels = AgentExportLockedModelRecorder()
+
+        let model = try await AgentContextExportResolver.resolveModel(
+            source: source,
+            store: store,
+            filePathDisplay: .relative,
+            codeMapUsage: .auto,
+            entryMetricsSnapshot: metricsSnapshot,
+            interimFileRowsHandler: { model in
+                interimModels.append(model)
+            }
+        )
+
+        let publishedInterimModels = interimModels.values
+        XCTAssertEqual(publishedInterimModels.count, 1)
+        let interimModel = try XCTUnwrap(publishedInterimModels.first)
+        XCTAssertEqual(interimModel.totalSelectedDisplayTokens, 42)
+        let interimMetrics = try XCTUnwrap(interimModel.rows.first?.metrics.knownValues)
+        XCTAssertEqual(interimMetrics.tokenCount, 42)
+        XCTAssertEqual(interimMetrics.tokenPercentage, 1)
+        XCTAssertEqual(interimMetrics.lineCount, 7)
+        XCTAssertEqual(interimModel.rows.count(where: { $0.kind != .codemap }), 1)
+        XCTAssertEqual(interimModel.rows.count(where: { $0.kind == .codemap }), 0)
+
+        XCTAssertEqual(model.totalSelectedDisplayTokens, 42)
+        let finalMetrics = try XCTUnwrap(model.rows.first?.metrics.knownValues)
+        XCTAssertEqual(finalMetrics.tokenCount, 42)
+        XCTAssertEqual(finalMetrics.tokenPercentage, 1)
+        XCTAssertEqual(finalMetrics.lineCount, 7)
+    }
+
     func testSelectedFilesModelWithoutCodemapsDoesNotEnumerateWholeRoots() async throws {
         #if DEBUG
             let root = try makeTemporaryRoot(name: "AgentExportNoBroadEnumeration")
@@ -222,6 +423,22 @@ final class AgentContextExportResolverTests: WorkspaceFileContextStoreCodemapSea
 
             let store = WorkspaceFileContextStore()
             _ = try await store.loadRoot(path: root.path)
+            let selectedLookup = await store.lookupPath(selectedURL.path, profile: .uiAssisted)
+            let selectedFile = try XCTUnwrap(selectedLookup?.file)
+            let metricsSnapshot = PromptContextEntryMetricsSnapshot(
+                totalSelectedDisplayTokens: 42,
+                metrics: [
+                    PromptContextEntryMetric(
+                        fileID: selectedFile.id,
+                        standardizedFullPath: selectedFile.standardizedFullPath,
+                        renderedDisplayPath: "Sources/Feature/Selected.swift",
+                        renderMode: .full,
+                        displayTokenCount: 42,
+                        displayPercentage: 1,
+                        includedLineCount: 7
+                    )
+                ]
+            )
             await store.resetFilesInRootRequestCountForTesting()
             let source = AgentContextExportSource(
                 tabID: UUID(),
@@ -232,17 +449,69 @@ final class AgentContextExportResolverTests: WorkspaceFileContextStoreCodemapSea
                 activeAgentSessionID: nil,
                 worktreeBindings: []
             )
+            let codemapOperationCountsBefore = await store.codemapPresentationOperationCountsForTesting()
 
-            let model = await AgentContextExportResolver.resolveModel(
+            let model = try await AgentContextExportResolver.resolveModel(
                 source: source,
                 store: store,
                 filePathDisplay: .relative,
-                codeMapUsage: .none
+                codeMapUsage: .none,
+                entryMetricsSnapshot: metricsSnapshot
             )
 
             XCTAssertEqual(model.rows.map(\.displayPath), ["Sources/Feature/Selected.swift"])
+            XCTAssertEqual(model.totalSelectedDisplayTokens, 42)
+            let metrics = try XCTUnwrap(model.rows.first?.metrics.knownValues)
+            XCTAssertEqual(metrics.tokenCount, 42)
+            XCTAssertEqual(metrics.tokenPercentage, 1)
+            XCTAssertEqual(metrics.lineCount, 7)
+            XCTAssertTrue(model.codemapPresentation.orderedEntries.isEmpty)
+            XCTAssertTrue(model.codemapPresentation.renderedEntriesByFileID.isEmpty)
+            XCTAssertEqual(model.codemapPresentation.coverage, .complete)
+            XCTAssertTrue(model.codemapPresentation.issues.isEmpty)
+
+            let zeroMetricsSnapshot = PromptContextEntryMetricsSnapshot(
+                totalSelectedDisplayTokens: 0,
+                metrics: [
+                    PromptContextEntryMetric(
+                        fileID: selectedFile.id,
+                        standardizedFullPath: selectedFile.standardizedFullPath,
+                        renderedDisplayPath: "Sources/Feature/Selected.swift",
+                        renderMode: .full,
+                        displayTokenCount: 0,
+                        displayPercentage: 0,
+                        includedLineCount: nil
+                    )
+                ]
+            )
+            let zeroSnapshotModel = try await AgentContextExportResolver.resolveModel(
+                source: source,
+                store: store,
+                filePathDisplay: .relative,
+                codeMapUsage: .none,
+                entryMetricsSnapshot: zeroMetricsSnapshot
+            )
+            XCTAssertEqual(zeroSnapshotModel.totalSelectedDisplayTokens, 0)
+            let zeroMetrics = try XCTUnwrap(zeroSnapshotModel.rows.first?.metrics.knownValues)
+            XCTAssertEqual(zeroMetrics.tokenCount, 0)
+            XCTAssertEqual(zeroMetrics.tokenPercentage, 0)
+            XCTAssertNil(zeroMetrics.lineCount)
+            XCTAssertEqual(zeroSnapshotModel.rows.first?.metrics.tokenSortKey, 0)
+
+            let emptySnapshotModel = try await AgentContextExportResolver.resolveModel(
+                source: source,
+                store: store,
+                filePathDisplay: .relative,
+                codeMapUsage: .none,
+                entryMetricsSnapshot: .empty
+            )
+            XCTAssertEqual(emptySnapshotModel.totalSelectedDisplayTokens, 0)
+            XCTAssertEqual(emptySnapshotModel.rows.first?.metrics, .unknown)
+
             let filesInRootRequestCount = await store.fileEnumerationRequestCountForTesting()
+            let codemapOperationCountsAfter = await store.codemapPresentationOperationCountsForTesting()
             XCTAssertEqual(filesInRootRequestCount, 0)
+            XCTAssertEqual(codemapOperationCountsAfter, codemapOperationCountsBefore)
         #endif
     }
 
@@ -254,7 +523,7 @@ final class AgentContextExportResolverTests: WorkspaceFileContextStoreCodemapSea
             selection: StoredSelection(selectedPaths: ["Sources/App.swift"], codemapAutoEnabled: false)
         )
 
-        let model = await AgentContextExportResolver.resolveModel(
+        let model = try await AgentContextExportResolver.resolveModel(
             source: source,
             store: fixture.store,
             filePathDisplay: .relative,
@@ -265,7 +534,18 @@ final class AgentContextExportResolverTests: WorkspaceFileContextStoreCodemapSea
         XCTAssertEqual(model.rows.count, 1)
         XCTAssertFalse(try XCTUnwrap(model.lookupContext.bindingProjection).isFullyMaterialized)
         XCTAssertEqual(row.displayPath, "Sources/App.swift")
-        XCTAssertEqual(row.directContentPath, fixture.worktreeRoot.appendingPathComponent("Sources/App.swift").standardizedFileURL.path)
+        XCTAssertEqual(
+            row.resolvedContentLocation?.resolvedFileURL,
+            fixture.worktreeRoot.appendingPathComponent("Sources/App.swift").standardizedFileURL
+        )
+        XCTAssertEqual(model.totalSelectedDisplayTokens, TokenCalculationService.estimateTokens(for: "let origin = \"worktree\"\n"))
+        let metrics = try XCTUnwrap(row.metrics.knownValues)
+        XCTAssertEqual(metrics.tokenCount, model.totalSelectedDisplayTokens)
+        XCTAssertEqual(metrics.tokenPercentage, 1)
+        XCTAssertEqual(metrics.lineCount, 1)
+        XCTAssertEqual(row.rootDisplayName, fixture.logicalRoot.lastPathComponent)
+        XCTAssertEqual(row.rootColorKey, fixture.logicalRoot.standardizedFileURL.path)
+        XCTAssertFalse(row.showRootPill)
 
         let previewText = await AgentContextExportResolver.loadRowContent(
             for: row,
@@ -276,6 +556,7 @@ final class AgentContextExportResolverTests: WorkspaceFileContextStoreCodemapSea
         XCTAssertEqual(previewText, "let origin = \"worktree\"\n")
         XCTAssertFalse(previewText?.contains("base") ?? true)
 
+        let completeProvider = CompleteGitDiffProviderSpy(text: "unexpected complete diff")
         let clipboard = await AgentContextExportResolver.buildClipboardContent(
             AgentContextClipboardRequest(
                 cfg: makeConfig(gitInclusion: .none),
@@ -291,13 +572,188 @@ final class AgentContextExportResolverTests: WorkspaceFileContextStoreCodemapSea
                 disabledPromptSections: [],
                 duplicateUserInstructionsAtTop: false,
                 reviewGitContext: .automaticOnly(),
-                completeGitDiffProvider: { "unexpected complete diff" }
+                completeGitDiffProvider: { await completeProvider.provide() ?? "" }
             )
         )
+
+        let completeProviderInvocationCount = await completeProvider.count()
 
         XCTAssertTrue(clipboard.contains("Sources/App.swift"), clipboard)
         XCTAssertTrue(clipboard.contains("let origin = \"worktree\""), clipboard)
         XCTAssertFalse(clipboard.contains("let origin = \"base\""), clipboard)
+        XCTAssertEqual(completeProviderInvocationCount, 0)
+    }
+
+    func testMetadataOnlyWorktreeMetricsUseBoundedAccountingReader() async throws {
+        let fixture = try await makeBoundFixture()
+        let source = makeSource(
+            logicalRoot: fixture.logicalRoot,
+            worktreeRoot: fixture.worktreeRoot,
+            selection: StoredSelection(selectedPaths: ["Sources/App.swift"], codemapAutoEnabled: false)
+        )
+        let content = "let measured = \"é🙂\"\nlet second = true\n"
+        let probe = ResolvedContentReaderProbe(content: content)
+        let accountingService = PromptContextAccountingService(resolvedContentReader: { location, workloadClass in
+            try await probe.read(location: location, workloadClass: workloadClass)
+        })
+
+        let model = try await AgentContextExportResolver.resolveModel(
+            source: source,
+            store: fixture.store,
+            filePathDisplay: .relative,
+            codeMapUsage: .none,
+            accountingService: accountingService
+        )
+
+        let recordedInputs = await probe.recordedInputs()
+        XCTAssertEqual(recordedInputs.count, 1)
+        let input = try XCTUnwrap(recordedInputs.first)
+        XCTAssertEqual(input.workloadClass, .promptAccounting)
+        XCTAssertEqual(input.location.resolvedRootURL, fixture.worktreeRoot.resolvingSymlinksInPath().standardizedFileURL)
+        XCTAssertEqual(
+            input.location.resolvedFileURL,
+            fixture.worktreeRoot.appendingPathComponent("Sources/App.swift").resolvingSymlinksInPath().standardizedFileURL
+        )
+        XCTAssertEqual(input.location.relativePath, "Sources/App.swift")
+        XCTAssertEqual(model.totalSelectedDisplayTokens, TokenCalculationService.estimateTokens(for: content))
+        XCTAssertEqual(model.rows.count, 1)
+        let row = try XCTUnwrap(model.rows.first)
+        let metrics = try XCTUnwrap(row.metrics.knownValues)
+        XCTAssertEqual(metrics.tokenCount, TokenCalculationService.estimateTokens(for: content))
+        XCTAssertEqual(metrics.tokenPercentage, 1)
+        XCTAssertEqual(metrics.lineCount, 2)
+    }
+
+    func testMetadataOnlyWorktreeMetricsHonorSharedReaderSizeBound() async throws {
+        let fixture = try await makeBoundFixture()
+        let oversizedContent = String(repeating: "a", count: 10_000_001)
+        try write(oversizedContent, to: fixture.worktreeRoot.appendingPathComponent("Sources/App.swift"))
+        let source = makeSource(
+            logicalRoot: fixture.logicalRoot,
+            worktreeRoot: fixture.worktreeRoot,
+            selection: StoredSelection(selectedPaths: ["Sources/App.swift"], codemapAutoEnabled: false)
+        )
+
+        let model = try await AgentContextExportResolver.resolveModel(
+            source: source,
+            store: fixture.store,
+            filePathDisplay: .relative,
+            codeMapUsage: .none
+        )
+
+        let boundedContent = "[File too large: 10000001 bytes]"
+        XCTAssertEqual(model.totalSelectedDisplayTokens, TokenCalculationService.estimateTokens(for: boundedContent))
+        let metrics = try XCTUnwrap(model.rows.first?.metrics.knownValues)
+        XCTAssertEqual(metrics.tokenCount, TokenCalculationService.estimateTokens(for: boundedContent))
+        XCTAssertEqual(metrics.lineCount, 1)
+    }
+
+    func testMetadataOnlyWorktreeResolutionCancellationStopsBeforeNextRead() async throws {
+        let fixture = try await makeBoundFixture()
+        let source = makeSource(
+            logicalRoot: fixture.logicalRoot,
+            worktreeRoot: fixture.worktreeRoot,
+            selection: StoredSelection(
+                selectedPaths: ["Sources/App.swift", "Sources/Keep.swift"],
+                codemapAutoEnabled: false
+            )
+        )
+        let probe = ResolvedContentReaderProbe(content: "unreachable", blocksFirstRead: true)
+        let accountingService = PromptContextAccountingService(resolvedContentReader: { location, workloadClass in
+            try await probe.read(location: location, workloadClass: workloadClass)
+        })
+        let finalModelAssemblyCount = AgentExportLockedCounter()
+        let resolutionTask = Task {
+            try await AgentContextExportResolver.resolveModel(
+                source: source,
+                store: fixture.store,
+                filePathDisplay: .relative,
+                codeMapUsage: .none,
+                accountingService: accountingService,
+                phaseDidBeginForTesting: { phase in
+                    if phase == .finalModelAssembly {
+                        finalModelAssemblyCount.increment()
+                    }
+                }
+            )
+        }
+        await probe.waitUntilReadStarts()
+
+        resolutionTask.cancel()
+        await probe.releaseFirstRead()
+
+        do {
+            _ = try await resolutionTask.value
+            XCTFail("Expected metadata-only resolution cancellation")
+        } catch is CancellationError {
+            // Expected
+        }
+        let inputs = await probe.recordedInputs()
+        XCTAssertEqual(inputs.count, 1)
+        XCTAssertEqual(inputs.first?.location.relativePath, "Sources/App.swift")
+        XCTAssertEqual(finalModelAssemblyCount.value, 0)
+    }
+
+    func testMetadataOnlyCancellationImmediatelyBeforeReturnPublishesNoModel() async throws {
+        let fixture = try await makeBoundFixture()
+        let source = makeSource(
+            logicalRoot: fixture.logicalRoot,
+            worktreeRoot: fixture.worktreeRoot,
+            selection: StoredSelection(selectedPaths: ["Sources/App.swift"], codemapAutoEnabled: false)
+        )
+        let finalModelAssemblyCount = AgentExportLockedCounter()
+
+        do {
+            _ = try await AgentContextExportResolver.resolveModel(
+                source: source,
+                store: fixture.store,
+                filePathDisplay: .relative,
+                codeMapUsage: .none,
+                phaseDidBeginForTesting: { phase in
+                    guard phase == .finalModelAssembly else { return }
+                    finalModelAssemblyCount.increment()
+                    withUnsafeCurrentTask { $0?.cancel() }
+                }
+            )
+            XCTFail("Expected cancellation immediately before model publication")
+        } catch is CancellationError {
+            // Expected
+        }
+        XCTAssertEqual(finalModelAssemblyCount.value, 1)
+    }
+
+    func testMetadataOnlyInsideRootSymlinkPreservesResolvedTargetURL() async throws {
+        let fixture = try await makeBoundFixture()
+        let targetURL = fixture.worktreeRoot.appendingPathComponent("Sources/Target.swift")
+        let symlinkURL = fixture.worktreeRoot.appendingPathComponent("Sources/Linked.swift")
+        try write("let target = true\n", to: targetURL)
+        try FileManager.default.createSymbolicLink(at: symlinkURL, withDestinationURL: targetURL)
+        let source = makeSource(
+            logicalRoot: fixture.logicalRoot,
+            worktreeRoot: fixture.worktreeRoot,
+            selection: StoredSelection(selectedPaths: ["Sources/Linked.swift"], codemapAutoEnabled: false)
+        )
+        let probe = ResolvedContentReaderProbe(content: "let target = true\n")
+        let accountingService = PromptContextAccountingService(resolvedContentReader: { location, workloadClass in
+            try await probe.read(location: location, workloadClass: workloadClass)
+        })
+
+        let model = try await AgentContextExportResolver.resolveModel(
+            source: source,
+            store: fixture.store,
+            filePathDisplay: .relative,
+            codeMapUsage: .none,
+            accountingService: accountingService
+        )
+
+        let recordedInputs = await probe.recordedInputs()
+        let input = try XCTUnwrap(recordedInputs.first)
+        XCTAssertEqual(input.location.resolvedFileURL, targetURL.resolvingSymlinksInPath().standardizedFileURL)
+        XCTAssertEqual(input.location.relativePath, "Sources/Target.swift")
+        let row = try XCTUnwrap(model.rows.first)
+        XCTAssertEqual(row.displayPath, "Sources/Linked.swift")
+        XCTAssertEqual(row.physicalPath, symlinkURL.standardizedFileURL.path)
+        XCTAssertEqual(row.resolvedContentLocation, input.location)
     }
 
     func testBoundWorktreeAutoCodemapDoesNotUseMetadataOnlyFastPathWhenAutoCodemapEnabled() async throws {
@@ -308,7 +764,7 @@ final class AgentContextExportResolverTests: WorkspaceFileContextStoreCodemapSea
             selection: StoredSelection(selectedPaths: ["Sources/App.swift"], codemapAutoEnabled: true)
         )
 
-        let model = await AgentContextExportResolver.resolveModel(
+        let model = try await AgentContextExportResolver.resolveModel(
             source: source,
             store: fixture.store,
             filePathDisplay: .relative,
@@ -317,7 +773,7 @@ final class AgentContextExportResolverTests: WorkspaceFileContextStoreCodemapSea
 
         XCTAssertEqual(model.lookupContext.bindingProjection?.isFullyMaterialized, true)
         XCTAssertEqual(model.rows.first?.displayPath, "Sources/App.swift")
-        XCTAssertTrue(model.rows.allSatisfy { $0.directContentPath == nil })
+        XCTAssertTrue(model.rows.allSatisfy { $0.resolvedContentLocation == nil })
     }
 
     func testMetadataOnlyWorktreeExportDoesNotDirectReadSymlinkEscapingRoot() async throws {
@@ -336,7 +792,7 @@ final class AgentContextExportResolverTests: WorkspaceFileContextStoreCodemapSea
             selection: StoredSelection(selectedPaths: ["Sources/Linked.swift"], codemapAutoEnabled: false)
         )
 
-        let model = await AgentContextExportResolver.resolveModel(
+        let model = try await AgentContextExportResolver.resolveModel(
             source: source,
             store: fixture.store,
             filePathDisplay: .relative,
@@ -344,7 +800,7 @@ final class AgentContextExportResolverTests: WorkspaceFileContextStoreCodemapSea
         )
 
         XCTAssertFalse(model.lookupContext.bindingProjection?.isFullyMaterialized == false)
-        XCTAssertTrue(model.rows.allSatisfy { $0.directContentPath == nil })
+        XCTAssertTrue(model.rows.allSatisfy { $0.resolvedContentLocation == nil })
         if let row = model.rows.first {
             let previewText = await AgentContextExportResolver.loadRowContent(
                 for: row,
@@ -364,7 +820,7 @@ final class AgentContextExportResolverTests: WorkspaceFileContextStoreCodemapSea
             selection: StoredSelection(codemapAutoEnabled: false)
         )
 
-        let model = await AgentContextExportResolver.resolveModel(
+        let model = try await AgentContextExportResolver.resolveModel(
             source: source,
             store: fixture.store,
             filePathDisplay: .relative,
@@ -406,7 +862,7 @@ final class AgentContextExportResolverTests: WorkspaceFileContextStoreCodemapSea
             )
         )
 
-        let model = await AgentContextExportResolver.resolveModel(
+        let model = try await AgentContextExportResolver.resolveModel(
             source: source,
             store: store,
             filePathDisplay: .relative,
@@ -477,7 +933,7 @@ final class AgentContextExportResolverTests: WorkspaceFileContextStoreCodemapSea
             worktreeBindings: []
         )
 
-        let model = await AgentContextExportResolver.resolveModel(
+        let model = try await AgentContextExportResolver.resolveModel(
             source: source,
             store: store,
             filePathDisplay: .relative,
@@ -487,6 +943,103 @@ final class AgentContextExportResolverTests: WorkspaceFileContextStoreCodemapSea
         XCTAssertEqual(model.rows.map(\.kind), [.full])
         guard case .unavailable = model.codemapCoverage else {
             return XCTFail("Selected unavailable codemap must report incomplete coverage")
+        }
+        XCTAssertFalse(model.codemapIssues.isEmpty)
+        XCTAssertEqual(runtimeAccessCount.value, 0)
+    }
+
+    func testResolveModelCancellationDuringPresentationStopsDownstreamPhases() async throws {
+        let root = try makeTemporaryRoot(name: "AgentExportPresentationCancellation")
+        try write("struct PresentationCancellation {}\n", to: root.appendingPathComponent("Sources/App.swift"))
+        let store = try makeIsolatedCodemapStore(name: #function)
+        _ = try await store.loadRoot(path: root.path)
+        let source = AgentContextExportSource(
+            tabID: UUID(),
+            promptText: "Review",
+            selection: StoredSelection(selectedPaths: ["Sources/App.swift"], codemapAutoEnabled: true),
+            selectedMetaPromptIDs: [],
+            tabName: "Agent Tab",
+            activeAgentSessionID: nil,
+            worktreeBindings: []
+        )
+        let presentationStarted = expectation(description: "Model resolution reached codemap presentation")
+        let presentationGate = AgentContextExportLookupGate()
+        let codemapFileRecordCount = AgentExportLockedCounter()
+        let metricsAssemblyCount = AgentExportLockedCounter()
+        let finalModelAssemblyCount = AgentExportLockedCounter()
+        let resolutionTask = Task {
+            try await AgentContextExportResolver.resolveModel(
+                source: source,
+                store: store,
+                filePathDisplay: .relative,
+                codeMapUsage: .complete,
+                presentationWillBeginForTesting: { () async throws(CancellationError) in
+                    presentationStarted.fulfill()
+                    await presentationGate.wait()
+                    guard !Task.isCancelled else { throw CancellationError() }
+                },
+                phaseDidBeginForTesting: { phase in
+                    switch phase {
+                    case .codemapFileRecords:
+                        codemapFileRecordCount.increment()
+                    case .metricsAssembly:
+                        metricsAssemblyCount.increment()
+                    case .finalModelAssembly:
+                        finalModelAssemblyCount.increment()
+                    }
+                }
+            )
+        }
+
+        await fulfillment(of: [presentationStarted], timeout: 5)
+        resolutionTask.cancel()
+        await presentationGate.open()
+        do {
+            let model = try await resolutionTask.value
+            XCTFail("Cancellation was swallowed and returned a downstream model with \(model.rows.count) rows")
+        } catch is CancellationError {
+        } catch {
+            XCTFail("Expected CancellationError, received \(error)")
+        }
+
+        XCTAssertEqual(codemapFileRecordCount.value, 0)
+        XCTAssertEqual(metricsAssemblyCount.value, 0)
+        XCTAssertEqual(finalModelAssemblyCount.value, 0)
+    }
+
+    func testManualUnavailableCodemapOmitsCodemapRowsAndReportsIncompleteCoverage() async throws {
+        let root = try makeTemporaryRoot(name: "AgentExportManualUnavailable")
+        try write("struct ManualUnavailable {}\n", to: root.appendingPathComponent("Sources/App.swift"))
+        let runtimeAccessCount = AgentExportLockedCounter()
+        let store = WorkspaceFileContextStore(codemapRuntimeProvider: {
+            runtimeAccessCount.increment()
+            throw AgentExportTestError.unexpectedRuntimeAccess
+        })
+        _ = try await store.loadRoot(path: root.path)
+        let source = AgentContextExportSource(
+            tabID: UUID(),
+            promptText: "Review",
+            selection: StoredSelection(
+                manualCodemapPaths: ["Sources/App.swift"],
+                codemapAutoEnabled: false
+            ),
+            selectedMetaPromptIDs: [],
+            tabName: "Agent Tab",
+            activeAgentSessionID: nil,
+            worktreeBindings: []
+        )
+
+        let model = try await AgentContextExportResolver.resolveModel(
+            source: source,
+            store: store,
+            filePathDisplay: .relative,
+            codeMapUsage: .auto
+        )
+
+        XCTAssertTrue(model.rows.isEmpty)
+        XCTAssertEqual(model.rows.count(where: { $0.kind == .codemap }), 0)
+        guard case .unavailable = model.codemapCoverage else {
+            return XCTFail("Manual unavailable codemap must report incomplete coverage")
         }
         XCTAssertFalse(model.codemapIssues.isEmpty)
         XCTAssertEqual(runtimeAccessCount.value, 0)
@@ -543,7 +1096,7 @@ final class AgentContextExportResolverTests: WorkspaceFileContextStoreCodemapSea
             }
         )
 
-        let model = await AgentContextExportResolver.resolveModel(
+        let model = try await AgentContextExportResolver.resolveModel(
             source: source,
             store: store,
             filePathDisplay: .relative,
@@ -614,7 +1167,7 @@ final class AgentContextExportResolverTests: WorkspaceFileContextStoreCodemapSea
             }
         )
 
-        let model = await AgentContextExportResolver.resolveModel(
+        let model = try await AgentContextExportResolver.resolveModel(
             source: source,
             store: store,
             filePathDisplay: .relative,
@@ -737,7 +1290,7 @@ final class AgentContextExportResolverTests: WorkspaceFileContextStoreCodemapSea
             selection: StoredSelection(selectedPaths: ["Sources/App.swift"], codemapAutoEnabled: false)
         )
 
-        let model = await AgentContextExportResolver.resolveModel(
+        let model = try await AgentContextExportResolver.resolveModel(
             source: source,
             store: store,
             filePathDisplay: .relative,
@@ -765,7 +1318,7 @@ final class AgentContextExportResolverTests: WorkspaceFileContextStoreCodemapSea
             codemapAutoEnabled: false
         )
         let source = makeSource(logicalRoot: fixture.logicalRoot, worktreeRoot: fixture.worktreeRoot, selection: original)
-        let model = await AgentContextExportResolver.resolveModel(
+        let model = try await AgentContextExportResolver.resolveModel(
             source: source,
             store: fixture.store,
             filePathDisplay: .relative,
@@ -851,7 +1404,7 @@ final class AgentContextExportResolverTests: WorkspaceFileContextStoreCodemapSea
             worktreeBindings: []
         )
         let lookupContext = await AgentContextExportResolver.lookupContext(source: source, store: store)
-        let model = await AgentContextExportResolver.resolveModel(
+        let model = try await AgentContextExportResolver.resolveModel(
             source: source,
             store: store,
             filePathDisplay: .relative,
@@ -863,6 +1416,71 @@ final class AgentContextExportResolverTests: WorkspaceFileContextStoreCodemapSea
         XCTAssertEqual(model.missingPaths, ["Sources/Hidden.swift"])
     }
 
+    func testSingleLogicalRootSelectionInMultiRootWorkspaceHidesRootPill() async throws {
+        let firstRoot = try makeTemporaryRoot(name: "AgentExportFirstRoot")
+        let secondRoot = try makeTemporaryRoot(name: "AgentExportSecondRoot")
+        let selectedFile = firstRoot.appendingPathComponent("Sources/Selected.swift")
+        try write("struct SelectedOnly {}\n", to: selectedFile)
+        try write("struct Unselected {}\n", to: secondRoot.appendingPathComponent("Sources/Unselected.swift"))
+        let store = WorkspaceFileContextStore()
+        _ = try await store.loadRoot(path: firstRoot.path)
+        _ = try await store.loadRoot(path: secondRoot.path)
+
+        let model = try await AgentContextExportResolver.resolveModel(
+            source: AgentContextExportSource(
+                tabID: UUID(),
+                promptText: "Review one root",
+                selection: StoredSelection(selectedPaths: [selectedFile.path], codemapAutoEnabled: false),
+                selectedMetaPromptIDs: [],
+                tabName: "Single-root selection",
+                activeAgentSessionID: nil,
+                worktreeBindings: []
+            ),
+            store: store,
+            filePathDisplay: .relative,
+            codeMapUsage: .none
+        )
+
+        let row = try XCTUnwrap(model.rows.first)
+        XCTAssertEqual(model.rows.count, 1)
+        XCTAssertEqual(row.rootColorKey, firstRoot.standardizedFileURL.path)
+        XCTAssertFalse(row.showRootPill)
+    }
+
+    func testSpanningLogicalRootsInMultiRootWorkspaceShowsRootPill() async throws {
+        let firstRoot = try makeTemporaryRoot(name: "AgentExportSpanningFirstRoot")
+        let secondRoot = try makeTemporaryRoot(name: "AgentExportSpanningSecondRoot")
+        let firstFile = firstRoot.appendingPathComponent("Sources/First.swift")
+        let secondFile = secondRoot.appendingPathComponent("Sources/Second.swift")
+        try write("struct FirstRootSelection {}\n", to: firstFile)
+        try write("struct SecondRootSelection {}\n", to: secondFile)
+        let store = WorkspaceFileContextStore()
+        _ = try await store.loadRoot(path: firstRoot.path)
+        _ = try await store.loadRoot(path: secondRoot.path)
+
+        let model = try await AgentContextExportResolver.resolveModel(
+            source: AgentContextExportSource(
+                tabID: UUID(),
+                promptText: "Review two roots",
+                selection: StoredSelection(selectedPaths: [firstFile.path, secondFile.path], codemapAutoEnabled: false),
+                selectedMetaPromptIDs: [],
+                tabName: "Spanning selection",
+                activeAgentSessionID: nil,
+                worktreeBindings: []
+            ),
+            store: store,
+            filePathDisplay: .relative,
+            codeMapUsage: .none
+        )
+
+        XCTAssertEqual(model.rows.count, 2)
+        XCTAssertEqual(
+            Set(model.rows.map(\.rootColorKey)),
+            Set([firstRoot.standardizedFileURL.path, secondRoot.standardizedFileURL.path])
+        )
+        XCTAssertTrue(model.rows.allSatisfy(\.showRootPill))
+    }
+
     func testDuplicateRootBasenamesProduceStableAgentPathsWithoutPhysicalLeaks() async throws {
         let firstParent = try makeTemporaryRoot(name: "AgentDuplicateRootFirst")
         let secondParent = try makeTemporaryRoot(name: "AgentDuplicateRootSecond")
@@ -871,13 +1489,13 @@ final class AgentContextExportResolverTests: WorkspaceFileContextStoreCodemapSea
         let firstFile = firstRoot.appendingPathComponent("Sources/App.swift")
         let secondFile = secondRoot.appendingPathComponent("Sources/App.swift")
         try write(SwiftFixtureSource.emptyStruct("FirstDuplicateRoot"), to: firstFile)
-        try write(SwiftFixtureSource.emptyStruct("SecondDuplicateRoot"), to: secondFile)
+        try write("struct SecondDuplicateRoot {\n    func largerSelectionRow() {\n        let repeated = \"more selected content\"\n        print(repeated)\n    }\n}\n", to: secondFile)
         let store = WorkspaceFileContextStore()
         _ = try await store.loadRoot(path: firstRoot.path)
         _ = try await store.loadRoot(path: secondRoot.path)
 
-        func model(paths: [String]) async -> AgentContextExportModel {
-            await AgentContextExportResolver.resolveModel(
+        func model(paths: [String]) async throws -> AgentContextExportModel {
+            try await AgentContextExportResolver.resolveModel(
                 source: AgentContextExportSource(
                     tabID: UUID(),
                     promptText: "Review duplicate roots",
@@ -893,12 +1511,16 @@ final class AgentContextExportResolverTests: WorkspaceFileContextStoreCodemapSea
             )
         }
 
-        let first = await model(paths: [secondFile.path, firstFile.path])
-        let second = await model(paths: [firstFile.path, secondFile.path])
+        let first = try await model(paths: [secondFile.path, firstFile.path])
+        let second = try await model(paths: [firstFile.path, secondFile.path])
         let paths = first.rows.map(\.displayPath)
 
         XCTAssertEqual(paths, second.rows.map(\.displayPath))
         XCTAssertEqual(Set(paths).count, 2)
+        XCTAssertEqual(first.rows.first?.rootColorKey, secondRoot.standardizedFileURL.path)
+        XCTAssertEqual(first.rows.first?.metrics.tokenSortKey, first.rows.map(\.metrics.tokenSortKey).max())
+        XCTAssertTrue(first.rows.allSatisfy(\.showRootPill))
+        XCTAssertEqual(Set(first.rows.map(\.rootColorKey)), Set([firstRoot.standardizedFileURL.path, secondRoot.standardizedFileURL.path]))
         XCTAssertTrue(paths.allSatisfy { $0.hasPrefix("root@") && $0.hasSuffix("/Sources/App.swift") })
         XCTAssertFalse(paths.contains { $0.contains(firstParent.path) || $0.contains(secondParent.path) })
         XCTAssertFalse(first.missingPaths.contains { $0.contains(firstParent.path) || $0.contains(secondParent.path) })
@@ -946,6 +1568,39 @@ final class AgentContextExportResolverTests: WorkspaceFileContextStoreCodemapSea
             bindings: [firstBinding]
         )
         XCTAssertNotEqual(firstSource.exportContextIdentity, changedSelectionSource.exportContextIdentity)
+
+        let changedSessionSource = makeSource(
+            tabID: tabID,
+            sessionID: UUID(),
+            selection: selection,
+            bindings: [firstBinding]
+        )
+        XCTAssertNotEqual(firstSource.exportContextIdentity, changedSessionSource.exportContextIdentity)
+    }
+
+    func testExportContextIdentityIncludesSessionWithoutWorktreeBindings() {
+        let tabID = UUID()
+        let selection = StoredSelection(selectedPaths: ["Sources/Selected.swift"], codemapAutoEnabled: false)
+        let first = AgentContextExportSource(
+            tabID: tabID,
+            promptText: "",
+            selection: selection,
+            selectedMetaPromptIDs: [],
+            tabName: nil,
+            activeAgentSessionID: UUID(),
+            worktreeBindings: []
+        )
+        let second = AgentContextExportSource(
+            tabID: tabID,
+            promptText: "",
+            selection: selection,
+            selectedMetaPromptIDs: [],
+            tabName: nil,
+            activeAgentSessionID: UUID(),
+            worktreeBindings: []
+        )
+
+        XCTAssertNotEqual(first.exportContextIdentity, second.exportContextIdentity)
     }
 
     func testRemoveRowRebasedOntoLatestSelectionPreservesNewlyAddedFiles() async throws {
@@ -955,7 +1610,7 @@ final class AgentContextExportResolverTests: WorkspaceFileContextStoreCodemapSea
             codemapAutoEnabled: false
         )
         let source = makeSource(logicalRoot: fixture.logicalRoot, worktreeRoot: fixture.worktreeRoot, selection: staleSelection)
-        let model = await AgentContextExportResolver.resolveModel(
+        let model = try await AgentContextExportResolver.resolveModel(
             source: source,
             store: fixture.store,
             filePathDisplay: .relative,
@@ -1017,7 +1672,7 @@ final class AgentContextExportResolverTests: WorkspaceFileContextStoreCodemapSea
             worktreeBindings: []
         )
 
-        let model = await AgentContextExportResolver.resolveModel(
+        let model = try await AgentContextExportResolver.resolveModel(
             source: source,
             store: store,
             filePathDisplay: .relative,
@@ -1165,6 +1820,474 @@ final class AgentContextExportResolverTests: WorkspaceFileContextStoreCodemapSea
         XCTAssertEqual(source.promptText, "active live prompt")
     }
 
+    @MainActor
+    func testCurrentManagerPresetIsUsedWithoutStandardSubstitution() {
+        let previousCodeMapsDisabled = GlobalSettingsStore.shared.globalCodeMapsDisabled()
+        GlobalSettingsStore.shared.setCodeMapsGloballyDisabled(false, commit: false)
+        defer {
+            GlobalSettingsStore.shared.setCodeMapsGloballyDisabled(previousCodeMapsDisabled, commit: false)
+        }
+
+        let store = WorkspaceFileContextStore()
+        let promptManager = makePrompt(store: store, windowID: 41008)
+        let storedPromptID = UUID()
+        let storedPrompt = PromptViewModel.StoredPrompt(
+            id: storedPromptID,
+            title: "Custom instructions",
+            content: "Keep this exact stored prompt"
+        )
+        let customPreset = CopyPreset(
+            name: "Manager-only preset",
+            description: "Manager-backed configuration outside the Compose base options",
+            icon: "shippingbox",
+            includeFiles: false,
+            includeUserPrompt: true,
+            includeMetaPrompts: true,
+            includeFileTree: false,
+            fileTreeMode: FileTreeOption.none,
+            codeMapUsage: .complete,
+            gitInclusion: .selected,
+            storedPromptIds: [storedPromptID]
+        )
+        let presetManager = CopyPresetManager.shared
+        presetManager.add(customPreset)
+        defer { presetManager.remove(id: customPreset.id) }
+
+        promptManager.storedPrompts = [storedPrompt]
+        promptManager.selectCopyPreset(customPreset.id)
+        let exportContext = AgentContextExportViewContext(
+            promptManager: promptManager,
+            selectionCoordinator: nil,
+            currentTabID: nil,
+            activeAgentSessionID: nil,
+            worktreeBindingsProvider: nil
+        )
+        let promptTab = AgentContextDrawerPromptTab(
+            promptManager: promptManager,
+            modelCoordinator: AgentSelectedFilesModelCoordinator(),
+            exportContext: exportContext,
+            isSwitchBlankingSelectedFiles: false
+        )
+
+        let state = promptTab.makeRenderState()
+
+        XCTAssertEqual(state.selectedPresetID, customPreset.id)
+        XCTAssertEqual(state.resolvedConfig.codeMapUsage, .complete)
+        XCTAssertEqual(state.resolvedConfig.fileTreeMode, .none)
+        XCTAssertEqual(state.resolvedConfig.gitInclusion, .selected)
+        XCTAssertEqual(state.selectedPromptIDs, [storedPromptID])
+        XCTAssertEqual(state.selectedPrompts.map(\.id), [storedPromptID])
+        XCTAssertEqual(state.selectedPrompts.map(\.content), [storedPrompt.content])
+        XCTAssertEqual(promptManager.promptSelection(for: .copy), [storedPromptID])
+    }
+
+    @MainActor
+    func testBuiltInOverrideUsesManagerResolvedConfiguration() {
+        let previousCodeMapsDisabled = GlobalSettingsStore.shared.globalCodeMapsDisabled()
+        GlobalSettingsStore.shared.setCodeMapsGloballyDisabled(false, commit: false)
+        defer {
+            GlobalSettingsStore.shared.setCodeMapsGloballyDisabled(previousCodeMapsDisabled, commit: false)
+        }
+
+        let presetManager = CopyPresetManager.shared
+        let presetID = BuiltInCopyPresets.standard.id
+        let previousOverride = presetManager.getOverrides(presetID)
+        presetManager.upsertOverrides(
+            CopyPresetOverrides(
+                presetID: presetID,
+                includeFiles: false,
+                includeFileTree: false,
+                fileTreeMode: FileTreeOption.none,
+                codeMapUsage: .complete,
+                gitInclusion: .complete
+            )
+        )
+        defer {
+            if let previousOverride {
+                presetManager.upsertOverrides(previousOverride)
+            } else {
+                presetManager.clearOverrides(for: presetID)
+            }
+        }
+
+        let store = WorkspaceFileContextStore()
+        let promptManager = makePrompt(store: store, windowID: 41009)
+        promptManager.selectCopyPreset(presetID)
+        let exportContext = AgentContextExportViewContext(
+            promptManager: promptManager,
+            selectionCoordinator: nil,
+            currentTabID: nil,
+            activeAgentSessionID: nil,
+            worktreeBindingsProvider: nil
+        )
+        let promptTab = AgentContextDrawerPromptTab(
+            promptManager: promptManager,
+            modelCoordinator: AgentSelectedFilesModelCoordinator(),
+            exportContext: exportContext,
+            isSwitchBlankingSelectedFiles: false
+        )
+
+        let state = promptTab.makeRenderState()
+        let request = exportContext.makeModelRequest(flushPendingUI: false)
+
+        XCTAssertEqual(state.selectedPresetID, presetID)
+        XCTAssertFalse(state.resolvedConfig.includeFiles)
+        XCTAssertFalse(state.resolvedConfig.includeFileTree)
+        XCTAssertEqual(state.resolvedConfig.fileTreeMode, .none)
+        XCTAssertEqual(state.resolvedConfig.codeMapUsage, .complete)
+        XCTAssertEqual(state.resolvedConfig.gitInclusion, .complete)
+        XCTAssertEqual(request.codeMapUsage, .complete)
+        XCTAssertEqual(request.identity.codeMapUsage, .complete)
+    }
+
+    @MainActor
+    func testModelRequestUsesActivePackagingCodemapMode() {
+        let previousCodeMapsDisabled = GlobalSettingsStore.shared.globalCodeMapsDisabled()
+        GlobalSettingsStore.shared.setCodeMapsGloballyDisabled(false, commit: false)
+        defer {
+            GlobalSettingsStore.shared.setCodeMapsGloballyDisabled(previousCodeMapsDisabled, commit: false)
+        }
+
+        let store = WorkspaceFileContextStore()
+        let promptManager = makePrompt(store: store, windowID: 41010)
+        promptManager.selectCopyPreset(
+            BuiltInCopyPresets.manual.id,
+            applySettings: false,
+            restoreManualSnapshot: false
+        )
+        let exportContext = AgentContextExportViewContext(
+            promptManager: promptManager,
+            selectionCoordinator: nil,
+            currentTabID: nil,
+            activeAgentSessionID: nil,
+            worktreeBindingsProvider: nil
+        )
+
+        let requests = [CodeMapUsage.none, .complete].map { codeMapUsage in
+            promptManager.codeMapUsage = codeMapUsage
+            return exportContext.makeModelRequest(flushPendingUI: false)
+        }
+
+        XCTAssertEqual(requests.map(\.codeMapUsage), [.none, .complete])
+        XCTAssertEqual(requests.map(\.identity.codeMapUsage), [.none, .complete])
+        XCTAssertNotEqual(requests[0].identity, requests[1].identity)
+    }
+
+    @MainActor
+    func testCopyPromptWithModelUsesFreshSourceAndBoundWorktreeLookup() async throws {
+        let promptA = "COPY_PROMPT_STALE_BASELINE_A"
+        let promptB = "COPY_PROMPT_LIVE_BASELINE_B"
+        let root = try makeTemporaryRoot(name: "AgentExportStalePrompt")
+        try write("let current = true\n", to: root.appendingPathComponent("Sources/App.swift"))
+
+        let store = WorkspaceFileContextStore()
+        _ = try await store.loadRoot(path: root.path)
+        let tabID = UUID()
+        let selection = StoredSelection(
+            selectedPaths: ["Sources/App.swift"],
+            codemapAutoEnabled: false
+        )
+        let workspace = WorkspaceModel(
+            name: "Stale prompt baseline",
+            repoPaths: [root.path],
+            ephemeralFlag: true,
+            composeTabs: [
+                ComposeTabState(
+                    id: tabID,
+                    name: "Copy baseline",
+                    selection: selection,
+                    promptText: promptA
+                )
+            ],
+            activeComposeTabID: tabID
+        )
+        let promptManager = makePrompt(store: store, windowID: 41007)
+        promptManager.loadComposeTabsFromWorkspace(workspace, syncPromptText: true)
+        let exportContext = AgentContextExportViewContext(
+            promptManager: promptManager,
+            selectionCoordinator: nil,
+            currentTabID: tabID,
+            activeAgentSessionID: nil,
+            worktreeBindingsProvider: nil
+        )
+        let model = try await AgentContextExportResolver.resolveModel(
+            source: exportContext.makeExportSource(flushPendingUI: false),
+            store: store,
+            filePathDisplay: .relative,
+            codeMapUsage: .none
+        )
+
+        promptManager.promptText = promptB
+        let latestSource = exportContext.makeExportSource(flushPendingUI: false)
+        XCTAssertEqual(model.source.exportContextIdentity, latestSource.exportContextIdentity)
+        XCTAssertEqual(model.source.promptText, promptA)
+        XCTAssertEqual(latestSource.promptText, promptB)
+
+        let cfg = makeConfig(gitInclusion: .none)
+        for _ in 0 ..< 5 {
+            let clipboard = await exportContext.buildClipboardContent(for: cfg, model: model)
+
+            XCTAssertTrue(clipboard.contains(promptB), clipboard)
+            XCTAssertFalse(clipboard.contains(promptA), clipboard)
+        }
+
+        let worktreeRoot = try makeTemporaryRoot(name: "AgentExportFreshLookup")
+        try write("let identity = \"fresh worktree\"\n", to: worktreeRoot.appendingPathComponent("Sources/App.swift"))
+        let sessionID = UUID()
+        let identityMismatchContext = AgentContextExportViewContext(
+            promptManager: promptManager,
+            selectionCoordinator: nil,
+            currentTabID: tabID,
+            activeAgentSessionID: sessionID,
+            worktreeBindingsProvider: { requestedSessionID, requestedTabID in
+                guard requestedSessionID == sessionID, requestedTabID == tabID else { return [] }
+                return [self.makeBinding(logicalRoot: root, worktreeRoot: worktreeRoot)]
+            }
+        )
+        let identityMismatchSource = identityMismatchContext.makeExportSource(flushPendingUI: false)
+        XCTAssertNotEqual(model.source.exportContextIdentity, identityMismatchSource.exportContextIdentity)
+
+        let identityMismatchClipboard = await identityMismatchContext.buildClipboardContent(for: cfg, model: model)
+        XCTAssertTrue(identityMismatchClipboard.contains(promptB), identityMismatchClipboard)
+        XCTAssertFalse(identityMismatchClipboard.contains(promptA), identityMismatchClipboard)
+        XCTAssertTrue(identityMismatchClipboard.contains("let identity = \"fresh worktree\""), identityMismatchClipboard)
+        XCTAssertFalse(identityMismatchClipboard.contains("let current = true"), identityMismatchClipboard)
+    }
+
+    @MainActor
+    func testClipboardUsesGitStateCapturedBeforeDelayedLookup() async throws {
+        let gitFixture = try ReviewGitRepositoryFixture(name: "AgentExportGitSnapshotOriginal")
+        let originalRoot = try gitFixture.makeRepository(
+            named: "repository",
+            files: ["Sources/Original.swift": "let selectedOrigin = \"baseline\"\n"]
+        )
+        _ = try gitFixture.runGit(["branch", "click-base"], at: originalRoot)
+        try gitFixture.write("let selectedOrigin = \"original\"\n", to: "Sources/Original.swift", at: originalRoot)
+        try gitFixture.stage("Sources/Original.swift", at: originalRoot)
+        try gitFixture.commit("Original selected state", at: originalRoot)
+        _ = try gitFixture.runGit(["branch", "later-base"], at: originalRoot)
+
+        let laterRoot = try makeTemporaryRoot(name: "AgentExportGitSnapshotLater")
+        try write("let selectedOrigin = \"later\"\n", to: laterRoot.appendingPathComponent("Sources/Later.swift"))
+
+        let store = WorkspaceFileContextStore()
+        _ = try await store.loadRoot(path: originalRoot.path)
+        let tabID = UUID()
+        let promptManager = makePrompt(store: store, windowID: 41011)
+        promptManager.loadComposeTabsFromWorkspace(
+            WorkspaceModel(
+                name: "Git click snapshot",
+                repoPaths: [originalRoot.path],
+                ephemeralFlag: true,
+                composeTabs: [
+                    ComposeTabState(
+                        id: tabID,
+                        name: "Git snapshot",
+                        selection: StoredSelection(
+                            selectedPaths: ["Sources/Original.swift"],
+                            codemapAutoEnabled: false
+                        ),
+                        promptText: "Review original Git state"
+                    )
+                ],
+                activeComposeTabID: tabID
+            ),
+            syncPromptText: true
+        )
+        promptManager.gitViewModel.selectedRootFolder = makeFolderViewModel(for: originalRoot)
+        promptManager.gitViewModel.selectedDiffBranch = "click-base"
+
+        let lookupStarted = expectation(description: "Clipboard lookup suspended")
+        let lookupGate = AgentContextExportLookupGate()
+        let exportContext = AgentContextExportViewContext(
+            promptManager: promptManager,
+            selectionCoordinator: nil,
+            currentTabID: tabID,
+            activeAgentSessionID: nil,
+            worktreeBindingsProvider: nil,
+            lookupContextProvider: { _, _ in
+                lookupStarted.fulfill()
+                await lookupGate.wait()
+                return .visibleWorkspace
+            }
+        )
+        let clipboardTask = Task {
+            await exportContext.buildClipboardContent(
+                for: makeConfig(gitInclusion: .selected),
+                model: nil
+            )
+        }
+
+        await fulfillment(of: [lookupStarted], timeout: 2)
+        promptManager.updateComposeTabSelectionPresentation(
+            StoredSelection(selectedPaths: ["Sources/Later.swift"], codemapAutoEnabled: false),
+            forTabID: tabID
+        )
+        promptManager.gitViewModel.selectedRootFolder = makeFolderViewModel(for: laterRoot)
+        promptManager.gitViewModel.selectedDiffBranch = "later-base"
+        await lookupGate.open()
+
+        let clipboard = await clipboardTask.value
+
+        XCTAssertTrue(clipboard.contains("let selectedOrigin = \"original\""), clipboard)
+        XCTAssertFalse(clipboard.contains("let selectedOrigin = \"later\""), clipboard)
+        XCTAssertTrue(clipboard.contains("<git_diff>"), clipboard)
+        XCTAssertTrue(clipboard.contains("-let selectedOrigin = \"baseline\""), clipboard)
+        XCTAssertTrue(clipboard.contains("+let selectedOrigin = \"original\""), clipboard)
+    }
+
+    @MainActor
+    func testCompleteClipboardUsesFrozenMergeBaseThroughDefaultResolver() async throws {
+        let gitFixture = try ReviewGitRepositoryFixture(name: "AgentExportCompleteLiveSnapshot")
+        let originalRoot = try gitFixture.makeRepository(
+            named: "repository",
+            files: ["Sources/Original.swift": "let completeOrigin = \"baseline\"\n"]
+        )
+        _ = try gitFixture.runGit(["branch", "click-base"], at: originalRoot)
+        try gitFixture.write("let completeOrigin = \"original\"\n", to: "Sources/Original.swift", at: originalRoot)
+        try gitFixture.stage("Sources/Original.swift", at: originalRoot)
+        try gitFixture.commit("Original complete state", at: originalRoot)
+        _ = try gitFixture.runGit(["branch", "later-base"], at: originalRoot)
+
+        let laterRoot = try makeTemporaryRoot(name: "AgentExportCompleteLiveLater")
+        let store = WorkspaceFileContextStore()
+        _ = try await store.loadRoot(path: originalRoot.path)
+        let tabID = UUID()
+        let promptManager = makePrompt(store: store, windowID: 41013)
+        promptManager.loadComposeTabsFromWorkspace(
+            WorkspaceModel(
+                name: "Complete live Git click snapshot",
+                repoPaths: [originalRoot.path],
+                ephemeralFlag: true,
+                composeTabs: [
+                    ComposeTabState(
+                        id: tabID,
+                        name: "Complete live Git snapshot",
+                        selection: StoredSelection(
+                            selectedPaths: ["Sources/Original.swift"],
+                            codemapAutoEnabled: false
+                        ),
+                        promptText: "Review complete live Git state"
+                    )
+                ],
+                activeComposeTabID: tabID
+            ),
+            syncPromptText: true
+        )
+        promptManager.gitViewModel.selectedRootFolder = makeFolderViewModel(for: originalRoot)
+        promptManager.gitViewModel.selectedDiffBranch = "click-base"
+
+        let lookupStarted = expectation(description: "Complete live clipboard lookup suspended")
+        let lookupGate = AgentContextExportLookupGate()
+        let exportContext = AgentContextExportViewContext(
+            promptManager: promptManager,
+            selectionCoordinator: nil,
+            currentTabID: tabID,
+            activeAgentSessionID: nil,
+            worktreeBindingsProvider: nil,
+            lookupContextProvider: { _, _ in
+                lookupStarted.fulfill()
+                await lookupGate.wait()
+                return .visibleWorkspace
+            }
+        )
+        let clipboardTask = Task {
+            await exportContext.buildClipboardContent(
+                for: makeConfig(gitInclusion: .complete),
+                model: nil
+            )
+        }
+
+        await fulfillment(of: [lookupStarted], timeout: 2)
+        promptManager.gitViewModel.selectedRootFolder = makeFolderViewModel(for: laterRoot)
+        promptManager.gitViewModel.selectedDiffBranch = "later-base"
+        await lookupGate.open()
+
+        let clipboard = await clipboardTask.value
+
+        XCTAssertTrue(clipboard.contains("<git_diff>"), clipboard)
+        XCTAssertTrue(clipboard.contains("-let completeOrigin = \"baseline\""), clipboard)
+        XCTAssertTrue(clipboard.contains("+let completeOrigin = \"original\""), clipboard)
+    }
+
+    @MainActor
+    func testCompleteDiffProviderUsesFrozenRootAndComparison() async throws {
+        let originalRoot = try makeTemporaryRoot(name: "AgentExportCompleteSnapshotOriginal")
+        let laterRoot = try makeTemporaryRoot(name: "AgentExportCompleteSnapshotLater")
+        try write("let completeOrigin = \"original\"\n", to: originalRoot.appendingPathComponent("Sources/Original.swift"))
+
+        let store = WorkspaceFileContextStore()
+        _ = try await store.loadRoot(path: originalRoot.path)
+        let tabID = UUID()
+        let promptManager = makePrompt(store: store, windowID: 41012)
+        promptManager.loadComposeTabsFromWorkspace(
+            WorkspaceModel(
+                name: "Complete Git click snapshot",
+                repoPaths: [originalRoot.path],
+                ephemeralFlag: true,
+                composeTabs: [
+                    ComposeTabState(
+                        id: tabID,
+                        name: "Complete Git snapshot",
+                        selection: StoredSelection(
+                            selectedPaths: ["Sources/Original.swift"],
+                            codemapAutoEnabled: false
+                        ),
+                        promptText: "Review complete Git state"
+                    )
+                ],
+                activeComposeTabID: tabID
+            ),
+            syncPromptText: true
+        )
+        promptManager.gitViewModel.selectedRootFolder = makeFolderViewModel(for: originalRoot)
+        promptManager.gitViewModel.selectedDiffBranch = "click-base"
+
+        let lookupStarted = expectation(description: "Complete clipboard lookup suspended")
+        let lookupGate = AgentContextExportLookupGate()
+        let inputRecorder = CompleteGitDiffInputRecorder()
+        let exportContext = AgentContextExportViewContext(
+            promptManager: promptManager,
+            selectionCoordinator: nil,
+            currentTabID: tabID,
+            activeAgentSessionID: nil,
+            worktreeBindingsProvider: nil,
+            lookupContextProvider: { _, _ in
+                lookupStarted.fulfill()
+                await lookupGate.wait()
+                return .visibleWorkspace
+            },
+            completeGitDiffResolver: { rootPath, compareIntent in
+                await inputRecorder.resolve(rootPath: rootPath, compareIntent: compareIntent)
+            }
+        )
+        let clipboardTask = Task {
+            await exportContext.buildClipboardContent(
+                for: makeConfig(gitInclusion: .complete),
+                model: nil
+            )
+        }
+
+        await fulfillment(of: [lookupStarted], timeout: 2)
+        promptManager.gitViewModel.selectedRootFolder = makeFolderViewModel(for: laterRoot)
+        promptManager.gitViewModel.selectedDiffBranch = "later-base"
+        await lookupGate.open()
+
+        let clipboard = await clipboardTask.value
+        let inputs = await inputRecorder.recordedInputs()
+
+        XCTAssertEqual(
+            inputs,
+            [
+                CompleteGitDiffInputRecorder.Input(
+                    rootPath: originalRoot.path,
+                    compareIntent: .uncommittedMergeBase(symbolicBase: "click-base")
+                )
+            ]
+        )
+        XCTAssertTrue(clipboard.contains("completeGitSnapshot"), clipboard)
+    }
+
     func testSelectedGitDiffPathsUseBoundWorktreeScope() async throws {
         let fixture = try await makeBoundFixture()
         let source = makeSource(
@@ -1220,6 +2343,51 @@ final class AgentContextExportResolverTests: WorkspaceFileContextStoreCodemapSea
         XCTAssertFalse(clipboard.contains("base checkout complete diff must not appear"), clipboard)
     }
 
+    func testCompleteGitDiffProviderTextAppearsInClipboard() async throws {
+        let root = try makeTemporaryRoot(name: "AgentExportCompleteGitDiff")
+        try write("let changed = true\n", to: root.appendingPathComponent("Sources/App.swift"))
+
+        let store = WorkspaceFileContextStore()
+        _ = try await store.loadRoot(path: root.path)
+        let source = AgentContextExportSource(
+            tabID: UUID(),
+            promptText: "Review complete diff",
+            selection: StoredSelection(selectedPaths: ["Sources/App.swift"], codemapAutoEnabled: false),
+            selectedMetaPromptIDs: [],
+            tabName: "Agent Tab",
+            activeAgentSessionID: nil,
+            worktreeBindings: []
+        )
+        let lookupContext = await AgentContextExportResolver.lookupContext(source: source, store: store)
+        let diffText = "diff --git a/Sources/App.swift b/Sources/App.swift\n+let completeGitSentinel = true"
+        let provider = CompleteGitDiffProviderSpy(text: diffText)
+
+        let clipboard = await AgentContextExportResolver.buildClipboardContent(
+            AgentContextClipboardRequest(
+                cfg: makeConfig(gitInclusion: .complete),
+                source: source,
+                store: store,
+                lookupContext: lookupContext,
+                filePathDisplay: .relative,
+                onlyIncludeRootsWithSelectedFiles: true,
+                showCodeMapMarkers: true,
+                metaInstructions: [],
+                includeDatetimeInUserInstructions: false,
+                promptSectionsOrder: PromptAssemblyBuilder.defaultSectionOrder,
+                disabledPromptSections: [],
+                duplicateUserInstructionsAtTop: false,
+                reviewGitContext: .automaticOnly(),
+                completeGitDiffProvider: { await provider.provide() ?? "" }
+            )
+        )
+
+        let providerInvocationCount = await provider.count()
+
+        XCTAssertTrue(clipboard.contains("<git_diff>"), clipboard)
+        XCTAssertTrue(clipboard.contains("completeGitSentinel"), clipboard)
+        XCTAssertEqual(providerInvocationCount, 1)
+    }
+
     func testPreviewContentIsPrefixBoundedWhileCopyRemainsFullContent() async throws {
         let root = try makeTemporaryRoot(name: "AgentExportPreviewBound")
         let content = String(repeating: "x", count: AgentContextPreviewContentPolicy.maximumBytes + 2000)
@@ -1236,7 +2404,7 @@ final class AgentContextExportResolverTests: WorkspaceFileContextStoreCodemapSea
             activeAgentSessionID: nil,
             worktreeBindings: []
         )
-        let model = await AgentContextExportResolver.resolveModel(
+        let model = try await AgentContextExportResolver.resolveModel(
             source: source,
             store: store,
             filePathDisplay: .relative,
@@ -1280,7 +2448,7 @@ final class AgentContextExportResolverTests: WorkspaceFileContextStoreCodemapSea
             activeAgentSessionID: nil,
             worktreeBindings: []
         )
-        let model = await AgentContextExportResolver.resolveModel(
+        let model = try await AgentContextExportResolver.resolveModel(
             source: source,
             store: store,
             filePathDisplay: .relative,
@@ -1306,6 +2474,23 @@ final class AgentContextExportResolverTests: WorkspaceFileContextStoreCodemapSea
         XCTAssertFalse(previewResult?.contains("Preview truncated") ?? true)
     }
 
+    @MainActor
+    private func makePrompt(store: WorkspaceFileContextStore, windowID: Int) -> PromptViewModel {
+        let secureService = SecureKeysService(secureStorage: TestSecureStorageBackend())
+        let keyManager = KeyManager(secureService: secureService)
+        let apiSettings = APISettingsViewModel(
+            aiQueriesService: AIQueriesService(keyManager: keyManager),
+            keyManager: keyManager,
+            loadStoredDataOnInit: false
+        )
+        return PromptViewModel(
+            fileManager: WorkspaceFilesViewModel(workspaceFileContextStore: store),
+            apiSettingsViewModel: apiSettings,
+            windowID: windowID,
+            settingsManager: WindowSettingsManager(windowID: windowID)
+        )
+    }
+
     func testEmptyDirectFilePreviewReturnsEmptyContent() async throws {
         let root = try makeTemporaryRoot(name: "AgentExportPreviewEmpty")
         try write("", to: root.appendingPathComponent("Sources/Empty.swift"))
@@ -1321,7 +2506,7 @@ final class AgentContextExportResolverTests: WorkspaceFileContextStoreCodemapSea
             activeAgentSessionID: nil,
             worktreeBindings: []
         )
-        let model = await AgentContextExportResolver.resolveModel(
+        let model = try await AgentContextExportResolver.resolveModel(
             source: source,
             store: store,
             filePathDisplay: .relative,
@@ -1457,6 +2642,18 @@ final class AgentContextExportResolverTests: WorkspaceFileContextStoreCodemapSea
         return WorkspaceFileContextStore(codemapRuntimeProvider: { runtime })
     }
 
+    private func makeFolderViewModel(for root: URL) -> FolderViewModel {
+        FolderViewModel(
+            folder: Folder(
+                name: root.lastPathComponent,
+                path: root.path,
+                modificationDate: Date(timeIntervalSince1970: 1000)
+            ),
+            rootPath: root.path,
+            isExpanded: true
+        )
+    }
+
     private func makeTemporaryRoot(name: String) throws -> URL {
         try makeTestDirectory(name: name)
     }
@@ -1484,6 +2681,23 @@ private final class AgentExportLockedCounter: @unchecked Sendable {
     func increment() {
         lock.lock()
         count += 1
+        lock.unlock()
+    }
+}
+
+private final class AgentExportLockedModelRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var models: [AgentContextExportModel] = []
+
+    var values: [AgentContextExportModel] {
+        lock.lock()
+        defer { lock.unlock() }
+        return models
+    }
+
+    func append(_ model: AgentContextExportModel) {
+        lock.lock()
+        models.append(model)
         lock.unlock()
     }
 }

--- a/Tests/RepoPromptTests/AgentMode/AgentContextInspectorColumnSizingTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentContextInspectorColumnSizingTests.swift
@@ -1,0 +1,32 @@
+import CoreGraphics
+@testable import RepoPromptApp
+import XCTest
+
+final class AgentContextInspectorColumnSizingTests: XCTestCase {
+    func testMetricsRespectDetailWidthRatioCapsAndOrdering() {
+        let narrow = AgentContextInspectorColumnSizing.metrics(forDetailWidth: 600)
+        XCTAssertEqual(narrow.minimumWidth, 320)
+        XCTAssertEqual(narrow.idealWidth, 320)
+        XCTAssertEqual(narrow.maximumWidth, 320)
+
+        let chatPreserving = AgentContextInspectorColumnSizing.metrics(forDetailWidth: 900)
+        XCTAssertEqual(chatPreserving.minimumWidth, 320)
+        XCTAssertEqual(chatPreserving.idealWidth, 540)
+        XCTAssertEqual(chatPreserving.maximumWidth, 540)
+
+        let twoThirds = AgentContextInspectorColumnSizing.metrics(forDetailWidth: 1080)
+        XCTAssertEqual(twoThirds.minimumWidth, 320)
+        XCTAssertEqual(twoThirds.idealWidth, 720)
+        XCTAssertEqual(twoThirds.maximumWidth, 720)
+
+        let absoluteCapped = AgentContextInspectorColumnSizing.metrics(forDetailWidth: 1500)
+        XCTAssertEqual(absoluteCapped.minimumWidth, 320)
+        XCTAssertEqual(absoluteCapped.idealWidth, 800)
+        XCTAssertEqual(absoluteCapped.maximumWidth, 800)
+
+        for metrics in [narrow, chatPreserving, twoThirds, absoluteCapped] {
+            XCTAssertLessThanOrEqual(metrics.minimumWidth, metrics.idealWidth)
+            XCTAssertLessThanOrEqual(metrics.idealWidth, metrics.maximumWidth)
+        }
+    }
+}

--- a/Tests/RepoPromptTests/AgentMode/AgentContextSelectedFileCardTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentContextSelectedFileCardTests.swift
@@ -1,0 +1,71 @@
+@testable import RepoPromptApp
+import XCTest
+
+final class AgentContextSelectedFileCardTests: XCTestCase {
+    func testMetricRowPresentationSwitchesOnReadiness() {
+        let unknownFull = AgentContextSelectedFileCardMetricRowPresentation.make(
+            rowKind: .full,
+            metrics: .unknown,
+            parentPathDisplay: "Sources/Feature",
+            displayPath: "Sources/Feature/App.swift",
+            sliceCountText: nil
+        )
+        XCTAssertEqual(unknownFull.content, .pathOnly("Sources/Feature"))
+        XCTAssertEqual(unknownFull.accessibilityLabel, "Path: Sources/Feature/App.swift")
+        XCTAssertFalse(unknownFull.accessibilityLabel?.contains("tokens") ?? true)
+        XCTAssertFalse(unknownFull.accessibilityLabel?.contains("selected context") ?? true)
+
+        let unknownSlicedWithoutParent = AgentContextSelectedFileCardMetricRowPresentation.make(
+            rowKind: .slices,
+            metrics: .unknown,
+            parentPathDisplay: nil,
+            displayPath: "SliceOnly.swift",
+            sliceCountText: "2"
+        )
+        XCTAssertEqual(unknownSlicedWithoutParent.content, .pathOnly("SliceOnly.swift"))
+        XCTAssertEqual(
+            unknownSlicedWithoutParent.accessibilityLabel,
+            "Path: SliceOnly.swift, Selected slice ranges: 2"
+        )
+
+        let unknownCodemap = AgentContextSelectedFileCardMetricRowPresentation.make(
+            rowKind: .codemap,
+            metrics: .unknown,
+            parentPathDisplay: "Sources/Generated",
+            displayPath: "Sources/Generated/Map.swift",
+            sliceCountText: nil
+        )
+        XCTAssertEqual(unknownCodemap.content, .hidden)
+        XCTAssertNil(unknownCodemap.accessibilityLabel)
+
+        let knownMetrics = AgentContextExportRow.Metrics.Known(
+            tokenCount: 1234,
+            tokenPercentage: 0.420,
+            lineCount: 17
+        )
+        let knownSliced = AgentContextSelectedFileCardMetricRowPresentation.make(
+            rowKind: .slices,
+            metrics: .known(knownMetrics),
+            parentPathDisplay: "Sources/Feature",
+            displayPath: "Sources/Feature/App.swift",
+            sliceCountText: "3"
+        )
+        XCTAssertEqual(knownSliced.content, .known(knownMetrics))
+        XCTAssertTrue(
+            knownSliced.accessibilityLabel?.contains("Approximate tokens: 1.2") ?? false
+        )
+        XCTAssertTrue(
+            knownSliced.accessibilityLabel?.contains("Share of selected context: 42%") ?? false
+        )
+        XCTAssertTrue(
+            knownSliced.accessibilityLabel?.contains("Included lines: 17") ?? false
+        )
+        XCTAssertTrue(
+            knownSliced.accessibilityLabel?.contains("Selected slice ranges: 3") ?? false
+        )
+        XCTAssertEqual(AgentContextSelectedFileCardMetricRowPresentation.percentText(for: knownMetrics), "42%")
+        let tokenTooltip = AgentContextSelectedFileCardMetricRowPresentation.tokenTooltip(for: knownMetrics)
+        XCTAssertTrue(tokenTooltip.hasPrefix("≈"))
+        XCTAssertTrue(tokenTooltip.contains("tokens"))
+    }
+}

--- a/Tests/RepoPromptTests/AgentMode/AgentModeChatSwitchActivationTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeChatSwitchActivationTests.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 import XCTest
 @_spi(TestSupport) @testable import RepoPromptApp
@@ -74,6 +75,194 @@ final class AgentModeChatSwitchActivationTests: XCTestCase {
         }
     }
 
+    func testTokenMetricsCompletionWhileInitialModelLoadsSupersedesObsoleteGeneration() async throws {
+        let fileID = UUID()
+        let tabID = UUID()
+        let source = AgentContextExportSource(
+            tabID: tabID,
+            promptText: "Metrics.swift",
+            selection: StoredSelection(selectedPaths: ["Sources/Metrics.swift"]),
+            selectedMetaPromptIDs: [],
+            tabName: "Metrics",
+            activeAgentSessionID: nil,
+            worktreeBindings: []
+        )
+        let initialRequest = AgentSelectedFilesModelRequest(
+            identity: AgentSelectedFilesModelIdentity(
+                exportContextIdentity: source.exportContextIdentity,
+                filePathDisplay: .relative,
+                codeMapUsage: .none
+            ),
+            source: source,
+            store: WorkspaceFileContextStore(),
+            filePathDisplay: .relative,
+            codeMapUsage: CodeMapUsage.none,
+            entryMetricsSnapshot: nil
+        )
+        let metricsSnapshot = PromptContextEntryMetricsSnapshot(
+            totalSelectedDisplayTokens: 73,
+            metrics: [
+                PromptContextEntryMetric(
+                    fileID: fileID,
+                    standardizedFullPath: "/tmp/RepoPromptTests/Sources/Metrics.swift",
+                    renderedDisplayPath: "Sources/Metrics.swift",
+                    renderMode: .full,
+                    displayTokenCount: 73,
+                    displayPercentage: 1,
+                    includedLineCount: 8
+                )
+            ]
+        )
+        func publishedSnapshot(refreshPending: Bool) -> TokenCountingViewModel.PublishedTokenSnapshot {
+            TokenCountingViewModel.PublishedTokenSnapshot(
+                breakdown: TokenCountingViewModel.TokenBreakdown(
+                    total: 73,
+                    files: 73,
+                    prompt: 0,
+                    meta: 0,
+                    fileTree: 0,
+                    git: 0,
+                    other: 0
+                ),
+                filesContentTokens: 73,
+                codeMapTokens: 0,
+                entryMetricsSnapshot: metricsSnapshot,
+                codeMapUsage: CodeMapUsage.none,
+                filePathDisplay: .relative,
+                isComplete: true,
+                isStale: false,
+                refreshPending: refreshPending
+            )
+        }
+
+        XCTAssertNil(
+            AgentSelectedFilesRequestMetricsSnapshotResolver.activeTokenMetricsSnapshot(
+                source: source,
+                activeComposeTabID: tabID,
+                codeMapUsage: .none,
+                filePathDisplay: .relative,
+                published: publishedSnapshot(refreshPending: true)
+            )
+        )
+        let completedMetrics = try XCTUnwrap(
+            AgentSelectedFilesRequestMetricsSnapshotResolver.activeTokenMetricsSnapshot(
+                source: source,
+                activeComposeTabID: tabID,
+                codeMapUsage: .none,
+                filePathDisplay: .relative,
+                published: publishedSnapshot(refreshPending: false)
+            )
+        )
+        let completionRequest = AgentSelectedFilesModelRequest(
+            identity: initialRequest.identity,
+            source: source,
+            store: initialRequest.store,
+            filePathDisplay: .relative,
+            codeMapUsage: .none,
+            entryMetricsSnapshot: completedMetrics
+        )
+        let resolver = ActivationTokenMetricsModelResolver(fileID: fileID)
+        let coordinator = AgentSelectedFilesModelCoordinator { request in
+            await resolver.resolve(request)
+        }
+
+        XCTAssertNil(
+            refreshSelectedFilesModelAfterTokenMetricsCompletion(
+                request: completionRequest,
+                coordinator: coordinator
+            )
+        )
+        XCTAssertEqual(coordinator.refreshIfNeeded(initialRequest), .started)
+        let didStartInitialLoad = await resolver.waitUntilStartCount(1)
+        XCTAssertTrue(didStartInitialLoad)
+        XCTAssertEqual(initialRequest.identity, completionRequest.identity)
+
+        XCTAssertNil(
+            refreshSelectedFilesModelAfterTokenMetricsCompletion(
+                request: initialRequest,
+                coordinator: coordinator
+            )
+        )
+        let startCountAfterPendingCompletion = await resolver.startCount()
+        XCTAssertEqual(startCountAfterPendingCompletion, 1)
+
+        XCTAssertEqual(
+            refreshSelectedFilesModelAfterTokenMetricsCompletion(
+                request: completionRequest,
+                coordinator: coordinator
+            ),
+            .started
+        )
+        let didStartCompletionRefresh = await resolver.waitUntilStartCount(2)
+        XCTAssertTrue(didStartCompletionRefresh)
+        XCTAssertEqual(coordinator.debugStats.cancellations, 1)
+        XCTAssertNil(coordinator.model)
+        XCTAssertTrue(coordinator.isLoading)
+
+        await resolver.releaseNext()
+        let didReturnObsoleteModel = await resolver.waitUntilCompletionCount(1)
+        XCTAssertTrue(didReturnObsoleteModel)
+        XCTAssertNil(coordinator.model)
+        XCTAssertTrue(coordinator.isLoading)
+        XCTAssertEqual(coordinator.debugStats.resolverCompletions, 0)
+
+        await resolver.releaseNext()
+        let enrichedMetrics = AgentContextExportRow.Metrics.known(
+            tokenCount: 73,
+            tokenPercentage: 1,
+            lineCount: 8
+        )
+        let didDisplayEnrichedMetrics = await waitUntilTokenMetricsModel(
+            coordinator,
+            expectedMetrics: enrichedMetrics
+        )
+        let startCount = await resolver.startCount()
+        XCTAssertTrue(didDisplayEnrichedMetrics)
+        XCTAssertEqual(startCount, 2)
+        XCTAssertEqual(coordinator.debugStats.refreshRequests, 2)
+        XCTAssertEqual(coordinator.debugStats.resolverCompletions, 1)
+    }
+
+    func testChatSwitchBlankingHidesInterimSelectionTotalAndResolvedEmptyRendersZero() {
+        XCTAssertNil(
+            presentedSelectedContextCount(
+                authoritativeRowCount: 7,
+                isSwitchBlankingRows: true
+            )
+        )
+        XCTAssertNil(
+            presentedSelectedContextCount(
+                authoritativeRowCount: nil,
+                isSwitchBlankingRows: false
+            )
+        )
+        XCTAssertEqual(
+            presentedSelectedContextCount(
+                authoritativeRowCount: 0,
+                isSwitchBlankingRows: false
+            ),
+            0
+        )
+    }
+
+    func testToggleComposeShortcutOutsideAgentModeDoesNotArmPresentation() async throws {
+        try await withFixture { fixture in
+            let drawerStore = fixture.viewModel.ui.contextDrawer
+            XCTAssertFalse(drawerStore.isPresented)
+
+            fixture.viewModel.setAgentModeActive(false)
+            GlobalKeyboardShortcutsCoordinator.shared.test_toggleComposeInspector(in: fixture.window)
+            XCTAssertFalse(drawerStore.isPresented)
+
+            fixture.viewModel.setAgentModeActive(true)
+            GlobalKeyboardShortcutsCoordinator.shared.test_toggleComposeInspector(in: fixture.window)
+            XCTAssertTrue(drawerStore.isPresented)
+
+            GlobalKeyboardShortcutsCoordinator.shared.test_toggleComposeInspector(in: fixture.window)
+            XCTAssertFalse(drawerStore.isPresented)
+        }
+    }
+
     func testWarmSwitchPublishesDestinationTranscriptBeforeSwitchReturns() async throws {
         try await withFixture { fixture in
             assertPresentation(
@@ -95,6 +284,22 @@ final class AgentModeChatSwitchActivationTests: XCTestCase {
                 expectedTexts: fixture.tabBTexts
             )
             XCTAssertNil(fixture.viewModel.activeSessionLoadInProgressTabID)
+        }
+    }
+
+    func testWarmSwitchPublishesDestinationTabOnlyWhileSwitchingFlagIsRaised() async throws {
+        try await withFixture { fixture in
+            var observations: [(tabID: UUID?, isSwitching: Bool)] = []
+            let cancellable = fixture.window.promptManager.$activeComposeTabID.sink { tabID in
+                observations.append((tabID, fixture.window.promptManager.isSwitchingComposeTab))
+            }
+            defer { cancellable.cancel() }
+
+            await fixture.window.promptManager.switchComposeTab(fixture.tabBID)
+
+            let destinationObservation = try XCTUnwrap(observations.first { $0.tabID == fixture.tabBID })
+            XCTAssertTrue(destinationObservation.isSwitching)
+            XCTAssertFalse(fixture.window.promptManager.isSwitchingComposeTab)
         }
     }
 
@@ -145,6 +350,20 @@ final class AgentModeChatSwitchActivationTests: XCTestCase {
                 XCTAssertNil(fixtureA.viewModel.activeSessionLoadInProgressTabID)
             }
         }
+    }
+
+    private func waitUntilTokenMetricsModel(
+        _ coordinator: AgentSelectedFilesModelCoordinator,
+        expectedMetrics: AgentContextExportRow.Metrics
+    ) async -> Bool {
+        for _ in 0 ..< 500 {
+            if coordinator.rowSplit.fileRows.first?.metrics == expectedMetrics, !coordinator.isLoading {
+                return true
+            }
+            await Task.yield()
+            try? await Task.sleep(nanoseconds: 1_000_000)
+        }
+        return coordinator.rowSplit.fileRows.first?.metrics == expectedMetrics && !coordinator.isLoading
     }
 
     private func withFixture(_ body: (Fixture) async throws -> Void) async throws {
@@ -297,5 +516,78 @@ final class AgentModeChatSwitchActivationTests: XCTestCase {
         let sessionB: AgentModeViewModel.TabSession
         let tabATexts: [String]
         let tabBTexts: [String]
+    }
+}
+
+private actor ActivationTokenMetricsModelResolver {
+    private let fileID: UUID
+    private let rootID = UUID()
+    private var starts = 0
+    private var completions = 0
+    private var continuations: [CheckedContinuation<Void, Never>] = []
+
+    init(fileID: UUID) {
+        self.fileID = fileID
+    }
+
+    func resolve(_ request: AgentSelectedFilesModelRequest) async -> AgentContextExportModel {
+        starts += 1
+        await withCheckedContinuation { continuation in
+            continuations.append(continuation)
+        }
+        completions += 1
+        let metric = request.entryMetricsSnapshot?.metric(forFileID: fileID)
+        let row = AgentContextExportRow(
+            id: ResolvedPromptFileEntryID(fileID: fileID, mode: .fullFile, lineRanges: nil),
+            kind: .full,
+            rootID: rootID,
+            relativePath: "Sources/Metrics.swift",
+            displayPath: "Sources/Metrics.swift",
+            displayName: "Metrics.swift",
+            directoryDisplay: "Sources",
+            lineRanges: nil,
+            metrics: metric.map {
+                AgentContextExportRow.Metrics.known(
+                    tokenCount: $0.displayTokenCount,
+                    tokenPercentage: $0.displayPercentage,
+                    lineCount: $0.includedLineCount
+                )
+            } ?? .unknown,
+            canRemove: true
+        )
+        return AgentContextExportModel(
+            source: request.source,
+            lookupContext: WorkspaceLookupContext(rootScope: .allLoaded, bindingProjection: nil),
+            rows: [row],
+            totalSelectedDisplayTokens: request.entryMetricsSnapshot?.totalSelectedDisplayTokens ?? 0,
+            missingPaths: [],
+            invalidPaths: [],
+            codemapPresentation: .empty
+        )
+    }
+
+    func waitUntilStartCount(_ count: Int) async -> Bool {
+        for _ in 0 ..< 500 {
+            if starts >= count { return true }
+            try? await Task.sleep(nanoseconds: 1_000_000)
+        }
+        return starts >= count
+    }
+
+    func waitUntilCompletionCount(_ count: Int) async -> Bool {
+        for _ in 0 ..< 500 {
+            if completions >= count { return true }
+            try? await Task.sleep(nanoseconds: 1_000_000)
+        }
+        return completions >= count
+    }
+
+    func releaseNext() {
+        guard !continuations.isEmpty else { return }
+        continuations.removeFirst().resume()
+    }
+
+    func startCount() -> Int {
+        starts
     }
 }

--- a/Tests/RepoPromptTests/AgentMode/AgentOraclePillRoutingTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentOraclePillRoutingTests.swift
@@ -25,9 +25,11 @@ final class AgentOraclePillRoutingTests: XCTestCase {
                 chatID: session.id.uuidString.lowercased(),
                 workspaceID: workspaceID,
                 tabID: tabID,
-                generation: 4
+                generation: 4,
+                presentation: .generatedAnswerReadOnly
             )
         )
+        XCTAssertEqual(request.presentation, .generatedAnswerReadOnly)
         XCTAssertTrue(
             AgentOraclePillLogic.shouldPresent(
                 session: session,
@@ -80,6 +82,17 @@ final class AgentOraclePillRoutingTests: XCTestCase {
                 currentWorkspaceID: UUID(),
                 currentTabID: tabID
             )
+        )
+    }
+
+    func testTranscriptActionPolicyMatchesPopoverPresentation() {
+        XCTAssertEqual(
+            AgentOraclePillLogic.transcriptActionPolicy(for: .standard),
+            .standard
+        )
+        XCTAssertEqual(
+            AgentOraclePillLogic.transcriptActionPolicy(for: .generatedAnswerReadOnly),
+            .nonMutating
         )
     }
 

--- a/Tests/RepoPromptTests/AgentMode/AgentSelectedFilesModelCoordinatorTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentSelectedFilesModelCoordinatorTests.swift
@@ -28,6 +28,60 @@ final class AgentSelectedFilesModelCoordinatorTests: XCTestCase {
     }
 
     @MainActor
+    func testTokenMetricsCompletionRefreshPreservesLoadedSameIdentityModel() async {
+        let fileID = UUID()
+        let resolver = GatedTokenMetricsModelResolver(fileID: fileID)
+        let coordinator = AgentSelectedFilesModelCoordinator { request in
+            await resolver.resolve(request)
+        }
+        let initialRequest = makeRequest(name: "Metrics.swift")
+        let enrichedRequest = AgentSelectedFilesModelRequest(
+            identity: initialRequest.identity,
+            source: initialRequest.source,
+            store: initialRequest.store,
+            filePathDisplay: initialRequest.filePathDisplay,
+            codeMapUsage: initialRequest.codeMapUsage,
+            entryMetricsSnapshot: makeMetricsSnapshot(fileID: fileID, name: "Metrics.swift")
+        )
+
+        XCTAssertEqual(coordinator.refreshIfNeeded(initialRequest), .started)
+        let didStartInitialLoad = await resolver.waitUntilStartCount(1)
+        XCTAssertTrue(didStartInitialLoad)
+        await resolver.releaseNext()
+        let didLoadInitialModel = await waitUntilModel(promptText: "Metrics.swift", in: coordinator)
+        XCTAssertTrue(didLoadInitialModel)
+        XCTAssertEqual(coordinator.rowSplit.fileRows.first?.metrics, .unknown)
+
+        XCTAssertEqual(coordinator.refreshIfNeeded(enrichedRequest), .skippedLoaded)
+        XCTAssertEqual(coordinator.rowSplit.fileRows.first?.metrics, .unknown)
+
+        XCTAssertEqual(coordinator.refreshAfterTokenMetricsCompletion(enrichedRequest), .started)
+        let didStartEnrichedRefresh = await resolver.waitUntilStartCount(2)
+        XCTAssertTrue(didStartEnrichedRefresh)
+        XCTAssertEqual(coordinator.rowSplit.fileRows.first?.metrics, .unknown)
+        XCTAssertEqual(coordinator.model?.totalSelectedDisplayTokens, 0)
+        XCTAssertTrue(coordinator.isLoading)
+        XCTAssertFalse(coordinator.canMutateDisplayedModel)
+
+        await resolver.releaseNext()
+        let expectedMetrics = AgentContextExportRow.Metrics.known(
+            tokenCount: 91,
+            tokenPercentage: 1,
+            lineCount: 11
+        )
+        let didDisplayEnrichedMetrics = await waitUntilDisplayedFileMetrics(
+            expectedMetrics,
+            promptText: "Metrics.swift",
+            in: coordinator
+        )
+        XCTAssertTrue(didDisplayEnrichedMetrics)
+        XCTAssertFalse(coordinator.isLoading)
+        XCTAssertEqual(coordinator.model?.totalSelectedDisplayTokens, 91)
+        XCTAssertEqual(coordinator.debugStats.resolverStarts, 2)
+        XCTAssertEqual(coordinator.debugStats.resolverCompletions, 2)
+    }
+
+    @MainActor
     func testDuplicateRequestWhileLoadingCoalescesIntoOneResolve() async {
         let resolver = GatedModelResolver()
         let coordinator = AgentSelectedFilesModelCoordinator { request in
@@ -53,40 +107,819 @@ final class AgentSelectedFilesModelCoordinatorTests: XCTestCase {
 
     @MainActor
     func testAutoCodemapRequestPublishesFileRowsBeforeFullModelCompletes() async {
-        let resolver = ProgressiveCodemapModelResolver()
-        let coordinator = AgentSelectedFilesModelCoordinator { request in
-            await resolver.resolve(request)
+        func assertProgressiveCodemapRequest(
+            name: String,
+            codeMapUsage: CodeMapUsage,
+            codemapAutoEnabled: Bool = false,
+            entryMetricsSnapshot: PromptContextEntryMetricsSnapshot? = nil
+        ) async {
+            let resolver = ProgressiveCodemapModelResolver()
+            let coordinator = AgentSelectedFilesModelCoordinator { request, interimFileRowsHandler in
+                await resolver.resolve(request, interimFileRowsHandler: interimFileRowsHandler)
+            }
+            let request = makeRequest(
+                name: name,
+                codeMapUsage: codeMapUsage,
+                codemapAutoEnabled: codemapAutoEnabled,
+                entryMetricsSnapshot: entryMetricsSnapshot
+            )
+
+            XCTAssertEqual(coordinator.refreshIfNeeded(request), .started)
+            let didDisplayFileRows = await waitUntilDisplayedModel(promptText: name, in: coordinator)
+            let didStartFullCodemapModel = await resolver.waitUntilStartCount(codeMapUsage, count: 1)
+
+            XCTAssertTrue(didDisplayFileRows)
+            XCTAssertTrue(didStartFullCodemapModel)
+            XCTAssertTrue(coordinator.isLoading)
+            XCTAssertFalse(coordinator.canMutateDisplayedModel)
+            XCTAssertEqual(coordinator.rowSplit.fileRows.count, 1)
+            XCTAssertEqual(coordinator.rowSplit.codemapRows.count, 0)
+            XCTAssertEqual(coordinator.model?.totalSelectedDisplayTokens, 0)
+            XCTAssertEqual(coordinator.model?.rows.first?.metrics, .unknown)
+            let startedUsages = await resolver.startedUsages()
+            XCTAssertEqual(startedUsages, [codeMapUsage])
+            let startedMetricsSnapshots = await resolver.startedMetricsSnapshots()
+            XCTAssertEqual(startedMetricsSnapshots.count, 1)
+            XCTAssertEqual(startedMetricsSnapshots[0], entryMetricsSnapshot)
+            let interimPublicationCount = await resolver.interimPublicationCount()
+            XCTAssertEqual(interimPublicationCount, 1)
+
+            await resolver.releaseNext(codeMapUsage)
+            let didLoadFullModel = await waitUntilModel(promptText: name, in: coordinator)
+
+            XCTAssertTrue(didLoadFullModel)
+            XCTAssertFalse(coordinator.isLoading)
+            XCTAssertTrue(coordinator.canMutateDisplayedModel)
+            XCTAssertEqual(coordinator.debugStats.resolverStarts, 1)
+            XCTAssertEqual(coordinator.debugStats.resolverCompletions, 1)
         }
-        let request = makeRequest(name: "A.swift", codeMapUsage: .auto, codemapAutoEnabled: true)
 
-        XCTAssertEqual(coordinator.refreshIfNeeded(request), .started)
-        let didDisplayFileRows = await waitUntilDisplayedModel(promptText: "A.swift", in: coordinator)
-        let didStartFullCodemapModel = await resolver.waitUntilStartCount(.auto, count: 1)
+        let providedMetricsSnapshot = PromptContextEntryMetricsSnapshot(
+            totalSelectedDisplayTokens: 123,
+            metrics: [
+                PromptContextEntryMetric(
+                    fileID: UUID(),
+                    standardizedFullPath: "/tmp/RepoPromptTests/Sources/Provided.swift",
+                    renderedDisplayPath: "Sources/Provided.swift",
+                    renderMode: .full,
+                    displayTokenCount: 123,
+                    displayPercentage: 1,
+                    includedLineCount: 9
+                )
+            ]
+        )
+        let activeTabID = UUID()
+        let selectedSource = AgentContextExportSource(
+            tabID: activeTabID,
+            promptText: "Provided.swift",
+            selection: StoredSelection(selectedPaths: ["Sources/Provided.swift"], codemapAutoEnabled: true),
+            selectedMetaPromptIDs: [],
+            tabName: "Test",
+            activeAgentSessionID: nil,
+            worktreeBindings: []
+        )
 
-        XCTAssertTrue(didDisplayFileRows)
-        XCTAssertTrue(didStartFullCodemapModel)
-        XCTAssertTrue(coordinator.isLoading)
-        XCTAssertFalse(coordinator.canMutateDisplayedModel)
-        XCTAssertEqual(coordinator.rowSplit.fileRows.count, 1)
-        XCTAssertEqual(coordinator.rowSplit.codemapRows.count, 0)
-        let startedUsages = await resolver.startedUsages()
-        XCTAssertEqual(startedUsages, [.none, .auto])
+        func publishedSnapshot(
+            isStale: Bool = false,
+            refreshPending: Bool = false,
+            codeMapUsage: CodeMapUsage? = .auto
+        ) -> TokenCountingViewModel.PublishedTokenSnapshot {
+            TokenCountingViewModel.PublishedTokenSnapshot(
+                breakdown: TokenCountingViewModel.TokenBreakdown(
+                    total: 123,
+                    files: 123,
+                    prompt: 0,
+                    meta: 0,
+                    fileTree: 0,
+                    git: 0,
+                    other: 0
+                ),
+                filesContentTokens: 123,
+                codeMapTokens: 0,
+                entryMetricsSnapshot: providedMetricsSnapshot,
+                codeMapUsage: codeMapUsage,
+                filePathDisplay: .relative,
+                isComplete: true,
+                isStale: isStale,
+                refreshPending: refreshPending || isStale
+            )
+        }
 
-        await resolver.releaseNext(.auto)
-        let didLoadFullModel = await waitUntilModel(promptText: "A.swift", in: coordinator)
+        XCTAssertEqual(
+            AgentSelectedFilesRequestMetricsSnapshotResolver.activeTokenMetricsSnapshot(
+                source: selectedSource,
+                activeComposeTabID: activeTabID,
+                codeMapUsage: .auto,
+                filePathDisplay: .relative,
+                published: publishedSnapshot()
+            ),
+            providedMetricsSnapshot
+        )
+        XCTAssertNil(
+            AgentSelectedFilesRequestMetricsSnapshotResolver.activeTokenMetricsSnapshot(
+                source: selectedSource,
+                activeComposeTabID: activeTabID,
+                codeMapUsage: .auto,
+                filePathDisplay: .relative,
+                published: publishedSnapshot(isStale: true)
+            )
+        )
+        XCTAssertNil(
+            AgentSelectedFilesRequestMetricsSnapshotResolver.activeTokenMetricsSnapshot(
+                source: selectedSource,
+                activeComposeTabID: activeTabID,
+                codeMapUsage: .auto,
+                filePathDisplay: .relative,
+                published: publishedSnapshot(refreshPending: true)
+            )
+        )
+        XCTAssertNil(
+            AgentSelectedFilesRequestMetricsSnapshotResolver.activeTokenMetricsSnapshot(
+                source: selectedSource,
+                activeComposeTabID: activeTabID,
+                codeMapUsage: .complete,
+                filePathDisplay: .relative,
+                published: publishedSnapshot()
+            )
+        )
+        XCTAssertNil(
+            AgentSelectedFilesRequestMetricsSnapshotResolver.activeTokenMetricsSnapshot(
+                source: AgentContextExportSource(
+                    tabID: activeTabID,
+                    promptText: "Provided.swift",
+                    selection: selectedSource.selection,
+                    selectedMetaPromptIDs: [],
+                    tabName: "Test",
+                    activeAgentSessionID: UUID(),
+                    worktreeBindings: []
+                ),
+                activeComposeTabID: activeTabID,
+                codeMapUsage: .auto,
+                filePathDisplay: .relative,
+                published: publishedSnapshot()
+            )
+        )
 
-        XCTAssertTrue(didLoadFullModel)
-        XCTAssertFalse(coordinator.isLoading)
-        XCTAssertTrue(coordinator.canMutateDisplayedModel)
-        XCTAssertEqual(coordinator.debugStats.resolverStarts, 1)
-        XCTAssertEqual(coordinator.debugStats.resolverCompletions, 1)
+        await assertProgressiveCodemapRequest(name: "Auto.swift", codeMapUsage: .auto, codemapAutoEnabled: true)
+        await assertProgressiveCodemapRequest(name: "Complete.swift", codeMapUsage: .complete)
+        await assertProgressiveCodemapRequest(
+            name: "Provided.swift",
+            codeMapUsage: .auto,
+            codemapAutoEnabled: true,
+            entryMetricsSnapshot: providedMetricsSnapshot
+        )
+    }
+
+    func testSelectionDisplayTextNamesManualCodemaps() {
+        let summary = AgentContextExportResolver.selectionSummary(
+            for: StoredSelection(manualCodemapPaths: ["Sources/Codemap.swift"], codemapAutoEnabled: false)
+        )
+
+        let text = AgentContextFileCodemapCountSummary.selectionDisplayText(from: summary)
+
+        XCTAssertEqual(summary.totalExplicitFileCount, 1)
+        XCTAssertEqual(summary.codemapFileCount, 1)
+        XCTAssertEqual(text.compact, "1 codemap")
+        XCTAssertEqual(text.detailed, "1 codemap")
     }
 
     @MainActor
-    func testIdentityChangeCancelsOldLoadAndAcceptsNewestResultOnly() async {
+    func testUnresolvedFileCodemapCountReadinessUsesResolutionStability() {
+        func unresolvedReadiness(
+            codeMapUsage: CodeMapUsage,
+            codemapAutoEnabled: Bool = false
+        ) -> AgentContextFileCodemapCountReadiness {
+            let request = makeRequest(
+                name: "\(codeMapUsage.rawValue).swift",
+                codeMapUsage: codeMapUsage,
+                codemapAutoEnabled: codemapAutoEnabled
+            )
+            let summary = AgentContextFileCodemapCountSummary.intent(
+                from: AgentContextExportResolver.selectionSummary(for: request.source.selection)
+            )
+            return AgentSelectedFilesModelCoordinator.unresolvedFileCodemapCountReadiness(
+                for: request.identity,
+                summary: summary
+            )
+        }
+
+        XCTAssertEqual(
+            unresolvedReadiness(codeMapUsage: .selected),
+            AgentContextFileCodemapCountReadiness(file: .unknown, codemap: .unknown)
+        )
+        XCTAssertEqual(
+            unresolvedReadiness(codeMapUsage: .complete),
+            AgentContextFileCodemapCountReadiness(file: .known(1), codemap: .unknown)
+        )
+        XCTAssertEqual(
+            unresolvedReadiness(codeMapUsage: .auto, codemapAutoEnabled: true),
+            AgentContextFileCodemapCountReadiness(file: .known(1), codemap: .unknown)
+        )
+        XCTAssertEqual(
+            unresolvedReadiness(codeMapUsage: .none),
+            AgentContextFileCodemapCountReadiness(file: .known(1), codemap: .known(0))
+        )
+
+        let manualCodemapSelection = StoredSelection(
+            manualCodemapPaths: ["Sources/Codemap.swift"],
+            codemapAutoEnabled: false
+        )
+        let manualCodemapSource = AgentContextExportSource(
+            tabID: UUID(),
+            promptText: "ManualCodemap.swift",
+            selection: manualCodemapSelection,
+            selectedMetaPromptIDs: [],
+            tabName: "Test",
+            activeAgentSessionID: nil,
+            worktreeBindings: []
+        )
+        let manualCodemapIdentity = AgentSelectedFilesModelIdentity(
+            exportContextIdentity: manualCodemapSource.exportContextIdentity,
+            filePathDisplay: .relative,
+            codeMapUsage: .none
+        )
+        let manualCodemapSummary = AgentContextFileCodemapCountSummary.intent(
+            from: AgentContextExportResolver.selectionSummary(for: manualCodemapSelection)
+        )
+
+        XCTAssertEqual(
+            AgentSelectedFilesModelCoordinator.unresolvedFileCodemapCountReadiness(
+                for: manualCodemapIdentity,
+                summary: manualCodemapSummary
+            ),
+            AgentContextFileCodemapCountReadiness(file: .known(0), codemap: .known(0))
+        )
+    }
+
+    func testRowSplitFileCodemapSummaryUsesMaterializedRows() {
+        let rootID = UUID()
+        let fullFileRow = AgentContextExportRow(
+            id: ResolvedPromptFileEntryID(fileID: UUID(), mode: .fullFile, lineRanges: nil),
+            kind: .full,
+            rootID: rootID,
+            relativePath: "Sources/Full.swift",
+            displayPath: "Sources/Full.swift",
+            displayName: "Full.swift",
+            directoryDisplay: "Sources",
+            lineRanges: nil,
+            canRemove: true
+        )
+        let slicedFileRow = AgentContextExportRow(
+            id: ResolvedPromptFileEntryID(
+                fileID: UUID(),
+                mode: .sliced,
+                lineRanges: [LineRange(start: 1, end: 2), LineRange(start: 5, end: 6)]
+            ),
+            kind: .slices,
+            rootID: rootID,
+            relativePath: "Sources/Sliced.swift",
+            displayPath: "Sources/Sliced.swift",
+            displayName: "Sliced.swift",
+            directoryDisplay: "Sources",
+            lineRanges: [LineRange(start: 1, end: 2), LineRange(start: 5, end: 6)],
+            canRemove: true
+        )
+        let codemapRow = AgentContextExportRow(
+            id: ResolvedPromptFileEntryID(fileID: UUID(), mode: .codemap, lineRanges: nil),
+            kind: .codemap,
+            rootID: rootID,
+            relativePath: "Sources/Codemap.swift",
+            displayPath: "Sources/Codemap.swift",
+            displayName: "Codemap.swift",
+            directoryDisplay: "Sources",
+            lineRanges: nil,
+            canRemove: true
+        )
+
+        let split = AgentSelectedFilesRowSplit(rows: [fullFileRow, slicedFileRow, codemapRow])
+
+        XCTAssertEqual(split.fileRows.map(\.kind), [.full, .slices])
+        XCTAssertEqual(split.codemapRows.map(\.kind), [.codemap])
+        XCTAssertEqual(split.fileCodemapCountSummary.fileCount, 2)
+        XCTAssertEqual(split.fileCodemapCountSummary.codemapCount, 1)
+        XCTAssertEqual(split.fileCodemapCountSummary.sliceRangeCount, 2)
+        XCTAssertEqual(split.fileCodemapCountSummary.headlineText, "2 files · 1 codemap · 2 slices")
+    }
+
+    @MainActor
+    func testLoadedFileCodemapSummaryRequiresMatchingIdentity() async {
+        let resolver = ImmediateModelResolver()
+        let coordinator = AgentSelectedFilesModelCoordinator { request in
+            await resolver.resolve(request)
+        }
+        let loadedRequest = makeRequest(name: "Loaded.swift")
+        let currentRequest = makeRequest(name: "Current.swift")
+
+        XCTAssertEqual(coordinator.refreshIfNeeded(loadedRequest), .started)
+        let didLoad = await waitUntilModel(promptText: "Loaded.swift", in: coordinator)
+        XCTAssertTrue(didLoad)
+
+        XCTAssertEqual(coordinator.loadedFileCodemapCountSummary(for: loadedRequest.identity)?.fileCount, 1)
+        XCTAssertNil(coordinator.loadedFileCodemapCountSummary(for: currentRequest.identity))
+    }
+
+    @MainActor
+    func testDisplayedCountReadinessReportsInterimUnknownAndCompletedCounts() async {
+        let resolver = ProgressiveCodemapModelResolver(finalCodemapCount: 2)
+        let coordinator = AgentSelectedFilesModelCoordinator { request, interimFileRowsHandler in
+            await resolver.resolve(request, interimFileRowsHandler: interimFileRowsHandler)
+        }
+        let request = makeRequest(name: "Progressive.swift", codeMapUsage: .auto, codemapAutoEnabled: true)
+        let otherRequest = makeRequest(name: "Other.swift", codeMapUsage: .auto, codemapAutoEnabled: true)
+
+        XCTAssertEqual(coordinator.refreshIfNeeded(request), .started)
+        let didDisplayInterimModel = await waitUntilDisplayedModel(promptText: "Progressive.swift", in: coordinator)
+        XCTAssertTrue(didDisplayInterimModel)
+
+        XCTAssertEqual(
+            coordinator.displayedFileCodemapCountReadiness(for: request.identity),
+            AgentContextFileCodemapCountReadiness(file: .known(1), codemap: .unknown)
+        )
+        XCTAssertNil(coordinator.displayedFileCodemapCountReadiness(for: otherRequest.identity))
+
+        await resolver.releaseNext(.auto)
+        let didLoadCompletedModel = await waitUntilModel(promptText: "Progressive.swift", in: coordinator)
+        XCTAssertTrue(didLoadCompletedModel)
+
+        XCTAssertEqual(
+            coordinator.displayedFileCodemapCountReadiness(for: request.identity),
+            AgentContextFileCodemapCountReadiness(file: .known(1), codemap: .known(2))
+        )
+    }
+
+    @MainActor
+    func testPendingCodemapPromptFilesTransitionPreservesRowsDuringMatchingRefresh() async {
+        let resolver = ProgressiveCodemapModelResolver(finalCodemapCount: 2)
+        let coordinator = AgentSelectedFilesModelCoordinator { request, interimFileRowsHandler in
+            await resolver.resolve(request, interimFileRowsHandler: interimFileRowsHandler)
+        }
+        let request = makeRequest(
+            name: "Transition.swift",
+            codeMapUsage: .auto,
+            codemapAutoEnabled: true
+        )
+        let pendingReadiness = AgentContextFileCodemapCountReadiness(file: .known(1), codemap: .unknown)
+
+        XCTAssertEqual(coordinator.refreshIfNeeded(request), .started)
+        let didDisplayInterimModel = await waitUntilDisplayedModel(
+            promptText: "Transition.swift",
+            in: coordinator
+        )
+        XCTAssertTrue(didDisplayInterimModel)
+        XCTAssertEqual(coordinator.rowSplit.rows.count, 1)
+        XCTAssertEqual(coordinator.displayedFileCodemapCountReadiness(for: request.identity), pendingReadiness)
+        XCTAssertTrue(coordinator.displayedModelMatches(request.identity))
+        XCTAssertFalse(coordinator.completedModelMatches(request.identity))
+        XCTAssertFalse(coordinator.canMutateDisplayedModel)
+
+        // Both Prompt and Files tabs use this cancellation path when transitioning away
+        coordinator.cancelLoading(keepLoadedModel: true)
+        XCTAssertEqual(coordinator.rowSplit.rows.count, 1)
+        XCTAssertEqual(coordinator.displayedFileCodemapCountReadiness(for: request.identity), pendingReadiness)
+        XCTAssertTrue(coordinator.displayedModelMatches(request.identity))
+        XCTAssertFalse(coordinator.completedModelMatches(request.identity))
+        XCTAssertFalse(coordinator.canMutateDisplayedModel)
+
+        XCTAssertEqual(coordinator.refreshIfNeeded(request), .started)
+        XCTAssertEqual(coordinator.rowSplit.rows.count, 1)
+        XCTAssertEqual(coordinator.displayedFileCodemapCountReadiness(for: request.identity), pendingReadiness)
+        XCTAssertTrue(coordinator.displayedModelMatches(request.identity))
+        XCTAssertFalse(coordinator.completedModelMatches(request.identity))
+        XCTAssertFalse(coordinator.canMutateDisplayedModel)
+
+        let didRestartResolution = await resolver.waitUntilStartCount(.auto, count: 2)
+        XCTAssertTrue(didRestartResolution)
+        let bothResolutionsArePending = await resolver.waitUntilPendingContinuationCount(.auto, count: 2)
+        XCTAssertTrue(bothResolutionsArePending)
+        await resolver.releaseNext(.auto)
+        await resolver.releaseNext(.auto)
+        let didLoadCompletedModel = await waitUntilModel(promptText: "Transition.swift", in: coordinator)
+        XCTAssertTrue(didLoadCompletedModel)
+        XCTAssertEqual(coordinator.rowSplit.rows.count, 3)
+        XCTAssertEqual(
+            coordinator.displayedFileCodemapCountReadiness(for: request.identity),
+            AgentContextFileCodemapCountReadiness(file: .known(1), codemap: .known(2))
+        )
+        XCTAssertTrue(coordinator.displayedModelMatches(request.identity))
+        XCTAssertTrue(coordinator.completedModelMatches(request.identity))
+        XCTAssertTrue(coordinator.canMutateDisplayedModel)
+    }
+
+    @MainActor
+    func testKnownVisibleFileMetricsArePreservedWhileCodemapPending() async {
+        let knownMetrics = AgentContextExportRow.Metrics.known(
+            tokenCount: 91,
+            tokenPercentage: 1,
+            lineCount: 11
+        )
+        let fileID = UUID()
+        let resolver = VisibleFileMetricsPreservationResolver(fileID: fileID)
+        let coordinator = AgentSelectedFilesModelCoordinator { request, interimFileRowsHandler in
+            await resolver.resolve(request, interimFileRowsHandler: interimFileRowsHandler)
+        }
+        let knownMetricsRequest = makeRequest(
+            name: "Metric.swift",
+            codeMapUsage: .auto,
+            codemapAutoEnabled: true,
+            entryMetricsSnapshot: makeMetricsSnapshot(fileID: fileID, name: "Metric.swift")
+        )
+        let missingMetricsRequest = makeRequest(
+            name: "Metric.swift",
+            codeMapUsage: .auto,
+            codemapAutoEnabled: true,
+            entryMetricsSnapshot: nil
+        )
+        XCTAssertNotEqual(knownMetricsRequest.identity, missingMetricsRequest.identity)
+
+        XCTAssertEqual(coordinator.refreshIfNeeded(knownMetricsRequest), .started)
+        let didDisplayKnownMetrics = await waitUntilDisplayedFileMetrics(
+            knownMetrics,
+            promptText: "Metric.swift",
+            in: coordinator
+        )
+        XCTAssertTrue(didDisplayKnownMetrics)
+        XCTAssertEqual(
+            coordinator.displayedFileCodemapCountReadiness(for: knownMetricsRequest.identity),
+            AgentContextFileCodemapCountReadiness(file: .known(1), codemap: .unknown)
+        )
+
+        XCTAssertEqual(coordinator.refreshIfNeeded(missingMetricsRequest, force: true), .started)
+        let didPublishSecondInterim = await resolver.waitUntilInterimPublicationCount(2)
+        XCTAssertTrue(didPublishSecondInterim)
+        XCTAssertEqual(coordinator.rowSplit.fileRows.first?.metrics, knownMetrics)
+        XCTAssertEqual(coordinator.rowSplit.fileRows.first?.rootDisplayName, "Metric Root")
+        XCTAssertEqual(coordinator.rowSplit.fileRows.first?.rootColorKey, "metric-root")
+        XCTAssertEqual(coordinator.rowSplit.fileRows.first?.showRootPill, true)
+        XCTAssertEqual(coordinator.model?.totalSelectedDisplayTokens, 91)
+        XCTAssertEqual(
+            coordinator.displayedFileCodemapCountReadiness(for: missingMetricsRequest.identity),
+            AgentContextFileCodemapCountReadiness(file: .known(1), codemap: .unknown)
+        )
+        await resolver.releaseAll(.auto)
+        await drainCancelledTask()
+    }
+
+    @MainActor
+    func testKnownVisibleFileMetricsAreNotPreservedAcrossDifferentRoots() async {
+        let knownMetrics = AgentContextExportRow.Metrics.known(
+            tokenCount: 91,
+            tokenPercentage: 1,
+            lineCount: 11
+        )
+        let fileID = UUID()
+        let resolver = VisibleFileMetricsPreservationResolver(
+            fileID: fileID,
+            rootIDs: [UUID(), UUID()]
+        )
+        let coordinator = AgentSelectedFilesModelCoordinator { request, interimFileRowsHandler in
+            await resolver.resolve(request, interimFileRowsHandler: interimFileRowsHandler)
+        }
+        let knownMetricsRequest = makeRequest(
+            name: "Metric.swift",
+            codeMapUsage: .auto,
+            codemapAutoEnabled: true,
+            entryMetricsSnapshot: makeMetricsSnapshot(fileID: fileID, name: "Metric.swift")
+        )
+        let missingMetricsRequest = makeRequest(
+            name: "Metric.swift",
+            codeMapUsage: .auto,
+            codemapAutoEnabled: true,
+            entryMetricsSnapshot: nil
+        )
+
+        XCTAssertEqual(coordinator.refreshIfNeeded(knownMetricsRequest), .started)
+        let didDisplayKnownMetrics = await waitUntilDisplayedFileMetrics(
+            knownMetrics,
+            promptText: "Metric.swift",
+            in: coordinator
+        )
+        XCTAssertTrue(didDisplayKnownMetrics)
+
+        XCTAssertEqual(coordinator.refreshIfNeeded(missingMetricsRequest, force: true), .started)
+        let didPublishSecondInterim = await resolver.waitUntilInterimPublicationCount(2)
+        XCTAssertTrue(didPublishSecondInterim)
+        XCTAssertEqual(coordinator.rowSplit.fileRows.first?.metrics, .unknown)
+        XCTAssertEqual(coordinator.model?.totalSelectedDisplayTokens, 0)
+
+        await resolver.releaseAll(.auto)
+        await drainCancelledTask()
+    }
+
+    @MainActor
+    func testKnownVisibleFileMetricsAreNotPreservedAcrossDifferentFiles() async {
+        let knownMetrics = AgentContextExportRow.Metrics.known(
+            tokenCount: 91,
+            tokenPercentage: 1,
+            lineCount: 11
+        )
+        let firstFileID = UUID()
+        let resolver = VisibleFileMetricsPreservationResolver(
+            fileID: firstFileID,
+            fileIDs: [firstFileID, UUID()]
+        )
+        let coordinator = AgentSelectedFilesModelCoordinator { request, interimFileRowsHandler in
+            await resolver.resolve(request, interimFileRowsHandler: interimFileRowsHandler)
+        }
+        let knownMetricsRequest = makeRequest(
+            name: "Metric.swift",
+            codeMapUsage: .auto,
+            codemapAutoEnabled: true,
+            entryMetricsSnapshot: makeMetricsSnapshot(fileID: firstFileID, name: "Metric.swift")
+        )
+        let missingMetricsRequest = makeRequest(
+            name: "Metric.swift",
+            codeMapUsage: .auto,
+            codemapAutoEnabled: true,
+            entryMetricsSnapshot: nil
+        )
+
+        XCTAssertEqual(coordinator.refreshIfNeeded(knownMetricsRequest), .started)
+        let didDisplayKnownMetrics = await waitUntilDisplayedFileMetrics(
+            knownMetrics,
+            promptText: "Metric.swift",
+            in: coordinator
+        )
+        XCTAssertTrue(didDisplayKnownMetrics)
+
+        XCTAssertEqual(coordinator.refreshIfNeeded(missingMetricsRequest, force: true), .started)
+        let didPublishSecondInterim = await resolver.waitUntilInterimPublicationCount(2)
+        XCTAssertTrue(didPublishSecondInterim)
+        XCTAssertEqual(coordinator.rowSplit.fileRows.first?.metrics, .unknown)
+        XCTAssertEqual(coordinator.model?.totalSelectedDisplayTokens, 0)
+
+        await resolver.releaseAll(.auto)
+        await drainCancelledTask()
+    }
+
+    @MainActor
+    func testDisplayedCountReadinessUsesCompletedCodemapSnapshotDuringSameIdentityRefresh() async {
+        let resolver = ProgressiveCodemapModelResolver(finalCodemapCount: 2)
+        let coordinator = AgentSelectedFilesModelCoordinator { request, interimFileRowsHandler in
+            await resolver.resolve(request, interimFileRowsHandler: interimFileRowsHandler)
+        }
+        let request = makeRequest(name: "Stable.swift", codeMapUsage: .auto, codemapAutoEnabled: true)
+
+        XCTAssertEqual(coordinator.refreshIfNeeded(request), .started)
+        let didStartInitialLoad = await resolver.waitUntilStartCount(.auto, count: 1)
+        XCTAssertTrue(didStartInitialLoad)
+        await resolver.releaseNext(.auto)
+        let didLoadInitialModel = await waitUntilModel(promptText: "Stable.swift", in: coordinator)
+        XCTAssertTrue(didLoadInitialModel)
+        XCTAssertEqual(coordinator.rowSplit.codemapRows.count, 2)
+
+        XCTAssertEqual(coordinator.refreshIfNeeded(request, force: true, preserveDisplayedModel: true), .started)
+        let didStartRefresh = await resolver.waitUntilStartCount(.auto, count: 2)
+        let didPublishInterimFileRows = await waitUntilFileOnlyLoading(promptText: "Stable.swift", in: coordinator)
+        XCTAssertTrue(didStartRefresh)
+        XCTAssertTrue(didPublishInterimFileRows)
+        XCTAssertTrue(coordinator.isLoading)
+        XCTAssertEqual(coordinator.rowSplit.fileRows.count, 1)
+        XCTAssertEqual(coordinator.rowSplit.codemapRows.count, 0)
+        XCTAssertEqual(
+            coordinator.displayedFileCodemapCountReadiness(for: request.identity),
+            AgentContextFileCodemapCountReadiness(file: .known(1), codemap: .known(2))
+        )
+
+        await resolver.releaseNext(.auto)
+        let didReloadCompletedModel = await waitUntilModel(promptText: "Stable.swift", in: coordinator)
+        XCTAssertTrue(didReloadCompletedModel)
+        XCTAssertEqual(
+            coordinator.displayedFileCodemapCountReadiness(for: request.identity),
+            AgentContextFileCodemapCountReadiness(file: .known(1), codemap: .known(2))
+        )
+    }
+
+    @MainActor
+    func testNonPreservedIdentityChangeClearsDisplayedRowsWhileLoading() async {
         let resolver = GatedModelResolver()
         let coordinator = AgentSelectedFilesModelCoordinator { request in
             await resolver.resolve(request)
+        }
+        let loadedRequest = makeRequest(name: "Loaded.swift")
+        let currentRequest = makeRequest(name: "Current.swift")
+
+        XCTAssertEqual(coordinator.refreshIfNeeded(loadedRequest), .started)
+        let didStartLoaded = await resolver.waitUntilStartCount("Loaded.swift", count: 1)
+        XCTAssertTrue(didStartLoaded)
+        await resolver.releaseNext("Loaded.swift")
+        let didLoad = await waitUntilModel(promptText: "Loaded.swift", in: coordinator)
+        XCTAssertTrue(didLoad)
+        XCTAssertEqual(coordinator.rowSplit.rows.count, 1)
+        XCTAssertTrue(coordinator.displayedModelMatches(loadedRequest.identity))
+        XCTAssertTrue(coordinator.completedModelMatches(loadedRequest.identity))
+
+        XCTAssertEqual(coordinator.refreshIfNeeded(currentRequest), .started)
+
+        XCTAssertNil(coordinator.model)
+        XCTAssertTrue(coordinator.rowSplit.rows.isEmpty)
+        XCTAssertTrue(coordinator.isLoading)
+        XCTAssertFalse(coordinator.canMutateDisplayedModel)
+        XCTAssertFalse(coordinator.displayedModelMatches(loadedRequest.identity))
+        XCTAssertFalse(coordinator.displayedModelMatches(currentRequest.identity))
+        XCTAssertFalse(coordinator.completedModelMatches(loadedRequest.identity))
+        XCTAssertFalse(coordinator.completedModelMatches(currentRequest.identity))
+
+        let didStartCurrent = await resolver.waitUntilStartCount("Current.swift", count: 1)
+        XCTAssertTrue(didStartCurrent)
+        await resolver.releaseNext("Current.swift")
+        let didLoadCurrent = await waitUntilModel(promptText: "Current.swift", in: coordinator)
+        XCTAssertTrue(didLoadCurrent)
+    }
+
+    @MainActor
+    func testPreservedSameIdentityRefreshKeepsDisplayedRowsWithoutMutation() async {
+        let resolver = GatedModelResolver()
+        let coordinator = AgentSelectedFilesModelCoordinator { request in
+            await resolver.resolve(request)
+        }
+        let request = makeRequest(name: "Stable.swift")
+
+        XCTAssertEqual(coordinator.refreshIfNeeded(request), .started)
+        let didStartInitialLoad = await resolver.waitUntilStartCount("Stable.swift", count: 1)
+        XCTAssertTrue(didStartInitialLoad)
+        await resolver.releaseNext("Stable.swift")
+        let didLoad = await waitUntilModel(promptText: "Stable.swift", in: coordinator)
+        XCTAssertTrue(didLoad)
+        XCTAssertEqual(coordinator.model?.source.promptText, "Stable.swift")
+        XCTAssertTrue(coordinator.canMutateDisplayedModel)
+
+        XCTAssertEqual(coordinator.refreshIfNeeded(request, force: true, preserveDisplayedModel: true), .started)
+        let didStartRefresh = await resolver.waitUntilStartCount("Stable.swift", count: 2)
+        XCTAssertTrue(didStartRefresh)
+
+        XCTAssertEqual(coordinator.model?.source.promptText, "Stable.swift")
+        XCTAssertEqual(coordinator.rowSplit.rows.count, 1)
+        XCTAssertTrue(coordinator.isLoading)
+        XCTAssertFalse(coordinator.canMutateDisplayedModel)
+        XCTAssertTrue(coordinator.displayedModelMatches(request.identity))
+        XCTAssertFalse(coordinator.completedModelMatches(request.identity))
+
+        await resolver.releaseNext("Stable.swift")
+        let didReload = await waitUntilModel(promptText: "Stable.swift", in: coordinator)
+        XCTAssertTrue(didReload)
+    }
+
+    @MainActor
+    func testDisplayedModelMatchesUsesFullIdentityDuringPreservedRefresh() async {
+        let resolver = GatedModelResolver()
+        let coordinator = AgentSelectedFilesModelCoordinator { request in
+            await resolver.resolve(request)
+        }
+        let loadedRequest = makeRequest(name: "Shared.swift", codeMapUsage: .none)
+        let currentRequest = AgentSelectedFilesModelRequest(
+            identity: AgentSelectedFilesModelIdentity(
+                exportContextIdentity: loadedRequest.source.exportContextIdentity,
+                filePathDisplay: loadedRequest.filePathDisplay,
+                codeMapUsage: .selected
+            ),
+            source: loadedRequest.source,
+            store: WorkspaceFileContextStore(),
+            filePathDisplay: loadedRequest.filePathDisplay,
+            codeMapUsage: .selected,
+            entryMetricsSnapshot: nil
+        )
+
+        XCTAssertEqual(coordinator.refreshIfNeeded(loadedRequest), .started)
+        let didStartInitialLoad = await resolver.waitUntilStartCount("Shared.swift", count: 1)
+        XCTAssertTrue(didStartInitialLoad)
+        await resolver.releaseNext("Shared.swift")
+        let didLoadInitialModel = await waitUntilModel(promptText: "Shared.swift", in: coordinator)
+        XCTAssertTrue(didLoadInitialModel)
+        XCTAssertTrue(coordinator.displayedModelMatches(loadedRequest.identity))
+        XCTAssertFalse(coordinator.displayedModelMatches(currentRequest.identity))
+
+        XCTAssertEqual(coordinator.refreshIfNeeded(currentRequest, preserveDisplayedModel: true), .started)
+        let didStartPreservedRefresh = await resolver.waitUntilStartCount("Shared.swift", count: 2)
+        XCTAssertTrue(didStartPreservedRefresh)
+
+        XCTAssertEqual(coordinator.model?.source.promptText, "Shared.swift")
+        XCTAssertTrue(coordinator.isLoading)
+        XCTAssertFalse(coordinator.canMutateDisplayedModel)
+        XCTAssertTrue(coordinator.displayedModelMatches(loadedRequest.identity))
+        XCTAssertFalse(coordinator.displayedModelMatches(currentRequest.identity))
+        XCTAssertFalse(coordinator.completedModelMatches(loadedRequest.identity))
+        XCTAssertFalse(coordinator.completedModelMatches(currentRequest.identity))
+
+        await resolver.releaseNext("Shared.swift")
+        let didLoadCurrentModel = await waitUntilModel(promptText: "Shared.swift", in: coordinator)
+        XCTAssertTrue(didLoadCurrentModel)
+        XCTAssertFalse(coordinator.displayedModelMatches(loadedRequest.identity))
+        XCTAssertTrue(coordinator.displayedModelMatches(currentRequest.identity))
+        XCTAssertTrue(coordinator.completedModelMatches(currentRequest.identity))
+    }
+
+    @MainActor
+    func testIdentityHelpersDistinguishInterimDisplayedModelFromCompletedModel() async {
+        let resolver = ProgressiveCodemapModelResolver()
+        let coordinator = AgentSelectedFilesModelCoordinator { request, interimFileRowsHandler in
+            await resolver.resolve(request, interimFileRowsHandler: interimFileRowsHandler)
+        }
+        let loadedRequest = makeRequest(name: "Loaded.swift")
+        let request = makeRequest(name: "Progressive.swift", codeMapUsage: .complete)
+
+        XCTAssertEqual(coordinator.refreshIfNeeded(loadedRequest), .started)
+        let didLoadInitialModel = await waitUntilModel(promptText: "Loaded.swift", in: coordinator)
+        XCTAssertTrue(didLoadInitialModel)
+        XCTAssertTrue(coordinator.displayedModelMatches(loadedRequest.identity))
+        XCTAssertTrue(coordinator.completedModelMatches(loadedRequest.identity))
+
+        XCTAssertEqual(coordinator.refreshIfNeeded(request, preserveDisplayedModel: true), .started)
+        let didDisplayInterimModel = await waitUntilDisplayedModel(promptText: "Progressive.swift", in: coordinator)
+        XCTAssertTrue(didDisplayInterimModel)
+        XCTAssertTrue(coordinator.isLoading)
+        XCTAssertFalse(coordinator.canMutateDisplayedModel)
+        XCTAssertFalse(coordinator.displayedModelMatches(loadedRequest.identity))
+        XCTAssertFalse(coordinator.completedModelMatches(loadedRequest.identity))
+        XCTAssertTrue(coordinator.displayedModelMatches(request.identity))
+        XCTAssertFalse(coordinator.completedModelMatches(request.identity))
+
+        await resolver.releaseNext(.complete)
+        let didLoadCompletedModel = await waitUntilModel(promptText: "Progressive.swift", in: coordinator)
+        XCTAssertTrue(didLoadCompletedModel)
+        XCTAssertFalse(coordinator.isLoading)
+        XCTAssertTrue(coordinator.canMutateDisplayedModel)
+        XCTAssertTrue(coordinator.displayedModelMatches(request.identity))
+        XCTAssertTrue(coordinator.completedModelMatches(request.identity))
+    }
+
+    @MainActor
+    func testCancelLoadingWithoutKeepingLoadedModelRetainsCachedModels() async {
+        let resolver = ImmediateModelResolver()
+        let coordinator = AgentSelectedFilesModelCoordinator { request in
+            await resolver.resolve(request)
+        }
+        let cachedRequest = makeRequest(name: "Cached.swift")
+        let displayedRequest = makeRequest(name: "Displayed.swift")
+
+        XCTAssertEqual(coordinator.refreshIfNeeded(cachedRequest), .started)
+        let didLoadCached = await waitUntilModel(promptText: "Cached.swift", in: coordinator)
+        XCTAssertTrue(didLoadCached)
+        XCTAssertEqual(coordinator.refreshIfNeeded(displayedRequest), .started)
+        let didLoadDisplayed = await waitUntilModel(promptText: "Displayed.swift", in: coordinator)
+        let startCountAfterLoads = await resolver.startCount()
+        XCTAssertTrue(didLoadDisplayed)
+        XCTAssertEqual(startCountAfterLoads, 2)
+
+        coordinator.cancelLoading(keepLoadedModel: false)
+        XCTAssertNil(coordinator.model)
+        XCTAssertTrue(coordinator.rowSplit.rows.isEmpty)
+        XCTAssertFalse(coordinator.isLoading)
+        XCTAssertFalse(coordinator.displayedModelMatches(cachedRequest.identity))
+        XCTAssertFalse(coordinator.completedModelMatches(cachedRequest.identity))
+
+        XCTAssertEqual(coordinator.refreshIfNeeded(cachedRequest), .skippedLoaded)
+
+        let finalStartCount = await resolver.startCount()
+        XCTAssertEqual(finalStartCount, 2)
+        XCTAssertEqual(coordinator.model?.source.promptText, "Cached.swift")
+        XCTAssertFalse(coordinator.isLoading)
+        XCTAssertTrue(coordinator.canMutateDisplayedModel)
+        XCTAssertTrue(coordinator.displayedModelMatches(cachedRequest.identity))
+        XCTAssertTrue(coordinator.completedModelMatches(cachedRequest.identity))
+    }
+
+    @MainActor
+    func testForceRefreshAfterClearingDisplayedModelBypassesCachedIdentity() async {
+        let resolver = GatedModelResolver()
+        let coordinator = AgentSelectedFilesModelCoordinator { request in
+            await resolver.resolve(request)
+        }
+        let request = makeRequest(name: "SameIdentity.swift")
+
+        XCTAssertEqual(coordinator.refreshIfNeeded(request), .started)
+        let didStartInitialLoad = await resolver.waitUntilStartCount("SameIdentity.swift", count: 1)
+        XCTAssertTrue(didStartInitialLoad)
+        await resolver.releaseNext("SameIdentity.swift")
+        let didLoadInitialModel = await waitUntilModel(promptText: "SameIdentity.swift", in: coordinator)
+        XCTAssertTrue(didLoadInitialModel)
+
+        coordinator.cancelLoading(keepLoadedModel: false)
+        XCTAssertNil(coordinator.model)
+        XCTAssertTrue(coordinator.rowSplit.rows.isEmpty)
+        XCTAssertFalse(coordinator.displayedModelMatches(request.identity))
+
+        XCTAssertEqual(coordinator.refreshIfNeeded(request, force: true), .started)
+        let didStartForcedReload = await resolver.waitUntilStartCount("SameIdentity.swift", count: 2)
+        let startCountBeforeRelease = await resolver.startCount()
+        XCTAssertTrue(didStartForcedReload)
+        XCTAssertEqual(startCountBeforeRelease, 2)
+        XCTAssertNil(coordinator.model)
+        XCTAssertTrue(coordinator.isLoading)
+        XCTAssertFalse(coordinator.displayedModelMatches(request.identity))
+
+        await resolver.releaseNext("SameIdentity.swift")
+        let didLoadForcedModel = await waitUntilModel(promptText: "SameIdentity.swift", in: coordinator)
+        XCTAssertTrue(didLoadForcedModel)
+        XCTAssertTrue(coordinator.displayedModelMatches(request.identity))
+        XCTAssertTrue(coordinator.completedModelMatches(request.identity))
+    }
+
+    @MainActor
+    func testCancelledGenerationPublishesCachesAndCompletesNothingWhileReplacementLoads() async {
+        let resolver = CancellableGatedModelResolver()
+        let coordinator = AgentSelectedFilesModelCoordinator {
+            (request: AgentSelectedFilesModelRequest) async throws(CancellationError) in
+            try await resolver.resolve(request)
         }
         let requestA = makeRequest(name: "A.swift")
         let requestB = makeRequest(name: "B.swift")
@@ -106,6 +939,7 @@ final class AgentSelectedFilesModelCoordinatorTests: XCTestCase {
         await drainCancelledTask()
         XCTAssertNil(coordinator.model)
         XCTAssertTrue(coordinator.isLoading)
+        XCTAssertEqual(coordinator.debugStats.resolverCompletions, 0)
 
         await resolver.releaseNext("B.swift")
         let didLoadNewestModel = await waitUntilModel(promptText: "B.swift", in: coordinator)
@@ -113,6 +947,13 @@ final class AgentSelectedFilesModelCoordinatorTests: XCTestCase {
         XCTAssertEqual(coordinator.model?.source.promptText, "B.swift")
         XCTAssertEqual(coordinator.debugStats.resolverStarts, 2)
         XCTAssertEqual(coordinator.debugStats.resolverCompletions, 1)
+
+        XCTAssertEqual(coordinator.refreshIfNeeded(requestA), .started)
+        let didStartAAgain = await resolver.waitUntilStartCount("A.swift", count: 2)
+        XCTAssertTrue(didStartAAgain)
+        coordinator.cancelLoading(keepLoadedModel: false)
+        await resolver.releaseNext("A.swift")
+        await drainCancelledTask()
     }
 
     @MainActor
@@ -382,10 +1223,52 @@ final class AgentSelectedFilesModelCoordinatorTests: XCTestCase {
         return coordinator.model?.source.promptText == promptText
     }
 
+    @MainActor
+    private func waitUntilFileOnlyLoading(
+        promptText: String,
+        in coordinator: AgentSelectedFilesModelCoordinator
+    ) async -> Bool {
+        for _ in 0 ..< 500 {
+            if coordinator.model?.source.promptText == promptText,
+               coordinator.isLoading,
+               coordinator.rowSplit.fileRows.count == 1,
+               coordinator.rowSplit.codemapRows.isEmpty
+            {
+                return true
+            }
+            await Task.yield()
+            try? await Task.sleep(nanoseconds: 1_000_000)
+        }
+        return coordinator.model?.source.promptText == promptText
+            && coordinator.isLoading
+            && coordinator.rowSplit.fileRows.count == 1
+            && coordinator.rowSplit.codemapRows.isEmpty
+    }
+
+    @MainActor
+    private func waitUntilDisplayedFileMetrics(
+        _ metrics: AgentContextExportRow.Metrics,
+        promptText: String,
+        in coordinator: AgentSelectedFilesModelCoordinator
+    ) async -> Bool {
+        for _ in 0 ..< 500 {
+            if coordinator.model?.source.promptText == promptText,
+               coordinator.rowSplit.fileRows.first?.metrics == metrics
+            {
+                return true
+            }
+            await Task.yield()
+            try? await Task.sleep(nanoseconds: 1_000_000)
+        }
+        return coordinator.model?.source.promptText == promptText
+            && coordinator.rowSplit.fileRows.first?.metrics == metrics
+    }
+
     private func makeRequest(
         name: String,
         codeMapUsage: CodeMapUsage = .none,
-        codemapAutoEnabled: Bool = false
+        codemapAutoEnabled: Bool = false,
+        entryMetricsSnapshot: PromptContextEntryMetricsSnapshot? = nil
     ) -> AgentSelectedFilesModelRequest {
         let source = AgentContextExportSource(
             tabID: UUID(),
@@ -405,7 +1288,25 @@ final class AgentSelectedFilesModelCoordinatorTests: XCTestCase {
             source: source,
             store: WorkspaceFileContextStore(),
             filePathDisplay: .relative,
-            codeMapUsage: codeMapUsage
+            codeMapUsage: codeMapUsage,
+            entryMetricsSnapshot: entryMetricsSnapshot
+        )
+    }
+
+    private func makeMetricsSnapshot(fileID: UUID, name: String) -> PromptContextEntryMetricsSnapshot {
+        PromptContextEntryMetricsSnapshot(
+            totalSelectedDisplayTokens: 91,
+            metrics: [
+                PromptContextEntryMetric(
+                    fileID: fileID,
+                    standardizedFullPath: "/tmp/RepoPromptTests/Sources/\(name)",
+                    renderedDisplayPath: "Sources/\(name)",
+                    renderMode: .full,
+                    displayTokenCount: 91,
+                    displayPercentage: 1,
+                    includedLineCount: 11
+                )
+            ]
         )
     }
 
@@ -464,21 +1365,107 @@ private actor GatedModelResolver {
     }
 }
 
-private actor ProgressiveCodemapModelResolver {
-    private var usages: [CodeMapUsage] = []
+private actor CancellableGatedModelResolver {
+    private var starts = 0
     private var startedCounts: [String: Int] = [:]
     private var continuations: [String: [CheckedContinuation<Void, Never>]] = [:]
 
+    func resolve(
+        _ request: AgentSelectedFilesModelRequest
+    ) async throws(CancellationError) -> AgentContextExportModel {
+        starts += 1
+        let key = request.source.promptText
+        await withCheckedContinuation { continuation in
+            continuations[key, default: []].append(continuation)
+            startedCounts[key, default: 0] += 1
+        }
+        guard !Task.isCancelled else { throw CancellationError() }
+        return makeModel(for: request)
+    }
+
+    func waitUntilStartCount(_ key: String, count: Int) async -> Bool {
+        for _ in 0 ..< 500 {
+            if startedCounts[key, default: 0] >= count { return true }
+            try? await Task.sleep(nanoseconds: 1_000_000)
+        }
+        return startedCounts[key, default: 0] >= count
+    }
+
+    func releaseNext(_ key: String) {
+        guard var queued = continuations[key], !queued.isEmpty else { return }
+        let continuation = queued.removeFirst()
+        continuations[key] = queued
+        continuation.resume()
+    }
+
+    func startCount() -> Int {
+        starts
+    }
+}
+
+private actor GatedTokenMetricsModelResolver {
+    private let fileID: UUID
+    private let rootID = UUID()
+    private var starts = 0
+    private var continuations: [CheckedContinuation<Void, Never>] = []
+
+    init(fileID: UUID) {
+        self.fileID = fileID
+    }
+
     func resolve(_ request: AgentSelectedFilesModelRequest) async -> AgentContextExportModel {
+        starts += 1
+        await withCheckedContinuation { continuation in
+            continuations.append(continuation)
+        }
+        return makeVisibleFileMetricsModel(for: request, fileID: fileID, rootID: rootID)
+    }
+
+    func waitUntilStartCount(_ count: Int) async -> Bool {
+        for _ in 0 ..< 500 {
+            if starts >= count { return true }
+            try? await Task.sleep(nanoseconds: 1_000_000)
+        }
+        return starts >= count
+    }
+
+    func releaseNext() {
+        guard !continuations.isEmpty else { return }
+        continuations.removeFirst().resume()
+    }
+}
+
+private actor ProgressiveCodemapModelResolver {
+    private let finalCodemapCount: Int
+    private var usages: [CodeMapUsage] = []
+    private var metricsSnapshots: [PromptContextEntryMetricsSnapshot?] = []
+    private var startedCounts: [String: Int] = [:]
+    private var continuations: [String: [CheckedContinuation<Void, Never>]] = [:]
+
+    private var interimPublications = 0
+
+    init(finalCodemapCount: Int = 0) {
+        self.finalCodemapCount = finalCodemapCount
+    }
+
+    func resolve(
+        _ request: AgentSelectedFilesModelRequest,
+        interimFileRowsHandler: AgentSelectedFilesModelCoordinator.ResolveInterimFileRows?
+    ) async -> AgentContextExportModel {
         usages.append(request.codeMapUsage)
+        metricsSnapshots.append(request.entryMetricsSnapshot)
         let key = request.codeMapUsage.rawValue
         startedCounts[key, default: 0] += 1
+        if let interimFileRowsHandler, request.codeMapUsage == .auto || request.codeMapUsage == .complete {
+            interimPublications += 1
+            await interimFileRowsHandler(makeModel(for: request))
+        }
         if request.codeMapUsage == .auto || request.codeMapUsage == .complete {
             await withCheckedContinuation { continuation in
                 continuations[key, default: []].append(continuation)
             }
         }
-        return makeModel(for: request)
+        return makeModel(for: request, codemapCount: finalCodemapCount)
     }
 
     func waitUntilStartCount(_ usage: CodeMapUsage, count: Int) async -> Bool {
@@ -488,6 +1475,15 @@ private actor ProgressiveCodemapModelResolver {
             try? await Task.sleep(nanoseconds: 1_000_000)
         }
         return startedCounts[key, default: 0] >= count
+    }
+
+    func waitUntilPendingContinuationCount(_ usage: CodeMapUsage, count: Int) async -> Bool {
+        let key = usage.rawValue
+        for _ in 0 ..< 500 {
+            if continuations[key, default: []].count >= count { return true }
+            try? await Task.sleep(nanoseconds: 1_000_000)
+        }
+        return continuations[key, default: []].count >= count
     }
 
     func releaseNext(_ usage: CodeMapUsage) {
@@ -501,26 +1497,167 @@ private actor ProgressiveCodemapModelResolver {
     func startedUsages() -> [CodeMapUsage] {
         usages
     }
+
+    func startedMetricsSnapshots() -> [PromptContextEntryMetricsSnapshot?] {
+        metricsSnapshots
+    }
+
+    func interimPublicationCount() -> Int {
+        interimPublications
+    }
 }
 
-private func makeModel(for request: AgentSelectedFilesModelRequest) -> AgentContextExportModel {
+private actor VisibleFileMetricsPreservationResolver {
+    private let fileIDs: [UUID]
+    private let rootIDs: [UUID]
+    private var interimPublications = 0
+    private var continuations: [String: [CheckedContinuation<Void, Never>]] = [:]
+
+    init(fileID: UUID, fileIDs: [UUID]? = nil, rootIDs: [UUID] = [UUID()]) {
+        self.fileIDs = fileIDs ?? [fileID]
+        self.rootIDs = rootIDs
+    }
+
+    func resolve(
+        _ request: AgentSelectedFilesModelRequest,
+        interimFileRowsHandler: AgentSelectedFilesModelCoordinator.ResolveInterimFileRows?
+    ) async -> AgentContextExportModel {
+        let key = request.codeMapUsage.rawValue
+        if let interimFileRowsHandler, request.codeMapUsage == .auto || request.codeMapUsage == .complete {
+            let publicationIndex = interimPublications
+            interimPublications += 1
+            await interimFileRowsHandler(makeVisibleFileMetricsModel(
+                for: request,
+                fileID: fileID(for: publicationIndex),
+                rootID: rootID(for: publicationIndex)
+            ))
+        }
+        if request.codeMapUsage == .auto || request.codeMapUsage == .complete {
+            await withCheckedContinuation { continuation in
+                continuations[key, default: []].append(continuation)
+            }
+        }
+        let publicationIndex = max(interimPublications - 1, 0)
+        return makeVisibleFileMetricsModel(
+            for: request,
+            fileID: fileID(for: publicationIndex),
+            rootID: rootID(for: publicationIndex),
+            codemapCount: 1
+        )
+    }
+
+    private func fileID(for publicationIndex: Int) -> UUID {
+        fileIDs[min(publicationIndex, fileIDs.count - 1)]
+    }
+
+    private func rootID(for publicationIndex: Int) -> UUID {
+        rootIDs[min(publicationIndex, rootIDs.count - 1)]
+    }
+
+    func waitUntilInterimPublicationCount(_ count: Int) async -> Bool {
+        for _ in 0 ..< 500 {
+            if interimPublications >= count { return true }
+            try? await Task.sleep(nanoseconds: 1_000_000)
+        }
+        return interimPublications >= count
+    }
+
+    func releaseAll(_ usage: CodeMapUsage) {
+        let key = usage.rawValue
+        let queued = continuations.removeValue(forKey: key) ?? []
+        for continuation in queued {
+            continuation.resume()
+        }
+    }
+}
+
+private func makeVisibleFileMetricsModel(
+    for request: AgentSelectedFilesModelRequest,
+    fileID: UUID,
+    rootID: UUID,
+    codemapCount: Int = 0
+) -> AgentContextExportModel {
     let fileName = request.source.promptText
+    let metric = request.entryMetricsSnapshot?.metric(forFileID: fileID)
     let row = AgentContextExportRow(
-        id: ResolvedPromptFileEntryID(fileID: UUID(), mode: .fullFile, lineRanges: nil),
+        id: ResolvedPromptFileEntryID(fileID: fileID, mode: .fullFile, lineRanges: nil),
         kind: .full,
-        rootID: UUID(),
+        rootID: rootID,
         relativePath: "Sources/\(fileName)",
         displayPath: "Sources/\(fileName)",
         displayName: fileName,
         directoryDisplay: "Sources",
         lineRanges: nil,
-        canRemove: true,
-        directContentPath: "/tmp/RepoPromptTests/Sources/\(fileName)"
+        metrics: metric.map {
+            AgentContextExportRow.Metrics.known(
+                tokenCount: $0.displayTokenCount,
+                tokenPercentage: $0.displayPercentage,
+                lineCount: $0.includedLineCount
+            )
+        } ?? .unknown,
+        rootDisplayName: "Metric Root",
+        rootColorKey: "metric-root",
+        showRootPill: true,
+        canRemove: true
     )
+    let codemapRows = (0 ..< codemapCount).map { index in
+        let codemapName = "Codemap\(index).swift"
+        return AgentContextExportRow(
+            id: ResolvedPromptFileEntryID(fileID: UUID(), mode: .codemap, lineRanges: nil),
+            kind: .codemap,
+            rootID: rootID,
+            relativePath: "Sources/\(codemapName)",
+            displayPath: "Sources/\(codemapName)",
+            displayName: codemapName,
+            directoryDisplay: "Sources",
+            lineRanges: nil,
+            canRemove: true
+        )
+    }
     return AgentContextExportModel(
         source: request.source,
         lookupContext: WorkspaceLookupContext(rootScope: .allLoaded, bindingProjection: nil),
-        rows: [row],
+        rows: [row] + codemapRows,
+        totalSelectedDisplayTokens: request.entryMetricsSnapshot?.totalSelectedDisplayTokens ?? 0,
+        missingPaths: [],
+        invalidPaths: [],
+        codemapPresentation: .empty
+    )
+}
+
+private func makeModel(for request: AgentSelectedFilesModelRequest, codemapCount: Int = 0) -> AgentContextExportModel {
+    let fileName = request.source.promptText
+    let rootID = UUID()
+    let row = AgentContextExportRow(
+        id: ResolvedPromptFileEntryID(fileID: UUID(), mode: .fullFile, lineRanges: nil),
+        kind: .full,
+        rootID: rootID,
+        relativePath: "Sources/\(fileName)",
+        displayPath: "Sources/\(fileName)",
+        displayName: fileName,
+        directoryDisplay: "Sources",
+        lineRanges: nil,
+        canRemove: true
+    )
+    let codemapRows = (0 ..< codemapCount).map { index in
+        let codemapName = "Codemap\(index).swift"
+        return AgentContextExportRow(
+            id: ResolvedPromptFileEntryID(fileID: UUID(), mode: .codemap, lineRanges: nil),
+            kind: .codemap,
+            rootID: rootID,
+            relativePath: "Sources/\(codemapName)",
+            displayPath: "Sources/\(codemapName)",
+            displayName: codemapName,
+            directoryDisplay: "Sources",
+            lineRanges: nil,
+            canRemove: true
+        )
+    }
+    return AgentContextExportModel(
+        source: request.source,
+        lookupContext: WorkspaceLookupContext(rootScope: .allLoaded, bindingProjection: nil),
+        rows: [row] + codemapRows,
+        totalSelectedDisplayTokens: 0,
         missingPaths: [],
         invalidPaths: [],
         codemapPresentation: .empty

--- a/Tests/RepoPromptTests/AgentMode/ToolCards/OracleOperationToolCardRoutingTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/ToolCards/OracleOperationToolCardRoutingTests.swift
@@ -34,6 +34,11 @@ final class OracleOperationToolCardRoutingTests: XCTestCase {
         XCTAssertEqual(userInfo["workspaceID"] as? UUID, workspaceID)
         XCTAssertEqual(userInfo["tabID"] as? UUID, tabID)
         XCTAssertEqual(userInfo["chatID"] as? String, "review-chat")
+        XCTAssertEqual(userInfo["presentation"] as? String, "generated_answer_read_only")
+        XCTAssertEqual(
+            AgentOraclePopoverRoute(notificationUserInfo: userInfo)?.presentation,
+            .generatedAnswerReadOnly
+        )
     }
 
     func testContextBuilderOperationRoutingRejectsMissingOrBlankChatIDWithoutAmbientFallback() {
@@ -54,6 +59,63 @@ final class OracleOperationToolCardRoutingTests: XCTestCase {
             openContext: AgentOracleOpenContext(windowID: 42, workspaceID: UUID(), tabID: nil),
             chatID: "exact-chat"
         ))
+    }
+
+    func testDrawerBuilderGeneratedAnswerRoutingAndTooltipsUseAnswerWording() throws {
+        let route = ContextBuilderGeneratedAnswerRoute(
+            workspaceID: UUID(),
+            tabID: UUID(),
+            chatID: "  generated-answer-chat  "
+        )
+        let changedWorkspaceID = UUID()
+        let changedTabID = UUID()
+        XCTAssertNotEqual(changedWorkspaceID, route.workspaceID)
+        XCTAssertNotEqual(changedTabID, route.tabID)
+
+        let ready = ContextBuilderPlanStatus.ready(route: route, previewText: "Generated answer")
+        var callbackRoute: ContextBuilderGeneratedAnswerRoute?
+        if case let .ready(readyRoute, _) = ready {
+            let openGeneratedAnswerChat: (ContextBuilderGeneratedAnswerRoute) -> Void = {
+                callbackRoute = $0
+            }
+            openGeneratedAnswerChat(readyRoute)
+        }
+        XCTAssertEqual(callbackRoute, route)
+
+        let userInfo = try XCTUnwrap(agentContextDrawerGeneratedAnswerPopoverUserInfo(
+            windowID: 8,
+            route: route
+        ))
+
+        XCTAssertEqual(Set(userInfo.keys.compactMap { $0 as? String }), [
+            "windowID",
+            "workspaceID",
+            "tabID",
+            "chatID",
+            "presentation"
+        ])
+        XCTAssertEqual(userInfo["windowID"] as? Int, 8)
+        XCTAssertEqual(userInfo["workspaceID"] as? UUID, route.workspaceID)
+        XCTAssertEqual(userInfo["tabID"] as? UUID, route.tabID)
+        XCTAssertEqual(userInfo["chatID"] as? String, "generated-answer-chat")
+        XCTAssertEqual(userInfo["presentation"] as? String, "generated_answer_read_only")
+        let decodedRoute = try XCTUnwrap(AgentOraclePopoverRoute(notificationUserInfo: userInfo))
+        XCTAssertEqual(decodedRoute.chatID, "generated-answer-chat")
+        XCTAssertEqual(decodedRoute.presentation, .generatedAnswerReadOnly)
+
+        let tooltips = [
+            ContextBuilderGeneratedAnswerActionText.useAsPromptTooltip,
+            ContextBuilderGeneratedAnswerActionText.copyTooltip,
+            ContextBuilderGeneratedAnswerActionText.previewTooltip,
+            ContextBuilderGeneratedAnswerActionText.viewInChatTooltip
+        ]
+        XCTAssertEqual(tooltips, [
+            "Use the generated answer as your prompt",
+            "Copy answer to clipboard",
+            "Preview the generated answer",
+            "Open answer in chat view"
+        ])
+        XCTAssertFalse(tooltips.contains { $0.localizedCaseInsensitiveContains("plan") })
     }
 
     func testOracleLatestPopoverRouteOmitsChatIDAndPreservesScope() throws {
@@ -131,12 +193,14 @@ final class OracleOperationToolCardRoutingTests: XCTestCase {
         XCTAssertEqual(route.workspaceID, workspaceID)
         XCTAssertEqual(route.tabID, overrideTabID)
         XCTAssertEqual(route.chatID, "exact-short-id")
+        XCTAssertEqual(route.presentation, .standard)
 
         let userInfo = route.notificationUserInfo
         XCTAssertEqual(userInfo["windowID"] as? Int, 42)
         XCTAssertEqual(userInfo["workspaceID"] as? UUID, workspaceID)
         XCTAssertEqual(userInfo["tabID"] as? UUID, overrideTabID)
         XCTAssertEqual(userInfo["chatID"] as? String, "exact-short-id")
+        XCTAssertNil(userInfo["presentation"])
         XCTAssertEqual(AgentOraclePopoverRoute(notificationUserInfo: userInfo), route)
 
         let stringCompatibleRoute = try XCTUnwrap(AgentOraclePopoverRoute(notificationUserInfo: [
@@ -149,6 +213,17 @@ final class OracleOperationToolCardRoutingTests: XCTestCase {
         XCTAssertEqual(stringCompatibleRoute.workspaceID, workspaceID)
         XCTAssertEqual(stringCompatibleRoute.tabID, contextTabID)
         XCTAssertEqual(stringCompatibleRoute.chatID, "short-chat")
+        XCTAssertEqual(stringCompatibleRoute.presentation, .standard)
+
+        let readOnlyRoute = try XCTUnwrap(AgentOraclePopoverRoute(
+            openContext: openContext,
+            chatID: "exact-short-id",
+            tabID: overrideTabID,
+            presentation: .generatedAnswerReadOnly
+        ))
+        XCTAssertNotEqual(readOnlyRoute, route)
+        XCTAssertEqual(readOnlyRoute.notificationUserInfo["presentation"] as? String, "generated_answer_read_only")
+        XCTAssertEqual(AgentOraclePopoverRoute(notificationUserInfo: readOnlyRoute.notificationUserInfo), readOnlyRoute)
 
         let chatUUID = UUID()
         let uuidChatRoute = try XCTUnwrap(AgentOraclePopoverRoute(notificationUserInfo: [
@@ -209,6 +284,12 @@ final class OracleOperationToolCardRoutingTests: XCTestCase {
         XCTAssertNil(AgentOraclePopoverRoute(notificationUserInfo: malformed))
         malformed = valid
         malformed["chatID"] = 42
+        XCTAssertNil(AgentOraclePopoverRoute(notificationUserInfo: malformed))
+        malformed = valid
+        malformed["presentation"] = "unknown"
+        XCTAssertNil(AgentOraclePopoverRoute(notificationUserInfo: malformed))
+        malformed = valid
+        malformed["presentation"] = 42
         XCTAssertNil(AgentOraclePopoverRoute(notificationUserInfo: malformed))
     }
 

--- a/Tests/RepoPromptTests/Chat/MessageBubbleActionPolicyTests.swift
+++ b/Tests/RepoPromptTests/Chat/MessageBubbleActionPolicyTests.swift
@@ -1,0 +1,9 @@
+@testable import RepoPromptApp
+import XCTest
+
+final class MessageBubbleActionPolicyTests: XCTestCase {
+    func testMutatingActionAvailabilityMatchesTranscriptPolicy() {
+        XCTAssertTrue(ChatTranscriptActionPolicy.standard.allowsMutatingActions)
+        XCTAssertFalse(ChatTranscriptActionPolicy.nonMutating.allowsMutatingActions)
+    }
+}

--- a/Tests/RepoPromptTests/MCP/MCPSelectionContentPackagingTests.swift
+++ b/Tests/RepoPromptTests/MCP/MCPSelectionContentPackagingTests.swift
@@ -110,10 +110,12 @@ final class MCPSelectionContentPackagingTests: XCTestCase {
         )
         let staleResult = PromptEntriesEvaluation.EntryResult(
             fileID: codemapEntry.file.id,
+            renderedDisplayPath: "Nested/Frozen.swift",
             renderMode: .codemap,
             displayTokens: 1,
             fullTokens: 1,
-            codemapTokens: 1
+            codemapTokens: 1,
+            displayLineCount: 1
         )
         let filesReply = await MCPServerViewModel.SelectionReplyAssembler.buildSelectedFilesReply(
             collections: collections,

--- a/Tests/RepoPromptTests/MCP/MCPSelectionReplyFreshnessTests.swift
+++ b/Tests/RepoPromptTests/MCP/MCPSelectionReplyFreshnessTests.swift
@@ -4,6 +4,19 @@ import XCTest
 
 @MainActor
 final class MCPSelectionReplyFreshnessTests: XCTestCase {
+    private var previousCodeMapsDisabled = false
+
+    override func setUp() {
+        super.setUp()
+        previousCodeMapsDisabled = GlobalSettingsStore.shared.globalCodeMapsDisabled()
+        GlobalSettingsStore.shared.setCodeMapsGloballyDisabled(false, commit: false)
+    }
+
+    override func tearDown() {
+        GlobalSettingsStore.shared.setCodeMapsGloballyDisabled(previousCodeMapsDisabled, commit: false)
+        super.tearDown()
+    }
+
     func testFullIssuePathReturnsAbsoluteForExactlyOneAuthorizedRoot() {
         let root = WorkspaceRootRef(id: UUID(), name: "Project", fullPath: "/workspace/project")
         let path = "/workspace/project/Sources/Missing.swift"
@@ -1020,6 +1033,174 @@ final class MCPSelectionReplyFreshnessTests: XCTestCase {
 
             await refreshGate.release()
             window.mcpServer.setBeforeVirtualTokenRefreshForTesting(nil)
+        }
+
+        func testBoundSliceReplyDoesNotReuseActivePublishedTokensForDifferentRanges() async throws {
+            let root = try makeTemporaryRoot(name: "BoundSlicePublishedOverlay")
+            defer { try? FileManager.default.removeItem(at: root.deletingLastPathComponent()) }
+            let fileURL = root.appendingPathComponent("Slice.swift")
+            let longLines = (0 ..< 12).map { index in
+                "    // bound slice line \(index) \(String(repeating: "token ", count: 20))"
+            }
+            let source = ([
+                "struct SliceTokenFixture {",
+                "    func activePublishedSlice() {}"
+            ] + longLines + [
+                "}"
+            ]).joined(separator: "\n") + "\n"
+            try write(source, to: fileURL)
+
+            let activeSelection = StoredSelection(
+                slices: [fileURL.path: [LineRange(start: 2, end: 2)]],
+                codemapAutoEnabled: false
+            )
+            let boundSelection = StoredSelection(
+                slices: [fileURL.path: [LineRange(start: 3, end: 14)]],
+                codemapAutoEnabled: false
+            )
+            let activeTabID = UUID()
+            let boundTabID = UUID()
+            let (window, workspaceID) = await makeWindow(
+                root: root,
+                tabID: activeTabID,
+                selection: activeSelection
+            )
+            defer { WindowStatesManager.shared.unregisterWindowState(window) }
+            let workspaceIndex = try XCTUnwrap(
+                window.workspaceManager.workspaces.firstIndex { $0.id == workspaceID }
+            )
+            window.workspaceManager.workspaces[workspaceIndex].composeTabs.append(
+                ComposeTabState(id: boundTabID, name: "Bound", selection: boundSelection)
+            )
+            _ = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(
+                in: window,
+                path: root.path
+            )
+            await window.promptManager.tokenCountingViewModel.forceImmediateRecount()
+
+            let activeContext = makeContext(
+                window: window,
+                workspaceID: workspaceID,
+                tabID: activeTabID,
+                selection: activeSelection
+            )
+            let activeReply = await window.mcpServer.buildCurrentSelectionReply(
+                includeBlocks: false,
+                display: .relative,
+                resolvedContext: MCPServerViewModel.ResolvedTabContextSnapshot(
+                    snapshot: activeContext,
+                    usesActiveTabCompatibility: true
+                ),
+                lookupContext: .visibleWorkspace
+            )
+            let activeFile = try XCTUnwrap(activeReply.files?.first)
+
+            let boundContext = makeContext(
+                window: window,
+                workspaceID: workspaceID,
+                tabID: boundTabID,
+                selection: boundSelection
+            )
+            let boundReply = await window.mcpServer.buildCurrentSelectionReply(
+                includeBlocks: false,
+                display: .relative,
+                resolvedContext: MCPServerViewModel.ResolvedTabContextSnapshot(
+                    snapshot: boundContext,
+                    usesActiveTabCompatibility: false
+                ),
+                lookupContext: .visibleWorkspace
+            )
+            let boundFile = try XCTUnwrap(boundReply.files?.first)
+
+            XCTAssertEqual(activeFile.renderMode, "slice")
+            XCTAssertEqual(boundFile.renderMode, "slice")
+            XCTAssertEqual(boundReply.tokenAccounting?.source, "bound_tab_cached_state")
+            XCTAssertTrue(boundReply.tokenAccounting?.incompleteComponents?.contains("files") == true)
+
+            for _ in 0 ..< 500 where window.mcpServer.virtualTokenRefreshTaskCountForTesting() > 0 {
+                try await Task.sleep(for: .milliseconds(10))
+            }
+
+            let refreshedReply = await window.mcpServer.buildCurrentSelectionReply(
+                includeBlocks: false,
+                display: .relative,
+                resolvedContext: MCPServerViewModel.ResolvedTabContextSnapshot(
+                    snapshot: boundContext,
+                    usesActiveTabCompatibility: false
+                ),
+                lookupContext: .visibleWorkspace
+            )
+            let refreshedFile = try XCTUnwrap(refreshedReply.files?.first)
+            XCTAssertGreaterThan(refreshedFile.tokens, activeFile.tokens)
+            XCTAssertEqual(refreshedReply.tokenAccounting?.source, "bound_tab_cache")
+            XCTAssertFalse(refreshedReply.tokenAccounting?.incompleteComponents?.contains("files") == true)
+
+            for _ in 0 ..< 500 where window.mcpServer.virtualTokenRefreshTaskCountForTesting() > 0 {
+                try await Task.sleep(for: .milliseconds(10))
+            }
+        }
+
+        func testBoundCacheHitReportsCurrentIncompleteComponents() async throws {
+            let root = try makeTemporaryRoot(name: "BoundCacheCurrentIncomplete")
+            defer { try? FileManager.default.removeItem(at: root.deletingLastPathComponent()) }
+            let fileURL = root.appendingPathComponent("Cached.swift")
+            try write(SwiftFixtureSource.emptyStruct("BoundCacheCurrentIncompleteType"), to: fileURL)
+
+            let tabID = UUID()
+            let selection = StoredSelection(selectedPaths: [fileURL.path])
+            let (window, workspaceID) = await makeWindow(root: root, tabID: tabID, selection: selection)
+            defer { WindowStatesManager.shared.unregisterWindowState(window) }
+            _ = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(
+                in: window,
+                path: root.path
+            )
+            await window.promptManager.tokenCountingViewModel.forceImmediateRecount()
+
+            let context = makeContext(
+                window: window,
+                workspaceID: workspaceID,
+                tabID: tabID,
+                selection: selection
+            )
+            let boundResolution = MCPServerViewModel.ResolvedTabContextSnapshot(
+                snapshot: context,
+                usesActiveTabCompatibility: false
+            )
+            _ = await window.mcpServer.buildCurrentSelectionReply(
+                includeBlocks: false,
+                display: .relative,
+                resolvedContext: boundResolution,
+                lookupContext: .visibleWorkspace
+            )
+            for _ in 0 ..< 100 where window.mcpServer.virtualTokenRefreshTaskCountForTesting() > 0 {
+                try await Task.sleep(for: .milliseconds(10))
+            }
+
+            let snapshots = try XCTUnwrap(window.mcpServer.mcpVirtualTokenSnapshotsByTabID[tabID])
+            let signature = try XCTUnwrap(snapshots.keys.first)
+            let snapshot = try XCTUnwrap(snapshots[signature])
+            window.mcpServer.mcpVirtualTokenSnapshotsByTabID[tabID]?[signature] = .init(
+                signature: snapshot.signature,
+                entryResultsByFileID: snapshot.entryResultsByFileID,
+                breakdown: snapshot.breakdown,
+                incompleteComponents: ["codemap_presentation"]
+            )
+
+            let cachedReply = await window.mcpServer.buildCurrentSelectionReply(
+                includeBlocks: false,
+                display: .relative,
+                resolvedContext: boundResolution,
+                lookupContext: .visibleWorkspace
+            )
+
+            XCTAssertEqual(cachedReply.tokenAccounting?.source, "bound_tab_cache")
+            XCTAssertEqual(cachedReply.tokenAccounting?.status, "stale")
+            XCTAssertTrue(cachedReply.tokenAccounting?.refreshPending == true)
+            XCTAssertFalse(cachedReply.tokenAccounting?.incompleteComponents?.contains("codemap_presentation") == true)
+
+            for _ in 0 ..< 100 where window.mcpServer.virtualTokenRefreshTaskCountForTesting() > 0 {
+                try await Task.sleep(for: .milliseconds(10))
+            }
         }
 
         func testBoundReplyUsesPublishedFileTokensWhileCodemapPresentationIsPending() async throws {

--- a/Tests/RepoPromptTests/Prompt/PromptContextAccountingServiceTests.swift
+++ b/Tests/RepoPromptTests/Prompt/PromptContextAccountingServiceTests.swift
@@ -346,6 +346,332 @@ final class PromptContextAccountingServiceTests: XCTestCase {
         #endif
     }
 
+    func testResolvedContentMetricsPreserveOrderIdentityAndAccountingSemantics() async throws {
+        let root = try makeTemporaryRoot(name: "ResolvedAccountingMetrics").resolvingSymlinksInPath().standardizedFileURL
+        let fullID = UUID()
+        let sliceID = UUID()
+        let rootID = UUID()
+        let fullContent = "let unicode = \"é🙂\"\nlet full = true\n"
+        let sliceContent = "skip\nslice one é\nslice two 🙂\nskip\n"
+        let sliceRanges = [LineRange(start: 2, end: 3)]
+        let contents = [
+            "Full.swift": fullContent,
+            "Slice.swift": sliceContent
+        ]
+        let recorder = ResolvedAccountingReaderRecorder(contents: contents)
+        let service = PromptContextAccountingService(resolvedContentReader: { location, workloadClass in
+            await recorder.read(location: location, workloadClass: workloadClass)
+        })
+        let entries = [
+            PromptContextResolvedContentMetricsEntry(
+                fileID: fullID,
+                rootID: rootID,
+                location: ResolvedFileContentLocation(
+                    resolvedRootURL: root,
+                    resolvedFileURL: root.appendingPathComponent("Full.swift"),
+                    relativePath: "Full.swift"
+                ),
+                renderedDisplayPath: "Logical/Full.swift",
+                lineRanges: nil
+            ),
+            PromptContextResolvedContentMetricsEntry(
+                fileID: sliceID,
+                rootID: rootID,
+                location: ResolvedFileContentLocation(
+                    resolvedRootURL: root,
+                    resolvedFileURL: root.appendingPathComponent("Slice.swift"),
+                    relativePath: "Slice.swift"
+                ),
+                renderedDisplayPath: "Logical/Slice.swift",
+                lineRanges: sliceRanges
+            )
+        ]
+
+        let snapshot = try await service.calculateEntryMetricsSnapshot(resolvedContentEntries: entries)
+
+        let inputs = await recorder.recordedInputs()
+        XCTAssertEqual(inputs.map(\.location.relativePath), ["Full.swift", "Slice.swift"])
+        XCTAssertEqual(inputs.map(\.workloadClass), [.promptAccounting, .promptAccounting])
+        let fullMetric = try XCTUnwrap(snapshot.metric(forFileID: fullID))
+        let sliceMetric = try XCTUnwrap(snapshot.metric(forFileID: sliceID))
+        let renderedSlice = SliceAssemblyBuilder.build(from: sliceContent, ranges: sliceRanges).combinedText
+        let expectedFullTokens = TokenCalculationService.estimateTokens(for: fullContent)
+        let expectedSliceTokens = TokenCalculationService.estimateTokens(for: renderedSlice)
+        let expectedTotal = expectedFullTokens + expectedSliceTokens
+        XCTAssertEqual(snapshot.totalSelectedDisplayTokens, expectedTotal)
+        XCTAssertEqual(fullMetric.standardizedFullPath, root.appendingPathComponent("Full.swift").path)
+        XCTAssertEqual(fullMetric.renderedDisplayPath, "Logical/Full.swift")
+        XCTAssertEqual(fullMetric.renderMode, .full)
+        XCTAssertEqual(fullMetric.displayTokenCount, expectedFullTokens)
+        XCTAssertEqual(fullMetric.displayPercentage, Double(expectedFullTokens) / Double(expectedTotal))
+        XCTAssertEqual(fullMetric.includedLineCount, 2)
+        XCTAssertEqual(sliceMetric.standardizedFullPath, root.appendingPathComponent("Slice.swift").path)
+        XCTAssertEqual(sliceMetric.renderedDisplayPath, "Logical/Slice.swift")
+        XCTAssertEqual(sliceMetric.renderMode, .slice)
+        XCTAssertEqual(sliceMetric.displayTokenCount, expectedSliceTokens)
+        XCTAssertEqual(sliceMetric.displayPercentage, Double(expectedSliceTokens) / Double(expectedTotal))
+        XCTAssertEqual(sliceMetric.includedLineCount, 2)
+    }
+
+    func testResolvedContentReadFailureThrowsWithoutPartialSnapshot() async throws {
+        let root = try makeTemporaryRoot(name: "ResolvedAccountingFailure").standardizedFileURL
+        let location = ResolvedFileContentLocation(
+            resolvedRootURL: root,
+            resolvedFileURL: root.appendingPathComponent("Failure.swift"),
+            relativePath: "Failure.swift"
+        )
+        let service = PromptContextAccountingService(resolvedContentReader: { _, _ in
+            throw ResolvedAccountingReaderError.failed
+        })
+
+        do {
+            _ = try await service.calculateEntryMetricsSnapshot(resolvedContentEntries: [
+                PromptContextResolvedContentMetricsEntry(
+                    fileID: UUID(),
+                    rootID: UUID(),
+                    location: location,
+                    renderedDisplayPath: "Failure.swift",
+                    lineRanges: nil
+                )
+            ])
+            XCTFail("Expected the resolved content read failure")
+        } catch ResolvedAccountingReaderError.failed {
+            // Expected
+        }
+    }
+
+    func testResolvedContentNilThrowsWithoutPartialSnapshot() async throws {
+        let root = try makeTemporaryRoot(name: "ResolvedAccountingUnavailable").standardizedFileURL
+        let location = ResolvedFileContentLocation(
+            resolvedRootURL: root,
+            resolvedFileURL: root.appendingPathComponent("Unavailable.swift"),
+            relativePath: "Unavailable.swift"
+        )
+        let service = PromptContextAccountingService(resolvedContentReader: { _, _ in nil })
+
+        do {
+            _ = try await service.calculateEntryMetricsSnapshot(resolvedContentEntries: [
+                PromptContextResolvedContentMetricsEntry(
+                    fileID: UUID(),
+                    rootID: UUID(),
+                    location: location,
+                    renderedDisplayPath: "Unavailable.swift",
+                    lineRanges: nil
+                )
+            ])
+            XCTFail("Expected unavailable resolved content to fail accounting")
+        } catch let error as PromptContextResolvedContentAccountingError {
+            XCTAssertEqual(error, .contentUnavailable(location))
+        }
+    }
+
+    func testResolvedContentCancellationBeforeFirstEntryStopsReads() async throws {
+        let root = try makeTemporaryRoot(name: "ResolvedAccountingCancelledBefore").standardizedFileURL
+        let location = ResolvedFileContentLocation(
+            resolvedRootURL: root,
+            resolvedFileURL: root.appendingPathComponent("Unread.swift"),
+            relativePath: "Unread.swift"
+        )
+        let recorder = ResolvedAccountingReaderRecorder(contents: ["Unread.swift": "unreachable"])
+        let service = PromptContextAccountingService(resolvedContentReader: { location, workloadClass in
+            await recorder.read(location: location, workloadClass: workloadClass)
+        })
+        let task = Task {
+            withUnsafeCurrentTask { $0?.cancel() }
+            return try await service.calculateEntryMetricsSnapshot(resolvedContentEntries: [
+                PromptContextResolvedContentMetricsEntry(
+                    fileID: UUID(),
+                    rootID: UUID(),
+                    location: location,
+                    renderedDisplayPath: "Unread.swift",
+                    lineRanges: nil
+                )
+            ])
+        }
+
+        do {
+            _ = try await task.value
+            XCTFail("Expected cancellation before the first read")
+        } catch is CancellationError {
+            // Expected
+        }
+        let inputs = await recorder.recordedInputs()
+        XCTAssertTrue(inputs.isEmpty)
+    }
+
+    func testResolvedContentCancellationAfterLastEntryThrowsWithoutSnapshot() async throws {
+        let root = try makeTemporaryRoot(name: "ResolvedAccountingCancelledAfter").standardizedFileURL
+        let location = ResolvedFileContentLocation(
+            resolvedRootURL: root,
+            resolvedFileURL: root.appendingPathComponent("Read.swift"),
+            relativePath: "Read.swift"
+        )
+        let recorder = ResolvedAccountingReaderRecorder(contents: ["Read.swift": "let read = true\n"])
+        let service = PromptContextAccountingService(resolvedContentReader: { location, workloadClass in
+            let content = await recorder.read(location: location, workloadClass: workloadClass)
+            withUnsafeCurrentTask { $0?.cancel() }
+            return content
+        })
+
+        do {
+            _ = try await service.calculateEntryMetricsSnapshot(resolvedContentEntries: [
+                PromptContextResolvedContentMetricsEntry(
+                    fileID: UUID(),
+                    rootID: UUID(),
+                    location: location,
+                    renderedDisplayPath: "Read.swift",
+                    lineRanges: nil
+                )
+            ])
+            XCTFail("Expected cancellation after the final resolved read")
+        } catch is CancellationError {
+            // Expected
+        }
+        let inputs = await recorder.recordedInputs()
+        XCTAssertEqual(inputs.map(\.location.relativePath), ["Read.swift"])
+    }
+
+    func testResolvedAndStoreBackedReadersDecodeSmallNonUTF8FileIdentically() async throws {
+        let root = try makeTemporaryRoot(name: "ResolvedAccountingDecoding").standardizedFileURL
+        let fileURL = root.appendingPathComponent("Encoded.txt")
+        try Data([0x63, 0x61, 0x66, 0xE9, 0x0A]).write(to: fileURL)
+        let store = WorkspaceFileContextStore()
+        let loadedRoot = try await store.loadRoot(path: root.path)
+
+        let storeContent = try await store.readContent(rootID: loadedRoot.id, relativePath: "Encoded.txt")
+        let resolvedContent = try await FileSystemService.loadEntireFileContentOptimized(
+            at: ResolvedFileContentLocation(
+                resolvedRootURL: root,
+                resolvedFileURL: fileURL,
+                relativePath: "Encoded.txt"
+            ),
+            workloadClass: .promptAccounting
+        )
+
+        XCTAssertNotNil(storeContent)
+        XCTAssertEqual(resolvedContent, storeContent)
+    }
+
+    func testEntryMetricsSnapshotCountsIncludedLinesForFullSlicesAndCodemaps() async throws {
+        let root = try makeTemporaryRoot(name: "AccountingEntryMetrics")
+        let fullURL = root.appendingPathComponent("Full.swift")
+        let sliceURL = root.appendingPathComponent("Slice.swift")
+        let codemapURL = root.appendingPathComponent("Codemap.swift")
+        let fullContent = "full one\r\nfull two\nfull three"
+        let sliceContent = "skip\nslice one\r\nslice two\nskip"
+        try write(fullContent, to: fullURL)
+        try write(sliceContent, to: sliceURL)
+        try write("struct CodemapOnly { func rendered() {} }", to: codemapURL)
+
+        let store = WorkspaceFileContextStore()
+        _ = try await store.loadRoot(path: root.path)
+        let codemapLookup = await store.lookupPath(codemapURL.path)
+        let codemapFile = try XCTUnwrap(codemapLookup?.file)
+        let renderedCodemap = makeSyntaxArtifact(
+            path: codemapURL.path,
+            symbolName: "renderedMetricSentinel",
+            imports: ["Foundation"]
+        )
+        .renderedCodeMap(displayPath: "Codemap.swift")
+        let presentation = try makePresentation(entries: [(codemapFile, renderedCodemap)])
+
+        let sliceRange = LineRange(start: 2, end: 3)
+        let result = await PromptContextAccountingService().calculatePromptStats(
+            request: PromptContextAccountingRequest(
+                selection: StoredSelection(
+                    selectedPaths: [fullURL.path, sliceURL.path],
+                    slices: [sliceURL.path: [sliceRange]],
+                    codemapAutoEnabled: true
+                ),
+                codeMapUsage: .auto,
+                filePathDisplay: .relative
+            ),
+            store: store,
+            codemapPresentation: presentation
+        )
+
+        let fullEntry = try XCTUnwrap(
+            result.resolvedEntries.first { $0.file.standardizedFullPath == fullURL.standardizedFileURL.path }
+        )
+        let sliceEntry = try XCTUnwrap(
+            result.resolvedEntries.first { $0.file.standardizedFullPath == sliceURL.standardizedFileURL.path }
+        )
+        let codemapEntry = try XCTUnwrap(
+            result.resolvedEntries.first { $0.file.standardizedFullPath == codemapURL.standardizedFileURL.path }
+        )
+        let sliceAssembly = FileViewModel.buildSliceAssembly(from: sliceContent, ranges: [sliceRange])
+        let expectedFullTokens = TokenCalculationService.estimateTokens(for: fullContent)
+        let expectedSliceTokens = TokenCalculationService.estimateTokens(for: sliceAssembly.combinedText)
+        let expectedCodemapTokens = TokenCalculationService.estimateTokens(for: renderedCodemap)
+        let expectedTotal = expectedFullTokens + expectedSliceTokens + expectedCodemapTokens
+        let metrics = result.entryMetricsSnapshot
+        let rowEntryMetrics = await PromptContextAccountingService().calculateEntryMetricsSnapshot(
+            entries: result.resolvedEntries.map { entry in
+                ResolvedPromptFileEntry(
+                    file: entry.file,
+                    isCodemap: entry.isCodemap,
+                    lineRanges: entry.lineRanges,
+                    mode: entry.mode,
+                    loadedContent: nil,
+                    rootFolderPath: entry.rootFolderPath,
+                    role: entry.role
+                )
+            },
+            store: store,
+            codemapPresentation: presentation,
+            filePathDisplay: .relative
+        )
+
+        XCTAssertEqual(rowEntryMetrics, metrics)
+        XCTAssertEqual(metrics.totalSelectedDisplayTokens, expectedTotal)
+        XCTAssertEqual(result.tokenResult.entryResultsByFileID.count, 3)
+        XCTAssertEqual(WorkspaceTextLineCounter.countLines(in: ""), 0)
+        XCTAssertEqual(WorkspaceTextLineCounter.countLines(in: "a\r\nb\rc\n"), 3)
+
+        let fullMetric = try XCTUnwrap(metrics.metric(forFileID: fullEntry.file.id))
+        XCTAssertEqual(fullMetric.standardizedFullPath, fullURL.standardizedFileURL.path)
+        XCTAssertEqual(fullMetric.renderedDisplayPath, "Full.swift")
+        XCTAssertEqual(
+            metrics.metric(forStandardizedFullPath: fullURL.standardizedFileURL.path)?.fileID,
+            fullEntry.file.id
+        )
+        XCTAssertEqual(fullMetric.renderMode, .full)
+        XCTAssertEqual(fullMetric.displayTokenCount, expectedFullTokens)
+        XCTAssertEqual(fullMetric.includedLineCount, 3)
+        XCTAssertEqual(
+            fullMetric.displayPercentage,
+            Double(expectedFullTokens) / Double(expectedTotal),
+            accuracy: 0.000_000_000_001
+        )
+
+        let sliceMetric = try XCTUnwrap(metrics.metric(forFileID: sliceEntry.file.id))
+        XCTAssertEqual(sliceMetric.standardizedFullPath, sliceURL.standardizedFileURL.path)
+        XCTAssertEqual(sliceMetric.renderedDisplayPath, "Slice.swift")
+        XCTAssertEqual(sliceMetric.renderMode, .slice)
+        XCTAssertEqual(sliceMetric.displayTokenCount, expectedSliceTokens)
+        XCTAssertEqual(sliceMetric.includedLineCount, 2)
+        XCTAssertEqual(
+            sliceMetric.displayPercentage,
+            Double(expectedSliceTokens) / Double(expectedTotal),
+            accuracy: 0.000_000_000_001
+        )
+
+        let codemapMetric = try XCTUnwrap(metrics.metric(forFileID: codemapEntry.file.id))
+        XCTAssertEqual(codemapMetric.standardizedFullPath, codemapURL.standardizedFileURL.path)
+        XCTAssertEqual(codemapMetric.renderedDisplayPath, "Codemap.swift")
+        XCTAssertEqual(codemapMetric.renderMode, .codemap)
+        XCTAssertEqual(codemapMetric.displayTokenCount, expectedCodemapTokens)
+        XCTAssertEqual(
+            codemapMetric.includedLineCount,
+            WorkspaceTextLineCounter.countLines(in: renderedCodemap)
+        )
+        XCTAssertEqual(
+            codemapMetric.displayPercentage,
+            Double(expectedCodemapTokens) / Double(expectedTotal),
+            accuracy: 0.000_000_000_001
+        )
+    }
+
     func testCodemapAccountingCountsExactRenderedHeaderAndImports() async throws {
         let root = try makeTemporaryRoot(name: "AccountingRenderedCodemapTokens")
         let fileURL = root.appendingPathComponent("Nested/Target.swift")
@@ -549,6 +875,36 @@ final class PromptContextAccountingServiceTests: XCTestCase {
             issues: [],
             publicationReceipt: nil
         )
+    }
+}
+
+private enum ResolvedAccountingReaderError: Error {
+    case failed
+}
+
+private actor ResolvedAccountingReaderRecorder {
+    struct Input {
+        let location: ResolvedFileContentLocation
+        let workloadClass: ContentReadWorkloadClass
+    }
+
+    private let contents: [String: String]
+    private var inputs: [Input] = []
+
+    init(contents: [String: String]) {
+        self.contents = contents
+    }
+
+    func read(
+        location: ResolvedFileContentLocation,
+        workloadClass: ContentReadWorkloadClass
+    ) -> String? {
+        inputs.append(Input(location: location, workloadClass: workloadClass))
+        return contents[location.relativePath]
+    }
+
+    func recordedInputs() -> [Input] {
+        inputs
     }
 }
 

--- a/Tests/RepoPromptTests/Prompt/PromptContextPreAssemblyServiceTests.swift
+++ b/Tests/RepoPromptTests/Prompt/PromptContextPreAssemblyServiceTests.swift
@@ -30,6 +30,20 @@ final class PromptContextPreAssemblyServiceTests: XCTestCase {
         }
     }
 
+    private actor InvocationCounter {
+        private var value = 0
+
+        @discardableResult
+        func increment() -> Int {
+            value += 1
+            return value
+        }
+
+        func count() -> Int {
+            value
+        }
+    }
+
     private actor FinalPackagingRetryTrace {
         struct Snapshot: Equatable {
             let operationCount: Int
@@ -185,6 +199,35 @@ final class PromptContextPreAssemblyServiceTests: XCTestCase {
         }
     }
 
+    func testResolveFullFileTreeIncludesRootsWhenSelectionIsEmptyAndRootFilteringEnabled() async throws {
+        let root = try makeTemporaryRoot(name: "PromptPreAssemblyFullTreeEmptySelection")
+        let sourceURL = root.appendingPathComponent("Sources/App.swift")
+        try FileSystemTestSupport.write("let fullTreeEmptySelectionSentinel = true\n", to: sourceURL)
+
+        let store = WorkspaceFileContextStore()
+        _ = try await store.loadRoot(path: root.path)
+        let request = PromptContextPreAssemblyRequest(
+            cfg: makeConfig(gitInclusion: .none, fileTreeMode: .files),
+            selection: StoredSelection(),
+            store: store,
+            lookupContext: WorkspaceLookupContext(rootScope: .allLoaded, bindingProjection: nil),
+            filePathDisplay: .relative,
+            onlyIncludeRootsWithSelectedFiles: true,
+            showCodeMapMarkers: true,
+            selectedGitDiffFolderPolicy: .filesOnly,
+            reviewGitContext: .automaticOnly(),
+            selectedGitDiffProvider: { _ in Self.automaticResult(nil) },
+            completeGitDiffProvider: { nil }
+        )
+
+        let result = await PromptContextPreAssemblyService.resolve(request)
+
+        let fileTreeContent = try XCTUnwrap(result.fileTreeContent)
+        XCTAssertTrue(fileTreeContent.contains(root.lastPathComponent), fileTreeContent)
+        XCTAssertTrue(fileTreeContent.contains("Sources"), fileTreeContent)
+        XCTAssertTrue(fileTreeContent.contains("App.swift"), fileTreeContent)
+    }
+
     func testResolveSelectedDiffUsesPhysicalizedSelectionAndPolicy() async throws {
         let fixture = try await makeBoundFixture()
         let captured = CapturedPaths()
@@ -215,6 +258,62 @@ final class PromptContextPreAssemblyServiceTests: XCTestCase {
             fixture.worktreeRoot.appendingPathComponent("Sources/Keep.swift").standardizedFileURL.path
         ]))
         XCTAssertFalse(paths.contains(fixture.logicalRoot.appendingPathComponent("Sources/App.swift").standardizedFileURL.path))
+    }
+
+    func testSelectedGitDiffClipboardUsesSelectedContextPathsOnly() async throws {
+        let fixture = try await makeBoundFixture()
+        let captured = CapturedPaths()
+        let completeProvider = InvocationCounter()
+        let selectedDiff = "diff --git a/Sources/App.swift b/Sources/App.swift\n+let selectedGitSentinel = true"
+        let request = PromptContextPreAssemblyRequest(
+            cfg: makeConfig(gitInclusion: .selected),
+            selection: StoredSelection(selectedPaths: ["Sources/App.swift"], codemapAutoEnabled: false),
+            store: fixture.store,
+            lookupContext: fixture.lookupContext,
+            filePathDisplay: .relative,
+            onlyIncludeRootsWithSelectedFiles: true,
+            showCodeMapMarkers: true,
+            selectedGitDiffFolderPolicy: .filesOnly,
+            selectedGitDiffLookupProfile: .uiAssisted,
+            reviewGitContext: .automaticOnly(),
+            selectedGitDiffProvider: { automaticRequest in
+                await captured.set(automaticRequest.pathResolution.paths)
+                return Self.automaticResult(selectedDiff)
+            },
+            completeGitDiffProvider: {
+                await completeProvider.increment()
+                return "complete diff must not appear"
+            }
+        )
+
+        let result = await PromptContextPreAssemblyService.resolve(request)
+        let clipboard = await PromptPackagingService.generateClipboardContent(
+            metaInstructions: [],
+            userInstructions: "",
+            files: result.entries,
+            fileTreeContent: result.fileTreeContent,
+            gitDiff: result.gitDiff,
+            includeSavedPrompts: false,
+            includeFiles: true,
+            includeUserPrompt: false,
+            filePathDisplay: .relative,
+            codemapPresentation: result.codemapPresentation,
+            promptSectionsOrder: PromptAssemblyBuilder.defaultSectionOrder,
+            disabledPromptSections: [],
+            duplicateUserInstructionsAtTop: false,
+            displayPathResolver: { entry in
+                result.displayPath(for: entry)
+            }
+        )
+        let paths = await captured.get()
+
+        let completeProviderInvocationCount = await completeProvider.count()
+
+        XCTAssertEqual(paths, [fixture.worktreeRoot.appendingPathComponent("Sources/App.swift").standardizedFileURL.path])
+        XCTAssertTrue(clipboard.contains("<git_diff>"), clipboard)
+        XCTAssertTrue(clipboard.contains("selectedGitSentinel"), clipboard)
+        XCTAssertFalse(clipboard.contains("complete diff must not appear"), clipboard)
+        XCTAssertEqual(completeProviderInvocationCount, 0)
     }
 
     func testCanonicalAutoCodemapsDrivePreassemblyAndClipboardWithoutHiddenRediscovery() async throws {
@@ -510,7 +609,10 @@ final class PromptContextPreAssemblyServiceTests: XCTestCase {
             )
             let gate = PreAssemblyContentReadGate()
             let task = Task {
-                try await PromptContextPreAssemblyService.withResolved(request) { _ in
+                try await PromptContextPreAssemblyService.withResolved(
+                    request,
+                    codemapPresentation: .empty
+                ) { _ in
                     await gate.markStartedAndWaitForRelease()
                     try Task.checkCancellation()
                     return "must-not-publish"
@@ -1155,6 +1257,7 @@ final class PromptContextPreAssemblyServiceTests: XCTestCase {
 
     private func makeConfig(
         gitInclusion: GitInclusion,
+        fileTreeMode: FileTreeOption = .auto,
         codeMapUsage: CodeMapUsage = .none
     ) -> PromptContextResolved {
         PromptContextResolved(
@@ -1162,7 +1265,7 @@ final class PromptContextPreAssemblyServiceTests: XCTestCase {
             includeUserPrompt: true,
             includeMetaPrompts: false,
             includeFileTree: true,
-            fileTreeMode: .auto,
+            fileTreeMode: fileTreeMode,
             codeMapUsage: codeMapUsage,
             gitInclusion: gitInclusion,
             storedPromptIds: []

--- a/Tests/RepoPromptTests/Prompt/TokenCountingViewModelTests.swift
+++ b/Tests/RepoPromptTests/Prompt/TokenCountingViewModelTests.swift
@@ -1,0 +1,187 @@
+@testable import RepoPromptApp
+import XCTest
+
+@MainActor
+final class TokenCountingViewModelTests: XCTestCase {
+    func testExpectedSelectionForPublishedSnapshotMatchesCompletedSnapshotAcrossSelectionModes() async {
+        let activeSelection = StoredSelection(selectedPaths: ["/tmp/RepoPromptTests/Active.swift"])
+
+        await assertPublishedSnapshotReady(
+            includeFiles: false,
+            providedSelection: activeSelection,
+            expectedSelection: StoredSelection(),
+            fileManager: WorkspaceFilesViewModel()
+        )
+
+        await assertPublishedSnapshotReady(
+            includeFiles: true,
+            providedSelection: activeSelection,
+            expectedSelection: activeSelection,
+            fileManager: WorkspaceFilesViewModel()
+        )
+
+        let fallbackFileManager = makeFallbackFileManager()
+        let fallbackSelection = fallbackFileManager.snapshotSelection()
+        XCTAssertFalse(fallbackSelection.selectedPaths.isEmpty)
+        await assertPublishedSnapshotReady(
+            includeFiles: true,
+            providedSelection: nil,
+            expectedSelection: fallbackSelection,
+            fileManager: fallbackFileManager
+        )
+    }
+
+    func testExpectedSelectionRetargetsChangedSelectionBeforeRecountCompletes() async {
+        let oldSelection = StoredSelection(selectedPaths: ["/tmp/RepoPromptTests/Old.swift"])
+        let newSelection = StoredSelection(selectedPaths: ["/tmp/RepoPromptTests/New.swift"])
+        let fileManager = WorkspaceFilesViewModel()
+        var currentSelection = oldSelection
+        let tokenCounter = makeTokenCounter(
+            includeFiles: true,
+            fileManager: fileManager,
+            getStoredSelection: { currentSelection }
+        )
+
+        let oldBlankingSelection = tokenCounter.currentExpectedSelectionForPublishedSnapshot()
+        XCTAssertEqual(oldBlankingSelection, oldSelection)
+        await tokenCounter.forceImmediateRecount()
+
+        currentSelection = newSelection
+        let retargetedBlankingSelection = tokenCounter.currentExpectedSelectionForPublishedSnapshot()
+        XCTAssertEqual(retargetedBlankingSelection, newSelection)
+        let pendingNewSnapshot = tokenCounter.latestPublishedTokenSnapshot(
+            for: retargetedBlankingSelection,
+            scheduleRefreshIfNeeded: false
+        )
+        XCTAssertTrue(pendingNewSnapshot.isStale)
+        XCTAssertTrue(pendingNewSnapshot.refreshPending)
+
+        await tokenCounter.forceImmediateRecount()
+
+        let newSnapshot = tokenCounter.latestPublishedTokenSnapshot(
+            for: retargetedBlankingSelection,
+            scheduleRefreshIfNeeded: false
+        )
+        XCTAssertTrue(newSnapshot.isComplete)
+        XCTAssertFalse(newSnapshot.isStale)
+        XCTAssertFalse(newSnapshot.refreshPending)
+        let oldSnapshot = tokenCounter.latestPublishedTokenSnapshot(
+            for: oldBlankingSelection,
+            scheduleRefreshIfNeeded: false
+        )
+        XCTAssertTrue(oldSnapshot.isStale)
+        await tokenCounter.stopTokenCountUpdateTimer()
+    }
+
+    private func assertPublishedSnapshotReady(
+        includeFiles: Bool,
+        providedSelection: StoredSelection?,
+        expectedSelection: StoredSelection,
+        fileManager: WorkspaceFilesViewModel
+    ) async {
+        let tokenCounter = makeTokenCounter(
+            includeFiles: includeFiles,
+            providedSelection: providedSelection,
+            fileManager: fileManager
+        )
+        let blankingSelection = tokenCounter.currentExpectedSelectionForPublishedSnapshot()
+        XCTAssertEqual(blankingSelection, expectedSelection)
+
+        await tokenCounter.forceImmediateRecount()
+
+        let snapshot = tokenCounter.latestPublishedTokenSnapshot(
+            for: blankingSelection,
+            scheduleRefreshIfNeeded: false
+        )
+        XCTAssertTrue(snapshot.isComplete)
+        XCTAssertFalse(snapshot.isStale)
+        XCTAssertFalse(snapshot.refreshPending)
+        await tokenCounter.stopTokenCountUpdateTimer()
+    }
+
+    private func makeTokenCounter(
+        includeFiles: Bool,
+        providedSelection: StoredSelection?,
+        fileManager: WorkspaceFilesViewModel
+    ) -> TokenCountingViewModel {
+        makeTokenCounter(
+            includeFiles: includeFiles,
+            fileManager: fileManager,
+            getStoredSelection: { providedSelection }
+        )
+    }
+
+    private func makeTokenCounter(
+        includeFiles: Bool,
+        fileManager: WorkspaceFilesViewModel,
+        getStoredSelection: @escaping @MainActor () -> StoredSelection?
+    ) -> TokenCountingViewModel {
+        let tokenCounter = TokenCountingViewModel()
+        let gitViewModel = GitViewModel(
+            fileManager: fileManager,
+            gitContextRefreshIntervalNanoseconds: 0
+        )
+        tokenCounter.configure(
+            fileManager: fileManager,
+            gitViewModel: gitViewModel,
+            getPromptText: { "" },
+            getSelectedInstructionsText: { "" },
+            getSettings: {
+                TokenCountingViewModel.TokenCalculationSettings(
+                    fileTreeOption: .none,
+                    codeMapUsage: .none,
+                    filePathDisplayOption: .relative,
+                    includeFilesInClipboard: includeFiles,
+                    duplicateUserInstructionsAtTop: false,
+                    onlyIncludeRootsWithSelectedFiles: false,
+                    codeMapsGloballyDisabled: false
+                )
+            },
+            getCopyContext: {
+                TokenCountingViewModel.CopyContextSnapshot(
+                    includeFiles: includeFiles,
+                    includeUserPrompt: false,
+                    includeMetaPrompts: false,
+                    includeFileTree: false,
+                    fileTreeMode: .none,
+                    codeMapUsage: .none,
+                    gitInclusion: .none,
+                    duplicateUserInstructionsAtTop: false
+                )
+            },
+            getStoredSelection: getStoredSelection
+        )
+        tokenCounter.suspendAutomaticRecounts()
+        return tokenCounter
+    }
+
+    private func makeFallbackFileManager() -> WorkspaceFilesViewModel {
+        let rootURL = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("TokenCountingViewModelTests", isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let root = FolderViewModel(
+            folder: Folder(name: "FixtureRoot", path: rootURL.path, modificationDate: Date(timeIntervalSince1970: 1000)),
+            rootPath: rootURL.path,
+            isExpanded: true
+        )
+        let file = FileViewModel(
+            file: File(
+                name: "Fallback.swift",
+                path: rootURL.appendingPathComponent("Fallback.swift").path,
+                modificationDate: Date(timeIntervalSince1970: 1000)
+            ),
+            rootPath: rootURL.path,
+            hierarchyLevel: 1,
+            rootIdentifier: root.id,
+            rootFolderPath: rootURL.path,
+            fileSystemService: nil,
+            parentFolder: root
+        )
+        root.addChildrenBatch([.file(file)])
+
+        let fileManager = WorkspaceFilesViewModel()
+        fileManager.registerRootFolderForTesting(root)
+        fileManager.selectFileForTesting(file)
+        return fileManager
+    }
+}

--- a/Tests/RepoPromptTests/WorkspaceContext/CodemapBindingEngineWarmManifestTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/CodemapBindingEngineWarmManifestTests.swift
@@ -470,6 +470,133 @@ final class CodemapBindingEngineWarmManifestTests: CodemapBindingEngineTestCase 
         XCTAssertEqual(accounting.counters.overlayReadyPublications, 0)
     }
 
+    func testSourceAuthorityDemandSurvivesOrdinaryGitChurnAfterRegistration() async throws {
+        enum FileState: String, CaseIterable {
+            case cleanTracked = "clean"
+            case unstagedTracked = "unstaged"
+            case stagedAndUnstagedTracked = "staged+unstaged"
+            case unrelatedStagedNoise = "unrelated staged noise"
+        }
+
+        enum GitChurn: String, CaseIterable {
+            case none
+            case gitStatusRefresh = "git status"
+            case gitAddUnrelated = "git add unrelated"
+            case gitAddDemandedFile = "git add demanded"
+            case gitCommitStagedChanges = "git commit staged changes"
+            case gitBranchSwitchBack = "git checkout branch and back"
+            case gitConfigWrite = "git config write"
+            case untrackedFileNoStage = "untracked file no stage"
+            case gitInfoAttributesWrite = "git info attributes write"
+            case configuredAttributesFileWrite = "configured attributes file write"
+
+            var cleanOnly: Bool {
+                switch self {
+                case .none, .gitStatusRefresh, .gitAddUnrelated, .gitAddDemandedFile:
+                    false
+                case .gitCommitStagedChanges, .gitBranchSwitchBack, .gitConfigWrite, .untrackedFileNoStage,
+                     .gitInfoAttributesWrite, .configuredAttributesFileWrite:
+                    true
+                }
+            }
+        }
+
+        let targetPath = "Sources/Target.swift"
+
+        for state in FileState.allCases {
+            for churn in GitChurn.allCases where !churn.cleanOnly || state == .cleanTracked {
+                let repository = try makeRepositoryFixture(name: "\(#function)-\(state.rawValue)-\(churn.rawValue)")
+                let root = try repository.makeRepository(
+                    named: "repository",
+                    files: [
+                        targetPath: "struct Target { let value = 1 }\n",
+                        "Sources/Existing.swift": "struct Existing {}\n"
+                    ]
+                )
+                switch state {
+                case .cleanTracked:
+                    break
+                case .unstagedTracked:
+                    try repository.write("struct Target { let unstaged = true }\n", to: targetPath, at: root)
+                case .stagedAndUnstagedTracked:
+                    try repository.write("struct Target { let staged = true }\n", to: targetPath, at: root)
+                    try repository.stage(targetPath, at: root)
+                    try repository.write("struct Target { let unstaged = true }\n", to: targetPath, at: root)
+                case .unrelatedStagedNoise:
+                    try repository.write("struct Noise { let staged = true }\n", to: "Sources/Noise.swift", at: root)
+                    try repository.stage("Sources/Noise.swift", at: root)
+                }
+                if churn == .configuredAttributesFileWrite {
+                    let configuredAttributes = root.appendingPathComponent("source-authority.attributes")
+                    try "*.swift text eol=lf\n".write(to: configuredAttributes, atomically: true, encoding: .utf8)
+                    _ = try repository.runGit(["config", "core.attributesFile", configuredAttributes.path], at: root)
+                }
+
+                let runtime = try CodeMapArtifactRuntime(
+                    rootURL: makeSecureDirectory(in: repository.sandbox, named: "artifacts")
+                )
+                let fixture = try await makeEngineFixture(root: root, runtime: runtime)
+                guard case .registered = await fixture.engine.registerRoot(fixture.registration) else {
+                    return XCTFail("Expected registration for \(state.rawValue) / \(churn.rawValue).")
+                }
+
+                switch churn {
+                case .none:
+                    break
+                case .gitStatusRefresh:
+                    _ = try repository.runGit(["status", "--porcelain=v1", "--untracked-files=all"], at: root)
+                case .gitAddUnrelated:
+                    try repository.write("struct Churn { let staged = true }\n", to: "Sources/Churn.swift", at: root)
+                    try repository.stage("Sources/Churn.swift", at: root)
+                case .gitAddDemandedFile:
+                    try repository.stage(targetPath, at: root)
+                case .gitCommitStagedChanges:
+                    try repository.write("struct CommitChurn { let staged = true }\n", to: "Sources/CommitChurn.swift", at: root)
+                    try repository.stage("Sources/CommitChurn.swift", at: root)
+                    try repository.commit("Commit churn", at: root)
+                case .gitBranchSwitchBack:
+                    _ = try repository.runGit(["checkout", "-b", "scratch-branch"], at: root)
+                    _ = try repository.runGit(["checkout", "main"], at: root)
+                case .gitConfigWrite:
+                    _ = try repository.runGit(["config", "user.email", "repoprompt@example.test"], at: root)
+                case .untrackedFileNoStage:
+                    try repository.write("struct UntrackedChurn {}\n", to: "Sources/UntrackedChurn.swift", at: root)
+                case .gitInfoAttributesWrite:
+                    try repository.write("*.swift text eol=lf\n", to: ".git/info/attributes", at: root)
+                case .configuredAttributesFileWrite:
+                    let configuredAttributes = root.appendingPathComponent("source-authority.attributes")
+                    try "*.swift text eol=crlf\n".write(to: configuredAttributes, atomically: true, encoding: .utf8)
+                }
+
+                let classificationBatch = await GitBlobIdentityService().classify(
+                    workspaceRoot: root,
+                    relativePaths: [targetPath]
+                )
+                let classification = try XCTUnwrap(classificationBatch.classifications.first)
+                let capability = try await eligible(fixture.capabilityService.state(for: fixture.rootEpoch))
+                let directSourceAuthority = try await fixture.capabilityService.makeSourceAuthority(
+                    capability: capability,
+                    observedRootEpoch: fixture.rootEpoch,
+                    observedRepositoryAuthority: capability.repositoryAuthority,
+                    candidateRepositoryRelativePath: XCTUnwrap(classification.repositoryRelativePath),
+                    observedPathGeneration: 1,
+                    currentPathGeneration: 1,
+                    observedIngressGeneration: 1,
+                    currentIngressGeneration: 1
+                )
+                XCTAssertNotNil(
+                    directSourceAuthority,
+                    "Expected source authority after \(state.rawValue) / \(churn.rawValue)."
+                )
+                let result = await fixture.engine.demand(fixture.demand(path: targetPath))
+                guard isReady(result) else {
+                    return XCTFail("Expected ready demand after \(state.rawValue) / \(churn.rawValue), got \(result).")
+                }
+                await fixture.engine.unloadRoot(rootEpoch: fixture.rootEpoch)
+            }
+        }
+    }
+
     func testPathInvalidationDuringBlockedWarmAdoptionRemainsRetryable() async throws {
         let repository = try makeRepositoryFixture(name: #function)
         let root = try repository.makeRepository(

--- a/Tests/RepoPromptTests/WorkspaceContext/WorkspaceCodemapGitCapabilityServiceTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/WorkspaceCodemapGitCapabilityServiceTests.swift
@@ -607,6 +607,209 @@ final class WorkspaceCodemapGitCapabilityServiceTests: XCTestCase {
         XCTAssertNotEqual(afterNestedAttributes.candidateAttributeGeneration, accepted.candidateAttributeGeneration)
     }
 
+    func testSourceAuthoritySurvivesRootWideGitChurn() async throws {
+        let fixture = try ReviewGitRepositoryFixture(name: #function)
+        let root = try fixture.makeRepository(named: "repository")
+        let path = "Sources/Feature.swift"
+        let service = WorkspaceCodemapGitCapabilityService(namespaceSalt: namespaceSalt)
+        let rootCapability = try await capability(service.resolve(root: request(for: root, seed: 56)))
+        let pathFingerprint = try fingerprint(at: root.appendingPathComponent(path))
+
+        let acceptedCandidate = await sourceAuthority(
+            service: service,
+            capability: rootCapability,
+            path: path
+        )
+        let accepted = try XCTUnwrap(acceptedCandidate)
+        XCTAssertEqual(accepted.acceptedPostPathFingerprint, pathFingerprint)
+
+        let indexURL = root.appendingPathComponent(".git/index")
+        let beforeIndexDescriptorUpdate = try fingerprint(at: indexURL)
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSinceNow: 3600)],
+            ofItemAtPath: indexURL.path
+        )
+        let afterIndexDescriptorUpdateFingerprint = try fingerprint(at: indexURL)
+        XCTAssertNotEqual(afterIndexDescriptorUpdateFingerprint, beforeIndexDescriptorUpdate)
+        await assertSourceAuthorityAvailable(service: service, capability: rootCapability, path: path)
+
+        _ = try fixture.runGit(["status", "--porcelain=v1", "--untracked-files=all"], at: root)
+        await assertSourceAuthorityAvailable(service: service, capability: rootCapability, path: path)
+
+        try fixture.write("let unrelatedCommit = true\n", to: "Sources/UnrelatedCommit.swift", at: root)
+        try fixture.stage("Sources/UnrelatedCommit.swift", at: root)
+        try fixture.commit("Unrelated source authority churn", at: root)
+        await assertSourceAuthorityAvailable(service: service, capability: rootCapability, path: path)
+
+        _ = try fixture.runGit(["checkout", "-b", "source-authority-branch"], at: root)
+        _ = try fixture.runGit(["checkout", "main"], at: root)
+        await assertSourceAuthorityAvailable(service: service, capability: rootCapability, path: path)
+
+        _ = try fixture.runGit(["config", "user.email", "repoprompt@example.test"], at: root)
+        await assertSourceAuthorityAvailable(service: service, capability: rootCapability, path: path)
+
+        try fixture.write("let untrackedChurn = true\n", to: "Sources/UntrackedChurn.swift", at: root)
+        await assertSourceAuthorityAvailable(service: service, capability: rootCapability, path: path)
+
+        try fixture.write("*.swift text eol=lf\n", to: ".git/info/attributes", at: root)
+        await assertSourceAuthorityAvailable(service: service, capability: rootCapability, path: path)
+
+        let configuredAttributes = root.appendingPathComponent("source-authority.attributes")
+        try "*.swift text eol=lf\n".write(to: configuredAttributes, atomically: true, encoding: .utf8)
+        _ = try fixture.runGit(["config", "core.attributesFile", configuredAttributes.path], at: root)
+        try "*.swift text eol=crlf\n".write(to: configuredAttributes, atomically: true, encoding: .utf8)
+        await assertSourceAuthorityAvailable(service: service, capability: rootCapability, path: path)
+
+        let relativeAttributes = root.appendingPathComponent("relative-source-authority.attributes")
+        try "*.swift text eol=lf\n".write(to: relativeAttributes, atomically: true, encoding: .utf8)
+        _ = try fixture.runGit(["config", "core.attributesFile", "relative-source-authority.attributes"], at: root)
+        try "*.swift text eol=crlf\n".write(to: relativeAttributes, atomically: true, encoding: .utf8)
+        await assertSourceAuthorityAvailable(service: service, capability: rootCapability, path: path)
+
+        let revalidatedAfterRootWideChurn = await service.revalidateSourceAuthorities(
+            capability: rootCapability,
+            tokens: [accepted]
+        )
+        XCTAssertTrue(revalidatedAfterRootWideChurn)
+    }
+
+    func testSourceAuthorityRejectsGlobalAttributeMutationDuringIssuance() async throws {
+        let fixture = try ReviewGitRepositoryFixture(name: #function)
+
+        let infoRaceRoot = try fixture.makeRepository(named: "info-attributes-race")
+        let infoAttributes = infoRaceRoot.appendingPathComponent(".git/info/attributes").standardizedFileURL
+        let infoAttributesReplacement = AuthorityEvidenceLeafReplacement(
+            target: infoAttributes,
+            replacementContents: Data("*.swift -text\n".utf8)
+        )
+        let infoRaceService = WorkspaceCodemapGitCapabilityService(
+            namespaceSalt: namespaceSalt,
+            hooks: WorkspaceCodemapGitCapabilityServiceHooks(
+                afterAuthorityEvidenceOpen: { infoAttributesReplacement.replaceIfTarget($0) }
+            )
+        )
+        let infoRaceCapability = try await capability(
+            infoRaceService.resolve(root: request(for: infoRaceRoot, seed: 57))
+        )
+        try "*.swift text\n".write(to: infoAttributes, atomically: true, encoding: .utf8)
+        await assertNil(sourceAuthority(
+            service: infoRaceService,
+            capability: infoRaceCapability,
+            path: "Sources/Feature.swift"
+        ))
+
+        let configuredRaceRoot = try fixture.makeRepository(named: "configured-attributes-race")
+        let configuredRaceAttributes = configuredRaceRoot
+            .appendingPathComponent("source-authority-race.attributes")
+            .standardizedFileURL
+        _ = try fixture.runGit(["config", "core.attributesFile", configuredRaceAttributes.path], at: configuredRaceRoot)
+        let configuredRaceReplacement = AuthorityEvidenceLeafReplacement(
+            target: configuredRaceAttributes,
+            replacementContents: Data("*.swift -text\n".utf8)
+        )
+        let configuredRaceService = WorkspaceCodemapGitCapabilityService(
+            namespaceSalt: namespaceSalt,
+            hooks: WorkspaceCodemapGitCapabilityServiceHooks(
+                afterAuthorityEvidenceOpen: { configuredRaceReplacement.replaceIfTarget($0) }
+            )
+        )
+        let configuredRaceCapability = try await capability(
+            configuredRaceService.resolve(root: request(for: configuredRaceRoot, seed: 58))
+        )
+        try "*.swift text\n".write(to: configuredRaceAttributes, atomically: true, encoding: .utf8)
+        await assertNil(sourceAuthority(
+            service: configuredRaceService,
+            capability: configuredRaceCapability,
+            path: "Sources/Feature.swift"
+        ))
+
+        let relativeRaceRoot = try fixture.makeRepository(named: "relative-attributes-race")
+        let relativeRaceAttributes = relativeRaceRoot
+            .appendingPathComponent("relative-source-authority-race.attributes")
+            .standardizedFileURL
+        _ = try fixture.runGit(
+            ["config", "core.attributesFile", "relative-source-authority-race.attributes"],
+            at: relativeRaceRoot
+        )
+        let relativeRaceReplacement = AuthorityEvidenceLeafReplacement(
+            target: relativeRaceAttributes,
+            replacementContents: Data("*.swift -text\n".utf8)
+        )
+        let relativeRaceService = WorkspaceCodemapGitCapabilityService(
+            namespaceSalt: namespaceSalt,
+            hooks: WorkspaceCodemapGitCapabilityServiceHooks(
+                afterAuthorityEvidenceOpen: { relativeRaceReplacement.replaceIfTarget($0) }
+            )
+        )
+        let relativeRaceCapability = try await capability(
+            relativeRaceService.resolve(root: request(for: relativeRaceRoot, seed: 59))
+        )
+        try "*.swift text\n".write(to: relativeRaceAttributes, atomically: true, encoding: .utf8)
+        await assertNil(sourceAuthority(
+            service: relativeRaceService,
+            capability: relativeRaceCapability,
+            path: "Sources/Feature.swift"
+        ))
+    }
+
+    func testSourceAuthorityRejectsGlobalAttributeMutationDuringRevalidation() async throws {
+        let fixture = try ReviewGitRepositoryFixture(name: #function)
+        let root = try fixture.makeRepository(named: "repository")
+        let infoAttributes = root.appendingPathComponent(".git/info/attributes").standardizedFileURL
+        let replacement = AuthorityEvidenceLeafReplacement(
+            target: infoAttributes,
+            replacementContents: Data("*.swift -text\n".utf8)
+        )
+        let service = WorkspaceCodemapGitCapabilityService(
+            namespaceSalt: namespaceSalt,
+            hooks: WorkspaceCodemapGitCapabilityServiceHooks(
+                afterAuthorityEvidenceOpen: { replacement.replaceIfTarget($0) }
+            )
+        )
+        let rootCapability = try await capability(service.resolve(root: request(for: root, seed: 60)))
+        let tokenCandidate = await sourceAuthority(
+            service: service,
+            capability: rootCapability,
+            path: "Sources/Feature.swift"
+        )
+        let token = try XCTUnwrap(tokenCandidate)
+
+        try "*.swift text\n".write(to: infoAttributes, atomically: true, encoding: .utf8)
+        let revalidatedRace = await service.revalidateSourceAuthorities(
+            capability: rootCapability,
+            tokens: [token]
+        )
+        XCTAssertFalse(revalidatedRace)
+    }
+
+    private func assertSourceAuthorityAvailable(
+        service: WorkspaceCodemapGitCapabilityService,
+        capability: GitCodemapRootCapability,
+        path: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        let authority = await sourceAuthority(service: service, capability: capability, path: path)
+        XCTAssertNotNil(authority, file: file, line: line)
+    }
+
+    private func sourceAuthority(
+        service: WorkspaceCodemapGitCapabilityService,
+        capability: GitCodemapRootCapability,
+        path: String
+    ) async -> WorkspaceCodemapSourceAuthorityToken? {
+        await service.makeSourceAuthority(
+            capability: capability,
+            observedRootEpoch: capability.rootEpoch,
+            observedRepositoryAuthority: capability.repositoryAuthority,
+            candidateRepositoryRelativePath: path,
+            observedPathGeneration: 7,
+            currentPathGeneration: 7,
+            observedIngressGeneration: 11,
+            currentIngressGeneration: 11
+        )
+    }
+
     func testSourceAuthorityNoFollowFingerprintRejectsSymlinkAndMutation() async throws {
         let fixture = try ReviewGitRepositoryFixture(name: #function)
         let root = try fixture.makeRepository(named: "repository")

--- a/Tests/RepoPromptTests/WorkspaceContext/WorkspaceSelectionCoordinatorTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/WorkspaceSelectionCoordinatorTests.swift
@@ -5,9 +5,14 @@ import XCTest
 @MainActor
 final class WorkspaceSelectionCoordinatorTests: XCTestCase {
     private var cancellables: Set<AnyCancellable> = []
+    private var temporaryRoots: [URL] = []
 
     override func tearDown() {
         cancellables.removeAll()
+        for url in temporaryRoots {
+            try? FileManager.default.removeItem(at: url)
+        }
+        temporaryRoots.removeAll()
         super.tearDown()
     }
 
@@ -288,8 +293,41 @@ final class WorkspaceSelectionCoordinatorTests: XCTestCase {
         XCTAssertEqual(harness.manager.mirrorCompletedSelections, [canonical])
         XCTAssertEqual(harness.manager.mirroredSelection, canonical)
 
-        // The fence is not ownership by value: a genuinely newer UI revision must still win.
+        // The fence is not ownership by value: a genuinely newer UI mutation must still win.
         let newerUI = StoredSelection(selectedPaths: ["/tmp/newer-ui.swift"])
+        harness.manager.presentationHandler = nil
+        harness.manager.pendingUISelection = newerUI
+        harness.manager.advanceLiveUISelectionRevision()
+        XCTAssertEqual(
+            coordinator.activeSelectionSnapshot(flushPendingUI: true).selection,
+            newerUI
+        )
+    }
+
+    func testRuntimeActiveSelectionFencesStaleUISnapshotBeforeMirrorCatchesUp() async {
+        let initial = StoredSelection()
+        let canonical = StoredSelection(selectedPaths: ["/tmp/runtime.swift"], codemapAutoEnabled: false)
+        let staleUI = StoredSelection()
+        let harness = CoordinatorHarness(initialSelection: initial)
+        harness.manager.pendingUISelection = staleUI
+        let coordinator = WorkspaceSelectionCoordinator(workspaceManager: harness.manager, store: harness.store)
+        harness.manager.activeUISnapshotResolver = { selection, tabID in
+            coordinator.selectionForActiveUISnapshot(selection, tabID: tabID)
+        }
+        harness.manager.presentationHandler = {
+            _ = coordinator.activeSelectionSnapshot(flushPendingUI: true)
+        }
+
+        _ = await coordinator.persistActiveSelection(canonical, source: .runtimeMutation)
+
+        XCTAssertEqual(harness.manager.presentedSelection, canonical)
+        XCTAssertEqual(harness.manager.publishSnapshotCallCount, 1)
+        XCTAssertEqual(harness.manager.composeTab(for: harness.identity)?.selection, canonical)
+        XCTAssertEqual(coordinator.selectionForActiveUISnapshot(staleUI, tabID: harness.tabID), canonical)
+        XCTAssertTrue(harness.manager.registeredSourceRevisions.isEmpty)
+        XCTAssertTrue(harness.manager.propagatedSelections.isEmpty)
+
+        let newerUI = StoredSelection(selectedPaths: ["/tmp/newer-runtime-ui.swift"])
         harness.manager.presentationHandler = nil
         harness.manager.pendingUISelection = newerUI
         harness.manager.advanceLiveUISelectionRevision()
@@ -759,6 +797,342 @@ final class WorkspaceSelectionCoordinatorTests: XCTestCase {
         XCTAssertEqual(harness.manager.publishSnapshotCallCount, 0)
     }
 
+    func testRuntimeRowMutationConveniencesDelegateThroughSelectionServiceAndPersistActiveSelection() async throws {
+        let root = try makeTemporaryRoot(name: "RuntimeRowMutations")
+        let demotedURL = root.appendingPathComponent("Demoted.swift")
+        let promotedURL = root.appendingPathComponent("Promoted.swift")
+        let selectedSliceURL = root.appendingPathComponent("SelectedSlice.swift")
+        let sliceOnlyURL = root.appendingPathComponent("SliceOnly.swift")
+        let removedURL = root.appendingPathComponent("Removed.swift")
+        let removedCodemapURL = root.appendingPathComponent("RemovedCodemap.swift")
+        try write("struct Demoted {}", to: demotedURL)
+        try write("struct Promoted {}", to: promotedURL)
+        try write("struct SelectedSlice {}", to: selectedSliceURL)
+        try write("struct SliceOnly {}", to: sliceOnlyURL)
+        try write("struct Removed {}", to: removedURL)
+        try write("struct RemovedCodemap {}", to: removedCodemapURL)
+
+        let initial = StoredSelection(
+            selectedPaths: [demotedURL.path, selectedSliceURL.path, sliceOnlyURL.path, removedURL.path],
+            manualCodemapPaths: [promotedURL.path, removedCodemapURL.path],
+            slices: [
+                demotedURL.path: [LineRange(start: 1, end: 1)],
+                selectedSliceURL.path: [LineRange(start: 1, end: 1)],
+                sliceOnlyURL.path: [LineRange(start: 1, end: 1)],
+                removedURL.path: [LineRange(start: 1, end: 1)]
+            ],
+            codemapAutoEnabled: true
+        )
+        let harness = CoordinatorHarness(initialSelection: initial)
+        _ = try await harness.store.loadRoot(path: root.path)
+        let coordinator = WorkspaceSelectionCoordinator(workspaceManager: harness.manager, store: harness.store)
+        var changes: [WorkspaceSelectionCoordinator.Change] = []
+        coordinator.changes
+            .sink { changes.append($0) }
+            .store(in: &cancellables)
+
+        let demoted = await coordinator.demotePathsInActiveSelection(paths: [demotedURL.path])
+        XCTAssertTrue(demoted.mutated)
+        XCTAssertTrue(demoted.invalidPaths.isEmpty)
+        XCTAssertTrue(demoted.codemapUnavailable.isEmpty)
+        XCTAssertFalse(demoted.selection.selectedPaths.contains(demotedURL.path))
+        XCTAssertTrue(demoted.selection.manualCodemapPaths.contains(demotedURL.path))
+        XCTAssertNil(demoted.selection.slices[demotedURL.path])
+        XCTAssertFalse(demoted.selection.codemapAutoEnabled)
+        XCTAssertEqual(harness.manager.composeTab(for: harness.identity)?.selection, demoted.selection)
+
+        let promoted = await coordinator.promotePathsInActiveSelection(paths: [promotedURL.path])
+        XCTAssertTrue(promoted.mutated)
+        XCTAssertTrue(promoted.invalidPaths.isEmpty)
+        XCTAssertTrue(promoted.selection.selectedPaths.contains(promotedURL.path))
+        XCTAssertFalse(promoted.selection.manualCodemapPaths.contains(promotedURL.path))
+        XCTAssertFalse(promoted.selection.codemapAutoEnabled)
+        XCTAssertEqual(harness.manager.composeTab(for: harness.identity)?.selection, promoted.selection)
+
+        let clearedSelectedSlices = await coordinator.clearSlicesInActiveSelection(paths: [selectedSliceURL.path])
+        XCTAssertTrue(clearedSelectedSlices.mutated)
+        XCTAssertTrue(clearedSelectedSlices.invalidPaths.isEmpty)
+        XCTAssertTrue(clearedSelectedSlices.selection.selectedPaths.contains(selectedSliceURL.path))
+        XCTAssertNil(clearedSelectedSlices.selection.slices[selectedSliceURL.path])
+        XCTAssertEqual(clearedSelectedSlices.selection.slices[sliceOnlyURL.path], [LineRange(start: 1, end: 1)])
+        XCTAssertEqual(harness.manager.composeTab(for: harness.identity)?.selection, clearedSelectedSlices.selection)
+
+        let clearedSliceOnly = await coordinator.clearSlicesInActiveSelection(paths: [sliceOnlyURL.path])
+        XCTAssertTrue(clearedSliceOnly.mutated)
+        XCTAssertTrue(clearedSliceOnly.invalidPaths.isEmpty)
+        XCTAssertTrue(clearedSliceOnly.selection.selectedPaths.contains(sliceOnlyURL.path))
+        XCTAssertNil(clearedSliceOnly.selection.slices[sliceOnlyURL.path])
+        XCTAssertEqual(clearedSliceOnly.selection.slices[removedURL.path], [LineRange(start: 1, end: 1)])
+        XCTAssertEqual(harness.manager.composeTab(for: harness.identity)?.selection, clearedSliceOnly.selection)
+
+        let removed = await coordinator.removePathsInActiveSelection(paths: [removedURL.path])
+        XCTAssertTrue(removed.mutated)
+        XCTAssertTrue(removed.invalidPaths.isEmpty)
+        XCTAssertFalse(removed.selection.selectedPaths.contains(removedURL.path))
+        XCTAssertFalse(removed.selection.manualCodemapPaths.contains(removedURL.path))
+        XCTAssertNil(removed.selection.slices[removedURL.path])
+        XCTAssertEqual(harness.manager.composeTab(for: harness.identity)?.selection, removed.selection)
+
+        let removedCodemap = await coordinator.removePathsInActiveSelection(
+            paths: [removedCodemapURL.path],
+            mode: "codemap_only"
+        )
+        XCTAssertTrue(removedCodemap.mutated)
+        XCTAssertTrue(removedCodemap.invalidPaths.isEmpty)
+        XCTAssertFalse(removedCodemap.selection.manualCodemapPaths.contains(removedCodemapURL.path))
+        XCTAssertFalse(removedCodemap.selection.selectedPaths.contains(removedCodemapURL.path))
+        XCTAssertEqual(harness.manager.composeTab(for: harness.identity)?.selection, removedCodemap.selection)
+        XCTAssertEqual(changes.map(\.source), Array(repeating: .runtimeMutation, count: 6))
+    }
+
+    func testSuspendedRemoveWhenTargetTabIsRemovedReportsNotMutated() async throws {
+        let root = try makeTemporaryRoot(name: "SuspendedRemoveTargetUnavailable")
+        let removedURL = root.appendingPathComponent("Removed.swift")
+        let retainedURL = root.appendingPathComponent("Retained.swift")
+        try write("struct Removed {}", to: removedURL)
+        try write("struct Retained {}", to: retainedURL)
+
+        let initial = StoredSelection(
+            selectedPaths: [removedURL.path, retainedURL.path],
+            codemapAutoEnabled: false
+        )
+        let harness = CoordinatorHarness(initialSelection: initial)
+        _ = try await harness.store.loadRoot(path: root.path)
+        let mutationGate = SelectionMutationGate()
+        let mutationService = WorkspaceSelectionMutationService(
+            store: harness.store,
+            removePathsDidCaptureExistingHook: { selection in
+                await mutationGate.captureAndWait(selection)
+            }
+        )
+        let coordinator = WorkspaceSelectionCoordinator(
+            workspaceManager: harness.manager,
+            store: harness.store,
+            mutationService: mutationService
+        )
+        let manager = harness.manager
+        var changes: [WorkspaceSelectionCoordinator.Change] = []
+        coordinator.changes
+            .sink { changes.append($0) }
+            .store(in: &cancellables)
+
+        let mutationTask = Task { @MainActor in
+            await coordinator.removePathsInActiveSelection(paths: [removedURL.path])
+        }
+        let capturedSelection = await mutationGate.waitUntilCaptured()
+        XCTAssertEqual(capturedSelection, initial)
+        manager.removeTab(harness.tabID)
+        XCTAssertNil(manager.composeTab(for: harness.identity))
+        await mutationGate.release()
+        let result = await mutationTask.value
+
+        XCTAssertFalse(result.mutated)
+        XCTAssertEqual(result.selection, initial)
+        XCTAssertNotEqual(result.selection, StoredSelection(selectedPaths: [retainedURL.path], codemapAutoEnabled: false))
+        XCTAssertNil(manager.composeTab(for: harness.identity))
+        XCTAssertEqual(manager.updateStoredOnlyCallCount, 0)
+        XCTAssertNil(manager.presentedSelection)
+        XCTAssertNil(manager.mirroredSelection)
+        XCTAssertTrue(manager.mirrorStartedSelections.isEmpty)
+        XCTAssertTrue(manager.propagatedSelections.isEmpty)
+        XCTAssertTrue(changes.isEmpty)
+    }
+
+    func testIdentityScopedRowMutationsStayOnCapturedTabAfterActiveTabSwitch() async throws {
+        let root = try makeTemporaryRoot(name: "IdentityScopedRowMutations")
+        let promotedURL = root.appendingPathComponent("Promoted.swift")
+        let demotedURL = root.appendingPathComponent("Demoted.swift")
+        let slicedURL = root.appendingPathComponent("Sliced.swift")
+        try write("struct Promoted {}", to: promotedURL)
+        try write("struct Demoted {}", to: demotedURL)
+        try write("struct Sliced {}", to: slicedURL)
+
+        let capturedSelection = StoredSelection(
+            selectedPaths: [demotedURL.path, slicedURL.path],
+            manualCodemapPaths: [promotedURL.path],
+            slices: [slicedURL.path: [LineRange(start: 1, end: 1)]],
+            codemapAutoEnabled: false
+        )
+        let activeSelection = StoredSelection(selectedPaths: ["/tmp/active-tab.swift"])
+        let activeTabID = UUID()
+        let harness = CoordinatorHarness(initialSelection: capturedSelection)
+        harness.manager.appendTab(ComposeTabState(id: activeTabID, name: "Active", selection: activeSelection))
+        harness.manager.setActiveTab(activeTabID)
+        _ = try await harness.store.loadRoot(path: root.path)
+        let coordinator = WorkspaceSelectionCoordinator(workspaceManager: harness.manager, store: harness.store)
+
+        let promoted = await coordinator.promotePathsInSelection(
+            paths: [promotedURL.path],
+            for: harness.identity,
+            expectedCurrentSelection: capturedSelection
+        )
+        let demoted = await coordinator.demotePathsInSelection(
+            paths: [demotedURL.path],
+            for: harness.identity,
+            expectedCurrentSelection: promoted.selection
+        )
+        let cleared = await coordinator.clearSlicesInSelection(
+            paths: [slicedURL.path],
+            for: harness.identity,
+            expectedCurrentSelection: demoted.selection
+        )
+
+        XCTAssertTrue(promoted.mutated)
+        XCTAssertTrue(demoted.mutated)
+        XCTAssertTrue(cleared.mutated)
+        XCTAssertTrue(cleared.selection.selectedPaths.contains(promotedURL.path))
+        XCTAssertTrue(cleared.selection.manualCodemapPaths.contains(demotedURL.path))
+        XCTAssertNil(cleared.selection.slices[slicedURL.path])
+        XCTAssertEqual(harness.manager.composeTab(for: harness.identity)?.selection, cleared.selection)
+        XCTAssertEqual(harness.manager.composeTab(with: activeTabID)?.selection, activeSelection)
+    }
+
+    func testIdentityScopedRowMutationsAndSnapshotPersistenceRejectPostCaptureSelectionChange() async throws {
+        let root = try makeTemporaryRoot(name: "GuardedRowMutations")
+        let promotedURL = root.appendingPathComponent("Promoted.swift")
+        let slicedURL = root.appendingPathComponent("Sliced.swift")
+        let concurrentURL = root.appendingPathComponent("Concurrent.swift")
+        try write("struct Promoted {}", to: promotedURL)
+        try write("struct Sliced {}", to: slicedURL)
+        try write("struct Concurrent {}", to: concurrentURL)
+
+        let capturedSelection = StoredSelection(
+            selectedPaths: [slicedURL.path],
+            manualCodemapPaths: [promotedURL.path],
+            slices: [slicedURL.path: [LineRange(start: 1, end: 1)]],
+            codemapAutoEnabled: false
+        )
+        let advancedSelection = StoredSelection(
+            selectedPaths: [slicedURL.path, concurrentURL.path],
+            manualCodemapPaths: capturedSelection.manualCodemapPaths,
+            slices: capturedSelection.slices,
+            codemapAutoEnabled: capturedSelection.codemapAutoEnabled
+        )
+        let harness = CoordinatorHarness(initialSelection: capturedSelection)
+        _ = try await harness.store.loadRoot(path: root.path)
+        let coordinator = WorkspaceSelectionCoordinator(workspaceManager: harness.manager, store: harness.store)
+        _ = await coordinator.persistSelection(
+            advancedSelection,
+            for: harness.identity,
+            mirrorToUIIfActive: false
+        )
+
+        let promoted = await coordinator.promotePathsInSelection(
+            paths: [promotedURL.path],
+            for: harness.identity,
+            expectedCurrentSelection: capturedSelection
+        )
+        let cleared = await coordinator.clearSlicesInSelection(
+            paths: [slicedURL.path],
+            for: harness.identity,
+            expectedCurrentSelection: capturedSelection
+        )
+        let persisted = await coordinator.persistSelection(
+            StoredSelection(),
+            for: harness.identity,
+            expectedCurrentSelection: capturedSelection
+        )
+
+        XCTAssertFalse(promoted.mutated)
+        XCTAssertEqual(promoted.selection, advancedSelection)
+        XCTAssertFalse(cleared.mutated)
+        XCTAssertEqual(cleared.selection, advancedSelection)
+        XCTAssertEqual(persisted, advancedSelection)
+        XCTAssertEqual(harness.manager.composeTab(for: harness.identity)?.selection, advancedSelection)
+    }
+
+    func testViewContextMutationTargetRoutesRemoveAndClearAndRejectsPostCaptureChange() async throws {
+        let root = try makeTemporaryRoot(name: "ViewContextMutationTarget")
+        let removedURL = root.appendingPathComponent("Removed.swift")
+        let clearedURL = root.appendingPathComponent("Cleared.swift")
+        let addedURL = root.appendingPathComponent("Added.swift")
+        let concurrentURL = root.appendingPathComponent("Concurrent.swift")
+        try write("struct Removed {}", to: removedURL)
+        try write("struct Cleared {}", to: clearedURL)
+        try write("struct Added {}", to: addedURL)
+        try write("struct Concurrent {}", to: concurrentURL)
+
+        let sourceSelection = StoredSelection(
+            selectedPaths: [removedURL.path, clearedURL.path],
+            codemapAutoEnabled: false
+        )
+        let selectionAtFirstCapture = StoredSelection(
+            selectedPaths: [removedURL.path, clearedURL.path, addedURL.path],
+            codemapAutoEnabled: false
+        )
+        let activeSelection = StoredSelection(selectedPaths: ["/tmp/active-tab.swift"])
+        let activeTabID = UUID()
+        let harness = CoordinatorHarness(initialSelection: selectionAtFirstCapture)
+        harness.manager.appendTab(ComposeTabState(id: activeTabID, name: "Active", selection: activeSelection))
+        _ = try await harness.store.loadRoot(path: root.path)
+        let coordinator = WorkspaceSelectionCoordinator(workspaceManager: harness.manager, store: harness.store)
+        let source = AgentContextExportSource(
+            tabID: harness.tabID,
+            promptText: "",
+            selection: sourceSelection,
+            selectedMetaPromptIDs: [],
+            tabName: "Captured",
+            activeAgentSessionID: nil,
+            worktreeBindings: []
+        )
+        let model = try await AgentContextExportResolver.resolveModel(
+            source: source,
+            store: harness.store,
+            filePathDisplay: .relative,
+            codeMapUsage: .none
+        )
+        let removedRow = try XCTUnwrap(model.rows.first { $0.displayPath == "Removed.swift" })
+        let exportContext = AgentContextExportViewContext(
+            promptManager: makePrompt(store: harness.store, windowID: 51003),
+            selectionCoordinator: coordinator,
+            currentTabID: harness.tabID,
+            activeAgentSessionID: nil,
+            worktreeBindingsProvider: nil
+        )
+
+        let removeTarget = try XCTUnwrap(exportContext.activeSelectionMutationTarget(for: source))
+        harness.manager.setActiveTab(activeTabID)
+        let afterRemove = await AgentContextExportResolver.removeRow(
+            removedRow,
+            from: removeTarget.expectedSelection,
+            lookupContext: model.lookupContext,
+            store: harness.store
+        )
+        await exportContext.persistSelection(afterRemove, target: removeTarget)
+
+        XCTAssertEqual(afterRemove.selectedPaths, [clearedURL.path, addedURL.path])
+        XCTAssertEqual(harness.manager.composeTab(for: harness.identity)?.selection, afterRemove)
+        XCTAssertEqual(harness.manager.composeTab(with: activeTabID)?.selection, activeSelection)
+
+        harness.manager.setActiveTab(harness.tabID)
+        let clearTarget = try XCTUnwrap(exportContext.activeSelectionMutationTarget(for: source))
+        harness.manager.setActiveTab(activeTabID)
+        let afterClear = AgentContextExportResolver.removeSelectionSnapshot(
+            source.selection,
+            from: clearTarget.expectedSelection
+        )
+        await exportContext.persistSelection(afterClear, target: clearTarget)
+
+        XCTAssertEqual(afterClear.selectedPaths, [addedURL.path])
+        XCTAssertEqual(harness.manager.composeTab(for: harness.identity)?.selection, afterClear)
+        XCTAssertEqual(harness.manager.composeTab(with: activeTabID)?.selection, activeSelection)
+
+        harness.manager.setActiveTab(harness.tabID)
+        let staleTarget = try XCTUnwrap(exportContext.activeSelectionMutationTarget(for: source))
+        let advancedSelection = StoredSelection(
+            selectedPaths: [addedURL.path, concurrentURL.path],
+            codemapAutoEnabled: false
+        )
+        _ = await coordinator.persistSelection(
+            advancedSelection,
+            for: harness.identity,
+            mirrorToUIIfActive: false
+        )
+        await exportContext.persistSelection(StoredSelection(), target: staleTarget)
+
+        XCTAssertEqual(harness.manager.composeTab(for: harness.identity)?.selection, advancedSelection)
+    }
+
     func testApplyingSelectionMirrorGuardSuppressesFlushPublication() async {
         let initial = StoredSelection(selectedPaths: ["/tmp/initial.swift"])
         let pending = StoredSelection(selectedPaths: ["/tmp/pending.swift"])
@@ -847,6 +1221,38 @@ final class WorkspaceSelectionCoordinatorTests: XCTestCase {
             XCTAssertEqual(decision.owner, .storedComposeTab, scenario.name)
         }
     }
+
+    private func makeTemporaryRoot(name: String) throws -> URL {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "WorkspaceSelectionCoordinatorTests-\(name)-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        temporaryRoots.append(root)
+        return root
+    }
+
+    private func write(_ contents: String, to url: URL) throws {
+        let parent = url.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+        try contents.write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    private func makePrompt(store: WorkspaceFileContextStore, windowID: Int) -> PromptViewModel {
+        let secureService = SecureKeysService(secureStorage: TestSecureStorageBackend())
+        let keyManager = KeyManager(secureService: secureService)
+        let apiSettings = APISettingsViewModel(
+            aiQueriesService: AIQueriesService(keyManager: keyManager),
+            keyManager: keyManager,
+            loadStoredDataOnInit: false
+        )
+        return PromptViewModel(
+            fileManager: WorkspaceFilesViewModel(workspaceFileContextStore: store),
+            apiSettingsViewModel: apiSettings,
+            windowID: windowID,
+            settingsManager: WindowSettingsManager(windowID: windowID)
+        )
+    }
 }
 
 @MainActor
@@ -894,6 +1300,31 @@ private final class FakeMCPSelectionRevisionLedger {
     func allocate() -> UInt64 {
         defer { nextRevision &+= 1 }
         return nextRevision
+    }
+}
+
+private actor SelectionMutationGate {
+    private var capturedSelection: StoredSelection?
+    private var released = false
+
+    func captureAndWait(_ selection: StoredSelection, timeout: Duration = .seconds(5)) async {
+        capturedSelection = selection
+        let deadline = ContinuousClock.now + timeout
+        while !released, ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+    }
+
+    func waitUntilCaptured(timeout: Duration = .seconds(2)) async -> StoredSelection? {
+        let deadline = ContinuousClock.now + timeout
+        while capturedSelection == nil, ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return capturedSelection
+    }
+
+    func release() {
+        released = true
     }
 }
 
@@ -1035,6 +1466,16 @@ private final class FakeWorkspaceSelectionManager: WorkspaceSelectionHost {
         guard var workspace = activeWorkspace else { return }
         workspace.composeTabs.append(tab)
         activeWorkspace = workspace
+    }
+
+    func removeTab(_ tabID: UUID) {
+        guard var workspace = activeWorkspace else { return }
+        workspace.composeTabs.removeAll { $0.id == tabID }
+        if workspace.activeComposeTabID == tabID {
+            workspace.activeComposeTabID = workspace.composeTabs.first?.id
+        }
+        activeWorkspace = workspace
+        selectionMirrorContextRevision &+= 1
     }
 
     func setActiveTab(_ tabID: UUID) {

--- a/Tests/RepoPromptTests/WorkspaceFiles/GitViewModelSelectionClearTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceFiles/GitViewModelSelectionClearTests.swift
@@ -1,0 +1,220 @@
+@testable import RepoPromptApp
+import XCTest
+
+@MainActor
+final class GitViewModelSelectionClearTests: XCTestCase {
+    func testClearSelectedChangedFilesPreservesSelectedFileThatBecameClean() async {
+        let fixture = makeFixture()
+        let gitViewModel = makeGitViewModel(fixture: fixture)
+        fixture.fileManager.selectPath(fixture.targetA.file.fullPath, kind: nil)
+        fixture.fileManager.selectPath(fixture.targetB.file.fullPath, kind: nil)
+        fixture.fileManager.selectPath(fixture.unrelated.file.fullPath, kind: nil)
+
+        await publishStatus(
+            changedFiles: [fixture.targetA],
+            generation: 1,
+            fixture: fixture,
+            gitViewModel: gitViewModel
+        )
+        await publishStatus(
+            changedFiles: [fixture.targetB],
+            generation: 2,
+            fixture: fixture,
+            gitViewModel: gitViewModel
+        )
+
+        await gitViewModel.clearSelectedChangedFilesFromFileManager()
+
+        XCTAssertEqual(
+            selectedPaths(in: fixture.fileManager),
+            [fixture.targetA.file.fullPath, fixture.unrelated.file.fullPath]
+        )
+    }
+
+    func testEmptyGitStatusClearsTrackedSelectedChangedPaths() async {
+        let fixture = makeFixture()
+        let gitViewModel = makeGitViewModel(fixture: fixture)
+        fixture.fileManager.selectPath(fixture.targetA.file.fullPath, kind: nil)
+
+        await publishStatus(
+            changedFiles: [fixture.targetA],
+            generation: 1,
+            fixture: fixture,
+            gitViewModel: gitViewModel
+        )
+        await publishStatus(
+            changedFiles: [],
+            generation: 2,
+            fixture: fixture,
+            gitViewModel: gitViewModel
+        )
+
+        XCTAssertEqual(gitViewModel.test_trackedSelectedChangedAbsolutePaths, [])
+        XCTAssertFalse(gitViewModel.hasTrackedSelectedChangedFiles)
+    }
+
+    func testHiddenPopoverCanonicalSelectionEmissionReconcilesTrackedChangedPaths() async {
+        let fixture = makeFixture()
+        let gitViewModel = makeGitViewModel(fixture: fixture)
+        XCTAssertFalse(gitViewModel.isPopoverVisible)
+
+        fixture.fileManager.selectPath(fixture.targetB.file.fullPath, kind: nil)
+        await publishStatus(
+            changedFiles: [fixture.targetB],
+            generation: 1,
+            fixture: fixture,
+            gitViewModel: gitViewModel
+        )
+        XCTAssertEqual(
+            gitViewModel.test_trackedSelectedChangedAbsolutePaths,
+            [fixture.targetB.file.fullPath]
+        )
+        XCTAssertTrue(gitViewModel.hasTrackedSelectedChangedFiles)
+
+        fixture.fileManager.deselectPath(fixture.targetB.file.fullPath, kind: nil)
+        XCTAssertEqual(gitViewModel.test_trackedSelectedChangedAbsolutePaths, [])
+        XCTAssertFalse(gitViewModel.hasTrackedSelectedChangedFiles)
+
+        fixture.fileManager.selectPath(fixture.targetB.file.fullPath, kind: nil)
+        XCTAssertEqual(
+            gitViewModel.test_trackedSelectedChangedAbsolutePaths,
+            [fixture.targetB.file.fullPath]
+        )
+        XCTAssertTrue(gitViewModel.hasTrackedSelectedChangedFiles)
+    }
+
+    func testSelectionChangeSupersedesInFlightStatusProjection() async {
+        let fixture = makeFixture()
+        let gitViewModel = makeGitViewModel(fixture: fixture)
+        fixture.fileManager.selectPath(fixture.targetA.file.fullPath, kind: nil)
+
+        await publishStatus(
+            changedFiles: [fixture.targetA],
+            generation: 1,
+            fixture: fixture,
+            gitViewModel: gitViewModel
+        )
+        let staleRebuildGeneration = gitViewModel.test_resolvedStateGeneration
+
+        fixture.fileManager.deselectPath(fixture.targetA.file.fullPath, kind: nil)
+        XCTAssertGreaterThan(gitViewModel.test_resolvedStateGeneration, staleRebuildGeneration)
+        XCTAssertEqual(gitViewModel.test_trackedSelectedChangedAbsolutePaths, [])
+
+        gitViewModel.test_publishSelectedChangedProjection(
+            changedAbsolutePaths: [fixture.targetA.file.fullPath],
+            selectedAbsolutePaths: [fixture.targetA.file.fullPath],
+            rebuildGeneration: staleRebuildGeneration
+        )
+
+        XCTAssertEqual(gitViewModel.test_trackedSelectedChangedAbsolutePaths, [])
+        XCTAssertEqual(selectedPaths(in: fixture.fileManager), [])
+    }
+
+    private func makeGitViewModel(
+        fixture: (
+            fileManager: WorkspaceFilesViewModel,
+            root: FolderViewModel,
+            targetA: FixtureFile,
+            targetB: FixtureFile,
+            unrelated: FixtureFile
+        )
+    ) -> GitViewModel {
+        GitViewModel(
+            fileManager: fixture.fileManager,
+            gitContextRefreshIntervalNanoseconds: 0
+        )
+    }
+
+    private func publishStatus(
+        changedFiles: [FixtureFile],
+        generation: Int,
+        fixture: (
+            fileManager: WorkspaceFilesViewModel,
+            root: FolderViewModel,
+            targetA: FixtureFile,
+            targetB: FixtureFile,
+            unrelated: FixtureFile
+        ),
+        gitViewModel: GitViewModel
+    ) async {
+        let snapshot = GitStatusActor.GitStatusSnapshot(
+            rootPath: "",
+            gitRootPath: (fixture.targetA.file.fullPath as NSString).deletingLastPathComponent,
+            isGitRepo: true,
+            backendKind: nil,
+            unstagedFiles: changedFiles.map {
+                VCSUncommittedFile(path: $0.relativePath, status: "M")
+            },
+            currentBranch: "main",
+            availableBranches: [],
+            availableRemoteBranches: [],
+            availableTags: [],
+            gitWorktreeContext: nil,
+            totalAdditions: 0,
+            totalDeletions: 0,
+            commitDelta: nil,
+            errorMessage: nil,
+            trigger: .explicitRefresh,
+            generation: generation
+        )
+        await gitViewModel.test_applyStatusSnapshot(snapshot)
+    }
+
+    private func selectedPaths(in fileManager: WorkspaceFilesViewModel) -> Set<String> {
+        Set(fileManager.selectedFiles.map(\.fullPath))
+    }
+
+    private func makeFixture() -> (
+        fileManager: WorkspaceFilesViewModel,
+        root: FolderViewModel,
+        targetA: FixtureFile,
+        targetB: FixtureFile,
+        unrelated: FixtureFile
+    ) {
+        let rootURL = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("GitViewModelSelectionClearTests", isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let date = Date(timeIntervalSince1970: 1000)
+        let root = FolderViewModel(
+            folder: Folder(name: "FixtureRoot", path: rootURL.path, modificationDate: date),
+            rootPath: rootURL.path,
+            isExpanded: true
+        )
+
+        let targetA = makeFile(name: "TargetA.swift", rootURL: rootURL, root: root, date: date)
+        let targetB = makeFile(name: "TargetB.swift", rootURL: rootURL, root: root, date: date)
+        let unrelated = makeFile(name: "Notes.md", rootURL: rootURL, root: root, date: date)
+        root.addChildrenBatch([.file(targetA.file), .file(targetB.file), .file(unrelated.file)])
+
+        let fileManager = WorkspaceFilesViewModel()
+        fileManager.registerRootFolderForTesting(root)
+        for file in [targetA.file, targetB.file, unrelated.file] {
+            fileManager.selectFileForTesting(file)
+            fileManager.deselectPath(file.fullPath, kind: nil)
+        }
+        return (fileManager, root, targetA, targetB, unrelated)
+    }
+
+    private func makeFile(
+        name: String,
+        rootURL: URL,
+        root: FolderViewModel,
+        date: Date
+    ) -> FixtureFile {
+        let file = FileViewModel(
+            file: File(name: name, path: rootURL.appendingPathComponent(name).path, modificationDate: date),
+            rootPath: rootURL.path,
+            hierarchyLevel: 1,
+            rootIdentifier: root.id,
+            rootFolderPath: rootURL.path,
+            fileSystemService: nil,
+            parentFolder: root
+        )
+        return FixtureFile(file: file, relativePath: name)
+    }
+
+    private struct FixtureFile {
+        let file: FileViewModel
+        let relativePath: String
+    }
+}

--- a/docs/architecture/compose.md
+++ b/docs/architecture/compose.md
@@ -1,0 +1,118 @@
+# Compose Inspector
+
+This contributor guide covers the Agent Mode Compose inspector, including selected-context review, prompt packaging, Copy Prompt, Context Builder, and the services that support them.
+
+## Scope and goals
+
+Compose lets a user review the context selected for the current agent chat, shape the prompt handed to another model, and run Context Builder without leaving the transcript.
+
+The inspector renders a resolved view of the current selection and sends user changes through the shared workspace selection services. Repository lookup, codemap resolution, and selection persistence stay outside the view layer; [`source-layout.md`](source-layout.md) defines the source-ownership boundary.
+
+Inspector visibility and navigation are scoped to the current app window. Selections, prompt settings, and Context Builder state use the feature's existing stores.
+
+## User-facing behavior
+
+### Open and close
+
+Compose opens from the **Compose** button in the top-right Agent Mode toolbar, from the selected-context pill below the composer, or from `⌘P` (configurable under Settings → Keyboard Shortcuts → Toggle Compose). The toolbar and shortcut toggle the inspector. The selected-context pill opens **Selections**, switches to it from another Compose tab, or closes the inspector when **Selections** is already active. The header control closes the inspector directly.
+
+The native macOS inspector column is resizable and adapts to preserve useful space for the chat.
+
+### Selections
+
+The **Selections** tab presents the context selected for the current agent chat, separating full and sliced files under **Files** from codemap-only entries under **Codemaps**. Users can filter by file name, path, root, or directory and sort by name or token count. Each row identifies its workspace root and selection mode, with token, context-percentage, and line-count metrics when available. Row actions support previewing, copying, removing, changing the selection mode, clearing slices, copying paths, opening files, and revealing files in Finder. **Clear** removes all displayed selections.
+
+### Prompt
+
+The **Prompt** tab combines receiving-model instructions with clipboard packaging controls: the Standard, Plan · Architect, Review, and Manual copy presets; stored prompts; and File Tree, Code Map, and Git options. Changing File Tree, Code Map, or Git selects the Manual preset. Copy Prompt uses the current prompt text and selection when clicked.
+
+### Context Builder
+
+The **Context Builder** tab explores the workspace, curates context within the configured budget, and produces Plan, Review, or Question output. Generated output can become the prompt, be copied or previewed, or open in the Agent Mode Oracle popover.
+
+Context Builder's **Preview**, **Open Oracle**, and **View in Chat** actions open the follow-up conversation in the Agent Mode Oracle popover. The popover presents the conversation for reading, copying, reviewing reasoning and model usage, selecting text, and navigating the transcript. It stays synchronized with the follow-up chat.
+
+### Loading behavior
+
+When the active chat changes, Compose waits for the new chat's selection before showing rows and totals. During updates to the current chat, matching rows remain visible while their data refreshes. File and codemap counts become available independently, and metrics remain hidden until their values are known.
+
+## Layering
+
+```mermaid
+flowchart LR
+    UI["Compose inspector"] --> STORE["AgentContextDrawerUIStore"]
+    UI --> MODEL["AgentSelectedFilesModelCoordinator"]
+    MODEL --> RESOLVER["AgentContextExportResolver"]
+    RESOLVER --> CONTEXT["WorkspaceFileContextStore"]
+    RESOLVER --> CODEMAP["WorkspaceCodemapPresentationCoordinator"]
+    UI --> SELECTION["WorkspaceSelectionCoordinator"]
+    UI --> PROMPT["PromptViewModel"]
+    UI --> BUILDER["ContextBuilderAgentViewModel"]
+```
+
+`AgentModeDetailWithSidebarView` mounts the native inspector beside the chat. `AgentContextInspectorPresenter` connects its visibility to the presentation store, and `AgentContextControlDrawerView` owns the tab shell and selected-context model lifecycle.
+
+## Invariants and rationale
+
+**Observation isolation.** Compose detail state is observed within the inspector subtree. The chat surface receives only the presentation state and the action that opens Compose, keeping filter, sort, navigation, loading, and row updates from invalidating the transcript.
+
+**Context Builder Oracle presentation.** Context Builder routes each follow-up conversation by workspace, tab, and chat. `AgentOraclePill` presents the shared chat transcript with its non-mutating action policy, while the chat session remains the source of truth for live message updates.
+
+**Native inspector layout.** SwiftUI's `.inspector` owns width, resizing, cursor behavior, and resize persistence. `AgentContextInspectorColumnSizing` derives a bounded inspector width from the available detail width so the chat remains usable in narrow layouts.
+
+**Context-aware loading.** `AgentSelectedFilesModelCoordinator` distinguishes the requested context, the context currently displayed, and any context being loaded. Rows are mutable only when the displayed data belongs to the active context and no replacement load is underway. A chat switch therefore withholds stale rows, while an update within the same chat can keep matching rows visible and read-only until the refresh completes.
+
+**Current-state copying.** Copy Prompt flushes pending selection edits, reads the current prompt, and captures the active selection and worktree bindings when clicked. Cached lookup data is reused only when it belongs to that same context.
+
+**Explicit readiness.** Counts and metrics carry readiness independently. Unknown values remain pending rather than appearing as zero, and the header token estimate appears only for a complete, current selection snapshot.
+
+## State ownership
+
+| Concern | Owner |
+| --- | --- |
+| Inspector visibility | `AgentContextDrawerPresentationStore` |
+| Active tab, filter, and sort | `AgentContextDrawerDetailStore` |
+| Open, close, and toggle behavior shared by Compose entry points | `AgentContextDrawerUIStore` |
+| Selected files and active-tab mutations | `StoredSelection` and `WorkspaceSelectionCoordinator` |
+| Instructions, copy configuration, and token counting | `PromptViewModel` |
+| Context Builder execution and generated output | `ContextBuilderAgentViewModel` |
+| Selected-context loading, readiness, caching, and mutation gating | `AgentSelectedFilesModelCoordinator` |
+
+## Selected-context model
+
+`AgentContextExportViewContext` captures the active Compose tab, agent session, prompt, selection, and worktree bindings. `AgentContextExportResolver` maps that context to display rows, metrics, previews, and clipboard content. Selection changes return through `WorkspaceSelectionCoordinator`, which updates the active tab's `StoredSelection`. Metrics distinguish known values from values that are still loading.
+
+## Copy pipeline
+
+Copy Prompt assembles the clipboard content from a single snapshot of the active context:
+
+1. Capture the current prompt, selection, worktree bindings, and matching lookup data.
+2. Resolve stored prompts and Git review context.
+3. Resolve the codemaps needed by the selected copy configuration.
+4. Collect selected file content, project structure, and Git diff content.
+5. Package the configured sections and write them to the pasteboard.
+
+## Validation
+
+Start with the focused suite for the boundary being changed:
+
+```bash
+make dev-test FILTER=AgentContextDrawerUIStoreTests
+make dev-test FILTER=AgentContextExportResolverTests
+make dev-test FILTER=AgentSelectedFilesModelCoordinatorTests
+make dev-test FILTER=AgentContextInspectorColumnSizingTests
+```
+
+Selection-card presentation, token accounting, Git actions, and chat-switch behavior have additional focused coverage in `AgentContextSelectedFileCardTests`, `TokenCountingViewModelTests`, `GitViewModelSelectionClearTests`, and `AgentModeChatSwitchActivationTests`. Use the contribution matrix in [`../../AGENTS.md`](../../AGENTS.md) for repository-wide lint, build, and PR-ready gates. Because Compose is running-app Agent Mode UI, also follow the live CE MCP smoke flow there when behavior changes.
+
+## References
+
+- `Sources/RepoPrompt/Features/AgentMode/Views/AgentModeDetailWithSidebarView.swift` — native inspector mounting, presenter, and detail-width column policy.
+- `Sources/RepoPrompt/Features/AgentMode/Views/ContextDrawer/` — Compose shell, tabs, selected-context rows, previews, and click-time export context.
+- `Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentContextDrawerUIStore.swift` — presentation and runtime detail state.
+- `Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentSelectedFilesModelCoordinator.swift` — context-aware loading, caching, readiness, and mutation gating.
+- `Sources/RepoPrompt/Features/AgentMode/Services/AgentContextExportResolver.swift` — selection resolution, previews, metrics, and clipboard assembly.
+- `Sources/RepoPrompt/Features/AgentMode/Services/AgentSelectedFilesDiagnostics.swift` — opt-in selected-context loading and readiness diagnostics.
+- `Sources/RepoPrompt/Infrastructure/WorkspaceContext/Selection/WorkspaceSelectionCoordinator.swift` — active-tab selection mutation.
+- `Sources/RepoPrompt/Infrastructure/WorkspaceContext/Presentation/WorkspaceCodemapPresentationCoordinator.swift` — codemap readiness and presentation coordination.
+- [`source-layout.md`](source-layout.md) — source ownership rules for Agent Mode feature code and workspace-context infrastructure.

--- a/docs/architecture/source-layout.md
+++ b/docs/architecture/source-layout.md
@@ -17,6 +17,7 @@ Sources/
       Views/
     Features/
       AgentMode/                 # Agent Mode UI, models, view models, onboarding, recommendations, and shared agent runtime ownership
+        Views/ContextDrawer/     # Compose inspector shell, tabs, selected-context rows, previews, and click-time export context
         Runtime/Providers/       # provider/runtime enum and provider factory shared by Context Builder, Agent Mode, MCP, and recommendations
         History/                 # cross-workspace session history scanner, MCP tool service (history.list_sessions / search / time / get_session)
       Chat/                      # chat/oracle models, services, diff state, view models, and views
@@ -84,7 +85,7 @@ The old native file-tree visualization is no longer a live product surface. Do n
 
 “File tree” remains valid when it refers to compatibility or textual context contracts, including the MCP `get_file_tree` tool, tool result cards, API/persisted symbols such as `FileTreeOption`, historical plans, and prompt/context output such as `<file_map>` / project structure maps. Contributor-facing UI and docs should prefer “project structure map” when describing generated textual context so it is not confused with the removed native UI.
 
-The old IDE-era Prompt selected-files panel is also removed. Do not add back `PresetBottomBar`, `SelectedFilesContentView`, `SelectedFilesPanelViewModel`, or the Prompt-owned copy/chat preset picker helpers. The live compact selected-files UI remains `SelectedFilesGrid` plus `FilePreviewPopover`, and the Settings chat preset picker lives under `Features/Settings`. Textual file previews use the read-only `TextKitView`; app syntax queries remain a separate parsing and validation concern rather than a colored preview renderer.
+The old IDE-era Prompt selected-files panel is also removed. Do not add back `PresetBottomBar`, `SelectedFilesContentView`, `SelectedFilesPanelViewModel`, or the Prompt-owned copy/chat preset picker helpers. The compact Prompt selected-files UI remains `SelectedFilesGrid` plus `FilePreviewPopover`. Agent Mode owns its current selected-context workflow in the native Compose inspector under `Features/AgentMode/Views/ContextDrawer`; see [`compose.md`](compose.md). The Settings chat preset picker lives under `Features/Settings`. Textual file previews use the read-only `TextKitView`; app syntax queries remain a separate parsing and validation concern rather than a colored preview renderer.
 
 ## Placement rules for new files
 


### PR DESCRIPTION
## Summary

- Add Compose as a native SwiftUI inspector beside the active Agent Mode chat, with Selections, Prompt, and Context Builder tabs
- Open Compose from the Agent Mode toolbar, selected-files pill, or customizable Toggle Compose keyboard shortcut, with consistent presentation state across entry points
- Add filtering, sorting, root attribution, full/codemap/slice actions, bounded previews, and readiness-aware token, percentage, and line metrics to Selections
- Publish selected-file rows and counts independently from codemap calculation, preserving matching metrics when available and showing explicit unknown states instead of blocking otherwise-ready context
- Keep context presentation stable across chat switches and refreshes, and permit selection mutations only from the active tab’s completed canonical projection
- Redesign Prompt around existing presets, stored prompts, File Tree, Code Map, and Git controls, with Copy Prompt capturing one coherent click-time snapshot of prompt text, selection, worktree bindings, and Git comparison state
- Embed the existing Context Builder workflow in Compose, including discovery configuration, run/cancel state, tool progress, generated Plan, Review, or Question output, and routing through the existing Agent Oracle flow
- Use the native SwiftUI inspector for sizing and resizing while isolating high-frequency Compose observation from the chat transcript to avoid resize and interaction lag

## Implementation Notes

- Compose reads selected context through the existing export resolver and selected-files model coordinator, while all selection mutations continue through the canonical workspace selection coordinator
- File and codemap readiness are modeled independently: explicit file rows can render while codemaps are pending, and cached metrics are reused only when their selection and configuration identity still matches
- Copy Prompt resolves a fresh export source at click time, reuses projected lookup data only for an exact context identity match, and freezes Git inputs before asynchronous packaging begins
- Context Builder is embedded through its existing view and view model rather than introducing a parallel Compose-specific execution path
- Presentation state is window/runtime scoped, while durable prompt, selection, and Context Builder state remains with its existing owners

## Review Approach

- The work received >90 incremental `rp-review`-assisted reviews across the implementation, with findings addressed as each area evolved
- The consolidated patch then received a bounded integration review using GPT-5.6 Sol XHigh across selection and accounting, prompt/export/Git, inspector lifecycle, and Context Builder integration, followed by cross-scope synthesis and focused re-review
- Findings were accepted only after confirming a reachable code path and concrete consequence; affected scopes were re-reviewed after fixes, and the final integration reviews concluded 'Ship'

## Validation

Passed locally on the rebased branch:

- Focused Compose tests:
  - `make dev-test FILTER=AgentContextExportResolverTests` -- 53 tests
  - `make dev-test FILTER=AgentSelectedFilesModelCoordinatorTests` -- 29 tests
  - `make dev-test FILTER=AgentContextDrawerUIStoreTests` -- 2 tests
  - `make dev-test FILTER=WorkspaceProjectedPathSearchTests` -- 9 tests
  - `make dev-test FILTER=ContextBuilderWorktreeInheritanceTests` -- 9 tests
- Authoritative root/provider listings and exact contract-ledger verification -- 3,346 entries
- `make dev-lint` — SwiftFormat: 0/1,470 files require formatting; SwiftLint strict passed
- Commit preflight: whitespace, staged-index secret scan, and repository guardrails

However, the latest `pr-ready` run didn't complete the full root suite. It reported failures in existing worktree-initialization and Codex liveness/fallback tests, so full-suite validation is still TBD

## Live App Validation

- Built, signed, packaged, and relaunched the CE debug app through conductor
- Passed packaged-app architecture, code-signing, embedded MCP helper layout, helper smoke, and live CE MCP smoke validation
- Manually confirmed Compose opens and closes through the toolbar, selected-files pill, and keyboard shortcut while preserving the active Agent Mode chat and selection
- Manually confirmed the selected-files pill targets **Selections**, switches to it from another Compose tab, and closes the inspector when **Selections** is already active
- Manually confirmed available file rows and counts render while codemap calculation remains pending, with unknown codemap metrics withheld rather than displayed as zero
- Exercised the feature across existing and new agent chats, inspector widths, and display sizes

## Known Follow-ups

- Codemap calculation can remain slow in some workspaces because readiness and generation are handled by the upstream background codemap pipeline. Compose publishes ready file rows and counts independently; improving codemap scheduling, progress feedback, and generation performance is separate follow-up work
- Copy Prompt can take longer than expected for large or codemap-heavy contexts. Its click-time snapshot and packaging correctness are covered here; latency profiling and optimization remain follow-up work
- At maximum inspector width on a 14-inch display, the agent chat title can intrude into the Compose chrome. This needs a separate title/chrome-layer solution; an earlier attempt to re-host the native inspector caused severe lifecycle instability

## Hosted Checks

- GitHub Secret Scan: passed
- GitHub Provider Tests: passed
- GitHub Style: passed
- GitHub Build and Test: passed
- GitHub Sentry-enabled Build: passed

## Screenshots

<img width="670" height="745" alt="Screenshot 2026-07-13 at 1 06 46 AM" src="https://github.com/user-attachments/assets/89034fbb-77b5-4b67-af2e-e2a81ff27124" />
<img width="669" height="745" alt="Screenshot 2026-07-13 at 1 12 09 AM" src="https://github.com/user-attachments/assets/fc5a26b4-282e-496c-a68b-b6bf030c3311" />
<img width="664" height="749" alt="Screenshot 2026-07-13 at 1 11 35 AM" src="https://github.com/user-attachments/assets/63ec1579-5071-4e8d-a07a-80fcdad6dad9" />
<img width="781" height="757" alt="Screenshot 2026-07-13 at 1 11 41 AM" src="https://github.com/user-attachments/assets/8697e1cd-520e-4804-b0b6-bb4d01938f9d" />
<img width="668" height="795" alt="Screenshot 2026-07-13 at 1 08 33 AM" src="https://github.com/user-attachments/assets/d3b5c212-1e50-46ba-81a3-01b907f97e97" />
<img width="670" height="742" alt="Screenshot 2026-07-13 at 1 11 26 AM" src="https://github.com/user-attachments/assets/8f611d2d-4e55-4ed3-b50c-590f0d0c9496" />