### PR TITLE
perf: coalesce compose inspector refresh work

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentSelectedFilesModelCoordinator.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentSelectedFilesModelCoordinator.swift
@@ -277,7 +277,6 @@ final class AgentSelectedFilesModelCoordinator: ObservableObject {
     private var cachedModelOrder: [AgentSelectedFilesModelIdentity] = []
     private var completedCountSnapshots: [AgentSelectedFilesModelIdentity: AgentContextFileCodemapCountSummary] = [:]
     private var completedEntryMetricsSnapshots: [AgentSelectedFilesModelIdentity: PromptContextEntryMetricsSnapshot] = [:]
-    private var loadingEntryMetricsSnapshot: PromptContextEntryMetricsSnapshot?
 
     private struct VisibleFileMetricsScope: Equatable {
         let filePathDisplay: FilePathDisplay
@@ -341,12 +340,6 @@ final class AgentSelectedFilesModelCoordinator: ObservableObject {
     ) -> AgentSelectedFilesRefreshOutcome? {
         guard let entryMetricsSnapshot = request.entryMetricsSnapshot else { return nil }
         guard displayedModelMatches(request.identity) || loadingIdentity == request.identity else { return nil }
-        if loadingIdentity == request.identity,
-           loadingEntryMetricsSnapshot == entryMetricsSnapshot
-        {
-            debugStats.skippedLoading += 1
-            return .skippedLoading
-        }
         if completedDisplayedModelMatches(request.identity),
            completedEntryMetricsSnapshots[request.identity] == entryMetricsSnapshot
         {
@@ -433,7 +426,6 @@ final class AgentSelectedFilesModelCoordinator: ObservableObject {
         let refreshID = UUID()
         self.refreshID = refreshID
         loadingIdentity = request.identity
-        loadingEntryMetricsSnapshot = request.entryMetricsSnapshot
         state = AgentSelectedFilesModelState(
             model: shouldClearDisplayedModel ? nil : state.model,
             rowSplit: shouldClearDisplayedModel ? .empty : state.rowSplit,
@@ -514,7 +506,6 @@ final class AgentSelectedFilesModelCoordinator: ObservableObject {
                           loadingIdentity == request.identity
                     else { return }
                     loadingIdentity = nil
-                    loadingEntryMetricsSnapshot = nil
                     self.refreshID = nil
                     refreshTask = nil
                     state = AgentSelectedFilesModelState(
@@ -568,7 +559,6 @@ final class AgentSelectedFilesModelCoordinator: ObservableObject {
                     totalSelectedDisplayTokens: resolvedModel.totalSelectedDisplayTokens
                 )
                 loadingIdentity = nil
-                loadingEntryMetricsSnapshot = nil
                 self.refreshID = nil
                 refreshTask = nil
                 debugStats.resolverCompletions += 1
@@ -595,7 +585,6 @@ final class AgentSelectedFilesModelCoordinator: ObservableObject {
         refreshTask = nil
         refreshID = nil
         loadingIdentity = nil
-        loadingEntryMetricsSnapshot = nil
         state = keepLoadedModel
             ? AgentSelectedFilesModelState(
                 model: state.model,
@@ -741,7 +730,6 @@ final class AgentSelectedFilesModelCoordinator: ObservableObject {
         refreshTask = nil
         refreshID = nil
         loadingIdentity = nil
-        loadingEntryMetricsSnapshot = nil
     }
 
     private func cacheModel(_ model: AgentContextExportModel, for identity: AgentSelectedFilesModelIdentity) {

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentSelectedFilesModelCoordinator.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/UI/AgentSelectedFilesModelCoordinator.swift
@@ -276,6 +276,8 @@ final class AgentSelectedFilesModelCoordinator: ObservableObject {
     private var cachedModels: [AgentSelectedFilesModelIdentity: AgentContextExportModel] = [:]
     private var cachedModelOrder: [AgentSelectedFilesModelIdentity] = []
     private var completedCountSnapshots: [AgentSelectedFilesModelIdentity: AgentContextFileCodemapCountSummary] = [:]
+    private var completedEntryMetricsSnapshots: [AgentSelectedFilesModelIdentity: PromptContextEntryMetricsSnapshot] = [:]
+    private var loadingEntryMetricsSnapshot: PromptContextEntryMetricsSnapshot?
 
     private struct VisibleFileMetricsScope: Equatable {
         let filePathDisplay: FilePathDisplay
@@ -337,8 +339,20 @@ final class AgentSelectedFilesModelCoordinator: ObservableObject {
     func refreshAfterTokenMetricsCompletion(
         _ request: AgentSelectedFilesModelRequest
     ) -> AgentSelectedFilesRefreshOutcome? {
-        guard request.entryMetricsSnapshot != nil else { return nil }
+        guard let entryMetricsSnapshot = request.entryMetricsSnapshot else { return nil }
         guard displayedModelMatches(request.identity) || loadingIdentity == request.identity else { return nil }
+        if loadingIdentity == request.identity,
+           loadingEntryMetricsSnapshot == entryMetricsSnapshot
+        {
+            debugStats.skippedLoading += 1
+            return .skippedLoading
+        }
+        if completedDisplayedModelMatches(request.identity),
+           completedEntryMetricsSnapshots[request.identity] == entryMetricsSnapshot
+        {
+            debugStats.skippedLoaded += 1
+            return .skippedLoaded
+        }
         return refresh(
             request,
             force: true,
@@ -419,6 +433,7 @@ final class AgentSelectedFilesModelCoordinator: ObservableObject {
         let refreshID = UUID()
         self.refreshID = refreshID
         loadingIdentity = request.identity
+        loadingEntryMetricsSnapshot = request.entryMetricsSnapshot
         state = AgentSelectedFilesModelState(
             model: shouldClearDisplayedModel ? nil : state.model,
             rowSplit: shouldClearDisplayedModel ? .empty : state.rowSplit,
@@ -499,6 +514,7 @@ final class AgentSelectedFilesModelCoordinator: ObservableObject {
                           loadingIdentity == request.identity
                     else { return }
                     loadingIdentity = nil
+                    loadingEntryMetricsSnapshot = nil
                     self.refreshID = nil
                     refreshTask = nil
                     state = AgentSelectedFilesModelState(
@@ -542,6 +558,7 @@ final class AgentSelectedFilesModelCoordinator: ObservableObject {
                     canMutateDisplayedModel: true
                 )
                 completedCountSnapshots[request.identity] = resolvedRowSplit.fileCodemapCountSummary
+                completedEntryMetricsSnapshots[request.identity] = request.entryMetricsSnapshot
                 cacheModel(resolvedModel, for: request.identity)
                 loadedIdentity = request.identity
                 displayedIdentity = request.identity
@@ -551,6 +568,7 @@ final class AgentSelectedFilesModelCoordinator: ObservableObject {
                     totalSelectedDisplayTokens: resolvedModel.totalSelectedDisplayTokens
                 )
                 loadingIdentity = nil
+                loadingEntryMetricsSnapshot = nil
                 self.refreshID = nil
                 refreshTask = nil
                 debugStats.resolverCompletions += 1
@@ -577,6 +595,7 @@ final class AgentSelectedFilesModelCoordinator: ObservableObject {
         refreshTask = nil
         refreshID = nil
         loadingIdentity = nil
+        loadingEntryMetricsSnapshot = nil
         state = keepLoadedModel
             ? AgentSelectedFilesModelState(
                 model: state.model,
@@ -722,6 +741,7 @@ final class AgentSelectedFilesModelCoordinator: ObservableObject {
         refreshTask = nil
         refreshID = nil
         loadingIdentity = nil
+        loadingEntryMetricsSnapshot = nil
     }
 
     private func cacheModel(_ model: AgentContextExportModel, for identity: AgentSelectedFilesModelIdentity) {
@@ -731,6 +751,7 @@ final class AgentSelectedFilesModelCoordinator: ObservableObject {
             let evicted = cachedModelOrder.removeFirst()
             cachedModels[evicted] = nil
             completedCountSnapshots[evicted] = nil
+            completedEntryMetricsSnapshots[evicted] = nil
         }
     }
 

--- a/Sources/RepoPrompt/Features/AgentMode/Views/AgentModeDetailWithSidebarView.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/AgentModeDetailWithSidebarView.swift
@@ -337,7 +337,7 @@ private struct AgentContextInspectorPresenter<PrimaryContent: View>: View {
     let drawerStore: AgentContextDrawerUIStore
     @ObservedObject var presentationStore: AgentContextDrawerPresentationStore
     let promptManager: PromptViewModel
-    @ObservedObject var runtimeVM: AgentRuntimeSidebarViewModel
+    let runtimeVM: AgentRuntimeSidebarViewModel
     let contextBuilderAgentVM: ContextBuilderAgentViewModel
     let oracleViewModel: OracleViewModel
     let selectionCoordinator: WorkspaceSelectionCoordinator
@@ -363,7 +363,7 @@ private struct AgentContextInspectorPresenter<PrimaryContent: View>: View {
         self.drawerStore = drawerStore
         _presentationStore = ObservedObject(wrappedValue: drawerStore.presentation)
         self.promptManager = promptManager
-        _runtimeVM = ObservedObject(wrappedValue: runtimeVM)
+        self.runtimeVM = runtimeVM
         self.contextBuilderAgentVM = contextBuilderAgentVM
         self.oracleViewModel = oracleViewModel
         self.selectionCoordinator = selectionCoordinator

--- a/Sources/RepoPrompt/Features/AgentMode/Views/ContextDrawer/AgentContextDrawerTokenEstimatePill.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/ContextDrawer/AgentContextDrawerTokenEstimatePill.swift
@@ -16,7 +16,10 @@ struct AgentContextDrawerTokenEstimatePill: View {
     }
 
     var body: some View {
-        let snapshot = tokenCounter.latestPublishedTokenSnapshot(for: tokenBlankingSelection)
+        let snapshot = tokenCounter.latestPublishedTokenSnapshot(
+            for: tokenBlankingSelection,
+            scheduleRefreshIfNeeded: false
+        )
         let contextWindowTokenBudget = contextWindowTokens
         let isWaiting = isWaitingForExpectedSelection(snapshot)
 

--- a/Tests/RepoPromptTests/AgentMode/AgentSelectedFilesModelCoordinatorTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentSelectedFilesModelCoordinatorTests.swift
@@ -62,9 +62,6 @@ final class AgentSelectedFilesModelCoordinatorTests: XCTestCase {
         XCTAssertEqual(coordinator.model?.totalSelectedDisplayTokens, 0)
         XCTAssertTrue(coordinator.isLoading)
         XCTAssertFalse(coordinator.canMutateDisplayedModel)
-        XCTAssertEqual(coordinator.refreshAfterTokenMetricsCompletion(enrichedRequest), .skippedLoading)
-        let startCountWhileLoading = await resolver.startCount()
-        XCTAssertEqual(startCountWhileLoading, 2)
 
         await resolver.releaseNext()
         let expectedMetrics = AgentContextExportRow.Metrics.known(

--- a/Tests/RepoPromptTests/AgentMode/AgentSelectedFilesModelCoordinatorTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentSelectedFilesModelCoordinatorTests.swift
@@ -62,6 +62,9 @@ final class AgentSelectedFilesModelCoordinatorTests: XCTestCase {
         XCTAssertEqual(coordinator.model?.totalSelectedDisplayTokens, 0)
         XCTAssertTrue(coordinator.isLoading)
         XCTAssertFalse(coordinator.canMutateDisplayedModel)
+        XCTAssertEqual(coordinator.refreshAfterTokenMetricsCompletion(enrichedRequest), .skippedLoading)
+        let startCountWhileLoading = await resolver.startCount()
+        XCTAssertEqual(startCountWhileLoading, 2)
 
         await resolver.releaseNext()
         let expectedMetrics = AgentContextExportRow.Metrics.known(
@@ -79,6 +82,9 @@ final class AgentSelectedFilesModelCoordinatorTests: XCTestCase {
         XCTAssertEqual(coordinator.model?.totalSelectedDisplayTokens, 91)
         XCTAssertEqual(coordinator.debugStats.resolverStarts, 2)
         XCTAssertEqual(coordinator.debugStats.resolverCompletions, 2)
+        XCTAssertEqual(coordinator.refreshAfterTokenMetricsCompletion(enrichedRequest), .skippedLoaded)
+        let startCountAfterCompletion = await resolver.startCount()
+        XCTAssertEqual(startCountAfterCompletion, 2)
     }
 
     @MainActor
@@ -1432,6 +1438,10 @@ private actor GatedTokenMetricsModelResolver {
     func releaseNext() {
         guard !continuations.isEmpty else { return }
         continuations.removeFirst().resume()
+    }
+
+    func startCount() -> Int {
+        starts
     }
 }
 


### PR DESCRIPTION
## Summary
- skip redundant compose-inspector resolver work when token metrics complete with an identical already-published snapshot
- stop the presenter wrapper from observing all runtime snapshot changes when only the drawer and token pill need that observation
- prevent the token estimate pill from scheduling refresh work during SwiftUI body evaluation
- extend coordinator coverage to prove identical completed snapshots do not trigger another resolve

Follow-up to #535 after a performance-focused audit.

## Review notes
The audit also identified larger possible costs in full-content rereads for selected worktree files and periodic Git selection reconciliation. Those are intentionally deferred until measured; this PR keeps the change small and addresses only confirmed redundant invalidation/work.

A Fable 5 High design review caught an unsafe first attempt to coalesce in-flight refreshes: a failed or cancelled request could consume the only completion event. That optimization was removed, preserving retry semantics while retaining safe completed-snapshot coalescing.

## Validation
- make dev-test FILTER=AgentSelectedFilesModelCoordinatorTests — 29 tests, 0 failures
- make dev-format — clean
- make dev-lint — clean
- contribution commit and push preflights — passed

The PR-ready full root suite completed with four failures in unrelated concurrency/timing tests:
- CodemapBindingEngineInvalidationTests.testRequestReservationAndCancellationDuringValidatedReadReleaseExactlyOnce
- DurableArtifactIdentityLeaseGCTests.testQuarantineGraceAbandonedWorkCleanupAndDirectOldVersionDeletion
- WorkspaceCodemapBindingEngineObservabilityTests.testGraphIndexManifestPersistenceOccursOnceAtEnumerationSeal
- WorkspaceFileContextStoreTests.testAggressiveAppliedIngressLimitsConcurrentRootFlushFanOut

The changed coordinator suite remained green. A focused rerun was queued but cancelled before acquiring the machine-wide heavy slot because another worktree held it; hosted exact-head CI should provide the final broad signal.