### PR TITLE
Synchronize transcript debug instrumentation callbacks

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Transcript/AgentTranscriptServices.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Transcript/AgentTranscriptServices.swift
@@ -1,5 +1,8 @@
 import CryptoKit
 import Foundation
+#if DEBUG
+    import Synchronization
+#endif
 import OSLog
 
 enum AgentConversationReplayMode: String, Equatable {
@@ -191,33 +194,58 @@ struct AgentConversationReplaySerialization: Equatable {
     }
 
     enum AgentTranscriptDebugInstrumentation {
-        nonisolated(unsafe) static var isEnabled = false
-        nonisolated(unsafe) static var protectedTailScanHandler: ((AgentTranscriptProtectedTailScanMetrics) -> Void)?
-        nonisolated(unsafe) static var compactionHandler: ((AgentTranscriptCompactionMetrics) -> Void)?
-        nonisolated(unsafe) static var workingSourceItemsHandler: ((AgentTranscriptWorkingSourceItemsMetrics) -> Void)?
-        nonisolated(unsafe) static var rebuildHandler: ((AgentTranscriptRebuildMetrics) -> Void)?
-        nonisolated(unsafe) static var projectionBuildHandler: ((AgentTranscriptProjectionBuildMetrics) -> Void)?
-        nonisolated(unsafe) static var refreshAttemptHandler: ((AgentTranscriptRefreshAttemptMetrics) -> Void)?
-        nonisolated(unsafe) static var presentationPublishHandler: ((AgentTranscriptPresentationPublishMetrics) -> Void)?
-        nonisolated(unsafe) static var sessionItemsReplacementHandler: ((AgentTranscriptSessionItemsReplacementMetrics) -> Void)?
-        nonisolated(unsafe) static var projectionIdentityHandler: ((AgentTranscriptProjectionIdentityMetrics) -> Void)?
-        private static let refreshSignatureLock = NSLock()
-        private nonisolated(unsafe) static var lastRefreshInputSignatureByTabID: [UUID: String] = [:]
+        struct Handlers {
+            let protectedTailScanHandler: ((AgentTranscriptProtectedTailScanMetrics) -> Void)?
+            let compactionHandler: ((AgentTranscriptCompactionMetrics) -> Void)?
+            let workingSourceItemsHandler: ((AgentTranscriptWorkingSourceItemsMetrics) -> Void)?
+            let rebuildHandler: ((AgentTranscriptRebuildMetrics) -> Void)?
+            let projectionBuildHandler: ((AgentTranscriptProjectionBuildMetrics) -> Void)?
+            let refreshAttemptHandler: ((AgentTranscriptRefreshAttemptMetrics) -> Void)?
+            let presentationPublishHandler: ((AgentTranscriptPresentationPublishMetrics) -> Void)?
+            let sessionItemsReplacementHandler: ((AgentTranscriptSessionItemsReplacementMetrics) -> Void)?
+            let projectionIdentityHandler: ((AgentTranscriptProjectionIdentityMetrics) -> Void)?
+
+            init(
+                protectedTailScanHandler: ((AgentTranscriptProtectedTailScanMetrics) -> Void)? = nil,
+                compactionHandler: ((AgentTranscriptCompactionMetrics) -> Void)? = nil,
+                workingSourceItemsHandler: ((AgentTranscriptWorkingSourceItemsMetrics) -> Void)? = nil,
+                rebuildHandler: ((AgentTranscriptRebuildMetrics) -> Void)? = nil,
+                projectionBuildHandler: ((AgentTranscriptProjectionBuildMetrics) -> Void)? = nil,
+                refreshAttemptHandler: ((AgentTranscriptRefreshAttemptMetrics) -> Void)? = nil,
+                presentationPublishHandler: ((AgentTranscriptPresentationPublishMetrics) -> Void)? = nil,
+                sessionItemsReplacementHandler: ((AgentTranscriptSessionItemsReplacementMetrics) -> Void)? = nil,
+                projectionIdentityHandler: ((AgentTranscriptProjectionIdentityMetrics) -> Void)? = nil
+            ) {
+                self.protectedTailScanHandler = protectedTailScanHandler
+                self.compactionHandler = compactionHandler
+                self.workingSourceItemsHandler = workingSourceItemsHandler
+                self.rebuildHandler = rebuildHandler
+                self.projectionBuildHandler = projectionBuildHandler
+                self.refreshAttemptHandler = refreshAttemptHandler
+                self.presentationPublishHandler = presentationPublishHandler
+                self.sessionItemsReplacementHandler = sessionItemsReplacementHandler
+                self.projectionIdentityHandler = projectionIdentityHandler
+            }
+        }
+
+        private struct State {
+            var isEnabled = false
+            var handlers = Handlers()
+            var lastRefreshInputSignatureByTabID: [UUID: String] = [:]
+        }
+
+        private static let state = Mutex(State())
+
+        static var isEnabled: Bool {
+            state.withLock { $0.isEnabled }
+        }
+
+        static func configure(_ handlers: Handlers) {
+            state.withLock { $0 = State(isEnabled: true, handlers: handlers) }
+        }
 
         static func reset() {
-            isEnabled = false
-            protectedTailScanHandler = nil
-            compactionHandler = nil
-            workingSourceItemsHandler = nil
-            rebuildHandler = nil
-            projectionBuildHandler = nil
-            refreshAttemptHandler = nil
-            presentationPublishHandler = nil
-            sessionItemsReplacementHandler = nil
-            projectionIdentityHandler = nil
-            refreshSignatureLock.lock()
-            lastRefreshInputSignatureByTabID = [:]
-            refreshSignatureLock.unlock()
+            state.withLock { $0 = State() }
         }
 
         static func durationMS(since start: TimeInterval) -> Double {
@@ -237,12 +265,14 @@ struct AgentConversationReplaySerialization: Equatable {
             incrementalPath: String,
             inputSignature: String
         ) {
-            guard isEnabled else { return }
-            refreshSignatureLock.lock()
-            let previous = lastRefreshInputSignatureByTabID[tabID]
-            lastRefreshInputSignatureByTabID[tabID] = inputSignature
-            refreshSignatureLock.unlock()
-            refreshAttemptHandler?(.init(
+            let emission: (((AgentTranscriptRefreshAttemptMetrics) -> Void)?, String?)? = state.withLock {
+                guard $0.isEnabled else { return nil }
+                let previous = $0.lastRefreshInputSignatureByTabID[tabID]
+                $0.lastRefreshInputSignatureByTabID[tabID] = inputSignature
+                return ($0.handlers.refreshAttemptHandler, previous)
+            }
+            guard let emission else { return }
+            emission.0?(.init(
                 reason: reason,
                 sourceItemsRevision: sourceItemsRevision,
                 itemCount: itemCount,
@@ -253,9 +283,54 @@ struct AgentConversationReplaySerialization: Equatable {
                 pendingMutationSummary: pendingMutationSummary,
                 incrementalPath: incrementalPath,
                 inputSignature: inputSignature,
-                previousInputSignature: previous,
-                isConsecutiveDuplicateInput: previous == inputSignature
+                previousInputSignature: emission.1,
+                isConsecutiveDuplicateInput: emission.1 == inputSignature
             ))
+        }
+
+        static func emitProtectedTailScan(_ metrics: @autoclosure () -> AgentTranscriptProtectedTailScanMetrics) {
+            emit(\.protectedTailScanHandler, metrics())
+        }
+
+        static func emitCompaction(_ metrics: @autoclosure () -> AgentTranscriptCompactionMetrics) {
+            emit(\.compactionHandler, metrics())
+        }
+
+        static func emitWorkingSourceItems(_ metrics: @autoclosure () -> AgentTranscriptWorkingSourceItemsMetrics) {
+            emit(\.workingSourceItemsHandler, metrics())
+        }
+
+        static func emitRebuild(_ metrics: @autoclosure () -> AgentTranscriptRebuildMetrics) {
+            emit(\.rebuildHandler, metrics())
+        }
+
+        static func emitProjectionBuild(_ metrics: @autoclosure () -> AgentTranscriptProjectionBuildMetrics) {
+            emit(\.projectionBuildHandler, metrics())
+        }
+
+        static func emitPresentationPublish(_ metrics: @autoclosure () -> AgentTranscriptPresentationPublishMetrics) {
+            emit(\.presentationPublishHandler, metrics())
+        }
+
+        static func emitSessionItemsReplacement(
+            _ metrics: @autoclosure () -> AgentTranscriptSessionItemsReplacementMetrics
+        ) {
+            emit(\.sessionItemsReplacementHandler, metrics())
+        }
+
+        static func emitProjectionIdentity(_ metrics: @autoclosure () -> AgentTranscriptProjectionIdentityMetrics) {
+            emit(\.projectionIdentityHandler, metrics())
+        }
+
+        private static func emit<Metrics>(
+            _ handlerKeyPath: KeyPath<Handlers, ((Metrics) -> Void)?>,
+            _ metrics: @autoclosure () -> Metrics
+        ) {
+            let handler = state.withLock {
+                guard $0.isEnabled else { return nil }
+                return $0.handlers[keyPath: handlerKeyPath]
+            }
+            handler?(metrics())
         }
 
         static func stableDigest(_ values: [String]) -> String {
@@ -2271,7 +2346,7 @@ enum AgentTranscriptIO {
         let repairedRows = repairedSourceItems(rows, diagnosticContext: "working_source_items")
         #if DEBUG
             if AgentTranscriptDebugInstrumentation.isEnabled {
-                AgentTranscriptDebugInstrumentation.workingSourceItemsHandler?(.init(
+                AgentTranscriptDebugInstrumentation.emitWorkingSourceItems(.init(
                     transcriptTurnCount: transcript.turns.count,
                     fullTurnCount: transcript.turns.count(where: { $0.retentionTier == .full }),
                     itemCount: repairedRows.count,
@@ -2448,7 +2523,7 @@ enum AgentTranscriptIO {
         #if DEBUG
             if AgentTranscriptDebugInstrumentation.isEnabled {
                 let worsening = retentionTierWorseningCounts(from: existingTranscript, to: compacted)
-                AgentTranscriptDebugInstrumentation.rebuildHandler?(.init(
+                AgentTranscriptDebugInstrumentation.emitRebuild(.init(
                     existingTurnCount: existingTranscript.turns.count,
                     workingItemsCount: workingItems.count,
                     existingWorkingItemCount: existingWorkingItemCount,
@@ -4832,7 +4907,7 @@ enum AgentTranscriptCompactor {
             let trimmed = structurallyTrimmedTranscript(copy)
             #if DEBUG
                 if AgentTranscriptDebugInstrumentation.isEnabled {
-                    AgentTranscriptDebugInstrumentation.compactionHandler?(.init(
+                    AgentTranscriptDebugInstrumentation.emitCompaction(.init(
                         mode: mode,
                         initialWorkingUnitCount: initialWorkingUnitCount,
                         finalWorkingUnitCount: CompactionPressure(transcript: trimmed).workingUnitCount,
@@ -4880,7 +4955,7 @@ enum AgentTranscriptCompactor {
         let trimmed = structurallyTrimmedTranscript(copy)
         #if DEBUG
             if AgentTranscriptDebugInstrumentation.isEnabled {
-                AgentTranscriptDebugInstrumentation.compactionHandler?(.init(
+                AgentTranscriptDebugInstrumentation.emitCompaction(.init(
                     mode: mode,
                     initialWorkingUnitCount: initialWorkingUnitCount,
                     finalWorkingUnitCount: CompactionPressure(transcript: trimmed).workingUnitCount,
@@ -5075,7 +5150,7 @@ enum AgentTranscriptCompactor {
 
             func emit(countedToolExecutionCount: Int, protectedTurnCount: Int) {
                 guard AgentTranscriptDebugInstrumentation.isEnabled else { return }
-                AgentTranscriptDebugInstrumentation.protectedTailScanHandler?(.init(
+                AgentTranscriptDebugInstrumentation.emitProtectedTailScan(.init(
                     transcriptTurnCount: transcript.turns.count,
                     limit: limit,
                     turnsVisited: turnsVisited,
@@ -5643,7 +5718,7 @@ enum AgentTranscriptProjectionBuilder {
                 "[AgentTranscriptProjection] build turns=\(transcript.turns.count) workingRows=\(workingRows.count) workingBlocks=\(workingBlocks.count) reusedPrefixTurns=\(reusablePrefix?.turnCount ?? 0) cacheHits=\(cacheHitCount) workingRowTail=[\(workingRowTail)] workingBlockTail=[\(workingBlockTail)]"
             )
             if AgentTranscriptDebugInstrumentation.isEnabled {
-                AgentTranscriptDebugInstrumentation.projectionBuildHandler?(.init(
+                AgentTranscriptDebugInstrumentation.emitProjectionBuild(.init(
                     turnCount: transcript.turns.count,
                     reusedPrefixTurnCount: reusablePrefix?.turnCount ?? 0,
                     cacheHitCount: cacheHitCount,

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Transcript/AgentTranscriptServices.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Transcript/AgentTranscriptServices.swift
@@ -1,8 +1,5 @@
 import CryptoKit
 import Foundation
-#if DEBUG
-    import Synchronization
-#endif
 import OSLog
 
 enum AgentConversationReplayMode: String, Equatable {
@@ -64,6 +61,8 @@ struct AgentConversationReplaySerialization: Equatable {
 }
 
 #if DEBUG
+    import Synchronization
+
     struct AgentTranscriptProtectedTailScanMetrics: Equatable {
         let transcriptTurnCount: Int
         let limit: Int

--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Transcript/AgentTranscriptServices.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Transcript/AgentTranscriptServices.swift
@@ -61,8 +61,6 @@ struct AgentConversationReplaySerialization: Equatable {
 }
 
 #if DEBUG
-    import Synchronization
-
     struct AgentTranscriptProtectedTailScanMetrics: Equatable {
         let transcriptTurnCount: Int
         let limit: Int
@@ -233,7 +231,18 @@ struct AgentConversationReplaySerialization: Equatable {
             var lastRefreshInputSignatureByTabID: [UUID: String] = [:]
         }
 
-        private static let state = Mutex(State())
+        private final class LockedState: @unchecked Sendable {
+            private let lock = NSLock()
+            private var value = State()
+
+            func withLock<T>(_ body: (inout State) -> T) -> T {
+                lock.lock()
+                defer { lock.unlock() }
+                return body(&value)
+            }
+        }
+
+        private static let state = LockedState()
 
         static var isEnabled: Bool {
             state.withLock { $0.isEnabled }
@@ -288,48 +297,49 @@ struct AgentConversationReplaySerialization: Equatable {
         }
 
         static func emitProtectedTailScan(_ metrics: @autoclosure () -> AgentTranscriptProtectedTailScanMetrics) {
-            emit(\.protectedTailScanHandler, metrics())
+            emit(\.protectedTailScanHandler, metrics)
         }
 
         static func emitCompaction(_ metrics: @autoclosure () -> AgentTranscriptCompactionMetrics) {
-            emit(\.compactionHandler, metrics())
+            emit(\.compactionHandler, metrics)
         }
 
         static func emitWorkingSourceItems(_ metrics: @autoclosure () -> AgentTranscriptWorkingSourceItemsMetrics) {
-            emit(\.workingSourceItemsHandler, metrics())
+            emit(\.workingSourceItemsHandler, metrics)
         }
 
         static func emitRebuild(_ metrics: @autoclosure () -> AgentTranscriptRebuildMetrics) {
-            emit(\.rebuildHandler, metrics())
+            emit(\.rebuildHandler, metrics)
         }
 
         static func emitProjectionBuild(_ metrics: @autoclosure () -> AgentTranscriptProjectionBuildMetrics) {
-            emit(\.projectionBuildHandler, metrics())
+            emit(\.projectionBuildHandler, metrics)
         }
 
         static func emitPresentationPublish(_ metrics: @autoclosure () -> AgentTranscriptPresentationPublishMetrics) {
-            emit(\.presentationPublishHandler, metrics())
+            emit(\.presentationPublishHandler, metrics)
         }
 
         static func emitSessionItemsReplacement(
             _ metrics: @autoclosure () -> AgentTranscriptSessionItemsReplacementMetrics
         ) {
-            emit(\.sessionItemsReplacementHandler, metrics())
+            emit(\.sessionItemsReplacementHandler, metrics)
         }
 
         static func emitProjectionIdentity(_ metrics: @autoclosure () -> AgentTranscriptProjectionIdentityMetrics) {
-            emit(\.projectionIdentityHandler, metrics())
+            emit(\.projectionIdentityHandler, metrics)
         }
 
         private static func emit<Metrics>(
             _ handlerKeyPath: KeyPath<Handlers, ((Metrics) -> Void)?>,
-            _ metrics: @autoclosure () -> Metrics
+            _ metrics: () -> Metrics
         ) {
-            let handler = state.withLock {
+            let handler: ((Metrics) -> Void)? = state.withLock {
                 guard $0.isEnabled else { return nil }
                 return $0.handlers[keyPath: handlerKeyPath]
             }
-            handler?(metrics())
+            guard let handler else { return }
+            handler(metrics())
         }
 
         static func stableDigest(_ values: [String]) -> String {

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+TabSession.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+TabSession.swift
@@ -1392,7 +1392,7 @@ extension AgentModeViewModel {
         func setItemsSilently(_ items: [AgentChatItem], reason: SilentItemReplacementReason) {
             #if DEBUG
                 if AgentTranscriptDebugInstrumentation.isEnabled {
-                    AgentTranscriptDebugInstrumentation.sessionItemsReplacementHandler?(.init(
+                    AgentTranscriptDebugInstrumentation.emitSessionItemsReplacement(.init(
                         reason: reason.rawValue,
                         previousItemCount: self.items.count,
                         newItemCount: items.count,

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -7937,7 +7937,7 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
                     currentBlockIdentityDigest,
                     currentSemanticDigest
                 ])
-                AgentTranscriptDebugInstrumentation.presentationPublishHandler?(.init(
+                AgentTranscriptDebugInstrumentation.emitPresentationPublish(.init(
                     visibleRowCount: candidateSnapshot.visibleRows.count,
                     workingRowCount: candidateSnapshot.workingRows.count,
                     visibleBlockCount: candidateSnapshot.visibleBlocks.count,
@@ -9893,7 +9893,7 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
                 let newBlockSemanticDigest = AgentTranscriptDebugInstrumentation.blockSemanticSignature(newBlocks)
                 let previousBlockIdentityDigest = AgentTranscriptDebugInstrumentation.blockIdentitySignature(previousBlocks)
                 let newBlockIdentityDigest = AgentTranscriptDebugInstrumentation.blockIdentitySignature(newBlocks)
-                AgentTranscriptDebugInstrumentation.projectionIdentityHandler?(.init(
+                AgentTranscriptDebugInstrumentation.emitProjectionIdentity(.init(
                     previousRowCount: previousRows.count,
                     newRowCount: newRows.count,
                     previousBlockCount: previousBlocks.count,

--- a/Tests/RepoPromptTests/AgentMode/Transcript/AgentTranscriptCrawlRefreshBenchmarkTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Transcript/AgentTranscriptCrawlRefreshBenchmarkTests.swift
@@ -73,17 +73,17 @@
                 )
 
                 let recorder = TranscriptInstrumentationRecorder()
-                AgentTranscriptDebugInstrumentation.reset()
-                AgentTranscriptDebugInstrumentation.isEnabled = true
-                AgentTranscriptDebugInstrumentation.protectedTailScanHandler = { recorder.record($0) }
-                AgentTranscriptDebugInstrumentation.compactionHandler = { recorder.record($0) }
-                AgentTranscriptDebugInstrumentation.workingSourceItemsHandler = { recorder.record($0) }
-                AgentTranscriptDebugInstrumentation.rebuildHandler = { recorder.record($0) }
-                AgentTranscriptDebugInstrumentation.projectionBuildHandler = { recorder.record($0) }
-                AgentTranscriptDebugInstrumentation.refreshAttemptHandler = { recorder.record($0) }
-                AgentTranscriptDebugInstrumentation.presentationPublishHandler = { recorder.record($0) }
-                AgentTranscriptDebugInstrumentation.sessionItemsReplacementHandler = { recorder.record($0) }
-                AgentTranscriptDebugInstrumentation.projectionIdentityHandler = { recorder.record($0) }
+                AgentTranscriptDebugInstrumentation.configure(.init(
+                    protectedTailScanHandler: { recorder.record($0) },
+                    compactionHandler: { recorder.record($0) },
+                    workingSourceItemsHandler: { recorder.record($0) },
+                    rebuildHandler: { recorder.record($0) },
+                    projectionBuildHandler: { recorder.record($0) },
+                    refreshAttemptHandler: { recorder.record($0) },
+                    presentationPublishHandler: { recorder.record($0) },
+                    sessionItemsReplacementHandler: { recorder.record($0) },
+                    projectionIdentityHandler: { recorder.record($0) }
+                ))
                 defer { AgentTranscriptDebugInstrumentation.reset() }
 
                 var aggregates: [CrawlRefreshBenchmarkAggregate] = []

--- a/Tests/RepoPromptTests/AgentMode/Transcript/AgentTranscriptDebugInstrumentationTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Transcript/AgentTranscriptDebugInstrumentationTests.swift
@@ -1,0 +1,93 @@
+#if DEBUG
+    import Foundation
+    import Synchronization
+    @testable import RepoPromptApp
+    import XCTest
+
+    final class AgentTranscriptDebugInstrumentationTests: XCTestCase {
+        override func tearDown() {
+            AgentTranscriptDebugInstrumentation.reset()
+            super.tearDown()
+        }
+
+        func testConcurrentConfigureResetAndEmissionUseUnlockedHandlerSnapshots() {
+            let recorder = InstrumentationValueRecorder<String>()
+            let firstHandlerStarted = DispatchSemaphore(value: 0)
+            let releaseFirstHandler = DispatchSemaphore(value: 0)
+            let firstEmissionFinished = DispatchSemaphore(value: 0)
+            let reconfigurationFinished = DispatchSemaphore(value: 0)
+
+            AgentTranscriptDebugInstrumentation.configure(.init(
+                workingSourceItemsHandler: { metrics in
+                    firstHandlerStarted.signal()
+                    releaseFirstHandler.wait()
+                    recorder.record("first:\(metrics.itemCount)")
+                }
+            ))
+
+            DispatchQueue.global().async {
+                AgentTranscriptDebugInstrumentation.emitWorkingSourceItems(.init(
+                    transcriptTurnCount: 1,
+                    fullTurnCount: 1,
+                    itemCount: 1,
+                    durationMS: 0
+                ))
+                firstEmissionFinished.signal()
+            }
+
+            guard firstHandlerStarted.wait(timeout: .now() + 5) == .success else {
+                releaseFirstHandler.signal()
+                _ = firstEmissionFinished.wait(timeout: .now() + 5)
+                XCTFail("The first instrumentation handler did not start")
+                return
+            }
+            DispatchQueue.global().async {
+                AgentTranscriptDebugInstrumentation.configure(.init(
+                    workingSourceItemsHandler: { metrics in
+                        recorder.record("second:\(metrics.itemCount)")
+                    }
+                ))
+                reconfigurationFinished.signal()
+            }
+
+            let reconfigurationResult = reconfigurationFinished.wait(timeout: .now() + 5)
+            if reconfigurationResult != .success {
+                releaseFirstHandler.signal()
+                _ = firstEmissionFinished.wait(timeout: .now() + 5)
+                XCTFail("Configuring instrumentation blocked while an earlier handler was running")
+                return
+            }
+
+            AgentTranscriptDebugInstrumentation.emitWorkingSourceItems(.init(
+                transcriptTurnCount: 2,
+                fullTurnCount: 2,
+                itemCount: 2,
+                durationMS: 0
+            ))
+            AgentTranscriptDebugInstrumentation.reset()
+            AgentTranscriptDebugInstrumentation.emitWorkingSourceItems(.init(
+                transcriptTurnCount: -1,
+                fullTurnCount: -1,
+                itemCount: -1,
+                durationMS: 0
+            ))
+            releaseFirstHandler.signal()
+
+            XCTAssertEqual(firstEmissionFinished.wait(timeout: .now() + 5), .success)
+            XCTAssertEqual(Set(recorder.values), Set(["first:1", "second:2"]))
+            XCTAssertFalse(AgentTranscriptDebugInstrumentation.isEnabled)
+        }
+    }
+
+    private final class InstrumentationValueRecorder<Value: Sendable>: Sendable {
+        private let storage = Mutex<[Value]>([])
+
+        var values: [Value] {
+            storage.withLock { $0 }
+        }
+
+        func record(_ value: Value) {
+            storage.withLock { $0.append(value) }
+        }
+    }
+#endif

--- a/Tests/RepoPromptTests/AgentMode/Transcript/AgentTranscriptDebugInstrumentationTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Transcript/AgentTranscriptDebugInstrumentationTests.swift
@@ -1,6 +1,5 @@
 #if DEBUG
     import Foundation
-    import Synchronization
     @testable import RepoPromptApp
     import XCTest
 
@@ -77,17 +76,40 @@
             XCTAssertEqual(Set(recorder.values), Set(["first:1", "second:2"]))
             XCTAssertFalse(AgentTranscriptDebugInstrumentation.isEnabled)
         }
+
+        func testMetricsRemainLazyUntilAHandlerIsConfigured() {
+            var evaluationCount = 0
+
+            func metrics() -> AgentTranscriptWorkingSourceItemsMetrics {
+                evaluationCount += 1
+                return .init(transcriptTurnCount: 1, fullTurnCount: 1, itemCount: 1, durationMS: 0)
+            }
+
+            AgentTranscriptDebugInstrumentation.emitWorkingSourceItems(metrics())
+            AgentTranscriptDebugInstrumentation.configure(.init())
+            AgentTranscriptDebugInstrumentation.emitWorkingSourceItems(metrics())
+            XCTAssertEqual(evaluationCount, 0)
+
+            AgentTranscriptDebugInstrumentation.configure(.init(workingSourceItemsHandler: { _ in }))
+            AgentTranscriptDebugInstrumentation.emitWorkingSourceItems(metrics())
+            XCTAssertEqual(evaluationCount, 1)
+        }
     }
 
-    private final class InstrumentationValueRecorder<Value: Sendable>: Sendable {
-        private let storage = Mutex<[Value]>([])
+    private final class InstrumentationValueRecorder<Value: Sendable>: @unchecked Sendable {
+        private let lock = NSLock()
+        private var storage: [Value] = []
 
         var values: [Value] {
-            storage.withLock { $0 }
+            lock.lock()
+            defer { lock.unlock() }
+            return storage
         }
 
         func record(_ value: Value) {
-            storage.withLock { $0.append(value) }
+            lock.lock()
+            storage.append(value)
+            lock.unlock()
         }
     }
 #endif


### PR DESCRIPTION
## Problem

`AgentTranscriptDebugInstrumentation` exposed its enable flag and nine handler closures as independently mutable `nonisolated(unsafe)` globals. Reset and emission could access them concurrently.

## Change

- Store enablement, handlers, and refresh signatures behind one `Synchronization.Mutex`.
- Publish configurations and reset atomically.
- Snapshot callbacks under the mutex and invoke them after unlocking.
- Keep the DEBUG-only boundary and existing signature-cache policy.
- Update the transcript benchmark to use the atomic configuration API.

## Regression coverage

A deterministic semaphore-gated test overlaps emission, reconfiguration, and reset. It verifies that callbacks run outside the mutex, a previously snapshotted callback can finish, and later emissions are suppressed after reset.

## Validation

- Exact branch diff and `git diff --check` passed.
- Staged whitespace and secret scans passed.
- Repeated branch autoreview is clean.
- Swift/macOS and Thread Sanitizer checks are pending on this draft's CI.

Fixes #731