### PR TITLE
Stabilize synthetic watcher integration tests

### DIFF
--- a/Tests/RepoPromptTests/MCP/Control/PersistentAgentModeMCPReadFileConnectionTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/PersistentAgentModeMCPReadFileConnectionTests.swift
@@ -490,6 +490,7 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
             editedLines.insert(contentsOf: (1 ... 25).map { "middle-insert-\($0)" }, at: 3039)
             editedLines.removeSubrange(5064 ..< 5084)
             let physicalURL = try fixture.worktreeLargeFileURL
+            try await fixture.useOnlySyntheticWatcherIngressForInstalledWorktree()
             let replacementURL = physicalURL.deletingLastPathComponent()
                 .appendingPathComponent(".SessionWorktree6500.swift.atomic-\(UUID().uuidString)")
             try (editedLines.joined(separator: "\n") + "\n").write(
@@ -560,6 +561,7 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
                 fixture.window.workspaceFilesViewModel.setHiddenSessionSliceRebaseWillCommitHandlerForTesting(nil)
                 Task { await staleCommitGate.release() }
             }
+            try await fixture.useOnlySyntheticWatcherIngressForInstalledWorktree()
             let staleReplacementURL = physicalURL.deletingLastPathComponent()
                 .appendingPathComponent(".SessionWorktree6500.swift.stale-\(UUID().uuidString)")
             let staleReplacementText = try String(contentsOf: physicalURL, encoding: .utf8)
@@ -683,6 +685,9 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
             try Self.assertSuccessfulResponse(fullSet, id: 4)
 
             let physicalURL = try fixture.worktreeSearchCreatedFileURL
+            try await fixture.useOnlySyntheticWatcherIngressForInstalledWorktree(
+                qualifyCachedSearchContent: true
+            )
             var originalLines = (1 ... 29).map { "search-line-\($0)" }
             originalLines[3] = "WATCHER_BEGIN_ANCHOR_9F3A7C"
             originalLines[14] = "WATCHER_MIDDLE_ANCHOR_9F3A7C"
@@ -753,6 +758,9 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
             editedLines.insert(contentsOf: (1 ... 4).map { "top-insert-\($0)" }, at: 0)
             editedLines.insert(contentsOf: (1 ... 3).map { "middle-insert-\($0)" }, at: 13)
             editedLines.removeSubrange(26 ... 27)
+            try await fixture.useOnlySyntheticWatcherIngressForInstalledWorktree(
+                qualifyCachedSearchContent: true
+            )
             let replacementURL = physicalURL.deletingLastPathComponent()
                 .appendingPathComponent(".SearchCreated.swift.atomic-\(UUID().uuidString)")
             try (editedLines.joined(separator: "\n") + "\n").write(
@@ -3219,6 +3227,25 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
         var installedWorktreeRootID: UUID {
             get throws {
                 try XCTUnwrap(worktreeRootID)
+            }
+        }
+
+        func useOnlySyntheticWatcherIngressForInstalledWorktree(
+            qualifyCachedSearchContent: Bool = false
+        ) async throws {
+            let rootID = try installedWorktreeRootID
+            let store = window.workspaceFileContextStore
+            let maybeService = await store.fileSystemServiceForTesting(rootID: rootID)
+            let service = try XCTUnwrap(maybeService)
+            await service.stopWatchingForChanges()
+            let attachedPublisherIngress = try await store.attachPublisherIngressWithoutStartingWatcherForTesting(
+                rootID: rootID
+            )
+            XCTAssertTrue(attachedPublisherIngress)
+            let watcherIsActive = try await store.rootWatcherIsActiveForTesting(rootID: rootID)
+            XCTAssertFalse(watcherIsActive)
+            if qualifyCachedSearchContent {
+                try await store.setCachedSearchContentWatcherActiveOverrideForTesting(rootID: rootID, true)
             }
         }
 

--- a/Tests/RepoPromptTests/MCP/Control/PersistentAgentModeMCPReadFileConnectionTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/PersistentAgentModeMCPReadFileConnectionTests.swift
@@ -3241,9 +3241,13 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
             let attachedPublisherIngress = try await store.attachPublisherIngressWithoutStartingWatcherForTesting(
                 rootID: rootID
             )
-            XCTAssertTrue(attachedPublisherIngress)
+            guard attachedPublisherIngress else {
+                throw ClientFixtureError.syntheticWatcherPublisherIngressUnavailable(rootID)
+            }
             let watcherIsActive = try await store.rootWatcherIsActiveForTesting(rootID: rootID)
-            XCTAssertFalse(watcherIsActive)
+            guard !watcherIsActive else {
+                throw ClientFixtureError.syntheticWatcherStillActive(rootID)
+            }
             if qualifyCachedSearchContent {
                 try await store.setCachedSearchContentWatcherActiveOverrideForTesting(rootID: rootID, true)
             }
@@ -3901,6 +3905,8 @@ final class PersistentAgentModeMCPReadFileConnectionTests: XCTestCase {
         case handoverPolicyApplicationFailed(String)
         case liveFixtureTooShort(Int)
         case presentationStateMismatch(String)
+        case syntheticWatcherPublisherIngressUnavailable(UUID)
+        case syntheticWatcherStillActive(UUID)
     }
 
     private struct RetainedConnectionSnapshot: Equatable {


### PR DESCRIPTION
## Summary
- stop the real FSEvents watcher before synthetic watcher payload scenarios
- keep publisher ingress attached so search coverage and slice rebasing remain exercised
- preserve cached-search qualification through the existing DEBUG-only override

## Root cause
Main CI run 29962478686 rebased the same worktree file mutation twice because the fixture combined a real watched filesystem mutation with an injected synthetic watcher event. This produced the repeated shard-4 range mismatch. Production behavior is unchanged.

## Validation
- `make dev-format`
- `make dev-test FILTER=PersistentAgentModeMCPReadFileConnectionTests` (20/20)
- `make dev-test FILTER=WorkspaceSavePreparationTests` (5/5)
- `make dev-lint`
- contribution commit/push preflights
- read-only review: no must-fix issues