### PR TITLE
Fix Tip socket ownership startup race

### DIFF
--- a/.github/workflows/main-tip.yml
+++ b/.github/workflows/main-tip.yml
@@ -14,7 +14,9 @@ on:
 
 concurrency:
   group: main-tip-channel
-  cancel-in-progress: false
+  # Tip is a rolling channel: once main advances, completing an older artifact only
+  # delays the commit users actually asked the channel to publish.
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -336,6 +338,7 @@ jobs:
         env:
           REPOPROMPT_PACKAGED_SMOKE_TIMEOUT: "240"
           REPOPROMPT_PACKAGED_SMOKE_HELPER_TIMEOUT: "60"
+          REPOPROMPT_PACKAGED_SMOKE_DIAGNOSTICS_DIR: ${{ runner.temp }}/tip-smoke-diagnostics
         run: |
           set -euo pipefail
           shopt -s nullglob
@@ -353,10 +356,20 @@ jobs:
             LOGNAME="$LOGNAME" \
             REPOPROMPT_PACKAGED_SMOKE_TIMEOUT="$REPOPROMPT_PACKAGED_SMOKE_TIMEOUT" \
             REPOPROMPT_PACKAGED_SMOKE_HELPER_TIMEOUT="$REPOPROMPT_PACKAGED_SMOKE_HELPER_TIMEOUT" \
+            REPOPROMPT_PACKAGED_SMOKE_DIAGNOSTICS_DIR="$REPOPROMPT_PACKAGED_SMOKE_DIAGNOSTICS_DIR" \
             ./trusted-control-plane/Scripts/smoke_packaged_mcp_roundtrip.sh \
             "extracted/RepoPrompt CE.app" \
             "Tip packaged app" \
             "${manifests[0]}"
+
+      - name: Upload Tip smoke diagnostics
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: RepoPrompt-CE-tip-smoke-diagnostics
+          path: ${{ runner.temp }}/tip-smoke-diagnostics
+          if-no-files-found: warn
+          retention-days: 3
 
   publish:
     name: Publish Tip Appcast

--- a/Scripts/smoke_packaged_mcp_roundtrip.sh
+++ b/Scripts/smoke_packaged_mcp_roundtrip.sh
@@ -16,6 +16,8 @@ APP_START=""
 TEMP_ROOT=""
 APP_LOG=""
 MCP_SOCKET_PATH=""
+DIAGNOSTICS_DIR="${REPOPROMPT_PACKAGED_SMOKE_DIAGNOSTICS_DIR:-}"
+HELPER_DEBUG_LOG=""
 
 fail() {
     printf 'ERROR: %s\n' "$*" >&2
@@ -38,6 +40,24 @@ process_matches() {
 
 cleanup() {
     local status=$?
+    # Diagnostics are best-effort and must never prevent exact-PID shutdown or temp cleanup.
+    set +e
+    if (( status != 0 )) && [[ -n "$DIAGNOSTICS_DIR" ]]; then
+        mkdir -p "$DIAGNOSTICS_DIR"
+        if process_matches && command -v sample >/dev/null 2>&1; then
+            log_phase "$SMOKE_LABEL capturing launched app sample after failure"
+            sample "$APP_PID" 5 1 -file "$DIAGNOSTICS_DIR/packaged-app.sample.txt" >/dev/null 2>&1 || true
+        fi
+        [[ -z "$APP_LOG" || ! -f "$APP_LOG" ]] || cp "$APP_LOG" "$DIAGNOSTICS_DIR/packaged-app.log"
+        [[ -z "$HELPER_DEBUG_LOG" || ! -f "$HELPER_DEBUG_LOG" ]] || cp "$HELPER_DEBUG_LOG" "$DIAGNOSTICS_DIR/helper-socket-debug.log"
+        if [[ -n "$TEMP_ROOT" && -d "$TEMP_ROOT" ]]; then
+            find "$TEMP_ROOT" -maxdepth 1 -type f \( -name 'windows-attempt-*' -o -name 'socket-owner.err' -o -name 'launched-process.json' \) \
+                -exec cp {} "$DIAGNOSTICS_DIR/" \; 2>/dev/null || true
+        fi
+        printf '%s\n' "--- packaged app sample excerpt ---" >&2
+        sed -n '1,220p' "$DIAGNOSTICS_DIR/packaged-app.sample.txt" >&2 2>/dev/null || true
+        printf 'Packaged smoke diagnostics retained at %s\n' "$DIAGNOSTICS_DIR" >&2
+    fi
     if process_matches; then
         kill -TERM "$APP_PID" 2>/dev/null || true
         for _ in 1 2 3 4 5 6 7 8 9 10; do
@@ -105,6 +125,7 @@ ISOLATED_TMP="$TEMP_ROOT/tmp"
 APP_LOG="$TEMP_ROOT/app.log"
 mkdir -p "$ISOLATED_HOME" "$ISOLATED_TMP"
 chmod 700 "$TEMP_ROOT" "$ISOLATED_HOME" "$ISOLATED_TMP"
+HELPER_DEBUG_LOG="$ISOLATED_HOME/Library/Application Support/RepoPrompt CE/socket-proxy-debug.log"
 
 "$SOCKET_OWNER_HELPER" preflight "$MCP_SOCKET_DIR" ||
     fail "$SMOKE_LABEL requires no pre-existing live release MCP socket in $MCP_SOCKET_DIR"
@@ -152,6 +173,7 @@ environment = {
     "LOGNAME": os.environ.get("LOGNAME", os.environ.get("USER", "runner")),
     "LANG": "C",
     "LC_ALL": "C",
+    "MCP_SOCKET_DEBUG": "1",
 }
 try:
     completed = subprocess.run(
@@ -161,7 +183,12 @@ try:
         capture_output=True,
         timeout=int(helper_timeout),
     )
-except subprocess.TimeoutExpired:
+except subprocess.TimeoutExpired as error:
+    for value, destination in ((error.stdout, sys.stdout), (error.stderr, sys.stderr)):
+        if value:
+            if isinstance(value, bytes):
+                value = value.decode("utf-8", errors="replace")
+            print(value, end="", file=destination)
     raise SystemExit(124)
 if completed.stdout:
     print(completed.stdout, end="")
@@ -207,6 +234,10 @@ while (( $(date +%s) <= deadline )); do
     last_status=$?
     set -e
     log_phase "$SMOKE_LABEL CLI windows attempt ${attempt} exited with $last_status"
+    if (( last_status != 0 )) && [[ -f "$HELPER_DEBUG_LOG" ]]; then
+        printf '%s\n' "--- helper socket debug tail (attempt $attempt) ---" >&2
+        tail -100 "$HELPER_DEBUG_LOG" >&2 || true
+    fi
     if (( last_status == 0 )); then
         cat "$attempt_stdout"
         cat "$attempt_stderr" >&2

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import base64
 import hashlib
+import importlib.util
 import json
 import os
 import plistlib
@@ -17,6 +18,7 @@ import tempfile
 import time
 import unittest
 import zipfile
+from unittest import mock
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
@@ -1067,6 +1069,14 @@ SIGNING_TEAM_ID=648A27MST5
         self.assertIn('[helper, "-e", "windows"]', source)
         self.assertIn('HELPER_REQUEST_TIMEOUT="${REPOPROMPT_PACKAGED_SMOKE_HELPER_TIMEOUT:-30}"', source)
         self.assertIn('timeout=int(helper_timeout)', source)
+        self.assertIn('"MCP_SOCKET_DEBUG": "1"', source)
+        self.assertIn('REPOPROMPT_PACKAGED_SMOKE_DIAGNOSTICS_DIR', source)
+        self.assertIn('sample "$APP_PID" 5 1', source)
+        cleanup = source.split("cleanup() {", 1)[1].split("\n}", 1)[0]
+        self.assertLess(cleanup.index("set +e"), cleanup.index("sample "))
+        self.assertLess(cleanup.index("set +e"), cleanup.index('kill -TERM "$APP_PID"'))
+        self.assertIn('helper-socket-debug.log', source)
+        self.assertIn('except subprocess.TimeoutExpired as error:', source)
         self.assertIn('REPOPROMPT_PACKAGED_SMOKE_HELPER_TIMEOUT must be a positive integer', source)
         self.assertIn('log_phase() {', source)
         self.assertIn('windows-attempt-${attempt}.out', source)
@@ -1091,6 +1101,27 @@ SIGNING_TEAM_ID=648A27MST5
         self.assertIn('rm -rf "$TEMP_ROOT"', source)
         self.assertNotIn("pkill", source)
         self.assertNotIn("open -n", source)
+
+    @unittest.skipUnless(sys.platform == "darwin", "macOS libproc socket descriptor inspection")
+    def test_packaged_socket_owner_find_treats_startup_snapshot_transition_as_retryable(self) -> None:
+        helper_path = SCRIPT_DIR / "verify_packaged_mcp_socket_owner.py"
+        spec = importlib.util.spec_from_file_location("verify_packaged_mcp_socket_owner_test", helper_path)
+        self.assertIsNotNone(spec)
+        self.assertIsNotNone(spec.loader)
+        helper = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(helper)
+
+        missing_snapshot = (None, {})
+        created_snapshot = ((101, 202), {})
+        with (
+            mock.patch.object(helper, "validate_expected_process") as validate_process,
+            mock.patch.object(helper, "capture_socket_snapshot", side_effect=[missing_snapshot, created_snapshot]),
+            mock.patch.object(helper, "live_release_claims", return_value={}),
+        ):
+            result = helper.find_owner(Path("/tmp/repoprompt-ce-mcp-test"), 123, Path("/tmp/RepoPrompt"))
+
+        self.assertIsNone(result)
+        self.assertEqual(validate_process.call_count, 2)
 
     @unittest.skipUnless(sys.platform == "darwin", "macOS libproc socket descriptor inspection")
     def test_packaged_socket_owner_helper_rejects_live_preflight_and_accepts_exact_owner(self) -> None:
@@ -2521,6 +2552,7 @@ shutil.copyfile(os.environ["FAKE_SWIFTFORMAT_ARCHIVE"], output)
 
         self.assertIn("name: Publish Tip", tip_workflow)
         self.assertIn("group: main-tip-channel", tip_workflow)
+        self.assertIn("cancel-in-progress: true", tip_workflow)
         self.assertIn("should-publish", tip_workflow)
         self.assertIn("stable-appcast.xml", tip_workflow)
         self.assertIn('build_number="$stable_build_number.$((build_sequence / 100)).$((build_sequence % 100))"', tip_workflow)
@@ -2529,6 +2561,9 @@ shutil.copyfile(os.environ["FAKE_SWIFTFORMAT_ARCHIVE"], output)
         self.assertIn("repoprompt-ce-tip-updates", tip_workflow)
         self.assertIn('REPOPROMPT_PACKAGED_SMOKE_TIMEOUT: "240"', tip_workflow)
         self.assertIn('REPOPROMPT_PACKAGED_SMOKE_HELPER_TIMEOUT: "60"', tip_workflow)
+        self.assertIn('REPOPROMPT_PACKAGED_SMOKE_DIAGNOSTICS_DIR: ${{ runner.temp }}/tip-smoke-diagnostics', tip_workflow)
+        self.assertIn("Upload Tip smoke diagnostics", tip_workflow)
+        self.assertIn("RepoPrompt-CE-tip-smoke-diagnostics", tip_workflow)
         self.assertIn('REPOPROMPT_PACKAGED_SMOKE_TIMEOUT="$REPOPROMPT_PACKAGED_SMOKE_TIMEOUT"', tip_workflow)
         self.assertIn(
             'REPOPROMPT_PACKAGED_SMOKE_HELPER_TIMEOUT="$REPOPROMPT_PACKAGED_SMOKE_HELPER_TIMEOUT"',

--- a/Scripts/verify_packaged_mcp_socket_owner.py
+++ b/Scripts/verify_packaged_mcp_socket_owner.py
@@ -43,6 +43,10 @@ class OwnershipError(RuntimeError):
     pass
 
 
+class SocketSnapshotChanged(OwnershipError):
+    """A normal concurrent socket-directory transition that callers may retry."""
+
+
 class ProcFDInfo(ctypes.Structure):
     _fields_ = [("proc_fd", ctypes.c_int32), ("proc_fdtype", ctypes.c_uint32)]
 
@@ -273,9 +277,9 @@ def verify_socket_snapshot(
 ) -> None:
     actual_directory, actual_sockets = capture_socket_snapshot(directory, allow_missing=expected_directory is None)
     if actual_directory != expected_directory:
-        raise OwnershipError(f"release socket directory changed during ownership inspection: {directory}")
+        raise SocketSnapshotChanged(f"release socket directory changed during ownership inspection: {directory}")
     if actual_sockets != expected_sockets:
-        raise OwnershipError(f"release socket paths changed during ownership inspection: {directory}")
+        raise SocketSnapshotChanged(f"release socket paths changed during ownership inspection: {directory}")
 
 
 def ownership_lock_path(socket_path: Path) -> Path:
@@ -567,7 +571,15 @@ def find_owner(directory: Path, expected_pid: int, expected_executable: Path) ->
     validate_expected_process(expected_pid, expected_executable)
     directory_identity, socket_identities = capture_socket_snapshot(directory, allow_missing=True)
     claims = live_release_claims(directory)
-    verify_socket_snapshot(directory, directory_identity, socket_identities)
+    try:
+        verify_socket_snapshot(directory, directory_identity, socket_identities)
+    except SocketSnapshotChanged:
+        # The expected app creates the owner-only directory, lock, and socket while the
+        # smoke polls. A transition during this one inspection is not proof of a foreign
+        # owner; return the documented retry status and require the next pass to prove
+        # the complete process, listener, path, lock, and bound-identity chain.
+        validate_expected_process(expected_pid, expected_executable)
+        return None
     validate_expected_process(expected_pid, expected_executable)
 
     for name, pids in sorted(claims.items()):
@@ -594,7 +606,11 @@ def find_owner(directory: Path, expected_pid: int, expected_executable: Path) ->
         )
     owned_path = directory / owned[0]
     validate_bound_identity_evidence(owned_path, expected_pid, socket_identities[owned[0]])
-    verify_socket_snapshot(directory, directory_identity, socket_identities)
+    try:
+        verify_socket_snapshot(directory, directory_identity, socket_identities)
+    except SocketSnapshotChanged:
+        validate_expected_process(expected_pid, expected_executable)
+        return None
     validate_expected_process(expected_pid, expected_executable)
     return owned_path
 


### PR DESCRIPTION
## Summary
- treat the expected app's socket directory/path creation during `find-owner` as retryable instead of a hard ownership failure
- keep all later PID, executable, listener, lock, and bound-inode checks fail-closed
- make rolling Tip runs supersede obsolete commits so the latest `main` is prioritized
- retain non-secret helper traces and an exact-process stack sample if the signed smoke still fails

## Evidence
The signed Tip smoke in run 30671707365 failed while the launched app was creating its socket directory:

```
ERROR: release socket directory changed during ownership inspection
```

That transition is expected between polling attempts. The prior implementation returned exit 1, while the smoke only retries exit 75.

## Validation
- 5 focused release/ownership tests pass, including live macOS libproc ownership tests and a deterministic missing→created snapshot regression
- `bash -n Scripts/smoke_packaged_mcp_roundtrip.sh`
- Python compile checks
- `make guardrails`
- contribution commit/push preflights and secret scans

Sentry remains compiled, configured, and active; the signed packaged `windows` round trip remains mandatory.