### PR TITLE
Use scoped locking for ACP async state transitions

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentACPModelRegistry.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Models/ModelSelection/AgentACPModelRegistry.swift
@@ -52,37 +52,39 @@ final class AgentACPModelRegistry {
     }
 
     func warmStandardStoreIfNeeded() async {
+        let plan: StandardStoreWarmPlan? = lock.withLock {
+            guard !didWarmStandardStore else { return nil }
+
+            let task: Task<[ACPProviderID: ACPDiscoveredSessionModels], Never>
+            if let existing = standardStoreWarmTask {
+                task = existing
+            } else {
+                let newTask = Task.detached(priority: .utility) {
+                    ACPDynamicModelStore.loadAll()
+                }
+                standardStoreWarmTask = newTask
+                task = newTask
+            }
+            return StandardStoreWarmPlan(
+                task: task,
+                generation: standardStoreWarmGeneration
+            )
+        }
+
+        guard let plan else { return }
+        let loadedSnapshots = await plan.task.value
+
+        lock.withLock {
+            guard plan.generation == standardStoreWarmGeneration else { return }
+            persistedSnapshotsByProvider = loadedSnapshots
+            didWarmStandardStore = true
+            standardStoreWarmTask = nil
+        }
+    }
+
+    private struct StandardStoreWarmPlan {
         let task: Task<[ACPProviderID: ACPDiscoveredSessionModels], Never>
         let generation: UInt64
-
-        lock.lock()
-        if didWarmStandardStore {
-            lock.unlock()
-            return
-        }
-        generation = standardStoreWarmGeneration
-        if let existing = standardStoreWarmTask {
-            task = existing
-        } else {
-            let newTask = Task.detached(priority: .utility) {
-                ACPDynamicModelStore.loadAll()
-            }
-            standardStoreWarmTask = newTask
-            task = newTask
-        }
-        lock.unlock()
-
-        let loadedSnapshots = await task.value
-
-        lock.lock()
-        guard generation == standardStoreWarmGeneration else {
-            lock.unlock()
-            return
-        }
-        persistedSnapshotsByProvider = loadedSnapshots
-        didWarmStandardStore = true
-        standardStoreWarmTask = nil
-        lock.unlock()
     }
 
     func resolvedSnapshotAfterWarmingStandardStore(

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/ACPHeadlessProviderLifecycle.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/ACPHeadlessProviderLifecycle.swift
@@ -12,6 +12,12 @@ final class ACPHeadlessProviderLifecycle: @unchecked Sendable {
         let cancelAndShutdown: @Sendable () async -> Void
     }
 
+    private enum DisposalTransition {
+        case idle
+        case wait
+        case teardown(task: Task<Void, Never>?, handles: [ControllerHandle])
+    }
+
     private let lock = NSLock()
     private var nextGeneration: UInt64 = 0
     private var activeStreamGeneration: UInt64?
@@ -19,22 +25,33 @@ final class ACPHeadlessProviderLifecycle: @unchecked Sendable {
     private var controllerByGeneration: [UInt64: ControllerHandle] = [:]
     private var disposeInProgress = false
     private var disposeWaiters: [CheckedContinuation<Void, Never>] = []
+    #if DEBUG
+        private let testDidRegisterDisposalWaiter: (@Sendable () -> Void)?
+
+        init(testDidRegisterDisposalWaiter: (@Sendable () -> Void)? = nil) {
+            self.testDidRegisterDisposalWaiter = testDidRegisterDisposalWaiter
+        }
+    #else
+        init() {}
+    #endif
 
     func waitForDisposalIfNeeded() async {
-        lock.lock()
-        let shouldWait = disposeInProgress
-        lock.unlock()
-
+        let shouldWait = lock.withLock { disposeInProgress }
         guard shouldWait else { return }
 
         await withCheckedContinuation { continuation in
-            lock.lock()
-            if disposeInProgress {
+            let shouldResumeImmediately = lock.withLock {
+                guard disposeInProgress else { return true }
                 disposeWaiters.append(continuation)
-                lock.unlock()
-            } else {
-                lock.unlock()
+                return false
+            }
+
+            if shouldResumeImmediately {
                 continuation.resume()
+            } else {
+                #if DEBUG
+                    testDidRegisterDisposalWaiter?()
+                #endif
             }
         }
     }
@@ -89,42 +106,48 @@ final class ACPHeadlessProviderLifecycle: @unchecked Sendable {
     }
 
     func dispose() async {
-        lock.lock()
-        if disposeInProgress {
-            lock.unlock()
-            await waitForDisposalIfNeeded()
-            return
-        }
+        let transition = lock.withLock { () -> DisposalTransition in
+            if disposeInProgress {
+                return .wait
+            }
 
-        let task = streamTask
-        let handles = Array(controllerByGeneration.values)
-        guard task != nil || !handles.isEmpty else {
+            let task = streamTask
+            let handles = Array(controllerByGeneration.values)
+            guard task != nil || !handles.isEmpty else {
+                streamTask = nil
+                activeStreamGeneration = nil
+                controllerByGeneration.removeAll()
+                return .idle
+            }
+
+            disposeInProgress = true
             streamTask = nil
             activeStreamGeneration = nil
             controllerByGeneration.removeAll()
-            lock.unlock()
+            return .teardown(task: task, handles: handles)
+        }
+
+        switch transition {
+        case .idle:
             return
-        }
+        case .wait:
+            await waitForDisposalIfNeeded()
+        case let .teardown(task, handles):
+            task?.cancel()
+            for handle in handles {
+                await handle.cancelAndShutdown()
+            }
 
-        disposeInProgress = true
-        streamTask = nil
-        activeStreamGeneration = nil
-        controllerByGeneration.removeAll()
-        lock.unlock()
+            let waiters = lock.withLock {
+                disposeInProgress = false
+                let waiters = disposeWaiters
+                disposeWaiters.removeAll()
+                return waiters
+            }
 
-        task?.cancel()
-        for handle in handles {
-            await handle.cancelAndShutdown()
-        }
-
-        lock.lock()
-        disposeInProgress = false
-        let waiters = disposeWaiters
-        disposeWaiters.removeAll()
-        lock.unlock()
-
-        for waiter in waiters {
-            waiter.resume()
+            for waiter in waiters {
+                waiter.resume()
+            }
         }
     }
 }

--- a/Tests/RepoPromptTests/AgentMode/ACPHeadlessProviderLifecycleTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/ACPHeadlessProviderLifecycleTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+@testable import RepoPromptApp
+import XCTest
+
+final class ACPHeadlessProviderLifecycleTests: XCTestCase {
+    func testDisposeKeepsLifecycleClosedUntilClaimedControllerTeardownCompletes() async throws {
+        let (waiterRegistrations, waiterRegistrationContinuation) = AsyncStream<Int>.makeStream(
+            bufferingPolicy: .unbounded
+        )
+        var waiterRegistrationIterator = waiterRegistrations.makeAsyncIterator()
+        let lifecycle = ACPHeadlessProviderLifecycle {
+            waiterRegistrationContinuation.yield(1)
+        }
+
+        let (teardownStarts, teardownStartContinuation) = AsyncStream<Int>.makeStream(
+            bufferingPolicy: .unbounded
+        )
+        var teardownStartIterator = teardownStarts.makeAsyncIterator()
+        let (teardownInvocations, teardownInvocationContinuation) = AsyncStream<Void>.makeStream(
+            bufferingPolicy: .unbounded
+        )
+        let teardownInvocationCountTask = Task {
+            var count = 0
+            for await _ in teardownInvocations {
+                count += 1
+            }
+            return count
+        }
+        let (teardownRelease, teardownReleaseContinuation) = AsyncStream<Void>.makeStream()
+
+        defer {
+            teardownReleaseContinuation.finish()
+            teardownInvocationContinuation.finish()
+            teardownStartContinuation.finish()
+            waiterRegistrationContinuation.finish()
+        }
+
+        let initialGeneration = try XCTUnwrap(lifecycle.startStreamTask { _ in Task {} })
+        let controllerID = UUID()
+        XCTAssertTrue(lifecycle.setActiveController(
+            ACPHeadlessProviderLifecycle.ControllerHandle(id: controllerID) {
+                teardownInvocationContinuation.yield(())
+                teardownStartContinuation.yield(1)
+                for await _ in teardownRelease {}
+            },
+            generation: initialGeneration
+        ))
+
+        let disposingTask = Task {
+            await lifecycle.dispose()
+        }
+        let teardownStarted = await teardownStartIterator.next()
+        XCTAssertEqual(teardownStarted, 1)
+
+        let disposeJoiner = Task {
+            await lifecycle.dispose()
+        }
+        let disposalWaiter = Task {
+            await lifecycle.waitForDisposalIfNeeded()
+        }
+        let firstWaiterRegistration = await waiterRegistrationIterator.next()
+        let secondWaiterRegistration = await waiterRegistrationIterator.next()
+        XCTAssertEqual(firstWaiterRegistration, 1)
+        XCTAssertEqual(secondWaiterRegistration, 1)
+
+        var didCreateLateTask = false
+        let lateGeneration = lifecycle.startStreamTask { _ in
+            didCreateLateTask = true
+            return Task {}
+        }
+        XCTAssertNil(lateGeneration)
+        XCTAssertFalse(didCreateLateTask)
+
+        teardownReleaseContinuation.finish()
+        await disposingTask.value
+        await disposeJoiner.value
+        await disposalWaiter.value
+
+        teardownInvocationContinuation.finish()
+        let teardownInvocationCount = await teardownInvocationCountTask.value
+        XCTAssertEqual(teardownInvocationCount, 1)
+
+        let reopenedGeneration = try XCTUnwrap(lifecycle.startStreamTask { _ in Task {} })
+        XCTAssertGreaterThan(reopenedGeneration, initialGeneration)
+        lifecycle.clearStreamTask(generation: reopenedGeneration)
+        await lifecycle.dispose()
+    }
+}


### PR DESCRIPTION
## Summary

- replace the async-context `NSLock.lock()` / `unlock()` pairs in ACP model warmup and headless provider disposal with scoped `NSLock.withLock` state transitions
- keep every await, task cancellation, controller shutdown, and continuation resume outside the critical section
- preserve the lifecycle idle reset and make stale registry warmup commits strict no-ops
- add a deterministic gated lifecycle regression test covering a disposer, concurrent dispose joiner, explicit disposal waiter, exactly-once teardown, start rejection during disposal, and later reopening

## Concurrency invariants

- no lock is held across `await`, cancellation, controller shutdown, or continuation resume
- `waitForDisposalIfNeeded()` consumes its immediate-resume decision inside `withCheckedContinuation`, so no checked continuation escapes unresumed
- idle disposal clears `streamTask`, `activeStreamGeneration`, and `controllerByGeneration`
- a registry generation mismatch commits no state
- no actors, `AsyncMutex`, new locks, unsafe isolation escape hatches, sleeps, timeouts, retries, or detached test tasks were added

## Focused validation

Passed:

- `RepoPromptTests.ACPHeadlessProviderLifecycleTests/testDisposeKeepsLifecycleClosedUntilClaimedControllerTeardownCompletes` — conductor `1355c64c-9172-441d-a404-daa4e14f293b`
- `RepoPromptTests.ContextBuilderModelStartupSelectionTests/testPersistedDynamicSelectionSurvivesStandardCatalogWarmup` — conductor `ae895f11-d39a-4c42-9202-fd65723d70da`
- `RepoPromptTests.ACPAgentSessionControllerModeConfigTests/testHeadlessProvidersApplyModelBeforeMode` — conductor `4ec04976-b71c-4b1c-b112-b5815897eee5`
- `make dev-swift-build PRODUCT=RepoPrompt` — conductor `21f5b99a-eda0-454c-b07b-e29e69f2d9b7`; the full log explicitly recompiles both changed source files and contains zero exact async `lock` / `unlock` diagnostics for them
- `make dev-lint` — conductor `0c028763-f8c0-4098-b460-640367b8368c`
- `make guardrails`
- mandatory push preflight: clean `origin/main..HEAD` range, guardrails passed, no staged or outgoing secret findings

## PR-ready status

The path-selected PR-ready lane was run and is **not reported as passed**:

- Swift lint passed — conductor `cc1a57cf-5d7b-4204-9262-4286eb15c227`
- root tests ran 4,051 tests and failed in one unrelated workspace test — conductor `90a42411-f829-45e2-a542-e09ae51d2d63`
  - `WorkspaceSavePreparationTests/testCancelledWorkingCommitAdoptsAuthorityBaselineForNextSave`
  - timed out waiting for runtime workspace creation
- because the PR-ready script stops at the failed root-test lane, its selected RepoPrompt product-build lane was skipped; the exact product build above remains the build evidence for this change

An earlier full-suite run (`b3b7ab27-1bfa-406c-8fbc-e7387e0d19be`) failed three assertions in the unrelated `CodemapBindingEngineWarmManifestTests/testConcurrentExactDuplicateCompletionPublishesOnceAndReleasesDuplicateLease`. That CodeMap failure did not recur in the PR-ready run. The ACP lifecycle regression test passed in both full-suite runs.
