### PR TITLE
Automate guarded Codex runtime update candidates

### DIFF
--- a/.github/workflows/codex-update-candidate.yml
+++ b/.github/workflows/codex-update-candidate.yml
@@ -1,0 +1,80 @@
+name: Codex Runtime Update Candidate
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Stable Codex version (for example 0.145.0)
+        required: false
+        type: string
+      tag:
+        description: Stable Codex tag (for example rust-v0.145.0)
+        required: false
+        type: string
+      latest_stable:
+        description: Explicitly resolve GitHub's latest stable openai/codex release
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  evidence:
+    name: Prepare Review-Only Evidence
+    if: github.ref == 'refs/heads/main'
+    runs-on: macos-26
+    steps:
+      - name: Check out trusted main
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
+      - name: Validate candidate selector
+        id: selector
+        shell: bash
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_TAG: ${{ inputs.tag }}
+          INPUT_LATEST: ${{ inputs.latest_stable }}
+        run: |
+          set -euo pipefail
+          count=0
+          args=()
+          if [[ -n "$INPUT_VERSION" ]]; then
+            count=$((count + 1))
+            args+=(--version "$INPUT_VERSION")
+          fi
+          if [[ -n "$INPUT_TAG" ]]; then
+            count=$((count + 1))
+            args+=(--tag "$INPUT_TAG")
+          fi
+          if [[ "$INPUT_LATEST" == "true" ]]; then
+            count=$((count + 1))
+            args+=(--latest-stable)
+          fi
+          if [[ "$count" -ne 1 ]]; then
+            echo "Set exactly one of version, tag, or latest_stable." >&2
+            exit 1
+          fi
+          printf '%s\0' "${args[@]}" > "$RUNNER_TEMP/codex-candidate-selector"
+
+      - name: Prepare guarded candidate evidence
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          args=()
+          while IFS= read -r -d '' value; do args+=("$value"); done < "$RUNNER_TEMP/codex-candidate-selector"
+          python3 Scripts/codex_update_candidate.py \
+            "${args[@]}" \
+            --output-dir .build/codex-update-candidate/evidence
+
+      - name: Upload candidate evidence
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: RepoPrompt-CE-Codex-runtime-update-candidate
+          path: .build/codex-update-candidate/evidence
+          if-no-files-found: error

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help doctor setup install-format-tools format-tools-status format format-check lint install-debug-cli uninstall-debug-cli debug-cli-status codex-acquire codex-status resolve build run test guardrails codex-schema-check conductor-selftest ci-app-test-runner-selftest release-selftest release-sync-cli-version release-preflight release-artifact install-local-production xcode xcode-open xcode-generate xcode-check xcode-validate xcode-generator-test xcode-clean dev-status dev-build dev-swift-build dev-run dev-launch-existing dev-codex-schema-check dev-test dev-test-impacted dev-test-shard-plan dev-test-list dev-provider-test dev-provider-test-list dev-smoke dev-smoke-launch dev-format dev-format-check dev-lint dev-format-tools-status dev-check-format-tools dev-install-format-tools dev-release-preflight dev-release-artifact dev-install-local-production dev-stop-app dev-daemon-stop clean
+.PHONY: help doctor setup install-format-tools format-tools-status format format-check lint install-debug-cli uninstall-debug-cli debug-cli-status codex-acquire codex-status codex-update-candidate resolve build run test guardrails codex-schema-check conductor-selftest ci-app-test-runner-selftest release-selftest release-sync-cli-version release-preflight release-artifact install-local-production xcode xcode-open xcode-generate xcode-check xcode-validate xcode-generator-test xcode-clean dev-status dev-build dev-swift-build dev-run dev-launch-existing dev-codex-schema-check dev-test dev-test-impacted dev-test-shard-plan dev-test-list dev-provider-test dev-provider-test-list dev-smoke dev-smoke-launch dev-format dev-format-check dev-lint dev-format-tools-status dev-check-format-tools dev-install-format-tools dev-release-preflight dev-release-artifact dev-install-local-production dev-stop-app dev-daemon-stop clean
 
 PRODUCT ?= all
 CODEX_ARCH ?= all
@@ -49,6 +49,7 @@ help:
 	@printf '  %-30s %s\n' 'debug-cli-status' 'Show CE debug CLI status'
 	@printf '  %-30s %s\n' 'codex-acquire' 'Acquire and verify pinned Codex package(s); override with CODEX_ARCH=host|arm64|x86_64'
 	@printf '  %-30s %s\n' 'codex-status' 'Verify cached pinned Codex packages without network access'
+	@printf '  %-30s %s\n' 'codex-update-candidate' 'Prepare review-only stable Codex update evidence; set one CODEX_CANDIDATE selector'
 	@printf '\n%s\n' 'Xcode workspace targets:'
 	@printf '  %-30s %s\n' 'xcode' 'Generate and open the disposable Xcode workspace'
 	@printf '  %-30s %s\n' 'xcode-generate' 'Generate the disposable Xcode workspace'
@@ -108,6 +109,17 @@ codex-acquire:
 codex-status:
 	python3 Scripts/codex_runtime_artifact.py status --cache-root "$${REPOPROMPT_CODEX_CACHE_ROOT:-.build/codex-runtime}"
 
+codex-update-candidate:
+	@set --; count=0; \
+	if [ -n "$(CODEX_CANDIDATE_VERSION)" ]; then count=$$((count + 1)); set -- "$$@" --version "$(CODEX_CANDIDATE_VERSION)"; fi; \
+	if [ -n "$(CODEX_CANDIDATE_TAG)" ]; then count=$$((count + 1)); set -- "$$@" --tag "$(CODEX_CANDIDATE_TAG)"; fi; \
+	if [ "$(CODEX_CANDIDATE_LATEST)" = "1" ]; then count=$$((count + 1)); set -- "$$@" --latest-stable; fi; \
+	if [ "$$count" -ne 1 ]; then \
+		echo "Set exactly one of CODEX_CANDIDATE_VERSION=X.Y.Z, CODEX_CANDIDATE_TAG=rust-vX.Y.Z, or CODEX_CANDIDATE_LATEST=1" >&2; \
+		exit 1; \
+	fi; \
+	python3 Scripts/codex_update_candidate.py "$$@"
+
 resolve:
 	swift package resolve
 
@@ -145,6 +157,8 @@ release-selftest:
 	python3 Scripts/test_release_promotion.py
 	python3 Scripts/test_release_tooling.py
 	python3 Scripts/test_codex_runtime_artifact.py
+	python3 Scripts/test_codex_update_candidate.py
+	python3 Scripts/test_codex_update_workflow.py
 
 release-sync-cli-version:
 	./Scripts/release.sh sync-cli-version

--- a/Scripts/codex_runtime_artifact.py
+++ b/Scripts/codex_runtime_artifact.py
@@ -67,6 +67,7 @@ TARGET_PAGE_SIZES = {
     CPU_TYPE_X86_64: 0x1000,
     CPU_TYPE_ARM64: 0x4000,
 }
+STABLE_VERSION_PATTERN = re.compile(r"[0-9]+\.[0-9]+\.[0-9]+")
 
 
 class ContractError(RuntimeError):
@@ -81,17 +82,28 @@ def sha256(path: Path) -> str:
     return digest.hexdigest()
 
 
-def load_manifest(path: Path, *, require_normalized_digests: bool = True) -> dict[str, Any]:
+def load_manifest(
+    path: Path,
+    *,
+    require_normalized_digests: bool = True,
+    expected_version: str | None = None,
+) -> dict[str, Any]:
+    effective_version = expected_version or SUPPORTED_VERSION
+    if STABLE_VERSION_PATTERN.fullmatch(effective_version) is None:
+        raise ContractError(f"expected Codex version must be a stable numeric triplet: {effective_version!r}")
+    effective_tag = f"rust-v{effective_version}"
+    effective_release_url = f"{OFFICIAL_REPOSITORY_URL}/releases/tag/{effective_tag}"
+    effective_download_url = f"{OFFICIAL_REPOSITORY_URL}/releases/download/{effective_tag}"
     try:
         manifest = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
         raise ContractError(f"could not read pinned manifest {path}: {exc}") from exc
     if manifest.get("schemaVersion") != 1:
         raise ContractError("unsupported Codex manifest schema")
-    if manifest.get("version") != SUPPORTED_VERSION or manifest.get("tag") != SUPPORTED_TAG:
-        raise ContractError(f"pinned manifest must describe Codex {SUPPORTED_VERSION} / {SUPPORTED_TAG}")
-    if manifest.get("releaseURL") != OFFICIAL_RELEASE_URL:
-        raise ContractError(f"pinned manifest releaseURL must be {OFFICIAL_RELEASE_URL}")
+    if manifest.get("version") != effective_version or manifest.get("tag") != effective_tag:
+        raise ContractError(f"pinned manifest must describe Codex {effective_version} / {effective_tag}")
+    if manifest.get("releaseURL") != effective_release_url:
+        raise ContractError(f"pinned manifest releaseURL must be {effective_release_url}")
     packages = manifest.get("packages")
     if not isinstance(packages, dict) or set(packages) != set(BUNDLE_TARGETS):
         raise ContractError("pinned manifest must contain exactly both macOS package targets")
@@ -101,7 +113,7 @@ def load_manifest(path: Path, *, require_normalized_digests: bool = True) -> dic
     if not isinstance(checksums, dict) or checksums.get("asset") != "codex-package_SHA256SUMS":
         raise ContractError("pinned manifest has an invalid official checksum asset")
     validate_digest(checksums.get("sha256"), "official checksum asset")
-    expected_checksums_url = f"{OFFICIAL_DOWNLOAD_URL}/{checksums['asset']}"
+    expected_checksums_url = f"{effective_download_url}/{checksums['asset']}"
     if checksums.get("url") != expected_checksums_url:
         raise ContractError(f"official checksum asset URL must be {expected_checksums_url}")
     for target, package in packages.items():
@@ -113,7 +125,7 @@ def load_manifest(path: Path, *, require_normalized_digests: bool = True) -> dic
         if package.get("architecture") != TARGET_ARCHITECTURES[target]:
             raise ContractError(f"{target}: architecture policy mismatch")
         validate_digest(package.get("sha256"), f"{target} archive")
-        expected_package_url = f"{OFFICIAL_DOWNLOAD_URL}/{expected_archive}"
+        expected_package_url = f"{effective_download_url}/{expected_archive}"
         if package.get("url") != expected_package_url:
             raise ContractError(f"{target}: official archive URL must be {expected_package_url}")
         entries = package.get("tree")

--- a/Scripts/codex_update_candidate.py
+++ b/Scripts/codex_update_candidate.py
@@ -1,0 +1,841 @@
+#!/usr/bin/env python3
+"""Prepare review-only evidence for a guarded OpenAI Codex runtime update."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import os
+import re
+import shutil
+import sys
+import tarfile
+import tempfile
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Sequence
+from urllib.parse import quote, urlparse
+
+import codex_runtime_artifact as artifact
+
+
+API_ROOT = "https://api.github.com/repos/openai/codex/releases"
+CHECKSUM_ASSET = "codex-package_SHA256SUMS"
+MAX_ASSET_SIZE = 2 * 1024 * 1024 * 1024
+MAX_ARCHIVE_MEMBERS = 10_000
+MAX_ARCHIVE_MEMBER_SIZE = 2 * 1024 * 1024 * 1024
+MAX_EXPANDED_ARCHIVE_SIZE = 4 * 1024 * 1024 * 1024
+DEFAULT_LIPO = "/usr/bin/lipo"
+DEFAULT_CODESIGN = "/usr/bin/codesign"
+STABLE_VERSION_PATTERN = re.compile(r"[0-9]+\.[0-9]+\.[0-9]+")
+STABLE_TAG_PATTERN = re.compile(r"rust-v([0-9]+\.[0-9]+\.[0-9]+)")
+REQUIRED_ASSET_NAMES = (
+    CHECKSUM_ASSET,
+    *(f"codex-package-{target}.tar.gz" for target in artifact.BUNDLE_TARGETS),
+)
+
+
+class CandidateError(RuntimeError):
+    pass
+
+
+def stable_version(value: str, *, label: str) -> str:
+    if STABLE_VERSION_PATTERN.fullmatch(value) is None:
+        raise CandidateError(f"{label} must be a stable numeric triplet, got {value!r}")
+    return value
+
+
+def version_from_tag(value: str, *, label: str) -> str:
+    match = STABLE_TAG_PATTERN.fullmatch(value)
+    if match is None:
+        raise CandidateError(f"{label} must match rust-v<stable numeric triplet>, got {value!r}")
+    return match.group(1)
+
+
+def version_tuple(value: str) -> tuple[int, int, int]:
+    stable_version(value, label="Codex version")
+    major, minor, patch = value.split(".")
+    return int(major), int(minor), int(patch)
+
+
+def ensure_newer(candidate: str, baseline: str) -> None:
+    if version_tuple(candidate) <= version_tuple(baseline):
+        raise CandidateError(
+            f"candidate Codex {candidate} must be newer than the known-good bundled pin {baseline}"
+        )
+
+
+def load_json_object(path: Path, *, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise CandidateError(f"could not read {label} {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise CandidateError(f"{label} must be a JSON object")
+    return value
+
+
+def github_api_json(url: str) -> dict[str, Any]:
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "RepoPrompt-CE-Codex-update-candidate/1",
+    }
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    request = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            final_url = urlparse(response.geturl())
+            if final_url.scheme != "https" or final_url.netloc != "api.github.com":
+                raise CandidateError(f"GitHub release API redirected to an unexpected origin: {response.geturl()}")
+            payload = response.read(10 * 1024 * 1024 + 1)
+    except (OSError, urllib.error.URLError) as exc:
+        raise CandidateError(f"GitHub release API request failed for {url}: {exc}") from exc
+    if len(payload) > 10 * 1024 * 1024:
+        raise CandidateError("GitHub release metadata exceeded the 10 MiB safety limit")
+    try:
+        value = json.loads(payload)
+    except json.JSONDecodeError as exc:
+        raise CandidateError(f"GitHub release API returned invalid JSON: {exc}") from exc
+    if not isinstance(value, dict):
+        raise CandidateError("GitHub release API response must be a JSON object")
+    return value
+
+
+def selection_mode(args: argparse.Namespace) -> str:
+    if args.version:
+        return "explicit-version"
+    if args.tag:
+        return "explicit-tag"
+    return "explicit-latest-stable"
+
+
+def validate_evidence_mode(args: argparse.Namespace) -> None:
+    if bool(args.release_json) != bool(args.asset_dir):
+        raise CandidateError("--release-json and --asset-dir must be provided together for a fully offline run")
+    baseline_path = Path(args.baseline_manifest).expanduser().resolve()
+    has_override = (
+        baseline_path != artifact.DEFAULT_MANIFEST.resolve()
+        or args.lipo != DEFAULT_LIPO
+        or args.codesign != DEFAULT_CODESIGN
+    )
+    fixture_inputs = bool(args.release_json or args.asset_dir)
+    if (fixture_inputs or has_override) and not args.fixture_mode:
+        raise CandidateError(
+            "--fixture-mode is required for offline metadata/assets or non-default baseline/tool overrides"
+        )
+    if args.fixture_mode and args.latest_stable:
+        raise CandidateError("--latest-stable is unavailable in fixture mode; use an explicit version or tag")
+
+
+def effective_tool_path(value: str) -> str:
+    resolved = shutil.which(value)
+    if resolved:
+        return str(Path(resolved).resolve())
+    return str(Path(value).expanduser().resolve(strict=False))
+
+
+def display_baseline_path(path: Path) -> str:
+    try:
+        return path.relative_to(artifact.ROOT.resolve()).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def build_provenance(
+    args: argparse.Namespace,
+    baseline_path: Path,
+) -> dict[str, Any]:
+    fixture_mode = bool(args.fixture_mode)
+    return {
+        "schemaVersion": 1,
+        "evidenceMode": "test-fixture-non-promotable" if fixture_mode else "official-github-online",
+        "nonPromotableTestFixture": fixture_mode,
+        "selectionMode": selection_mode(args),
+        "releaseMetadataSource": (
+            str(Path(args.release_json).expanduser().resolve())
+            if args.release_json
+            else "https://api.github.com/repos/openai/codex/releases"
+        ),
+        "assetSources": (
+            [str(Path(args.asset_dir).expanduser().resolve())]
+            if args.asset_dir
+            else []
+        ),
+        "baselineManifest": {
+            "path": display_baseline_path(baseline_path),
+            "sha256": artifact.sha256(baseline_path),
+        },
+        "verificationTools": {
+            "lipo": effective_tool_path(args.lipo),
+            "codesign": effective_tool_path(args.codesign),
+        },
+    }
+
+
+def load_release(args: argparse.Namespace, expected_tag: str | None) -> dict[str, Any]:
+    if args.release_json:
+        return load_json_object(Path(args.release_json), label="release metadata")
+    if args.latest_stable:
+        url = f"{API_ROOT}/latest"
+    else:
+        if expected_tag is None:
+            raise CandidateError("an explicit Codex tag is required")
+        url = f"{API_ROOT}/tags/{quote(expected_tag, safe='')}"
+    return github_api_json(url)
+
+
+def required_assets(release: dict[str, Any], tag: str) -> dict[str, dict[str, Any]]:
+    assets = release.get("assets")
+    if not isinstance(assets, list):
+        raise CandidateError("release metadata assets must be a list")
+    matches: dict[str, list[dict[str, Any]]] = {name: [] for name in REQUIRED_ASSET_NAMES}
+    for index, raw in enumerate(assets):
+        if not isinstance(raw, dict):
+            raise CandidateError(f"release asset {index} is not an object")
+        name = raw.get("name")
+        if not isinstance(name, str) or not name:
+            raise CandidateError(f"release asset {index} has no valid name")
+        if name in matches:
+            matches[name].append(raw)
+    selected: dict[str, dict[str, Any]] = {}
+    for name in REQUIRED_ASSET_NAMES:
+        values = matches[name]
+        if len(values) != 1:
+            raise CandidateError(f"release metadata must contain exactly one asset named {name}; found {len(values)}")
+        asset_value = values[0]
+        expected_url = f"{artifact.OFFICIAL_REPOSITORY_URL}/releases/download/{tag}/{name}"
+        if asset_value.get("browser_download_url") != expected_url:
+            raise CandidateError(f"release asset {name} must use the exact official URL {expected_url}")
+        size = asset_value.get("size")
+        if isinstance(size, bool) or not isinstance(size, int) or size <= 0 or size > MAX_ASSET_SIZE:
+            raise CandidateError(f"release asset {name} has an invalid size: {size!r}")
+        selected[name] = asset_value
+    return selected
+
+
+def validate_release(
+    release: dict[str, Any],
+    expected_tag: str | None,
+) -> tuple[str, str, dict[str, dict[str, Any]]]:
+    if release.get("draft") is not False:
+        raise CandidateError("Codex update candidates must not use draft releases")
+    if release.get("prerelease") is not False:
+        raise CandidateError("Codex update candidates must not use prereleases")
+    tag = release.get("tag_name")
+    if not isinstance(tag, str):
+        raise CandidateError("release metadata has no valid tag_name")
+    version = version_from_tag(tag, label="release tag_name")
+    if expected_tag is not None and tag != expected_tag:
+        raise CandidateError(f"release tag mismatch: expected {expected_tag}, got {tag}")
+    expected_release_url = f"{artifact.OFFICIAL_REPOSITORY_URL}/releases/tag/{tag}"
+    if release.get("html_url") != expected_release_url:
+        raise CandidateError(f"release html_url must be the exact official URL {expected_release_url}")
+    return version, tag, required_assets(release, tag)
+
+
+def path_is_within(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+        return True
+    except ValueError:
+        return False
+
+
+def validate_output_path(path: Path) -> Path:
+    resolved = path.expanduser().resolve(strict=False)
+    vendor_root = (artifact.ROOT / "Vendor").resolve()
+    if path_is_within(resolved, vendor_root):
+        raise CandidateError("candidate output must not be written under Vendor; the live manifest is review-only")
+    if resolved.exists() or resolved.is_symlink():
+        raise CandidateError(f"candidate output already exists: {resolved}")
+    return resolved
+
+
+def download_asset(url: str, destination: Path, expected_size: int) -> None:
+    request = urllib.request.Request(
+        url,
+        headers={"User-Agent": "RepoPrompt-CE-Codex-update-candidate/1"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=120) as response:
+            final_url = urlparse(response.geturl())
+            if final_url.scheme != "https":
+                raise CandidateError(f"asset download redirected away from HTTPS: {response.geturl()}")
+            content_length = response.headers.get("Content-Length")
+            if content_length is not None:
+                try:
+                    declared_size = int(content_length)
+                except ValueError as exc:
+                    raise CandidateError(f"asset response has an invalid Content-Length: {content_length!r}") from exc
+                if declared_size != expected_size:
+                    raise CandidateError(
+                        f"asset response size disagrees with release metadata: metadata={expected_size} response={declared_size}"
+                    )
+            written = 0
+            with destination.open("xb") as output:
+                while True:
+                    chunk = response.read(min(1024 * 1024, expected_size + 1 - written))
+                    if not chunk:
+                        break
+                    output.write(chunk)
+                    written += len(chunk)
+                    if written > expected_size:
+                        raise CandidateError(
+                            f"asset download exceeded release metadata size {expected_size}: {url}"
+                        )
+            if written != expected_size:
+                raise CandidateError(
+                    f"asset download ended at {written} bytes; release metadata requires {expected_size}: {url}"
+                )
+    except CandidateError:
+        destination.unlink(missing_ok=True)
+        raise
+    except (OSError, urllib.error.URLError) as exc:
+        destination.unlink(missing_ok=True)
+        raise CandidateError(f"asset download failed for {url}: {exc}") from exc
+
+
+def acquire_assets(
+    selected: dict[str, dict[str, Any]],
+    destination: Path,
+    asset_dir: Path | None,
+) -> dict[str, Path]:
+    destination.mkdir(parents=True)
+    acquired: dict[str, Path] = {}
+    for name in REQUIRED_ASSET_NAMES:
+        output = destination / name
+        if asset_dir is None:
+            download_asset(
+                selected[name]["browser_download_url"],
+                output,
+                selected[name]["size"],
+            )
+        else:
+            source = asset_dir / name
+            if not source.is_file() or source.is_symlink():
+                raise CandidateError(f"offline asset directory is missing a regular file: {name}")
+            source_size = source.stat().st_size
+            if source_size != selected[name]["size"]:
+                raise CandidateError(
+                    f"offline asset size mismatch for {name}: metadata={selected[name]['size']} actual={source_size}"
+                )
+            shutil.copyfile(source, output)
+        actual_size = output.stat().st_size
+        if actual_size != selected[name]["size"]:
+            raise CandidateError(
+                f"release asset size mismatch for {name}: metadata={selected[name]['size']} actual={actual_size}"
+            )
+        acquired[name] = output
+    return acquired
+
+
+def verify_archive_checksums(acquired: dict[str, Path]) -> dict[str, str]:
+    sums = acquired[CHECKSUM_ASSET]
+    digests: dict[str, str] = {CHECKSUM_ASSET: artifact.sha256(sums)}
+    for target in artifact.BUNDLE_TARGETS:
+        archive = f"codex-package-{target}.tar.gz"
+        published = artifact.official_digest(sums, archive)
+        actual = artifact.sha256(acquired[archive])
+        if actual != published:
+            raise CandidateError(
+                f"archive checksum mismatch for {archive}: upstream={published} actual={actual}"
+            )
+        digests[archive] = actual
+    return digests
+
+
+def archive_paths(path: Path) -> set[str]:
+    discovered: set[str] = set()
+    expanded_size = 0
+    with tarfile.open(path, "r:gz") as tar:
+        for member_count, member in enumerate(tar, start=1):
+            if member_count > MAX_ARCHIVE_MEMBERS:
+                raise CandidateError(f"archive exceeds the {MAX_ARCHIVE_MEMBERS} member safety limit")
+            if member.size < 0 or member.size > MAX_ARCHIVE_MEMBER_SIZE:
+                raise CandidateError(
+                    f"archive member {member.name!r} exceeds the {MAX_ARCHIVE_MEMBER_SIZE} byte safety limit"
+                )
+            expanded_size += member.size
+            if expanded_size > MAX_EXPANDED_ARCHIVE_SIZE:
+                raise CandidateError(
+                    f"archive expanded size exceeds the {MAX_EXPANDED_ARCHIVE_SIZE} byte safety limit"
+                )
+            normalized = member.name.rstrip("/")
+            relative = str(artifact.validate_relative_path(normalized, "archive member"))
+            if relative in discovered:
+                raise CandidateError(f"archive contains duplicate member: {relative}")
+            discovered.add(relative)
+    missing = artifact.REQUIRED_LAYOUT - discovered
+    if missing:
+        raise CandidateError(f"candidate package omits required layout: {sorted(missing)}")
+    return discovered
+
+
+def structural_tree(entries: Sequence[dict[str, Any]]) -> dict[str, tuple[str, bool | None]]:
+    result: dict[str, tuple[str, bool | None]] = {}
+    for entry in entries:
+        kind = entry["kind"]
+        executable = entry.get("executable") if kind == "file" else None
+        result[entry["path"]] = kind, executable
+    return result
+
+
+def inspect_target(
+    target: str,
+    archive: Path,
+    destination: Path,
+    baseline: dict[str, Any],
+    codesign: str,
+) -> tuple[Path, list[dict[str, Any]], list[str]]:
+    destination.mkdir(parents=True)
+    destination.chmod(artifact.EXPECTED_DIRECTORY_MODE)
+    discovered = archive_paths(archive)
+    artifact.safe_extract(archive, destination, discovered)
+    snapshot = artifact.snapshot_tree(destination)
+    actual_entries = [snapshot[path] for path in sorted(snapshot)]
+    expected_entries = baseline["packages"][target]["tree"]
+    actual_structure = structural_tree(actual_entries)
+    expected_structure = structural_tree(expected_entries)
+    if actual_structure != expected_structure:
+        missing = sorted(set(expected_structure) - set(actual_structure))
+        extra = sorted(set(actual_structure) - set(expected_structure))
+        changed = sorted(
+            path
+            for path in set(actual_structure) & set(expected_structure)
+            if actual_structure[path] != expected_structure[path]
+        )
+        raise CandidateError(
+            f"{target}: package layout drift requires manual artifact-policy review"
+            f"\nmissing={missing}\nextra={extra}\nchanged={changed}"
+        )
+    mach_o_files = sorted(
+        path
+        for path, entry in snapshot.items()
+        if entry["kind"] == "file" and artifact.is_mach_o_file(destination / path)
+    )
+    baseline_mach_o = sorted(baseline["machOFiles"])
+    if mach_o_files != baseline_mach_o:
+        raise CandidateError(
+            f"{target}: Mach-O inventory drift requires manual artifact-policy review"
+            f"\nexpected={baseline_mach_o}\nactual={mach_o_files}"
+        )
+    entries_by_path = {entry["path"]: entry for entry in actual_entries}
+    for relative in mach_o_files:
+        if entries_by_path[relative].get("executable") is not True:
+            raise CandidateError(f"{target}: discovered Mach-O is not executable: {relative}")
+        entries_by_path[relative]["normalizedSha256"] = artifact.normalized_mach_o_sha256(
+            destination / relative,
+            codesign,
+        )
+    return destination, actual_entries, mach_o_files
+
+
+def build_candidate_manifest(
+    baseline: dict[str, Any],
+    version: str,
+    tag: str,
+    digests: dict[str, str],
+    trees: dict[str, list[dict[str, Any]]],
+    mach_o_files: list[str],
+) -> dict[str, Any]:
+    download_root = f"{artifact.OFFICIAL_REPOSITORY_URL}/releases/download/{tag}"
+    packages: dict[str, Any] = {}
+    for target in artifact.BUNDLE_TARGETS:
+        archive = f"codex-package-{target}.tar.gz"
+        packages[target] = {
+            "archive": archive,
+            "url": f"{download_root}/{archive}",
+            "sha256": digests[archive],
+            "architecture": artifact.TARGET_ARCHITECTURES[target],
+            "tree": trees[target],
+        }
+    return {
+        "schemaVersion": 1,
+        "version": version,
+        "tag": tag,
+        "releaseURL": f"{artifact.OFFICIAL_REPOSITORY_URL}/releases/tag/{tag}",
+        "checksums": {
+            "asset": CHECKSUM_ASSET,
+            "url": f"{download_root}/{CHECKSUM_ASSET}",
+            "sha256": digests[CHECKSUM_ASSET],
+        },
+        "packages": packages,
+        "requiredLayout": copy.deepcopy(baseline["requiredLayout"]),
+        "machOFiles": mach_o_files,
+        "signedExecutables": copy.deepcopy(baseline["signedExecutables"]),
+    }
+
+
+def changed_file_paths(
+    baseline: dict[str, Any],
+    candidate: dict[str, Any],
+    target: str,
+) -> list[str]:
+    baseline_entries = {entry["path"]: entry for entry in baseline["packages"][target]["tree"]}
+    candidate_entries = {entry["path"]: entry for entry in candidate["packages"][target]["tree"]}
+    return sorted(
+        path
+        for path in baseline_entries
+        if baseline_entries[path].get("sha256") != candidate_entries[path].get("sha256")
+        or baseline_entries[path].get("normalizedSha256") != candidate_entries[path].get("normalizedSha256")
+    )
+
+
+def bullet_paths(paths: Sequence[str]) -> str:
+    if not paths:
+        return "  - None"
+    return "\n".join(f"  - `{path}`" for path in paths)
+
+
+def markdown_encoded(value: str) -> str:
+    return json.dumps(value, ensure_ascii=True).replace("`", "\\u0060")
+
+
+def render_report(
+    baseline: dict[str, Any],
+    candidate: dict[str, Any],
+    release: dict[str, Any],
+    asset_digests: dict[str, str],
+    provenance: dict[str, Any],
+) -> str:
+    baseline_version = baseline["version"]
+    version = candidate["version"]
+    tag = candidate["tag"]
+    fixture_mode = provenance["nonPromotableTestFixture"]
+    release_name = release.get("name") if isinstance(release.get("name"), str) else ""
+    manifest_name = (
+        "NON_PROMOTABLE_TEST_FIXTURE-candidate-manifest.json"
+        if fixture_mode
+        else "candidate-manifest.json"
+    )
+    lines = [
+        (
+            "# NON-PROMOTABLE TEST FIXTURE — Codex Runtime Candidate"
+            if fixture_mode
+            else "# Guarded Codex Runtime Update Candidate"
+        ),
+        "",
+        (
+            "> **NON-PROMOTABLE TEST FIXTURE:** caller-supplied metadata, assets, baseline, or tools may be present; this output is not official release evidence."
+            if fixture_mode
+            else "> **Review gate:** this official online evidence does not trust, apply, merge, promote Tip, or release a Codex runtime update."
+        ),
+        "",
+        "## 1. Candidate identity and provenance",
+        "",
+        f"- Evidence mode: `{provenance['evidenceMode']}`.",
+        f"- Candidate: Codex `{version}` (`{tag}`).",
+        f"- {'Fixture-declared release URL' if fixture_mode else 'Official release'}: {candidate['releaseURL']}",
+        f"- Selection mode: `{provenance['selectionMode']}`.",
+        f"- Release metadata name (JSON encoded): `{markdown_encoded(release_name)}`.",
+        f"- Baseline manifest path (JSON encoded): `{markdown_encoded(provenance['baselineManifest']['path'])}`; SHA-256 `{provenance['baselineManifest']['sha256']}`.",
+        f"- Effective `lipo` path (JSON encoded): `{markdown_encoded(provenance['verificationTools']['lipo'])}`.",
+        f"- Effective `codesign` path (JSON encoded): `{markdown_encoded(provenance['verificationTools']['codesign'])}`.",
+        (
+            "- Fixture metadata contained each required asset exactly once at the expected URL shape."
+            if fixture_mode
+            else "- Official GitHub metadata contained each required asset exactly once at its exact official URL."
+        ),
+    ]
+    for name in sorted(REQUIRED_ASSET_NAMES):
+        lines.append(f"- `{name}` SHA-256: `{asset_digests[name]}`")
+    lines.extend(
+        [
+            "",
+            f"## 2. Baseline comparison (known-good {baseline_version})",
+            "",
+            "- Package path/kind/executable layout matches the known-good manifest for both targets; drift would have failed the run.",
+            "- Mach-O inventory and thin per-target architecture policy match the known-good manifest; drift would have failed the run.",
+            "- Both primary executables match the pinned OpenAI signing identities, hardened-runtime policy, and trusted-timestamp requirement.",
+        ]
+    )
+    for target in artifact.BUNDLE_TARGETS:
+        changed = changed_file_paths(baseline, candidate, target)
+        lines.extend(
+            [
+                f"- `{target}` changed file payloads ({len(changed)}):",
+                bullet_paths(changed),
+            ]
+        )
+    lines.extend(
+        [
+            "",
+            "## 3. Proposed repository edits (NOT applied)",
+            "",
+            f"`Vendor/Codex/manifest.json` remains the single artifact authority and remains pinned to `{baseline_version}`. Review `{manifest_name}`; do not copy it into the repository until every gate below is resolved.",
+            "",
+            "Version-coupled surfaces requiring one reviewed rotation change include:",
+            "- `Vendor/Codex/manifest.json` and `Scripts/codex_runtime_artifact.py`.",
+            "- `Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/Shared/CodexRuntimeAuthority.swift` and its focused tests.",
+            "- `Scripts/Fixtures/codex-app-server-contract.json` and `.github/workflows/ci.yml`.",
+            "- `docs/releasing.md`, `Scripts/codex_vendor_guardrails.sh`, and Codex legal inventory files.",
+            "",
+            "## 4. Schema-gate work",
+            "",
+            "- Generate app-server schemas with the candidate CLI and run `make dev-codex-schema-check`.",
+            "- Reconcile every bounded request/response assumption in `Scripts/Fixtures/codex-app-server-contract.json`.",
+            "- Move the contract `minimumCodexVersion` and CI `@openai/codex` pin together only after review.",
+            "- A valid artifact does not prove app-server compatibility.",
+            "",
+            "## 5. App-server behavioral checks",
+            "",
+            "- Recheck `memory_mode` initialization for both fresh and resumed threads when `memories.generate_memories=false`.",
+            "- Exercise `thread/start` and `thread/resume` request/response shapes and reconnect behavior.",
+            "- Revalidate MCP direct-only behavior for `mcp__RepoPromptCE` and `[features.code_mode].direct_only_tool_namespaces`.",
+            "- Confirm no upstream default or protocol change creates a version-specific compatibility layer in RepoPrompt.",
+            "",
+            "## 6. License and NOTICE review",
+            "",
+            "- Compare upstream `LICENSE` and `NOTICE` at the candidate tag with `ThirdPartyLicenses/codex/`.",
+            "- Recheck the packaged Zsh licence, refresh the flat legal `SHA256SUMS`, and review `THIRD_PARTY_NOTICES.md`.",
+            "- Artifact verification does not approve legal-text changes.",
+            "",
+            "## 7. External override floor policy",
+            "",
+            "- **UNRESOLVED MANUAL POLICY GATE:** `CodexRuntimeAuthority.minimumExternalVersion` currently equals `bundledVersion`.",
+            "- This candidate makes no external override floor decision and applies no Swift edit.",
+            "- A maintainer must decide explicitly whether the floor moves, then revalidate `CodexIntegrationConfiguration` direct-only contract refusal behavior and user guidance.",
+            "",
+            "## 8. Required validation",
+            "",
+            "- `python3 Scripts/test_codex_runtime_artifact.py`",
+            "- `python3 Scripts/test_codex_update_candidate.py`",
+            "- `make guardrails` and `make release-selftest`",
+            "- Apply the reviewed candidate in a dedicated change, then run `make codex-acquire`, `make codex-status`, and `make dev-codex-schema-check`.",
+            "- Run focused `CodexRuntimeAuthorityTests`, integration/app-server checks, universal release-candidate packaging, and packaged MCP smoke validation.",
+            "",
+            "## 9. Rollback and known-good pin",
+            "",
+            f"- Known-good rollback: Codex `{baseline_version}` (`{baseline['tag']}`).",
+        ]
+    )
+    for target in artifact.BUNDLE_TARGETS:
+        package = baseline["packages"][target]
+        lines.append(f"- `{target}` archive SHA-256: `{package['sha256']}`")
+    lines.extend(
+        [
+            "- Before merge, rollback means declining the candidate. After a reviewed rotation, rollback means reverting that rotation commit and rebuilding from the known-good manifest.",
+            "",
+            "## 10. Manual approval and soak",
+            "",
+            "- Explicit maintainer approval is required after artifact, schema, behavior, legal, and floor-policy review.",
+            "- Do not automatically merge, promote Tip, publish stable, or treat GitHub's stable label as trust evidence.",
+            "- Soak the reviewed runtime through the intended candidate/Tip process before any stable promotion; OpenAI stable releases may still contain regressions.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def sanitized_release_metadata(
+    release: dict[str, Any],
+    selected: dict[str, dict[str, Any]],
+    digests: dict[str, str],
+    provenance: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "evidenceMode": provenance["evidenceMode"],
+        "nonPromotableTestFixture": provenance["nonPromotableTestFixture"],
+        "tag_name": release["tag_name"],
+        "name": release.get("name") if isinstance(release.get("name"), str) else "",
+        "html_url": release["html_url"],
+        "draft": release["draft"],
+        "prerelease": release["prerelease"],
+        "assets": [
+            {
+                "name": name,
+                "browser_download_url": selected[name]["browser_download_url"],
+                "size": selected[name]["size"],
+                "sha256": digests[name],
+            }
+            for name in sorted(REQUIRED_ASSET_NAMES)
+        ],
+    }
+
+
+def write_json(path: Path, value: Any) -> None:
+    path.write_text(json.dumps(value, indent=2, sort_keys=False) + "\n", encoding="utf-8")
+
+
+def write_evidence_sums(root: Path, names: Sequence[str]) -> None:
+    lines = [f"{artifact.sha256(root / name)}  {name}" for name in sorted(names)]
+    (root / "EVIDENCE_SHA256SUMS").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def prepare_candidate(args: argparse.Namespace) -> Path:
+    validate_evidence_mode(args)
+
+    baseline_path = Path(args.baseline_manifest).expanduser().resolve()
+    baseline = artifact.load_manifest(baseline_path)
+    baseline_version = baseline["version"]
+    provenance = build_provenance(args, baseline_path)
+
+    explicit_version: str | None = None
+    expected_tag: str | None = None
+    if args.version:
+        explicit_version = stable_version(args.version, label="--version")
+        expected_tag = f"rust-v{explicit_version}"
+    elif args.tag:
+        expected_tag = args.tag
+        explicit_version = version_from_tag(expected_tag, label="--tag")
+    if explicit_version is not None:
+        ensure_newer(explicit_version, baseline_version)
+
+    if args.output_dir:
+        validate_output_path(Path(args.output_dir))
+
+    release = load_release(args, expected_tag)
+    version, tag, selected = validate_release(release, expected_tag)
+    if not provenance["nonPromotableTestFixture"]:
+        provenance["releaseMetadataSource"] = (
+            f"{API_ROOT}/latest"
+            if args.latest_stable
+            else f"{API_ROOT}/tags/{quote(tag, safe='')}"
+        )
+        provenance["assetSources"] = [
+            selected[name]["browser_download_url"]
+            for name in sorted(REQUIRED_ASSET_NAMES)
+        ]
+    if explicit_version is not None and version != explicit_version:
+        raise CandidateError(f"release version mismatch: expected {explicit_version}, got {version}")
+    ensure_newer(version, baseline_version)
+
+    output = validate_output_path(
+        Path(args.output_dir) if args.output_dir else artifact.ROOT / ".build" / "codex-update-candidate" / tag
+    )
+    output.parent.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory(prefix="repoprompt-codex-candidate-work-") as work_value:
+        work = Path(work_value)
+        acquired = acquire_assets(
+            selected,
+            work / "assets",
+            Path(args.asset_dir).expanduser().resolve() if args.asset_dir else None,
+        )
+        digests = verify_archive_checksums(acquired)
+        extracted_roots: dict[str, Path] = {}
+        trees: dict[str, list[dict[str, Any]]] = {}
+        inventories: dict[str, list[str]] = {}
+        for target in artifact.BUNDLE_TARGETS:
+            archive_name = f"codex-package-{target}.tar.gz"
+            root, tree, inventory = inspect_target(
+                target,
+                acquired[archive_name],
+                work / "extracted" / target,
+                baseline,
+                args.codesign,
+            )
+            extracted_roots[target] = root
+            trees[target] = tree
+            inventories[target] = inventory
+        inventory_values = list(inventories.values())
+        if any(value != inventory_values[0] for value in inventory_values[1:]):
+            raise CandidateError("macOS targets have divergent Mach-O inventories")
+
+        candidate = build_candidate_manifest(
+            baseline,
+            version,
+            tag,
+            digests,
+            trees,
+            inventory_values[0],
+        )
+        stage = Path(tempfile.mkdtemp(prefix=f".{output.name}.", dir=output.parent))
+        try:
+            fixture_mode = provenance["nonPromotableTestFixture"]
+            manifest_name = (
+                "NON_PROMOTABLE_TEST_FIXTURE-candidate-manifest.json"
+                if fixture_mode
+                else "candidate-manifest.json"
+            )
+            manifest_path = stage / manifest_name
+            write_json(manifest_path, candidate)
+            verified = artifact.load_manifest(manifest_path, expected_version=version)
+            for target in artifact.BUNDLE_TARGETS:
+                artifact.verify_package(
+                    extracted_roots[target],
+                    target,
+                    verified,
+                    args.lipo,
+                    args.codesign,
+                )
+            release_metadata = sanitized_release_metadata(release, selected, digests, provenance)
+            write_json(stage / "release-metadata.json", release_metadata)
+            write_json(stage / "candidate-provenance.json", provenance)
+            shutil.copyfile(acquired[CHECKSUM_ASSET], stage / "upstream-codex-package_SHA256SUMS")
+            report = render_report(baseline, verified, release, digests, provenance)
+            (stage / "candidate-report.md").write_text(report, encoding="utf-8")
+            evidence_names = [
+                manifest_name,
+                "candidate-provenance.json",
+                "candidate-report.md",
+                "release-metadata.json",
+                "upstream-codex-package_SHA256SUMS",
+            ]
+            if fixture_mode:
+                fixture_marker = "NON_PROMOTABLE_TEST_FIXTURE.txt"
+                (stage / fixture_marker).write_text(
+                    "NON-PROMOTABLE TEST FIXTURE\nThis directory is not official Codex release evidence.\n",
+                    encoding="utf-8",
+                )
+                evidence_names.append(fixture_marker)
+            write_evidence_sums(stage, evidence_names)
+            os.replace(stage, output)
+        except Exception:
+            shutil.rmtree(stage, ignore_errors=True)
+            raise
+    return output
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Prepare guarded, review-only evidence for an official stable Codex runtime update"
+    )
+    selector = parser.add_mutually_exclusive_group(required=True)
+    selector.add_argument("--version", help="explicit stable Codex version (for example 0.145.0)")
+    selector.add_argument("--tag", help="explicit stable Codex tag (for example rust-v0.145.0)")
+    selector.add_argument(
+        "--latest-stable",
+        action="store_true",
+        help="explicitly resolve GitHub's latest stable openai/codex release",
+    )
+    parser.add_argument("--output-dir", help="new evidence directory; defaults under .build/codex-update-candidate")
+    parser.add_argument(
+        "--baseline-manifest",
+        default=str(artifact.DEFAULT_MANIFEST),
+        help="read-only known-good manifest baseline",
+    )
+    parser.add_argument(
+        "--fixture-mode",
+        action="store_true",
+        help="mark caller-controlled/offline evidence as a non-promotable test fixture",
+    )
+    parser.add_argument("--release-json", help="offline release metadata fixture (requires --fixture-mode)")
+    parser.add_argument("--asset-dir", help="offline directory containing required assets (requires --fixture-mode)")
+    parser.add_argument("--lipo", default=DEFAULT_LIPO)
+    parser.add_argument("--codesign", default=DEFAULT_CODESIGN)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        output = prepare_candidate(args)
+    except (CandidateError, artifact.ContractError, OSError, UnicodeError, tarfile.TarError) as exc:
+        print(f"ERROR: Codex update candidate failed: {exc}", file=sys.stderr)
+        return 1
+    if args.fixture_mode:
+        print(f"OK: prepared NON-PROMOTABLE TEST FIXTURE evidence: {output}")
+    else:
+        print(f"OK: prepared official online Codex candidate evidence: {output}")
+    print("REVIEW REQUIRED: no repository pin, trust decision, merge, Tip promotion, or release was performed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Scripts/codex_vendor_guardrails.sh
+++ b/Scripts/codex_vendor_guardrails.sh
@@ -14,6 +14,14 @@ fail() {
 
 python3 Scripts/codex_runtime_artifact.py validate-manifest
 
+python3 Scripts/validate_codex_update_workflow.py
+grep -F 'python3 Scripts/test_codex_update_candidate.py' Makefile >/dev/null ||
+    fail "release-selftest must cover guarded Codex update candidates"
+grep -F 'python3 Scripts/test_codex_update_workflow.py' Makefile >/dev/null ||
+    fail "release-selftest must cover the structured Codex candidate workflow contract"
+grep -F 'Scripts/codex_update_candidate.py' docs/releasing.md >/dev/null ||
+    fail "docs/releasing.md is missing the guarded Codex update flow"
+
 for path in \
     ThirdPartyLicenses/codex/LICENSE \
     ThirdPartyLicenses/codex/NOTICE \

--- a/Scripts/test_codex_update_candidate.py
+++ b/Scripts/test_codex_update_candidate.py
@@ -1,0 +1,434 @@
+#!/usr/bin/env python3
+"""Offline tests for guarded Codex runtime update candidate preparation."""
+
+from __future__ import annotations
+
+import copy
+import io
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import codex_runtime_artifact as artifact
+import codex_update_candidate as candidate
+import test_codex_runtime_artifact as artifact_fixtures
+
+
+ROOT = Path(__file__).resolve().parent.parent
+TOOL = ROOT / "Scripts" / "codex_update_candidate.py"
+BASELINE = ROOT / "Vendor" / "Codex" / "manifest.json"
+VERSION = "0.145.0"
+TAG = f"rust-v{VERSION}"
+TARGETS = (
+    ("aarch64-apple-darwin", "arm64"),
+    ("x86_64-apple-darwin", "x86_64"),
+)
+
+
+class CodexUpdateCandidateTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = Path(tempfile.mkdtemp(prefix="codex-update-candidate-test-"))
+        self.addCleanup(lambda: shutil.rmtree(self.temp, ignore_errors=True))
+        self.assets = self.temp / "assets"
+        self.assets.mkdir()
+        self.sources = self.temp / "sources"
+        self.sources.mkdir()
+        self.bin = self.temp / "bin"
+        self.bin.mkdir()
+        self.lipo = self.bin / "lipo"
+        self.codesign = self.bin / "codesign"
+        self._write_fake_tools()
+        for target, architecture in TARGETS:
+            self._write_package(target, architecture)
+        self._rebuild_assets_and_release()
+
+    def _write_fake_tools(self) -> None:
+        artifact_fixtures.write_executable(
+            self.lipo,
+            """#!/usr/bin/env bash
+set -euo pipefail
+case "$2" in
+  *aarch64-apple-darwin*) printf 'arm64\\n' ;;
+  *x86_64-apple-darwin*) printf 'x86_64\\n' ;;
+  *) printf 'unknown\\n' ;;
+esac
+""",
+        )
+        artifact_fixtures.write_executable(
+            self.codesign,
+            """#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "--remove-signature" ]]; then exit 1; fi
+if [[ "$1" == "--verify" ]]; then exit 0; fi
+path="${!#}"
+cat >&2 <<EOF
+Identifier=$(basename "$path")
+CodeDirectory flags=0x10000(runtime)
+Authority=${FAKE_AUTHORITY:-Developer ID Application: OpenAI OpCo, LLC (2DC432GLL2)}
+TeamIdentifier=${FAKE_TEAM_IDENTIFIER:-2DC432GLL2}
+Timestamp=Jul 25, 2026 at 12:00:00
+EOF
+""",
+        )
+
+    def _write_package(self, target: str, architecture: str) -> None:
+        root = self.sources / target
+        for directory in (
+            root / "bin",
+            root / "codex-path",
+            root / "codex-resources" / "zsh" / "bin",
+        ):
+            directory.mkdir(parents=True, exist_ok=True)
+            directory.chmod(0o755)
+        metadata = {
+            "layoutVersion": 1,
+            "version": VERSION,
+            "target": target,
+            "variant": "codex",
+            "entrypoint": "bin/codex",
+            "resourcesDir": "codex-resources",
+            "pathDir": "codex-path",
+        }
+        (root / "codex-package.json").write_text(json.dumps(metadata, indent=2) + "\n", encoding="utf-8")
+        for relative in (
+            "bin/codex",
+            "bin/codex-code-mode-host",
+            "codex-path/rg",
+            "codex-resources/zsh/bin/zsh",
+        ):
+            artifact_fixtures.write_mach_o_fixture(
+                root / relative,
+                architecture,
+                f"candidate={VERSION}\ntarget={target}\npath={relative}\n".encode(),
+            )
+
+    @staticmethod
+    def _make_archive(source: Path, destination: Path) -> None:
+        with tarfile.open(destination, "w:gz") as tar:
+            for path in sorted(source.rglob("*")):
+                tar.add(path, arcname=path.relative_to(source).as_posix(), recursive=False)
+
+    def _rebuild_assets_and_release(self) -> None:
+        archive_names: list[str] = []
+        for target, _architecture in TARGETS:
+            archive_name = f"codex-package-{target}.tar.gz"
+            archive_names.append(archive_name)
+            self._make_archive(self.sources / target, self.assets / archive_name)
+        sums = self.assets / "codex-package_SHA256SUMS"
+        sums.write_text(
+            "".join(
+                f"{artifact.sha256(self.assets / name)}  {name}\n"
+                for name in archive_names
+            ),
+            encoding="utf-8",
+        )
+        names = [sums.name, *archive_names]
+        release = {
+            "tag_name": TAG,
+            "name": f"Codex {VERSION}",
+            "html_url": f"https://github.com/openai/codex/releases/tag/{TAG}",
+            "draft": False,
+            "prerelease": False,
+            "assets": [
+                {
+                    "name": name,
+                    "browser_download_url": f"https://github.com/openai/codex/releases/download/{TAG}/{name}",
+                    "size": (self.assets / name).stat().st_size,
+                }
+                for name in names
+            ],
+        }
+        self.release_path = self.temp / "release.json"
+        self.release_path.write_text(json.dumps(release, indent=2) + "\n", encoding="utf-8")
+
+    def _release(self) -> dict[str, object]:
+        return json.loads(self.release_path.read_text(encoding="utf-8"))
+
+    def _write_release(self, release: dict[str, object]) -> None:
+        self.release_path.write_text(json.dumps(release, indent=2) + "\n", encoding="utf-8")
+
+    def _run(
+        self,
+        output: Path,
+        *,
+        selector: tuple[str, ...] = ("--version", VERSION),
+        env: dict[str, str] | None = None,
+        expected: int = 0,
+        fixture_mode: bool = True,
+    ) -> subprocess.CompletedProcess[str]:
+        command = [
+            sys.executable,
+            str(TOOL),
+            *selector,
+            *(["--fixture-mode"] if fixture_mode else []),
+            "--release-json",
+            str(self.release_path),
+            "--asset-dir",
+            str(self.assets),
+            "--output-dir",
+            str(output),
+            "--lipo",
+            str(self.lipo),
+            "--codesign",
+            str(self.codesign),
+        ]
+        result = subprocess.run(
+            command,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env={**os.environ, **(env or {})},
+        )
+        self.assertEqual(result.returncode, expected, msg=f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}")
+        return result
+
+    def _run_raw(self, *arguments: str, expected: int = 0) -> subprocess.CompletedProcess[str]:
+        result = subprocess.run(
+            [sys.executable, str(TOOL), *arguments],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=os.environ,
+        )
+        self.assertEqual(result.returncode, expected, msg=f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}")
+        return result
+
+    def test_happy_path_is_deterministic_non_promotable_and_preserves_live_manifest(self) -> None:
+        original_manifest = BASELINE.read_bytes()
+        first = self.temp / "candidate-first"
+        second = self.temp / "candidate-second"
+        tagged = self.temp / "candidate-tagged"
+        self._run(first)
+        self._run(second)
+        self._run(tagged, selector=("--tag", TAG))
+
+        manifest_name = "NON_PROMOTABLE_TEST_FIXTURE-candidate-manifest.json"
+        expected_files = {
+            manifest_name,
+            "candidate-provenance.json",
+            "candidate-report.md",
+            "release-metadata.json",
+            "upstream-codex-package_SHA256SUMS",
+            "NON_PROMOTABLE_TEST_FIXTURE.txt",
+            "EVIDENCE_SHA256SUMS",
+        }
+        self.assertEqual({path.name for path in first.iterdir()}, expected_files)
+        self.assertEqual({path.name for path in second.iterdir()}, expected_files)
+        self.assertEqual({path.name for path in tagged.iterdir()}, expected_files)
+        for name in expected_files:
+            self.assertEqual((first / name).read_bytes(), (second / name).read_bytes(), name)
+
+        provenance = json.loads((first / "candidate-provenance.json").read_text(encoding="utf-8"))
+        self.assertEqual(provenance["evidenceMode"], "test-fixture-non-promotable")
+        self.assertTrue(provenance["nonPromotableTestFixture"])
+        self.assertEqual(provenance["selectionMode"], "explicit-version")
+        self.assertEqual(provenance["releaseMetadataSource"], str(self.release_path.resolve()))
+        self.assertEqual(provenance["assetSources"], [str(self.assets.resolve())])
+        self.assertEqual(provenance["baselineManifest"]["path"], "Vendor/Codex/manifest.json")
+        self.assertEqual(provenance["baselineManifest"]["sha256"], artifact.sha256(BASELINE))
+        self.assertEqual(provenance["verificationTools"]["lipo"], str(self.lipo.resolve()))
+        self.assertEqual(provenance["verificationTools"]["codesign"], str(self.codesign.resolve()))
+        tagged_provenance = json.loads((tagged / "candidate-provenance.json").read_text(encoding="utf-8"))
+        self.assertEqual(tagged_provenance["selectionMode"], "explicit-tag")
+
+        verified = artifact.load_manifest(first / manifest_name, expected_version=VERSION)
+        self.assertEqual(verified["tag"], TAG)
+        report = (first / "candidate-report.md").read_text(encoding="utf-8")
+        for required in (
+            "NON-PROMOTABLE TEST FIXTURE",
+            "test-fixture-non-promotable",
+            "Schema-gate work",
+            "memory_mode",
+            "thread/start",
+            "thread/resume",
+            "mcp__RepoPromptCE",
+            "minimumExternalVersion",
+            "License and NOTICE review",
+            "Manual approval and soak",
+            "0.144.6",
+            str(self.lipo),
+            str(self.codesign),
+        ):
+            self.assertIn(required, report)
+        self.assertEqual(BASELINE.read_bytes(), original_manifest)
+
+    def test_fixture_mode_and_provenance_boundaries_fail_closed(self) -> None:
+        offline_without_mode = self._run_raw(
+            "--version",
+            VERSION,
+            "--release-json",
+            str(self.release_path),
+            "--asset-dir",
+            str(self.assets),
+            "--output-dir",
+            str(self.temp / "unmarked-offline"),
+            expected=1,
+        )
+        self.assertIn("--fixture-mode is required", offline_without_mode.stderr)
+
+        latest_fixture = self._run(
+            self.temp / "fixture-latest",
+            selector=("--latest-stable",),
+            expected=1,
+        )
+        self.assertIn("--latest-stable is unavailable in fixture mode", latest_fixture.stderr)
+
+        baseline_copy = self.temp / "baseline.json"
+        shutil.copyfile(BASELINE, baseline_copy)
+        for label, override in (
+            ("baseline", ("--baseline-manifest", str(baseline_copy))),
+            ("lipo", ("--lipo", str(self.lipo))),
+            ("codesign", ("--codesign", str(self.codesign))),
+        ):
+            with self.subTest(label=label):
+                rejected = self._run_raw(
+                    "--version",
+                    VERSION,
+                    *override,
+                    "--output-dir",
+                    str(self.temp / f"official-override-{label}"),
+                    expected=1,
+                )
+                self.assertIn("--fixture-mode is required", rejected.stderr)
+
+    def test_release_name_is_json_encoded_before_markdown_rendering(self) -> None:
+        release = self._release()
+        release["name"] = "unsafe` name\n## INJECTED [link](https://example.invalid)"
+        self._write_release(release)
+        output = self.temp / "encoded-name"
+        self._run(output)
+        report = (output / "candidate-report.md").read_text(encoding="utf-8")
+        self.assertNotIn("\n## INJECTED", report)
+        self.assertIn("\\n## INJECTED", report)
+        self.assertIn("\\u0060", report)
+
+    def test_online_download_and_archive_expansion_are_bounded(self) -> None:
+        class FakeResponse(io.BytesIO):
+            def __init__(self, payload: bytes, content_length: str | None = None) -> None:
+                super().__init__(payload)
+                self.headers = {} if content_length is None else {"Content-Length": content_length}
+
+            def __enter__(self) -> "FakeResponse":
+                return self
+
+            def __exit__(self, *_args: object) -> None:
+                self.close()
+
+            @staticmethod
+            def geturl() -> str:
+                return "https://release-assets.githubusercontent.com/candidate"
+
+        oversized_output = self.temp / "oversized-download"
+        with mock.patch.object(
+            candidate.urllib.request,
+            "urlopen",
+            return_value=FakeResponse(b"12345"),
+        ):
+            with self.assertRaisesRegex(candidate.CandidateError, "exceeded release metadata size"):
+                candidate.download_asset("https://github.com/openai/codex/asset", oversized_output, 4)
+        self.assertFalse(oversized_output.exists())
+
+        wrong_length_output = self.temp / "wrong-content-length"
+        with mock.patch.object(
+            candidate.urllib.request,
+            "urlopen",
+            return_value=FakeResponse(b"1234", content_length="5"),
+        ):
+            with self.assertRaisesRegex(candidate.CandidateError, "response size disagrees"):
+                candidate.download_asset("https://github.com/openai/codex/asset", wrong_length_output, 4)
+        self.assertFalse(wrong_length_output.exists())
+
+        archive = self.assets / "codex-package-aarch64-apple-darwin.tar.gz"
+        with mock.patch.object(candidate, "MAX_EXPANDED_ARCHIVE_SIZE", 1):
+            with self.assertRaisesRegex(candidate.CandidateError, "expanded size"):
+                candidate.archive_paths(archive)
+        with mock.patch.object(candidate, "MAX_ARCHIVE_MEMBERS", 1):
+            with self.assertRaisesRegex(candidate.CandidateError, "member safety limit"):
+                candidate.archive_paths(archive)
+
+    def test_release_metadata_rejects_draft_prerelease_mismatch_missing_and_duplicate_assets(self) -> None:
+        baseline = self._release()
+        checksum_asset = copy.deepcopy(baseline["assets"][0])
+        mutations = {
+            "draft": lambda value: value.__setitem__("draft", True),
+            "prerelease": lambda value: value.__setitem__("prerelease", True),
+            "tag mismatch": lambda value: value.__setitem__("tag_name", "rust-v0.145.1"),
+            "missing asset": lambda value: value["assets"].pop(),
+            "duplicate asset": lambda value: value["assets"].append(copy.deepcopy(checksum_asset)),
+            "wrong asset URL": lambda value: value["assets"][0].__setitem__(
+                "browser_download_url", "https://example.invalid/codex-package_SHA256SUMS"
+            ),
+        }
+        for index, (label, mutate) in enumerate(mutations.items()):
+            with self.subTest(label=label):
+                release = copy.deepcopy(baseline)
+                mutate(release)
+                self._write_release(release)
+                self._run(self.temp / f"rejected-{index}", expected=1)
+                self.assertFalse((self.temp / f"rejected-{index}").exists())
+        self._write_release(baseline)
+
+    def test_checksum_disagreement_fails_without_candidate_output(self) -> None:
+        sums = self.assets / "codex-package_SHA256SUMS"
+        lines = sums.read_text(encoding="utf-8").splitlines()
+        lines[0] = f"{'0' * 64}  {lines[0].split()[1]}"
+        sums.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        release = self._release()
+        release["assets"][0]["size"] = sums.stat().st_size
+        self._write_release(release)
+        output = self.temp / "checksum-rejected"
+        result = self._run(output, expected=1)
+        self.assertIn("checksum mismatch", result.stderr)
+        self.assertFalse(output.exists())
+
+    def test_package_layout_drift_fails_closed(self) -> None:
+        unexpected = self.sources / "aarch64-apple-darwin" / "unexpected-runtime-file"
+        unexpected.write_text("drift\n", encoding="utf-8")
+        self._rebuild_assets_and_release()
+        output = self.temp / "layout-rejected"
+        result = self._run(output, expected=1)
+        self.assertIn("package layout drift", result.stderr)
+        self.assertFalse(output.exists())
+
+    def test_signing_identity_drift_fails_closed(self) -> None:
+        output = self.temp / "signature-rejected"
+        result = self._run(output, env={"FAKE_TEAM_IDENTIFIER": "WRONGTEAM"}, expected=1)
+        self.assertIn("TeamIdentifier", result.stderr)
+        self.assertFalse(output.exists())
+
+    def test_selector_and_output_safety_fail_closed(self) -> None:
+        malformed = self._run(
+            self.temp / "malformed",
+            selector=("--version", "0.145.0-rc.1"),
+            expected=1,
+        )
+        self.assertIn("stable numeric triplet", malformed.stderr)
+
+        not_newer = self._run(
+            self.temp / "not-newer",
+            selector=("--version", "0.144.6"),
+            expected=1,
+        )
+        self.assertIn("must be newer", not_newer.stderr)
+
+        vendor_output = ROOT / "Vendor" / "Codex" / "candidate-test-output"
+        self.assertFalse(vendor_output.exists())
+        rejected = self._run(vendor_output, expected=1)
+        self.assertIn("must not be written under Vendor", rejected.stderr)
+        self.assertFalse(vendor_output.exists())
+
+        existing = self.temp / "existing"
+        existing.mkdir()
+        rejected = self._run(existing, expected=1)
+        self.assertIn("already exists", rejected.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Scripts/test_codex_update_workflow.py
+++ b/Scripts/test_codex_update_workflow.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Tests for the structured Codex update workflow contract validator."""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+import validate_codex_update_workflow as validator
+
+
+class CodexUpdateWorkflowValidatorTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = Path(tempfile.mkdtemp(prefix="codex-update-workflow-test-"))
+        self.addCleanup(lambda: shutil.rmtree(self.temp, ignore_errors=True))
+        self.baseline = validator.DEFAULT_WORKFLOW.read_text(encoding="utf-8")
+
+    def validate_text(self, text: str) -> None:
+        path = self.temp / "workflow.yml"
+        path.write_text(text, encoding="utf-8")
+        validator.validate_workflow(path)
+
+    def test_repository_workflow_satisfies_structured_contract(self) -> None:
+        validator.validate_workflow()
+
+    def test_security_and_trigger_mutations_fail_closed(self) -> None:
+        mutations = {
+            "automatic push trigger": self.baseline.replace(
+                "  workflow_dispatch:\n",
+                "  workflow_dispatch:\n  push:\n    branches: [main]\n",
+                1,
+            ),
+            "write permission": self.baseline.replace("contents: read", "contents: write", 1),
+            "job permission override": self.baseline.replace(
+                "    runs-on: macos-26\n",
+                "    runs-on: macos-26\n    permissions:\n      contents: write\n",
+                1,
+            ),
+            "non-main gate": self.baseline.replace("refs/heads/main", "refs/heads/candidate", 1),
+            "persisted checkout credentials": self.baseline.replace(
+                "persist-credentials: false",
+                "persist-credentials: true",
+                1,
+            ),
+            "candidate tool substitution": self.baseline.replace(
+                "python3 Scripts/codex_update_candidate.py",
+                "python3 Scripts/other_candidate.py",
+                1,
+            ),
+            "fixture input in official lane": self.baseline.replace(
+                "--output-dir .build/codex-update-candidate/evidence",
+                "--fixture-mode --output-dir .build/codex-update-candidate/evidence",
+                1,
+            ),
+            "upload action substitution": self.baseline.replace(
+                validator.UPLOAD_ACTION,
+                "actions/upload-artifact@v4",
+                1,
+            ),
+            "upload path substitution": self.baseline.replace(
+                "path: .build/codex-update-candidate/evidence",
+                "path: .build",
+                1,
+            ),
+        }
+        for label, mutated in mutations.items():
+            with self.subTest(label=label):
+                self.assertNotEqual(mutated, self.baseline)
+                with self.assertRaises(validator.WorkflowContractError):
+                    self.validate_text(mutated)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Scripts/validate_codex_update_workflow.py
+++ b/Scripts/validate_codex_update_workflow.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Validate the manual, read-only Codex candidate evidence workflow contract."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Sequence
+
+
+ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_WORKFLOW = ROOT / ".github" / "workflows" / "codex-update-candidate.yml"
+CHECKOUT_ACTION = "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"
+UPLOAD_ACTION = "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02"
+EXPECTED_STEP_NAMES = (
+    "Check out trusted main",
+    "Validate candidate selector",
+    "Prepare guarded candidate evidence",
+    "Upload candidate evidence",
+)
+EXPECTED_SELECTOR_LINES = (
+    "set -euo pipefail",
+    "count=0",
+    "args=()",
+    'if [[ -n "$INPUT_VERSION" ]]; then',
+    "count=$((count + 1))",
+    'args+=(--version "$INPUT_VERSION")',
+    "fi",
+    'if [[ -n "$INPUT_TAG" ]]; then',
+    "count=$((count + 1))",
+    'args+=(--tag "$INPUT_TAG")',
+    "fi",
+    'if [[ "$INPUT_LATEST" == "true" ]]; then',
+    "count=$((count + 1))",
+    "args+=(--latest-stable)",
+    "fi",
+    'if [[ "$count" -ne 1 ]]; then',
+    'echo "Set exactly one of version, tag, or latest_stable." >&2',
+    "exit 1",
+    "fi",
+    'printf \'%s\\0\' "${args[@]}" > "$RUNNER_TEMP/codex-candidate-selector"',
+)
+EXPECTED_CANDIDATE_LINES = (
+    "set -euo pipefail",
+    "args=()",
+    'while IFS= read -r -d \'\' value; do args+=("$value"); done < "$RUNNER_TEMP/codex-candidate-selector"',
+    "python3 Scripts/codex_update_candidate.py \\",
+    '"${args[@]}" \\',
+    "--output-dir .build/codex-update-candidate/evidence",
+)
+MAPPING_PATTERN = re.compile(r"([A-Za-z0-9_-]+):(?:[ ]*(.*))?")
+
+
+class WorkflowContractError(RuntimeError):
+    pass
+
+
+def indentation(line: str) -> int:
+    if "\t" in line[: len(line) - len(line.lstrip())]:
+        raise WorkflowContractError("workflow indentation must not contain tabs")
+    return len(line) - len(line.lstrip(" "))
+
+
+def mapping_at(lines: Sequence[str], indent: int) -> dict[str, tuple[str, int]]:
+    result: dict[str, tuple[str, int]] = {}
+    prefix = " " * indent
+    for index, line in enumerate(lines):
+        if not line.strip() or line.lstrip().startswith("#") or indentation(line) != indent:
+            continue
+        raw = line[len(prefix) :]
+        match = MAPPING_PATTERN.fullmatch(raw)
+        if match is None:
+            raise WorkflowContractError(f"expected a mapping at line {index + 1}: {line!r}")
+        key, value = match.group(1), match.group(2) or ""
+        if key in result:
+            raise WorkflowContractError(f"duplicate workflow key at indentation {indent}: {key}")
+        result[key] = value, index
+    return result
+
+
+def block_for(lines: Sequence[str], key: str, indent: int) -> list[str]:
+    entries = mapping_at(lines, indent)
+    if key not in entries:
+        raise WorkflowContractError(f"missing workflow key: {key}")
+    _value, start = entries[key]
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        if lines[index].strip() and indentation(lines[index]) <= indent:
+            end = index
+            break
+    return list(lines[start:end])
+
+
+def scalar(value: str) -> str:
+    stripped = value.strip()
+    if len(stripped) >= 2 and stripped[0] == stripped[-1] and stripped[0] in {"'", '"'}:
+        return stripped[1:-1]
+    return stripped
+
+
+def step_blocks(lines: Sequence[str]) -> list[tuple[str, list[str]]]:
+    starts: list[int] = []
+    names: list[str] = []
+    for index, line in enumerate(lines):
+        if not line.strip() or indentation(line) != 6:
+            continue
+        match = re.fullmatch(r" {6}- name:[ ]*(.+)", line)
+        if match is None:
+            raise WorkflowContractError(f"unexpected step entry: {line!r}")
+        starts.append(index)
+        names.append(scalar(match.group(1)))
+    blocks: list[tuple[str, list[str]]] = []
+    for position, start in enumerate(starts):
+        end = starts[position + 1] if position + 1 < len(starts) else len(lines)
+        blocks.append((names[position], list(lines[start:end])))
+    return blocks
+
+
+def block_scalar_text(lines: Sequence[str], key: str, indent: int) -> str:
+    entries = mapping_at(lines, indent)
+    value, start = entries.get(key, ("", -1))
+    if start < 0 or value not in {"|", "|-", ">", ">-"}:
+        raise WorkflowContractError(f"step must contain a block scalar {key}")
+    content: list[str] = []
+    for line in lines[start + 1 :]:
+        if line.strip() and indentation(line) <= indent:
+            break
+        if line.strip():
+            content.append(line.strip())
+    return "\n".join(content)
+
+
+def validate_workflow(path: Path = DEFAULT_WORKFLOW) -> None:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as exc:
+        raise WorkflowContractError(f"could not read workflow {path}: {exc}") from exc
+    lines = text.splitlines()
+
+    root = mapping_at(lines, 0)
+    if set(root) != {"name", "on", "permissions", "jobs"}:
+        raise WorkflowContractError(f"unexpected root workflow keys: {sorted(set(root))}")
+
+    triggers = mapping_at(block_for(lines, "on", 0)[1:], 2)
+    if set(triggers) != {"workflow_dispatch"}:
+        raise WorkflowContractError(
+            f"Codex candidate workflow must have only workflow_dispatch; found {sorted(triggers)}"
+        )
+
+    permissions = mapping_at(block_for(lines, "permissions", 0)[1:], 2)
+    permission_values = {key: scalar(value) for key, (value, _index) in permissions.items()}
+    if permission_values != {"contents": "read"}:
+        raise WorkflowContractError(
+            f"Codex candidate workflow permissions must be exactly contents: read; found {permission_values}"
+        )
+
+    jobs_block = block_for(lines, "jobs", 0)
+    jobs = mapping_at(jobs_block[1:], 2)
+    if set(jobs) != {"evidence"}:
+        raise WorkflowContractError(f"workflow must contain only the evidence job; found {sorted(jobs)}")
+    evidence = block_for(jobs_block[1:], "evidence", 2)
+    evidence_mapping = mapping_at(evidence[1:], 4)
+    if set(evidence_mapping) != {"name", "if", "runs-on", "steps"}:
+        raise WorkflowContractError(f"unexpected evidence job keys: {sorted(evidence_mapping)}")
+    if scalar(evidence_mapping["if"][0]) != "github.ref == 'refs/heads/main'":
+        raise WorkflowContractError("evidence job must be gated to refs/heads/main")
+    if scalar(evidence_mapping["runs-on"][0]) != "macos-26":
+        raise WorkflowContractError("evidence job must run on macos-26")
+
+    steps = step_blocks(block_for(evidence[1:], "steps", 4)[1:])
+    if tuple(name for name, _block in steps) != EXPECTED_STEP_NAMES:
+        raise WorkflowContractError(f"unexpected workflow steps: {[name for name, _block in steps]}")
+    by_name = {name: block for name, block in steps}
+
+    checkout = by_name[EXPECTED_STEP_NAMES[0]]
+    checkout_mapping = mapping_at(checkout[1:], 8)
+    if scalar(checkout_mapping.get("uses", ("", 0))[0]) != CHECKOUT_ACTION:
+        raise WorkflowContractError("checkout action must remain SHA-pinned")
+    checkout_with = mapping_at(block_for(checkout[1:], "with", 8)[1:], 10)
+    if {key: scalar(value) for key, (value, _index) in checkout_with.items()} != {
+        "persist-credentials": "false"
+    }:
+        raise WorkflowContractError("checkout must set only persist-credentials: false")
+
+    selector_text = block_scalar_text(by_name[EXPECTED_STEP_NAMES[1]][1:], "run", 8)
+    if tuple(selector_text.splitlines()) != EXPECTED_SELECTOR_LINES:
+        raise WorkflowContractError("selector step command contract drifted")
+
+    candidate_text = block_scalar_text(by_name[EXPECTED_STEP_NAMES[2]][1:], "run", 8)
+    if tuple(candidate_text.splitlines()) != EXPECTED_CANDIDATE_LINES:
+        raise WorkflowContractError("official candidate command contract drifted")
+
+    upload = by_name[EXPECTED_STEP_NAMES[3]]
+    upload_mapping = mapping_at(upload[1:], 8)
+    if scalar(upload_mapping.get("uses", ("", 0))[0]) != UPLOAD_ACTION:
+        raise WorkflowContractError("upload-artifact action must remain SHA-pinned")
+    upload_with = mapping_at(block_for(upload[1:], "with", 8)[1:], 10)
+    upload_values = {key: scalar(value) for key, (value, _index) in upload_with.items()}
+    if upload_values != {
+        "name": "RepoPrompt-CE-Codex-runtime-update-candidate",
+        "path": ".build/codex-update-candidate/evidence",
+        "if-no-files-found": "error",
+    }:
+        raise WorkflowContractError(f"upload evidence contract drifted: {upload_values}")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--workflow", default=str(DEFAULT_WORKFLOW))
+    args = parser.parse_args(argv)
+    try:
+        validate_workflow(Path(args.workflow))
+    except WorkflowContractError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    print(f"OK: Codex update workflow is manual, main-only, read-only, and artifact-only: {args.workflow}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -119,6 +119,48 @@ updating every archive and exact-tree hash in the manifest, capturing the new
 license/notice files, and rerunning the offline artifact tests plus a protected
 release candidate. Never derive a new pin from an unverified local installation.
 
+### Guarded Codex update candidates
+
+`Scripts/codex_update_candidate.py` prepares evidence for a possible rotation; it
+does not edit or replace `Vendor/Codex/manifest.json`. Select exactly one explicit
+stable version/tag, or opt in explicitly to GitHub's latest stable release:
+
+```bash
+make codex-update-candidate CODEX_CANDIDATE_VERSION=0.145.0
+make codex-update-candidate CODEX_CANDIDATE_TAG=rust-v0.145.0
+make codex-update-candidate CODEX_CANDIDATE_LATEST=1
+```
+
+Official mode accepts no baseline or verification-tool override: it uses the
+repository manifest, `/usr/bin/lipo`, `/usr/bin/codesign`, and live official
+`openai/codex` metadata/assets. `--release-json`, `--asset-dir`, or any non-default
+baseline/tool requires `--fixture-mode`; that mode rejects `--latest-stable` and
+marks the report, manifest filename, metadata, marker file, and provenance as a
+**NON-PROMOTABLE TEST FIXTURE**. Fixture provenance records the baseline path and
+digest, explicit selection mode, input sources, and effective tools so fixture
+evidence cannot make an official-online claim.
+
+The tool rejects draft and prerelease releases, requires exactly one checksum
+asset and both exact macOS package assets, bounds downloads to the release-declared
+size, bounds archive members and total expansion, and verifies the archives
+against the upstream checksums. It then
+uses the same artifact verifier as packaging to reject extracted-layout, Mach-O
+inventory/architecture, normalized-payload, and OpenAI signing-identity drift.
+The official output directory contains a proposed `candidate-manifest.json`,
+`candidate-provenance.json`, sanitized `release-metadata.json`, the upstream
+checksum file, self-checksums, and a deterministic `candidate-report.md`. The live
+0.144.6 pin remains authoritative
+until a maintainer reviews and deliberately applies a complete rotation change.
+
+The manual **Codex Runtime Update Candidate** workflow runs only from `main`, has
+`contents: read`, uploads those evidence files, and cannot commit, open a pull
+request, promote Tip, or publish a release. Local and workflow runs share the same
+repository-owned tool. A report is not approval: it leaves the external override
+floor as an explicit policy decision and requires schema-gate review (including
+`memory_mode`, MCP direct-only behavior, and `thread/start`/`thread/resume`),
+license/NOTICE review, focused validation, rollback confirmation, maintainer
+approval, and soak before any stable rotation.
+
 ## Release ownership
 
 Ordinary contributors prepare release candidates. They do not need Apple


### PR DESCRIPTION
## Summary

- add a repository-owned guarded Codex runtime update candidate generator
- verify official stable release metadata, checksums, both macOS packages, bounded extraction, package layout, Mach-O architecture, and OpenAI signing through the existing artifact authority
- publish deterministic candidate manifest/report/provenance evidence without modifying the live pin
- add a manual, main-only, read-only GitHub Actions evidence workflow
- add explicit non-promotable fixture mode plus structured workflow contract validation
- document the review, schema, behavior, legal, floor-policy, rollback, approval, and soak gates

## Safety model

- `Vendor/Codex/manifest.json` remains the sole runtime artifact authority
- bundled Codex remains pinned to **0.144.6** in this PR
- no automatic manifest application, PR creation, merge, Tip promotion, or release
- `minimumExternalVersion` remains an explicit maintainer decision during a later reviewed rotation
- fixture/offline evidence cannot present itself as official or promotable

## Validation

- `Scripts/test_codex_update_candidate.py`: 9 passed
- `Scripts/test_codex_update_workflow.py`: 2 passed
- `Scripts/test_codex_runtime_artifact.py`: 24 passed
- Codex vendor and repository guardrails passed
- mandatory commit preflight passed
- mandatory PR-ready preflight passed, including outgoing-range secret scan, conductor self-tests, and generated Xcode workspace validation

## Follow-up

After this lands, prepare a separate reviewed candidate for the desired stable Codex version, explicitly resolve the external override floor, run the schema/behavior/legal gates, and soak it before promotion.
