### PR TITLE
Refresh approved contributors

### DIFF
--- a/.github/APPROVED_CONTRIBUTORS
+++ b/.github/APPROVED_CONTRIBUTORS
@@ -35,6 +35,7 @@ AdrianAlonsoDev pr
 afadlallah pr
 agamrp pr
 agentdouble0zero pr
+agustif pr
 ahafonof pr
 AI-MickyJ pr
 ajitaravind pr
@@ -51,6 +52,7 @@ alexdav pr
 alexg021 pr
 alexss200010 pr
 alimbaydoun pr
+alvaroybanez pr
 amadad pr
 amit-feldman pr
 amit0365 pr
@@ -105,6 +107,7 @@ bikeusaland pr
 bilal-ghafoor pr
 bismuthpartners pr
 bitboxer0 pr
+bkoc pr
 blksrfc pr
 bobtheitguy31337 pr
 bonkey pr
@@ -323,6 +326,7 @@ hmottestad pr
 HomunculusLabs pr
 hosmelq pr
 hovr pr
+hsinskip pr
 hstove pr
 hugo-sss pr
 HunterHillegas pr
@@ -561,6 +565,7 @@ phpfour pr
 phren0logy pr
 pnascimento9596 pr
 pottedmeat pr
+pranavsuri4303 pr
 pryley pr
 pszanser pr
 pyronaur pr
@@ -699,6 +704,7 @@ twentyonedot pr
 twilwa pr
 tyom pr
 tyrobben pr
+Tyschultz7 pr
 tzutoo pr
 Uarmagan pr
 uchkw pr

--- a/.github/APPROVED_CONTRIBUTORS
+++ b/.github/APPROVED_CONTRIBUTORS
@@ -123,6 +123,7 @@ brettmadill pr
 brianhays pr
 brichase pr
 brytoncooper pr
+BTCElectrician pr
 BullThistle pr
 bz8768 pr
 c-p-b pr
@@ -326,7 +327,6 @@ hmottestad pr
 HomunculusLabs pr
 hosmelq pr
 hovr pr
-hsinskip pr
 hstove pr
 hugo-sss pr
 HunterHillegas pr
@@ -522,6 +522,7 @@ nick3t pr
 nickdavis pr
 nickperry12 pr
 nicolasburgosg pr
+NiestrojMateusz pr
 Nitron pr
 nkeat12 pr
 NKHN-AU pr
@@ -704,7 +705,6 @@ twentyonedot pr
 twilwa pr
 tyom pr
 tyrobben pr
-Tyschultz7 pr
 tzutoo pr
 Uarmagan pr
 uchkw pr


### PR DESCRIPTION
## Summary

- Previous contributor count: 768
- New contributor count: 774
- Final additions: `agustif`, `alvaroybanez`, `bkoc`, `BTCElectrician`, `NiestrojMateusz`, `pranavsuri4303`
- Preserves every existing entry from current `main`, including the existing case-insensitive `rameezshuhaib` entry.

## Reconciliation

- Carried `BTCElectrician` and `NiestrojMateusz` forward from #478, #509, and #549. Both accounts still resolve as GitHub `User` accounts.
- Withheld the proposed `hsinskip` and `Tyschultz7` additions because those exact GitHub logins currently return 404. They can be added in a later refresh once the intended accounts resolve.
- #557 is otherwise represented by this refresh.

## Source refresh snapshot

- Eligible live-handle count: 732
- Ignored claim counts: `empty_github_username=240`, `incomplete_status=187`, `github_access_ineligible=0`, `duplicate_handle=9`

## Validation

- `Scripts/contributor_allowlist_guardrails.sh` — passed with 774 entries
- Contribution commit preflight — passed
- Contribution push preflight — passed for commit `38640b5`
