### PR TITLE
Harden Code Map recovery after performance cutover

### DIFF
--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceCodemapBindingEngine.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceCodemapBindingEngine.swift
@@ -428,6 +428,7 @@ actor WorkspaceCodemapBindingEngine {
         var workerID: UUID?
         var task: Task<Void, Never>?
         var workerRecoveryCount: UInt64
+        var workerRecoveryExhausted: Bool
         var lastWorkerCompletionReason: WorkspaceCodemapGraphIndexWorkerCompletionReason?
         var workerRestartRequestedReason: WorkspaceCodemapGraphIndexWorkerCompletionReason?
         var isPriorityPromoted: Bool
@@ -611,7 +612,32 @@ actor WorkspaceCodemapBindingEngine {
             let expiryTask: Task<Void, Never>
         }
 
+        private actor DebugGraphIndexNonCooperativeWorkerGate {
+            private var isReleased = false
+            private var continuation: CheckedContinuation<Void, Never>?
+
+            func wait() async {
+                guard !isReleased else { return }
+                await withCheckedContinuation { continuation in
+                    if isReleased {
+                        continuation.resume()
+                    } else {
+                        self.continuation = continuation
+                    }
+                }
+            }
+
+            func release() {
+                isReleased = true
+                continuation?.resume()
+                continuation = nil
+            }
+        }
+
         private var debugGraphIndexAdmissionHolds: [UUID: DebugGraphIndexAdmissionHold] = [:]
+        private var debugGraphIndexNonCooperativeWorkerGates: [
+            UUID: DebugGraphIndexNonCooperativeWorkerGate
+        ] = [:]
         private var debugGraphIndexEventRing = WorkspaceCodemapGraphIndexDebugEventRing()
         private var debugGraphIndexAdmissionEnqueuedAtNanoseconds: [UUID: UInt64] = [:]
         private var debugGraphIndexQueueWaitMillisecondsByRootEpoch: [
@@ -1017,7 +1043,10 @@ actor WorkspaceCodemapBindingEngine {
             case .scheduled, .waitingForAdmission, .readingCatalogPage, .loadingEnvelopes,
                  .classifyingBatch, .resolvingArtifacts, .stagingManifestCache,
                  .publishingGraphChanges, .checkpointed, .persistingManifestCache, .suspendedBusy:
-                guard existing.task == nil else { return .handedOff }
+                guard existing.task == nil,
+                      !existing.workerRecoveryExhausted,
+                      existing.workerRecoveryCount < policy.maximumGraphIndexWorkerRecoveryCount
+                else { return .handedOff }
                 return startGraphIndexWorker(
                     jobID: existing.id,
                     rootEpoch: rootEpoch,
@@ -1058,6 +1087,7 @@ actor WorkspaceCodemapBindingEngine {
             workerID: nil,
             task: nil,
             workerRecoveryCount: 0,
+            workerRecoveryExhausted: false,
             lastWorkerCompletionReason: nil,
             workerRestartRequestedReason: nil,
             isPriorityPromoted: false,
@@ -1089,7 +1119,11 @@ actor WorkspaceCodemapBindingEngine {
         guard var job = graphIndexJobs[rootEpoch],
               job.id == jobID,
               job.task == nil,
+              !job.workerRecoveryExhausted,
               graphIndexJobIsCurrent(job)
+        else { return false }
+        guard recoveryReason == nil ||
+            job.workerRecoveryCount < policy.maximumGraphIndexWorkerRecoveryCount
         else { return false }
         let workerID = UUID()
         job.workerID = workerID
@@ -1146,6 +1180,16 @@ actor WorkspaceCodemapBindingEngine {
              .classifyingBatch, .resolvingArtifacts, .stagingManifestCache,
              .publishingGraphChanges, .checkpointed, .persistingManifestCache, .suspendedBusy:
             break
+        }
+        let workerRecoveryLimitReached =
+            job.workerRecoveryCount >= policy.maximumGraphIndexWorkerRecoveryCount
+        if job.task == nil,
+           job.workerRecoveryExhausted || workerRecoveryLimitReached
+        {
+            job.workerRecoveryExhausted = false
+            job.workerRecoveryCount = 0
+        } else if job.workerRecoveryExhausted {
+            return .unavailable
         }
         prioritizedGraphIndexRootEpoch = rootEpoch
         job.isPriorityPromoted = true
@@ -1863,6 +1907,72 @@ actor WorkspaceCodemapBindingEngine {
                 jobID: job.id,
                 phase: job.phase,
                 reason: graphIndexDebugReason(for: reason)
+            )
+        }
+
+        func debugInstallNonCooperativeGraphIndexWorkerForTesting(
+            rootEpoch: WorkspaceCodemapRootEpoch
+        ) -> Bool {
+            guard var job = graphIndexJobs[rootEpoch], job.task == nil else { return false }
+            let workerID = UUID()
+            let jobID = job.id
+            let gate = DebugGraphIndexNonCooperativeWorkerGate()
+            debugGraphIndexNonCooperativeWorkerGates[jobID] = gate
+            job.workerID = workerID
+            job.workerFinishedUptimeNanoseconds = nil
+            let task = Task(priority: .utility) { [weak self] in
+                await gate.wait()
+                guard let self else { return }
+                await finishGraphIndexWorker(
+                    jobID: jobID,
+                    workerID: workerID,
+                    rootEpoch: rootEpoch,
+                    reason: .cancelled
+                )
+            }
+            job.task = task
+            graphIndexJobs[rootEpoch] = job
+            return true
+        }
+
+        func debugDrainNonCooperativeGraphIndexWorkerForTesting(
+            rootEpoch: WorkspaceCodemapRootEpoch
+        ) async -> Bool {
+            guard let job = graphIndexJobs[rootEpoch],
+                  let gate = debugGraphIndexNonCooperativeWorkerGates[job.id]
+            else { return false }
+            await gate.release()
+            return true
+        }
+
+        func debugGraphIndexWorkerRecoveryStateForTesting(
+            rootEpoch: WorkspaceCodemapRootEpoch
+        ) -> (count: UInt64, exhausted: Bool, workerPresent: Bool, watchdogArmed: Bool)? {
+            guard let job = graphIndexJobs[rootEpoch] else { return nil }
+            return (
+                job.workerRecoveryCount,
+                job.workerRecoveryExhausted,
+                job.task != nil,
+                graphIndexWatchdogTasks[job.id] != nil
+            )
+        }
+
+        func debugGraphIndexManifestRetentionForTesting(
+            rootEpoch: WorkspaceCodemapRootEpoch
+        ) -> (
+            stageCount: Int,
+            cachedRecordCount: Int,
+            stagedRecordCount: Int,
+            stagedByteCount: UInt64,
+            globalStagedByteCount: UInt64
+        )? {
+            guard let job = graphIndexJobs[rootEpoch] else { return nil }
+            return (
+                job.manifestStages.count,
+                job.manifestStages.values.reduce(0) { $0 + $1.cachedRecordsByPath.count },
+                job.manifestStages.values.reduce(0) { $0 + $1.stagedRecordsByPath.count },
+                job.manifestStagedByteCount,
+                graphIndexManifestStagedByteCount
             )
         }
 
@@ -3033,7 +3143,9 @@ actor WorkspaceCodemapBindingEngine {
         job.pageStartProcessedCandidateBaseline = nil
         job.retryAttempt = 0
         job.retry = nil
-        job.workerRecoveryCount = 0
+        if !job.workerRecoveryExhausted {
+            job.workerRecoveryCount = 0
+        }
         job.checkpoint = makeGraphIndexCheckpoint(job)
         graphIndexJobs[rootEpoch] = job
         #if DEBUG
@@ -3129,7 +3241,10 @@ actor WorkspaceCodemapBindingEngine {
             guard let current = currentGraphIndexJob(jobID: jobID, rootEpoch: rootEpoch),
                   let stage = current.manifestStages[pipelineIdentity]
             else { return }
-            guard !stage.isDegraded, !stage.stagedRecordsByPath.isEmpty else { continue }
+            guard !stage.isDegraded, !stage.stagedRecordsByPath.isEmpty else {
+                heartbeatGraphIndexManifestSealStage(jobID: jobID, rootEpoch: rootEpoch)
+                continue
+            }
             let submission = await submitManifestMutations(
                 rootEpoch: rootEpoch,
                 pipelineIdentity: pipelineIdentity,
@@ -3191,6 +3306,7 @@ actor WorkspaceCodemapBindingEngine {
                     degraded: true
                 )
             }
+            heartbeatGraphIndexManifestSealStage(jobID: jobID, rootEpoch: rootEpoch)
         }
         guard var completed = currentGraphIndexJob(jobID: jobID, rootEpoch: rootEpoch) else { return }
         completed.manifestSealState = completed.manifestStages.values.contains(where: \.isDegraded)
@@ -3201,7 +3317,17 @@ actor WorkspaceCodemapBindingEngine {
         completed.phaseEnteredUptimeNanoseconds = completedUptimeNanoseconds
         completed.lastProgressUptimeNanoseconds = completedUptimeNanoseconds
         completed.checkpoint = makeGraphIndexCheckpoint(completed)
+        releaseGraphIndexManifestStageStorage(&completed)
         graphIndexJobs[rootEpoch] = completed
+    }
+
+    private func heartbeatGraphIndexManifestSealStage(
+        jobID: UUID,
+        rootEpoch: WorkspaceCodemapRootEpoch
+    ) {
+        guard var job = currentGraphIndexJob(jobID: jobID, rootEpoch: rootEpoch) else { return }
+        job.lastProgressUptimeNanoseconds = uptimeNanoseconds()
+        graphIndexJobs[rootEpoch] = job
     }
 
     private func recoverVirginGraphIndexSealAuthority(
@@ -4917,11 +5043,18 @@ actor WorkspaceCodemapBindingEngine {
             }
             return .current
         }
-        guard job.workerRecoveryCount < policy.maximumGraphIndexWorkerRecoveryCount else {
+        guard !job.workerRecoveryExhausted,
+              job.workerRecoveryCount < policy.maximumGraphIndexWorkerRecoveryCount
+        else {
+            job.workerRecoveryExhausted = true
             job.lastWorkerCompletionReason = .watchdogRecoveryExhausted
             job.workerRestartRequestedReason = nil
+            let task = job.task
             graphIndexJobs[rootEpoch] = job
             graphIndexWatchdogTasks.removeValue(forKey: jobID)?.cancel()
+            // A cancellation-ignoring worker may still own mutation/publication work for an admitted batch.
+            // Keep its admission and resources quarantined until finishGraphIndexWorker releases them.
+            task?.cancel()
             #if DEBUG
                 recordGraphIndexDebugEvent(
                     kind: .graphIndexWorkerFinished,
@@ -4952,15 +5085,24 @@ actor WorkspaceCodemapBindingEngine {
         requestGraphIndexWorkerRestart(
             jobID: jobID,
             rootEpoch: rootEpoch,
-            reason: .watchdogNoProgress
+            reason: .watchdogNoProgress,
+            countsTowardRecoveryLimit: true
         )
+        if let currentWorkerID = job.workerID {
+            armGraphIndexWatchdog(
+                jobID: jobID,
+                workerID: currentWorkerID,
+                rootEpoch: rootEpoch
+            )
+        }
         return .restartRequested
     }
 
     private func requestGraphIndexWorkerRestart(
         jobID: UUID,
         rootEpoch: WorkspaceCodemapRootEpoch,
-        reason: WorkspaceCodemapGraphIndexWorkerCompletionReason
+        reason: WorkspaceCodemapGraphIndexWorkerCompletionReason,
+        countsTowardRecoveryLimit: Bool = false
     ) {
         guard var job = graphIndexJobs[rootEpoch],
               job.id == jobID,
@@ -4969,6 +5111,9 @@ actor WorkspaceCodemapBindingEngine {
         else { return }
         job.workerRestartRequestedReason = reason
         job.lastWorkerCompletionReason = reason
+        if countsTowardRecoveryLimit {
+            job.workerRecoveryCount = addingSaturating(job.workerRecoveryCount, 1)
+        }
         let task = job.task
         graphIndexJobs[rootEpoch] = job
         if !job.isActiveBatch {
@@ -4998,10 +5143,15 @@ actor WorkspaceCodemapBindingEngine {
         drainingGraphIndexTasks.removeValue(forKey: jobID)
         drainingGraphIndexResources.removeValue(forKey: jobID)
         drainingGraphIndexRootEpochs.removeValue(forKey: jobID)
+        #if DEBUG
+            debugGraphIndexNonCooperativeWorkerGates.removeValue(forKey: jobID)
+        #endif
         let restartReason = job.workerRestartRequestedReason
         job.workerID = nil
         job.task = nil
-        job.lastWorkerCompletionReason = restartReason ?? reason
+        job.lastWorkerCompletionReason = job.workerRecoveryExhausted
+            ? .watchdogRecoveryExhausted
+            : restartReason ?? reason
         job.workerRestartRequestedReason = nil
         job.workerFinishedUptimeNanoseconds = uptimeNanoseconds()
         job.isQueuedForAdmission = false
@@ -5010,13 +5160,6 @@ actor WorkspaceCodemapBindingEngine {
         job.checkpoint = makeGraphIndexCheckpoint(job)
         graphIndexJobs[rootEpoch] = job
         #if DEBUG
-            recordGraphIndexDebugEvent(
-                kind: .graphIndexWorkerFinished,
-                rootEpoch: rootEpoch,
-                jobID: jobID,
-                phase: job.phase,
-                reason: .workerFinished
-            )
             recordGraphIndexDebugEvent(
                 kind: .graphIndexWorkerFinished,
                 rootEpoch: rootEpoch,
@@ -5034,7 +5177,10 @@ actor WorkspaceCodemapBindingEngine {
             nil
         }
         let recoveryReason = restartReason ?? automaticRecoveryReason
+        let watchdogRecoveryWasReserved = restartReason == .watchdogNoProgress
         if let recoveryReason,
+           !job.workerRecoveryExhausted,
+           watchdogRecoveryWasReserved ||
            job.workerRecoveryCount < policy.maximumGraphIndexWorkerRecoveryCount,
            graphIndexJobIsCurrent(job),
            !graphIndexJobPhaseIsTerminal(job.phase)
@@ -5042,7 +5188,7 @@ actor WorkspaceCodemapBindingEngine {
             _ = startGraphIndexWorker(
                 jobID: jobID,
                 rootEpoch: rootEpoch,
-                recoveryReason: recoveryReason
+                recoveryReason: watchdogRecoveryWasReserved ? nil : recoveryReason
             )
         }
         scheduleQueuedRequests()
@@ -5081,13 +5227,17 @@ actor WorkspaceCodemapBindingEngine {
         }
     #endif
 
-    private func discardGraphIndexManifestStages(_ job: inout GraphIndexJob) {
+    private func releaseGraphIndexManifestStageStorage(_ job: inout GraphIndexJob) {
         let releasedByteCount = job.manifestStagedByteCount
         graphIndexManifestStagedByteCount = graphIndexManifestStagedByteCount >= releasedByteCount
             ? graphIndexManifestStagedByteCount - releasedByteCount
             : 0
         job.manifestStages.removeAll(keepingCapacity: false)
         job.manifestStagedByteCount = 0
+    }
+
+    private func discardGraphIndexManifestStages(_ job: inout GraphIndexJob) {
+        releaseGraphIndexManifestStageStorage(&job)
         job.manifestSealState = .discarded
     }
 

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceCodemapGitCapabilityService.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceCodemapGitCapabilityService.swift
@@ -782,6 +782,32 @@ actor WorkspaceCodemapGitCapabilityService {
                 try Task.checkCancellation()
             }
 
+            var postPathFingerprints = [GitBlobLStatFingerprint?](
+                repeating: nil,
+                count: candidates.count
+            )
+            for index in candidates.indices {
+                guard let path = candidatePaths[index],
+                      let prePathFingerprint = prePathFingerprints[index]
+                else { continue }
+                do {
+                    let postPathFingerprint = try pathFingerprintClient.fingerprint(
+                        capability.repositoryLayout.workTreeRoot,
+                        path
+                    )
+                    #if DEBUG
+                        await hooks.afterSourcePathFingerprintCapture()
+                    #endif
+                    guard postPathFingerprint == prePathFingerprint,
+                          postPathFingerprint.isRegularFile
+                    else { continue }
+                    postPathFingerprints[index] = postPathFingerprint
+                } catch {
+                    continue
+                }
+                try Task.checkCancellation()
+            }
+
             let postRepository = try await captureAuthority(
                 loadedRoot: loadedRoot,
                 expectedLayout: capability.repositoryLayout,
@@ -798,33 +824,23 @@ actor WorkspaceCodemapGitCapabilityService {
             for index in candidates.indices {
                 guard let path = candidatePaths[index],
                       let prePathFingerprint = prePathFingerprints[index],
+                      let postPathFingerprint = postPathFingerprints[index],
                       let attributeGeneration = postAttributeGenerations[index]
                 else { continue }
-                do {
-                    let postPathFingerprint = try pathFingerprintClient.fingerprint(
-                        capability.repositoryLayout.workTreeRoot,
-                        path
-                    )
-                    guard postPathFingerprint == prePathFingerprint,
-                          postPathFingerprint.isRegularFile
-                    else { continue }
-                    let candidate = candidates[index]
-                    authorities[index] = WorkspaceCodemapSourceAuthorityToken.issue(
-                        capability: capability,
-                        observedRootEpoch: observedRootEpoch,
-                        observedRepositoryAuthority: observedRepositoryAuthority,
-                        candidateRepositoryRelativePath: path,
-                        acceptedPrePathFingerprint: prePathFingerprint,
-                        acceptedPostPathFingerprint: postPathFingerprint,
-                        candidateAttributeGeneration: attributeGeneration,
-                        observedPathGeneration: candidate.observedPathGeneration,
-                        currentPathGeneration: candidate.currentPathGeneration,
-                        observedIngressGeneration: candidate.observedIngressGeneration,
-                        currentIngressGeneration: candidate.currentIngressGeneration
-                    )
-                } catch {
-                    continue
-                }
+                let candidate = candidates[index]
+                authorities[index] = WorkspaceCodemapSourceAuthorityToken.issue(
+                    capability: capability,
+                    observedRootEpoch: observedRootEpoch,
+                    observedRepositoryAuthority: observedRepositoryAuthority,
+                    candidateRepositoryRelativePath: path,
+                    acceptedPrePathFingerprint: prePathFingerprint,
+                    acceptedPostPathFingerprint: postPathFingerprint,
+                    candidateAttributeGeneration: attributeGeneration,
+                    observedPathGeneration: candidate.observedPathGeneration,
+                    currentPathGeneration: candidate.currentPathGeneration,
+                    observedIngressGeneration: candidate.observedIngressGeneration,
+                    currentIngressGeneration: candidate.currentIngressGeneration
+                )
                 try Task.checkCancellation()
             }
             guard !Task.isCancelled,

--- a/Tests/RepoPromptTests/WorkspaceContext/WorkspaceCodemapBindingEngineObservabilityTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/WorkspaceCodemapBindingEngineObservabilityTests.swift
@@ -95,7 +95,7 @@
             XCTAssertTrue(events.contains { $0.reason == WorkspaceCodemapGraphIndexDebugReason.pageAccepted })
             XCTAssertTrue(events.contains { $0.reason == WorkspaceCodemapGraphIndexDebugReason.checkpointed })
             XCTAssertTrue(events.contains { $0.reason == WorkspaceCodemapGraphIndexDebugReason.complete })
-            XCTAssertTrue(events.contains { $0.reason == WorkspaceCodemapGraphIndexDebugReason.workerFinished })
+            XCTAssertTrue(events.contains { $0.reason == WorkspaceCodemapGraphIndexDebugReason.workerComplete })
             XCTAssertEqual(events.map(\.ordinal), events.map(\.ordinal).sorted())
         }
 
@@ -191,26 +191,110 @@
                 await fixture.engine.debugGraphIndexJobSnapshot(rootEpoch: fixture.rootEpoch)?
                     .isQueuedForAdmission == true
             }
+            let originalJobSnapshot = await fixture.engine.debugGraphIndexJobSnapshot(
+                rootEpoch: fixture.rootEpoch
+            )
+            let originalJob = try XCTUnwrap(originalJobSnapshot)
+            await fixture.engine.debugSimulateGraphIndexWorkerExitForTesting(
+                rootEpoch: fixture.rootEpoch,
+                reason: .admissionUnavailable
+            )
+            let installed = await fixture.engine.debugInstallNonCooperativeGraphIndexWorkerForTesting(
+                rootEpoch: fixture.rootEpoch
+            )
+            XCTAssertTrue(installed)
+            await fixture.engine.debugSetGraphIndexLastProgressForTesting(
+                rootEpoch: fixture.rootEpoch,
+                uptimeNanoseconds: 1
+            )
 
             for expectedRecoveryCount in 1 ... 2 {
-                await fixture.engine.debugSimulateGraphIndexWorkerExitForTesting(
-                    rootEpoch: fixture.rootEpoch,
-                    reason: .admissionUnavailable
-                )
-                await fixture.engine.debugSetGraphIndexLastProgressForTesting(
-                    rootEpoch: fixture.rootEpoch,
-                    uptimeNanoseconds: 1
-                )
                 let watchdogDisposition = await fixture.engine.debugEvaluateGraphIndexWatchdogForTesting(
                     rootEpoch: fixture.rootEpoch,
                     nowUptimeNanoseconds: 60_000_000_001
                 )
-                XCTAssertEqual(watchdogDisposition, .restarted)
-                let recoveredSnapshot = await fixture.engine.debugGraphIndexJobSnapshot(
+                XCTAssertEqual(watchdogDisposition, .restartRequested)
+                let recoveryState = await fixture.engine.debugGraphIndexWorkerRecoveryStateForTesting(
                     rootEpoch: fixture.rootEpoch
                 )
-                XCTAssertEqual(recoveredSnapshot?.workerRecoveryCount, UInt64(expectedRecoveryCount))
+                let recovery = try XCTUnwrap(recoveryState)
+                XCTAssertEqual(recovery.count, UInt64(expectedRecoveryCount))
+                XCTAssertFalse(recovery.exhausted)
+                XCTAssertTrue(recovery.workerPresent)
+                XCTAssertTrue(recovery.watchdogArmed)
             }
+
+            let exhaustedDisposition = await fixture.engine.debugEvaluateGraphIndexWatchdogForTesting(
+                rootEpoch: fixture.rootEpoch,
+                nowUptimeNanoseconds: 60_000_000_001
+            )
+            XCTAssertEqual(exhaustedDisposition, .exhausted)
+            let observedExhaustedSnapshot = await fixture.engine.debugGraphIndexJobSnapshot(
+                rootEpoch: fixture.rootEpoch
+            )
+            let exhaustedSnapshot = try XCTUnwrap(observedExhaustedSnapshot)
+            XCTAssertTrue(exhaustedSnapshot.workerPresent)
+            XCTAssertEqual(exhaustedSnapshot.workerRecoveryCount, 2)
+            XCTAssertEqual(exhaustedSnapshot.lastWorkerCompletionReason, .watchdogRecoveryExhausted)
+            let exhaustedRecoveryState = await fixture.engine.debugGraphIndexWorkerRecoveryStateForTesting(
+                rootEpoch: fixture.rootEpoch
+            )
+            let exhaustedRecovery = try XCTUnwrap(exhaustedRecoveryState)
+            XCTAssertTrue(exhaustedRecovery.exhausted)
+            XCTAssertFalse(exhaustedRecovery.watchdogArmed)
+
+            let quarantinedSchedule = await fixture.engine.scheduleGraphIndex(
+                rootEpoch: fixture.rootEpoch
+            )
+            XCTAssertEqual(quarantinedSchedule, .handedOff)
+            let quarantinedPrioritize = await fixture.engine.prioritizeGraphIndexNow(
+                rootEpoch: fixture.rootEpoch
+            )
+            XCTAssertEqual(quarantinedPrioritize, .unavailable)
+            let quarantinedRecoveryState = await fixture.engine.debugGraphIndexWorkerRecoveryStateForTesting(
+                rootEpoch: fixture.rootEpoch
+            )
+            let quarantinedRecovery = try XCTUnwrap(quarantinedRecoveryState)
+            XCTAssertEqual(quarantinedRecovery.count, 2)
+            XCTAssertTrue(quarantinedRecovery.exhausted)
+            XCTAssertTrue(quarantinedRecovery.workerPresent)
+
+            let drainRequested = await fixture.engine.debugDrainNonCooperativeGraphIndexWorkerForTesting(
+                rootEpoch: fixture.rootEpoch
+            )
+            XCTAssertTrue(drainRequested)
+            try await AsyncTestWait.waitUntil("exhausted graph worker drain", timeout: 5) {
+                await fixture.engine.debugGraphIndexWorkerRecoveryStateForTesting(
+                    rootEpoch: fixture.rootEpoch
+                )?.workerPresent == false
+            }
+            let drainedSchedule = await fixture.engine.scheduleGraphIndex(rootEpoch: fixture.rootEpoch)
+            XCTAssertEqual(drainedSchedule, .handedOff)
+            let drainedRecoveryState = await fixture.engine.debugGraphIndexWorkerRecoveryStateForTesting(
+                rootEpoch: fixture.rootEpoch
+            )
+            let drainedRecovery = try XCTUnwrap(drainedRecoveryState)
+            XCTAssertEqual(drainedRecovery.count, 2)
+            XCTAssertTrue(drainedRecovery.exhausted)
+            XCTAssertFalse(drainedRecovery.workerPresent)
+
+            let restartDisposition = await fixture.engine.prioritizeGraphIndexNow(
+                rootEpoch: fixture.rootEpoch
+            )
+            XCTAssertEqual(restartDisposition, .restarted)
+            let restartedJobSnapshot = await fixture.engine.debugGraphIndexJobSnapshot(
+                rootEpoch: fixture.rootEpoch
+            )
+            let restartedJob = try XCTUnwrap(restartedJobSnapshot)
+            XCTAssertEqual(restartedJob.jobID, originalJob.jobID)
+            XCTAssertEqual(restartedJob.checkpointPresent, originalJob.checkpointPresent)
+            XCTAssertTrue(restartedJob.workerPresent)
+            let resetRecoveryState = await fixture.engine.debugGraphIndexWorkerRecoveryStateForTesting(
+                rootEpoch: fixture.rootEpoch
+            )
+            let resetRecovery = try XCTUnwrap(resetRecoveryState)
+            XCTAssertEqual(resetRecovery.count, 1)
+            XCTAssertFalse(resetRecovery.exhausted)
 
             await fixture.engine.debugSimulateGraphIndexWorkerExitForTesting(
                 rootEpoch: fixture.rootEpoch,
@@ -220,18 +304,48 @@
                 rootEpoch: fixture.rootEpoch,
                 uptimeNanoseconds: 1
             )
-            let exhaustedDisposition = await fixture.engine.debugEvaluateGraphIndexWatchdogForTesting(
+            let maximumRecoveryDisposition = await fixture.engine.debugEvaluateGraphIndexWatchdogForTesting(
                 rootEpoch: fixture.rootEpoch,
                 nowUptimeNanoseconds: 60_000_000_001
             )
-            XCTAssertEqual(exhaustedDisposition, .exhausted)
-            let exhaustedSnapshot = await fixture.engine.debugGraphIndexJobSnapshot(
+            XCTAssertEqual(maximumRecoveryDisposition, .restarted)
+            let runningAtMaximumState = await fixture.engine.debugGraphIndexWorkerRecoveryStateForTesting(
                 rootEpoch: fixture.rootEpoch
             )
-            let exhausted = try XCTUnwrap(exhaustedSnapshot)
-            XCTAssertFalse(exhausted.workerPresent)
-            XCTAssertEqual(exhausted.workerRecoveryCount, 2)
-            XCTAssertEqual(exhausted.lastWorkerCompletionReason, .watchdogRecoveryExhausted)
+            let runningAtMaximum = try XCTUnwrap(runningAtMaximumState)
+            XCTAssertEqual(runningAtMaximum.count, 2)
+            XCTAssertFalse(runningAtMaximum.exhausted)
+            XCTAssertTrue(runningAtMaximum.workerPresent)
+            let runningAtMaximumPrioritize = await fixture.engine.prioritizeGraphIndexNow(
+                rootEpoch: fixture.rootEpoch
+            )
+            XCTAssertEqual(runningAtMaximumPrioritize, .promoted)
+
+            await fixture.engine.debugSimulateGraphIndexWorkerExitForTesting(
+                rootEpoch: fixture.rootEpoch,
+                reason: .admissionUnavailable
+            )
+            let deadAtMaximumSchedule = await fixture.engine.scheduleGraphIndex(rootEpoch: fixture.rootEpoch)
+            XCTAssertEqual(deadAtMaximumSchedule, .handedOff)
+            let deadAtMaximumState = await fixture.engine.debugGraphIndexWorkerRecoveryStateForTesting(
+                rootEpoch: fixture.rootEpoch
+            )
+            let deadAtMaximum = try XCTUnwrap(deadAtMaximumState)
+            XCTAssertEqual(deadAtMaximum.count, 2)
+            XCTAssertFalse(deadAtMaximum.exhausted)
+            XCTAssertFalse(deadAtMaximum.workerPresent)
+
+            let deadAtMaximumPrioritize = await fixture.engine.prioritizeGraphIndexNow(
+                rootEpoch: fixture.rootEpoch
+            )
+            XCTAssertEqual(deadAtMaximumPrioritize, .restarted)
+            let resetAtMaximumState = await fixture.engine.debugGraphIndexWorkerRecoveryStateForTesting(
+                rootEpoch: fixture.rootEpoch
+            )
+            let resetAtMaximum = try XCTUnwrap(resetAtMaximumState)
+            XCTAssertEqual(resetAtMaximum.count, 1)
+            XCTAssertFalse(resetAtMaximum.exhausted)
+            XCTAssertTrue(resetAtMaximum.workerPresent)
             _ = await fixture.engine.debugReleaseGraphIndexAdmissionHold(
                 hold.holdID,
                 rootEpoch: fixture.rootEpoch
@@ -680,6 +794,15 @@
             XCTAssertEqual(counters.graphIndexSealManifestSubmissions, 1)
             XCTAssertEqual(counters.graphIndexSealManifestWaits, 1)
             XCTAssertEqual(counters.graphIndexSealManifestWrites, 1)
+            let retainedManifestSnapshot = await fixture.engine.debugGraphIndexManifestRetentionForTesting(
+                rootEpoch: fixture.rootEpoch
+            )
+            let retainedManifest = try XCTUnwrap(retainedManifestSnapshot)
+            XCTAssertEqual(retainedManifest.stageCount, 0)
+            XCTAssertEqual(retainedManifest.cachedRecordCount, 0)
+            XCTAssertEqual(retainedManifest.stagedRecordCount, 0)
+            XCTAssertEqual(retainedManifest.stagedByteCount, 0)
+            XCTAssertEqual(retainedManifest.globalStagedByteCount, 0)
 
             let observedJob = await fixture.engine.debugGraphIndexJobSnapshot(
                 rootEpoch: fixture.rootEpoch

--- a/Tests/RepoPromptTests/WorkspaceContext/WorkspaceCodemapGitCapabilityServiceTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/WorkspaceCodemapGitCapabilityServiceTests.swift
@@ -662,6 +662,42 @@ final class WorkspaceCodemapGitCapabilityServiceTests: XCTestCase {
         XCTAssertNotNil(batchAuthorities[1])
         XCTAssertNotNil(batchAuthorities[2])
 
+        let postPathRoot = try fixture.makeRepository(named: "post-path-authority")
+        try fixture.write("let value = true\n", to: path, at: postPathRoot)
+        let postPathMutation = AuthorityFileMutationOnInvocation(
+            url: postPathRoot.appendingPathComponent(".git/index"),
+            targetInvocation: 2
+        )
+        let postPathService = WorkspaceCodemapGitCapabilityService(
+            namespaceSalt: namespaceSalt,
+            hooks: WorkspaceCodemapGitCapabilityServiceHooks(
+                afterSourcePathFingerprintCapture: {
+                    await postPathMutation.mutateOnTargetInvocation()
+                }
+            )
+        )
+        let postPathCapability = try await capability(
+            postPathService.resolve(root: request(for: postPathRoot, seed: 53))
+        )
+        let postPathCapturesBefore = await postPathService.snapshotForTesting().authorityCaptureCount
+        let postPathAuthorities = await postPathService.makeSourceAuthorities(
+            capability: postPathCapability,
+            observedRootEpoch: postPathCapability.rootEpoch,
+            observedRepositoryAuthority: postPathCapability.repositoryAuthority,
+            candidates: [WorkspaceCodemapSourceAuthorityRequest(
+                candidateRepositoryRelativePath: path,
+                observedPathGeneration: 1,
+                currentPathGeneration: 1,
+                observedIngressGeneration: 1,
+                currentIngressGeneration: 1
+            )]
+        )
+        let postPathCapturesAfter = await postPathService.snapshotForTesting().authorityCaptureCount
+        XCTAssertEqual(postPathCapturesAfter - postPathCapturesBefore, 2)
+        let postPathFingerprintCaptureCount = await postPathMutation.invocationCount()
+        XCTAssertEqual(postPathFingerprintCaptureCount, 2)
+        XCTAssertNil(postPathAuthorities[0])
+
         for (offset, evidenceKind) in ["index", "config", "ref"].enumerated() {
             let mutationRoot = try fixture.makeRepository(named: "authority-\(evidenceKind)")
             try fixture.write("let a = true\n", to: "Sources/A.swift", at: mutationRoot)
@@ -1240,6 +1276,28 @@ private final class ExactPathFingerprintRecorder: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         return Snapshot(callCount: callCount, allPathsMatched: allPathsMatched)
+    }
+}
+
+private actor AuthorityFileMutationOnInvocation {
+    private let url: URL
+    private let targetInvocation: Int
+    private var invocations = 0
+
+    init(url: URL, targetInvocation: Int) {
+        self.url = url
+        self.targetInvocation = targetInvocation
+    }
+
+    func mutateOnTargetInvocation() {
+        invocations += 1
+        guard invocations == targetInvocation else { return }
+        let data = (try? Data(contentsOf: url)) ?? Data()
+        try? (data + Data("\n# post-path authority mutation\n".utf8)).write(to: url, options: .atomic)
+    }
+
+    func invocationCount() -> Int {
+        invocations
     }
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #659 after its performance cutover merged.

- bound and rearm graph-index watchdog recovery when a worker ignores cancellation
- quarantine an exhausted worker fail-closed until it drains, then require an explicit retry
- refresh seal-stage liveness and release completed manifest staging/cache storage
- move the final repository capability fence immediately before token issuance without adding Git captures
- expand existing focused regression coverage without changing test IDs or the curated ledger

## Why

Post-merge review of #659 found a watchdog hole: a cancellation-ignoring worker could leave recovery unbounded or stall automatic progress indefinitely. The same review found retained seal-stage memory and a widened final repository-authority window.

This change tightens those boundaries without reopening the manifest/page write-amplification path fixed by #659.

## Performance safety

- preserves one manifest load and zero page submissions/waits/writes in the seal-path contract
- preserves exactly two repository captures per capability batch
- adds watchdog bookkeeping only on timeout/recovery paths
- releases completed manifest stage caches and staged bytes
- does not change process-global caps or workspace fairness policy

Workspace-weighted scheduling fairness remains a separate follow-up because it changes scheduling ownership and policy rather than the correctness boundaries addressed here.

## Validation

- `make dev-test FILTER=WorkspaceCodemapBindingEngineObservabilityTests` — 12 tests passed
- `make dev-test FILTER=WorkspaceCodemapGitCapabilityServiceTests` — 17 tests passed
- `make dev-lint`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh commit`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh pr-ready`

No visible app launch or live performance rerun was performed.
