### PR TITLE
P0: Protect live Agent session identity during admission

### DIFF
--- a/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentSessionLifecycleAuthority.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/Runtime/AgentSessionLifecycleAuthority.swift
@@ -1,0 +1,320 @@
+import CryptoKit
+import Foundation
+import OSLog
+
+/// Single decision authority for Agent compose-tab/session identity transitions.
+///
+/// Callers may own presentation, persistence, provider, or MCP mechanics, but none of
+/// those layers may independently retarget a live Agent operation. They consume the
+/// immutable identities and typed decisions produced here.
+@MainActor
+final class AgentSessionLifecycleAuthority {
+    struct Identity: Equatable, Hashable {
+        let workspaceID: UUID
+        let tabID: UUID
+        let sessionID: UUID?
+        let persistentBindingGeneration: UUID?
+        let bindingTransitionGeneration: UInt64
+    }
+
+    struct ProtectionClaim: Equatable {
+        let identity: Identity
+        let tab: ComposeTabState
+        let isLive: Bool
+        let isActive: Bool
+        let isPinned: Bool
+        let hasActiveRun: Bool
+
+        var isProtected: Bool {
+            isLive || isPinned
+        }
+    }
+
+    struct MutationTarget: Equatable {
+        let tabID: UUID
+        let identity: Identity?
+    }
+
+    enum CallerCategory: String {
+        case agentRunStart = "agent_run_start"
+        case agentSessionControl = "agent_session_control"
+        case domainProjection = "domain_projection"
+        case providerLifecycle = "provider_lifecycle"
+    }
+
+    enum Intent: String {
+        case createOrContinue = "create_or_continue"
+        case applyProjection = "apply_projection"
+        case setStatus = "set_status"
+        case shareThoughts = "share_thoughts"
+        case waitForInstruction = "wait_for_instruction"
+        case askUser = "ask_user"
+        case providerStart = "provider_start"
+    }
+
+    enum Phase: String {
+        case beforeBinding = "before_binding"
+        case bindingPersisted = "binding_persisted"
+        case beforeProviderStart = "before_provider_start"
+        case afterProviderStart = "after_provider_start"
+        case mutationValidation = "mutation_validation"
+        case projectionReconciliation = "projection_reconciliation"
+    }
+
+    enum Decision: String {
+        case admitted
+        case protected
+        case rejected
+        case unchanged
+    }
+
+    enum RejectionReason: String, Error {
+        case workspacePersistenceRejected = "workspace_persistence_rejected"
+        case workspaceChanged = "workspace_changed"
+        case tabMissing = "tab_missing"
+        case sessionMissing = "session_missing"
+        case sessionIdentityChanged = "session_identity_changed"
+        case bindingGenerationChanged = "binding_generation_changed"
+        case transitionGenerationChanged = "transition_generation_changed"
+    }
+
+    enum AdmissionDecision: Equatable {
+        case commit
+        case rollback(RejectionReason)
+    }
+
+    struct Event: Equatable {
+        let caller: CallerCategory
+        let intent: Intent
+        let phase: Phase
+        let decision: Decision
+        let identity: Identity?
+        let previousSessionID: UUID?
+        let currentSessionID: UUID?
+        let isPinned: Bool
+        let isLive: Bool
+        let isActive: Bool
+        let isProtected: Bool
+        let workspaceSaveResult: String
+        let reason: String
+    }
+
+    struct ProjectionOutcome: Equatable {
+        let workspaces: [WorkspaceModel]
+        let protectedWorkspaceIDs: Set<UUID>
+        let protectedClaimCount: Int
+    }
+
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "RepoPrompt",
+        category: "AgentSessionLifecycle"
+    )
+
+    #if DEBUG
+        private static var eventObserver: ((Event) -> Void)?
+
+        static func setEventObserverForTesting(_ observer: ((Event) -> Void)?) {
+            eventObserver = observer
+        }
+    #endif
+
+    func validateMutationTarget(
+        expected: Identity,
+        current: ProtectionClaim?
+    ) -> Result<MutationTarget, RejectionReason> {
+        guard let current else { return .failure(.tabMissing) }
+        guard current.identity.tabID == expected.tabID else { return .failure(.tabMissing) }
+        guard current.identity.sessionID == expected.sessionID else {
+            return .failure(.sessionIdentityChanged)
+        }
+        guard current.identity.persistentBindingGeneration == expected.persistentBindingGeneration else {
+            return .failure(.bindingGenerationChanged)
+        }
+        guard current.identity.bindingTransitionGeneration == expected.bindingTransitionGeneration else {
+            return .failure(.transitionGenerationChanged)
+        }
+        return .success(MutationTarget(tabID: expected.tabID, identity: expected))
+    }
+
+    /// Owns the commit/rollback decision for every create-or-continue admission.
+    /// Presentation and persistence layers provide facts but do not independently
+    /// decide whether provider-visible identity may be published.
+    func decideAdmission(
+        persistence: WorkspacePersistenceOutcome,
+        targetWorkspaceID: UUID,
+        bindingStillCurrent: Bool
+    ) -> AdmissionDecision {
+        guard persistence.acceptedForLifecycleAdmission else {
+            return .rollback(.workspacePersistenceRejected)
+        }
+        guard persistence.workspaceID == targetWorkspaceID else {
+            return .rollback(.workspaceChanged)
+        }
+        guard bindingStillCurrent else {
+            return .rollback(.sessionIdentityChanged)
+        }
+        return .commit
+    }
+
+    func reconcileProjection(
+        projectedWorkspaces: [WorkspaceModel],
+        currentWorkspaces: [WorkspaceModel],
+        claims: [ProtectionClaim]
+    ) -> ProjectionOutcome {
+        let protectedClaims = claims.filter(\.isProtected)
+        guard !protectedClaims.isEmpty else {
+            return ProjectionOutcome(
+                workspaces: projectedWorkspaces,
+                protectedWorkspaceIDs: [],
+                protectedClaimCount: 0
+            )
+        }
+
+        let claimsByWorkspace = Dictionary(grouping: protectedClaims, by: { $0.identity.workspaceID })
+        let currentByID = Dictionary(
+            currentWorkspaces.map { ($0.id, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        var reconciled = projectedWorkspaces
+        var protectedWorkspaceIDs = Set<UUID>()
+        var protectedClaimCount = 0
+
+        for (workspaceID, workspaceClaims) in claimsByWorkspace {
+            guard let currentWorkspace = currentByID[workspaceID] else { continue }
+            let projectedIndex: Int
+            if let existingIndex = reconciled.firstIndex(where: { $0.id == workspaceID }) {
+                projectedIndex = existingIndex
+            } else {
+                reconciled.append(currentWorkspace)
+                projectedIndex = reconciled.index(before: reconciled.endIndex)
+                protectedWorkspaceIDs.insert(workspaceID)
+                protectedClaimCount += workspaceClaims.count
+                recordProjectionProtection(
+                    claims: workspaceClaims,
+                    previousTabs: [],
+                    reason: "workspace_missing_from_projection"
+                )
+                continue
+            }
+
+            let previous = reconciled[projectedIndex]
+            var next = previous
+            let protectedTabIDs = Set(workspaceClaims.map(\.identity.tabID))
+            next.stashedTabs.removeAll { protectedTabIDs.contains($0.tab.id) }
+
+            for claim in workspaceClaims {
+                let tabID = claim.identity.tabID
+                if let sessionID = claim.identity.sessionID {
+                    for tabIndex in next.composeTabs.indices
+                        where next.composeTabs[tabIndex].id != tabID
+                        && next.composeTabs[tabIndex].activeAgentSessionID == sessionID
+                    {
+                        next.composeTabs[tabIndex].activeAgentSessionID = nil
+                    }
+                }
+                if let index = next.composeTabs.firstIndex(where: { $0.id == tabID }) {
+                    next.composeTabs[index] = claim.tab
+                } else if let localIndex = currentWorkspace.composeTabs.firstIndex(where: { $0.id == tabID }) {
+                    next.composeTabs.insert(claim.tab, at: min(localIndex, next.composeTabs.count))
+                } else {
+                    next.composeTabs.append(claim.tab)
+                }
+            }
+
+            if let activeTabID = currentWorkspace.activeComposeTabID,
+               protectedTabIDs.contains(activeTabID)
+            {
+                next.activeComposeTabID = activeTabID
+            }
+
+            guard next != previous else { continue }
+            reconciled[projectedIndex] = next
+            protectedWorkspaceIDs.insert(workspaceID)
+            let changedClaims = workspaceClaims.filter { claim in
+                let previousTab = previous.composeTabs.first(where: { $0.id == claim.identity.tabID })
+                return previousTab != claim.tab
+                    || previous.stashedTabs.contains(where: { $0.tab.id == claim.identity.tabID })
+                    || (claim.isActive && previous.activeComposeTabID != claim.identity.tabID)
+            }
+            protectedClaimCount += changedClaims.count
+            recordProjectionProtection(
+                claims: changedClaims,
+                previousTabs: previous.composeTabs,
+                reason: "stale_projection_reconciled"
+            )
+        }
+
+        return ProjectionOutcome(
+            workspaces: reconciled,
+            protectedWorkspaceIDs: protectedWorkspaceIDs,
+            protectedClaimCount: protectedClaimCount
+        )
+    }
+
+    func record(_ event: Event) {
+        let identity = event.identity
+        let line = [
+            "caller=\(event.caller.rawValue)",
+            "intent=\(event.intent.rawValue)",
+            "phase=\(event.phase.rawValue)",
+            "decision=\(event.decision.rawValue)",
+            "workspace=\(Self.hashedID(identity?.workspaceID))",
+            "tab=\(Self.hashedID(identity?.tabID))",
+            "session=\(Self.hashedID(identity?.sessionID))",
+            "previousSession=\(Self.hashedID(event.previousSessionID))",
+            "currentSession=\(Self.hashedID(event.currentSessionID))",
+            "binding=\(Self.hashedID(identity?.persistentBindingGeneration))",
+            "transition=\(identity.map { String($0.bindingTransitionGeneration) } ?? "nil")",
+            "pinned=\(event.isPinned)",
+            "live=\(event.isLive)",
+            "active=\(event.isActive)",
+            "protected=\(event.isProtected)",
+            "workspaceSave=\(Self.sanitizedCategory(event.workspaceSaveResult))",
+            "reason=\(Self.sanitizedCategory(event.reason))"
+        ].joined(separator: " ")
+        Self.logger.notice("\(line, privacy: .public)")
+        #if DEBUG
+            Self.eventObserver?(event)
+        #endif
+    }
+
+    private func recordProjectionProtection(
+        claims: [ProtectionClaim],
+        previousTabs: [ComposeTabState],
+        reason: String
+    ) {
+        // One event per affected identity, capped to keep a damaged projection bounded.
+        for claim in claims.prefix(8) {
+            let previousSessionID = previousTabs
+                .first(where: { $0.id == claim.identity.tabID })?
+                .activeAgentSessionID
+            record(Event(
+                caller: .domainProjection,
+                intent: .applyProjection,
+                phase: .projectionReconciliation,
+                decision: .protected,
+                identity: claim.identity,
+                previousSessionID: previousSessionID,
+                currentSessionID: claim.identity.sessionID,
+                isPinned: claim.isPinned,
+                isLive: claim.isLive,
+                isActive: claim.isActive,
+                isProtected: true,
+                workspaceSaveResult: "pending_recovery",
+                reason: reason
+            ))
+        }
+    }
+
+    private static func hashedID(_ id: UUID?) -> String {
+        guard let id else { return "nil" }
+        let digest = SHA256.hash(data: Data(id.uuidString.utf8))
+        return digest.prefix(6).map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func sanitizedCategory(_ raw: String) -> String {
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "_-"))
+        let scalars = raw.unicodeScalars.prefix(64).map { allowed.contains($0) ? Character(String($0)) : "_" }
+        return String(scalars)
+    }
+}

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+Types.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel+Types.swift
@@ -435,6 +435,22 @@ extension AgentModeViewModel {
         let tabID: UUID
         let sessionID: UUID?
         let origin: Origin
+        let lifecycleIdentity: AgentSessionLifecycleAuthority.Identity?
+        let discardRestoreIndexEntry: AgentSessionIndexEntry?
+
+        init(
+            tabID: UUID,
+            sessionID: UUID?,
+            origin: Origin,
+            lifecycleIdentity: AgentSessionLifecycleAuthority.Identity? = nil,
+            discardRestoreIndexEntry: AgentSessionIndexEntry? = nil
+        ) {
+            self.tabID = tabID
+            self.sessionID = sessionID
+            self.origin = origin
+            self.lifecycleIdentity = lifecycleIdentity
+            self.discardRestoreIndexEntry = discardRestoreIndexEntry
+        }
     }
 
     struct AutoEditPermissionGuidance: Equatable {

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -584,6 +584,7 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
     let clearConsumedAttachmentsAfterProviderConsumption: Bool
     let applyEditsApprovalStore: ApplyEditsApprovalStore
     private lazy var runService: AgentModeRunService = makeRunService()
+    private let sessionLifecycleAuthority = AgentSessionLifecycleAuthority()
 
     private var isRestoringState = false
     private var activeUISyncSuppressionDepth = 0
@@ -766,6 +767,7 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         ) {
             self.promptManager = promptManager
             self.workspaceManager = workspaceManager
+            installAgentSessionLifecycleProjectionAuthority()
         }
 
         func test_setAllowsScheduledDerivedTranscriptRefreshWithoutPromptManager(_ value: Bool) {
@@ -2350,6 +2352,7 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
     private func setupObservers() {
         guard let promptManager else { return }
         installPromptManagerCascadeResolvers(promptManager)
+        installAgentSessionLifecycleProjectionAuthority()
 
         // Observe post-storage tab changes. This notification does not replay the current value;
         // setAgentModeActive(true) remains the explicit activation bootstrap.
@@ -2447,6 +2450,251 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
                 self?.revalidateSelectedCustomWorkflows()
             }
             .store(in: &cancellables)
+    }
+
+    private func installAgentSessionLifecycleProjectionAuthority() {
+        workspaceManager?.setAgentSessionProjectionReconciler { [weak self] projected, current in
+            guard let self else {
+                return AgentSessionLifecycleAuthority.ProjectionOutcome(
+                    workspaces: projected,
+                    protectedWorkspaceIDs: [],
+                    protectedClaimCount: 0
+                )
+            }
+            return sessionLifecycleAuthority.reconcileProjection(
+                projectedWorkspaces: projected,
+                currentWorkspaces: current,
+                claims: agentSessionLifecycleProtectionClaims(in: current)
+            )
+        }
+    }
+
+    private func agentSessionLifecycleProtectionClaims(
+        in workspaces: [WorkspaceModel]
+    ) -> [AgentSessionLifecycleAuthority.ProtectionClaim] {
+        workspaces.flatMap { workspace in
+            workspace.composeTabs.compactMap { tab in
+                let sessionID = tab.activeAgentSessionID
+                let liveSession = sessionID.flatMap { expectedSessionID in
+                    sessions[tab.id]?.activeAgentSessionID == expectedSessionID
+                        ? sessions[tab.id]
+                        : nil
+                }
+                let isLive = liveSession != nil
+                guard isLive || tab.isPinned else { return nil }
+                return AgentSessionLifecycleAuthority.ProtectionClaim(
+                    identity: AgentSessionLifecycleAuthority.Identity(
+                        workspaceID: workspace.id,
+                        tabID: tab.id,
+                        sessionID: sessionID,
+                        persistentBindingGeneration: liveSession?.persistentSessionBindingIdentity?.generation,
+                        bindingTransitionGeneration: liveSession?.bindingTransitionGeneration ?? 0
+                    ),
+                    tab: tab,
+                    isLive: isLive,
+                    isActive: workspace.activeComposeTabID == tab.id,
+                    isPinned: tab.isPinned,
+                    hasActiveRun: liveSession?.runState.isActive == true
+                )
+            }
+        }
+    }
+
+    private func agentSessionLifecycleIdentity(
+        tabID: UUID,
+        expectedSessionID: UUID
+    ) -> AgentSessionLifecycleAuthority.Identity? {
+        guard let session = sessions[tabID],
+              session.activeAgentSessionID == expectedSessionID,
+              let workspace = workspaceManager?.workspaces.first(where: { workspace in
+                  workspace.composeTabs.contains(where: {
+                      $0.id == tabID && $0.activeAgentSessionID == expectedSessionID
+                  })
+              })
+        else { return nil }
+        return AgentSessionLifecycleAuthority.Identity(
+            workspaceID: workspace.id,
+            tabID: tabID,
+            sessionID: expectedSessionID,
+            persistentBindingGeneration: session.persistentSessionBindingIdentity?.generation,
+            bindingTransitionGeneration: session.bindingTransitionGeneration
+        )
+    }
+
+    private func agentSessionLifecycleClaim(
+        tabID: UUID,
+        expectedSessionID: UUID
+    ) -> AgentSessionLifecycleAuthority.ProtectionClaim? {
+        guard let identity = agentSessionLifecycleIdentity(
+            tabID: tabID,
+            expectedSessionID: expectedSessionID
+        ),
+            let workspace = workspaceManager?.workspace(withID: identity.workspaceID),
+            let tab = workspace.composeTabs.first(where: { $0.id == tabID }),
+            let session = sessions[tabID]
+        else { return nil }
+        return AgentSessionLifecycleAuthority.ProtectionClaim(
+            identity: identity,
+            tab: tab,
+            isLive: true,
+            isActive: workspace.activeComposeTabID == tabID,
+            isPinned: tab.isPinned,
+            hasActiveRun: session.runState.isActive
+        )
+    }
+
+    func resolveAgentSessionLifecycleMutationTarget(
+        tabID: UUID,
+        expectedSessionID: UUID?,
+        intent: AgentSessionLifecycleAuthority.Intent
+    ) throws -> AgentSessionLifecycleAuthority.MutationTarget {
+        guard let expectedSessionID else {
+            guard workspaceManager?.composeTab(with: tabID) != nil else {
+                throw MCPError.invalidParams("The Agent session target no longer exists; bind the current context again.")
+            }
+            if let sessionID = sessions[tabID]?.activeAgentSessionID,
+               let identity = agentSessionLifecycleIdentity(
+                   tabID: tabID,
+                   expectedSessionID: sessionID
+               )
+            {
+                return .init(tabID: tabID, identity: identity)
+            }
+            return .init(tabID: tabID, identity: nil)
+        }
+
+        guard let current = agentSessionLifecycleClaim(
+            tabID: tabID,
+            expectedSessionID: expectedSessionID
+        ) else {
+            sessionLifecycleAuthority.record(.init(
+                caller: .agentSessionControl,
+                intent: intent,
+                phase: .mutationValidation,
+                decision: .rejected,
+                identity: nil,
+                previousSessionID: expectedSessionID,
+                currentSessionID: sessions[tabID]?.activeAgentSessionID,
+                isPinned: workspaceManager?.composeTab(with: tabID)?.isPinned ?? false,
+                isLive: sessions[tabID] != nil,
+                isActive: workspaceManager?.activeWorkspace?.activeComposeTabID == tabID,
+                isProtected: false,
+                workspaceSaveResult: "not_applicable",
+                reason: AgentSessionLifecycleAuthority.RejectionReason.sessionIdentityChanged.rawValue
+            ))
+            throw MCPError.invalidParams(
+                "The Agent session binding changed before this operation completed; bind the current context again."
+            )
+        }
+        return .init(tabID: tabID, identity: current.identity)
+    }
+
+    @discardableResult
+    private func requireCurrentAgentSessionLifecycleTarget(
+        _ target: AgentSessionLifecycleAuthority.MutationTarget,
+        intent: AgentSessionLifecycleAuthority.Intent
+    ) throws -> TabSession? {
+        guard let expected = target.identity else {
+            guard workspaceManager?.composeTab(with: target.tabID) != nil else {
+                throw MCPError.invalidParams("The Agent session target no longer exists; bind the current context again.")
+            }
+            return sessions[target.tabID]
+        }
+        guard let expectedSessionID = expected.sessionID else {
+            throw MCPError.invalidParams(
+                "The Agent session target has no session identity; no mutation was applied."
+            )
+        }
+        let current = agentSessionLifecycleClaim(
+            tabID: expected.tabID,
+            expectedSessionID: expectedSessionID
+        )
+        switch sessionLifecycleAuthority.validateMutationTarget(expected: expected, current: current) {
+        case .success:
+            return sessions[target.tabID]
+        case let .failure(reason):
+            sessionLifecycleAuthority.record(.init(
+                caller: .agentSessionControl,
+                intent: intent,
+                phase: .mutationValidation,
+                decision: .rejected,
+                identity: expected,
+                previousSessionID: expected.sessionID,
+                currentSessionID: sessions[target.tabID]?.activeAgentSessionID,
+                isPinned: current?.isPinned ?? false,
+                isLive: current?.isLive ?? false,
+                isActive: current?.isActive ?? false,
+                isProtected: current?.isProtected ?? false,
+                workspaceSaveResult: "not_applicable",
+                reason: reason.rawValue
+            ))
+            throw MCPError.invalidParams(
+                "The Agent session identity changed before this operation completed; no mutation was applied."
+            )
+        }
+    }
+
+    func recordAgentSessionProviderLifecycle(
+        target: MCPSessionTarget,
+        phase: AgentSessionLifecycleAuthority.Phase,
+        decision: AgentSessionLifecycleAuthority.Decision,
+        reason: String
+    ) {
+        let claim = target.lifecycleIdentity.flatMap { identity in
+            identity.sessionID.flatMap { sessionID in
+                agentSessionLifecycleClaim(tabID: identity.tabID, expectedSessionID: sessionID)
+            }
+        }
+        sessionLifecycleAuthority.record(.init(
+            caller: .providerLifecycle,
+            intent: .providerStart,
+            phase: phase,
+            decision: decision,
+            identity: target.lifecycleIdentity,
+            previousSessionID: target.sessionID,
+            currentSessionID: sessions[target.tabID]?.activeAgentSessionID,
+            isPinned: claim?.isPinned ?? false,
+            isLive: claim?.isLive ?? false,
+            isActive: claim?.isActive ?? false,
+            isProtected: claim?.isProtected ?? false,
+            workspaceSaveResult: target.lifecycleIdentity == nil ? "not_admitted" : "binding_persisted",
+            reason: reason
+        ))
+    }
+
+    /// Final lifecycle-admission fence used immediately before provider dispatch.
+    /// Worktree preparation and other async setup may complete after the target was
+    /// first resolved, so the immutable binding identity must still be current.
+    func requireCurrentAgentSessionLifecycleAdmission(
+        _ target: MCPSessionTarget
+    ) throws {
+        guard let sessionID = target.sessionID,
+              let identity = target.lifecycleIdentity,
+              identity.sessionID == Optional(sessionID)
+        else {
+            sessionLifecycleAuthority.record(.init(
+                caller: .providerLifecycle,
+                intent: .providerStart,
+                phase: .beforeProviderStart,
+                decision: .rejected,
+                identity: target.lifecycleIdentity,
+                previousSessionID: target.sessionID,
+                currentSessionID: sessions[target.tabID]?.activeAgentSessionID,
+                isPinned: workspaceManager?.composeTab(with: target.tabID)?.isPinned ?? false,
+                isLive: sessions[target.tabID] != nil,
+                isActive: workspaceManager?.activeWorkspace?.activeComposeTabID == target.tabID,
+                isProtected: false,
+                workspaceSaveResult: "not_admitted",
+                reason: AgentSessionLifecycleAuthority.RejectionReason.sessionMissing.rawValue
+            ))
+            throw MCPError.invalidParams(
+                "The Agent session did not retain a durable lifecycle identity. No provider was started."
+            )
+        }
+        _ = try requireCurrentAgentSessionLifecycleTarget(
+            .init(tabID: target.tabID, identity: identity),
+            intent: .providerStart
+        )
     }
 
     private func installPromptManagerCascadeResolvers(_ promptManager: PromptViewModel) {
@@ -6395,6 +6643,7 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         inheritWorktreeBindings: Bool = false
     ) async throws -> MCPSessionTarget {
         if let sessionID {
+            let discardRestoreIndexEntry = ownerValidatedSessionIndex[sessionID]
             let indexedParentSessionID = ownerValidatedSessionIndex[sessionID]?.parentSessionID
             let existingTabID: UUID? = switch persistentBindingResolution(for: sessionID) {
             case let .unique(tabID): tabID
@@ -6412,12 +6661,9 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
             guard createIfNeeded else {
                 throw MCPError.invalidParams("The requested agent session is not currently available.")
             }
-            let createdTabID = try await mcpCreateBackgroundSessionTab(name: sessionName)
-            let createdSession = session(for: createdTabID)
-            _ = try await rebindPersistentSession(
-                sessionID,
-                to: createdSession,
-                requiresHydration: true
+            let createdTabID = try await mcpCreateBackgroundSessionTab(
+                name: sessionName,
+                sessionID: sessionID
             )
             let hydrated = await ensureSessionReady(tabID: createdTabID)
             await loadSessionFromDisk(for: hydrated)
@@ -6426,7 +6672,16 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
                 to: hydrated,
                 inheritWorktreeBindings: inheritWorktreeBindings
             )
-            return .init(tabID: hydrated.tabID, sessionID: sessionID, origin: .createdForSessionResume)
+            return .init(
+                tabID: hydrated.tabID,
+                sessionID: sessionID,
+                origin: .createdForSessionResume,
+                lifecycleIdentity: agentSessionLifecycleIdentity(
+                    tabID: hydrated.tabID,
+                    expectedSessionID: sessionID
+                ),
+                discardRestoreIndexEntry: discardRestoreIndexEntry
+            )
         }
 
         if let tabID {
@@ -6434,14 +6689,10 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
                 throw MCPError.invalidParams("Tab '\(tabID.uuidString)' was not found.")
             }
             let hydrated = await ensureSessionReady(tabID: tabID)
-            let resolvedSessionID: UUID?
-            if createIfNeeded {
-                guard let installedSessionID = ensureSessionBoundToTab(hydrated) else {
-                    throw MCPError.invalidParams("The target tab could not be bound to an agent session.")
-                }
-                resolvedSessionID = installedSessionID
+            let resolvedSessionID: UUID? = if createIfNeeded {
+                try await durablyEnsureSessionBoundToTab(hydrated)
             } else {
-                resolvedSessionID = hydrated.activeAgentSessionID
+                hydrated.activeAgentSessionID
             }
             if parentSessionID != nil {
                 applySpawnParentSessionID(
@@ -6450,15 +6701,26 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
                     inheritWorktreeBindings: inheritWorktreeBindings
                 )
             }
-            return .init(tabID: hydrated.tabID, sessionID: resolvedSessionID, origin: .existingTab)
+            return .init(
+                tabID: hydrated.tabID,
+                sessionID: resolvedSessionID,
+                origin: .existingTab,
+                lifecycleIdentity: resolvedSessionID.flatMap {
+                    agentSessionLifecycleIdentity(tabID: hydrated.tabID, expectedSessionID: $0)
+                }
+            )
         }
 
         guard createIfNeeded else {
             throw MCPError.invalidParams("No target agent session was specified.")
         }
-        let createdTabID = try await mcpCreateBackgroundSessionTab(name: sessionName)
+        let intendedSessionID = UUID()
+        let createdTabID = try await mcpCreateBackgroundSessionTab(
+            name: sessionName,
+            sessionID: intendedSessionID
+        )
         let hydrated = await ensureSessionReady(tabID: createdTabID)
-        guard let createdSessionID = ensureSessionBoundToTab(hydrated) else {
+        guard hydrated.activeAgentSessionID == intendedSessionID else {
             throw MCPError.invalidParams("The new tab could not be bound to an agent session.")
         }
         applySpawnParentSessionID(
@@ -6466,7 +6728,15 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
             to: hydrated,
             inheritWorktreeBindings: inheritWorktreeBindings
         )
-        return .init(tabID: hydrated.tabID, sessionID: createdSessionID, origin: .createdNewTab)
+        return .init(
+            tabID: hydrated.tabID,
+            sessionID: intendedSessionID,
+            origin: .createdNewTab,
+            lifecycleIdentity: agentSessionLifecycleIdentity(
+                tabID: hydrated.tabID,
+                expectedSessionID: intendedSessionID
+            )
+        )
     }
 
     private func mcpExistingSessionTarget(
@@ -6476,7 +6746,32 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         inheritWorktreeBindings: Bool
     ) async throws -> MCPSessionTarget {
         let hydrated = await ensureSessionReady(tabID: tabID)
-        if hydrated.activeAgentSessionID != sessionID {
+        if let currentSessionID = hydrated.activeAgentSessionID,
+           currentSessionID != sessionID
+        {
+            sessionLifecycleAuthority.record(.init(
+                caller: .agentRunStart,
+                intent: .createOrContinue,
+                phase: .beforeBinding,
+                decision: .rejected,
+                identity: agentSessionLifecycleIdentity(
+                    tabID: tabID,
+                    expectedSessionID: currentSessionID
+                ),
+                previousSessionID: currentSessionID,
+                currentSessionID: sessionID,
+                isPinned: workspaceManager?.composeTab(with: tabID)?.isPinned ?? false,
+                isLive: true,
+                isActive: workspaceManager?.activeWorkspace?.activeComposeTabID == tabID,
+                isProtected: true,
+                workspaceSaveResult: "not_attempted",
+                reason: AgentSessionLifecycleAuthority.RejectionReason.sessionIdentityChanged.rawValue
+            ))
+            throw MCPError.invalidParams(
+                "The requested session conflicts with a live tab binding; the live session was preserved."
+            )
+        }
+        if hydrated.activeAgentSessionID == nil {
             _ = try await rebindPersistentSession(
                 sessionID,
                 to: hydrated,
@@ -6494,20 +6789,145 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
             to: hydrated,
             inheritWorktreeBindings: inheritWorktreeBindings
         )
-        return .init(tabID: hydrated.tabID, sessionID: resolvedSessionID, origin: .existingSession)
+        return .init(
+            tabID: hydrated.tabID,
+            sessionID: resolvedSessionID,
+            origin: .existingSession,
+            lifecycleIdentity: agentSessionLifecycleIdentity(
+                tabID: hydrated.tabID,
+                expectedSessionID: resolvedSessionID
+            )
+        )
     }
 
-    private func mcpCreateBackgroundSessionTab(name: String?) async throws -> UUID {
+    private func mcpCreateBackgroundSessionTab(
+        name: String?,
+        sessionID: UUID
+    ) async throws -> UUID {
         guard let promptManager else {
             throw MCPError.internalError("Prompt manager unavailable.")
         }
-        guard let createdTab = await promptManager.createBackgroundComposeTab(
-            strategy: .blank,
-            name: name
-        ) else {
-            throw MCPError.internalError("The background agent session tab could not be created.")
+        let tentativeIdentity: AgentSessionLifecycleAuthority.Identity? = nil
+        sessionLifecycleAuthority.record(.init(
+            caller: .agentRunStart,
+            intent: .createOrContinue,
+            phase: .beforeBinding,
+            decision: .unchanged,
+            identity: tentativeIdentity,
+            previousSessionID: nil,
+            currentSessionID: sessionID,
+            isPinned: false,
+            isLive: false,
+            isActive: false,
+            isProtected: false,
+            workspaceSaveResult: "pending",
+            reason: "admission_requested"
+        ))
+
+        switch await promptManager.createDurableBackgroundAgentSessionTab(
+            name: name,
+            sessionID: sessionID,
+            lifecycleAuthority: sessionLifecycleAuthority
+        ) {
+        case let .created(createdTab, persistence):
+            let identity = persistence.workspaceID.map {
+                AgentSessionLifecycleAuthority.Identity(
+                    workspaceID: $0,
+                    tabID: createdTab.id,
+                    sessionID: sessionID,
+                    persistentBindingGeneration: nil,
+                    bindingTransitionGeneration: 0
+                )
+            }
+            sessionLifecycleAuthority.record(.init(
+                caller: .agentRunStart,
+                intent: .createOrContinue,
+                phase: .bindingPersisted,
+                decision: .admitted,
+                identity: identity,
+                previousSessionID: nil,
+                currentSessionID: sessionID,
+                isPinned: createdTab.isPinned,
+                isLive: false,
+                isActive: false,
+                isProtected: true,
+                workspaceSaveResult: persistence.diagnosticCategory,
+                reason: "binding_persisted_before_provider"
+            ))
+            return createdTab.id
+        case let .rejected(persistence):
+            sessionLifecycleAuthority.record(.init(
+                caller: .agentRunStart,
+                intent: .createOrContinue,
+                phase: .beforeProviderStart,
+                decision: .rejected,
+                identity: tentativeIdentity,
+                previousSessionID: nil,
+                currentSessionID: sessionID,
+                isPinned: false,
+                isLive: false,
+                isActive: false,
+                isProtected: false,
+                workspaceSaveResult: persistence.diagnosticCategory,
+                reason: AgentSessionLifecycleAuthority.RejectionReason.workspacePersistenceRejected.rawValue
+            ))
+            throw MCPError.internalError(
+                "The Agent session could not be started because its workspace binding was not durably accepted. No provider was started; resolve workspace persistence and retry."
+            )
         }
-        return createdTab.id
+    }
+
+    private func durablyEnsureSessionBoundToTab(_ session: TabSession) async throws -> UUID {
+        if let existingSessionID = session.activeAgentSessionID {
+            return existingSessionID
+        }
+        guard let workspaceManager,
+              let workspaceID = workspaceManager.workspaces.first(where: {
+                  $0.composeTabs.contains(where: { $0.id == session.tabID })
+              })?.id
+        else {
+            throw MCPError.internalError("Workspace unavailable during Agent session admission.")
+        }
+        guard let installedSessionID = ensureSessionBoundToTab(session) else {
+            throw MCPError.invalidParams("The target tab could not be bound to an agent session.")
+        }
+        let persistence = await workspaceManager.pollAndSaveStateWithOutcomeAsync(
+            workspaceID: workspaceID,
+            source: WorkspaceSaveSource("agentSessionLifecycleExistingTabAdmission")
+        )
+        let bindingStillCurrent = session.activeAgentSessionID == installedSessionID
+            && workspaceManager.composeTab(with: session.tabID)?.activeAgentSessionID == installedSessionID
+        guard sessionLifecycleAuthority.decideAdmission(
+            persistence: persistence,
+            targetWorkspaceID: workspaceID,
+            bindingStillCurrent: bindingStillCurrent
+        ) == .commit else {
+            _ = installPersistentSessionBinding(
+                sessionID: nil,
+                on: session,
+                updateWorkspaceMetadata: true,
+                invalidateAsyncWork: true
+            )
+            sessionLifecycleAuthority.record(.init(
+                caller: .agentRunStart,
+                intent: .createOrContinue,
+                phase: .beforeProviderStart,
+                decision: .rejected,
+                identity: nil,
+                previousSessionID: nil,
+                currentSessionID: installedSessionID,
+                isPinned: workspaceManager.composeTab(with: session.tabID)?.isPinned ?? false,
+                isLive: true,
+                isActive: workspaceManager.activeWorkspace?.activeComposeTabID == session.tabID,
+                isProtected: false,
+                workspaceSaveResult: persistence.diagnosticCategory,
+                reason: AgentSessionLifecycleAuthority.RejectionReason.workspacePersistenceRejected.rawValue
+            ))
+            throw MCPError.internalError(
+                "The Agent session binding was rejected by workspace persistence. No provider was started."
+            )
+        }
+        return installedSessionID
     }
 
     func mcpConfigureSession(
@@ -6955,7 +7375,13 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
                 cleanupSessionStore: true
             )
             if let entry = ownerValidatedSessionIndex[sessionID], entry.tabID == target.tabID {
-                removeSessionIndex(sessionID: sessionID)
+                if target.origin == .createdForSessionResume,
+                   let restoreEntry = target.discardRestoreIndexEntry
+                {
+                    applyLocalSessionIndexUpsert(restoreEntry)
+                } else {
+                    removeSessionIndex(sessionID: sessionID)
+                }
             }
         }
         sessions.removeValue(forKey: target.tabID)
@@ -15473,6 +15899,15 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         scheduleSave(for: resolvedTabID)
     }
 
+    func shareThoughts(
+        _ thoughts: String,
+        title: String? = nil,
+        target: AgentSessionLifecycleAuthority.MutationTarget
+    ) throws {
+        _ = try requireCurrentAgentSessionLifecycleTarget(target, intent: .shareThoughts)
+        shareThoughts(thoughts, title: title, tabID: target.tabID)
+    }
+
     // MARK: - Wait for Instruction (MCP Tool Support)
 
     static func shouldHideAgentToolFromTranscript(_ name: String?) -> Bool {
@@ -15483,10 +15918,17 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
     func waitForNextUserInstruction(
         tabID: UUID,
         prompt: String? = nil,
-        timeoutSeconds: TimeInterval? = nil
+        timeoutSeconds: TimeInterval? = nil,
+        lifecycleTarget: AgentSessionLifecycleAuthority.MutationTarget? = nil
     ) async throws -> UserInstructionResponse {
         // Ensure session exists (creates if needed, loads persisted state)
         let session = await ensureSessionReady(tabID: tabID, reconnectActiveProviders: true)
+        if let lifecycleTarget {
+            _ = try requireCurrentAgentSessionLifecycleTarget(
+                lifecycleTarget,
+                intent: .waitForInstruction
+            )
+        }
 
         if session.instructionContinuation != nil || session.instructionTimeoutTask != nil {
             cancelPendingInstruction(for: session)
@@ -15550,6 +15992,19 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         }
     }
 
+    func waitForNextUserInstruction(
+        target: AgentSessionLifecycleAuthority.MutationTarget,
+        prompt: String? = nil,
+        timeoutSeconds: TimeInterval? = nil
+    ) async throws -> UserInstructionResponse {
+        try await waitForNextUserInstruction(
+            tabID: target.tabID,
+            prompt: prompt,
+            timeoutSeconds: timeoutSeconds,
+            lifecycleTarget: target
+        )
+    }
+
     // MARK: - Ask User Question (MCP Tool Support)
 
     /// Legacy single-question adapter retained until the public MCP ask_user schema migrates.
@@ -15601,11 +16056,26 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         try await askUser(tabID: tabID, interaction: interaction)
     }
 
-    func askUser(
-        tabID: UUID,
+    func askUserInteraction(
+        target: AgentSessionLifecycleAuthority.MutationTarget,
         interaction: AgentAskUserInteraction
     ) async throws -> AgentAskUserResponse {
+        try await askUser(
+            tabID: target.tabID,
+            interaction: interaction,
+            lifecycleTarget: target
+        )
+    }
+
+    func askUser(
+        tabID: UUID,
+        interaction: AgentAskUserInteraction,
+        lifecycleTarget: AgentSessionLifecycleAuthority.MutationTarget? = nil
+    ) async throws -> AgentAskUserResponse {
         let session = await ensureSessionReady(tabID: tabID, reconnectActiveProviders: true)
+        if let lifecycleTarget {
+            _ = try requireCurrentAgentSessionLifecycleTarget(lifecycleTarget, intent: .askUser)
+        }
         try interaction.validate()
         try rejectAskUserIfBlockingInteractionExists(in: session)
 
@@ -16297,6 +16767,38 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
     /// Agent-mode sidebar rows are session-first, but the user-facing title is also
     /// mirrored through the compose tab so window/tab UI and persisted workspace
     /// state stay in sync.
+    func renameSession(
+        target: AgentSessionLifecycleAuthority.MutationTarget,
+        to newName: String
+    ) throws {
+        let validatedName = AgentSession.validatedName(newName)
+        guard !validatedName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        let session = try requireCurrentAgentSessionLifecycleTarget(target, intent: .setStatus)
+        promptManager?.renameComposeTab(target.tabID, to: validatedName)
+
+        guard let identity = target.identity,
+              let identitySessionID = identity.sessionID
+        else { return }
+        guard let session, session.activeAgentSessionID == identitySessionID else {
+            throw MCPError.invalidParams(
+                "The Agent session identity changed before its title could be persisted."
+            )
+        }
+        if var entry = ownerValidatedSessionIndex[identitySessionID] {
+            entry.name = validatedName
+            applyLocalSessionIndexUpsert(entry)
+        }
+        session.isDirty = true
+        scheduleSave(for: target.tabID)
+        handleObservedMCPStateChange(for: session)
+        codexCoordinator.scheduleCodexThreadNameSyncIfPossible(
+            for: session,
+            name: validatedName,
+            explicitThreadID: session.codexConversationID,
+            source: "renameSession.lifecycleAuthority"
+        )
+    }
+
     func renameSession(tabID: UUID, to newName: String) {
         let validatedName = AgentSession.validatedName(newName)
         guard !validatedName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }

--- a/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
+++ b/Sources/RepoPrompt/Features/AgentMode/ViewModels/AgentModeViewModel.swift
@@ -16774,11 +16774,10 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
         let validatedName = AgentSession.validatedName(newName)
         guard !validatedName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
         let session = try requireCurrentAgentSessionLifecycleTarget(target, intent: .setStatus)
-        promptManager?.renameComposeTab(target.tabID, to: validatedName)
-
-        guard let identity = target.identity,
-              let identitySessionID = identity.sessionID
-        else { return }
+        guard let identitySessionID = target.identity?.sessionID else {
+            promptManager?.renameComposeTab(target.tabID, to: validatedName)
+            return
+        }
         guard let session, session.activeAgentSessionID == identitySessionID else {
             throw MCPError.invalidParams(
                 "The Agent session identity changed before its title could be persisted."
@@ -16797,6 +16796,7 @@ final class AgentModeViewModel: ObservableObject, CodexManagedSessionShutdownPar
             explicitThreadID: session.codexConversationID,
             source: "renameSession.lifecycleAuthority"
         )
+        promptManager?.renameComposeTab(target.tabID, to: validatedName)
     }
 
     func renameSession(tabID: UUID, to newName: String) {

--- a/Sources/RepoPrompt/Features/Prompt/ViewModels/PromptViewModel.swift
+++ b/Sources/RepoPrompt/Features/Prompt/ViewModels/PromptViewModel.swift
@@ -191,6 +191,11 @@ class PromptViewModel: ObservableObject {
         case failed
     }
 
+    enum DurableBackgroundComposeTabCreationResult: Equatable {
+        case created(ComposeTabState, WorkspacePersistenceOutcome)
+        case rejected(WorkspacePersistenceOutcome)
+    }
+
     typealias ComposeTabsWillCloseListener = @Sendable (_ tabIDs: Set<UUID>, _ reason: ComposeTabRemovalReason) async -> Void
     typealias ComposeTabsDidRemoveListener = @MainActor @Sendable (
         _ tabIDs: Set<UUID>,
@@ -2738,6 +2743,79 @@ class PromptViewModel: ObservableObject {
         manager.markWorkspaceDirty()
         manager.pollAndSaveState()
         return newTab
+    }
+
+    /// Transactional primitive used by Agent-session lifecycle admission.
+    /// The tab is created already bound to its intended durable session identity and
+    /// is not returned to provider-start callers until the workspace authority accepts it.
+    @MainActor
+    func createDurableBackgroundAgentSessionTab(
+        name: String?,
+        sessionID: UUID,
+        lifecycleAuthority: AgentSessionLifecycleAuthority
+    ) async -> DurableBackgroundComposeTabCreationResult {
+        guard
+            let manager = workspaceManager,
+            let workspace = manager.activeWorkspace,
+            let index = manager.workspaces.firstIndex(where: { $0.id == workspace.id }),
+            let newTab = makeComposeTab(
+                for: .blank,
+                explicitName: name,
+                workspaceIndex: index,
+                manager: manager,
+                blankAgentSessionID: sessionID
+            )
+        else {
+            return .rejected(.rejected(reason: "workspace_unavailable"))
+        }
+
+        flushAndSnapshotSourceTabIfNeeded(for: .blank, in: manager, workspaceIndex: index)
+        manager.workspaces[index].composeTabs.append(newTab)
+        loadComposeTabsFromWorkspace(manager.workspaces[index])
+        manager.markWorkspaceDirty()
+
+        let persistence = await manager.pollAndSaveStateWithOutcomeAsync(
+            workspaceID: workspace.id,
+            source: WorkspaceSaveSource("agentSessionLifecycleAdmission")
+        )
+        let bindingStillCurrent = manager.workspaces
+            .first(where: { $0.id == workspace.id })?
+            .composeTabs.contains(where: {
+                $0.id == newTab.id && $0.activeAgentSessionID == sessionID
+            }) == true
+        guard lifecycleAuthority.decideAdmission(
+            persistence: persistence,
+            targetWorkspaceID: workspace.id,
+            bindingStillCurrent: bindingStillCurrent
+        ) == .commit else {
+            rollbackProvisionalAgentSessionTab(
+                newTab.id,
+                workspaceID: workspace.id,
+                manager: manager
+            )
+            return .rejected(persistence)
+        }
+
+        return .created(newTab, persistence)
+    }
+
+    @MainActor
+    private func rollbackProvisionalAgentSessionTab(
+        _ tabID: UUID,
+        workspaceID: UUID,
+        manager: WorkspaceManagerViewModel
+    ) {
+        guard let index = manager.workspaces.firstIndex(where: { $0.id == workspaceID }) else {
+            return
+        }
+        manager.workspaces[index].composeTabs.removeAll { $0.id == tabID }
+        manager.workspaces[index].stashedTabs.removeAll { $0.tab.id == tabID }
+        if manager.workspaces[index].activeComposeTabID == tabID {
+            manager.workspaces[index].activeComposeTabID = manager.workspaces[index].composeTabs.first?.id
+        }
+        loadComposeTabsFromWorkspace(manager.workspaces[index])
+        dirtyTabIDs.remove(tabID)
+        manager.markWorkspaceDirty()
     }
 
     /// Switch to a compose tab and wait for the tab state to fully apply.

--- a/Sources/RepoPrompt/Features/Workspaces/ViewModels/WorkspaceManagerViewModel.swift
+++ b/Sources/RepoPrompt/Features/Workspaces/ViewModels/WorkspaceManagerViewModel.swift
@@ -263,6 +263,41 @@ enum WorkspaceOpenError: LocalizedError {
     }
 }
 
+enum WorkspacePersistenceOutcome: Equatable {
+    case persisted(workspaceID: UUID, stateVersion: Int)
+    case notRequired(workspaceID: UUID)
+    case rejected(reason: String)
+
+    var workspaceID: UUID? {
+        switch self {
+        case let .persisted(workspaceID, _), let .notRequired(workspaceID):
+            workspaceID
+        case .rejected:
+            nil
+        }
+    }
+
+    var acceptedForLifecycleAdmission: Bool {
+        switch self {
+        case .persisted, .notRequired:
+            true
+        case .rejected:
+            false
+        }
+    }
+
+    var diagnosticCategory: String {
+        switch self {
+        case .persisted:
+            "persisted"
+        case .notRequired:
+            "not_required"
+        case let .rejected(reason):
+            reason
+        }
+    }
+}
+
 /// The main WorkspaceManager, refactored to store each WorkspaceModel
 /// in its own folder + workspace.json, and maintain an index file for all known workspaces.
 @MainActor
@@ -796,12 +831,33 @@ class WorkspaceManagerViewModel: ObservableObject {
     let workspaceSearchService: WorkspaceSearchService
     /// Non-nil only in production composition; nil is the isolated legacy test owner.
     private let domainWorkspaceAuthorityClient: DomainWorkspaceAuthorityClient?
+    private var agentSessionProjectionReconciler: ((
+        _ projectedWorkspaces: [WorkspaceModel],
+        _ currentWorkspaces: [WorkspaceModel]
+    ) -> AgentSessionLifecycleAuthority.ProjectionOutcome)?
     private var lastDomainProjectionSequence: UInt64 = 0
     private lazy var checkoutRefreshService = WorkspaceCheckoutRefreshService(
         store: fileManager.workspaceFileContextStore,
         searchService: workspaceSearchService
     )
     private weak var selectionCoordinator: WorkspaceSelectionCoordinator?
+
+    #if DEBUG
+        private var workspacePersistenceOutcomeOverrideForTesting: WorkspacePersistenceOutcome?
+
+        func setWorkspacePersistenceOutcomeOverrideForTesting(_ outcome: WorkspacePersistenceOutcome?) {
+            workspacePersistenceOutcomeOverrideForTesting = outcome
+        }
+    #endif
+
+    func setAgentSessionProjectionReconciler(
+        _ reconciler: @escaping (
+            _ projectedWorkspaces: [WorkspaceModel],
+            _ currentWorkspaces: [WorkspaceModel]
+        ) -> AgentSessionLifecycleAuthority.ProjectionOutcome
+    ) {
+        agentSessionProjectionReconciler = reconciler
+    }
 
     var liveUISelectionRevision: UInt64 {
         fileManager.selectionStateRevision
@@ -4190,14 +4246,24 @@ class WorkspaceManagerViewModel: ObservableObject {
                 invalidateDomainReadRegistration(for: workspaceID)
             }
         }
-        workspaces = projectedWorkspaces
-        recordRepoPathBaselines(for: projectedWorkspaces)
+        let lifecycleProjection = agentSessionProjectionReconciler?(
+            projectedWorkspaces,
+            workspaces
+        )
+        let reconciledWorkspaces = lifecycleProjection?.workspaces ?? projectedWorkspaces
+        workspaces = reconciledWorkspaces
+        recordRepoPathBaselines(for: reconciledWorkspaces)
         if let preferredActiveWorkspaceID,
-           projectedWorkspaces.contains(where: { $0.id == preferredActiveWorkspaceID })
+           reconciledWorkspaces.contains(where: { $0.id == preferredActiveWorkspaceID })
         {
             activeWorkspaceID = preferredActiveWorkspaceID
-        } else if !projectedWorkspaces.contains(where: { $0.id == activeWorkspaceID }) {
-            activeWorkspaceID = projectedWorkspaces.first?.id
+        } else if !reconciledWorkspaces.contains(where: { $0.id == activeWorkspaceID }) {
+            activeWorkspaceID = reconciledWorkspaces.first?.id
+        }
+        if let protectedWorkspaceIDs = lifecycleProjection?.protectedWorkspaceIDs {
+            for workspaceID in protectedWorkspaceIDs {
+                bumpStateVersion(for: workspaceID)
+            }
         }
     }
 
@@ -5431,7 +5497,7 @@ class WorkspaceManagerViewModel: ObservableObject {
             object: nil,
             userInfo: [
                 "windowID": promptViewModel.windowID,
-                "workspaceID": active.id
+                "workspaceID": workspaceID
             ]
         )
 
@@ -5453,14 +5519,25 @@ class WorkspaceManagerViewModel: ObservableObject {
         scheduleSave(workspaceID: workspaceID, fileURL: fileURL, source: source)
     }
 
-    func pollAndSaveStateAsync(source: WorkspaceSaveSource = .pollAndSaveStateAsync) async {
-        guard let active = activeWorkspace else { return }
+    func pollAndSaveStateAsync(
+        source: WorkspaceSaveSource = .pollAndSaveStateAsync
+    ) async {
+        _ = await pollAndSaveStateWithOutcomeAsync(source: source)
+    }
 
-        let wsID = active.id
+    func pollAndSaveStateWithOutcomeAsync(
+        workspaceID requestedWorkspaceID: UUID? = nil,
+        source: WorkspaceSaveSource = .pollAndSaveStateAsync
+    ) async -> WorkspacePersistenceOutcome {
+        guard let wsID = requestedWorkspaceID ?? activeWorkspace?.id,
+              workspace(withID: wsID) != nil
+        else {
+            return .rejected(reason: "active_workspace_unavailable")
+        }
         let cur = stateVersionByWorkspaceID[wsID, default: 0]
         let last = lastSavedVersionByWorkspaceID[wsID, default: -1]
 
-        guard cur != last else { return } // not dirty → nothing to do
+        guard cur != last else { return .notRequired(workspaceID: wsID) } // not dirty → nothing to do
 
         // Post notification to allow SwiftUI views to flush pending state
         NotificationCenter.default.post(
@@ -5468,36 +5545,59 @@ class WorkspaceManagerViewModel: ObservableObject {
             object: nil,
             userInfo: [
                 "windowID": promptViewModel.windowID,
-                "workspaceID": active.id
+                "workspaceID": wsID
             ]
         )
 
-        // Call before-save listeners on the active
-        if let active = activeWorkspace {
+        // Call before-save listeners for the workspace this admission is saving.
+        if let targetWorkspace = workspace(withID: wsID) {
             for listenerRecord in beforeSaveListeners {
-                listenerRecord.listener(active)
+                listenerRecord.listener(targetWorkspace)
             }
         }
 
-        guard let index = workspaceIndex(for: wsID) else { return }
+        guard let index = workspaceIndex(for: wsID) else {
+            return .rejected(reason: "workspace_changed_before_capture")
+        }
         let snapshot = captureActiveTabSnapshotForWorkspaceIndex(index, source: source)
-        guard let capturedWorkspace = workspace(withID: wsID) else { return }
+        guard let capturedWorkspace = workspace(withID: wsID) else {
+            return .rejected(reason: "workspace_changed_after_capture")
+        }
         let fileURL = workspaceFileURL(for: capturedWorkspace)
         reloadComposeTabsAfterSaveCaptureIfNeeded(capturedWorkspace, capturedSnapshot: snapshot)
         if let snapshot {
             composeTabSnapshotSubject.send(snapshot)
         }
+        #if DEBUG
+            if let workspacePersistenceOutcomeOverrideForTesting {
+                return workspacePersistenceOutcomeOverrideForTesting
+            }
+        #endif
         guard let savedStateVersion = await saveWorkspaceAsync(
             workspaceID: wsID,
             fileURL: fileURL,
             source: source
-        ) else { return }
+        ) else {
+            let issueCategory = if domainWorkspaceAuthorityIssue?.message
+                .localizedCaseInsensitiveContains("workspace_not_writable") == true
+            {
+                "workspace_not_writable"
+            } else {
+                "workspace_save_failed"
+            }
+            return .rejected(
+                reason: issueCategory
+            )
+        }
         await WorkspaceDiskWriter.shared.flush(url: fileURL)
-        guard workspace(withID: wsID) != nil else { return }
+        guard workspace(withID: wsID) != nil else {
+            return .rejected(reason: "workspace_changed_after_save")
+        }
         lastSavedVersionByWorkspaceID[wsID] = max(
             lastSavedVersionByWorkspaceID[wsID, default: -1],
             savedStateVersion
         )
+        return .persisted(workspaceID: wsID, stateVersion: savedStateVersion)
     }
 
     func restoreWorkspaceState(
@@ -6048,7 +6148,11 @@ class WorkspaceManagerViewModel: ObservableObject {
 
         let diskSnapshot = await loadWorkspaceSnapshotFromDisk()
         if !diskSnapshot.isEmpty {
-            workspaces = diskSnapshot
+            let lifecycleProjection = agentSessionProjectionReconciler?(
+                diskSnapshot,
+                workspaces
+            )
+            workspaces = lifecycleProjection?.workspaces ?? diskSnapshot
         }
 
         let activeWorkspaceIDs = Set(windowStates.allWindows.compactMap { $0.workspaceManager.activeWorkspace?.id })

--- a/Sources/RepoPrompt/Infrastructure/MCP/Agent/AgentRunMCPToolService.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/Agent/AgentRunMCPToolService.swift
@@ -631,7 +631,15 @@ struct AgentRunMCPToolService {
             ])
         #endif
         let outcome: AgentExternalMCPRunStarter.StartOutcome
+        var providerDispatchAttempted = false
         do {
+            try agentModeVM.requireCurrentAgentSessionLifecycleAdmission(target)
+            agentModeVM.recordAgentSessionProviderLifecycle(
+                target: target,
+                phase: .beforeProviderStart,
+                decision: .admitted,
+                reason: "binding_identity_validated"
+            )
             WorktreeStartupInstrumentation.record(.providerStart, context: worktreeStartupContext)
             #if DEBUG
                 if worktreeStartupBenchmarkToken != nil {
@@ -641,6 +649,7 @@ struct AgentRunMCPToolService {
                     )
                 }
             #endif
+            providerDispatchAttempted = true
             outcome = try await startRun(
                 target,
                 message,
@@ -653,6 +662,12 @@ struct AgentRunMCPToolService {
                 workflow,
                 spawnParentSessionID,
                 oracleLaunchSource.source
+            )
+            agentModeVM.recordAgentSessionProviderLifecycle(
+                target: target,
+                phase: .afterProviderStart,
+                decision: .admitted,
+                reason: "provider_start_accepted"
             )
             #if DEBUG
                 if worktreeStartupBenchmarkToken != nil {
@@ -669,6 +684,19 @@ struct AgentRunMCPToolService {
                 }
             #endif
         } catch {
+            let providerFailureReason = if !providerDispatchAttempted {
+                "lifecycle_identity_rejected"
+            } else if error is CancellationError {
+                "provider_start_cancelled"
+            } else {
+                "provider_start_failed"
+            }
+            agentModeVM.recordAgentSessionProviderLifecycle(
+                target: target,
+                phase: providerDispatchAttempted ? .afterProviderStart : .beforeProviderStart,
+                decision: .rejected,
+                reason: providerFailureReason
+            )
             let decoratedError = startWorktreeCoordinator.providerStartError(
                 error,
                 targetSessionID: target.sessionID,

--- a/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/ViewModels/MCPServerViewModel.swift
@@ -463,6 +463,16 @@ final class MCPServerViewModel: ObservableObject {
             try await oracleToolService.executeAskOracle(args: args)
         }
 
+        func resolveAgentSessionLifecycleMutationTargetForTesting(
+            connectionID: UUID?
+        ) async throws -> AgentSessionLifecycleAuthority.MutationTarget {
+            try await resolveAgentSessionLifecycleMutationTarget(
+                args: [:],
+                connectionID: connectionID,
+                intent: .setStatus
+            )
+        }
+
         func setOracleReviewPackagingTraceObserverForTesting(
             _ observer: OracleReviewPackagingTraceContext.Observer?
         ) {
@@ -1117,9 +1127,13 @@ final class MCPServerViewModel: ObservableObject {
             }
             return connectionID
         },
-        resolveAgentModeTabID: { [weak self] args, connectionID in
+        resolveAgentModeTabID: { [weak self] args, connectionID, intent in
             guard let self else { throw MCPError.internalError("Window deallocated while resolving agent mode tab") }
-            return try await resolveTabIDForAgentMode(args: args, connectionID: connectionID)
+            return try await resolveAgentSessionLifecycleMutationTarget(
+                args: args,
+                connectionID: connectionID,
+                intent: intent
+            )
         },
         resolveContextBuilderTab: { [weak self] args, targetWindow, connectionID in
             guard let self else { throw MCPError.internalError("Window deallocated while resolving context_builder tab") }
@@ -3609,7 +3623,8 @@ final class MCPServerViewModel: ObservableObject {
         args: [String: Value],
         connectionID: UUID?
     ) async throws -> UUID {
-        // 1) Explicit _tabID override (hidden param), validated against real tabs.
+        // Oracle tools use this only to anchor context packaging to a compose tab;
+        // they do not mutate or start the tab's Agent session identity.
         let explicitRaw = rawExplicitTabID(args: args)
         let workspaceTabIDs = Set(workspaceManager?.activeWorkspace?.composeTabs.map(\.id) ?? [])
         let availableTabIDs = workspaceTabIDs.isEmpty
@@ -3622,7 +3637,6 @@ final class MCPServerViewModel: ObservableObject {
             return explicitUUID
         }
 
-        // 2) Try to get tab from MCP connection context (bound tab)
         let resolvedConnectionID: UUID? = if let connectionID {
             connectionID
         } else {
@@ -3635,14 +3649,12 @@ final class MCPServerViewModel: ObservableObject {
             return boundTab
         }
 
-        // 3) Fallback to active compose tab in the window
         if let activeTab = promptVM.activeComposeTabID,
            composeTabExists(activeTab)
         {
             return activeTab
         }
 
-        // 4) Create a blank tab as a last resort
         if let newTab = await promptVM.ensureActiveComposeTab(
             nil,
             creationStrategy: .blank,
@@ -3654,10 +3666,113 @@ final class MCPServerViewModel: ObservableObject {
         throw MCPError.invalidParams("No active compose tab available; open or create a tab first.")
     }
 
+    private func resolveAgentSessionLifecycleMutationTarget(
+        args: [String: Value],
+        connectionID: UUID?,
+        intent: AgentSessionLifecycleAuthority.Intent
+    ) async throws -> AgentSessionLifecycleAuthority.MutationTarget {
+        // 1) Explicit _tabID override (hidden param), validated against real tabs.
+        let explicitRaw = rawExplicitTabID(args: args)
+        let workspaceTabIDs = Set(workspaceManager?.activeWorkspace?.composeTabs.map(\.id) ?? [])
+        let availableTabIDs = workspaceTabIDs.isEmpty
+            ? Set(promptVM.currentComposeTabs.map(\.id))
+            : workspaceTabIDs
+        if let explicitUUID = try Self.resolveExplicitTabIDForAgentMode(
+            rawTabID: explicitRaw,
+            availableTabIDs: availableTabIDs
+        ) {
+            let expectedSessionID = workspaceManager?.composeTab(with: explicitUUID)?.activeAgentSessionID
+            return try requireTargetWindow().agentModeViewModel
+                .resolveAgentSessionLifecycleMutationTarget(
+                    tabID: explicitUUID,
+                    expectedSessionID: expectedSessionID,
+                    intent: intent
+                )
+        }
+
+        // 2) Try to get tab from MCP connection context (bound tab)
+        let resolvedConnectionID: UUID? = if let connectionID {
+            connectionID
+        } else {
+            await service.currentRequestConnectionID()
+        }
+        let requiresBoundAgentSessionContext = switch intent {
+        case .setStatus, .shareThoughts, .waitForInstruction, .askUser:
+            true
+        case .createOrContinue, .applyProjection, .providerStart:
+            false
+        }
+        if requiresBoundAgentSessionContext,
+           let resolvedConnectionID
+        {
+            guard let boundContext = tabContextByConnectionID[resolvedConnectionID],
+                  boundContext.windowID == windowID
+            else {
+                throw MCPError.invalidParams(
+                    "The Agent session connection no longer has its bound tab; the operation was not retargeted. Bind the current context again."
+                )
+            }
+            guard composeTabExists(boundContext.tabID) else {
+                throw MCPError.invalidParams(
+                    "The Agent session's bound tab no longer exists; the operation was not retargeted. Bind the current context again."
+                )
+            }
+            return try requireTargetWindow().agentModeViewModel
+                .resolveAgentSessionLifecycleMutationTarget(
+                    tabID: boundContext.tabID,
+                    expectedSessionID: boundContext.activeAgentSessionID,
+                    intent: intent
+                )
+        }
+        if let resolvedConnectionID,
+           let boundContext = tabContextByConnectionID[resolvedConnectionID],
+           boundContext.windowID == windowID
+        {
+            guard composeTabExists(boundContext.tabID) else {
+                throw MCPError.invalidParams(
+                    "The Agent session's bound tab no longer exists; the operation was not retargeted. Bind the current context again."
+                )
+            }
+            return try requireTargetWindow().agentModeViewModel
+                .resolveAgentSessionLifecycleMutationTarget(
+                    tabID: boundContext.tabID,
+                    expectedSessionID: boundContext.activeAgentSessionID,
+                    intent: intent
+                )
+        }
+
+        // 3) Fallback to active compose tab in the window
+        if let activeTab = promptVM.activeComposeTabID,
+           composeTabExists(activeTab)
+        {
+            return try requireTargetWindow().agentModeViewModel
+                .resolveAgentSessionLifecycleMutationTarget(
+                    tabID: activeTab,
+                    expectedSessionID: nil,
+                    intent: intent
+                )
+        }
+
+        // 4) Create a blank tab as a last resort
+        if let newTab = await promptVM.ensureActiveComposeTab(
+            nil,
+            creationStrategy: .blank,
+            name: nil
+        ) {
+            return try requireTargetWindow().agentModeViewModel
+                .resolveAgentSessionLifecycleMutationTarget(
+                    tabID: newTab.id,
+                    expectedSessionID: newTab.activeAgentSessionID,
+                    intent: intent
+                )
+        }
+
+        throw MCPError.invalidParams("No active compose tab available; open or create a tab first.")
+    }
+
     /// Resolves an explicit `_tabID` from the args, returning nil when not provided.
-    /// Unlike `resolveExistingTabIDForAgentControl`, this does NOT fall back to the
-    /// connection-bound tab or active tab. This ensures run-starting operations
-    /// (agent_run.start) creates a fresh session by default.
+    /// This does not fall back to the connection-bound or active tab. Run-starting
+    /// operations therefore create a fresh session by default.
     private func resolveRequestedTabIDForAgentControl(
         args: [String: Value]
     ) throws -> UUID? {
@@ -3669,34 +3784,6 @@ final class MCPServerViewModel: ObservableObject {
             rawTabID: rawExplicitTabID(args: args),
             availableTabIDs: availableTabIDs
         )
-    }
-
-    private func resolveExistingTabIDForAgentControl(
-        args: [String: Value],
-        metadata: RequestMetadata
-    ) async throws -> UUID? {
-        let workspaceTabIDs = Set(workspaceManager?.activeWorkspace?.composeTabs.map(\.id) ?? [])
-        let availableTabIDs = workspaceTabIDs.isEmpty
-            ? Set(promptVM.currentComposeTabs.map(\.id))
-            : workspaceTabIDs
-        if let explicitUUID = try Self.resolveExplicitTabIDForAgentMode(
-            rawTabID: rawExplicitTabID(args: args),
-            availableTabIDs: availableTabIDs
-        ) {
-            return explicitUUID
-        }
-        if let connectionID = metadata.connectionID,
-           let boundTabID = boundTabID(forConnection: connectionID),
-           composeTabExists(boundTabID)
-        {
-            return boundTabID
-        }
-        if let activeTabID = promptVM.activeComposeTabID,
-           composeTabExists(activeTabID)
-        {
-            return activeTabID
-        }
-        return nil
     }
 
     func bindCurrentRequestToTabIfPossible(

--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPAgentSessionControlToolProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPAgentSessionControlToolProvider.swift
@@ -137,16 +137,20 @@ final class MCPAgentSessionControlToolProvider: MCPAppToolProviding {
 
         let connectionID = try await dependencies.requireAgentModeConnection(MCPWindowToolName.shareThoughts)
         let targetWindow = try dependencies.requireTargetWindow()
-        let tabID = try await dependencies.resolveAgentModeTabID(args, connectionID)
+        let target = try await dependencies.resolveAgentModeTabID(args, connectionID, .shareThoughts)
 
         // Invariant: background tool updates are tab-scoped and must not steal tab focus.
-        await MainActor.run {
-            targetWindow.agentModeViewModel.shareThoughts(thoughts, title: title, tabID: tabID)
+        try await MainActor.run {
+            try targetWindow.agentModeViewModel.shareThoughts(
+                thoughts,
+                title: title,
+                target: target
+            )
         }
 
         return .object([
             "ok": .bool(true),
-            "context_id": .string(tabID.uuidString)
+            "context_id": .string(target.tabID.uuidString)
         ])
     }
 
@@ -160,18 +164,21 @@ final class MCPAgentSessionControlToolProvider: MCPAppToolProviding {
         let sessionNameToApply = (trimmedSessionName?.isEmpty == false) ? trimmedSessionName : nil
 
         let targetWindow = try dependencies.requireTargetWindow()
-        let tabID = try await dependencies.resolveAgentModeTabID(args, connectionID)
+        let target = try await dependencies.resolveAgentModeTabID(args, connectionID, .setStatus)
 
         // Invariant: background status updates are tab-scoped and must not steal tab focus.
-        await MainActor.run {
+        try await MainActor.run {
             if let sessionNameToApply {
-                targetWindow.agentModeViewModel.renameSession(tabID: tabID, to: sessionNameToApply)
+                try targetWindow.agentModeViewModel.renameSession(
+                    target: target,
+                    to: sessionNameToApply
+                )
             }
         }
 
         var result: [String: Value] = [
             "ok": .bool(true),
-            "context_id": .string(tabID.uuidString),
+            "context_id": .string(target.tabID.uuidString),
             "session_name_applied": .bool(sessionNameToApply != nil)
         ]
         if let sessionNameToApply {
@@ -197,11 +204,11 @@ final class MCPAgentSessionControlToolProvider: MCPAppToolProviding {
 
         let targetWindow = try dependencies.requireTargetWindow()
         let connectionID = ServerNetworkManager.currentConnectionID
-        let tabID = try await dependencies.resolveAgentModeTabID(args, connectionID)
+        let target = try await dependencies.resolveAgentModeTabID(args, connectionID, .waitForInstruction)
 
         // Invariant: waiting state is stored on the target session; do not switch tabs here.
         let response = try await targetWindow.agentModeViewModel.waitForNextUserInstruction(
-            tabID: tabID,
+            target: target,
             prompt: prompt,
             timeoutSeconds: timeout
         )

--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPAppPhysicalCapabilityAdapters.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPAppPhysicalCapabilityAdapters.swift
@@ -46,7 +46,11 @@ enum MCPAppPhysicalCapabilityAdapters {
     typealias RequireTargetWindow = @MainActor @Sendable () throws -> WindowState
     typealias RequireCurrentTabContext = @MainActor @Sendable (_ toolName: String) async throws -> MCPServerViewModel.TabContextSnapshot
     typealias RequireAgentModeConnection = @Sendable (_ toolName: String) async throws -> UUID
-    typealias ResolveAgentModeTabID = @Sendable (_ args: [String: Value], _ connectionID: UUID?) async throws -> UUID
+    typealias ResolveAgentModeTabID = @Sendable (
+        _ args: [String: Value],
+        _ connectionID: UUID?,
+        _ intent: AgentSessionLifecycleAuthority.Intent
+    ) async throws -> AgentSessionLifecycleAuthority.MutationTarget
     typealias ResolveContextBuilderTab = @MainActor @Sendable (
         _ args: [String: Value],
         _ targetWindow: WindowState,

--- a/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPAskUserToolProvider.swift
+++ b/Sources/RepoPrompt/Infrastructure/MCP/WindowTools/MCPAskUserToolProvider.swift
@@ -43,14 +43,15 @@ final class MCPAskUserToolProvider: MCPAppToolProviding {
                         )
                     }
                 case .agentModeRun:
-                    guard let tabID = try? await resolveAgentModeTabID(
+                    guard let target = try? await resolveAgentModeTabID(
                         request.payload,
-                        connectionID
+                        connectionID,
+                        .askUser
                     ) else {
                         return false
                     }
                     return await MainActor.run {
-                        targetWindow.agentModeViewModel.canPresentAskUserInteraction(tabID: tabID)
+                        targetWindow.agentModeViewModel.canPresentAskUserInteraction(tabID: target.tabID)
                     }
                 case .unknown:
                     return false
@@ -201,7 +202,8 @@ final class MCPAskUserToolProvider: MCPAppToolProviding {
 
         case .agentModeRun:
             // Route to agent mode UI.
-            let tabID = try await dependencies.resolveAgentModeTabID(args, connectionID)
+            let target = try await dependencies.resolveAgentModeTabID(args, connectionID, .askUser)
+            let tabID = target.tabID
             // For non-MCP-controlled sessions, surface the tab so the user can
             // see and answer the question. MCP-controlled runs handle interactions
             // programmatically via `respond`, so pulling focus would be disruptive.
@@ -226,7 +228,7 @@ final class MCPAskUserToolProvider: MCPAppToolProviding {
                 }
             ) {
                 try await targetWindow.agentModeViewModel.askUserInteraction(
-                    tabID: tabID,
+                    target: target,
                     interaction: parsed.interaction
                 )
             }

--- a/Tests/RepoPromptTests/MCP/TabContextRoutingTests.swift
+++ b/Tests/RepoPromptTests/MCP/TabContextRoutingTests.swift
@@ -13,6 +13,66 @@ final class TabContextRoutingTests: XCTestCase {
         super.tearDown()
     }
 
+    #if DEBUG
+        @MainActor
+        func testMissingBoundAgentSessionTabIsRejectedWithoutActiveTabRetargeting() async throws {
+            let previousAutoStart = GlobalSettingsStore.shared.mcpAutoStart()
+            GlobalSettingsStore.shared.setMCPAutoStart(false, commit: false)
+            let window = WindowState()
+            GlobalSettingsStore.shared.setMCPAutoStart(previousAutoStart, commit: false)
+            WindowStatesManager.shared.registerWindowState(window)
+            defer { WindowStatesManager.shared.unregisterWindowState(window) }
+
+            let workspace = window.workspaceManager.createWorkspace(
+                name: "Missing bound Agent tab",
+                repoPaths: [],
+                ephemeral: true
+            )
+            _ = await window.workspaceManager.switchWorkspace(
+                to: workspace,
+                saveState: false,
+                reason: "missingBoundAgentSessionTabTest"
+            )
+            let activeWorkspace = try XCTUnwrap(window.workspaceManager.activeWorkspace)
+            window.promptManager.loadComposeTabsFromWorkspace(activeWorkspace, syncPromptText: true)
+            let activeTabID = try XCTUnwrap(activeWorkspace.activeComposeTabID)
+            window.promptManager.setComposeTabPinned(true, for: activeTabID)
+
+            let connectionID = UUID()
+            window.mcpServer.tabContextByConnectionID[connectionID] = .init(
+                tabID: UUID(),
+                windowID: window.windowID,
+                workspaceID: activeWorkspace.id,
+                promptText: "",
+                selection: StoredSelection(),
+                selectedMetaPromptIDs: [],
+                tabName: "Missing bound tab",
+                runID: UUID(),
+                activeAgentSessionID: UUID(),
+                explicitlyBound: true
+            )
+
+            await XCTAssertThrowsErrorAsync({
+                try await window.mcpServer.resolveAgentSessionLifecycleMutationTargetForTesting(
+                    connectionID: connectionID
+                )
+            }) { error in
+                XCTAssertTrue(String(describing: error).contains("not retargeted"), String(describing: error))
+            }
+            window.mcpServer.tabContextByConnectionID.removeValue(forKey: connectionID)
+            await XCTAssertThrowsErrorAsync({
+                try await window.mcpServer.resolveAgentSessionLifecycleMutationTargetForTesting(
+                    connectionID: connectionID
+                )
+            }) { error in
+                XCTAssertTrue(String(describing: error).contains("not retargeted"), String(describing: error))
+            }
+            XCTAssertEqual(window.promptManager.activeComposeTabID, activeTabID)
+            XCTAssertTrue(window.workspaceManager.composeTab(with: activeTabID)?.isPinned == true)
+            await window.tearDown()
+        }
+    #endif
+
     func testScopedReadRebindsStaleRebindableBindingsButNeverRunScoped() {
         let t1 = DomainContextIdentity(workspaceID: UUID(), contextID: UUID())
         let t2 = DomainContextIdentity(workspaceID: UUID(), contextID: UUID())

--- a/Tests/RepoPromptTests/Prompt/BackgroundComposeTabAdmissionTests.swift
+++ b/Tests/RepoPromptTests/Prompt/BackgroundComposeTabAdmissionTests.swift
@@ -247,6 +247,200 @@ final class BackgroundComposeTabAdmissionTests: XCTestCase {
         XCTAssertTrue(attemptedTabIDs.isEmpty)
     }
 
+    func testRejectedConcurrentAgentAdmissionsPreserveActiveLivePinnedSession() async throws {
+        let fixture = makeFixture(initialTabCount: 2)
+        let tabID = try XCTUnwrap(fixture.prompt.activeComposeTabID)
+        fixture.prompt.setComposeTabPinned(true, for: tabID)
+        let sessionID = try XCTUnwrap(fixture.manager.composeTab(with: tabID)?.activeAgentSessionID)
+        let viewModel = makeAgentModeViewModel(prompt: fixture.prompt, manager: fixture.manager)
+        let session = viewModel.session(for: tabID)
+        _ = viewModel.test_installPersistentSessionBinding(sessionID: sessionID, on: session)
+        session.runState = .running
+        viewModel.setAgentRunActive(tabID, isActive: true)
+        fixture.manager.setWorkspacePersistenceOutcomeOverrideForTesting(
+            .rejected(reason: "workspace_not_writable")
+        )
+        defer { fixture.manager.setWorkspacePersistenceOutcomeOverrideForTesting(nil) }
+
+        let originalWorkspace = try XCTUnwrap(fixture.manager.activeWorkspace)
+        let originalTabs = originalWorkspace.composeTabs
+        let originalStashedTabs = originalWorkspace.stashedTabs
+
+        let first = Task { @MainActor in
+            await self.admissionWasRejected(viewModel)
+        }
+        let second = Task { @MainActor in
+            await self.admissionWasRejected(viewModel)
+        }
+        let rejections = await [first.value, second.value]
+
+        XCTAssertEqual(rejections, [true, true])
+        let finalWorkspace = try XCTUnwrap(fixture.manager.activeWorkspace)
+        XCTAssertEqual(finalWorkspace.composeTabs.map(\.id), originalTabs.map(\.id))
+        XCTAssertEqual(finalWorkspace.composeTabs.map(\.name), originalTabs.map(\.name))
+        XCTAssertEqual(finalWorkspace.composeTabs.map(\.isPinned), originalTabs.map(\.isPinned))
+        XCTAssertEqual(
+            finalWorkspace.composeTabs.map(\.activeAgentSessionID),
+            originalTabs.map(\.activeAgentSessionID)
+        )
+        XCTAssertEqual(finalWorkspace.stashedTabs, originalStashedTabs)
+        XCTAssertEqual(finalWorkspace.activeComposeTabID, tabID)
+        XCTAssertEqual(fixture.prompt.activeComposeTabID, tabID)
+        XCTAssertTrue(fixture.prompt.currentComposeTabs.contains(where: {
+            $0.id == tabID && $0.isPinned && $0.activeAgentSessionID == sessionID
+        }))
+        XCTAssertTrue(viewModel.sessions[tabID] === session)
+        XCTAssertEqual(session.activeAgentSessionID, sessionID)
+        XCTAssertEqual(session.runState, .running)
+        XCTAssertEqual(Set(viewModel.sessions.keys), Set([tabID]))
+    }
+
+    func testStaleProjectionCannotReplaceActiveLivePinnedSession() throws {
+        let fixture = makeFixture(initialTabCount: 2)
+        let tabID = try XCTUnwrap(fixture.prompt.activeComposeTabID)
+        fixture.prompt.setComposeTabPinned(true, for: tabID)
+        let sessionID = try XCTUnwrap(fixture.manager.composeTab(with: tabID)?.activeAgentSessionID)
+        let viewModel = makeAgentModeViewModel(prompt: fixture.prompt, manager: fixture.manager)
+        let session = viewModel.session(for: tabID)
+        _ = viewModel.test_installPersistentSessionBinding(sessionID: sessionID, on: session)
+        session.runState = .running
+        viewModel.setAgentRunActive(tabID, isActive: true)
+
+        let currentWorkspace = try XCTUnwrap(fixture.manager.activeWorkspace)
+        var staleWorkspace = currentWorkspace
+        var staleTab = try XCTUnwrap(currentWorkspace.composeTabs.first(where: { $0.id == tabID }))
+        staleTab.name = "Stale replacement"
+        staleTab.isPinned = false
+        staleTab.activeAgentSessionID = UUID()
+        staleWorkspace.composeTabs.removeAll { $0.id == tabID }
+        staleWorkspace.activeComposeTabID = staleWorkspace.composeTabs.first?.id
+        staleWorkspace.stashedTabs.append(StashedTab(
+            tab: staleTab,
+            stashedAt: Date()
+        ))
+
+        fixture.manager.applyDomainWorkspaceProjection(
+            [staleWorkspace],
+            fileURLsByWorkspaceID: [:],
+            revisionsByWorkspaceID: [:],
+            digestsByWorkspaceID: [:],
+            catalogRevision: 1,
+            preferredActiveWorkspaceID: currentWorkspace.id,
+            publicationSequence: 1
+        )
+
+        let reconciled = try XCTUnwrap(fixture.manager.activeWorkspace)
+        let protectedTab = try XCTUnwrap(reconciled.composeTabs.first(where: { $0.id == tabID }))
+        XCTAssertTrue(protectedTab.isPinned)
+        XCTAssertEqual(protectedTab.activeAgentSessionID, sessionID)
+        XCTAssertEqual(protectedTab.name, currentWorkspace.composeTabs.first(where: { $0.id == tabID })?.name)
+        XCTAssertEqual(reconciled.activeComposeTabID, tabID)
+        XCTAssertFalse(reconciled.stashedTabs.contains(where: { $0.tab.id == tabID }))
+        XCTAssertTrue(viewModel.sessions[tabID] === session)
+        XCTAssertEqual(session.runState, .running)
+    }
+
+    func testLateTitleProviderAndInteractionAttemptsCannotCrossChangedSessionIdentity() async throws {
+        let fixture = makeFixture(initialTabCount: 1)
+        let tabID = try XCTUnwrap(fixture.prompt.activeComposeTabID)
+        fixture.prompt.setComposeTabPinned(true, for: tabID)
+        let originalSessionID = try XCTUnwrap(fixture.manager.composeTab(with: tabID)?.activeAgentSessionID)
+        let viewModel = makeAgentModeViewModel(prompt: fixture.prompt, manager: fixture.manager)
+        let session = viewModel.session(for: tabID)
+        _ = viewModel.test_installPersistentSessionBinding(sessionID: originalSessionID, on: session)
+        let target = try viewModel.resolveAgentSessionLifecycleMutationTarget(
+            tabID: tabID,
+            expectedSessionID: originalSessionID,
+            intent: .setStatus
+        )
+        let runTarget = AgentModeViewModel.MCPSessionTarget(
+            tabID: tabID,
+            sessionID: originalSessionID,
+            origin: .existingSession,
+            lifecycleIdentity: target.identity
+        )
+        let originalName = fixture.manager.composeTab(with: tabID)?.name
+
+        let replacementSessionID = UUID()
+        _ = viewModel.test_installPersistentSessionBinding(
+            sessionID: replacementSessionID,
+            on: session,
+            updateWorkspaceMetadata: true
+        )
+
+        XCTAssertThrowsError(try viewModel.renameSession(target: target, to: "Late stale title"))
+        XCTAssertThrowsError(try viewModel.requireCurrentAgentSessionLifecycleAdmission(runTarget))
+        let interaction = AgentAskUserInteraction(
+            title: "Late question",
+            questions: [
+                AgentAskUserQuestion(
+                    id: "answer",
+                    question: "Should not be shown",
+                    allowsMultiple: false,
+                    allowsCustom: true
+                )
+            ]
+        )
+        await assertThrowsErrorAsync {
+            try await viewModel.askUserInteraction(target: target, interaction: interaction)
+        }
+        await assertThrowsErrorAsync {
+            try await viewModel.waitForNextUserInstruction(target: target)
+        }
+        XCTAssertEqual(fixture.manager.composeTab(with: tabID)?.name, originalName)
+        XCTAssertEqual(fixture.manager.composeTab(with: tabID)?.activeAgentSessionID, replacementSessionID)
+        XCTAssertEqual(session.activeAgentSessionID, replacementSessionID)
+        XCTAssertNil(session.pendingAskUser)
+        XCTAssertNil(session.instructionContinuation)
+    }
+
+    func testLifecycleAdmissionAcceptsCorrectAlreadySavedWorkspaceAndRejectsWrongWorkspace() {
+        let authority = AgentSessionLifecycleAuthority()
+        let workspaceID = UUID()
+
+        XCTAssertEqual(
+            authority.decideAdmission(
+                persistence: .notRequired(workspaceID: workspaceID),
+                targetWorkspaceID: workspaceID,
+                bindingStillCurrent: true
+            ),
+            .commit
+        )
+        XCTAssertEqual(
+            authority.decideAdmission(
+                persistence: .persisted(workspaceID: UUID(), stateVersion: 7),
+                targetWorkspaceID: workspaceID,
+                bindingStillCurrent: true
+            ),
+            .rollback(.workspaceChanged)
+        )
+    }
+
+    private func admissionWasRejected(_ viewModel: AgentModeViewModel) async -> Bool {
+        do {
+            _ = try await viewModel.mcpResolveOrCreateSessionTarget(
+                tabID: nil,
+                sessionID: nil,
+                createIfNeeded: true,
+                sessionName: "Rejected concurrent workflow"
+            )
+            return false
+        } catch {
+            return true
+        }
+    }
+
+    private func assertThrowsErrorAsync(
+        _ expression: () async throws -> some Any,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        do {
+            _ = try await expression()
+            XCTFail("Expected expression to throw", file: file, line: line)
+        } catch {}
+    }
+
     private func makeFixture(initialTabCount: Int) -> (manager: WorkspaceManagerViewModel, prompt: PromptViewModel) {
         let fileManager = WorkspaceFilesViewModel()
         let keyManager = KeyManager(


### PR DESCRIPTION
## Urgency

P0 state-integrity repair. A live Agent Mode session disappeared mid-run and an older pinned transcript was projected into the same compose-tab identity. The title mismatch was only a symptom; the protected-session replacement was the defect.

## Confirmed incident path

Read-only evidence from the affected workspace and unified logs established this sequence:

1. A new background Agent workflow created an in-memory compose tab and started provider threads.
2. Workspace-authority persistence was continuously rejecting saves with `workspace_not_writable`, including immediately around provider startup.
3. Provider startup continued even though the new compose/session binding was never durably admitted.
4. A later Domain/inactive projection applied stale durable workspace state wholesale, replacing the live tab association with the older pinned session projection.
5. MCP control routing then fell back through the surviving old binding; a late title save partially committed the new title onto the old durable AgentSession while its provider/transcript identity remained old.

Correlations preserved for maintainers: workspace `FA8D…`, compose tab `B5EB…`, durable AgentSession `77D…`, new provider threads `019fd31f…` / `019fd320…`. The original application data and live app were never mutated during investigation.

## Repair

- Introduce `AgentSessionLifecycleAuthority` as the single admission/mutation/projection policy owner.
- Make create-or-continue transactional:
  - snapshot immutable workspace/tab/session identity and binding generations;
  - durably establish the workspace-scoped compose/session binding;
  - reject/roll back on persistence failure or identity drift;
  - only then permit provider startup.
- Revalidate immutable identity immediately before provider dispatch and before late title/share/wait/ask mutations.
- Reconcile Domain and disk projections through the same authority so live **or pinned** tabs cannot be replaced, stashed, hidden, duplicated, or rolled back by stale projection state.
- Fail closed for Agent control intents when the request connection's bound tab/session is missing, purged, wrong-window, or stale; never retarget to the active pinned tab.
- Preserve pre-existing durable index metadata when a resume admission is discarded.
- Keep Oracle context packaging as tab-only routing; it does not mutate Agent identity and retains its independent worktree/owner fail-closed checks.
- Add bounded privacy-safe causal events at the lifecycle boundary: caller/intent/phase, hashed workspace-tab-session-generation correlations, pinned/live/active/protected state, workspace-save outcome, and rejection/partial-success reason. No prompt, transcript, path, provider secret, or raw title is logged; projection events are capped.

## Why #720 / #722 / #723 did not cover this

- #720 contained automatic capacity eviction; it did not establish transactional Agent session admission or protect against stale projection replacement.
- #722 fenced authoritative Context Builder completion; it did not govern compose/session binding identity or provider-start admission.
- #723 removed the background tab limit/eviction trigger; it did not address `workspace_not_writable`, projection rollback, stale MCP binding fallback, or late identity completions.

Those changes reduced known loss paths but left the actual replacement trigger untraceable. This PR adds the owning-boundary causal record and enforces the invariant independently of tab count.

## Deterministic regression coverage

- active + live + pinned session survives concurrent new workflow admissions when workspace persistence is rejected;
- stale Domain projection cannot replace/stash/unpin the protected session;
- late title/provider/ask/wait attempts cannot cross a changed session identity/generation;
- workspace-scoped admission accepts only the correct persisted/not-required outcome;
- missing and purged connection bindings fail closed without active-tab retarget;
- existing legacy tab/removal coverage remains intact.

## Validation

Green:

- `BackgroundComposeTabAdmissionTests`: 13/13 — ticket `649cb42f-9a55-4680-857f-8448ba2fd4bd`
- `TabContextRoutingTests`: 61/61 — tickets `b14f2d3e-f5f5-4cf3-bdb8-f03a65c9c713`, `e060c6ff-fc20-41d8-b110-425e6b8545b7`
- `MCPAskOracleWorktreeTests`: 25/25 — ticket `71ab69bc-bb78-418d-95df-23dcf80659c6`
- `CodexManagedAuthRecoveryServiceTests`: 30/30 — ticket `e9213557-d1f9-4009-99e9-ee47d606e0b1`
- `DurableArtifactStoreTests`: 9/9 — ticket `3782a703-fb6b-4262-810e-c6fa317c6c4a`
- `make dev-lint` — ticket `5bff6a8e-c327-498c-a08c-0a779ab02765`
- `make dev-swift-build PRODUCT=RepoPrompt` — ticket `512a5b2f-cc0e-486b-a915-e5bbcdfb7eec`
- repository commit and push preflights: guardrails + staged/outgoing secret scans clean
- Fable 5 High pre-implementation and two post-diff reviews: **NO OBJECTIVE BLOCKER** after corrections

PR-ready full-root evidence:

- First run found a real Oracle-only resolver integration regression plus an unrelated durable-artifact failure. The Oracle boundary was corrected and its full 25-test suite is green.
- Second run passed the incident and Oracle boundaries but reported one Codex auth test and a different durable-artifact test. Both complete suites passed immediately in isolation (30/30 and 9/9), indicating full-suite interference/flakiness rather than an outgoing-path defect. Product build, lint, focused integration suites, guardrails, and secret scans are green.

No app launch, relaunch, stop, live smoke, production-data mutation, or merge was performed.

## Remaining uncertainty / follow-up boundary

The exact scheduler ordering that selected the stale projection in the original live process cannot be reproduced from historical logs, but every confirmed enabling edge is now deterministic and fenced. Follow-up hardening can unify the `wait_for_instruction` run-purpose gate and add explicit UI recovery for a protected tab whose entire workspace is administratively deleted; neither is required to prevent this incident class.
