### PR TITLE
Cancel superseded pull request CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/Scripts/test_release_tooling.py
+++ b/Scripts/test_release_tooling.py
@@ -2553,6 +2553,20 @@ shutil.copyfile(os.environ["FAKE_SWIFTFORMAT_ARCHIVE"], output)
             publish_staged.index("prepare_dist"),
         )
 
+    def test_ci_workflow_cancels_only_superseded_pull_request_runs(self) -> None:
+        ci_workflow = (SCRIPT_DIR.parent / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+        concurrency_block = ci_workflow.split("concurrency:", 1)[1].split("\npermissions:", 1)[0]
+        normalized_concurrency = " ".join(concurrency_block.split())
+
+        self.assertIn(
+            "group: ci-${{ github.event.pull_request.number || github.run_id }}",
+            normalized_concurrency,
+        )
+        self.assertIn(
+            "cancel-in-progress: ${{ github.event_name == 'pull_request' }}",
+            normalized_concurrency,
+        )
+        self.assertNotIn("cancel-in-progress: true", concurrency_block)
 
     def test_main_tip_workflow_keeps_tip_separate_and_uses_hardened_smoke(self) -> None:
         tip_workflow = (SCRIPT_DIR.parent / ".github" / "workflows" / "main-tip.yml").read_text(encoding="utf-8")


### PR DESCRIPTION
Fixes #740.

### Problem

Each pull request synchronization starts a complete eight-job macOS CI run, but the workflow did not group runs by pull request. After a follow-up commit, failed and queued jobs from the previous revision remained active alongside the replacement run.

### Change

Add pull-request-scoped workflow concurrency. Runs share a group keyed by pull request number, and newer revisions cancel older runs in that group. Pushes to `main` use their unique run ID and are never cancelled by this policy. Job names, matrix topology, and required-check evidence for the latest revision are unchanged.

### Regression coverage

A workflow contract test verifies the pull request number group, event-scoped cancellation expression, and absence of unconditional cancellation.

### Validation

- `python3 -m unittest Scripts.test_release_tooling.ReleaseToolingTests.test_ci_workflow_cancels_only_superseded_pull_request_runs` — passed (1 test)
- `make ci-app-test-runner-selftest` — passed (38 tests)
- `git diff --check` — passed