### PR TITLE
Make async test oracles deterministic

### DIFF
--- a/Tests/RepoPromptTests/Helpers/CodemapSeamTestSupport.swift
+++ b/Tests/RepoPromptTests/Helpers/CodemapSeamTestSupport.swift
@@ -10,6 +10,38 @@ class WorkspaceFileContextStoreCodemapSeamTestSupport: XCTestCase {
         return WorkspaceCodemapBindingEnginePolicy(maximumManifestAdoptionRecordCount: recordLimit)
     }
 
+    func awaitCodemapGraphsReady(
+        store: WorkspaceFileContextStore,
+        rootIDs: Set<UUID>,
+        timeout: Duration = .seconds(60)
+    ) async throws -> [WorkspaceCodemapRootStatusSnapshot] {
+        precondition(!rootIDs.isEmpty)
+        let updates = await store.codemapRootStatusUpdates()
+        return try await withThrowingTaskGroup(of: [WorkspaceCodemapRootStatusSnapshot].self) { group in
+            group.addTask {
+                for await update in updates {
+                    try Task.checkCancellation()
+                    let roots = update.roots.filter { rootIDs.contains($0.rootEpoch.rootID) }
+                    if roots.count == rootIDs.count, roots.allSatisfy({ $0.availability == .ready }) {
+                        return roots.sorted {
+                            workspaceCodemapRootEpochPrecedes($0.rootEpoch, $1.rootEpoch)
+                        }
+                    }
+                }
+                throw CodemapStoreTestError.timedOut
+            }
+            group.addTask {
+                try await Task.sleep(for: timeout)
+                throw CodemapStoreTestError.timedOut
+            }
+            defer { group.cancelAll() }
+            guard let result = try await group.next() else {
+                throw CodemapStoreTestError.timedOut
+            }
+            return result
+        }
+    }
+
     func waitForCompletionBeforeExternalDeadline(
         _ completion: CodemapBoundedCompletionState,
         clock: ContinuousClock,

--- a/Tests/RepoPromptTests/MCP/AgentRunWorktreeStartTests.swift
+++ b/Tests/RepoPromptTests/MCP/AgentRunWorktreeStartTests.swift
@@ -2520,7 +2520,7 @@ final class AgentRunWorktreeStartTests: AgentRunWorktreeStartGitSeedTestCase {
         XCTAssertEqual(releasedOwnership.installedOwnerCount, 0)
         XCTAssertEqual(releasedOwnership.rootClaimCount, 0)
 
-        await fulfillment(of: [rootRemovalAcknowledged], timeout: 1)
+        await fulfillment(of: [rootRemovalAcknowledged], timeout: TestFenceDefaults.enterWait)
         await window.workspaceFileContextStore.setRootUnloadTerminationDidCompleteHandler(nil)
         let rootsAfterUnbind = await window.workspaceFileContextStore.roots()
         XCTAssertFalse(rootsAfterUnbind.contains { $0.id == physicalRoot.id })

--- a/Tests/RepoPromptTests/MCP/AgentRunWorktreeStartTests.swift
+++ b/Tests/RepoPromptTests/MCP/AgentRunWorktreeStartTests.swift
@@ -2505,17 +2505,25 @@ final class AgentRunWorktreeStartTests: AgentRunWorktreeStartGitSeedTestCase {
         XCTAssertEqual(repeatedDiagnostics.first { $0.rootID == physicalRoot.id }?.crawlCount, 1)
         XCTAssertEqual(repeatedDiagnostics.first { $0.rootID == physicalRoot.id }?.sessionWorktreeOwnerCount, 1)
 
+        let rootRemovalAcknowledged = expectation(description: "session worktree root removal completed")
+        await window.workspaceFileContextStore.setRootUnloadTerminationDidCompleteHandler { diagnostics in
+            guard diagnostics.watcherStopReports.contains(where: { $0.rootID == physicalRoot.id }) else { return }
+            rootRemovalAcknowledged.fulfill()
+        }
         _ = try await viewModel.transitionWorktreeBindings(
             [],
             forSessionID: sessionID,
             intent: .externalManagement
         )
         XCTAssertTrue(session.worktreeBindings.isEmpty)
-        let rootsAfterUnbind = await window.workspaceFileContextStore.roots()
-        XCTAssertFalse(rootsAfterUnbind.contains { $0.id == physicalRoot.id })
         let releasedOwnership = await window.workspaceFileContextStore.sessionWorktreeOwnershipDebugSnapshotForTesting()
         XCTAssertEqual(releasedOwnership.installedOwnerCount, 0)
         XCTAssertEqual(releasedOwnership.rootClaimCount, 0)
+
+        await fulfillment(of: [rootRemovalAcknowledged], timeout: 1)
+        await window.workspaceFileContextStore.setRootUnloadTerminationDidCompleteHandler(nil)
+        let rootsAfterUnbind = await window.workspaceFileContextStore.roots()
+        XCTAssertFalse(rootsAfterUnbind.contains { $0.id == physicalRoot.id })
     }
 
     func testBindingTransitionValidatesAndMaterializesChangedSecondaryBindingWithoutRestartingPrimaryIdentity() async throws {

--- a/Tests/RepoPromptTests/WorkspaceContext/CodemapAutomaticSelectionGraphNativeTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/CodemapAutomaticSelectionGraphNativeTests.swift
@@ -173,28 +173,16 @@ final class CodemapAutomaticSelectionGraphNativeTests: WorkspaceFileContextStore
         }
         let automaticDemandTicketOffset = fixture.demandedTickets.values.count
 
-        let clock = ContinuousClock()
-        let deadline = clock.now.advanced(by: .seconds(60))
-        var resolved: WorkspaceCodemapAutomaticSelectionResult?
-        while clock.now < deadline {
-            let identities = await store.codemapAutomaticSelectionSourceIdentities(
-                forFileIDs: [source.id],
-                rootScope: .visibleWorkspace
-            )
-            if let identity = identities.first {
-                let result = try await store.resolveAutomaticCodemapSelection(
-                    sources: [identity],
-                    rootScope: .visibleWorkspace
-                )
-                if result.targets.contains(where: { $0.fileID == target.id }), result.receipt != nil {
-                    resolved = result
-                    break
-                }
-            }
-            try await Task.sleep(for: .milliseconds(25))
-        }
-
-        let result = try XCTUnwrap(resolved)
+        _ = try await awaitCodemapGraphsReady(store: store, rootIDs: [loaded.id])
+        let identities = await store.codemapAutomaticSelectionSourceIdentities(
+            forFileIDs: [source.id],
+            rootScope: .visibleWorkspace
+        )
+        let identity = try XCTUnwrap(identities.first)
+        let result = try await store.resolveAutomaticCodemapSelection(
+            sources: [identity],
+            rootScope: .visibleWorkspace
+        )
         XCTAssertEqual(result.targets.map(\.fileID), [target.id])
         XCTAssertFalse(result.targets.contains { $0.fileID == source.id || $0.fileID == unrelated.id })
         let buildCountBeforeRepeatQuery = fixture.buildCount.value
@@ -291,47 +279,26 @@ final class CodemapAutomaticSelectionGraphNativeTests: WorkspaceFileContextStore
         let secondSource = try XCTUnwrap(secondFiles.first { $0.standardizedRelativePath == "Sources/Source.swift" })
         let secondTarget = try XCTUnwrap(secondFiles.first { $0.standardizedRelativePath == "Sources/Target.swift" })
 
-        let clock = ContinuousClock()
-        let deadline = clock.now.advanced(by: .seconds(60))
-        var isolated: WorkspaceCodemapAutomaticSelectionResult?
-        var merged: WorkspaceCodemapAutomaticSelectionResult?
-        while clock.now < deadline {
-            let identities = await store.codemapAutomaticSelectionSourceIdentities(
-                forFileIDs: [firstSource.id, secondSource.id],
-                rootScope: .visibleWorkspace
-            )
-            if identities.count == 2 {
-                let orderedIdentities = identities.sorted {
-                    workspaceCodemapRootEpochPrecedes($0.rootEpoch, $1.rootEpoch)
-                }
-                let expectedOrderedRootIDs = orderedIdentities.map(\.rootEpoch.rootID)
-                let targetByRoot = [firstRoot.id: firstTarget.id, secondRoot.id: secondTarget.id]
-                let expectedOrderedTargetIDs = expectedOrderedRootIDs.compactMap { targetByRoot[$0] }
-                let firstIdentity = try XCTUnwrap(identities.first { $0.fileID == firstSource.id })
-                let firstResult = try await store.resolveAutomaticCodemapSelection(
-                    sources: [firstIdentity],
-                    rootScope: .visibleWorkspace
-                )
-                let mergedResult = try await store.resolveAutomaticCodemapSelection(
-                    sources: Array(identities.reversed()),
-                    rootScope: .visibleWorkspace
-                )
-                if firstResult.targets.map(\.fileID) == [firstTarget.id],
-                   mergedResult.roots.map(\.rootEpoch.rootID) == expectedOrderedRootIDs,
-                   mergedResult.targets.map(\.fileID) == expectedOrderedTargetIDs
-                {
-                    isolated = firstResult
-                    merged = mergedResult
-                    break
-                }
-            }
-            try await Task.sleep(for: .milliseconds(25))
-        }
-
-        let isolatedResult = try XCTUnwrap(isolated)
+        _ = try await awaitCodemapGraphsReady(
+            store: store,
+            rootIDs: [firstRoot.id, secondRoot.id]
+        )
+        let identities = await store.codemapAutomaticSelectionSourceIdentities(
+            forFileIDs: [firstSource.id, secondSource.id],
+            rootScope: .visibleWorkspace
+        )
+        XCTAssertEqual(identities.count, 2)
+        let firstIdentity = try XCTUnwrap(identities.first { $0.fileID == firstSource.id })
+        let isolatedResult = try await store.resolveAutomaticCodemapSelection(
+            sources: [firstIdentity],
+            rootScope: .visibleWorkspace
+        )
         XCTAssertEqual(isolatedResult.targets.map(\.fileID), [firstTarget.id])
         XCTAssertFalse(isolatedResult.targets.contains { $0.fileID == secondTarget.id })
-        let mergedResult = try XCTUnwrap(merged)
+        let mergedResult = try await store.resolveAutomaticCodemapSelection(
+            sources: Array(identities.reversed()),
+            rootScope: .visibleWorkspace
+        )
         let expectedRootIDs = mergedResult.roots.map(\.rootEpoch).sorted(
             by: workspaceCodemapRootEpochPrecedes
         ).map(\.rootID)
@@ -388,6 +355,7 @@ final class CodemapAutomaticSelectionGraphNativeTests: WorkspaceFileContextStore
         for source in sources {
             _ = try await waitForAutomaticSelection(
                 store: store,
+                rootIDs: [source.rootID],
                 sourceFileIDs: [source.id],
                 expectedTargetFileIDs: [XCTUnwrap(targetsByRoot[source.rootID])]
             )
@@ -466,36 +434,18 @@ final class CodemapAutomaticSelectionGraphNativeTests: WorkspaceFileContextStore
             $0.standardizedRelativePath == "Sources/Target.swift"
         })
 
-        let clock = ContinuousClock()
-        let deadline = clock.now.advanced(by: .seconds(60))
-        var resolved: WorkspaceCodemapAutomaticSelectionResult?
-        var lastCandidate: WorkspaceCodemapAutomaticSelectionResult?
-        while clock.now < deadline {
-            let identities = await store.codemapAutomaticSelectionSourceIdentities(
-                forFileIDs: [budgetSource.id, healthySource.id],
-                rootScope: .visibleWorkspace
-            )
-            if identities.count == 2 {
-                let candidate = try await store.resolveAutomaticCodemapSelection(
-                    sources: Array(identities.reversed()),
-                    rootScope: .visibleWorkspace
-                )
-                lastCandidate = candidate
-                let budgetResult = candidate.roots.first { $0.rootEpoch.rootID == budgetRoot.id }
-                let healthyResult = candidate.roots.first { $0.rootEpoch.rootID == healthyRoot.id }
-                if budgetResult?.issues.contains(.budget(.referenceFailureLimit(attempted: 1, limit: 0))) == true,
-                   healthyResult?.targets.map(\.fileID) == [healthyTarget.id]
-                {
-                    resolved = candidate
-                    break
-                }
-            }
-            try await Task.sleep(for: .milliseconds(25))
-        }
-
-        let result = try XCTUnwrap(
-            resolved,
-            "Timed out waiting for independent budget/healthy root results; last candidate: \(String(describing: lastCandidate))"
+        _ = try await awaitCodemapGraphsReady(
+            store: store,
+            rootIDs: [budgetRoot.id, healthyRoot.id]
+        )
+        let identities = await store.codemapAutomaticSelectionSourceIdentities(
+            forFileIDs: [budgetSource.id, healthySource.id],
+            rootScope: .visibleWorkspace
+        )
+        XCTAssertEqual(identities.count, 2)
+        let result = try await store.resolveAutomaticCodemapSelection(
+            sources: Array(identities.reversed()),
+            rootScope: .visibleWorkspace
         )
         let budgetResult = try XCTUnwrap(result.roots.first { $0.rootEpoch.rootID == budgetRoot.id })
         let healthyResult = try XCTUnwrap(result.roots.first { $0.rootEpoch.rootID == healthyRoot.id })
@@ -548,6 +498,7 @@ final class CodemapAutomaticSelectionGraphNativeTests: WorkspaceFileContextStore
         let target = try XCTUnwrap(files.first { $0.standardizedRelativePath == "Sources/Target.swift" })
         _ = try await waitForAutomaticSelection(
             store: store,
+            rootIDs: [root.id],
             sourceFileIDs: [source.id],
             expectedTargetFileIDs: [target.id]
         )
@@ -603,6 +554,7 @@ final class CodemapAutomaticSelectionGraphNativeTests: WorkspaceFileContextStore
         let target = try XCTUnwrap(files.first { $0.standardizedRelativePath == "Sources/Target.swift" })
         _ = try await waitForAutomaticSelection(
             store: store,
+            rootIDs: [root.id],
             sourceFileIDs: [source.id],
             expectedTargetFileIDs: [target.id]
         )
@@ -662,6 +614,7 @@ final class CodemapAutomaticSelectionGraphNativeTests: WorkspaceFileContextStore
         let target = try XCTUnwrap(files.first { $0.standardizedRelativePath == "Sources/Target.swift" })
         _ = try await waitForAutomaticSelection(
             store: store,
+            rootIDs: [root.id],
             sourceFileIDs: [source.id],
             expectedTargetFileIDs: [target.id]
         )
@@ -734,6 +687,7 @@ final class CodemapAutomaticSelectionGraphNativeTests: WorkspaceFileContextStore
         let target = try XCTUnwrap(files.first { $0.standardizedRelativePath == "Sources/Target.swift" })
         _ = try await waitForAutomaticSelection(
             store: store,
+            rootIDs: [root.id],
             sourceFileIDs: [source.id],
             expectedTargetFileIDs: [target.id]
         )
@@ -808,6 +762,7 @@ final class CodemapAutomaticSelectionGraphNativeTests: WorkspaceFileContextStore
         let second = try XCTUnwrap(files.first { $0.standardizedRelativePath == "Sources/Second.swift" })
         _ = try await waitForAutomaticSelection(
             store: store,
+            rootIDs: [root.id],
             sourceFileIDs: [source.id],
             expectedTargetFileIDs: [first.id, second.id]
         )
@@ -852,6 +807,7 @@ final class CodemapAutomaticSelectionGraphNativeTests: WorkspaceFileContextStore
         let second = try XCTUnwrap(files.first { $0.standardizedRelativePath == "Sources/Second.swift" })
         _ = try await waitForAutomaticSelection(
             store: store,
+            rootIDs: [root.id],
             sourceFileIDs: [source.id],
             expectedTargetFileIDs: [first.id, second.id]
         )
@@ -910,6 +866,7 @@ final class CodemapAutomaticSelectionGraphNativeTests: WorkspaceFileContextStore
         })
         let first = try await waitForAutomaticSelection(
             store: store,
+            rootIDs: [firstRoot.id],
             sourceFileIDs: [firstSource.id],
             expectedTargetFileIDs: [firstTarget.id]
         )
@@ -933,6 +890,7 @@ final class CodemapAutomaticSelectionGraphNativeTests: WorkspaceFileContextStore
         })
         let reloaded = try await waitForAutomaticSelection(
             store: store,
+            rootIDs: [reloadedRoot.id],
             sourceFileIDs: [reloadedSource.id],
             expectedTargetFileIDs: [reloadedTarget.id]
         )
@@ -968,27 +926,18 @@ final class CodemapAutomaticSelectionGraphNativeTests: WorkspaceFileContextStore
         let first = try XCTUnwrap(files.first { $0.standardizedRelativePath == "Sources/First.swift" })
         let second = try XCTUnwrap(files.first { $0.standardizedRelativePath == "Sources/Second.swift" })
 
-        let clock = ContinuousClock()
-        let deadline = clock.now.advanced(by: .seconds(60))
-        var resolved: WorkspaceCodemapAutomaticSelectionResult?
-        while clock.now < deadline {
-            let identities = await store.codemapAutomaticSelectionSourceIdentities(
-                forFileIDs: [source.id],
-                rootScope: .visibleWorkspace
-            )
-            if let identity = identities.first {
-                let candidate = try await store.resolveAutomaticCodemapSelection(
-                    sources: [identity],
-                    rootScope: .visibleWorkspace
-                )
-                if Set(candidate.targets.map(\.fileID)) == Set([first.id, second.id]), candidate.receipt != nil {
-                    resolved = candidate
-                    break
-                }
-            }
-            try await Task.sleep(for: .milliseconds(25))
-        }
-        let receipt = try XCTUnwrap(resolved?.receipt)
+        _ = try await awaitCodemapGraphsReady(store: store, rootIDs: [loaded.id])
+        let identities = await store.codemapAutomaticSelectionSourceIdentities(
+            forFileIDs: [source.id],
+            rootScope: .visibleWorkspace
+        )
+        let identity = try XCTUnwrap(identities.first)
+        let resolved = try await store.resolveAutomaticCodemapSelection(
+            sources: [identity],
+            rootScope: .visibleWorkspace
+        )
+        XCTAssertEqual(Set(resolved.targets.map(\.fileID)), Set([first.id, second.id]))
+        let receipt = try XCTUnwrap(resolved.receipt)
 
         try "struct FirstTarget { let changed: Bool }\n".write(
             to: rootURL.appendingPathComponent("Sources/First.swift"),
@@ -1000,18 +949,10 @@ final class CodemapAutomaticSelectionGraphNativeTests: WorkspaceFileContextStore
             deltas: [.fileModified("Sources/First.swift", Date())]
         )
 
-        var revalidation = await store.revalidateAutomaticCodemapSelection(
+        let revalidation = await store.revalidateAutomaticCodemapSelection(
             receipt,
             rootScope: .visibleWorkspace
         )
-        let mutationDeadline = clock.now.advanced(by: .seconds(10))
-        while revalidation.validTargets.contains(where: { $0.fileID == first.id }), clock.now < mutationDeadline {
-            try await Task.sleep(for: .milliseconds(25))
-            revalidation = await store.revalidateAutomaticCodemapSelection(
-                receipt,
-                rootScope: .visibleWorkspace
-            )
-        }
         XCTAssertEqual(revalidation.validTargets.map(\.fileID), [second.id])
         XCTAssertTrue(revalidation.issues.contains(.targetGenerationChanged(
             rootEpoch: receipt.roots[0].rootEpoch,
@@ -1049,6 +990,7 @@ final class CodemapAutomaticSelectionGraphNativeTests: WorkspaceFileContextStore
         let target = try XCTUnwrap(files.first { $0.standardizedRelativePath == "Sources/Target.swift" })
         _ = try await waitForAutomaticSelection(
             store: store,
+            rootIDs: [root.id],
             sourceFileIDs: [source.id],
             expectedTargetFileIDs: [target.id]
         )
@@ -1152,27 +1094,22 @@ final class CodemapAutomaticSelectionGraphNativeTests: WorkspaceFileContextStore
 
     private func waitForAutomaticSelection(
         store: WorkspaceFileContextStore,
+        rootIDs: Set<UUID>,
         sourceFileIDs: [UUID],
         expectedTargetFileIDs: [UUID]
     ) async throws -> WorkspaceCodemapAutomaticSelectionResult {
-        let clock = ContinuousClock()
-        let deadline = clock.now.advanced(by: .seconds(60))
-        while clock.now < deadline {
-            let identities = await store.codemapAutomaticSelectionSourceIdentities(
-                forFileIDs: sourceFileIDs,
-                rootScope: .visibleWorkspace
-            )
-            if identities.count == sourceFileIDs.count {
-                let result = try await store.resolveAutomaticCodemapSelection(
-                    sources: identities,
-                    rootScope: .visibleWorkspace
-                )
-                if result.targets.map(\.fileID) == expectedTargetFileIDs, result.receipt != nil {
-                    return result
-                }
-            }
-            try await Task.sleep(for: .milliseconds(25))
-        }
-        throw CodemapStoreTestError.timedOut
+        _ = try await awaitCodemapGraphsReady(store: store, rootIDs: rootIDs)
+        let identities = await store.codemapAutomaticSelectionSourceIdentities(
+            forFileIDs: sourceFileIDs,
+            rootScope: .visibleWorkspace
+        )
+        XCTAssertEqual(identities.count, sourceFileIDs.count)
+        let result = try await store.resolveAutomaticCodemapSelection(
+            sources: identities,
+            rootScope: .visibleWorkspace
+        )
+        XCTAssertEqual(result.targets.map(\.fileID), expectedTargetFileIDs)
+        XCTAssertNotNil(result.receipt)
+        return result
     }
 }

--- a/Tests/RepoPromptTests/Workspaces/WorkspaceSavePreparationTests.swift
+++ b/Tests/RepoPromptTests/Workspaces/WorkspaceSavePreparationTests.swift
@@ -5,6 +5,9 @@ import XCTest
     @MainActor
     final class WorkspaceSavePreparationTests: XCTestCase {
         private var originalMCPAutoStart = false
+        private var savePreparationGates: [WorkspaceSavePreparationGate] = []
+        private var saveTasks: [Task<Void, Never>] = []
+        private var managersWithSavePreparationHooks: [WorkspaceManagerViewModel] = []
 
         override func setUp() async throws {
             try await super.setUp()
@@ -14,6 +17,17 @@ import XCTest
         }
 
         override func tearDown() async throws {
+            for managersWithSavePreparationHook in managersWithSavePreparationHooks {
+                managersWithSavePreparationHook.setWorkspaceSavePreparationDidFinishHandlerForTesting(nil)
+            }
+            savePreparationGates.forEach { $0.cancel() }
+            saveTasks.forEach { $0.cancel() }
+            for saveTask in saveTasks {
+                await saveTask.value
+            }
+            managersWithSavePreparationHooks.removeAll()
+            savePreparationGates.removeAll()
+            saveTasks.removeAll()
             await WorkspaceManagerViewModel.WorkspaceDiskWriter.shared.removeAllForTesting()
             GlobalSettingsStore.shared.setMCPAutoStart(originalMCPAutoStart, commit: false)
             try await super.tearDown()
@@ -33,20 +47,23 @@ import XCTest
             manager.markWorkspaceDirty()
 
             let gate = WorkspaceSavePreparationGate()
+            savePreparationGates.append(gate)
+            managersWithSavePreparationHooks.append(manager)
             manager.setWorkspaceSavePreparationDidFinishHandlerForTesting { workspaceID, fileURL, _ in
                 await gate.arriveAndWait(workspaceID: workspaceID, fileURL: fileURL)
             }
             let saveTask = Task { @MainActor in
                 await manager.pollAndSaveStateAsync()
             }
-            let arrival = await gate.waitUntilArrived()
+            saveTasks.append(saveTask)
+            let arrival = try await gate.waitUntilArrivedAndBlocked()
             XCTAssertEqual(arrival.workspaceID, workspaceA.id)
             XCTAssertEqual(arrival.fileURL, manager.workspaceFileURL(for: workspaceA))
             try manager.workspaces.swapAt(
                 XCTUnwrap(manager.workspaces.firstIndex { $0.id == workspaceA.id }),
                 XCTUnwrap(manager.workspaces.firstIndex { $0.id == workspaceB.id })
             )
-            await gate.release()
+            gate.release()
             await saveTask.value
             manager.setWorkspaceSavePreparationDidFinishHandlerForTesting(nil)
 
@@ -69,15 +86,18 @@ import XCTest
             let expectedURL = manager.workspaceFileURL(for: workspace)
 
             let gate = WorkspaceSavePreparationGate()
+            savePreparationGates.append(gate)
+            managersWithSavePreparationHooks.append(manager)
             manager.setWorkspaceSavePreparationDidFinishHandlerForTesting { workspaceID, fileURL, _ in
                 await gate.arriveAndWait(workspaceID: workspaceID, fileURL: fileURL)
             }
             let saveTask = Task { @MainActor in
                 await manager.pollAndSaveStateAsync()
             }
-            _ = await gate.waitUntilArrived()
+            saveTasks.append(saveTask)
+            _ = try await gate.waitUntilArrivedAndBlocked()
             manager.workspaces.removeAll { $0.id == workspace.id }
-            await gate.release()
+            gate.release()
             await saveTask.value
             manager.setWorkspaceSavePreparationDidFinishHandlerForTesting(nil)
 
@@ -189,36 +209,102 @@ import XCTest
         }
     }
 
-    private actor WorkspaceSavePreparationGate {
+    private final class WorkspaceSavePreparationGate: @unchecked Sendable {
         struct Arrival {
             let workspaceID: UUID
             let fileURL: URL
         }
 
+        private let condition = NSCondition()
+        private let releaseFence = TestReleaseFence(name: "workspace save preparation gate")
         private var arrival: Arrival?
-        private var arrivalWaiters: [CheckedContinuation<Arrival, Never>] = []
-        private var releaseContinuation: CheckedContinuation<Void, Never>?
+        private var arrivalWaiters: [UUID: CheckedContinuation<Arrival?, Never>] = [:]
+        private var cancelledArrivalWaiters = Set<UUID>()
+        private var isCancelled = false
 
         func arriveAndWait(workspaceID: UUID, fileURL: URL) async {
-            let value = Arrival(workspaceID: workspaceID, fileURL: fileURL)
-            arrival = value
-            arrivalWaiters.forEach { $0.resume(returning: value) }
-            arrivalWaiters.removeAll()
-            await withCheckedContinuation { continuation in
-                releaseContinuation = continuation
-            }
+            recordArrival(Arrival(workspaceID: workspaceID, fileURL: fileURL))
+            await releaseFence.enterAndWait()
         }
 
-        func waitUntilArrived() async -> Arrival {
-            if let arrival { return arrival }
-            return await withCheckedContinuation { continuation in
-                arrivalWaiters.append(continuation)
+        func waitUntilArrivedAndBlocked() async throws -> Arrival {
+            guard let arrival = await waitUntilArrived() else {
+                throw CancellationError()
             }
+            guard await releaseFence.waitUntilEntered() else {
+                throw CancellationError()
+            }
+            return arrival
         }
 
         func release() {
-            releaseContinuation?.resume()
-            releaseContinuation = nil
+            releaseFence.release()
+        }
+
+        func cancel() {
+            condition.lock()
+            isCancelled = true
+            let pending = Array(arrivalWaiters.values)
+            arrivalWaiters.removeAll()
+            cancelledArrivalWaiters.removeAll()
+            condition.broadcast()
+            condition.unlock()
+            pending.forEach { $0.resume(returning: nil) }
+            releaseFence.release()
+        }
+
+        private func waitUntilArrived() async -> Arrival? {
+            let waiterID = UUID()
+            return await withTaskCancellationHandler {
+                await withCheckedContinuation { continuation in
+                    registerArrivalWaiter(continuation, waiterID: waiterID)
+                }
+            } onCancel: {
+                cancelArrivalWaiter(waiterID)
+            }
+        }
+
+        private func recordArrival(_ value: Arrival) {
+            condition.lock()
+            guard !isCancelled else {
+                condition.unlock()
+                return
+            }
+            arrival = value
+            let pending = Array(arrivalWaiters.values)
+            arrivalWaiters.removeAll()
+            cancelledArrivalWaiters.removeAll()
+            condition.broadcast()
+            condition.unlock()
+            pending.forEach { $0.resume(returning: value) }
+        }
+
+        private func registerArrivalWaiter(
+            _ continuation: CheckedContinuation<Arrival?, Never>,
+            waiterID: UUID
+        ) {
+            condition.lock()
+            if let arrival {
+                condition.unlock()
+                continuation.resume(returning: arrival)
+            } else if isCancelled || Task.isCancelled || cancelledArrivalWaiters.remove(waiterID) != nil {
+                condition.unlock()
+                continuation.resume(returning: nil)
+            } else {
+                arrivalWaiters[waiterID] = continuation
+                condition.unlock()
+            }
+        }
+
+        private func cancelArrivalWaiter(_ waiterID: UUID) {
+            condition.lock()
+            let continuation = arrivalWaiters.removeValue(forKey: waiterID)
+            if continuation == nil {
+                cancelledArrivalWaiters.insert(waiterID)
+            }
+            condition.broadcast()
+            condition.unlock()
+            continuation?.resume(returning: nil)
         }
     }
 


### PR DESCRIPTION
## Summary

This is one focused, test-only follow-up to the async timing failures observed after [PR #621](https://github.com/repoprompt/repoprompt-ce/pull/621). It replaces three wall-clock or scheduler-dependent behavioral oracles with acknowledgement from the subsystem that owns completion.

### 1. Graph-native codemap readiness

- Await the store's root-status publication for a complete, current committed graph before issuing one automatic-selection query.
- Revalidate mutation receipts once after the existing synchronous invalidation/fence acknowledgement.
- Remove repeated 25 ms polling and result-shaped retry loops from the real-store tests.

The strict product contracts remain unchanged: cross-root isolation and deterministic merge ordering, receipt/fence revalidation, healthy-root coexistence under graph budgets, demand/ticket cleanup, size and demand caps, manual override/reset behavior, and canonical target ordering.

### 2. Workspace-save preparation gates

- Replace the fragile single continuation with a cancellation-safe arrival/release fence.
- Track gates, save tasks, and installed hooks so teardown always releases and drains them.
- Wait until preparation is both observed and blocked before mutating workspace ordering/removal.

This preserves exact captured workspace identity/URL, removal-before-enqueue behavior, acknowledgement boundaries, and the single same-identity retry contract. It addresses the hosted failures where [main CI run 30148583986](https://github.com/repoprompt/repoprompt-ce/actions/runs/30148583986) failed the retry identity assertion and [run 30164799288](https://github.com/repoprompt/repoprompt-ce/actions/runs/30164799288) later hung the reorder case until the 180-second suite watchdog.

### 3. Session-worktree root teardown

- Observe root-unload termination completion before asserting that the physical session-worktree root is absent.
- Keep the existing strict ownership and no-codemap-work assertions.

This preserves immediate binding/ownership release while making the filesystem watcher/root teardown assertion follow the owning completion event.

## Determinism and scope

- No retries, sleeps, or timeout increases were added.
- No executable test IDs or ledger rows changed.
- No production source or shared CI workflow changed.
- The three fixes touch disjoint test boundaries and do not relax their outcomes.
- The known ledger mismatch (14 missing / 4 stale Codex liveness IDs) reproduces on this branch and is unrelated to these unchanged test IDs; this PR intentionally does not modify it.

## Validation

- `make dev-test FILTER=CodemapAutomaticSelectionGraphNativeTests` — 16 passed
- `make dev-test FILTER=WorkspaceSavePreparationTests` — 5 passed
- `make dev-test FILTER='AgentRunWorktreeStartTests/testBindingTransitionMaterializesSessionWorktreeWithoutCodemapWork'` — 1 passed
- `make dev-test-list` — passed
- `make dev-lint` — passed
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh push` — passed
- Combined Oracle review — no findings
