### PR TITLE
fix: require authoritative context builder completion

### DIFF
--- a/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel+MCP.swift
+++ b/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel+MCP.swift
@@ -1583,6 +1583,7 @@ extension OracleViewModel {
         finalReviewAuthorization: ContextBuilderFinalReviewAuthorization? = nil,
         agentModeSessionID: UUID? = nil,
         agentModeRunID: UUID? = nil,
+        completionPolicy: OracleResponseCompletionPolicy = .interactive,
         onProgress: ((_ text: String, _ reasoning: String?) -> Void)? = nil
     ) async throws -> ChatSendReply {
         // Check cancellation at entry
@@ -1667,8 +1668,8 @@ extension OracleViewModel {
         // (One Task.sleep for entire stream, not per-chunk - avoids CPU churn)
         let timeout: Duration = .seconds(4 * 60 * 60)
 
-        let (finalText, _, finalTokenInfo, providerCleanupHandle) = try await withThrowingTaskGroup(
-            of: (String, String, ChatTokenInfo, ProviderConversationCleanupHandle?).self
+        let (finalText, _, finalTokenInfo, providerCleanupHandle, terminalOutcome) = try await withThrowingTaskGroup(
+            of: (String, String, ChatTokenInfo, ProviderConversationCleanupHandle?, ChatStreamTerminalOutcome?).self
         ) { group in
             // Timeout task - throws after 4 hours
             group.addTask {
@@ -1682,6 +1683,7 @@ extension OracleViewModel {
                 var accReasoning = ""
                 var tokens = ChatTokenInfo()
                 var cleanupHandle: ProviderConversationCleanupHandle?
+                var terminalOutcome: ChatStreamTerminalOutcome?
                 var iterator = stream.makeAsyncIterator()
 
                 while let chunk = try await iterator.next() {
@@ -1706,8 +1708,12 @@ extension OracleViewModel {
                         let reasoning = accReasoning.isEmpty ? nil : accReasoning
                         await MainActor.run { onProgress(text, reasoning) }
                     }
+                    if let outcome = chunk.terminalOutcome {
+                        terminalOutcome = outcome
+                        break
+                    }
                 }
-                return (accText, accReasoning, tokens, cleanupHandle)
+                return (accText, accReasoning, tokens, cleanupHandle, terminalOutcome)
             }
 
             // Wait for stream to complete or timeout to fire
@@ -1716,8 +1722,22 @@ extension OracleViewModel {
             return result
         }
 
+        if completionPolicy == .contextBuilderStrict {
+            switch terminalOutcome {
+            case .completed:
+                break
+            case let .incomplete(reason):
+                throw OracleContextBuilderCompletionError.providerTerminatedIncomplete(reason: reason)
+            case nil:
+                throw OracleContextBuilderCompletionError.streamEndedWithoutProviderCompletion
+            }
+        }
+
         let trimmedResponse = finalText.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
         guard !trimmedResponse.isEmpty else {
+            if completionPolicy == .contextBuilderStrict {
+                throw OracleContextBuilderCompletionError.emptyProcessedContent
+            }
             throw ChatToolError.internalError("Request produced no content.")
         }
 

--- a/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel+MCP.swift
+++ b/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel+MCP.swift
@@ -1197,33 +1197,28 @@ extension OracleViewModel {
                 reviewGitContextOverride: reviewGitContextOverride
             )
         }
+        let queryId: UUID?
         #if DEBUG
             let trace = OracleReviewPackagingDiagnostics.makeTraceContext(
                 tabContext: tabContext,
                 observer: oracleReviewPackagingTraceObserverForTesting
             )
-            await OracleReviewPackagingDiagnostics.withTrace(trace, operation: send)
+            queryId = await OracleReviewPackagingDiagnostics.withTrace(trace, operation: send)
         #else
-            await send()
+            queryId = await send()
         #endif
-        let queryId = activeQueryId(for: chatID) ?? currentQueryId
-
-        if let q = queryId {
-            try await waitUntilMessageFinalised(q)
+        guard let queryId else {
+            throw OracleContextBuilderCompletionError.missingExactQuery
         }
+        let response = try await waitForContextBuilderCompletion(queryId)
 
         // ────────── 6. Build typed reply ──────────
-        let errors: [String] = []
-        let aiMsg = queryId.flatMap { id in
-            getChatMessage(withId: id)
-        }.flatMap { $0.isUser ? nil : $0 }
-
         let replyObj = ChatSendReply(
             chatId: chatID,
             shortId: sessions.first(where: { $0.id == chatID })?.shortID ?? "",
             mode: mode,
-            response: aiMsg?.content,
-            errors: errors.isEmpty ? nil : errors
+            response: response,
+            errors: nil
         )
 
         // Serialise to MCP Value → dictionary

--- a/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel.swift
+++ b/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel.swift
@@ -3311,9 +3311,21 @@ class OracleViewModel: ObservableObject {
         }
 
         // 1️⃣ Snapshot the final assistant text (MainActor)
-        let finalContent = await MainActor.run { () -> String in
+        var finalContent = await MainActor.run { () -> String in
             messageStore[sessionID]?.first(where: { $0.id == aiResponseId })?
                 .content ?? partialBuffer
+        }
+        if case let .providerTerminatedIncomplete(reason) = outcome {
+            let error = OracleContextBuilderCompletionError.providerTerminatedIncomplete(reason: reason)
+            let incompleteContent = finalContent + "\n\n--\nError:\n\(error.localizedDescription)"
+            finalContent = incompleteContent
+            await MainActor.run {
+                self.withSessionMessages(sessionID) { msgs in
+                    if let idx = msgs.firstIndex(where: { $0.id == aiResponseId }) {
+                        msgs[idx].updateContent(incompleteContent)
+                    }
+                }
+            }
         }
 
         // 2️⃣ Process final display content before toggling the finished flags that external tools poll for.

--- a/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel.swift
+++ b/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel.swift
@@ -259,6 +259,49 @@ struct OracleMessageLifecycleActivityEvent: Equatable {
     }
 }
 
+enum OracleResponseCompletionPolicy: Equatable {
+    case interactive
+    case contextBuilderStrict
+}
+
+enum OracleMessageFinalizationOutcome: Equatable {
+    case providerCompleted
+    case providerTerminatedIncomplete(reason: String)
+    case streamEndedWithoutProviderCompletion
+    case interactiveWatchdog
+    case cancelled
+    case failed(message: String)
+}
+
+enum OracleContextBuilderCompletionError: LocalizedError, Equatable {
+    case missingExactQuery
+    case missingFinalizationOutcome
+    case providerTerminatedIncomplete(reason: String)
+    case streamEndedWithoutProviderCompletion
+    case interactiveWatchdogFinalization
+    case providerStreamFailed(message: String)
+    case emptyProcessedContent
+
+    var errorDescription: String? {
+        switch self {
+        case .missingExactQuery:
+            "The exact Context Builder query could not be found."
+        case .missingFinalizationOutcome:
+            "The Context Builder query finalized without a terminal outcome."
+        case let .providerTerminatedIncomplete(reason):
+            "The provider ended the response before successful completion (reason: \(reason))."
+        case .streamEndedWithoutProviderCompletion:
+            "The provider stream ended before reporting completion."
+        case .interactiveWatchdogFinalization:
+            "The Context Builder query was finalized by the interactive inactivity watchdog."
+        case let .providerStreamFailed(message):
+            message
+        case .emptyProcessedContent:
+            "The Context Builder query completed without a response."
+        }
+    }
+}
+
 actor MessageFinalisationHub {
     private struct WaiterKey: Hashable {
         let messageID: UUID
@@ -267,7 +310,7 @@ actor MessageFinalisationHub {
 
     private var waiters: [UUID: [UUID: CheckedContinuation<Void, Never>]] = [:]
     private var cancelledWaiters: Set<WaiterKey> = []
-    private var completed: Set<UUID> = []
+    private var completedOutcomes: [UUID: OracleMessageFinalizationOutcome] = [:]
 
     func register(
         _ id: UUID,
@@ -275,15 +318,17 @@ actor MessageFinalisationHub {
         cont: CheckedContinuation<Void, Never>
     ) {
         let key = WaiterKey(messageID: id, waiterID: waiterID)
-        if completed.contains(id) || cancelledWaiters.remove(key) != nil {
+        if completedOutcomes[id] != nil || cancelledWaiters.remove(key) != nil {
             cont.resume()
             return
         }
         waiters[id, default: [:]][waiterID] = cont
     }
 
-    func fulfil(_ id: UUID) {
-        completed.insert(id)
+    func fulfil(_ id: UUID, outcome: OracleMessageFinalizationOutcome) {
+        if completedOutcomes[id] == nil {
+            completedOutcomes[id] = outcome
+        }
         cancelledWaiters = Set(cancelledWaiters.filter { $0.messageID != id })
         guard let list = waiters.removeValue(forKey: id) else { return }
         for continuation in list.values {
@@ -294,7 +339,7 @@ actor MessageFinalisationHub {
     /// Cancels only the requesting task's waiter. Message completion remains authoritative
     /// for every other current or future waiter.
     func cancel(_ id: UUID, waiterID: UUID) {
-        guard !completed.contains(id) else { return }
+        guard completedOutcomes[id] == nil else { return }
         if let continuation = waiters[id]?.removeValue(forKey: waiterID) {
             if waiters[id]?.isEmpty == true {
                 waiters.removeValue(forKey: id)
@@ -306,7 +351,11 @@ actor MessageFinalisationHub {
     }
 
     func isCompleted(_ id: UUID) -> Bool {
-        completed.contains(id)
+        completedOutcomes[id] != nil
+    }
+
+    func outcome(for id: UUID) -> OracleMessageFinalizationOutcome? {
+        completedOutcomes[id]
     }
 
     /// Clean up any orphaned waiters (safety mechanism)
@@ -1019,6 +1068,7 @@ class OracleViewModel: ObservableObject {
     private var lastTextStreamActivityAt: [UUID: Date] = [:]
     private var hasSeenNonReasoningText: Set<UUID> = []
     private var providerStopSeen: Set<UUID> = []
+    private var completionPolicies: [UUID: OracleResponseCompletionPolicy] = [:]
     /// Tracks when we last armed the inactivity watchdog per query (for throttling)
     private var lastInactivityWatchdogArmAt: [UUID: Date] = [:]
     /// Minimum interval between watchdog re-arms during streaming (reduces Task churn)
@@ -1206,6 +1256,10 @@ class OracleViewModel: ObservableObject {
     @MainActor
     private func scheduleStreamInactivityWatchdog(for queryId: UUID) {
         streamInactivityWatchdogs[queryId]?.cancel()
+        guard completionPolicies[queryId] != .contextBuilderStrict else {
+            streamInactivityWatchdogs[queryId] = nil
+            return
+        }
         let grace = currentInactivityGrace(for: queryId)
         let task = Task { [weak self] in
             guard grace > 0 else { return }
@@ -1303,7 +1357,12 @@ class OracleViewModel: ObservableObject {
         cancelFinalizationWatchdog(for: queryId)
         clearStreamActivityTracking(for: queryId)
         Task {
-            await self.finalizeAIResponse(aiResponseId: queryId, sessionID: sessionID, partialBuffer: content)
+            await self.finalizeAIResponse(
+                aiResponseId: queryId,
+                sessionID: sessionID,
+                partialBuffer: content,
+                outcome: .interactiveWatchdog
+            )
         }
     }
 
@@ -1330,6 +1389,7 @@ class OracleViewModel: ObservableObject {
 
     @MainActor
     private func scheduleFinalizationWatchdog(for queryId: UUID, delay: TimeInterval = 1.5) {
+        guard completionPolicies[queryId] != .contextBuilderStrict else { return }
         guard finalizationWatchdogs[queryId] == nil else {
             EditFlowPerf.event(
                 EditFlowPerf.Stage.Finalization.watchdogSkip,
@@ -1463,11 +1523,81 @@ class OracleViewModel: ObservableObject {
         clearStreamActivityTracking(for: queryId)
 
         Task {
-            await self.finalizeAIResponse(aiResponseId: queryId, sessionID: sessionID, partialBuffer: content)
+            await self.finalizeAIResponse(
+                aiResponseId: queryId,
+                sessionID: sessionID,
+                partialBuffer: content,
+                outcome: .interactiveWatchdog
+            )
         }
     }
 
     // MARK: - Message Finalisation
+
+    nonisolated func waitForContextBuilderCompletion(_ id: UUID) async throws -> String {
+        if await finalisationHub.outcome(for: id) == nil {
+            let hasExactMessage = await MainActor.run {
+                guard let sessionID = self.sessionIDByMessageId[id],
+                      let messages = self.messageStore[sessionID]
+                else {
+                    return false
+                }
+                return messages.contains(where: { $0.id == id && !$0.isUser })
+            }
+            guard hasExactMessage else {
+                throw OracleContextBuilderCompletionError.missingExactQuery
+            }
+
+            let waiterID = UUID()
+            await withTaskCancellationHandler {
+                await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+                    Task {
+                        await finalisationHub.register(
+                            id,
+                            waiterID: waiterID,
+                            cont: cont
+                        )
+                    }
+                }
+            } onCancel: {
+                Task { await finalisationHub.cancel(id, waiterID: waiterID) }
+            }
+            try Task.checkCancellation()
+        }
+
+        guard let outcome = await finalisationHub.outcome(for: id) else {
+            throw OracleContextBuilderCompletionError.missingFinalizationOutcome
+        }
+        switch outcome {
+        case .providerCompleted:
+            let content = await MainActor.run { () -> String? in
+                guard let sessionID = self.sessionIDByMessageId[id],
+                      let message = self.messageStore[sessionID]?.first(where: { $0.id == id && !$0.isUser }),
+                      message.isFinalized
+                else {
+                    return nil
+                }
+                return message.content
+            }
+            guard let content else {
+                throw OracleContextBuilderCompletionError.missingExactQuery
+            }
+            guard !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                throw OracleContextBuilderCompletionError.emptyProcessedContent
+            }
+            return content
+        case let .providerTerminatedIncomplete(reason):
+            throw OracleContextBuilderCompletionError.providerTerminatedIncomplete(reason: reason)
+        case .streamEndedWithoutProviderCompletion:
+            throw OracleContextBuilderCompletionError.streamEndedWithoutProviderCompletion
+        case .interactiveWatchdog:
+            throw OracleContextBuilderCompletionError.interactiveWatchdogFinalization
+        case .cancelled:
+            throw CancellationError()
+        case let .failed(message):
+            throw OracleContextBuilderCompletionError.providerStreamFailed(message: message)
+        }
+    }
 
     nonisolated func waitUntilMessageFinalised(_ id: UUID) async throws {
         let messageState = await MainActor.run { () -> Bool? in
@@ -2813,6 +2943,7 @@ class OracleViewModel: ObservableObject {
     // MARK: - Main Send/Receive Flow
 
     @MainActor
+    @discardableResult
     func sendMessage(
         _ newUserMessage: String,
         sessionID: UUID? = nil,
@@ -2825,9 +2956,10 @@ class OracleViewModel: ObservableObject {
         lookupContextOverride: WorkspaceLookupContext? = nil,
         reviewGitContextOverride: FrozenPromptGitReviewContext? = nil,
         overrideAIMessage: AIMessage? = nil,
+        completionPolicy: OracleResponseCompletionPolicy = .interactive,
         onProgress: ((_ text: String, _ reasoning: String?) -> Void)? = nil
-    ) async {
-        guard !newUserMessage.isEmpty else { return }
+    ) async -> UUID? {
+        guard !newUserMessage.isEmpty else { return nil }
         _ = true
 
         let targetSessionID: UUID
@@ -2837,7 +2969,7 @@ class OracleViewModel: ObservableObject {
             targetSessionID = currentSessionID
         } else {
             await startNewChatSession()
-            guard let currentSessionID else { return }
+            guard let currentSessionID else { return nil }
             targetSessionID = currentSessionID
         }
 
@@ -2885,7 +3017,11 @@ class OracleViewModel: ObservableObject {
             }
             registerMessage(errorMessage.id, sessionID: targetSessionID)
             autosaveChatHistory(for: targetSessionID)
-            return
+            await finalisationHub.fulfil(
+                errorMessage.id,
+                outcome: .failed(message: errorMessage.content)
+            )
+            return errorMessage.id
         }
 
         // Derive a string representation for storage / UI
@@ -2912,6 +3048,7 @@ class OracleViewModel: ObservableObject {
             msgs.append(aiPlaceholder)
         }
         registerMessage(aiResponseId, sessionID: targetSessionID)
+        completionPolicies[aiResponseId] = completionPolicy
         setSessionStreaming(targetSessionID, queryId: aiResponseId, streamId: nil)
 
         if currentSessionID == targetSessionID {
@@ -2996,6 +3133,8 @@ class OracleViewModel: ObservableObject {
 
                 var partialBuffer = ""
                 var reasoningBuffer = ""
+                var latestTokenInfo = ChatTokenInfo()
+                var incompleteProviderReason: String?
                 var didFinalize = false
 
                 for try await output in stream {
@@ -3012,7 +3151,13 @@ class OracleViewModel: ObservableObject {
                     let delta = output.text
                     let reasoningDelta = output.reasoning
                     let tokenInfo = output.tokens
+                    if tokenInfo.promptTokens != nil || tokenInfo.completionTokens != nil || tokenInfo.cost != nil {
+                        latestTokenInfo = tokenInfo
+                    }
                     let isStreamFinalized = output.isFinal
+                    if case let .incomplete(reason) = output.terminalOutcome {
+                        incompleteProviderReason = reason
+                    }
                     if let cleanupHandle = output.cleanupHandle {
                         providerCleanupHandle = cleanupHandle
                     }
@@ -3071,7 +3216,12 @@ class OracleViewModel: ObservableObject {
                         }
 
                         Task {
-                            await self.finalizeAIResponse(aiResponseId: aiResponseId, sessionID: targetSessionID, partialBuffer: partialBuffer)
+                            await self.finalizeAIResponse(
+                                aiResponseId: aiResponseId,
+                                sessionID: targetSessionID,
+                                partialBuffer: partialBuffer,
+                                outcome: .providerCompleted
+                            )
                             await self.cleanupOracleProviderConversation(providerCleanupHandle, model: model)
                         }
                     }
@@ -3081,8 +3231,28 @@ class OracleViewModel: ObservableObject {
                     await MainActor.run {
                         self.cancelStreamInactivityWatchdog(for: aiResponseId)
                     }
+                    await MainActor.run {
+                        self.withSessionMessages(targetSessionID) { msgs in
+                            if let idx = msgs.firstIndex(where: { $0.id == aiResponseId }) {
+                                msgs[idx].updateTokenInfo(latestTokenInfo)
+                            }
+                        }
+                        if self.currentSessionID == targetSessionID {
+                            self.updateLatestTokenCounts()
+                        }
+                    }
+                    let outcome: OracleMessageFinalizationOutcome = if let incompleteProviderReason {
+                        .providerTerminatedIncomplete(reason: incompleteProviderReason)
+                    } else {
+                        .streamEndedWithoutProviderCompletion
+                    }
                     Task {
-                        await self.finalizeAIResponse(aiResponseId: aiResponseId, sessionID: targetSessionID, partialBuffer: partialBuffer)
+                        await self.finalizeAIResponse(
+                            aiResponseId: aiResponseId,
+                            sessionID: targetSessionID,
+                            partialBuffer: partialBuffer,
+                            outcome: outcome
+                        )
                         await self.cleanupOracleProviderConversation(providerCleanupHandle, model: model)
                     }
                 }
@@ -3099,6 +3269,7 @@ class OracleViewModel: ObservableObject {
                 }
             }
         }
+        return aiResponseId
     }
 
     func cleanupOracleProviderConversation(
@@ -3117,7 +3288,8 @@ class OracleViewModel: ObservableObject {
     private func finalizeAIResponse(
         aiResponseId: UUID,
         sessionID: UUID,
-        partialBuffer: String
+        partialBuffer: String,
+        outcome: OracleMessageFinalizationOutcome
     ) async {
         // Single-flight finalisation: provider stop, watchdogs, and cancellation can
         // all race to finalize the same message.
@@ -3175,7 +3347,15 @@ class OracleViewModel: ObservableObject {
 
         // 5️⃣ Notify observers and any waiters that this message is finalised
         emitMessageLifecycleActivity(.finalizationCompleted, for: aiResponseId)
-        Task { await finalisationHub.fulfil(aiResponseId) }
+        await concludeFinalisation(aiResponseId, outcome: outcome)
+    }
+
+    private func concludeFinalisation(
+        _ id: UUID,
+        outcome: OracleMessageFinalizationOutcome
+    ) async {
+        completionPolicies.removeValue(forKey: id)
+        await finalisationHub.fulfil(id, outcome: outcome)
     }
 
     // MARK: - Error Handling
@@ -3195,18 +3375,19 @@ class OracleViewModel: ObservableObject {
             print("AI response was cancelled.")
             guard let index = messageStore[sessionID]?.firstIndex(where: { $0.id == aiResponseId }) else {
                 clearSessionStreaming(sessionID)
-                Task { await finalisationHub.fulfil(aiResponseId) }
+                await concludeFinalisation(aiResponseId, outcome: .cancelled)
                 return
             }
 
             if messageStore[sessionID]?[index].isFinalized == true {
                 clearSessionStreaming(sessionID)
-                Task { await finalisationHub.fulfil(aiResponseId) }
+                await concludeFinalisation(aiResponseId, outcome: .cancelled)
                 return
             }
 
             let finalContent = messageStore[sessionID]?[index].content ?? ""
             if finalContent.isEmpty {
+                await concludeFinalisation(aiResponseId, outcome: .cancelled)
                 withSessionMessages(sessionID) { msgs in
                     if let idx = msgs.firstIndex(where: { $0.id == aiResponseId }) {
                         msgs.remove(at: idx)
@@ -3215,12 +3396,16 @@ class OracleViewModel: ObservableObject {
                 purgeMessageCaches(for: aiResponseId)
                 clearSessionStreaming(sessionID)
                 autosaveChatHistory(for: sessionID)
-                Task { await finalisationHub.fulfil(aiResponseId) }
                 return
             }
 
             Task {
-                await self.finalizeAIResponse(aiResponseId: aiResponseId, sessionID: sessionID, partialBuffer: finalContent)
+                await self.finalizeAIResponse(
+                    aiResponseId: aiResponseId,
+                    sessionID: sessionID,
+                    partialBuffer: finalContent,
+                    outcome: .cancelled
+                )
             }
             return
         }
@@ -3253,7 +3438,10 @@ class OracleViewModel: ObservableObject {
         }
 
         clearSessionStreaming(sessionID)
-        Task { await finalisationHub.fulfil(aiResponseId) }
+        await concludeFinalisation(
+            aiResponseId,
+            outcome: .failed(message: errorMessage)
+        )
     }
 
     // MARK: - Conversation Entries Helper
@@ -3432,18 +3620,19 @@ class OracleViewModel: ObservableObject {
 
         guard !skipPartialParseAndSave, let queryId = qid else {
             if let qid {
-                Task { await finalisationHub.fulfil(qid) }
+                await concludeFinalisation(qid, outcome: .cancelled)
             }
             return
         }
 
         guard let idx = messageStore[sessionID]?.firstIndex(where: { $0.id == queryId && !$0.isUser }) else {
-            Task { await finalisationHub.fulfil(queryId) }
+            await concludeFinalisation(queryId, outcome: .cancelled)
             return
         }
 
         let finalContent = messageStore[sessionID]?[idx].content.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         if finalContent.isEmpty {
+            await concludeFinalisation(queryId, outcome: .cancelled)
             withSessionMessages(sessionID) { msgs in
                 if let index = msgs.firstIndex(where: { $0.id == queryId && !$0.isUser }) {
                     msgs.remove(at: index)
@@ -3451,7 +3640,6 @@ class OracleViewModel: ObservableObject {
             }
             purgeMessageCaches(for: queryId)
             autosaveChatHistory(for: sessionID)
-            Task { await finalisationHub.fulfil(queryId) }
             return
         }
 
@@ -3464,7 +3652,7 @@ class OracleViewModel: ObservableObject {
         autosaveChatHistory(for: sessionID)
 
         // Notify any waiters that this message is finalised (cancelled)
-        Task { await finalisationHub.fulfil(queryId) }
+        await concludeFinalisation(queryId, outcome: .cancelled)
     }
 
     @MainActor

--- a/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderAgentViewModel.swift
+++ b/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderAgentViewModel.swift
@@ -4502,7 +4502,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
         sessionID: UUID,
         progressReporter: ContextBuilderMCPProgressReporter?,
         activityReporter: ContextBuilderMCPActivityReporter?
-    ) async throws {
+    ) async throws -> String {
         let (activityEvents, activityContinuation) = AsyncStream<OracleMessageLifecycleActivityEvent>.makeStream(
             bufferingPolicy: .bufferingNewest(32)
         )
@@ -4514,10 +4514,10 @@ final class ContextBuilderAgentViewModel: ObservableObject {
             activityContinuation.finish()
         }
 
-        try await ContextBuilderFollowUpFinalizationMonitor.wait(
+        return try await ContextBuilderFollowUpFinalizationMonitor.wait(
             activityEvents: activityEvents,
             waitForFinalization: {
-                try await oracleViewModel.waitUntilMessageFinalised(queryID)
+                try await oracleViewModel.waitForContextBuilderCompletion(queryID)
             },
             cancelStreaming: {
                 await oracleViewModel.cancelStreaming(in: sessionID)
@@ -4638,7 +4638,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
             }
 
             await progressReporter?(.messageSend)
-            await oracleViewModel.sendMessage(
+            guard let queryId = await oracleViewModel.sendMessage(
                 prompt,
                 sessionID: createdSession.id,
                 overrideModel: model,
@@ -4648,6 +4648,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
                 selectionOverride: selection,
                 lookupContextOverride: lookupContext,
                 overrideAIMessage: aiMessage,
+                completionPolicy: .contextBuilderStrict,
                 onProgress: { [weak self] text, reasoning in
                     guard let self,
                           let session = sessions[tabID],
@@ -4658,17 +4659,16 @@ final class ContextBuilderAgentViewModel: ObservableObject {
                     requestBackgroundPlanUIRefresh(for: tabID)
                     onProgress?(text, reasoning)
                 }
-            )
+            ) else {
+                throw ChatToolError.internalError("Failed to start follow-up stream")
+            }
 
             guard session.isBackgroundPlanGenerating else {
                 throw CancellationError()
             }
             await progressReporter?(.activeQueryAcquisition)
-            guard let queryId = oracleViewModel.activeQueryId(for: createdSession.id) else {
-                throw ChatToolError.internalError("Failed to start follow-up stream")
-            }
             await progressReporter?(.streaming)
-            try await waitForFollowUpFinalization(
+            let responseText = try await waitForFollowUpFinalization(
                 in: oracleViewModel,
                 queryID: queryId,
                 sessionID: createdSession.id,
@@ -4679,8 +4679,6 @@ final class ContextBuilderAgentViewModel: ObservableObject {
                 throw CancellationError()
             }
 
-            let aiMsg = oracleViewModel.getChatMessage(withId: queryId).flatMap { $0.isUser ? nil : $0 }
-            let responseText = aiMsg?.content
             let reply = ChatSendReply(
                 chatId: createdSession.id,
                 shortId: createdSession.shortID,
@@ -4716,6 +4714,8 @@ final class ContextBuilderAgentViewModel: ObservableObject {
                 session.generatedAnswerRoute = nil
                 session.backgroundPlanError = nil
             } else {
+                session.backgroundPlanResponseText = nil
+                session.backgroundPlanReasoningText = nil
                 session.backgroundPlanError = error.asFriendlyString()
             }
             session.isBackgroundPlanGenerating = false
@@ -4802,6 +4802,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
 
         if workspaceManager?.activeWorkspaceID != identity.workspaceID {
             let session = session(for: tabID)
+            session.generatedAnswerRoute = nil
             session.isBackgroundPlanGenerating = true
             session.backgroundPlanError = nil
             session.backgroundPlanResponseText = nil
@@ -4823,6 +4824,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
                     finalReviewAuthorization: finalReviewAuthorization,
                     agentModeSessionID: agentModeSessionID,
                     agentModeRunID: agentModeRunID,
+                    completionPolicy: .contextBuilderStrict,
                     onProgress: { [weak self] text, reasoning in
                         guard let self, let session = sessions[tabID], session.isBackgroundPlanGenerating else { return }
                         session.backgroundPlanResponseText = text
@@ -4844,6 +4846,7 @@ final class ContextBuilderAgentViewModel: ObservableObject {
                 session.backgroundPlanError = error is CancellationError ? nil : error.asFriendlyString()
                 session.backgroundPlanResponseText = nil
                 session.backgroundPlanReasoningText = nil
+                session.generatedAnswerRoute = nil
                 updateRuntimeBindings(from: session)
                 throw error
             }

--- a/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderFollowUpFinalizationMonitor.swift
+++ b/Sources/RepoPrompt/Features/ContextBuilder/ViewModels/ContextBuilderFollowUpFinalizationMonitor.swift
@@ -118,7 +118,7 @@ actor ContextBuilderFollowUpFinalizationState {
 enum ContextBuilderFollowUpFinalizationMonitor {
     typealias Clock = @Sendable () -> TimeInterval
     typealias Sleep = @Sendable (_ seconds: TimeInterval) async throws -> Void
-    typealias WaitForFinalization = @Sendable () async throws -> Void
+    typealias WaitForFinalization = @Sendable () async throws -> String
     typealias CancelStreaming = @Sendable () async -> Void
     typealias ReportPhase = @Sendable (_ phase: ContextBuilderMCPProgressPhase) async -> Void
     typealias ReportActivity = @Sendable (
@@ -127,8 +127,9 @@ enum ContextBuilderFollowUpFinalizationMonitor {
     ) async -> Void
 
     private enum MonitorResult {
-        case finalised
+        case finalised(String)
         case timedOut(ContextBuilderFollowUpTimeoutSnapshot)
+        case contextBuilderFailed(OracleContextBuilderCompletionError)
         case failed(String)
         case cancelled
         case observerEnded
@@ -145,15 +146,17 @@ enum ContextBuilderFollowUpFinalizationMonitor {
         cancelStreaming: @escaping CancelStreaming,
         reportPhase: ReportPhase? = nil,
         reportActivity: ReportActivity? = nil
-    ) async throws {
+    ) async throws -> String {
         let state = ContextBuilderFollowUpFinalizationState(startedAt: clock())
         let result = await withTaskGroup(of: MonitorResult.self) { group in
             group.addTask {
                 do {
-                    try await waitForFinalization()
-                    return .finalised
+                    let response = try await waitForFinalization()
+                    return .finalised(response)
                 } catch is CancellationError {
                     return .cancelled
+                } catch let error as OracleContextBuilderCompletionError {
+                    return .contextBuilderFailed(error)
                 } catch {
                     return .failed(error.localizedDescription)
                 }
@@ -200,15 +203,17 @@ enum ContextBuilderFollowUpFinalizationMonitor {
         }
 
         switch result {
-        case .finalised:
+        case let .finalised(response):
             if await state.claimFinalizationTransitionOnCompletion() {
                 await reportPhase?(.messageFinalization)
             }
-            return
+            return response
         case let .timedOut(timeout):
             // The timeout outcome is already fixed before cancellation can trigger finalization.
             await cancelStreaming()
             throw ChatToolError.internalError(timeout.message)
+        case let .contextBuilderFailed(error):
+            throw error
         case let .failed(message):
             throw ChatToolError.internalError("Follow-up finalization monitoring failed: \(message)")
         case .cancelled, .observerEnded:

--- a/Sources/RepoPrompt/Infrastructure/AI/AIQueriesService.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/AIQueriesService.swift
@@ -20,27 +20,36 @@ public struct ChatTokenInfo: Codable, Equatable {
     }
 }
 
-/// The output of our Chat stream, now carrying a TokenInfo block.
+public enum ChatStreamTerminalOutcome: Sendable, Equatable {
+    case completed
+    case incomplete(reason: String)
+}
+
+/// A normalized provider stream event. A terminal outcome exists only when the provider explicitly reports completion or incomplete termination; ordinary stream exhaustion remains non-terminal.
 public struct ChatStreamOutput {
     public let text: String
     public let reasoning: String?
     public let tokens: ChatTokenInfo
-    public let isFinal: Bool
+    public let terminalOutcome: ChatStreamTerminalOutcome?
     public let cleanupHandle: ProviderConversationCleanupHandle?
     public let isTransportActivity: Bool
+
+    public var isFinal: Bool {
+        terminalOutcome == .completed
+    }
 
     public init(
         text: String,
         reasoning: String?,
         tokens: ChatTokenInfo,
-        isFinal: Bool,
+        terminalOutcome: ChatStreamTerminalOutcome? = nil,
         cleanupHandle: ProviderConversationCleanupHandle? = nil,
         isTransportActivity: Bool = false
     ) {
         self.text = text
         self.reasoning = reasoning
         self.tokens = tokens
-        self.isFinal = isFinal
+        self.terminalOutcome = terminalOutcome
         self.cleanupHandle = cleanupHandle
         self.isTransportActivity = isTransportActivity
     }
@@ -327,9 +336,26 @@ public class AIQueriesService {
             text: "",
             reasoning: nil,
             tokens: ChatTokenInfo(),
-            isFinal: false,
             isTransportActivity: true
         )
+    }
+
+    static func terminalOutcome(for result: AIStreamResult) throws -> ChatStreamTerminalOutcome? {
+        switch result.type {
+        case "message_stop":
+            return .completed
+        case AIStreamResult.incompleteType:
+            guard let reason = result.stopReason?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !reason.isEmpty
+            else {
+                throw AIProviderError.invalidResponse(
+                    detail: "The provider reported incomplete termination without a reason."
+                )
+            }
+            return .incomplete(reason: reason)
+        default:
+            return nil
+        }
     }
 
     static func cleanupHandle(for result: AIStreamResult, model: AIModel) -> ProviderConversationCleanupHandle? {
@@ -473,11 +499,12 @@ public class AIQueriesService {
                                 lastTokenInfo = chunkTokenInfo
                             }
 
-                            // If the provider signals end of message or buffers are ready to be flushed.
-                            if result.type == "message_stop" || shouldYield {
+                            let terminalOutcome = try Self.terminalOutcome(for: result)
+
+                            // Flush when the provider reports a terminal outcome or buffers are ready.
+                            if terminalOutcome != nil || shouldYield {
                                 let (combinedText, combinedReasoning, bufferedTokenInfo, _) = await self.taskManager.flushBuffer(for: taskId)
-                                let isFinal = (result.type == "message_stop")
-                                if isFinal { sawMessageStop = true }
+                                if terminalOutcome == .completed { sawMessageStop = true }
 
                                 // Prefer buffered counts; fall back to this chunk's counts
                                 let tokenInfo = bufferedTokenInfo ?? chunkTokenInfo
@@ -487,11 +514,11 @@ public class AIQueriesService {
                                         text: combinedText,
                                         reasoning: combinedReasoning.map(ReasoningTextFormatter.normalize),
                                         tokens: tokenInfo,
-                                        isFinal: isFinal,
+                                        terminalOutcome: terminalOutcome,
                                         cleanupHandle: cleanupHandle
                                     )
                                 )
-                                if isFinal {
+                                if terminalOutcome != nil {
                                     break streamLoop
                                 }
                             }
@@ -503,7 +530,7 @@ public class AIQueriesService {
                             _ = await self.taskManager.flushBuffer(for: taskId)
                             continuation.finish(throwing: CancellationError())
                         } else if !sawMessageStop {
-                            // Stream ended without message_stop - flush any remaining buffer as final
+                            // Stream ended without message_stop - flush remaining content as non-final
                             let (combinedText, combinedReasoning, bufferedTokenInfo, didHaveContent) = await self.taskManager.flushBuffer(for: taskId)
                             if didHaveContent {
                                 let tokenInfo = bufferedTokenInfo ?? lastTokenInfo ?? ChatTokenInfo()
@@ -512,7 +539,6 @@ public class AIQueriesService {
                                         text: combinedText,
                                         reasoning: combinedReasoning.map(ReasoningTextFormatter.normalize),
                                         tokens: tokenInfo,
-                                        isFinal: true,
                                         cleanupHandle: cleanupHandle
                                     )
                                 )

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/AIProviderFactory.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/AIProviderFactory.swift
@@ -347,12 +347,19 @@ private extension String {
     }
 }
 
+enum AIProviderCompletionOutcome: Equatable {
+    case completed
+    case incomplete(reason: String)
+}
+
 /// Updated `AIStreamResult` to include optional `reasoning`, token counts, and tool metadata.
 struct AIStreamResult {
     /// Standard type strings for stream results
     static let lifecycleType = "lifecycle"
     /// Transport-level activity with no semantic assistant payload.
     static let transportActivityType = "transport_activity"
+    /// Provider-reported terminal state that preserves partial output without declaring success.
+    static let incompleteType = "message_incomplete"
 
     let type: String // e.g. "content", "message_stop", "tool_call", "tool_result", "final_content", "lifecycle", "transport_activity"
     let text: String? // normal content (like streaming tokens)
@@ -431,12 +438,20 @@ struct AICompletionResult {
     let promptTokens: Int?
     let completionTokens: Int?
     let cost: Double?
+    let completionOutcome: AIProviderCompletionOutcome
 
-    init(text: String, promptTokens: Int? = nil, completionTokens: Int? = nil, cost: Double? = nil) {
+    init(
+        text: String,
+        promptTokens: Int? = nil,
+        completionTokens: Int? = nil,
+        cost: Double? = nil,
+        completionOutcome: AIProviderCompletionOutcome = .completed
+    ) {
         self.text = text
         self.promptTokens = promptTokens
         self.completionTokens = completionTokens
         self.cost = cost
+        self.completionOutcome = completionOutcome
     }
 }
 

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/AnthropicProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/AnthropicProvider.swift
@@ -8,6 +8,15 @@ class AnthropicProvider: AIProvider {
         service = AnthropicServiceFactory.service(apiKey: apiKey, betaHeaders: betaHeaders)
     }
 
+    static func isSuccessfulCompletionStopReason(_ stopReason: String) -> Bool {
+        switch stopReason.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "end_turn", "stop_sequence":
+            true
+        default:
+            false
+        }
+    }
+
     private func createMessages(for aiMessage: AIMessage) -> [MessageParameter.Message] {
         let tail = aiMessage.buildTail(embedSystemPrompt: false)
         let lastUserIndex = aiMessage.conversationMessages.lastIndex { $0.role == .user }
@@ -52,7 +61,12 @@ class AnthropicProvider: AIProvider {
             let result = try await completeMessage(aiMessage, model: model, maxTokens: maxTokens)
             return AsyncThrowingStream { continuation in
                 continuation.yield(AIStreamResult(type: "content", text: result.text, reasoning: nil, promptTokens: nil, completionTokens: nil))
-                continuation.yield(AIStreamResult(type: "message_stop", text: nil, reasoning: nil, promptTokens: result.promptTokens, completionTokens: result.completionTokens))
+                switch result.completionOutcome {
+                case .completed:
+                    continuation.yield(AIStreamResult(type: "message_stop", text: nil, reasoning: nil, promptTokens: result.promptTokens, completionTokens: result.completionTokens))
+                case let .incomplete(reason):
+                    continuation.yield(AIStreamResult(type: AIStreamResult.incompleteType, text: nil, promptTokens: result.promptTokens, completionTokens: result.completionTokens, stopReason: reason))
+                }
                 continuation.finish()
             }
         }
@@ -127,9 +141,12 @@ class AnthropicProvider: AIProvider {
                     // Track token counts
                     var promptTokens: Int? = nil
                     var completionTokens: Int? = nil
+                    var observedStopReason: String?
+                    var didObserveMessageStop = false
 
                     for try await result in stream {
                         var reasoning: String? = nil
+                        var shouldYieldEvent = true
 
                         // Handle different stream events
                         switch result.streamEvent {
@@ -157,7 +174,20 @@ class AnthropicProvider: AIProvider {
                                 currentThinking = ""
                             }
 
+                        case .messageDelta:
+                            if let stopReason = result.delta?.stopReason?.trimmingCharacters(in: .whitespacesAndNewlines),
+                               !stopReason.isEmpty
+                            {
+                                observedStopReason = stopReason
+                            }
+                            if let usage = result.usage {
+                                promptTokens = usage.inputTokens
+                                completionTokens = usage.outputTokens + (usage.thinkingTokens ?? 0)
+                            }
+
                         case .messageStop:
+                            didObserveMessageStop = true
+                            shouldYieldEvent = false
                             // Extract token usage from the end of stream
                             if let usage = result.usage {
                                 promptTokens = usage.inputTokens
@@ -176,21 +206,29 @@ class AnthropicProvider: AIProvider {
                             type: result.type,
                             text: result.contentBlock?.text ?? result.delta?.text,
                             reasoning: reasoning,
-                            promptTokens: promptTokens, // Only include tokens in final message_stop
+                            promptTokens: promptTokens,
                             completionTokens: completionTokens
                         )
 
-                        continuation.yield(aiResult)
+                        if shouldYieldEvent {
+                            continuation.yield(aiResult)
+                        }
                     }
 
-                    // Send final message_stop with token counts
-                    continuation.yield(AIStreamResult(
-                        type: "message_stop",
-                        text: nil,
-                        reasoning: nil,
-                        promptTokens: promptTokens,
-                        completionTokens: completionTokens
-                    ))
+                    if didObserveMessageStop {
+                        let stopReason = observedStopReason ?? "missing_stop_reason"
+                        let type = Self.isSuccessfulCompletionStopReason(stopReason)
+                            ? "message_stop"
+                            : AIStreamResult.incompleteType
+                        continuation.yield(AIStreamResult(
+                            type: type,
+                            text: nil,
+                            reasoning: nil,
+                            promptTokens: promptTokens,
+                            completionTokens: completionTokens,
+                            stopReason: stopReason
+                        ))
+                    }
 
                     continuation.finish()
                 } catch {
@@ -280,10 +318,16 @@ class AnthropicProvider: AIProvider {
         let thinkingTokens = response.usage.thinkingTokens ?? 0
         let completionTokens = outputTokens + thinkingTokens
 
+        let stopReason = response.stopReason ?? "missing_stop_reason"
+        let completionOutcome: AIProviderCompletionOutcome = Self.isSuccessfulCompletionStopReason(stopReason)
+            ? .completed
+            : .incomplete(reason: stopReason)
+
         return AICompletionResult(
             text: text,
             promptTokens: promptTokens,
-            completionTokens: completionTokens
+            completionTokens: completionTokens,
+            completionOutcome: completionOutcome
         )
     }
 

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/AzureOpenAIProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/AzureOpenAIProvider.swift
@@ -239,8 +239,8 @@ extension AzureOpenAIProvider: ResponsesJobProvider {
 
                         // Check for terminal states
                         switch response.status {
-                        case .completed:
-                            // Extract the output text from the response
+                        case .completed, .incomplete:
+                            // Extract any available output before reporting the terminal outcome
                             var outputText = ""
                             var reasoningText = ""
                             for item in response.output {
@@ -286,14 +286,16 @@ extension AzureOpenAIProvider: ResponsesJobProvider {
                                 )
                             }
 
+                            let didComplete = response.status == .completed
                             continuation.yield(
                                 AIStreamResult(
-                                    type: "message_stop",
+                                    type: didComplete ? "message_stop" : AIStreamResult.incompleteType,
                                     text: nil,
                                     reasoning: nil,
                                     promptTokens: response.usage?.inputTokens,
                                     completionTokens: response.usage?.outputTokens,
-                                    cost: nil
+                                    cost: nil,
+                                    stopReason: didComplete ? nil : response.incompleteDetails?.reason ?? "unknown"
                                 )
                             )
                             continuation.finish()
@@ -302,10 +304,6 @@ extension AzureOpenAIProvider: ResponsesJobProvider {
                         case .failed:
                             let message = response.error?.message ?? "Background job failed."
                             throw AIProviderError.invalidResponse(detail: message)
-
-                        case .incomplete:
-                            let detail = response.incompleteDetails?.reason ?? "Background job incomplete."
-                            throw AIProviderError.invalidResponse(detail: detail)
 
                         case .cancelled:
                             throw AIProviderError.invalidResponse(detail: "Background job was cancelled.")
@@ -668,6 +666,7 @@ final class AzureOpenAIProvider: AIProvider {
                 do {
                     var promptTokens: Int?
                     var completionTokens: Int?
+                    var observedCompletionOutcome: AIProviderCompletionOutcome?
 
                     for try await event in stream {
                         if Task.isCancelled { break }
@@ -681,6 +680,7 @@ final class AzureOpenAIProvider: AIProvider {
                                 continuation.yield(AIStreamResult(type: "content", text: nil, reasoning: delta.delta, promptTokens: nil, completionTokens: nil))
                             }
                         case let .responseCompleted(completed):
+                            observedCompletionOutcome = .completed
                             if let usage = completed.response.usage {
                                 promptTokens = usage.inputTokens
                                 completionTokens = usage.outputTokens
@@ -689,8 +689,8 @@ final class AzureOpenAIProvider: AIProvider {
                             let message = failed.response.error?.message ?? "Responses API returned a failure."
                             throw AIProviderError.invalidResponse(detail: message)
                         case let .responseIncomplete(incomplete):
-                            let detail = incomplete.response.incompleteDetails?.reason ?? "Responses API marked the response as incomplete."
-                            throw AIProviderError.invalidResponse(detail: detail)
+                            let reason = incomplete.response.incompleteDetails?.reason ?? "unknown"
+                            observedCompletionOutcome = .incomplete(reason: reason)
                         case let .error(errorEvent):
                             throw APIError.requestFailed(description: errorEvent.prettyDescription)
                         default:
@@ -698,7 +698,14 @@ final class AzureOpenAIProvider: AIProvider {
                         }
                     }
 
-                    continuation.yield(AIStreamResult(type: "message_stop", text: nil, reasoning: nil, promptTokens: promptTokens, completionTokens: completionTokens))
+                    switch observedCompletionOutcome {
+                    case .completed:
+                        continuation.yield(AIStreamResult(type: "message_stop", text: nil, reasoning: nil, promptTokens: promptTokens, completionTokens: completionTokens))
+                    case let .incomplete(reason):
+                        continuation.yield(AIStreamResult(type: AIStreamResult.incompleteType, text: nil, promptTokens: promptTokens, completionTokens: completionTokens, stopReason: reason))
+                    case nil:
+                        break
+                    }
                     continuation.finish()
                 } catch {
                     continuation.finish(throwing: error)
@@ -711,9 +718,9 @@ final class AzureOpenAIProvider: AIProvider {
 
     private func performResponseCompletion(parameters: ModelResponseParameter) async throws -> ResponseModel {
         let response = try await azureService.responseCreate(parameters)
-        guard response.status == .completed else {
+        guard response.status == .completed || response.status == .incomplete else {
             let status = response.status?.rawValue ?? "unknown"
-            let detail = response.error?.message ?? response.incompleteDetails?.reason ?? "Response status was '\(status)'"
+            let detail = response.error?.message ?? "Response status was '\(status)'"
             throw AIProviderError.invalidResponse(detail: detail)
         }
         return response
@@ -760,7 +767,12 @@ final class AzureOpenAIProvider: AIProvider {
             let result = try await completeMessage(aiMessage, model: model, maxTokens: finalMaxTokens)
             return AsyncThrowingStream { continuation in
                 continuation.yield(AIStreamResult(type: "content", text: result.text, reasoning: nil, promptTokens: nil, completionTokens: nil))
-                continuation.yield(AIStreamResult(type: "message_stop", text: nil, reasoning: nil, promptTokens: result.promptTokens, completionTokens: result.completionTokens))
+                switch result.completionOutcome {
+                case .completed:
+                    continuation.yield(AIStreamResult(type: "message_stop", text: nil, reasoning: nil, promptTokens: result.promptTokens, completionTokens: result.completionTokens))
+                case let .incomplete(reason):
+                    continuation.yield(AIStreamResult(type: AIStreamResult.incompleteType, text: nil, promptTokens: result.promptTokens, completionTokens: result.completionTokens, stopReason: reason))
+                }
                 continuation.finish()
             }
         }
@@ -780,6 +792,7 @@ final class AzureOpenAIProvider: AIProvider {
                 do {
                     var promptTokens: Int?
                     var completionTokens: Int?
+                    var observedCompletionOutcome: AIProviderCompletionOutcome?
 
                     for try await chunk in stream {
                         if Task.isCancelled { break }
@@ -789,8 +802,10 @@ final class AzureOpenAIProvider: AIProvider {
                             completionTokens = usage.completionTokens
                         }
 
-                        let content = chunk.choices?.first?.delta?.content ?? ""
-                        let reasoning = chunk.choices?.first?.delta?.reasoningContent ?? ""
+                        let choice = chunk.choices?.first
+                        let content = choice?.delta?.content ?? ""
+                        let reasoning = choice?.delta?.reasoningContent ?? ""
+                        let finishReason = choice?.finishReason
 
                         if !content.isEmpty || !reasoning.isEmpty {
                             continuation.yield(
@@ -803,9 +818,19 @@ final class AzureOpenAIProvider: AIProvider {
                                 )
                             )
                         }
+                        if let completionOutcome = openAIChatCompletionOutcome(finishReason) {
+                            observedCompletionOutcome = completionOutcome
+                        }
                     }
 
-                    continuation.yield(AIStreamResult(type: "message_stop", text: nil, reasoning: nil, promptTokens: promptTokens, completionTokens: completionTokens))
+                    switch observedCompletionOutcome {
+                    case .completed:
+                        continuation.yield(AIStreamResult(type: "message_stop", text: nil, reasoning: nil, promptTokens: promptTokens, completionTokens: completionTokens))
+                    case let .incomplete(reason):
+                        continuation.yield(AIStreamResult(type: AIStreamResult.incompleteType, text: nil, promptTokens: promptTokens, completionTokens: completionTokens, stopReason: reason))
+                    case nil:
+                        break
+                    }
                     continuation.finish()
                 } catch {
                     continuation.finish(throwing: error)
@@ -841,10 +866,17 @@ final class AzureOpenAIProvider: AIProvider {
                 let promptTokens = response.usage?.inputTokens
                 let completionTokens = response.usage?.outputTokens
 
+                let completionOutcome: AIProviderCompletionOutcome = if response.status == .completed {
+                    .completed
+                } else {
+                    .incomplete(reason: response.incompleteDetails?.reason ?? "unknown")
+                }
+
                 return AICompletionResult(
                     text: text,
                     promptTokens: promptTokens,
-                    completionTokens: completionTokens
+                    completionTokens: completionTokens,
+                    completionOutcome: completionOutcome
                 )
             } catch let error as APIError {
                 throw AIProviderError.apiError(source: error)
@@ -864,12 +896,16 @@ final class AzureOpenAIProvider: AIProvider {
             maxTokens: finalMaxTokens
         )
         let response = try await azureService.startChat(parameters: parameters)
-        let text = response.choices?.first?.message?.content ?? ""
+        let choice = response.choices?.first
+        let text = choice?.message?.content ?? ""
+        let completionOutcome = openAIChatCompletionOutcome(choice?.finishReason)
+            ?? .incomplete(reason: "missing_finish_reason")
 
         return AICompletionResult(
             text: text,
             promptTokens: response.usage?.promptTokens,
-            completionTokens: response.usage?.completionTokens
+            completionTokens: response.usage?.completionTokens,
+            completionOutcome: completionOutcome
         )
     }
 

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/OpenAIProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/OpenAIProvider.swift
@@ -1,6 +1,18 @@
 import Foundation
 import SwiftOpenAI
 
+func openAIChatCompletionOutcome(_ finishReason: IntOrStringValue?) -> AIProviderCompletionOutcome? {
+    guard let finishReason else { return nil }
+    switch finishReason {
+    case .string("stop"):
+        return .completed
+    case let .string(reason):
+        return .incomplete(reason: reason)
+    case let .int(reason):
+        return .incomplete(reason: String(reason))
+    }
+}
+
 class OpenAIProvider: AIProvider {
     // Instance-level cache
     private let cachedApiKey: String?
@@ -246,7 +258,12 @@ class OpenAIProvider: AIProvider {
             let result = try await completeMessage(aiMessage, model: model, maxTokens: finalMaxTokens)
             return AsyncThrowingStream { continuation in
                 continuation.yield(AIStreamResult(type: "content", text: result.text, reasoning: nil, promptTokens: nil, completionTokens: result.completionTokens))
-                continuation.yield(AIStreamResult(type: "message_stop", text: nil, reasoning: nil, promptTokens: result.promptTokens, completionTokens: result.completionTokens))
+                switch result.completionOutcome {
+                case .completed:
+                    continuation.yield(AIStreamResult(type: "message_stop", text: nil, reasoning: nil, promptTokens: result.promptTokens, completionTokens: result.completionTokens))
+                case let .incomplete(reason):
+                    continuation.yield(AIStreamResult(type: AIStreamResult.incompleteType, text: nil, promptTokens: result.promptTokens, completionTokens: result.completionTokens, stopReason: reason))
+                }
                 continuation.finish()
             }
         }
@@ -302,6 +319,7 @@ class OpenAIProvider: AIProvider {
                 do {
                     var promptTokens: Int? = nil
                     var completionTokens: Int? = nil
+                    var observedCompletionOutcome: AIProviderCompletionOutcome?
 
                     for try await result in stream {
                         // Check cancellation to exit promptly when consumer stops reading
@@ -314,8 +332,10 @@ class OpenAIProvider: AIProvider {
                             continue
                         }
 
-                        let content = result.choices?.first?.delta?.content ?? ""
-                        let reasoning = result.choices?.first?.delta?.reasoningContent ?? ""
+                        let choice = result.choices?.first
+                        let content = choice?.delta?.content ?? ""
+                        let reasoning = choice?.delta?.reasoningContent ?? ""
+                        let finishReason = choice?.finishReason
 
                         // Extract token usage from the final response chunk if available
                         if let usage = result.usage {
@@ -328,8 +348,18 @@ class OpenAIProvider: AIProvider {
                                 AIStreamResult(type: "content", text: content, reasoning: reasoning, promptTokens: promptTokens, completionTokens: completionTokens)
                             )
                         }
+                        if let completionOutcome = openAIChatCompletionOutcome(finishReason) {
+                            observedCompletionOutcome = completionOutcome
+                        }
                     }
-                    continuation.yield(AIStreamResult(type: "message_stop", text: nil, reasoning: nil, promptTokens: promptTokens, completionTokens: completionTokens))
+                    switch observedCompletionOutcome {
+                    case .completed:
+                        continuation.yield(AIStreamResult(type: "message_stop", text: nil, reasoning: nil, promptTokens: promptTokens, completionTokens: completionTokens))
+                    case let .incomplete(reason):
+                        continuation.yield(AIStreamResult(type: AIStreamResult.incompleteType, text: nil, promptTokens: promptTokens, completionTokens: completionTokens, stopReason: reason))
+                    case nil:
+                        break
+                    }
                     continuation.finish()
                 } catch {
                     continuation.finish(throwing: error)
@@ -358,11 +388,15 @@ class OpenAIProvider: AIProvider {
             // Assuming responseCreate exists in the service layer as per previous code.
             let response = try await service.responseCreate(parameters)
 
-            // Check response status and potential errors before extracting text
-            guard response.status == .completed else {
+            let completionOutcome: AIProviderCompletionOutcome
+            if response.status == .completed {
+                completionOutcome = .completed
+            } else if response.status == .incomplete {
+                completionOutcome = .incomplete(reason: response.incompleteDetails?.reason ?? "unknown")
+            } else {
                 let statusString = response.status?.rawValue ?? "unknown"
-                let errorDetail = response.error?.message ?? response.incompleteDetails?.reason ?? "Response status was '\(statusString)'"
-                throw AIProviderError.invalidResponse(detail: "Responses API call did not complete successfully. Status: \(statusString). Detail: \(errorDetail)")
+                let errorDetail = response.error?.message ?? "Response status was '\(statusString)'"
+                throw AIProviderError.invalidResponse(detail: "Responses API call failed. Status: \(statusString). Detail: \(errorDetail)")
             }
 
             // Extract text content using the convenience property
@@ -382,7 +416,8 @@ class OpenAIProvider: AIProvider {
             return AICompletionResult(
                 text: responseText,
                 promptTokens: promptTokens,
-                completionTokens: completionTokens
+                completionTokens: completionTokens,
+                completionOutcome: completionOutcome
             )
 
         } catch let error as APIError {
@@ -481,13 +516,17 @@ class OpenAIProvider: AIProvider {
         let promptTokens = response.usage?.promptTokens
         let completionTokens = response.usage?.completionTokens
 
-        let content = response.choices?.first?.message?.content ?? ""
+        let choice = response.choices?.first
+        let content = choice?.message?.content ?? ""
+        let completionOutcome = openAIChatCompletionOutcome(choice?.finishReason)
+            ?? .incomplete(reason: "missing_finish_reason")
 
         // Return an AICompletionResult with content and token counts
         return AICompletionResult(
             text: content,
             promptTokens: promptTokens,
-            completionTokens: completionTokens
+            completionTokens: completionTokens,
+            completionOutcome: completionOutcome
         )
     }
 
@@ -527,6 +566,7 @@ class OpenAIProvider: AIProvider {
                 do {
                     var promptTokens: Int?
                     var completionTokens: Int?
+                    var observedCompletionOutcome: AIProviderCompletionOutcome?
 
                     for try await event in stream {
                         if Task.isCancelled { break }
@@ -558,6 +598,7 @@ class OpenAIProvider: AIProvider {
                                 )
                             }
                         case let .responseCompleted(completed):
+                            observedCompletionOutcome = .completed
                             if let usage = completed.response.usage {
                                 promptTokens = usage.inputTokens
                                 completionTokens = usage.outputTokens
@@ -566,8 +607,8 @@ class OpenAIProvider: AIProvider {
                             let message = failed.response.error?.message ?? "Responses API returned a failure."
                             throw AIProviderError.invalidResponse(detail: message)
                         case let .responseIncomplete(incomplete):
-                            let detail = incomplete.response.incompleteDetails?.reason ?? "Responses API marked the response as incomplete."
-                            throw AIProviderError.invalidResponse(detail: detail)
+                            let reason = incomplete.response.incompleteDetails?.reason ?? "unknown"
+                            observedCompletionOutcome = .incomplete(reason: reason)
                         case let .error(errorEvent):
                             throw APIError.requestFailed(description: errorEvent.prettyDescription)
                         default:
@@ -575,16 +616,31 @@ class OpenAIProvider: AIProvider {
                         }
                     }
 
-                    continuation.yield(
-                        AIStreamResult(
-                            type: "message_stop",
-                            text: nil,
-                            reasoning: nil,
-                            promptTokens: promptTokens,
-                            completionTokens: completionTokens,
-                            cost: nil
+                    switch observedCompletionOutcome {
+                    case .completed:
+                        continuation.yield(
+                            AIStreamResult(
+                                type: "message_stop",
+                                text: nil,
+                                reasoning: nil,
+                                promptTokens: promptTokens,
+                                completionTokens: completionTokens,
+                                cost: nil
+                            )
                         )
-                    )
+                    case let .incomplete(reason):
+                        continuation.yield(
+                            AIStreamResult(
+                                type: AIStreamResult.incompleteType,
+                                text: nil,
+                                promptTokens: promptTokens,
+                                completionTokens: completionTokens,
+                                stopReason: reason
+                            )
+                        )
+                    case nil:
+                        break
+                    }
                     continuation.finish()
                 } catch {
                     continuation.finish(throwing: error)
@@ -784,8 +840,8 @@ extension OpenAIProvider: ResponsesJobProvider {
 
                         // Check for terminal states
                         switch response.status {
-                        case .completed:
-                            // Extract the output text from the response
+                        case .completed, .incomplete:
+                            // Extract any available output before reporting the terminal outcome
                             var outputText = ""
                             var reasoningText = ""
                             for item in response.output {
@@ -831,14 +887,16 @@ extension OpenAIProvider: ResponsesJobProvider {
                                 )
                             }
 
+                            let didComplete = response.status == .completed
                             continuation.yield(
                                 AIStreamResult(
-                                    type: "message_stop",
+                                    type: didComplete ? "message_stop" : AIStreamResult.incompleteType,
                                     text: nil,
                                     reasoning: nil,
                                     promptTokens: response.usage?.inputTokens,
                                     completionTokens: response.usage?.outputTokens,
-                                    cost: nil
+                                    cost: nil,
+                                    stopReason: didComplete ? nil : response.incompleteDetails?.reason ?? "unknown"
                                 )
                             )
                             continuation.finish()
@@ -847,10 +905,6 @@ extension OpenAIProvider: ResponsesJobProvider {
                         case .failed:
                             let message = response.error?.message ?? "Background job failed."
                             throw AIProviderError.invalidResponse(detail: message)
-
-                        case .incomplete:
-                            let detail = response.incompleteDetails?.reason ?? "Background job incomplete."
-                            throw AIProviderError.invalidResponse(detail: detail)
 
                         case .cancelled:
                             throw AIProviderError.invalidResponse(detail: "Background job was cancelled.")

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/OpenRouterProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/OpenRouterProvider.swift
@@ -48,7 +48,12 @@ class OpenRouterProvider: AIProvider {
             let result = try await completeMessage(aiMessage, model: model, maxTokens: maxTokens)
             return AsyncThrowingStream { continuation in
                 continuation.yield(AIStreamResult(type: "content", text: result.text, reasoning: nil, promptTokens: nil, completionTokens: nil))
-                continuation.yield(AIStreamResult(type: "message_stop", text: nil, reasoning: nil, promptTokens: result.promptTokens, completionTokens: result.completionTokens, cost: result.cost))
+                switch result.completionOutcome {
+                case .completed:
+                    continuation.yield(AIStreamResult(type: "message_stop", text: nil, reasoning: nil, promptTokens: result.promptTokens, completionTokens: result.completionTokens, cost: result.cost))
+                case let .incomplete(reason):
+                    continuation.yield(AIStreamResult(type: AIStreamResult.incompleteType, text: nil, promptTokens: result.promptTokens, completionTokens: result.completionTokens, cost: result.cost, stopReason: reason))
+                }
                 continuation.finish()
             }
         }
@@ -80,11 +85,14 @@ class OpenRouterProvider: AIProvider {
                     var promptTokens: Int? = nil
                     var completionTokens: Int? = nil
                     var cost: Double? = nil
+                    var observedCompletionOutcome: AIProviderCompletionOutcome?
 
                     for try await chunk in stream {
                         // Use optional chaining to unwrap the optional 'choices'
-                        let content = chunk.choices?.first?.delta?.content
-                        let reasoning = chunk.choices?.first?.delta?.reasoningContent
+                        let choice = chunk.choices?.first
+                        let content = choice?.delta?.content
+                        let reasoning = choice?.delta?.reasoningContent
+                        let finishReason = choice?.finishReason
 
                         // Extract token usage from the final response chunk if available
                         if let usage = chunk.usage {
@@ -99,10 +107,19 @@ class OpenRouterProvider: AIProvider {
                         } else if let r = reasoning, !r.isEmpty {
                             continuation.yield(AIStreamResult(type: "content", text: nil, reasoning: r))
                         }
+                        if let completionOutcome = openAIChatCompletionOutcome(finishReason) {
+                            observedCompletionOutcome = completionOutcome
+                        }
                     }
 
-                    // Indicate the message has ended with token counts
-                    continuation.yield(AIStreamResult(type: "message_stop", text: nil, reasoning: nil, promptTokens: promptTokens, completionTokens: completionTokens, cost: cost))
+                    switch observedCompletionOutcome {
+                    case .completed:
+                        continuation.yield(AIStreamResult(type: "message_stop", text: nil, reasoning: nil, promptTokens: promptTokens, completionTokens: completionTokens, cost: cost))
+                    case let .incomplete(reason):
+                        continuation.yield(AIStreamResult(type: AIStreamResult.incompleteType, text: nil, promptTokens: promptTokens, completionTokens: completionTokens, cost: cost, stopReason: reason))
+                    case nil:
+                        break
+                    }
                     continuation.finish()
                 } catch {
                     continuation.finish(throwing: error)
@@ -136,14 +153,17 @@ class OpenRouterProvider: AIProvider {
         let completionTokens = completion.usage?.completionTokens
         let cost = completion.usage?.cost
 
-        // Use optional chaining for 'choices'
-        let content = completion.choices?.first?.message?.content ?? ""
+        let choice = completion.choices?.first
+        let content = choice?.message?.content ?? ""
+        let completionOutcome = openAIChatCompletionOutcome(choice?.finishReason)
+            ?? .incomplete(reason: "missing_finish_reason")
 
         return AICompletionResult(
             text: content,
             promptTokens: promptTokens,
             completionTokens: completionTokens,
-            cost: cost
+            cost: cost,
+            completionOutcome: completionOutcome
         )
     }
 

--- a/Tests/RepoPromptTests/AI/OracleTransportActivityPropagationTests.swift
+++ b/Tests/RepoPromptTests/AI/OracleTransportActivityPropagationTests.swift
@@ -199,26 +199,22 @@ final class OracleTransportActivityPropagationTests: XCTestCase {
             text: "",
             reasoning: nil,
             tokens: ChatTokenInfo(),
-            isFinal: false,
             isTransportActivity: true
         )
         let emptyOutput = ChatStreamOutput(
             text: "",
             reasoning: nil,
-            tokens: ChatTokenInfo(),
-            isFinal: false
+            tokens: ChatTokenInfo()
         )
         let contentOutput = ChatStreamOutput(
             text: "hello",
             reasoning: nil,
-            tokens: ChatTokenInfo(),
-            isFinal: false
+            tokens: ChatTokenInfo()
         )
         let reasoningOutput = ChatStreamOutput(
             text: "",
             reasoning: "thinking",
-            tokens: ChatTokenInfo(),
-            isFinal: false
+            tokens: ChatTokenInfo()
         )
 
         XCTAssertEqual(OracleViewModel.lifecycleActivityKind(for: transportOutput), .streamActivity)

--- a/Tests/RepoPromptTests/AI/ProviderStreamCompletionTests.swift
+++ b/Tests/RepoPromptTests/AI/ProviderStreamCompletionTests.swift
@@ -1,0 +1,49 @@
+import Foundation
+@testable import RepoPromptApp
+import SwiftOpenAI
+import XCTest
+
+final class ProviderStreamCompletionTests: XCTestCase {
+    func testOpenAIStopReasonReportsSuccessfulCompletion() {
+        XCTAssertEqual(openAIChatCompletionOutcome(.string("stop")), .completed)
+        XCTAssertNil(openAIChatCompletionOutcome(nil))
+    }
+
+    func testOpenAIIncompleteStopReasonIsPreserved() {
+        XCTAssertEqual(
+            openAIChatCompletionOutcome(.string("length")),
+            .incomplete(reason: "length")
+        )
+    }
+
+    func testAnthropicSuccessfulCompletionReasonsAreExplicit() {
+        XCTAssertTrue(AnthropicProvider.isSuccessfulCompletionStopReason("end_turn"))
+        XCTAssertTrue(AnthropicProvider.isSuccessfulCompletionStopReason("stop_sequence"))
+        XCTAssertFalse(AnthropicProvider.isSuccessfulCompletionStopReason("max_tokens"))
+        XCTAssertFalse(AnthropicProvider.isSuccessfulCompletionStopReason("tool_use"))
+    }
+
+    func testAIQueriesNormalizesIncompleteTerminationWithoutMarkingSuccess() throws {
+        let result = AIStreamResult(
+            type: AIStreamResult.incompleteType,
+            text: nil,
+            stopReason: "max_tokens"
+        )
+
+        let outcome = try AIQueriesService.terminalOutcome(for: result)
+
+        XCTAssertEqual(outcome, .incomplete(reason: "max_tokens"))
+        XCTAssertNotEqual(outcome, .completed)
+    }
+
+    func testAIQueriesRejectsIncompleteTerminationWithoutReason() {
+        let result = AIStreamResult(type: AIStreamResult.incompleteType, text: nil)
+
+        XCTAssertThrowsError(try AIQueriesService.terminalOutcome(for: result)) { error in
+            XCTAssertEqual(
+                error.localizedDescription,
+                "The provider reported incomplete termination without a reason."
+            )
+        }
+    }
+}

--- a/Tests/RepoPromptTests/Chat/OracleMessageFinalisationHubTests.swift
+++ b/Tests/RepoPromptTests/Chat/OracleMessageFinalisationHubTests.swift
@@ -45,7 +45,7 @@ final class OracleMessageFinalisationHubTests: XCTestCase {
         let futureResumedBeforeFulfilment = await futureSignal.isMarked()
         XCTAssertFalse(futureResumedBeforeFulfilment)
 
-        await hub.fulfil(messageID)
+        await hub.fulfil(messageID, outcome: .providerCompleted)
         await retainedWaiter.value
         await futureWaiter.value
 
@@ -87,10 +87,21 @@ final class OracleMessageFinalisationHubTests: XCTestCase {
         XCTAssertFalse(retainedResumedBeforeFulfilment)
         XCTAssertFalse(completedBeforeFulfilment)
 
-        await hub.fulfil(messageID)
+        await hub.fulfil(messageID, outcome: .providerCompleted)
         await retainedWaiter.value
         let retainedResumedAfterFulfilment = await retainedSignal.isMarked()
         XCTAssertTrue(retainedResumedAfterFulfilment)
+    }
+
+    func testFirstTerminalOutcomeRemainsAuthoritative() async {
+        let hub = MessageFinalisationHub()
+        let messageID = UUID()
+
+        await hub.fulfil(messageID, outcome: .streamEndedWithoutProviderCompletion)
+        await hub.fulfil(messageID, outcome: .providerCompleted)
+
+        let outcome = await hub.outcome(for: messageID)
+        XCTAssertEqual(outcome, .streamEndedWithoutProviderCompletion)
     }
 
     private func makeWaiter(

--- a/Tests/RepoPromptTests/ContextBuilder/ContextBuilderFollowUpFinalizationMonitorTests.swift
+++ b/Tests/RepoPromptTests/ContextBuilder/ContextBuilderFollowUpFinalizationMonitorTests.swift
@@ -87,7 +87,7 @@ final class ContextBuilderFollowUpFinalizationMonitorTests: XCTestCase {
         defer { continuation.finish() }
 
         do {
-            try await ContextBuilderFollowUpFinalizationMonitor.wait(
+            _ = try await ContextBuilderFollowUpFinalizationMonitor.wait(
                 activityEvents: events,
                 configuration: ContextBuilderFollowUpFinalizationConfiguration(
                     overallTimeout: 100,
@@ -101,6 +101,7 @@ final class ContextBuilderFollowUpFinalizationMonitorTests: XCTestCase {
                 },
                 waitForFinalization: {
                     try await finalizationGate.wait()
+                    return "response"
                 },
                 cancelStreaming: {
                     await cancellationRecorder.recordCancellation()
@@ -131,7 +132,7 @@ final class ContextBuilderFollowUpFinalizationMonitorTests: XCTestCase {
 
         let monitor = Task { () -> Result<Void, Error> in
             do {
-                try await ContextBuilderFollowUpFinalizationMonitor.wait(
+                _ = try await ContextBuilderFollowUpFinalizationMonitor.wait(
                     activityEvents: events,
                     configuration: ContextBuilderFollowUpFinalizationConfiguration(
                         overallTimeout: 100,
@@ -145,6 +146,7 @@ final class ContextBuilderFollowUpFinalizationMonitorTests: XCTestCase {
                     },
                     waitForFinalization: {
                         try await finalizationGate.wait()
+                        return "response"
                     },
                     cancelStreaming: {
                         await finalizationGate.complete()
@@ -175,14 +177,14 @@ final class ContextBuilderFollowUpFinalizationMonitorTests: XCTestCase {
         let (events, continuation) = AsyncStream<OracleMessageLifecycleActivityEvent>.makeStream()
         defer { continuation.finish() }
 
-        try await ContextBuilderFollowUpFinalizationMonitor.wait(
+        _ = try await ContextBuilderFollowUpFinalizationMonitor.wait(
             activityEvents: events,
             configuration: ContextBuilderFollowUpFinalizationConfiguration(
                 overallTimeout: 100,
                 inactivityTimeout: 10,
                 checkInterval: 60
             ),
-            waitForFinalization: {},
+            waitForFinalization: { "response" },
             cancelStreaming: {},
             reportPhase: { phase in
                 await recorder.recordPhase(phase)
@@ -204,7 +206,7 @@ final class ContextBuilderFollowUpFinalizationMonitorTests: XCTestCase {
         continuation.yield(OracleMessageLifecycleActivityEvent(kind: .providerStopObserved))
 
         let monitor = Task {
-            try await ContextBuilderFollowUpFinalizationMonitor.wait(
+            _ = try await ContextBuilderFollowUpFinalizationMonitor.wait(
                 activityEvents: events,
                 configuration: ContextBuilderFollowUpFinalizationConfiguration(
                     overallTimeout: 100,
@@ -213,6 +215,7 @@ final class ContextBuilderFollowUpFinalizationMonitorTests: XCTestCase {
                 ),
                 waitForFinalization: {
                     await finalizationGate.arriveAndWait()
+                    return "response"
                 },
                 cancelStreaming: {},
                 reportPhase: { phase in
@@ -229,7 +232,7 @@ final class ContextBuilderFollowUpFinalizationMonitorTests: XCTestCase {
         await fulfillment(of: [activityExpectation, finalizationPhaseExpectation], timeout: 1)
         await finalizationGate.release()
         continuation.finish()
-        try await monitor.value
+        _ = try await monitor.value
 
         let snapshot = await recorder.snapshot()
         XCTAssertEqual(snapshot.phases, [.messageFinalization])
@@ -238,6 +241,30 @@ final class ContextBuilderFollowUpFinalizationMonitorTests: XCTestCase {
             "Oracle finalization watchdog armed",
             "Oracle provider stop observed"
         ])
+    }
+
+    func testContextBuilderCompletionErrorIdentityIsPreserved() async {
+        let expected = OracleContextBuilderCompletionError.providerStreamFailed(
+            message: "The provider rejected the request."
+        )
+        let (events, continuation) = AsyncStream<OracleMessageLifecycleActivityEvent>.makeStream()
+        defer { continuation.finish() }
+
+        do {
+            _ = try await ContextBuilderFollowUpFinalizationMonitor.wait(
+                activityEvents: events,
+                configuration: ContextBuilderFollowUpFinalizationConfiguration(
+                    overallTimeout: 100,
+                    inactivityTimeout: 10,
+                    checkInterval: 60
+                ),
+                waitForFinalization: { throw expected },
+                cancelStreaming: {}
+            )
+            XCTFail("Expected the strict completion error")
+        } catch {
+            XCTAssertEqual(error as? OracleContextBuilderCompletionError, expected)
+        }
     }
 }
 

--- a/Tests/RepoPromptTests/ContextBuilder/ContextBuilderMCPProgressTimelineTests.swift
+++ b/Tests/RepoPromptTests/ContextBuilder/ContextBuilderMCPProgressTimelineTests.swift
@@ -209,7 +209,7 @@ final class ContextBuilderMCPProgressTimelineTests: XCTestCase {
                                     text: "deterministic follow-up",
                                     reasoning: nil,
                                     tokens: ChatTokenInfo(),
-                                    isFinal: true
+                                    terminalOutcome: .completed
                                 ))
                                 continuation.finish()
                             }

--- a/Tests/RepoPromptTests/ContextBuilder/ContextBuilderStrictFinalizationTests.swift
+++ b/Tests/RepoPromptTests/ContextBuilder/ContextBuilderStrictFinalizationTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import MCP
 @testable import RepoPromptApp
 import XCTest
 
@@ -61,10 +62,12 @@ final class ContextBuilderStrictFinalizationTests: XCTestCase {
                 })
             )
             XCTAssertEqual(viewModel.currentFollowUpOracleChatID(for: tabID), oracleSession.shortID)
-            XCTAssertTrue(
+            let retainedResponse = try XCTUnwrap(
                 composition.oracleViewModel.messagesSnapshot(for: oracleSession.id)
-                    .contains(where: { !$0.isUser && $0.content == "partial response" })
+                    .first(where: { !$0.isUser })
             )
+            XCTAssertTrue(retainedResponse.content.hasPrefix("partial response"))
+            XCTAssertTrue(retainedResponse.content.contains("reason: max_tokens"))
             guard case .error = viewModel.planStatus(for: tabID) else {
                 return XCTFail("Expected Context Builder error state")
             }
@@ -74,7 +77,7 @@ final class ContextBuilderStrictFinalizationTests: XCTestCase {
     }
 
     @MainActor
-    func testInteractiveIncompleteTerminationPreservesPartialResponse() async throws {
+    func testInteractiveIncompleteTerminationPreservesPartialResponseAndShowsReason() async throws {
         #if DEBUG
             let composition = makeComposition(
                 windowID: -180,
@@ -112,8 +115,135 @@ final class ContextBuilderStrictFinalizationTests: XCTestCase {
                 composition.oracleViewModel.messagesSnapshot(for: sessionID)
                     .first(where: { $0.id == queryID })
             )
-            XCTAssertEqual(response.content, "partial response")
+            XCTAssertTrue(response.content.hasPrefix("partial response"))
+            XCTAssertTrue(response.content.contains("reason: max_tokens"))
             XCTAssertTrue(response.isFinalized)
+        #else
+            throw XCTSkip("Strict finalization injection is DEBUG-only.")
+        #endif
+    }
+
+    @MainActor
+    func testAskOracleIncompleteTerminationFailsAndPreservesTranscript() async throws {
+        #if DEBUG
+            let composition = makeComposition(
+                windowID: -181,
+                terminalOutcome: .incomplete(reason: "max_tokens")
+            )
+            await composition.workspaceManager.awaitInitialized()
+
+            let root = makeTemporaryRoot(label: "ask-oracle-incomplete")
+            defer { try? FileManager.default.removeItem(at: root) }
+
+            let workspace = composition.workspaceManager.createWorkspace(
+                name: "Ask Oracle incomplete completion test",
+                repoPaths: [root.path],
+                ephemeral: true
+            )
+            await composition.workspaceManager.switchWorkspace(
+                to: workspace,
+                saveState: false,
+                reason: "ContextBuilderStrictFinalizationTests.ask-oracle-incomplete"
+            )
+
+            let settings = GlobalSettingsStore.shared
+            let previousShowPresets = settings.mcpShowModelPresets()
+            let previousDisablePresets = settings.mcpTemporarilyDisablePresets()
+            let previousPlanningModel = composition.promptManager.planningModelName
+            let previousCustomProviderValidity = composition.apiSettingsViewModel.isCustomProviderValid
+            defer {
+                settings.setMCPShowModelPresets(previousShowPresets, commit: false)
+                settings.setMCPTemporarilyDisablePresets(previousDisablePresets, commit: false)
+                composition.promptManager.planningModelName = previousPlanningModel
+                composition.apiSettingsViewModel.isCustomProviderValid = previousCustomProviderValidity
+            }
+            settings.setMCPShowModelPresets(false, commit: false)
+            settings.setMCPTemporarilyDisablePresets(false, commit: false)
+            composition.apiSettingsViewModel.isCustomProviderValid = true
+            composition.promptManager.planningModelName = AIModel.customProviderUser(
+                name: "strict-finalization-test"
+            ).rawValue
+            let oracleSession = try await composition.oracleViewModel.createSession(
+                named: "Ask Oracle incomplete response"
+            )
+
+            do {
+                _ = try await composition.oracleViewModel.tool_chatSend(
+                    args: [
+                        "message": .string("Review the response."),
+                        "mode": .string("review"),
+                        "chat_id": .string(oracleSession.id.uuidString)
+                    ],
+                    promptVM: composition.promptManager
+                )
+                XCTFail("Expected Ask Oracle incomplete provider termination to fail")
+            } catch {
+                XCTAssertEqual(
+                    error as? OracleContextBuilderCompletionError,
+                    .providerTerminatedIncomplete(reason: "max_tokens")
+                )
+            }
+
+            let response = try XCTUnwrap(
+                composition.oracleViewModel.messagesSnapshot(for: oracleSession.id)
+                    .first(where: { !$0.isUser })
+            )
+            XCTAssertTrue(response.content.hasPrefix("partial response"))
+            XCTAssertTrue(response.content.contains("reason: max_tokens"))
+            XCTAssertTrue(response.isFinalized)
+        #else
+            throw XCTSkip("Strict finalization injection is DEBUG-only.")
+        #endif
+    }
+
+    @MainActor
+    func testAskOracleProviderCompletionReturnsExactResponse() async throws {
+        #if DEBUG
+            let composition = makeComposition(windowID: -182, terminalOutcome: .completed)
+            await composition.workspaceManager.awaitInitialized()
+
+            let root = makeTemporaryRoot(label: "ask-oracle-completed")
+            defer { try? FileManager.default.removeItem(at: root) }
+
+            let workspace = composition.workspaceManager.createWorkspace(
+                name: "Ask Oracle completed response test",
+                repoPaths: [root.path],
+                ephemeral: true
+            )
+            await composition.workspaceManager.switchWorkspace(
+                to: workspace,
+                saveState: false,
+                reason: "ContextBuilderStrictFinalizationTests.ask-oracle-completed"
+            )
+
+            let settings = GlobalSettingsStore.shared
+            let previousShowPresets = settings.mcpShowModelPresets()
+            let previousDisablePresets = settings.mcpTemporarilyDisablePresets()
+            let previousPlanningModel = composition.promptManager.planningModelName
+            let previousCustomProviderValidity = composition.apiSettingsViewModel.isCustomProviderValid
+            defer {
+                settings.setMCPShowModelPresets(previousShowPresets, commit: false)
+                settings.setMCPTemporarilyDisablePresets(previousDisablePresets, commit: false)
+                composition.promptManager.planningModelName = previousPlanningModel
+                composition.apiSettingsViewModel.isCustomProviderValid = previousCustomProviderValidity
+            }
+            settings.setMCPShowModelPresets(false, commit: false)
+            settings.setMCPTemporarilyDisablePresets(false, commit: false)
+            composition.apiSettingsViewModel.isCustomProviderValid = true
+            composition.promptManager.planningModelName = AIModel.customProviderUser(
+                name: "strict-finalization-test"
+            ).rawValue
+
+            let reply = try await composition.oracleViewModel.tool_chatSend(
+                args: [
+                    "message": .string("Review the response."),
+                    "mode": .string("review")
+                ],
+                promptVM: composition.promptManager
+            )
+
+            XCTAssertEqual(reply["response"]?.stringValue, "partial response")
+            XCTAssertNil(reply["errors"])
         #else
             throw XCTSkip("Strict finalization injection is DEBUG-only.")
         #endif

--- a/Tests/RepoPromptTests/ContextBuilder/ContextBuilderStrictFinalizationTests.swift
+++ b/Tests/RepoPromptTests/ContextBuilder/ContextBuilderStrictFinalizationTests.swift
@@ -1,0 +1,331 @@
+import Foundation
+@testable import RepoPromptApp
+import XCTest
+
+final class ContextBuilderStrictFinalizationTests: XCTestCase {
+    @MainActor
+    func testActiveContextBuilderIncompleteTerminationFailsAndPreservesOracleChat() async throws {
+        #if DEBUG
+            let composition = makeComposition(
+                windowID: -177,
+                terminalOutcome: .incomplete(reason: "max_tokens")
+            )
+            await composition.workspaceManager.awaitInitialized()
+
+            let root = makeTemporaryRoot(label: "active")
+            defer { try? FileManager.default.removeItem(at: root) }
+
+            let workspace = composition.workspaceManager.createWorkspace(
+                name: "Context Builder strict active test",
+                repoPaths: [root.path],
+                ephemeral: true
+            )
+            await composition.workspaceManager.switchWorkspace(
+                to: workspace,
+                saveState: false,
+                reason: "ContextBuilderStrictFinalizationTests.active"
+            )
+            let activeWorkspace = try XCTUnwrap(composition.workspaceManager.activeWorkspace)
+            let tabID = try XCTUnwrap(
+                activeWorkspace.activeComposeTabID ?? activeWorkspace.composeTabs.first?.id
+            )
+            let agentModeSessionID = UUID()
+            let agentModeRunID = UUID()
+            let viewModel = composition.contextBuilderAgentViewModel
+            installModelHook(on: viewModel)
+            defer { viewModel.installRunTestHooks(nil) }
+
+            do {
+                _ = try await viewModel.runMCPPlanOrQuestion(
+                    for: tabID,
+                    oracleViewModel: composition.oracleViewModel,
+                    agentModeSessionID: agentModeSessionID,
+                    agentModeRunID: agentModeRunID,
+                    mode: .plan,
+                    prompt: "Produce a plan.",
+                    selection: StoredSelection(),
+                    reviewGitContext: .automaticOnly()
+                )
+                XCTFail("Expected incomplete provider termination to fail")
+            } catch {
+                XCTAssertEqual(
+                    error as? OracleContextBuilderCompletionError,
+                    .providerTerminatedIncomplete(reason: "max_tokens")
+                )
+            }
+
+            let oracleSession = try XCTUnwrap(
+                composition.oracleViewModel.sessions.first(where: {
+                    $0.agentModeSessionID == agentModeSessionID &&
+                        $0.agentModeRunID == agentModeRunID
+                })
+            )
+            XCTAssertEqual(viewModel.currentFollowUpOracleChatID(for: tabID), oracleSession.shortID)
+            XCTAssertTrue(
+                composition.oracleViewModel.messagesSnapshot(for: oracleSession.id)
+                    .contains(where: { !$0.isUser && $0.content == "partial response" })
+            )
+            guard case .error = viewModel.planStatus(for: tabID) else {
+                return XCTFail("Expected Context Builder error state")
+            }
+        #else
+            throw XCTSkip("Strict finalization injection is DEBUG-only.")
+        #endif
+    }
+
+    @MainActor
+    func testInteractiveIncompleteTerminationPreservesPartialResponse() async throws {
+        #if DEBUG
+            let composition = makeComposition(
+                windowID: -180,
+                terminalOutcome: .incomplete(reason: "max_tokens")
+            )
+            await composition.workspaceManager.awaitInitialized()
+
+            let root = makeTemporaryRoot(label: "interactive-incomplete")
+            defer { try? FileManager.default.removeItem(at: root) }
+
+            let workspace = composition.workspaceManager.createWorkspace(
+                name: "Interactive incomplete completion test",
+                repoPaths: [root.path],
+                ephemeral: true
+            )
+            await composition.workspaceManager.switchWorkspace(
+                to: workspace,
+                saveState: false,
+                reason: "ContextBuilderStrictFinalizationTests.interactive-incomplete"
+            )
+
+            let sentQueryID = await composition.oracleViewModel.sendMessage(
+                "Produce a response.",
+                overrideModel: .customProvider(
+                    name: "Unconfigured test provider",
+                    provider: "custom",
+                    model: "unconfigured-test-model"
+                )
+            )
+            let queryID = try XCTUnwrap(sentQueryID)
+            let sessionID = try XCTUnwrap(composition.oracleViewModel.currentSessionID)
+            try await composition.oracleViewModel.waitUntilMessageFinalised(queryID)
+
+            let response = try XCTUnwrap(
+                composition.oracleViewModel.messagesSnapshot(for: sessionID)
+                    .first(where: { $0.id == queryID })
+            )
+            XCTAssertEqual(response.content, "partial response")
+            XCTAssertTrue(response.isFinalized)
+        #else
+            throw XCTSkip("Strict finalization injection is DEBUG-only.")
+        #endif
+    }
+
+    @MainActor
+    func testInactiveContextBuilderCleanEOFFailsBeforePersistence() async throws {
+        #if DEBUG
+            let composition = makeComposition(windowID: -178)
+            await composition.workspaceManager.awaitInitialized()
+
+            let activeRoot = makeTemporaryRoot(label: "headless-active")
+            let inactiveRoot = makeTemporaryRoot(label: "headless-target")
+            defer {
+                try? FileManager.default.removeItem(at: activeRoot)
+                try? FileManager.default.removeItem(at: inactiveRoot)
+            }
+
+            let activeWorkspace = composition.workspaceManager.createWorkspace(
+                name: "Context Builder strict headless active workspace",
+                repoPaths: [activeRoot.path],
+                ephemeral: true
+            )
+            await composition.workspaceManager.switchWorkspace(
+                to: activeWorkspace,
+                saveState: false,
+                reason: "ContextBuilderStrictFinalizationTests.headless-active"
+            )
+            let inactiveWorkspace = composition.workspaceManager.createWorkspace(
+                name: "Context Builder strict headless target workspace",
+                repoPaths: [inactiveRoot.path],
+                ephemeral: true
+            )
+            let tabID = try XCTUnwrap(
+                inactiveWorkspace.activeComposeTabID ?? inactiveWorkspace.composeTabs.first?.id
+            )
+            let identity = WorkspaceSelectionIdentity(
+                workspaceID: inactiveWorkspace.id,
+                tabID: tabID
+            )
+            let viewModel = composition.contextBuilderAgentViewModel
+            installModelHook(on: viewModel)
+            defer { viewModel.installRunTestHooks(nil) }
+            let initialPersistedSessionIDs = try await Set(
+                composition.oracleViewModel.chatData.recentSessions(
+                    for: inactiveWorkspace,
+                    limit: 100,
+                    composeTabID: tabID
+                ).map(\.id)
+            )
+
+            do {
+                _ = try await viewModel.runMCPPlanOrQuestion(
+                    for: identity,
+                    oracleViewModel: composition.oracleViewModel,
+                    mode: .plan,
+                    prompt: "Produce a plan.",
+                    selection: StoredSelection(),
+                    reviewGitContext: .automaticOnly()
+                )
+                XCTFail("Expected headless clean EOF without provider completion to fail")
+            } catch {
+                XCTAssertEqual(
+                    error as? OracleContextBuilderCompletionError,
+                    .streamEndedWithoutProviderCompletion
+                )
+            }
+
+            let persistedSessionIDs = try await Set(
+                composition.oracleViewModel.chatData.recentSessions(
+                    for: inactiveWorkspace,
+                    limit: 100,
+                    composeTabID: tabID
+                ).map(\.id)
+            )
+            XCTAssertEqual(persistedSessionIDs, initialPersistedSessionIDs)
+            XCTAssertNil(viewModel.currentFollowUpOracleChatID(for: tabID))
+            guard case .error = viewModel.planStatus(for: tabID) else {
+                return XCTFail("Expected Context Builder error state")
+            }
+        #else
+            throw XCTSkip("Strict finalization injection is DEBUG-only.")
+        #endif
+    }
+
+    @MainActor
+    func testInactiveContextBuilderProviderCompletionPersistsReply() async throws {
+        #if DEBUG
+            let composition = makeComposition(windowID: -179, terminalOutcome: .completed)
+            await composition.workspaceManager.awaitInitialized()
+
+            let activeRoot = makeTemporaryRoot(label: "headless-success-active")
+            let inactiveRoot = makeTemporaryRoot(label: "headless-success-target")
+            defer {
+                try? FileManager.default.removeItem(at: activeRoot)
+                try? FileManager.default.removeItem(at: inactiveRoot)
+            }
+
+            let activeWorkspace = composition.workspaceManager.createWorkspace(
+                name: "Context Builder strict headless success active workspace",
+                repoPaths: [activeRoot.path],
+                ephemeral: true
+            )
+            await composition.workspaceManager.switchWorkspace(
+                to: activeWorkspace,
+                saveState: false,
+                reason: "ContextBuilderStrictFinalizationTests.headless-success-active"
+            )
+            let inactiveWorkspace = composition.workspaceManager.createWorkspace(
+                name: "Context Builder strict headless success target workspace",
+                repoPaths: [inactiveRoot.path],
+                ephemeral: true
+            )
+            let tabID = try XCTUnwrap(
+                inactiveWorkspace.activeComposeTabID ?? inactiveWorkspace.composeTabs.first?.id
+            )
+            let identity = WorkspaceSelectionIdentity(
+                workspaceID: inactiveWorkspace.id,
+                tabID: tabID
+            )
+            let viewModel = composition.contextBuilderAgentViewModel
+            installModelHook(on: viewModel)
+            defer { viewModel.installRunTestHooks(nil) }
+
+            let reply = try await viewModel.runMCPPlanOrQuestion(
+                for: identity,
+                oracleViewModel: composition.oracleViewModel,
+                mode: .plan,
+                prompt: "Produce a plan.",
+                selection: StoredSelection(),
+                reviewGitContext: .automaticOnly()
+            )
+
+            XCTAssertEqual(reply.response, "partial response")
+            XCTAssertEqual(viewModel.currentFollowUpOracleChatID(for: tabID), reply.shortId)
+
+            let persistedSession = try await composition.oracleViewModel.chatData.findSession(
+                for: inactiveWorkspace,
+                id: reply.shortId,
+                composeTabID: tabID
+            )
+            XCTAssertEqual(persistedSession?.id, reply.chatId)
+            XCTAssertEqual(persistedSession?.shortID, reply.shortId)
+            XCTAssertEqual(persistedSession?.messages.last?.rawText, "partial response")
+        #else
+            throw XCTSkip("Strict finalization injection is DEBUG-only.")
+        #endif
+    }
+
+    #if DEBUG
+        @MainActor
+        private func makeComposition(
+            windowID: Int,
+            terminalOutcome: ChatStreamTerminalOutcome? = nil
+        ) -> WindowStateComposition {
+            let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
+            GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
+            let composition = WindowStateCompositionFactory.make(
+                windowID: windowID,
+                deferredInitialAgentSystemWorkspaceRefresh: true,
+                sharedMCPService: MCPService(),
+                aiQueriesServiceFactory: { keyManager in
+                    AIQueriesService(
+                        keyManager: keyManager,
+                        sendPromptOverride: { _, _ in
+                            let stream = AsyncThrowingStream<ChatStreamOutput, Error> { continuation in
+                                continuation.yield(
+                                    ChatStreamOutput(
+                                        text: "partial response",
+                                        reasoning: nil,
+                                        tokens: ChatTokenInfo(),
+                                        terminalOutcome: terminalOutcome
+                                    )
+                                )
+                                continuation.finish()
+                            }
+                            return (UUID(), stream)
+                        }
+                    )
+                }
+            )
+            GlobalSettingsStore.shared.setMCPAutoStart(previousAutoStart, commit: false)
+            return composition
+        }
+
+        @MainActor
+        private func installModelHook(on viewModel: ContextBuilderAgentViewModel) {
+            viewModel.installRunTestHooks(
+                ContextBuilderAgentViewModel.RunTestHooks(
+                    beforeProcessingProviderEvent: nil,
+                    providerEventDisposition: nil,
+                    teardownCompleted: nil,
+                    resolveMCPFollowUpModel: { _ in
+                        (
+                            model: .customProvider(
+                                name: "Unconfigured test provider",
+                                provider: "custom",
+                                model: "unconfigured-test-model"
+                            ),
+                            chatPresetID: nil,
+                            mcpControlInfo: nil
+                        )
+                    }
+                )
+            )
+        }
+
+        private func makeTemporaryRoot(label: String) -> URL {
+            let root = FileManager.default.temporaryDirectory
+                .appendingPathComponent("ContextBuilderStrictFinalizationTests-\(label)-\(UUID().uuidString)")
+            try? FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            return root
+        }
+    #endif
+}

--- a/Tests/RepoPromptTests/MCP/MCPAskOracleWorktreeTests.swift
+++ b/Tests/RepoPromptTests/MCP/MCPAskOracleWorktreeTests.swift
@@ -2244,7 +2244,7 @@ import XCTest
                                         completionTokens: 92,
                                         cost: 93
                                     ),
-                                    isFinal: true,
+                                    terminalOutcome: .completed,
                                     cleanupHandle: ProviderConversationCleanupHandle(
                                         provider: "ignored",
                                         conversationID: "ignored"
@@ -2255,7 +2255,7 @@ import XCTest
                                     text: "transported oracle response",
                                     reasoning: nil,
                                     tokens: ChatTokenInfo(),
-                                    isFinal: true
+                                    terminalOutcome: .completed
                                 ))
                                 continuation.finish()
                             }


### PR DESCRIPTION
Context Builder was able to treat ordinary Oracle message finalization as successful provider completion, such that a clean EOF / incomplete provider termination / interactive watchdog could consequently return partial assistant content (including a waiting message) as the final plan, question, or review result.

This issue has been especially noticeable for longer CB runs, and would cause the agent to continuously cancel and redo the oracle call.

This patch gives response-producing Context Builder calls a strict, exact-query completion boundary while preserving ordinary interactive chat behavior.

## Summary

- Require authoritative provider completion before active or headless Context Builder calls succeed
- Distinguish successful completion, incomplete provider termination, clean EOF, watchdog finalization, cancellation, and failure
- Prevent Context Builder queries from being completed by interactive inactivity watchdogs
- Preserve partial or failed Oracle chats for inspection while keeping Context Builder in an error state
- Keep ordinary interactive chat usable by finalizing available partial content after incomplete termination
- Normalize successful and incomplete terminal reasons across OpenAI, OpenRouter, Anthropic, and Azure providers
- Remove post-send query lookup and post-wait message re-read races by returning the exact query ID and completed response directly

## Implementation Notes

- Completion policy is installed before streaming begins, so fast provider events cannot race strict-mode configuration
- Finalization outcomes are recorded first-write-wins per query and consumed by the strict Context Builder waiter
- Provider-specific terminal reasons are normalized at adapter boundaries; Oracle receives provider-neutral completed or incomplete outcomes
- Active and inactive-workspace paths apply the same semantic completion requirement, with persistence occurring only after strict success
- No ordinary MCP wait redesign, compatibility layer, or broader provider architecture migration was introduced

## Review Approach

- The staged patch received iterative maintainability and integration reviews covering provider terminal semantics, exact-query ownership, concurrency safety, interactive behavior, persistence, and test quality
- Review findings identified incomplete terminal gates, unchecked error transfer, interactive partial-content regressions, and unstable test assumptions; each was addressed with focused regression coverage
- Optional waiter refactoring and broader completion taxonomies were excluded to keep the contribution bounded

## Validation

Passed locally on the committed branch:

- `make dev-test FILTER=ProviderStreamCompletionTests`
- `make dev-test FILTER=ContextBuilderStrictFinalizationTests` — 4 tests
- `make dev-test FILTER=OracleMessageFinalisationHubTests` — 3 tests
- `make dev-lint`

## Live App Validation

- Built and launched the patched CE debug app with `make dev-run`
- Completed a real and lengthy (>12 mins duration) Codex-CLI GPT-5.6-backed `context_builder` review request over MCP
- The complete review returned normally without premature finalization, retrying, or restarting the app or MCP connection