### PR TITLE
Prevent cancelled CLI requests from stalling or spawning

### DIFF
--- a/Sources/RepoPrompt/Infrastructure/Concurrency/TaskSemaphore.swift
+++ b/Sources/RepoPrompt/Infrastructure/Concurrency/TaskSemaphore.swift
@@ -5,12 +5,14 @@ import Foundation
 ///
 /// Usage:
 ///   let sem = TaskSemaphore(4)
-///   await sem.acquire()
+///   guard await sem.acquire() else { throw CancellationError() }
 ///   defer { await sem.release() }
 public actor TaskSemaphore {
+    private typealias Waiter = (id: UUID, continuation: CheckedContinuation<Bool, Never>)
+
     private let capacity: Int
     private var permits: Int
-    private var waiters: [CheckedContinuation<Void, Never>] = []
+    private var waiters: [Waiter] = []
 
     public init(_ permits: Int) {
         precondition(permits > 0, "Semaphore must have at least one permit")
@@ -19,21 +21,43 @@ public actor TaskSemaphore {
     }
 
     /// Suspend until a permit is available, then take it.
-    public func acquire() async {
+    ///
+    /// Returns `false` when the caller is already cancelled or is cancelled
+    /// while waiting. A cancelled waiter never consumes a permit.
+    @discardableResult
+    public func acquire() async -> Bool {
         if permits > 0 {
+            guard !Task.isCancelled else { return false }
             permits -= 1
-            return
+            return true
         }
-        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
-            waiters.append(cont)
+
+        let waiterID = UUID()
+        let acquired = await withTaskCancellationHandler {
+            await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
+                if Task.isCancelled {
+                    continuation.resume(returning: false)
+                } else {
+                    waiters.append((id: waiterID, continuation: continuation))
+                }
+            }
+        } onCancel: { [weak self] in
+            Task { await self?.removeCancelledWaiter(waiterID) }
         }
+
+        guard acquired else { return false }
+        guard !Task.isCancelled else {
+            release()
+            return false
+        }
+        return true
     }
 
     /// Return a permit to the pool and resume the next waiter if any.
     public func release() {
         if !waiters.isEmpty {
-            let cont = waiters.removeFirst()
-            cont.resume()
+            let waiter = waiters.removeFirst()
+            waiter.continuation.resume(returning: true)
         } else {
             #if DEBUG
                 assert(permits < capacity, "TaskSemaphore over-release detected")
@@ -42,10 +66,17 @@ public actor TaskSemaphore {
         }
     }
 
+    private func removeCancelledWaiter(_ id: UUID) {
+        guard let index = waiters.firstIndex(where: { $0.id == id }) else { return }
+        let waiter = waiters.remove(at: index)
+        waiter.continuation.resume(returning: false)
+    }
+
     /// Structured helper: acquires, runs `body`, then releases exactly once.
-    public func withPermit<T>(_ body: @Sendable () async throws -> T) async rethrows -> T {
-        await acquire()
+    public func withPermit<T>(_ body: @Sendable () async throws -> T) async throws -> T {
+        guard await acquire() else { throw CancellationError() }
         defer { release() } // actor-local; no extra Task hop
+        try Task.checkCancellation()
         return try await body()
     }
 }

--- a/Sources/RepoPrompt/Infrastructure/FileSystem/IgnoreRulesManager.swift
+++ b/Sources/RepoPrompt/Infrastructure/FileSystem/IgnoreRulesManager.swift
@@ -534,7 +534,7 @@ actor IgnoreRulesManager {
         // Create a single shared compilation task.
         let task = Task<CompiledIgnoreRules, Error> {
             // Bounded parallelism
-            await ioSemaphore.acquire()
+            guard await ioSemaphore.acquire() else { throw CancellationError() }
             do {
                 // Perform the (blocking) file read on the current executor – it's fine
                 // because we have limited the total number of concurrent reads.

--- a/Sources/RepoPrompt/Infrastructure/Process/CLIProcessRunner.swift
+++ b/Sources/RepoPrompt/Infrastructure/Process/CLIProcessRunner.swift
@@ -368,7 +368,7 @@ final class CLIProcessRunner {
     ) async throws -> AsyncThrowingStream<StreamEvent, Error> {
         // Hold the permit for the entire lifetime of the child process
         ProcessDiagnostics.log("🔵 [GATE] Acquiring gate...")
-        await gate.acquire()
+        guard await gate.acquire() else { throw CancellationError() }
         ProcessDiagnostics.log("🟢 [GATE] Acquired")
 
         // If the caller cancelled before we even start heavy work, bail out now.

--- a/Tests/RepoPromptTests/Infrastructure/Concurrency/TaskSemaphoreTests.swift
+++ b/Tests/RepoPromptTests/Infrastructure/Concurrency/TaskSemaphoreTests.swift
@@ -1,0 +1,45 @@
+import Foundation
+@testable import RepoPromptApp
+import XCTest
+
+final class TaskSemaphoreTests: XCTestCase {
+    func testCancellationCompletesAcquireWithoutWaitingForRelease() async throws {
+        let semaphore = TaskSemaphore(1)
+        let initiallyAcquired = await semaphore.acquire()
+        XCTAssertTrue(initiallyAcquired)
+
+        let started = AsyncTestCondition(false)
+        let completion = AsyncTestCondition<Bool?>(nil)
+        let waiter = Task {
+            started.update { $0 = true }
+            let acquired = await semaphore.acquire()
+            completion.update { $0 = acquired }
+            return acquired
+        }
+
+        try await started.waitUntil("semaphore waiter started") { $0 }
+        waiter.cancel()
+
+        let completedBeforeRelease = (try? await completion.waitUntil(
+            "cancelled semaphore waiter completion",
+            timeout: 1
+        ) { $0 != nil }) != nil
+
+        if !completedBeforeRelease {
+            // Keep a known-bad implementation from leaking a parked task and
+            // hanging teardown after the assertion below fails.
+            await semaphore.release()
+        }
+
+        XCTAssertTrue(completedBeforeRelease)
+        let waiterAcquired = await waiter.value
+        XCTAssertFalse(waiterAcquired)
+
+        await semaphore.release()
+
+        let followUp = Task { await semaphore.acquire() }
+        let followUpAcquired = await followUp.value
+        XCTAssertTrue(followUpAcquired)
+        await semaphore.release()
+    }
+}

--- a/Tests/RepoPromptTests/Infrastructure/Concurrency/TaskSemaphoreTests.swift
+++ b/Tests/RepoPromptTests/Infrastructure/Concurrency/TaskSemaphoreTests.swift
@@ -20,10 +20,11 @@ final class TaskSemaphoreTests: XCTestCase {
         try await started.waitUntil("semaphore waiter started") { $0 }
         waiter.cancel()
 
-        let completedBeforeRelease = (try? await completion.waitUntil(
+        let completionResult = try? await completion.waitUntil(
             "cancelled semaphore waiter completion",
             timeout: 1
-        ) { $0 != nil }) != nil
+        ) { $0 != nil }
+        let completedBeforeRelease = completionResult != nil
 
         if !completedBeforeRelease {
             // Keep a known-bad implementation from leaking a parked task and


### PR DESCRIPTION
Fixes #491.

### What was going wrong

`CLIProcessRunner` uses `TaskSemaphore` as its admission gate. If all permits are busy, a new request waits. Before this change, cancelling that waiting request did not wake it or remove it from the semaphore.

That produced two bad outcomes:

- the cancelled request could remain suspended indefinitely; or
- when a permit was eventually released, the cancelled request could resume, enter `withPermit(...)`, and reach process creation.

```mermaid
flowchart LR
    A["A holds the only permit"] --> B["B waits"]
    B --> C["B is cancelled"]
    C -->|before| D["B remains queued"]
    D --> E["A releases; B may continue"]
    E --> F["Cancelled request can spawn"]
    C -->|after| G["B is removed and resumed false"]
    G --> H["CancellationError; body is skipped"]
```

### Change

Make each queued semaphore waiter cancellation-aware and make admission return an explicit success/failure result.

- A cancelled waiter is removed and resumed with `false`.
- If cancellation races a permit handoff, the handoff is returned to the semaphore rather than consumed by cancelled work.
- `withPermit(...)` throws `CancellationError` before entering its body when admission fails or cancellation is observed.
- Manual `acquire()` callers handle a failed admission result.

This keeps cancellation ownership inside the semaphore and preserves permit accounting for later live requests.

### Regression coverage

`TaskSemaphoreTests.testCancellationCompletesAcquireWithoutWaitingForRelease` holds the only permit, queues a second task, cancels it, and requires that it complete before the held permit is released. It then releases the permit and verifies that a follow-up task can acquire it.

On the affected base behavior, the first completion assertion times out because the queued continuation remains parked; the test also has cleanup to avoid leaving that known-bad waiter suspended during teardown.

### Validation

- `git diff --check` — passed
- Swift/XCTest and repository guardrail execution require the macOS/Xcode toolchain; hosted macOS CI is the remaining build and test proof for this branch.