### PR TITLE
Fix Context Builder cancellation after discovery commit

### DIFF
--- a/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderAgentViewModel.swift
+++ b/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderAgentViewModel.swift
@@ -456,6 +456,10 @@ final class ContextBuilderAgentViewModel: ObservableObject {
             let committedTabSnapshotCaptured: (
                 (_ runID: UUID, _ snapshot: MCPServerViewModel.ContextBuilderCommittedTabSnapshot) -> Void
             )?
+            let afterCommittedTabSnapshotCaptured: (@MainActor @Sendable (
+                _ runID: UUID,
+                _ snapshot: MCPServerViewModel.ContextBuilderCommittedTabSnapshot
+            ) async -> Void)?
 
             init(
                 beforeProcessingProviderEvent: ((_ result: AIStreamResult, _ runID: UUID) async -> Void)?,
@@ -467,7 +471,11 @@ final class ContextBuilderAgentViewModel: ObservableObject {
                 validateContextBuilderProviders: (@MainActor @Sendable () async -> Void)? = nil,
                 committedTabSnapshotCaptured: (
                     (_ runID: UUID, _ snapshot: MCPServerViewModel.ContextBuilderCommittedTabSnapshot) -> Void
-                )? = nil
+                )? = nil,
+                afterCommittedTabSnapshotCaptured: (@MainActor @Sendable (
+                    _ runID: UUID,
+                    _ snapshot: MCPServerViewModel.ContextBuilderCommittedTabSnapshot
+                ) async -> Void)? = nil
             ) {
                 self.beforeProcessingProviderEvent = beforeProcessingProviderEvent
                 self.providerEventDisposition = providerEventDisposition
@@ -477,6 +485,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
                 self.runMCPFollowUp = runMCPFollowUp
                 self.validateContextBuilderProviders = validateContextBuilderProviders
                 self.committedTabSnapshotCaptured = committedTabSnapshotCaptured
+                self.afterCommittedTabSnapshotCaptured = afterCommittedTabSnapshotCaptured
             }
         }
 
@@ -2091,14 +2100,18 @@ final class ContextBuilderAgentViewModel: ObservableObject {
     private func launchContextBuilderRun(_ record: ContextBuilderRunRecord) {
         let task = Task { @MainActor [weak self, weak record] in
             guard let self, let record else { return }
-            let outcome = await performContextBuilderAgentRun(record: record)
+            var outcome = await performContextBuilderAgentRun(record: record)
             await record.reportProgress(.runFinalization)
+            let deferredCancellationPolicy = record.consumeDeferredCancellationAtSafeBoundary()
+            if deferredCancellationPolicy != nil {
+                outcome = .cancelled
+            }
             finalizeContextBuilderRun(
                 record,
                 outcome: outcome,
-                waiterResolution: .snapshot,
+                waiterResolution: deferredCancellationPolicy?.waiterResolution ?? .snapshot,
                 cancelExecution: false,
-                saveHistory: true,
+                saveHistory: deferredCancellationPolicy?.saveHistory ?? true,
                 source: "contextBuilder.execution"
             )
             await restoreToolRestrictions(agent: record.agentKind, runID: record.runID)
@@ -2873,7 +2886,12 @@ final class ContextBuilderAgentViewModel: ObservableObject {
             debugLog("cancelMCPContextBuilderRun: no active MCP record for runID \(runID)")
             return
         }
-        cancelRun(record, waiterResolution: .cancellationError, saveHistory: true)
+        cancelRun(
+            record,
+            waiterResolution: .cancellationError,
+            deferredWaiterResolution: .snapshot,
+            saveHistory: true
+        )
     }
 
     /// Cancel a MCP-triggered discovery run by tab ID.
@@ -2883,12 +2901,18 @@ final class ContextBuilderAgentViewModel: ObservableObject {
             debugLog("cancelMCPContextBuilderRun: no active MCP record for tabID \(tabID)")
             return
         }
-        cancelRun(record, waiterResolution: .cancellationError, saveHistory: true)
+        cancelRun(
+            record,
+            waiterResolution: .cancellationError,
+            deferredWaiterResolution: .snapshot,
+            saveHistory: true
+        )
     }
 
     private func cancelRun(
         _ record: ContextBuilderRunRecord,
         waiterResolution: ContextBuilderRunWaiterResolution,
+        deferredWaiterResolution: ContextBuilderRunWaiterResolution? = nil,
         saveHistory: Bool
     ) {
         guard acceptsEvents(from: record) else {
@@ -2900,21 +2924,30 @@ final class ContextBuilderAgentViewModel: ObservableObject {
             )
             return
         }
-        guard record.canAcceptCancellation else {
-            debugLog("Cancel ignored after final context commit claim for run \(record.runID)")
-            return
-        }
-        _ = beginCancellation(forTabID: record.tabID)
-        debugLog("Cancel requested for run \(record.runID) tab \(record.tabID)")
-
-        finalizeContextBuilderRun(
-            record,
-            outcome: .cancelled,
-            waiterResolution: waiterResolution,
-            cancelExecution: true,
-            saveHistory: saveHistory,
-            source: "contextBuilder.cancel"
+        let deferredSettlementPolicy = ContextBuilderRunCancellationSettlementPolicy(
+            waiterResolution: deferredWaiterResolution ?? waiterResolution,
+            saveHistory: saveHistory
         )
+        switch record.requestCancellation(deferredSettlementPolicy: deferredSettlementPolicy) {
+        case .settleImmediately:
+            _ = beginCancellation(forTabID: record.tabID)
+            debugLog("Cancel requested for run \(record.runID) tab \(record.tabID)")
+            finalizeContextBuilderRun(
+                record,
+                outcome: .cancelled,
+                waiterResolution: waiterResolution,
+                cancelExecution: true,
+                saveHistory: saveHistory,
+                source: "contextBuilder.cancel"
+            )
+        case .deferredUntilFinalContextCommitCompletes:
+            _ = beginCancellation(forTabID: record.tabID)
+            debugLog("Cancel deferred until final context commit completes for run \(record.runID)")
+        case .alreadyRequested:
+            debugLog("Cancel already requested for run \(record.runID)")
+        case .terminal:
+            debugLog("Cancel ignored for terminal run \(record.runID)")
+        }
     }
 
     @discardableResult
@@ -3005,10 +3038,11 @@ final class ContextBuilderAgentViewModel: ObservableObject {
     private func retainCommittedTabSnapshot(
         _ snapshot: MCPServerViewModel.ContextBuilderCommittedTabSnapshot,
         on record: ContextBuilderRunRecord
-    ) -> Bool {
+    ) async -> Bool {
         guard record.installCommittedTabSnapshot(snapshot) else { return false }
         #if DEBUG
             runTestHooks?.committedTabSnapshotCaptured?(record.runID, snapshot)
+            await runTestHooks?.afterCommittedTabSnapshotCaptured?(record.runID, snapshot)
         #endif
         return true
     }
@@ -3046,8 +3080,10 @@ final class ContextBuilderAgentViewModel: ObservableObject {
                     guard matches.count == 1,
                           let identity = matches.first,
                           var tab = manager.composeTab(for: identity),
-                          activeAgentRuns.remove(runID) != nil,
-                          acceptsEvents(from: record)
+                          activeAgentRuns.contains(runID),
+                          acceptsEvents(from: record),
+                          record.claimFinalContextCommit(),
+                          activeAgentRuns.remove(runID) != nil
                     else {
                         return MCPServerViewModel.ContextBuilderTabContextCommitResult(
                             outcome: .staleOrNoLongerCurrent,
@@ -3084,7 +3120,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
                         ),
                         usedAgentOutputAsPrompt: usedAgentOutputAsPrompt
                     )
-                    guard retainCommittedTabSnapshot(snapshot, on: record) else {
+                    guard await retainCommittedTabSnapshot(snapshot, on: record) else {
                         return MCPServerViewModel.ContextBuilderTabContextCommitResult(
                             outcome: .failed("Context Builder could not retain its committed tab snapshot."),
                             committedTab: nil
@@ -3260,10 +3296,12 @@ final class ContextBuilderAgentViewModel: ObservableObject {
                 #endif
                 guard result.outcome == .committed,
                       let committedTab = result.committedTab,
-                      retainCommittedTabSnapshot(committedTab, on: record)
+                      await retainCommittedTabSnapshot(committedTab, on: record)
                 else { return false }
                 record.session.usedAgentOutputAsPrompt = committedTab.usedAgentOutputAsPrompt
-                return activeAgentRuns.contains(runID) && acceptsEvents(from: record)
+                return !record.hasDeferredCancellationPending
+                    && activeAgentRuns.contains(runID)
+                    && acceptsEvents(from: record)
             },
             beforeTerminationRequest: {
                 await record.reportProgress(.childConnectionTermination)

--- a/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderRunLifecycle.swift
+++ b/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderRunLifecycle.swift
@@ -27,9 +27,28 @@ enum ContextBuilderRunTerminalOutcome: Equatable {
     }
 }
 
-enum ContextBuilderRunWaiterResolution {
+enum ContextBuilderRunWaiterResolution: Equatable {
     case snapshot
     case cancellationError
+}
+
+struct ContextBuilderRunCancellationSettlementPolicy: Equatable {
+    let waiterResolution: ContextBuilderRunWaiterResolution
+    let saveHistory: Bool
+}
+
+enum ContextBuilderRunCancellationState: Equatable {
+    case none
+    case requested
+    case deferredUntilFinalContextCommitCompletes
+    case applied
+}
+
+enum ContextBuilderRunCancellationDisposition: Equatable {
+    case settleImmediately
+    case deferredUntilFinalContextCommitCompletes
+    case alreadyRequested
+    case terminal
 }
 
 enum ContextBuilderResponseDeliveryDrainOutcome: Equatable {
@@ -167,6 +186,8 @@ final class ContextBuilderRunRecord {
     private var continuation: CheckedContinuation<ContextBuilderAgentViewModel.MCPContextBuilderRunCompletion, Error>?
     private var provider: HeadlessAgentProvider?
     private(set) var finalContextCommitClaimed = false
+    private(set) var cancellationState = ContextBuilderRunCancellationState.none
+    private(set) var deferredCancellationSettlementPolicy: ContextBuilderRunCancellationSettlementPolicy?
     private(set) var terminalOutcome: ContextBuilderRunTerminalOutcome?
     private(set) var teardownStartedAt: Date?
     private(set) var teardownFinishedAt: Date?
@@ -209,8 +230,8 @@ final class ContextBuilderRunRecord {
         terminalOutcome != nil
     }
 
-    var canAcceptCancellation: Bool {
-        terminalOutcome == nil && !finalContextCommitClaimed
+    var hasDeferredCancellationPending: Bool {
+        cancellationState == .deferredUntilFinalContextCommitCompletes
     }
 
     var isTeardownPending: Bool {
@@ -219,9 +240,36 @@ final class ContextBuilderRunRecord {
 
     @discardableResult
     func claimFinalContextCommit() -> Bool {
-        guard terminalOutcome == nil, !finalContextCommitClaimed else { return false }
+        guard terminalOutcome == nil,
+              cancellationState == .none,
+              !finalContextCommitClaimed
+        else { return false }
         finalContextCommitClaimed = true
         return true
+    }
+
+    func requestCancellation(
+        deferredSettlementPolicy: ContextBuilderRunCancellationSettlementPolicy
+    ) -> ContextBuilderRunCancellationDisposition {
+        guard terminalOutcome == nil else { return .terminal }
+        guard cancellationState == .none else { return .alreadyRequested }
+
+        if finalContextCommitClaimed {
+            cancellationState = .deferredUntilFinalContextCommitCompletes
+            deferredCancellationSettlementPolicy = deferredSettlementPolicy
+            return .deferredUntilFinalContextCommitCompletes
+        }
+        cancellationState = .requested
+        return .settleImmediately
+    }
+
+    func consumeDeferredCancellationAtSafeBoundary() -> ContextBuilderRunCancellationSettlementPolicy? {
+        guard terminalOutcome == nil,
+              cancellationState == .deferredUntilFinalContextCommitCompletes,
+              let deferredCancellationSettlementPolicy
+        else { return nil }
+        cancellationState = .applied
+        return deferredCancellationSettlementPolicy
     }
 
     @discardableResult

--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPContextBuilderToolProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPContextBuilderToolProvider.swift
@@ -527,14 +527,8 @@ final class MCPContextBuilderToolProvider: MCPWindowToolProviding {
                     "Context Builder run complete, building selection..."
                 )
 
-                let resultTab: ComposeTabState
-                switch snapshot.terminalDisposition {
-                case .completed:
-                    guard let committedTab = snapshot.committedTab else {
-                        throw MCPError.internalError(
-                            "Context Builder completed without an exact committed tab snapshot"
-                        )
-                    }
+                let committedResultTab: ComposeTabState?
+                if let committedTab = snapshot.committedTab {
                     guard committedTab.nestedRunID == snapshot.runID,
                           committedTab.identity == resolvedIdentity,
                           committedTab.tab.id == finalTabID
@@ -543,36 +537,52 @@ final class MCPContextBuilderToolProvider: MCPWindowToolProviding {
                             "Context Builder committed tab identity does not match the completed run"
                         )
                     }
-                    let canonicalState = await MainActor.run { () -> (ComposeTabState?, UInt64) in
-                        let manager = targetWindow.workspaceManager
-                        return (
-                            manager.composeTab(for: committedTab.identity),
-                            manager.selectionRevisionForMCP(
-                                workspaceID: committedTab.identity.workspaceID,
-                                tabID: committedTab.identity.tabID
+                    if snapshot.terminalDisposition == .completed {
+                        let canonicalState = await MainActor.run { () -> (ComposeTabState?, UInt64) in
+                            let manager = targetWindow.workspaceManager
+                            return (
+                                manager.composeTab(for: committedTab.identity),
+                                manager.selectionRevisionForMCP(
+                                    workspaceID: committedTab.identity.workspaceID,
+                                    tabID: committedTab.identity.tabID
+                                )
                             )
-                        )
-                    }
-                    let committedSnapshotIsCurrent: Bool = if responseType == .review {
-                        canonicalState.1 == committedTab.selectionRevision
-                            && canonicalState.0?.selection == committedTab.tab.selection
-                    } else {
-                        canonicalState.1 >= committedTab.selectionRevision
-                            && (
-                                canonicalState.1 != committedTab.selectionRevision
-                                    || canonicalState.0?.selection == committedTab.tab.selection
+                        }
+                        let committedSnapshotIsCurrent: Bool = if responseType == .review {
+                            canonicalState.1 == committedTab.selectionRevision
+                                && canonicalState.0?.selection == committedTab.tab.selection
+                        } else {
+                            canonicalState.1 >= committedTab.selectionRevision
+                                && (
+                                    canonicalState.1 != committedTab.selectionRevision
+                                        || canonicalState.0?.selection == committedTab.tab.selection
+                                )
+                        }
+                        guard committedSnapshotIsCurrent else {
+                            throw MCPError.internalError(
+                                "Context Builder committed tab snapshot is no longer valid"
                             )
+                        }
                     }
-                    guard committedSnapshotIsCurrent else {
+                    committedResultTab = committedTab.tab
+                } else {
+                    committedResultTab = nil
+                }
+
+                let resultTab: ComposeTabState
+                switch snapshot.terminalDisposition {
+                case .completed:
+                    guard let committedResultTab else {
                         throw MCPError.internalError(
-                            "Context Builder committed tab snapshot is no longer valid"
+                            "Context Builder completed without an exact committed tab snapshot"
                         )
                     }
-                    resultTab = committedTab.tab
+                    resultTab = committedResultTab
                 case .cancelled, .failed:
-                    // Genuine discovery failures retain the exact immutable pre-run tab instead of
-                    // falling back to an active or duplicate tab after child cleanup.
-                    resultTab = initialResultTab
+                    // Cancellation or failure after a successful commit must report the exact
+                    // committed prompt and selection. Pre-commit outcomes retain the immutable
+                    // initial tab instead of consulting mutable active-tab state.
+                    resultTab = committedResultTab ?? initialResultTab
                 }
 
                 let overrides = resultTab.contextOverrides

--- a/Tests/RepoPromptTests/ContextBuilder/ContextBuilderMCPProgressTimelineTests.swift
+++ b/Tests/RepoPromptTests/ContextBuilder/ContextBuilderMCPProgressTimelineTests.swift
@@ -563,6 +563,142 @@ final class ContextBuilderMCPProgressTimelineTests: XCTestCase {
         #endif
     }
 
+    @MainActor
+    func testPostCommitMCPCancellationReturnsCommittedPromptAndSelection() async throws {
+        #if DEBUG
+            let provider = ContextBuilderImmediateCompletionProvider()
+            let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
+            GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
+            let window = WindowState { _, _, _ in provider }
+            GlobalSettingsStore.shared.setMCPAutoStart(previousAutoStart, commit: false)
+            WindowStatesManager.shared.registerWindowState(window)
+            defer { WindowStatesManager.shared.unregisterWindowState(window) }
+            await window.workspaceManager.awaitInitialized()
+
+            let root = FileManager.default.temporaryDirectory
+                .appendingPathComponent("ContextBuilderPostCommitCancellationTests-\(UUID().uuidString)")
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: root) }
+            let selectedFile = root.appendingPathComponent("committed.swift")
+            try "struct CommittedSelection {}\n".write(to: selectedFile, atomically: true, encoding: .utf8)
+
+            let workspace = window.workspaceManager.createWorkspace(
+                name: "Context Builder post-commit cancellation test",
+                repoPaths: [root.path],
+                ephemeral: true
+            )
+            await window.workspaceManager.switchWorkspace(
+                to: workspace,
+                saveState: false,
+                reason: "ContextBuilderMCPProgressTimelineTests.postCommitCancellation"
+            )
+
+            let activeWorkspace = try XCTUnwrap(window.workspaceManager.activeWorkspace)
+            ContextBuilderTestReadinessSupport.seedCanonicalProviderReadiness(
+                apiSettingsViewModel: window.apiSettingsViewModel,
+                workspaceID: activeWorkspace.id
+            )
+            let tabID = try XCTUnwrap(
+                activeWorkspace.activeComposeTabID ?? activeWorkspace.composeTabs.first?.id
+            )
+            let identity = WorkspaceSelectionIdentity(workspaceID: activeWorkspace.id, tabID: tabID)
+            var initialTab = try XCTUnwrap(window.workspaceManager.composeTab(for: identity))
+            initialTab.promptText = "Initial prompt"
+            initialTab.selection = StoredSelection()
+            XCTAssertTrue(window.workspaceManager.updateComposeTabStoredOnly(
+                initialTab,
+                inWorkspaceID: activeWorkspace.id
+            ))
+            window.promptManager.promptText = initialTab.promptText
+
+            let committedPrompt = "Committed prompt"
+            let committedSelection = StoredSelection(selectedPaths: [selectedFile.path])
+            let commitGate = ContextBuilderPostCommitCancellationGate()
+            let committedSnapshotRecorder = ContextBuilderCommittedSnapshotRecorder()
+            let followUpRecorder = ContextBuilderFollowUpInvocationRecorder()
+            window.contextBuilderAgentViewModel.installRunTestHooks(
+                ContextBuilderAgentViewModel.RunTestHooks(
+                    beforeProcessingProviderEvent: { [weak window] result, _ in
+                        guard result.type == "content", let window else { return }
+                        await MainActor.run {
+                            guard var tab = window.workspaceManager.composeTab(for: identity) else { return }
+                            tab.promptText = committedPrompt
+                            tab.selection = committedSelection
+                            _ = window.workspaceManager.updateComposeTabStoredOnly(
+                                tab,
+                                inWorkspaceID: identity.workspaceID
+                            )
+                        }
+                    },
+                    providerEventDisposition: nil,
+                    teardownCompleted: nil,
+                    allowSyntheticRoutingWithoutFinalContext: true,
+                    runMCPFollowUp: { mode, prompt, selection in
+                        await followUpRecorder.record(mode: mode, prompt: prompt, selection: selection)
+                        let chatID = UUID()
+                        return ChatSendReply(
+                            chatId: chatID,
+                            shortId: String(chatID.uuidString.prefix(8)).lowercased(),
+                            mode: mode.mcpModeName,
+                            response: "must not be generated",
+                            errors: nil
+                        )
+                    },
+                    committedTabSnapshotCaptured: { runID, snapshot in
+                        committedSnapshotRecorder.record(runID: runID, snapshot: snapshot)
+                    },
+                    afterCommittedTabSnapshotCaptured: { runID, _ in
+                        await commitGate.arriveAndWait(runID: runID)
+                    }
+                )
+            )
+            defer { window.contextBuilderAgentViewModel.installRunTestHooks(nil) }
+
+            let tools = await window.mcpServer.windowMCPTools
+            let contextBuilder = try XCTUnwrap(
+                tools.first { $0.name == MCPWindowToolName.contextBuilder }
+            )
+            let resultTask = Task { @MainActor in
+                try await contextBuilder([
+                    "instructions": .string("Inspect the committed selection."),
+                    "response_type": .string("plan"),
+                    "context_id": .string(tabID.uuidString)
+                ])
+            }
+
+            let runID = await commitGate.waitUntilArrived()
+            await window.contextBuilderAgentViewModel.cancelMCPContextBuilderRun(runID: runID)
+            XCTAssertTrue(window.contextBuilderAgentViewModel.sessions[tabID]?.isCancelling == true)
+            await commitGate.release()
+
+            let result = try await resultTask.value
+            guard case let .object(resultObject) = result else {
+                return XCTFail("Expected Context Builder object result")
+            }
+            XCTAssertEqual(resultObject["status"]?.stringValue, "cancelled")
+            XCTAssertEqual(resultObject["prompt"]?.stringValue, committedPrompt)
+            XCTAssertEqual(resultObject["file_count"], .int(1))
+            XCTAssertTrue(
+                resultObject["selection"]?.stringValue?.contains(selectedFile.lastPathComponent) == true
+            )
+            XCTAssertNil(resultObject["plan"])
+            let followUpInvocation = await followUpRecorder.snapshot()
+            XCTAssertNil(followUpInvocation)
+
+            let storedTab = try XCTUnwrap(window.workspaceManager.composeTab(for: identity))
+            XCTAssertEqual(storedTab.promptText, committedPrompt)
+            XCTAssertEqual(storedTab.selection, committedSelection)
+            let captures = committedSnapshotRecorder.snapshotAll()
+            XCTAssertEqual(captures.count, 1)
+            XCTAssertEqual(captures.first?.runID, runID)
+            XCTAssertEqual(captures.first?.snapshot.tab.promptText, committedPrompt)
+            XCTAssertEqual(captures.first?.snapshot.tab.selection, committedSelection)
+            XCTAssertEqual(window.contextBuilderAgentViewModel.sessions[tabID]?.agentRunState, .cancelled)
+        #else
+            throw XCTSkip("Provider-path Context Builder injection is DEBUG-only.")
+        #endif
+    }
+
     func testTypedPromptResolverEnforcesPrecedenceAndReservedMarkupGrammar() {
         struct Case {
             let name: String
@@ -973,6 +1109,39 @@ private final class ContextBuilderImmediateCompletionProvider: HeadlessAgentProv
     }
 
     func dispose() async {}
+}
+
+private actor ContextBuilderPostCommitCancellationGate {
+    private var arrivedRunID: UUID?
+    private var arrivalWaiters: [CheckedContinuation<UUID, Never>] = []
+    private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+    private var isReleased = false
+
+    func arriveAndWait(runID: UUID) async {
+        arrivedRunID = runID
+        let waiters = arrivalWaiters
+        arrivalWaiters.removeAll()
+        waiters.forEach { $0.resume(returning: runID) }
+        guard !isReleased else { return }
+        await withCheckedContinuation { continuation in
+            releaseWaiters.append(continuation)
+        }
+    }
+
+    func waitUntilArrived() async -> UUID {
+        if let arrivedRunID { return arrivedRunID }
+        return await withCheckedContinuation { continuation in
+            arrivalWaiters.append(continuation)
+        }
+    }
+
+    func release() {
+        guard !isReleased else { return }
+        isReleased = true
+        let waiters = releaseWaiters
+        releaseWaiters.removeAll()
+        waiters.forEach { $0.resume() }
+    }
 }
 
 private actor ContextBuilderDiscoveryInputRecorder {

--- a/Tests/RepoPromptTests/ContextBuilder/ContextBuilderRunLifecycleTests.swift
+++ b/Tests/RepoPromptTests/ContextBuilder/ContextBuilderRunLifecycleTests.swift
@@ -30,10 +30,10 @@ final class ContextBuilderRunLifecycleTests: XCTestCase {
 
         await Task.yield()
         let record = try XCTUnwrap(capturedRecord)
-        XCTAssertTrue(record.canAcceptCancellation)
+        XCTAssertEqual(record.cancellationState, .none)
         XCTAssertTrue(record.claimFinalContextCommit())
         XCTAssertTrue(record.finalContextCommitClaimed)
-        XCTAssertFalse(record.canAcceptCancellation)
+        XCTAssertEqual(record.cancellationState, .none)
         XCTAssertFalse(record.claimFinalContextCommit())
         XCTAssertTrue(record.claimTerminal(.completed))
         XCTAssertFalse(record.claimTerminal(.cancelled))
@@ -57,6 +57,144 @@ final class ContextBuilderRunLifecycleTests: XCTestCase {
         let snapshot = try await waiter.value
         XCTAssertEqual(snapshot.runID, record.runID)
         XCTAssertEqual(snapshot.agentOutput, "done")
+    }
+
+    func testCancellationDuringFinalCommitDefersUntilSafeBoundary() {
+        let tabID = UUID()
+        let session = ContextBuilderAgentViewModel.TabSession(tabID: tabID)
+        let record = makeRecord(
+            tabID: tabID,
+            session: session,
+            ownership: session.beginRunAttempt(source: "deferred-cancel")
+        )
+        let settlementPolicy = ContextBuilderRunCancellationSettlementPolicy(
+            waiterResolution: .snapshot,
+            saveHistory: true
+        )
+
+        XCTAssertTrue(record.claimFinalContextCommit())
+        XCTAssertEqual(
+            record.requestCancellation(deferredSettlementPolicy: settlementPolicy),
+            .deferredUntilFinalContextCommitCompletes
+        )
+        XCTAssertEqual(record.cancellationState, .deferredUntilFinalContextCommitCompletes)
+        XCTAssertEqual(record.deferredCancellationSettlementPolicy, settlementPolicy)
+        XCTAssertTrue(record.hasDeferredCancellationPending)
+        XCTAssertEqual(
+            record.requestCancellation(deferredSettlementPolicy: settlementPolicy),
+            .alreadyRequested
+        )
+
+        XCTAssertEqual(record.consumeDeferredCancellationAtSafeBoundary(), settlementPolicy)
+        XCTAssertEqual(record.cancellationState, .applied)
+        XCTAssertNil(record.consumeDeferredCancellationAtSafeBoundary())
+        XCTAssertTrue(record.claimTerminal(.cancelled))
+        XCTAssertFalse(record.claimTerminal(.completed))
+    }
+
+    func testDeferredWorkspaceCancellationPreservesErrorPolicyAfterCommitBoundaryCheck() {
+        let tabID = UUID()
+        let session = ContextBuilderAgentViewModel.TabSession(tabID: tabID)
+        let record = makeRecord(
+            tabID: tabID,
+            session: session,
+            ownership: session.beginRunAttempt(source: "workspace-cancel")
+        )
+        let workspaceCancellationPolicy = ContextBuilderRunCancellationSettlementPolicy(
+            waiterResolution: .cancellationError,
+            saveHistory: false
+        )
+
+        XCTAssertTrue(record.claimFinalContextCommit())
+        XCTAssertNil(record.consumeDeferredCancellationAtSafeBoundary())
+        XCTAssertEqual(
+            record.requestCancellation(deferredSettlementPolicy: workspaceCancellationPolicy),
+            .deferredUntilFinalContextCommitCompletes
+        )
+        XCTAssertEqual(
+            record.consumeDeferredCancellationAtSafeBoundary(),
+            workspaceCancellationPolicy
+        )
+        XCTAssertTrue(record.claimTerminal(.cancelled))
+        XCTAssertFalse(record.claimTerminal(.completed))
+    }
+
+    func testCancelCommitRaceResolvesExactlyOnceForEitherOrdering() {
+        let settlementPolicy = ContextBuilderRunCancellationSettlementPolicy(
+            waiterResolution: .snapshot,
+            saveHistory: true
+        )
+        let cancelFirstTabID = UUID()
+        let cancelFirstSession = ContextBuilderAgentViewModel.TabSession(tabID: cancelFirstTabID)
+        let cancelFirst = makeRecord(
+            tabID: cancelFirstTabID,
+            session: cancelFirstSession,
+            ownership: cancelFirstSession.beginRunAttempt(source: "cancel-first")
+        )
+
+        XCTAssertEqual(
+            cancelFirst.requestCancellation(deferredSettlementPolicy: settlementPolicy),
+            .settleImmediately
+        )
+        XCTAssertFalse(cancelFirst.claimFinalContextCommit())
+        XCTAssertTrue(cancelFirst.claimTerminal(.cancelled))
+        XCTAssertFalse(cancelFirst.claimTerminal(.completed))
+        XCTAssertEqual(
+            cancelFirst.requestCancellation(deferredSettlementPolicy: settlementPolicy),
+            .terminal
+        )
+
+        let commitFirstTabID = UUID()
+        let commitFirstSession = ContextBuilderAgentViewModel.TabSession(tabID: commitFirstTabID)
+        let commitFirst = makeRecord(
+            tabID: commitFirstTabID,
+            session: commitFirstSession,
+            ownership: commitFirstSession.beginRunAttempt(source: "commit-first")
+        )
+
+        XCTAssertTrue(commitFirst.claimFinalContextCommit())
+        XCTAssertEqual(
+            commitFirst.requestCancellation(deferredSettlementPolicy: settlementPolicy),
+            .deferredUntilFinalContextCommitCompletes
+        )
+        XCTAssertEqual(
+            commitFirst.consumeDeferredCancellationAtSafeBoundary(),
+            settlementPolicy
+        )
+        XCTAssertTrue(commitFirst.claimTerminal(.cancelled))
+        XCTAssertFalse(commitFirst.claimTerminal(.completed))
+        XCTAssertEqual(
+            commitFirst.requestCancellation(deferredSettlementPolicy: settlementPolicy),
+            .terminal
+        )
+    }
+
+    func testPreCommitCancellationRemainsImmediate() {
+        let tabID = UUID()
+        let session = ContextBuilderAgentViewModel.TabSession(tabID: tabID)
+        let record = makeRecord(
+            tabID: tabID,
+            session: session,
+            ownership: session.beginRunAttempt(source: "pre-commit-cancel")
+        )
+        let settlementPolicy = ContextBuilderRunCancellationSettlementPolicy(
+            waiterResolution: .cancellationError,
+            saveHistory: false
+        )
+
+        XCTAssertEqual(
+            record.requestCancellation(deferredSettlementPolicy: settlementPolicy),
+            .settleImmediately
+        )
+        XCTAssertEqual(record.cancellationState, .requested)
+        XCTAssertNil(record.deferredCancellationSettlementPolicy)
+        XCTAssertFalse(record.hasDeferredCancellationPending)
+        XCTAssertFalse(record.claimFinalContextCommit())
+        XCTAssertTrue(record.claimTerminal(.cancelled))
+        XCTAssertEqual(
+            record.requestCancellation(deferredSettlementPolicy: settlementPolicy),
+            .terminal
+        )
     }
 
     func testTerminalCommitCapturesPromptFallbackBeforeContextCleanup() async throws {


### PR DESCRIPTION
## Summary
- record cancellation requests that arrive while Context Builder's final context commit is in flight instead of silently ignoring them
- apply deferred cancellation at the next safe boundary while preserving the existing exactly-once terminal authority
- return the immutable committed prompt and selection for direct MCP cancellation after commit, while keeping workspace/tab/window teardown as a cancellation error
- skip typed Oracle generation for cancelled or failed discovery outcomes

## Root cause
Claiming the final context commit made the run reject cancellation before it had terminally settled. If cancellation arrived in that window, the request was ignored. Even when the app retained the committed selection, the typed MCP result selected the immutable pre-run tab for cancelled/failed outcomes, which could expose a blank or stale prompt/selection.

## Correct behavior
- pre-commit cancellation remains immediate
- cancellation during the atomic commit is deferred rather than interrupting the commit
- the first cancellation request owns its waiter/history policy and the run settles exactly once
- direct MCP cancellation after commit returns a cancelled typed result containing the committed context
- workspace switch/removal and tab/window close retain cancellation-error semantics
- only run-owned resources are cancelled; the parent MCP transport remains untouched

## Validation
- `ContextBuilderRunLifecycleTests`: 15 passed
- `ContextBuilderMCPProgressTimelineTests`: 12 passed
- `make dev-lint`: passed
- `make dev-swift-build PRODUCT=RepoPrompt`: passed
- commit and push contribution preflights: passed
- independent Fable 5 high plan and implementation reviews: no unresolved must-fix findings

## Scope
This intentionally does not add generic deadlines, new settlement coordinators, progress telemetry, selection-projection convergence changes, or transport recovery. The follow-up CB track will address the uninstrumented selection-ingress/startup/finalization waits and caller-visible phase observability separately. General discovery performance remains a distinct measurement-led optimization track.
