### PR TITLE
Fix automatic Agent Mode tab eviction

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentSessionDataService.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentSessionDataService.swift
@@ -1380,8 +1380,8 @@ actor AgentSessionDataService {
             candidateFilesByPath[fileURL.path] = fileURL
         }
 
-        for fileURL in candidateFilesByPath.values {
-            try? await deleteSessionFileDurably(fileURL.standardizedFileURL)
+        for fileURL in candidateFilesByPath.values.sorted(by: { $0.path < $1.path }) {
+            try await deleteSessionFileDurably(fileURL.standardizedFileURL)
         }
         await removeMetadataRecords(matching: { $0.composeTabID == tabID }, folder: agentSessionsFolder)
     }

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/WorkspaceLifetime/AgentWorkspaceSessionIndexStore.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/WorkspaceLifetime/AgentWorkspaceSessionIndexStore.swift
@@ -36,8 +36,7 @@ protocol AgentWorkspaceSessionIndexStoreDelegate: AnyObject {
 
     /// Called when `sessionIndex`, `sessionListSortDates`, or
     /// `sessionListCacheReady` changes. The delegate dispatches to
-    /// `syncSidebarUIState` and `scheduleSidebarAutoArchiveIfReady` as
-    /// appropriate for the reason.
+    /// `syncSidebarUIState` as appropriate for the reason.
     func sessionIndexStore(
         _ store: AgentWorkspaceSessionIndexStore,
         didChangeStateWithReason reason: SessionIndexStateChangeReason

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+SidebarAutoArchive.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+SidebarAutoArchive.swift
@@ -2,73 +2,28 @@ import Foundation
 
 @MainActor
 extension AgentModeViewModel {
-    enum SidebarAutoArchiveReason: String, Equatable {
-        case sessionListReady
-        case sessionIndexChanged
-        case liveSessionSetChanged
-        case runProtectionChanged
-        case mcpProtectionChanged
-        case explicitTest
-    }
-
-    func scheduleSidebarAutoArchiveIfReady(reason: SidebarAutoArchiveReason) {
-        guard ownerValidatedSessionListCacheReady else { return }
-        scheduleSidebarAutoArchive(reason: reason)
-    }
-
-    func scheduleSidebarAutoArchive(reason: SidebarAutoArchiveReason) {
-        guard ownerValidatedSessionListCacheReady, canRunSidebarAutoArchive, !isApplyingSidebarAutoArchive else { return }
-        sidebarAutoArchiveTask?.cancel()
-        sidebarAutoArchiveTask = Task { [weak self] in
-            try? await Task.sleep(nanoseconds: 250_000_000)
-            guard !Task.isCancelled else { return }
-            await self?.performSidebarAutoArchiveIfNeeded(reason: reason)
-        }
-    }
-
-    @discardableResult
-    func performSidebarAutoArchiveIfNeeded(
-        reason: SidebarAutoArchiveReason,
-        now: Date = Date()
-    ) async -> Set<UUID> {
-        guard ownerValidatedSessionListCacheReady, canRunSidebarAutoArchive, !isApplyingSidebarAutoArchive else { return [] }
-        guard let promptManager,
+    /// Computes the legacy archive policy as a read-only suggestion. Callers must
+    /// not treat the decision as authorization to mutate tabs or sessions.
+    func sidebarAutoArchiveSuggestion(now: Date = Date()) -> AgentModeSidebarAutoArchivePolicy.Decision {
+        guard ownerValidatedSessionListCacheReady,
+              let promptManager,
               let workspaceID = workspaceManager?.activeWorkspace?.id,
-              let owner = sidebarAutoArchiveOwner(workspaceID: workspaceID)
+              sidebarAutoArchiveOwner(workspaceID: workspaceID) != nil
         else {
-            return []
+            return .empty(evaluatedSessionCount: 0)
         }
 
-        let openTabs = promptManager.currentComposeTabs
-        let sidebarRows = sidebarSessions(for: openTabs)
-        guard sidebarRows.count > sidebarAutoArchivePolicy.configuration.baseVisibleSessionLimit else { return [] }
+        let sidebarRows = sidebarSessions(for: promptManager.currentComposeTabs)
+        guard sidebarRows.count > sidebarAutoArchivePolicy.configuration.baseVisibleSessionLimit else {
+            return .empty(evaluatedSessionCount: sidebarRows.count)
+        }
 
-        let protectedTabIDs = sidebarAutoArchiveProtectedTabIDs(for: sidebarRows)
-
-        let decision = sidebarAutoArchivePolicy.decision(
+        return sidebarAutoArchivePolicy.decision(
             for: sidebarRows,
             currentTabID: currentTabID,
-            protectedTabIDs: protectedTabIDs,
+            protectedTabIDs: sidebarAutoArchiveProtectedTabIDs(for: sidebarRows),
             now: now
         )
-        guard !decision.tabIDsToArchive.isEmpty else { return [] }
-
-        isApplyingSidebarAutoArchive = true
-        defer { isApplyingSidebarAutoArchive = false }
-
-        let archivedTabIDs = await promptManager.autoArchiveComposeTabsForSidebarPolicy(
-            withIDs: decision.tabIDsToArchive,
-            expectedWorkspaceID: workspaceID,
-            isArchiveContextCurrent: { [weak self] in
-                guard !Task.isCancelled, let self else { return false }
-                return sidebarAutoArchiveOwner(workspaceID: workspaceID) == owner
-            }
-        )
-        guard sidebarAutoArchiveOwner(workspaceID: workspaceID) == owner else { return [] }
-        if !archivedTabIDs.isEmpty {
-            syncSidebarUIState(refresh: true, reason: .sessionList)
-        }
-        return archivedTabIDs
     }
 
     func sidebarAutoArchiveProtectedTabIDs(for sidebarRows: [SidebarSession]) -> Set<UUID> {
@@ -76,11 +31,12 @@ extension AgentModeViewModel {
         if let currentTabID {
             protectedTabIDs.insert(currentTabID)
         }
+
         let currentIndex = ownerValidatedSessionIndex
         for row in sidebarRows {
             let persistedEntry = row.sessionID.flatMap { currentIndex[$0] }
                 ?? preferredSidebarEntry(for: row.tabID, tabName: row.title)
-            if !isComposeTabEligibleForAutomaticStash(row.tabID)
+            if isComposeTabProtectedFromSidebarArchiveSuggestion(row.tabID)
                 || row.isMCPControlled
                 || persistedEntry?.isMCPOriginated == true
                 || isProtectedPersistedRunState(persistedEntry?.lastRunStateRaw)

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+SidebarUI.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+SidebarUI.swift
@@ -299,7 +299,7 @@ extension AgentModeViewModel {
     }
 
     /// Remove observed-state entries and pending attention badges for tabs
-    /// that are going away. Called from `handleComposeTabsWillClose(...)`.
+    /// that were removed. Called from `handleComposeTabsDidRemove(...)`.
     func cleanupSidebarRunAttention(tabIDs: Set<UUID>) {
         guard !tabIDs.isEmpty else { return }
         for tabID in tabIDs {

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -685,6 +685,7 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         var test_sidebarSessionRowsBuildCount = 0
         var test_sidebarListProjectionBuildCount = 0
         private var test_afterMCPStoreEpochBegan: (@MainActor () async -> Void)?
+        private var test_composeTabRemovalTeardownObserver: (@MainActor (UUID) -> Void)?
         private var test_terminalPublicationOverride: ((
             AgentRunTerminalCommitRevision,
             AgentRunEpochTransitionKind?,
@@ -722,6 +723,10 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
 
         func test_setAgentSessionsDeleter(_ deleter: @escaping AgentSessionsDeleter) {
             agentSessionsDeleter = deleter
+        }
+
+        func test_setComposeTabRemovalTeardownObserver(_ observer: @escaping @MainActor (UUID) -> Void) {
+            test_composeTabRemovalTeardownObserver = observer
         }
 
         var test_codexCoordinator: CodexAgentModeCoordinator {
@@ -2359,8 +2364,7 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
             }
             .store(in: &cancellables)
 
-        // Required persistence is a vetoable preflight; destructive AgentMode cleanup
-        // runs only after it succeeds and can veto Prompt projection removal on deletion failure.
+        // Required persistence is the only vetoable removal phase.
         listeners.addToken(
             promptManager.setComposeTabsRemovalPreflight { [weak self] tabIDs, reason, workspaceID in
                 guard let self else { return .proceed }
@@ -2370,12 +2374,12 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
             promptManager?.removeComposeTabsRemovalPreflight(token)
         }
         listeners.addToken(
-            promptManager.setComposeTabsRemovalPreparation { [weak self] tabIDs, reason, workspaceID in
-                guard let self else { return .proceed }
-                return await handleComposeTabsWillClose(tabIDs, reason: reason, workspaceID: workspaceID)
+            promptManager.addComposeTabsDidRemoveListener { [weak self] tabIDs, reason, workspaceID in
+                guard let self else { return }
+                await handleComposeTabsDidRemove(tabIDs, reason: reason, workspaceID: workspaceID)
             }
         ) { [weak promptManager] token in
-            promptManager?.removeComposeTabsRemovalPreparation(token)
+            promptManager?.removeComposeTabsDidRemoveListener(token)
         }
 
         // Observe workspace changes
@@ -11124,20 +11128,23 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         return .proceed
     }
 
-    @discardableResult
-    func handleComposeTabsWillClose(
+    func handleComposeTabsDidRemove(
         _ tabIDs: Set<UUID>,
         reason: PromptViewModel.ComposeTabRemovalReason,
         workspaceID: UUID? = nil
-    ) async -> PromptViewModel.ComposeTabRemovalDecision {
+    ) async {
         let removalWorkspace = workspaceID.flatMap { workspaceID in
             workspaceManager?.workspaces.first(where: { $0.id == workspaceID })
         } ?? workspaceManager?.activeWorkspace
 
+        let orderedTabIDs = tabIDs.sorted(by: { $0.uuidString < $1.uuidString })
         // Drop any sidebar attention / observed run-state for tabs that are
         // going away so we don't leave dangling entries referring to dead IDs.
         cleanupSidebarRunAttention(tabIDs: tabIDs)
-        for tabID in tabIDs {
+        for tabID in orderedTabIDs {
+            #if DEBUG
+                test_composeTabRemovalTeardownObserver?(tabID)
+            #endif
             let boundID = boundSessionID(for: tabID)
             if let session = sessions[tabID] {
                 removePendingUIRefresh(for: tabID)
@@ -11178,9 +11185,7 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
                     do {
                         try await agentSessionsDeleter(tabID, workspace)
                     } catch {
-                        let message = String(describing: error)
-                        print("[AgentModeVM] Failed to delete session data: \(message)")
-                        return .abort(.init(stage: .durableSessionDeletion, tabID: tabID, message: message))
+                        print("[AgentModeVM] Failed to delete removed tab session data for \(tabID): \(error)")
                     }
                 }
                 removeSessionIndex(forTabID: tabID)
@@ -11193,9 +11198,7 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
                     do {
                         try await agentSessionsDeleter(tabID, workspace)
                     } catch {
-                        let message = String(describing: error)
-                        print("[AgentModeVM] Failed to delete session data: \(message)")
-                        return .abort(.init(stage: .durableSessionDeletion, tabID: tabID, message: message))
+                        print("[AgentModeVM] Failed to delete removed stashed session data for \(tabID): \(error)")
                     }
                 }
                 removeSessionIndex(forTabID: tabID)
@@ -11207,12 +11210,11 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
             #if DEBUG
                 AgentModePerfDiagnostics.markSidebarDeleteAgentCleanupComplete(
                     tabID: tabID,
-                    source: "AgentModeViewModel.handleComposeTabsWillClose",
+                    source: "AgentModeViewModel.handleComposeTabsDidRemove",
                     fields: ["reason": String(describing: reason)]
                 )
             #endif
         }
-        return .proceed
     }
 
     // MARK: - Persistence

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -472,7 +472,6 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
     @Published private(set) var sessions: [UUID: TabSession] = [:] {
         didSet {
             syncSidebarUIState(refresh: true, reason: .sessionList)
-            scheduleSidebarAutoArchiveIfReady(reason: .liveSessionSetChanged)
         }
     }
 
@@ -533,7 +532,6 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
     @Published private(set) var tabsWithActiveAgentRun: Set<UUID> = [] {
         didSet {
             syncSidebarUIState(refresh: true, reason: .runState)
-            scheduleSidebarAutoArchiveIfReady(reason: .runProtectionChanged)
         }
     }
 
@@ -543,7 +541,6 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         didSet {
             syncSidebarUIState(refresh: true, reason: .mcpControl)
             syncComposerUIState()
-            scheduleSidebarAutoArchiveIfReady(reason: .mcpProtectionChanged)
         }
     }
 
@@ -623,10 +620,48 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
     private var activeSessionIndexRefreshPrioritizedEntries: [UUID: AgentSessionIndexEntry] = [:]
     private var activeSessionIndexRefreshFullEntries: [UUID: AgentSessionIndexEntry] = [:]
     private var activeSessionIndexRefreshHasPublishedFullBatch = false
+    struct AgentSessionPersistenceFailure: Error, Equatable {
+        enum Operation: String, Equatable {
+            case save
+            case delete
+        }
+
+        let operation: Operation
+        let tabID: UUID
+        let message: String
+    }
+
+    private enum AgentSessionSaveResult {
+        case saved
+        case notRequired
+        case deferred(String)
+        case failed(AgentSessionPersistenceFailure)
+    }
+
+    typealias AgentSessionSaver = @MainActor (
+        _ session: AgentSession,
+        _ workspace: WorkspaceModel,
+        _ canonicalItemCount: Int
+    ) async throws -> URL
+    typealias AgentSessionsDeleter = @MainActor (_ tabID: UUID, _ workspace: WorkspaceModel) async throws -> Void
+
     private var saveInFlightSessionIDs: Set<UUID> = []
     private var saveRequestedWhileInFlightSessionIDs: Set<UUID> = []
-    var sidebarAutoArchiveTask: Task<Void, Never>?
-    var isApplyingSidebarAutoArchive = false
+    private var saveCompletionWaitersBySessionID: [UUID: [CheckedContinuation<Void, Never>]] = [:]
+    private var bypassesAgentSessionPersistenceSuppressionForTesting = false
+    private var agentSessionSaver: AgentSessionSaver = { session, workspace, canonicalItemCount in
+        try await AgentSessionDataService.shared.saveAgentSession(
+            session,
+            for: workspace,
+            preparation: .alreadyCanonicalTranscript,
+            trustedCanonicalItemCount: canonicalItemCount
+        )
+    }
+
+    private var agentSessionsDeleter: AgentSessionsDeleter = { tabID, workspace in
+        try await AgentSessionDataService.shared.deleteAgentSessions(forComposeTabID: tabID, for: workspace)
+    }
+
     let sidebarAutoArchivePolicy = AgentModeSidebarAutoArchivePolicy()
     private var initialSystemWorkspaceSessionListRefreshDeferralReason: String?
     private var initialSystemWorkspaceSessionListRefreshDeferralFallbackTask: Task<Void, Never>?
@@ -680,6 +715,15 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
             dataService
         }
 
+        func test_setAgentSessionSaver(_ saver: @escaping AgentSessionSaver) {
+            bypassesAgentSessionPersistenceSuppressionForTesting = true
+            agentSessionSaver = saver
+        }
+
+        func test_setAgentSessionsDeleter(_ deleter: @escaping AgentSessionsDeleter) {
+            agentSessionsDeleter = deleter
+        }
+
         var test_codexCoordinator: CodexAgentModeCoordinator {
             codexCoordinator
         }
@@ -716,10 +760,6 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         ) {
             self.promptManager = promptManager
             self.workspaceManager = workspaceManager
-        }
-
-        func test_setSidebarAutoArchiveActive(_ isActive: Bool) {
-            isAgentModeActive = isActive
         }
 
         func test_setAllowsScheduledDerivedTranscriptRefreshWithoutPromptManager(_ value: Bool) {
@@ -978,13 +1018,6 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
             )
         }
     #endif
-
-    var canRunSidebarAutoArchive: Bool {
-        isAgentModeActive
-            && !workspaceSwitchInFlight
-            && workspaceManager?.isSwitchingWorkspace != true
-            && !hasPreparedForWindowClose
-    }
 
     var sidebarContentFingerprintTabs: [ComposeTabState] {
         promptManager?.currentComposeTabs ?? workspaceManager?.activeWorkspace?.composeTabs ?? []
@@ -1812,7 +1845,6 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         skillCatalogRefreshDebounceTask?.cancel()
         initialSystemWorkspaceSessionListRefreshDeferralFallbackTask?.cancel()
         sessionListCacheTask?.cancel()
-        sidebarAutoArchiveTask?.cancel()
         sessionListCacheGeneration &+= 1
     }
 
@@ -2327,14 +2359,23 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
             }
             .store(in: &cancellables)
 
-        // Register for tab-close events
+        // Required persistence is a vetoable preflight; destructive AgentMode cleanup
+        // runs only after it succeeds and can veto Prompt projection removal on deletion failure.
         listeners.addToken(
-            promptManager.addComposeTabsWillCloseListener { [weak self] tabIDs, reason in
-                guard let self else { return }
-                await handleComposeTabsWillClose(tabIDs, reason: reason)
+            promptManager.setComposeTabsRemovalPreflight { [weak self] tabIDs, reason, workspaceID in
+                guard let self else { return .proceed }
+                return await preflightComposeTabsRemoval(tabIDs, reason: reason, workspaceID: workspaceID)
             }
         ) { [weak promptManager] token in
-            promptManager?.removeComposeTabsWillCloseListener(token)
+            promptManager?.removeComposeTabsRemovalPreflight(token)
+        }
+        listeners.addToken(
+            promptManager.setComposeTabsRemovalPreparation { [weak self] tabIDs, reason, workspaceID in
+                guard let self else { return .proceed }
+                return await handleComposeTabsWillClose(tabIDs, reason: reason, workspaceID: workspaceID)
+            }
+        ) { [weak promptManager] token in
+            promptManager?.removeComposeTabsRemovalPreparation(token)
         }
 
         // Observe workspace changes
@@ -2404,10 +2445,6 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
     }
 
     private func installPromptManagerCascadeResolvers(_ promptManager: PromptViewModel) {
-        promptManager.composeTabAutoStashEligibilityProvider = { [weak self] tabID in
-            guard let self else { return true }
-            return isComposeTabEligibleForAutomaticStash(tabID)
-        }
         promptManager.composeTabCascadeResolver = { [weak self] tabIDs, reason in
             guard let self else { return .init() }
             return await MainActor.run {
@@ -2422,20 +2459,20 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         }
     }
 
-    func isComposeTabEligibleForAutomaticStash(_ tabID: UUID) -> Bool {
+    func isComposeTabProtectedFromSidebarArchiveSuggestion(_ tabID: UUID) -> Bool {
         guard let session = sessions[tabID] else { return true }
-        guard !session.runState.isActive else { return false }
-        guard !tabsWithActiveAgentRun.contains(tabID) else { return false }
-        guard session.mcpControlContext == nil else { return false }
-        guard !session.hasPendingQuestionUI else { return false }
-        guard session.pendingApproval == nil else { return false }
-        guard session.pendingPermissionsRequest == nil else { return false }
-        guard session.pendingMCPElicitationRequest == nil else { return false }
-        guard session.pendingApplyEditsReview == nil else { return false }
-        guard session.pendingUserInputRequest == nil else { return false }
-        guard session.waitingPrompt == nil else { return false }
-        guard session.instructionContinuation == nil else { return false }
-        return true
+        if session.runState.isActive { return true }
+        if tabsWithActiveAgentRun.contains(tabID) { return true }
+        if session.mcpControlContext != nil { return true }
+        if session.hasPendingQuestionUI { return true }
+        if session.pendingApproval != nil { return true }
+        if session.pendingPermissionsRequest != nil { return true }
+        if session.pendingMCPElicitationRequest != nil { return true }
+        if session.pendingApplyEditsReview != nil { return true }
+        if session.pendingUserInputRequest != nil { return true }
+        if session.waitingPrompt != nil { return true }
+        if session.instructionContinuation != nil { return true }
+        return false
     }
 
     private func sessionTreeCascadePlan(
@@ -2766,8 +2803,6 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
             claudeCoordinator.stop()
             stopOpenCodeModelsSubscription()
             stopCursorModelsSubscription()
-            sidebarAutoArchiveTask?.cancel()
-            sidebarAutoArchiveTask = nil
             cancelSessionIndexRefresh(releaseFrozenOrder: true)
             return
         }
@@ -2819,8 +2854,6 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         unregisterObserverRegistrations()
         stopOpenCodeModelsSubscription()
         stopCursorModelsSubscription()
-        sidebarAutoArchiveTask?.cancel()
-        sidebarAutoArchiveTask = nil
         uiRefreshTask?.cancel()
         uiRefreshTask = nil
         pendingUIRefreshScopesByTabID.removeAll()
@@ -10439,8 +10472,6 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         }
         stopOpenCodeModelsSubscription()
         stopCursorModelsSubscription()
-        sidebarAutoArchiveTask?.cancel()
-        sidebarAutoArchiveTask = nil
         uiRefreshTask?.cancel()
         uiRefreshTask = nil
         pendingUIRefreshScopesByTabID.removeAll()
@@ -10988,7 +11019,6 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         activeSessionIndexRefreshHasPublishedFullBatch = false
         sessionIndexStore.setSessionListCacheReady(true, for: token.owner)
         sessionIndexStore.releaseSidebarRestoreFrozenOrder(for: token.owner)
-        scheduleSidebarAutoArchive(reason: .sessionListReady)
     }
 
     private func applySidebarIndexFailure(token: SessionIndexRefreshToken) {
@@ -11067,10 +11097,43 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         return true
     }
 
+    func preflightComposeTabsRemoval(
+        _ tabIDs: Set<UUID>,
+        reason _: PromptViewModel.ComposeTabRemovalReason,
+        workspaceID: UUID
+    ) async -> PromptViewModel.ComposeTabRemovalDecision {
+        guard workspaceManager?.workspaces.contains(where: { $0.id == workspaceID }) == true else {
+            return .abort(.init(
+                stage: .requiredSessionFlush,
+                tabID: nil,
+                message: "The owning workspace changed before required session persistence."
+            ))
+        }
+        for tabID in tabIDs.sorted(by: { $0.uuidString < $1.uuidString }) {
+            switch await flushSaveRequired(for: tabID, workspaceID: workspaceID) {
+            case .success:
+                continue
+            case let .failure(failure):
+                return .abort(.init(
+                    stage: .requiredSessionFlush,
+                    tabID: tabID,
+                    message: failure.message
+                ))
+            }
+        }
+        return .proceed
+    }
+
+    @discardableResult
     func handleComposeTabsWillClose(
         _ tabIDs: Set<UUID>,
-        reason: PromptViewModel.ComposeTabRemovalReason
-    ) async {
+        reason: PromptViewModel.ComposeTabRemovalReason,
+        workspaceID: UUID? = nil
+    ) async -> PromptViewModel.ComposeTabRemovalDecision {
+        let removalWorkspace = workspaceID.flatMap { workspaceID in
+            workspaceManager?.workspaces.first(where: { $0.id == workspaceID })
+        } ?? workspaceManager?.activeWorkspace
+
         // Drop any sidebar attention / observed run-state for tabs that are
         // going away so we don't leave dangling entries referring to dead IDs.
         cleanupSidebarRunAttention(tabIDs: tabIDs)
@@ -11098,9 +11161,6 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
                 await cleanupACPStateForDeletedSession(session)
                 await codexCoordinator.shutdownCodexSession(session)
                 await claudeCoordinator.shutdownClaudeSession(session)
-
-                // Flush save before deleting backing file
-                await flushSave(for: tabID)
             }
             await cleanupMCPRunRoutingIfPresent(
                 boundSessionID: boundID,
@@ -11114,8 +11174,14 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
                 sessions.removeValue(forKey: tabID)
                 tabsWithActiveAgentRun.remove(tabID)
             case .close:
-                if let workspace = workspaceManager?.activeWorkspace {
-                    try? await dataService.deleteAgentSessions(forComposeTabID: tabID, for: workspace)
+                if let workspace = removalWorkspace {
+                    do {
+                        try await agentSessionsDeleter(tabID, workspace)
+                    } catch {
+                        let message = String(describing: error)
+                        print("[AgentModeVM] Failed to delete session data: \(message)")
+                        return .abort(.init(stage: .durableSessionDeletion, tabID: tabID, message: message))
+                    }
                 }
                 removeSessionIndex(forTabID: tabID)
                 tabDraftText.removeValue(forKey: tabID)
@@ -11123,8 +11189,14 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
                 sessions.removeValue(forKey: tabID)
                 tabsWithActiveAgentRun.remove(tabID)
             case .deleteStashed:
-                if let workspace = workspaceManager?.activeWorkspace {
-                    try? await dataService.deleteAgentSessions(forComposeTabID: tabID, for: workspace)
+                if let workspace = removalWorkspace {
+                    do {
+                        try await agentSessionsDeleter(tabID, workspace)
+                    } catch {
+                        let message = String(describing: error)
+                        print("[AgentModeVM] Failed to delete session data: \(message)")
+                        return .abort(.init(stage: .durableSessionDeletion, tabID: tabID, message: message))
+                    }
                 }
                 removeSessionIndex(forTabID: tabID)
                 tabDraftText.removeValue(forKey: tabID)
@@ -11140,6 +11212,7 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
                 )
             #endif
         }
+        return .proceed
     }
 
     // MARK: - Persistence
@@ -11250,42 +11323,55 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         scheduleSave(for: tabID)
     }
 
-    private func saveSession(for tabID: UUID) async {
+    @discardableResult
+    private func saveSession(for tabID: UUID) async -> AgentSessionSaveResult {
         #if DEBUG
             let diagnosticsStartMS = AgentModePerfDiagnostics.timestampMSIfEnabled()
             AgentModePerfDiagnostics.increment("save.session.invoked", tabID: tabID)
         #endif
-        guard !AppLaunchConfiguration.current.suppressesAgentSessionPersistence else {
+        guard !AppLaunchConfiguration.current.suppressesAgentSessionPersistence
+            || bypassesAgentSessionPersistenceSuppressionForTesting
+        else {
             #if DEBUG
                 AgentModePerfDiagnostics.event("save.session.skipped", tabID: tabID, fields: ["reason": "suppressed"])
             #endif
-            return
+            return .notRequired
         }
-        guard let session = sessions[tabID],
-              let workspace = workspaceManager?.activeWorkspace,
-              session.isDirty || session.activeAgentSessionID == nil
-        else {
+        guard let session = sessions[tabID] else {
             #if DEBUG
-                AgentModePerfDiagnostics.event("save.session.skipped", tabID: tabID, fields: ["reason": "missingOrClean"])
+                AgentModePerfDiagnostics.event("save.session.skipped", tabID: tabID, fields: ["reason": "missing"])
             #endif
-            return
+            return .notRequired
+        }
+        guard session.isDirty || session.activeAgentSessionID == nil else {
+            #if DEBUG
+                AgentModePerfDiagnostics.event("save.session.skipped", tabID: tabID, fields: ["reason": "clean"])
+            #endif
+            return .notRequired
+        }
+        guard let workspace = workspaceManager?.activeWorkspace else {
+            return .failed(.init(operation: .save, tabID: tabID, message: "Active workspace is unavailable."))
         }
 
         let hasConversationContent = !session.items.isEmpty || !session.transcript.turns.isEmpty || session.runState.isActive || session.hasPendingQuestionUI || session.pendingApproval != nil || session.pendingPermissionsRequest != nil || session.pendingApplyEditsReview != nil || session.pendingWorktreeMergeReview != nil || session.worktreeMergeOperations.contains { $0.status.isActive }
         if session.activeAgentSessionID == nil, !hasConversationContent {
-            return
+            return .notRequired
         }
         guard let sessionID = ensureSessionBoundToTab(session) else {
-            return
+            return .failed(.init(operation: .save, tabID: tabID, message: "A required session binding could not be established."))
         }
         session.saveRequestGeneration &+= 1
         if saveInFlightSessionIDs.contains(sessionID) {
             saveRequestedWhileInFlightSessionIDs.insert(sessionID)
-            return
+            return .deferred("A save for this session is already in flight.")
         }
         saveInFlightSessionIDs.insert(sessionID)
         defer {
             saveInFlightSessionIDs.remove(sessionID)
+            let completionWaiters = saveCompletionWaitersBySessionID.removeValue(forKey: sessionID) ?? []
+            for waiter in completionWaiters {
+                waiter.resume()
+            }
             if saveRequestedWhileInFlightSessionIDs.remove(sessionID) != nil {
                 if let currentOwner = try? authoritativeLiveSession(for: sessionID) {
                     scheduleSave(for: currentOwner.tabID)
@@ -11506,20 +11592,15 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
               isSaveCommitTokenCurrent(saveToken)
         else {
             requestFreshSaveForCurrentOwner(sessionID: sessionID, fallbackSession: session)
-            return
+            return .deferred("The session binding changed before persistence could commit.")
         }
 
         do {
-            let fileURL = try await dataService.saveAgentSession(
-                agentSession,
-                for: workspace,
-                preparation: .alreadyCanonicalTranscript,
-                trustedCanonicalItemCount: canonicalItemCount
-            )
+            let fileURL = try await agentSessionSaver(agentSession, workspace, canonicalItemCount)
             agentSession.fileURL = fileURL
             guard isSaveCommitTokenCurrent(saveToken) else {
                 requestFreshSaveForCurrentOwner(sessionID: sessionID, fallbackSession: session)
-                return
+                return .deferred("The session changed while persistence was committing.")
             }
             session.isDirty = false
             session.lastUserMessageAt = lastUserMessageAt
@@ -11557,18 +11638,86 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
                     )
                 }
             #endif
+            return .saved
         } catch {
             #if DEBUG
                 AgentModePerfDiagnostics.event("save.session.error", tabID: tabID, fields: ["error": String(describing: error)])
             #endif
-            print("[AgentModeVM] Failed to save session: \(error)")
+            let failure = AgentSessionPersistenceFailure(
+                operation: .save,
+                tabID: tabID,
+                message: String(describing: error)
+            )
+            print("[AgentModeVM] Failed to save session: \(failure.message)")
+            return .failed(failure)
+        }
+    }
+
+    private func waitForInFlightSave(sessionID: UUID) async {
+        guard saveInFlightSessionIDs.contains(sessionID) else { return }
+        await withCheckedContinuation { continuation in
+            guard saveInFlightSessionIDs.contains(sessionID) else {
+                continuation.resume()
+                return
+            }
+            saveCompletionWaitersBySessionID[sessionID, default: []].append(continuation)
         }
     }
 
     func flushSave(for tabID: UUID) async {
         guard let session = sessions[tabID] else { return }
         session.saveDebounceTask?.cancel()
-        await saveSession(for: tabID)
+        _ = await saveSession(for: tabID)
+    }
+
+    private func flushSaveRequired(
+        for tabID: UUID,
+        workspaceID: UUID
+    ) async -> Result<Void, AgentSessionPersistenceFailure> {
+        guard let capturedSession = sessions[tabID] else { return .success(()) }
+        let capturedBinding = capturedSession.persistentSessionBindingIdentity
+        capturedSession.saveDebounceTask?.cancel()
+
+        if let sessionID = capturedSession.activeAgentSessionID {
+            while saveInFlightSessionIDs.contains(sessionID) {
+                await waitForInFlightSave(sessionID: sessionID)
+            }
+        }
+
+        guard workspaceManager?.activeWorkspace?.id == workspaceID else {
+            return .failure(.init(
+                operation: .save,
+                tabID: tabID,
+                message: "The owning workspace changed during required persistence."
+            ))
+        }
+        guard sessions[tabID] === capturedSession,
+              capturedSession.persistentSessionBindingIdentity == capturedBinding
+        else {
+            return .failure(.init(
+                operation: .save,
+                tabID: tabID,
+                message: "The live session owner changed during required persistence."
+            ))
+        }
+
+        switch await saveSession(for: tabID) {
+        case .saved:
+            guard !capturedSession.isDirty else {
+                return .failure(.init(
+                    operation: .save,
+                    tabID: tabID,
+                    message: "The session changed while required persistence was committing."
+                ))
+            }
+            return .success(())
+        case .notRequired:
+            return .success(())
+        case let .deferred(message):
+            return .failure(.init(operation: .save, tabID: tabID, message: message))
+        case let .failed(failure):
+            return .failure(failure)
+        }
     }
 
     private func persistCurrentSession() {
@@ -16583,13 +16732,16 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
     @discardableResult
     func createAndActivateSessionTab() async -> UUID? {
         guard let promptManager else { return nil }
-        await promptManager.createBlankComposeTab(createAgentSession: true)
-        guard let tabID = currentTabID else { return nil }
-        let session = session(for: tabID)
+        guard case let .created(createdTab) = await promptManager.createBlankComposeTab(createAgentSession: true) else {
+            return nil
+        }
+        let session = session(for: createdTab.id)
         markSessionAsFreshlyCreated(session)
         invalidateSidebarRestoreOrdering()
-        updateBindingsFromSession(session)
-        return tabID
+        if currentTabID == createdTab.id {
+            updateBindingsFromSession(session)
+        }
+        return createdTab.id
     }
 
     // MARK: - Session Handoff
@@ -16966,7 +17118,6 @@ extension AgentModeViewModel: AgentWorkspaceSessionIndexStoreDelegate {
         switch reason {
         case .sessionIndex:
             syncSidebarUIState(refresh: true, reason: .sessionIndex)
-            scheduleSidebarAutoArchiveIfReady(reason: .sessionIndexChanged)
         case .sortDates:
             syncSidebarUIState(refresh: true, reason: .sortDates)
         case .sessionList:

--- a/Sources/RepoPrompt/Features/Prompt/ViewModels/PromptViewModel.swift
+++ b/Sources/RepoPrompt/Features/Prompt/ViewModels/PromptViewModel.swift
@@ -173,7 +173,6 @@ class PromptViewModel: ObservableObject {
 
     enum ComposeTabRemovalFailureStage: String, Equatable {
         case requiredSessionFlush
-        case durableSessionDeletion
     }
 
     struct ComposeTabRemovalFailure: Error, Equatable {
@@ -193,6 +192,11 @@ class PromptViewModel: ObservableObject {
     }
 
     typealias ComposeTabsWillCloseListener = @Sendable (_ tabIDs: Set<UUID>, _ reason: ComposeTabRemovalReason) async -> Void
+    typealias ComposeTabsDidRemoveListener = @MainActor @Sendable (
+        _ tabIDs: Set<UUID>,
+        _ reason: ComposeTabRemovalReason,
+        _ workspaceID: UUID
+    ) async -> Void
     typealias ComposeTabsRemovalHook = @MainActor @Sendable (
         _ tabIDs: Set<UUID>,
         _ reason: ComposeTabRemovalReason,
@@ -201,8 +205,8 @@ class PromptViewModel: ObservableObject {
     typealias ComposeTabCascadeResolver = @Sendable (_ tabIDs: Set<UUID>, _ reason: ComposeTabRemovalReason) async -> AgentSessionCascadePlan
     typealias StashedTabCascadeResolver = @Sendable (_ stashedTabIDs: Set<UUID>) async -> AgentSessionCascadePlan
     private var composeTabsWillCloseListeners: [UUID: ComposeTabsWillCloseListener] = [:]
+    private var composeTabsDidRemoveListeners: [UUID: ComposeTabsDidRemoveListener] = [:]
     private var composeTabsRemovalPreflight: (token: UUID, hook: ComposeTabsRemovalHook)?
-    private var composeTabsRemovalPreparation: (token: UUID, hook: ComposeTabsRemovalHook)?
     var composeTabCascadeResolver: ComposeTabCascadeResolver?
     var stashedTabCascadeResolver: StashedTabCascadeResolver?
 
@@ -2417,16 +2421,15 @@ class PromptViewModel: ObservableObject {
     }
 
     @MainActor
-    func setComposeTabsRemovalPreparation(_ hook: @escaping ComposeTabsRemovalHook) -> UUID {
+    func addComposeTabsDidRemoveListener(_ listener: @escaping ComposeTabsDidRemoveListener) -> UUID {
         let token = UUID()
-        composeTabsRemovalPreparation = (token, hook)
+        composeTabsDidRemoveListeners[token] = listener
         return token
     }
 
     @MainActor
-    func removeComposeTabsRemovalPreparation(_ token: UUID) {
-        guard composeTabsRemovalPreparation?.token == token else { return }
-        composeTabsRemovalPreparation = nil
+    func removeComposeTabsDidRemoveListener(_ token: UUID) {
+        composeTabsDidRemoveListeners.removeValue(forKey: token)
     }
 
     @MainActor
@@ -2440,13 +2443,14 @@ class PromptViewModel: ObservableObject {
     }
 
     @MainActor
-    private func prepareComposeTabsRemoval(
+    private func notifyComposeTabsDidRemove(
         _ tabIDs: Set<UUID>,
         reason: ComposeTabRemovalReason,
         workspaceID: UUID
-    ) async -> ComposeTabRemovalDecision {
-        guard let hook = composeTabsRemovalPreparation?.hook else { return .proceed }
-        return await hook(tabIDs, reason, workspaceID)
+    ) async {
+        for listener in Array(composeTabsDidRemoveListeners.values) {
+            await listener(tabIDs, reason, workspaceID)
+        }
     }
 
     @MainActor
@@ -2470,6 +2474,29 @@ class PromptViewModel: ObservableObject {
                 }
             }
         }
+    }
+
+    @MainActor
+    private func runPostProjectionComposeTabCleanup(
+        _ tabIDs: Set<UUID>,
+        reason: ComposeTabRemovalReason,
+        workspaceID: UUID
+    ) async {
+        if reason != .stash {
+            deleteGitDataForClosingTabs(tabIDs: tabIDs)
+        }
+        await notifyComposeTabsWillClose(tabIDs, reason: reason)
+        await cleanupMCPStateForClosingTabs(tabIDs)
+        await notifyComposeTabsDidRemove(tabIDs, reason: reason, workspaceID: workspaceID)
+        #if DEBUG
+            for tabID in tabIDs {
+                AgentModePerfDiagnostics.markSidebarDeleteFullCleanupComplete(
+                    tabID: tabID,
+                    source: "PromptViewModel.runPostProjectionComposeTabCleanup",
+                    fields: ["reason": String(describing: reason)]
+                )
+            }
+        #endif
     }
 
     @MainActor
@@ -2887,38 +2914,6 @@ class PromptViewModel: ObservableObject {
         {
             flushAndSnapshotActiveTab(in: manager, workspaceIndex: index)
         }
-        switch await prepareComposeTabsRemoval(
-            tabsBeingClosed,
-            reason: reason,
-            workspaceID: workspace.id
-        ) {
-        case .proceed:
-            break
-        case let .abort(failure):
-            logComposeTabRemovalAbort(failure)
-            return
-        }
-        guard mutationOwnerIsCurrent() else { return }
-
-        // Non-vetoing feature cleanup runs only after required AgentMode preparation succeeds.
-        await notifyComposeTabsWillClose(tabsBeingClosed, reason: reason)
-        guard mutationOwnerIsCurrent() else { return }
-        await cleanupMCPStateForClosingTabs(tabsBeingClosed)
-        guard mutationOwnerIsCurrent() else { return }
-        #if DEBUG
-            for tabID in tabsBeingClosed {
-                AgentModePerfDiagnostics.markSidebarDeleteFullCleanupComplete(
-                    tabID: tabID,
-                    source: "PromptViewModel.closeComposeTabs.closeListenersAndMCP",
-                    fields: ["reason": String(describing: reason)]
-                )
-            }
-        #endif
-
-        if reason == .close {
-            deleteGitDataForClosingTabs(tabIDs: tabsBeingClosed)
-        }
-
         if reason == .stash {
             let refreshedTabs = manager.workspaces[index].composeTabs
             for tabID in tabsBeingClosed {
@@ -2960,6 +2955,7 @@ class PromptViewModel: ObservableObject {
             #endif
             manager.markWorkspaceDirty()
             manager.pollAndSaveState()
+            await runPostProjectionComposeTabCleanup(tabsBeingClosed, reason: reason, workspaceID: workspace.id)
             if reason == .close, expandCascade, !stashedTabIDsToDelete.isEmpty {
                 await deleteStashedTabs(withIDs: stashedTabIDsToDelete, expandCascade: false)
             }
@@ -3007,6 +3003,7 @@ class PromptViewModel: ObservableObject {
         #endif
         manager.markWorkspaceDirty()
         manager.pollAndSaveState()
+        await runPostProjectionComposeTabCleanup(tabsBeingClosed, reason: reason, workspaceID: workspace.id)
         if reason == .close, expandCascade, !stashedTabIDsToDelete.isEmpty {
             await deleteStashedTabs(withIDs: stashedTabIDsToDelete, expandCascade: false)
         }
@@ -3269,23 +3266,6 @@ class PromptViewModel: ObservableObject {
                     logComposeTabRemovalAbort(failure)
                     return
                 }
-                switch await prepareComposeTabsRemoval(
-                    composeTabIDsBeingDeleted,
-                    reason: .close,
-                    workspaceID: workspace.id
-                ) {
-                case .proceed:
-                    break
-                case let .abort(failure):
-                    logComposeTabRemovalAbort(failure)
-                    return
-                }
-                guard mutationOwnerIsCurrent() else { return }
-                await notifyComposeTabsWillClose(composeTabIDsBeingDeleted, reason: .close)
-                guard mutationOwnerIsCurrent() else { return }
-                await cleanupMCPStateForClosingTabs(composeTabIDsBeingDeleted)
-                guard mutationOwnerIsCurrent() else { return }
-                deleteGitDataForClosingTabs(tabIDs: composeTabIDsBeingDeleted)
                 var remainingComposeTabs = composeTabsBeforeDelete
                 remainingComposeTabs.removeAll { composeTabIDsBeingDeleted.contains($0.id) }
                 dirtyTabIDs.subtract(composeTabIDsBeingDeleted)
@@ -3323,6 +3303,14 @@ class PromptViewModel: ObservableObject {
                         activeComposeTabID = newActiveID
                     }
                 }
+                loadComposeTabsFromWorkspace(manager.workspaces[index])
+                manager.markWorkspaceDirty()
+                manager.pollAndSaveState()
+                await runPostProjectionComposeTabCleanup(
+                    composeTabIDsBeingDeleted,
+                    reason: .close,
+                    workspaceID: workspace.id
+                )
             }
         }
 
@@ -3341,25 +3329,11 @@ class PromptViewModel: ObservableObject {
             logComposeTabRemovalAbort(failure)
             return
         }
-        switch await prepareComposeTabsRemoval(
-            tabIDs,
-            reason: .deleteStashed,
-            workspaceID: workspace.id
-        ) {
-        case .proceed:
-            break
-        case let .abort(failure):
-            logComposeTabRemovalAbort(failure)
-            return
-        }
-        guard mutationOwnerIsCurrent() else { return }
-        await notifyComposeTabsWillClose(tabIDs, reason: .deleteStashed)
-        guard mutationOwnerIsCurrent() else { return }
-        deleteGitDataForClosingTabs(tabIDs: tabIDs)
         manager.workspaces[index].stashedTabs.removeAll { resolvedStashedTabIDs.contains($0.id) }
         loadComposeTabsFromWorkspace(manager.workspaces[index])
         manager.markWorkspaceDirty()
         manager.pollAndSaveState()
+        await runPostProjectionComposeTabCleanup(tabIDs, reason: .deleteStashed, workspaceID: workspace.id)
     }
 
     @MainActor

--- a/Sources/RepoPrompt/Features/Prompt/ViewModels/PromptViewModel.swift
+++ b/Sources/RepoPrompt/Features/Prompt/ViewModels/PromptViewModel.swift
@@ -57,6 +57,10 @@ class PromptViewModel: ObservableObject {
         ) {
             automaticReviewGitDiffProviderOverrideForTesting = override
         }
+
+        func testSetDirtyTabIDs(_ tabIDs: Set<UUID>) {
+            dirtyTabIDs = tabIDs
+        }
     #endif
 
     // MARK: - Type Definitions and Enums
@@ -151,12 +155,7 @@ class PromptViewModel: ObservableObject {
     @Published private(set) var dirtyTabIDs: Set<UUID> = []
     @Published private(set) var isSwitchingComposeTab: Bool = false
     private var activeTabApplyTask: Task<Void, Never>?
-    private static let defaultComposeTabSoftLimit = 50
-    private let maxComposeTabs = PromptViewModel.defaultComposeTabSoftLimit
     private var isDirtyStateUpdateScheduled = false
-
-    typealias ComposeTabAutoStashEligibilityProvider = @MainActor (_ tabID: UUID) -> Bool
-    var composeTabAutoStashEligibilityProvider: ComposeTabAutoStashEligibilityProvider?
 
     // MARK: - Tab Close Listeners
 
@@ -172,16 +171,40 @@ class PromptViewModel: ObservableObject {
         var stashedTabIDs: Set<UUID> = []
     }
 
+    enum ComposeTabRemovalFailureStage: String, Equatable {
+        case requiredSessionFlush
+        case durableSessionDeletion
+    }
+
+    struct ComposeTabRemovalFailure: Error, Equatable {
+        let stage: ComposeTabRemovalFailureStage
+        let tabID: UUID?
+        let message: String
+    }
+
+    enum ComposeTabRemovalDecision: Equatable {
+        case proceed
+        case abort(ComposeTabRemovalFailure)
+    }
+
+    enum ForegroundComposeTabCreationResult: Equatable {
+        case created(ComposeTabState)
+        case failed
+    }
+
     typealias ComposeTabsWillCloseListener = @Sendable (_ tabIDs: Set<UUID>, _ reason: ComposeTabRemovalReason) async -> Void
+    typealias ComposeTabsRemovalHook = @MainActor @Sendable (
+        _ tabIDs: Set<UUID>,
+        _ reason: ComposeTabRemovalReason,
+        _ workspaceID: UUID
+    ) async -> ComposeTabRemovalDecision
     typealias ComposeTabCascadeResolver = @Sendable (_ tabIDs: Set<UUID>, _ reason: ComposeTabRemovalReason) async -> AgentSessionCascadePlan
     typealias StashedTabCascadeResolver = @Sendable (_ stashedTabIDs: Set<UUID>) async -> AgentSessionCascadePlan
     private var composeTabsWillCloseListeners: [UUID: ComposeTabsWillCloseListener] = [:]
+    private var composeTabsRemovalPreflight: (token: UUID, hook: ComposeTabsRemovalHook)?
+    private var composeTabsRemovalPreparation: (token: UUID, hook: ComposeTabsRemovalHook)?
     var composeTabCascadeResolver: ComposeTabCascadeResolver?
     var stashedTabCascadeResolver: StashedTabCascadeResolver?
-
-    var composeTabLimit: Int {
-        maxComposeTabs
-    }
 
     // MARK: - UI State Properties
 
@@ -2380,11 +2403,66 @@ class PromptViewModel: ObservableObject {
         composeTabsWillCloseListeners.removeValue(forKey: token)
     }
 
-    /// Notifies all registered listeners that tabs are about to close, awaiting their cleanup.
+    @MainActor
+    func setComposeTabsRemovalPreflight(_ hook: @escaping ComposeTabsRemovalHook) -> UUID {
+        let token = UUID()
+        composeTabsRemovalPreflight = (token, hook)
+        return token
+    }
+
+    @MainActor
+    func removeComposeTabsRemovalPreflight(_ token: UUID) {
+        guard composeTabsRemovalPreflight?.token == token else { return }
+        composeTabsRemovalPreflight = nil
+    }
+
+    @MainActor
+    func setComposeTabsRemovalPreparation(_ hook: @escaping ComposeTabsRemovalHook) -> UUID {
+        let token = UUID()
+        composeTabsRemovalPreparation = (token, hook)
+        return token
+    }
+
+    @MainActor
+    func removeComposeTabsRemovalPreparation(_ token: UUID) {
+        guard composeTabsRemovalPreparation?.token == token else { return }
+        composeTabsRemovalPreparation = nil
+    }
+
+    @MainActor
+    private func runComposeTabsRemovalPreflight(
+        _ tabIDs: Set<UUID>,
+        reason: ComposeTabRemovalReason,
+        workspaceID: UUID
+    ) async -> ComposeTabRemovalDecision {
+        guard let hook = composeTabsRemovalPreflight?.hook else { return .proceed }
+        return await hook(tabIDs, reason, workspaceID)
+    }
+
+    @MainActor
+    private func prepareComposeTabsRemoval(
+        _ tabIDs: Set<UUID>,
+        reason: ComposeTabRemovalReason,
+        workspaceID: UUID
+    ) async -> ComposeTabRemovalDecision {
+        guard let hook = composeTabsRemovalPreparation?.hook else { return .proceed }
+        return await hook(tabIDs, reason, workspaceID)
+    }
+
+    @MainActor
+    private func logComposeTabRemovalAbort(_ failure: ComposeTabRemovalFailure) {
+        print(
+            "[PromptViewModel] Compose tab removal aborted at \(failure.stage.rawValue)"
+                + (failure.tabID.map { " tab=\($0.uuidString)" } ?? "")
+                + ": \(failure.message)"
+        )
+    }
+
+    /// Notifies non-vetoing cleanup listeners after required persistence and AgentMode preparation succeed.
     @MainActor
     private func notifyComposeTabsWillClose(_ tabIDs: Set<UUID>, reason: ComposeTabRemovalReason) async {
         guard !tabIDs.isEmpty, !composeTabsWillCloseListeners.isEmpty else { return }
-        let listeners = composeTabsWillCloseListeners.values
+        let listeners = Array(composeTabsWillCloseListeners.values)
         await withTaskGroup(of: Void.self) { group in
             for listener in listeners {
                 group.addTask {
@@ -2455,81 +2533,6 @@ class PromptViewModel: ObservableObject {
         snapshotActiveComposeTabIfNeeded(in: manager, workspaceIndex: index)
     }
 
-    // MARK: - Auto-stash at Tab Limit
-
-    /// Auto-stash the least recently used, non-active tab to make room for a new tab.
-    /// Prefers non-dirty tabs; falls back to dirty if necessary.
-    /// Returns true if a tab was successfully stashed.
-    @MainActor
-    private func autoStashLeastRecentlyUsedTab(
-        excluding excludedID: UUID? = nil
-    ) async -> Bool {
-        guard
-            let manager = workspaceManager,
-            let workspace = manager.activeWorkspace,
-            let index = manager.workspaces.firstIndex(where: { $0.id == workspace.id })
-        else { return false }
-
-        let tabs = manager.workspaces[index].composeTabs
-        guard tabs.count > 1 else { return false } // never stash the last tab
-
-        let dirty = dirtyTabIDs
-
-        // Exclude the specified tab (typically the currently active one) and any
-        // tab the owning feature reports as unsafe to auto-stash.
-        let candidates = tabs.filter { tab in
-            tab.id != excludedID && (composeTabAutoStashEligibilityProvider?(tab.id) ?? true)
-        }
-        guard !candidates.isEmpty else { return false }
-
-        let sortedCandidates = candidates.sorted(by: { lhs, rhs in
-            let lhsRank = autoStashPriority(for: lhs, dirtyTabIDs: dirty)
-            let rhsRank = autoStashPriority(for: rhs, dirtyTabIDs: dirty)
-            if lhsRank != rhsRank {
-                return lhsRank < rhsRank
-            }
-            if lhs.lastModified != rhs.lastModified {
-                return lhs.lastModified < rhs.lastModified
-            }
-            return lhs.id.uuidString < rhs.id.uuidString
-        })
-
-        for target in sortedCandidates {
-            let affectedTabIDs = await autoStashAffectedComposeTabIDs(for: target.id)
-            guard canAutoStashAffectedComposeTabs(affectedTabIDs, among: tabs, excluding: excludedID) else {
-                continue
-            }
-            await stashTab(target.id)
-            return true
-        }
-        return false
-    }
-
-    @MainActor
-    private func autoStashAffectedComposeTabIDs(for tabID: UUID) async -> Set<UUID> {
-        var affectedTabIDs: Set<UUID> = [tabID]
-        if let composeTabCascadeResolver {
-            let cascadePlan = await composeTabCascadeResolver([tabID], .stash)
-            affectedTabIDs.formUnion(cascadePlan.composeTabIDs)
-        }
-        return affectedTabIDs
-    }
-
-    @MainActor
-    private func canAutoStashAffectedComposeTabs(
-        _ affectedTabIDs: Set<UUID>,
-        among tabs: [ComposeTabState],
-        excluding excludedID: UUID?
-    ) -> Bool {
-        let openTabIDs = Set(tabs.map(\.id))
-        let affectedOpenTabIDs = affectedTabIDs.intersection(openTabIDs)
-        guard !affectedOpenTabIDs.isEmpty else { return false }
-        guard affectedOpenTabIDs.count < openTabIDs.count else { return false }
-        return affectedOpenTabIDs.allSatisfy { tabID in
-            tabID != excludedID && (composeTabAutoStashEligibilityProvider?(tabID) ?? true)
-        }
-    }
-
     @MainActor
     private func withComposeTabSwitching<T>(
         targetTabID: UUID? = nil,
@@ -2580,35 +2583,16 @@ class PromptViewModel: ObservableObject {
     }
 
     @MainActor
-    private func ensureCapacityForNewComposeTab(
-        in manager: WorkspaceManagerViewModel,
-        workspaceIndex index: Int,
-        excluding excludedID: UUID? = nil
-    ) async -> Bool {
-        let currentCount = manager.workspaces[index].composeTabs.count
-        guard currentCount >= maxComposeTabs else { return true }
-
-        let excluded = excludedID ?? manager.workspaces[index].activeComposeTabID
-        return await autoStashLeastRecentlyUsedTab(excluding: excluded)
-    }
-
-    @MainActor
     private func createComposeTab(
         strategy: ComposeTabCreationStrategy = .duplicateCurrent,
         name: String? = nil,
         blankAgentSessionID: UUID? = nil
-    ) async {
+    ) async -> ForegroundComposeTabCreationResult {
         guard
             let manager = workspaceManager,
             let workspace = manager.activeWorkspace,
             let index = manager.workspaces.firstIndex(where: { $0.id == workspace.id })
-        else { return }
-
-        guard await ensureCapacityForNewComposeTab(
-            in: manager,
-            workspaceIndex: index,
-            excluding: manager.workspaces[index].activeComposeTabID
-        ) else { return }
+        else { return .failed }
 
         let didSnapshotSource = flushAndSnapshotSourceTabIfNeeded(for: strategy, in: manager, workspaceIndex: index)
         guard let newTab = makeComposeTab(
@@ -2617,7 +2601,7 @@ class PromptViewModel: ObservableObject {
             workspaceIndex: index,
             manager: manager,
             blankAgentSessionID: blankAgentSessionID
-        ) else { return }
+        ) else { return .failed }
 
         // Flush pending editor state and snapshot current tab before switching
         if !didSnapshotSource {
@@ -2637,17 +2621,24 @@ class PromptViewModel: ObservableObject {
 
         manager.markWorkspaceDirty()
         manager.pollAndSaveState()
+        guard manager.workspaces.indices.contains(index),
+              manager.workspaces[index].id == workspace.id,
+              manager.workspaces[index].composeTabs.contains(where: { $0.id == newTab.id })
+        else { return .failed }
+        return .created(newTab)
     }
 
+    @discardableResult
     @MainActor
-    func createDuplicateComposeTab(named name: String? = nil) async {
+    func createDuplicateComposeTab(named name: String? = nil) async -> ForegroundComposeTabCreationResult {
         await createComposeTab(strategy: .duplicateCurrent, name: name)
     }
 
+    @discardableResult
     @MainActor
-    func createBlankComposeTab(createAgentSession: Bool = false) async {
+    func createBlankComposeTab(createAgentSession: Bool = false) async -> ForegroundComposeTabCreationResult {
         let blankAgentSessionID = createAgentSession ? UUID() : nil
-        await createComposeTab(strategy: .blank, blankAgentSessionID: blankAgentSessionID)
+        return await createComposeTab(strategy: .blank, blankAgentSessionID: blankAgentSessionID)
     }
 
     /// Create a fork-duplicate tab in the background (without switching to it).
@@ -2689,8 +2680,9 @@ class PromptViewModel: ObservableObject {
         return manager.composeTab(with: newTab.id) ?? newTab
     }
 
+    @discardableResult
     @MainActor
-    func createComposeTab(from preset: WorkspacePreset) async {
+    func createComposeTab(from preset: WorkspacePreset) async -> ForegroundComposeTabCreationResult {
         await createComposeTab(strategy: .preset(preset), name: preset.name)
     }
 
@@ -2826,8 +2818,7 @@ class PromptViewModel: ObservableObject {
         preferredActiveID: UUID? = nil,
         reason: ComposeTabRemovalReason = .close,
         expandCascade: Bool = true,
-        isMutationContextCurrent: (@MainActor () -> Bool)? = nil,
-        isMutationOwnerCurrent: (@MainActor () -> Bool)? = nil
+        isMutationContextCurrent: (@MainActor () -> Bool)? = nil
     ) async {
         guard !ids.isEmpty else { return }
         guard
@@ -2836,24 +2827,14 @@ class PromptViewModel: ObservableObject {
             let index = manager.workspaces.firstIndex(where: { $0.id == workspace.id })
         else { return }
 
-        func mutationContextIsCurrent() -> Bool {
-            guard manager.activeWorkspace?.id == workspace.id,
-                  manager.workspaces.indices.contains(index),
-                  manager.workspaces[index].id == workspace.id
-            else {
-                return false
-            }
-            return isMutationContextCurrent?() ?? true
+        func mutationOwnerIsCurrent() -> Bool {
+            manager.activeWorkspace?.id == workspace.id
+                && manager.workspaces.indices.contains(index)
+                && manager.workspaces[index].id == workspace.id
         }
 
-        func mutationOwnerIsCurrent() -> Bool {
-            guard manager.activeWorkspace?.id == workspace.id,
-                  manager.workspaces.indices.contains(index),
-                  manager.workspaces[index].id == workspace.id
-            else {
-                return false
-            }
-            return isMutationOwnerCurrent?() ?? true
+        func mutationContextIsCurrent() -> Bool {
+            mutationOwnerIsCurrent() && (isMutationContextCurrent?() ?? true)
         }
 
         guard mutationContextIsCurrent() else { return }
@@ -2886,10 +2867,40 @@ class PromptViewModel: ObservableObject {
             return adjacentTabID(afterClosing: previousActiveID, tabs: tabsBeforeClose, closingIDs: tabsBeingClosed)
         }()
 
-        // Notify listeners BEFORE mutation so they can cancel running tasks.
-        // The caller's target context may be invalidated by this intentional cleanup,
-        // so post-notify checks use the stable mutation owner instead.
+        // Required persistence must succeed before any runtime teardown or projection mutation.
         guard mutationContextIsCurrent() else { return }
+        switch await runComposeTabsRemovalPreflight(
+            tabsBeingClosed,
+            reason: reason,
+            workspaceID: workspace.id
+        ) {
+        case .proceed:
+            break
+        case let .abort(failure):
+            logComposeTabRemovalAbort(failure)
+            return
+        }
+        guard mutationContextIsCurrent() else { return }
+        if reason == .stash,
+           let activeID = manager.workspaces[index].activeComposeTabID,
+           tabsBeingClosed.contains(activeID)
+        {
+            flushAndSnapshotActiveTab(in: manager, workspaceIndex: index)
+        }
+        switch await prepareComposeTabsRemoval(
+            tabsBeingClosed,
+            reason: reason,
+            workspaceID: workspace.id
+        ) {
+        case .proceed:
+            break
+        case let .abort(failure):
+            logComposeTabRemovalAbort(failure)
+            return
+        }
+        guard mutationOwnerIsCurrent() else { return }
+
+        // Non-vetoing feature cleanup runs only after required AgentMode preparation succeeds.
         await notifyComposeTabsWillClose(tabsBeingClosed, reason: reason)
         guard mutationOwnerIsCurrent() else { return }
         await cleanupMCPStateForClosingTabs(tabsBeingClosed)
@@ -3118,7 +3129,6 @@ class PromptViewModel: ObservableObject {
         let ids = Set(manager.workspaces[index].composeTabs.map(\.id))
         guard !ids.isEmpty else { return }
 
-        flushAndSnapshotActiveTab(in: manager, workspaceIndex: index)
         await closeComposeTabs(withIDs: ids, reason: .stash)
     }
 
@@ -3141,130 +3151,11 @@ class PromptViewModel: ObservableObject {
         // Don't allow stashing if it's the last tab
         guard manager.workspaces[index].composeTabs.count > 1 else { return }
 
-        // Flush and snapshot current state if this is the active tab
-        if id == activeComposeTabID {
-            flushAndSnapshotActiveTab(in: manager, workspaceIndex: index)
-        }
-
         await closeComposeTabs(
             withIDs: [id],
             reason: .stash,
             isMutationContextCurrent: isMutationContextCurrent
         )
-    }
-
-    @discardableResult
-    @MainActor
-    func autoArchiveComposeTabsForSidebarPolicy(
-        withIDs ids: Set<UUID>,
-        expectedWorkspaceID: UUID,
-        isArchiveContextCurrent: @escaping @MainActor () -> Bool
-    ) async -> Set<UUID> {
-        guard !ids.isEmpty, isArchiveContextCurrent() else { return [] }
-        guard
-            let manager = workspaceManager,
-            let workspace = manager.activeWorkspace,
-            workspace.id == expectedWorkspaceID,
-            let index = manager.workspaces.firstIndex(where: { $0.id == workspace.id })
-        else { return [] }
-
-        func validatedArchivePlan(
-            candidateIDs: Set<UUID>,
-            tabs: [ComposeTabState],
-            activeTabID: UUID?
-        ) async -> (rootIDs: Set<UUID>, affectedOpenTabIDs: Set<UUID>) {
-            let openTabIDs = Set(tabs.map(\.id))
-            guard openTabIDs.count > 1 else { return ([], []) }
-
-            var rootIDsToArchive: Set<UUID> = []
-            var affectedOpenTabIDsToArchive: Set<UUID> = []
-            let tabOrder = Dictionary(uniqueKeysWithValues: tabs.enumerated().map { ($1.id, $0) })
-            let requestedOpenIDs = candidateIDs
-                .intersection(openTabIDs)
-                .sorted { lhs, rhs in
-                    let lhsOrder = tabOrder[lhs] ?? Int.max
-                    let rhsOrder = tabOrder[rhs] ?? Int.max
-                    if lhsOrder != rhsOrder { return lhsOrder < rhsOrder }
-                    return lhs.uuidString < rhs.uuidString
-                }
-
-            for tabID in requestedOpenIDs {
-                guard isArchiveContextCurrent(),
-                      manager.activeWorkspace?.id == expectedWorkspaceID
-                else {
-                    return ([], [])
-                }
-                guard tabID != activeTabID else { continue }
-                guard composeTabAutoStashEligibilityProvider?(tabID) ?? true else { continue }
-
-                let affectedTabIDs = await autoStashAffectedComposeTabIDs(for: tabID)
-                guard isArchiveContextCurrent(),
-                      manager.activeWorkspace?.id == expectedWorkspaceID
-                else {
-                    return ([], [])
-                }
-                guard canAutoStashAffectedComposeTabs(affectedTabIDs, among: tabs, excluding: activeTabID) else {
-                    continue
-                }
-
-                let affectedOpenTabIDs = affectedTabIDs.intersection(openTabIDs)
-                let proposedAffectedOpenTabIDs = affectedOpenTabIDsToArchive.union(affectedOpenTabIDs)
-                guard proposedAffectedOpenTabIDs.count < openTabIDs.count else { continue }
-                guard proposedAffectedOpenTabIDs.allSatisfy({ affectedTabID in
-                    affectedTabID != activeTabID && (composeTabAutoStashEligibilityProvider?(affectedTabID) ?? true)
-                }) else { continue }
-
-                rootIDsToArchive.insert(tabID)
-                affectedOpenTabIDsToArchive = proposedAffectedOpenTabIDs
-            }
-
-            return (rootIDsToArchive, affectedOpenTabIDsToArchive)
-        }
-
-        let initialTabs = manager.workspaces[index].composeTabs
-        let initialActiveTabID = manager.workspaces[index].activeComposeTabID ?? activeComposeTabID
-        let initialPlan = await validatedArchivePlan(
-            candidateIDs: ids,
-            tabs: initialTabs,
-            activeTabID: initialActiveTabID
-        )
-        guard !initialPlan.rootIDs.isEmpty else { return [] }
-
-        let refreshedTabs = manager.workspaces[index].composeTabs
-        let refreshedActiveTabID = manager.workspaces[index].activeComposeTabID ?? activeComposeTabID
-        let refreshedPlan = await validatedArchivePlan(
-            candidateIDs: initialPlan.rootIDs,
-            tabs: refreshedTabs,
-            activeTabID: refreshedActiveTabID
-        )
-        guard !refreshedPlan.rootIDs.isEmpty else { return [] }
-        guard isArchiveContextCurrent(),
-              manager.activeWorkspace?.id == expectedWorkspaceID
-        else {
-            return []
-        }
-
-        await closeComposeTabs(
-            withIDs: refreshedPlan.affectedOpenTabIDs,
-            reason: .stash,
-            expandCascade: false,
-            isMutationContextCurrent: {
-                isArchiveContextCurrent()
-                    && manager.activeWorkspace?.id == expectedWorkspaceID
-            },
-            isMutationOwnerCurrent: {
-                isArchiveContextCurrent()
-                    && manager.activeWorkspace?.id == expectedWorkspaceID
-            }
-        )
-        guard isArchiveContextCurrent(),
-              manager.activeWorkspace?.id == expectedWorkspaceID,
-              manager.workspaces.indices.contains(index)
-        else {
-            return []
-        }
-        let remainingOpenTabIDs = Set(manager.workspaces[index].composeTabs.map(\.id))
-        return refreshedPlan.affectedOpenTabIDs.subtracting(remainingOpenTabIDs)
     }
 
     @MainActor
@@ -3291,12 +3182,6 @@ class PromptViewModel: ObservableObject {
 
         // Find the stashed tab
         guard let stashIndex = manager.workspaces[index].stashedTabs.firstIndex(where: { $0.id == stashedTabID }) else { return }
-
-        guard await ensureCapacityForNewComposeTab(
-            in: manager,
-            workspaceIndex: index,
-            excluding: manager.workspaces[index].activeComposeTabID
-        ) else { return }
 
         // Flush and snapshot current state before switching
         flushAndSnapshotActiveTab(in: manager, workspaceIndex: index)
@@ -3342,10 +3227,17 @@ class PromptViewModel: ObservableObject {
             let index = manager.workspaces.firstIndex(where: { $0.id == workspace.id })
         else { return }
 
+        func mutationOwnerIsCurrent() -> Bool {
+            manager.activeWorkspace?.id == workspace.id
+                && manager.workspaces.indices.contains(index)
+                && manager.workspaces[index].id == workspace.id
+        }
+
         var resolvedStashedTabIDs = stashedTabIDs
         var composeTabIDsToDelete: Set<UUID> = []
         if expandCascade, let stashedTabCascadeResolver {
             let cascadePlan = await stashedTabCascadeResolver(stashedTabIDs)
+            guard mutationOwnerIsCurrent() else { return }
             resolvedStashedTabIDs.formUnion(cascadePlan.stashedTabIDs)
             composeTabIDsToDelete.formUnion(cascadePlan.composeTabIDs)
         }
@@ -3366,8 +3258,33 @@ class PromptViewModel: ObservableObject {
                         closingIDs: composeTabIDsBeingDeleted
                     )
                 }()
+                switch await runComposeTabsRemovalPreflight(
+                    composeTabIDsBeingDeleted,
+                    reason: .close,
+                    workspaceID: workspace.id
+                ) {
+                case .proceed:
+                    break
+                case let .abort(failure):
+                    logComposeTabRemovalAbort(failure)
+                    return
+                }
+                switch await prepareComposeTabsRemoval(
+                    composeTabIDsBeingDeleted,
+                    reason: .close,
+                    workspaceID: workspace.id
+                ) {
+                case .proceed:
+                    break
+                case let .abort(failure):
+                    logComposeTabRemovalAbort(failure)
+                    return
+                }
+                guard mutationOwnerIsCurrent() else { return }
                 await notifyComposeTabsWillClose(composeTabIDsBeingDeleted, reason: .close)
+                guard mutationOwnerIsCurrent() else { return }
                 await cleanupMCPStateForClosingTabs(composeTabIDsBeingDeleted)
+                guard mutationOwnerIsCurrent() else { return }
                 deleteGitDataForClosingTabs(tabIDs: composeTabIDsBeingDeleted)
                 var remainingComposeTabs = composeTabsBeforeDelete
                 remainingComposeTabs.removeAll { composeTabIDsBeingDeleted.contains($0.id) }
@@ -3413,7 +3330,31 @@ class PromptViewModel: ObservableObject {
         guard !stashedTabsToDelete.isEmpty else { return }
 
         let tabIDs = Set(stashedTabsToDelete.map(\.tab.id))
+        switch await runComposeTabsRemovalPreflight(
+            tabIDs,
+            reason: .deleteStashed,
+            workspaceID: workspace.id
+        ) {
+        case .proceed:
+            break
+        case let .abort(failure):
+            logComposeTabRemovalAbort(failure)
+            return
+        }
+        switch await prepareComposeTabsRemoval(
+            tabIDs,
+            reason: .deleteStashed,
+            workspaceID: workspace.id
+        ) {
+        case .proceed:
+            break
+        case let .abort(failure):
+            logComposeTabRemovalAbort(failure)
+            return
+        }
+        guard mutationOwnerIsCurrent() else { return }
         await notifyComposeTabsWillClose(tabIDs, reason: .deleteStashed)
+        guard mutationOwnerIsCurrent() else { return }
         deleteGitDataForClosingTabs(tabIDs: tabIDs)
         manager.workspaces[index].stashedTabs.removeAll { resolvedStashedTabIDs.contains($0.id) }
         loadComposeTabsFromWorkspace(manager.workspaces[index])

--- a/Tests/RepoPromptTests/AgentMode/AgentModeRunServiceLifecycleTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeRunServiceLifecycleTests.swift
@@ -684,7 +684,7 @@ final class AgentModeRunServiceLifecycleTests: XCTestCase {
             fixture.host.test_installLiveSession(fixture.session)
             XCTAssertTrue(Self.processIsRunning(fixture.processID), name)
 
-            await fixture.host.handleComposeTabsWillClose([fixture.session.tabID], reason: reason)
+            await fixture.host.handleComposeTabsDidRemove([fixture.session.tabID], reason: reason)
 
             XCTAssertNil(fixture.session.acpController, name)
             XCTAssertNil(fixture.host.sessions[fixture.session.tabID], name)

--- a/Tests/RepoPromptTests/AgentMode/AgentModeViewModelInactiveRefreshTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/AgentModeViewModelInactiveRefreshTests.swift
@@ -1093,7 +1093,7 @@ final class AgentModeViewModelInactiveRefreshTests: XCTestCase {
         XCTAssertEqual(requestCountAfterStaleHandler, requestCountBeforeStaleHandler)
     }
 
-    func testAutoArchiveSkipsMutationAfterSameWorkspaceReactivation() async {
+    func testSidebarAutoArchiveSuggestionDoesNotMutateTabsOrSessions() {
         let tabs = (0 ... AgentModeViewModel.sessionSidebarPageSize + 10).map { offset in
             ComposeTabState(
                 id: UUID(),
@@ -1104,7 +1104,7 @@ final class AgentModeViewModelInactiveRefreshTests: XCTestCase {
         }
         let activeTabID = tabs.last?.id
         let workspace = makeWorkspace(
-            name: "Same workspace reactivation",
+            name: "Sidebar archive suggestion",
             tabs: tabs,
             activeTabID: activeTabID
         )
@@ -1116,45 +1116,30 @@ final class AgentModeViewModelInactiveRefreshTests: XCTestCase {
             promptManager: fixture.prompt,
             workspaceManager: fixture.manager
         )
-        viewModel.test_setSidebarAutoArchiveActive(true)
 
-        let initialOwner = viewModel.test_receiveWorkspaceSwitchNotification(workspace)
+        let owner = viewModel.test_receiveWorkspaceSwitchNotification(workspace)
         viewModel.test_installSessionIndexSnapshot(
             [:],
-            owner: initialOwner,
-            latestOwner: initialOwner,
+            owner: owner,
+            latestOwner: owner,
             activeWorkspace: workspace
         )
 
-        let closeGate = SidebarIndexStreamGate()
-        let closeListenerToken = fixture.prompt.addComposeTabsWillCloseListener { _, reason in
-            guard reason == .stash else { return }
-            await closeGate.wait()
-        }
-        defer {
-            fixture.prompt.removeComposeTabsWillCloseListener(closeListenerToken)
-        }
-        let archiveTask = Task {
-            await viewModel.performSidebarAutoArchiveIfNeeded(
-                reason: .explicitTest,
-                now: Date()
-            )
-        }
-        await closeGate.waitForWaiter()
+        let protectedSession = viewModel.session(for: tabs[0].id)
+        protectedSession.runState = .running
+        let idleSession = viewModel.session(for: tabs[1].id)
+        XCTAssertTrue(viewModel.isComposeTabProtectedFromSidebarArchiveSuggestion(tabs[0].id))
+        XCTAssertFalse(viewModel.isComposeTabProtectedFromSidebarArchiveSuggestion(tabs[1].id))
 
-        let reactivatedOwner = viewModel.test_receiveWorkspaceSwitchNotification(workspace)
-        viewModel.test_installSessionIndexSnapshot(
-            [:],
-            owner: reactivatedOwner,
-            latestOwner: reactivatedOwner,
-            activeWorkspace: workspace
-        )
-        await closeGate.release()
-        let archivedTabIDs = await archiveTask.value
+        let originalOpenIDs = fixture.manager.activeWorkspace?.composeTabs.map(\.id)
+        let originalStashedTabs = fixture.manager.activeWorkspace?.stashedTabs
+        let decision = viewModel.sidebarAutoArchiveSuggestion(now: Date())
 
-        XCTAssertTrue(archivedTabIDs.isEmpty)
-        XCTAssertEqual(Set(fixture.manager.activeWorkspace?.composeTabs.map(\.id) ?? []), Set(tabs.map(\.id)))
-        XCTAssertTrue(fixture.manager.activeWorkspace?.stashedTabs.isEmpty == true)
+        XCTAssertFalse(decision.tabIDsToArchive.contains(tabs[0].id))
+        XCTAssertEqual(fixture.manager.activeWorkspace?.composeTabs.map(\.id), originalOpenIDs)
+        XCTAssertEqual(fixture.manager.activeWorkspace?.stashedTabs, originalStashedTabs)
+        XCTAssertTrue(viewModel.sessions[tabs[0].id] === protectedSession)
+        XCTAssertTrue(viewModel.sessions[tabs[1].id] === idleSession)
     }
 
     func testRestoredMatchingBindingPreservesRefreshAndRestoresIndexOnlyHierarchy() async throws {

--- a/Tests/RepoPromptTests/Prompt/BackgroundComposeTabAdmissionTests.swift
+++ b/Tests/RepoPromptTests/Prompt/BackgroundComposeTabAdmissionTests.swift
@@ -34,6 +34,164 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
         XCTAssertEqual(finalWorkspace.stashedTabs, originalStashedTabs)
     }
 
+    func testForegroundAgentCreationCrosses499Through502WithoutUnrelatedMutation() async throws {
+        let fixture = makeFixture(initialTabCount: 499)
+        let viewModel = makeAgentModeViewModel(prompt: fixture.prompt, manager: fixture.manager)
+        let originalWorkspace = try XCTUnwrap(fixture.manager.activeWorkspace)
+        let originalTabs = originalWorkspace.composeTabs
+        let originalTabIDs = originalTabs.map(\.id)
+        let originalPins = Dictionary(uniqueKeysWithValues: originalTabs.map { ($0.id, $0.isPinned) })
+        let originalBindings = Dictionary(uniqueKeysWithValues: originalTabs.map { ($0.id, $0.activeAgentSessionID) })
+        let originalStashedTabs = originalWorkspace.stashedTabs
+        let originalDirtyTabIDs = Set(originalTabIDs.prefix(7))
+        fixture.prompt.testSetDirtyTabIDs(originalDirtyTabIDs)
+
+        let sideEffects = ComposeRemovalSideEffectRecorder()
+        fixture.prompt.composeTabCascadeResolver = { tabIDs, _ in
+            await sideEffects.recordCascade(tabIDs)
+            return .init()
+        }
+        let closeToken = fixture.prompt.addComposeTabsWillCloseListener { tabIDs, _ in
+            await sideEffects.recordClose(tabIDs)
+        }
+        defer { fixture.prompt.removeComposeTabsWillCloseListener(closeToken) }
+
+        var createdIDs: [UUID] = []
+        for expectedCount in 500 ... 502 {
+            let creationResult = await viewModel.createAndActivateSessionTab()
+            let createdID = try XCTUnwrap(creationResult)
+            createdIDs.append(createdID)
+            XCTAssertEqual(fixture.prompt.activeComposeTabID, createdID)
+            XCTAssertEqual(fixture.manager.activeWorkspace?.activeComposeTabID, createdID)
+            XCTAssertEqual(fixture.manager.activeWorkspace?.composeTabs.count, expectedCount)
+            XCTAssertEqual(fixture.manager.composeTab(with: createdID)?.activeAgentSessionID, viewModel.sessions[createdID]?.activeAgentSessionID)
+        }
+
+        let finalWorkspace = try XCTUnwrap(fixture.manager.activeWorkspace)
+        let existingTabs = Array(finalWorkspace.composeTabs.prefix(originalTabs.count))
+        XCTAssertEqual(existingTabs.map(\.id), originalTabIDs)
+        XCTAssertEqual(Dictionary(uniqueKeysWithValues: existingTabs.map { ($0.id, $0.isPinned) }), originalPins)
+        XCTAssertEqual(Dictionary(uniqueKeysWithValues: existingTabs.map { ($0.id, $0.activeAgentSessionID) }), originalBindings)
+        XCTAssertEqual(fixture.prompt.dirtyTabIDs.intersection(originalTabIDs), originalDirtyTabIDs)
+        XCTAssertEqual(finalWorkspace.stashedTabs, originalStashedTabs)
+        XCTAssertEqual(Array(finalWorkspace.composeTabs.suffix(createdIDs.count)).map(\.id), createdIDs)
+        let recordedSideEffects = await sideEffects.snapshot()
+        XCTAssertEqual(recordedSideEffects, .init())
+    }
+
+    func testFailedForegroundCreationDoesNotReturnOrMarkOldActiveTab() async throws {
+        let fixture = makeFixture(initialTabCount: 1)
+        let oldActiveTabID = try XCTUnwrap(fixture.prompt.activeComposeTabID)
+        let viewModel = makeAgentModeViewModel(prompt: fixture.prompt, manager: fixture.manager)
+        XCTAssertNil(viewModel.sessions[oldActiveTabID])
+
+        fixture.manager.activeWorkspace = nil
+        let createdID = await viewModel.createAndActivateSessionTab()
+
+        XCTAssertNil(createdID)
+        XCTAssertEqual(fixture.prompt.activeComposeTabID, oldActiveTabID)
+        XCTAssertNil(viewModel.sessions[oldActiveTabID])
+    }
+
+    func testUnstashAboveFiftyRestoresRequestedTabWithoutUnrelatedMutation() async throws {
+        let fixture = makeFixture(initialTabCount: 51)
+        let originalWorkspace = try XCTUnwrap(fixture.manager.activeWorkspace)
+        let originalTabs = originalWorkspace.composeTabs
+        let originalIDs = originalTabs.map(\.id)
+        let originalPins = Dictionary(uniqueKeysWithValues: originalTabs.map { ($0.id, $0.isPinned) })
+        let originalBindings = Dictionary(uniqueKeysWithValues: originalTabs.map { ($0.id, $0.activeAgentSessionID) })
+        let stashed = try XCTUnwrap(originalWorkspace.stashedTabs.first)
+        let dirtyIDs = Set(originalIDs.prefix(5))
+        fixture.prompt.testSetDirtyTabIDs(dirtyIDs)
+
+        await fixture.prompt.unstashTab(stashed.id)
+
+        let finalWorkspace = try XCTUnwrap(fixture.manager.activeWorkspace)
+        XCTAssertEqual(finalWorkspace.composeTabs.count, 52)
+        XCTAssertEqual(Array(finalWorkspace.composeTabs.prefix(originalIDs.count)).map(\.id), originalIDs)
+        XCTAssertEqual(finalWorkspace.composeTabs.last?.id, stashed.tab.id)
+        XCTAssertEqual(finalWorkspace.activeComposeTabID, stashed.tab.id)
+        XCTAssertTrue(finalWorkspace.stashedTabs.isEmpty)
+        XCTAssertEqual(
+            Dictionary(uniqueKeysWithValues: finalWorkspace.composeTabs.prefix(originalIDs.count).map { ($0.id, $0.isPinned) }),
+            originalPins
+        )
+        XCTAssertEqual(
+            Dictionary(uniqueKeysWithValues: finalWorkspace.composeTabs.prefix(originalIDs.count).map { ($0.id, $0.activeAgentSessionID) }),
+            originalBindings
+        )
+        XCTAssertEqual(fixture.prompt.dirtyTabIDs.intersection(originalIDs), dirtyIDs)
+    }
+
+    func testWorkspaceSwitchDuringRemovalPreparationDoesNotMutateCapturedWorkspace() async throws {
+        let fixture = makeFixture(initialTabCount: 2)
+        let capturedWorkspace = try XCTUnwrap(fixture.manager.activeWorkspace)
+        let capturedTabIDs = capturedWorkspace.composeTabs.map(\.id)
+        let tabID = try XCTUnwrap(capturedTabIDs.last)
+        let otherTab = ComposeTabState(name: "Other workspace tab")
+        let otherWorkspace = WorkspaceModel(
+            name: "Other workspace",
+            repoPaths: [],
+            ephemeralFlag: true,
+            composeTabs: [otherTab],
+            activeComposeTabID: otherTab.id
+        )
+        fixture.manager.workspaces.append(otherWorkspace)
+
+        let preflightToken = fixture.prompt.setComposeTabsRemovalPreflight { _, _, _ in .proceed }
+        let preparationToken = fixture.prompt.setComposeTabsRemovalPreparation { _, _, _ in
+            fixture.manager.activeWorkspace = otherWorkspace
+            return .proceed
+        }
+        defer {
+            fixture.prompt.removeComposeTabsRemovalPreflight(preflightToken)
+            fixture.prompt.removeComposeTabsRemovalPreparation(preparationToken)
+        }
+
+        await fixture.prompt.closeComposeTab(tabID)
+
+        let storedCapturedWorkspace = try XCTUnwrap(
+            fixture.manager.workspaces.first(where: { $0.id == capturedWorkspace.id })
+        )
+        XCTAssertEqual(storedCapturedWorkspace.composeTabs.map(\.id), capturedTabIDs)
+        XCTAssertEqual(fixture.manager.activeWorkspace?.id, otherWorkspace.id)
+    }
+
+    func testFailedRequiredFlushKeepsTabRuntimeAndProjection() async throws {
+        let fixture = makeFixture(initialTabCount: 2)
+        let tabID = try XCTUnwrap(fixture.prompt.activeComposeTabID)
+        let sessionID = try XCTUnwrap(fixture.manager.composeTab(with: tabID)?.activeAgentSessionID)
+        let viewModel = makeAgentModeViewModel(prompt: fixture.prompt, manager: fixture.manager)
+        let session = viewModel.session(for: tabID)
+        _ = viewModel.test_installPersistentSessionBinding(sessionID: sessionID, on: session)
+        session.setItemsSilently([.user("must persist", sequenceIndex: 0)], reason: .testOverride)
+        session.isDirty = true
+        session.runState = .running
+
+        let saveAttempts = SaveAttemptRecorder()
+        viewModel.test_setAgentSessionSaver { _, _, _ in
+            await saveAttempts.record()
+            throw RequiredFlushTestError.injectedFailure
+        }
+        let preflightToken = fixture.prompt.setComposeTabsRemovalPreflight { tabIDs, reason, workspaceID in
+            await viewModel.preflightComposeTabsRemoval(tabIDs, reason: reason, workspaceID: workspaceID)
+        }
+        defer { fixture.prompt.removeComposeTabsRemovalPreflight(preflightToken) }
+
+        let originalOpenIDs = fixture.manager.activeWorkspace?.composeTabs.map(\.id)
+        let originalStashedTabs = fixture.manager.activeWorkspace?.stashedTabs
+        await fixture.prompt.closeComposeTab(tabID)
+
+        let saveAttemptCount = await saveAttempts.count()
+        XCTAssertEqual(saveAttemptCount, 1)
+        XCTAssertEqual(fixture.manager.activeWorkspace?.composeTabs.map(\.id), originalOpenIDs)
+        XCTAssertEqual(fixture.manager.activeWorkspace?.stashedTabs, originalStashedTabs)
+        XCTAssertEqual(fixture.prompt.activeComposeTabID, tabID)
+        XCTAssertTrue(viewModel.sessions[tabID] === session)
+        XCTAssertEqual(session.runState, .running)
+        XCTAssertTrue(session.isDirty)
+    }
+
     private func makeFixture(initialTabCount: Int) -> (manager: WorkspaceManagerViewModel, prompt: PromptViewModel) {
         let fileManager = WorkspaceFilesViewModel()
         let keyManager = KeyManager(
@@ -59,6 +217,7 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
             ComposeTabState(
                 name: "Existing \(index)",
                 lastModified: Date(timeIntervalSince1970: TimeInterval(index)),
+                isPinned: index.isMultiple(of: 11),
                 activeAgentSessionID: UUID()
             )
         }
@@ -79,4 +238,131 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
         prompt.loadComposeTabsFromWorkspace(workspace)
         return (manager, prompt)
     }
+
+    private func makeAgentModeViewModel(
+        prompt: PromptViewModel,
+        manager: WorkspaceManagerViewModel
+    ) -> AgentModeViewModel {
+        let viewModel = AgentModeViewModel(
+            codexControllerFactory: { _, _, _, _, _, _ in ComposeAdmissionFakeCodexController() }
+        )
+        viewModel.test_setSidebarAutoArchiveDependencies(promptManager: prompt, workspaceManager: manager)
+        return viewModel
+    }
+}
+
+private actor ComposeRemovalSideEffectRecorder {
+    struct Snapshot: Equatable {
+        var cascadeCount = 0
+        var closeCount = 0
+        var affectedTabIDs: Set<UUID> = []
+    }
+
+    private var value = Snapshot()
+
+    func recordCascade(_ tabIDs: Set<UUID>) {
+        value.cascadeCount += 1
+        value.affectedTabIDs.formUnion(tabIDs)
+    }
+
+    func recordClose(_ tabIDs: Set<UUID>) {
+        value.closeCount += 1
+        value.affectedTabIDs.formUnion(tabIDs)
+    }
+
+    func snapshot() -> Snapshot {
+        value
+    }
+}
+
+private actor SaveAttemptRecorder {
+    private var value = 0
+
+    func record() {
+        value += 1
+    }
+
+    func count() -> Int {
+        value
+    }
+}
+
+private enum RequiredFlushTestError: Error {
+    case injectedFailure
+}
+
+private final class ComposeAdmissionFakeCodexController: CodexSessionControllerTurnDispatchTestDefaults {
+    var hasActiveThread: Bool {
+        false
+    }
+
+    var events: AsyncStream<CodexNativeSessionController.Event> {
+        AsyncStream { continuation in continuation.finish() }
+    }
+
+    func ensureEventsStreamReady() {}
+
+    func startOrResume(
+        existing _: CodexNativeSessionController.SessionRef?,
+        baseInstructions _: String
+    ) async throws -> CodexNativeSessionController.SessionRef {
+        .init(conversationID: "fake", rolloutPath: nil, model: nil, reasoningEffort: nil)
+    }
+
+    func startOrResume(
+        existing _: CodexNativeSessionController.SessionRef?,
+        baseInstructions _: String,
+        model: String?,
+        reasoningEffort: String?
+    ) async throws -> CodexNativeSessionController.SessionRef {
+        .init(conversationID: "fake", rolloutPath: nil, model: model, reasoningEffort: reasoningEffort)
+    }
+
+    func startOrResume(
+        existing _: CodexNativeSessionController.SessionRef?,
+        baseInstructions _: String,
+        model: String?,
+        reasoningEffort: String?,
+        serviceTier _: String?
+    ) async throws -> CodexNativeSessionController.SessionRef {
+        .init(conversationID: "fake", rolloutPath: nil, model: model, reasoningEffort: reasoningEffort)
+    }
+
+    func readThreadSnapshot(
+        includeTurns _: Bool,
+        timeout _: TimeInterval?
+    ) async throws -> CodexNativeSessionController.ThreadSnapshot {
+        .init(
+            conversationID: "fake",
+            rolloutPath: nil,
+            model: nil,
+            reasoningEffort: nil,
+            runtimeStatus: .idle,
+            currentTurnID: nil,
+            activeTurnIDs: [],
+            latestTurnStatus: nil
+        )
+    }
+
+    func setThreadName(_: String, threadID _: String?) async throws {}
+    func compactThread() async throws {}
+    func getThreadGoal() async throws -> CodexNativeSessionController.ThreadGoal? {
+        nil
+    }
+
+    func setThreadGoalObjective(_: String) async throws -> CodexNativeSessionController.ThreadGoal {
+        throw CancellationError()
+    }
+
+    func setThreadGoalStatus(_: CodexNativeSessionController.ThreadGoalStatus) async throws -> CodexNativeSessionController.ThreadGoal {
+        throw CancellationError()
+    }
+
+    func clearThreadGoal() async throws -> Bool {
+        false
+    }
+
+    func cancelCurrentTurn() async {}
+    func shutdown() async {}
+    func respondToServerRequest(id _: CodexAppServerRequestID, result _: [String: Any]) async {}
 }

--- a/Tests/RepoPromptTests/Prompt/BackgroundComposeTabAdmissionTests.swift
+++ b/Tests/RepoPromptTests/Prompt/BackgroundComposeTabAdmissionTests.swift
@@ -123,40 +123,6 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
         XCTAssertEqual(fixture.prompt.dirtyTabIDs.intersection(originalIDs), dirtyIDs)
     }
 
-    func testWorkspaceSwitchDuringRemovalPreparationDoesNotMutateCapturedWorkspace() async throws {
-        let fixture = makeFixture(initialTabCount: 2)
-        let capturedWorkspace = try XCTUnwrap(fixture.manager.activeWorkspace)
-        let capturedTabIDs = capturedWorkspace.composeTabs.map(\.id)
-        let tabID = try XCTUnwrap(capturedTabIDs.last)
-        let otherTab = ComposeTabState(name: "Other workspace tab")
-        let otherWorkspace = WorkspaceModel(
-            name: "Other workspace",
-            repoPaths: [],
-            ephemeralFlag: true,
-            composeTabs: [otherTab],
-            activeComposeTabID: otherTab.id
-        )
-        fixture.manager.workspaces.append(otherWorkspace)
-
-        let preflightToken = fixture.prompt.setComposeTabsRemovalPreflight { _, _, _ in .proceed }
-        let preparationToken = fixture.prompt.setComposeTabsRemovalPreparation { _, _, _ in
-            fixture.manager.activeWorkspace = otherWorkspace
-            return .proceed
-        }
-        defer {
-            fixture.prompt.removeComposeTabsRemovalPreflight(preflightToken)
-            fixture.prompt.removeComposeTabsRemovalPreparation(preparationToken)
-        }
-
-        await fixture.prompt.closeComposeTab(tabID)
-
-        let storedCapturedWorkspace = try XCTUnwrap(
-            fixture.manager.workspaces.first(where: { $0.id == capturedWorkspace.id })
-        )
-        XCTAssertEqual(storedCapturedWorkspace.composeTabs.map(\.id), capturedTabIDs)
-        XCTAssertEqual(fixture.manager.activeWorkspace?.id, otherWorkspace.id)
-    }
-
     func testFailedRequiredFlushKeepsTabRuntimeAndProjection() async throws {
         let fixture = makeFixture(initialTabCount: 2)
         let tabID = try XCTUnwrap(fixture.prompt.activeComposeTabID)
@@ -190,6 +156,95 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
         XCTAssertTrue(viewModel.sessions[tabID] === session)
         XCTAssertEqual(session.runState, .running)
         XCTAssertTrue(session.isDirty)
+    }
+
+    func testFailedDurableDeletionDoesNotResurrectRemovedComposeTab() async throws {
+        let fixture = makeFixture(initialTabCount: 2)
+        let tabID = try XCTUnwrap(fixture.prompt.activeComposeTabID)
+        let sessionID = try XCTUnwrap(fixture.manager.composeTab(with: tabID)?.activeAgentSessionID)
+        let viewModel = makeAgentModeViewModel(prompt: fixture.prompt, manager: fixture.manager)
+        let session = viewModel.session(for: tabID)
+        _ = viewModel.test_installPersistentSessionBinding(sessionID: sessionID, on: session)
+        session.runState = .running
+        viewModel.setAgentRunActive(tabID, isActive: true)
+
+        var teardownTabIDs: [UUID] = []
+        viewModel.test_setComposeTabRemovalTeardownObserver { removedTabID in
+            XCTAssertFalse(fixture.manager.activeWorkspace?.composeTabs.contains(where: { $0.id == removedTabID }) == true)
+            XCTAssertFalse(fixture.prompt.currentComposeTabs.contains(where: { $0.id == removedTabID }))
+            teardownTabIDs.append(removedTabID)
+        }
+        viewModel.test_setAgentSessionsDeleter { _, _ in
+            throw RequiredFlushTestError.injectedFailure
+        }
+        let didRemoveToken = installDidRemoveListener(prompt: fixture.prompt, viewModel: viewModel)
+        defer { fixture.prompt.removeComposeTabsDidRemoveListener(didRemoveToken) }
+        await fixture.prompt.closeComposeTab(tabID)
+
+        XCTAssertFalse(fixture.manager.activeWorkspace?.composeTabs.contains(where: { $0.id == tabID }) == true)
+        XCTAssertNil(viewModel.sessions[tabID])
+        XCTAssertEqual(teardownTabIDs, [tabID])
+    }
+
+    func testFailedStashedDeletionDoesNotResurrectRemovedProjection() async throws {
+        let fixture = makeFixture(initialTabCount: 2)
+        let stashedTab = try XCTUnwrap(fixture.manager.activeWorkspace?.stashedTabs.first)
+        let viewModel = makeAgentModeViewModel(prompt: fixture.prompt, manager: fixture.manager)
+        _ = viewModel.session(for: stashedTab.tab.id)
+        viewModel.test_setAgentSessionsDeleter { _, _ in
+            throw RequiredFlushTestError.injectedFailure
+        }
+        let didRemoveToken = installDidRemoveListener(prompt: fixture.prompt, viewModel: viewModel)
+        defer { fixture.prompt.removeComposeTabsDidRemoveListener(didRemoveToken) }
+
+        await fixture.prompt.deleteStashedTab(stashedTab.id)
+
+        XCTAssertFalse(fixture.prompt.currentStashedTabs.contains(where: { $0.id == stashedTab.id }))
+        XCTAssertFalse(fixture.manager.activeWorkspace?.stashedTabs.contains(where: { $0.id == stashedTab.id }) == true)
+        XCTAssertNil(viewModel.sessions[stashedTab.tab.id])
+    }
+
+    func testMultiTabDeletionFailureContinuesRemainingCleanup() async throws {
+        let fixture = makeFixture(initialTabCount: 3)
+        let tabs = try XCTUnwrap(fixture.manager.activeWorkspace?.composeTabs)
+        let viewModel = makeAgentModeViewModel(prompt: fixture.prompt, manager: fixture.manager)
+        for tab in tabs {
+            _ = viewModel.session(for: tab.id)
+        }
+        let orderedTabIDs = tabs.map(\.id).sorted(by: { $0.uuidString < $1.uuidString })
+        let attempts = DeletionAttemptRecorder(failingTabID: orderedTabIDs[1])
+        viewModel.test_setAgentSessionsDeleter { tabID, _ in
+            try await attempts.delete(tabID)
+        }
+        let didRemoveToken = installDidRemoveListener(prompt: fixture.prompt, viewModel: viewModel)
+        defer { fixture.prompt.removeComposeTabsDidRemoveListener(didRemoveToken) }
+
+        await fixture.prompt.closeAllComposeTabs()
+
+        let attemptedTabIDs = await attempts.attempted()
+        XCTAssertEqual(attemptedTabIDs, orderedTabIDs)
+        for tab in tabs {
+            XCTAssertNil(viewModel.sessions[tab.id])
+        }
+    }
+
+    func testStashRunsPostProjectionTeardownWithoutDurableDeletion() async throws {
+        let fixture = makeFixture(initialTabCount: 2)
+        let tabID = try XCTUnwrap(fixture.prompt.activeComposeTabID)
+        let viewModel = makeAgentModeViewModel(prompt: fixture.prompt, manager: fixture.manager)
+        _ = viewModel.session(for: tabID)
+        let attempts = DeletionAttemptRecorder(failingTabID: nil)
+        viewModel.test_setAgentSessionsDeleter { deletedTabID, _ in
+            try await attempts.delete(deletedTabID)
+        }
+        let didRemoveToken = installDidRemoveListener(prompt: fixture.prompt, viewModel: viewModel)
+        defer { fixture.prompt.removeComposeTabsDidRemoveListener(didRemoveToken) }
+        await fixture.prompt.stashTab(tabID)
+
+        XCTAssertTrue(fixture.manager.activeWorkspace?.stashedTabs.contains(where: { $0.tab.id == tabID }) == true)
+        XCTAssertNil(viewModel.sessions[tabID])
+        let attemptedTabIDs = await attempts.attempted()
+        XCTAssertTrue(attemptedTabIDs.isEmpty)
     }
 
     private func makeFixture(initialTabCount: Int) -> (manager: WorkspaceManagerViewModel, prompt: PromptViewModel) {
@@ -249,6 +304,15 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
         viewModel.test_setSidebarAutoArchiveDependencies(promptManager: prompt, workspaceManager: manager)
         return viewModel
     }
+
+    private func installDidRemoveListener(
+        prompt: PromptViewModel,
+        viewModel: AgentModeViewModel
+    ) -> UUID {
+        prompt.addComposeTabsDidRemoveListener { tabIDs, reason, workspaceID in
+            await viewModel.handleComposeTabsDidRemove(tabIDs, reason: reason, workspaceID: workspaceID)
+        }
+    }
 }
 
 private actor ComposeRemovalSideEffectRecorder {
@@ -284,6 +348,26 @@ private actor SaveAttemptRecorder {
 
     func count() -> Int {
         value
+    }
+}
+
+private actor DeletionAttemptRecorder {
+    private let failingTabID: UUID?
+    private var tabIDs: [UUID] = []
+
+    init(failingTabID: UUID?) {
+        self.failingTabID = failingTabID
+    }
+
+    func delete(_ tabID: UUID) throws {
+        tabIDs.append(tabID)
+        if tabID == failingTabID {
+            throw RequiredFlushTestError.injectedFailure
+        }
+    }
+
+    func attempted() -> [UUID] {
+        tabIDs
     }
 }
 


### PR DESCRIPTION
## Summary

- remove automatic Agent Mode tab eviction from foreground/background admission and sidebar refresh paths
- preserve pinned and unpinned tabs instead of silently dropping them at legacy count limits
- keep sidebar archival as a non-mutating suggestion and make destructive cleanup explicit
- harden failed creation, unstash, and workspace-switch handling so unrelated tabs are not selected or removed
- add regression coverage for crossing 499 through 502 tabs, restoring above 50 tabs, failed required flushes, and workspace changes during removal preparation

## Why

A newly created, pinned Agent Mode session could disappear from the sidebar even though the provider session remained durable. The effective data-loss behavior came from remaining automatic admission/refresh eviction paths after the earlier cap-removal work.

## Validation

- push preflight passed: source/contributor/legal/runtime guardrails, clean-tree check, exact outgoing-range review, and secret scan
- strict Swift lint passed
- BackgroundComposeTabAdmissionTests: 6 passed
- AgentModeViewModelInactiveRefreshTests: 35 passed
- AgentSessionDataServiceDeletionTests: passed
- RepoPrompt product build passed
- removed-policy symbol audit and git diff --check passed

The full PR-ready suite ran 4,057 tests with 11 skipped. One unrelated Codemap test produced two assertions: CodemapAutomaticSelectionGraphNativeTests.testPendingViewModelSelectionRetriesWhenMarkerBecomesReadyWithoutRootStatusChange. The coordinated daemon then became unresponsive after recording that terminal result, so that unrelated test could not be rerun in the resumed sandbox.

## Scope note

If a workspace changes after destructive Agent Mode preparation has already begun, Prompt now avoids mutating the captured projection, but runtime teardown may already be partial. Making that entire operation transactional is intentionally outside this bounded containment PR.