### PR TITLE
Report preset save failures and roll back non-durable edits

### DIFF
--- a/Sources/RepoPrompt/Features/Chat/ViewModels/Presets/ChatPresetManager.swift
+++ b/Sources/RepoPrompt/Features/Chat/ViewModels/Presets/ChatPresetManager.swift
@@ -22,17 +22,19 @@ class ChatPresetManager: ObservableObject {
             rebuildAllPresetsCache()
         }
     }
+    @Published private(set) var persistenceErrorMessage: String?
 
     // MARK: - Storage
 
-    private let presetFileStore = PresetFileStore.shared
+    private let presetFileStore: PresetFileStore
 
     /// All presets (built-in + user), with overrides applied to built-ins
     @Published private(set) var allPresets: [ChatPreset] = []
 
     // MARK: - Initialization
 
-    private init() {
+    init(presetFileStore: PresetFileStore = .shared) {
+        self.presetFileStore = presetFileStore
         load()
         rebuildAllPresetsCache()
     }
@@ -79,7 +81,7 @@ class ChatPresetManager: ObservableObject {
 
     /// Save user presets to Application Support JSON.
     func save() {
-        persistChatState()
+        persistChatStateReportingFailure()
     }
 
     /// Add a new user preset
@@ -88,8 +90,9 @@ class ChatPresetManager: ObservableObject {
             print("Cannot add built-in preset as user preset")
             return
         }
-        userPresets.append(preset)
-        save()
+        mutateAndPersist {
+            userPresets.append(preset)
+        }
     }
 
     /// Update an existing user preset
@@ -100,8 +103,9 @@ class ChatPresetManager: ObservableObject {
         }
 
         if let index = userPresets.firstIndex(where: { $0.id == preset.id }) {
-            userPresets[index] = preset
-            save()
+            mutateAndPersist {
+                userPresets[index] = preset
+            }
         }
     }
 
@@ -112,14 +116,16 @@ class ChatPresetManager: ObservableObject {
             return
         }
 
-        userPresets.removeAll { $0.id == preset.id }
-        save()
+        mutateAndPersist {
+            userPresets.removeAll { $0.id == preset.id }
+        }
     }
 
     /// Remove a user preset by ID
     func remove(id: UUID) {
-        userPresets.removeAll { $0.id == id }
-        save()
+        mutateAndPersist {
+            userPresets.removeAll { $0.id == id }
+        }
     }
 
     /// Add a preset (convenience method matching the settings view)
@@ -139,9 +145,10 @@ class ChatPresetManager: ObservableObject {
 
     /// Toggle preset visibility
     func togglePresetVisibility(_ preset: ChatPreset) {
-        let currentVisibility = presetVisibility[preset.id] ?? true
-        presetVisibility[preset.id] = !currentVisibility
-        saveVisibility()
+        mutateAndPersist {
+            let currentVisibility = presetVisibility[preset.id] ?? true
+            presetVisibility[preset.id] = !currentVisibility
+        }
     }
 
     /// Check if a preset is visible
@@ -152,11 +159,6 @@ class ChatPresetManager: ObservableObject {
     /// Load visibility settings from Application Support JSON.
     private func loadVisibility() {
         presetVisibility = presetFileStore.loadWorkflowPresets().chatVisibility
-    }
-
-    /// Save visibility settings to Application Support JSON.
-    private func saveVisibility() {
-        persistChatState()
     }
 
     /// Create a chat preset from current settings
@@ -268,8 +270,9 @@ class ChatPresetManager: ObservableObject {
         if trimmed.isEmpty {
             clearOverrides(for: override.presetID)
         } else {
-            overrides[override.presetID] = trimmed
-            saveOverrides()
+            mutateAndPersist {
+                overrides[override.presetID] = trimmed
+            }
         }
     }
 
@@ -282,8 +285,9 @@ class ChatPresetManager: ObservableObject {
 
     /// Clear all overrides for a preset
     func clearOverrides(for id: UUID) {
-        overrides.removeValue(forKey: id)
-        saveOverrides()
+        mutateAndPersist {
+            overrides.removeValue(forKey: id)
+        }
     }
 
     /// Get a resolved preset with overrides applied
@@ -325,17 +329,46 @@ class ChatPresetManager: ObservableObject {
         overrides = Dictionary(overridesList.map { ($0.presetID, $0) }, uniquingKeysWith: { _, new in new })
     }
 
-    /// Save overrides to Application Support JSON.
-    private func saveOverrides() {
-        persistChatState()
+    func clearPersistenceError() {
+        persistenceErrorMessage = nil
     }
 
-    private func persistChatState() {
+    private func mutateAndPersist(_ mutation: () -> Void) {
+        let previousUserPresets = userPresets
+        let previousVisibility = presetVisibility
+        let previousOverrides = overrides
+        mutation()
+
+        do {
+            try persistChatState()
+            persistenceErrorMessage = nil
+        } catch {
+            userPresets = previousUserPresets
+            presetVisibility = previousVisibility
+            overrides = previousOverrides
+            reportPersistenceFailure(error)
+        }
+    }
+
+    private func persistChatStateReportingFailure() {
+        do {
+            try persistChatState()
+            persistenceErrorMessage = nil
+        } catch {
+            reportPersistenceFailure(error)
+        }
+    }
+
+    private func persistChatState() throws {
         let overridesList = Array(overrides.values)
-        presetFileStore.updateWorkflowPresets { document in
+        try presetFileStore.updateWorkflowPresets { document in
             document.chatUserPresets = userPresets
             document.chatVisibility = presetVisibility
             document.chatOverrides = overridesList
         }
+    }
+
+    private func reportPersistenceFailure(_ error: Error) {
+        persistenceErrorMessage = "Your chat preset change wasn't saved and has been reverted. \(error.localizedDescription)"
     }
 }

--- a/Sources/RepoPrompt/Features/Chat/ViewModels/Presets/ChatPresetManager.swift
+++ b/Sources/RepoPrompt/Features/Chat/ViewModels/Presets/ChatPresetManager.swift
@@ -79,11 +79,6 @@ class ChatPresetManager: ObservableObject {
         overrides = Dictionary(document.chatOverrides.map { ($0.presetID, $0) }, uniquingKeysWith: { _, new in new })
     }
 
-    /// Save user presets to Application Support JSON.
-    func save() {
-        persistChatStateReportingFailure()
-    }
-
     /// Add a new user preset
     func add(_ preset: ChatPreset) {
         guard !preset.isBuiltIn else {
@@ -346,15 +341,6 @@ class ChatPresetManager: ObservableObject {
             userPresets = previousUserPresets
             presetVisibility = previousVisibility
             overrides = previousOverrides
-            reportPersistenceFailure(error)
-        }
-    }
-
-    private func persistChatStateReportingFailure() {
-        do {
-            try persistChatState()
-            persistenceErrorMessage = nil
-        } catch {
             reportPersistenceFailure(error)
         }
     }

--- a/Sources/RepoPrompt/Features/Chat/ViewModels/Presets/ChatPresetManager.swift
+++ b/Sources/RepoPrompt/Features/Chat/ViewModels/Presets/ChatPresetManager.swift
@@ -22,6 +22,7 @@ class ChatPresetManager: ObservableObject {
             rebuildAllPresetsCache()
         }
     }
+
     @Published private(set) var persistenceErrorMessage: String?
 
     // MARK: - Storage

--- a/Sources/RepoPrompt/Features/Prompt/ViewModels/Copy/CopyPresetManager.swift
+++ b/Sources/RepoPrompt/Features/Prompt/ViewModels/Copy/CopyPresetManager.swift
@@ -22,6 +22,7 @@ class CopyPresetManager: ObservableObject {
             rebuildAllPresetsCache()
         }
     }
+
     @Published private(set) var persistenceErrorMessage: String?
 
     // MARK: - Storage

--- a/Sources/RepoPrompt/Features/Prompt/ViewModels/Copy/CopyPresetManager.swift
+++ b/Sources/RepoPrompt/Features/Prompt/ViewModels/Copy/CopyPresetManager.swift
@@ -22,17 +22,19 @@ class CopyPresetManager: ObservableObject {
             rebuildAllPresetsCache()
         }
     }
+    @Published private(set) var persistenceErrorMessage: String?
 
     // MARK: - Storage
 
-    private let presetFileStore = PresetFileStore.shared
+    private let presetFileStore: PresetFileStore
 
     /// All presets (built-in + user), with overrides applied to built-ins
     @Published private(set) var allPresets: [CopyPreset] = []
 
     // MARK: - Initialization
 
-    private init() {
+    init(presetFileStore: PresetFileStore = .shared) {
+        self.presetFileStore = presetFileStore
         load()
         rebuildAllPresetsCache()
     }
@@ -81,7 +83,7 @@ class CopyPresetManager: ObservableObject {
 
     /// Save user presets to Application Support JSON.
     func save() {
-        persistCopyState()
+        persistCopyStateReportingFailure()
     }
 
     /// Add a new user preset
@@ -90,8 +92,9 @@ class CopyPresetManager: ObservableObject {
             print("Cannot add built-in preset as user preset")
             return
         }
-        userPresets.append(preset)
-        save()
+        mutateAndPersist {
+            userPresets.append(preset)
+        }
     }
 
     /// Update an existing user preset
@@ -102,8 +105,9 @@ class CopyPresetManager: ObservableObject {
         }
 
         if let index = userPresets.firstIndex(where: { $0.id == preset.id }) {
-            userPresets[index] = preset
-            save()
+            mutateAndPersist {
+                userPresets[index] = preset
+            }
         }
     }
 
@@ -114,14 +118,16 @@ class CopyPresetManager: ObservableObject {
             return
         }
 
-        userPresets.removeAll { $0.id == preset.id }
-        save()
+        mutateAndPersist {
+            userPresets.removeAll { $0.id == preset.id }
+        }
     }
 
     /// Remove a user preset by ID
     func remove(id: UUID) {
-        userPresets.removeAll { $0.id == id }
-        save()
+        mutateAndPersist {
+            userPresets.removeAll { $0.id == id }
+        }
     }
 
     /// Add a preset (convenience method matching the settings view)
@@ -141,9 +147,10 @@ class CopyPresetManager: ObservableObject {
 
     /// Toggle preset visibility
     func togglePresetVisibility(_ preset: CopyPreset) {
-        let currentVisibility = presetVisibility[preset.id] ?? true
-        presetVisibility[preset.id] = !currentVisibility
-        saveVisibility()
+        mutateAndPersist {
+            let currentVisibility = presetVisibility[preset.id] ?? true
+            presetVisibility[preset.id] = !currentVisibility
+        }
     }
 
     /// Check if a preset is visible
@@ -154,11 +161,6 @@ class CopyPresetManager: ObservableObject {
     /// Load visibility settings from Application Support JSON.
     private func loadVisibility() {
         presetVisibility = presetFileStore.loadWorkflowPresets().copyVisibility
-    }
-
-    /// Save visibility settings to Application Support JSON.
-    private func saveVisibility() {
-        persistCopyState()
     }
 
     /// Create a preset from current settings
@@ -234,8 +236,9 @@ class CopyPresetManager: ObservableObject {
         if trimmed.isEmpty {
             clearOverrides(for: override.presetID)
         } else {
-            overrides[override.presetID] = trimmed
-            saveOverrides()
+            mutateAndPersist {
+                overrides[override.presetID] = trimmed
+            }
         }
     }
 
@@ -248,8 +251,9 @@ class CopyPresetManager: ObservableObject {
 
     /// Clear all overrides for a preset
     func clearOverrides(for id: UUID) {
-        overrides.removeValue(forKey: id)
-        saveOverrides()
+        mutateAndPersist {
+            overrides.removeValue(forKey: id)
+        }
     }
 
     /// Get a resolved preset with overrides applied
@@ -298,17 +302,46 @@ class CopyPresetManager: ObservableObject {
         )
     }
 
-    /// Save overrides to Application Support JSON.
-    private func saveOverrides() {
-        persistCopyState()
+    func clearPersistenceError() {
+        persistenceErrorMessage = nil
     }
 
-    private func persistCopyState() {
+    private func mutateAndPersist(_ mutation: () -> Void) {
+        let previousUserPresets = userPresets
+        let previousVisibility = presetVisibility
+        let previousOverrides = overrides
+        mutation()
+
+        do {
+            try persistCopyState()
+            persistenceErrorMessage = nil
+        } catch {
+            userPresets = previousUserPresets
+            presetVisibility = previousVisibility
+            overrides = previousOverrides
+            reportPersistenceFailure(error)
+        }
+    }
+
+    private func persistCopyStateReportingFailure() {
+        do {
+            try persistCopyState()
+            persistenceErrorMessage = nil
+        } catch {
+            reportPersistenceFailure(error)
+        }
+    }
+
+    private func persistCopyState() throws {
         let overridesList = Array(overrides.values)
-        presetFileStore.updateWorkflowPresets { document in
+        try presetFileStore.updateWorkflowPresets { document in
             document.copyUserPresets = userPresets
             document.copyVisibility = presetVisibility
             document.copyOverrides = overridesList
         }
+    }
+
+    private func reportPersistenceFailure(_ error: Error) {
+        persistenceErrorMessage = "Your copy preset change wasn't saved and has been reverted. \(error.localizedDescription)"
     }
 }

--- a/Sources/RepoPrompt/Features/Prompt/ViewModels/Copy/CopyPresetManager.swift
+++ b/Sources/RepoPrompt/Features/Prompt/ViewModels/Copy/CopyPresetManager.swift
@@ -81,11 +81,6 @@ class CopyPresetManager: ObservableObject {
         )
     }
 
-    /// Save user presets to Application Support JSON.
-    func save() {
-        persistCopyStateReportingFailure()
-    }
-
     /// Add a new user preset
     func add(_ preset: CopyPreset) {
         guard !preset.isBuiltIn else {
@@ -319,15 +314,6 @@ class CopyPresetManager: ObservableObject {
             userPresets = previousUserPresets
             presetVisibility = previousVisibility
             overrides = previousOverrides
-            reportPersistenceFailure(error)
-        }
-    }
-
-    private func persistCopyStateReportingFailure() {
-        do {
-            try persistCopyState()
-            persistenceErrorMessage = nil
-        } catch {
             reportPersistenceFailure(error)
         }
     }

--- a/Sources/RepoPrompt/Features/Settings/Views/ChatPresetsSettingsView.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/ChatPresetsSettingsView.swift
@@ -121,6 +121,20 @@ struct ChatPresetsSettingsView: View {
         } message: {
             Text("Are you sure you want to delete '\(presetToDelete?.name ?? "")'? This action cannot be undone.")
         }
+        .alert("Preset Save Failed", isPresented: persistenceErrorBinding) {
+            Button("OK", role: .cancel) { presetManager.clearPersistenceError() }
+        } message: {
+            Text(presetManager.persistenceErrorMessage ?? "The preset change couldn't be saved.")
+        }
+    }
+
+    private var persistenceErrorBinding: Binding<Bool> {
+        Binding(
+            get: { presetManager.persistenceErrorMessage != nil },
+            set: { isPresented in
+                if !isPresented { presetManager.clearPersistenceError() }
+            }
+        )
     }
 
     // MARK: - Header

--- a/Sources/RepoPrompt/Features/Settings/Views/ChatPresetsSettingsView.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/ChatPresetsSettingsView.swift
@@ -121,10 +121,11 @@ struct ChatPresetsSettingsView: View {
         } message: {
             Text("Are you sure you want to delete '\(presetToDelete?.name ?? "")'? This action cannot be undone.")
         }
-        .alert("Preset Save Failed", isPresented: persistenceErrorBinding) {
-            Button("OK", role: .cancel) { presetManager.clearPersistenceError() }
-        } message: {
-            Text(presetManager.persistenceErrorMessage ?? "The preset change couldn't be saved.")
+        .background {
+            PresetPersistenceErrorAlertHost(
+                message: presetManager.persistenceErrorMessage ?? "The preset change couldn't be saved.",
+                isPresented: persistenceErrorBinding
+            )
         }
     }
 

--- a/Sources/RepoPrompt/Features/Settings/Views/CopyPresetsSettingsView.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/CopyPresetsSettingsView.swift
@@ -152,6 +152,20 @@ struct CopyPresetsSettingsView: View {
         } message: {
             Text("Are you sure you want to delete '\(presetToDelete?.name ?? "")'? This action cannot be undone.")
         }
+        .alert("Preset Save Failed", isPresented: persistenceErrorBinding) {
+            Button("OK", role: .cancel) { presetManager.clearPersistenceError() }
+        } message: {
+            Text(presetManager.persistenceErrorMessage ?? "The preset change couldn't be saved.")
+        }
+    }
+
+    private var persistenceErrorBinding: Binding<Bool> {
+        Binding(
+            get: { presetManager.persistenceErrorMessage != nil },
+            set: { isPresented in
+                if !isPresented { presetManager.clearPersistenceError() }
+            }
+        )
     }
 
     // MARK: - Header

--- a/Sources/RepoPrompt/Features/Settings/Views/CopyPresetsSettingsView.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/CopyPresetsSettingsView.swift
@@ -152,10 +152,11 @@ struct CopyPresetsSettingsView: View {
         } message: {
             Text("Are you sure you want to delete '\(presetToDelete?.name ?? "")'? This action cannot be undone.")
         }
-        .alert("Preset Save Failed", isPresented: persistenceErrorBinding) {
-            Button("OK", role: .cancel) { presetManager.clearPersistenceError() }
-        } message: {
-            Text(presetManager.persistenceErrorMessage ?? "The preset change couldn't be saved.")
+        .background {
+            PresetPersistenceErrorAlertHost(
+                message: presetManager.persistenceErrorMessage ?? "The preset change couldn't be saved.",
+                isPresented: persistenceErrorBinding
+            )
         }
     }
 

--- a/Sources/RepoPrompt/Features/Settings/Views/ModelPresetsSettingsView.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/ModelPresetsSettingsView.swift
@@ -47,6 +47,20 @@ struct ModelPresetsSettingsView: View {
                 }
             )
         }
+        .alert("Preset Save Failed", isPresented: persistenceErrorBinding) {
+            Button("OK", role: .cancel) { presetsManager.clearPersistenceError() }
+        } message: {
+            Text(presetsManager.persistenceErrorMessage ?? "The preset change couldn't be saved.")
+        }
+    }
+
+    private var persistenceErrorBinding: Binding<Bool> {
+        Binding(
+            get: { presetsManager.persistenceErrorMessage != nil },
+            set: { isPresented in
+                if !isPresented { presetsManager.clearPersistenceError() }
+            }
+        )
     }
 
     private var emptyStateView: some View {

--- a/Sources/RepoPrompt/Features/Settings/Views/ModelPresetsSettingsView.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/ModelPresetsSettingsView.swift
@@ -82,8 +82,9 @@ struct ModelPresetsSettingsView: View {
             Button(action: {
                 // Create default preset from current chat model
                 let defaultPreset = ModelPreset.fromCurrentChatModel(modelRawString: promptViewModel.preferredModel)
-                presetsManager.addPreset(defaultPreset)
-                editingPreset = defaultPreset
+                if presetsManager.addPreset(defaultPreset) {
+                    editingPreset = defaultPreset
+                }
             }) {
                 Label("Create Default Preset", systemImage: "plus.circle")
             }

--- a/Sources/RepoPrompt/Features/Settings/Views/ModelPresetsSettingsView.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/ModelPresetsSettingsView.swift
@@ -47,10 +47,11 @@ struct ModelPresetsSettingsView: View {
                 }
             )
         }
-        .alert("Preset Save Failed", isPresented: persistenceErrorBinding) {
-            Button("OK", role: .cancel) { presetsManager.clearPersistenceError() }
-        } message: {
-            Text(presetsManager.persistenceErrorMessage ?? "The preset change couldn't be saved.")
+        .background {
+            PresetPersistenceErrorAlertHost(
+                message: presetsManager.persistenceErrorMessage ?? "The preset change couldn't be saved.",
+                isPresented: persistenceErrorBinding
+            )
         }
     }
 

--- a/Sources/RepoPrompt/Features/Settings/Views/ModelPresetsSheet.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/ModelPresetsSheet.swift
@@ -40,10 +40,11 @@ struct ModelPresetsSheet: View {
                 }
             )
         }
-        .alert("Preset Save Failed", isPresented: persistenceErrorBinding) {
-            Button("OK", role: .cancel) { presetsManager.clearPersistenceError() }
-        } message: {
-            Text(presetsManager.persistenceErrorMessage ?? "The preset change couldn't be saved.")
+        .background {
+            PresetPersistenceErrorAlertHost(
+                message: presetsManager.persistenceErrorMessage ?? "The preset change couldn't be saved.",
+                isPresented: persistenceErrorBinding
+            )
         }
     }
 

--- a/Sources/RepoPrompt/Features/Settings/Views/ModelPresetsSheet.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/ModelPresetsSheet.swift
@@ -95,8 +95,9 @@ struct ModelPresetsSheet: View {
             Button(action: {
                 // Create default preset from current chat model
                 let defaultPreset = ModelPreset.fromCurrentChatModel(modelRawString: promptViewModel.preferredModel)
-                presetsManager.addPreset(defaultPreset)
-                editingPreset = defaultPreset
+                if presetsManager.addPreset(defaultPreset) {
+                    editingPreset = defaultPreset
+                }
             }) {
                 Label("Create Default Preset", systemImage: "plus.circle")
             }

--- a/Sources/RepoPrompt/Features/Settings/Views/ModelPresetsSheet.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/ModelPresetsSheet.swift
@@ -40,6 +40,20 @@ struct ModelPresetsSheet: View {
                 }
             )
         }
+        .alert("Preset Save Failed", isPresented: persistenceErrorBinding) {
+            Button("OK", role: .cancel) { presetsManager.clearPersistenceError() }
+        } message: {
+            Text(presetsManager.persistenceErrorMessage ?? "The preset change couldn't be saved.")
+        }
+    }
+
+    private var persistenceErrorBinding: Binding<Bool> {
+        Binding(
+            get: { presetsManager.persistenceErrorMessage != nil },
+            set: { isPresented in
+                if !isPresented { presetsManager.clearPersistenceError() }
+            }
+        )
     }
 
     private var headerView: some View {

--- a/Sources/RepoPrompt/Features/Settings/Views/PresetPersistenceErrorAlertHost.swift
+++ b/Sources/RepoPrompt/Features/Settings/Views/PresetPersistenceErrorAlertHost.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+struct PresetPersistenceErrorAlertHost: View {
+    let message: String
+    @Binding var isPresented: Bool
+
+    var body: some View {
+        Color.clear
+            .frame(width: 0, height: 0)
+            .alert("Preset Save Failed", isPresented: $isPresented) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                Text(message)
+            }
+    }
+}

--- a/Sources/RepoPrompt/Infrastructure/AI/Models/ModelPreset.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Models/ModelPreset.swift
@@ -339,11 +339,13 @@ struct ChatPresetMappings: Codable, Equatable {
 class ModelPresetsManager: ObservableObject {
     static let shared = ModelPresetsManager()
 
-    private let presetFileStore = PresetFileStore.shared
+    private let presetFileStore: PresetFileStore
 
     @Published var presets: [ModelPreset] = []
+    @Published private(set) var persistenceErrorMessage: String?
 
-    private init() {
+    init(presetFileStore: PresetFileStore = .shared) {
+        self.presetFileStore = presetFileStore
         loadPresets()
     }
 
@@ -353,42 +355,64 @@ class ModelPresetsManager: ObservableObject {
     }
 
     /// Saves presets to Application Support JSON.
-    private func savePresets() {
-        presetFileStore.saveModelPresets(
+    private func savePresets() throws {
+        try presetFileStore.saveModelPresets(
             PresetFileStore.ModelPresetDocument(modelPresets: presets)
         )
     }
 
     /// Adds a new preset
     func addPreset(_ preset: ModelPreset) {
-        presets.append(preset)
-        savePresets()
+        mutateAndPersist {
+            presets.append(preset)
+        }
     }
 
     /// Updates an existing preset
     func updatePreset(_ preset: ModelPreset) {
         if let index = presets.firstIndex(where: { $0.id == preset.id }) {
-            presets[index] = preset
-            savePresets()
+            mutateAndPersist {
+                presets[index] = preset
+            }
         }
     }
 
     /// Removes a preset
     func removePreset(_ preset: ModelPreset) {
-        presets.removeAll { $0.id == preset.id }
-        savePresets()
+        mutateAndPersist {
+            presets.removeAll { $0.id == preset.id }
+        }
     }
 
     /// Removes presets at the specified offsets
     func removePresets(at offsets: IndexSet) {
-        presets.remove(atOffsets: offsets)
-        savePresets()
+        mutateAndPersist {
+            presets.remove(atOffsets: offsets)
+        }
     }
 
     /// Moves presets for reordering
     func movePresets(from source: IndexSet, to destination: Int) {
-        presets.move(fromOffsets: source, toOffset: destination)
-        savePresets()
+        mutateAndPersist {
+            presets.move(fromOffsets: source, toOffset: destination)
+        }
+    }
+
+    func clearPersistenceError() {
+        persistenceErrorMessage = nil
+    }
+
+    private func mutateAndPersist(_ mutation: () -> Void) {
+        let previousPresets = presets
+        mutation()
+
+        do {
+            try savePresets()
+            persistenceErrorMessage = nil
+        } catch {
+            presets = previousPresets
+            persistenceErrorMessage = "Your model preset change wasn't saved and has been reverted. \(error.localizedDescription)"
+        }
     }
 
     /// Returns available presets for a specific mode

--- a/Sources/RepoPrompt/Infrastructure/AI/Models/ModelPreset.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Models/ModelPreset.swift
@@ -362,7 +362,8 @@ class ModelPresetsManager: ObservableObject {
     }
 
     /// Adds a new preset
-    func addPreset(_ preset: ModelPreset) {
+    @discardableResult
+    func addPreset(_ preset: ModelPreset) -> Bool {
         mutateAndPersist {
             presets.append(preset)
         }
@@ -402,16 +403,19 @@ class ModelPresetsManager: ObservableObject {
         persistenceErrorMessage = nil
     }
 
-    private func mutateAndPersist(_ mutation: () -> Void) {
+    @discardableResult
+    private func mutateAndPersist(_ mutation: () -> Void) -> Bool {
         let previousPresets = presets
         mutation()
 
         do {
             try savePresets()
             persistenceErrorMessage = nil
+            return true
         } catch {
             presets = previousPresets
             persistenceErrorMessage = "Your model preset change wasn't saved and has been reverted. \(error.localizedDescription)"
+            return false
         }
     }
 

--- a/Sources/RepoPrompt/Infrastructure/Persistence/Presets/PresetFileStore.swift
+++ b/Sources/RepoPrompt/Infrastructure/Persistence/Presets/PresetFileStore.swift
@@ -69,7 +69,7 @@ final class PresetFileStore {
             } catch {
                 let fallback = WorkflowPresetDocument(updatedAt: now())
                 if backupCorruptFile(at: workflowFileURL, prefix: "workflowPresets", error: error) {
-                    saveWorkflowPresets(fallback)
+                    saveBootstrapWorkflowPresets(fallback)
                 } else {
                     preservingUnbackedCorruptWorkflowDocument = true
                 }
@@ -78,37 +78,39 @@ final class PresetFileStore {
         }
 
         let document = WorkflowPresetDocument(updatedAt: now())
-        saveWorkflowPresets(document)
+        saveBootstrapWorkflowPresets(document)
         return document
     }
 
     func updateWorkflowPresets(
         _ mutation: (inout WorkflowPresetDocument) -> Void
-    ) {
+    ) throws {
         var document = loadWorkflowPresets()
         mutation(&document)
-        saveWorkflowPresets(document)
+        try saveWorkflowPresets(document)
     }
 
-    func saveWorkflowPresets(_ document: WorkflowPresetDocument) {
-        guard !preservingUnsupportedFutureWorkflowDocument else { return }
-        guard !preservingUnbackedCorruptWorkflowDocument else { return }
+    func saveWorkflowPresets(_ document: WorkflowPresetDocument) throws {
+        guard !preservingUnsupportedFutureWorkflowDocument else {
+            let version = unsupportedFutureSchemaVersionOnDisk(at: workflowFileURL)
+                ?? Self.currentSchemaVersion + 1
+            throw PresetFileStoreError.unsupportedFutureSchema(version)
+        }
+        guard !preservingUnbackedCorruptWorkflowDocument else {
+            throw PresetFileStoreError.unbackedCorruptDocumentPreserved
+        }
         if let version = unsupportedFutureSchemaVersionOnDisk(at: workflowFileURL) {
             preservingUnsupportedFutureWorkflowDocument = true
             print("⚠️ Workflow presets JSON schema v\(version) is newer than supported v\(Self.currentSchemaVersion); preserving file and skipping save.")
-            return
+            throw PresetFileStoreError.unsupportedFutureSchema(version)
         }
 
         var documentToWrite = document
         documentToWrite.schemaVersion = Self.currentSchemaVersion
         documentToWrite.updatedAt = now()
-        do {
-            try ensurePresetDirectoryExists(for: workflowFileURL)
-            let data = try Self.fileEncoder.encode(documentToWrite)
-            try data.write(to: workflowFileURL, options: .atomic)
-        } catch {
-            print("⚠️ Failed to save workflow presets JSON at \(workflowFileURL.path): \(error)")
-        }
+        try ensurePresetDirectoryExists(for: workflowFileURL)
+        let data = try Self.fileEncoder.encode(documentToWrite)
+        try data.write(to: workflowFileURL, options: .atomic)
     }
 
     func loadWorkflowDocument() throws -> WorkflowPresetDocument {
@@ -138,7 +140,7 @@ final class PresetFileStore {
             } catch {
                 let fallback = ModelPresetDocument(updatedAt: now())
                 if backupCorruptFile(at: modelFileURL, prefix: "modelPresets", error: error) {
-                    saveModelPresets(fallback)
+                    saveBootstrapModelPresets(fallback)
                 } else {
                     preservingUnbackedCorruptModelDocument = true
                 }
@@ -147,29 +149,31 @@ final class PresetFileStore {
         }
 
         let document = ModelPresetDocument(updatedAt: now())
-        saveModelPresets(document)
+        saveBootstrapModelPresets(document)
         return document
     }
 
-    func saveModelPresets(_ document: ModelPresetDocument) {
-        guard !preservingUnsupportedFutureModelDocument else { return }
-        guard !preservingUnbackedCorruptModelDocument else { return }
+    func saveModelPresets(_ document: ModelPresetDocument) throws {
+        guard !preservingUnsupportedFutureModelDocument else {
+            let version = unsupportedFutureSchemaVersionOnDisk(at: modelFileURL)
+                ?? Self.currentSchemaVersion + 1
+            throw PresetFileStoreError.unsupportedFutureSchema(version)
+        }
+        guard !preservingUnbackedCorruptModelDocument else {
+            throw PresetFileStoreError.unbackedCorruptDocumentPreserved
+        }
         if let version = unsupportedFutureSchemaVersionOnDisk(at: modelFileURL) {
             preservingUnsupportedFutureModelDocument = true
             print("⚠️ Model presets JSON schema v\(version) is newer than supported v\(Self.currentSchemaVersion); preserving file and skipping save.")
-            return
+            throw PresetFileStoreError.unsupportedFutureSchema(version)
         }
 
         var documentToWrite = document
         documentToWrite.schemaVersion = Self.currentSchemaVersion
         documentToWrite.updatedAt = now()
-        do {
-            try ensurePresetDirectoryExists(for: modelFileURL)
-            let data = try Self.fileEncoder.encode(documentToWrite)
-            try data.write(to: modelFileURL, options: .atomic)
-        } catch {
-            print("⚠️ Failed to save model presets JSON at \(modelFileURL.path): \(error)")
-        }
+        try ensurePresetDirectoryExists(for: modelFileURL)
+        let data = try Self.fileEncoder.encode(documentToWrite)
+        try data.write(to: modelFileURL, options: .atomic)
     }
 
     func loadModelDocument() throws -> ModelPresetDocument {
@@ -185,6 +189,22 @@ final class PresetFileStore {
     }
 
     // MARK: - Files
+
+    private func saveBootstrapWorkflowPresets(_ document: WorkflowPresetDocument) {
+        do {
+            try saveWorkflowPresets(document)
+        } catch {
+            print("⚠️ Failed to create workflow presets JSON at \(workflowFileURL.path): \(error)")
+        }
+    }
+
+    private func saveBootstrapModelPresets(_ document: ModelPresetDocument) {
+        do {
+            try saveModelPresets(document)
+        } catch {
+            print("⚠️ Failed to create model presets JSON at \(modelFileURL.path): \(error)")
+        }
+    }
 
     private func ensurePresetDirectoryExists(for fileURL: URL) throws {
         try fileManager.createDirectory(
@@ -243,8 +263,18 @@ final class PresetFileStore {
         let schemaVersion: Int
     }
 
-    enum PresetFileStoreError: Error, Equatable {
+    enum PresetFileStoreError: LocalizedError, Equatable {
         case unsupportedFutureSchema(Int)
+        case unbackedCorruptDocumentPreserved
+
+        var errorDescription: String? {
+            switch self {
+            case let .unsupportedFutureSchema(version):
+                "The preset file uses schema v\(version), but this build supports up to v\(PresetFileStore.currentSchemaVersion). The newer file was preserved."
+            case .unbackedCorruptDocumentPreserved:
+                "The unreadable preset file could not be backed up, so it was preserved."
+            }
+        }
     }
 
     private static let fileEncoder: JSONEncoder = {

--- a/Tests/RepoPromptTests/PresetJSONOnlyPersistenceTests.swift
+++ b/Tests/RepoPromptTests/PresetJSONOnlyPersistenceTests.swift
@@ -129,10 +129,18 @@ final class PresetJSONOnlyPersistenceTests: XCTestCase {
         let manager = ModelPresetsManager(presetFileStore: store)
         let preset = ModelPreset(name: "Unsaved model", model: .claude4Sonnet)
 
-        manager.addPreset(preset)
+        XCTAssertFalse(manager.addPreset(preset))
 
         XCTAssertFalse(manager.presets.contains(where: { $0.id == preset.id }))
         XCTAssertNotNil(manager.persistenceErrorMessage)
+
+        let blockedParent = store.modelFileURL.deletingLastPathComponent()
+        try FileManager.default.removeItem(at: blockedParent)
+        try FileManager.default.createDirectory(at: blockedParent, withIntermediateDirectories: true)
+
+        XCTAssertTrue(manager.addPreset(preset))
+        XCTAssertTrue(manager.presets.contains(where: { $0.id == preset.id }))
+        XCTAssertNil(manager.persistenceErrorMessage)
     }
 
     func testCorruptPresetJSONIsBackedUpAndReplacedWithEmptyDocument() throws {

--- a/Tests/RepoPromptTests/PresetJSONOnlyPersistenceTests.swift
+++ b/Tests/RepoPromptTests/PresetJSONOnlyPersistenceTests.swift
@@ -60,14 +60,79 @@ final class PresetJSONOnlyPersistenceTests: XCTestCase {
             modelFileURL: temp.appendingPathComponent("Presets/modelPresets.json")
         )
 
-        store.saveWorkflowPresets(.init())
-        store.saveModelPresets(.init())
+        try store.saveWorkflowPresets(.init())
+        try store.saveModelPresets(.init())
 
         XCTAssertTrue(FileManager.default.fileExists(atPath: store.workflowFileURL.path))
         XCTAssertTrue(FileManager.default.fileExists(atPath: store.modelFileURL.path))
         for key in legacyKeys {
             XCTAssertNil(UserDefaults.standard.object(forKey: key), key)
         }
+    }
+
+    func testPresetSaveReportsBlockedDestination() throws {
+        let temp = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: temp) }
+        let blockedParent = temp.appendingPathComponent("not-a-directory")
+        try Data("blocking file".utf8).write(to: blockedParent)
+        let store = PresetFileStore(
+            workflowFileURL: blockedParent.appendingPathComponent("workflowPresets.json"),
+            modelFileURL: blockedParent.appendingPathComponent("modelPresets.json")
+        )
+
+        XCTAssertThrowsError(try store.saveWorkflowPresets(.init()))
+        XCTAssertThrowsError(try store.saveModelPresets(.init()))
+    }
+
+    @MainActor
+    func testChatPresetManagerRollsBackFailedSaveAndPublishesError() throws {
+        let temp = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: temp) }
+        let store = try makeBlockedStore(in: temp)
+        let manager = ChatPresetManager(presetFileStore: store)
+        let preset = ChatPreset(name: "Unsaved chat", mode: .chat)
+
+        manager.addPreset(preset)
+
+        XCTAssertFalse(manager.userPresets.contains(where: { $0.id == preset.id }))
+        XCTAssertNotNil(manager.persistenceErrorMessage)
+
+        let blockedParent = store.workflowFileURL.deletingLastPathComponent()
+        try FileManager.default.removeItem(at: blockedParent)
+        try FileManager.default.createDirectory(at: blockedParent, withIntermediateDirectories: true)
+        manager.addPreset(preset)
+
+        XCTAssertTrue(manager.userPresets.contains(where: { $0.id == preset.id }))
+        XCTAssertNil(manager.persistenceErrorMessage)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: store.workflowFileURL.path))
+    }
+
+    @MainActor
+    func testCopyPresetManagerRollsBackFailedSaveAndPublishesError() throws {
+        let temp = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: temp) }
+        let store = try makeBlockedStore(in: temp)
+        let manager = CopyPresetManager(presetFileStore: store)
+        let preset = CopyPreset(name: "Unsaved copy")
+
+        manager.addPreset(preset)
+
+        XCTAssertFalse(manager.userPresets.contains(where: { $0.id == preset.id }))
+        XCTAssertNotNil(manager.persistenceErrorMessage)
+    }
+
+    @MainActor
+    func testModelPresetManagerRollsBackFailedSaveAndPublishesError() throws {
+        let temp = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: temp) }
+        let store = try makeBlockedStore(in: temp)
+        let manager = ModelPresetsManager(presetFileStore: store)
+        let preset = ModelPreset(name: "Unsaved model", model: .claude4Sonnet)
+
+        manager.addPreset(preset)
+
+        XCTAssertFalse(manager.presets.contains(where: { $0.id == preset.id }))
+        XCTAssertNotNil(manager.persistenceErrorMessage)
     }
 
     func testCorruptPresetJSONIsBackedUpAndReplacedWithEmptyDocument() throws {
@@ -92,6 +157,26 @@ final class PresetJSONOnlyPersistenceTests: XCTestCase {
         XCTAssertTrue(backups.contains { $0.hasPrefix("modelPresets.corrupt-") })
     }
 
+    func testUnbackedCorruptPresetDocumentIsPreservedAndSaveReportsFailure() throws {
+        let temp = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: temp) }
+        let presetsDirectory = temp.appendingPathComponent("Presets", isDirectory: true)
+        let workflowURL = presetsDirectory.appendingPathComponent("workflowPresets.json")
+        try FileManager.default.createDirectory(at: presetsDirectory, withIntermediateDirectories: true)
+        try Data("not json".utf8).write(to: workflowURL)
+        try Data("blocking file".utf8).write(to: presetsDirectory.appendingPathComponent("Backups"))
+        let store = PresetFileStore(
+            workflowFileURL: workflowURL,
+            modelFileURL: presetsDirectory.appendingPathComponent("modelPresets.json")
+        )
+
+        XCTAssertTrue(store.loadWorkflowPresets().copyUserPresets.isEmpty)
+        XCTAssertThrowsError(try store.saveWorkflowPresets(.init())) { error in
+            XCTAssertEqual(error as? PresetFileStore.PresetFileStoreError, .unbackedCorruptDocumentPreserved)
+        }
+        XCTAssertEqual(try String(contentsOf: workflowURL, encoding: .utf8), "not json")
+    }
+
     func testFuturePresetSchemaIsPreservedAndNotOverwritten() throws {
         let temp = try makeTempDirectory()
         defer { try? FileManager.default.removeItem(at: temp) }
@@ -105,8 +190,12 @@ final class PresetJSONOnlyPersistenceTests: XCTestCase {
         let store = PresetFileStore(workflowFileURL: workflowURL, modelFileURL: modelURL)
         XCTAssertTrue(store.loadWorkflowPresets().copyUserPresets.isEmpty)
         XCTAssertTrue(store.loadModelPresets().modelPresets.isEmpty)
-        store.saveWorkflowPresets(.init(copyVisibility: [UUID(): false]))
-        store.saveModelPresets(.init())
+        XCTAssertThrowsError(try store.saveWorkflowPresets(.init(copyVisibility: [UUID(): false]))) { error in
+            XCTAssertEqual(error as? PresetFileStore.PresetFileStoreError, .unsupportedFutureSchema(999))
+        }
+        XCTAssertThrowsError(try store.saveModelPresets(.init())) { error in
+            XCTAssertEqual(error as? PresetFileStore.PresetFileStoreError, .unsupportedFutureSchema(999))
+        }
 
         XCTAssertEqual(try String(contentsOf: workflowURL, encoding: .utf8), futureJSON)
         XCTAssertEqual(try String(contentsOf: modelURL, encoding: .utf8), futureJSON)
@@ -118,8 +207,8 @@ final class PresetJSONOnlyPersistenceTests: XCTestCase {
         let workflowURL = temp.appendingPathComponent("Presets/workflowPresets.json")
         let modelURL = temp.appendingPathComponent("Presets/modelPresets.json")
         let store = PresetFileStore(workflowFileURL: workflowURL, modelFileURL: modelURL)
-        store.saveWorkflowPresets(.init(copyVisibility: [UUID(): true]))
-        store.saveModelPresets(.init())
+        try store.saveWorkflowPresets(.init(copyVisibility: [UUID(): true]))
+        try store.saveModelPresets(.init())
 
         let futureJSON = #"{"schemaVersion":999,"updatedAt":"2026-05-20T00:00:00Z"}"#
         try Data(futureJSON.utf8).write(to: workflowURL)
@@ -132,8 +221,12 @@ final class PresetJSONOnlyPersistenceTests: XCTestCase {
             XCTAssertEqual(error as? PresetFileStore.PresetFileStoreError, .unsupportedFutureSchema(999))
         }
 
-        store.saveWorkflowPresets(.init())
-        store.saveModelPresets(.init())
+        XCTAssertThrowsError(try store.saveWorkflowPresets(.init())) { error in
+            XCTAssertEqual(error as? PresetFileStore.PresetFileStoreError, .unsupportedFutureSchema(999))
+        }
+        XCTAssertThrowsError(try store.saveModelPresets(.init())) { error in
+            XCTAssertEqual(error as? PresetFileStore.PresetFileStoreError, .unsupportedFutureSchema(999))
+        }
 
         XCTAssertEqual(try String(contentsOf: workflowURL, encoding: .utf8), futureJSON)
         XCTAssertEqual(try String(contentsOf: modelURL, encoding: .utf8), futureJSON)
@@ -144,5 +237,14 @@ final class PresetJSONOnlyPersistenceTests: XCTestCase {
             .appendingPathComponent("PresetJSONOnlyPersistenceTests-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
         return url
+    }
+
+    private func makeBlockedStore(in directory: URL) throws -> PresetFileStore {
+        let blockedParent = directory.appendingPathComponent("not-a-directory")
+        try Data("blocking file".utf8).write(to: blockedParent)
+        return PresetFileStore(
+            workflowFileURL: blockedParent.appendingPathComponent("workflowPresets.json"),
+            modelFileURL: blockedParent.appendingPathComponent("modelPresets.json")
+        )
     }
 }


### PR DESCRIPTION
## Problem

Chat, Copy, and Model preset managers published edits before writing their JSON documents. `PresetFileStore` swallowed write failures, so Settings could appear to accept a change that would disappear after restart.

## Change

- Propagate preset write and preservation failures.
- Apply manager mutations transactionally and restore prior state after failed writes.
- Present retained persistence errors in the preset Settings views without competing with delete confirmations.
- Preserve newer-schema documents, unbacked corrupt documents, and best-effort bootstrap behavior.

## Regression coverage

`PresetJSONOnlyPersistenceTests` covers blocked workflow/model destinations, rollback and error publication in all three managers, retry after repairing the destination, future-schema preservation, and unbacked corrupt-document preservation.

## Validation

- Exact branch diff and `git diff --check` passed.
- Staged whitespace and secret scans passed.
- Repeated branch autoreview is clean.
- Swift/macOS checks are pending on this draft's CI.

Fixes #727