### PR TITLE
Reuse exact CI artifacts for fast Tip retries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,76 @@ jobs:
       - name: Run release workflow tests
         run: make release-selftest
 
+  tip-stage:
+    name: Tip Stage (secretless exact head)
+    if: >-
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main' &&
+      github.repository == 'repoprompt/repoprompt-ce'
+    runs-on: macos-26
+    permissions:
+      contents: read
+    steps:
+      - name: Check out exact main commit
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Resolve Tip build metadata
+        id: tip
+        env:
+          EXPECTED_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          [[ "$(git rev-parse HEAD)" == "$EXPECTED_SHA" ]] || {
+            echo "Tip stage checkout does not match github.sha" >&2
+            exit 1
+          }
+          stable_appcast="$RUNNER_TEMP/stable-appcast.xml"
+          curl --fail --location --retry 3 --silent --show-error \
+            https://github.com/repoprompt/repoprompt-ce-updates/releases/latest/download/appcast.xml \
+            --output "$stable_appcast"
+          python3 Scripts/resolve_tip_build.py \
+            --repository "$GITHUB_WORKSPACE" \
+            --commit "$EXPECTED_SHA" \
+            --stable-appcast "$stable_appcast" \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Stage exact Tip source without secrets
+        env:
+          TIP_COMMIT: ${{ steps.tip.outputs.commit }}
+          TIP_SHORT_SHA: ${{ steps.tip.outputs.short-sha }}
+          TIP_BUILD_NUMBER: ${{ steps.tip.outputs.build-number }}
+          TIP_TAG: ${{ steps.tip.outputs.tag }}
+          TIP_STABLE_BUILD_NUMBER: ${{ steps.tip.outputs.stable-build-number }}
+          TIP_COMMIT_SEQUENCE: ${{ steps.tip.outputs.commit-sequence }}
+          TIP_STAGE_REPOSITORY: repoprompt/repoprompt-ce
+          TIP_STAGE_WORKFLOW: .github/workflows/ci.yml
+          TIP_STAGE_EVENT: push
+          TIP_STAGE_BRANCH: main
+          TIP_STAGE_RUN_ID: ${{ github.run_id }}
+          TIP_STAGE_RUN_ATTEMPT: ${{ github.run_attempt }}
+          TIP_STAGE_ARTIFACT_NAME: RepoPrompt-CE-tip-stage-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.sha }}
+          REPOPROMPT_REQUIRE_TIP_STAGE_METADATA: "1"
+          REPOPROMPT_CONTROL_PLANE_SCRIPTS_DIR: ${{ github.workspace }}/Scripts
+          REPOPROMPT_RELEASE_SOURCE_ROOT: ${{ github.workspace }}
+          REPOPROMPT_ENABLE_SENTRY: "1"
+        run: ./Scripts/main_tip_release.sh stage
+
+      - name: Upload exact Tip stage artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: RepoPrompt-CE-tip-stage-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.sha }}
+          path: |
+            dist/*-stage.zip
+            dist/*-stage.zip.sha256
+            dist/*-stage-metadata.json
+          if-no-files-found: error
+          retention-days: 30
+          compression-level: 0
+
   build-and-test:
     name: Build and Test (app shard ${{ matrix.shard }})
     runs-on: macos-26

--- a/.github/workflows/main-tip.yml
+++ b/.github/workflows/main-tip.yml
@@ -7,9 +7,17 @@ on:
     branches: [main]
   workflow_dispatch:
     inputs:
-      commit:
-        description: Commit SHA on protected main to publish as tip
-        required: false
+      ci_run_id:
+        description: Successful canonical CI run ID containing the Tip stage artifact
+        required: true
+        type: string
+      ci_run_attempt:
+        description: Exact attempt number for the successful CI run
+        required: true
+        type: string
+      expected_sha:
+        description: Exact full protected-main SHA built by that CI attempt
+        required: true
         type: string
 
 concurrency:
@@ -27,22 +35,31 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
 
 permissions:
+  actions: read
   contents: read
 
 jobs:
   setup:
     name: Resolve Tip Commit
     if: >-
-      github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
+      github.repository == 'repoprompt/repoprompt-ce' &&
+      (github.event_name == 'workflow_dispatch' ||
+        github.event.workflow_run.conclusion == 'success')
     runs-on: macos-26
     outputs:
-      commit: ${{ steps.tip.outputs.commit }}
-      short-sha: ${{ steps.tip.outputs.short-sha }}
-      build-number: ${{ steps.tip.outputs.build-number }}
-      tag: ${{ steps.tip.outputs.tag }}
+      commit: ${{ steps.build.outputs.commit }}
+      short-sha: ${{ steps.build.outputs.short-sha }}
+      build-number: ${{ steps.build.outputs.build-number }}
+      tag: ${{ steps.build.outputs.tag }}
       tooling-commit: ${{ steps.tip.outputs.tooling-commit }}
-      should-publish: ${{ steps.tip.outputs.should-publish }}
+      should-publish: ${{ steps.build.outputs.should-publish }}
+      source-run-id: ${{ steps.tip.outputs.source-run-id }}
+      source-run-attempt: ${{ steps.tip.outputs.source-run-attempt }}
+      stage-artifact-id: ${{ steps.tip.outputs.artifact-id }}
+      stage-artifact-name: ${{ steps.tip.outputs.artifact-name }}
+      stable-build-number: ${{ steps.build.outputs.stable-build-number }}
+      commit-sequence: ${{ steps.build.outputs.commit-sequence }}
+      archive-basename: ${{ steps.build.outputs.archive-basename }}
     steps:
       - name: Check out trusted tooling
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -51,54 +68,77 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Resolve protected main commit
+      - name: Resolve exact successful CI stage
         id: tip
         env:
-          REQUESTED_COMMIT: ${{ inputs.commit || github.event.workflow_run.head_sha }}
+          CANONICAL_REPOSITORY: repoprompt/repoprompt-ce
+          SOURCE_RUN_ID: ${{ github.event_name == 'workflow_dispatch' && inputs.ci_run_id || github.event.workflow_run.id }}
+          SOURCE_RUN_ATTEMPT: ${{ github.event_name == 'workflow_dispatch' && inputs.ci_run_attempt || github.event.workflow_run.run_attempt }}
+          EXPECTED_SHA: ${{ github.event_name == 'workflow_dispatch' && inputs.expected_sha || github.event.workflow_run.head_sha }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          [[ "$SOURCE_RUN_ID" =~ ^[1-9][0-9]*$ ]] || { echo "CI run ID must be a positive integer" >&2; exit 1; }
+          [[ "$SOURCE_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]] || { echo "CI run attempt must be a positive integer" >&2; exit 1; }
+          run_json="$RUNNER_TEMP/ci-run.json"
+          workflow_json="$RUNNER_TEMP/ci-workflow.json"
+          artifacts_json="$RUNNER_TEMP/ci-artifacts.json"
+          gh api "repos/$CANONICAL_REPOSITORY/actions/runs/$SOURCE_RUN_ID" > "$run_json"
+          gh api "repos/$CANONICAL_REPOSITORY/actions/workflows/ci.yml" > "$workflow_json"
+          gh api "repos/$CANONICAL_REPOSITORY/actions/runs/$SOURCE_RUN_ID/artifacts?per_page=100" > "$artifacts_json"
+          python3 Scripts/verify_tip_ci_artifact.py resolve \
+            --repository "$CANONICAL_REPOSITORY" \
+            --workflow-path .github/workflows/ci.yml \
+            --run-id "$SOURCE_RUN_ID" \
+            --run-attempt "$SOURCE_RUN_ATTEMPT" \
+            --expected-sha "$EXPECTED_SHA" \
+            --run-json "$run_json" \
+            --workflow-json "$workflow_json" \
+            --artifacts-json "$artifacts_json" \
+            --github-output "$GITHUB_OUTPUT"
+
+          git fetch --no-tags origin main
+          git rev-parse --verify "$EXPECTED_SHA^{commit}" >/dev/null
+          git merge-base --is-ancestor "$EXPECTED_SHA" origin/main || {
+            echo "CI head SHA is not reachable from protected origin/main" >&2
+            exit 1
+          }
+          {
+            echo "source-run-id=$SOURCE_RUN_ID"
+            echo "tooling-commit=$(git rev-parse HEAD)"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Download exact CI stage for identity resolution
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          artifact-ids: ${{ steps.tip.outputs.artifact-id }}
+          github-token: ${{ github.token }}
+          repository: repoprompt/repoprompt-ce
+          run-id: ${{ steps.tip.outputs.source-run-id }}
+          path: staged-tip-setup
+          merge-multiple: true
+
+      - name: Resolve staged Tip build identity
+        id: build
+        env:
+          EXPECTED_SHA: ${{ github.event_name == 'workflow_dispatch' && inputs.expected_sha || github.event.workflow_run.head_sha }}
           TIP_UPDATE_REPOSITORY: ${{ vars.TIP_UPDATE_REPOSITORY || 'repoprompt/repoprompt-ce-tip-updates' }}
           TIP_GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          git fetch --no-tags origin main
-          commit="${REQUESTED_COMMIT:-$(git rev-parse origin/main)}"
-          commit="$(git rev-parse "$commit^{commit}")"
-          git merge-base --is-ancestor "$commit" origin/main || {
-            echo "Requested tip commit is not reachable from origin/main" >&2
-            exit 1
-          }
-          short_sha="$(git rev-parse --short=12 "$commit")"
-          build_sequence="$(git rev-list --count "$commit")"
-          (( build_sequence <= 9999 )) || {
-            echo "Tip build sequence exceeds the three-component CFBundleVersion capacity" >&2
-            exit 1
-          }
-
-          stable_appcast="$RUNNER_TEMP/stable-appcast.xml"
-          curl --fail --location --retry 3 --silent --show-error \
-            https://github.com/repoprompt/repoprompt-ce-updates/releases/latest/download/appcast.xml \
-            --output "$stable_appcast"
-          stable_build_number="$(python3 - "$stable_appcast" <<'PYTHON'
-          import sys
-          import xml.etree.ElementTree as ET
-
-          root = ET.parse(sys.argv[1]).getroot()
-          versions = [
-              (element.text or "").strip()
-              for element in root.iter()
-              if element.tag.rsplit("}", 1)[-1] == "version"
-          ]
-          if len(versions) != 1 or not versions[0].isdigit():
-              raise SystemExit("Stable appcast must contain exactly one numeric sparkle:version")
-          print(versions[0])
-          PYTHON
-          )"
-          (( ${#stable_build_number} <= 4 )) || {
-            echo "Stable build number exceeds CFBundleVersion's four-digit major component" >&2
-            exit 1
-          }
-          build_number="$stable_build_number.$((build_sequence / 100)).$((build_sequence % 100))"
-          archive_basename="RepoPrompt-tip-$short_sha-$build_number"
-          tag="tip-$short_sha"
+          shopt -s nullglob
+          entries=(staged-tip-setup/*)
+          metadata=(staged-tip-setup/*-stage-metadata.json)
+          [[ "${#entries[@]}" == "3" ]] || { echo "Expected exactly three staged Tip files" >&2; exit 1; }
+          [[ "${#metadata[@]}" == "1" ]] || { echo "Expected exactly one staged Tip metadata file" >&2; exit 1; }
+          tip_json="$RUNNER_TEMP/tip-build.json"
+          python3 Scripts/resolve_tip_build.py \
+            --repository "$GITHUB_WORKSPACE" \
+            --commit "$EXPECTED_SHA" \
+            --stage-metadata "${metadata[0]}" \
+            --github-output "$GITHUB_OUTPUT" > "$tip_json"
+          tag="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["tag"])' "$tip_json")"
+          archive_basename="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["archive_basename"])' "$tip_json")"
 
           lookup_classification="$(./Scripts/lookup_public_tip_release.sh \
             "$TIP_UPDATE_REPOSITORY" \
@@ -107,7 +147,7 @@ jobs:
           case "$lookup_classification" in
             found)
               should_publish=false
-              echo "Existing tip release response classification=complete; skipping rebuild."
+              echo "Existing tip release response classification=complete; skipping publish."
               ;;
             not-found)
               should_publish=true
@@ -117,69 +157,16 @@ jobs:
               exit 1
               ;;
           esac
-          {
-            echo "commit=$commit"
-            echo "short-sha=$short_sha"
-            echo "build-number=$build_number"
-            echo "tag=$tag"
-            echo "tooling-commit=$(git rev-parse HEAD)"
-            echo "should-publish=$should_publish"
-          } >> "$GITHUB_OUTPUT"
-
-  stage:
-    name: Build Tip Source Without Secrets
-    needs: setup
-    if: needs.setup.outputs.should-publish == 'true'
-    runs-on: macos-26
-    permissions:
-      contents: read
-    steps:
-      - name: Check out trusted tooling
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          ref: ${{ needs.setup.outputs.tooling-commit }}
-          path: trusted-control-plane
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Check out tip source
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          ref: ${{ needs.setup.outputs.commit }}
-          path: tip-source
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Stage tip artifact
-        env:
-          TIP_COMMIT: ${{ needs.setup.outputs.commit }}
-          TIP_SHORT_SHA: ${{ needs.setup.outputs.short-sha }}
-          TIP_BUILD_NUMBER: ${{ needs.setup.outputs.build-number }}
-          TIP_TAG: ${{ needs.setup.outputs.tag }}
-          REPOPROMPT_CONTROL_PLANE_SCRIPTS_DIR: ${{ github.workspace }}/trusted-control-plane/Scripts
-          REPOPROMPT_RELEASE_SOURCE_ROOT: ${{ github.workspace }}/tip-source
-          # Link Sentry and preserve dSYMs without exposing DSN or auth in this stage.
-          REPOPROMPT_ENABLE_SENTRY: "1"
-        run: ./trusted-control-plane/Scripts/main_tip_release.sh stage
-
-      - name: Upload staged tip source
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
-        with:
-          name: RepoPrompt-CE-staged-tip
-          path: |
-            tip-source/dist/*-stage.zip
-            tip-source/dist/*-stage.zip.sha256
-          if-no-files-found: error
-          retention-days: 1
+          echo "should-publish=$should_publish" >> "$GITHUB_OUTPUT"
 
   sign:
     name: Sign and Notarize Tip
-    needs:
-      - setup
-      - stage
+    needs: setup
+    if: needs.setup.outputs.should-publish == 'true'
     environment: tip-release
     runs-on: macos-26
     permissions:
+      actions: read
       contents: read
     steps:
       - name: Check out trusted tooling
@@ -190,11 +177,15 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Download staged tip source
+      - name: Download exact CI Tip stage artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
-          name: RepoPrompt-CE-staged-tip
+          artifact-ids: ${{ needs.setup.outputs.stage-artifact-id }}
+          github-token: ${{ github.token }}
+          repository: repoprompt/repoprompt-ce
+          run-id: ${{ needs.setup.outputs.source-run-id }}
           path: staged-tip
+          merge-multiple: true
 
       - name: Check out approved tip source as data
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -207,17 +198,45 @@ jobs:
       - name: Verify and expand staged tip source
         env:
           RELEASE_COMMIT: ${{ needs.setup.outputs.commit }}
+          SOURCE_RUN_ID: ${{ needs.setup.outputs.source-run-id }}
+          SOURCE_RUN_ATTEMPT: ${{ needs.setup.outputs.source-run-attempt }}
+          STAGE_ARTIFACT_NAME: ${{ needs.setup.outputs.stage-artifact-name }}
+          STABLE_BUILD_NUMBER: ${{ needs.setup.outputs.stable-build-number }}
+          COMMIT_SEQUENCE: ${{ needs.setup.outputs.commit-sequence }}
+          TIP_TAG: ${{ needs.setup.outputs.tag }}
+          ARCHIVE_BASENAME: ${{ needs.setup.outputs.archive-basename }}
           REPOPROMPT_RELEASE_BUILD_NUMBER_OVERRIDE: ${{ needs.setup.outputs.build-number }}
         run: |
           set -euo pipefail
           shopt -s nullglob
+          entries=(staged-tip/*)
           archives=(staged-tip/*-stage.zip)
           checksums=(staged-tip/*-stage.zip.sha256)
+          metadata=(staged-tip/*-stage-metadata.json)
+          [[ "${#entries[@]}" == "3" ]] || { echo "Expected exactly three staged tip artifact files" >&2; exit 1; }
           [[ "${#archives[@]}" == "1" ]] || { echo "Expected one staged tip ZIP" >&2; exit 1; }
           [[ "${#checksums[@]}" == "1" ]] || { echo "Expected one staged tip checksum" >&2; exit 1; }
+          [[ "${#metadata[@]}" == "1" ]] || { echo "Expected one staged tip metadata file" >&2; exit 1; }
+          [[ "${archives[0]}" == "staged-tip/$ARCHIVE_BASENAME-stage.zip" ]] || { echo "Staged tip archive name mismatch" >&2; exit 1; }
           [[ "${checksums[0]}" == "${archives[0]}.sha256" ]] || { echo "Staged tip checksum name mismatch" >&2; exit 1; }
+          [[ "${metadata[0]}" == "staged-tip/$ARCHIVE_BASENAME-stage-metadata.json" ]] || { echo "Staged tip metadata name mismatch" >&2; exit 1; }
           (cd staged-tip && shasum -a 256 -c "$(basename "${checksums[0]}")")
           ./trusted-control-plane/Scripts/extract_staged_release.py "${archives[0]}" tip-source RepoPrompt
+          python3 trusted-control-plane/Scripts/verify_tip_ci_artifact.py verify-metadata \
+            --repository repoprompt/repoprompt-ce \
+            --workflow-path .github/workflows/ci.yml \
+            --run-id "$SOURCE_RUN_ID" \
+            --run-attempt "$SOURCE_RUN_ATTEMPT" \
+            --expected-sha "$RELEASE_COMMIT" \
+            --artifact-name "$STAGE_ARTIFACT_NAME" \
+            --stable-build-number "$STABLE_BUILD_NUMBER" \
+            --commit-sequence "$COMMIT_SEQUENCE" \
+            --build-number "$REPOPROMPT_RELEASE_BUILD_NUMBER_OVERRIDE" \
+            --tag "$TIP_TAG" \
+            --metadata "${metadata[0]}" \
+            --archive "${archives[0]}" \
+            --checksum "${checksums[0]}" \
+            --app-manifest tip-source/.build/release/RepoPrompt-artifact-manifest.json
           REPOPROMPT_RELEASE_SOURCE_ROOT=tip-source \
             REPOPROMPT_APPROVED_SOURCE_ROOT=approved-source \
             ./trusted-control-plane/Scripts/validate_staged_release.sh
@@ -308,7 +327,7 @@ jobs:
       - name: Upload signed tip assets for smoke and publish
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
-          name: RepoPrompt-CE-signed-tip
+          name: RepoPrompt-CE-signed-tip-${{ github.run_id }}-${{ needs.setup.outputs.commit }}
           path: |
             tip-source/dist/*.zip
             tip-source/dist/*.dmg
@@ -317,7 +336,7 @@ jobs:
             tip-source/dist/*-artifact-manifest.json
             tip-source/dist/*-metadata.json
           if-no-files-found: error
-          retention-days: 1
+          retention-days: 30
 
   smoke-no-secrets:
     name: Smoke Tip Without Release Secrets
@@ -339,7 +358,7 @@ jobs:
       - name: Download signed tip assets
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
-          name: RepoPrompt-CE-signed-tip
+          name: RepoPrompt-CE-signed-tip-${{ github.run_id }}-${{ needs.setup.outputs.commit }}
           path: signed-tip
 
       - name: Verify and smoke signed tip
@@ -374,7 +393,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
-          name: RepoPrompt-CE-tip-smoke-diagnostics
+          name: RepoPrompt-CE-tip-smoke-diagnostics-${{ github.run_attempt }}
           path: ${{ runner.temp }}/tip-smoke-diagnostics
           if-no-files-found: warn
           retention-days: 3
@@ -400,7 +419,7 @@ jobs:
       - name: Download signed tip assets
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
-          name: RepoPrompt-CE-signed-tip
+          name: RepoPrompt-CE-signed-tip-${{ github.run_id }}-${{ needs.setup.outputs.commit }}
           path: tip-assets
 
       - name: Publish tip update release

--- a/Scripts/main_tip_release.sh
+++ b/Scripts/main_tip_release.sh
@@ -45,6 +45,7 @@ FINAL_ARTIFACT_MANIFEST="$DIST_DIR/$ARCHIVE_BASENAME-artifact-manifest.json"
 FINAL_METADATA="$DIST_DIR/$ARCHIVE_BASENAME-metadata.json"
 STAGE_ARCHIVE="$DIST_DIR/$ARCHIVE_BASENAME-stage.zip"
 STAGE_ARCHIVE_CHECKSUM="$STAGE_ARCHIVE.sha256"
+STAGE_METADATA="$DIST_DIR/$ARCHIVE_BASENAME-stage-metadata.json"
 RUN_WITHOUT_GITHUB_TOKENS="$CONTROL_PLANE_SCRIPTS_DIR/run_without_github_tokens.sh"
 SIGN_UPDATE="$TRUSTED_ROOT/Vendor/Sparkle/bin/sign_update"
 TMP_DIR=""
@@ -133,6 +134,98 @@ write_tip_metadata() {
 JSON
 }
 
+write_tip_stage_metadata() {
+    [[ "${REPOPROMPT_REQUIRE_TIP_STAGE_METADATA:-0}" == "1" ]] || return 0
+    for name in \
+        TIP_STAGE_REPOSITORY \
+        TIP_STAGE_WORKFLOW \
+        TIP_STAGE_EVENT \
+        TIP_STAGE_BRANCH \
+        TIP_STAGE_RUN_ID \
+        TIP_STAGE_RUN_ATTEMPT \
+        TIP_STAGE_ARTIFACT_NAME \
+        TIP_STABLE_BUILD_NUMBER \
+        TIP_COMMIT_SEQUENCE; do
+        require_env "$name"
+    done
+    [[ "$TIP_STAGE_RUN_ID" =~ ^[1-9][0-9]*$ ]] || fail "TIP_STAGE_RUN_ID must be a positive integer"
+    [[ "$TIP_STAGE_RUN_ATTEMPT" =~ ^[1-9][0-9]*$ ]] || fail "TIP_STAGE_RUN_ATTEMPT must be a positive integer"
+    [[ "$TIP_COMMIT_SEQUENCE" =~ ^[1-9][0-9]*$ ]] || fail "TIP_COMMIT_SEQUENCE must be a positive integer"
+
+    local archive_digest checksum_digest app_manifest_digest
+    archive_digest="$(shasum -a 256 "$STAGE_ARCHIVE" | awk '{print $1}')"
+    checksum_digest="$(shasum -a 256 "$STAGE_ARCHIVE_CHECKSUM" | awk '{print $1}')"
+    app_manifest_digest="$(shasum -a 256 "$BUILD_ARTIFACT_MANIFEST" | awk '{print $1}')"
+    python3 - \
+        "$STAGE_METADATA" \
+        "$TIP_STAGE_REPOSITORY" \
+        "$TIP_STAGE_WORKFLOW" \
+        "$TIP_STAGE_EVENT" \
+        "$TIP_STAGE_BRANCH" \
+        "$TIP_STAGE_RUN_ID" \
+        "$TIP_STAGE_RUN_ATTEMPT" \
+        "$TIP_COMMIT" \
+        "$TIP_STAGE_ARTIFACT_NAME" \
+        "$TIP_STABLE_BUILD_NUMBER" \
+        "$TIP_COMMIT_SEQUENCE" \
+        "$TIP_BUILD_NUMBER" \
+        "$TIP_TAG" \
+        "$(basename "$STAGE_ARCHIVE")" \
+        "$archive_digest" \
+        "$(basename "$STAGE_ARCHIVE_CHECKSUM")" \
+        "$checksum_digest" \
+        "$app_manifest_digest" <<'PYTHON'
+import json
+import sys
+from pathlib import Path
+
+(
+    output,
+    repository,
+    workflow,
+    event,
+    branch,
+    run_id,
+    run_attempt,
+    head_sha,
+    artifact_name,
+    stable_build_number,
+    commit_sequence,
+    build_number,
+    tag,
+    archive,
+    archive_sha256,
+    checksum,
+    checksum_sha256,
+    app_manifest_sha256,
+) = sys.argv[1:]
+metadata = {
+    "schema_version": 1,
+    "repository": repository,
+    "workflow": workflow,
+    "event": event,
+    "branch": branch,
+    "run_id": int(run_id),
+    "run_attempt": int(run_attempt),
+    "head_sha": head_sha,
+    "artifact_name": artifact_name,
+    "stable_build_number": stable_build_number,
+    "commit_sequence": int(commit_sequence),
+    "build_number": build_number,
+    "tag": tag,
+    "archive": archive,
+    "archive_sha256": archive_sha256,
+    "checksum": checksum,
+    "checksum_sha256": checksum_sha256,
+    "app_manifest_sha256": app_manifest_sha256,
+}
+Path(output).write_text(
+    json.dumps(metadata, indent=2, sort_keys=True) + "\n",
+    encoding="utf-8",
+)
+PYTHON
+}
+
 require_tip_sentry_configuration() {
     release_sentry_linking_enabled ||
         fail "Official Tip signing requires REPOPROMPT_ENABLE_SENTRY=1"
@@ -204,6 +297,7 @@ stage_tip() {
     write_tip_metadata
     ditto -c -k --norsrc "$stage_root" "$STAGE_ARCHIVE"
     (cd "$DIST_DIR" && shasum -a 256 "$(basename "$STAGE_ARCHIVE")" > "$(basename "$STAGE_ARCHIVE_CHECKSUM")")
+    write_tip_stage_metadata
     printf 'OK: staged tip build %s (%s) for %s.\n' "$TIP_TAG" "$TIP_BUILD_NUMBER" "$TIP_COMMIT"
 }
 

--- a/Scripts/resolve_tip_build.py
+++ b/Scripts/resolve_tip_build.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Resolve deterministic RepoPrompt CE Tip build metadata."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+from pathlib import Path
+
+
+FULL_SHA = re.compile(r"[0-9a-f]{40}")
+STABLE_BUILD = re.compile(r"[1-9][0-9]{0,3}")
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"ERROR: {message}")
+
+
+def run_git(repository: Path, *arguments: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repository), *arguments],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        fail((result.stderr or result.stdout or "git command failed").strip())
+    return result.stdout.strip()
+
+
+def validate_stable_build(value: object, source: str) -> str:
+    if not isinstance(value, str) or not STABLE_BUILD.fullmatch(value):
+        fail(f"{source} must be a canonical positive decimal with at most four digits")
+    return value
+
+
+def parse_stable_build(appcast: Path) -> str:
+    import xml.etree.ElementTree as ET
+
+    try:
+        root = ET.parse(appcast).getroot()
+    except (OSError, ET.ParseError) as error:
+        fail(f"could not parse stable appcast: {error}")
+    versions = [
+        (element.text or "").strip()
+        for element in root.iter()
+        if element.tag.rsplit("}", 1)[-1] == "version"
+    ]
+    if len(versions) != 1:
+        fail(f"stable appcast must contain exactly one sparkle:version, got {len(versions)}")
+    return validate_stable_build(versions[0], "stable appcast sparkle:version")
+
+
+def read_stage_metadata(path: Path) -> dict[str, object]:
+    try:
+        metadata = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        fail(f"could not parse Tip stage metadata: {error}")
+    if not isinstance(metadata, dict):
+        fail("Tip stage metadata must be a JSON object")
+    return metadata
+
+
+def resolve(
+    repository: Path,
+    commit: str,
+    stable_build: str,
+    app_name: str,
+) -> dict[str, object]:
+    if not FULL_SHA.fullmatch(commit):
+        fail("Tip commit must be a full lowercase 40-character SHA")
+    resolved_commit = run_git(repository, "rev-parse", "--verify", f"{commit}^{{commit}}")
+    if resolved_commit != commit:
+        fail(f"Tip commit did not resolve exactly: expected {commit}, got {resolved_commit}")
+    sequence_text = run_git(repository, "rev-list", "--count", commit)
+    if not sequence_text.isdigit():
+        fail("Tip commit sequence must be numeric")
+    sequence = int(sequence_text)
+    if sequence < 1 or sequence > 9999:
+        fail("Tip commit sequence must be between 1 and 9999")
+
+    stable_build = validate_stable_build(stable_build, "stable build number")
+    short_sha = commit[:12]
+    build_number = f"{stable_build}.{sequence // 100}.{sequence % 100}"
+    tag = f"tip-{short_sha}"
+    archive_basename = f"{app_name}-tip-{short_sha}-{build_number}"
+    return {
+        "commit": commit,
+        "short_sha": short_sha,
+        "stable_build_number": stable_build,
+        "commit_sequence": sequence,
+        "build_number": build_number,
+        "tag": tag,
+        "archive_basename": archive_basename,
+    }
+
+
+def write_github_output(path: Path, metadata: dict[str, object]) -> None:
+    names = {
+        "commit": "commit",
+        "short_sha": "short-sha",
+        "stable_build_number": "stable-build-number",
+        "commit_sequence": "commit-sequence",
+        "build_number": "build-number",
+        "tag": "tag",
+        "archive_basename": "archive-basename",
+    }
+    with path.open("a", encoding="utf-8") as output:
+        for key, name in names.items():
+            output.write(f"{name}={metadata[key]}\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repository", required=True, type=Path)
+    parser.add_argument("--commit", required=True)
+    stable_source = parser.add_mutually_exclusive_group(required=True)
+    stable_source.add_argument("--stable-appcast", type=Path)
+    stable_source.add_argument("--stage-metadata", type=Path)
+    parser.add_argument("--app-name", default="RepoPrompt")
+    parser.add_argument("--github-output", type=Path)
+    args = parser.parse_args()
+
+    stage_metadata = None
+    if args.stable_appcast is not None:
+        stable_build = parse_stable_build(args.stable_appcast)
+    else:
+        stage_metadata = read_stage_metadata(args.stage_metadata)
+        stable_build = validate_stable_build(
+            stage_metadata.get("stable_build_number"),
+            "Tip stage metadata stable_build_number",
+        )
+
+    metadata = resolve(args.repository, args.commit, stable_build, args.app_name)
+    if stage_metadata is not None:
+        expected = {
+            "head_sha": metadata["commit"],
+            "stable_build_number": metadata["stable_build_number"],
+            "commit_sequence": metadata["commit_sequence"],
+            "build_number": metadata["build_number"],
+            "tag": metadata["tag"],
+            "archive": f"{metadata['archive_basename']}-stage.zip",
+        }
+        for key, value in expected.items():
+            if stage_metadata.get(key) != value:
+                fail(
+                    f"Tip stage metadata {key} mismatch: "
+                    f"expected {value!r}, got {stage_metadata.get(key)!r}"
+                )
+    if args.github_output is not None:
+        write_github_output(args.github_output, metadata)
+    print(json.dumps(metadata, sort_keys=True, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -2554,8 +2554,316 @@ shutil.copyfile(os.environ["FAKE_SWIFTFORMAT_ARCHIVE"], output)
         )
 
 
+    def test_tip_build_resolver_rejects_bad_appcasts_commits_and_overflow(self) -> None:
+        root = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, root, True)
+        repository = root / "repository"
+        repository.mkdir()
+        subprocess.run(["git", "init", "-q", str(repository)], check=True)
+        subprocess.run(["git", "-C", str(repository), "config", "user.email", "tip@example.invalid"], check=True)
+        subprocess.run(["git", "-C", str(repository), "config", "user.name", "Tip Test"], check=True)
+        for index in range(3):
+            (repository / "fixture").write_text(f"{index}\n", encoding="utf-8")
+            subprocess.run(["git", "-C", str(repository), "add", "fixture"], check=True)
+            subprocess.run(["git", "-C", str(repository), "commit", "-qm", f"fixture {index}"], check=True)
+        commit = subprocess.check_output(
+            ["git", "-C", str(repository), "rev-parse", "HEAD"],
+            text=True,
+        ).strip()
+        appcast = root / "appcast.xml"
+        appcast.write_text(
+            '<rss xmlns:sparkle="https://sparkle-project.org/xml-namespaces/sparkle"><channel>'
+            "<item><sparkle:version>42</sparkle:version></item></channel></rss>\n",
+            encoding="utf-8",
+        )
+        command = [
+            sys.executable,
+            str(SCRIPT_DIR / "resolve_tip_build.py"),
+            "--repository",
+            str(repository),
+            "--commit",
+            commit,
+            "--stable-appcast",
+            str(appcast),
+        ]
+        resolved = subprocess.run(command, text=True, capture_output=True)
+        self.assertEqual(resolved.returncode, 0, resolved.stderr)
+        metadata = json.loads(resolved.stdout)
+        self.assertEqual(metadata["stable_build_number"], "42")
+        self.assertEqual(metadata["commit_sequence"], 3)
+        self.assertEqual(metadata["build_number"], "42.0.3")
+        self.assertEqual(metadata["tag"], f"tip-{commit[:12]}")
+
+        malformed_documents = [
+            "<rss>",
+            "<rss><channel /></rss>",
+            "<rss><version>1</version><version>2</version></rss>",
+        ]
+        for document in malformed_documents:
+            with self.subTest(document=document):
+                appcast.write_text(document, encoding="utf-8")
+                rejected = subprocess.run(command, text=True, capture_output=True)
+                self.assertNotEqual(rejected.returncode, 0)
+
+        for version in ("0", "01", "+1", "1.2", "10000"):
+            with self.subTest(version=version):
+                appcast.write_text(f"<rss><version>{version}</version></rss>\n", encoding="utf-8")
+                rejected = subprocess.run(command, text=True, capture_output=True)
+                self.assertNotEqual(rejected.returncode, 0)
+                self.assertIn("canonical positive decimal", rejected.stderr)
+
+        appcast.write_text("<rss><version>42</version></rss>\n", encoding="utf-8")
+        missing_commit = command.copy()
+        missing_commit[missing_commit.index(commit)] = "0" * 40
+        rejected = subprocess.run(missing_commit, text=True, capture_output=True)
+        self.assertNotEqual(rejected.returncode, 0)
+
+        module_spec = importlib.util.spec_from_file_location("resolve_tip_build", SCRIPT_DIR / "resolve_tip_build.py")
+        self.assertIsNotNone(module_spec)
+        self.assertIsNotNone(module_spec.loader)
+        module = importlib.util.module_from_spec(module_spec)
+        module_spec.loader.exec_module(module)
+        with mock.patch.object(module, "run_git", side_effect=[commit, "10000"]):
+            with self.assertRaisesRegex(SystemExit, "between 1 and 9999"):
+                module.resolve(repository, commit, "42", "RepoPrompt")
+
+    def test_tip_build_resolver_reuses_and_checks_staged_identity(self) -> None:
+        repository = SCRIPT_DIR.parent
+        commit = subprocess.check_output(
+            ["git", "-C", str(repository), "rev-parse", "HEAD"],
+            text=True,
+        ).strip()
+        sequence = int(
+            subprocess.check_output(
+                ["git", "-C", str(repository), "rev-list", "--count", commit],
+                text=True,
+            ).strip()
+        )
+        root = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, root, True)
+        metadata_path = root / "stage-metadata.json"
+        expected = {
+            "head_sha": commit,
+            "stable_build_number": "42",
+            "commit_sequence": sequence,
+            "build_number": f"42.{sequence // 100}.{sequence % 100}",
+            "tag": f"tip-{commit[:12]}",
+            "archive": f"RepoPrompt-tip-{commit[:12]}-42.{sequence // 100}.{sequence % 100}-stage.zip",
+        }
+        metadata_path.write_text(json.dumps(expected), encoding="utf-8")
+        command = [
+            sys.executable,
+            str(SCRIPT_DIR / "resolve_tip_build.py"),
+            "--repository",
+            str(repository),
+            "--commit",
+            commit,
+            "--stage-metadata",
+            str(metadata_path),
+        ]
+        resolved = subprocess.run(command, text=True, capture_output=True)
+        self.assertEqual(resolved.returncode, 0, resolved.stderr)
+        tampered = dict(expected)
+        tampered["build_number"] = "42.0.0"
+        metadata_path.write_text(json.dumps(tampered), encoding="utf-8")
+        rejected = subprocess.run(command, text=True, capture_output=True)
+        self.assertNotEqual(rejected.returncode, 0)
+        self.assertIn("build_number mismatch", rejected.stderr)
+
+    def test_tip_ci_artifact_verifier_correlates_run_and_payload_metadata(self) -> None:
+        root = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, root, True)
+        commit = "a" * 40
+        run_id = 12345
+        run_attempt = 3
+        artifact_attempt = 2
+        repository_id = 987
+        artifact_name = f"RepoPrompt-CE-tip-stage-{run_id}-{artifact_attempt}-{commit}"
+        run = {
+            "id": run_id,
+            "run_attempt": run_attempt,
+            "name": "CI",
+            "workflow_id": 55,
+            "path": ".github/workflows/ci.yml@refs/heads/main",
+            "event": "push",
+            "head_branch": "main",
+            "status": "completed",
+            "conclusion": "success",
+            "head_sha": commit,
+            "repository": {"id": repository_id, "full_name": "repoprompt/repoprompt-ce"},
+            "head_repository": {"id": repository_id, "full_name": "repoprompt/repoprompt-ce"},
+        }
+        workflow = {"id": 55, "path": ".github/workflows/ci.yml"}
+        artifact = {
+            "id": 777,
+            "name": artifact_name,
+            "expired": False,
+            "size_in_bytes": 100,
+            "digest": f"sha256:{'b' * 64}",
+            "workflow_run": {
+                "id": run_id,
+                "head_sha": commit,
+                "head_branch": "main",
+                "repository_id": repository_id,
+                "head_repository_id": repository_id,
+            },
+        }
+        earlier_artifact = dict(
+            artifact,
+            id=776,
+            name=f"RepoPrompt-CE-tip-stage-{run_id}-1-{commit}",
+        )
+        run_path = root / "run.json"
+        workflow_path = root / "workflow.json"
+        artifacts_path = root / "artifacts.json"
+        output_path = root / "output"
+        run_path.write_text(json.dumps(run), encoding="utf-8")
+        workflow_path.write_text(json.dumps(workflow), encoding="utf-8")
+        artifacts_path.write_text(json.dumps({"artifacts": [earlier_artifact, artifact]}), encoding="utf-8")
+        resolve_command = [
+            sys.executable,
+            str(SCRIPT_DIR / "verify_tip_ci_artifact.py"),
+            "resolve",
+            "--repository",
+            "repoprompt/repoprompt-ce",
+            "--workflow-path",
+            ".github/workflows/ci.yml",
+            "--run-id",
+            str(run_id),
+            "--run-attempt",
+            str(run_attempt),
+            "--expected-sha",
+            commit,
+            "--run-json",
+            str(run_path),
+            "--workflow-json",
+            str(workflow_path),
+            "--artifacts-json",
+            str(artifacts_path),
+            "--github-output",
+            str(output_path),
+        ]
+        resolved = subprocess.run(resolve_command, text=True, capture_output=True)
+        self.assertEqual(resolved.returncode, 0, resolved.stderr)
+        output = output_path.read_text(encoding="utf-8")
+        self.assertIn("artifact-id=777", output)
+        self.assertIn(f"source-run-attempt={artifact_attempt}", output)
+        self.assertNotIn("artifact-digest", output)
+
+        for field, bad_value in (
+            ("run_attempt", 4),
+            ("event", "pull_request"),
+            ("head_branch", "feature"),
+            ("head_sha", "c" * 40),
+            ("conclusion", "failure"),
+        ):
+            with self.subTest(field=field):
+                tampered_run = dict(run)
+                tampered_run[field] = bad_value
+                run_path.write_text(json.dumps(tampered_run), encoding="utf-8")
+                rejected = subprocess.run(resolve_command, text=True, capture_output=True)
+                self.assertNotEqual(rejected.returncode, 0)
+        run_path.write_text(json.dumps(run), encoding="utf-8")
+
+        tampered_run = dict(run)
+        tampered_run["repository"] = {"id": repository_id, "full_name": "attacker/fork"}
+        run_path.write_text(json.dumps(tampered_run), encoding="utf-8")
+        rejected = subprocess.run(resolve_command, text=True, capture_output=True)
+        self.assertNotEqual(rejected.returncode, 0)
+        run_path.write_text(json.dumps(run), encoding="utf-8")
+
+        artifacts_path.write_text(json.dumps({"artifacts": [artifact, artifact]}), encoding="utf-8")
+        rejected = subprocess.run(resolve_command, text=True, capture_output=True)
+        self.assertNotEqual(rejected.returncode, 0)
+        self.assertIn("exactly one Tip stage artifact for attempt", rejected.stderr)
+        future_artifact = dict(
+            artifact,
+            name=f"RepoPrompt-CE-tip-stage-{run_id}-{run_attempt + 1}-{commit}",
+        )
+        artifacts_path.write_text(json.dumps({"artifacts": [future_artifact]}), encoding="utf-8")
+        rejected = subprocess.run(resolve_command, text=True, capture_output=True)
+        self.assertNotEqual(rejected.returncode, 0)
+        self.assertIn("attempt exceeds the completed CI run attempt", rejected.stderr)
+        tampered_artifact = dict(artifact)
+        tampered_artifact["workflow_run"] = dict(artifact["workflow_run"], id=run_id + 1)
+        artifacts_path.write_text(json.dumps({"artifacts": [tampered_artifact]}), encoding="utf-8")
+        rejected = subprocess.run(resolve_command, text=True, capture_output=True)
+        self.assertNotEqual(rejected.returncode, 0)
+        artifacts_path.write_text(json.dumps({"artifacts": [artifact]}), encoding="utf-8")
+
+        archive = root / "RepoPrompt-tip-aaaaaaaaaaaa-42.1.23-stage.zip"
+        checksum = root / f"{archive.name}.sha256"
+        manifest = root / "RepoPrompt-artifact-manifest.json"
+        archive.write_bytes(b"stage archive")
+        manifest.write_bytes(b'{"manifest":1}\n')
+        archive_digest = hashlib.sha256(archive.read_bytes()).hexdigest()
+        checksum.write_text(f"{archive_digest}  {archive.name}\n", encoding="utf-8")
+        stage_metadata = {
+            "schema_version": 1,
+            "repository": "repoprompt/repoprompt-ce",
+            "workflow": ".github/workflows/ci.yml",
+            "event": "push",
+            "branch": "main",
+            "run_id": run_id,
+            "run_attempt": artifact_attempt,
+            "head_sha": commit,
+            "artifact_name": artifact_name,
+            "stable_build_number": "42",
+            "commit_sequence": 123,
+            "build_number": "42.1.23",
+            "tag": "tip-aaaaaaaaaaaa",
+            "archive": archive.name,
+            "archive_sha256": archive_digest,
+            "checksum": checksum.name,
+            "checksum_sha256": hashlib.sha256(checksum.read_bytes()).hexdigest(),
+            "app_manifest_sha256": hashlib.sha256(manifest.read_bytes()).hexdigest(),
+        }
+        metadata_path = root / "stage-metadata.json"
+        metadata_path.write_text(json.dumps(stage_metadata), encoding="utf-8")
+        metadata_command = [
+            sys.executable,
+            str(SCRIPT_DIR / "verify_tip_ci_artifact.py"),
+            "verify-metadata",
+            "--repository",
+            "repoprompt/repoprompt-ce",
+            "--workflow-path",
+            ".github/workflows/ci.yml",
+            "--run-id",
+            str(run_id),
+            "--run-attempt",
+            str(artifact_attempt),
+            "--expected-sha",
+            commit,
+            "--artifact-name",
+            artifact_name,
+            "--stable-build-number",
+            "42",
+            "--commit-sequence",
+            "123",
+            "--build-number",
+            "42.1.23",
+            "--tag",
+            "tip-aaaaaaaaaaaa",
+            "--metadata",
+            str(metadata_path),
+            "--archive",
+            str(archive),
+            "--checksum",
+            str(checksum),
+            "--app-manifest",
+            str(manifest),
+        ]
+        verified = subprocess.run(metadata_command, text=True, capture_output=True)
+        self.assertEqual(verified.returncode, 0, verified.stderr)
+        manifest.write_bytes(b"tampered\n")
+        rejected = subprocess.run(metadata_command, text=True, capture_output=True)
+        self.assertNotEqual(rejected.returncode, 0)
+        self.assertIn("app_manifest_sha256 mismatch", rejected.stderr)
+
     def test_main_tip_workflow_keeps_tip_separate_and_uses_hardened_smoke(self) -> None:
-        tip_workflow = (SCRIPT_DIR.parent / ".github" / "workflows" / "main-tip.yml").read_text(encoding="utf-8")
+        workflows_dir = SCRIPT_DIR.parent / ".github" / "workflows"
+        tip_workflow = (workflows_dir / "main-tip.yml").read_text(encoding="utf-8")
+        ci_workflow = (workflows_dir / "ci.yml").read_text(encoding="utf-8")
         tip_script = (SCRIPT_DIR / "main_tip_release.sh").read_text(encoding="utf-8")
         package_script = (SCRIPT_DIR / "package_app.sh").read_text(encoding="utf-8")
 
@@ -2575,8 +2883,10 @@ shutil.copyfile(os.environ["FAKE_SWIFTFORMAT_ARCHIVE"], output)
         )
         self.assertNotIn("cancel-in-progress: true", concurrency_block)
         self.assertIn("should-publish", tip_workflow)
-        self.assertIn("stable-appcast.xml", tip_workflow)
-        self.assertIn('build_number="$stable_build_number.$((build_sequence / 100)).$((build_sequence % 100))"', tip_workflow)
+        self.assertNotIn("stable-appcast.xml", tip_workflow)
+        self.assertIn("--stage-metadata", tip_workflow)
+        self.assertIn("stable-appcast.xml", ci_workflow)
+        self.assertIn("Scripts/resolve_tip_build.py", ci_workflow)
         self.assertIn("environment: tip-release", tip_workflow)
         self.assertIn("TIP_UPDATE_REPOSITORY_TOKEN", tip_workflow)
         self.assertIn("repoprompt-ce-tip-updates", tip_workflow)
@@ -2584,7 +2894,7 @@ shutil.copyfile(os.environ["FAKE_SWIFTFORMAT_ARCHIVE"], output)
         self.assertIn('REPOPROMPT_PACKAGED_SMOKE_HELPER_TIMEOUT: "60"', tip_workflow)
         self.assertIn('REPOPROMPT_PACKAGED_SMOKE_DIAGNOSTICS_DIR: ${{ runner.temp }}/tip-smoke-diagnostics', tip_workflow)
         self.assertIn("Upload Tip smoke diagnostics", tip_workflow)
-        self.assertIn("RepoPrompt-CE-tip-smoke-diagnostics", tip_workflow)
+        self.assertIn("RepoPrompt-CE-tip-smoke-diagnostics-${{ github.run_attempt }}", tip_workflow)
         self.assertIn('REPOPROMPT_PACKAGED_SMOKE_TIMEOUT="$REPOPROMPT_PACKAGED_SMOKE_TIMEOUT"', tip_workflow)
         self.assertIn(
             'REPOPROMPT_PACKAGED_SMOKE_HELPER_TIMEOUT="$REPOPROMPT_PACKAGED_SMOKE_HELPER_TIMEOUT"',
@@ -2600,7 +2910,8 @@ shutil.copyfile(os.environ["FAKE_SWIFTFORMAT_ARCHIVE"], output)
         self.assertNotIn("release-draft-creation", tip_workflow)
         self.assertNotIn("PUBLIC_UPDATE_REPOSITORY_TOKEN", tip_workflow)
 
-        stage_job = tip_workflow.split("\n  stage:", 1)[1].split("\n  sign:", 1)[0]
+        self.assertNotIn("\n  stage:", tip_workflow)
+        stage_job = ci_workflow.split("\n  tip-stage:", 1)[1].split("\n  build-and-test:", 1)[0]
         sign_job = tip_workflow.split("\n  sign:", 1)[1].split("\n  smoke-no-secrets:", 1)[0]
         sign_step = sign_job.split("      - name: Sign and notarize staged tip", 1)[1].split(
             "      - name: Remove ephemeral keychain", 1
@@ -2609,12 +2920,22 @@ shutil.copyfile(os.environ["FAKE_SWIFTFORMAT_ARCHIVE"], output)
             "      - name: Upload signed tip assets", 1
         )[0]
         self.assertIn('REPOPROMPT_ENABLE_SENTRY: "1"', stage_job)
+        self.assertIn("github.event_name == 'push'", stage_job)
+        self.assertIn("github.ref == 'refs/heads/main'", stage_job)
+        self.assertIn("github.repository == 'repoprompt/repoprompt-ce'", stage_job)
+        self.assertIn("RepoPrompt-CE-tip-stage-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.sha }}", stage_job)
+        self.assertIn("retention-days: 30", stage_job)
+        self.assertIn("compression-level: 0", stage_job)
         for protected_name in (
+            "secrets.",
             "SENTRY_DSN",
             "SENTRY_AUTH_TOKEN",
             "REPOPROMPT_SENTRY_ORG",
             "REPOPROMPT_SENTRY_PROJECT",
             "REPOPROMPT_SENTRY_AUTH_TOKEN_FILE",
+            "SIGN_IDENTITY",
+            "NOTARYTOOL_",
+            "SPARKLE_PRIVATE_KEY",
         ):
             self.assertNotIn(protected_name, stage_job)
         self.assertIn("Install Sentry CLI for Tip symbol upload", sign_job)
@@ -2639,6 +2960,22 @@ shutil.copyfile(os.environ["FAKE_SWIFTFORMAT_ARCHIVE"], output)
             ),
             1,
         )
+        verify_stage = sign_job.index("Verify and expand staged tip source")
+        import_certificate = sign_job.index("Import Developer ID certificate")
+        prepare_secrets = sign_job.index("Prepare provisioning profile and notarization key")
+        prepare_sentry = sign_job.index("Prepare Tip Sentry auth token file")
+        self.assertIn("verify_tip_ci_artifact.py verify-metadata", sign_job)
+        self.assertIn("extract_staged_release.py", sign_job)
+        self.assertIn("validate_staged_release.sh", sign_job)
+        self.assertLess(verify_stage, import_certificate)
+        self.assertLess(verify_stage, prepare_secrets)
+        self.assertLess(verify_stage, prepare_sentry)
+        self.assertIn("RepoPrompt-CE-signed-tip-${{ github.run_id }}-${{ needs.setup.outputs.commit }}", sign_job)
+        self.assertEqual(
+            tip_workflow.count("RepoPrompt-CE-signed-tip-${{ github.run_id }}-${{ needs.setup.outputs.commit }}"),
+            3,
+        )
+        self.assertIn("retention-days: 30", sign_job)
         self.assertLess(
             sign_job.index("Install Sentry CLI for Tip symbol upload"),
             sign_job.index("Sign and notarize staged tip"),
@@ -2712,20 +3049,39 @@ shutil.copyfile(os.environ["FAKE_SWIFTFORMAT_ARCHIVE"], output)
             package_script,
         )
 
-    def test_main_tip_setup_uses_read_only_github_token_for_release_lookup_helper(self) -> None:
+    def test_main_tip_requires_explicit_exact_ci_provenance(self) -> None:
         tip_workflow = (SCRIPT_DIR.parent / ".github" / "workflows" / "main-tip.yml").read_text(encoding="utf-8")
-        setup_job = tip_workflow.split("\n  setup:", 1)[1].split("\n  stage:", 1)[0]
-        after_setup = tip_workflow.split("\n  stage:", 1)[1]
+        setup_job = tip_workflow.split("\n  setup:", 1)[1].split("\n  sign:", 1)[0]
+        sign_job = tip_workflow.split("\n  sign:", 1)[1].split("\n  smoke-no-secrets:", 1)[0]
         before_publish, publish_job = tip_workflow.split("\n  publish:", 1)
 
-        self.assertIn("permissions:\n  contents: read", tip_workflow)
+        self.assertIn("actions: read", tip_workflow)
+        for input_name in ("ci_run_id", "ci_run_attempt", "expected_sha"):
+            self.assertRegex(
+                tip_workflow,
+                rf"(?m)^      {input_name}:\n(?:        [^\n]*\n)*        required: true$",
+            )
+        self.assertNotIn("latest", setup_job.lower())
+        self.assertIn("github.event.workflow_run.id", setup_job)
+        self.assertIn("github.event.workflow_run.run_attempt", setup_job)
+        self.assertIn("github.event.workflow_run.head_sha", setup_job)
+        self.assertIn('gh api "repos/$CANONICAL_REPOSITORY/actions/runs/$SOURCE_RUN_ID"', setup_job)
+        self.assertIn("verify_tip_ci_artifact.py resolve", setup_job)
+        self.assertIn("--run-attempt \"$SOURCE_RUN_ATTEMPT\"", setup_job)
+        self.assertIn("--expected-sha \"$EXPECTED_SHA\"", setup_job)
+        self.assertIn("artifact-ids: ${{ steps.tip.outputs.artifact-id }}", setup_job)
+        self.assertIn("run-id: ${{ steps.tip.outputs.source-run-id }}", setup_job)
+        self.assertIn("merge-multiple: true", setup_job)
         self.assertIn("./Scripts/lookup_public_tip_release.sh", setup_job)
         self.assertIn("TIP_GH_TOKEN: ${{ github.token }}", setup_job)
-        self.assertEqual(tip_workflow.count("${{ github.token }}"), 1)
-        self.assertNotIn("${{ github.token }}", after_setup)
         self.assertNotIn("environment: tip-release", setup_job)
+        self.assertNotIn("secrets.", setup_job)
         self.assertNotIn("Authorization:", setup_job)
-        self.assertNotIn("api.github.com", setup_job)
+        self.assertIn("artifact-ids: ${{ needs.setup.outputs.stage-artifact-id }}", sign_job)
+        self.assertIn("run-id: ${{ needs.setup.outputs.source-run-id }}", sign_job)
+        self.assertIn("merge-multiple: true", sign_job)
+        self.assertEqual(tip_workflow.count("merge-multiple: true"), 2)
+        self.assertNotIn("stage-artifact-digest", tip_workflow)
         self.assertNotIn("TIP_UPDATE_REPOSITORY_TOKEN", before_publish)
         self.assertIn("TIP_GH_TOKEN: ${{ secrets.TIP_UPDATE_REPOSITORY_TOKEN }}", publish_job)
         self.assertEqual(tip_workflow.count("TIP_UPDATE_REPOSITORY_TOKEN"), 1)
@@ -3271,16 +3627,18 @@ label_generated_tip_appcast""",
         workflows_dir = SCRIPT_DIR.parent / ".github" / "workflows"
         release_workflow = (workflows_dir / "release.yml").read_text(encoding="utf-8")
         tip_workflow = (workflows_dir / "main-tip.yml").read_text(encoding="utf-8")
+        ci_workflow = (workflows_dir / "ci.yml").read_text(encoding="utf-8")
 
         release_stage_job = release_workflow.split("\n  stage:", 1)[1].split("\n  publish:", 1)[0]
-        tip_stage_job = tip_workflow.split("\n  stage:", 1)[1].split("\n  sign:", 1)[0]
+        tip_stage_job = ci_workflow.split("\n  tip-stage:", 1)[1].split("\n  build-and-test:", 1)[0]
         release_stage_function = release_script.split("stage_publish_release() {", 1)[1].split("\n}", 1)[0]
         tip_stage_function = tip_script.split("stage_tip() {", 1)[1].split("\n}", 1)[0]
         release_resolver = release_script.split("resolve_without_lockfile_drift() {", 1)[1].split("\n}", 1)[0]
         tip_resolver = tip_script.split("resolve_without_lockfile_drift() {", 1)[1].split("\n}", 1)[0]
 
         self.assertIn("run: ./trusted-control-plane/Scripts/release.sh stage-publish", release_stage_job)
-        self.assertIn("run: ./trusted-control-plane/Scripts/main_tip_release.sh stage", tip_stage_job)
+        self.assertIn("run: ./Scripts/main_tip_release.sh stage", tip_stage_job)
+        self.assertNotIn("\n  stage:", tip_workflow)
         self.assertIn("resolve_without_lockfile_drift", release_stage_function)
         self.assertIn("resolve_without_lockfile_drift", tip_stage_function)
         self.assertIn('"$RUN_WITHOUT_GITHUB_TOKENS" swift package resolve', release_resolver)

--- a/Scripts/verify_tip_ci_artifact.py
+++ b/Scripts/verify_tip_ci_artifact.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Validate the exact CI run, Actions artifact, and Tip stage metadata."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+
+FULL_SHA = re.compile(r"[0-9a-f]{40}")
+FILE_DIGEST = re.compile(r"[0-9a-f]{64}")
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"ERROR: {message}")
+
+
+def read_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        fail(f"could not parse {path.name}: {error}")
+
+
+def require_equal(actual: Any, expected: Any, label: str) -> None:
+    if actual != expected:
+        fail(f"{label} mismatch: expected {expected!r}, got {actual!r}")
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+    except OSError as error:
+        fail(f"could not hash {path}: {error}")
+    return digest.hexdigest()
+
+
+def write_github_output(path: Path, values: dict[str, object]) -> None:
+    with path.open("a", encoding="utf-8") as output:
+        for name, value in values.items():
+            output.write(f"{name}={value}\n")
+
+
+def resolve_artifact(args: argparse.Namespace) -> dict[str, object]:
+    if not FULL_SHA.fullmatch(args.expected_sha):
+        fail("expected SHA must be a full lowercase 40-character SHA")
+    if args.run_id < 1 or args.run_attempt < 1:
+        fail("CI run ID and attempt must be positive integers")
+
+    run = read_json(args.run_json)
+    workflow = read_json(args.workflow_json)
+    artifacts_document = read_json(args.artifacts_json)
+    if not isinstance(run, dict) or not isinstance(workflow, dict) or not isinstance(artifacts_document, dict):
+        fail("GitHub API documents must be JSON objects")
+
+    require_equal(run.get("id"), args.run_id, "CI run ID")
+    require_equal(run.get("run_attempt"), args.run_attempt, "CI run attempt")
+    require_equal(run.get("name"), args.workflow_name, "CI workflow name")
+    require_equal(run.get("workflow_id"), workflow.get("id"), "CI workflow ID")
+    require_equal(str(run.get("path", "")).split("@", 1)[0], args.workflow_path, "CI workflow path")
+    require_equal(str(workflow.get("path", "")).split("@", 1)[0], args.workflow_path, "workflow API path")
+    require_equal(run.get("event"), args.event, "CI event")
+    require_equal(run.get("head_branch"), args.branch, "CI head branch")
+    require_equal(run.get("status"), "completed", "CI status")
+    require_equal(run.get("conclusion"), "success", "CI conclusion")
+    require_equal(run.get("head_sha"), args.expected_sha, "CI head SHA")
+    require_equal((run.get("repository") or {}).get("full_name"), args.repository, "CI repository")
+    require_equal((run.get("head_repository") or {}).get("full_name"), args.repository, "CI head repository")
+    repository_id = (run.get("repository") or {}).get("id")
+    head_repository_id = (run.get("head_repository") or {}).get("id")
+    if not isinstance(repository_id, int) or repository_id < 1:
+        fail("CI repository ID must be a positive integer")
+    require_equal(head_repository_id, repository_id, "CI head repository ID")
+
+    name_pattern = re.compile(
+        rf"RepoPrompt-CE-tip-stage-{args.run_id}-([1-9][0-9]*)-{args.expected_sha}"
+    )
+    artifacts = artifacts_document.get("artifacts")
+    if not isinstance(artifacts, list):
+        fail("workflow artifacts response must contain an artifacts array")
+    candidates: list[tuple[int, dict[str, object]]] = []
+    for artifact in artifacts:
+        if not isinstance(artifact, dict) or not isinstance(artifact.get("name"), str):
+            continue
+        match = name_pattern.fullmatch(artifact["name"])
+        if match is None:
+            continue
+        artifact_attempt = int(match.group(1))
+        if artifact_attempt > args.run_attempt:
+            fail("Tip stage artifact attempt exceeds the completed CI run attempt")
+        candidates.append((artifact_attempt, artifact))
+    if not candidates:
+        fail("expected at least one run-bound Tip stage artifact")
+    artifact_attempt = max(attempt for attempt, _ in candidates)
+    matching = [artifact for attempt, artifact in candidates if attempt == artifact_attempt]
+    if len(matching) != 1:
+        fail(f"expected exactly one Tip stage artifact for attempt {artifact_attempt}, got {len(matching)}")
+    artifact = matching[0]
+    expected_name = f"RepoPrompt-CE-tip-stage-{args.run_id}-{artifact_attempt}-{args.expected_sha}"
+    artifact_id = artifact.get("id")
+    if not isinstance(artifact_id, int) or artifact_id < 1:
+        fail("Tip stage artifact ID must be a positive integer")
+    if artifact.get("expired") is not False:
+        fail("Tip stage artifact is expired")
+    size = artifact.get("size_in_bytes")
+    if not isinstance(size, int) or size < 1:
+        fail("Tip stage artifact must be nonempty")
+    artifact_run = artifact.get("workflow_run") or {}
+    require_equal(artifact_run.get("id"), args.run_id, "artifact workflow run ID")
+    require_equal(artifact_run.get("head_sha"), args.expected_sha, "artifact head SHA")
+    require_equal(artifact_run.get("head_branch"), args.branch, "artifact head branch")
+    require_equal(artifact_run.get("repository_id"), repository_id, "artifact repository ID")
+    require_equal(artifact_run.get("head_repository_id"), repository_id, "artifact head repository ID")
+
+    return {
+        "artifact-id": artifact_id,
+        "artifact-name": expected_name,
+        "source-run-attempt": artifact_attempt,
+    }
+
+
+def verify_stage_metadata(args: argparse.Namespace) -> None:
+    metadata = read_json(args.metadata)
+    if not isinstance(metadata, dict):
+        fail("Tip stage metadata must be a JSON object")
+    expected_keys = {
+        "schema_version",
+        "repository",
+        "workflow",
+        "event",
+        "branch",
+        "run_id",
+        "run_attempt",
+        "head_sha",
+        "artifact_name",
+        "stable_build_number",
+        "commit_sequence",
+        "build_number",
+        "tag",
+        "archive",
+        "archive_sha256",
+        "checksum",
+        "checksum_sha256",
+        "app_manifest_sha256",
+    }
+    require_equal(set(metadata), expected_keys, "Tip stage metadata keys")
+    expected_values = {
+        "schema_version": 1,
+        "repository": args.repository,
+        "workflow": args.workflow_path,
+        "event": args.event,
+        "branch": args.branch,
+        "run_id": args.run_id,
+        "run_attempt": args.run_attempt,
+        "head_sha": args.expected_sha,
+        "artifact_name": args.artifact_name,
+        "stable_build_number": args.stable_build_number,
+        "commit_sequence": args.commit_sequence,
+        "build_number": args.build_number,
+        "tag": args.tag,
+        "archive": args.archive.name,
+        "checksum": args.checksum.name,
+    }
+    for key, expected in expected_values.items():
+        require_equal(metadata.get(key), expected, f"Tip stage metadata {key}")
+
+    archive_digest = sha256(args.archive)
+    checksum_digest = sha256(args.checksum)
+    manifest_digest = sha256(args.app_manifest)
+    for key, expected in {
+        "archive_sha256": archive_digest,
+        "checksum_sha256": checksum_digest,
+        "app_manifest_sha256": manifest_digest,
+    }.items():
+        value = metadata.get(key)
+        if not isinstance(value, str) or not FILE_DIGEST.fullmatch(value):
+            fail(f"Tip stage metadata {key} must be a lowercase SHA-256")
+        require_equal(value, expected, f"Tip stage metadata {key}")
+
+    try:
+        checksum_lines = args.checksum.read_text(encoding="utf-8").splitlines()
+    except OSError as error:
+        fail(f"could not read stage checksum: {error}")
+    expected_checksum_line = f"{archive_digest}  {args.archive.name}"
+    require_equal(checksum_lines, [expected_checksum_line], "stage checksum contents")
+    print("OK: Tip stage metadata matches the exact successful CI artifact.")
+
+
+def positive_integer(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError("must be an integer") from None
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be positive")
+    return parsed
+
+
+def add_common(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--workflow-path", required=True)
+    parser.add_argument("--event", default="push")
+    parser.add_argument("--branch", default="main")
+    parser.add_argument("--run-id", required=True, type=positive_integer)
+    parser.add_argument("--run-attempt", required=True, type=positive_integer)
+    parser.add_argument("--expected-sha", required=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    resolve_parser = subparsers.add_parser("resolve")
+    add_common(resolve_parser)
+    resolve_parser.add_argument("--workflow-name", default="CI")
+    resolve_parser.add_argument("--run-json", required=True, type=Path)
+    resolve_parser.add_argument("--workflow-json", required=True, type=Path)
+    resolve_parser.add_argument("--artifacts-json", required=True, type=Path)
+    resolve_parser.add_argument("--github-output", required=True, type=Path)
+
+    metadata_parser = subparsers.add_parser("verify-metadata")
+    add_common(metadata_parser)
+    metadata_parser.add_argument("--artifact-name", required=True)
+    metadata_parser.add_argument("--stable-build-number", required=True)
+    metadata_parser.add_argument("--commit-sequence", required=True, type=positive_integer)
+    metadata_parser.add_argument("--build-number", required=True)
+    metadata_parser.add_argument("--tag", required=True)
+    metadata_parser.add_argument("--metadata", required=True, type=Path)
+    metadata_parser.add_argument("--archive", required=True, type=Path)
+    metadata_parser.add_argument("--checksum", required=True, type=Path)
+    metadata_parser.add_argument("--app-manifest", required=True, type=Path)
+
+    args = parser.parse_args()
+    if args.command == "resolve":
+        values = resolve_artifact(args)
+        write_github_output(args.github_output, values)
+        print(json.dumps(values, sort_keys=True, separators=(",", ":")))
+    else:
+        verify_stage_metadata(args)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -221,31 +221,43 @@ repository. Tip workflows must never write to `repoprompt-ce-updates`, must not
 use `v*` tags, and must not feed into `Promote Release`. Stable promotion remains
 the only path that updates the stable appcast.
 
-`Publish Tip` runs after successful CI on `main` and can also be dispatched
-manually. It stages the tip source without secrets, signs and notarizes without
-executing packaged app/helper code, runs the PR #441 hardened packaged smoke on a
-fresh no-secret runner, then publishes a normal GitHub release in the dedicated
-tip update repository using an immutable tag shaped like `tip-<shortsha>`. The
-release is marked latest inside the tip-only repository so GitHub's
+Canonical `main` push CI stages the exact `github.sha` in a parallel,
+secretless `tip-stage` job. Pull-request CI cannot run that job. The producer
+uploads `RepoPrompt-CE-tip-stage-<ci-run-id>-<attempt>-<full-sha>` with the stage
+ZIP, its checksum, and the minimal run/build identity metadata for 30 days.
+`Publish Tip` consumes that exact artifact only after a successful canonical CI
+`workflow_run`; manual dispatch requires the CI run ID, its current completed
+attempt, and the expected full SHA explicitly and never selects a latest run.
+
+The protected workflow verifies the upstream repository, CI workflow, push
+event, `main` branch, run ID, attempt, full head SHA, artifact identity, checksum,
+stage metadata, packaged manifest, dSYMs, and approved source before importing
+release credentials. It then signs and notarizes without executing packaged
+app/helper code, runs the PR #441 hardened packaged smoke on a fresh no-secret
+runner, and publishes a normal GitHub release in the dedicated tip update
+repository using an immutable tag shaped like `tip-<shortsha>`. The release is
+marked latest inside the tip-only repository so GitHub's
 `releases/latest/download/appcast.xml` URL resolves for opted-in clients. Do not
 mark the tip release as a prerelease: GitHub excludes prereleases from
 `releases/latest`.
 
-Tip `CFBundleVersion` values sort between adjacent stable builds. The workflow
-reads the currently published stable appcast and combines that stable build with
-the source commit count. For example, commit sequence `795` on stable build `28`
-becomes Tip build `28.7.95`: it is newer than stable `28`, while stable `29`
-still supersedes it. This keeps Stable and Tip in one monotonic Sparkle version
-space without forcing stable releases to adopt repository-sized build numbers.
-The source commit count must remain at or below `9999`; replace this encoding
-before the repository reaches that limit.
+Tip `CFBundleVersion` values sort between adjacent stable builds. The CI
+producer reads the currently published stable appcast and the shared resolver
+combines that stable build with the exact source commit count. For example,
+commit sequence `795` on stable build `28` becomes Tip build `28.7.95`: it is
+newer than stable `28`, while stable `29` still supersedes it. The consumer uses
+the same resolver against the retained metadata, so a later stable release does
+not change the identity of an already-staged Tip. This keeps Stable and Tip in
+one monotonic Sparkle version space without forcing stable releases to adopt
+repository-sized build numbers. The source commit count must remain at or below
+`9999`; replace this encoding before the repository reaches that limit.
 
 The workflow uses GitHub concurrency to allow one active and one pending run.
 New successful `main` runs replace an older pending run while an active signing
-or notarization run finishes. Before compiling, it uses the workflow's read-only
-`github.token` to check for a complete release for the immutable `tip-<shortsha>`
-tag and skips an already-published commit. The protected update-repository token
-remains confined to the publishing job.
+or notarization run finishes. Before signing, it uses the workflow's read-only
+`github.token` to check for a complete release for the immutable
+`tip-<shortsha>` tag and skips an already-published commit. The protected
+update-repository token remains confined to the publishing job.
 
 Configure a protected GitHub Actions environment named `tip-release`. It can use
 the same Developer ID, provisioning, notarization, and Sparkle secrets as stable
@@ -266,6 +278,24 @@ the job, and requires the final artifact manifest to record
 `telemetry_enabled: true`. The workflow materializes Sentry auth in an
 owner-only temporary token file and removes it through the job's always-run
 cleanup step.
+
+The CI consumer accepts the newest retained Tip stage artifact at or before the
+successful run attempt. This matters for **Re-run failed jobs**: if the Tip stage
+job already passed, GitHub keeps that earlier-attempt artifact while rerunning
+only failed shards under a newer overall attempt. The artifact's own attempt is
+still bound into its name and signed-stage metadata and is verified before any
+release secret is exposed.
+
+After signing succeeds, `Publish Tip` retains the uniquely named signed asset
+artifact for 30 days. If packaged smoke or publishing fails, open that same
+workflow run in GitHub Actions and choose **Re-run failed jobs**. GitHub reuses
+the successful sign job and its retained artifact, so those downstream jobs do
+not rebuild or resign. Do not start an unbound replacement run or rerun all jobs
+for this recovery path. After 30 days the signed artifact expires and the
+shortcut is unavailable; use a new manual `Publish Tip` dispatch with the exact
+still-retained CI run ID, its current completed attempt, and expected SHA (which
+signs again), or let a new canonical `main` CI run stage a new artifact. This retention mechanism does
+not make publishing idempotent and does not resume a partially created release.
 
 ## Contributor release candidate
 


### PR DESCRIPTION
## Summary

- build the exact protected-main Tip stage once inside canonical push CI
- retain and reuse that immutable run/attempt/SHA-bound artifact for signing, smoke, publish, failed-job reruns, and explicit recovery dispatches
- centralize Tip build identity resolution and validate repository/workflow/run/artifact metadata, archive checksum, and packaged manifest before importing release secrets
- retain signed assets for fast downstream retries while preserving Sentry, Developer ID, notarization, Sparkle, and real packaged-app smoke boundaries

## Why

The existing pipeline recompiles the universal release source during Publish Tip, even though canonical CI has already spent roughly 60–90 minutes building the same source. A smoke or publish retry repeats that cost. The measured local universal release artifact validation for this change took **1h 30m 29s**.

## Security and provenance

- producer is canonical push CI on main, checked out at exact github.sha
- artifact identity binds CI run ID, producing attempt, full SHA, repository IDs, workflow, event, and branch
- archive checksum, stage metadata, approved source, and packaged manifest are verified before certificate/profile/notary/Sentry secrets
- Sentry remains linked in the secretless stage; DSN/auth and symbol upload remain in protected signing
- signed packaged-app smoke remains a required no-secret gate before appcast publication
- manual recovery requires explicit CI run ID, current completed attempt, and expected full SHA; it never selects latest

## Validation

- Fab High architecture review and final review: approved; review-blocking by-ID extraction issue fixed
- python3 -m unittest Scripts.test_release_tooling
- make release-selftest
- make ci-app-test-runner-selftest (55 tests)
- make guardrails
- actionlint on CI and Publish Tip workflows
- shell syntax, Python compile, and git diff --check
- coordinated release artifact ticket 563dc9da-87eb-4096-9b3a-3354cbe1b718: passed in 1h 30m 29s, including universal arm64+x86_64 Sentry-linked products/dSYMs, packaging, signing verification, architecture/layout/manifest checks, and embedded MCP helper smoke

## Follow-ups

This PR intentionally does not change the release gate or simplify the packaged smoke harness. Those remain separate, net-simplifying follow-up tracks after artifact reuse lands.

