### PR TITLE
Keep Tip update alerts compact

### DIFF
--- a/Scripts/main_tip_release.sh
+++ b/Scripts/main_tip_release.sh
@@ -28,7 +28,6 @@ fi
 TIP_BUILD_NUMBER="${TIP_BUILD_NUMBER//[[:space:]]/}"
 TIP_TAG="${TIP_TAG:-tip-$TIP_SHORT_SHA}"
 TIP_UPDATE_REPOSITORY="${TIP_UPDATE_REPOSITORY:-repoprompt/repoprompt-ce-tip-updates}"
-TIP_RELEASE_URL="${TIP_RELEASE_URL:-https://github.com/$TIP_UPDATE_REPOSITORY/releases/tag/$TIP_TAG}"
 TIP_DOWNLOAD_URL_PREFIX="${TIP_DOWNLOAD_URL_PREFIX:-https://github.com/$TIP_UPDATE_REPOSITORY/releases/download/$TIP_TAG/}"
 TIP_GH_TOKEN="${TIP_GH_TOKEN:-${GH_TOKEN:-}}"
 
@@ -222,7 +221,7 @@ derive_sparkle_public_key() {
 }
 
 label_generated_tip_appcast() {
-    python3 - "$APPCAST" "$MARKETING_VERSION" "$TIP_BUILD_NUMBER" "$TIP_SHORT_SHA" "$TIP_RELEASE_URL" <<'PYTHON'
+    python3 - "$APPCAST" "$MARKETING_VERSION" "$TIP_BUILD_NUMBER" "$TIP_SHORT_SHA" <<'PYTHON'
 import sys
 import xml.etree.ElementTree as ET
 
@@ -235,7 +234,7 @@ if len(items) != 1:
     raise SystemExit(f"tip appcast must contain exactly one item, got {len(items)}")
 
 item = items[0]
-marketing_version, build_number, short_sha, release_url = sys.argv[2:]
+marketing_version, build_number, short_sha = sys.argv[2:]
 
 def singleton_or_create(element_name, qualified_name):
     elements = item.findall(qualified_name)
@@ -251,10 +250,13 @@ short_version = singleton_or_create(
     "sparkle:shortVersionString", f"{{{sparkle}}}shortVersionString"
 )
 short_version.text = marketing_version
-release_notes_link = singleton_or_create(
-    "sparkle:releaseNotesLink", f"{{{sparkle}}}releaseNotesLink"
-)
-release_notes_link.text = release_url
+# Sparkle embeds releaseNotesLink targets inside its stock update window.
+# Tip releases intentionally keep that dialog compact instead of loading a full
+# GitHub release page as web content.
+for release_notes_link in item.findall(f"{{{sparkle}}}releaseNotesLink"):
+    item.remove(release_notes_link)
+for description in item.findall("description"):
+    item.remove(description)
 
 tree.write(sys.argv[1], encoding="utf-8", xml_declaration=True)
 PYTHON
@@ -280,6 +282,7 @@ titles = item.findall("title")
 versions = item.findall(f"{{{sparkle}}}version")
 short_versions = item.findall(f"{{{sparkle}}}shortVersionString")
 release_notes_links = item.findall(f"{{{sparkle}}}releaseNotesLink")
+descriptions = item.findall("description")
 if len(titles) != 1:
     raise SystemExit(f"tip appcast item must contain exactly one title, got {len(titles)}")
 if len(versions) != 1:
@@ -291,11 +294,12 @@ if len(short_versions) != 1:
         "tip appcast item must contain exactly one "
         f"sparkle:shortVersionString, got {len(short_versions)}"
     )
-if len(release_notes_links) != 1:
+if release_notes_links:
     raise SystemExit(
-        "tip appcast item must contain exactly one "
-        f"sparkle:releaseNotesLink, got {len(release_notes_links)}"
+        "tip appcast item must not contain sparkle:releaseNotesLink"
     )
+if descriptions:
+    raise SystemExit("tip appcast item must not contain description")
 values = [
     enclosure.attrib.get("url", ""),
     enclosure.attrib.get(f"{{{sparkle}}}edSignature", ""),
@@ -303,15 +307,14 @@ values = [
     versions[0].text or "",
     short_versions[0].text or "",
     titles[0].text or "",
-    release_notes_links[0].text or "",
 ]
 print("\x1f".join([str(len(values)), *values]))
 PYTHON
 
-    local appcast_field_count enclosure_url enclosure_signature enclosure_length appcast_build appcast_marketing appcast_title release_notes_link
-    IFS=$'\x1f' read -r appcast_field_count enclosure_url enclosure_signature enclosure_length appcast_build appcast_marketing appcast_title release_notes_link < "$appcast_values"
-    [[ "$appcast_field_count" == "7" ]] ||
-        fail "Tip appcast metadata field count mismatch: expected 7, got $appcast_field_count"
+    local appcast_field_count enclosure_url enclosure_signature enclosure_length appcast_build appcast_marketing appcast_title
+    IFS=$'\x1f' read -r appcast_field_count enclosure_url enclosure_signature enclosure_length appcast_build appcast_marketing appcast_title < "$appcast_values"
+    [[ "$appcast_field_count" == "6" ]] ||
+        fail "Tip appcast metadata field count mismatch: expected 6, got $appcast_field_count"
     [[ "$enclosure_url" == "$TIP_DOWNLOAD_URL_PREFIX$(basename "$UPDATE_ZIP")" ]] ||
         fail "Tip appcast enclosure URL mismatch: $enclosure_url"
     [[ -n "$enclosure_signature" ]] || fail "Tip appcast enclosure is missing an EdDSA signature"
@@ -323,8 +326,6 @@ PYTHON
         fail "Tip appcast marketing version mismatch: expected $MARKETING_VERSION, got $appcast_marketing"
     [[ "$appcast_title" == "Tip build $TIP_BUILD_NUMBER · v$MARKETING_VERSION · commit $TIP_SHORT_SHA" ]] ||
         fail "Tip appcast presentation title mismatch: $appcast_title"
-    [[ "$release_notes_link" == "$TIP_RELEASE_URL" ]] ||
-        fail "Tip appcast release notes link mismatch: $release_notes_link"
 
     local private_key_file="$TMP_DIR/tip-sparkle-private-key"
     local public_key_file="$TMP_DIR/tip-sparkle-public-key"

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -2882,15 +2882,18 @@ sys.stdout.write(str(status))
         ).stdout.strip()
 
         expected_title = "Tip build 1.2.3 · v9.8.7 · commit 0123456789ab"
-        expected_release_notes_link = "https://example.invalid/tip/details"
-
         def write_appcast(
             enclosure_signature: str,
             *,
             marketing_version: str = "9.8.7",
             title: str = expected_title,
-            release_notes_link: str = expected_release_notes_link,
+            release_notes_link: str | None = None,
         ) -> None:
+            release_notes_xml = (
+                f"      <sparkle:releaseNotesLink>{release_notes_link}</sparkle:releaseNotesLink>\n"
+                if release_notes_link is not None
+                else ""
+            )
             appcast.write_text(
                 f"""<?xml version="1.0" encoding="utf-8"?>
 <rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
@@ -2899,8 +2902,7 @@ sys.stdout.write(str(status))
       <title>{title}</title>
       <sparkle:version>1.2.3</sparkle:version>
       <sparkle:shortVersionString>{marketing_version}</sparkle:shortVersionString>
-      <sparkle:releaseNotesLink>{release_notes_link}</sparkle:releaseNotesLink>
-      <enclosure url="https://example.invalid/tip/{archive.name}"
+{release_notes_xml}      <enclosure url="https://example.invalid/tip/{archive.name}"
                  length="{archive.stat().st_size}"
                  sparkle:edSignature="{enclosure_signature}" />
     </item>
@@ -2918,7 +2920,6 @@ sys.stdout.write(str(status))
                 "TIP_COMMIT": "0123456789abcdef" * 2 + "01234567",
                 "TIP_SHORT_SHA": "0123456789ab",
                 "TIP_BUILD_NUMBER": "1.2.3",
-                "TIP_RELEASE_URL": expected_release_notes_link,
                 "TIP_DOWNLOAD_URL_PREFIX": "https://example.invalid/tip/",
                 "SPARKLE_PRIVATE_KEY": private_key,
                 "VALIDATOR_APP_BUNDLE": str(app_bundle),
@@ -2975,12 +2976,12 @@ validate_generated_tip_appcast""",
         self.assertNotEqual(wrong_title.returncode, 0)
         self.assertIn("Tip appcast presentation title mismatch: Wrong tip title", wrong_title.stderr)
 
-        write_appcast(signature, release_notes_link="https://example.invalid/tip/wrong-details")
-        wrong_release_notes_link = subprocess.run(command, env=env, text=True, capture_output=True)
-        self.assertNotEqual(wrong_release_notes_link.returncode, 0)
+        write_appcast(signature, release_notes_link="https://example.invalid/tip/details")
+        embedded_release_page = subprocess.run(command, env=env, text=True, capture_output=True)
+        self.assertNotEqual(embedded_release_page.returncode, 0)
         self.assertIn(
-            "Tip appcast release notes link mismatch: https://example.invalid/tip/wrong-details",
-            wrong_release_notes_link.stderr,
+            "tip appcast item must not contain sparkle:releaseNotesLink",
+            embedded_release_page.stderr,
         )
 
         write_appcast("")
@@ -2998,6 +2999,8 @@ validate_generated_tip_appcast""",
   <channel><item><title>Version 9.8.7</title>
     <sparkle:version>29.8.52</sparkle:version>
     <sparkle:shortVersionString>9.8.7</sparkle:shortVersionString>
+    <sparkle:releaseNotesLink>https://github.com/example/release</sparkle:releaseNotesLink>
+    <description>Embedded release content</description>
   </item></channel>
 </rss>
 """,
@@ -3011,7 +3014,6 @@ APPCAST="$2"
 MARKETING_VERSION="9.8.7"
 TIP_BUILD_NUMBER="29.8.52"
 TIP_SHORT_SHA="abc1234def56"
-TIP_RELEASE_URL="https://github.com/repoprompt/repoprompt-ce-tip-updates/releases/tag/tip-abc1234def56"
 label_generated_tip_appcast""",
             "tip-appcast-label",
             str(SCRIPT_DIR / "main_tip_release.sh"),
@@ -3031,10 +3033,8 @@ label_generated_tip_appcast""",
             item.findtext(f"{{{sparkle}}}version"),
         )
         self.assertEqual(item.findtext("title"), "Tip build 29.8.52 · v9.8.7 · commit abc1234def56")
-        self.assertEqual(
-            item.findtext(f"{{{sparkle}}}releaseNotesLink"),
-            "https://github.com/repoprompt/repoprompt-ce-tip-updates/releases/tag/tip-abc1234def56",
-        )
+        self.assertIsNone(item.find(f"{{{sparkle}}}releaseNotesLink"))
+        self.assertIsNone(item.find("description"))
 
     def test_release_sentry_runtime_wiring_uses_protected_dsn_and_stable_resolution(self) -> None:
         root = SCRIPT_DIR.parent


### PR DESCRIPTION
## Summary
- remove Tip appcast releaseNotesLink metadata that caused Sparkle to embed the entire GitHub release page
- strip any generated releaseNotesLink or description content so the stock update dialog stays compact
- retain the marketing-version and build-number text added by #641
- add contract coverage that rejects embedded Tip release content

## Result
The update alert keeps the compact layout and still shows both identities, for example:

> RepoPrompt CE.app 1.1.0 (31.11.98) is now available—you have 1.1.0 (31.11.89). Would you like to download it now?

The GitHub Tip release still exists; it is simply no longer loaded as web content inside Sparkle.

## Validation
- focused Tip appcast tests (2 tests, 0 failures)
- bash -n Scripts/main_tip_release.sh
- python3 -m py_compile Scripts/test_release_tooling.py
- make dev-release-preflight
- commit and push safety preflights