### PR TITLE
Fix replace-all matching with reused full-file indexes

### DIFF
--- a/Sources/RepoPromptDomainRuntime/Diffing/DiffBatchGenerator.swift
+++ b/Sources/RepoPromptDomainRuntime/Diffing/DiffBatchGenerator.swift
@@ -43,7 +43,7 @@ package enum DiffBatchGenerator {
         outcomes.reserveCapacity(edits.count)
         allChunks.reserveCapacity(edits.count)
 
-        // Pre‑compute the high‑precision line‑index for first‑hit optimisation.
+        // Precompute matching data once so replace-all edits can keep full-file coordinates.
         var processed: [DiffGenerationUtility.LineData] = []
         processed.reserveCapacity(orig.count)
         for line in orig {
@@ -60,13 +60,14 @@ package enum DiffBatchGenerator {
 
                 let diff = try await DiffGenerationUtility.generateDiff(
                     fileContent: orig,
-                    lineIndexMap: start == 0 ? indexMap : nil, // optimisation only for first search
+                    lineIndexMap: start == 0 || edit.replaceAll ? indexMap : nil,
                     startSelector: nil,
                     endSelector: nil,
                     searchBlock: edit.search.isEmpty ? nil : edit.search,
                     newContent: sanitizedContent,
                     action: edit.search.isEmpty ? .rewrite : .modify,
                     diffPrecision: prec,
+                    processedFileContent: edit.replaceAll ? processed : nil,
                     searchStartLine: start,
                     mcpAmbiguityCheck: edit.replaceAll ? false : mcpAmbiguityCheck,
                     replaceAll: edit.replaceAll,

--- a/Sources/RepoPromptDomainRuntime/Diffing/DiffGenerationUtility.swift
+++ b/Sources/RepoPromptDomainRuntime/Diffing/DiffGenerationUtility.swift
@@ -78,6 +78,7 @@ package class DiffGenerationUtility {
         newContent: [String],
         action: FileAction,
         diffPrecision: DiffPrecision = .normal,
+        processedFileContent: [LineData]? = nil,
         searchStartLine: Int = 0,
         mcpAmbiguityCheck: Bool = false,
         replaceAll: Bool = false,
@@ -102,6 +103,7 @@ package class DiffGenerationUtility {
                     newContent: newContent,
                     diffPrecision: diffPrecision,
                     lineIndexMap: lineIndexMap,
+                    processedFileContent: processedFileContent,
                     searchStartLine: searchStartLine,
                     mcpAmbiguityCheck: mcpAmbiguityCheck,
                     replaceAll: replaceAll,
@@ -281,6 +283,7 @@ package class DiffGenerationUtility {
         newContent: [String],
         diffPrecision: DiffPrecision = .normal,
         lineIndexMap: [String: [Int]]? = nil,
+        processedFileContent: [LineData]? = nil,
         searchStartLine: Int = 0,
         mcpAmbiguityCheck: Bool = false,
         replaceAll: Bool = false,
@@ -308,34 +311,31 @@ package class DiffGenerationUtility {
 
         // Handle replace_all by finding multiple matches
         if replaceAll {
+            let processedFile = processedFileContent ?? fileContent.map {
+                processLine($0, precision: diffPrecision)
+            }
+            let fullIndexMap = lineIndexMap ?? buildLineIndexMapHigh(content: processedFile)
             var allChunks: [DiffChunk] = []
             allChunks.reserveCapacity(1)
             var currentStartLine = searchStartLine
 
             while currentStartLine < fileContent.count {
-                // ➊ Search only after `currentStartLine`
-                let fileSlice = fileContent[currentStartLine...]
-                let processedFileSlice = fileSlice.map { processLine($0, precision: diffPrecision) }
-
-                let sliceIndexMap = lineIndexMap ?? buildLineIndexMapHigh(content: processedFileSlice)
-
-                // ➋ Locate match *inside* the slice
-                let localMatch: Int
+                // ➊ Locate the next match using full-file coordinates.
+                let globalMatch: Int
                 do {
-                    localMatch = try await findBestMatchUsingNGrams(
+                    globalMatch = try await findBestMatchUsingNGrams(
                         selector: processedSearch,
-                        in: processedFileSlice,
-                        lineIndexMap: sliceIndexMap,
-                        mcpAmbiguityCheck: false // Skip ambiguity check for replace_all
+                        in: processedFile,
+                        lineIndexMap: fullIndexMap,
+                        mcpAmbiguityCheck: false, // Skip ambiguity check for replace_all
+                        minimumMatchIndex: currentStartLine
                     )
                 } catch DiffGenerationError.noMatchFound {
                     break // No more matches found
                 }
 
-                if localMatch == -1 { break }
+                if globalMatch == -1 { break }
 
-                // Convert to absolute indices in original file
-                let globalMatch = localMatch + currentStartLine
                 let globalEnd = globalMatch + sanitizedSearch.count
 
                 guard globalEnd <= fileContent.count else {
@@ -495,7 +495,13 @@ package class DiffGenerationUtility {
 
     /// Finds the best match for a selector in the given content using an n-gram similarity search,
     /// then refines that match in a smaller window.
-    package static func findBestMatchUsingNGrams(selector: [LineData], in content: [LineData], lineIndexMap: [String: [Int]], mcpAmbiguityCheck: Bool = false) async throws -> Int {
+    package static func findBestMatchUsingNGrams(
+        selector: [LineData],
+        in content: [LineData],
+        lineIndexMap: [String: [Int]],
+        mcpAmbiguityCheck: Bool = false,
+        minimumMatchIndex: Int = 0
+    ) async throws -> Int {
         // 1) Basic validation - ensure inputs are valid
         guard !selector.isEmpty else {
             throw DiffGenerationError.invalidSelector
@@ -512,7 +518,12 @@ package class DiffGenerationUtility {
         let quickIndex: Int? = if mcpAmbiguityCheck {
             try matchSelectorFastWithAmbiguityCheck(selector: selector, content: content, lineIndex: lineIndexMap)
         } else {
-            try matchSelectorFast(selector: selector, content: content, lineIndex: lineIndexMap)
+            try matchSelectorFast(
+                selector: selector,
+                content: content,
+                lineIndex: lineIndexMap,
+                minimumMatchIndex: minimumMatchIndex
+            )
         }
 
         if let quickIndex {
@@ -1244,7 +1255,8 @@ package class DiffGenerationUtility {
         content: [LineData],
         lineIndex: [String: [Int]],
         maxFuzzyKeys maxKeys: Int = 400,
-        fuzzyThreshold sim: Double = 0.90
+        fuzzyThreshold sim: Double = 0.90,
+        minimumMatchIndex: Int = 0
     ) throws -> Int? {
         // ── Guard rails ─────────────────────────────────────────────────────────
         guard !selector.isEmpty, !content.isEmpty else {
@@ -1274,7 +1286,9 @@ package class DiffGenerationUtility {
 
         /// ── Helper: candidate list for selector line 0 --------------------------
         func strictOrLoosePositions(for line: LineData) -> [Int] {
-            lineIndex[line.removedTagsHigh] ?? lineIndex[line.removedTags] ?? []
+            let strict = (lineIndex[line.removedTagsHigh] ?? []).filter { $0 >= minimumMatchIndex }
+            if !strict.isEmpty { return strict }
+            return (lineIndex[line.removedTags] ?? []).filter { $0 >= minimumMatchIndex }
         }
 
         var starts = strictOrLoosePositions(for: selector[0])
@@ -1300,7 +1314,7 @@ package class DiffGenerationUtility {
                     print("  🔍 Fuzzy probe test \(seen)/\(maxKeys): \(sKey) ↔ \(k)  Dice: \(coeff)")
                 }
                 guard coeff >= fuzzyThresh else { continue }
-                for p in pos {
+                for p in pos where p >= minimumMatchIndex {
                     starts.append(p)
                     fuzzyScoreMap[p] = max(fuzzyScoreMap[p] ?? 0, coeff)
                 }
@@ -1322,7 +1336,9 @@ package class DiffGenerationUtility {
                 for (k, pos) in lineIndex where scanned < maxKeys {
                     scanned += 1
                     if sKey.diceCoefficient(against: k) >= fuzzyThresh {
-                        collected += pos.compactMap { $0 > 0 ? $0 - 1 : nil }
+                        collected += pos.compactMap {
+                            $0 > minimumMatchIndex ? $0 - 1 : nil
+                        }
                     }
                 }
                 second = collected

--- a/Sources/RepoPromptDomainRuntime/Diffing/DiffGenerationUtility.swift
+++ b/Sources/RepoPromptDomainRuntime/Diffing/DiffGenerationUtility.swift
@@ -1308,13 +1308,15 @@ package class DiffGenerationUtility {
             var seen = 0
             for (k, pos) in lineIndex {
                 if seen >= maxKeys { break }
+                let positionsAtOrAfterMinimum = pos.filter { $0 >= minimumMatchIndex }
+                guard !positionsAtOrAfterMinimum.isEmpty else { continue }
                 seen += 1
                 let coeff = sKey.diceCoefficient(against: k)
                 if enableDetailedLogging {
                     print("  🔍 Fuzzy probe test \(seen)/\(maxKeys): \(sKey) ↔ \(k)  Dice: \(coeff)")
                 }
                 guard coeff >= fuzzyThresh else { continue }
-                for p in pos where p >= minimumMatchIndex {
+                for p in positionsAtOrAfterMinimum {
                     starts.append(p)
                     fuzzyScoreMap[p] = max(fuzzyScoreMap[p] ?? 0, coeff)
                 }
@@ -1334,9 +1336,11 @@ package class DiffGenerationUtility {
                 var collected: [Int] = []
                 var scanned = 0
                 for (k, pos) in lineIndex where scanned < maxKeys {
+                    let positionsAtOrAfterMinimum = pos.filter { $0 >= minimumMatchIndex }
+                    guard !positionsAtOrAfterMinimum.isEmpty else { continue }
                     scanned += 1
                     if sKey.diceCoefficient(against: k) >= fuzzyThresh {
-                        collected += pos.compactMap {
+                        collected += positionsAtOrAfterMinimum.compactMap {
                             $0 > minimumMatchIndex ? $0 - 1 : nil
                         }
                     }

--- a/Tests/RepoPromptTests/Diffing/DiffGenerationUtilityRoutingTests.swift
+++ b/Tests/RepoPromptTests/Diffing/DiffGenerationUtilityRoutingTests.swift
@@ -2,6 +2,78 @@
 import XCTest
 
 final class DiffGenerationUtilityRoutingTests: XCTestCase {
+    func testReplaceAllHonorsSearchStartLineWithFullFileIndex() async throws {
+        let fileContent = ["same", "skip", "same", "middle", "same"]
+        let processed = fileContent.map {
+            DiffGenerationUtility.processLine($0, precision: .high)
+        }
+        let lineIndexMap = DiffGenerationUtility.buildLineIndexMapHigh(content: processed)
+
+        let chunks = try await DiffGenerationUtility.generateDiff(
+            fileContent: fileContent,
+            lineIndexMap: lineIndexMap,
+            startSelector: nil,
+            endSelector: nil,
+            searchBlock: ["same"],
+            newContent: ["replacement"],
+            action: .modify,
+            diffPrecision: .high,
+            processedFileContent: processed,
+            searchStartLine: 2,
+            replaceAll: true
+        )
+        let result = try DiffChunkTextApplier.apply(
+            chunks: chunks,
+            to: fileContent.joined(separator: "\n")
+        )
+
+        XCTAssertEqual(chunks.map(\.startLine), [2, 4])
+        XCTAssertEqual(result, "same\nskip\nreplacement\nmiddle\nreplacement")
+    }
+
+    func testBatchReplaceAllKeepsFullFileIndexCoordinatesAfterFirstMatch() async throws {
+        let original = [
+            "header",
+            "padding",
+            "TARGET",
+            "remove",
+            "gap one",
+            "gap two",
+            "gap three",
+            "TARGET",
+            "remove",
+            "footer"
+        ].joined(separator: "\n")
+        let request = ApplyEditsRequest(
+            path: "file.swift",
+            mode: .batch([
+                ApplyEditsOperation(
+                    search: "target\nremove",
+                    replace: "replacement",
+                    replaceAll: true
+                )
+            ]),
+            verbose: false
+        )
+
+        let result = try await ApplyEditsEngine.default.apply(request: request, to: original)
+
+        XCTAssertNil(result.note, "Case normalization should route through batch diff generation")
+        XCTAssertEqual(
+            result.updatedText,
+            [
+                "header",
+                "padding",
+                "replacement",
+                "gap one",
+                "gap two",
+                "gap three",
+                "replacement",
+                "footer"
+            ].joined(separator: "\n")
+        )
+    }
+
     func testReplaceAllBypassesDuplicateMatchAmbiguityAndAppliesCumulativeOffsets() async throws {
         let rows = [
             (

--- a/Tests/RepoPromptTests/Diffing/DiffGenerationUtilityRoutingTests.swift
+++ b/Tests/RepoPromptTests/Diffing/DiffGenerationUtilityRoutingTests.swift
@@ -47,10 +47,18 @@ final class DiffGenerationUtilityRoutingTests: XCTestCase {
         }
         let fuzzyAlias = try XCTUnwrap(fuzzyAliases.first { candidate in
             let candidateLine = DiffGenerationUtility.processLine(candidate, precision: .high)
+            let candidateKeys = DiffGenerationUtility
+                .buildLineIndexMapHigh(content: [candidateLine])
+                .keys
             var candidateIndex = prefixIndex
-            candidateIndex[candidateLine.removedTagsHigh] = [minimumMatchIndex]
-            let position = Array(candidateIndex.keys).firstIndex(of: candidateLine.removedTagsHigh)
-            return (position ?? 0) >= 400
+            for key in candidateKeys {
+                candidateIndex[key] = [minimumMatchIndex]
+            }
+            let orderedKeys = Array(candidateIndex.keys)
+            let positions = candidateKeys.compactMap { key in
+                orderedKeys.firstIndex(of: key)
+            }
+            return !positions.isEmpty && positions.allSatisfy { $0 >= 400 }
         },
             "The test needs a fuzzy alias after the 400-key probe boundary"
         )

--- a/Tests/RepoPromptTests/Diffing/DiffGenerationUtilityRoutingTests.swift
+++ b/Tests/RepoPromptTests/Diffing/DiffGenerationUtilityRoutingTests.swift
@@ -35,6 +35,7 @@ final class DiffGenerationUtilityRoutingTests: XCTestCase {
         let selectorText = "calculate total for selected invoice line items"
         let selector = DiffGenerationUtility.processLine(selectorText, precision: .high)
         let minimumMatchIndex = 401
+        let maxFuzzyKeys = 400
         let prefix = (0 ..< minimumMatchIndex).map {
             "calculate total for selected invoice line item \($0)"
         }
@@ -42,7 +43,7 @@ final class DiffGenerationUtilityRoutingTests: XCTestCase {
             DiffGenerationUtility.processLine($0, precision: .high)
         }
         let prefixIndex = DiffGenerationUtility.buildLineIndexMapHigh(content: processedPrefix)
-        let fuzzyAliases = (0 ..< 4_096).map {
+        let fuzzyAliases = (0 ..< (maxFuzzyKeys * 10)).map {
             "calculate total for selected invoice line item candidate \(String($0, radix: 36))"
         }
         let fuzzyCandidate = try XCTUnwrap(
@@ -73,7 +74,7 @@ final class DiffGenerationUtilityRoutingTests: XCTestCase {
             selector: [selector],
             content: content,
             lineIndex: lineIndex,
-            maxFuzzyKeys: 400,
+            maxFuzzyKeys: maxFuzzyKeys,
             fuzzyThreshold: 0.80,
             minimumMatchIndex: minimumMatchIndex
         )

--- a/Tests/RepoPromptTests/Diffing/DiffGenerationUtilityRoutingTests.swift
+++ b/Tests/RepoPromptTests/Diffing/DiffGenerationUtilityRoutingTests.swift
@@ -35,28 +35,22 @@ final class DiffGenerationUtilityRoutingTests: XCTestCase {
         let selectorText = "calculate total for selected invoice line items"
         let selector = DiffGenerationUtility.processLine(selectorText, precision: .high)
         let minimumMatchIndex = 401
-        let prefix = (0 ..< minimumMatchIndex).map { "unrelated pre-boundary key \($0)" }
+        let prefix = (0 ..< minimumMatchIndex).map {
+            "calculate total for selected invoice line item \($0)"
+        }
         let processedPrefix = prefix.map {
             DiffGenerationUtility.processLine($0, precision: .high)
         }
         let prefixIndex = DiffGenerationUtility.buildLineIndexMapHigh(content: processedPrefix)
-        let fuzzyAliases = (0 ..< 1024).map {
-            "calculate total for selected invoice line item \($0)"
+        let fuzzyAliases = (0 ..< 4_096).map {
+            "calculate total for selected invoice line item candidate \(String($0, radix: 36))"
         }
         let fuzzyAlias = try XCTUnwrap(fuzzyAliases.first { candidate in
             let candidateLine = DiffGenerationUtility.processLine(candidate, precision: .high)
-            let candidateKeys = DiffGenerationUtility
-                .buildLineIndexMapHigh(content: [candidateLine])
-                .keys
             var candidateIndex = prefixIndex
-            for key in candidateKeys {
-                candidateIndex[key] = [minimumMatchIndex]
-            }
-            let orderedKeys = Array(candidateIndex.keys)
-            let positions = candidateKeys.compactMap { key in
-                orderedKeys.firstIndex(of: key)
-            }
-            return !positions.isEmpty && positions.allSatisfy { $0 >= 400 }
+            candidateIndex[candidateLine.removedTagsHigh] = [minimumMatchIndex]
+            let position = Array(candidateIndex.keys).firstIndex(of: candidateLine.removedTagsHigh)
+            return (position ?? 0) >= 400
         },
             "The test needs a fuzzy alias after the 400-key probe boundary"
         )

--- a/Tests/RepoPromptTests/Diffing/DiffGenerationUtilityRoutingTests.swift
+++ b/Tests/RepoPromptTests/Diffing/DiffGenerationUtilityRoutingTests.swift
@@ -36,30 +36,32 @@ final class DiffGenerationUtilityRoutingTests: XCTestCase {
         let selector = DiffGenerationUtility.processLine(selectorText, precision: .high)
         let minimumMatchIndex = 401
         let prefix = (0 ..< minimumMatchIndex).map { "unrelated pre-boundary key \($0)" }
-        let content = prefix.map {
+        let processedPrefix = prefix.map {
             DiffGenerationUtility.processLine($0, precision: .high)
-        } + [selector]
-
-        var lineIndex = Dictionary(
-            uniqueKeysWithValues: prefix.enumerated().map { index, line in
-                (DiffGenerationUtility.processLine(line, precision: .high).removedTagsHigh, [index])
-            }
-        )
-        let fuzzyAliases = (0 ..< 1_024).map {
+        }
+        let prefixIndex = DiffGenerationUtility.buildLineIndexMapHigh(content: processedPrefix)
+        let fuzzyAliases = (0 ..< 1024).map {
             "calculate total for selected invoice line item \($0)"
         }
-        let fuzzyAlias = try XCTUnwrap(
-            fuzzyAliases.first { candidate in
-                var candidateIndex = lineIndex
-                candidateIndex[candidate] = [minimumMatchIndex]
-                guard let position = Array(candidateIndex.keys).firstIndex(of: candidate) else {
-                    return false
-                }
-                return position >= 400
-            },
+        let fuzzyAlias = try XCTUnwrap(fuzzyAliases.first { candidate in
+            let candidateLine = DiffGenerationUtility.processLine(candidate, precision: .high)
+            let candidateKeys = DiffGenerationUtility
+                .buildLineIndexMapHigh(content: [candidateLine])
+                .keys
+            var candidateIndex = prefixIndex
+            for key in candidateKeys {
+                candidateIndex[key] = [minimumMatchIndex]
+            }
+            let orderedKeys = Array(candidateIndex.keys)
+            let positions = candidateKeys.compactMap { key in
+                orderedKeys.firstIndex(of: key)
+            }
+            return !positions.isEmpty && positions.allSatisfy { $0 >= 400 }
+        },
             "The test needs a fuzzy alias after the 400-key probe boundary"
         )
-        lineIndex[fuzzyAlias] = [minimumMatchIndex]
+        let content = processedPrefix + [DiffGenerationUtility.processLine(fuzzyAlias, precision: .high)]
+        let lineIndex = DiffGenerationUtility.buildLineIndexMapHigh(content: content)
 
         let result = try DiffGenerationUtility.matchSelectorFast(
             selector: [selector],

--- a/Tests/RepoPromptTests/Diffing/DiffGenerationUtilityRoutingTests.swift
+++ b/Tests/RepoPromptTests/Diffing/DiffGenerationUtilityRoutingTests.swift
@@ -31,6 +31,48 @@ final class DiffGenerationUtilityRoutingTests: XCTestCase {
         XCTAssertEqual(result, "same\nskip\nreplacement\nmiddle\nreplacement")
     }
 
+    func testFuzzyProbeIgnoresPreBoundaryKeysBeforeSpendingBudget() throws {
+        let selectorText = "calculate total for selected invoice line items"
+        let selector = DiffGenerationUtility.processLine(selectorText, precision: .high)
+        let minimumMatchIndex = 401
+        let prefix = (0 ..< minimumMatchIndex).map { "unrelated pre-boundary key \($0)" }
+        let content = prefix.map {
+            DiffGenerationUtility.processLine($0, precision: .high)
+        } + [selector]
+
+        var lineIndex = Dictionary(
+            uniqueKeysWithValues: prefix.enumerated().map { index, line in
+                (DiffGenerationUtility.processLine(line, precision: .high).removedTagsHigh, [index])
+            }
+        )
+        let fuzzyAliases = (0 ..< 1_024).map {
+            "calculate total for selected invoice line item \($0)"
+        }
+        let fuzzyAlias = try XCTUnwrap(
+            fuzzyAliases.first { candidate in
+                var candidateIndex = lineIndex
+                candidateIndex[candidate] = [minimumMatchIndex]
+                guard let position = Array(candidateIndex.keys).firstIndex(of: candidate) else {
+                    return false
+                }
+                return position >= 400
+            },
+            "The test needs a fuzzy alias after the 400-key probe boundary"
+        )
+        lineIndex[fuzzyAlias] = [minimumMatchIndex]
+
+        let result = try DiffGenerationUtility.matchSelectorFast(
+            selector: [selector],
+            content: content,
+            lineIndex: lineIndex,
+            maxFuzzyKeys: 400,
+            fuzzyThreshold: 0.80,
+            minimumMatchIndex: minimumMatchIndex
+        )
+
+        XCTAssertEqual(result, minimumMatchIndex)
+    }
+
     func testBatchReplaceAllKeepsFullFileIndexCoordinatesAfterFirstMatch() async throws {
         let original = [
             "header",

--- a/Tests/RepoPromptTests/Diffing/DiffGenerationUtilityRoutingTests.swift
+++ b/Tests/RepoPromptTests/Diffing/DiffGenerationUtilityRoutingTests.swift
@@ -45,25 +45,29 @@ final class DiffGenerationUtilityRoutingTests: XCTestCase {
         let fuzzyAliases = (0 ..< 4_096).map {
             "calculate total for selected invoice line item candidate \(String($0, radix: 36))"
         }
-        let fuzzyAlias = try XCTUnwrap(fuzzyAliases.first { candidate in
-            let candidateLine = DiffGenerationUtility.processLine(candidate, precision: .high)
-            let candidateKeys = DiffGenerationUtility
-                .buildLineIndexMapHigh(content: [candidateLine])
-                .keys
-            var candidateIndex = prefixIndex
-            for key in candidateKeys {
-                candidateIndex[key] = [minimumMatchIndex]
-            }
-            let orderedKeys = Array(candidateIndex.keys)
-            let positions = candidateKeys.compactMap { key in
-                orderedKeys.firstIndex(of: key)
-            }
-            return !positions.isEmpty && positions.allSatisfy { $0 >= 400 }
-        },
+        let fuzzyCandidate = try XCTUnwrap(
+            fuzzyAliases.compactMap { candidate -> (String, [String: [Int]])? in
+                let candidateLine = DiffGenerationUtility.processLine(candidate, precision: .high)
+                let candidateKeys = DiffGenerationUtility
+                    .buildLineIndexMapHigh(content: [candidateLine])
+                    .keys
+                var candidateIndex = prefixIndex
+                for key in candidateKeys {
+                    candidateIndex[key] = [minimumMatchIndex]
+                }
+                let orderedKeys = Array(candidateIndex.keys)
+                let positions = candidateKeys.compactMap { key in
+                    orderedKeys.firstIndex(of: key)
+                }
+                guard !positions.isEmpty, positions.allSatisfy({ $0 >= 400 }) else {
+                    return nil
+                }
+                return (candidate, candidateIndex)
+            }.first,
             "The test needs a fuzzy alias after the 400-key probe boundary"
         )
-        let content = processedPrefix + [DiffGenerationUtility.processLine(fuzzyAlias, precision: .high)]
-        let lineIndex = DiffGenerationUtility.buildLineIndexMapHigh(content: content)
+        let content = processedPrefix + [DiffGenerationUtility.processLine(fuzzyCandidate.0, precision: .high)]
+        let lineIndex = fuzzyCandidate.1
 
         let result = try DiffGenerationUtility.matchSelectorFast(
             selector: [selector],


### PR DESCRIPTION
## Summary

Replace-all now searches one processed full-file representation with an advancing absolute lower bound.

This fixes later matches being skipped when `DiffBatchGenerator` supplies a full-file index and removes repeated suffix normalization and index construction.

## Change

- Reuse the batch generator's processed lines and full-file index.
- Build processed lines and the index once when callers do not supply them.
- Filter matcher candidates using an absolute minimum match index.
- Preserve ambiguity, indentation, ordering, and original-file chunk coordinates.

## Regression coverage

Tests cover a nonzero `searchStartLine` with a non-nil full-file index, the complete batch diff fallback route with separated matches, and a deterministic fuzzy-probe case with more than 400 distinct keys before `minimumMatchIndex`. The latter verifies that an eligible fuzzy-only match after the boundary is still found.

For a synthetic 5,000-line/20-match case, source-level operation counting changes normalization from 60,460 `processLine` calls to 5,000 and index construction from 21 suffix indexes to one full-file index.

## Validation

- Exact branch diff and `git diff --check` passed.
- Staged whitespace and secret scans passed.
- Branch autoreview is clean.
- Swift/macOS checks are pending on the new head's CI.

Fixes #729