### PR TITLE
Fix bundled Codex release signing

### DIFF
--- a/Scripts/codex_runtime_artifact.py
+++ b/Scripts/codex_runtime_artifact.py
@@ -11,6 +11,7 @@ import platform
 import re
 import shutil
 import stat
+import struct
 import subprocess
 import sys
 import tarfile
@@ -47,6 +48,25 @@ TARGET_ARCHITECTURES = {
     "x86_64-apple-darwin": "x86_64",
 }
 EXPECTED_DIRECTORY_MODE = 0o755
+MACH_O_MAGICS = {
+    b"\xce\xfa\xed\xfe",  # 32-bit little-endian
+    b"\xcf\xfa\xed\xfe",  # 64-bit little-endian
+    b"\xfe\xed\xfa\xce",  # 32-bit big-endian
+    b"\xfe\xed\xfa\xcf",  # 64-bit big-endian
+    b"\xca\xfe\xba\xbe",  # universal binary
+    b"\xca\xfe\xba\xbf",  # universal binary with 64-bit offsets
+    b"\xbe\xba\xfe\xca",
+    b"\xbf\xba\xfe\xca",
+}
+MH_MAGIC_64 = 0xFEEDFACF
+LC_SEGMENT_64 = 0x19
+LC_CODE_SIGNATURE = 0x1D
+CPU_TYPE_X86_64 = 0x01000007
+CPU_TYPE_ARM64 = 0x0100000C
+TARGET_PAGE_SIZES = {
+    CPU_TYPE_X86_64: 0x1000,
+    CPU_TYPE_ARM64: 0x4000,
+}
 
 
 class ContractError(RuntimeError):
@@ -61,7 +81,7 @@ def sha256(path: Path) -> str:
     return digest.hexdigest()
 
 
-def load_manifest(path: Path) -> dict[str, Any]:
+def load_manifest(path: Path, *, require_normalized_digests: bool = True) -> dict[str, Any]:
     try:
         manifest = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
@@ -113,19 +133,24 @@ def load_manifest(path: Path) -> dict[str, Any]:
                 if not isinstance(entry.get("executable"), bool):
                     raise ContractError(f"{target}: missing executable policy for {entry.get('path')}")
     mach_o_files = manifest.get("machOFiles")
-    if not isinstance(mach_o_files, list) or set(mach_o_files) != {
-        "bin/codex",
-        "bin/codex-code-mode-host",
-        "codex-path/rg",
-        "codex-resources/zsh/bin/zsh",
-    }:
-        raise ContractError("pinned manifest is missing Mach-O architecture policy")
+    if not isinstance(mach_o_files, list) or not mach_o_files or len(mach_o_files) != len(set(mach_o_files)):
+        raise ContractError("pinned manifest must contain a unique, non-empty Mach-O inventory")
+    for relative in mach_o_files:
+        validate_relative_path(relative, "Mach-O manifest path")
     for target, package in packages.items():
         entries_by_path = {entry["path"]: entry for entry in package["tree"]}
         for relative in mach_o_files:
             entry = entries_by_path.get(relative)
             if not entry or entry.get("kind") != "file" or entry.get("executable") is not True:
                 raise ContractError(f"{target}: Mach-O policy path is not a pinned executable file: {relative}")
+            normalized_digest = entry.get("normalizedSha256")
+            if require_normalized_digests or normalized_digest is not None:
+                validate_digest(normalized_digest, f"{target} normalized Mach-O {relative}")
+        for entry in package["tree"]:
+            if entry["path"] not in mach_o_files and "normalizedSha256" in entry:
+                raise ContractError(
+                    f"{target}: non-Mach-O manifest entry has a normalized digest: {entry['path']}"
+                )
     signed = manifest.get("signedExecutables")
     if not isinstance(signed, list) or {item.get("path") for item in signed if isinstance(item, dict)} != {
         "bin/codex",
@@ -223,6 +248,111 @@ def run_tool(argv: list[str], description: str) -> str:
     return output
 
 
+def is_mach_o_file(path: Path) -> bool:
+    try:
+        with path.open("rb") as handle:
+            return handle.read(4) in MACH_O_MAGICS
+    except OSError as exc:
+        raise ContractError(f"could not inspect Mach-O magic for {path}: {exc}") from exc
+
+
+def parse_thin_mach_o_64(data: bytes | bytearray, context: str) -> tuple[int, list[tuple[int, int, int]]]:
+    if len(data) < 32:
+        raise ContractError(f"{context}: truncated Mach-O header")
+    magic, cpu_type = struct.unpack_from("<Ii", data, 0)
+    if magic != MH_MAGIC_64 or cpu_type not in TARGET_PAGE_SIZES:
+        raise ContractError(
+            f"{context}: normalized hashing supports only thin arm64/x86_64 Mach-O files"
+        )
+    command_count, command_bytes = struct.unpack_from("<II", data, 16)
+    command_offset = 32
+    command_end = command_offset + command_bytes
+    if command_end > len(data):
+        raise ContractError(f"{context}: Mach-O load-command table exceeds the file")
+    commands: list[tuple[int, int, int]] = []
+    for _ in range(command_count):
+        if command_offset + 8 > command_end:
+            raise ContractError(f"{context}: truncated Mach-O load command")
+        command, command_size = struct.unpack_from("<II", data, command_offset)
+        if command_size < 8 or command_offset + command_size > command_end:
+            raise ContractError(f"{context}: invalid Mach-O load-command size")
+        commands.append((command, command_offset, command_size))
+        command_offset += command_size
+    if command_offset != command_end:
+        raise ContractError(f"{context}: Mach-O load-command size accounting mismatch")
+    return cpu_type, commands
+
+
+def read_mach_o_load_commands(path: Path) -> tuple[int, list[tuple[int, int, int]]]:
+    context = str(path)
+    try:
+        with path.open("rb") as handle:
+            header = handle.read(32)
+            if len(header) < 32:
+                raise ContractError(f"{context}: truncated Mach-O header")
+            command_bytes = struct.unpack_from("<I", header, 20)[0]
+            load_commands = handle.read(command_bytes)
+            if len(load_commands) != command_bytes:
+                raise ContractError(f"{context}: truncated Mach-O load-command table")
+    except OSError as exc:
+        raise ContractError(f"could not read Mach-O load commands for {path}: {exc}") from exc
+    return parse_thin_mach_o_64(header + load_commands, context)
+
+
+def normalized_mach_o_sha256(path: Path, codesign: str) -> str:
+    context = str(path)
+    _cpu_type, original_commands = read_mach_o_load_commands(path)
+    signature_commands = [command for command in original_commands if command[0] == LC_CODE_SIGNATURE]
+    if len(signature_commands) > 1:
+        raise ContractError(f"{context}: multiple LC_CODE_SIGNATURE commands are unsupported")
+
+    with tempfile.TemporaryDirectory(prefix="repoprompt-codex-normalize-") as temp_value:
+        safe_copy = Path(temp_value) / path.name
+        shutil.copy2(path, safe_copy)
+        if signature_commands:
+            run_tool(
+                [codesign, "--remove-signature", str(safe_copy)],
+                f"signature removal for normalized Mach-O {path}",
+            )
+        cpu_type, commands = read_mach_o_load_commands(safe_copy)
+        if any(command == LC_CODE_SIGNATURE for command, _offset, _size in commands):
+            raise ContractError(f"{context}: signature removal left LC_CODE_SIGNATURE present")
+        with safe_copy.open("rb") as handle:
+            header = handle.read(32)
+            command_bytes = struct.unpack_from("<I", header, 20)[0]
+            commands_data = header + handle.read(command_bytes)
+        linkedit_commands = [
+            (offset, size)
+            for command, offset, size in commands
+            if command == LC_SEGMENT_64
+            and commands_data[offset + 8 : offset + 24].rstrip(b"\0") == b"__LINKEDIT"
+        ]
+        if len(linkedit_commands) != 1:
+            raise ContractError(f"{context}: expected exactly one __LINKEDIT segment")
+        linkedit_offset, linkedit_size = linkedit_commands[0]
+        if linkedit_size < 72:
+            raise ContractError(f"{context}: truncated __LINKEDIT segment command")
+        file_offset, file_size = struct.unpack_from("<QQ", commands_data, linkedit_offset + 40)
+        normalized_size = safe_copy.stat().st_size
+        if file_offset + file_size > normalized_size:
+            raise ContractError(f"{context}: __LINKEDIT file range exceeds normalized Mach-O")
+        page_size = TARGET_PAGE_SIZES[cpu_type]
+        # codesign --remove-signature restores the unsigned file range but leaves
+        # __LINKEDIT.vmsize rounded from the former signature size. Re-derive the
+        # field from the restored filesize so vendor-, ad-hoc-, and release-signed
+        # copies normalize identically without ignoring executable payload bytes.
+        canonical_vm_size = ((file_size + page_size - 1) // page_size) * page_size
+        replacement_offset = linkedit_offset + 32
+        digest = hashlib.sha256()
+        with safe_copy.open("rb") as handle:
+            digest.update(handle.read(replacement_offset))
+            digest.update(struct.pack("<Q", canonical_vm_size))
+            handle.seek(replacement_offset + 8)
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+        return digest.hexdigest()
+
+
 def parse_codesign_metadata(details: str) -> dict[str, list[str]]:
     fields: dict[str, list[str]] = {}
     for raw_line in details.splitlines():
@@ -271,18 +401,53 @@ def verify_package(
     manifest: dict[str, Any],
     lipo: str,
     codesign: str,
+    signed_team_identifier: str | None = None,
+    verify_normalized_digests: bool = True,
 ) -> None:
     package = manifest["packages"][target]
-    expected = {entry["path"]: entry for entry in package["tree"]}
+    expected = {
+        entry["path"]: {key: value for key, value in entry.items() if key != "normalizedSha256"}
+        for entry in package["tree"]
+    }
     actual = snapshot_tree(root)
-    if actual != expected:
+    discovered_mach_o_files = {
+        relative
+        for relative, entry in actual.items()
+        if entry["kind"] == "file" and is_mach_o_file(root / relative)
+    }
+    manifested_mach_o_files = set(manifest["machOFiles"])
+    if discovered_mach_o_files != manifested_mach_o_files:
+        raise ContractError(
+            f"{target}: Mach-O inventory does not match pinned manifest"
+            f"\nunlisted={sorted(discovered_mach_o_files - manifested_mach_o_files)}"
+            f"\nmissing={sorted(manifested_mach_o_files - discovered_mach_o_files)}"
+        )
+    def tree_mismatch() -> ContractError:
         missing = sorted(set(expected) - set(actual))
         extra = sorted(set(actual) - set(expected))
         changed = sorted(path for path in set(actual) & set(expected) if actual[path] != expected[path])
-        raise ContractError(
+        return ContractError(
             f"{target}: package tree does not match pinned manifest"
             f"\nmissing={missing}\nextra={extra}\nchanged={changed}"
         )
+
+    if signed_team_identifier is None and actual != expected:
+        raise tree_mismatch()
+    if verify_normalized_digests:
+        entries_by_path = {entry["path"]: entry for entry in package["tree"]}
+        for relative in manifest["machOFiles"]:
+            actual_normalized = normalized_mach_o_sha256(root / relative, codesign)
+            expected_normalized = entries_by_path[relative]["normalizedSha256"]
+            if actual_normalized != expected_normalized:
+                raise ContractError(
+                    f"{target}: {relative} normalized Mach-O SHA-256 mismatch: "
+                    f"expected {expected_normalized}, got {actual_normalized}"
+                )
+    if signed_team_identifier is not None:
+        for relative in manifest["machOFiles"]:
+            expected[relative]["sha256"] = actual[relative]["sha256"]
+    if actual != expected:
+        raise tree_mismatch()
     metadata_path = root / "codex-package.json"
     try:
         metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
@@ -307,26 +472,49 @@ def verify_package(
             raise ContractError(
                 f"{target}: {relative} architectures {architectures!r} do not equal [{expected_arch!r}]"
             )
-    for policy in manifest["signedExecutables"]:
+    if signed_team_identifier is None:
+        signature_policies = manifest["signedExecutables"]
+    else:
+        signature_policies = [
+            {
+                "path": relative,
+                "teamIdentifier": signed_team_identifier,
+                "authorityPrefix": "Developer ID Application:",
+            }
+            for relative in manifest["machOFiles"]
+        ]
+    for policy in signature_policies:
         binary = root / policy["path"]
-        run_tool([codesign, "--verify", "--strict", "--verbose=2", str(binary)], f"signature check for {policy['path']}")
-        details = run_tool([codesign, "-dv", "--verbose=4", str(binary)], f"signature metadata for {policy['path']}")
+        run_tool(
+            [codesign, "--verify", "--strict", "--verbose=2", str(binary)],
+            f"signature check for {policy['path']}",
+        )
+        details = run_tool(
+            [codesign, "-dv", "--verbose=4", str(binary)],
+            f"signature metadata for {policy['path']}",
+        )
         fields = parse_codesign_metadata(details)
-        exact_single_fields = {
-            "Identifier": policy["identifier"],
-            "TeamIdentifier": policy["teamIdentifier"],
-        }
-        for key, expected in exact_single_fields.items():
-            actual = fields.get(key, [])
-            if actual != [expected]:
+        exact_single_fields = {"TeamIdentifier": policy["teamIdentifier"]}
+        if signed_team_identifier is None:
+            exact_single_fields["Identifier"] = policy["identifier"]
+        for key, expected_value in exact_single_fields.items():
+            actual_values = fields.get(key, [])
+            if actual_values != [expected_value]:
                 raise ContractError(
-                    f"{target}: {policy['path']} signature metadata {key} must equal {expected!r}, got {actual!r}"
+                    f"{target}: {policy['path']} signature metadata {key} must equal "
+                    f"{expected_value!r}, got {actual_values!r}"
                 )
         authorities = fields.get("Authority", [])
-        if not authorities or authorities[0] != policy["authority"]:
+        if signed_team_identifier is None:
+            valid_authority = bool(authorities) and authorities[0] == policy["authority"]
+            authority_requirement = f"must equal {policy['authority']!r}"
+        else:
+            valid_authority = bool(authorities) and authorities[0].startswith(policy["authorityPrefix"])
+            authority_requirement = "must be a Developer ID Application certificate"
+        if not valid_authority:
             raise ContractError(
-                f"{target}: {policy['path']} leaf signing authority must equal {policy['authority']!r},"
-                f" got {authorities!r}"
+                f"{target}: {policy['path']} leaf signing authority {authority_requirement}, "
+                f"got {authorities!r}"
             )
         if not re.search(r"^CodeDirectory .*flags=.*\([^)]*\bruntime\b[^)]*\)", details, re.MULTILINE):
             raise ContractError(f"{target}: {policy['path']} is missing the hardened-runtime signing flag")
@@ -418,6 +606,7 @@ def verify_bundle(
     manifest: dict[str, Any],
     lipo: str,
     codesign: str,
+    signed_team_identifier: str | None = None,
 ) -> None:
     if not root.is_dir() or root.is_symlink():
         raise ContractError(f"Codex bundle root is not a real directory: {root}")
@@ -434,8 +623,14 @@ def verify_bundle(
         package = root / target
         if not package.is_dir() or package.is_symlink():
             raise ContractError(f"Codex bundle target is not a real directory: {package}")
-        verify_package(package, target, manifest, lipo, codesign)
-    print(f"OK: verified bundled Codex {manifest['version']} targets: {', '.join(targets)}")
+        verify_package(package, target, manifest, lipo, codesign, signed_team_identifier)
+    signing_label = (
+        f" release signatures for team {signed_team_identifier}" if signed_team_identifier is not None else ""
+    )
+    print(
+        f"OK: verified bundled Codex {manifest['version']} targets{signing_label}: "
+        f"{', '.join(targets)}"
+    )
 
 
 def stage_bundle(args: argparse.Namespace, manifest: dict[str, Any]) -> None:
@@ -492,6 +687,49 @@ def acquire(args: argparse.Namespace, manifest: dict[str, Any]) -> None:
             acquire_target(target, manifest, cache_root, source, args.lipo, args.codesign)
 
 
+def refresh_normalized_digests(
+    args: argparse.Namespace,
+    manifest: dict[str, Any],
+    manifest_path: Path,
+) -> None:
+    cache_root = Path(args.cache_root)
+    targets = selected_targets(args.arch)
+    for target in targets:
+        package_root = cache_root / manifest["version"] / target
+        if not package_root.is_dir():
+            raise ContractError(f"missing verified Codex package for normalized digest refresh: {package_root}")
+        verify_package(
+            package_root,
+            target,
+            manifest,
+            args.lipo,
+            args.codesign,
+            verify_normalized_digests=False,
+        )
+        entries_by_path = {
+            entry["path"]: entry for entry in manifest["packages"][target]["tree"]
+        }
+        for relative in manifest["machOFiles"]:
+            entries_by_path[relative]["normalizedSha256"] = normalized_mach_o_sha256(
+                package_root / relative,
+                args.codesign,
+            )
+
+    temporary = manifest_path.with_name(f".{manifest_path.name}.tmp")
+    temporary.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    os.replace(temporary, manifest_path)
+    refreshed = load_manifest(manifest_path)
+    for target in targets:
+        verify_package(
+            cache_root / refreshed["version"] / target,
+            target,
+            refreshed,
+            args.lipo,
+            args.codesign,
+        )
+    print(f"OK: refreshed normalized Codex Mach-O digests in {manifest_path}")
+
+
 def status(args: argparse.Namespace, manifest: dict[str, Any]) -> None:
     failed = False
     for target in BUNDLE_TARGETS:
@@ -537,8 +775,23 @@ def build_parser() -> argparse.ArgumentParser:
     )
     verify_bundle_parser.add_argument("--arch", default="all")
     verify_bundle_parser.add_argument("--bundle", required=True)
+    verify_bundle_parser.add_argument(
+        "--signed-team-identifier",
+        help="verify every Mach-O as release-resigned by this Developer ID team",
+    )
+    list_mach_o_parser = subparsers.add_parser(
+        "list-bundle-mach-o-paths",
+        help="list target-relative paths for every pinned Mach-O in bundle signing order",
+    )
+    list_mach_o_parser.add_argument("--arch", default="all")
     status_parser = subparsers.add_parser("status", help="verify both cached packages without network access")
     status_parser.add_argument("--cache-root", default=str(DEFAULT_CACHE_ROOT))
+    refresh_parser = subparsers.add_parser(
+        "refresh-normalized-digests",
+        help="derive normalized Mach-O digests from exact verified cached packages and update the manifest",
+    )
+    refresh_parser.add_argument("--arch", default="all")
+    refresh_parser.add_argument("--cache-root", default=str(DEFAULT_CACHE_ROOT))
     subparsers.add_parser("validate-manifest", help="validate the repository pin without network or cached packages")
     subparsers.add_parser("manifest-version", help="print the validated pinned version for packaging paths")
     return parser
@@ -548,7 +801,11 @@ def main() -> int:
     parser = build_parser()
     args = parser.parse_args()
     try:
-        manifest = load_manifest(Path(args.manifest))
+        manifest_path = Path(args.manifest)
+        manifest = load_manifest(
+            manifest_path,
+            require_normalized_digests=args.command != "refresh-normalized-digests",
+        )
         if args.command == "acquire":
             acquire(args, manifest)
         elif args.command == "verify":
@@ -557,9 +814,22 @@ def main() -> int:
         elif args.command == "stage-bundle":
             stage_bundle(args, manifest)
         elif args.command == "verify-bundle":
-            verify_bundle(Path(args.bundle), selected_targets(args.arch), manifest, args.lipo, args.codesign)
+            verify_bundle(
+                Path(args.bundle),
+                selected_targets(args.arch),
+                manifest,
+                args.lipo,
+                args.codesign,
+                args.signed_team_identifier,
+            )
+        elif args.command == "list-bundle-mach-o-paths":
+            for target in selected_targets(args.arch):
+                for relative in manifest["machOFiles"]:
+                    print(f"{target}/{relative}")
         elif args.command == "status":
             status(args, manifest)
+        elif args.command == "refresh-normalized-digests":
+            refresh_normalized_digests(args, manifest, manifest_path)
         elif args.command == "manifest-version":
             print(manifest["version"])
         else:

--- a/Scripts/codex_runtime_artifact.py
+++ b/Scripts/codex_runtime_artifact.py
@@ -716,17 +716,20 @@ def refresh_normalized_digests(
             )
 
     temporary = manifest_path.with_name(f".{manifest_path.name}.tmp")
-    temporary.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
-    os.replace(temporary, manifest_path)
-    refreshed = load_manifest(manifest_path)
-    for target in targets:
-        verify_package(
-            cache_root / refreshed["version"] / target,
-            target,
-            refreshed,
-            args.lipo,
-            args.codesign,
-        )
+    try:
+        temporary.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+        refreshed = load_manifest(temporary)
+        for target in targets:
+            verify_package(
+                cache_root / refreshed["version"] / target,
+                target,
+                refreshed,
+                args.lipo,
+                args.codesign,
+            )
+        os.replace(temporary, manifest_path)
+    finally:
+        temporary.unlink(missing_ok=True)
     print(f"OK: refreshed normalized Codex Mach-O digests in {manifest_path}")
 
 

--- a/Scripts/codex_vendor_guardrails.sh
+++ b/Scripts/codex_vendor_guardrails.sh
@@ -56,12 +56,26 @@ for script in \
     Scripts/sign_staged_release.sh \
     Scripts/validate_staged_release.sh; do
     grep -F 'verify-bundle' "$script" >/dev/null ||
-        fail "$script must verify the exact target-specific Codex bundle"
+        fail "$script must verify the target-specific Codex bundle contract"
     grep -F -- '--arch all' "$script" >/dev/null ||
         fail "$script must require both pinned Codex targets"
     if grep -F -- '--arch aarch64-apple-darwin' "$script" >/dev/null; then
         fail "$script must not validate only the arm64 Codex package"
     fi
+done
+
+grep -F 'list-bundle-mach-o-paths --arch all' Scripts/sign_staged_release.sh >/dev/null ||
+    fail "Developer ID signing must enumerate every manifest-owned Codex Mach-O"
+grep -F 'sign_path "$CODEX_BUNDLE/$relative_path"' Scripts/sign_staged_release.sh >/dev/null ||
+    fail "Developer ID signing must sign each enumerated Codex Mach-O at its final bundle path"
+for script in \
+    Scripts/main_tip_release.sh \
+    Scripts/promote_release.sh \
+    Scripts/publish_public_update_test.sh \
+    Scripts/release.sh \
+    Scripts/sign_staged_release.sh; do
+    grep -F -- '--signed-team-identifier' "$script" >/dev/null ||
+        fail "$script must verify final Codex Mach-Os against the RepoPrompt Developer ID team"
 done
 
 printf 'OK: pinned Codex artifact, universal bundle, and legal inventory contracts are complete.\n'

--- a/Scripts/main_tip_release.sh
+++ b/Scripts/main_tip_release.sh
@@ -77,12 +77,18 @@ validate_public_app() {
     local app_bundle="$1"
     local manifest="$2"
     local label="$3"
+    local signed_team_identifier="${4:-}"
     "$CONTROL_PLANE_SCRIPTS_DIR/validate_embedded_mcp_helper_layout.sh" "$app_bundle" "$label MCP helper layout"
     "$CONTROL_PLANE_SCRIPTS_DIR/validate_app_architectures.sh" "$app_bundle" "arm64,x86_64" "$label architectures"
-    python3 "$CONTROL_PLANE_SCRIPTS_DIR/codex_runtime_artifact.py" \
-        --manifest "$CODEX_MANIFEST" verify-bundle \
-        --arch all \
+    local codex_verification_args=(
+        --manifest "$CODEX_MANIFEST" verify-bundle
+        --arch all
         --bundle "$app_bundle/Contents/Resources/BundledRuntimes/Codex"
+    )
+    if [[ -n "$signed_team_identifier" ]]; then
+        codex_verification_args+=(--signed-team-identifier "$signed_team_identifier")
+    fi
+    python3 "$CONTROL_PLANE_SCRIPTS_DIR/codex_runtime_artifact.py" "${codex_verification_args[@]}"
     "$CONTROL_PLANE_SCRIPTS_DIR/write_app_artifact_manifest.py" verify \
         --app "$app_bundle" \
         --manifest "$manifest" \
@@ -93,13 +99,14 @@ validate_distribution_zip() {
     local archive="$1"
     local manifest="$2"
     local label="$3"
+    local signed_team_identifier="${4:-}"
     local extract_dir="$TMP_DIR/${label//[^A-Za-z0-9]/-}-extract"
     rm -rf "$extract_dir"
     mkdir -p "$extract_dir"
     ditto -x -k "$archive" "$extract_dir"
     local extracted_app="$extract_dir/$DISTRIBUTION_APP_BUNDLE_NAME"
     [[ -d "$extracted_app" ]] || fail "$label ZIP must contain $DISTRIBUTION_APP_BUNDLE_NAME at its root"
-    validate_public_app "$extracted_app" "$manifest" "$label extracted app"
+    validate_public_app "$extracted_app" "$manifest" "$label extracted app" "$signed_team_identifier"
 }
 
 resolve_without_lockfile_drift() {
@@ -375,7 +382,7 @@ sign_tip() {
         --expected-architectures "arm64,x86_64"
     assert_tip_manifest_telemetry_enabled
     write_tip_metadata
-    validate_public_app "$APP_BUNDLE" "$FINAL_ARTIFACT_MANIFEST" "Final tip Developer ID app"
+    validate_public_app "$APP_BUNDLE" "$FINAL_ARTIFACT_MANIFEST" "Final tip Developer ID app" "$SIGNING_TEAM_ID"
     upload_release_sentry_symbols \
         "$SENTRY_SYMBOLS_DIR" \
         "$CONTROL_PLANE_SCRIPTS_DIR/upload_sentry_debug_symbols.sh" \
@@ -388,7 +395,7 @@ sign_tip() {
     mkdir -p "$distribution_dir"
     ditto "$APP_BUNDLE" "$distribution_dir/$DISTRIBUTION_APP_BUNDLE_NAME"
     ditto -c -k --norsrc --keepParent "$distribution_dir/$DISTRIBUTION_APP_BUNDLE_NAME" "$UPDATE_ZIP"
-    validate_distribution_zip "$UPDATE_ZIP" "$FINAL_ARTIFACT_MANIFEST" "Final tip distribution"
+    validate_distribution_zip "$UPDATE_ZIP" "$FINAL_ARTIFACT_MANIFEST" "Final tip distribution" "$SIGNING_TEAM_ID"
     hdiutil create -volname "$DISPLAY_NAME Tip" -srcfolder "$distribution_dir" -ov -format UDZO "$DMG"
     submit_notarization "$DMG"
     xcrun stapler staple "$DMG"

--- a/Scripts/promote_release.sh
+++ b/Scripts/promote_release.sh
@@ -272,7 +272,8 @@ validate_app_bundle() {
     python3 "$CONTROL_PLANE_SCRIPTS_DIR/codex_runtime_artifact.py" \
         --manifest "$ROOT_DIR/Vendor/Codex/manifest.json" verify-bundle \
         --arch all \
-        --bundle "$app_bundle/Contents/Resources/BundledRuntimes/Codex"
+        --bundle "$app_bundle/Contents/Resources/BundledRuntimes/Codex" \
+        --signed-team-identifier "$SIGNING_TEAM_ID"
     validate_embedded_mcp_helper_layout "$app_bundle" "Reviewed ZIP MCP helper layout"
     "$CONTROL_PLANE_SCRIPTS_DIR/validate_app_architectures.sh" \
         "$app_bundle" \
@@ -297,7 +298,8 @@ validate_dmg_matches_zip_app() {
     python3 "$CONTROL_PLANE_SCRIPTS_DIR/codex_runtime_artifact.py" \
         --manifest "$ROOT_DIR/Vendor/Codex/manifest.json" verify-bundle \
         --arch all \
-        --bundle "$dmg_app/Contents/Resources/BundledRuntimes/Codex"
+        --bundle "$dmg_app/Contents/Resources/BundledRuntimes/Codex" \
+        --signed-team-identifier "$SIGNING_TEAM_ID"
     "$CONTROL_PLANE_SCRIPTS_DIR/validate_app_architectures.sh" \
         "$dmg_app" \
         "arm64,x86_64" \

--- a/Scripts/publish_public_update_test.sh
+++ b/Scripts/publish_public_update_test.sh
@@ -75,7 +75,8 @@ xcrun stapler validate "$APP_BUNDLE"
 python3 "$ROOT_DIR/Scripts/codex_runtime_artifact.py" \
     --manifest "$ROOT_DIR/Vendor/Codex/manifest.json" verify-bundle \
     --arch all \
-    --bundle "$APP_BUNDLE/Contents/Resources/BundledRuntimes/Codex"
+    --bundle "$APP_BUNDLE/Contents/Resources/BundledRuntimes/Codex" \
+    --signed-team-identifier "$SIGNING_TEAM_ID"
 "$ROOT_DIR/Scripts/write_app_artifact_manifest.py" verify \
     --app "$APP_BUNDLE" \
     --manifest "$ARTIFACT_MANIFEST" \

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -162,12 +162,18 @@ validate_public_app() {
     local app_bundle="$1"
     local manifest="$2"
     local label="$3"
+    local signed_team_identifier="${4:-}"
     "$CONTROL_PLANE_SCRIPTS_DIR/validate_embedded_mcp_helper_layout.sh" "$app_bundle" "$label MCP helper layout"
     "$CONTROL_PLANE_SCRIPTS_DIR/validate_app_architectures.sh" "$app_bundle" "arm64,x86_64" "$label architectures"
-    python3 "$CONTROL_PLANE_SCRIPTS_DIR/codex_runtime_artifact.py" \
-        --manifest "$CODEX_MANIFEST" verify-bundle \
-        --arch all \
+    local codex_verification_args=(
+        --manifest "$CODEX_MANIFEST" verify-bundle
+        --arch all
         --bundle "$app_bundle/Contents/Resources/BundledRuntimes/Codex"
+    )
+    if [[ -n "$signed_team_identifier" ]]; then
+        codex_verification_args+=(--signed-team-identifier "$signed_team_identifier")
+    fi
+    python3 "$CONTROL_PLANE_SCRIPTS_DIR/codex_runtime_artifact.py" "${codex_verification_args[@]}"
     "$CONTROL_PLANE_SCRIPTS_DIR/write_app_artifact_manifest.py" verify \
         --app "$app_bundle" \
         --manifest "$manifest" \
@@ -178,13 +184,14 @@ validate_distribution_zip() {
     local archive="$1"
     local manifest="$2"
     local label="$3"
+    local signed_team_identifier="${4:-}"
     local extract_dir="$TMP_DIR/${label//[^A-Za-z0-9]/-}-extract"
     rm -rf "$extract_dir"
     mkdir -p "$extract_dir"
     ditto -x -k "$archive" "$extract_dir"
     local extracted_app="$extract_dir/$DISTRIBUTION_APP_BUNDLE_NAME"
     [[ -d "$extracted_app" ]] || fail "$label ZIP must contain $DISTRIBUTION_APP_BUNDLE_NAME at its root"
-    validate_public_app "$extracted_app" "$manifest" "$label extracted app"
+    validate_public_app "$extracted_app" "$manifest" "$label extracted app" "$signed_team_identifier"
 }
 
 write_final_artifact_manifest() {
@@ -537,7 +544,7 @@ publish_staged_release() {
     xcrun stapler staple "$APP_BUNDLE"
     xcrun stapler validate "$APP_BUNDLE"
     write_final_artifact_manifest
-    validate_public_app "$APP_BUNDLE" "$FINAL_ARTIFACT_MANIFEST" "Final Developer ID app"
+    validate_public_app "$APP_BUNDLE" "$FINAL_ARTIFACT_MANIFEST" "Final Developer ID app" "$SIGNING_TEAM_ID"
     prepare_sentry_release
     upload_required_sentry_symbols
 
@@ -545,7 +552,7 @@ publish_staged_release() {
     mkdir -p "$distribution_dir"
     ditto "$APP_BUNDLE" "$distribution_dir/$DISTRIBUTION_APP_BUNDLE_NAME"
     ditto -c -k --norsrc --keepParent "$distribution_dir/$DISTRIBUTION_APP_BUNDLE_NAME" "$UPDATE_ZIP"
-    validate_distribution_zip "$UPDATE_ZIP" "$FINAL_ARTIFACT_MANIFEST" "Final distribution"
+    validate_distribution_zip "$UPDATE_ZIP" "$FINAL_ARTIFACT_MANIFEST" "Final distribution" "$SIGNING_TEAM_ID"
 
     hdiutil create -volname "$DISPLAY_NAME" -srcfolder "$distribution_dir" -ov -format UDZO "$DMG"
     submit_notarization "$DMG"

--- a/Scripts/sign_staged_release.sh
+++ b/Scripts/sign_staged_release.sh
@@ -13,6 +13,7 @@ TRUSTED_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 ENTITLEMENTS_TEMPLATE="$TRUSTED_ROOT/AppBundle/RepoPrompt.entitlements.template"
 TRUSTED_SPARKLE_FRAMEWORK="$TRUSTED_ROOT/Vendor/Sparkle/Sparkle.xcframework/macos-arm64_x86_64/Sparkle.framework"
 STAGED_SPARKLE_FRAMEWORK="$APP_BUNDLE/Contents/Frameworks/Sparkle.framework"
+CODEX_BUNDLE="$APP_BUNDLE/Contents/Resources/BundledRuntimes/Codex"
 ARTIFACT_MANIFEST="$ROOT_DIR/.build/release/$APP_NAME-artifact-manifest.json"
 
 fail() {
@@ -31,7 +32,7 @@ REPOPROMPT_RELEASE_SOURCE_ROOT="$TRUSTED_ROOT" \
 python3 "$SCRIPT_DIR/codex_runtime_artifact.py" \
     --manifest "$CODEX_MANIFEST" verify-bundle \
     --arch all \
-    --bundle "$APP_BUNDLE/Contents/Resources/BundledRuntimes/Codex"
+    --bundle "$CODEX_BUNDLE"
 
 rm -rf "$STAGED_SPARKLE_FRAMEWORK"
 mkdir -p "$(dirname "$STAGED_SPARKLE_FRAMEWORK")"
@@ -95,6 +96,12 @@ sign_sparkle_framework() {
 }
 
 sign_sparkle_framework "$STAGED_SPARKLE_FRAMEWORK"
+codex_mach_o_paths="$(python3 "$SCRIPT_DIR/codex_runtime_artifact.py" \
+    --manifest "$CODEX_MANIFEST" list-bundle-mach-o-paths --arch all)"
+while IFS= read -r relative_path; do
+    [[ -n "$relative_path" ]] || continue
+    sign_path "$CODEX_BUNDLE/$relative_path"
+done <<< "$codex_mach_o_paths"
 sign_path "$APP_BUNDLE/Contents/MacOS/repoprompt-mcp"
 sign_path "$APP_BUNDLE/Contents/MacOS/$APP_NAME"
 sign_path "$APP_BUNDLE" --entitlements "$app_entitlements"
@@ -102,7 +109,8 @@ codesign --verify --deep --strict --verbose=2 "$APP_BUNDLE"
 python3 "$SCRIPT_DIR/codex_runtime_artifact.py" \
     --manifest "$CODEX_MANIFEST" verify-bundle \
     --arch all \
-    --bundle "$APP_BUNDLE/Contents/Resources/BundledRuntimes/Codex"
+    --bundle "$CODEX_BUNDLE" \
+    --signed-team-identifier "$SIGNING_TEAM_ID"
 "$SCRIPT_DIR/validate_app_architectures.sh" \
     "$APP_BUNDLE" \
     "arm64,x86_64" \

--- a/Scripts/test_codex_runtime_artifact.py
+++ b/Scripts/test_codex_runtime_artifact.py
@@ -8,6 +8,7 @@ import json
 import os
 import shutil
 import stat
+import struct
 import subprocess
 import sys
 import tarfile
@@ -34,6 +35,59 @@ def write_executable(path: Path, content: str) -> None:
     path.chmod(0o755)
 
 
+def mach_o_fixture_bytes(architecture: str, payload: bytes) -> bytes:
+    cpu_type = 0x0100000C if architecture == "arm64" else 0x01000007
+    page_size = 0x4000 if architecture == "arm64" else 0x1000
+    file_offset = 0x1000
+    file_size = len(payload)
+    vm_size = ((file_size + page_size - 1) // page_size) * page_size
+    header = struct.pack(
+        "<IiiIIIII",
+        0xFEEDFACF,
+        cpu_type,
+        0,
+        2,
+        1,
+        72,
+        0,
+        0,
+    )
+    linkedit = struct.pack(
+        "<II16sQQQQiiII",
+        0x19,
+        72,
+        b"__LINKEDIT".ljust(16, b"\0"),
+        0x100000000,
+        vm_size,
+        file_offset,
+        file_size,
+        1,
+        1,
+        0,
+        0,
+    )
+    return header + linkedit + bytes(file_offset - len(header) - len(linkedit)) + payload
+
+
+def write_mach_o_fixture(path: Path, architecture: str, payload: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(mach_o_fixture_bytes(architecture, payload))
+    path.chmod(0o755)
+
+
+def apply_fixture_signature(path: Path, signature: bytes = b"fixture-signature") -> None:
+    data = bytearray(path.read_bytes())
+    command_count, command_bytes = struct.unpack_from("<II", data, 16)
+    signature_offset = len(data)
+    struct.pack_into("<II", data, 16, command_count + 1, command_bytes + 16)
+    struct.pack_into("<IIII", data, 32 + command_bytes, 0x1D, 16, signature_offset, len(signature))
+    linkedit_file_size = struct.unpack_from("<Q", data, 32 + 48)[0] + len(signature)
+    struct.pack_into("<Q", data, 32 + 48, linkedit_file_size)
+    struct.pack_into("<Q", data, 32 + 32, linkedit_file_size + 0x2000)
+    data.extend(signature)
+    path.write_bytes(data)
+
+
 class CodexRuntimeArtifactTests(unittest.TestCase):
     def setUp(self) -> None:
         self.temp = Path(tempfile.mkdtemp(prefix="codex-artifact-test-"))
@@ -46,26 +100,70 @@ class CodexRuntimeArtifactTests(unittest.TestCase):
         self.bin.mkdir()
         self.lipo = self.bin / "lipo"
         self.codesign = self.bin / "codesign"
+        self.signature_stripper = self.bin / "strip_fixture_signature.py"
         write_executable(
             self.lipo,
             """#!/usr/bin/env bash
 set -euo pipefail
 if [[ -n "${FAKE_ARCH:-}" ]]; then printf '%s\\n' "$FAKE_ARCH"; exit 0; fi
-sed -n 's/^ARCH=//p' "$2" | head -1
+case "$2" in
+  *aarch64-apple-darwin*) printf 'arm64\\n' ;;
+  *x86_64-apple-darwin*) printf 'x86_64\\n' ;;
+  *) printf 'unknown\\n' ;;
+esac
+""",
+        )
+        write_executable(
+            self.signature_stripper,
+            """#!/usr/bin/env python3
+import struct
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+data = bytearray(path.read_bytes())
+command_count, command_bytes = struct.unpack_from("<II", data, 16)
+offset = 32
+signature = None
+for _ in range(command_count):
+    command, size = struct.unpack_from("<II", data, offset)
+    if command == 0x1D:
+        signature = (offset, size, *struct.unpack_from("<II", data, offset + 8))
+        break
+    offset += size
+if signature is None:
+    raise SystemExit(1)
+command_offset, command_size, signature_offset, signature_size = signature
+if signature_offset + signature_size != len(data):
+    raise SystemExit(2)
+del data[signature_offset:]
+remaining_commands = data[32 : 32 + command_bytes]
+relative = command_offset - 32
+del remaining_commands[relative : relative + command_size]
+remaining_commands.extend(bytes(command_size))
+data[32 : 32 + command_bytes] = remaining_commands
+struct.pack_into("<II", data, 16, command_count - 1, command_bytes - command_size)
+file_size = struct.unpack_from("<Q", data, 32 + 48)[0] - signature_size
+struct.pack_into("<Q", data, 32 + 48, file_size)
+path.write_bytes(data)
 """,
         )
         write_executable(
             self.codesign,
             """#!/usr/bin/env bash
 set -euo pipefail
+if [[ "$1" == "--remove-signature" ]]; then
+    "$FAKE_SIGNATURE_STRIPPER" "${!#}"
+    exit
+fi
 if [[ "$1" == "--verify" ]]; then
     [[ "${FAKE_SIGNATURE_FAILURE:-0}" != "1" ]]
     exit
 fi
 path="${!#}"
 identifier="$(basename "$path")"
-team_identifier="2DC432GLL2"
-authority="Developer ID Application: OpenAI OpCo, LLC (2DC432GLL2)"
+team_identifier="${FAKE_TEAM_IDENTIFIER:-2DC432GLL2}"
+authority="${FAKE_AUTHORITY:-Developer ID Application: OpenAI OpCo, LLC (2DC432GLL2)}"
 if [[ "${FAKE_SIGNATURE_METADATA_FAILURE:-0}" == "1" ]]; then identifier=wrong; fi
 case "${FAKE_SIGNATURE_PREFIX_COLLISION:-}" in
   identifier) identifier="${identifier}-collision" ;;
@@ -106,7 +204,11 @@ fi
             "codex-path/rg",
             "codex-resources/zsh/bin/zsh",
         ):
-            write_executable(root / relative, f"ARCH={architecture}\nfixture={relative}\n")
+            write_mach_o_fixture(
+                root / relative,
+                architecture,
+                f"ARCH={architecture}\nfixture={relative}\n".encode(),
+            )
         return root
 
     @staticmethod
@@ -117,14 +219,15 @@ fi
             if path.is_dir():
                 result.append({"path": relative, "kind": "directory"})
             else:
-                result.append(
-                    {
-                        "path": relative,
-                        "kind": "file",
-                        "sha256": digest(path),
-                        "executable": bool(path.stat().st_mode & 0o111),
-                    }
-                )
+                entry: dict[str, object] = {
+                    "path": relative,
+                    "kind": "file",
+                    "sha256": digest(path),
+                    "executable": bool(path.stat().st_mode & 0o111),
+                }
+                if path.read_bytes()[:4] == b"\xcf\xfa\xed\xfe":
+                    entry["normalizedSha256"] = digest(path)
+                result.append(entry)
         return result
 
     @staticmethod
@@ -230,7 +333,18 @@ fi
             str(self.codesign),
             *arguments,
         ]
-        result = subprocess.run(command, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env={**os.environ, **(env or {})})
+        tool_env = {
+            **os.environ,
+            "FAKE_SIGNATURE_STRIPPER": str(self.signature_stripper),
+            **(env or {}),
+        }
+        result = subprocess.run(
+            command,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=tool_env,
+        )
         self.assertEqual(result.returncode, expected, msg=f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}")
         return result
 
@@ -270,15 +384,130 @@ fi
             {path.name for path in self.bundle.iterdir()},
             {"aarch64-apple-darwin", "x86_64-apple-darwin"},
         )
-        self.assertEqual(
-            (self.bundle / "aarch64-apple-darwin" / "bin" / "codex").read_text(encoding="utf-8").splitlines()[0],
-            "ARCH=arm64",
+        self.assertIn(
+            b"ARCH=arm64",
+            (self.bundle / "aarch64-apple-darwin" / "bin" / "codex").read_bytes(),
         )
-        self.assertEqual(
-            (self.bundle / "x86_64-apple-darwin" / "bin" / "codex").read_text(encoding="utf-8").splitlines()[0],
-            "ARCH=x86_64",
+        self.assertIn(
+            b"ARCH=x86_64",
+            (self.bundle / "x86_64-apple-darwin" / "bin" / "codex").read_bytes(),
         )
         self.run_tool("verify-bundle", "--arch", "all", "--bundle", str(self.bundle))
+
+    def test_release_resigned_bundle_verifies_every_manifest_mach_o_for_expected_team(self) -> None:
+        self.acquire_all()
+        self.run_tool(
+            "stage-bundle",
+            "--arch",
+            "all",
+            "--cache-root",
+            str(self.cache),
+            "--bundle",
+            str(self.bundle),
+        )
+        listed = self.run_tool("list-bundle-mach-o-paths", "--arch", "all")
+        expected_paths = [
+            f"{target}/{relative}"
+            for target in ("aarch64-apple-darwin", "x86_64-apple-darwin")
+            for relative in (
+                "bin/codex",
+                "bin/codex-code-mode-host",
+                "codex-path/rg",
+                "codex-resources/zsh/bin/zsh",
+            )
+        ]
+        self.assertEqual(listed.stdout.splitlines(), expected_paths)
+
+        for relative in expected_paths:
+            apply_fixture_signature(
+                self.bundle / relative,
+                signature=f"signature-only:{relative}".encode(),
+            )
+
+        exact = self.run_tool(
+            "verify-bundle",
+            "--arch",
+            "all",
+            "--bundle",
+            str(self.bundle),
+            expected=1,
+        )
+        self.assertIn("package tree does not match pinned manifest", exact.stderr)
+
+        release_env = {
+            "FAKE_TEAM_IDENTIFIER": "648A27MST5",
+            "FAKE_AUTHORITY": "Developer ID Application: RepoPrompt Fixture (648A27MST5)",
+        }
+        verified = self.run_tool(
+            "verify-bundle",
+            "--arch",
+            "all",
+            "--bundle",
+            str(self.bundle),
+            "--signed-team-identifier",
+            "648A27MST5",
+            env=release_env,
+        )
+        self.assertIn("release signatures for team 648A27MST5", verified.stdout)
+
+        wrong_team = self.run_tool(
+            "verify-bundle",
+            "--arch",
+            "all",
+            "--bundle",
+            str(self.bundle),
+            "--signed-team-identifier",
+            "WRONGTEAM",
+            env=release_env,
+            expected=1,
+        )
+        self.assertIn("TeamIdentifier must equal 'WRONGTEAM'", wrong_team.stderr)
+
+        drifted_binary = self.bundle / expected_paths[0]
+        drifted = bytearray(drifted_binary.read_bytes())
+        drifted[0x1000] ^= 0x01
+        drifted_binary.write_bytes(drifted)
+        payload_drift = self.run_tool(
+            "verify-bundle",
+            "--arch",
+            "all",
+            "--bundle",
+            str(self.bundle),
+            "--signed-team-identifier",
+            "648A27MST5",
+            env=release_env,
+            expected=1,
+        )
+        self.assertIn("normalized Mach-O SHA-256 mismatch", payload_drift.stderr)
+
+    def test_release_resigned_bundle_still_rejects_unsigned_payload_drift(self) -> None:
+        self.acquire_all()
+        self.run_tool(
+            "stage-bundle",
+            "--arch",
+            "all",
+            "--cache-root",
+            str(self.cache),
+            "--bundle",
+            str(self.bundle),
+        )
+        metadata = self.bundle / "aarch64-apple-darwin" / "codex-package.json"
+        metadata.write_bytes(metadata.read_bytes() + b"drift")
+        result = self.run_tool(
+            "verify-bundle",
+            "--arch",
+            "all",
+            "--bundle",
+            str(self.bundle),
+            "--signed-team-identifier",
+            "648A27MST5",
+            env={
+                "FAKE_TEAM_IDENTIFIER": "648A27MST5",
+                "FAKE_AUTHORITY": "Developer ID Application: RepoPrompt Fixture (648A27MST5)",
+            },
+            expected=1,
+        )
+        self.assertIn("package tree does not match pinned manifest", result.stderr)
 
     def test_acquired_and_staged_package_roots_are_mode_0755(self) -> None:
         self.acquire_all()
@@ -420,6 +649,31 @@ fi
                 result = self.run_tool("validate-manifest", expected=1)
                 self.assertIn("URL", result.stderr)
 
+    def test_refresh_normalized_digests_derives_manifest_values_from_verified_cache(self) -> None:
+        self.acquire_all()
+        manifest = json.loads(self.manifest_path.read_text(encoding="utf-8"))
+        for package in manifest["packages"].values():
+            for entry in package["tree"]:
+                entry.pop("normalizedSha256", None)
+        self.manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+        result = self.run_tool(
+            "refresh-normalized-digests",
+            "--arch",
+            "all",
+            "--cache-root",
+            str(self.cache),
+        )
+        self.assertIn("refreshed normalized Codex Mach-O digests", result.stdout)
+        refreshed = json.loads(self.manifest_path.read_text(encoding="utf-8"))
+        for target, package in refreshed["packages"].items():
+            entries = {entry["path"]: entry for entry in package["tree"]}
+            for relative in refreshed["machOFiles"]:
+                self.assertEqual(
+                    entries[relative]["normalizedSha256"],
+                    digest(self.cache / "0.144.6" / target / relative),
+                )
+
     def test_manifest_version_drives_packaging_cache_path(self) -> None:
         result = self.run_tool("manifest-version")
         self.assertEqual(result.stdout.strip(), "0.144.6")
@@ -473,6 +727,34 @@ fi
             expected=1,
         )
         self.assertIn("unpinned member", result.stderr)
+
+    def test_package_verification_rejects_unlisted_mach_o_helper(self) -> None:
+        self.acquire_all()
+        target = "aarch64-apple-darwin"
+        package = self.cache / "0.144.6" / target
+        hidden = package / "bin" / "future-helper"
+        write_mach_o_fixture(hidden, "arm64", b"future helper payload")
+        manifest = json.loads(self.manifest_path.read_text(encoding="utf-8"))
+        manifest["packages"][target]["tree"].append(
+            {
+                "path": "bin/future-helper",
+                "kind": "file",
+                "sha256": digest(hidden),
+                "executable": True,
+            }
+        )
+        self.manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+        result = self.run_tool(
+            "verify",
+            "--arch",
+            "arm64",
+            "--package",
+            str(package),
+            expected=1,
+        )
+        self.assertIn("Mach-O inventory does not match pinned manifest", result.stderr)
+        self.assertIn("bin/future-helper", result.stderr)
 
     def test_cached_tree_drift_is_rejected(self) -> None:
         self.acquire_all()

--- a/Scripts/test_codex_runtime_artifact.py
+++ b/Scripts/test_codex_runtime_artifact.py
@@ -157,6 +157,15 @@ if [[ "$1" == "--remove-signature" ]]; then
     exit
 fi
 if [[ "$1" == "--verify" ]]; then
+    if [[ -n "${FAKE_VERIFY_COUNTER:-}" ]]; then
+        verify_count=0
+        if [[ -f "$FAKE_VERIFY_COUNTER" ]]; then verify_count="$(cat "$FAKE_VERIFY_COUNTER")"; fi
+        verify_count=$((verify_count + 1))
+        printf '%s\n' "$verify_count" > "$FAKE_VERIFY_COUNTER"
+        if [[ -n "${FAKE_VERIFY_FAILURE_AFTER:-}" ]] && (( verify_count > FAKE_VERIFY_FAILURE_AFTER )); then
+            exit 1
+        fi
+    fi
     [[ "${FAKE_SIGNATURE_FAILURE:-0}" != "1" ]]
     exit
 fi
@@ -673,6 +682,30 @@ fi
                     entries[relative]["normalizedSha256"],
                     digest(self.cache / "0.144.6" / target / relative),
                 )
+
+    def test_failed_normalized_digest_candidate_leaves_manifest_unchanged(self) -> None:
+        self.acquire_all()
+        original = self.manifest_path.read_bytes()
+        counter = self.temp / "codesign-verify-count"
+
+        result = self.run_tool(
+            "refresh-normalized-digests",
+            "--arch",
+            "all",
+            "--cache-root",
+            str(self.cache),
+            env={
+                "FAKE_VERIFY_COUNTER": str(counter),
+                "FAKE_VERIFY_FAILURE_AFTER": "4",
+            },
+            expected=1,
+        )
+
+        self.assertIn("signature check", result.stderr)
+        self.assertEqual(self.manifest_path.read_bytes(), original)
+        self.assertFalse(
+            self.manifest_path.with_name(f".{self.manifest_path.name}.tmp").exists()
+        )
 
     def test_manifest_version_drives_packaging_cache_path(self) -> None:
         result = self.run_tool("manifest-version")

--- a/Scripts/test_release_promotion.py
+++ b/Scripts/test_release_promotion.py
@@ -35,7 +35,12 @@ class ReleasePromotionTests(unittest.TestCase):
         for call in calls:
             self.assertIn("--manifest", call)
             self.assertIn("Vendor/Codex/manifest.json verify-bundle --arch all --bundle", call)
-            self.assertTrue(call.endswith("Contents/Resources/BundledRuntimes/Codex"))
+            self.assertTrue(
+                call.endswith(
+                    "Contents/Resources/BundledRuntimes/Codex "
+                    "--signed-team-identifier 648A27MST5"
+                )
+            )
 
     def test_verify_rejects_missing_codex_manifest(self) -> None:
         result, _capture, _tools = self.run_promotion("verify", missing_codex_manifest=True)
@@ -249,7 +254,7 @@ class ReleasePromotionTests(unittest.TestCase):
         shutil.copy2(SCRIPT_DIR / "load_release_metadata.sh", scripts / "load_release_metadata.sh")
         shutil.copy2(SCRIPT_DIR / "verify_sparkle_signature.swift", scripts / "verify_sparkle_signature.swift")
         (scripts / "codex_runtime_artifact.py").write_text(
-            "#!/usr/bin/env python3\nimport os\nimport sys\nfrom pathlib import Path\n\nargs = sys.argv[1:]\nexpected_manifest = Path(os.environ[\"FAKE_CODEX_MANIFEST\"])\nif len(args) != 7 or args[:6] != [\n    \"--manifest\",\n    str(expected_manifest),\n    \"verify-bundle\",\n    \"--arch\",\n    \"all\",\n    \"--bundle\",\n]:\n    print(f\"ERROR: unexpected Codex verifier arguments: {args!r}\", file=sys.stderr)\n    raise SystemExit(64)\nbundle = Path(args[6])\nif not expected_manifest.is_file():\n    print(f\"ERROR: missing approved Codex manifest: {expected_manifest}\", file=sys.stderr)\n    raise SystemExit(65)\nexpected_targets = {\"aarch64-apple-darwin\", \"x86_64-apple-darwin\"}\nif not bundle.is_dir() or {path.name for path in bundle.iterdir()} != expected_targets:\n    print(f\"ERROR: missing embedded Codex package targets: {bundle}\", file=sys.stderr)\n    raise SystemExit(66)\nexpected_suffix = Path(\"Contents/Resources/BundledRuntimes/Codex\")\nif tuple(bundle.parts[-len(expected_suffix.parts):]) != expected_suffix.parts:\n    print(f\"ERROR: unexpected embedded Codex bundle path: {bundle}\", file=sys.stderr)\n    raise SystemExit(67)\nwith Path(os.environ[\"FAKE_TOOL_CAPTURE\"]).open(\"a\", encoding=\"utf-8\") as handle:\n    handle.write(\"codex \" + \" \".join(args) + \"\\n\")\nprint(\"OK: fixture Codex bundle contract.\")\n",
+            "#!/usr/bin/env python3\nimport os\nimport sys\nfrom pathlib import Path\n\nargs = sys.argv[1:]\nexpected_manifest = Path(os.environ[\"FAKE_CODEX_MANIFEST\"])\nif len(args) != 9 or args[:6] != [\n    \"--manifest\",\n    str(expected_manifest),\n    \"verify-bundle\",\n    \"--arch\",\n    \"all\",\n    \"--bundle\",\n] or args[7:] != [\"--signed-team-identifier\", \"648A27MST5\"]:\n    print(f\"ERROR: unexpected Codex verifier arguments: {args!r}\", file=sys.stderr)\n    raise SystemExit(64)\nbundle = Path(args[6])\nif not expected_manifest.is_file():\n    print(f\"ERROR: missing approved Codex manifest: {expected_manifest}\", file=sys.stderr)\n    raise SystemExit(65)\nexpected_targets = {\"aarch64-apple-darwin\", \"x86_64-apple-darwin\"}\nif not bundle.is_dir() or {path.name for path in bundle.iterdir()} != expected_targets:\n    print(f\"ERROR: missing embedded Codex package targets: {bundle}\", file=sys.stderr)\n    raise SystemExit(66)\nexpected_suffix = Path(\"Contents/Resources/BundledRuntimes/Codex\")\nif tuple(bundle.parts[-len(expected_suffix.parts):]) != expected_suffix.parts:\n    print(f\"ERROR: unexpected embedded Codex bundle path: {bundle}\", file=sys.stderr)\n    raise SystemExit(67)\nwith Path(os.environ[\"FAKE_TOOL_CAPTURE\"]).open(\"a\", encoding=\"utf-8\") as handle:\n    handle.write(\"codex \" + \" \".join(args) + \"\\n\")\nprint(\"OK: fixture Codex bundle contract.\")\n",
             encoding="utf-8",
         )
         codex_vendor = root / "Vendor" / "Codex"

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -201,14 +201,37 @@ APP_SIGN_ARGS=(){app_signing_body}
         self.assertIn("trap 'finish $?' EXIT", package_script)
         self.assertIn('local status="$1" now total', package_script)
 
-    def test_staged_signing_uses_trusted_verifier_with_approved_codex_identity(self) -> None:
+    def test_staged_signing_resigns_every_codex_mach_o_before_mcp_and_outer_app(self) -> None:
         source = (SCRIPT_DIR / "sign_staged_release.sh").read_text(encoding="utf-8")
 
         self.assertIn('CODEX_MANIFEST="$METADATA_ROOT/Vendor/Codex/manifest.json"', source)
         self.assertIn('python3 "$SCRIPT_DIR/codex_runtime_artifact.py"', source)
         self.assertEqual(source.count('--manifest "$CODEX_MANIFEST" verify-bundle'), 2)
-        self.assertEqual(source.count('--arch all'), 2)
+        self.assertEqual(source.count("list-bundle-mach-o-paths --arch all"), 1)
+        self.assertEqual(source.count('--signed-team-identifier "$SIGNING_TEAM_ID"'), 1)
         self.assertNotIn('$TRUSTED_ROOT/Vendor/Codex/manifest.json', source)
+
+        sparkle_sign = source.index('sign_sparkle_framework "$STAGED_SPARKLE_FRAMEWORK"')
+        enumerate_codex = source.index("list-bundle-mach-o-paths --arch all")
+        codex_sign = source.index('sign_path "$CODEX_BUNDLE/$relative_path"')
+        mcp_sign = source.index('sign_path "$APP_BUNDLE/Contents/MacOS/repoprompt-mcp"')
+        app_sign = source.index('sign_path "$APP_BUNDLE/Contents/MacOS/$APP_NAME"')
+        outer_sign = source.index('sign_path "$APP_BUNDLE" --entitlements "$app_entitlements"')
+        self.assertLess(sparkle_sign, enumerate_codex)
+        self.assertLess(enumerate_codex, codex_sign)
+        self.assertLess(codex_sign, mcp_sign)
+        self.assertLess(mcp_sign, app_sign)
+        self.assertLess(app_sign, outer_sign)
+        self.assertNotIn('sign_path "$CODEX_BUNDLE"', source)
+
+        for release_script_name in (
+            "release.sh",
+            "main_tip_release.sh",
+            "promote_release.sh",
+            "publish_public_update_test.sh",
+        ):
+            release_source = (SCRIPT_DIR / release_script_name).read_text(encoding="utf-8")
+            self.assertIn("--signed-team-identifier", release_source, release_script_name)
 
     def test_release_paths_use_static_validation_in_privileged_contexts_and_token_stripped_local_smoke(self) -> None:
         package_script = (SCRIPT_DIR / "package_app.sh").read_text(encoding="utf-8")

--- a/Vendor/Codex/manifest.json
+++ b/Vendor/Codex/manifest.json
@@ -23,13 +23,15 @@
           "path": "bin/codex",
           "kind": "file",
           "sha256": "80a3933d11a9d13ef806aa24f7bb8afc9169cfe4e9b09d6da6a92922cbde9cff",
-          "executable": true
+          "executable": true,
+          "normalizedSha256": "408aaca5c58fa692f797a24b14f74da5e7c6308b6246c97cfe806946d568d194"
         },
         {
           "path": "bin/codex-code-mode-host",
           "kind": "file",
           "sha256": "de329ec247b5ebbdf796b5888a7c2a9d731e221321584c5abdcc686c70b2db81",
-          "executable": true
+          "executable": true,
+          "normalizedSha256": "469f2e818590f24b9c829718af3d7297a551448d8ab5f9dff29a3ea13de09ea5"
         },
         {
           "path": "codex-package.json",
@@ -45,7 +47,8 @@
           "path": "codex-path/rg",
           "kind": "file",
           "sha256": "4fdf1d8365af224bc70e3c1490d8461d859c37cc70e739a11e987af0215f3e94",
-          "executable": true
+          "executable": true,
+          "normalizedSha256": "ef0ed58c935b6e9e846de2724b15eb6e324ad935607a4984accbfad499f9fe15"
         },
         {
           "path": "codex-resources",
@@ -63,7 +66,8 @@
           "path": "codex-resources/zsh/bin/zsh",
           "kind": "file",
           "sha256": "b69893d9da08786211bac0862212e26a8a31af24eb77da21692671c58d388b8d",
-          "executable": true
+          "executable": true,
+          "normalizedSha256": "5cc9238f3e211be71cd25cde1bbe4319849951d4b1fdf942d925091388bd95fd"
         }
       ]
     },
@@ -81,13 +85,15 @@
           "path": "bin/codex",
           "kind": "file",
           "sha256": "bd6ec7e28b4682e010f6bf3953166d2a2b178d50beb448c137d33d53450b2802",
-          "executable": true
+          "executable": true,
+          "normalizedSha256": "edd0d961f73cf707f0b00dc4094c8ee06f465d9aca79fbfd7715740472c4d19a"
         },
         {
           "path": "bin/codex-code-mode-host",
           "kind": "file",
           "sha256": "a0e7ae85ff7e70045d2dbe74162c80eb84519e202b66a1e6e3943a321b21664d",
-          "executable": true
+          "executable": true,
+          "normalizedSha256": "bb9982f5912db05aacb907865cb5757c8784debee64e4cbf79edbb807862a4d1"
         },
         {
           "path": "codex-package.json",
@@ -103,7 +109,8 @@
           "path": "codex-path/rg",
           "kind": "file",
           "sha256": "3bafa7e6ee51ba3ac4ed065883484a309be09b26ea6dad561ae4049bfe049c50",
-          "executable": true
+          "executable": true,
+          "normalizedSha256": "7c4723c1a6f184a274ae07d6bd8b4804b29a5e6c343b6edb8f04a7c5abbe3d62"
         },
         {
           "path": "codex-resources",
@@ -121,7 +128,8 @@
           "path": "codex-resources/zsh/bin/zsh",
           "kind": "file",
           "sha256": "901782b34a9742b9962199332934ac77229073760bf837bc86b156ce4b86b9fa",
-          "executable": true
+          "executable": true,
+          "normalizedSha256": "901782b34a9742b9962199332934ac77229073760bf837bc86b156ce4b86b9fa"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- individually Developer-ID sign every manifest-owned bundled Codex Mach-O before signing the enclosing app
- preserve exact OpenAI package verification before signing and verify signature-normalized content digests afterward
- require complete Mach-O inventory and apply the same contract to Tip, stable, promotion, and public-update validation

## Root cause
PR #605 added pinned Codex runtimes, but the shared staged release signer did not individually sign their eight nested Mach-O files. Apple notarization submission `71b64ead-0d0e-43c3-9b20-effab7d85535` therefore returned `Invalid` in Tip run `29941666336`, despite the enclosing app passing local codesign verification.

## Validation
- `python3 Scripts/test_codex_runtime_artifact.py` (23 passed)
- `python3 Scripts/test_release_tooling.py` (76 passed)
- `python3 Scripts/test_release_promotion.py` (22 passed)
- official cached Codex packages re-verified for both architectures
- `bash Scripts/codex_vendor_guardrails.sh`
- shell/Python syntax checks and `git diff --check`
- `make dev-release-preflight` (ticket `afbd44be-d3db-4bce-96b4-d85395bcbc1a`)
- mandatory commit and push contribution preflights

The protected Developer ID + Apple notarization run remains the required end-to-end confirmation after merge.