### PR TITLE
Clarify MCP resource read instructions

### DIFF
--- a/Sources/RepoPrompt/Infrastructure/MCP/RepoPromptMCPInstructions.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/RepoPromptMCPInstructions.swift
@@ -50,6 +50,8 @@ enum RepoPromptMCPInstructions {
         AGENT DELEGATION: Your system prompt lists the delegation tool available to you and how to use it. Use that tool to spawn or drive separate Agent Mode sessions when the task needs work in a fresh session or read-only exploration probes; do not assume any specific delegation tool is in scope for this connection.
 
         SHARING AN ORACLE / CONTEXT_BUILDER EXPORT: Pass `export_response: true` on `context_builder`, `ask_oracle`, or `oracle_send` to capture the response as a shareable file. The call returns `oracle_export_path` (the file path) and `oracle_export_instruction` (a ready-made "Read the Oracle export at `<path>` with `read_file` …" sentence). To hand the export to a delegated child agent, include `oracle_export_path` inside the `message` you send on your next delegation call — your system prompt names the specific delegation tool you should use. The child agent already has `read_file` and will open the export itself.
+
+        RESOURCE READING: Do not use `read_mcp_resource` for workspace files or root-prefixed paths such as `agno/AGENTS.md`; use `read_file` instead. Only use `read_mcp_resource` with exact URIs returned by `list_mcp_resources`, such as `repoprompt://instructions`.
         """
     }
 
@@ -78,6 +80,8 @@ enum RepoPromptMCPInstructions {
         SHARING AN ORACLE / CONTEXT_BUILDER EXPORT: Pass `export_response: true` on `context_builder` or `oracle_send` to capture the response as a shareable file. The call returns `oracle_export_path` (the file path) and `oracle_export_instruction` (a ready-made "Read the Oracle export at `<path>` with `read_file` …" sentence). To hand the export to a delegated child agent, include `oracle_export_path` inside the `message` you send on your next `agent_run` `start` or `steer` call. You may emit `oracle_export_instruction` verbatim at the head of that `message`; the child already has `read_file` and will open the export itself.
 
         Workspace tabs isolate tab contexts for parallel tasks. Use bind_context with context_id to bind this connection to the intended tab context for multi-window/tab routing.
+
+        RESOURCE READING: Do not use `read_mcp_resource` for workspace files or root-prefixed paths such as `agno/AGENTS.md`; use `read_file` instead. Only use `read_mcp_resource` with exact URIs returned by `list_mcp_resources`, such as `repoprompt://instructions`.
         """
     }
 
@@ -97,6 +101,8 @@ enum RepoPromptMCPInstructions {
         - manage_selection — curate file context for the response
         - workspace_context — render the current selection as a snapshot
         - git — read-only git operations (status/diff/log/blame)
+
+        RESOURCE READING: Do not use `read_mcp_resource` for workspace files or root-prefixed paths such as `agno/AGENTS.md`; use `read_file` instead. Only use `read_mcp_resource` with exact URIs returned by `list_mcp_resources`, such as `repoprompt://instructions`.
         """
     }
 }

--- a/Tests/RepoPromptTests/MCP/RepoPromptMCPInstructionsTests.swift
+++ b/Tests/RepoPromptTests/MCP/RepoPromptMCPInstructionsTests.swift
@@ -1,0 +1,37 @@
+//
+//  RepoPromptMCPInstructionsTests.swift
+//  RepoPrompt
+//
+//  Regression tests for the MCP server instructions returned by RepoPromptMCPInstructions.
+//
+
+@testable import RepoPromptApp
+import XCTest
+
+final class RepoPromptMCPInstructionsTests: XCTestCase {
+    /// All three run purposes must warn clients that `read_mcp_resource` is only for exact
+    /// advertised URIs (e.g. `repoprompt://instructions`) and that workspace/root-prefixed
+    /// paths must be read with `read_file`.
+    func testResourceReadGuidanceIsPresentForEveryRunPurpose() {
+        let purposes: [MCPRunPurpose] = [.agentModeRun, .discoverRun, .unknown]
+        let requiredPhrases = [
+            "read_mcp_resource",
+            "read_file",
+            "list_mcp_resources",
+            "repoprompt://instructions",
+            "workspace files",
+            "agno/AGENTS.md"
+        ]
+
+        for purpose in purposes {
+            let instructions = RepoPromptMCPInstructions.text(for: purpose)
+
+            for phrase in requiredPhrases {
+                XCTAssert(
+                    instructions.contains(phrase),
+                    "Instructions for MCPRunPurpose.\(purpose) are missing required phrase \"\(phrase)\"."
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add MCP instruction guidance warning clients not to use `read_mcp_resource` for workspace files or root-prefixed paths like `agno/AGENTS.md`.
- Point clients to `read_file` for workspace paths and restrict `read_mcp_resource` to exact URIs returned by `list_mcp_resources`, such as `repoprompt://instructions`.
- Add a regression test covering `.agentModeRun`, `.discoverRun`, and `.unknown` instructions.

## Problem fixed
Codex and other MCP clients may attempt to read workspace files like `agno/AGENTS.md` through generic MCP resource APIs. RepoPrompt CE only exposes `repoprompt://instructions` as an MCP resource; workspace files must be read through `read_file`. This change hardens the MCP instructions so clients avoid treating root-prefixed workspace paths as resource URIs, without broadening the `resources/read` handler.

## Validation
- `make dev-format-check`
- `make dev-test FILTER=RepoPromptMCPInstructionsTests`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh commit`
- `.agents/skills/rpce-contribution-check/scripts/preflight.sh push`
