### PR TITLE
Optimize Agent Mode sidebar projection caching

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+SidebarSessions.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+SidebarSessions.swift
@@ -366,13 +366,29 @@ extension AgentModeViewModel {
         return pinned + unpinned
     }
 
+    private func makeSessionSidebarStashedTabSignatures(
+        for stashedTabs: [StashedTab]
+    ) -> [AgentSessionSidebarStashedTabSignature] {
+        stashedTabs.enumerated().map { index, stashedTab in
+            AgentSessionSidebarStashedTabSignature(
+                stashedTabID: stashedTab.id,
+                stashedAt: stashedTab.stashedAt,
+                rawTabName: stashedTab.tab.name,
+                tabMetadata: makeSessionSidebarTabMetadataSignature(
+                    for: stashedTab.tab,
+                    order: index
+                )
+            )
+        }
+    }
+
     /// Session-linked sidebar data source.
     /// Blank compose tabs stay hidden until they are explicitly linked to an agent session.
     func sidebarSessions(for tabs: [ComposeTabState]) -> [SidebarSession] {
         let cacheKey = SidebarSessionRowsCacheKey(
             workspaceID: workspaceManager?.activeWorkspaceID,
             sidebarRevision: ui.sessionSidebar.snapshot.revision,
-            tabs: tabs
+            tabMetadataSignatures: makeSessionSidebarTabMetadataSignatures(for: tabs)
         )
         if let cached = sidebarSessionRowsCache, cached.key == cacheKey {
             return cached.rows
@@ -415,6 +431,9 @@ extension AgentModeViewModel {
             mcpControlledTabIDs: mcpControlledTabIDs
         ).build()
         sidebarSessionRowsCache = (cacheKey, rows)
+        #if DEBUG
+            test_sidebarSessionRowsBuildCount &+= 1
+        #endif
         return rows
     }
 
@@ -481,8 +500,8 @@ extension AgentModeViewModel {
             workspaceID: workspaceManager?.activeWorkspaceID,
             sidebarSnapshot: sidebarSnapshot,
             currentTabID: currentTabID,
-            composeTabs: composeTabs,
-            stashedTabs: stashedTabs,
+            composeTabMetadataSignatures: makeSessionSidebarTabMetadataSignatures(for: composeTabs),
+            stashedTabSignatures: makeSessionSidebarStashedTabSignatures(for: stashedTabs),
             archivedSessionsExpanded: archivedSessionsExpanded
         )
         if let cached = sidebarListProjectionCache, cached.key == key {

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+SidebarUI.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+SidebarUI.swift
@@ -308,6 +308,30 @@ extension AgentModeViewModel {
         _ = ui.sessionSidebar.clearRunStateAttention(for: tabIDs)
     }
 
+    /// Captures the compact compose-tab metadata that can affect sidebar rows.
+    /// This is the shared authority for refresh fingerprints and projection caches.
+    func makeSessionSidebarTabMetadataSignature(
+        for tab: ComposeTabState,
+        order: Int
+    ) -> AgentSessionSidebarTabMetadataSignature {
+        AgentSessionSidebarTabMetadataSignature(
+            tabID: tab.id,
+            order: order,
+            normalizedName: AgentSessionRestoreSupport.normalizedSessionTitle(tab.name),
+            activeAgentSessionID: tab.activeAgentSessionID,
+            isPinned: tab.isPinned,
+            lastModified: tab.lastModified
+        )
+    }
+
+    func makeSessionSidebarTabMetadataSignatures(
+        for tabs: [ComposeTabState]
+    ) -> [AgentSessionSidebarTabMetadataSignature] {
+        tabs.enumerated().map { index, tab in
+            makeSessionSidebarTabMetadataSignature(for: tab, order: index)
+        }
+    }
+
     /// Captures the current VM-level sidebar inputs (compose tab titles/metadata,
     /// sessions, sessionIndex, sort dates, badges, tree state, current tab, etc.)
     /// into a value-type fingerprint. Snapshotting every `TabSession` into
@@ -315,18 +339,7 @@ extension AgentModeViewModel {
     /// independent of class identity.
     func makeSessionSidebarContentFingerprint(for sidebarTabs: [ComposeTabState]? = nil) -> AgentSessionSidebarContentFingerprint {
         let tabs = sidebarTabs ?? sidebarContentFingerprintTabs
-        let tabMetadataSignatures: [AgentSessionSidebarTabMetadataSignature] = tabs
-            .enumerated()
-            .map { index, tab in
-                AgentSessionSidebarTabMetadataSignature(
-                    tabID: tab.id,
-                    order: index,
-                    normalizedName: AgentSessionRestoreSupport.normalizedSessionTitle(tab.name),
-                    activeAgentSessionID: tab.activeAgentSessionID,
-                    isPinned: tab.isPinned,
-                    lastModified: tab.lastModified
-                )
-            }
+        let tabMetadataSignatures = makeSessionSidebarTabMetadataSignatures(for: tabs)
         let signatures: [AgentSessionSidebarTabSignature] = sessions
             .keys
             .sorted { $0.uuidString < $1.uuidString }

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+Types.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+Types.swift
@@ -174,15 +174,15 @@ extension AgentModeViewModel {
     struct SidebarSessionRowsCacheKey: Equatable {
         let workspaceID: UUID?
         let sidebarRevision: Int
-        let tabs: [ComposeTabState]
+        let tabMetadataSignatures: [AgentSessionSidebarTabMetadataSignature]
     }
 
     struct SidebarListProjectionCacheKey: Equatable {
         let workspaceID: UUID?
         let sidebarSnapshot: AgentSessionSidebarSnapshot
         let currentTabID: UUID?
-        let composeTabs: [ComposeTabState]
-        let stashedTabs: [StashedTab]
+        let composeTabMetadataSignatures: [AgentSessionSidebarTabMetadataSignature]
+        let stashedTabSignatures: [AgentSessionSidebarStashedTabSignature]
         let archivedSessionsExpanded: Bool
     }
 
@@ -215,6 +215,16 @@ extension AgentModeViewModel {
         let activeAgentSessionID: UUID?
         let isPinned: Bool
         let lastModified: Date
+    }
+
+    /// Signature of a stashed tab's archived-sidebar projection inputs and the
+    /// fields read from cached `StashedTab` row values. Full compose state is
+    /// intentionally excluded because restore/delete resolve the current tab by ID.
+    struct AgentSessionSidebarStashedTabSignature: Equatable {
+        let stashedTabID: UUID
+        let stashedAt: Date
+        let rawTabName: String
+        let tabMetadata: AgentSessionSidebarTabMetadataSignature
     }
 
     /// Signature of a single `TabSession`'s sidebar-relevant state. Captured into a

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -647,6 +647,7 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         private var test_activeWorkspaceIDForSessionIndexOverride: UUID?
         private var test_allowsScheduledDerivedTranscriptRefreshWithoutPromptManager = false
         private var test_persistentBindingResolutionSnapshotBuildCount = 0
+        var test_sidebarSessionRowsBuildCount = 0
         var test_sidebarListProjectionBuildCount = 0
         private var test_afterMCPStoreEpochBegan: (@MainActor () async -> Void)?
         private var test_terminalPublicationOverride: ((

--- a/Tests/RepoPromptTests/AgentMode/AgentModeViewModelInactiveRefreshTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeViewModelInactiveRefreshTests.swift
@@ -758,12 +758,17 @@ final class AgentModeViewModelInactiveRefreshTests: XCTestCase {
                 activeAgentSessionID: UUID()
             )
         }
+        let archivedSessionIDs = [UUID(), UUID()]
+        let archiveDate = Date(timeIntervalSince1970: 1000)
         let stashedTabs = (0 ..< 200).map { index in
-            StashedTab(tab: ComposeTabState(
-                id: UUID(),
-                name: "Archived \(index)",
-                activeAgentSessionID: UUID()
-            ))
+            StashedTab(
+                tab: ComposeTabState(
+                    id: UUID(),
+                    name: "Archived \(index)",
+                    activeAgentSessionID: index < archivedSessionIDs.count ? archivedSessionIDs[index] : UUID()
+                ),
+                stashedAt: archiveDate.addingTimeInterval(TimeInterval(index))
+            )
         }
         var workspace = makeWorkspace(
             name: "Sidebar projection scale",
@@ -774,44 +779,130 @@ final class AgentModeViewModelInactiveRefreshTests: XCTestCase {
         let manager = makeWorkspaceManager(workspaces: [workspace])
         manager.activeWorkspace = workspace
         viewModel.workspaceManager = manager
+        let owner = AgentModeViewModel.SessionIndexOwner(workspaceID: workspace.id, activationEpoch: 1)
+        let archivedEntries = Dictionary(uniqueKeysWithValues: archivedSessionIDs.enumerated().map { index, sessionID in
+            let entry = makeIndexEntry(
+                id: sessionID,
+                tabID: stashedTabs[index].tab.id,
+                lastUserMessageAt: archiveDate,
+                savedAt: archiveDate
+            )
+            return (entry.id, entry)
+        })
+        viewModel.test_installSessionIndexSnapshot(
+            archivedEntries,
+            owner: owner,
+            latestOwner: owner,
+            activeWorkspace: workspace
+        )
         let snapshot = viewModel.ui.sessionSidebar.snapshot
 
-        _ = viewModel.sidebarListProjection(
+        let initialProjection = viewModel.sidebarListProjection(
             composeTabs: composeTabs,
             stashedTabs: stashedTabs,
             currentTabID: composeTabs.first?.id,
             sidebarSnapshot: snapshot,
-            archivedSessionsExpanded: false
+            archivedSessionsExpanded: true
         )
         _ = viewModel.sidebarListProjection(
             composeTabs: composeTabs,
             stashedTabs: stashedTabs,
             currentTabID: composeTabs.first?.id,
             sidebarSnapshot: snapshot,
-            archivedSessionsExpanded: false
+            archivedSessionsExpanded: true
         )
+        XCTAssertEqual(initialProjection.sortedArchivedSessionTabsForRows.map(\.id), [stashedTabs[1].id, stashedTabs[0].id])
+        XCTAssertEqual(viewModel.test_sidebarSessionRowsBuildCount, 1)
         XCTAssertEqual(viewModel.test_sidebarListProjectionBuildCount, 1)
 
-        var renamedTabs = composeTabs
-        renamedTabs[0].name = "Renamed"
+        var unrelatedComposeChurn = composeTabs
+        unrelatedComposeChurn[0].promptText = "Draft changed"
+        unrelatedComposeChurn[0].selection = StoredSelection(selectedPaths: ["Sources/Changed.swift"])
+        unrelatedComposeChurn[0].expandedFolders = ["Sources", "Tests"]
+        var unrelatedStashedChurn = stashedTabs
+        unrelatedStashedChurn[0].tab.promptText = "Archived draft changed"
+        unrelatedStashedChurn[0].tab.selection = StoredSelection(selectedPaths: ["Sources/Archived.swift"])
+        unrelatedStashedChurn[0].tab.expandedFolders = ["Sources/RepoPrompt"]
+
         _ = viewModel.sidebarListProjection(
-            composeTabs: renamedTabs,
-            stashedTabs: stashedTabs,
+            composeTabs: unrelatedComposeChurn,
+            stashedTabs: unrelatedStashedChurn,
             currentTabID: composeTabs.first?.id,
             sidebarSnapshot: snapshot,
-            archivedSessionsExpanded: false
+            archivedSessionsExpanded: true
         )
+        _ = viewModel.sidebarSessions(for: unrelatedComposeChurn)
+        XCTAssertEqual(viewModel.test_sidebarSessionRowsBuildCount, 1)
+        XCTAssertEqual(viewModel.test_sidebarListProjectionBuildCount, 1)
+
+        var rawRenamedStashedTabs = unrelatedStashedChurn
+        rawRenamedStashedTabs[0].tab.name = " Archived 0 "
+        let rawRenamedProjection = viewModel.sidebarListProjection(
+            composeTabs: unrelatedComposeChurn,
+            stashedTabs: rawRenamedStashedTabs,
+            currentTabID: composeTabs.first?.id,
+            sidebarSnapshot: snapshot,
+            archivedSessionsExpanded: true
+        )
+        XCTAssertEqual(
+            rawRenamedProjection.sortedArchivedSessionTabsForRows.first(where: { $0.id == stashedTabs[0].id })?.tab.name,
+            " Archived 0 "
+        )
+        XCTAssertEqual(viewModel.test_sidebarSessionRowsBuildCount, 1)
         XCTAssertEqual(viewModel.test_sidebarListProjectionBuildCount, 2)
 
-        viewModel.setSessionSidebarSearchText("Session 2")
+        var pinnedStashedTabs = rawRenamedStashedTabs
+        pinnedStashedTabs[0].tab.isPinned = true
+        let pinnedProjection = viewModel.sidebarListProjection(
+            composeTabs: unrelatedComposeChurn,
+            stashedTabs: pinnedStashedTabs,
+            currentTabID: composeTabs.first?.id,
+            sidebarSnapshot: snapshot,
+            archivedSessionsExpanded: true
+        )
+        XCTAssertEqual(pinnedProjection.sortedArchivedSessionTabsForRows.first?.id, stashedTabs[0].id)
+        XCTAssertEqual(viewModel.test_sidebarSessionRowsBuildCount, 1)
+        XCTAssertEqual(viewModel.test_sidebarListProjectionBuildCount, 3)
+
+        var restashedTabs = rawRenamedStashedTabs
+        restashedTabs[0].stashedAt = stashedTabs[1].stashedAt.addingTimeInterval(1)
+        let restashedProjection = viewModel.sidebarListProjection(
+            composeTabs: unrelatedComposeChurn,
+            stashedTabs: restashedTabs,
+            currentTabID: composeTabs.first?.id,
+            sidebarSnapshot: snapshot,
+            archivedSessionsExpanded: true
+        )
+        XCTAssertEqual(restashedProjection.sortedArchivedSessionTabsForRows.first?.id, stashedTabs[0].id)
+        XCTAssertEqual(viewModel.test_sidebarSessionRowsBuildCount, 1)
+        XCTAssertEqual(viewModel.test_sidebarListProjectionBuildCount, 4)
+
+        var renamedTabs = unrelatedComposeChurn
+        renamedTabs[0].name = "Renamed"
+        let renamedProjection = viewModel.sidebarListProjection(
+            composeTabs: renamedTabs,
+            stashedTabs: restashedTabs,
+            currentTabID: composeTabs.first?.id,
+            sidebarSnapshot: snapshot,
+            archivedSessionsExpanded: true
+        )
+        XCTAssertEqual(
+            renamedProjection.filteredSessions.first(where: { $0.tabID == renamedTabs[0].id })?.title,
+            "Renamed"
+        )
+        XCTAssertEqual(viewModel.test_sidebarSessionRowsBuildCount, 2)
+        XCTAssertEqual(viewModel.test_sidebarListProjectionBuildCount, 5)
+
+        viewModel.ui.sessionSidebar.refresh()
         _ = viewModel.sidebarListProjection(
             composeTabs: renamedTabs,
-            stashedTabs: stashedTabs,
+            stashedTabs: restashedTabs,
             currentTabID: composeTabs.first?.id,
             sidebarSnapshot: viewModel.ui.sessionSidebar.snapshot,
             archivedSessionsExpanded: true
         )
-        XCTAssertEqual(viewModel.test_sidebarListProjectionBuildCount, 3)
+        XCTAssertEqual(viewModel.test_sidebarSessionRowsBuildCount, 3)
+        XCTAssertEqual(viewModel.test_sidebarListProjectionBuildCount, 6)
     }
 
     func testBatchWorktreeBindingStatesBuildsAuthoritySnapshotOnceAtScale() {


### PR DESCRIPTION
## Summary

- replace sidebar cache keys that embedded full `ComposeTabState` / `StashedTab` values with compact sidebar-relevant signatures
- share one `AgentSessionSidebarTabMetadataSignature` helper between content fingerprints and cache-key construction
- preserve archived row correctness by signing every stashed-tab field consumed by projection output or ID resolution
- add DEBUG build-count regression coverage for prompt text, selection, expanded-folder, metadata, ordering, and sidebar-revision changes

## Why

The existing caches compared full compose and stashed tab values. Prompt editing, selection changes, and expanded-folder churn therefore invalidated sidebar projections even though those fields cannot affect sidebar rows. Live sampling of the beachballing app showed repeated Agent Mode sidebar reconstruction on the main thread.

## Validation

- `make dev-format`
- `make dev-lint` — passed (`0/1431` files require formatting; SwiftLint strict passed)
- `make dev-test FILTER=AgentModeViewModelInactiveRefreshTests` — 35 tests, 0 failures
- `make dev-test FILTER=AgentModeSidebarSessionBuilderTests` — 9 tests, 0 failures
- `make dev-run` — exact worktree built, packaged, and launched successfully
- live 15-second profile: `AgentModeSessionsSidebarView.body` appeared in 38 weighted samples while `AgentModeSidebarSessionBuilder.build` appeared 0 times; the compact metadata-signature path was active
- commit and push contribution preflights — whitespace, guardrails, staged/outgoing secret scans passed

A concurrently scheduled full-root run in this worktree was non-green in unrelated codemap/context-builder tests, including MCP bootstrap socket contention while the explicitly launched debug app remained running. The PR-ready lint phase passed; its duplicate root-test ticket was canceled before admission after waiting behind the shared build queue. Hosted CI should provide the clean full-suite result.

## Scope

No changes to `AgentModeSidebarSessionBuilder` or row-output behavior. No test-target splitting, list-command caching, SwiftPM cache, codemap, persistence, or app lifecycle changes.
