### PR TITLE
Fix Codex app-server tool override policy

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -1429,7 +1429,6 @@ final class AgentModeViewModel: ObservableObject {
         let codexControllerFactory: CodexAgentModeCoordinator.CodexControllerFactory = { runID, tabID, windowID, workspacePath, permissionProfile, _, computerUseEnabled in
             let client = CodexAppServerClient()
             let options = CodexNativeSessionController.Options.agentModeDefault(
-                forceExperimentalSteering: true,
                 approvalPolicyProvider: { permissionProfile.codexApprovalPolicy },
                 sandboxModeProvider: { permissionProfile.codexSandboxMode },
                 approvalReviewerProvider: { permissionProfile.codexApprovalReviewer },

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppOnly/CodexOverrides.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppOnly/CodexOverrides.swift
@@ -3,13 +3,10 @@ import Foundation
 enum CodexOverrides {
     private static let forcedDisabledConfig: [String: Bool] = [
         "features.apps": false,
-        "features.js_repl": false,
-        "features.js_repl_tools_only": false,
         "features.memories": false,
         "features.goals": false,
         "features.computer_use": false,
         "features.plugins": false,
-        "features.tool_search": false,
         // Disable MCP elicitation until RepoPrompt supports the mcpServer/elicitation/request
         // server request and its {action, content, _meta} response contract. Without this,
         // Codex routes MCP tool approvals through elicitation by default (ToolCallMcpElicitation
@@ -23,9 +20,7 @@ enum CodexOverrides {
     private static let computerUseEnabledConfig: [String: Bool] = [
         "features.computer_use": true,
         "features.plugins": true,
-        "features.tool_search": true,
         "features.tool_call_mcp_elicitation": true,
-        "features.tool_search_always_defer_mcp_tools": true,
         "features.tool_suggest": true
     ]
 
@@ -53,13 +48,7 @@ enum CodexOverrides {
         var toolOutputTokenLimit: Int
         var shellToolEnabled: Bool?
         var webSearchRequestEnabled: Bool?
-        var viewImageToolEnabled: Bool?
-        /// Best-effort only in the current Codex stack: shipped model metadata can still expose
-        /// built-in patching, and shell/unified-exec can still route patch activity when enabled.
-        var includeApplyPatchTool: Bool?
-        var parallelToolCallsEnabled: Bool?
         var multiAgentEnabled: Bool?
-        var experimentalSteeringEnabled: Bool?
         /// Keep reasoning summaries enabled for newer Codex models that now default them off.
         var modelReasoningSummary: ReasoningSummary? = .auto
     }
@@ -89,22 +78,9 @@ enum CodexOverrides {
         }
         if let webSearchRequestEnabled = toolPolicy.webSearchRequestEnabled {
             args.append(contentsOf: ["-c", "web_search=\(webSearchMode(enabled: webSearchRequestEnabled))"])
-            args.append(contentsOf: ["-c", "features.web_search_request=\(webSearchRequestEnabled)"])
-        }
-        if let viewImageToolEnabled = toolPolicy.viewImageToolEnabled {
-            args.append(contentsOf: ["-c", "features.view_image_tool=\(viewImageToolEnabled)"])
-        }
-        if let includeApplyPatchTool = toolPolicy.includeApplyPatchTool {
-            args.append(contentsOf: ["-c", "features.apply_patch_freeform=\(includeApplyPatchTool)"])
-        }
-        if let parallelToolCallsEnabled = toolPolicy.parallelToolCallsEnabled {
-            args.append(contentsOf: ["-c", "features.parallel_tool_calls=\(parallelToolCallsEnabled)"])
         }
         if let multiAgentEnabled = toolPolicy.multiAgentEnabled {
             args.append(contentsOf: ["-c", "features.multi_agent=\(multiAgentEnabled)"])
-        }
-        if let experimentalSteeringEnabled = toolPolicy.experimentalSteeringEnabled {
-            args.append(contentsOf: ["-c", "features.steer=\(experimentalSteeringEnabled)"])
         }
         if let modelReasoningSummary = toolPolicy.modelReasoningSummary {
             args.append(contentsOf: ["-c", "model_reasoning_summary=\(modelReasoningSummary.rawValue)"])
@@ -128,22 +104,9 @@ enum CodexOverrides {
         }
         if let webSearchRequestEnabled = toolPolicy.webSearchRequestEnabled {
             overrides["web_search"] = webSearchMode(enabled: webSearchRequestEnabled)
-            overrides["features.web_search_request"] = webSearchRequestEnabled
-        }
-        if let viewImageToolEnabled = toolPolicy.viewImageToolEnabled {
-            overrides["features.view_image_tool"] = viewImageToolEnabled
-        }
-        if let includeApplyPatchTool = toolPolicy.includeApplyPatchTool {
-            overrides["features.apply_patch_freeform"] = includeApplyPatchTool
-        }
-        if let parallelToolCallsEnabled = toolPolicy.parallelToolCallsEnabled {
-            overrides["features.parallel_tool_calls"] = parallelToolCallsEnabled
         }
         if let multiAgentEnabled = toolPolicy.multiAgentEnabled {
             overrides["features.multi_agent"] = multiAgentEnabled
-        }
-        if let experimentalSteeringEnabled = toolPolicy.experimentalSteeringEnabled {
-            overrides["features.steer"] = experimentalSteeringEnabled
         }
         if let modelReasoningSummary = toolPolicy.modelReasoningSummary {
             overrides["model_reasoning_summary"] = modelReasoningSummary.rawValue

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexNativeSessionController.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexNativeSessionController.swift
@@ -489,7 +489,6 @@ final class CodexNativeSessionController {
         }
 
         static func agentModeDefault(
-            forceExperimentalSteering: Bool,
             approvalPolicyProvider: @escaping () -> CodexAgentToolPreferences.ApprovalPolicy = { CodexAgentToolPreferences.approvalPolicy() },
             sandboxModeProvider: @escaping () -> CodexAgentToolPreferences.SandboxMode = { CodexAgentToolPreferences.sandboxMode() },
             approvalReviewerProvider: @escaping () -> CodexAgentToolPreferences.ApprovalReviewer = { CodexAgentToolPreferences.approvalReviewer() },
@@ -510,10 +509,6 @@ final class CodexNativeSessionController {
                         )
                     }
                     return CodexNativeSessionController.defaultAppServerConfigOverrides(
-                        forceExperimentalSteering: forceExperimentalSteering,
-                        approvalPolicy: approvalPolicyProvider(),
-                        sandboxMode: sandboxModeProvider(),
-                        approvalReviewer: approvalReviewerProvider(),
                         shellToolEnabled: shellToolEnabled,
                         suppressThirdPartyMCPServers: suppressThirdPartyMCPServers,
                         goalSupportEnabled: featurePolicy.goalSupportEnabled,
@@ -743,7 +738,6 @@ final class CodexNativeSessionController {
         tabID: UUID,
         windowID: Int,
         workspacePath: String?,
-        forceExperimentalSteering: Bool = false,
         options: Options? = nil,
         clientShutdownBehavior: ClientShutdownBehavior = .none,
         expectedMCPClientName: String? = nil,
@@ -754,7 +748,7 @@ final class CodexNativeSessionController {
         self.tabID = tabID
         self.windowID = windowID
         self.workspacePath = workspacePath
-        self.options = options ?? Self.Options.agentModeDefault(forceExperimentalSteering: forceExperimentalSteering)
+        self.options = options ?? Self.Options.agentModeDefault()
         self.clientShutdownBehavior = clientShutdownBehavior
         self.expectedMCPClientName = expectedMCPClientName
         self.requestExecutor = requestExecutor
@@ -7987,27 +7981,18 @@ final class CodexNativeSessionController {
     static func defaultAppServerToolPolicy(
         shellToolEnabled: Bool,
         webSearchRequestEnabled: Bool,
-        forceExperimentalSteering: Bool,
         modelReasoningSummary: CodexOverrides.ReasoningSummary? = .auto
     ) -> CodexOverrides.ToolPolicy {
         CodexOverrides.ToolPolicy(
             toolOutputTokenLimit: MCPIntegrationHelper.desiredCodexToolOutputTokenLimit,
             shellToolEnabled: shellToolEnabled,
             webSearchRequestEnabled: webSearchRequestEnabled,
-            viewImageToolEnabled: true,
-            // Best-effort only; native FileChange events are still the authoritative patch signal.
-            includeApplyPatchTool: false,
             multiAgentEnabled: false,
-            experimentalSteeringEnabled: forceExperimentalSteering ? true : nil,
             modelReasoningSummary: modelReasoningSummary
         )
     }
 
     static func defaultAppServerConfigOverrides(
-        forceExperimentalSteering: Bool,
-        approvalPolicy: CodexAgentToolPreferences.ApprovalPolicy? = nil,
-        sandboxMode: CodexAgentToolPreferences.SandboxMode? = nil,
-        approvalReviewer: CodexAgentToolPreferences.ApprovalReviewer? = nil,
         shellToolEnabled: Bool? = nil,
         suppressThirdPartyMCPServers: Bool = false,
         goalSupportEnabled: Bool = false,
@@ -8022,7 +8007,6 @@ final class CodexNativeSessionController {
         let toolPolicy = defaultAppServerToolPolicy(
             shellToolEnabled: shellToolEnabled ?? preferences.bashToolEnabled,
             webSearchRequestEnabled: preferences.searchToolEnabled,
-            forceExperimentalSteering: forceExperimentalSteering,
             modelReasoningSummary: modelReasoningSummary
         )
         var overrides = CodexOverrides.appServerConfigMap(
@@ -8038,12 +8022,7 @@ final class CodexNativeSessionController {
         for (key, value) in mcpOverrides {
             overrides[key] = value
         }
-        let effectiveApprovalPolicy = approvalPolicy ?? preferences.approvalPolicy
-        let effectiveSandboxMode = sandboxMode ?? preferences.sandboxMode
-        let effectiveApprovalReviewer = approvalReviewer ?? preferences.approvalReviewer
-        overrides["approval_policy"] = effectiveApprovalPolicy.appServerConfigOverrideValue
-        overrides["sandbox_mode"] = effectiveSandboxMode.appServerConfigOverrideValue
-        overrides["approvals_reviewer"] = effectiveApprovalReviewer.appServerConfigOverrideValue
+        overrides["features.code_mode.direct_only_tool_namespaces"] = ["mcp__RepoPromptCE"]
         return overrides
     }
 

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/CodexCLIProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/CodexCLIProvider.swift
@@ -817,8 +817,6 @@ final class CodexCLIProvider: AIProvider {
             toolOutputTokenLimit: MCPIntegrationHelper.desiredCodexToolOutputTokenLimit,
             shellToolEnabled: false,
             webSearchRequestEnabled: false,
-            viewImageToolEnabled: false,
-            includeApplyPatchTool: false,
             multiAgentEnabled: false
         )
     }
@@ -834,8 +832,6 @@ final class CodexCLIProvider: AIProvider {
         for (key, value) in mcpOverrides {
             overrides[key] = value
         }
-        overrides["approval_policy"] = CodexAgentToolPreferences.ApprovalPolicy.never.appServerConfigOverrideValue
-        overrides["sandbox_mode"] = CodexAgentToolPreferences.SandboxMode.readOnly.appServerConfigOverrideValue
         return overrides
     }
 

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/CodexExecAgentProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/CodexExecAgentProvider.swift
@@ -57,8 +57,6 @@ final class CodexExecAgentProvider: HeadlessAgentProvider {
             toolOutputTokenLimit: MCPIntegrationHelper.desiredCodexToolOutputTokenLimit,
             shellToolEnabled: false,
             webSearchRequestEnabled: nil,
-            viewImageToolEnabled: false,
-            includeApplyPatchTool: false,
             multiAgentEnabled: false,
             modelReasoningSummary: nil
         )

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/CodexIntegrationConfiguration.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/CodexIntegrationConfiguration.swift
@@ -74,19 +74,13 @@ enum CodexIntegrationConfiguration {
             CodexOverrides.ToolPolicy(
                 toolOutputTokenLimit: desiredToolOutputTokenLimit,
                 shellToolEnabled: false,
-                webSearchRequestEnabled: false,
-                viewImageToolEnabled: false,
-                includeApplyPatchTool: false,
-                parallelToolCallsEnabled: nil
+                webSearchRequestEnabled: false
             )
         case .terminal:
             CodexOverrides.ToolPolicy(
                 toolOutputTokenLimit: desiredToolOutputTokenLimit,
                 shellToolEnabled: nil,
-                webSearchRequestEnabled: nil,
-                viewImageToolEnabled: nil,
-                includeApplyPatchTool: false,
-                parallelToolCallsEnabled: nil
+                webSearchRequestEnabled: nil
             )
         }
 

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/Shared/CodexAgentToolPreferences.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/Shared/CodexAgentToolPreferences.swift
@@ -8,7 +8,6 @@ enum CodexAgentToolPreferences {
 
     enum ApprovalPolicy: CaseIterable {
         case onRequest
-        case onFailure
         case unlessTrusted
         case never
 
@@ -16,8 +15,6 @@ enum CodexAgentToolPreferences {
             switch self {
             case .onRequest:
                 "On Request"
-            case .onFailure:
-                "On Failure"
             case .unlessTrusted:
                 "Unless Trusted"
             case .never:
@@ -29,8 +26,6 @@ enum CodexAgentToolPreferences {
             switch self {
             case .onRequest:
                 "on-request"
-            case .onFailure:
-                "on-failure"
             case .unlessTrusted:
                 "unless-trusted"
             case .never:
@@ -44,8 +39,6 @@ enum CodexAgentToolPreferences {
                 switch self {
                 case .onRequest:
                     "on-request"
-                case .onFailure:
-                    "on-failure"
                 case .unlessTrusted:
                     "untrusted"
                 case .never:
@@ -55,8 +48,6 @@ enum CodexAgentToolPreferences {
                 switch self {
                 case .onRequest:
                     "onRequest"
-                case .onFailure:
-                    "onFailure"
                 case .unlessTrusted:
                     "unlessTrusted"
                 case .never:
@@ -65,25 +56,12 @@ enum CodexAgentToolPreferences {
             }
         }
 
-        var appServerConfigOverrideValue: String {
-            switch self {
-            case .onRequest:
-                "on-request"
-            case .onFailure:
-                "on-failure"
-            case .unlessTrusted:
-                "untrusted"
-            case .never:
-                "never"
-            }
-        }
-
         init?(storedValue: String) {
             switch storedValue {
             case "onRequest", "on-request":
                 self = .onRequest
             case "onFailure", "on-failure":
-                self = .onFailure
+                self = .onRequest
             case "unlessTrusted", "unless-trusted", "untrusted":
                 self = .unlessTrusted
             case "never":
@@ -144,17 +122,6 @@ enum CodexAgentToolPreferences {
             }
         }
 
-        var appServerConfigOverrideValue: String {
-            switch self {
-            case .readOnly:
-                "read-only"
-            case .workspaceWrite:
-                "workspace-write"
-            case .dangerFullAccess:
-                "danger-full-access"
-            }
-        }
-
         init?(storedValue: String) {
             switch storedValue {
             case "readOnly", "read-only":
@@ -196,13 +163,8 @@ enum CodexAgentToolPreferences {
             case .user:
                 "user"
             case .autoReview:
-                // Codex accepts both auto_review and guardian_subagent; send the legacy value for older app-server builds.
-                "guardian_subagent"
+                "auto_review"
             }
-        }
-
-        var appServerConfigOverrideValue: String {
-            appServerRequestValue
         }
 
         init?(storedValue: String) {

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexMCPBootstrapReadinessTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexMCPBootstrapReadinessTests.swift
@@ -178,7 +178,6 @@ final class CodexMCPBootstrapReadinessTests: XCTestCase {
 
     private func makeAgentModeOptions() -> CodexNativeSessionController.Options {
         .agentModeDefault(
-            forceExperimentalSteering: false,
             approvalPolicyProvider: { .never },
             sandboxModeProvider: { .readOnly },
             approvalReviewerProvider: { .user }

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexNativeSessionControllerGoalConfigTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexNativeSessionControllerGoalConfigTests.swift
@@ -15,21 +15,20 @@ final class CodexNativeSessionControllerGoalConfigTests: XCTestCase {
 
     func testAgentModeDefaultCarriesGoalFeatureConfigToStartAndResume() async throws {
         let options = CodexNativeSessionController.Options.agentModeDefault(
-            forceExperimentalSteering: false,
             approvalPolicyProvider: { .never },
             sandboxModeProvider: { .readOnly },
-            approvalReviewerProvider: { .user }
+            approvalReviewerProvider: { .autoReview }
         )
 
         try await assertStartAndResumeGoalConfig(
             options: options,
-            expectedGoalSupportEnabled: true
+            expectedGoalSupportEnabled: true,
+            expectedApprovalReviewer: "auto_review"
         )
     }
 
     func testAgentModeDefaultCarriesExplicitGoalOptOutToStartAndResume() async throws {
         let options = CodexNativeSessionController.Options.agentModeDefault(
-            forceExperimentalSteering: false,
             approvalPolicyProvider: { .never },
             sandboxModeProvider: { .readOnly },
             approvalReviewerProvider: { .user },
@@ -44,7 +43,6 @@ final class CodexNativeSessionControllerGoalConfigTests: XCTestCase {
 
     func testAgentModeDefaultCarriesExplicitGoalOptInToStartAndResume() async throws {
         let options = CodexNativeSessionController.Options.agentModeDefault(
-            forceExperimentalSteering: false,
             approvalPolicyProvider: { .never },
             sandboxModeProvider: { .readOnly },
             approvalReviewerProvider: { .user },
@@ -59,7 +57,6 @@ final class CodexNativeSessionControllerGoalConfigTests: XCTestCase {
 
     func testAgentModeDefaultCarriesReasoningSummaryOptInToStartAndResume() async throws {
         let options = CodexNativeSessionController.Options.agentModeDefault(
-            forceExperimentalSteering: false,
             approvalPolicyProvider: { .never },
             sandboxModeProvider: { .readOnly },
             approvalReviewerProvider: { .user },
@@ -75,11 +72,11 @@ final class CodexNativeSessionControllerGoalConfigTests: XCTestCase {
     }
 
     func testDefaultConfigOverridesOmitThreadReasoningSummaryWhenUnspecified() {
-        let config = CodexNativeSessionController.defaultAppServerConfigOverrides(
-            forceExperimentalSteering: false
-        )
+        let config = CodexNativeSessionController.defaultAppServerConfigOverrides()
 
         XCTAssertNil(config["model_reasoning_summary"])
+        XCTAssertEqual(CodexAgentToolPreferences.ApprovalPolicy(storedValue: "on-failure"), .onRequest)
+        XCTAssertEqual(CodexAgentToolPreferences.ApprovalReviewer.autoReview.appServerRequestValue, "auto_review")
     }
 
     func testDefaultAppServerClientLaunchOmitsProcessReasoningSummaryOverride() async throws {
@@ -317,7 +314,8 @@ final class CodexNativeSessionControllerGoalConfigTests: XCTestCase {
     private func assertStartAndResumeGoalConfig(
         options: CodexNativeSessionController.Options,
         expectedGoalSupportEnabled: Bool,
-        expectedReasoningSummary: String = "none"
+        expectedReasoningSummary: String = "none",
+        expectedApprovalReviewer: String = "user"
     ) async throws {
         let (startController, startRecordURL) = try await makeController(options: options)
         _ = try await startController.startOrResume(existing: nil, baseInstructions: "Agent")
@@ -327,9 +325,11 @@ final class CodexNativeSessionControllerGoalConfigTests: XCTestCase {
             in: recordedParams(for: "thread/start", at: startRecordURL),
             expectedGoalSupportEnabled: expectedGoalSupportEnabled,
             expectedReasoningSummary: expectedReasoningSummary,
+            expectedApprovalReviewer: expectedApprovalReviewer,
             label: "thread/start"
         )
         try assertProcessLaunchOmitsReasoningSummaryOverride(at: startRecordURL, label: "thread/start process")
+        try assertProcessLaunchOmitsDirectOnlyNamespaceOverride(at: startRecordURL, label: "thread/start process")
 
         let (resumeController, resumeRecordURL) = try await makeController(options: options)
         let existing = CodexNativeSessionController.SessionRef(
@@ -345,14 +345,15 @@ final class CodexNativeSessionControllerGoalConfigTests: XCTestCase {
             in: recordedParams(for: "thread/resume", at: resumeRecordURL),
             expectedGoalSupportEnabled: expectedGoalSupportEnabled,
             expectedReasoningSummary: expectedReasoningSummary,
+            expectedApprovalReviewer: expectedApprovalReviewer,
             label: "thread/resume"
         )
         try assertProcessLaunchOmitsReasoningSummaryOverride(at: resumeRecordURL, label: "thread/resume process")
+        try assertProcessLaunchOmitsDirectOnlyNamespaceOverride(at: resumeRecordURL, label: "thread/resume process")
     }
 
     private func makeOptions() -> CodexNativeSessionController.Options {
         .agentModeDefault(
-            forceExperimentalSteering: false,
             approvalPolicyProvider: { .never },
             sandboxModeProvider: { .readOnly },
             approvalReviewerProvider: { .user }
@@ -499,16 +500,38 @@ final class CodexNativeSessionControllerGoalConfigTests: XCTestCase {
         in params: [String: Any],
         expectedGoalSupportEnabled: Bool,
         expectedReasoningSummary: String,
+        expectedApprovalReviewer: String,
         label: String
     ) throws {
+        XCTAssertEqual(params["approvalPolicy"] as? String, "never", label)
+        XCTAssertEqual(params["sandbox"] as? String, "read-only", label)
+        XCTAssertEqual(params["approvalsReviewer"] as? String, expectedApprovalReviewer, label)
         let config = try XCTUnwrap(params["config"] as? [String: Any], label)
         XCTAssertEqual(config["features.goals"] as? Bool, expectedGoalSupportEnabled, label)
         XCTAssertEqual(config["features.computer_use"] as? Bool, false, label)
+        XCTAssertEqual(
+            config["features.code_mode.direct_only_tool_namespaces"] as? [String],
+            ["mcp__RepoPromptCE"],
+            label
+        )
         XCTAssertEqual(config["model_reasoning_summary"] as? String, expectedReasoningSummary, label)
+        XCTAssertEqual(config["features.multi_agent"] as? Bool, false, label)
+        XCTAssertNil(config["features.code_mode.enabled"], label)
+        XCTAssertNil(config["approval_policy"], label)
+        XCTAssertNil(config["sandbox_mode"], label)
+        XCTAssertNil(config["approvals_reviewer"], label)
     }
 
     private func assertProcessLaunchOmitsReasoningSummaryOverride(at recordURL: URL, label: String) throws {
         let arguments = try recordedProcessArguments(at: recordURL)
         XCTAssertFalse(arguments.contains { $0.hasPrefix("model_reasoning_summary=") }, label)
+    }
+
+    private func assertProcessLaunchOmitsDirectOnlyNamespaceOverride(at recordURL: URL, label: String) throws {
+        let arguments = try recordedProcessArguments(at: recordURL)
+        XCTAssertFalse(
+            arguments.contains { $0.hasPrefix("features.code_mode.direct_only_tool_namespaces=") },
+            label
+        )
     }
 }

--- a/Tests/RepoPromptTests/MCP/CodexIntegration/CodexIntegrationConfigurationTests.swift
+++ b/Tests/RepoPromptTests/MCP/CodexIntegration/CodexIntegrationConfigurationTests.swift
@@ -391,9 +391,7 @@ final class CodexIntegrationConfigurationTests: XCTestCase {
         var policy = CodexOverrides.ToolPolicy(
             toolOutputTokenLimit: CodexIntegrationConfiguration.desiredToolOutputTokenLimit,
             shellToolEnabled: false,
-            webSearchRequestEnabled: false,
-            viewImageToolEnabled: false,
-            includeApplyPatchTool: false
+            webSearchRequestEnabled: false
         )
 
         policy.modelReasoningSummary = CodexOverrides.ReasoningSummary.none
@@ -411,19 +409,15 @@ final class CodexIntegrationConfigurationTests: XCTestCase {
         policy.modelReasoningSummary = nil
         XCTAssertNil(CodexOverrides.appServerConfigMap(toolPolicy: policy)["model_reasoning_summary"])
 
-        let omittedDefault = CodexNativeSessionController.defaultAppServerConfigOverrides(
-            forceExperimentalSteering: false
-        )
+        let omittedDefault = CodexNativeSessionController.defaultAppServerConfigOverrides()
         XCTAssertNil(omittedDefault["model_reasoning_summary"])
 
         let explicitOff = CodexNativeSessionController.defaultAppServerConfigOverrides(
-            forceExperimentalSteering: false,
             reasoningSummariesEnabled: false
         )
         XCTAssertEqual(explicitOff["model_reasoning_summary"] as? String, "none")
 
         let optIn = CodexNativeSessionController.defaultAppServerConfigOverrides(
-            forceExperimentalSteering: false,
             reasoningSummariesEnabled: true
         )
         XCTAssertEqual(optIn["model_reasoning_summary"] as? String, "auto")
@@ -434,20 +428,40 @@ final class CodexIntegrationConfigurationTests: XCTestCase {
             toolOutputTokenLimit: CodexIntegrationConfiguration.desiredToolOutputTokenLimit,
             shellToolEnabled: false,
             webSearchRequestEnabled: false,
-            viewImageToolEnabled: false,
-            includeApplyPatchTool: false
+            multiAgentEnabled: false
         )
         let cliOverrides = CodexOverrides.cliConfigArgs(toolPolicy: policy)
         XCTAssertFalse(cliOverrides.contains { $0.contains("features.parallel_tool_calls") })
 
         let appServerOverrides = CodexOverrides.appServerConfigMap(toolPolicy: policy)
-        XCTAssertNil(appServerOverrides["features.parallel_tool_calls"])
+        let staleOverrideKeys = [
+            "features.web_search_request",
+            "features.js_repl",
+            "features.js_repl_tools_only",
+            "features.tool_search",
+            "features.tool_search_always_defer_mcp_tools",
+            "features.apply_patch_freeform",
+            "features.steer",
+            "features.view_image_tool",
+            "features.parallel_tool_calls"
+        ]
+        for key in staleOverrideKeys {
+            XCTAssertFalse(cliOverrides.contains { $0.contains(key) }, key)
+            XCTAssertNil(appServerOverrides[key], key)
+        }
+        XCTAssertTrue(cliOverrides.contains("web_search=disabled"))
+        XCTAssertTrue(cliOverrides.contains("features.shell_tool=false"))
+        XCTAssertTrue(cliOverrides.contains("features.unified_exec=false"))
+        XCTAssertTrue(cliOverrides.contains("features.multi_agent=false"))
+        XCTAssertEqual(appServerOverrides["web_search"] as? String, "disabled")
+        XCTAssertEqual(appServerOverrides["features.shell_tool"] as? Bool, false)
+        XCTAssertEqual(appServerOverrides["features.unified_exec"] as? Bool, false)
+        XCTAssertEqual(appServerOverrides["features.multi_agent"] as? Bool, false)
 
         let nativeOverrides = CodexOverrides.appServerConfigMap(
             toolPolicy: CodexNativeSessionController.defaultAppServerToolPolicy(
                 shellToolEnabled: false,
-                webSearchRequestEnabled: false,
-                forceExperimentalSteering: false
+                webSearchRequestEnabled: false
             )
         )
         XCTAssertNil(nativeOverrides["features.parallel_tool_calls"])

--- a/Tests/RepoPromptTests/Security/AgentPermissionSecureStoreTests.swift
+++ b/Tests/RepoPromptTests/Security/AgentPermissionSecureStoreTests.swift
@@ -317,7 +317,7 @@ final class AgentPermissionSecureStoreTests: XCTestCase {
 
         secureStrings.failSaveKeys = [key]
         XCTAssertFalse(store.updateCodexPermissions { document in
-            document.approvalPolicyRaw = CodexAgentToolPreferences.ApprovalPolicy.onFailure.persistedValue
+            document.approvalPolicyRaw = CodexAgentToolPreferences.ApprovalPolicy.onRequest.persistedValue
         })
 
         let effective = store.codexPermissions()


### PR DESCRIPTION
## Summary
- send `features.code_mode.direct_only_tool_namespaces = ["mcp__RepoPromptCE"]` in Codex app-server thread start/resume config
- remove audited deprecated, removed, unknown, and ineffective Codex feature overrides plus their dead policy plumbing
- keep typed app-server approval, sandbox, and reviewer parameters authoritative
- migrate legacy On Failure approval values to On Request and emit canonical `auto_review`

## Why
RepoPrompt MCP tools should stay directly visible to Codex while bypassing tool search and the nested Code Mode exec surface. This also prevents RepoPrompt calls from inheriting Code Mode cell cancellation.

## Validation
- `make dev-format` — passed; 0 files changed
- `make dev-lint` — passed
- contribution commit and push preflights — passed
- Claude Fable 5 high review — no must-fix findings; cleanup recommendations applied
- focused controller/configuration tests could not acquire the machine-wide Swift slot because a separate release artifact build held it for more than an hour; the waiting tickets were canceled to avoid leaving stale local jobs, and hosted PR checks provide the integration signal

## Compatibility notes
- this does not force Code Mode on
- the namespace override requires a recent Codex build (introduced upstream in commit `78a9e169`; first observed tag `rust-v0.143.0-alpha.10`)
- already-loaded threads pick up the policy after a restart or cold resume
