### PR TITLE
Point fork dependencies at RepoPrompt organization

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -247,7 +247,7 @@
     {
       "identity" : "swift-sdk",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/provencher/swift-sdk.git",
+      "location" : "https://github.com/repoprompt/swift-sdk.git",
       "state" : {
         "revision" : "85dec2fc7a27252bc33dc7728be6af6b3bd398c0"
       }
@@ -298,7 +298,7 @@
     {
       "identity" : "swiftopenai",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/provencher/SwiftOpenAI",
+      "location" : "https://github.com/repoprompt/SwiftOpenAI",
       "state" : {
         "revision" : "1211782eb337e7968124448a20d9260df1952012"
       }

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ var packageDependencies: [Package.Dependency] = [
     .package(url: "https://github.com/swiftlang/swift-markdown", exact: "0.6.0"),
     .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", exact: "2.8.0"),
     .package(url: "https://github.com/apple/swift-system.git", exact: "1.6.4"),
-    .package(url: "https://github.com/provencher/swift-sdk.git", revision: "85dec2fc7a27252bc33dc7728be6af6b3bd398c0"),
+    .package(url: "https://github.com/repoprompt/swift-sdk.git", revision: "85dec2fc7a27252bc33dc7728be6af6b3bd398c0"),
     // RepoPromptApp and RepoPromptCodeMapCore share this customized wrapper/runtime graph.
     .package(
         url: "https://github.com/repoprompt/swift-tree-sitter.git",
@@ -38,7 +38,7 @@ var packageDependencies: [Package.Dependency] = [
     .package(url: "https://github.com/tree-sitter/tree-sitter-cpp", exact: "0.23.4"),
     .package(url: "https://github.com/tree-sitter/tree-sitter-php.git", exact: "0.24.2"),
     .package(url: "https://github.com/jamesrochabrun/SwiftAnthropic", revision: "b7d030cd7453f314c780f5492385f73d704cbd5d"),
-    .package(url: "https://github.com/provencher/SwiftOpenAI", revision: "1211782eb337e7968124448a20d9260df1952012"),
+    .package(url: "https://github.com/repoprompt/SwiftOpenAI", revision: "1211782eb337e7968124448a20d9260df1952012"),
     .package(path: "Vendor/UniversalCharsetDetection"),
     .package(url: "https://github.com/loopwork-ai/JSONSchema.git", exact: "1.3.0"),
     .package(url: "https://github.com/loopwork-ai/ontology.git", exact: "0.6.0"),

--- a/ThirdPartyLicenses/swiftpm/inventory.tsv
+++ b/ThirdPartyLicenses/swiftpm/inventory.tsv
@@ -25,13 +25,13 @@ swift-nio-http2	1.43.0	https://github.com/apple/swift-nio-http2.git	swift-nio-ht
 swift-nio-ssl	2.37.0	https://github.com/apple/swift-nio-ssl.git	swift-nio-ssl/
 swift-nio-transport-services	1.28.0	https://github.com/apple/swift-nio-transport-services.git	swift-nio-transport-services/
 swift-numerics	1.1.1	https://github.com/apple/swift-numerics.git	swift-numerics/
-swift-sdk	85dec2fc7a27252bc33dc7728be6af6b3bd398c0	https://github.com/provencher/swift-sdk.git	swift-sdk/
+swift-sdk	85dec2fc7a27252bc33dc7728be6af6b3bd398c0	https://github.com/repoprompt/swift-sdk.git	swift-sdk/
 swift-service-context	1.3.0	https://github.com/apple/swift-service-context.git	swift-service-context/
 swift-service-lifecycle	2.8.0	https://github.com/swift-server/swift-service-lifecycle.git	swift-service-lifecycle/
 swift-system	1.6.4	https://github.com/apple/swift-system.git	swift-system/
 swift-tree-sitter	a778ef4fb7f0d3ad00185f42ce83c688373c4361	https://github.com/repoprompt/swift-tree-sitter.git	../tree-sitter/README.md
 swiftanthropic	b7d030cd7453f314c780f5492385f73d704cbd5d	https://github.com/jamesrochabrun/SwiftAnthropic	swiftanthropic/
-swiftopenai	1211782eb337e7968124448a20d9260df1952012	https://github.com/provencher/SwiftOpenAI	swiftopenai/
+swiftopenai	1211782eb337e7968124448a20d9260df1952012	https://github.com/repoprompt/SwiftOpenAI	swiftopenai/
 tree-sitter	0.25.10	https://github.com/tree-sitter/tree-sitter	../tree-sitter/README.md
 tree-sitter-c	0.24.2	https://github.com/tree-sitter/tree-sitter-c	../tree-sitter/README.md
 tree-sitter-c-sharp	0.23.5	https://github.com/tree-sitter/tree-sitter-c-sharp.git	../tree-sitter/README.md

--- a/docs/open-source-readiness.md
+++ b/docs/open-source-readiness.md
@@ -48,10 +48,10 @@ The root [`Package.swift`](../Package.swift) uses exact versions or fixed revisi
 
 | Dependency | Current manifest form | Current `Package.resolved` state | Readiness note |
 | --- | --- | --- | --- |
-| `https://github.com/provencher/swift-sdk.git` | `revision` | `cb6a62f7c266ed535792b3e9e6e05dc3f0dac8e4` | Pinned. |
+| `https://github.com/repoprompt/swift-sdk.git` | `revision` | `85dec2fc7a27252bc33dc7728be6af6b3bd398c0` | Pinned. |
 | `https://github.com/repoprompt/swift-tree-sitter.git` | `revision` | `a778ef4fb7f0d3ad00185f42ce83c688373c4361` | Customized wrapper fork pinned to one remote authority. |
 | `https://github.com/jamesrochabrun/SwiftAnthropic` | `revision` | `b7d030cd7453f314c780f5492385f73d704cbd5d` | Pinned. |
-| `https://github.com/provencher/SwiftOpenAI` | `revision` | `1211782eb337e7968124448a20d9260df1952012` | Pinned. |
+| `https://github.com/repoprompt/SwiftOpenAI` | `revision` | `1211782eb337e7968124448a20d9260df1952012` | Pinned. |
 
 Released, buildable Tree-sitter grammar packages use source-preserving exact semantic-version requirements, while committed `Package.resolved` revisions continue to define the precise resolved snapshots and CodeMap cache identity. The customized `SwiftTreeSitter` wrapper is pinned directly to the RepoPrompt fork revision `a778ef4fb7f0d3ad00185f42ce83c688373c4361`. The curated [`ThirdPartyLicenses/tree-sitter/`](../ThirdPartyLicenses/tree-sitter/) bundle maps that wrapper revision, the grammar requirements and revisions, its resolved Tree-sitter 0.25.10 runtime, and the runtime's ICU subset notice. `Package.resolved` should stay committed so local and CI resolutions match unless maintainers intentionally update dependency versions.
 


### PR DESCRIPTION
## Summary

- point the `swift-sdk` dependency at `repoprompt/swift-sdk`
- point the `SwiftOpenAI` dependency at `repoprompt/SwiftOpenAI`
- update the resolved package metadata, SwiftPM license inventory, and open-source readiness documentation

Both repositories were transferred from the `provencher` account to the `repoprompt` organization. The pinned revisions are unchanged and were verified to exist at their new locations.

## Validation

- contribution commit preflight
- contribution push preflight
- GitHub API lookup of both pinned commits at the new repository locations
- no remaining committed `github.com/provencher` dependency URLs