### PR TITLE
Settle cancelled Codex stderr waiters promptly

### DIFF
--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexProcessStderrCapture.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexProcessStderrCapture.swift
@@ -8,8 +8,6 @@ final class CodexProcessStderrCapture: @unchecked Sendable {
         let wasTruncated: Bool
     }
 
-    /// Reservation precedes cancellation-handler installation, so a terminal result may
-    /// temporarily exist before the checked continuation is available to resume.
     private struct Waiter {
         var continuation: CheckedContinuation<Bool, Never>?
         var timeoutTask: Task<Void, Never>?
@@ -81,13 +79,13 @@ final class CodexProcessStderrCapture: @unchecked Sendable {
 
     func waitUntilFinished(timeout: TimeInterval) async -> Bool {
         let waiterID = UUID()
-        if let immediateResult = reserveWaiter(waiterID) {
-            return immediateResult
-        }
         let timeoutNanoseconds = UInt64(max(timeout, 0) * 1_000_000_000)
         return await withTaskCancellationHandler {
             await withCheckedContinuation { continuation in
-                guard installContinuation(continuation, for: waiterID) else { return }
+                if let immediateResult = registerWaiter(continuation, for: waiterID) {
+                    continuation.resume(returning: immediateResult)
+                    return
+                }
 
                 let timeoutTask = Task.detached { [weak self] in
                     do {
@@ -114,7 +112,10 @@ final class CodexProcessStderrCapture: @unchecked Sendable {
         return snapshot
     }
 
-    private func reserveWaiter(_ waiterID: UUID) -> Bool? {
+    private func registerWaiter(
+        _ continuation: CheckedContinuation<Bool, Never>,
+        for waiterID: UUID
+    ) -> Bool? {
         lock.lock()
         defer { lock.unlock() }
         if isFinished {
@@ -124,34 +125,11 @@ final class CodexProcessStderrCapture: @unchecked Sendable {
             return false
         }
         waiters[waiterID] = Waiter(
-            continuation: nil,
+            continuation: continuation,
             timeoutTask: nil,
             terminalResult: nil
         )
         return nil
-    }
-
-    private func installContinuation(
-        _ continuation: CheckedContinuation<Bool, Never>,
-        for waiterID: UUID
-    ) -> Bool {
-        lock.lock()
-        guard var waiter = waiters[waiterID] else {
-            lock.unlock()
-            assertionFailure("Reserved stderr waiter disappeared before continuation installation")
-            continuation.resume(returning: false)
-            return false
-        }
-        if let terminalResult = waiter.terminalResult {
-            waiters.removeValue(forKey: waiterID)
-            lock.unlock()
-            continuation.resume(returning: terminalResult)
-            return false
-        }
-        waiter.continuation = continuation
-        waiters[waiterID] = waiter
-        lock.unlock()
-        return true
     }
 
     private func installTimeoutTask(_ timeoutTask: Task<Void, Never>, for waiterID: UUID) {

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexProcessStderrCapture.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexProcessStderrCapture.swift
@@ -8,16 +8,44 @@ final class CodexProcessStderrCapture: @unchecked Sendable {
         let wasTruncated: Bool
     }
 
+    /// Reservation precedes cancellation-handler installation, so a terminal result may
+    /// temporarily exist before the checked continuation is available to resume.
+    private struct Waiter {
+        var continuation: CheckedContinuation<Bool, Never>?
+        var timeoutTask: Task<Void, Never>?
+        var terminalResult: Bool?
+    }
+
     private let lock = NSLock()
     private let byteLimit: Int
     private var tail = Data()
     private var wasTruncated = false
     private var isFinished = false
-    private var waiters: [UUID: CheckedContinuation<Bool, Never>] = [:]
+    private var waiters: [UUID: Waiter] = [:]
+    #if DEBUG
+        private let beforeContinuationInstallForTesting: (@Sendable () async -> Void)?
+        private let waiterDidRegisterForTesting: (@Sendable () -> Void)?
+    #endif
 
     init(byteLimit: Int) {
         self.byteLimit = max(byteLimit, 0)
+        #if DEBUG
+            beforeContinuationInstallForTesting = nil
+            waiterDidRegisterForTesting = nil
+        #endif
     }
+
+    #if DEBUG
+        init(
+            byteLimit: Int,
+            beforeContinuationInstallForTesting: (@Sendable () async -> Void)? = nil,
+            waiterDidRegisterForTesting: (@Sendable () -> Void)? = nil
+        ) {
+            self.byteLimit = max(byteLimit, 0)
+            self.beforeContinuationInstallForTesting = beforeContinuationInstallForTesting
+            self.waiterDidRegisterForTesting = waiterDidRegisterForTesting
+        }
+    #endif
 
     func append(_ chunk: Data) {
         guard !chunk.isEmpty else { return }
@@ -52,34 +80,58 @@ final class CodexProcessStderrCapture: @unchecked Sendable {
             return
         }
         isFinished = true
-        let continuations = waiters.values
-        waiters.removeAll()
+        var pendingWaiters: [Waiter] = []
+        for waiterID in Array(waiters.keys) {
+            guard var waiter = waiters[waiterID], waiter.terminalResult == nil else { continue }
+            waiter.terminalResult = true
+            if waiter.continuation == nil {
+                waiters[waiterID] = waiter
+            } else {
+                waiters.removeValue(forKey: waiterID)
+                pendingWaiters.append(waiter)
+            }
+        }
         lock.unlock()
 
-        for continuation in continuations {
-            continuation.resume(returning: true)
+        for waiter in pendingWaiters {
+            waiter.timeoutTask?.cancel()
+            waiter.continuation?.resume(returning: true)
         }
     }
 
     func waitUntilFinished(timeout: TimeInterval) async -> Bool {
         let waiterID = UUID()
-        return await withCheckedContinuation { continuation in
-            lock.lock()
-            if isFinished {
-                lock.unlock()
-                continuation.resume(returning: true)
-                return
+        if let immediateResult = reserveWaiter(waiterID) {
+            return immediateResult
+        }
+        #if DEBUG
+            if let beforeContinuationInstallForTesting {
+                await beforeContinuationInstallForTesting()
             }
-            waiters[waiterID] = continuation
-            lock.unlock()
+        #endif
+        let timeoutNanoseconds = UInt64(max(timeout, 0) * 1_000_000_000)
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                guard installContinuation(continuation, for: waiterID) else { return }
+                #if DEBUG
+                    waiterDidRegisterForTesting?()
+                #endif
 
-            let timeoutNanoseconds = UInt64(max(timeout, 0) * 1_000_000_000)
-            Task.detached { [weak self] in
-                if timeoutNanoseconds > 0 {
-                    try? await Task.sleep(nanoseconds: timeoutNanoseconds)
+                let timeoutTask = Task.detached { [weak self] in
+                    do {
+                        if timeoutNanoseconds > 0 {
+                            try await Task.sleep(nanoseconds: timeoutNanoseconds)
+                        }
+                        try Task.checkCancellation()
+                    } catch {
+                        return
+                    }
+                    self?.settleWaiter(waiterID, returning: false)
                 }
-                self?.expireWaiter(waiterID)
+                installTimeoutTask(timeoutTask, for: waiterID)
             }
+        } onCancel: {
+            settleWaiter(waiterID, returning: false)
         }
     }
 
@@ -90,10 +142,74 @@ final class CodexProcessStderrCapture: @unchecked Sendable {
         return snapshot
     }
 
-    private func expireWaiter(_ waiterID: UUID) {
+    private func reserveWaiter(_ waiterID: UUID) -> Bool? {
         lock.lock()
-        let continuation = waiters.removeValue(forKey: waiterID)
+        defer { lock.unlock() }
+        if isFinished {
+            return true
+        }
+        if Task<Never, Never>.isCancelled {
+            return false
+        }
+        waiters[waiterID] = Waiter(
+            continuation: nil,
+            timeoutTask: nil,
+            terminalResult: nil
+        )
+        return nil
+    }
+
+    private func installContinuation(
+        _ continuation: CheckedContinuation<Bool, Never>,
+        for waiterID: UUID
+    ) -> Bool {
+        lock.lock()
+        guard var waiter = waiters[waiterID] else {
+            lock.unlock()
+            assertionFailure("Reserved stderr waiter disappeared before continuation installation")
+            continuation.resume(returning: false)
+            return false
+        }
+        if let terminalResult = waiter.terminalResult {
+            waiters.removeValue(forKey: waiterID)
+            lock.unlock()
+            continuation.resume(returning: terminalResult)
+            return false
+        }
+        waiter.continuation = continuation
+        waiters[waiterID] = waiter
         lock.unlock()
-        continuation?.resume(returning: false)
+        return true
+    }
+
+    private func installTimeoutTask(_ timeoutTask: Task<Void, Never>, for waiterID: UUID) {
+        lock.lock()
+        guard var waiter = waiters[waiterID] else {
+            lock.unlock()
+            timeoutTask.cancel()
+            return
+        }
+        waiter.timeoutTask = timeoutTask
+        waiters[waiterID] = waiter
+        lock.unlock()
+    }
+
+    private func settleWaiter(_ waiterID: UUID, returning result: Bool) {
+        lock.lock()
+        guard var waiter = waiters[waiterID], waiter.terminalResult == nil else {
+            lock.unlock()
+            return
+        }
+        waiter.terminalResult = result
+        let continuation = waiter.continuation
+        let timeoutTask = waiter.timeoutTask
+        if continuation == nil {
+            waiters[waiterID] = waiter
+        } else {
+            waiters.removeValue(forKey: waiterID)
+        }
+        lock.unlock()
+        timeoutTask?.cancel()
+        continuation?.resume(returning: result)
     }
 }

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexProcessStderrCapture.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexProcessStderrCapture.swift
@@ -22,30 +22,24 @@ final class CodexProcessStderrCapture: @unchecked Sendable {
     private var wasTruncated = false
     private var isFinished = false
     private var waiters: [UUID: Waiter] = [:]
-    #if DEBUG
-        private let beforeContinuationInstallForTesting: (@Sendable () async -> Void)?
-        private let waiterDidRegisterForTesting: (@Sendable () -> Void)?
-    #endif
+    private let beforeContinuationInstallForTesting: (@Sendable () async -> Void)?
+    private let waiterDidRegisterForTesting: (@Sendable () -> Void)?
 
     init(byteLimit: Int) {
         self.byteLimit = max(byteLimit, 0)
-        #if DEBUG
-            beforeContinuationInstallForTesting = nil
-            waiterDidRegisterForTesting = nil
-        #endif
+        beforeContinuationInstallForTesting = nil
+        waiterDidRegisterForTesting = nil
     }
 
-    #if DEBUG
-        init(
-            byteLimit: Int,
-            beforeContinuationInstallForTesting: (@Sendable () async -> Void)? = nil,
-            waiterDidRegisterForTesting: (@Sendable () -> Void)? = nil
-        ) {
-            self.byteLimit = max(byteLimit, 0)
-            self.beforeContinuationInstallForTesting = beforeContinuationInstallForTesting
-            self.waiterDidRegisterForTesting = waiterDidRegisterForTesting
-        }
-    #endif
+    init(
+        byteLimit: Int,
+        beforeContinuationInstallForTesting: (@Sendable () async -> Void)?,
+        waiterDidRegisterForTesting: (@Sendable () -> Void)?
+    ) {
+        self.byteLimit = max(byteLimit, 0)
+        self.beforeContinuationInstallForTesting = beforeContinuationInstallForTesting
+        self.waiterDidRegisterForTesting = waiterDidRegisterForTesting
+    }
 
     func append(_ chunk: Data) {
         guard !chunk.isEmpty else { return }
@@ -104,18 +98,14 @@ final class CodexProcessStderrCapture: @unchecked Sendable {
         if let immediateResult = reserveWaiter(waiterID) {
             return immediateResult
         }
-        #if DEBUG
-            if let beforeContinuationInstallForTesting {
-                await beforeContinuationInstallForTesting()
-            }
-        #endif
+        if let beforeContinuationInstallForTesting {
+            await beforeContinuationInstallForTesting()
+        }
         let timeoutNanoseconds = UInt64(max(timeout, 0) * 1_000_000_000)
         return await withTaskCancellationHandler {
             await withCheckedContinuation { continuation in
                 guard installContinuation(continuation, for: waiterID) else { return }
-                #if DEBUG
-                    waiterDidRegisterForTesting?()
-                #endif
+                waiterDidRegisterForTesting?()
 
                 let timeoutTask = Task.detached { [weak self] in
                     do {

--- a/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexProcessStderrCapture.swift
+++ b/Sources/RepoPrompt/Infrastructure/AI/Providers/Codex/AppServer/CodexProcessStderrCapture.swift
@@ -22,23 +22,9 @@ final class CodexProcessStderrCapture: @unchecked Sendable {
     private var wasTruncated = false
     private var isFinished = false
     private var waiters: [UUID: Waiter] = [:]
-    private let beforeContinuationInstallForTesting: (@Sendable () async -> Void)?
-    private let waiterDidRegisterForTesting: (@Sendable () -> Void)?
 
     init(byteLimit: Int) {
         self.byteLimit = max(byteLimit, 0)
-        beforeContinuationInstallForTesting = nil
-        waiterDidRegisterForTesting = nil
-    }
-
-    init(
-        byteLimit: Int,
-        beforeContinuationInstallForTesting: (@Sendable () async -> Void)?,
-        waiterDidRegisterForTesting: (@Sendable () -> Void)?
-    ) {
-        self.byteLimit = max(byteLimit, 0)
-        self.beforeContinuationInstallForTesting = beforeContinuationInstallForTesting
-        self.waiterDidRegisterForTesting = waiterDidRegisterForTesting
     }
 
     func append(_ chunk: Data) {
@@ -98,14 +84,10 @@ final class CodexProcessStderrCapture: @unchecked Sendable {
         if let immediateResult = reserveWaiter(waiterID) {
             return immediateResult
         }
-        if let beforeContinuationInstallForTesting {
-            await beforeContinuationInstallForTesting()
-        }
         let timeoutNanoseconds = UInt64(max(timeout, 0) * 1_000_000_000)
         return await withTaskCancellationHandler {
             await withCheckedContinuation { continuation in
                 guard installContinuation(continuation, for: waiterID) else { return }
-                waiterDidRegisterForTesting?()
 
                 let timeoutTask = Task.detached { [weak self] in
                     do {

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexAppServerClientProcessExitTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexAppServerClientProcessExitTests.swift
@@ -14,6 +14,61 @@ final class CodexAppServerClientProcessExitTests: XCTestCase {
         try super.tearDownWithError()
     }
 
+    func testStderrCaptureCancellationBeforeRegistrationReturnsFalse() async {
+        let registrationGate = CodexStderrWaitRegistrationGate()
+        let completed = expectation(description: "cancelled stderr wait completed")
+        let capture = CodexProcessStderrCapture(
+            byteLimit: 8 * 1024,
+            beforeContinuationInstallForTesting: { await registrationGate.pause() }
+        )
+        let wait = Task {
+            let result = await capture.waitUntilFinished(timeout: 60)
+            completed.fulfill()
+            return result
+        }
+
+        await registrationGate.waitUntilPaused()
+        wait.cancel()
+        await registrationGate.resume()
+        await fulfillment(of: [completed], timeout: 1)
+        capture.finish()
+
+        XCTAssertFalse(await wait.value)
+    }
+
+    func testStderrCaptureCancellationRemovesOnlyCancelledWaiter() async {
+        let registered = expectation(description: "stderr waiters registered")
+        registered.expectedFulfillmentCount = 2
+        let capture = CodexProcessStderrCapture(
+            byteLimit: 8 * 1024,
+            waiterDidRegisterForTesting: { registered.fulfill() }
+        )
+        let cancelledWaitCompleted = expectation(description: "cancelled stderr waiter completed")
+        let cancelledWait = Task {
+            let result = await capture.waitUntilFinished(timeout: 60)
+            cancelledWaitCompleted.fulfill()
+            return result
+        }
+        let finishingWait = Task { await capture.waitUntilFinished(timeout: 60) }
+        await fulfillment(of: [registered], timeout: 1)
+
+        cancelledWait.cancel()
+        await fulfillment(of: [cancelledWaitCompleted], timeout: 1)
+        capture.finish()
+
+        XCTAssertFalse(await cancelledWait.value)
+        XCTAssertTrue(await finishingWait.value)
+    }
+
+    func testStderrCaptureZeroTimeoutAndFinishedSemanticsRemainDistinct() async {
+        let capture = CodexProcessStderrCapture(byteLimit: 8 * 1024)
+
+        XCTAssertFalse(await capture.waitUntilFinished(timeout: 0))
+
+        capture.finish()
+        XCTAssertTrue(await capture.waitUntilFinished(timeout: 0))
+    }
+
     func testStderrCaptureRetainsExactRawSuffixAtEveryBoundary() async {
         let invalidUTF8 = Data([0x66, 0x80, 0x67])
         let scenarios: [[Data]] = [
@@ -914,6 +969,30 @@ private actor CompletionFlag {
 
     func markComplete() {
         isComplete = true
+    }
+}
+
+private actor CodexStderrWaitRegistrationGate {
+    private var didPause = false
+    private var pauseWaiters: [CheckedContinuation<Void, Never>] = []
+    private var resumeContinuation: CheckedContinuation<Void, Never>?
+
+    func pause() async {
+        didPause = true
+        let pending = pauseWaiters
+        pauseWaiters.removeAll()
+        pending.forEach { $0.resume() }
+        await withCheckedContinuation { resumeContinuation = $0 }
+    }
+
+    func waitUntilPaused() async {
+        guard !didPause else { return }
+        await withCheckedContinuation { pauseWaiters.append($0) }
+    }
+
+    func resume() {
+        resumeContinuation?.resume()
+        resumeContinuation = nil
     }
 }
 

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexAppServerClientProcessExitTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexAppServerClientProcessExitTests.swift
@@ -14,55 +14,15 @@ final class CodexAppServerClientProcessExitTests: XCTestCase {
         try super.tearDownWithError()
     }
 
-    func testStderrCaptureCancellationBeforeRegistrationReturnsFalse() async {
-        let registrationGate = CodexStderrWaitRegistrationGate()
-        let completed = expectation(description: "cancelled stderr wait completed")
-        let capture = CodexProcessStderrCapture(
-            byteLimit: 8 * 1024,
-            beforeContinuationInstallForTesting: { await registrationGate.pause() },
-            waiterDidRegisterForTesting: nil
-        )
-        let wait = Task {
-            let result = await capture.waitUntilFinished(timeout: 60)
-            completed.fulfill()
-            return result
-        }
+    func testStderrCaptureCancellationReturnsFalsePromptly() async {
+        let capture = CodexProcessStderrCapture(byteLimit: 8 * 1024)
+        let wait = Task { await capture.waitUntilFinished(timeout: 60) }
 
-        await registrationGate.waitUntilPaused()
+        await Task.yield()
         wait.cancel()
-        await registrationGate.resume()
-        await fulfillment(of: [completed], timeout: 1)
-        capture.finish()
 
         let result = await wait.value
         XCTAssertFalse(result)
-    }
-
-    func testStderrCaptureCancellationRemovesOnlyCancelledWaiter() async {
-        let registered = expectation(description: "stderr waiters registered")
-        registered.expectedFulfillmentCount = 2
-        let capture = CodexProcessStderrCapture(
-            byteLimit: 8 * 1024,
-            beforeContinuationInstallForTesting: nil,
-            waiterDidRegisterForTesting: { registered.fulfill() }
-        )
-        let cancelledWaitCompleted = expectation(description: "cancelled stderr waiter completed")
-        let cancelledWait = Task {
-            let result = await capture.waitUntilFinished(timeout: 60)
-            cancelledWaitCompleted.fulfill()
-            return result
-        }
-        let finishingWait = Task { await capture.waitUntilFinished(timeout: 60) }
-        await fulfillment(of: [registered], timeout: 1)
-
-        cancelledWait.cancel()
-        await fulfillment(of: [cancelledWaitCompleted], timeout: 1)
-        capture.finish()
-
-        let cancelledResult = await cancelledWait.value
-        let finishingResult = await finishingWait.value
-        XCTAssertFalse(cancelledResult)
-        XCTAssertTrue(finishingResult)
     }
 
     func testStderrCaptureZeroTimeoutAndFinishedSemanticsRemainDistinct() async {
@@ -976,30 +936,6 @@ private actor CompletionFlag {
 
     func markComplete() {
         isComplete = true
-    }
-}
-
-private actor CodexStderrWaitRegistrationGate {
-    private var didPause = false
-    private var pauseWaiters: [CheckedContinuation<Void, Never>] = []
-    private var resumeContinuation: CheckedContinuation<Void, Never>?
-
-    func pause() async {
-        didPause = true
-        let pending = pauseWaiters
-        pauseWaiters.removeAll()
-        pending.forEach { $0.resume() }
-        await withCheckedContinuation { resumeContinuation = $0 }
-    }
-
-    func waitUntilPaused() async {
-        guard !didPause else { return }
-        await withCheckedContinuation { pauseWaiters.append($0) }
-    }
-
-    func resume() {
-        resumeContinuation?.resume()
-        resumeContinuation = nil
     }
 }
 

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexAppServerClientProcessExitTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexAppServerClientProcessExitTests.swift
@@ -14,15 +14,50 @@ final class CodexAppServerClientProcessExitTests: XCTestCase {
         try super.tearDownWithError()
     }
 
-    func testStderrCaptureCancellationReturnsFalsePromptly() async {
+    func testStderrCaptureCancellationBeforeContinuationInstallationReturnsFalse() async {
         let capture = CodexProcessStderrCapture(byteLimit: 8 * 1024)
-        let wait = Task { await capture.waitUntilFinished(timeout: 60) }
+        let started = expectation(description: "stderr wait started")
+        let wait = Task {
+            started.fulfill()
+            return await capture.waitUntilFinished(timeout: 60)
+        }
 
-        await Task.yield()
+        await fulfillment(of: [started], timeout: 1)
         wait.cancel()
 
+        let promptResult = await waitForStderrResult(wait)
+        XCTAssertEqual(promptResult, false)
+
+        capture.finish()
         let result = await wait.value
         XCTAssertFalse(result)
+    }
+
+    func testStderrCaptureCancellationRemovesOnlyCancelledWaiter() async {
+        let capture = CodexProcessStderrCapture(byteLimit: 8 * 1024)
+        let cancelledStarted = expectation(description: "cancelled stderr wait started")
+        let finishingStarted = expectation(description: "finishing stderr wait started")
+        let cancelledWait = Task {
+            cancelledStarted.fulfill()
+            return await capture.waitUntilFinished(timeout: 60)
+        }
+        let finishingWait = Task {
+            finishingStarted.fulfill()
+            return await capture.waitUntilFinished(timeout: 60)
+        }
+
+        await fulfillment(of: [cancelledStarted, finishingStarted], timeout: 1)
+        await Task.yield()
+        cancelledWait.cancel()
+
+        let cancelledPromptResult = await waitForStderrResult(cancelledWait)
+        XCTAssertEqual(cancelledPromptResult, false)
+
+        capture.finish()
+        let cancelledResult = await cancelledWait.value
+        let finishingResult = await finishingWait.value
+        XCTAssertFalse(cancelledResult)
+        XCTAssertTrue(finishingResult)
     }
 
     func testStderrCaptureZeroTimeoutAndFinishedSemanticsRemainDistinct() async {
@@ -34,6 +69,22 @@ final class CodexAppServerClientProcessExitTests: XCTestCase {
         capture.finish()
         let finished = await capture.waitUntilFinished(timeout: 0)
         XCTAssertTrue(finished)
+    }
+
+    private func waitForStderrResult(
+        _ task: Task<Bool, Never>,
+        timeoutNanoseconds: UInt64 = 1_000_000_000
+    ) async -> Bool? {
+        await withTaskGroup(of: Bool?.self) { group in
+            group.addTask { await task.value }
+            group.addTask {
+                try? await Task.sleep(nanoseconds: timeoutNanoseconds)
+                return nil
+            }
+            let result = await group.next()!
+            group.cancelAll()
+            return result
+        }
     }
 
     func testStderrCaptureRetainsExactRawSuffixAtEveryBoundary() async {

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexAppServerClientProcessExitTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexAppServerClientProcessExitTests.swift
@@ -33,7 +33,8 @@ final class CodexAppServerClientProcessExitTests: XCTestCase {
         await fulfillment(of: [completed], timeout: 1)
         capture.finish()
 
-        XCTAssertFalse(await wait.value)
+        let result = await wait.value
+        XCTAssertFalse(result)
     }
 
     func testStderrCaptureCancellationRemovesOnlyCancelledWaiter() async {
@@ -56,17 +57,21 @@ final class CodexAppServerClientProcessExitTests: XCTestCase {
         await fulfillment(of: [cancelledWaitCompleted], timeout: 1)
         capture.finish()
 
-        XCTAssertFalse(await cancelledWait.value)
-        XCTAssertTrue(await finishingWait.value)
+        let cancelledResult = await cancelledWait.value
+        let finishingResult = await finishingWait.value
+        XCTAssertFalse(cancelledResult)
+        XCTAssertTrue(finishingResult)
     }
 
     func testStderrCaptureZeroTimeoutAndFinishedSemanticsRemainDistinct() async {
         let capture = CodexProcessStderrCapture(byteLimit: 8 * 1024)
 
-        XCTAssertFalse(await capture.waitUntilFinished(timeout: 0))
+        let timedOut = await capture.waitUntilFinished(timeout: 0)
+        XCTAssertFalse(timedOut)
 
         capture.finish()
-        XCTAssertTrue(await capture.waitUntilFinished(timeout: 0))
+        let finished = await capture.waitUntilFinished(timeout: 0)
+        XCTAssertTrue(finished)
     }
 
     func testStderrCaptureRetainsExactRawSuffixAtEveryBoundary() async {

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexAppServerClientProcessExitTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexAppServerClientProcessExitTests.swift
@@ -19,7 +19,8 @@ final class CodexAppServerClientProcessExitTests: XCTestCase {
         let completed = expectation(description: "cancelled stderr wait completed")
         let capture = CodexProcessStderrCapture(
             byteLimit: 8 * 1024,
-            beforeContinuationInstallForTesting: { await registrationGate.pause() }
+            beforeContinuationInstallForTesting: { await registrationGate.pause() },
+            waiterDidRegisterForTesting: nil
         )
         let wait = Task {
             let result = await capture.waitUntilFinished(timeout: 60)
@@ -42,6 +43,7 @@ final class CodexAppServerClientProcessExitTests: XCTestCase {
         registered.expectedFulfillmentCount = 2
         let capture = CodexProcessStderrCapture(
             byteLimit: 8 * 1024,
+            beforeContinuationInstallForTesting: nil,
             waiterDidRegisterForTesting: { registered.fulfill() }
         )
         let cancelledWaitCompleted = expectation(description: "cancelled stderr waiter completed")

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexAppServerClientProcessExitTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexAppServerClientProcessExitTests.swift
@@ -14,7 +14,7 @@ final class CodexAppServerClientProcessExitTests: XCTestCase {
         try super.tearDownWithError()
     }
 
-    func testStderrCaptureCancellationBeforeContinuationInstallationReturnsFalse() async {
+    func testStderrCaptureCancellationDuringWaiterRegistrationReturnsFalse() async {
         let capture = CodexProcessStderrCapture(byteLimit: 8 * 1024)
         let started = expectation(description: "stderr wait started")
         let wait = Task {
@@ -75,15 +75,21 @@ final class CodexAppServerClientProcessExitTests: XCTestCase {
         _ task: Task<Bool, Never>,
         timeoutNanoseconds: UInt64 = 1_000_000_000
     ) async -> Bool? {
-        await withTaskGroup(of: Bool?.self) { group in
-            group.addTask { await task.value }
-            group.addTask {
-                try? await Task.sleep(nanoseconds: timeoutNanoseconds)
-                return nil
+        await withCheckedContinuation { continuation in
+            let gate = StderrResultGate(continuation: continuation)
+            Task {
+                gate.complete(await task.value)
             }
-            let result = await group.next()!
-            group.cancelAll()
-            return result
+            let timeoutTask = Task {
+                do {
+                    try await Task.sleep(nanoseconds: timeoutNanoseconds)
+                    try Task.checkCancellation()
+                    gate.complete(nil)
+                } catch {
+                    return
+                }
+            }
+            gate.install(timeoutTask: timeoutTask)
         }
     }
 
@@ -916,6 +922,45 @@ final class CodexAppServerClientProcessExitTests: XCTestCase {
             try await Task.sleep(nanoseconds: 10_000_000)
         }
         throw WaitUntilError.timedOut(label)
+    }
+}
+
+private final class StderrResultGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Bool?, Never>?
+    private var timeoutTask: Task<Void, Never>?
+    private var didComplete = false
+
+    init(continuation: CheckedContinuation<Bool?, Never>) {
+        self.continuation = continuation
+    }
+
+    func install(timeoutTask: Task<Void, Never>) {
+        lock.lock()
+        if didComplete {
+            lock.unlock()
+            timeoutTask.cancel()
+            return
+        }
+        self.timeoutTask = timeoutTask
+        lock.unlock()
+    }
+
+    func complete(_ result: Bool?) {
+        lock.lock()
+        guard !didComplete else {
+            lock.unlock()
+            return
+        }
+        didComplete = true
+        let continuation = self.continuation
+        self.continuation = nil
+        let timeoutTask = self.timeoutTask
+        self.timeoutTask = nil
+        lock.unlock()
+
+        timeoutTask?.cancel()
+        continuation?.resume(returning: result)
     }
 }
 

--- a/Tests/RepoPromptTests/AgentMode/Codex/CodexAppServerClientProcessExitTests.swift
+++ b/Tests/RepoPromptTests/AgentMode/Codex/CodexAppServerClientProcessExitTests.swift
@@ -78,7 +78,8 @@ final class CodexAppServerClientProcessExitTests: XCTestCase {
         await withCheckedContinuation { continuation in
             let gate = StderrResultGate(continuation: continuation)
             Task {
-                gate.complete(await task.value)
+                let result = await task.value
+                gate.complete(result)
             }
             let timeoutTask = Task {
                 do {
@@ -734,7 +735,6 @@ final class CodexAppServerClientProcessExitTests: XCTestCase {
         import signal
         import sys
         import time
-
         sys.stdin.readline()
         os.write(2, base64.b64decode(\(String(reflecting: stderr.base64EncodedString()))))
         release_path = \(releasePath.map(String.init(reflecting:)) ?? "None")
@@ -764,7 +764,6 @@ final class CodexAppServerClientProcessExitTests: XCTestCase {
         import json
         import os
         import sys
-
         attempt_path = \(String(reflecting: attemptURL.path))
         try:
             with open(attempt_path, "r", encoding="utf-8") as handle:
@@ -774,7 +773,6 @@ final class CodexAppServerClientProcessExitTests: XCTestCase {
         attempt += 1
         with open(attempt_path, "w", encoding="utf-8") as handle:
             handle.write(str(attempt))
-
         for line in sys.stdin:
             request = json.loads(line)
             method = request.get("method")
@@ -801,7 +799,6 @@ final class CodexAppServerClientProcessExitTests: XCTestCase {
         import os
         import sys
         import time
-
         sys.stdin.readline()
         os.close(1)
         while True:
@@ -816,7 +813,6 @@ final class CodexAppServerClientProcessExitTests: XCTestCase {
         #!/usr/bin/env python3
         import os
         import sys
-
         sys.stdin.readline()
         os.write(2, os.getcwd().encode("utf-8"))
         os.close(1)
@@ -931,18 +927,18 @@ private final class StderrResultGate: @unchecked Sendable {
     private var timeoutTask: Task<Void, Never>?
     private var didComplete = false
 
-    init(continuation: CheckedContinuation<Bool?, Never>) {
-        self.continuation = continuation
+    init(continuation initialContinuation: CheckedContinuation<Bool?, Never>) {
+        continuation = initialContinuation
     }
 
-    func install(timeoutTask: Task<Void, Never>) {
+    func install(timeoutTask newTimeoutTask: Task<Void, Never>) {
         lock.lock()
         if didComplete {
             lock.unlock()
-            timeoutTask.cancel()
+            newTimeoutTask.cancel()
             return
         }
-        self.timeoutTask = timeoutTask
+        timeoutTask = newTimeoutTask
         lock.unlock()
     }
 
@@ -953,14 +949,14 @@ private final class StderrResultGate: @unchecked Sendable {
             return
         }
         didComplete = true
-        let continuation = self.continuation
-        self.continuation = nil
-        let timeoutTask = self.timeoutTask
-        self.timeoutTask = nil
+        let storedContinuation = continuation
+        continuation = nil
+        let storedTimeoutTask = timeoutTask
+        timeoutTask = nil
         lock.unlock()
 
-        timeoutTask?.cancel()
-        continuation?.resume(returning: result)
+        storedTimeoutTask?.cancel()
+        storedContinuation?.resume(returning: result)
     }
 }
 


### PR DESCRIPTION
## Problem

`CodexProcessStderrCapture.waitUntilFinished(timeout:)` ignored task cancellation. A cancelled process-exit settlement remained suspended until stderr finished or the bounded timeout elapsed, while its detached timeout task continued independently.

## Change

Each wait now installs its checked continuation while registering the waiter under the cancellation handler and the existing lock. Finish, timeout, and cancellation transition that record under the same lock; the first result wins. Timeout cancellation and continuation resumption occur after unlocking.

Finished stderr returns `true`; timeout and cancellation return `false`. Cancelling one waiter does not affect the producer or other waiters.

## Regression coverage

Tests cover:

- cancellation during waiter registration, with a bounded prompt-settlement assertion and terminal finish cleanup;
- cancelling one of two waiters, verifying the cancelled waiter returns `false` while the other returns `true`;
- zero timeout and the already-finished fast path.

The timeout assertion uses a test-owned continuation gate, so a suspended waiter returns at the prompt bound without structurally joining the losing task. No test-only hooks are added to the production capture source.

## Validation

- Exact branch diff and `git diff --check` passed.
- Staged whitespace and secret scans passed.
- Swift/macOS and repository guardrails are pending on hosted CI because this checkout is running without the Apple toolchain.

Fixes #728