### PR TITLE
fix(release): support Sentry org:ci tokens

### DIFF
--- a/Scripts/promote_release.sh
+++ b/Scripts/promote_release.sh
@@ -124,7 +124,7 @@ sentry_api_request() {
     status="$(curl "${args[@]}" "$(sentry_deploy_endpoint)")" ||
         fail "Unable to call the Sentry deploy API"
     if [[ "$status" == "403" ]]; then
-        fail "Sentry deploy API rejected the promotion token (HTTP 403); verify the manual project:releases release gate"
+        fail "Sentry deploy API rejected the organization token (HTTP 403); verify org:ci access to $REPOPROMPT_SENTRY_ORG/$REPOPROMPT_SENTRY_PROJECT"
     fi
     [[ "$status" =~ ^2[0-9][0-9]$ ]] ||
         fail "Sentry deploy API request failed with HTTP $status"

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -22,6 +22,8 @@ CHECKSUMS="$DIST_DIR/SHA256SUMS"
 BUILD_ARTIFACT_MANIFEST="$ROOT_DIR/.build/release/$APP_NAME-artifact-manifest.json"
 SENTRY_SYMBOLS_DIR="$ROOT_DIR/.build/sentry-symbols/release"
 SENTRY_RELEASE_NAME="$BUNDLE_ID@$MARKETING_VERSION+$BUILD_NUMBER"
+SENTRY_API_BASE_URL="${REPOPROMPT_SENTRY_API_BASE_URL:-https://sentry.io/api/0}"
+SENTRY_CURL_CONFIG=""
 FINAL_ARTIFACT_MANIFEST="$DIST_DIR/$ARCHIVE_BASENAME-artifact-manifest.json"
 STAGE_ARCHIVE="$DIST_DIR/$ARCHIVE_BASENAME-stage.zip"
 STAGE_ARCHIVE_CHECKSUM="$STAGE_ARCHIVE.sha256"
@@ -187,52 +189,188 @@ require_sentry_publish_configuration() {
     [[ -n "${SENTRY_AUTH_TOKEN:-}" || -n "${REPOPROMPT_SENTRY_AUTH_TOKEN_FILE:-${SENTRY_AUTH_TOKEN_FILE:-}}" ]] || fail "Official Sentry-enabled release publishing requires SENTRY_AUTH_TOKEN or REPOPROMPT_SENTRY_AUTH_TOKEN_FILE for Sentry release metadata and debug symbol upload."
     require_env REPOPROMPT_SENTRY_ORG
     require_env REPOPROMPT_SENTRY_PROJECT
+    require_command curl
+    require_command jq
     require_command sentry-cli
 }
 
-load_sentry_auth_token_for_publish() {
+prepare_sentry_api_access() {
     sentry_linking_enabled || return 0
-    if [[ -z "${SENTRY_AUTH_TOKEN:-}" ]]; then
-        local token_file="${REPOPROMPT_SENTRY_AUTH_TOKEN_FILE:-${SENTRY_AUTH_TOKEN_FILE:-}}"
-        [[ -n "$token_file" ]] || fail "Missing Sentry auth token file"
-        [[ -f "$token_file" ]] || fail "Sentry auth token file does not exist: $token_file"
-        SENTRY_AUTH_TOKEN="$(tr -d '\r\n' < "$token_file")"
-        export SENTRY_AUTH_TOKEN
+    [[ -n "$SENTRY_CURL_CONFIG" && -f "$SENTRY_CURL_CONFIG" ]] && return 0
+    [[ -n "$TMP_DIR" ]] || fail "Sentry API access requires an initialized release workspace"
+    local token="${SENTRY_AUTH_TOKEN:-}"
+    if [[ -z "$token" ]]; then
+        local configured_token_file="${REPOPROMPT_SENTRY_AUTH_TOKEN_FILE:-${SENTRY_AUTH_TOKEN_FILE:-}}"
+        [[ -n "$configured_token_file" ]] || fail "Missing Sentry auth token file"
+        [[ -f "$configured_token_file" ]] || fail "Sentry auth token file does not exist: $configured_token_file"
+        token="$(tr -d '\r\n' < "$configured_token_file")"
     fi
-    [[ -n "$SENTRY_AUTH_TOKEN" ]] || fail "Sentry auth token file was empty"
+    [[ -n "$token" ]] || fail "Sentry auth token file was empty"
+
+    SENTRY_CURL_CONFIG="$TMP_DIR/sentry-curl.conf"
+    local normalized_token_file="$TMP_DIR/sentry-auth-token"
+    (
+        umask 077
+        printf '%s' "$token" > "$normalized_token_file"
+        printf 'header = "Authorization: Bearer %s"\n' "$token" > "$SENTRY_CURL_CONFIG"
+    )
+    chmod 600 "$normalized_token_file" "$SENTRY_CURL_CONFIG"
+    REPOPROMPT_SENTRY_AUTH_TOKEN_FILE="$normalized_token_file"
+    export REPOPROMPT_SENTRY_AUTH_TOKEN_FILE
+    unset SENTRY_AUTH_TOKEN
+}
+
+sentry_releases_endpoint() {
+    local encoded_org
+    encoded_org="$(jq -rn --arg value "$REPOPROMPT_SENTRY_ORG" '$value | @uri')"
+    printf '%s/organizations/%s/releases/' "${SENTRY_API_BASE_URL%/}" "$encoded_org"
+}
+
+sentry_release_endpoint() {
+    local encoded_release
+    encoded_release="$(jq -rn --arg value "$SENTRY_RELEASE_NAME" '$value | @uri')"
+    printf '%s%s/' "$(sentry_releases_endpoint)" "$encoded_release"
+}
+
+sentry_release_preflight_endpoint() {
+    local encoded_project
+    encoded_project="$(jq -rn --arg value "$REPOPROMPT_SENTRY_PROJECT" '$value | @uri')"
+    printf '%s?project=%s&per_page=1' "$(sentry_releases_endpoint)" "$encoded_project"
+}
+
+sentry_api_request() {
+    local method="$1"
+    local endpoint="$2"
+    local output_file="$3"
+    local body_file="${4:-}"
+    local args=(
+        --silent
+        --show-error
+        --output "$output_file"
+        --write-out '%{http_code}'
+        --request "$method"
+        --config "$SENTRY_CURL_CONFIG"
+        --header 'Accept: application/json'
+    )
+    if [[ -n "$body_file" ]]; then
+        args+=(--header 'Content-Type: application/json' --data-binary "@$body_file")
+    fi
+
+    local status
+    status="$(curl "${args[@]}" "$endpoint")" ||
+        fail "Unable to call the Sentry release API"
+    [[ "$status" =~ ^[0-9]{3}$ ]] || fail "Sentry release API returned an invalid HTTP status"
+    printf '%s' "$status"
+}
+
+fail_sentry_release_api_status() {
+    local action="$1"
+    local status="$2"
+    case "$status" in
+        401)
+            fail "Sentry release API rejected the organization token (HTTP 401); verify that SENTRY_AUTH_TOKEN is current"
+            ;;
+        403)
+            fail "Sentry release API rejected the organization token (HTTP 403); verify org:ci access to $REPOPROMPT_SENTRY_ORG/$REPOPROMPT_SENTRY_PROJECT"
+            ;;
+        *)
+            fail "Sentry release API could not $action (HTTP $status)"
+            ;;
+    esac
+}
+
+validate_sentry_release_response() {
+    local response_file="$1"
+    local label="$2"
+    jq -e \
+        --arg version "$SENTRY_RELEASE_NAME" \
+        --arg project "$REPOPROMPT_SENTRY_PROJECT" \
+        '.version == $version and
+            (.projects | type == "array") and
+            any(.projects[]?; .slug == $project)' \
+        "$response_file" >/dev/null ||
+        fail "Sentry release API returned malformed or mismatched JSON for $label"
+}
+
+preflight_sentry_release_access() {
+    sentry_linking_enabled || return 0
+    prepare_sentry_api_access
+    local response_file="$TMP_DIR/sentry-release-preflight.json"
+    local status
+    status="$(sentry_api_request GET "$(sentry_release_preflight_endpoint)" "$response_file")"
+    [[ "$status" =~ ^2[0-9][0-9]$ ]] ||
+        fail_sentry_release_api_status "verify release access" "$status"
+    jq -e 'type == "array" and all(.[]; .version | type == "string")' "$response_file" >/dev/null ||
+        fail "Sentry release API returned malformed JSON during access preflight"
+    printf 'OK: Sentry org:ci release access verified for %s/%s.\n' \
+        "$REPOPROMPT_SENTRY_ORG" "$REPOPROMPT_SENTRY_PROJECT"
 }
 
 prepare_sentry_release() {
     sentry_linking_enabled || return 0
-    load_sentry_auth_token_for_publish
+    prepare_sentry_api_access
     local source_repository="${SOURCE_GITHUB_REPOSITORY:-$GITHUB_REPOSITORY}"
     [[ -n "$source_repository" ]] || fail "Missing SOURCE_GITHUB_REPOSITORY for Sentry commit association"
     printf 'Preparing Sentry release %s for %s/%s.\n' "$SENTRY_RELEASE_NAME" "$REPOPROMPT_SENTRY_ORG" "$REPOPROMPT_SENTRY_PROJECT"
-    local lookup_error=""
-    if lookup_error="$(sentry-cli --org "$REPOPROMPT_SENTRY_ORG" releases info "$SENTRY_RELEASE_NAME" 2>&1 >/dev/null)"; then
-        :
-    else
-        local normalized_lookup_error
-        normalized_lookup_error="$(printf '%s' "$lookup_error" | tr '[:upper:]' '[:lower:]')"
-        if [[ "$normalized_lookup_error" == *"release not found"* ||
-            "$normalized_lookup_error" == *"release does not exist"* ||
-            "$normalized_lookup_error" =~ (^|[^0-9])404([^0-9]|$) ]]; then
-            sentry-cli --org "$REPOPROMPT_SENTRY_ORG" releases new \
-                --project "$REPOPROMPT_SENTRY_PROJECT" \
-                "$SENTRY_RELEASE_NAME"
-        else
-            fail "Unable to look up Sentry release $SENTRY_RELEASE_NAME; refusing to create it after an authentication, authorization, or network failure."
-        fi
+    local release_response="$TMP_DIR/sentry-release.json"
+    local status
+    status="$(sentry_api_request GET "$(sentry_release_endpoint)" "$release_response")"
+    if [[ "$status" == "404" ]]; then
+        local create_body="$TMP_DIR/sentry-release-create.json"
+        jq -n \
+            --arg version "$SENTRY_RELEASE_NAME" \
+            --arg project "$REPOPROMPT_SENTRY_PROJECT" \
+            --arg repository "$source_repository" \
+            --arg commit "$RELEASE_COMMIT" \
+            '{version: $version, projects: [$project], refs: [{repository: $repository, commit: $commit}]}' \
+            > "$create_body"
+        chmod 600 "$create_body"
+        status="$(sentry_api_request POST "$(sentry_releases_endpoint)" "$release_response" "$create_body")"
+        [[ "$status" =~ ^2[0-9][0-9]$ ]] ||
+            fail_sentry_release_api_status "create release $SENTRY_RELEASE_NAME" "$status"
+    elif [[ ! "$status" =~ ^2[0-9][0-9]$ ]]; then
+        fail_sentry_release_api_status "look up release $SENTRY_RELEASE_NAME" "$status"
     fi
-    sentry-cli --org "$REPOPROMPT_SENTRY_ORG" releases set-commits \
-        "$SENTRY_RELEASE_NAME" \
-        --commit "$source_repository@$RELEASE_COMMIT"
+    validate_sentry_release_response "$release_response" "release preparation"
+
+    local refs_body="$TMP_DIR/sentry-release-refs.json"
+    jq -n \
+        --arg repository "$source_repository" \
+        --arg commit "$RELEASE_COMMIT" \
+        '{refs: [{repository: $repository, commit: $commit}]}' > "$refs_body"
+    chmod 600 "$refs_body"
+    status="$(sentry_api_request PUT "$(sentry_release_endpoint)" "$release_response" "$refs_body")"
+    [[ "$status" =~ ^2[0-9][0-9]$ ]] ||
+        fail_sentry_release_api_status "associate release commits" "$status"
+    validate_sentry_release_response "$release_response" "commit association"
 }
 
 finalize_sentry_release() {
     sentry_linking_enabled || return 0
-    load_sentry_auth_token_for_publish
-    sentry-cli --org "$REPOPROMPT_SENTRY_ORG" releases finalize "$SENTRY_RELEASE_NAME"
+    prepare_sentry_api_access
+    local release_response="$TMP_DIR/sentry-release-finalize.json"
+    local status
+    status="$(sentry_api_request GET "$(sentry_release_endpoint)" "$release_response")"
+    [[ "$status" =~ ^2[0-9][0-9]$ ]] ||
+        fail_sentry_release_api_status "look up release $SENTRY_RELEASE_NAME before finalization" "$status"
+    validate_sentry_release_response "$release_response" "release finalization"
+    if jq -e '.dateReleased | type == "string"' "$release_response" >/dev/null; then
+        printf 'OK: Sentry release %s is already finalized.\n' "$SENTRY_RELEASE_NAME"
+        return
+    fi
+    jq -e '.dateReleased == null' "$release_response" >/dev/null ||
+        fail "Sentry release API returned malformed finalization state"
+
+    local finalize_body="$TMP_DIR/sentry-release-finalize-body.json"
+    jq -n --arg date_released "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
+        '{dateReleased: $date_released}' > "$finalize_body"
+    chmod 600 "$finalize_body"
+    status="$(sentry_api_request PUT "$(sentry_release_endpoint)" "$release_response" "$finalize_body")"
+    [[ "$status" =~ ^2[0-9][0-9]$ ]] ||
+        fail_sentry_release_api_status "finalize release $SENTRY_RELEASE_NAME" "$status"
+    validate_sentry_release_response "$release_response" "release finalization"
+    jq -e '.dateReleased | type == "string"' "$release_response" >/dev/null ||
+        fail "Sentry release API did not confirm finalization"
 }
 
 upload_required_sentry_symbols() {
@@ -348,6 +486,7 @@ publish_staged_release() {
     verify_publish_inputs
     require_env REPOPROMPT_APPROVED_SOURCE_ROOT
     TMP_DIR="$(mktemp -d)"
+    preflight_sentry_release_access
 
     [[ -d "$APP_BUNDLE" ]] || fail "Missing secret-free staged app bundle: $APP_BUNDLE"
     REPOPROMPT_RELEASE_SOURCE_ROOT="$ROOT_DIR" \

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -1270,41 +1270,107 @@ printf '%s' "${SENTRY_AUTH_TOKEN:-}" > "$TOKEN_CAPTURE"
         self,
         lookup_mode: str,
         attempts: int = 1,
-    ) -> tuple[subprocess.CompletedProcess[str], list[str]]:
+    ) -> tuple[subprocess.CompletedProcess[str], list[dict[str, object]]]:
         temp_dir = Path(tempfile.mkdtemp())
         self.addCleanup(shutil.rmtree, temp_dir, True)
-        call_log = temp_dir / "sentry-calls.log"
-        release_state = temp_dir / "release-created"
-        fake_cli = temp_dir / "sentry-cli"
-        fake_cli.write_text(
-            """#!/usr/bin/env bash
-set -euo pipefail
-printf '%s\n' "$*" >> "$SENTRY_CALL_LOG"
-if [[ "$*" == *"releases info"* ]]; then
-    case "$SENTRY_LOOKUP_MODE" in
-        not-found-once)
-            if [[ -f "$SENTRY_RELEASE_STATE" ]]; then
-                exit 0
-            fi
-            printf 'error: release not found (404)\n' >&2
-            exit 1
-            ;;
-        denied)
-            printf 'error: authentication failed\n' >&2
-            exit 2
-            ;;
-        existing)
-            exit 0
-            ;;
-    esac
-fi
-if [[ "$*" == *"releases new"* ]]; then
-    : > "$SENTRY_RELEASE_STATE"
-fi
+        call_log = temp_dir / "sentry-api-calls.jsonl"
+        release_state = temp_dir / "sentry-release.json"
+        api_tmp = temp_dir / "api-tmp"
+        api_tmp.mkdir()
+        fake_curl = temp_dir / "curl"
+        fake_curl.write_text(
+            """#!/usr/bin/env python3
+import json
+import os
+import stat
+import sys
+from pathlib import Path
+from urllib.parse import unquote, urlparse
+
+args = sys.argv[1:]
+
+def option(name):
+    return args[args.index(name) + 1]
+
+config = Path(option("--config"))
+if stat.S_IMODE(config.stat().st_mode) != 0o600:
+    raise SystemExit(90)
+if config.read_text(encoding="utf-8") != 'header = "Authorization: Bearer fixture-token"\\n':
+    raise SystemExit(91)
+token_file = Path(os.environ["REPOPROMPT_SENTRY_AUTH_TOKEN_FILE"])
+if stat.S_IMODE(token_file.stat().st_mode) != 0o600:
+    raise SystemExit(92)
+if token_file.read_text(encoding="utf-8") != "fixture-token":
+    raise SystemExit(93)
+if "SENTRY_AUTH_TOKEN" in os.environ:
+    raise SystemExit(94)
+
+scenario = os.environ["SENTRY_LOOKUP_MODE"]
+if scenario == "transport":
+    raise SystemExit(7)
+
+method = option("--request")
+output = Path(option("--output"))
+url = args[-1]
+body = None
+if "--data-binary" in args:
+    body_arg = option("--data-binary")
+    if not body_arg.startswith("@"):
+        raise SystemExit(95)
+    body = json.loads(Path(body_arg[1:]).read_text(encoding="utf-8"))
+
+with Path(os.environ["SENTRY_CALL_LOG"]).open("a", encoding="utf-8") as handle:
+    handle.write(json.dumps({"method": method, "url": url, "body": body}) + "\\n")
+
+state_path = Path(os.environ["SENTRY_RELEASE_STATE"])
+parsed = urlparse(url)
+is_preflight = parsed.query != ""
+is_collection = parsed.path.endswith("/releases/")
+version = unquote(parsed.path.rstrip("/").split("/")[-1])
+
+def release_payload():
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    return {
+        "version": state["version"],
+        "projects": [{"slug": "fixture-project"}],
+        "dateReleased": state.get("dateReleased"),
+    }
+
+if is_preflight:
+    if scenario == "unauthorized":
+        status, response = 401, {"detail": "SECRET_BODY_MARKER"}
+    elif scenario == "denied":
+        status, response = 403, {"detail": "SECRET_BODY_MARKER"}
+    elif scenario == "malformed":
+        status, response = 200, {}
+    else:
+        status, response = 200, []
+elif method == "GET" and not is_collection:
+    if state_path.exists():
+        status, response = 200, release_payload()
+    else:
+        status, response = 404, {"detail": "SECRET_BODY_MARKER"}
+elif method == "POST" and is_collection:
+    state_path.write_text(
+        json.dumps({"version": body["version"], "dateReleased": None}),
+        encoding="utf-8",
+    )
+    status, response = 201, release_payload()
+elif method == "PUT" and not is_collection and state_path.exists():
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    if "dateReleased" in body:
+        state["dateReleased"] = body["dateReleased"]
+        state_path.write_text(json.dumps(state), encoding="utf-8")
+    status, response = 200, release_payload()
+else:
+    status, response = 500, {"detail": "unexpected fixture request", "version": version}
+
+output.write_text(json.dumps(response), encoding="utf-8")
+sys.stdout.write(str(status))
 """,
             encoding="utf-8",
         )
-        fake_cli.chmod(0o755)
+        fake_curl.chmod(0o755)
         env = os.environ.copy()
         env.update(
             {
@@ -1313,11 +1379,13 @@ fi
                 "SENTRY_AUTH_TOKEN": "fixture-token",
                 "REPOPROMPT_SENTRY_ORG": "fixture-org",
                 "REPOPROMPT_SENTRY_PROJECT": "fixture-project",
+                "REPOPROMPT_SENTRY_API_BASE_URL": "https://sentry.example/api/0",
                 "SOURCE_GITHUB_REPOSITORY": "fixture/repository",
                 "RELEASE_COMMIT": "0123456789abcdef",
                 "SENTRY_LOOKUP_MODE": lookup_mode,
                 "SENTRY_CALL_LOG": str(call_log),
                 "SENTRY_RELEASE_STATE": str(release_state),
+                "FIXTURE_TMP_DIR": str(api_tmp),
                 "ATTEMPTS": str(attempts),
             }
         )
@@ -1325,7 +1393,10 @@ fi
             [
                 "bash",
                 "-c",
-                'source "$1"; for ((attempt = 0; attempt < ATTEMPTS; attempt++)); do prepare_sentry_release; done',
+                'source "$1"; TMP_DIR="$FIXTURE_TMP_DIR"; '
+                "preflight_sentry_release_access; "
+                "for ((attempt = 0; attempt < ATTEMPTS; attempt++)); do prepare_sentry_release; done; "
+                "finalize_sentry_release; finalize_sentry_release",
                 "sentry-release-test",
                 str(SCRIPT_DIR / "release.sh"),
             ],
@@ -1333,40 +1404,69 @@ fi
             text=True,
             capture_output=True,
         )
-        calls = call_log.read_text(encoding="utf-8").splitlines() if call_log.exists() else []
+        calls = (
+            [json.loads(line) for line in call_log.read_text(encoding="utf-8").splitlines()]
+            if call_log.exists()
+            else []
+        )
         return result, calls
 
     def test_sentry_release_prepare_creates_only_for_not_found_and_is_retry_safe(self) -> None:
         result, calls = self.run_sentry_prepare_fixture("not-found-once", attempts=2)
 
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual(sum("releases info" in call for call in calls), 2)
-        self.assertEqual(sum("releases new" in call for call in calls), 1)
-        self.assertEqual(sum("releases set-commits" in call for call in calls), 2)
-        self.assertTrue(
-            any(
-                "--org fixture-org releases new --project fixture-project "
-                "com.pvncher.repoprompt.ce@" in call
-                for call in calls
-            )
+        collection_posts = [call for call in calls if call["method"] == "POST"]
+        refs_updates = [
+            call
+            for call in calls
+            if call["method"] == "PUT" and "refs" in (call["body"] or {})
+        ]
+        finalizations = [
+            call
+            for call in calls
+            if call["method"] == "PUT" and "dateReleased" in (call["body"] or {})
+        ]
+        self.assertEqual(len(collection_posts), 1)
+        self.assertEqual(len(refs_updates), 2)
+        self.assertEqual(len(finalizations), 1)
+        self.assertEqual(
+            collection_posts[0]["body"]["refs"],
+            [{"repository": "fixture/repository", "commit": "0123456789abcdef"}],
         )
-        self.assertTrue(
-            all(
-                "--commit fixture/repository@0123456789abcdef" in call
-                for call in calls
-                if "releases set-commits" in call
-            )
-        )
+        self.assertTrue(all("%40" in call["url"] and "%2B" in call["url"] for call in refs_updates))
+        self.assertIn("already finalized", result.stdout)
+        self.assertNotIn("fixture-token", result.stdout + result.stderr + json.dumps(calls))
+        self.assertNotIn("SECRET_BODY_MARKER", result.stdout + result.stderr)
 
     def test_sentry_release_prepare_does_not_create_after_lookup_failure(self) -> None:
         result, calls = self.run_sentry_prepare_fixture("denied")
 
         self.assertNotEqual(result.returncode, 0)
-        self.assertEqual(sum("releases info" in call for call in calls), 1)
-        self.assertFalse(any("releases new" in call for call in calls))
-        self.assertFalse(any("releases set-commits" in call for call in calls))
-        self.assertIn("refusing to create it", result.stderr)
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0]["method"], "GET")
+        self.assertFalse(any(call["method"] in {"POST", "PUT"} for call in calls))
+        self.assertIn("org:ci access", result.stderr)
         self.assertNotIn("fixture-token", result.stdout + result.stderr)
+        self.assertNotIn("SECRET_BODY_MARKER", result.stdout + result.stderr)
+
+    def test_sentry_release_preflight_distinguishes_invalid_token_without_mutation(self) -> None:
+        result, calls = self.run_sentry_prepare_fixture("unauthorized")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(len(calls), 1)
+        self.assertFalse(any(call["method"] in {"POST", "PUT"} for call in calls))
+        self.assertIn("HTTP 401", result.stderr)
+        self.assertIn("SENTRY_AUTH_TOKEN is current", result.stderr)
+        self.assertNotIn("fixture-token", result.stdout + result.stderr)
+        self.assertNotIn("SECRET_BODY_MARKER", result.stdout + result.stderr)
+
+    def test_sentry_release_preflight_rejects_malformed_json_before_mutation(self) -> None:
+        result, calls = self.run_sentry_prepare_fixture("malformed")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(len(calls), 1)
+        self.assertFalse(any(call["method"] in {"POST", "PUT"} for call in calls))
+        self.assertIn("malformed JSON during access preflight", result.stderr)
 
     def test_sentry_symbol_flow_is_explicit_secret_safe_and_release_only_by_default(self) -> None:
         package_script = (SCRIPT_DIR / "package_app.sh").read_text(encoding="utf-8")
@@ -1393,15 +1493,19 @@ fi
         self.assertIn('SENTRY_RELEASE_NAME="$BUNDLE_ID@$MARKETING_VERSION+$BUILD_NUMBER"', release_script)
         self.assertIn('require_sentry_publish_configuration() {', release_script)
         self.assertIn('require_command sentry-cli', release_script)
+        self.assertIn('preflight_sentry_release_access', release_script)
         self.assertIn('prepare_sentry_release', release_script)
-        self.assertIn('releases new', release_script)
-        self.assertIn('releases set-commits', release_script)
-        self.assertIn('--commit "$source_repository@$RELEASE_COMMIT"', release_script)
+        self.assertIn('sentry_api_request POST', release_script)
+        self.assertIn('sentry_api_request PUT', release_script)
+        self.assertIn("'{refs: [{repository: $repository, commit: $commit}]}'", release_script)
         self.assertIn('finalize_sentry_release', release_script)
-        self.assertIn('releases finalize "$SENTRY_RELEASE_NAME"', release_script)
+        self.assertIn("'{dateReleased: $date_released}'", release_script)
+        self.assertNotIn('sentry-cli --org', release_script)
         self.assertNotIn('record_sentry_production_deploy', release_script)
         self.assertNotIn('releases deploys "$SENTRY_RELEASE_NAME" new', release_script)
-        self.assertIn('SENTRY_AUTH_TOKEN="$(tr -d', release_script)
+        self.assertIn('token="$(tr -d', release_script)
+        self.assertIn('REPOPROMPT_SENTRY_AUTH_TOKEN_FILE="$normalized_token_file"', release_script)
+        self.assertIn('unset SENTRY_AUTH_TOKEN', release_script)
 
         self.assertIn('preflight_sentry_deploy_access', promote_script)
         self.assertIn('record_verified_sentry_deploy_if_needed', promote_script)
@@ -1412,6 +1516,10 @@ fi
         self.assertNotIn("--retry", sentry_request)
 
         publish_staged = release_script.split("publish_staged_release() {", 1)[1].split("\n}\n\ncase", 1)[0]
+        self.assertLess(
+            publish_staged.index("preflight_sentry_release_access"),
+            publish_staged.index("sign_staged_release.sh"),
+        )
         self.assertLess(publish_staged.index("prepare_sentry_release"), publish_staged.index("upload_required_sentry_symbols"))
         self.assertLess(publish_staged.index("upload_required_sentry_symbols"), publish_staged.index("gh release view"))
         self.assertLess(publish_staged.index("gh release view"), publish_staged.index("gh release create"))

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -287,7 +287,7 @@ Add these environment secrets:
 | `PUBLIC_UPDATE_REPOSITORY_TOKEN` | Fine-grained GitHub token scoped only to `repoprompt/repoprompt-ce-updates` with repository contents read/write permission. |
 | `TIP_UPDATE_REPOSITORY_TOKEN` | Fine-grained GitHub token scoped only to `repoprompt/repoprompt-ce-tip-updates` with repository contents read/write permission. Do not reuse the stable update token. |
 | `SENTRY_DSN` | Sentry DSN injected into official signed builds for release routing. It is not a credential, but keep it in the protected release environment so unofficial artifacts do not route telemetry to the official project. |
-| `SENTRY_AUTH_TOKEN` | Sentry release token used for draft-time debug-symbol/release metadata and verified-promotion deploy recording. Provisioning it with `project:releases` only is a manual release gate; tooling does not inspect or change token scopes. |
+| `SENTRY_AUTH_TOKEN` | Sentry Organization Token used for draft-time debug-symbol/release metadata and verified-promotion deploy recording. Create it with the fixed `org:ci` scope; Organization Token scopes are immutable, and release tooling does not inspect or change them. |
 
 Add these non-secret release environment variables when Sentry symbol upload is enabled:
 
@@ -313,8 +313,11 @@ When Sentry is enabled, release staging generates dSYMs under
 `.build/sentry-symbols/release` and carries them inside the staged release ZIP.
 `release.sh publish-staged` requires `SENTRY_AUTH_TOKEN` (or
 `REPOPROMPT_SENTRY_AUTH_TOKEN_FILE`), `REPOPROMPT_SENTRY_ORG`, and
-`REPOPROMPT_SENTRY_PROJECT` for official Sentry-enabled releases, then uploads
-those debug symbols. After the GitHub draft exists, it finalizes the Sentry
+`REPOPROMPT_SENTRY_PROJECT` for official Sentry-enabled releases. Before code
+signing or notarization, it performs a read-only release API preflight. Release
+lookup, creation, commit association, and finalization use Sentry's release API,
+which accepts Organization Tokens with `org:ci`; only debug-symbol upload uses
+`sentry-cli`. After the GitHub draft exists, the script finalizes the Sentry
 release to mark its commit metadata and symbols ready. Finalization does not
 mean that the release is deployed to production.
 The upload helper runs:


### PR DESCRIPTION
## Summary

- use Sentry's organization release API for release lookup, creation, commit association, and finalization
- add a read-only `org:ci` access preflight before signing or notarization
- keep `sentry-cli debug-files upload` as the only CLI-based Sentry operation
- normalize the token into mode-`0600` temporary files and remove the raw token from child-process environments
- document Sentry Organization Tokens and correct the promotion error guidance

## Root cause

The publish workflow used `sentry-cli releases info/new/set-commits/finalize`. Sentry Organization Tokens expose the fixed `org:ci` scope, which the documented release API accepts, but the CLI lookup path additionally attempted an organization query that rejected the token. That made a valid CI token fail only after signing and notarization had completed.

## Safety and recovery

- preflight is read-only and runs before code signing
- `401` and `403` are distinguished without printing API response bodies or credentials
- release creation happens only after an exact `404`
- POST is not automatically retried; a rerun performs an exact lookup and resumes an already-created release
- commit association and finalization are idempotent
- release/project response JSON is validated before continuing

## Validation

- `python3 Scripts/test_release_tooling.py` (66 tests)
- `make guardrails`
- `shellcheck -e SC1091,SC2034,SC2153 Scripts/release.sh Scripts/promote_release.sh`
- `make dev-release-preflight`
- contribution `commit`, `push`, and `pr-ready` preflights
