### PR TITLE
Fix Tip release optimizer ownership crash

### DIFF
--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceCodemapBindingEngine.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceCodemapBindingEngine.swift
@@ -321,6 +321,11 @@ actor WorkspaceCodemapBindingEngine {
         let observedPredecessorAuthority: CodeMapRootManifestAuthority?
     }
 
+    private struct ManifestWriterFailureDisposition {
+        let terminalObservedStaleAuthority: Bool
+        let terminalCompletion: ManifestRevisionCompletion
+    }
+
     private struct ManifestWriterWorkKey: Hashable {
         let scope: PipelineScope
         let sessionID: UUID
@@ -7689,6 +7694,27 @@ actor WorkspaceCodemapBindingEngine {
         ), false)
     }
 
+    /// Keep the error downcast and optional projection outside the optimized async writer.
+    /// Swift 6.3.2 CopyPropagation otherwise produces invalid ownership SIL for this value.
+    @inline(never)
+    private func manifestWriterFailureDisposition(
+        _ error: any Error
+    ) -> ManifestWriterFailureDisposition {
+        guard let failure = error as? WorkspaceCodemapObservedStaleAuthorityError,
+              let observedAuthority = failure.observedPredecessorAuthority
+        else {
+            return ManifestWriterFailureDisposition(
+                terminalObservedStaleAuthority: false,
+                terminalCompletion: .failed
+            )
+        }
+        return ManifestWriterFailureDisposition(
+            terminalObservedStaleAuthority:
+            observedAuthority.authorityGeneration >= failure.currentAuthorityGeneration,
+            terminalCompletion: .staleAuthority(observedAuthority: observedAuthority)
+        )
+    }
+
     private func runManifestWriter(
         namespace: CodeMapRootManifestNamespace,
         writerID: UUID
@@ -7971,13 +7997,7 @@ actor WorkspaceCodemapBindingEngine {
                 #if DEBUG
                     manifestAttemptCompletedUptimeNanoseconds = uptimeNanoseconds()
                 #endif
-                let observedStaleAuthorityError = error as? WorkspaceCodemapObservedStaleAuthorityError
-                let terminalObservedStaleAuthority = observedStaleAuthorityError
-                    .flatMap { failure in
-                        failure.observedPredecessorAuthorityGeneration.map {
-                            $0 >= failure.currentAuthorityGeneration
-                        }
-                    } ?? false
+                let failureDisposition = manifestWriterFailureDisposition(error)
                 guard var currentWriter = currentManifestWriterState(
                     namespace: namespace,
                     writerID: writerID,
@@ -7992,7 +8012,7 @@ actor WorkspaceCodemapBindingEngine {
                 }
                 currentWriter.deferredWork.append(contentsOf: currentWriter.queuedWork.drain())
                 recordManifestWriterPeakQueuedItems(in: currentWriter)
-                if terminalObservedStaleAuthority ||
+                if failureDisposition.terminalObservedStaleAuthority ||
                     currentWriter.deferredFailureCount >= Self.maximumManifestWriterDeferredAttempts,
                     let exhaustedHead = currentWriter.deferredHeadBatch
                 {
@@ -8002,11 +8022,7 @@ actor WorkspaceCodemapBindingEngine {
                         exhaustedHead.items,
                         from: &currentWriter,
                         terminalWaiterRevision: exhaustedHead.highestRevision,
-                        terminalCompletion: observedStaleAuthorityError.flatMap {
-                            $0.observedPredecessorAuthority.map {
-                                .staleAuthority(observedAuthority: $0)
-                            }
-                        } ?? .failed
+                        terminalCompletion: failureDisposition.terminalCompletion
                     )
                 }
                 shedNewestDeferredManifestWorkIfNeeded(from: &currentWriter)


### PR DESCRIPTION
## Summary
- isolate stale-authority error projection from the optimized async manifest writer
- preserve terminal stale-authority and waiter-completion semantics
- avoid the Swift 6.3.2 CopyPropagation ownership crash blocking Tip builds from 30549a1

## Evidence
- exact Tip failure reproduced in GitHub run 30323981908 attempts 1 and 2
- `make dev-test FILTER=WorkspaceCodemapBindingEngineObservabilityTests`
- `make dev-lint`
- `make dev-release-preflight`
- `make dev-release-artifact` (universal arm64+x86_64, Sentry-enabled release compile passed)
- Oracle review: no must-fix or meaningful concerns

The local release artifact is ad-hoc and validation-only; production Tip signing/notarization remains in the protected workflow.