### PR TITLE
Clear transcript refresh signatures after tab removal

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/Transcript/AgentTranscriptServices.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/Transcript/AgentTranscriptServices.swift
@@ -220,6 +220,15 @@ struct AgentConversationReplaySerialization: Equatable {
             refreshSignatureLock.unlock()
         }
 
+        static func removeRefreshInputSignatures(for tabIDs: Set<UUID>) {
+            guard !tabIDs.isEmpty else { return }
+            refreshSignatureLock.lock()
+            for tabID in tabIDs {
+                lastRefreshInputSignatureByTabID.removeValue(forKey: tabID)
+            }
+            refreshSignatureLock.unlock()
+        }
+
         static func durationMS(since start: TimeInterval) -> Double {
             max(0, (Date.timeIntervalSinceReferenceDate - start) * 1000)
         }

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -11216,6 +11216,9 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
                 )
             #endif
         }
+        #if DEBUG
+            AgentTranscriptDebugInstrumentation.removeRefreshInputSignatures(for: tabIDs)
+        #endif
     }
 
     // MARK: - Persistence

--- a/Tests/RepoPromptTests/Prompt/BackgroundComposeTabAdmissionTests.swift
+++ b/Tests/RepoPromptTests/Prompt/BackgroundComposeTabAdmissionTests.swift
@@ -247,6 +247,39 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
         XCTAssertTrue(attemptedTabIDs.isEmpty)
     }
 
+    func testPostRemovalClearsOnlyRemovedTabTranscriptRefreshSignature() async throws {
+        let fixture = makeFixture(initialTabCount: 2)
+        let removedTabID = try XCTUnwrap(fixture.prompt.activeComposeTabID)
+        let retainedTabID = try XCTUnwrap(
+            fixture.manager.activeWorkspace?.composeTabs.first(where: { $0.id != removedTabID })?.id
+        )
+        let viewModel = makeAgentModeViewModel(prompt: fixture.prompt, manager: fixture.manager)
+        _ = viewModel.session(for: removedTabID)
+
+        AgentTranscriptDebugInstrumentation.reset()
+        defer { AgentTranscriptDebugInstrumentation.reset() }
+        AgentTranscriptDebugInstrumentation.isEnabled = true
+        var attempts: [AgentTranscriptRefreshAttemptMetrics] = []
+        AgentTranscriptDebugInstrumentation.refreshAttemptHandler = { attempts.append($0) }
+
+        emitTranscriptRefreshAttempt(tabID: removedTabID, inputSignature: "removed-signature")
+        emitTranscriptRefreshAttempt(tabID: retainedTabID, inputSignature: "retained-signature")
+
+        let didRemoveToken = installDidRemoveListener(prompt: fixture.prompt, viewModel: viewModel)
+        defer { fixture.prompt.removeComposeTabsDidRemoveListener(didRemoveToken) }
+        await fixture.prompt.stashTab(removedTabID)
+
+        attempts.removeAll()
+        emitTranscriptRefreshAttempt(tabID: removedTabID, inputSignature: "removed-signature")
+        emitTranscriptRefreshAttempt(tabID: retainedTabID, inputSignature: "retained-signature")
+
+        XCTAssertEqual(attempts.count, 2)
+        XCTAssertNil(attempts[0].previousInputSignature)
+        XCTAssertFalse(attempts[0].isConsecutiveDuplicateInput)
+        XCTAssertEqual(attempts[1].previousInputSignature, "retained-signature")
+        XCTAssertTrue(attempts[1].isConsecutiveDuplicateInput)
+    }
+
     private func makeFixture(initialTabCount: Int) -> (manager: WorkspaceManagerViewModel, prompt: PromptViewModel) {
         let fileManager = WorkspaceFilesViewModel()
         let keyManager = KeyManager(
@@ -312,6 +345,22 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
         prompt.addComposeTabsDidRemoveListener { tabIDs, reason, workspaceID in
             await viewModel.handleComposeTabsDidRemove(tabIDs, reason: reason, workspaceID: workspaceID)
         }
+    }
+
+    private func emitTranscriptRefreshAttempt(tabID: UUID, inputSignature: String) {
+        AgentTranscriptDebugInstrumentation.emitRefreshAttempt(
+            tabID: tabID,
+            reason: "test",
+            sourceItemsRevision: 0,
+            itemCount: 0,
+            nextSequenceIndex: 0,
+            runState: "idle",
+            selectedAgent: "test",
+            projectionProtection: "none",
+            pendingMutationSummary: "none",
+            incrementalPath: "test",
+            inputSignature: inputSignature
+        )
     }
 }
 


### PR DESCRIPTION
## Problem

DEBUG transcript instrumentation retained the latest refresh input signature for every tab until a global reset. Closing or stashing a tab left stale state behind, and restoring the same UUID could classify its first refresh as a duplicate from the previous runtime session.

## Change

Clear signatures selectively after `handleComposeTabsDidRemove` completes runtime teardown. The operation uses the existing lock, applies only to confirmed removed IDs, and preserves unrelated live-tab signatures.

No arbitrary capacity eviction or handler-synchronization change is included.

## Regression coverage

The test seeds a removed and retained tab, stashes the target through the real post-removal lifecycle, and verifies that only the removed tab loses its previous signature.

## Validation

- Exact branch diff and `git diff --check` passed.
- Staged whitespace and secret scans passed.
- Branch autoreview is clean.
- Swift/macOS checks are pending on this draft's CI.

Fixes #726