### PR TITLE
Fix current-main CI blockers after M7 merge

### DIFF
--- a/Sources/RepoPrompt/Infrastructure/MCP/MCPConnectionManager.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/MCPConnectionManager.swift
@@ -415,7 +415,9 @@ private final class BootstrapTransferredSocketLedger: @unchecked Sendable {
 typealias MCPConnectionCallLane = MCPDomainConnectionCallLane
 typealias MCPConnectionCallLimiters = MCPDomainConnectionCallLimiters
 typealias MCPConnectionCallLimiterWatchdogDiagnostics = MCPDomainConnectionCallLimiterWatchdogDiagnostics
-typealias MCPConnectionCallLimiterDebugSnapshot = MCPDomainConnectionCallLimiterDebugSnapshot
+#if DEBUG
+    typealias MCPConnectionCallLimiterDebugSnapshot = MCPDomainConnectionCallLimiterDebugSnapshot
+#endif
 typealias AsyncLimiter = MCPDomainAsyncLimiter
 
 enum MCPRunRouteAuthorityDecision: Equatable {

--- a/Tests/RepoPromptDomainRuntimeTests/MCPDomainResponseDeliveryTrackerTests.swift
+++ b/Tests/RepoPromptDomainRuntimeTests/MCPDomainResponseDeliveryTrackerTests.swift
@@ -10,8 +10,6 @@ final class MCPDomainResponseDeliveryTrackerTests: XCTestCase {
         XCTAssertEqual(before.pendingRequestCount, 1)
 
         let waiter = Task { await tracker.waitUntilDrained() }
-        await Task.yield()
-        XCTAssertEqual(tracker.snapshot().waiterCount, 1)
         tracker.recordDeliveredServerFrame(Self.frame(#"{"jsonrpc":"2.0","id":1,"result":{}}"#))
 
         let drained = await waiter.value

--- a/Tests/RepoPromptTests/MCP/WorktreeAPISmokeHarnessTests.swift
+++ b/Tests/RepoPromptTests/MCP/WorktreeAPISmokeHarnessTests.swift
@@ -1058,7 +1058,21 @@ final class WorktreeAPISmokeHarnessTests: XCTestCase {
         }
         let activeWorkspace = try XCTUnwrap(window.workspaceManager.activeWorkspace)
         window.promptManager.loadComposeTabsFromWorkspace(activeWorkspace, syncPromptText: true)
-        _ = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(in: window, path: root.path)
+        let loadedRoot = try await WorkspaceRootLoadTestSupport.loadRootMatchingCurrentFileSystemSettings(
+            in: window,
+            path: root.path
+        )
+        let admission = try await window.workspaceFileContextStore.admitReusableSnapshotForLoadedRoot(
+            rootID: loadedRoot.id,
+            expectedStandardizedPath: loadedRoot.standardizedFullPath
+        )
+        guard case .admitted = admission else {
+            throw NSError(
+                domain: "WorktreeAPISmokeHarnessTests",
+                code: 2,
+                userInfo: [NSLocalizedDescriptionKey: "Loaded root did not admit reusable startup evidence: \(admission)"]
+            )
+        }
         return window
     }
 

--- a/Tests/RepoPromptTests/MCP/WorktreeAPISmokeHarnessTests.swift
+++ b/Tests/RepoPromptTests/MCP/WorktreeAPISmokeHarnessTests.swift
@@ -934,10 +934,17 @@ final class WorktreeAPISmokeHarnessTests: XCTestCase {
             resolveSpawnParentSourceTabID: { _ in nil },
             resolveSpawnParentSessionID: { _, _ in nil },
             withHeartbeat: { _, _, _, _, operation in try await operation() },
-            startRun: { target, _, _, agentModeVM, agentRaw, modelRaw, reasoningEffortRaw, _, _, _, _ in
+            startRun: { target, _, metadata, agentModeVM, agentRaw, modelRaw, reasoningEffortRaw, taskLabelKind, _, _, _ in
                 guard let sessionID = target.sessionID else {
                     throw MCPError.internalError("Smoke start target did not resolve a session ID.")
                 }
+                try await agentModeVM.mcpActivateControlContext(
+                    forTabID: target.tabID,
+                    sessionID: sessionID,
+                    originatingConnectionID: metadata.connectionID,
+                    taskLabelKind: taskLabelKind,
+                    startPending: true
+                )
                 let bindings = agentModeVM.worktreeBindings(forAgentSessionID: sessionID, tabID: target.tabID)
                 let snapshot = AgentRunMCPSnapshot(
                     sessionID: sessionID,

--- a/Tests/RepoPromptTests/WorkspaceContext/WorkspaceFileContextStoreTests.swift
+++ b/Tests/RepoPromptTests/WorkspaceContext/WorkspaceFileContextStoreTests.swift
@@ -3836,13 +3836,7 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
             let barrier = Task {
                 await store.awaitAppliedIngressForAllRoots()
             }
-            for _ in 0 ..< 1000 {
-                if await flushGate.startCount() >= 8 { break }
-                await Task.yield()
-            }
-            for _ in 0 ..< 50 {
-                await Task.yield()
-            }
+            await flushGate.waitUntilStartedCount(8)
             let startsBeforeRelease = await flushGate.startCount()
             XCTAssertEqual(startsBeforeRelease, 8)
 
@@ -8463,6 +8457,14 @@ final class WorkspaceFileContextStoreTests: XCTestCase {
                 guard !started else { return }
                 await withCheckedContinuation { continuation in
                     startWaiters.append(continuation)
+                }
+            }
+
+            func waitUntilStartedCount(_ expectedCount: Int) async {
+                while startedCount < expectedCount {
+                    await withCheckedContinuation { continuation in
+                        startWaiters.append(continuation)
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary

- replace yield-count polling in the workspace ingress fan-out test with actor-isolated count readiness while retaining the exact 8-before-release / 9-after-release contract
- keep response-delivery coverage on the contractual physical-delivery and drained end state without asserting transient unstructured-task registration order
- make the worktree smoke fixture complete the coordinator-owned MCP control-context/start-pending lifecycle for existing and created worktrees
- compile the connection-call-limiter debug snapshot alias only in DEBUG builds
- integrate current `main` at `191a1a6cab3aa28cb9ca8ea1ebc426dc26696bb4` with a normal merge commit

## Validation

- exact three failing methods passed on the integrated head
- `MCPDomainResponseDeliveryTrackerTests`: 5/5 passed
- `WorktreeAPISmokeHarnessTests`: 6/6 passed
- `WorkspaceFileContextStoreTests`: 133/133 passed
- coordinated SwiftFormat + SwiftLint strict passed
- coordinated release preflight passed
- coordinated release artifact produced the arm64 release executable and cleared the original non-DEBUG compile failure; the ticket was externally canceled during the later x86_64 cold build after 5,284s, so it is not counted as a full artifact pass and hosted Release Candidate CI remains required
- commit-mode and push-mode contribution preflights passed

## Scope

No workflow, packaging-flag, timeout, retry, or production-behavior changes. The release alias remains unavailable outside DEBUG.
