### PR TITLE
Dismiss tooltips when owner windows change lifecycle

### DIFF
--- a/Sources/RepoPrompt/Infrastructure/UI/Tooltip/TooltipOverlayController.swift
+++ b/Sources/RepoPrompt/Infrastructure/UI/Tooltip/TooltipOverlayController.swift
@@ -137,11 +137,11 @@ final class TooltipOverlayController {
             owner.removeChildWindow(w)
         }
 
-        // Remove notification observer
-        if let token = ownerWillCloseObserver {
+        // Remove notification observers
+        for token in ownerLifecycleObservers {
             NotificationCenter.default.removeObserver(token)
-            ownerWillCloseObserver = nil
         }
+        ownerLifecycleObservers.removeAll()
 
         win = nil
         owner = nil
@@ -158,7 +158,7 @@ final class TooltipOverlayController {
     private var cachedPlacement: TooltipPlacement = .top
     private var cachedPreset: FontScalePreset?
 
-    private var ownerWillCloseObserver: NSObjectProtocol?
+    private var ownerLifecycleObservers: [NSObjectProtocol] = []
 
     /// Distance (in points) between the tooltip bubble and its anchor view.
     /// Kept small to avoid a large visual gap; still multiplied by
@@ -178,15 +178,22 @@ final class TooltipOverlayController {
         // This avoids hierarchy issues with menus
         win = tooltipWindow
 
-        ownerWillCloseObserver = NotificationCenter.default.addObserver(
-            forName: NSWindow.willCloseNotification,
-            object: owner,
-            queue: .main
-        ) // ensure main thread
-            { [weak self] _ in
-                Task { @MainActor [weak self] in
-                    self?.hide()
+        for notification in [
+            NSWindow.willCloseNotification,
+            NSWindow.didResignKeyNotification,
+            NSWindow.didMoveNotification
+        ] {
+            ownerLifecycleObservers.append(
+                NotificationCenter.default.addObserver(
+                    forName: notification,
+                    object: owner,
+                    queue: .main
+                ) { [weak self] _ in
+                    Task { @MainActor [weak self] in
+                        self?.hide()
+                    }
                 }
+            )
         }
     }
 


### PR DESCRIPTION
## Summary

- dismiss a hover tooltip when its owning window closes, moves, or resigns key-window status
- clean up all owner-lifecycle notification observers through the existing `hide()` path
- keep tooltip presentation independent of MCP call sites and preserve the existing non-child-window hierarchy

Closes #563.

## Root cause

The shared tooltip overlay is a standalone borderless `NSWindow` at `.floating` level. It previously observed only `NSWindow.willCloseNotification`.

SwiftUI popovers may be ordered out or resign key-window status without closing their backing window. The tooltip could therefore outlive the MCP Server popover, remain at its previous screen coordinates, and float above unrelated windows.

## Scope

This is intentionally a one-file lifecycle fix in `TooltipOverlayController`.

It supersedes the broader approach from #227, which added a global dismiss coordinator, MCP-specific calls, invalid-anchor handling, and a new test suite. This change does not alter MCP behavior, add a parallel tooltip authority, or reintroduce child-window hierarchy behavior.

## Validation

- `make guardrails` — passed
- scoped SwiftFormat lint on `TooltipOverlayController.swift` — passed; 0/1 files require formatting
- scoped strict SwiftLint on `TooltipOverlayController.swift` — passed; 0 violations
- `make dev-swift-build PRODUCT=RepoPrompt` — passed
- `make dev-build` — passed; patched debug app built, signed, and packaged
- live UI validation — reproduced with release v1.0.29 (30), then confirmed fixed in the patched debug app while the release app remained running
- contribution `commit` and `push` preflights — passed, including staged/outgoing secret scans and guardrails

The computed-outgoing-range `pr-ready` lane reached the repository-wide SwiftFormat baseline mismatch and stopped on thousands of findings in untouched files. The changed file passes both scoped SwiftFormat and strict SwiftLint.

No new XCTest is included because reposting AppKit notifications would test the observer implementation rather than the SwiftUI popover/order-out lifecycle that produces the visual defect. The real UI lifecycle was exercised directly.

## Screenshot

The current before screenshot will be attached to #563. No after screenshot is included because the corrected behavior is the absence of the detached tooltip.
