### PR TITLE
Fix Finder launch and install commands when only Xcode beta is installed

### DIFF
--- a/Launch RepoPrompt CE.command
+++ b/Launch RepoPrompt CE.command
@@ -3,6 +3,7 @@ set -uo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONDUCTOR="$ROOT_DIR/conductor"
+FULL_XCODE_RESOLVER="$ROOT_DIR/Scripts/resolve_full_xcode_developer_dir.sh"
 APP_ARGS=("$@")
 
 if ! command -v python3 >/dev/null 2>&1; then
@@ -19,7 +20,23 @@ elif [[ ! -x "$CONDUCTOR" ]]; then
     echo "Make sure this file is still in the repoprompt-ce folder and that conductor is executable."
     read -r -p "Press Return to close this window..." || true
     exit 1
+elif [[ ! -x "$FULL_XCODE_RESOLVER" ]]; then
+    echo "Couldn't find the full-Xcode resolver:"
+    echo "$FULL_XCODE_RESOLVER"
+    echo
+    echo "Make sure the repository's Scripts folder is complete, then reopen this launcher."
+    read -r -p "Press Return to close this window..." || true
+    exit 1
 fi
+
+if ! DEVELOPER_DIR="$("$FULL_XCODE_RESOLVER")"; then
+    echo
+    echo "Couldn't select a compatible full Xcode installation."
+    echo "Install Xcode in /Applications or set DEVELOPER_DIR to its Contents/Developer folder, then retry."
+    read -r -p "Press Return to close this window..." || true
+    exit 1
+fi
+export DEVELOPER_DIR
 
 launch_app() {
     echo
@@ -110,6 +127,7 @@ echo "RepoPrompt CE — local debug launcher"
 echo
 echo "Project: $ROOT_DIR"
 echo "Mode:    coordinated (builds and launches run through the dev daemon)"
+echo "Xcode:   $DEVELOPER_DIR"
 
 cd "$ROOT_DIR" || exit 1
 launch_app

--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ The launcher requires Python 3, builds RepoPrompt CE through the coordinated
 developer daemon, opens the debug app, and keeps a small terminal window
 available for rebuild, status, and stop controls. It does not provide an
 uncoordinated no-Python fallback because lifecycle actions validate the exact
-debug executable path.
+debug executable path. It preserves an explicit compatible `DEVELOPER_DIR`, or
+selects an installed full Xcode for the launcher process without changing the
+system-wide `xcode-select` setting.
 
 The debug launcher uses an available `Apple Development:` signing identity. If
 your Mac does not have one, run the same debug app from Terminal with explicit
@@ -87,6 +89,9 @@ in Finder. The Finder launcher uses the coordinated developer daemon.
 The installer builds RepoPrompt CE from source and replaces any existing
 `/Applications/RepoPrompt CE.app` using a dedicated self-signed certificate
 trusted only on your Mac. macOS may ask you to approve the certificate.
+It requires a full Xcode installation and selects a compatible installed Xcode
+for the installer process without changing your system-wide `xcode-select`
+setting.
 
 The resulting app is local-only. It is not notarized and should not be copied to
 another Mac or redistributed.
@@ -94,7 +99,8 @@ another Mac or redistributed.
 ### Source-build requirements
 
 - macOS 26 or later
-- Xcode 26, or matching Command Line Tools with the macOS 26 SDK
+- Xcode 26, or matching Command Line Tools with the macOS 26 SDK. The Finder
+  debug launcher and local production installer require the full Xcode app.
 
 ### Develop in Xcode
 

--- a/Scripts/install_local_production.sh
+++ b/Scripts/install_local_production.sh
@@ -16,6 +16,7 @@ LOCAL_SIGNING_IDENTITY_REGISTRY_PATH="${LOCAL_SIGNING_IDENTITY_REGISTRY_PATH:-$H
 LOCAL_SIGNING_IDENTITY_SHA256="${LOCAL_SIGNING_IDENTITY_SHA256:-}"
 ROTATE_LOCAL_SIGNING_IDENTITY="${ROTATE_LOCAL_SIGNING_IDENTITY:-0}"
 LOCAL_SIGNING_IDENTITY_TOOL="$ROOT_DIR/Scripts/local_signing_identity.py"
+FULL_XCODE_RESOLVER="$ROOT_DIR/Scripts/resolve_full_xcode_developer_dir.sh"
 TMP_DIR=""
 STAGED_DIR=""
 STAGED_APP=""
@@ -204,6 +205,11 @@ for command in codesign ditto openssl plutil python3 security shasum swift; do
     require_command "$command"
 done
 [[ -f "$LOCAL_SIGNING_IDENTITY_TOOL" ]] || fail "Missing local signing identity tool: $LOCAL_SIGNING_IDENTITY_TOOL"
+[[ -x "$FULL_XCODE_RESOLVER" ]] || fail "Missing full-Xcode resolver: $FULL_XCODE_RESOLVER"
+
+DEVELOPER_DIR="$("$FULL_XCODE_RESOLVER")"
+export DEVELOPER_DIR
+printf 'Local production Xcode developer directory: %s\n' "$DEVELOPER_DIR"
 
 LOGIN_KEYCHAIN="$(security default-keychain -d user | sed -e 's/^[[:space:]]*"//' -e 's/"[[:space:]]*$//')"
 [[ -n "$LOGIN_KEYCHAIN" && -f "$LOGIN_KEYCHAIN" ]] || fail "Could not resolve the user's default login keychain."
@@ -279,8 +285,7 @@ LOCAL_SELF_SIGNED_RELEASE=1 \
     SIGN_IDENTITY="$SIGN_IDENTITY" \
     "$ROOT_DIR/Scripts/package_app.sh" release
 
-BUILD_DIR="$(swift build -c release --show-bin-path)"
-SOURCE_APP="$BUILD_DIR/$APP_NAME.app"
+SOURCE_APP="$ROOT_DIR/.build/release/$APP_NAME.app"
 [[ -d "$SOURCE_APP" ]] || fail "Missing packaged local production app: $SOURCE_APP"
 [[ "$(plutil -extract RepoPromptSigningMode raw "$SOURCE_APP/Contents/Info.plist")" == "local-self-signed" ]] ||
     fail "Packaged app is missing the local self-signed signing-mode marker."

--- a/Scripts/resolve_full_xcode_developer_dir.sh
+++ b/Scripts/resolve_full_xcode_developer_dir.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MINIMUM_MACOS_SDK_MAJOR=26
+
+fail() {
+    printf 'ERROR: %s\n' "$*" >&2
+    exit 1
+}
+
+developer_dir_is_usable() {
+    local developer_dir="$1"
+    local sdk_version
+
+    [[ -d "$developer_dir" ]] || return 1
+    [[ -x "$developer_dir/usr/bin/xcodebuild" ]] || return 1
+    [[ -d "$developer_dir/Platforms/MacOSX.platform" ]] || return 1
+    if ! sdk_version="$(DEVELOPER_DIR="$developer_dir" xcrun --sdk macosx --show-sdk-version 2>/dev/null)"; then
+        return 1
+    fi
+    [[ "$sdk_version" =~ ^([0-9]+)(\.|$) ]] || return 1
+    (( BASH_REMATCH[1] >= MINIMUM_MACOS_SDK_MAJOR ))
+}
+
+append_candidate() {
+    local candidate="$1"
+    local existing
+    for existing in "${CANDIDATES[@]:-}"; do
+        [[ "$existing" != "$candidate" ]] || return 0
+    done
+    CANDIDATES+=("$candidate")
+}
+
+if [[ -n "${DEVELOPER_DIR:-}" ]]; then
+    developer_dir_is_usable "$DEVELOPER_DIR" ||
+        fail "DEVELOPER_DIR must point to a full Xcode with the macOS $MINIMUM_MACOS_SDK_MAJOR SDK or newer: $DEVELOPER_DIR"
+    printf '%s\n' "$DEVELOPER_DIR"
+    exit 0
+fi
+
+SELECTED_DEVELOPER_DIR="$(xcode-select --print-path 2>/dev/null || true)"
+if [[ -n "$SELECTED_DEVELOPER_DIR" ]] && developer_dir_is_usable "$SELECTED_DEVELOPER_DIR"; then
+    printf '%s\n' "$SELECTED_DEVELOPER_DIR"
+    exit 0
+fi
+
+CANDIDATES=()
+if (( $# )); then
+    for candidate in "$@"; do
+        append_candidate "$candidate"
+    done
+else
+    append_candidate "/Applications/Xcode.app/Contents/Developer"
+    append_candidate "/Applications/Xcode-beta.app/Contents/Developer"
+    shopt -s nullglob
+    for xcode_app in /Applications/Xcode*.app "$HOME"/Applications/Xcode*.app; do
+        append_candidate "$xcode_app/Contents/Developer"
+    done
+    shopt -u nullglob
+fi
+
+for candidate in "${CANDIDATES[@]}"; do
+    case "$candidate" in
+        *[Bb][Ee][Tt][Aa]*) continue ;;
+    esac
+    if developer_dir_is_usable "$candidate"; then
+        printf '%s\n' "$candidate"
+        exit 0
+    fi
+done
+
+for candidate in "${CANDIDATES[@]}"; do
+    case "$candidate" in
+        *[Bb][Ee][Tt][Aa]*) ;;
+        *) continue ;;
+    esac
+    if developer_dir_is_usable "$candidate"; then
+        printf '%s\n' "$candidate"
+        exit 0
+    fi
+done
+
+selection_note=""
+if [[ -n "$SELECTED_DEVELOPER_DIR" ]]; then
+    selection_note=" Current xcode-select path: $SELECTED_DEVELOPER_DIR."
+fi
+fail "RepoPrompt CE requires a full Xcode with the macOS $MINIMUM_MACOS_SDK_MAJOR SDK or newer.$selection_note Install Xcode in /Applications or set DEVELOPER_DIR=/path/to/Xcode.app/Contents/Developer and retry."

--- a/Scripts/test_debug_app_process.py
+++ b/Scripts/test_debug_app_process.py
@@ -125,6 +125,12 @@ class DebugAppProcessTests(unittest.TestCase):
 
 
 class LifecycleSurfaceTests(unittest.TestCase):
+    @staticmethod
+    def copy_finder_launcher(root: Path) -> Path:
+        launcher = root / "Launch RepoPrompt CE.command"
+        launcher.write_text((SCRIPT_DIR.parent / launcher.name).read_text(encoding="utf-8"), encoding="utf-8")
+        return launcher
+
     def test_lifecycle_surfaces_have_no_process_name_kill_fallback(self) -> None:
         run_script = (SCRIPT_DIR / "run.sh").read_text(encoding="utf-8")
         conductor_script = (SCRIPT_DIR / "conductor.py").read_text(encoding="utf-8")
@@ -156,8 +162,7 @@ class LifecycleSurfaceTests(unittest.TestCase):
         self.assertIsNotNone(dirname)
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            launcher = root / "Launch RepoPrompt CE.command"
-            launcher.write_text((SCRIPT_DIR.parent / launcher.name).read_text(encoding="utf-8"), encoding="utf-8")
+            launcher = self.copy_finder_launcher(root)
             bin_dir = root / "bin"
             bin_dir.mkdir()
             (bin_dir / "dirname").symlink_to(dirname)
@@ -177,6 +182,78 @@ class LifecycleSurfaceTests(unittest.TestCase):
         self.assertIn("safe coordinated launcher requires Python 3", result.stdout)
         self.assertIn("No uncoordinated fallback is provided", result.stdout)
         self.assertNotIn("Building and relaunching", result.stdout)
+
+    def test_finder_launcher_exports_resolved_full_xcode_to_conductor(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            launcher = self.copy_finder_launcher(root)
+            scripts = root / "Scripts"
+            scripts.mkdir()
+            developer_dir = root / "Xcode-beta.app" / "Contents" / "Developer"
+            resolver = scripts / "resolve_full_xcode_developer_dir.sh"
+            resolver.write_text(
+                f"#!/usr/bin/env bash\nprintf '%s\\n' {str(developer_dir)!r}\n",
+                encoding="utf-8",
+            )
+            resolver.chmod(0o755)
+            capture = root / "capture.txt"
+            conductor = root / "conductor"
+            conductor.write_text(
+                "#!/usr/bin/env bash\n"
+                "printf '%s\\n' \"$DEVELOPER_DIR\" > \"$LAUNCHER_CAPTURE\"\n"
+                "printf '%s\\n' \"$*\" >> \"$LAUNCHER_CAPTURE\"\n",
+                encoding="utf-8",
+            )
+            conductor.chmod(0o755)
+            env = os.environ.copy()
+            env["LAUNCHER_CAPTURE"] = str(capture)
+            env.pop("DEVELOPER_DIR", None)
+
+            result = subprocess.run(
+                ["/bin/bash", str(launcher)],
+                env=env,
+                input="q\n",
+                text=True,
+                capture_output=True,
+                timeout=5,
+            )
+            captured_lines = capture.read_text(encoding="utf-8").splitlines()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(captured_lines, [str(developer_dir), "app relaunch"])
+        self.assertIn(f"Xcode:   {developer_dir}", result.stdout)
+
+    def test_finder_launcher_resolver_failure_precedes_lifecycle_action(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            launcher = self.copy_finder_launcher(root)
+            scripts = root / "Scripts"
+            scripts.mkdir()
+            resolver = scripts / "resolve_full_xcode_developer_dir.sh"
+            resolver.write_text("#!/usr/bin/env bash\necho 'no compatible Xcode' >&2\nexit 1\n", encoding="utf-8")
+            resolver.chmod(0o755)
+            lifecycle_marker = root / "lifecycle-invoked"
+            conductor = root / "conductor"
+            conductor.write_text(
+                f"#!/usr/bin/env bash\nprintf 'invoked\\n' > {str(lifecycle_marker)!r}\n",
+                encoding="utf-8",
+            )
+            conductor.chmod(0o755)
+
+            result = subprocess.run(
+                ["/bin/bash", str(launcher)],
+                env=os.environ.copy(),
+                input="\n",
+                text=True,
+                capture_output=True,
+                timeout=5,
+            )
+            lifecycle_was_invoked = lifecycle_marker.exists()
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("Couldn't select a compatible full Xcode installation", result.stdout)
+        self.assertIn("no compatible Xcode", result.stderr)
+        self.assertFalse(lifecycle_was_invoked)
 
 
 if __name__ == "__main__":

--- a/Scripts/test_local_production_installer.py
+++ b/Scripts/test_local_production_installer.py
@@ -191,6 +191,110 @@ class LocalProductionIdentityToolTests(unittest.TestCase):
 
 
 class LocalProductionInstallerTests(unittest.TestCase):
+    def test_full_xcode_resolver_preserves_explicit_compatible_developer_dir(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            developer_dir = self.create_fake_xcode(root / "Explicit Xcode.app", sdk_version="27.0")
+            candidate_dir = self.create_fake_xcode(root / "Candidate Xcode.app", sdk_version="27.0")
+            marker = root / "xcode-select-invoked"
+            bin_dir = self.create_xcode_resolver_stubs(root, marker=marker)
+            env = os.environ.copy()
+            env.update(
+                {
+                    "PATH": f"{bin_dir}:{env.get('PATH', '')}",
+                    "DEVELOPER_DIR": str(developer_dir),
+                }
+            )
+
+            result = subprocess.run(
+                [str(SCRIPT_DIR / "resolve_full_xcode_developer_dir.sh"), str(candidate_dir)],
+                env=env,
+                text=True,
+                capture_output=True,
+                timeout=10,
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), str(developer_dir))
+        self.assertFalse(marker.exists())
+
+    def test_full_xcode_resolver_discovers_first_compatible_candidate(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            selected_clt = root / "CommandLineTools"
+            selected_clt.mkdir()
+            old_xcode = self.create_fake_xcode(root / "Xcode-old.app", sdk_version="25.4")
+            compatible_xcode = self.create_fake_xcode(root / "Xcode-beta.app", sdk_version="27.0")
+            bin_dir = self.create_xcode_resolver_stubs(root, selected_path=selected_clt)
+            env = os.environ.copy()
+            env.pop("DEVELOPER_DIR", None)
+            env["PATH"] = f"{bin_dir}:{env.get('PATH', '')}"
+
+            result = subprocess.run(
+                [
+                    str(SCRIPT_DIR / "resolve_full_xcode_developer_dir.sh"),
+                    str(old_xcode),
+                    str(compatible_xcode),
+                ],
+                env=env,
+                text=True,
+                capture_output=True,
+                timeout=10,
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), str(compatible_xcode))
+
+    def test_full_xcode_resolver_prefers_compatible_stable_candidate_over_beta(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            selected_clt = root / "CommandLineTools"
+            selected_clt.mkdir()
+            beta_xcode = self.create_fake_xcode(root / "Xcode-beta.app", sdk_version="27.0")
+            stable_xcode = self.create_fake_xcode(root / "Xcode-26.3.app", sdk_version="26.3")
+            bin_dir = self.create_xcode_resolver_stubs(root, selected_path=selected_clt)
+            env = os.environ.copy()
+            env.pop("DEVELOPER_DIR", None)
+            env["PATH"] = f"{bin_dir}:{env.get('PATH', '')}"
+
+            result = subprocess.run(
+                [
+                    str(SCRIPT_DIR / "resolve_full_xcode_developer_dir.sh"),
+                    str(beta_xcode),
+                    str(stable_xcode),
+                ],
+                env=env,
+                text=True,
+                capture_output=True,
+                timeout=10,
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), str(stable_xcode))
+
+    def test_full_xcode_resolver_fails_actionably_when_no_candidate_is_compatible(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            selected_clt = root / "CommandLineTools"
+            selected_clt.mkdir()
+            old_xcode = self.create_fake_xcode(root / "Xcode-old.app", sdk_version="25.4")
+            bin_dir = self.create_xcode_resolver_stubs(root, selected_path=selected_clt)
+            env = os.environ.copy()
+            env.pop("DEVELOPER_DIR", None)
+            env["PATH"] = f"{bin_dir}:{env.get('PATH', '')}"
+
+            result = subprocess.run(
+                [str(SCRIPT_DIR / "resolve_full_xcode_developer_dir.sh"), str(old_xcode)],
+                env=env,
+                text=True,
+                capture_output=True,
+                timeout=10,
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("requires a full Xcode with the macOS 26 SDK or newer", result.stderr)
+        self.assertIn(str(selected_clt), result.stderr)
+
     def test_finder_launcher_routes_confirmed_install_through_conductor(self) -> None:
         launcher = ROOT_DIR / "Install RepoPrompt CE Local Production.command"
         self.assertTrue(os.access(launcher, os.X_OK))
@@ -285,6 +389,15 @@ class LocalProductionInstallerTests(unittest.TestCase):
             f"{SHA1_A}|{SHA256_A}|{generation}",
         )
         self.assertNotIn("find-identity", context["security_log"].read_text(encoding="utf-8"))
+
+    def test_installer_uses_packager_output_without_reinvoking_swift(self) -> None:
+        result, context = self.run_installer([certificate(SHA1_A, SHA256_A)], expected_sha1=SHA1_A)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertFalse(context["swift_log"].exists())
+        self.assertEqual(
+            (context["install_dir"] / "RepoPrompt CE.app" / "payload.txt").read_text(encoding="utf-8"),
+            "new\n",
+        )
 
     def test_multiple_first_use_candidates_fail_with_fingerprints_and_explicit_selection_succeeds(self) -> None:
         failed, _ = self.run_installer(
@@ -512,6 +625,10 @@ class LocalProductionInstallerTests(unittest.TestCase):
         scripts.mkdir(parents=True)
         shutil.copy2(SCRIPT_DIR / "install_local_production.sh", scripts / "install_local_production.sh")
         shutil.copy2(SCRIPT_DIR / "local_signing_identity.py", scripts / "local_signing_identity.py")
+        shutil.copy2(
+            SCRIPT_DIR / "resolve_full_xcode_developer_dir.sh",
+            scripts / "resolve_full_xcode_developer_dir.sh",
+        )
         if fail_registry_verification or fail_registry_write:
             real_tool = scripts / "local_signing_identity_real.py"
             shutil.move(scripts / "local_signing_identity.py", real_tool)
@@ -548,7 +665,7 @@ class LocalProductionInstallerTests(unittest.TestCase):
             encoding="utf-8",
         )
 
-        build_dir = temp_dir / "build"
+        build_dir = root / ".build" / "release"
         install_dir = temp_dir / "Applications"
         installed_app = install_dir / "RepoPrompt CE.app"
         installed_app.mkdir(parents=True)
@@ -623,7 +740,19 @@ class LocalProductionInstallerTests(unittest.TestCase):
             esac
             """,
         )
-        self.write_stub(bin_dir, "swift", 'printf "%s\\n" "$FAKE_BUILD_DIR"\n')
+        swift_log = temp_dir / "swift.log"
+        self.write_stub(bin_dir, "swift", 'printf "%s\\n" "$*" >> "$SWIFT_LOG"\nexit 97\n')
+        self.write_stub(
+            bin_dir,
+            "xcrun",
+            """\
+            if [[ "$*" == "--sdk macosx --show-sdk-version" && "${DEVELOPER_DIR:-}" == "$FAKE_DEVELOPER_DIR" ]]; then
+                printf '27.0\\n'
+                exit 0
+            fi
+            exit 1
+            """,
+        )
         self.write_stub(
             bin_dir,
             "codesign",
@@ -680,6 +809,7 @@ class LocalProductionInstallerTests(unittest.TestCase):
         )
 
         env = os.environ.copy()
+        fake_developer_dir = self.create_fake_xcode(temp_dir / "Xcode.app", sdk_version="27.0")
         env.update(
             {
                 "PATH": f"{bin_dir}:{env.get('PATH', '')}",
@@ -689,12 +819,14 @@ class LocalProductionInstallerTests(unittest.TestCase):
                 "LOCAL_SIGNING_IDENTITY_INVENTORY_FIXTURE": str(fixture),
                 "LOCAL_SIGNING_IDENTITY_EVALUATED_AT": "2030-01-01T00:00:00Z",
                 "FAKE_BUILD_DIR": str(build_dir),
+                "FAKE_DEVELOPER_DIR": str(fake_developer_dir),
                 "FAKE_KEYCHAIN": str(keychain),
                 "FAKE_INVENTORY_FIXTURE": str(fixture),
                 "FAKE_AFTER_MINT_FIXTURE": str(after_fixture),
                 "FAKE_IMPORTED_IDENTITY": str(import_log),
                 "FAKE_DESIGNATED_SHA1": expected_sha1,
                 "SECURITY_LOG": str(security_log),
+                "SWIFT_LOG": str(swift_log),
                 "PACKAGE_CAPTURE": str(package_capture),
                 "OPENSSL_REJECTS_LEGACY": "1" if openssl_rejects_legacy else "0",
                 "FAIL_FINAL_INSTALL_MOVE": "1" if fail_final_install_move else "0",
@@ -706,6 +838,7 @@ class LocalProductionInstallerTests(unittest.TestCase):
                 "TMPDIR": str(installer_tmp),
                 "FAKE_REGISTRY_PATH": str(registry_path),
                 "FAKE_INSTALLED_APP": str(installed_app),
+                "DEVELOPER_DIR": str(fake_developer_dir),
             }
         )
         if selected:
@@ -721,6 +854,7 @@ class LocalProductionInstallerTests(unittest.TestCase):
             "package_capture": package_capture,
             "security_log": security_log,
             "import_log": import_log,
+            "swift_log": swift_log,
             "tmp_root": installer_tmp,
         }
         return self.invoke(context), context
@@ -748,6 +882,47 @@ class LocalProductionInstallerTests(unittest.TestCase):
         path = bin_dir / name
         path.write_text("#!/usr/bin/env bash\nset -euo pipefail\n" + textwrap.dedent(body), encoding="utf-8")
         path.chmod(0o755)
+
+    @staticmethod
+    def create_fake_xcode(app_path: Path, *, sdk_version: str) -> Path:
+        developer_dir = app_path / "Contents" / "Developer"
+        (developer_dir / "usr" / "bin").mkdir(parents=True)
+        (developer_dir / "Platforms" / "MacOSX.platform").mkdir(parents=True)
+        xcodebuild = developer_dir / "usr" / "bin" / "xcodebuild"
+        xcodebuild.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+        xcodebuild.chmod(0o755)
+        (developer_dir / ".fixture-sdk-version").write_text(f"{sdk_version}\n", encoding="utf-8")
+        return developer_dir
+
+    @classmethod
+    def create_xcode_resolver_stubs(
+        cls,
+        root: Path,
+        *,
+        selected_path: Path | None = None,
+        marker: Path | None = None,
+    ) -> Path:
+        bin_dir = root / "bin"
+        bin_dir.mkdir(exist_ok=True)
+        selected = str(selected_path or root / "CommandLineTools")
+        marker_command = f"printf 'invoked\\n' > {str(marker)!r}\n" if marker else ""
+        cls.write_stub(
+            bin_dir,
+            "xcode-select",
+            f"""\
+            {marker_command}printf '%s\\n' {selected!r}
+            """,
+        )
+        cls.write_stub(
+            bin_dir,
+            "xcrun",
+            """\
+            [[ "$*" == "--sdk macosx --show-sdk-version" ]] || exit 64
+            [[ -f "${DEVELOPER_DIR:-}/.fixture-sdk-version" ]] || exit 65
+            cat "$DEVELOPER_DIR/.fixture-sdk-version"
+            """,
+        )
+        return bin_dir
 
 
 if __name__ == "__main__":

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -340,7 +340,10 @@ a local-only production app by double-clicking
 in Finder. The Finder launcher requires Python 3, confirms replacement of any
 existing installed app, runs the coordinated developer daemon, and keeps the
 terminal window open so certificate approval prompts and build results remain
-visible.
+visible. Local production packaging requires a full Xcode installation. The
+installer preserves an explicit compatible `DEVELOPER_DIR`; otherwise it uses
+the selected full Xcode or discovers a compatible Xcode app for that process
+without changing the system-wide `xcode-select` setting.
 
 The equivalent command-line path is:
 


### PR DESCRIPTION
## Summary

Fix the Finder-based Launch and Install commands on Macs where Xcode 26 has been removed and Xcode 27 beta is the only compatible full Xcode installed.

- Add a shared resolver for a full Xcode containing the macOS 26 SDK or newer.
- Preserve a compatible explicit `DEVELOPER_DIR`.
- Otherwise use the selected full Xcode or discover an installed Xcode app, preferring stable releases before beta versions.
- Export the resolved developer directory to the launcher, conductor, and production installer without changing the system-wide `xcode-select` setting.
- Fail before performing lifecycle actions when no compatible Xcode is available, with an actionable error.
- Use the production packager’s known `.build/release` output instead of invoking SwiftPM a second time to locate the app.
- Add launcher and installer coverage for explicit selection, Command Line Tools fallback, beta discovery, stable-version preference, failure handling, environment propagation, and avoiding the redundant Swift invocation.
- Document the full-Xcode requirement and selection behavior.

## Problem

After removing Xcode 26 and installing Xcode 27 beta, the `.command` files could inherit a stale or Command Line Tools developer directory. This caused SwiftPM to fail while initializing its build system even though a compatible full Xcode was installed.

## Validation

- Manually ran `Launch RepoPrompt CE.command`; the debug app built and relaunched successfully.
- Manually ran `Install RepoPrompt CE Local Production.command`; the local self-signed production app built and installed successfully.
- Verified with Xcode 27 beta installed and Xcode 26 removed.