### PR TITLE
Fix M5 credential pruning type inference

### DIFF
--- a/Sources/RepoPromptDomainRuntime/DomainCredentialEnvelope.swift
+++ b/Sources/RepoPromptDomainRuntime/DomainCredentialEnvelope.swift
@@ -334,7 +334,7 @@ package actor DomainCredentialEnvelopeStore {
 
     private func pruneExpiredRecords() {
         let now = clock.now
-        let expiredIDs = records.compactMap { id, record in
+        let expiredIDs = records.compactMap { id, record -> UUID? in
             guard record.state == .active, now >= record.descriptor.expiresAt else { return nil }
             return id
         }


### PR DESCRIPTION
## Summary
- add the explicit `UUID?` result type Swift needs for the multi-statement credential-record `compactMap`
- restore all app and Sentry builds broken by M5 on current `main`
- leave Tip release workflows and runtime behavior unchanged

## Evidence
Current-main CI run 30745299523 failed every app build at `DomainCredentialEnvelope.swift:337` with `generic parameter ElementOfResult could not be inferred`.

## Validation
- `make dev-swift-build PRODUCT=RepoPrompt`
- `make dev-format` (0 files reformatted)
- `make dev-lint`
- contribution preflight: `commit` and `push`
