### PR TITLE
feat: show sessionless compose tabs in agent chats

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeSidebarSessionBuilder.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeSidebarSessionBuilder.swift
@@ -6,7 +6,7 @@ struct AgentModeSidebarSessionBuilder {
     typealias TabSession = AgentModeViewModel.TabSession
 
     let allTabs: [ComposeTabState]
-    let linkedTabs: [ComposeTabState]
+    let rowTabs: [ComposeTabState]
     let sessions: [UUID: TabSession]
     let authoritativeSessionIDByTabID: [UUID: UUID]
     let sessionIndex: [UUID: AgentSessionIndexEntry]
@@ -20,7 +20,7 @@ struct AgentModeSidebarSessionBuilder {
         let tabNameByID: [UUID: String]
         let tabOrder: [UUID: Int]
         let sortDateByTabID: [UUID: Date]
-        let explicitSessionIDByTabID: [UUID: UUID]
+        let resolvedSessionIDByTabID: [UUID: UUID]
         let bestEntryByTabID: [UUID: AgentSessionIndexEntry]
         let useFrozenRestoreOrder: Bool
     }
@@ -30,7 +30,7 @@ struct AgentModeSidebarSessionBuilder {
             let startMS = AgentModePerfDiagnostics.timestampMSIfEnabled()
         #endif
         let context = makeBuildContext()
-        let rows = linkedTabs.map { tab in
+        let rows = rowTabs.map { tab in
             sidebarRow(for: tab, context: context)
         }
         let baseSortedSessions = sortedSidebarRows(rows, context: context)
@@ -44,9 +44,10 @@ struct AgentModeSidebarSessionBuilder {
                 fields: [
                     "allTabCount": String(allTabs.count),
                     "hasParentMetadata": String(hasParentMetadata),
-                    "linkedTabCount": String(linkedTabs.count),
                     "mcpControlledCount": String(mcpControlledTabIDs.count),
                     "resultCount": String(result.count),
+                    "rowTabCount": String(rowTabs.count),
+                    "sessionlessRowCount": String(result.count(where: { $0.sessionID == nil })),
                     "sessionCount": String(sessions.count),
                     "sessionIndexCount": String(sessionIndex.count),
                     "sortDateCount": String(sessionListSortDates.count)
@@ -77,10 +78,10 @@ struct AgentModeSidebarSessionBuilder {
         for tab in allTabs where tabByID[tab.id] == nil {
             tabByID[tab.id] = tab
         }
-        let tabNameByID = sidebarTabNameLookup(for: linkedTabs)
-        let tabOrder = sidebarTabOrder(for: linkedTabs)
+        let tabNameByID = sidebarTabNameLookup(for: rowTabs)
+        let tabOrder = sidebarTabOrder(for: rowTabs)
         let explicitSessionIDByTabID = authoritativeSessionIDByTabID.filter { tabID, _ in
-            linkedTabs.contains(where: { $0.id == tabID })
+            rowTabs.contains(where: { $0.id == tabID })
         }
         let explicitTabIDBySessionID = Dictionary(
             explicitSessionIDByTabID.map { ($0.value, $0.key) },
@@ -88,16 +89,21 @@ struct AgentModeSidebarSessionBuilder {
         )
         let indexEntriesByTabID = Dictionary(grouping: sessionIndex.values, by: \.tabID)
         let bestEntryByTabID = sidebarEntryMap(
-            for: linkedTabs,
+            for: rowTabs,
             tabNameByID: tabNameByID,
             explicitSessionIDByTabID: explicitSessionIDByTabID,
             explicitTabIDBySessionID: explicitTabIDBySessionID,
             indexEntriesBySessionID: sessionIndex,
             indexEntriesByTabID: indexEntriesByTabID
         )
+        let resolvedSessionIDByTabID = Dictionary(
+            uniqueKeysWithValues: rowTabs.compactMap { tab in
+                (explicitSessionIDByTabID[tab.id] ?? bestEntryByTabID[tab.id]?.id).map { (tab.id, $0) }
+            }
+        )
         let sortDateByTabID = sidebarSortDateLookup(
-            for: linkedTabs,
-            explicitSessionIDByTabID: explicitSessionIDByTabID,
+            for: rowTabs,
+            resolvedSessionIDByTabID: resolvedSessionIDByTabID,
             bestEntryByTabID: bestEntryByTabID
         )
         return BuildContext(
@@ -105,9 +111,12 @@ struct AgentModeSidebarSessionBuilder {
             tabNameByID: tabNameByID,
             tabOrder: tabOrder,
             sortDateByTabID: sortDateByTabID,
-            explicitSessionIDByTabID: explicitSessionIDByTabID,
+            resolvedSessionIDByTabID: resolvedSessionIDByTabID,
             bestEntryByTabID: bestEntryByTabID,
-            useFrozenRestoreOrder: shouldFreezeSidebarOrdering(for: linkedTabs)
+            useFrozenRestoreOrder: shouldFreezeSidebarOrdering(
+                for: rowTabs,
+                resolvedSessionIDByTabID: resolvedSessionIDByTabID
+            )
         )
     }
 
@@ -129,13 +138,14 @@ struct AgentModeSidebarSessionBuilder {
 
     private func sidebarSortDateLookup(
         for tabs: [ComposeTabState],
-        explicitSessionIDByTabID: [UUID: UUID],
+        resolvedSessionIDByTabID: [UUID: UUID],
         bestEntryByTabID: [UUID: AgentSessionIndexEntry]
     ) -> [UUID: Date] {
         var sortDateByTabID: [UUID: Date] = [:]
         for tab in tabs where sortDateByTabID[tab.id] == nil {
+            guard let resolvedSessionID = resolvedSessionIDByTabID[tab.id] else { continue }
             let liveSession: TabSession? = if let session = sessions[tab.id],
-                                              session.activeAgentSessionID == explicitSessionIDByTabID[tab.id],
+                                              session.activeAgentSessionID == resolvedSessionID,
                                               session.hasLoadedPersistedState
             {
                 session
@@ -153,13 +163,14 @@ struct AgentModeSidebarSessionBuilder {
         return sortDateByTabID
     }
 
-    private func shouldFreezeSidebarOrdering(for tabs: [ComposeTabState]) -> Bool {
+    private func shouldFreezeSidebarOrdering(
+        for tabs: [ComposeTabState],
+        resolvedSessionIDByTabID: [UUID: UUID]
+    ) -> Bool {
         guard !sessionListCacheReady, !sidebarRestoreFrozenOrderByTabID.isEmpty else { return false }
-        return tabs.allSatisfy { sidebarRestoreFrozenOrderByTabID[$0.id] != nil }
-    }
-
-    private func frozenSidebarOrderIndex(for tabID: UUID, fallback: Int) -> Int {
-        sidebarRestoreFrozenOrderByTabID[tabID] ?? fallback
+        let sessionBackedTabs = tabs.filter { resolvedSessionIDByTabID[$0.id] != nil }
+        guard !sessionBackedTabs.isEmpty else { return false }
+        return sessionBackedTabs.allSatisfy { sidebarRestoreFrozenOrderByTabID[$0.id] != nil }
     }
 
     private func sidebarEntryMap(
@@ -243,10 +254,10 @@ struct AgentModeSidebarSessionBuilder {
         for tab: ComposeTabState,
         context: BuildContext
     ) -> SidebarSession {
-        let authoritativeSessionID = context.explicitSessionIDByTabID[tab.id]
-            ?? context.bestEntryByTabID[tab.id]?.id
-        let boundLiveSession: TabSession? = if let session = sessions[tab.id],
-                                               session.activeAgentSessionID == authoritativeSessionID
+        let resolvedSessionID = context.resolvedSessionIDByTabID[tab.id]
+        let boundLiveSession: TabSession? = if let resolvedSessionID,
+                                               let session = sessions[tab.id],
+                                               session.activeAgentSessionID == resolvedSessionID
         {
             session
         } else {
@@ -268,7 +279,6 @@ struct AgentModeSidebarSessionBuilder {
         )
         let savedAt = sidebarSavedAt(for: tab, liveSession: metadataLiveSession, indexEntry: entry)
         let activityDate = Self.sidebarActivityDate(lastUserMessageAt: lastUserMessageAt, savedAt: savedAt)
-        let resolvedSessionID = authoritativeSessionID ?? entry?.id
         let resolvedParentSessionID = metadataLiveSession?.parentSessionID ?? entry?.parentSessionID
         let isMCPControlled = mcpControlledTabIDs.contains(tab.id)
         let worktree = sidebarRowWorktree(liveSession: metadataLiveSession, entry: entry)
@@ -403,13 +413,18 @@ struct AgentModeSidebarSessionBuilder {
         context: BuildContext
     ) -> [SidebarSession] {
         rows.sorted { lhs, rhs in
-            let lhsIndex = context.tabOrder[lhs.tabID] ?? Int.max
-            let rhsIndex = context.tabOrder[rhs.tabID] ?? Int.max
             if context.useFrozenRestoreOrder {
-                let lhsFrozenIndex = frozenSidebarOrderIndex(for: lhs.tabID, fallback: lhsIndex)
-                let rhsFrozenIndex = frozenSidebarOrderIndex(for: rhs.tabID, fallback: rhsIndex)
-                if lhsFrozenIndex != rhsFrozenIndex {
-                    return lhsFrozenIndex < rhsFrozenIndex
+                let lhsFrozenIndex = sidebarRestoreFrozenOrderByTabID[lhs.tabID]
+                let rhsFrozenIndex = sidebarRestoreFrozenOrderByTabID[rhs.tabID]
+                switch (lhsFrozenIndex, rhsFrozenIndex) {
+                case let (.some(lhsIndex), .some(rhsIndex)) where lhsIndex != rhsIndex:
+                    return lhsIndex < rhsIndex
+                case (.some, .none):
+                    return true
+                case (.none, .some):
+                    return false
+                default:
+                    break
                 }
             }
             return sidebarRowPrecedes(lhs, rhs, tabOrder: context.tabOrder)

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+SidebarSessions.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+SidebarSessions.swift
@@ -382,46 +382,72 @@ extension AgentModeViewModel {
         }
     }
 
-    /// Session-linked sidebar data source.
-    /// Blank compose tabs stay hidden until they are explicitly linked to an agent session.
+    /// Session-linked sidebar data source for runtime behavior and navigation.
+    /// Compose tabs stay hidden until they are explicitly linked to an Agent session.
     func sidebarSessions(for tabs: [ComposeTabState]) -> [SidebarSession] {
+        buildSidebarSessions(
+            for: tabs,
+            includeComposeTabsWithoutAgentSessions: false
+        )
+    }
+
+    /// Presentation data source for the active Agent Chats list.
+    func agentChatsSidebarSessions(for tabs: [ComposeTabState]) -> [SidebarSession] {
+        buildSidebarSessions(
+            for: tabs,
+            includeComposeTabsWithoutAgentSessions: true
+        )
+    }
+
+    private func buildSidebarSessions(
+        for tabs: [ComposeTabState],
+        includeComposeTabsWithoutAgentSessions: Bool
+    ) -> [SidebarSession] {
         let cacheKey = SidebarSessionRowsCacheKey(
             workspaceID: workspaceManager?.activeWorkspaceID,
             sidebarRevision: ui.sessionSidebar.snapshot.revision,
             tabMetadataSignatures: makeSessionSidebarTabMetadataSignatures(for: tabs)
         )
-        if let cached = sidebarSessionRowsCache, cached.key == cacheKey {
-            return cached.rows
+        let cachedRows = includeComposeTabsWithoutAgentSessions
+            ? agentChatsSidebarRowsCache
+            : sidebarSessionRowsCache
+        if let cachedRows, cachedRows.key == cacheKey {
+            return cachedRows.rows
         }
 
         let currentIndex = ownerValidatedSessionIndex
-        let indexEntriesByTabID = Dictionary(grouping: currentIndex.values, by: \.tabID)
         let authoritativeSessionIDByTabID = Dictionary(
             uniqueKeysWithValues: tabs.compactMap { tab in
                 authoritativeSessionID(for: tab).map { (tab.id, $0) }
             }
         )
-        let explicitTabIDBySessionID = Dictionary(
-            authoritativeSessionIDByTabID.map { ($0.value, $0.key) },
-            uniquingKeysWith: { _, latest in latest }
-        )
-        let linkedTabs = tabs.filter { tab in
-            if authoritativeSessionIDByTabID[tab.id] != nil {
-                return true
+        let rowTabs: [ComposeTabState]
+        if includeComposeTabsWithoutAgentSessions {
+            rowTabs = tabs
+        } else {
+            let indexEntriesByTabID = Dictionary(grouping: currentIndex.values, by: \.tabID)
+            let explicitTabIDBySessionID = Dictionary(
+                authoritativeSessionIDByTabID.map { ($0.value, $0.key) },
+                uniquingKeysWith: { _, latest in latest }
+            )
+            rowTabs = tabs.filter { tab in
+                if authoritativeSessionIDByTabID[tab.id] != nil {
+                    return true
+                }
+                let candidateEntries = (indexEntriesByTabID[tab.id] ?? []).filter { entry in
+                    guard let explicitTabID = explicitTabIDBySessionID[entry.id] else { return true }
+                    return explicitTabID == tab.id
+                }
+                return AgentModeSidebarSessionBuilder.preferredSidebarEntry(
+                    for: tab.id,
+                    tabName: tab.name,
+                    entries: candidateEntries
+                ) != nil
             }
-            let candidateEntries = (indexEntriesByTabID[tab.id] ?? []).filter { entry in
-                guard let explicitTabID = explicitTabIDBySessionID[entry.id] else { return true }
-                return explicitTabID == tab.id
-            }
-            return AgentModeSidebarSessionBuilder.preferredSidebarEntry(
-                for: tab.id,
-                tabName: tab.name,
-                entries: candidateEntries
-            ) != nil
         }
         let rows = AgentModeSidebarSessionBuilder(
             allTabs: tabs,
-            linkedTabs: linkedTabs,
+            rowTabs: rowTabs,
             sessions: sessions,
             authoritativeSessionIDByTabID: authoritativeSessionIDByTabID,
             sessionIndex: currentIndex,
@@ -430,7 +456,11 @@ extension AgentModeViewModel {
             sidebarRestoreFrozenOrderByTabID: ownerValidatedSidebarRestoreFrozenOrderByTabID,
             mcpControlledTabIDs: mcpControlledTabIDs
         ).build()
-        sidebarSessionRowsCache = (cacheKey, rows)
+        if includeComposeTabsWithoutAgentSessions {
+            agentChatsSidebarRowsCache = (cacheKey, rows)
+        } else {
+            sidebarSessionRowsCache = (cacheKey, rows)
+        }
         #if DEBUG
             test_sidebarSessionRowsBuildCount &+= 1
         #endif
@@ -473,8 +503,17 @@ extension AgentModeViewModel {
         for tabs: [ComposeTabState],
         searchText: String
     ) -> [AgentSidebarThreadKey] {
+        defaultCollapsedSidebarThreadKeys(
+            in: sidebarSessions(for: tabs),
+            searchText: searchText
+        )
+    }
+
+    private func defaultCollapsedSidebarThreadKeys(
+        in rows: [SidebarSession],
+        searchText: String
+    ) -> [AgentSidebarThreadKey] {
         guard searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return [] }
-        let rows = sidebarSessions(for: tabs)
         return rows.indices.compactMap { index -> AgentSidebarThreadKey? in
             let nextIndex = rows.index(after: index)
             guard rows[index].depth > 0,
@@ -494,7 +533,8 @@ extension AgentModeViewModel {
         stashedTabs: [StashedTab],
         currentTabID: UUID?,
         sidebarSnapshot: AgentSessionSidebarSnapshot,
-        archivedSessionsExpanded: Bool
+        archivedSessionsExpanded: Bool,
+        showComposeTabsWithoutAgentSessions: Bool
     ) -> SidebarListProjection {
         let key = SidebarListProjectionCacheKey(
             workspaceID: workspaceManager?.activeWorkspaceID,
@@ -502,14 +542,19 @@ extension AgentModeViewModel {
             currentTabID: currentTabID,
             composeTabMetadataSignatures: makeSessionSidebarTabMetadataSignatures(for: composeTabs),
             stashedTabSignatures: makeSessionSidebarStashedTabSignatures(for: stashedTabs),
-            archivedSessionsExpanded: archivedSessionsExpanded
+            archivedSessionsExpanded: archivedSessionsExpanded,
+            showComposeTabsWithoutAgentSessions: showComposeTabsWithoutAgentSessions
         )
         if let cached = sidebarListProjectionCache, cached.key == key {
             return cached.projection
         }
 
-        let filteredSessions = displaySidebarSessions(
-            for: composeTabs,
+        let canonicalRows = showComposeTabsWithoutAgentSessions
+            ? agentChatsSidebarSessions(for: composeTabs)
+            : sidebarSessions(for: composeTabs)
+        let filteredSessions = filteredSidebarSessions(
+            canonicalRows,
+            inputTabCount: composeTabs.count,
             currentTabID: currentTabID,
             searchText: sidebarSnapshot.searchText,
             diagnosticSource: "listProjection"
@@ -537,7 +582,7 @@ extension AgentModeViewModel {
             sortedArchivedSessionTabsForRows: archivedSessionTabs.sortedTabs,
             archivedDateInfoByStashedTabID: archivedSessionTabs.dateInfoByStashedTabID,
             defaultCollapseSeedKeys: defaultCollapsedSidebarThreadKeys(
-                for: composeTabs,
+                in: canonicalRows,
                 searchText: sidebarSnapshot.searchText
             )
         )
@@ -558,12 +603,27 @@ extension AgentModeViewModel {
         searchText: String? = nil,
         diagnosticSource: String? = nil
     ) -> [SidebarSession] {
+        filteredSidebarSessions(
+            sidebarSessions(for: tabs),
+            inputTabCount: tabs.count,
+            currentTabID: currentTabID,
+            searchText: searchText ?? sessionSidebarSearchText,
+            diagnosticSource: diagnosticSource ?? "unknown"
+        )
+    }
+
+    private func filteredSidebarSessions(
+        _ sortedSessions: [SidebarSession],
+        inputTabCount: Int,
+        currentTabID: UUID?,
+        searchText: String,
+        diagnosticSource: String
+    ) -> [SidebarSession] {
         #if DEBUG
             let startMS = AgentModePerfDiagnostics.timestampMSIfEnabled()
         #endif
-        let source = diagnosticSource ?? "unknown"
-        let sortedSessions = sidebarSessions(for: tabs)
-        let effectiveSearchText = searchText ?? sessionSidebarSearchText
+        let source = diagnosticSource.isEmpty ? "unknown" : diagnosticSource
+        let effectiveSearchText = searchText
         let searchTrimmed = effectiveSearchText.trimmingCharacters(in: .whitespacesAndNewlines)
         let result: [SidebarSession]
         if searchTrimmed.isEmpty {
@@ -621,7 +681,7 @@ extension AgentModeViewModel {
                     "canonicalCount": String(sortedSessions.count),
                     "currentTabID": AgentModePerfDiagnostics.shortID(currentTabID),
                     "filteredCount": String(result.count),
-                    "inputTabCount": String(tabs.count),
+                    "inputTabCount": String(inputTabCount),
                     "searchActive": String(!searchTrimmed.isEmpty),
                     "source": source
                 ]
@@ -1056,10 +1116,15 @@ extension AgentModeViewModel {
     }
 
     private func worktreeBindingSummaries(forTabID tabID: UUID) -> [AgentSessionWorktreeBindingSummary] {
-        if let liveSession = sessions[tabID], !liveSession.worktreeBindings.isEmpty {
+        guard let sessionID = boundSessionID(for: tabID) else { return [] }
+        if let liveSession = sessions[tabID],
+           liveSession.activeAgentSessionID == sessionID,
+           !liveSession.worktreeBindings.isEmpty
+        {
             return liveSession.worktreeBindings.worktreeBindingSummaries
         }
-        return preferredSidebarEntry(for: tabID)?.worktreeBindingSummaries ?? []
+        guard let entry = preferredSidebarEntry(for: tabID), entry.id == sessionID else { return [] }
+        return entry.worktreeBindingSummaries
     }
 
     /// Worktree merge attentions for `tabID` keyed by logical workspace-root
@@ -1088,9 +1153,10 @@ extension AgentModeViewModel {
     }
 
     private func worktreeMergeOperations(forTabID tabID: UUID) -> [AgentSessionWorktreeMergeOperation] {
-        if let liveSession = sessions[tabID], !liveSession.worktreeMergeOperations.isEmpty {
-            return liveSession.worktreeMergeOperations
-        }
-        return []
+        guard let sessionID = boundSessionID(for: tabID),
+              let liveSession = sessions[tabID],
+              liveSession.activeAgentSessionID == sessionID
+        else { return [] }
+        return liveSession.worktreeMergeOperations
     }
 }

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+Types.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+Types.swift
@@ -184,6 +184,7 @@ extension AgentModeViewModel {
         let composeTabMetadataSignatures: [AgentSessionSidebarTabMetadataSignature]
         let stashedTabSignatures: [AgentSessionSidebarStashedTabSignature]
         let archivedSessionsExpanded: Bool
+        let showComposeTabsWithoutAgentSessions: Bool
     }
 
     struct SidebarListProjection {

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -636,6 +636,7 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
     /// first forced refresh so the initial request always publishes.
     var lastSidebarContentFingerprint: AgentSessionSidebarContentFingerprint?
     var sidebarSessionRowsCache: (key: SidebarSessionRowsCacheKey, rows: [SidebarSession])?
+    var agentChatsSidebarRowsCache: (key: SidebarSessionRowsCacheKey, rows: [SidebarSession])?
     var sidebarListProjectionCache: (key: SidebarListProjectionCacheKey, projection: SidebarListProjection)?
     private var lastKnownWorkspaceSnapshot: WorkspaceModel?
     var tabDraftText: [UUID: String] = [:]
@@ -16152,16 +16153,14 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
 
         promptManager?.renameComposeTab(tabID, to: validatedName)
 
-        let sessionID = boundSessionID(for: tabID)
-        if let sessionID,
-           var entry = ownerValidatedSessionIndex[sessionID]
-        {
+        guard let sessionID = boundSessionID(for: tabID) else { return }
+        if var entry = ownerValidatedSessionIndex[sessionID] {
             entry.name = validatedName
             applyLocalSessionIndexUpsert(entry)
         }
 
         if let session = sessions[tabID] {
-            if session.activeAgentSessionID == nil, let sessionID {
+            if session.activeAgentSessionID == nil {
                 _ = installPersistentSessionBinding(
                     sessionID: sessionID,
                     on: session,
@@ -16178,9 +16177,7 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
                 explicitThreadID: session.codexConversationID,
                 source: "renameSession"
             )
-        } else if let sessionID,
-                  let workspace = workspaceManager?.activeWorkspace ?? lastKnownWorkspaceSnapshot
-        {
+        } else if let workspace = workspaceManager?.activeWorkspace ?? lastKnownWorkspaceSnapshot {
             Task { [dataService] in
                 try? await dataService.renameAgentSession(
                     id: sessionID,

--- a/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionRows.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionRows.swift
@@ -8,7 +8,6 @@ struct AgentSessionRow: View {
     let isPinned: Bool
     let isMCPControlled: Bool
     let runState: AgentSessionRunState
-    let isWaiting: Bool
     /// When non-nil, the session raised a completed/failed/waiting transition
     /// while the user was NOT viewing it. Drives a persistent attention badge
     /// that survives re-renders until the session is selected/resumed or the
@@ -34,7 +33,7 @@ struct AgentSessionRow: View {
     var onToggleThreadCollapse: (() -> Void)?
     let onSelect: () -> Void
     let onTogglePin: () -> Void
-    let onStash: () -> Void
+    var onStash: (() -> Void)?
     let onDelete: () -> Void
     let onRename: (String) -> Void
     var onDismissAttention: (() -> Void)?
@@ -227,14 +226,16 @@ struct AgentSessionRow: View {
                 .onHover { isRenameHovered = $0 }
                 .hoverTooltip(renameActionLabel)
 
-                Button(action: onStash) {
-                    Image(systemName: "tray.and.arrow.down")
-                        .font(.system(size: 11))
-                        .foregroundColor(isStashHovered ? .accentColor : .secondary)
+                if let onStash {
+                    Button(action: onStash) {
+                        Image(systemName: "tray.and.arrow.down")
+                            .font(.system(size: 11))
+                            .foregroundColor(isStashHovered ? .accentColor : .secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .onHover { isStashHovered = $0 }
+                    .hoverTooltip(stashActionLabel)
                 }
-                .buttonStyle(.plain)
-                .onHover { isStashHovered = $0 }
-                .hoverTooltip(stashActionLabel)
 
                 Button(action: requestDeleteConfirmation) {
                     Image(systemName: "trash")
@@ -268,7 +269,9 @@ struct AgentSessionRow: View {
 
             Button(renameActionLabel, action: beginRename)
 
-            Button(stashActionLabel, action: onStash)
+            if let onStash {
+                Button(stashActionLabel, action: onStash)
+            }
 
             if attentionRunState != nil, let onDismissAttention {
                 Button(dismissAttentionActionLabel, action: onDismissAttention)

--- a/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionsSidebarView.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Views/Components/AgentSessionsSidebarView.swift
@@ -257,6 +257,8 @@ struct AgentModeSessionsListView: View {
     let currentTabID: UUID?
     @State private var archivedSessionsExpanded = false
     @State private var showingClearArchivedConfirmation = false
+    @AppStorage(SettingKeys.agentModeShowComposeTabsWithoutAgentSessions)
+    private var showComposeTabsWithoutAgentSessions = false
     @ObservedObject private var fontScale = FontScaleManager.shared
     private var fontPreset: FontScalePreset {
         fontScale.preset
@@ -304,7 +306,8 @@ struct AgentModeSessionsListView: View {
             stashedTabs: promptManager.currentStashedTabs,
             currentTabID: currentTabID,
             sidebarSnapshot: sidebarSnapshot,
-            archivedSessionsExpanded: archivedSessionsExpanded
+            archivedSessionsExpanded: archivedSessionsExpanded,
+            showComposeTabsWithoutAgentSessions: showComposeTabsWithoutAgentSessions
         )
         let defaultCollapseSeedKeys = snapshot.defaultCollapseSeedKeys
         let activeSections = AgentSidebarDateSectionBuilder.activeSections(for: snapshot.pagedSessions)
@@ -319,14 +322,32 @@ struct AgentModeSessionsListView: View {
 
                     ForEach(section.groups) { group in
                         ForEach(group.rows, id: \.id) { session in
+                            let hasAgentSession = session.sessionID != nil
+                            let runState: AgentSessionRunState = hasAgentSession
+                                ? agentModeVM.runState(for: session.tabID)
+                                : .idle
+                            let attentionRunState: AgentSessionRunState? = hasAgentSession
+                                ? sidebarUI.snapshot.attentionRunStateByTabID[session.tabID]
+                                : nil
+                            let toggleThreadAction: (() -> Void)? = session.hasThreadChildren
+                                ? { agentModeVM.requestSidebarThreadDisclosureToggle(for: session) }
+                                : nil
+                            // Archived Sessions excludes tabs without indexed conversation content,
+                            // so stashing a session-less tab would hide it from both sidebar lists.
+                            let stashAction: (() -> Void)? = hasAgentSession
+                                ? { Task { await promptManager.stashTab(session.tabID) } }
+                                : nil
+                            let dismissAttentionAction: (() -> Void)? = hasAgentSession
+                                ? { agentModeVM.dismissSidebarRunAttention(tabID: session.tabID) }
+                                : nil
+
                             AgentSessionRow(
                                 title: session.title,
                                 isActive: session.tabID == currentTabID,
                                 isPinned: session.isPinned,
                                 isMCPControlled: session.isMCPControlled,
-                                runState: agentModeVM.runState(for: session.tabID),
-                                isWaiting: agentModeVM.isTabWaiting(session.tabID),
-                                attentionRunState: sidebarUI.snapshot.attentionRunStateByTabID[session.tabID],
+                                runState: runState,
+                                attentionRunState: attentionRunState,
                                 worktree: session.worktree,
                                 worktreeMergeAttention: session.worktreeMergeAttention,
                                 threadDepth: session.depth,
@@ -334,20 +355,14 @@ struct AgentModeSessionsListView: View {
                                 isThreadCollapsed: session.isThreadCollapsed,
                                 hiddenThreadDescendantCount: session.hiddenThreadDescendantCount,
                                 hiddenThreadDescendantAttentionCount: session.hiddenThreadDescendantAttentionCount,
-                                onToggleThreadCollapse: session.hasThreadChildren
-                                    ? {
-                                        agentModeVM.requestSidebarThreadDisclosureToggle(for: session)
-                                    }
-                                    : nil,
+                                onToggleThreadCollapse: toggleThreadAction,
                                 onSelect: {
                                     Task { await promptManager.switchComposeTab(session.tabID) }
                                 },
                                 onTogglePin: {
                                     promptManager.toggleComposeTabPinned(session.tabID)
                                 },
-                                onStash: {
-                                    Task { await promptManager.stashTab(session.tabID) }
-                                },
+                                onStash: stashAction,
                                 onDelete: {
                                     #if DEBUG
                                         agentModeVM.debugBeginSidebarDeleteRequest(
@@ -361,9 +376,7 @@ struct AgentModeSessionsListView: View {
                                 onRename: { newName in
                                     agentModeVM.renameSession(tabID: session.tabID, to: newName)
                                 },
-                                onDismissAttention: {
-                                    agentModeVM.dismissSidebarRunAttention(tabID: session.tabID)
-                                }
+                                onDismissAttention: dismissAttentionAction
                             )
                         }
                     }

--- a/Sources/RepoPrompt/Features/Settings/Models/GlobalSettingsManager.swift
+++ b/Sources/RepoPrompt/Features/Settings/Models/GlobalSettingsManager.swift
@@ -33,6 +33,10 @@ enum SettingKeys {
 
     /// App-wide UI font scale preset body size.
     static let fontPresetBodySize = "fontPresetBodySize"
+
+    /// Whether Agent Chats includes open Compose tabs without Agent sessions.
+    /// Referenced by Agent Mode Overview and the Agent Chats list.
+    static let agentModeShowComposeTabsWithoutAgentSessions = "agentModeShowComposeTabsWithoutAgentSessions"
 }
 
 extension Notification.Name {

--- a/Sources/RepoPrompt/Features/Settings/Views/AgentModeGeneralSettingsView.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/AgentModeGeneralSettingsView.swift
@@ -11,9 +11,10 @@ import SwiftUI
 /// the canonical pages, and surfaces at-a-glance CLI provider connection
 /// status so users can spot missing configuration without leaving Overview.
 ///
-/// SEARCH-HELPER: Agent Mode Overview, Agent Mode Behavior, Safe Managed summary,
-/// Oracle Model summary, Context Builder summary, Agent Role Defaults summary,
-/// CLI provider status, Direct-Agent Permissions deep link, Sub-Agent Permissions deep link
+/// SEARCH-HELPER: Agent Mode Overview, Agent Mode Behavior, Agent Chats,
+/// Show MCP-created chats, Compose tabs without Agent sessions, Safe Managed summary, Oracle Model summary,
+/// Context Builder summary, Agent Role Defaults summary, CLI provider status,
+/// Direct-Agent Permissions deep link, Sub-Agent Permissions deep link
 ///
 /// Related:
 /// - Agent Models:      /RepoPrompt/Views/Settings/AgentModelsSettingsView.swift
@@ -29,6 +30,8 @@ struct AgentModeGeneralSettingsView: View {
     /// Observe secure permission-store changes so the read-only summary rebuilds
     /// without relying on @AppStorage for sensitive policy keys.
     @State private var subagentPolicyRevision = 0
+    @AppStorage(SettingKeys.agentModeShowComposeTabsWithoutAgentSessions)
+    private var showComposeTabsWithoutAgentSessions = false
 
     @State private var handoffInstructionsDraft = ""
     @State private var handoffInstructionsBaseline = ""
@@ -137,7 +140,36 @@ struct AgentModeGeneralSettingsView: View {
             )
 
             agentWorkflowsLinkRow
+
+            agentChatsCard
         }
+    }
+
+    // MARK: - Agent Chats
+
+    private var agentChatsCard: some View {
+        HStack(alignment: .top, spacing: fontPreset.scaledClamped(12, max: 18)) {
+            Image(systemName: "bubble.left")
+                .font(fontPreset.swiftUIFont(sizeAtNormal: 17))
+                .frame(width: fontPreset.scaledClamped(22, max: 30), alignment: .center)
+                .foregroundColor(.accentColor)
+
+            VStack(alignment: .leading, spacing: fontPreset.scaledClamped(6, max: 10)) {
+                Text("Agent Chats")
+                    .font(fontPreset.swiftUIFont(sizeAtNormal: 13, weight: .semibold))
+
+                Toggle("Show chats created by MCP tools", isOn: $showComposeTabsWithoutAgentSessions)
+                    .toggleStyle(.switch)
+
+                Text("Lists chats created by MCP tools before an agent has run in them, so you can observe and iterate on their selections, prompts, and Context Builder runs in Compose.")
+                    .font(fontPreset.swiftUIFont(sizeAtNormal: 12))
+                    .foregroundColor(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: fontPreset.scaledClamped(10, max: 14))
+        }
+        .padding(.vertical, fontPreset.scaledClamped(6, max: 10))
     }
 
     // MARK: - Provider cleanup

--- a/Sources/RepoPrompt/Features/Settings/Views/SettingsView.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/SettingsView.swift
@@ -1073,7 +1073,15 @@ enum SettingsTab: String, CaseIterable {
                 "cleanup_sessions",
                 "investigate workflow",
                 "refactor workflow",
-                "orchestrate workflow"
+                "orchestrate workflow",
+                "agent chats",
+                "compose tabs",
+                "show mcp-created chats",
+                "mcp-created chats",
+                "compose tabs without agent sessions",
+                "sessionless compose tabs",
+                "show compose tabs",
+                "agent session visibility"
             ]
         case .agentModels:
             [

--- a/Tests/RepoPromptTests/AgentMode/AgentModeSidebarSessionBuilderTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeSidebarSessionBuilderTests.swift
@@ -451,14 +451,108 @@ final class AgentModeSidebarSessionBuilderTests: XCTestCase {
         )
     }
 
+    func testSessionlessComposeTabDoesNotConsumeUnboundLiveSessionMetadata() throws {
+        let tabID = id(60)
+        let phantomParentID = id(160)
+        let composeTab = tab(tabID, sessionID: nil, name: "T9", lastModified: date(20))
+        let unboundSession = AgentModeViewModel.TabSession(tabID: tabID)
+        unboundSession.parentSessionID = phantomParentID
+        unboundSession.hasLoadedPersistedState = true
+        unboundSession.lastActivityAt = date(200)
+
+        let rows = build(
+            tabs: [composeTab],
+            sessions: [tabID: unboundSession],
+            sessionIndex: [:]
+        )
+
+        let sessionlessRow = try row(for: tabID, in: rows)
+        XCTAssertEqual(sessionlessRow.title, "New Chat")
+        XCTAssertNil(sessionlessRow.sessionID)
+        XCTAssertNil(sessionlessRow.parentSessionID)
+        XCTAssertEqual(sessionlessRow.depth, 0)
+        XCTAssertNil(sessionlessRow.lastUserMessageAt)
+        XCTAssertEqual(sessionlessRow.activityDate, date(20))
+        XCTAssertNil(sessionlessRow.worktree)
+        XCTAssertNil(sessionlessRow.worktreeMergeAttention)
+        let identifiers = sessionlessRow.searchFields.fields
+            .filter { $0.kind == .identifier }
+            .map(\.text)
+        XCTAssertEqual(identifiers, [tabID.uuidString])
+    }
+
+    func testSessionlessRootDoesNotChangeValidSessionHierarchy() {
+        let sessionlessTabID = id(61)
+        let parentTabID = id(62)
+        let childTabID = id(63)
+        let grandchildTabID = id(64)
+        let parentSessionID = id(161)
+        let childSessionID = id(162)
+        let grandchildSessionID = id(163)
+        let tabs = [
+            tab(sessionlessTabID, sessionID: nil, lastModified: date(50)),
+            tab(parentTabID, sessionID: parentSessionID),
+            tab(childTabID, sessionID: childSessionID),
+            tab(grandchildTabID, sessionID: grandchildSessionID)
+        ]
+        let index = sessionIndex([
+            entry(parentSessionID, tabID: parentTabID, lastUserMessageAt: date(30)),
+            entry(childSessionID, tabID: childTabID, parentSessionID: parentSessionID, lastUserMessageAt: date(20)),
+            entry(
+                grandchildSessionID,
+                tabID: grandchildTabID,
+                parentSessionID: childSessionID,
+                lastUserMessageAt: date(10)
+            )
+        ])
+
+        let rows = build(tabs: tabs, sessionIndex: index)
+
+        XCTAssertEqual(rows.map(\.tabID), [sessionlessTabID, parentTabID, childTabID, grandchildTabID])
+        XCTAssertEqual(rows.map(\.depth), [0, 0, 1, 2])
+    }
+
+    func testSessionlessRowsPreserveFrozenSessionRestoreOrder() {
+        let pinnedSessionlessTabID = id(65)
+        let unpinnedSessionlessTabID = id(66)
+        let firstSessionTabID = id(67)
+        let secondSessionTabID = id(68)
+        let firstSessionID = id(164)
+        let secondSessionID = id(165)
+        let tabs = [
+            tab(unpinnedSessionlessTabID, sessionID: nil, lastModified: date(100)),
+            tab(secondSessionTabID, sessionID: secondSessionID),
+            tab(pinnedSessionlessTabID, sessionID: nil, isPinned: true, lastModified: date(200)),
+            tab(firstSessionTabID, sessionID: firstSessionID)
+        ]
+        let index = sessionIndex([
+            entry(firstSessionID, tabID: firstSessionTabID, lastUserMessageAt: date(10)),
+            entry(secondSessionID, tabID: secondSessionTabID, lastUserMessageAt: date(20))
+        ])
+
+        let rows = build(
+            tabs: tabs,
+            sessionIndex: index,
+            sessionListCacheReady: false,
+            frozenOrderByTabID: [firstSessionTabID: 0, secondSessionTabID: 1]
+        )
+
+        XCTAssertEqual(
+            rows.map(\.tabID),
+            [pinnedSessionlessTabID, firstSessionTabID, secondSessionTabID, unpinnedSessionlessTabID]
+        )
+    }
+
     private func build(
         tabs: [ComposeTabState],
         sessions: [UUID: AgentModeViewModel.TabSession] = [:],
-        sessionIndex: [UUID: AgentSessionIndexEntry]
+        sessionIndex: [UUID: AgentSessionIndexEntry],
+        sessionListCacheReady: Bool = true,
+        frozenOrderByTabID: [UUID: Int] = [:]
     ) -> [AgentModeViewModel.SidebarSession] {
         AgentModeSidebarSessionBuilder(
             allTabs: tabs,
-            linkedTabs: tabs,
+            rowTabs: tabs,
             sessions: sessions,
             authoritativeSessionIDByTabID: Dictionary(
                 uniqueKeysWithValues: tabs.compactMap { tab in
@@ -467,8 +561,8 @@ final class AgentModeSidebarSessionBuilderTests: XCTestCase {
             ),
             sessionIndex: sessionIndex,
             sessionListSortDates: [:],
-            sessionListCacheReady: true,
-            sidebarRestoreFrozenOrderByTabID: [:],
+            sessionListCacheReady: sessionListCacheReady,
+            sidebarRestoreFrozenOrderByTabID: frozenOrderByTabID,
             mcpControlledTabIDs: []
         ).build()
     }
@@ -490,13 +584,14 @@ final class AgentModeSidebarSessionBuilderTests: XCTestCase {
 
     private func tab(
         _ tabID: UUID,
-        sessionID: UUID,
+        sessionID: UUID?,
+        name: String? = nil,
         isPinned: Bool = false,
         lastModified: Date? = nil
     ) -> ComposeTabState {
         ComposeTabState(
             id: tabID,
-            name: "Tab \(tabID.uuidString.suffix(4))",
+            name: name ?? "Tab \(tabID.uuidString.suffix(4))",
             lastModified: lastModified ?? date(1),
             isPinned: isPinned,
             activeAgentSessionID: sessionID

--- a/Tests/RepoPromptTests/AgentMode/AgentModeViewModelInactiveRefreshTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeViewModelInactiveRefreshTests.swift
@@ -802,14 +802,16 @@ final class AgentModeViewModelInactiveRefreshTests: XCTestCase {
             stashedTabs: stashedTabs,
             currentTabID: composeTabs.first?.id,
             sidebarSnapshot: snapshot,
-            archivedSessionsExpanded: true
+            archivedSessionsExpanded: true,
+            showComposeTabsWithoutAgentSessions: false
         )
         _ = viewModel.sidebarListProjection(
             composeTabs: composeTabs,
             stashedTabs: stashedTabs,
             currentTabID: composeTabs.first?.id,
             sidebarSnapshot: snapshot,
-            archivedSessionsExpanded: true
+            archivedSessionsExpanded: true,
+            showComposeTabsWithoutAgentSessions: false
         )
         XCTAssertEqual(initialProjection.sortedArchivedSessionTabsForRows.map(\.id), [stashedTabs[1].id, stashedTabs[0].id])
         XCTAssertEqual(viewModel.test_sidebarSessionRowsBuildCount, 1)
@@ -829,7 +831,8 @@ final class AgentModeViewModelInactiveRefreshTests: XCTestCase {
             stashedTabs: unrelatedStashedChurn,
             currentTabID: composeTabs.first?.id,
             sidebarSnapshot: snapshot,
-            archivedSessionsExpanded: true
+            archivedSessionsExpanded: true,
+            showComposeTabsWithoutAgentSessions: false
         )
         _ = viewModel.sidebarSessions(for: unrelatedComposeChurn)
         XCTAssertEqual(viewModel.test_sidebarSessionRowsBuildCount, 1)
@@ -842,7 +845,8 @@ final class AgentModeViewModelInactiveRefreshTests: XCTestCase {
             stashedTabs: rawRenamedStashedTabs,
             currentTabID: composeTabs.first?.id,
             sidebarSnapshot: snapshot,
-            archivedSessionsExpanded: true
+            archivedSessionsExpanded: true,
+            showComposeTabsWithoutAgentSessions: false
         )
         XCTAssertEqual(
             rawRenamedProjection.sortedArchivedSessionTabsForRows.first(where: { $0.id == stashedTabs[0].id })?.tab.name,
@@ -858,7 +862,8 @@ final class AgentModeViewModelInactiveRefreshTests: XCTestCase {
             stashedTabs: pinnedStashedTabs,
             currentTabID: composeTabs.first?.id,
             sidebarSnapshot: snapshot,
-            archivedSessionsExpanded: true
+            archivedSessionsExpanded: true,
+            showComposeTabsWithoutAgentSessions: false
         )
         XCTAssertEqual(pinnedProjection.sortedArchivedSessionTabsForRows.first?.id, stashedTabs[0].id)
         XCTAssertEqual(viewModel.test_sidebarSessionRowsBuildCount, 1)
@@ -871,7 +876,8 @@ final class AgentModeViewModelInactiveRefreshTests: XCTestCase {
             stashedTabs: restashedTabs,
             currentTabID: composeTabs.first?.id,
             sidebarSnapshot: snapshot,
-            archivedSessionsExpanded: true
+            archivedSessionsExpanded: true,
+            showComposeTabsWithoutAgentSessions: false
         )
         XCTAssertEqual(restashedProjection.sortedArchivedSessionTabsForRows.first?.id, stashedTabs[0].id)
         XCTAssertEqual(viewModel.test_sidebarSessionRowsBuildCount, 1)
@@ -884,7 +890,8 @@ final class AgentModeViewModelInactiveRefreshTests: XCTestCase {
             stashedTabs: restashedTabs,
             currentTabID: composeTabs.first?.id,
             sidebarSnapshot: snapshot,
-            archivedSessionsExpanded: true
+            archivedSessionsExpanded: true,
+            showComposeTabsWithoutAgentSessions: false
         )
         XCTAssertEqual(
             renamedProjection.filteredSessions.first(where: { $0.tabID == renamedTabs[0].id })?.title,
@@ -899,10 +906,185 @@ final class AgentModeViewModelInactiveRefreshTests: XCTestCase {
             stashedTabs: restashedTabs,
             currentTabID: composeTabs.first?.id,
             sidebarSnapshot: viewModel.ui.sessionSidebar.snapshot,
-            archivedSessionsExpanded: true
+            archivedSessionsExpanded: true,
+            showComposeTabsWithoutAgentSessions: false
         )
         XCTAssertEqual(viewModel.test_sidebarSessionRowsBuildCount, 3)
         XCTAssertEqual(viewModel.test_sidebarListProjectionBuildCount, 6)
+    }
+
+    func testAgentChatsProjectionShowsSessionlessTabsWithoutThrashingSessionRows() {
+        let viewModel = makeViewModel()
+        let linkedTabID = UUID()
+        let linkedSessionID = UUID()
+        let sessionlessTabID = UUID()
+        let linkedTab = ComposeTabState(
+            id: linkedTabID,
+            name: "Linked",
+            lastModified: Date(timeIntervalSince1970: 100),
+            activeAgentSessionID: linkedSessionID
+        )
+        let sessionlessTab = ComposeTabState(
+            id: sessionlessTabID,
+            name: "MCP Audit",
+            lastModified: Date(timeIntervalSince1970: 200)
+        )
+        let composeTabs = [linkedTab, sessionlessTab]
+        let stashedSessionlessTab = StashedTab(tab: sessionlessTab)
+        var workspace = makeWorkspace(
+            name: "Sessionless Agent Chats",
+            tabs: composeTabs,
+            activeTabID: sessionlessTabID
+        )
+        workspace.stashedTabs = [stashedSessionlessTab]
+        let manager = makeWorkspaceManager(workspaces: [workspace])
+        manager.activeWorkspace = workspace
+        viewModel.workspaceManager = manager
+        let snapshot = viewModel.ui.sessionSidebar.snapshot
+
+        let hiddenProjection = viewModel.sidebarListProjection(
+            composeTabs: composeTabs,
+            stashedTabs: workspace.stashedTabs,
+            currentTabID: sessionlessTabID,
+            sidebarSnapshot: snapshot,
+            archivedSessionsExpanded: true,
+            showComposeTabsWithoutAgentSessions: false
+        )
+        XCTAssertEqual(hiddenProjection.filteredSessions.map(\.tabID), [linkedTabID])
+
+        let visibleProjection = viewModel.sidebarListProjection(
+            composeTabs: composeTabs,
+            stashedTabs: workspace.stashedTabs,
+            currentTabID: sessionlessTabID,
+            sidebarSnapshot: snapshot,
+            archivedSessionsExpanded: true,
+            showComposeTabsWithoutAgentSessions: true
+        )
+        XCTAssertEqual(Set(visibleProjection.filteredSessions.map(\.tabID)), Set([linkedTabID, sessionlessTabID]))
+        XCTAssertNil(visibleProjection.filteredSessions.first(where: { $0.tabID == sessionlessTabID })?.sessionID)
+        XCTAssertTrue(visibleProjection.archivedSessionTabsForHeader.isEmpty)
+        XCTAssertTrue(visibleProjection.sortedArchivedSessionTabsForRows.isEmpty)
+        XCTAssertEqual(viewModel.test_sidebarSessionRowsBuildCount, 2)
+        XCTAssertEqual(viewModel.test_sidebarListProjectionBuildCount, 2)
+
+        XCTAssertEqual(viewModel.sidebarSessions(for: composeTabs).map(\.tabID), [linkedTabID])
+        XCTAssertEqual(
+            Set(viewModel.agentChatsSidebarSessions(for: composeTabs).map(\.tabID)),
+            Set([linkedTabID, sessionlessTabID])
+        )
+        XCTAssertEqual(viewModel.test_sidebarSessionRowsBuildCount, 2)
+    }
+
+    func testRenameSessionlessComposeTabDoesNotBindOrDirtyAgentSession() {
+        let viewModel = makeViewModel()
+        let tabID = UUID()
+        let workspace = makeWorkspace(
+            name: "Sessionless rename",
+            tabs: [ComposeTabState(id: tabID, name: "Before")],
+            activeTabID: tabID
+        )
+        let fixture = makeWorkspaceFixture(workspaces: [workspace])
+        fixture.manager.activeWorkspace = workspace
+        viewModel.test_setSidebarAutoArchiveDependencies(
+            promptManager: fixture.prompt,
+            workspaceManager: fixture.manager
+        )
+        let liveSession = AgentModeViewModel.TabSession(tabID: tabID)
+        viewModel.test_installLiveSession(liveSession)
+        let bindingIdentityBefore = liveSession.persistentSessionBindingIdentity
+        let bindingGenerationBefore = liveSession.bindingTransitionGeneration
+        let saveGenerationBefore = liveSession.saveRequestGeneration
+
+        viewModel.renameSession(tabID: tabID, to: "After")
+
+        XCTAssertEqual(fixture.manager.activeWorkspace?.composeTabs.first?.name, "After")
+        XCTAssertNil(liveSession.activeAgentSessionID)
+        XCTAssertEqual(liveSession.persistentSessionBindingIdentity, bindingIdentityBefore)
+        XCTAssertEqual(liveSession.bindingTransitionGeneration, bindingGenerationBefore)
+        XCTAssertEqual(liveSession.saveRequestGeneration, saveGenerationBefore)
+        XCTAssertFalse(liveSession.isDirty)
+        XCTAssertTrue(viewModel.test_ownerValidatedSessionIndex.isEmpty)
+    }
+
+    func testSessionlessSidebarRowPromotesWithStableIdentity() throws {
+        let viewModel = makeViewModel()
+        let tabID = UUID()
+        let workspace = makeWorkspace(
+            name: "Sessionless promotion",
+            tabs: [ComposeTabState(id: tabID, name: "Promote me")],
+            activeTabID: tabID
+        )
+        let manager = makeWorkspaceManager(workspaces: [workspace])
+        manager.activeWorkspace = workspace
+        viewModel.workspaceManager = manager
+        let snapshot = viewModel.ui.sessionSidebar.snapshot
+        let initialProjection = viewModel.sidebarListProjection(
+            composeTabs: workspace.composeTabs,
+            stashedTabs: [],
+            currentTabID: tabID,
+            sidebarSnapshot: snapshot,
+            archivedSessionsExpanded: false,
+            showComposeTabsWithoutAgentSessions: true
+        )
+        let initialRow = try XCTUnwrap(initialProjection.filteredSessions.first(where: { $0.tabID == tabID }))
+        XCTAssertNil(initialRow.sessionID)
+        XCTAssertTrue(viewModel.sidebarSessions(for: workspace.composeTabs).isEmpty)
+
+        let sessionID = UUID()
+        let liveSession = AgentModeViewModel.TabSession(tabID: tabID)
+        viewModel.test_installLiveSession(liveSession)
+        _ = viewModel.test_installPersistentSessionBinding(
+            sessionID: sessionID,
+            on: liveSession,
+            updateWorkspaceMetadata: true
+        )
+        let promotedTabs = try XCTUnwrap(manager.activeWorkspace?.composeTabs)
+        let promotedProjection = viewModel.sidebarListProjection(
+            composeTabs: promotedTabs,
+            stashedTabs: [],
+            currentTabID: tabID,
+            sidebarSnapshot: snapshot,
+            archivedSessionsExpanded: false,
+            showComposeTabsWithoutAgentSessions: true
+        )
+        let promotedRows = promotedProjection.filteredSessions.filter { $0.tabID == tabID }
+        let promotedRow = try XCTUnwrap(promotedRows.first)
+
+        XCTAssertEqual(promotedRows.count, 1)
+        XCTAssertEqual(promotedRow.id, initialRow.id)
+        XCTAssertEqual(promotedRow.tabID, initialRow.tabID)
+        XCTAssertEqual(promotedRow.sessionID, sessionID)
+        XCTAssertEqual(viewModel.sidebarSessions(for: promotedTabs).map(\.tabID), [tabID])
+        XCTAssertTrue(viewModel.hasAgentSession(for: tabID))
+    }
+
+    func testSessionlessActiveTabDoesNotExposeUnboundWorktreeOrMergeIndicators() {
+        let viewModel = makeViewModel()
+        let tabID = UUID()
+        let workspace = makeWorkspace(
+            name: "Sessionless worktree indicators",
+            tabs: [ComposeTabState(id: tabID)],
+            activeTabID: tabID
+        )
+        let manager = makeWorkspaceManager(workspaces: [workspace])
+        manager.activeWorkspace = workspace
+        viewModel.workspaceManager = manager
+        let liveSession = AgentModeViewModel.TabSession(tabID: tabID)
+        liveSession.worktreeBindings = [makeWorktreeBinding()]
+        liveSession.worktreeMergeOperations = [makeWorktreeMergeOperation()]
+        viewModel.test_installLiveSession(liveSession)
+
+        XCTAssertTrue(viewModel.worktreeIndicators(forTabID: tabID).isEmpty)
+        XCTAssertTrue(viewModel.worktreeMergeAttentionsByLogicalRootPath(forTabID: tabID).isEmpty)
+
+        _ = viewModel.test_installPersistentSessionBinding(
+            sessionID: UUID(),
+            on: liveSession,
+            updateWorkspaceMetadata: true
+        )
+
+        XCTAssertEqual(viewModel.worktreeIndicators(forTabID: tabID).count, 1)
+        XCTAssertFalse(viewModel.worktreeMergeAttentionsByLogicalRootPath(forTabID: tabID).isEmpty)
     }
 
     func testBatchWorktreeBindingStatesBuildsAuthoritySnapshotOnceAtScale() {
@@ -1091,6 +1273,46 @@ final class AgentModeViewModelInactiveRefreshTests: XCTestCase {
         XCTAssertTrue(viewModel.test_ownerValidatedSessionListCacheReady)
         let requestCountAfterStaleHandler = await harness.currentRequestCount()
         XCTAssertEqual(requestCountAfterStaleHandler, requestCountBeforeStaleHandler)
+    }
+
+    func testSidebarAutoArchiveIgnoresDisplayedSessionlessComposeTabs() async {
+        let tabs = (0 ... AgentModeViewModel.sessionSidebarPageSize + 10).map { offset in
+            ComposeTabState(
+                id: UUID(),
+                name: "Sessionless \(offset)",
+                lastModified: Date(timeIntervalSince1970: TimeInterval(offset + 1))
+            )
+        }
+        let activeTabID = tabs.last?.id
+        let workspace = makeWorkspace(
+            name: "Displayed sessionless tabs",
+            tabs: tabs,
+            activeTabID: activeTabID
+        )
+        let fixture = makeWorkspaceFixture(workspaces: [workspace])
+        fixture.manager.activeWorkspace = workspace
+        fixture.prompt.loadComposeTabsFromWorkspace(workspace)
+        let viewModel = makeViewModel()
+        viewModel.test_setSidebarAutoArchiveDependencies(
+            promptManager: fixture.prompt,
+            workspaceManager: fixture.manager
+        )
+        viewModel.test_setSidebarAutoArchiveActive(true)
+        let owner = viewModel.test_receiveWorkspaceSwitchNotification(workspace)
+        viewModel.test_installSessionIndexSnapshot(
+            [:],
+            owner: owner,
+            latestOwner: owner,
+            activeWorkspace: workspace
+        )
+
+        let displayedRows = viewModel.agentChatsSidebarSessions(for: tabs)
+        let archivedTabIDs = await viewModel.performSidebarAutoArchiveIfNeeded(reason: .explicitTest)
+
+        XCTAssertEqual(displayedRows.count, tabs.count)
+        XCTAssertTrue(archivedTabIDs.isEmpty)
+        XCTAssertEqual(fixture.prompt.currentComposeTabs.count, tabs.count)
+        XCTAssertTrue(fixture.prompt.currentStashedTabs.isEmpty)
     }
 
     func testAutoArchiveSkipsMutationAfterSameWorkspaceReactivation() async {
@@ -1793,6 +2015,58 @@ final class AgentModeViewModelInactiveRefreshTests: XCTestCase {
         AgentSessionSidebarBuildBatch(
             entriesBySessionID: Dictionary(uniqueKeysWithValues: entries.map { ($0.id, $0) }),
             preferredSessionIDByTabID: Dictionary(uniqueKeysWithValues: entries.map { ($0.tabID, $0.id) })
+        )
+    }
+
+    private func makeWorktreeBinding() -> AgentSessionWorktreeBinding {
+        AgentSessionWorktreeBinding(
+            id: "sessionless-binding",
+            repositoryID: "sessionless-repository",
+            repoKey: "sessionless-repo",
+            logicalRootPath: "/tmp/sessionless-repo",
+            logicalRootName: "sessionless-repo",
+            worktreeID: "sessionless-worktree",
+            worktreeRootPath: "/tmp/sessionless-worktree",
+            worktreeName: "sessionless-worktree",
+            branch: "feature/sessionless",
+            head: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            boundAt: Date(timeIntervalSinceReferenceDate: 1),
+            source: "test"
+        )
+    }
+
+    private func makeWorktreeMergeOperation() -> AgentSessionWorktreeMergeOperation {
+        let source = GitWorktreeMergeEndpoint(
+            worktreeID: "sessionless-source",
+            repositoryID: "sessionless-repository",
+            repoKey: "sessionless-repo",
+            path: "/tmp/sessionless-worktree",
+            name: "feature",
+            branch: "feature/sessionless",
+            head: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            isMain: false
+        )
+        let target = GitWorktreeMergeEndpoint(
+            worktreeID: "sessionless-target",
+            repositoryID: "sessionless-repository",
+            repoKey: "sessionless-repo",
+            path: "/tmp/sessionless-target",
+            name: "main",
+            branch: "main",
+            head: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            isMain: true
+        )
+        return AgentSessionWorktreeMergeOperation(
+            id: "sessionless-merge",
+            source: source,
+            target: target,
+            mergeBase: "cccccccccccccccccccccccccccccccccccccccc",
+            sourceHead: source.head,
+            targetHeadBefore: target.head,
+            status: .conflicted,
+            conflictFiles: ["Conflict.swift"],
+            createdAt: Date(timeIntervalSinceReferenceDate: 1),
+            updatedAt: Date(timeIntervalSinceReferenceDate: 2)
         )
     }
 

--- a/Tests/RepoPromptTests/MCP/AppSettingsMCPServiceAgentModeSettingsTests.swift
+++ b/Tests/RepoPromptTests/MCP/AppSettingsMCPServiceAgentModeSettingsTests.swift
@@ -60,6 +60,54 @@ final class AppSettingsMCPServiceAgentModeSettingsTests: XCTestCase {
         XCTAssertFalse(store.codexReasoningSummariesEnabled())
     }
 
+    func testAgentChatsPresentationPreferenceRemainsOutsideAppSettingsCatalog() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AppSettingsMCPServiceAgentModeSettingsTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let suiteName = "AppSettingsMCPServiceAgentModeSettingsTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let store = GlobalSettingsStore(
+            defaults: defaults,
+            fileStore: GlobalSettingsFileStore(fileURL: root.appendingPathComponent("globalSettings.json"))
+        )
+        let service = AppSettingsMCPService(store: store)
+        let listed = try await service.handleForTesting([
+            "op": .string("list"),
+            "group": .string("agent_mode"),
+            "detailed": .bool(true)
+        ])
+        let settings = try XCTUnwrap(listed.objectValue?["settings"]?.arrayValue)
+        let keys = settings.compactMap { $0.objectValue?["key"]?.stringValue }
+        let candidateKey = "agent_mode.show_compose_tabs_without_agent_sessions"
+        XCTAssertFalse(keys.contains(candidateKey))
+
+        for arguments: [String: Value] in [
+            [
+                "op": .string("get"),
+                "key": .string(candidateKey)
+            ],
+            [
+                "op": .string("set"),
+                "key": .string(candidateKey),
+                "value": .bool(true)
+            ]
+        ] {
+            do {
+                _ = try await service.handleForTesting(arguments)
+                XCTFail("Expected \(candidateKey) to remain outside the app_settings catalog")
+            } catch {
+                XCTAssertTrue(
+                    String(describing: error).contains("Unknown or unavailable app setting key '\(candidateKey)'."),
+                    String(describing: error)
+                )
+            }
+        }
+    }
+
     func testHandoffInstructionsRemainOutsideAppSettingsCatalog() async throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("AppSettingsMCPServiceAgentModeSettingsTests-\(UUID().uuidString)", isDirectory: true)


### PR DESCRIPTION
MCP tools can create chat contexts containing file selections, prompts, and Context Builder work, but Agent Chats hides them until an agent runs. This makes MCP-created work difficult to revisit from the app and iterate on inside Compose.

This patch adds a default-off setting that exposes those chats in Agent Chats while keeping Agent-session behavior unchanged.

## Summary

- Add **Show chats created by MCP tools** under Settings -> Agent Mode -> Overview
- List open chats before an Agent session exists, including chats created through MCP
- Support selection, pinning, renaming, and deletion without creating or mutating Agent sessions
- Keep Agent-only status, stash, worktree metadata, archived sessions, and auto-archive behavior session-backed
- Preserve row identity when an Agent session later starts

## Implementation Notes

- Agent Chats uses a separate presentation projection and cache, leaving session-only sidebar consumers unchanged
- Session-less rows ignore unbound live-session metadata and expose only chat-owned state
- The preference is app-wide UI state and remains outside the `app_settings` catalog

## Review Approach

- Standard `rp-review` workflows were conducted using Fable 5 High (1x) and Sol Pro (2x)
- One integration review identified rename and unbound worktree-metadata leaks; both were fixed with regression coverage, and Sol Pro's followup review concluded Ship

## Validation

Passed locally:

- Focused sidebar builder, projection, action-boundary, and MCP settings tests
- `make dev-lint`
- `make dev-swift-build PRODUCT=RepoPrompt`
- `make guardrails`

I confirmed in the live CE debug app: default-off behavior, immediate toggle updates, MCP-created blank and fork chats with zero synthesized Agent sessions, and the expected session-less row actions.

The full root suite was also run; remaining failures were unrelated existing failures in Agent-run, Git-policy, transport, and workspace-materialization tests.

## Screenshots

<img width="1165" height="641" alt="Screenshot 2026-08-03 at 10 59 21 PM" src="https://github.com/user-attachments/assets/f442ce14-56d2-4bac-adfa-2a2e13411c5c" />