### PR TITLE
Fix path-scoped Git artifact publication freezes

### DIFF
--- a/Sources/RepoPrompt/Infrastructure/MCP/MCPToolWorkCountDiagnostics.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/MCPToolWorkCountDiagnostics.swift
@@ -13,6 +13,7 @@ enum MCPToolWorkCountDiagnostics {
         let outputBytes: Int
         let parseMicroseconds: Int
         let commands: [String]
+        let inlinePathspecCounts: [Int]
         let outcome: String
     }
 
@@ -40,6 +41,7 @@ enum MCPToolWorkCountDiagnostics {
             private var outputBytes = 0
             private var parseMicroseconds = 0
             private var commands: [String] = []
+            private var inlinePathspecCounts: [Int] = []
 
             init(operation: String, requestIdentity: MCPRequestTimelineIdentity?) {
                 self.operation = operation
@@ -71,6 +73,10 @@ enum MCPToolWorkCountDiagnostics {
                 }
                 if commands.count < 128 {
                     commands.append(arguments.prefix(4).joined(separator: " "))
+                    let pathspecCount = arguments.firstIndex(of: "--").map {
+                        arguments.count - $0 - 1
+                    } ?? 0
+                    inlinePathspecCounts.append(pathspecCount)
                 }
                 lock.unlock()
             }
@@ -95,6 +101,7 @@ enum MCPToolWorkCountDiagnostics {
                     outputBytes: outputBytes,
                     parseMicroseconds: parseMicroseconds,
                     commands: commands,
+                    inlinePathspecCounts: inlinePathspecCounts,
                     outcome: outcome
                 )
             }

--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPGitToolProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPGitToolProvider.swift
@@ -510,8 +510,11 @@ final class MCPGitToolProvider: MCPWindowToolProviding {
         // Generic callers retain first-root compatibility. Exact Agent Context Builder Discover
         // runs instead use the immutable selected-repository target carried by their tab snapshot.
         let metadata = await dependencies.captureRequestMetadata()
+        let hasExplicitPathspecs = !(args["path"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
+            || (args["paths"]?.arrayValue?.contains { !($0.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true) } ?? false)
         let preLookupSelectedPublicationContext: MCPServerViewModel.ResolvedTabContextSnapshot? = if op == .diff,
                                                                                                      args["artifacts"]?.boolValue == true,
+                                                                                                     !hasExplicitPathspecs,
                                                                                                      (args["scope"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() ?? "all") == "selected"
         {
             try dependencies.resolveTabContextSnapshot(
@@ -715,16 +718,22 @@ final class MCPGitToolProvider: MCPWindowToolProviding {
             )
             try Task.checkCancellation()
 
-            var readyCandidates: [GitDiffPublishedArtifact] = []
-            var advertisedCandidates: [GitDiffPublishedArtifact] = []
-            for published in publishedSets {
-                readyCandidates.append(contentsOf: ingress.selectionReadyArtifacts(for: published))
-                advertisedCandidates.append(contentsOf: ingress.advertisementReadyArtifacts(for: published))
-                for artifact in published.orderedArtifacts {
-                    guard let failure = ingress.failuresByArtifact[artifact] else { continue }
+            let readinessAggregation = try await ingress.aggregateReadiness(for: publishedSets)
+            let readyCandidates = readinessAggregation.selectionReadyArtifacts
+            let advertisedCandidates = readinessAggregation.advertisementReadyArtifacts
+            let warningLimitPerSnapshot = 20
+            for (snapshotDirectory, failures) in readinessAggregation.failuresBySnapshotDirectory {
+                for failure in failures.prefix(warningLimitPerSnapshot) {
+                    let artifact = failure.artifact
                     let label = artifact.clientAlias ?? artifact.gitDataRelativePath
-                    warningParts[published.snapshotRef.snapshotDirRel, default: []].append(
-                        "Git artifact readiness: \(label) was not selection-ready (\(artifactIngressFailureDescription(failure)))."
+                    warningParts[snapshotDirectory, default: []].append(
+                        "Git artifact readiness: \(label) was not selection-ready (\(artifactIngressFailureDescription(failure.status)))."
+                    )
+                }
+                let omittedCount = failures.count - min(failures.count, warningLimitPerSnapshot)
+                if omittedCount > 0 {
+                    warningParts[snapshotDirectory, default: []].append(
+                        "Git artifact readiness: \(omittedCount) additional failure(s) omitted."
                     )
                 }
             }
@@ -741,12 +750,7 @@ final class MCPGitToolProvider: MCPWindowToolProviding {
                 } catch is CancellationError {
                     throw CancellationError()
                 } catch {
-                    let affectedSnapshotRefs = Set(publishedSets.compactMap { published -> String? in
-                        ingress.selectionReadyArtifacts(for: published).isEmpty
-                            ? nil
-                            : published.snapshotRef.snapshotDirRel
-                    })
-                    for snapshotRef in affectedSnapshotRefs {
+                    for snapshotRef in readinessAggregation.selectionReadySnapshotDirectories {
                         warningParts[snapshotRef, default: []].append(
                             "Git artifact readiness: cataloged primary artifacts could not be committed to the canonical tab selection (\(error.localizedDescription)); autoSelected was omitted."
                         )
@@ -1136,8 +1140,9 @@ final class MCPGitToolProvider: MCPWindowToolProviding {
                 // physical projection. Bound logical-root descendants are translated to their
                 // worktree roots for snapshot publication, while the source selection committed
                 // back to the tab remains logical.
+                let usesSelectedScope = scope == .selected && pathspecs == nil
                 let allSelectedAbsolutePaths: [String]
-                if scope == .selected {
+                if usesSelectedScope {
                     let resolvedContext = try preLookupSelectedPublicationContext
                         ?? dependencies.resolveTabContextSnapshot(
                             metadata,
@@ -1177,7 +1182,7 @@ final class MCPGitToolProvider: MCPWindowToolProviding {
                     let tabID = dependencies.boundTabID(connectionID)
 
                     // Group selection paths by repo
-                    let pathsByRepo = scope == .selected ? groupAbsolutePathsByRepo(paths: allSelectedAbsolutePaths, repos: repos) : [:]
+                    let pathsByRepo = usesSelectedScope ? groupAbsolutePathsByRepo(paths: allSelectedAbsolutePaths, repos: repos) : [:]
                     let outcomes = await BoundedOrderedConcurrentMap.map(
                         repos,
                         maxConcurrent: Self.maxConcurrentRepositories
@@ -1185,8 +1190,28 @@ final class MCPGitToolProvider: MCPWindowToolProviding {
                         do {
                             let repoCompare = try await resolveCompareSpec(compareRaw, for: repo)
                             let repoWorktree = await requestContext.worktreeDTO(for: repo.rootURL)
-                            let repoSelectedPaths = scope == .selected ? (pathsByRepo[repo] ?? []) : []
-                            if scope == .selected, repoSelectedPaths.isEmpty {
+                            let repoSelectedPaths = usesSelectedScope ? (pathsByRepo[repo] ?? []) : []
+                            if let pathspecs,
+                               GitDiffPathNormalization.gitPathspecs(
+                                   from: pathspecs,
+                                   repoRootPath: repo.rootPath
+                               ).isEmpty
+                            {
+                                return MCPGitArtifactRepoOutcome(
+                                    result: Reply.RepoResultDTO(
+                                        repoRoot: repo.rootPath,
+                                        repoKey: repo.repoKey,
+                                        repoName: repo.displayName,
+                                        worktree: repoWorktree,
+                                        emptyReason: "No requested paths in this repo"
+                                    ),
+                                    diff: nil,
+                                    manifest: nil,
+                                    snapshotDir: nil,
+                                    publishedArtifacts: nil
+                                )
+                            }
+                            if usesSelectedScope, repoSelectedPaths.isEmpty {
                                 return MCPGitArtifactRepoOutcome(
                                     result: Reply.RepoResultDTO(
                                         repoRoot: repo.rootPath,
@@ -1211,6 +1236,7 @@ final class MCPGitToolProvider: MCPWindowToolProviding {
                                 compareInput: repoCompare.input,
                                 scope: scope,
                                 selectedAbsolutePaths: repoSelectedPaths,
+                                pathspecs: pathspecs,
                                 contextLines: contextLines,
                                 detectRenames: detectRenames,
                                 snapshotIDOverride: snapshotIDOverride,
@@ -1322,6 +1348,7 @@ final class MCPGitToolProvider: MCPWindowToolProviding {
                     compareInput: compare.input,
                     scope: scope,
                     selectedAbsolutePaths: allSelectedAbsolutePaths,
+                    pathspecs: pathspecs,
                     contextLines: contextLines,
                     detectRenames: detectRenames,
                     snapshotIDOverride: snapshotIDOverride,

--- a/Sources/RepoPrompt/Infrastructure/Utilities/WorkspacePathNormalizations.swift
+++ b/Sources/RepoPrompt/Infrastructure/Utilities/WorkspacePathNormalizations.swift
@@ -59,25 +59,75 @@ enum GitDiffPathNormalization {
         paths.map(normalizedAbsolutePath)
     }
 
+    private struct NormalizedGitPathspec: Hashable {
+        let plain: String
+        let requiresLiteralMagic: Bool
+    }
+
     static func gitPathspecs(from paths: [String], repoRootPath: String) -> [String] {
+        var seen = Set<String>()
+        return normalizedGitPathspecs(from: paths, repoRootPath: repoRootPath).compactMap { normalized in
+            seen.insert(normalized.plain).inserted ? normalized.plain : nil
+        }
+    }
+
+    /// Produces command pathspecs while preserving user-authored relative Git pathspec semantics.
+    /// Absolute inputs are app/worktree-derived paths and must be literalized before invoking Git.
+    static func gitDiscoveryPathspecs(from paths: [String], repoRootPath: String) -> [String] {
+        var seen = Set<String>()
+        return normalizedGitPathspecs(from: paths, repoRootPath: repoRootPath).compactMap { normalized in
+            let pathspec = normalized.requiresLiteralMagic
+                ? literalGitPathspec(normalized.plain)
+                : normalized.plain
+            return seen.insert(pathspec).inserted ? pathspec : nil
+        }
+    }
+
+    static func literalGitPathspecs(_ paths: [String]) -> [String] {
+        paths.map(literalGitPathspec)
+    }
+
+    private static func literalGitPathspec(_ path: String) -> String {
+        ":(literal)\(path)"
+    }
+
+    private static func normalizedGitPathspecs(
+        from paths: [String],
+        repoRootPath: String
+    ) -> [NormalizedGitPathspec] {
         let standardizedRoot = normalizedAbsolutePath(repoRootPath)
-        return paths.map { rawPath in
-            let expanded = (rawPath as NSString).expandingTildeInPath
-            guard expanded.hasPrefix("/") else { return rawPath }
+        var results: [NormalizedGitPathspec] = []
+        results.reserveCapacity(paths.count)
+
+        for rawPath in paths {
+            let trimmed = rawPath.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty, !StandardizedPath.containsNUL(trimmed) else { continue }
+
+            let expanded = (trimmed as NSString).expandingTildeInPath
+            guard expanded.hasPrefix("/") else {
+                results.append(NormalizedGitPathspec(plain: trimmed, requiresLiteralMagic: false))
+                continue
+            }
 
             let standardizedPath = normalizedAbsolutePath(expanded)
             guard StandardizedPath.isDescendant(standardizedPath, of: standardizedRoot) else {
-                return standardizedPath
+                continue
             }
-            guard standardizedPath != standardizedRoot else { return "." }
+            if standardizedPath == standardizedRoot {
+                results.append(NormalizedGitPathspec(plain: ".", requiresLiteralMagic: true))
+                continue
+            }
 
             let suffix: Substring = if standardizedRoot == "/" {
                 standardizedPath.dropFirst()
             } else {
                 standardizedPath.dropFirst(standardizedRoot.count)
             }
-            return StandardizedPath.relative(String(suffix))
+            let pathspec = StandardizedPath.relative(String(suffix))
+            guard !pathspec.isEmpty else { continue }
+            results.append(NormalizedGitPathspec(plain: pathspec, requiresLiteralMagic: true))
         }
+        return results
     }
 
     static func gitRelativePaths(from absolutePaths: [String], repoRootPath: String) -> [String] {

--- a/Sources/RepoPrompt/Infrastructure/VCS/GitBackend.swift
+++ b/Sources/RepoPrompt/Infrastructure/VCS/GitBackend.swift
@@ -204,12 +204,14 @@ actor GitBackend: VCSBackend {
         compare: GitDiffCompareSpec,
         includeUntrackedWhenApplicable: Bool,
         detectRenames: Bool,
+        paths: [String]?,
         at repoURL: URL
     ) async throws -> [VCSUncommittedFile] {
         let files = try await gitService.getChangedFilesStats(
             compare: compare,
             includeUntrackedWhenApplicable: includeUntrackedWhenApplicable,
             detectRenames: detectRenames,
+            paths: paths,
             at: repoURL
         )
         return files.map { file in

--- a/Sources/RepoPrompt/Infrastructure/VCS/GitDiff/GitDiffEngine.swift
+++ b/Sources/RepoPrompt/Infrastructure/VCS/GitDiff/GitDiffEngine.swift
@@ -93,6 +93,13 @@ actor GitDiffEngine {
         let normalizedPathspecs = pathspecs.map {
             GitDiffPathNormalization.gitPathspecs(from: $0, repoRootPath: repoURL.path)
         }
+        let discoveryPathspecs = pathspecs.map {
+            GitDiffPathNormalization.gitDiscoveryPathspecs(from: $0, repoRootPath: repoURL.path)
+        }
+        let hasUserAuthoredRelativePathspecs = pathspecs?.contains { rawPath in
+            let trimmed = rawPath.trimmingCharacters(in: .whitespacesAndNewlines)
+            return !(trimmed as NSString).expandingTildeInPath.hasPrefix("/")
+        } ?? false
         let scope: GitDiffScope = hasPathspecs ? .selected : .all
         let requestedPaths = hasPathspecs ? normalizedPathspecs : nil
 
@@ -111,11 +118,15 @@ actor GitDiffEngine {
             compare: normalizedCompare,
             includeUntrackedWhenApplicable: includeUntracked,
             detectRenames: detectRenames,
+            paths: hasPathspecs ? (discoveryPathspecs ?? []) : nil,
             at: repoURL
         )
 
-        // Filter by pathspecs if provided
-        let filtered: [VCSUncommittedFile] = if let normalizedPathspecs, !normalizedPathspecs.isEmpty {
+        // Keep backend-agnostic filtering as a defensive projection boundary.
+        let filtered: [VCSUncommittedFile] = if hasUserAuthoredRelativePathspecs {
+            // Git is authoritative for user-authored relative pathspec glob/magic semantics.
+            changedFiles
+        } else if let normalizedPathspecs, !normalizedPathspecs.isEmpty {
             filterByPathspecs(changedFiles, pathspecs: normalizedPathspecs)
         } else {
             changedFiles
@@ -128,7 +139,7 @@ actor GitDiffEngine {
         var diffText: String?
         var perFile: [String: String]?
         if generateDiffText, !filtered.isEmpty {
-            let pathFilter = normalizedPathspecs
+            let pathFilter = discoveryPathspecs
 
             // Get diff text via backend (handles normalization for jj)
             let trackedDiff = try await backend.getDiffText(
@@ -228,10 +239,16 @@ actor GitDiffEngine {
 
         let backend = await vcsService.backend(forRepoRoot: repoURL)
         let normalizedCompare = backend.normalizeCompareSpec(compare)
+        let discoveryPaths = scope == .selected
+            ? GitDiffPathNormalization.literalGitPathspecs(
+                gitRelativePaths(from: normalizedSelected, repoRootPath: repoURL.path)
+            )
+            : nil
         let changedFiles = try await backend.getChangedFilesStats(
             compare: normalizedCompare,
             includeUntrackedWhenApplicable: includeUntracked,
             detectRenames: detectRenames,
+            paths: discoveryPaths,
             at: repoURL
         )
         let filtered = filterChangedFiles(
@@ -248,7 +265,7 @@ actor GitDiffEngine {
         var diffText: String?
         var perFile: [String: String]?
         if generateDiffText {
-            let pathFilter = (scope == .selected) ? requestedPaths : nil
+            let pathFilter = (scope == .selected) ? discoveryPaths : nil
             if scope == .all || (pathFilter?.isEmpty == false) {
                 // Get diff text via backend (handles normalization for jj)
                 let trackedDiff = try await backend.getDiffText(
@@ -321,10 +338,16 @@ actor GitDiffEngine {
             }
 
             let compareSpec = GitDiffCompareSpec.uncommitted(base: normalizedBase)
+            let discoveryPaths = scope == .selected
+                ? GitDiffPathNormalization.literalGitPathspecs(
+                    gitRelativePaths(from: normalizedSelected, repoRootPath: repoURL.path)
+                )
+                : nil
             let changedFiles = try await backend.getChangedFilesStats(
                 compare: compareSpec,
                 includeUntrackedWhenApplicable: true,
                 detectRenames: false,
+                paths: discoveryPaths,
                 at: repoURL
             )
             let filtered = filterChangedFiles(
@@ -346,7 +369,7 @@ actor GitDiffEngine {
             let trackedDiff: String = if !tracked.isEmpty {
                 try await backend.getDiffText(
                     compare: compareSpec,
-                    paths: tracked,
+                    paths: GitDiffPathNormalization.literalGitPathspecs(tracked),
                     contextLines: 3,
                     detectRenames: false,
                     at: repoURL
@@ -389,10 +412,16 @@ actor GitDiffEngine {
             }
 
             let compareSpec = GitDiffCompareSpec.uncommittedMergeBase(base: normalizedBase)
+            let discoveryPaths = scope == .selected
+                ? GitDiffPathNormalization.literalGitPathspecs(
+                    gitRelativePaths(from: normalizedSelected, repoRootPath: repoURL.path)
+                )
+                : nil
             let changedFiles = try await backend.getChangedFilesStats(
                 compare: compareSpec,
                 includeUntrackedWhenApplicable: true,
                 detectRenames: false,
+                paths: discoveryPaths,
                 at: repoURL
             )
             let filtered = filterChangedFiles(
@@ -413,7 +442,7 @@ actor GitDiffEngine {
             let trackedDiff: String = if !tracked.isEmpty {
                 try await backend.getDiffText(
                     compare: compareSpec,
-                    paths: tracked,
+                    paths: GitDiffPathNormalization.literalGitPathspecs(tracked),
                     contextLines: 3,
                     detectRenames: false,
                     at: repoURL
@@ -516,7 +545,7 @@ actor GitDiffEngine {
             }
             diffText = try await backend.getDiffText(
                 compare: .revspec(ref),
-                paths: gitPaths,
+                paths: GitDiffPathNormalization.literalGitPathspecs(gitPaths),
                 contextLines: 3,
                 detectRenames: false,
                 at: repoURL

--- a/Sources/RepoPrompt/Infrastructure/VCS/GitDiff/GitDiffSnapshotPublisher.swift
+++ b/Sources/RepoPrompt/Infrastructure/VCS/GitDiff/GitDiffSnapshotPublisher.swift
@@ -26,17 +26,13 @@ actor GitDiffSnapshotPublisher {
         compareInput: String?,
         scope: GitDiffScope,
         selectedAbsolutePaths: [String],
+        pathspecs: [String]? = nil,
         contextLines: Int,
         detectRenames: Bool,
         snapshotIDOverride: String?,
         tabID: UUID? = nil
     ) async throws -> GitDiffSnapshotManifest {
         let normalizedSelected = normalizedAbsolutePaths(selectedAbsolutePaths)
-        let requestedPaths: [String]? = {
-            guard scope == .selected else { return nil }
-            let gitPaths = gitRelativePaths(from: normalizedSelected, repoRootPath: repo.rootPath)
-            return normalizeRequestedPaths(gitPaths)
-        }()
 
         return try await publishNewSnapshot(
             workspaceDirectory: workspaceDirectory,
@@ -46,8 +42,8 @@ actor GitDiffSnapshotPublisher {
             compareResolved: compareDisplay,
             compareInput: compareInput,
             scope: scope,
-            requestedPaths: requestedPaths,
             selectedAbsolutePaths: normalizedSelected,
+            pathspecs: pathspecs,
             contextLines: contextLines,
             detectRenames: detectRenames,
             snapshotIDOverride: snapshotIDOverride,
@@ -64,23 +60,34 @@ actor GitDiffSnapshotPublisher {
         compareResolved: String,
         compareInput: String?,
         scope: GitDiffScope,
-        requestedPaths: [String]?,
         selectedAbsolutePaths: [String],
+        pathspecs: [String]?,
         contextLines: Int,
         detectRenames: Bool,
         snapshotIDOverride: String?,
         tabID: UUID?
     ) async throws -> GitDiffSnapshotManifest {
-        let inputs = try await engine.buildSnapshotInputs(
-            compare: compare,
-            scope: scope,
-            selectedAbsolutePaths: selectedAbsolutePaths,
-            repoURL: repo.rootURL,
-            contextLines: contextLines,
-            detectRenames: detectRenames,
-            includeUntrackedInUnstaged: true,
-            generateDiffText: mode != .quick
-        )
+        let inputs: GitDiffEngine.GitDiffSnapshotBuildResult = if let pathspecs, !pathspecs.isEmpty {
+            try await engine.buildSnapshotInputs(
+                compare: compare,
+                pathspecs: pathspecs,
+                repoURL: repo.rootURL,
+                contextLines: contextLines,
+                detectRenames: detectRenames,
+                generateDiffText: mode != .quick
+            )
+        } else {
+            try await engine.buildSnapshotInputs(
+                compare: compare,
+                scope: scope,
+                selectedAbsolutePaths: selectedAbsolutePaths,
+                repoURL: repo.rootURL,
+                contextLines: contextLines,
+                detectRenames: detectRenames,
+                includeUntrackedInUnstaged: true,
+                generateDiffText: mode != .quick
+            )
+        }
 
         let snapshotID = resolveSnapshotID(
             override: snapshotIDOverride,
@@ -98,7 +105,7 @@ actor GitDiffSnapshotPublisher {
             mode: mode,
             compareRaw: compareResolved,
             compareInput: compareInput,
-            scope: scope,
+            scope: inputs.scope,
             requestedPaths: inputs.requestedPaths,
             fingerprint: inputs.fingerprint,
             contextLines: contextLines,
@@ -163,6 +170,7 @@ actor GitDiffSnapshotPublisher {
         compareInput: String?,
         scope: GitDiffScope,
         selectedAbsolutePaths: [String],
+        pathspecs: [String]? = nil,
         contextLines: Int,
         detectRenames: Bool,
         snapshotIDOverride: String?,
@@ -178,6 +186,7 @@ actor GitDiffSnapshotPublisher {
             compareInput: compareInput,
             scope: scope,
             selectedAbsolutePaths: selectedAbsolutePaths,
+            pathspecs: pathspecs,
             contextLines: contextLines,
             detectRenames: detectRenames,
             snapshotIDOverride: snapshotIDOverride,
@@ -187,20 +196,5 @@ actor GitDiffSnapshotPublisher {
 
     private func normalizedAbsolutePaths(_ paths: [String]) -> [String] {
         GitDiffPathNormalization.normalizedAbsolutePaths(paths)
-    }
-
-    private func gitRelativePaths(from absolutePaths: [String], repoRootPath: String) -> [String] {
-        GitDiffPathNormalization.gitRelativePaths(from: absolutePaths, repoRootPath: repoRootPath)
-    }
-
-    private func normalizeRequestedPaths(_ paths: [String]?) -> [String]? {
-        guard let paths else { return nil }
-        let cleaned = Set(
-            paths
-                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-                .filter { !$0.isEmpty }
-        )
-        guard !cleaned.isEmpty else { return nil }
-        return cleaned.sorted()
     }
 }

--- a/Sources/RepoPrompt/Infrastructure/VCS/GitService.swift
+++ b/Sources/RepoPrompt/Infrastructure/VCS/GitService.swift
@@ -3226,6 +3226,7 @@ actor GitService {
     func getDiffNumstat(
         compare: GitDiffCompareSpec,
         detectRenames: Bool = false,
+        paths: [String]? = nil,
         at repoURL: URL
     ) async throws -> String {
         let (argsPrefix, refArg) = diffArgs(for: compare, kind: .numstat)
@@ -3234,7 +3235,7 @@ actor GitService {
             contextLines: nil,
             detectRenames: detectRenames,
             refArg: refArg,
-            paths: nil,
+            paths: paths,
             at: repoURL
         )
     }
@@ -3242,6 +3243,7 @@ actor GitService {
     func getDiffNameStatus(
         compare: GitDiffCompareSpec,
         detectRenames: Bool = false,
+        paths: [String]? = nil,
         at repoURL: URL
     ) async throws -> String {
         let (argsPrefix, refArg) = diffArgs(for: compare, kind: .nameStatus)
@@ -3250,7 +3252,7 @@ actor GitService {
             contextLines: nil,
             detectRenames: detectRenames,
             refArg: refArg,
-            paths: nil,
+            paths: paths,
             at: repoURL
         )
     }
@@ -3259,8 +3261,10 @@ actor GitService {
         compare: GitDiffCompareSpec,
         includeUntrackedWhenApplicable: Bool,
         detectRenames: Bool = false,
+        paths: [String]? = nil,
         at repoURL: URL
     ) async throws -> [UncommittedFile] {
+        if let paths, paths.isEmpty { return [] }
         let includeUntracked = includeUntrackedWhenApplicable && {
             switch compare {
             case .uncommitted, .uncommittedMergeBase, .unstaged:
@@ -3270,9 +3274,9 @@ actor GitService {
             }
         }()
 
-        async let numOutTask = getDiffNumstat(compare: compare, detectRenames: detectRenames, at: repoURL)
-        async let nameOutTask = getDiffNameStatus(compare: compare, detectRenames: detectRenames, at: repoURL)
-        async let untrackedFilesTask = includeUntracked ? getUntrackedPaths(at: repoURL) : []
+        async let numOutTask = getDiffNumstat(compare: compare, detectRenames: detectRenames, paths: paths, at: repoURL)
+        async let nameOutTask = getDiffNameStatus(compare: compare, detectRenames: detectRenames, paths: paths, at: repoURL)
+        async let untrackedFilesTask = includeUntracked ? getUntrackedPaths(paths: paths, at: repoURL) : []
         let (numOut, nameOut, untrackedFiles) = try await (numOutTask, nameOutTask, untrackedFilesTask)
         let (statsMap, statusMap) = MCPToolWorkCountDiagnostics.measureGitParse {
             (parseNumstatOutput(numOut), parseNameStatusOutput(nameOut))
@@ -3323,9 +3327,15 @@ actor GitService {
         }.map(\.file)
     }
 
-    private func getUntrackedPaths(at repoURL: URL) async throws -> [String] {
+    private func getUntrackedPaths(paths: [String]?, at repoURL: URL) async throws -> [String] {
+        if let paths, paths.isEmpty { return [] }
+        var args = ["ls-files", "--others", "--exclude-standard"]
+        if let paths {
+            args.append("--")
+            args.append(contentsOf: paths)
+        }
         let (stdout, stderr, exitCode) = try await runGit(
-            ["ls-files", "--others", "--exclude-standard"],
+            args,
             at: repoURL
         )
         guard exitCode == 0 else {

--- a/Sources/RepoPrompt/Infrastructure/VCS/JujutsuBackend.swift
+++ b/Sources/RepoPrompt/Infrastructure/VCS/JujutsuBackend.swift
@@ -286,19 +286,21 @@ public actor JujutsuBackend: VCSBackendWithWarnings {
         compare: GitDiffCompareSpec,
         includeUntrackedWhenApplicable: Bool,
         detectRenames: Bool,
+        paths: [String]?,
         at repoURL: URL
     ) async throws -> [VCSUncommittedFile] {
+        if let paths, paths.isEmpty { return [] }
         // jj has no untracked concept; ignore includeUntrackedWhenApplicable.
         // jj rename detection differs; ignore detectRenames.
         let normalized = normalizeCompareSpecWithWarning(compare).spec
         let refs = try resolveDiffRefs(for: normalized, repoURL: repoURL)
 
         // 1) Summary for statuses (M/A/D/R/C etc)
-        let summaryText = try await jjDiffSummary(from: refs.from, to: refs.to, repoURL: repoURL, paths: nil)
+        let summaryText = try await jjDiffSummary(from: refs.from, to: refs.to, repoURL: repoURL, paths: paths)
         var entries = parseJjDiffSummary(summaryText)
 
         // 2) Stat for insertions/deletions (best-effort parse)
-        let statText = try await jjDiffStat(from: refs.from, to: refs.to, repoURL: repoURL, paths: nil)
+        let statText = try await jjDiffStat(from: refs.from, to: refs.to, repoURL: repoURL, paths: paths)
         let statMap = parseJjDiffStat(statText)
 
         // Merge
@@ -316,7 +318,7 @@ public actor JujutsuBackend: VCSBackendWithWarnings {
 
         // If stat parsing failed entirely, fall back to scanning a git-format diff for accurate counts.
         if !entries.isEmpty, statMap.isEmpty {
-            let diffText = try await jjDiffGit(from: refs.from, to: refs.to, repoURL: repoURL, contextLines: 0, paths: nil)
+            let diffText = try await jjDiffGit(from: refs.from, to: refs.to, repoURL: repoURL, contextLines: 0, paths: paths)
             let counts = computeAddDelByFileFromUnifiedDiff(diffText)
             for i in entries.indices {
                 let path = entries[i].path

--- a/Sources/RepoPrompt/Infrastructure/VCS/VCSBackend.swift
+++ b/Sources/RepoPrompt/Infrastructure/VCS/VCSBackend.swift
@@ -114,12 +114,14 @@ public protocol VCSBackend: Sendable {
     ///   - compare: The compare specification.
     ///   - includeUntrackedWhenApplicable: Whether to include untracked files.
     ///   - detectRenames: Whether to detect renames.
+    ///   - paths: Optional repository-relative paths used to scope changed-file discovery.
     ///   - repoURL: The repository root URL.
     /// - Returns: Array of changed files with stats.
     func getChangedFilesStats(
         compare: GitDiffCompareSpec,
         includeUntrackedWhenApplicable: Bool,
         detectRenames: Bool,
+        paths: [String]?,
         at repoURL: URL
     ) async throws -> [VCSUncommittedFile]
 
@@ -211,6 +213,22 @@ public protocol VCSBackend: Sendable {
 // MARK: - Default Implementations
 
 public extension VCSBackend {
+    /// Compatibility overload for whole-repository changed-file discovery.
+    func getChangedFilesStats(
+        compare: GitDiffCompareSpec,
+        includeUntrackedWhenApplicable: Bool,
+        detectRenames: Bool,
+        at repoURL: URL
+    ) async throws -> [VCSUncommittedFile] {
+        try await getChangedFilesStats(
+            compare: compare,
+            includeUntrackedWhenApplicable: includeUntrackedWhenApplicable,
+            detectRenames: detectRenames,
+            paths: nil,
+            at: repoURL
+        )
+    }
+
     /// Default implementation checks if findRepoRoot returns non-nil.
     func isRepository(at url: URL) async -> Bool {
         do {

--- a/Sources/RepoPrompt/Infrastructure/VCS/VCSService.swift
+++ b/Sources/RepoPrompt/Infrastructure/VCS/VCSService.swift
@@ -352,6 +352,7 @@ public extension VCSService {
         compare: GitDiffCompareSpec,
         includeUntrackedWhenApplicable: Bool = true,
         detectRenames: Bool = false,
+        paths: [String]? = nil,
         at repoURL: URL
     ) async throws -> [VCSUncommittedFile] {
         let backend = await backend(forRepoRoot: repoURL)
@@ -359,6 +360,7 @@ public extension VCSService {
             compare: compare,
             includeUntrackedWhenApplicable: includeUntrackedWhenApplicable,
             detectRenames: detectRenames,
+            paths: paths,
             at: repoURL
         )
     }

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspacePublishedGitArtifactIngress.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspacePublishedGitArtifactIngress.swift
@@ -26,46 +26,113 @@ struct WorkspacePublishedGitArtifactIngressOutcome: Equatable {
     let status: WorkspacePublishedGitArtifactIngressOutcomeStatus
 }
 
+struct WorkspacePublishedGitArtifactReadinessFailure: Equatable {
+    let artifact: GitDiffPublishedArtifact
+    let status: WorkspacePublishedGitArtifactIngressOutcomeStatus
+}
+
+struct WorkspacePublishedGitArtifactReadinessAggregation: Equatable {
+    let selectionReadyArtifacts: [GitDiffPublishedArtifact]
+    let advertisementReadyArtifacts: [GitDiffPublishedArtifact]
+    let selectionReadySnapshotDirectories: Set<String>
+    let failuresBySnapshotDirectory: [String: [WorkspacePublishedGitArtifactReadinessFailure]]
+}
+
 struct WorkspacePublishedGitArtifactIngressResult: Equatable {
     let outcomes: [WorkspacePublishedGitArtifactIngressOutcome]
+    let recordsByAbsolutePath: [String: WorkspaceFileRecord]
+    let failuresByArtifact: [GitDiffPublishedArtifact: WorkspacePublishedGitArtifactIngressOutcomeStatus]
 
-    var recordsByAbsolutePath: [String: WorkspaceFileRecord] {
-        Dictionary(uniqueKeysWithValues: outcomes.compactMap { outcome in
-            outcome.status.record.map { (outcome.artifact.absolutePath, $0) }
-        })
-    }
+    init(outcomes: [WorkspacePublishedGitArtifactIngressOutcome]) {
+        self.outcomes = outcomes
 
-    var failuresByArtifact: [GitDiffPublishedArtifact: WorkspacePublishedGitArtifactIngressOutcomeStatus] {
-        let catalogedArtifacts = Set(outcomes.compactMap { outcome in
-            outcome.status.record == nil ? nil : outcome.artifact
-        })
+        var records: [String: WorkspaceFileRecord] = [:]
+        var catalogedArtifacts = Set<GitDiffPublishedArtifact>()
         var failures: [GitDiffPublishedArtifact: WorkspacePublishedGitArtifactIngressOutcomeStatus] = [:]
-        for outcome in outcomes where outcome.status.record == nil {
-            guard !catalogedArtifacts.contains(outcome.artifact) else { continue }
-            if failures[outcome.artifact] == nil {
+        records.reserveCapacity(outcomes.count)
+        failures.reserveCapacity(outcomes.count)
+
+        for outcome in outcomes {
+            if let record = outcome.status.record {
+                records[outcome.artifact.absolutePath] = record
+                catalogedArtifacts.insert(outcome.artifact)
+                failures.removeValue(forKey: outcome.artifact)
+            } else if !catalogedArtifacts.contains(outcome.artifact), failures[outcome.artifact] == nil {
                 failures[outcome.artifact] = outcome.status
             }
         }
-        return failures
+
+        recordsByAbsolutePath = records
+        failuresByArtifact = failures
     }
 
     func selectionReadyArtifacts(
         for publishedArtifacts: GitDiffPublishedArtifactSet
     ) -> [GitDiffPublishedArtifact] {
-        let records = recordsByAbsolutePath
-        guard records[publishedArtifacts.manifest.absolutePath] != nil else { return [] }
+        guard recordsByAbsolutePath[publishedArtifacts.manifest.absolutePath] != nil else { return [] }
         return publishedArtifacts.primarySelectionArtifacts.filter {
-            records[$0.absolutePath] != nil
+            recordsByAbsolutePath[$0.absolutePath] != nil
         }
     }
 
     func advertisementReadyArtifacts(
         for publishedArtifacts: GitDiffPublishedArtifactSet
     ) -> [GitDiffPublishedArtifact] {
-        let records = recordsByAbsolutePath
-        guard records[publishedArtifacts.manifest.absolutePath] != nil else { return [] }
+        guard recordsByAbsolutePath[publishedArtifacts.manifest.absolutePath] != nil else { return [] }
         return publishedArtifacts.advertisedSelectionArtifacts.filter {
-            records[$0.absolutePath] != nil
+            recordsByAbsolutePath[$0.absolutePath] != nil
         }
+    }
+
+    /// Builds all publication readiness projections in published artifact order.
+    /// The ingress indexes above are constructed once, so this is O(A) after the O(N) ingress pass.
+    func aggregateReadiness(
+        for publishedSets: [GitDiffPublishedArtifactSet]
+    ) async throws -> WorkspacePublishedGitArtifactReadinessAggregation {
+        try Task.checkCancellation()
+
+        var selectionReady: [GitDiffPublishedArtifact] = []
+        var advertisementReady: [GitDiffPublishedArtifact] = []
+        var selectionReadySnapshotDirectories = Set<String>()
+        var failuresBySnapshotDirectory: [String: [WorkspacePublishedGitArtifactReadinessFailure]] = [:]
+        var processedArtifactCount = 0
+
+        for published in publishedSets {
+            let snapshotDirectory = published.snapshotRef.snapshotDirRel
+            let manifestIsReady = recordsByAbsolutePath[published.manifest.absolutePath] != nil
+            if manifestIsReady {
+                let readyPrimary = published.primarySelectionArtifacts.filter {
+                    recordsByAbsolutePath[$0.absolutePath] != nil
+                }
+                if !readyPrimary.isEmpty {
+                    selectionReadySnapshotDirectories.insert(snapshotDirectory)
+                    selectionReady.append(contentsOf: readyPrimary)
+                }
+                advertisementReady.append(contentsOf: published.advertisedSelectionArtifacts.filter {
+                    recordsByAbsolutePath[$0.absolutePath] != nil
+                })
+            }
+
+            for artifact in published.orderedArtifacts {
+                if let status = failuresByArtifact[artifact] {
+                    failuresBySnapshotDirectory[snapshotDirectory, default: []].append(
+                        WorkspacePublishedGitArtifactReadinessFailure(artifact: artifact, status: status)
+                    )
+                }
+                processedArtifactCount += 1
+                if processedArtifactCount.isMultiple(of: 256) {
+                    try Task.checkCancellation()
+                    await Task.yield()
+                }
+            }
+        }
+
+        try Task.checkCancellation()
+        return WorkspacePublishedGitArtifactReadinessAggregation(
+            selectionReadyArtifacts: selectionReady,
+            advertisementReadyArtifacts: advertisementReady,
+            selectionReadySnapshotDirectories: selectionReadySnapshotDirectories,
+            failuresBySnapshotDirectory: failuresBySnapshotDirectory
+        )
     }
 }

--- a/Tests/RepoPromptTests/MCP/MCPGitPrimaryArtifactPublicationTests.swift
+++ b/Tests/RepoPromptTests/MCP/MCPGitPrimaryArtifactPublicationTests.swift
@@ -534,15 +534,23 @@ final class MCPGitPrimaryArtifactPublicationTests: XCTestCase {
             )
         )
 
+        let readiness = try await ingress.aggregateReadiness(for: [firstSet, secondSet])
+        let readyCandidates = firstSet.primarySelectionArtifacts + [secondSet.map]
+        XCTAssertEqual(readiness.selectionReadyArtifacts, readyCandidates)
         XCTAssertEqual(
-            ingress.selectionReadyArtifacts(for: firstSet),
-            firstSet.primarySelectionArtifacts
+            readiness.advertisementReadyArtifacts,
+            firstSet.advertisedSelectionArtifacts + [secondSet.map] + secondSet.perFilePatches
         )
-        XCTAssertEqual(ingress.selectionReadyArtifacts(for: secondSet), [secondSet.map])
+        XCTAssertEqual(
+            readiness.selectionReadySnapshotDirectories,
+            Set([firstSet.snapshotRef.snapshotDirRel, secondSet.snapshotRef.snapshotDirRel])
+        )
+        XCTAssertEqual(
+            readiness.failuresBySnapshotDirectory[secondSet.snapshotRef.snapshotDirRel],
+            [WorkspacePublishedGitArtifactReadinessFailure(artifact: missingPatch, status: .missingOnDisk)]
+        )
+        XCTAssertNil(readiness.failuresBySnapshotDirectory[firstSet.snapshotRef.snapshotDirRel])
         XCTAssertEqual(ingress.failuresByArtifact[missingPatch], .missingOnDisk)
-
-        let readyCandidates = ingress.selectionReadyArtifacts(for: firstSet)
-            + ingress.selectionReadyArtifacts(for: secondSet)
         let concurrentSource = secondRepo.appendingPathComponent("Sources/Concurrent.swift").path
         let existing = StoredSelection(
             selectedPaths: [concurrentSource],

--- a/Tests/RepoPromptTests/Services/VCS/GitCommandWorkCountDiagnosticsTests.swift
+++ b/Tests/RepoPromptTests/Services/VCS/GitCommandWorkCountDiagnosticsTests.swift
@@ -86,6 +86,68 @@ import XCTest
             }
         }
 
+        func testExplicitArtifactPathScopesDiscoveryAmidManyUnrelatedUntrackedFiles() async throws {
+            let fixture = try GitWorkCountFixture()
+            defer { fixture.cleanup() }
+            for index in 0 ..< 128 {
+                try fixture.writeUntracked("Noise/File-\(index).txt", contents: "noise \(index)\n")
+            }
+
+            let vcs = VCSService()
+            let store = GitDiffSnapshotStore()
+            let publisher = GitDiffSnapshotPublisher(
+                engine: GitDiffEngine(vcsService: vcs, gitService: GitService()),
+                store: store,
+                vcsService: vcs
+            )
+            let repo = GitRepoDescriptor(rootURL: fixture.repo)
+            let requestedAbsolutePath = fixture.repo.appendingPathComponent("Untracked.txt").path
+            let snapshotID = "path-scoped-\(UUID().uuidString)"
+
+            let (manifest, snapshot) = try await captureResult(operation: "artifact_path_scoped") {
+                try await publisher.publish(
+                    workspaceDirectory: fixture.workspace,
+                    repo: repo,
+                    mode: .standard,
+                    compareSpec: .uncommitted(base: "HEAD"),
+                    compareDisplay: "uncommitted:HEAD",
+                    compareInput: nil,
+                    scope: .all,
+                    selectedAbsolutePaths: [],
+                    pathspecs: [requestedAbsolutePath],
+                    contextLines: 3,
+                    detectRenames: false,
+                    snapshotIDOverride: snapshotID,
+                    tabID: nil
+                )
+            }
+
+            XCTAssertEqual(manifest.scope, .selected)
+            XCTAssertEqual(manifest.requestedPaths, ["Untracked.txt"])
+            XCTAssertEqual(manifest.files.map(\.gitPath), ["Untracked.txt"])
+            XCTAssertEqual(manifest.summary.files, 1)
+
+            let discoveryCommands = zip(snapshot.commands, snapshot.inlinePathspecCounts).filter { command, _ in
+                command.hasPrefix("diff --numstat")
+                    || command.hasPrefix("diff --name-status")
+                    || command.hasPrefix("ls-files --others")
+            }
+            XCTAssertEqual(discoveryCommands.count, 3, snapshot.commands.joined(separator: "\n"))
+            XCTAssertTrue(discoveryCommands.allSatisfy { _, pathspecCount in pathspecCount == 1 })
+
+            let snapshotDirectory = store.snapshotDir(
+                workspaceDirectory: fixture.workspace,
+                repoKey: repo.repoKey,
+                snapshotID: snapshotID
+            )
+            let allPatch = try String(
+                contentsOf: snapshotDirectory.appendingPathComponent("diff/all.patch"),
+                encoding: .utf8
+            )
+            XCTAssertTrue(allPatch.contains("Untracked.txt"), allPatch)
+            XCTAssertFalse(allPatch.contains("Noise/"), allPatch)
+        }
+
         func testBatchedUntrackedDiffPreservesRepositoryRelativePatchPaths() async throws {
             let fixture = try GitWorkCountFixture()
             defer { fixture.cleanup() }
@@ -131,9 +193,17 @@ import XCTest
             operation: String,
             body: () async throws -> Void
         ) async throws -> MCPToolWorkCountDiagnostics.GitInvocationSnapshot {
+            let (_, snapshot) = try await captureResult(operation: operation, body: body)
+            return snapshot
+        }
+
+        private func captureResult<T>(
+            operation: String,
+            body: () async throws -> T
+        ) async throws -> (T, MCPToolWorkCountDiagnostics.GitInvocationSnapshot) {
             MCPToolWorkCountDiagnostics.resetForTesting()
-            try await MCPToolWorkCountDiagnostics.withGitInvocation(operation: operation, body)
-            return try XCTUnwrap(MCPToolWorkCountDiagnostics.debugSnapshots().git.last)
+            let result = try await MCPToolWorkCountDiagnostics.withGitInvocation(operation: operation, body)
+            return try (result, XCTUnwrap(MCPToolWorkCountDiagnostics.debugSnapshots().git.last))
         }
     }
 

--- a/Tests/RepoPromptTests/Services/VCS/GitDiffEngineWorktreePathFilterTests.swift
+++ b/Tests/RepoPromptTests/Services/VCS/GitDiffEngineWorktreePathFilterTests.swift
@@ -3,6 +3,61 @@ import Foundation
 import XCTest
 
 final class GitDiffEngineWorktreePathFilterTests: XCTestCase {
+    func testAbsolutePathOutsideLinkedWorktreeReturnsEmptyWithoutWholeCheckoutFallback() async throws {
+        let fixture = try LinkedWorktreeDiffFixture()
+        defer { fixture.cleanup() }
+        let engine = GitDiffEngine(vcsService: VCSService(), gitService: GitService())
+        let outsidePath = fixture.repo.appendingPathComponent(fixture.relativePath).path
+
+        let filtered = try await engine.buildSnapshotInputs(
+            compare: .uncommitted(base: "HEAD"),
+            pathspecs: [outsidePath],
+            repoURL: fixture.worktree,
+            contextLines: 3,
+            detectRenames: false,
+            generateDiffText: true
+        )
+
+        XCTAssertEqual(filtered.scope, .selected)
+        XCTAssertEqual(filtered.requestedPaths, [])
+        XCTAssertTrue(filtered.changedFiles.isEmpty)
+        XCTAssertEqual(filtered.summary.files, 0)
+        XCTAssertNil(filtered.diffText)
+    }
+
+    func testAbsoluteMetacharacterPathIsLiteralWhileRelativePathspecKeepsGitGlobSemantics() async throws {
+        let fixture = try LinkedWorktreeDiffFixture()
+        defer { fixture.cleanup() }
+        let literalPath = "pages/[slug].tsx"
+        let globMatchPath = "pages/s.tsx"
+        try fixture.writeUntracked(literalPath, contents: "literal route\n")
+        try fixture.writeUntracked(globMatchPath, contents: "glob route\n")
+        let engine = GitDiffEngine(vcsService: VCSService(), gitService: GitService())
+
+        let absoluteFiltered = try await engine.buildSnapshotInputs(
+            compare: .uncommitted(base: "HEAD"),
+            pathspecs: [fixture.worktree.appendingPathComponent(literalPath).path],
+            repoURL: fixture.worktree,
+            contextLines: 3,
+            detectRenames: false,
+            generateDiffText: true
+        )
+        XCTAssertEqual(absoluteFiltered.requestedPaths, [literalPath])
+        XCTAssertEqual(absoluteFiltered.changedFiles.map(\.path), [literalPath])
+        XCTAssertTrue(absoluteFiltered.diffText?.contains(literalPath) == true)
+        XCTAssertFalse(absoluteFiltered.diffText?.contains(globMatchPath) == true)
+
+        let relativeGlobFiltered = try await engine.buildSnapshotInputs(
+            compare: .uncommitted(base: "HEAD"),
+            pathspecs: [literalPath],
+            repoURL: fixture.worktree,
+            contextLines: 3,
+            detectRenames: false,
+            generateDiffText: false
+        )
+        XCTAssertEqual(relativeGlobFiltered.changedFiles.map(\.path), [literalPath, globMatchPath])
+    }
+
     func testAbsolutePathFilterInLinkedWorktreeMatchesUnfilteredDiff() async throws {
         let fixture = try LinkedWorktreeDiffFixture()
         defer { fixture.cleanup() }
@@ -68,6 +123,12 @@ private struct LinkedWorktreeDiffFixture {
 
     func cleanup() {
         try? FileManager.default.removeItem(at: sandbox)
+    }
+
+    func writeUntracked(_ relativePath: String, contents: String) throws {
+        let url = worktree.appendingPathComponent(relativePath)
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try contents.write(to: url, atomically: true, encoding: .utf8)
     }
 
     private func runGit(_ arguments: [String], cwd: URL) throws {


### PR DESCRIPTION
## Summary

- preserve explicit `path` / `paths` semantics for published Git artifacts instead of falling back to whole-checkout publication
- push pathspecs into tracked and untracked discovery so unrelated files are not enumerated or read before filtering
- literalize app-derived paths while preserving user-authored relative Git pathspec/glob semantics
- replace quadratic main-actor artifact readiness lookups with indexed O(N+A) aggregation, cancellation/yield points, and bounded warnings
- add regressions for one requested untracked file amid 128 unrelated files, linked-worktree paths, metacharacter filenames, and partial readiness aggregation

## Root cause

Artifact-mode Git diff parsed explicit paths but did not pass them to `GitDiffSnapshotPublisher`; the default `.all` scope therefore captured the complete untracked checkout. After publication, `preparePublishedArtifacts` queried a computed `failuresByArtifact` index once per artifact on the main actor, producing O(n²) work for large snapshots.

This change aligns artifact and ordinary-diff path semantics and scopes discovery before patch/index construction.

## Validation

Passed locally through the coordinated developer daemon:

- `make dev-format`
- `make dev-test FILTER=GitDiffEngineWorktreePathFilterTests` — 3 passed
- `make dev-test FILTER=GitCommandWorkCountDiagnosticsTests` — 6 passed
- `make dev-test FILTER=WorkspacePublishedGitArtifactIngressTests` — 4 passed
- `make dev-test FILTER=MCPGitPrimaryArtifactPublicationTests` — 4 passed
- `make dev-lint`
- `make dev-swift-build PRODUCT=RepoPrompt`
- contribution preflight `commit` and `push` safety gates

The full `pr-ready` root test lane ran but failed in unrelated CodeMap concurrency/timing tests, including `CodeMapArtifactBuildCoordinatorTests`, `CodemapAutomaticSelectionGraphNativeTests`, and `CodemapBindingEngineManifestWriteTests`. None of the failing files are modified by this PR; focused owning-boundary suites passed. Hosted checks should provide the clean-base signal.

Two independent Fable 5 High reviews found no remaining blocker. The first identified literal filenames such as `pages/[slug].tsx` as a Git-pathspec regression risk; that finding was fixed and regression-tested before commit.

## Follow-ups

This PR fixes the reported path-scoped trigger and quadratic readiness aggregation, but deliberately does not add a new artifact-budget contract. `scope: "all"` remains capable of producing very large artifacts.

High-priority follow-up work should add:

- conservative file-count and byte budgets with structured preflight errors
- cancellation checks and partial-snapshot cleanup during mirror copying and snapshot writes
- progress reporting and cache cleanup/retention controls
- optional pathspec-file support for very large explicit selections
