### PR TITLE
Fix bundled Codex V8 JIT entitlements

### DIFF
--- a/AppBundle/CodexV8JIT.entitlements
+++ b/AppBundle/CodexV8JIT.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+</dict>
+</plist>

--- a/Scripts/codex_runtime_artifact.py
+++ b/Scripts/codex_runtime_artifact.py
@@ -8,6 +8,7 @@ import hashlib
 import json
 import os
 import platform
+import plistlib
 import re
 import shutil
 import stat
@@ -68,6 +69,21 @@ TARGET_PAGE_SIZES = {
     CPU_TYPE_ARM64: 0x4000,
 }
 STABLE_VERSION_PATTERN = re.compile(r"[0-9]+\.[0-9]+\.[0-9]+")
+MANIFEST_SCHEMA_VERSION = 2
+# Closed-world entitlement policy: these are the only entitlement keys any bundled
+# Codex Mach-O may ever carry. Growing this set is an intentionally reviewable
+# privilege change; verification rejects every key outside this allowlist.
+APPROVED_ENTITLEMENT_KEYS = frozenset(
+    {
+        "com.apple.security.cs.allow-jit",
+        "com.apple.security.cs.allow-unsigned-executable-memory",
+    }
+)
+V8_JIT_ENTITLEMENT_PROFILE = {key: True for key in sorted(APPROVED_ENTITLEMENT_KEYS)}
+SIGNING_PLAN_PROFILE_LABELS = {
+    "v8-jit": V8_JIT_ENTITLEMENT_PROFILE,
+    "none": {},
+}
 
 
 class ContractError(RuntimeError):
@@ -98,7 +114,7 @@ def load_manifest(
         manifest = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
         raise ContractError(f"could not read pinned manifest {path}: {exc}") from exc
-    if manifest.get("schemaVersion") != 1:
+    if manifest.get("schemaVersion") != MANIFEST_SCHEMA_VERSION:
         raise ContractError("unsupported Codex manifest schema")
     if manifest.get("version") != effective_version or manifest.get("tag") != effective_tag:
         raise ContractError(f"pinned manifest must describe Codex {effective_version} / {effective_tag}")
@@ -163,6 +179,17 @@ def load_manifest(
                 raise ContractError(
                     f"{target}: non-Mach-O manifest entry has a normalized digest: {entry['path']}"
                 )
+    release_entitlements = manifest.get("releaseSigningEntitlements")
+    if not isinstance(release_entitlements, dict):
+        raise ContractError("pinned manifest must contain the release-signing entitlement profile")
+    if set(release_entitlements) != set(mach_o_files):
+        raise ContractError(
+            "release-signing entitlement profile must cover exactly the Mach-O inventory"
+            f"\nmissing={sorted(set(mach_o_files) - set(release_entitlements))}"
+            f"\nextra={sorted(set(release_entitlements) - set(mach_o_files))}"
+        )
+    for relative, profile in release_entitlements.items():
+        validate_entitlement_profile(profile, f"release-signing entitlements for {relative}")
     signed = manifest.get("signedExecutables")
     if not isinstance(signed, list) or {item.get("path") for item in signed if isinstance(item, dict)} != {
         "bin/codex",
@@ -179,7 +206,29 @@ def load_manifest(
             raise ContractError(f"{policy['path']}: hardened runtime must be required")
         if policy.get("requiresTimestamp") is not True:
             raise ContractError(f"{policy['path']}: a trusted signing timestamp must be required")
+        validate_entitlement_profile(
+            policy.get("entitlements"),
+            f"vendor signature policy entitlements for {policy['path']}",
+        )
     return manifest
+
+
+def validate_entitlement_profile(raw: object, context: str) -> dict[str, bool]:
+    if not isinstance(raw, dict):
+        raise ContractError(f"{context}: entitlement profile must be an object")
+    for key, value in raw.items():
+        if key not in APPROVED_ENTITLEMENT_KEYS:
+            raise ContractError(f"{context}: unapproved entitlement key {key!r}")
+        if value is not True:
+            raise ContractError(f"{context}: entitlement {key!r} must be exactly true")
+    return dict(raw)
+
+
+def signing_plan_profile_label(profile: dict[str, bool], context: str) -> str:
+    for label, expected in SIGNING_PLAN_PROFILE_LABELS.items():
+        if profile == expected:
+            return label
+    raise ContractError(f"{context}: unsupported release-signing entitlement profile {profile!r}")
 
 
 def validate_digest(raw: object, context: str) -> str:
@@ -365,6 +414,51 @@ def normalized_mach_o_sha256(path: Path, codesign: str) -> str:
         return digest.hexdigest()
 
 
+def signed_entitlements_dictionary(binary: Path, codesign: str, context: str) -> dict[str, Any]:
+    argv = [codesign, "-d", "--entitlements", ":-", str(binary)]
+    try:
+        result = subprocess.run(argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    except OSError as exc:
+        raise ContractError(f"could not run entitlement inspection for {context}: {exc}") from exc
+    if result.returncode != 0:
+        diagnostics = result.stderr.decode("utf-8", errors="replace").strip()
+        raise ContractError(
+            f"entitlement inspection failed for {context} ({' '.join(argv)}):\n{diagnostics}"
+        )
+    payload = result.stdout.strip()
+    if not payload:
+        return {}
+    try:
+        value = plistlib.loads(payload)
+    except Exception as exc:
+        raise ContractError(f"{context}: malformed signed entitlements: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ContractError(f"{context}: signed entitlements must decode to a dictionary")
+    return value
+
+
+def verify_signed_entitlements(
+    binary: Path,
+    expected: dict[str, Any],
+    codesign: str,
+    context: str,
+) -> None:
+    actual = signed_entitlements_dictionary(binary, codesign, context)
+    if actual == expected:
+        return
+    missing = sorted(set(expected) - set(actual))
+    unexpected = sorted(set(actual) - set(expected))
+    changed = sorted(
+        key for key in set(actual) & set(expected) if actual[key] != expected[key]
+    )
+    raise ContractError(
+        f"{context}: signed entitlements do not match the pinned entitlement profile"
+        f"\nmissing={missing}\nunexpected={unexpected}\nchanged={changed}"
+        f"\nexpected={json.dumps(expected, sort_keys=True)}"
+        f"\nactual={json.dumps(actual, sort_keys=True, default=repr)}"
+    )
+
+
 def parse_codesign_metadata(details: str) -> dict[str, list[str]]:
     fields: dict[str, list[str]] = {}
     for raw_line in details.splitlines():
@@ -492,6 +586,7 @@ def verify_package(
                 "path": relative,
                 "teamIdentifier": signed_team_identifier,
                 "authorityPrefix": "Developer ID Application:",
+                "entitlements": manifest["releaseSigningEntitlements"][relative],
             }
             for relative in manifest["machOFiles"]
         ]
@@ -533,6 +628,12 @@ def verify_package(
         timestamps = fields.get("Timestamp", [])
         if len(timestamps) != 1 or not timestamps[0].strip() or timestamps[0].strip().casefold() == "none":
             raise ContractError(f"{target}: {policy['path']} is missing a trusted signing timestamp")
+        verify_signed_entitlements(
+            binary,
+            policy["entitlements"],
+            codesign,
+            f"{target}: {policy['path']}",
+        )
 
 
 def safe_extract(archive: Path, destination: Path, expected_paths: set[str]) -> None:
@@ -799,6 +900,11 @@ def build_parser() -> argparse.ArgumentParser:
         help="list target-relative paths for every pinned Mach-O in bundle signing order",
     )
     list_mach_o_parser.add_argument("--arch", default="all")
+    signing_plan_parser = subparsers.add_parser(
+        "list-bundle-signing-plan",
+        help="list every pinned Mach-O in bundle signing order with its release entitlement profile",
+    )
+    signing_plan_parser.add_argument("--arch", default="all")
     status_parser = subparsers.add_parser("status", help="verify both cached packages without network access")
     status_parser.add_argument("--cache-root", default=str(DEFAULT_CACHE_ROOT))
     refresh_parser = subparsers.add_parser(
@@ -841,6 +947,14 @@ def main() -> int:
             for target in selected_targets(args.arch):
                 for relative in manifest["machOFiles"]:
                     print(f"{target}/{relative}")
+        elif args.command == "list-bundle-signing-plan":
+            for target in selected_targets(args.arch):
+                for relative in manifest["machOFiles"]:
+                    label = signing_plan_profile_label(
+                        manifest["releaseSigningEntitlements"][relative],
+                        f"{target}/{relative}",
+                    )
+                    print(f"{target}/{relative}\t{label}")
         elif args.command == "status":
             status(args, manifest)
         elif args.command == "refresh-normalized-digests":

--- a/Scripts/codex_update_candidate.py
+++ b/Scripts/codex_update_candidate.py
@@ -455,7 +455,7 @@ def build_candidate_manifest(
             "tree": trees[target],
         }
     return {
-        "schemaVersion": 1,
+        "schemaVersion": artifact.MANIFEST_SCHEMA_VERSION,
         "version": version,
         "tag": tag,
         "releaseURL": f"{artifact.OFFICIAL_REPOSITORY_URL}/releases/tag/{tag}",
@@ -467,6 +467,7 @@ def build_candidate_manifest(
         "packages": packages,
         "requiredLayout": copy.deepcopy(baseline["requiredLayout"]),
         "machOFiles": mach_o_files,
+        "releaseSigningEntitlements": copy.deepcopy(baseline["releaseSigningEntitlements"]),
         "signedExecutables": copy.deepcopy(baseline["signedExecutables"]),
     }
 

--- a/Scripts/codex_vendor_guardrails.sh
+++ b/Scripts/codex_vendor_guardrails.sh
@@ -72,10 +72,45 @@ for script in \
     fi
 done
 
-grep -F 'list-bundle-mach-o-paths --arch all' Scripts/sign_staged_release.sh >/dev/null ||
-    fail "Developer ID signing must enumerate every manifest-owned Codex Mach-O"
+grep -F 'list-bundle-signing-plan --arch all' Scripts/sign_staged_release.sh >/dev/null ||
+    fail "Developer ID signing must enumerate every manifest-owned Codex Mach-O with its entitlement profile"
 grep -F 'sign_path "$CODEX_BUNDLE/$relative_path"' Scripts/sign_staged_release.sh >/dev/null ||
     fail "Developer ID signing must sign each enumerated Codex Mach-O at its final bundle path"
+grep -F 'sign_path "$CODEX_BUNDLE/$relative_path" --entitlements "$CODEX_V8_ENTITLEMENTS"' Scripts/sign_staged_release.sh >/dev/null ||
+    fail "Developer ID signing must apply the trusted V8 JIT entitlement allowlist to profiled Codex executables"
+grep -F 'CODEX_V8_ENTITLEMENTS="$TRUSTED_ROOT/AppBundle/CodexV8JIT.entitlements"' Scripts/sign_staged_release.sh >/dev/null ||
+    fail "Developer ID signing must source the Codex V8 entitlement allowlist from the trusted control plane"
+if grep -F 'sign_path "$CODEX_BUNDLE' Scripts/sign_staged_release.sh | grep -F -- '--preserve-metadata' >/dev/null; then
+    fail "Codex signing must use the explicit entitlement allowlist, never vendor entitlement preservation"
+fi
+python3 - <<'PYTHON' || fail "Codex release entitlement policy drifted from the trusted closed-world profile"
+import json
+import plistlib
+import sys
+from pathlib import Path
+
+V8_PROFILE = {
+    "com.apple.security.cs.allow-jit": True,
+    "com.apple.security.cs.allow-unsigned-executable-memory": True,
+}
+EXPECTED_RELEASE_PROFILES = {
+    "bin/codex": V8_PROFILE,
+    "bin/codex-code-mode-host": V8_PROFILE,
+    "codex-path/rg": {},
+    "codex-resources/zsh/bin/zsh": {},
+}
+manifest = json.loads(Path("Vendor/Codex/manifest.json").read_text(encoding="utf-8"))
+if manifest.get("schemaVersion") != 2:
+    sys.exit("pinned Codex manifest must use entitlement-aware schema version 2")
+if manifest.get("releaseSigningEntitlements") != EXPECTED_RELEASE_PROFILES:
+    sys.exit("pinned release-signing entitlement profiles must grant V8 JIT to exactly bin/codex and bin/codex-code-mode-host")
+for policy in manifest.get("signedExecutables", []):
+    if policy.get("entitlements") != V8_PROFILE:
+        sys.exit(f"vendor signature policy for {policy.get('path')} must pin exactly the two approved V8 entitlements")
+plist = plistlib.loads(Path("AppBundle/CodexV8JIT.entitlements").read_bytes())
+if plist != V8_PROFILE:
+    sys.exit("AppBundle/CodexV8JIT.entitlements must contain exactly the two approved V8 entitlements")
+PYTHON
 for script in \
     Scripts/main_tip_release.sh \
     Scripts/promote_release.sh \

--- a/Scripts/sign_staged_release.sh
+++ b/Scripts/sign_staged_release.sh
@@ -11,6 +11,7 @@ load_release_metadata "$METADATA_ROOT"
 APP_BUNDLE="$ROOT_DIR/.build/release/$APP_NAME.app"
 TRUSTED_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 ENTITLEMENTS_TEMPLATE="$TRUSTED_ROOT/AppBundle/RepoPrompt.entitlements.template"
+CODEX_V8_ENTITLEMENTS="$TRUSTED_ROOT/AppBundle/CodexV8JIT.entitlements"
 TRUSTED_SPARKLE_FRAMEWORK="$TRUSTED_ROOT/Vendor/Sparkle/Sparkle.xcframework/macos-arm64_x86_64/Sparkle.framework"
 STAGED_SPARKLE_FRAMEWORK="$APP_BUNDLE/Contents/Frameworks/Sparkle.framework"
 CODEX_BUNDLE="$APP_BUNDLE/Contents/Resources/BundledRuntimes/Codex"
@@ -70,6 +71,7 @@ text = text.replace("__BUNDLE_ID__", bundle_id).replace("__SIGNING_TEAM_ID__", t
 Path(output).write_text(text, encoding="utf-8")
 PYTHON
 plutil -lint "$app_entitlements"
+plutil -lint "$CODEX_V8_ENTITLEMENTS"
 plutil -replace RepoPromptDebugSecureStorageBackend -string keychain "$APP_BUNDLE/Contents/Info.plist"
 plutil -replace RepoPromptSigningMode -string developer-id "$APP_BUNDLE/Contents/Info.plist"
 
@@ -96,12 +98,25 @@ sign_sparkle_framework() {
 }
 
 sign_sparkle_framework "$STAGED_SPARKLE_FRAMEWORK"
-codex_mach_o_paths="$(python3 "$SCRIPT_DIR/codex_runtime_artifact.py" \
-    --manifest "$CODEX_MANIFEST" list-bundle-mach-o-paths --arch all)"
-while IFS= read -r relative_path; do
+# Manifest-driven Codex signing: each Mach-O gets exactly the release entitlement
+# profile pinned in Vendor/Codex/manifest.json. The trusted V8 JIT allowlist is a
+# repository-owned plist; vendor entitlement metadata is never preserved blindly.
+codex_signing_plan="$(python3 "$SCRIPT_DIR/codex_runtime_artifact.py" \
+    --manifest "$CODEX_MANIFEST" list-bundle-signing-plan --arch all)"
+while IFS=$'\t' read -r relative_path entitlement_profile; do
     [[ -n "$relative_path" ]] || continue
-    sign_path "$CODEX_BUNDLE/$relative_path"
-done <<< "$codex_mach_o_paths"
+    case "$entitlement_profile" in
+    v8-jit)
+        sign_path "$CODEX_BUNDLE/$relative_path" --entitlements "$CODEX_V8_ENTITLEMENTS"
+        ;;
+    none)
+        sign_path "$CODEX_BUNDLE/$relative_path"
+        ;;
+    *)
+        fail "Unsupported Codex release entitlement profile for $relative_path: ${entitlement_profile:-<missing>}"
+        ;;
+    esac
+done <<< "$codex_signing_plan"
 sign_path "$APP_BUNDLE/Contents/MacOS/repoprompt-mcp"
 sign_path "$APP_BUNDLE/Contents/MacOS/$APP_NAME"
 sign_path "$APP_BUNDLE" --entitlements "$app_entitlements"

--- a/Scripts/test_codex_runtime_artifact.py
+++ b/Scripts/test_codex_runtime_artifact.py
@@ -19,6 +19,10 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 TOOL = ROOT / "Scripts" / "codex_runtime_artifact.py"
+V8_ENTITLEMENTS = {
+    "com.apple.security.cs.allow-jit": True,
+    "com.apple.security.cs.allow-unsigned-executable-memory": True,
+}
 
 
 def digest(path: Path) -> str:
@@ -169,6 +173,30 @@ if [[ "$1" == "--verify" ]]; then
     [[ "${FAKE_SIGNATURE_FAILURE:-0}" != "1" ]]
     exit
 fi
+if [[ "$*" == *"--entitlements"* ]]; then
+    if [[ "${FAKE_ENTITLEMENTS_MALFORMED:-0}" == "1" ]]; then
+        printf 'not-a-plist'
+        exit 0
+    fi
+    entitlement_target="$(basename "${!#}")"
+    profile="none"
+    case "$entitlement_target" in
+    codex|codex-code-mode-host) profile="v8" ;;
+    esac
+    if [[ "${FAKE_ENTITLEMENTS_GRANT_ALL:-0}" == "1" ]]; then profile="v8"; fi
+    if [[ "${FAKE_ENTITLEMENTS_OMIT:-}" == "$entitlement_target" ]]; then profile="none"; fi
+    if [[ "$profile" == "none" ]]; then
+        exit 0
+    fi
+    jit_value="<true/>"
+    if [[ "${FAKE_ENTITLEMENTS_FALSE:-0}" == "1" ]]; then jit_value="<false/>"; fi
+    extra_key=""
+    if [[ "${FAKE_ENTITLEMENTS_EXTRA:-0}" == "1" ]]; then
+        extra_key="<key>com.apple.security.get-task-allow</key><true/>"
+    fi
+    printf '<?xml version="1.0" encoding="UTF-8"?>\n<plist version="1.0"><dict><key>com.apple.security.cs.allow-jit</key>%s<key>com.apple.security.cs.allow-unsigned-executable-memory</key><true/>%s</dict></plist>\n' "$jit_value" "$extra_key"
+    exit 0
+fi
 path="${!#}"
 identifier="$(basename "$path")"
 team_identifier="${FAKE_TEAM_IDENTIFIER:-2DC432GLL2}"
@@ -265,7 +293,7 @@ fi
             encoding="utf-8",
         )
         manifest = {
-            "schemaVersion": 1,
+            "schemaVersion": 2,
             "version": "0.145.0",
             "tag": "rust-v0.145.0",
             "releaseURL": "https://github.com/openai/codex/releases/tag/rust-v0.145.0",
@@ -288,6 +316,12 @@ fi
                 "codex-path/rg",
                 "codex-resources/zsh/bin/zsh",
             ],
+            "releaseSigningEntitlements": {
+                "bin/codex": dict(V8_ENTITLEMENTS),
+                "bin/codex-code-mode-host": dict(V8_ENTITLEMENTS),
+                "codex-path/rg": {},
+                "codex-resources/zsh/bin/zsh": {},
+            },
             "signedExecutables": [
                 {
                     "path": "bin/codex",
@@ -296,6 +330,7 @@ fi
                     "authority": "Developer ID Application: OpenAI OpCo, LLC (2DC432GLL2)",
                     "requiresHardenedRuntime": True,
                     "requiresTimestamp": True,
+                    "entitlements": dict(V8_ENTITLEMENTS),
                 },
                 {
                     "path": "bin/codex-code-mode-host",
@@ -304,6 +339,7 @@ fi
                     "authority": "Developer ID Application: OpenAI OpCo, LLC (2DC432GLL2)",
                     "requiresHardenedRuntime": True,
                     "requiresTimestamp": True,
+                    "entitlements": dict(V8_ENTITLEMENTS),
                 },
             ],
         }
@@ -871,6 +907,142 @@ fi
                     expected=1,
                 )
                 self.assertIn("must equal", result.stderr)
+
+    def test_vendor_entitlement_policy_mismatches_are_rejected(self) -> None:
+        self.acquire_all()
+        package = self.cache / "0.145.0" / "aarch64-apple-darwin"
+        for label, env, message in (
+            ("missing", {"FAKE_ENTITLEMENTS_OMIT": "codex-code-mode-host"}, "signed entitlements do not match"),
+            ("extra key", {"FAKE_ENTITLEMENTS_EXTRA": "1"}, "signed entitlements do not match"),
+            ("false value", {"FAKE_ENTITLEMENTS_FALSE": "1"}, "signed entitlements do not match"),
+            ("malformed", {"FAKE_ENTITLEMENTS_MALFORMED": "1"}, "malformed signed entitlements"),
+        ):
+            with self.subTest(label=label):
+                result = self.run_tool(
+                    "verify", "--arch", "arm64", "--package", str(package),
+                    env=env, expected=1,
+                )
+                self.assertIn(message, result.stderr)
+
+    def test_release_resigned_bundle_enforces_per_mach_o_entitlement_profiles(self) -> None:
+        self.acquire_all()
+        self.run_tool(
+            "stage-bundle", "--arch", "all", "--cache-root", str(self.cache),
+            "--bundle", str(self.bundle),
+        )
+        for target in ("aarch64-apple-darwin", "x86_64-apple-darwin"):
+            for relative in (
+                "bin/codex",
+                "bin/codex-code-mode-host",
+                "codex-path/rg",
+                "codex-resources/zsh/bin/zsh",
+            ):
+                apply_fixture_signature(
+                    self.bundle / target / relative,
+                    signature=f"signature-only:{target}/{relative}".encode(),
+                )
+        release_env = {
+            "FAKE_TEAM_IDENTIFIER": "648A27MST5",
+            "FAKE_AUTHORITY": "Developer ID Application: RepoPrompt Fixture (648A27MST5)",
+        }
+
+        self.run_tool(
+            "verify-bundle", "--arch", "all", "--bundle", str(self.bundle),
+            "--signed-team-identifier", "648A27MST5", env=release_env,
+        )
+
+        stripped_host = self.run_tool(
+            "verify-bundle", "--arch", "all", "--bundle", str(self.bundle),
+            "--signed-team-identifier", "648A27MST5",
+            env={**release_env, "FAKE_ENTITLEMENTS_OMIT": "codex-code-mode-host"},
+            expected=1,
+        )
+        self.assertIn("bin/codex-code-mode-host", stripped_host.stderr)
+        self.assertIn("signed entitlements do not match", stripped_host.stderr)
+        self.assertIn("missing=", stripped_host.stderr)
+
+        over_entitled = self.run_tool(
+            "verify-bundle", "--arch", "all", "--bundle", str(self.bundle),
+            "--signed-team-identifier", "648A27MST5",
+            env={**release_env, "FAKE_ENTITLEMENTS_GRANT_ALL": "1"},
+            expected=1,
+        )
+        self.assertIn("codex-path/rg", over_entitled.stderr)
+        self.assertIn("unexpected=", over_entitled.stderr)
+
+    def test_list_bundle_signing_plan_maps_profiles_to_every_mach_o(self) -> None:
+        listed = self.run_tool("list-bundle-signing-plan", "--arch", "all")
+        expected = [
+            f"{target}/{relative}\t{label}"
+            for target in ("aarch64-apple-darwin", "x86_64-apple-darwin")
+            for relative, label in (
+                ("bin/codex", "v8-jit"),
+                ("bin/codex-code-mode-host", "v8-jit"),
+                ("codex-path/rg", "none"),
+                ("codex-resources/zsh/bin/zsh", "none"),
+            )
+        ]
+        self.assertEqual(listed.stdout.splitlines(), expected)
+
+    def test_manifest_rejects_legacy_schema_and_open_world_entitlement_profiles(self) -> None:
+        baseline = self.manifest_path.read_text(encoding="utf-8")
+        mutations = (
+            (
+                "legacy schema",
+                lambda manifest: manifest.__setitem__("schemaVersion", 1),
+                "unsupported Codex manifest schema",
+            ),
+            (
+                "missing release profile",
+                lambda manifest: manifest.__delitem__("releaseSigningEntitlements"),
+                "must contain the release-signing entitlement profile",
+            ),
+            (
+                "uncovered Mach-O",
+                lambda manifest: manifest["releaseSigningEntitlements"].__delitem__("codex-path/rg"),
+                "cover exactly the Mach-O inventory",
+            ),
+            (
+                "unlisted profile path",
+                lambda manifest: manifest["releaseSigningEntitlements"].__setitem__("bin/future-helper", {}),
+                "cover exactly the Mach-O inventory",
+            ),
+            (
+                "unapproved release key",
+                lambda manifest: manifest["releaseSigningEntitlements"]["bin/codex"].__setitem__(
+                    "com.apple.security.get-task-allow", True
+                ),
+                "unapproved entitlement key",
+            ),
+            (
+                "non-true release value",
+                lambda manifest: manifest["releaseSigningEntitlements"]["bin/codex"].__setitem__(
+                    "com.apple.security.cs.allow-jit", False
+                ),
+                "must be exactly true",
+            ),
+            (
+                "vendor policy without entitlements",
+                lambda manifest: manifest["signedExecutables"][0].__delitem__("entitlements"),
+                "entitlement profile must be an object",
+            ),
+            (
+                "unapproved vendor key",
+                lambda manifest: manifest["signedExecutables"][1]["entitlements"].__setitem__(
+                    "com.apple.security.cs.disable-library-validation", True
+                ),
+                "unapproved entitlement key",
+            ),
+        )
+        for label, mutate, message in mutations:
+            with self.subTest(label=label):
+                manifest = json.loads(baseline)
+                mutate(manifest)
+                self.manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+                result = self.run_tool("validate-manifest", expected=1)
+                self.assertIn(message, result.stderr)
+        self.manifest_path.write_text(baseline, encoding="utf-8")
+        self.run_tool("validate-manifest")
 
     def test_package_script_embeds_before_outer_sign_and_never_resigns_codex(self) -> None:
         source = (ROOT / "Scripts" / "package_app.sh").read_text(encoding="utf-8")

--- a/Scripts/test_codex_update_candidate.py
+++ b/Scripts/test_codex_update_candidate.py
@@ -67,6 +67,10 @@ esac
 set -euo pipefail
 if [[ "$1" == "--remove-signature" ]]; then exit 1; fi
 if [[ "$1" == "--verify" ]]; then exit 0; fi
+if [[ "$*" == *"--entitlements"* ]]; then
+    printf '<?xml version="1.0" encoding="UTF-8"?>\n<plist version="1.0"><dict><key>com.apple.security.cs.allow-jit</key><true/><key>com.apple.security.cs.allow-unsigned-executable-memory</key><true/></dict></plist>\n'
+    exit 0
+fi
 path="${!#}"
 cat >&2 <<EOF
 Identifier=$(basename "$path")

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -207,22 +207,54 @@ APP_SIGN_ARGS=(){app_signing_body}
         self.assertIn('CODEX_MANIFEST="$METADATA_ROOT/Vendor/Codex/manifest.json"', source)
         self.assertIn('python3 "$SCRIPT_DIR/codex_runtime_artifact.py"', source)
         self.assertEqual(source.count('--manifest "$CODEX_MANIFEST" verify-bundle'), 2)
-        self.assertEqual(source.count("list-bundle-mach-o-paths --arch all"), 1)
+        self.assertEqual(source.count("list-bundle-signing-plan --arch all"), 1)
+        self.assertNotIn("list-bundle-mach-o-paths", source)
         self.assertEqual(source.count('--signed-team-identifier "$SIGNING_TEAM_ID"'), 1)
         self.assertNotIn('$TRUSTED_ROOT/Vendor/Codex/manifest.json', source)
+        self.assertIn('CODEX_V8_ENTITLEMENTS="$TRUSTED_ROOT/AppBundle/CodexV8JIT.entitlements"', source)
+        self.assertIn('plutil -lint "$CODEX_V8_ENTITLEMENTS"', source)
+        for line in source.splitlines():
+            if 'sign_path "$CODEX_BUNDLE' in line:
+                self.assertNotIn("--preserve-metadata", line)
 
         sparkle_sign = source.index('sign_sparkle_framework "$STAGED_SPARKLE_FRAMEWORK"')
-        enumerate_codex = source.index("list-bundle-mach-o-paths --arch all")
-        codex_sign = source.index('sign_path "$CODEX_BUNDLE/$relative_path"')
+        enumerate_codex = source.index("list-bundle-signing-plan --arch all")
+        codex_sign = source.index('sign_path "$CODEX_BUNDLE/$relative_path" --entitlements "$CODEX_V8_ENTITLEMENTS"')
+        codex_sign_unprofiled = source.index('sign_path "$CODEX_BUNDLE/$relative_path"\n', codex_sign + 1)
         mcp_sign = source.index('sign_path "$APP_BUNDLE/Contents/MacOS/repoprompt-mcp"')
         app_sign = source.index('sign_path "$APP_BUNDLE/Contents/MacOS/$APP_NAME"')
         outer_sign = source.index('sign_path "$APP_BUNDLE" --entitlements "$app_entitlements"')
         self.assertLess(sparkle_sign, enumerate_codex)
         self.assertLess(enumerate_codex, codex_sign)
-        self.assertLess(codex_sign, mcp_sign)
+        self.assertLess(codex_sign, codex_sign_unprofiled)
+        self.assertLess(codex_sign_unprofiled, mcp_sign)
         self.assertLess(mcp_sign, app_sign)
         self.assertLess(app_sign, outer_sign)
         self.assertNotIn('sign_path "$CODEX_BUNDLE"', source)
+
+    def test_codex_v8_entitlement_allowlist_matches_pinned_manifest_policy(self) -> None:
+        v8_profile = {
+            "com.apple.security.cs.allow-jit": True,
+            "com.apple.security.cs.allow-unsigned-executable-memory": True,
+        }
+        plist = plistlib.loads((SCRIPT_DIR.parent / "AppBundle" / "CodexV8JIT.entitlements").read_bytes())
+        self.assertEqual(plist, v8_profile)
+
+        manifest = json.loads(
+            (SCRIPT_DIR.parent / "Vendor" / "Codex" / "manifest.json").read_text(encoding="utf-8")
+        )
+        self.assertEqual(manifest["schemaVersion"], 2)
+        self.assertEqual(
+            manifest["releaseSigningEntitlements"],
+            {
+                "bin/codex": v8_profile,
+                "bin/codex-code-mode-host": v8_profile,
+                "codex-path/rg": {},
+                "codex-resources/zsh/bin/zsh": {},
+            },
+        )
+        for policy in manifest["signedExecutables"]:
+            self.assertEqual(policy["entitlements"], v8_profile, policy["path"])
 
         for release_script_name in (
             "release.sh",

--- a/Vendor/Codex/manifest.json
+++ b/Vendor/Codex/manifest.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "version": "0.145.0",
   "tag": "rust-v0.145.0",
   "releaseURL": "https://github.com/openai/codex/releases/tag/rust-v0.145.0",
@@ -147,6 +147,18 @@
     "codex-path/rg",
     "codex-resources/zsh/bin/zsh"
   ],
+  "releaseSigningEntitlements": {
+    "bin/codex": {
+      "com.apple.security.cs.allow-jit": true,
+      "com.apple.security.cs.allow-unsigned-executable-memory": true
+    },
+    "bin/codex-code-mode-host": {
+      "com.apple.security.cs.allow-jit": true,
+      "com.apple.security.cs.allow-unsigned-executable-memory": true
+    },
+    "codex-path/rg": {},
+    "codex-resources/zsh/bin/zsh": {}
+  },
   "signedExecutables": [
     {
       "path": "bin/codex",
@@ -154,7 +166,11 @@
       "teamIdentifier": "2DC432GLL2",
       "authority": "Developer ID Application: OpenAI OpCo, LLC (2DC432GLL2)",
       "requiresHardenedRuntime": true,
-      "requiresTimestamp": true
+      "requiresTimestamp": true,
+      "entitlements": {
+        "com.apple.security.cs.allow-jit": true,
+        "com.apple.security.cs.allow-unsigned-executable-memory": true
+      }
     },
     {
       "path": "bin/codex-code-mode-host",
@@ -162,7 +178,11 @@
       "teamIdentifier": "2DC432GLL2",
       "authority": "Developer ID Application: OpenAI OpCo, LLC (2DC432GLL2)",
       "requiresHardenedRuntime": true,
-      "requiresTimestamp": true
+      "requiresTimestamp": true,
+      "entitlements": {
+        "com.apple.security.cs.allow-jit": true,
+        "com.apple.security.cs.allow-unsigned-executable-memory": true
+      }
     }
   ]
 }


### PR DESCRIPTION
## Root cause

Release signing re-signs every bundled Codex Mach-O with the Developer ID identity, but the previous flow (`list-bundle-mach-o-paths` + plain `sign_path`) applied **no entitlements**, stripping the V8 JIT entitlements that OpenAI's vendor signatures carry on `bin/codex` and `bin/codex-code-mode-host`. Under the hardened runtime, V8/deno-core then aborts at JIT initialization, crashing the bundled Codex runtime (Code Mode host) in release builds.

## Security policy

Closed-world entitlement policy — the only approved entitlement keys anywhere in the bundled Codex inventory are:

- `com.apple.security.cs.allow-jit`
- `com.apple.security.cs.allow-unsigned-executable-memory`

Exactly `bin/codex` and `bin/codex-code-mode-host` receive that V8 JIT profile; `codex-path/rg` and `codex-resources/zsh/bin/zsh` are pinned to **no** entitlements. Vendor entitlement metadata is never blindly preserved (`--preserve-metadata` is explicitly forbidden by guardrails); the profile comes from a repository-owned plist in the trusted control plane. Any new key, any non-`true` value, or any coverage drift is a hard verification failure, making privilege growth an intentionally reviewable change.

## Changes

- **`AppBundle/CodexV8JIT.entitlements`** (new): trusted two-key V8 JIT entitlement allowlist plist, `plutil -lint`-validated during signing.
- **`Vendor/Codex/manifest.json`**: schema v2; new `releaseSigningEntitlements` map covering exactly the Mach-O inventory; vendor `signedExecutables` policies now pin the expected signed entitlements.
- **`Scripts/codex_runtime_artifact.py`**: manifest schema v2 validation with approved-key/exact-`true`/exact-coverage enforcement; new `list-bundle-signing-plan` subcommand (path + profile label per Mach-O); `verify`/`verify-bundle` now read signed entitlements via `codesign -d --entitlements :-` and reject missing/unexpected/changed keys and malformed plists for both vendor and re-signed bundles.
- **`Scripts/sign_staged_release.sh`**: signs from the manifest-driven signing plan — `v8-jit` entries get `--entitlements "$CODEX_V8_ENTITLEMENTS"`, `none` entries sign without entitlements, unknown profiles fail hard.
- **`Scripts/codex_update_candidate.py`**: candidate manifests carry the schema version and copy the pinned release entitlement profile forward.
- **`Scripts/codex_vendor_guardrails.sh`**: enforces the signing-plan enumeration, the trusted allowlist source, the `--preserve-metadata` ban, and byte-exact policy agreement across manifest, entitlements plist, and vendor policies.

## Tests / validation

- `Scripts/test_codex_runtime_artifact.py`: 28 tests — vendor entitlement mismatch rejection (missing/extra/false/malformed), per-Mach-O release profile enforcement on re-signed bundles, signing-plan output, manifest schema/closed-world mutations.
- `Scripts/test_codex_update_candidate.py`: 9 tests.
- Workflow tests: 2.
- `Scripts/test_release_tooling.py`: 77 tests — signing order, no `--preserve-metadata` on Codex signs, allowlist/manifest policy agreement.
- `Scripts/codex_vendor_guardrails.sh` and `make guardrails` pass.
- Verified official Codex 0.145 packages for both architectures against the new entitlement verification.
- `make dev-release-preflight` passed (ticket `bf848e28-087b-4556-a0a9-69465f69b390`).
- Integrated review: no findings.

## Remaining release gates

- Real Developer ID signing run (release signing path with an actual Developer ID identity).
- arm64 Code Mode smoke on a release artifact confirming the bundled Codex runtime executes with JIT entitlements intact.

Closes #646