### PR TITLE
Show build numbers in Sparkle update alerts

### DIFF
--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -2994,6 +2994,10 @@ label_generated_tip_appcast""",
         sparkle = "http://www.andymatuschak.org/xml-namespaces/sparkle"
         self.assertEqual(item.findtext(f"{{{sparkle}}}version"), "29.8.52")
         self.assertEqual(item.findtext(f"{{{sparkle}}}shortVersionString"), "9.8.7")
+        self.assertNotEqual(
+            item.findtext(f"{{{sparkle}}}shortVersionString"),
+            item.findtext(f"{{{sparkle}}}version"),
+        )
         self.assertEqual(item.findtext("title"), "Tip build 29.8.52 · v9.8.7 · commit abc1234def56")
         self.assertEqual(
             item.findtext(f"{{{sparkle}}}releaseNotesLink"),

--- a/Sources/RepoPrompt/App/AppDelegate.swift
+++ b/Sources/RepoPrompt/App/AppDelegate.swift
@@ -28,6 +28,7 @@ class AppDelegate: NSObject, ObservableObject, NSApplicationDelegate {
 
     let sparkleManager: SparkleUpdaterManager
     private let sparkleFeedDelegate: SparkleUpdateFeedDelegate
+    private let sparkleVersionDisplay: SparkleVersionDisplay
 
     /// NEW: weak reference injected by `RepoPromptApp`
     weak var windowStatesManager: WindowStatesManager?
@@ -49,10 +50,12 @@ class AppDelegate: NSObject, ObservableObject, NSApplicationDelegate {
         // Initialize Sparkle updater
         let feedDelegate = SparkleUpdateFeedDelegate()
         sparkleFeedDelegate = feedDelegate
+        let versionDisplay = SparkleVersionDisplay()
+        sparkleVersionDisplay = versionDisplay
         let updaterController = SPUStandardUpdaterController(
             startingUpdater: false,
             updaterDelegate: feedDelegate,
-            userDriverDelegate: nil
+            userDriverDelegate: versionDisplay
         )
         sparkleManager = SparkleUpdaterManager(updaterController: updaterController)
         SparkleUpdaterManager.shared = sparkleManager

--- a/Sources/RepoPrompt/App/Sparkle/AvailableUpdateNotice.swift
+++ b/Sources/RepoPrompt/App/Sparkle/AvailableUpdateNotice.swift
@@ -142,6 +142,26 @@ struct AvailableUpdateNotice: Equatable {
         }
     }
 
+    static func marketingVersion(fromTipTitle title: String?) -> String? {
+        guard let title = title?.trimmingCharacters(in: .whitespacesAndNewlines),
+              title.lowercased().hasPrefix("tip build "),
+              let versionSeparator = title.range(of: " · v", options: .caseInsensitive),
+              let commitSeparator = title.range(
+                  of: " · commit ",
+                  options: .caseInsensitive,
+                  range: versionSeparator.upperBound ..< title.endIndex
+              )
+        else { return nil }
+
+        let candidate = title[versionSeparator.upperBound ..< commitSeparator.lowerBound]
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let allowedCharacters = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: ".-"))
+        guard !candidate.isEmpty,
+              candidate.unicodeScalars.allSatisfy({ allowedCharacters.contains($0) })
+        else { return nil }
+        return candidate
+    }
+
     static func shortCommitSHA(fromTipTitle title: String?) -> String? {
         guard let title,
               let separator = title.range(of: " · commit ", options: .caseInsensitive)

--- a/Sources/RepoPrompt/App/Sparkle/SparkleUpdateManager.swift
+++ b/Sources/RepoPrompt/App/Sparkle/SparkleUpdateManager.swift
@@ -402,10 +402,14 @@ final class SparkleUpdaterManager: ObservableObject {
         } ?? isVersion(appcastInfo.latestVersion, newerThan: currentVersion)
 
         if isNewer {
-            let sanitizedLatestVersion = Self.sanitizeVersionString(appcastInfo.latestVersion)
+            let presentationVersion = Self.presentationVersion(
+                channel: checkedChannel,
+                displayVersion: appcastInfo.latestVersion,
+                title: appcastInfo.title
+            )
             applyAvailableUpdateState(
                 channel: checkedChannel,
-                version: sanitizedLatestVersion,
+                version: presentationVersion,
                 buildNumber: appcastInfo.latestBuildNumber,
                 shortCommitSHA: AvailableUpdateNotice.shortCommitSHA(fromTipTitle: appcastInfo.title),
                 date: appcastInfo.date,
@@ -476,7 +480,11 @@ final class SparkleUpdaterManager: ObservableObject {
 
                     self.applyAvailableUpdateState(
                         channel: resultChannel,
-                        version: Self.sanitizeVersionString(appcastItem.displayVersionString),
+                        version: Self.presentationVersion(
+                            channel: resultChannel,
+                            displayVersion: appcastItem.displayVersionString,
+                            title: appcastItem.title
+                        ),
                         buildNumber: appcastItem.versionString,
                         shortCommitSHA: AvailableUpdateNotice.shortCommitSHA(fromTipTitle: appcastItem.title),
                         date: appcastItem.date,
@@ -521,6 +529,16 @@ final class SparkleUpdaterManager: ObservableObject {
         else { return true }
         guard let candidateBuild = SparkleBuildVersion(candidateBuildNumber) else { return false }
         return candidateBuild >= knownBuild
+    }
+
+    static func presentationVersion(
+        channel: UpdateChannel,
+        displayVersion: String,
+        title: String?
+    ) -> String {
+        let fallbackVersion = sanitizeVersionString(displayVersion)
+        guard channel == .tip else { return fallbackVersion }
+        return AvailableUpdateNotice.marketingVersion(fromTipTitle: title) ?? fallbackVersion
     }
 
     static func sanitizeVersionString(_ version: String) -> String {

--- a/Sources/RepoPrompt/App/Sparkle/SparkleVersionDisplay.swift
+++ b/Sources/RepoPrompt/App/Sparkle/SparkleVersionDisplay.swift
@@ -1,0 +1,87 @@
+import Foundation
+import Sparkle
+
+struct SparkleVersionIdentities: Equatable {
+    let available: String
+    let installed: String
+}
+
+/// Supplies Sparkle's stock user driver with complete available and installed
+/// identities while leaving update comparison on the underlying build versions.
+final class SparkleVersionDisplay: NSObject, SPUStandardUserDriverDelegate, SUVersionDisplay {
+    func standardUserDriverRequestsVersionDisplayer() -> (any SUVersionDisplay)? {
+        self
+    }
+
+    func formatUpdateVersion(
+        fromUpdate update: SUAppcastItem,
+        andBundleDisplayVersion inOutBundleDisplayVersion: AutoreleasingUnsafeMutablePointer<NSString>,
+        withBundleVersion bundleVersion: String
+    ) -> String {
+        let identities = Self.formattedIdentities(
+            availableDisplayVersion: update.displayVersionString,
+            availableBuildNumber: update.versionString,
+            availableTitle: update.title,
+            installedDisplayVersion: inOutBundleDisplayVersion.pointee as String,
+            installedBuildNumber: bundleVersion
+        )
+        return Self.apply(
+            identities,
+            toInstalledDisplayVersion: inOutBundleDisplayVersion
+        )
+    }
+
+    static func apply(
+        _ identities: SparkleVersionIdentities,
+        toInstalledDisplayVersion installedDisplayVersion: AutoreleasingUnsafeMutablePointer<NSString>
+    ) -> String {
+        installedDisplayVersion.pointee = identities.installed as NSString
+        return identities.available
+    }
+
+    static func formattedIdentities(
+        availableDisplayVersion: String,
+        availableBuildNumber: String,
+        availableTitle: String?,
+        installedDisplayVersion: String,
+        installedBuildNumber: String
+    ) -> SparkleVersionIdentities {
+        let availableMarketingVersion = AvailableUpdateNotice.marketingVersion(
+            fromTipTitle: availableTitle
+        ) ?? SparkleUpdaterManager.sanitizeVersionString(availableDisplayVersion)
+        let installedMarketingVersion = SparkleUpdaterManager.sanitizeVersionString(
+            installedDisplayVersion
+        )
+
+        return SparkleVersionIdentities(
+            available: formatIdentity(
+                marketingVersion: availableMarketingVersion,
+                buildNumber: availableBuildNumber,
+                prefixesMarketingVersion: true
+            ),
+            installed: formatIdentity(
+                marketingVersion: installedMarketingVersion,
+                buildNumber: installedBuildNumber,
+                prefixesMarketingVersion: false
+            )
+        )
+    }
+
+    private static func formatIdentity(
+        marketingVersion: String,
+        buildNumber: String,
+        prefixesMarketingVersion: Bool
+    ) -> String {
+        let marketingVersion = marketingVersion.trimmingCharacters(in: .whitespacesAndNewlines)
+        let buildNumber = buildNumber.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if !marketingVersion.isEmpty, !buildNumber.isEmpty {
+            let prefix = prefixesMarketingVersion ? "v" : ""
+            return "\(prefix)\(marketingVersion) (\(buildNumber))"
+        }
+        if !marketingVersion.isEmpty {
+            return prefixesMarketingVersion ? "v\(marketingVersion)" : marketingVersion
+        }
+        return buildNumber
+    }
+}

--- a/Tests/RepoPromptTests/App/AppPlatformUtilityRecoveryTests.swift
+++ b/Tests/RepoPromptTests/App/AppPlatformUtilityRecoveryTests.swift
@@ -123,6 +123,7 @@ final class AppPlatformUtilityRecoveryTests: XCTestCase {
         XCTAssertEqual(version.version, "2.1.20")
         XCTAssertEqual(version.buildNumber, "320")
         XCTAssertEqual(version.title, "Tip build 320 · v2.1.20 · commit abc1234def56")
+        XCTAssertEqual(AvailableUpdateNotice.marketingVersion(fromTipTitle: version.title), "2.1.20")
         XCTAssertEqual(AvailableUpdateNotice.shortCommitSHA(fromTipTitle: version.title), "abc1234def56")
         XCTAssertEqual(version.releaseNotesURL, "https://example.com/release-notes.html")
         XCTAssertEqual(version.downloadURL, "https://example.com/RepoPrompt-2.1.20.zip")
@@ -270,11 +271,75 @@ final class AppPlatformUtilityRecoveryTests: XCTestCase {
     }
 
     func testSparkleDisplayVersionNormalizationRemovesTipDecoration() {
+        let enrichedTipTitle = "Tip build 29.8.52 · v1.0.28 · commit abc1234def56"
+
         XCTAssertEqual(
-            SparkleUpdaterManager.sanitizeVersionString("  Tip build v1.0.28  "),
+            AvailableUpdateNotice.marketingVersion(fromTipTitle: enrichedTipTitle),
             "1.0.28"
         )
-        XCTAssertEqual(SparkleUpdaterManager.sanitizeVersionString("v1.0.29"), "1.0.29")
+        XCTAssertNil(AvailableUpdateNotice.marketingVersion(fromTipTitle: "Tip build v1.0.27"))
+        XCTAssertEqual(
+            SparkleUpdaterManager.presentationVersion(
+                channel: .tip,
+                displayVersion: "1.0.28",
+                title: enrichedTipTitle
+            ),
+            "1.0.28"
+        )
+        XCTAssertEqual(
+            SparkleUpdaterManager.presentationVersion(
+                channel: .tip,
+                displayVersion: "Tip build v1.0.27",
+                title: "Tip build v1.0.27"
+            ),
+            "1.0.27"
+        )
+        XCTAssertEqual(
+            SparkleUpdaterManager.presentationVersion(
+                channel: .stable,
+                displayVersion: "v1.0.29",
+                title: enrichedTipTitle
+            ),
+            "1.0.29"
+        )
+
+        let tipIdentities = SparkleVersionDisplay.formattedIdentities(
+            availableDisplayVersion: "1.1.0",
+            availableBuildNumber: "31.11.89",
+            availableTitle: "Tip build 31.11.89 · v1.1.0 · commit abc1234def56",
+            installedDisplayVersion: "1.1.0",
+            installedBuildNumber: "31.10.88"
+        )
+        XCTAssertEqual(tipIdentities.available, "v1.1.0 (31.11.89)")
+        XCTAssertEqual(tipIdentities.installed, "1.1.0 (31.10.88)")
+
+        var installedDisplayVersion: NSString = "1.1.0"
+        let availableDisplayVersion = SparkleVersionDisplay.apply(
+            tipIdentities,
+            toInstalledDisplayVersion: &installedDisplayVersion
+        )
+        XCTAssertEqual(availableDisplayVersion, "v1.1.0 (31.11.89)")
+        XCTAssertEqual(installedDisplayVersion, "1.1.0 (31.10.88)")
+
+        let stableIdentities = SparkleVersionDisplay.formattedIdentities(
+            availableDisplayVersion: "1.2.0",
+            availableBuildNumber: "32",
+            availableTitle: "Version 1.2.0",
+            installedDisplayVersion: "1.1.0",
+            installedBuildNumber: "31"
+        )
+        XCTAssertEqual(stableIdentities.available, "v1.2.0 (32)")
+        XCTAssertEqual(stableIdentities.installed, "1.1.0 (31)")
+
+        let legacyTipIdentities = SparkleVersionDisplay.formattedIdentities(
+            availableDisplayVersion: "Tip build v1.0.27",
+            availableBuildNumber: "29.8.51",
+            availableTitle: "Tip build v1.0.27",
+            installedDisplayVersion: "v1.0.26",
+            installedBuildNumber: "29.8.50"
+        )
+        XCTAssertEqual(legacyTipIdentities.available, "v1.0.27 (29.8.51)")
+        XCTAssertEqual(legacyTipIdentities.installed, "1.0.26 (29.8.50)")
     }
 
     func testAppcastRequestIdentityRejectsDelayedAndOverlappingResults() throws {


### PR DESCRIPTION
## Summary
- format Sparkle's stock update alert with marketing version and build number for both the available and installed app
- preserve tip appcast comparison metadata while parsing the enriched tip title for display
- add regression coverage for the exact available/installed identities

For the reported example, the popup now reads:

> RepoPrompt CE.app v1.1.0 (31.11.89) is now available—you have 1.1.0 (31.10.88). Would you like to download it now?

## Validation
- make dev-format
- make dev-lint
- make dev-test FILTER=AppPlatformUtilityRecoveryTests (16 tests, 0 failures)
- focused release metadata tests (2 tests, 0 failures)
- make dev-swift-build PRODUCT=RepoPrompt
- make dev-release-preflight
- commit and push safety preflights

## Full-suite note
The PR-ready full root suite was attempted. Unrelated Codemap graph/invalidation tests timed out or failed after roughly 20 minutes, so the run was canceled after those failures were recorded. The focused update suite, app build, lint, and release preflight all pass.