### PR TITLE
Fix agent workspace performance regression

### DIFF
--- a/Sources/RepoPrompt/App/WindowStateComposition.swift
+++ b/Sources/RepoPrompt/App/WindowStateComposition.swift
@@ -155,8 +155,8 @@ enum WindowStateCompositionFactory {
             oracleViewModel: oracleViewModel,
             applyEditsApprovalStore: applyEditsApprovalStore
         )
-        workspaceFilesViewModel.setSessionWorktreeBindingsProvider { [weak agentModeViewModel] sessionID in
-            agentModeViewModel?.worktreeBindings(forAgentSessionID: sessionID) ?? []
+        workspaceFilesViewModel.setSessionWorktreeBindingStatesProvider { [weak agentModeViewModel] sessionIDs in
+            agentModeViewModel?.worktreeBindingStates(forAgentSessionIDs: sessionIDs) ?? [:]
         }
         if deferredInitialAgentSystemWorkspaceRefresh {
             agentModeViewModel.deferInitialSystemWorkspaceSessionListRefresh(reason: "programmaticNewWindowWorkspaceSwitch")

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+SidebarSessions.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+SidebarSessions.swift
@@ -369,6 +369,15 @@ extension AgentModeViewModel {
     /// Session-linked sidebar data source.
     /// Blank compose tabs stay hidden until they are explicitly linked to an agent session.
     func sidebarSessions(for tabs: [ComposeTabState]) -> [SidebarSession] {
+        let cacheKey = SidebarSessionRowsCacheKey(
+            workspaceID: workspaceManager?.activeWorkspaceID,
+            sidebarRevision: ui.sessionSidebar.snapshot.revision,
+            tabs: tabs
+        )
+        if let cached = sidebarSessionRowsCache, cached.key == cacheKey {
+            return cached.rows
+        }
+
         let currentIndex = ownerValidatedSessionIndex
         let indexEntriesByTabID = Dictionary(grouping: currentIndex.values, by: \.tabID)
         let authoritativeSessionIDByTabID = Dictionary(
@@ -394,7 +403,7 @@ extension AgentModeViewModel {
                 entries: candidateEntries
             ) != nil
         }
-        return AgentModeSidebarSessionBuilder(
+        let rows = AgentModeSidebarSessionBuilder(
             allTabs: tabs,
             linkedTabs: linkedTabs,
             sessions: sessions,
@@ -405,6 +414,8 @@ extension AgentModeViewModel {
             sidebarRestoreFrozenOrderByTabID: ownerValidatedSidebarRestoreFrozenOrderByTabID,
             mcpControlledTabIDs: mcpControlledTabIDs
         ).build()
+        sidebarSessionRowsCache = (cacheKey, rows)
+        return rows
     }
 
     func collapsibleSidebarThreadKeys(
@@ -453,6 +464,69 @@ extension AgentModeViewModel {
             else { return nil }
             return AgentSidebarThreadKey.key(sessionID: rows[index].sessionID, tabID: rows[index].tabID)
         }
+    }
+
+    /// Memoized projection consumed by the SwiftUI list. The key names every
+    /// correctness input that can change rows: authoritative sidebar generation,
+    /// search/collapse/attention state, pagination, selection, workspace identity,
+    /// compose/stashed tab state, and archive expansion.
+    func sidebarListProjection(
+        composeTabs: [ComposeTabState],
+        stashedTabs: [StashedTab],
+        currentTabID: UUID?,
+        sidebarSnapshot: AgentSessionSidebarSnapshot,
+        archivedSessionsExpanded: Bool
+    ) -> SidebarListProjection {
+        let key = SidebarListProjectionCacheKey(
+            workspaceID: workspaceManager?.activeWorkspaceID,
+            sidebarSnapshot: sidebarSnapshot,
+            currentTabID: currentTabID,
+            composeTabs: composeTabs,
+            stashedTabs: stashedTabs,
+            archivedSessionsExpanded: archivedSessionsExpanded
+        )
+        if let cached = sidebarListProjectionCache, cached.key == key {
+            return cached.projection
+        }
+
+        let filteredSessions = displaySidebarSessions(
+            for: composeTabs,
+            currentTabID: currentTabID,
+            searchText: sidebarSnapshot.searchText,
+            diagnosticSource: "listProjection"
+        )
+        let effectiveVisibleSessionCount = effectiveSidebarVisibleSessionCount(
+            filteredSessions: filteredSessions,
+            currentTabID: currentTabID,
+            visibleSessionCount: sidebarSnapshot.visibleSessionCount
+        )
+        let pagedSessions = pagedSidebarSessions(
+            filteredSessions: filteredSessions,
+            currentTabID: currentTabID,
+            visibleSessionCount: effectiveVisibleSessionCount
+        )
+        let archivedSessionTabs = archivedSessionTabsForSidebarSnapshot(
+            stashedTabs,
+            searchText: sidebarSnapshot.searchText,
+            prepareSortedRows: archivedSessionsExpanded
+        )
+        let projection = SidebarListProjection(
+            filteredSessions: filteredSessions,
+            pagedSessions: pagedSessions,
+            effectiveVisibleSessionCount: effectiveVisibleSessionCount,
+            archivedSessionTabsForHeader: archivedSessionTabs.filteredTabs,
+            sortedArchivedSessionTabsForRows: archivedSessionTabs.sortedTabs,
+            archivedDateInfoByStashedTabID: archivedSessionTabs.dateInfoByStashedTabID,
+            defaultCollapseSeedKeys: defaultCollapsedSidebarThreadKeys(
+                for: composeTabs,
+                searchText: sidebarSnapshot.searchText
+            )
+        )
+        sidebarListProjectionCache = (key, projection)
+        #if DEBUG
+            test_sidebarListProjectionBuildCount &+= 1
+        #endif
+        return projection
     }
 
     func seedDefaultCollapsedSidebarThreads(_ eligibleKeys: [AgentSidebarThreadKey]) {

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+Types.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+Types.swift
@@ -135,6 +135,19 @@ extension AgentModeViewModel {
         case ambiguous(tabIDs: [UUID])
     }
 
+    /// Immutable authority inputs shared by a batch of persistent-session lookups.
+    /// Building these maps is the expensive part: it walks every live, compose, and
+    /// stashed tab. Individual resolutions remain session-specific and preserve the
+    /// same ambiguity and indexed-fallback rules as the scalar lookup.
+    struct PersistentBindingResolutionSnapshot {
+        let liveClaimsByTabID: [UUID: UUID]
+        let workspaceClaimsByTabID: [UUID: Set<UUID>]
+        let claimedTabIDsBySessionID: [UUID: Set<UUID>]
+        let conflictingTabIDsBySessionID: [UUID: Set<UUID>]
+        let indexedTabIDBySessionID: [UUID: UUID]
+        let composeTabIDs: Set<UUID>
+    }
+
     enum PersistentBindingMutationError: Error, Equatable {
         case staleTransition
         case blockedByOwnership
@@ -156,6 +169,39 @@ extension AgentModeViewModel {
         case search
         case visibleCount
         case explicit
+    }
+
+    struct SidebarSessionRowsCacheKey: Equatable {
+        let workspaceID: UUID?
+        let sidebarRevision: Int
+        let tabs: [ComposeTabState]
+    }
+
+    struct SidebarListProjectionCacheKey: Equatable {
+        let workspaceID: UUID?
+        let sidebarSnapshot: AgentSessionSidebarSnapshot
+        let currentTabID: UUID?
+        let composeTabs: [ComposeTabState]
+        let stashedTabs: [StashedTab]
+        let archivedSessionsExpanded: Bool
+    }
+
+    struct SidebarListProjection {
+        let filteredSessions: [SidebarSession]
+        let pagedSessions: [SidebarSession]
+        let effectiveVisibleSessionCount: Int
+        let archivedSessionTabsForHeader: [StashedTab]
+        let sortedArchivedSessionTabsForRows: [StashedTab]
+        let archivedDateInfoByStashedTabID: [UUID: SidebarSessionDateInfo]
+        let defaultCollapseSeedKeys: [AgentSidebarThreadKey]
+
+        var hasMoreSessions: Bool {
+            filteredSessions.count > effectiveVisibleSessionCount
+        }
+
+        var remainingSessionCount: Int {
+            max(0, filteredSessions.count - effectiveVisibleSessionCount)
+        }
     }
 
     /// Signature of a compose tab's sidebar-rendered metadata. Captured separately

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -635,6 +635,8 @@ final class AgentModeViewModel: ObservableObject {
     /// revisions when sidebar-visible content has not changed. Nil before the
     /// first forced refresh so the initial request always publishes.
     var lastSidebarContentFingerprint: AgentSessionSidebarContentFingerprint?
+    var sidebarSessionRowsCache: (key: SidebarSessionRowsCacheKey, rows: [SidebarSession])?
+    var sidebarListProjectionCache: (key: SidebarListProjectionCacheKey, projection: SidebarListProjection)?
     private var lastKnownWorkspaceSnapshot: WorkspaceModel?
     var tabDraftText: [UUID: String] = [:]
     private var cancellables = Set<AnyCancellable>()
@@ -644,6 +646,8 @@ final class AgentModeViewModel: ObservableObject {
         private var test_currentTabIDOverride: UUID?
         private var test_activeWorkspaceIDForSessionIndexOverride: UUID?
         private var test_allowsScheduledDerivedTranscriptRefreshWithoutPromptManager = false
+        private var test_persistentBindingResolutionSnapshotBuildCount = 0
+        var test_sidebarListProjectionBuildCount = 0
         private var test_afterMCPStoreEpochBegan: (@MainActor () async -> Void)?
         private var test_terminalPublicationOverride: ((
             AgentRunTerminalCommitRevision,
@@ -784,6 +788,20 @@ final class AgentModeViewModel: ObservableObject {
 
         func test_bindingResolution(sessionID: UUID) -> PersistentBindingResolution {
             persistentBindingResolution(for: sessionID)
+        }
+
+        func test_worktreeBindingStates(
+            forAgentSessionIDs sessionIDs: Set<UUID>
+        ) -> [UUID: AgentSessionWorktreeBindingState] {
+            worktreeBindingStates(forAgentSessionIDs: sessionIDs)
+        }
+
+        func test_resetPersistentBindingResolutionSnapshotBuildCount() {
+            test_persistentBindingResolutionSnapshotBuildCount = 0
+        }
+
+        var test_persistentBindingResolutionBuildCount: Int {
+            test_persistentBindingResolutionSnapshotBuildCount
         }
 
         func test_bindingTransitionToken(for session: TabSession) -> PersistentBindingTransitionToken {
@@ -3603,47 +3621,73 @@ final class AgentModeViewModel: ObservableObject {
         )?.sessionID
     }
 
-    private func persistentBindingResolution(for sessionID: UUID) -> PersistentBindingResolution {
-        var authoritativeCandidates = Set<UUID>()
-        var conflictingTabIDs = Set<UUID>()
-        let liveClaims = Dictionary(uniqueKeysWithValues: sessions.values.compactMap { session in
+    private func makePersistentBindingResolutionSnapshot() -> PersistentBindingResolutionSnapshot {
+        #if DEBUG
+            test_persistentBindingResolutionSnapshotBuildCount &+= 1
+        #endif
+        let liveClaimsByTabID = Dictionary(uniqueKeysWithValues: sessions.values.compactMap { session in
             session.activeAgentSessionID.map { (session.tabID, $0) }
         })
-        var workspaceClaims: [UUID: Set<UUID>] = [:]
+        var workspaceClaimsByTabID: [UUID: Set<UUID>] = [:]
+        var composeTabIDs = Set<UUID>()
 
         let workspaces = workspaceManager?.workspaces ?? lastKnownWorkspaceSnapshot.map { [$0] } ?? []
         for workspace in workspaces {
             for tab in workspace.composeTabs {
+                if workspaceManager != nil {
+                    composeTabIDs.insert(tab.id)
+                }
                 if let claimedSessionID = tab.activeAgentSessionID {
-                    workspaceClaims[tab.id, default: []].insert(claimedSessionID)
+                    workspaceClaimsByTabID[tab.id, default: []].insert(claimedSessionID)
                 }
             }
             for stashed in workspace.stashedTabs {
                 if let claimedSessionID = stashed.tab.activeAgentSessionID {
-                    workspaceClaims[stashed.tab.id, default: []].insert(claimedSessionID)
+                    workspaceClaimsByTabID[stashed.tab.id, default: []].insert(claimedSessionID)
                 }
             }
         }
 
-        for (tabID, liveSessionID) in liveClaims {
-            if liveSessionID == sessionID {
-                authoritativeCandidates.insert(tabID)
+        var claimedTabIDsBySessionID: [UUID: Set<UUID>] = [:]
+        var conflictingTabIDsBySessionID: [UUID: Set<UUID>] = [:]
+        for (tabID, sessionID) in liveClaimsByTabID {
+            claimedTabIDsBySessionID[sessionID, default: []].insert(tabID)
+        }
+        for (tabID, persistedClaims) in workspaceClaimsByTabID {
+            for sessionID in persistedClaims {
+                claimedTabIDsBySessionID[sessionID, default: []].insert(tabID)
             }
-            if let persistedClaims = workspaceClaims[tabID],
-               persistedClaims.contains(where: { $0 != liveSessionID }),
-               liveSessionID == sessionID || persistedClaims.contains(sessionID)
+            if persistedClaims.count > 1 {
+                for sessionID in persistedClaims {
+                    conflictingTabIDsBySessionID[sessionID, default: []].insert(tabID)
+                }
+            }
+            if let liveSessionID = liveClaimsByTabID[tabID],
+               persistedClaims.contains(where: { $0 != liveSessionID })
             {
-                conflictingTabIDs.insert(tabID)
+                conflictingTabIDsBySessionID[liveSessionID, default: []].insert(tabID)
+                for sessionID in persistedClaims {
+                    conflictingTabIDsBySessionID[sessionID, default: []].insert(tabID)
+                }
             }
         }
-        for (tabID, persistedClaims) in workspaceClaims {
-            if persistedClaims.contains(sessionID) {
-                authoritativeCandidates.insert(tabID)
-            }
-            if persistedClaims.count > 1, persistedClaims.contains(sessionID) {
-                conflictingTabIDs.insert(tabID)
-            }
-        }
+
+        return PersistentBindingResolutionSnapshot(
+            liveClaimsByTabID: liveClaimsByTabID,
+            workspaceClaimsByTabID: workspaceClaimsByTabID,
+            claimedTabIDsBySessionID: claimedTabIDsBySessionID,
+            conflictingTabIDsBySessionID: conflictingTabIDsBySessionID,
+            indexedTabIDBySessionID: ownerValidatedSessionIndex.mapValues(\.tabID),
+            composeTabIDs: composeTabIDs
+        )
+    }
+
+    private func persistentBindingResolution(
+        for sessionID: UUID,
+        using snapshot: PersistentBindingResolutionSnapshot
+    ) -> PersistentBindingResolution {
+        let authoritativeCandidates = snapshot.claimedTabIDsBySessionID[sessionID] ?? []
+        let conflictingTabIDs = snapshot.conflictingTabIDsBySessionID[sessionID] ?? []
 
         if !conflictingTabIDs.isEmpty || authoritativeCandidates.count > 1 {
             let candidates = authoritativeCandidates.union(conflictingTabIDs).sorted { $0.uuidString < $1.uuidString }
@@ -3662,14 +3706,21 @@ final class AgentModeViewModel: ObservableObject {
         if let tabID = authoritativeCandidates.first {
             return .unique(tabID: tabID)
         }
-        if let indexedTabID = ownerValidatedSessionIndex[sessionID]?.tabID,
-           workspaceManager?.composeTab(with: indexedTabID) != nil,
-           liveClaims[indexedTabID] == nil,
-           workspaceClaims[indexedTabID]?.isEmpty != false
+        if let indexedTabID = snapshot.indexedTabIDBySessionID[sessionID],
+           snapshot.composeTabIDs.contains(indexedTabID),
+           snapshot.liveClaimsByTabID[indexedTabID] == nil,
+           snapshot.workspaceClaimsByTabID[indexedTabID]?.isEmpty != false
         {
             return .unique(tabID: indexedTabID)
         }
         return .notFound
+    }
+
+    private func persistentBindingResolution(for sessionID: UUID) -> PersistentBindingResolution {
+        persistentBindingResolution(
+            for: sessionID,
+            using: makePersistentBindingResolutionSnapshot()
+        )
     }
 
     private func ambiguousAgentSessionError() -> MCPError {
@@ -5689,26 +5740,56 @@ final class AgentModeViewModel: ObservableObject {
         return true
     }
 
-    func worktreeBindingState(
+    private func worktreeBindingState(
         forAgentSessionID sessionID: UUID,
-        tabID: UUID? = nil
+        tabID: UUID?,
+        resolutionSnapshot: PersistentBindingResolutionSnapshot
     ) -> AgentSessionWorktreeBindingState {
-        do {
-            if let live = try authoritativeLiveSession(for: sessionID) {
+        switch persistentBindingResolution(for: sessionID, using: resolutionSnapshot) {
+        case let .unique(authoritativeTabID):
+            if let live = sessions[authoritativeTabID], live.activeAgentSessionID == sessionID {
                 return live.hasLoadedPersistedState ? .hydrated(live.worktreeBindings) : .unhydrated
             }
-        } catch {
-            return .unavailable
-        }
-        if let tabID, let live = sessions[tabID], live.activeAgentSessionID == sessionID {
-            return live.hasLoadedPersistedState ? .hydrated(live.worktreeBindings) : .unhydrated
-        }
-        switch persistentBindingResolution(for: sessionID) {
-        case .unique:
+            // Retain the scalar API's explicit-tab compatibility for a unique
+            // persisted claim whose live session has not yet joined the map.
+            if let tabID, let live = sessions[tabID], live.activeAgentSessionID == sessionID {
+                return live.hasLoadedPersistedState ? .hydrated(live.worktreeBindings) : .unhydrated
+            }
             return .unhydrated
         case .notFound, .ambiguous:
             return .unavailable
         }
+    }
+
+    func worktreeBindingState(
+        forAgentSessionID sessionID: UUID,
+        tabID: UUID? = nil
+    ) -> AgentSessionWorktreeBindingState {
+        worktreeBindingState(
+            forAgentSessionID: sessionID,
+            tabID: tabID,
+            resolutionSnapshot: makePersistentBindingResolutionSnapshot()
+        )
+    }
+
+    /// Resolves a set of session IDs against one immutable authority snapshot.
+    /// Callers that project many tabs must use this instead of repeating the
+    /// scalar lookup, which would rebuild live and persisted claims per session.
+    func worktreeBindingStates(
+        forAgentSessionIDs sessionIDs: Set<UUID>
+    ) -> [UUID: AgentSessionWorktreeBindingState] {
+        guard !sessionIDs.isEmpty else { return [:] }
+        let snapshot = makePersistentBindingResolutionSnapshot()
+        return Dictionary(uniqueKeysWithValues: sessionIDs.map { sessionID in
+            (
+                sessionID,
+                worktreeBindingState(
+                    forAgentSessionID: sessionID,
+                    tabID: nil,
+                    resolutionSnapshot: snapshot
+                )
+            )
+        })
     }
 
     func worktreeBindings(forAgentSessionID sessionID: UUID, tabID: UUID? = nil) -> [AgentSessionWorktreeBinding] {

--- a/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionsSidebarView.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionsSidebarView.swift
@@ -294,91 +294,19 @@ struct AgentModeSessionsListView: View {
         fontPreset.scaledClamped(4, max: 6)
     }
 
-    private struct SidebarListSnapshot {
-        let filteredSessions: [AgentModeViewModel.SidebarSession]
-        let pagedSessions: [AgentModeViewModel.SidebarSession]
-        let effectiveVisibleSessionCount: Int
-        let archivedSessionTabsForHeader: [StashedTab]
-        let sortedArchivedSessionTabsForRows: [StashedTab]
-        let archivedDateInfoByStashedTabID: [UUID: AgentModeViewModel.SidebarSessionDateInfo]
-
-        var hasMoreSessions: Bool {
-            filteredSessions.count > effectiveVisibleSessionCount
-        }
-
-        var remainingSessionCount: Int {
-            max(0, filteredSessions.count - effectiveVisibleSessionCount)
-        }
-    }
-
-    /// Session-first sidebar list. Sessions remain stable regardless of tab switching.
-    private var sidebarListSnapshot: SidebarListSnapshot {
-        #if DEBUG
-            let snapshotStartMS = AgentModePerfDiagnostics.timestampMSIfEnabled()
-        #endif
-        let sidebarSnapshot = sidebarUI.snapshot
-        let filteredSessions = agentModeVM.displaySidebarSessions(
-            for: promptManager.currentComposeTabs,
-            currentTabID: currentTabID,
-            searchText: sidebarSnapshot.searchText,
-            diagnosticSource: "listSnapshot"
-        )
-        let effectiveVisibleSessionCount = agentModeVM.effectiveSidebarVisibleSessionCount(
-            filteredSessions: filteredSessions,
-            currentTabID: currentTabID,
-            visibleSessionCount: sidebarSnapshot.visibleSessionCount
-        )
-        let pagedSessions = agentModeVM.pagedSidebarSessions(
-            filteredSessions: filteredSessions,
-            currentTabID: currentTabID,
-            visibleSessionCount: effectiveVisibleSessionCount
-        )
-        let archivedSessionTabs = agentModeVM.archivedSessionTabsForSidebarSnapshot(
-            promptManager.currentStashedTabs,
-            searchText: sidebarSnapshot.searchText,
-            prepareSortedRows: archivedSessionsExpanded
-        )
-        let archivedSessionTabsForHeader = archivedSessionTabs.filteredTabs
-        let sortedArchivedSessionTabsForRows = archivedSessionTabs.sortedTabs
-        let snapshot = SidebarListSnapshot(
-            filteredSessions: filteredSessions,
-            pagedSessions: pagedSessions,
-            effectiveVisibleSessionCount: effectiveVisibleSessionCount,
-            archivedSessionTabsForHeader: archivedSessionTabsForHeader,
-            sortedArchivedSessionTabsForRows: sortedArchivedSessionTabsForRows,
-            archivedDateInfoByStashedTabID: archivedSessionTabs.dateInfoByStashedTabID
-        )
-        #if DEBUG
-            AgentModePerfDiagnostics.durationEvent(
-                "sidebar.listSnapshot",
-                startMS: snapshotStartMS,
-                fields: [
-                    "archivedCount": String(archivedSessionTabsForHeader.count),
-                    "archivedFilteredCount": String(archivedSessionTabsForHeader.count),
-                    "archivedSortedCount": String(sortedArchivedSessionTabsForRows.count),
-                    "archivedSortedPrepared": String(archivedSessionsExpanded),
-                    "composeTabCount": String(promptManager.currentComposeTabs.count),
-                    "currentTabID": AgentModePerfDiagnostics.shortID(currentTabID),
-                    "effectiveVisibleSessionCount": String(effectiveVisibleSessionCount),
-                    "filteredCount": String(filteredSessions.count),
-                    "pagedCount": String(pagedSessions.count),
-                    "searchActive": String(!sidebarSnapshot.searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty),
-                    "stashedTabCount": String(promptManager.currentStashedTabs.count)
-                ]
-            )
-        #endif
-        return snapshot
-    }
-
     var body: some View {
         #if DEBUG
             let _ = Self.recordBodyMetric()
         #endif
-        let snapshot = sidebarListSnapshot
-        let defaultCollapseSeedKeys = agentModeVM.defaultCollapsedSidebarThreadKeys(
-            for: promptManager.currentComposeTabs,
-            searchText: sidebarUI.snapshot.searchText
+        let sidebarSnapshot = sidebarUI.snapshot
+        let snapshot = agentModeVM.sidebarListProjection(
+            composeTabs: promptManager.currentComposeTabs,
+            stashedTabs: promptManager.currentStashedTabs,
+            currentTabID: currentTabID,
+            sidebarSnapshot: sidebarSnapshot,
+            archivedSessionsExpanded: archivedSessionsExpanded
         )
+        let defaultCollapseSeedKeys = snapshot.defaultCollapseSeedKeys
         let activeSections = AgentSidebarDateSectionBuilder.activeSections(for: snapshot.pagedSessions)
         let firstActiveSectionID = activeSections.first?.id
         ScrollView {

--- a/Sources/RepoPrompt/Features/WorkspaceFiles/ViewModels/WorkspaceFilesViewModel.swift
+++ b/Sources/RepoPrompt/Features/WorkspaceFiles/ViewModels/WorkspaceFilesViewModel.swift
@@ -850,7 +850,7 @@ class WorkspaceFilesViewModel: ObservableObject {
     private var sliceRebaseSourceSnapshotByFullPath: [String: SliceRebaseSourceSnapshot] = [:]
     private var sliceRebaseCommitTasksByFullPath: [String: Task<Void, Never>] = [:]
     private var sliceRebaseCommitIDsByFullPath: [String: UUID] = [:]
-    private var sessionWorktreeBindingsProvider: (@MainActor (UUID) -> [AgentSessionWorktreeBinding])?
+    private var sessionWorktreeBindingStatesProvider: (@MainActor (Set<UUID>) -> [UUID: AgentSessionWorktreeBindingState])?
     private var hiddenSessionHandledGenerationByRootLifetime: [HiddenSessionRootLifetimeKey: UInt64] = [:]
     private var hiddenSessionRootLifetimeByPhysicalPath: [String: HiddenSessionRootLifetimeKey] = [:]
     /// Monotonic revision incremented for any partition save seen in the current workspace.
@@ -1346,10 +1346,26 @@ class WorkspaceFilesViewModel: ObservableObject {
         fileSystemSettingsCancellable?.cancel()
     }
 
+    /// Compatibility setter for narrow callers. Production composition installs
+    /// the batch provider below so a multi-tab projection shares one authority scan.
     func setSessionWorktreeBindingsProvider(
         _ provider: @escaping @MainActor (UUID) -> [AgentSessionWorktreeBinding]
     ) {
-        sessionWorktreeBindingsProvider = provider
+        sessionWorktreeBindingStatesProvider = { sessionIDs in
+            Dictionary(uniqueKeysWithValues: sessionIDs.map { sessionID in
+                (sessionID, .hydrated(provider(sessionID)))
+            })
+        }
+    }
+
+    func setSessionWorktreeBindingStatesProvider(
+        _ provider: @escaping @MainActor (Set<UUID>) -> [UUID: AgentSessionWorktreeBindingState]
+    ) {
+        sessionWorktreeBindingStatesProvider = provider
+    }
+
+    private func sessionWorktreeBindingState(for sessionID: UUID) -> AgentSessionWorktreeBindingState {
+        sessionWorktreeBindingStatesProvider?([sessionID])[sessionID] ?? .unavailable
     }
 
     func attachSelectionCoordinator(_ coordinator: WorkspaceSelectionCoordinator) {
@@ -1634,13 +1650,19 @@ class WorkspaceFilesViewModel: ObservableObject {
             return true
         }
 
+        let modifiedFileIDs = Set(event.modifiedFileIDs)
+        let modifiedFilesByID: [UUID: WorkspaceFileRecord] = Dictionary(uniqueKeysWithValues: snapshot.files.compactMap { file in
+            guard modifiedFileIDs.contains(file.id), file.rootID == event.rootID else { return nil }
+            return (file.id, file)
+        })
+        let targetsByFileID = await hiddenSessionSliceRebaseTargets(
+            physicalRootPath: snapshot.root.standardizedFullPath,
+            modifiedFilesByID: modifiedFilesByID
+        ) ?? [:]
+
         for fileID in event.modifiedFileIDs {
-            guard let file = snapshot.files.first(where: { $0.id == fileID }),
-                  file.rootID == event.rootID,
-                  let targets = await hiddenSessionSliceRebaseTargets(
-                      physicalRootPath: snapshot.root.standardizedFullPath,
-                      physicalFullPath: file.standardizedFullPath
-                  ),
+            guard let file = modifiedFilesByID[fileID],
+                  let targets = targetsByFileID[fileID],
                   !targets.isEmpty
             else { continue }
             let eventSource = event.modifiedFileSourceSnapshotsByID[fileID]
@@ -1674,15 +1696,42 @@ class WorkspaceFilesViewModel: ObservableObject {
     @MainActor
     private func hiddenSessionSliceRebaseTargets(
         physicalRootPath: String,
-        physicalFullPath: String
-    ) async -> [HiddenSessionSliceRebaseTarget]? {
-        guard let provider = sessionWorktreeBindingsProvider,
-              let workspace = workspaceManager?.activeWorkspace
+        modifiedFilesByID: [UUID: WorkspaceFileRecord]
+    ) async -> [UUID: [HiddenSessionSliceRebaseTarget]]? {
+        guard let provider = sessionWorktreeBindingStatesProvider,
+              let workspace = workspaceManager?.activeWorkspace,
+              !modifiedFilesByID.isEmpty
         else { return nil }
-        var targets: [HiddenSessionSliceRebaseTarget] = []
-        for tab in workspace.composeTabs {
-            guard let sessionID = tab.activeAgentSessionID else { continue }
-            let bindings = provider(sessionID)
+
+        // Slice presence and relative-path eligibility are independent of binding
+        // authority. Apply them first so the expensive global binding snapshot is
+        // requested only for tabs that can target at least one modified file.
+        let candidateTabs = workspace.composeTabs.compactMap { tab -> (
+            tab: ComposeTabState,
+            sessionID: UUID,
+            slices: [String: [LineRange]],
+            candidateFileIDs: Set<UUID>
+        )? in
+            guard let sessionID = tab.activeAgentSessionID else { return nil }
+            let slices = StoredSelectionPathNormalization.standardizedSlices(tab.selection.slices)
+            guard !slices.isEmpty else { return nil }
+            let slicePaths = Array(slices.keys)
+            let candidateFileIDs = Set(modifiedFilesByID.compactMap { fileID, file -> UUID? in
+                let relativePath = file.standardizedRelativePath
+                guard slicePaths.contains(where: {
+                    $0 == relativePath || $0.hasSuffix("/\(relativePath)")
+                }) else { return nil }
+                return fileID
+            })
+            guard !candidateFileIDs.isEmpty else { return nil }
+            return (tab, sessionID, slices, candidateFileIDs)
+        }
+        guard !candidateTabs.isEmpty else { return [:] }
+
+        let bindingStates = provider(Set(candidateTabs.map(\.sessionID)))
+        var targetsByFileID: [UUID: [HiddenSessionSliceRebaseTarget]] = [:]
+        for candidate in candidateTabs {
+            guard case let .hydrated(bindings) = bindingStates[candidate.sessionID] else { continue }
             let matchingBindings = bindings.filter {
                 StandardizedPath.absolute(($0.worktreeRootPath as NSString).expandingTildeInPath) == physicalRootPath
             }
@@ -1692,24 +1741,29 @@ class WorkspaceFilesViewModel: ObservableObject {
             })
             let fingerprint = AgentWorkspaceLookupContextSource.worktreeBindingFingerprint(bindings)
             guard await workspaceFileContextStore.sessionWorktreeOwnershipCovers(
-                ownerID: sessionID,
+                ownerID: candidate.sessionID,
                 bindingFingerprint: fingerprint,
                 physicalRootPaths: physicalRootPaths
-            ), let logicalFullPath = WorkspaceRootBindingProjection.logicalAbsolutePath(
-                forPhysicalPath: physicalFullPath,
-                binding: binding
             ) else { continue }
-            let slices = StoredSelectionPathNormalization.standardizedSlices(tab.selection.slices)
-            guard slices[logicalFullPath]?.isEmpty == false else { continue }
-            targets.append(HiddenSessionSliceRebaseTarget(
-                identity: WorkspaceSelectionIdentity(workspaceID: workspace.id, tabID: tab.id),
-                logicalFullPath: logicalFullPath,
-                agentSessionID: sessionID,
-                bindingFingerprint: fingerprint,
-                physicalRootPaths: physicalRootPaths
-            ))
+
+            for fileID in candidate.candidateFileIDs {
+                guard let file = modifiedFilesByID[fileID],
+                      let logicalFullPath = WorkspaceRootBindingProjection.logicalAbsolutePath(
+                          forPhysicalPath: file.standardizedFullPath,
+                          binding: binding
+                      ),
+                      candidate.slices[logicalFullPath]?.isEmpty == false
+                else { continue }
+                targetsByFileID[fileID, default: []].append(HiddenSessionSliceRebaseTarget(
+                    identity: WorkspaceSelectionIdentity(workspaceID: workspace.id, tabID: candidate.tab.id),
+                    logicalFullPath: logicalFullPath,
+                    agentSessionID: candidate.sessionID,
+                    bindingFingerprint: fingerprint,
+                    physicalRootPaths: physicalRootPaths
+                ))
+            }
         }
-        return targets
+        return targetsByFileID
     }
 
     @MainActor
@@ -1932,14 +1986,13 @@ class WorkspaceFilesViewModel: ObservableObject {
     private func hiddenSessionSliceRangesIfTargetCurrent(
         _ target: HiddenSessionSliceRebaseTarget
     ) async -> [LineRange]? {
-        guard let provider = sessionWorktreeBindingsProvider,
-              let manager = workspaceManager,
+        guard let manager = workspaceManager,
               let tab = manager.composeTab(for: target.identity),
               tab.activeAgentSessionID == target.agentSessionID,
               let ranges = StoredSelectionPathNormalization.standardizedSlices(tab.selection.slices)[target.logicalFullPath],
-              !ranges.isEmpty
+              !ranges.isEmpty,
+              case let .hydrated(bindings) = sessionWorktreeBindingState(for: target.agentSessionID)
         else { return nil }
-        let bindings = provider(target.agentSessionID)
         guard AgentWorkspaceLookupContextSource.worktreeBindingFingerprint(bindings) == target.bindingFingerprint,
               Set(bindings.map {
                   StandardizedPath.absolute(($0.worktreeRootPath as NSString).expandingTildeInPath)

--- a/Sources/RepoPrompt/Features/Workspaces/ViewModels/WorkspaceManagerViewModel.swift
+++ b/Sources/RepoPrompt/Features/Workspaces/ViewModels/WorkspaceManagerViewModel.swift
@@ -6896,9 +6896,29 @@ class WorkspaceManagerViewModel: ObservableObject {
     actor WorkspaceDiskWriter {
         // MARK: internal model
 
+        private struct WorkspacePayloadIdentity: Equatable {
+            let workspaceID: UUID
+            let dateModified: Date
+        }
+
+        private struct WorkspacePayloadHeader: Decodable {
+            let id: UUID
+            let dateModified: Date
+
+            var identity: WorkspacePayloadIdentity {
+                WorkspacePayloadIdentity(workspaceID: id, dateModified: dateModified)
+            }
+        }
+
+        private struct DecodeWork: Equatable {
+            var identityPayloadCount = 0
+            var fullWorkspacePayloadCount = 0
+        }
+
         private struct Pending {
             var newestData: Data
             var newestMetadata: WorkspaceSavePayloadMetadata?
+            var newestIdentity: WorkspacePayloadIdentity?
             var newestLifecycleCorrelation: EditFlowPerf.LifecycleCorrelation?
             var task: Task<Void, Never>?
         }
@@ -6915,6 +6935,7 @@ class WorkspaceManagerViewModel: ObservableObject {
             let selectionKey: WorkspaceTabSelectionKey?
             let effectiveSelectionRevision: UInt64
             let shouldWrite: Bool
+            let decodeWork: DecodeWork
         }
 
         private var pendingByURL: [URL: Pending] = [:]
@@ -6923,6 +6944,7 @@ class WorkspaceManagerViewModel: ObservableObject {
         private var lastWrittenSelectionRevisionByWorkspaceTab: [WorkspaceTabSelectionKey: UInt64] = [:]
         #if DEBUG
             private var atomicWriteGateForTesting: (@Sendable () async -> Void)?
+            private var decodeWorkForTesting = DecodeWork()
         #endif
 
         // MARK: public API
@@ -6941,6 +6963,12 @@ class WorkspaceManagerViewModel: ObservableObject {
             let lifecycleCorrelation = EditFlowPerf.currentLifecycleCorrelation
             WorkspaceSaveTracer.event("workspaceSave.enqueue", metadata: metadata, url: url)
             recordLatestSelectionIfNeeded(metadata)
+            let identity = Self.payloadIdentity(metadata: metadata, data: data)
+            #if DEBUG
+                if metadata == nil, identity != nil {
+                    decodeWorkForTesting.identityPayloadCount &+= 1
+                }
+            #endif
 
             if var pending = pendingByURL[url] {
                 let decision: String
@@ -6950,15 +6978,22 @@ class WorkspaceManagerViewModel: ObservableObject {
                 {
                     pending.newestData = data
                     pending.newestMetadata = metadata
+                    pending.newestIdentity = identity
                     pending.newestLifecycleCorrelation = lifecycleCorrelation ?? pending.newestLifecycleCorrelation
                     decision = "replacedExistingNewerSelectionRevision"
-                } else if Self.shouldKeepExistingWorkspacePayload(existing: pending.newestData, incoming: data, url: url) {
+                } else if Self.shouldKeepExistingWorkspacePayload(
+                    existing: pending.newestIdentity,
+                    incoming: identity,
+                    incomingMetadata: metadata,
+                    url: url
+                ) {
                     decision = "keptExistingNewerDate"
                     WorkspaceSaveTracer.event("workspaceSave.coalesce", metadata: metadata, url: url, extra: ["decision": decision])
                     return
                 } else {
                     pending.newestData = data
                     pending.newestMetadata = metadata
+                    pending.newestIdentity = identity
                     pending.newestLifecycleCorrelation = lifecycleCorrelation ?? pending.newestLifecycleCorrelation
                     decision = "storedAsNewest"
                 }
@@ -6970,6 +7005,7 @@ class WorkspaceManagerViewModel: ObservableObject {
             pendingByURL[url] = Pending(
                 newestData: data,
                 newestMetadata: metadata,
+                newestIdentity: identity,
                 newestLifecycleCorrelation: lifecycleCorrelation,
                 task: nil
             )
@@ -7037,6 +7073,13 @@ class WorkspaceManagerViewModel: ObservableObject {
                 atomicWriteGateForTesting = gate
             }
 
+            func decodeWorkSnapshotForTesting() -> (identityPayloadCount: Int, fullWorkspacePayloadCount: Int) {
+                (
+                    decodeWorkForTesting.identityPayloadCount,
+                    decodeWorkForTesting.fullWorkspacePayloadCount
+                )
+            }
+
             func removeAllForTesting() {
                 for (_, pending) in pendingByURL {
                     pending.task?.cancel()
@@ -7045,6 +7088,7 @@ class WorkspaceManagerViewModel: ObservableObject {
                 latestSelectionByWorkspaceTab.removeAll()
                 lastWrittenSelectionRevisionByWorkspaceTab.removeAll()
                 atomicWriteGateForTesting = nil
+                decodeWorkForTesting = DecodeWork()
                 let allWaiters = waitersByURL.values.flatMap(\.self)
                 waitersByURL.removeAll()
                 for waiter in allWaiters {
@@ -7055,8 +7099,38 @@ class WorkspaceManagerViewModel: ObservableObject {
 
         // MARK: private helpers
 
-        private static func decodedWorkspacePayload(_ data: Data) -> WorkspaceModel? {
+        private static func payloadIdentity(
+            metadata: WorkspaceSavePayloadMetadata?,
+            data: Data
+        ) -> WorkspacePayloadIdentity? {
+            if let metadata {
+                return WorkspacePayloadIdentity(
+                    workspaceID: metadata.workspaceID,
+                    dateModified: metadata.workspaceDateModified
+                )
+            }
+            return decodedWorkspacePayloadIdentity(data)
+        }
+
+        private static func decodedWorkspacePayloadIdentity(_ data: Data) -> WorkspacePayloadIdentity? {
             guard !data.isEmpty else { return nil }
+            return try? JSONDecoder().decode(WorkspacePayloadHeader.self, from: data).identity
+        }
+
+        private static func decodedWorkspacePayloadIdentity(
+            _ data: Data,
+            decodeWork: inout DecodeWork
+        ) -> WorkspacePayloadIdentity? {
+            decodeWork.identityPayloadCount &+= 1
+            return decodedWorkspacePayloadIdentity(data)
+        }
+
+        private static func decodedWorkspacePayload(
+            _ data: Data,
+            decodeWork: inout DecodeWork
+        ) -> WorkspaceModel? {
+            guard !data.isEmpty else { return nil }
+            decodeWork.fullWorkspacePayloadCount &+= 1
             return try? JSONDecoder().decode(WorkspaceModel.self, from: data)
         }
 
@@ -7076,11 +7150,16 @@ class WorkspaceManagerViewModel: ObservableObject {
             )
         }
 
-        private static func shouldKeepExistingWorkspacePayload(existing: Data, incoming: Data, url: URL) -> Bool {
-            guard let existingWorkspace = decodedWorkspacePayload(existing),
-                  let incomingWorkspace = decodedWorkspacePayload(incoming),
-                  existingWorkspace.id == incomingWorkspace.id,
-                  existingWorkspace.dateModified > incomingWorkspace.dateModified
+        private static func shouldKeepExistingWorkspacePayload(
+            existing: WorkspacePayloadIdentity?,
+            incoming: WorkspacePayloadIdentity?,
+            incomingMetadata: WorkspaceSavePayloadMetadata?,
+            url: URL
+        ) -> Bool {
+            guard let existing,
+                  let incoming,
+                  existing.workspaceID == incoming.workspaceID,
+                  existing.dateModified > incoming.dateModified
             else {
                 return false
             }
@@ -7088,8 +7167,8 @@ class WorkspaceManagerViewModel: ObservableObject {
                 WorkspaceRestorePerfLog.event(
                     "workspaceDiskWriter.skipStaleCoalescedPayload",
                     fields: [
-                        "workspaceID": WorkspaceRestorePerfLog.shortID(incomingWorkspace.id),
-                        "workspaceName": incomingWorkspace.name,
+                        "workspaceID": WorkspaceRestorePerfLog.shortID(incoming.workspaceID),
+                        "workspaceName": incomingMetadata?.workspaceName ?? "unknown",
                         "url": url.lastPathComponent
                     ]
                 )
@@ -7099,40 +7178,69 @@ class WorkspaceManagerViewModel: ObservableObject {
 
         private static func effectivePayloadForWrite(
             payload: Data,
+            incomingIdentity: WorkspacePayloadIdentity?,
             url: URL,
             metadata: WorkspaceSavePayloadMetadata?,
             latestRecord: LatestSelectionRecord?,
             lastWrittenRevision: UInt64
         ) -> EffectiveWritePayload {
-            guard let metadata,
-                  let incomingWorkspace = decodedWorkspacePayload(payload),
-                  incomingWorkspace.id == metadata.workspaceID
-            else {
-                let shouldWrite = !shouldSkipStaleWorkspaceDiskWrite(payload: payload, url: url, metadata: metadata)
-                return EffectiveWritePayload(data: payload, metadata: metadata, selectionKey: metadata?.selectionKey, effectiveSelectionRevision: metadata?.activeSelectionRevision ?? 0, shouldWrite: shouldWrite)
+            var decodeWork = DecodeWork()
+            func result(
+                data: Data,
+                metadata: WorkspaceSavePayloadMetadata?,
+                selectionKey: WorkspaceTabSelectionKey?,
+                effectiveSelectionRevision: UInt64,
+                shouldWrite: Bool
+            ) -> EffectiveWritePayload {
+                EffectiveWritePayload(
+                    data: data,
+                    metadata: metadata,
+                    selectionKey: selectionKey,
+                    effectiveSelectionRevision: effectiveSelectionRevision,
+                    shouldWrite: shouldWrite,
+                    decodeWork: decodeWork
+                )
             }
 
-            let key = metadata.selectionKey
-            let incomingRevision = metadata.activeSelectionRevision
+            guard let incomingIdentity else {
+                return result(
+                    data: payload,
+                    metadata: metadata,
+                    selectionKey: metadata?.selectionKey,
+                    effectiveSelectionRevision: metadata?.activeSelectionRevision ?? 0,
+                    shouldWrite: true
+                )
+            }
+
+            let key = metadata?.selectionKey
+            let incomingRevision = metadata?.activeSelectionRevision ?? 0
             let latestRevision = latestRecord?.revision ?? incomingRevision
-            let latestSelection = latestRecord?.selection ?? metadata.activeSelection
+            let latestSelection = latestRecord?.selection ?? metadata?.activeSelection
             let latestMetadata = latestRecord?.metadata ?? metadata
-            let diskWorkspace: WorkspaceModel? = if FileManager.default.fileExists(atPath: url.path),
-                                                    let diskData = try? Data(contentsOf: url),
-                                                    let decoded = decodedWorkspacePayload(diskData),
-                                                    decoded.id == incomingWorkspace.id
-            {
-                decoded
-            } else {
-                nil
+            let diskData = FileManager.default.fileExists(atPath: url.path)
+                ? try? Data(contentsOf: url)
+                : nil
+            let diskIdentity = diskData.flatMap {
+                decodedWorkspacePayloadIdentity($0, decodeWork: &decodeWork)
             }
 
-            if let diskWorkspace, diskWorkspace.dateModified > incomingWorkspace.dateModified {
-                if latestRevision > lastWrittenRevision,
+            if let diskData,
+               let diskIdentity,
+               diskIdentity.workspaceID == incomingIdentity.workspaceID,
+               diskIdentity.dateModified > incomingIdentity.dateModified
+            {
+                if let metadata,
+                   latestRevision > lastWrittenRevision,
                    let latestSelection,
-                   let activeTabID = metadata.activeTabID
+                   let activeTabID = metadata.activeTabID,
+                   let diskWorkspace = decodedWorkspacePayload(diskData, decodeWork: &decodeWork),
+                   diskWorkspace.id == incomingIdentity.workspaceID
                 {
-                    let applied = WorkspaceManagerViewModel.workspaceByApplyingSelection(latestSelection, toActiveTab: activeTabID, in: diskWorkspace)
+                    let applied = WorkspaceManagerViewModel.workspaceByApplyingSelection(
+                        latestSelection,
+                        toActiveTab: activeTabID,
+                        in: diskWorkspace
+                    )
                     if applied.applied {
                         var merged = applied.workspace
                         merged.dateModified = Date()
@@ -7144,22 +7252,41 @@ class WorkspaceManagerViewModel: ObservableObject {
                                 extra: [
                                     "latestSelectionRevision": "\(latestRevision)",
                                     "lastWrittenSelectionRevision": "\(lastWrittenRevision)",
-                                    "latestPayloadID": latestMetadata.payloadID.uuidString
+                                    "latestPayloadID": latestMetadata?.payloadID.uuidString ?? "none"
                                 ]
                             )
-                            return EffectiveWritePayload(data: encoded, metadata: latestMetadata, selectionKey: key, effectiveSelectionRevision: latestRevision, shouldWrite: true)
+                            return result(
+                                data: encoded,
+                                metadata: latestMetadata,
+                                selectionKey: key,
+                                effectiveSelectionRevision: latestRevision,
+                                shouldWrite: true
+                            )
                         }
                     }
                 }
                 WorkspaceSaveTracer.event("workspaceSave.write.skipStaleDiskPayload", metadata: metadata, url: url)
-                return EffectiveWritePayload(data: payload, metadata: metadata, selectionKey: key, effectiveSelectionRevision: incomingRevision, shouldWrite: false)
+                return result(
+                    data: payload,
+                    metadata: metadata,
+                    selectionKey: key,
+                    effectiveSelectionRevision: incomingRevision,
+                    shouldWrite: false
+                )
             }
 
-            if latestRevision > incomingRevision,
+            if let metadata,
+               latestRevision > incomingRevision,
                let latestSelection,
-               let activeTabID = metadata.activeTabID
+               let activeTabID = metadata.activeTabID,
+               let incomingWorkspace = decodedWorkspacePayload(payload, decodeWork: &decodeWork),
+               incomingWorkspace.id == incomingIdentity.workspaceID
             {
-                let applied = WorkspaceManagerViewModel.workspaceByApplyingSelection(latestSelection, toActiveTab: activeTabID, in: incomingWorkspace)
+                let applied = WorkspaceManagerViewModel.workspaceByApplyingSelection(
+                    latestSelection,
+                    toActiveTab: activeTabID,
+                    in: incomingWorkspace
+                )
                 if applied.applied,
                    let encoded = try? JSONEncoder().encode(applied.workspace)
                 {
@@ -7170,37 +7297,37 @@ class WorkspaceManagerViewModel: ObservableObject {
                         extra: [
                             "incomingSelectionRevision": "\(incomingRevision)",
                             "latestSelectionRevision": "\(latestRevision)",
-                            "latestPayloadID": latestMetadata.payloadID.uuidString
+                            "latestPayloadID": latestMetadata?.payloadID.uuidString ?? "none"
                         ]
                     )
-                    return EffectiveWritePayload(data: encoded, metadata: latestMetadata, selectionKey: key, effectiveSelectionRevision: latestRevision, shouldWrite: true)
+                    return result(
+                        data: encoded,
+                        metadata: latestMetadata,
+                        selectionKey: key,
+                        effectiveSelectionRevision: latestRevision,
+                        shouldWrite: true
+                    )
                 }
             }
 
-            return EffectiveWritePayload(data: payload, metadata: metadata, selectionKey: key, effectiveSelectionRevision: incomingRevision, shouldWrite: true)
-        }
-
-        private static func shouldSkipStaleWorkspaceDiskWrite(payload: Data, url: URL, metadata: WorkspaceSavePayloadMetadata?) -> Bool {
-            guard FileManager.default.fileExists(atPath: url.path),
-                  let incomingWorkspace = decodedWorkspacePayload(payload),
-                  let diskData = try? Data(contentsOf: url),
-                  let diskWorkspace = decodedWorkspacePayload(diskData),
-                  diskWorkspace.id == incomingWorkspace.id,
-                  diskWorkspace.dateModified > incomingWorkspace.dateModified
-            else {
-                return false
-            }
-            WorkspaceSaveTracer.event("workspaceSave.write.skipStaleDiskPayload", metadata: metadata, url: url)
-            return true
+            return result(
+                data: payload,
+                metadata: metadata,
+                selectionKey: key,
+                effectiveSelectionRevision: incomingRevision,
+                shouldWrite: true
+            )
         }
 
         private func runNext(for url: URL) {
             guard var slot = pendingByURL[url] else { return }
             let payload = slot.newestData
             let metadata = slot.newestMetadata
+            let incomingIdentity = slot.newestIdentity
             let lifecycleCorrelation = slot.newestLifecycleCorrelation
             slot.newestData = Data()
             slot.newestMetadata = nil
+            slot.newestIdentity = nil
             slot.newestLifecycleCorrelation = nil
             pendingByURL[url] = slot
             let latestRecord = metadata?.selectionKey.flatMap { latestSelectionByWorkspaceTab[$0] }
@@ -7212,6 +7339,7 @@ class WorkspaceManagerViewModel: ObservableObject {
             let task = Task.detached(priority: .utility) { [weak self] in
                 let effective = Self.effectivePayloadForWrite(
                     payload: payload,
+                    incomingIdentity: incomingIdentity,
                     url: url,
                     metadata: metadata,
                     latestRecord: latestRecord,
@@ -7259,6 +7387,10 @@ class WorkspaceManagerViewModel: ObservableObject {
         }
 
         private func writerFinished(for url: URL, effective: EffectiveWritePayload, writeSucceeded: Bool) {
+            #if DEBUG
+                decodeWorkForTesting.identityPayloadCount &+= effective.decodeWork.identityPayloadCount
+                decodeWorkForTesting.fullWorkspacePayloadCount &+= effective.decodeWork.fullWorkspacePayloadCount
+            #endif
             if writeSucceeded,
                let key = effective.selectionKey,
                effective.effectiveSelectionRevision > 0

--- a/Tests/RepoPromptTests/AgentMode/AgentModeViewModelInactiveRefreshTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeViewModelInactiveRefreshTests.swift
@@ -749,6 +749,106 @@ final class AgentModeViewModelInactiveRefreshTests: XCTestCase {
         }
     }
 
+    func testSidebarListProjectionMemoizesWithinExplicitRenderGeneration() {
+        let viewModel = makeViewModel()
+        let composeTabs = (0 ..< 400).map { index in
+            ComposeTabState(
+                id: UUID(),
+                name: "Session \(index)",
+                activeAgentSessionID: UUID()
+            )
+        }
+        let stashedTabs = (0 ..< 200).map { index in
+            StashedTab(tab: ComposeTabState(
+                id: UUID(),
+                name: "Archived \(index)",
+                activeAgentSessionID: UUID()
+            ))
+        }
+        var workspace = makeWorkspace(
+            name: "Sidebar projection scale",
+            tabs: composeTabs,
+            activeTabID: composeTabs.first?.id
+        )
+        workspace.stashedTabs = stashedTabs
+        let manager = makeWorkspaceManager(workspaces: [workspace])
+        manager.activeWorkspace = workspace
+        viewModel.workspaceManager = manager
+        let snapshot = viewModel.ui.sessionSidebar.snapshot
+
+        _ = viewModel.sidebarListProjection(
+            composeTabs: composeTabs,
+            stashedTabs: stashedTabs,
+            currentTabID: composeTabs.first?.id,
+            sidebarSnapshot: snapshot,
+            archivedSessionsExpanded: false
+        )
+        _ = viewModel.sidebarListProjection(
+            composeTabs: composeTabs,
+            stashedTabs: stashedTabs,
+            currentTabID: composeTabs.first?.id,
+            sidebarSnapshot: snapshot,
+            archivedSessionsExpanded: false
+        )
+        XCTAssertEqual(viewModel.test_sidebarListProjectionBuildCount, 1)
+
+        var renamedTabs = composeTabs
+        renamedTabs[0].name = "Renamed"
+        _ = viewModel.sidebarListProjection(
+            composeTabs: renamedTabs,
+            stashedTabs: stashedTabs,
+            currentTabID: composeTabs.first?.id,
+            sidebarSnapshot: snapshot,
+            archivedSessionsExpanded: false
+        )
+        XCTAssertEqual(viewModel.test_sidebarListProjectionBuildCount, 2)
+
+        viewModel.setSessionSidebarSearchText("Session 2")
+        _ = viewModel.sidebarListProjection(
+            composeTabs: renamedTabs,
+            stashedTabs: stashedTabs,
+            currentTabID: composeTabs.first?.id,
+            sidebarSnapshot: viewModel.ui.sessionSidebar.snapshot,
+            archivedSessionsExpanded: true
+        )
+        XCTAssertEqual(viewModel.test_sidebarListProjectionBuildCount, 3)
+    }
+
+    func testBatchWorktreeBindingStatesBuildsAuthoritySnapshotOnceAtScale() {
+        let viewModel = makeViewModel()
+        let composeCount = 300
+        let stashedCount = 300
+        var composeTabs: [ComposeTabState] = []
+        var sessionIDs = Set<UUID>()
+
+        for _ in 0 ..< composeCount {
+            let tabID = UUID()
+            let sessionID = UUID()
+            let session = AgentModeViewModel.TabSession(tabID: tabID)
+            _ = viewModel.test_installPersistentSessionBinding(sessionID: sessionID, on: session)
+            viewModel.test_installLiveSession(session)
+            composeTabs.append(ComposeTabState(id: tabID, activeAgentSessionID: sessionID))
+            sessionIDs.insert(sessionID)
+        }
+
+        var workspace = makeWorkspace(
+            name: "Batch binding scale",
+            tabs: composeTabs,
+            activeTabID: composeTabs.first?.id
+        )
+        workspace.stashedTabs = (0 ..< stashedCount).map { _ in
+            StashedTab(tab: ComposeTabState(id: UUID(), activeAgentSessionID: UUID()))
+        }
+        viewModel.workspaceManager = makeWorkspaceManager(workspaces: [workspace])
+        viewModel.test_resetPersistentBindingResolutionSnapshotBuildCount()
+
+        let states = viewModel.test_worktreeBindingStates(forAgentSessionIDs: sessionIDs)
+
+        XCTAssertEqual(states.count, composeCount)
+        XCTAssertTrue(states.values.allSatisfy { $0 == .unhydrated })
+        XCTAssertEqual(viewModel.test_persistentBindingResolutionBuildCount, 1)
+    }
+
     func testPersistentBindingMoveIsBlockedByRunOwnershipAndStoreRegistration() async throws {
         let viewModel = makeViewModel()
         let sessionID = UUID()

--- a/Tests/RepoPromptTests/Helpers/CodemapSeamTestSupport.swift
+++ b/Tests/RepoPromptTests/Helpers/CodemapSeamTestSupport.swift
@@ -112,6 +112,7 @@ class WorkspaceFileContextStoreCodemapSeamTestSupport: XCTestCase {
     func readyArtifactDemand(
         store: WorkspaceFileContextStore,
         forFileID fileID: UUID,
+        priority: CodeMapArtifactBuildPriority = .demand,
         timeout: Duration = .seconds(30),
         file: StaticString = #filePath,
         line: UInt = #line
@@ -120,7 +121,7 @@ class WorkspaceFileContextStoreCodemapSeamTestSupport: XCTestCase {
         let deadline = clock.now.advanced(by: timeout)
         var lastNonReadyResult: WorkspaceCodemapArtifactDemandResult?
         while clock.now < deadline {
-            let initial = await store.requestCodemapArtifact(forFileID: fileID)
+            let initial = await store.requestCodemapArtifact(forFileID: fileID, priority: priority)
             switch initial {
             case let .pending(ticket):
                 let result = try await settledResult(store: store, ticket: ticket)

--- a/Tests/RepoPromptTests/WorkspaceContext/CodemapAutomaticSelectionGraphNativeTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/CodemapAutomaticSelectionGraphNativeTests.swift
@@ -61,8 +61,8 @@ final class CodemapAutomaticSelectionGraphNativeTests: WorkspaceFileContextStore
         let seed = try XCTUnwrap(files.first {
             $0.standardizedRelativePath == "Sources/Seed.swift"
         })
-        let ticket = try await pendingTicket(store.requestCodemapArtifact(forFileID: seed.id))
-        _ = try await readyResult(settledResult(store: store, ticket: ticket))
+        let initialDemand = try await readyArtifactDemand(store: store, forFileID: seed.id)
+        let ticket = initialDemand.ticket
 
         await store.setCodemapPathInvalidationStageHandlerForTesting { epoch, _, stage in
             guard epoch == ticket.rootEpoch, stage == .rootMutationFence else { return }

--- a/Tests/RepoPromptTests/WorkspaceContext/CodemapAutomaticSelectionGraphNativeTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/CodemapAutomaticSelectionGraphNativeTests.swift
@@ -196,19 +196,11 @@ final class CodemapAutomaticSelectionGraphNativeTests: WorkspaceFileContextStore
         let target = try XCTUnwrap(files.first { $0.standardizedRelativePath == "Sources/Target.swift" })
         let unrelated = try XCTUnwrap(files.first { $0.standardizedRelativePath == "Sources/Unrelated.swift" })
 
-        let sourceSeed = await store.requestCodemapArtifact(
+        _ = try await readyArtifactDemand(
+            store: store,
             forFileID: source.id,
             priority: .background
         )
-        let sourceReady: WorkspaceCodemapArtifactDemandResult = switch sourceSeed {
-        case let .pending(ticket):
-            try await settledResult(store: store, ticket: ticket)
-        default:
-            sourceSeed
-        }
-        guard case .ready = sourceReady else {
-            return XCTFail("Expected the source artifact to be ready before graph-native selection.")
-        }
         let automaticDemandTicketOffset = fixture.demandedTickets.values.count
 
         _ = try await awaitCodemapGraphsReady(store: store, rootIDs: [loaded.id])

--- a/Tests/RepoPromptTests/WorkspaceContext/WorkspaceFilesAppliedIndexProjectionTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/WorkspaceFilesAppliedIndexProjectionTests.swift
@@ -810,6 +810,99 @@ import XCTest
             XCTAssertFalse(hidden.hasLifetimeMapping)
         }
 
+        func testHiddenSessionMultiFileBatchPrefiltersTabsAndInvokesBindingProviderOnce() async throws {
+            let rootURL = try temporaryRoots.makeRoot(suiteName: "AppliedIndexHiddenSessionBatch")
+            for name in ["One.swift", "Two.swift", "Three.swift"] {
+                try "let value = true\n".write(
+                    to: rootURL.appendingPathComponent(name),
+                    atomically: false,
+                    encoding: .utf8
+                )
+            }
+            let store = WorkspaceFileContextStore()
+            let root = try await store.loadRoot(path: rootURL.path, kind: .sessionWorktree)
+            let rootLifetimeID = try await store.rootLifetimeIDForTesting(rootID: root.id)
+            let files = await store.files(inRoot: root.id)
+            XCTAssertEqual(files.count, 3)
+
+            let fileManager = WorkspaceFilesViewModel(workspaceFileContextStore: store)
+            let keyManager = KeyManager(
+                secureService: SecureKeysService(secureStorage: TestSecureStorageBackend())
+            )
+            let apiSettings = APISettingsViewModel(
+                aiQueriesService: AIQueriesService(keyManager: keyManager),
+                keyManager: keyManager,
+                loadStoredDataOnInit: false
+            )
+            let prompt = PromptViewModel(
+                fileManager: fileManager,
+                apiSettingsViewModel: apiSettings,
+                windowID: -1,
+                settingsManager: WindowSettingsManager(windowID: -1)
+            )
+            let workspaceManager = WorkspaceManagerViewModel(
+                fileManager: fileManager,
+                promptViewModel: prompt,
+                performInitialWorkspaceActivation: false
+            )
+            let eligibleSessionID = UUID()
+            var tabs = (0 ..< 500).map { index in
+                ComposeTabState(
+                    id: UUID(),
+                    name: "Unrelated \(index)",
+                    activeAgentSessionID: UUID()
+                )
+            }
+            tabs.append(ComposeTabState(
+                id: UUID(),
+                name: "Eligible",
+                activeAgentSessionID: eligibleSessionID,
+                selection: StoredSelection(
+                    selectedPaths: ["/logical/One.swift"],
+                    slices: ["/logical/One.swift": [LineRange(start: 1, end: 1)]],
+                    codemapAutoEnabled: false
+                )
+            ))
+            let workspace = WorkspaceModel(
+                name: "Hidden batch",
+                repoPaths: [rootURL.path],
+                ephemeralFlag: true,
+                composeTabs: tabs,
+                activeComposeTabID: tabs.last?.id
+            )
+            workspaceManager.workspaces = [workspace]
+            workspaceManager.activeWorkspace = workspace
+            fileManager.setWorkspaceManager(workspaceManager)
+
+            var providerInvocationCount = 0
+            var requestedSessionIDs = Set<UUID>()
+            fileManager.setSessionWorktreeBindingStatesProvider { sessionIDs in
+                providerInvocationCount &+= 1
+                requestedSessionIDs = sessionIDs
+                return Dictionary(uniqueKeysWithValues: sessionIDs.map { ($0, .unavailable) })
+            }
+
+            await fileManager.applyWorkspaceAppliedIndexEventForTesting(WorkspaceAppliedIndexBatchEvent(
+                rootID: root.id,
+                rootPath: root.standardizedFullPath,
+                generation: 1,
+                rootLifetimeID: rootLifetimeID,
+                modifiedFileIDs: files.map(\.id)
+            ))
+
+            XCTAssertEqual(providerInvocationCount, 1)
+            XCTAssertEqual(requestedSessionIDs, [eligibleSessionID])
+            for file in files {
+                let debug = fileManager.hiddenSessionSliceRebaseDebugSnapshotForTesting(
+                    fullPath: file.standardizedFullPath,
+                    rootID: root.id,
+                    rootLifetimeID: rootLifetimeID
+                )
+                XCTAssertEqual(debug.handledGeneration, 1)
+                XCTAssertFalse(debug.hasPendingTask)
+            }
+        }
+
         func testValidRootUnloadClearsUUIDPathIndexesAndHandledGeneration() async throws {
             let rootURL = try temporaryRoots.makeRoot(suiteName: "AppliedIndexValidUnload")
             let store = WorkspaceFileContextStore()

--- a/Tests/RepoPromptTests/WorkspaceContext/WorkspaceSelectionPersistenceTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/WorkspaceSelectionPersistenceTests.swift
@@ -103,6 +103,147 @@ final class WorkspaceSelectionPersistenceTests: XCTestCase {
         XCTAssertEqual(decoded.composeTabs[0].promptText, "disk-field")
     }
 
+    func testDiskWriterUsesHeaderOnlyForOrdinaryFreshnessComparison() async throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("WorkspaceSelectionPersistenceTests-")
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let url = tempDir.appendingPathComponent("workspace.json")
+        let writer = WorkspaceManagerViewModel.WorkspaceDiskWriter.shared
+        await writer.removeAllForTesting()
+
+        let workspaceID = UUID()
+        let tabID = UUID()
+        let disk = Self.workspace(
+            id: workspaceID,
+            tabID: tabID,
+            selection: Self.selection(count: 3),
+            dateModified: Date(timeIntervalSince1970: 100),
+            promptText: "disk"
+        )
+        try JSONEncoder().encode(disk).write(to: url, options: .atomic)
+        let incoming = Self.workspace(
+            id: workspaceID,
+            tabID: tabID,
+            selection: Self.selection(count: 4),
+            dateModified: Date(timeIntervalSince1970: 200),
+            promptText: "incoming"
+        )
+        let metadata = WorkspaceManagerViewModel.metadata(
+            for: incoming,
+            source: "test.headerOnlyFreshness",
+            activeSelectionRevision: 1
+        )
+
+        try await writer.enqueueWorkspace(
+            data: JSONEncoder().encode(incoming),
+            url: url,
+            metadata: metadata
+        )
+        await writer.flush(url: url)
+
+        let decoded = try JSONDecoder().decode(WorkspaceModel.self, from: Data(contentsOf: url))
+        XCTAssertEqual(decoded.composeTabs[0].promptText, "incoming")
+        let decodeWork = await writer.decodeWorkSnapshotForTesting()
+        XCTAssertEqual(decodeWork.identityPayloadCount, 1)
+        XCTAssertEqual(decodeWork.fullWorkspacePayloadCount, 0)
+    }
+
+    func testDiskWriterSkipsNewerDiskPayloadWithoutFullWorkspaceDecode() async throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("WorkspaceSelectionPersistenceTests-")
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let url = tempDir.appendingPathComponent("workspace.json")
+        let writer = WorkspaceManagerViewModel.WorkspaceDiskWriter.shared
+        await writer.removeAllForTesting()
+
+        let workspaceID = UUID()
+        let tabID = UUID()
+        let disk = Self.workspace(
+            id: workspaceID,
+            tabID: tabID,
+            selection: Self.selection(count: 3),
+            dateModified: Date(timeIntervalSince1970: 300),
+            promptText: "newer disk"
+        )
+        try JSONEncoder().encode(disk).write(to: url, options: .atomic)
+        let incoming = Self.workspace(
+            id: workspaceID,
+            tabID: tabID,
+            selection: Self.selection(count: 4),
+            dateModified: Date(timeIntervalSince1970: 200),
+            promptText: "stale incoming"
+        )
+        let metadata = WorkspaceManagerViewModel.metadata(
+            for: incoming,
+            source: "test.headerOnlyStaleSkip",
+            activeSelectionRevision: 0
+        )
+
+        try await writer.enqueueWorkspace(
+            data: JSONEncoder().encode(incoming),
+            url: url,
+            metadata: metadata
+        )
+        await writer.flush(url: url)
+
+        let decoded = try JSONDecoder().decode(WorkspaceModel.self, from: Data(contentsOf: url))
+        XCTAssertEqual(decoded.composeTabs[0].promptText, "newer disk")
+        let decodeWork = await writer.decodeWorkSnapshotForTesting()
+        XCTAssertEqual(decodeWork.identityPayloadCount, 1)
+        XCTAssertEqual(decodeWork.fullWorkspacePayloadCount, 0)
+    }
+
+    func testDiskWriterDoesNotTreatDifferentWorkspaceIDAsStale() async throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("WorkspaceSelectionPersistenceTests-")
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let url = tempDir.appendingPathComponent("workspace.json")
+        let writer = WorkspaceManagerViewModel.WorkspaceDiskWriter.shared
+        await writer.removeAllForTesting()
+
+        let tabID = UUID()
+        let disk = Self.workspace(
+            id: UUID(),
+            tabID: tabID,
+            selection: Self.selection(count: 3),
+            dateModified: Date(timeIntervalSince1970: 300),
+            promptText: "different workspace"
+        )
+        try JSONEncoder().encode(disk).write(to: url, options: .atomic)
+        let incoming = Self.workspace(
+            id: UUID(),
+            tabID: tabID,
+            selection: Self.selection(count: 4),
+            dateModified: Date(timeIntervalSince1970: 200),
+            promptText: "incoming workspace"
+        )
+        let metadata = WorkspaceManagerViewModel.metadata(
+            for: incoming,
+            source: "test.differentWorkspaceIdentity",
+            activeSelectionRevision: 0
+        )
+
+        try await writer.enqueueWorkspace(
+            data: JSONEncoder().encode(incoming),
+            url: url,
+            metadata: metadata
+        )
+        await writer.flush(url: url)
+
+        let decoded = try JSONDecoder().decode(WorkspaceModel.self, from: Data(contentsOf: url))
+        XCTAssertEqual(decoded.id, incoming.id)
+        XCTAssertEqual(decoded.composeTabs[0].promptText, "incoming workspace")
+        let decodeWork = await writer.decodeWorkSnapshotForTesting()
+        XCTAssertEqual(decodeWork.identityPayloadCount, 1)
+        XCTAssertEqual(decodeWork.fullWorkspacePayloadCount, 0)
+    }
+
     func testDiskWriterFlushAndAtomicWriteTelemetryCarryDurabilityAttributionWithoutPaths() async throws {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("WorkspaceSelectionPersistenceTests-")


### PR DESCRIPTION
## Summary

- batch hidden-session slice-rebase target discovery per applied-index event
- resolve all candidate agent sessions against one authoritative binding snapshot
- memoize Agent Mode sidebar rows/projections with explicit invalidation inputs
- replace ordinary full workspace JSON decodes with lightweight identity/header decoding
- add scale and semantic regression coverage for all three hot paths

## Root cause

The sampled beachball multiplied modified files by compose tabs and then rebuilt live/persisted binding claims across every workspace, on the main actor. Large session histories also caused repeated sidebar sorting/projection work, while workspace persistence repeatedly decoded multi-megabyte payloads in the background.

This change preserves fail-closed binding ambiguity, ownership revalidation, stale-write ordering, selection-revision merging, and persisted user state while removing the multiplicative work.

## Validation

- `make dev-lint` — passed
- `make dev-test FILTER=AgentModeViewModelInactiveRefreshTests` — 35 passed
- `make dev-test FILTER=WorkspaceFilesAppliedIndexProjectionTests` — 16 passed
- `make dev-test FILTER=WorkspaceSelectionPersistenceTests` — 8 passed
- `make dev-swift-build PRODUCT=RepoPrompt` — passed
- staged/outgoing secret scans and repository guardrails — passed
- Fable High review of the worktree diff — no must-fix findings

The full `pr-ready` root suite was attempted but exceeded its 3600-second limit. Before timeout it reported unrelated CodeMap failures in `CodeMapArtifactBuildCoordinatorTests`, `CodeMapRootManifestStoreTests`, and `CodemapAutomaticSelectionGraphNativeTests`. The changed focused suites above pass on the current `main` base.

## Scope

No workspace-storage cleanup or migration is included. CodeMap/Git classification behavior is unchanged because the captures did not establish a bounded cross-subsystem fix.
