### PR TITLE
Remove the 500-tab background Agent limit

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -6465,10 +6465,9 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         }
         guard let createdTab = await promptManager.createBackgroundComposeTab(
             strategy: .blank,
-            name: name,
-            capacityPolicy: .mcpBackgroundAgent
+            name: name
         ) else {
-            throw MCPError.invalidParams("Background agent session capacity is full. Wait for detached agents to finish, close or stash idle agent sessions, or raise agentMode.maxBackgroundAgentComposeTabs.")
+            throw MCPError.internalError("The background agent session tab could not be created.")
         }
         return createdTab.id
     }

--- a/Sources/RepoPrompt/Features/Prompt/ViewModels/PromptViewModel.swift
+++ b/Sources/RepoPrompt/Features/Prompt/ViewModels/PromptViewModel.swift
@@ -155,17 +155,8 @@ class PromptViewModel: ObservableObject {
     private let maxComposeTabs = PromptViewModel.defaultComposeTabSoftLimit
     private var isDirtyStateUpdateScheduled = false
 
-    enum ComposeTabCapacityPolicy: Equatable {
-        case uiInteractive
-        case mcpBackgroundAgent
-    }
-
     typealias ComposeTabAutoStashEligibilityProvider = @MainActor (_ tabID: UUID) -> Bool
     var composeTabAutoStashEligibilityProvider: ComposeTabAutoStashEligibilityProvider?
-
-    private var backgroundAgentComposeTabHardLimit: Int {
-        max(maxComposeTabs, settingsManager.maxBackgroundAgentComposeTabs())
-    }
 
     // MARK: - Tab Close Listeners
 
@@ -2592,18 +2583,10 @@ class PromptViewModel: ObservableObject {
     private func ensureCapacityForNewComposeTab(
         in manager: WorkspaceManagerViewModel,
         workspaceIndex index: Int,
-        policy: ComposeTabCapacityPolicy,
         excluding excludedID: UUID? = nil
     ) async -> Bool {
         let currentCount = manager.workspaces[index].composeTabs.count
-        switch policy {
-        case .uiInteractive:
-            guard currentCount >= maxComposeTabs else { return true }
-        case .mcpBackgroundAgent:
-            let hardLimit = backgroundAgentComposeTabHardLimit
-            guard currentCount >= hardLimit else { return true }
-            guard currentCount == hardLimit else { return false }
-        }
+        guard currentCount >= maxComposeTabs else { return true }
 
         let excluded = excludedID ?? manager.workspaces[index].activeComposeTabID
         return await autoStashLeastRecentlyUsedTab(excluding: excluded)
@@ -2624,7 +2607,6 @@ class PromptViewModel: ObservableObject {
         guard await ensureCapacityForNewComposeTab(
             in: manager,
             workspaceIndex: index,
-            policy: .uiInteractive,
             excluding: manager.workspaces[index].activeComposeTabID
         ) else { return }
 
@@ -2697,7 +2679,7 @@ class PromptViewModel: ObservableObject {
             return manager.composeTab(with: id)
         }
 
-        // Create a new background tab using the existing helper (handles auto-stash), then foreground it.
+        // Create a new background tab, then foreground it.
         guard let newTab = await createBackgroundComposeTab(
             strategy: creationStrategy,
             name: name
@@ -2718,21 +2700,13 @@ class PromptViewModel: ObservableObject {
     @MainActor
     func createBackgroundComposeTab(
         strategy: ComposeTabCreationStrategy = .duplicateCurrent,
-        name: String? = nil,
-        capacityPolicy: ComposeTabCapacityPolicy = .uiInteractive
+        name: String? = nil
     ) async -> ComposeTabState? {
         guard
             let manager = workspaceManager,
             let workspace = manager.activeWorkspace,
             let index = manager.workspaces.firstIndex(where: { $0.id == workspace.id })
         else { return nil }
-
-        guard await ensureCapacityForNewComposeTab(
-            in: manager,
-            workspaceIndex: index,
-            policy: capacityPolicy,
-            excluding: manager.workspaces[index].activeComposeTabID
-        ) else { return nil }
 
         flushAndSnapshotSourceTabIfNeeded(for: strategy, in: manager, workspaceIndex: index)
         guard let newTab = makeComposeTab(for: strategy, explicitName: name, workspaceIndex: index, manager: manager) else { return nil }
@@ -3321,7 +3295,6 @@ class PromptViewModel: ObservableObject {
         guard await ensureCapacityForNewComposeTab(
             in: manager,
             workspaceIndex: index,
-            policy: .uiInteractive,
             excluding: manager.workspaces[index].activeComposeTabID
         ) else { return }
 

--- a/Sources/RepoPrompt/Features/Settings/Models/GlobalSettingsDocument.swift
+++ b/Sources/RepoPrompt/Features/Settings/Models/GlobalSettingsDocument.swift
@@ -550,6 +550,8 @@ struct GlobalScalarPreferences: Codable, Equatable {
         // DEPRECATED: Auto-Expand Tool Cards was removed in 2026-04.
         // Kept temporarily for decode/rollback compatibility only; do not read from UI/runtime.
         var agentAutoExpandToolCards: Bool?
+        // DEPRECATED: The background Agent compose-tab limit was removed in 2026-08.
+        // Kept for decode/rollback compatibility and round-trip preservation only.
         var maxBackgroundAgentComposeTabs: Int?
         var showBuiltInWorkflowCleanupGuidance: Bool?
         var codexGoalSupportEnabled: Bool?

--- a/Sources/RepoPrompt/Features/Settings/Models/GlobalSettingsManager.swift
+++ b/Sources/RepoPrompt/Features/Settings/Models/GlobalSettingsManager.swift
@@ -340,8 +340,6 @@ class GlobalSettingsStore: ObservableObject {
     private var globalDefaults = GlobalDefaults(discoverAgentRaw: nil, discoverModelsByAgent: nil)
     private var scalarPreferences = GlobalScalarPreferences()
 
-    private static let defaultBackgroundAgentComposeTabHardLimit = 500
-    private static let defaultComposeTabSoftLimit = 50
     private static let defaultAppearanceModeRaw = "System"
     private static let defaultFilePathDisplayOptionRaw = "Full"
     private static let defaultSelectedFilesSortMethodRaw = "nameAscending"
@@ -1241,18 +1239,6 @@ class GlobalSettingsStore: ObservableObject {
             object: nil,
             userInfo: ["key": key]
         )
-    }
-
-    func maxBackgroundAgentComposeTabs() -> Int {
-        let configuredLimit = scalarPreferences.agentMode?.maxBackgroundAgentComposeTabs ?? Self.defaultBackgroundAgentComposeTabHardLimit
-        let rawLimit = configuredLimit > 0 ? configuredLimit : Self.defaultBackgroundAgentComposeTabHardLimit
-        return max(Self.defaultComposeTabSoftLimit, rawLimit)
-    }
-
-    func setMaxBackgroundAgentComposeTabs(_ limit: Int?, commit: Bool = true) {
-        updateAgentModeScalar(commit: commit) { settings in
-            settings.maxBackgroundAgentComposeTabs = limit
-        }
     }
 
     func showBuiltInWorkflowCleanupGuidance() -> Bool {

--- a/Sources/RepoPrompt/Features/Settings/Models/WindowSettingsManager.swift
+++ b/Sources/RepoPrompt/Features/Settings/Models/WindowSettingsManager.swift
@@ -56,7 +56,6 @@ protocol SettingsManaging {
     func effectiveAgentModelsProfile(workspaceID: UUID?) -> AgentModelsSettingsProfile
     func setAgentModelsMCPAgentRoleOverrides(_ overrides: [String: String]?, scope: AgentModelsEditingScope)
     func copyAgentModelsProfile(from source: AgentModelsEditingScope, to destination: AgentModelsEditingScope)
-    func maxBackgroundAgentComposeTabs() -> Int
     func commitWorkspace(_ workspaceID: UUID)
     func discardWindowOverrides(for workspaceID: UUID)
     func commitAllVisitedWorkspaces()
@@ -357,10 +356,6 @@ final class WindowSettingsManager: ObservableObject, SettingsManaging {
 
     func copyAgentModelsProfile(from source: AgentModelsEditingScope, to destination: AgentModelsEditingScope) {
         store.copyAgentModelsProfile(from: source, to: destination)
-    }
-
-    func maxBackgroundAgentComposeTabs() -> Int {
-        store.maxBackgroundAgentComposeTabs()
     }
 
     // MARK: - Lifecycle helpers

--- a/Tests/RepoPromptTests/ContextBuilder/ContextBuilderSelectionTransactionTests.swift
+++ b/Tests/RepoPromptTests/ContextBuilder/ContextBuilderSelectionTransactionTests.swift
@@ -186,8 +186,7 @@ final class ContextBuilderSelectionTransactionTests: XCTestCase {
         let workspaceID = try XCTUnwrap(window.workspaceManager.activeWorkspace?.id)
         let backgroundTab = await window.promptManager.createBackgroundComposeTab(
             strategy: .blank,
-            name: "Transaction \(name)",
-            capacityPolicy: .mcpBackgroundAgent
+            name: "Transaction \(name)"
         )
         let tabID = try XCTUnwrap(backgroundTab?.id)
         return Fixture(

--- a/Tests/RepoPromptTests/MCP/WorktreeAPISmokeHarnessTests.swift
+++ b/Tests/RepoPromptTests/MCP/WorktreeAPISmokeHarnessTests.swift
@@ -1079,8 +1079,7 @@ final class WorktreeAPISmokeHarnessTests: XCTestCase {
     private static func createBackgroundTab(in window: WindowState, name: String) async throws -> ComposeTabState {
         let tab = await window.promptManager.createBackgroundComposeTab(
             strategy: .blank,
-            name: name,
-            capacityPolicy: .mcpBackgroundAgent
+            name: name
         )
         return try XCTUnwrap(tab)
     }

--- a/Tests/RepoPromptTests/Prompt/BackgroundComposeTabAdmissionTests.swift
+++ b/Tests/RepoPromptTests/Prompt/BackgroundComposeTabAdmissionTests.swift
@@ -1,0 +1,82 @@
+@testable import RepoPromptApp
+import XCTest
+
+@MainActor
+final class BackgroundComposeTabAdmissionTests: XCTestCase {
+    func testBackgroundCreationCrossesLegacyLimitWithoutMutatingExistingTabs() async throws {
+        let fixture = makeFixture(initialTabCount: 499)
+        let originalWorkspace = try XCTUnwrap(fixture.manager.activeWorkspace)
+        let originalTabIDs = originalWorkspace.composeTabs.map(\.id)
+        let originalSessionIDsByTabID = Dictionary(
+            uniqueKeysWithValues: originalWorkspace.composeTabs.map { ($0.id, $0.activeAgentSessionID) }
+        )
+        let originalActiveTabID = try XCTUnwrap(originalWorkspace.activeComposeTabID)
+        let originalStashedTabs = originalWorkspace.stashedTabs
+
+        for expectedCount in 500 ... 502 {
+            let created = await fixture.prompt.createBackgroundComposeTab(
+                strategy: .blank,
+                name: "Background \(expectedCount)"
+            )
+
+            XCTAssertNotNil(created, "Background creation should reach \(expectedCount) tabs")
+            XCTAssertEqual(fixture.manager.activeWorkspace?.composeTabs.count, expectedCount)
+        }
+
+        let finalWorkspace = try XCTUnwrap(fixture.manager.activeWorkspace)
+        let existingTabs = Array(finalWorkspace.composeTabs.prefix(originalTabIDs.count))
+        XCTAssertEqual(existingTabs.map(\.id), originalTabIDs)
+        XCTAssertEqual(
+            Dictionary(uniqueKeysWithValues: existingTabs.map { ($0.id, $0.activeAgentSessionID) }),
+            originalSessionIDsByTabID
+        )
+        XCTAssertEqual(finalWorkspace.activeComposeTabID, originalActiveTabID)
+        XCTAssertEqual(finalWorkspace.stashedTabs, originalStashedTabs)
+    }
+
+    private func makeFixture(initialTabCount: Int) -> (manager: WorkspaceManagerViewModel, prompt: PromptViewModel) {
+        let fileManager = WorkspaceFilesViewModel()
+        let keyManager = KeyManager(
+            secureService: SecureKeysService(secureStorage: TestSecureStorageBackend())
+        )
+        let apiSettings = APISettingsViewModel(
+            aiQueriesService: AIQueriesService(keyManager: keyManager),
+            keyManager: keyManager,
+            loadStoredDataOnInit: false
+        )
+        let prompt = PromptViewModel(
+            fileManager: fileManager,
+            apiSettingsViewModel: apiSettings,
+            windowID: -1,
+            settingsManager: WindowSettingsManager(windowID: -1)
+        )
+        let manager = WorkspaceManagerViewModel(
+            fileManager: fileManager,
+            promptViewModel: prompt,
+            performInitialWorkspaceActivation: false
+        )
+        let tabs = (0 ..< initialTabCount).map { index in
+            ComposeTabState(
+                name: "Existing \(index)",
+                lastModified: Date(timeIntervalSince1970: TimeInterval(index)),
+                activeAgentSessionID: UUID()
+            )
+        }
+        let stashed = StashedTab(
+            tab: ComposeTabState(name: "Already stashed", activeAgentSessionID: UUID()),
+            stashedAt: Date(timeIntervalSince1970: 1)
+        )
+        let workspace = WorkspaceModel(
+            name: "Background compose admission",
+            repoPaths: [],
+            ephemeralFlag: true,
+            composeTabs: tabs,
+            activeComposeTabID: tabs.last?.id,
+            stashedTabs: [stashed]
+        )
+        manager.workspaces = [workspace]
+        manager.activeWorkspace = workspace
+        prompt.loadComposeTabsFromWorkspace(workspace)
+        return (manager, prompt)
+    }
+}


### PR DESCRIPTION
## Summary

- remove the legacy 500-tab admission limit from background compose-tab creation
- keep interactive 50-tab eviction and unstash-capacity behavior unchanged
- retain the deprecated JSON field only for decode/rollback compatibility and round-trip preservation
- add a regression test covering 499 -> 500 -> 501 -> 502 tabs without mutating existing tab IDs, agent session IDs, active selection, or stashed tabs

## Why

Background Agent creation and resume could fail at 500 compose tabs or auto-stash an unrelated tab at the boundary. Background creation should be admission-free and must not mutate unrelated tab/session state.

This applies consistently to all callers of background compose-tab creation, including Agent Mode, Oracle, MCP, routing, fork, and stress-harness paths. Performance and scale work beyond removing the artificial admission gate is intentionally deferred.

## Validation

- Fable 5 High implementation review: **APPROVED**, no blocking findings
- contribution commit and push safety preflights: passed
- lint: passed, SwiftFormat 0/1450
- `BackgroundComposeTabAdmissionTests`: passed
- `ContextBuilderSelectionTransactionTests`: passed
- `WorktreeAPISmokeHarnessTests`: passed (6 tests)
- settings JSON compatibility/round-trip tests: passed
- `RepoPrompt` product build: passed
- `git diff --check`: passed

### Full-suite note

The PR-ready full root suite ran for the conductor's one-hour limit and then timed out. Before timeout it reported unrelated failures in:

- `ContextBuilderNestedMCPFailureTests` timeout-settlement assertion
- `DomainAgentRunSessionStoreTests` timing threshold (230 ms)
- `DurableArtifactIdentityLeaseGCTests` durable publication fixture
- `MCPAskOracleWorktreeTests` worktree packaging assertions

None of those areas are changed by this PR. The affected suites reached by the full run passed, and the one affected suite not reached before timeout was rerun in isolation and passed. An earlier full run also had a separate durable-artifact flake that passed on isolated rerun.

## Follow-ups

- optional MCP-level regression asserting `agent_run` create/resume cannot return the former capacity error
- performance/scale characterization for very large background-tab counts