### PR TITLE
Allow MessageReaper to tear down with queued messages

### DIFF
--- a/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel.swift
+++ b/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel.swift
@@ -14,13 +14,35 @@ private func oracleViewModelDebugLog(_ message: @autoclosure () -> String) {
 
 /// MessageReaper - Gradually releases messages to prevent UI stalls
 @MainActor
+protocol MessageReaperTimerFactory {
+    func makeRepeatingTimer(
+        interval: TimeInterval,
+        block: @escaping (Timer) -> Void
+    ) -> Timer
+}
+
+private struct DefaultMessageReaperTimerFactory: MessageReaperTimerFactory {
+    func makeRepeatingTimer(
+        interval: TimeInterval,
+        block: @escaping (Timer) -> Void
+    ) -> Timer {
+        Timer.scheduledTimer(withTimeInterval: interval, repeats: true, block: block)
+    }
+}
+
+@MainActor
 final class MessageReaper {
     private var bins: [[AIChatMessage]] = []
     private var timer: Timer?
     private var timerChunkSize = 0
+    private let timerFactory: any MessageReaperTimerFactory
 
     /// Minimum tick interval to prevent busy-loop when interval=0.0 is passed
     private static let minTickInterval: TimeInterval = 1.0 / 60.0 // ~16ms
+
+    init(timerFactory: any MessageReaperTimerFactory = DefaultMessageReaperTimerFactory()) {
+        self.timerFactory = timerFactory
+    }
 
     deinit {
         timer?.invalidate()
@@ -44,9 +66,13 @@ final class MessageReaper {
         // Sanitize interval and enforce minimum to prevent busy-loop
         let sanitized = interval.isFinite ? interval : 0
         let tickInterval = max(Self.minTickInterval, max(0.0, sanitized))
-        let newTimer = Timer.scheduledTimer(withTimeInterval: tickInterval, repeats: true) { [weak self] timer in
+        let newTimer = timerFactory.makeRepeatingTimer(interval: tickInterval) { [weak self] timer in
             MainActor.assumeIsolated {
-                self?.handleDrainTimer(timer)
+                guard let self else {
+                    timer.invalidate()
+                    return
+                }
+                self.handleDrainTimer(timer)
             }
         }
         newTimer.tolerance = tickInterval * 0.2 // Reduce energy churn

--- a/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel.swift
+++ b/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel.swift
@@ -110,7 +110,11 @@ private final class MessageReaperState {
 final class MessageReaper {
     private let state: MessageReaperState
 
-    init(timerFactory: any MessageReaperTimerFactory = DefaultMessageReaperTimerFactory()) {
+    init() {
+        self.init(timerFactory: DefaultMessageReaperTimerFactory())
+    }
+
+    init(timerFactory: any MessageReaperTimerFactory) {
         state = MessageReaperState(timerFactory: timerFactory)
     }
 

--- a/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel.swift
+++ b/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel.swift
@@ -22,6 +22,10 @@ final class MessageReaper {
     /// Minimum tick interval to prevent busy-loop when interval=0.0 is passed
     private static let minTickInterval: TimeInterval = 1.0 / 60.0 // ~16ms
 
+    deinit {
+        timer?.invalidate()
+    }
+
     func drain(
         _ source: inout [AIChatMessage],
         chunkSize: Int = 64,
@@ -40,18 +44,16 @@ final class MessageReaper {
         // Sanitize interval and enforce minimum to prevent busy-loop
         let sanitized = interval.isFinite ? interval : 0
         let tickInterval = max(Self.minTickInterval, max(0.0, sanitized))
-        let newTimer = Timer.scheduledTimer(
-            timeInterval: tickInterval,
-            target: self,
-            selector: #selector(handleDrainTimer(_:)),
-            userInfo: nil,
-            repeats: true
-        )
+        let newTimer = Timer.scheduledTimer(withTimeInterval: tickInterval, repeats: true) { [weak self] timer in
+            MainActor.assumeIsolated {
+                self?.handleDrainTimer(timer)
+            }
+        }
         newTimer.tolerance = tickInterval * 0.2 // Reduce energy churn
         timer = newTimer
     }
 
-    @objc private func handleDrainTimer(_ timer: Timer) {
+    private func handleDrainTimer(_ timer: Timer) {
         guard !bins.isEmpty else {
             timer.invalidate()
             self.timer = nil

--- a/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel.swift
+++ b/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel.swift
@@ -31,7 +31,7 @@ private struct DefaultMessageReaperTimerFactory: MessageReaperTimerFactory {
 }
 
 @MainActor
-final class MessageReaper {
+private final class MessageReaperState {
     private var bins: [[AIChatMessage]] = []
     private var timer: Timer?
     private var timerChunkSize = 0
@@ -40,7 +40,7 @@ final class MessageReaper {
     /// Minimum tick interval to prevent busy-loop when interval=0.0 is passed
     private static let minTickInterval: TimeInterval = 1.0 / 60.0 // ~16ms
 
-    init(timerFactory: any MessageReaperTimerFactory = DefaultMessageReaperTimerFactory()) {
+    init(timerFactory: any MessageReaperTimerFactory) {
         self.timerFactory = timerFactory
     }
 
@@ -66,13 +66,9 @@ final class MessageReaper {
         // Sanitize interval and enforce minimum to prevent busy-loop
         let sanitized = interval.isFinite ? interval : 0
         let tickInterval = max(Self.minTickInterval, max(0.0, sanitized))
-        let newTimer = timerFactory.makeRepeatingTimer(interval: tickInterval) { [weak self] timer in
+        let newTimer = timerFactory.makeRepeatingTimer(interval: tickInterval) { [state = self] timer in
             MainActor.assumeIsolated {
-                guard let self else {
-                    timer.invalidate()
-                    return
-                }
-                self.handleDrainTimer(timer)
+                state.handleDrainTimer(timer)
             }
         }
         newTimer.tolerance = tickInterval * 0.2 // Reduce energy churn
@@ -103,7 +99,27 @@ final class MessageReaper {
 
         if !bucket.isEmpty {
             bins.append(bucket)
+        } else if bins.isEmpty {
+            timer.invalidate()
+            self.timer = nil
         }
+    }
+}
+
+@MainActor
+final class MessageReaper {
+    private let state: MessageReaperState
+
+    init(timerFactory: any MessageReaperTimerFactory = DefaultMessageReaperTimerFactory()) {
+        state = MessageReaperState(timerFactory: timerFactory)
+    }
+
+    func drain(
+        _ source: inout [AIChatMessage],
+        chunkSize: Int = 64,
+        interval: TimeInterval = 0.0
+    ) {
+        state.drain(&source, chunkSize: chunkSize, interval: interval)
     }
 }
 

--- a/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel.swift
+++ b/Sources/RepoPrompt/Features/Chat/ViewModels/Oracle/OracleViewModel.swift
@@ -110,7 +110,7 @@ private final class MessageReaperState {
 final class MessageReaper {
     private let state: MessageReaperState
 
-    init() {
+    convenience init() {
         self.init(timerFactory: DefaultMessageReaperTimerFactory())
     }
 

--- a/Tests/RepoPromptTests/Chat/MessageReaperTests.swift
+++ b/Tests/RepoPromptTests/Chat/MessageReaperTests.swift
@@ -1,0 +1,19 @@
+@testable import RepoPromptApp
+import XCTest
+
+@MainActor
+final class MessageReaperTests: XCTestCase {
+    func testReaperDeallocatesWhileMessagesRemainQueued() {
+        var reaper: MessageReaper? = MessageReaper()
+        weak var weakReaper: MessageReaper?
+        var messages = [AIChatMessage(content: "pending", isUser: false)]
+        weakReaper = reaper
+
+        reaper?.drain(&messages, chunkSize: 1, interval: 60)
+
+        XCTAssertTrue(messages.isEmpty)
+        XCTAssertNotNil(weakReaper)
+        reaper = nil
+        XCTAssertNil(weakReaper)
+    }
+}

--- a/Tests/RepoPromptTests/Chat/MessageReaperTests.swift
+++ b/Tests/RepoPromptTests/Chat/MessageReaperTests.swift
@@ -16,4 +16,31 @@ final class MessageReaperTests: XCTestCase {
         reaper = nil
         XCTAssertNil(weakReaper)
     }
+
+    func testReaperDeinitInvalidatesItsRepeatingTimer() {
+        let timerFactory = RecordingMessageReaperTimerFactory()
+        var reaper: MessageReaper? = MessageReaper(timerFactory: timerFactory)
+        var messages = [AIChatMessage(content: "pending", isUser: false)]
+
+        reaper?.drain(&messages, chunkSize: 1, interval: 60)
+        XCTAssertTrue(timerFactory.timer?.isValid == true)
+
+        reaper = nil
+
+        XCTAssertFalse(timerFactory.timer?.isValid == true)
+    }
+}
+
+@MainActor
+private final class RecordingMessageReaperTimerFactory: MessageReaperTimerFactory {
+    private(set) var timer: Timer?
+
+    func makeRepeatingTimer(
+        interval: TimeInterval,
+        block: @escaping (Timer) -> Void
+    ) -> Timer {
+        let timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true, block: block)
+        self.timer = timer
+        return timer
+    }
 }

--- a/Tests/RepoPromptTests/Chat/MessageReaperTests.swift
+++ b/Tests/RepoPromptTests/Chat/MessageReaperTests.swift
@@ -4,9 +4,14 @@ import XCTest
 @MainActor
 final class MessageReaperTests: XCTestCase {
     func testReaperDeallocatesWhileMessagesRemainQueued() {
-        var reaper: MessageReaper? = MessageReaper()
+        let timerFactory = RecordingMessageReaperTimerFactory()
+        var reaper: MessageReaper? = MessageReaper(timerFactory: timerFactory)
         weak var weakReaper: MessageReaper?
-        var messages = [AIChatMessage(content: "pending", isUser: false)]
+        var messages = [
+            AIChatMessage(content: "pending 1", isUser: false),
+            AIChatMessage(content: "pending 2", isUser: false),
+            AIChatMessage(content: "pending 3", isUser: false)
+        ]
         weakReaper = reaper
 
         reaper?.drain(&messages, chunkSize: 1, interval: 60)
@@ -15,9 +20,17 @@ final class MessageReaperTests: XCTestCase {
         XCTAssertNotNil(weakReaper)
         reaper = nil
         XCTAssertNil(weakReaper)
+        XCTAssertTrue(timerFactory.timer?.isValid == true)
+
+        timerFactory.timer?.fire()
+        XCTAssertTrue(timerFactory.timer?.isValid == true)
+        timerFactory.timer?.fire()
+        XCTAssertTrue(timerFactory.timer?.isValid == true)
+        timerFactory.timer?.fire()
+        XCTAssertFalse(timerFactory.timer?.isValid == true)
     }
 
-    func testReaperDeinitInvalidatesItsRepeatingTimer() {
+    func testReaperTimerInvalidatesAfterQueuedMessagesDrain() {
         let timerFactory = RecordingMessageReaperTimerFactory()
         var reaper: MessageReaper? = MessageReaper(timerFactory: timerFactory)
         var messages = [AIChatMessage(content: "pending", isUser: false)]
@@ -26,6 +39,7 @@ final class MessageReaperTests: XCTestCase {
         XCTAssertTrue(timerFactory.timer?.isValid == true)
 
         reaper = nil
+        timerFactory.timer?.fire()
 
         XCTAssertFalse(timerFactory.timer?.isValid == true)
     }


### PR DESCRIPTION
## Problem

`MessageReaper` uses a repeating timer to release retired messages in bounded chunks. Its target/selector timer retained the reaper until invalidation, delaying teardown when the sole external owner was released while bins remained queued.

This is bounded MessageReaper lifecycle hardening, not evidence of an indefinite `OracleViewModel` leak.

## Change

Use a block-based repeating timer whose closure owns an independent `MessageReaperState`, not the public reaper owner. Releasing the sole `MessageReaper` owner therefore leaves queued bins under the timer's bounded-drain state instead of dropping the backlog synchronously on the main actor. The state invalidates and clears the repeating timer as soon as its final chunk is released; deinit remains a backstop. Interval sanitization, tolerance, cadence, and chunking remain unchanged.

## Regression coverage

A MainActor test queues three messages with a long interval, releases the sole strong owner before a tick, and verifies that the timer remains valid while queued work remains. It manually fires the timer one chunk at a time and asserts invalidation after the final chunk. A second test verifies timer invalidation after a one-message queue drains.

## Validation

- Exact branch diff and `git diff --check` passed.
- Staged whitespace and secret scans passed.
- Swift/macOS checks are pending on the new head's CI.

Fixes #730