### PR TITLE
Keep failed CI from evicting Tip builds

### DIFF
--- a/.github/workflows/main-tip.yml
+++ b/.github/workflows/main-tip.yml
@@ -13,10 +13,22 @@ on:
         type: string
 
 concurrency:
-  group: main-tip-channel
+  group: >-
+    ${{
+      (github.event_name == 'workflow_dispatch' ||
+        github.event.workflow_run.conclusion == 'success') &&
+      'main-tip-channel' ||
+      format('main-tip-skipped-{0}', github.run_id)
+    }}
   # Tip is a rolling channel: once main advances, completing an older artifact only
-  # delays the commit users actually asked the channel to publish.
-  cancel-in-progress: true
+  # delays the commit users actually asked the channel to publish. A failed CI
+  # notification receives a unique group so it cannot evict a healthy pending or
+  # in-flight Tip build before setup's success guard skips the replacement run.
+  cancel-in-progress: >-
+    ${{
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    }}
 
 permissions:
   contents: read

--- a/.github/workflows/main-tip.yml
+++ b/.github/workflows/main-tip.yml
@@ -24,11 +24,7 @@ concurrency:
   # delays the commit users actually asked the channel to publish. A failed CI
   # notification receives a unique group so it cannot evict a healthy pending or
   # in-flight Tip build before setup's success guard skips the replacement run.
-  cancel-in-progress: >-
-    ${{
-      github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
-    }}
+  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
 
 permissions:
   contents: read

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -2560,7 +2560,7 @@ shutil.copyfile(os.environ["FAKE_SWIFTFORMAT_ARCHIVE"], output)
             normalized_concurrency,
         )
         self.assertIn(
-            "cancel-in-progress: >- ${{ github.event_name == 'workflow_dispatch' || "
+            "cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' || "
             "github.event.workflow_run.conclusion == 'success' }}",
             normalized_concurrency,
         )

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -2551,8 +2551,20 @@ shutil.copyfile(os.environ["FAKE_SWIFTFORMAT_ARCHIVE"], output)
         package_script = (SCRIPT_DIR / "package_app.sh").read_text(encoding="utf-8")
 
         self.assertIn("name: Publish Tip", tip_workflow)
-        self.assertIn("group: main-tip-channel", tip_workflow)
-        self.assertIn("cancel-in-progress: true", tip_workflow)
+        concurrency_block = tip_workflow.split("concurrency:", 1)[1].split("\npermissions:", 1)[0]
+        normalized_concurrency = " ".join(concurrency_block.split())
+        self.assertIn(
+            "group: >- ${{ (github.event_name == 'workflow_dispatch' || "
+            "github.event.workflow_run.conclusion == 'success') && "
+            "'main-tip-channel' || format('main-tip-skipped-{0}', github.run_id) }}",
+            normalized_concurrency,
+        )
+        self.assertIn(
+            "cancel-in-progress: >- ${{ github.event_name == 'workflow_dispatch' || "
+            "github.event.workflow_run.conclusion == 'success' }}",
+            normalized_concurrency,
+        )
+        self.assertNotIn("cancel-in-progress: true", concurrency_block)
         self.assertIn("should-publish", tip_workflow)
         self.assertIn("stable-appcast.xml", tip_workflow)
         self.assertIn('build_number="$stable_build_number.$((build_sequence / 100)).$((build_sequence % 100))"', tip_workflow)


### PR DESCRIPTION
## Summary
- isolate failed-CI Publish Tip audit runs from the rolling channel concurrency group
- preserve latest-wins cancellation for successful CI and manual Tip dispatches
- strengthen the release-tooling contract for the exact concurrency expressions

## Root cause
GitHub concurrency replaces pending runs in the same group regardless of `cancel-in-progress`, and evaluates concurrency before job-level `if` guards. A failed main CI notification therefore canceled/replaced a healthy Tip build and then skipped its own setup job.

## Validation
- `actionlint .github/workflows/main-tip.yml`
- `python3 -m unittest Scripts.test_release_tooling.ReleaseToolingTests.test_main_tip_workflow_keeps_tip_separate_and_uses_hardened_smoke`
- `git diff --check`
- `make guardrails`
- contribution preflight: commit + push