### PR TITLE
Add Agent Mode session handoff prompt

### DIFF
--- a/Sources/RepoPrompt/App/WindowState.swift
+++ b/Sources/RepoPrompt/App/WindowState.swift
@@ -768,6 +768,7 @@ class WindowState: ObservableObject {
             return nil
         }
         return AgentChatOptionsMenuTarget(
+            windowID: windowID,
             workspaceID: workspace.id,
             tabID: tabID,
             agentSessionID: agentSessionID,
@@ -776,7 +777,8 @@ class WindowState: ObservableObject {
     }
 
     func agentChatTitleClusterMenuTargetIsValid(_ target: AgentChatOptionsMenuTarget) -> Bool {
-        guard let workspace = workspaceManager.activeWorkspace,
+        guard target.windowID == windowID,
+              let workspace = workspaceManager.activeWorkspace,
               workspace.id == target.workspaceID,
               workspace.composeTabs.contains(where: { $0.id == target.tabID })
         else {
@@ -804,7 +806,13 @@ class WindowState: ObservableObject {
         )
     }
 
-    func agentChatTitleClusterMenuActions() -> AgentChatOptionsMenuActions {
+    func agentChatTitleClusterMenuActions(
+        copyToClipboard: @escaping (String) -> Void = { value in
+            let pasteboard = NSPasteboard.general
+            pasteboard.clearContents()
+            pasteboard.setString(value, forType: .string)
+        }
+    ) -> AgentChatOptionsMenuActions {
         AgentChatOptionsMenuActions(
             togglePin: { [weak self] target in
                 self?.toggleAgentChatPinFromTitlebar(target: target)
@@ -814,6 +822,12 @@ class WindowState: ObservableObject {
             },
             stash: { [weak self] target in
                 self?.stashAgentChatFromTitlebar(target: target)
+            },
+            copyHandoffPrompt: { [weak self] target in
+                self?.copyAgentChatHandoffPromptFromTitlebar(
+                    target: target,
+                    copyToClipboard: copyToClipboard
+                )
             },
             delete: { [weak self] target in
                 self?.confirmDeleteAgentChatFromTitlebar(target: target)
@@ -831,6 +845,18 @@ class WindowState: ObservableObject {
     private func toggleAgentChatPinFromTitlebar(target: AgentChatOptionsMenuTarget) {
         guard agentChatTitleClusterMenuTargetIsValid(target) else { return }
         promptManager.toggleComposeTabPinned(target.tabID)
+    }
+
+    private func copyAgentChatHandoffPromptFromTitlebar(
+        target: AgentChatOptionsMenuTarget,
+        copyToClipboard: (String) -> Void
+    ) {
+        guard agentChatTitleClusterMenuTargetIsValid(target) else { return }
+        let prompt = AgentSessionHandoffPrompt.render(
+            target: target,
+            cliCommandName: MCPFilesystemConstants.identity.pathCLICommandName
+        )
+        copyToClipboard(prompt)
     }
 
     private func stashAgentChatFromTitlebar(target: AgentChatOptionsMenuTarget) {

--- a/Sources/RepoPrompt/Features/AgentMode/Views/Titlebar/AgentChatOptionsMenuPresenter.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Titlebar/AgentChatOptionsMenuPresenter.swift
@@ -1,10 +1,35 @@
 import AppKit
 
 struct AgentChatOptionsMenuTarget: Equatable {
+    let windowID: Int
     let workspaceID: UUID
     let tabID: UUID
     let agentSessionID: UUID
     let tabName: String
+}
+
+enum AgentSessionHandoffPrompt {
+    static func render(
+        target: AgentChatOptionsMenuTarget,
+        cliCommandName: String
+    ) -> String {
+        """
+        Use RepoPrompt CE to continue this exact Agent Mode session.
+
+        Window ID: \(target.windowID)
+        Workspace ID: \(target.workspaceID.uuidString)
+        Context ID (compose tab): \(target.tabID.uuidString)
+        Agent session ID: \(target.agentSessionID.uuidString)
+
+        MCP:
+        1. Call `bind_context` with `{"op":"bind","window_id":\(target.windowID),"context_id":"\(target.tabID.uuidString)"}`.
+        2. Call `agent_manage` with `{"op":"extract_handoff","session_id":"\(target.agentSessionID.uuidString)"}`.
+        3. Consume the returned `<forked_session>` XML before continuing.
+
+        CLI equivalent (`\(cliCommandName)`):
+        `\(cliCommandName) -w \(target.windowID) --context-id \(target.tabID.uuidString) -c agent_manage -j '{"op":"extract_handoff","session_id":"\(target.agentSessionID.uuidString)"}'`
+        """
+    }
 }
 
 struct AgentChatOptionsMenuSnapshot: Equatable {
@@ -16,6 +41,7 @@ struct AgentChatOptionsMenuActions {
     let togglePin: (AgentChatOptionsMenuTarget) -> Void
     let rename: (AgentChatOptionsMenuTarget) -> Void
     let stash: (AgentChatOptionsMenuTarget) -> Void
+    let copyHandoffPrompt: (AgentChatOptionsMenuTarget) -> Void
     let delete: (AgentChatOptionsMenuTarget) -> Void
 }
 
@@ -50,23 +76,28 @@ enum AgentChatOptionsMenuPresenter {
         let menu = NSMenu(title: "Chat Options")
         menu.autoenablesItems = false
         menu.addItem(AgentChatOptionsMenuItem(
-            title: snapshot.isPinned ? "Unpin Chat" : "Pin Chat",
+            title: snapshot.isPinned ? "Unpin" : "Pin",
             symbolName: snapshot.isPinned ? "pin.slash" : "pin",
             handler: { actions.togglePin(target) }
         ))
         menu.addItem(AgentChatOptionsMenuItem(
-            title: "Rename Chat…",
+            title: "Rename",
             symbolName: "pencil",
             handler: { actions.rename(target) }
         ))
         menu.addItem(AgentChatOptionsMenuItem(
-            title: "Stash Chat",
+            title: "Stash",
             symbolName: "tray.and.arrow.down",
             handler: { actions.stash(target) }
         ))
+        menu.addItem(AgentChatOptionsMenuItem(
+            title: "Handoff",
+            symbolName: "arrow.right.doc.on.clipboard",
+            handler: { actions.copyHandoffPrompt(target) }
+        ))
         menu.addItem(.separator())
         menu.addItem(AgentChatOptionsMenuItem(
-            title: "Delete Chat…",
+            title: "Delete",
             symbolName: "trash",
             handler: { actions.delete(target) }
         ))

--- a/Tests/RepoPromptTests/App/AgentChatTitlebarSafetyTests.swift
+++ b/Tests/RepoPromptTests/App/AgentChatTitlebarSafetyTests.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Foundation
+import MCP
 @testable import RepoPromptApp
 import XCTest
 
@@ -41,6 +42,7 @@ final class AgentChatTitlebarSafetyTests: XCTestCase {
 
     func testMenuItemsCaptureImmutableRepresentedTarget() throws {
         let target = AgentChatOptionsMenuTarget(
+            windowID: 7,
             workspaceID: UUID(),
             tabID: UUID(),
             agentSessionID: UUID(),
@@ -54,19 +56,40 @@ final class AgentChatTitlebarSafetyTests: XCTestCase {
                 togglePin: { invocations.append(("pin", $0)) },
                 rename: { invocations.append(("rename", $0)) },
                 stash: { invocations.append(("stash", $0)) },
+                copyHandoffPrompt: { invocations.append(("copy", $0)) },
                 delete: { invocations.append(("delete", $0)) }
             )
         )
 
         XCTAssertEqual(menu.items.map(\.title), [
-            "Unpin Chat",
-            "Rename Chat…",
-            "Stash Chat",
+            "Unpin",
+            "Rename",
+            "Stash",
+            "Handoff",
             "",
-            "Delete Chat…"
+            "Delete"
         ])
 
-        for index in [0, 1, 2, 4] {
+        let unpinnedMenu = AgentChatOptionsMenuPresenter.makeMenu(
+            snapshot: AgentChatOptionsMenuSnapshot(target: target, isPinned: false),
+            actions: AgentChatOptionsMenuActions(
+                togglePin: { _ in },
+                rename: { _ in },
+                stash: { _ in },
+                copyHandoffPrompt: { _ in },
+                delete: { _ in }
+            )
+        )
+        XCTAssertEqual(unpinnedMenu.items.map(\.title), [
+            "Pin",
+            "Rename",
+            "Stash",
+            "Handoff",
+            "",
+            "Delete"
+        ])
+
+        for index in [0, 1, 2, 3, 5] {
             let item = menu.items[index]
             XCTAssertTrue(item.target === item)
             XCTAssertTrue(try NSApplication.shared.sendAction(
@@ -76,14 +99,76 @@ final class AgentChatTitlebarSafetyTests: XCTestCase {
             ))
         }
 
-        XCTAssertEqual(invocations.map(\.0), ["pin", "rename", "stash", "delete"])
-        XCTAssertEqual(invocations.map(\.1), Array(repeating: target, count: 4))
+        XCTAssertEqual(invocations.map(\.0), ["pin", "rename", "stash", "copy", "delete"])
+        XCTAssertEqual(invocations.map(\.1), Array(repeating: target, count: 5))
+    }
+
+    func testHandoffPromptRendersExactBuildAwareMCPAndCLIRouting() throws {
+        let target = try AgentChatOptionsMenuTarget(
+            windowID: 7,
+            workspaceID: XCTUnwrap(UUID(uuidString: "11111111-1111-1111-1111-111111111111")),
+            tabID: XCTUnwrap(UUID(uuidString: "22222222-2222-2222-2222-222222222222")),
+            agentSessionID: XCTUnwrap(UUID(uuidString: "33333333-3333-3333-3333-333333333333")),
+            tabName: "Captured"
+        )
+        let bindRequest = try WindowRoutingService.parseBindContextRequest([
+            "op": .string("bind"),
+            "window_id": .int(target.windowID),
+            "context_id": .string(target.tabID.uuidString)
+        ])
+        XCTAssertEqual(bindRequest.op, .bind)
+        XCTAssertEqual(bindRequest.windowID, target.windowID)
+        XCTAssertEqual(bindRequest.contextID, target.tabID)
+        XCTAssertEqual(bindRequest.matchKind, .contextID)
+
+        let expectedDebug = """
+        Use RepoPrompt CE to continue this exact Agent Mode session.
+
+        Window ID: 7
+        Workspace ID: 11111111-1111-1111-1111-111111111111
+        Context ID (compose tab): 22222222-2222-2222-2222-222222222222
+        Agent session ID: 33333333-3333-3333-3333-333333333333
+
+        MCP:
+        1. Call `bind_context` with `{"op":"bind","window_id":7,"context_id":"22222222-2222-2222-2222-222222222222"}`.
+        2. Call `agent_manage` with `{"op":"extract_handoff","session_id":"33333333-3333-3333-3333-333333333333"}`.
+        3. Consume the returned `<forked_session>` XML before continuing.
+
+        CLI equivalent (`rpce-cli-debug`):
+        `rpce-cli-debug -w 7 --context-id 22222222-2222-2222-2222-222222222222 -c agent_manage -j '{"op":"extract_handoff","session_id":"33333333-3333-3333-3333-333333333333"}'`
+        """
+        let expectedRelease = """
+        Use RepoPrompt CE to continue this exact Agent Mode session.
+
+        Window ID: 7
+        Workspace ID: 11111111-1111-1111-1111-111111111111
+        Context ID (compose tab): 22222222-2222-2222-2222-222222222222
+        Agent session ID: 33333333-3333-3333-3333-333333333333
+
+        MCP:
+        1. Call `bind_context` with `{"op":"bind","window_id":7,"context_id":"22222222-2222-2222-2222-222222222222"}`.
+        2. Call `agent_manage` with `{"op":"extract_handoff","session_id":"33333333-3333-3333-3333-333333333333"}`.
+        3. Consume the returned `<forked_session>` XML before continuing.
+
+        CLI equivalent (`rpce-cli`):
+        `rpce-cli -w 7 --context-id 22222222-2222-2222-2222-222222222222 -c agent_manage -j '{"op":"extract_handoff","session_id":"33333333-3333-3333-3333-333333333333"}'`
+        """
+
+        XCTAssertEqual(
+            AgentSessionHandoffPrompt.render(target: target, cliCommandName: "rpce-cli-debug"),
+            expectedDebug
+        )
+        XCTAssertEqual(
+            AgentSessionHandoffPrompt.render(target: target, cliCommandName: "rpce-cli"),
+            expectedRelease
+        )
     }
 
     func testSnapshotAndTargetValidationFailClosedAcrossLifecycleChanges() async throws {
         try await withFixture { fixture in
             let snapshot = try XCTUnwrap(fixture.window.agentChatTitleClusterMenuSnapshot())
             let target = snapshot.target
+            XCTAssertEqual(target.windowID, fixture.window.windowID)
             XCTAssertEqual(target.workspaceID, fixture.workspaceID)
             XCTAssertEqual(target.tabID, fixture.tabAID)
             XCTAssertEqual(target.agentSessionID, fixture.sessionAID)
@@ -92,6 +177,16 @@ final class AgentChatTitlebarSafetyTests: XCTestCase {
 
             XCTAssertFalse(fixture.window.agentChatTitleClusterMenuTargetIsValid(
                 AgentChatOptionsMenuTarget(
+                    windowID: target.windowID + 1,
+                    workspaceID: target.workspaceID,
+                    tabID: target.tabID,
+                    agentSessionID: target.agentSessionID,
+                    tabName: target.tabName
+                )
+            ))
+            XCTAssertFalse(fixture.window.agentChatTitleClusterMenuTargetIsValid(
+                AgentChatOptionsMenuTarget(
+                    windowID: target.windowID,
                     workspaceID: UUID(),
                     tabID: target.tabID,
                     agentSessionID: target.agentSessionID,
@@ -100,6 +195,7 @@ final class AgentChatTitlebarSafetyTests: XCTestCase {
             ))
             XCTAssertFalse(fixture.window.agentChatTitleClusterMenuTargetIsValid(
                 AgentChatOptionsMenuTarget(
+                    windowID: target.windowID,
                     workspaceID: target.workspaceID,
                     tabID: UUID(),
                     agentSessionID: target.agentSessionID,
@@ -108,6 +204,7 @@ final class AgentChatTitlebarSafetyTests: XCTestCase {
             ))
             XCTAssertFalse(fixture.window.agentChatTitleClusterMenuTargetIsValid(
                 AgentChatOptionsMenuTarget(
+                    windowID: target.windowID,
                     workspaceID: target.workspaceID,
                     tabID: target.tabID,
                     agentSessionID: UUID(),
@@ -139,6 +236,38 @@ final class AgentChatTitlebarSafetyTests: XCTestCase {
             fixture.window.agentChatTitleClusterMenuActions().togglePin(target)
             XCTAssertEqual(fixture.tab(fixture.tabAID)?.isPinned, true)
             XCTAssertEqual(fixture.tab(fixture.tabBID)?.isPinned, false)
+        }
+    }
+
+    func testCopyHandoffPromptWritesValidTargetAndRejectsStaleTarget() async throws {
+        try await withFixture { fixture in
+            let target = try XCTUnwrap(fixture.window.agentChatTitleClusterMenuSnapshot()?.target)
+            var clipboard = "sentinel"
+            var writeCount = 0
+            let actions = fixture.window.agentChatTitleClusterMenuActions { value in
+                clipboard = value
+                writeCount += 1
+            }
+
+            actions.copyHandoffPrompt(target)
+
+            XCTAssertEqual(writeCount, 1)
+            XCTAssertEqual(
+                clipboard,
+                AgentSessionHandoffPrompt.render(
+                    target: target,
+                    cliCommandName: MCPFilesystemConstants.identity.pathCLICommandName
+                )
+            )
+
+            clipboard = "sentinel"
+            fixture.window.promptManager.renameComposeTab(target.tabID, to: "Stale")
+            XCTAssertFalse(fixture.window.agentChatTitleClusterMenuTargetIsValid(target))
+
+            actions.copyHandoffPrompt(target)
+
+            XCTAssertEqual(writeCount, 1)
+            XCTAssertEqual(clipboard, "sentinel")
         }
     }
 


### PR DESCRIPTION
## Summary
- add a `Handoff` action to the Agent Mode chat options menu
- copy exact window, workspace, compose-context, and agent-session routing identities
- direct receiving agents to the existing `bind_context` and `agent_manage.extract_handoff` authorities
- emit the correct `rpce-cli-debug` or `rpce-cli` command for the running build
- fail closed when the captured menu target becomes stale before clipboard mutation

## Validation
- push safety preflight: passed
- strict SwiftFormat/SwiftLint: passed (Conductor `1a9f6671-4f95-4084-a1e7-a24f41ed9938`)
- `AgentChatTitlebarSafetyTests`: 7 passed, 0 failed (Conductor `97c4b7d9-a492-45bc-8497-26b463c2dfbd`)
- `swift build --product RepoPrompt`: passed (Conductor `a755bbaf-e685-4aae-a746-3aeeeb072eda`)
- live debug build/launch: passed (Conductor `c8fedec2-8867-4d90-8ba6-e98cf238dcf4`)
- full root PR-ready test lane reached its 3600s timeout without reporting a test failure before termination (Conductor `eb4311d8-7157-413e-b1bb-d3486d1bc09c`); the affected focused suite and product build were rerun successfully as listed above
