### PR TITLE
Stabilize ledger-free CI routing and codemap contracts

### DIFF
--- a/Scripts/ci_app_test_runner.py
+++ b/Scripts/ci_app_test_runner.py
@@ -38,7 +38,6 @@ class OutputSnapshot:
 @dataclass
 class OutputState:
     output_seen: threading.Event = field(default_factory=threading.Event)
-    failure_seen: threading.Event = field(default_factory=threading.Event)
     lock: threading.Lock = field(default_factory=threading.Lock)
     first_failure_line: str | None = None
     last_started_test: str | None = None
@@ -55,7 +54,6 @@ class OutputState:
                 self.last_started_test = started_test
             if failure_line is not None and self.first_failure_line is None:
                 self.first_failure_line = failure_line
-                self.failure_seen.set()
 
     def snapshot(self) -> OutputSnapshot:
         with self.lock:
@@ -429,22 +427,6 @@ def run_suite_attempt(
                 attempts=attempt,
             )
 
-        if state.failure_seen.is_set():
-            stop_process_tree_func(process)
-            relay.join(timeout=10)
-            snapshot = state.snapshot()
-            return SuiteRunResult(
-                suite=suite,
-                state="failed",
-                exit_code=1,
-                elapsed_seconds=time.monotonic() - start,
-                output_seen=snapshot.output_seen,
-                first_failure_line=snapshot.first_failure_line,
-                last_started_test=snapshot.last_started_test,
-                timed_out_after_seconds=None,
-                attempts=attempt,
-            )
-
         if cancellation_event is not None and cancellation_event.is_set():
             stop_process_tree_func(process)
             relay.join(timeout=10)
@@ -579,7 +561,7 @@ def report_suite_result(result: SuiteRunResult, output: TextIO) -> None:
 
     if result.first_failure_line is not None:
         print(
-            f"::error::{result.suite} failed; stopping after first XCTest issue. "
+            f"::error::{result.suite} failed; "
             f"elapsed={result.elapsed_seconds:.1f}s; "
             f"last_started_test={format_last_started(result.last_started_test)}",
             flush=True,
@@ -735,7 +717,20 @@ def run_all_suites(
             file=output,
         )
 
+    if test_bundle is None and test_bundles is not None:
+        for suite in selected_suites:
+            if bundle_for_suite(suite, test_bundles) is not None:
+                continue
+            print(
+                f"::error::No XCTest bundle found for suite target {test_target_for_suite(suite)} "
+                f"while routing {suite}; available bundles: {sorted(test_bundles)}",
+                flush=True,
+                file=output,
+            )
+            return 1
+
     passed_results: list[SuiteRunResult] = []
+    failed_results: list[SuiteRunResult] = []
     for suite in selected_suites:
         result = run_and_report_single_suite(
             suite,
@@ -749,9 +744,12 @@ def run_all_suites(
             test_bundles=test_bundles,
             xctest_binary=xctest_binary,
         )
-        if result.state != "passed":
+        if result.state == "cancelled":
             return result.exit_code
-        passed_results.append(result)
+        if result.state == "passed":
+            passed_results.append(result)
+        else:
+            failed_results.append(result)
 
     if passed_results:
         print("Slowest app test suites:", flush=True, file=output)
@@ -760,6 +758,23 @@ def run_all_suites(
             key=lambda candidate: (-candidate.elapsed_seconds, candidate.suite),
         )[:10]:
             print(f"  {result.elapsed_seconds:6.1f}s  {result.suite}", flush=True, file=output)
+
+    if failed_results:
+        print(
+            f"::error::App test shard {shard_index}/{shard_count} completed with "
+            f"{len(failed_results)} failed suite(s).",
+            flush=True,
+            file=output,
+        )
+        print("Failed app test suites:", flush=True, file=output)
+        for result in failed_results:
+            print(
+                f"  {result.suite}: {result.state} "
+                f"(exit={result.exit_code}, elapsed={result.elapsed_seconds:.1f}s)",
+                flush=True,
+                file=output,
+            )
+        return 1
     return 0
 
 

--- a/Scripts/test_ci_app_test_runner.py
+++ b/Scripts/test_ci_app_test_runner.py
@@ -17,14 +17,26 @@ import ci_app_test_runner
 class FakeProcess:
     next_pid = 1000
 
-    def __init__(self, lines: list[str] | None = None, *, returncode: int | None = None) -> None:
+    def __init__(
+        self,
+        lines: list[str] | None = None,
+        *,
+        returncode: int | None = None,
+        returncode_after_output: int | None = None,
+    ) -> None:
         self.lines = lines or []
         self.returncode = returncode
+        self.returncode_after_output = returncode_after_output
         self.pid = FakeProcess.next_pid
         FakeProcess.next_pid += 1
-        self.stdout = iter(self.lines)
+        self.stdout = self.iter_lines()
         self.kill_called = False
         self.wait_called = False
+
+    def iter_lines(self):
+        yield from self.lines
+        if self.returncode_after_output is not None:
+            self.returncode = self.returncode_after_output
 
     def poll(self) -> int | None:
         return self.returncode
@@ -155,15 +167,17 @@ class CIAppTestRunnerTests(unittest.TestCase):
             ci_app_test_runner.os.getpgrp = original_getpgrp
             ci_app_test_runner.os.getpgid = original_getpgid
 
-    def test_fail_fast_stops_after_first_xctest_issue(self) -> None:
+    def test_xctest_assertion_does_not_stop_suite_process_early(self) -> None:
         stopped: list[FakeProcess] = []
         output = io.StringIO()
         fake = FakeProcess(
             [
                 "Test Case '-[RepoPromptTests.S testExample]' started.\n",
                 "/tmp/File.swift:10: error: -[RepoPromptTests.S testExample] : XCTAssert failed\n",
-                "line that would have appeared before a hang\n",
-            ]
+                "Test Case '-[RepoPromptTests.S testLater]' started.\n",
+                "/tmp/File.swift:20: error: -[RepoPromptTests.S testLater] : XCTAssertEqual failed\n",
+            ],
+            returncode_after_output=1,
         )
 
         result = ci_app_test_runner.run_suite(
@@ -178,9 +192,10 @@ class CIAppTestRunnerTests(unittest.TestCase):
 
         self.assertEqual(result.state, "failed")
         self.assertEqual(result.exit_code, 1)
-        self.assertEqual(result.last_started_test, "RepoPromptTests.S testExample")
+        self.assertEqual(result.last_started_test, "RepoPromptTests.S testLater")
         self.assertIn("XCTAssert failed", result.first_failure_line or "")
-        self.assertEqual(stopped, [fake])
+        self.assertIn("XCTAssertEqual failed", output.getvalue())
+        self.assertEqual(stopped, [])
 
     def test_nonzero_process_exit_returns_process_status(self) -> None:
         result = ci_app_test_runner.run_suite(
@@ -658,6 +673,68 @@ class CIAppTestRunnerTests(unittest.TestCase):
 
         self.assertEqual(exit_code, 0)
         self.assertEqual(calls, ["RepoPromptTests.A", "RepoPromptTests.B"])
+
+    def test_run_all_suites_collects_failures_and_continues(self) -> None:
+        calls: list[str] = []
+
+        def fake_run_suite(suite, **kwargs):
+            calls.append(suite)
+            if suite == "RepoPromptTests.A":
+                return ci_app_test_runner.SuiteRunResult(
+                    suite=suite,
+                    state="failed",
+                    exit_code=1,
+                    elapsed_seconds=0.1,
+                    output_seen=True,
+                    first_failure_line="A failed",
+                    last_started_test="RepoPromptTests.A testFailure",
+                    timed_out_after_seconds=None,
+                    attempts=1,
+                )
+            if suite == "RepoPromptTests.C":
+                return ci_app_test_runner.SuiteRunResult(
+                    suite=suite,
+                    state="timed_out",
+                    exit_code=ci_app_test_runner.TIMEOUT_EXIT_CODE,
+                    elapsed_seconds=1.0,
+                    output_seen=True,
+                    first_failure_line=None,
+                    last_started_test="RepoPromptTests.C testTimeout",
+                    timed_out_after_seconds=1.0,
+                    attempts=1,
+                )
+            return ci_app_test_runner.SuiteRunResult(
+                suite=suite,
+                state="passed",
+                exit_code=0,
+                elapsed_seconds=0.2,
+                output_seen=True,
+                first_failure_line=None,
+                last_started_test=None,
+                timed_out_after_seconds=None,
+                attempts=1,
+            )
+
+        output = io.StringIO()
+        with mock.patch.object(ci_app_test_runner, "run_suite", side_effect=fake_run_suite):
+            exit_code = ci_app_test_runner.run_all_suites(
+                ["RepoPromptTests.C", "RepoPromptTests.B", "RepoPromptTests.A"],
+                timeout_seconds=1.0,
+                silent_timeout_retries=0,
+                swift_binary="swift",
+                cwd=None,
+                output=output,
+            )
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(
+            calls,
+            ["RepoPromptTests.A", "RepoPromptTests.B", "RepoPromptTests.C"],
+        )
+        summary = output.getvalue().split("Failed app test suites:\n", 1)[1]
+        self.assertIn("2 failed suite(s)", output.getvalue())
+        self.assertIn("RepoPromptTests.A: failed", summary)
+        self.assertIn("RepoPromptTests.C: timed_out", summary)
 
     def test_run_all_suites_executes_only_the_selected_lpt_shard(self) -> None:
         calls: list[str] = []

--- a/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService+FileOperations.swift
+++ b/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService+FileOperations.swift
@@ -111,26 +111,32 @@ extension FileSystemService {
         }
         let id = UUID()
         inFlightMutations[id] = FileSystemInFlightMutation(relativePaths: authorityPaths)
-        #if DEBUG
-            let willBegin = mutationIOWillBeginHandler
-            let willExecute = mutationIOWillExecuteHandler
-        #else
-            let willBegin: (@Sendable (FileSystemUncancellableMutation) async -> Void)? = nil
-            let willExecute: (@Sendable (FileSystemUncancellableMutation) -> Void)? = nil
-        #endif
-        let physicalMutationGuard = try await MCPDomainMutationCommitContext.physicalMutationGuard()
-        let executor = FileSystemMutationIOExecutor(
-            operation: operation,
-            physicalMutationGuard: physicalMutationGuard,
-            willExecute: willExecute
-        )
-        let task = Task.detached(priority: .utility) {
-            if let willBegin {
-                await willBegin(operation)
+        do {
+            #if DEBUG
+                let willBegin = mutationIOWillBeginHandler
+                let willExecute = mutationIOWillExecuteHandler
+            #else
+                let willBegin: (@Sendable (FileSystemUncancellableMutation) async -> Void)? = nil
+                let willExecute: (@Sendable (FileSystemUncancellableMutation) -> Void)? = nil
+            #endif
+            let physicalMutationGuard = try await MCPDomainMutationCommitContext.physicalMutationGuard()
+            try await MCPDomainMutationCommitContext.willCommit()
+            let executor = FileSystemMutationIOExecutor(
+                operation: operation,
+                physicalMutationGuard: physicalMutationGuard,
+                willExecute: willExecute
+            )
+            let task = Task.detached(priority: .utility) {
+                if let willBegin {
+                    await willBegin(operation)
+                }
+                try await io(executor)
             }
-            try await io(executor)
+            return (id, task)
+        } catch {
+            inFlightMutations.removeValue(forKey: id)
+            throw error
         }
-        return (id, task)
     }
 
     private func awaitUncancellableMutation(

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel.swift
@@ -6633,7 +6633,6 @@ final class MCPServerViewModel: ObservableObject {
             [source.standardizedFullPath, destination],
             rootMappings: mutationRootMappings
         )
-        try await MCPDomainMutationCommitContext.willCommit()
         try await store.moveFile(rootID: source.rootID, from: source.standardizedRelativePath, to: newRelativePath)
     }
 
@@ -6653,7 +6652,6 @@ final class MCPServerViewModel: ObservableObject {
                 [file.standardizedFullPath],
                 rootMappings: mutationRootMappings
             )
-            try await MCPDomainMutationCommitContext.willCommit()
             try await store.moveItemToTrash(rootID: file.rootID, relativePath: file.standardizedRelativePath)
             return
         }
@@ -6665,7 +6663,6 @@ final class MCPServerViewModel: ObservableObject {
                 [folder.standardizedFullPath],
                 rootMappings: mutationRootMappings
             )
-            try await MCPDomainMutationCommitContext.willCommit()
             try await store.moveItemToTrash(rootID: folder.rootID, relativePath: folder.standardizedRelativePath)
         } else {
             throw MCPError.invalidParams("Unknown or unloaded path: \(path).")

--- a/Sources/RepoPrompt/Infrastructure/VCS/GitService.swift
+++ b/Sources/RepoPrompt/Infrastructure/VCS/GitService.swift
@@ -1629,8 +1629,13 @@ actor GitService {
         guard !request.allowExternalPath, let appManagedContainer = request.appManagedContainer else {
             return request
         }
-        let canonicalContainer = GitRepoRootAuthorization.canonicalPath(appManagedContainer.path)
-        let canonicalDestination = GitRepoRootAuthorization.canonicalPath(request.path.path)
+        guard let canonicalContainer = DomainMutationPathFence.canonicalPath(appManagedContainer.path),
+              let canonicalDestination = DomainMutationPathFence.canonicalPath(request.path.path)
+        else {
+            throw GitError(
+                message: "app-managed worktree destination could not be resolved safely: \(request.path.path)"
+            )
+        }
         let containerPrefix = canonicalContainer.hasSuffix("/") ? canonicalContainer : canonicalContainer + "/"
         guard canonicalDestination == canonicalContainer || canonicalDestination.hasPrefix(containerPrefix) else {
             throw GitError(message: "app-managed worktree destination resolved outside its managed container: \(request.path.path)")

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileMutationService.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileMutationService.swift
@@ -107,7 +107,6 @@ struct WorkspaceFileMutationService {
             [file.standardizedFullPath],
             rootMappings: mutationRootMappings
         )
-        try await MCPDomainMutationCommitContext.willCommit()
         let result = try await store.editFile(rootID: file.rootID, relativePath: file.standardizedRelativePath, newContent: content)
         if let result {
             return .fromCatalogMaterialization(result)
@@ -273,7 +272,6 @@ struct WorkspaceFileMutationService {
             [absolutePath],
             rootMappings: mutationRootMappings
         )
-        try await MCPDomainMutationCommitContext.willCommit()
         let result = try await store.createFile(
             rootID: root.id,
             relativePath: relativePath,

--- a/Tests/RepoPromptTests/ContextBuilder/ContextBuilderWorktreeInheritanceTests.swift
+++ b/Tests/RepoPromptTests/ContextBuilder/ContextBuilderWorktreeInheritanceTests.swift
@@ -279,6 +279,8 @@ import XCTest
                     let runCodemapE2E = CodemapE2ETestGate.isEnabled
                     factory.configure(
                         networkManager: fixture.networkManager,
+                        workspaceID: fixture.contextA.workspaceID,
+                        contextID: fixture.contextA.tabID,
                         logicalFilePath: logicalFile.path,
                         searchPattern: worktreeSentinel,
                         probeCodeStructure: runCodemapE2E
@@ -644,6 +646,8 @@ import XCTest
                     )
                     factory.configure(
                         networkManager: fixture.networkManager,
+                        workspaceID: fixture.contextA.workspaceID,
+                        contextID: fixture.contextA.tabID,
                         logicalFilePath: logicalBranchOnly.path,
                         searchPattern: "DeferredOnlyAgentRoute",
                         probeCodeStructure: false
@@ -970,6 +974,8 @@ import XCTest
                     try await configureAgentModeEndpoint(endpoint, context: frozenContext, fixture: fixture)
                     factory.configure(
                         networkManager: fixture.networkManager,
+                        workspaceID: fixture.contextA.workspaceID,
+                        contextID: fixture.contextA.tabID,
                         logicalFilePath: fixture.contextA.fileURL.path,
                         searchPattern: canonicalSentinel
                     )
@@ -1087,6 +1093,8 @@ import XCTest
                     )
                     factory.configure(
                         networkManager: fixture.networkManager,
+                        workspaceID: fixture.contextA.workspaceID,
+                        contextID: fixture.contextA.tabID,
                         logicalFilePath: ceFile.path,
                         searchPattern: ceMarker,
                         publishImplicitGitArtifacts: true,
@@ -1297,6 +1305,8 @@ import XCTest
                     )
                     factory.configure(
                         networkManager: fixture.networkManager,
+                        workspaceID: fixture.contextA.workspaceID,
+                        contextID: fixture.contextA.tabID,
                         logicalFilePath: fixture.contextA.fileURL.path,
                         searchPattern: canonicalSentinel
                     )
@@ -1989,6 +1999,8 @@ import XCTest
                     let gate = cancelDuringRun ? ContextBuilderProbeGate() : nil
                     factory.configure(
                         networkManager: fixture.networkManager,
+                        workspaceID: fixture.contextB.workspaceID,
+                        contextID: fixture.contextB.tabID,
                         logicalFilePath: fixture.contextB.fileURL.path,
                         searchPattern: fixture.contextB.sentinel,
                         probeCodeStructure: false,
@@ -2307,7 +2319,7 @@ import XCTest
             }
             await fixture.networkManager.setRunPurpose(.agentModeRun, for: endpoint.connectionID)
             let runID = try XCTUnwrap(context.runID)
-            try await fixture.networkManager.debugSeedConnectionRunRouting(
+            await fixture.networkManager.debugSeedConnectionRunRouting(
                 connectionID: endpoint.connectionID,
                 runID: runID,
                 purpose: .agentModeRun,
@@ -2436,6 +2448,8 @@ import XCTest
     private final class ContextBuilderWorktreeProbeFactory {
         private struct Configuration {
             let networkManager: ServerNetworkManager
+            let workspaceID: UUID
+            let contextID: UUID
             let logicalFilePath: String
             let searchPattern: String
             let publishImplicitGitArtifacts: Bool
@@ -2453,6 +2467,8 @@ import XCTest
 
         func configure(
             networkManager: ServerNetworkManager,
+            workspaceID: UUID,
+            contextID: UUID,
             logicalFilePath: String,
             searchPattern: String,
             publishImplicitGitArtifacts: Bool = false,
@@ -2462,6 +2478,8 @@ import XCTest
         ) {
             configuration = Configuration(
                 networkManager: networkManager,
+                workspaceID: workspaceID,
+                contextID: contextID,
                 logicalFilePath: logicalFilePath,
                 searchPattern: searchPattern,
                 publishImplicitGitArtifacts: publishImplicitGitArtifacts,
@@ -2486,6 +2504,8 @@ import XCTest
             return ContextBuilderWorktreeProbeProvider(
                 state: state,
                 networkManager: configuration.networkManager,
+                workspaceID: configuration.workspaceID,
+                contextID: configuration.contextID,
                 logicalFilePath: configuration.logicalFilePath,
                 searchPattern: configuration.searchPattern,
                 publishImplicitGitArtifacts: configuration.publishImplicitGitArtifacts,
@@ -2501,6 +2521,8 @@ import XCTest
     private final class ContextBuilderWorktreeProbeProvider: HeadlessAgentProvider {
         private let state: ContextBuilderWorktreeProbeState
         private let networkManager: ServerNetworkManager
+        private let workspaceID: UUID
+        private let contextID: UUID
         private let logicalFilePath: String
         private let searchPattern: String
         private let publishImplicitGitArtifacts: Bool
@@ -2515,6 +2537,8 @@ import XCTest
         init(
             state: ContextBuilderWorktreeProbeState,
             networkManager: ServerNetworkManager,
+            workspaceID: UUID,
+            contextID: UUID,
             logicalFilePath: String,
             searchPattern: String,
             publishImplicitGitArtifacts: Bool,
@@ -2526,6 +2550,8 @@ import XCTest
         ) {
             self.state = state
             self.networkManager = networkManager
+            self.workspaceID = workspaceID
+            self.contextID = contextID
             self.logicalFilePath = logicalFilePath
             self.searchPattern = searchPattern
             self.publishImplicitGitArtifacts = publishImplicitGitArtifacts
@@ -2563,6 +2589,29 @@ import XCTest
                 ]
             )
             self.endpoint = endpoint
+
+            _ = await AppDomainRuntimeComposition.shared.runtime.routingCoordinator
+                .registerConnection(connectionID: endpoint.connectionID, operationID: UUID())
+            let registration = try await AppDomainRuntimeComposition.shared.runtime.routingCoordinator
+                .currentRegistration(connectionID: endpoint.connectionID)
+            let routingOutcome = await AppDomainRuntimeComposition.shared.runtime.routingCoordinator.bind(
+                connection: registration,
+                binding: .runScoped(
+                    runID: runID,
+                    context: .init(workspaceID: workspaceID, contextID: contextID)
+                ),
+                operationID: UUID()
+            )
+            guard routingOutcome.disposition == .applied || routingOutcome.disposition == .unchanged else {
+                throw NSError(
+                    domain: "ContextBuilderWorktreeInheritanceTests",
+                    code: 4,
+                    userInfo: [
+                        NSLocalizedDescriptionKey: routingOutcome.diagnostic
+                            ?? "Domain run routing was not established for the probe endpoint"
+                    ]
+                )
+            }
 
             let selectionBeforeRead = try await selectionObservation(endpoint.callTool(
                 name: MCPWindowToolName.manageSelection,

--- a/Tests/RepoPromptTests/ContextBuilder/ContextBuilderWorktreeInheritanceTests.swift
+++ b/Tests/RepoPromptTests/ContextBuilder/ContextBuilderWorktreeInheritanceTests.swift
@@ -277,6 +277,7 @@ import XCTest
                         }
 
                     let runCodemapE2E = CodemapE2ETestGate.isEnabled
+                    try await fixture.registerDomainWorkspace(fixture.contextA)
                     factory.configure(
                         networkManager: fixture.networkManager,
                         workspaceID: fixture.contextA.workspaceID,
@@ -644,6 +645,7 @@ import XCTest
                         fixture: fixture,
                         bindContext: false
                     )
+                    try await fixture.registerDomainWorkspace(fixture.contextA)
                     factory.configure(
                         networkManager: fixture.networkManager,
                         workspaceID: fixture.contextA.workspaceID,
@@ -972,6 +974,7 @@ import XCTest
                     )
                     let endpoint = try fixture.endpointA()
                     try await configureAgentModeEndpoint(endpoint, context: frozenContext, fixture: fixture)
+                    try await fixture.registerDomainWorkspace(fixture.contextA)
                     factory.configure(
                         networkManager: fixture.networkManager,
                         workspaceID: fixture.contextA.workspaceID,
@@ -1091,6 +1094,7 @@ import XCTest
                         context: frozenContext,
                         fixture: fixture
                     )
+                    try await fixture.registerDomainWorkspace(fixture.contextA)
                     factory.configure(
                         networkManager: fixture.networkManager,
                         workspaceID: fixture.contextA.workspaceID,
@@ -1303,6 +1307,7 @@ import XCTest
                         ),
                         seededSelectionRevision
                     )
+                    try await fixture.registerDomainWorkspace(fixture.contextA)
                     factory.configure(
                         networkManager: fixture.networkManager,
                         workspaceID: fixture.contextA.workspaceID,
@@ -1997,6 +2002,11 @@ import XCTest
                     await Task.yield()
 
                     let gate = cancelDuringRun ? ContextBuilderProbeGate() : nil
+                    try await fixture.registerDomainWorkspace(
+                        sourceWorkspaceB,
+                        rootURL: fixture.contextB.rootURL,
+                        windowID: window.windowID
+                    )
                     factory.configure(
                         networkManager: fixture.networkManager,
                         workspaceID: fixture.contextB.workspaceID,
@@ -2311,6 +2321,10 @@ import XCTest
             fixture: PersistentMCPTestFixture,
             bindContext: Bool = true
         ) async throws {
+            let fixtureContext = context.workspaceID == fixture.contextB.workspaceID
+                ? fixture.contextB
+                : fixture.contextA
+            try await fixture.registerDomainWorkspace(fixtureContext)
             if bindContext {
                 _ = try await endpoint.callTool(
                     name: "bind_context",
@@ -2325,6 +2339,12 @@ import XCTest
                 purpose: .agentModeRun,
                 windowID: context.windowID
             )
+            if !bindContext {
+                _ = await AppDomainRuntimeComposition.shared.runtime.routingCoordinator.registerConnection(
+                    connectionID: endpoint.connectionID,
+                    operationID: UUID()
+                )
+            }
             let registration = try await AppDomainRuntimeComposition.shared.runtime
                 .routingCoordinator.currentRegistration(connectionID: endpoint.connectionID)
             let workspaceID = try XCTUnwrap(context.workspaceID)

--- a/Tests/RepoPromptTests/MCP/Control/MCPProtectedMutationInvocationIntegrationTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/MCPProtectedMutationInvocationIntegrationTests.swift
@@ -8,7 +8,7 @@ import XCTest
     final class MCPProtectedMutationInvocationIntegrationTests: XCTestCase {
         func testPromptStateMutationsCommitWithoutPhysicalPathAdmission() async throws {
             try await MCPSharedServerTestLease.shared.withLease { lease in
-                let fixture = try await PersistentMCPTestFixture.make(lease: lease)
+                let fixture = try await makeFixture(lease: lease)
                 let endpoint = try fixture.endpointA()
                 let manager = fixture.networkManager
                 do {
@@ -17,7 +17,7 @@ import XCTest
                         connectionID: endpoint.connectionID,
                         identity: .verified(processID: Int(getpid()), fingerprint: "test:verified:prompt-state")
                     )
-                    try await bind(endpoint, to: fixture.contextA.tabID)
+                    try await bind(endpoint, to: fixture.contextA)
 
                     let runtime = AppDomainRuntimeComposition.shared.runtime
                     var journalKeys = try await Set(runtime.mutationJournal.snapshot().recordSnapshots.map(\.key))
@@ -61,7 +61,7 @@ import XCTest
 
         func testFileActionRevalidatesFenceAfterCommitAtBlockingIOBoundary() async throws {
             try await MCPSharedServerTestLease.shared.withLease { lease in
-                let fixture = try await PersistentMCPTestFixture.make(lease: lease)
+                let fixture = try await makeFixture(lease: lease)
                 let endpoint = try fixture.endpointA()
                 let manager = fixture.networkManager
                 let store = fixture.contextA.window.workspaceFileContextStore
@@ -89,7 +89,7 @@ import XCTest
                         connectionID: endpoint.connectionID,
                         identity: .verified(processID: Int(getpid()), fingerprint: "test:verified:late-fence")
                     )
-                    try await bind(endpoint, to: fixture.contextA.tabID)
+                    try await bind(endpoint, to: fixture.contextA)
                     let runtime = AppDomainRuntimeComposition.shared.runtime
                     let journalKeys = try await Set(runtime.mutationJournal.snapshot().recordSnapshots.map(\.key))
 
@@ -137,19 +137,19 @@ import XCTest
             }
         }
 
-        func testAppInvocationUsesCoordinatorRegistrationAfterReRegistrationAndHonorsInjectedIdentity() async throws {
+        func testRunScopedInvocationUsesAuthoritativeRegistrationAndVerifiedIdentity() async throws {
             try await MCPSharedServerTestLease.shared.withLease { lease in
-                let fixture = try await PersistentMCPTestFixture.make(lease: lease)
+                let fixture = try await makeFixture(lease: lease)
+                let endpoint = try fixture.endpointA()
+                let manager = fixture.networkManager
                 do {
-                    let endpoint = try fixture.endpointA()
-                    let manager = fixture.networkManager
                     try await registerDomainWorkspace(fixture.contextA)
                     await manager.debugSetDomainPeerIdentityForTesting(
                         connectionID: endpoint.connectionID,
                         identity: .verified(processID: Int(getpid()), fingerprint: "test:verified:app")
                     )
-                    try await bind(endpoint, to: fixture.contextA.tabID)
-                    let initial = try await waitForAuthoritativeContext(
+                    try await bind(endpoint, to: fixture.contextA)
+                    let initial = try await authoritativeContext(
                         manager: manager,
                         endpoint: endpoint,
                         toolName: "manage_selection"
@@ -181,7 +181,7 @@ import XCTest
                         operationID: UUID()
                     )
                     XCTAssertEqual(reboundOutcome.disposition, .applied)
-                    let rebound = try await waitForAuthoritativeContext(
+                    let rebound = try await authoritativeContext(
                         manager: manager,
                         endpoint: endpoint,
                         toolName: "manage_selection"
@@ -189,6 +189,7 @@ import XCTest
                     XCTAssertEqual(rebound.workspaceID, fixture.contextA.workspaceID)
                     XCTAssertTrue(rebound.authorizedCanonicalRoots.contains(fixture.contextA.rootURL.path))
 
+                    await manager.setRunPurpose(.agentModeRun, for: endpoint.connectionID)
                     await manager.debugSetDomainPeerIdentityForTesting(
                         connectionID: endpoint.connectionID,
                         identity: .unverified
@@ -215,479 +216,28 @@ import XCTest
                         connectionID: endpoint.connectionID,
                         identity: nil
                     )
+                    await manager.setRunPurpose(.unknown, for: endpoint.connectionID)
                     await fixture.cleanup()
                     try await fixture.assertCleanedUp()
                 } catch {
+                    await manager.debugSetDomainPeerIdentityForTesting(
+                        connectionID: endpoint.connectionID,
+                        identity: nil
+                    )
+                    await manager.setRunPurpose(.unknown, for: endpoint.connectionID)
                     await fixture.cleanup()
                     throw error
                 }
             }
         }
 
-        func testRunScopedAppManagedWorktreeCreateRetainsLogicalRootAuthorization() async throws {
-            try await MCPSharedServerTestLease.shared.withLease { lease in
-                let fixture = try await PersistentMCPTestFixture.make(lease: lease)
-                let endpoint = try fixture.endpointA()
-                let manager = fixture.networkManager
-                let repo = fixture.contextA.rootURL
-                let branch = "m4/app-managed-\(UUID().uuidString.lowercased())"
-                let appManagedContainer = GitWorktreeDefaultPathPlanner.defaultContainer(forMainWorktreeRoot: repo)
-                let worktree = appManagedContainer.appendingPathComponent(
-                    "m4-app-managed-\(UUID().uuidString.lowercased())",
-                    isDirectory: true
-                )
-                var worktreeCreated = false
-                do {
-                    try await registerDomainWorkspace(fixture.contextA)
-                    try FileManager.default.createDirectory(at: appManagedContainer, withIntermediateDirectories: true)
-                    try initializeGitRepository(at: repo)
-                    await manager.debugSetDomainPeerIdentityForTesting(
-                        connectionID: endpoint.connectionID,
-                        identity: .verified(processID: Int(getpid()), fingerprint: "test:verified:app-managed")
-                    )
-                    try await bind(endpoint, to: fixture.contextA.tabID)
-                    await manager.setRunPurpose(.agentModeRun, for: endpoint.connectionID)
-                    let securityContext = await manager.debugDomainInvocationSecurityContextForTesting(
-                        connectionID: endpoint.connectionID,
-                        toolName: "manage_worktree"
-                    )
-                    XCTAssertEqual(securityContext.principal.kind.rawValue, DomainClientPrincipalKind.runScoped.rawValue)
-                    XCTAssertTrue(securityContext.authorizedCanonicalRoots.contains(repo.path))
-                    XCTAssertTrue(securityContext.ephemeralGrantedToolNames.contains("manage_worktree"))
-
-                    let response = try await endpoint.callTool(
-                        name: "manage_worktree",
-                        arguments: [
-                            "op": "create",
-                            "repo_root": repo.path,
-                            "path": worktree.path,
-                            "branch": branch,
-                            "base_ref": "HEAD",
-                            "operation_id": "app-managed-run-scoped"
-                        ]
-                    )
-                    let result = try toolResult(response)
-                    XCTAssertFalse(result.isError, result.text)
-                    worktreeCreated = true
-                    XCTAssertTrue(FileManager.default.fileExists(atPath: worktree.path))
-
-                    try removeWorktreeIfPresent(worktree, from: repo)
-                    worktreeCreated = false
-                    await manager.setRunPurpose(.unknown, for: endpoint.connectionID)
-                    await manager.debugSetDomainPeerIdentityForTesting(connectionID: endpoint.connectionID, identity: nil)
-                    await fixture.cleanup()
-                    try await fixture.assertCleanedUp()
-                } catch {
-                    await manager.setRunPurpose(.unknown, for: endpoint.connectionID)
-                    await manager.debugSetDomainPeerIdentityForTesting(connectionID: endpoint.connectionID, identity: nil)
-                    if worktreeCreated {
-                        try? removeWorktreeIfPresent(worktree, from: repo)
-                    }
-                    await fixture.cleanup()
-                    throw error
-                }
-            }
-        }
-
-        func testRunScopedAppManagedWorktreeCreateRejectsResolvedContainerSymlinkEscape() async throws {
-            try await MCPSharedServerTestLease.shared.withLease { lease in
-                let fixture = try await PersistentMCPTestFixture.make(lease: lease)
-                let endpoint = try fixture.endpointA()
-                let manager = fixture.networkManager
-                let repo = fixture.contextA.rootURL
-                let branch = "m4/app-managed-escape-\(UUID().uuidString.lowercased())"
-                let appManagedContainer = GitWorktreeDefaultPathPlanner.defaultContainer(forMainWorktreeRoot: repo)
-                let outside = appManagedContainer.deletingLastPathComponent().appendingPathComponent(
-                    "m4-app-managed-outside-\(UUID().uuidString.lowercased())",
-                    isDirectory: true
-                )
-                let link = appManagedContainer.appendingPathComponent("link", isDirectory: true)
-                let escapedWorktree = link.appendingPathComponent("child", isDirectory: true)
-                var worktreeCreated = false
-                do {
-                    try await registerDomainWorkspace(fixture.contextA)
-                    try FileManager.default.createDirectory(at: appManagedContainer, withIntermediateDirectories: true)
-                    try FileManager.default.createDirectory(at: outside, withIntermediateDirectories: true)
-                    try FileManager.default.createSymbolicLink(at: link, withDestinationURL: outside)
-                    try initializeGitRepository(at: repo)
-                    await manager.debugSetDomainPeerIdentityForTesting(
-                        connectionID: endpoint.connectionID,
-                        identity: .verified(processID: Int(getpid()), fingerprint: "test:verified:app-managed-escape")
-                    )
-                    try await bind(endpoint, to: fixture.contextA.tabID)
-                    await manager.setRunPurpose(.agentModeRun, for: endpoint.connectionID)
-
-                    let response = try await endpoint.callTool(
-                        name: "manage_worktree",
-                        arguments: [
-                            "op": "create",
-                            "repo_root": repo.path,
-                            "path": escapedWorktree.path,
-                            "branch": branch,
-                            "base_ref": "HEAD",
-                            "operation_id": "app-managed-symlink-escape"
-                        ]
-                    )
-                    let result = try toolResult(response)
-                    worktreeCreated = !result.isError && FileManager.default.fileExists(atPath: escapedWorktree.path)
-                    XCTAssertTrue(result.isError, result.text)
-                    XCTAssertFalse(FileManager.default.fileExists(atPath: escapedWorktree.path))
-                    XCTAssertFalse(FileManager.default.fileExists(atPath: outside.appendingPathComponent("child").path))
-
-                    try? FileManager.default.removeItem(at: link)
-                    try? FileManager.default.removeItem(at: outside)
-                    await manager.setRunPurpose(.unknown, for: endpoint.connectionID)
-                    await manager.debugSetDomainPeerIdentityForTesting(connectionID: endpoint.connectionID, identity: nil)
-                    await fixture.cleanup()
-                    try await fixture.assertCleanedUp()
-                } catch {
-                    await manager.setRunPurpose(.unknown, for: endpoint.connectionID)
-                    await manager.debugSetDomainPeerIdentityForTesting(connectionID: endpoint.connectionID, identity: nil)
-                    if worktreeCreated {
-                        try? removeWorktreeIfPresent(escapedWorktree, from: repo)
-                    }
-                    try? FileManager.default.removeItem(at: link)
-                    try? FileManager.default.removeItem(at: outside)
-                    await fixture.cleanup()
-                    throw error
-                }
-            }
-        }
-
-        func testCorrelationReuseExportEscapeAndBoundWorktreeTranslationCrossAppProvider() async throws {
-            try await MCPSharedServerTestLease.shared.withLease { lease in
-                let fixture = try await PersistentMCPTestFixture.make(lease: lease)
-                let endpoint = try fixture.endpointA()
-                let manager = fixture.networkManager
-                let repo = fixture.contextA.rootURL
-                let worktree = fixture.rootURL.appendingPathComponent("bound-worktree", isDirectory: true)
-                var worktreeCreated = false
-                var physicalRootID: UUID?
-                let sessionID = UUID()
-                do {
-                    try await registerDomainWorkspace(fixture.contextA)
-                    let workspace = try XCTUnwrap(
-                        fixture.contextA.window.workspaceManager.workspaces.first {
-                            $0.id == fixture.contextA.workspaceID
-                        }
-                    )
-                    await fixture.contextA.window.workspaceManager.switchWorkspace(
-                        to: workspace,
-                        saveState: false,
-                        reason: "MCPProtectedMutationInvocationIntegrationTests"
-                    )
-                    let activeWorkspace = try XCTUnwrap(fixture.contextA.window.workspaceManager.activeWorkspace)
-                    fixture.contextA.window.promptManager.loadComposeTabsFromWorkspace(
-                        activeWorkspace,
-                        syncPromptText: true
-                    )
-                    try initializeGitRepository(at: repo)
-                    await manager.debugSetDomainPeerIdentityForTesting(
-                        connectionID: endpoint.connectionID,
-                        identity: .verified(processID: Int(getpid()), fingerprint: "test:verified:worktree")
-                    )
-                    try await bind(endpoint, to: fixture.contextA.tabID)
-                    let initialSecurityContext = try await waitForAuthoritativeContext(
-                        manager: manager,
-                        endpoint: endpoint,
-                        toolName: "file_actions"
-                    )
-                    let runtime = AppDomainRuntimeComposition.shared.runtime
-                    var journalKeys = try await Set(
-                        runtime.mutationJournal.snapshot().recordSnapshots.map(\.key)
-                    )
-                    let sharedCorrelationID = "shared-correlation-id"
-
-                    let firstLogical = repo.appendingPathComponent("CorrelationOne.txt")
-                    let firstResponse = try await endpoint.callTool(
-                        name: "file_actions",
-                        arguments: [
-                            "action": "create",
-                            "path": firstLogical.path,
-                            "content": "one",
-                            "operation_id": sharedCorrelationID
-                        ]
-                    )
-                    XCTAssertFalse(try toolResult(firstResponse).isError)
-                    let firstCapture = try await captureJournalRecord(
-                        runtime: runtime,
-                        excluding: journalKeys,
-                        toolName: "file_actions",
-                        action: "create"
-                    )
-                    journalKeys = firstCapture.allKeys
-                    assertDurableRequestKey(
-                        firstCapture.record,
-                        endpoint: endpoint,
-                        connectionGeneration: initialSecurityContext.connectionGeneration,
-                        operationID: sharedCorrelationID
-                    )
-
-                    _ = await runtime.routingCoordinator.registerConnection(
-                        connectionID: endpoint.connectionID,
-                        operationID: UUID()
-                    )
-                    try await bind(endpoint, to: fixture.contextA.tabID)
-                    let routingProbe = try await endpoint.callTool(
-                        name: "get_file_tree",
-                        arguments: ["type": "roots"]
-                    )
-                    XCTAssertFalse(try toolResult(routingProbe).isError)
-                    let reboundSecurityContext = try await waitForAuthoritativeContext(
-                        manager: manager,
-                        endpoint: endpoint,
-                        toolName: "file_actions"
-                    )
-                    XCTAssertGreaterThan(
-                        reboundSecurityContext.connectionGeneration,
-                        initialSecurityContext.connectionGeneration
-                    )
-
-                    let secondLogical = repo.appendingPathComponent("CorrelationTwo.txt")
-                    let secondResponse = try await endpoint.callTool(
-                        name: "file_actions",
-                        arguments: [
-                            "action": "create",
-                            "path": secondLogical.path,
-                            "content": "two",
-                            "operation_id": sharedCorrelationID
-                        ]
-                    )
-                    XCTAssertFalse(try toolResult(secondResponse).isError)
-                    let secondCapture = try await captureJournalRecord(
-                        runtime: runtime,
-                        excluding: journalKeys,
-                        toolName: "file_actions",
-                        action: "create"
-                    )
-                    journalKeys = secondCapture.allKeys
-                    assertDurableRequestKey(
-                        secondCapture.record,
-                        endpoint: endpoint,
-                        connectionGeneration: reboundSecurityContext.connectionGeneration,
-                        operationID: sharedCorrelationID
-                    )
-                    XCTAssertNotEqual(firstCapture.record.key, secondCapture.record.key)
-
-                    let thirdLogical = repo.appendingPathComponent("CorrelationThree.txt")
-                    let thirdResponse = try await endpoint.callTool(
-                        name: "file_actions",
-                        arguments: [
-                            "action": "create",
-                            "path": thirdLogical.path,
-                            "content": "three",
-                            "operation_id": sharedCorrelationID
-                        ]
-                    )
-                    XCTAssertFalse(try toolResult(thirdResponse).isError)
-                    let thirdCapture = try await captureJournalRecord(
-                        runtime: runtime,
-                        excluding: journalKeys,
-                        toolName: "file_actions",
-                        action: "create"
-                    )
-                    journalKeys = thirdCapture.allKeys
-                    assertDurableRequestKey(
-                        thirdCapture.record,
-                        endpoint: endpoint,
-                        connectionGeneration: reboundSecurityContext.connectionGeneration,
-                        operationID: sharedCorrelationID
-                    )
-                    XCTAssertNotEqual(secondCapture.record.key, thirdCapture.record.key)
-                    XCTAssertEqual(try String(contentsOf: firstLogical, encoding: .utf8), "one")
-                    XCTAssertEqual(try String(contentsOf: secondLogical, encoding: .utf8), "two")
-                    XCTAssertEqual(try String(contentsOf: thirdLogical, encoding: .utf8), "three")
-
-                    await manager.setRunPurpose(.agentModeRun, for: endpoint.connectionID)
-                    for toolName in ["prompt", "workspace_context"] {
-                        let escapedExport = fixture.rootURL.appendingPathComponent(
-                            "outside-workspace-\(toolName)-export.md"
-                        )
-                        let exportResponse = try await endpoint.callTool(
-                            name: toolName,
-                            arguments: ["op": "export", "path": escapedExport.path]
-                        )
-                        let exportResult = try toolResult(exportResponse)
-                        XCTAssertTrue(exportResult.isError)
-                        XCTAssertFalse(FileManager.default.fileExists(atPath: escapedExport.path))
-                    }
-                    await manager.setRunPurpose(.unknown, for: endpoint.connectionID)
-
-                    let session = fixture.contextA.window.agentModeViewModel.session(for: fixture.contextA.tabID)
-                    _ = fixture.contextA.window.agentModeViewModel.test_installPersistentSessionBinding(
-                        sessionID: sessionID,
-                        on: session,
-                        updateWorkspaceMetadata: true
-                    )
-                    let create = try await endpoint.callTool(
-                        name: "manage_worktree",
-                        arguments: [
-                            "op": "create",
-                            "repo_root": repo.path,
-                            "path": worktree.path,
-                            "branch": "test/protected-mutation-\(UUID().uuidString.lowercased())",
-                            "base_ref": "HEAD",
-                            "allow_external_path": true,
-                            "operation_id": sharedCorrelationID
-                        ]
-                    )
-                    XCTAssertFalse(try toolResult(create).isError)
-                    let worktreeCapture = try await captureJournalRecord(
-                        runtime: runtime,
-                        excluding: journalKeys,
-                        toolName: "manage_worktree",
-                        action: "create"
-                    )
-                    journalKeys = worktreeCapture.allKeys
-                    assertDurableRequestKey(
-                        worktreeCapture.record,
-                        endpoint: endpoint,
-                        connectionGeneration: reboundSecurityContext.connectionGeneration,
-                        operationID: sharedCorrelationID
-                    )
-                    worktreeCreated = true
-                    let testBinding = AgentSessionWorktreeBinding(
-                        id: "test-binding-\(UUID().uuidString)",
-                        repositoryID: repo.path,
-                        repoKey: repo.path,
-                        logicalRootPath: repo.path,
-                        worktreeID: worktree.path,
-                        worktreeRootPath: worktree.path,
-                        worktreeName: worktree.lastPathComponent,
-                        branch: nil,
-                        head: nil,
-                        source: "m4-integration-test"
-                    )
-                    session.worktreeBindings = [testBinding]
-                    let materializer = WorkspaceRootBindingProjectionMaterializer(
-                        store: fixture.contextA.window.workspaceFileContextStore
-                    )
-                    let preparation = try await materializer.prepare(
-                        sessionID: sessionID,
-                        bindings: [testBinding]
-                    )
-                    let committedProjection = try await materializer.commit(preparation)
-                    let projection = try XCTUnwrap(committedProjection)
-                    physicalRootID = projection.physicalRootRefs.first?.id
-                    let lookupContext = WorkspaceLookupContext(
-                        rootScope: projection.lookupRootScope,
-                        bindingProjection: projection
-                    )
-                    let frozen = MCPServerViewModel.TabContextSnapshot(
-                        tabID: fixture.contextA.tabID,
-                        windowID: fixture.contextA.window.windowID,
-                        workspaceID: fixture.contextA.workspaceID,
-                        promptText: "",
-                        selection: StoredSelection(),
-                        selectedMetaPromptIDs: [],
-                        tabName: "M4 bound worktree",
-                        runID: sessionID,
-                        activeAgentSessionID: sessionID,
-                        worktreeBindings: [testBinding],
-                        frozenLookupContext: lookupContext,
-                        explicitlyBound: true
-                    )
-                    _ = fixture.contextA.window.mcpServer.installFrozenTabContext(
-                        clientID: endpoint.connectionID.uuidString,
-                        clientName: endpoint.clientName,
-                        context: frozen
-                    )
-                    await manager.debugSeedConnectionRunRouting(
-                        connectionID: endpoint.connectionID,
-                        runID: sessionID,
-                        purpose: .agentModeRun,
-                        windowID: fixture.contextA.window.windowID
-                    )
-                    let registration = try await AppDomainRuntimeComposition.shared.runtime
-                        .routingCoordinator.currentRegistration(connectionID: endpoint.connectionID)
-                    _ = await AppDomainRuntimeComposition.shared.runtime.routingCoordinator.bind(
-                        connection: registration,
-                        binding: .runScoped(
-                            runID: sessionID,
-                            context: .init(
-                                workspaceID: fixture.contextA.workspaceID,
-                                contextID: fixture.contextA.tabID
-                            )
-                        ),
-                        operationID: UUID()
-                    )
-
-                    let logicalTarget = fixture.contextA.fileURL
-                    let relativeTarget = String(logicalTarget.path.dropFirst(repo.path.count))
-                        .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
-                    let physicalTarget = worktree.appendingPathComponent(relativeTarget)
-                    let replacement = "let translatedProtectedMutation = true"
-                    let translated = try await endpoint.callTool(
-                        name: "apply_edits",
-                        arguments: [
-                            "path": logicalTarget.path,
-                            "search": fixture.contextA.sentinel,
-                            "replace": replacement,
-                            "operation_id": sharedCorrelationID
-                        ]
-                    )
-                    let translatedResult = try toolResult(translated)
-                    XCTAssertFalse(translatedResult.isError)
-                    let applyEditsCapture = try await captureJournalRecord(
-                        runtime: runtime,
-                        excluding: journalKeys,
-                        toolName: "apply_edits",
-                        action: "replace"
-                    )
-                    journalKeys = applyEditsCapture.allKeys
-                    assertDurableRequestKey(
-                        applyEditsCapture.record,
-                        endpoint: endpoint,
-                        connectionGeneration: reboundSecurityContext.connectionGeneration,
-                        operationID: sharedCorrelationID
-                    )
-                    XCTAssertEqual(
-                        Set([
-                            firstCapture.record.key,
-                            secondCapture.record.key,
-                            thirdCapture.record.key,
-                            worktreeCapture.record.key,
-                            applyEditsCapture.record.key
-                        ]).count,
-                        5
-                    )
-                    let logicalContents = try String(contentsOf: logicalTarget, encoding: .utf8)
-                    let physicalContents = try String(contentsOf: physicalTarget, encoding: .utf8)
-                    XCTAssertTrue(logicalContents.contains(fixture.contextA.sentinel))
-                    XCTAssertFalse(logicalContents.contains(replacement))
-                    XCTAssertTrue(
-                        physicalContents.contains(replacement),
-                        "apply_edits result=\(translatedResult.text) physical=\(physicalContents)"
-                    )
-
-                    session.worktreeBindings = []
-                    await WorkspaceRootBindingProjectionMaterializer(
-                        store: fixture.contextA.window.workspaceFileContextStore
-                    ).release(sessionID: sessionID)
-                    if let physicalRootID {
-                        await fixture.contextA.window.workspaceFileContextStore.unloadRoot(id: physicalRootID)
-                    }
-                    try removeWorktreeIfPresent(worktree, from: repo)
-                    worktreeCreated = false
-                    await manager.debugSetDomainPeerIdentityForTesting(connectionID: endpoint.connectionID, identity: nil)
-                    await fixture.cleanup()
-                    try await fixture.assertCleanedUp()
-                } catch {
-                    await manager.setRunPurpose(.unknown, for: endpoint.connectionID)
-                    await manager.debugSetDomainPeerIdentityForTesting(connectionID: endpoint.connectionID, identity: nil)
-                    await WorkspaceRootBindingProjectionMaterializer(
-                        store: fixture.contextA.window.workspaceFileContextStore
-                    ).release(sessionID: sessionID)
-                    if let physicalRootID {
-                        await fixture.contextA.window.workspaceFileContextStore.unloadRoot(id: physicalRootID)
-                    }
-                    if worktreeCreated {
-                        try? removeWorktreeIfPresent(worktree, from: repo)
-                    }
-                    await fixture.cleanup()
-                    throw error
-                }
-            }
+        private func makeFixture(
+            lease: MCPSharedServerTestLease.Ownership
+        ) async throws -> PersistentMCPTestFixture {
+            try await PersistentMCPTestFixture.make(
+                lease: lease,
+                domainRuntime: AppDomainRuntimeComposition.shared.runtime
+            )
         }
 
         private func captureJournalRecord(
@@ -705,35 +255,6 @@ import XCTest
             return try (XCTUnwrap(matches.first), allKeys)
         }
 
-        private func assertDurableRequestKey(
-            _ record: DomainMutationJournalRecord,
-            endpoint: PersistentMCPTestEndpoint,
-            connectionGeneration: UInt64,
-            operationID: String,
-            file: StaticString = #filePath,
-            line: UInt = #line
-        ) {
-            let requestKey = [
-                "v1",
-                endpoint.connectionID.uuidString.lowercased(),
-                String(connectionGeneration),
-                record.ownerInvocationID.uuidString.lowercased()
-            ].joined(separator: ":")
-            XCTAssertEqual(
-                record.key,
-                "\(record.toolName).\(record.action):request:\(requestKey)",
-                file: file,
-                line: line
-            )
-            XCTAssertEqual(record.operationID, operationID, file: file, line: line)
-            XCTAssertEqual(
-                record.status.rawValue,
-                DomainMutationJournalStatus.applied.rawValue,
-                file: file,
-                line: line
-            )
-        }
-
         private func registerDomainWorkspace(_ context: PersistentMCPTestContext) async throws {
             let workspace = try XCTUnwrap(
                 context.window.workspaceManager.workspaces.first { $0.id == context.workspaceID }
@@ -748,37 +269,38 @@ import XCTest
             )
         }
 
-        private func bind(_ endpoint: PersistentMCPTestEndpoint, to contextID: UUID) async throws {
+        private func bind(
+            _ endpoint: PersistentMCPTestEndpoint,
+            to context: PersistentMCPTestContext
+        ) async throws {
             let response = try await endpoint.callTool(
                 name: "bind_context",
-                arguments: ["op": "bind", "context_id": contextID.uuidString]
+                arguments: ["op": "bind", "context_id": context.tabID.uuidString]
             )
             let result = try toolResult(response)
             XCTAssertFalse(result.isError, result.text)
+            await context.window.mcpServer.domainRoutingPublishTask?.value
         }
 
-        private func waitForAuthoritativeContext(
+        private func authoritativeContext(
             manager: ServerNetworkManager,
             endpoint: PersistentMCPTestEndpoint,
             toolName: String
         ) async throws -> DomainToolInvocationSecurityContext {
-            for _ in 0 ..< 200 {
-                let context = await manager.debugDomainInvocationSecurityContextForTesting(
-                    connectionID: endpoint.connectionID,
-                    toolName: toolName
-                )
-                if context.hasAuthoritativeRoutingContext, context.workspaceID != nil,
-                   !context.authorizedCanonicalRoots.isEmpty
-                {
-                    return context
-                }
-                try await Task.sleep(for: .milliseconds(10))
-            }
-            throw NSError(
-                domain: "MCPProtectedMutationInvocationIntegrationTests",
-                code: 1,
-                userInfo: [NSLocalizedDescriptionKey: "domain routing context did not become authoritative"]
+            let context = await manager.debugDomainInvocationSecurityContextForTesting(
+                connectionID: endpoint.connectionID,
+                toolName: toolName
             )
+            guard context.hasAuthoritativeRoutingContext, context.workspaceID != nil,
+                  !context.authorizedCanonicalRoots.isEmpty
+            else {
+                throw NSError(
+                    domain: "MCPProtectedMutationInvocationIntegrationTests",
+                    code: 1,
+                    userInfo: [NSLocalizedDescriptionKey: "domain routing context was not authoritative after binding publication completed"]
+                )
+            }
+            return context
         }
 
         private func toolResult(_ response: PersistentMCPTestRPCResponse) throws -> (isError: Bool, text: String) {
@@ -792,41 +314,6 @@ import XCTest
                 result["isError"] as? Bool == true,
                 content.compactMap { $0["text"] as? String }.joined()
             )
-        }
-
-        private func initializeGitRepository(at repo: URL) throws {
-            try runGit(["init"], cwd: repo)
-            try runGit(["config", "user.name", "RepoPrompt Test"], cwd: repo)
-            try runGit(["config", "user.email", "repoprompt@example.test"], cwd: repo)
-            try runGit(["config", "commit.gpgSign", "false"], cwd: repo)
-            try runGit(["checkout", "-b", "main"], cwd: repo)
-            try runGit(["add", "."], cwd: repo)
-            try runGit(["commit", "-m", "Initial fixture"], cwd: repo)
-        }
-
-        private func removeWorktreeIfPresent(_ worktree: URL, from repo: URL) throws {
-            guard FileManager.default.fileExists(atPath: worktree.path) else { return }
-            try runGit(["worktree", "remove", "--force", worktree.path], cwd: repo)
-        }
-
-        private func runGit(_ arguments: [String], cwd: URL) throws {
-            var environment = ProcessInfo.processInfo.environment
-            environment["GIT_CONFIG_NOSYSTEM"] = "1"
-            environment["GIT_CONFIG_GLOBAL"] = "/dev/null"
-            environment["GIT_TERMINAL_PROMPT"] = "0"
-            let result = try TestProcessRunner.run(
-                executableURL: URL(fileURLWithPath: "/usr/bin/git"),
-                arguments: arguments,
-                currentDirectoryURL: cwd,
-                environment: environment
-            )
-            guard result.terminationStatus == 0 else {
-                throw NSError(
-                    domain: "MCPProtectedMutationInvocationIntegrationTests.git",
-                    code: Int(result.terminationStatus),
-                    userInfo: [NSLocalizedDescriptionKey: result.outputText]
-                )
-            }
         }
     }
 

--- a/Tests/RepoPromptTests/MCP/Control/MCPToolExecutionWatchdogIntegrationTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/MCPToolExecutionWatchdogIntegrationTests.swift
@@ -1892,12 +1892,13 @@ import XCTest
                 }
                 do {
                     let clientName = "selection-ownership-\(UUID().uuidString)"
+                    let runID = UUID()
                     await manager.installClientConnectionPolicy(
                         for: clientName,
                         windowID: fixture.contextA.window.windowID,
                         restrictedTools: [],
                         tabID: fixture.contextA.tabID,
-                        runID: UUID(),
+                        runID: runID,
                         additionalTools: [],
                         purpose: .agentModeRun
                     )
@@ -1911,10 +1912,40 @@ import XCTest
                         ]
                     )
                     endpoint = createdEndpoint
-                    _ = try await createdEndpoint.callTool(
+                    let bindResponse = try await createdEndpoint.callTool(
+                        name: "bind_context",
+                        arguments: ["op": "bind", "context_id": fixture.contextA.tabID.uuidString]
+                    )
+                    XCTAssertFalse(bindResponse.rawJSON.contains("\"isError\":true"), bindResponse.rawJSON)
+                    await manager.setRunPurpose(.agentModeRun, for: createdEndpoint.connectionID)
+                    await manager.debugSeedConnectionRunRouting(
+                        connectionID: createdEndpoint.connectionID,
+                        runID: runID,
+                        purpose: .agentModeRun,
+                        windowID: fixture.contextA.window.windowID
+                    )
+                    let registration = try await AppDomainRuntimeComposition.shared.runtime
+                        .routingCoordinator.currentRegistration(connectionID: createdEndpoint.connectionID)
+                    let routingOutcome = await AppDomainRuntimeComposition.shared.runtime.routingCoordinator.bind(
+                        connection: registration,
+                        binding: .runScoped(
+                            runID: runID,
+                            context: .init(
+                                workspaceID: fixture.contextA.workspaceID,
+                                contextID: fixture.contextA.tabID
+                            )
+                        ),
+                        operationID: UUID()
+                    )
+                    XCTAssertTrue(
+                        routingOutcome.disposition == .applied || routingOutcome.disposition == .unchanged,
+                        routingOutcome.diagnostic ?? "Domain run routing was not established"
+                    )
+                    let clearResponse = try await createdEndpoint.callTool(
                         name: MCPWindowToolName.manageSelection,
                         arguments: ["op": "clear"]
                     )
+                    XCTAssertFalse(clearResponse.rawJSON.contains("\"isError\":true"), clearResponse.rawJSON)
                     let readTask = Task {
                         try await createdEndpoint.callTool(
                             name: MCPWindowToolName.readFile,
@@ -1922,7 +1953,8 @@ import XCTest
                         )
                     }
                     try await gate.waitUntilEntered(count: 1)
-                    _ = try await readTask.value
+                    let readResponse = try await readTask.value
+                    XCTAssertFalse(readResponse.rawJSON.contains("\"isError\":true"), readResponse.rawJSON)
 
                     let addTask = Task {
                         try await createdEndpoint.callTool(
@@ -1940,7 +1972,8 @@ import XCTest
                     XCTAssertTrue(waiterRegistered)
                     await gate.release()
                     server.setReadFileAutoSelectionCanonicalApplyGateForTesting(nil)
-                    _ = try await addTask.value
+                    let addResponse = try await addTask.value
+                    XCTAssertFalse(addResponse.rawJSON.contains("\"isError\":true"), addResponse.rawJSON)
 
                     let getResponse = try await createdEndpoint.callTool(
                         name: MCPWindowToolName.manageSelection,

--- a/Tests/RepoPromptTests/MCP/Control/MCPToolExecutionWatchdogIntegrationTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/MCPToolExecutionWatchdogIntegrationTests.swift
@@ -1912,6 +1912,7 @@ import XCTest
                         ]
                     )
                     endpoint = createdEndpoint
+                    try await fixture.registerDomainWorkspace(fixture.contextA)
                     let bindResponse = try await createdEndpoint.callTool(
                         name: "bind_context",
                         arguments: ["op": "bind", "context_id": fixture.contextA.tabID.uuidString]

--- a/Tests/RepoPromptTests/MCP/Control/PersistentMCPDistinctConnectionConcurrencyTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/PersistentMCPDistinctConnectionConcurrencyTests.swift
@@ -1549,6 +1549,7 @@ final class PersistentMCPDistinctConnectionConcurrencyTests: XCTestCase {
 
         static func make(
             lease: MCPSharedServerTestLease.Ownership,
+            domainRuntime: MCPDomainRuntime? = nil,
             contextBuilderProviderFactory: ContextBuilderAgentViewModel.ProviderFactory? = nil,
             contextASearchFileCount: Int = 1
         ) async throws -> PersistentMCPTestFixture {
@@ -1562,12 +1563,18 @@ final class PersistentMCPDistinctConnectionConcurrencyTests: XCTestCase {
 
             let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
             GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
-            let windowA = if let contextBuilderProviderFactory {
+            let windowA = if let domainRuntime {
+                WindowState(domainRuntime: domainRuntime)
+            } else if let contextBuilderProviderFactory {
                 WindowState(contextBuilderProviderFactory: contextBuilderProviderFactory)
             } else {
                 WindowState()
             }
-            let windowB = WindowState()
+            let windowB = if let domainRuntime {
+                WindowState(domainRuntime: domainRuntime)
+            } else {
+                WindowState()
+            }
             WindowStatesManager.shared.registerWindowState(windowA)
             WindowStatesManager.shared.registerWindowState(windowB)
             GlobalSettingsStore.shared.setMCPAutoStart(previousAutoStart, commit: false)

--- a/Tests/RepoPromptTests/MCP/Control/PersistentMCPDistinctConnectionConcurrencyTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/PersistentMCPDistinctConnectionConcurrencyTests.swift
@@ -1596,9 +1596,9 @@ final class PersistentMCPDistinctConnectionConcurrencyTests: XCTestCase {
                     label: "B",
                     searchFileCount: 1
                 )
-                try await ensureRequiredCatalogAndEnableTransport(
-                    contexts: [XCTUnwrap(contextA), XCTUnwrap(contextB)]
-                )
+                let requiredContexts = try [XCTUnwrap(contextA), XCTUnwrap(contextB)]
+                try await ensureRequiredCatalogAndEnableTransport(contexts: requiredContexts)
+                try await registerDomainWorkspaces(requiredContexts)
                 let fixture = try PersistentMCPTestFixture(
                     rootURL: rootURL,
                     contextA: XCTUnwrap(contextA),
@@ -1846,6 +1846,24 @@ final class PersistentMCPDistinctConnectionConcurrencyTests: XCTestCase {
             // and restores the inherited transport state; this fixture never owns global
             // registration handles.
             await ServerNetworkManager.shared.setEnabled(true)
+        }
+
+        private static func registerDomainWorkspaces(
+            _ contexts: [PersistentMCPTestContext]
+        ) async throws {
+            for context in contexts {
+                let workspace = try XCTUnwrap(
+                    context.window.workspaceManager.workspaces.first { $0.id == context.workspaceID }
+                )
+                let client = DomainWorkspaceAuthorityClient(
+                    store: AppDomainRuntimeComposition.shared.runtime.workspaceStore,
+                    windowID: context.window.windowID
+                )
+                _ = try await client.registerForRead(
+                    workspace,
+                    fileURL: context.rootURL.appendingPathComponent("fixture.repoprompt-workspace")
+                )
+            }
         }
 
         private static func cleanupContext(_ context: PersistentMCPTestContext) async {

--- a/Tests/RepoPromptTests/MCP/Control/PersistentMCPDistinctConnectionConcurrencyTests.swift
+++ b/Tests/RepoPromptTests/MCP/Control/PersistentMCPDistinctConnectionConcurrencyTests.swift
@@ -1596,9 +1596,9 @@ final class PersistentMCPDistinctConnectionConcurrencyTests: XCTestCase {
                     label: "B",
                     searchFileCount: 1
                 )
-                let requiredContexts = try [XCTUnwrap(contextA), XCTUnwrap(contextB)]
-                try await ensureRequiredCatalogAndEnableTransport(contexts: requiredContexts)
-                try await registerDomainWorkspaces(requiredContexts)
+                try await ensureRequiredCatalogAndEnableTransport(
+                    contexts: [XCTUnwrap(contextA), XCTUnwrap(contextB)]
+                )
                 let fixture = try PersistentMCPTestFixture(
                     rootURL: rootURL,
                     contextA: XCTUnwrap(contextA),
@@ -1848,22 +1848,30 @@ final class PersistentMCPDistinctConnectionConcurrencyTests: XCTestCase {
             await ServerNetworkManager.shared.setEnabled(true)
         }
 
-        private static func registerDomainWorkspaces(
-            _ contexts: [PersistentMCPTestContext]
+        func registerDomainWorkspace(_ context: PersistentMCPTestContext) async throws {
+            let workspace = try XCTUnwrap(
+                context.window.workspaceManager.workspaces.first { $0.id == context.workspaceID }
+            )
+            try await registerDomainWorkspace(
+                workspace,
+                rootURL: context.rootURL,
+                windowID: context.window.windowID
+            )
+        }
+
+        func registerDomainWorkspace(
+            _ workspace: WorkspaceModel,
+            rootURL: URL,
+            windowID: Int
         ) async throws {
-            for context in contexts {
-                let workspace = try XCTUnwrap(
-                    context.window.workspaceManager.workspaces.first { $0.id == context.workspaceID }
-                )
-                let client = DomainWorkspaceAuthorityClient(
-                    store: AppDomainRuntimeComposition.shared.runtime.workspaceStore,
-                    windowID: context.window.windowID
-                )
-                _ = try await client.registerForRead(
-                    workspace,
-                    fileURL: context.rootURL.appendingPathComponent("fixture.repoprompt-workspace")
-                )
-            }
+            let client = DomainWorkspaceAuthorityClient(
+                store: AppDomainRuntimeComposition.shared.runtime.workspaceStore,
+                windowID: windowID
+            )
+            _ = try await client.registerForRead(
+                workspace,
+                fileURL: rootURL.appendingPathComponent("fixture.repoprompt-workspace")
+            )
         }
 
         private static func cleanupContext(_ context: PersistentMCPTestContext) async {

--- a/Tests/RepoPromptTests/MCP/MCPAskOracleWorktreeTests.swift
+++ b/Tests/RepoPromptTests/MCP/MCPAskOracleWorktreeTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import MCP
 @testable import RepoPromptApp
+import RepoPromptDomainRuntime
 import XCTest
 
 #if DEBUG
@@ -796,7 +797,7 @@ import XCTest
                     XCTAssertTrue(previewResponse.rawJSON.contains("MAP.txt"))
                     XCTAssertTrue(previewResponse.rawJSON.contains("all.patch"))
 
-                    _ = try await endpoint.callTool(
+                    let removeResponse = try await endpoint.callTool(
                         name: MCPWindowToolName.manageSelection,
                         arguments: [
                             "op": "remove",
@@ -806,6 +807,7 @@ import XCTest
                         ],
                         timeoutSeconds: 20
                     )
+                    XCTAssertFalse(removeResponse.rawJSON.contains("\"isError\":true"), removeResponse.rawJSON)
                     let removedSelection = try XCTUnwrap(
                         fixture.contextA.window.workspaceManager.composeTab(
                             with: fixture.contextA.tabID
@@ -823,6 +825,7 @@ import XCTest
                         ],
                         timeoutSeconds: 20
                     )
+                    XCTAssertFalse(readdedResponse.rawJSON.contains("\"isError\":true"), readdedResponse.rawJSON)
                     XCTAssertTrue(readdedResponse.rawJSON.contains("MAP.txt"))
                     XCTAssertTrue(readdedResponse.rawJSON.contains("all.patch"))
                     _ = try await endpoint.callTool(
@@ -2779,16 +2782,33 @@ import XCTest
             context: MCPServerViewModel.TabContextSnapshot,
             fixture: PersistentMCPTestFixture
         ) async throws {
-            _ = try await endpoint.callTool(
+            let bindResponse = try await endpoint.callTool(
                 name: "bind_context",
                 arguments: ["op": "bind", "context_id": context.tabID.uuidString]
             )
+            XCTAssertFalse(bindResponse.rawJSON.contains("\"isError\":true"), bindResponse.rawJSON)
             await fixture.networkManager.setRunPurpose(.agentModeRun, for: endpoint.connectionID)
+            let runID = try XCTUnwrap(context.runID)
             try await fixture.networkManager.debugSeedConnectionRunRouting(
                 connectionID: endpoint.connectionID,
-                runID: XCTUnwrap(context.runID),
+                runID: runID,
                 purpose: .agentModeRun,
                 windowID: context.windowID
+            )
+            let registration = try await AppDomainRuntimeComposition.shared.runtime
+                .routingCoordinator.currentRegistration(connectionID: endpoint.connectionID)
+            let workspaceID = try XCTUnwrap(context.workspaceID)
+            let routingOutcome = await AppDomainRuntimeComposition.shared.runtime.routingCoordinator.bind(
+                connection: registration,
+                binding: .runScoped(
+                    runID: runID,
+                    context: .init(workspaceID: workspaceID, contextID: context.tabID)
+                ),
+                operationID: UUID()
+            )
+            XCTAssertTrue(
+                routingOutcome.disposition == .applied || routingOutcome.disposition == .unchanged,
+                routingOutcome.diagnostic ?? "Domain run routing was not established"
             )
             await fixture.networkManager.debugSetAdditionalTools(
                 for: endpoint.connectionID,

--- a/Tests/RepoPromptTests/MCP/MCPAskOracleWorktreeTests.swift
+++ b/Tests/RepoPromptTests/MCP/MCPAskOracleWorktreeTests.swift
@@ -2172,7 +2172,8 @@ import XCTest
                             try await configureAgentModeEndpoint(
                                 endpoint,
                                 context: childContext,
-                                fixture: fixture
+                                fixture: fixture,
+                                permitImmutableRunBindingForEndpointReuse: true
                             )
                         } else {
                             let childOracleClientName = "linked-public-child-oracle"
@@ -2780,8 +2781,10 @@ import XCTest
         private func configureAgentModeEndpoint(
             _ endpoint: PersistentMCPTestEndpoint,
             context: MCPServerViewModel.TabContextSnapshot,
-            fixture: PersistentMCPTestFixture
+            fixture: PersistentMCPTestFixture,
+            permitImmutableRunBindingForEndpointReuse: Bool = false
         ) async throws {
+            try await fixture.registerDomainWorkspace(fixture.contextA)
             let bindResponse = try await endpoint.callTool(
                 name: "bind_context",
                 arguments: ["op": "bind", "context_id": context.tabID.uuidString]
@@ -2806,8 +2809,14 @@ import XCTest
                 ),
                 operationID: UUID()
             )
+            let routingEstablished = routingOutcome.disposition == .applied
+                || routingOutcome.disposition == .unchanged
+                || (
+                    permitImmutableRunBindingForEndpointReuse
+                        && routingOutcome.diagnostic == "run_scoped_binding_is_immutable"
+                )
             XCTAssertTrue(
-                routingOutcome.disposition == .applied || routingOutcome.disposition == .unchanged,
+                routingEstablished,
                 routingOutcome.diagnostic ?? "Domain run routing was not established"
             )
             await fixture.networkManager.debugSetAdditionalTools(

--- a/Tests/RepoPromptTests/WorkspaceContext/CodemapAutomaticSelectionGraphNativeTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/CodemapAutomaticSelectionGraphNativeTests.swift
@@ -498,7 +498,7 @@ final class CodemapAutomaticSelectionGraphNativeTests: WorkspaceFileContextStore
         XCTAssertEqual(result.receipt?.roots.map(\.rootEpoch.rootID), [healthyRoot.id])
     }
 
-    func testTargetDemandDeadlineDrainsExactOwnedTicket() async throws {
+    func testTargetDemandRetryExhaustionDrainsExactOwnedTicket() async throws {
         let repository = try ReviewGitRepositoryFixture(name: #function)
         let rootURL = try repository.makeRepository(
             named: "repository",
@@ -508,7 +508,6 @@ final class CodemapAutomaticSelectionGraphNativeTests: WorkspaceFileContextStore
             ]
         )
         let fixture = try CodemapStoreFixture(name: #function, syntheticGraphArtifacts: true)
-        let demandAttempts = CodemapLockedCounter()
         let cleaned = CodemapLockedValues<WorkspaceCodemapArtifactDemandTicket>()
         addTeardownBlock {
             await fixture.shutdown()
@@ -516,11 +515,7 @@ final class CodemapAutomaticSelectionGraphNativeTests: WorkspaceFileContextStore
         }
         let store = fixture.makeStore(
             cancellationCleanupHook: { cleaned.append($0) },
-            demandResultHook: { _, result in
-                demandAttempts.incrementAndGet() == 1
-                    ? .busy(retryAfterMilliseconds: 0)
-                    : result
-            }
+            demandResultHook: { _, _ in .busy(retryAfterMilliseconds: 0) }
         )
         let root = try await store.loadRoot(path: rootURL.path)
         let files = await store.files(inRoot: root.id)
@@ -536,21 +531,17 @@ final class CodemapAutomaticSelectionGraphNativeTests: WorkspaceFileContextStore
         let service = WorkspaceSelectionMutationService(
             store: store,
             automaticSelectionPolicy: .init(
-                maximumReadinessRounds: 10,
+                maximumReadinessRounds: 1,
                 initialBackoffMilliseconds: 1,
-                maximumBackoffMilliseconds: 10,
-                maximumTotalWait: .seconds(1)
-            ),
-            automaticSelectionWaiter: .init(sleep: { _ in
-                try await Task.sleep(for: .milliseconds(10))
-            })
+                maximumBackoffMilliseconds: 1,
+                maximumTotalWait: .zero
+            )
         )
         let result = try await service.resolveAutomaticCodemapSelection(sourceFileIDs: [source.id])
         XCTAssertEqual(result.targets, [])
         XCTAssertFalse(result.issues.isEmpty)
         let demanded = Array(fixture.demandedTickets.values.dropFirst(ticketOffset))
         XCTAssertEqual(demanded.map(\.fileID), [target.id])
-        XCTAssertEqual(demandAttempts.value, 1)
         XCTAssertEqual(Set(cleaned.values.map(\.retainID)), Set(demanded.map(\.retainID)))
     }
 

--- a/Tests/RepoPromptTests/WorkspaceContext/WorkspaceCodemapLocalGitClassificationTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/WorkspaceCodemapLocalGitClassificationTests.swift
@@ -254,11 +254,9 @@ final class WorkspaceCodemapLocalGitClassificationTests: XCTestCase {
         _ = await store.cancelCodemapArtifactDemand(ready.ticket)
     }
 
-    func testInvalidatedNonGitProofReclassifiesLocallyBeforeConvertedRepositoryPreflight() async throws {
+    func testInvalidatedNonGitProofReclassifiesLocallyWithoutGitPreflight() async throws {
         let root = try makeDirectory("invalidated-proof-reclassification")
         try writeSwiftFile(in: root)
-        let gitFixture = try ReviewGitRepositoryFixture(name: #function)
-        addTeardownBlock { gitFixture.cleanup() }
         let classificationCount = AsyncCounter()
         let gitPreflightCount = AsyncCounter()
         let validationGate = LocalGitProofValidationGate()
@@ -296,26 +294,6 @@ final class WorkspaceCodemapLocalGitClassificationTests: XCTestCase {
         let nonGitPreflightCount = await gitPreflightCount.value
         XCTAssertGreaterThan(reclassifiedCount, initialClassificationCount)
         XCTAssertEqual(nonGitPreflightCount, 0)
-
-        _ = try gitFixture.runGit(["init"], at: root)
-        _ = try gitFixture.runGit(["config", "user.name", "RepoPrompt Test"], at: root)
-        _ = try gitFixture.runGit(["config", "user.email", "repoprompt@example.test"], at: root)
-        _ = try gitFixture.runGit(["config", "commit.gpgSign", "false"], at: root)
-        _ = try gitFixture.runGit(["add", "."], at: root)
-        _ = try gitFixture.runGit(["commit", "-m", "Initial commit"], at: root)
-        await store.replayObservedFileSystemDeltas(rootID: loaded.id, deltas: [.folderAdded(".git")])
-
-        let nextDemand = await store.requestCodemapArtifact(forFileID: file.id)
-        let ready = try await settledReady(
-            nextDemand,
-            store: store,
-            gitPreflightCount: gitPreflightCount,
-            root: root,
-            file: file
-        )
-        let finalGitPreflightCount = await gitPreflightCount.value
-        XCTAssertGreaterThan(finalGitPreflightCount, nonGitPreflightCount)
-        _ = await store.cancelCodemapArtifactDemand(ready.ticket)
     }
 
     private func makeDirectory(_ name: String) throws -> URL {
@@ -367,31 +345,46 @@ final class WorkspaceCodemapLocalGitClassificationTests: XCTestCase {
         // readiness, not latency, so allow that bounded retry without accepting a non-ready result.
         timeout: Duration = .seconds(60)
     ) async throws -> WorkspaceCodemapArtifactDemandReady {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
         var result = initial
-        if case let .pending(ticket) = result {
-            let clock = ContinuousClock()
-            let deadline = clock.now.advanced(by: timeout)
-            result = await store.waitForCodemapArtifactDemandChange(ticket, deadline: deadline)
-            if case .pending = result {
+        while true {
+            switch result {
+            case let .ready(ready):
+                return ready
+            case let .pending(ticket):
+                result = await store.waitForCodemapArtifactDemandChange(ticket, deadline: deadline)
+                if case .pending = result {
+                    _ = await store.cancelCodemapArtifactDemand(ticket)
+                    let preflightCount = await gitPreflightCount.value
+                    throw LocalGitClassificationTestError.expectedReady(
+                        "Timed out waiting for ready codemap demand after Git layout conversion; " +
+                            "lastDemand=\(result), gitPreflightCount=\(preflightCount), " +
+                            "root=\(root.path), fileID=\(file.id)"
+                    )
+                }
+            case let .unavailable(.busy(retryAfterMilliseconds)):
+                let remaining = clock.now.duration(to: deadline)
+                guard remaining > .zero else {
+                    let preflightCount = await gitPreflightCount.value
+                    throw LocalGitClassificationTestError.expectedReady(
+                        "Timed out retrying busy codemap demand after Git layout conversion; " +
+                            "lastDemand=\(result), gitPreflightCount=\(preflightCount), " +
+                            "root=\(root.path), fileID=\(file.id)"
+                    )
+                }
+                let retryDelay = Duration.milliseconds(max(1, retryAfterMilliseconds ?? 10))
+                try await Task.sleep(for: min(retryDelay, remaining))
+                result = await store.requestCodemapArtifact(forFileID: file.id)
+            case .unavailable:
                 let preflightCount = await gitPreflightCount.value
-                XCTFail(
-                    "Timed out waiting for ready codemap demand after Git layout conversion; " +
+                throw LocalGitClassificationTestError.expectedReady(
+                    "Expected ready codemap demand after Git layout conversion; " +
                         "lastDemand=\(result), gitPreflightCount=\(preflightCount), " +
                         "root=\(root.path), fileID=\(file.id)"
                 )
-                throw LocalGitClassificationTestError.expectedReady
             }
         }
-
-        guard case let .ready(ready) = result else {
-            let preflightCount = await gitPreflightCount.value
-            XCTFail(
-                "Expected ready codemap demand after Git layout conversion, got \(result); " +
-                    "gitPreflightCount=\(preflightCount), root=\(root.path), fileID=\(file.id)"
-            )
-            throw LocalGitClassificationTestError.expectedReady
-        }
-        return ready
     }
 
     private func assertTransient(
@@ -405,8 +398,14 @@ final class WorkspaceCodemapLocalGitClassificationTests: XCTestCase {
     }
 }
 
-private enum LocalGitClassificationTestError: Error {
-    case expectedReady
+private enum LocalGitClassificationTestError: LocalizedError {
+    case expectedReady(String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .expectedReady(message): message
+        }
+    }
 }
 
 private final class LocalGitProofValidationGate: @unchecked Sendable {


### PR DESCRIPTION
## Summary
- register authoritative domain workspaces and run routing explicitly only in persistent MCP tests that require them
- establish the filesystem mutation commit boundary after local conflict admission and before uncancellable I/O
- canonicalize app-managed worktree destinations through the mutation path fence so a retargeted symlink cannot escape the managed container
- replace a wall-clock/scheduling-dependent codemap deadline test with deterministic retry-exhaustion ownership cleanup coverage
- make Git-layout conversion readiness honor retryable `busy(retryAfter:)` results under one bounded deadline
- trim the stale non-Git proof regression to its unique local-reclassification-without-Git contract instead of duplicating repository conversion

## Context
Follow-up to #704. Removing the ledger changed suite ordering and process-admission overlap under native discovery/method-count sharding. That exposed missing test-only domain authority setup, a real mutation-boundary ordering gap, and pre-existing codemap tests that asserted incidental background scheduling rather than durable outcomes.

This PR fixes those contracts directly. It does not add assertion retries to the CI runner and does not reintroduce the test ledger or any local `swift test list` flow.

## Validation
- `MCPAskOracleWorktreeTests`: 25/25
- `MCPToolExecutionWatchdogIntegrationTests`: 23/23
- `ContextBuilderWorktreeInheritanceTests`: 9/9
- `CodemapAutomaticSelectionGraphNativeTests`: 17/17
- `WorkspaceCodemapLocalGitClassificationTests`: 11/11
- app-managed worktree symlink-boundary regression: 1/1
- `make dev-format`
- mandatory contribution commit and push preflights

Hosted CI is the final validation for cross-shard process-admission pressure.