### PR TITLE
Trace worktree startup stall in shard 2

### DIFF
--- a/Sources/RepoPrompt/Features/Diagnostics/App/WorktreeStartupInstrumentation.swift
+++ b/Sources/RepoPrompt/Features/Diagnostics/App/WorktreeStartupInstrumentation.swift
@@ -900,6 +900,8 @@ enum WorktreeStartupInstrumentation {
         private static var storedDeltaCompatibilityEvaluations: [DeltaCompatibilityEvaluationRecord] = []
         private static var deltaCompatibilityEvaluationEvictionCount = 0
         private static var benchmarkMetricsByTag: [BenchmarkMetricTag: BenchmarkMetricSnapshot] = [:]
+        private static var eventObserversForTesting: [UUID: @Sendable (Event, UInt64) -> Void] = [:]
+        private static var eventObservationSequence: UInt64 = 0
     #endif
 
     static func record(
@@ -909,25 +911,38 @@ enum WorktreeStartupInstrumentation {
         fallback: WorkspaceRootSeedFallbackReason? = nil
     ) {
         lock.lock()
-        defer { lock.unlock() }
+        let event = Event(
+            phase: phase,
+            context: context,
+            route: route,
+            fallback: fallback
+        )
         if events.count == maximumEventCount {
             events.removeFirst()
             #if DEBUG
                 eventEvictionCount = incremented(eventEvictionCount)
             #endif
         }
-        events.append(Event(
-            phase: phase,
-            context: context,
-            route: route,
-            fallback: fallback
-        ))
+        events.append(event)
         if let route {
             routeCounts[route, default: 0] += 1
         }
         if let fallback {
             fallbackCounts[fallback, default: 0] += 1
         }
+        #if DEBUG
+            eventObservationSequence = eventObservationSequence == .max
+                ? .max
+                : eventObservationSequence + 1
+            let observationSequence = eventObservationSequence
+            let observers = Array(eventObserversForTesting.values)
+        #endif
+        lock.unlock()
+        #if DEBUG
+            for observer in observers {
+                observer(event, observationSequence)
+            }
+        #endif
     }
 
     static func recordGitCommand(
@@ -1512,6 +1527,22 @@ enum WorktreeStartupInstrumentation {
     }
 
     #if DEBUG
+        static func addEventObserverForTesting(
+            _ observer: @escaping @Sendable (Event, UInt64) -> Void
+        ) -> UUID {
+            let token = UUID()
+            lock.lock()
+            eventObserversForTesting[token] = observer
+            lock.unlock()
+            return token
+        }
+
+        static func removeEventObserverForTesting(_ token: UUID) {
+            lock.lock()
+            eventObserversForTesting.removeValue(forKey: token)
+            lock.unlock()
+        }
+
         static func resetForTesting() {
             lock.lock()
             events.removeAll(keepingCapacity: true)

--- a/Tests/RepoPromptTests/MCP/WorktreeAPISmokeHarnessTests.swift
+++ b/Tests/RepoPromptTests/MCP/WorktreeAPISmokeHarnessTests.swift
@@ -13,8 +13,8 @@ final class WorktreeAPISmokeHarnessTests: XCTestCase {
                 startupTrace.record(event, sequence: sequence)
             }
             defer {
-                startupTrace.deactivate()
                 WorktreeStartupInstrumentation.removeEventObserverForTesting(startupTraceToken)
+                startupTrace.finish()
             }
         #endif
         Self.traceSmokePhase("fixture.begin")
@@ -1259,16 +1259,29 @@ final class WorktreeAPISmokeHarnessTests: XCTestCase {
 
 #if DEBUG
     private final class WorktreeStartupEventTraceSink: @unchecked Sendable {
-        private let lock = NSLock()
+        private static let maximumPendingEventCount = 64
+
+        private let queue = DispatchQueue(label: "com.repoprompt.tests.worktree-startup-trace")
+        private let pendingCapacity = DispatchSemaphore(value: maximumPendingEventCount)
         private var isActive = true
         private var startNanosecondsByCorrelationID: [UUID: UInt64] = [:]
 
         func record(_ event: WorktreeStartupInstrumentation.Event, sequence: UInt64) {
-            lock.lock()
-            guard isActive else {
-                lock.unlock()
-                return
+            guard pendingCapacity.wait(timeout: .now()) == .success else { return }
+            queue.async { [self] in
+                defer { pendingCapacity.signal() }
+                guard isActive else { return }
+                emit(event, sequence: sequence)
             }
+        }
+
+        func finish() {
+            queue.sync {
+                isActive = false
+            }
+        }
+
+        private func emit(_ event: WorktreeStartupInstrumentation.Event, sequence: UInt64) {
             let startNanoseconds = startNanosecondsByCorrelationID[event.correlationID]
                 ?? event.timestampNanoseconds
             startNanosecondsByCorrelationID[event.correlationID] = startNanoseconds
@@ -1282,13 +1295,6 @@ final class WorktreeAPISmokeHarnessTests: XCTestCase {
                 + " route=\(event.route?.rawValue ?? "none")"
                 + " fallback=\(event.fallback?.rawValue ?? "none")\n"
             FileHandle.standardError.write(Data(line.utf8))
-            lock.unlock()
-        }
-
-        func deactivate() {
-            lock.lock()
-            isActive = false
-            lock.unlock()
         }
     }
 

--- a/Tests/RepoPromptTests/MCP/WorktreeAPISmokeHarnessTests.swift
+++ b/Tests/RepoPromptTests/MCP/WorktreeAPISmokeHarnessTests.swift
@@ -7,6 +7,16 @@ import XCTest
 @MainActor
 final class WorktreeAPISmokeHarnessTests: XCTestCase {
     func testManageWorktreeAndAgentRunAPISmokeFlow() async throws {
+        #if DEBUG
+            let startupTrace = WorktreeStartupEventTraceSink()
+            let startupTraceToken = WorktreeStartupInstrumentation.addEventObserverForTesting { event, sequence in
+                startupTrace.record(event, sequence: sequence)
+            }
+            defer {
+                startupTrace.deactivate()
+                WorktreeStartupInstrumentation.removeEventObserverForTesting(startupTraceToken)
+            }
+        #endif
         Self.traceSmokePhase("fixture.begin")
         let fixture = try Self.makeGitFixture()
         Self.traceSmokePhase("fixture.ready")
@@ -1248,6 +1258,40 @@ final class WorktreeAPISmokeHarnessTests: XCTestCase {
 }
 
 #if DEBUG
+    private final class WorktreeStartupEventTraceSink: @unchecked Sendable {
+        private let lock = NSLock()
+        private var isActive = true
+        private var startNanosecondsByCorrelationID: [UUID: UInt64] = [:]
+
+        func record(_ event: WorktreeStartupInstrumentation.Event, sequence: UInt64) {
+            lock.lock()
+            guard isActive else {
+                lock.unlock()
+                return
+            }
+            let startNanoseconds = startNanosecondsByCorrelationID[event.correlationID]
+                ?? event.timestampNanoseconds
+            startNanosecondsByCorrelationID[event.correlationID] = startNanoseconds
+            let elapsedNanoseconds = event.timestampNanoseconds >= startNanoseconds
+                ? event.timestampNanoseconds - startNanoseconds
+                : 0
+            let line = "[WorktreeAPISmoke] startup sequence=\(sequence)"
+                + " correlation=\(event.correlationID.uuidString)"
+                + " phase=\(event.phase.rawValue)"
+                + " elapsed_us=\(elapsedNanoseconds / 1000)"
+                + " route=\(event.route?.rawValue ?? "none")"
+                + " fallback=\(event.fallback?.rawValue ?? "none")\n"
+            FileHandle.standardError.write(Data(line.utf8))
+            lock.unlock()
+        }
+
+        func deactivate() {
+            lock.lock()
+            isActive = false
+            lock.unlock()
+        }
+    }
+
     private final class WorktreeContextBuilderImmediateCompletionProvider: HeadlessAgentProvider {
         func streamAgentMessage(
             _ message: AgentMessage,


### PR DESCRIPTION
## Summary

Adds DEBUG-only, write-only phase tracing to the existing `WorktreeAPISmokeHarnessTests` flow so hosted shard logs reveal the last completed `WorktreeStartupInstrumentation` event when the second `agent_run.start(worktree_create:)` stalls.

This is a diagnostic draft, **not yet a liveness fix**. It does not change timeouts, retries, assertions, CI configuration, or pass/fail behavior.

## Why separate

The same exact failure occurs on unrelated PRs #719 and #720, both based on `4cbac57`:

- `WorktreeAPISmokeHarnessTests/testManageWorktreeAndAgentRunAPISmokeFlow`
- external timeout at 180.1s / 180.2s
- stall after `create-start.tab-ready` during the second start with `worktree_create`

That makes this an inherited current-main race rather than a PR #719 ACP regression.

## Design

- Reuses the existing startup instrumentation; no parallel phase authority.
- Token-owned DEBUG observer, callbacks after the instrumentation lock is released.
- Emits sequence, correlation UUID, phase, elapsed microseconds, route, and fallback only; no paths or user content.
- Keeps the omnibus same-process smoke intact because splitting it into separate XCTest methods would remove the triggering interleaving.

Caveat: synchronous stderr tracing can mildly perturb a timing-sensitive race. The trace is diagnostic-only and any failure to reproduce with tracing will be treated as evidence, not success.

## Local validation

- Exact smoke: passed (1 test, 19.569s)
- `WorktreeStartupInstrumentationTests`: 22 passed (2.597s)
- `make dev-format`: passed, 0 files changed
- `make dev-lint`: passed
- Mandatory commit and push preflights: passed

Healthy local final startup reached `providerStart` in 7.124s; seeded commit to `rootReady` was ~15.5ms. No gradual performance regression was reproduced locally.

## Next step

Use the hosted shard trace to localize the suspended await, then repair the proven owner and add the lowest-layer deterministic regression in this same separate PR. Do not merge this diagnostic-only state.
