### PR TITLE
Preserve codemap authority across publication retries

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/Services/AgentContextExportResolver.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Services/AgentContextExportResolver.swift
@@ -248,6 +248,20 @@ enum AgentContextExportResolver {
         let invalidPaths: [String]
     }
 
+    private struct PresentationAuthoritySnapshot {
+        let lookupContext: WorkspaceLookupContext
+        let physicalSelection: StoredSelection
+        let rootScope: WorkspaceLookupRootScope
+        let roots: [WorkspaceRootRef]
+        let logicalRootDisplayNamesByRootID: [UUID: String]
+        let presentationPlan: AgentCodemapPresentationPlan
+    }
+
+    private struct ModelPresentationAttempt {
+        let authority: PresentationAuthoritySnapshot
+        let resolution: RowResolution
+    }
+
     static func selectionSummary(for selection: StoredSelection) -> AgentContextSelectionSummary {
         var explicitFileKeys = Set(selection.selectedPaths.map(normalizedSelectionKey))
         var slicedFileKeys = Set<String>()
@@ -350,67 +364,54 @@ enum AgentContextExportResolver {
             return displayModel
         }
 
-        let lookupContext = await lookupContext(source: source, store: store)
-        let physicalizeStartMS = AgentSelectedFilesDiagnostics.timestampMSIfEnabled()
-        let physicalSelection = lookupContext.physicalizeSelection(source.selection)
-        var physicalizeFields = AgentSelectedFilesDiagnostics.selectionFields(physicalSelection)
-        physicalizeFields["hasProjection"] = String(lookupContext.bindingProjection != nil)
-        AgentSelectedFilesDiagnostics.durationEvent("resolver.physicalizeSelection", startMS: physicalizeStartMS, fields: physicalizeFields)
-
-        let resolveRowsStartMS = AgentSelectedFilesDiagnostics.timestampMSIfEnabled()
-        let resolution = await resolveRows(
-            selection: physicalSelection,
-            store: store,
-            rootScope: lookupContext.rootScope,
-            profile: .uiAssisted
-        )
-        AgentSelectedFilesDiagnostics.durationEvent(
-            "resolver.resolveRows",
-            startMS: resolveRowsStartMS,
-            fields: [
-                "rowEntries": String(resolution.rows.count),
-                "missingPaths": String(resolution.missingPaths.count),
-                "invalidPaths": String(resolution.invalidPaths.count)
-            ]
-        )
-
-        let roots = await store.rootRefs(scope: lookupContext.rootScope)
-        let presentationPlan = await WorkspaceCodemapPresentationIntentResolver.plan(
-            codeMapUsage: codeMapUsage,
-            selection: physicalSelection,
-            store: store,
-            rootScope: lookupContext.rootScope,
-            profile: .uiAssisted
-        )
-        let logicalRootDisplayNames = await lookupContext.logicalRootDisplayNamesByRootID(store: store)
         let coordinator = presentationCoordinator ?? WorkspaceCodemapPresentationCoordinator(store: store)
         do {
             return try await coordinator.withPresentation(
-                for: presentationPlan.intent,
-                rootScope: lookupContext.rootScope,
-                logicalRootDisplayNamesByRootID: logicalRootDisplayNames
-            ) { presentation in
+                prepareAttempt: {
+                    let attempt = await modelPresentationAttempt(
+                        source: source,
+                        store: store,
+                        codeMapUsage: codeMapUsage
+                    )
+                    return WorkspaceCodemapPresentationAttempt(
+                        context: attempt,
+                        intent: attempt.authority.presentationPlan.intent,
+                        rootScope: attempt.authority.rootScope,
+                        logicalRootDisplayNamesByRootID: attempt.authority.logicalRootDisplayNamesByRootID,
+                        requestedCodemapCount: requestedCodemapCount(
+                            for: attempt.authority.presentationPlan.intent,
+                            codeMapUsage: codeMapUsage
+                        )
+                    )
+                }
+            ) { attempt, presentation in
                 let presentation = merging(
                     presentation,
-                    preflightIssues: presentationPlan.preflightIssues
+                    preflightIssues: attempt.authority.presentationPlan.preflightIssues
+                )
+                let resolution = await validatedSelectedFallbackResolution(
+                    attempt.resolution,
+                    presentation: presentation,
+                    store: store,
+                    codeMapUsage: codeMapUsage
                 )
                 let codemapFilesByID = await codemapFileRecordsByID(
                     for: presentation,
                     resolution: resolution,
-                    roots: roots,
+                    roots: attempt.authority.roots,
                     store: store,
                     codeMapUsage: codeMapUsage
                 )
                 return makeModel(
                     source: source,
-                    lookupContext: lookupContext,
+                    lookupContext: attempt.authority.lookupContext,
                     resolution: resolution,
-                    roots: roots,
+                    roots: attempt.authority.roots,
                     codemapFilesByID: codemapFilesByID,
                     filePathDisplay: filePathDisplay,
                     codeMapUsage: codeMapUsage,
                     codemapPresentation: presentation,
-                    logicalRootDisplayNamesByRootID: logicalRootDisplayNames
+                    logicalRootDisplayNamesByRootID: attempt.authority.logicalRootDisplayNamesByRootID
                 )
             }
         } catch {
@@ -419,71 +420,74 @@ enum AgentContextExportResolver {
             } else {
                 .coordinationUnavailable
             }
+            let attempt = await modelPresentationAttempt(
+                source: source,
+                store: store,
+                codeMapUsage: codeMapUsage
+            )
             let presentation = merging(
                 unavailablePresentation(issue),
-                preflightIssues: presentationPlan.preflightIssues
+                preflightIssues: attempt.authority.presentationPlan.preflightIssues
+            )
+            let resolution = await validatedSelectedFallbackResolution(
+                attempt.resolution,
+                presentation: presentation,
+                store: store,
+                codeMapUsage: codeMapUsage
             )
             let codemapFilesByID = await codemapFileRecordsByID(
                 for: presentation,
                 resolution: resolution,
-                roots: roots,
+                roots: attempt.authority.roots,
                 store: store,
                 codeMapUsage: codeMapUsage
             )
             return makeModel(
                 source: source,
-                lookupContext: lookupContext,
+                lookupContext: attempt.authority.lookupContext,
                 resolution: resolution,
-                roots: roots,
+                roots: attempt.authority.roots,
                 codemapFilesByID: codemapFilesByID,
                 filePathDisplay: filePathDisplay,
                 codeMapUsage: codeMapUsage,
                 codemapPresentation: presentation,
-                logicalRootDisplayNamesByRootID: logicalRootDisplayNames
+                logicalRootDisplayNamesByRootID: attempt.authority.logicalRootDisplayNamesByRootID
             )
         }
     }
 
-    static func buildClipboardContent(_ request: AgentContextClipboardRequest) async -> String {
-        let lookupContext = await authoritativeLookupContextForClipboardIfNeeded(request)
-        let effectiveRequest = AgentContextClipboardRequest(
-            cfg: request.cfg,
-            source: request.source,
-            store: request.store,
-            lookupContext: lookupContext,
-            filePathDisplay: request.filePathDisplay,
-            onlyIncludeRootsWithSelectedFiles: request.onlyIncludeRootsWithSelectedFiles,
-            showCodeMapMarkers: request.showCodeMapMarkers,
-            metaInstructions: request.metaInstructions,
-            includeDatetimeInUserInstructions: request.includeDatetimeInUserInstructions,
-            promptSectionsOrder: request.promptSectionsOrder,
-            disabledPromptSections: request.disabledPromptSections,
-            duplicateUserInstructionsAtTop: request.duplicateUserInstructionsAtTop,
-            reviewGitContext: request.reviewGitContext,
-            completeGitDiffProvider: request.completeGitDiffProvider
-        )
-        let physicalSelection = lookupContext.physicalizeSelection(request.source.selection)
-        let rootScope = lookupContext.rootScope.excludingWorkspaceGitData
-        let presentationPlan = await codemapPresentationPlan(
-            codeMapUsage: request.cfg.codeMapUsage,
-            selection: physicalSelection,
-            store: request.store,
-            rootScope: rootScope,
-            profile: .uiAssisted
-        )
+    static func buildClipboardContent(
+        _ request: AgentContextClipboardRequest,
+        presentationCoordinator: WorkspaceCodemapPresentationCoordinator? = nil
+    ) async -> String {
+        let coordinator = presentationCoordinator ?? WorkspaceCodemapPresentationCoordinator(store: request.store)
         do {
-            return try await WorkspaceCodemapPresentationCoordinator(store: request.store).withPresentation(
-                for: presentationPlan.intent,
-                rootScope: rootScope,
-                logicalRootDisplayNamesByRootID: lookupContext.logicalRootDisplayNamesByRootID(
-                    store: request.store
-                )
-            ) { presentation in
+            return try await coordinator.withPresentation(
+                prepareAttempt: {
+                    let authority = await presentationAuthoritySnapshot(
+                        source: request.source,
+                        store: request.store,
+                        codeMapUsage: request.cfg.codeMapUsage,
+                        fallbackLookupContext: request.lookupContext,
+                        excludingWorkspaceGitData: true
+                    )
+                    return WorkspaceCodemapPresentationAttempt(
+                        context: authority,
+                        intent: authority.presentationPlan.intent,
+                        rootScope: authority.rootScope,
+                        logicalRootDisplayNamesByRootID: authority.logicalRootDisplayNamesByRootID,
+                        requestedCodemapCount: requestedCodemapCount(
+                            for: authority.presentationPlan.intent,
+                            codeMapUsage: request.cfg.codeMapUsage
+                        )
+                    )
+                }
+            ) { authority, presentation in
                 await assembleClipboardContent(
-                    effectiveRequest,
+                    clipboardRequest(request, lookupContext: authority.lookupContext),
                     codemapPresentation: merging(
                         presentation,
-                        preflightIssues: presentationPlan.preflightIssues
+                        preflightIssues: authority.presentationPlan.preflightIssues
                     )
                 )
             }
@@ -493,11 +497,18 @@ enum AgentContextExportResolver {
             } else {
                 .coordinationUnavailable
             }
+            let authority = await presentationAuthoritySnapshot(
+                source: request.source,
+                store: request.store,
+                codeMapUsage: request.cfg.codeMapUsage,
+                fallbackLookupContext: request.lookupContext,
+                excludingWorkspaceGitData: true
+            )
             return await assembleClipboardContent(
-                effectiveRequest,
+                clipboardRequest(request, lookupContext: authority.lookupContext),
                 codemapPresentation: merging(
                     unavailablePresentation(issue),
-                    preflightIssues: presentationPlan.preflightIssues
+                    preflightIssues: authority.presentationPlan.preflightIssues
                 )
             )
         }
@@ -602,22 +613,164 @@ enum AgentContextExportResolver {
         )
     }
 
-    private static func authoritativeLookupContextForClipboardIfNeeded(
-        _ request: AgentContextClipboardRequest
+    private static func authoritativeLookupContext(
+        source: AgentContextExportSource,
+        store: WorkspaceFileContextStore,
+        fallback: WorkspaceLookupContext
     ) async -> WorkspaceLookupContext {
-        guard request.source.hasWorktreeBindings,
-              let projection = request.lookupContext.bindingProjection,
-              !projection.isFullyMaterialized
-        else {
-            return request.lookupContext
-        }
-
+        guard source.hasWorktreeBindings else { return fallback }
         return await AgentWorkspaceLookupContextResolver.authoritativeLookupContextOrFailClosed(
             source: AgentWorkspaceLookupContextSource(
-                activeAgentSessionID: request.source.activeAgentSessionID,
-                worktreeBindings: request.source.worktreeBindings
+                activeAgentSessionID: source.activeAgentSessionID,
+                worktreeBindings: source.worktreeBindings
             ),
-            store: request.store
+            store: store
+        )
+    }
+
+    private static func presentationAuthoritySnapshot(
+        source: AgentContextExportSource,
+        store: WorkspaceFileContextStore,
+        codeMapUsage: CodeMapUsage,
+        fallbackLookupContext: WorkspaceLookupContext,
+        excludingWorkspaceGitData: Bool
+    ) async -> PresentationAuthoritySnapshot {
+        let lookupContext = await authoritativeLookupContext(
+            source: source,
+            store: store,
+            fallback: fallbackLookupContext
+        )
+        let physicalSelection = lookupContext.physicalizeSelection(source.selection)
+        let rootScope = excludingWorkspaceGitData
+            ? lookupContext.rootScope.excludingWorkspaceGitData
+            : lookupContext.rootScope
+        let roots = await store.rootRefs(scope: rootScope)
+        let presentationPlan = await codemapPresentationPlan(
+            codeMapUsage: codeMapUsage,
+            selection: physicalSelection,
+            store: store,
+            rootScope: rootScope,
+            profile: .uiAssisted
+        )
+        let logicalRootDisplayNamesByRootID = await lookupContext.logicalRootDisplayNamesByRootID(
+            store: store
+        )
+        return PresentationAuthoritySnapshot(
+            lookupContext: lookupContext,
+            physicalSelection: physicalSelection,
+            rootScope: rootScope,
+            roots: roots,
+            logicalRootDisplayNamesByRootID: logicalRootDisplayNamesByRootID,
+            presentationPlan: presentationPlan
+        )
+    }
+
+    private static func modelPresentationAttempt(
+        source: AgentContextExportSource,
+        store: WorkspaceFileContextStore,
+        codeMapUsage: CodeMapUsage
+    ) async -> ModelPresentationAttempt {
+        let authority = await presentationAuthoritySnapshot(
+            source: source,
+            store: store,
+            codeMapUsage: codeMapUsage,
+            fallbackLookupContext: .visibleWorkspace,
+            excludingWorkspaceGitData: false
+        )
+        let resolution = await resolveRows(
+            selection: authority.physicalSelection,
+            store: store,
+            rootScope: authority.rootScope,
+            profile: .uiAssisted
+        )
+        return ModelPresentationAttempt(authority: authority, resolution: resolution)
+    }
+
+    private static func requestedCodemapCount(
+        for intent: WorkspaceCodemapOperationPresentationIntent,
+        codeMapUsage: CodeMapUsage
+    ) -> Int? {
+        guard codeMapUsage == .selected else { return nil }
+        guard case let .exact(fileIDs, _) = intent else { return 0 }
+        return Set(fileIDs).count
+    }
+
+    private static func clipboardRequest(
+        _ request: AgentContextClipboardRequest,
+        lookupContext: WorkspaceLookupContext
+    ) -> AgentContextClipboardRequest {
+        AgentContextClipboardRequest(
+            cfg: request.cfg,
+            source: request.source,
+            store: request.store,
+            lookupContext: lookupContext,
+            filePathDisplay: request.filePathDisplay,
+            onlyIncludeRootsWithSelectedFiles: request.onlyIncludeRootsWithSelectedFiles,
+            showCodeMapMarkers: request.showCodeMapMarkers,
+            metaInstructions: request.metaInstructions,
+            includeDatetimeInUserInstructions: request.includeDatetimeInUserInstructions,
+            promptSectionsOrder: request.promptSectionsOrder,
+            disabledPromptSections: request.disabledPromptSections,
+            duplicateUserInstructionsAtTop: request.duplicateUserInstructionsAtTop,
+            reviewGitContext: request.reviewGitContext,
+            completeGitDiffProvider: request.completeGitDiffProvider
+        )
+    }
+
+    private static func validatedSelectedFallbackResolution(
+        _ resolution: RowResolution,
+        presentation: WorkspaceCodemapOperationPresentation,
+        store: WorkspaceFileContextStore,
+        codeMapUsage: CodeMapUsage
+    ) async -> RowResolution {
+        guard codeMapUsage == .selected else { return resolution }
+        guard !Task.isCancelled else {
+            return cancelledSelectedFallbackResolution(resolution)
+        }
+        var rows: [RowResolutionEntry] = []
+        rows.reserveCapacity(resolution.rows.count)
+        var missingPaths = resolution.missingPaths
+        for row in resolution.rows {
+            let file = row.entry.file
+            if let rendered = presentation.renderedEntriesByFileID[file.id],
+               rendered.rootEpoch.rootID == file.rootID
+            {
+                rows.append(row)
+                continue
+            }
+            do {
+                guard try await store.readContent(
+                    rootID: file.rootID,
+                    relativePath: file.standardizedRelativePath,
+                    workloadClass: .promptAccounting
+                ) != nil else {
+                    missingPaths.append(file.standardizedRelativePath)
+                    continue
+                }
+                rows.append(row)
+            } catch {
+                if Task.isCancelled || error is CancellationError {
+                    return cancelledSelectedFallbackResolution(resolution)
+                }
+                missingPaths.append(file.standardizedRelativePath)
+            }
+        }
+        return RowResolution(
+            rows: rows,
+            selectedFileIDs: resolution.selectedFileIDs,
+            missingPaths: Array(Set(missingPaths)).sorted(),
+            invalidPaths: resolution.invalidPaths
+        )
+    }
+
+    private static func cancelledSelectedFallbackResolution(
+        _ resolution: RowResolution
+    ) -> RowResolution {
+        RowResolution(
+            rows: [],
+            selectedFileIDs: resolution.selectedFileIDs,
+            missingPaths: resolution.missingPaths,
+            invalidPaths: resolution.invalidPaths
         )
     }
 

--- a/Sources/RepoPrompt/Features/Prompt/Services/PromptContextAccountingService.swift
+++ b/Sources/RepoPrompt/Features/Prompt/Services/PromptContextAccountingService.swift
@@ -657,6 +657,14 @@ actor PromptContextAccountingService {
                 let ranges = sliceRanges(for: path, file: file, location: result.location, in: selection.slices)
                 let useSelectedCodemap = codeMapUsage == .selected && codemapPresentation.renderedEntriesByFileID[file.id] != nil
                 let content = useSelectedCodemap ? nil : selectedFileReadResults[selectedPathIndex]?.content
+                if codeMapUsage == .selected,
+                   !useSelectedCodemap,
+                   case .loadContent = contentPolicy,
+                   content == nil
+                {
+                    missingPaths.append(file.standardizedRelativePath)
+                    continue
+                }
                 let entry = ResolvedPromptFileEntry(
                     file: file,
                     isCodemap: useSelectedCodemap,
@@ -734,6 +742,14 @@ actor PromptContextAccountingService {
                             }
                         #endif
                     }
+                    if codeMapUsage == .selected,
+                       !useSelectedCodemap,
+                       case .loadContent = contentPolicy,
+                       content == nil
+                    {
+                        missingPaths.append(file.standardizedRelativePath)
+                        continue
+                    }
                     let entry = ResolvedPromptFileEntry(
                         file: file,
                         isCodemap: useSelectedCodemap,
@@ -809,6 +825,16 @@ actor PromptContextAccountingService {
                 )
             case .cachedOnly:
                 await store.cachedSearchContentSnapshot(for: file).content
+            }
+            let hasSelectedCodemap = codeMapUsage == .selected
+                && codemapPresentation.renderedEntriesByFileID[file.id] != nil
+            if codeMapUsage == .selected,
+               !hasSelectedCodemap,
+               case .loadContent = contentPolicy,
+               content == nil
+            {
+                missingPaths.append(file.standardizedRelativePath)
+                continue
             }
             let entry = ResolvedPromptFileEntry(file: file, lineRanges: ranges, mode: .sliced, loadedContent: content ?? nil, rootFolderPath: result.location.rootPath)
             append(entry, to: &entries, seenIDs: &seenIDs)

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/Presentation/WorkspaceCodemapPresentationCoordinator.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/Presentation/WorkspaceCodemapPresentationCoordinator.swift
@@ -132,6 +132,14 @@ enum WorkspaceCodemapStructureExecutionPhase: Equatable {
     case publicationRevalidation
 }
 
+struct WorkspaceCodemapPresentationAttempt<Context> {
+    let context: Context
+    let intent: WorkspaceCodemapOperationPresentationIntent
+    let rootScope: WorkspaceLookupRootScope
+    let logicalRootDisplayNamesByRootID: [UUID: String]
+    let requestedCodemapCount: Int?
+}
+
 struct WorkspaceCodemapPresentationCoordinator {
     private struct AutomaticPreparation {
         let candidates: [WorkspaceCodemapOperationPresentationCandidate]
@@ -221,47 +229,95 @@ struct WorkspaceCodemapPresentationCoordinator {
             try Task.checkCancellation()
             return value
         }
-        let clock = ContinuousClock()
-        let deadline = clock.now.advanced(by: policy.maximumTotalWait)
-        var lastStaleReason: WorkspaceCodemapOperationPublicationStaleReason?
-
-        for attempt in 0 ... 1 {
-            try Task.checkCancellation()
-            let ownership = WorkspaceCodemapOperationPresentationOwnership()
-            do {
-                let result = try await makePresentation(
+        return try await withPresentation(
+            prepareAttempt: {
+                WorkspaceCodemapPresentationAttempt(
+                    context: (),
                     intent: intent,
                     rootScope: rootScope,
                     logicalRootDisplayNamesByRootID: logicalRootDisplayNamesByRootID,
+                    requestedCodemapCount: nil
+                )
+            }
+        ) { _, presentation in
+            try await operation(presentation)
+        }
+    }
+
+    func withPresentation<Context, Value>(
+        prepareAttempt: () async throws -> WorkspaceCodemapPresentationAttempt<Context>,
+        operation: (Context, WorkspaceCodemapOperationPresentation) async throws -> Value
+    ) async throws -> Value {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: policy.maximumTotalWait)
+        var lastStaleReason: WorkspaceCodemapOperationPublicationStaleReason?
+        var initialRequestedCodemapCount: Int?
+        var lastAttempt: WorkspaceCodemapPresentationAttempt<Context>?
+
+        for attempt in 0 ... 1 {
+            try Task.checkCancellation()
+            let prepared = try await prepareAttempt()
+            lastAttempt = prepared
+            if initialRequestedCodemapCount == nil {
+                initialRequestedCodemapCount = prepared.requestedCodemapCount
+            }
+            let ownership = WorkspaceCodemapOperationPresentationOwnership()
+            do {
+                var result = try await makePresentation(
+                    intent: prepared.intent,
+                    rootScope: prepared.rootScope,
+                    logicalRootDisplayNamesByRootID: prepared.logicalRootDisplayNamesByRootID,
                     ownership: ownership,
                     clock: clock,
                     deadline: deadline
                 )
+                if let reason = lastStaleReason,
+                   let requestedCount = initialRequestedCodemapCount
+                {
+                    result = preservingPriorStaleCoverage(
+                        result,
+                        reason: reason,
+                        requestedCodemapCount: requestedCount
+                    )
+                }
                 if let reason = retryableStaleReason(in: result.issues) {
                     lastStaleReason = reason
-                    await release(ownership)
-                    if attempt == 0, clock.now < deadline { continue }
-                    let value = try await operation(incompletePublication(reason: reason))
-                    try Task.checkCancellation()
-                    return value
+                    if attempt == 0, clock.now < deadline {
+                        await release(ownership)
+                        continue
+                    }
+                    guard initialRequestedCodemapCount != nil,
+                          !result.orderedEntries.isEmpty
+                    else {
+                        await release(ownership)
+                        let value = try await operation(
+                            prepared.context,
+                            incompletePublication(reason: reason)
+                        )
+                        try Task.checkCancellation()
+                        return value
+                    }
                 }
                 if let reason = lastStaleReason,
                    result.publicationReceipt == nil,
                    result.orderedEntries.isEmpty
                 {
                     await release(ownership)
-                    let value = try await operation(incompletePublication(reason: reason))
+                    let value = try await operation(
+                        prepared.context,
+                        incompletePublication(reason: reason)
+                    )
                     try Task.checkCancellation()
                     return value
                 }
-                let value = try await operation(result)
+                let value = try await operation(prepared.context, result)
                 try Task.checkCancellation()
                 if let receipt = result.publicationReceipt {
                     await beforePublicationRevalidation(receipt)
                     try Task.checkCancellation()
                     let disposition = await store.revalidateCodemapOperationPresentationForPublication(
                         receipt,
-                        rootScope: rootScope
+                        rootScope: prepared.rootScope
                     )
                     switch disposition {
                     case .current:
@@ -271,7 +327,10 @@ struct WorkspaceCodemapPresentationCoordinator {
                         lastStaleReason = reason
                         await release(ownership)
                         if attempt == 0, clock.now < deadline { continue }
-                        let fallbackValue = try await operation(incompletePublication(reason: reason))
+                        let fallbackValue = try await operation(
+                            prepared.context,
+                            incompletePublication(reason: reason)
+                        )
                         try Task.checkCancellation()
                         return fallbackValue
                     }
@@ -284,7 +343,15 @@ struct WorkspaceCodemapPresentationCoordinator {
                 throw error
             }
         }
-        let value = try await operation(incompletePublication(reason: lastStaleReason ?? .rootScope))
+        let prepared: WorkspaceCodemapPresentationAttempt<Context> = if let lastAttempt {
+            lastAttempt
+        } else {
+            try await prepareAttempt()
+        }
+        let value = try await operation(
+            prepared.context,
+            incompletePublication(reason: lastStaleReason ?? .rootScope)
+        )
         try Task.checkCancellation()
         return value
     }
@@ -1500,6 +1567,30 @@ struct WorkspaceCodemapPresentationCoordinator {
             coverage: .unavailable([issue]),
             issues: [issue],
             publicationReceipt: nil
+        )
+    }
+
+    private func preservingPriorStaleCoverage(
+        _ presentation: WorkspaceCodemapOperationPresentation,
+        reason: WorkspaceCodemapOperationPublicationStaleReason,
+        requestedCodemapCount: Int
+    ) -> WorkspaceCodemapOperationPresentation {
+        guard presentation.orderedEntries.count < requestedCodemapCount else {
+            return presentation
+        }
+        let issue = WorkspaceCodemapOperationIssue.publicationStale(reason)
+        let issues = presentation.issues.contains(issue)
+            ? presentation.issues
+            : presentation.issues + [issue]
+        let coverage: WorkspaceCodemapOperationPresentationCoverage = presentation.orderedEntries.isEmpty
+            ? .unavailable(issues)
+            : .partial(issues)
+        return WorkspaceCodemapOperationPresentation(
+            id: presentation.id,
+            orderedEntries: presentation.orderedEntries,
+            coverage: coverage,
+            issues: issues,
+            publicationReceipt: presentation.publicationReceipt
         )
     }
 

--- a/Tests/RepoPromptTests/AgentMode/AgentContextExportResolverTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentContextExportResolverTests.swift
@@ -2,7 +2,7 @@ import Foundation
 @testable import RepoPromptApp
 import XCTest
 
-final class AgentContextExportResolverTests: XCTestCase {
+final class AgentContextExportResolverTests: WorkspaceFileContextStoreCodemapSeamTestSupport {
     func testDisplayFileCountUsesExplicitSelectionAndExcludesAutoCodemaps() {
         let selection = StoredSelection(
             selectedPaths: ["A.swift", "B.swift", "C.swift", "D.swift", "E.swift"],
@@ -492,7 +492,7 @@ final class AgentContextExportResolverTests: XCTestCase {
         XCTAssertEqual(runtimeAccessCount.value, 0)
     }
 
-    func testRevokedCodemapLifetimeOmitsStaleTargetBeforeModelPublication() async throws {
+    func testRevokedCodemapLifetimeOmitsUnavailableTargetAndReportsLogicalMissingPath() async throws {
         let repositoryFixture = try ReviewGitRepositoryFixture(name: #function)
         defer { repositoryFixture.cleanup() }
         let logicalRoot = try repositoryFixture.makeRepository(
@@ -518,6 +518,15 @@ final class AgentContextExportResolverTests: XCTestCase {
         let physicalRootID = try XCTUnwrap(boundRoots.first {
             $0.standardizedFullPath == worktreeRoot.standardizedFileURL.path
         }?.id)
+        let targetLookup = await store.lookupPath(
+            worktreeRoot.appendingPathComponent("Sources/Target.swift").path,
+            rootScope: lookupContext.rootScope
+        )
+        let target = try XCTUnwrap(targetLookup?.file)
+        let ready = try await readyArtifactDemand(store: store, forFileID: target.id)
+        addTeardownBlock {
+            _ = await store.cancelCodemapArtifactDemand(ready.ticket)
+        }
         let revalidationCount = AgentExportLockedCounter()
         let coordinator = WorkspaceCodemapPresentationCoordinator(
             store: store,
@@ -529,6 +538,7 @@ final class AgentContextExportResolverTests: XCTestCase {
                 revalidationCount.increment()
                 if revalidationCount.value == 1 {
                     await store.unloadRoot(id: physicalRootID)
+                    try? FileManager.default.removeItem(at: worktreeRoot)
                 }
             }
         )
@@ -541,12 +551,175 @@ final class AgentContextExportResolverTests: XCTestCase {
             presentationCoordinator: coordinator
         )
 
-        XCTAssertEqual(model.rows.map(\.kind), [.full])
+        XCTAssertTrue(model.rows.isEmpty)
+        XCTAssertEqual(model.missingPaths, ["Sources/Target.swift"])
+        XCTAssertFalse(model.missingPaths.contains { $0.contains(worktreeRoot.path) })
         XCTAssertTrue(model.codemapPresentation.orderedEntries.isEmpty)
         guard case .unavailable = model.codemapCoverage else {
             return XCTFail("Revoked complete export must publish typed incomplete coverage")
         }
-        XCTAssertGreaterThanOrEqual(revalidationCount.value, 1)
+        XCTAssertEqual(revalidationCount.value, 1)
+    }
+
+    func testRevokedCodemapReloadFallsBackToFreshAuthoritativeFullContent() async throws {
+        let canonicalSentinel = "canonicalCodemapReloadSentinel"
+        let revokedSentinel = "revokedCodemapReloadSentinel"
+        let freshSentinel = "freshCodemapReloadSentinel"
+        let repositoryFixture = try ReviewGitRepositoryFixture(name: #function)
+        defer { repositoryFixture.cleanup() }
+        let logicalRoot = try repositoryFixture.makeRepository(
+            named: "agent-export-reload-logical",
+            files: ["Sources/Target.swift": "struct \(canonicalSentinel) {}\n"]
+        )
+        let worktreeRoot = try repositoryFixture.makeRepository(
+            named: "agent-export-reload-worktree",
+            files: ["Sources/Target.swift": "struct \(revokedSentinel) { func revoked() {} }\n"]
+        )
+        let targetURL = worktreeRoot.appendingPathComponent("Sources/Target.swift")
+        let store = try makeIsolatedCodemapStore(name: #function)
+        _ = try await store.loadRoot(path: logicalRoot.path)
+        let source = makeSource(
+            logicalRoot: logicalRoot,
+            worktreeRoot: worktreeRoot,
+            selection: StoredSelection(selectedPaths: ["Sources/Target.swift"], codemapAutoEnabled: false)
+        )
+        let lookupContext = await AgentContextExportResolver.lookupContext(source: source, store: store)
+        let boundRoots = await store.rootRefs(scope: lookupContext.rootScope)
+        let physicalRoot = try XCTUnwrap(boundRoots.first {
+            $0.standardizedFullPath == worktreeRoot.standardizedFileURL.path
+        })
+        let targetLookup = await store.lookupPath(targetURL.path, rootScope: lookupContext.rootScope)
+        let target = try XCTUnwrap(targetLookup?.file)
+        let ready = try await readyArtifactDemand(store: store, forFileID: target.id)
+        addTeardownBlock {
+            _ = await store.cancelCodemapArtifactDemand(ready.ticket)
+        }
+        let revalidationCount = AgentExportLockedCounter()
+        let coordinator = WorkspaceCodemapPresentationCoordinator(
+            store: store,
+            policy: WorkspaceCodemapPresentationRequestPolicy(
+                maximumReadinessRounds: 20,
+                maximumTotalWait: .seconds(10)
+            ),
+            beforePublicationRevalidation: { _ in
+                revalidationCount.increment()
+                guard revalidationCount.value == 1 else { return }
+                await store.unloadRoot(id: physicalRoot.id)
+                try? FileManager.default.removeItem(at: worktreeRoot.appendingPathComponent(".git"))
+                try? "struct \(freshSentinel) { func current() {} }\n".write(
+                    to: targetURL,
+                    atomically: true,
+                    encoding: .utf8
+                )
+            }
+        )
+
+        let model = await AgentContextExportResolver.resolveModel(
+            source: source,
+            store: store,
+            filePathDisplay: .relative,
+            codeMapUsage: .selected,
+            presentationCoordinator: coordinator
+        )
+
+        let row = try XCTUnwrap(model.rows.first)
+        XCTAssertEqual(row.kind, .full)
+        XCTAssertNotEqual(row.rootID, physicalRoot.id)
+        guard case .unavailable = model.codemapCoverage else {
+            return XCTFail("Unavailable replacement codemap must retain typed unavailable coverage")
+        }
+        let preview = await AgentContextExportResolver.loadRowContent(
+            for: row,
+            model: model,
+            store: store,
+            purpose: .preview
+        )
+        XCTAssertTrue(preview?.contains(freshSentinel) == true, preview ?? "")
+        XCTAssertFalse(preview?.contains(revokedSentinel) == true, preview ?? "")
+        XCTAssertFalse(preview?.contains(canonicalSentinel) == true, preview ?? "")
+        XCTAssertFalse(row.displayPath.contains(worktreeRoot.path), row.displayPath)
+        XCTAssertEqual(revalidationCount.value, 1)
+    }
+
+    func testRevokedCodemapClipboardPublishesFreshBoundBytesOnly() async throws {
+        let canonicalSentinel = "canonicalClipboardRevocationSentinel"
+        let revokedSentinel = "revokedClipboardRevocationSentinel"
+        let freshSentinel = "freshClipboardRevocationSentinel"
+        let repositoryFixture = try ReviewGitRepositoryFixture(name: #function)
+        defer { repositoryFixture.cleanup() }
+        let logicalRoot = try repositoryFixture.makeRepository(
+            named: "agent-export-clipboard-logical",
+            files: ["Sources/Target.swift": "struct \(canonicalSentinel) {}\n"]
+        )
+        let worktreeRoot = try repositoryFixture.makeRepository(
+            named: "agent-export-clipboard-worktree",
+            files: ["Sources/Target.swift": "struct \(revokedSentinel) { func revoked() {} }\n"]
+        )
+        let targetURL = worktreeRoot.appendingPathComponent("Sources/Target.swift")
+        let store = try makeIsolatedCodemapStore(name: #function)
+        _ = try await store.loadRoot(path: logicalRoot.path)
+        let source = makeSource(
+            logicalRoot: logicalRoot,
+            worktreeRoot: worktreeRoot,
+            selection: StoredSelection(selectedPaths: ["Sources/Target.swift"], codemapAutoEnabled: false)
+        )
+        let lookupContext = await AgentContextExportResolver.lookupContext(source: source, store: store)
+        let boundRoots = await store.rootRefs(scope: lookupContext.rootScope)
+        let physicalRoot = try XCTUnwrap(boundRoots.first {
+            $0.standardizedFullPath == worktreeRoot.standardizedFileURL.path
+        })
+        let targetLookup = await store.lookupPath(targetURL.path, rootScope: lookupContext.rootScope)
+        let target = try XCTUnwrap(targetLookup?.file)
+        let ready = try await readyArtifactDemand(store: store, forFileID: target.id)
+        addTeardownBlock {
+            _ = await store.cancelCodemapArtifactDemand(ready.ticket)
+        }
+        let revalidationCount = AgentExportLockedCounter()
+        let coordinator = WorkspaceCodemapPresentationCoordinator(
+            store: store,
+            policy: WorkspaceCodemapPresentationRequestPolicy(
+                maximumReadinessRounds: 20,
+                maximumTotalWait: .seconds(10)
+            ),
+            beforePublicationRevalidation: { _ in
+                revalidationCount.increment()
+                guard revalidationCount.value == 1 else { return }
+                await store.unloadRoot(id: physicalRoot.id)
+                try? FileManager.default.removeItem(at: worktreeRoot.appendingPathComponent(".git"))
+                try? "struct \(freshSentinel) { func current() {} }\n".write(
+                    to: targetURL,
+                    atomically: true,
+                    encoding: .utf8
+                )
+            }
+        )
+
+        let clipboard = await AgentContextExportResolver.buildClipboardContent(
+            AgentContextClipboardRequest(
+                cfg: makeConfig(gitInclusion: .none, codeMapUsage: .selected),
+                source: source,
+                store: store,
+                lookupContext: lookupContext,
+                filePathDisplay: .relative,
+                onlyIncludeRootsWithSelectedFiles: true,
+                showCodeMapMarkers: true,
+                metaInstructions: [],
+                includeDatetimeInUserInstructions: false,
+                promptSectionsOrder: PromptAssemblyBuilder.defaultSectionOrder,
+                disabledPromptSections: [],
+                duplicateUserInstructionsAtTop: false,
+                reviewGitContext: .automaticOnly(),
+                completeGitDiffProvider: { "" }
+            ),
+            presentationCoordinator: coordinator
+        )
+
+        XCTAssertTrue(clipboard.contains(freshSentinel), clipboard)
+        XCTAssertFalse(clipboard.contains(revokedSentinel), clipboard)
+        XCTAssertFalse(clipboard.contains(canonicalSentinel), clipboard)
+        XCTAssertFalse(clipboard.contains(worktreeRoot.path), clipboard)
+        XCTAssertFalse(clipboard.contains(worktreeRoot.lastPathComponent), clipboard)
+        XCTAssertEqual(revalidationCount.value, 1)
     }
 
     func testBoundExportFailsClosedWhenPhysicalWorktreeCannotBeLoaded() async throws {

--- a/Tests/RepoPromptTests/AgentMode/AgentContextExportResolverTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentContextExportResolverTests.swift
@@ -302,7 +302,6 @@ final class AgentContextExportResolverTests: WorkspaceFileContextStoreCodemapSea
 
     func testBoundWorktreeAutoCodemapDoesNotUseMetadataOnlyFastPathWhenAutoCodemapEnabled() async throws {
         let fixture = try await makeBoundFixture()
-        _ = try await fixture.store.loadRoot(path: fixture.worktreeRoot.path)
         let source = makeSource(
             logicalRoot: fixture.logicalRoot,
             worktreeRoot: fixture.worktreeRoot,
@@ -316,6 +315,7 @@ final class AgentContextExportResolverTests: WorkspaceFileContextStoreCodemapSea
             codeMapUsage: .auto
         )
 
+        XCTAssertEqual(model.lookupContext.bindingProjection?.isFullyMaterialized, true)
         XCTAssertEqual(model.rows.first?.displayPath, "Sources/App.swift")
         XCTAssertTrue(model.rows.allSatisfy { $0.directContentPath == nil })
     }
@@ -743,7 +743,10 @@ final class AgentContextExportResolverTests: WorkspaceFileContextStoreCodemapSea
             filePathDisplay: .relative,
             codeMapUsage: .none
         )
-        XCTAssertEqual(model.lookupContext.bindingProjection?.physicalRootPaths, Set([unloadablePhysicalRoot.standardizedFileURL.path]))
+        XCTAssertEqual(
+            model.lookupContext,
+            AgentWorkspaceLookupContextResolver.failClosedLookupContext
+        )
         XCTAssertTrue(model.rows.isEmpty)
         XCTAssertEqual(model.missingPaths, ["Sources/App.swift"])
         XCTAssertFalse(model.missingPaths.contains { $0.contains(unloadablePhysicalRoot.path) })

--- a/Tests/RepoPromptTests/Prompt/PromptContextPreAssemblyServiceTests.swift
+++ b/Tests/RepoPromptTests/Prompt/PromptContextPreAssemblyServiceTests.swift
@@ -116,6 +116,74 @@ final class PromptContextPreAssemblyServiceTests: XCTestCase {
         XCTAssertEqual(result.gitDiff, PromptContextGitDiffPolicy.deferredCompleteWorktreeGitDiffMessage)
     }
 
+    func testSelectedUnavailableCodemapOmitsNilFallbackReadAndReportsLogicalMissingPath() async throws {
+        let logicalRoot = try makeTemporaryRoot(name: "PromptPreAssemblyBinaryLogical")
+        let worktreeRoot = try makeTemporaryRoot(name: "PromptPreAssemblyBinaryWorktree")
+        let relativePath = "Assets/Opaque.dat"
+        try FileManager.default.createDirectory(
+            at: logicalRoot.appendingPathComponent("Assets"),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: worktreeRoot.appendingPathComponent("Assets"),
+            withIntermediateDirectories: true
+        )
+        try Data([0x00, 0x01, 0x02, 0x03]).write(
+            to: logicalRoot.appendingPathComponent(relativePath)
+        )
+        try Data([0x00, 0x04, 0x05, 0x06]).write(
+            to: worktreeRoot.appendingPathComponent(relativePath)
+        )
+
+        let store = WorkspaceFileContextStore()
+        _ = try await store.loadRoot(path: logicalRoot.path)
+        let projection = await WorkspaceRootBindingProjectionMaterializer(store: store).materialize(
+            sessionID: UUID(),
+            bindings: [makeBinding(logicalRoot: logicalRoot, worktreeRoot: worktreeRoot)]
+        )
+        let lookupContext = try WorkspaceLookupContext(
+            rootScope: XCTUnwrap(projection).lookupRootScope,
+            bindingProjection: projection
+        )
+        let issue = WorkspaceCodemapOperationIssue.coordinationUnavailable
+        let unavailablePresentation = WorkspaceCodemapOperationPresentation(
+            orderedEntries: [],
+            coverage: .unavailable([issue]),
+            issues: [issue],
+            publicationReceipt: nil
+        )
+        let request = PromptContextPreAssemblyRequest(
+            cfg: makeConfig(gitInclusion: .none, codeMapUsage: .selected),
+            selection: StoredSelection(
+                selectedPaths: [relativePath],
+                codemapAutoEnabled: false
+            ),
+            store: store,
+            lookupContext: lookupContext,
+            filePathDisplay: .relative,
+            onlyIncludeRootsWithSelectedFiles: true,
+            showCodeMapMarkers: true,
+            selectedGitDiffFolderPolicy: .filesOnly,
+            reviewGitContext: .automaticOnly(),
+            selectedGitDiffProvider: { _ in Self.automaticResult(nil) },
+            completeGitDiffProvider: { nil }
+        )
+
+        let result = await PromptContextPreAssemblyService.resolve(
+            request,
+            codemapPresentation: unavailablePresentation
+        )
+
+        XCTAssertTrue(result.entries.isEmpty)
+        XCTAssertEqual(result.missingPaths, [relativePath])
+        XCTAssertFalse(result.missingPaths.contains {
+            $0.contains(worktreeRoot.standardizedFileURL.path)
+        })
+        guard case .unavailable = result.codemapPresentation.coverage else {
+            return XCTFail("Failed selected codemap fallback must remain unavailable")
+        }
+    }
+
     func testResolveSelectedDiffUsesPhysicalizedSelectionAndPolicy() async throws {
         let fixture = try await makeBoundFixture()
         let captured = CapturedPaths()

--- a/Tests/RepoPromptTests/WorkspaceContext/CodemapPresentationTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/CodemapPresentationTests.swift
@@ -1035,6 +1035,157 @@ final class CodemapPresentationTests: WorkspaceFileContextStoreCodemapSeamTestSu
         }
     }
 
+    func testPreparedRetryWithEmptyIntentPreservesUnavailablePublicationStaleCoverage() async throws {
+        let repositoryFixture = try ReviewGitRepositoryFixture(name: #function)
+        let root = try repositoryFixture.makeRepository(
+            named: "repository",
+            files: [
+                "Sources/Feature.swift": "protocol FeatureProtocol { func feature() -> String }\nstruct Feature: FeatureProtocol { func feature() -> String { \"feature\" } }\n"
+            ]
+        )
+        let fixture = try CodemapStoreFixture(name: #function)
+        addTeardownBlock {
+            await fixture.shutdown()
+            repositoryFixture.cleanup()
+        }
+        let store = fixture.makeStore()
+        let loaded = try await store.loadRoot(path: root.path)
+        let loadedFiles = await store.files(inRoot: loaded.id)
+        let file = try XCTUnwrap(loadedFiles.first)
+        let ready = try await readyArtifactDemand(store: store, forFileID: file.id)
+        addTeardownBlock { _ = await store.cancelCodemapArtifactDemand(ready.ticket) }
+        let preparationCount = CodemapLockedCounter()
+        let publicationCount = CodemapLockedCounter()
+        let coordinator = WorkspaceCodemapPresentationCoordinator(
+            store: store,
+            beforePublicationRevalidation: { _ in
+                publicationCount.increment()
+                if publicationCount.value == 1 {
+                    await store.unloadRoot(id: loaded.id)
+                }
+            }
+        )
+
+        let presentation = try await coordinator.withPresentation(
+            prepareAttempt: {
+                preparationCount.increment()
+                let intent: WorkspaceCodemapOperationPresentationIntent = preparationCount.value == 1
+                    ? .exact(fileIDs: [file.id], completeRootSet: false)
+                    : .none
+                return WorkspaceCodemapPresentationAttempt(
+                    context: (),
+                    intent: intent,
+                    rootScope: .allLoaded,
+                    logicalRootDisplayNamesByRootID: [:],
+                    requestedCodemapCount: preparationCount.value == 1 ? 1 : 0
+                )
+            }
+        ) { _, presentation in
+            presentation
+        }
+
+        XCTAssertTrue(presentation.orderedEntries.isEmpty)
+        guard case .unavailable = presentation.coverage else {
+            return XCTFail("A stale requested codemap cannot become complete when retry intent is empty")
+        }
+        XCTAssertTrue(presentation.issues.contains {
+            if case .publicationStale = $0 { return true }
+            return false
+        })
+        XCTAssertEqual(preparationCount.value, 2)
+        XCTAssertEqual(publicationCount.value, 1)
+    }
+
+    func testPreparedRetryPreservesValidSiblingAsPartialAfterTargetRevocation() async throws {
+        let repositoryFixture = try ReviewGitRepositoryFixture(name: #function)
+        let revokedRoot = try repositoryFixture.makeRepository(
+            named: "revoked",
+            files: [
+                "Sources/Revoked.swift": "protocol RevokedProtocol { func revoked() }\nstruct Revoked: RevokedProtocol { func revoked() {} }\n"
+            ]
+        )
+        let stableRoot = try repositoryFixture.makeRepository(
+            named: "stable",
+            files: [
+                "Sources/Stable.swift": "protocol StableProtocol { func stable() }\nstruct Stable: StableProtocol { func stable() {} }\n"
+            ]
+        )
+        let fixture = try CodemapStoreFixture(name: #function)
+        addTeardownBlock {
+            await fixture.shutdown()
+            repositoryFixture.cleanup()
+        }
+        let store = fixture.makeStore()
+        let revokedLoaded = try await store.loadRoot(path: revokedRoot.path)
+        let stableLoaded = try await store.loadRoot(path: stableRoot.path)
+        let revokedFiles = await store.files(inRoot: revokedLoaded.id)
+        let stableFiles = await store.files(inRoot: stableLoaded.id)
+        let revoked = try XCTUnwrap(revokedFiles.first)
+        let stable = try XCTUnwrap(stableFiles.first)
+        async let revokedDemand = readyArtifactDemand(
+            store: store,
+            forFileID: revoked.id,
+            timeout: .seconds(60)
+        )
+        async let stableDemand = readyArtifactDemand(
+            store: store,
+            forFileID: stable.id,
+            timeout: .seconds(60)
+        )
+        let (revokedReady, stableReady) = try await (revokedDemand, stableDemand)
+        addTeardownBlock {
+            _ = await store.cancelCodemapArtifactDemand(revokedReady.ticket)
+            _ = await store.cancelCodemapArtifactDemand(stableReady.ticket)
+        }
+        let preparationCount = CodemapLockedCounter()
+        let publicationCount = CodemapLockedCounter()
+        let coordinator = WorkspaceCodemapPresentationCoordinator(
+            store: store,
+            policy: WorkspaceCodemapPresentationRequestPolicy(
+                maximumReadinessRounds: 20,
+                maximumTotalWait: .seconds(10)
+            ),
+            beforePublicationRevalidation: { receipt in
+                publicationCount.increment()
+                guard publicationCount.value == 1,
+                      let revokedTicket = receipt.demandTickets.first(where: {
+                          $0.fileID == revoked.id
+                      })
+                else { return }
+                _ = await store.cancelCodemapArtifactDemand(revokedTicket)
+            }
+        )
+
+        let presentation = try await coordinator.withPresentation(
+            prepareAttempt: {
+                preparationCount.increment()
+                let fileIDs = preparationCount.value == 1 ? [revoked.id, stable.id] : [stable.id]
+                return WorkspaceCodemapPresentationAttempt(
+                    context: (),
+                    intent: .exact(fileIDs: fileIDs, completeRootSet: false),
+                    rootScope: .allLoaded,
+                    logicalRootDisplayNamesByRootID: [:],
+                    requestedCodemapCount: fileIDs.count
+                )
+            }
+        ) { _, presentation in
+            presentation
+        }
+
+        guard case .partial = presentation.coverage else {
+            return XCTFail(
+                "A valid sibling must remain partial after another requested codemap is revoked; coverage=\(presentation.coverage), entries=\(presentation.orderedEntries.map(\.fileID)), issues=\(presentation.issues), preparations=\(preparationCount.value), publications=\(publicationCount.value)"
+            )
+        }
+        XCTAssertEqual(presentation.orderedEntries.map(\.fileID), [stable.id])
+        XCTAssertTrue(presentation.issues.contains {
+            if case .publicationStale = $0 { return true }
+            return false
+        })
+        XCTAssertEqual(preparationCount.value, 2)
+        XCTAssertGreaterThanOrEqual(publicationCount.value, 1)
+    }
+
     func testOperationPresentationCancellationDuringPendingWaitReleasesOwnedDemandOnce() async throws {
         let repositoryFixture = try ReviewGitRepositoryFixture(name: #function)
         let root = try repositoryFixture.makeRepository(


### PR DESCRIPTION
## Summary
- rebuild codemap presentation authority, selection rows, and fallback context on each bounded publication attempt
- fail closed for bound worktrees so revocation cannot substitute canonical-checkout content
- omit unreadable selected fallbacks with logical missing-path reporting
- preserve truthful `.partial` / `.unavailable` coverage after requested codemap publication becomes stale

## Correct behavior
- never publish stale codemap bytes
- retry once against current authority under the existing shared deadline
- publish fresh full/sliced fallback only after a current-authority read succeeds
- report unavailable selected content instead of silently dropping it
- retain the existing loaded-root/runtime-unavailable soft fallback
- keep failures local; no MCP transport or app restart failure

## Scope
Production:
- `WorkspaceCodemapPresentationCoordinator.swift`
- `AgentContextExportResolver.swift`
- `PromptContextAccountingService.swift`

Regression coverage:
- deterministic hard unload and reload/current-authority behavior
- actual clipboard bytes with distinct canonical, revoked, and fresh sentinels
- partial and unavailable coverage across bounded retry
- selected nil-read logical missing reporting
- unchanged soft-failure contract

## Validation
- resolver revocation scenarios: 3/3 passed
- unchanged soft-failure regression: 1/1 passed
- coordinator retry coverage: 2/2 passed
- selected nil-read accounting: 1/1 passed
- `make dev-lint`: passed
- `make dev-swift-build PRODUCT=RepoPrompt`: passed
- staged and outgoing secret scans: passed
- repository guardrails: passed
- independent Claude Fable 5 high implementation review: APPROVE, no must-fix findings

## Sequencing
Land as a focused publication-correctness prerequisite before Track C child-failure propagation.