### PR TITLE
Fix protected mutation commit boundary

### DIFF
--- a/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService+FileOperations.swift
+++ b/Sources/RepoPrompt/Infrastructure/FileSystem/FileSystemService+FileOperations.swift
@@ -119,8 +119,8 @@ extension FileSystemService {
                 let willBegin: (@Sendable (FileSystemUncancellableMutation) async -> Void)? = nil
                 let willExecute: (@Sendable (FileSystemUncancellableMutation) -> Void)? = nil
             #endif
-            let physicalMutationGuard = try await MCPDomainMutationCommitContext.physicalMutationGuard()
             try await MCPDomainMutationCommitContext.willCommit()
+            let physicalMutationGuard = try await MCPDomainMutationCommitContext.physicalMutationGuard()
             let executor = FileSystemMutationIOExecutor(
                 operation: operation,
                 physicalMutationGuard: physicalMutationGuard,

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel.swift
@@ -6633,7 +6633,6 @@ final class MCPServerViewModel: ObservableObject {
             [source.standardizedFullPath, destination],
             rootMappings: mutationRootMappings
         )
-        try await MCPDomainMutationCommitContext.willCommit()
         try await store.moveFile(rootID: source.rootID, from: source.standardizedRelativePath, to: newRelativePath)
     }
 
@@ -6653,7 +6652,6 @@ final class MCPServerViewModel: ObservableObject {
                 [file.standardizedFullPath],
                 rootMappings: mutationRootMappings
             )
-            try await MCPDomainMutationCommitContext.willCommit()
             try await store.moveItemToTrash(rootID: file.rootID, relativePath: file.standardizedRelativePath)
             return
         }
@@ -6665,7 +6663,6 @@ final class MCPServerViewModel: ObservableObject {
                 [folder.standardizedFullPath],
                 rootMappings: mutationRootMappings
             )
-            try await MCPDomainMutationCommitContext.willCommit()
             try await store.moveItemToTrash(rootID: folder.rootID, relativePath: folder.standardizedRelativePath)
         } else {
             throw MCPError.invalidParams("Unknown or unloaded path: \(path).")

--- a/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileMutationService.swift
+++ b/Sources/RepoPrompt/Infrastructure/WorkspaceContext/WorkspaceFileMutationService.swift
@@ -107,7 +107,6 @@ struct WorkspaceFileMutationService {
             [file.standardizedFullPath],
             rootMappings: mutationRootMappings
         )
-        try await MCPDomainMutationCommitContext.willCommit()
         let result = try await store.editFile(rootID: file.rootID, relativePath: file.standardizedRelativePath, newContent: content)
         if let result {
             return .fromCatalogMaterialization(result)
@@ -273,7 +272,6 @@ struct WorkspaceFileMutationService {
             [absolutePath],
             rootMappings: mutationRootMappings
         )
-        try await MCPDomainMutationCommitContext.willCommit()
         let result = try await store.createFile(
             rootID: root.id,
             relativePath: relativePath,


### PR DESCRIPTION
## Summary
- remove premature domain `willCommit()` markers from store-backed create/edit/move/trash paths
- keep `FileSystemService.startUncancellableMutation` authoritative: reject in-flight conflicts before marking durable commit
- fetch the physical mutation guard after `willCommit()` so executor-boundary path-fence revalidation remains active

## Root cause
Current-main CI run 30746934795 and a focused local run reproduced `MCPToolExecutionWatchdogIntegrationTests.testRealFileActionTimeoutDetachesIOReconcilesCatalogAndKeepsQueuedCallUsable`. A same-path mutation conflict occurred before physical I/O, but the outer commit marker caused the domain provider to misclassify it as `partialSuccessAfterCommit`.

No assertions, sleeps, or retries were weakened. Direct physical mutation paths that bypass `FileSystemService` retain their explicit commit markers.

## Validation
- exact regression: 1/1 passed
- `MCPToolExecutionWatchdogIntegrationTests`: 23/23 passed
- `DomainProtectedMutationJournalTests`: 11/11 passed
- `make dev-lint`
- Fable 5 High review: no must-fix findings; recommended included guard-order correction
- contribution preflight: `commit` and `push`
