### PR TITLE
Fix release codemap event type visibility

### DIFF
--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileContextStore.swift
@@ -182,27 +182,27 @@ struct WorkspaceSessionRootLifetimeSnapshot: @unchecked Sendable {
 }
 
 actor WorkspaceFileContextStore {
+    enum CodemapGraphIndexBuildStoreEventKind: String, Hashable {
+        case rootInventoryAndSearchReady
+        case scheduled
+        case started
+        case eligibilityEligible
+        case eligibilityTerminal
+        case eligibilityTransient
+        case setupJoining
+        case engineScheduling
+        case handedOff
+        case cancelled
+        case superseded
+        case retryScheduled
+        case retryStarted
+        case repositoryAuthorityDetached
+    }
+
     #if DEBUG
         enum CodemapGraphIndexBuildLaunchPolicyForTesting: Equatable {
             case enabled
             case disabled
-        }
-
-        enum CodemapGraphIndexBuildStoreEventKind: String, Hashable {
-            case rootInventoryAndSearchReady
-            case scheduled
-            case started
-            case eligibilityEligible
-            case eligibilityTerminal
-            case eligibilityTransient
-            case setupJoining
-            case engineScheduling
-            case handedOff
-            case cancelled
-            case superseded
-            case retryScheduled
-            case retryStarted
-            case repositoryAuthorityDetached
         }
 
         struct CodemapGraphIndexBuildStoreEvent: Hashable {


### PR DESCRIPTION
## Summary
- make `CodemapGraphIndexBuildStoreEventKind` visible in all build configurations
- keep graph-index event storage, test launch policy, and event recording behavior DEBUG-only

## Root cause
The Release compiler sees `recordCodemapGraphIndexBuildStoreEvent` and its enum-member call sites, but #621 declared the parameter type inside a broad `#if DEBUG` block. Debug CI therefore compiled while release packaging failed before enum-member inference.

## Validation
- repository commit preflight passed
- repository push preflight passed
- no local builds, tests, lint, pr-ready, conductor jobs, or app lifecycle actions were run; hosted CI and Release Candidate remain authoritative