### PR TITLE
Add a Codex project hook approval flow to Agent Mode

### DIFF
--- a/Scripts/Fixtures/codex-app-server-contract.json
+++ b/Scripts/Fixtures/codex-app-server-contract.json
@@ -133,6 +133,118 @@
     },
     {
       "union": "ClientRequest.json",
+      "method": "hooks/list",
+      "alwaysSent": [
+        "cwds"
+      ],
+      "responseSchema": "v2/HooksListResponse.json",
+      "consumedResponse": [
+        {
+          "path": "data",
+          "presence": "required",
+          "nullable": false
+        },
+        {
+          "path": "data[].cwd",
+          "presence": "required",
+          "nullable": false
+        },
+        {
+          "path": "data[].errors",
+          "presence": "required",
+          "nullable": false
+        },
+        {
+          "path": "data[].warnings",
+          "presence": "required",
+          "nullable": false
+        },
+        {
+          "path": "data[].hooks",
+          "presence": "required",
+          "nullable": false
+        },
+        {
+          "path": "data[].hooks[].key",
+          "presence": "required",
+          "nullable": false
+        },
+        {
+          "path": "data[].hooks[].currentHash",
+          "presence": "required",
+          "nullable": false
+        },
+        {
+          "path": "data[].hooks[].enabled",
+          "presence": "required",
+          "nullable": false
+        },
+        {
+          "path": "data[].hooks[].eventName",
+          "presence": "required",
+          "nullable": false
+        },
+        {
+          "path": "data[].hooks[].handlerType",
+          "presence": "required",
+          "nullable": false
+        },
+        {
+          "path": "data[].hooks[].command",
+          "presence": "optional",
+          "nullable": true
+        },
+        {
+          "path": "data[].hooks[].sourcePath",
+          "presence": "required",
+          "nullable": false
+        },
+        {
+          "path": "data[].hooks[].source",
+          "presence": "required",
+          "nullable": false
+        },
+        {
+          "path": "data[].hooks[].trustStatus",
+          "presence": "required",
+          "nullable": false
+        }
+      ],
+      "consumedEnumValues": {
+        "data[].hooks[].trustStatus": [
+          "managed",
+          "untrusted",
+          "trusted",
+          "modified"
+        ]
+      }
+    },
+    {
+      "union": "ClientRequest.json",
+      "method": "config/batchWrite",
+      "alwaysSent": [
+        "edits",
+        "edits[].keyPath",
+        "edits[].value",
+        "edits[].mergeStrategy",
+        "reloadUserConfig"
+      ],
+      "enumValues": {
+        "edits[].mergeStrategy": [
+          "upsert"
+        ]
+      },
+      "responseSchema": "v2/ConfigWriteResponse.json",
+      "consumedResponse": [
+        {
+          "path": "status",
+          "presence": "required",
+          "nullable": false
+        }
+      ]
+    },
+    {
+      "union": "ClientRequest.json",
       "method": "skills/extraRoots/set",
       "alwaysSent": [
         "extraRoots"

--- a/Scripts/test_codex_app_server_schema.py
+++ b/Scripts/test_codex_app_server_schema.py
@@ -88,6 +88,8 @@ class CodexAppServerSchemaGateTests(unittest.TestCase):
             ("ClientRequest.json", "account/login/start"),
             ("ClientRequest.json", "account/login/cancel"),
             ("ClientRequest.json", "model/list"),
+            ("ClientRequest.json", "hooks/list"),
+            ("ClientRequest.json", "config/batchWrite"),
             ("ClientRequest.json", "skills/extraRoots/set"),
             ("ClientRequest.json", "thread/start"),
             ("ClientRequest.json", "thread/resume"),
@@ -129,7 +131,7 @@ class CodexAppServerSchemaGateTests(unittest.TestCase):
             ("ServerRequest.json", "item/fileChange/requestApproval"),
         }
 
-        self.assertEqual(len(checks), 43)
+        self.assertEqual(len(checks), 45)
         self.assertEqual({(check["union"], check["method"]) for check in checks}, expected)
 
     def test_bundle_validation_accepts_declared_fields_nested_paths_and_enum(self) -> None:

--- a/Sources/RepoPrompt/Features/AgentMode/Models/CodexHookApprovalModels.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Models/CodexHookApprovalModels.swift
@@ -33,8 +33,20 @@ struct AgentCodexHookReviewRequest: Identifiable, Hashable {
         case writeFailed
         case verificationFailed
 
-        var allowsApprovalDecision: Bool {
+        var allowsTrustDecision: Bool {
             self == .reviewRequired || self == .writeFailed || self == .verificationFailed
+        }
+
+        var allowsContinueWithoutHooks: Bool {
+            allowsTrustDecision || self == .discoveryFailed
+        }
+
+        var allowsDiscoveryRetry: Bool {
+            self == .discoveryFailed
+        }
+
+        var isResolving: Bool {
+            self == .discovering || self == .submitting
         }
     }
 
@@ -127,7 +139,7 @@ struct AgentCodexHookGateAudit: Equatable {
 
     let status: Status
     let approvedCount: Int
-    let skippedCount: Int
+    let skippedCount: Int?
     let resolvedAt: Date
     let interactionID: UUID
 }

--- a/Sources/RepoPrompt/Features/AgentMode/Models/CodexHookApprovalModels.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Models/CodexHookApprovalModels.swift
@@ -168,7 +168,7 @@ enum AgentCodexHookReviewResolutionError: Error, LocalizedError, Equatable {
         case .staleController:
             "The Codex controller binding changed. Start the turn again to review the current project hooks."
         case .strictModeRequiresApproval:
-            "Continue Without Hooks is disabled by the Codex hook approval strict mode setting. Approve the project hooks to continue."
+            "Codex hook approval strict mode requires approving every project hook in the current review before continuing."
         }
     }
 }

--- a/Sources/RepoPrompt/Features/AgentMode/Models/CodexHookApprovalModels.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Models/CodexHookApprovalModels.swift
@@ -1,0 +1,162 @@
+import Foundation
+
+struct AgentCodexHookReviewHook: Hashable {
+    let key: String
+    let eventName: String
+    let sourcePath: String
+    let currentHash: String
+    let enabled: Bool
+    let trustStatus: CodexHookTrustStatus
+    let commandOrHandler: String?
+
+    init(metadata: CodexHookMetadata) {
+        key = metadata.key
+        eventName = metadata.eventName
+        sourcePath = metadata.sourcePath
+        currentHash = metadata.currentHash
+        enabled = metadata.enabled
+        trustStatus = metadata.trustStatus
+        commandOrHandler = metadata.commandOrHandler
+    }
+
+    var trustCandidate: CodexHookTrustCandidate {
+        CodexHookTrustCandidate(key: key, currentHash: currentHash)
+    }
+}
+
+struct AgentCodexHookReviewRequest: Identifiable, Hashable {
+    enum Phase: String, Hashable {
+        case reviewRequired
+        case discovering
+        case submitting
+        case discoveryFailed
+        case writeFailed
+        case verificationFailed
+
+        var allowsApprovalDecision: Bool {
+            self == .reviewRequired || self == .writeFailed || self == .verificationFailed
+        }
+    }
+
+    let id: UUID
+    let executionCWD: String
+    let hooks: [AgentCodexHookReviewHook]
+    let warnings: [String]
+    var phase: Phase
+    var errorMessage: String?
+    let detectedAt: Date
+    let gateGeneration: UInt64
+
+    init(
+        tabID: UUID,
+        runAttemptID: UUID?,
+        runID: UUID?,
+        executionCWD: String,
+        hooks: [AgentCodexHookReviewHook],
+        warnings: [String] = [],
+        phase: Phase,
+        errorMessage: String? = nil,
+        detectedAt: Date = Date(),
+        gateGeneration: UInt64
+    ) {
+        let trimmedCWD = executionCWD.trimmingCharacters(in: .whitespacesAndNewlines)
+        let standardizedCWD = trimmedCWD.hasPrefix("/")
+            ? URL(fileURLWithPath: trimmedCWD).standardizedFileURL.path
+            : "<execution-cwd-unavailable>"
+        let sortedHooks = hooks.sorted { lhs, rhs in
+            let lhsKey = CodexHookUTF8Identity(lhs.key)
+            let rhsKey = CodexHookUTF8Identity(rhs.key)
+            if lhsKey == rhsKey {
+                return CodexHookUTF8Identity(lhs.currentHash).lexicographicallyPrecedes(
+                    CodexHookUTF8Identity(rhs.currentHash)
+                )
+            }
+            return lhsKey.lexicographicallyPrecedes(rhsKey)
+        }
+        let attemptSeed = runAttemptID?.uuidString
+            ?? runID?.uuidString
+            ?? "gate-generation-\(gateGeneration)"
+        var identityComponents = [
+            Self.lengthPrefixed("codex-hook-review"),
+            Self.lengthPrefixed(tabID.uuidString),
+            Self.lengthPrefixed(attemptSeed),
+            Self.lengthPrefixed(standardizedCWD)
+        ]
+        if sortedHooks.isEmpty {
+            identityComponents.append(Self.lengthPrefixed("discovery-failure"))
+        } else {
+            for hook in sortedHooks {
+                identityComponents.append(Self.lengthPrefixed(hook.key))
+                identityComponents.append(Self.lengthPrefixed(hook.currentHash))
+            }
+        }
+
+        id = StableUserInteractionIdentity.uuid(from: identityComponents.joined(separator: "|"))
+        self.executionCWD = standardizedCWD
+        self.hooks = sortedHooks
+        self.warnings = warnings
+        self.phase = phase
+        self.errorMessage = errorMessage
+        self.detectedAt = detectedAt
+        self.gateGeneration = gateGeneration
+    }
+
+    var trustCandidates: [CodexHookTrustCandidate] {
+        hooks.map(\.trustCandidate)
+    }
+
+    private static func lengthPrefixed(_ value: String) -> String {
+        "\(value.utf8.count):\(value)"
+    }
+}
+
+enum AgentCodexHookReviewDecision: Equatable {
+    case approveSelected(hookKeys: [String])
+    case approveAll
+    case continueWithoutHooks
+    case retryDiscovery
+}
+
+struct AgentCodexHookGateAudit: Equatable {
+    enum Status: String, Equatable {
+        case approvedAll
+        case approvedSelected
+        case continuedWithoutHooks
+        case resolvedExternally
+    }
+
+    let status: Status
+    let approvedCount: Int
+    let skippedCount: Int
+    let resolvedAt: Date
+    let interactionID: UUID
+}
+
+enum AgentCodexHookReviewResolutionError: Error, LocalizedError, Equatable {
+    case noPendingReview
+    case staleRequest(currentID: UUID)
+    case busy
+    case invalidDecision
+    case invalidSelection
+    case staleController
+    case strictModeRequiresApproval
+
+    var errorDescription: String? {
+        switch self {
+        case .noPendingReview:
+            "No Codex project-hook review is pending."
+        case .staleRequest:
+            "The Codex project-hook inventory changed. Review the current interaction and retry."
+        case .busy:
+            "A Codex project-hook operation is already in progress."
+        case .invalidDecision:
+            "That decision is not available for the current Codex project-hook review phase."
+        case .invalidSelection:
+            "Approve Selected requires one or more unique hook keys from the current review."
+        case .staleController:
+            "The Codex controller binding changed. Start the turn again to review the current project hooks."
+        case .strictModeRequiresApproval:
+            "Continue Without Hooks is disabled by the Codex hook approval strict mode setting. Approve the project hooks to continue."
+        }
+    }
+}

--- a/Sources/RepoPrompt/Features/AgentMode/Models/UserInteractionModels.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Models/UserInteractionModels.swift
@@ -1,7 +1,7 @@
 import CryptoKit
 import Foundation
 
-private enum StableUserInteractionIdentity {
+enum StableUserInteractionIdentity {
     static func uuid(from seed: String) -> UUID {
         let digest = Array(SHA256.hash(data: Data(seed.utf8)))
         let bytes: uuid_t = (

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Codex/CodexAgentModeCoordinator.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Codex/CodexAgentModeCoordinator.swift
@@ -685,6 +685,36 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
             && binding == codexHookGateBinding(for: session, controller: controller)
     }
 
+    private func synchronizeCodexThreadReferenceAfterHookGate(
+        session: AgentTabSession,
+        controller: any CodexSessionControlling
+    ) {
+        guard let currentController = session.codexController,
+              Self.sameCodexControllerInstance(currentController, controller),
+              let reference = controller.currentSessionReference
+        else {
+            return
+        }
+        let conversationID = reference.conversationID.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !conversationID.isEmpty,
+              conversationID != session.codexConversationID
+              || reference.rolloutPath != session.codexRolloutPath
+        else {
+            return
+        }
+        session.codexConversationID = conversationID
+        session.codexRolloutPath = reference.rolloutPath
+        session.providerCleanupHandle = ProviderConversationCleanupHandle(
+            provider: AgentProviderKind.codexExec.rawValue,
+            conversationID: conversationID,
+            rolloutPath: reference.rolloutPath
+        )
+        session.codexModel = reference.model
+        session.codexReasoningEffort = reference.reasoningEffort
+        session.isDirty = true
+        viewModel?.scheduleSave(for: session.tabID)
+    }
+
     private func publishCodexHookGateState(for session: AgentTabSession) {
         viewModel?.reconcileInteractiveRunState(session)
         updateCodexStallWatchdogState(for: session)
@@ -801,6 +831,10 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
                 throw AgentCodexHookReviewResolutionError.staleController
             }
             try await suspendForCodexHookReview(session: session, binding: binding)
+            synchronizeCodexThreadReferenceAfterHookGate(
+                session: session,
+                controller: controller
+            )
             return
         }
 
@@ -827,6 +861,10 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
                 session.codexHookGateActiveBinding = nil
                 session.codexHookGateInventoryFingerprint = nil
                 session.codexHookGateBindingMemo = binding
+                synchronizeCodexThreadReferenceAfterHookGate(
+                    session: session,
+                    controller: controller
+                )
                 return
             }
             session.codexHookGateAttemptToken = nil
@@ -861,6 +899,10 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
 
         publishCodexHookGateState(for: session)
         try await suspendForCodexHookReview(session: session, binding: binding)
+        synchronizeCodexThreadReferenceAfterHookGate(
+            session: session,
+            controller: controller
+        )
     }
 
     func resolveCodexHookReview(

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Codex/CodexAgentModeCoordinator.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Codex/CodexAgentModeCoordinator.swift
@@ -956,6 +956,10 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
             guard selected.count == hookKeys.count else {
                 throw AgentCodexHookReviewResolutionError.invalidSelection
             }
+            let allUnresolvedKeys = Set(request.hooks.map { CodexHookUTF8Identity($0.key) })
+            guard !isCodexHookApprovalStrictModeEnabled() || requestedKeys == allUnresolvedKeys else {
+                throw AgentCodexHookReviewResolutionError.strictModeRequiresApproval
+            }
             try await submitCodexHookApproval(
                 session: session,
                 request: request,
@@ -1020,6 +1024,19 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
                     request: request,
                     phase: .verificationFailed,
                     errorMessage: CodexHookTrustError.postWriteVerificationFailed(latest: verified).localizedDescription
+                )
+                return
+            }
+            let approvedIdentities = Set(candidates.map(\.selectionIdentity))
+            let expectedSkippedIdentities = Set(request.trustCandidates.map(\.selectionIdentity))
+                .subtracting(approvedIdentities)
+            let verifiedUnresolvedIdentities = Set(verified.unresolvedProjectHooks.map(\.selectionIdentity))
+            guard verifiedUnresolvedIdentities.isSubset(of: expectedSkippedIdentities) else {
+                applyCodexHookInventoryRefresh(
+                    verified,
+                    session: session,
+                    priorRequest: request,
+                    binding: binding
                 )
                 return
             }

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Codex/CodexAgentModeCoordinator.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Codex/CodexAgentModeCoordinator.swift
@@ -2925,6 +2925,11 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
         if let identity = session.codexAuthoritativeActiveTurn {
             return codexFallbackBlockingTurn(for: identity)
         }
+        // An owner turn that has been accepted but has not yet reached its lifecycle start
+        // still owns the thread, so anything queued in that window belongs behind it.
+        if let hookGateOwnerBlocker = session.codexFallbackHookGateOwnerBlocker {
+            return hookGateOwnerBlocker
+        }
         guard let inFlight = session.codexFallbackDispatchInFlight else {
             return nil
         }
@@ -3051,6 +3056,10 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
         var retryDelayNanos: UInt64 = 100_000_000
         while !Task.isCancelled {
             guard session.codexFallbackDispatchInFlight == nil,
+                  // An accepted owner turn owns the queue until its lifecycle resolves, and
+                  // resolving it releases or abandons these entries through the lifecycle
+                  // paths. Polling the thread in the meantime can only reach a wrong answer.
+                  session.codexFallbackHookGateOwnerBlocker == nil,
                   let head = session.codexFallbackQueue.first,
                   head.id == queueID,
                   head.state == .queued,
@@ -3062,19 +3071,38 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
                   session.runID == head.originRunID,
                   session.activeRunAttemptID == head.originRunAttemptID
             else { return }
+            let observedBlockingTurn = head.blockingTurn
+            let observedHookGateGeneration = session.codexHookGateGeneration
             do {
                 let snapshot = try await controller.readThreadSnapshot(includeTurns: true, timeout: 2)
+                // Reading the snapshot suspends, so the answer only describes a queue that is
+                // still exactly as it was when the read was issued. A blocker installed or
+                // rebound in that window refers to a turn the read never saw, and an owner
+                // turn that has been accepted may not have reached the thread yet — neither
+                // can be retired by this answer, so both send the pump back around.
                 if snapshot.conversationID == head.originThreadID,
                    snapshot.runtimeStatus == .idle,
                    snapshot.currentTurnID == nil,
-                   snapshot.activeTurnIDs.isEmpty
+                   snapshot.activeTurnIDs.isEmpty,
+                   session.codexFallbackDispatchInFlight == nil,
+                   session.codexFallbackHookGateOwnerBlocker == nil,
+                   session.codexHookGateGeneration == observedHookGateGeneration,
+                   let currentHead = session.codexFallbackQueue.first,
+                   currentHead.id == queueID,
+                   currentHead.state == .queued,
+                   currentHead.blockingTurn == observedBlockingTurn
                 {
-                    if let blockingTurn = head.blockingTurn,
-                       session.codexAuthoritativeActiveTurn?.turnID == blockingTurn.turnID
+                    if let observedBlockingTurn,
+                       session.codexAuthoritativeActiveTurn?.turnID == observedBlockingTurn.turnID
                     {
                         session.codexAuthoritativeActiveTurn = nil
                     }
                     session.codexAnonymousActiveTurn = nil
+                    // Dropping the proven-finished blocker is what lets the claim path — which
+                    // refuses a still-blocked head — take the head, and clearing by value keeps
+                    // the rest of the queue on one shared blocker so the head's own lifecycle
+                    // start rebinds them onto the turn it opens.
+                    clearCodexFallbackBlockers(matching: observedBlockingTurn, session: session)
                     _ = await dispatchCodexFallbackHead(
                         session: session,
                         expectedQueueID: queueID,
@@ -3122,6 +3150,10 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
             guard !session.runState.isActive else { return nil }
         } else {
             guard session.activeRunAttemptID == head.originRunAttemptID else { return nil }
+            // A bound entry is releasable only through the successor path, which claims it
+            // against the completion of the exact turn it is bound to. Claiming it here would
+            // start a second turn while that turn is still running.
+            guard head.blockingTurn == nil else { return nil }
         }
         guard activateCodexFallbackAttachmentReservation(head, session: session) else { return nil }
         if beginsSuccessorAttempt {
@@ -3301,6 +3333,7 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
         session.codexFallbackSuccessorRetryTask?.cancel()
         session.codexFallbackSuccessorRetryTask = nil
         session.mcpFollowUpRunPending = false
+        session.codexFallbackHookGateOwnerBlocker = nil
         let queued = session.codexFallbackQueue
         session.codexFallbackQueue.removeAll()
         for entry in queued {
@@ -3364,6 +3397,39 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
         abandonCodexFallbackQueue(session: session, reason: reason)
     }
 
+    /// Retargets every queued entry currently waiting on `previousBlockingTurn`. Only
+    /// `.queued` entries participate: a claimed entry's blocker describes a dispatch already
+    /// under way, which each caller resolves on its own terms.
+    private func retargetQueuedCodexFallbackBlockers(
+        from previousBlockingTurn: AgentTabSession.CodexFallbackBlockingTurn?,
+        to blockingTurn: AgentTabSession.CodexFallbackBlockingTurn?,
+        session: AgentTabSession
+    ) {
+        for index in session.codexFallbackQueue.indices {
+            guard session.codexFallbackQueue[index].state == .queued,
+                  session.codexFallbackQueue[index].blockingTurn == previousBlockingTurn
+            else { continue }
+            session.codexFallbackQueue[index].blockingTurn = blockingTurn
+        }
+    }
+
+    /// Releases entries whose blocking turn is proven finished. An in-flight dispatch is
+    /// deliberately left alone: it is already past the claim and owns its own completion.
+    private func clearCodexFallbackBlockers(
+        matching blockingTurn: AgentTabSession.CodexFallbackBlockingTurn?,
+        session: AgentTabSession
+    ) {
+        guard blockingTurn != nil else { return }
+        retargetQueuedCodexFallbackBlockers(
+            from: blockingTurn,
+            to: nil,
+            session: session
+        )
+    }
+
+    /// Moves the queue onto a different blocking turn, in-flight dispatch included: a rebind
+    /// means the turn everything was waiting on has been superseded rather than finished, and
+    /// the in-flight entry is the one whose lifecycle carries the queue forward.
     private func rebindCodexFallbackBlockers(
         from previousBlockingTurn: AgentTabSession.CodexFallbackBlockingTurn?,
         to blockingTurn: AgentTabSession.CodexFallbackBlockingTurn,
@@ -3375,18 +3441,189 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
             inFlight.blockingTurn = blockingTurn
             session.codexFallbackDispatchInFlight = inFlight
         }
-        for index in session.codexFallbackQueue.indices {
-            guard session.codexFallbackQueue[index].state == .queued,
-                  session.codexFallbackQueue[index].blockingTurn == previousBlockingTurn
-            else { continue }
-            session.codexFallbackQueue[index].blockingTurn = blockingTurn
-        }
+        retargetQueuedCodexFallbackBlockers(
+            from: previousBlockingTurn,
+            to: blockingTurn,
+            session: session
+        )
+    }
+
+    /// The gate ownership and run lineage a first-turn dispatch held when it issued
+    /// `turn/start`. Captured before the call because the call can outlive all of it:
+    /// cancellation or controller replacement can hand the session to a different
+    /// controller, run attempt, and gate owner while the request is still in flight.
+    private struct CodexHookGateOwnerDispatchScope {
+        let ownerToken: UUID
+        let controllerInstanceID: ObjectIdentifier
+        let controllerGeneration: UUID
+        let threadID: String
+        let runID: UUID?
+        let runAttemptID: UUID
+    }
+
+    private func codexHookGateOwnerDispatchScope(
+        ownerToken: UUID?,
+        controller: any CodexSessionControlling,
+        session: AgentTabSession
+    ) -> CodexHookGateOwnerDispatchScope? {
+        guard let ownerToken,
+              let threadID = session.codexConversationID,
+              let runAttemptID = session.activeRunAttemptID
+        else { return nil }
+        return .init(
+            ownerToken: ownerToken,
+            controllerInstanceID: ObjectIdentifier(controller),
+            controllerGeneration: session.codexControllerGeneration,
+            threadID: threadID,
+            runID: session.runID,
+            runAttemptID: runAttemptID
+        )
+    }
+
+    /// Issues a hook-gate owner's first `turn/start` and binds the coalesced queue to the
+    /// turn it accepts. The scope is captured before the call rather than after, because the
+    /// call can outlive the gate ownership and run lineage it was issued under.
+    @discardableResult
+    private func startCodexHookGateOwnerTurn(
+        ownerToken: UUID?,
+        controller: any CodexSessionControlling,
+        session: AgentTabSession,
+        start: () async throws -> CodexTurnStartReceipt
+    ) async throws -> CodexTurnStartReceipt {
+        let scope = codexHookGateOwnerDispatchScope(
+            ownerToken: ownerToken,
+            controller: controller,
+            session: session
+        )
+        let receipt = try await start()
+        bindQueuedCodexFallbacksToAcceptedHookGateTurn(
+            scope: scope,
+            submissionID: receipt.provisionalSubmissionID,
+            session: session
+        )
+        return receipt
+    }
+
+    /// Binds queued follow-ups to the turn a hook-gate owner has just had accepted.
+    ///
+    /// Releasing the gate resumes every coalesced waiter at once, and a resumed waiter's
+    /// claim path validates run lineage only, so without a blocker it would start a second
+    /// turn while this one is still running. The accepted `turn/start` receipt is the only
+    /// identifier for the new turn available synchronously here — the authoritative identity
+    /// arrives later on an independent event stream — so binding cannot wait for it.
+    ///
+    /// Every field of the blocker comes from the captured scope, and the scope must still be
+    /// the session's current gate owner and lineage: a return that lost either would otherwise
+    /// stamp a superseded turn's submission ID onto whatever controller and run now hold the
+    /// session, and the gate would reject that same token moments later.
+    private func bindQueuedCodexFallbacksToAcceptedHookGateTurn(
+        scope: CodexHookGateOwnerDispatchScope?,
+        submissionID: String,
+        session: AgentTabSession
+    ) {
+        guard let scope,
+              session.codexHookGateDispatchOwnerToken == scope.ownerToken,
+              let controller = session.codexController,
+              ObjectIdentifier(controller) == scope.controllerInstanceID,
+              session.codexControllerGeneration == scope.controllerGeneration,
+              session.codexConversationID == scope.threadID,
+              session.runID == scope.runID,
+              session.activeRunAttemptID == scope.runAttemptID,
+              session.codexFallbackDispatchInFlight == nil,
+              session.codexFallbackHookGateOwnerBlocker == nil,
+              session.codexFallbackQueue.contains(where: {
+                  $0.state == .queued && $0.blockingTurn == nil
+              })
+        else { return }
+        let blockingTurn = AgentTabSession.CodexFallbackBlockingTurn(
+            threadID: scope.threadID,
+            turnID: submissionID,
+            controllerInstanceID: scope.controllerInstanceID,
+            controllerGeneration: scope.controllerGeneration,
+            runID: scope.runID,
+            runAttemptID: scope.runAttemptID
+        )
+        session.codexFallbackHookGateOwnerBlocker = blockingTurn
+        rebindCodexFallbackBlockers(from: nil, to: blockingTurn, session: session)
+    }
+
+    /// Binds queued follow-ups when a hook-gate owner's turn announces its lifecycle start
+    /// before its `turn/start` call returns — the receipt and the event stream are
+    /// independent, so either can arrive first. The gate is still held, so no waiter has
+    /// resumed and the queue is still bindable. Waiting for the receipt instead would risk
+    /// this turn ending first, leaving the completion with no blocker to release.
+    private func bindQueuedCodexFallbacksToStartedHookGateOwnerTurn(
+        _ identity: AgentTabSession.CodexAuthoritativeTurnIdentity,
+        session: AgentTabSession
+    ) {
+        guard session.codexHookGateDispatchOwnerToken != nil,
+              session.codexFallbackHookGateOwnerBlocker == nil,
+              session.codexFallbackDispatchInFlight == nil,
+              identity.threadID == session.codexConversationID,
+              identity.runID == session.runID,
+              identity.runAttemptID == session.activeRunAttemptID,
+              session.codexFallbackQueue.contains(where: {
+                  $0.state == .queued && $0.blockingTurn == nil
+              })
+        else { return }
+        let blockingTurn = codexFallbackBlockingTurn(for: identity)
+        session.codexFallbackHookGateOwnerBlocker = blockingTurn
+        rebindCodexFallbackBlockers(from: nil, to: blockingTurn, session: session)
+    }
+
+    /// Resolves follow-ups belonging to an owner turn that ended without ever becoming
+    /// identifiable — a nil-ID lifecycle, or a run terminalized with no correlated
+    /// completion. Successor release matches an exact identity and a terminal run only hands
+    /// work on through that path, so such a turn can never release its queue.
+    ///
+    /// Both shapes of ownership are resolved here, because the receipt and the lifecycle race
+    /// each other. An owner that has already had its turn accepted is found through the
+    /// receipt-derived blocker; one still inside `turn/start` has no blocker to match yet, and
+    /// is found through the gate it still holds — its coalesced follow-ups are exactly the
+    /// unblocked entries that gate is holding back. Missing the second shape would leave those
+    /// entries with no owner to wait on and a run lineage they can no longer claim under.
+    private func reconcileCodexFallbackQueueForUnidentifiedOwnerTerminal(
+        session: AgentTabSession,
+        reason: String
+    ) {
+        let pending = session.codexFallbackHookGateOwnerBlocker
+        session.codexFallbackHookGateOwnerBlocker = nil
+        let boundToAcceptedOwnerTurn = pending.map { blockingTurn in
+            session.codexFallbackQueue.contains { $0.blockingTurn == blockingTurn }
+                || session.codexFallbackDispatchInFlight?.blockingTurn == blockingTurn
+        } ?? false
+        let coalescedBehindUnacceptedOwnerTurn = session.codexHookGateDispatchOwnerToken != nil
+            && session.codexFallbackQueue.contains { $0.state == .queued && $0.blockingTurn == nil }
+        guard boundToAcceptedOwnerTurn || coalescedBehindUnacceptedOwnerTurn else { return }
+        abandonCodexFallbackQueue(session: session, reason: reason)
+    }
+
+    /// Promotes a receipt-derived blocker to the authoritative blocker for the same turn.
+    /// Successor release matches blockers by exact equality, so an entry left holding the
+    /// receipt-derived value would never be handed to the turn it is waiting on.
+    private func upgradeCodexFallbackHookGateOwnerBlocker(
+        to identity: AgentTabSession.CodexAuthoritativeTurnIdentity,
+        session: AgentTabSession
+    ) {
+        guard let pending = session.codexFallbackHookGateOwnerBlocker,
+              identity.threadID == pending.threadID,
+              identity.controllerInstanceID == pending.controllerInstanceID,
+              identity.controllerGeneration == pending.controllerGeneration,
+              identity.runID == pending.runID,
+              identity.runAttemptID == pending.runAttemptID
+        else { return }
+        session.codexFallbackHookGateOwnerBlocker = nil
+        let blockingTurn = codexFallbackBlockingTurn(for: identity)
+        guard blockingTurn != pending else { return }
+        rebindCodexFallbackBlockers(from: pending, to: blockingTurn, session: session)
     }
 
     private func bindCodexFallbackQueueToStartedTurn(
         _ identity: AgentTabSession.CodexAuthoritativeTurnIdentity,
         session: AgentTabSession
     ) {
+        upgradeCodexFallbackHookGateOwnerBlocker(to: identity, session: session)
+        bindQueuedCodexFallbacksToStartedHookGateOwnerTurn(identity, session: session)
         guard var inFlight = session.codexFallbackDispatchInFlight else { return }
         // Successor dispatches begin a new run attempt, so lineage deliberately
         // excludes runAttemptID.
@@ -5055,13 +5292,19 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
                     )
                 }
             }
-            _ = try await controller.startUserTurn(
-                text: replayTurn.text,
-                images: replayTurn.images,
-                model: replayTurn.model,
-                reasoningEffort: replayTurn.reasoningEffort,
-                serviceTier: replayTurn.serviceTier
-            )
+            try await startCodexHookGateOwnerTurn(
+                ownerToken: hookGateDispatchOwnerToken,
+                controller: controller,
+                session: session
+            ) {
+                try await controller.startUserTurn(
+                    text: replayTurn.text,
+                    images: replayTurn.images,
+                    model: replayTurn.model,
+                    reasoningEffort: replayTurn.reasoningEffort,
+                    serviceTier: replayTurn.serviceTier
+                )
+            }
             dispatched = true
             await applySuccessfulCodexNativeSend(
                 for: session,
@@ -5129,11 +5372,28 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
     /// lifecycle work — shutdown, event tasks, run IDs, reconnect flags, pending interactions,
     /// tracking — stays with each teardown path.
     private func clearCodexControllerInstanceState(for session: AgentTabSession) {
+        abandonCodexFallbackQueueForRetiredCodexController(session: session)
         session.codexController = nil
         session.codexControllerPermissionProfile = nil
         session.codexControllerTaskLabelKind = nil
         session.codexControllerWorkspacePaths = nil
         session.codexControllerFeatureState = nil
+    }
+
+    /// Queued follow-ups are pinned to the controller instance that accepted them, so a
+    /// retired controller leaves them unclaimable by construction — no later lineage check can
+    /// ever match them again. Returning them to the composer is the only disposition that does
+    /// not silently drop the user's text.
+    private func abandonCodexFallbackQueueForRetiredCodexController(session: AgentTabSession) {
+        guard session.codexController != nil,
+              !session.codexFallbackQueue.isEmpty
+              || session.codexFallbackDispatchInFlight != nil
+              || session.codexFallbackHookGateOwnerBlocker != nil
+        else { return }
+        abandonCodexFallbackQueue(
+            session: session,
+            reason: "Codex queued follow-up was cancelled because the controller was replaced."
+        )
     }
 
     /// Cancels every tab-scoped background task that watches or drives the
@@ -6290,13 +6550,19 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
                     beginTrackedCodexUserTurn(session)
                     updateCodexStallWatchdogState(for: session)
                     logCodex("[AgentModeVM] sendCodexNativeMessage: calling controller.startUserTurn")
-                    _ = try await controller.startUserTurn(
-                        text: text,
-                        images: attachments,
-                        model: selection.model,
-                        reasoningEffort: selection.reasoningEffort,
-                        serviceTier: selection.serviceTier
-                    )
+                    try await startCodexHookGateOwnerTurn(
+                        ownerToken: hookGateDispatchOwnerToken,
+                        controller: controller,
+                        session: session
+                    ) {
+                        try await controller.startUserTurn(
+                            text: text,
+                            images: attachments,
+                            model: selection.model,
+                            reasoningEffort: selection.reasoningEffort,
+                            serviceTier: selection.serviceTier
+                        )
+                    }
                     dispatched = true
                 }
             case let .steer(identity):
@@ -7335,6 +7601,13 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
         clearCodexPendingAuthRetryTurn(session)
         cancelCodexTransportClosedFallback(for: session.tabID)
         resetTrackedCodexTurns(session)
+        // Terminalizing without a correlated completion — a server request issue, a watchdog
+        // teardown — retires the very turn the queue is waiting on. Resetting tracked turns
+        // without resolving the queue here is what would leave the pump nothing to wait for.
+        reconcileCodexFallbackQueueForUnidentifiedOwnerTerminal(
+            session: session,
+            reason: "Codex queued follow-ups were cancelled because the run ended before the turn they followed was identified."
+        )
         resetCodexWatchdogState(session)
         clearCodexNativeToolLiveness(session)
         session.activeReasoningItemID = nil
@@ -7921,6 +8194,12 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
             }
             let turnKind = completion.turnKind
             let completedIdentity = completion.authoritativeIdentity
+            // The lifecycle start event can land before the accepted receipt is recorded, in
+            // which case it never rebound the queue. Upgrade here so successor matching and
+            // blocked-queue abandonment both see the authoritative blocker.
+            if let completedIdentity {
+                upgradeCodexFallbackHookGateOwnerBlocker(to: completedIdentity, session: session)
+            }
             let providerSuccessor = await codexFallbackSuccessorForCompletion(
                 turnID: turnID,
                 status: status,
@@ -7932,6 +8211,12 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
                 status: status,
                 session: session
             )
+            if completedIdentity == nil {
+                reconcileCodexFallbackQueueForUnidentifiedOwnerTerminal(
+                    session: session,
+                    reason: "Codex queued follow-ups were cancelled because the turn they followed ended with \(status) without an identifiable turn."
+                )
+            }
             if turnKind == .compact {
                 if status == .completed {
                     markCodexContextCompacted(session)
@@ -8944,7 +9229,11 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
         }
 
         @_spi(TestSupport)
-        public func test_handleCodexNativeEvent(
+        public func test_retireCodexControllerInstance(session: AgentTabSession) {
+            clearCodexControllerInstanceState(for: session)
+        }
+
+        func test_handleCodexNativeEvent(
             _ event: CodexNativeSessionController.Event,
             session: AgentTabSession,
             sourceController: (any CodexSessionControlling)? = nil

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Codex/CodexAgentModeCoordinator.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Codex/CodexAgentModeCoordinator.swift
@@ -263,6 +263,7 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
     private let activeAgentRunWaitQuery: ActiveAgentRunWaitQuery
     private var activeAgentRunWaitDrain: ActiveAgentRunWaitDrain
     private let authRecovery: any CodexManagedAuthRecovering
+    private let codexHookApprovalSettings: any CodexHookApprovalSettingsProviding
     private var codexModelsSubscriptionTask: Task<Void, Never>?
     private let commandRunningStatusCoalesceDelayNanos: UInt64 = 75_000_000
     private let commandRunningLiveOutputCoalesceDelayNanos: UInt64 = 225_000_000
@@ -372,6 +373,7 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
         connectionPolicyInstaller: @escaping ConnectionPolicyInstaller,
         shouldManageCodexTooling: Bool,
         authRecovery: any CodexManagedAuthRecovering = CodexManagedAuthRecoveryService.shared,
+        codexHookApprovalSettings: any CodexHookApprovalSettingsProviding,
         activeToolQuery: @escaping ActiveToolQuery = { _ in false },
         activeAgentRunWaitQuery: @escaping ActiveAgentRunWaitQuery = { _ in false },
         activeAgentRunWaitDrain: @escaping ActiveAgentRunWaitDrain = { _, _, _, _ in true },
@@ -392,6 +394,7 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
         self.connectionPolicyInstaller = connectionPolicyInstaller
         self.shouldManageCodexTooling = shouldManageCodexTooling
         self.authRecovery = authRecovery
+        self.codexHookApprovalSettings = codexHookApprovalSettings
         self.activeToolQuery = activeToolQuery
         self.activeAgentRunWaitQuery = activeAgentRunWaitQuery
         self.activeAgentRunWaitDrain = activeAgentRunWaitDrain
@@ -557,6 +560,7 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
 
     private func hasPendingCodexInteraction(for session: AgentTabSession) -> Bool {
         session.pendingApproval != nil
+            || session.hasPendingCodexHookReviewWait
             || session.pendingPermissionsRequest != nil
             || session.pendingMCPElicitationRequest != nil
             || !session.queuedMCPElicitationRequests.isEmpty
@@ -568,12 +572,16 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
     @discardableResult
     private func clearCodexPendingInteractions(in session: AgentTabSession) -> Bool {
         let didClear = session.pendingApproval != nil
+            || session.hasPendingCodexHookReviewWait
             || session.pendingPermissionsRequest != nil
             || session.pendingMCPElicitationRequest != nil
             || !session.queuedMCPElicitationRequests.isEmpty
             || session.pendingUserInputRequest != nil
             || !session.queuedUserInputRequests.isEmpty
         session.pendingApproval = nil
+        if session.hasActiveCodexHookGateOperation {
+            session.resetCodexHookGateBinding()
+        }
         session.pendingPermissionsRequest = nil
         session.pendingMCPElicitationRequest = nil
         session.queuedMCPElicitationRequests.removeAll()
@@ -595,7 +603,10 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
         _ turnID: String?,
         session: AgentTabSession
     ) {
-        guard let turnID,
+        // Hook approval is a controller-binding startup gate, not a turn-scoped
+        // server request. A turnStarted event must never stale-match or clear it.
+        guard !session.hasPendingCodexHookReviewWait,
+              let turnID,
               hasPendingCodexInteraction(for: session),
               !pendingCodexInteractionMatches(turnID: turnID, session: session)
         else {
@@ -606,6 +617,523 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
         viewModel?.publishMCPStateChange(for: session)
         handleRunInteractionStateChange(for: session, reason: .pendingQuestionCancelled)
         logCodex("[AgentModeVM][CodexUI] cleared stale pending Codex interactions for tab \(session.tabID) before new turn \(turnID)")
+    }
+
+    func isCodexHookApprovalStrictModeEnabled() -> Bool {
+        codexHookApprovalSettings.codexHookApprovalStrictModeEnabled(
+            workspaceID: viewModel?.activeWorkspaceIDForSessionIndexOwnership
+        )
+    }
+
+    private struct CodexHookGateOperationAuthority {
+        enum Scope {
+            case initialDiscovery
+            case review(requestID: UUID, gateGeneration: UInt64)
+        }
+
+        let attemptToken: UUID
+        let scope: Scope
+        let binding: AgentTabSession.CodexHookGateBindingIdentity
+
+        init(
+            attemptToken: UUID,
+            scope: Scope,
+            binding: AgentTabSession.CodexHookGateBindingIdentity
+        ) {
+            self.attemptToken = attemptToken
+            self.scope = scope
+            self.binding = binding
+        }
+
+        @MainActor
+        func isCurrent(in session: AgentTabSession) -> Bool {
+            guard session.codexHookGateAttemptToken == attemptToken,
+                  let currentController = session.codexController,
+                  ObjectIdentifier(currentController as AnyObject) == binding.controllerInstanceID,
+                  binding.controllerGeneration == session.codexControllerGeneration
+            else {
+                return false
+            }
+            switch scope {
+            case .initialDiscovery:
+                return true
+            case let .review(requestID, gateGeneration):
+                return session.pendingCodexHookReview?.id == requestID
+                    && session.codexHookGateGeneration == gateGeneration
+                    && session.codexHookGateActiveBinding == binding
+            }
+        }
+    }
+
+    private func codexHookGateBinding(
+        for session: AgentTabSession,
+        controller: any CodexSessionControlling
+    ) -> AgentTabSession.CodexHookGateBindingIdentity {
+        .init(
+            controllerInstanceID: ObjectIdentifier(controller),
+            controllerGeneration: session.codexControllerGeneration
+        )
+    }
+
+    private func isCurrentCodexHookGateBinding(
+        _ binding: AgentTabSession.CodexHookGateBindingIdentity,
+        session: AgentTabSession,
+        controller: any CodexSessionControlling
+    ) -> Bool {
+        guard let currentController = session.codexController else { return false }
+        return Self.sameCodexControllerInstance(currentController, controller)
+            && binding == codexHookGateBinding(for: session, controller: controller)
+    }
+
+    private func publishCodexHookGateState(for session: AgentTabSession) {
+        viewModel?.reconcileInteractiveRunState(session)
+        updateCodexStallWatchdogState(for: session)
+        viewModel?.requestUIRefresh(tabID: session.tabID, urgent: true)
+        viewModel?.publishMCPStateChange(for: session)
+    }
+
+    private func finishCodexHookReviewAttempt(
+        session: AgentTabSession,
+        request: AgentCodexHookReviewRequest,
+        phase: AgentCodexHookReviewRequest.Phase,
+        errorMessage: String?
+    ) {
+        session.codexHookGateAttemptToken = nil
+        var transitionedRequest = request
+        transitionedRequest.phase = phase
+        transitionedRequest.errorMessage = errorMessage
+        session.pendingCodexHookReview = transitionedRequest
+        publishCodexHookGateState(for: session)
+    }
+
+    private func codexHookReviewRequest(
+        session: AgentTabSession,
+        executionCWD: String,
+        hooks: [CodexHookMetadata],
+        warnings: [String],
+        phase: AgentCodexHookReviewRequest.Phase,
+        errorMessage: String? = nil
+    ) -> AgentCodexHookReviewRequest {
+        AgentCodexHookReviewRequest(
+            tabID: session.tabID,
+            runAttemptID: session.activeRunAttemptID,
+            runID: session.runID,
+            executionCWD: executionCWD,
+            hooks: hooks.map(AgentCodexHookReviewHook.init(metadata:)),
+            warnings: warnings,
+            phase: phase,
+            errorMessage: errorMessage,
+            gateGeneration: session.codexHookGateGeneration
+        )
+    }
+
+    private func codexHookDiscoveryFailureMessage(_ error: Error) -> String {
+        if let hookError = error as? CodexHookTrustError,
+           case let .discoveryFailed(cwdErrors) = hookError
+        {
+            let details = cwdErrors.prefix(3).map { raw in
+                let normalized = raw
+                    .components(separatedBy: .newlines)
+                    .joined(separator: " ")
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                return String(normalized.prefix(300))
+            }.filter { !$0.isEmpty }
+            if !details.isEmpty {
+                return "Codex hook discovery failed: \(details.joined(separator: "; "))"
+            }
+        }
+        return (error as? LocalizedError)?.errorDescription
+            ?? "Codex hook discovery failed. Retry hook discovery."
+    }
+
+    private func codexHookExecutionCWD(for session: AgentTabSession) -> String {
+        if let path = session.codexControllerWorkspacePaths?.executionDirectory,
+           !path.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        {
+            return path
+        }
+        if let paths = try? runtimeWorkspacePathsProvider(session),
+           let path = paths.executionDirectory,
+           !path.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        {
+            return path
+        }
+        return "<execution-cwd-unavailable>"
+    }
+
+    private func suspendForCodexHookReview(
+        session: AgentTabSession,
+        binding: AgentTabSession.CodexHookGateBindingIdentity
+    ) async throws {
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                guard !Task.isCancelled,
+                      session.codexHookGateActiveBinding == binding,
+                      session.hasPendingCodexHookReviewRequest,
+                      session.codexHookReviewContinuation == nil
+                else {
+                    continuation.resume(throwing: CancellationError())
+                    return
+                }
+                session.codexHookReviewContinuation = continuation
+            }
+        } onCancel: { [weak self, weak session] in
+            Task { @MainActor in
+                guard let self, let session,
+                      session.codexHookGateActiveBinding == binding
+                else { return }
+                session.resetCodexHookGateBinding()
+                self.publishCodexHookGateState(for: session)
+            }
+        }
+    }
+
+    private func gateFirstTurnForProjectHooks(
+        session: AgentTabSession,
+        controller: any CodexSessionControlling
+    ) async throws {
+        let binding = codexHookGateBinding(for: session, controller: controller)
+        if session.codexHookGateBindingMemo == binding {
+            return
+        }
+        guard !session.hasPendingCodexHookReviewWait else {
+            guard session.codexHookGateActiveBinding == binding else {
+                throw AgentCodexHookReviewResolutionError.staleController
+            }
+            try await suspendForCodexHookReview(session: session, binding: binding)
+            return
+        }
+
+        session.codexHookGateGeneration &+= 1
+        session.codexHookGateActiveBinding = binding
+        session.codexHookGateAudit = nil
+        let attemptToken = UUID()
+        session.codexHookGateAttemptToken = attemptToken
+        let authority = CodexHookGateOperationAuthority(
+            attemptToken: attemptToken,
+            scope: .initialDiscovery,
+            binding: binding
+        )
+
+        do {
+            let inventory = try await controller.listHooksForCurrentWorkspace()
+            try Task.checkCancellation()
+            guard authority.isCurrent(in: session) else {
+                throw CancellationError()
+            }
+            let unresolved = inventory.unresolvedProjectHooks
+            if unresolved.isEmpty {
+                session.codexHookGateAttemptToken = nil
+                session.codexHookGateActiveBinding = nil
+                session.codexHookGateInventoryFingerprint = nil
+                session.codexHookGateBindingMemo = binding
+                return
+            }
+            session.codexHookGateAttemptToken = nil
+            session.codexHookGateInventoryFingerprint = inventory.fingerprint
+            session.pendingCodexHookReview = codexHookReviewRequest(
+                session: session,
+                executionCWD: inventory.executionCWD,
+                hooks: unresolved,
+                warnings: inventory.warnings,
+                phase: .reviewRequired
+            )
+        } catch is CancellationError {
+            if session.codexHookGateAttemptToken == attemptToken {
+                session.resetCodexHookGateBinding()
+            }
+            throw CancellationError()
+        } catch {
+            guard authority.isCurrent(in: session) else {
+                throw CancellationError()
+            }
+            session.codexHookGateAttemptToken = nil
+            session.codexHookGateInventoryFingerprint = nil
+            session.pendingCodexHookReview = codexHookReviewRequest(
+                session: session,
+                executionCWD: codexHookExecutionCWD(for: session),
+                hooks: [],
+                warnings: [],
+                phase: .discoveryFailed,
+                errorMessage: codexHookDiscoveryFailureMessage(error)
+            )
+        }
+
+        publishCodexHookGateState(for: session)
+        try await suspendForCodexHookReview(session: session, binding: binding)
+    }
+
+    func resolveCodexHookReview(
+        session: AgentTabSession,
+        requestID: UUID,
+        decision: AgentCodexHookReviewDecision
+    ) async throws {
+        guard var request = session.pendingCodexHookReview else {
+            throw AgentCodexHookReviewResolutionError.noPendingReview
+        }
+        guard request.id == requestID else {
+            throw AgentCodexHookReviewResolutionError.staleRequest(currentID: request.id)
+        }
+        guard request.phase != .submitting, request.phase != .discovering else {
+            throw AgentCodexHookReviewResolutionError.busy
+        }
+        guard let controller = session.codexController,
+              let binding = session.codexHookGateActiveBinding,
+              request.gateGeneration == session.codexHookGateGeneration,
+              isCurrentCodexHookGateBinding(binding, session: session, controller: controller)
+        else {
+            throw AgentCodexHookReviewResolutionError.staleController
+        }
+
+        switch decision {
+        case .continueWithoutHooks:
+            guard request.phase.allowsApprovalDecision else {
+                throw AgentCodexHookReviewResolutionError.invalidDecision
+            }
+            guard !isCodexHookApprovalStrictModeEnabled() else {
+                throw AgentCodexHookReviewResolutionError.strictModeRequiresApproval
+            }
+            completeCodexHookReview(
+                session: session,
+                request: request,
+                binding: binding,
+                status: .continuedWithoutHooks,
+                approvedCount: 0,
+                skippedCount: request.hooks.count,
+                notice: "Continued without trusting \(request.hooks.count) Codex project hook(s). The hooks remain untrusted for this controller binding."
+            )
+
+        case .retryDiscovery:
+            guard request.phase == .discoveryFailed else {
+                throw AgentCodexHookReviewResolutionError.invalidDecision
+            }
+            request.phase = .discovering
+            request.errorMessage = nil
+            session.pendingCodexHookReview = request
+            let token = UUID()
+            session.codexHookGateAttemptToken = token
+            let authority = CodexHookGateOperationAuthority(
+                attemptToken: token,
+                scope: .review(requestID: requestID, gateGeneration: request.gateGeneration),
+                binding: binding
+            )
+            publishCodexHookGateState(for: session)
+            do {
+                let inventory = try await controller.listHooksForCurrentWorkspace()
+                try Task.checkCancellation()
+                guard authority.isCurrent(in: session) else { return }
+                applyCodexHookInventoryRefresh(
+                    inventory,
+                    session: session,
+                    priorRequest: request,
+                    binding: binding
+                )
+            } catch is CancellationError {
+                guard session.codexHookGateAttemptToken == token else { return }
+                session.resetCodexHookGateBinding()
+                publishCodexHookGateState(for: session)
+            } catch {
+                guard authority.isCurrent(in: session) else { return }
+                finishCodexHookReviewAttempt(
+                    session: session,
+                    request: request,
+                    phase: .discoveryFailed,
+                    errorMessage: codexHookDiscoveryFailureMessage(error)
+                )
+            }
+
+        case let .approveSelected(hookKeys):
+            guard !hookKeys.isEmpty,
+                  Set(hookKeys.map(CodexHookUTF8Identity.init)).count == hookKeys.count
+            else {
+                throw AgentCodexHookReviewResolutionError.invalidSelection
+            }
+            let requestedKeys = Set(hookKeys.map(CodexHookUTF8Identity.init))
+            let selected = request.hooks.filter { requestedKeys.contains(CodexHookUTF8Identity($0.key)) }
+            guard selected.count == hookKeys.count else {
+                throw AgentCodexHookReviewResolutionError.invalidSelection
+            }
+            try await submitCodexHookApproval(
+                session: session,
+                request: request,
+                candidates: selected.map(\.trustCandidate),
+                status: .approvedSelected,
+                controller: controller,
+                binding: binding
+            )
+
+        case .approveAll:
+            guard !request.hooks.isEmpty else {
+                throw AgentCodexHookReviewResolutionError.invalidSelection
+            }
+            try await submitCodexHookApproval(
+                session: session,
+                request: request,
+                candidates: request.trustCandidates,
+                status: .approvedAll,
+                controller: controller,
+                binding: binding
+            )
+        }
+    }
+
+    private func submitCodexHookApproval(
+        session: AgentTabSession,
+        request: AgentCodexHookReviewRequest,
+        candidates: [CodexHookTrustCandidate],
+        status: AgentCodexHookGateAudit.Status,
+        controller: any CodexSessionControlling,
+        binding: AgentTabSession.CodexHookGateBindingIdentity
+    ) async throws {
+        guard request.phase.allowsApprovalDecision else {
+            throw AgentCodexHookReviewResolutionError.invalidDecision
+        }
+        guard let fingerprint = session.codexHookGateInventoryFingerprint else {
+            throw AgentCodexHookReviewResolutionError.invalidDecision
+        }
+        var submittingRequest = request
+        submittingRequest.phase = .submitting
+        submittingRequest.errorMessage = nil
+        session.pendingCodexHookReview = submittingRequest
+        let token = UUID()
+        session.codexHookGateAttemptToken = token
+        let authority = CodexHookGateOperationAuthority(
+            attemptToken: token,
+            scope: .review(requestID: request.id, gateGeneration: request.gateGeneration),
+            binding: binding
+        )
+        publishCodexHookGateState(for: session)
+
+        do {
+            let verified = try await controller.trustHooksForCurrentWorkspace(
+                expectedCandidates: candidates,
+                expectedInventoryFingerprint: fingerprint
+            )
+            try Task.checkCancellation()
+            guard authority.isCurrent(in: session) else { return }
+            guard verified.verifies(candidates) else {
+                finishCodexHookReviewAttempt(
+                    session: session,
+                    request: request,
+                    phase: .verificationFailed,
+                    errorMessage: CodexHookTrustError.postWriteVerificationFailed(latest: verified).localizedDescription
+                )
+                return
+            }
+            completeCodexHookReview(
+                session: session,
+                request: request,
+                binding: binding,
+                status: status,
+                approvedCount: candidates.count,
+                skippedCount: max(0, request.hooks.count - candidates.count),
+                notice: "Trusted \(candidates.count) Codex project hook(s); \(max(0, request.hooks.count - candidates.count)) remain untrusted for this controller binding."
+            )
+        } catch is CancellationError {
+            guard session.codexHookGateAttemptToken == token else { return }
+            session.resetCodexHookGateBinding()
+            publishCodexHookGateState(for: session)
+        } catch let error as CodexHookTrustError {
+            guard authority.isCurrent(in: session) else { return }
+            switch error {
+            case let .inventoryChanged(replacement):
+                session.codexHookGateAttemptToken = nil
+                applyCodexHookInventoryRefresh(
+                    replacement,
+                    session: session,
+                    priorRequest: request,
+                    binding: binding
+                )
+            case .postWriteVerificationFailed:
+                finishCodexHookReviewAttempt(
+                    session: session,
+                    request: request,
+                    phase: .verificationFailed,
+                    errorMessage: error.localizedDescription
+                )
+            default:
+                finishCodexHookReviewAttempt(
+                    session: session,
+                    request: request,
+                    phase: .writeFailed,
+                    errorMessage: error.localizedDescription
+                )
+            }
+        } catch {
+            guard authority.isCurrent(in: session) else { return }
+            finishCodexHookReviewAttempt(
+                session: session,
+                request: request,
+                phase: .writeFailed,
+                errorMessage: error.localizedDescription
+            )
+        }
+    }
+
+    private func applyCodexHookInventoryRefresh(
+        _ inventory: CodexHookInventory,
+        session: AgentTabSession,
+        priorRequest: AgentCodexHookReviewRequest,
+        binding: AgentTabSession.CodexHookGateBindingIdentity
+    ) {
+        let unresolved = inventory.unresolvedProjectHooks
+        if unresolved.isEmpty {
+            completeCodexHookReview(
+                session: session,
+                request: priorRequest,
+                binding: binding,
+                status: .resolvedExternally,
+                approvedCount: 0,
+                skippedCount: 0,
+                notice: "Codex project hooks were resolved externally after the review was shown."
+            )
+            return
+        }
+        session.codexHookGateAttemptToken = nil
+        session.codexHookGateInventoryFingerprint = inventory.fingerprint
+        session.pendingCodexHookReview = codexHookReviewRequest(
+            session: session,
+            executionCWD: inventory.executionCWD,
+            hooks: unresolved,
+            warnings: inventory.warnings,
+            phase: .reviewRequired
+        )
+        publishCodexHookGateState(for: session)
+    }
+
+    private func completeCodexHookReview(
+        session: AgentTabSession,
+        request: AgentCodexHookReviewRequest,
+        binding: AgentTabSession.CodexHookGateBindingIdentity,
+        status: AgentCodexHookGateAudit.Status,
+        approvedCount: Int,
+        skippedCount: Int,
+        notice: String
+    ) {
+        guard session.pendingCodexHookReview?.id == request.id,
+              session.codexHookGateActiveBinding == binding
+        else { return }
+        let continuation = session.codexHookReviewContinuation
+        session.codexHookReviewContinuation = nil
+        session.pendingCodexHookReview = nil
+        session.codexHookGateAttemptToken = nil
+        session.codexHookGateInventoryFingerprint = nil
+        session.codexHookGateActiveBinding = nil
+        session.codexHookGateBindingMemo = binding
+        session.codexHookGateAudit = AgentCodexHookGateAudit(
+            status: status,
+            approvedCount: approvedCount,
+            skippedCount: skippedCount,
+            resolvedAt: Date(),
+            interactionID: request.id
+        )
+        session.appendItem(AgentChatItem.system(
+            notice,
+            sequenceIndex: session.nextSequenceIndex
+        ))
+        viewModel?.scheduleSave(for: session.tabID)
+        publishCodexHookGateState(for: session)
+        continuation?.resume()
     }
 
     private static func isCodexWaitingOnUserInputFlag(_ flag: String) -> Bool {
@@ -643,6 +1171,7 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
         }
         if activeFlags.contains(where: Self.isCodexWaitingOnApprovalFlag),
            session.pendingApproval == nil,
+           !session.hasPendingCodexHookReviewWait,
            session.pendingPermissionsRequest == nil,
            session.pendingMCPElicitationRequest == nil,
            session.queuedMCPElicitationRequests.isEmpty,
@@ -2531,6 +3060,18 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
         expectedQueueID: UUID,
         beginsSuccessorAttempt: Bool
     ) async -> Bool {
+        guard let queuedHead = session.codexFallbackQueue.first,
+              queuedHead.id == expectedQueueID,
+              let controller = session.codexController,
+              ObjectIdentifier(controller) == queuedHead.originControllerInstanceID
+        else {
+            return false
+        }
+        do {
+            try await gateFirstTurnForProjectHooks(session: session, controller: controller)
+        } catch {
+            return false
+        }
         guard let head = claimCodexFallbackHead(
             session: session,
             expectedQueueID: expectedQueueID,
@@ -2557,6 +3098,7 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
             return
         }
         do {
+            updateCodexStallWatchdogState(for: session)
             _ = try await controller.startUserTurn(
                 text: head.providerText,
                 images: head.images,
@@ -2771,12 +3313,24 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
         status: CodexNativeSessionController.TurnStatus,
         completedIdentity: AgentTabSession.CodexAuthoritativeTurnIdentity?,
         session: AgentTabSession
-    ) -> AgentRunTerminalCommitBarrier.ProviderSuccessor? {
+    ) async -> AgentRunTerminalCommitBarrier.ProviderSuccessor? {
         guard status == .completed,
               let turnID,
               let completedIdentity,
               completedIdentity.turnID == turnID,
-              var head = session.codexFallbackQueue.first,
+              let queuedHead = session.codexFallbackQueue.first,
+              queuedHead.state == .queued,
+              queuedHead.blockingTurn == codexFallbackBlockingTurn(for: completedIdentity),
+              let controller = session.codexController,
+              ObjectIdentifier(controller) == queuedHead.originControllerInstanceID
+        else { return nil }
+        do {
+            try await gateFirstTurnForProjectHooks(session: session, controller: controller)
+        } catch {
+            return nil
+        }
+        guard var head = session.codexFallbackQueue.first,
+              head.id == queuedHead.id,
               head.state == .queued,
               head.blockingTurn == codexFallbackBlockingTurn(for: completedIdentity)
         else { return nil }
@@ -4358,6 +4912,7 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
             guard replayTurn.expectedTurnID == nil else {
                 return false
             }
+            try await gateFirstTurnForProjectHooks(session: session, controller: controller)
             _ = try await controller.startUserTurn(
                 text: replayTurn.text,
                 images: replayTurn.images,
@@ -5575,6 +6130,7 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
             setRunningStatus("Sending message…", source: .transport, session: session, urgent: true)
             switch dispatchPlan {
             case .start:
+                try await gateFirstTurnForProjectHooks(session: session, controller: controller)
                 beginTrackedCodexUserTurn(session)
                 updateCodexStallWatchdogState(for: session)
                 logCodex("[AgentModeVM] sendCodexNativeMessage: calling controller.startUserTurn")
@@ -5740,13 +6296,6 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
             )
         } catch {
             session.codexPendingTurnKind = nil
-            guard session.runID == sendRunID,
-                  let activeController = session.codexController,
-                  Self.sameCodexControllerInstance(activeController, controller)
-            else {
-                logCodex("[AgentModeVM] sendCodexNativeMessage: ignoring late send error for stale controller - \(error.localizedDescription)")
-                return .stale(reason: "Codex ignored a late send failure because the active run/controller changed.")
-            }
             if error is CancellationError {
                 clearCodexPendingAuthRetryTurn(session)
                 if terminalizeRejectedSend {
@@ -5766,6 +6315,13 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
                     viewModel?.requestUIRefresh(tabID: session.tabID, urgent: true)
                 }
                 return .cancelled
+            }
+            guard session.runID == sendRunID,
+                  let activeController = session.codexController,
+                  Self.sameCodexControllerInstance(activeController, controller)
+            else {
+                logCodex("[AgentModeVM] sendCodexNativeMessage: ignoring late send error for stale controller - \(error.localizedDescription)")
+                return .stale(reason: "Codex ignored a late send failure because the active run/controller changed.")
             }
             logCodex("[AgentModeVM] sendCodexNativeMessage: error - \(error)")
             if await attemptManagedCodexAuthRecovery(
@@ -7192,7 +7748,7 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
             }
             let turnKind = completion.turnKind
             let completedIdentity = completion.authoritativeIdentity
-            let providerSuccessor = codexFallbackSuccessorForCompletion(
+            let providerSuccessor = await codexFallbackSuccessorForCompletion(
                 turnID: turnID,
                 status: status,
                 completedIdentity: completedIdentity,

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Codex/CodexAgentModeCoordinator.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Codex/CodexAgentModeCoordinator.swift
@@ -1086,14 +1086,15 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
                 )
                 return
             }
+            let selectionSkippedCount = max(0, request.hooks.count - candidates.count)
             completeCodexHookReview(
                 session: session,
                 request: request,
                 binding: binding,
                 status: status,
                 approvedCount: candidates.count,
-                skippedCount: max(0, request.hooks.count - candidates.count),
-                notice: "Trusted \(candidates.count) Codex project hook(s); \(max(0, request.hooks.count - candidates.count)) remain untrusted for this controller binding."
+                skippedCount: selectionSkippedCount,
+                notice: "Trusted \(candidates.count) Codex project hook(s); \(verifiedUnresolvedIdentities.count) remain untrusted for this controller binding."
             )
         } catch is CancellationError {
             guard session.codexHookGateAttemptToken == token else { return }

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Codex/CodexAgentModeCoordinator.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Codex/CodexAgentModeCoordinator.swift
@@ -887,24 +887,27 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
 
         switch decision {
         case .continueWithoutHooks:
-            guard request.phase.allowsApprovalDecision else {
+            guard request.phase.allowsContinueWithoutHooks else {
                 throw AgentCodexHookReviewResolutionError.invalidDecision
             }
             guard !isCodexHookApprovalStrictModeEnabled() else {
                 throw AgentCodexHookReviewResolutionError.strictModeRequiresApproval
             }
+            let skippedCount = request.phase == .discoveryFailed ? nil : request.hooks.count
+            let skippedDescription = skippedCount.map { "\($0) Codex project hook(s)" }
+                ?? "an unknown number of Codex project hooks"
             completeCodexHookReview(
                 session: session,
                 request: request,
                 binding: binding,
                 status: .continuedWithoutHooks,
                 approvedCount: 0,
-                skippedCount: request.hooks.count,
-                notice: "Continued without trusting \(request.hooks.count) Codex project hook(s). The hooks remain untrusted for this controller binding."
+                skippedCount: skippedCount,
+                notice: "Continued without trusting \(skippedDescription). The hooks remain untrusted for this controller binding."
             )
 
         case .retryDiscovery:
-            guard request.phase == .discoveryFailed else {
+            guard request.phase.allowsDiscoveryRetry else {
                 throw AgentCodexHookReviewResolutionError.invalidDecision
             }
             request.phase = .discovering
@@ -985,7 +988,7 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
         controller: any CodexSessionControlling,
         binding: AgentTabSession.CodexHookGateBindingIdentity
     ) async throws {
-        guard request.phase.allowsApprovalDecision else {
+        guard request.phase.allowsTrustDecision else {
             throw AgentCodexHookReviewResolutionError.invalidDecision
         }
         guard let fingerprint = session.codexHookGateInventoryFingerprint else {
@@ -1107,7 +1110,7 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
         binding: AgentTabSession.CodexHookGateBindingIdentity,
         status: AgentCodexHookGateAudit.Status,
         approvedCount: Int,
-        skippedCount: Int,
+        skippedCount: Int?,
         notice: String
     ) {
         guard session.pendingCodexHookReview?.id == request.id,

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Codex/CodexAgentModeCoordinator.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Codex/CodexAgentModeCoordinator.swift
@@ -818,29 +818,54 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
         }
     }
 
+    private func awaitActiveCodexHookGate(
+        session: AgentTabSession,
+        binding: AgentTabSession.CodexHookGateBindingIdentity
+    ) async throws {
+        let waiterID = UUID()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                guard !Task.isCancelled,
+                      session.codexHookGateActiveBinding == binding,
+                      session.hasActiveCodexHookGateOperation
+                else {
+                    continuation.resume(throwing: CancellationError())
+                    return
+                }
+                session.codexHookGateCoalescedContinuations[waiterID] = continuation
+            }
+        } onCancel: { [weak session] in
+            Task { @MainActor in
+                session?.cancelCodexHookGateCoalescedWaiter(waiterID)
+            }
+        }
+    }
+
     private func gateFirstTurnForProjectHooks(
         session: AgentTabSession,
         controller: any CodexSessionControlling
-    ) async throws {
+    ) async throws -> UUID? {
         let binding = codexHookGateBinding(for: session, controller: controller)
-        if session.codexHookGateBindingMemo == binding {
-            return
-        }
-        guard !session.hasPendingCodexHookReviewWait else {
+        if session.hasActiveCodexHookGateOperation {
             guard session.codexHookGateActiveBinding == binding else {
                 throw AgentCodexHookReviewResolutionError.staleController
             }
-            try await suspendForCodexHookReview(session: session, binding: binding)
+            try await awaitActiveCodexHookGate(session: session, binding: binding)
             synchronizeCodexThreadReferenceAfterHookGate(
                 session: session,
                 controller: controller
             )
-            return
+            return nil
+        }
+        if session.codexHookGateBindingMemo == binding {
+            return nil
         }
 
         session.codexHookGateGeneration &+= 1
         session.codexHookGateActiveBinding = binding
         session.codexHookGateAudit = nil
+        let dispatchOwnerToken = UUID()
+        session.codexHookGateDispatchOwnerToken = dispatchOwnerToken
         let attemptToken = UUID()
         session.codexHookGateAttemptToken = attemptToken
         let authority = CodexHookGateOperationAuthority(
@@ -858,14 +883,13 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
             let unresolved = inventory.unresolvedProjectHooks
             if unresolved.isEmpty {
                 session.codexHookGateAttemptToken = nil
-                session.codexHookGateActiveBinding = nil
                 session.codexHookGateInventoryFingerprint = nil
                 session.codexHookGateBindingMemo = binding
                 synchronizeCodexThreadReferenceAfterHookGate(
                     session: session,
                     controller: controller
                 )
-                return
+                return dispatchOwnerToken
             }
             session.codexHookGateAttemptToken = nil
             session.codexHookGateInventoryFingerprint = inventory.fingerprint
@@ -903,6 +927,7 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
             session: session,
             controller: controller
         )
+        return dispatchOwnerToken
     }
 
     func resolveCodexHookReview(
@@ -1185,7 +1210,6 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
         session.pendingCodexHookReview = nil
         session.codexHookGateAttemptToken = nil
         session.codexHookGateInventoryFingerprint = nil
-        session.codexHookGateActiveBinding = nil
         session.codexHookGateBindingMemo = binding
         session.codexHookGateAudit = AgentCodexHookGateAudit(
             status: status,
@@ -3134,10 +3158,23 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
         else {
             return false
         }
+        let hookGateDispatchOwnerToken: UUID?
         do {
-            try await gateFirstTurnForProjectHooks(session: session, controller: controller)
+            hookGateDispatchOwnerToken = try await gateFirstTurnForProjectHooks(
+                session: session,
+                controller: controller
+            )
         } catch {
             return false
+        }
+        var dispatched = false
+        defer {
+            if let hookGateDispatchOwnerToken {
+                session.finishCodexHookGateOwnerDispatch(
+                    token: hookGateDispatchOwnerToken,
+                    succeeded: dispatched
+                )
+            }
         }
         guard let head = claimCodexFallbackHead(
             session: session,
@@ -3146,14 +3183,15 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
         ) else {
             return false
         }
-        await dispatchClaimedCodexFallback(head, session: session)
+        dispatched = await dispatchClaimedCodexFallback(head, session: session)
         return true
     }
 
+    @discardableResult
     private func dispatchClaimedCodexFallback(
         _ head: AgentTabSession.CodexFallbackQueueEntry,
         session: AgentTabSession
-    ) async {
+    ) async -> Bool {
         guard let controller = session.codexController,
               ObjectIdentifier(controller) == head.originControllerInstanceID
         else {
@@ -3162,7 +3200,7 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
                 entry: head,
                 message: "Codex queued follow-up lost its controller before dispatch."
             )
-            return
+            return false
         }
         do {
             updateCodexStallWatchdogState(for: session)
@@ -3176,7 +3214,7 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
             guard var inFlight = session.codexFallbackDispatchInFlight,
                   inFlight.id == head.id,
                   session.codexController.map(ObjectIdentifier.init) == head.originControllerInstanceID
-            else { return }
+            else { return true }
             if case .lifecycleStarted = inFlight.state {
                 session.codexFallbackDispatchInFlight = nil
             } else {
@@ -3196,12 +3234,14 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
                     stage: .running
                 )
             }
+            return true
         } catch {
             await failCodexFallbackDispatch(
                 session: session,
                 entry: head,
                 message: "Codex queued follow-up failed to start: \(error.localizedDescription)"
             )
+            return false
         }
     }
 
@@ -3391,10 +3431,23 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
               let controller = session.codexController,
               ObjectIdentifier(controller) == queuedHead.originControllerInstanceID
         else { return nil }
+        let hookGateDispatchOwnerToken: UUID?
         do {
-            try await gateFirstTurnForProjectHooks(session: session, controller: controller)
+            hookGateDispatchOwnerToken = try await gateFirstTurnForProjectHooks(
+                session: session,
+                controller: controller
+            )
         } catch {
             return nil
+        }
+        var claimedSuccessor = false
+        defer {
+            if let hookGateDispatchOwnerToken {
+                session.finishCodexHookGateOwnerDispatch(
+                    token: hookGateDispatchOwnerToken,
+                    succeeded: claimedSuccessor
+                )
+            }
         }
         guard var head = session.codexFallbackQueue.first,
               head.id == queuedHead.id,
@@ -3403,6 +3456,7 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
         else { return nil }
         head.state = .eligibleForSuccessor(completedTurnID: turnID)
         session.codexFallbackQueue[0] = head
+        claimedSuccessor = true
         return .init(
             id: head.id,
             transitionKind: .relatedFollowUp,
@@ -4988,7 +5042,19 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
             guard replayTurn.expectedTurnID == nil else {
                 return false
             }
-            try await gateFirstTurnForProjectHooks(session: session, controller: controller)
+            let hookGateDispatchOwnerToken = try await gateFirstTurnForProjectHooks(
+                session: session,
+                controller: controller
+            )
+            var dispatched = false
+            defer {
+                if let hookGateDispatchOwnerToken {
+                    session.finishCodexHookGateOwnerDispatch(
+                        token: hookGateDispatchOwnerToken,
+                        succeeded: dispatched
+                    )
+                }
+            }
             _ = try await controller.startUserTurn(
                 text: replayTurn.text,
                 images: replayTurn.images,
@@ -4996,6 +5062,7 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
                 reasoningEffort: replayTurn.reasoningEffort,
                 serviceTier: replayTurn.serviceTier
             )
+            dispatched = true
             await applySuccessfulCodexNativeSend(
                 for: session,
                 runID: runID,
@@ -6206,17 +6273,32 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
             setRunningStatus("Sending message…", source: .transport, session: session, urgent: true)
             switch dispatchPlan {
             case .start:
-                try await gateFirstTurnForProjectHooks(session: session, controller: controller)
-                beginTrackedCodexUserTurn(session)
-                updateCodexStallWatchdogState(for: session)
-                logCodex("[AgentModeVM] sendCodexNativeMessage: calling controller.startUserTurn")
-                _ = try await controller.startUserTurn(
-                    text: text,
-                    images: attachments,
-                    model: selection.model,
-                    reasoningEffort: selection.reasoningEffort,
-                    serviceTier: selection.serviceTier
+                let hookGateDispatchOwnerToken = try await gateFirstTurnForProjectHooks(
+                    session: session,
+                    controller: controller
                 )
+                var dispatched = false
+                do {
+                    defer {
+                        if let hookGateDispatchOwnerToken {
+                            session.finishCodexHookGateOwnerDispatch(
+                                token: hookGateDispatchOwnerToken,
+                                succeeded: dispatched
+                            )
+                        }
+                    }
+                    beginTrackedCodexUserTurn(session)
+                    updateCodexStallWatchdogState(for: session)
+                    logCodex("[AgentModeVM] sendCodexNativeMessage: calling controller.startUserTurn")
+                    _ = try await controller.startUserTurn(
+                        text: text,
+                        images: attachments,
+                        model: selection.model,
+                        reasoningEffort: selection.reasoningEffort,
+                        serviceTier: selection.serviceTier
+                    )
+                    dispatched = true
+                }
             case let .steer(identity):
                 logCodex("[AgentModeVM] sendCodexNativeMessage: calling controller.steerUserTurn expectedTurnID=\(identity.turnID)")
                 do {
@@ -8843,6 +8925,22 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
             _ gate: (@Sendable () async -> Void)?
         ) {
             testWorkspaceResolutionFailurePublicationGate = gate
+        }
+
+        @_spi(TestSupport)
+        public func test_gateFirstTurnForProjectHooks(
+            session: AgentTabSession,
+            controller: any CodexSessionControlling
+        ) async throws {
+            if let dispatchOwnerToken = try await gateFirstTurnForProjectHooks(
+                session: session,
+                controller: controller
+            ) {
+                session.finishCodexHookGateOwnerDispatch(
+                    token: dispatchOwnerToken,
+                    succeeded: true
+                )
+            }
         }
 
         @_spi(TestSupport)

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Codex/CodexAgentModeCoordinator.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Codex/CodexAgentModeCoordinator.swift
@@ -3967,6 +3967,15 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
         ObjectIdentifier(lhs as AnyObject) == ObjectIdentifier(rhs as AnyObject)
     }
 
+    private static func capturedSendIsCurrent(
+        session: AgentTabSession,
+        sendRunID: UUID,
+        controller: any CodexSessionControlling
+    ) -> Bool {
+        session.runID == sendRunID
+            && session.codexController.map { sameCodexControllerInstance($0, controller) } == true
+    }
+
     private func clearCodexRecoveryAttempt(
         for runID: UUID?,
         runAttemptID: UUID? = nil
@@ -6289,10 +6298,11 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
             return .sent
         } catch let steerError as CodexTurnSteerError {
             session.codexPendingTurnKind = nil
-            guard session.runID == sendRunID,
-                  let activeController = session.codexController,
-                  Self.sameCodexControllerInstance(activeController, controller)
-            else {
+            guard Self.capturedSendIsCurrent(
+                session: session,
+                sendRunID: sendRunID,
+                controller: controller
+            ) else {
                 return .stale(reason: "Codex ignored a late steer rejection because the active run/controller changed.")
             }
             let decision: CodexTurnFallbackDecision = switch steerError {
@@ -6319,8 +6329,20 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
                 controller: controller
             )
         } catch {
-            session.codexPendingTurnKind = nil
             if error is CancellationError {
+                guard Self.capturedSendIsCurrent(
+                    session: session,
+                    sendRunID: sendRunID,
+                    controller: controller
+                ) else {
+                    viewModel?.finalizeAttachmentsForTurn(
+                        for: session,
+                        reservationID: attachmentReservationID,
+                        disposition: .restoreToPending
+                    )
+                    return .stale(reason: "Codex ignored a late send cancellation because the active run/controller changed.")
+                }
+                session.codexPendingTurnKind = nil
                 clearCodexPendingAuthRetryTurn(session)
                 if terminalizeRejectedSend {
                     await finalizeCodexRun(
@@ -6340,10 +6362,12 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
                 }
                 return .cancelled
             }
-            guard session.runID == sendRunID,
-                  let activeController = session.codexController,
-                  Self.sameCodexControllerInstance(activeController, controller)
-            else {
+            session.codexPendingTurnKind = nil
+            guard Self.capturedSendIsCurrent(
+                session: session,
+                sendRunID: sendRunID,
+                controller: controller
+            ) else {
                 logCodex("[AgentModeVM] sendCodexNativeMessage: ignoring late send error for stale controller - \(error.localizedDescription)")
                 return .stale(reason: "Codex ignored a late send failure because the active run/controller changed.")
             }

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Codex/CodexAgentModeCoordinator.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Codex/CodexAgentModeCoordinator.swift
@@ -1031,7 +1031,11 @@ final class CodexAgentModeCoordinator: AgentModeRunInteractionStateObserving {
             let expectedSkippedIdentities = Set(request.trustCandidates.map(\.selectionIdentity))
                 .subtracting(approvedIdentities)
             let verifiedUnresolvedIdentities = Set(verified.unresolvedProjectHooks.map(\.selectionIdentity))
-            guard verifiedUnresolvedIdentities.isSubset(of: expectedSkippedIdentities) else {
+            let strictModeRequiresRefresh = isCodexHookApprovalStrictModeEnabled()
+                && !verifiedUnresolvedIdentities.isEmpty
+            guard !strictModeRequiresRefresh,
+                  verifiedUnresolvedIdentities.isSubset(of: expectedSkippedIdentities)
+            else {
                 applyCodexHookInventoryRefresh(
                     verified,
                     session: session,

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/CodexIntegratedAgentModeRunner.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Runners/CodexIntegratedAgentModeRunner.swift
@@ -51,7 +51,7 @@ final class CodexIntegratedAgentModeRunner {
                 guard mcpServerReady else {
                     return .failed(message: "MCP catalog registration failed before Agent launch.")
                 }
-                return await codexCoordinator.sendCodexNativeMessage(
+                let outcome = await self.codexCoordinator.sendCodexNativeMessage(
                     session: session,
                     text: initialMessageForRun,
                     attachments: attachments,
@@ -59,6 +59,13 @@ final class CodexIntegratedAgentModeRunner {
                     attachmentReservationID: attachmentReservationID,
                     terminalizeRejectedSend: createdOwnership
                 )
+                // Explicit cancellation can terminalize the original run before its
+                // suspended send observes CancellationError. Preserve the caller-level
+                // cancellation signal when there is no active successor to protect.
+                if case .stale = outcome, Task.isCancelled, !session.runState.isActive {
+                    return .cancelled
+                }
+                return outcome
             }
             let outcome = execution.nativeOutcome
             hooks.providerInput.recordPendingHandoffSendOutcome(session, outcome.didSend)

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+InteractionActions.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+InteractionActions.swift
@@ -25,6 +25,30 @@ extension AgentModeViewModel {
         }
     }
 
+    func submitCodexHookReviewDecision(
+        tabID: UUID,
+        requestID: UUID,
+        decision: AgentCodexHookReviewDecision
+    ) async throws {
+        guard let session = sessions[tabID],
+              let currentRequest = session.pendingCodexHookReview
+        else {
+            throw AgentCodexHookReviewResolutionError.noPendingReview
+        }
+        guard currentRequest.id == requestID else {
+            throw AgentCodexHookReviewResolutionError.staleRequest(currentID: currentRequest.id)
+        }
+        try await codexCoordinator.resolveCodexHookReview(
+            session: session,
+            requestID: requestID,
+            decision: decision
+        )
+    }
+
+    func isCodexHookApprovalStrictModeEnabled() -> Bool {
+        codexCoordinator.isCodexHookApprovalStrictModeEnabled()
+    }
+
     func submitMCPElicitationResponse(
         tabID: UUID,
         requestID: UUID,

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+RunInteractionUI.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+RunInteractionUI.swift
@@ -14,6 +14,7 @@ extension AgentModeViewModel {
             pendingAskUser: pendingAskUser(for: tabID),
             pendingUserInputRequest: pendingUserInputRequest(for: tabID),
             pendingApproval: pendingApproval(for: tabID),
+            pendingCodexHookReview: pendingCodexHookReview(for: tabID),
             pendingPermissionsRequest: pendingPermissionsRequest(for: tabID),
             pendingMCPElicitationRequest: pendingMCPElicitationRequest(for: tabID),
             pendingApplyEditsReview: pendingApplyEditsReview(for: tabID),

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+Types.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+Types.swift
@@ -413,12 +413,20 @@ extension AgentModeViewModel {
             case nonScalar
         }
 
+        enum AnswerValueShape: Equatable {
+            case scalarString
+            case stringArray
+            case structuredObject
+        }
+
+        let suppliedArgumentNames: Set<String>
         let text: String?
         let skip: Bool
         let explicitSkip: Bool
         let responseArgument: ResponseArgument
-        let containsDecisionArgument: Bool
         let amendment: String?
+        let answerValueShapesByQuestionID: [String: AnswerValueShape]
+        let hasNormalizedAnswerFieldNames: Bool
         let answersByQuestionID: [String: [String]]
         let askUserAnswersByQuestionID: [String: AgentAskUserAnswer]
         let hasStructuredAnswerObjects: Bool
@@ -427,12 +435,14 @@ extension AgentModeViewModel {
         let elicitationMeta: [String: AgentJSONValue]
 
         init(
+            suppliedArgumentNames: Set<String> = [],
             text: String?,
             skip: Bool,
             explicitSkip: Bool = false,
             responseArgument: ResponseArgument,
-            containsDecisionArgument: Bool,
             amendment: String?,
+            answerValueShapesByQuestionID: [String: AnswerValueShape] = [:],
+            hasNormalizedAnswerFieldNames: Bool = false,
             answersByQuestionID: [String: [String]],
             askUserAnswersByQuestionID: [String: AgentAskUserAnswer] = [:],
             hasStructuredAnswerObjects: Bool = false,
@@ -440,18 +450,24 @@ extension AgentModeViewModel {
             elicitationContent: [String: AgentJSONValue] = [:],
             elicitationMeta: [String: AgentJSONValue] = [:]
         ) {
+            self.suppliedArgumentNames = suppliedArgumentNames
             self.text = text
             self.skip = skip
             self.explicitSkip = explicitSkip
             self.responseArgument = responseArgument
-            self.containsDecisionArgument = containsDecisionArgument
             self.amendment = amendment
+            self.answerValueShapesByQuestionID = answerValueShapesByQuestionID
+            self.hasNormalizedAnswerFieldNames = hasNormalizedAnswerFieldNames
             self.answersByQuestionID = answersByQuestionID
             self.askUserAnswersByQuestionID = askUserAnswersByQuestionID
             self.hasStructuredAnswerObjects = hasStructuredAnswerObjects
             self.elicitationActionRaw = elicitationActionRaw
             self.elicitationContent = elicitationContent
             self.elicitationMeta = elicitationMeta
+        }
+
+        func containsArgument(_ name: String) -> Bool {
+            suppliedArgumentNames.contains(name)
         }
     }
 

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -1720,6 +1720,7 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
             codexControllerFactory: codexControllerFactory,
             connectionPolicyInstaller: connectionPolicyInstaller,
             shouldManageCodexTooling: true,
+            codexHookApprovalSettings: GlobalSettingsStore.shared,
             activeToolQuery: { [weak mcpServer] runID in
                 mcpServer?.hasActiveToolExecutions(runID: runID) ?? false
             },
@@ -1855,6 +1856,8 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
             testMCPServer: MCPServerViewModel? = nil,
             testWorkspaceFileContextStore: WorkspaceFileContextStore? = nil,
             testCodexActiveToolQuery: CodexActiveToolQuery? = nil,
+            testCodexManagedAuthRecovery: (any CodexManagedAuthRecovering)? = nil,
+            testCodexHookApprovalSettingsProvider: (any CodexHookApprovalSettingsProviding)? = nil,
             testCodexActiveAgentRunWaitQuery: CodexAgentRunWaitQuery? = nil,
             testCodexActiveAgentRunWaitDrain: CodexAgentRunWaitDrain? = nil,
             testCodexLeaseRoutingTimeoutMs: Int? = nil,
@@ -1915,6 +1918,8 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
                 codexControllerFactory: codexControllerFactory,
                 connectionPolicyInstaller: connectionPolicyInstaller,
                 shouldManageCodexTooling: shouldManageCodexTooling,
+                authRecovery: testCodexManagedAuthRecovery ?? CodexManagedAuthRecoveryService.shared,
+                codexHookApprovalSettings: testCodexHookApprovalSettingsProvider ?? GlobalSettingsStore.shared,
                 activeToolQuery: testCodexActiveToolQuery
                     ?? { [weak testMCPServer] runID in
                         testMCPServer?.hasActiveToolExecutions(runID: runID) ?? false
@@ -2934,6 +2939,7 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         if session.mcpControlContext != nil { return true }
         if session.hasPendingQuestionUI { return true }
         if session.pendingApproval != nil { return true }
+        if session.hasPendingCodexHookReviewWait { return true }
         if session.pendingPermissionsRequest != nil { return true }
         if session.pendingMCPElicitationRequest != nil { return true }
         if session.pendingApplyEditsReview != nil { return true }
@@ -4007,7 +4013,7 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
     }
 
     func reconcileInteractiveRunState(_ session: TabSession) {
-        let nextState: AgentSessionRunState? = if session.pendingApplyEditsReview != nil || session.pendingWorktreeMergeReview != nil || session.pendingApproval != nil || session.pendingPermissionsRequest != nil || session.pendingMCPElicitationRequest != nil {
+        let nextState: AgentSessionRunState? = if session.pendingApplyEditsReview != nil || session.pendingWorktreeMergeReview != nil || session.pendingApproval != nil || session.hasPendingCodexHookReviewRequest || session.pendingPermissionsRequest != nil || session.pendingMCPElicitationRequest != nil {
             .waitingForApproval
         } else if session.hasPendingQuestionUI {
             .waitingForQuestion
@@ -5110,6 +5116,9 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         session.pendingAskUser = nil
         session.pendingUserInputRequest = nil
         session.pendingApproval = nil
+        if session.hasActiveCodexHookGateOperation {
+            session.resetCodexHookGateBinding()
+        }
         session.pendingPermissionsRequest = nil
         session.pendingMCPElicitationRequest = nil
         session.pendingApplyEditsReview = nil
@@ -5149,6 +5158,8 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
             session.$pendingAskUser.map { _ in () }.eraseToAnyPublisher(),
             session.$pendingUserInputRequest.map { _ in () }.eraseToAnyPublisher(),
             session.$pendingApproval.map { _ in () }.eraseToAnyPublisher(),
+            session.$pendingCodexHookReview.map { _ in () }.eraseToAnyPublisher(),
+            session.$codexHookGateAudit.map { _ in () }.eraseToAnyPublisher(),
             session.$pendingPermissionsRequest.map { _ in () }.eraseToAnyPublisher(),
             session.$pendingMCPElicitationRequest.map { _ in () }.eraseToAnyPublisher(),
             session.$pendingApplyEditsReview.map { _ in () }.eraseToAnyPublisher(),
@@ -12481,7 +12492,7 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
             return .failed(.init(operation: .save, tabID: tabID, message: "Active workspace is unavailable."))
         }
 
-        let hasConversationContent = !session.items.isEmpty || !session.transcript.turns.isEmpty || session.runState.isActive || session.hasPendingQuestionUI || session.pendingApproval != nil || session.pendingPermissionsRequest != nil || session.pendingApplyEditsReview != nil || session.pendingWorktreeMergeReview != nil || session.worktreeMergeOperations.contains { $0.status.isActive }
+        let hasConversationContent = !session.items.isEmpty || !session.transcript.turns.isEmpty || session.runState.isActive || session.hasPendingQuestionUI || session.pendingApproval != nil || session.hasPendingCodexHookReviewWait || session.pendingPermissionsRequest != nil || session.pendingApplyEditsReview != nil || session.pendingWorktreeMergeReview != nil || session.worktreeMergeOperations.contains { $0.status.isActive }
         if session.activeAgentSessionID == nil, !hasConversationContent {
             return .notRequired
         }
@@ -13943,7 +13954,15 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
                         )
                     }
                 }
-                if case let .preDispatchRejected(message)? = sendOutcome,
+                let rejectedManualSubmissionMessage: String? = switch sendOutcome {
+                case let .preDispatchRejected(message)?:
+                    message
+                case .cancelled?:
+                    "Codex send was cancelled before provider dispatch."
+                default:
+                    nil
+                }
+                if let rejectedManualSubmissionMessage,
                    codexAttemptID == nil
                 {
                     // The dispatch ticket remains held through this synchronous
@@ -13965,7 +13984,7 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
                             taggedFiles: taggedFilesToSend,
                             selectedWorkflow: restorationSelectedWorkflow,
                             selectedWorkflowMutationGeneration: restorationSelectedWorkflowMutationGeneration,
-                            message: message
+                            message: rejectedManualSubmissionMessage
                         )
                     }
                 } else {
@@ -16813,7 +16832,7 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         if session.pendingAskUser != nil {
             throw MCPError.invalidParams("ask_user is already waiting for a response in this session.")
         }
-        if session.pendingApproval != nil || session.pendingPermissionsRequest != nil || session.pendingApplyEditsReview != nil || session.pendingWorktreeMergeReview != nil {
+        if session.pendingApproval != nil || session.hasPendingCodexHookReviewWait || session.pendingPermissionsRequest != nil || session.pendingApplyEditsReview != nil || session.pendingWorktreeMergeReview != nil {
             throw MCPError.invalidParams("ask_user cannot be shown while an approval is pending.")
         }
         if session.pendingMCPElicitationRequest != nil || !session.queuedMCPElicitationRequests.isEmpty {
@@ -17047,6 +17066,9 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
 
     private func cancelPendingApproval(for session: TabSession) {
         session.pendingApproval = nil
+        if session.hasActiveCodexHookGateOperation {
+            session.resetCodexHookGateBinding()
+        }
         session.pendingPermissionsRequest = nil
         session.pendingMCPElicitationRequest = nil
         session.queuedMCPElicitationRequests.removeAll()
@@ -17914,6 +17936,7 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         let hasPendingInteraction = session.runState == .waitingForUser
             || session.hasPendingQuestionUI
             || session.pendingApproval != nil
+            || session.hasPendingCodexHookReviewWait
             || session.pendingPermissionsRequest != nil
             || session.pendingApplyEditsReview != nil
         let hasActiveRun = session.runState.isActive

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -5880,6 +5880,7 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
             statusText: resolvedStatusText,
             latestAssistantPreview: mcpResolvedAssistantPreview(session: session, status: status),
             interaction: interaction,
+            hookGate: session.codexHookGateAudit.map { AgentRunMCPSnapshot.HookGate(audit: $0) },
             transcriptItemCount: transcriptItemCount,
             updatedAt: Date(),
             parentSessionID: session.parentSessionID,
@@ -5923,7 +5924,7 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
     }
 
     private func mcpCanonicalApprovalResponse(from payload: MCPInteractionResponsePayload) throws -> String {
-        if payload.containsDecisionArgument {
+        if payload.containsArgument("decision") {
             throw MCPError.invalidParams(
                 "decision is not a supported field for agent_run op=respond. For approval interactions, use the top-level scalar response field, for example response=\"accept\". No response was applied."
             )
@@ -5949,7 +5950,152 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         }
     }
 
+    private enum MCPCodexHookAction: String {
+        case approveSelected = "approve_selected"
+        case trustAll = "trust_all"
+        case continueWithoutHooks = "continue_without_hooks"
+        case retry
+
+        var option: AgentRunMCPSnapshot.Interaction.Option {
+            switch self {
+            case .approveSelected:
+                .init(label: rawValue, description: "Trust only the hook_keys answer and continue")
+            case .trustAll:
+                .init(label: rawValue, description: "Trust every hook shown and continue")
+            case .continueWithoutHooks:
+                .init(
+                    label: rawValue,
+                    description: "Continue this Codex session without enabling the shown project hooks"
+                )
+            case .retry:
+                .init(label: rawValue, description: "Retry project-hook discovery")
+            }
+        }
+    }
+
+    private func mcpCodexHookDecisionOptions(
+        for request: AgentCodexHookReviewRequest,
+        strictModeEnabled: Bool
+    ) -> [AgentRunMCPSnapshot.Interaction.Option] {
+        var actions = [MCPCodexHookAction]()
+        if request.phase.allowsTrustDecision {
+            actions.append(contentsOf: [.approveSelected, .trustAll])
+        }
+        if request.phase.allowsDiscoveryRetry {
+            actions.append(.retry)
+        }
+        if request.phase.allowsContinueWithoutHooks, !strictModeEnabled {
+            actions.append(.continueWithoutHooks)
+        }
+        return actions.map(\.option)
+    }
+
+    private func mcpCodexHookInteraction(
+        for request: AgentCodexHookReviewRequest,
+        strictModeEnabled: Bool
+    ) -> AgentRunMCPSnapshot.Interaction {
+        var details: [AgentRunMCPSnapshot.Interaction.Detail] = [
+            .init(label: "Execution Directory", value: request.executionCWD, isCode: true),
+            .init(label: "Phase", value: request.phase.rawValue, isCode: false)
+        ]
+        if let errorMessage = request.errorMessage, !errorMessage.isEmpty {
+            details.append(.init(label: "Error", value: errorMessage, isCode: false))
+        }
+        for warning in request.warnings {
+            details.append(.init(label: "Warning", value: warning, isCode: false))
+        }
+        for (index, hook) in request.hooks.enumerated() {
+            let prefix = "Hook \(index + 1)"
+            details.append(.init(label: "\(prefix) Key", value: hook.key, isCode: true))
+            details.append(.init(label: "\(prefix) Event", value: hook.eventName, isCode: false))
+            details.append(.init(label: "\(prefix) Source", value: hook.sourcePath, isCode: true))
+            details.append(.init(label: "\(prefix) Enabled", value: hook.enabled ? "true" : "false", isCode: false))
+            details.append(.init(label: "\(prefix) Trust", value: hook.trustStatus.rawValue, isCode: false))
+            details.append(.init(label: "\(prefix) Current Hash", value: hook.currentHash, isCode: true))
+            if let command = hook.commandOrHandler, !command.isEmpty {
+                details.append(.init(label: "\(prefix) Command / Handler", value: command, isCode: true))
+            }
+        }
+        let fields: [AgentRunMCPSnapshot.Interaction.Field] = if request.hooks.isEmpty {
+            []
+        } else {
+            [
+                .init(
+                    id: "hook_keys",
+                    prompt: "Hooks to approve",
+                    context: "Provide exact hook keys only when response is approve_selected.",
+                    isSecret: false,
+                    allowsOther: false,
+                    allowsMultiple: true,
+                    allowsCustom: false,
+                    emitAllowsOther: false,
+                    options: request.hooks.map { hook in
+                        .init(
+                            label: hook.key,
+                            description: "\(hook.eventName) · \(hook.sourcePath) · \(hook.trustStatus.rawValue)"
+                        )
+                    }
+                )
+            ]
+        }
+        return .init(
+            id: request.id,
+            kind: .hookApproval,
+            responseType: .decision,
+            title: "Project Hook Approval",
+            prompt: "The initial Codex turn is blocked pending project-hook trust.",
+            context: "Execution directory: \(request.executionCWD)",
+            allowsMultiple: nil,
+            options: mcpCodexHookDecisionOptions(for: request, strictModeEnabled: strictModeEnabled),
+            fields: fields,
+            details: details
+        )
+    }
+
+    private func mcpCanonicalCodexHookResponse(from payload: MCPInteractionResponsePayload) throws -> String {
+        if payload.containsArgument("decision")
+            || payload.containsArgument("skip")
+            || payload.containsArgument("amendment")
+            || payload.containsArgument("content")
+            || payload.containsArgument("meta")
+            || payload.containsArgument("_meta")
+        {
+            throw MCPError.invalidParams(
+                "Hook approval accepts only response and flat string-array answers. decision, skip, amendment, content, and _meta are not supported. No response was applied."
+            )
+        }
+        if payload.hasStructuredAnswerObjects {
+            throw MCPError.invalidParams(
+                "Hook approval answers must use flat string arrays; structured answer objects are not supported. No response was applied."
+            )
+        }
+        switch payload.responseArgument {
+        case .missing:
+            throw MCPError.invalidParams(
+                "response is required for hook approval interactions. No response was applied."
+            )
+        case .nonScalar:
+            throw MCPError.invalidParams(
+                "response must be a non-empty top-level scalar string for hook approval interactions. No response was applied."
+            )
+        case let .scalar(response):
+            let canonical = response.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            guard !canonical.isEmpty else {
+                throw MCPError.invalidParams(
+                    "response must be a non-empty top-level scalar string for hook approval interactions. No response was applied."
+                )
+            }
+            return canonical
+        }
+    }
+
     private func mcpPendingInteraction(for session: TabSession) -> AgentRunMCPSnapshot.Interaction? {
+        if let request = session.pendingCodexHookReview {
+            return mcpCodexHookInteraction(
+                for: request,
+                strictModeEnabled: codexCoordinator.isCodexHookApprovalStrictModeEnabled()
+            )
+        }
         if let review = session.pendingWorktreeMergeReview {
             var details: [AgentRunMCPSnapshot.Interaction.Detail] = [
                 .init(label: "Operation ID", value: review.operationID, isCode: false),
@@ -8473,6 +8619,97 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
             }
             let response = AgentRequestUserInputResponse(answersByQuestionID: answers)
             submitUserInputResponse(tabID: session.tabID, requestID: request.requestID, response: response)
+            handleObservedMCPStateChange(for: session)
+            return nil
+        case .hookApproval:
+            guard let request = session.pendingCodexHookReview,
+                  request.id == interactionID
+            else {
+                throw MCPError.invalidParams("The pending hook approval no longer matches interaction_id.")
+            }
+            guard !request.phase.isResolving else {
+                throw MCPError.invalidParams(AgentCodexHookReviewResolutionError.busy.localizedDescription)
+            }
+            let rawDecision = try mcpCanonicalCodexHookResponse(from: payload)
+            guard let action = MCPCodexHookAction(rawValue: rawDecision) else {
+                throw MCPError.invalidParams(
+                    "response must use one of the canonical decisions advertised by the current hook_approval interaction."
+                )
+            }
+            var allowedArgumentNames = Set(["response"])
+            if action == .approveSelected {
+                allowedArgumentNames.insert("answers")
+            }
+            guard payload.suppliedArgumentNames.isSubset(of: allowedArgumentNames) else {
+                throw MCPError.invalidParams(
+                    "Hook approval received an unsupported top-level argument. No response was applied."
+                )
+            }
+            let decision: AgentCodexHookReviewDecision
+            switch action {
+            case .approveSelected:
+                guard request.phase.allowsTrustDecision else {
+                    throw MCPError.invalidParams(AgentCodexHookReviewResolutionError.invalidDecision.localizedDescription)
+                }
+                guard payload.containsArgument("answers"),
+                      !payload.hasNormalizedAnswerFieldNames,
+                      payload.answerValueShapesByQuestionID == ["hook_keys": .stringArray],
+                      let hookKeys = payload.answersByQuestionID["hook_keys"],
+                      !hookKeys.isEmpty,
+                      Set(hookKeys.map(CodexHookUTF8Identity.init)).count == hookKeys.count
+                else {
+                    throw MCPError.invalidParams(
+                        "approve_selected requires exactly answers={\"hook_keys\": [\"<exact key>\", ...]} with one or more unique hook keys."
+                    )
+                }
+                let availableKeys = Set(request.hooks.map { CodexHookUTF8Identity($0.key) })
+                guard hookKeys.allSatisfy({ availableKeys.contains(CodexHookUTF8Identity($0)) }) else {
+                    throw MCPError.invalidParams(
+                        "approve_selected contains a hook key that is not part of the current interaction. Poll for the latest hook approval snapshot."
+                    )
+                }
+                decision = .approveSelected(hookKeys: hookKeys)
+            case .trustAll:
+                guard request.phase.allowsTrustDecision else {
+                    throw MCPError.invalidParams(AgentCodexHookReviewResolutionError.invalidDecision.localizedDescription)
+                }
+                guard !payload.containsArgument("answers") else {
+                    throw MCPError.invalidParams("trust_all requires the answers argument to be absent.")
+                }
+                decision = .approveAll
+            case .continueWithoutHooks:
+                guard request.phase.allowsContinueWithoutHooks else {
+                    throw MCPError.invalidParams(AgentCodexHookReviewResolutionError.invalidDecision.localizedDescription)
+                }
+                guard !payload.containsArgument("answers") else {
+                    throw MCPError.invalidParams("continue_without_hooks requires the answers argument to be absent.")
+                }
+                guard !codexCoordinator.isCodexHookApprovalStrictModeEnabled() else {
+                    throw MCPError.invalidParams(
+                        AgentCodexHookReviewResolutionError.strictModeRequiresApproval.localizedDescription
+                    )
+                }
+                decision = .continueWithoutHooks
+            case .retry:
+                guard request.phase.allowsDiscoveryRetry else {
+                    throw MCPError.invalidParams(AgentCodexHookReviewResolutionError.invalidDecision.localizedDescription)
+                }
+                guard !payload.containsArgument("answers") else {
+                    throw MCPError.invalidParams("retry requires the answers argument to be absent.")
+                }
+                decision = .retryDiscovery
+            }
+            do {
+                try await codexCoordinator.resolveCodexHookReview(
+                    session: session,
+                    requestID: request.id,
+                    decision: decision
+                )
+            } catch let error as AgentCodexHookReviewResolutionError {
+                throw MCPError.invalidParams(error.localizedDescription)
+            } catch {
+                throw MCPError.invalidParams("The hook approval operation could not be completed. Review the current interaction and retry.")
+            }
             handleObservedMCPStateChange(for: session)
             return nil
         case .approval:
@@ -17410,6 +17647,11 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
     func pendingApproval(for tabID: UUID?) -> AgentApprovalRequest? {
         guard let tabID, let session = sessions[tabID] else { return nil }
         return session.uiPendingApproval
+    }
+
+    func pendingCodexHookReview(for tabID: UUID?) -> AgentCodexHookReviewRequest? {
+        guard let tabID, let session = sessions[tabID] else { return nil }
+        return session.uiPendingCodexHookReview
     }
 
     func pendingPermissionsRequest(for tabID: UUID?) -> AgentPermissionsRequest? {

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentTabSession.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentTabSession.swift
@@ -126,8 +126,10 @@ final class AgentTabSession: ObservableObject {
     @Published var pendingApproval: AgentApprovalRequest? = nil
     @Published var pendingCodexHookReview: AgentCodexHookReviewRequest? = nil
     var codexHookReviewContinuation: CheckedContinuation<Void, Error>?
+    var codexHookGateCoalescedContinuations: [UUID: CheckedContinuation<Void, Error>] = [:]
     var codexHookGateGeneration: UInt64 = 0
     var codexHookGateAttemptToken: UUID?
+    var codexHookGateDispatchOwnerToken: UUID?
     var codexHookGateInventoryFingerprint: String?
     @Published var codexHookGateAudit: AgentCodexHookGateAudit?
     var codexHookGateBindingMemo: CodexHookGateBindingIdentity?
@@ -715,17 +717,49 @@ final class AgentTabSession: ObservableObject {
     }
 
     var hasActiveCodexHookGateOperation: Bool {
-        hasPendingCodexHookReviewWait || codexHookGateAttemptToken != nil
+        hasPendingCodexHookReviewWait
+            || codexHookGateAttemptToken != nil
+            || codexHookGateDispatchOwnerToken != nil
+            || !codexHookGateCoalescedContinuations.isEmpty
+    }
+
+    func finishCodexHookGateOwnerDispatch(
+        token: UUID,
+        succeeded: Bool
+    ) {
+        guard codexHookGateDispatchOwnerToken == token else { return }
+        codexHookGateDispatchOwnerToken = nil
+        codexHookGateActiveBinding = nil
+        let continuations = Array(codexHookGateCoalescedContinuations.values)
+        codexHookGateCoalescedContinuations.removeAll()
+        for continuation in continuations {
+            if succeeded {
+                continuation.resume()
+            } else {
+                continuation.resume(throwing: CancellationError())
+            }
+        }
+    }
+
+    func cancelCodexHookGateCoalescedWaiter(_ waiterID: UUID) {
+        codexHookGateCoalescedContinuations.removeValue(forKey: waiterID)?
+            .resume(throwing: CancellationError())
     }
 
     @discardableResult
     func cancelCodexHookReview() -> Bool {
         let continuation = codexHookReviewContinuation
+        let coalescedContinuations = Array(codexHookGateCoalescedContinuations.values)
         guard hasActiveCodexHookGateOperation else { return false }
         codexHookReviewContinuation = nil
+        codexHookGateCoalescedContinuations.removeAll()
         pendingCodexHookReview = nil
         codexHookGateAttemptToken = nil
+        codexHookGateDispatchOwnerToken = nil
         continuation?.resume(throwing: CancellationError())
+        for continuation in coalescedContinuations {
+            continuation.resume(throwing: CancellationError())
+        }
         return true
     }
 

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentTabSession.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentTabSession.swift
@@ -428,6 +428,12 @@ final class AgentTabSession: ObservableObject {
     var codexPendingSteerLifecycleReconciliation: CodexPendingSteerLifecycleReconciliation?
     var codexFallbackQueue: [CodexFallbackQueueEntry] = []
     var codexFallbackDispatchInFlight: CodexFallbackQueueEntry?
+    /// Bridges queued follow-ups to a hook-gate owner's turn for as long as that turn has no
+    /// settled identity of its own. Whichever of the accepted `turn/start` receipt or the
+    /// lifecycle start arrives first supplies the value — they race, and the queue has to be
+    /// bound by then either way. It is transient by design: the turn's terminal event either
+    /// upgrades it to the identity-derived blocker or resolves the queue outright.
+    var codexFallbackHookGateOwnerBlocker: CodexFallbackBlockingTurn?
     var codexFallbackPumpTask: Task<Void, Never>?
     var codexFallbackSuccessorRetryTask: Task<Void, Never>?
     let codexDispatchSerialGate = CodexDispatchSerialGate()
@@ -535,6 +541,11 @@ final class AgentTabSession: ObservableObject {
             codexAuthoritativeActiveTurn = nil
             codexAnonymousActiveTurn = nil
             codexRoutingObservedTurnID = nil
+            // A replaced controller can never deliver the lifecycle of a turn the previous
+            // one accepted, so a surviving blocker would gate the fallback pump on an event
+            // that is never coming. Disposition of the entries themselves belongs to the
+            // coordinator, which retires the queue with the controller.
+            codexFallbackHookGateOwnerBlocker = nil
         }
     }
 

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentTabSession.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentTabSession.swift
@@ -124,6 +124,14 @@ final class AgentTabSession: ObservableObject {
     @Published var pendingAskUser: AgentAskUserPendingState? = nil
     @Published var pendingUserInputRequest: AgentRequestUserInputRequest? = nil
     @Published var pendingApproval: AgentApprovalRequest? = nil
+    @Published var pendingCodexHookReview: AgentCodexHookReviewRequest? = nil
+    var codexHookReviewContinuation: CheckedContinuation<Void, Error>?
+    var codexHookGateGeneration: UInt64 = 0
+    var codexHookGateAttemptToken: UUID?
+    var codexHookGateInventoryFingerprint: String?
+    @Published var codexHookGateAudit: AgentCodexHookGateAudit?
+    var codexHookGateBindingMemo: CodexHookGateBindingIdentity?
+    var codexHookGateActiveBinding: CodexHookGateBindingIdentity?
     @Published var pendingPermissionsRequest: AgentPermissionsRequest? = nil
     @Published var pendingMCPElicitationRequest: AgentMCPElicitationRequest? = nil
     @Published var pendingApplyEditsReview: PendingApplyEditsReview? = nil
@@ -250,6 +258,11 @@ final class AgentTabSession: ObservableObject {
         case compact
         case review
         case unknown
+    }
+
+    struct CodexHookGateBindingIdentity: Equatable {
+        let controllerInstanceID: ObjectIdentifier
+        let controllerGeneration: UUID
     }
 
     struct CodexAuthoritativeTurnIdentity: Equatable {
@@ -515,6 +528,7 @@ final class AgentTabSession: ObservableObject {
             let oldIdentity = oldValue.map { ObjectIdentifier($0) }
             let newIdentity = codexController.map { ObjectIdentifier($0) }
             guard oldIdentity != newIdentity else { return }
+            resetCodexHookGateBinding()
             codexControllerGeneration = UUID()
             codexAuthoritativeActiveTurn = nil
             codexAnonymousActiveTurn = nil
@@ -681,12 +695,46 @@ final class AgentTabSession: ObservableObject {
         pendingAssistantDelta = ""
         agentTask?.cancel()
         agentTask = nil
+        if hasActiveCodexHookGateOperation {
+            resetCodexHookGateBinding()
+        }
         codexEventTask?.cancel()
         codexEventTask = nil
         codexEventTaskRunID = nil
         applyEditsApprovalSubscriptionTask?.cancel()
         applyEditsApprovalSubscriptionTask = nil
         applyEditsApprovalSubscriptionID = nil
+    }
+
+    var hasPendingCodexHookReviewRequest: Bool {
+        pendingCodexHookReview != nil
+    }
+
+    var hasPendingCodexHookReviewWait: Bool {
+        hasPendingCodexHookReviewRequest || codexHookReviewContinuation != nil
+    }
+
+    var hasActiveCodexHookGateOperation: Bool {
+        hasPendingCodexHookReviewWait || codexHookGateAttemptToken != nil
+    }
+
+    @discardableResult
+    func cancelCodexHookReview() -> Bool {
+        let continuation = codexHookReviewContinuation
+        guard hasActiveCodexHookGateOperation else { return false }
+        codexHookReviewContinuation = nil
+        pendingCodexHookReview = nil
+        codexHookGateAttemptToken = nil
+        continuation?.resume(throwing: CancellationError())
+        return true
+    }
+
+    func resetCodexHookGateBinding() {
+        _ = cancelCodexHookReview()
+        codexHookGateInventoryFingerprint = nil
+        codexHookGateActiveBinding = nil
+        codexHookGateBindingMemo = nil
+        codexHookGateAudit = nil
     }
 
     @discardableResult
@@ -730,6 +778,7 @@ final class AgentTabSession: ObservableObject {
             || pendingAskUser != nil
             || pendingUserInputRequest != nil
             || pendingApproval != nil
+            || hasActiveCodexHookGateOperation
             || pendingPermissionsRequest != nil
             || pendingMCPElicitationRequest != nil
             || pendingApplyEditsReview != nil
@@ -957,6 +1006,10 @@ final class AgentTabSession: ObservableObject {
 
     var uiPendingApproval: AgentApprovalRequest? {
         shouldSurfaceInteractionsInUI ? pendingApproval : nil
+    }
+
+    var uiPendingCodexHookReview: AgentCodexHookReviewRequest? {
+        shouldSurfaceInteractionsInUI ? pendingCodexHookReview : nil
     }
 
     var uiPendingPermissionsRequest: AgentPermissionsRequest? {

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentRunInteractionUIStore.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentRunInteractionUIStore.swift
@@ -9,6 +9,7 @@ struct AgentRunInteractionUISnapshot: Equatable {
     var pendingAskUser: AgentAskUserPendingState?
     var pendingUserInputRequest: AgentRequestUserInputRequest?
     var pendingApproval: AgentApprovalRequest?
+    var pendingCodexHookReview: AgentCodexHookReviewRequest? = .none
     var pendingPermissionsRequest: AgentPermissionsRequest?
     var pendingMCPElicitationRequest: AgentMCPElicitationRequest?
     var pendingApplyEditsReview: PendingApplyEditsReview?
@@ -58,6 +59,7 @@ struct AgentRunInteractionUISnapshot: Equatable {
         pendingAskUser: nil,
         pendingUserInputRequest: nil,
         pendingApproval: nil,
+        pendingCodexHookReview: nil,
         pendingPermissionsRequest: nil,
         pendingMCPElicitationRequest: nil,
         pendingApplyEditsReview: nil,
@@ -96,6 +98,9 @@ final class AgentRunInteractionUIStore: ObservableObject {
                     "askUserTimeoutStartedAt": snapshot.pendingAskUser?.timeoutStartedAt?.description ?? "nil",
                     "hasPendingInput": String(snapshot.pendingUserInputRequest != nil),
                     "hasPendingApproval": String(snapshot.pendingApproval != nil),
+                    "hasPendingCodexHookReview": String(snapshot.pendingCodexHookReview != nil),
+                    "codexHookReviewPhase": snapshot.pendingCodexHookReview?.phase.rawValue ?? "nil",
+                    "codexHookReviewID": AgentModePerfDiagnostics.shortID(snapshot.pendingCodexHookReview?.id),
                     "hasPendingPermissions": String(snapshot.pendingPermissionsRequest != nil),
                     "hasPendingMCPElicitation": String(snapshot.pendingMCPElicitationRequest != nil),
                     "hasApplyReview": String(snapshot.pendingApplyEditsReview != nil),

--- a/Sources/RepoPrompt/Features/AgentMode/Views/AgentModeView.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/AgentModeView.swift
@@ -1852,6 +1852,10 @@ struct AgentModeChatDetailView: View {
         runInteractionSnapshot.pendingApproval?.id
     }
 
+    private var pendingCodexHookReviewID: UUID? {
+        runInteractionSnapshot.pendingCodexHookReview?.id
+    }
+
     private var pendingMCPElicitationID: UUID? {
         runInteractionSnapshot.pendingMCPElicitationRequest?.id
     }
@@ -1861,7 +1865,10 @@ struct AgentModeChatDetailView: View {
     }
 
     private var isInteractionBlockerVisible: Bool {
-        pendingApprovalID != nil || pendingMCPElicitationID != nil || pendingApplyEditsReviewID != nil
+        pendingCodexHookReviewID != nil
+            || pendingApprovalID != nil
+            || pendingMCPElicitationID != nil
+            || pendingApplyEditsReviewID != nil
     }
 
     var body: some View {
@@ -2399,7 +2406,24 @@ struct AgentModeChatDetailView: View {
             transcriptBlockRows(blocks: visibleTranscriptBlocks)
         }
         runningIndicatorSlot
-        if let review = runInteractionSnapshot.pendingApplyEditsReview {
+        if let request = runInteractionSnapshot.pendingCodexHookReview {
+            CodexHookReviewCard(
+                request: request,
+                isStrictModeEnabled: {
+                    agentModeVM.isCodexHookApprovalStrictModeEnabled()
+                },
+                onDecision: { decision in
+                    guard let tabID = currentTabID else { return }
+                    try await agentModeVM.submitCodexHookReviewDecision(
+                        tabID: tabID,
+                        requestID: request.id,
+                        decision: decision
+                    )
+                }
+            )
+            .id("pendingCodexHookReview")
+            .transition(.opacity)
+        } else if let review = runInteractionSnapshot.pendingApplyEditsReview {
             AgentApplyEditsReviewCard(
                 review: review,
                 onAccept: {

--- a/Sources/RepoPrompt/Features/Diagnostics/AgentMode/Stress/AgentModeViewModel+StressHarnessSupport.swift
+++ b/Sources/RepoPrompt/Features/Diagnostics/AgentMode/Stress/AgentModeViewModel+StressHarnessSupport.swift
@@ -95,6 +95,7 @@
             session.codexFallbackPumpTask = nil
             session.codexFallbackQueue = []
             session.codexFallbackDispatchInFlight = nil
+            session.codexFallbackHookGateOwnerBlocker = nil
             session.codexPendingTurnKind = nil
             session.codexAuthoritativeActiveTurn = nil
             session.codexAnonymousActiveTurn = nil

--- a/Sources/RepoPrompt/Features/Settings/Models/GlobalSettingsDocument.swift
+++ b/Sources/RepoPrompt/Features/Settings/Models/GlobalSettingsDocument.swift
@@ -593,6 +593,8 @@ struct GlobalScalarPreferences: Codable, Equatable {
         var codexGoalSupportEnabled: Bool?
         var codexReasoningSummariesEnabled: Bool?
         var codexMemoriesEnabled: Bool?
+        var codexHookApprovalStrictModeEnabled: Bool?
+        var codexHookApprovalStrictModeWorkspaceOverrides: [String: Bool]?
         var providerConversationCleanupAction: String?
         var restrictMCPAgentDiscoveryToRoleLabels: Bool?
         var agentSessionHandoffInstructions: String?
@@ -608,6 +610,8 @@ struct GlobalScalarPreferences: Codable, Equatable {
             codexGoalSupportEnabled: Bool? = nil,
             codexReasoningSummariesEnabled: Bool? = nil,
             codexMemoriesEnabled: Bool? = nil,
+            codexHookApprovalStrictModeEnabled: Bool? = nil,
+            codexHookApprovalStrictModeWorkspaceOverrides: [String: Bool]? = nil,
             providerConversationCleanupAction: String? = nil,
             restrictMCPAgentDiscoveryToRoleLabels: Bool? = nil,
             agentSessionHandoffInstructions: String? = nil
@@ -622,6 +626,8 @@ struct GlobalScalarPreferences: Codable, Equatable {
             self.codexGoalSupportEnabled = codexGoalSupportEnabled
             self.codexReasoningSummariesEnabled = codexReasoningSummariesEnabled
             self.codexMemoriesEnabled = codexMemoriesEnabled
+            self.codexHookApprovalStrictModeEnabled = codexHookApprovalStrictModeEnabled
+            self.codexHookApprovalStrictModeWorkspaceOverrides = codexHookApprovalStrictModeWorkspaceOverrides
             self.providerConversationCleanupAction = providerConversationCleanupAction
             self.restrictMCPAgentDiscoveryToRoleLabels = restrictMCPAgentDiscoveryToRoleLabels
             self.agentSessionHandoffInstructions = agentSessionHandoffInstructions

--- a/Sources/RepoPrompt/Features/Settings/Models/GlobalSettingsManager.swift
+++ b/Sources/RepoPrompt/Features/Settings/Models/GlobalSettingsManager.swift
@@ -314,6 +314,13 @@ struct GlobalSettingsWriteDiagnostic: Equatable {
     let caller: String
 }
 
+// MARK: - Codex Hook Approval Settings
+
+@MainActor
+protocol CodexHookApprovalSettingsProviding {
+    func codexHookApprovalStrictModeEnabled(workspaceID: UUID?) -> Bool
+}
+
 // MARK: - Global Settings Store (Persistent)
 
 /// This is the single source of truth for workspace default settings.
@@ -321,7 +328,7 @@ struct GlobalSettingsWriteDiagnostic: Equatable {
 /// `~/Library/Application Support/RepoPrompt CE/Settings/globalSettings.json`.
 /// Windows use WindowSettingsManager to maintain local overlays.
 @MainActor
-class GlobalSettingsStore: ObservableObject {
+class GlobalSettingsStore: ObservableObject, CodexHookApprovalSettingsProviding {
     static let shared = GlobalSettingsStore()
 
     private let defaults: UserDefaults
@@ -1320,6 +1327,55 @@ class GlobalSettingsStore: ObservableObject {
     func setCodexMemoriesEnabled(_ enabled: Bool, commit: Bool = true) {
         updateAgentModeScalar(commit: commit) { settings in
             settings.codexMemoriesEnabled = enabled
+        }
+    }
+
+    func globalCodexHookApprovalStrictModeEnabled() -> Bool {
+        scalarPreferences.agentMode?.codexHookApprovalStrictModeEnabled ?? false
+    }
+
+    func codexHookApprovalStrictModeWorkspaceOverride(workspaceID: UUID) -> Bool? {
+        scalarPreferences.agentMode?.codexHookApprovalStrictModeWorkspaceOverrides?[workspaceID.uuidString]
+    }
+
+    func codexHookApprovalStrictModeEnabled(workspaceID: UUID?) -> Bool {
+        if let workspaceID,
+           let workspaceOverride = codexHookApprovalStrictModeWorkspaceOverride(workspaceID: workspaceID)
+        {
+            return workspaceOverride
+        }
+        return globalCodexHookApprovalStrictModeEnabled()
+    }
+
+    func setGlobalCodexHookApprovalStrictModeEnabled(_ enabled: Bool, commit: Bool = true) {
+        updateAgentModeScalar(commit: commit) { settings in
+            settings.codexHookApprovalStrictModeEnabled = enabled
+        }
+    }
+
+    func setCodexHookApprovalStrictModeEnabled(
+        _ enabled: Bool,
+        workspaceID: UUID?,
+        commit: Bool = true
+    ) {
+        if let workspaceID,
+           codexHookApprovalStrictModeWorkspaceOverride(workspaceID: workspaceID) != nil
+        {
+            setCodexHookApprovalStrictModeOverride(enabled, for: workspaceID, commit: commit)
+        } else {
+            setGlobalCodexHookApprovalStrictModeEnabled(enabled, commit: commit)
+        }
+    }
+
+    func setCodexHookApprovalStrictModeOverride(
+        _ override: Bool?,
+        for workspaceID: UUID,
+        commit: Bool = true
+    ) {
+        updateAgentModeScalar(commit: commit) { settings in
+            var overrides = settings.codexHookApprovalStrictModeWorkspaceOverrides ?? [:]
+            overrides[workspaceID.uuidString] = override
+            settings.codexHookApprovalStrictModeWorkspaceOverrides = overrides.isEmpty ? nil : overrides
         }
     }
 

--- a/Sources/RepoPrompt/Features/Settings/Views/AgentModeGeneralSettingsView.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/AgentModeGeneralSettingsView.swift
@@ -1,6 +1,45 @@
 import Combine
 import SwiftUI
 
+enum CodexHookApprovalWorkspaceSetting: CaseIterable, Hashable {
+    case appDefault
+    case alwaysRequireApproval
+    case dontRequireApproval
+
+    init(workspaceOverride: Bool?) {
+        switch workspaceOverride {
+        case true:
+            self = .alwaysRequireApproval
+        case false:
+            self = .dontRequireApproval
+        case nil:
+            self = .appDefault
+        }
+    }
+
+    var workspaceOverride: Bool? {
+        switch self {
+        case .appDefault:
+            nil
+        case .alwaysRequireApproval:
+            true
+        case .dontRequireApproval:
+            false
+        }
+    }
+
+    func label(globalStrictModeEnabled: Bool) -> String {
+        switch self {
+        case .appDefault:
+            "App default (currently: \(globalStrictModeEnabled ? "required" : "not required"))"
+        case .alwaysRequireApproval:
+            "Always require approval"
+        case .dontRequireApproval:
+            "Don't require approval"
+        }
+    }
+}
+
 /// Consolidated settings view for Agent Mode — the "Overview" tab.
 ///
 /// Model choices (Oracle, Context Builder Agent, Agent Role Defaults) are now
@@ -223,8 +262,16 @@ struct AgentModeGeneralSettingsView: View {
                 Toggle("Require Codex project-hook approval", isOn: codexHookApprovalStrictModeBinding)
                     .font(fontPreset.swiftUIFont(sizeAtNormal: 13, weight: .semibold))
                 if workspaceID != nil {
-                    Toggle("Override for this workspace", isOn: codexHookApprovalUsesWorkspaceOverrideBinding)
-                        .font(fontPreset.swiftUIFont(sizeAtNormal: 12))
+                    Picker("In this workspace:", selection: codexHookApprovalWorkspaceSettingBinding) {
+                        ForEach(CodexHookApprovalWorkspaceSetting.allCases, id: \.self) { setting in
+                            Text(setting.label(
+                                globalStrictModeEnabled: globalSettings.globalCodexHookApprovalStrictModeEnabled()
+                            ))
+                            .tag(setting)
+                        }
+                    }
+                    .pickerStyle(.menu)
+                    .font(fontPreset.swiftUIFont(sizeAtNormal: 12))
                 }
                 Text("When enabled, Continue Without Hooks is unavailable. Codex first turns remain blocked until the displayed project hooks are approved or become trusted externally.")
                     .font(fontPreset.swiftUIFont(sizeAtNormal: 12))
@@ -238,28 +285,27 @@ struct AgentModeGeneralSettingsView: View {
 
     private var codexHookApprovalStrictModeBinding: Binding<Bool> {
         Binding(
-            get: { globalSettings.codexHookApprovalStrictModeEnabled(workspaceID: workspaceID) },
-            set: { enabled in
-                globalSettings.setCodexHookApprovalStrictModeEnabled(
-                    enabled,
-                    workspaceID: workspaceID
-                )
-            }
+            get: { globalSettings.globalCodexHookApprovalStrictModeEnabled() },
+            set: { globalSettings.setGlobalCodexHookApprovalStrictModeEnabled($0) }
         )
     }
 
-    private var codexHookApprovalUsesWorkspaceOverrideBinding: Binding<Bool> {
+    private var codexHookApprovalWorkspaceSettingBinding: Binding<CodexHookApprovalWorkspaceSetting> {
         Binding(
             get: {
-                guard let workspaceID else { return false }
-                return globalSettings.codexHookApprovalStrictModeWorkspaceOverride(workspaceID: workspaceID) != nil
+                guard let workspaceID else { return .appDefault }
+                return CodexHookApprovalWorkspaceSetting(
+                    workspaceOverride: globalSettings.codexHookApprovalStrictModeWorkspaceOverride(
+                        workspaceID: workspaceID
+                    )
+                )
             },
-            set: { useOverride in
+            set: { setting in
                 guard let workspaceID else { return }
-                let override = useOverride
-                    ? globalSettings.codexHookApprovalStrictModeEnabled(workspaceID: workspaceID)
-                    : nil
-                globalSettings.setCodexHookApprovalStrictModeOverride(override, for: workspaceID)
+                globalSettings.setCodexHookApprovalStrictModeOverride(
+                    setting.workspaceOverride,
+                    for: workspaceID
+                )
             }
         )
     }

--- a/Sources/RepoPrompt/Features/Settings/Views/AgentModeGeneralSettingsView.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/AgentModeGeneralSettingsView.swift
@@ -25,6 +25,7 @@ import SwiftUI
 struct AgentModeGeneralSettingsView: View {
     @ObservedObject var promptVM: PromptViewModel
     @ObservedObject var apiSettingsVM: APISettingsViewModel
+    var workspaceID: UUID?
     var onNavigate: ((SettingsTab) -> Void)?
 
     /// Observe secure permission-store changes so the read-only summary rebuilds
@@ -128,6 +129,8 @@ struct AgentModeGeneralSettingsView: View {
 
             providerCleanupActionCard
 
+            codexHookApprovalStrictModeCard
+
             handoffInstructionsCard
 
             agentPermissionsCard
@@ -205,6 +208,59 @@ struct AgentModeGeneralSettingsView: View {
         Binding(
             get: { globalSettings.providerConversationCleanupAction() },
             set: { globalSettings.setProviderConversationCleanupAction($0) }
+        )
+    }
+
+    // MARK: - Codex hook approval
+
+    private var codexHookApprovalStrictModeCard: some View {
+        HStack(alignment: .top, spacing: fontPreset.scaledClamped(12, max: 18)) {
+            Image(systemName: "checkmark.shield")
+                .font(fontPreset.swiftUIFont(sizeAtNormal: 17))
+                .frame(width: fontPreset.scaledClamped(22, max: 30), alignment: .center)
+                .foregroundColor(.accentColor)
+            VStack(alignment: .leading, spacing: fontPreset.scaledClamped(6, max: 10)) {
+                Toggle("Require Codex project-hook approval", isOn: codexHookApprovalStrictModeBinding)
+                    .font(fontPreset.swiftUIFont(sizeAtNormal: 13, weight: .semibold))
+                if workspaceID != nil {
+                    Toggle("Override for this workspace", isOn: codexHookApprovalUsesWorkspaceOverrideBinding)
+                        .font(fontPreset.swiftUIFont(sizeAtNormal: 12))
+                }
+                Text("When enabled, Continue Without Hooks is unavailable. Codex first turns remain blocked until the displayed project hooks are approved or become trusted externally.")
+                    .font(fontPreset.swiftUIFont(sizeAtNormal: 12))
+                    .foregroundColor(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer(minLength: fontPreset.scaledClamped(10, max: 14))
+        }
+        .padding(.vertical, fontPreset.scaledClamped(6, max: 10))
+    }
+
+    private var codexHookApprovalStrictModeBinding: Binding<Bool> {
+        Binding(
+            get: { globalSettings.codexHookApprovalStrictModeEnabled(workspaceID: workspaceID) },
+            set: { enabled in
+                globalSettings.setCodexHookApprovalStrictModeEnabled(
+                    enabled,
+                    workspaceID: workspaceID
+                )
+            }
+        )
+    }
+
+    private var codexHookApprovalUsesWorkspaceOverrideBinding: Binding<Bool> {
+        Binding(
+            get: {
+                guard let workspaceID else { return false }
+                return globalSettings.codexHookApprovalStrictModeWorkspaceOverride(workspaceID: workspaceID) != nil
+            },
+            set: { useOverride in
+                guard let workspaceID else { return }
+                let override = useOverride
+                    ? globalSettings.codexHookApprovalStrictModeEnabled(workspaceID: workspaceID)
+                    : nil
+                globalSettings.setCodexHookApprovalStrictModeOverride(override, for: workspaceID)
+            }
         )
     }
 

--- a/Sources/RepoPrompt/Features/Settings/Views/SettingsView.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/SettingsView.swift
@@ -391,6 +391,7 @@ struct SettingsView: View {
             AgentModeGeneralSettingsView(
                 promptVM: promptViewModel,
                 apiSettingsVM: apiSettingsViewModel,
+                workspaceID: windowState.workspaceManager.activeWorkspace?.id,
                 onNavigate: { tab in selectedTab = tab }
             )
             .transition(.opacity.animation(.easeInOut(duration: 0.15)))

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexAppServerClient.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexAppServerClient.swift
@@ -1198,6 +1198,9 @@ actor CodexAppServerClient {
     private static func defaultProcessAppearsAlive(_ process: SpawnedProcess) -> Bool {
         // Use a non-destructive child-state check so exited/zombie children do not
         // look healthy, while leaving final reap/cleanup to the normal teardown path.
+        // `waitid` can report a stopped child on Darwin even with WEXITED; accepting
+        // any matching si_pid would misclassify SIGSTOP as exit and then join the
+        // exit observer forever before a request deadline can be armed.
         if ProcessTermination.childIsTerminalOrAlreadyReaped(process.pid) {
             return false
         }

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexAppServerClient.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexAppServerClient.swift
@@ -91,6 +91,22 @@ enum CodexAppServerRequestID: Hashable {
 }
 
 actor CodexAppServerClient {
+    struct FaultInjection {
+        let transportTerminationCleanup: @Sendable () async -> Void
+        let requestTimeoutDelivery: @Sendable (_ method: String, _ generation: UInt64) async -> Void
+        let subscriptionPreparation: @Sendable () async -> Void
+
+        init(
+            transportTerminationCleanup: @escaping @Sendable () async -> Void = {},
+            requestTimeoutDelivery: @escaping @Sendable (_ method: String, _ generation: UInt64) async -> Void = { _, _ in },
+            subscriptionPreparation: @escaping @Sendable () async -> Void = {}
+        ) {
+            self.transportTerminationCleanup = transportTerminationCleanup
+            self.requestTimeoutDelivery = requestTimeoutDelivery
+            self.subscriptionPreparation = subscriptionPreparation
+        }
+    }
+
     struct RequestFailure: Equatable {
         let method: String
         let code: Int?
@@ -183,6 +199,16 @@ actor CodexAppServerClient {
         let params: [String: CodexJSONValue]
     }
 
+    struct NotificationSubscription {
+        let stream: AsyncStream<Notification>
+        let transportGeneration: UInt64
+    }
+
+    struct ServerRequestSubscription {
+        let stream: AsyncStream<ServerRequest>
+        let transportGeneration: UInt64
+    }
+
     struct ProcessExitEvidence: Equatable {
         let executablePath: String
         let launchDirectory: String
@@ -244,10 +270,14 @@ actor CodexAppServerClient {
         }
     }
 
+    struct AmbiguousMutationError: Error {}
+
     enum TransportTerminationReason: Equatable {
         case stdinWrite(method: String?, errno: Int32?)
         case stdoutEOF
         case timeout(method: String, requestID: String)
+        case settlementDeadline(method: String, generation: UInt64)
+        case ambiguousMutationFailure(method: String, generation: UInt64)
         case explicitStop
         case livenessCheckFailed(method: String?)
         case decodeRecoveryBudgetExceeded(generation: UInt64)
@@ -283,6 +313,12 @@ actor CodexAppServerClient {
     private struct PendingRequestMetadata {
         let method: String
         let transportGeneration: UInt64
+        let onMutationUnsettled: (@Sendable (_ generation: UInt64) -> Void)?
+    }
+
+    private enum MutationFailureCause {
+        case timeout(Error)
+        case ambiguous
     }
 
     private struct ExitObservation {
@@ -323,6 +359,10 @@ actor CodexAppServerClient {
             nsError.localizedRecoverySuggestion
         ].compactMap(\.self)
         return candidates.contains(where: isTimeoutErrorMessage)
+    }
+
+    static func isAmbiguousMutationError(_ error: Error) -> Bool {
+        error is AmbiguousMutationError
     }
 
     private static func isTimeoutErrorMessage(_ message: String) -> Bool {
@@ -406,6 +446,7 @@ actor CodexAppServerClient {
     private let provisionsRepoPromptMCPOnStart: Bool
     private let processExitObserverFactory: @Sendable (pid_t) -> ChildProcessExitObserver
     private let expectedAgentPIDRegistrar: ExpectedAgentPIDRegistrar
+    private let faultInjection: FaultInjection
     #if DEBUG
         private var terminalObserverJoinCount = 0
     #endif
@@ -429,7 +470,8 @@ actor CodexAppServerClient {
         processExitObserverFactory: @escaping @Sendable (pid_t) -> ChildProcessExitObserver = {
             ChildProcessExitObserver(pid: $0)
         },
-        expectedAgentPIDRegistrar: ExpectedAgentPIDRegistrar = .serverNetworkManager
+        expectedAgentPIDRegistrar: ExpectedAgentPIDRegistrar = .serverNetworkManager,
+        faultInjection: FaultInjection = .init()
     ) {
         self.writeFrameHandler = writeFrameHandler
         self.livenessProbe = livenessProbe
@@ -438,6 +480,7 @@ actor CodexAppServerClient {
         self.provisionsRepoPromptMCPOnStart = provisionsRepoPromptMCPOnStart
         self.processExitObserverFactory = processExitObserverFactory
         self.expectedAgentPIDRegistrar = expectedAgentPIDRegistrar
+        self.faultInjection = faultInjection
     }
 
     func updateConfig(_ config: Config) {
@@ -602,6 +645,28 @@ actor CodexAppServerClient {
         }
     }
 
+    func healthyTransportGeneration() -> UInt64? {
+        guard let activeTransport,
+              isInitialized,
+              !didTerminateTransport,
+              livenessProbe(activeTransport.process)
+        else {
+            return nil
+        }
+        return activeTransport.generation
+    }
+
+    func subscribeNotificationsWithTransportGeneration() async throws -> NotificationSubscription {
+        await faultInjection.subscriptionPreparation()
+        guard let generation = healthyTransportGeneration() else {
+            throw lastTransportFailure ?? ClientError.processNotRunning
+        }
+        return NotificationSubscription(
+            stream: subscribeNotifications(),
+            transportGeneration: generation
+        )
+    }
+
     func subscribeServerRequests() -> AsyncStream<ServerRequest> {
         AsyncStream { continuation in
             let id = UUID()
@@ -612,7 +677,22 @@ actor CodexAppServerClient {
         }
     }
 
+    func subscribeServerRequestsWithTransportGeneration() async throws -> ServerRequestSubscription {
+        await faultInjection.subscriptionPreparation()
+        guard let generation = healthyTransportGeneration() else {
+            throw lastTransportFailure ?? ClientError.processNotRunning
+        }
+        return ServerRequestSubscription(
+            stream: subscribeServerRequests(),
+            transportGeneration: generation
+        )
+    }
+
     func startIfNeeded() async throws {
+        try await startIfNeeded(initializationTimeout: nil)
+    }
+
+    func startIfNeeded(initializationTimeout: TimeInterval?) async throws {
         let authority = startupAuthorityEpoch
         if let termination = transportTerminationTask,
            termination.generation == transportGeneration
@@ -640,7 +720,10 @@ actor CodexAppServerClient {
         try ensureStartupAuthority(authority)
         let startupID = UUID()
         let task = Task<Void, Error> {
-            try await self.performStartupIfNeeded(startupAuthority: authority)
+            try await self.performStartupIfNeeded(
+                startupAuthority: authority,
+                initializationTimeout: initializationTimeout
+            )
         }
         startupTask = (id: startupID, task: task)
         do {
@@ -832,9 +915,13 @@ actor CodexAppServerClient {
         }
         timeoutTasks.removeAll()
         let requests = pendingRequests
+        let requestMetadata = pendingRequestMetadata
         pendingRequests.removeAll()
         pendingRequestMetadata.removeAll()
-        for continuation in requests.values {
+        for (requestID, continuation) in requests {
+            if let metadata = requestMetadata[requestID] {
+                metadata.onMutationUnsettled?(metadata.transportGeneration)
+            }
             continuation.resume(throwing: requestFailure)
         }
 
@@ -1074,6 +1161,7 @@ actor CodexAppServerClient {
 
     private func finishTransportTermination(_ terminatingTransport: TerminatingTransport?) async {
         guard let terminatingTransport else { return }
+        await faultInjection.transportTerminationCleanup()
         if let expectedAgentPIDToClear = terminatingTransport.expectedAgentPIDToClear {
             await expectedAgentPIDRegistrar.clear(
                 expectedAgentPIDToClear.pid,
@@ -1135,11 +1223,90 @@ actor CodexAppServerClient {
         )
     }
 
+    /// Performs a state-mutating request with a hard settlement boundary.
+    ///
+    /// A JSON-RPC timeout alone is insufficient for mutations because the server may
+    /// still apply the request after the caller resumes. This path captures the owning
+    /// transport generation, terminates that exact process on deadline, and awaits
+    /// process-family cleanup before returning the timeout. A stale completion from the
+    /// fenced generation therefore cannot mutate state after serialization is released.
+    func requestWithSettlementDeadline(
+        method: String,
+        params: [String: Any]?,
+        deadline: TimeInterval,
+        onUnsettled: @escaping @Sendable (_ generation: UInt64) -> Void = { _ in }
+    ) async throws -> [String: Any] {
+        guard let activeTransport, !didTerminateTransport else {
+            throw lastTransportFailure ?? ClientError.processNotRunning
+        }
+        let generation = activeTransport.generation
+        do {
+            return try await request(
+                method: method,
+                params: params,
+                timeout: deadline,
+                useDefaultTimeout: false,
+                onMutationUnsettled: onUnsettled
+            )
+        } catch {
+            let cause: MutationFailureCause
+            if Self.isTimeoutError(error) {
+                cause = .timeout(error)
+            } else {
+                // A decoded JSON-RPC error is an authoritative server response: the
+                // owning generation has conclusively rejected the mutation. Every other
+                // failure is locally ambiguous after dispatch and must settle the exact
+                // generation before trust-write serialization can be released.
+                if let clientError = error as? ClientError,
+                   case .requestFailed = clientError
+                {
+                    throw error
+                }
+                cause = .ambiguous
+            }
+            throw await settleMutationFailure(
+                method: method,
+                generation: generation,
+                cause: cause
+            )
+        }
+    }
+
+    private func settleMutationFailure(
+        method: String,
+        generation: UInt64,
+        cause: MutationFailureCause
+    ) async -> Error {
+        let reason: TransportTerminationReason
+        let returnedError: Error
+        switch cause {
+        case let .timeout(error):
+            if activeTransport?.generation == generation, !didTerminateTransport,
+               config.enableDebugLogging
+            {
+                print("[CodexAppServer] Settlement deadline reached for \(method) on generation \(generation); retiring transport")
+            }
+            reason = .settlementDeadline(method: method, generation: generation)
+            returnedError = error
+        case .ambiguous:
+            reason = .ambiguousMutationFailure(method: method, generation: generation)
+            returnedError = AmbiguousMutationError()
+        }
+        await terminateTransport(
+            flushStdout: false,
+            expectedGeneration: generation,
+            requestFailure: .processNotRunning,
+            reason: reason
+        )
+        return returnedError
+    }
+
     func request(
         method: String,
         params: [String: Any]?,
         timeout: TimeInterval?,
-        useDefaultTimeout: Bool
+        useDefaultTimeout: Bool,
+        onMutationUnsettled: (@Sendable (_ generation: UInt64) -> Void)? = nil
     ) async throws -> [String: Any] {
         try Task.checkCancellation()
         guard let activeTransport, !didTerminateTransport else {
@@ -1160,7 +1327,8 @@ actor CodexAppServerClient {
                 pendingRequests[requestID] = continuation
                 pendingRequestMetadata[requestID] = PendingRequestMetadata(
                     method: method,
-                    transportGeneration: generation
+                    transportGeneration: generation,
+                    onMutationUnsettled: onMutationUnsettled
                 )
                 if let deadline {
                     scheduleTimeout(for: requestID, after: deadline)
@@ -1307,7 +1475,7 @@ actor CodexAppServerClient {
         return models
     }
 
-    private func initializeIfNeeded() async throws {
+    private func initializeIfNeeded(timeout: TimeInterval?) async throws {
         if isInitialized {
             return
         }
@@ -1324,7 +1492,9 @@ actor CodexAppServerClient {
             params: [
                 "clientInfo": clientInfo,
                 "capabilities": capabilities
-            ]
+            ],
+            timeout: timeout,
+            useDefaultTimeout: timeout == nil
         )
         try notify(method: "initialized", params: nil)
         isInitialized = true
@@ -1336,14 +1506,17 @@ actor CodexAppServerClient {
         }
     }
 
-    private func performStartupIfNeeded(startupAuthority: UInt64) async throws {
+    private func performStartupIfNeeded(
+        startupAuthority: UInt64,
+        initializationTimeout: TimeInterval?
+    ) async throws {
         do {
             try ensureStartupAuthority(startupAuthority)
             if activeTransport == nil {
                 try await startProcess(startupAuthority: startupAuthority)
             }
             try ensureStartupAuthority(startupAuthority)
-            try await initializeIfNeeded()
+            try await initializeIfNeeded(timeout: initializationTimeout)
         } catch is CancellationError {
             if let termination = transportTerminationTask,
                termination.generation == transportGeneration
@@ -2021,6 +2194,10 @@ actor CodexAppServerClient {
             return
         }
         let metadata = pendingRequestMetadata.removeValue(forKey: id)
+        if let metadata {
+            await faultInjection.requestTimeoutDelivery(metadata.method, metadata.transportGeneration)
+            metadata.onMutationUnsettled?(metadata.transportGeneration)
+        }
         if let metadata,
            Self.shouldPoisonTransportOnTimeout(method: metadata.method)
         {
@@ -2053,8 +2230,11 @@ actor CodexAppServerClient {
 
     private func failPendingRequestIfPresent(id: String, error: Error) {
         timeoutTasks.removeValue(forKey: id)?.cancel()
-        pendingRequestMetadata.removeValue(forKey: id)
+        let metadata = pendingRequestMetadata.removeValue(forKey: id)
         if let continuation = pendingRequests.removeValue(forKey: id) {
+            if let metadata {
+                metadata.onMutationUnsettled?(metadata.transportGeneration)
+            }
             continuation.resume(throwing: error)
         }
     }
@@ -2133,6 +2313,24 @@ actor CodexAppServerClient {
 
         func debugPendingRequestCount() -> Int {
             pendingRequests.count
+        }
+
+        func debugNotificationSubscriberCount() -> Int {
+            notificationContinuations.count
+        }
+
+        func debugServerRequestSubscriberCount() -> Int {
+            serverRequestContinuations.count
+        }
+
+        func debugBeginTransportFailure() {
+            let generation = transportGeneration
+            beginTransportTermination(
+                flushStdout: false,
+                expectedGeneration: generation,
+                requestFailure: .processNotRunning,
+                reason: .stdoutEOF
+            )
         }
 
         func debugTimeoutTaskCount() -> Int {

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexHookTrustModels.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexHookTrustModels.swift
@@ -191,23 +191,21 @@ struct CodexHookInventory: Hashable {
         projectHooks.filter { !$0.trustStatus.isResolved }
     }
 
-    func validatedUnresolvedProjectHooks(
+    func validatesUnresolvedProjectHooks(
         for candidates: [CodexHookTrustCandidate]
-    ) -> [CodexHookMetadata]? {
-        guard !candidates.isEmpty else { return nil }
+    ) -> Bool {
+        guard !candidates.isEmpty else { return false }
         var selectedKeys = Set<CodexHookUTF8Identity>()
-        var selectedHooks: [CodexHookMetadata] = []
         for candidate in candidates {
             guard candidate.isValid,
                   selectedKeys.insert(candidate.keyIdentity).inserted,
                   let hook = unresolvedProjectHooks.first(where: { $0.keyIdentity == candidate.keyIdentity }),
                   hook.hashIdentity == candidate.hashIdentity
             else {
-                return nil
+                return false
             }
-            selectedHooks.append(hook)
         }
-        return selectedHooks
+        return true
     }
 
     func verifies(_ candidates: [CodexHookTrustCandidate]) -> Bool {

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexHookTrustModels.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexHookTrustModels.swift
@@ -1,0 +1,376 @@
+import CryptoKit
+import Foundation
+
+struct CodexHookUTF8Identity: Hashable {
+    let bytes: [UInt8]
+
+    init(_ value: String) {
+        bytes = Array(value.utf8)
+    }
+
+    func lexicographicallyPrecedes(_ other: Self) -> Bool {
+        bytes.lexicographicallyPrecedes(other.bytes)
+    }
+}
+
+struct CodexHookSelectionIdentity: Hashable {
+    let key: CodexHookUTF8Identity
+    let hash: CodexHookUTF8Identity
+}
+
+struct CodexHookInventoryIdentity: Hashable {
+    let executionCWD: CodexHookUTF8Identity
+    let hooks: [CodexHookMetadataIdentity]
+    let warnings: [CodexHookUTF8Identity]
+}
+
+struct CodexHookMetadataIdentity: Hashable {
+    let eventName: CodexHookUTF8Identity
+    let source: CodexHookUTF8Identity
+    let sourcePath: CodexHookUTF8Identity
+    let selection: CodexHookSelectionIdentity
+    let enabled: Bool
+    let handlerType: CodexHookUTF8Identity
+    let trustStatus: CodexHookTrustStatus
+    let commandOrHandler: CodexHookUTF8Identity?
+}
+
+enum CodexHookTrustStatus: String, Hashable {
+    case managed
+    case untrusted
+    case trusted
+    case modified
+
+    init(protocolValue: String) throws {
+        guard let value = Self(rawValue: protocolValue) else {
+            throw CodexHookTrustError.malformedListResponse
+        }
+        self = value
+    }
+
+    var isResolved: Bool {
+        self == .trusted || self == .managed
+    }
+}
+
+struct CodexHookMetadata: Hashable {
+    let eventName: String
+    let source: String
+    let sourcePath: String
+    let key: String
+    let currentHash: String
+    let enabled: Bool
+    let handlerType: String
+    let trustStatus: CodexHookTrustStatus
+    let commandOrHandler: String?
+
+    init(
+        eventName: String,
+        source: String,
+        sourcePath: String,
+        key: String,
+        currentHash: String,
+        enabled: Bool,
+        handlerType: String,
+        trustStatus: CodexHookTrustStatus,
+        commandOrHandler: String?
+    ) throws {
+        guard !eventName.isBlank,
+              !source.isBlank,
+              !sourcePath.isBlank,
+              !key.isBlank,
+              !currentHash.isBlank,
+              !handlerType.isBlank
+        else {
+            throw CodexHookTrustError.malformedListResponse
+        }
+        self.eventName = eventName
+        self.source = source
+        self.sourcePath = sourcePath
+        self.key = key
+        self.currentHash = currentHash
+        self.enabled = enabled
+        self.handlerType = handlerType
+        self.trustStatus = trustStatus
+        self.commandOrHandler = commandOrHandler
+    }
+
+    var keyIdentity: CodexHookUTF8Identity {
+        CodexHookUTF8Identity(key)
+    }
+
+    var hashIdentity: CodexHookUTF8Identity {
+        CodexHookUTF8Identity(currentHash)
+    }
+
+    var selectionIdentity: CodexHookSelectionIdentity {
+        CodexHookSelectionIdentity(key: keyIdentity, hash: hashIdentity)
+    }
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.metadataIdentity == rhs.metadataIdentity
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(metadataIdentity)
+    }
+
+    var metadataIdentity: CodexHookMetadataIdentity {
+        CodexHookMetadataIdentity(
+            eventName: CodexHookUTF8Identity(eventName),
+            source: CodexHookUTF8Identity(source),
+            sourcePath: CodexHookUTF8Identity(sourcePath),
+            selection: selectionIdentity,
+            enabled: enabled,
+            handlerType: CodexHookUTF8Identity(handlerType),
+            trustStatus: trustStatus,
+            commandOrHandler: commandOrHandler.map(CodexHookUTF8Identity.init)
+        )
+    }
+}
+
+struct CodexHookInventory: Hashable {
+    let executionCWD: String
+    let hooks: [CodexHookMetadata]
+    let warnings: [String]
+
+    init(
+        executionCWD: String,
+        hooks: [CodexHookMetadata],
+        warnings: [String] = []
+    ) throws {
+        let standardizedCWD = Self.standardizedPath(executionCWD)
+        guard !standardizedCWD.isBlank else {
+            throw CodexHookTrustError.malformedListResponse
+        }
+
+        var uniqueHooks: [CodexHookMetadata] = []
+        for hook in hooks {
+            if let existing = uniqueHooks.first(where: { $0.key == hook.key }) {
+                guard existing.keyIdentity == hook.keyIdentity,
+                      existing.metadataIdentity == hook.metadataIdentity
+                else {
+                    throw CodexHookTrustError.malformedListResponse
+                }
+                continue
+            }
+            uniqueHooks.append(hook)
+        }
+
+        self.executionCWD = standardizedCWD
+        self.hooks = uniqueHooks.sorted {
+            if $0.keyIdentity == $1.keyIdentity {
+                return $0.hashIdentity.lexicographicallyPrecedes($1.hashIdentity)
+            }
+            return $0.keyIdentity.lexicographicallyPrecedes($1.keyIdentity)
+        }
+        self.warnings = warnings
+    }
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.inventoryIdentity == rhs.inventoryIdentity
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(inventoryIdentity)
+    }
+
+    var inventoryIdentity: CodexHookInventoryIdentity {
+        CodexHookInventoryIdentity(
+            executionCWD: CodexHookUTF8Identity(executionCWD),
+            hooks: hooks.map(\.metadataIdentity),
+            warnings: warnings.map(CodexHookUTF8Identity.init)
+        )
+    }
+
+    var projectHooks: [CodexHookMetadata] {
+        hooks.filter { $0.source == "project" }
+    }
+
+    var unresolvedProjectHooks: [CodexHookMetadata] {
+        projectHooks.filter { !$0.trustStatus.isResolved }
+    }
+
+    func validatedUnresolvedProjectHooks(
+        for candidates: [CodexHookTrustCandidate]
+    ) -> [CodexHookMetadata]? {
+        guard !candidates.isEmpty else { return nil }
+        var selectedKeys = Set<CodexHookUTF8Identity>()
+        var selectedHooks: [CodexHookMetadata] = []
+        for candidate in candidates {
+            guard candidate.isValid,
+                  selectedKeys.insert(candidate.keyIdentity).inserted,
+                  let hook = unresolvedProjectHooks.first(where: { $0.keyIdentity == candidate.keyIdentity }),
+                  hook.hashIdentity == candidate.hashIdentity
+            else {
+                return nil
+            }
+            selectedHooks.append(hook)
+        }
+        return selectedHooks
+    }
+
+    func verifies(_ candidates: [CodexHookTrustCandidate]) -> Bool {
+        candidates.allSatisfy { candidate in
+            hooks.contains {
+                $0.selectionIdentity == candidate.selectionIdentity && $0.trustStatus.isResolved
+            }
+        }
+    }
+
+    var fingerprint: String {
+        var data = Data()
+        Self.appendLengthPrefixed(executionCWD, to: &data)
+        for hook in hooks {
+            Self.appendLengthPrefixed(hook.key, to: &data)
+            Self.appendLengthPrefixed(hook.currentHash, to: &data)
+        }
+        return SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+
+    static func decode(result: [String: Any], executionCWD: String) throws -> Self {
+        guard let entries = result["data"] as? [[String: Any]] else {
+            throw CodexHookTrustError.malformedListResponse
+        }
+
+        let standardizedExpectedCWD = standardizedPath(executionCWD)
+        let matchingEntries = try entries.filter { entry in
+            guard let cwd = entry["cwd"] as? String, !cwd.isBlank else {
+                throw CodexHookTrustError.malformedListResponse
+            }
+            return standardizedPath(cwd) == standardizedExpectedCWD
+        }
+        guard matchingEntries.count == 1, entries.count == 1, let entry = matchingEntries.first,
+              let rawHooks = entry["hooks"] as? [[String: Any]],
+              let errors = entry["errors"] as? [String],
+              let warnings = entry["warnings"] as? [String]
+        else {
+            throw CodexHookTrustError.malformedListResponse
+        }
+
+        guard errors.isEmpty else {
+            throw CodexHookTrustError.discoveryFailed(cwdErrors: errors)
+        }
+        let hooks = try rawHooks.map(Self.decodeHook)
+        return try Self(
+            executionCWD: standardizedExpectedCWD,
+            hooks: hooks,
+            warnings: warnings
+        )
+    }
+
+    private static func decodeHook(_ raw: [String: Any]) throws -> CodexHookMetadata {
+        guard let eventName = raw["eventName"] as? String,
+              let source = raw["source"] as? String,
+              let sourcePath = raw["sourcePath"] as? String,
+              let key = raw["key"] as? String,
+              let currentHash = raw["currentHash"] as? String,
+              let enabled = raw["enabled"] as? Bool,
+              let rawTrustStatus = raw["trustStatus"] as? String,
+              let handlerType = raw["handlerType"] as? String
+        else {
+            throw CodexHookTrustError.malformedListResponse
+        }
+
+        let command: String?
+        if let rawCommand = raw["command"] {
+            if rawCommand is NSNull {
+                command = nil
+            } else if let rawCommand = rawCommand as? String {
+                command = rawCommand
+            } else {
+                throw CodexHookTrustError.malformedListResponse
+            }
+        } else {
+            command = nil
+        }
+
+        return try CodexHookMetadata(
+            eventName: eventName,
+            source: source,
+            sourcePath: sourcePath,
+            key: key,
+            currentHash: currentHash,
+            enabled: enabled,
+            handlerType: handlerType,
+            trustStatus: CodexHookTrustStatus(protocolValue: rawTrustStatus),
+            commandOrHandler: command
+        )
+    }
+
+    private static func standardizedPath(_ path: String) -> String {
+        guard !path.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return "" }
+        return URL(fileURLWithPath: path).standardizedFileURL.path
+    }
+
+    private static func appendLengthPrefixed(_ value: String, to data: inout Data) {
+        let bytes = Data(value.utf8)
+        var length = UInt64(bytes.count).bigEndian
+        withUnsafeBytes(of: &length) { data.append(contentsOf: $0) }
+        data.append(bytes)
+    }
+}
+
+struct CodexHookTrustCandidate: Hashable {
+    let key: String
+    let currentHash: String
+
+    var keyIdentity: CodexHookUTF8Identity {
+        CodexHookUTF8Identity(key)
+    }
+
+    var hashIdentity: CodexHookUTF8Identity {
+        CodexHookUTF8Identity(currentHash)
+    }
+
+    var selectionIdentity: CodexHookSelectionIdentity {
+        CodexHookSelectionIdentity(key: keyIdentity, hash: hashIdentity)
+    }
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.selectionIdentity == rhs.selectionIdentity
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(selectionIdentity)
+    }
+
+    var isValid: Bool {
+        !key.isBlank && !currentHash.isBlank
+    }
+}
+
+enum CodexHookTrustError: Error, LocalizedError {
+    case unsupportedMethod(method: String)
+    case malformedListResponse
+    case discoveryFailed(cwdErrors: [String])
+    case inventoryChanged(replacement: CodexHookInventory)
+    case batchWriteFailed
+    case postWriteVerificationFailed(latest: CodexHookInventory?)
+    case cancelled
+
+    var errorDescription: String? {
+        switch self {
+        case let .unsupportedMethod(method):
+            "Codex does not support the required \(method) hook-trust operation. Update Codex and retry."
+        case .malformedListResponse:
+            "Codex hook discovery returned an invalid result. Retry hook discovery."
+        case let .discoveryFailed(cwdErrors):
+            "Codex reported \(cwdErrors.count) hook discovery error(s). Review the project hook configuration and retry."
+        case .inventoryChanged:
+            "The project hook inventory changed before approval. Review the refreshed inventory and retry."
+        case .batchWriteFailed:
+            "Codex could not persist hook trust. Retry approval."
+        case .postWriteVerificationFailed:
+            "Codex could not verify hook trust after writing it. Review the current inventory and retry."
+        case .cancelled:
+            "The Codex hook-trust operation was cancelled. Retry when ready."
+        }
+    }
+}
+
+private extension String {
+    var isBlank: Bool {
+        trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexHookTrustModels.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexHookTrustModels.swift
@@ -130,6 +130,11 @@ struct CodexHookMetadata: Hashable {
 }
 
 struct CodexHookInventory: Hashable {
+    private static let maxHookCount = 4096
+    private static let maxDiagnosticCount = 1024
+    private static let maxFieldUTF8Bytes = 256 * 1024
+    private static let maxInventoryUTF8Bytes = 4 * 1024 * 1024
+
     let executionCWD: String
     let hooks: [CodexHookMetadata]
     let warnings: [String]
@@ -210,7 +215,7 @@ struct CodexHookInventory: Hashable {
 
     func verifies(_ candidates: [CodexHookTrustCandidate]) -> Bool {
         candidates.allSatisfy { candidate in
-            hooks.contains {
+            projectHooks.contains {
                 $0.selectionIdentity == candidate.selectionIdentity && $0.trustStatus.isResolved
             }
         }
@@ -227,18 +232,20 @@ struct CodexHookInventory: Hashable {
     }
 
     static func decode(result: [String: Any], executionCWD: String) throws -> Self {
-        guard let entries = result["data"] as? [[String: Any]] else {
+        guard executionCWD.utf8.count <= maxFieldUTF8Bytes,
+              let entries = result["data"] as? [[String: Any]],
+              entries.count == 1,
+              let entry = entries.first,
+              let rawEntryCWD = entry["cwd"] as? String,
+              !rawEntryCWD.isBlank,
+              rawEntryCWD.utf8.count <= maxFieldUTF8Bytes
+        else {
             throw CodexHookTrustError.malformedListResponse
         }
 
         let standardizedExpectedCWD = standardizedPath(executionCWD)
-        let matchingEntries = try entries.filter { entry in
-            guard let cwd = entry["cwd"] as? String, !cwd.isBlank else {
-                throw CodexHookTrustError.malformedListResponse
-            }
-            return standardizedPath(cwd) == standardizedExpectedCWD
-        }
-        guard matchingEntries.count == 1, entries.count == 1, let entry = matchingEntries.first,
+        guard !standardizedExpectedCWD.isBlank,
+              standardizedPath(rawEntryCWD) == standardizedExpectedCWD,
               let rawHooks = entry["hooks"] as? [[String: Any]],
               let errors = entry["errors"] as? [String],
               let warnings = entry["warnings"] as? [String]
@@ -246,15 +253,60 @@ struct CodexHookInventory: Hashable {
             throw CodexHookTrustError.malformedListResponse
         }
 
+        guard rawHooks.count <= maxHookCount,
+              errors.count <= maxDiagnosticCount,
+              warnings.count <= maxDiagnosticCount
+        else {
+            throw CodexHookTrustError.malformedListResponse
+        }
+
+        var inventoryUTF8Bytes = 0
+        try addInventoryUTF8Bytes(rawEntryCWD, total: &inventoryUTF8Bytes)
+        for error in errors {
+            try addInventoryUTF8Bytes(error, total: &inventoryUTF8Bytes)
+        }
+        for warning in warnings {
+            try addInventoryUTF8Bytes(warning, total: &inventoryUTF8Bytes)
+        }
+
         guard errors.isEmpty else {
             throw CodexHookTrustError.discoveryFailed(cwdErrors: errors)
         }
         let hooks = try rawHooks.map(Self.decodeHook)
+        for hook in hooks {
+            var fields = [
+                hook.eventName,
+                hook.source,
+                hook.sourcePath,
+                hook.key,
+                hook.currentHash,
+                hook.handlerType
+            ]
+            if let commandOrHandler = hook.commandOrHandler {
+                fields.append(commandOrHandler)
+            }
+            for field in fields {
+                try addInventoryUTF8Bytes(field, total: &inventoryUTF8Bytes)
+            }
+        }
         return try Self(
             executionCWD: standardizedExpectedCWD,
             hooks: hooks,
             warnings: warnings
         )
+    }
+
+    private static func addInventoryUTF8Bytes(
+        _ value: String,
+        total: inout Int
+    ) throws {
+        let count = value.utf8.count
+        guard count <= maxFieldUTF8Bytes,
+              total <= maxInventoryUTF8Bytes - count
+        else {
+            throw CodexHookTrustError.malformedListResponse
+        }
+        total += count
     }
 
     private static func decodeHook(_ raw: [String: Any]) throws -> CodexHookMetadata {

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexHookTrustService.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexHookTrustService.swift
@@ -1,0 +1,156 @@
+import Foundation
+
+struct CodexHookTrustService {
+    typealias RequestExecutor = @Sendable (
+        _ method: String,
+        _ params: [String: Any]?,
+        _ timeout: TimeInterval?
+    ) async throws -> [String: Any]
+
+    let requestExecutor: RequestExecutor
+    let executionCWD: String?
+    let timeout: TimeInterval?
+
+    func listHooks() async throws -> CodexHookInventory {
+        try Task.checkCancellation()
+        return try await loadHookInventory()
+    }
+
+    func trustHooks(
+        expectedCandidates: [CodexHookTrustCandidate],
+        expectedInventoryFingerprint: String
+    ) async throws -> CodexHookInventory {
+        try Task.checkCancellation()
+        let preflightInventory = try await loadHookInventory()
+        guard preflightInventory.fingerprint == expectedInventoryFingerprint else {
+            throw CodexHookTrustError.inventoryChanged(replacement: preflightInventory)
+        }
+        let trustValues = try validatedTrustValues(
+            for: expectedCandidates,
+            in: preflightInventory
+        )
+
+        try Task.checkCancellation()
+        let writeOutcome = await performCancellationShieldedRequest(
+            method: "config/batchWrite",
+            params: [
+                "edits": [[
+                    "keyPath": "hooks.state",
+                    "value": trustValues,
+                    "mergeStrategy": "upsert"
+                ]],
+                "reloadUserConfig": true
+            ]
+        )
+        guard !Task.isCancelled else {
+            throw CodexHookTrustError.cancelled
+        }
+
+        let writeResult: [String: Any]
+        switch writeOutcome {
+        case let .success(result):
+            writeResult = result
+        case let .failure(error):
+            if error is CancellationError {
+                throw CodexHookTrustError.cancelled
+            }
+            if Self.isUnsupportedMethodError(error) {
+                throw CodexHookTrustError.unsupportedMethod(method: "config/batchWrite")
+            }
+            throw CodexHookTrustError.batchWriteFailed
+        }
+        guard writeResult["status"] as? String == "ok" else {
+            throw CodexHookTrustError.batchWriteFailed
+        }
+
+        return try await verifyCandidates(expectedCandidates)
+    }
+
+    private func validatedTrustValues(
+        for candidates: [CodexHookTrustCandidate],
+        in inventory: CodexHookInventory
+    ) throws -> [String: Any] {
+        guard inventory.validatedUnresolvedProjectHooks(for: candidates) != nil else {
+            throw CodexHookTrustError.inventoryChanged(replacement: inventory)
+        }
+
+        var trustValues: [String: Any] = [:]
+        for candidate in candidates {
+            trustValues[candidate.key] = ["trusted_hash": candidate.currentHash]
+        }
+        return trustValues
+    }
+
+    private func verifyCandidates(
+        _ candidates: [CodexHookTrustCandidate]
+    ) async throws -> CodexHookInventory {
+        try Task.checkCancellation()
+        let verifiedInventory: CodexHookInventory
+        do {
+            verifiedInventory = try await loadHookInventory()
+        } catch is CancellationError {
+            throw CodexHookTrustError.cancelled
+        } catch let error as CodexHookTrustError {
+            switch error {
+            case .unsupportedMethod, .cancelled:
+                throw error
+            default:
+                throw CodexHookTrustError.postWriteVerificationFailed(latest: nil)
+            }
+        } catch {
+            throw CodexHookTrustError.postWriteVerificationFailed(latest: nil)
+        }
+
+        guard verifiedInventory.verifies(candidates) else {
+            throw CodexHookTrustError.postWriteVerificationFailed(latest: verifiedInventory)
+        }
+        try Task.checkCancellation()
+        return verifiedInventory
+    }
+
+    private func loadHookInventory() async throws -> CodexHookInventory {
+        guard let executionCWD,
+              !executionCWD.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
+            throw CodexHookTrustError.malformedListResponse
+        }
+
+        let result: [String: Any]
+        do {
+            result = try await requestExecutor(
+                "hooks/list",
+                ["cwds": [executionCWD]],
+                timeout
+            )
+        } catch is CancellationError {
+            throw CodexHookTrustError.cancelled
+        } catch {
+            if Self.isUnsupportedMethodError(error) {
+                throw CodexHookTrustError.unsupportedMethod(method: "hooks/list")
+            }
+            throw CodexHookTrustError.malformedListResponse
+        }
+        return try CodexHookInventory.decode(result: result, executionCWD: executionCWD)
+    }
+
+    private func performCancellationShieldedRequest(
+        method: String,
+        params: [String: Any]?
+    ) async -> Result<[String: Any], Error> {
+        let requestTask = Task {
+            try await requestExecutor(method, params, nil)
+        }
+        do {
+            return try await .success(requestTask.value)
+        } catch {
+            return .failure(error)
+        }
+    }
+
+    private static func isUnsupportedMethodError(_ error: Error) -> Bool {
+        guard case let CodexAppServerClient.ClientError.requestFailed(failure) = error else {
+            return false
+        }
+        return failure.code == -32601
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexHookTrustService.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexHookTrustService.swift
@@ -1,19 +1,42 @@
 import Foundation
 
+enum CodexHookTrustMutationSettlement {
+    case response([String: Any])
+    case unsettled
+}
+
+typealias CodexHookTrustMutationExecutor = @Sendable (
+    _ method: String,
+    _ params: [String: Any]?,
+    _ deadline: TimeInterval
+) async throws -> CodexHookTrustMutationSettlement
+
 struct CodexHookTrustService {
     typealias RequestExecutor = @Sendable (
         _ method: String,
         _ params: [String: Any]?,
         _ timeout: TimeInterval?
     ) async throws -> [String: Any]
+    enum RequestError: Error {
+        case unsupportedMethod
+    }
+
+    private enum ShieldedWriteOutcome {
+        case response([String: Any])
+        case recovered(CodexHookInventory)
+        case failure(Error)
+        case recoveryFailed
+    }
 
     let requestExecutor: RequestExecutor
+    let mutationExecutor: CodexHookTrustMutationExecutor
     let executionCWD: String?
     let timeout: TimeInterval?
+    let writeSettlementDeadline: TimeInterval
 
     func listHooks() async throws -> CodexHookInventory {
         try Task.checkCancellation()
-        return try await loadHookInventory()
+        return try await loadHookInventory(timeout: timeout)
     }
 
     func trustHooks(
@@ -21,7 +44,7 @@ struct CodexHookTrustService {
         expectedInventoryFingerprint: String
     ) async throws -> CodexHookInventory {
         try Task.checkCancellation()
-        let preflightInventory = try await loadHookInventory()
+        let preflightInventory = try await loadHookInventory(timeout: writeSettlementDeadline)
         guard preflightInventory.fingerprint == expectedInventoryFingerprint else {
             throw CodexHookTrustError.inventoryChanged(replacement: preflightInventory)
         }
@@ -31,7 +54,7 @@ struct CodexHookTrustService {
         )
 
         try Task.checkCancellation()
-        let writeOutcome = await performCancellationShieldedRequest(
+        let writeOutcome = await performCancellationShieldedWrite(
             method: "config/batchWrite",
             params: [
                 "edits": [[
@@ -46,10 +69,17 @@ struct CodexHookTrustService {
             throw CodexHookTrustError.cancelled
         }
 
-        let writeResult: [String: Any]
         switch writeOutcome {
-        case let .success(result):
-            writeResult = result
+        case let .response(writeResult):
+            guard writeResult["status"] as? String == "ok" else {
+                throw CodexHookTrustError.batchWriteFailed
+            }
+            return try await verifyCandidates(expectedCandidates)
+        case let .recovered(recoveredInventory):
+            guard recoveredInventory.verifies(expectedCandidates) else {
+                throw CodexHookTrustError.postWriteVerificationFailed(latest: recoveredInventory)
+            }
+            return recoveredInventory
         case let .failure(error):
             if error is CancellationError {
                 throw CodexHookTrustError.cancelled
@@ -58,12 +88,9 @@ struct CodexHookTrustService {
                 throw CodexHookTrustError.unsupportedMethod(method: "config/batchWrite")
             }
             throw CodexHookTrustError.batchWriteFailed
+        case .recoveryFailed:
+            throw CodexHookTrustError.postWriteVerificationFailed(latest: nil)
         }
-        guard writeResult["status"] as? String == "ok" else {
-            throw CodexHookTrustError.batchWriteFailed
-        }
-
-        return try await verifyCandidates(expectedCandidates)
     }
 
     private func validatedTrustValues(
@@ -87,7 +114,7 @@ struct CodexHookTrustService {
         try Task.checkCancellation()
         let verifiedInventory: CodexHookInventory
         do {
-            verifiedInventory = try await loadHookInventory()
+            verifiedInventory = try await loadHookInventory(timeout: writeSettlementDeadline)
         } catch is CancellationError {
             throw CodexHookTrustError.cancelled
         } catch let error as CodexHookTrustError {
@@ -108,7 +135,7 @@ struct CodexHookTrustService {
         return verifiedInventory
     }
 
-    private func loadHookInventory() async throws -> CodexHookInventory {
+    private func loadHookInventory(timeout: TimeInterval?) async throws -> CodexHookInventory {
         guard let executionCWD,
               !executionCWD.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         else {
@@ -133,24 +160,34 @@ struct CodexHookTrustService {
         return try CodexHookInventory.decode(result: result, executionCWD: executionCWD)
     }
 
-    private func performCancellationShieldedRequest(
+    private func performCancellationShieldedWrite(
         method: String,
         params: [String: Any]?
-    ) async -> Result<[String: Any], Error> {
-        let requestTask = Task {
-            try await requestExecutor(method, params, nil)
+    ) async -> ShieldedWriteOutcome {
+        let requestTask = Task<ShieldedWriteOutcome, Never> {
+            do {
+                switch try await mutationExecutor(method, params, writeSettlementDeadline) {
+                case let .response(response):
+                    return ShieldedWriteOutcome.response(response)
+                case .unsettled:
+                    do {
+                        return try await ShieldedWriteOutcome.recovered(
+                            loadHookInventory(timeout: writeSettlementDeadline)
+                        )
+                    } catch {
+                        return ShieldedWriteOutcome.recoveryFailed
+                    }
+                }
+            } catch {
+                return ShieldedWriteOutcome.failure(error)
+            }
         }
-        do {
-            return try await .success(requestTask.value)
-        } catch {
-            return .failure(error)
-        }
+        return await requestTask.value
     }
 
     private static func isUnsupportedMethodError(_ error: Error) -> Bool {
-        guard case let CodexAppServerClient.ClientError.requestFailed(failure) = error else {
-            return false
-        }
-        return failure.code == -32601
+        guard let requestError = error as? RequestError else { return false }
+        guard case .unsupportedMethod = requestError else { return false }
+        return true
     }
 }

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexHookTrustService.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexHookTrustService.swift
@@ -70,7 +70,7 @@ struct CodexHookTrustService {
         for candidates: [CodexHookTrustCandidate],
         in inventory: CodexHookInventory
     ) throws -> [String: Any] {
-        guard inventory.validatedUnresolvedProjectHooks(for: candidates) != nil else {
+        guard inventory.validatesUnresolvedProjectHooks(for: candidates) else {
             throw CodexHookTrustError.inventoryChanged(replacement: inventory)
         }
 

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexNativeSessionController.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexNativeSessionController.swift
@@ -102,6 +102,11 @@ protocol CodexSessionControlling: AnyObject {
     func setThreadGoalObjective(_ objective: String) async throws -> CodexNativeSessionController.ThreadGoal
     func setThreadGoalStatus(_ status: CodexNativeSessionController.ThreadGoalStatus) async throws -> CodexNativeSessionController.ThreadGoal
     func clearThreadGoal() async throws -> Bool
+    func listHooksForCurrentWorkspace() async throws -> CodexHookInventory
+    func trustHooksForCurrentWorkspace(
+        expectedCandidates: [CodexHookTrustCandidate],
+        expectedInventoryFingerprint: String
+    ) async throws -> CodexHookInventory
     func pendingTurnFailure(turnID: String?) async -> CodexNativeSessionController.TurnFailure?
     func acknowledgePendingTurnFailure(
         turnID: String?,
@@ -116,6 +121,17 @@ protocol CodexSessionControlling: AnyObject {
 extension CodexSessionControlling {
     func outstandingBlockingNativeToolCallNames() async -> [String] {
         []
+    }
+
+    func listHooksForCurrentWorkspace() async throws -> CodexHookInventory {
+        throw CodexHookTrustError.unsupportedMethod(method: "hooks/list")
+    }
+
+    func trustHooksForCurrentWorkspace(
+        expectedCandidates _: [CodexHookTrustCandidate],
+        expectedInventoryFingerprint _: String
+    ) async throws -> CodexHookInventory {
+        throw CodexHookTrustError.unsupportedMethod(method: "config/batchWrite")
     }
 
     func cleanupConversation(_ handle: ProviderConversationCleanupHandle, action: ProviderConversationCleanupAction) async -> ProviderConversationCleanupOutcome {
@@ -167,6 +183,7 @@ final class CodexNativeSessionController {
     private static let maxCompletedCanonicalItemScopes = 512
     private static let maxCanonicalCompletionTurnIDs = 128
     private static let maxPendingTurnFailures = 64
+    private static let hookTrustWriteMutex = AsyncMutex()
     private static let computerUseMCPServerName = "computer-use"
     private static let runningOutputTruncationMarker = "\n...(output truncated)...\n"
     private static let removedSyntheticNotificationMethods: Set<String> = [
@@ -735,6 +752,7 @@ final class CodexNativeSessionController {
     private var eventsContinuation: AsyncStream<Event>.Continuation?
     private let eventsContinuationLock = NSLock()
     private let eventHandlingMutex = AsyncMutex()
+    private let hookOperationMutex = AsyncMutex()
     private let eventsStream: AsyncStream<Event>
     /// Protected by `eventsContinuationLock`.
     private var lifecycleState: LifecycleState = .fresh
@@ -858,6 +876,60 @@ final class CodexNativeSessionController {
             timeout: timeout,
             useDefaultTimeout: useDefaultTimeout
         )
+    }
+
+    private func hookTrustService() -> CodexHookTrustService {
+        CodexHookTrustService(
+            requestExecutor: { [weak self] method, params, timeout in
+                guard let self else { throw CodexAppServerClient.ClientError.invalidResponse }
+                return try await performRequest(
+                    method: method,
+                    params: params,
+                    timeout: timeout,
+                    useDefaultTimeout: false
+                )
+            },
+            executionCWD: workspacePaths.executionDirectory,
+            timeout: options.requestTimeout
+        )
+    }
+
+    func listHooksForCurrentWorkspace() async throws -> CodexHookInventory {
+        let service = hookTrustService()
+        do {
+            return try await hookOperationMutex.withLock {
+                try await service.listHooks()
+            }
+        } catch is CancellationError {
+            throw CodexHookTrustError.cancelled
+        } catch let error as CodexHookTrustError {
+            throw error
+        } catch {
+            throw CodexHookTrustError.malformedListResponse
+        }
+    }
+
+    func trustHooksForCurrentWorkspace(
+        expectedCandidates: [CodexHookTrustCandidate],
+        expectedInventoryFingerprint: String
+    ) async throws -> CodexHookInventory {
+        let service = hookTrustService()
+        do {
+            return try await hookOperationMutex.withLock {
+                try await Self.hookTrustWriteMutex.withLock {
+                    try await service.trustHooks(
+                        expectedCandidates: expectedCandidates,
+                        expectedInventoryFingerprint: expectedInventoryFingerprint
+                    )
+                }
+            }
+        } catch is CancellationError {
+            throw CodexHookTrustError.cancelled
+        } catch let error as CodexHookTrustError {
+            throw error
+        } catch {
+            throw CodexHookTrustError.batchWriteFailed
+        }
     }
 
     func cleanupConversation(

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexNativeSessionController.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexNativeSessionController.swift
@@ -1,6 +1,59 @@
 import Foundation
 import OSLog
 
+private actor CodexInboundStreamTaskStartGate {
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var isOpen = false
+
+    func wait() async {
+        guard !isOpen else { return }
+        await withCheckedContinuation { continuation = $0 }
+    }
+
+    func open() {
+        isOpen = true
+        continuation?.resume()
+        continuation = nil
+    }
+}
+
+private final class CodexHookTrustRecoveryRace: @unchecked Sendable {
+    enum Outcome {
+        case succeeded
+        case failed(Error)
+        case deadline
+    }
+
+    private let lock = NSLock()
+    private var outcome: Outcome?
+    private var continuation: CheckedContinuation<Outcome, Never>?
+
+    func wait() async -> Outcome {
+        lock.lock()
+        if let outcome {
+            lock.unlock()
+            return outcome
+        }
+        return await withCheckedContinuation { continuation in
+            self.continuation = continuation
+            lock.unlock()
+        }
+    }
+
+    func resolve(_ outcome: Outcome) {
+        lock.lock()
+        guard self.outcome == nil else {
+            lock.unlock()
+            return
+        }
+        self.outcome = outcome
+        let continuation = continuation
+        self.continuation = nil
+        lock.unlock()
+        continuation?.resume(returning: outcome)
+    }
+}
+
 struct CodexTurnStartReceipt: Equatable {
     let provisionalSubmissionID: String
 }
@@ -140,6 +193,12 @@ extension CodexSessionControlling {
 }
 
 final class CodexNativeSessionController {
+    private struct InboundStreamTaskRecord {
+        let token: UUID
+        let transportGeneration: UInt64
+        let task: Task<Void, Never>
+    }
+
     private static let logger = Logger(
         subsystem: "com.repoprompt.agents",
         category: "CodexNativeSessionController"
@@ -184,6 +243,7 @@ final class CodexNativeSessionController {
     private static let maxCanonicalCompletionTurnIDs = 128
     private static let maxPendingTurnFailures = 64
     private static let hookTrustWriteMutex = AsyncMutex()
+    private static let maxHookTrustWriteSettlementDeadline: TimeInterval = 30
     private static let computerUseMCPServerName = "computer-use"
     private static let runningOutputTruncationMarker = "\n...(output truncated)...\n"
     private static let removedSyntheticNotificationMethods: Set<String> = [
@@ -662,6 +722,19 @@ final class CodexNativeSessionController {
         case stopOnShutdown
     }
 
+    struct HookTrustFaultInjection {
+        let settlementRecoveryExecutor: (@Sendable () async throws -> Void)?
+        let mutationExecutor: CodexHookTrustMutationExecutor?
+
+        init(
+            settlementRecoveryExecutor: (@Sendable () async throws -> Void)? = nil,
+            mutationExecutor: CodexHookTrustMutationExecutor? = nil
+        ) {
+            self.settlementRecoveryExecutor = settlementRecoveryExecutor
+            self.mutationExecutor = mutationExecutor
+        }
+    }
+
     private enum ThreadMemoryMode: String {
         case enabled
         case disabled
@@ -683,6 +756,13 @@ final class CodexNativeSessionController {
     private enum InboundStreamKind {
         case notifications
         case serverRequests
+
+        var sourceDescription: String {
+            switch self {
+            case .notifications: "notifications"
+            case .serverRequests: "serverRequests"
+            }
+        }
     }
 
     private struct LifecycleAuthorityReconciliationLineage: Equatable {
@@ -711,6 +791,7 @@ final class CodexNativeSessionController {
     private let clientShutdownBehavior: ClientShutdownBehavior
     private let expectedMCPClientName: String?
     private let requestExecutor: (@Sendable (String, [String: Any]?, TimeInterval?) async throws -> [String: Any])?
+    private let hookTrustFaultInjection: HookTrustFaultInjection
     private let rawEventFileLoggingEnabled: Bool
     private var rawEventLogFileURL: URL?
     private var rawEventLogFileThreadID: String?
@@ -747,12 +828,24 @@ final class CodexNativeSessionController {
         threadID?.isEmpty == false
     }
 
-    private var notificationTask: Task<Void, Never>?
-    private var serverRequestTask: Task<Void, Never>?
+    private let inboundStreamInstallationMutex = AsyncMutex()
+    private let inboundStreamTaskLock = NSLock()
+    /// Protected by `inboundStreamTaskLock`.
+    private var notificationTask: InboundStreamTaskRecord?
+    /// Protected by `inboundStreamTaskLock`.
+    private var serverRequestTask: InboundStreamTaskRecord?
     private var eventsContinuation: AsyncStream<Event>.Continuation?
     private let eventsContinuationLock = NSLock()
     private let eventHandlingMutex = AsyncMutex()
     private let hookOperationMutex = AsyncMutex()
+    private let hookTrustSettlementStateLock = NSLock()
+    /// Protected by `hookTrustSettlementStateLock`. While set, inbound stream closure
+    /// belongs to a planned unsettled-write retirement and must not terminalize this
+    /// otherwise reusable controller.
+    private var retiringHookTrustGeneration: UInt64?
+    /// Protected by `hookTrustSettlementStateLock`. Generations are monotonic and
+    /// retained so a cancelled handler that exits after recovery remains suppressed.
+    private var retiredHookTrustTransportGenerations: Set<UInt64> = []
     private let eventsStream: AsyncStream<Event>
     /// Protected by `eventsContinuationLock`.
     private var lifecycleState: LifecycleState = .fresh
@@ -882,23 +975,239 @@ final class CodexNativeSessionController {
         CodexHookTrustService(
             requestExecutor: { [weak self] method, params, timeout in
                 guard let self else { throw CodexAppServerClient.ClientError.invalidResponse }
-                return try await performRequest(
+                do {
+                    if let requestExecutor {
+                        return try await requestExecutor(method, params, timeout)
+                    }
+                    try await ensureHookTrustTransportReady()
+                    return try await client.request(
+                        method: method,
+                        params: params,
+                        timeout: timeout,
+                        useDefaultTimeout: false
+                    )
+                } catch {
+                    throw mapHookTrustRequestError(error)
+                }
+            },
+            mutationExecutor: { [weak self] method, params, deadline in
+                guard let self else { throw CodexAppServerClient.ClientError.invalidResponse }
+                return try await executeHookTrustMutation(
                     method: method,
                     params: params,
-                    timeout: timeout,
-                    useDefaultTimeout: false
+                    deadline: deadline
                 )
             },
             executionCWD: workspacePaths.executionDirectory,
-            timeout: options.requestTimeout
+            timeout: options.requestTimeout,
+            writeSettlementDeadline: hookTrustWriteSettlementDeadline
         )
+    }
+
+    private func executeHookTrustMutation(
+        method: String,
+        params: [String: Any]?,
+        deadline: TimeInterval
+    ) async throws -> CodexHookTrustMutationSettlement {
+        let settlement: CodexHookTrustMutationSettlement
+        do {
+            if let mutationExecutor = hookTrustFaultInjection.mutationExecutor {
+                settlement = try await mutationExecutor(method, params, deadline)
+            } else if let requestExecutor {
+                settlement = try await .response(requestExecutor(method, params, deadline))
+            } else {
+                try await ensureHookTrustTransportReady()
+                settlement = try await .response(
+                    client.requestWithSettlementDeadline(
+                        method: method,
+                        params: params,
+                        deadline: deadline,
+                        onUnsettled: { [weak self] generation in
+                            self?.markHookTrustTransportRetiring(generation: generation)
+                        }
+                    )
+                )
+            }
+        } catch {
+            guard CodexAppServerClient.isTimeoutError(error)
+                || CodexAppServerClient.isAmbiguousMutationError(error)
+            else {
+                throw mapHookTrustRequestError(error)
+            }
+            settlement = .unsettled
+        }
+
+        if case .unsettled = settlement {
+            try await performHookTrustTransportRecovery()
+        }
+        return settlement
+    }
+
+    private func mapHookTrustRequestError(_ error: Error) -> Error {
+        guard case let CodexAppServerClient.ClientError.requestFailed(failure) = error,
+              failure.code == -32601
+        else {
+            return error
+        }
+        return CodexHookTrustService.RequestError.unsupportedMethod
+    }
+
+    private var hookTrustWriteSettlementDeadline: TimeInterval {
+        guard let configured = options.requestTimeout,
+              configured.isFinite,
+              configured > 0
+        else {
+            return Self.maxHookTrustWriteSettlementDeadline
+        }
+        return min(configured, Self.maxHookTrustWriteSettlementDeadline)
+    }
+
+    private func ensureHookTrustTransportReady() async throws {
+        let canUseController = withEventsStateLock {
+            lifecycleState == .binding || lifecycleState == .active
+        }
+        guard canUseController else {
+            throw CodexAppServerClient.ClientError.processNotRunning
+        }
+        try await client.startIfNeeded()
+        try await ensureInboundStreamsStartedForRecovery()
+    }
+
+    private func markHookTrustTransportRetiring(generation: UInt64) {
+        hookTrustSettlementStateLock.lock()
+        retiringHookTrustGeneration = generation
+        hookTrustSettlementStateLock.unlock()
+        recordRetiredHookTrustGeneration(generation)
+        Self.logger.error("Codex hook-trust mutation unsettled; retiring transport generation=\(generation, privacy: .public)")
+        #if DEBUG
+            AgentModePerfDiagnostics.event(
+                "provider.codex.hookTrust.transportRetiring",
+                tabID: tabID,
+                fields: [
+                    "settlementDeadlineSeconds": String(hookTrustWriteSettlementDeadline),
+                    "transportGeneration": String(generation)
+                ]
+            )
+        #endif
+    }
+
+    private func recordRetiredHookTrustGeneration(_ generation: UInt64) {
+        hookTrustSettlementStateLock.lock()
+        retiredHookTrustTransportGenerations.insert(generation)
+        if retiredHookTrustTransportGenerations.count > 32,
+           let oldest = retiredHookTrustTransportGenerations.min()
+        {
+            retiredHookTrustTransportGenerations.remove(oldest)
+        }
+        hookTrustSettlementStateLock.unlock()
+    }
+
+    private func shouldSuppressHookTrustStreamEnd(transportGeneration: UInt64?) -> Bool {
+        guard let transportGeneration else { return false }
+        hookTrustSettlementStateLock.lock()
+        defer { hookTrustSettlementStateLock.unlock() }
+        return retiredHookTrustTransportGenerations.contains(transportGeneration)
+    }
+
+    private func finishHookTrustTransportRecovery(succeeded: Bool) {
+        hookTrustSettlementStateLock.lock()
+        let generation = retiringHookTrustGeneration
+        retiringHookTrustGeneration = nil
+        hookTrustSettlementStateLock.unlock()
+        guard let generation else { return }
+        Self.logger.notice("Codex hook-trust settlement recovery finished; generation=\(generation, privacy: .public) succeeded=\(succeeded, privacy: .public)")
+        #if DEBUG
+            AgentModePerfDiagnostics.event(
+                "provider.codex.hookTrust.settlementRecoveryFinished",
+                tabID: tabID,
+                fields: [
+                    "succeeded": String(succeeded),
+                    "retiredTransportGeneration": String(generation)
+                ]
+            )
+        #endif
+    }
+
+    private func recoverHookTrustTransportAfterUnsettledWrite() async throws {
+        let retiredGeneration = currentRetiringHookTrustGeneration()
+        retireInboundStreamTasks(transportGeneration: retiredGeneration)
+
+        let race = CodexHookTrustRecoveryRace()
+        let recoveryTask = Task { [weak self] in
+            guard let self else {
+                race.resolve(.failed(CodexAppServerClient.ClientError.invalidResponse))
+                return
+            }
+            do {
+                try await client.startIfNeeded(
+                    initializationTimeout: hookTrustWriteSettlementDeadline
+                )
+                try await ensureInboundStreamsStartedForRecovery()
+                race.resolve(.succeeded)
+            } catch {
+                race.resolve(.failed(error))
+            }
+        }
+        let timeoutTask = Task.detached { [deadline = hookTrustWriteSettlementDeadline] in
+            try? await Task.sleep(nanoseconds: UInt64(deadline * 1_000_000_000))
+            guard !Task.isCancelled else { return }
+            race.resolve(.deadline)
+        }
+
+        switch await race.wait() {
+        case .succeeded:
+            timeoutTask.cancel()
+        case let .failed(error):
+            timeoutTask.cancel()
+            recoveryTask.cancel()
+            retireAllInboundStreamTasks()
+            await client.stop()
+            throw error
+        case .deadline:
+            recoveryTask.cancel()
+            retireAllInboundStreamTasks()
+            await client.stop()
+            throw CodexAppServerClient.ClientError.requestFailed(.init(
+                method: "initialize",
+                code: nil,
+                message: "Hook-trust transport recovery timed out after \(hookTrustWriteSettlementDeadline)s",
+                data: nil
+            ))
+        }
+    }
+
+    private func currentRetiringHookTrustGeneration() -> UInt64? {
+        hookTrustSettlementStateLock.lock()
+        defer { hookTrustSettlementStateLock.unlock() }
+        return retiringHookTrustGeneration
+    }
+
+    private func performHookTrustTransportRecovery() async throws {
+        var succeeded = false
+        defer { finishHookTrustTransportRecovery(succeeded: succeeded) }
+        if let settlementRecoveryExecutor = hookTrustFaultInjection.settlementRecoveryExecutor {
+            try await settlementRecoveryExecutor()
+        } else {
+            try await recoverHookTrustTransportAfterUnsettledWrite()
+        }
+        succeeded = true
     }
 
     func listHooksForCurrentWorkspace() async throws -> CodexHookInventory {
         let service = hookTrustService()
+        #if DEBUG
+            let lockWaitStartMS = AgentModePerfDiagnostics.timestampMSIfEnabled()
+        #endif
         do {
             return try await hookOperationMutex.withLock {
-                try await service.listHooks()
+                #if DEBUG
+                    AgentModePerfDiagnostics.durationEvent(
+                        "provider.codex.hookTrust.localLockWait",
+                        startMS: lockWaitStartMS,
+                        tabID: tabID
+                    )
+                #endif
+                return try await service.listHooks()
             }
         } catch is CancellationError {
             throw CodexHookTrustError.cancelled
@@ -914,10 +1223,28 @@ final class CodexNativeSessionController {
         expectedInventoryFingerprint: String
     ) async throws -> CodexHookInventory {
         let service = hookTrustService()
+        #if DEBUG
+            let localLockWaitStartMS = AgentModePerfDiagnostics.timestampMSIfEnabled()
+        #endif
         do {
             return try await hookOperationMutex.withLock {
-                try await Self.hookTrustWriteMutex.withLock {
-                    try await service.trustHooks(
+                #if DEBUG
+                    AgentModePerfDiagnostics.durationEvent(
+                        "provider.codex.hookTrust.localLockWait",
+                        startMS: localLockWaitStartMS,
+                        tabID: tabID
+                    )
+                    let globalLockWaitStartMS = AgentModePerfDiagnostics.timestampMSIfEnabled()
+                #endif
+                return try await Self.hookTrustWriteMutex.withLock {
+                    #if DEBUG
+                        AgentModePerfDiagnostics.durationEvent(
+                            "provider.codex.hookTrust.globalLockWait",
+                            startMS: globalLockWaitStartMS,
+                            tabID: tabID
+                        )
+                    #endif
+                    return try await service.trustHooks(
                         expectedCandidates: expectedCandidates,
                         expectedInventoryFingerprint: expectedInventoryFingerprint
                     )
@@ -955,7 +1282,8 @@ final class CodexNativeSessionController {
         options: Options? = nil,
         clientShutdownBehavior: ClientShutdownBehavior = .none,
         expectedMCPClientName: String? = nil,
-        requestExecutor: (@Sendable (String, [String: Any]?, TimeInterval?) async throws -> [String: Any])? = nil
+        requestExecutor: (@Sendable (String, [String: Any]?, TimeInterval?) async throws -> [String: Any])? = nil,
+        hookTrustFaultInjection: HookTrustFaultInjection = .init()
     ) {
         self.client = client
         self.runID = runID
@@ -966,6 +1294,7 @@ final class CodexNativeSessionController {
         self.clientShutdownBehavior = clientShutdownBehavior
         self.expectedMCPClientName = expectedMCPClientName
         self.requestExecutor = requestExecutor
+        self.hookTrustFaultInjection = hookTrustFaultInjection
         rawEventFileLoggingEnabled = Self.isRawEventFileLoggingEnabled()
         rawEventLogFileURL = nil
         rawEventLogFileThreadID = nil
@@ -978,6 +1307,10 @@ final class CodexNativeSessionController {
     }
 
     deinit {
+        inboundStreamTaskLock.lock()
+        let notificationTask = notificationTask?.task
+        let serverRequestTask = serverRequestTask?.task
+        inboundStreamTaskLock.unlock()
         notificationTask?.cancel()
         serverRequestTask?.cancel()
         finishEventsStreamIfNeeded()
@@ -2059,10 +2392,7 @@ final class CodexNativeSessionController {
                 lifecycleState = .shuttingDown
             }
         }
-        notificationTask?.cancel()
-        notificationTask = nil
-        serverRequestTask?.cancel()
-        serverRequestTask = nil
+        retireAllInboundStreamTasks()
         assistantEmittedTextByTurnID.removeAll(keepingCapacity: false)
         completedCanonicalItemScopes.removeAll(keepingCapacity: false)
         completedCanonicalItemScopeOrder.removeAll(keepingCapacity: false)
@@ -2394,8 +2724,14 @@ final class CodexNativeSessionController {
     }
 
     private func ensureInboundStreamsStarted() async {
-        await startNotificationStreamIfNeeded()
-        await startServerRequestStreamIfNeeded()
+        try? await ensureInboundStreamsStartedForRecovery()
+    }
+
+    private func ensureInboundStreamsStartedForRecovery() async throws {
+        try await inboundStreamInstallationMutex.withLock {
+            try await startNotificationStreamIfNeeded()
+            try await startServerRequestStreamIfNeeded()
+        }
     }
 
     private func shouldInstallInboundStreamTask() -> Bool {
@@ -2409,16 +2745,60 @@ final class CodexNativeSessionController {
         }
     }
 
-    private func startNotificationStreamIfNeeded() async {
-        guard notificationTask == nil else { return }
-        let stream = await client.subscribeNotifications()
+    private func startNotificationStreamIfNeeded() async throws {
+        try await installInboundStreamIfNeeded(
+            kind: .notifications,
+            acquireSubscription: { [client] in
+                let subscription = try await client.subscribeNotificationsWithTransportGeneration()
+                return (subscription.stream, subscription.transportGeneration)
+            },
+            handleElement: { controller, notification in
+                await controller.handleOrBufferNotification(notification)
+            }
+        )
+    }
+
+    private func startServerRequestStreamIfNeeded() async throws {
+        try await installInboundStreamIfNeeded(
+            kind: .serverRequests,
+            acquireSubscription: { [client] in
+                let subscription = try await client.subscribeServerRequestsWithTransportGeneration()
+                return (subscription.stream, subscription.transportGeneration)
+            },
+            handleElement: { controller, request in
+                await controller.handleOrBufferServerRequest(request)
+            }
+        )
+    }
+
+    private func installInboundStreamIfNeeded<Element>(
+        kind: InboundStreamKind,
+        acquireSubscription: () async throws -> (stream: AsyncStream<Element>, transportGeneration: UInt64),
+        handleElement: @escaping (CodexNativeSessionController, Element) async -> Void
+    ) async throws {
+        guard let healthyGeneration = await client.healthyTransportGeneration() else {
+            retireInboundStreamTask(kind: kind)
+            throw CodexAppServerClient.ClientError.processNotRunning
+        }
+        if reconcileInboundStreamTask(kind: kind, healthyGeneration: healthyGeneration) {
+            return
+        }
+
+        let subscription = try await acquireSubscription()
+        try Task.checkCancellation()
+        guard await client.healthyTransportGeneration() == subscription.transportGeneration else {
+            throw CodexAppServerClient.ClientError.processNotRunning
+        }
         guard shouldInstallInboundStreamTask() else { return }
-        notificationTask = Task { [weak self] in
-            for await notification in stream {
+        let token = UUID()
+        let startGate = CodexInboundStreamTaskStartGate()
+        let task = Task { [weak self] in
+            await startGate.wait()
+            for await element in subscription.stream {
                 guard let self else { return }
                 do {
                     try await eventHandlingMutex.withLock {
-                        await self.handleOrBufferNotification(notification)
+                        await handleElement(self, element)
                     }
                 } catch is CancellationError {
                     return
@@ -2427,30 +2807,108 @@ final class CodexNativeSessionController {
                 }
             }
             guard let self else { return }
-            await handleInboundStreamDidExit(kind: .notifications, source: "notifications")
+            await handleInboundStreamDidExit(
+                kind: kind,
+                source: kind.sourceDescription,
+                ownershipToken: token,
+                transportGeneration: subscription.transportGeneration
+            )
+        }
+        installInboundStreamTask(
+            .init(
+                token: token,
+                transportGeneration: subscription.transportGeneration,
+                task: task
+            ),
+            kind: kind
+        )
+        await startGate.open()
+    }
+
+    private func currentInboundStreamTask(kind: InboundStreamKind) -> InboundStreamTaskRecord? {
+        inboundStreamTaskLock.lock()
+        defer { inboundStreamTaskLock.unlock() }
+        switch kind {
+        case .notifications:
+            return notificationTask
+        case .serverRequests:
+            return serverRequestTask
         }
     }
 
-    private func startServerRequestStreamIfNeeded() async {
-        guard serverRequestTask == nil else { return }
-        let stream = await client.subscribeServerRequests()
-        guard shouldInstallInboundStreamTask() else { return }
-        serverRequestTask = Task { [weak self] in
-            for await request in stream {
-                guard let self else { return }
-                do {
-                    try await eventHandlingMutex.withLock {
-                        await self.handleOrBufferServerRequest(request)
-                    }
-                } catch is CancellationError {
-                    return
-                } catch {
-                    return
-                }
+    private func reconcileInboundStreamTask(
+        kind: InboundStreamKind,
+        healthyGeneration: UInt64
+    ) -> Bool {
+        let existing = currentInboundStreamTask(kind: kind)
+        guard let existing else { return false }
+        guard existing.transportGeneration != healthyGeneration else { return true }
+        retireInboundStreamTask(kind: kind, ownershipToken: existing.token)
+        return false
+    }
+
+    private func retireInboundStreamTask(
+        kind: InboundStreamKind,
+        ownershipToken: UUID? = nil
+    ) {
+        let retired = inboundStreamTaskLock.withLock { () -> InboundStreamTaskRecord? in
+            switch kind {
+            case .notifications:
+                guard ownershipToken == nil || notificationTask?.token == ownershipToken else { return nil }
+                let record = notificationTask
+                notificationTask = nil
+                return record
+            case .serverRequests:
+                guard ownershipToken == nil || serverRequestTask?.token == ownershipToken else { return nil }
+                let record = serverRequestTask
+                serverRequestTask = nil
+                return record
             }
-            guard let self else { return }
-            await handleInboundStreamDidExit(kind: .serverRequests, source: "serverRequests")
         }
+        retired?.task.cancel()
+    }
+
+    private func installInboundStreamTask(
+        _ record: InboundStreamTaskRecord,
+        kind: InboundStreamKind
+    ) {
+        inboundStreamTaskLock.lock()
+        switch kind {
+        case .notifications:
+            notificationTask = record
+        case .serverRequests:
+            serverRequestTask = record
+        }
+        inboundStreamTaskLock.unlock()
+    }
+
+    private func retireInboundStreamTasks(transportGeneration: UInt64?) {
+        guard let transportGeneration else { return }
+        recordRetiredHookTrustGeneration(transportGeneration)
+
+        inboundStreamTaskLock.lock()
+        let notification = notificationTask?.transportGeneration == transportGeneration
+            ? notificationTask
+            : nil
+        let serverRequests = serverRequestTask?.transportGeneration == transportGeneration
+            ? serverRequestTask
+            : nil
+        if notification != nil { notificationTask = nil }
+        if serverRequests != nil { serverRequestTask = nil }
+        inboundStreamTaskLock.unlock()
+        notification?.task.cancel()
+        serverRequests?.task.cancel()
+    }
+
+    private func retireAllInboundStreamTasks() {
+        inboundStreamTaskLock.lock()
+        let notification = notificationTask
+        let serverRequests = serverRequestTask
+        notificationTask = nil
+        serverRequestTask = nil
+        inboundStreamTaskLock.unlock()
+        notification?.task.cancel()
+        serverRequests?.task.cancel()
     }
 
     private func beginBindingSession() {
@@ -2503,12 +2961,38 @@ final class CodexNativeSessionController {
         bufferedInbound.append(inbound)
     }
 
-    private func handleInboundStreamDidExit(kind: InboundStreamKind, source: String) async {
-        switch kind {
-        case .notifications:
-            notificationTask = nil
-        case .serverRequests:
-            serverRequestTask = nil
+    private func handleInboundStreamDidExit(
+        kind: InboundStreamKind,
+        source: String,
+        ownershipToken: UUID,
+        transportGeneration: UInt64?
+    ) async {
+        let stillOwnsSlot = inboundStreamTaskLock.withLock {
+            switch kind {
+            case .notifications:
+                let ownsSlot = notificationTask?.token == ownershipToken
+                if ownsSlot { notificationTask = nil }
+                return ownsSlot
+            case .serverRequests:
+                let ownsSlot = serverRequestTask?.token == ownershipToken
+                if ownsSlot { serverRequestTask = nil }
+                return ownsSlot
+            }
+        }
+        if shouldSuppressHookTrustStreamEnd(transportGeneration: transportGeneration) {
+            let generationDescription = transportGeneration.map(String.init) ?? "unknown"
+            Self.logCodexDebug(
+                "[CodexNativeController] suppressing planned hook-trust transport retirement "
+                    + "source=\(source) generation=\(generationDescription)"
+            )
+            return
+        }
+        guard stillOwnsSlot else {
+            Self.logCodexDebug(
+                "[CodexNativeController] ignoring superseded inbound stream ending "
+                    + "source=\(source)"
+            )
+            return
         }
         do {
             try await eventHandlingMutex.withLock {
@@ -3714,6 +4198,24 @@ final class CodexNativeSessionController {
     }
 
     #if DEBUG
+        func test_markHookTrustTransportRetiring(generation: UInt64) {
+            markHookTrustTransportRetiring(generation: generation)
+        }
+
+        func test_shouldSuppressHookTrustStreamEnd(transportGeneration: UInt64?) -> Bool {
+            shouldSuppressHookTrustStreamEnd(transportGeneration: transportGeneration)
+        }
+
+        func test_ensureInboundStreamsStarted() async {
+            await ensureInboundStreamsStarted()
+        }
+
+        func test_inboundStreamTransportGenerations() -> (notifications: UInt64?, serverRequests: UInt64?) {
+            inboundStreamTaskLock.withLock {
+                (notificationTask?.transportGeneration, serverRequestTask?.transportGeneration)
+            }
+        }
+
         func test_installThreadState(
             threadID: String,
             authoritativeTurnID: String? = nil,

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexNativeSessionController.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexNativeSessionController.swift
@@ -52,6 +52,23 @@ private final class CodexHookTrustRecoveryRace: @unchecked Sendable {
         lock.unlock()
         continuation?.resume(returning: outcome)
     }
+
+    @discardableResult
+    func resolveSucceeded(commit: () -> Void) -> Bool {
+        lock.lock()
+        guard outcome == nil else {
+            lock.unlock()
+            return false
+        }
+        commit()
+        let resolved = Outcome.succeeded
+        outcome = resolved
+        let continuation = continuation
+        self.continuation = nil
+        lock.unlock()
+        continuation?.resume(returning: resolved)
+        return true
+    }
 }
 
 struct CodexTurnStartReceipt: Equatable {
@@ -106,6 +123,7 @@ enum CodexTurnInterruptError: Error, LocalizedError, Equatable {
 
 protocol CodexSessionControlling: AnyObject {
     var hasActiveThread: Bool { get }
+    var currentSessionReference: CodexNativeSessionController.SessionRef? { get }
     var events: AsyncStream<CodexNativeSessionController.Event> { get }
 
     func ensureEventsStreamReady()
@@ -172,6 +190,10 @@ protocol CodexSessionControlling: AnyObject {
 }
 
 extension CodexSessionControlling {
+    var currentSessionReference: CodexNativeSessionController.SessionRef? {
+        nil
+    }
+
     func outstandingBlockingNativeToolCallNames() async -> [String] {
         []
     }
@@ -725,13 +747,16 @@ final class CodexNativeSessionController {
     struct HookTrustFaultInjection {
         let settlementRecoveryExecutor: (@Sendable () async throws -> Void)?
         let mutationExecutor: CodexHookTrustMutationExecutor?
+        let threadRebindCommitPreparation: (@Sendable () async -> Void)?
 
         init(
             settlementRecoveryExecutor: (@Sendable () async throws -> Void)? = nil,
-            mutationExecutor: CodexHookTrustMutationExecutor? = nil
+            mutationExecutor: CodexHookTrustMutationExecutor? = nil,
+            threadRebindCommitPreparation: (@Sendable () async -> Void)? = nil
         ) {
             self.settlementRecoveryExecutor = settlementRecoveryExecutor
             self.mutationExecutor = mutationExecutor
+            self.threadRebindCommitPreparation = threadRebindCommitPreparation
         }
     }
 
@@ -780,6 +805,14 @@ final class CodexNativeSessionController {
         let kind: LifecycleAuthorityObservationKind
     }
 
+    private struct ThreadBindingContext {
+        let existing: SessionRef?
+        let baseInstructions: String
+        let model: String?
+        let reasoningEffort: String?
+        let serviceTier: String?
+    }
+
     private let client: CodexAppServerClient
     private let runID: UUID
     private let tabID: UUID
@@ -799,6 +832,8 @@ final class CodexNativeSessionController {
 
     private var threadID: String?
     private var threadPath: String?
+    private var activeSessionReference: SessionRef?
+    private var threadBindingContext: ThreadBindingContext?
     private var routingCurrentTurnID: String?
     private var authoritativeLifecycleTurnID: String?
     private var activeTurnIDs: Set<String> = []
@@ -826,6 +861,10 @@ final class CodexNativeSessionController {
 
     var hasActiveThread: Bool {
         threadID?.isEmpty == false
+    }
+
+    var currentSessionReference: SessionRef? {
+        activeSessionReference
     }
 
     private let inboundStreamInstallationMutex = AsyncMutex()
@@ -1128,6 +1167,100 @@ final class CodexNativeSessionController {
         #endif
     }
 
+    private static func isMissingFreshThreadResumeError(
+        _ error: Error,
+        threadID: String
+    ) -> Bool {
+        guard case let CodexAppServerClient.ClientError.requestFailed(failure) = error,
+              failure.method == "thread/resume",
+              failure.code == -32600
+        else {
+            return false
+        }
+        let normalized = failure.message
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        let normalizedThreadID = threadID.lowercased()
+        return normalized == "no rollout found for thread id \(normalizedThreadID)"
+            || normalized == "thread not found: \(normalizedThreadID)"
+            || normalized == "thread not loaded: \(normalizedThreadID)"
+    }
+
+    private func prepareHookTrustThreadBindingRestoration() async throws -> ThreadSnapshot {
+        guard let binding = threadBindingContext,
+              let priorReference = activeSessionReference,
+              let priorThreadID = Self.nonEmptyString(priorReference.conversationID)
+        else {
+            throw CodexAppServerClient.ClientError.invalidResponse
+        }
+
+        let skillExtraRoots = options.skillExtraRootsProvider().map(\.standardizedFileURL.path)
+        if !skillExtraRoots.isEmpty {
+            _ = try await performRequest(
+                method: "skills/extraRoots/set",
+                params: ["extraRoots": skillExtraRoots],
+                timeout: hookTrustWriteSettlementDeadline
+            )
+        }
+
+        if binding.existing != nil {
+            let desiredMemoryMode: ThreadMemoryMode? = await MainActor.run {
+                guard let memoriesEnabledProvider = options.memoriesEnabledProvider else { return nil }
+                return memoriesEnabledProvider() ? .enabled : .disabled
+            }
+            if let desiredMemoryMode {
+                try await setThreadMemoryMode(
+                    desiredMemoryMode,
+                    threadID: priorThreadID,
+                    timeout: hookTrustWriteSettlementDeadline
+                )
+            }
+        }
+
+        let configOverrides = await options.configOverridesProvider()
+        let result: [String: Any]
+        var startedFreshReplacement = false
+        do {
+            result = try await requestThreadBinding(
+                resumeThreadID: priorThreadID,
+                existing: priorReference,
+                baseInstructions: binding.baseInstructions,
+                model: binding.model,
+                serviceTier: binding.serviceTier,
+                configOverrides: configOverrides,
+                timeout: hookTrustWriteSettlementDeadline
+            )
+        } catch {
+            guard binding.existing == nil,
+                  Self.isMissingFreshThreadResumeError(error, threadID: priorThreadID)
+            else {
+                throw error
+            }
+            startedFreshReplacement = true
+            Self.logger.notice("Codex hook-trust recovery could not resume the pre-turn thread; starting a fresh replacement thread")
+            result = try await requestThreadBinding(
+                resumeThreadID: nil,
+                existing: nil,
+                baseInstructions: binding.baseInstructions,
+                model: binding.model,
+                serviceTier: binding.serviceTier,
+                configOverrides: configOverrides,
+                timeout: hookTrustWriteSettlementDeadline
+            )
+        }
+
+        let snapshot = Self.parseThreadSnapshot(from: result, fallbackEffort: binding.reasoningEffort)
+        guard Self.nonEmptyString(snapshot.conversationID) != nil else {
+            throw CodexAppServerClient.ClientError.invalidResponse
+        }
+        if !startedFreshReplacement,
+           snapshot.conversationID != priorThreadID
+        {
+            throw CodexAppServerClient.ClientError.invalidResponse
+        }
+        return snapshot
+    }
+
     private func recoverHookTrustTransportAfterUnsettledWrite() async throws {
         let retiredGeneration = currentRetiringHookTrustGeneration()
         retireInboundStreamTasks(transportGeneration: retiredGeneration)
@@ -1143,7 +1276,16 @@ final class CodexNativeSessionController {
                     initializationTimeout: hookTrustWriteSettlementDeadline
                 )
                 try await ensureInboundStreamsStartedForRecovery()
-                race.resolve(.succeeded)
+                let snapshot = try await prepareHookTrustThreadBindingRestoration()
+                await hookTrustFaultInjection.threadRebindCommitPreparation?()
+                let didCommit = try await eventHandlingMutex.withLock {
+                    race.resolveSucceeded {
+                        restoreThreadSnapshot(snapshot)
+                    }
+                }
+                if didCommit {
+                    recordAppliedThreadSnapshot(snapshot)
+                }
             } catch {
                 race.resolve(.failed(error))
             }
@@ -1563,6 +1705,74 @@ final class CodexNativeSessionController {
         appendRawEventLogRecord(record)
     }
 
+    private func requestThreadBinding(
+        resumeThreadID: String?,
+        existing: SessionRef?,
+        baseInstructions: String,
+        model: String?,
+        serviceTier: String?,
+        configOverrides: [String: Any],
+        timeout: TimeInterval?
+    ) async throws -> [String: Any] {
+        if let resumeThreadID {
+            var params: [String: Any] = ["threadId": resumeThreadID]
+            if let rolloutPath = existing?.rolloutPath?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !rolloutPath.isEmpty
+            {
+                params["path"] = rolloutPath
+            }
+            if let model {
+                params["model"] = model
+            }
+            Self.addServiceTier(serviceTier, to: &params)
+            if let executionDirectory = workspacePaths.executionDirectory {
+                params["cwd"] = executionDirectory
+            }
+            if !configOverrides.isEmpty {
+                params["config"] = configOverrides
+            }
+            // baseInstructions is intentionally omitted on thread/resume: the app-server
+            // preserves original instructions across resume (confirmed by Codex protocol
+            // tests: resume_switches_models_preserves_base_instructions). Resending them
+            // wastes ~5-6k tokens on every reconnect for no benefit.
+            return try await requestWithCompatibleAppServerRequestValueStyle(
+                method: "thread/resume",
+                timeout: timeout
+            ) { requestValueStyle in
+                var requestParams = params
+                requestParams["approvalPolicy"] = options.approvalPolicyProvider().appServerRequestValue(style: requestValueStyle)
+                requestParams["sandbox"] = options.sandboxModeProvider().appServerRequestValue(style: requestValueStyle)
+                requestParams["approvalsReviewer"] = options.approvalReviewerProvider().appServerRequestValue
+                return requestParams
+            }
+        }
+
+        var params: [String: Any] = [:]
+        if let model {
+            params["model"] = model
+        }
+        Self.addServiceTier(serviceTier, to: &params)
+        if let executionDirectory = workspacePaths.executionDirectory {
+            params["cwd"] = executionDirectory
+        }
+        if !configOverrides.isEmpty {
+            params["config"] = configOverrides
+        }
+        if !baseInstructions.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            params["baseInstructions"] = baseInstructions
+        }
+        return try await requestWithCompatibleAppServerRequestValueStyle(
+            method: "thread/start",
+            timeout: timeout
+        ) { requestValueStyle in
+            var requestParams = params
+            requestParams["approvalPolicy"] = options.approvalPolicyProvider().appServerRequestValue(style: requestValueStyle)
+            requestParams["sandbox"] = options.sandboxModeProvider().appServerRequestValue(style: requestValueStyle)
+            requestParams["approvalsReviewer"] = options.approvalReviewerProvider().appServerRequestValue
+            return requestParams
+        }
+    }
+
     func startOrResume(existing: SessionRef?, baseInstructions: String) async throws -> SessionRef {
         try await startOrResume(
             existing: existing,
@@ -1718,7 +1928,11 @@ final class CodexNativeSessionController {
                     return memoriesEnabledProvider() ? .enabled : .disabled
                 }
                 if let desiredMemoryMode {
-                    try await setThreadMemoryMode(desiredMemoryMode, threadID: resumeThreadID)
+                    try await setThreadMemoryMode(
+                        desiredMemoryMode,
+                        threadID: resumeThreadID,
+                        timeout: options.requestTimeout
+                    )
                 }
             }
 
@@ -1732,63 +1946,15 @@ final class CodexNativeSessionController {
             #endif
 
             do {
-                if let resumeThreadID {
-                    var params: [String: Any] = ["threadId": resumeThreadID]
-                    if let rolloutPath = existing?.rolloutPath?.trimmingCharacters(in: .whitespacesAndNewlines),
-                       !rolloutPath.isEmpty
-                    {
-                        params["path"] = rolloutPath
-                    }
-                    if let model {
-                        params["model"] = model
-                    }
-                    Self.addServiceTier(serviceTier, to: &params)
-                    if let executionDirectory = workspacePaths.executionDirectory {
-                        params["cwd"] = executionDirectory
-                    }
-                    if !configOverrides.isEmpty {
-                        params["config"] = configOverrides
-                    }
-                    // baseInstructions is intentionally omitted on thread/resume: the app-server
-                    // preserves original instructions across resume (confirmed by Codex protocol
-                    // tests: resume_switches_models_preserves_base_instructions). Resending them
-                    // wastes ~5-6k tokens on every reconnect for no benefit.
-                    result = try await requestWithCompatibleAppServerRequestValueStyle(
-                        method: "thread/resume",
-                        timeout: options.requestTimeout
-                    ) { requestValueStyle in
-                        var requestParams = params
-                        requestParams["approvalPolicy"] = options.approvalPolicyProvider().appServerRequestValue(style: requestValueStyle)
-                        requestParams["sandbox"] = options.sandboxModeProvider().appServerRequestValue(style: requestValueStyle)
-                        requestParams["approvalsReviewer"] = options.approvalReviewerProvider().appServerRequestValue
-                        return requestParams
-                    }
-                } else {
-                    var params: [String: Any] = [:]
-                    if let model {
-                        params["model"] = model
-                    }
-                    Self.addServiceTier(serviceTier, to: &params)
-                    if let executionDirectory = workspacePaths.executionDirectory {
-                        params["cwd"] = executionDirectory
-                    }
-                    if !configOverrides.isEmpty {
-                        params["config"] = configOverrides
-                    }
-                    if !baseInstructions.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                        params["baseInstructions"] = baseInstructions
-                    }
-                    result = try await requestWithCompatibleAppServerRequestValueStyle(
-                        method: "thread/start",
-                        timeout: options.requestTimeout
-                    ) { requestValueStyle in
-                        var requestParams = params
-                        requestParams["approvalPolicy"] = options.approvalPolicyProvider().appServerRequestValue(style: requestValueStyle)
-                        requestParams["sandbox"] = options.sandboxModeProvider().appServerRequestValue(style: requestValueStyle)
-                        requestParams["approvalsReviewer"] = options.approvalReviewerProvider().appServerRequestValue
-                        return requestParams
-                    }
-                }
+                result = try await requestThreadBinding(
+                    resumeThreadID: resumeThreadID,
+                    existing: existing,
+                    baseInstructions: baseInstructions,
+                    model: model,
+                    serviceTier: serviceTier,
+                    configOverrides: configOverrides,
+                    timeout: options.requestTimeout
+                )
                 #if DEBUG
                     await recordLifecyclePhase(
                         threadPhase,
@@ -1816,6 +1982,13 @@ final class CodexNativeSessionController {
                 return sessionRef
             }
             try markStartOrResumeSucceeded()
+            threadBindingContext = ThreadBindingContext(
+                existing: existing,
+                baseInstructions: baseInstructions,
+                model: model,
+                reasoningEffort: reasoningEffort,
+                serviceTier: serviceTier
+            )
             return sessionRef
         } catch {
             try? await eventHandlingMutex.withLockIgnoringCancellation {
@@ -1829,14 +2002,18 @@ final class CodexNativeSessionController {
         }
     }
 
-    private func setThreadMemoryMode(_ mode: ThreadMemoryMode, threadID: String) async throws {
+    private func setThreadMemoryMode(
+        _ mode: ThreadMemoryMode,
+        threadID: String,
+        timeout: TimeInterval?
+    ) async throws {
         _ = try await performRequest(
             method: "thread/memoryMode/set",
             params: [
                 "threadId": threadID,
                 "mode": mode.rawValue
             ],
-            timeout: options.requestTimeout
+            timeout: timeout
         )
     }
 
@@ -2430,6 +2607,7 @@ final class CodexNativeSessionController {
     private func restoreThreadSnapshot(_ snapshot: ThreadSnapshot) {
         threadID = snapshot.conversationID
         threadPath = snapshot.rolloutPath
+        activeSessionReference = snapshot.sessionRef
         routingCurrentTurnID = snapshot.currentTurnID
         activeTurnIDs = Set(snapshot.activeTurnIDs)
         activeTurnOrder = snapshot.activeTurnIDs
@@ -2452,11 +2630,18 @@ final class CodexNativeSessionController {
 
     private func applyThreadResponse(_ result: [String: Any], fallbackEffort: String?) -> SessionRef {
         let snapshot = Self.parseThreadSnapshot(from: result, fallbackEffort: fallbackEffort)
+        return applyThreadSnapshot(snapshot)
+    }
+
+    private func applyThreadSnapshot(_ snapshot: ThreadSnapshot) -> SessionRef {
         restoreThreadSnapshot(snapshot)
+        recordAppliedThreadSnapshot(snapshot)
+        return snapshot.sessionRef
+    }
+
+    private func recordAppliedThreadSnapshot(_ snapshot: ThreadSnapshot) {
         #if DEBUG
             ensureRawEventLogFileReadyIfNeeded()
-        #endif
-        #if DEBUG
             writeRawEventLogRecord(kind: "session.threadReady", payload: [
                 "conversationID": snapshot.conversationID,
                 "rolloutPath": snapshot.rolloutPath ?? NSNull(),
@@ -2464,7 +2649,6 @@ final class CodexNativeSessionController {
                 "currentTurnID": snapshot.currentTurnID ?? NSNull()
             ] as [String: Any])
         #endif
-        return snapshot.sessionRef
     }
 
     private static func parseThreadSnapshot(

--- a/Sources/RepoPrompt/Infrastructure/MCP/Agent/AgentRunMCPSnapshot.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/Agent/AgentRunMCPSnapshot.swift
@@ -25,6 +25,23 @@ extension DomainAgentRunSnapshot.WorktreeBinding {
     }
 }
 
+extension DomainAgentRunSnapshot.HookGate {
+    init(audit: AgentCodexHookGateAudit) {
+        let status: Status = switch audit.status {
+        case .approvedAll: .approvedAll
+        case .approvedSelected: .approvedSelected
+        case .continuedWithoutHooks: .continuedWithoutHooks
+        case .resolvedExternally: .resolvedExternally
+        }
+        self.init(
+            status: status,
+            approvedHookCount: audit.approvedCount,
+            skippedHookCount: audit.skippedCount,
+            resolvedAt: audit.resolvedAt
+        )
+    }
+}
+
 extension DomainAgentRunSnapshot {
     init(
         sessionID: UUID,
@@ -39,6 +56,7 @@ extension DomainAgentRunSnapshot {
         statusText: String?,
         latestAssistantPreview: String?,
         interaction: Interaction?,
+        hookGate: HookGate? = nil,
         transcriptItemCount: Int,
         updatedAt: Date,
         parentSessionID: UUID?,
@@ -59,6 +77,7 @@ extension DomainAgentRunSnapshot {
             statusText: statusText,
             latestAssistantPreview: latestAssistantPreview,
             interaction: interaction,
+            hookGate: hookGate,
             transcriptItemCount: transcriptItemCount,
             updatedAt: updatedAt,
             parentSessionID: parentSessionID,
@@ -136,6 +155,8 @@ extension DomainAgentRunSnapshot.Interaction.Kind {
         switch self {
         case .approval:
             "approval needed"
+        case .hookApproval:
+            "project hook approval"
         case .question:
             "question"
         case .instruction:

--- a/Sources/RepoPrompt/Infrastructure/MCP/Agent/AgentRunMCPToolService.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/Agent/AgentRunMCPToolService.swift
@@ -930,8 +930,8 @@ struct AgentRunMCPToolService {
             await Task.yield()
             return await currentSnapshot(sessionID: sessionID, agentModeVM: agentModeVM).toValue()
         }
-        if let parsed = cancelResult.objectValue.flatMap(snapshot(from:)) {
-            return decoratedRunValue(snapshot: parsed)
+        if let object = cancelResult.objectValue {
+            return try decoratedRunValue(snapshot: snapshot(from: object))
         }
         return cancelResult
     }
@@ -1316,7 +1316,7 @@ struct AgentRunMCPToolService {
                 if let waitScopeRegistration {
                     await endAgentRunWait(waitScopeRegistration.token, resolution.completion)
                 }
-                return await finalDecoratedSingleWaitValue(
+                return try await finalDecoratedSingleWaitValue(
                     from: resolution.rawValue,
                     sessionID: sessionID,
                     agentModeVM: agentModeVM,
@@ -1340,7 +1340,7 @@ struct AgentRunMCPToolService {
             let completion = completionBox.get() ?? singleWaitScopeCompletion(from: snapshot, sessionID: sessionID)
             await endAgentRunWait(waitScopeRegistration.token, completion)
         }
-        return await finalDecoratedSingleWaitValue(
+        return try await finalDecoratedSingleWaitValue(
             from: snapshot,
             sessionID: sessionID,
             agentModeVM: agentModeVM,
@@ -1420,12 +1420,12 @@ struct AgentRunMCPToolService {
         agentModeVM: AgentModeViewModel,
         workflow: AgentWorkflowDefinition?,
         initialDelivery: AgentModeViewModel.MCPInstructionDispatch?
-    ) async -> Value {
+    ) async throws -> Value {
         let resolvedSnapshot: AgentRunMCPSnapshot
         let wakeReason = rawValue.objectValue.flatMap(wakeReason(from:))
         let steeringMessage = rawValue.objectValue.flatMap(steeringMessage(from:))
-        if let parsedSnapshot = rawValue.objectValue.flatMap(snapshot(from:)) {
-            resolvedSnapshot = parsedSnapshot
+        if let object = rawValue.objectValue {
+            resolvedSnapshot = try snapshot(from: object)
         } else {
             resolvedSnapshot = await currentSnapshot(sessionID: sessionID, agentModeVM: agentModeVM)
         }
@@ -1776,9 +1776,11 @@ struct AgentRunMCPToolService {
     }
 
     #if DEBUG
-        func test_decodeSnapshot(from value: Value) -> AgentRunMCPSnapshot? {
-            guard let object = value.objectValue else { return nil }
-            return snapshot(from: object)
+        func test_decodeSnapshot(from value: Value) throws -> AgentRunMCPSnapshot {
+            guard let object = value.objectValue else {
+                throw MCPError.internalError("Agent run snapshot was not an object.")
+            }
+            return try snapshot(from: object)
         }
 
         static func test_decoratedMultiWaitInterruptValue(
@@ -2174,25 +2176,23 @@ struct AgentRunMCPToolService {
         object["wait"]?.objectValue?["steering_message"]?.stringValue
     }
 
-    private func snapshot(from object: [String: Value]) -> AgentRunMCPSnapshot? {
+    private func snapshot(from object: [String: Value]) throws -> AgentRunMCPSnapshot {
         guard let sessionIDRaw = object["session_id"]?.stringValue,
               let sessionID = UUID(uuidString: sessionIDRaw),
               let statusRaw = object["status"]?.stringValue,
               let status = AgentRunMCPSnapshot.Status(rawValue: statusRaw)
         else {
-            return nil
+            throw MCPError.internalError("Agent run snapshot identity or status was malformed.")
         }
         let session = object["session"]?.objectValue
         let agent = object["agent"]?.objectValue
         let runID = object["run_id"]?.stringValue.flatMap(UUID.init(uuidString:))
         let interaction: AgentRunMCPSnapshot.Interaction?
         if let rawInteraction = object["interaction"] {
-            guard let interactionObject = rawInteraction.objectValue,
-                  let decodedInteraction = self.interaction(from: interactionObject)
-            else {
-                return nil
+            guard let interactionObject = rawInteraction.objectValue else {
+                throw MCPError.internalError("Agent run snapshot interaction was malformed.")
             }
-            interaction = decodedInteraction
+            interaction = try self.interaction(from: interactionObject)
         } else {
             interaction = nil
         }
@@ -2201,7 +2201,7 @@ struct AgentRunMCPToolService {
             guard let hookGateObject = rawHookGate.objectValue,
                   let decodedHookGate = self.hookGate(from: hookGateObject)
             else {
-                return nil
+                throw MCPError.internalError("Agent run snapshot hook gate was malformed.")
             }
             hookGate = decodedHookGate
         } else {
@@ -2211,8 +2211,8 @@ struct AgentRunMCPToolService {
         let tabID = (session?["context_id"] ?? session?["tab_id"])?.stringValue.flatMap(UUID.init(uuidString:))
         let parentSessionID = session?["parent_session_id"]?.stringValue.flatMap(UUID.init(uuidString:))
         let failureReason = object["failure_reason"]?.stringValue.flatMap(AgentRunMCPSnapshot.FailureReason.init(rawValue:))
-        let worktreeBindings = worktreeBindings(from: object)
-        let activeWorktreeMerges = activeWorktreeMerges(from: object)
+        let worktreeBindings = try worktreeBindings(from: object)
+        let activeWorktreeMerges = try activeWorktreeMerges(from: object)
         return AgentRunMCPSnapshot(
             sessionID: sessionID,
             runID: runID,
@@ -2262,9 +2262,12 @@ struct AgentRunMCPToolService {
         )
     }
 
-    private func activeWorktreeMerges(from object: [String: Value]) -> [AgentSessionWorktreeMergeSummary] {
-        guard let values = object["active_worktree_merges"]?.arrayValue else { return [] }
-        return values.compactMap { value in
+    private func activeWorktreeMerges(from object: [String: Value]) throws -> [AgentSessionWorktreeMergeSummary] {
+        guard let rawValue = object["active_worktree_merges"] else { return [] }
+        guard let values = rawValue.arrayValue else {
+            throw MCPError.internalError("Agent run snapshot active worktree merges were malformed.")
+        }
+        return try values.map { value in
             guard let object = value.objectValue,
                   let id = object["id"]?.stringValue,
                   let statusRaw = object["status"]?.stringValue,
@@ -2279,7 +2282,9 @@ struct AgentRunMCPToolService {
                   let targetPath = object["target_path"]?.stringValue,
                   let updatedAtRaw = object["updated_at"]?.stringValue,
                   let updatedAt = Self.timestampFormatter.date(from: updatedAtRaw)
-            else { return nil }
+            else {
+                throw MCPError.internalError("Agent run snapshot active worktree merge was malformed.")
+            }
             return AgentSessionWorktreeMergeSummary(
                 id: id,
                 status: status,
@@ -2299,11 +2304,18 @@ struct AgentRunMCPToolService {
         }
     }
 
-    private func worktreeBindings(from object: [String: Value]) -> [AgentRunMCPSnapshot.WorktreeBinding] {
-        if let values = object["worktree_bindings"]?.arrayValue {
-            return values.compactMap { value in
-                guard let object = value.objectValue else { return nil }
-                return worktreeBinding(from: object)
+    private func worktreeBindings(from object: [String: Value]) throws -> [AgentRunMCPSnapshot.WorktreeBinding] {
+        if let rawValue = object["worktree_bindings"] {
+            guard let values = rawValue.arrayValue else {
+                throw MCPError.internalError("Agent run snapshot worktree bindings were malformed.")
+            }
+            return try values.map { value in
+                guard let object = value.objectValue,
+                      let binding = worktreeBinding(from: object)
+                else {
+                    throw MCPError.internalError("Agent run snapshot worktree binding was malformed.")
+                }
+                return binding
             }
         }
         if let object = object["worktree"]?.objectValue,
@@ -2346,7 +2358,7 @@ struct AgentRunMCPToolService {
         )
     }
 
-    private func interaction(from object: [String: Value]) -> AgentRunMCPSnapshot.Interaction? {
+    private func interaction(from object: [String: Value]) throws -> AgentRunMCPSnapshot.Interaction {
         guard let idRaw = object["id"]?.stringValue,
               let id = UUID(uuidString: idRaw),
               let kindRaw = object["kind"]?.stringValue,
@@ -2354,53 +2366,113 @@ struct AgentRunMCPToolService {
               let responseTypeRaw = object["response_type"]?.stringValue,
               let responseType = AgentRunMCPSnapshot.Interaction.ResponseType(rawValue: responseTypeRaw)
         else {
-            return nil
+            throw MCPError.internalError("Agent run snapshot interaction identity was malformed.")
         }
-        let options = object["options"]?.arrayValue?.compactMap { option -> AgentRunMCPSnapshot.Interaction.Option? in
-            guard let optionObject = option.objectValue,
-                  let label = optionObject["label"]?.stringValue else { return nil }
-            return .init(label: label, description: optionObject["description"]?.stringValue)
-        } ?? []
-        let fields = object["fields"]?.arrayValue?.compactMap { field -> AgentRunMCPSnapshot.Interaction.Field? in
-            guard let fieldObject = field.objectValue,
-                  let id = fieldObject["id"]?.stringValue,
-                  let prompt = fieldObject["prompt"]?.stringValue else { return nil }
-            let fieldOptions = fieldObject["options"]?.arrayValue?.compactMap { option -> AgentRunMCPSnapshot.Interaction.Option? in
-                guard let optionObject = option.objectValue,
-                      let label = optionObject["label"]?.stringValue else { return nil }
-                return .init(label: label, description: optionObject["description"]?.stringValue)
-            } ?? []
-            return .init(
-                id: id,
-                header: fieldObject["header"]?.stringValue,
-                prompt: prompt,
-                context: fieldObject["context"]?.stringValue,
-                isSecret: fieldObject["is_secret"]?.boolValue == true,
-                allowsOther: fieldObject["allows_other"]?.boolValue == true,
-                allowsMultiple: fieldObject["allows_multiple"]?.boolValue,
-                allowsCustom: fieldObject["allows_custom"]?.boolValue,
-                emitAllowsOther: fieldObject.keys.contains("allows_other"),
-                options: fieldOptions
-            )
-        } ?? []
-        let details = object["details"]?.arrayValue?.compactMap { detail -> AgentRunMCPSnapshot.Interaction.Detail? in
-            guard let detailObject = detail.objectValue,
-                  let label = detailObject["label"]?.stringValue,
-                  let value = detailObject["value"]?.stringValue else { return nil }
-            return .init(label: label, value: value, isCode: detailObject["is_code"]?.boolValue == true)
-        } ?? []
-        return .init(
+        let options = try interactionOptions(from: object["options"])
+        let fields: [AgentRunMCPSnapshot.Interaction.Field]
+        if let rawFields = object["fields"] {
+            guard let fieldValues = rawFields.arrayValue else {
+                throw MCPError.internalError("Agent run snapshot interaction fields were malformed.")
+            }
+            fields = try fieldValues.map { field in
+                guard let fieldObject = field.objectValue,
+                      let id = fieldObject["id"]?.stringValue,
+                      let prompt = fieldObject["prompt"]?.stringValue
+                else {
+                    throw MCPError.internalError("Agent run snapshot interaction field was malformed.")
+                }
+                return try .init(
+                    id: id,
+                    header: optionalString(in: fieldObject, key: "header"),
+                    prompt: prompt,
+                    context: optionalString(in: fieldObject, key: "context"),
+                    isSecret: optionalBool(in: fieldObject, key: "is_secret") ?? false,
+                    allowsOther: optionalBool(in: fieldObject, key: "allows_other") ?? false,
+                    allowsMultiple: nullableBool(in: fieldObject, key: "allows_multiple"),
+                    allowsCustom: nullableBool(in: fieldObject, key: "allows_custom"),
+                    emitAllowsOther: fieldObject.keys.contains("allows_other"),
+                    options: interactionOptions(from: fieldObject["options"])
+                )
+            }
+        } else {
+            fields = []
+        }
+        let details: [AgentRunMCPSnapshot.Interaction.Detail]
+        if let rawDetails = object["details"] {
+            guard let detailValues = rawDetails.arrayValue else {
+                throw MCPError.internalError("Agent run snapshot interaction details were malformed.")
+            }
+            details = try detailValues.map { detail in
+                guard let detailObject = detail.objectValue,
+                      let label = detailObject["label"]?.stringValue,
+                      let value = detailObject["value"]?.stringValue
+                else {
+                    throw MCPError.internalError("Agent run snapshot interaction detail was malformed.")
+                }
+                return try .init(
+                    label: label,
+                    value: value,
+                    isCode: optionalBool(in: detailObject, key: "is_code") ?? false
+                )
+            }
+        } else {
+            details = []
+        }
+        return try .init(
             id: id,
             kind: kind,
             responseType: responseType,
-            title: object["title"]?.stringValue,
-            prompt: object["prompt"]?.stringValue,
-            context: object["context"]?.stringValue,
-            allowsMultiple: object["allows_multiple"]?.boolValue,
+            title: optionalString(in: object, key: "title"),
+            prompt: optionalString(in: object, key: "prompt"),
+            context: optionalString(in: object, key: "context"),
+            allowsMultiple: nullableBool(in: object, key: "allows_multiple"),
             options: options,
             fields: fields,
             details: details
         )
+    }
+
+    private func interactionOptions(
+        from value: Value?
+    ) throws -> [AgentRunMCPSnapshot.Interaction.Option] {
+        guard let value else { return [] }
+        guard let optionValues = value.arrayValue else {
+            throw MCPError.internalError("Agent run snapshot interaction options were malformed.")
+        }
+        return try optionValues.map { option in
+            guard let optionObject = option.objectValue,
+                  let label = optionObject["label"]?.stringValue
+            else {
+                throw MCPError.internalError("Agent run snapshot interaction option was malformed.")
+            }
+            return try .init(
+                label: label,
+                description: optionalString(in: optionObject, key: "description")
+            )
+        }
+    }
+
+    private func optionalString(in object: [String: Value], key: String) throws -> String? {
+        guard let value = object[key] else { return nil }
+        if case .null = value { return nil }
+        guard let string = value.stringValue else {
+            throw MCPError.internalError("Agent run snapshot interaction contained a malformed string field.")
+        }
+        return string
+    }
+
+    private func optionalBool(in object: [String: Value], key: String) throws -> Bool? {
+        guard let value = object[key] else { return nil }
+        guard let bool = value.boolValue else {
+            throw MCPError.internalError("Agent run snapshot interaction contained a malformed boolean field.")
+        }
+        return bool
+    }
+
+    private func nullableBool(in object: [String: Value], key: String) throws -> Bool? {
+        guard let value = object[key] else { return nil }
+        if case .null = value { return nil }
+        return try optionalBool(in: object, key: key)
     }
 
     private func collectCurrentSnapshots(sessionIDs: [UUID], agentModeVM: AgentModeViewModel) async -> [AgentRunMCPSnapshot] {

--- a/Sources/RepoPrompt/Infrastructure/MCP/Agent/AgentRunMCPToolService.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/Agent/AgentRunMCPToolService.swift
@@ -1776,6 +1776,11 @@ struct AgentRunMCPToolService {
     }
 
     #if DEBUG
+        func test_decodeSnapshot(from value: Value) -> AgentRunMCPSnapshot? {
+            guard let object = value.objectValue else { return nil }
+            return snapshot(from: object)
+        }
+
         static func test_decoratedMultiWaitInterruptValue(
             sessionIDs: [UUID],
             representativeSnapshot: AgentRunMCPSnapshot? = nil,
@@ -2180,7 +2185,28 @@ struct AgentRunMCPToolService {
         let session = object["session"]?.objectValue
         let agent = object["agent"]?.objectValue
         let runID = object["run_id"]?.stringValue.flatMap(UUID.init(uuidString:))
-        let interaction = object["interaction"]?.objectValue.flatMap(interaction(from:))
+        let interaction: AgentRunMCPSnapshot.Interaction?
+        if let rawInteraction = object["interaction"] {
+            guard let interactionObject = rawInteraction.objectValue,
+                  let decodedInteraction = self.interaction(from: interactionObject)
+            else {
+                return nil
+            }
+            interaction = decodedInteraction
+        } else {
+            interaction = nil
+        }
+        let hookGate: AgentRunMCPSnapshot.HookGate?
+        if let rawHookGate = object["hook_gate"] {
+            guard let hookGateObject = rawHookGate.objectValue,
+                  let decodedHookGate = self.hookGate(from: hookGateObject)
+            else {
+                return nil
+            }
+            hookGate = decodedHookGate
+        } else {
+            hookGate = nil
+        }
         let updatedAt = object["updated_at"]?.stringValue.flatMap(Self.timestampFormatter.date(from:)) ?? Date()
         let tabID = (session?["context_id"] ?? session?["tab_id"])?.stringValue.flatMap(UUID.init(uuidString:))
         let parentSessionID = session?["parent_session_id"]?.stringValue.flatMap(UUID.init(uuidString:))
@@ -2200,12 +2226,39 @@ struct AgentRunMCPToolService {
             statusText: object["status_text"]?.stringValue,
             latestAssistantPreview: object["assistant_text"]?.stringValue,
             interaction: interaction,
+            hookGate: hookGate,
             transcriptItemCount: object["transcript_item_count"]?.intValue ?? 0,
             updatedAt: updatedAt,
             parentSessionID: parentSessionID,
             failureReason: failureReason,
             worktreeBindings: worktreeBindings,
             appActiveWorktreeMerges: activeWorktreeMerges
+        )
+    }
+
+    private func hookGate(from object: [String: Value]) -> AgentRunMCPSnapshot.HookGate? {
+        guard let statusRaw = object["status"]?.stringValue,
+              let status = AgentRunMCPSnapshot.HookGate.Status(rawValue: statusRaw),
+              let approvedHookCount = object["approved_hook_count"]?.intValue,
+              let resolvedAtRaw = object["resolved_at"]?.stringValue,
+              let resolvedAt = Self.timestampFormatter.date(from: resolvedAtRaw)
+        else {
+            return nil
+        }
+        let skippedHookCount: Int?
+        if let rawSkippedHookCount = object["skipped_hook_count"] {
+            guard let decodedSkippedHookCount = rawSkippedHookCount.intValue else {
+                return nil
+            }
+            skippedHookCount = decodedSkippedHookCount
+        } else {
+            skippedHookCount = nil
+        }
+        return .init(
+            status: status,
+            approvedHookCount: approvedHookCount,
+            skippedHookCount: skippedHookCount,
+            resolvedAt: resolvedAt
         )
     }
 
@@ -2321,8 +2374,12 @@ struct AgentRunMCPToolService {
                 id: id,
                 header: fieldObject["header"]?.stringValue,
                 prompt: prompt,
+                context: fieldObject["context"]?.stringValue,
                 isSecret: fieldObject["is_secret"]?.boolValue == true,
                 allowsOther: fieldObject["allows_other"]?.boolValue == true,
+                allowsMultiple: fieldObject["allows_multiple"]?.boolValue,
+                allowsCustom: fieldObject["allows_custom"]?.boolValue,
+                emitAllowsOther: fieldObject.keys.contains("allows_other"),
                 options: fieldOptions
             )
         } ?? []
@@ -2427,13 +2484,21 @@ struct AgentRunMCPToolService {
         let flat: [String: [String]]
         let structured: [String: AgentAskUserAnswer]
         let hasStructuredObjects: Bool
+        let valueShapes: [String: AgentModeViewModel.MCPInteractionResponsePayload.AnswerValueShape]
+        let hasNormalizedFieldNames: Bool
     }
 
     private func parseResponsePayload(args: [String: Value]) throws -> AgentModeViewModel.MCPInteractionResponsePayload {
         let parsedAnswers: ParsedAnswers = if let rawAnswers = args["answers"] {
             try parseAnswers(rawAnswers)
         } else {
-            ParsedAnswers(flat: [:], structured: [:], hasStructuredObjects: false)
+            ParsedAnswers(
+                flat: [:],
+                structured: [:],
+                hasStructuredObjects: false,
+                valueShapes: [:],
+                hasNormalizedFieldNames: false
+            )
         }
 
         let responseArgument: AgentModeViewModel.MCPInteractionResponsePayload.ResponseArgument = switch args["response"] {
@@ -2462,18 +2527,19 @@ struct AgentRunMCPToolService {
         if explicitSkip, responseRaw != nil, !responseIsSkipSentinel {
             throw MCPError.invalidParams("skip cannot be combined with response.")
         }
-        let containsDecisionArgument = args.keys.contains("decision")
-
         let content = try parseAgentJSONObject(args["content"], name: "content")
         let meta = try parseAgentJSONObject(args["meta"] ?? args["_meta"], name: "meta")
 
+        let routingArgumentNames = Set(["op", "session_id", "interaction_id"])
         return AgentModeViewModel.MCPInteractionResponsePayload(
+            suppliedArgumentNames: Set(args.keys).subtracting(routingArgumentNames),
             text: responseRaw,
             skip: isSkip,
             explicitSkip: explicitSkip,
             responseArgument: responseArgument,
-            containsDecisionArgument: containsDecisionArgument,
             amendment: normalizedString(args["amendment"]),
+            answerValueShapesByQuestionID: parsedAnswers.valueShapes,
+            hasNormalizedAnswerFieldNames: parsedAnswers.hasNormalizedFieldNames,
             answersByQuestionID: parsedAnswers.flat,
             askUserAnswersByQuestionID: parsedAnswers.structured,
             hasStructuredAnswerObjects: parsedAnswers.hasStructuredObjects,
@@ -2523,20 +2589,38 @@ struct AgentRunMCPToolService {
         var flat = [String: [String]]()
         var structured = [String: AgentAskUserAnswer]()
         var hasStructuredObjects = false
+        var valueShapes = [String: AgentModeViewModel.MCPInteractionResponsePayload.AnswerValueShape]()
+        var hasNormalizedFieldNames = false
         for entry in object {
             let questionID = entry.key.trimmingCharacters(in: .whitespacesAndNewlines)
+            hasNormalizedFieldNames = hasNormalizedFieldNames || questionID != entry.key
             guard !questionID.isEmpty else {
                 throw MCPError.invalidParams("answers cannot contain an empty question ID.")
             }
 
-            if entry.value.objectValue != nil {
+            let valueShape: AgentModeViewModel.MCPInteractionResponsePayload.AnswerValueShape
+            if entry.value.stringValue != nil {
+                valueShape = .scalarString
+            } else if entry.value.arrayValue != nil {
+                valueShape = .stringArray
+            } else if entry.value.objectValue != nil {
+                valueShape = .structuredObject
                 hasStructuredObjects = true
+            } else {
+                throw MCPError.invalidParams("answers['\(questionID)'] must be a string, array of strings, or object.")
             }
             let parsed = try parseAnswerValue(entry.value, questionID: questionID)
+            valueShapes[questionID] = valueShape
             flat[questionID] = parsed.answers
             structured[questionID] = parsed
         }
-        return ParsedAnswers(flat: flat, structured: structured, hasStructuredObjects: hasStructuredObjects)
+        return ParsedAnswers(
+            flat: flat,
+            structured: structured,
+            hasStructuredObjects: hasStructuredObjects,
+            valueShapes: valueShapes,
+            hasNormalizedFieldNames: hasNormalizedFieldNames
+        )
     }
 
     private func parseAnswerValue(_ value: Value, questionID: String) throws -> AgentAskUserAnswer {

--- a/Sources/RepoPrompt/Infrastructure/MCP/AppSettingsMCPService.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/AppSettingsMCPService.swift
@@ -9,6 +9,10 @@ import RepoPromptDomainRuntime
 /// keys present in `AppSettingsMCPRegistry.definitions` are visible to MCP clients.
 final class AppSettingsMCPService: Service {
     static let toolName = MCPGlobalToolName.appSettings
+    private static let humanOnlySettingKeys: Set<String> = [
+        "agent_mode.codex_hook_approval_strict_mode_enabled",
+        "agent_mode.codex_hook_approval_strict_mode_workspace_overrides"
+    ]
 
     let domainRegistrationID = MCPDomainToolRegistrationID()
 
@@ -174,6 +178,11 @@ final class AppSettingsMCPService: Service {
         }
         guard let rawValue = args["value"] else {
             throw MCPError.invalidParams("app_settings op='set' requires 'value'.")
+        }
+        guard !Self.humanOnlySettingKeys.contains(key) else {
+            throw MCPError.invalidParams(
+                "Setting '\(key)' is security-sensitive and can only be changed by a human in RepoPrompt Settings."
+            )
         }
 
         let definition = try AppSettingsMCPRegistry.definition(forKey: key)

--- a/Sources/RepoPrompt/Infrastructure/Process/ProcessTermination.swift
+++ b/Sources/RepoPrompt/Infrastructure/Process/ProcessTermination.swift
@@ -545,7 +545,13 @@ enum ProcessTermination {
             var info = siginfo_t()
             let result = Darwin.waitid(P_PID, id_t(pid), &info, WEXITED | WNOHANG | WNOWAIT)
             if result == 0 {
-                return info.si_pid == pid
+                guard info.si_pid == pid else { return false }
+                switch info.si_code {
+                case CLD_EXITED, CLD_KILLED, CLD_DUMPED:
+                    return true
+                default:
+                    return false
+                }
             }
             if errno == EINTR {
                 continue

--- a/Sources/RepoPrompt/Infrastructure/UI/Agent/CodexHookReviewCard.swift
+++ b/Sources/RepoPrompt/Infrastructure/UI/Agent/CodexHookReviewCard.swift
@@ -1,0 +1,280 @@
+import SwiftUI
+
+struct CodexHookReviewCardState: Equatable {
+    private(set) var interactionID: UUID
+    var selectedHookKeys = Set<String>()
+    var isContinueConfirmationPresented = false
+    var actionErrorMessage: String?
+
+    mutating func synchronize(interactionID: UUID) {
+        guard interactionID != self.interactionID else { return }
+        self.interactionID = interactionID
+        selectedHookKeys.removeAll()
+        isContinueConfirmationPresented = false
+        actionErrorMessage = nil
+    }
+
+    mutating func strictModeDidChange(isEnabled: Bool) {
+        if isEnabled {
+            isContinueConfirmationPresented = false
+        }
+    }
+}
+
+@MainActor
+struct CodexHookReviewCard: View {
+    let request: AgentCodexHookReviewRequest
+    let isStrictModeEnabled: () -> Bool
+    let onDecision: (AgentCodexHookReviewDecision) async throws -> Void
+
+    /// Observed only to invalidate the card when the effective settings value may have changed.
+    @ObservedObject private var settingsInvalidationSource: GlobalSettingsStore
+    @State private var state: CodexHookReviewCardState
+
+    init(
+        request: AgentCodexHookReviewRequest,
+        settingsInvalidationSource: GlobalSettingsStore = .shared,
+        isStrictModeEnabled: @escaping () -> Bool,
+        onDecision: @escaping (AgentCodexHookReviewDecision) async throws -> Void
+    ) {
+        self.request = request
+        _settingsInvalidationSource = ObservedObject(wrappedValue: settingsInvalidationSource)
+        self.isStrictModeEnabled = isStrictModeEnabled
+        self.onDecision = onDecision
+        _state = State(initialValue: CodexHookReviewCardState(interactionID: request.id))
+    }
+
+    private var isBusy: Bool {
+        request.phase.isResolving
+    }
+
+    private var usesDiscoveryFailureLayout: Bool {
+        request.phase == .discoveryFailed || (request.phase == .discovering && request.hooks.isEmpty)
+    }
+
+    var body: some View {
+        let strictModeEnabled = isStrictModeEnabled()
+        VStack(alignment: .leading, spacing: 12) {
+            header
+            if usesDiscoveryFailureLayout {
+                discoveryFailureContent(strictModeEnabled: strictModeEnabled)
+            } else {
+                reviewContent(strictModeEnabled: strictModeEnabled)
+            }
+        }
+        .padding(12)
+        .background(Color.orange.opacity(0.08))
+        .cornerRadius(8)
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(Color.orange.opacity(0.3), lineWidth: 1)
+        )
+        .onChange(of: request.id) { _, newID in
+            state.synchronize(interactionID: newID)
+        }
+        .onChange(of: strictModeEnabled) { _, isEnabled in
+            state.strictModeDidChange(isEnabled: isEnabled)
+        }
+        .confirmationDialog(
+            "Continue without enabling project hooks?",
+            isPresented: $state.isContinueConfirmationPresented,
+            titleVisibility: .visible
+        ) {
+            Button("Continue Without Hooks", role: .destructive) {
+                submit(.continueWithoutHooks)
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text(continueConfirmationMessage)
+        }
+    }
+
+    private var header: some View {
+        HStack(spacing: 8) {
+            Image(systemName: usesDiscoveryFailureLayout ? "exclamationmark.shield.fill" : "checkmark.shield.fill")
+                .font(.title2)
+                .foregroundColor(.orange)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(usesDiscoveryFailureLayout ? "Project Hook Discovery Failed" : "Project Hooks Need Approval")
+                    .font(.headline)
+                Text("The initial Codex turn is paused")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            Spacer()
+            if isBusy {
+                ProgressView()
+                    .controlSize(.small)
+            }
+        }
+    }
+
+    private func discoveryFailureContent(strictModeEnabled: Bool) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            metadataRow(label: "Execution directory", value: request.executionCWD, isCode: true)
+            Text(request.errorMessage ?? "Codex could not discover project hooks for this directory.")
+                .font(.callout)
+                .foregroundColor(.red)
+                .textSelection(.enabled)
+            if let actionErrorMessage = state.actionErrorMessage, !actionErrorMessage.isEmpty {
+                Text(actionErrorMessage)
+                    .font(.callout)
+                    .foregroundColor(.red)
+                    .textSelection(.enabled)
+            }
+
+            HStack {
+                if !strictModeEnabled {
+                    continueButton
+                }
+                Spacer()
+                Button {
+                    submit(.retryDiscovery)
+                } label: {
+                    Label("Retry", systemImage: "arrow.clockwise")
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(isBusy)
+            }
+        }
+    }
+
+    private func reviewContent(strictModeEnabled: Bool) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Review the repository-provided hooks below. No hook is selected by default.")
+                .font(.callout)
+                .foregroundColor(.secondary)
+            metadataRow(label: "Execution directory", value: request.executionCWD, isCode: true)
+
+            if let errorMessage = request.errorMessage, !errorMessage.isEmpty {
+                Text(errorMessage)
+                    .font(.callout)
+                    .foregroundColor(.red)
+                    .textSelection(.enabled)
+            }
+
+            if let actionErrorMessage = state.actionErrorMessage, !actionErrorMessage.isEmpty {
+                Text(actionErrorMessage)
+                    .font(.callout)
+                    .foregroundColor(.red)
+                    .textSelection(.enabled)
+            }
+
+            ForEach(request.warnings, id: \.self) { warning in
+                Label(warning, systemImage: "exclamationmark.triangle")
+                    .font(.caption)
+                    .foregroundColor(.orange)
+                    .textSelection(.enabled)
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                ForEach(request.hooks, id: \.key) { hook in
+                    hookRow(hook)
+                }
+            }
+
+            HStack {
+                if !strictModeEnabled {
+                    continueButton
+                }
+                Spacer()
+                Button {
+                    submit(.approveAll)
+                } label: {
+                    Label("Trust All Shown", systemImage: "checkmark.seal")
+                }
+                .buttonStyle(.bordered)
+                .disabled(isBusy || request.hooks.isEmpty)
+
+                Button {
+                    submit(.approveSelected(hookKeys: request.hooks.compactMap { hook in
+                        state.selectedHookKeys.contains(hook.key) ? hook.key : nil
+                    }))
+                } label: {
+                    Label("Approve Selected & Continue", systemImage: "checkmark.circle.fill")
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(isBusy || state.selectedHookKeys.isEmpty)
+            }
+        }
+    }
+
+    private var continueButton: some View {
+        Button(role: .destructive) {
+            state.isContinueConfirmationPresented = true
+        } label: {
+            Label("Continue Without Hooks", systemImage: "exclamationmark.triangle")
+        }
+        .buttonStyle(.bordered)
+        .disabled(isBusy)
+    }
+
+    private func hookRow(_ hook: AgentCodexHookReviewHook) -> some View {
+        HStack(alignment: .top, spacing: 10) {
+            Button {
+                if state.selectedHookKeys.contains(hook.key) {
+                    state.selectedHookKeys.remove(hook.key)
+                } else {
+                    state.selectedHookKeys.insert(hook.key)
+                }
+            } label: {
+                Image(systemName: state.selectedHookKeys.contains(hook.key) ? "checkmark.square.fill" : "square")
+                    .font(.title3)
+            }
+            .buttonStyle(.plain)
+            .disabled(isBusy)
+            .accessibilityLabel(state.selectedHookKeys.contains(hook.key) ? "Deselect hook" : "Select hook")
+
+            VStack(alignment: .leading, spacing: 5) {
+                Text(hook.key)
+                    .font(.caption.monospaced())
+                    .textSelection(.enabled)
+                HStack(spacing: 8) {
+                    Text(hook.eventName)
+                    Text(hook.enabled ? "Enabled" : "Disabled")
+                    Text(hook.trustStatus.rawValue.capitalized)
+                }
+                .font(.caption)
+                .foregroundColor(.secondary)
+                metadataRow(label: "Source", value: hook.sourcePath, isCode: true)
+                metadataRow(label: "Current hash", value: hook.currentHash, isCode: true)
+                if let command = hook.commandOrHandler, !command.isEmpty {
+                    metadataRow(label: "Command / handler", value: command, isCode: true)
+                }
+            }
+        }
+        .padding(10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.primary.opacity(0.04))
+        .cornerRadius(6)
+    }
+
+    private var continueConfirmationMessage: String {
+        if request.phase == .discoveryFailed {
+            return "This skips an unknown number of project hooks for the current Codex session. Repository guardrails may not run."
+        }
+        return "This skips \(request.hooks.count) project hook(s) for the current Codex session. Repository guardrails may not run."
+    }
+
+    private func submit(_ decision: AgentCodexHookReviewDecision) {
+        state.actionErrorMessage = nil
+        Task { @MainActor in
+            do {
+                try await onDecision(decision)
+            } catch {
+                state.actionErrorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    private func metadataRow(label: String, value: String, isCode: Bool) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(label)
+                .font(.caption2)
+                .foregroundColor(.secondary)
+            Text(value)
+                .font(isCode ? .caption.monospaced() : .caption)
+                .textSelection(.enabled)
+        }
+    }
+}

--- a/Sources/RepoPromptDomainRuntime/DomainAgentSessionModels.swift
+++ b/Sources/RepoPromptDomainRuntime/DomainAgentSessionModels.swift
@@ -224,6 +224,7 @@ package struct DomainAgentRunSnapshot: Equatable, Sendable {
             case question
             case userInput = "user_input"
             case approval
+            case hookApproval = "hook_approval"
             case mcpElicitation = "mcp_elicitation"
         }
 
@@ -394,6 +395,39 @@ package struct DomainAgentRunSnapshot: Equatable, Sendable {
         }
     }
 
+    package struct HookGate: Equatable, Sendable {
+        package enum Status: String, Equatable, Sendable {
+            case approvedAll = "approved_all"
+            case approvedSelected = "approved_selected"
+            case continuedWithoutHooks = "continued_without_hooks"
+            case resolvedExternally = "resolved_externally"
+        }
+
+        package let status: Status
+        package let approvedHookCount: Int
+        package let skippedHookCount: Int?
+        package let resolvedAt: Date
+
+        package init(status: Status, approvedHookCount: Int, skippedHookCount: Int?, resolvedAt: Date) {
+            self.status = status
+            self.approvedHookCount = approvedHookCount
+            self.skippedHookCount = skippedHookCount
+            self.resolvedAt = resolvedAt
+        }
+
+        package func asObject() -> [String: Value] {
+            var object: [String: Value] = [
+                "status": .string(status.rawValue),
+                "approved_hook_count": .int(approvedHookCount),
+                "resolved_at": .string(DomainAgentRunSnapshot.timestamp(resolvedAt))
+            ]
+            if let skippedHookCount {
+                object["skipped_hook_count"] = .int(skippedHookCount)
+            }
+            return object
+        }
+    }
+
     package enum FailureReason: String, Equatable, Sendable {
         case processCrash = "process_crash"
         case timeout
@@ -437,6 +471,7 @@ package struct DomainAgentRunSnapshot: Equatable, Sendable {
     package let statusText: String?
     package let latestAssistantPreview: String?
     package let interaction: Interaction?
+    package let hookGate: HookGate?
     package let transcriptItemCount: Int
     package let updatedAt: Date
     package let parentSessionID: UUID?
@@ -457,6 +492,7 @@ package struct DomainAgentRunSnapshot: Equatable, Sendable {
         statusText: String?,
         latestAssistantPreview: String?,
         interaction: Interaction?,
+        hookGate: HookGate? = nil,
         transcriptItemCount: Int,
         updatedAt: Date,
         parentSessionID: UUID?,
@@ -476,6 +512,7 @@ package struct DomainAgentRunSnapshot: Equatable, Sendable {
         self.statusText = statusText
         self.latestAssistantPreview = latestAssistantPreview
         self.interaction = interaction
+        self.hookGate = hookGate
         self.transcriptItemCount = transcriptItemCount
         self.updatedAt = updatedAt
         self.parentSessionID = parentSessionID
@@ -511,6 +548,9 @@ package struct DomainAgentRunSnapshot: Equatable, Sendable {
         if let interaction {
             object["interaction"] = .object(interaction.asObject())
             object["interaction_id"] = .string(interaction.id.uuidString)
+        }
+        if let hookGate {
+            object["hook_gate"] = .object(hookGate.asObject())
         }
         if let failureReason {
             object["failure_reason"] = .string(failureReason.rawValue)

--- a/Tests/RepoPromptTests/AI/ProcessTerminationExitStatusTests.swift
+++ b/Tests/RepoPromptTests/AI/ProcessTerminationExitStatusTests.swift
@@ -253,6 +253,46 @@ final class ProcessTerminationExitStatusTests: XCTestCase {
         XCTAssertTrue(ProcessTermination.childIsTerminalOrAlreadyReaped(spawned.pid))
     }
 
+    func testTerminalChildProbeRejectsStoppedChild() async throws {
+        let spawned = try ProcessLauncher.spawn(
+            command: "/bin/sleep",
+            arguments: ["60"],
+            environment: [:],
+            workingDirectory: nil
+        )
+        spawned.stdin?.closeFile()
+        var didReap = false
+        defer {
+            if !didReap {
+                _ = Darwin.kill(spawned.pid, SIGKILL)
+            }
+        }
+
+        XCTAssertEqual(Darwin.kill(spawned.pid, SIGSTOP), 0)
+        let deadline = Date().addingTimeInterval(2)
+        var observedStoppedStatus = false
+        while Date() < deadline {
+            var info = siginfo_t()
+            let result = Darwin.waitid(P_PID, id_t(spawned.pid), &info, WSTOPPED | WNOHANG | WNOWAIT)
+            if result == 0, info.si_pid == spawned.pid, info.si_code == CLD_STOPPED {
+                observedStoppedStatus = true
+                break
+            }
+            if result == -1, errno != EINTR {
+                break
+            }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+
+        XCTAssertTrue(observedStoppedStatus)
+        XCTAssertFalse(ProcessTermination.childIsTerminalOrAlreadyReaped(spawned.pid))
+        XCTAssertEqual(Darwin.kill(spawned.pid, SIGKILL), 0)
+        let status = try await ProcessTermination.reapChildStatus(pid: spawned.pid)
+        didReap = true
+        XCTAssertEqual(status, .uncaughtSignal(signal: SIGKILL))
+        XCTAssertTrue(ProcessTermination.childIsTerminalOrAlreadyReaped(spawned.pid))
+    }
+
     func testObservedTerminationEscalatesBeforeGroupOnlyCleanup() async throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("ProcessTerminationExitStatusTests-\(UUID().uuidString)", isDirectory: true)

--- a/Tests/RepoPromptTests/AgentMode/AgentModeProviderConversationCleanupTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeProviderConversationCleanupTests.swift
@@ -290,7 +290,7 @@ private final class PersistedCleanupRecorder: @unchecked Sendable {
     }
 }
 
-private final class CleanupRecordingCodexController: CodexSessionControlling, @unchecked Sendable {
+private final class CleanupRecordingCodexController: CodexSessionControllerTurnDispatchTestDefaults, @unchecked Sendable {
     struct CleanupCall {
         let handle: ProviderConversationCleanupHandle
         let action: ProviderConversationCleanupAction

--- a/Tests/RepoPromptTests/AgentMode/AgentModeRunServiceLifecycleTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeRunServiceLifecycleTests.swift
@@ -2578,7 +2578,7 @@ private final class LifecycleNoopHeadlessProvider: HeadlessAgentProvider {
     func dispose() async {}
 }
 
-final class LifecycleNoopCodexController: CodexSessionControlling {
+final class LifecycleNoopCodexController: CodexSessionControllerTurnDispatchTestDefaults {
     enum SendBehavior: CustomStringConvertible {
         case success
         case failure
@@ -2673,6 +2673,7 @@ final class LifecycleNoopCodexController: CodexSessionControlling {
     }
 
     func compactThread() async throws {}
+
     func getThreadGoal() async throws -> CodexNativeSessionController.ThreadGoal? {
         nil
     }

--- a/Tests/RepoPromptTests/AgentMode/AgentModeStopSubmitTargetTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeStopSubmitTargetTests.swift
@@ -996,7 +996,7 @@ private final class StopSubmitSendRecorder: @unchecked Sendable {
     }
 }
 
-private final class StopSubmitNoopCodexController: CodexSessionControlling {
+private final class StopSubmitNoopCodexController: CodexSessionControllerTurnDispatchTestDefaults {
     private let recorder: StopSubmitSendRecorder?
     private let activeThread: Bool
     private let eventStream: AsyncStream<CodexNativeSessionController.Event>

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexAgentModeCoordinatorHookApprovalTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexAgentModeCoordinatorHookApprovalTests.swift
@@ -124,6 +124,53 @@ final class CodexAgentModeCoordinatorHookApprovalTests: XCTestCase {
         XCTAssertEqual(outcome, .sent)
     }
 
+    func testStrictModeRejectsPartialApproveSelectedButAllowsAllKeys() async throws {
+        let alpha = try hook(key: "alpha")
+        let beta = try hook(key: "beta")
+        let initial = try inventory(hooks: [alpha, beta])
+        let verified = try inventory(hooks: [
+            hook(key: "alpha", status: .trusted),
+            hook(key: "beta", status: .trusted)
+        ])
+        let settings = HookApprovalFakeSettingsProvider(enabled: false)
+        let controller = HookApprovalFakeCodexController(
+            listResults: [.success(initial)],
+            trustResults: [.success(verified)]
+        )
+        let (viewModel, session) = makeSession(controller: controller, settings: settings)
+        let sendTask = Task { await self.send(on: viewModel, session: session) }
+        let request = try await waitForRequest(session)
+
+        settings.enabled = true
+        do {
+            try await viewModel.test_codexCoordinator.resolveCodexHookReview(
+                session: session,
+                requestID: request.id,
+                decision: .approveSelected(hookKeys: ["alpha"])
+            )
+            XCTFail("Expected strict-mode rejection")
+        } catch let error as AgentCodexHookReviewResolutionError {
+            XCTAssertEqual(error, .strictModeRequiresApproval)
+            XCTAssertTrue(error.localizedDescription.localizedCaseInsensitiveContains("strict mode"))
+        }
+        XCTAssertEqual(session.pendingCodexHookReview?.id, request.id)
+        XCTAssertNotNil(session.codexHookReviewContinuation)
+        XCTAssertEqual(controller.startCount, 0)
+        XCTAssertTrue(controller.trustCalls.isEmpty)
+
+        try await viewModel.test_codexCoordinator.resolveCodexHookReview(
+            session: session,
+            requestID: request.id,
+            decision: .approveSelected(hookKeys: ["alpha", "beta"])
+        )
+        await assertOutcome(sendTask, equals: .sent)
+        XCTAssertEqual(controller.trustCalls.count, 1)
+        XCTAssertEqual(Set(controller.trustCalls[0].candidates.map(\.key)), Set(["alpha", "beta"]))
+        XCTAssertEqual(session.codexHookGateAudit?.status, .approvedSelected)
+        XCTAssertEqual(session.codexHookGateAudit?.approvedCount, 2)
+        XCTAssertEqual(session.codexHookGateAudit?.skippedCount, 0)
+    }
+
     func testDiscoveryFailureCarriesCwdErrorAndRetryToZeroResolvesExternally() async throws {
         let controller = try HookApprovalFakeCodexController(
             listResults: [
@@ -197,6 +244,48 @@ final class CodexAgentModeCoordinatorHookApprovalTests: XCTestCase {
         XCTAssertEqual(outcome, .sent)
         XCTAssertEqual(session.codexHookGateAudit?.status, .resolvedExternally)
         XCTAssertEqual(controller.startCount, 1)
+    }
+
+    func testPostWriteInventoryDriftPublishesReplacementAndKeepsTurnSuspended() async throws {
+        let initial = try inventory(hooks: [hook(key: "alpha")])
+        let postWriteDrift = try inventory(hooks: [
+            hook(key: "alpha", status: .trusted),
+            hook(key: "beta")
+        ])
+        let fullyVerified = try inventory(hooks: [
+            hook(key: "alpha", status: .trusted),
+            hook(key: "beta", status: .trusted)
+        ])
+        let controller = HookApprovalFakeCodexController(
+            listResults: [.success(initial)],
+            trustResults: [.success(postWriteDrift), .success(fullyVerified)]
+        )
+        let (viewModel, session) = makeSession(controller: controller)
+        let sendTask = Task { await self.send(on: viewModel, session: session) }
+        let firstRequest = try await waitForRequest(session)
+
+        try await viewModel.test_codexCoordinator.resolveCodexHookReview(
+            session: session,
+            requestID: firstRequest.id,
+            decision: .approveAll
+        )
+
+        let replacement = try XCTUnwrap(session.pendingCodexHookReview)
+        XCTAssertNotEqual(replacement.id, firstRequest.id)
+        XCTAssertEqual(replacement.hooks.map(\.key), ["beta"])
+        XCTAssertNotNil(session.codexHookReviewContinuation)
+        XCTAssertNil(session.codexHookGateAudit)
+        XCTAssertEqual(controller.startCount, 0)
+
+        try await viewModel.test_codexCoordinator.resolveCodexHookReview(
+            session: session,
+            requestID: replacement.id,
+            decision: .approveAll
+        )
+        await assertOutcome(sendTask, equals: .sent)
+        XCTAssertEqual(controller.startCount, 1)
+        XCTAssertEqual(controller.trustCalls.count, 2)
+        XCTAssertEqual(session.codexHookGateAudit?.status, .approvedAll)
     }
 
     func testControllerReplacementCancelsSuspendedFirstTurnExactlyOnce() async throws {
@@ -531,7 +620,11 @@ final class CodexAgentModeCoordinatorHookApprovalTests: XCTestCase {
                 sendTask.cancel()
                 sendTask.cancel()
             case .tabClose:
-                await viewModel.handleComposeTabsWillClose([session.tabID], reason: .stash)
+                _ = await viewModel.handleComposeTabsDidRemove(
+                    [session.tabID],
+                    reason: .stash,
+                    workspaceID: UUID()
+                )
             case .appTeardown:
                 await viewModel.prepareForWindowClose()
             }
@@ -757,7 +850,7 @@ final class CodexAgentModeCoordinatorHookApprovalTests: XCTestCase {
             settings: settings,
             authRecovery: authRecovery
         )
-        session.runID = UUID()
+        session.installRunID(UUID())
         session.beginRunAttempt(source: "test.codexHookApproval")
         bindReadyController(controller, to: session)
         return (viewModel, session)
@@ -803,7 +896,8 @@ final class CodexAgentModeCoordinatorHookApprovalTests: XCTestCase {
         session.codexControllerFeatureState = .init(
             computerUseEnabled: false,
             goalSupportEnabled: CodexGoalSupport.isEnabled,
-            reasoningSummariesEnabled: CodexReasoningSummaries.isEnabled
+            reasoningSummariesEnabled: CodexReasoningSummaries.isEnabled,
+            memoriesEnabled: CodexMemories.isEnabled
         )
     }
 
@@ -811,7 +905,7 @@ final class CodexAgentModeCoordinatorHookApprovalTests: XCTestCase {
         if let ownership = session.activeRunOwnership {
             _ = session.endRunAttempt(ifCurrent: ownership, source: "test.codexHookApproval.reset")
         }
-        session.runID = UUID()
+        session.installRunID(UUID())
         session.runState = .idle
         session.codexPendingTurnKind = nil
         session.codexAuthoritativeActiveTurn = nil
@@ -1065,17 +1159,37 @@ private actor HookApprovalCompletionCounter {
 }
 
 private actor HookApprovalFakeAuthRecovery: CodexManagedAuthRecovering {
+    private let account = CodexManagedAccount(
+        email: "hook-approval@example.com",
+        accountType: "chatgpt",
+        authenticationMode: "managed_chatgpt",
+        managedLoginValidated: true
+    )
     private(set) var refreshCount = 0
 
     func refreshManagedAccount() async -> CodexManagedAuthRefreshResult {
         refreshCount += 1
-        return .recovered
+        return .recovered(account: account)
+    }
+
+    func managedAccountSnapshot() async -> CodexManagedAccount? {
+        account
     }
 
     func startManagedChatgptLogin(
         openURL _: @MainActor @escaping @Sendable (URL) -> Void
     ) async -> CodexManagedChatgptLoginResult {
-        .authenticated
+        .authenticated(account: account)
+    }
+
+    func startManagedChatgptDeviceCodeLogin(
+        presentDeviceCode _: @MainActor @escaping @Sendable (CodexManagedChatgptDeviceCode, Bool) -> Void
+    ) async -> CodexManagedChatgptLoginResult {
+        .authenticated(account: account)
+    }
+
+    func logoutManagedAccount() async -> CodexManagedAuthLogoutResult {
+        .signedOut
     }
 }
 

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexAgentModeCoordinatorHookApprovalTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexAgentModeCoordinatorHookApprovalTests.swift
@@ -20,6 +20,42 @@ final class CodexAgentModeCoordinatorHookApprovalTests: XCTestCase {
         XCTAssertNil(session.pendingCodexHookReview)
     }
 
+    func testConcurrentInitialGateEntrantsShareOneDiscoveryAndReview() async throws {
+        let discoveryGate = HookApprovalAsyncGate()
+        let controller = try HookApprovalFakeCodexController(
+            listResults: [.success(inventory(hooks: [hook(key: "alpha")]))],
+            listGate: discoveryGate
+        )
+        let (viewModel, session) = makeSession(controller: controller)
+
+        let firstGate = Task {
+            try await viewModel.test_codexCoordinator.test_gateFirstTurnForProjectHooks(
+                session: session,
+                controller: controller
+            )
+        }
+        try await discoveryGate.waitUntilWaiting()
+        let secondGate = Task {
+            try await viewModel.test_codexCoordinator.test_gateFirstTurnForProjectHooks(
+                session: session,
+                controller: controller
+            )
+        }
+        try await Task.sleep(nanoseconds: 20_000_000)
+        XCTAssertEqual(controller.listCount, 1)
+        XCTAssertEqual(session.codexHookGateGeneration, 1)
+
+        await discoveryGate.release()
+        let request = try await waitForRequest(session)
+        XCTAssertEqual(session.pendingCodexHookReview?.id, request.id)
+        try await continueWithoutHooks(request, session: session, viewModel: viewModel)
+
+        try await firstGate.value
+        try await secondGate.value
+        XCTAssertEqual(controller.operations, ["list"])
+        XCTAssertNil(session.pendingCodexHookReview)
+    }
+
     func testContinueWithoutHooksBlocksFirstTurnThenReleasesBindingOnce() async throws {
         let controller = try HookApprovalFakeCodexController(
             listResults: [.success(inventory(hooks: [hook(key: "alpha")]))]
@@ -1190,6 +1226,7 @@ private final class HookApprovalFakeCodexController: CodexSessionControllerPassi
     var listResults: [Result<CodexHookInventory, Error>]
     var trustResults: [Result<CodexHookInventory, Error>]
     var startResults: [Result<CodexTurnStartReceipt, Error>]
+    private let listGate: HookApprovalAsyncGate?
     private let trustGate: HookApprovalAsyncGate?
     private(set) var operations: [String] = []
     private(set) var trustCalls: [TrustCall] = []
@@ -1204,11 +1241,13 @@ private final class HookApprovalFakeCodexController: CodexSessionControllerPassi
         listResults: [Result<CodexHookInventory, Error>],
         trustResults: [Result<CodexHookInventory, Error>] = [],
         startResults: [Result<CodexTurnStartReceipt, Error>] = [],
+        listGate: HookApprovalAsyncGate? = nil,
         trustGate: HookApprovalAsyncGate? = nil
     ) {
         self.listResults = listResults
         self.trustResults = trustResults
         self.startResults = startResults
+        self.listGate = listGate
         self.trustGate = trustGate
     }
 
@@ -1232,6 +1271,7 @@ private final class HookApprovalFakeCodexController: CodexSessionControllerPassi
 
     func listHooksForCurrentWorkspace() async throws -> CodexHookInventory {
         operations.append("list")
+        await listGate?.wait()
         guard !listResults.isEmpty else {
             throw CodexHookTrustError.malformedListResponse
         }

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexAgentModeCoordinatorHookApprovalTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexAgentModeCoordinatorHookApprovalTests.swift
@@ -89,6 +89,34 @@ final class CodexAgentModeCoordinatorHookApprovalTests: XCTestCase {
         XCTAssertEqual(session.codexHookGateAudit?.skippedCount, 1)
     }
 
+    func testPartialApprovalNoticeUsesVerifiedUnresolvedCountWhenSkippedHookResolvesExternally() async throws {
+        let initial = try inventory(hooks: [hook(key: "alpha"), hook(key: "beta")])
+        let verified = try inventory(hooks: [hook(key: "alpha", status: .trusted)])
+        let controller = HookApprovalFakeCodexController(
+            listResults: [.success(initial)],
+            trustResults: [.success(verified)]
+        )
+        let (viewModel, session) = makeSession(controller: controller)
+        let sendTask = Task { await self.send(on: viewModel, session: session) }
+        let request = try await waitForRequest(session)
+
+        try await viewModel.test_codexCoordinator.resolveCodexHookReview(
+            session: session,
+            requestID: request.id,
+            decision: .approveSelected(hookKeys: ["alpha"])
+        )
+
+        await assertOutcome(sendTask, equals: .sent)
+        XCTAssertEqual(session.codexHookGateAudit?.status, .approvedSelected)
+        XCTAssertEqual(session.codexHookGateAudit?.approvedCount, 1)
+        XCTAssertEqual(session.codexHookGateAudit?.skippedCount, 1)
+        let notice = try XCTUnwrap(session.items.last { item in
+            item.kind == .system && item.text.contains("Trusted 1 Codex project hook(s)")
+        })
+        XCTAssertTrue(notice.text.contains("0 remain untrusted for this controller binding"))
+        XCTAssertFalse(notice.text.contains("1 remain untrusted for this controller binding"))
+    }
+
     func testStrictModeIsReadLiveAndRejectsContinueWithoutMutation() async throws {
         let settings = HookApprovalFakeSettingsProvider(enabled: false)
         let controller = try HookApprovalFakeCodexController(

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexAgentModeCoordinatorHookApprovalTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexAgentModeCoordinatorHookApprovalTests.swift
@@ -1,0 +1,1094 @@
+import Foundation
+import XCTest
+@_spi(TestSupport) @testable import RepoPromptApp
+
+@MainActor
+final class CodexAgentModeCoordinatorHookApprovalTests: XCTestCase {
+    func testHookDiscoveryPrecedesFirstTurnAndDoesNotRunAtBindingTime() async throws {
+        let controller = try HookApprovalFakeCodexController(
+            listResults: [.success(inventory(hooks: []))]
+        )
+        let (viewModel, session) = makeSession(controller: controller)
+
+        try await Task.sleep(nanoseconds: 20_000_000)
+        XCTAssertEqual(controller.operations, [])
+
+        let outcome = await send(on: viewModel, session: session)
+
+        XCTAssertEqual(outcome, .sent)
+        XCTAssertEqual(controller.operations, ["list", "start"])
+        XCTAssertNil(session.pendingCodexHookReview)
+    }
+
+    func testContinueWithoutHooksBlocksFirstTurnThenReleasesBindingOnce() async throws {
+        let controller = try HookApprovalFakeCodexController(
+            listResults: [.success(inventory(hooks: [hook(key: "alpha")]))]
+        )
+        let (viewModel, session) = makeSession(controller: controller)
+        let sendTask = Task { await self.send(on: viewModel, session: session) }
+
+        let request = try await waitForRequest(session)
+        XCTAssertEqual(request.phase, .reviewRequired)
+        XCTAssertEqual(controller.startCount, 0)
+        XCTAssertEqual(session.runState, .waitingForApproval)
+
+        try await viewModel.test_codexCoordinator.resolveCodexHookReview(
+            session: session,
+            requestID: request.id,
+            decision: .continueWithoutHooks
+        )
+
+        let outcome = await sendTask.value
+        XCTAssertEqual(outcome, .sent)
+        XCTAssertEqual(controller.operations, ["list", "start"])
+        XCTAssertEqual(session.codexHookGateAudit?.status, .continuedWithoutHooks)
+        XCTAssertEqual(session.codexHookGateAudit?.approvedCount, 0)
+        XCTAssertEqual(session.codexHookGateAudit?.skippedCount, 1)
+        XCTAssertTrue(session.items.contains { $0.kind == .system && $0.text.contains("Continued without trusting 1") })
+    }
+
+    func testApproveSelectedUsesExactCandidatesAndRetainsFailureIdentity() async throws {
+        let first = try hook(key: "alpha")
+        let second = try hook(key: "beta")
+        let initial = try inventory(hooks: [first, second])
+        let verified = try inventory(hooks: [
+            hook(key: "alpha", status: .trusted),
+            second
+        ])
+        let controller = HookApprovalFakeCodexController(
+            listResults: [.success(initial)],
+            trustResults: [.failure(CodexHookTrustError.batchWriteFailed), .success(verified)]
+        )
+        let (viewModel, session) = makeSession(controller: controller)
+        let sendTask = Task { await self.send(on: viewModel, session: session) }
+        let request = try await waitForRequest(session)
+
+        try await viewModel.test_codexCoordinator.resolveCodexHookReview(
+            session: session,
+            requestID: request.id,
+            decision: .approveSelected(hookKeys: ["alpha"])
+        )
+        let failed = try XCTUnwrap(session.pendingCodexHookReview)
+        XCTAssertEqual(failed.id, request.id)
+        XCTAssertEqual(failed.phase, .writeFailed)
+        XCTAssertEqual(controller.startCount, 0)
+
+        try await viewModel.test_codexCoordinator.resolveCodexHookReview(
+            session: session,
+            requestID: failed.id,
+            decision: .approveSelected(hookKeys: ["alpha"])
+        )
+
+        let outcome = await sendTask.value
+        XCTAssertEqual(outcome, .sent)
+        XCTAssertEqual(controller.trustCalls.count, 2)
+        XCTAssertEqual(controller.trustCalls.last?.candidates, [CodexHookTrustCandidate(key: "alpha", currentHash: "hash-alpha")])
+        XCTAssertEqual(controller.trustCalls.last?.fingerprint, initial.fingerprint)
+        XCTAssertEqual(session.codexHookGateAudit?.status, .approvedSelected)
+        XCTAssertEqual(session.codexHookGateAudit?.approvedCount, 1)
+        XCTAssertEqual(session.codexHookGateAudit?.skippedCount, 1)
+    }
+
+    func testStrictModeIsReadLiveAndRejectsContinueWithoutMutation() async throws {
+        let settings = HookApprovalFakeSettingsProvider(enabled: false)
+        let controller = try HookApprovalFakeCodexController(
+            listResults: [.success(inventory(hooks: [hook(key: "alpha")]))]
+        )
+        let (viewModel, session) = makeSession(controller: controller, settings: settings)
+        let sendTask = Task { await self.send(on: viewModel, session: session) }
+        let request = try await waitForRequest(session)
+
+        settings.enabled = true
+        do {
+            try await viewModel.test_codexCoordinator.resolveCodexHookReview(
+                session: session,
+                requestID: request.id,
+                decision: .continueWithoutHooks
+            )
+            XCTFail("Expected strict-mode rejection")
+        } catch let error as AgentCodexHookReviewResolutionError {
+            XCTAssertEqual(error, .strictModeRequiresApproval)
+            XCTAssertTrue(error.localizedDescription.localizedCaseInsensitiveContains("strict mode"))
+        }
+        XCTAssertEqual(session.pendingCodexHookReview?.id, request.id)
+        XCTAssertEqual(controller.startCount, 0)
+        XCTAssertTrue(controller.trustCalls.isEmpty)
+
+        settings.enabled = false
+        try await viewModel.test_codexCoordinator.resolveCodexHookReview(
+            session: session,
+            requestID: request.id,
+            decision: .continueWithoutHooks
+        )
+        let outcome = await sendTask.value
+        XCTAssertEqual(outcome, .sent)
+    }
+
+    func testDiscoveryFailureCarriesCwdErrorAndRetryToZeroResolvesExternally() async throws {
+        let controller = try HookApprovalFakeCodexController(
+            listResults: [
+                .failure(CodexHookTrustError.discoveryFailed(cwdErrors: ["invalid hook table in /repo/.codex/config.toml"])),
+                .success(inventory(hooks: []))
+            ]
+        )
+        let (viewModel, session) = makeSession(controller: controller)
+        let sendTask = Task { await self.send(on: viewModel, session: session) }
+        let failed = try await waitForRequest(session)
+
+        XCTAssertEqual(failed.phase, .discoveryFailed)
+        XCTAssertTrue(failed.errorMessage?.contains("invalid hook table") == true)
+        XCTAssertEqual(controller.startCount, 0)
+
+        try await viewModel.test_codexCoordinator.resolveCodexHookReview(
+            session: session,
+            requestID: failed.id,
+            decision: .retryDiscovery
+        )
+
+        let outcome = await sendTask.value
+        XCTAssertEqual(outcome, .sent)
+        XCTAssertNil(session.pendingCodexHookReview)
+        XCTAssertEqual(session.codexHookGateAudit?.status, .resolvedExternally)
+        XCTAssertEqual(controller.operations, ["list", "list", "start"])
+    }
+
+    func testInventoryDriftReplacesIdentityAndDriftToZeroResolvesExternally() async throws {
+        let initial = try inventory(hooks: [hook(key: "alpha")])
+        let replacement = try inventory(hooks: [hook(key: "beta")])
+        let empty = try inventory(hooks: [])
+        let controller = HookApprovalFakeCodexController(
+            listResults: [.success(initial)],
+            trustResults: [
+                .failure(CodexHookTrustError.inventoryChanged(replacement: replacement)),
+                .failure(CodexHookTrustError.inventoryChanged(replacement: empty))
+            ]
+        )
+        let (viewModel, session) = makeSession(controller: controller)
+        let sendTask = Task { await self.send(on: viewModel, session: session) }
+        let firstRequest = try await waitForRequest(session)
+
+        try await viewModel.test_codexCoordinator.resolveCodexHookReview(
+            session: session,
+            requestID: firstRequest.id,
+            decision: .approveAll
+        )
+        let drifted = try XCTUnwrap(session.pendingCodexHookReview)
+        XCTAssertNotEqual(drifted.id, firstRequest.id)
+        XCTAssertEqual(drifted.hooks.map(\.key), ["beta"])
+        XCTAssertEqual(controller.startCount, 0)
+
+        do {
+            try await viewModel.test_codexCoordinator.resolveCodexHookReview(
+                session: session,
+                requestID: firstRequest.id,
+                decision: .approveAll
+            )
+            XCTFail("Expected stale request rejection")
+        } catch let error as AgentCodexHookReviewResolutionError {
+            XCTAssertEqual(error, .staleRequest(currentID: drifted.id))
+        }
+
+        try await viewModel.test_codexCoordinator.resolveCodexHookReview(
+            session: session,
+            requestID: drifted.id,
+            decision: .approveAll
+        )
+        let outcome = await sendTask.value
+        XCTAssertEqual(outcome, .sent)
+        XCTAssertEqual(session.codexHookGateAudit?.status, .resolvedExternally)
+        XCTAssertEqual(controller.startCount, 1)
+    }
+
+    func testControllerReplacementCancelsSuspendedFirstTurnExactlyOnce() async throws {
+        let controller = try HookApprovalFakeCodexController(
+            listResults: [.success(inventory(hooks: [hook(key: "alpha")]))]
+        )
+        let replacement = try HookApprovalFakeCodexController(
+            listResults: [.success(inventory(hooks: []))]
+        )
+        let (viewModel, session) = makeSession(controller: controller)
+        let sendTask = Task { await self.send(on: viewModel, session: session) }
+        _ = try await waitForRequest(session)
+
+        session.codexController = replacement
+
+        let outcome = await sendTask.value
+        XCTAssertEqual(outcome, .cancelled)
+        XCTAssertNil(session.pendingCodexHookReview)
+        XCTAssertNil(session.codexHookReviewContinuation)
+        XCTAssertEqual(controller.startCount, 0)
+        XCTAssertEqual(replacement.startCount, 0)
+    }
+
+    func testBindingMemoizesSameControllerAndReplacementPromptsAgain() async throws {
+        let controller = try HookApprovalFakeCodexController(
+            listResults: [.success(inventory(hooks: [hook(key: "alpha")]))]
+        )
+        let (viewModel, session) = makeSession(controller: controller)
+        let firstSend = Task { await self.send(on: viewModel, session: session) }
+        let firstRequest = try await waitForRequest(session)
+        try await continueWithoutHooks(firstRequest, session: session, viewModel: viewModel)
+        await assertOutcome(firstSend, equals: .sent)
+
+        prepareDirectStart(session)
+        let secondOutcome = await send(on: viewModel, session: session)
+        XCTAssertEqual(secondOutcome, .sent)
+        XCTAssertEqual(controller.listCount, 1)
+        XCTAssertEqual(controller.startCount, 2)
+
+        let replacement = try HookApprovalFakeCodexController(
+            listResults: [.success(inventory(hooks: [hook(key: "beta")]))]
+        )
+        session.codexController = replacement
+        prepareDirectStart(session)
+        let replacementSend = Task { await self.send(on: viewModel, session: session) }
+        let replacementRequest = try await waitForRequest(session)
+        XCTAssertEqual(replacementRequest.hooks.map(\.key), ["beta"])
+        XCTAssertEqual(replacement.listCount, 1)
+        XCTAssertEqual(replacement.startCount, 0)
+        try await continueWithoutHooks(replacementRequest, session: session, viewModel: viewModel)
+        await assertOutcome(replacementSend, equals: .sent)
+    }
+
+    func testControlOnlyBindingRoutesDeferHookReviewUntilLaterFirstSend() async throws {
+        enum Route: CaseIterable {
+            case restore
+            case reconnect
+            case goal
+            case compact
+        }
+
+        CodexGoalSupport.setEnabledForTesting(true)
+        defer { CodexGoalSupport.setEnabledForTesting(nil) }
+
+        for route in Route.allCases {
+            let controller = try HookApprovalFakeCodexController(
+                listResults: [.success(inventory(hooks: [hook(key: "hook-\(route)")]))]
+            )
+            let (viewModel, session) = makeUnboundSession(controller: controller)
+            let coordinator = viewModel.test_codexCoordinator
+
+            switch route {
+            case .restore:
+                coordinator.restoreCodexMetadata(
+                    from: AgentSession(
+                        agentKind: AgentProviderKind.codexExec.rawValue,
+                        codexConversationID: "thread"
+                    ),
+                    session: session
+                )
+                await coordinator.ensureCodexNativeSession(session: session)
+            case .reconnect:
+                session.codexConversationID = "thread"
+                session.codexNeedsReconnect = true
+                await coordinator.ensureCodexNativeSession(session: session)
+            case .goal:
+                session.codexConversationID = "thread"
+                _ = await coordinator.executeNativeSlashCommand(
+                    .goal,
+                    argumentsText: "",
+                    session: session
+                )
+            case .compact:
+                session.codexConversationID = "thread"
+                _ = await coordinator.executeNativeSlashCommand(
+                    .compact,
+                    argumentsText: "",
+                    session: session
+                )
+            }
+
+            XCTAssertNotNil(session.codexController, "\(route)")
+            XCTAssertEqual(controller.listCount, 0, "\(route)")
+            XCTAssertNil(session.pendingCodexHookReview, "\(route)")
+
+            prepareDirectStart(session)
+            let sendTask = Task { await self.send(on: viewModel, session: session) }
+            let request = try await waitForRequest(session)
+            XCTAssertEqual(controller.listCount, 1, "\(route)")
+            XCTAssertEqual(controller.startCount, 0, "\(route)")
+            try await continueWithoutHooks(request, session: session, viewModel: viewModel)
+            await assertOutcome(sendTask, equals: .sent, message: "\(route)")
+        }
+    }
+
+    func testManagedAuthRecoveryReplayRunsHookGateBeforeSecondStart() async throws {
+        let controller = try HookApprovalFakeCodexController(
+            listResults: [
+                .success(inventory(hooks: [])),
+                .success(inventory(hooks: [hook(key: "replay")]))
+            ],
+            startResults: [
+                .failure(HookApprovalTestError.managedAuthRequired),
+                .success(.init(provisionalSubmissionID: "replayed"))
+            ]
+        )
+        let authRecovery = HookApprovalFakeAuthRecovery()
+        let (viewModel, session) = makeSession(controller: controller, authRecovery: authRecovery)
+        let sendTask = Task { await self.send(on: viewModel, session: session) }
+
+        let request = try await waitForRequest(session)
+        XCTAssertEqual(request.hooks.map(\.key), ["replay"])
+        let refreshCount = await authRecovery.refreshCount
+        XCTAssertEqual(refreshCount, 1)
+        XCTAssertEqual(controller.listCount, 2)
+        XCTAssertEqual(controller.startCount, 1)
+
+        try await continueWithoutHooks(request, session: session, viewModel: viewModel)
+        await assertOutcome(sendTask, equals: .sent)
+        XCTAssertEqual(controller.startCount, 2)
+    }
+
+    func testTrustAllSuccessReleasesTurnAndRecordsApprovedAllAudit() async throws {
+        let unresolved = try hook(key: "alpha")
+        let verified = try inventory(hooks: [hook(key: "alpha", status: .trusted)])
+        let controller = try HookApprovalFakeCodexController(
+            listResults: [.success(inventory(hooks: [unresolved]))],
+            trustResults: [.success(verified)]
+        )
+        let (viewModel, session) = makeSession(controller: controller)
+        let sendTask = Task { await self.send(on: viewModel, session: session) }
+        let request = try await waitForRequest(session)
+
+        try await viewModel.test_codexCoordinator.resolveCodexHookReview(
+            session: session,
+            requestID: request.id,
+            decision: .approveAll
+        )
+
+        await assertOutcome(sendTask, equals: .sent)
+        XCTAssertEqual(session.codexHookGateAudit?.status, .approvedAll)
+        XCTAssertEqual(session.codexHookGateAudit?.approvedCount, 1)
+        XCTAssertEqual(session.codexHookGateAudit?.skippedCount, 0)
+        XCTAssertEqual(controller.operations, ["list", "trust", "start"])
+    }
+
+    func testVerificationFailureRetainsIdentityAndTrustAllRetryReleasesTurn() async throws {
+        let unresolved = try inventory(hooks: [hook(key: "alpha")])
+        let verified = try inventory(hooks: [hook(key: "alpha", status: .trusted)])
+        let controller = HookApprovalFakeCodexController(
+            listResults: [.success(unresolved)],
+            trustResults: [.success(unresolved), .success(verified)]
+        )
+        let (viewModel, session) = makeSession(controller: controller)
+        let sendTask = Task { await self.send(on: viewModel, session: session) }
+        let request = try await waitForRequest(session)
+
+        try await viewModel.test_codexCoordinator.resolveCodexHookReview(
+            session: session,
+            requestID: request.id,
+            decision: .approveAll
+        )
+        let failed = try XCTUnwrap(session.pendingCodexHookReview)
+        XCTAssertEqual(failed.phase, .verificationFailed)
+        XCTAssertEqual(failed.id, request.id)
+        XCTAssertEqual(controller.startCount, 0)
+
+        try await viewModel.test_codexCoordinator.resolveCodexHookReview(
+            session: session,
+            requestID: failed.id,
+            decision: .approveAll
+        )
+        await assertOutcome(sendTask, equals: .sent)
+        XCTAssertEqual(controller.trustCalls.count, 2)
+        XCTAssertEqual(session.codexHookGateAudit?.status, .approvedAll)
+    }
+
+    func testRetryDiscoveryNonemptyInventoryReplacesIdentityWithoutResumingTurn() async throws {
+        let controller = try HookApprovalFakeCodexController(
+            listResults: [
+                .failure(CodexHookTrustError.discoveryFailed(cwdErrors: ["broken config"])),
+                .success(inventory(hooks: [hook(key: "replacement")]))
+            ]
+        )
+        let (viewModel, session) = makeSession(controller: controller)
+        let sendTask = Task { await self.send(on: viewModel, session: session) }
+        let failed = try await waitForRequest(session)
+
+        try await viewModel.test_codexCoordinator.resolveCodexHookReview(
+            session: session,
+            requestID: failed.id,
+            decision: .retryDiscovery
+        )
+
+        let replacement = try XCTUnwrap(session.pendingCodexHookReview)
+        XCTAssertNotEqual(replacement.id, failed.id)
+        XCTAssertEqual(replacement.phase, .reviewRequired)
+        XCTAssertEqual(replacement.hooks.map(\.key), ["replacement"])
+        XCTAssertEqual(controller.startCount, 0)
+        _ = session.cancelCodexHookReview()
+        await assertOutcome(sendTask, equals: .cancelled)
+    }
+
+    func testDuplicateTrustAllResponseIsBusyAndRunsOneOperation() async throws {
+        let trustGate = HookApprovalAsyncGate()
+        let controller = try HookApprovalFakeCodexController(
+            listResults: [.success(inventory(hooks: [hook(key: "alpha")]))],
+            trustResults: [.success(inventory(hooks: [hook(key: "alpha", status: .trusted)]))],
+            trustGate: trustGate
+        )
+        let (viewModel, session) = makeSession(controller: controller)
+        let sendTask = Task { await self.send(on: viewModel, session: session) }
+        let request = try await waitForRequest(session)
+        let firstResponse = Task {
+            try await viewModel.test_codexCoordinator.resolveCodexHookReview(
+                session: session,
+                requestID: request.id,
+                decision: .approveAll
+            )
+        }
+        try await trustGate.waitUntilWaiting()
+
+        do {
+            try await viewModel.test_codexCoordinator.resolveCodexHookReview(
+                session: session,
+                requestID: request.id,
+                decision: .approveAll
+            )
+            XCTFail("Expected duplicate response to be busy")
+        } catch let error as AgentCodexHookReviewResolutionError {
+            XCTAssertEqual(error, .busy)
+        }
+        XCTAssertEqual(controller.trustCalls.count, 1)
+        await trustGate.release()
+        try await firstResponse.value
+        await assertOutcome(sendTask, equals: .sent)
+        XCTAssertEqual(controller.trustCalls.count, 1)
+    }
+
+    func testLateApprovalResultsRequireGenerationBindingAndAttemptTokenIndependently() async throws {
+        enum InvalidatedAuthority: CaseIterable {
+            case gateGeneration
+            case bindingIdentity
+            case attemptToken
+        }
+
+        for authority in InvalidatedAuthority.allCases {
+            let trustGate = HookApprovalAsyncGate()
+            let controller = try HookApprovalFakeCodexController(
+                listResults: [.success(inventory(hooks: [hook(key: "alpha")]))],
+                trustResults: [.success(inventory(hooks: [hook(key: "alpha", status: .trusted)]))],
+                trustGate: trustGate
+            )
+            let (viewModel, session) = makeSession(controller: controller)
+            let sendTask = Task { await self.send(on: viewModel, session: session) }
+            let request = try await waitForRequest(session)
+            let response = Task {
+                try await viewModel.test_codexCoordinator.resolveCodexHookReview(
+                    session: session,
+                    requestID: request.id,
+                    decision: .approveAll
+                )
+            }
+            try await trustGate.waitUntilWaiting()
+
+            switch authority {
+            case .gateGeneration:
+                session.codexHookGateGeneration &+= 1
+            case .bindingIdentity:
+                let unrelated = HookApprovalFakeCodexController(listResults: [])
+                session.codexHookGateActiveBinding = .init(
+                    controllerInstanceID: ObjectIdentifier(unrelated),
+                    controllerGeneration: session.codexControllerGeneration
+                )
+            case .attemptToken:
+                session.codexHookGateAttemptToken = UUID()
+            }
+
+            await trustGate.release()
+            try await response.value
+            XCTAssertNil(session.codexHookGateAudit, "\(authority)")
+            XCTAssertEqual(controller.startCount, 0, "\(authority)")
+            XCTAssertNotNil(session.pendingCodexHookReview, "\(authority)")
+            _ = session.cancelCodexHookReview()
+            await assertOutcome(sendTask, equals: .cancelled, message: "\(authority)")
+        }
+    }
+
+    func testCancellationRoutesResumeSuspendedTurnExactlyOnce() async throws {
+        enum CancellationRoute: CaseIterable {
+            case directTask
+            case tabClose
+            case appTeardown
+        }
+
+        for route in CancellationRoute.allCases {
+            let controller = try HookApprovalFakeCodexController(
+                listResults: [.success(inventory(hooks: [hook(key: "alpha")]))]
+            )
+            let (viewModel, session) = makeSession(controller: controller)
+            let counter = HookApprovalCompletionCounter()
+            let sendTask = Task { await self.send(on: viewModel, session: session) }
+            let observed = Task {
+                let outcome = await sendTask.value
+                await counter.record(outcome)
+                return outcome
+            }
+            _ = try await waitForRequest(session)
+
+            switch route {
+            case .directTask:
+                sendTask.cancel()
+                sendTask.cancel()
+            case .tabClose:
+                await viewModel.handleComposeTabsWillClose([session.tabID], reason: .stash)
+            case .appTeardown:
+                await viewModel.prepareForWindowClose()
+            }
+
+            await assertOutcome(observed, equals: .cancelled, message: "\(route)")
+            try await Task.sleep(nanoseconds: 20_000_000)
+            let completionCount = await counter.count
+            XCTAssertEqual(completionCount, 1, "\(route)")
+            XCTAssertNil(session.codexHookReviewContinuation, "\(route)")
+            XCTAssertNil(session.pendingCodexHookReview, "\(route)")
+        }
+    }
+
+    func testTrustAllSuccessResumesSuspendedTurnExactlyOnce() async throws {
+        let controller = try HookApprovalFakeCodexController(
+            listResults: [.success(inventory(hooks: [hook(key: "alpha")]))],
+            trustResults: [.success(inventory(hooks: [hook(key: "alpha", status: .trusted)]))]
+        )
+        let (viewModel, session) = makeSession(controller: controller)
+        let counter = HookApprovalCompletionCounter()
+        let sendTask = Task { await self.send(on: viewModel, session: session) }
+        let observed = Task {
+            let outcome = await sendTask.value
+            await counter.record(outcome)
+            return outcome
+        }
+        let request = try await waitForRequest(session)
+
+        try await viewModel.test_codexCoordinator.resolveCodexHookReview(
+            session: session,
+            requestID: request.id,
+            decision: .approveAll
+        )
+        await assertOutcome(observed, equals: .sent)
+        _ = session.cancelCodexHookReview()
+        try await Task.sleep(nanoseconds: 20_000_000)
+        let completionCount = await counter.count
+        XCTAssertEqual(completionCount, 1)
+    }
+
+    func testCancelledComposerFirstMessageRestoresDraftAndAttachmentsExactlyOnce() async throws {
+        let controller = try HookApprovalFakeCodexController(
+            listResults: [.success(inventory(hooks: [hook(key: "alpha")]))]
+        )
+        let (viewModel, session) = makeComposerSession(controller: controller)
+        viewModel.test_setCurrentTabIDOverride(session.tabID)
+        defer { viewModel.test_setCurrentTabIDOverride(nil) }
+
+        let image = AgentImageAttachment(
+            source: .localFile(path: "/tmp/hook-approval-cancelled.png"),
+            title: "hook-approval-cancelled.png"
+        )
+        let taggedFile = AgentTaggedFileAttachment(
+            relativePath: "Sources/Secret.swift",
+            displayName: "Secret.swift"
+        )
+        let draft = "unsent first message"
+        session.pendingImageAttachments = [image]
+        session.pendingTaggedFileAttachments = [taggedFile]
+        viewModel.storeDraftText(for: session.tabID, draft)
+
+        let target = try XCTUnwrap(viewModel.makeComposerSubmitTarget(tabID: session.tabID, session: session))
+        let attempt = AgentComposerSubmitAttempt(
+            id: UUID(),
+            target: target,
+            inputRevision: 1,
+            noticeRevision: 0,
+            rawDraftSnapshot: draft
+        )
+        let claim: AgentModeViewModel.AgentComposerSubmitClaim
+        switch viewModel.claimComposerSubmitAttempt(attempt) {
+        case let .claimed(value):
+            claim = value
+        case let .rejected(rejection):
+            return XCTFail("Expected composer claim, got \(rejection)")
+        }
+        let submitResult = await viewModel.executeComposerSubmitAttempt(text: draft, claim: claim)
+        XCTAssertEqual(submitResult, .submitted)
+        _ = try await waitForRequest(session)
+
+        await viewModel.cancelAgentRun(tabID: session.tabID, completion: .terminalTeardownCompleted)
+        await viewModel.cancelAgentRun(tabID: session.tabID, completion: .terminalTeardownCompleted)
+        try await waitUntil {
+            viewModel.retrieveDraftText(for: session.tabID) == draft
+                && session.pendingImageAttachments == [image]
+                && session.pendingTaggedFileAttachments == [taggedFile]
+        }
+        XCTAssertEqual(session.pendingImageAttachments, [image])
+        XCTAssertEqual(session.pendingTaggedFileAttachments, [taggedFile])
+        XCTAssertEqual(viewModel.retrieveDraftText(for: session.tabID), draft)
+        XCTAssertEqual(session.items.count(where: { $0.kind == .user }), 0)
+    }
+
+    func testStableHookReviewIdentityIgnoresPhaseAndErrorButTracksSeedComponents() throws {
+        let tabID = UUID()
+        let attemptID = UUID()
+        let runID = UUID()
+        let baseHook = try AgentCodexHookReviewHook(metadata: hook(key: "alpha"))
+        func request(
+            tabID: UUID = tabID,
+            attemptID: UUID = attemptID,
+            cwd: String = "/repo",
+            hook: AgentCodexHookReviewHook = baseHook,
+            phase: AgentCodexHookReviewRequest.Phase = .reviewRequired,
+            error: String? = nil
+        ) -> AgentCodexHookReviewRequest {
+            AgentCodexHookReviewRequest(
+                tabID: tabID,
+                runAttemptID: attemptID,
+                runID: runID,
+                executionCWD: cwd,
+                hooks: [hook],
+                phase: phase,
+                errorMessage: error,
+                gateGeneration: 7
+            )
+        }
+
+        let baseline = request()
+        XCTAssertEqual(request(phase: .submitting).id, baseline.id)
+        XCTAssertEqual(request(phase: .verificationFailed, error: "different failure text").id, baseline.id)
+        XCTAssertNotEqual(request(tabID: UUID()).id, baseline.id)
+        XCTAssertNotEqual(request(attemptID: UUID()).id, baseline.id)
+        XCTAssertNotEqual(request(cwd: "/other").id, baseline.id)
+
+        let sameKeyDifferentHash = try AgentCodexHookReviewHook(
+            metadata: CodexHookMetadata(
+                eventName: "PreToolUse",
+                source: "project",
+                sourcePath: "/repo/.codex/config.toml",
+                key: "alpha",
+                currentHash: "explicit-different-hash",
+                enabled: true,
+                handlerType: "command",
+                trustStatus: .untrusted,
+                commandOrHandler: "./hooks/alpha"
+            )
+        )
+        XCTAssertNotEqual(request(hook: sameKeyDifferentHash).id, baseline.id)
+
+        let differentKeySameHash = try AgentCodexHookReviewHook(
+            metadata: CodexHookMetadata(
+                eventName: "PreToolUse",
+                source: "project",
+                sourcePath: "/repo/.codex/config.toml",
+                key: "beta",
+                currentHash: "hash-alpha",
+                enabled: true,
+                handlerType: "command",
+                trustStatus: .untrusted,
+                commandOrHandler: "./hooks/alpha"
+            )
+        )
+        XCTAssertNotEqual(request(hook: differentKeySameHash).id, baseline.id)
+
+        XCTAssertNotEqual(
+            try request(hook: AgentCodexHookReviewHook(metadata: hook(key: "beta"))).id,
+            baseline.id
+        )
+    }
+
+    func testHookOutcomeTranscriptNoticesExcludeInventoryMetadata() async throws {
+        let sensitiveHook = try CodexHookMetadata(
+            eventName: "PreToolUse",
+            source: "project",
+            sourcePath: "/repo/private/.codex/config.toml",
+            key: "private-hook-key",
+            currentHash: "private-hash",
+            enabled: true,
+            handlerType: "command",
+            trustStatus: .untrusted,
+            commandOrHandler: "/repo/private/run-secret-hook"
+        )
+        let trusted = try CodexHookMetadata(
+            eventName: sensitiveHook.eventName,
+            source: sensitiveHook.source,
+            sourcePath: sensitiveHook.sourcePath,
+            key: sensitiveHook.key,
+            currentHash: sensitiveHook.currentHash,
+            enabled: true,
+            handlerType: sensitiveHook.handlerType,
+            trustStatus: .trusted,
+            commandOrHandler: sensitiveHook.commandOrHandler
+        )
+        let approvalController = try HookApprovalFakeCodexController(
+            listResults: [.success(inventory(hooks: [sensitiveHook]))],
+            trustResults: [.success(inventory(hooks: [trusted]))]
+        )
+        let (approvalViewModel, approvalSession) = makeSession(controller: approvalController)
+        let approvalSend = Task { await self.send(on: approvalViewModel, session: approvalSession) }
+        let approvalRequest = try await waitForRequest(approvalSession)
+        try await approvalViewModel.test_codexCoordinator.resolveCodexHookReview(
+            session: approvalSession,
+            requestID: approvalRequest.id,
+            decision: .approveAll
+        )
+        await assertOutcome(approvalSend, equals: .sent)
+        assertHookNoticesArePrivate(approvalSession)
+
+        let externalController = HookApprovalFakeCodexController(
+            listResults: [.failure(CodexHookTrustError.discoveryFailed(cwdErrors: ["private discovery error"]))]
+        )
+        let (externalViewModel, externalSession) = makeSession(controller: externalController)
+        let externalSend = Task { await self.send(on: externalViewModel, session: externalSession) }
+        let externalRequest = try await waitForRequest(externalSession)
+        externalController.listResults = try [.success(inventory(hooks: []))]
+        try await externalViewModel.test_codexCoordinator.resolveCodexHookReview(
+            session: externalSession,
+            requestID: externalRequest.id,
+            decision: .retryDiscovery
+        )
+        await assertOutcome(externalSend, equals: .sent)
+        assertHookNoticesArePrivate(externalSession)
+    }
+
+    private func makeSession(
+        controller: HookApprovalFakeCodexController,
+        settings: HookApprovalFakeSettingsProvider? = nil,
+        authRecovery: (any CodexManagedAuthRecovering)? = nil
+    ) -> (AgentModeViewModel, AgentModeViewModel.TabSession) {
+        let (viewModel, session) = makeUnboundSession(
+            controller: controller,
+            settings: settings,
+            authRecovery: authRecovery
+        )
+        session.runID = UUID()
+        session.beginRunAttempt(source: "test.codexHookApproval")
+        bindReadyController(controller, to: session)
+        return (viewModel, session)
+    }
+
+    private func makeUnboundSession(
+        controller: HookApprovalFakeCodexController,
+        settings: HookApprovalFakeSettingsProvider? = nil,
+        authRecovery: (any CodexManagedAuthRecovering)? = nil
+    ) -> (AgentModeViewModel, AgentModeViewModel.TabSession) {
+        let settings = settings ?? HookApprovalFakeSettingsProvider(enabled: false)
+        let viewModel = AgentModeViewModel(
+            testWorkspacePath: "/repo",
+            codexControllerFactory: { _, _, _, _, _, _ in controller },
+            testCodexManagedAuthRecovery: authRecovery,
+            testCodexHookApprovalSettingsProvider: settings
+        )
+        viewModel.test_initializeRunService()
+        let session = viewModel.session(for: UUID())
+        session.selectedAgent = .codexExec
+        session.runState = .idle
+        return (viewModel, session)
+    }
+
+    private func makeComposerSession(
+        controller: HookApprovalFakeCodexController
+    ) -> (AgentModeViewModel, AgentModeViewModel.TabSession) {
+        let (viewModel, session) = makeUnboundSession(controller: controller)
+        bindReadyController(controller, to: session)
+        session.testInstallPersistentSessionBinding(sessionID: UUID())
+        session.hasLoadedPersistedState = true
+        return (viewModel, session)
+    }
+
+    private func bindReadyController(
+        _ controller: HookApprovalFakeCodexController,
+        to session: AgentModeViewModel.TabSession
+    ) {
+        session.codexController = controller
+        session.codexControllerPermissionProfile = session.permissionProfile
+        session.codexControllerWorkspacePaths = .uniform("/repo")
+        session.codexConversationID = "thread"
+        session.codexControllerFeatureState = .init(
+            computerUseEnabled: false,
+            goalSupportEnabled: CodexGoalSupport.isEnabled,
+            reasoningSummariesEnabled: CodexReasoningSummaries.isEnabled
+        )
+    }
+
+    private func prepareDirectStart(_ session: AgentModeViewModel.TabSession) {
+        if let ownership = session.activeRunOwnership {
+            _ = session.endRunAttempt(ifCurrent: ownership, source: "test.codexHookApproval.reset")
+        }
+        session.runID = UUID()
+        session.runState = .idle
+        session.codexPendingTurnKind = nil
+        session.codexAuthoritativeActiveTurn = nil
+        session.codexAnonymousActiveTurn = nil
+        session.codexPendingAuthRetryTurn = nil
+        _ = session.beginRunAttempt(source: "test.codexHookApproval.nextStart")
+    }
+
+    private func continueWithoutHooks(
+        _ request: AgentCodexHookReviewRequest,
+        session: AgentModeViewModel.TabSession,
+        viewModel: AgentModeViewModel
+    ) async throws {
+        try await viewModel.test_codexCoordinator.resolveCodexHookReview(
+            session: session,
+            requestID: request.id,
+            decision: .continueWithoutHooks
+        )
+    }
+
+    private func assertHookNoticesArePrivate(
+        _ session: AgentModeViewModel.TabSession,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let notices = session.items.filter { $0.kind == .system }.map(\.text).joined(separator: "\n")
+        XCTAssertTrue(
+            notices.contains("Trusted 1") || notices.contains("resolved externally"),
+            notices,
+            file: file,
+            line: line
+        )
+        for secret in [
+            "private-hook-key",
+            "/repo/private/run-secret-hook",
+            "/repo/private/.codex/config.toml",
+            "/repo",
+            "private-hash"
+        ] {
+            XCTAssertFalse(notices.contains(secret), "Leaked \(secret): \(notices)", file: file, line: line)
+        }
+    }
+
+    private func waitUntil(
+        timeout: TimeInterval = 2,
+        _ predicate: @escaping () -> Bool
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if predicate() { return }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTFail("Timed out waiting for Codex hook approval state")
+    }
+
+    private func assertOutcome(
+        _ task: Task<CodexAgentModeCoordinator.NativeSendOutcome, Never>,
+        equals expected: CodexAgentModeCoordinator.NativeSendOutcome,
+        message: String = "",
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        let actual = await task.value
+        XCTAssertEqual(actual, expected, message, file: file, line: line)
+    }
+
+    private func send(
+        on viewModel: AgentModeViewModel,
+        session: AgentModeViewModel.TabSession
+    ) async -> CodexAgentModeCoordinator.NativeSendOutcome {
+        await viewModel.test_codexCoordinator.sendCodexNativeMessage(
+            session: session,
+            text: "hello",
+            attachments: []
+        )
+    }
+
+    private func waitForRequest(
+        _ session: AgentModeViewModel.TabSession,
+        timeout: TimeInterval = 2
+    ) async throws -> AgentCodexHookReviewRequest {
+        try await waitForPendingCodexHookReview(
+            in: session,
+            timeout: timeout,
+            diagnostic: "Timed out waiting for Codex hook review; runState=\(session.runState), items=\(session.items.map { "\($0.kind):\($0.text)" })"
+        )
+    }
+
+    private func inventory(hooks: [CodexHookMetadata]) throws -> CodexHookInventory {
+        try CodexHookInventory(executionCWD: "/repo", hooks: hooks)
+    }
+
+    private func hook(
+        key: String,
+        status: CodexHookTrustStatus = .untrusted,
+        enabled: Bool = true
+    ) throws -> CodexHookMetadata {
+        try CodexHookMetadata(
+            eventName: "PreToolUse",
+            source: "project",
+            sourcePath: "/repo/.codex/config.toml",
+            key: key,
+            currentHash: "hash-\(key)",
+            enabled: enabled,
+            handlerType: "command",
+            trustStatus: status,
+            commandOrHandler: "./hooks/\(key)"
+        )
+    }
+}
+
+@MainActor
+private final class HookApprovalFakeSettingsProvider: CodexHookApprovalSettingsProviding {
+    var enabled: Bool
+
+    init(enabled: Bool) {
+        self.enabled = enabled
+    }
+
+    func codexHookApprovalStrictModeEnabled(workspaceID _: UUID?) -> Bool {
+        enabled
+    }
+}
+
+private final class HookApprovalFakeCodexController: CodexSessionControllerPassiveStubDefaults {
+    struct TrustCall: Equatable {
+        let candidates: [CodexHookTrustCandidate]
+        let fingerprint: String
+    }
+
+    var listResults: [Result<CodexHookInventory, Error>]
+    var trustResults: [Result<CodexHookInventory, Error>]
+    var startResults: [Result<CodexTurnStartReceipt, Error>]
+    private let trustGate: HookApprovalAsyncGate?
+    private(set) var operations: [String] = []
+    private(set) var trustCalls: [TrustCall] = []
+    private(set) var startCount = 0
+
+    var listCount: Int {
+        operations.count(where: { $0 == "list" })
+    }
+
+    init(
+        listResults: [Result<CodexHookInventory, Error>],
+        trustResults: [Result<CodexHookInventory, Error>] = [],
+        startResults: [Result<CodexTurnStartReceipt, Error>] = [],
+        trustGate: HookApprovalAsyncGate? = nil
+    ) {
+        self.listResults = listResults
+        self.trustResults = trustResults
+        self.startResults = startResults
+        self.trustGate = trustGate
+    }
+
+    var hasActiveThread: Bool {
+        true
+    }
+
+    var events: AsyncStream<CodexNativeSessionController.Event> {
+        AsyncStream { _ in }
+    }
+
+    func startOrResume(
+        existing _: CodexNativeSessionController.SessionRef?,
+        baseInstructions _: String,
+        model: String?,
+        reasoningEffort: String?,
+        serviceTier _: String?
+    ) async throws -> CodexNativeSessionController.SessionRef {
+        .init(conversationID: "thread", rolloutPath: nil, model: model, reasoningEffort: reasoningEffort)
+    }
+
+    func listHooksForCurrentWorkspace() async throws -> CodexHookInventory {
+        operations.append("list")
+        guard !listResults.isEmpty else {
+            throw CodexHookTrustError.malformedListResponse
+        }
+        return try listResults.removeFirst().get()
+    }
+
+    func trustHooksForCurrentWorkspace(
+        expectedCandidates: [CodexHookTrustCandidate],
+        expectedInventoryFingerprint: String
+    ) async throws -> CodexHookInventory {
+        operations.append("trust")
+        trustCalls.append(.init(candidates: expectedCandidates, fingerprint: expectedInventoryFingerprint))
+        await trustGate?.wait()
+        guard !trustResults.isEmpty else {
+            throw CodexHookTrustError.batchWriteFailed
+        }
+        return try trustResults.removeFirst().get()
+    }
+
+    func startUserTurn(
+        text _: String,
+        images _: [AgentImageAttachment],
+        model _: String?,
+        reasoningEffort _: String?,
+        serviceTier _: String?
+    ) async throws -> CodexTurnStartReceipt {
+        operations.append("start")
+        startCount += 1
+        if !startResults.isEmpty {
+            return try startResults.removeFirst().get()
+        }
+        return .init(provisionalSubmissionID: "submission-\(startCount)")
+    }
+
+    func readThreadSnapshot(includeTurns _: Bool, timeout _: TimeInterval?) async throws -> CodexNativeSessionController.ThreadSnapshot {
+        throw CancellationError()
+    }
+
+    func shutdown() async {}
+}
+
+private actor HookApprovalAsyncGate {
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var isWaiting = false
+    private var isReleased = false
+
+    func wait() async {
+        guard !isReleased else { return }
+        isWaiting = true
+        await withCheckedContinuation { continuation = $0 }
+    }
+
+    func waitUntilWaiting(timeout: TimeInterval = 2) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if isWaiting { return }
+            try await Task.sleep(nanoseconds: 1_000_000)
+        }
+        throw HookApprovalTestError.gateTimeout
+    }
+
+    func release() {
+        isReleased = true
+        continuation?.resume()
+        continuation = nil
+    }
+}
+
+private actor HookApprovalCompletionCounter {
+    private(set) var count = 0
+    private(set) var outcomes: [CodexAgentModeCoordinator.NativeSendOutcome] = []
+
+    func record(_ outcome: CodexAgentModeCoordinator.NativeSendOutcome) {
+        count += 1
+        outcomes.append(outcome)
+    }
+}
+
+private actor HookApprovalFakeAuthRecovery: CodexManagedAuthRecovering {
+    private(set) var refreshCount = 0
+
+    func refreshManagedAccount() async -> CodexManagedAuthRefreshResult {
+        refreshCount += 1
+        return .recovered
+    }
+
+    func startManagedChatgptLogin(
+        openURL _: @MainActor @escaping @Sendable (URL) -> Void
+    ) async -> CodexManagedChatgptLoginResult {
+        .authenticated
+    }
+}
+
+private enum HookApprovalTestError: LocalizedError {
+    case managedAuthRequired
+    case gateTimeout
+
+    var errorDescription: String? {
+        switch self {
+        case .managedAuthRequired:
+            "account/chatgptAuthTokens/refresh failed"
+        case .gateTimeout:
+            "Timed out waiting for the test gate."
+        }
+    }
+}

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexAgentModeCoordinatorHookApprovalTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexAgentModeCoordinatorHookApprovalTests.swift
@@ -394,7 +394,9 @@ final class CodexAgentModeCoordinatorHookApprovalTests: XCTestCase {
         session.codexController = replacement
 
         let outcome = await sendTask.value
-        XCTAssertEqual(outcome, .cancelled)
+        guard case .stale = outcome else {
+            return XCTFail("Expected stale cancellation after controller replacement, got \(outcome)")
+        }
         XCTAssertNil(session.pendingCodexHookReview)
         XCTAssertNil(session.codexHookReviewContinuation)
         XCTAssertEqual(controller.startCount, 0)

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexAgentModeCoordinatorHookApprovalTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexAgentModeCoordinatorHookApprovalTests.swift
@@ -577,6 +577,35 @@ final class CodexAgentModeCoordinatorHookApprovalTests: XCTestCase {
         XCTAssertEqual(session.codexHookGateAudit?.status, .approvedAll)
     }
 
+    func testFailedHookGateDoesNotPersistUncommittedControllerReferenceOnCancellation() async throws {
+        let unresolved = try inventory(hooks: [hook(key: "alpha")])
+        let controller = HookApprovalFakeCodexController(
+            listResults: [.success(unresolved)],
+            trustResults: [.failure(CodexHookTrustError.batchWriteFailed)]
+        )
+        controller.currentSessionReference = .init(
+            conversationID: "uncommitted-recovery-thread",
+            rolloutPath: "/tmp/uncommitted-rollout.jsonl",
+            model: "gpt-test",
+            reasoningEffort: "medium"
+        )
+        let (viewModel, session) = makeSession(controller: controller)
+        let sendTask = Task { await self.send(on: viewModel, session: session) }
+        let request = try await waitForRequest(session)
+
+        try await viewModel.test_codexCoordinator.resolveCodexHookReview(
+            session: session,
+            requestID: request.id,
+            decision: .approveAll
+        )
+        XCTAssertEqual(session.pendingCodexHookReview?.phase, .writeFailed)
+
+        _ = session.cancelCodexHookReview()
+        await assertOutcome(sendTask, equals: .cancelled)
+        XCTAssertEqual(session.codexConversationID, "thread")
+        XCTAssertNil(session.codexRolloutPath)
+    }
+
     func testRetryDiscoveryNonemptyInventoryReplacesIdentityWithoutResumingTurn() async throws {
         let controller = try HookApprovalFakeCodexController(
             listResults: [
@@ -1137,6 +1166,7 @@ private final class HookApprovalFakeCodexController: CodexSessionControllerPassi
     private(set) var operations: [String] = []
     private(set) var trustCalls: [TrustCall] = []
     private(set) var startCount = 0
+    var currentSessionReference: CodexNativeSessionController.SessionRef?
 
     var listCount: Int {
         operations.count(where: { $0 == "list" })

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexAgentModeCoordinatorHookApprovalTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexAgentModeCoordinatorHookApprovalTests.swift
@@ -171,6 +171,98 @@ final class CodexAgentModeCoordinatorHookApprovalTests: XCTestCase {
         XCTAssertEqual(session.codexHookGateAudit?.skippedCount, 0)
     }
 
+    func testStrictModeEnabledDuringPartialApprovalRefreshesSkippedHooks() async throws {
+        let alpha = try hook(key: "alpha")
+        let beta = try hook(key: "beta")
+        let initial = try inventory(hooks: [alpha, beta])
+        let partiallyVerified = try inventory(hooks: [
+            hook(key: "alpha", status: .trusted),
+            beta
+        ])
+        let fullyVerified = try inventory(hooks: [
+            hook(key: "alpha", status: .trusted),
+            hook(key: "beta", status: .trusted)
+        ])
+        let settings = HookApprovalFakeSettingsProvider(enabled: false)
+        let trustGate = HookApprovalAsyncGate()
+        let controller = HookApprovalFakeCodexController(
+            listResults: [.success(initial)],
+            trustResults: [.success(partiallyVerified), .success(fullyVerified)],
+            trustGate: trustGate
+        )
+        let (viewModel, session) = makeSession(controller: controller, settings: settings)
+        let sendTask = Task { await self.send(on: viewModel, session: session) }
+        let request = try await waitForRequest(session)
+        let response = Task {
+            try await viewModel.test_codexCoordinator.resolveCodexHookReview(
+                session: session,
+                requestID: request.id,
+                decision: .approveSelected(hookKeys: ["alpha"])
+            )
+        }
+        try await trustGate.waitUntilWaiting()
+
+        settings.enabled = true
+        await trustGate.release()
+        try await response.value
+
+        let replacement = try XCTUnwrap(session.pendingCodexHookReview)
+        XCTAssertNotEqual(replacement.id, request.id)
+        XCTAssertEqual(replacement.hooks.map(\.key), ["beta"])
+        XCTAssertNotNil(session.codexHookReviewContinuation)
+        XCTAssertNil(session.codexHookGateAudit)
+        XCTAssertNil(session.codexHookGateBindingMemo)
+        XCTAssertEqual(controller.startCount, 0)
+
+        try await viewModel.test_codexCoordinator.resolveCodexHookReview(
+            session: session,
+            requestID: replacement.id,
+            decision: .approveAll
+        )
+        await assertOutcome(sendTask, equals: .sent)
+        XCTAssertEqual(controller.startCount, 1)
+        XCTAssertEqual(controller.trustCalls.count, 2)
+        XCTAssertEqual(session.codexHookGateAudit?.status, .approvedAll)
+    }
+
+    func testStrictModeEnabledDuringFullApprovalWithCleanVerificationCompletes() async throws {
+        let initial = try inventory(hooks: [hook(key: "alpha"), hook(key: "beta")])
+        let verified = try inventory(hooks: [
+            hook(key: "alpha", status: .trusted),
+            hook(key: "beta", status: .trusted)
+        ])
+        let settings = HookApprovalFakeSettingsProvider(enabled: false)
+        let trustGate = HookApprovalAsyncGate()
+        let controller = HookApprovalFakeCodexController(
+            listResults: [.success(initial)],
+            trustResults: [.success(verified)],
+            trustGate: trustGate
+        )
+        let (viewModel, session) = makeSession(controller: controller, settings: settings)
+        let sendTask = Task { await self.send(on: viewModel, session: session) }
+        let request = try await waitForRequest(session)
+        let response = Task {
+            try await viewModel.test_codexCoordinator.resolveCodexHookReview(
+                session: session,
+                requestID: request.id,
+                decision: .approveAll
+            )
+        }
+        try await trustGate.waitUntilWaiting()
+
+        settings.enabled = true
+        await trustGate.release()
+        try await response.value
+
+        await assertOutcome(sendTask, equals: .sent)
+        XCTAssertNil(session.pendingCodexHookReview)
+        XCTAssertNil(session.codexHookReviewContinuation)
+        XCTAssertEqual(controller.startCount, 1)
+        XCTAssertEqual(controller.trustCalls.count, 1)
+        XCTAssertEqual(session.codexHookGateAudit?.status, .approvedAll)
+        XCTAssertNotNil(session.codexHookGateBindingMemo)
+    }
+
     func testDiscoveryFailureCarriesCwdErrorAndRetryToZeroResolvesExternally() async throws {
         let controller = try HookApprovalFakeCodexController(
             listResults: [

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexAgentModeCoordinatorLivenessTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexAgentModeCoordinatorLivenessTests.swift
@@ -1163,6 +1163,108 @@ final class CodexAgentModeCoordinatorLivenessTests: XCTestCase {
         session.pendingUserInputRequest = makeUserInputRequest(id: "stop-watchdog")
     }
 
+    func testLateStartCancellationAfterRunAndControllerReplacementPreservesSuccessor() async {
+        let cancellationGate = LivenessSnapshotReadGate()
+        let controller = LivenessFakeCodexController(
+            snapshot: .idle,
+            activeTurnIDs: [],
+            startUserTurnCancellationGate: cancellationGate
+        )
+        let viewModel = makeViewModel(controller: controller)
+        let session = preparedCodexSession(in: viewModel, controller: controller)
+        session.runState = .idle
+        session.codexAuthoritativeActiveTurn = nil
+        session.codexRoutingObservedTurnID = nil
+        let attachment = AgentImageAttachment(
+            source: .localFile(path: "/tmp/stale-cancelled-send.png"),
+            title: "stale-cancelled-send.png"
+        )
+        let reservationID = UUID()
+        session.attachmentTurnState = .reserved(
+            reservationID: reservationID,
+            attachments: [attachment]
+        )
+
+        let sendTask = Task {
+            await viewModel.test_codexCoordinator.sendCodexNativeMessage(
+                session: session,
+                text: "stale send",
+                attachments: [attachment],
+                attachmentReservationID: reservationID
+            )
+        }
+        await cancellationGate.waitUntilWaiting()
+
+        let successorRunID = UUID()
+        let successorController = LivenessFakeCodexController(snapshot: .active(activeFlags: []))
+        session.installRunID(successorRunID)
+        session.beginRunAttempt(source: "test.successor")
+        session.codexController = successorController
+        session.runState = .running
+        session.codexPendingTurnKind = .user
+        let successorAuthRetryTurn = AgentTabSession.CodexPendingAuthRetryTurn(
+            text: "successor retry",
+            images: [],
+            model: "gpt-5.6",
+            reasoningEffort: "high",
+            serviceTier: "priority",
+            attachmentReservationID: nil,
+            expectedTurnID: "successor-turn"
+        )
+        session.codexPendingAuthRetryTurn = successorAuthRetryTurn
+        session.runningStatusText = "Newer run active"
+        session.runningStatusSource = .transport
+        cancellationGate.release()
+
+        let outcome = await sendTask.value
+        guard case let .stale(reason) = outcome else {
+            return XCTFail("Expected stale cancellation outcome, got \(outcome)")
+        }
+        XCTAssertTrue(reason.contains("active run/controller changed"))
+        XCTAssertEqual(session.runID, successorRunID)
+        XCTAssertTrue((session.codexController as AnyObject) === successorController)
+        XCTAssertEqual(session.runState, .running)
+        XCTAssertEqual(session.codexPendingTurnKind, .user)
+        XCTAssertEqual(session.codexPendingAuthRetryTurn, successorAuthRetryTurn)
+        XCTAssertEqual(session.runningStatusText, "Newer run active")
+        XCTAssertEqual(session.runningStatusSource, .transport)
+        XCTAssertEqual(session.pendingImageAttachments, [attachment])
+        guard case .idle = session.attachmentTurnState else {
+            return XCTFail("The stale send's scoped attachment reservation was not released")
+        }
+    }
+
+    func testCurrentStartCancellationStillTerminalizesRun() async {
+        let cancellationGate = LivenessSnapshotReadGate()
+        let controller = LivenessFakeCodexController(
+            snapshot: .idle,
+            activeTurnIDs: [],
+            startUserTurnCancellationGate: cancellationGate
+        )
+        let viewModel = makeViewModel(controller: controller)
+        let session = preparedCodexSession(in: viewModel, controller: controller)
+        session.runState = .idle
+        session.codexAuthoritativeActiveTurn = nil
+        session.codexRoutingObservedTurnID = nil
+
+        let sendTask = Task {
+            await viewModel.test_codexCoordinator.sendCodexNativeMessage(
+                session: session,
+                text: "current send",
+                attachments: []
+            )
+        }
+        await cancellationGate.waitUntilWaiting()
+        cancellationGate.release()
+
+        let outcome = await sendTask.value
+        XCTAssertEqual(outcome, .cancelled)
+        XCTAssertEqual(session.runState, .cancelled)
+        XCTAssertNil(session.activeRunOwnership)
+        XCTAssertNil(session.runningStatusText)
+        XCTAssertTrue((session.codexController as AnyObject) === controller)
+    }
+
     func testStructuredLivenessAdvancesLifecycleWithoutTranscriptRows() async {
         let controller = LivenessFakeCodexController(snapshot: .active(activeFlags: []))
         let viewModel = makeViewModel(controller: controller)
@@ -3389,6 +3491,7 @@ private final class LivenessFakeCodexController: CodexSessionControllerTurnDispa
     private let steerError: Error?
     private let steerDelayNanos: UInt64
     private let startUserTurnDelayNanos: UInt64
+    private let startUserTurnCancellationGate: LivenessSnapshotReadGate?
     private let alwaysFailsSnapshotRead: Bool
     private let failsEveryEvenSnapshotRead: Bool
     private let failsPostReattachSnapshotRead: Bool
@@ -3412,6 +3515,7 @@ private final class LivenessFakeCodexController: CodexSessionControllerTurnDispa
         steerError: Error? = nil,
         steerDelayNanos: UInt64 = 0,
         startUserTurnDelayNanos: UInt64 = 0,
+        startUserTurnCancellationGate: LivenessSnapshotReadGate? = nil,
         alwaysFailsSnapshotRead: Bool = false,
         failsEveryEvenSnapshotRead: Bool = false,
         failsPostReattachSnapshotRead: Bool = false,
@@ -3437,6 +3541,7 @@ private final class LivenessFakeCodexController: CodexSessionControllerTurnDispa
         self.steerError = steerError
         self.steerDelayNanos = steerDelayNanos
         self.startUserTurnDelayNanos = startUserTurnDelayNanos
+        self.startUserTurnCancellationGate = startUserTurnCancellationGate
         self.alwaysFailsSnapshotRead = alwaysFailsSnapshotRead
         self.failsEveryEvenSnapshotRead = failsEveryEvenSnapshotRead
         self.failsPostReattachSnapshotRead = failsPostReattachSnapshotRead
@@ -3592,6 +3697,10 @@ private final class LivenessFakeCodexController: CodexSessionControllerTurnDispa
         recordSendUserTurn()
         startUserTurnCount += 1
         startedUserTurnTexts.append(text)
+        if let startUserTurnCancellationGate {
+            await startUserTurnCancellationGate.wait()
+            throw CancellationError()
+        }
         if startUserTurnDelayNanos > 0 {
             try await Task.sleep(nanoseconds: startUserTurnDelayNanos)
         }

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexAgentModeCoordinatorLivenessTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexAgentModeCoordinatorLivenessTests.swift
@@ -3111,6 +3111,60 @@ final class CodexAgentModeCoordinatorLivenessTests: XCTestCase {
         )
     }
 
+    func testPendingCodexHookReviewSuppressesStallWatchdog() async throws {
+        let controller = LivenessFakeCodexController(snapshot: .active(activeFlags: []))
+        let viewModel = makeViewModel(
+            controller: controller,
+            watchdogProbeThreshold: 0.02,
+            watchdogRecoveryThreshold: 0.06
+        )
+        let session = preparedCodexSession(in: viewModel, controller: controller)
+        session.pendingCodexHookReview = makeHookReviewRequest(for: session)
+        session.runState = .waitingForApproval
+
+        await viewModel.test_codexCoordinator.test_handleCodexNativeEvent(
+            .assistantDelta("blocked"),
+            session: session,
+            sourceController: controller
+        )
+        try await Task.sleep(nanoseconds: 120_000_000)
+
+        XCTAssertEqual(controller.readSnapshotCountSync(), 0)
+        XCTAssertNotNil(session.pendingCodexHookReview)
+    }
+
+    func testTurnStartedDoesNotClearBindingScopedCodexHookReview() async {
+        let controller = LivenessFakeCodexController(snapshot: .active(activeFlags: []))
+        let viewModel = makeViewModel(controller: controller)
+        let session = preparedCodexSession(in: viewModel, controller: controller)
+        let request = makeHookReviewRequest(for: session)
+        session.pendingCodexHookReview = request
+        session.runState = .waitingForApproval
+
+        await viewModel.test_codexCoordinator.test_handleCodexNativeEvent(
+            .turnStarted(turnID: "replacement-turn"),
+            session: session,
+            sourceController: controller
+        )
+
+        XCTAssertEqual(session.pendingCodexHookReview?.id, request.id)
+    }
+
+    private func makeHookReviewRequest(
+        for session: AgentModeViewModel.TabSession
+    ) -> AgentCodexHookReviewRequest {
+        AgentCodexHookReviewRequest(
+            tabID: session.tabID,
+            runAttemptID: session.activeRunAttemptID,
+            runID: session.runID,
+            executionCWD: "/tmp",
+            hooks: [],
+            phase: .discoveryFailed,
+            errorMessage: "Discovery failed",
+            gateGeneration: session.codexHookGateGeneration
+        )
+    }
+
     private func makeViewModel(
         controller: LivenessFakeCodexController,
         drain: AgentModeViewModel.CodexAgentRunWaitDrain? = nil,
@@ -3315,7 +3369,7 @@ private final class LivenessSnapshotReadGate: @unchecked Sendable {
     }
 }
 
-private final class LivenessFakeCodexController: CodexSessionControlling {
+private final class LivenessFakeCodexController: CodexSessionControllerTurnDispatchTestDefaults {
     private var readSnapshotCount = 0
     private var readSnapshotIncludeTurnsValues: [Bool] = []
     private var startOrResumeCount = 0
@@ -3571,6 +3625,7 @@ private final class LivenessFakeCodexController: CodexSessionControlling {
     }
 
     func compactThread() async throws {}
+
     func getThreadGoal() async throws -> CodexNativeSessionController.ThreadGoal? {
         nil
     }

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexAppServerClientProcessExitTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexAppServerClientProcessExitTests.swift
@@ -439,6 +439,176 @@ final class CodexAppServerClientProcessExitTests: XCTestCase {
         await client.stop()
     }
 
+    func testSettlementDeadlineRetiresOwningGenerationBeforeFreshReconnect() async throws {
+        let directory = try makeTemporaryDirectory()
+        let recordURL = directory.appendingPathComponent("requests.jsonl")
+        let executable = try makePersistentServer(
+            in: directory,
+            recordURL: recordURL,
+            ignoredMethods: ["config/batchWrite"]
+        )
+        let client = try await makeClient(executable: executable, launchDirectory: directory, timeout: 5)
+        addTeardownBlock { await client.stop() }
+        try await client.startIfNeeded()
+        let retiredGeneration = await client.debugTransportGeneration()
+        let retiredPIDValue = await client.debugProcessID()
+        let retiredPID = try XCTUnwrap(retiredPIDValue)
+        let deadlineGeneration = SettlementDeadlineGenerationRecorder()
+
+        do {
+            _ = try await client.requestWithSettlementDeadline(
+                method: "config/batchWrite",
+                params: ["edits": []],
+                deadline: 0.05,
+                onUnsettled: { generation in deadlineGeneration.record(generation) }
+            )
+            XCTFail("The ignored mutation must reach its settlement deadline")
+        } catch let CodexAppServerClient.ClientError.requestFailed(failure) {
+            XCTAssertTrue(failure.message.contains("timed out"))
+        } catch {
+            XCTFail("Settlement deadline was relabeled as \(error)")
+        }
+
+        XCTAssertEqual(deadlineGeneration.value, retiredGeneration)
+        let processIsRunning = await client.debugIsProcessRunning()
+        let processIDAfterSettlement = await client.debugProcessID()
+        let terminationReason = await client.debugLastTransportTerminationReason()
+        XCTAssertFalse(processIsRunning)
+        XCTAssertNil(processIDAfterSettlement)
+        XCTAssertEqual(
+            terminationReason,
+            .settlementDeadline(method: "config/batchWrite", generation: retiredGeneration)
+        )
+        var status: Int32 = 0
+        errno = 0
+        XCTAssertEqual(waitpid(retiredPID, &status, WNOHANG), -1)
+        XCTAssertEqual(errno, ECHILD)
+
+        try await client.startIfNeeded()
+        let replacementGeneration = await client.debugTransportGeneration()
+        XCTAssertGreaterThan(replacementGeneration, retiredGeneration)
+        _ = try await client.request(method: "hooks/list", params: ["cwds": [directory.path]], timeout: 1)
+        try await waitForRecordedMethod("hooks/list", at: recordURL)
+    }
+
+    func testSettlementDeadlineReportsCapturedGenerationAfterConcurrentTerminationClaim() async throws {
+        let timeoutDeliveryGate = OneShotAsyncHookGate()
+        let deadlineGeneration = SettlementDeadlineGenerationRecorder()
+        let client = CodexAppServerClient(
+            writeFrameHandler: { _, _ in },
+            livenessProbe: { _ in true },
+            faultInjection: .init(
+                requestTimeoutDelivery: { _, _ in
+                    await timeoutDeliveryGate.holdFirstInvocation()
+                }
+            )
+        )
+        addTeardownBlock { await client.stop() }
+        await client.debugInstallTestTransport()
+        let capturedGeneration = await client.debugTransportGeneration()
+
+        let requestTask = Task {
+            try await client.requestWithSettlementDeadline(
+                method: "config/batchWrite",
+                params: ["edits": []],
+                deadline: 0.01,
+                onUnsettled: { generation in deadlineGeneration.record(generation) }
+            )
+        }
+        try await waitUntil("timeout request removal", timeout: 2) {
+            await timeoutDeliveryGate.hasEntered
+        }
+
+        await client.debugBeginTransportFailure()
+        try await waitUntil("concurrent transport termination", timeout: 2) {
+            await !(client.debugIsProcessRunning())
+        }
+        await timeoutDeliveryGate.release()
+
+        do {
+            _ = try await requestTask.value
+            XCTFail("The mutation must preserve its timeout failure")
+        } catch let CodexAppServerClient.ClientError.requestFailed(failure) {
+            XCTAssertTrue(failure.message.contains("timed out"))
+        } catch {
+            XCTFail("Timeout was relabeled as \(error)")
+        }
+        XCTAssertEqual(deadlineGeneration.value, capturedGeneration)
+    }
+
+    func testSubscriptionCreationRejectsTransportDeathAfterStartupCompletion() async throws {
+        let subscriptionGate = OneShotAsyncHookGate()
+        let client = CodexAppServerClient(
+            livenessProbe: { _ in true },
+            faultInjection: .init(
+                subscriptionPreparation: {
+                    await subscriptionGate.holdFirstInvocation()
+                }
+            )
+        )
+        addTeardownBlock { await client.stop() }
+        await client.debugInstallTestTransport()
+        let retiredGeneration = await client.debugTransportGeneration()
+
+        let subscriptionTask = Task {
+            try await client.subscribeNotificationsWithTransportGeneration()
+        }
+        try await waitUntil("subscription preparation", timeout: 2) {
+            await subscriptionGate.hasEntered
+        }
+        await client.debugBeginTransportFailure()
+        try await waitUntil("transport death before subscription installation", timeout: 2) {
+            await !(client.debugIsProcessRunning())
+        }
+        await subscriptionGate.release()
+
+        do {
+            _ = try await subscriptionTask.value
+            XCTFail("A subscription must not be created without a healthy transport")
+        } catch CodexAppServerClient.ClientError.processNotRunning {
+            // Expected: the retired generation cannot acquire a subscription slot.
+        } catch {
+            XCTFail("Unexpected subscription error: \(error)")
+        }
+
+        await client.debugInstallTestTransport()
+        let replacementGeneration = await client.debugTransportGeneration()
+        let replacement = try await client.subscribeNotificationsWithTransportGeneration()
+        XCTAssertGreaterThan(replacementGeneration, retiredGeneration)
+        XCTAssertEqual(replacement.transportGeneration, replacementGeneration)
+    }
+
+    func testRecoveryInitializationUsesExplicitDeadlineAndReapsTimedOutGeneration() async throws {
+        let directory = try makeTemporaryDirectory()
+        let recordURL = directory.appendingPathComponent("requests.jsonl")
+        let executable = try makePersistentServer(
+            in: directory,
+            recordURL: recordURL,
+            ignoredMethods: ["initialize"]
+        )
+        let client = try await makeClient(
+            executable: executable,
+            launchDirectory: directory,
+            timeout: 60
+        )
+        addTeardownBlock { await client.stop() }
+
+        do {
+            try await client.startIfNeeded(initializationTimeout: 0.05)
+            XCTFail("Ignored recovery initialize must reach its explicit deadline")
+        } catch let CodexAppServerClient.ClientError.requestFailed(failure) {
+            XCTAssertTrue(failure.message.contains("timed out"))
+        } catch {
+            XCTFail("Recovery initialize timeout was relabeled as \(error)")
+        }
+
+        await client.stop()
+        let processIsRunning = await client.debugIsProcessRunning()
+        let processID = await client.debugProcessID()
+        XCTAssertFalse(processIsRunning)
+        XCTAssertNil(processID)
+    }
+
     func testStaleObservedExitCannotMutateReplacementGeneration() async throws {
         let directory = try makeTemporaryDirectory()
         let recordURL = directory.appendingPathComponent("requests.jsonl")
@@ -1028,6 +1198,46 @@ private actor CompletionFlag {
 
     func markComplete() {
         isComplete = true
+    }
+}
+
+private final class SettlementDeadlineGenerationRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var generation: UInt64?
+
+    func record(_ generation: UInt64) {
+        lock.lock()
+        self.generation = generation
+        lock.unlock()
+    }
+
+    var value: UInt64? {
+        lock.lock()
+        defer { lock.unlock() }
+        return generation
+    }
+}
+
+private actor OneShotAsyncHookGate {
+    private var didEnter = false
+    private var isReleased = false
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    var hasEntered: Bool {
+        didEnter
+    }
+
+    func holdFirstInvocation() async {
+        guard !didEnter else { return }
+        didEnter = true
+        guard !isReleased else { return }
+        await withCheckedContinuation { continuation = $0 }
+    }
+
+    func release() {
+        isReleased = true
+        continuation?.resume()
+        continuation = nil
     }
 }
 

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexAppServerClientProcessExitTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexAppServerClientProcessExitTests.swift
@@ -439,6 +439,82 @@ final class CodexAppServerClientProcessExitTests: XCTestCase {
         await client.stop()
     }
 
+    func testStoppedControllerPreflightReleasesGlobalTrustMutexAndRetrySucceeds() async throws {
+        let directory = try makeTemporaryDirectory()
+        let recordURL = directory.appendingPathComponent("requests.jsonl")
+        let executable = try makeHookTrustServer(in: directory, recordURL: recordURL)
+        let firstClient = try await makeClient(executable: executable, launchDirectory: directory, timeout: 5)
+        let secondClient = try await makeClient(executable: executable, launchDirectory: directory, timeout: 5)
+        addTeardownBlock {
+            await firstClient.stop()
+            await secondClient.stop()
+        }
+        try await firstClient.startIfNeeded()
+        try await secondClient.startIfNeeded()
+
+        var options = CodexNativeSessionController.Options.agentModeDefault()
+        options.requestTimeout = 0.1
+        let firstController = CodexNativeSessionController(
+            client: firstClient,
+            runID: UUID(),
+            tabID: UUID(),
+            windowID: 1,
+            workspacePaths: .uniform(directory.path),
+            options: options
+        )
+        let secondController = CodexNativeSessionController(
+            client: secondClient,
+            runID: UUID(),
+            tabID: UUID(),
+            windowID: 1,
+            workspacePaths: .uniform(directory.path),
+            options: options
+        )
+        addTeardownBlock {
+            await firstController.shutdown()
+            await secondController.shutdown()
+        }
+        try await firstController.test_beginBindingSession()
+        try await secondController.test_beginBindingSession()
+        await firstController.test_ensureInboundStreamsStarted()
+        await secondController.test_ensureInboundStreamsStarted()
+        let firstDisplayed = try await firstController.listHooksForCurrentWorkspace()
+        let secondDisplayed = try await secondController.listHooksForCurrentWorkspace()
+        let candidate = CodexHookTrustCandidate(key: "hook-key", currentHash: "hook-hash")
+
+        let firstProcessIDValue = await firstClient.debugProcessID()
+        let firstProcessID = try XCTUnwrap(firstProcessIDValue)
+        XCTAssertEqual(Darwin.kill(firstProcessID, SIGSTOP), 0)
+        addTeardownBlock { _ = Darwin.kill(firstProcessID, SIGCONT) }
+
+        let startedAt = ContinuousClock.now
+        do {
+            _ = try await firstController.trustHooksForCurrentWorkspace(
+                expectedCandidates: [candidate],
+                expectedInventoryFingerprint: firstDisplayed.fingerprint
+            )
+            XCTFail("Hook trust must fail closed when preflight cannot settle")
+        } catch CodexHookTrustError.malformedListResponse {
+            // Expected: the explicit preflight deadline fired while the child was stopped.
+        } catch {
+            XCTFail("Stopped-process hook preflight was relabeled as \(error)")
+        }
+        XCTAssertLessThan(startedAt.duration(to: .now), .seconds(2))
+
+        let secondVerified = try await secondController.trustHooksForCurrentWorkspace(
+            expectedCandidates: [candidate],
+            expectedInventoryFingerprint: secondDisplayed.fingerprint
+        )
+        XCTAssertTrue(secondVerified.verifies([candidate]))
+
+        XCTAssertEqual(Darwin.kill(firstProcessID, SIGCONT), 0)
+        let firstVerified = try await firstController.trustHooksForCurrentWorkspace(
+            expectedCandidates: [candidate],
+            expectedInventoryFingerprint: firstDisplayed.fingerprint
+        )
+        XCTAssertTrue(firstVerified.verifies([candidate]))
+    }
+
     func testSettlementDeadlineRetiresOwningGenerationBeforeFreshReconnect() async throws {
         let directory = try makeTemporaryDirectory()
         let recordURL = directory.appendingPathComponent("requests.jsonl")
@@ -987,6 +1063,46 @@ final class CodexAppServerClientProcessExitTests: XCTestCase {
         os.write(2, os.getcwd().encode("utf-8"))
         os.close(1)
         os._exit(41)
+        """
+        return try writeExecutable(script, to: executable)
+    }
+
+    private func makeHookTrustServer(in directory: URL, recordURL: URL) throws -> URL {
+        let executable = directory.appendingPathComponent("hook-trust-codex")
+        let script = """
+        #!/usr/bin/env python3
+        import json
+        import sys
+
+        record_path = \(String(reflecting: recordURL.path))
+        cwd = \(String(reflecting: directory.path))
+        trusted = False
+        for line in sys.stdin:
+            request = json.loads(line)
+            method = request.get("method")
+            with open(record_path, "a", encoding="utf-8") as handle:
+                handle.write(json.dumps({"method": method}) + "\\n")
+                handle.flush()
+            if "id" not in request:
+                continue
+            if method == "hooks/list":
+                hook = {
+                    "eventName": "preToolUse",
+                    "source": "project",
+                    "sourcePath": cwd + "/.codex/config.toml",
+                    "key": "hook-key",
+                    "currentHash": "hook-hash",
+                    "enabled": True,
+                    "trustStatus": "trusted" if trusted else "untrusted",
+                    "handlerType": "command",
+                }
+                result = {"data": [{"cwd": cwd, "hooks": [hook], "errors": [], "warnings": []}]}
+            elif method == "config/batchWrite":
+                trusted = True
+                result = {"status": "ok"}
+            else:
+                result = {}
+            print(json.dumps({"jsonrpc": "2.0", "id": request["id"], "result": result}), flush=True)
         """
         return try writeExecutable(script, to: executable)
     }

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexFallbackFIFOTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexFallbackFIFOTests.swift
@@ -295,6 +295,85 @@ final class CodexFallbackFIFOTests: XCTestCase {
         XCTAssertEqual(attachments, [image])
     }
 
+    func testFollowUpDuringInitialHookDiscoveryCoalescesGateAndPreservesRun() async throws {
+        let discoveryGate = FallbackAsyncGate()
+        let dispatchGate = FallbackAsyncGate()
+        let controller = try FallbackFIFOController(
+            snapshot: .idle,
+            activeTurnIDs: [],
+            steerResults: [
+                .failure(CodexTurnSteerError.noActiveTurn(
+                    requestFailure(message: "no active turn to steer")
+                ))
+            ],
+            startGate: dispatchGate,
+            hookInventory: fallbackHookInventory(),
+            hookListGate: discoveryGate
+        )
+        let (viewModel, session) = makeRunningSession(controller: controller)
+        let runID = session.runID
+        session.runState = .idle
+
+        let initialSend = Task {
+            await viewModel.test_codexCoordinator.sendCodexNativeMessage(
+                session: session,
+                text: "initial gated send",
+                attachments: []
+            )
+        }
+        guard await discoveryGate.waitUntilWaiting() else {
+            initialSend.cancel()
+            return XCTFail("Initial send did not enter hook discovery")
+        }
+
+        let followUp = await viewModel.test_codexCoordinator.sendCodexNativeMessage(
+            session: session,
+            text: "queued while discovery is active",
+            attachments: [],
+            fallbackContext: fallbackContext(
+                queueID: UUID(),
+                origin: .manual,
+                text: "queued while discovery is active"
+            )
+        )
+        guard case .queuedFallback = followUp else {
+            initialSend.cancel()
+            await discoveryGate.release()
+            return XCTFail("Expected queued follow-up, got \(followUp)")
+        }
+        try await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertEqual(controller.hookListCount, 1)
+
+        await discoveryGate.release()
+        let request = try await waitForHookRequest(session)
+        try await viewModel.test_codexCoordinator.resolveCodexHookReview(
+            session: session,
+            requestID: request.id,
+            decision: .continueWithoutHooks
+        )
+
+        guard await dispatchGate.waitUntilWaiting() else {
+            initialSend.cancel()
+            return XCTFail("Initial gated send did not reach turn/start")
+        }
+        try await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertEqual(controller.startedTexts, ["initial gated send"])
+        XCTAssertEqual(session.codexFallbackQueue.count, 1)
+
+        await dispatchGate.release()
+        let initialOutcome = await initialSend.value
+        XCTAssertEqual(initialOutcome, .sent)
+        try await waitUntil { controller.startCount == 2 }
+        XCTAssertTrue(session.codexFallbackQueue.isEmpty)
+        XCTAssertEqual(session.runID, runID)
+        XCTAssertEqual(controller.hookListCount, 1)
+        XCTAssertEqual(session.codexHookGateGeneration, 1)
+        XCTAssertEqual(
+            controller.startedTexts,
+            ["initial gated send", "queued while discovery is active"]
+        )
+    }
+
     func testTerminalSuccessorFallbackWaitsForHookReviewBeforeSuccessorClaim() async throws {
         let image = AgentImageAttachment(
             source: .localFile(path: "/tmp/successor-hook-gate.png"),
@@ -361,7 +440,7 @@ final class CodexFallbackFIFOTests: XCTestCase {
     }
 
     func testDurablyQueuedMCPFallbackInterruptsWaiterOnlyAfterQueueAck() async throws {
-        let steerGate = FallbackStartGate()
+        let steerGate = FallbackAsyncGate()
         let controller = FallbackFIFOController(
             snapshot: .idle,
             activeTurnIDs: [],
@@ -510,7 +589,7 @@ final class CodexFallbackFIFOTests: XCTestCase {
     }
 
     func testPublishedSuccessorClaimsHeadBeforeProviderStartReturns() async throws {
-        let startGate = FallbackStartGate()
+        let startGate = FallbackAsyncGate()
         let nonSteerable = CodexTurnSteerError.activeTurnNotSteerable(
             turnKind: "compact",
             failure: requestFailure(message: "cannot steer a compact turn")
@@ -558,7 +637,7 @@ final class CodexFallbackFIFOTests: XCTestCase {
     }
 
     func testManualFallbackQueuedDuringDispatchingRebindsToObservedSuccessor() async throws {
-        let startGate = FallbackStartGate()
+        let startGate = FallbackAsyncGate()
         let nonSteerable = CodexTurnSteerError.activeTurnNotSteerable(
             turnKind: "compact",
             failure: requestFailure(message: "cannot steer a compact turn")
@@ -604,7 +683,7 @@ final class CodexFallbackFIFOTests: XCTestCase {
     }
 
     func testMCPFallbackQueuedWhileAwaitingLifecycleStartRebindsAndDrains() async throws {
-        let startGate = FallbackStartGate()
+        let startGate = FallbackAsyncGate()
         let nonSteerable = CodexTurnSteerError.activeTurnNotSteerable(
             turnKind: "compact",
             failure: requestFailure(message: "cannot steer a compact turn")
@@ -1228,11 +1307,13 @@ private final class FallbackFIFOController: CodexSessionControlling {
     private let activeTurnIDs: [String]
     private var snapshotResults: [Result<CodexNativeSessionController.ThreadSnapshot, Error>]
     private var steerResults: [Result<CodexTurnSteerReceipt, Error>]
-    private let startGate: FallbackStartGate?
-    private let steerGate: FallbackStartGate?
+    private let startGate: FallbackAsyncGate?
+    private let steerGate: FallbackAsyncGate?
     private let hookInventory: CodexHookInventory?
+    private let hookListGate: FallbackAsyncGate?
 
     private(set) var steerTurnIDs: [String] = []
+    private(set) var startedTexts: [String] = []
     private(set) var startCount = 0
     private(set) var hookListCount = 0
     private(set) var hasActiveThread = true
@@ -1242,9 +1323,10 @@ private final class FallbackFIFOController: CodexSessionControlling {
         activeTurnIDs: [String] = ["turn"],
         snapshotResults: [Result<CodexNativeSessionController.ThreadSnapshot, Error>] = [],
         steerResults: [Result<CodexTurnSteerReceipt, Error>],
-        startGate: FallbackStartGate? = nil,
-        steerGate: FallbackStartGate? = nil,
-        hookInventory: CodexHookInventory? = nil
+        startGate: FallbackAsyncGate? = nil,
+        steerGate: FallbackAsyncGate? = nil,
+        hookInventory: CodexHookInventory? = nil,
+        hookListGate: FallbackAsyncGate? = nil
     ) {
         self.snapshot = snapshot
         self.activeTurnIDs = activeTurnIDs
@@ -1253,6 +1335,7 @@ private final class FallbackFIFOController: CodexSessionControlling {
         self.startGate = startGate
         self.steerGate = steerGate
         self.hookInventory = hookInventory
+        self.hookListGate = hookListGate
     }
 
     var events: AsyncStream<CodexNativeSessionController.Event> {
@@ -1324,12 +1407,13 @@ private final class FallbackFIFOController: CodexSessionControlling {
     }
 
     func startUserTurn(
-        text _: String,
+        text: String,
         images _: [AgentImageAttachment],
         model _: String?,
         reasoningEffort _: String?,
         serviceTier _: String?
     ) async throws -> CodexTurnStartReceipt {
+        startedTexts.append(text)
         startCount += 1
         await startGate?.wait()
         return .init(provisionalSubmissionID: "submission-\(startCount)")
@@ -1356,6 +1440,7 @@ private final class FallbackFIFOController: CodexSessionControlling {
 
     func listHooksForCurrentWorkspace() async throws -> CodexHookInventory {
         hookListCount += 1
+        await hookListGate?.wait()
         if let hookInventory {
             return hookInventory
         }
@@ -1431,7 +1516,7 @@ private final class MismatchRetryNativeControllerRecorder: @unchecked Sendable {
     }
 }
 
-private actor FallbackStartGate {
+private actor FallbackAsyncGate {
     private var continuation: CheckedContinuation<Void, Never>?
     private var released = false
     private var waiting = false

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexFallbackFIFOTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexFallbackFIFOTests.swift
@@ -229,6 +229,137 @@ final class CodexFallbackFIFOTests: XCTestCase {
         XCTAssertNil(session.codexAuthoritativeActiveTurn)
     }
 
+    func testIdlePumpFallbackWaitsForHookReviewBeforeClaimingHeadOrAttachments() async throws {
+        let image = AgentImageAttachment(
+            source: .localFile(path: "/tmp/idle-hook-gate.png"),
+            title: "idle-hook-gate.png"
+        )
+        let reservationID = UUID()
+        let controller = try FallbackFIFOController(
+            snapshot: .idle,
+            activeTurnIDs: [],
+            steerResults: [
+                .failure(CodexTurnSteerError.noActiveTurn(
+                    requestFailure(message: "no active turn to steer")
+                ))
+            ],
+            hookInventory: fallbackHookInventory()
+        )
+        let (viewModel, session) = makeRunningSession(controller: controller)
+        let originalAttemptID = session.activeRunAttemptID
+        session.attachmentTurnState = .reserved(
+            reservationID: reservationID,
+            attachments: [image]
+        )
+        let context = fallbackContext(
+            queueID: UUID(),
+            origin: .manual,
+            text: "idle gated fallback",
+            images: [image]
+        )
+
+        let outcome = await viewModel.test_codexCoordinator.sendCodexNativeMessage(
+            session: session,
+            text: context.providerText,
+            attachments: [image],
+            fallbackContext: context,
+            attachmentReservationID: reservationID
+        )
+        guard case .queuedFallback = outcome else {
+            return XCTFail("Expected queued fallback, got \(outcome)")
+        }
+        let request = try await waitForHookRequest(session)
+
+        XCTAssertEqual(controller.hookListCount, 1)
+        XCTAssertEqual(controller.startCount, 0)
+        XCTAssertEqual(session.codexFallbackQueue.first?.state, .queued)
+        XCTAssertNil(session.codexFallbackDispatchInFlight)
+        XCTAssertEqual(session.activeRunAttemptID, originalAttemptID)
+        guard case .idle = session.attachmentTurnState else {
+            return XCTFail("Fallback attachments must remain detached while review is suspended")
+        }
+
+        try await viewModel.test_codexCoordinator.resolveCodexHookReview(
+            session: session,
+            requestID: request.id,
+            decision: .continueWithoutHooks
+        )
+        try await waitUntil { controller.startCount == 1 }
+        XCTAssertTrue(session.codexFallbackQueue.isEmpty)
+        XCTAssertNotNil(session.codexFallbackDispatchInFlight)
+        XCTAssertEqual(session.activeRunAttemptID, originalAttemptID)
+        guard case let .consumed(storedID, attachments) = session.attachmentTurnState else {
+            return XCTFail("Claimed idle fallback must consume its attachment reservation")
+        }
+        XCTAssertEqual(storedID, reservationID)
+        XCTAssertEqual(attachments, [image])
+    }
+
+    func testTerminalSuccessorFallbackWaitsForHookReviewBeforeSuccessorClaim() async throws {
+        let image = AgentImageAttachment(
+            source: .localFile(path: "/tmp/successor-hook-gate.png"),
+            title: "successor-hook-gate.png"
+        )
+        let reservationID = UUID()
+        let nonSteerable = CodexTurnSteerError.activeTurnNotSteerable(
+            turnKind: "compact",
+            failure: requestFailure(message: "cannot steer a compact turn")
+        )
+        let controller = try FallbackFIFOController(
+            steerResults: [.failure(nonSteerable)],
+            hookInventory: fallbackHookInventory()
+        )
+        let (viewModel, session) = makeRunningSession(controller: controller)
+        let originalAttemptID = session.activeRunAttemptID
+        session.attachmentTurnState = .reserved(
+            reservationID: reservationID,
+            attachments: [image]
+        )
+        let context = fallbackContext(
+            queueID: UUID(),
+            origin: .manual,
+            text: "successor gated fallback",
+            images: [image]
+        )
+
+        _ = await viewModel.test_codexCoordinator.sendCodexNativeMessage(
+            session: session,
+            text: context.providerText,
+            attachments: [image],
+            fallbackContext: context,
+            attachmentReservationID: reservationID
+        )
+        let completion = Task {
+            await viewModel.test_codexCoordinator.test_handleCodexNativeEvent(
+                .turnCompleted(turnID: "turn", status: .completed),
+                session: session
+            )
+        }
+        let request = try await waitForHookRequest(session)
+
+        XCTAssertEqual(controller.hookListCount, 1)
+        XCTAssertEqual(controller.startCount, 0)
+        XCTAssertEqual(session.codexFallbackQueue.first?.state, .queued)
+        XCTAssertNil(session.codexFallbackDispatchInFlight)
+        XCTAssertEqual(session.activeRunAttemptID, originalAttemptID)
+        guard case .idle = session.attachmentTurnState else {
+            return XCTFail("Successor attachments must remain detached while review is suspended")
+        }
+
+        try await viewModel.test_codexCoordinator.resolveCodexHookReview(
+            session: session,
+            requestID: request.id,
+            decision: .continueWithoutHooks
+        )
+        await completion.value
+        try await waitUntil { controller.startCount == 1 }
+        XCTAssertTrue(session.codexFallbackQueue.isEmpty)
+        let inFlight = try XCTUnwrap(session.codexFallbackDispatchInFlight)
+        XCTAssertNotEqual(session.activeRunAttemptID, originalAttemptID)
+        XCTAssertEqual(inFlight.attachmentReservationID, reservationID)
+        XCTAssertEqual(inFlight.images, [image])
+    }
+
     func testDurablyQueuedMCPFallbackInterruptsWaiterOnlyAfterQueueAck() async throws {
         let steerGate = FallbackStartGate()
         let controller = FallbackFIFOController(
@@ -981,12 +1112,13 @@ final class CodexFallbackFIFOTests: XCTestCase {
     private func fallbackContext(
         queueID: UUID,
         origin: AgentModeViewModel.TabSession.CodexFallbackOrigin,
-        text: String
+        text: String,
+        images: [AgentImageAttachment] = []
     ) -> AgentModeViewModel.TabSession.CodexFallbackSubmissionContext {
         .init(
             queueID: queueID,
             providerText: text,
-            images: [],
+            images: images,
             taggedFileAttachments: [],
             draftText: text,
             optimisticUserItemID: nil,
@@ -1048,6 +1180,36 @@ final class CodexFallbackFIFOTests: XCTestCase {
         XCTAssertEqual(wake.snapshot.sessionID, sessionID, file: file, line: line)
     }
 
+    private func fallbackHookInventory() throws -> CodexHookInventory {
+        try CodexHookInventory(
+            executionCWD: "/repo",
+            hooks: [
+                CodexHookMetadata(
+                    eventName: "PreToolUse",
+                    source: "project",
+                    sourcePath: "/repo/.codex/config.toml",
+                    key: "fallback-hook",
+                    currentHash: "fallback-hash",
+                    enabled: true,
+                    handlerType: "command",
+                    trustStatus: .untrusted,
+                    commandOrHandler: "./hooks/fallback"
+                )
+            ]
+        )
+    }
+
+    private func waitForHookRequest(
+        _ session: AgentModeViewModel.TabSession,
+        timeout: TimeInterval = 2
+    ) async throws -> AgentCodexHookReviewRequest {
+        try await waitForPendingCodexHookReview(
+            in: session,
+            timeout: timeout,
+            diagnostic: "Timed out waiting for fallback hook review"
+        )
+    }
+
     private func waitUntil(
         timeout: TimeInterval = 2,
         _ predicate: @escaping () -> Bool
@@ -1068,9 +1230,11 @@ private final class FallbackFIFOController: CodexSessionControlling {
     private var steerResults: [Result<CodexTurnSteerReceipt, Error>]
     private let startGate: FallbackStartGate?
     private let steerGate: FallbackStartGate?
+    private let hookInventory: CodexHookInventory?
 
     private(set) var steerTurnIDs: [String] = []
     private(set) var startCount = 0
+    private(set) var hookListCount = 0
     private(set) var hasActiveThread = true
 
     init(
@@ -1079,7 +1243,8 @@ private final class FallbackFIFOController: CodexSessionControlling {
         snapshotResults: [Result<CodexNativeSessionController.ThreadSnapshot, Error>] = [],
         steerResults: [Result<CodexTurnSteerReceipt, Error>],
         startGate: FallbackStartGate? = nil,
-        steerGate: FallbackStartGate? = nil
+        steerGate: FallbackStartGate? = nil,
+        hookInventory: CodexHookInventory? = nil
     ) {
         self.snapshot = snapshot
         self.activeTurnIDs = activeTurnIDs
@@ -1087,6 +1252,7 @@ private final class FallbackFIFOController: CodexSessionControlling {
         self.steerResults = steerResults
         self.startGate = startGate
         self.steerGate = steerGate
+        self.hookInventory = hookInventory
     }
 
     var events: AsyncStream<CodexNativeSessionController.Event> {
@@ -1187,6 +1353,15 @@ private final class FallbackFIFOController: CodexSessionControlling {
     }
 
     func compactThread() async throws {}
+
+    func listHooksForCurrentWorkspace() async throws -> CodexHookInventory {
+        hookListCount += 1
+        if let hookInventory {
+            return hookInventory
+        }
+        return try CodexHookInventory(executionCWD: "/tmp", hooks: [])
+    }
+
     func getThreadGoal() async throws -> CodexNativeSessionController.ThreadGoal? {
         nil
     }

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexFallbackFIFOTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexFallbackFIFOTests.swift
@@ -229,6 +229,397 @@ final class CodexFallbackFIFOTests: XCTestCase {
         XCTAssertNil(session.codexAuthoritativeActiveTurn)
     }
 
+    func testIdlePumpDrainsQueueTailInOrderAfterHeadOpensItsOwnTurn() async throws {
+        let noActiveTurn = CodexTurnSteerError.noActiveTurn(
+            requestFailure(message: "no active turn to steer")
+        )
+        let controller = FallbackFIFOController(
+            snapshot: .idle,
+            activeTurnIDs: [],
+            steerResults: [.failure(noActiveTurn), .failure(noActiveTurn)]
+        )
+        let (viewModel, session) = makeRunningSession(controller: controller)
+
+        _ = await viewModel.test_codexCoordinator.sendCodexNativeMessage(
+            session: session,
+            text: "first",
+            attachments: []
+        )
+        _ = await viewModel.test_codexCoordinator.sendCodexNativeMessage(
+            session: session,
+            text: "second",
+            attachments: []
+        )
+        XCTAssertEqual(session.codexFallbackQueue.count, 2)
+
+        try await waitUntil { controller.startCount == 1 }
+        XCTAssertEqual(session.codexFallbackQueue.count, 1)
+        XCTAssertEqual(controller.startedTexts, ["first"])
+
+        await viewModel.test_codexCoordinator.test_handleCodexNativeEvent(
+            .turnStarted(turnID: "pumped-1"),
+            session: session
+        )
+        XCTAssertEqual(session.codexFallbackQueue.first?.blockingTurn?.turnID, "pumped-1")
+        XCTAssertEqual(controller.startCount, 1)
+
+        await viewModel.test_codexCoordinator.test_handleCodexNativeEvent(
+            .turnCompleted(turnID: "pumped-1", status: .completed),
+            session: session
+        )
+        try await waitUntil { controller.startCount == 2 }
+        XCTAssertTrue(session.codexFallbackQueue.isEmpty)
+        XCTAssertEqual(controller.startedTexts, ["first", "second"])
+    }
+
+    // MARK: - Owner-turn binding races
+
+    /// Sequences a hook-gate owner to accept its turn while the pump's thread read is already
+    /// in flight, so the pump resumes holding an idle answer that predates the binding.
+    private func makeOwnerBindingRaceSession(
+        startGate: FallbackAsyncGate? = nil,
+        snapshotGate: FallbackAsyncGate? = nil
+    ) -> (AgentModeViewModel, AgentModeViewModel.TabSession, FallbackFIFOController) {
+        let controller = FallbackFIFOController(
+            snapshot: .idle,
+            activeTurnIDs: [],
+            steerResults: [
+                .failure(CodexTurnSteerError.noActiveTurn(
+                    requestFailure(message: "no active turn to steer")
+                ))
+            ],
+            startGate: startGate,
+            snapshotGate: snapshotGate
+        )
+        let (viewModel, session) = makeRunningSession(controller: controller)
+        session.runState = .idle
+        return (viewModel, session, controller)
+    }
+
+    func testIdleSnapshotDeliveredAfterOwnerBindingDoesNotReleaseTheQueue() async throws {
+        let snapshotGate = FallbackAsyncGate()
+        let (viewModel, session, controller) = makeOwnerBindingRaceSession(snapshotGate: snapshotGate)
+        session.runState = .running
+
+        let queued = await viewModel.test_codexCoordinator.sendCodexNativeMessage(
+            session: session,
+            text: "queued behind the owner",
+            attachments: []
+        )
+        guard case .queuedFallback = queued else {
+            await snapshotGate.release()
+            return XCTFail("Expected queued follow-up, got \(queued)")
+        }
+        guard await snapshotGate.waitUntilWaiting() else {
+            return XCTFail("Idle pump did not reach the thread read")
+        }
+
+        // The read is now in flight against an unblocked head: the state the pump would
+        // otherwise act on when the answer arrives.
+        session.codexFallbackQueue[0].blockingTurn = nil
+        session.codexAuthoritativeActiveTurn = nil
+        session.runState = .idle
+
+        let ownerOutcome = await viewModel.test_codexCoordinator.sendCodexNativeMessage(
+            session: session,
+            text: "owner start",
+            attachments: []
+        )
+        XCTAssertEqual(ownerOutcome, .sent)
+        XCTAssertEqual(controller.startCount, 1)
+        let boundTurnID = session.codexFallbackQueue.first?.blockingTurn?.turnID
+        XCTAssertEqual(boundTurnID, "submission-1")
+        XCTAssertNotNil(session.codexFallbackHookGateOwnerBlocker)
+
+        await snapshotGate.release()
+        try await waitUntil { session.codexFallbackPumpTask == nil }
+
+        XCTAssertEqual(controller.startCount, 1)
+        XCTAssertEqual(controller.startedTexts, ["owner start"])
+        XCTAssertEqual(session.codexFallbackQueue.count, 1)
+        XCTAssertEqual(session.codexFallbackQueue.first?.blockingTurn?.turnID, "submission-1")
+        XCTAssertNil(session.codexFallbackDispatchInFlight)
+    }
+
+    func testOwnerLifecycleCompletingBeforeStartReceiptStillDrainsQueueInOrder() async throws {
+        let startGate = FallbackAsyncGate()
+        let (viewModel, session, controller) = makeOwnerBindingRaceSession(startGate: startGate)
+
+        let ownerSend = try await startGatedOwnerWithCoalescedFollowUp(
+            viewModel: viewModel,
+            session: session,
+            startGate: startGate
+        )
+
+        // Both lifecycle events land while the owner's turn/start call is still outstanding.
+        await viewModel.test_codexCoordinator.test_handleCodexNativeEvent(
+            .turnStarted(turnID: "owner-turn"),
+            session: session
+        )
+        XCTAssertEqual(session.codexFallbackQueue.first?.blockingTurn?.turnID, "owner-turn")
+        XCTAssertEqual(controller.startCount, 1)
+
+        // Successor release coalesces behind the very gate this owner still holds, so the
+        // completion is delivered now and settles once the outstanding call returns.
+        let completion = Task {
+            await viewModel.test_codexCoordinator.test_handleCodexNativeEvent(
+                .turnCompleted(turnID: "owner-turn", status: .completed),
+                session: session
+            )
+        }
+
+        await startGate.release()
+        let ownerOutcome = await ownerSend.value
+        XCTAssertEqual(ownerOutcome, .sent)
+        await completion.value
+        try await waitUntil { controller.startCount == 2 }
+        try await waitUntil { session.codexFallbackPumpTask == nil }
+        XCTAssertEqual(controller.startedTexts, ["owner start", "queued follow-up"])
+        XCTAssertTrue(session.codexFallbackQueue.isEmpty)
+        XCTAssertNil(session.codexFallbackHookGateOwnerBlocker)
+    }
+
+    func testAnonymousOwnerTurnTerminalRestoresBoundFollowUps() async throws {
+        let startGate = FallbackAsyncGate()
+        let (viewModel, session, controller) = makeOwnerBindingRaceSession(startGate: startGate)
+
+        let ownerSend = try await startGatedOwnerWithCoalescedFollowUp(
+            viewModel: viewModel,
+            session: session,
+            startGate: startGate
+        )
+
+        try await settleGatedOwnerReceipt(
+            viewModel: viewModel,
+            session: session,
+            controller: controller,
+            startGate: startGate,
+            ownerSend: ownerSend
+        )
+
+        // A nil-ID lifecycle can never be matched by successor release, so the follow-up has
+        // to come back rather than wait on a turn that is already gone.
+        await viewModel.test_codexCoordinator.test_handleCodexNativeEvent(
+            .turnStarted(turnID: nil),
+            session: session
+        )
+        XCTAssertEqual(session.codexFallbackQueue.first?.blockingTurn?.turnID, "submission-1")
+        await viewModel.test_codexCoordinator.test_handleCodexNativeEvent(
+            .turnCompleted(turnID: nil, status: .completed),
+            session: session
+        )
+
+        XCTAssertTrue(session.codexFallbackQueue.isEmpty)
+        XCTAssertNil(session.codexFallbackHookGateOwnerBlocker)
+        XCTAssertNil(session.codexFallbackDispatchInFlight)
+        XCTAssertEqual(controller.startCount, 1)
+        XCTAssertEqual(controller.startedTexts, ["owner start"])
+        let restoration = try XCTUnwrap(viewModel.draftRestorationEvent)
+        XCTAssertEqual(restoration.text, "queued follow-up")
+    }
+
+    func testAnonymousOwnerTurnInterruptedAbandonsBoundFollowUps() async throws {
+        let startGate = FallbackAsyncGate()
+        let (viewModel, session, controller) = makeOwnerBindingRaceSession(startGate: startGate)
+
+        let ownerSend = try await startGatedOwnerWithCoalescedFollowUp(
+            viewModel: viewModel,
+            session: session,
+            startGate: startGate
+        )
+
+        try await settleGatedOwnerReceipt(
+            viewModel: viewModel,
+            session: session,
+            controller: controller,
+            startGate: startGate,
+            ownerSend: ownerSend
+        )
+
+        await viewModel.test_codexCoordinator.test_handleCodexNativeEvent(
+            .turnStarted(turnID: nil),
+            session: session
+        )
+        await viewModel.test_codexCoordinator.test_handleCodexNativeEvent(
+            .turnCompleted(turnID: nil, status: .interrupted),
+            session: session
+        )
+
+        XCTAssertTrue(session.codexFallbackQueue.isEmpty)
+        XCTAssertNil(session.codexFallbackHookGateOwnerBlocker)
+        XCTAssertEqual(controller.startCount, 1)
+        let restoration = try XCTUnwrap(viewModel.draftRestorationEvent)
+        XCTAssertEqual(restoration.tabID, session.tabID)
+        XCTAssertEqual(restoration.text, "queued follow-up")
+    }
+
+    func testControllerReplacementDuringStartRPCDropsTheOwnerBinding() async throws {
+        let startGate = FallbackAsyncGate()
+        let (viewModel, session, controller) = makeOwnerBindingRaceSession(startGate: startGate)
+
+        let ownerSend = try await startGatedOwnerWithCoalescedFollowUp(
+            viewModel: viewModel,
+            session: session,
+            startGate: startGate
+        )
+
+        // The controller is retired while the request is still outstanding. Its queue is
+        // pinned to that instance, so it can never be claimed again under any later lineage.
+        viewModel.test_codexCoordinator.test_retireCodexControllerInstance(session: session)
+
+        await startGate.release()
+        _ = await ownerSend.value
+
+        try assertFollowUpReturnedToComposer(
+            viewModel: viewModel,
+            session: session,
+            controller: controller
+        )
+        XCTAssertEqual(controller.startCount, 1)
+    }
+
+    /// Drives an owner to the point where it holds the hook gate inside `turn/start` with a
+    /// coalesced, unblocked follow-up behind it — the window where the owner has no blocker
+    /// yet and the queue has nothing to wait on but the gate.
+    private func startGatedOwnerWithCoalescedFollowUp(
+        viewModel: AgentModeViewModel,
+        session: AgentModeViewModel.TabSession,
+        startGate: FallbackAsyncGate
+    ) async throws -> Task<CodexAgentModeCoordinator.NativeSendOutcome, Never> {
+        let ownerSend = Task {
+            await viewModel.test_codexCoordinator.sendCodexNativeMessage(
+                session: session,
+                text: "owner start",
+                attachments: []
+            )
+        }
+        guard await startGate.waitUntilWaiting() else {
+            ownerSend.cancel()
+            XCTFail("Owner send did not reach turn/start")
+            return ownerSend
+        }
+        let queued = await viewModel.test_codexCoordinator.sendCodexNativeMessage(
+            session: session,
+            text: "queued follow-up",
+            attachments: []
+        )
+        guard case .queuedFallback = queued else {
+            ownerSend.cancel()
+            await startGate.release()
+            XCTFail("Expected queued follow-up, got \(queued)")
+            return ownerSend
+        }
+        // The pump clears the finished fixture turn and then coalesces behind the owner's gate.
+        try await waitUntil { session.codexFallbackQueue.first?.blockingTurn == nil }
+        return ownerSend
+    }
+
+    /// Lets the gated owner's `turn/start` return, which binds the queue to the receipt and
+    /// releases the coalesced waiter. Returns once that waiter has run its claim and been
+    /// refused, so a scenario can deliver lifecycle events against a settled arrangement.
+    private func settleGatedOwnerReceipt(
+        viewModel: AgentModeViewModel,
+        session: AgentModeViewModel.TabSession,
+        controller: FallbackFIFOController,
+        startGate: FallbackAsyncGate,
+        ownerSend: Task<CodexAgentModeCoordinator.NativeSendOutcome, Never>
+    ) async throws {
+        await startGate.release()
+        let ownerOutcome = await ownerSend.value
+        XCTAssertEqual(ownerOutcome, .sent)
+        try await waitUntil { session.codexFallbackPumpTask == nil }
+        XCTAssertEqual(controller.startCount, 1)
+        XCTAssertEqual(session.codexFallbackQueue.first?.blockingTurn?.turnID, "submission-1")
+    }
+
+    private func assertFollowUpReturnedToComposer(
+        viewModel: AgentModeViewModel,
+        session: AgentModeViewModel.TabSession,
+        controller: FallbackFIFOController,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws {
+        XCTAssertTrue(session.codexFallbackQueue.isEmpty, file: file, line: line)
+        XCTAssertNil(session.codexFallbackDispatchInFlight, file: file, line: line)
+        XCTAssertNil(session.codexFallbackHookGateOwnerBlocker, file: file, line: line)
+        XCTAssertEqual(controller.startedTexts, ["owner start"], file: file, line: line)
+        let restoration = try XCTUnwrap(viewModel.draftRestorationEvent, file: file, line: line)
+        XCTAssertEqual(restoration.tabID, session.tabID, file: file, line: line)
+        XCTAssertEqual(restoration.text, "queued follow-up", file: file, line: line)
+    }
+
+    func testAnonymousOwnerLifecycleBeforeStartReceiptReturnsFollowUpToComposer() async throws {
+        let startGate = FallbackAsyncGate()
+        let (viewModel, session, controller) = makeOwnerBindingRaceSession(startGate: startGate)
+        let ownerSend = try await startGatedOwnerWithCoalescedFollowUp(
+            viewModel: viewModel,
+            session: session,
+            startGate: startGate
+        )
+
+        // Both nil-ID events land while the owner's turn/start is still outstanding, so no
+        // blocker exists yet and no identity will ever exist to release the queue.
+        await viewModel.test_codexCoordinator.test_handleCodexNativeEvent(
+            .turnStarted(turnID: nil),
+            session: session
+        )
+        await viewModel.test_codexCoordinator.test_handleCodexNativeEvent(
+            .turnCompleted(turnID: nil, status: .completed),
+            session: session
+        )
+        try assertFollowUpReturnedToComposer(
+            viewModel: viewModel,
+            session: session,
+            controller: controller
+        )
+
+        await startGate.release()
+        let ownerOutcome = await ownerSend.value
+        XCTAssertEqual(ownerOutcome, .sent)
+        try assertFollowUpReturnedToComposer(
+            viewModel: viewModel,
+            session: session,
+            controller: controller
+        )
+        XCTAssertEqual(controller.startCount, 1)
+    }
+
+    func testServerRequestIssueBeforeAuthoritativeStartReturnsFollowUpToComposer() async throws {
+        let startGate = FallbackAsyncGate()
+        let (viewModel, session, controller) = makeOwnerBindingRaceSession(startGate: startGate)
+        let ownerSend = try await startGatedOwnerWithCoalescedFollowUp(
+            viewModel: viewModel,
+            session: session,
+            startGate: startGate
+        )
+
+        // Terminalizes the run directly: no turnCompleted is ever correlated for this turn.
+        await viewModel.test_codexCoordinator.test_handleCodexNativeEvent(
+            .serverRequestIssue(.init(
+                requestID: .int(1),
+                method: "applyPatchApproval",
+                kind: .unsupportedMethod,
+                message: "server request issue"
+            )),
+            session: session
+        )
+        try assertFollowUpReturnedToComposer(
+            viewModel: viewModel,
+            session: session,
+            controller: controller
+        )
+
+        await startGate.release()
+        let ownerOutcome = await ownerSend.value
+        XCTAssertEqual(ownerOutcome, .sent)
+        try assertFollowUpReturnedToComposer(
+            viewModel: viewModel,
+            session: session,
+            controller: controller
+        )
+        XCTAssertEqual(controller.startCount, 1)
+    }
+
     func testIdlePumpFallbackWaitsForHookReviewBeforeClaimingHeadOrAttachments() async throws {
         let image = AgentImageAttachment(
             source: .localFile(path: "/tmp/idle-hook-gate.png"),
@@ -363,6 +754,35 @@ final class CodexFallbackFIFOTests: XCTestCase {
         await dispatchGate.release()
         let initialOutcome = await initialSend.value
         XCTAssertEqual(initialOutcome, .sent)
+
+        // The pump task only finishes once the resumed waiter has run its claim, so waiting
+        // on it proves the claim path executed and was refused rather than merely delayed.
+        try await waitUntil { session.codexFallbackPumpTask == nil }
+        XCTAssertEqual(controller.startCount, 1)
+        XCTAssertEqual(controller.startedTexts, ["initial gated send"])
+        XCTAssertNil(session.codexFallbackDispatchInFlight)
+        XCTAssertEqual(session.codexFallbackQueue.count, 1)
+        XCTAssertEqual(session.codexFallbackQueue.first?.state, .queued)
+        XCTAssertEqual(
+            session.codexFallbackQueue.first?.blockingTurn?.turnID,
+            "submission-1"
+        )
+
+        await viewModel.test_codexCoordinator.test_handleCodexNativeEvent(
+            .turnStarted(turnID: "initial-turn"),
+            session: session
+        )
+        XCTAssertEqual(session.codexAuthoritativeActiveTurn?.turnID, "initial-turn")
+        XCTAssertEqual(
+            session.codexFallbackQueue.first?.blockingTurn?.turnID,
+            "initial-turn"
+        )
+        XCTAssertEqual(controller.startCount, 1)
+
+        await viewModel.test_codexCoordinator.test_handleCodexNativeEvent(
+            .turnCompleted(turnID: "initial-turn", status: .completed),
+            session: session
+        )
         try await waitUntil { controller.startCount == 2 }
         XCTAssertTrue(session.codexFallbackQueue.isEmpty)
         XCTAssertEqual(session.runID, runID)
@@ -1309,6 +1729,7 @@ private final class FallbackFIFOController: CodexSessionControlling {
     private var steerResults: [Result<CodexTurnSteerReceipt, Error>]
     private let startGate: FallbackAsyncGate?
     private let steerGate: FallbackAsyncGate?
+    private let snapshotGate: FallbackAsyncGate?
     private let hookInventory: CodexHookInventory?
     private let hookListGate: FallbackAsyncGate?
 
@@ -1325,6 +1746,7 @@ private final class FallbackFIFOController: CodexSessionControlling {
         steerResults: [Result<CodexTurnSteerReceipt, Error>],
         startGate: FallbackAsyncGate? = nil,
         steerGate: FallbackAsyncGate? = nil,
+        snapshotGate: FallbackAsyncGate? = nil,
         hookInventory: CodexHookInventory? = nil,
         hookListGate: FallbackAsyncGate? = nil
     ) {
@@ -1334,6 +1756,7 @@ private final class FallbackFIFOController: CodexSessionControlling {
         self.steerResults = steerResults
         self.startGate = startGate
         self.steerGate = steerGate
+        self.snapshotGate = snapshotGate
         self.hookInventory = hookInventory
         self.hookListGate = hookListGate
     }
@@ -1391,6 +1814,9 @@ private final class FallbackFIFOController: CodexSessionControlling {
         includeTurns _: Bool,
         timeout _: TimeInterval?
     ) async throws -> CodexNativeSessionController.ThreadSnapshot {
+        // Held after the answer is determined, so the caller observes a read that was issued
+        // against one state and delivered against another.
+        await snapshotGate?.wait()
         if !snapshotResults.isEmpty {
             return try snapshotResults.removeFirst().get()
         }
@@ -1517,14 +1943,16 @@ private final class MismatchRetryNativeControllerRecorder: @unchecked Sendable {
 }
 
 private actor FallbackAsyncGate {
-    private var continuation: CheckedContinuation<Void, Never>?
+    // A gated call can be entered more than once concurrently — an owner turn and the queued
+    // follow-up released behind it both sit on the same gate — so every waiter is retained.
+    private var continuations: [CheckedContinuation<Void, Never>] = []
     private var released = false
     private var waiting = false
 
     func wait() async {
         guard !released else { return }
         waiting = true
-        await withCheckedContinuation { continuation = $0 }
+        await withCheckedContinuation { continuations.append($0) }
     }
 
     func waitUntilWaiting(timeout: TimeInterval = 5) async -> Bool {
@@ -1538,7 +1966,10 @@ private actor FallbackAsyncGate {
 
     func release() {
         released = true
-        continuation?.resume()
-        continuation = nil
+        let pending = continuations
+        continuations.removeAll()
+        for continuation in pending {
+            continuation.resume()
+        }
     }
 }

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexNativeSessionControllerHookApprovalTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexNativeSessionControllerHookApprovalTests.swift
@@ -46,7 +46,24 @@ final class CodexNativeSessionControllerHookApprovalTests: XCTestCase {
             ("handler-only duplicate conflict", listResult(cwd: "/tmp/repo", hooks: [
                 hook(key: "a", hash: "h", status: "untrusted", handlerType: "command"),
                 hook(key: "a", hash: "h", status: "untrusted", handlerType: "prompt")
-            ]))
+            ])),
+            ("partially decoded data", ["data": [listEntry(cwd: "/tmp/repo", hooks: []), "malformed"]]),
+            ("oversized hook collection", listResult(
+                cwd: "/tmp/repo",
+                hooks: Array(repeating: hook(key: "a", hash: "h", status: "untrusted"), count: 4097)
+            )),
+            ("oversized hook field", listResult(cwd: "/tmp/repo", hooks: [
+                hook(key: String(repeating: "x", count: 256 * 1024 + 1), hash: "h", status: "untrusted")
+            ])),
+            ("oversized empty inventory warnings", listResult(
+                cwd: "/tmp/repo",
+                hooks: [],
+                warnings: Array(repeating: String(repeating: "w", count: 4097), count: 1024)
+            )),
+            ("oversized raw cwd", listResult(
+                cwd: String(repeating: "c", count: 256 * 1024 + 1),
+                hooks: []
+            ))
         ]
 
         for (name, result) in cases {
@@ -363,26 +380,28 @@ final class CodexNativeSessionControllerHookApprovalTests: XCTestCase {
         let secondCallStarted = expectation(description: "second trust call started")
         let writeGate = HookApprovalAsyncGate()
         let firstRecorder = HookRequestRecorder(steps: [
-            .init(method: "hooks/list", result: listResult(cwd: "/tmp/repo", hooks: unresolved))
+            .init(method: "hooks/list", result: listResult(cwd: "/tmp/repo", hooks: unresolved)),
+            .init(method: "hooks/list", result: listResult(cwd: "/tmp/repo", hooks: trusted))
         ])
         let secondRecorder = HookRequestRecorder(steps: [
             .init(method: "hooks/list", result: listResult(cwd: "/tmp/repo", hooks: unresolved)),
             .init(method: "config/batchWrite", result: ["status": "ok"]),
             .init(method: "hooks/list", result: listResult(cwd: "/tmp/repo", hooks: trusted))
         ])
-        let firstController = makeController(cwd: "/tmp/repo", requestTimeout: 0.01) { method, params, timeout in
-            if method == "config/batchWrite" {
-                firstRecorder.record(method: method, params: params, timeout: timeout)
-                firstWriteStarted.fulfill()
-                if let timeout {
-                    Task { await writeGate.wait() }
-                    try await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
-                    throw NSError(domain: "simulated-client-timeout", code: 1)
+        let firstController = makeController(
+            cwd: "/tmp/repo",
+            requestTimeout: 0.01,
+            faultInjection: .init(
+                settlementRecoveryExecutor: { await writeGate.wait() },
+                mutationExecutor: { method, params, deadline in
+                    firstRecorder.record(method: method, params: params, timeout: deadline)
+                    firstWriteStarted.fulfill()
+                    try await Task.sleep(nanoseconds: UInt64(deadline * 1_000_000_000))
+                    return .unsettled
                 }
-                await writeGate.wait()
-                return ["status": "ok"]
-            }
-            return try firstRecorder.handle(method: method, params: params, timeout: timeout)
+            )
+        ) { method, params, timeout in
+            try firstRecorder.handle(method: method, params: params, timeout: timeout)
         }
         let secondController = makeController(cwd: "/tmp/repo", requestTimeout: 0.01, recorder: secondRecorder)
         let candidates = [CodexHookTrustCandidate(key: "one", currentHash: "h1")]
@@ -395,7 +414,7 @@ final class CodexNativeSessionControllerHookApprovalTests: XCTestCase {
         }
         await fulfillment(of: [firstWriteStarted], timeout: 2)
         try await Task.sleep(nanoseconds: 50_000_000)
-        XCTAssertNil(firstRecorder.requests().last?.timeout)
+        XCTAssertEqual(firstRecorder.requests().last?.timeout, 0.01)
         firstTask.cancel()
         let secondTask = Task {
             secondCallStarted.fulfill()
@@ -420,8 +439,267 @@ final class CodexNativeSessionControllerHookApprovalTests: XCTestCase {
             }
         }
         _ = try await secondTask.value
-        XCTAssertEqual(firstRecorder.requests().map(\.method), ["hooks/list", "config/batchWrite"])
+        XCTAssertEqual(firstRecorder.requests().map(\.method), ["hooks/list", "config/batchWrite", "hooks/list"])
         XCTAssertEqual(secondRecorder.requests().map(\.method), ["hooks/list", "config/batchWrite", "hooks/list"])
+    }
+
+    func testInjectedSettlementRecoveryBalancesRetiredGenerationAndScopesSuppression() async throws {
+        let unresolved = [hook(key: "one", hash: "h1", status: "untrusted")]
+        let trusted = [hook(key: "one", hash: "h1", status: "trusted")]
+        let displayed = try inventory(hooks: unresolved)
+        let recorder = HookRequestRecorder(steps: [
+            .init(method: "hooks/list", result: listResult(cwd: "/tmp/repo", hooks: unresolved)),
+            .init(method: "hooks/list", result: listResult(cwd: "/tmp/repo", hooks: trusted))
+        ])
+        let controller = makeController(
+            cwd: "/tmp/repo",
+            requestTimeout: 0.01,
+            faultInjection: .init(
+                settlementRecoveryExecutor: {},
+                mutationExecutor: { _, _, _ in .unsettled }
+            )
+        ) { method, params, timeout in
+            try recorder.handle(method: method, params: params, timeout: timeout)
+        }
+        controller.test_markHookTrustTransportRetiring(generation: 41)
+        XCTAssertTrue(controller.test_shouldSuppressHookTrustStreamEnd(transportGeneration: 41))
+        XCTAssertFalse(controller.test_shouldSuppressHookTrustStreamEnd(transportGeneration: 42))
+
+        _ = try await controller.trustHooksForCurrentWorkspace(
+            expectedCandidates: candidates(from: displayed),
+            expectedInventoryFingerprint: displayed.fingerprint
+        )
+
+        XCTAssertTrue(controller.test_shouldSuppressHookTrustStreamEnd(transportGeneration: 41))
+    }
+
+    func testRecoveryRelistUsesHardDeadlineAndReleasesGlobalTrustMutexOnExpiry() async throws {
+        let unresolved = [hook(key: "one", hash: "h1", status: "untrusted")]
+        let trusted = [hook(key: "one", hash: "h1", status: "trusted")]
+        let displayed = try inventory(hooks: unresolved)
+        let firstRecorder = HookRequestRecorder(steps: [
+            .init(method: "hooks/list", result: listResult(cwd: "/tmp/repo", hooks: unresolved)),
+            .init(method: "hooks/list", error: HookApprovalTestError.injectedFailure)
+        ])
+        let firstController = makeController(
+            cwd: "/tmp/repo",
+            requestTimeout: nil,
+            faultInjection: .init(
+                settlementRecoveryExecutor: {},
+                mutationExecutor: { method, params, deadline in
+                    firstRecorder.record(method: method, params: params, timeout: deadline)
+                    return .unsettled
+                }
+            )
+        ) { method, params, timeout in
+            try firstRecorder.handle(method: method, params: params, timeout: timeout)
+        }
+
+        await assertTrustFailure(
+            controller: firstController,
+            candidates: candidates(from: displayed),
+            fingerprint: displayed.fingerprint
+        ) { error in
+            guard case .postWriteVerificationFailed(latest: nil) = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+        XCTAssertEqual(firstRecorder.requests().map(\.timeout), [30, 30, 30])
+
+        let secondRecorder = HookRequestRecorder(steps: [
+            .init(method: "hooks/list", result: listResult(cwd: "/tmp/repo", hooks: unresolved)),
+            .init(method: "config/batchWrite", result: ["status": "ok"]),
+            .init(method: "hooks/list", result: listResult(cwd: "/tmp/repo", hooks: trusted))
+        ])
+        _ = try await makeController(cwd: "/tmp/repo", requestTimeout: nil, recorder: secondRecorder)
+            .trustHooksForCurrentWorkspace(
+                expectedCandidates: candidates(from: displayed),
+                expectedInventoryFingerprint: displayed.fingerprint
+            )
+        XCTAssertEqual(secondRecorder.requests().map(\.timeout), [30, 30, 30])
+    }
+
+    func testAmbiguousTransportFailureHoldsGlobalMutexUntilProcessCleanupSettles() async throws {
+        let unresolved = [hook(key: "one", hash: "h1", status: "untrusted")]
+        let trusted = [hook(key: "one", hash: "h1", status: "trusted")]
+        let displayed = try inventory(hooks: unresolved)
+        let cleanupStarted = expectation(description: "transport cleanup started")
+        let cleanupGate = HookApprovalAsyncGate()
+        let client = CodexAppServerClient(
+            writeFrameHandler: { _, _ in },
+            livenessProbe: { _ in true },
+            faultInjection: .init(
+                transportTerminationCleanup: {
+                    cleanupStarted.fulfill()
+                    await cleanupGate.wait()
+                }
+            )
+        )
+        await client.debugInstallTestTransport()
+        let firstRecorder = HookRequestRecorder(steps: [
+            .init(method: "hooks/list", result: listResult(cwd: "/tmp/repo", hooks: unresolved)),
+            .init(method: "hooks/list", result: listResult(cwd: "/tmp/repo", hooks: trusted)),
+            .init(method: "hooks/list", result: listResult(cwd: "/tmp/repo", hooks: trusted))
+        ])
+        let recoveryRan = expectation(description: "ambiguous mutation recovery ran")
+        let firstController = makeController(
+            client: client,
+            cwd: "/tmp/repo",
+            faultInjection: .init(
+                settlementRecoveryExecutor: { recoveryRan.fulfill() },
+                mutationExecutor: { method, params, deadline in
+                    do {
+                        return try await .response(
+                            client.requestWithSettlementDeadline(
+                                method: method,
+                                params: params,
+                                deadline: deadline
+                            )
+                        )
+                    } catch {
+                        guard CodexAppServerClient.isTimeoutError(error)
+                            || CodexAppServerClient.isAmbiguousMutationError(error)
+                        else {
+                            throw error
+                        }
+                        return .unsettled
+                    }
+                }
+            )
+        ) { method, params, timeout in
+            try firstRecorder.handle(method: method, params: params, timeout: timeout)
+        }
+        let secondRecorder = HookRequestRecorder(steps: [
+            .init(method: "hooks/list", result: listResult(cwd: "/tmp/repo", hooks: unresolved)),
+            .init(method: "config/batchWrite", result: ["status": "ok"]),
+            .init(method: "hooks/list", result: listResult(cwd: "/tmp/repo", hooks: trusted))
+        ])
+        let secondController = makeController(cwd: "/tmp/repo", recorder: secondRecorder)
+        let candidates = candidates(from: displayed)
+
+        let firstTask = Task {
+            try await firstController.trustHooksForCurrentWorkspace(
+                expectedCandidates: candidates,
+                expectedInventoryFingerprint: displayed.fingerprint
+            )
+        }
+        try await waitUntil("mutation request dispatch") {
+            await client.debugPendingRequestCount() == 1
+        }
+        await client.debugBeginTransportFailure()
+        await fulfillment(of: [cleanupStarted], timeout: 2)
+        let secondTask = Task {
+            try await secondController.trustHooksForCurrentWorkspace(
+                expectedCandidates: candidates,
+                expectedInventoryFingerprint: displayed.fingerprint
+            )
+        }
+        for _ in 0 ..< 50 {
+            await Task.yield()
+        }
+        XCTAssertTrue(secondRecorder.requests().isEmpty)
+
+        await cleanupGate.release()
+        _ = try await firstTask.value
+        await fulfillment(of: [recoveryRan], timeout: 2)
+        _ = try await firstController.listHooksForCurrentWorkspace()
+        _ = try await secondTask.value
+        XCTAssertEqual(firstRecorder.requests().map(\.method), ["hooks/list", "hooks/list", "hooks/list"])
+        XCTAssertEqual(secondRecorder.requests().map(\.method), ["hooks/list", "config/batchWrite", "hooks/list"])
+    }
+
+    func testAmbiguousBatchWriteRebuildsTransportBeforeOrdinaryControllerRequest() async throws {
+        let unresolved = [hook(key: "one", hash: "h1", status: "untrusted")]
+        let trusted = [hook(key: "one", hash: "h1", status: "trusted")]
+        let displayed = try inventory(hooks: unresolved)
+        let router = HookApprovalClientFrameRouter(hookListResults: [
+            listResult(cwd: "/tmp/repo", hooks: unresolved),
+            listResult(cwd: "/tmp/repo", hooks: trusted),
+            listResult(cwd: "/tmp/repo", hooks: trusted)
+        ])
+        let client = CodexAppServerClient(
+            writeFrameHandler: { _, frame in try router.handle(frame) },
+            livenessProbe: { _ in true }
+        )
+        router.attach(client)
+        await client.debugInstallTestTransport()
+        let retiredGeneration = await client.debugTransportGeneration()
+        var options = CodexNativeSessionController.Options.agentModeDefault()
+        options.requestTimeout = 120
+        let controller = CodexNativeSessionController(
+            client: client,
+            runID: UUID(),
+            tabID: UUID(),
+            windowID: 1,
+            workspacePaths: .uniform("/tmp/repo"),
+            options: options,
+            hookTrustFaultInjection: .init(
+                settlementRecoveryExecutor: { await client.debugInstallTestTransport() }
+            )
+        )
+        try await controller.test_beginBindingSession()
+
+        _ = try await controller.trustHooksForCurrentWorkspace(
+            expectedCandidates: candidates(from: displayed),
+            expectedInventoryFingerprint: displayed.fingerprint
+        )
+        let replacementGeneration = await client.debugTransportGeneration()
+        XCTAssertGreaterThan(replacementGeneration, retiredGeneration)
+
+        _ = try await controller.listHooksForCurrentWorkspace()
+        let installedGenerations = controller.test_inboundStreamTransportGenerations()
+        XCTAssertEqual(installedGenerations.notifications, replacementGeneration)
+        XCTAssertEqual(installedGenerations.serverRequests, replacementGeneration)
+        XCTAssertTrue(controller.test_shouldSuppressHookTrustStreamEnd(transportGeneration: retiredGeneration))
+        XCTAssertFalse(controller.test_shouldSuppressHookTrustStreamEnd(transportGeneration: replacementGeneration))
+        XCTAssertEqual(router.seenMethods, ["hooks/list", "config/batchWrite", "hooks/list", "hooks/list"])
+        await controller.shutdown()
+        await client.stop()
+    }
+
+    func testConcurrentInboundStreamStartupInstallsOneOwnedSubscriptionPerKind() async throws {
+        let client = CodexAppServerClient(livenessProbe: { _ in true })
+        await client.debugInstallTestTransport()
+        let controller = makeController(client: client, cwd: "/tmp/repo") { _, _, _ in [:] }
+        try await controller.test_beginBindingSession()
+
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0 ..< 16 {
+                group.addTask { await controller.test_ensureInboundStreamsStarted() }
+            }
+        }
+
+        let notificationSubscriberCount = await client.debugNotificationSubscriberCount()
+        let serverRequestSubscriberCount = await client.debugServerRequestSubscriberCount()
+        XCTAssertEqual(notificationSubscriberCount, 1)
+        XCTAssertEqual(serverRequestSubscriberCount, 1)
+        await controller.shutdown()
+        await client.stop()
+    }
+
+    func testInboundStreamStartupReplacesSlotsFromStaleTransportGeneration() async throws {
+        let client = CodexAppServerClient(livenessProbe: { _ in true })
+        await client.debugInstallTestTransport()
+        let controller = makeController(client: client, cwd: "/tmp/repo") { _, _, _ in [:] }
+        try await controller.test_beginBindingSession()
+        await controller.test_ensureInboundStreamsStarted()
+        let retiredGeneration = await client.debugTransportGeneration()
+
+        await client.debugInstallTestTransport()
+        let replacementGeneration = await client.debugTransportGeneration()
+        XCTAssertGreaterThan(replacementGeneration, retiredGeneration)
+        await controller.test_ensureInboundStreamsStarted()
+
+        let installedGenerations = controller.test_inboundStreamTransportGenerations()
+        XCTAssertEqual(installedGenerations.notifications, replacementGeneration)
+        XCTAssertEqual(installedGenerations.serverRequests, replacementGeneration)
+        try await waitUntil("stale inbound subscriptions to retire") {
+            let notificationCount = await client.debugNotificationSubscriberCount()
+            let serverRequestCount = await client.debugServerRequestSubscriberCount()
+            return notificationCount == 1 && serverRequestCount == 1
+        }
+        await controller.shutdown()
+        await client.stop()
     }
 
     func testHookOperationMutexSerializesOverlappingOperationsOnOneController() async throws {
@@ -603,6 +881,29 @@ final class CodexNativeSessionControllerHookApprovalTests: XCTestCase {
                 return XCTFail("Unexpected error: \(error)")
             }
             XCTAssertEqual(latest?.hooks, [])
+        }
+    }
+
+    func testTrustedNonProjectHookCannotSubstituteForMissingProjectHook() async throws {
+        let unresolved = [hook(key: "one", hash: "h1", status: "untrusted")]
+        let displayed = try inventory(hooks: unresolved)
+        let recorder = HookRequestRecorder(steps: [
+            .init(method: "hooks/list", result: listResult(cwd: "/tmp/repo", hooks: unresolved)),
+            .init(method: "config/batchWrite", result: ["status": "ok"]),
+            .init(method: "hooks/list", result: listResult(cwd: "/tmp/repo", hooks: [
+                hook(key: "one", hash: "h1", status: "trusted", source: "user")
+            ]))
+        ])
+
+        await assertTrustFailure(
+            controller: makeController(cwd: "/tmp/repo", recorder: recorder),
+            candidates: candidates(from: displayed),
+            fingerprint: displayed.fingerprint
+        ) { error in
+            guard case let .postWriteVerificationFailed(latest) = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertEqual(latest?.projectHooks, [])
         }
     }
 
@@ -885,31 +1186,48 @@ final class CodexNativeSessionControllerHookApprovalTests: XCTestCase {
         }
     }
 
+    private func waitUntil(
+        _ description: String,
+        timeout: TimeInterval = 2,
+        condition: () async -> Bool
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if await condition() { return }
+            try await Task.sleep(nanoseconds: 5_000_000)
+        }
+        XCTFail("Timed out waiting for \(description)")
+    }
+
     private func makeController(
+        client: CodexAppServerClient = CodexAppServerClient(),
         cwd: String?,
         requestTimeout: TimeInterval? = 120,
         recorder: HookRequestRecorder
     ) -> CodexNativeSessionController {
-        makeController(cwd: cwd, requestTimeout: requestTimeout) { method, params, timeout in
+        makeController(client: client, cwd: cwd, requestTimeout: requestTimeout) { method, params, timeout in
             try recorder.handle(method: method, params: params, timeout: timeout)
         }
     }
 
     private func makeController(
+        client: CodexAppServerClient = CodexAppServerClient(),
         cwd: String?,
         requestTimeout: TimeInterval? = 120,
+        faultInjection: CodexNativeSessionController.HookTrustFaultInjection = .init(),
         executor: @escaping @Sendable (String, [String: Any]?, TimeInterval?) async throws -> [String: Any]
     ) -> CodexNativeSessionController {
         var options = CodexNativeSessionController.Options.agentModeDefault()
         options.requestTimeout = requestTimeout
         return CodexNativeSessionController(
-            client: CodexAppServerClient(),
+            client: client,
             runID: UUID(),
             tabID: UUID(),
             windowID: 1,
             workspacePaths: .uniform(cwd),
             options: options,
-            requestExecutor: executor
+            requestExecutor: executor,
+            hookTrustFaultInjection: faultInjection
         )
     }
 
@@ -921,6 +1239,63 @@ final class CodexNativeSessionControllerHookApprovalTests: XCTestCase {
             return [:]
         }
         return values
+    }
+}
+
+private final class HookApprovalClientFrameRouter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var client: CodexAppServerClient?
+    private var hookListResults: [[String: Any]]
+    private var methods: [String] = []
+
+    init(hookListResults: [[String: Any]]) {
+        self.hookListResults = hookListResults
+    }
+
+    func attach(_ client: CodexAppServerClient) {
+        lock.withLock { self.client = client }
+    }
+
+    var seenMethods: [String] {
+        lock.withLock { methods }
+    }
+
+    func handle(_ frame: Data) throws {
+        guard let object = try JSONSerialization.jsonObject(with: frame) as? [String: Any],
+              let method = object["method"] as? String,
+              let requestID = object["id"]
+        else {
+            throw HookApprovalTestError.unexpectedRequest("invalid JSON-RPC frame")
+        }
+
+        let action = try lock.withLock { () -> (CodexAppServerClient, [String: Any]?) in
+            guard let client else {
+                throw HookApprovalTestError.unexpectedRequest("unattached client")
+            }
+            methods.append(method)
+            switch method {
+            case "hooks/list":
+                guard !hookListResults.isEmpty else {
+                    throw HookApprovalTestError.unexpectedRequest(method)
+                }
+                return (client, hookListResults.removeFirst())
+            case "config/batchWrite":
+                return (client, nil)
+            default:
+                throw HookApprovalTestError.unexpectedRequest(method)
+            }
+        }
+
+        if let result = action.1 {
+            let response = try JSONSerialization.data(withJSONObject: [
+                "jsonrpc": "2.0",
+                "id": requestID,
+                "result": result
+            ])
+            Task { await action.0.debugIngestRawStdoutLine(response) }
+        } else {
+            Task { await action.0.debugBeginTransportFailure() }
+        }
     }
 }
 
@@ -993,6 +1368,7 @@ private final class HookRequestRecorder: @unchecked Sendable {
 }
 
 private enum HookApprovalTestError: Error {
+    case injectedFailure
     case unexpectedRequest(String)
 }
 

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexNativeSessionControllerHookApprovalTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexNativeSessionControllerHookApprovalTests.swift
@@ -657,6 +657,127 @@ final class CodexNativeSessionControllerHookApprovalTests: XCTestCase {
         await client.stop()
     }
 
+    func testUnsettledMutationRecoveryRebindsThreadBeforeFirstTurn() async throws {
+        let fixture = try await makeHookTrustRebindFixture()
+
+        let verified = try await fixture.controller.trustHooksForCurrentWorkspace(
+            expectedCandidates: candidates(from: fixture.inventory),
+            expectedInventoryFingerprint: fixture.inventory.fingerprint
+        )
+        XCTAssertTrue(verified.verifies(candidates(from: fixture.inventory)))
+        XCTAssertEqual(fixture.controller.currentSessionReference?.conversationID, "replacement-thread")
+
+        let receipt = try await fixture.controller.startUserTurn(
+            text: "first turn after approval",
+            images: [],
+            model: "gpt-test",
+            reasoningEffort: "medium",
+            serviceTier: nil
+        )
+        XCTAssertEqual(receipt.provisionalSubmissionID, "replacement-turn")
+
+        let requestLog = try String(contentsOf: fixture.requestLogURL, encoding: .utf8)
+        let records = try requestLog.split(separator: "\n").map { line in
+            try XCTUnwrap(
+                JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any]
+            )
+        }
+        let replacementMethods = records.compactMap { record -> String? in
+            guard record["process"] as? Int == 2 else { return nil }
+            return record["method"] as? String
+        }
+        let resumeIndex = try XCTUnwrap(replacementMethods.firstIndex(of: "thread/resume"))
+        let startIndex = try XCTUnwrap(replacementMethods.firstIndex(of: "thread/start"))
+        XCTAssertLessThan(resumeIndex, startIndex)
+        let turnStart = try XCTUnwrap(records.first { record in
+            record["process"] as? Int == 2 && record["method"] as? String == "turn/start"
+        })
+        let turnParams = try XCTUnwrap(turnStart["params"] as? [String: Any])
+        XCTAssertEqual(turnParams["threadId"] as? String, "replacement-thread")
+    }
+
+    func testWrongRecoveryResumeIdentityDoesNotCommitAndRetryCanRecover() async throws {
+        let fixture = try await makeHookTrustRebindFixture(wrongResumeProcessNumber: 2)
+
+        do {
+            _ = try await fixture.controller.trustHooksForCurrentWorkspace(
+                expectedCandidates: candidates(from: fixture.inventory),
+                expectedInventoryFingerprint: fixture.inventory.fingerprint
+            )
+            XCTFail("Expected the mismatched recovery identity to fail closed")
+        } catch {}
+        XCTAssertEqual(fixture.controller.currentSessionReference, fixture.initialReference)
+
+        try FileManager.default.removeItem(at: fixture.trustedMarkerURL)
+        let verified = try await fixture.controller.trustHooksForCurrentWorkspace(
+            expectedCandidates: candidates(from: fixture.inventory),
+            expectedInventoryFingerprint: fixture.inventory.fingerprint
+        )
+        XCTAssertTrue(verified.verifies(candidates(from: fixture.inventory)))
+        XCTAssertEqual(fixture.controller.currentSessionReference?.conversationID, "replacement-thread")
+        let receipt = try await fixture.controller.startUserTurn(
+            text: "first turn after retry",
+            images: [],
+            model: "gpt-test",
+            reasoningEffort: "medium",
+            serviceTier: nil
+        )
+        XCTAssertEqual(receipt.provisionalSubmissionID, "replacement-turn")
+    }
+
+    func testRecoveryDeadlineBeforeThreadCommitPreservesIdentityAndRetryCanRecover() async throws {
+        let commitGate = HookApprovalAsyncGate()
+        let firstCommitClaim = HookApprovalFirstCallClaim()
+        let rebindPrepared = expectation(description: "replacement thread response prepared")
+        let rebindReleased = expectation(description: "losing rebind continued after deadline")
+        let fixture = try await makeHookTrustRebindFixture(
+            requestTimeout: 0.15,
+            faultInjection: .init(
+                threadRebindCommitPreparation: {
+                    guard await firstCommitClaim.claim() else { return }
+                    rebindPrepared.fulfill()
+                    await commitGate.wait()
+                    rebindReleased.fulfill()
+                }
+            )
+        )
+        addTeardownBlock { await commitGate.release() }
+
+        let firstAttempt = Task {
+            try await fixture.controller.trustHooksForCurrentWorkspace(
+                expectedCandidates: candidates(from: fixture.inventory),
+                expectedInventoryFingerprint: fixture.inventory.fingerprint
+            )
+        }
+        await fulfillment(of: [rebindPrepared], timeout: 2)
+        do {
+            _ = try await firstAttempt.value
+            XCTFail("Expected the recovery deadline to fail closed")
+        } catch {}
+        XCTAssertEqual(fixture.controller.currentSessionReference, fixture.initialReference)
+
+        await commitGate.release()
+        await fulfillment(of: [rebindReleased], timeout: 2)
+        try await Task.sleep(nanoseconds: 20_000_000)
+        XCTAssertEqual(fixture.controller.currentSessionReference, fixture.initialReference)
+
+        try FileManager.default.removeItem(at: fixture.trustedMarkerURL)
+        let verified = try await fixture.controller.trustHooksForCurrentWorkspace(
+            expectedCandidates: candidates(from: fixture.inventory),
+            expectedInventoryFingerprint: fixture.inventory.fingerprint
+        )
+        XCTAssertTrue(verified.verifies(candidates(from: fixture.inventory)))
+        XCTAssertEqual(fixture.controller.currentSessionReference?.conversationID, "replacement-thread")
+        let receipt = try await fixture.controller.startUserTurn(
+            text: "first turn after deadline retry",
+            images: [],
+            model: "gpt-test",
+            reasoningEffort: "medium",
+            serviceTier: nil
+        )
+        XCTAssertEqual(receipt.provisionalSubmissionID, "replacement-turn")
+    }
+
     func testConcurrentInboundStreamStartupInstallsOneOwnedSubscriptionPerKind() async throws {
         let client = CodexAppServerClient(livenessProbe: { _ in true })
         await client.debugInstallTestTransport()
@@ -1231,6 +1352,174 @@ final class CodexNativeSessionControllerHookApprovalTests: XCTestCase {
         )
     }
 
+    private struct HookTrustRebindFixture {
+        let controller: CodexNativeSessionController
+        let trustedMarkerURL: URL
+        let requestLogURL: URL
+        let initialReference: CodexNativeSessionController.SessionRef
+        let inventory: CodexHookInventory
+    }
+
+    private func makeHookTrustRebindFixture(
+        requestTimeout: TimeInterval = 2,
+        wrongResumeProcessNumber: Int? = nil,
+        faultInjection: CodexNativeSessionController.HookTrustFaultInjection = .init()
+    ) async throws -> HookTrustRebindFixture {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CodexHookTrustRebindTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        let processCountURL = directory.appendingPathComponent("process-count")
+        let trustedMarkerURL = directory.appendingPathComponent("trusted")
+        let requestLogURL = directory.appendingPathComponent("requests.jsonl")
+        let executableURL = try makeHookTrustRebindServer(
+            in: directory,
+            processCountURL: processCountURL,
+            trustedMarkerURL: trustedMarkerURL,
+            requestLogURL: requestLogURL,
+            wrongResumeProcessNumber: wrongResumeProcessNumber
+        )
+        let client = CodexAppServerClient()
+        await client.updateConfig(.init(
+            commandName: executableURL.path,
+            additionalPathHints: [],
+            requestTimeout: 2,
+            processLaunchDirectory: directory.path
+        ))
+        var options = CodexNativeSessionController.Options.agentModeDefault(
+            approvalPolicyProvider: { .never },
+            sandboxModeProvider: { .readOnly },
+            approvalReviewerProvider: { .user }
+        )
+        options.requestTimeout = requestTimeout
+        options.skillExtraRootsProvider = { [] }
+        let controller = CodexNativeSessionController(
+            client: client,
+            runID: UUID(),
+            tabID: UUID(),
+            windowID: 1,
+            workspacePaths: .uniform(directory.path),
+            options: options,
+            clientShutdownBehavior: .stopOnShutdown,
+            hookTrustFaultInjection: faultInjection
+        )
+        addTeardownBlock {
+            await controller.shutdown()
+            try? FileManager.default.removeItem(at: directory)
+        }
+
+        let initialReference = try await controller.startOrResume(
+            existing: nil,
+            baseInstructions: "Agent",
+            model: "gpt-test",
+            reasoningEffort: "medium",
+            serviceTier: nil
+        )
+        XCTAssertEqual(initialReference.conversationID, "initial-thread")
+        let inventory = try await controller.listHooksForCurrentWorkspace()
+        return HookTrustRebindFixture(
+            controller: controller,
+            trustedMarkerURL: trustedMarkerURL,
+            requestLogURL: requestLogURL,
+            initialReference: initialReference,
+            inventory: inventory
+        )
+    }
+
+    private func makeHookTrustRebindServer(
+        in directory: URL,
+        processCountURL: URL,
+        trustedMarkerURL: URL,
+        requestLogURL: URL,
+        wrongResumeProcessNumber: Int? = nil
+    ) throws -> URL {
+        let executableURL = directory.appendingPathComponent("fake-codex")
+        let script = """
+        #!/usr/bin/env python3
+        import json
+        import os
+        import sys
+
+        if sys.argv[1:] == ["--version"]:
+            print("codex 0.147.0")
+            raise SystemExit(0)
+
+        process_count_path = \(String(reflecting: processCountURL.path))
+        trusted_marker_path = \(String(reflecting: trustedMarkerURL.path))
+        request_log_path = \(String(reflecting: requestLogURL.path))
+        wrong_resume_process_number = \(wrongResumeProcessNumber.map(String.init) ?? "None")
+        try:
+            with open(process_count_path, "r", encoding="utf-8") as handle:
+                process_number = int(handle.read()) + 1
+        except Exception:
+            process_number = 1
+        with open(process_count_path, "w", encoding="utf-8") as handle:
+            handle.write(str(process_number))
+
+        loaded_threads = set()
+
+        def respond(request_id, result):
+            print(json.dumps({"jsonrpc": "2.0", "id": request_id, "result": result}), flush=True)
+
+        def reject(request_id, message):
+            print(json.dumps({"jsonrpc": "2.0", "id": request_id, "error": {"code": -32600, "message": message}}), flush=True)
+
+        def hook_list():
+            status = "trusted" if os.path.exists(trusted_marker_path) else "untrusted"
+            return {"data": [{"cwd": \(String(reflecting: directory.path)), "errors": [], "warnings": [], "hooks": [{
+                "eventName": "preToolUse",
+                "source": "project",
+                "sourcePath": \(String(reflecting: directory.appendingPathComponent(".codex/config.toml").path)),
+                "key": "one",
+                "currentHash": "h1",
+                "enabled": True,
+                "trustStatus": status,
+                "handlerType": "command"
+            }]}]}
+
+        for line in sys.stdin:
+            try:
+                request = json.loads(line)
+            except Exception:
+                continue
+            method = request.get("method")
+            params = request.get("params") or {}
+            with open(request_log_path, "a", encoding="utf-8") as handle:
+                handle.write(json.dumps({"process": process_number, "method": method, "params": params}, sort_keys=True) + "\\n")
+            if "id" not in request:
+                continue
+            request_id = request["id"]
+            if method == "initialize":
+                respond(request_id, {})
+            elif method == "thread/start":
+                thread_id = "initial-thread" if process_number == 1 else "replacement-thread"
+                loaded_threads.add(thread_id)
+                respond(request_id, {"thread": {"id": thread_id, "path": None, "status": {"type": "idle"}, "turns": []}, "model": "gpt-test", "reasoningEffort": "medium"})
+            elif method == "thread/resume":
+                if process_number == wrong_resume_process_number:
+                    respond(request_id, {"thread": {"id": "wrong-thread", "path": "/tmp/wrong-rollout.jsonl", "status": {"type": "idle"}, "turns": []}, "model": "gpt-test", "reasoningEffort": "medium"})
+                else:
+                    reject(request_id, "no rollout found for thread id " + str(params.get("threadId")))
+            elif method == "hooks/list":
+                respond(request_id, hook_list())
+            elif method == "config/batchWrite":
+                with open(trusted_marker_path, "w", encoding="utf-8") as handle:
+                    handle.write("trusted")
+                os._exit(0)
+            elif method == "turn/start":
+                thread_id = params.get("threadId")
+                if thread_id not in loaded_threads:
+                    reject(request_id, "thread not found: " + str(thread_id))
+                else:
+                    respond(request_id, {"turn": {"id": "replacement-turn"}})
+            else:
+                respond(request_id, {})
+        """
+        try script.write(to: executableURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executableURL.path)
+        return executableURL
+    }
+
     private func batchValues(from requests: [HookRequestRecorder.Request]) -> [String: Any] {
         guard let write = requests.first(where: { $0.method == "config/batchWrite" }),
               let edits = write.params?["edits"] as? [[String: Any]],
@@ -1370,6 +1659,16 @@ private final class HookRequestRecorder: @unchecked Sendable {
 private enum HookApprovalTestError: Error {
     case injectedFailure
     case unexpectedRequest(String)
+}
+
+private actor HookApprovalFirstCallClaim {
+    private var isClaimed = false
+
+    func claim() -> Bool {
+        guard !isClaimed else { return false }
+        isClaimed = true
+        return true
+    }
 }
 
 private actor HookApprovalAsyncGate {

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexNativeSessionControllerHookApprovalTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexNativeSessionControllerHookApprovalTests.swift
@@ -1,0 +1,1067 @@
+import Foundation
+@_spi(TestSupport) @testable import RepoPromptApp
+import XCTest
+
+final class CodexNativeSessionControllerHookApprovalTests: XCTestCase {
+    func testListDecodesAllTrustStatusesWarningsFingerprintAndExternalSourcePaths() async throws {
+        let cwd = "/tmp/worktree/repo/./"
+        let hooks = [
+            hook(key: "z", hash: "hash-z", status: "modified", sourcePath: "/tmp/main/repo/.codex/config.toml"),
+            hook(key: "a", hash: "hash-a", status: "managed", command: NSNull()),
+            hook(key: "b", hash: "hash-b", status: "untrusted", enabled: false, command: "deny.sh"),
+            hook(key: "c", hash: "hash-c", status: "trusted", source: "user")
+        ]
+        let recorder = HookRequestRecorder(steps: [
+            .init(method: "hooks/list", result: listResult(cwd: "/tmp/worktree/repo", hooks: hooks, warnings: ["review warning"]))
+        ])
+        let controller = makeController(cwd: cwd, recorder: recorder)
+
+        let inventory = try await controller.listHooksForCurrentWorkspace()
+
+        XCTAssertEqual(inventory.executionCWD, "/tmp/worktree/repo")
+        XCTAssertEqual(inventory.hooks.map(\.key), ["a", "b", "c", "z"])
+        XCTAssertEqual(inventory.hooks.map(\.trustStatus), [.managed, .untrusted, .trusted, .modified])
+        XCTAssertEqual(inventory.projectHooks.map(\.key), ["a", "b", "z"])
+        XCTAssertEqual(inventory.unresolvedProjectHooks.map(\.key), ["b", "z"])
+        XCTAssertEqual(inventory.warnings, ["review warning"])
+        XCTAssertEqual(inventory.hooks.first(where: { $0.key == "b" })?.commandOrHandler, "deny.sh")
+        XCTAssertEqual(inventory.hooks.first(where: { $0.key == "z" })?.sourcePath, "/tmp/main/repo/.codex/config.toml")
+        XCTAssertEqual(recorder.requests().first?.params?["cwds"] as? [String], [cwd])
+
+        let reordered = try CodexHookInventory.decode(
+            result: listResult(cwd: "/tmp/worktree/repo/../repo", hooks: hooks.reversed()),
+            executionCWD: "/tmp/worktree/repo"
+        )
+        XCTAssertEqual(inventory.fingerprint, reordered.fingerprint)
+    }
+
+    func testListRejectsUnknownMalformedConflictingDuplicatesAndCwdErrors() async {
+        let cases: [(String, [String: Any])] = [
+            ("unknown status", listResult(cwd: "/tmp/repo", hooks: [hook(key: "a", hash: "h", status: "future")])),
+            ("blank key", listResult(cwd: "/tmp/repo", hooks: [hook(key: " ", hash: "h", status: "untrusted")])),
+            ("conflicting duplicate", listResult(cwd: "/tmp/repo", hooks: [
+                hook(key: "a", hash: "h1", status: "untrusted"),
+                hook(key: "a", hash: "h2", status: "untrusted")
+            ])),
+            ("handler-only duplicate conflict", listResult(cwd: "/tmp/repo", hooks: [
+                hook(key: "a", hash: "h", status: "untrusted", handlerType: "command"),
+                hook(key: "a", hash: "h", status: "untrusted", handlerType: "prompt")
+            ]))
+        ]
+
+        for (name, result) in cases {
+            let recorder = HookRequestRecorder(steps: [.init(method: "hooks/list", result: result)])
+            let controller = makeController(cwd: "/tmp/repo", recorder: recorder)
+            do {
+                _ = try await controller.listHooksForCurrentWorkspace()
+                XCTFail("Expected malformed response for \(name)")
+            } catch let error as CodexHookTrustError {
+                guard case .malformedListResponse = error else {
+                    return XCTFail("Unexpected error for \(name): \(error)")
+                }
+                XCTAssertFalse(error.localizedDescription.contains("future"))
+            } catch {
+                XCTFail("Unexpected error type for \(name): \(error)")
+            }
+        }
+
+        let cwdErrors = ["SENTINEL_CWD_DISCOVERY_FAILURE_665"]
+        let recorder = HookRequestRecorder(steps: [
+            .init(method: "hooks/list", result: listResult(cwd: "/tmp/repo", hooks: [], errors: cwdErrors))
+        ])
+        do {
+            _ = try await makeController(cwd: "/tmp/repo", recorder: recorder)
+                .listHooksForCurrentWorkspace()
+            XCTFail("Expected cwd discovery failure")
+        } catch let error as CodexHookTrustError {
+            guard case let .discoveryFailed(receivedErrors) = error else {
+                return XCTFail("Unexpected cwd error: \(error)")
+            }
+            XCTAssertEqual(receivedErrors, cwdErrors)
+            XCTAssertTrue(error.localizedDescription.contains("1"))
+            XCTAssertFalse(error.localizedDescription.contains(cwdErrors[0]))
+        } catch {
+            XCTFail("Unexpected cwd error type: \(error)")
+        }
+    }
+
+    func testExactDuplicateRecordsAreDeduplicated() async throws {
+        let duplicate = hook(key: "a", hash: "h", status: "untrusted")
+        let recorder = HookRequestRecorder(steps: [
+            .init(method: "hooks/list", result: listResult(cwd: "/tmp/repo", hooks: [duplicate, duplicate]))
+        ])
+        let inventory = try await makeController(cwd: "/tmp/repo", recorder: recorder)
+            .listHooksForCurrentWorkspace()
+        XCTAssertEqual(inventory.hooks.count, 1)
+    }
+
+    func testCanonicallyEquivalentByteDistinctHookKeysFailClosed() async throws {
+        let composedKey = "hook-\u{00E9}"
+        let decomposedKey = "hook-e\u{0301}"
+        XCTAssertEqual(composedKey, decomposedKey)
+        XCTAssertNotEqual(Array(composedKey.utf8), Array(decomposedKey.utf8))
+        let composedInventory = try inventory(hooks: [
+            hook(key: composedKey, hash: "h", status: "untrusted")
+        ])
+        let decomposedInventory = try inventory(hooks: [
+            hook(key: decomposedKey, hash: "h", status: "untrusted")
+        ])
+        XCTAssertNotEqual(composedInventory.hooks[0], decomposedInventory.hooks[0])
+        XCTAssertNotEqual(composedInventory, decomposedInventory)
+        XCTAssertEqual(Set([composedInventory, decomposedInventory]).count, 2)
+        let recorder = HookRequestRecorder(steps: [
+            .init(method: "hooks/list", result: listResult(cwd: "/tmp/repo", hooks: [
+                hook(key: composedKey, hash: "h", status: "untrusted"),
+                hook(key: decomposedKey, hash: "h", status: "untrusted")
+            ]))
+        ])
+
+        await assertMalformed {
+            try await self.makeController(cwd: "/tmp/repo", recorder: recorder)
+                .listHooksForCurrentWorkspace()
+        }
+    }
+
+    func testCanonicallyEquivalentNonliteralCandidateKeyOrHashFailsBeforeMutation() async throws {
+        let composed = "\u{00E9}"
+        let decomposed = "e\u{0301}"
+        XCTAssertEqual(composed, decomposed)
+        XCTAssertNotEqual(Array(composed.utf8), Array(decomposed.utf8))
+        let hooks = [hook(key: "key-\(composed)", hash: "hash-\(composed)", status: "untrusted")]
+        let displayed = try inventory(hooks: hooks)
+        let candidates = [
+            CodexHookTrustCandidate(key: "key-\(decomposed)", currentHash: "hash-\(composed)"),
+            CodexHookTrustCandidate(key: "key-\(composed)", currentHash: "hash-\(decomposed)")
+        ]
+        let literalCandidate = CodexHookTrustCandidate(
+            key: "key-\(composed)",
+            currentHash: "hash-\(composed)"
+        )
+        XCTAssertNotEqual(literalCandidate, candidates[0])
+        XCTAssertNotEqual(literalCandidate, candidates[1])
+        XCTAssertEqual(Set([literalCandidate] + candidates).count, 3)
+
+        for candidate in candidates {
+            let recorder = HookRequestRecorder(steps: [
+                .init(method: "hooks/list", result: listResult(cwd: "/tmp/repo", hooks: hooks))
+            ])
+            do {
+                _ = try await makeController(cwd: "/tmp/repo", recorder: recorder)
+                    .trustHooksForCurrentWorkspace(
+                        expectedCandidates: [candidate],
+                        expectedInventoryFingerprint: displayed.fingerprint
+                    )
+                XCTFail("Expected byte-distinct candidate rejection")
+            } catch let error as CodexHookTrustError {
+                guard case .inventoryChanged = error else {
+                    return XCTFail("Unexpected error: \(error)")
+                }
+            }
+            XCTAssertEqual(recorder.requests().map(\.method), ["hooks/list"])
+        }
+    }
+
+    func testSelectedOnlyTrustUsesOneDeterministicAggregateWriteAndVerifies() async throws {
+        let unresolved = [
+            hook(key: "z-key", hash: "hash-z", status: "untrusted"),
+            hook(key: "a-key", hash: "hash-a", status: "modified"),
+            hook(key: "ignored", hash: "hash-ignored", status: "untrusted")
+        ]
+        let displayed = try inventory(hooks: unresolved)
+        let verified = [
+            hook(key: "z-key", hash: "hash-z", status: "trusted"),
+            hook(key: "a-key", hash: "hash-a", status: "managed"),
+            hook(key: "ignored", hash: "hash-ignored", status: "untrusted")
+        ]
+        let recorder = HookRequestRecorder(steps: [
+            .init(method: "hooks/list", result: listResult(cwd: "/tmp/repo", hooks: unresolved)),
+            .init(method: "config/batchWrite", result: ["status": "ok"]),
+            .init(method: "hooks/list", result: listResult(cwd: "/tmp/repo", hooks: verified))
+        ])
+        let controller = makeController(cwd: "/tmp/repo", recorder: recorder)
+
+        let inventory = try await controller.trustHooksForCurrentWorkspace(
+            expectedCandidates: [
+                .init(key: "z-key", currentHash: "hash-z"),
+                .init(key: "a-key", currentHash: "hash-a")
+            ],
+            expectedInventoryFingerprint: displayed.fingerprint
+        )
+
+        XCTAssertEqual(inventory.unresolvedProjectHooks.map(\.key), ["ignored"])
+        let requests = recorder.requests()
+        XCTAssertEqual(requests.map(\.method), ["hooks/list", "config/batchWrite", "hooks/list"])
+        let write = try XCTUnwrap(requests[1].params)
+        XCTAssertEqual(write["reloadUserConfig"] as? Bool, true)
+        let edits = try XCTUnwrap(write["edits"] as? [[String: Any]])
+        XCTAssertEqual(edits.count, 1)
+        XCTAssertEqual(edits[0]["keyPath"] as? String, "hooks.state")
+        XCTAssertEqual(edits[0]["mergeStrategy"] as? String, "upsert")
+        let values = try XCTUnwrap(edits[0]["value"] as? [String: Any])
+        XCTAssertEqual(Set(values.keys), Set(["a-key", "z-key"]))
+        XCTAssertNil(values["ignored"])
+        XCTAssertEqual((values["a-key"] as? [String: String])?["trusted_hash"], "hash-a")
+        XCTAssertEqual((values["z-key"] as? [String: String])?["trusted_hash"], "hash-z")
+    }
+
+    func testTrustAllWritesEveryDisplayedCandidate() async throws {
+        let unresolved = [
+            hook(key: "one", hash: "h1", status: "untrusted"),
+            hook(key: "two", hash: "h2", status: "modified")
+        ]
+        let displayed = try inventory(hooks: unresolved)
+        let recorder = HookRequestRecorder(steps: [
+            .init(method: "hooks/list", result: listResult(cwd: "/tmp/repo", hooks: unresolved)),
+            .init(method: "config/batchWrite", result: ["status": "ok"]),
+            .init(method: "hooks/list", result: listResult(cwd: "/tmp/repo", hooks: [
+                hook(key: "one", hash: "h1", status: "trusted"),
+                hook(key: "two", hash: "h2", status: "trusted")
+            ]))
+        ])
+
+        let result = try await makeController(cwd: "/tmp/repo", recorder: recorder)
+            .trustHooksForCurrentWorkspace(
+                expectedCandidates: candidates(from: displayed),
+                expectedInventoryFingerprint: displayed.fingerprint
+            )
+
+        XCTAssertTrue(result.unresolvedProjectHooks.isEmpty)
+        let values = batchValues(from: recorder.requests())
+        XCTAssertEqual(Set(values.keys), Set(["one", "two"]))
+    }
+
+    func testPreWriteDriftPreventsMutation() async throws {
+        let displayedHooks = [hook(key: "one", hash: "old", status: "untrusted")]
+        let displayed = try inventory(hooks: displayedHooks)
+        let recorder = HookRequestRecorder(steps: [
+            .init(method: "hooks/list", result: listResult(cwd: "/tmp/repo", hooks: [
+                hook(key: "one", hash: "new", status: "modified")
+            ]))
+        ])
+
+        do {
+            _ = try await makeController(cwd: "/tmp/repo", recorder: recorder)
+                .trustHooksForCurrentWorkspace(
+                    expectedCandidates: [.init(key: "one", currentHash: "old")],
+                    expectedInventoryFingerprint: displayed.fingerprint
+                )
+            XCTFail("Expected inventory drift")
+        } catch let error as CodexHookTrustError {
+            guard case let .inventoryChanged(replacement) = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertEqual(replacement.hooks.first?.currentHash, "new")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+        XCTAssertEqual(recorder.requests().map(\.method), ["hooks/list"])
+    }
+
+    func testPostWriteUntrustedModifiedAndPartialVerificationStayBlocked() async throws {
+        let unresolved = [
+            hook(key: "one", hash: "h1", status: "untrusted"),
+            hook(key: "two", hash: "h2", status: "modified")
+        ]
+        let displayed = try inventory(hooks: unresolved)
+        let verificationCases: [(String, [[String: Any]])] = [
+            ("untrusted", [
+                hook(key: "one", hash: "h1", status: "untrusted"),
+                hook(key: "two", hash: "h2", status: "untrusted")
+            ]),
+            ("modified", [
+                hook(key: "one", hash: "h1", status: "modified"),
+                hook(key: "two", hash: "h2", status: "modified")
+            ]),
+            ("partial", [
+                hook(key: "one", hash: "h1", status: "untrusted"),
+                hook(key: "two", hash: "h2", status: "trusted")
+            ]),
+            ("hash drift", [
+                hook(key: "one", hash: "changed-h1", status: "trusted"),
+                hook(key: "two", hash: "h2", status: "trusted")
+            ])
+        ]
+
+        for (name, verificationHooks) in verificationCases {
+            let recorder = HookRequestRecorder(steps: [
+                .init(method: "hooks/list", result: listResult(cwd: "/tmp/repo", hooks: unresolved)),
+                .init(method: "config/batchWrite", result: ["status": "ok"]),
+                .init(method: "hooks/list", result: listResult(cwd: "/tmp/repo", hooks: verificationHooks))
+            ])
+            await assertTrustFailure(
+                controller: makeController(cwd: "/tmp/repo", recorder: recorder),
+                candidates: candidates(from: displayed),
+                fingerprint: displayed.fingerprint
+            ) { error in
+                guard case let .postWriteVerificationFailed(latest) = error else {
+                    return XCTFail("Unexpected error for \(name): \(error)")
+                }
+                XCTAssertNotNil(latest)
+            }
+        }
+    }
+
+    func testAppGlobalTrustWriteMutexSerializesControllers() async throws {
+        let unresolved = [hook(key: "one", hash: "h1", status: "untrusted")]
+        let trusted = [hook(key: "one", hash: "h1", status: "trusted")]
+        let displayed = try inventory(hooks: unresolved)
+        let firstVerificationStarted = expectation(description: "first verification started")
+        let secondCallStarted = expectation(description: "second trust call started")
+        let verificationGate = HookApprovalAsyncGate()
+        let firstRecorder = HookRequestRecorder(steps: [
+            .init(method: "hooks/list", result: listResult(cwd: "/tmp/repo", hooks: unresolved)),
+            .init(method: "config/batchWrite", result: ["status": "ok"]),
+            .init(method: "hooks/list", result: listResult(cwd: "/tmp/repo", hooks: trusted))
+        ])
+        let secondRecorder = HookRequestRecorder(steps: [
+            .init(method: "hooks/list", result: listResult(cwd: "/tmp/repo", hooks: unresolved)),
+            .init(method: "config/batchWrite", result: ["status": "ok"]),
+            .init(method: "hooks/list", result: listResult(cwd: "/tmp/repo", hooks: trusted))
+        ])
+        let firstController = makeController(cwd: "/tmp/repo") { method, params, timeout in
+            let result = try firstRecorder.handle(method: method, params: params, timeout: timeout)
+            if method == "hooks/list", firstRecorder.requests().count == 3 {
+                firstVerificationStarted.fulfill()
+                await verificationGate.wait()
+            }
+            return result
+        }
+        let secondController = makeController(cwd: "/tmp/repo", recorder: secondRecorder)
+        let candidates = [CodexHookTrustCandidate(key: "one", currentHash: "h1")]
+
+        let firstTask = Task {
+            try await firstController.trustHooksForCurrentWorkspace(
+                expectedCandidates: candidates,
+                expectedInventoryFingerprint: displayed.fingerprint
+            )
+        }
+        await fulfillment(of: [firstVerificationStarted], timeout: 2)
+        let secondTask = Task {
+            secondCallStarted.fulfill()
+            return try await secondController.trustHooksForCurrentWorkspace(
+                expectedCandidates: candidates,
+                expectedInventoryFingerprint: displayed.fingerprint
+            )
+        }
+        await fulfillment(of: [secondCallStarted], timeout: 2)
+        for _ in 0 ..< 50 {
+            await Task.yield()
+        }
+        XCTAssertTrue(secondRecorder.requests().isEmpty)
+
+        await verificationGate.release()
+        _ = try await firstTask.value
+        _ = try await secondTask.value
+        XCTAssertEqual(secondRecorder.requests().map(\.method), ["hooks/list", "config/batchWrite", "hooks/list"])
+    }
+
+    func testCancelledBatchWriteHoldsGlobalMutexUntilServerOperationSettles() async throws {
+        let unresolved = [hook(key: "one", hash: "h1", status: "untrusted")]
+        let trusted = [hook(key: "one", hash: "h1", status: "trusted")]
+        let displayed = try inventory(hooks: unresolved)
+        let firstWriteStarted = expectation(description: "first batch write started")
+        let secondCallStarted = expectation(description: "second trust call started")
+        let writeGate = HookApprovalAsyncGate()
+        let firstRecorder = HookRequestRecorder(steps: [
+            .init(method: "hooks/list", result: listResult(cwd: "/tmp/repo", hooks: unresolved))
+        ])
+        let secondRecorder = HookRequestRecorder(steps: [
+            .init(method: "hooks/list", result: listResult(cwd: "/tmp/repo", hooks: unresolved)),
+            .init(method: "config/batchWrite", result: ["status": "ok"]),
+            .init(method: "hooks/list", result: listResult(cwd: "/tmp/repo", hooks: trusted))
+        ])
+        let firstController = makeController(cwd: "/tmp/repo", requestTimeout: 0.01) { method, params, timeout in
+            if method == "config/batchWrite" {
+                firstRecorder.record(method: method, params: params, timeout: timeout)
+                firstWriteStarted.fulfill()
+                if let timeout {
+                    Task { await writeGate.wait() }
+                    try await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+                    throw NSError(domain: "simulated-client-timeout", code: 1)
+                }
+                await writeGate.wait()
+                return ["status": "ok"]
+            }
+            return try firstRecorder.handle(method: method, params: params, timeout: timeout)
+        }
+        let secondController = makeController(cwd: "/tmp/repo", requestTimeout: 0.01, recorder: secondRecorder)
+        let candidates = [CodexHookTrustCandidate(key: "one", currentHash: "h1")]
+
+        let firstTask = Task {
+            try await firstController.trustHooksForCurrentWorkspace(
+                expectedCandidates: candidates,
+                expectedInventoryFingerprint: displayed.fingerprint
+            )
+        }
+        await fulfillment(of: [firstWriteStarted], timeout: 2)
+        try await Task.sleep(nanoseconds: 50_000_000)
+        XCTAssertNil(firstRecorder.requests().last?.timeout)
+        firstTask.cancel()
+        let secondTask = Task {
+            secondCallStarted.fulfill()
+            return try await secondController.trustHooksForCurrentWorkspace(
+                expectedCandidates: candidates,
+                expectedInventoryFingerprint: displayed.fingerprint
+            )
+        }
+        await fulfillment(of: [secondCallStarted], timeout: 2)
+        for _ in 0 ..< 50 {
+            await Task.yield()
+        }
+        XCTAssertTrue(secondRecorder.requests().isEmpty)
+
+        await writeGate.release()
+        do {
+            _ = try await firstTask.value
+            XCTFail("Expected cancellation after write settlement")
+        } catch let error as CodexHookTrustError {
+            guard case .cancelled = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+        _ = try await secondTask.value
+        XCTAssertEqual(firstRecorder.requests().map(\.method), ["hooks/list", "config/batchWrite"])
+        XCTAssertEqual(secondRecorder.requests().map(\.method), ["hooks/list", "config/batchWrite", "hooks/list"])
+    }
+
+    func testHookOperationMutexSerializesOverlappingOperationsOnOneController() async throws {
+        let listStarted = expectation(description: "first list started")
+        let secondCallStarted = expectation(description: "second list call started")
+        let listGate = HookApprovalAsyncGate()
+        let recorder = HookRequestRecorder(steps: [])
+        let result = listResult(cwd: "/tmp/repo", hooks: [])
+        let controller = makeController(cwd: "/tmp/repo") { method, params, timeout in
+            recorder.record(method: method, params: params, timeout: timeout)
+            if recorder.requests().count == 1 {
+                listStarted.fulfill()
+                await listGate.wait()
+            }
+            return result
+        }
+
+        let firstTask = Task { try await controller.listHooksForCurrentWorkspace() }
+        await fulfillment(of: [listStarted], timeout: 2)
+        let secondTask = Task {
+            secondCallStarted.fulfill()
+            return try await controller.listHooksForCurrentWorkspace()
+        }
+        await fulfillment(of: [secondCallStarted], timeout: 2)
+        for _ in 0 ..< 50 {
+            await Task.yield()
+        }
+        XCTAssertEqual(recorder.requests().count, 1)
+
+        await listGate.release()
+        _ = try await firstTask.value
+        _ = try await secondTask.value
+        XCTAssertEqual(recorder.requests().map(\.method), ["hooks/list", "hooks/list"])
+    }
+
+    func testCancellationDuringPostWriteVerificationRemainsCancelled() async throws {
+        let unresolved = [hook(key: "one", hash: "h1", status: "untrusted")]
+        let displayed = try inventory(hooks: unresolved)
+        let verificationStarted = expectation(description: "verification list started")
+        let recorder = HookRequestRecorder(steps: [
+            .init(method: "hooks/list", result: listResult(cwd: "/tmp/repo", hooks: unresolved)),
+            .init(method: "config/batchWrite", result: ["status": "ok"]),
+            .init(method: "hooks/list", result: listResult(cwd: "/tmp/repo", hooks: [
+                hook(key: "one", hash: "h1", status: "trusted")
+            ]))
+        ])
+        let controller = makeController(cwd: "/tmp/repo") { method, params, timeout in
+            let result = try recorder.handle(method: method, params: params, timeout: timeout)
+            if method == "hooks/list", recorder.requests().count == 3 {
+                verificationStarted.fulfill()
+                try await Task.sleep(nanoseconds: 60_000_000_000)
+            }
+            return result
+        }
+        let task = Task {
+            try await controller.trustHooksForCurrentWorkspace(
+                expectedCandidates: [.init(key: "one", currentHash: "h1")],
+                expectedInventoryFingerprint: displayed.fingerprint
+            )
+        }
+        await fulfillment(of: [verificationStarted], timeout: 2)
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            XCTFail("Expected verification cancellation")
+        } catch let error as CodexHookTrustError {
+            guard case .cancelled = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+        XCTAssertEqual(recorder.requests().map(\.method), ["hooks/list", "config/batchWrite", "hooks/list"])
+    }
+
+    func testNonUnsupportedListFailuresAreSanitizedMalformedResponses() async {
+        let sentinel = "SENTINEL_LIST_FAILURE_665"
+        let failures: [Error] = [
+            CodexAppServerClient.ClientError.requestFailed(.init(
+                method: "hooks/list",
+                code: -32000,
+                message: sentinel,
+                data: nil
+            )),
+            CodexAppServerClient.ClientError.transportWriteFailed(message: sentinel, errno: nil)
+        ]
+
+        for failure in failures {
+            let recorder = HookRequestRecorder(steps: [.init(method: "hooks/list", error: failure)])
+            do {
+                _ = try await makeController(cwd: "/tmp/repo", recorder: recorder)
+                    .listHooksForCurrentWorkspace()
+                XCTFail("Expected malformed discovery failure")
+            } catch let error as CodexHookTrustError {
+                guard case .malformedListResponse = error else {
+                    return XCTFail("Unexpected error: \(error)")
+                }
+                XCTAssertFalse(error.localizedDescription.contains(sentinel))
+            } catch {
+                XCTFail("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    func testThrownBatchWriteFailureIsSanitized() async throws {
+        let sentinel = "SENTINEL_BATCH_FAILURE_665"
+        let unresolved = [hook(key: "one", hash: "h1", status: "untrusted")]
+        let displayed = try inventory(hooks: unresolved)
+        let failure = CodexAppServerClient.ClientError.requestFailed(.init(
+            method: "config/batchWrite",
+            code: -32000,
+            message: sentinel,
+            data: nil
+        ))
+        let recorder = HookRequestRecorder(steps: [
+            .init(method: "hooks/list", result: listResult(cwd: "/tmp/repo", hooks: unresolved)),
+            .init(method: "config/batchWrite", error: failure)
+        ])
+
+        await assertTrustFailure(
+            controller: makeController(cwd: "/tmp/repo", recorder: recorder),
+            candidates: candidates(from: displayed),
+            fingerprint: displayed.fingerprint
+        ) { error in
+            guard case .batchWriteFailed = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertFalse(error.localizedDescription.contains(sentinel))
+        }
+        XCTAssertEqual(recorder.requests().map(\.method), ["hooks/list", "config/batchWrite"])
+    }
+
+    func testMalformedAndTransportFailedVerificationResponsesAreSanitized() async throws {
+        let sentinel = "SENTINEL_VERIFICATION_FAILURE_665"
+        let unresolved = [hook(key: "one", hash: "h1", status: "untrusted")]
+        let displayed = try inventory(hooks: unresolved)
+        let verificationSteps: [HookRequestRecorder.Step] = [
+            .init(method: "hooks/list", result: [:]),
+            .init(
+                method: "hooks/list",
+                error: CodexAppServerClient.ClientError.transportReadSetupFailed(message: sentinel, errno: nil)
+            )
+        ]
+
+        for verificationStep in verificationSteps {
+            let recorder = HookRequestRecorder(steps: [
+                .init(method: "hooks/list", result: listResult(cwd: "/tmp/repo", hooks: unresolved)),
+                .init(method: "config/batchWrite", result: ["status": "ok"]),
+                verificationStep
+            ])
+            await assertTrustFailure(
+                controller: makeController(cwd: "/tmp/repo", recorder: recorder),
+                candidates: candidates(from: displayed),
+                fingerprint: displayed.fingerprint
+            ) { error in
+                guard case let .postWriteVerificationFailed(latest) = error else {
+                    return XCTFail("Unexpected error: \(error)")
+                }
+                XCTAssertNil(latest)
+                XCTAssertFalse(error.localizedDescription.contains(sentinel))
+            }
+        }
+    }
+
+    func testSelectedHookMissingAfterWriteFailsVerification() async throws {
+        let unresolved = [hook(key: "one", hash: "h1", status: "untrusted")]
+        let displayed = try inventory(hooks: unresolved)
+        let recorder = HookRequestRecorder(steps: [
+            .init(method: "hooks/list", result: listResult(cwd: "/tmp/repo", hooks: unresolved)),
+            .init(method: "config/batchWrite", result: ["status": "ok"]),
+            .init(method: "hooks/list", result: listResult(cwd: "/tmp/repo", hooks: []))
+        ])
+
+        await assertTrustFailure(
+            controller: makeController(cwd: "/tmp/repo", recorder: recorder),
+            candidates: candidates(from: displayed),
+            fingerprint: displayed.fingerprint
+        ) { error in
+            guard case let .postWriteVerificationFailed(latest) = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertEqual(latest?.hooks, [])
+        }
+    }
+
+    func testEmptyAndDuplicateCandidatesFailBeforeBatchWrite() async throws {
+        let unresolved = [hook(key: "one", hash: "h1", status: "untrusted")]
+        let displayed = try inventory(hooks: unresolved)
+        let cases: [[CodexHookTrustCandidate]] = [
+            [],
+            [
+                .init(key: "one", currentHash: "h1"),
+                .init(key: "one", currentHash: "h1")
+            ]
+        ]
+
+        for candidates in cases {
+            let recorder = HookRequestRecorder(steps: [
+                .init(method: "hooks/list", result: listResult(cwd: "/tmp/repo", hooks: unresolved))
+            ])
+            do {
+                _ = try await makeController(cwd: "/tmp/repo", recorder: recorder)
+                    .trustHooksForCurrentWorkspace(
+                        expectedCandidates: candidates,
+                        expectedInventoryFingerprint: displayed.fingerprint
+                    )
+                XCTFail("Expected candidate rejection")
+            } catch let error as CodexHookTrustError {
+                guard case .inventoryChanged = error else {
+                    return XCTFail("Unexpected error: \(error)")
+                }
+            } catch {
+                XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertEqual(recorder.requests().map(\.method), ["hooks/list"])
+        }
+    }
+
+    func testStructuredMethodNotFoundClassifiesListAndWriteWithoutMessageLeakage() async throws {
+        let sentinel = "SENTINEL_SERVER_MESSAGE_665"
+        let listFailure = CodexAppServerClient.ClientError.requestFailed(.init(
+            method: "hooks/list",
+            code: -32601,
+            message: sentinel,
+            data: nil
+        ))
+        let listRecorder = HookRequestRecorder(steps: [
+            .init(method: "hooks/list", error: listFailure)
+        ])
+        do {
+            _ = try await makeController(cwd: "/tmp/repo", recorder: listRecorder)
+                .listHooksForCurrentWorkspace()
+            XCTFail("Expected unsupported list")
+        } catch let error as CodexHookTrustError {
+            guard case .unsupportedMethod(method: "hooks/list") = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertFalse(error.localizedDescription.contains(sentinel))
+        }
+
+        let unresolved = [hook(key: "one", hash: "h1", status: "untrusted")]
+        let displayed = try inventory(hooks: unresolved)
+        let writeFailure = CodexAppServerClient.ClientError.requestFailed(.init(
+            method: "config/batchWrite",
+            code: -32601,
+            message: sentinel,
+            data: nil
+        ))
+        let writeRecorder = HookRequestRecorder(steps: [
+            .init(method: "hooks/list", result: listResult(cwd: "/tmp/repo", hooks: unresolved)),
+            .init(method: "config/batchWrite", error: writeFailure)
+        ])
+        do {
+            _ = try await makeController(cwd: "/tmp/repo", recorder: writeRecorder)
+                .trustHooksForCurrentWorkspace(
+                    expectedCandidates: [.init(key: "one", currentHash: "h1")],
+                    expectedInventoryFingerprint: displayed.fingerprint
+                )
+            XCTFail("Expected unsupported write")
+        } catch let error as CodexHookTrustError {
+            guard case .unsupportedMethod(method: "config/batchWrite") = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertFalse(error.localizedDescription.contains(sentinel))
+        }
+    }
+
+    func testNonOKBatchWriteStatusFailsWithoutVerificationList() async throws {
+        let unresolved = [hook(key: "one", hash: "h1", status: "untrusted")]
+        let displayed = try inventory(hooks: unresolved)
+        let recorder = HookRequestRecorder(steps: [
+            .init(method: "hooks/list", result: listResult(cwd: "/tmp/repo", hooks: unresolved)),
+            .init(method: "config/batchWrite", result: ["status": "error"])
+        ])
+
+        await assertTrustFailure(
+            controller: makeController(cwd: "/tmp/repo", recorder: recorder),
+            candidates: candidates(from: displayed),
+            fingerprint: displayed.fingerprint
+        ) { error in
+            guard case .batchWriteFailed = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+        XCTAssertEqual(recorder.requests().map(\.method), ["hooks/list", "config/batchWrite"])
+    }
+
+    func testCancellationAfterBatchWriteWasSentDoesNotReportSuccess() async throws {
+        let unresolved = [hook(key: "one", hash: "h1", status: "untrusted")]
+        let displayed = try inventory(hooks: unresolved)
+        let writeStarted = expectation(description: "batch write sent")
+        let writeGate = HookApprovalAsyncGate()
+        let recorder = HookRequestRecorder(steps: [
+            .init(method: "hooks/list", result: listResult(cwd: "/tmp/repo", hooks: unresolved))
+        ])
+        let controller = makeController(cwd: "/tmp/repo") { method, params, timeout in
+            if method == "config/batchWrite" {
+                recorder.record(method: method, params: params, timeout: timeout)
+                writeStarted.fulfill()
+                await writeGate.wait()
+                return ["status": "ok"]
+            }
+            return try recorder.handle(method: method, params: params, timeout: timeout)
+        }
+        let task = Task {
+            try await controller.trustHooksForCurrentWorkspace(
+                expectedCandidates: [.init(key: "one", currentHash: "h1")],
+                expectedInventoryFingerprint: displayed.fingerprint
+            )
+        }
+        await fulfillment(of: [writeStarted], timeout: 2)
+        task.cancel()
+        await writeGate.release()
+
+        do {
+            _ = try await task.value
+            XCTFail("Expected cancellation after possibly persisted write")
+        } catch let error as CodexHookTrustError {
+            guard case .cancelled = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+        XCTAssertEqual(recorder.requests().map(\.method), ["hooks/list", "config/batchWrite"])
+    }
+
+    func testEveryHookTrustErrorDescriptionExcludesSensitiveInventoryValues() throws {
+        let sentinel = "SENTINEL_HOOK_SECRET_665"
+        let sensitiveHook = hook(
+            key: "key-\(sentinel)",
+            hash: "hash-\(sentinel)",
+            status: "untrusted",
+            sourcePath: "/private/\(sentinel)/config.toml",
+            command: "run-\(sentinel)"
+        )
+        let inventory = try inventory(hooks: [sensitiveHook])
+        let errors: [CodexHookTrustError] = [
+            .unsupportedMethod(method: "hooks/list"),
+            .malformedListResponse,
+            .discoveryFailed(cwdErrors: [sentinel]),
+            .inventoryChanged(replacement: inventory),
+            .batchWriteFailed,
+            .postWriteVerificationFailed(latest: inventory),
+            .cancelled
+        ]
+
+        for error in errors {
+            XCTAssertFalse(error.localizedDescription.contains(sentinel), "Leaked from \(error)")
+        }
+    }
+
+    func testExecutionCWDWhitespaceIsPreservedForRequestAndFingerprint() async throws {
+        let executionCWD = "/tmp/repo "
+        let recorder = HookRequestRecorder(steps: [
+            .init(method: "hooks/list", result: listResult(cwd: executionCWD, hooks: []))
+        ])
+        let listedInventory = try await makeController(cwd: executionCWD, recorder: recorder)
+            .listHooksForCurrentWorkspace()
+        let trimmedInventory = try inventory(hooks: [])
+
+        XCTAssertEqual(recorder.requests().first?.params?["cwds"] as? [String], [executionCWD])
+        XCTAssertEqual(listedInventory.executionCWD, executionCWD)
+        XCTAssertNotEqual(listedInventory.fingerprint, trimmedInventory.fingerprint)
+    }
+
+    func testCancellationStopsBeforeBatchWrite() async {
+        let requestStarted = expectation(description: "preflight hooks/list started")
+        let recorder = HookRequestRecorder(steps: [])
+        let controller = makeController(cwd: "/tmp/repo") { method, params, timeout in
+            recorder.record(method: method, params: params, timeout: timeout)
+            requestStarted.fulfill()
+            try await Task.sleep(nanoseconds: 60_000_000_000)
+            return [:]
+        }
+
+        let task = Task {
+            try await controller.trustHooksForCurrentWorkspace(
+                expectedCandidates: [.init(key: "one", currentHash: "h1")],
+                expectedInventoryFingerprint: "fingerprint"
+            )
+        }
+        await fulfillment(of: [requestStarted], timeout: 2)
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            XCTFail("Expected cancellation")
+        } catch let error as CodexHookTrustError {
+            guard case .cancelled = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+        XCTAssertEqual(recorder.requests().map(\.method), ["hooks/list"])
+    }
+
+    func testMissingExecutionCWDAndAmbiguousCwdResultFailClosed() async {
+        let missingController = makeController(cwd: nil, recorder: HookRequestRecorder(steps: []))
+        await assertMalformed { try await missingController.listHooksForCurrentWorkspace() }
+
+        let recorder = HookRequestRecorder(steps: [
+            .init(method: "hooks/list", result: ["data": [
+                listEntry(cwd: "/tmp/repo", hooks: []),
+                listEntry(cwd: "/tmp/other", hooks: [])
+            ]])
+        ])
+        await assertMalformed {
+            try await self.makeController(cwd: "/tmp/repo", recorder: recorder)
+                .listHooksForCurrentWorkspace()
+        }
+    }
+
+    private func inventory(
+        cwd: String = "/tmp/repo",
+        hooks: [[String: Any]]
+    ) throws -> CodexHookInventory {
+        try CodexHookInventory.decode(
+            result: listResult(cwd: cwd, hooks: hooks),
+            executionCWD: cwd
+        )
+    }
+
+    private func candidates(from inventory: CodexHookInventory) -> [CodexHookTrustCandidate] {
+        inventory.unresolvedProjectHooks.map {
+            CodexHookTrustCandidate(key: $0.key, currentHash: $0.currentHash)
+        }
+    }
+
+    private func assertTrustFailure(
+        controller: CodexNativeSessionController,
+        candidates: [CodexHookTrustCandidate],
+        fingerprint: String,
+        file: StaticString = #filePath,
+        line: UInt = #line,
+        validate: (CodexHookTrustError) -> Void
+    ) async {
+        do {
+            _ = try await controller.trustHooksForCurrentWorkspace(
+                expectedCandidates: candidates,
+                expectedInventoryFingerprint: fingerprint
+            )
+            XCTFail("Expected hook-trust failure", file: file, line: line)
+        } catch let error as CodexHookTrustError {
+            validate(error)
+        } catch {
+            XCTFail("Unexpected error: \(error)", file: file, line: line)
+        }
+    }
+
+    private func assertMalformed(
+        _ operation: () async throws -> CodexHookInventory
+    ) async {
+        do {
+            _ = try await operation()
+            XCTFail("Expected malformed response")
+        } catch let error as CodexHookTrustError {
+            guard case .malformedListResponse = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    private func makeController(
+        cwd: String?,
+        requestTimeout: TimeInterval? = 120,
+        recorder: HookRequestRecorder
+    ) -> CodexNativeSessionController {
+        makeController(cwd: cwd, requestTimeout: requestTimeout) { method, params, timeout in
+            try recorder.handle(method: method, params: params, timeout: timeout)
+        }
+    }
+
+    private func makeController(
+        cwd: String?,
+        requestTimeout: TimeInterval? = 120,
+        executor: @escaping @Sendable (String, [String: Any]?, TimeInterval?) async throws -> [String: Any]
+    ) -> CodexNativeSessionController {
+        var options = CodexNativeSessionController.Options.agentModeDefault()
+        options.requestTimeout = requestTimeout
+        return CodexNativeSessionController(
+            client: CodexAppServerClient(),
+            runID: UUID(),
+            tabID: UUID(),
+            windowID: 1,
+            workspacePaths: .uniform(cwd),
+            options: options,
+            requestExecutor: executor
+        )
+    }
+
+    private func batchValues(from requests: [HookRequestRecorder.Request]) -> [String: Any] {
+        guard let write = requests.first(where: { $0.method == "config/batchWrite" }),
+              let edits = write.params?["edits"] as? [[String: Any]],
+              let values = edits.first?["value"] as? [String: Any]
+        else {
+            return [:]
+        }
+        return values
+    }
+}
+
+private final class HookRequestRecorder: @unchecked Sendable {
+    struct Request {
+        let method: String
+        let params: [String: Any]?
+        let timeout: TimeInterval?
+    }
+
+    struct Step {
+        let method: String
+        let result: [String: Any]
+        let error: Error?
+
+        init(method: String, result: [String: Any]) {
+            self.method = method
+            self.result = result
+            error = nil
+        }
+
+        init(method: String, error: Error) {
+            self.method = method
+            result = [:]
+            self.error = error
+        }
+    }
+
+    private let lock = NSLock()
+    private var steps: [Step]
+    private var recordedRequests: [Request] = []
+
+    init(steps: [Step]) {
+        self.steps = steps
+    }
+
+    func handle(
+        method: String,
+        params: [String: Any]?,
+        timeout: TimeInterval?
+    ) throws -> [String: Any] {
+        lock.lock()
+        defer { lock.unlock() }
+        recordedRequests.append(.init(method: method, params: params, timeout: timeout))
+        guard !steps.isEmpty else {
+            throw HookApprovalTestError.unexpectedRequest(method)
+        }
+        let step = steps.removeFirst()
+        guard step.method == method else {
+            throw HookApprovalTestError.unexpectedRequest(method)
+        }
+        if let error = step.error {
+            throw error
+        }
+        return step.result
+    }
+
+    func record(method: String, params: [String: Any]?, timeout: TimeInterval?) {
+        lock.lock()
+        recordedRequests.append(.init(method: method, params: params, timeout: timeout))
+        lock.unlock()
+    }
+
+    func requests() -> [Request] {
+        lock.lock()
+        let result = recordedRequests
+        lock.unlock()
+        return result
+    }
+}
+
+private enum HookApprovalTestError: Error {
+    case unexpectedRequest(String)
+}
+
+private actor HookApprovalAsyncGate {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        guard !isOpen else { return }
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+
+    func release() {
+        isOpen = true
+        let pending = waiters
+        waiters.removeAll()
+        for waiter in pending {
+            waiter.resume()
+        }
+    }
+}
+
+private func listResult(
+    cwd: String,
+    hooks: [[String: Any]],
+    errors: [String] = [],
+    warnings: [String] = []
+) -> [String: Any] {
+    ["data": [listEntry(cwd: cwd, hooks: hooks, errors: errors, warnings: warnings)]]
+}
+
+private func listEntry(
+    cwd: String,
+    hooks: [[String: Any]],
+    errors: [String] = [],
+    warnings: [String] = []
+) -> [String: Any] {
+    [
+        "cwd": cwd,
+        "hooks": hooks,
+        "errors": errors,
+        "warnings": warnings
+    ]
+}
+
+private func hook(
+    key: String,
+    hash: String,
+    status: String,
+    source: String = "project",
+    sourcePath: String = "/tmp/repo/.codex/config.toml",
+    enabled: Bool = true,
+    handlerType: String = "command",
+    command: Any? = nil
+) -> [String: Any] {
+    var value: [String: Any] = [
+        "eventName": "preToolUse",
+        "source": source,
+        "sourcePath": sourcePath,
+        "key": key,
+        "currentHash": hash,
+        "enabled": enabled,
+        "trustStatus": status,
+        "handlerType": handlerType
+    ]
+    if let command {
+        value["command"] = command
+    }
+    return value
+}

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexSteerAckTrackerTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexSteerAckTrackerTests.swift
@@ -554,7 +554,7 @@ private enum AckTrackerTestError: LocalizedError {
     }
 }
 
-private final class AckTrackerCodexController: CodexSessionControlling {
+private final class AckTrackerCodexController: CodexSessionControllerTurnDispatchTestDefaults {
     private let gate: AckTrackerSteerGate
     private let steerResult: Result<CodexTurnSteerReceipt, Error>?
     private(set) var hasActiveThread = true
@@ -617,6 +617,7 @@ private final class AckTrackerCodexController: CodexSessionControlling {
     }
 
     func compactThread() async throws {}
+
     func getThreadGoal() async throws -> CodexNativeSessionController.ThreadGoal? {
         nil
     }

--- a/Tests/RepoPromptTests/AgentMode/CodexHookReviewCardStateTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/CodexHookReviewCardStateTests.swift
@@ -38,17 +38,39 @@ final class CodexHookReviewCardStateTests: XCTestCase {
         var state = CodexHookReviewCardState(interactionID: UUID())
         var isStrictModeEnabled = false
         XCTAssertTrue(!isStrictModeEnabled)
+        XCTAssertEqual(
+            CodexHookApprovalWorkspaceSetting.allCases.map {
+                $0.label(globalStrictModeEnabled: isStrictModeEnabled)
+            },
+            [
+                "App default (currently: not required)",
+                "Always require approval",
+                "Don't require approval"
+            ]
+        )
         state.isContinueConfirmationPresented = true
 
         isStrictModeEnabled = true
         state.strictModeDidChange(isEnabled: isStrictModeEnabled)
 
         XCTAssertFalse(!isStrictModeEnabled)
+        XCTAssertEqual(
+            CodexHookApprovalWorkspaceSetting.appDefault.label(
+                globalStrictModeEnabled: isStrictModeEnabled
+            ),
+            "App default (currently: required)"
+        )
         XCTAssertFalse(state.isContinueConfirmationPresented)
 
         isStrictModeEnabled = false
         state.strictModeDidChange(isEnabled: isStrictModeEnabled)
 
         XCTAssertTrue(!isStrictModeEnabled)
+        XCTAssertEqual(
+            CodexHookApprovalWorkspaceSetting.appDefault.label(
+                globalStrictModeEnabled: isStrictModeEnabled
+            ),
+            "App default (currently: not required)"
+        )
     }
 }

--- a/Tests/RepoPromptTests/AgentMode/CodexHookReviewCardStateTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/CodexHookReviewCardStateTests.swift
@@ -1,0 +1,54 @@
+import Foundation
+@testable import RepoPromptApp
+import XCTest
+
+final class CodexHookReviewCardStateTests: XCTestCase {
+    func testSelectionStartsEmpty() {
+        let state = CodexHookReviewCardState(interactionID: UUID())
+
+        XCTAssertTrue(state.selectedHookKeys.isEmpty)
+    }
+
+    func testSelectionIsPreservedForPhaseOrErrorUpdatesWithSameInteractionID() {
+        let interactionID = UUID()
+        var state = CodexHookReviewCardState(interactionID: interactionID)
+        state.selectedHookKeys = ["hook-a"]
+        state.actionErrorMessage = "write failed"
+
+        state.synchronize(interactionID: interactionID)
+
+        XCTAssertEqual(state.selectedHookKeys, ["hook-a"])
+        XCTAssertEqual(state.actionErrorMessage, "write failed")
+    }
+
+    func testSelectionResetsWhenInteractionIDChanges() {
+        var state = CodexHookReviewCardState(interactionID: UUID())
+        state.selectedHookKeys = ["hook-a"]
+        state.isContinueConfirmationPresented = true
+        state.actionErrorMessage = "stale"
+
+        state.synchronize(interactionID: UUID())
+
+        XCTAssertTrue(state.selectedHookKeys.isEmpty)
+        XCTAssertFalse(state.isContinueConfirmationPresented)
+        XCTAssertNil(state.actionErrorMessage)
+    }
+
+    func testLiveStrictModeToggleHidesAndShowsContinueAndDismissesConfirmation() {
+        var state = CodexHookReviewCardState(interactionID: UUID())
+        var isStrictModeEnabled = false
+        XCTAssertTrue(!isStrictModeEnabled)
+        state.isContinueConfirmationPresented = true
+
+        isStrictModeEnabled = true
+        state.strictModeDidChange(isEnabled: isStrictModeEnabled)
+
+        XCTAssertFalse(!isStrictModeEnabled)
+        XCTAssertFalse(state.isContinueConfirmationPresented)
+
+        isStrictModeEnabled = false
+        state.strictModeDidChange(isEnabled: isStrictModeEnabled)
+
+        XCTAssertTrue(!isStrictModeEnabled)
+    }
+}

--- a/Tests/RepoPromptTests/Helpers/AgentRunMCPControlledSessionContext.swift
+++ b/Tests/RepoPromptTests/Helpers/AgentRunMCPControlledSessionContext.swift
@@ -1,0 +1,101 @@
+import Foundation
+import MCP
+@testable import RepoPromptApp
+
+@MainActor
+final class AgentRunMCPControlledSessionContext {
+    let window: WindowState
+    let sessionID: UUID
+    let session: AgentModeViewModel.TabSession
+    let service: AgentRunMCPToolService
+
+    private init(
+        window: WindowState,
+        sessionID: UUID,
+        session: AgentModeViewModel.TabSession,
+        service: AgentRunMCPToolService
+    ) {
+        self.window = window
+        self.sessionID = sessionID
+        self.session = session
+        self.service = service
+    }
+
+    static func make(
+        workspaceNamePrefix: String,
+        workspaceSwitchReason: String,
+        clientName: String,
+        unusedStartRunMessage: String
+    ) async throws -> AgentRunMCPControlledSessionContext {
+        let settings = GlobalSettingsStore.shared
+        let previousAutoStart = settings.mcpAutoStart()
+        settings.setMCPAutoStart(false, commit: false)
+        defer { settings.setMCPAutoStart(previousAutoStart, commit: false) }
+
+        let window = WindowState()
+        WindowStatesManager.shared.registerWindowState(window)
+        do {
+            let workspace = window.workspaceManager.createWorkspace(
+                name: "\(workspaceNamePrefix) \(UUID().uuidString.prefix(8))",
+                repoPaths: [FileManager.default.currentDirectoryPath],
+                ephemeral: true
+            )
+            await window.workspaceManager.switchWorkspace(
+                to: workspace,
+                saveState: false,
+                reason: workspaceSwitchReason
+            )
+            guard let activeWorkspace = window.workspaceManager.activeWorkspace else {
+                throw MCPError.internalError("Expected active ephemeral workspace")
+            }
+            window.promptManager.loadComposeTabsFromWorkspace(activeWorkspace, syncPromptText: true)
+
+            let sessionID = UUID()
+            let session = await window.agentModeViewModel.ensureSessionReady(tabID: UUID())
+            _ = window.agentModeViewModel.test_installPersistentSessionBinding(sessionID: sessionID, on: session)
+            try await window.agentModeViewModel.mcpActivateControlContext(
+                forTabID: session.tabID,
+                sessionID: sessionID,
+                originatingConnectionID: nil,
+                startPending: true
+            )
+
+            let windowID = window.windowID
+            let service = AgentRunMCPToolService(
+                toolName: MCPWindowToolName.agentRun,
+                captureRequestMetadata: {
+                    MCPServerViewModel.RequestMetadata(
+                        connectionID: UUID(),
+                        clientName: clientName,
+                        windowID: windowID
+                    )
+                },
+                requireTargetWindow: { window },
+                resolveRequestedTabID: { _ in nil },
+                resolveSpawnParentSourceTabID: { _ in nil },
+                resolveSpawnParentSessionID: { _, _ in nil },
+                withHeartbeat: { _, _, _, _, operation in try await operation() },
+                startRun: { _, _, _, _, _, _, _, _, _, _, _ in
+                    throw MCPError.internalError(unusedStartRunMessage)
+                }
+            )
+            return AgentRunMCPControlledSessionContext(
+                window: window,
+                sessionID: sessionID,
+                session: session,
+                service: service
+            )
+        } catch {
+            window.beginClose()
+            await window.tearDown()
+            WindowStatesManager.shared.unregisterWindowState(window)
+            throw error
+        }
+    }
+
+    func cleanup() async {
+        window.beginClose()
+        await window.tearDown()
+        WindowStatesManager.shared.unregisterWindowState(window)
+    }
+}

--- a/Tests/RepoPromptTests/Helpers/CodexHookReviewTestSupport.swift
+++ b/Tests/RepoPromptTests/Helpers/CodexHookReviewTestSupport.swift
@@ -1,0 +1,22 @@
+import Foundation
+@testable import RepoPromptApp
+import XCTest
+
+@MainActor
+func waitForPendingCodexHookReview(
+    in session: AgentModeViewModel.TabSession,
+    timeout: TimeInterval = 2,
+    diagnostic: @autoclosure () -> String
+) async throws -> AgentCodexHookReviewRequest {
+    let deadline = Date().addingTimeInterval(timeout)
+    while Date() < deadline {
+        if let request = session.pendingCodexHookReview,
+           session.codexHookReviewContinuation != nil
+        {
+            return request
+        }
+        try await Task.sleep(nanoseconds: 10_000_000)
+    }
+    XCTFail(diagnostic())
+    throw CancellationError()
+}

--- a/Tests/RepoPromptTests/Helpers/CodexSessionControllerTestDefaults.swift
+++ b/Tests/RepoPromptTests/Helpers/CodexSessionControllerTestDefaults.swift
@@ -4,6 +4,10 @@ import Foundation
 protocol CodexSessionControllerTurnDispatchTestDefaults: CodexSessionControlling {}
 
 extension CodexSessionControllerTurnDispatchTestDefaults {
+    func listHooksForCurrentWorkspace() async throws -> CodexHookInventory {
+        try CodexHookInventory(executionCWD: "/tmp", hooks: [])
+    }
+
     func startUserTurn(
         text _: String,
         images _: [AgentImageAttachment],

--- a/Tests/RepoPromptTests/MCP/AgentRunMCPToolServiceHookApprovalTests.swift
+++ b/Tests/RepoPromptTests/MCP/AgentRunMCPToolServiceHookApprovalTests.swift
@@ -88,6 +88,29 @@ final class AgentRunMCPToolServiceHookApprovalTests: XCTestCase {
         }
     }
 
+    func testStrictModeRejectsApproveSelectedSubsetWithoutMutation() async throws {
+        let fixture = try await HookApprovalMCPFixture.make()
+        addTeardownBlock { @MainActor in await fixture.cleanup() }
+        let secondHookKey = "SECOND_PRIVATE_HOOK_KEY"
+        let request = try fixture.installReview(
+            phase: .reviewRequired,
+            hookKeys: [HookApprovalMCPFixture.hookKey, secondHookKey]
+        )
+        fixture.setStrictMode(true)
+
+        let message = await fixture.invalidRespondMessage(
+            requestID: request.id,
+            payload: [
+                "response": .string("approve_selected"),
+                "answers": .object(["hook_keys": .array([.string(HookApprovalMCPFixture.hookKey)])])
+            ]
+        )
+
+        XCTAssertTrue(message.localizedCaseInsensitiveContains("strict mode"), message)
+        XCTAssertEqual(fixture.session.pendingCodexHookReview?.id, request.id)
+        XCTAssertTrue(fixture.controller.trustCalls.isEmpty)
+    }
+
     func testDiscoveryRetryToZeroSurfacesResolvedExternallyAudit() async throws {
         let fixture = try await HookApprovalMCPFixture.make()
         addTeardownBlock { @MainActor in await fixture.cleanup() }
@@ -387,14 +410,17 @@ private final class HookApprovalMCPFixture {
     }
 
     @discardableResult
-    func installReview(phase: AgentCodexHookReviewRequest.Phase) throws -> AgentCodexHookReviewRequest {
+    func installReview(
+        phase: AgentCodexHookReviewRequest.Phase,
+        hookKeys: [String] = [HookApprovalMCPFixture.hookKey]
+    ) throws -> AgentCodexHookReviewRequest {
         let hooks: [AgentCodexHookReviewHook]
         let fingerprint: String?
         if phase == .discoveryFailed || phase == .discovering {
             hooks = []
             fingerprint = nil
         } else {
-            let inventory = try unresolvedInventory()
+            let inventory = try unresolvedInventory(hookKeys: hookKeys)
             hooks = inventory.unresolvedProjectHooks.map(AgentCodexHookReviewHook.init)
             fingerprint = inventory.fingerprint
         }
@@ -465,8 +491,19 @@ private final class HookApprovalMCPFixture {
         }
     }
 
-    func unresolvedInventory() throws -> CodexHookInventory {
-        try CodexHookInventory(executionCWD: "/repo", hooks: [hook(status: .untrusted)])
+    func unresolvedInventory(
+        hookKeys: [String] = [HookApprovalMCPFixture.hookKey]
+    ) throws -> CodexHookInventory {
+        try CodexHookInventory(
+            executionCWD: "/repo",
+            hooks: hookKeys.map { key in
+                try hook(
+                    key: key,
+                    currentHash: key == Self.hookKey ? Self.currentHash : "hash-\(key)",
+                    status: .untrusted
+                )
+            }
+        )
     }
 
     func trustedInventory() throws -> CodexHookInventory {
@@ -478,13 +515,17 @@ private final class HookApprovalMCPFixture {
         await context.cleanup()
     }
 
-    private func hook(status: CodexHookTrustStatus) throws -> CodexHookMetadata {
+    private func hook(
+        key: String = HookApprovalMCPFixture.hookKey,
+        currentHash: String = HookApprovalMCPFixture.currentHash,
+        status: CodexHookTrustStatus
+    ) throws -> CodexHookMetadata {
         try CodexHookMetadata(
             eventName: "PreToolUse",
             source: "project",
             sourcePath: Self.sourcePath,
-            key: Self.hookKey,
-            currentHash: Self.currentHash,
+            key: key,
+            currentHash: currentHash,
             enabled: true,
             handlerType: "command",
             trustStatus: status,

--- a/Tests/RepoPromptTests/MCP/AgentRunMCPToolServiceHookApprovalTests.swift
+++ b/Tests/RepoPromptTests/MCP/AgentRunMCPToolServiceHookApprovalTests.swift
@@ -39,6 +39,64 @@ final class AgentRunMCPToolServiceHookApprovalTests: XCTestCase {
         }
     }
 
+    func testSnapshotRoundTripAcceptsSerializedNullOptionalInteractionFields() async throws {
+        let fixture = try await HookApprovalMCPFixture.make()
+        addTeardownBlock { @MainActor in await fixture.cleanup() }
+        let value = try await fixture.service.execute(args: [
+            "op": .string("poll"),
+            "session_id": .string(fixture.sessionID.uuidString)
+        ])
+        var snapshotObject = try XCTUnwrap(value.objectValue)
+        let interactionID = UUID()
+        let interaction = AgentRunMCPSnapshot.Interaction(
+            id: interactionID,
+            kind: .question,
+            responseType: .structured,
+            title: nil,
+            prompt: nil,
+            context: nil,
+            allowsMultiple: nil,
+            options: [.init(label: "Continue", description: nil)],
+            fields: [.init(
+                id: "choice",
+                header: nil,
+                prompt: "Choose",
+                context: nil,
+                isSecret: false,
+                allowsOther: false,
+                allowsMultiple: nil,
+                allowsCustom: nil,
+                options: [.init(label: "Field option", description: nil)]
+            )],
+            details: []
+        )
+        var serializedInteraction = interaction.asObject()
+        serializedInteraction["context"] = .null
+        serializedInteraction["allows_multiple"] = .null
+        var serializedField = try XCTUnwrap(
+            serializedInteraction["fields"]?.arrayValue?.first?.objectValue
+        )
+        serializedField["context"] = .null
+        serializedField["allows_multiple"] = .null
+        serializedField["allows_custom"] = .null
+        serializedInteraction["fields"] = .array([.object(serializedField)])
+        snapshotObject["interaction"] = .object(serializedInteraction)
+
+        let decoded = try fixture.service.test_decodeSnapshot(from: .object(snapshotObject))
+        let decodedInteraction = try XCTUnwrap(decoded.interaction)
+        XCTAssertEqual(decodedInteraction.id, interactionID)
+        XCTAssertNil(decodedInteraction.title)
+        XCTAssertNil(decodedInteraction.prompt)
+        XCTAssertNil(decodedInteraction.context)
+        XCTAssertNil(decodedInteraction.allowsMultiple)
+        XCTAssertNil(decodedInteraction.options.first?.description)
+        XCTAssertNil(decodedInteraction.fields.first?.header)
+        XCTAssertNil(decodedInteraction.fields.first?.context)
+        XCTAssertNil(decodedInteraction.fields.first?.allowsMultiple)
+        XCTAssertNil(decodedInteraction.fields.first?.allowsCustom)
+        XCTAssertNil(decodedInteraction.fields.first?.options.first?.description)
+    }
+
     func testAllPhasesMapOptionsAndStrictModeFiltersLive() async throws {
         let fixture = try await HookApprovalMCPFixture.make()
         addTeardownBlock { @MainActor in await fixture.cleanup() }
@@ -253,11 +311,37 @@ final class AgentRunMCPToolServiceHookApprovalTests: XCTestCase {
         var object = try XCTUnwrap(value.objectValue)
 
         object["interaction"] = .object([:])
-        XCTAssertNil(fixture.service.test_decodeSnapshot(from: .object(object)))
+        XCTAssertThrowsError(try fixture.service.test_decodeSnapshot(from: .object(object))) { error in
+            self.assertInternalMCPError(error)
+        }
 
         object = try XCTUnwrap(value.objectValue)
         object["hook_gate"] = .string("malformed")
-        XCTAssertNil(fixture.service.test_decodeSnapshot(from: .object(object)))
+        XCTAssertThrowsError(try fixture.service.test_decodeSnapshot(from: .object(object))) { error in
+            self.assertInternalMCPError(error)
+        }
+
+        object = try XCTUnwrap(value.objectValue)
+        var interaction = try XCTUnwrap(object["interaction"]?.objectValue)
+        interaction["fields"] = .array([
+            .object(["id": .string("hook_keys")])
+        ])
+        object["interaction"] = .object(interaction)
+        XCTAssertThrowsError(try fixture.service.test_decodeSnapshot(from: .object(object))) { error in
+            self.assertInternalMCPError(error)
+        }
+
+        object = try XCTUnwrap(value.objectValue)
+        object["worktree_bindings"] = .array([.object([:])])
+        XCTAssertThrowsError(try fixture.service.test_decodeSnapshot(from: .object(object))) { error in
+            self.assertInternalMCPError(error)
+        }
+
+        object = try XCTUnwrap(value.objectValue)
+        object["active_worktree_merges"] = .array([.object([:])])
+        XCTAssertThrowsError(try fixture.service.test_decodeSnapshot(from: .object(object))) { error in
+            self.assertInternalMCPError(error)
+        }
     }
 
     func testHookGateCountsDecodeFailClosedAndAbsentSkippedMeansUnknown() async throws {
@@ -276,18 +360,22 @@ final class AgentRunMCPToolServiceHookApprovalTests: XCTestCase {
         ).asObject()
 
         object["hook_gate"] = .object(validHookGate)
-        let decoded = try XCTUnwrap(fixture.service.test_decodeSnapshot(from: .object(object)))
+        let decoded = try fixture.service.test_decodeSnapshot(from: .object(object))
         XCTAssertNil(decoded.hookGate?.skippedHookCount)
 
         var missingApprovedCount = validHookGate
         missingApprovedCount.removeValue(forKey: "approved_hook_count")
         object["hook_gate"] = .object(missingApprovedCount)
-        XCTAssertNil(fixture.service.test_decodeSnapshot(from: .object(object)))
+        XCTAssertThrowsError(try fixture.service.test_decodeSnapshot(from: .object(object))) { error in
+            self.assertInternalMCPError(error)
+        }
 
         var malformedSkippedCount = validHookGate
         malformedSkippedCount["skipped_hook_count"] = .string("unknown")
         object["hook_gate"] = .object(malformedSkippedCount)
-        XCTAssertNil(fixture.service.test_decodeSnapshot(from: .object(object)))
+        XCTAssertThrowsError(try fixture.service.test_decodeSnapshot(from: .object(object))) { error in
+            self.assertInternalMCPError(error)
+        }
     }
 
     func testConcurrentAndDuplicateResponsesDoNotDoubleMutate() async throws {
@@ -343,6 +431,20 @@ final class AgentRunMCPToolServiceHookApprovalTests: XCTestCase {
             )
             XCTAssertTrue(message.localizedCaseInsensitiveContains("already in progress"), message)
             XCTAssertEqual(fixture.session.pendingCodexHookReview?.id, request.id)
+        }
+    }
+
+    private func assertInternalMCPError(
+        _ error: Error,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        guard let mcpError = error as? MCPError else {
+            return XCTFail("Expected MCPError.internalError, got \(error)", file: file, line: line)
+        }
+        XCTAssertEqual(mcpError.code, -32603, file: file, line: line)
+        guard case .internalError = mcpError else {
+            return XCTFail("Expected MCPError.internalError, got code \(mcpError.code)", file: file, line: line)
         }
     }
 }
@@ -484,7 +586,12 @@ private final class HookApprovalMCPFixture {
             XCTFail("Expected invalid params")
             return ""
         } catch let error as MCPError {
-            return String(describing: error)
+            XCTAssertEqual(error.code, -32602)
+            guard case let .invalidParams(message) = error else {
+                XCTFail("Expected MCPError.invalidParams, got code \(error.code)")
+                return ""
+            }
+            return message ?? ""
         } catch {
             XCTFail("Expected MCPError.invalidParams, got \(error)")
             return ""

--- a/Tests/RepoPromptTests/MCP/AgentRunMCPToolServiceHookApprovalTests.swift
+++ b/Tests/RepoPromptTests/MCP/AgentRunMCPToolServiceHookApprovalTests.swift
@@ -1,0 +1,556 @@
+import Foundation
+import MCP
+@_spi(TestSupport) @testable import RepoPromptApp
+import XCTest
+
+@MainActor
+final class AgentRunMCPToolServiceHookApprovalTests: XCTestCase {
+    func testWaitRoundTripPreservesHookApprovalFieldCapabilitiesAndMetadata() async throws {
+        let fixture = try await HookApprovalMCPFixture.make()
+        addTeardownBlock { @MainActor in await fixture.cleanup() }
+        let request = try fixture.installReview(phase: .reviewRequired)
+
+        let value = try await fixture.service.execute(args: [
+            "op": .string("wait"),
+            "session_id": .string(fixture.sessionID.uuidString),
+            "timeout": .int(1)
+        ])
+        let object = try XCTUnwrap(value.objectValue)
+        let interaction = try XCTUnwrap(object["interaction"]?.objectValue)
+        XCTAssertEqual(interaction["id"]?.stringValue, request.id.uuidString)
+        XCTAssertEqual(interaction["kind"]?.stringValue, "hook_approval")
+        XCTAssertEqual(interaction["response_type"]?.stringValue, "decision")
+
+        let field = try XCTUnwrap(interaction["fields"]?.arrayValue?.first?.objectValue)
+        XCTAssertEqual(field["id"]?.stringValue, "hook_keys")
+        XCTAssertEqual(field["allows_multiple"]?.boolValue, true)
+        XCTAssertEqual(field["allows_custom"]?.boolValue, false)
+        XCTAssertNil(field["allows_other"])
+        XCTAssertEqual(field["options"]?.arrayValue?.first?.objectValue?["label"]?.stringValue, HookApprovalMCPFixture.hookKey)
+
+        let serialized = String(describing: interaction)
+        for expected in [
+            HookApprovalMCPFixture.hookKey,
+            HookApprovalMCPFixture.sourcePath,
+            HookApprovalMCPFixture.currentHash,
+            HookApprovalMCPFixture.command
+        ] {
+            XCTAssertTrue(serialized.contains(expected), expected)
+        }
+    }
+
+    func testAllPhasesMapOptionsAndStrictModeFiltersLive() async throws {
+        let fixture = try await HookApprovalMCPFixture.make()
+        addTeardownBlock { @MainActor in await fixture.cleanup() }
+
+        let cases: [(AgentCodexHookReviewRequest.Phase, [String])] = [
+            (.reviewRequired, ["approve_selected", "trust_all", "continue_without_hooks"]),
+            (.writeFailed, ["approve_selected", "trust_all", "continue_without_hooks"]),
+            (.verificationFailed, ["approve_selected", "trust_all", "continue_without_hooks"]),
+            (.discoveryFailed, ["retry", "continue_without_hooks"]),
+            (.discovering, []),
+            (.submitting, [])
+        ]
+        for (phase, expected) in cases {
+            _ = try fixture.installReview(phase: phase)
+            XCTAssertEqual(fixture.interactionOptions(), expected, phase.rawValue)
+        }
+
+        _ = try fixture.installReview(phase: .reviewRequired)
+        fixture.setStrictMode(true)
+        XCTAssertEqual(fixture.interactionOptions(), ["approve_selected", "trust_all"])
+        _ = try fixture.installReview(phase: .discoveryFailed)
+        XCTAssertEqual(fixture.interactionOptions(), ["retry"])
+    }
+
+    func testApproveSelectedCanonicalResponseSurfacesSanitizedOutcomeAudit() async throws {
+        let fixture = try await HookApprovalMCPFixture.make()
+        addTeardownBlock { @MainActor in await fixture.cleanup() }
+        let request = try fixture.installReview(phase: .reviewRequired)
+        let trustedInventory = try fixture.trustedInventory()
+        fixture.controller.trustResults = [.success(trustedInventory)]
+
+        let value = try await fixture.respond(
+            requestID: request.id,
+            response: "approve_selected",
+            answers: ["hook_keys": [.string(HookApprovalMCPFixture.hookKey)]]
+        )
+
+        XCTAssertNil(fixture.session.pendingCodexHookReview)
+        XCTAssertEqual(fixture.controller.trustCalls.first?.candidates.map(\.key), [HookApprovalMCPFixture.hookKey])
+        let hookGate = try XCTUnwrap(value.objectValue?["hook_gate"]?.objectValue)
+        XCTAssertEqual(hookGate["status"]?.stringValue, "approved_selected")
+        XCTAssertEqual(hookGate["approved_hook_count"]?.intValue, 1)
+        XCTAssertEqual(hookGate["skipped_hook_count"]?.intValue, 0)
+        let serializedAudit = String(describing: hookGate)
+        for privateValue in HookApprovalMCPFixture.privateMetadata {
+            XCTAssertFalse(serializedAudit.contains(privateValue), privateValue)
+        }
+    }
+
+    func testDiscoveryRetryToZeroSurfacesResolvedExternallyAudit() async throws {
+        let fixture = try await HookApprovalMCPFixture.make()
+        addTeardownBlock { @MainActor in await fixture.cleanup() }
+        let request = try fixture.installReview(phase: .discoveryFailed)
+        let emptyInventory = try CodexHookInventory(executionCWD: "/repo", hooks: [])
+        fixture.controller.listResults = [.success(emptyInventory)]
+
+        let value = try await fixture.respond(requestID: request.id, response: "retry")
+
+        XCTAssertNil(fixture.session.pendingCodexHookReview)
+        let hookGate = try XCTUnwrap(value.objectValue?["hook_gate"]?.objectValue)
+        XCTAssertEqual(hookGate["status"]?.stringValue, "resolved_externally")
+        XCTAssertEqual(hookGate["approved_hook_count"]?.intValue, 0)
+        XCTAssertEqual(hookGate["skipped_hook_count"]?.intValue, 0)
+    }
+
+    func testDiscoveryFailureContinueWithoutHooksSurfacesBypassAudit() async throws {
+        let fixture = try await HookApprovalMCPFixture.make()
+        addTeardownBlock { @MainActor in await fixture.cleanup() }
+        let request = try fixture.installReview(phase: .discoveryFailed)
+
+        let value = try await fixture.respond(requestID: request.id, response: "continue_without_hooks")
+
+        XCTAssertNil(fixture.session.pendingCodexHookReview)
+        let hookGate = try XCTUnwrap(value.objectValue?["hook_gate"]?.objectValue)
+        XCTAssertEqual(hookGate["status"]?.stringValue, "continued_without_hooks")
+        XCTAssertEqual(hookGate["approved_hook_count"]?.intValue, 0)
+        XCTAssertNil(hookGate["skipped_hook_count"])
+        XCTAssertTrue(fixture.session.items.contains { item in
+            item.kind == .system && item.text.contains("unknown number of Codex project hooks")
+        })
+    }
+
+    func testDiscoveryFailureRejectsApprovalDecisionsWithoutMutation() async throws {
+        let fixture = try await HookApprovalMCPFixture.make()
+        addTeardownBlock { @MainActor in await fixture.cleanup() }
+        let request = try fixture.installReview(phase: .discoveryFailed)
+
+        for response in ["approve_selected", "trust_all"] {
+            let message = await fixture.invalidRespondMessage(
+                requestID: request.id,
+                payload: ["response": .string(response)]
+            )
+            XCTAssertTrue(message.localizedCaseInsensitiveContains("not available"), response)
+            XCTAssertEqual(fixture.session.pendingCodexHookReview?.id, request.id, response)
+            XCTAssertTrue(fixture.controller.trustCalls.isEmpty, response)
+        }
+    }
+
+    func testCanonicalValidationRejectsAliasesPayloadsAndInvalidSelectionsWithoutMutation() async throws {
+        let fixture = try await HookApprovalMCPFixture.make()
+        addTeardownBlock { @MainActor in await fixture.cleanup() }
+        let request = try fixture.installReview(phase: .reviewRequired)
+        let cases: [(String, [String: Value])] = [
+            ("alias", ["response": .string("approve")]),
+            ("decision", ["response": .string("trust_all"), "decision": .string("trust_all")]),
+            ("skip", ["response": .string("trust_all"), "skip": .bool(false)]),
+            ("amendment", ["response": .string("trust_all"), "amendment": .string("")]),
+            ("content", ["response": .string("trust_all"), "content": .object([:])]),
+            ("meta", ["response": .string("trust_all"), "_meta": .object([:])]),
+            ("unknown top-level field", ["response": .string("trust_all"), "unexpected": .array([])]),
+            (
+                "structured answers",
+                [
+                    "response": .string("approve_selected"),
+                    "answers": .object(["hook_keys": .object(["answers": .array([.string(HookApprovalMCPFixture.hookKey)])])])
+                ]
+            ),
+            (
+                "scalar hook keys",
+                [
+                    "response": .string("approve_selected"),
+                    "answers": .object(["hook_keys": .string(HookApprovalMCPFixture.hookKey)])
+                ]
+            ),
+            (
+                "empty hook keys",
+                [
+                    "response": .string("approve_selected"),
+                    "answers": .object(["hook_keys": .array([])])
+                ]
+            ),
+            (
+                "empty answers object",
+                [
+                    "response": .string("trust_all"),
+                    "answers": .object([:])
+                ]
+            ),
+            (
+                "unknown empty answer field",
+                [
+                    "response": .string("trust_all"),
+                    "answers": .object(["unexpected": .array([])])
+                ]
+            ),
+            (
+                "approve selected unknown empty answer field",
+                [
+                    "response": .string("approve_selected"),
+                    "answers": .object(["unexpected": .array([])])
+                ]
+            ),
+            (
+                "duplicate keys",
+                [
+                    "response": .string("approve_selected"),
+                    "answers": .object([
+                        "hook_keys": .array([
+                            .string(HookApprovalMCPFixture.hookKey),
+                            .string(HookApprovalMCPFixture.hookKey)
+                        ])
+                    ])
+                ]
+            ),
+            (
+                "unknown key",
+                [
+                    "response": .string("approve_selected"),
+                    "answers": .object(["hook_keys": .array([.string("UNKNOWN_PRIVATE_KEY")])])
+                ]
+            )
+        ]
+
+        for (label, payload) in cases {
+            await fixture.assertInvalidRespond(requestID: request.id, payload: payload, label: label)
+            XCTAssertEqual(fixture.session.pendingCodexHookReview?.id, request.id, label)
+            XCTAssertTrue(fixture.controller.trustCalls.isEmpty, label)
+        }
+    }
+
+    func testMalformedNestedSnapshotSectionsFailAtomically() async throws {
+        let fixture = try await HookApprovalMCPFixture.make()
+        addTeardownBlock { @MainActor in await fixture.cleanup() }
+        _ = try fixture.installReview(phase: .reviewRequired)
+        let value = try await fixture.service.execute(args: [
+            "op": .string("poll"),
+            "session_id": .string(fixture.sessionID.uuidString)
+        ])
+        var object = try XCTUnwrap(value.objectValue)
+
+        object["interaction"] = .object([:])
+        XCTAssertNil(fixture.service.test_decodeSnapshot(from: .object(object)))
+
+        object = try XCTUnwrap(value.objectValue)
+        object["hook_gate"] = .string("malformed")
+        XCTAssertNil(fixture.service.test_decodeSnapshot(from: .object(object)))
+    }
+
+    func testHookGateCountsDecodeFailClosedAndAbsentSkippedMeansUnknown() async throws {
+        let fixture = try await HookApprovalMCPFixture.make()
+        addTeardownBlock { @MainActor in await fixture.cleanup() }
+        let value = try await fixture.service.execute(args: [
+            "op": .string("poll"),
+            "session_id": .string(fixture.sessionID.uuidString)
+        ])
+        var object = try XCTUnwrap(value.objectValue)
+        let validHookGate = AgentRunMCPSnapshot.HookGate(
+            status: .continuedWithoutHooks,
+            approvedHookCount: 0,
+            skippedHookCount: nil,
+            resolvedAt: Date()
+        ).asObject()
+
+        object["hook_gate"] = .object(validHookGate)
+        let decoded = try XCTUnwrap(fixture.service.test_decodeSnapshot(from: .object(object)))
+        XCTAssertNil(decoded.hookGate?.skippedHookCount)
+
+        var missingApprovedCount = validHookGate
+        missingApprovedCount.removeValue(forKey: "approved_hook_count")
+        object["hook_gate"] = .object(missingApprovedCount)
+        XCTAssertNil(fixture.service.test_decodeSnapshot(from: .object(object)))
+
+        var malformedSkippedCount = validHookGate
+        malformedSkippedCount["skipped_hook_count"] = .string("unknown")
+        object["hook_gate"] = .object(malformedSkippedCount)
+        XCTAssertNil(fixture.service.test_decodeSnapshot(from: .object(object)))
+    }
+
+    func testConcurrentAndDuplicateResponsesDoNotDoubleMutate() async throws {
+        let fixture = try await HookApprovalMCPFixture.make()
+        addTeardownBlock { @MainActor in await fixture.cleanup() }
+        let request = try fixture.installReview(phase: .reviewRequired)
+        let trustedInventory = try fixture.trustedInventory()
+        fixture.controller.trustResults = [.success(trustedInventory)]
+        let gate = HookApprovalMCPAsyncGate()
+        fixture.controller.trustGate = gate
+
+        let firstResponse = Task { @MainActor in
+            try await fixture.respond(requestID: request.id, response: "trust_all")
+        }
+        await gate.waitUntilEntered()
+
+        let concurrentMessage = await fixture.invalidRespondMessage(
+            requestID: request.id,
+            payload: ["response": .string("trust_all")]
+        )
+        XCTAssertTrue(concurrentMessage.localizedCaseInsensitiveContains("already in progress"), concurrentMessage)
+
+        await gate.release()
+        _ = try await firstResponse.value
+
+        let duplicateMessage = await fixture.invalidRespondMessage(
+            requestID: request.id,
+            payload: ["response": .string("trust_all")]
+        )
+        XCTAssertTrue(duplicateMessage.localizedCaseInsensitiveContains("no pending interaction"), duplicateMessage)
+        XCTAssertEqual(fixture.controller.trustCalls.count, 1)
+    }
+
+    func testStrictContinueAndResolvingPhasesRejectWithoutMutation() async throws {
+        let fixture = try await HookApprovalMCPFixture.make()
+        addTeardownBlock { @MainActor in await fixture.cleanup() }
+
+        var request = try fixture.installReview(phase: .reviewRequired)
+        fixture.setStrictMode(true)
+        let strictMessage = await fixture.invalidRespondMessage(
+            requestID: request.id,
+            payload: ["response": .string("continue_without_hooks")]
+        )
+        XCTAssertTrue(strictMessage.localizedCaseInsensitiveContains("strict mode"), strictMessage)
+        XCTAssertEqual(fixture.session.pendingCodexHookReview?.id, request.id)
+
+        fixture.setStrictMode(false)
+        for phase in [AgentCodexHookReviewRequest.Phase.discovering, .submitting] {
+            request = try fixture.installReview(phase: phase)
+            let message = await fixture.invalidRespondMessage(
+                requestID: request.id,
+                payload: ["response": .string("trust_all")]
+            )
+            XCTAssertTrue(message.localizedCaseInsensitiveContains("already in progress"), message)
+            XCTAssertEqual(fixture.session.pendingCodexHookReview?.id, request.id)
+        }
+    }
+}
+
+@MainActor
+private final class HookApprovalMCPFixture {
+    static let hookKey = "PRIVATE_HOOK_KEY"
+    static let sourcePath = "/repo/private/.codex/config.toml"
+    static let currentHash = "PRIVATE_CURRENT_HASH"
+    static let command = "/repo/private/run-hook --secret"
+    static let privateMetadata = [hookKey, sourcePath, currentHash, command]
+
+    private let context: AgentRunMCPControlledSessionContext
+    let controller = HookApprovalMCPFakeController()
+    private let previousStrictMode: Bool
+
+    var window: WindowState {
+        context.window
+    }
+
+    var sessionID: UUID {
+        context.sessionID
+    }
+
+    var session: AgentModeViewModel.TabSession {
+        context.session
+    }
+
+    var service: AgentRunMCPToolService {
+        context.service
+    }
+
+    private init(
+        context: AgentRunMCPControlledSessionContext,
+        previousStrictMode: Bool
+    ) {
+        self.context = context
+        self.previousStrictMode = previousStrictMode
+    }
+
+    static func make() async throws -> HookApprovalMCPFixture {
+        let settings = GlobalSettingsStore.shared
+        let previousStrictMode = settings.globalCodexHookApprovalStrictModeEnabled()
+        settings.setGlobalCodexHookApprovalStrictModeEnabled(false, commit: false)
+
+        do {
+            let context = try await AgentRunMCPControlledSessionContext.make(
+                workspaceNamePrefix: "Hook Approval MCP",
+                workspaceSwitchReason: "hookApprovalMCPTests",
+                clientName: "hook-approval-mcp-tests",
+                unusedStartRunMessage: "startRun should not be used by hook approval MCP tests"
+            )
+            return HookApprovalMCPFixture(
+                context: context,
+                previousStrictMode: previousStrictMode
+            )
+        } catch {
+            settings.setGlobalCodexHookApprovalStrictModeEnabled(previousStrictMode, commit: false)
+            throw error
+        }
+    }
+
+    func setStrictMode(_ enabled: Bool) {
+        GlobalSettingsStore.shared.setGlobalCodexHookApprovalStrictModeEnabled(enabled, commit: false)
+    }
+
+    @discardableResult
+    func installReview(phase: AgentCodexHookReviewRequest.Phase) throws -> AgentCodexHookReviewRequest {
+        let hooks: [AgentCodexHookReviewHook]
+        let fingerprint: String?
+        if phase == .discoveryFailed || phase == .discovering {
+            hooks = []
+            fingerprint = nil
+        } else {
+            let inventory = try unresolvedInventory()
+            hooks = inventory.unresolvedProjectHooks.map(AgentCodexHookReviewHook.init)
+            fingerprint = inventory.fingerprint
+        }
+        session.codexController = controller
+        session.codexHookGateGeneration &+= 1
+        let request = AgentCodexHookReviewRequest(
+            tabID: session.tabID,
+            runAttemptID: session.activeRunAttemptID,
+            runID: session.runID,
+            executionCWD: "/repo",
+            hooks: hooks,
+            warnings: ["PRIVATE_WARNING"],
+            phase: phase,
+            errorMessage: phase == .discoveryFailed ? "PRIVATE_DISCOVERY_ERROR" : nil,
+            gateGeneration: session.codexHookGateGeneration
+        )
+        session.codexHookGateInventoryFingerprint = fingerprint
+        session.codexHookGateActiveBinding = .init(
+            controllerInstanceID: ObjectIdentifier(controller),
+            controllerGeneration: session.codexControllerGeneration
+        )
+        session.pendingCodexHookReview = request
+        session.codexHookGateAudit = nil
+        session.runState = .waitingForApproval
+        return request
+    }
+
+    func interactionOptions() -> [String] {
+        window.agentModeViewModel.mcpSnapshot(sessionID: sessionID)?.interaction?.options.map(\.label) ?? []
+    }
+
+    func respond(
+        requestID: UUID,
+        response: String,
+        answers: [String: [Value]] = [:]
+    ) async throws -> Value {
+        var args: [String: Value] = [
+            "op": .string("respond"),
+            "session_id": .string(sessionID.uuidString),
+            "interaction_id": .string(requestID.uuidString),
+            "response": .string(response)
+        ]
+        if !answers.isEmpty {
+            args["answers"] = .object(answers.mapValues(Value.array))
+        }
+        return try await service.execute(args: args)
+    }
+
+    func assertInvalidRespond(requestID: UUID, payload: [String: Value], label: String) async {
+        let message = await invalidRespondMessage(requestID: requestID, payload: payload)
+        XCTAssertFalse(message.isEmpty, label)
+    }
+
+    func invalidRespondMessage(requestID: UUID, payload: [String: Value]) async -> String {
+        var args = payload
+        args["op"] = .string("respond")
+        args["session_id"] = .string(sessionID.uuidString)
+        args["interaction_id"] = .string(requestID.uuidString)
+        do {
+            _ = try await service.execute(args: args)
+            XCTFail("Expected invalid params")
+            return ""
+        } catch let error as MCPError {
+            return String(describing: error)
+        } catch {
+            XCTFail("Expected MCPError.invalidParams, got \(error)")
+            return ""
+        }
+    }
+
+    func unresolvedInventory() throws -> CodexHookInventory {
+        try CodexHookInventory(executionCWD: "/repo", hooks: [hook(status: .untrusted)])
+    }
+
+    func trustedInventory() throws -> CodexHookInventory {
+        try CodexHookInventory(executionCWD: "/repo", hooks: [hook(status: .trusted)])
+    }
+
+    func cleanup() async {
+        GlobalSettingsStore.shared.setGlobalCodexHookApprovalStrictModeEnabled(previousStrictMode, commit: false)
+        await context.cleanup()
+    }
+
+    private func hook(status: CodexHookTrustStatus) throws -> CodexHookMetadata {
+        try CodexHookMetadata(
+            eventName: "PreToolUse",
+            source: "project",
+            sourcePath: Self.sourcePath,
+            key: Self.hookKey,
+            currentHash: Self.currentHash,
+            enabled: true,
+            handlerType: "command",
+            trustStatus: status,
+            commandOrHandler: Self.command
+        )
+    }
+}
+
+private final class HookApprovalMCPFakeController: CodexSessionControllerPassiveStubDefaults {
+    struct TrustCall {
+        let candidates: [CodexHookTrustCandidate]
+        let fingerprint: String
+    }
+
+    var listResults: [Result<CodexHookInventory, Error>] = []
+    var trustResults: [Result<CodexHookInventory, Error>] = []
+    private(set) var trustCalls: [TrustCall] = []
+    var trustGate: HookApprovalMCPAsyncGate?
+
+    var events: AsyncStream<CodexNativeSessionController.Event> {
+        AsyncStream { _ in }
+    }
+
+    func listHooksForCurrentWorkspace() async throws -> CodexHookInventory {
+        guard !listResults.isEmpty else {
+            throw CodexHookTrustError.malformedListResponse
+        }
+        return try listResults.removeFirst().get()
+    }
+
+    func trustHooksForCurrentWorkspace(
+        expectedCandidates: [CodexHookTrustCandidate],
+        expectedInventoryFingerprint: String
+    ) async throws -> CodexHookInventory {
+        trustCalls.append(.init(candidates: expectedCandidates, fingerprint: expectedInventoryFingerprint))
+        if let trustGate {
+            await trustGate.wait()
+        }
+        guard !trustResults.isEmpty else {
+            throw CodexHookTrustError.batchWriteFailed
+        }
+        return try trustResults.removeFirst().get()
+    }
+
+    func shutdown() async {}
+}
+
+private actor HookApprovalMCPAsyncGate {
+    private var entered = false
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    func wait() async {
+        entered = true
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func waitUntilEntered() async {
+        while !entered {
+            await Task.yield()
+        }
+    }
+
+    func release() {
+        continuation?.resume()
+        continuation = nil
+    }
+}

--- a/Tests/RepoPromptTests/MCP/AgentRunMCPToolServiceRespondDiagnosticsTests.swift
+++ b/Tests/RepoPromptTests/MCP/AgentRunMCPToolServiceRespondDiagnosticsTests.swift
@@ -121,6 +121,34 @@ final class AgentRunMCPToolServiceRespondDiagnosticsTests: XCTestCase {
         }
     }
 
+    func testHookApprovalStaleInteractionDiagnosticDoesNotLeakMetadata() async throws {
+        let fixture = try await ControlledApprovalSessionFixture.make()
+        addTeardownBlock { @MainActor in await fixture.cleanup() }
+        let currentInteractionID = try fixture.installHookApprovalPrivacySentinels()
+        let staleInteractionID = UUID()
+        let pendingReview = try XCTUnwrap(fixture.session.pendingCodexHookReview)
+        let expectedMessage = "interaction_id \"\(staleInteractionID.uuidString)\" does not match the current pending hook_approval interaction_id \"\(currentInteractionID.uuidString)\". No response was applied. Call agent_run with op=\"poll\" or op=\"wait\" and session_id=\"\(fixture.sessionID.uuidString)\" to fetch the latest snapshot before responding."
+
+        await assertInvalidParams(
+            service: fixture.service,
+            sessionID: fixture.sessionID,
+            interactionID: staleInteractionID,
+            arguments: ["response": .string("approve_selected")],
+            expectedMessage: expectedMessage,
+            label: "hook approval stale identity"
+        )
+        XCTAssertEqual(fixture.session.pendingCodexHookReview, pendingReview)
+        for sentinel in [
+            "HOOK_KEY_SENTINEL",
+            "HOOK_PATH_SENTINEL",
+            "HOOK_HASH_SENTINEL",
+            "HOOK_COMMAND_SENTINEL",
+            "HOOK_ERROR_SENTINEL"
+        ] {
+            XCTAssertFalse(expectedMessage.contains(sentinel), sentinel)
+        }
+    }
+
     private func assertInvalidParams(
         service: AgentRunMCPToolService,
         sessionID: UUID,
@@ -152,83 +180,48 @@ final class AgentRunMCPToolServiceRespondDiagnosticsTests: XCTestCase {
             "ELICITATION_SENTINEL", "ASSISTANT_SENTINEL", "RESPONSE_SENTINEL", "WORKTREE_SENTINEL"
         ]
 
-        let window: WindowState
-        let sessionID: UUID
-        let session: AgentModeViewModel.TabSession
-        let service: AgentRunMCPToolService
+        private let context: AgentRunMCPControlledSessionContext
 
-        private init(window: WindowState, sessionID: UUID, session: AgentModeViewModel.TabSession) {
-            self.window = window
-            self.sessionID = sessionID
-            self.session = session
-            let windowID = window.windowID
-            service = AgentRunMCPToolService(
-                toolName: MCPWindowToolName.agentRun,
-                captureRequestMetadata: {
-                    MCPServerViewModel.RequestMetadata(
-                        connectionID: UUID(),
-                        clientName: "agent-run-respond-diagnostics-tests",
-                        windowID: windowID
-                    )
-                },
-                requireTargetWindow: { window },
-                resolveRequestedTabID: { _ in nil },
-                resolveSpawnParentSourceTabID: { _ in nil },
-                resolveSpawnParentSessionID: { _, _ in nil },
-                withHeartbeat: { _, _, _, _, operation in try await operation() },
-                startRun: { _, _, _, _, _, _, _, _, _, _, _ in
-                    throw MCPError.internalError("startRun should not be used by respond diagnostics tests")
-                }
-            )
+        var window: WindowState {
+            context.window
+        }
+
+        var sessionID: UUID {
+            context.sessionID
+        }
+
+        var session: AgentModeViewModel.TabSession {
+            context.session
+        }
+
+        var service: AgentRunMCPToolService {
+            context.service
+        }
+
+        private init(context: AgentRunMCPControlledSessionContext) {
+            self.context = context
         }
 
         static func make() async throws -> ControlledApprovalSessionFixture {
-            let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
-            GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
-            defer { GlobalSettingsStore.shared.setMCPAutoStart(previousAutoStart, commit: false) }
-
-            let window = WindowState()
-            WindowStatesManager.shared.registerWindowState(window)
-            do {
-                let workspace = window.workspaceManager.createWorkspace(
-                    name: "Respond Diagnostics \(UUID().uuidString.prefix(8))",
-                    repoPaths: [FileManager.default.currentDirectoryPath],
-                    ephemeral: true
-                )
-                await window.workspaceManager.switchWorkspace(
-                    to: workspace,
-                    saveState: false,
-                    reason: "agentRunRespondDiagnosticsTests"
-                )
-                guard let activeWorkspace = window.workspaceManager.activeWorkspace else {
-                    throw MCPError.internalError("Expected active ephemeral workspace")
-                }
-                window.promptManager.loadComposeTabsFromWorkspace(activeWorkspace, syncPromptText: true)
-
-                let sessionID = UUID()
-                let session = await window.agentModeViewModel.ensureSessionReady(tabID: UUID())
-                _ = window.agentModeViewModel.test_installPersistentSessionBinding(sessionID: sessionID, on: session)
-                try await window.agentModeViewModel.mcpActivateControlContext(
-                    forTabID: session.tabID,
-                    sessionID: sessionID,
-                    originatingConnectionID: nil,
-                    startPending: true
-                )
-                session.runState = .waitingForApproval
-                return ControlledApprovalSessionFixture(window: window, sessionID: sessionID, session: session)
-            } catch {
-                window.beginClose()
-                await window.tearDown()
-                WindowStatesManager.shared.unregisterWindowState(window)
-                throw error
-            }
+            let context = try await AgentRunMCPControlledSessionContext.make(
+                workspaceNamePrefix: "Respond Diagnostics",
+                workspaceSwitchReason: "agentRunRespondDiagnosticsTests",
+                clientName: "agent-run-respond-diagnostics-tests",
+                unusedStartRunMessage: "startRun should not be used by respond diagnostics tests"
+            )
+            context.session.runState = .waitingForApproval
+            return ControlledApprovalSessionFixture(context: context)
         }
 
         var currentPendingInteractionID: UUID? {
-            session.pendingWorktreeMergeReview?.id ?? session.pendingPermissionsRequest?.id ?? session.pendingApproval?.id
+            session.pendingCodexHookReview?.id
+                ?? session.pendingWorktreeMergeReview?.id
+                ?? session.pendingPermissionsRequest?.id
+                ?? session.pendingApproval?.id
         }
 
         func clearPendingApprovals() {
+            session.pendingCodexHookReview = nil
             session.pendingWorktreeMergeReview = nil
             session.pendingPermissionsRequest = nil
             session.pendingApproval = nil
@@ -253,6 +246,32 @@ final class AgentRunMCPToolServiceRespondDiagnosticsTests: XCTestCase {
                 details: privacySentinels ? [.init(label: "OPTION_SENTINEL", value: "RESPONSE_SENTINEL")] : []
             )
             return id
+        }
+
+        func installHookApprovalPrivacySentinels() throws -> UUID {
+            let metadata = try CodexHookMetadata(
+                eventName: "PreToolUse",
+                source: "project",
+                sourcePath: "/private/HOOK_PATH_SENTINEL",
+                key: "HOOK_KEY_SENTINEL",
+                currentHash: "HOOK_HASH_SENTINEL",
+                enabled: true,
+                handlerType: "command",
+                trustStatus: .untrusted,
+                commandOrHandler: "HOOK_COMMAND_SENTINEL"
+            )
+            let request = AgentCodexHookReviewRequest(
+                tabID: session.tabID,
+                runAttemptID: nil,
+                runID: nil,
+                executionCWD: "/private/HOOK_PATH_SENTINEL",
+                hooks: [AgentCodexHookReviewHook(metadata: metadata)],
+                phase: .writeFailed,
+                errorMessage: "HOOK_ERROR_SENTINEL",
+                gateGeneration: 1
+            )
+            session.pendingCodexHookReview = request
+            return request.id
         }
 
         @discardableResult
@@ -283,9 +302,7 @@ final class AgentRunMCPToolServiceRespondDiagnosticsTests: XCTestCase {
         }
 
         func cleanup() async {
-            window.beginClose()
-            await window.tearDown()
-            WindowStatesManager.shared.unregisterWindowState(window)
+            await context.cleanup()
         }
 
         private static func makePreview() -> GitWorktreeMergePreview {

--- a/Tests/RepoPromptTests/MCP/AgentRunMCPToolServiceRespondDiagnosticsTests.swift
+++ b/Tests/RepoPromptTests/MCP/AgentRunMCPToolServiceRespondDiagnosticsTests.swift
@@ -166,7 +166,11 @@ final class AgentRunMCPToolServiceRespondDiagnosticsTests: XCTestCase {
             _ = try await service.execute(args: args)
             XCTFail("Expected invalid params: \(label)")
         } catch let error as MCPError {
-            XCTAssertEqual(String(describing: error), "[-32602] Invalid params: \(expectedMessage)", label)
+            XCTAssertEqual(error.code, -32602, label)
+            guard case let .invalidParams(message) = error else {
+                return XCTFail("Expected MCPError.invalidParams for \(label), got code \(error.code)")
+            }
+            XCTAssertEqual(message, expectedMessage, label)
         } catch {
             XCTFail("Expected MCPError.invalidParams for \(label), got \(error)")
         }

--- a/Tests/RepoPromptTests/MCP/AppSettingsMCPServiceAgentModeSettingsTests.swift
+++ b/Tests/RepoPromptTests/MCP/AppSettingsMCPServiceAgentModeSettingsTests.swift
@@ -125,11 +125,36 @@ final class AppSettingsMCPServiceAgentModeSettingsTests: XCTestCase {
         let workspaceID = UUID()
 
         XCTAssertFalse(store.codexHookApprovalStrictModeEnabled(workspaceID: workspaceID))
+        XCTAssertEqual(
+            CodexHookApprovalWorkspaceSetting(
+                workspaceOverride: store.codexHookApprovalStrictModeWorkspaceOverride(workspaceID: workspaceID)
+            ),
+            .appDefault
+        )
+
         store.setGlobalCodexHookApprovalStrictModeEnabled(true)
         XCTAssertTrue(store.codexHookApprovalStrictModeEnabled(workspaceID: workspaceID))
-        store.setCodexHookApprovalStrictModeOverride(false, for: workspaceID)
-        XCTAssertFalse(store.codexHookApprovalStrictModeEnabled(workspaceID: workspaceID))
+        XCTAssertNil(store.codexHookApprovalStrictModeWorkspaceOverride(workspaceID: workspaceID))
 
+        for (setting, expectedEffectiveValue) in [
+            (CodexHookApprovalWorkspaceSetting.dontRequireApproval, false),
+            (.alwaysRequireApproval, true),
+            (.appDefault, true)
+        ] {
+            store.setCodexHookApprovalStrictModeOverride(setting.workspaceOverride, for: workspaceID)
+            XCTAssertEqual(
+                CodexHookApprovalWorkspaceSetting(
+                    workspaceOverride: store.codexHookApprovalStrictModeWorkspaceOverride(workspaceID: workspaceID)
+                ),
+                setting
+            )
+            XCTAssertEqual(store.codexHookApprovalStrictModeEnabled(workspaceID: workspaceID), expectedEffectiveValue)
+        }
+
+        store.setCodexHookApprovalStrictModeOverride(
+            CodexHookApprovalWorkspaceSetting.dontRequireApproval.workspaceOverride,
+            for: workspaceID
+        )
         let reloaded = GlobalSettingsStore(
             defaults: defaults,
             fileStore: GlobalSettingsFileStore(fileURL: fileURL)

--- a/Tests/RepoPromptTests/MCP/AppSettingsMCPServiceAgentModeSettingsTests.swift
+++ b/Tests/RepoPromptTests/MCP/AppSettingsMCPServiceAgentModeSettingsTests.swift
@@ -108,6 +108,56 @@ final class AppSettingsMCPServiceAgentModeSettingsTests: XCTestCase {
         }
     }
 
+    func testCodexHookApprovalStrictModeIsHumanOnlyAndPersistsWorkspaceOverride() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AppSettingsMCPServiceAgentModeSettingsTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let suiteName = "AppSettingsMCPServiceAgentModeSettingsTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let fileURL = root.appendingPathComponent("globalSettings.json")
+        let store = GlobalSettingsStore(
+            defaults: defaults,
+            fileStore: GlobalSettingsFileStore(fileURL: fileURL)
+        )
+        let workspaceID = UUID()
+
+        XCTAssertFalse(store.codexHookApprovalStrictModeEnabled(workspaceID: workspaceID))
+        store.setGlobalCodexHookApprovalStrictModeEnabled(true)
+        XCTAssertTrue(store.codexHookApprovalStrictModeEnabled(workspaceID: workspaceID))
+        store.setCodexHookApprovalStrictModeOverride(false, for: workspaceID)
+        XCTAssertFalse(store.codexHookApprovalStrictModeEnabled(workspaceID: workspaceID))
+
+        let reloaded = GlobalSettingsStore(
+            defaults: defaults,
+            fileStore: GlobalSettingsFileStore(fileURL: fileURL)
+        )
+        XCTAssertTrue(reloaded.globalCodexHookApprovalStrictModeEnabled())
+        XCTAssertEqual(reloaded.codexHookApprovalStrictModeWorkspaceOverride(workspaceID: workspaceID), false)
+        XCTAssertFalse(reloaded.codexHookApprovalStrictModeEnabled(workspaceID: workspaceID))
+
+        let service = AppSettingsMCPService(store: reloaded)
+        for key in [
+            "agent_mode.codex_hook_approval_strict_mode_enabled",
+            "agent_mode.codex_hook_approval_strict_mode_workspace_overrides"
+        ] {
+            do {
+                _ = try await service.handleForTesting([
+                    "op": .string("set"),
+                    "key": .string(key),
+                    "value": .bool(true)
+                ])
+                XCTFail("Expected human-only setting rejection for \(key)")
+            } catch {
+                let diagnostic = String(describing: error)
+                XCTAssertTrue(diagnostic.contains("security-sensitive"), diagnostic)
+                XCTAssertTrue(diagnostic.contains("human"), diagnostic)
+            }
+        }
+    }
+
     func testHandoffInstructionsRemainOutsideAppSettingsCatalog() async throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("AppSettingsMCPServiceAgentModeSettingsTests-\(UUID().uuidString)", isDirectory: true)

--- a/docs/architecture/codex-app-server-schema-gate.md
+++ b/docs/architecture/codex-app-server-schema-gate.md
@@ -35,8 +35,9 @@ requirement.
 
 The initial projection covers:
 
-- the client requests RPCE sends for initialization, model discovery, thread lifecycle, goals,
-  turns, interruption, steering, compaction, and the optional memory-mode setting;
+- the client requests RPCE sends for initialization, model discovery, hook discovery, hook-trust
+  config writes, thread lifecycle, goals, turns, interruption, steering, compaction, and the optional
+  memory-mode setting;
 - request fields RPCE always or conditionally emits, including nested initialize metadata, turn-input
   variants, sandbox-policy variants, and detection of newly required upstream fields;
 - incoming parameter and response paths RPCE reads, with explicit required, optional, conditional,
@@ -52,7 +53,14 @@ The versioned contract is fail-closed: missing or unknown keys are errors. Metho
 local `$ref`, `allOf`, `oneOf`, and `anyOf` composition and accepts both single-value `enum`
 and `const` discriminators, so upstream organizational refactors do not create false removals.
 
-The hardened 0.147.0 baseline checks 42 methods, 186 parameter paths, and 78 response paths. A failure names
+For `config/batchWrite`, the generated `ConfigEdit.value` schema is unconstrained (`true`), so the
+gate declares the closest available projection, `edits[].value`; the dynamic
+hook-key → `{trusted_hash}` object shape cannot be expressed by the current checker.
+
+After a trust write, the post-write `hooks/list` result is the semantic success authority;
+`config/batchWrite.status` alone is not.
+
+The hardened 0.147.0 baseline checks 45 methods, 192 parameter paths, and 93 response paths. A failure names
 the union, method, and exact missing field, required field, response path, or enum value.
 
 This is intentionally not a complete protocol mirror. New upstream methods do not fail the gate

--- a/docs/architecture/codex-app-server-schema-gate.md
+++ b/docs/architecture/codex-app-server-schema-gate.md
@@ -60,7 +60,7 @@ hook-key → `{trusted_hash}` object shape cannot be expressed by the current ch
 After a trust write, the post-write `hooks/list` result is the semantic success authority;
 `config/batchWrite.status` alone is not.
 
-The hardened 0.147.0 baseline checks 45 methods, 192 parameter paths, and 93 response paths. A failure names
+The hardened 0.147.0 baseline checks 45 methods, 193 parameter paths, and 93 response paths. A failure names
 the union, method, and exact missing field, required field, response path, or enum value.
 
 This is intentionally not a complete protocol mirror. New upstream methods do not fail the gate


### PR DESCRIPTION
Fixes #665.

## What this does

Codex 0.145.0 only runs repo-level `.codex` PreToolUse hooks when the effective `CODEX_HOME` config carries a `[hooks.state]` `trusted_hash` approval entry for each hook; otherwise the hooks are silently skipped. Because CE binds its bundled Codex app server to an app-private `CODEX_HOME`, hook approvals users made in `~/.codex` never carry over, so repo guardrail hooks (for example, hooks that block `terraform destroy`) silently stopped running for CE Agent Mode sessions — fail-open, with no signal.

This PR adds a fail-closed approval lifecycle. After a thread binds but before the first `turn/start`, the coordinator lists project hooks for the execution cwd. Any `untrusted` or `modified` project hook blocks the first turn behind a review interaction, surfaced both as a SwiftUI card and over the `agent_run` MCP contract. Approval writes the `trusted_hash` entries through `config/batchWrite` into CE's private home, re-verifies with a second `hooks/list`, and only then releases the pending turn. Live threads pick up the trust write without rebinding (verified against the pinned runtime).

## Design highlights

- **Lazy, per-controller-binding gate** covering every dispatch route that can start a first turn: direct send, fallback idle pump, terminal-successor fallback, and managed-auth replay. Restore/reconnect/goal/compact bindings don't trigger review until a turn is actually sent.
- **Serialized trust writes.** `config/batchWrite` is read-modify-write per process with no cross-process merge (verified empirically: concurrent writers clobber, last writer wins), so CE serializes all trust writes behind an app-global mutex, held until server-side settlement with cancellation shielding.
- **Fail closed everywhere.** Discovery, parse, write, and verification failures block the turn with retry/continue options; unknown trust statuses fail decode; verification runs a second `hooks/list` after every write. Inventory drift to zero during review resolves as a distinct `resolved_externally` audit, never as a silent bypass.
- **Explicit continuation, never a default.** Continuing without hooks is a deliberate user action, recorded in the transcript with a counts-only audit. A discovery-failure bypass reports its skipped count as unknown rather than zero.
- **Opt-in strict mode.** By default, the review card lets a human explicitly choose "Continue Without Hooks" — the session runs unguarded, and the transcript records that choice. Checking **Settings → Agent Mode → "Require Codex project-hook approval"** removes that option: sessions stay blocked until the displayed hooks are approved (or become trusted externally, e.g. via the codex TUI). An "In this workspace" picker — App default (labeled with the live global value) / Always require approval / Don't require approval — lets a single workspace keep its own value instead of the global one, e.g. global off for scratch repos, strict on for an infrastructure repo whose hooks guard `terraform destroy`. The setting is human-only — the `app_settings` MCP surface rejects writes to it.
- **Headless parity.** MCP `hook_approval` interaction with phase-specific options, `hook_keys` selective approval, an exact top-level argument allowlist, and atomic snapshot decoding so wait/poll round trips can't silently drop the interaction. Full hook metadata (source path, command, hash) is intentionally present in the pending interaction — it's required for informed approval — while diagnostics, stale-ID errors, transcripts, and audits stay counts-only.
- **Schema gate.** `hooks/list` and `config/batchWrite` shapes are pinned in the app-server contract fixture (floor 0.145.0) so runtime drift is caught by `make dev-codex-schema-check`.

## Notes for reviewers

- The MCP approval surface uses the same authority model as the existing approval/question interactions: the `agent_run` caller (the user's orchestrator) resolves interactions. The gated session itself cannot self-approve — its first turn has not started while the gate is pending.
- Project trust still gates hook discovery entirely (codex behavior): repos not trusted in the private home list no hooks, so the hook gate composes with — and does not replace — project trust handling.
- One codex upstream quirk documented during verification: a schema-invalid hook declaration (flat `command` on the matcher table) is silently ignored by `hooks/list` with zero errors, indistinguishable from a hook-less repo. The gate cannot catch that class; candidate for an upstream codex report.
- `FileSystemContentLoadingConcurrencyTests.testCancelledQueuedContentReadWorkerPermitWaitRecordsCancellationWithoutAcquisitionOrLeak` failed under full-suite load in two separate full-suite runs on this branch and passed focused (24/24) with zero content change both times; the subsystem is untouched here. Flagging as a pre-existing load-sensitive flake.

## Testing

- New/expanded unit coverage across the five commits: controller trust operations (25), gate core + coverage batch (20), FIFO gate ordering (21), card state, MCP lifecycle (11), MCP diagnostics/privacy, settings persistence + human-only rejection, plus empty-inventory compatibility across existing suites. Contract ledger verified.
- Full root suite, `dev-lint`, `dev-format-check`, both product builds, `dev-codex-schema-check`, and the repo `pr-ready` preflight lane green.
- Live end-to-end canary on the debug build: the gate blocked the first turn on a scratch repo with an untrusted PreToolUse hook; `trust_all` over MCP wrote the `hooks.state` entries and the deny hook then blocked `bash -c true` on the same live thread with its stderr reason — no rebind. Changing the hook declaration re-triggered review as `modified`; `continue_without_hooks` resumed the turn with the hook skipped and a counts-only transcript notice. On a real guarded infrastructure repo, both project hooks were trusted via the flow and `terraform apply -help` was then blocked by that repo's own guardrail gate while `echo` passed through the same chain — the original #665 bypass is closed with no over-blocking.

## Screenshots

<img width="1117" height="848" alt="Screenshot 2026-07-29 at 11 43 31 AM" src="https://github.com/user-attachments/assets/5622bd04-8a54-46e1-911f-9540b93dae32" />

<img width="1140" height="860" alt="Screenshot 2026-07-29 at 11 43 43 AM" src="https://github.com/user-attachments/assets/4a2fd518-48e2-42b2-8268-27bd58da3baf" />

<img width="1136" height="870" alt="Screenshot 2026-07-29 at 11 44 00 AM" src="https://github.com/user-attachments/assets/e51aac8e-5c55-4fbc-a508-57d6e92fb548" />

<img width="1452" height="945" alt="Screenshot 2026-07-29 at 9 58 17 AM" src="https://github.com/user-attachments/assets/863db9a2-1399-4d27-9a26-fdeb8efa5d35" />

<img width="1451" height="941" alt="Screenshot 2026-07-29 at 10 02 22 AM" src="https://github.com/user-attachments/assets/48044119-64bc-47fd-a8e6-c190e8888bf1" />

<img width="1454" height="943" alt="Screenshot 2026-07-29 at 10 35 38 AM" src="https://github.com/user-attachments/assets/9d889622-7095-414a-8c64-bf3a61f36569" />

Attached in the first comment: the settings card (default state, open picker, and global-on + workspace opt-out) and Agent Mode transcripts showing block-after-approval and the explicit-bypass notice.

## Release note

Agent Mode may now pause before its first Codex turn to ask you to approve repository-declared Codex hooks (`.codex` config). Approvals persist per hook version; an opt-in strict mode (Settings → Agent Mode) requires approval and removes the continue-without-hooks option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fph5yrP8bV9yu3BjD2xh32
