### PR TITLE
Preserve Context Builder pending context through routing

### DIFF
--- a/Sources/RepoPrompt/Infrastructure/MCP/MCPConnectionManager.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/MCPConnectionManager.swift
@@ -2955,7 +2955,8 @@ actor ServerNetworkManager {
     private func mapConnectionToRunIDForPendingPolicy(
         _ connectionID: UUID,
         runID: UUID,
-        windowID: Int
+        windowID: Int,
+        clientName: String
     ) async -> MCPServerViewModel.PendingPolicyRunIDMappingToken? {
         let token = await MainActor.run { () -> MCPServerViewModel.PendingPolicyRunIDMappingToken? in
             guard let window = WindowStatesManager.shared.window(withID: windowID) else {
@@ -2965,7 +2966,8 @@ actor ServerNetworkManager {
             return window.mcpServer.registerPendingPolicyRunIDMapping(
                 connectionID: connectionID,
                 runID: runID,
-                windowID: windowID
+                windowID: windowID,
+                clientName: clientName
             )
         }
         guard let token else {
@@ -10215,7 +10217,8 @@ actor ServerNetworkManager {
                 pendingPolicyRunIDMappingToken = await mapConnectionToRunIDForPendingPolicy(
                     connectionID,
                     runID: runID,
-                    windowID: policy.windowID
+                    windowID: policy.windowID,
+                    clientName: clientName
                 )
                 routed = pendingPolicyRunIDMappingToken != nil
             }

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+TabContext.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel+TabContext.swift
@@ -185,6 +185,9 @@ extension MCPServerViewModel {
         let previousRunPrimaryConnectionID: UUID?
         let previousPendingPolicyTokenID: UUID?
         let previousWindowID: Int?
+        var promotedContext: TabContextSnapshot?
+        var promotedContextClientName: String?
+        var promotedContextWindowID: Int?
     }
 
     /// Ordered, immutable coordinator lanes displaced by one pending-policy replacement.
@@ -379,6 +382,10 @@ extension MCPServerViewModel {
 
         func contains(clientName: String, windowID: Int, runID: UUID) -> Bool {
             storage[clientName]?[windowID]?[runID] != nil
+        }
+
+        func contains(clientName: String, runID: UUID) -> Bool {
+            storage[clientName]?.values.contains { $0[runID] != nil } == true
         }
 
         @discardableResult
@@ -1361,7 +1368,8 @@ extension MCPServerViewModel {
     private func bindPendingContextToConnection(
         clientName: String,
         windowID: Int,
-        connectionID: UUID
+        connectionID: UUID,
+        registerRunMapping: Bool = true
     ) -> TabContextSnapshot? {
         let queueBefore = pendingRunScopedTabContexts.queueLength(clientName: clientName, windowID: windowID)
         let runHint = connectionIDToRunID[connectionID]
@@ -1389,7 +1397,9 @@ extension MCPServerViewModel {
                 activateReadFileAutoSelection(&rebound)
                 tabContextByConnectionID[connectionID] = rebound
                 presentationWindowByConnection[connectionID] = rebound.windowID
-                _ = registerRunIDMapping(connectionID: connectionID, runID: runID, windowID: rebound.windowID)
+                if registerRunMapping {
+                    _ = registerRunIDMapping(connectionID: connectionID, runID: runID, windowID: rebound.windowID)
+                }
                 recordLastContext(clientName: clientName, context: rebound)
                 beginMirroringForConnection(connectionID, context: rebound)
                 tabContextLog("bindPendingContextToConnection handover: runID=\(runID) tab=\(rebound.tabID) \(previousConnection) -> \(connectionID) queueBefore=\(queueBefore)")
@@ -1421,9 +1431,13 @@ extension MCPServerViewModel {
         publishDomainRoutingBinding(connectionID: connectionID, context: context)
         presentationWindowByConnection[connectionID] = context.windowID
         if let runID = context.runID {
-            let mappingSucceeded = registerRunIDMapping(connectionID: connectionID, runID: runID, windowID: context.windowID)
-            // If we successfully registered the mapping, or if the initial runHint matched, count it as used
-            usedRunHint = usedRunHint || (runHint == runID) || mappingSucceeded
+            if registerRunMapping {
+                let mappingSucceeded = registerRunIDMapping(connectionID: connectionID, runID: runID, windowID: context.windowID)
+                // If we successfully registered the mapping, or if the initial runHint matched, count it as used
+                usedRunHint = usedRunHint || (runHint == runID) || mappingSucceeded
+            } else {
+                usedRunHint = usedRunHint || runHint == runID
+            }
         }
         recordLastContext(clientName: clientName, context: context)
         beginMirroringForConnection(connectionID, context: context)
@@ -1432,6 +1446,31 @@ extension MCPServerViewModel {
             "bindPendingContextToConnection clientName=\(clientName) window=\(windowID) connectionID=\(connectionID) runID=\(context.runID?.uuidString ?? "nil") tab=\(context.tabID) queueBefore=\(queueBefore) remaining=\(result.remaining) usedRunHint=\(usedRunHint) fallback=false"
         )
         return context
+    }
+
+    @MainActor
+    @discardableResult
+    func promotePendingContextForRunMapping(
+        clientName: String,
+        windowID: Int,
+        connectionID: UUID
+    ) -> TabContextSnapshot? {
+        guard connectionIDToRunID[connectionID] != nil,
+              let runID = connectionIDToRunID[connectionID],
+              pendingRunScopedTabContexts.contains(
+                  clientName: clientName,
+                  windowID: windowID,
+                  runID: runID
+              )
+        else {
+            return nil
+        }
+        return bindPendingContextToConnection(
+            clientName: clientName,
+            windowID: windowID,
+            connectionID: connectionID,
+            registerRunMapping: false
+        )
     }
 
     struct RequestMetadata {
@@ -3584,7 +3623,8 @@ extension MCPServerViewModel {
     func registerPendingPolicyRunIDMapping(
         connectionID: UUID,
         runID: UUID,
-        windowID: Int
+        windowID: Int,
+        clientName: String? = nil
     ) -> PendingPolicyRunIDMappingToken? {
         if let bound = tabContextByConnectionID[connectionID],
            let boundRun = bound.runID,
@@ -3605,7 +3645,7 @@ extension MCPServerViewModel {
         }
 
         let previousRunID = connectionIDToRunID[connectionID]
-        let token = PendingPolicyRunIDMappingToken(
+        var token = PendingPolicyRunIDMappingToken(
             id: UUID(),
             connectionID: connectionID,
             runID: runID,
@@ -3615,10 +3655,11 @@ extension MCPServerViewModel {
             previousRunID: previousRunID,
             previousRunPrimaryConnectionID: previousRunID.flatMap { connectionIDByRunID[$0] },
             previousPendingPolicyTokenID: previousRunID.flatMap { pendingPolicyRunIDMappingTokenIDByRunID[$0] },
-            previousWindowID: presentationWindowByConnection[connectionID]
+            previousWindowID: presentationWindowByConnection[connectionID],
+            promotedContext: nil,
+            promotedContextClientName: nil,
+            promotedContextWindowID: nil
         )
-        installReadFileAutoSelectionHandoverLineage(for: token)
-
         if let displacedConnectionID = token.displacedConnectionID,
            connectionIDToRunID[displacedConnectionID] == runID
         {
@@ -3634,6 +3675,18 @@ extension MCPServerViewModel {
         connectionIDByRunID[runID] = connectionID
         connectionIDToRunID[connectionID] = runID
         pendingPolicyRunIDMappingTokenIDByRunID[runID] = token.id
+        if let clientName,
+           let promotedContext = promotePendingContextForRunMapping(
+               clientName: clientName,
+               windowID: windowID,
+               connectionID: connectionID
+           )
+        {
+            token.promotedContext = promotedContext
+            token.promotedContextClientName = clientName
+            token.promotedContextWindowID = windowID
+        }
+        installReadFileAutoSelectionHandoverLineage(for: token)
         tabContextLog("registerPendingPolicyRunIDMapping connectionID=\(connectionID) runID=\(runID) windowID=\(windowID)")
         return token
     }
@@ -3666,8 +3719,6 @@ extension MCPServerViewModel {
 
         readFileAutoSelectionHandoverLineageByConnectionID.removeValue(forKey: token.connectionID)
         guard token.displacedConnectionRunID == token.runID,
-              connectionIDByRunID[token.runID] == displacedConnectionID,
-              connectionIDToRunID[displacedConnectionID] == token.runID,
               let displacedContext = tabContextByConnectionID[displacedConnectionID],
               displacedContext.runID == token.runID,
               successorContext.windowID == displacedContext.windowID,
@@ -3728,6 +3779,25 @@ extension MCPServerViewModel {
         }
 
         pendingPolicyRunIDMappingTokenIDByRunID.removeValue(forKey: token.runID)
+        let promotedContextToRestore: (context: TabContextSnapshot, clientName: String, windowID: Int)? = {
+            guard let promotedContext = token.promotedContext,
+                  let promotedRunID = promotedContext.runID,
+                  let promotedContextClientName = token.promotedContextClientName,
+                  let promotedContextWindowID = token.promotedContextWindowID,
+                  let boundContext = tabContextByConnectionID[token.connectionID],
+                  boundContext.runID == promotedRunID,
+                  boundContext.tabID == promotedContext.tabID,
+                  boundContext.windowID == promotedContext.windowID,
+                  boundContext.workspaceID == promotedContext.workspaceID,
+                  !pendingRunScopedTabContexts.contains(
+                      clientName: promotedContextClientName,
+                      runID: promotedRunID
+                  )
+            else {
+                return nil
+            }
+            return (promotedContext, promotedContextClientName, promotedContextWindowID)
+        }()
         removeTabContext(
             forConnectionID: token.connectionID,
             clientName: clientName,
@@ -3735,6 +3805,13 @@ extension MCPServerViewModel {
             runID: token.runID,
             removeQueuedPendingContext: false
         )
+        if let promotedContextToRestore {
+            _ = pendingRunScopedTabContexts.enqueueReplacing(
+                promotedContextToRestore.context,
+                clientName: promotedContextToRestore.clientName,
+                windowID: promotedContextToRestore.windowID
+            )
+        }
         if connectionIDByRunID[token.runID] == token.connectionID {
             connectionIDByRunID.removeValue(forKey: token.runID)
         }

--- a/Tests/RepoPromptTests/ContextBuilder/ContextBuilderRunLifecycleTests.swift
+++ b/Tests/RepoPromptTests/ContextBuilder/ContextBuilderRunLifecycleTests.swift
@@ -575,6 +575,113 @@ final class ContextBuilderRunLifecycleTests: XCTestCase {
         XCTAssertFalse(failureDetachedDuringDrain.succeeded)
     }
 
+    func testMappedRunPromotesQueuedContextBeforePeerEOFTeardown() async throws {
+        #if DEBUG
+            let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
+            GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
+            let window = WindowState()
+            GlobalSettingsStore.shared.setMCPAutoStart(previousAutoStart, commit: false)
+            WindowStatesManager.shared.registerWindowState(window)
+            defer { WindowStatesManager.shared.unregisterWindowState(window) }
+            await window.workspaceManager.awaitInitialized()
+
+            let root = FileManager.default.temporaryDirectory
+                .appendingPathComponent("ContextBuilderQueuedRouteCleanupTests-\(UUID().uuidString)")
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: root) }
+
+            let workspace = window.workspaceManager.createWorkspace(
+                name: "Context Builder queued route cleanup test",
+                repoPaths: [root.path],
+                ephemeral: true
+            )
+            await window.workspaceManager.switchWorkspace(
+                to: workspace,
+                saveState: false,
+                reason: "ContextBuilderRunLifecycleTests.queuedRouteCleanup"
+            )
+
+            let activeWorkspace = try XCTUnwrap(window.workspaceManager.activeWorkspace)
+            let tabID = try XCTUnwrap(
+                activeWorkspace.activeComposeTabID ?? activeWorkspace.composeTabs.first?.id
+            )
+            let clientName = "context-builder-queued-route-cleanup-test"
+            let connectionID = UUID()
+            let runID = UUID()
+            let prompt = "queued exact context survives orderly peer EOF"
+            var tab = try XCTUnwrap(window.workspaceManager.composeTab(with: tabID))
+            tab.promptText = prompt
+            XCTAssertTrue(window.workspaceManager.updateComposeTabStoredOnly(tab, inWorkspaceID: activeWorkspace.id))
+
+            window.mcpServer.installTabContext(
+                clientID: nil,
+                clientName: clientName,
+                windowID: window.windowID,
+                workspaceID: activeWorkspace.id,
+                snapshot: tab,
+                runID: runID,
+                signalRouting: false
+            )
+            XCTAssertEqual(
+                window.mcpServer.pendingContextQueueLength(
+                    clientName: clientName,
+                    windowID: window.windowID
+                ),
+                1
+            )
+
+            XCTAssertNotNil(
+                window.mcpServer.registerPendingPolicyRunIDMapping(
+                    connectionID: connectionID,
+                    runID: runID,
+                    windowID: window.windowID,
+                    clientName: clientName
+                )
+            )
+            XCTAssertEqual(window.mcpServer.connectionID(forRunID: runID), connectionID)
+
+            await ServerNetworkManager.shared.debugRegisterConnectionForSocketFixture(
+                connectionID: connectionID,
+                connection: ContextBuilderCleanupTestConnection(),
+                clientName: clientName,
+                sessionToken: UUID().uuidString
+            )
+            await ServerNetworkManager.shared.debugSeedConnectionRunRouting(
+                connectionID: connectionID,
+                runID: runID,
+                purpose: .discoverRun,
+                windowID: window.windowID
+            )
+
+            // Deliberately do not call any context-resolving tool path. The child only
+            // initialized/listed tools and then ended through orderly peer EOF.
+            await ServerNetworkManager.shared.removeConnection(
+                connectionID,
+                context: MCPConnectionCloseContext(
+                    reason: MCPTransportTerminalCause.peerEOF.rawValue,
+                    initiator: .peer
+                )
+            )
+
+            XCTAssertTrue(
+                window.mcpServer.isDetachedContextBuilderConnection(
+                    connectionID: connectionID,
+                    runID: runID
+                )
+            )
+            let commitOutcome = await window.mcpServer.commitContextBuilderTabContext(
+                connectionID: connectionID,
+                expectedRunID: runID,
+                isStillCurrent: { true }
+            )
+            XCTAssertEqual(commitOutcome.outcome, .committed)
+            XCTAssertEqual(commitOutcome.committedTab?.nestedRunID, runID)
+            XCTAssertEqual(commitOutcome.committedTab?.identity.tabID, tabID)
+        #else
+            throw XCTSkip("Queued route cleanup test uses DEBUG-only connection fixtures.")
+        #endif
+    }
+
     func testRealConnectionCleanupCannotEraseContextBeforeCommit() async throws {
         #if DEBUG
             let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()

--- a/Tests/RepoPromptTests/MCP/Control/MCPAgentPolicyAdmissionRaceTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/MCPAgentPolicyAdmissionRaceTests.swift
@@ -2192,6 +2192,58 @@ final class MCPAgentPolicyAdmissionRaceTests: XCTestCase {
     }
 
     @MainActor
+    func testPendingPolicyRollbackRestoresContextPromotedDuringRouteMapping() throws {
+        #if DEBUG
+            let window = makeWindow()
+            defer { WindowStatesManager.shared.unregisterWindowState(window) }
+            let runID = UUID()
+            let connectionID = UUID()
+            let windowID = window.windowID
+
+            window.mcpServer.installTabContext(
+                clientID: nil,
+                clientName: clientName,
+                windowID: windowID,
+                workspaceID: nil,
+                snapshot: ComposeTabState(),
+                runID: runID,
+                signalRouting: false
+            )
+            XCTAssertEqual(
+                window.mcpServer.pendingContextQueueLength(clientName: clientName, windowID: windowID),
+                1
+            )
+
+            let token = try XCTUnwrap(window.mcpServer.registerPendingPolicyRunIDMapping(
+                connectionID: connectionID,
+                runID: runID,
+                windowID: windowID,
+                clientName: clientName
+            ))
+            XCTAssertEqual(
+                window.mcpServer.pendingContextQueueLength(clientName: clientName, windowID: windowID),
+                0
+            )
+
+            let rollbackResult = window.mcpServer.rollbackPendingPolicyRunIDMapping(
+                token,
+                clientName: clientName,
+                windowID: windowID,
+                signalRoutingFailure: false
+            )
+
+            XCTAssertEqual(rollbackResult, .restored)
+            XCTAssertEqual(
+                window.mcpServer.pendingContextQueueLength(clientName: clientName, windowID: windowID),
+                1
+            )
+            XCTAssertNil(window.mcpServer.tabContextByConnectionID[connectionID])
+        #else
+            throw XCTSkip("Pending policy rollback diagnostics require DEBUG helpers.")
+        #endif
+    }
+
+    @MainActor
     func testPendingPolicyRollbackDoesNotRestorePreviousRunAfterPrimaryGenerationChanges() throws {
         #if DEBUG
             let window = makeWindow()

--- a/Tests/RepoPromptTests/MCP/TabContextRoutingTests.swift
+++ b/Tests/RepoPromptTests/MCP/TabContextRoutingTests.swift
@@ -445,6 +445,57 @@ final class TabContextRoutingTests: XCTestCase {
     }
 
     @MainActor
+    func testPendingPolicyReadSelectionLineageInstallsAfterQueuedRoutePromotion() throws {
+        let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
+        GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
+        let window = WindowState()
+        WindowStatesManager.shared.registerWindowState(window)
+        GlobalSettingsStore.shared.setMCPAutoStart(previousAutoStart, commit: false)
+        defer { WindowStatesManager.shared.unregisterWindowState(window) }
+
+        let runID = UUID()
+        let workspaceID = UUID()
+        let tabID = UUID()
+        let liveConnectionID = UUID()
+        let replacementConnectionID = UUID()
+        let snapshot = ComposeTabState(id: tabID, name: "Agent")
+
+        window.mcpServer.installTabContext(
+            clientID: liveConnectionID.uuidString,
+            clientName: "agent",
+            windowID: window.windowID,
+            workspaceID: workspaceID,
+            snapshot: snapshot,
+            runID: runID,
+            signalRouting: false
+        )
+        window.mcpServer.installTabContext(
+            clientID: nil,
+            clientName: "agent",
+            windowID: window.windowID,
+            workspaceID: workspaceID,
+            snapshot: snapshot,
+            runID: runID,
+            signalRouting: false
+        )
+
+        let token = try XCTUnwrap(window.mcpServer.registerPendingPolicyRunIDMapping(
+            connectionID: replacementConnectionID,
+            runID: runID,
+            windowID: window.windowID,
+            clientName: "agent"
+        ))
+
+        XCTAssertEqual(token.displacedConnectionID, liveConnectionID)
+        XCTAssertEqual(
+            window.mcpServer.readFileAutoSelectionHandoverPredecessorConnectionIDsForTesting(
+                connectionID: replacementConnectionID
+            ),
+            [liveConnectionID]
+        )
+    }
+
+    @MainActor
     func testPendingPolicyReadSelectionLineageSurvivesSameConnectionTokenSupersession() throws {
         let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
         GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)


### PR DESCRIPTION
## Summary

- promote exact queued Context Builder context when pending-policy routing establishes the run/connection mapping
- preserve it through orderly peer EOF even when the child never calls a context-resolving tool
- restore promoted context exactly once if tentative policy mapping rolls back
- preserve read-file auto-selection handover lineage for replacement connections
- add lifecycle, rollback, and reconnect regression coverage

## Root cause

Frozen run context was queued before the child connection existed, but it was only bound during a later context-resolving tool call. A child that initialized/listed tools and exited normally therefore reached teardown with no bound context to detach, and final commit reported missingFinalContext(connection none).

## Validation

- ContextBuilderRunLifecycleTests: 12/12 passed
- MCPAgentPolicyAdmissionRaceTests: 32/32 passed
- TabContextRoutingTests: 49/49 passed
- read-file auto-selection suite: 20/20 passed
- strict Swift format/lint: passed
- RepoPrompt coordinated build: passed
- exact-ID ledger verification: passed
- final Codex autoreview: clean

The full pr-ready suite was attempted and stopped on two unrelated tests outside this diff; both passed immediately when rerun in isolation.

Closes #562